### PR TITLE
update migration dependency to avoid error

### DIFF
--- a/wagtail/project_template/core/migrations/0001_initial.py
+++ b/wagtail/project_template/core/migrations/0001_initial.py
@@ -7,7 +7,7 @@ from django.db import models, migrations
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('wagtailcore', '0002_initial_data'),
+        ('wagtailcore', '0008_populate_latest_revision_created_at'),
     ]
 
     operations = [


### PR DESCRIPTION
This error took me several hours to isolate.

To reproduce, using Django 1.7:
1. Add an app with a name earlier than "core" in dictionary ordering (for example, "calendar"). Evidently this is an execution order thing.
2. Add a `wagtailcore.models.Page` derived model to the app.
3. Run `./manage.py migrate`

```
  Applying core.0001_initial... OK
  Applying core.0002_create_homepage...Traceback (most recent call last):
  File "./manage.py", line 10, in <module>
    execute_from_command_line(sys.argv)
  File ".../django/core/management/__init__.py", line 385, in execute_from_command_line
    utility.execute()
  File ".../django/core/management/__init__.py", line 377, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File ".../django/core/management/base.py", line 288, in run_from_argv
    self.execute(*args, **options.__dict__)
  File ".../django/core/management/base.py", line 338, in execute
    output = self.handle(*args, **options)
  File ".../django/core/management/commands/migrate.py", line 160, in handle
    executor.migrate(targets, plan, fake=options.get("fake", False))
  File ".../django/db/migrations/executor.py", line 63, in migrate
    self.apply_migration(migration, fake=fake)
  File ".../django/db/migrations/executor.py", line 97, in apply_migration
    migration.apply(project_state, schema_editor)
  File ".../django/db/migrations/migration.py", line 107, in apply
    operation.database_forwards(self.app_label, schema_editor, project_state, new_state)
  File ".../django/db/migrations/operations/special.py", line 117, in database_forwards
    self.code(from_state.render(), schema_editor)
  File ".../core/migrations/0002_create_homepage.py", line 30, in create_homepage
    locked=False,
  File ".../django/db/models/manager.py", line 92, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File ".../django/db/models/query.py", line 370, in create
    obj = self.model(**kwargs)
  File ".../django/db/models/base.py", line 453, in __init__
    raise TypeError("'%s' is an invalid keyword argument for this function" % list(kwargs)[0])
TypeError: 'locked' is an invalid keyword argument for this function
```

The same change is needed in torchbox/wagtail-template for Wagtail 0.7 compatibility (why is this code maintained in two places?).
