### PR TITLE
Move normalise_query_string into wagtailsearch.utils and use it in the backends

### DIFF
--- a/wagtail/wagtailsearch/backends/db.py
+++ b/wagtail/wagtailsearch/backends/db.py
@@ -1,9 +1,8 @@
-import warnings
-
 from django.db import models
 
 from wagtail.wagtailsearch.backends.base import BaseSearch
 from wagtail.wagtailsearch.indexed import Indexed
+from wagtail.wagtailsearch.utils import normalise_query_string
 
 
 class DBSearch(BaseSearch):
@@ -29,6 +28,9 @@ class DBSearch(BaseSearch):
         pass # Not needed
 
     def search(self, query_string, model, fields=None, filters={}, prefetch_related=[]):
+        # Normalise query string
+        query_string = normalise_query_string(query_string)
+
         # Get terms
         terms = query_string.split()
         if not terms:

--- a/wagtail/wagtailsearch/backends/elasticsearch.py
+++ b/wagtail/wagtailsearch/backends/elasticsearch.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 
-import string
 import json
 import warnings
 
@@ -11,6 +10,7 @@ from elasticsearch.helpers import bulk
 
 from wagtail.wagtailsearch.backends.base import BaseSearch
 from wagtail.wagtailsearch.indexed import Indexed
+from wagtail.wagtailsearch.utils import normalise_query_string
 
 
 class ElasticSearchQuery(object):
@@ -417,8 +417,8 @@ class ElasticSearch(BaseSearch):
         if not issubclass(model, Indexed) or not issubclass(model, models.Model):
             return []
 
-        # Clean up query string
-        query_string = "".join([c for c in query_string if c not in string.punctuation])
+        # Normalise query string
+        query_string = normalise_query_string(query_string)
 
         # Check that theres still a query string after the clean up
         if not query_string:

--- a/wagtail/wagtailsearch/models.py
+++ b/wagtail/wagtailsearch/models.py
@@ -1,18 +1,18 @@
+import datetime
+
 from django.db import models
 from django.utils import timezone
 
-from indexed import Indexed
-import datetime
-import string
+from wagtail.wagtailsearch.indexed import Indexed
+from wagtail.wagtailsearch.utils import normalise_query_string, MAX_QUERY_STRING_LENGTH
 
-MAX_QUERY_STRING_LENGTH = 255
 
 class Query(models.Model):
     query_string = models.CharField(max_length=MAX_QUERY_STRING_LENGTH, unique=True)
 
     def save(self, *args, **kwargs):
         # Normalise query string
-        self.query_string = self.normalise_query_string(self.query_string)
+        self.query_string = normalise_query_string(self.query_string)
 
         super(Query, self).save(*args, **kwargs)
 
@@ -40,28 +40,12 @@ class Query(models.Model):
 
     @classmethod
     def get(cls, query_string):
-        return cls.objects.get_or_create(query_string=cls.normalise_query_string(query_string))[0]
+        return cls.objects.get_or_create(query_string=normalise_query_string(query_string))[0]
 
     @classmethod
     def get_most_popular(cls, date_since=None):
         # TODO: Implement date_since
         return cls.objects.filter(daily_hits__isnull=False).annotate(_hits=models.Sum('daily_hits__hits')).distinct().order_by('-_hits')
-
-    @staticmethod
-    def normalise_query_string(query_string):
-        # Truncate query string
-        if len(query_string) > MAX_QUERY_STRING_LENGTH:
-            query_string = query_string[:MAX_QUERY_STRING_LENGTH]
-        # Convert query_string to lowercase
-        query_string = query_string.lower()
-
-        # Strip punctuation characters
-        query_string = ''.join([c for c in query_string if c not in string.punctuation])
-
-        # Remove double spaces
-        query_string = ' '.join(query_string.split())
-
-        return query_string
 
 
 class QueryDailyHits(models.Model):

--- a/wagtail/wagtailsearch/tests/test_backends.py
+++ b/wagtail/wagtailsearch/tests/test_backends.py
@@ -160,6 +160,15 @@ class TestDBBackend(BackendTests, TestCase):
 class TestElasticSearchBackend(BackendTests, TestCase):
     backend_path = 'wagtail.wagtailsearch.backends.elasticsearch.ElasticSearch'
 
+    def test_search_with_spaces_only(self):
+        # Search for some space characters and hope it doesn't crash
+        results = self.backend.search("   ", models.SearchTest)
+
+        # Queries are lazily evaluated, force it to run
+        list(results)
+
+        # Didn't crash, yay!
+
 
 @override_settings(WAGTAILSEARCH_BACKENDS={
     'default': {'BACKEND': 'wagtail.wagtailsearch.backends.db.DBSearch'}

--- a/wagtail/wagtailsearch/tests/test_queries.py
+++ b/wagtail/wagtailsearch/tests/test_queries.py
@@ -1,8 +1,12 @@
+from StringIO import StringIO
+
 from django.test import TestCase
 from django.core import management
+
 from wagtail.wagtailsearch import models
 from wagtail.tests.utils import unittest, WagtailTestUtils
-from StringIO import StringIO
+from wagtail.wagtailsearch.utils import normalise_query_string
+
 
 
 class TestHitCounter(TestCase):
@@ -55,12 +59,12 @@ class TestQueryStringNormalisation(TestCase):
 
     def test_truncation(self):
         test_querystring = 'a' * 1000
-        result = models.Query.normalise_query_string(test_querystring)
+        result = normalise_query_string(test_querystring)
         self.assertEqual(len(result), 255)
 
     def test_no_truncation(self):
         test_querystring = 'a' * 10
-        result = models.Query.normalise_query_string(test_querystring)
+        result = normalise_query_string(test_querystring)
         self.assertEqual(len(result), 10)
 
 

--- a/wagtail/wagtailsearch/utils.py
+++ b/wagtail/wagtailsearch/utils.py
@@ -1,0 +1,20 @@
+import string
+
+
+MAX_QUERY_STRING_LENGTH = 255
+
+
+def normalise_query_string(query_string):
+    # Truncate query string
+    if len(query_string) > MAX_QUERY_STRING_LENGTH:
+        query_string = query_string[:MAX_QUERY_STRING_LENGTH]
+    # Convert query_string to lowercase
+    query_string = query_string.lower()
+
+    # Strip punctuation characters
+    query_string = ''.join([c for c in query_string if c not in string.punctuation])
+
+    # Remove double spaces
+    query_string = ' '.join(query_string.split())
+
+    return query_string

--- a/wagtail/wagtailsearch/views/queries.py
+++ b/wagtail/wagtailsearch/views/queries.py
@@ -6,6 +6,7 @@ from wagtail.wagtailadmin.modal_workflow import render_modal_workflow
 from wagtail.wagtailadmin.forms import SearchForm
 
 from wagtail.wagtailsearch import models
+from wagtail.wagtailsearch.utils import normalise_query_string
 
 
 @permission_required('wagtailadmin.access_admin')
@@ -19,7 +20,7 @@ def chooser(request, get_results=False):
         searchform = SearchForm(request.GET)
         if searchform.is_valid():
             query_string = searchform.cleaned_data['q']
-            queries = queries.filter(query_string__icontains=models.Query.normalise_query_string(query_string))
+            queries = queries.filter(query_string__icontains=normalise_query_string(query_string))
     else:
         searchform = SearchForm()
 


### PR DESCRIPTION
This fixes a bug which causes all search views to crash when the user searches for a bunch of spaces.

I've also cleaned up a few imports.
