### PR TITLE
Import unittest2 from Django

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,6 @@ dj16=
     Django>=1.6,<1.7
     pyelasticsearch==0.6.1
     elasticutils==0.8.2
-    unittest2
 
 [tox]
 envlist =

--- a/wagtail/tests/utils.py
+++ b/wagtail/tests/utils.py
@@ -1,5 +1,16 @@
 from django.contrib.auth.models import User
 
+# We need to make sure that we're using the same unittest library that Django uses internally
+# Otherwise, we get issues with the "SkipTest" and "ExpectedFailure" exceptions being recognised as errors
+try:
+    # Firstly, try to import unittest from Django
+    from django.utils import unittest
+except ImportError:
+    # Django doesn't include unittest
+    # We must be running on Django 1.7+ which doesn't support Python 2.6 so
+    # the standard unittest library should be unittest2
+    import unittest
+
 
 def login(client):
     # Create a user

--- a/wagtail/wagtailadmin/tests.py
+++ b/wagtail/wagtailadmin/tests.py
@@ -1,7 +1,6 @@
 from django.test import TestCase
-import unittest2 as unittest
 from wagtail.tests.models import SimplePage, EventPage
-from wagtail.tests.utils import login
+from wagtail.tests.utils import login, unittest
 from wagtail.wagtailcore.models import Page
 from django.core.urlresolvers import reverse
 

--- a/wagtail/wagtailimages/tests.py
+++ b/wagtail/wagtailimages/tests.py
@@ -4,9 +4,7 @@ from django.contrib.auth.models import User, Group, Permission
 from django.core.urlresolvers import reverse
 from django.core.files.uploadedfile import SimpleUploadedFile
 
-import unittest2 as unittest
-
-from wagtail.tests.utils import login
+from wagtail.tests.utils import login, unittest
 from wagtail.wagtailimages.models import get_image_model
 from wagtail.wagtailimages.templatetags import image_tags
 

--- a/wagtail/wagtailsearch/tests/test_backends.py
+++ b/wagtail/wagtailsearch/tests/test_backends.py
@@ -2,7 +2,7 @@ from django.test import TestCase
 from django.test.utils import override_settings
 from django.conf import settings
 from django.core import management
-import unittest2 as unittest
+from wagtail.tests.utils import unittest
 from wagtail.wagtailsearch import models, get_search_backend
 from wagtail.wagtailsearch.backends.db import DBSearch
 from wagtail.wagtailsearch.backends import InvalidSearchBackendError

--- a/wagtail/wagtailsearch/tests/test_queries.py
+++ b/wagtail/wagtailsearch/tests/test_queries.py
@@ -1,9 +1,8 @@
 from django.test import TestCase
 from django.core import management
 from wagtail.wagtailsearch import models
-from wagtail.tests.utils import login
+from wagtail.tests.utils import login, unittest
 from StringIO import StringIO
-import unittest2 as unittest
 
 
 class TestHitCounter(TestCase):

--- a/wagtail/wagtailsnippets/tests.py
+++ b/wagtail/wagtailsnippets/tests.py
@@ -5,7 +5,7 @@ when you run "manage.py test".
 Replace this with more appropriate tests for your application.
 """
 
-import unittest2 as unittest
+from wagtail.tests.utils import unittest
 
 from django.test import TestCase
 


### PR DESCRIPTION
This commit solves two problems:
- Django 1.7 uses the stock python unittest module instead of using the unittest2 backport. This is an issue as when we raise the Skip and ExpectedFailure exceptions, these are seen by Django as errors. This commit makes sure that we always use the same unittest module that Django is using to prevent this from happening.
- Removes the need to install unittest2 (by importing it from django.utils.unittest instead)
