### PR TITLE
[WIP] Unify link choosers

### DIFF
--- a/wagtail/tests/testapp/wagtail_hooks.py
+++ b/wagtail/tests/testapp/wagtail_hooks.py
@@ -1,3 +1,6 @@
+from __future__ import absolute_import, unicode_literals
+
+from django.forms.utils import flatatt
 from django.http import HttpResponse
 
 from wagtail.wagtailadmin.menu import MenuItem
@@ -75,3 +78,25 @@ def polite_pages_only(parent_page, pages, request):
         pages = pages.filter(slug__startswith='hello')
 
     return pages
+
+
+class FooLinkHandler(object):
+    @staticmethod
+    def get_db_attributes(tag):
+        return {'foo': tag.attrs['data-foo']}
+
+    @staticmethod
+    def expand_db_attributes(attrs, for_editor):
+        new_attrs = {'href': 'http://example.com/{}/'.format(attrs['foo'])}
+        if for_editor:
+            new_attrs.update({
+                'data-foo': attrs['foo'],
+                'data-linktype': 'foo',
+            })
+        return '<a{}>'.format(flatatt(new_attrs))
+
+
+# RemovedInWagtail16Warning
+@hooks.register('register_rich_text_link_handler')
+def register_foo_link_handler():
+    return ('foo', FooLinkHandler())

