### PR TITLE
Remove explorer, page search for users with no page permissions

### DIFF
--- a/wagtail/wagtailadmin/templates/wagtailadmin/base.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/base.html
@@ -11,14 +11,7 @@
                 <span>{% trans "Dashboard" %}</span>
             </a>
 
-            <form class="nav-search" action="{% url 'wagtailadmin_pages:search' %}" method="get">
-                <div>
-                    <label for="menu-search-q">{% trans "Search" %}</label>
-                    <input type="text" id="menu-search-q" name="q" placeholder="{% trans 'Search' %}" />
-                    <button class="button" type="submit">{% trans "Search" %}</button>
-                </div>
-            </form>
-
+            {% menu_search %}
             {% main_nav %}
         </div>
 

--- a/wagtail/wagtailadmin/templates/wagtailadmin/shared/menu_search.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/shared/menu_search.html
@@ -1,0 +1,10 @@
+{% load i18n %}
+
+<form class="nav-search" action="{{ search_url }}" method="get">
+    <div>
+        <label for="menu-search-q">{% trans "Search" %}</label>
+        <input type="text" id="menu-search-q" name="q" placeholder="{% trans 'Search' %}" />
+        <button class="button" type="submit">{% trans "Search" %}</button>
+    </div>
+</form>
+

--- a/wagtail/wagtailadmin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/wagtailadmin/templatetags/wagtailadmin_tags.py
@@ -8,6 +8,7 @@ from django.conf import settings
 from django.contrib.humanize.templatetags.humanize import intcomma
 from django.contrib.messages.constants import DEFAULT_TAGS as MESSAGE_TAGS
 from django.template.defaultfilters import stringfilter
+from django.template.loader import render_to_string
 from django.utils.html import conditional_escape
 from django.utils.safestring import mark_safe
 
@@ -42,6 +43,20 @@ def explorer_subnav(nodes):
     return {
         'nodes': nodes
     }
+
+
+@register.simple_tag(takes_context=True)
+def menu_search(context):
+    request = context['request']
+
+    search_areas = admin_search_areas.search_items_for_request(request)
+    if not search_areas:
+        return ''
+    search_area = search_areas[0]
+
+    return render_to_string('wagtailadmin/shared/menu_search.html', {
+        'search_url': search_area.url,
+    })
 
 
 @register.inclusion_tag('wagtailadmin/shared/main_nav.html', takes_context=True)

