### PR TITLE
Catch 'jav\tascript:alert("XSS")' as a bad URL

### DIFF
--- a/wagtail/wagtailcore/tests/test_whitelist.py
+++ b/wagtail/wagtailcore/tests/test_whitelist.py
@@ -17,6 +17,13 @@ class TestCheckUrl(TestCase):
     def test_disallowed_url_scheme(self):
         self.assertFalse(bool(check_url("invalid://url")))
 
+    def test_crafty_disallowed_url_scheme(self):
+        """
+        Some URL parsers do not parse 'jav\tascript:' as a valid scheme.
+        Browsers, however, do. The checker needs to catch these crafty schemes
+        """
+        self.assertFalse(bool(check_url("jav\tascript:alert('XSS')")))
+
 
 class TestAttributeRule(TestCase):
     def setUp(self):


### PR DESCRIPTION
The URL checker from html5lib was used as inspiration. As html5lib is
based on the same ideas that browsers (should) use for parsing and
checking, this solution should be much more robust.
