### PR TITLE
Fix for #24 -- running migrations with sqlite3

### DIFF
--- a/wagtail/wagtailcore/migrations/0002_initial_data.py
+++ b/wagtail/wagtailcore/migrations/0002_initial_data.py
@@ -2,11 +2,14 @@
 from south.utils import datetime_utils as datetime
 from south.db import db
 from south.v2 import DataMigration
-from django.db import models
+from django.db import models, connection
+from django.db.transaction import set_autocommit
 
 class Migration(DataMigration):
 
     def forwards(self, orm):
+        if connection.vendor == 'sqlite':
+            set_autocommit(True)    
         page_content_type, created = orm['contenttypes.contenttype'].objects.get_or_create(
             model='page', app_label='wagtailcore', defaults={'name': 'page'})
 

--- a/wagtail/wagtaildocs/migrations/0002_initial_data.py
+++ b/wagtail/wagtaildocs/migrations/0002_initial_data.py
@@ -2,11 +2,14 @@
 from south.utils import datetime_utils as datetime
 from south.db import db
 from south.v2 import DataMigration
-from django.db import models
+from django.db import models, connection
+from django.db.transaction import set_autocommit
 
 class Migration(DataMigration):
 
     def forwards(self, orm):
+        if connection.vendor == 'sqlite':
+            set_autocommit(True)
         document_content_type, created = orm['contenttypes.ContentType'].objects.get_or_create(
             model='document', app_label='wagtaildocs', defaults={'name': 'document'})
         add_permission, created = orm['auth.permission'].objects.get_or_create(

--- a/wagtail/wagtailimages/migrations/0002_initial_data.py
+++ b/wagtail/wagtailimages/migrations/0002_initial_data.py
@@ -2,11 +2,14 @@
 from south.utils import datetime_utils as datetime
 from south.db import db
 from south.v2 import DataMigration
-from django.db import models
+from django.db import models, connection
+from django.db.transaction import set_autocommit
 
 class Migration(DataMigration):
 
     def forwards(self, orm):
+        if connection.vendor == 'sqlite':
+            set_autocommit(True)    
         image_content_type, created = orm['contenttypes.ContentType'].objects.get_or_create(
             model='image', app_label='wagtailimages', defaults={'name': 'image'})
         add_permission, created = orm['auth.permission'].objects.get_or_create(


### PR DESCRIPTION
When using sqlite3 we set autocommit to True at the beginning of the migration 0002 for wagtail core / docs / images in order to disable transactions there and be able to do a simple `python manage.py migrate` (without 0001 --all) also in sqlite3.
