### PR TITLE
Increase contrast of colours to validate WCAG AA

### DIFF
--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/_variables.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/_variables.scss
@@ -27,7 +27,7 @@ $breakpoint-desktop-larger: 100em; // 1600px
 // colours
 $color-teal: #246060;
 $color-teal-darker: darken($color-teal, 10%);
-$color-teal-dark: #0F2828;
+$color-teal-dark: #0f2828;
 $color-blue: #71b2d4;
 $color-red: #cd3238;
 $color-orange: #e9b04d;

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/_variables.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/_variables.scss
@@ -25,9 +25,9 @@ $breakpoint-desktop-large: 75em; // 1200px
 $breakpoint-desktop-larger: 100em; // 1600px
 
 // colours
-$color-teal: #43b1b0;
+$color-teal: #246060;
 $color-teal-darker: darken($color-teal, 10%);
-$color-teal-dark: #246060;
+$color-teal-dark: #0F2828;
 $color-blue: #71b2d4;
 $color-red: #cd3238;
 $color-orange: #e9b04d;
@@ -45,10 +45,10 @@ $color-grey-3: #d9d9d9;
 $color-grey-4: #e6e6e6;
 $color-grey-5: #fafafa;
 
-$color-menu-text: #cacaca; // was #aaa wich was too low contrast
+$color-menu-text: #cacaca;
 
 $color-thead-bg: $color-grey-5;
-$color-header-bg: $color-teal; // #ff6a58;
+$color-header-bg: $color-teal;
 $color-fieldset-hover: $color-grey-5;
 $color-input-border: $color-grey-4;
 $color-input-focus: #f4fcfc;
@@ -61,6 +61,7 @@ $color-button-no: $color-red;
 $color-button-no-hover: darken($color-button-no, 20%);
 $color-button-warning: $color-orange;
 $color-button-warning-hover: darken($color-orange, 20%);
+$color-button-warning-text: $color-grey-1;
 $color-link: $color-teal;
 $color-link-hover: $color-teal-dark;
 

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_dropdowns.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_dropdowns.scss
@@ -216,6 +216,7 @@
 
     .dropdown-toggle {
         background-color: $color-button-warning;
+        color: $color-button-warning-text;
 
         &:hover {
             background-color: $color-button-warning-hover;

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_forms.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_forms.scss
@@ -255,10 +255,11 @@ input[type=checkbox]:checked:before {
     &.warning {
         background-color: $color-button-warning;
         border: 1px solid $color-button-warning;
+        color: $color-button-warning-text;
 
         &.button-secondary {
             border: 1px solid $color-button-warning;
-            color: $color-button-warning;
+            color: darken($color-button-warning, 40%);
             background-color: transparent;
         }
 
@@ -269,7 +270,7 @@ input[type=checkbox]:checked:before {
         }
 
         &.button-nobg:hover {
-            color: $color-button-warning;
+            color: darken($color-button-warning, 40%);
             background-color: transparent;
         }
     }

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_listing.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_listing.scss
@@ -427,6 +427,7 @@ table.listing {
         }
 
         .privacy-indicator {
+            color: $color-white;
             font-size: 1em;
             opacity: 1;
             position: absolute;

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_messages.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_messages.scss
@@ -44,11 +44,17 @@
     }
 
     .warning {
-        background-color: $color-orange;
-
+        background-color: $color-button-warning;
+        color: $color-button-warning-text;
         &:before {
             font-family: wagtail;
             content: '!';
+        }
+        .avatar {
+            &:before {
+                color: $color-button-warning-text;
+                border: 1px solid $color-button-warning-text;
+            }
         }
     }
 

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_messages.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_messages.scss
@@ -46,10 +46,12 @@
     .warning {
         background-color: $color-button-warning;
         color: $color-button-warning-text;
+
         &:before {
             font-family: wagtail;
             content: '!';
         }
+
         .avatar {
             &:before {
                 color: $color-button-warning-text;

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/core.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/core.scss
@@ -221,7 +221,7 @@ footer {
                 content: 'n';
                 padding-left: 20px;
                 font-size: 2em;
-                color: lighten($color-teal, 10%)!important;
+                color: lighten($color-teal, 10%);
                 line-height: 0.9em;
             }
         }

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/core.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/core.scss
@@ -221,7 +221,7 @@ footer {
                 content: 'n';
                 padding-left: 20px;
                 font-size: 2em;
-                color: $color-teal-darker;
+                color: lighten($color-teal, 10%)!important;
                 line-height: 0.9em;
             }
         }


### PR DESCRIPTION
This is a pull request for issue #2224.

Wagtail doesn't currently validate against WCAG colour contrast guidelines. In 1.7 @strindhaug   improved the contrast in PR #2985, which helps but doesn't solve the problem with the background colour within headers and on revision pages (or any page where the warning button is displayed).

@alexgleason and I had previously worked on a [pip installable module](https://pypi.python.org/pypi/wagtailatomicadmin/) to get round this problem, and some others, on certain projects, but it used some horrible hacks to get around this particular issue, and was a very brittle solution to the problem.

The proposed solution is to use the existing `$color-teal-dark` as `$color-teal` and change `$color-teal-dark` to `#0F2828`.

**Explorer page with breadcrumb**
<img width="1426" alt="capture d ecran 2016-10-25 a 07 20 33" src="https://cloud.githubusercontent.com/assets/11335309/19675259/2801d6ac-9a85-11e6-977d-a72c14d9931e.png">

**Revision page**
<img width="1429" alt="capture d ecran 2016-10-25 a 07 20 00" src="https://cloud.githubusercontent.com/assets/11335309/19675262/2a93d014-9a85-11e6-877b-b736353014ab.png">
