### PR TITLE
Bulk deletion of form submissions

### DIFF
--- a/wagtail/wagtailforms/templates/wagtailforms/confirm_delete.html
+++ b/wagtail/wagtailforms/templates/wagtailforms/confirm_delete.html
@@ -1,19 +1,19 @@
 {% extends "wagtailadmin/base.html" %}
 {% load i18n %}
-{% block titletag %}{% blocktrans with title=page.title %}Delete {{ title }}{% endblocktrans %}{% endblock %}
+{% block titletag %}{% blocktrans with title=page.title %}Delete form data {{ title }}{% endblocktrans %}{% endblock %}
 {% block bodyclass %}menu-explorer{% endblock %}
 
 {% block content %}
-    {% trans "Delete" as del_str %}
+    {% trans "Delete form data" as del_str %}
     {% include "wagtailadmin/shared/header.html" with title=del_str subtitle=page.title icon="doc-empty-inverse" %}
 
     <div class="nice-padding">
         <p>
-            {% trans 'Are you sure you want to delete this form submission?' %}
+            {% trans 'Are you sure you want to delete these form submissions?' %}
         </p>
-        <form action="{% url 'wagtailforms:delete_submission' page.id submission.id %}" method="POST">
+        <form action="{% url 'wagtailforms:delete_submissions' page.id %}?{{ request.GET.urlencode }}" method="POST">
             {% csrf_token %}
-            <input type="submit" value="{% trans 'Delete it' %}" class="button serious">
+            <input type="submit" value="{% trans 'Delete' %}" class="button serious">
         </form>
     </div>
 {% endblock %}

--- a/wagtail/wagtailforms/templates/wagtailforms/confirm_delete.html
+++ b/wagtail/wagtailforms/templates/wagtailforms/confirm_delete.html
@@ -9,7 +9,11 @@
 
     <div class="nice-padding">
         <p>
-            {% trans 'Are you sure you want to delete these form submissions?' %}
+            {% blocktrans count counter=submissions.count %}
+                Are you sure you want to delete this form submission?
+            {% plural %}
+                Are you sure you want to delete these form submissions?
+            {% endblocktrans %}
         </p>
         <form action="{% url 'wagtailforms:delete_submissions' page.id %}?{{ request.GET.urlencode }}" method="POST">
             {% csrf_token %}

--- a/wagtail/wagtailforms/templates/wagtailforms/index_submissions.html
+++ b/wagtail/wagtailforms/templates/wagtailforms/index_submissions.html
@@ -23,6 +23,67 @@
                 },
                 lang: 'lang'
             });
+
+            var selectAllCheckbox = document.getElementById('select-all');
+            var deleteButton = document.getElementById('delete-submissions');
+            var selectedSubmissions = {};
+
+            function updateActions() {
+                var everySubmissionSelected = Object.values(selectedSubmissions).every(function(v) { return v; });
+                var someSubmissionsSelected = Object.values(selectedSubmissions).some(function(v) { return v; })
+
+                // Select all box state
+                if (everySubmissionSelected) {
+                    // Every submission has been selected
+                    selectAllCheckbox.checked = true;
+                    selectAllCheckbox.indeterminate = false;
+                } else if (someSubmissionsSelected) {
+                    // At least one, but not all submissions have been selected
+                    selectAllCheckbox.checked = false;
+                    selectAllCheckbox.indeterminate = true;
+                } else {
+                    // No submissions have been selected
+                    selectAllCheckbox.checked = false;
+                    selectAllCheckbox.indeterminate = false;
+                }
+
+                // Delete button state
+                if (someSubmissionsSelected) {
+                    deleteButton.classList.remove('disabled')
+                    deleteButton.disabled = false;
+                } else {
+                    deleteButton.classList.add('disabled')
+                    deleteButton.disabled = true;
+                }
+            }
+
+            // Initialise selectedSubmissions
+            $('input[type=checkbox].select-submission').each(function() {
+                selectedSubmissions[this.dataset.submissionId] = false;
+            });
+
+
+            // Event handlers
+
+            $(selectAllCheckbox).on('change', function() {
+                // Select/deselect all
+                for (var submissionId in selectedSubmissions) {
+                    selectedSubmissions[submissionId] = this.checked;
+                }
+
+                // Update checkbox states in DOM
+                $('input[type=checkbox].select-submission').each(function() {
+                    this.checked = selectedSubmissions[this.dataset.submissionId];
+                });
+
+                updateActions();
+            });
+
+            $('input[type=checkbox].select-submission').on('change', function() {
+                selectedSubmissions[this.dataset.submissionId] = this.checked;
+
+                updateActions();
+            });
         });
     </script>
 {% endblock %}
