### PR TITLE
Adds password validation

### DIFF
--- a/wagtail/wagtailusers/forms.py
+++ b/wagtail/wagtailusers/forms.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, unicode_literals
 
 from itertools import groupby
 
-from django import VERSION as django_version
+import django
 from django import forms
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -20,8 +20,7 @@ from wagtail.wagtailcore.models import (
 from wagtail.wagtailusers.models import UserProfile
 
 
-DJANGO_GTE_1_9 = django_version >= (1, 9)
-if DJANGO_GTE_1_9:
+if django.VERSION >= (1, 9):
     from django.contrib.auth.password_validation import (
         password_validators_help_text_html, validate_password
     )
@@ -97,7 +96,7 @@ class UserForm(UsernameForm):
         if self.password_required:
             self.fields['password1'].help_text = (
                 mark_safe(password_validators_help_text_html())
-                if DJANGO_GTE_1_9 else '')
+                if django.VERSION >= (1, 9) else '')
             self.fields['password1'].required = True
             self.fields['password2'].required = True
 
@@ -124,7 +123,7 @@ class UserForm(UsernameForm):
 
     def clean_password1(self):
         password = self.cleaned_data.get('password1')
-        if DJANGO_GTE_1_9 and password:
+        if django.VERSION >= (1, 9) and password:
             validate_password(password, user=self.instance)
         return password
 

--- a/wagtail/wagtailusers/forms.py
+++ b/wagtail/wagtailusers/forms.py
@@ -68,7 +68,7 @@ class UserForm(UsernameForm):
     password_required = True
 
     error_messages = {
-        'duplicate_username': _('A user with that username already exists.'),
+        'duplicate_username': _("A user with that username already exists."),
         'password_mismatch': _("The two password fields didn't match."),
     }
 
