### PR TITLE
Added missing fields/exclude option to some modelforms

### DIFF
--- a/wagtail/wagtailadmin/edit_handlers.py
+++ b/wagtail/wagtailadmin/edit_handlers.py
@@ -93,6 +93,11 @@ def get_form_for_model(
 
     if exclude is not None:
         attrs['exclude'] = exclude
+    else:
+        # If neither fields or exclude is set, set exclude to an empty list
+        if fields is None:
+            attrs['exclude'] = []
+
     if issubclass(model, Page):
         attrs['exclude'] = attrs.get('exclude', []) + ['content_type', 'path', 'depth', 'numchild']
 

--- a/wagtail/wagtaildocs/forms.py
+++ b/wagtail/wagtaildocs/forms.py
@@ -8,6 +8,7 @@ class DocumentForm(forms.ModelForm):
 
     class Meta:
         model = Document
+        fields = ('title', 'file', 'tags')
         widgets = {
             'file': forms.FileInput()
         }

--- a/wagtail/wagtailimages/forms.py
+++ b/wagtail/wagtailimages/forms.py
@@ -9,6 +9,8 @@ from wagtail.wagtailimages.formats import get_image_formats
 def get_image_form():
     return modelform_factory(
         get_image_model(),
+        exclude=(),
+
         # set the 'file' widget to a FileInput rather than the default ClearableFileInput
         # so that when editing, we don't get the 'currently: ...' banner which is
         # a bit pointless here

--- a/wagtail/wagtailsearch/forms.py
+++ b/wagtail/wagtailsearch/forms.py
@@ -22,6 +22,7 @@ class EditorsPickForm(forms.ModelForm):
 
     class Meta:
         model = models.EditorsPick
+        fields = ('query', 'page', 'description')
 
         widgets = {
             'description': forms.Textarea(attrs=dict(rows=3)),

--- a/wagtail/wagtailsites/forms.py
+++ b/wagtail/wagtailsites/forms.py
@@ -12,3 +12,4 @@ class SiteForm(forms.ModelForm):
 
     class Meta:
         model = Site
+        fields = ('hostname', 'port', 'root_page', 'is_default_site')


### PR DESCRIPTION
This cleans up some of the warnings when using Django 1.7, but not all of them. Theres still some missing fields/exclude in calls to `modelformset_factory` (which are hard to trace). Also theres still some warnings coming from Treebeard which hasn't got an official Django 1.7 build out yet.