@@ -55,10 +116,15 @@
     </header>
     <div class="nice-padding">
         {% if submissions %}
-            {% include "wagtailforms/list_submissions.html" %}
+            <form action="{% url 'wagtailforms:delete_submissions' form_page.id %}" method="get">
+                <input type="checkbox" id="select-all" />
+                <button class="button text-replace no icon icon-bin disabled" id="delete-submissions" disabled></button>
 
-            {% include "wagtailadmin/shared/pagination_nav.html" with items=submissions is_searching=False linkurl='-' %}
-            {# Here we pass an invalid non-empty URL name as linkurl to generate pagination links with the URL path omitted #}
+                {% include "wagtailforms/list_submissions.html" %}
+
+                {% include "wagtailadmin/shared/pagination_nav.html" with items=submissions is_searching=False linkurl='-' %}
+                {# Here we pass an invalid non-empty URL name as linkurl to generate pagination links with the URL path omitted #}
+            </form>
         {% else %}
             <p class="no-results-message">{% blocktrans with title=form_page.title %}There have been no submissions of the '{{ title }}' form.{% endblocktrans %}</p>
         {% endif %}

--- a/wagtail/wagtailforms/templates/wagtailforms/index_submissions.html
+++ b/wagtail/wagtailforms/templates/wagtailforms/index_submissions.html
@@ -29,8 +29,9 @@
             var selectedSubmissions = {};
 
             function updateActions() {
-                var everySubmissionSelected = Object.values(selectedSubmissions).every(function(v) { return v; });
-                var someSubmissionsSelected = Object.values(selectedSubmissions).some(function(v) { return v; })
+                var submissionCheckboxes = $('input[type=checkbox].select-submission');
+                var someSubmissionsSelected = submissionCheckboxes.is(':checked');
+                var everySubmissionSelected = !submissionCheckboxes.is(':not(:checked)');
 
                 // Select all box state
                 if (everySubmissionSelected) {
@@ -57,31 +58,21 @@
                 }
             }
 
-            // Initialise selectedSubmissions
-            $('input[type=checkbox].select-submission').each(function() {
-                selectedSubmissions[this.value] = false;
-            });
-
 
             // Event handlers
 
             $(selectAllCheckbox).on('change', function() {
-                // Select/deselect all
-                for (var submissionId in selectedSubmissions) {
-                    selectedSubmissions[submissionId] = this.checked;
-                }
+                let checked = this.checked;
 
-                // Update checkbox states in DOM
+                // Update checkbox states
                 $('input[type=checkbox].select-submission').each(function() {
-                    this.checked = selectedSubmissions[this.value];
+                    this.checked = checked;
                 });
 
                 updateActions();
             });
 
             $('input[type=checkbox].select-submission').on('change', function() {
-                selectedSubmissions[this.value] = this.checked;
-
                 updateActions();
             });
         });

--- a/wagtail/wagtailforms/templates/wagtailforms/index_submissions.html
+++ b/wagtail/wagtailforms/templates/wagtailforms/index_submissions.html
@@ -117,7 +117,6 @@
     <div class="nice-padding">
         {% if submissions %}
             <form action="{% url 'wagtailforms:delete_submissions' form_page.id %}" method="get">
-                <input type="checkbox" id="select-all" />
                 <button class="button text-replace no icon icon-bin disabled" id="delete-submissions" disabled></button>
 
                 {% include "wagtailforms/list_submissions.html" %}

