### PR TITLE
Maintain the 'next' GET argument through the add_subpage workflow.

### DIFF
--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/add_subpage.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/add_subpage.html
@@ -17,7 +17,7 @@
                     <li>
                         <div class="row row-flush">
                             <div class="col6">
-                                <a href="{% url 'wagtailadmin_pages:add' app_label model_name parent_page.id %}" class="icon icon-plus-inverse icon-larger">{{ verbose_name }}</a>
+                                <a href="{% url 'wagtailadmin_pages:add' app_label model_name parent_page.id %}{% if next %}?next={{ next }}{% endif %}" class="icon icon-plus-inverse icon-larger">{{ verbose_name }}</a>
                             </div>
 
                             <small class="col6" style="text-align:right">

--- a/wagtail/wagtailadmin/views/pages.py
+++ b/wagtail/wagtailadmin/views/pages.py
@@ -127,6 +127,7 @@ def add_subpage(request, parent_page_id):
     return render(request, 'wagtailadmin/pages/add_subpage.html', {
         'parent_page': parent_page,
         'page_types': page_types,
+        'next': get_valid_next_url_from_request(request),
     })
 
 


### PR DESCRIPTION
Every other Page workflow seems to maintain this argument, to ensure that the
user ends up back at the page they were on when they started. This PR enables
the add_subpage workflow to do the same. It doesn't change any behavior unless the `wagtailadmin_explore:add_subpage` view is visited with a "?next=/some/url/" GET argument (which nothing in base Wagtail currently does).

I haven't added tests for this PR, but they should be pretty trivial. I'd do it myself, but I'm about to go on an extended vacation (in... 30 minutes), so I'm afraid I haven't got the time. If this PR is unaccepted by the time I return, I'll write the tests.

The purpose of this patch is to support the Sitemap plugin that I recently coded for Caltech's multitenant site. I wrote it in a way that will make it fairly simple to convert into a wagtail contrib module, if you'll have it (otherwise, I'll put it up on PyPI). However, I don't have time right now to do that conversion, so that PR will have to wait.