--- a/wagtail/wagtailadmin/tests/test_admin_search.py
+++ b/wagtail/wagtailadmin/tests/test_admin_search.py
@@ -1,0 +1,120 @@
+"""
+Tests for the search box in the admin side menu, and the custom search hooks.
+"""
+from __future__ import absolute_import, unicode_literals
+
+from django.contrib.auth.models import Permission
+from django.core.urlresolvers import reverse
+from django.template import Context, Template
+from django.test import RequestFactory, TestCase
+
+from wagtail.tests.utils import WagtailTestUtils
+from wagtail.wagtailadmin.utils import user_has_any_page_permission
+from wagtail.wagtailcore.models import Site
+
+
+class BaseSearchAreaTestCase(WagtailTestUtils, TestCase):
+    rf = RequestFactory()
+
+    def search_other(self, current_url='/admin/', data=None):
+        request = self.rf.get(current_url, data=data)
+        request.user = self.user
+        request.site = Site.objects.get()
+        template = Template("{% load wagtailadmin_tags %}{% search_other %}")
+        return template.render(Context({'request': request}))
+
+    def menu_search(self, current_url='/admin/', data=None):
+        request = self.rf.get(current_url, data=data)
+        request.user = self.user
+        request.site = Site.objects.get()
+        template = Template("{% load wagtailadmin_tags %}{% menu_search %}")
+        return template.render(Context({'request': request}))
+
+
+class TestSearchAreas(BaseSearchAreaTestCase):
+    def setUp(self):
+        super(TestSearchAreas, self).setUp()
+        self.user = self.login()
+
+    def test_other_searches(self):
+        search_url = reverse('wagtailadmin_pages:search')
+        query = "Hello"
+        base_css = "icon icon-custom"
+        test_string = '<a href="/customsearch/?q=%s" class="%s" is-custom="true">My Search</a>'
+        # Testing the option link exists
+        response = self.client.get(search_url, {'q': query})
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'wagtailadmin/pages/search.html')
+        self.assertTemplateUsed(response, 'wagtailadmin/shared/search_area.html')
+        self.assertTemplateUsed(response, 'wagtailadmin/shared/search_other.html')
+        self.assertContains(response, test_string % (query, base_css), html=True)
+
+        # Testing is_shown
+        response = self.client.get(search_url, {'q': query, 'hide-option': "true"})
+        self.assertNotContains(response, test_string % (query, base_css), status_code=200, html=True)
+
+        # Testing is_active
+        response = self.client.get(search_url, {'q': query, 'active-option': "true"})
+        self.assertContains(response, test_string % (query, base_css + " nolink"), status_code=200, html=True)
+
+    def test_menu_search(self):
+        rendered = self.menu_search()
+        self.assertIn(reverse('wagtailadmin_pages:search'), rendered)
+
+    def test_search_other(self):
+        rendered = self.search_other()
+        self.assertIn(reverse('wagtailadmin_pages:search'), rendered)
+        self.assertIn('/customsearch/', rendered)
+
+        self.assertIn('Pages', rendered)
+        self.assertIn('My Search', rendered)
+
+
+class TestSearchAreaNoPagePermissions(BaseSearchAreaTestCase):
+    """
+    Test the admin search when the user does not have permission to manage
+    pages. The search bar should show the first available search area instead.
+    """
+    def setUp(self):
+        self.user = self.login()
+        self.assertFalse(user_has_any_page_permission(self.user))
+
+    def create_test_user(self):
+        user = super(TestSearchAreaNoPagePermissions, self).create_test_user()
+        user.is_superuser = False
+        user.user_permissions.add(
+            Permission.objects.get(content_type__app_label='wagtailadmin', codename='access_admin')
+        )
+        user.save()
+        return user
+
+    def test_dashboard(self):
+        """
+        Check that the menu search area on the dashboard is not searching
+        pages, as they are not allowed.
+        """
+        response = self.client.get('/admin/')
+        # The menu search bar should go to /customsearch/, not /admin/pages/search/
+        self.assertNotContains(response, reverse('wagtailadmin_pages:search'))
+        self.assertContains(response, 'action="/customsearch/"')
+
+    def test_menu_search(self):
+        """
+        The search form should go to the custom search, not the page search.
+        """
+        rendered = self.menu_search()
+        self.assertNotIn(reverse('wagtailadmin_pages:search'), rendered)
+        self.assertIn('action="/customsearch/"', rendered)
+
+    def test_search_other(self):
+        """The pages search link should be hidden."""
+        rendered = self.search_other()
+        self.assertNotIn(reverse('wagtailadmin_pages:search'), rendered)
+        self.assertIn('/customsearch/', rendered)
+
+        self.assertNotIn('Pages', rendered)
+        self.assertIn('My Search', rendered)
+
+    def test_no_searches(self):
+        rendered = self.menu_search(data={'hide-option': 'true'})
+        self.assertEqual(rendered, '')

--- a/wagtail/wagtailadmin/tests/test_explorer_nav.py
+++ b/wagtail/wagtailadmin/tests/test_explorer_nav.py
@@ -146,10 +146,8 @@ class TestExplorerNavView(TestCase, WagtailTestUtils):
         self.assertEqual(response.context['nodes'][0][0], Page.objects.get(id=2).specific)
         self.assertEqual(len(response.context['nodes'][0][1]), 0)
 
-    def test_nonadmin_with_no_page_perms_sees_nothing_in_nav(self):
+    def test_nonadmin_with_no_page_perms_is_redirected(self):
         self.assertTrue(self.client.login(username='mary', password='password'))
         response = self.client.get(reverse('wagtailadmin_explorer_nav'))
 
