### PR TITLE
[WIP] PostgreSQL search backend

### DIFF
--- a/wagtail/contrib/wagtailpostgressearch/__init__.py
+++ b/wagtail/contrib/wagtailpostgressearch/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'wagtail.contrib.wagtailpostgressearch.apps.WagtailPostgresSearchAppConfig'

--- a/wagtail/contrib/wagtailpostgressearch/apps.py
+++ b/wagtail/contrib/wagtailpostgressearch/apps.py
@@ -1,0 +1,13 @@
+from django.apps import AppConfig
+from django.db import connection
+from django.core.exceptions import ImproperlyConfigured
+
+
+class WagtailPostgresSearchAppConfig(AppConfig):
+    name = 'wagtail.contrib.wagtailpostgressearch'
+    label = 'wagtailpostgressearch'
+    verbose_name = "Wagtail Postgres search"
+
+    def ready(self):
+        if connection.vendor != 'postgresql':
+            raise ImproperlyConfigured("Use postgres")

--- a/wagtail/contrib/wagtailpostgressearch/backend.py
+++ b/wagtail/contrib/wagtailpostgressearch/backend.py
@@ -1,0 +1,135 @@
+from django.db import models, connection, transaction
+from django.apps import apps
+from django.contrib.contenttypes.models import ContentType
+
+from wagtail.wagtailsearch.backends.base import BaseSearch, BaseSearchQuery, BaseSearchResults
+from wagtail.wagtailsearch import index
+
+from wagtail.contrib.wagtailpostgressearch.models import IndexedItem
+
+
+def get_content_types(model):
+    # Returns the content type objects for the specified model and all of its
+    # subclasses
+    return ContentType.objects.get_for_models(*[
+        child_model for child_model in apps.get_models()
+        if child_model == model or issubclass(child_model, model)
+    ]).values()
+
+
+class PostgresSearchQuery(BaseSearchQuery):
+    def _process_lookup(self, field, lookup, value):
+        return models.Q(**{field.get_attname(self.queryset.model) + '__' + lookup: value})
+
+    def _connect_filters(self, filters, connector, negated):
+        if connector == 'AND':
+            q = models.Q(*filters)
+        elif connector == 'OR':
+            q = models.Q(filters[0])
+            for fil in filters[1:]:
+                q |= fil
+        else:
+            return
+
+        if negated:
+            q = ~q
+
+        return q
+
+    def get_pks(self):
+        queryset = self.queryset
+
+        # Filters
+        queryset = queryset.filter(self._get_filters_from_queryset())
+
+        indexed_items = IndexedItem.objects.filter(
+            object_id__in=queryset.values_list('id'),
+            content_type__in=get_content_types(self.queryset.model),
+        )
+
+        # Search query
+        if self.query_string is not None:
+            indexed_items = indexed_items.extra(
+                 select={'score': "ts_rank_cd(content, plainto_tsquery('simple', unaccent(%s)))"},
+                 select_params=[self.query_string],
+
+                 where=["content @@ plainto_tsquery('simple', unaccent(%s))"],
+                 params=[self.query_string],
+
+                 order_by=['-score'],
+            )
+
+        return indexed_items.values_list('object_id', flat=True)
+
+
+class PostgresSearchResults(BaseSearchResults):
+    def get_pks(self):
+        return self.query.get_pks()[self.start:self.stop]
+
+    def _do_search(self):
+        pks = self.get_pks()
+
+        # Initialise results dictionary
+        results = dict((str(pk), None) for pk in pks)
+
+        # Find objects in database and add them to dict
+        queryset = self.query.queryset.filter(pk__in=pks)
+        for obj in queryset:
+            results[str(obj.pk)] = obj
+
+        # Return results in order given by search
+        return [results[str(pk)] for pk in pks if results[str(pk)]]
+
+    def _do_count(self):
+        return self.get_pks().count()
+
+
+class PostgresSearch(BaseSearch):
+    search_query_class = PostgresSearchQuery
+    search_results_class = PostgresSearchResults
+
+    def __init__(self, params):
+        super(PostgresSearch, self).__init__(params)
+
+    def reset_index(self):
+        IndexedItem.objects.all().delete()
+
+    def add_type(self, model):
+        pass # Not needed
+
+    def refresh_index(self):
+        pass # Not needed
+
+    def add(self, obj):
+        model = type(obj)
+        content_parts = []
+
+        for field in model.get_search_fields():
+            value = field.get_value(obj)
+
+            if isinstance(field, index.SearchField) and value:
+                content_parts.append(value)
+
+        content_type = ContentType.objects.get_for_model(type(obj))
+
+        with transaction.atomic():
+            IndexedItem.objects.filter(content_type=content_type, object_id=obj.id).delete()
+
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    "INSERT INTO wagtailpostgressearch_indexeditem "
+                    "(content_type_id, object_id, content) "
+                    "VALUES (%s, %s, to_tsvector('simple', unaccent(%s)))",
+                    (content_type.id, obj.id, " ".join(content_parts))
+                )
+
+    def add_bulk(self, model, obj_list):
+        for obj in obj_list:
+            self.add(obj)
+
+    def delete(self, obj):
+        content_type = ContentType.objects.get_for_model(type(obj))
+        IndexedItem.objects.filter(content_type=content_type, object_id=obj.id).delete()
+
+
+SearchBackend = PostgresSearch

