### PR TITLE
Adding the Meta attribute `group` to Blocks.

### DIFF
--- a/docs/topics/streamfield.rst
+++ b/docs/topics/streamfield.rst
@@ -64,6 +64,9 @@ All block types accept the following optional keyword arguments:
 ``template``
   The path to a Django template that will be used to render this block on the front end. See `Template rendering`_.
 
+``group``
+  The group used to categorize this block, i.e. any blocks with the same group name will be shown together in the editor interface with the group name as a heading.
+
 The basic block types provided by Wagtail are as follows:
 
 CharBlock

--- a/wagtail/wagtailadmin/templates/wagtailadmin/block_forms/stream_menu.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/block_forms/stream_menu.html
@@ -1,10 +1,14 @@
 <div class="stream-menu {% if state == 'closed' %}stream-menu-closed{% endif %}" id="{{ menu_id }}">
     <a href="#" class="toggle"><span>Insert block</span></a>
     <div class="stream-menu-inner">
-        <ul>
-            {% for child_block in child_blocks %}
-                <li><button type="button" class="button action-add-block-{{ child_block.name }} icon icon-{{ child_block.meta.icon }}"><span>{{ child_block.label }}</span></button></li>
-            {% endfor %}
-        </ul>
+        {% regroup child_blocks by meta.group as grouped_child_blocks %}
+        {% for child_blocks in grouped_child_blocks %}
+            <h3>{{child_blocks.grouper}}</h3>
+            <ul>
+                {% for child_block in child_blocks.list %}
+                    <li><button type="button" class="button action-add-block-{{ child_block.name }} icon icon-{{ child_block.meta.icon }}"><span>{{ child_block.label }}</span></button></li>
+                {% endfor %}
+            </ul>
+        {% endfor %}
     </div>
 </div>

--- a/wagtail/wagtailadmin/templates/wagtailadmin/block_forms/stream_menu.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/block_forms/stream_menu.html
@@ -3,7 +3,7 @@
     <div class="stream-menu-inner">
         {% regroup child_blocks by meta.group as grouped_child_blocks %}
         {% for child_blocks in grouped_child_blocks %}
-            <h3>{{child_blocks.grouper}}</h3>
+            {% if child_blocks.grouper %}<h3>{{child_blocks.grouper}}</h3>{% endif %}
             <ul>
                 {% for child_block in child_blocks.list %}
                     <li><button type="button" class="button action-add-block-{{ child_block.name }} icon icon-{{ child_block.meta.icon }}"><span>{{ child_block.label }}</span></button></li>

--- a/wagtail/wagtailcore/blocks/base.py
+++ b/wagtail/wagtailcore/blocks/base.py
@@ -50,6 +50,7 @@ class Block(six.with_metaclass(BaseBlock, object)):
         label = None
         icon = "placeholder"
         classname = None
+        group = ''
 
     """
     Setting a 'dependencies' list serves as a shortcut for the common case where a complex block type

--- a/wagtail/wagtailcore/blocks/stream_block.py
+++ b/wagtail/wagtailcore/blocks/stream_block.py
@@ -140,7 +140,7 @@ class BaseStreamBlock(Block):
         return render_to_string('wagtailadmin/block_forms/stream.html', {
             'prefix': prefix,
             'list_members_html': list_members_html,
-            'child_blocks': self.child_blocks.values(),
+            'child_blocks': sorted(self.child_blocks.values(), key=lambda child_block: child_block.meta.group),
             'header_menu_prefix': '%s-before' % prefix,
             'block_errors': error_dict.get(NON_FIELD_ERRORS),
         })

--- a/wagtail/wagtailcore/tests/test_blocks.py
+++ b/wagtail/wagtailcore/tests/test_blocks.py
@@ -1999,6 +1999,40 @@ class TestStreamBlock(SimpleTestCase):
         self.assertEqual(stream_value[0].block_type, 'heading')
         self.assertEqual(stream_value[0].value, 'A different default heading')
 
+    def test_render_considers_group_attribute(self):
+        """If group attributes are set in Block Meta classes, render a <h3> for each different block"""
+
+        class Group1Block1(blocks.CharBlock):
+            class Meta:
+                group = 'group1'
+
+        class Group1Block2(blocks.CharBlock):
+            class Meta:
+                group = 'group1'
+
+        class Group2Block1(blocks.CharBlock):
+            class Meta:
+                group = 'group2'
+
+        class Group2Block2(blocks.CharBlock):
+            class Meta:
+                group = 'group2'
+
+        class NoGroupBlock(blocks.CharBlock):
+            pass
+
+        block = blocks.StreamBlock([
+            ('b1', Group1Block1()),
+            ('b2', Group1Block2()),
+            ('b3', Group2Block1()),
+            ('b4', Group2Block2()),
+            ('ngb', NoGroupBlock()),
+        ])
+        html = block.render_form('')
+        self.assertNotIn('<h3></h3>', block.render_form(''))
+        self.assertIn('<h3>group1</h3>', html)
+        self.assertIn('<h3>group2</h3>', html)
+
 
 class TestPageChooserBlock(TestCase):
     fixtures = ['test.json']


### PR DESCRIPTION
The idea is that Streamfield-Blocks can be grouped in the CMS
by setting Meta's `group` attribute.
This gives a better overview, particularly with many blocks.
If the attribute remains unset, nothing changes.
