### PR TITLE
Fix #263

### DIFF
--- a/wagtail/wagtailadmin/templates/wagtailadmin/chooser/_search_behaviour.js
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/chooser/_search_behaviour.js
@@ -1,6 +1,6 @@
-modal.ajaxifyForm($('form.search-bar', modal.body));
+modal.ajaxifyForm($('form.search-form', modal.body));
 
-var searchUrl = $('form.search-bar', modal.body).attr('action');
+var searchUrl = $('form.search-form', modal.body).attr('action');
 
 function search() {
     $.ajax({


### PR DESCRIPTION
This pull request fixes a bug recently reported by @helenb (#263).

The issue was caused by a forms classname being changed but a selector referencing it was not updated.

This caused the chooser to not be able to find an action URL for the search form causing the browser to load the edit page into the page chooser modal.
