### PR TITLE
Fix bug where help_text covers controls for stream-field

### DIFF
--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/layouts/page-editor.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/layouts/page-editor.scss
@@ -408,9 +408,12 @@ footer .preview {
         }
 
         &.stream-field {
-            &:hover .object-help,
             .object-help {
                 opacity: 0;
+                position: relative;
+            }
+            &:hover .object-help {
+                opacity: 1;
             }
         }
 

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/layouts/page-editor.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/layouts/page-editor.scss
@@ -411,6 +411,8 @@ footer .preview {
             .object-help {
                 opacity: 0;
                 position: relative;
+                width: 100%;
+                padding-left: 6.4em;
             }
             &:hover .object-help {
                 opacity: 1;

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/layouts/page-editor.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/layouts/page-editor.scss
@@ -414,6 +414,7 @@ footer .preview {
                 width: 100%;
                 padding-left: 6.4em;
             }
+            
             &:hover .object-help {
                 opacity: 1;
             }


### PR DESCRIPTION
Fix for https://github.com/torchbox/wagtail/issues/2792

Change the position of help text to relative (rather than absolute) for stream fields so that the help text doesn't overlap with the controls on the top block in the stream field.

Since this will create a bit extra space between the stream field title and the content, the help text uses full width so that it in almost all cases will only be one line.
