### PR TITLE
Fix ForeignKey selectbox in ChooserBlock (2)

### DIFF
--- a/wagtail/wagtailcore/blocks/field_block.py
+++ b/wagtail/wagtailcore/blocks/field_block.py
@@ -510,6 +510,13 @@ class ChooserBlock(FieldBlock):
             except self.target_model.DoesNotExist:
                 return None
 
+    def value_for_form(self, value):
+        # When reloading a page it would return an instance, we want an ID.
+        if isinstance(value, self.target_model):
+            return value.pk
+        else:
+            return value
+            
     def clean(self, value):
         # ChooserBlock works natively with model instances as its 'value' type (because that's what you
         # want to work with when doing front-end templating), but ModelChoiceField.clean expects an ID

--- a/wagtail/wagtailcore/tests/test_blocks.py
+++ b/wagtail/wagtailcore/tests/test_blocks.py
@@ -2001,6 +2001,25 @@ class TestStreamBlock(SimpleTestCase):
         self.assertEqual(stream_value[0].value, 'A different default heading')
 
 
+class TestChooserBlock(TestCase):
+    fixtures = ['test.json']
+
+    def test_form_render(self):
+        class CustomChooserBlock(blocks.ChooserBlock):
+            target_model = Page
+            widget = forms.Select
+
+        block = CustomChooserBlock()
+
+        empty_form_html = block.render_form(None, 'page')
+        self.assertIn('<select id="page" name="page" placeholder="">', empty_form_html)
+
+        christmas_page = Page.objects.get(slug='christmas')
+        christmas_form_html = block.render_form(christmas_page, 'page')
+        expected_html = '<option value="%d" selected="selected">Christmas</option>' % christmas_page.id
+        self.assertIn(expected_html, christmas_form_html)
+
+
 class TestPageChooserBlock(TestCase):
     fixtures = ['test.json']
 


### PR DESCRIPTION
This adds a test for the changes in #2714

> If you have a related model in your page through a ChooserBlock the selected value isn't shown on a second load (after save). This change should fix that.

> Fixes #2218