### PR TITLE
wagtailadmin.views.add_subpage view now sorts content types by their verbose names.

### DIFF
--- a/wagtail/wagtailadmin/views/pages.py
+++ b/wagtail/wagtailadmin/views/pages.py
@@ -73,7 +73,9 @@ def add_subpage(request, parent_page_id):
     if not parent_page.permissions_for_user(request.user).can_add_subpage():
         raise PermissionDenied
 
-    page_types = sorted(parent_page.allowed_subpage_types(), key=lambda pagetype: pagetype.name.lower())
+    page_types = sorted(parent_page.allowed_subpage_types(),
+        key=lambda pagetype: pagetype.model_class().get_verbose_name().lower()
+    )
 
     if len(page_types) == 1:
         # Only one page type is available - redirect straight to the create form rather than


### PR DESCRIPTION
I noticed that adding a verbose_name to a model's metaclass changed what it was called on the "CREATE A PAGE IN XYZType" list, but didn't affect its sort order within that list. This was very confusing, so I dug into the code to find out why. The `wagtailadmin.views.add_subpage()` view was sorting the content types by their model name, rather than their verbose name, so I fixed that.
