### PR TITLE
Make non field error messages be shown in place of the generic validation error message

### DIFF
--- a/wagtail/wagtailadmin/templates/wagtailadmin/base.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/base.html
@@ -31,10 +31,13 @@
         <div class="content">
             {# Always show messages div so it can be appended to by JS #}
             <div class="messages">
-                {% if messages %}
+                {% if messages or form.non_field_errors %}
                     <ul>
                         {% for message in messages %}
                             <li class="{% message_tags message %}">{{ message|safe }}</li>
+                        {% endfor %}
+                        {% for error in form.non_field_errors %}
+                            <li class="error">{{ error }}</li>
                         {% endfor %}
                     </ul>
                 {% endif %}

--- a/wagtail/wagtailadmin/views/pages.py
+++ b/wagtail/wagtailadmin/views/pages.py
@@ -251,8 +251,13 @@ def create(request, content_type_app_name, content_type_model_name, parent_page_
                     # Ensure the 'next' url is passed through again if present
                     target_url += '?next=%s' % urlquote(next_url)
                 return redirect(target_url)
+
         else:
-            messages.error(request, _("The page could not be created due to validation errors"))
+            if form.non_field_errors:
+                pass
+            else:
+                messages.error(request, _("The page could not be created due to validation errors"))
+
             edit_handler = edit_handler_class(instance=page, form=form)
     else:
         signals.init_new_page.send(sender=create, page=page, parent=parent_page)
@@ -434,6 +439,10 @@ def edit(request, page_id):
         else:
             if page.locked:
                 messages.error(request, _("The page could not be saved as it is locked"))
+
+            elif form.non_field_errors:
+                pass
+
             else:
                 messages.error(request, _("The page could not be saved due to validation errors"))
 


### PR DESCRIPTION
Make non field error message be shown in the messages section where it currently would say 'The page could not be saved due to validation errors' if they are available. This is incredibly useful in the case of custom validation where you may want to raise a whole page/form error.
