### PR TITLE
Support registering admin hooks through decorators

### DIFF
--- a/wagtail/tests/wagtail_hooks.py
+++ b/wagtail/tests/wagtail_hooks.py
@@ -3,14 +3,17 @@ from django.http import HttpResponse
 from wagtail.wagtailcore import hooks
 from wagtail.wagtailcore.whitelist import attribute_rule, check_url, allow_without_attributes
 
+
+# Register one hook using decorators...
+@hooks.register('insert_editor_css')
 def editor_css():
     return """<link rel="stylesheet" href="/path/to/my/custom.css">"""
-hooks.register('insert_editor_css', editor_css)
 
 
 def editor_js():
     return """<script src="/path/to/my/custom.js"></script>"""
 hooks.register('insert_editor_js', editor_js)
+# And the other using old-style function calls
 
 
 def whitelister_element_rules():

--- a/wagtail/wagtailcore/hooks.py
+++ b/wagtail/wagtailcore/hooks.py
@@ -7,13 +7,26 @@ except ImportError:
 
 _hooks = {}
 
-# TODO: support 'register' as a decorator:
-#    @hooks.register('construct_main_menu')
-#    def construct_main_menu(menu_items):
-#        ...
 
+def register(hook_name, fn=None):
+    """
+    Register hook for ``hook_name``. Can be used as a decorator::
 
-def register(hook_name, fn):
+        @register('hook_name')
+        def my_hook(...):
+            pass
+
+    or as a function call::
+
+        def my_hook(...):
+            pass
+        register('hook_name', my_hook)
+    """
+
+    # Pretend to be a decorator if fn is not supplied
+    if fn is None:
+        return lambda fn: register(hook_name, fn)
+
     if hook_name not in _hooks:
         _hooks[hook_name] = []
     _hooks[hook_name].append(fn)


### PR DESCRIPTION
Fixes the TODO note left in the code.

The change is backwards compatible with the function-style registrations. The tests have been updated such that one uses the decorator, and one continues to use the function style.
