### PR TITLE
Separated the routing function into two in order to access the page

### DIFF
--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -361,7 +361,7 @@ class Page(MP_Node, ClusterableModel, Indexed):
             raise Http404
 
         if page.live:
-            return self.serve(request)
+            return page.serve(request)
         else:
             raise Http404
 


### PR DESCRIPTION
Page's `route` function is used to find the appropriate child page
from the request path and serve it. I needed to plug into the
routing function in order to write an archive view, which would use
part of the path to arrive to a blog index page, and then use the
remaining path components to filter the posts. For example:

if a blog lives in :

`www.example.com/blog/`

Archives fo the blog index could be accessed by going to:

`www.example.com/blog/author/username`

or

`www.example.com/blog/tag/a_tag/`

or

`www.example.com/blog/date/2012/jan`

So, my proposal is to separate the `route` function into two.

`get_page_from_path` now takes the `path_components` argument
and recursively returns the appropriate page.

`route` takes the `request` and `path_components`, uses
`get_page_from_path` to find the appropriate page, and serves
it if it is live.

Now I can use views to access the `get_page_from_path` function
from `Page` and use subsequent path arguments to serve the
right archive page.
