### PR TITLE
Only show Administrator checkbox to superuser on user create or edit.

### DIFF
--- a/wagtail/wagtailusers/templates/wagtailusers/users/create.html
+++ b/wagtail/wagtailusers/templates/wagtailusers/users/create.html
@@ -11,7 +11,7 @@
     <ul class="tab-nav merged">
         <li class="active"><a href="#account">{% trans "Account" %}</a></li>
         <li><a href="#roles">{% trans "Roles" %}</a></li>
-    </ul>   
+    </ul>
 
     <form action="{% url 'wagtailusers_users_create' %}" method="POST">
         <div class="tab-content">
@@ -24,13 +24,15 @@
                     {% include "wagtailadmin/shared/field_as_li.html" with field=form.last_name %}
                     {% include "wagtailadmin/shared/field_as_li.html" with field=form.password1 %}
                     {% include "wagtailadmin/shared/field_as_li.html" with field=form.password2 %}
-                    
+
                     <li><a href="#roles" class="button lowpriority tab-toggle icon icon-arrow-right-after" />{% trans "Roles" %}</a></li>
                 </ul>
             </section>
             <section id="roles" class="nice-padding">
                 <ul class="fields">
-                    {% include "wagtailadmin/shared/field_as_li.html" with field=form.is_superuser %}
+                    {% if request.user.is_superuser %}
+                        {% include "wagtailadmin/shared/field_as_li.html" with field=form.is_superuser %}
+                    {% endif %}
                     {% include "wagtailadmin/shared/field_as_li.html" with field=form.groups %}
                     <li><input type="submit" value='{% trans "Add user" %}' /></li>
                 </ul>

--- a/wagtail/wagtailusers/templates/wagtailusers/users/edit.html
+++ b/wagtail/wagtailusers/templates/wagtailusers/users/edit.html
@@ -4,14 +4,14 @@
 {% block titletag %}{% trans "Editing" %} {{ user.get_username}}{% endblock %}
 {% block bodyclass %}menu-users{% endblock %}
 {% block content %}
-    
+
     {% trans "Editing" as editing_str %}
     {% include "wagtailadmin/shared/header.html" with title=editing_str subtitle=user.get_username merged=1 tabbed=1 icon="user" %}
 
     <ul class="tab-nav merged">
         <li class="active"><a href="#account">{% trans "Account" %}</a></li>
         <li><a href="#roles">{% trans "Roles" %}</a></li>
-    </ul>   
+    </ul>
 
     <form action="{% url 'wagtailusers_users_edit' user.id %}" method="POST">
         <div class="tab-content">
@@ -26,13 +26,15 @@
                     {% include "wagtailadmin/shared/field_as_li.html" with field=form.password1 %}
                     {% include "wagtailadmin/shared/field_as_li.html" with field=form.password2 %}
                     {% include "wagtailadmin/shared/field_as_li.html" with field=form.is_active %}
-                    
+
                     <li><input type="submit" value="{% trans 'Save' %}" /></li>
                 </ul>
             </section>
             <section id="roles" class="nice-padding">
                 <ul class="fields">
-                    {% include "wagtailadmin/shared/field_as_li.html" with field=form.is_superuser %}
+                    {% if request.user.is_superuser %}
+                        {% include "wagtailadmin/shared/field_as_li.html" with field=form.is_superuser %}
+                    {% endif %}
                     {% include "wagtailadmin/shared/field_as_li.html" with field=form.groups %}
                     <li><input type="submit" value="{% trans 'Save' %}" /></li>
                 </ul>

--- a/wagtail/wagtailusers/tests.py
+++ b/wagtail/wagtailusers/tests.py
@@ -11,6 +11,7 @@ from django.contrib.auth.models import Group, Permission
 from wagtail.tests.utils import WagtailTestUtils
 from wagtail.wagtailcore import hooks
 from wagtail.wagtailusers.models import UserProfile
+from wagtail.wagtailusers.forms import UserCreationForm, UserEditForm
 from wagtail.wagtailcore.models import Page, GroupPagePermission
 
 
