### PR TITLE
respect DOM re-ordering of formsets even if the parent form errored

### DIFF
--- a/wagtail/wagtailadmin/edit_handlers.py
+++ b/wagtail/wagtailadmin/edit_handlers.py
@@ -562,6 +562,11 @@ class BaseInlinePanel(EditHandler):
                 child_edit_handler_class(instance=subform.instance, form=subform)
             )
 
+        # if this formset is valid, it may have been re-ordered; respect that
+        # in case the parent form errored and we need to re-render
+        if self.formset.can_order and self.formset.is_valid():
+            self.children = sorted(self.children, key=lambda x: x.form.cleaned_data['ORDER'])
+
         empty_form = self.formset.empty_form
         empty_form.fields['DELETE'].widget = forms.HiddenInput()
         if self.formset.can_order:


### PR DESCRIPTION
Happy to add tests for this once #335 is merged. This fixes #72 by reordering the `children` attribute of the BaseInlinePanel EditHandler, as it is the list of children which are iterated over in the templates when rendering the formset.
