### PR TITLE
Bug: Embedly key argument never used

### DIFF
--- a/wagtail/wagtailembeds/embeds.py
+++ b/wagtail/wagtailembeds/embeds.py
@@ -52,7 +52,7 @@ def embedly(url, max_width=None, key=None):
         key = settings.EMBEDLY_KEY
 
     # Get embedly client
-    client = Embedly(key=settings.EMBEDLY_KEY)
+    client = Embedly(key=key)
 
     # Call embedly
     if max_width is not None:


### PR DESCRIPTION
Probably low priority, since it's unlikely a user would be juggling multiple Embedly keys, but it looked funny so I thought I'd fix it.