--- a/wagtail/wagtailforms/templates/wagtailforms/index_submissions.html
+++ b/wagtail/wagtailforms/templates/wagtailforms/index_submissions.html
@@ -88,7 +88,7 @@
     </script>
 {% endblock %}
 {% block content %}
-    <header class="nice-padding" style="margin-bottom: 0px;">
+    <header class="nice-padding">
         <form action="" method="get" novalidate>
             <div class="row">
                 <div class="left">

--- a/wagtail/wagtailforms/templates/wagtailforms/index_submissions.html
+++ b/wagtail/wagtailforms/templates/wagtailforms/index_submissions.html
@@ -59,7 +59,7 @@
 
             // Initialise selectedSubmissions
             $('input[type=checkbox].select-submission').each(function() {
-                selectedSubmissions[this.dataset.submissionId] = false;
+                selectedSubmissions[this.value] = false;
             });
 
 
@@ -73,14 +73,14 @@
 
                 // Update checkbox states in DOM
                 $('input[type=checkbox].select-submission').each(function() {
-                    this.checked = selectedSubmissions[this.dataset.submissionId];
+                    this.checked = selectedSubmissions[this.value];
                 });
 
                 updateActions();
             });
 
             $('input[type=checkbox].select-submission').on('change', function() {
-                selectedSubmissions[this.dataset.submissionId] = this.checked;
+                selectedSubmissions[this.value] = this.checked;
 
                 updateActions();
             });

--- a/wagtail/wagtailforms/templates/wagtailforms/index_submissions.html
+++ b/wagtail/wagtailforms/templates/wagtailforms/index_submissions.html
@@ -50,10 +50,10 @@
                 // Delete button state
                 if (someSubmissionsSelected) {
                     deleteButton.classList.remove('disabled')
-                    deleteButton.disabled = false;
+                    deleteButton.style.visibility = "visible";
                 } else {
                     deleteButton.classList.add('disabled')
-                    deleteButton.disabled = true;
+                    deleteButton.style.visibility = "hidden";
                 }
             }
 
@@ -88,7 +88,7 @@
     </script>
 {% endblock %}
 {% block content %}
-    <header class="nice-padding">
+    <header class="nice-padding" style="margin-bottom: 0px;">
         <form action="" method="get" novalidate>
             <div class="row">
                 <div class="left">
@@ -117,8 +117,6 @@
     <div class="nice-padding">
         {% if submissions %}
             <form action="{% url 'wagtailforms:delete_submissions' form_page.id %}" method="get">
-                <button class="button text-replace no icon icon-bin disabled" id="delete-submissions" disabled></button>
-
                 {% include "wagtailforms/list_submissions.html" %}
 
                 {% include "wagtailadmin/shared/pagination_nav.html" with items=submissions is_searching=False linkurl='-' %}

--- a/wagtail/wagtailforms/templates/wagtailforms/list_submissions.html
+++ b/wagtail/wagtailforms/templates/wagtailforms/list_submissions.html
@@ -6,6 +6,7 @@
     <col />
     <thead>
         <tr>
+            <th></th>
             {% for heading in data_headings %}
                 <th>{{ heading }}</th>
             {% endfor %}
@@ -14,6 +15,9 @@
     <tbody>
         {% for row in data_rows %}
             <tr>
+                <td>
+                    <input type="checkbox" name="select-{{ row.model_id }}" class="select-submission" data-submission-id="{{ row.model_id }}" />
+                </td>
                 {% for cell in row.fields %}
                     <td>
                         {{ cell }}

--- a/wagtail/wagtailforms/templates/wagtailforms/list_submissions.html
+++ b/wagtail/wagtailforms/templates/wagtailforms/list_submissions.html
@@ -21,7 +21,7 @@
         {% for row in data_rows %}
             <tr>
                 <td>
-                    <input type="checkbox" name="select-{{ row.model_id }}" class="select-submission" data-submission-id="{{ row.model_id }}" />
+                    <input type="checkbox" name="select-{{ row.model_id }}" class="select-submission" value="{{ row.model_id }}" />
                 </td>
                 {% for cell in row.fields %}
                     <td>

