### PR TITLE
Fix #94

### DIFF
--- a/wagtail/wagtailadmin/static/wagtailadmin/js/page-editor.js
+++ b/wagtail/wagtailadmin/static/wagtailadmin/js/page-editor.js
@@ -181,6 +181,17 @@ function InlinePanel(opts) {
                 self.updateMoveButtonDisabledStates();
             });
         }
+
+        /* Hide container on page load if it is marked as deleted. Remove the error
+         message so that it doesn't count towards the number of errors on the tab at the
+         top of the page. */
+        if ( $('#' + deleteInputId).val() === "1" ) {
+            $('#' + childId).hide(0, function() {
+                self.updateMoveButtonDisabledStates();
+                self.setHasContent();
+            });
+            $('#' + childId).find(".error-message").remove();
+        }
     };
 
     self.formsUl = $('#' + opts.formsetPrefix + '-FORMS');

--- a/wagtail/wagtailadmin/views/pages.py
+++ b/wagtail/wagtailadmin/views/pages.py
@@ -5,7 +5,7 @@ from django.contrib import messages
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.auth.decorators import permission_required
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
-from django.utils.translation import ugettext as _ 
+from django.utils.translation import ugettext as _
 from django.views.decorators.vary import vary_on_headers
 
 from wagtail.wagtailadmin.edit_handlers import TabbedInterface, ObjectList


### PR DESCRIPTION
If an item is deleted on the edit page and there is a validation error when the edit page is submitted, the deleted item will no longer appear or be counted towards the error total when the page reloads.
