### PR TITLE
Improvements to type() PageQuerySet method

### DIFF
--- a/wagtail/wagtailcore/query.py
+++ b/wagtail/wagtailcore/query.py
@@ -1,4 +1,4 @@
-from django.db.models import Q
+from django.db.models import Q, get_models
 from django.contrib.contenttypes.models import ContentType
 from treebeard.mp_tree import MP_NodeQuerySet
 
@@ -152,9 +152,13 @@ class PageQuerySet(MP_NodeQuerySet):
         """
         return self.exclude(self.sibling_of_q(other, inclusive))
 
-    def type_q(self, model):
-        content_type = ContentType.objects.get_for_model(model)
-        return Q(content_type=content_type)
+    def type_q(self, klass):
+        content_types = ContentType.objects.get_for_models(*[
+            model for model in get_models()
+            if issubclass(model, klass)
+        ]).values()
+
+        return Q(content_type__in=content_types)
 
     def type(self, model):
         """


### PR DESCRIPTION
This commit makes the type PageQuerySet method include all concrete
models that descend from the specified model in the filter.

This makes this method useful for cases where you have many page types
descending from a single abstract model and want to search across all
these page types (which you can't do in Django normally).
