### PR TITLE
Don't send notifications to inactive users

### DIFF
--- a/wagtail/wagtailadmin/tasks.py
+++ b/wagtail/wagtailadmin/tasks.py
@@ -41,7 +41,7 @@ def users_with_page_permission(page, permission_type, include_superusers=True):
     if include_superusers:
         q |= Q(is_superuser=True)
 
-    return User.objects.filter(q).distinct()
+    return User.objects.filter(is_active=True).filter(q).distinct()
 
 
 @task


### PR DESCRIPTION
This pull request fixes issue #90 where notifications were being sent to users who are inactive.
