### PR TITLE
Make wagtailsearch language aware

### DIFF
--- a/wagtail/wagtailsearch/backends/__init__.py
+++ b/wagtail/wagtailsearch/backends/__init__.py
@@ -56,7 +56,7 @@ def get_search_backend(backend=None, **kwargs):
                 backend = key
                 break
 
-    # if none found above, then fall back to 'default' 
+    # if none found above, then fall back to 'default'
     if backend is None:
         backend = 'default'
 

--- a/wagtail/wagtailsearch/backends/__init__.py
+++ b/wagtail/wagtailsearch/backends/__init__.py
@@ -92,7 +92,7 @@ def get_language_aware_search_backend(default_backend='default'):
     cur_language = translation.get_language()
     if hasattr(settings, 'WAGTAILSEARCH_BACKENDS'):
         for backend, params in settings.WAGTAILSEARCH_BACKENDS.items():
-            if getattr(params, 'LANGUAGE_CODE', None) == cur_language:
+            if params.get('LANGUAGE_CODE', None) == cur_language:
                 return get_search_backend(backend)
     return get_search_backend(default_backend)
 

--- a/wagtail/wagtailsearch/backends/__init__.py
+++ b/wagtail/wagtailsearch/backends/__init__.py
@@ -5,7 +5,7 @@
 import sys
 from importlib import import_module
 
-from django.utils import six
+from django.utils import six, translation
 from django.utils.module_loading import import_string
 from django.core.exceptions import ImproperlyConfigured
 from django.conf import settings
@@ -86,3 +86,14 @@ def get_search_backends(with_auto_update=False):
             yield get_search_backend(backend)
     else:
         yield get_search_backend('default')
+
+
+def get_language_aware_search_backend():
+    cur_language = translation.get_language()
+    if hasattr(settings, 'WAGTAILSEARCH_BACKENDS'):
+        for backend, params in settings.WAGTAILSEARCH_BACKENDS.items():
+            if getattr(params, 'LANGUAGE_CODE', None) == cur_language:
+                return get_search_backend(backend)
+    return get_search_backend('default')
+
+    

--- a/wagtail/wagtailsearch/backends/__init__.py
+++ b/wagtail/wagtailsearch/backends/__init__.py
@@ -88,12 +88,12 @@ def get_search_backends(with_auto_update=False):
         yield get_search_backend('default')
 
 
-def get_language_aware_search_backend():
+def get_language_aware_search_backend(default_backend='default'):
     cur_language = translation.get_language()
     if hasattr(settings, 'WAGTAILSEARCH_BACKENDS'):
         for backend, params in settings.WAGTAILSEARCH_BACKENDS.items():
             if getattr(params, 'LANGUAGE_CODE', None) == cur_language:
                 return get_search_backend(backend)
-    return get_search_backend('default')
+    return get_search_backend(default_backend)
 
     

--- a/wagtail/wagtailsearch/backends/__init__.py
+++ b/wagtail/wagtailsearch/backends/__init__.py
@@ -95,5 +95,3 @@ def get_language_aware_search_backend(default_backend='default'):
             if params.get('LANGUAGE_CODE', None) == cur_language:
                 return get_search_backend(backend)
     return get_search_backend(default_backend)
-
-    