--- a/wagtail/wagtailforms/templates/wagtailforms/list_submissions.html
+++ b/wagtail/wagtailforms/templates/wagtailforms/list_submissions.html
@@ -6,7 +6,7 @@
     <col />
     <thead>
         <tr>
-            <th></th>
+            <th><input type="checkbox" id="select-all" /></th>
             {% for heading in data_headings %}
                 <th>{{ heading }}</th>
             {% endfor %}

--- a/wagtail/wagtailforms/templates/wagtailforms/list_submissions.html
+++ b/wagtail/wagtailforms/templates/wagtailforms/list_submissions.html
@@ -9,7 +9,6 @@
             {% for heading in data_headings %}
                 <th>{{ heading }}</th>
             {% endfor %}
-            <th>{% trans "Actions" %}</th>
         </tr>
     </thead>
     <tbody>
@@ -21,10 +20,6 @@
                     </td>
                 {% endfor %}
                 <td>
-                <a class="button button-small button-secondary" href="
-                    {% url 'wagtailforms:delete_submission' form_page.id row.model_id %}">
-                    {% trans 'delete' %}</a>
-                </td>
             </tr>
         {% endfor %}
     </tbody>

--- a/wagtail/wagtailforms/templates/wagtailforms/list_submissions.html
+++ b/wagtail/wagtailforms/templates/wagtailforms/list_submissions.html
@@ -6,6 +6,11 @@
     <col />
     <thead>
         <tr>
+            <th colspan="{{ data_headings|length|add:1 }}">
+                <button class="button no" id="delete-submissions" style="visibility: hidden">Delete selected submissions</button>
+            </th>
+        </tr>
+        <tr>
             <th><input type="checkbox" id="select-all" /></th>
             {% for heading in data_headings %}
                 <th>{{ heading }}</th>

--- a/wagtail/wagtailforms/templates/wagtailforms/list_submissions.html
+++ b/wagtail/wagtailforms/templates/wagtailforms/list_submissions.html
@@ -21,7 +21,7 @@
         {% for row in data_rows %}
             <tr>
                 <td>
-                    <input type="checkbox" name="select-{{ row.model_id }}" class="select-submission" value="{{ row.model_id }}" />
+                    <input type="checkbox" name="selected-submissions" class="select-submission" value="{{ row.model_id }}" />
                 </td>
                 {% for cell in row.fields %}
                     <td>

--- a/wagtail/wagtailforms/tests/test_views.py
+++ b/wagtail/wagtailforms/tests/test_views.py
@@ -771,7 +771,7 @@ class TestDeleteFormSubmission(TestCase, WagtailTestUtils):
         response = self.client.get(reverse(
             'wagtailforms:delete_submissions',
             args=(self.form_page.id, )
-        ) + '?select-{}=on'.format(FormSubmission.objects.first().id))
+        ) + '?selected-submissions={}'.format(FormSubmission.objects.first().id))
         # Check show confirm page when HTTP method is GET
         self.assertTemplateUsed(response, 'wagtailforms/confirm_delete.html')
 
@@ -782,7 +782,7 @@ class TestDeleteFormSubmission(TestCase, WagtailTestUtils):
         response = self.client.post(reverse(
             'wagtailforms:delete_submissions',
             args=(self.form_page.id, )
-        ) + '?select-{}=on'.format(FormSubmission.objects.first().id))
+        ) + '?selected-submissions={}'.format(FormSubmission.objects.first().id))
 
         # Check that the submission is gone
         self.assertEqual(FormSubmission.objects.count(), 1)
@@ -793,7 +793,7 @@ class TestDeleteFormSubmission(TestCase, WagtailTestUtils):
         response = self.client.post(reverse(
             'wagtailforms:delete_submissions',
             args=(self.form_page.id, )
-        ) + '?select-{}=on&select-{}=on'.format(FormSubmission.objects.first().id, FormSubmission.objects.last().id))
+        ) + '?selected-submissions={}&selected-submissions={}'.format(FormSubmission.objects.first().id, FormSubmission.objects.last().id))
 
         # Check that both submissions are gone
         self.assertEqual(FormSubmission.objects.count(), 0)
