### PR TITLE
Added python 2.6 classifier to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,8 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Framework :: Django',
         'Topic :: Internet :: WWW/HTTP :: Site Management',


### PR DESCRIPTION
This pull request just adds a missing classifier for Python 2.6 support to setup.py
