### PR TITLE
replace self with cls for class method

### DIFF
--- a/wagtail/wagtailadmin/edit_handlers.py
+++ b/wagtail/wagtailadmin/edit_handlers.py
@@ -448,8 +448,8 @@ class BaseFieldPanel(EditHandler):
         return mark_safe(render_to_string(self.field_template, context))
 
     @classmethod
-    def required_fields(self):
-        return [self.field_name]
+    def required_fields(cls):
+        return [cls.field_name]
 
 
 class FieldPanel(object):


### PR DESCRIPTION
This is a simple pep8 cleanup spotted using [lgtm](https://lgtm.com).

The first argument of a class method, a new method or any metaclass method should be called cls. This makes the purpose of the argument clear to other developers.