### PR TITLE
Change AbstractForm to a mixin class called FormPageMixin

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -37,6 +37,7 @@ Changelog
  * Fix: Non-text content is now preserved when adding or editing a link within rich text (Matt Westcott)
  * Fix: Fixed preview when `SECURE_SSL_REDIRECT = True` (Aymeric Augustin)
  * Fix: Prevent hang when truncating an image filename without an extension (Ricky Robinett)
+ * Deprecated ``AbstractForm`` in favor of mixin class ``FormPageMixin``.
 
 
 1.6.3 (30.09.2016)

--- a/docs/reference/contrib/forms.rst
+++ b/docs/reference/contrib/forms.rst
@@ -4,7 +4,7 @@
 Form builder
 ============
 
-The ``wagtailforms`` module allows you to set up single-page forms, such as a 'Contact us' form, as pages of a Wagtail site. It provides a set of base models that site implementers can extend to create their own ``FormPage`` type with their own site-specific templates. Once a page type has been set up in this way, editors can build forms within the usual page editor, consisting of any number of fields. Form submissions are stored for later retrieval through a new 'Forms' section within the Wagtail admin interface; in addition, they can be optionally e-mailed to an address specified by the editor.
+The ``wagtailforms`` module allows you to set up single-page forms, such as a 'Contact us' form, as pages of a Wagtail site. It provides a set of base models that site implementers can extend to create their own ``FormPage`` type with their own site-specific templates. Once a page type has been set up in this way, editors can build forms within the usual page editor, consisting of any number of fields. Form submissions are stored for later retrieval through a new 'Forms' section within the Wagtail admin interface.
 
 
 Usage
@@ -19,7 +19,7 @@ Add ``wagtail.wagtailforms`` to your ``INSTALLED_APPS``:
        'wagtail.wagtailforms',
     ]
 
-Within the ``models.py`` of one of your apps, create a model that extends ``wagtailforms.models.AbstractEmailForm``:
+Within the ``models.py`` of one of your apps, create a model that extends ``wagtailforms.models.FormPageMixin`` and ``Page``:
 
 
 .. code-block:: python
@@ -27,32 +27,41 @@ Within the ``models.py`` of one of your apps, create a model that extends ``wagt
     from modelcluster.fields import ParentalKey
     from wagtail.wagtailadmin.edit_handlers import (FieldPanel, FieldRowPanel,
         InlinePanel, MultiFieldPanel)
+    from wagtail.wagtailcore.models import Page
     from wagtail.wagtailcore.fields import RichTextField
-    from wagtail.wagtailforms.models import AbstractEmailForm, AbstractFormField
+    from wagtail.wagtailforms.models import FormPageMixin, AbstractFormField
 
     class FormField(AbstractFormField):
         page = ParentalKey('FormPage', related_name='form_fields')
 
-    class FormPage(AbstractEmailForm):
+    class FormPage(FormPageMixin, Page):
         intro = RichTextField(blank=True)
         thank_you_text = RichTextField(blank=True)
 