@@ -79,11 +79,11 @@ class UserForm(UsernameForm):
     password1 = forms.CharField(
         label=_('Password'), required=False,
         widget=forms.PasswordInput,
-        help_text=_('Leave blank if not changing.'))
+        help_text=_("Leave blank if not changing."))
     password2 = forms.CharField(
-        label=_('Password confirmation'), required=False,
+        label=_("Password confirmation"), required=False,
         widget=forms.PasswordInput,
-        help_text=_('Enter the same password as above, for verification.'))
+        help_text=_("Enter the same password as above, for verification."))
 
     is_superuser = forms.BooleanField(
         label=_("Administrator"), required=False,
@@ -128,8 +128,8 @@ class UserForm(UsernameForm):
         return password
 
     def clean_password2(self):
-        password1 = self.cleaned_data.get('password1')
-        password2 = self.cleaned_data.get('password2')
+        password1 = self.cleaned_data.get("password1")
+        password2 = self.cleaned_data.get("password2")
         if password2 != password1:
             self.add_error('password2', forms.ValidationError(
                 self.error_messages['password_mismatch'],

--- a/wagtail/wagtailusers/forms.py
+++ b/wagtail/wagtailusers/forms.py
@@ -2,7 +2,8 @@ from __future__ import absolute_import, unicode_literals
 
 from itertools import groupby
 
-from django import forms, VERSION as django_version
+from django import VERSION as django_version
+from django import forms
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group, Permission

--- a/wagtail/wagtailusers/forms.py
+++ b/wagtail/wagtailusers/forms.py
@@ -54,34 +54,94 @@ class UsernameForm(forms.ModelForm):
         return User.USERNAME_FIELD not in standard_fields
 
 
-class UserCreationForm(UsernameForm):
+class UserForm(UsernameForm):
     required_css_class = "required"
 
+    password_required = True
+
     error_messages = {
-        'duplicate_username': _("A user with that username already exists."),
+        'duplicate_username': _('A user with that username already exists.'),
         'password_mismatch': _("The two password fields didn't match."),
     }
 
-    is_superuser = forms.BooleanField(
-        label=_("Administrator"),
-        required=False,
-        help_text=_("Administrators have full access to manage any object or setting.")
-    )
+    email = forms.EmailField(required=True, label=_('Email'))
+    first_name = forms.CharField(required=True, label=_('First Name'))
+    last_name = forms.CharField(required=True, label=_('Last Name'))
 
     password1 = forms.CharField(
-        label=_("Password"),
-        required=False,
+        label=_('Password'), required=False,
         widget=forms.PasswordInput,
-        help_text=_("Leave blank if not changing."))
+        help_text=_('Leave blank if not changing.'))
     password2 = forms.CharField(
-        label=_("Password confirmation"), required=False,
+        label=_('Password confirmation'), required=False,
         widget=forms.PasswordInput,
-        help_text=_("Enter the same password as above, for verification."))
+        help_text=_('Enter the same password as above, for verification.'))
 
-    email = forms.EmailField(required=True, label=_("Email"))
-    first_name = forms.CharField(required=True, label=_("First Name"))
-    last_name = forms.CharField(required=True, label=_("Last Name"))
+    is_superuser = forms.BooleanField(
+        label=_("Administrator"), required=False,
+        help_text=_('Administrators have full access to manage any object '
+                    'or setting.'))
 
+    def __init__(self, *args, **kwargs):
+        super(UserForm, self).__init__(*args, **kwargs)
+
+        if self.password_required:
+            self.fields['password1'].help_text = ''
+            self.fields['password1'].required = True
+            self.fields['password2'].required = True
+
+    # We cannot call this method clean_username since this the name of the
+    # username field may be different, so clean_username would not be reliably
+    # called. We therefore call _clean_username explicitly in _clean_fields.
+    def _clean_username(self):
+        username_field = User.USERNAME_FIELD
+        # This method is called even if username if empty, contrary to clean_*
+        # methods, so we have to check again here that data is defined.
+        if username_field not in self.cleaned_data:
+            return
+        username = self.cleaned_data[username_field]
+
+        users = User._default_manager.all()
+        if self.instance.pk is not None:
+            users = users.exclude(pk=self.instance.pk)
+        if users.filter(**{username_field: username}).exists():
+            self.add_error(User.USERNAME_FIELD, forms.ValidationError(
+                self.error_messages['duplicate_username'],
+                code='duplicate_username',
+            ))
+        return username
+
+    def clean_password2(self):
+        password1 = self.cleaned_data.get('password1')
+        password2 = self.cleaned_data.get('password2')
+        if password2 != password1:
+            self.add_error('password2', forms.ValidationError(
+                self.error_messages['password_mismatch'],
+                code='password_mismatch',
+            ))
+        return password2
+
+    def _clean_fields(self):
+        super(UserForm, self)._clean_fields()
+        self._clean_username()
+
+    def save(self, commit=True):
+        user = super(UserForm, self).save(commit=False)
+
+        password = self.cleaned_data['password1']
+        if password:
+            user.set_password(password)
+
+        # Superusers can always access the admin interface.
+        user.is_staff = user.is_superuser
+
+        if commit:
+            user.save()
+            self.save_m2m()
+        return user
+
+
+class UserCreationForm(UserForm):
     class Meta:
         model = User
         fields = set([User.USERNAME_FIELD]) | standard_fields | custom_fields
@@ -89,70 +149,9 @@ class UserCreationForm(UsernameForm):
             'groups': forms.CheckboxSelectMultiple
         }
 
-    def clean_username(self):
-        username_field = User.USERNAME_FIELD
-        username = self.cleaned_data[username_field]
-        try:
-            User._default_manager.get(**{username_field: username})
-        except User.DoesNotExist:
-            return username
-        raise forms.ValidationError(
-            self.error_messages['duplicate_username'],
-            code='duplicate_username',
-        )
 
