### PR TITLE
Margin amendments

### DIFF
--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_header.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_header.scss
@@ -29,12 +29,6 @@ header {
     .col {
         float: left;
         margin-right: 2em;
-
-        // @media screen and (max-width: $breakpoint-mobile) {
-        //     // To all hamburger menu to be visible
-        //     padding-left: 2em;
-        //     margin-top: -2px;
-        // No... This fixes the snippet page but breaks all else
         }
     }
 

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_header.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_header.scss
@@ -29,6 +29,13 @@ header {
     .col {
         float: left;
         margin-right: 2em;
+
+        // @media screen and (max-width: $breakpoint-mobile) {
+        //     // To all hamburger menu to be visible
+        //     padding-left: 2em;
+        //     margin-top: -2px;
+        // No... This fixes the snippet page but breaks all else
+        }
     }
 
     .left {
@@ -53,6 +60,13 @@ header {
     &.tab-merged, 
     &.no-border {
         border: 0;
+
+        @media screen and (max-width: $breakpoint-mobile) {
+            // To all hamburger menu to be visible
+            padding-left: $desktop-nice-padding;
+            padding-top: 11px;
+        }
+
     }
 
     &.merged.no-border {
@@ -150,11 +164,6 @@ header {
 
         .col9 {
             @include column(9);
-        }
-
-        .breadcrumb {
-            margin-left: -($desktop-nice-padding);
-            margin-right: -($desktop-nice-padding);
         }
     }
 }

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_header.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_header.scss
@@ -9,7 +9,7 @@ header {
         color: $color-white;
     }
 
-    h1, 
+    h1,
     h2 {
         margin: 0;
         color: $color-white;
@@ -30,7 +30,6 @@ header {
         float: left;
         margin-right: 2em;
         }
-    }
 
     .left {
         float: left;
@@ -51,7 +50,7 @@ header {
         margin-bottom: 0;
     }
 
-    &.tab-merged, 
+    &.tab-merged,
     &.no-border {
         border: 0;
 
@@ -89,7 +88,7 @@ header {
         @include visuallyhidden();
     }
 
-    input[type=text], 
+    input[type=text],
     select {
         border-width: 0;
 
@@ -134,7 +133,7 @@ header {
         .second {
             clear: none;
 
-            .right, 
+            .right,
             .left {
                 float: right;
             }

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_listing.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_listing.scss
@@ -432,6 +432,9 @@ table.listing {
             position: absolute;
             right: 10%;
             top: 2em;
+            // @media screen and (min-width: $breakpoint-desktop-larger) {
+            //     right: 20em;
+            // }
         }
 
         .locked-indicator {
@@ -669,9 +672,6 @@ table.listing {
     .children,
     .no-children {
         @include transition(background-color 0.2s ease);
-        @media screen and (min-width: $breakpoint-desktop-larger) {
-            padding-right: 19em
-        }
     }
 
     .children a,

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_listing.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_listing.scss
@@ -430,7 +430,7 @@ table.listing {
             font-size: 1em;
             opacity: 1;
             position: absolute;
-            right: 5%;
+            right: 10%;
             top: 2em;
         }
 
@@ -669,6 +669,9 @@ table.listing {
     .children,
     .no-children {
         @include transition(background-color 0.2s ease);
+        @media screen and (min-width: $breakpoint-desktop-larger) {
+            padding-right: 19em
+        }
     }
 
     .children a,

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_listing.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_listing.scss
@@ -279,7 +279,7 @@ ul.listing {
 
     th.ord,
     &.full-width th:first-child.ord {
-        padding-left: 10px;
+        padding-left: 25px;
     }
 
     th.ord a:before {
@@ -645,7 +645,7 @@ table.listing {
 
         &.full-width td:first-child,
         &.full-width th:first-child {
-            padding-left: 50px;
+            padding-left: 25px;
         }
 
         &.full-width .divider td {
@@ -677,5 +677,12 @@ table.listing {
     .children a,
     .no-children a {
         @include transition(all 0.2s ease);
+    }
+}
+
+// Ordering
+td.ord {
+    .handle {
+    margin-top: -28px;
     }
 }

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_listing.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_listing.scss
@@ -683,6 +683,6 @@ table.listing {
 // Ordering
 td.ord {
     .handle {
-    margin-top: -28px;
+        margin-top: -28px;
     }
 }

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_messages.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_messages.scss
@@ -20,9 +20,11 @@
     }
 
     li {
-        @include nice-padding;
-        padding-top: 1.3em;
-        padding-bottom: 1.3em;
+        // @include nice-padding;
+        padding-top: 1.6em;
+        padding-right: 3em;
+        padding-bottom: 1.6em;
+        padding-left: 1.6em;
         color: $color-white;
     }
 
@@ -90,7 +92,7 @@
 
 @media screen and (min-width: $breakpoint-mobile) {
     .messages ul li {
-        padding-left: $desktop-nice-padding;
-        padding-right: $desktop-nice-padding;
+        padding-left: 1.6em;
+        padding-right: 3em;
     }
 }

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_modals.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_modals.scss
@@ -98,7 +98,13 @@ $zindex-modal-background: 500;
     padding-bottom: 2em;
 
     header {
+        padding-left: 2em;
         padding-right: 100px;
+    }
+
+    .header-title {
+        padding-left: 1em!important;
+        /* @TODO That specificity isn't working out so well... */
     }
 }
 

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_modals.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_modals.scss
@@ -103,9 +103,8 @@ $zindex-modal-background: 500;
     }
 
     .header-title {
-        padding-left: 1em!important;
-        /* We need !important as the modal is nested within the page-editor and
-        page-editor.scss is compiled after this file */
+        padding-left: 0em!important;
+        margin-left: -28px;
     }
 }
 

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_modals.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_modals.scss
@@ -103,7 +103,7 @@ $zindex-modal-background: 500;
     }
 
     .header-title {
-        padding-left: 0em!important;
+        padding-left: 0 !important;
         margin-left: -36px;
     }
 }

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_modals.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_modals.scss
@@ -104,7 +104,7 @@ $zindex-modal-background: 500;
 
     .header-title {
         padding-left: 0em!important;
-        margin-left: -28px;
+        margin-left: -36px;
     }
 }
 

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_modals.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_modals.scss
@@ -104,7 +104,8 @@ $zindex-modal-background: 500;
 
     .header-title {
         padding-left: 1em!important;
-        /* @TODO That specificity isn't working out so well... */
+        /* We need !important as the modal is nested within the page-editor and
+        page-editor.scss is compiled after this file */
     }
 }
 

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_tabs.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_tabs.scss
@@ -10,6 +10,10 @@
         padding: 0;
         position: relative;
         margin-right: 1px;
+
+        &:first-of-type {
+            padding-left: 1.2em;
+        }
     }
 
     a {
@@ -118,5 +122,9 @@
     .modal-content .tab-nav li {
         padding: 0;
         min-width: 0;
+
+        &:first-of-type {
+            padding-left: 2.5em;
+        }
     }
 }

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_tabs.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_tabs.scss
@@ -128,3 +128,14 @@
         }
     }
 }
+
+@media screen and (max-width: $breakpoint-mobile) {
+    // To allow tabs on the edit page to be editable
+    .tab-nav li:first-of-type {
+        padding-left: 1.6em;
+    }
+
+    .tab-nav li {
+        width: 25%;
+    }
+}

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/core.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/core.scss
@@ -436,6 +436,8 @@ footer,
     .breadcrumb {
         padding-top: 0;
         background: $color-teal-darker;
+        margin-left: -($desktop-nice-padding);
+        margin-right: -($desktop-nice-padding);
 
         li {
             a,
@@ -489,6 +491,12 @@ footer,
         width: 90em;
     }
 }
+
+// @media screen and (max-width: $breakpoint-mobile) {
+//     .breadcrumb {
+//         padding-left: $mobile-nice-padding;
+//     }
+// }
 
 // Transitions (resolution agnostic)
 .content-wrapper,

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/core.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/core.scss
@@ -116,7 +116,7 @@ body {
     @include row();
     background: $color-white;
     border-top: 0 solid $color-grey-5; // this top border provides space for the floating logo to toggle the menu
-    height: 100%;
+    min-height: 100%;
     padding-bottom: 4em;
     position: relative; // yuk. necessary for positions for jquery ui widgets
 }
@@ -482,7 +482,7 @@ footer,
 
 @media screen and (min-width: 90em) {
     .wrapper {
-        width: 100%;
+        // width: 100%;
     }
 
     footer {

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/core.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/core.scss
@@ -145,13 +145,13 @@ footer {
 
     .actions {
         width: 250px;
-        margin-right: $grid-gutter-width/2;
+        margin-right: $grid-gutter-width / 2;
     }
 
     .meta {
         float: right;
         text-align: right;
-        padding: 7px $grid-gutter-width/2;
+        padding: 7px $grid-gutter-width / 2;
         font-size: 0.85em;
 
         p {
@@ -491,12 +491,6 @@ footer,
         width: 90em;
     }
 }
-
-// @media screen and (max-width: $breakpoint-mobile) {
-//     .breadcrumb {
-//         padding-left: $mobile-nice-padding;
-//     }
-// }
 
 // Transitions (resolution agnostic)
 .content-wrapper,

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/core.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/core.scss
@@ -72,6 +72,8 @@ body {
 
 .wrapper {
     @include clearfix();
+    height: 100vh;
+    min-height: 800px;
     transition: transform 0.2s ease;
 }
 
@@ -114,6 +116,7 @@ body {
     @include row();
     background: $color-white;
     border-top: 0 solid $color-grey-5; // this top border provides space for the floating logo to toggle the menu
+    height: 100%;
     padding-bottom: 4em;
     position: relative; // yuk. necessary for positions for jquery ui widgets
 }
@@ -479,7 +482,7 @@ footer,
 
 @media screen and (min-width: 90em) {
     .wrapper {
-        max-width: $breakpoint-desktop-larger;
+        width: 100%;
     }
 
     footer {

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/layouts/page-editor.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/layouts/page-editor.scss
@@ -30,7 +30,7 @@
     }
 
     .header-title {
-        padding-left: 4em;
+        padding-left: 3.1em;
     }
 }
 

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/layouts/page-editor.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/layouts/page-editor.scss
@@ -31,6 +31,13 @@
 
     .header-title {
         padding-left: 3.1em;
+
+        @media screen and (max-width: $breakpoint-mobile) {
+            padding-left: 0;
+            margin-left: -28px;
+            // Because it's nested within tab-merged which we've given padding
+            // on mobile viewports due to snippets
+        }
     }
 }
 

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/layouts/page-editor.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/layouts/page-editor.scss
@@ -66,7 +66,7 @@
         position: relative;
         z-index: 1;
         top: 1em;
-        padding-right: $grid-gutter-width/2;
+        padding-right: $grid-gutter-width / 2;
         margin-top: 4em;
         opacity: 1;
         padding-left: 3em;
@@ -410,7 +410,7 @@ footer .preview {
             z-index: 1;
             right: 0;
             top: 1em;
-            padding-right: $grid-gutter-width/2;
+            padding-right: $grid-gutter-width / 2;
             float: right;
             margin-top: 4em;
             opacity: 0;

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/layouts/page-editor.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/layouts/page-editor.scss
@@ -9,7 +9,7 @@
     }
 
     .breadcrumb {
-        margin: -1.2em 0 2em 0;
+        margin: -1.2em 0 2em;
     }
 
     .modal .breadcrumb {

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/layouts/page-editor.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/layouts/page-editor.scss
@@ -9,8 +9,7 @@
     }
 
     .breadcrumb {
-        margin-top: -1.2em;
-        margin-bottom: 2em;
+        margin: -1.2em 0 2em 0;
     }
 
     .modal .breadcrumb {
@@ -28,6 +27,10 @@
         .home {
             padding-left: 0;
         }
+    }
+
+    .header-title {
+        padding-left: 4em;
     }
 }
 

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/create.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/create.html
@@ -12,7 +12,8 @@
 
         <div class="row row-flush">
             <div class="left col9 header-title">
-                <h1 class="icon icon-doc-empty-inverse">{% trans 'New' %} <span>{{ content_type.model_class.get_verbose_name }}</span></h1>
+                <h1 class="icon icon-doc-empty-inverse">
+                {% trans 'New' %} <span>{{ content_type.model_class.get_verbose_name }}</span></h1>
             </div>
         </div>
     </header>

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/create.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/create.html
@@ -7,11 +7,11 @@
 
 {% block content %}
 
-    <header class="merged tab-merged nice-padding">
+    <header class="merged tab-merged">
         {% include "wagtailadmin/shared/breadcrumb.html" with page=parent_page include_self=1 %}
 
         <div class="row row-flush">
-            <div class="left col9">
+            <div class="left col9 header-title">
                 <h1 class="icon icon-doc-empty-inverse">{% trans 'New' %} <span>{{ content_type.model_class.get_verbose_name }}</span></h1>
             </div>
         </div>

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/edit.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/edit.html
@@ -12,7 +12,8 @@
 
         <div class="row row-flush">
             <div class="left col9 header-title">
-                <h1 class="icon icon-doc-empty-inverse">{% blocktrans with title=page.get_admin_display_title page_type=content_type.model_class.get_verbose_name %}Editing {{ page_type }} <span>{{ title }}</span>{% endblocktrans %}</h1>
+                <h1 class="icon icon-doc-empty-inverse">
+                {% blocktrans with title=page.get_admin_display_title page_type=content_type.model_class.get_verbose_name %}Editing {{ page_type }} <span>{{ title }}</span>{% endblocktrans %}</h1>
             </div>
             <div class="right col3">
                 {% trans "Status" %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/edit.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/edit.html
@@ -7,11 +7,11 @@
 
 {% block content %}
     {% page_permissions page as page_perms %}
-    <header class="merged tab-merged nice-padding">
+    <header class="merged tab-merged">
         {% include "wagtailadmin/shared/breadcrumb.html" with page=page %}
 
         <div class="row row-flush">
-            <div class="left col9">
+            <div class="left col9 header-title">
                 <h1 class="icon icon-doc-empty-inverse">{% blocktrans with title=page.get_admin_display_title page_type=content_type.model_class.get_verbose_name %}Editing {{ page_type }} <span>{{ title }}</span>{% endblocktrans %}</h1>
             </div>
             <div class="right col3">

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/listing/_list.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/listing/_list.html
@@ -2,7 +2,7 @@
 {% load wagtailadmin_tags %}
 <table class="listing {% if full_width %}full-width{% endif %} {% block table_classname %}{% endblock %}">
     {% if show_ordering_column %}
-        <col width="50px" />
+        <col width="65px" />
     {% endif %}
     <col />
     {% if show_parent %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/shared/header.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/shared/header.html
@@ -20,7 +20,7 @@
 <header class="nice-padding {% if merged %}merged{% endif %} {% if tabbed %}tab-merged{% endif %} {% if search_form %}hasform{% endif %}">
     <div class="row">
         <div class="left">
-            <div class="col">
+            <div class="col header-title">
                 <h1 class="icon icon-{{ icon }}">{{ title }}{% if subtitle %} <span>{{ subtitle }}</span>{% endif %}</h1>
             </div>
             {% if search_url %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/shared/header.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/shared/header.html
@@ -18,10 +18,11 @@
     add_text - text for the 'add' button
 {% endcomment %}
 <header class="{% if merged %}merged{% endif %} {% if tabbed %}tab-merged{% endif %} {% if search_form %}hasform{% endif %}">
-    <div class="row">
+    <div class="row nice-padding">
         <div class="left">
             <div class="col header-title">
-                <h1 class="icon icon-{{ icon }}">{{ title }}{% if subtitle %} <span>{{ subtitle }}</span>{% endif %}</h1>
+                <h1 class="icon icon-{{ icon }}">
+                {{ title }}{% if subtitle %} <span>{{ subtitle }}</span>{% endif %}</h1>
             </div>
             {% if search_url %}
                 <form class="col search-form" action="{% url search_url %}{% if query_parameters %}?{{ query_parameters }}{% endif %}" method="get" novalidate>

--- a/wagtail/wagtailadmin/templates/wagtailadmin/shared/header.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/shared/header.html
@@ -17,7 +17,7 @@
     add_link - if present, display an 'add' button. This is a URL route name (taking no parameters) to be used as the link URL for the button
     add_text - text for the 'add' button
 {% endcomment %}
-<header class="nice-padding {% if merged %}merged{% endif %} {% if tabbed %}tab-merged{% endif %} {% if search_form %}hasform{% endif %}">
+<header class="{% if merged %}merged{% endif %} {% if tabbed %}tab-merged{% endif %} {% if search_form %}hasform{% endif %}">
     <div class="row">
         <div class="left">
             <div class="col header-title">

--- a/wagtail/wagtailsnippets/templates/wagtailsnippets/snippets/type_index.html
+++ b/wagtail/wagtailsnippets/templates/wagtailsnippets/snippets/type_index.html
@@ -17,8 +17,9 @@
 
     <header class="nice-padding">
         <div class="row row-flush">
-            <div class="left col9 header-title">
-                <h1 class="icon icon-snippet">{% blocktrans with snippet_type_name_plural=model_opts.verbose_name_plural|capfirst %}Snippets <span>{{ snippet_type_name_plural }}</span>{% endblocktrans %}</h1>
+            <div class="left col9 header-snippet">
+                <h1 class="icon icon-snippet">
+                {% blocktrans with snippet_type_name_plural=model_opts.verbose_name_plural|capfirst %}Snippets <span>{{ snippet_type_name_plural }}</span>{% endblocktrans %}</h1>
 
                 {% if is_searchable %}
                     <form class="col search-form" action="{% url 'wagtailsnippets:list' model_opts.app_label model_opts.model_name %}" method="get" novalidate>

--- a/wagtail/wagtailsnippets/templates/wagtailsnippets/snippets/type_index.html
+++ b/wagtail/wagtailsnippets/templates/wagtailsnippets/snippets/type_index.html
@@ -17,7 +17,7 @@
 
     <header class="nice-padding">
         <div class="row row-flush">
-            <div class="left col9">
+            <div class="left col9 header-title">
                 <h1 class="icon icon-snippet">{% blocktrans with snippet_type_name_plural=model_opts.verbose_name_plural|capfirst %}Snippets <span>{{ snippet_type_name_plural }}</span>{% endblocktrans %}</h1>
 
                 {% if is_searchable %}


### PR DESCRIPTION
There are, especially with the titles on page listing and the page editor, some very awkward margins. This is the case on both desktop and mobile. This PR seeks to vertically align the left margin between breadcrumb, title and tabs. It additionally makes the white background span the viewport on screens over 1600px.

Again, it's a PR based on some of the UI work done for the wagtailatomicadmin app @alexgleason and I were working on.

**Before**
<img width="1428" alt="capture d ecran 2016-10-27 a 20 29 25" src="https://cloud.githubusercontent.com/assets/11335309/19782748/196cfe74-9c87-11e6-9f62-b3632a8d9108.png">

**After**
<img width="1132" alt="capture d ecran 2016-10-27 a 20 20 55" src="https://cloud.githubusercontent.com/assets/11335309/19782749/1971e09c-9c87-11e6-81b2-5eceb2398bf4.png">

**Before**
<img width="1437" alt="capture d ecran 2016-10-27 a 20 28 46" src="https://cloud.githubusercontent.com/assets/11335309/19782785/4dc4aa96-9c87-11e6-9fd2-2f454427c874.png">

**After**
<img width="1427" alt="capture d ecran 2016-10-27 a 20 24 49" src="https://cloud.githubusercontent.com/assets/11335309/19782786/4dc597bc-9c87-11e6-992a-7b773a85a57a.png">

**Before**
<img width="553" alt="capture d ecran 2016-10-27 a 20 54 43" src="https://cloud.githubusercontent.com/assets/11335309/19782872/a5747e10-9c87-11e6-964c-8b68d07286bd.png">

**After**
<img width="674" alt="capture d ecran 2016-10-27 a 20 19 47" src="https://cloud.githubusercontent.com/assets/11335309/19782871/a571438a-9c87-11e6-9dbe-c1f671626923.png">

**Before**
<img width="1438" alt="capture d ecran 2016-10-27 a 20 33 57" src="https://cloud.githubusercontent.com/assets/11335309/19782726/ff882934-9c86-11e6-878d-7dde025f7731.png">

**After**
<img width="1438" alt="capture d ecran 2016-10-27 a 20 37 08" src="https://cloud.githubusercontent.com/assets/11335309/19782727/ff89bd4e-9c86-11e6-9731-919048881946.png">

I've erred on the side of being verbose with the commits but if it's better for me to rebase them then more than happy to.