@@ -434,3 +435,65 @@ class TestGroupEditView(TestCase, WagtailTestUtils):
         # See that the non-registered permission is still there
         self.assertEqual(self.test_group.permissions.count(), 1)
         self.assertEqual(self.test_group.permissions.all()[0], self.non_registered_perm)
+
+
+class TestUserCreationForm(TestCase):
+    def build_form(self, is_superuser):
+        return {
+            'is_superuser': is_superuser,
+            'first_name': 'test',
+            'last_name': 'user',
+            'email': 'test@example.org',
+            'username': 'testuser',
+            'password1': 'test1234',
+            'password2': 'test1234'
+        }
+
+    def test_admin_user_can_create_admin_user(self):
+        admin = get_user_model()(is_superuser=True)
+        form = UserCreationForm(admin, self.build_form(True))
+
+        self.assertTrue(form.is_valid())
+
+    def test_normal_user_can_not_create_admin_user(self):
+        normal = get_user_model()(is_superuser=False)
+        form = UserCreationForm(normal, self.build_form(True))
+
+        self.assertFalse(form.is_valid())
+
+    def test_normal_user_can_create_normal_user(self):
+        normal = get_user_model()(is_superuser=False)
+        form = UserCreationForm(normal, self.build_form(False))
+
+        self.assertTrue(form.is_valid())
+
+
+class TestUserEditForm(TestCase):
+    def build_form(self, is_superuser):
+        return {
+            'is_superuser': is_superuser,
+            'first_name': 'test',
+            'last_name': 'user',
+            'email': 'test@example.org',
+            'username': 'testuser',
+            'password1': 'test1234',
+            'password2': 'test1234'
+        }
+
+    def test_admin_user_can_edit_admin_user(self):
+        admin = get_user_model()(is_superuser=True)
+        form = UserEditForm(admin, self.build_form(True))
+
+        self.assertTrue(form.is_valid())
+
+    def test_normal_user_can_not_edit_admin_user(self):
+        normal = get_user_model()(is_superuser=False)
+        form = UserEditForm(normal, self.build_form(True))
+
+        self.assertFalse(form.is_valid())
+
+    def test_normal_user_can_edit_normal_user(self):
+        normal = get_user_model()(is_superuser=False)
+        form = UserEditForm(normal, self.build_form(False))
+
+        self.assertTrue(form.is_valid())

--- a/wagtail/wagtailusers/views/users.py
+++ b/wagtail/wagtailusers/views/users.py
@@ -80,7 +80,7 @@ def index(request):
 @permission_required(change_user_perm)
 def create(request):
     if request.POST:
-        form = UserCreationForm(request.POST)
+        form = UserCreationForm(request.user, request.POST)
         if form.is_valid():
             user = form.save()
             messages.success(request, _("User '{0}' created.").format(user), buttons=[
@@ -90,7 +90,7 @@ def create(request):
         else:
             messages.error(request, _("The user could not be created due to errors.") )
     else:
-        form = UserCreationForm()
+        form = UserCreationForm(request.user)
 
     return render(request, 'wagtailusers/users/create.html', {
         'form': form,
@@ -101,7 +101,7 @@ def create(request):
 def edit(request, user_id):
     user = get_object_or_404(User, id=user_id)
     if request.POST:
-        form = UserEditForm(request.POST, instance=user)
+        form = UserEditForm(request.user, request.POST, instance=user)
         if form.is_valid():
             user = form.save()
             messages.success(request, _("User '{0}' updated.").format(user), buttons=[
@@ -111,7 +111,7 @@ def edit(request, user_id):
         else:
             messages.error(request, _("The user could not be saved due to errors."))
     else:
-        form = UserEditForm(instance=user)
+        form = UserEditForm(request.user, instance=user)
 
     return render(request, 'wagtailusers/users/edit.html', {
         'user': user,


### PR DESCRIPTION
This is the start of fixing #537.

Users who are not marked as a superuser in the Django auth system will not longer be able to create a superuser themselves.

This PR hides the checkbox option on the page, and also adds a form validation to the `UserCreationForm` and `UserEditForms`.
