### PR TITLE
Fix 584

### DIFF
--- a/wagtail/tests/fixtures/test.json
+++ b/wagtail/tests/fixtures/test.json
@@ -256,6 +256,20 @@
         "page": 8
     }
 },
+{
+    "pk": 3,
+    "model": "tests.formfield",
+    "fields": {
+        "sort_order": 3,
+        "label": "Your choices",
+        "field_type": "checkboxes",
+        "required": false,
+        "choices": "foo,bar,baz",
+        "default_value": "",
+        "help_text": "",
+        "page": 8
+    }
+},
 
 {
     "pk": 10,

--- a/wagtail/wagtailforms/models.py
+++ b/wagtail/wagtailforms/models.py
@@ -46,7 +46,15 @@ class FormSubmission(models.Model):
     submit_time = models.DateTimeField(auto_now_add=True)
 
     def get_data(self):
-        return json.loads(self.form_data)
+        # Convert sequences to strings.
+        # This check is required because form values used to be stored
+        # as strings and our now stored as lists, so form data may
+        # contain a mix of lists and strings.
+        data = json.loads(self.form_data)
+        for k, v in data.iteritems():
+            if hasattr(v, '__iter__'):
+                data[k] = ", ".join(data[k])
+        return data
 
     def __str__(self):
         return self.form_data
@@ -133,7 +141,7 @@ class AbstractForm(Page):
     def process_form_submission(self, form):
         # remove csrf_token from form.data
         form_data = dict(
-            i for i in form.data.items()
+            i for i in form.data.iterlists()
             if i[0] != 'csrfmiddlewaretoken'
         )
 


### PR DESCRIPTION
_Issue_

If a form is configured to have a checkbox field with multiple choices and a user submits that form with multiple boxes checked for that field, then only the last box checked will be recorded. This occurs because form data is extracted using the items() method.

_Fix_

I considered the following approaches:
1. When saving a form submission, convert lists to strings. Save all data as strings.
2. When saving a form submission, save all values as lists. Single values are saved as lists of one item. When form data is viewed in Wagtail Admin, display the lists as comma-separated strings.
3. When saving a form submission, save strings as strings and lists as lists.

This pull request implements option (2) for the following reasons:
1. Saving lists as lists preserves their structure. Saving all items as lists preserves uniformity of data representation.
2. The Wagtail Admin Forms page is likely to be viewed less often than the form itself and by administrators rather than website visitors, so it is better to incur performance overhead there.
3. This approach is much simpler than an implementation of option 3 would be.

Disadvantages of this approach:
1. Most field types do not require their values to be stored as lists, almost all saved forms submissions will consist of large numbers of single-entry lists.
2. Existing installations will have saved their form data as strings, but will begin saving it as lists after they upgrade. This will make reporting more complex and may break existing reporting code. 
