### PR TITLE
RequestCacheMiddleware: add a local memory cache instance as request.cache.

### DIFF
--- a/docs/advanced_topics/settings.rst
+++ b/docs/advanced_topics/settings.rst
@@ -39,6 +39,7 @@ Middleware (``settings.py``)
     'django.middleware.security.SecurityMiddleware',
 
     'wagtail.wagtailcore.middleware.SiteMiddleware',
+    'wagtail.wagtailcore.middleware.RequestCacheMiddleware',
 
     'wagtail.wagtailredirects.middleware.RedirectMiddleware',
   ]
@@ -441,6 +442,7 @@ These two files should reside in your project directory (``myproject/myproject/`
       'django.middleware.security.SecurityMiddleware',
 
       'wagtail.wagtailcore.middleware.SiteMiddleware',
+      'wagtail.wagtailcore.middleware.RequestCacheMiddleware',
       'wagtail.wagtailredirects.middleware.RedirectMiddleware',
   ]
 

--- a/docs/getting_started/integrating_into_django.rst
+++ b/docs/getting_started/integrating_into_django.rst
@@ -34,6 +34,7 @@ In your settings file, add the following apps to ``INSTALLED_APPS``::
 Add the following entries to ``MIDDLEWARE_CLASSES``::
 
     'wagtail.wagtailcore.middleware.SiteMiddleware',
+    'wagtail.wagtailcore.middleware.RequestCacheMiddleware',
     'wagtail.wagtailredirects.middleware.RedirectMiddleware',
 
 Add a ``STATIC_ROOT`` setting, if your project does not have one already:

--- a/wagtail/project_template/project_name/settings/base.py
+++ b/wagtail/project_template/project_name/settings/base.py
@@ -63,6 +63,7 @@ MIDDLEWARE_CLASSES = [
     'django.middleware.security.SecurityMiddleware',
 
     'wagtail.wagtailcore.middleware.SiteMiddleware',
+    'wagtail.wagtailcore.middleware.RequestCacheMiddleware',
     'wagtail.wagtailredirects.middleware.RedirectMiddleware',
 ]
 

--- a/wagtail/tests/settings.py
+++ b/wagtail/tests/settings.py
@@ -77,6 +77,7 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 
     'wagtail.wagtailcore.middleware.SiteMiddleware',
+    'wagtail.wagtailcore.middleware.RequestCacheMiddleware',
     'wagtail.wagtailredirects.middleware.RedirectMiddleware',
 )
 

--- a/wagtail/wagtailcore/middleware.py
+++ b/wagtail/wagtailcore/middleware.py
@@ -1,9 +1,11 @@
 from __future__ import absolute_import, unicode_literals
 
 from wagtail.wagtailcore.models import Site
+from wagtail.wagtailcore.request_cache import RequestCache
 
 
 class SiteMiddleware(object):
+
     def process_request(self, request):
         """
         Set request.site to contain the Site object responsible for handling this request,
@@ -13,3 +15,12 @@ class SiteMiddleware(object):
             request.site = Site.find_for_request(request)
         except Site.DoesNotExist:
             request.site = None
+
+
+class RequestCacheMiddleware(object):
+    """
+    Creates a fresh cache instance as request.cache. The cache instance lives only as long as request does.
+    """
+
+    def process_request(self, request):
+        request.cache = RequestCache()

--- a/wagtail/wagtailcore/request_cache.py
+++ b/wagtail/wagtailcore/request_cache.py
@@ -1,0 +1,21 @@
+from __future__ import absolute_import, unicode_literals
+
+from django.core.cache.backends.base import BaseCache
+from django.core.cache.backends.locmem import LocMemCache
+from django.utils.synch import RWLock
+
+
+class RequestCache(LocMemCache):
+    """
+    RequestCache is a customized LocMemCache which stores its data cache as an instance attribute, rather than
+    a global. It's designed to live only as long as the request object that RequestCacheMiddleware attaches it to.
+    """
+
+    def __init__(self):
+        # We explicitly do not call super() here, because while we want BaseCache.__init__() to run, we *don't*
+        # want LocMemCache.__init__() to run, because that would store our caches in its globals.
+        BaseCache.__init__(self, {})
+
+        self._cache = {}
+        self._expire_info = {}
+        self._lock = RWLock()


### PR DESCRIPTION
This is useful for those times when a single request will need to perform a very expensive operation multiples times, but the results of that operation are specific to the current request. Unlike all other caching mechanisms provided by Django, RequestCache's data will be garbage collected alongside the request object.

This PR is part of the functionality from #2463, which @gasman asked me to split into multiple PRs to make it easier to review.
