### PR TITLE
Fix revisions still copying for child pages

### DIFF
--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -716,7 +716,7 @@ class Page(six.with_metaclass(PageBase, MP_Node, ClusterableModel, index.Indexed
         # Copy child pages
         if recursive:
             for child_page in self.get_children():
-                child_page.specific.copy(recursive=True, to=page_copy)
+                child_page.specific.copy(recursive=True, to=page_copy, copy_revisions=copy_revisions)
 
         return page_copy
 

--- a/wagtail/wagtailcore/tests/test_page_model.py
+++ b/wagtail/wagtailcore/tests/test_page_model.py
@@ -456,6 +456,19 @@ class TestCopyPage(TestCase):
         # Check that the new revision is not scheduled
         self.assertEqual(new_christmas_event.revisions.first().approved_go_live_at, None)
 
+    def test_copy_page_doesnt_copy_revisions_if_told_not_to_do_so(self):
+        christmas_event = EventPage.objects.get(url_path='/home/events/christmas/')
+        christmas_event.save_revision()
+
+        # Copy it
+        new_christmas_event = christmas_event.copy(update_attrs={'title': "New christmas event", 'slug': 'new-christmas-event'}, copy_revisions=False)
+
+        # Check that the revisions weren't copied
+        self.assertEqual(new_christmas_event.revisions.count(), 0, "Revisions were copied")
+
+        # Check that the revisions weren't removed from old page
+        self.assertEqual(christmas_event.revisions.count(), 1, "Revisions were removed from the original page")
+
     def test_copy_page_copies_child_objects_with_nonspecific_class(self):
         # Get chrismas page as Page instead of EventPage
         christmas_event = Page.objects.get(url_path='/home/events/christmas/')
@@ -515,6 +528,23 @@ class TestCopyPage(TestCase):
 
         # Check that the revisions were copied
         self.assertEqual(new_christmas_event.specific.revisions.count(), 1, "Revisions weren't copied")
+
+        # Check that the revisions weren't removed from old page
+        self.assertEqual(old_christmas_event.specific.revisions.count(), 1, "Revisions were removed from the original page")
+
+    def test_copy_page_copies_recursively_but_doesnt_copy_revisions_if_told_not_to_do_so(self):
+        events_index = EventIndex.objects.get(url_path='/home/events/')
+        old_christmas_event = events_index.get_children().filter(slug='christmas').first()
+        old_christmas_event.save_revision()
+
+        # Copy it
+        new_events_index = events_index.copy(recursive=True, update_attrs={'title': "New events index", 'slug': 'new-events-index'}, copy_revisions=False)
+
+        # Get christmas event
+        new_christmas_event = new_events_index.get_children().filter(slug='christmas').first()
+
+        # Check that the revisions weren't copied
+        self.assertEqual(new_christmas_event.specific.revisions.count(), 0, "Revisions were copied")
 
         # Check that the revisions weren't removed from old page
         self.assertEqual(old_christmas_event.specific.revisions.count(), 1, "Revisions were removed from the original page")


### PR DESCRIPTION
When Page.copy runs recursively, it forgot to pass through the
copy_revisions value that the user specified causing revisions to always
be copied for subpages regardless of what the user wanted
