### PR TITLE
Remember input data in page chooser when switching between Internal/External/Email link

### DIFF
--- a/wagtail/wagtailadmin/templates/wagtailadmin/chooser/_link_types.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/chooser/_link_types.html
@@ -7,20 +7,28 @@
             {% if parent_page_id %}
                 <a href="{% url 'wagtailadmin_choose_page_child' parent_page_id %}{% querystring p=None parent_page_id=None %}">{% trans "Internal link" %}</a>
             {% else %}
-                <a href="{% url 'wagtailadmin_choose_page' %}{% querystring p=None parent_page_id=None %}">{% trans "Internal link" %}</a>
+                <a href="{% url 'wagtailadmin_choose_page' %}{% querystring p=None parent_page_id=None link_url=None link_text=None %}">{% trans "Internal link" %}</a>
             {% endif %}
         {% endif %}
 
         {% if current == 'external' %}
             | <b>{% trans "External link" %}</b>
         {% elif allow_external_link %}
-            | <a href="{% url 'wagtailadmin_choose_page_external_link' %}{% querystring p=None parent_page_id=parent_page_id %}">{% trans "External link" %}</a>
+            {% if current == 'internal' %}
+                | <a href="{% url 'wagtailadmin_choose_page_external_link' %}{% querystring p=None parent_page_id=parent_page_id %}">{% trans "External link" %}</a>
+            {% else %}
+                | <a href="{% url 'wagtailadmin_choose_page_external_link' %}{% querystring p=None parent_page_id=parent_page_id link_url=None link_text=None %}">{% trans "External link" %}</a>           
+            {% endif %}
         {% endif %}
 
         {% if current == 'email' %}
             | <b>{% trans "Email link" %}</b>
         {% elif allow_email_link %}
-            | <a href="{% url 'wagtailadmin_choose_page_email_link' %}{% querystring p=None parent_page_id=parent_page_id %}">{% trans "Email link" %}</a>
+            {% if current == 'internal' %}
+                | <a href="{% url 'wagtailadmin_choose_page_email_link' %}{% querystring p=None parent_page_id=parent_page_id %}">{% trans "Email link" %}</a>
+            {% else %}
+                | <a href="{% url 'wagtailadmin_choose_page_email_link' %}{% querystring p=None parent_page_id=parent_page_id link_url=None link_text=None %}">{% trans "Email link" %}</a>
+            {% endif %}
         {% endif %}
     </p>
 {% endif %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/chooser/email_link.js
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/chooser/email_link.js
@@ -1,6 +1,6 @@
 function(modal) {
     $('p.link-types a', modal.body).click(function() {
-        modal.loadUrl(this.href);
+        modal.loadUrl(this.href, buildUrlParams());
         return false;
     });
 
@@ -8,4 +8,8 @@ function(modal) {
         modal.postForm(this.action, $(this).serialize());
         return false;
     });
+
+    function buildUrlParams() {
+        return $('form input:visible', modal.body).serialize().replace('email_address', 'link_url');
+    }
 }

--- a/wagtail/wagtailadmin/templates/wagtailadmin/chooser/external_link.js
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/chooser/external_link.js
@@ -1,6 +1,6 @@
 function(modal) {
     $('p.link-types a', modal.body).click(function() {
-        modal.loadUrl(this.href);
+        modal.loadUrl(this.href, buildUrlParams());
         return false;
     });
 
@@ -8,4 +8,8 @@ function(modal) {
         modal.postForm(this.action, $(this).serialize());
         return false;
     });
+
+    function buildUrlParams() {
+        return $('form input:visible', modal.body).serialize().replace('url', 'link_url');
+    }
 }


### PR DESCRIPTION
Fixes #2692 

Hi, this is my first contribution to wagtail, so I'd appreciate any feedback. I feel _link_types.html might be getting messy with the extra if blocks, but that looked like the cleanest solution to me. 
## My Solution

I am serializing the visible inputs on the modal and passing them as the urlParams to the loadUrl function of modal-workflow.js. 

I replace email_address with link_url for the email link, and url with link_url for the external link, so these values are preserved when the user goes between tabs. This is how the initial values of the forms were set up when the edit link function was added, so I wanted to be consistent with that.

On the _link_types.html page where the links for the tabs are built, I am keeping the current link parameters if you are on the internal link tab, and wiped them out when you are on either the external or email link tabs, as they will be rebuilt when you go to click another tab.

Thanks!