@@ -806,7 +806,7 @@ class TestDeleteFormSubmission(TestCase, WagtailTestUtils):
         response = self.client.post(reverse(
             'wagtailforms:delete_submissions',
             args=(self.form_page.id, )
-        ) + '?select-{}=on'.format(FormSubmission.objects.first().id))
+        ) + '?selected-submissions={}'.format(FormSubmission.objects.first().id))
 
         # Check that the user received a 403 response
         self.assertEqual(response.status_code, 403)
@@ -823,7 +823,7 @@ class TestDeleteFormSubmission(TestCase, WagtailTestUtils):
             response = self.client.post(reverse(
                 'wagtailforms:delete_submissions',
                 args=(self.form_page.id, )
-            ) + '?select-{}=on'.format(FormSubmission.objects.first().id))
+            ) + '?selected-submissions={}'.format(FormSubmission.objects.first().id))
 
         # An user can't delete a from submission with the hook
         self.assertEqual(response.status_code, 403)
@@ -833,7 +833,7 @@ class TestDeleteFormSubmission(TestCase, WagtailTestUtils):
         response = self.client.post(reverse(
             'wagtailforms:delete_submissions',
             args=(self.form_page.id, )
-        ) + '?select-{}=on'.format(CustomFormPageSubmission.objects.first().id))
+        ) + '?selected-submissions={}'.format(CustomFormPageSubmission.objects.first().id))
         self.assertEqual(FormSubmission.objects.count(), 1)
         self.assertRedirects(response, reverse("wagtailforms:list_submissions", args=(self.form_page.id,)))
 
@@ -849,7 +849,7 @@ class TestDeleteCustomFormSubmission(TestCase):
         response = self.client.get(reverse(
             'wagtailforms:delete_submissions',
             args=(self.form_page.id, )
-        ) + '?select-{}=on'.format(CustomFormPageSubmission.objects.first().id))
+        ) + '?selected-submissions={}'.format(CustomFormPageSubmission.objects.first().id))
 
         # Check show confirm page when HTTP method is GET
         self.assertTemplateUsed(response, 'wagtailforms/confirm_delete.html')
@@ -861,7 +861,7 @@ class TestDeleteCustomFormSubmission(TestCase):
         response = self.client.post(reverse(
             'wagtailforms:delete_submissions',
             args=(self.form_page.id, )
-        ) + '?select-{}=on'.format(CustomFormPageSubmission.objects.first().id))
+        ) + '?selected-submissions={}'.format(CustomFormPageSubmission.objects.first().id))
 
         # Check that the submission is gone
         self.assertEqual(CustomFormPageSubmission.objects.count(), 1)
@@ -872,7 +872,7 @@ class TestDeleteCustomFormSubmission(TestCase):
         response = self.client.post(reverse(
             'wagtailforms:delete_submissions',
             args=(self.form_page.id, )
-        ) + '?select-{}=on&select-{}=on'.format(CustomFormPageSubmission.objects.first().id, CustomFormPageSubmission.objects.last().id))
+        ) + '?selected-submissions={}&selected-submissions={}'.format(CustomFormPageSubmission.objects.first().id, CustomFormPageSubmission.objects.last().id))
 
         # Check that both submissions are gone
         self.assertEqual(CustomFormPageSubmission.objects.count(), 0)
@@ -885,7 +885,7 @@ class TestDeleteCustomFormSubmission(TestCase):
         response = self.client.post(reverse(
             'wagtailforms:delete_submissions',
             args=(self.form_page.id, )
-        ) + '?select-{}=on'.format(CustomFormPageSubmission.objects.first().id))
+        ) + '?selected-submissions={}'.format(CustomFormPageSubmission.objects.first().id))
 
         # Check that the user received a 403 response
         self.assertEqual(response.status_code, 403)

