### PR TITLE
Bump django-taggit version to 0.12.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ install_requires = [
     "django-compressor>=1.4",
     "django-libsass>=0.2",
     "django-modelcluster>=0.4",
-    "django-taggit==0.12.1",
+    "django-taggit==0.12.2",
     "django-treebeard==2.0",
     "Pillow>=2.3.0",
     "beautifulsoup4>=4.3.2",


### PR DESCRIPTION
0.12.1 did not have all of its migrations applied, which played havoc with migrations of apps that depended upon django-taggit
