### PR TITLE
Fixed admin submenus not working correctly when more than one registered

### DIFF
--- a/wagtail/wagtailadmin/static/wagtailadmin/js/submenu.js
+++ b/wagtail/wagtailadmin/static/wagtailadmin/js/submenu.js
@@ -10,7 +10,7 @@ $(function(){
             }
 
             // Close other active submenus first, if any
-            if($('.nav-wrapper.submenu-active').length){
+            if($('.nav-wrapper.submenu-active').length && !$(this).closest('li').hasClass('submenu-active')){
                 $('.nav-main .submenu-active, .nav-wrapper').removeClass('submenu-active');
             }
 


### PR DESCRIPTION
The relevant code in `submenu.js` is now able to first close already active submenus when another one is being clicked. This solves issue #851.

This PR replaces #852, because I reorganized my repository.
