### PR TITLE
[WIP] RTL interface in admin panel

### DIFF
--- a/wagtail/wagtailadmin/templates/wagtailadmin/skeleton.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/skeleton.html
@@ -1,13 +1,13 @@
 <!doctype html>
 {% load compress static i18n %}
-<html class="no-js" lang="{{ LANGUAGE_CODE|default:"en-gb" }}">
+<html class="no-js" lang="{{ LANGUAGE_CODE|default:"en-gb" }}" {% if LANGUAGE_BIDI %}dir="rtl"{% endif %}>
 <head>
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <title>Wagtail - {% block titletag %}{% endblock %}</title>
     <meta name="description" content="" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    
+
     <script src="{% static 'wagtailadmin/js/vendor/modernizr-2.6.2.min.js' %}"></script>
 
     {% compress css %}


### PR DESCRIPTION
Hi,
This sets the page to the correct direction for RTL languages. I took the same approach as Django-admin's. I'm not quite sure how come it works without the `{% get_current_language_bidi as LANGUAGE_BIDI %}` but it seems to work fine even without django.contrib.admin .

I'm using body[dir=rtl] as a CSS selector for applying to all RTL relevant parts, which I'll commit soon.
