### PR TITLE
[WIP] Proxy page models

### DIFF
--- a/wagtail/wagtailcore/query.py
+++ b/wagtail/wagtailcore/query.py
@@ -161,7 +161,7 @@ class PageQuerySet(MP_NodeQuerySet):
         content_types = ContentType.objects.get_for_models(*[
             model for model in apps.get_models()
             if issubclass(model, klass)
-        ]).values()
+        ], for_concrete_model=False).values()
 
         return Q(content_type__in=content_types)
 


### PR DESCRIPTION
This PR includes some tweaks to Wagtail core to allow users to define new page types using proxy models instead of multi-table inheritance. The implementation is currently only for demonstration purposes (not much time).

There's two use-cases I think this would be useful for
- Defining new page types that extend another (which don't need model changes) without introducing a third level of MTI
- Creating page types that don't use multi-table inheritance at all (I can see this becoming much more useful when we introduce an abstract base page class)

Currently (Wagtail 1.1), if you define a proxy page model. Wagtail would add another entry into the "add subpage" view, except it's an exact duplicate of the parent class.

![proxy-pages](https://cloud.githubusercontent.com/assets/1093808/10104568/40f9b24e-63a2-11e5-94f7-de000e005243.png)
### Implementation

To implement this, I've simply gone through `wagtailcore/models.py` and added `for_concrete_model=False` to each call to `get_for_model`. This fixes the issues with "add subpage" and allows pages to be created for these models.

By default, proxy models objects attribute returns all instances of their parent class, so I've added a `ProxyPageManager` which filters the pages to only include instances of the proxy model, emulating behaviour of multi-table inheritance. (this manager is currently forced on the proxy model, but I'd like to make this opt-in).
### Example

Finally, here's the code I created to test this:

``` python
from django.db import models

from wagtail.wagtailcore.models import Page
from wagtail.wagtailadmin.edit_handlers import FieldPanel


class BlogEntryPage(Page):
    date = models.DateTimeField()
    body = models.TextField()

    content_panels = Page.content_panels + [
        FieldPanel('date'),
        FieldPanel('body'),
    ]


class AwesomeBlogEntryPage(BlogEntryPage):
    class Meta:
        proxy = True
```

Both content types can be created in the admin:

![proxy_models_2](https://cloud.githubusercontent.com/assets/1093808/10105009/792e2ddc-63a4-11e5-844d-82d5b3219555.png)

Pages appear to be two distinct types to the user:

![proxy_models_3](https://cloud.githubusercontent.com/assets/1093808/10105144/1125e9cc-63a5-11e5-82b3-f3a75a66168c.png)

And in the shell:

``` python
# Proxy models appear in their parent classes objects
>>> BlogEntryPage.objects.all()
[<BlogEntryPage: blog>, <BlogEntryPage: Awesome blog entry>]

# When using PageProxyManager, only instances of the proxy are included in the proxy models objects
>>> AwesomeBlogEntryPage.objects.all()
[<AwesomeBlogEntryPage: blog>]
```

Underneath, there is one database table for both models (they are told apart by the content_type field)
