### PR TITLE
allow Page.__init__ to take a 'parent' kwarg for business logic in admin

### DIFF
--- a/wagtail/wagtailadmin/views/pages.py
+++ b/wagtail/wagtailadmin/views/pages.py
@@ -168,7 +168,7 @@ def create(request, content_type_app_name, content_type_model_name, parent_page_
     #     messages.error(request, "Sorry, you do not have access to create a page of type '%s' here." % content_type.name)
     #     return redirect('wagtailadmin_pages_select_type')
 
-    page = page_class(owner=request.user)
+    page = page_class(owner=request.user,parent=parent_page)
     edit_handler_class = get_page_edit_handler(page_class)
     form_class = edit_handler_class.get_form_class(page_class)
 

--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -249,6 +249,7 @@ class Page(MP_Node, ClusterableModel, Indexed):
     }
 
     def __init__(self, *args, **kwargs):
+        parent = kwargs.pop('parent',None)
         super(Page, self).__init__(*args, **kwargs)
         if not self.id and not self.content_type_id:
             # this model is being newly created rather than retrieved from the db;


### PR DESCRIPTION
I'm using it so I can initiate fields based on the parent instance. Seems like a useful and innocuous feature.
