### PR TITLE
Truncate long search strings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ services:
 # Package installation
 install:
   - python setup.py install
-  - pip install psycopg2 pyelasticsearch elasticutils==0.8.2 wand
+  - pip install psycopg2 pyelasticsearch elasticutils==0.8.2 wand embedly
   - pip install coveralls
 # Pre-test configuration
 before_script:

--- a/wagtail/wagtailsearch/models.py
+++ b/wagtail/wagtailsearch/models.py
@@ -5,9 +5,10 @@ from indexed import Indexed
 import datetime
 import string
 
+MAX_QUERY_STRING_LENGTH = 255
 
 class Query(models.Model):
-    query_string = models.CharField(max_length=255, unique=True)
+    query_string = models.CharField(max_length=MAX_QUERY_STRING_LENGTH, unique=True)
 
     def save(self, *args, **kwargs):
         # Normalise query string
@@ -48,6 +49,9 @@ class Query(models.Model):
 
     @staticmethod
     def normalise_query_string(query_string):
+        # Truncate query string
+        if len(query_string) > MAX_QUERY_STRING_LENGTH:
+            query_string = query_string[:MAX_QUERY_STRING_LENGTH]
         # Convert query_string to lowercase
         query_string = query_string.lower()
 

--- a/wagtail/wagtailsearch/tests/test_queries.py
+++ b/wagtail/wagtailsearch/tests/test_queries.py
@@ -53,6 +53,16 @@ class TestQueryStringNormalisation(TestCase):
         for query in queries:
             self.assertNotEqual(self.query, models.Query.get(query))
 
+    def test_truncation(self):
+        test_querystring = 'a' * 1000
+        result = models.Query.normalise_query_string(test_querystring)
+        self.assertEqual(len(result), 255)
+
+    def test_no_truncation(self):
+        test_querystring = 'a' * 10
+        result = models.Query.normalise_query_string(test_querystring)
+        self.assertEqual(len(result), 10)
+
 
 class TestQueryPopularity(TestCase):
     def test_query_popularity(self):


### PR DESCRIPTION
Search query strings must not exceed 255 characters; they will be
truncated if they do. Also added embedly library for Travis.
