### PR TITLE
Use database cache for testing

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -82,6 +82,10 @@ if not settings.configured:
             'wagtail.wagtailredirects',
             'wagtail.tests',
         ],
+
+        # Using DatabaseCache to make sure that the cache is cleared between tests.
+        # This prevents false-positives in some wagtail core tests where we are
+        # changing the 'wagtail_root_paths' key which may cause future tests to fail.
         CACHES = {
             'default': {
                 'BACKEND': 'django.core.cache.backends.db.DatabaseCache',


### PR DESCRIPTION
Currently, the cache is not flushed between tests.

This can cause false positives where a previous test has been messing with cache keys which a future test uses (eg, wagtail_root_paths)

This commit makes django use the database as the cache which is automatically flushed between tests