--- a/wagtail/wagtailadmin/link_choosers.py
+++ b/wagtail/wagtailadmin/link_choosers.py
@@ -1,0 +1,136 @@
+from __future__ import absolute_import, print_function, unicode_literals
+
+from functools import total_ordering
+
+from django.utils.encoding import python_2_unicode_compatible
+from django.utils.functional import cached_property
+from django.utils.translation import ugettext_lazy as _
+
+from wagtail.wagtailcore import hooks
+from wagtail.wagtailcore.models import Page
+
+
+class LinkChooserRegistry(object):
+
+    @cached_property
+    def items(self):
+        registered_hooks = hooks.get_hooks('register_link_chooser')
+        return sorted(hook() for hook in registered_hooks)
+
+    def __iter__(self):
+        return iter(self.items)
+
+    def __len__(self):
+        return len(self.items)
+
+
+registry = LinkChooserRegistry()
+
+
+@total_ordering
+@python_2_unicode_compatible
+class LinkChooser(object):
+    id = None
+    title = None
+    url_name = None
+    priority = None
+
+    def __eq__(self, other):
+        if not isinstance(other, LinkChooser):
+            return NotImplemented
+        return self.priority == other.priority
+
+    def __lt__(self, other):
+        if not isinstance(other, LinkChooser):
+            return NotImplemented
+        return self.priority < other.priority
+
+    def __str__(self):
+        return 'LinkChooser({})'.format(self.id)
+
+    def __repr__(self):
+        return '<{}.{}>'.format(self.__class__.__module__, self.__class__.__name__)
+
+    @classmethod
+    def get_db_attributes(cls, tag):
+        """
+        Given an element from a RichText editor, return a dict of all the
+        attributes required to store the element in the database
+        representation.
+
+        The opposite of ``expand_db_attributes``.
+        """
+        raise NotImplementedError()
+
+    @classmethod
+    def expand_db_attributes(cls, attrs, for_editor):
+        """
+        Given a dict of attributes from a link in some RichText stored in the
+        database, return a dict of HTML attributes to build an ``<a>`` tag.
+
+        If ``for_editor`` is true, the RichText is being edited, otherwise it
+        is being displayed to the user.
+        """
+        raise NotImplementedError()
+
+
+class InternalLinkChooser(LinkChooser):
+    """
+    PageLinkHandler will be invoked whenever we encounter an <a> element in
+    HTML content with an attribute of data-linktype="page". The resulting
+    element in the database representation will be: <a linktype="page"
+    id="42">hello world</a>
+    """
+
+    id = 'page'
+    title = _('Internal link')
+    url_name = 'wagtailadmin_choose_page'
+    priority = 100
+
+    @classmethod
+    def get_db_attributes(cls, tag):
+        """
+        Given an <a> tag that we've identified as a page link embed (because it has a
+        data-linktype="page" attribute), return a dict of the attributes we should
+        have on the resulting <a linktype="page"> element.
+        """
+        return {'id': tag['data-id']}
+
+    @classmethod
+    def expand_db_attributes(cls, attrs, for_editor):
+        try:
+            page = Page.objects.get(id=attrs['id'])
+        except Page.DoesNotExist:
+            return {}
+
+        attrs = {'href': page.url}
+        if for_editor:
+            attrs['data-id'] = page.id
+        return attrs
+
+
+class SimpleLinkChooser(LinkChooser):
+    """
+    A link type that only has an href.
+    """
+    @classmethod
+    def get_db_attributes(cls, tag):
+        return {'href': tag['href']}
+
+    @classmethod
+    def expand_db_attributes(cls, attrs, for_editor):
+        return {'href': attrs['href']}
+
+
+class ExternalLinkChooser(SimpleLinkChooser):
+    id = 'external'
+    title = _('External link')
+    url_name = 'wagtailadmin_choose_page_external_link'
+    priority = 200
+
+
+class EmailLinkChooser(SimpleLinkChooser):
+    id = 'email'
+    title = _('Email link')
+    url_name = 'wagtailadmin_choose_page_email_link'
+    priority = 300

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/js/hallo-plugins/hallo-wagtaillink.js
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/js/hallo-plugins/hallo-wagtaillink.js
@@ -50,7 +50,7 @@
                             url: url,
                             bind: {
                                 click: function(e) {
-                                    if (!$(e.target).is('p.link-types a')) return;
+                                    if (!$(e.target).is('.link-types a')) return;
                                     var link = e.target;
                                     modal.loadUrl(link.href);
                                     return false;

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/js/hallo-plugins/hallo-wagtaillink.js
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/js/hallo-plugins/hallo-wagtaillink.js
@@ -40,29 +40,38 @@
                         return widget.options.editable.element.trigger('change');
                     } else {
                         lastSelection = widget.options.editable.getSelection();
+
+                        url = window.chooserUrls.pageChooser;
                         if (lastSelection.collapsed) {
-                            url = window.chooserUrls.pageChooser + '?allow_external_link=true&allow_email_link=true&prompt_for_link_text=true';
-                        } else {
-                            url = window.chooserUrls.pageChooser + '?allow_external_link=true&allow_email_link=true';
+                            url += '?prompt_for_link_text=true';
                         }
 
-                        return ModalWorkflow({
+                        modal = ModalWorkflow({
                             url: url,
+                            bind: {
+                                click: function(e) {
+                                    if (!$(e.target).is('p.link-types a')) return;
+                                    var link = e.target;
+                                    modal.loadUrl(link.href);
+                                    return false;
+                                }
+                            },
                             responses: {
-                                pageChosen: function(pageData) {
+                                linkChosen: function(link) {
                                     var a;
 
                                     a = document.createElement('a');
-                                    a.setAttribute('href', pageData.url);
-                                    if (pageData.id) {
-                                        a.setAttribute('data-id', pageData.id);
-                                        a.setAttribute('data-linktype', 'page');
-                                    }
+                                    a.setAttribute('href', link.url);
+                                    a.setAttribute('data-linktype', link.type);
+
+                                    Object.keys(link.data || {}).forEach(function(key) {
+                                        a.setAttribute('data-' + key, link.data[key]);
+                                    });
 
                                     if ((!lastSelection.collapsed) && lastSelection.canSurroundContents()) {
                                         lastSelection.surroundContents(a);
                                     } else {
-                                        a.appendChild(document.createTextNode(pageData.title));
+                                        a.appendChild(document.createTextNode(link.title));
                                         lastSelection.insertNode(a);
                                     }
 
@@ -70,6 +79,7 @@
                                 }
                             }
                         });
+                        return modal;
                     }
                 });
             }

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/js/modal-workflow.js
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/js/modal-workflow.js
@@ -23,7 +23,11 @@ function ModalWorkflow(opts) {
     $('body').append(container);
     container.modal('hide');
 
+    // Bind any handlers in opts to the container element
+
     self.body = container.find('.modal-body');
+    self.body.data('modal', self);
+    self.body.on(opts.bind || {});
 
     self.loadUrl = function(url, urlParams) {
         $.get(url, urlParams, self.loadResponseText, 'text');

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_forms.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_forms.scss
@@ -1230,3 +1230,35 @@ button {
         }
     }
 }
+
+
+// =============================================================================
+// Inline form elements.
+// =============================================================================
+
+.inline-form {
+    @extend %clearfix;
+    border-bottom: solid 2px #eee;
+    margin-bottom: 1.5rem;
+
+
+    > .left {
+        float: left;
+    }
+
+    > :first-child {
+        width: 75%;
+        margin-right: 1rem;
+    }
+
+    .field-content {
+        width: 100%;
+    }
+
+    input[type=submit] {
+        padding-top: .75rem;
+        padding-bottom: .75rem;
+        height: auto;
+        margin-top: .5rem;
+    }
+}

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_modals.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_modals.scss
@@ -3,7 +3,7 @@ $zindex-modal-background: 500;
 .fade {
     @include transition(opacity .15s linear);
     opacity: 0;
-    
+
     &.in {
         opacity: 1;
     }
@@ -76,7 +76,7 @@ $zindex-modal-background: 500;
     left: 0;
     z-index: ($zindex-modal-background - 10);
     background-color: $color-black;
-    
+
     // Fade for backdrop
     &.fade { opacity: 0; }
     &.in { opacity: 0.5; }
@@ -113,4 +113,61 @@ $zindex-modal-background: 500;
         max-width: $breakpoint-desktop-larger;
         padding: 0 0 2em;
     }
+}
+
+
+
+.modal-tabs {
+    @extend %tab-nav;
+    margin-bottom: 0;
+}
+
+.modal-tabs--secondary {
+    margin-top: 0;
+    padding-top: 1.5rem;
+}
+
+
+    // TODO: Specificity arms race
+    .modal-tabs--secondary > .modal-tabs__item > a {
+        background: #d6d6d6;
+        color: #444;
+        border-top-color: #d6d6d6;
+
+        &:hover {
+            border-top-color: rgba(0, 0, 0, 0.4);
+        }
+    }
+
+    .modal-tabs--secondary > .modal-tabs__item.active > a {
+        background: #fff;
+        color: #222;
+        border-top-color: #333;
+    }
+
+
+// Much specificity required to add modifier.
+// TODO: refactor tabs to use lower specificity
+.modal-tabs--secondary,
+.modal-tabs__item--secondary.active > a {
+    background: #eee;
+}
+
+
+    .modal-tabs__item {
+        &:first-child {
+            margin-left: 0;
+        }
+
+        > a {
+            padding-left: 1.5rem;
+            padding-right: 1.5rem;
+            padding-bottom: .8125rem;
+            font-size: 13px;
+        }
+    }
+
+
+.modal-tabs__content {
+    padding-top: 1.5rem;
 }

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_tabs.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_tabs.scss
@@ -1,4 +1,4 @@
-.tab-nav {
+%tab-nav {
     @include row();
     padding: 0;
     background: $color-grey-4;
@@ -52,14 +52,14 @@
         }
     }
 