--- a/wagtail/wagtailforms/tests/test_views.py
+++ b/wagtail/wagtailforms/tests/test_views.py
@@ -767,11 +767,11 @@ class TestDeleteFormSubmission(TestCase, WagtailTestUtils):
         self.assertTrue(self.client.login(username='siteeditor', password='password'))
         self.form_page = Page.objects.get(url_path='/home/contact-us/')
 
-    def test_delete_submission_show_cofirmation(self):
+    def test_delete_submission_show_confirmation(self):
         response = self.client.get(reverse(
-            'wagtailforms:delete_submission',
-            args=(self.form_page.id, FormSubmission.objects.first().id)
-        ))
+            'wagtailforms:delete_submissions',
+            args=(self.form_page.id, )
+        ) + '?select-{}=on'.format(FormSubmission.objects.first().id))
         # Check show confirm page when HTTP method is GET
         self.assertTemplateUsed(response, 'wagtailforms/confirm_delete.html')
 
@@ -780,12 +780,23 @@ class TestDeleteFormSubmission(TestCase, WagtailTestUtils):
 
     def test_delete_submission_with_permissions(self):
         response = self.client.post(reverse(
-            'wagtailforms:delete_submission',
-            args=(self.form_page.id, FormSubmission.objects.first().id)
-        ))
+            'wagtailforms:delete_submissions',
+            args=(self.form_page.id, )
+        ) + '?select-{}=on'.format(FormSubmission.objects.first().id))
 
         # Check that the submission is gone
         self.assertEqual(FormSubmission.objects.count(), 1)
+        # Should be redirected to list of submissions
+        self.assertRedirects(response, reverse("wagtailforms:list_submissions", args=(self.form_page.id,)))
+
+    def test_delete_multiple_submissions_with_permissions(self):
+        response = self.client.post(reverse(
+            'wagtailforms:delete_submissions',
+            args=(self.form_page.id, )
+        ) + '?select-{}=on&select-{}=on'.format(FormSubmission.objects.first().id, FormSubmission.objects.last().id))
+
+        # Check that both submissions are gone
+        self.assertEqual(FormSubmission.objects.count(), 0)
         # Should be redirected to list of submissions
         self.assertRedirects(response, reverse("wagtailforms:list_submissions", args=(self.form_page.id,)))
 
@@ -793,9 +804,9 @@ class TestDeleteFormSubmission(TestCase, WagtailTestUtils):
         self.assertTrue(self.client.login(username="eventeditor", password="password"))
 
         response = self.client.post(reverse(
-            'wagtailforms:delete_submission',
-            args=(self.form_page.id, FormSubmission.objects.first().id)
-        ))
+            'wagtailforms:delete_submissions',
+            args=(self.form_page.id, )
+        ) + '?select-{}=on'.format(FormSubmission.objects.first().id))
 
         # Check that the user received a 403 response
         self.assertEqual(response.status_code, 403)
@@ -810,9 +821,9 @@ class TestDeleteFormSubmission(TestCase, WagtailTestUtils):
 
         with self.register_hook('filter_form_submissions_for_user', construct_forms_for_user):
             response = self.client.post(reverse(
-                'wagtailforms:delete_submission',
-                args=(self.form_page.id, FormSubmission.objects.first().id)
-            ))
+                'wagtailforms:delete_submissions',
+                args=(self.form_page.id, )
+            ) + '?select-{}=on'.format(FormSubmission.objects.first().id))
 
         # An user can't delete a from submission with the hook
         self.assertEqual(response.status_code, 403)
@@ -820,9 +831,9 @@ class TestDeleteFormSubmission(TestCase, WagtailTestUtils):
 
         # An user can delete a form submission without the hook
         response = self.client.post(reverse(
-            'wagtailforms:delete_submission',
-            args=(self.form_page.id, FormSubmission.objects.first().id)
-        ))
+            'wagtailforms:delete_submissions',
+            args=(self.form_page.id, )
+        ) + '?select-{}=on'.format(CustomFormPageSubmission.objects.first().id))
         self.assertEqual(FormSubmission.objects.count(), 1)
         self.assertRedirects(response, reverse("wagtailforms:list_submissions", args=(self.form_page.id,)))
 
