### PR TITLE
Docs revisions (spelling fixes, queryset examples, expansion of Editing API and Page class reference)

### DIFF
--- a/docs/building_your_site/frontenddevelopers.rst
+++ b/docs/building_your_site/frontenddevelopers.rst
@@ -19,7 +19,7 @@ Displaying Pages
 ==========================
 
 Template Location
------------------
+~~~~~~~~~~~~~~~~~
 
 For each of your ``Page``-derived models, Wagtail will look for a template in the following location, relative to your project root::
 
@@ -36,7 +36,7 @@ Class names are converted from camel case to underscores. For example, the templ
 
 
 Self
-----
+~~~~
 
 By default, the context passed to a model's template consists of two properties: ``self`` and ``request``. ``self`` is the model object being displayed. ``request`` is the normal Django request object. So, to include the title of a ``Page``, use ``{{ self.title }}``.
 
@@ -45,9 +45,8 @@ Static files (css, js, images)
 ========================
 
 
-
 Images
-~~~~~~~~~~
+~~~~~~
 
 Images uploaded to Wagtail go into the image library and from there are added to pages via the :doc:`page editor interface </editor_manual/new_pages/inserting_images>`.
 
@@ -55,7 +54,7 @@ Unlike other CMS, adding images to a page does not involve choosing a "version" 
 
 Images from the library **must** be requested using this syntax, but images in your codebase can be added via conventional means e.g ``img`` tags. Only images from the library can be manipulated on the fly.
 
-Read more about the image manipulation syntax here :ref:`Images tag <image-tag>`.
+Read more about the image manipulation syntax here :ref:`image_tag`.
 
 
 ========================
@@ -64,7 +63,9 @@ Template tags & filters
 
 In addition to Django's standard tags and filters, Wagtail provides some of it's own, which can be ``load``-ed `as you would any other <https://docs.djangoproject.com/en/dev/topics/templates/#custom-tag-and-filter-libraries>`_
 
-.. _image-tag:
+
+.. _image_tag:
+
 Images (tag)
 ~~~~~~~~~~~~
 
@@ -123,8 +124,9 @@ The available ``method`` s are:
     Wagtail *does not allow deforming or stretching images*. Image dimension ratios will always be kept. Wagtail also *does not support upscaling*. Small images forced to appear at larger sizes will "max out" at their their native dimensions.
 
 
-To request the "original" version of an image, it is suggested you rely on the lack of upscalling support by requesting an image much larger than it's maximum dimensions. e.g to insert an image who's dimensions are uncertain/unknown, at it's maximum size, try: ``{% image self.image width-10000 %}``. This assumes the image is unlikely to be larger than 10000px wide.
+To request the "original" version of an image, it is suggested you rely on the lack of upscaling support by requesting an image much larger than it's maximum dimensions. e.g to insert an image who's dimensions are uncertain/unknown, at it's maximum size, try: ``{% image self.image width-10000 %}``. This assumes the image is unlikely to be larger than 10000px wide.
 
+.. _rich-text-filter:
 Rich text (filter)
 ~~~~~~~~~~~~~~~~~~
 

--- a/docs/model_recipes.rst
+++ b/docs/model_recipes.rst
@@ -1,4 +1,6 @@
 
+.. _model_recipes:
+
 Model Recipes
 =============
 
@@ -174,3 +176,24 @@ Here, ``blogs.filter(tags__name=tag)`` invokes a reverse Django queryset filter 
 Iterating through ``self.tags.all`` will display each tag associated with ``self``, while the link(s) back to the index make use of the filter option added to the ``BlogIndexPage`` model. A Django query could also use the ``tagged_items`` related name field to get ``BlogPage`` objects associated with a tag.
 
 This is just one possible way of creating a taxonomy for Wagtail objects. With all of the components for a taxonomy available through Wagtail, you should be able to fulfill even the most exotic taxonomic schemes.
+
+
+Custom Page Contexts by Overriding get_context()
+------------------------------------------------
+
+
+
+Load Alternate Templates by Overriding get_template()
+-----------------------------------------------------
+
+
+
+Page Modes
+----------
+
+get_page_modes
+show_as_mode
+
+
+
+

--- a/docs/snippets.rst
+++ b/docs/snippets.rst
@@ -1,9 +1,12 @@
+
+.. _snippets:
+
 Snippets
 ========
 
 Snippets are pieces of content which do not necessitate a full webpage to render. They could be used for making secondary content, such as headers, footers, and sidebars, editable in the Wagtail admin. Snippets are models which do not inherit the ``Page`` class and are thus not organized into the Wagtail tree, but can still be made editable by assigning panels and identifying the model as a snippet with ``register_snippet()``.
 
-Snippets are not searchable or orderable in the Wagtail admin, so decide carefully if the content type you would want to build into a snippet might be more suited to a page.
+Snippets are not search-able or order-able in the Wagtail admin, so decide carefully if the content type you would want to build into a snippet might be more suited to a page.
 
 Snippet Models
 --------------

--- a/docs/wagtail_search.rst
+++ b/docs/wagtail_search.rst
@@ -127,7 +127,7 @@ Lets also add a simple interface for the search with a ``<input>`` element to ga
     <div id="json-results"></div>
   </div>
 
-Finally, we'll use JQuery to make the aynchronous requests and handle the interactivity:
+Finally, we'll use JQuery to make the asynchronous requests and handle the interactivity:
 
 .. code-block:: guess
  
@@ -186,7 +186,7 @@ Results are returned as a JSON object with this structure:
     ]
   }
 
-What if you wanted access to the rest of the results context or didn't feel like using JSON? Wagtail also provides a generalized AJAX interface where you can use your own template to serve results asyncronously.
+What if you wanted access to the rest of the results context or didn't feel like using JSON? Wagtail also provides a generalized AJAX interface where you can use your own template to serve results asynchronously.
 
 The AJAX interface uses the same view as the normal HTML search, ``wagtailsearch_search``, but will serve different results if Django classifies the request as AJAX (``request.is_ajax()``). Another entry in your project settings will let you override the template used to serve this response:
 
@@ -194,7 +194,7 @@ The AJAX interface uses the same view as the normal HTML search, ``wagtailsearch
 
   WAGTAILSEARCH_RESULTS_TEMPLATE_AJAX = 'myapp/includes/search_listing.html'
 
-In this template, you'll have access to the same context variablies provided to the HTML template. You could provide a template in JSON format with extra properties, such as ``query.hits`` and editor's picks, or render an HTML snippet that can go directly into your results ``<div>``. If you need more flexibility, such as multiple formats/templates based on differing requests, you can set up a custom search view.
+In this template, you'll have access to the same context variables provided to the HTML template. You could provide a template in JSON format with extra properties, such as ``query.hits`` and editor's picks, or render an HTML snippet that can go directly into your results ``<div>``. If you need more flexibility, such as multiple formats/templates based on differing requests, you can set up a custom search view.
 
 .. _editors-picks:
 


### PR DESCRIPTION
-  Spellcheck of docs pages. 
-  Fixes backend "building your site" example code to include querysets per (https://github.com/torchbox/wagtail/pull/256#discussion-diff-13001063)
-  Stubbed out a `Page` class reference. I welcome any changes to these since they basically define what the Wagtail project considers "safe" properties and methods to mess with when subclassing. I just did a best guess based on the number of lines in the function.
-  Fixed a few problems with RST headings (that I may have introduced in my previous PR) in the frontend "building your site" section.
-  Stubbed out some new model recipes I saw as useful
-  Expanded the Editing API doc with more on Wagtail-provided content types and field customization.