-    li.active a {
+    .active a {
         box-shadow: none;
         color: $color-grey-1;
         background-color: $color-white;
         border-top: 0.3em solid $color-grey-1;
     }
 
-    li.settings a {
+    .settings a {
         &:before {
             font-family: wagtail;
             vertical-align: middle;
@@ -78,22 +78,9 @@
         margin-top: 0;
         background-color: $color-header-bg;
     }
-}
 
-.tab-content {
-    section {
-        display: none;
-        padding-top: 1em;
-
-        &.active {
-            display: block;
-        }
-    }
-}
-
-@media screen and (min-width: $breakpoint-mobile) {
-    .tab-nav {
-        // For cases where tab-nav should merge with header 
+    @media screen and (min-width: $breakpoint-mobile) {
+        // For cases where tab-nav should merge with header
         &.merged {
             background-color: $color-header-bg;
         }
@@ -109,12 +96,30 @@
             padding-right: $desktop-nice-padding - 10;
         }
 
-        li.settings a {
+        .settings a {
             padding-left: 2em;
             padding-right: 2em;
         }
     }
+}
 
+
+.tab-nav {
+    @extend %tab-nav;
+}
+
+.tab-content {
+    section {
+        display: none;
+        padding-top: 1em;
+
+        &.active {
+            display: block;
+        }
+    }
+}
+
+@media screen and (min-width: $breakpoint-mobile) {
     .modal-content .tab-nav li {
         padding: 0;
         min-width: 0;

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/core.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/core.scss
@@ -275,7 +275,8 @@ footer {
     }
 }
 
-.clearfix {
+.clearfix,
+%clearfix {
     @include clearfix();
 }
 

--- a/wagtail/wagtailadmin/templates/wagtailadmin/chooser/_link_types.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/chooser/_link_types.html
@@ -1,22 +1,15 @@
-{% load i18n wagtailadmin_tags %}
-{% if allow_external_link or allow_email_link or current == 'external' or current == 'email' %}
-    <p class="link-types">
-        {% if current == 'internal' %}
-            <b>{% trans "Internal link" %}</b>
+{% load wagtailadmin_tags %}
+
+{% if link_types|length > 1 %}
+<p class="link-types">
+    {% for link_type in link_types %}
+        {% if current == link_type.id %}
+            <b>{{ link_type.title }}</b>
         {% else %}
-            <a href="{% url 'wagtailadmin_choose_page' %}{% querystring p=None %}">{% trans "Internal link" %}</a>
+            <a data-link-type="{{ link_type.id }}" href="{% url link_type.url_name %}{% querystring p=None %}">{{ link_type.title }}</a>
         {% endif %}
 
-        {% if current == 'external' %}
-            | <b>{% trans "External link" %}</b>
-        {% elif allow_external_link %}
-            | <a href="{% url 'wagtailadmin_choose_page_external_link' %}{% querystring p=None %}">{% trans "External link" %}</a>
-        {% endif %}
-
-        {% if current == 'email' %}
-            | <b>{% trans "Email link" %}</b>
-        {% elif allow_email_link %}
-            | <a href="{% url 'wagtailadmin_choose_page_email_link' %}{% querystring p=None %}">{% trans "Email link" %}</a>
-        {% endif %}
-    </p>
+        {% if not forloop.last %}|{% endif %}
+    {% endfor %}
+</p>
 {% endif %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/chooser/_link_types.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/chooser/_link_types.html
@@ -1,15 +1,15 @@
 {% load wagtailadmin_tags %}
 
 {% if link_types|length > 1 %}
-<p class="link-types">
+<ul class='merged nice-padding modal-tabs link-types'>
     {% for link_type in link_types %}
+        <li class='modal-tabs__item {% if current == link_type.id %} active{% endif %}'>
         {% if current == link_type.id %}
-            <b>{{ link_type.title }}</b>
+            <a data-link-type="{{ link_type.id }}">{{ link_type.title }}</a>
         {% else %}
             <a data-link-type="{{ link_type.id }}" href="{% url link_type.url_name %}{% querystring p=None %}">{{ link_type.title }}</a>
         {% endif %}
-
-        {% if not forloop.last %}|{% endif %}
+        </li>
     {% endfor %}
-</p>
+</ul>
 {% endif %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/chooser/browse.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/chooser/browse.html
@@ -6,11 +6,11 @@
     {% trans "Choose a page" as choose_str %}
 {% endif %}
 
-{% include "wagtailadmin/shared/header.html" with title=choose_str subtitle=page_type_names|join:", " search_url="wagtailadmin_choose_page_search" query_parameters="page_type="|add:page_type_string icon="doc-empty-inverse" %}
+{% include "wagtailadmin/shared/header.html" with title=choose_str subtitle=page_type_names|join:", " search_url="wagtailadmin_choose_page_search" query_parameters="page_type="|add:page_type_string icon="doc-empty-inverse" merged=1 %}
 
-<div class="nice-padding">
-    {% chooser_link_types current='page' %}
+{% chooser_link_types current='page' %}
 
+<div class="modal-tabs__content nice-padding">
     {% if page_types_restricted %}
         <p class="help-block help-warning">
             {% blocktrans with type=page_type_names|join:", " count counter=page_type_names|length %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/chooser/browse.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/chooser/browse.html
@@ -1,4 +1,5 @@
-{% load i18n %}
+{% load i18n wagtailadmin_tags %}
+
 {% if page_types_restricted %}
     {% trans "Choose" as choose_str %}
 {% else %}
@@ -8,7 +9,7 @@
 {% include "wagtailadmin/shared/header.html" with title=choose_str subtitle=page_type_names|join:", " search_url="wagtailadmin_choose_page_search" query_parameters="page_type="|add:page_type_string icon="doc-empty-inverse" %}
 
 <div class="nice-padding">
-    {% include 'wagtailadmin/chooser/_link_types.html' with current='internal' %}
+    {% chooser_link_types current='page' %}
 
     {% if page_types_restricted %}
         <p class="help-block help-warning">

--- a/wagtail/wagtailadmin/templates/wagtailadmin/chooser/browse.js
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/chooser/browse.js
@@ -1,6 +1,6 @@
 function(modal) {
     /* Set up page navigation and link-types links to open in the modal */
-    $('a.navigate-pages, .link-types a', modal.body).click(function() {
+    $('a.navigate-pages', modal.body).click(function() {
         modal.loadUrl(this.href);
         return false;
     });
@@ -42,16 +42,24 @@ function(modal) {
         $(this).data('timer', wait);
     });
 
+    function choosePage() {
+        var pageData = $(this).data();
+        modal.respond('linkChosen', {
+            'type': 'page',
+            'url': pageData.url,
+            'title': pageData.title,
+            'data': {'id': pageData.id},
+        });
+        modal.close();
+
+        return false;
+    }
+
     /* Set up behaviour of choose-page links in the newly-loaded search results,
     to pass control back to the calling page */
     function ajaxifySearchResults() {
-        $('.page-results a.choose-page', modal.body).click(function() {
-            var pageData = $(this).data();
-            modal.respond('pageChosen', $(this).data());
-            modal.close();
+        $('.page-results a.choose-page', modal.body).click(choosePage);
 
-            return false;
-        });
         /* pagination links within search results should be AJAX-fetched
         and the result loaded into .page-results (and ajaxified) */
         $('.page-results a.navigate-pages', modal.body).click(function() {
@@ -60,19 +68,12 @@ function(modal) {
         });
     }
 
+    /* Set up behaviour of choose-page links, to pass control back to the calling page */
+    $('a.choose-page', modal.body).click(choosePage);
+
     /*
     Focus on the search box when opening the modal.
     FIXME: this doesn't seem to have any effect (at least on Chrome)
     */
     $('#id_q', modal.body).focus();
-
-    /* Set up behaviour of choose-page links, to pass control back to the calling page */
-    $('a.choose-page', modal.body).click(function() {
-        var pageData = $(this).data();
-        pageData.parentId = {{ parent_page.id }};
-        modal.respond('pageChosen', $(this).data());
-        modal.close();
-
-        return false;
-    });
 }

--- a/wagtail/wagtailadmin/templates/wagtailadmin/chooser/email_link.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/chooser/email_link.html
@@ -1,9 +1,9 @@
 {% load i18n wagtailadmin_tags %}
 {% trans "Add an email link" as email_str %}
-{% include "wagtailadmin/shared/header.html" with title=email_str %}
+{% include "wagtailadmin/shared/header.html" with title=email_str merged=1 %}
 
-<div class="nice-padding">
-    {% chooser_link_types current='email' %}
+{% chooser_link_types current='email' %}
+<div class="modal-tabs__content nice-padding">
 
     <form action="{% url 'wagtailadmin_choose_page_email_link' %}{% querystring %}" method="post">
         {% csrf_token %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/chooser/email_link.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/chooser/email_link.html
@@ -3,7 +3,7 @@
 {% include "wagtailadmin/shared/header.html" with title=email_str %}
 
 <div class="nice-padding">
-    {% include 'wagtailadmin/chooser/_link_types.html' with current='email' %}
+    {% chooser_link_types current='email' %}
 
     <form action="{% url 'wagtailadmin_choose_page_email_link' %}{% querystring %}" method="post">
         {% csrf_token %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/chooser/email_link.js
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/chooser/email_link.js
@@ -1,8 +1,4 @@
 function(modal) {
-    $('p.link-types a', modal.body).click(function() {
-        modal.loadUrl(this.href);
-        return false;
-    });
 
     $('form', modal.body).submit(function() {
         modal.postForm(this.action, $(this).serialize());

--- a/wagtail/wagtailadmin/templates/wagtailadmin/chooser/external_link.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/chooser/external_link.html
@@ -1,9 +1,9 @@
 {% load i18n wagtailadmin_tags %}
 {% trans "Add an external link" as add_str %}
-{% include "wagtailadmin/shared/header.html" with title=add_str %}
+{% include "wagtailadmin/shared/header.html" with title=add_str merged=1 %}
 
-<div class="nice-padding">
-    {% chooser_link_types current='external' %}
+{% chooser_link_types current='external' %}
+<div class="modal-tabs__content nice-padding">
 
     <form action="{% url 'wagtailadmin_choose_page_external_link' %}{% querystring %}" method="post">
         {% csrf_token %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/chooser/external_link.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/chooser/external_link.html
@@ -3,7 +3,7 @@
 {% include "wagtailadmin/shared/header.html" with title=add_str %}
 
 <div class="nice-padding">
-    {% include 'wagtailadmin/chooser/_link_types.html' with current='external' %}
+    {% chooser_link_types current='external' %}
 
     <form action="{% url 'wagtailadmin_choose_page_external_link' %}{% querystring %}" method="post">
         {% csrf_token %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/chooser/external_link.js
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/chooser/external_link.js
@@ -1,9 +1,4 @@
 function(modal) {
-    $('p.link-types a', modal.body).click(function() {
-        modal.loadUrl(this.href);
-        return false;
-    });
-
     $('form', modal.body).submit(function() {
         modal.postForm(this.action, $(this).serialize());
         return false;

--- a/wagtail/wagtailadmin/templates/wagtailadmin/chooser/external_link_chosen.js
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/chooser/external_link_chosen.js
@@ -1,5 +1,6 @@
 function(modal) {
-    modal.respond('pageChosen', {
+    modal.respond('linkChosen', {
+        'type': '{{ type|escapejs }}',
         'url': '{{ url|escapejs }}',
         'title': '{{ link_text|escapejs }}'
     });

--- a/wagtail/wagtailadmin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/wagtailadmin/templatetags/wagtailadmin_tags.py
@@ -9,6 +9,7 @@ from django.template.defaultfilters import stringfilter
 from django.utils.safestring import mark_safe
 
 from wagtail.utils.pagination import DEFAULT_PAGE_KEY
+from wagtail.wagtailadmin.link_choosers import registry
 from wagtail.wagtailadmin.menu import admin_menu
 from wagtail.wagtailadmin.search import admin_search_areas
 from wagtail.wagtailcore import hooks
@@ -292,3 +293,14 @@ def page_listing_buttons(context, page, page_perms, is_parent=False):
         hook(page, page_perms, is_parent)
         for hook in button_hooks))
     return {'page': page, 'buttons': buttons}
+
+
+@register.inclusion_tag('wagtailadmin/chooser/_link_types.html',
+                        takes_context=True)
+def chooser_link_types(context, current):
+    return {
+        'request': context['request'],
+        'querystring': context.get('querystring', ''),
+        'current': current,
+        'link_types': registry,
+    }

--- a/wagtail/wagtailadmin/views/chooser.py
+++ b/wagtail/wagtailadmin/views/chooser.py
@@ -156,6 +156,7 @@ def external_link(request):
                 request,
                 None, 'wagtailadmin/chooser/external_link_chosen.js',
                 {
+                    'type': 'external',
                     'url': form.cleaned_data['url'],
                     'link_text': form.cleaned_data['link_text'] if prompt_for_link_text else form.cleaned_data['url']
                 }
@@ -187,6 +188,7 @@ def email_link(request):
                 request,
                 None, 'wagtailadmin/chooser/external_link_chosen.js',
                 {
+                    'type': 'email',
                     'url': 'mailto:' + form.cleaned_data['email_address'],
                     'link_text': form.cleaned_data['link_text'] if (
                         prompt_for_link_text and form.cleaned_data['link_text']

--- a/wagtail/wagtailadmin/wagtail_hooks.py
+++ b/wagtail/wagtailadmin/wagtail_hooks.py
@@ -10,6 +10,8 @@ from wagtail.wagtailadmin.widgets import Button, ButtonWithDropdownFromHook, Pag
 from wagtail.wagtailcore import hooks
 from wagtail.wagtailcore.permissions import collection_permission_policy
 
+from .link_choosers import EmailLinkChooser, ExternalLinkChooser, InternalLinkChooser
+
 
 class ExplorerMenuItem(MenuItem):
     @property
@@ -95,3 +97,18 @@ def page_listing_more_buttons(page, page_perms, is_parent=False):
         yield Button(_('Delete'), reverse('wagtailadmin_pages:delete', args=[page.id]), priority=30)
     if page_perms.can_unpublish():
         yield Button(_('Unpublish'), reverse('wagtailadmin_pages:unpublish', args=[page.id]), priority=40)
+
+
+@hooks.register('register_link_chooser')
+def register_internal_link_chooser():
+    return InternalLinkChooser()
+
+
+@hooks.register('register_link_chooser')
+def register_external_link_chooser():
+    return ExternalLinkChooser()
+
+
+@hooks.register('register_link_chooser')
+def register_email_link_chooser():
+    return EmailLinkChooser()

--- a/wagtail/wagtailcore/rich_text.py
+++ b/wagtail/wagtailcore/rich_text.py
@@ -1,12 +1,14 @@
 from __future__ import unicode_literals
 
 import re  # parsing HTML with regexes LIKE A BOSS.
+import warnings
 
 from django.forms.utils import flatatt
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.lru_cache import lru_cache
 from django.utils.safestring import mark_safe
 
+from wagtail.utils.deprecation import RemovedInWagtail16Warning
 from wagtail.wagtailadmin.link_choosers import registry as link_chooser_registry
 from wagtail.wagtailcore import hooks
 from wagtail.wagtailcore.whitelist import Whitelister
@@ -33,6 +35,23 @@ def get_embed_handler(embed_type):
         has_loaded_embed_handlers = True
 
     return EMBED_HANDLERS[embed_type]
+
+
+# RemovedInWagtail16Warning: This whole function
+@lru_cache()
+def get_old_link_handlers():
+    handlers = []
+    for hook in hooks.get_hooks('register_rich_text_link_handler'):
+        message = '%s.%s: "register_rich_text_link_handler" is deprecated. Use "register_link_chooser"' % (
+            hook.__module__, hook.__name__)
+        warnings.warn(message, RemovedInWagtail16Warning)
+        handlers.append(hook())
+    return dict(handlers)
+
+
+# RemovedInWagtail16Warning: This whole function
+def get_old_link_handler(link_type):
+    return get_old_link_handlers()[link_type]
 
 
 @lru_cache()
@@ -89,7 +108,13 @@ class DbWhitelister(Whitelister):
                 cls.clean_node(doc, child)
 
             link_type = tag['data-linktype']
-            link_handler = get_link_chooser(link_type)
+            try:
+                link_handler = get_link_chooser(link_type)
+            except KeyError:
+                try:
+                    link_handler = get_old_link_handler(link_type)
+                except KeyError:
+                    raise ValueError('Unknown link chooser "{}"'.format(link_type))
             link_attrs = link_handler.get_db_attributes(tag)
             link_attrs['linktype'] = link_type
             tag.attrs.clear()
@@ -126,11 +151,25 @@ def expand_db_html(html, for_editor=False):
         if 'linktype' not in attrs:
             # return unchanged
             return m.group(0)
-        handler = get_link_chooser(attrs['linktype'])
-        attrs = handler.expand_db_attributes(attrs, for_editor)
-        if for_editor:
-            attrs['data-linktype'] = handler.id
-        return '<a{}>'.format(flatatt(attrs))
+        try:
+            handler = get_link_chooser(attrs['linktype'])
+        except KeyError:
+            pass
+        else:
+            attrs = handler.expand_db_attributes(attrs, for_editor)
+            if for_editor:
+                attrs['data-linktype'] = handler.id
+            return '<a{}>'.format(flatatt(attrs))
+
+        # RemovedInWagtail16Warning: old-style link handlers will be removed
+        try:
+            handler = get_old_link_handler(attrs['linktype'])
+        except KeyError:
+            pass
+        else:
+            return handler.expand_db_attributes(attrs, for_editor)
+
+        raise ValueError('Unknown link chooser "{}"'.format(attrs['linktype']))
 
     def replace_embed_tag(m):
         attrs = extract_attrs(m.group(1))

--- a/wagtail/wagtailcore/tests/test_blocks.py
+++ b/wagtail/wagtailcore/tests/test_blocks.py
@@ -165,13 +165,10 @@ class TestRichTextBlock(TestCase):
         block = blocks.RichTextBlock()
         value = RichText('<p>Merry <a linktype="page" id="4">Christmas</a>!</p>')
         result = block.render_form(value, prefix='richtext')
-        self.assertIn(
-            (
-                '&lt;p&gt;Merry &lt;a data-linktype=&quot;page&quot; data-id=&quot;4&quot;'
-                ' href=&quot;/events/christmas/&quot;&gt;Christmas&lt;/a&gt;!&lt;/p&gt;'
-            ),
-            result
-        )
+
+        self.assertIn('data-linktype=&quot;page&quot;', result)
+        self.assertIn('data-id=&quot;4&quot;', result)
+        self.assertIn('href=&quot;/events/christmas/&quot;', result)
 
     def test_validate_required_richtext_block(self):
         block = blocks.RichTextBlock()

--- a/wagtail/wagtailcore/tests/test_rich_text.py
+++ b/wagtail/wagtailcore/tests/test_rich_text.py
@@ -55,6 +55,14 @@ class TestDbWhiteLister(TestCase):
         DbWhitelister.clean_tag_node(soup, tag)
         self.assertEqual(str(tag), '<a id="1" linktype="document">foo</a>')
 
+    def test_clean_tag_node_with_old_data_linktype(self):
+        soup = BeautifulSoup(
+            '<a data-linktype="foo" data-foo="bar" irrelevant="baz">foo</a>',
+            'html5lib')
+        tag = soup.a
+        DbWhitelister.clean_tag_node(soup, tag)
+        self.assertHTMLEqual(str(tag), '<a foo="bar" linktype="foo">foo</a>')
+
     def test_clean_tag_node(self):
         soup = BeautifulSoup('<a irrelevant="baz">foo</a>', 'html5lib')
         tag = soup.a
@@ -100,6 +108,16 @@ class TestExpandDbHtml(TestCase):
         html = '<embed embedtype="media" url="http://www.youtube.com/watch" />'
         result = expand_db_html(html)
         self.assertIn('test html', result)
+
+    def test_expand_old_link_handler(self):
+        self.assertHTMLEqual(
+            expand_db_html('<a linktype="foo" foo="bar">baz</a>'),
+            '<a href="http://example.com/bar/">baz</a>')
+
+    def test_expand_old_link_handler_for_editor(self):
+        self.assertHTMLEqual(
+            expand_db_html('<a linktype="foo" foo="bar">baz</a>', for_editor=True),
+            '<a href="http://example.com/bar/" data-linktype="foo" data-foo="bar">baz</a>')
 
 
 class TestRichTextValue(TestCase):

--- a/wagtail/wagtaildocs/rich_text.py
+++ b/wagtail/wagtaildocs/rich_text.py
@@ -1,9 +1,16 @@
-from django.utils.html import escape
+from django.utils.translation import ugettext_lazy as _
 
+from wagtail.wagtailadmin.link_choosers import LinkChooser
 from wagtail.wagtaildocs.models import get_document_model
 
 
-class DocumentLinkHandler(object):
+class DocumentLinkHandler(LinkChooser):
+
+    id = 'document'
+    title = _('Document')
+    url_name = 'wagtaildocs:chooser'
+    priority = 400
+
     @staticmethod
     def get_db_attributes(tag):
         return {'id': tag['data-id']}
@@ -13,12 +20,10 @@ class DocumentLinkHandler(object):
         Document = get_document_model()
         try:
             doc = Document.objects.get(id=attrs['id'])
-
-            if for_editor:
-                editor_attrs = 'data-linktype="document" data-id="%d" ' % doc.id
-            else:
-                editor_attrs = ''
-
-            return '<a %shref="%s">' % (editor_attrs, escape(doc.url))
         except Document.DoesNotExist:
-            return "<a>"
+            return {}
+
+        attrs = {'href': doc.url}
+        if for_editor:
+            attrs['data-id'] = doc.id
+        return attrs

--- a/wagtail/wagtaildocs/templates/wagtaildocs/chooser/chooser.html
+++ b/wagtail/wagtaildocs/templates/wagtaildocs/chooser/chooser.html
@@ -2,14 +2,13 @@
 {% trans "Choose a document" as  choose_str %}
 {% include "wagtailadmin/shared/header.html" with title=choose_str tabbed=1 merged=1 icon="doc-full-inverse" %}
 
-<div class="nice-padding">
-    {% chooser_link_types current='document' %}
-</div>
+{% chooser_link_types current='document' %}
+
 
 {% if uploadform %}
-    <ul class="tab-nav merged">
-        <li class="{% if not uploadform.errors %}active {% endif %}"><a href="#search">{% trans "Search" %}</a></li>
-        <li class="{% if uploadform.errors %}active {% endif %}"><a href="#upload">{% trans "Upload" %}</a></li>
+    <ul class="nice-padding tab-nav modal-tabs modal-tabs--secondary">
+        <li class="modal-tabs__item {% if not uploadform.errors %}active {% endif %}"><a href="#search">{% trans "Search" %}</a></li>
+        <li class="modal-tabs__item {% if uploadform.errors %}active {% endif %}"><a href="#upload">{% trans "Upload" %}</a></li>
     </ul>
 {% endif %}
 
@@ -18,14 +17,21 @@
 
 
         <form class="document-search search-bar" action="{% url 'wagtaildocs:chooser' %}" method="GET">
-            <ul class="fields">
-                {% for field in searchform %}
-                    {% include "wagtailadmin/shared/field_as_li.html" with field=field %}
-                {% endfor %}
-                {% if collections %}
-                    {% include "wagtailadmin/shared/collection_chooser.html" %}
-                {% endif %}
-            </ul>
+            <div class="inline-form">
+                <div class="left">
+                    <ul class="fields">
+                        {% for field in searchform %}
+                            {% include "wagtailadmin/shared/field_as_li.html" with field=field show_label=False %}
+                        {% endfor %}
+                        {% if collections %}
+                            {% include "wagtailadmin/shared/collection_chooser.html" %}
+                        {% endif %}
+                    </ul>
+                </div>
+                <div class="left submit">
+                    <input type="submit" value="{% trans 'Search' %}" />
+                </div>
+            </div>
         </form>
         <div id="search-results" class="listing documents">
             {% include "wagtaildocs/chooser/results.html" %}
@@ -34,9 +40,6 @@
     {% if uploadform %}
 
         <section id="upload" class="{% if uploadform.errors %}active {% endif %}nice-padding">
-
-            {% chooser_link_types current='document' %}
-
             <form class="document-upload" action="{% url 'wagtaildocs:chooser_upload' %}" method="POST" enctype="multipart/form-data">
                 {% csrf_token %}
                 <ul class="fields">

--- a/wagtail/wagtaildocs/templates/wagtaildocs/chooser/chooser.html
+++ b/wagtail/wagtaildocs/templates/wagtaildocs/chooser/chooser.html
@@ -1,7 +1,10 @@
-{% load i18n %}
+{% load i18n wagtailadmin_tags %}
 {% trans "Choose a document" as  choose_str %}
 {% include "wagtailadmin/shared/header.html" with title=choose_str tabbed=1 merged=1 icon="doc-full-inverse" %}
 
+<div class="nice-padding">
+    {% chooser_link_types current='document' %}
+</div>
 
 {% if uploadform %}
     <ul class="tab-nav merged">
@@ -12,6 +15,8 @@
 
 <div class="tab-content">
     <section id="search" class="{% if not uploadform.errors %}active {% endif %}nice-padding">
+
+
         <form class="document-search search-bar" action="{% url 'wagtaildocs:chooser' %}" method="GET">
             <ul class="fields">
                 {% for field in searchform %}
@@ -27,7 +32,11 @@
         </div>
     </section>
     {% if uploadform %}
+
         <section id="upload" class="{% if uploadform.errors %}active {% endif %}nice-padding">
+
+            {% chooser_link_types current='document' %}
+
             <form class="document-upload" action="{% url 'wagtaildocs:chooser_upload' %}" method="POST" enctype="multipart/form-data">
                 {% csrf_token %}
                 <ul class="fields">

--- a/wagtail/wagtaildocs/templates/wagtaildocs/chooser/chooser.js
+++ b/wagtail/wagtaildocs/templates/wagtaildocs/chooser/chooser.js
@@ -1,5 +1,10 @@
 {% load i18n %}
 function(modal) {
+
+    var $tab = $('[data-link-type="document"]');
+    $tab.parent().addClass('modal-tabs__item--secondary');
+
+
     function ajaxifyLinks (context) {
         $('a.document-choice', context).click(function() {
             modal.loadUrl(this.href);

--- a/wagtail/wagtaildocs/templates/wagtaildocs/chooser/document_chosen.js
+++ b/wagtail/wagtaildocs/templates/wagtaildocs/chooser/document_chosen.js
@@ -1,4 +1,4 @@
 function(modal) {
-    modal.respond('documentChosen', {{ document_json|safe }});
+    modal.respond('linkChosen', {{ document_json|safe }});
     modal.close();
 }

--- a/wagtail/wagtaildocs/tests.py
+++ b/wagtail/wagtaildocs/tests.py
@@ -723,7 +723,7 @@ class TestDocumentChooserUploadView(TestCase, WagtailTestUtils):
 
         # Check that the response is a javascript file saying the document was chosen
         self.assertTemplateUsed(response, 'wagtaildocs/chooser/document_chosen.js')
-        self.assertContains(response, "modal.respond('documentChosen'")
+        self.assertContains(response, "modal.respond('linkChosen'")
 
         # Document should be created
         self.assertTrue(models.Document.objects.filter(title="Test document").exists())
@@ -1084,31 +1084,19 @@ class TestDocumentRichTextLinkHandler(TestCase):
         soup = BeautifulSoup('<a data-id="test-id">foo</a>', 'html5lib')
         tag = soup.a
         result = DocumentLinkHandler.get_db_attributes(tag)
-        self.assertEqual(result,
-                         {'id': 'test-id'})
+        self.assertEqual(result, {'id': 'test-id'})
 
     def test_expand_db_attributes_document_does_not_exist(self):
-        result = DocumentLinkHandler.expand_db_attributes(
-            {'id': 0},
-            False
-        )
-        self.assertEqual(result, '<a>')
+        result = DocumentLinkHandler.expand_db_attributes({'id': '0'}, False)
+        self.assertEqual(result, {})
 
     def test_expand_db_attributes_for_editor(self):
-        result = DocumentLinkHandler.expand_db_attributes(
-            {'id': 1},
-            True
-        )
-        self.assertEqual(result,
-                         '<a data-linktype="document" data-id="1" href="/documents/1/test.pdf">')
+        result = DocumentLinkHandler.expand_db_attributes({'id': '1'}, True)
+        self.assertEqual(result, {'href': '/documents/1/test.pdf', 'data-id': 1})
 
     def test_expand_db_attributes_not_for_editor(self):
-        result = DocumentLinkHandler.expand_db_attributes(
-            {'id': 1},
-            False
-        )
-        self.assertEqual(result,
-                         '<a href="/documents/1/test.pdf">')
+        result = DocumentLinkHandler.expand_db_attributes({'id': 1}, False)
+        self.assertEqual(result, {'href': '/documents/1/test.pdf'})
 
 
 class TestEditOnlyPermissions(TestCase, WagtailTestUtils):

--- a/wagtail/wagtaildocs/views/chooser.py
+++ b/wagtail/wagtaildocs/views/chooser.py
@@ -11,6 +11,7 @@ from wagtail.wagtailcore.models import Collection
 from wagtail.wagtaildocs.forms import get_document_form
 from wagtail.wagtaildocs.models import get_document_model
 from wagtail.wagtaildocs.permissions import permission_policy
+from wagtail.wagtaildocs.rich_text import DocumentLinkHandler
 from wagtail.wagtailsearch.backends import get_search_backends
 
 permission_checker = PermissionPolicyChecker(permission_policy)
@@ -23,9 +24,11 @@ def get_document_json(document):
     """
 
     return json.dumps({
-        'id': document.id,
+        'type': DocumentLinkHandler.id,
         'title': document.title,
+        'url': reverse('wagtaildocs_serve', args=(document.id, document.filename)),
         'edit_link': reverse('wagtaildocs:edit', args=(document.id,)),
+        'data': {'id': document.id},
     })
 
 

--- a/wagtail/wagtaildocs/wagtail_hooks.py
+++ b/wagtail/wagtaildocs/wagtail_hooks.py
@@ -1,4 +1,5 @@
 from django.conf.urls import include, url
+from django.contrib.auth.models import Permission
 from django.contrib.staticfiles.templatetags.staticfiles import static
 from django.core import urlresolvers
 from django.utils.html import format_html, format_html_join
@@ -62,9 +63,15 @@ def editor_js():
     )
 
 
-@hooks.register('register_rich_text_link_handler')
-def register_document_link_handler():
-    return ('document', DocumentLinkHandler)
+@hooks.register('register_permissions')
+def register_permissions():
+    return Permission.objects.filter(content_type__app_label='wagtaildocs',
+                                     codename__in=['add_document', 'change_document'])
+
+
+@hooks.register('register_link_chooser')
+def register_document_link_chooser():
+    return DocumentLinkHandler()
 
 
 class DocumentsSummaryItem(SummaryItem):


### PR DESCRIPTION
This is still a work in progress, but the concept works!

My colleague @seb-b and I recently tried to add a News Article chooser for [Wagtail News](https://pypi.python.org/pypi/wagtailnews/), and we found it to be much more difficult than it needed to be. We needed to make a new hallo plugin, even though there were multiple ones already there that did the same basic thing. We needed to add a DB whitelister in a completely different place. We needed to register against many different hooks, and make a variety of magical classes and views. We needed to insert some funky JS snippets to register our plugin and register a URL. Lots of this had already been done in other places, and it felt like we were duplicating a lot of code.

I had a look through it, and there were so many more similarities than there were differences, so I had a go at unifying it all together. This PR is my progress so far.

Internal links, external links, and email links are now all handled in a similar fashion, with DB whitelisters and being registered via hooks. Document links got a similar treatment. There is now a single hook that takes care of setting it all up - whitelisting, adding to the link chooser panel, and other related things. The definition for a chooser is contained to a single, basic class. You can see these classes in the `link_handlers.py` files I have added.

This needs some documentation, and some thoughts on how to make it backwards compatible. Your thoughts on what I have done so far are also welcome.