--- a/wagtail/contrib/wagtailpostgressearch/migrations/0001_initial.py
+++ b/wagtail/contrib/wagtailpostgressearch/migrations/0001_initial.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from django.db.migrations.operations.base import Operation
+
+import wagtail.contrib.wagtailpostgressearch.models
+
+
+class CreateExtension(Operation):
+    reversible = True
+
+    def __init__(self, name):
+        self.name = name
+
+    def state_forwards(self, app_label, state):
+        pass
+
+    def database_forwards(self, app_label, schema_editor, from_state, to_state):
+        schema_editor.execute("CREATE EXTENSION IF NOT EXISTS %s" % self.name)
+
+    def database_backwards(self, app_label, schema_editor, from_state, to_state):
+        schema_editor.execute("DROP EXTENSION %s" % self.name)
+
+    def describe(self):
+        return "Creates extension %s" % self.name
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('contenttypes', '0001_initial'),
+    ]
+
+    operations = [
+        CreateExtension('unaccent'),
+        migrations.CreateModel(
+            name='IndexedItem',
+            fields=[
+                ('id', models.AutoField(primary_key=True, serialize=False, verbose_name='ID', auto_created=True)),
+                ('object_id', models.PositiveIntegerField()),
+                ('content_type', models.ForeignKey(to='contenttypes.ContentType')),
+                ('content', wagtail.contrib.wagtailpostgressearch.models.TSVectorField()),
+            ],
+        ),
+        migrations.AlterUniqueTogether(
+            name='indexeditem',
+            unique_together=set([('content_type', 'object_id')]),
+        ),
+    ]

--- a/wagtail/contrib/wagtailpostgressearch/models.py
+++ b/wagtail/contrib/wagtailpostgressearch/models.py
@@ -1,0 +1,21 @@
+from django.db import models
+from django.contrib.contenttypes.fields import GenericForeignKey
+from django.contrib.contenttypes.models import ContentType
+
+
+class TSVectorField(models.TextField):
+    def db_type(self, connection):
+        return 'tsvector'
+
+
+class IndexedItem(models.Model):
+    content_type = models.ForeignKey(ContentType)
+    object_id = models.PositiveIntegerField()
+    content_object = GenericForeignKey('content_type', 'object_id')
+
+    content = TSVectorField()
+
+    class Meta:
+        unique_together = (
+            ('content_type', 'object_id'),
+        )

--- a/wagtail/contrib/wagtailpostgressearch/tests.py
+++ b/wagtail/contrib/wagtailpostgressearch/tests.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.test import TestCase
+
+from wagtail.tests.search.models import SearchTest
+from wagtail.wagtailsearch.tests.test_backends import BackendTests
+
+
+class TestPostgresBackend(BackendTests, TestCase):
+    backend_path = 'wagtail.contrib.wagtailpostgressearch.backend'
+
+    def test_unaccent(self):
+        self.backend.reset_index()
+
+        # Add some test data
+        obj = SearchTest()
+        obj.title = "Ĥéllø"
+        obj.live = True
+        obj.save()
+        self.backend.add(obj)
+
+        # Search and check
+        results = self.backend.search("Hello", SearchTest.objects.all())
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].id, obj.id)

--- a/wagtail/tests/settings.py
+++ b/wagtail/tests/settings.py
@@ -143,8 +143,19 @@ COMPRESS_ENABLED = False  # disable compression so that we can run tests on the 
 WAGTAILSEARCH_BACKENDS = {
     'default': {
         'BACKEND': 'wagtail.wagtailsearch.backends.db',
-    }
+    },
 }
+
+
+if os.environ.get('DATABASE_ENGINE', None) == 'django.db.backends.postgresql_psycopg2':
+    INSTALLED_APPS += (
+        'wagtail.contrib.wagtailpostgressearch',
+    )
+
+    WAGTAILSEARCH_BACKENDS['postgres'] = {
+        'BACKEND': 'wagtail.contrib.wagtailpostgressearch.backend',
+    }
+
 
 AUTH_USER_MODEL = 'customuser.CustomUser'
 


### PR DESCRIPTION
This PR adds a new contrib app called `wagtail.contrib.wagtailpostgressearch`. This provides a new search backend for wagtailsearch to use that uses PostgreSQLs built in full text search features (see: http://www.postgresql.org/docs/8.3/static/textsearch.html, http://blog.lostpropertyhq.com/postgres-full-text-search-is-good-enough/).

This allows you to use Wagtail without Elasticsearch, but without all the limitations of the current database backend (it should be faster than the database backend too).

Features in the PostgreSQL backend that are not in the database backend:
- Full text search
- Indexing of callable fields
- Searching fields in subclasses

A few possible enhancements:
- Partial matching
- Per field boosting
- Stemming
- ~~Use `unaccent` extension~~ done!
- Speed it up even more with a GIN/GiST index

TODO:
- [ ] Clean up code
- [ ] Improve tests
- [ ] Write docs
