### PR TITLE
Adding missing python requirements for testing.

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,4 +2,6 @@
 
 # For coverage and PEP8 linting
 coverage==3.7.1
+elasticutils==0.8.2
 flake8==2.1.0
+pyelasticsearch==0.6.1


### PR DESCRIPTION
elasticutils and pyelasticsearch are required for running tests.