-    def clean_password2(self):
-        password1 = self.cleaned_data.get("password1")
-        password2 = self.cleaned_data.get("password2")
-        if password1 and password2 and password1 != password2:
-            raise forms.ValidationError(
-                self.error_messages['password_mismatch'],
-                code='password_mismatch',
-            )
-        return password2
-
-    def save(self, commit=True):
-        user = super(UserCreationForm, self).save(commit=False)
-        user.set_password(self.cleaned_data["password1"])
-
-        # users can access django-admin iff they are a superuser
-        user.is_staff = user.is_superuser
-
-        if commit:
-            user.save()
-            self.save_m2m()
-        return user
-
-
-# Largely the same as django.contrib.auth.forms.UserCreationForm, but with enough subtle changes
-# (to make password non-required) that it isn't worth inheriting...
-class UserEditForm(UsernameForm):
-    required_css_class = "required"
-
-    error_messages = {
-        'duplicate_username': _("A user with that username already exists."),
-        'password_mismatch': _("The two password fields didn't match."),
-    }
-
-    email = forms.EmailField(required=True, label=_("Email"))
-    first_name = forms.CharField(required=True, label=_("First Name"))
-    last_name = forms.CharField(required=True, label=_("Last Name"))
-
-    password1 = forms.CharField(
-        label=_("Password"),
-        required=False,
-        widget=forms.PasswordInput,
-        help_text=_("Leave blank if not changing."))
-    password2 = forms.CharField(
-        label=_("Password confirmation"), required=False,
-        widget=forms.PasswordInput,
-        help_text=_("Enter the same password as above, for verification."))
-
-    is_superuser = forms.BooleanField(
-        label=_("Administrator"),
-        required=False,
-        help_text=_("Administrators have full access to manage any object or setting.")
-    )
+class UserEditForm(UserForm):
+    password_required = False
 
     class Meta:
         model = User
@@ -160,39 +159,6 @@ class UserEditForm(UsernameForm):
         widgets = {
             'groups': forms.CheckboxSelectMultiple
         }
-
-    def clean_username(self):
-        # Since User.username is unique, this check is redundant,
-        # but it sets a nicer error message than the ORM. See #13147.
-        username = self.cleaned_data["username"]
-        username_field = User.USERNAME_FIELD
-        try:
-            User._default_manager.exclude(pk=self.instance.pk).get(**{
-                username_field: username})
-        except User.DoesNotExist:
-            return username
-        raise forms.ValidationError(self.error_messages['duplicate_username'])
-
-    def clean_password2(self):
-        password1 = self.cleaned_data.get("password1")
-        password2 = self.cleaned_data.get("password2")
-        if password1 != password2:
-            raise forms.ValidationError(
-                self.error_messages['password_mismatch'])
-        return password2
-
-    def save(self, commit=True):
-        user = super(UserEditForm, self).save(commit=False)
-
-        # users can access django-admin iff they are a superuser
-        user.is_staff = user.is_superuser
-
-        if self.cleaned_data["password1"]:
-            user.set_password(self.cleaned_data["password1"])
-        if commit:
-            user.save()
-            self.save_m2m()
-        return user
 
 
 class GroupForm(forms.ModelForm):


### PR DESCRIPTION
As discussed in #3005, this pull request adds password validation to the user creation and edit forms.

I also took the liberty to factorize the two forms, since they were mostly copies of each other. The only difference is that I marked the password fields as required in the creation form, and I removed the “Leave blank if not changing.” on that same form. It was possible to create a user account without a password and I removed this possibility, but it seemed to be a bug, because the message “Leave blank if not changing.” was not consistent with a creation form…

Unfortunately, there is a small bug remaining concerning the password change form: when `AUTH_PASSWORD_VALIDATORS` is set,  [Django sets the help text with HTML](https://github.com/django/django/blob/4b9330ccc04575f9e5126529ec355a450d12e77c/django/contrib/auth/forms.py#L82) but doesn’t mark it as safe, so we see HTML tags.
