### PR TITLE
Fix #536: Show non_field_errors

### DIFF
--- a/wagtail/wagtailadmin/templates/wagtailadmin/base.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/base.html
@@ -35,11 +35,12 @@
             <div class="messages">
                 {% if messages or edit_handler and edit_handler.form and edit_handler.form.non_field_errors %}
                     <ul>
-                        {% for message in messages %}
-                            <li class="{% message_tags message %}">{{ message|safe }}</li>
-                        {% endfor %}
                         {% if edit_handler and edit_handler.form and edit_handler.form.non_field_errors %}
                             <li class="error">{{ edit_handler.form.non_field_errors.as_text }}</li>
+                        {% else %}
+                            {% for message in messages %}
+                                <li class="{% message_tags message %}">{{ message|safe }}</li>
+                            {% endfor %}
                         {% endif %}
                     </ul>
                 {% endif %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/base.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/base.html
@@ -29,7 +29,6 @@
 
     <div class="content-wrapper">
         <div class="content">
-            
             {# Always show messages div so it can be appended to by JS #}
             <div class="messages">
             {% block messages %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/base.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/base.html
@@ -37,7 +37,7 @@
                         {% if has_errors and messages %}<div style='display: none'>{% endif %}
 
                         {% for message in messages %}
-                            <li{% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message|safe }}</li>
+                            <li class="{% message_tags message %}">{{ message|safe }}</li>
                         {% endfor %}
 
                         {% if has_errors and messages %}</div>{% endif %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/base.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/base.html
@@ -31,20 +31,22 @@
         <div class="content">
             
             {% block messages %}
-            {# Always show messages div so it can be appended to by JS #}
-            <div class="messages">
-                {% if messages or edit_handler and edit_handler.form and edit_handler.form.non_field_errors %}
+                {% form_has_errors as has_errors %}
+                {% if messages or has_errors %}
                     <ul>
-                        {% if edit_handler and edit_handler.form and edit_handler.form.non_field_errors %}
+                        {% if has_errors and messages %}<div style='display: none'>{% endif %}
+
+                        {% for message in messages %}
+                            <li{% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message|safe }}</li>
+                        {% endfor %}
+
+                        {% if has_errors and messages %}</div>{% endif %}
+
+                        {% if has_errors %}
                             <li class="error">{{ edit_handler.form.non_field_errors.as_text }}</li>
-                        {% else %}
-                            {% for message in messages %}
-                                <li class="{% message_tags message %}">{{ message|safe }}</li>
-                            {% endfor %}
                         {% endif %}
                     </ul>
                 {% endif %}
-            </div>
             {% endblock %}
 
             <div id="nav-toggle" class="nav-toggle icon text-replace">{% trans "Menu" %}</div>

--- a/wagtail/wagtailadmin/templates/wagtailadmin/base.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/base.html
@@ -30,6 +30,8 @@
     <div class="content-wrapper">
         <div class="content">
             
+            {# Always show messages div so it can be appended to by JS #}
+            <div class="messages">
             {% block messages %}
                 {% form_has_errors as has_errors %}
                 {% if messages or has_errors %}
@@ -48,6 +50,8 @@
                     </ul>
                 {% endif %}
             {% endblock %}
+            </div>
+
 
             <div id="nav-toggle" class="nav-toggle icon text-replace">{% trans "Menu" %}</div>
 

--- a/wagtail/wagtailadmin/templates/wagtailadmin/base.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/base.html
@@ -29,16 +29,22 @@
 
     <div class="content-wrapper">
         <div class="content">
+            
+            {% block messages %}
             {# Always show messages div so it can be appended to by JS #}
             <div class="messages">
-                {% if messages %}
+                {% if messages or edit_handler and edit_handler.form and edit_handler.form.non_field_errors %}
                     <ul>
                         {% for message in messages %}
                             <li class="{% message_tags message %}">{{ message|safe }}</li>
                         {% endfor %}
+                        {% if edit_handler and edit_handler.form and edit_handler.form.non_field_errors %}
+                            <li class="error">{{ edit_handler.form.non_field_errors.as_text }}</li>
+                        {% endif %}
                     </ul>
                 {% endif %}
             </div>
+            {% endblock %}
 
             <div id="nav-toggle" class="nav-toggle icon text-replace">{% trans "Menu" %}</div>
 

--- a/wagtail/wagtailadmin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/wagtailadmin/templatetags/wagtailadmin_tags.py
@@ -312,3 +312,16 @@ def message_tags(message):
         return level_tag
     else:
         return ''
+
+
+@register.assignment_tag(takes_context=True)
+def form_has_errors(context):
+
+    edit_handler = template.Variable('edit_handler').resolve(context)
+
+    if edit_handler is not None:
+        if hasattr(edit_handler, 'form'):
+            if hasattr(edit_handler.form, 'non_field_errors'):
+                return True
+
+    return False

--- a/wagtail/wagtailadmin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/wagtailadmin/templatetags/wagtailadmin_tags.py
@@ -316,12 +316,15 @@ def message_tags(message):
 
 @register.assignment_tag(takes_context=True)
 def form_has_errors(context):
-
-    edit_handler = template.Variable('edit_handler').resolve(context)
+    try:
+        edit_handler = template.Variable('edit_handler').resolve(context)
+    except template.VariableDoesNotExist:
+        return False
 
     if edit_handler is not None:
         if hasattr(edit_handler, 'form'):
             if hasattr(edit_handler.form, 'non_field_errors'):
-                return True
+                if len(edit_handler.form.non_field_errors()):
+                    return True
 
     return False


### PR DESCRIPTION
This addresses issue #536, the ability to show non_field_errors on the admin UI.

Also allows for the messages block to be overridden by custom admin templates, if desired.

Agree more work could be done on the UX of this feature, however I don't see that as a blocker to including this fix. 
