### PR TITLE
Makefile, flake8 for PEP8 and contributors added

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -1,0 +1,10 @@
+
+Original Authors
+================
+
+* Matthew Westcott matthew.westcott@torchbox.com
+
+Contributors
+============
+
+* Paul Hallett (twilio) hello@phalt.co

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+.PHONY: clean-pyc
+
+help:
+	@echo "clean-pyc - remove Python file artifacts"
+	@echo "lint - check style with flake8"
+	@echo "test - run tests quickly with the default Python"
+	@echo "coverage - check code coverage quickly with the default Python"
+
+clean-pyc:
+	find . -name '*.pyc' -exec rm -f {} +
+	find . -name '*.pyo' -exec rm -f {} +
+	find . -name '*~' -exec rm -f {} +
+
+lint:
+	flake8 wagtail
+
+test:
+	python setup.py test
+
+test-all:
+	tox
+
+coverage:
+	coverage run --source wagtail setup.py
+	coverage report -m
+	coverage html
+	open htmlcov/index.html

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,5 @@
+# Requirements essentail for developing wagtail (not needed to run it)
+
+# For coverage and PEP8 linting
+coverage==3.7.1
+flake8==2.1.0


### PR DESCRIPTION
This adds:
- Makefile for running common commands such as `make test` to run tests, `make lint` to run PEP8 linting.
- requirements-dev.txt for running tests.
- Contributors file because you need it!
