### PR TITLE
Add config to allow change UserPagePermissionsProxy

### DIFF
--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -24,6 +24,7 @@ from django.template.response import TemplateResponse
 from django.utils import six, timezone
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.functional import cached_property
+from django.utils.module_loading import import_string
 from django.utils.six import StringIO
 from django.utils.six.moves.urllib.parse import urlparse
 from django.utils.text import capfirst, slugify
@@ -1573,6 +1574,16 @@ class GroupPagePermission(models.Model):
 
 
 class UserPagePermissionsProxy(object):
+
+    def __new__(cls, *args, **kwargs):
+        klass_path = getattr(settings, 'WAGTAIL_USER_PAGE_PERMISSION_PROXY', 'wagtail.wagtailcore.models.DefaultUserPagePermissionsProxy')
+        klass = import_string(klass_path)
+        obj = super().__new__(klass, *args, **kwargs)
+        obj.__init__(*args, **kwargs)
+        return obj
+
+
+class DefaultUserPagePermissionsProxy(object):
     """Helper object that encapsulates all the page permission rules that this user has
     across the page hierarchy."""
     def __init__(self, user):

--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -1578,8 +1578,7 @@ class UserPagePermissionsProxy(object):
     def __new__(cls, *args, **kwargs):
         klass_path = getattr(settings, 'WAGTAIL_USER_PAGE_PERMISSION_PROXY', 'wagtail.wagtailcore.models.DefaultUserPagePermissionsProxy')
         klass = import_string(klass_path)
-        obj = super().__new__(klass, *args, **kwargs)
-        obj.__init__(*args, **kwargs)
+        obj = klass(*args, **kwargs)
         return obj
 
 

--- a/wagtail/wagtailcore/tests/test_page_permissions.py
+++ b/wagtail/wagtailcore/tests/test_page_permissions.py
@@ -5,7 +5,9 @@ from django.contrib.auth.models import Group
 from django.test import TestCase
 
 from wagtail.tests.testapp.models import BusinessSubIndex, EventIndex, EventPage
-from wagtail.wagtailcore.models import GroupPagePermission, Page, UserPagePermissionsProxy
+from wagtail.wagtailcore.models import (
+    DefaultUserPagePermissionsProxy, GroupPagePermission, Page, UserPagePermissionsProxy
+)
 
 
 class TestPagePermission(TestCase):
@@ -466,3 +468,24 @@ class TestPagePermission(TestCase):
         perms = UserPagePermissionsProxy(user).for_page(christmas_page)
 
         self.assertFalse(perms.can_lock())
+
+
+class CustomUserPagePermission(DefaultUserPagePermissionsProxy):
+    pass
+
+
+class TestPagePermissionProxy(TestCase):
+    fixtures = ['test.json']
+
+    def test_default_user_page_permission_proxy(self):
+        user = get_user_model().objects.get(username='inactiveuser')
+        permission_proxy = UserPagePermissionsProxy(user)
+        self.assertIsInstance(permission_proxy, DefaultUserPagePermissionsProxy)
+
+
+    def test_override_user_page_permission_proxy(self):
+        custom_permission = 'wagtail.wagtailcore.tests.test_page_permissions.CustomUserPagePermission'
+        with self.settings(WAGTAIL_USER_PAGE_PERMISSION_PROXY=custom_permission):
+            user = get_user_model().objects.get(username='inactiveuser')
+            permission_proxy = UserPagePermissionsProxy(user)
+            self.assertIsInstance(permission_proxy, CustomUserPagePermission)


### PR DESCRIPTION
Add `WAGTAIL_USER_PAGE_PERMISSION_PROXY` config to let user change the PermissionProxy used. 

Thinking about a long-term, I'm imagining we will have use cases to change a lot of Page methods/properties, so being able to swap the `Page` object and override methods/properties seems simpler than creating tons of settings. But changing `Page` to be swappable will need more work.  

What do you guys think about this change? Any suggestions? 
