### PR TITLE
Project template: Fixed migration dependency

### DIFF
--- a/wagtail/project_template/core/migrations/0001_initial.py
+++ b/wagtail/project_template/core/migrations/0001_initial.py
@@ -7,7 +7,7 @@ from django.db import models, migrations
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('wagtailcore', '0002_initial_data'),
+        ('wagtailcore', '__latest__'),
     ]
 
     operations = [


### PR DESCRIPTION
The project template currently crashes on first migrate because it tries
to run the create homepage migration before the Page.locked field is
created.

This commit fixes (and hopefully, future proofs) this by telling Django
that the core app migrations depend on the latest wagtailcore migration,
which should make Django fully migrate wagtailcore before starting the
core app.
