### PR TITLE
Spam detection for FormBuilder submissions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ install_requires = [
     "html5lib>=0.999,<1",
     "Unidecode>=0.04.14",
     "Willow>=0.3b4,<0.4",
+    "antispam>=0.0.10,<0.1.0",
 ]
 
 # Testing dependencies

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,8 @@ exclude = wagtail/project_template/*
 max-line-length = 120
 
 [testenv]
-commands=coverage run runtests.py --elasticsearch
+install_command = pip install -e ".[testing]" -U {opts} {packages}
+commands = coverage run runtests.py --elasticsearch
 
 basepython =
     py27: python2.7
@@ -19,23 +20,9 @@ basepython =
     py35: python3.5
 
 deps =
-    django-modelcluster>=1.1b1
-    django-taggit>=0.17.5
-    django-treebeard>=3.0,<5.0
     django-sendfile==0.3.6
-    djangorestframework==3.1.3
-    Pillow>=2.3.0
-    beautifulsoup4>=4.3.2
-    html5lib>=0.999,<1
-    Unidecode>=0.04.14
-    elasticsearch==1.1.0
-    mock==1.0.1
-    python-dateutil==2.2
-    pytz==2014.7
     Embedly
-    Willow>=0.3b4,<0.4
     jinja2==2.8
-    coverage
 
     dj18: Django>=1.8.1,<1.9
     dj19: Django>=1.9,<1.10

--- a/wagtail/wagtailforms/migrations/0004_formsubmission_is_spam.py
+++ b/wagtail/wagtailforms/migrations/0004_formsubmission_is_spam.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('wagtailforms', '0003_capitalizeverbose'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='formsubmission',
+            name='is_spam',
+            field=models.BooleanField(default=False, verbose_name='is spam'),
+            preserve_default=False,
+        ),
+    ]

--- a/wagtail/wagtailforms/models.py
+++ b/wagtail/wagtailforms/models.py
@@ -18,7 +18,7 @@ from wagtail.wagtailadmin.utils import send_mail
 from wagtail.wagtailcore.models import Orderable, Page, UserPagePermissionsProxy, get_page_models
 
 from .forms import FormBuilder
-from .utils import is_spam, train_spam_recognition
+from .utils import AntiSpamDetector, get_message_from_dict
 
 FORM_FIELD_CHOICES = (
     ('singleline', _('Single line text')),
@@ -159,17 +159,19 @@ class AbstractForm(Page):
         return form_class(*args, **form_params)
 
     def process_form_submission(self, form):
-        # Check if submission data tends to be spam
-        spam = is_spam(form.cleaned_data)
+        # Check if submission data is presumably spam
+        spam_detector = AntiSpamDetector()
+        message = get_message_from_dict(form.cleaned_data)
+        is_spam = spam_detector.is_spam(message)
 
         FormSubmission.objects.create(
             form_data=json.dumps(form.cleaned_data, cls=DjangoJSONEncoder),
             page=self,
-            is_spam=spam,
+            is_spam=is_spam,
         )
 
-        # Help train the spam detector model on every submission
-        train_spam_recognition(form.cleaned_data, spam)
+        # Help train the spam detector on every submission
+        spam_detector.train(message, is_spam)
 
     def serve(self, request):
         if request.method == 'POST':

--- a/wagtail/wagtailforms/models.py
+++ b/wagtail/wagtailforms/models.py
@@ -18,6 +18,7 @@ from wagtail.wagtailadmin.utils import send_mail
 from wagtail.wagtailcore.models import Orderable, Page, UserPagePermissionsProxy, get_page_models
 
 from .forms import FormBuilder
+from .utils import is_spam
 
 FORM_FIELD_CHOICES = (
     ('singleline', _('Single line text')),
@@ -161,6 +162,7 @@ class AbstractForm(Page):
         FormSubmission.objects.create(
             form_data=json.dumps(form.cleaned_data, cls=DjangoJSONEncoder),
             page=self,
+            is_spam=is_spam(form.cleaned_data),
         )
 
     def serve(self, request):

--- a/wagtail/wagtailforms/models.py
+++ b/wagtail/wagtailforms/models.py
@@ -40,11 +40,10 @@ HTML_EXTENSION_RE = re.compile(r"(.*)\.html")
 @python_2_unicode_compatible
 class FormSubmission(models.Model):
     """Data for a Form submission."""
-
     form_data = models.TextField()
     page = models.ForeignKey(Page, on_delete=models.CASCADE)
-
     submit_time = models.DateTimeField(verbose_name=_('submit time'), auto_now_add=True)
+    is_spam = models.BooleanField(verbose_name=_('is spam'))
 
     def get_data(self):
         return json.loads(self.form_data)

--- a/wagtail/wagtailforms/templates/wagtailforms/confirm_switch_spam.html
+++ b/wagtail/wagtailforms/templates/wagtailforms/confirm_switch_spam.html
@@ -1,0 +1,38 @@
+{% extends "wagtailadmin/base.html" %}
+
+{% load i18n %}
+
+{% block titletag %}
+    {% if submission.is_spam %}
+        {% trans "Mark form submission as not spam" %}
+    {% else %}
+        {% trans "Mark form submission as spam" %}
+    {% endif %}
+{% endblock %}
+
+{% block bodyclass %}menu-explorer{% endblock %}
+
+{% block content %}
+    {% if submission.is_spam %}
+        {% trans "Mark form submission as not spam" as title_str %}
+
+    {% else %}
+        {% trans "Mark form submission as spam" as title_str %}
+    {% endif %}
+
+    {% include "wagtailadmin/shared/header.html" with title=title_str subtitle=page.title icon=submission.is_spam|yesno:"unlocked,locked" %}
+
+    <div class="nice-padding">
+        <p>
+            {% if submission.is_spam %}
+                {% trans 'Are you sure you want to mark this form submission as not spam?' %}
+            {% else %}
+                {% trans 'Are you sure you want to mark this form submission as spam?' %}
+            {% endif %}
+        </p>
+        <form action="{% url 'wagtailforms:switch_spam' page.id submission.id %}" method="POST">
+            {% csrf_token %}
+            <input type="submit" value="{% if submission.is_spam %}{% trans 'Mark as not spam' %}{% else %}{% trans 'Mark as spam' %}{% endif %}" class="serious">
+        </form>
+    </div>
+{% endblock %}

--- a/wagtail/wagtailforms/templates/wagtailforms/list_submissions.html
+++ b/wagtail/wagtailforms/templates/wagtailforms/list_submissions.html
@@ -7,6 +7,7 @@
     <thead>
         <tr>
             <th>{% trans "Submission Date" %}</th>
+            <th>{% trans "Spam" %}</th>
             {% for heading in data_headings %}
                 <th>{{ heading }}</th>
             {% endfor %}

--- a/wagtail/wagtailforms/templates/wagtailforms/list_submissions.html
+++ b/wagtail/wagtailforms/templates/wagtailforms/list_submissions.html
@@ -1,34 +1,43 @@
 {% load i18n %}
+
 <div class="overflow">
-<table class="listing">
-    <col />
-    <col />
-    <col />
-    <thead>
-        <tr>
-            <th>{% trans "Submission Date" %}</th>
-            <th>{% trans "Spam" %}</th>
-            {% for heading in data_headings %}
-                <th>{{ heading }}</th>
-            {% endfor %}
-            <th>{% trans "Actions" %}</th>
-        </tr>
-    </thead>
-    <tbody>
-        {% for row in data_rows %}
+    <table class="listing">
+        <col />
+        <col />
+        <col />
+        <thead>
             <tr>
-                {% for cell in row.fields %}
-                    <td>
-                        {{ cell }}
-                    </td>
+                <th>{% trans "Submission Date" %}</th>
+                <th>{% trans "Spam" %}</th>
+                {% for heading in data_headings %}
+                    <th>{{ heading }}</th>
                 {% endfor %}
-                <td>
-                <a class="button button-small button-secondary" href="
-                    {% url 'wagtailforms:delete_submission' form_page.id row.model_id %}">
-                    delete</a>
-                </td>
+                <th>{% trans "Actions" %}</th>
             </tr>
-        {% endfor %}
-    </tbody>
-</table>
+        </thead>
+        <tbody>
+            {% for row in data_rows %}
+                <tr>
+                    {% for cell in row.fields %}
+                        <td>
+                            {{ cell }}
+                        </td>
+                    {% endfor %}
+                    <td>
+                        <ul>
+                            <li><a class="button button-secondary button-small" href="{% url 'wagtailforms:delete_submission' form_page.id row.model_id %}" title="{% trans "Delete this submission" %}">{% trans "Delete" %}</a></li>
+
+                            {% if row.fields.1 %}
+                                {% trans "Not spam" as link_str %}
+                            {% else %}
+                                {% trans "Spam" as link_str %}
+                            {% endif %}
+
+                            <li><a class="button button-secondary button-small" href="{% url 'wagtailforms:switch_spam' form_page.id row.model_id %}" title="{{ link_str }}">{{ link_str }}</a></li>
+                        </ul>
+                    </td>
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
 </div>

--- a/wagtail/wagtailforms/urls.py
+++ b/wagtail/wagtailforms/urls.py
@@ -5,5 +5,6 @@ from wagtail.wagtailforms import views
 urlpatterns = [
     url(r'^$', views.index, name='index'),
     url(r'^submissions/(\d+)/$', views.list_submissions, name='list_submissions'),
-    url(r'^submissions/(\d+)/(\d+)/delete/$', views.delete_submission, name='delete_submission')
+    url(r'^submissions/(\d+)/(\d+)/delete/$', views.delete_submission, name='delete_submission'),
+    url(r'^submissions/(\d+)/(\d+)/switch_spam/$', views.switch_spam, name='switch_spam')
 ]

--- a/wagtail/wagtailforms/utils.py
+++ b/wagtail/wagtailforms/utils.py
@@ -1,12 +1,58 @@
+import os
+import shutil
+
 from django.utils.six import string_types
 import antispam
 
+# To be set if a custom model should be used (and trained)
+ANTISPAM_MODEL_FILE = "my_model.dat"
 
-def is_spam(data):
+
+def get_detector():
+    # Return the default antispam detector with its builtin model or, if applicable, a detector with a custom model
+    detector = antispam
+
+    if ANTISPAM_MODEL_FILE:
+        if not os.path.isfile(ANTISPAM_MODEL_FILE):
+            copy_default_model()
+
+        detector = antispam.Detector(ANTISPAM_MODEL_FILE)
+
+    return detector
+
+
+def get_msg_from_data(data):
+    # Return all strings in given data dictionary as a concatenated message
     text_content = ""
 
     for value in data.itervalues():
         if isinstance(value, string_types):
             text_content += " " + value
 
-    return antispam.is_spam(text_content) if text_content else False
+    return text_content
+
+
+def is_spam(data):
+    # Check if data is presumably spam
+    msg = get_msg_from_data(data)
+
+    return get_detector().is_spam(msg) if msg else False
+
+
+def train_spam_recognition(data, spam, priviledged=False):
+    # Only train custom models
+    if ANTISPAM_MODEL_FILE:
+        msg = get_msg_from_data(data)
+        detector = get_detector()
+        score = detector.score(msg)
+
+        # Only train detector when receiving priviledged requests or high/low quality messages
+        if priviledged or score < 0.15 or score > 0.85:
+            detector.train(msg, spam)
+            detector.save()
+
+
+def copy_default_model():
+    # Workaround to get the default model path
+    antispam.score("foo")
+    shutil.copy(antispam.module.obj.model.DEFAULT_DATA_PATH, ANTISPAM_MODEL_FILE)

--- a/wagtail/wagtailforms/utils.py
+++ b/wagtail/wagtailforms/utils.py
@@ -1,0 +1,12 @@
+from django.utils.six import string_types
+import antispam
+
+
+def is_spam(data):
+    text_content = ""
+
+    for value in data.itervalues():
+        if isinstance(value, string_types):
+            text_content += " " + value
+
+    return antispam.is_spam(text_content) if text_content else False

--- a/wagtail/wagtailforms/views.py
+++ b/wagtail/wagtailforms/views.py
@@ -13,6 +13,8 @@ from wagtail.wagtailcore.models import Page
 from wagtail.wagtailforms.forms import SelectDateForm
 from wagtail.wagtailforms.models import FormSubmission, get_forms_for_user
 
+from .utils import train_spam_recognition
+
 
 def index(request):
     form_pages = get_forms_for_user(request.user)
@@ -122,6 +124,9 @@ def switch_spam(request, page_id, submission_id):
         # Switch the current spam state
         submission.is_spam = not submission.is_spam
         submission.save()
+
+        # Train the spam detector model with the users decision
+        train_spam_recognition(submission.get_data(), submission.is_spam, priviledged=True)
 
         messages.success(request, _("Submission marked as {negation} spam.").format(negation="" if submission.is_spam else _("not")))
         return redirect('wagtailforms:list_submissions', page_id)

--- a/wagtail/wagtailforms/views.py
+++ b/wagtail/wagtailforms/views.py
@@ -13,7 +13,7 @@ from wagtail.wagtailcore.models import Page
 from wagtail.wagtailforms.forms import SelectDateForm
 from wagtail.wagtailforms.models import FormSubmission, get_forms_for_user
 
-from .utils import train_spam_recognition
+from .utils import AntiSpamDetector, get_message_from_dict
 
 
 def index(request):
@@ -126,7 +126,7 @@ def switch_spam(request, page_id, submission_id):
         submission.save()
 
         # Train the spam detector model with the users decision
-        train_spam_recognition(submission.get_data(), submission.is_spam, priviledged=True)
+        AntiSpamDetector.train(get_message_from_dict(submission.get_data()), submission.is_spam, priviledged=True)
 
         messages.success(request, _("Submission marked as {negation} spam.").format(negation="" if submission.is_spam else _("not")))
         return redirect('wagtailforms:list_submissions', page_id)

--- a/wagtail/wagtailforms/views.py
+++ b/wagtail/wagtailforms/views.py
@@ -78,11 +78,12 @@ def list_submissions(request, page_id):
 
         writer = csv.writer(response)
 
-        header_row = ['Submission date'] + [label for name, label in data_fields]
+        header_row = ['Submission date'] + ['Spam'] + [label for name, label in data_fields]
 
         writer.writerow(header_row)
         for s in submissions:
             data_row = [s.submit_time]
+            data_row.append[s.is_spam]
             form_data = s.get_data()
             for name, label in data_fields:
                 data_row.append(smart_str(form_data.get(name)))
@@ -95,7 +96,7 @@ def list_submissions(request, page_id):
     data_rows = []
     for s in submissions:
         form_data = s.get_data()
-        data_row = [s.submit_time] + [form_data.get(name) for name, label in data_fields]
+        data_row = [s.submit_time] + [s.is_spam] + [form_data.get(name) for name, label in data_fields]
         data_rows.append({
             "model_id": s.id,
             "fields": data_row

--- a/wagtail/wagtailforms/views.py
+++ b/wagtail/wagtailforms/views.py
@@ -109,3 +109,24 @@ def list_submissions(request, page_id):
         'data_headings': data_headings,
         'data_rows': data_rows
     })
+
+
+def switch_spam(request, page_id, submission_id):
+    if not get_forms_for_user(request.user).filter(id=page_id).exists():
+        raise PermissionDenied
+
+    submission = get_object_or_404(FormSubmission, id=submission_id)
+    page = get_object_or_404(Page, id=page_id)
+
+    if request.method == 'POST':
+        # Switch the current spam state
+        submission.is_spam = not submission.is_spam
+        submission.save()
+
+        messages.success(request, _("Submission marked as {negation} spam.").format(negation="" if submission.is_spam else _("not")))
+        return redirect('wagtailforms:list_submissions', page_id)
+
+    return render(request, 'wagtailforms/confirm_switch_spam.html', {
+        'page': page,
+        'submission': submission
+    })


### PR DESCRIPTION
At least public form pages need a mechanism to protect form submissions against spam.

We've recently relaunched an existing low-traffic site (< 50 visits/week, above-average regional google ranking) using wagtail. There is also a form page to get in touch, and within the first week they received 12 spam messages.

Until now this pull request implements spam detection based on a bayesian spam filter. Any feedback and guidance is highly appreciated.

Some details implemented yet:
- Form submissions are marked with a spam flag
- Every submission is evaluated
- Submissions can be marked as spam/not spam afterwards
- A custom spam detection model may be used (and will be trained with every admin decision or very high/low scoring submissions)

Todo and further ideas:
- Refactor utility functions into class (e.g. `Detector`)
- Configure custom model (storage location, empty or default initialisation)
- Re-train custom model based on all existing form submissions (batch)
- Add tests and docs 
- Configure spam detection for every form page separately (no approach at hand)

Another idea was to implement form honeypots, but I couldn't find a suitable library.
