### PR TITLE
Fix issue #3085 -- 'Parent' link in page chooser search should not navigate away

### DIFF
--- a/wagtail/wagtailadmin/templates/wagtailadmin/chooser/browse.js
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/chooser/browse.js
@@ -68,6 +68,12 @@ function(modal) {
             $('.page-results', modal.body).load(this.href, ajaxifySearchResults);
             return false;
         });
+        /* Set up links to parent pages sho that they can be browsed within the
+        modal */
+        $('.page-results a.navigate-parent', modal.body).click(function() {
+            modal.loadUrl(this.href);
+            return false;
+        });
     }
 
     function ajaxifyBrowseResults() {

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/listing/_list.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/listing/_list.html
@@ -57,7 +57,7 @@
                         {% with page.get_parent as parent %}
                             <td class="parent" valign="top">
                                 {% if parent %}
-                                    <a href="{% url 'wagtailadmin_explore' parent.id %}">{{ parent.get_admin_display_title }}</a>
+                                    <a href="{% url 'wagtailadmin_choose_page_child' parent.id %}" class="navigate-parent">{{ parent.get_admin_display_title }}</a>
                                 {% endif %}
                             </td>
                         {% endwith %}


### PR DESCRIPTION
The handling of links is slightly different between `ajaxifyBrowseResults` and `ajaxifySearchResults` in browse.js so I created a new class to distinguish parent links from other links. 

Also, the naming of the url, `wagtailadmin_choose_page_child`, is slightly confusing, since it can be used to choose either a child or parent, based on what id you supply as an argument. Perhaps there should be a url called `wagtailadmin_choose_page_parent`, but it would have the same url pattern as `wagtailadmin_choose_page_child` - making it redundant.

Perhaps a new name is needed for the `r'^choose-page/(\d+)/$'` url to reflect this.
