### PR TITLE
Pull all test database options from env variables

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -34,8 +34,9 @@ if not settings.configured:
         DATABASES={
             'default': {
                 'ENGINE': os.environ.get('DATABASE_ENGINE', 'django.db.backends.postgresql_psycopg2'),
-                'NAME': 'wagtaildemo',
+                'NAME': os.environ.get('DATABASE_NAME', 'wagtaildemo'),
                 'USER': os.environ.get('DATABASE_USER', 'postgres'),
+                'PASSWORD': os.environ.get('DATABASE_PASS', None),
             }
         },
         ROOT_URLCONF='wagtail.tests.urls',


### PR DESCRIPTION
Just pulling two and assuming others broke the base configuration I was
using, which uses a different database name and has a password.

The change is backwards-compatible with the current set up.
