### PR TITLE
Add search to admin homepage

### DIFF
--- a/wagtail/wagtailadmin/forms.py
+++ b/wagtail/wagtailadmin/forms.py
@@ -3,6 +3,7 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.forms import AuthenticationForm, PasswordResetForm
 from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_lazy
+from django.utils.encoding import force_text
 
 class SearchForm(forms.Form):
     def __init__(self, *args, **kwargs):
@@ -12,7 +13,7 @@ class SearchForm(forms.Form):
         if _placeholder is not None:
             placeholder = _placeholder
         else:
-            placeholder = 'Search {0}'.format(placeholder_suffix)
+            placeholder = 'Search {0}'.format(force_text(placeholder_suffix))
         self.fields['q'].widget.attrs = {'placeholder': placeholder}
 
     q = forms.CharField(label=_("Search term"), widget=forms.TextInput())

--- a/wagtail/wagtailadmin/static/wagtailadmin/scss/components/forms.scss
+++ b/wagtail/wagtailadmin/static/wagtailadmin/scss/components/forms.scss
@@ -270,6 +270,11 @@ input[type=submit], input[type=reset], input[type=button], .button, button{
         }
     }
 
+    &.button-full-width {
+        display: block;
+        width: 100%;
+    }
+
     + input[type=submit],
     + input[type=reset],
     + input[type=button],

--- a/wagtail/wagtailadmin/templates/wagtailadmin/home/search.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/home/search.html
@@ -1,0 +1,17 @@
+<section class="panel nice-padding">
+    <div class="row row-flush">
+        <form class="search-form" action="{% url "wagtailadmin_pages_search" %}" method="get">
+            <div class="col10">
+
+                <label class="visuallyhidden" for="{{ search_form.q.id_for_label }}">{{ search_form.q.label }}</label>
+                <div class="input field-small iconfield icon-search">
+                    {{ search_form.q }}
+                </div>
+            </div>
+            <div class="col2">
+                <input value="Search" type="submit" class="button-full-width">
+
+            </div>
+        <form>
+    </div>
+</section>

--- a/wagtail/wagtailadmin/views/home.py
+++ b/wagtail/wagtailadmin/views/home.py
@@ -3,6 +3,7 @@ from django.contrib.auth.decorators import permission_required
 from django.conf import settings
 from django.template import RequestContext
 from django.template.loader import render_to_string
+from django.utils.translation import ugettext_lazy as _
 
 from wagtail.wagtailadmin import hooks
 from wagtail.wagtailadmin.forms import SearchForm
@@ -27,7 +28,19 @@ class SiteSummaryPanel(object):
             'total_pages': Page.objects.count() - 1,  # subtract 1 because the root node is not a real page
             'total_images': get_image_model().objects.count(),
             'total_docs': Document.objects.count(),
-            'search_form': SearchForm(),
+        }, RequestContext(self.request))
+
+
+class SearchPanel(object):
+    name = 'search'
+    order = 150
+
+    def __init__(self, request):
+        self.request = request
+
+    def render(self):
+        return render_to_string('wagtailadmin/home/search.html', {
+            'search_form': SearchForm(placeholder_suffix=_('pages')),
         }, RequestContext(self.request))
 
 
@@ -71,6 +84,7 @@ def home(request):
 
     panels = [
         SiteSummaryPanel(request),
+        SearchPanel(request),
         PagesForModerationPanel(request),
         RecentEditsPanel(request),
     ]


### PR DESCRIPTION
The form was already included, but not rendered anywhere.

I experimented with making the search real time like the other search
pages, but I could not get the design to look right and feel nice. It
was too busy with the other components on the page. Having the search
jump to the real search page was the best compromise that I could come
up with.
