### PR TITLE
Docs: responsive embeds and images CSS suggestion

### DIFF
--- a/docs/building_your_site/frontenddevelopers.rst
+++ b/docs/building_your_site/frontenddevelopers.rst
@@ -190,6 +190,32 @@ Only fields using ``RichTextField`` need this applied in the template.
 .. Note::
     Note that the template tag loaded differs from the name of the filter.
 
+Responsive Embeds
+-----------------
+
+Wagtail embeds and images are included at their full width, which may overflow the bounds of the content container you've defined in your templates. To make images and embeds responsive -- meaning they'll resize to fit their container -- include the following CSS.
+
+.. code-block:: css
+
+    .rich-text img {
+        max-width: 100%;
+        height: auto;
+    }
+
+    .responsive-object {
+        position: relative;
+    }
+        .responsive-object iframe,
+        .responsive-object object,
+        .responsive-object embed {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+        }
+
+
 Internal links (tag)
 ~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
I thought it might be helpful to suggest some CSS in conjunction with the rich text template tag to make embeds/images responsive. The image tag and embed filters provide pixel width control, but the rich text filter does not, so a CSS-inexperienced user might struggle with ways to control output width with that tag.

It also occurs to me that the embed filters are not documented, along with including embeds in models. I plan to add those in a later PR once I've tested and understood them.
