### PR TITLE
Typo fix in wagtailforms help text

### DIFF
--- a/wagtail/wagtailforms/locale/bg/LC_MESSAGES/django.po
+++ b/wagtail/wagtailforms/locale/bg/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 msgid ""
 msgstr ""
@@ -67,12 +67,12 @@ msgstr ""
 
 #: models.py:67
 msgid ""
-"Comma seperated list of choices. Only applicable in checkboxes, radio and "
+"Comma separated list of choices. Only applicable in checkboxes, radio and "
 "dropdown."
 msgstr ""
 
 #: models.py:72
-msgid "Default value. Comma seperated values supported for checkboxes."
+msgid "Default value. Comma separated values supported for checkboxes."
 msgstr ""
 
 #: models.py:191

--- a/wagtail/wagtailforms/locale/ca/LC_MESSAGES/django.po
+++ b/wagtail/wagtailforms/locale/ca/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 msgid ""
 msgstr ""
@@ -67,12 +67,12 @@ msgstr ""
 
 #: models.py:67
 msgid ""
-"Comma seperated list of choices. Only applicable in checkboxes, radio and "
+"Comma separated list of choices. Only applicable in checkboxes, radio and "
 "dropdown."
 msgstr ""
 
 #: models.py:72
-msgid "Default value. Comma seperated values supported for checkboxes."
+msgid "Default value. Comma separated values supported for checkboxes."
 msgstr ""
 
 #: models.py:191

--- a/wagtail/wagtailforms/locale/de/LC_MESSAGES/django.po
+++ b/wagtail/wagtailforms/locale/de/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 msgid ""
 msgstr ""
@@ -67,12 +67,12 @@ msgstr ""
 
 #: models.py:67
 msgid ""
-"Comma seperated list of choices. Only applicable in checkboxes, radio and "
+"Comma separated list of choices. Only applicable in checkboxes, radio and "
 "dropdown."
 msgstr ""
 
 #: models.py:72
-msgid "Default value. Comma seperated values supported for checkboxes."
+msgid "Default value. Comma separated values supported for checkboxes."
 msgstr ""
 
 #: models.py:191

--- a/wagtail/wagtailforms/locale/el/LC_MESSAGES/django.po
+++ b/wagtail/wagtailforms/locale/el/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 msgid ""
 msgstr ""
@@ -67,12 +67,12 @@ msgstr ""
 
 #: models.py:67
 msgid ""
-"Comma seperated list of choices. Only applicable in checkboxes, radio and "
+"Comma separated list of choices. Only applicable in checkboxes, radio and "
 "dropdown."
 msgstr ""
 
 #: models.py:72
-msgid "Default value. Comma seperated values supported for checkboxes."
+msgid "Default value. Comma separated values supported for checkboxes."
 msgstr ""
 
 #: models.py:191

--- a/wagtail/wagtailforms/locale/en/LC_MESSAGES/django.po
+++ b/wagtail/wagtailforms/locale/en/LC_MESSAGES/django.po
@@ -67,12 +67,12 @@ msgstr ""
 
 #: models.py:67
 msgid ""
-"Comma seperated list of choices. Only applicable in checkboxes, radio and "
+"Comma separated list of choices. Only applicable in checkboxes, radio and "
 "dropdown."
 msgstr ""
 
 #: models.py:72
-msgid "Default value. Comma seperated values supported for checkboxes."
+msgid "Default value. Comma separated values supported for checkboxes."
 msgstr ""
 
 #: models.py:191

--- a/wagtail/wagtailforms/locale/es/LC_MESSAGES/django.po
+++ b/wagtail/wagtailforms/locale/es/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 msgid ""
 msgstr ""
@@ -67,12 +67,12 @@ msgstr ""
 
 #: models.py:67
 msgid ""
-"Comma seperated list of choices. Only applicable in checkboxes, radio and "
+"Comma separated list of choices. Only applicable in checkboxes, radio and "
 "dropdown."
 msgstr ""
 
 #: models.py:72
-msgid "Default value. Comma seperated values supported for checkboxes."
+msgid "Default value. Comma separated values supported for checkboxes."
 msgstr ""
 
 #: models.py:191

--- a/wagtail/wagtailforms/locale/eu/LC_MESSAGES/django.po
+++ b/wagtail/wagtailforms/locale/eu/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 msgid ""
 msgstr ""
