### PR TITLE
add template tag for dynamic image url

### DIFF
--- a/wagtail/wagtailimages/jinja2tags.py
+++ b/wagtail/wagtailimages/jinja2tags.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, unicode_literals
 from jinja2.ext import Extension
 
 from .shortcuts import get_rendition_or_not_found
+from .templatetags.wagtailimages_tags import image_url
 
 
 def image(image, filterspec, **attrs):
@@ -23,6 +24,7 @@ class WagtailImagesExtension(Extension):
 
         self.environment.globals.update({
             'image': image,
+            'image_url': image_url,
         })
 
 

--- a/wagtail/wagtailimages/templatetags/wagtailimages_tags.py
+++ b/wagtail/wagtailimages/templatetags/wagtailimages_tags.py
@@ -7,6 +7,9 @@ from django.utils.functional import cached_property
 
 from wagtail.wagtailimages.models import Filter
 from wagtail.wagtailimages.shortcuts import get_rendition_or_not_found
+from wagtail.wagtailimages.views.serve import (
+    generate_image_url, generate_signature,
+)
 
 register = template.Library()
 allowed_filter_pattern = re.compile("^[A-Za-z0-9_\-\.]+$")
@@ -98,3 +101,8 @@ class ImageNode(template.Node):
             for key in self.attrs:
                 resolved_attrs[key] = self.attrs[key].resolve(context)
             return rendition.img_tag(resolved_attrs)
+
+
+@register.simple_tag()
+def image_url(image, filter_spec, key=None):
+    return generate_image_url(image, filter_spec, key)

--- a/wagtail/wagtailimages/templatetags/wagtailimages_tags.py
+++ b/wagtail/wagtailimages/templatetags/wagtailimages_tags.py
@@ -104,5 +104,5 @@ class ImageNode(template.Node):
 
 
 @register.simple_tag()
-def image_url(image, filter_spec, key=None):
-    return generate_image_url(image, filter_spec, key)
+def image_url(viewname, image, filter_spec, key=None):
+    return generate_image_url(image, filter_spec, viewname, key)

--- a/wagtail/wagtailimages/tests/test_jinja2.py
+++ b/wagtail/wagtailimages/tests/test_jinja2.py
@@ -80,3 +80,9 @@ class TestImagesJinja(TestCase):
             self.render('{{ image(myimage, "width-200") }}', {'myimage': self.bad_image}),
             '<img alt="missing image" src="/media/not-found" width="0" height="0">'
         )
+
+    def test_image_url(self):
+        self.assertRegex(
+            self.render('{{ image_url(myimage, "width-200") }}', {'myimage': self.image}),
+            '/images/.*/width-200/{}'.format(self.image.file.name.split('/')[-1]),
+        )

--- a/wagtail/wagtailimages/tests/test_jinja2.py
+++ b/wagtail/wagtailimages/tests/test_jinja2.py
@@ -82,7 +82,13 @@ class TestImagesJinja(TestCase):
         )
 
     def test_image_url(self):
-        self.assertRegex(
-            self.render('{{ image_url(myimage, "width-200") }}', {'myimage': self.image}),
+        self.assertRegexpMatches(
+            self.render('{{ image_url("wagtailimages_serve", myimage, "width-200") }}', {'myimage': self.image}),
             '/images/.*/width-200/{}'.format(self.image.file.name.split('/')[-1]),
+        )
+
+    def test_image_url_custom_view(self):
+        self.assertRegexpMatches(
+            self.render('{{ image_url("wagtailimages_serve_custom_view", myimage, "width-200") }}', {'myimage': self.image}),
+            '/testimages/custom_view/.*/width-200/{}'.format(self.image.file.name.split('/')[-1]),
         )

--- a/wagtail/wagtailimages/tests/urls.py
+++ b/wagtail/wagtailimages/tests/urls.py
@@ -9,6 +9,7 @@ urlpatterns = [
     url(r'^actions/serve/(.*)/(\d*)/(.*)/[^/]*', ServeView.as_view(action='serve'), name='wagtailimages_serve_action_serve'),
     url(r'^actions/redirect/(.*)/(\d*)/(.*)/[^/]*', ServeView.as_view(action='redirect'), name='wagtailimages_serve_action_redirect'),
     url(r'^custom_key/(.*)/(\d*)/(.*)/[^/]*', ServeView.as_view(key='custom'), name='wagtailimages_serve_custom_key'),
+    url(r'^custom_view/([^/]*)/(\d*)/([^/]*)/[^/]*$', ServeView.as_view(), name='wagtailimages_serve_custom_view'),
     url(r'^sendfile/(.*)/(\d*)/(.*)/[^/]*', SendFileView.as_view(), name='wagtailimages_sendfile'),
     url(r'^sendfile-dummy/(.*)/(\d*)/(.*)/[^/]*', SendFileView.as_view(backend=dummy_sendfile_backend.sendfile), name='wagtailimages_sendfile_dummy'),
 ]

--- a/wagtail/wagtailimages/views/serve.py
+++ b/wagtail/wagtailimages/views/serve.py
@@ -8,6 +8,7 @@ from wsgiref.util import FileWrapper
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured, PermissionDenied
+from django.core.urlresolvers import reverse
 from django.http import HttpResponse, HttpResponsePermanentRedirect, StreamingHttpResponse
 from django.shortcuts import get_object_or_404
 from django.utils.decorators import classonlymethod
@@ -35,6 +36,15 @@ def generate_signature(image_id, filter_spec, key=None):
 
 def verify_signature(signature, image_id, filter_spec, key=None):
     return signature == generate_signature(image_id, filter_spec, key=key)
+
+
+def generate_image_url(image, filter_spec, key=None):
+    signature = generate_signature(image.id, filter_spec, key)
+    url = reverse('wagtailimages_serve',
+                  args=(signature, image.id, filter_spec))
+    # Append image's original filename to the URL
+    url += image.file.name[len('original_images/'):]
+    return url
 
 
 class ServeView(View):

--- a/wagtail/wagtailimages/views/serve.py
+++ b/wagtail/wagtailimages/views/serve.py
@@ -38,11 +38,9 @@ def verify_signature(signature, image_id, filter_spec, key=None):
     return signature == generate_signature(image_id, filter_spec, key=key)
 
 
-def generate_image_url(image, filter_spec, key=None):
+def generate_image_url(image, filter_spec, viewname='wagtailimages_serve', key=None):
     signature = generate_signature(image.id, filter_spec, key)
-    url = reverse('wagtailimages_serve',
-                  args=(signature, image.id, filter_spec))
-    # Append image's original filename to the URL
+    url = reverse(viewname, args=(signature, image.id, filter_spec))
     url += image.file.name[len('original_images/'):]
     return url
 


### PR DESCRIPTION
Dynamic image view allow us to serve image rendition outside the main request (which is a real performance boost in some cases!! In my use case, it goes from ~400 to ~15 SQL queries!! ).

However, building rendition image url on Python side could be not enough. A common use-case could be do generate url in templates. I'm pretty sure I'm not the only one?

This PR basically copy/paste the example given in the docs : http://docs.wagtail.io/en/latest/advanced_topics/images/image_serve_view.html#generating-dynamic-image-urls-in-python

The util function is just wrapped into a simple template tag so it can still be used directly in Python code.

Hope it could be merge and thanks for review!

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/torchbox/wagtail/2461)

<!-- Reviewable:end -->
