### PR TITLE
Use `Meta.abstract`, not `is_abstract`

### DIFF
--- a/wagtail/contrib/wagtailroutablepage/models.py
+++ b/wagtail/contrib/wagtailroutablepage/models.py
@@ -68,7 +68,5 @@ class RoutablePage(Page):
         view, args, kwargs = self.resolve_subpage('/')
         return view(*args, **kwargs)
 
-    is_abstract = True
-
     class Meta:
         abstract = True

--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -263,11 +263,7 @@ class PageBase(models.base.ModelBase):
 
         cls._clean_subpage_types = None  # to be filled in on first call to cls.clean_subpage_types
 
-        if not dct.get('is_abstract'):
-            # subclasses are only abstract if the subclass itself defines itself so
-            cls.is_abstract = False
-
-        if not cls.is_abstract:
+        if not cls._meta.abstract:
             # register this type in the list of page content types
             PAGE_MODEL_CLASSES.append(cls)
 

--- a/wagtail/wagtailforms/models.py
+++ b/wagtail/wagtailforms/models.py
@@ -116,7 +116,6 @@ class AbstractForm(Page):
     """A Form Page. Pages implementing a form should inhert from it"""
 
     form_builder = FormBuilder
-    is_abstract = True  # Don't display me in "Add"
 
     def __init__(self, *args, **kwargs):
         super(AbstractForm, self).__init__(*args, **kwargs)
@@ -186,7 +185,6 @@ class AbstractForm(Page):
 
 class AbstractEmailForm(AbstractForm):
     """A Form Page that sends email. Pages implementing a form to be send to an email should inherit from it"""
-    is_abstract = True  # Don't display me in "Add"
 
     to_address = models.CharField(max_length=255, blank=True, help_text=_("Optional - form submissions will be emailed to this address"))
     from_address = models.CharField(max_length=255, blank=True)


### PR DESCRIPTION
Page registration in the Page Metaclass now uses `Meta.abstract` over `is_abstract`.

`is_abstract` is non-standard, and replaces existing Django functionality. Infact, all classes in Wagtail code where `is_abstract` is defined also include the `Meta.abstract` flag.
