### PR TITLE
Fix unicode error with admin widgets

### DIFF
--- a/wagtail/utils/widgets.py
+++ b/wagtail/utils/widgets.py
@@ -10,7 +10,7 @@ class WidgetWithScript(Widget):
 
         final_attrs = self.build_attrs(attrs, name=name)
         id_ = final_attrs.get('id', None)
-        if 'id_' is None:
+        if id_ is None:
             return widget
 
         js = self.render_js_init(id_, name, value)


### PR DESCRIPTION
Widgets with Unicode text in them raised an error, as an ASCII format string was used to compose the widget and its associated JavaScript. This fix makes sure all strings are Unicode to fix this.

Fixes #815.
