### PR TITLE
Return the function again from the hook decorator

### DIFF
--- a/wagtail/wagtailcore/hooks.py
+++ b/wagtail/wagtailcore/hooks.py
@@ -25,7 +25,10 @@ def register(hook_name, fn=None):
 
     # Pretend to be a decorator if fn is not supplied
     if fn is None:
-        return lambda fn: register(hook_name, fn)
+        def decorator(fn):
+            register(hook_name, fn)
+            return fn
+        return decorator
 
     if hook_name not in _hooks:
         _hooks[hook_name] = []


### PR DESCRIPTION
The decorator variant of hook registration did not return anything,
meaning that the decorated function would end up being `None`. This was
not noticed, as the functions are rarely called manually, as opposed to
being invoked via the hook.
