### PR TITLE
Search Changes 3 - New field configuration format

### DIFF
--- a/wagtail/wagtailadmin/taggable.py
+++ b/wagtail/wagtailadmin/taggable.py
@@ -4,27 +4,20 @@ from django.contrib.contenttypes.models import ContentType
 from django.db.models import Count
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 
-from wagtail.wagtailsearch import Indexed, get_search_backend
+from wagtail.wagtailsearch import indexed
+from wagtail.wagtailsearch.backends import get_search_backend
 
 
-class TagSearchable(Indexed):
+class TagSearchable(indexed.Indexed):
     """
     Mixin to provide a 'search' method, searching on the 'title' field and tags,
     for models that provide those things.
     """
 
-    indexed_fields = {
-        'title': {
-            'type': 'string',
-            'analyzer': 'edgengram_analyzer',
-            'boost': 10,
-        },
-        'get_tags': {
-            'type': 'string',
-            'analyzer': 'edgengram_analyzer',
-            'boost': 10,
-        },
-    }
+    search_fields = (
+        indexed.SearchField('title', partial_match=True, boost=10),
+        indexed.SearchField('get_tags', partial_match=True, boost=10)
+    )
 
     @property
     def get_tags(self):

--- a/wagtail/wagtaildocs/models.py
+++ b/wagtail/wagtaildocs/models.py
@@ -12,6 +12,7 @@ from django.utils.translation import ugettext_lazy  as _
 from django.utils.encoding import python_2_unicode_compatible
 
 from wagtail.wagtailadmin.taggable import TagSearchable
+from wagtail.wagtailsearch import indexed
 
 
 @python_2_unicode_compatible
@@ -23,14 +24,9 @@ class Document(models.Model, TagSearchable):
 
     tags = TaggableManager(help_text=None, blank=True, verbose_name=_('Tags'))
 
-    indexed_fields = {
-        'uploaded_by_user_id': {
-            'type': 'integer',
-            'store': 'yes',
-            'indexed': 'no',
-            'boost': 0,
-        },
-    }
+    search_fields = TagSearchable.search_fields + (
+        indexed.FilterField('uploaded_by_user'),
+    )
 
     def __str__(self):
         return self.title

--- a/wagtail/wagtailimages/models.py
+++ b/wagtail/wagtailimages/models.py
@@ -20,6 +20,7 @@ from unidecode import unidecode
 
 from wagtail.wagtailadmin.taggable import TagSearchable
 from wagtail.wagtailimages.backends import get_image_backend
+from wagtail.wagtailsearch import indexed
 from .utils import validate_image_format
 
 
@@ -48,14 +49,9 @@ class AbstractImage(models.Model, TagSearchable):
 
     tags = TaggableManager(help_text=None, blank=True, verbose_name=_('Tags'))
 
-    indexed_fields = {
-        'uploaded_by_user_id': {
-            'type': 'integer',
-            'store': 'yes',
-            'indexed': 'no',
-            'boost': 0,
-        },
-    }
+    search_fields = TagSearchable.search_fields + (
+        indexed.FilterField('uploaded_by_user'),
+    )
 
     def __str__(self):
         return self.title

--- a/wagtail/wagtailsearch/models.py
+++ b/wagtail/wagtailsearch/models.py
@@ -4,7 +4,7 @@ from django.db import models
 from django.utils import timezone
 from django.utils.encoding import python_2_unicode_compatible
 
-from wagtail.wagtailsearch.indexed import Indexed
+from wagtail.wagtailsearch import indexed
 from wagtail.wagtailsearch.utils import normalise_query_string, MAX_QUERY_STRING_LENGTH
 
 
@@ -82,12 +82,17 @@ class EditorsPick(models.Model):
 
 # Used for tests
 
-class SearchTest(models.Model, Indexed):
+class SearchTest(models.Model, indexed.Indexed):
     title = models.CharField(max_length=255)
     content = models.TextField()
     live = models.BooleanField(default=False)
 
-    indexed_fields = ("title", "content", "callable_indexed_field", "live")
+    search_fields = (
+        indexed.SearchField('title'),
+        indexed.SearchField('content'),
+        indexed.SearchField('callable_indexed_field'),
+        indexed.SearchField('live'),
+    )
 
     def callable_indexed_field(self):
         return "Callable"
@@ -96,4 +101,6 @@ class SearchTest(models.Model, Indexed):
 class SearchTestChild(SearchTest):
     extra_content = models.TextField()
 
-    indexed_fields = "extra_content"
+    search_fields = SearchTest.search_fields + (
+        indexed.SearchField('extra_content'),
+    )


### PR DESCRIPTION
This adds a new configuration format to wagtailsearch. Previously, users had to use the Elasticsearch mapping DSL inside python dictionaries.

In the new format, users have to provide a list of SearchField/FilterField objects in the `search_fields` attribute:

``` python
class MyClass(models.Model, indexed.Indexed):
    title = models.CharField(max_length=255)
    live = models.BooleanField()

    search_fields = [
        indexed.SearchField('title', partial_match=True, boost=10),
        indexed.FilterField('live'),
    ]
```

Each field can have a maximum of one SearchField and one FilterField defined for them. If a field has more than one of any of these, the last one in the list is used. This allows child classes to override configuration of parent classes.

You now have to explicity ask it to inherit search_fields from a parent class.

``` python
class MyChildClass(MyClass):
    content = models.TextField(max_length=255)

    search_fields = MyClass.search_fields + [
        indexed.SearchField('title'), # Disables partial matching and boosting on title
        indexed.SearchField('content'),
    ]
```

The main advantages of the new format are:
- Easier to read/write
- More control over inheritance
- Simpler implementation
- Backend agnostic

This temporarily converts the new configuration format back into the old one for the backends. In a later PR (#346), the backends will be changed to use the new SearchField/FilterField classes.
