### PR TITLE
[WIP] Elasticsearch highlighting

### DIFF
--- a/wagtail/wagtailsearch/backends/elasticsearch.py
+++ b/wagtail/wagtailsearch/backends/elasticsearch.py
@@ -458,7 +458,7 @@ class ElasticsearchSearchResults(BaseSearchResults):
         return body
 
     def _get_content_type(self, content_type):
-        app_label, model = content_type.rsplit('_', 2)[1:]
+        app_label, model = content_type.rsplit('_', 2)[-2:]
 
         return ContentType.objects.get_by_natural_key(app_label, model)
 

--- a/wagtail/wagtailsearch/backends/elasticsearch.py
+++ b/wagtail/wagtailsearch/backends/elasticsearch.py
@@ -444,7 +444,7 @@ class ElasticsearchSearchResults(BaseSearchResults):
             if sort is not None:
                 body['sort'] = sort
 
-            if self.highlight_params['fields']:
+            if self.highlight_params.get('fields'):
                 highlight = {
                     'fields': self.highlight_params['fields'].values(),
                 }
@@ -483,7 +483,7 @@ class ElasticsearchSearchResults(BaseSearchResults):
             pks.append(pk)
 
             # Get highlight
-            for field_name, field_def in self.highlight_params['fields'].items():
+            for field_name, field_def in self.highlight_params.get('fields', {}).items():
                 field_column_name = field_def.keys()[0]
 
                 field_highlight = highlight.get(pk, {})

--- a/wagtail/wagtailsearch/backends/elasticsearch.py
+++ b/wagtail/wagtailsearch/backends/elasticsearch.py
@@ -412,6 +412,8 @@ class ElasticsearchSearchResults(BaseSearchResults):
         for field_def in fields:
             field_name = field_def.keys()[0] if isinstance(field_def, dict) and len(field_def) else None
             if field_name:
+                # Use wildcard column name on request. This allows us to query against all content types.
+                # Alternative solution: get all indexed models and add all possible column names into request.
                 field_column_name = '*{}'.format(field_name)
                 post_processed_field_def = {
                     field_column_name: field_def[field_name]
@@ -439,6 +441,7 @@ class ElasticsearchSearchResults(BaseSearchResults):
             if sort is not None:
                 body['sort'] = sort
 
+            # Add highlighting into a body, if fields are specified
             if self.highlight_params.get('fields'):
                 highlight = {
                     'fields': self.highlight_params['fields'].values(),
@@ -490,6 +493,7 @@ class ElasticsearchSearchResults(BaseSearchResults):
 
             fields_to_highlight = self.highlight_params.get('fields', {}).keys()
             if fields_to_highlight:
+                # TODO: replace specific_class with content type. Doesn't work with non-Page models
                 obj_model = obj.specific_class
                 obj_mapping = self.backend.mapping_class(obj_model)
                 searchable_search_fields = {f.field_name: f for f in obj_model.get_searchable_search_fields()}

--- a/wagtail/wagtailsearch/backends/elasticsearch2.py
+++ b/wagtail/wagtailsearch/backends/elasticsearch2.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
+from django.contrib.contenttypes.models import ContentType
 from wagtail.wagtailsearch.index import FilterField, RelatedFields, SearchField
 
 from .elasticsearch import (
@@ -121,7 +122,11 @@ class Elasticsearch2SearchQuery(ElasticsearchSearchQuery):
 
 
 class Elasticsearch2SearchResults(ElasticsearchSearchResults):
-    pass
+
+    def _get_content_type(self, content_type):
+        app_label, model = content_type.split('.')
+
+        return ContentType.objects.get_by_natural_key(app_label.lower(), model.lower())
 
 
 class Elasticsearch2SearchBackend(ElasticsearchSearchBackend):

--- a/wagtail/wagtailsearch/tests/test_elasticsearch2_backend.py
+++ b/wagtail/wagtailsearch/tests/test_elasticsearch2_backend.py
@@ -582,6 +582,9 @@ class TestElasticsearch2SearchResults(TestCase):
                         '_type': 'searchtests_searchtest',
                         'fields': {
                             'pk': [str(result)],
+                            'content_type': [
+                                'searchtests.SearchTest'
+                            ]
                         }
                     }
                     for result in results
@@ -604,7 +607,7 @@ class TestElasticsearch2SearchResults(TestCase):
             from_=0,
             body={'query': 'QUERY'},
             _source=False,
-            fields='pk',
+            fields=['pk', 'content_type'],
             index='wagtail__searchtests_searchtest'
         )
 
@@ -620,7 +623,7 @@ class TestElasticsearch2SearchResults(TestCase):
             from_=10,
             body={'query': 'QUERY'},
             _source=False,
-            fields='pk',
+            fields=['pk', 'content_type'],
             index='wagtail__searchtests_searchtest',
             size=1
         )
