### PR TITLE
Use AppConfig.ready to register signal handlers

### DIFF
--- a/docs/contrib_components/frontendcache.rst
+++ b/docs/contrib_components/frontendcache.rst
@@ -28,14 +28,18 @@ Firstly, add ``"wagtail.contrib.wagtailfrontendcache"`` to your INSTALLED_APPS:
         "wagtail.contrib.wagtailfrontendcache"
      ]
 
+.. versionchanged:: 0.8
 
-The ``wagtailfrontendcache`` module provides a set of signal handlers which will automatically purge the cache whenever a page is published or deleted. You should register these somewhere at the top of your ``urls.py`` file:
+    Signal handlers are now automatically registered in Django 1.7 and upwards
+
+The ``wagtailfrontendcache`` module provides a set of signal handlers which will automatically purge the cache whenever a page is published or deleted.
+
+If you are using Django version 1.7 or newer, these signal handlers are automatically registered when the ``wagtail.contrib.wagtailfrontendcache`` app is loaded. Otherwise, they must be registered as your application starts up. This can be done by placing the following code in your ``urls.py``:
 
 .. code-block:: python
 
     # urls.py
     from wagtail.contrib.wagtailfrontendcache.signal_handlers import register_signal_handlers
-
     register_signal_handlers()
 
 

