### PR TITLE
Add construct_explorer_page_queryset hook to explorer nagivation and page chooser

### DIFF
--- a/wagtail/wagtailadmin/navigation.py
+++ b/wagtail/wagtailadmin/navigation.py
@@ -2,8 +2,8 @@ from __future__ import absolute_import, unicode_literals
 
 from django.db.models import Q
 
-from wagtail.wagtailcore.models import Page
 from wagtail.wagtailcore import hooks
+from wagtail.wagtailcore.models import Page
 
 
 def get_pages_with_direct_explore_permission(user):

--- a/wagtail/wagtailadmin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/wagtailadmin/templatetags/wagtailadmin_tags.py
@@ -34,7 +34,7 @@ else:
 @register.inclusion_tag('wagtailadmin/shared/explorer_nav.html', takes_context=True)
 def explorer_nav(context):
     return {
-        'nodes': get_navigation_menu_items(context['request'].user)
+        'nodes': get_navigation_menu_items(context['request'].user, request=context['request'])
     }
 
 

--- a/wagtail/wagtailadmin/tests/test_explorer_nav.py
+++ b/wagtail/wagtailadmin/tests/test_explorer_nav.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import, unicode_literals
 from django.core.urlresolvers import reverse
 from django.test import TestCase
 
+from wagtail.tests.testapp.models import EventPage
 from wagtail.tests.utils import WagtailTestUtils
 from wagtail.wagtailcore.models import Page
 
@@ -153,3 +154,24 @@ class TestExplorerNavView(TestCase, WagtailTestUtils):
         self.assertEqual(response.status_code, 200)
         # Being in no Groups, Mary should ot be shown any nodes.
         self.assertEqual(len(response.context['nodes']), 0)
+
+    def test_explorer_nav_with_hook_construct_explorer_page_queryset(self):
+        root_page = Page.objects.get(id=1)
+
+        # Add child page
+        polite_page = Page(
+            title="Hello world!",
+            slug="hello-world",
+        )
+        root_page.add_child(instance=polite_page)
+
+        self.assertTrue(self.client.login(username='superman', password='password'))
+        response = self.client.get(
+            reverse('wagtailadmin_explorer_nav'),
+            {'polite_pages_only': 'yes_please'}
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'wagtailadmin/shared/explorer_nav.html')
+        self.assertEqual(len(response.context['nodes']), 1)
+        self.assertEqual(response.context['nodes'][0][0].id, polite_page.id)

--- a/wagtail/wagtailadmin/tests/test_explorer_nav.py
+++ b/wagtail/wagtailadmin/tests/test_explorer_nav.py
@@ -5,7 +5,6 @@ from __future__ import absolute_import, unicode_literals
 from django.core.urlresolvers import reverse
 from django.test import TestCase
 
-from wagtail.tests.testapp.models import EventPage
 from wagtail.tests.utils import WagtailTestUtils
 from wagtail.wagtailcore.models import Page
 

--- a/wagtail/wagtailadmin/tests/test_page_chooser.py
+++ b/wagtail/wagtailadmin/tests/test_page_chooser.py
@@ -199,6 +199,21 @@ class TestChooserBrowseChild(TestCase, WagtailTestUtils):
         response = self.get({'p': 100})
         self.assertEqual(response.context['pages'].number, 5)
 
+    def test_with_hook_construct_explorer_page_queryset(self):
+        polite_page = SimplePage(
+            title="Hello world!",
+            slug="hello-world",
+            content="hello santa"
+        )
+        self.root_page.add_child(instance=polite_page)
+
+        response = self.get({'polite_pages_only': 'yes_please'})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'wagtailadmin/chooser/browse.html')
+        self.assertEqual(len(response.context['pages']), 1)
+        self.assertEqual(response.context['pages'][0].id, polite_page.id)
+
 
 class TestChooserSearch(TestCase, WagtailTestUtils):
     def setUp(self):
@@ -296,6 +311,28 @@ class TestChooserSearch(TestCase, WagtailTestUtils):
     def test_with_invalid_page_type(self):
         response = self.get({'page_type': 'foo'})
         self.assertEqual(response.status_code, 404)
+
+    def test_with_hook_construct_explorer_page_queryset(self):
+        polite_page = SimplePage(
+            title="Hello world!",
+            slug="hello-world",
+            content="hello santa"
+        )
+        self.root_page.add_child(instance=polite_page)
+
+        not_polite = SimplePage(
+            title="Hello world! from not polite",
+            slug="bye-world",
+            content="bye santa"
+        )
+        self.root_page.add_child(instance=not_polite)
+
+        response = self.get({'polite_pages_only': 'yes_please', 'q': 'hello'})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'wagtailadmin/chooser/_search_results.html')
+        self.assertEqual(len(response.context['pages']), 1)
+        self.assertEqual(response.context['pages'][0].id, polite_page.id)
 
 
 class TestAutomaticRootPageDetection(TestCase, WagtailTestUtils):

--- a/wagtail/wagtailadmin/views/chooser.py
+++ b/wagtail/wagtailadmin/views/chooser.py
@@ -8,9 +8,9 @@ from django.shortcuts import get_object_or_404, render
 from wagtail.utils.pagination import paginate
 from wagtail.wagtailadmin.forms import EmailLinkChooserForm, ExternalLinkChooserForm, SearchForm
 from wagtail.wagtailadmin.modal_workflow import render_modal_workflow
+from wagtail.wagtailcore import hooks
 from wagtail.wagtailcore.models import Page
 from wagtail.wagtailcore.utils import resolve_model_string
-from wagtail.wagtailcore import hooks
 
 
 def shared_context(request, extra_context=None):

--- a/wagtail/wagtailadmin/views/pages.py
+++ b/wagtail/wagtailadmin/views/pages.py
@@ -32,7 +32,7 @@ def get_valid_next_url_from_request(request):
 
 def explorer_nav(request):
     return render(request, 'wagtailadmin/shared/explorer_nav.html', {
-        'nodes': get_navigation_menu_items(request.user),
+        'nodes': get_navigation_menu_items(request.user, request=request),
     })
 
 


### PR DESCRIPTION
This pull request add `construct_explorer_page_queryset` hook to navigation (explorer_nav) and to page chooser (browse and search).

Using gasman scenario from (#2196):
> Example scenario - we have a section containing many pages with a 'language' field, and want to filter the explorer listing so that users only see pages in their own language.

We also want our users to see only the pages on their language on navigation and chooser views.

A few notes about the PR:
- Should we rename this hooks with something different? One for each case? So we don't affect users which already uses this hook? 
- I have added `request` param to `get_navigation_menu_items` as named with None as default but all Wagtail references were updated, I was afraid to break stuff for other people that have customised Wagtail. 
- On chooser `search` it became a little bit more complex because we're Searching and searches doesn't have the pages as queryset as the other cases, so I needed to standardise the pages object to call the hook with the same type of object (queryset).