-        content_panels = AbstractEmailForm.content_panels + [
+        content_panels = [
             FieldPanel('intro', classname="full"),
             InlinePanel('form_fields', label="Form fields"),
             FieldPanel('thank_you_text', classname="full"),
-            MultiFieldPanel([
-                FieldRowPanel([
-                    FieldPanel('from_address', classname="col6"),
-                    FieldPanel('to_address', classname="col6"),
-                ]),
-                FieldPanel('subject'),
-            ], "Email"),
         ]
 
-``AbstractEmailForm`` defines the fields ``to_address``, ``from_address`` and ``subject``, and expects ``form_fields`` to be defined. Any additional fields are treated as ordinary page content - note that ``FormPage`` is responsible for serving both the form page itself and the landing page after submission, so the model definition should include all necessary content fields for both of those views.
+As illustrated above, ``FormPageMixin`` expects ``form_fields`` to be defined. Any additional fields are treated as ordinary page content - note that ``FormPage`` is responsible for serving both the form page itself and the landing page after submission, so the model definition should include all necessary content fields for both of those views.
 
-If you do not want your form page type to offer form-to-email functionality, you can inherit from AbstractForm instead of ``AbstractEmailForm``, and omit the ``to_address``, ``from_address`` and ``subject`` fields from the ``content_panels`` definition.
+Wagtail also provides a Page type to use for creating a form, in which the submission is emailed to a recipient defined by the editor. To achieve this form-to-email functionality, you can inherit from ``FormPageMixin`` instead of ``AbstractEmailForm``, and include the ``to_address``, ``from_address`` and ``subject`` fields in the ``content_panels`` definition, like so:
+
+.. code-block:: python
+
+    ...
+    content_panels = [
+        ...,
+        MultiFieldPanel([
+         FieldRowPanel([
+             FieldPanel('from_address', classname="col6"),
+             FieldPanel('to_address', classname="col6"),
+         ]),
+         FieldPanel('subject'),
+        ], "Email"),
+    ]
+
 
 You now need to create two templates named ``form_page.html`` and ``form_page_landing.html`` (where ``form_page`` is the underscore-formatted version of the class name). ``form_page.html`` differs from a standard Wagtail template in that it is passed a variable ``form``, containing a Django ``Form`` object, in addition to the usual ``page`` variable. A very basic template for the form would thus be:
 

--- a/wagtail/tests/testapp/models.py
+++ b/wagtail/tests/testapp/models.py
@@ -29,7 +29,7 @@ from wagtail.wagtailcore.blocks import CharBlock, RichTextBlock
 from wagtail.wagtailcore.fields import RichTextField, StreamField
 from wagtail.wagtailcore.models import Orderable, Page, PageManager
 from wagtail.wagtaildocs.edit_handlers import DocumentChooserPanel
-from wagtail.wagtailforms.models import AbstractEmailForm, AbstractFormField, AbstractFormSubmission
+from wagtail.wagtailforms.models import FormPageMixin, AbstractEmailForm, AbstractFormSubmission, AbstractFormField
 from wagtail.wagtailimages.blocks import ImageChooserBlock
 from wagtail.wagtailimages.edit_handlers import ImageChooserPanel
 from wagtail.wagtailimages.models import AbstractImage, Image

--- a/wagtail/wagtailforms/models.py
+++ b/wagtail/wagtailforms/models.py
@@ -128,7 +128,7 @@ def get_form_types():
     if _FORM_CONTENT_TYPES is None:
         form_models = [
             model for model in get_page_models()
-            if issubclass(model, AbstractForm)
+            if issubclass(model, FormPageMixin)
         ]
 
         _FORM_CONTENT_TYPES = list(
@@ -151,9 +151,10 @@ def get_forms_for_user(user):
     return editable_forms
 
 
-class AbstractForm(Page):
+class FormPageMixin(object):
     """
-    A Form Page. Pages implementing a form should inherit from it
+    A mixin class that includes form handling. Pages implementing a form should
+    inherit from it.
     """
 
     form_builder = FormBuilder
@@ -161,7 +162,7 @@ class AbstractForm(Page):
     base_form_class = WagtailAdminFormPageForm
 
     def __init__(self, *args, **kwargs):
-        super(AbstractForm, self).__init__(*args, **kwargs)
+        super(FormPageMixin, self).__init__(*args, **kwargs)
         if not hasattr(self, 'landing_page_template'):
             name, ext = os.path.splitext(self.template)
             self.landing_page_template = name + '_landing' + ext
@@ -269,12 +270,18 @@ class AbstractForm(Page):
                 self.get_context(request)
             )
         else:
-            return super(AbstractForm, self).serve_preview(request, mode)
+            return super(FormPageMixin, self).serve_preview(request, mode)
 
 
-class AbstractEmailForm(AbstractForm):
+class AbstractForm(FormPageMixin, Page):
+    class Meta:
+        abstract = True
+
+
+class AbstractEmailForm(FormPageMixin, Page):
     """
-    A Form Page that sends email. Pages implementing a form to be send to an email should inherit from it
+    A Page class that includes form handling for sending emails.
+    Pages implementing a form that sends email should inherit from this.
     """
 
     to_address = models.CharField(


### PR DESCRIPTION
- Since AbstractForm inherited from Page, any custom Page subclass couldn't use it.
- Changing it to a mixin allows subclasses of Page to gain Form Builder.
### TODO
- ~~Write tests~~
### Testing
- Run tests: `python runtests.py wagtail.wagtailforms`
- Create a Page class that inherits from Page and the mixin with the form fields related and the appropriate template files made:

``` python
from modelcluster.fields import ParentalKey
from wagtail.wagtailcore.models import Page
from wagtail.wagtailforms.models import FormPageMixin, AbstractFormField

class FormField(AbstractFormField):
    page = ParentalKey('FormPage', related_name='form_fields')

class FormPage(FormPageMixin, Page):
    content_panels = Page.content_panels + [
        InlinePanel('form_fields', label="Form fields")
    ]
```
- Create migration file, run the migration, and login to the admin
- Add a page with fields and test the page to make sure it submits properly.
### Other notes

This spawned from a discussion on [this thread](https://groups.google.com/forum/#!topic/wagtail-developers/K4_LGKzO8gE) where @gasman encouraged a pull request for it.
