### PR TITLE
Change admin welcome to explorable root

### DIFF
--- a/wagtail/wagtailadmin/templates/wagtailadmin/home.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/home.html
@@ -1,5 +1,5 @@
 {% extends "wagtailadmin/base.html" %}
-{% load gravatar staticfiles i18n %}
+{% load gravatar staticfiles wagtailadmin_tags i18n %}
 {% block titletag %}{% trans "Dashboard" %}{% endblock %}
 {% block bodyclass %}homepage{% endblock %}
 
@@ -18,7 +18,8 @@
                 </div>
             {% endif %}
             <div class="col9">
-                <h1>{% block branding_welcome %}{% blocktrans %}Welcome to the {{ site_name }} Wagtail CMS{% endblocktrans %}{% endblock %}</h1>
+                {% explorer_site user site_name as current_site %}
+                <h1>{% block branding_welcome %}{% blocktrans %}Welcome to the {{ current_site }} Wagtail CMS{% endblocktrans %}{% endblock %}</h1>
                 <h2>{{ user.get_full_name|default:user.get_username }}</h2>
             </div>
         </div>

--- a/wagtail/wagtailadmin/templates/wagtailadmin/home.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/home.html
@@ -18,8 +18,8 @@
                 </div>
             {% endif %}
             <div class="col9">
-                {% explorer_site user site_name as current_site %}
-                <h1>{% block branding_welcome %}{% blocktrans %}Welcome to the {{ current_site }} Wagtail CMS{% endblocktrans %}{% endblock %}</h1>
+                {% explorer_site user site_name as current_explorable_site %}
+                <h1>{% block branding_welcome %}{% blocktrans with current_site=current_explorable_site %}Welcome to the {{ current_site }} Wagtail CMS{% endblocktrans %}{% endblock %}</h1>
                 <h2>{{ user.get_full_name|default:user.get_username }}</h2>
             </div>
         </div>

--- a/wagtail/wagtailadmin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/wagtailadmin/templatetags/wagtailadmin_tags.py
@@ -72,6 +72,7 @@ def explorer_breadcrumb(context, page, include_self=False):
         'pages': page.get_ancestors(inclusive=include_self).descendant_of(cca, inclusive=True)
     }
 
+
 @register.simple_tag
 def explorer_site(user, root_site_name="Root"):
     """

--- a/wagtail/wagtailadmin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/wagtailadmin/templatetags/wagtailadmin_tags.py
@@ -79,7 +79,6 @@ def explorer_site(user, root_site_name="Root"):
     """
     explorable_root = get_pages_with_direct_explore_permission(user).first()
     if explorable_root.title == "Root":
-        print explorable_root
         return root_site_name
     else:
         return explorable_root

--- a/wagtail/wagtailadmin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/wagtailadmin/templatetags/wagtailadmin_tags.py
@@ -73,17 +73,20 @@ def explorer_breadcrumb(context, page, include_self=False):
     }
 
 
-@register.assignment_tag
-def explorer_site(user, root_site_name="Root"):
+@register.assignment_tag(takes_context=True)
+def explorer_site(context, user, root_site_name="Root"):
     """
     Usage: {% explorer_site user site_name}
+    Determines the root owning site record of the highest explorable ancestor page for the currently
+    logged in user.
     """
     explorable_root = get_pages_with_direct_explore_permission(user).first()
     if explorable_root:
         if explorable_root.title == "Root":
             return root_site_name
         else:
-            return explorable_root
+            site_name = str(explorable_root.get_site()).replace('[default]', '')
+            return site_name if site_name != "None" else root_site_name
     else:
         return None
 

--- a/wagtail/wagtailadmin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/wagtailadmin/templatetags/wagtailadmin_tags.py
@@ -79,10 +79,13 @@ def explorer_site(user, root_site_name="Root"):
     Usage: {% explorer_site user site_name}
     """
     explorable_root = get_pages_with_direct_explore_permission(user).first()
-    if explorable_root.title == "Root":
-        return root_site_name
+    if explorable_root:
+        if explorable_root.title == "Root":
+            return root_site_name
+        else:
+            return explorable_root
     else:
-        return explorable_root
+        return None
 
 
 @register.inclusion_tag('wagtailadmin/shared/search_other.html', takes_context=True)

--- a/wagtail/wagtailadmin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/wagtailadmin/templatetags/wagtailadmin_tags.py
@@ -72,6 +72,18 @@ def explorer_breadcrumb(context, page, include_self=False):
         'pages': page.get_ancestors(inclusive=include_self).descendant_of(cca, inclusive=True)
     }
 
+@register.simple_tag
+def explorer_site(user, root_site_name="Root"):
+    """
+    Usage: {% explorer_site user site_name}
+    """
+    explorable_root = get_pages_with_direct_explore_permission(user).first()
+    if explorable_root.title == "Root":
+        print explorable_root
+        return root_site_name
+    else:
+        return explorable_root
+
 
 @register.inclusion_tag('wagtailadmin/shared/search_other.html', takes_context=True)
 def search_other(context, current=None):

--- a/wagtail/wagtailadmin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/wagtailadmin/templatetags/wagtailadmin_tags.py
@@ -73,7 +73,7 @@ def explorer_breadcrumb(context, page, include_self=False):
     }
 
 
-@register.simple_tag
+@register.assignment_tag
 def explorer_site(user, root_site_name="Root"):
     """
     Usage: {% explorer_site user site_name}

--- a/wagtail/wagtailadmin/tests/test_pages_views.py
+++ b/wagtail/wagtailadmin/tests/test_pages_views.py
@@ -408,6 +408,31 @@ class TestExplorablePageVisibility(TestCase, WagtailTestUtils):
         self.assertNotContains(response, "Welcome to example.com!")
 
 
+class TestAdminHomePageTitle(TestCase, WagtailTestUtils):
+    '''
+    Test the rendering of the highest explorable page name in the admin home page.
+    We should not be showing users the name of the root installation or any parent pages
+    that they do not have access to.
+
+    Uses the same test fixture as TestExplorablePageVisibility.
+    '''
+    fixtures = ['test_explorable_pages.json']
+
+    def test_admin_sees_root_site_name(self):
+        self.assertTrue(self.client.login(username='superman', password='password'))
+        response = self.client.get(reverse('wagtailadmin_home'))
+        self.assertEqual(response.status_code, 200)
+        # The administrator should see the welcome message for the root of the installation
+        self.assertInHTML("""<h1>Welcome to the Test Site Wagtail CMS</h1>""", str(response.content))
+
+    def test_child_page_user_sees_only_child_page_title(self):
+        self.assertTrue(self.client.login(username='josh', password='password'))
+        response = self.client.get(reverse('wagtailadmin_home'))
+        self.assertEqual(response.status_code, 200)
+        # Josh should not see the welcome message for the root
+        self.assertNotContains(response, "Welcome to the Test Site Wagtail CMS")
+
+
 class TestPageCreation(TestCase, WagtailTestUtils):
     def setUp(self):
         # Find root page


### PR DESCRIPTION
Continuation of work towards multi-tenancy in wagtail.  

Adds a template tag for retrieving the name of the highest currently explorable ancestor. Additionally implements said tag in the admin homepage. 

ex.
My Site 
-----My First Page
-----My Next Page

User 1 is permissioned to only see My First Page. Now in the admin panel, instead of seeing "Welcome to the My Site Wagtail CMS", he sees "Welcome to the My First Page Wagtail CMS". 
