### PR TITLE
Change page url functions to use reverse

### DIFF
--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -13,6 +13,7 @@ from django.http import Http404
 from django.core.cache import cache
 from django.core.handlers.wsgi import WSGIRequest
 from django.core.handlers.base import BaseHandler
+from django.core.urlresolvers import reverse
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.auth.models import Group
 from django.conf import settings
@@ -488,7 +489,7 @@ class Page(six.with_metaclass(PageBase, MP_Node, ClusterableModel, indexed.Index
         """Return the full URL (including protocol / domain) to this page, or None if it is not routable"""
         for (id, root_path, root_url) in Site.get_site_root_paths():
             if self.url_path.startswith(root_path):
-                return root_url + self.url_path[len(root_path) - 1:]
+                return root_url + reverse('wagtail', args=(self.url_path[len(root_path):],))
 
     @property
     def url(self):
@@ -503,7 +504,7 @@ class Page(six.with_metaclass(PageBase, MP_Node, ClusterableModel, indexed.Index
         root_paths = Site.get_site_root_paths()
         for (id, root_path, root_url) in Site.get_site_root_paths():
             if self.url_path.startswith(root_path):
-                return ('' if len(root_paths) == 1 else root_url) + self.url_path[len(root_path) - 1:]
+                return ('' if len(root_paths) == 1 else root_url) + reverse('wagtail', args=(self.url_path[len(root_path):],))
 
     def relative_url(self, current_site):
         """
@@ -513,7 +514,7 @@ class Page(six.with_metaclass(PageBase, MP_Node, ClusterableModel, indexed.Index
         """
         for (id, root_path, root_url) in Site.get_site_root_paths():
             if self.url_path.startswith(root_path):
-                return ('' if current_site.id == id else root_url) + self.url_path[len(root_path) - 1:]
+                return ('' if current_site.id == id else root_url) + reverse('wagtail', args=(self.url_path[len(root_path):],))
 
     @classmethod
     def search(cls, query_string, show_unpublished=False, search_title_only=False, extra_filters={}, prefetch_related=[], path=None):

--- a/wagtail/wagtailcore/urls.py
+++ b/wagtail/wagtailcore/urls.py
@@ -10,5 +10,5 @@ urlpatterns = [
     # a '/'. If a trailing slash is not present, we leave CommonMiddleware to
     # handle it as usual (i.e. redirect it to the trailing slash version if
     # settings.APPEND_SLASH is True)
-    url(r'^((?:[\w\-]+/)*)$', views.serve)
+    url(r'^((?:[\w\-]+/)*)$', views.serve, name="wagtail")
 ]


### PR DESCRIPTION
Fixes issue #69

I'd like to have Wagtail support running below the URL, for cases where Wagtail is used for a subsection of the site, and to support translations using Django's i18n_patterns which nests urls under the language code.

Reversing the root path using the main Wagtail url entry doesn't have any effect on the standard wagtail setup, so this still works fine.

```
urlpatterns = patterns('',
    url(r'', include(wagtail_urls,)),
)
```

And with the proposed changes here, these two cases would work as well.

```
urlpatterns += i18n_patterns(
    url(r'', include(wagtail_urls,)),
)

urlpatterns = patterns('',
    url(r'^pizza/', include(wagtail_urls,)),
)
```
