### PR TITLE
Fix the inconsistent use of `blogpages`

### DIFF
--- a/docs/getting_started/tutorial.rst
+++ b/docs/getting_started/tutorial.rst
@@ -532,7 +532,7 @@ This method is now available from our templates. Update ``blog_index_page.html``
 
     ...
 
-    {% for post in page.get_children %}
+    {% for post in blogpages %}
         {% with post=post.specific %}
             <h2><a href="{% pageurl post %}">{{ post.title }}</a></h2>
 


### PR DESCRIPTION
`page.get_children` was changed earlier to `blogpages` in order to show the blog posts ordered and hide the unpublished ones but in a later example `page.get_children` is used again.