### PR TITLE
Return a 403 response for unauthenticated ajax requests

### DIFF
--- a/wagtail/wagtailadmin/tests/test_account_management.py
+++ b/wagtail/wagtailadmin/tests/test_account_management.py
@@ -113,6 +113,16 @@ class TestAuthentication(TestCase, WagtailTestUtils):
         # Check that the user was redirected to the login page and that next was set correctly
         self.assertRedirects(response, reverse('wagtailadmin_login') + '?next=' + reverse('wagtailadmin_home'))
 
+    def test_not_logged_in_gives_403_to_ajax_requests(self):
+        """
+        This tests that a not logged in user is given a 403 error on AJAX requests
+        """
+        # Get dashboard
+        response = self.client.get(reverse('wagtailadmin_home'), HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+
+        # AJAX requests should be given a 403 error instead of being redirected
+        self.assertEqual(response.status_code, 403)
+
     def test_not_logged_in_redirect_default_settings(self):
         """
         This does the same as the above test but checks that it
@@ -144,6 +154,21 @@ class TestAuthentication(TestCase, WagtailTestUtils):
         # Check that the user was redirected to the login page and that next was set correctly
         self.assertRedirects(response, reverse('wagtailadmin_login') + '?next=' + reverse('wagtailadmin_home'))
         self.assertContains(response, 'You do not have permission to access the admin')
+
+    def test_logged_in_no_permission_gives_403_to_ajax_requests(self):
+        """
+        This tests that a logged in user without admin access permissions is
+        given a 403 error on ajax requests
+        """
+        # Login as unprivileged user
+        get_user_model().objects.create_user(username='unprivileged', password='123')
+        self.assertTrue(self.client.login(username='unprivileged', password='123'))
+
+        # Get dashboard
+        response = self.client.get(reverse('wagtailadmin_home'), HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+
+        # AJAX requests should be given a 403 error instead of being redirected
+        self.assertEqual(response.status_code, 403)
 
 
 class TestAccountSection(TestCase, WagtailTestUtils):

--- a/wagtail/wagtailadmin/tests/tests.py
+++ b/wagtail/wagtailadmin/tests/tests.py
@@ -252,6 +252,14 @@ class TestUserPassesTestPermissionDecorator(TestCase):
         response = self.client.get(reverse('testapp_bob_only_zone'))
         self.assertRedirects(response, reverse('wagtailadmin_home'))
 
+    def test_user_fails_test_ajax(self):
+        # create and log in as a user not called Bob
+        get_user_model().objects.create_superuser(first_name='Vic', last_name='Reeves', username='test', email='test@email.com', password='password')
+        self.assertTrue(self.client.login(username='test', password='password'))
+
+        response = self.client.get(reverse('testapp_bob_only_zone'), HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        self.assertEqual(response.status_code, 403)
+
 
 class TestUserHasAnyPagePermission(TestCase):
     def test_superuser(self):

--- a/wagtail/wagtailadmin/utils.py
+++ b/wagtail/wagtailadmin/utils.py
@@ -6,6 +6,7 @@ from functools import wraps
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
+from django.core.exceptions import PermissionDenied
 from django.core.mail import send_mail as django_send_mail
 from django.db.models import Count, Q
 from django.shortcuts import redirect
@@ -81,6 +82,9 @@ def users_with_page_permission(page, permission_type, include_superusers=True):
 
 def permission_denied(request):
     """Return a standard 'permission denied' response"""
+    if request.is_ajax():
+        raise PermissionDenied
+
     from wagtail.wagtailadmin import messages
 
     messages.error(request, _('Sorry, you do not have permission to access this area.'))


### PR DESCRIPTION
At the moment, Wagtail redirects all requests (including AJAX) to the
login view. This is not usually the expected thing to do for AJAX and can
lead to the login page being nested in a component somewhere (which
looks horrible).

This changes the behaviour so requests that come from AJAX are given a
plain 403 error. This allows the code that performed the request to
handle the issue properly.
