### PR TITLE
add 'target' attribute to <a> whitelist

### DIFF
--- a/wagtail/wagtailcore/whitelist.py
+++ b/wagtail/wagtailcore/whitelist.py
@@ -52,7 +52,7 @@ allow_without_attributes = attribute_rule({})
 class Whitelister(object):
     element_rules = {
         '[document]': allow_without_attributes,
-        'a': attribute_rule({'href': check_url}),
+        'a': attribute_rule({'href': check_url, 'target': True}),
         'b': allow_without_attributes,
         'br': allow_without_attributes,
         'div': allow_without_attributes,


### PR DESCRIPTION
`target` is a commonly used attribute on the `<a>` tag. After using the `hallohtml` plugin, it's easy to add the target, although there isn't a built-in way to access this.
