### PR TITLE
Listblock max_length min_length validation

### DIFF
--- a/docs/topics/streamfield.rst
+++ b/docs/topics/streamfield.rst
@@ -350,6 +350,8 @@ Any block type is valid as the sub-block type, including structural types:
         ('amount', blocks.CharBlock()),
     ])))
 
+The keyword arguments ``max_length`` and ``min_length`` are accepted.
+
 
 StreamBlock
 ~~~~~~~~~~~

--- a/docs/topics/streamfield.rst
+++ b/docs/topics/streamfield.rst
@@ -352,6 +352,14 @@ Any block type is valid as the sub-block type, including structural types:
 
 The keyword arguments ``max_length`` and ``min_length`` are accepted.
 
+.. code-block:: python
+
+    ('ingredients_list', blocks.ListBlock(
+        blocks.CharBlock(label="Ingredient"),
+        max_length=3,
+        min_length=1
+    ))
+
 
 StreamBlock
 ~~~~~~~~~~~

--- a/wagtail/wagtailcore/blocks/list_block.py
+++ b/wagtail/wagtailcore/blocks/list_block.py
@@ -2,23 +2,39 @@ from __future__ import absolute_import, unicode_literals
 
 from django import forms
 from django.contrib.staticfiles.templatetags.staticfiles import static
-from django.core.exceptions import ValidationError
+from django.core.exceptions import NON_FIELD_ERRORS, ValidationError
 from django.forms.utils import ErrorList
 from django.template.loader import render_to_string
 from django.utils.html import format_html, format_html_join
 from django.utils.safestring import mark_safe
+from django.utils.translation import ugettext as _
 
 from wagtail.wagtailcore.utils import escape_script
 
 from .base import Block
 from .utils import js_dict
 
-__all__ = ['ListBlock']
+__all__ = ['ListBlock', 'ListBlockValidationError']
+
+
+class ListBlockValidationError(ValidationError):
+    def __init__(self, block_errors=None, non_block_errors=None):
+        params = {}
+        if block_errors:
+            params.update(block_errors)
+        if non_block_errors:
+            params[NON_FIELD_ERRORS] = non_block_errors
+        super(ListBlockValidationError, self).__init__(
+            'Validation error in ListBlock', params=params)
 
 
 class ListBlock(Block):
 
-    def __init__(self, child_block, **kwargs):
+    def __init__(self, child_block, max_length=None, min_length=None, **kwargs):
+        self.list_options = {
+            'max_length': max_length,
+            'min_length': min_length
+        }
         super(ListBlock, self).__init__(**kwargs)
 
         if isinstance(child_block, type):
@@ -71,18 +87,17 @@ class ListBlock(Block):
         return "ListBlock(%s)" % js_dict(opts)
 
     def render_form(self, value, prefix='', errors=None):
+        error_dict = {}
         if errors:
             if len(errors) > 1:
-                # We rely on ListBlock.clean throwing a single ValidationError with a specially crafted
+                # We rely on ListBlock.clean throwing a single ListBlockValidationError with a specially crafted
                 # 'params' attribute that we can pull apart and distribute to the child blocks
                 raise TypeError('ListBlock.render_form unexpectedly received multiple errors')
-            error_list = errors.as_data()[0].params
-        else:
-            error_list = None
+            error_dict = errors.as_data()[0].params
 
         list_members_html = [
             self.render_list_member(child_val, "%s-%d" % (prefix, i), i,
-                                    errors=error_list[i] if error_list else None)
+                                    errors=error_dict.get(i))
             for (i, child_val) in enumerate(value)
         ]
 
@@ -90,6 +105,7 @@ class ListBlock(Block):
             'help_text': getattr(self.meta, 'help_text', None),
             'prefix': prefix,
             'list_members_html': list_members_html,
+            'block_errors': error_dict.get(NON_FIELD_ERRORS),
         })
 
     def value_from_datadict(self, data, files, prefix):
@@ -113,19 +129,27 @@ class ListBlock(Block):
 
     def clean(self, value):
         result = []
-        errors = []
+        errors = {}
         for child_val in value:
             try:
                 result.append(self.child_block.clean(child_val))
             except ValidationError as e:
-                errors.append(ErrorList([e]))
-            else:
-                errors.append(None)
+                errors[i] = ErrorList([e])
 
-        if any(errors):
+        max_length = self.list_options['max_length']
+        if max_length and max_length < len(value):
+            raise ListBlockValidationError(non_block_errors=ErrorList([
+                ValidationError(_("Maximum of %s is reached" % max_length))]))
+
+        min_length = self.list_options['min_length']
+        if min_length and min_length > len(value):
+            raise ListBlockValidationError(non_block_errors=ErrorList([
+                ValidationError(_("Minimum of %s is required" % min_length))]))
+
+        if errors:
             # The message here is arbitrary - outputting error messages is delegated to the child blocks,
             # which only involves the 'params' list