@@ -834,11 +845,12 @@ class TestDeleteCustomFormSubmission(TestCase):
         self.assertTrue(self.client.login(username='siteeditor', password='password'))
         self.form_page = Page.objects.get(url_path='/home/contact-us-one-more-time/')
 
-    def test_delete_submission_show_cofirmation(self):
+    def test_delete_submission_show_confirmation(self):
         response = self.client.get(reverse(
-            'wagtailforms:delete_submission',
-            args=(self.form_page.id, CustomFormPageSubmission.objects.first().id)
-        ))
+            'wagtailforms:delete_submissions',
+            args=(self.form_page.id, )
+        ) + '?select-{}=on'.format(CustomFormPageSubmission.objects.first().id))
+
         # Check show confirm page when HTTP method is GET
         self.assertTemplateUsed(response, 'wagtailforms/confirm_delete.html')
 
@@ -847,22 +859,33 @@ class TestDeleteCustomFormSubmission(TestCase):
 
     def test_delete_submission_with_permissions(self):
         response = self.client.post(reverse(
-            'wagtailforms:delete_submission',
-            args=(self.form_page.id, CustomFormPageSubmission.objects.first().id)
-        ))
+            'wagtailforms:delete_submissions',
+            args=(self.form_page.id, )
+        ) + '?select-{}=on'.format(CustomFormPageSubmission.objects.first().id))
 
         # Check that the submission is gone
         self.assertEqual(CustomFormPageSubmission.objects.count(), 1)
         # Should be redirected to list of submissions
         self.assertRedirects(response, reverse("wagtailforms:list_submissions", args=(self.form_page.id, )))
 
+    def test_delete_multiple_submissions_with_permissions(self):
+        response = self.client.post(reverse(
+            'wagtailforms:delete_submissions',
+            args=(self.form_page.id, )
+        ) + '?select-{}=on&select-{}=on'.format(CustomFormPageSubmission.objects.first().id, CustomFormPageSubmission.objects.last().id))
+
+        # Check that both submissions are gone
+        self.assertEqual(CustomFormPageSubmission.objects.count(), 0)
+        # Should be redirected to list of submissions
+        self.assertRedirects(response, reverse("wagtailforms:list_submissions", args=(self.form_page.id,)))
+
     def test_delete_submission_bad_permissions(self):
         self.assertTrue(self.client.login(username="eventeditor", password="password"))
 
         response = self.client.post(reverse(
-            'wagtailforms:delete_submission',
-            args=(self.form_page.id, CustomFormPageSubmission.objects.first().id)
-        ))
+            'wagtailforms:delete_submissions',
+            args=(self.form_page.id, )
+        ) + '?select-{}=on'.format(CustomFormPageSubmission.objects.first().id))
 
         # Check that the user received a 403 response
         self.assertEqual(response.status_code, 403)

--- a/wagtail/wagtailforms/urls.py
+++ b/wagtail/wagtailforms/urls.py
@@ -7,5 +7,5 @@ from wagtail.wagtailforms import views
 urlpatterns = [
     url(r'^$', views.index, name='index'),
     url(r'^submissions/(\d+)/$', views.list_submissions, name='list_submissions'),
-    url(r'^submissions/(\d+)/(\d+)/delete/$', views.delete_submission, name='delete_submission')
+    url(r'^submissions/(\d+)/delete/$', views.delete_submissions, name='delete_submissions')
 ]

--- a/wagtail/wagtailforms/views.py
+++ b/wagtail/wagtailforms/views.py
@@ -7,7 +7,7 @@ from django.core.exceptions import PermissionDenied
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils.encoding import smart_str
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ungettext
 
 from wagtail.utils.pagination import paginate
 from wagtail.wagtailadmin import messages
@@ -37,9 +37,17 @@ def delete_submissions(request, page_id):
     submissions = page.get_submission_class()._default_manager.filter(id__in=submission_ids)
 
     if request.method == 'POST':
