### PR TITLE
breadcrumb moved to an include and added on all page editor interfaces

### DIFF
--- a/wagtail/wagtailadmin/templates/wagtailadmin/chooser/_search_results.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/chooser/_search_results.html
@@ -1,12 +1,7 @@
 {% load i18n %}
 {% if not is_searching %}
     <h2>{% trans "Explorer" %}</h2>
-    <ul class="breadcrumb">
-        <li class="home"><a href="{% url 'wagtailadmin_explore_root' %}?{{ querystring }}" class="icon icon-home text-replace navigate-pages">{% trans "Home" %}</a></li>
-        {% for page in parent_page.get_ancestors %}
-            <li><a href="{% url 'wagtailadmin_choose_page_child' page.id %}?{{ querystring }}" class="navigate-pages" >{{ page.title }}</a></li>
-        {% endfor %}
-    </ul>
+    {% include "wagtailadmin/shared/breadcrumb.html" with page=parent_page %}
 
 {% else %}
     <h2>

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/create.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/create.html
@@ -6,8 +6,16 @@
 {% block bodyclass %}menu-explorer page-editor create{% endblock %}
 
 {% block content %}
-    {% trans "New" as new_str %}
-    {% include "wagtailadmin/shared/header.html" with title=new_str merged=1 tabbed=1 subtitle=content_type.model_class.get_verbose_name icon="doc-empty-inverse" %}
+
+    <header class="merged tab-merged nice-padding">
+        {% include "wagtailadmin/shared/breadcrumb.html" with page=parent_page include_self=1 %}
+
+        <div class="row row-flush">
+            <div class="left col9">
+                <h1 class="icon icon-doc-empty-inverse">{% trans 'New' %} <span>{{ content_type.model_class.get_verbose_name }}</span></h1>
+            </div>
+        </div>
+    </header>
 
     <form id="page-edit-form" action="{% url 'wagtailadmin_pages_create' content_type.app_label content_type.model parent_page.id %}" method="POST">
         {% csrf_token %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/edit.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/edit.html
@@ -7,18 +7,11 @@
 
 {% block content %}
     <header class="merged tab-merged nice-padding">
-        {% if not page.get_parent.is_root %}
-            <ul class="breadcrumb single">
-                {% if not page.get_parent.get_parent.is_root %}
-                    <li><a href="{% url 'wagtailadmin_explore' page.get_parent.get_parent.id %}" title="{{ page.get_parent.get_parent.title }}">...</a></li>
-                {% endif %}                  
-                <li><a href="{% url 'wagtailadmin_explore' page.get_parent.id %}">{{ page.get_parent.title }}</a></li>
-            </ul>
-        {% endif %}
+        {% include "wagtailadmin/shared/breadcrumb.html" with page=page %}
 
         <div class="row row-flush">
             <div class="left col9">
-                <h1>{% blocktrans with title=page.title %}Editing <span>{{ title }}</span>{% endblocktrans %}</h1>
+                <h1 class="icon icon-doc-empty-inverse">{% blocktrans with title=page.title %}Editing <span>{{ title }}</span>{% endblocktrans %}</h1>
             </div>
             <div class="right col3">
                  {% trans "Status:" %} {% if page.live %}<a href="{{ page.url }}" class="status-tag {% if page.live %}primary{% endif %}">{{ page.status_string }}</a>{% else %}<span class="status-tag">{{ page.status_string }}</span>{% endif %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/index.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/index.html
@@ -8,17 +8,7 @@
     <header class="merged no-border nice-padding no-v-padding">
         <h1 class="visuallyhidden">Explorer</h1>
 
-        {% if not parent_page.is_root %}
-            <ul class="breadcrumb">
-                {% for page in parent_page.get_ancestors %}
-                    {% if page.is_root %}
-                        <li class="home"><a href="{% url 'wagtailadmin_explore_root' %}" class="icon icon-home text-replace">{% trans 'Home' %}</a></li>
-                    {% else %}
-                        <li><a href="{% url 'wagtailadmin_explore' page.id %}">{{ page.title }}</a></li>
-                    {% endif %}
-                {% endfor %}
-            </ul>
-        {% endif %}
+        {% include "wagtailadmin/shared/breadcrumb.html" with page=parent_page %}
     </header>
    
     <form id="page-reorder-form">

--- a/wagtail/wagtailadmin/templates/wagtailadmin/shared/breadcrumb.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/shared/breadcrumb.html
@@ -1,0 +1,14 @@
+{% load i18n %}
+
+<ul class="breadcrumb">
+    {% for page in page.get_ancestors %}
+        {% if page.is_root %}
+            <li class="home"><a href="{% url 'wagtailadmin_explore_root' %}" class="icon icon-home text-replace">{% trans 'Home' %}</a></li>
+        {% else %}
+            <li><a href="{% url 'wagtailadmin_explore' page.id %}">{{ page.title }}</a></li>
+        {% endif %}
+    {% endfor %}
+    {% if include_self %}
+        <li><a href="{% url 'wagtailadmin_explore' page.id %}">{{ page.title }}</a></li>
+    {% endif %}
+</ul>


### PR DESCRIPTION
Previously the breadcrumb on the page Edit interface was a curious version with only 1 level accessible.
