### PR TITLE
Moved ratio calculation to Embed model

### DIFF
--- a/wagtail/wagtailembeds/format.py
+++ b/wagtail/wagtailembeds/format.py
@@ -1,4 +1,3 @@
-from __future__ import division  # Use true division
 from __future__ import absolute_import, unicode_literals
 
 from django.template.loader import render_to_string
@@ -11,17 +10,9 @@ def embed_to_frontend_html(url):
     try:
         embed = embeds.get_embed(url)
 
-        # Work out ratio
-        if embed.width and embed.height:
-            ratio = str(embed.height / embed.width * 100) + "%"
-        else:
-            ratio = None
-
         # Render template
         return render_to_string('wagtailembeds/embed_frontend.html', {
             'embed': embed,
-            'ratio': ratio,
-            'is_responsive': ratio is not None,
         })
     except EmbedException:
         # silently ignore failed embeds, rather than letting them crash the page

--- a/wagtail/wagtailembeds/models.py
+++ b/wagtail/wagtailembeds/models.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, division, unicode_literals
 
 from django.db import models
 from django.utils.encoding import python_2_unicode_compatible
@@ -39,6 +39,21 @@ class Embed(models.Model):
     class Meta:
         unique_together = ('url', 'max_width')
         verbose_name = _('embed')
+
+    @property
+    def ratio(self):
+        if self.width and self.height:
+            return self.height / self.width
+
+    @property
+    def ratio_css(self):
+        ratio = self.ratio
+        if ratio:
+            return str(ratio * 100) + "%"
+
+    @property
+    def is_responsive(self):
+        return self.ratio is not None
 
     def __str__(self):
         return self.url

--- a/wagtail/wagtailembeds/templates/wagtailembeds/embed_frontend.html
+++ b/wagtail/wagtailembeds/templates/wagtailembeds/embed_frontend.html
@@ -1,3 +1,3 @@
-<div{% if is_responsive %} style="padding-bottom: {{ ratio }};" class="responsive-object"{% endif %}>
+<div{% if embed.is_responsive %} style="padding-bottom: {{ embed.ratio_css }};" class="responsive-object"{% endif %}>
     {{ embed.html|safe }}
 </div>

--- a/wagtail/wagtailembeds/tests.py
+++ b/wagtail/wagtailembeds/tests.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import, division, unicode_literals
 
 import unittest
 
@@ -94,6 +94,11 @@ class TestEmbeds(TestCase):
         self.assertEqual(embed.title, "Test: www.test.com/1234")
         self.assertEqual(embed.type, 'video')
         self.assertEqual(embed.width, 400)
+
+        # Check ratio calculations
+        self.assertEqual(embed.ratio, 480 / 400)
+        self.assertEqual(embed.ratio_css, '120.0%')
+        self.assertTrue(embed.is_responsive)
 
         # Check that there has only been one hit to the backend
         self.assertEqual(self.hit_count, 1)


### PR DESCRIPTION
This allows the calculation to be used anywhere where we have an embed.

For example:

``` html+django
<div style="padding-bottom: {{ embed.ratio_css|default:0 }};" class="responsive-object">
```
