### PR TITLE
Fix twitter oembed structure

### DIFF
--- a/wagtail/wagtailembeds/embeds.py
+++ b/wagtail/wagtailembeds/embeds.py
@@ -80,7 +80,7 @@ def embedly(url, max_width=None, key=None):
     if oembed['provider_name'] == 'Twitter':
         title = oembed['author_name']
     else:
-        titlte = oembed['title']
+        title = oembed['title']
 
     # Return embed as a dict
     return {
@@ -125,7 +125,7 @@ def oembed(url, max_width=None):
     if oembed['provider_name'] == 'Twitter':
         title = oembed['author_name']
     else:
-        titlte = oembed['title']
+        title = oembed['title']
     return {
         'title': title,
         'type': oembed['type'],


### PR DESCRIPTION
Twitter doesn't provide `title` key in embed JSON output. So we need to use another tag, for example `author_name`, to avoid errors.