@@ -67,12 +67,12 @@ msgstr ""
 
 #: models.py:67
 msgid ""
-"Comma seperated list of choices. Only applicable in checkboxes, radio and "
+"Comma separated list of choices. Only applicable in checkboxes, radio and "
 "dropdown."
 msgstr ""
 
 #: models.py:72
-msgid "Default value. Comma seperated values supported for checkboxes."
+msgid "Default value. Comma separated values supported for checkboxes."
 msgstr ""
 
 #: models.py:191

--- a/wagtail/wagtailforms/locale/fr/LC_MESSAGES/django.po
+++ b/wagtail/wagtailforms/locale/fr/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 msgid ""
 msgstr ""
@@ -67,12 +67,12 @@ msgstr ""
 
 #: models.py:67
 msgid ""
-"Comma seperated list of choices. Only applicable in checkboxes, radio and "
+"Comma separated list of choices. Only applicable in checkboxes, radio and "
 "dropdown."
 msgstr ""
 
 #: models.py:72
-msgid "Default value. Comma seperated values supported for checkboxes."
+msgid "Default value. Comma separated values supported for checkboxes."
 msgstr ""
 
 #: models.py:191

--- a/wagtail/wagtailforms/locale/gl/LC_MESSAGES/django.po
+++ b/wagtail/wagtailforms/locale/gl/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 msgid ""
 msgstr ""
@@ -67,12 +67,12 @@ msgstr ""
 
 #: models.py:67
 msgid ""
-"Comma seperated list of choices. Only applicable in checkboxes, radio and "
+"Comma separated list of choices. Only applicable in checkboxes, radio and "
 "dropdown."
 msgstr ""
 
 #: models.py:72
-msgid "Default value. Comma seperated values supported for checkboxes."
+msgid "Default value. Comma separated values supported for checkboxes."
 msgstr ""
 
 #: models.py:191

--- a/wagtail/wagtailforms/locale/mn/LC_MESSAGES/django.po
+++ b/wagtail/wagtailforms/locale/mn/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 msgid ""
 msgstr ""
@@ -67,12 +67,12 @@ msgstr ""
 
 #: models.py:67
 msgid ""
-"Comma seperated list of choices. Only applicable in checkboxes, radio and "
+"Comma separated list of choices. Only applicable in checkboxes, radio and "
 "dropdown."
 msgstr ""
 
 #: models.py:72
-msgid "Default value. Comma seperated values supported for checkboxes."
+msgid "Default value. Comma separated values supported for checkboxes."
 msgstr ""
 
 #: models.py:191

--- a/wagtail/wagtailforms/locale/pl/LC_MESSAGES/django.po
+++ b/wagtail/wagtailforms/locale/pl/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 msgid ""
 msgstr ""
@@ -67,12 +67,12 @@ msgstr ""
 
 #: models.py:67
 msgid ""
-"Comma seperated list of choices. Only applicable in checkboxes, radio and "
+"Comma separated list of choices. Only applicable in checkboxes, radio and "
 "dropdown."
 msgstr ""
 
 #: models.py:72
-msgid "Default value. Comma seperated values supported for checkboxes."
+msgid "Default value. Comma separated values supported for checkboxes."
 msgstr ""
 
 #: models.py:191

--- a/wagtail/wagtailforms/locale/pt_BR/LC_MESSAGES/django.po
+++ b/wagtail/wagtailforms/locale/pt_BR/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 msgid ""
 msgstr ""
@@ -67,12 +67,12 @@ msgstr ""
 
 #: models.py:67
 msgid ""
-"Comma seperated list of choices. Only applicable in checkboxes, radio and "
+"Comma separated list of choices. Only applicable in checkboxes, radio and "
 "dropdown."
 msgstr ""
 
 #: models.py:72
-msgid "Default value. Comma seperated values supported for checkboxes."
+msgid "Default value. Comma separated values supported for checkboxes."
 msgstr ""
 
 #: models.py:191

--- a/wagtail/wagtailforms/locale/pt_PT/LC_MESSAGES/django.po
+++ b/wagtail/wagtailforms/locale/pt_PT/LC_MESSAGES/django.po
@@ -69,14 +69,14 @@ msgstr "O nome do campo do formulário"
 
 #: models.py:67
 msgid ""
