### PR TITLE
Added page_published signal

### DIFF
--- a/wagtail/wagtailadmin/tests/test_pages_views.py
+++ b/wagtail/wagtailadmin/tests/test_pages_views.py
@@ -174,9 +174,9 @@ class TestPageCreation(TestCase, WagtailTestUtils):
         # Connect a mock signal handler to page_published signal
         signal_fired = [False]
         signal_page = [None]
-        def page_published_handler(sender, page, **kwargs):
+        def page_published_handler(sender, instance, **kwargs):
             signal_fired[0] = True
-            signal_page[0] = page
+            signal_page[0] = instance
         page_published.connect(page_published_handler)
 
         # Post
@@ -345,9 +345,9 @@ class TestPageEdit(TestCase, WagtailTestUtils):
         # Connect a mock signal handler to page_published signal
         signal_fired = [False]
         signal_page = [None]
-        def page_published_handler(sender, page, **kwargs):
+        def page_published_handler(sender, instance, **kwargs):
             signal_fired[0] = True
-            signal_page[0] = page
+            signal_page[0] = instance
         page_published.connect(page_published_handler)
 
         # Tests publish from edit page
@@ -672,9 +672,9 @@ class TestApproveRejectModeration(TestCase, WagtailTestUtils):
         # Connect a mock signal handler to page_published signal
         signal_fired = [False]
         signal_page = [None]
-        def page_published_handler(sender, page, **kwargs):
+        def page_published_handler(sender, instance, **kwargs):
             signal_fired[0] = True
-            signal_page[0] = page
+            signal_page[0] = instance
         page_published.connect(page_published_handler)
 
         # Post

--- a/wagtail/wagtailadmin/views/pages.py
+++ b/wagtail/wagtailadmin/views/pages.py
@@ -159,7 +159,7 @@ def create(request, content_type_app_name, content_type_model_name, parent_page_
             page.save_revision(user=request.user, submitted_for_moderation=is_submitting)
 
             if is_publishing:
-                page_published.send(sender=page_class, page=page)
+                page_published.send(sender=page_class, instance=page)
                 messages.success(request, _("Page '{0}' published.").format(page.title))
             elif is_submitting:
                 messages.success(request, _("Page '{0}' submitted for moderation.").format(page.title))
@@ -240,7 +240,7 @@ def edit(request, page_id):
             page.save_revision(user=request.user, submitted_for_moderation=is_submitting)
 
             if is_publishing:
-                page_published.send(sender=page.__class__, page=page)
+                page_published.send(sender=page.__class__, instance=page)
                 messages.success(request, _("Page '{0}' published.").format(page.title))
             elif is_submitting:
                 messages.success(request, _("Page '{0}' submitted for moderation.").format(page.title))
@@ -609,7 +609,7 @@ def approve_moderation(request, revision_id):
 
     if request.POST:
         revision.publish()
-        page_published.send(sender=revision.page.__class__, page=revision.page.specific)
+        page_published.send(sender=revision.page.__class__, instance=revision.page.specific)
         messages.success(request, _("Page '{0}' published.").format(revision.page.title))
         tasks.send_notification.delay(revision.id, 'approved', request.user.id)
 

--- a/wagtail/wagtailcore/signals.py
+++ b/wagtail/wagtailcore/signals.py
@@ -1,4 +1,4 @@
 from django.dispatch import Signal
 
 
-page_published = Signal(providing_args=['page'])
+page_published = Signal(providing_args=['instance'])


### PR DESCRIPTION
This is fired whenever "publish" is pressed on the create/edit page or whenever a moderator approves a submission.
