### PR TITLE
Only show latest edit per page (fixes #45) and remove a stray print

### DIFF
--- a/wagtail/wagtailadmin/views/home.py
+++ b/wagtail/wagtailadmin/views/home.py
@@ -51,8 +51,13 @@ class RecentEditsPanel(object):
     def __init__(self, request):
         self.request = request
         # Last n edited pages
-        self.last_edits = PageRevision.objects.filter(user=request.user).order_by('-created_at')[:5]
-
+        self.last_edits = PageRevision.objects.raw(
+            """
+            select wp.* FROM
+                wagtailcore_pagerevision wp JOIN (
+                    SELECT max(created_at) as max_created_at, page_id FROM wagtailcore_pagerevision group by page_id 
+                ) as max_rev on max_rev.max_created_at = wp.created_at and wp.user_id = %s order by wp.created_at desc
+            """, [request.user.id])[:5]
     def render(self):
         return render_to_string('wagtailadmin/home/recent_edits.html', {
             'last_edits': self.last_edits,

--- a/wagtail/wagtailembeds/views/chooser.py
+++ b/wagtail/wagtailembeds/views/chooser.py
@@ -25,7 +25,6 @@ def chooser_upload(request):
             error = None
             try:
                 embed_html = embed_to_editor_html(form.cleaned_data['url'])
-                print embed_html
                 return render_modal_workflow(
                     request, None, 'wagtailembeds/chooser/embed_chosen.js',
                     {'embed_html': embed_html}


### PR DESCRIPTION
This one works with both postgresql + sqlite3 and fixes #45 !
Also remove a stray print - this actually did not allow embeds to work if the embed_html contained unicode characters (!)
