### PR TITLE
Allow search frontend urls to be imported from wagtailsearch.urls

### DIFF
--- a/wagtail/tests/urls.py
+++ b/wagtail/tests/urls.py
@@ -3,13 +3,13 @@ from django.conf.urls import patterns, include, url
 from wagtail.wagtailcore import urls as wagtail_urls
 from wagtail.wagtailadmin import urls as wagtailadmin_urls
 from wagtail.wagtaildocs import urls as wagtaildocs_urls
-from wagtail.wagtailsearch.urls import frontend as wagtailsearch_frontend_urls
+from wagtail.wagtailsearch import urls as wagtailsearch_urls
 from wagtail.contrib.wagtailsitemaps.views import sitemap
 
 
 urlpatterns = patterns('',
     url(r'^admin/', include(wagtailadmin_urls)),
-    url(r'^search/', include(wagtailsearch_frontend_urls)),
+    url(r'^search/', include(wagtailsearch_urls)),
     url(r'^documents/', include(wagtaildocs_urls)),
 
     url(r'^sitemap\.xml$', sitemap),

--- a/wagtail/wagtailsearch/urls/__init__.py
+++ b/wagtail/wagtailsearch/urls/__init__.py
@@ -1,0 +1,1 @@
+from wagtail.wagtailsearch.urls.frontend import urlpatterns


### PR DESCRIPTION
When editors picks is merged (PR #358), I plan to move `wagtailsearch.frontend.urls` to `wagtailsearch.urls`

This commit adds forwards-compatibility for this change
