### PR TITLE
[#2493] Add support for related foreign objects to Elastic search

### DIFF
--- a/wagtail/tests/search/migrations/0002_subobject.py
+++ b/wagtail/tests/search/migrations/0002_subobject.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('searchtests', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='SearchTestSubObject',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('parent', models.ForeignKey(to='searchtests.SearchTest', related_name='subobjects', on_delete=models.deletion.CASCADE)),
+                ('name', models.CharField(max_length=255)),
+            ],
+            bases=(models.Model,),
+        ),
+    ]

--- a/wagtail/tests/search/models.py
+++ b/wagtail/tests/search/models.py
@@ -19,6 +19,9 @@ class SearchTest(models.Model, index.Indexed):
             index.SearchField('name', partial_match=True),
             index.FilterField('slug'),
         ]),
+        index.RelatedFields('subobjects', [
+            index.SearchField('name', partial_match=True),
+        ]),
         index.SearchField('content'),
         index.SearchField('callable_indexed_field'),
         index.FilterField('title'),
@@ -69,3 +72,11 @@ class SearchTestChild(SearchTest):
             index.FilterField('live'),
         ]),
     ]
+
+
+class SearchTestSubObject(models.Model):
+    parent = models.ForeignKey(SearchTest, related_name='subobjects')
+    name = models.CharField(max_length=255)
+
+    def __str__(self):
+        return self.name

--- a/wagtail/wagtailsearch/index.py
+++ b/wagtail/wagtailsearch/index.py
@@ -168,6 +168,9 @@ class RelatedFields(object):
         if isinstance(field, RelatedField):
             return getattr(obj, self.field_name)
 
+        if isinstance(field, ForeignObjectRel):
+            return getattr(obj, self.field_name)
+
     def select_on_queryset(self, queryset):
         """
         This method runs either prefetch_related or select_related on the queryset

--- a/wagtail/wagtailsearch/tests/test_backends.py
+++ b/wagtail/wagtailsearch/tests/test_backends.py
@@ -42,6 +42,7 @@ class BackendTests(WagtailTestUtils):
         testa = models.SearchTest()
         testa.title = "Hello World"
         testa.save()
+        testa.subobjects.create(name='A subobject')
         self.backend.add(testa)
         self.testa = testa
 

--- a/wagtail/wagtailsearch/tests/test_elasticsearch_backend.py
+++ b/wagtail/wagtailsearch/tests/test_elasticsearch_backend.py
@@ -775,7 +775,7 @@ class TestElasticSearchMapping(TestCase):
                         },
                     },
                     'subobjects': {
-                       'type': 'nested',
+                        'type': 'nested',
                         'properties': {
                             'name': {'type': 'string', 'include_in_all': True, 'index_analyzer': 'edgengram_analyzer'},
                         },


### PR DESCRIPTION
This adds support for related foreign objects to Elastic search (most support for this functionality was already written/existing). Support for related foreign objects does not exist in the DBSearch, so maybe this is something for the future as well :-).