+        count = submissions.count()
         submissions.delete()
 
-        messages.success(request, _("X submissions have been deleted."))  # FIXME
+        messages.success(request, ungettext(
+            "One submission has been deleted.",
+            "%(count)d submissions have been deleted.",
+            count) % {
+                'count': count,
+            }
+        )
+
         return redirect('wagtailforms:list_submissions', page_id)
 
     return render(request, 'wagtailforms/confirm_delete.html', {

--- a/wagtail/wagtailforms/views.py
+++ b/wagtail/wagtailforms/views.py
@@ -33,7 +33,7 @@ def delete_submissions(request, page_id):
     page = get_object_or_404(Page, id=page_id).specific
 
     # Get submissions
-    submission_ids = [int(key[7:]) for key in request.GET.keys() if key.startswith('select-')]
+    submission_ids = request.GET.getlist('selected-submissions')
     submissions = page.get_submission_class()._default_manager.filter(id__in=submission_ids)
 
     if request.method == 'POST':

--- a/wagtail/wagtailforms/views.py
+++ b/wagtail/wagtailforms/views.py
@@ -7,7 +7,7 @@ from django.core.exceptions import PermissionDenied
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils.encoding import smart_str
-from django.utils.translation import ugettext as _, ungettext
+from django.utils.translation import ungettext
 
 from wagtail.utils.pagination import paginate
 from wagtail.wagtailadmin import messages
@@ -40,10 +40,13 @@ def delete_submissions(request, page_id):
         count = submissions.count()
         submissions.delete()
 
-        messages.success(request, ungettext(
-            "One submission has been deleted.",
-            "%(count)d submissions have been deleted.",
-            count) % {
+        messages.success(
+            request,
+            ungettext(
+                "One submission has been deleted.",
+                "%(count)d submissions have been deleted.",
+                count
+            ) % {
                 'count': count,
             }
         )

--- a/wagtail/wagtailforms/views.py
+++ b/wagtail/wagtailforms/views.py
@@ -26,22 +26,25 @@ def index(request):
     })
 
 
-def delete_submission(request, page_id, submission_id):
+def delete_submissions(request, page_id):
     if not get_forms_for_user(request.user).filter(id=page_id).exists():
         raise PermissionDenied
 
     page = get_object_or_404(Page, id=page_id).specific
-    submission = get_object_or_404(page.get_submission_class(), id=submission_id)
+
+    # Get submissions
+    submission_ids = [int(key[7:]) for key in request.GET.keys() if key.startswith('select-')]
+    submissions = page.get_submission_class()._default_manager.filter(id__in=submission_ids)
 
     if request.method == 'POST':
-        submission.delete()
+        submissions.delete()
 
-        messages.success(request, _("Submission deleted."))
+        messages.success(request, _("X submissions have been deleted."))  # FIXME
         return redirect('wagtailforms:list_submissions', page_id)
 
     return render(request, 'wagtailforms/confirm_delete.html', {
         'page': page,
-        'submission': submission
+        'submissions': submissions,
     })
 
 


### PR DESCRIPTION
This pull request replaces the exsting deletion interface for form submissions (implemented in #1528) with one that allows deleting multiple submissions at the same time.

## Motivation

Some of our clients have a lot of form submissions and would like to delete them all to comply with data protection. It is very time consuming to have to do this one at a time. There is also a problem with the action buttons being on the right, which makes them difficult to get to for forms that have many fields.

## Solution

Each submission now has a checkbox to the left of it. When a checkbox is checked a delete button appears at the top. Clicking the delete button takes the user to the "confirm delete" view. It's possible to select multiple submisssions and delete them together.

It also has a gmail-like select/deselect all button at the very top to speed up mass-deletions.

## Screenshot

The "delete selected submissions" button only appears when one or more submissions have been selected

![bulk-delete-submissions](https://cloud.githubusercontent.com/assets/1093808/21348558/91079e42-c6a5-11e6-8ad7-3802c558a1e1.png)