### PR TITLE
Fix deprecation warning for renamed wagtail_images

### DIFF
--- a/wagtail/wagtailimages/templates/wagtailimages/multiple/add.html
+++ b/wagtail/wagtailimages/templates/wagtailimages/multiple/add.html
@@ -1,5 +1,5 @@
 {% extends "wagtailadmin/base.html" %}
-{% load image_tags i18n compress static %}
+{% load wagtailimages_tags i18n compress static %}
 {% block titletag %}{% trans "Add multiple images" %}{% endblock %}
 {% block bodyclass %}menu-images{% endblock %}
 {% block extra_css %}


### PR DESCRIPTION
Simple change to get rid of deprecation warning
