### PR TITLE
Tabbing from password field goes to Submit

### DIFF
--- a/wagtail/wagtailadmin/forms.py
+++ b/wagtail/wagtailadmin/forms.py
@@ -40,10 +40,14 @@ class EmailLinkChooserWithLinkTextForm(forms.Form):
 class LoginForm(AuthenticationForm):
     username = forms.CharField(
         max_length=254,
-        widget=forms.TextInput(attrs={'placeholder': ugettext_lazy("Enter your username")}),
+        widget=forms.TextInput(attrs={'placeholder': ugettext_lazy("Enter your username"),
+                                      'tabindex': '1',
+                                      }),
     )
     password = forms.CharField(
-        widget=forms.PasswordInput(attrs={'placeholder': ugettext_lazy("Enter password")}),
+        widget=forms.PasswordInput(attrs={'placeholder': ugettext_lazy("Enter password"),
+                                          'tabindex': '2',
+                                          }),
     )
 
 

--- a/wagtail/wagtailadmin/templates/wagtailadmin/login.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/login.html
@@ -55,7 +55,7 @@
                     </li>
                 {% endcomment %}
                 <li class="submit">
-                    <input type="submit" value="{% trans 'Sign in' %}"/>
+                    <input type="submit" value="{% trans 'Sign in' %}" tabindex="3"/>
                 </li>
             </ul>
         </form>


### PR DESCRIPTION
When I log in to a site, my muscle memory typically goes:
- type username
- [TAB]
- type password
- [TAB]
- [Enter]

On the Wagtail log in page at the moment, the second [TAB] followed by [Enter] instead opens the 'Forgot password' page. I'm now bored of reading the Wagtail 'forgot password' page.

This pull request redresses that.
