### PR TITLE
Add missing migrations

### DIFF
--- a/wagtail/tests/migrations/0004_auto_20141008_0420.py
+++ b/wagtail/tests/migrations/0004_auto_20141008_0420.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('tests', '0003_auto_20140905_0634'),
+    ]
+
+    operations = [
+        migrations.DeleteModel(
+            name='SearchTestOldConfig',
+        ),
+        migrations.DeleteModel(
+            name='SearchTestOldConfigList',
+        ),
+    ]

--- a/wagtail/wagtailcore/migrations/0006_auto_20141008_0420.py
+++ b/wagtail/wagtailcore/migrations/0006_auto_20141008_0420.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('wagtailcore', '0005_add_page_lock_permission_to_moderators'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='grouppagepermission',
+            name='permission_type',
+            field=models.CharField(max_length=20, choices=[(b'add', b'Add/edit pages you own'), (b'edit', b'Add/edit any page'), (b'publish', b'Publish any page'), (b'lock', b'Lock/unlock any page')]),
+        ),
+    ]


### PR DESCRIPTION
What it says on the tin. With a fresh checkout of master:

``` shell
$ django-admin makemigrations --settings wagtail.tests.settings
Migrations for 'tests':
  0004_auto_20141008_0420.py:
    - Delete model SearchTestOldConfig
    - Delete model SearchTestOldConfigList
Migrations for 'wagtailcore':
  0006_auto_20141008_0420.py:
    - Alter field permission_type on grouppagepermission
```
