### PR TITLE
Enable to extend admin panel with custom widgets

### DIFF
--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/_editor_css.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/_editor_css.html
@@ -18,6 +18,4 @@
     <link rel="stylesheet" href="{{ STATIC_URL }}wagtailadmin/scss/vendor/jquery.tagit.css">
 {% endcompress %}
 
-{% compress css %}
-    {{ edit_handler.form.media.css }}
-{% endcompress %}
+{{ edit_handler.form.media.css }}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/_editor_js.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/_editor_js.html
@@ -44,9 +44,7 @@
     Additional js from widgets media. Allows for custom widgets in admin panel.
     Can be used for TODO above (including image-choser.js at wagtailimages)
 {% endcomment %}
-{% compress js %}
-    {{ edit_handler.form.media.js }}
-{% endcompress %}
+{{ edit_handler.form.media.js }}
 
 <script>
     window.chooserUrls = {


### PR DESCRIPTION
When declaring custom widget with assets (Media class), assets were not included in admin panel.

This fix inserts assets into page edit.