-"Comma seperated list of choices. Only applicable in checkboxes, radio and "
+"Comma separated list of choices. Only applicable in checkboxes, radio and "
 "dropdown."
 msgstr ""
 "Lista de opções separadas por vírgula. Só utilizável nas caixas de seleção, "
 "botões e listas pendentes."
 
 #: models.py:72
-msgid "Default value. Comma seperated values supported for checkboxes."
+msgid "Default value. Comma separated values supported for checkboxes."
 msgstr ""
 "Valor pré-definido. Valores separados por vírgula admitidos nas caixas de "
 "seleção."

--- a/wagtail/wagtailforms/locale/ro/LC_MESSAGES/django.po
+++ b/wagtail/wagtailforms/locale/ro/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 msgid ""
 msgstr ""
@@ -67,12 +67,12 @@ msgstr ""
 
 #: models.py:67
 msgid ""
-"Comma seperated list of choices. Only applicable in checkboxes, radio and "
+"Comma separated list of choices. Only applicable in checkboxes, radio and "
 "dropdown."
 msgstr ""
 
 #: models.py:72
-msgid "Default value. Comma seperated values supported for checkboxes."
+msgid "Default value. Comma separated values supported for checkboxes."
 msgstr ""
 
 #: models.py:191

--- a/wagtail/wagtailforms/locale/ru/LC_MESSAGES/django.po
+++ b/wagtail/wagtailforms/locale/ru/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 # Eugene MechanisM <contact@mechanism.name>, 2014
 msgid ""
@@ -68,12 +68,12 @@ msgstr "Метка поля формы"
 
 #: models.py:67
 msgid ""
-"Comma seperated list of choices. Only applicable in checkboxes, radio and "
+"Comma separated list of choices. Only applicable in checkboxes, radio and "
 "dropdown."
 msgstr "Разделенный запятыми список вариантов. Применяется только для флажков, радиокнопок и в выпадающем списке."
 
 #: models.py:72
-msgid "Default value. Comma seperated values supported for checkboxes."
+msgid "Default value. Comma separated values supported for checkboxes."
 msgstr "Значение по умолчанию. Разделенные запятыми значения для флажков."
 
 #: models.py:191

--- a/wagtail/wagtailforms/locale/vi/LC_MESSAGES/django.po
+++ b/wagtail/wagtailforms/locale/vi/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 msgid ""
 msgstr ""
@@ -67,12 +67,12 @@ msgstr ""
 
 #: models.py:67
 msgid ""
-"Comma seperated list of choices. Only applicable in checkboxes, radio and "
+"Comma separated list of choices. Only applicable in checkboxes, radio and "
 "dropdown."
 msgstr ""
 
 #: models.py:72
-msgid "Default value. Comma seperated values supported for checkboxes."
+msgid "Default value. Comma separated values supported for checkboxes."
 msgstr ""
 
 #: models.py:191

--- a/wagtail/wagtailforms/locale/zh/LC_MESSAGES/django.po
+++ b/wagtail/wagtailforms/locale/zh/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 msgid ""
 msgstr ""
@@ -67,12 +67,12 @@ msgstr ""
 
 #: models.py:67
 msgid ""
-"Comma seperated list of choices. Only applicable in checkboxes, radio and "
+"Comma separated list of choices. Only applicable in checkboxes, radio and "
 "dropdown."
 msgstr ""
 
 #: models.py:72
-msgid "Default value. Comma seperated values supported for checkboxes."
+msgid "Default value. Comma separated values supported for checkboxes."
 msgstr ""
 
 #: models.py:191

--- a/wagtail/wagtailforms/models.py
+++ b/wagtail/wagtailforms/models.py
@@ -64,12 +64,12 @@ class AbstractFormField(Orderable):
     choices = models.CharField(
         max_length=512,
         blank=True,
-        help_text=_('Comma seperated list of choices. Only applicable in checkboxes, radio and dropdown.')
+        help_text=_('Comma separated list of choices. Only applicable in checkboxes, radio and dropdown.')
     )
     default_value = models.CharField(
         max_length=255,
         blank=True,
-        help_text=_('Default value. Comma seperated values supported for checkboxes.')
+        help_text=_('Default value. Comma separated values supported for checkboxes.')
     )
     help_text = models.CharField(max_length=255, blank=True)
 


### PR DESCRIPTION
s/seperated/separated/
