### PR TITLE
Make Page.copy also copy revisions

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,4 @@ coverage==3.7.1
 flake8==2.2.1
 mock==1.0.1
 python-dateutil==2.2
+pytz==2014.7

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ base =
     elasticsearch==1.1.0
     mock==1.0.1
     python-dateutil==2.2
+    pytz==2014.7
     Embedly
     coverage
 

--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -635,6 +635,8 @@ class Page(six.with_metaclass(PageBase, MP_Node, ClusterableModel, index.Indexed
         if copy_revisions:
             for revision in self.revisions.all():
                 revision.pk = None
+                revision.submitted_for_moderation = False
+                revision.approved_go_live_at = None
                 revision.page = page_copy
                 revision.save()
 


### PR DESCRIPTION
When I originally implemented `Page.copy`, I didn't see any use in copying revisions so I left this out to save space.

I've recently found that revisions can be quite handy for knowing when something was created and when it was last edited and this information is lost whenever the page is copied. This pull request makes `Page.copy` copy the pages revisions.
