### PR TITLE
Various fixes to Elasticsearch configuration

### DIFF
--- a/wagtail/wagtailsearch/backends/elasticsearch.py
+++ b/wagtail/wagtailsearch/backends/elasticsearch.py
@@ -339,11 +339,19 @@ class ElasticSearch(BaseSearch):
             for url in self.es_urls:
                 parsed_url = urlparse(url)
 
+                use_ssl = parsed_url.scheme == 'https'
+                port = parsed_url.port or (443 if use_ssl else 80)
+
+                http_auth = None
+                if parsed_url.username is not None and parsed_url.password is not None:
+                    http_auth = (parsed_url.username, parsed_url.password)
+
                 self.es_hosts.append({
                     'host': parsed_url.hostname,
-                    'port': parsed_url.port or 9200,
+                    'port': port,
                     'url_prefix': parsed_url.path,
-                    'use_ssl': parsed_url.scheme == 'https',
+                    'use_ssl': use_ssl,
+                    'http_auth': http_auth,
                 })
 
         # Get ElasticSearch interface

--- a/wagtail/wagtailsearch/tests/test_elasticsearch_backend.py
+++ b/wagtail/wagtailsearch/tests/test_elasticsearch_backend.py
@@ -508,13 +508,29 @@ class TestBackendConfiguration(TestCase):
     def test_urls(self):
         # This test backwards compatibility with old URLS setting
         backend = self.ElasticSearch(params={
-            'URLS': ['http://localhost:12345', 'https://127.0.0.1:54321'],
+            'URLS': [
+                'http://localhost:12345',
+                'https://127.0.0.1:54321',
+                'http://username:password@elasticsearch.mysite.com',
+                'https://elasticsearch.mysite.com/hello',
+            ],
         })
 
-        self.assertEqual(len(backend.es_hosts), 2)
+        self.assertEqual(len(backend.es_hosts), 4)
         self.assertEqual(backend.es_hosts[0]['host'], 'localhost')
         self.assertEqual(backend.es_hosts[0]['port'], 12345)
         self.assertEqual(backend.es_hosts[0]['use_ssl'], False)
+
         self.assertEqual(backend.es_hosts[1]['host'], '127.0.0.1')
         self.assertEqual(backend.es_hosts[1]['port'], 54321)
         self.assertEqual(backend.es_hosts[1]['use_ssl'], True)
+
+        self.assertEqual(backend.es_hosts[2]['host'], 'elasticsearch.mysite.com')
+        self.assertEqual(backend.es_hosts[2]['port'], 80)
+        self.assertEqual(backend.es_hosts[2]['use_ssl'], False)
+        self.assertEqual(backend.es_hosts[2]['http_auth'], ('username', 'password'))
+
+        self.assertEqual(backend.es_hosts[3]['host'], 'elasticsearch.mysite.com')
+        self.assertEqual(backend.es_hosts[3]['port'], 443)
+        self.assertEqual(backend.es_hosts[3]['use_ssl'], True)
+        self.assertEqual(backend.es_hosts[3]['url_prefix'], '/hello')


### PR DESCRIPTION
- It's now possible to specify http auth paramters in the URL
- I've changed the default port to 443 to SSL connections and 80 for
  non-SSL connections. Previously, both were set to 9200.

The second change was motivated by the fact that searchly don't specify a port in their URLs when they actually want users to connect to port 443. Also, I think it makes sense for a HTTP URL to default to ports 80 and 443, even though they're most commonly going to be pointing at port 9200.
