### PR TITLE
Redirect from login view if user already logged in

### DIFF
--- a/wagtail/wagtailadmin/urls.py
+++ b/wagtail/wagtailadmin/urls.py
@@ -6,13 +6,6 @@ from wagtail.wagtailadmin.forms import LoginForm, PasswordResetForm
 
 urlpatterns = patterns(
     'django.contrib.auth.views',
-    url(
-        r'^login/$', 'login', {
-            'template_name': 'wagtailadmin/login.html',
-            'authentication_form': LoginForm,
-            'extra_context': {'show_password_reset': getattr(settings, 'WAGTAIL_PASSWORD_MANAGEMENT_ENABLED', True)},
-        } , name='wagtailadmin_login'
-    ),
     url(r'^logout/$', 'logout', {'next_page': 'wagtailadmin_login'}),
 
     # Password reset
@@ -79,4 +72,11 @@ urlpatterns += patterns(
 
     url(r'^account/$', 'account.account', name='wagtailadmin_account'),
     url(r'^account/change_password/$', 'account.change_password', name='wagtailadmin_account_change_password'),
+    url(
+        r'^login/$', 'account.login_wrapper', {
+            'template_name': 'wagtailadmin/login.html',
+            'authentication_form': LoginForm,
+            'extra_context': {'show_password_reset': getattr(settings, 'WAGTAIL_PASSWORD_MANAGEMENT_ENABLED', True)},
+        } , name='wagtailadmin_login'
+    ),
 )

--- a/wagtail/wagtailadmin/views/account.py
+++ b/wagtail/wagtailadmin/views/account.py
@@ -39,4 +39,3 @@ def login_wrapper(request, **kwargs):
         return redirect(settings.LOGIN_REDIRECT_URL)
     else:
         return login(request, **kwargs)
-        


### PR DESCRIPTION
This code is to add the feature requested in #25 (Login screen should redirect somewhere appropriate if visited while already logged in).

If the user is already logged in they will be redirected to the `LOGIN_REDIRECT_URL` defined in the settings file.