--- a/wagtail/wagtailsearch/backends/elasticsearch.py
+++ b/wagtail/wagtailsearch/backends/elasticsearch.py
@@ -664,7 +664,7 @@ class ElasticSearch(BaseSearch):
         self.index_name = params.pop('INDEX', 'wagtail')
         self.timeout = params.pop('TIMEOUT', 10)
         self.language_code = params.pop(
-            'LANGUAGE_CODE', getattr(settings, 'LANGUAGE_CODE', 'en')
+            'LANGUAGE_CODE', getattr(settings, 'LANGUAGE_CODE', 'en')(
         
         if params.pop('ATOMIC_REBUILD', False):
             self.rebuilder_class = self.atomic_rebuilder_class

--- a/wagtail/wagtailsearch/backends/elasticsearch.py
+++ b/wagtail/wagtailsearch/backends/elasticsearch.py
@@ -7,6 +7,7 @@ from django.utils.six.moves.urllib.parse import urlparse
 from elasticsearch import Elasticsearch, NotFoundError
 from elasticsearch.helpers import bulk
 
+from django.conf import settings
 from django.db import models
 from django.utils.crypto import get_random_string
 
@@ -662,7 +663,9 @@ class ElasticSearch(BaseSearch):
         self.hosts = params.pop('HOSTS', None)
         self.index_name = params.pop('INDEX', 'wagtail')
         self.timeout = params.pop('TIMEOUT', 10)
-
+        self.language_code = params.pop(
+            'LANGUAGE_CODE', getattr(settings, 'LANGUAGE_CODE', 'en')
+        
         if params.pop('ATOMIC_REBUILD', False):
             self.rebuilder_class = self.atomic_rebuilder_class
         else:

--- a/wagtail/wagtailsearch/backends/elasticsearch.py
+++ b/wagtail/wagtailsearch/backends/elasticsearch.py
@@ -665,7 +665,7 @@ class ElasticSearch(BaseSearch):
         self.timeout = params.pop('TIMEOUT', 10)
         self.language_code = params.pop(
             'LANGUAGE_CODE', getattr(settings, 'LANGUAGE_CODE', 'en'))
-        
+
         if params.pop('ATOMIC_REBUILD', False):
             self.rebuilder_class = self.atomic_rebuilder_class
         else:

--- a/wagtail/wagtailsearch/backends/elasticsearch.py
+++ b/wagtail/wagtailsearch/backends/elasticsearch.py
@@ -664,7 +664,7 @@ class ElasticSearch(BaseSearch):
         self.index_name = params.pop('INDEX', 'wagtail')
         self.timeout = params.pop('TIMEOUT', 10)
         self.language_code = params.pop(
-            'LANGUAGE_CODE', getattr(settings, 'LANGUAGE_CODE', 'en')(
+            'LANGUAGE_CODE', getattr(settings, 'LANGUAGE_CODE', 'en'))
         
         if params.pop('ATOMIC_REBUILD', False):
             self.rebuilder_class = self.atomic_rebuilder_class

--- a/wagtail/wagtailsearch/management/commands/update_index.py
+++ b/wagtail/wagtailsearch/management/commands/update_index.py
@@ -42,7 +42,7 @@ class Command(BaseCommand):
         index = rebuilder.start()
 
         for model, queryset in object_list:
-            self.stdout.write(backend_name + ": Indexing model '%s.%s'" % (
+            self.stdout.write(backend_name + u": Indexing model '%s.%s'" % (
                 model._meta.app_label,
                 model.__name__,
             ))
@@ -56,7 +56,7 @@ class Command(BaseCommand):
                 index.add_items(model, chunk)
                 count += len(chunk)
 
-            self.stdout.write("Indexed %d %s" % (
+            self.stdout.write(u"Indexed %d %s" % (
                 count, model._meta.verbose_name_plural))
             self.print_newline()
 

--- a/wagtail/wagtailsearch/management/commands/update_index.py
+++ b/wagtail/wagtailsearch/management/commands/update_index.py
@@ -23,7 +23,7 @@ class Command(BaseCommand):
 
         # Get backend
         backend = get_search_backend(backend_name)
-        
+
         # Activate backend language
         cur_language = translation.get_language()
         backend_language = getattr(backend, 'language_code', None)
@@ -63,11 +63,11 @@ class Command(BaseCommand):
         # Finish rebuild
         self.stdout.write(backend_name + ": Finishing rebuild")
         rebuilder.finish()
-        
+
         # Return to Original Thread Language
         if backend_language is not None:
             translation.activate(cur_language)
-            
+
     option_list = BaseCommand.option_list + (
         make_option(
             '--backend',

--- a/wagtail/wagtailsearch/management/commands/update_index.py
+++ b/wagtail/wagtailsearch/management/commands/update_index.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from optparse import make_option
 
 from django.core.management.base import BaseCommand
@@ -42,7 +44,7 @@ class Command(BaseCommand):
         index = rebuilder.start()
 
         for model, queryset in object_list:
-            self.stdout.write(backend_name + u": Indexing model '%s.%s'" % (
+            self.stdout.write(backend_name + ": Indexing model '%s.%s'" % (
                 model._meta.app_label,
                 model.__name__,
             ))
@@ -56,7 +58,7 @@ class Command(BaseCommand):
                 index.add_items(model, chunk)
                 count += len(chunk)
 
-            self.stdout.write(u"Indexed %d %s" % (
+            self.stdout.write("Indexed %d %s" % (
                 count, model._meta.verbose_name_plural))
             self.print_newline()
 

--- a/wagtail/wagtailsearch/queryset.py
+++ b/wagtail/wagtailsearch/queryset.py
@@ -1,12 +1,12 @@
-from wagtail.wagtailsearch.backends import get_language_aware_search_backend
+from wagtail.wagtailsearch.backends import get_search_backend
 
 
 class SearchableQuerySetMixin(object):
     def search(self, query_string, fields=None,
-               operator=None, order_by_relevance=True, backend='default'):
+               operator=None, order_by_relevance=True, backend=None):
         """
         This runs a search query on all the items in the QuerySet
         """
-        search_backend = get_language_aware_search_backend(backend)
+        search_backend = get_search_backend(backend)
         return search_backend.search(query_string, self, fields=fields,
                                      operator=operator, order_by_relevance=order_by_relevance)

--- a/wagtail/wagtailsearch/queryset.py
+++ b/wagtail/wagtailsearch/queryset.py
@@ -1,4 +1,5 @@
-from wagtail.wagtailsearch.backends import get_search_backend
+from django.conf import settings
+from wagtail.wagtailsearch.backends import get_language_aware_search_backend
 
 
 class SearchableQuerySetMixin(object):
@@ -7,6 +8,6 @@ class SearchableQuerySetMixin(object):
         """
         This runs a search query on all the items in the QuerySet
         """
-        search_backend = get_search_backend(backend)
+        search_backend = get_language_aware_search_backend(backend)
         return search_backend.search(query_string, self, fields=fields,
                                      operator=operator, order_by_relevance=order_by_relevance)

--- a/wagtail/wagtailsearch/queryset.py
+++ b/wagtail/wagtailsearch/queryset.py
@@ -1,4 +1,3 @@
-from django.conf import settings
 from wagtail.wagtailsearch.backends import get_language_aware_search_backend
 
 

--- a/wagtail/wagtailsearch/signal_handlers.py
+++ b/wagtail/wagtailsearch/signal_handlers.py
@@ -1,3 +1,4 @@
+from django.utils import translation
 from django.db.models.signals import post_save, post_delete
 
 from wagtail.wagtailsearch.index import get_indexed_models
@@ -20,8 +21,13 @@ def post_save_signal_handler(instance, **kwargs):
     indexed_instance = get_indexed_instance(instance)
 
     if indexed_instance:
+        cur_language = translation.get_language()
         for backend in get_search_backends(with_auto_update=True):
+            backend_language = getattr(backend, 'language_code', None)
+            if backend_language is not None:
+                translation.activate(backend_language)
             backend.add(indexed_instance)
+        translation.activate(cur_language)
 
 
 def post_delete_signal_handler(instance, **kwargs):


### PR DESCRIPTION
This is based on issue #1177 

I added changes to wagtailsearch app to make it language aware. The changes are based on having multiple search indexes, one for each language.

``` python
WAGTAILSEARCH_BACKENDS = {
    'default': {
        'BACKEND': 'wagtail.wagtailsearch.backends.elasticsearch.ElasticSearch',
        'URLS': ['http://localhost:9200'],
        'INDEX': 'wagtail',
        'TIMEOUT': 5,
    },
    'en': {
        'BACKEND': 'wagtail.wagtailsearch.backends.elasticsearch.ElasticSearch',
        'URLS': ['http://localhost:9200'],
        'INDEX': 'wagtail_en',
        'TIMEOUT': 5,
        'LANGUAGE_CODE': 'en'
    },
    'ar': {
        'BACKEND': 'wagtail.wagtailsearch.backends.elasticsearch.ElasticSearch',
        'URLS': ['http://localhost:9200'],
        'INDEX': 'wagtail_ar',
        'TIMEOUT': 5,
        'LANGUAGE_CODE': 'ar'
    },
}
```

there is no need to make any changes in the way we use search() method.

``` python
PageModel.objects.search('search query')
```

search method is language aware, It will try to use the backend with LANGUAGE_CODE equals to current language, and it falls back to 'default' language if none was found.

also update_index will update each index with its correct language

and post_save signal also updated to be language aware.

**NOTE: these changes are applied to ElasticSearch backend only. It must not affect Db Backend.**

closes #1177 
