### PR TITLE
fix wrong path with `original_images`

### DIFF
--- a/wagtail/wagtailimages/templates/wagtailimages/images/_file_field.html
+++ b/wagtail/wagtailimages/templates/wagtailimages/images/_file_field.html
@@ -1,7 +1,7 @@
 {% extends "wagtailadmin/shared/field_as_li.html" %}
 {% load i18n %}
 {% block form_field %}
-    <a href="{{MEDIA_URL}}images/{{ image.file }}" class="icon icon-image">{{ image.filename }}</a><br /><br />
+    <a href="{{ image.file.url }}" class="icon icon-image">{{ image.filename }}</a><br /><br />
 
     {% trans "Change image:" %}
     {{ field }}


### PR DESCRIPTION
Use `image.file.url` directly
