### PR TITLE
Elasticsearch: Cast __in lookup values to list

### DIFF
--- a/wagtail/wagtailsearch/backends/elasticsearch.py
+++ b/wagtail/wagtailsearch/backends/elasticsearch.py
@@ -205,7 +205,7 @@ class ElasticSearchQuery(object):
             if lookup == 'in':
                 return {
                     'terms': {
-                        field_index_name: value,
+                        field_index_name: list(value),
                     }
                 }
 


### PR DESCRIPTION
This makes sure lazily-evaluated lists (like querysets) are evaluated so they can be converted to JSON
