### PR TITLE
Cache `Site.get_site_root_paths` in the request scope

### DIFF
--- a/docs/releases/1.8.rst
+++ b/docs/releases/1.8.rst
@@ -132,3 +132,23 @@ The ``wagtail.contrib.wagtailfrontendcache.backends.CloudflareBackend`` module h
     }
 
 For details of how to obtain the zone identifier, see `the Cloudflare API documentation <https://api.cloudflare.com/#getting-started-resource-ids>`_.
+
+
+``Page.get_url_parts`` and ``Page.relative_url`` now accept a ``hints`` kwarg
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``get_url_parts`` and ``relative_url`` methods on ``Page`` now accept an optional ``hints`` keyword argument. If you have overridden either of these methods on any of your page models, you will need to update the method signature to support this keyword argument; most likely, this will involve changing the line:
+
+.. code-block:: python
+
+    def get_url_parts(self):
+
+to:
+
+.. code-block:: python
+
+    def get_url_parts(self, hints=None):
+
+and passing ``hints=hints`` at the point where you are calling ``get_url_parts`` on ``super`` (if applicable).
+
+See: :meth:`wagtail.wagtailcore.models.Page.get_url_parts` and :meth:`wagtail.wagtailcore.models.Page.relative_url`

--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, unicode_literals
 
 import json
 import logging
+import warnings
 from collections import defaultdict
 from django import VERSION as DJANGO_VERSION
 
@@ -32,6 +33,7 @@ from modelcluster.models import ClusterableModel, get_all_child_relations
 from treebeard.mp_tree import MP_Node
 
 from wagtail.utils.compat import user_is_authenticated
+from wagtail.utils.deprecation import RemovedInWagtail110Warning
 from wagtail.wagtailcore.query import PageQuerySet, TreeQuerySet
 from wagtail.wagtailcore.signals import page_published, page_unpublished
 from wagtail.wagtailcore.url_routing import RouteResult
@@ -595,6 +597,18 @@ class Page(six.with_metaclass(PageBase, AbstractPage, index.Indexed, Clusterable
                     id='wagtailcore.E002'
                 )
             )
+
+        if not accepts_kwarg(cls.relative_url, 'hints'):
+            warnings.warn(
+                "%s.relative_url should accept a 'hints' keyword argument. "
+                "See http://docs.wagtail.io/en/v1.8/reference/pages/model_reference.html#wagtail.wagtailcore.models.Page.relative_url" % cls,
+                RemovedInWagtail110Warning)
+
+        if not accepts_kwarg(cls.get_url_parts, 'hints'):
+            warnings.warn(
+                "%s.get_url_parts should accept a 'hints' keyword argument. "
+                "See http://docs.wagtail.io/en/v1.8/reference/pages/model_reference.html#wagtail.wagtailcore.models.Page.get_url_parts" % cls,
+                RemovedInWagtail110Warning)
 
         return errors
 

