### PR TITLE
Fixed ZeroDivisionError in fill filter

### DIFF
--- a/wagtail/wagtailimages/backends/base.py
+++ b/wagtail/wagtailimages/backends/base.py
@@ -165,7 +165,7 @@ class BaseImageBackend(object):
             crop_min_height = crop_min_scale / crop_aspect_ratio
 
             # Sometimes, the focal point may be bigger than the image...
-            if not crop_min_scale > crop_max_scale:
+            if not crop_min_scale >= crop_max_scale:
                 # Calculate max crop closeness to prevent upscaling
                 max_crop_closeness = max(
                     1 - (fl_width - crop_min_width) / (crop_max_width - crop_min_width),


### PR DESCRIPTION
When a focal point matches the size of the image, the crop sizes are
also the same.

These sizes are subtracted from each other in the fill filter
(which would equal zero) and this number then gets used as the
denominator in a division causing the ZeroDivisionError to be raised.

The fix is simple, don't do any crop closeness calculations if the focal
point size equals the image size. Crop closeness wouldn't work anyway in
this case
