### PR TITLE
Make all live and draft links open in a new win

### DIFF
--- a/wagtail/wagtailadmin/messages.py
+++ b/wagtail/wagtailadmin/messages.py
@@ -31,5 +31,5 @@ def error(request, message, buttons=None):
     return messages.error(request, render(message, buttons))
 
 
-def button(url, text):
-    return url, text
+def button(url, text, new_window=False):
+    return url, text, new_window

--- a/wagtail/wagtailadmin/templates/wagtailadmin/home/pages_for_moderation.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/home/pages_for_moderation.html
@@ -40,7 +40,7 @@
                                         </form>
                                     </li>
                                     <li><a href="{% url 'wagtailadmin_pages:edit' revision.page.id %}" class="button button-small button-secondary">{% trans 'Edit' %}</a></li>
-                                    <li><a href="{% url 'wagtailadmin_pages:preview_for_moderation' revision.id %}" class="button button-small button-secondary">{% trans 'Preview' %}</a></li>
+                                    <li><a href="{% url 'wagtailadmin_pages:preview_for_moderation' revision.id %}" class="button button-small button-secondary" target="_blank">{% trans 'Preview' %}</a></li>
                                 </ul>
                             </td>
                             <td valign="top">

--- a/wagtail/wagtailadmin/templates/wagtailadmin/home/recent_edits.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/home/recent_edits.html
@@ -27,10 +27,10 @@
                                 <ul class="actions">
                                     <li><a href="{% url 'wagtailadmin_pages:edit' page.id %}" class="button button-small button-secondary">{% trans "Edit" %}</a></li>
                                     {% if page.has_unpublished_changes %}
-                                        <li><a href="{% url 'wagtailadmin_pages:view_draft' page.id %}" class="button button-small button-secondary">{% trans 'Draft' %}</a></li>
+                                        <li><a href="{% url 'wagtailadmin_pages:view_draft' page.id %}" class="button button-small button-secondary" target="_blank">{% trans 'Draft' %}</a></li>
                                     {% endif %}
                                     {% if page.live %}
-                                        <li><a href="{{ page.url }}" class="button button-small button-secondary">{% trans 'Live' %}</a></li>
+                                        <li><a href="{{ page.url }}" class="button button-small button-secondary" target="_blank">{% trans 'Live' %}</a></li>
                                     {% endif %}
                                 </ul>
                             </td>

--- a/wagtail/wagtailadmin/templates/wagtailadmin/shared/messages.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/shared/messages.html
@@ -3,7 +3,7 @@
 {% if buttons %}
     <span class="buttons">
         {% for button in buttons %}
-            <a href="{{ button.0 }}" class="button button-small button-secondary">{{ button.1 }}</a>
+            <a href="{{ button.0 }}" class="button button-small button-secondary"{% if button.2 %} target="_blank"{% endif %}>{{ button.1 }}</a>
         {% endfor %}
     </span>
 {% endif %}

--- a/wagtail/wagtailadmin/views/pages.py
+++ b/wagtail/wagtailadmin/views/pages.py
@@ -224,7 +224,7 @@ def create(request, content_type_app_name, content_type_model_name, parent_page_
                     ])
                 else:
                     messages.success(request, _("Page '{0}' created and published.").format(page.get_admin_display_title()), buttons=[
-                        messages.button(page.url, _('View live')),
+                        messages.button(page.url, _('View live'), new_window=True),
                         messages.button(reverse('wagtailadmin_pages:edit', args=(page.id,)), _('Edit'))
                     ])
             elif is_submitting:
@@ -232,8 +232,15 @@ def create(request, content_type_app_name, content_type_model_name, parent_page_
                     request,
                     _("Page '{0}' created and submitted for moderation.").format(page.get_admin_display_title()),
                     buttons=[
-                        messages.button(reverse('wagtailadmin_pages:view_draft', args=(page.id,)), _('View draft')),
-                        messages.button(reverse('wagtailadmin_pages:edit', args=(page.id,)), _('Edit'))
+                        messages.button(
+                            reverse('wagtailadmin_pages:view_draft', args=(page.id,)),
+                            _('View draft'),
+                            new_window=True
+                        ),
+                        messages.button(
+                            reverse('wagtailadmin_pages:edit', args=(page.id,)),
+                            _('Edit')
+                        )
                     ]
                 )
                 if not send_notification(page.get_latest_revision().id, 'submitted', request.user.pk):
@@ -381,7 +388,8 @@ def edit(request, page_id):
                     messages.success(request, message, buttons=[
                         messages.button(
                             page.url,
-                            _('View live')
+                            _('View live'),
+                            new_window=True
                         ),
                         messages.button(
                             reverse('wagtailadmin_pages:edit', args=(page_id,)),
@@ -400,7 +408,8 @@ def edit(request, page_id):
                 messages.success(request, message, buttons=[
                     messages.button(
                         reverse('wagtailadmin_pages:view_draft', args=(page_id,)),
-                        _('View draft')
+                        _('View draft'),
+                        new_window=True
                     ),
                     messages.button(
                         reverse('wagtailadmin_pages:edit', args=(page_id,)),
@@ -893,7 +902,7 @@ def approve_moderation(request, revision_id):
     if request.method == 'POST':
         revision.approve_moderation()
         messages.success(request, _("Page '{0}' published.").format(revision.page.get_admin_display_title()), buttons=[
-            messages.button(revision.page.url, _('View live')),
+            messages.button(revision.page.url, _('View live'), new_window=True),
             messages.button(reverse('wagtailadmin_pages:edit', args=(revision.page.id,)), _('Edit'))
         ])
         if not send_notification(revision.id, 'approved', request.user.pk):


### PR DESCRIPTION
Some *live* and *view draft* links were opening in a new window and some weren't for no apparent reason. 
This fixes that inconsistency.

The links that were opening in the same window were in the:
- moderation section
- recent edits section
- messages