-        self.assertEqual(response.status_code, 200)
-        # Being in no Groups, Mary should ot be shown any nodes.
-        self.assertEqual(len(response.context['nodes']), 0)
+        self.assertRedirects(response, reverse('wagtailadmin_home'))

--- a/wagtail/wagtailadmin/tests/test_pages_views.py
+++ b/wagtail/wagtailadmin/tests/test_pages_views.py
@@ -1865,8 +1865,7 @@ class TestPageDelete(TestCase, WagtailTestUtils):
 
 class TestPageSearch(TestCase, WagtailTestUtils):
     def setUp(self):
-        # Login
-        self.login()
+        self.user = self.login()
 
     def get(self, params=None, **extra):
         return self.client.get(reverse('wagtailadmin_pages:search'), params or {}, **extra)
@@ -1929,24 +1928,14 @@ class TestPageSearch(TestCase, WagtailTestUtils):
         results = response.context['pages']
         self.assertTrue(any([r.slug == 'root' for r in results]))
 
-    def test_other_searches(self):
-        query = "Hello"
-        base_css = "icon icon-custom"
-        test_string = '<a href="/customsearch/?q=%s" class="%s" is-custom="true">My Search</a>'
-        # Testing the option link exists
-        response = self.get({'q': query})
-        self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, 'wagtailadmin/pages/search.html')
-        self.assertTemplateUsed(response, 'wagtailadmin/shared/search_area.html')
-        self.assertContains(response, test_string % (query, base_css), html=True)
-
-        # Testing is_shown
-        response = self.get({'q': query, 'hide-option': "true"})
-        self.assertNotContains(response, test_string % (query, base_css), status_code=200, html=True)
-
-        # Testing is_active
-        response = self.get({'q': query, 'active-option': "true"})
-        self.assertContains(response, test_string % (query, base_css + " nolink"), status_code=200, html=True)
+    def test_search_no_perms(self):
+        self.user.is_superuser = False
+        self.user.user_permissions.add(
+            Permission.objects.get(content_type__app_label='wagtailadmin', codename='access_admin')
+        )
+        self.user.save()
+        response = self.get()
+        self.assertRedirects(response, '/admin/')
 
 
 class TestPageMove(TestCase, WagtailTestUtils):

--- a/wagtail/wagtailadmin/utils.py
+++ b/wagtail/wagtailadmin/utils.py
@@ -234,3 +234,27 @@ def send_notification(page_revision_id, notification, excluded_user_id):
             )
 
     return sent_count == len(email_recipients)
+
+
+def user_has_any_page_permission(user):
+    """
+    Check if a user has any permission to add, edit, or otherwise manage any
+    page.
+    """
+    # Can't do nothin if you're not active.
+    if not user.is_active:
+        return False
+
+    # Superusers can do anything.
+    if user.is_superuser:
+        return True
+
+    # At least one of the users groups has a GroupPagePermission.
+    # The user can probably do something.
+    if GroupPagePermission.objects.filter(group__in=user.groups.all()).exists():
+        return True
+
+    # Specific permissions for a page type do not mean anything.
+
+    # No luck! This user can not do anything with pages.
+    return False

--- a/wagtail/wagtailadmin/views/pages.py
+++ b/wagtail/wagtailadmin/views/pages.py
@@ -18,7 +18,8 @@ from wagtail.utils.pagination import paginate
 from wagtail.wagtailadmin import messages, signals
 from wagtail.wagtailadmin.forms import CopyForm, SearchForm
 from wagtail.wagtailadmin.navigation import get_navigation_menu_items
-from wagtail.wagtailadmin.utils import send_notification
+from wagtail.wagtailadmin.utils import (
+    send_notification, user_has_any_page_permission, user_passes_test)
 from wagtail.wagtailcore import hooks
 from wagtail.wagtailcore.models import Page, PageRevision, UserPagePermissionsProxy
 
@@ -880,6 +881,7 @@ def copy(request, page_id):
 
 
 @vary_on_headers('X-Requested-With')
+@user_passes_test(user_has_any_page_permission)
 def search(request):
     pages = []
     q = None

