### PR TITLE
Added logging for page operations

### DIFF
--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -670,7 +670,7 @@ class Page(six.with_metaclass(PageBase, MP_Node, ClusterableModel, index.Indexed
         new_self._update_descendant_url_paths(old_url_path, new_url_path)
 
         # Log
-        logger.info("Page moved: \"%s\" id=%d path=%s", self.title, self.id, self.url_path)
+        logger.info("Page moved: \"%s\" id=%d path=%s", self.title, self.id, new_url_path)
 
     def copy(self, recursive=False, to=None, update_attrs=None, copy_revisions=True):
         # Make a copy


### PR DESCRIPTION
This pull request adds python logging into wagtailcore for most page operations:
- [x] Create
- [x] Edit
- [x] Delete
- [x] Publish
- [x] Unpublish
- [x] Submit for moderation
- [x] Schedule for publishing
- [x] Move
- [x] Copy
- [x] Moderator accept
- [x] Moderator reject

None of them add any request or user information. They only log that the actual event has occured.
