### PR TITLE
Don't display hidden fields in upload form on image chooser

### DIFF
--- a/wagtail/wagtailimages/templates/wagtailimages/chooser/chooser.html
+++ b/wagtail/wagtailimages/templates/wagtailimages/chooser/chooser.html
@@ -38,7 +38,11 @@
                 {% csrf_token %}
                 <ul class="fields">
                     {% for field in uploadform %}
-                        {% include "wagtailadmin/shared/field_as_li.html" with field=field %}
+                        {% if field.is_hidden %}
+                            {{ field }}
+                        {% else %}
+                            {% include "wagtailadmin/shared/field_as_li.html" with field=field %}
+                        {% endif %}
                     {% endfor %}
                     <li><input type="submit" value="{% trans 'Upload' %}" /></li>
                 </ul>


### PR DESCRIPTION
This is a regression in 0.7 introduced when we added manual image cropping
