### PR TITLE
Pass parent context into block's get_context method

### DIFF
--- a/wagtail/wagtailcore/blocks/base.py
+++ b/wagtail/wagtailcore/blocks/base.py
@@ -226,15 +226,17 @@ class Block(six.with_metaclass(BaseBlock, object)):
         """
         return value
 
-    def get_context(self, value):
+    def get_context(self, value, context=None):
         """
         Return a dict of context variables (derived from the block value, or otherwise)
         to be added to the template context when rendering this value through a template.
         """
-        return {
+        context = context or {}
+        context.update({
             'self': value,
             self.TEMPLATE_VAR: value,
-        }
+        })
+        return context
 
     def _render_with_context(self, value, context=None):
         """
@@ -282,8 +284,7 @@ class Block(six.with_metaclass(BaseBlock, object)):
         if context is None:
             new_context = self.get_context(value)
         else:
-            new_context = dict(context)
-            new_context.update(self.get_context(value))
+            new_context = self.get_context(value, dict(context))
 
         return mark_safe(render_to_string(template, new_context))
 


### PR DESCRIPTION
Having access to the page context inside the `get_context` method is
useful in some situations. Prior to this, one would need to override
`render` to use the page context.

My use case was a block that showed a list of recent pages. These were added via `get_context` but I needed to exclude the current page the block is displayed on if it was in the list. It makes more sense to have all the context be available in `get_context` rather than some getting injected in inside the `render` method.

Existing tests pass. Happy to add docs and/or tests if this is a welcome contribution.

See also #2786 