@@ -636,7 +639,7 @@ class TestElasticsearch2SearchResults(TestCase):
             from_=1,
             body={'query': 'QUERY'},
             _source=False,
-            fields='pk',
+            fields=['pk', 'content_type'],
             index='wagtail__searchtests_searchtest',
             size=3
         )
@@ -652,7 +655,7 @@ class TestElasticsearch2SearchResults(TestCase):
             from_=10,
             body={'query': 'QUERY'},
             _source=False,
-            fields='pk',
+            fields=['pk', 'content_type'],
             index='wagtail__searchtests_searchtest',
             size=10
         )
@@ -669,7 +672,7 @@ class TestElasticsearch2SearchResults(TestCase):
             from_=20,
             body={'query': 'QUERY'},
             _source=False,
-            fields='pk',
+            fields=['pk', 'content_type'],
             index='wagtail__searchtests_searchtest',
             size=1
         )

--- a/wagtail/wagtailsearch/tests/test_elasticsearch_backend.py
+++ b/wagtail/wagtailsearch/tests/test_elasticsearch_backend.py
@@ -583,6 +583,9 @@ class TestElasticsearchSearchResults(TestCase):
                         '_type': 'searchtests_searchtest',
                         'fields': {
                             'pk': [str(result)],
+                            'content_type': [
+                                'searchtests_searchtest'
+                            ]
                         }
                     }
                     for result in results
@@ -605,7 +608,7 @@ class TestElasticsearchSearchResults(TestCase):
             from_=0,
             body={'query': 'QUERY'},
             _source=False,
-            fields='pk',
+            fields=['pk', 'content_type'],
             index='wagtail'
         )
 
@@ -621,7 +624,7 @@ class TestElasticsearchSearchResults(TestCase):
             from_=10,
             body={'query': 'QUERY'},
             _source=False,
-            fields='pk',
+            fields=['pk', 'content_type'],
             index='wagtail',
             size=1
         )
@@ -637,7 +640,7 @@ class TestElasticsearchSearchResults(TestCase):
             from_=1,
             body={'query': 'QUERY'},
             _source=False,
-            fields='pk',
+            fields=['pk', 'content_type'],
             index='wagtail',
             size=3
         )
@@ -653,7 +656,7 @@ class TestElasticsearchSearchResults(TestCase):
             from_=10,
             body={'query': 'QUERY'},
             _source=False,
-            fields='pk',
+            fields=['pk', 'content_type'],
             index='wagtail',
             size=10
         )
@@ -670,7 +673,7 @@ class TestElasticsearchSearchResults(TestCase):
             from_=20,
             body={'query': 'QUERY'},
             _source=False,
-            fields='pk',
+            fields=['pk', 'content_type'],
             index='wagtail',
             size=1
         )


### PR DESCRIPTION
A new method to Elasticsearch 1/2 backends that allows to highlight search results.

Usage example:

``` python
search_query = 'Wagtail'
search_results = Page.objects.live().search(search_query)
search_results = search_results.highlight(
    fields={
        'title': {},
        'body': {},
    },
    require_field_match=False
)
```

How to access highlighted fields:

``` python
search_result.title_highlight
search_result.body_highlight
```

Notes:
1. Both `search_result.title_highlight` and `search_result.body_highlight` may be `None`.
2. Highlighted fields may contain invalid html. It seems to me that implementor should decide how to work with these fields. For example, he can remove invalid tags like this:
   
   ``` python
   for search_result in search_results:
       if search_result.title_highlight:
           search_result.title_highlight = str(BeautifulSoup(search_result.title_highlight, 'html.parser'))
   
       if search_result.body_highlight:
           search_result.body_highlight = str(BeautifulSoup(search_result.body_highlight, 'html.parser'))
   ```

---

PR needs tests. I'll add them, when we are happy with the approach.

Topics for discussion:
1. In the current implementation (24ad275) it's possible to query on `Page`'s `QuerySet` and highlight fields for `EventPage`, for example. Do we need this feature?
2. Would be great to be able to specify a name of an attribute where to set highlighted text. But the current implementation (24ad275) we can pass fields as pure dict which gives us ability to use any [Elasticsearch parameters for highlighting](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-highlighting.html). If we want to set target attribute, we probably need another representation of fields for `highlight` method.
