### PR TITLE
Page changes

### DIFF
--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -328,6 +328,12 @@ class Page(MP_Node, ClusterableModel, Indexed):
 
         return revision.as_page_object()
 
+    def get_context(self, request):
+        return {
+            'self': self,
+            'request': request,
+        }
+
     def get_template(self, request):
         if request.is_ajax():
             return self.ajax_template or self.template
@@ -335,9 +341,11 @@ class Page(MP_Node, ClusterableModel, Indexed):
             return self.template
 
     def serve(self, request):
-        return TemplateResponse(request, self.get_template(request), {
-            'self': self
-        })
+        return TemplateResponse(
+            request, 
+            self.get_template(request), 
+            self.get_context(request)
+        )
 
     def is_navigable(self):
         """


### PR DESCRIPTION
This pull request adds two new features to the Page class:

Ajax Templates/get_template method
You can now set an ajax template by setting the ajax_template attribute on a page model. Wagtails default serve method will use this template instead of the standard one for ajax requests. If you want more advanced behaviour, you can override the new get_template method.

get_context method
Instead of overriding serve, you can now just override get_context and return only the context variables you need. This is useful when you have a subclass of a custom page type and want to reuse that page types context with some modifications. 

Note: This pull request previously contained another feature which allows urlconfs to be inserted into pages. This will be added into a separate module.

The original pull request can now be found on my page-changes-2 branch.
