### PR TITLE
Search: Prevent abstract models from being indexed

### DIFF
--- a/wagtail/wagtailsearch/backends/base.py
+++ b/wagtail/wagtailsearch/backends/base.py
@@ -1,21 +1,13 @@
-from django.db import models
 from django.db.models.query import QuerySet
 from django.core.exceptions import ImproperlyConfigured
 
-from wagtail.wagtailsearch.index import Indexed
+from wagtail.wagtailsearch.index import class_is_indexed
 from wagtail.wagtailsearch.utils import normalise_query_string
 
 
 class BaseSearch(object):
     def __init__(self, params):
         pass
-
-    def object_can_be_indexed(self, obj):
-        # Object must be a decendant of Indexed and be a django model
-        if not isinstance(obj, Indexed) or not isinstance(obj, models.Model):
-            return False
-
-        return True
 
     def reset_index(self):
         return NotImplemented
@@ -47,8 +39,8 @@ class BaseSearch(object):
             model = model_or_queryset
             queryset = model_or_queryset.objects.all()
 
-        # Model must be a descendant of Indexed and be a django model
-        if not issubclass(model, Indexed) or not issubclass(model, models.Model):
+        # Model must be a class that is in the index
+        if not class_is_indexed(model):
             return []
 
         # Normalise query string

--- a/wagtail/wagtailsearch/index.py
+++ b/wagtail/wagtailsearch/index.py
@@ -72,6 +72,17 @@ class Indexed(object):
     search_fields = ()
 
 
+def get_indexed_models():
+    return [
+        model for model in models.get_models()
+        if issubclass(model, Indexed) and not model._meta.abstract
+    ]
+
+
+def class_is_indexed(cls):
+    return issubclass(cls, Indexed) and issubclass(cls, models.Model) and not cls._meta.abstract
+
+
 class BaseField(object):
     suffix = ''
 

--- a/wagtail/wagtailsearch/management/commands/update_index.py
+++ b/wagtail/wagtailsearch/management/commands/update_index.py
@@ -1,22 +1,18 @@
 from optparse import make_option
 
 from django.core.management.base import BaseCommand
-from django.db import models
 from django.conf import settings
 
-from wagtail.wagtailsearch.index import Indexed
+from wagtail.wagtailsearch.index import Indexed, get_indexed_models
 from wagtail.wagtailsearch.backends import get_search_backend
 
 
 class Command(BaseCommand):
     def get_object_list(self):
-        # Get list of indexed models
-        indexed_models = [model for model in models.get_models() if issubclass(model, Indexed)]
-
         # Return list of (model_name, queryset) tuples
         return [
             (model, model.get_indexed_objects())
-            for model in indexed_models
+            for model in get_indexed_models()
         ]
 
     def update_backend(self, backend_name, object_list):

--- a/wagtail/wagtailsearch/signal_handlers.py
+++ b/wagtail/wagtailsearch/signal_handlers.py
@@ -1,7 +1,6 @@
 from django.db.models.signals import post_save, post_delete
-from django.db import models
 
-from wagtail.wagtailsearch.index import Indexed
+from wagtail.wagtailsearch.index import Indexed, get_indexed_models
 from wagtail.wagtailsearch.backends import get_search_backends
 
 
@@ -34,10 +33,7 @@ def post_delete_signal_handler(instance, **kwargs):
 
 
 def register_signal_handlers():
-    # Get list of models that should be indexed
-    indexed_models = [model for model in models.get_models() if issubclass(model, Indexed)]
-
     # Loop through list and register signal handlers for each one
-    for model in indexed_models:
+    for model in get_indexed_models():
         post_save.connect(post_save_signal_handler, sender=model)
         post_delete.connect(post_delete_signal_handler, sender=model)


### PR DESCRIPTION
This builds on top of #714 to help prevent merge conflicts

If you have an abstract model in between two concrete models in the class inheritance hierarchy. Wagtailsearch will attempt to add that abstract model into the index which would cause many duplicates to be made.

This pull requests fixes this behaviour and also does some cleanup to centralise the "can this model be indexed?" logic
