### PR TITLE
Adds support for custom date and datetime formats (#2595)

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,7 @@ Changelog
 1.7 (xx.xx.xxxx)
 ~~~~~~~~~~~~~~~~
 
+ * Added support for custom date and datetime formats (Bojan Mihelac)
  * Elasticsearch 2 support (Karl Hobley)
  * Added support for AWS CloudFront in frontend cache invalidation module (Rob Moorman)
  * Unpublishing a page now gives the option to unpublish subpages too (Jordi Joan)

--- a/docs/advanced_topics/settings.rst
+++ b/docs/advanced_topics/settings.rst
@@ -362,7 +362,8 @@ Date and DateTime inputs
     WAGTAIL_DATE_FORMAT = '%d.%m.%Y.'
     WAGTAIL_DATETIME_FORMAT = '%d.%m.%Y. %H:%M'
 
-Allows using of custom date and datetime formats in wagtail inputs.
+
+Allows the use of custom date and datetime formats in Wagtail inputs.
 
 
 URL Patterns

--- a/docs/advanced_topics/settings.rst
+++ b/docs/advanced_topics/settings.rst
@@ -354,6 +354,17 @@ When enabled Wagtail shows where a particular image, document or snippet is bein
 
     The usage count only applies to direct (database) references. Using documents, images and snippets within StreamFields or rich text fields will not be taken into account.
 
+Date and DateTime inputs
+------------------------
+
+.. code-block:: python
+
+    WAGTAIL_DATE_FORMAT = '%d.%m.%Y.'
+    WAGTAIL_DATETIME_FORMAT = '%d.%m.%Y. %H:%M'
+
+Allows using of custom date and datetime formats in wagtail inputs.
+
+
 URL Patterns
 ~~~~~~~~~~~~
 

--- a/docs/topics/streamfield.rst
+++ b/docs/topics/streamfield.rst
@@ -157,7 +157,16 @@ DateBlock
 
 ``wagtail.wagtailcore.blocks.DateBlock``
 
-A date picker. The keyword arguments ``required`` and ``help_text`` are accepted.
+A date picker. The keyword arguments ``required``, ``help_text``, ``format``, ``input_formats`` and ``js_format`` are accepted.
+
+``format`` (default: None)
+  Date format. If not specifed Wagtail will use ``WAGTAIL_DATE_FORMAT`` setting with failback to '%Y-%m-%d'.
+
+``js_format`` (default: None)
+  Javascript datepicker format. Leave empty for automatic conversion.
+
+``input_formats`` (default: None)
+  Input formats to be passed to django field.
 
 TimeBlock
 ~~~~~~~~~
@@ -171,7 +180,16 @@ DateTimeBlock
 
 ``wagtail.wagtailcore.blocks.DateTimeBlock``
 
-A combined date / time picker. The keyword arguments ``required`` and ``help_text`` are accepted.
+A combined date / time picker. The keyword arguments ``required``, ``help_text``, ``format``, ``input_formats`` and ``js_format`` are accepted.
+
+``format`` (default: None)
+  Date format. If not specifed Wagtail will use ``WAGTAIL_DATETIME_FORMAT`` setting with failback to '%Y-%m-%d %H:%M'.
+
+``js_format`` (default: None)
+  Javascript datepicker format. Leave empty for automatic conversion.
+
+``input_formats`` (default: None)
+  Input formats to be passed to django field.
 
 RichTextBlock
 ~~~~~~~~~~~~~

--- a/wagtail/wagtailadmin/datetimepicker.py
+++ b/wagtail/wagtailadmin/datetimepicker.py
@@ -1,0 +1,39 @@
+from __future__ import absolute_import, unicode_literals
+
+
+# Adapted from https://djangosnippets.org/snippets/10563/
+# original author bernd-wechner
+def to_datetimepicker_format(python_format_string):
+    """
+    Given a python datetime format string, attempts to convert it to
+    the nearest PHP datetime format string possible.
+    """
+    python2PHP = {
+        "%a": "D",
+        "%A": "l",
+        "%b": "M",
+        "%B": "F",
+        "%c": "",
+        "%d": "d",
+        "%H": "H",
+        "%I": "h",
+        "%j": "z",
+        "%m": "m",
+        "%M": "i",
+        "%p": "A",
+        "%S": "s",
+        "%U": "",
+        "%w": "w",
+        "%W": "W",
+        "%x": "",
+        "%X": "",
+        "%y": "y",
+        "%Y": "Y",
+        "%Z": "e",
+    }
+
+    php_format_string = python_format_string
+    for py, php in python2PHP.items():
+        php_format_string = php_format_string.replace(py, php)
+
+    return php_format_string

--- a/wagtail/wagtailadmin/tests/test_widgets.py
+++ b/wagtail/wagtailadmin/tests/test_widgets.py
@@ -88,18 +88,18 @@ class TestAdminDateInput(TestCase):
         widget = widgets.AdminDateInput(format='%d.%m.%Y.', js_format='d.m.Y.')
 
         js_init = widget.render_js_init('test-id', 'test', None)
-        self.assertEqual(
+        self.assertIn(
+            '"format": "d.m.Y."',
             js_init,
-            'initDateChooser("test-id", {"dayOfWeekStart": 0, "format": "d.m.Y."});'
         )
 
     def test_render_js_init_with_format(self):
         widget = widgets.AdminDateInput(format='%d.%m.%Y.')
 
         js_init = widget.render_js_init('test-id', 'test', None)
-        self.assertEqual(
+        self.assertIn(
+            '"format": "d.m.Y."',
             js_init,
-            'initDateChooser("test-id", {"dayOfWeekStart": 0, "format": "d.m.Y."});'
         )
 
     @override_settings(WAGTAIL_DATE_FORMAT='%d.%m.%Y.')
@@ -107,9 +107,9 @@ class TestAdminDateInput(TestCase):
         widget = widgets.AdminDateInput()
 
         js_init = widget.render_js_init('test-id', 'test', None)
-        self.assertEqual(
+        self.assertIn(
+            '"format": "d.m.Y."',
             js_init,
-            'initDateChooser("test-id", {"dayOfWeekStart": 0, "format": "d.m.Y."});'
         )
 
 
@@ -125,17 +125,18 @@ class TestAdminDateTimeInput(TestCase):
         widget = widgets.AdminDateTimeInput(format='%d.%m.%Y. %H:%M')
 
         js_init = widget.render_js_init('test-id', 'test', None)
-        self.assertEqual(
+        self.assertIn(
+            '"format": "d.m.Y. H:i"',
             js_init,
-            'initDateTimeChooser("test-id", {"dayOfWeekStart": 0, "format": "d.m.Y. H:i"});'
         )
+
 
     @override_settings(WAGTAIL_DATETIME_FORMAT='%d.%m.%Y. %H:%M')
     def test_render_js_init_with_format_from_settings(self):
         widget = widgets.AdminDateTimeInput()
 
         js_init = widget.render_js_init('test-id', 'test', None)
-        self.assertEqual(
+        self.assertIn(
+            '"format": "d.m.Y. H:i"',
             js_init,
-            'initDateTimeChooser("test-id", {"dayOfWeekStart": 0, "format": "d.m.Y. H:i"});'
         )

--- a/wagtail/wagtailadmin/tests/test_widgets.py
+++ b/wagtail/wagtailadmin/tests/test_widgets.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 
 from django.test import TestCase
+from django.test.utils import override_settings
 
 from wagtail.tests.testapp.models import EventPage, SimplePage
 from wagtail.wagtailadmin import widgets
@@ -72,4 +73,69 @@ class TestAdminPageChooserWidget(TestCase):
         js_init = widget.render_js_init('test-id', 'test', self.child_page)
         self.assertEqual(
             js_init, "createPageChooser(\"test-id\", [\"wagtailcore.page\"], %d, true);" % self.root_page.id
+        )
+
+
+class TestAdminDateInput(TestCase):
+
+    def test_render_js_init(self):
+        widget = widgets.AdminDateInput()
+
+        js_init = widget.render_js_init('test-id', 'test', None)
+        self.assertEqual(js_init, 'initDateChooser("test-id", {"dayOfWeekStart": 0});')
+
+    def test_render_js_init_with_format_and_js_format(self):
+        widget = widgets.AdminDateInput(format='%d.%m.%Y.', js_format='d.m.Y.')
+
+        js_init = widget.render_js_init('test-id', 'test', None)
+        self.assertEqual(
+            js_init,
+            'initDateChooser("test-id", {"dayOfWeekStart": 0, "format": "d.m.Y."});'
+        )
+
+    def test_render_js_init_with_format(self):
+        widget = widgets.AdminDateInput(format='%d.%m.%Y.')
+
+        js_init = widget.render_js_init('test-id', 'test', None)
+        self.assertEqual(
+            js_init,
+            'initDateChooser("test-id", {"dayOfWeekStart": 0, "format": "d.m.Y."});'
+        )
+
+    @override_settings(WAGTAIL_DATE_FORMAT='%d.%m.%Y.')
+    def test_render_js_init_with_format_from_settings(self):
+        widget = widgets.AdminDateInput()
+
+        js_init = widget.render_js_init('test-id', 'test', None)
+        self.assertEqual(
+            js_init,
+            'initDateChooser("test-id", {"dayOfWeekStart": 0, "format": "d.m.Y."});'
+        )
+
+
+class TestAdminDateTimeInput(TestCase):
+
+    def test_render_js_init(self):
+        widget = widgets.AdminDateTimeInput()
+
+        js_init = widget.render_js_init('test-id', 'test', None)
+        self.assertEqual(js_init, 'initDateTimeChooser("test-id", {"dayOfWeekStart": 0});')
+
+    def test_render_js_init_with_format(self):
+        widget = widgets.AdminDateTimeInput(format='%d.%m.%Y. %H:%M')
+
+        js_init = widget.render_js_init('test-id', 'test', None)
+        self.assertEqual(
+            js_init,
+            'initDateTimeChooser("test-id", {"dayOfWeekStart": 0, "format": "d.m.Y. H:i"});'
+        )
+
+    @override_settings(WAGTAIL_DATETIME_FORMAT='%d.%m.%Y. %H:%M')
+    def test_render_js_init_with_format_from_settings(self):
+        widget = widgets.AdminDateTimeInput()
+
+        js_init = widget.render_js_init('test-id', 'test', None)
+        self.assertEqual(
+            js_init,
+            'initDateTimeChooser("test-id", {"dayOfWeekStart": 0, "format": "d.m.Y. H:i"});'
         )

--- a/wagtail/wagtailadmin/widgets.py
+++ b/wagtail/wagtailadmin/widgets.py
@@ -16,9 +16,9 @@ from django.utils.translation import ugettext_lazy as _
 from taggit.forms import TagWidget
 
 from wagtail.utils.widgets import WidgetWithScript
+from wagtail.wagtailadmin.datetimepicker import to_datetimepicker_format
 from wagtail.wagtailcore import hooks
 from wagtail.wagtailcore.models import Page
-from wagtail.wagtailadmin.datetimepicker import to_datetimepicker_format
 
 
 DEFAULT_DATE_FORMAT = '%Y-%m-%d'

--- a/wagtail/wagtailcore/blocks/field_block.py
+++ b/wagtail/wagtailcore/blocks/field_block.py
@@ -214,14 +214,23 @@ class BooleanBlock(FieldBlock):
 
 class DateBlock(FieldBlock):
 
-    def __init__(self, required=True, help_text=None, **kwargs):
+    def __init__(self, required=True, help_text=None, format=None, js_format=None,
+                 **kwargs):
         self.field_options = {'required': required, 'help_text': help_text}
+        try:
+            self.field_options['input_formats'] = kwargs.pop('input_formats')
+        except KeyError:
+            pass
+        self.format = format
+        self.js_format = js_format
         super(DateBlock, self).__init__(**kwargs)
 
     @cached_property
     def field(self):
         from wagtail.wagtailadmin.widgets import AdminDateInput
-        field_kwargs = {'widget': AdminDateInput}
+        field_kwargs = {
+            'widget': AdminDateInput(format=self.format, js_format=self.js_format),
+        }
         field_kwargs.update(self.field_options)
         return forms.DateField(**field_kwargs)
 
@@ -265,12 +274,20 @@ class DateTimeBlock(FieldBlock):
 
     def __init__(self, required=True, help_text=None, **kwargs):
         self.field_options = {'required': required, 'help_text': help_text}
+        try:
+            self.field_options['input_formats'] = kwargs.pop('input_formats')
+        except KeyError:
+            pass
         super(DateTimeBlock, self).__init__(**kwargs)
 
     @cached_property
     def field(self):
         from wagtail.wagtailadmin.widgets import AdminDateTimeInput
-        field_kwargs = {'widget': AdminDateTimeInput}
+        field_kwargs = {
+            'widget': AdminDateTimeInput(format=self.format, js_format=self.js_format),
+        }
+        if self.format:
+            field_kwargs['format'] = self.format
         field_kwargs.update(self.field_options)
         return forms.DateTimeField(**field_kwargs)
 

--- a/wagtail/wagtailcore/blocks/field_block.py
+++ b/wagtail/wagtailcore/blocks/field_block.py
@@ -272,12 +272,15 @@ class TimeBlock(FieldBlock):
 
 class DateTimeBlock(FieldBlock):
 
-    def __init__(self, required=True, help_text=None, **kwargs):
+    def __init__(self, required=True, help_text=None, format=None, js_format=None,
+                 **kwargs):
         self.field_options = {'required': required, 'help_text': help_text}
         try:
             self.field_options['input_formats'] = kwargs.pop('input_formats')
         except KeyError:
             pass
+        self.format = format
+        self.js_format = js_format
         super(DateTimeBlock, self).__init__(**kwargs)
 
     @cached_property
@@ -286,8 +289,6 @@ class DateTimeBlock(FieldBlock):
         field_kwargs = {
             'widget': AdminDateTimeInput(format=self.format, js_format=self.js_format),
         }
-        if self.format:
-            field_kwargs['format'] = self.format
         field_kwargs.update(self.field_options)
         return forms.DateTimeField(**field_kwargs)
 

--- a/wagtail/wagtailcore/tests/test_blocks.py
+++ b/wagtail/wagtailcore/tests/test_blocks.py
@@ -6,8 +6,8 @@ import collections
 import json
 import unittest
 import warnings
-from decimal import Decimal
 from datetime import date
+from decimal import Decimal
 
 # non-standard import name for ugettext_lazy, to prevent strings from being picked up for translation
 from django import forms

--- a/wagtail/wagtailcore/tests/test_blocks.py
+++ b/wagtail/wagtailcore/tests/test_blocks.py
@@ -6,7 +6,7 @@ import collections
 import json
 import unittest
 import warnings
-from datetime import date
+from datetime import date, datetime
 from decimal import Decimal
 
 # non-standard import name for ugettext_lazy, to prevent strings from being picked up for translation
@@ -2134,6 +2134,22 @@ class TestDateBlock(TestCase):
         )
         self.assertInHTML(
             '<input id="dateblock" name="dateblock" placeholder="" type="text" value="13.08.2015" />',
+            result
+        )
+
+
+class TestDateTimeBlock(TestCase):
+
+    def test_render_form_with_format(self):
+        block = blocks.DateTimeBlock(format='%d.%m.%Y %H:%M')
+        value = datetime(2015, 8, 13, 10, 0)
+        result = block.render_form(value, prefix='datetimeblock')
+        self.assertIn(
+            '"format": "d.m.Y H:i"',
+            result
+        )
+        self.assertInHTML(
+            '<input id="datetimeblock" name="datetimeblock" placeholder="" type="text" value="13.08.2015 10:00" />',
             result
         )
 

--- a/wagtail/wagtailcore/tests/test_blocks.py
+++ b/wagtail/wagtailcore/tests/test_blocks.py
@@ -2129,10 +2129,10 @@ class TestDateBlock(TestCase):
         value = date(2015, 8, 13)
         result = block.render_form(value, prefix='dateblock')
         self.assertIn(
-            '<script>initDateChooser("dateblock", {"dayOfWeekStart": 0, "format": "d.m.Y"});</script>',
+            '"format": "d.m.Y"',
             result
         )
-        self.assertIn(
+        self.assertInHTML(
             '<input id="dateblock" name="dateblock" placeholder="" type="text" value="13.08.2015" />',
             result
         )

--- a/wagtail/wagtailcore/tests/test_blocks.py
+++ b/wagtail/wagtailcore/tests/test_blocks.py
@@ -7,6 +7,7 @@ import json
 import unittest
 import warnings
 from decimal import Decimal
+from datetime import date
 
 # non-standard import name for ugettext_lazy, to prevent strings from being picked up for translation
 from django import forms
@@ -2106,6 +2107,35 @@ class TestPageChooserBlock(TestCase):
 
         self.assertEqual(nonrequired_block.clean(christmas_page), christmas_page)
         self.assertEqual(nonrequired_block.clean(None), None)
+
+
+class TestDateBlock(TestCase):
+
+    def test_render_form(self):
+        block = blocks.DateBlock()
+        value = date(2015, 8, 13)
+        result = block.render_form(value, prefix='dateblock')
+        self.assertIn(
+            '<script>initDateChooser("dateblock", {"dayOfWeekStart": 0});</script>',
+            result
+        )
+        self.assertIn(
+            '<input id="dateblock" name="dateblock" placeholder="" type="text" value="2015-08-13" />',
+            result
+        )
+
+    def test_render_form_with_format(self):
+        block = blocks.DateBlock(format='%d.%m.%Y')
+        value = date(2015, 8, 13)
+        result = block.render_form(value, prefix='dateblock')
+        self.assertIn(
+            '<script>initDateChooser("dateblock", {"dayOfWeekStart": 0, "format": "d.m.Y"});</script>',
+            result
+        )
+        self.assertIn(
+            '<input id="dateblock" name="dateblock" placeholder="" type="text" value="13.08.2015" />',
+            result
+        )
 
 
 class TestSystemCheck(TestCase):


### PR DESCRIPTION
It is possible to set default format for date/datetime inputs. This works together
with standard django localization.

```
# django settings
USE_I18N = True
LANGUAGE_CODE = 'sl'

# wagtail settings
WAGTAIL_DATE_FORMAT = '%d.%m.%Y.'
WAGTAIL_DATETIME_FORMAT = '%d.%m.%Y. %H:%M'
```

DateBlock, DateTimeBlock accepts additional keyword arguments:
`format`, `input_formats` and `js_format`. `js_format` is automatically
converted fro `format` when possible.
