### PR TITLE
Feature/frontendcache 2527

### DIFF
--- a/wagtail/contrib/wagtailfrontendcache/signal_handlers.py
+++ b/wagtail/contrib/wagtailfrontendcache/signal_handlers.py
@@ -1,9 +1,21 @@
 from __future__ import absolute_import, unicode_literals
 
+import logging
+
 from django.apps import apps
 
-from wagtail.contrib.wagtailfrontendcache.utils import purge_page_from_cache
+from wagtail.contrib.wagtailfrontendcache.utils import purge_page_from_cache, purge_url_from_cache
 from wagtail.wagtailcore.signals import page_published, page_unpublished
+from django.db.models.signals import post_save, pre_save
+
+logger = logging.getLogger('wagtail.frontendcache')
+
+
+def has_path_changed(instance, field):
+    if not instance.pk:
+        return False
+    old_value = instance.__class__._default_manager.filter(pk=instance.pk).values(field).get()[field]
+    return not getattr(instance, field) == old_value
 
 
 def page_published_signal_handler(instance, **kwargs):
@@ -12,6 +24,19 @@ def page_published_signal_handler(instance, **kwargs):
 
 def page_unpublished_signal_handler(instance, **kwargs):
     purge_page_from_cache(instance)
+
+
+def page_pre_saved_signal_handler(instance, **kwargs):
+    if has_path_changed(instance, 'url_path'):
+        instance.old_url = instance.url
+    else:
+        instance.old_url = None
+
+
+def page_post_saved_signal_handler(instance, **kwargs):
+    if not kwargs['update_fields']:
+        if instance.old_url:
+            purge_url_from_cache(instance.old_url)
 
 
 def register_signal_handlers():
@@ -23,3 +48,5 @@ def register_signal_handlers():
     for model in indexed_models:
         page_published.connect(page_published_signal_handler, sender=model)
         page_unpublished.connect(page_unpublished_signal_handler, sender=model)
+        pre_save.connect(page_pre_saved_signal_handler, sender=model)
+        post_save.connect(page_post_saved_signal_handler, sender=model)

--- a/wagtail/contrib/wagtailfrontendcache/signal_handlers.py
+++ b/wagtail/contrib/wagtailfrontendcache/signal_handlers.py
@@ -1,20 +1,20 @@
 from __future__ import absolute_import, unicode_literals
 
-import logging
-
 from django.apps import apps
 
 from wagtail.contrib.wagtailfrontendcache.utils import purge_page_from_cache, purge_url_from_cache
+from django.core.exceptions import ObjectDoesNotExist
 from wagtail.wagtailcore.signals import page_published, page_unpublished
 from django.db.models.signals import post_save, pre_save
-
-logger = logging.getLogger('wagtail.frontendcache')
 
 
 def has_path_changed(instance, field):
     if not instance.pk:
         return False
-    old_value = instance.__class__._default_manager.filter(pk=instance.pk).values(field).get()[field]
+    try:
+        old_value = instance.__class__._default_manager.filter(pk=instance.pk).values(field).get()[field]
+    except ObjectDoesNotExist:
+        return False
     return not getattr(instance, field) == old_value
 
 

--- a/wagtail/wagtailcore/migrations/0029_page_old_url.py
+++ b/wagtail/wagtailcore/migrations/0029_page_old_url.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('wagtailcore', '0028_merge'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='page',
+            name='old_url',
+            field=models.TextField(null=True, help_text='Will be null if page url has not changed after a save. Otherwise will be the previous page url.', editable=False, verbose_name='old page url', blank=True),
+        ),
+    ]

--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -365,6 +365,14 @@ class Page(six.with_metaclass(PageBase, MP_Node, ClusterableModel, index.Indexed
         editable=False
     )
 
+    old_url = models.TextField(
+        help_text='Will be null if page url has not changed after a save. Otherwise will be the previous page url.',
+        verbose_name='old page url',
+        blank=True,
+        null=True,
+        editable=False
+    )
+
     search_fields = SearchFieldsShouldBeAList([
         index.SearchField('title', partial_match=True, boost=2),
         index.FilterField('id'),


### PR DESCRIPTION
Fixing #2527 
Cache is purged when slug is changed or when page is moved.
