### PR TITLE
Deprecate automatic `template` attribute, use `get_template`

### DIFF
--- a/wagtail/tests/settings.py
+++ b/wagtail/tests/settings.py
@@ -1,12 +1,15 @@
 from __future__ import absolute_import, unicode_literals
 
 import os
+
 import django
 
 WAGTAIL_ROOT = os.path.dirname(os.path.dirname(__file__))
 STATIC_ROOT = os.path.join(WAGTAIL_ROOT, 'tests', 'test-static')
 MEDIA_ROOT = os.path.join(WAGTAIL_ROOT, 'tests', 'test-media')
 MEDIA_URL = '/media/'
+
+TIME_ZONE = 'Asia/Tokyo'
 
 DATABASES = {
     'default': {

--- a/wagtail/tests/testapp/models.py
+++ b/wagtail/tests/testapp/models.py
@@ -146,7 +146,6 @@ class PageWithOldStyleRouteMethod(Page):
     we need to continue accepting this convention (albeit as a deprecated API).
     """
     content = models.TextField()
-    template = 'tests/simple_page.html'
 
     def route(self, request, path_components):
         return self.serve(request)
@@ -430,7 +429,7 @@ class FormPageWithCustomSubmission(AbstractEmailForm):
         if self.get_submission_class().objects.filter(page=self, user__pk=request.user.pk).exists():
             return render(
                 request,
-                self.template,
+                self.get_template(request),
                 self.get_context(request)
             )
 
@@ -527,6 +526,9 @@ register_snippet(AdvertWithTabbedInterface)
 class StandardIndex(Page):
     """ Index for the site """
     parent_page_types = [Page]
+
+    template = 'index.html'
+    ajax_template = 'ajax.html'
 
 
 # A custom panel setup where all Promote fields are placed in the Content tab instead;

--- a/wagtail/wagtailadmin/tests/test_edit_handlers.py
+++ b/wagtail/wagtailadmin/tests/test_edit_handlers.py
@@ -115,10 +115,11 @@ def clear_edit_handler(page_cls):
         def decorated(self):
             # Clear any old EditHandlers generated
             page_cls.get_edit_handler.cache_clear()
-            fn(self)
-            # Clear the bad EditHandler generated just now
-            page_cls.get_edit_handler.cache_clear()
-        return decorated
+            try:
+                fn(self)
+            finally:
+                # Clear the bad EditHandler generated just now
+                page_cls.get_edit_handler.cache_clear()
     return decorator
 
 

--- a/wagtail/wagtailadmin/tests/test_rich_text.py
+++ b/wagtail/wagtailadmin/tests/test_rich_text.py
@@ -8,7 +8,34 @@ from django.test.utils import override_settings
 from wagtail.tests.testapp.rich_text import CustomRichTextArea
 from wagtail.tests.utils import WagtailTestUtils
 from wagtail.wagtailadmin.rich_text import HalloRichTextArea, get_rich_text_editor_widget
-from wagtail.wagtailcore.models import Page
+from wagtail.wagtailcore.models import Page, get_page_models
+
+
+class BaseRichTextEditHandlerTestCase(TestCase):
+    def _clear_edit_handler_cache(self):
+        """
+        These tests generate new EditHandlers with different settings. The
+        cached edit handlers should be cleared before and after each test run
+        to ensure that no changes leak through to other tests.
+        """
+        from wagtail.tests.testapp.models import DefaultRichBlockFieldPage
+
+        block_page_edit_handler = DefaultRichBlockFieldPage.get_edit_handler()
+        if block_page_edit_handler._form_class:
+            rich_text_block = block_page_edit_handler._form_class.base_fields['body'].block.child_blocks['rich_text']
+            if hasattr(rich_text_block, 'field'):
+                del rich_text_block.field
+
+        for page_class in get_page_models():
+            page_class.get_edit_handler.cache_clear()
+
+    def setUp(self):
+        super(BaseRichTextEditHandlerTestCase, self).setUp()
+        self._clear_edit_handler_cache()
+
+    def tearDown(self):
+        self._clear_edit_handler_cache()
+        super(BaseRichTextEditHandlerTestCase, self).tearDown()
 
 
 class TestGetRichTextEditorWidget(TestCase):
@@ -50,9 +77,10 @@ class TestGetRichTextEditorWidget(TestCase):
 
 
 @override_settings()
-class TestDefaultRichText(TestCase, WagtailTestUtils):
+class TestDefaultRichText(BaseRichTextEditHandlerTestCase, WagtailTestUtils):
 
     def setUp(self):
+        super(TestDefaultRichText, self).setUp()
         # Find root page
         self.root_page = Page.objects.get(id=2)
 
@@ -61,19 +89,6 @@ class TestDefaultRichText(TestCase, WagtailTestUtils):
         # Simulate the absence of a setting
         if hasattr(settings, 'WAGTAILADMIN_RICH_TEXT_EDITORS'):
             del settings.WAGTAILADMIN_RICH_TEXT_EDITORS
-
-    def tearDown(self):
-        from wagtail.tests.testapp.models import DefaultRichBlockFieldPage
-        from wagtail.tests.testapp.models import DefaultRichTextFieldPage
-
-        DefaultRichTextFieldPage.get_edit_handler()._form_class = None
-
-        block_page_edit_handler = DefaultRichBlockFieldPage.get_edit_handler()
-        if block_page_edit_handler._form_class:
-            rich_text_block = block_page_edit_handler._form_class.base_fields['body'].block.child_blocks['rich_text']
-            if hasattr(rich_text_block, 'field'):
-                del rich_text_block.field
-        block_page_edit_handler._form_class = None
 
     def test_default_editor_in_rich_text_field(self):
         response = self.client.get(reverse(
@@ -103,26 +118,15 @@ class TestDefaultRichText(TestCase, WagtailTestUtils):
         'WIDGET': 'wagtail.tests.testapp.rich_text.CustomRichTextArea'
     },
 })
-class TestOverriddenDefaultRichText(TestCase, WagtailTestUtils):
+class TestOverriddenDefaultRichText(BaseRichTextEditHandlerTestCase, WagtailTestUtils):
 
     def setUp(self):
+        super(TestOverriddenDefaultRichText, self).setUp()
+
         # Find root page
         self.root_page = Page.objects.get(id=2)
 
         self.login()
-
-    def tearDown(self):
-        from wagtail.tests.testapp.models import DefaultRichBlockFieldPage
-        from wagtail.tests.testapp.models import DefaultRichTextFieldPage
-
-        DefaultRichTextFieldPage.get_edit_handler()._form_class = None
-
-        block_page_edit_handler = DefaultRichBlockFieldPage.get_edit_handler()
-        if block_page_edit_handler._form_class:
-            rich_text_block = block_page_edit_handler._form_class.base_fields['body'].block.child_blocks['rich_text']
-            if hasattr(rich_text_block, 'field'):
-                del rich_text_block.field
-        block_page_edit_handler._form_class = None
 
     def test_overridden_default_editor_in_rich_text_field(self):
         response = self.client.get(reverse(
@@ -157,20 +161,15 @@ class TestOverriddenDefaultRichText(TestCase, WagtailTestUtils):
         'WIDGET': 'wagtail.tests.testapp.rich_text.CustomRichTextArea'
     },
 })
-class TestCustomDefaultRichText(TestCase, WagtailTestUtils):
+class TestCustomDefaultRichText(BaseRichTextEditHandlerTestCase, WagtailTestUtils):
 
     def setUp(self):
+        super(TestCustomDefaultRichText, self).setUp()
+
         # Find root page
         self.root_page = Page.objects.get(id=2)
 
         self.login()
-
-    def tearDown(self):
-        from wagtail.tests.testapp.models import CustomRichBlockFieldPage
-        from wagtail.tests.testapp.models import CustomRichTextFieldPage
-
-        CustomRichBlockFieldPage.get_edit_handler()._form_class = None
-        CustomRichTextFieldPage.get_edit_handler()._form_class = None
 
     def test_custom_editor_in_rich_text_field(self):
         response = self.client.get(reverse(

--- a/wagtail/wagtailforms/tests/test_models.py
+++ b/wagtail/wagtailforms/tests/test_models.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import, unicode_literals
 import json
 
 from django.core import mail
-from django.test import TestCase
+from django.test import RequestFactory, TestCase
 
 from wagtail.tests.testapp.models import CustomFormPageSubmission, FormField, JadeFormPage
 from wagtail.tests.utils import WagtailTestUtils
@@ -394,4 +394,6 @@ class TestNonHtmlExtension(TestCase):
 
     def test_non_html_extension(self):
         form_page = JadeFormPage(title="test")
-        self.assertEqual(form_page.landing_page_template, "tests/form_page_landing.jade")
+        self.assertEqual(
+            form_page.get_landing_page_template(RequestFactory().get('/test/')),
+            "tests/form_page_landing.jade")


### PR DESCRIPTION
Instead of automatically generating a `template` attribute in the PageBase metaclass - which made it very difficult to override - the automatic template name generation is now done inside `get_template()`.

`template` and `ajax_template` have been made in to a `@property`, which raises a RemovedInWagtail13Warning when accessed. They can still be overridden in Page subclasses to hardcode the template name manually. In Wagtail 1.3, the `template` and `ajax_template` attributes will be set to `None`.

`AbstractForm` pages had a `landing_page_template` attribute that was generated in `__init__` using the `template` attribute. A `is_landing_page` parameter has been added to `get_template` which automatically generates this landing page template name instead.
