### PR TITLE
Add setting to use wagtailsearchpromotions to manage queries

### DIFF
--- a/wagtail/contrib/wagtailsearchpromotions/templates/wagtailsearchpromotions/confirm_delete.html
+++ b/wagtail/contrib/wagtailsearchpromotions/templates/wagtailsearchpromotions/confirm_delete.html
@@ -6,7 +6,11 @@
     {% include "wagtailadmin/shared/header.html" with title=delete_str subtitle=query.query_string %}
 
     <div class="nice-padding">
-        <p>{% trans "Are you sure you want to delete all promoted results for this search term?" %}</p>
+        {% if is_editor %}
+            <p>{% trans "Are you sure you want to delete this search term?" %}</p>
+        {% else %}
+            <p>{% trans "Are you sure you want to delete all promoted results for this search term?" %}</p>
+        {% endif %}
         <form action="{% url 'wagtailsearchpromotions:delete' query.id %}" method="POST">
             {% csrf_token %}
             <input type="submit" value="{% trans 'Yes, delete' %}" class="button serious" />

--- a/wagtail/contrib/wagtailsearchpromotions/templates/wagtailsearchpromotions/list.html
+++ b/wagtail/contrib/wagtailsearchpromotions/templates/wagtailsearchpromotions/list.html
@@ -1,10 +1,12 @@
 {% load i18n %}
 <table class="listing">
-    <col width="40%" />
-    <col width="40%"/>
-    <col />
+    {% if is_editor %}<col width="5%"/>{% endif %}
+    <col width="20%"/>
+    <col/>
+    <col width="10%"/>
     <thead>
         <tr>
+            {% if is_editor %}<th></th>{% endif %}
             <th class="title">{% trans "Search term(s)" %}</th>
             <th>{% trans "Promoted results" %}</th>
             <th>{% trans "Views (past week)" %}</th>
@@ -13,6 +15,11 @@
     <tbody>
         {% for query in queries %}
             <tr>
+                {% if is_editor %}
+                    <td>
+                        <a href="{% url 'wagtailsearchpromotions:delete' query.id %}" class="icon text-replace icon-bin">{% trans "Delete" %}</a>
+                    </td>
+                {% endif %}
                 <td class="title">
                     <h2><a href="{% url 'wagtailsearchpromotions:edit' query.id %}" title="{% trans 'Edit this promotion' %}">{{ query.query_string }}</a></h2>
                 </td>

--- a/wagtail/contrib/wagtailsearchpromotions/templates/wagtailsearchpromotions/results.html
+++ b/wagtail/contrib/wagtailsearchpromotions/templates/wagtailsearchpromotions/results.html
@@ -2,7 +2,7 @@
 {% if queries %}
     {% if is_searching %}
         <h2>
-        {% blocktrans count counter=queries|length %}
+        {% blocktrans count counter=queries_count %}
             There is one match
         {% plural %}
             There are {{ counter }} matches

--- a/wagtail/contrib/wagtailsearchpromotions/views.py
+++ b/wagtail/contrib/wagtailsearchpromotions/views.py
@@ -1,6 +1,10 @@
 from __future__ import absolute_import, unicode_literals
 
+from django.conf import settings
 from django.core.urlresolvers import reverse
+from django.db.models import Q
+from django.db.models.aggregates import Sum
+from django.db.models.functions import Coalesce
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils.translation import ugettext as _
 from django.views.decorators.vary import vary_on_headers
@@ -14,6 +18,25 @@ from wagtail.wagtailsearch import forms as search_forms
 from wagtail.wagtailsearch.models import Query
 
 
+query_editor_setting = 'WAGTAILSEARCHPROMOTIONS_QUERY_EDITOR'
+
+# If acting as query editor, allow saving a query with no promotions
+if getattr(settings, query_editor_setting, False):
+    forms.SearchPromotionsFormSet.minimum_forms = 0
+
+
+# Factored out for reuse as public-facing "top searches"
+def get_hit_queryset():
+    queryset = Query.objects.filter(
+        Q(daily_hits__isnull=False) | Q(editors_picks__isnull=False))
+    queryset = Query.objects.filter(pk__in=queryset).annotate(_hits=Coalesce(Sum('daily_hits__hits'), 0))
+    return queryset.order_by('-_hits', 'query_string')
+
+
+def get_promoted_queryset():
+    return Query.objects.filter(editors_picks__isnull=False).distinct()
+
+
 @any_permission_required(
     'wagtailsearchpromotions.add_searchpromotion',
     'wagtailsearchpromotions.change_searchpromotion',
@@ -21,31 +44,41 @@ from wagtail.wagtailsearch.models import Query
 )
 @vary_on_headers('X-Requested-With')
 def index(request):
+    is_editor = getattr(settings, query_editor_setting, False)
     is_searching = False
+    queries_count = None
     query_string = request.GET.get('q', "")
 
-    queries = Query.objects.filter(editors_picks__isnull=False).distinct()
+    if is_editor:
+        queries = get_hit_queryset()
+    else:
+        queries = get_promoted_queryset()
 
     # Search
     if query_string:
         queries = queries.filter(query_string__icontains=query_string)
         is_searching = True
+        queries_count = queries.count()
 
     paginator, queries = paginate(request, queries)
 
     if request.is_ajax():
         return render(request, "wagtailsearchpromotions/results.html", {
+            'is_editor': is_editor,
             'is_searching': is_searching,
             'queries': queries,
+            'queries_count': queries_count,
             'query_string': query_string,
         })
     else:
         return render(request, 'wagtailsearchpromotions/index.html', {
+            'is_editor': is_editor,
             'is_searching': is_searching,
             'queries': queries,
             'query_string': query_string,
             'search_form': SearchForm(
-                data=dict(q=query_string) if query_string else None, placeholder=_("Search promoted results")
+                data=dict(q=query_string) if query_string else None,
+                placeholder=_("Search all terms" if is_editor else "Search promoted results")
             ),
         })
 
@@ -145,13 +178,18 @@ def edit(request, query_id):
 
 @permission_required('wagtailsearchpromotions.delete_searchpromotion')
 def delete(request, query_id):
+    is_editor = getattr(settings, query_editor_setting, False)
     query = get_object_or_404(Query, id=query_id)
 
     if request.method == 'POST':
-        query.editors_picks.all().delete()
+        if is_editor:
+            query.delete()
+        else:
+            query.editors_picks.all().delete()
         messages.success(request, _("Editor's picks deleted."))
         return redirect('wagtailsearchpromotions:index')
 
     return render(request, 'wagtailsearchpromotions/confirm_delete.html', {
+        'is_editor': is_editor,
         'query': query,
     })


### PR DESCRIPTION
Add `WAGTAILSEARCHPROMOTIONS_QUERY_EDITOR=True` in settings to change the UI to:
- show all saved queries whether they are promoted or not (ordered by decreasing popularity)
- allow queries to be deleted as well as promotions

This approach is used in a site where the query hits records are used to power search suggestions including a "top searches" feature. This mode of operation provides more visiblity of popular search terms to admins, and allows unwanted terms to be removed.

The result isn't perfect and probably needs some discussion :)
