### PR TITLE
Removes hard coded links to /admin

### DIFF
--- a/wagtail/wagtailadmin/static/wagtailadmin/js/hallo-plugins/hallo-wagtaillink.coffee
+++ b/wagtail/wagtailadmin/static/wagtailadmin/js/hallo-plugins/hallo-wagtaillink.coffee
@@ -41,9 +41,9 @@
 
                     if lastSelection.collapsed
                         # TODO: don't hard-code this, as it may be changed in urls.py
-                        url = '/admin/choose-page/?allow_external_link=true&allow_email_link=true&prompt_for_link_text=true'
+                        url = window.page_chooser+'?allow_external_link=true&allow_email_link=true&prompt_for_link_text=true'
                     else
-                        url = '/admin/choose-page/?allow_external_link=true&allow_email_link=true'
+                        url = window.page_chooser+'?allow_external_link=true&allow_email_link=true'
 
                     ModalWorkflow
                         url: url

--- a/wagtail/wagtailadmin/static/wagtailadmin/js/page-chooser.js
+++ b/wagtail/wagtailadmin/static/wagtailadmin/js/page-chooser.js
@@ -4,8 +4,7 @@ function createPageChooser(id, pageType, openAtParentId) {
     var input = $('#' + id);
 
     $('.action-choose', chooserElement).click(function() {
-        var initialUrl = '/admin/choose-page/';
-        /* TODO: don't hard-code this URL, as it may be changed in urls.py */
+        var initialUrl = window.page_chooser;
         if (openAtParentId) {
             initialUrl += openAtParentId + '/';
         }

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/_editor_js.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/_editor_js.html
@@ -29,6 +29,13 @@
     <script src="{{ STATIC_URL }}wagtaildocs/js/document-chooser.js"></script>
     <script src="{{ STATIC_URL }}wagtailsnippets/js/snippet-chooser.js"></script>
     <script src="{{ STATIC_URL }}admin/js/urlify.js"></script>
+    <script type='text/javascript'>
+        window.document_chooser='{% url "wagtaildocs_chooser" %}';
+        window.image_chooser='{% url "wagtailimages_chooser" %}';
+        window.embeds_chooser='{% url "wagtailembeds_chooser" %}';
+        window.page_chooser='{% url "wagtailadmin_choose_page" %}';
+        window.snippet_chooser='{% url "wagtailsnippets_choose_generic" %}';
+    </script>
 {% endcompress %}
 
 <script>

--- a/wagtail/wagtaildocs/static/wagtaildocs/js/document-chooser.js
+++ b/wagtail/wagtaildocs/static/wagtaildocs/js/document-chooser.js
@@ -5,7 +5,7 @@ function createDocumentChooser(id) {
 
     $('.action-choose', chooserElement).click(function() {
         ModalWorkflow({
-            'url': '/admin/documents/chooser/', /* TODO: don't hard-code this, as it may be changed in urls.py */
+            'url': window.document_chooser,
             'responses': {
                 'documentChosen': function(docData) {
                     input.val(docData.id);

--- a/wagtail/wagtaildocs/static/wagtaildocs/js/hallo-plugins/hallo-wagtaildoclink.coffee
+++ b/wagtail/wagtaildocs/static/wagtaildocs/js/hallo-plugins/hallo-wagtaildoclink.coffee
@@ -24,7 +24,7 @@
             button.on "click", (event) ->
                 lastSelection = widget.options.editable.getSelection()
                 ModalWorkflow
-                    url: '/admin/documents/chooser/' # TODO: don't hard-code this, as it may be changed in urls.py
+                    url: window.document_chooser
                     responses:
                         documentChosen: (docData) ->
                             a = document.createElement('a')

--- a/wagtail/wagtailembeds/static/wagtailembeds/js/hallo-plugins/hallo-wagtailembeds.coffee
+++ b/wagtail/wagtailembeds/static/wagtailembeds/js/hallo-plugins/hallo-wagtailembeds.coffee
@@ -25,7 +25,7 @@
                 lastSelection = widget.options.editable.getSelection()
                 insertionPoint = $(lastSelection.endContainer).parentsUntil('.richtext').last()
                 ModalWorkflow
-                    url: '/admin/embeds/chooser/' # TODO: don't hard-code this, as it may be changed in urls.py
+                    url: window.embeds_chooser
                     responses:
                         embedChosen: (embedData) ->
                             elem = $(embedData).get(0)

--- a/wagtail/wagtailimages/static/wagtailimages/js/hallo-plugins/hallo-wagtailimage.coffee
+++ b/wagtail/wagtailimages/static/wagtailimages/js/hallo-plugins/hallo-wagtailimage.coffee
@@ -25,7 +25,7 @@
                 lastSelection = widget.options.editable.getSelection()
                 insertionPoint = $(lastSelection.endContainer).parentsUntil('.richtext').last()
                 ModalWorkflow
-                    url: '/admin/images/chooser/?select_format=true' # TODO: don't hard-code this, as it may be changed in urls.py
+                    url: window.image_chooser+'?select_format=true'
                     responses:
                         imageChosen: (imageData) ->
                             elem = $(imageData.html).get(0)

--- a/wagtail/wagtailimages/static/wagtailimages/js/image-chooser.js
+++ b/wagtail/wagtailimages/static/wagtailimages/js/image-chooser.js
@@ -5,7 +5,7 @@ function createImageChooser(id) {
 
     $('.action-choose', chooserElement).click(function() {
         ModalWorkflow({
-            'url': '/admin/images/chooser/', /* TODO: don't hard-code this, as it may be changed in urls.py */
+            'url': window.image_chooser,
             'responses': {
                 'imageChosen': function(imageData) {
                     input.val(imageData.id);

--- a/wagtail/wagtailsnippets/static/wagtailsnippets/js/snippet-chooser.js
+++ b/wagtail/wagtailsnippets/static/wagtailsnippets/js/snippet-chooser.js
@@ -5,7 +5,7 @@ function createSnippetChooser(id, contentType) {
 
     $('.action-choose', chooserElement).click(function() {
         ModalWorkflow({
-            'url': '/admin/snippets/choose/' + contentType + '/', /* TODO: don't hard-code this, as it may be changed in urls.py */
+            'url': window.snippet_chooser + contentType + '/',  
             'responses': {
                 'snippetChosen': function(snippetData) {
                     input.val(snippetData.id);

--- a/wagtail/wagtailsnippets/urls.py
+++ b/wagtail/wagtailsnippets/urls.py
@@ -5,6 +5,7 @@ urlpatterns = patterns(
     'wagtail.wagtailsnippets.views',
     url(r'^$', 'snippets.index', name='wagtailsnippets_index'),
 
+    url(r'^choose/$', 'chooser.choose', name='wagtailsnippets_choose_generic'),
     url(r'^choose/(\w+)/(\w+)/$', 'chooser.choose', name='wagtailsnippets_choose'),
     url(r'^choose/(\w+)/(\w+)/(\d+)/$', 'chooser.chosen', name='wagtailsnippets_chosen'),
 


### PR DESCRIPTION
This is a fix for issue #6:

The _editor_js.html page has been modified in order to get the urls to the various views through the {% url %} tag and add them to the global window variable. I believe that this is actually the best solution in our case and I like it much better than the other available options because the other options were either to add a new view that would return a javascript array with the urls or to add a management command that would generate a static javascript file with the same array. In both cases we'd need to add _more_ instructions to the installation of wagtail and confuse people wanting to use it more. In this solution, the links just work :)
