### PR TITLE
added support for elasticsearch mapper-attachments (v1.7 and 2.x)

### DIFF
--- a/docs/topics/search/indexing.rst
+++ b/docs/topics/search/indexing.rst
@@ -97,6 +97,9 @@ Options
  - **boost** (``int/float``) - This allows you to set fields as being more important than others. Setting this to a high number on a field will cause pages with matches in that field to be ranked higher. By default, this is set to 2 on the Page title field and 1 on all other fields.
  - **es_extra** (``dict``) - This field is to allow the developer to set or override any setting on the field in the ElasticSearch mapping. Use this if you want to make use of any ElasticSearch features that are not yet supported in Wagtail.
 
+ .. note::
+
+      To index django's ``FileFields`` you need to install the ``mapper-attachments`` plugin for ElasticSearch. For Version >= 5 this has been renamed to ``ingest-attachment`` and not yet been tested.
 
 ``index.FilterField``
 ---------------------

--- a/wagtail/wagtailsearch/index.py
+++ b/wagtail/wagtailsearch/index.py
@@ -1,16 +1,17 @@
 from __future__ import absolute_import, unicode_literals
 
+import base64
 import inspect
 import logging
 
 from django.apps import apps
 from django.core import checks
 from django.db import models
+from django.db.models import FileField
 from django.db.models.fields import FieldDoesNotExist
 from django.db.models.fields.related import ForeignObjectRel, OneToOneRel, RelatedField
 
 from wagtail.wagtailsearch.backends import get_search_backends_with_name
-
 
 logger = logging.getLogger('wagtail.search.index')
 
@@ -203,6 +204,8 @@ class BaseField(object):
         try:
             field = self.get_field(obj.__class__)
             value = field.value_from_object(obj)
+            if isinstance(field, FileField):
+                value = base64.b64encode(obj.file.file.read()).decode()
             if hasattr(field, 'get_searchable_content'):
                 value = field.get_searchable_content(value)
             return value


### PR DESCRIPTION
to full-text index PDFs and such, one can now just install
ElasticSearch's mapper-attachment
(https://www.elastic.co/guide/en/elasticsearch/plugins/master/mapper-attachments.html)

this replaces issue #2992 
