### PR TITLE
Fix for custom users without the 'is_staff' field

### DIFF
--- a/wagtail/wagtailusers/forms.py
+++ b/wagtail/wagtailusers/forms.py
@@ -184,8 +184,9 @@ class UserEditForm(UsernameForm):
     def save(self, commit=True):
         user = super(UserEditForm, self).save(commit=False)
 
-        # users can access django-admin iff they are a superuser
-        user.is_staff = user.is_superuser
+        # users can access django-admin if they are a superuser
+        if not hasattr(user.__class__, 'is_staff') and 'is_staff' in vars(user):
+            user.is_staff = user.is_superuser
 
         if self.cleaned_data["password1"]:
             user.set_password(self.cleaned_data["password1"])


### PR DESCRIPTION
Currently when using a custom user without the `is_staff` field, the error `can't set attribute` will be raised, as upon saving a user in wagtail admin, the save function will attempt to set `user.is_staff` to the value of `user.is_superuser`. For example my custom user had something like this.

```
    @property
    def is_staff(self):
        "Is the user a member of staff?"
        # Simplest possible answer: All admins are staff
        return self.is_admin
```

I'll add tests if there's no problems with what I've got so far.
