### PR TITLE
Edit API docs expanded with hooks, modelcluster, and InlinePanel usage

### DIFF
--- a/docs/model_recipes.rst
+++ b/docs/model_recipes.rst
@@ -118,6 +118,8 @@ Will return::
     tauntaun kennel bed and breakfast
 
 
+.. _tagging:
+
 Tagging
 -------
 


### PR DESCRIPTION
I've also stubbed out some other sections for the Edit API, but I might just do a high-level overview of them since there's so much vanilla Django that goes into them (and lots of it goes beyond my Django skills at the moment).

I'll probably flesh out the rest of the model recipe section next since I'm eager to explore the implementation of  view modes and access control.
