### PR TITLE
Make RoutablePage a mixin

### DIFF
--- a/docs/core_components/pages/advanced_topics/routable_page_mixin.rst
+++ b/docs/core_components/pages/advanced_topics/routable_page_mixin.rst
@@ -1,4 +1,4 @@
-.. _routable_page:
+.. _routable_page_mixin:
 
 ====================================
 Embedding URL configuration in Pages
@@ -6,15 +6,15 @@ Embedding URL configuration in Pages
 
 .. versionadded:: 0.5
 
-The ``RoutablePage`` class provides a convenient way for a page to respond on multiple sub-URLs with different views. For example, a blog section on a site might provide several different types of index page at URLs like ``/blog/2013/06/``, ``/blog/authors/bob/``, ``/blog/tagged/python/``, all served by the same ``BlogIndex`` page.
+The ``RoutablePageMixin`` mixin provides a convenient way for a page to respond on multiple sub-URLs with different views. For example, a blog section on a site might provide several different types of index page at URLs like ``/blog/2013/06/``, ``/blog/authors/bob/``, ``/blog/tagged/python/``, all served by the same ``BlogIndex`` page.
 
-A ``RoutablePage`` exists within the page tree like any other page, but URL paths underneath it are checked against a list of patterns, using Django's urlconf scheme. If none of the patterns match, control is passed to subpages as usual (or failing that, a 404 error is thrown).
+A ``Page`` using ``RoutablePageMixin`` exists within the page tree like any other page, but URL paths underneath it are checked against a list of patterns, using Django's urlconf scheme. If none of the patterns match, control is passed to subpages as usual (or failing that, a 404 error is thrown).
 
 
 The basics
 ==========
 
-To use ``RoutablePage``, you need to make your class inherit from :class:`wagtail.contrib.wagtailroutablepage.models.RoutablePage` and configure the ``subpage_urls`` attribute with your URL configuration.
+To use ``RoutablePageMixin``, you need to make your class inherit from both :class:`wagtail.contrib.wagtailroutablepage.models.RoutablePageMixin` and :class:`wagtail.wagtailcore.models.Page`, and configure the ``subpage_urls`` attribute with your URL configuration.
 
 Here's an example of an ``EventPage`` with three views:
 
@@ -22,10 +22,11 @@ Here's an example of an ``EventPage`` with three views:
 
     from django.conf.urls import url
 
-    from wagtail.contrib.wagtailroutablepage.models import RoutablePage
+    from wagtail.contrib.wagtailroutablepage.models import RoutablePageMixin
+    from wagtail.wagtailcore.models import Page
 
 
-    class EventPage(RoutablePage):
+    class EventPage(RoutablePageMixin, Page):
         subpage_urls = (
             url(r'^$', 'current_events', name='current_events'),
             url(r'^past/$', 'past_events', name='past_events'),
@@ -51,11 +52,11 @@ Here's an example of an ``EventPage`` with three views:
             ...
 
 
-The ``RoutablePage`` class
-==========================
+The ``RoutablePageMixin`` class
+===============================
 
 .. automodule:: wagtail.contrib.wagtailroutablepage.models
-.. autoclass:: RoutablePage
+.. autoclass:: RoutablePageMixin
 
     .. autoattribute:: subpage_urls
 
@@ -65,7 +66,9 @@ The ``RoutablePage`` class
 
             from django.conf.urls import url
 
-            class MyPage(RoutablePage):
+            from wagtail.wagtailcore.models import Page
+
+            class MyPage(RoutablePageMixin, Page):
                 subpage_urls = (
                     url(r'^$', 'serve', name='main'),
                     url(r'^archive/$', 'archive', name='archive'),

--- a/docs/core_components/pages/index.rst
+++ b/docs/core_components/pages/index.rst
@@ -21,4 +21,4 @@ The presentation of your content, the actual webpages, includes the normal use o
     editing_api
     advanced_topics/queryset_methods
     advanced_topics/private_pages
-    advanced_topics/routable_page
+    advanced_topics/routable_page_mixin

--- a/docs/releases/0.5.rst
+++ b/docs/releases/0.5.rst
@@ -37,7 +37,7 @@ RoutablePage
 
 A ``RoutablePage`` model has been added to allow embedding Django-style URL routing within a page.
 
-:ref:`routable_page`
+:ref:`routable_page_mixin`
 
 
 Usage stats for images, documents and snippets

--- a/wagtail/contrib/wagtailroutablepage/models.py
+++ b/wagtail/contrib/wagtailroutablepage/models.py
@@ -8,9 +8,10 @@ from wagtail.wagtailcore.models import Page
 from wagtail.wagtailcore.url_routing import RouteResult
 
 
-class RoutablePage(Page):
+class RoutablePageMixin(object):
     """
-    This class extends Page by adding methods to allow urlconfs to be embedded inside pages
+    This class can be mixed in to a Page subclass to allow urlconfs to be
+    embedded inside pages.
     """
     #: Set this to a tuple of ``django.conf.urls.url`` objects.
     subpage_urls = None
@@ -59,7 +60,7 @@ class RoutablePage(Page):
             except Http404:
                 pass
 
-        return super(RoutablePage, self).route(request, path_components)
+        return super(RoutablePageMixin, self).route(request, path_components)
 
     def serve(self, request, view, args, kwargs):
         return view(request, *args, **kwargs)
@@ -67,6 +68,13 @@ class RoutablePage(Page):
     def serve_preview(self, request, mode_name):
         view, args, kwargs = self.resolve_subpage('/')
         return view(*args, **kwargs)
+
+
+class RoutablePage(RoutablePageMixin, Page):
+    """
+    This class extends Page by adding methods to allow urlconfs
+    to be embedded inside pages
+    """
 
     is_abstract = True
 


### PR DESCRIPTION
If a developer wanted to have a site-wide base page class, and also have some pages be `RoutablePage`s, a conflict between the automatically generated `page_ptr` fields would occur.

``` python
from wagtail.wagtailcore.models import Page
from wagtail.contrib.wagtailroutablepage.models import RoutablePage

class SitePageBase(Page):
    # common functionality
    is_abstract = True
    class Meta:
        abstract = True

class MyPage(RoutablePage, SitePageBase):
    # This model is invalid
    pass
```

`RoutablePage` has been changed to be a mixin `RoutablePageMixin`. Page classes can use this to gain the `RoutablePage` functionality while still retaining the ability to subclass other models.

A `RoutablePage` class that derives from both `RoutablePageMixin` and `Page` has been left in for backwards compatibility, so old code will continue to function without any modifications.