-            raise ValidationError('Validation error in ListBlock', params=errors)
+            raise ListBlockValidationError(block_errors=errors)
 
         return result
 

--- a/wagtail/wagtailcore/blocks/list_block.py
+++ b/wagtail/wagtailcore/blocks/list_block.py
@@ -139,16 +139,16 @@ class ListBlock(Block):
         max_length = self.list_options['max_length']
         if max_length and max_length < len(value):
             raise ListBlockValidationError(non_block_errors=ErrorList([
-                ValidationError(_("Maximum of %s is reached" % max_length))]))
+                ValidationError(_("The maximum number of items is %s" % max_length))]))
 
         min_length = self.list_options['min_length']
         if min_length and min_length > len(value):
             raise ListBlockValidationError(non_block_errors=ErrorList([
-                ValidationError(_("Minimum of %s is required" % min_length))]))
+                ValidationError(_("The minimum number of items is %s" % min_length))]))
 
         if errors:
             # The message here is arbitrary - outputting error messages is delegated to the child blocks,
-            # which only involves the 'params' list
+            # which only involves the list of block errors
             raise ListBlockValidationError(block_errors=errors)
 
         return result

--- a/wagtail/wagtailcore/blocks/list_block.py
+++ b/wagtail/wagtailcore/blocks/list_block.py
@@ -130,7 +130,7 @@ class ListBlock(Block):
     def clean(self, value):
         result = []
         errors = {}
-        for child_val in value:
+        for i, child_val in enumerate(value):
             try:
                 result.append(self.child_block.clean(child_val))
             except ValidationError as e:

--- a/wagtail/wagtailcore/tests/test_blocks.py
+++ b/wagtail/wagtailcore/tests/test_blocks.py
@@ -1458,7 +1458,7 @@ class TestListBlock(unittest.TestCase):
         with self.assertRaises(ValidationError) as catcher:
             block.clean(value)
         self.assertEqual(catcher.exception.params, {
-            '__all__': ['Maximum of 1 is reached'],
+            '__all__': ['The maximum number of items is 1'],
         })
 
     def test_min_length_validation_error(self):
@@ -1472,8 +1472,20 @@ class TestListBlock(unittest.TestCase):
         with self.assertRaises(ValidationError) as catcher:
             block.clean(value)
         self.assertEqual(catcher.exception.params, {
-            '__all__': ['Minimum of 3 is required'],
+            '__all__': ['The minimum number of items is 3'],
         })
+
+    def test_passes_min_and_max_length_validation(self):
+        block = blocks.ListBlock(blocks.CharBlock(), max_length=3, min_length=2)
+
+        value = [
+            blocks.CharBlock(value='Foo'),
+            blocks.CharBlock(value='Bar'),
+            blocks.CharBlock(value='Biz')
+        ]
+
+        result = block.clean(value)
+        self.assertEqual(len(result), 3)
 
 
 class TestStreamBlock(SimpleTestCase):

--- a/wagtail/wagtailcore/tests/test_blocks.py
+++ b/wagtail/wagtailcore/tests/test_blocks.py
@@ -1475,38 +1475,6 @@ class TestListBlock(unittest.TestCase):
             '__all__': ['Minimum of 3 is required'],
         })
 
-    def test_validation_errors(self):
-        class ValidatedBlock(blocks.StreamBlock):
-            char = blocks.CharBlock()
-            url = blocks.URLBlock()
-        block = ValidatedBlock()
-
-        value = [
-            blocks.BoundBlock(
-                block=block.child_blocks['char'],
-                value='',
-            ),
-            blocks.BoundBlock(
-                block=block.child_blocks['char'],
-                value='foo',
-            ),
-            blocks.BoundBlock(
-                block=block.child_blocks['url'],
-                value='http://example.com/',
-            ),
-            blocks.BoundBlock(
-                block=block.child_blocks['url'],
-                value='not a url',
-            ),
-        ]
-
-        with self.assertRaises(ValidationError) as catcher:
-            block.clean(value)
-        self.assertEqual(catcher.exception.params, {
-            0: ['This field is required.'],
-            3: ['Enter a valid URL.'],
-        })
-
 
 class TestStreamBlock(SimpleTestCase):
     def test_initialisation(self):


### PR DESCRIPTION
This pull request resolves the required max- and min length arguments for the `ListBLock`, see issue #2379.

In this case it validates the length of the list with the optional max and min arguments. Maybe we can apply this validation in an earlier stage as well; hiding the _Add another_ button with JavaScript for example.

<img width="1271" alt="screen shot 2016-11-09 at 22 09 22" src="https://cloud.githubusercontent.com/assets/529396/20155353/bdf5f3d0-a6cb-11e6-9fa5-8037ae72d3ba.png">