--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -794,6 +794,14 @@ class Page(six.with_metaclass(PageBase, AbstractPage, index.Indexed, Clusterable
         and ``get_site`` properties and methods; pages with custom URL routing
         should override this method in order to have those operations return
         the custom URLs.
+
+        Accepts an optional keyword argument ``hints``, a dict of data that may
+        be used to avoid repeated database / cache lookups. Currently the only
+        recognised item in this dict is ``site_root_paths``, a copy of the site
+        records list returned by ``Site.get_site_root_paths()``. Typically, a
+        page model that overrides ``get_url_parts`` should not need to deal with
+        ``hints`` directly, and should just pass it to the original method when
+        calling ``super``.
         """
         if hints is not None and 'site_root_paths' in hints:
             site_root_paths = hints['site_root_paths']
@@ -853,7 +861,9 @@ class Page(six.with_metaclass(PageBase, AbstractPage, index.Indexed, Clusterable
         """
         Return the 'most appropriate' URL for this page taking into account the site we're currently on;
         a local URL if the site matches, or a fully qualified one otherwise.
-        Return None if the page is not routable.
+        Return None if the page is not routable. Accepts an optional keyword argument ``hints``, a dict
+        of data that may be used to avoid repeated database / cache lookups; see ``get_url_parts``
+        for details.
         """
         if accepts_kwarg(self.get_url_parts, 'hints'):
             url_parts = self.get_url_parts(hints=hints)

--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -879,6 +879,8 @@ class Page(six.with_metaclass(PageBase, AbstractPage, index.Indexed, Clusterable
         of data that may be used to avoid repeated database / cache lookups; see ``get_url_parts``
         for details.
         """
+        # RemovedInWagtail110Warning - this accepts_kwarg test can be removed when we drop support
+        # for get_url_parts methods which omit the `hints` kwarg
         if accepts_kwarg(self.get_url_parts, 'hints'):
             url_parts = self.get_url_parts(hints=hints)
         else:

--- a/wagtail/wagtailcore/templatetags/wagtailcore_tags.py
+++ b/wagtail/wagtailcore/templatetags/wagtailcore_tags.py
@@ -25,6 +25,8 @@ def pageurl(context, page):
         # request.site not available in the current context; fall back on page.url
         return page.url
 
+    # RemovedInWagtail110Warning - this accepts_kwarg test can be removed when we drop support
+    # for relative_url methods which omit the `hints` kwarg
     if accepts_kwarg(page.relative_url, 'hints'):
         # Pass page.relative_url a hints dictionary containing a 'site_root_paths' list
         # which we obtain from Site.get_site_root_paths() and cache in the request object.

--- a/wagtail/wagtailcore/templatetags/wagtailcore_tags.py
+++ b/wagtail/wagtailcore/templatetags/wagtailcore_tags.py
@@ -6,8 +6,9 @@ from django.utils.encoding import force_text
 from django.utils.safestring import mark_safe
 
 from wagtail import __version__
-from wagtail.wagtailcore.models import Page
+from wagtail.wagtailcore.models import Page, Site
 from wagtail.wagtailcore.rich_text import RichText, expand_db_html
+from wagtail.wagtailcore.utils import accepts_kwarg
 
 register = template.Library()
 
@@ -18,7 +19,28 @@ def pageurl(context, page):
     Outputs a page's URL as relative (/foo/bar/) if it's within the same site as the
     current page, or absolute (http://example.com/foo/bar/) if not.
     """
-    return page.relative_url(context['request'].site)
+    try:
+        current_site = context['request'].site
+    except (KeyError, AttributeError):
+        # request.site not available in the current context; fall back on page.url
+        return page.url
+
+    if accepts_kwarg(page.relative_url, 'hints'):
+        # Pass page.relative_url a hints dictionary containing a 'site_root_paths' list
+        # which we obtain from Site.get_site_root_paths() and cache in the request object.
+        # This avoids page.relative_url having to make a database/cache fetch for this list
+        # each time it's called.
+        try:
+            site_root_paths = context['request'].wagtail_site_root_paths
+        except AttributeError:
+            site_root_paths = Site.get_site_root_paths()
+            context['request'].wagtail_site_root_paths = site_root_paths
+
+        return page.relative_url(current_site, hints={
+            'site_root_paths': site_root_paths
+        })
+    else:
+        return page.relative_url(current_site)
 
 
 @register.simple_tag(takes_context=True)
@@ -27,7 +49,7 @@ def slugurl(context, slug):
     page = Page.objects.filter(slug=slug).first()
 
     if page:
-        return page.relative_url(context['request'].site)
+        return pageurl(context, page)
     else:
         return None
 

--- a/wagtail/wagtailcore/tests/test_utils.py
+++ b/wagtail/wagtailcore/tests/test_utils.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import, unicode_literals
 from django.test import TestCase
 from django.utils.text import slugify
 
-from wagtail.wagtailcore.utils import cautious_slugify
+from wagtail.wagtailcore.utils import accepts_kwarg, cautious_slugify
 
 
 class TestCautiousSlugify(TestCase):
@@ -36,3 +36,19 @@ class TestCautiousSlugify(TestCase):
 
         for (original, expected_result) in test_cases:
             self.assertEqual(cautious_slugify(original), expected_result)
+
+
+class TestAcceptsKwarg(TestCase):
+    def test_accepts_kwarg(self):
+        def func_without_banana(apple, orange=42):
+            pass
+
+        def func_with_banana(apple, banana=42):
+            pass
+
+        def func_with_kwargs(apple, **kwargs):
+            pass
+
+        self.assertFalse(accepts_kwarg(func_without_banana, 'banana'))
+        self.assertTrue(accepts_kwarg(func_with_banana, 'banana'))
+        self.assertTrue(accepts_kwarg(func_with_kwargs, 'banana'))

--- a/wagtail/wagtailcore/utils.py
+++ b/wagtail/wagtailcore/utils.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import, unicode_literals
 
+import inspect
 import re
+import sys
 import unicodedata
 
 from django.apps import apps
@@ -94,3 +96,20 @@ def cautious_slugify(value):
     # mark_safe); this will also strip out the backslashes from the 'backslashreplace'
     # conversion
     return slugify(value)
+
+
+def accepts_kwarg(func, kwarg):
+    """
+    Determine whether the callable `func` has a signature that accepts the keyword argument `kwarg`
+    """
+    if sys.version_info >= (3, 3):
+        signature = inspect.signature(func)
+        try:
+            signature.bind_partial(**{kwarg: None})
+            return True
+        except TypeError:
+            return False
+    else:
+        # Fall back on inspect.getargspec, available on Python 2.7 but deprecated since 3.5
+        argspec = inspect.getargspec(func)
+        return (kwarg in argspec.args) or (argspec.keywords is not None)


### PR DESCRIPTION
Fixes #2916

Avoids repeated cache / database lookups on repeated calls to `{% pageurl %}`, by caching the result of `Site.get_site_root_paths` in the request scope. Since the actual lookup happens in `Page.get_url_parts`, which is called via `Page.relative_url`, I've had to do some creative re-plumbing to pass that cached result around in a new `hints` kwarg.

Since it's common for page models to override either/both of `get_url_parts` and `relative_url`, this in turn means we need to put the old `hints`-less signature through the deprecation process.