### PR TITLE
Only offer allowed parent pages in copy page destination chooser

### DIFF
--- a/wagtail/wagtailadmin/forms.py
+++ b/wagtail/wagtailadmin/forms.py
@@ -125,7 +125,9 @@ class CopyForm(forms.Form):
         self.fields['new_parent_page'] = forms.ModelChoiceField(
             initial=self.page.get_parent(),
             queryset=Page.objects.all(),
-            widget=widgets.AdminPageChooser(can_choose_root=True),
+            widget=widgets.AdminPageChooser(
+                can_choose_root=True,
+                target_models=self.page.specific_class.allowed_parent_page_models()),
             label=_("New parent page"),
             help_text=_("This copy will be a child of this given parent page.")
         )


### PR DESCRIPTION
Prevent bypassing `parent_page_types`/`subpage_types` when copying a page.
