### PR TITLE
Bugfixes for Model recipe docs

### DIFF
--- a/docs/core_components/pages/model_recipes.rst
+++ b/docs/core_components/pages/model_recipes.rst
@@ -88,7 +88,10 @@ First, ``models.py``:
 
     from django.shortcuts import render
     from wagtail.wagtailcore.url_routing import RouteResult
-
+    from django.http.response import Http404
+    from wagtail.wagtailadmin.edit_handlers import FieldPanel, MultiFieldPanel
+    from wagtail.wagtailcore.models import Page
+    
     ...
 
     class Echoer(Page):
@@ -105,7 +108,7 @@ First, ``models.py``:
                     raise Http404
 
         def serve(self, path_components=[]):
-            render(request, self.template, {
+            return render(request, self.template, {
                 'self': self,
                 'echo': ' '.join(path_components),
             })
@@ -115,7 +118,7 @@ First, ``models.py``:
     ]
 
     Echoer.promote_panels = [
-        MultiFieldPanel(COMMON_PANELS, "Common page configuration"),
+        MultiFieldPanel(Page.promote_panels, "Common page configuration"),
     ]
 
 This model, ``Echoer``, doesn't define any properties, but does subclass ``Page`` so objects will be able to have a custom title and slug. The template just has to display our ``{{ echo }}`` property.


### PR DESCRIPTION
I was following through the Wagtail docs for Model Recipes when I ran into a few different problems after trying to use the Echoer class code in my models.py file. These changes fix all the problems I was having. One is apparently a copy-paste bug (`COMMON_PANELS` doesn't exist outside of wagtail's test code), and the other is a missing return statement.
