### PR TITLE
Issue 278 search images and documents by tag (in db backend)

### DIFF
--- a/wagtail/tests/search/models.py
+++ b/wagtail/tests/search/models.py
@@ -16,7 +16,7 @@ class SearchTest(index.Indexed, models.Model):
     search_fields = [
         index.SearchField('title', partial_match=True),
         index.RelatedFields('tags', [
-            index.SearchField('name', partial_match=True),
+            index.SearchField('name', partial_match=True, db_search="tags__name"),
             index.FilterField('slug'),
         ]),
         index.SearchField('content'),

--- a/wagtail/wagtaildocs/models.py
+++ b/wagtail/wagtaildocs/models.py
@@ -44,7 +44,7 @@ class AbstractDocument(CollectionMember, index.Indexed, models.Model):
     search_fields = CollectionMember.search_fields + [
         index.SearchField('title', partial_match=True, boost=10),
         index.RelatedFields('tags', [
-            index.SearchField('name', partial_match=True, boost=10),
+            index.SearchField('name', partial_match=True, boost=10, db_search="tags__name"),
         ]),
         index.FilterField('uploaded_by_user'),
     ]

--- a/wagtail/wagtailimages/models.py
+++ b/wagtail/wagtailimages/models.py
@@ -155,7 +155,7 @@ class AbstractImage(CollectionMember, index.Indexed, models.Model):
     search_fields = CollectionMember.search_fields + [
         index.SearchField('title', partial_match=True, boost=10),
         index.RelatedFields('tags', [
-            index.SearchField('name', partial_match=True, boost=10),
+            index.SearchField('name', partial_match=True, boost=10, db_search="tags__name"),
         ]),
         index.FilterField('uploaded_by_user'),
     ]

--- a/wagtail/wagtailsearch/backends/db.py
+++ b/wagtail/wagtailsearch/backends/db.py
@@ -38,8 +38,10 @@ class DatabaseSearchQuery(BaseSearchQuery):
 
         if self.query_string is not None:
             # Get fields
-            fields = self.fields or [field.field_name for field in model.get_searchable_search_fields()]
-
+            fields = self.fields or [
+                field.db_search if field.db_search else field.field_name
+                for field in model.get_db_searchable_search_fields()
+            ]
             # Get terms
             terms = self.query_string.split()
             if not terms:
@@ -49,11 +51,6 @@ class DatabaseSearchQuery(BaseSearchQuery):
             for term in terms:
                 term_query = models.Q()
                 for field_name in fields:
-                    # Check if the field exists (this will filter out indexed callables)
-                    try:
-                        model._meta.get_field(field_name)
-                    except models.fields.FieldDoesNotExist:
-                        continue
 
                     # Filter on this field
                     term_query |= models.Q(**{'%s__icontains' % field_name: term})

--- a/wagtail/wagtailsearch/tests/test_backends.py
+++ b/wagtail/wagtailsearch/tests/test_backends.py
@@ -62,6 +62,7 @@ class BackendTests(WagtailTestUtils):
         testb.title = "Hello"
         testb.live = True
         testb.save()
+        testb.tags.add("tag")
         self.backend.add(testb)
         self.testb = testb
 

--- a/wagtail/wagtailsearch/tests/test_db_backend.py
+++ b/wagtail/wagtailsearch/tests/test_db_backend.py
@@ -26,3 +26,7 @@ class TestDBBackend(BackendTests, TestCase):
         for result in results:
             # DB backend doesn't do scoring, so annotate_score should just add None
             self.assertIsNone(result._score)
+
+    def test_tag_result(self):
+        results = self.backend.search("tag", models.SearchTest)
+        self.assertEqual(set(results), {self.testb})


### PR DESCRIPTION
Fix for #278 

We should probably revert https://github.com/torchbox/wagtail/pull/2026

Not sure if this needs documentation, it's meant to be used with the DB backend so
it really only applies to the Image and Document models. DB search backend doesn't
search subclasses of Page anyways. I suppose if someone wants to they can use it on
their own Indexed model but it will cost them performance as there is no queryset 
optimization going on.
