### PR TITLE
Example of better separated action buttons

### DIFF
--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/edit.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/edit.html
@@ -40,27 +40,31 @@
                     <div class="dropdown dropup dropdown-button match-width {% if is_revision %}warning{% endif %}">
                         <button type="submit" class="button action-save button-longrunning {% if is_revision %}warning{% endif %}" tabindex="3" data-clicked-text="{% trans 'Saving...' %}" {% if page.locked %}disabled {% endif %}><span class="icon icon-spinner"></span><em>{% if page.locked %}{% trans 'Page locked' %}{% else %}{% if is_revision %}{% trans 'Replace current draft' %}{% else %}{% trans 'Save draft' %}{% endif %}{% endif %}</em></button>
 
-                        {% if not page.locked %}
+                        {% if not page.locked and not is_revision %}
                             <div class="dropdown-toggle icon icon-arrow-up"></div>
                             <ul role="menu">
-                                {% if not is_revision and page_perms.can_unpublish %}
-                                    <li><a href="{% url 'wagtailadmin_pages:unpublish' page.id %}">{% trans 'Unpublish' %}</a></li>
+                                {% if page_perms.can_delete %}
+                                    <li style="border-width: 0;"><a href="{% url 'wagtailadmin_pages:delete' page.id %}" class="shortcut button no">
+                                      <span class="icon icon-bin"></span>
+                                      {% trans 'Delete' %}</a></li>
                                 {% endif %}
-                                {% if not is_revision and page_perms.can_delete %}
-                                    <li><a href="{% url 'wagtailadmin_pages:delete' page.id %}" class="shortcut">{% trans 'Delete' %}</a></li>
+                                {% if page_perms.can_unpublish %}
+                                    <li style="border-width: 0;"><a href="{% url 'wagtailadmin_pages:unpublish' page.id %}" class="button warning">
+                                      <span class="icon icon-cross"></span>
+                                      {% trans 'Unpublish' %}</a></li>
                                 {% endif %}
-                                {% if page_perms.can_publish %}
-                                    <li>
-                                        <button type="submit" name="action-publish" value="action-publish" class="button button-longrunning {% if is_revision %}warning{% endif %}" tabindex="3" data-clicked-text="{% trans 'Publishing...' %}" {% if page.locked %}disabled {% endif %}><span class="icon icon-spinner"></span><em>{% if is_revision %}{% trans 'Publish this revision' %}{% else %}{% trans 'Publish' %}{% endif %}</em></button>
-                                    </li>
-                                {% endif %}
-                                {% if not is_revision %}
-                                    <li><input type="submit" name="action-submit" value="{% trans 'Submit for moderation' %}" class="button" /></li>
-                                {% endif %}
+                                <li style="border-width: 0;">&nbsp;</li>
+
+                                <li><button type="submit" name="action-submit" value="{% trans 'Submit for moderation' %}" class="button xbutton-secondary xyes">
+                                  <span class="icon icon-success"></span>
+                                  {% trans 'Submit for moderation' %}</button></li>
+
                             </ul>
                         {% endif %}
                     </div>
                 </li>
+
+
 
                 <li class="actions preview">
                     {% trans 'Preview' as preview_label %}
@@ -80,6 +84,18 @@
                         {% include "wagtailadmin/pages/_preview_button_on_edit.html" with label=preview_label icon=1 %}
                     {% endif %}
                 </li>
+
+                {% if page_perms.can_publish %}
+                    <li class="actions" style="width: auto;">
+                        <button type="submit" name="action-publish" value="action-publish"
+                        class="button yes button-longrunning icon icon-tick {% if is_revision %}warning{% endif %}" tabindex="3" data-clicked-text="{% trans 'Publishing...' %}" {% if page.locked %}disabled {% endif %}><span class="icon icon-spinner"></span><em>
+                          {% if is_revision %}
+                            {% trans 'Publish this revision' %}
+                          {% else %}
+                            {% trans 'Publish' %}{% endif %}
+                        </em></button>
+                    </li>
+                {% endif %}
 
                 <li class="meta">
                     <p class="modified">


### PR DESCRIPTION
A very minimal change to address some of the ideas from https://github.com/wagtail/wagtail/issues/2214
as well as some of my personal annoyances with the current design.

Features:

- Separate publish button for faster and less annoying publishing.
- Color coded buttons for publish, unpublish and delete.
- Reordered dropdown elements based on how destructive each option is.
- A spacer between "positive" (save/submit) and "negative" (unpublish/delete) actions in the dropdown.
- Add icons for most options (somewhat arbitrarily chosen) for quick recognition without having to read.
 
This only adds one button so it doesn't increase the width of the button bar too much.

**Current footer:**
![old footer](https://cloud.githubusercontent.com/assets/11335309/12911108/db028f66-cf07-11e5-8808-b3938b5ca72a.png)

**New footer:**
![new footer](https://cloud.githubusercontent.com/assets/2144849/21388431/83c65598-c77c-11e6-85d9-be7b57e56a23.png)



**Tag this pull request with: "Work in progress" or "Request for comments" etc.**