### PR TITLE
Fix page reordering in Wagtail Admin

### DIFF
--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/index.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/index.html
@@ -9,12 +9,12 @@
 
         {% include "wagtailadmin/shared/breadcrumb.html" with page=parent_page %}
     </header>
-   
+
     <form id="page-reorder-form">
         {% csrf_token %}
 
         {% page_permissions parent_page as parent_page_perms %}
-        {% include "wagtailadmin/pages/list.html" with sortable=1 allow_navigation=1 full_width=1 parent_page=parent_page orderable=parent_page_perms.can_reorder_children %} 
+        {% include "wagtailadmin/pages/list.html" with sortable=1 allow_navigation=1 full_width=1 parent_page=parent_page orderable=parent_page_perms.can_reorder_children %}
     </form>
 {% endblock %}
 
@@ -30,9 +30,10 @@
                 var orderform = $('#page-reorder-form');
 
                 $('.listing tbody').sortable({
-                    cursor: "move", 
-                    containment: "parent", 
-                    handle: ".handle", 
+                    cursor: "move",
+                    tolerance: "pointer",
+                    containment: "parent",
+                    handle: ".handle",
                     items: "> tr",
                     axis: "y",
                     placeholder: "dropzone",

--- a/wagtail/wagtailadmin/views/pages.py
+++ b/wagtail/wagtailadmin/views/pages.py
@@ -634,8 +634,13 @@ def set_page_position(request, page_to_move_id):
         # so don't bother to catch InvalidMoveToDescendant
 
         if position_page:
-            # Move page into this position
-            page_to_move.move(position_page, pos='left')
+            # If the page has been moved to the right, insert it to the
+            # right. If left, then left.
+            old_position = list(parent_page.get_children()).index(page_to_move)
+            if int(position) < old_position:
+                page_to_move.move(position_page, pos='left')
+            elif int(position) > old_position:
+                page_to_move.move(position_page, pos='right')
         else:
             # Move page to end
             page_to_move.move(parent_page, pos='last-child')


### PR DESCRIPTION
This pull request fixes two bugs found while investigating issue #661. 

1) Jquery UI's Sortable plugin would sometimes not detect that an item had been moved into the first or last position of the list, depending on the exact position of the mouse pointer.
2) Newly-moved pages were always inserted to the left of pages whose old position they were supposed to occupy. So given a list of the form:

_foo bar baz_

Moving _foo_ into _baz_'s position,

_bar foo baz_

Resulted in _foo_ being inserted to the left of _baz_, giving:

_foo bar baz_  

**Fixes**:

1) Change the 'tolerance' setting on Jquery UI's Sortable plugin so that it can detect when an item has been pulled into the first or last position in a list.
2) Detect whether a page was moved to the right or to the left. Insert it to the right if right, left if left.