--- a/docs/core_components/search/indexing.rst
+++ b/docs/core_components/search/indexing.rst
@@ -25,21 +25,19 @@ If the search index is kept separate from the database (when using Elasticsearch
 Signal handlers
 ---------------
 
+.. versionchanged:: 0.8
+
+    Signal handlers are now automatically registered in Django 1.7 and upwards
+
 Wagtailsearch provides some signal handlers which bind to the save/delete signals of all indexed models. This would automatically add and delete them from all backends you have registered in ``WAGTAILSEARCH_BACKENDS``.
 
-To register the signal handlers, add the following code somewhere it would be executed at startup. We reccommend adding this to your projects ``urls.py``:
+If you are using Django version 1.7 or newer, these signal handlers are automatically registered when the ``wagtail.wagtailsearch`` app is loaded. Otherwise, they must be registered as your application starts up. This can be done by placing the following code in your ``urls.py``:
 
-.. code-block: python
+.. code-block:: python
 
     # urls.py
     from wagtail.wagtailsearch.signal_handlers import register_signal_handlers
-
     register_signal_handlers()
-
-
-.. note::
-
-    If your project was made with the ``wagtail start`` command, this will already be set up for you.
 
 
 The ``update_index`` command

--- a/docs/howto/settings.rst
+++ b/docs/howto/settings.rst
@@ -273,18 +273,6 @@ Other Django Settings Used by Wagtail
 For information on what these settings do, see `Django Settings <https://docs.djangoproject.com/en/dev/ref/settings/>`__.
 
 
-Search Signal Handlers
-----------------------
-
-.. code-block:: python
-
-  from wagtail.wagtailsearch import register_signal_handlers as wagtailsearch_register_signal_handlers
-  
-  wagtailsearch_register_signal_handlers()
-
-This loads Wagtail's search signal handlers, which need to be loaded very early in the Django life cycle. While not technically a urlconf, this is a convenient place to load them. Calling this function registers signal handlers to watch for when indexed models get saved or deleted. This allows wagtailsearch to update ElasticSearch automatically.
-
-
 URL Patterns
 ------------
 
@@ -296,8 +284,6 @@ URL Patterns
   from wagtail.wagtailadmin import urls as wagtailadmin_urls
   from wagtail.wagtaildocs import urls as wagtaildocs_urls
   from wagtail.wagtailsearch.urls import frontend as wagtailsearch_frontend_urls
-
-  admin.autodiscover()
 
   urlpatterns = patterns('',
     url(r'^django-admin/', include(admin.site.urls)),
@@ -570,13 +556,6 @@ urls.py
   from wagtail.wagtailadmin import urls as wagtailadmin_urls
   from wagtail.wagtaildocs import urls as wagtaildocs_urls
   from wagtail.wagtailsearch.urls import frontend as wagtailsearch_frontend_urls
-
-  admin.autodiscover()
-
-
-  # Signal handlers
-  from wagtail.wagtailsearch import register_signal_handlers as wagtailsearch_register_signal_handlers
-  wagtailsearch_register_signal_handlers()
 
 
   urlpatterns = patterns('',

--- a/docs/releases/0.8.rst
+++ b/docs/releases/0.8.rst
@@ -1,0 +1,33 @@
+=========================
+Wagtail 0.8 release notes
+=========================
+
+.. contents::
+    :local:
+    :depth: 1
+
+
+What's new
+==========
+
+
+
+Minor features
+~~~~~~~~~~~~~~
+
+ * Signal handlers for ``wagtail.wagtailsearch`` and ``wagtail.contrib.wagtailfrontendcache`` are automatically registered.
+
+
+Bug fixes
+~~~~~~~~~
+
+ * 
+
+
+Upgrade considerations
+======================
+
+Automatic registration of signal handlers
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Signal handlers for the ``wagtailsearch`` core app and ``wagtailfrontendcache`` contrib app are automatically registered. Calls to ``register_signal_handlers`` from your ``urls.py`` can be removed.

--- a/wagtail/contrib/wagtailfrontendcache/apps.py
+++ b/wagtail/contrib/wagtailfrontendcache/apps.py
@@ -1,7 +1,11 @@
 from django.apps import AppConfig
+from wagtail.contrib.wagtailfrontendcache.signal_handlers import register_signal_handlers
 
 
 class WagtailFrontendCacheAppConfig(AppConfig):
     name = 'wagtail.contrib.wagtailfrontendcache'
     label = 'wagtailfrontendcache'
     verbose_name = "Wagtail frontend cache"
+
+    def ready(self):
+        register_signal_handlers()

--- a/wagtail/contrib/wagtailfrontendcache/signal_handlers.py
+++ b/wagtail/contrib/wagtailfrontendcache/signal_handlers.py
@@ -1,6 +1,5 @@
 from django.db import models
 
-from wagtail.wagtailcore.models import Page
 from wagtail.wagtailcore.signals import page_published, page_unpublished
 
 from wagtail.contrib.wagtailfrontendcache.utils import purge_page_from_cache
@@ -16,6 +15,7 @@ def page_unpublished_signal_handler(instance, **kwargs):
 
 def register_signal_handlers():
     # Get list of models that are page types
+    Page = models.get_model('wagtailcore', 'Page')
     indexed_models = [model for model in models.get_models() if issubclass(model, Page)]
 
     # Loop through list and register signal handlers for each one

--- a/wagtail/project_template/project_name/urls.py
+++ b/wagtail/project_template/project_name/urls.py
@@ -11,14 +11,6 @@ from wagtail.wagtaildocs import urls as wagtaildocs_urls
 from wagtail.wagtailcore import urls as wagtail_urls
 
 
-admin.autodiscover()
-
-
-# Register search signal handlers
-from wagtail.wagtailsearch.signal_handlers import register_signal_handlers as wagtailsearch_register_signal_handlers
-wagtailsearch_register_signal_handlers()
-
-
 urlpatterns = patterns('',
     url(r'^django-admin/', include(admin.site.urls)),
 

--- a/wagtail/wagtaildocs/tests.py
+++ b/wagtail/wagtaildocs/tests.py
@@ -438,9 +438,6 @@ class TestIssue613(TestCase, WagtailTestUtils):
         self.search_backend = self.get_elasticsearch_backend()
         self.login()
 
-        from wagtail.wagtailsearch.signal_handlers import register_signal_handlers
-        register_signal_handlers()
-
     def add_document(self, **params):
         # Build a fake file
         fake_file = ContentFile(b("A boring example document"))

--- a/wagtail/wagtailimages/tests.py
+++ b/wagtail/wagtailimages/tests.py
@@ -989,9 +989,6 @@ class TestIssue613(TestCase, WagtailTestUtils):
         self.search_backend = self.get_elasticsearch_backend()
         self.login()
 
-        from wagtail.wagtailsearch.signal_handlers import register_signal_handlers
-        register_signal_handlers()
-
     def add_image(self, **params):
         post_data = {
             'title': "Test image",

--- a/wagtail/wagtailsearch/apps.py
+++ b/wagtail/wagtailsearch/apps.py
@@ -1,7 +1,11 @@
 from django.apps import AppConfig
+from wagtail.wagtailsearch.signal_handlers import register_signal_handlers
 
 
 class WagtailSearchAppConfig(AppConfig):
     name = 'wagtail.wagtailsearch'
     label = 'wagtailsearch'
     verbose_name = "Wagtail search"
+
+    def ready(self):
+        register_signal_handlers()


### PR DESCRIPTION
Django 1.6 is still supported by manually calling `register_signal_handlers` as it was before, but for Django 1.7 this can be done automatically.

Tests in 1.6 will likely not pass now, as the signal handlers are no longer registered manually by the tests. Is 1.6 compatibility still important? If so, I will fix the tests. The project template states Django `>=1.7` as a requirement, but  `install_requires` in `setup.py` states `>=1.6.2`.

References to `admin.autodiscover()` in the project template and docs have been removed as well, as this is called from the AdminConfig when `django.contrib.admin` is loaded in 1.7.
