### PR TITLE
Fix #3126 - Fix double-escaping of embedded video urls

### DIFF
--- a/wagtail/wagtailcore/rich_text.py
+++ b/wagtail/wagtailcore/rich_text.py
@@ -155,7 +155,8 @@ def extract_attrs(attr_string):
     """
     attributes = {}
     for name, val in FIND_ATTRS.findall(attr_string):
-        attributes[name] = val
+        # Replaces '&amp' per '&' here in order to prevent extracted URLs to be double-escaped.
+        attributes[name] = val.replace('&amp;', '&')
     return attributes
 
 


### PR DESCRIPTION
Ref: #3126 

Changes include:
* Marking the embedded video urls as safe in the 'embed_editor.html' template