--- a/wagtail/wagtailadmin/views/pages.py
+++ b/wagtail/wagtailadmin/views/pages.py
@@ -31,12 +31,14 @@ def get_valid_next_url_from_request(request):
     return next_url
 
 
+@user_passes_test(user_has_any_page_permission)
 def explorer_nav(request):
     return render(request, 'wagtailadmin/shared/explorer_nav.html', {
         'nodes': get_navigation_menu_items(request.user),
     })
 
 
+@user_passes_test(user_has_any_page_permission)
 def index(request, parent_page_id=None):
     if parent_page_id:
         parent_page = get_object_or_404(Page, id=parent_page_id).specific
@@ -805,6 +807,7 @@ def set_page_position(request, page_to_move_id):
     return HttpResponse('')
 
 
+@user_passes_test(user_has_any_page_permission)
 def copy(request, page_id):
     page = Page.objects.get(id=page_id)
 
@@ -1019,6 +1022,7 @@ def unlock(request, page_id):
         return redirect('wagtailadmin_explore', page.get_parent().id)
 
 
+@user_passes_test(user_has_any_page_permission)
 def revisions_index(request, page_id):
     page = get_object_or_404(Page, id=page_id).specific
 
@@ -1078,6 +1082,7 @@ def revisions_revert(request, page_id, revision_id):
     })
 
 
+@user_passes_test(user_has_any_page_permission)
 def revisions_view(request, page_id, revision_id):
     page = get_object_or_404(Page, id=page_id).specific
     revision = get_object_or_404(page.revisions, id=revision_id)

--- a/wagtail/wagtaildocs/wagtail_hooks.py
+++ b/wagtail/wagtaildocs/wagtail_hooks.py
@@ -84,6 +84,11 @@ class DocumentsSummaryItem(SummaryItem):
             'total_docs': get_document_model().objects.count(),
         }
 
+    def is_shown(self):
+        return permission_policy.user_has_any_permission(
+            self.request.user, ['add', 'change', 'delete']
+        )
+
 
 @hooks.register('construct_homepage_summary_items')
 def add_documents_summary_item(request, items):

--- a/wagtail/wagtailimages/wagtail_hooks.py
+++ b/wagtail/wagtailimages/wagtail_hooks.py
@@ -94,6 +94,11 @@ class ImagesSummaryItem(SummaryItem):
             'total_images': get_image_model().objects.count(),
         }
 
+    def is_shown(self):
+        return permission_policy.user_has_any_permission(
+            self.request.user, ['add', 'change', 'delete']
+        )
+
 
 @hooks.register('construct_homepage_summary_items')
 def add_images_summary_item(request, items):


### PR DESCRIPTION
For a site we are making, we have two classes of users: content editor who can edit pages and other content, and researchers who can only edit some specific models through modeladmin views. This PR removes the explorer menu item and the ability to search and browse pages for users without any page editing / moderating permissions. It also changes the search in the menu to use the first available SearchArea, instead of hard coding the page search area.

Removing the explorer completely seems like it could be a controversial change. Wagtail, until recently, was all about making pages after all. Now, with the advent of model admin and other plugins that work with non-page models, making Wagtail work without pages makes sense. With the current Wagtail, a user with model admin permissions but without normal page permissions is presented with an interface that is still oriented towards pages. The first thing in the menu is a search page that searches pages. The second thing in the menu is an explorer with all of the pages. They can not do anything with these pages, so these items are mostly useless. They can aimlessly browse the explorer looking for something to do, but there is nothing. Removing the explorer in this case is user friendly. The same with the search. Any page search results are useless to them, and probably not what they are looking for anyway. Making the menu search obey the SearchArea order and pick the first `is_shown` item (or hiding itself completely if there are no `is_shown` items) helps the user again by removing functionality that is not useful to them.

Currently, it is not possible to restore the ability to browse pages to a user without other page permissions. I am not sure what the point of allowing this would be, certainly considering that some of the functionality is broken in this use case (the page copy view specifically), so I do not think that is an issue.
