### PR TITLE
Remove all (3) raw SQL statements

### DIFF
--- a/wagtail/wagtailadmin/views/pages.py
+++ b/wagtail/wagtailadmin/views/pages.py
@@ -43,9 +43,7 @@ def index(request, parent_page_id=None):
 @permission_required('wagtailadmin.access_admin')
 def select_type(request):
     # Get the list of page types that can be created within the pages that currently exist
-    existing_page_types = ContentType.objects.raw("""
-        SELECT DISTINCT content_type_id AS id FROM wagtailcore_page
-    """)
+    existing_page_types = get_page_types()
 
     all_page_types = sorted(get_page_types(), key=lambda pagetype: pagetype.name.lower())
     page_types = set()

--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -638,17 +638,9 @@ def get_navigation_menu_items():
     # or are at the top-level (this rule required so that an empty site out-of-the-box has a working menu)
     navigable_content_type_ids = get_navigable_page_content_type_ids()
     if navigable_content_type_ids:
-        pages = Page.objects.raw("""
-            SELECT * FROM wagtailcore_page
-            WHERE numchild > 0 OR content_type_id IN %s OR depth = 2
-            ORDER BY path
-        """, [tuple(navigable_content_type_ids)])
+        pages = Page.objects.filter(Q(content_type__in=navigable_content_type_ids)|Q(depth=2)|Q(numchild__gt=0)).order_by('path')
     else:
-        pages = Page.objects.raw("""
-            SELECT * FROM wagtailcore_page
-            WHERE numchild > 0 OR depth = 2
-            ORDER BY path
-        """)
+        pages = Page.objects.filter(Q(depth=2)|Q(numchild__gt=0)).order_by('path')
 
     # Turn this into a tree structure:
     #     tree_node = (page, children)


### PR DESCRIPTION
This will allow Django to generate the SQL statements, so there aren't any backend issues. I was playing with adding `subpage_types` to a `Page` subclass, and was getting errors because the SQL wasn't compatible with sqlite.
