### PR TITLE
Renames duplicate method on TestSnippetRegistering

### DIFF
--- a/wagtail/wagtailsnippets/tests.py
+++ b/wagtail/wagtailsnippets/tests.py
@@ -188,7 +188,7 @@ class TestSnippetRegistering(TestCase):
 
         self.assertIn(RegisterFunction, SNIPPET_MODELS)
 
-    def test_register_function(self):
+    def test_register_decorator(self):
         @register_snippet
         class RegisterDecorator(models.Model):
             pass


### PR DESCRIPTION
Renames duplicate method on TestSnippetRegistering from test_register_function to test_register_decorator
