### PR TITLE
Provide welcome page for new users

### DIFF
--- a/wagtail/wagtailadmin/templates/wagtailadmin/account/account.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/account/account.html
@@ -51,7 +51,15 @@
                     </small>
                 </li>
             {% endif %}
+            <li class="row row-flush">
+                <div class="col6">
+                    <a href="{% url 'wagtailadmin_account_user_preferences' %}" class="button button-primary">{% trans "User preferences" %}</a>
+                </div>
 
+                <small class="col6">
+                    {% trans "Change your preferences when accessing the wagtail admin." %}
+                </small>
+            </li>
         </ul>
     </div>
 {% endblock %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/account/user_preferences.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/account/user_preferences.html
@@ -1,0 +1,20 @@
+{% extends "wagtailadmin/base.html" %}
+{% load i18n %}
+
+{% block titletag %}{% trans "User Preferences" %}{% endblock %}
+{% block content %}
+    {% trans "User Preferences" as prefs_str %}
+    {% include "wagtailadmin/shared/header.html" with title=prefs_str %}
+
+    <div class="nice-padding">
+        <form action="{% url 'wagtailadmin_account_user_preferences' %}" method="POST">
+            {% csrf_token %}
+            <ul class="fields">
+                {% for field in form %}
+                    {% include "wagtailadmin/shared/field_as_li.html" with field=field %}
+                {% endfor %}
+                <li class="submit"><input type="submit" value="{% trans 'Update' %}" /></li>
+            </ul>
+        </form>
+    </div>
+{% endblock %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/home.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/home.html
@@ -39,6 +39,12 @@
             </ul>
         </div>
         <hr>
+        <ul class="multiple">
+            <li>
+                <header class="">blub</header>
+            </li>
+        </ul>
+        <hr>
     {% endif %}
 
     {% if panels %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/home.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/home.html
@@ -1,5 +1,6 @@
 {% extends "wagtailadmin/base.html" %}
-{% load gravatar staticfiles i18n %}
+{% load gravatar staticfiles i18n wagtailadmin_tags %}
+
 {% block titletag %}{% trans "Dashboard" %}{% endblock %}
 {% block bodyclass %}homepage{% endblock %}
 
@@ -25,13 +26,15 @@
     {% if user.userprofile.show_welcome_screen %}
         {% url 'wagtailadmin_account_change_password' as user_change_password_url %}
         {% url 'wagtailadmin_account_user_preferences' as user_preferences_url %}
+        {% wagtail_editor_docs_url as docs_url %}
+
         <div class="nice-padding">
             <h1>{% blocktrans with name=user.first_name|default:"there" %}Hi {{ name }}, looks as if you are new here!{% endblocktrans %}</h1>
             <p>{% trans "Check out the following first steps or directly get started with the page explorer on the left hand side:" %}</p>
             <ul>
                 <li>{% blocktrans with account_url="https://gravatar.com/emails/" %}<b>First visit?</b> You may want to <a href="{{ account_url }}">add a profile image using gravatar</a> or <a href="{{ user_change_password_url }}">set your own password</a>.{% endblocktrans %}</li>
                 <li>{% trans "<b>Just looking around?</b> Use the dashboard below to start browsing existing content like pages, images and documents." %}</li>
-                <li>{% blocktrans with docs_url="http://docs.wagtail.io/en/stable/editor_manual/index.html" %}<b>Hands on?</b> We recommend the <a href="{{ docs_url }}" target="_blank">editors manual</a> full of helpful instructions to quickly get started.{% endblocktrans %}</li>
+                <li>{% blocktrans %}<b>Hands on?</b> We recommend the <a href="{{ docs_url }}" target="_blank">editors manual</a> full of helpful instructions to quickly get started.{% endblocktrans %}</li>
                 <li>{% blocktrans %}<b>Already familiar with wagtail?</b> <a href="{{ user_preferences_url }}">Change your preferences</a> to disable this section.{% endblocktrans %}</li>
             </ul>
         </div>

--- a/wagtail/wagtailadmin/templates/wagtailadmin/home.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/home.html
@@ -22,11 +22,29 @@
         </div>
     </header>
 
+    {% if user.userprofile.show_welcome_screen %}
+        {% url 'wagtailadmin_account_change_password' as user_change_password_url %}
+        {% url 'wagtailadmin_account_user_preferences' as user_preferences_url %}
+        <div class="nice-padding">
+            <h1>{% blocktrans with name=user.first_name|default:"there" %}Hi {{ name }}, looks as if you are new here!{% endblocktrans %}</h1>
+            <p>{% trans "Check out the following first steps or directly get started with the page explorer on the left hand side:" %}</p>
+            <ul>
+                <li>{% blocktrans with account_url="https://gravatar.com/emails/" %}<b>First visit?</b> You may want to <a href="{{ account_url }}">add a profile image using gravatar</a> or <a href="{{ user_change_password_url }}">set your own password</a>.{% endblocktrans %}</li>
+                <li>{% trans "<b>Just looking around?</b> Use the dashboard below to start browsing existing content like pages, images and documents." %}</li>
+                <li>{% blocktrans with docs_url="http://docs.wagtail.io/en/stable/editor_manual/index.html" %}<b>Hands on?</b> We recommend the <a href="{{ docs_url }}" target="_blank">editors manual</a> full of helpful instructions to quickly get started.{% endblocktrans %}</li>
+                <li>{% blocktrans %}<b>Already familiar with wagtail?</b> <a href="{{ user_preferences_url }}">Change your preferences</a> to disable this section.{% endblocktrans %}</li>
+            </ul>
+        </div>
+        <hr>
+    {% endif %}
+
     {% if panels %}
         {% for panel in panels %}
             {{ panel.render }}
         {% endfor %}
     {% else %}
-        <p>{% trans "This is your dashboard on which helpful information about content you've created will be displayed." %}</p>
+        <div class="nice-padding">
+            <p>{% trans "This is your dashboard on which helpful information about content you've created will be displayed." %}</p>
+        </div>
     {% endif %}
 {% endblock %}

--- a/wagtail/wagtailadmin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/wagtailadmin/templatetags/wagtailadmin_tags.py
@@ -16,6 +16,7 @@ from wagtail.utils.pagination import DEFAULT_PAGE_KEY, replace_page_in_query
 from wagtail.wagtailadmin.menu import admin_menu
 from wagtail.wagtailadmin.navigation import get_explorable_root_page
 from wagtail.wagtailadmin.search import admin_search_areas
+from wagtail.wagtailadmin.utils import get_wagtail_version
 from wagtail.wagtailcore import hooks
 from wagtail.wagtailcore.models import (
     CollectionViewRestriction,
@@ -380,3 +381,12 @@ def replace_page_param(query, page_number, page_key='p'):
 @register.filter('abs')
 def _abs(val):
     return abs(val)
+
+@register.assignment_tag
+def wagtail_editor_docs_url():
+    """
+    Usage: {% wagtail_editor_docs_url as docs_url %}
+    Sets the variable 'docs_url' to the editors documentation index page depending on the current wagtail version.
+    """
+    version, patch_version = get_wagtail_version()
+    return 'http://docs.wagtail.io/en/v' + patch_version + '/editor_manual/index.html'

--- a/wagtail/wagtailadmin/tests/test_account_management.py
+++ b/wagtail/wagtailadmin/tests/test_account_management.py
@@ -342,6 +342,29 @@ class TestAccountSection(TestCase, WagtailTestUtils):
         }
         response = self.client.post(reverse('wagtailadmin_account_language_preferences'), post_data)
 
+    def test_user_preferences_view(self):
+        """
+        This tests that the user preferences view responds with the
+        user preferences page
+        """
+        # Get user preferences page
+        response = self.client.get(reverse('wagtailadmin_account_user_preferences'))
+
+        # Check that the user recieved a user preferences page
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'wagtailadmin/account/user_preferences.html')
+
+    def test_user_preferences_view_post(self):
+        """
+        This posts to the user preferences view and checks that the
+        user's profile is updated
+        """
+        # Post new values to the user preferences page
+        post_data = {
+            'show_welcome_screen': 'false',
+        }
+        response = self.client.post(reverse('wagtailadmin_account_user_preferences'), post_data)
+
         # Check that the user was redirected to the account page
         self.assertRedirects(response, reverse('wagtailadmin_account'))
 
@@ -361,6 +384,10 @@ class TestAccountSection(TestCase, WagtailTestUtils):
     def test_not_show_options_if_only_one_language_is_permitted(self):
         response = self.client.post(reverse('wagtailadmin_account'))
         self.assertNotContains(response, 'Language Preferences')
+        profile = UserProfile.get_for_user(get_user_model().objects.get(username='test'))
+
+        # Check that the user preferences are as submitted
+        self.assertFalse(profile.show_welcome_screen)
 
 
 class TestAccountManagementForNonModerator(TestCase, WagtailTestUtils):

--- a/wagtail/wagtailadmin/tests/tests.py
+++ b/wagtail/wagtailadmin/tests/tests.py
@@ -8,14 +8,15 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group, Permission
 from django.core import mail
 from django.core.urlresolvers import reverse, reverse_lazy
-from django.test import TestCase, override_settings
+from django.template import Context, Template
+from django.test import SimpleTestCase, TestCase, override_settings
 from django.utils.translation import ugettext_lazy as _
 from taggit.models import Tag
 
 from wagtail.tests.utils import WagtailTestUtils
 from wagtail.wagtailadmin.menu import MenuItem
 from wagtail.wagtailadmin.site_summary import PagesSummaryItem
-from wagtail.wagtailadmin.utils import send_mail, user_has_any_page_permission
+from wagtail.wagtailadmin.utils import get_wagtail_version, send_mail, user_has_any_page_permission
 from wagtail.wagtailcore.models import Page, Site
 
 
@@ -314,3 +315,21 @@ class Test404(TestCase, WagtailTestUtils):
 
         # Check that the user was redirected to the login page and that next was set correctly
         self.assertRedirects(response, reverse('wagtailadmin_login') + '?next=/admin/sdfgdsfgdsfgsdf')
+
+class TestEditorDocsUrlTag(SimpleTestCase):
+    def setUp(self):
+        self.template = Template('{% load wagtailadmin_tags %}{% wagtail_editor_docs_url as docs_url %}{{ docs_url }}')
+
+    def test_docs_baseurl_is_in_url(self):
+        rendered = self.template.render(Context({}))
+        self.assertIn('http://docs.wagtail.io/', rendered)
+
+    def test_current_version_is_in_url(self):
+        rendered = self.template.render(Context({}))
+        version, patch_version = get_wagtail_version()
+        self.assertIn('/v' + patch_version + '/', rendered)
+
+    def test_editor_manual_is_in_url(self):
+        rendered = self.template.render(Context({}))
+        self.assertIn('/editor_manual/', rendered)
+

--- a/wagtail/wagtailadmin/urls/__init__.py
+++ b/wagtail/wagtailadmin/urls/__init__.py
@@ -55,6 +55,7 @@ urlpatterns = [
         account.language_preferences,
         name='wagtailadmin_account_language_preferences'
     ),
+    url(r'^account/user_preferences/$', account.user_preferences, name='wagtailadmin_account_user_preferences'),
     url(r'^logout/$', account.logout, name='wagtailadmin_logout'),
 ]
 

--- a/wagtail/wagtailadmin/utils.py
+++ b/wagtail/wagtailadmin/utils.py
@@ -4,6 +4,8 @@ from __future__ import absolute_import, unicode_literals
 import logging
 from functools import wraps
 
+import re
+
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
@@ -17,6 +19,7 @@ from django.utils.translation import override, ugettext_lazy
 from modelcluster.fields import ParentalKey
 from taggit.models import Tag
 
+from wagtail.wagtailcore import __version__
 from wagtail.wagtailcore.models import GroupPagePermission, Page, PageRevision
 from wagtail.wagtailusers.models import UserProfile
 
@@ -297,3 +300,14 @@ def user_has_any_page_permission(user):
 
     # No luck! This user can not do anything with pages.
     return False
+
+
+def get_wagtail_version():
+    """
+    Returns the current wagtail version in two variants:
+    1. Full version
+    2. Patch version, without pre-release suffixes
+    """
+    regex = re.compile(r'^(\d+\.\d+\.?\d?)')
+
+    return __version__, regex.search(__version__).group(1)

--- a/wagtail/wagtailadmin/views/account.py
+++ b/wagtail/wagtailadmin/views/account.py
@@ -19,6 +19,7 @@ from wagtail.wagtailadmin import forms
 from wagtail.wagtailadmin.utils import get_available_admin_languages
 from wagtail.wagtailcore.models import UserPagePermissionsProxy
 from wagtail.wagtailusers.forms import NotificationPreferencesForm, PreferredLanguageForm
+from wagtail.wagtailusers.forms import NotificationPreferencesForm, UserPreferencesForm
 from wagtail.wagtailusers.models import UserProfile
 
 
@@ -125,6 +126,20 @@ def language_preferences(request):
         form = PreferredLanguageForm(instance=UserProfile.get_for_user(request.user))
 
     return render(request, 'wagtailadmin/account/language_preferences.html', {
+
+def user_preferences(request):
+
+    if request.POST:
+        form = UserPreferencesForm(request.POST, instance=UserProfile.get_for_user(request.user))
+
+        if form.is_valid():
+            form.save()
+            messages.success(request, _("Your preferences have been updated successfully!"))
+            return redirect('wagtailadmin_account')
+    else:
+        form = UserPreferencesForm(instance=UserProfile.get_for_user(request.user))
+
+    return render(request, 'wagtailadmin/account/user_preferences.html', {
         'form': form,
     })
 

--- a/wagtail/wagtailusers/forms.py
+++ b/wagtail/wagtailusers/forms.py
@@ -387,3 +387,8 @@ class PreferredLanguageForm(forms.ModelForm):
     class Meta:
         model = UserProfile
         fields = ("preferred_language",)
+
+class UserPreferencesForm(forms.ModelForm):
+    class Meta:
+        model = UserProfile
+        fields = ("show_welcome_screen",)

--- a/wagtail/wagtailusers/migrations/0005_userprofile_show_welcome_screen.py
+++ b/wagtail/wagtailusers/migrations/0005_userprofile_show_welcome_screen.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('wagtailusers', '0004_capitalizeverbose'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='userprofile',
+            name='show_welcome_screen',
+            field=models.BooleanField(help_text='Show welcome screen on every login', default=True, verbose_name='Welcome screen'),
+        ),
+    ]

--- a/wagtail/wagtailusers/models.py
+++ b/wagtail/wagtailusers/models.py
@@ -35,6 +35,11 @@ class UserProfile(models.Model):
         max_length=10,
         help_text=_("Select language for the admin"),
         default=''
+
+    show_welcome_screen = models.BooleanField(
+        verbose_name=_('Welcome screen'),
+        default=True,
+        help_text=_("Show welcome screen on every login")
     )
 
     @classmethod


### PR DESCRIPTION
This is a first step to resolve #575 and help new users/editors to get started.
1. Provides first steps on the home screen until the user dismisses this section
2. Adds user preferences to the account pages

The solution doesn't provide wagtail internal avatar support as suggested by @davecranwell and may not be the expected eyecatcher, but follows the wagtail styleguide.

Any feedback is greatly appreciated.
