### PR TITLE
Improved footer menu with 3 shortcut buttons and one drop-up for all other actions

### DIFF
--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_dropdowns.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_dropdowns.scss
@@ -417,6 +417,3 @@
 .is-open .u-toggle {
     display: block;
 }
-
-
-

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/core.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/core.scss
@@ -430,11 +430,6 @@ footer,
         }
     }
 
-    footer {
-        width: 80%;
-        margin-left: 50px;
-    }
-
     .content {
         border-top: 0;
         background-color: none;
@@ -457,7 +452,7 @@ footer,
 
     footer {
         width: 80%;
-        margin-left: 50px;
+        margin-left: 1em;
     }
 
 
@@ -495,6 +490,7 @@ footer,
 
     footer {
         width: 90em;
+        margin-left: 50px;
     }
 }
 

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/_preview_button_on_edit.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/_preview_button_on_edit.html
@@ -1,4 +1,5 @@
 <button class="button action-preview {% if icon %}icon icon-view{% endif %}"
     data-action="{% url 'wagtailadmin_pages:preview_on_edit' page.id %}{% if mode %}?mode={{ mode|urlencode }}{% endif %}"
     data-placeholder="{% url 'wagtailadmin_pages:preview' %}"
-    data-windowname="wagtail_preview_{{ page.id }}">{{ label }}</button>
+    data-windowname="wagtail_preview_{{ page.id }}">{% if icon %}<span class="hidesmall">{{ label }}</span>{% else %}{{ label }}{% endif %}
+    </button>

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/_preview_button_on_edit.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/_preview_button_on_edit.html
@@ -1,5 +1,12 @@
 <button class="button action-preview {% if icon %}icon icon-view{% endif %}"
     data-action="{% url 'wagtailadmin_pages:preview_on_edit' page.id %}{% if mode %}?mode={{ mode|urlencode }}{% endif %}"
     data-placeholder="{% url 'wagtailadmin_pages:preview' %}"
-    data-windowname="wagtail_preview_{{ page.id }}">{% if icon %}<span class="hidesmall">{{ label }}</span>{% else %}{{ label }}{% endif %}
+    data-windowname="wagtail_preview_{{ page.id }}">{% if icon == 2 %}<span class="hidesmall">{{ label }}</span>
+    {% comment %}
+    {% elif icon == 1 %}
+
+    <span class="hidesmall">{{ label }}</span>
+    <b style="display: inline-block; width: 3em;">&nbsp;</b>
+    {% endcomment %}
+    {% else %}{{ label }}{% endif %}
     </button>

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/_temp_style.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/_temp_style.html
@@ -1,0 +1,134 @@
+<style media="screen">
+  .actions.variable {
+    width: auto;
+  }
+  .actions.variable .dropdown ul li a,
+  .actions.variable .dropdown ul li .button {
+    padding-right: 1em;
+    max-width: 18em;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .dropdown.dropdown-button.moreactions {
+      min-width: 3em;
+      height: 2.4em;
+      font-size: 0.9em;
+      /*margin: 0 auto;*/
+      margin: 0 0 0 auto;
+  }
+  .dropdown.moreactions.open ul {
+    left: auto;
+    right: 35%;
+    margin-right: -4em;
+
+    bottom: 3.9em;
+    min-width: 15em;
+    border-radius: 0.5em;
+    overflow: visible;
+    padding-top: 8px;
+    padding-bottom: 8px;
+  }
+  .dropdown.moreactions.open ul:after {
+    content: "";
+    position: absolute;
+    bottom: -2em;
+    margin-bottom: 2px;
+    right: 2em;
+    border-top: 2em solid #43b1b0;
+    border-left: 2em solid transparent;
+    border-right: 2em solid transparent;
+
+  }
+  .dropdown.moreactions.open ul li .noborder {
+    border: 0;
+    color: #fff;
+  }
+  .dropdown.moreactions.open ul li.spacer {
+    border-bottom-width: 4px;
+  }
+  .dropdown.dropdown-button.moreactions .dropdown-toggle {
+    border-radius: 3px;
+    border: 0;
+    width: 3em;
+    height: 2.4em;
+    line-height: 2.4em;
+    padding: 0;
+    text-align: center;
+  }
+  .dropdown.dropup.dropdown-button.moreactions.open .dropdown-toggle {
+    border-radius: 3px;
+  }
+  .hidesmall {
+    display: none;
+  }
+  .onlybig {
+    display: none;
+  }
+  .icon.rotate90:before {
+    -webkit-transform: rotate(0.25turn);
+    transform: rotate(0.25turn);
+    transform-origin: 50% 60% 0;
+    display: inline-block;
+
+  }
+  .spaced-flex {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    justify-content: space-between;
+  }
+  .spaced-flex li {
+    flex: 1 0 auto;
+  }
+  .spaced-flex .dropdown.dropdown-button.moreactions .dropdown-toggle,
+  .spaced-flex li>button {
+    min-width: 70%;
+  }
+  .center-button button {
+    margin: 0 auto;
+    display: block;
+  }
+  @media screen and (min-width: 50em) {
+    .dropdown.moreactions.open ul {
+      bottom: 4.5em;
+      right: 35%;
+      margin-right: -7.5em;
+    }
+    .dropdown.moreactions.open ul:after {
+      left: auto;
+      right: 7.5em;
+      margin-right: -2em;
+    }
+    .dropdown.dropdown-button.moreactions {
+        height: 3em;
+        font-size: 0.95em;
+    }
+    .dropdown.dropdown-button.moreactions .dropdown-toggle {
+      height: 3em;
+      line-height: 3em;
+    }
+    .hidesmall {
+      display: inline-block;
+    }
+    .actions.variable .dropdown ul li a,
+    .actions.variable .dropdown ul li .button {
+      max-width: 22em;
+    }
+    .meta {
+      width: 30%;
+    }
+  }
+
+  @media screen and (min-width: 90em) {
+    .onlybig {
+      display: inline-block;
+    }
+    .actions.variable .dropdown ul li a,
+    .actions.variable .dropdown ul li .button {
+      max-width: 30em;
+    }
+    .meta {
+      width: 40%;
+    }
+  }
+</style>

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/create.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/create.html
@@ -24,7 +24,85 @@
 
         {% page_permissions parent_page as parent_page_perms %}
         <footer>
-            <ul>
+          {% include "wagtailadmin/pages/_temp_style.html" %}
+          <ul class="spaced-flex">
+            <li class="actions variable">
+              <button type="submit" class="button action-save button-longrunning {% if is_revision %}warning{% endif %}" tabindex="3"
+              data-clicked-text="{% trans 'Saving...' %}" {% if page.locked %}disabled {% endif %}>
+              <span class="icon icon-spinner"></span><em>
+                {% if page.locked %}
+                <b class="icon icon-locked"></b>
+                <b class="hidesmall">{% trans 'Page locked' %}</b>{% else %}
+                <i class="icon icon-doc-full-inverse"></i>
+                <b class="hidesmall">{% if is_revision %}{% trans 'Replace current draft' %}{% else %}{% trans 'Save draft' %}{% endif %}{% endif %}</b>
+              </em></button>
+            </li>
+            {% if parent_page_perms.can_publish_subpage %}
+              <li class="actions variable center-button">
+                <button type="submit" name="action-publish" value="action-publish" class="button button-longrunning"
+                tabindex="3" data-clicked-text="{% trans 'Publishing...' %}" {% if page.locked %}disabled {% endif %}><span
+                class="icon icon-spinner"></span><em>
+                  <i class="icon icon-arrow-up-big rotate90"></i>
+                  <b class="hidesmall">{% trans 'Publish' %}</b></em></button>
+              </li>
+            {% elif not is_revision and not page.locked %}
+              <li class="actions variable center-button">
+                  <button type="submit" name="action-submit" value="{% trans 'Submit for moderation' %}" title="{% trans 'Submit for moderation' %}" class="button icon icon-mail" >
+                    <b class="hidesmall">{% trans 'Submit for moderation' %}</b>
+                  </button>
+              </li>
+            {% endif %}
+            {% trans 'Preview' as preview_label %}
+            <li class="actions variable">
+              <div class="dropdown dropup dropdown-button moreactions {% if is_revision %}warning{% endif %}">
+                  <div class="dropdown-toggle" title="{% trans "More actions..." %}">
+                    &bull;&bull;&bull;
+                  </div>
+                  <ul role="menu">
+
+                    {% if preview_modes|length > 1 %}
+                    {% comment %}
+                    {% if not preview_modes|length > 1 %}
+
+                      <!-- dummy preview modes -->
+                      <li>
+                          {% include "wagtailadmin/pages/_preview_button_on_edit.html" with icon=1 label="Preview mode 1" %}
+                      </li>
+                      <li>
+                          {% include "wagtailadmin/pages/_preview_button_on_edit.html" with icon=1 label="Preview 2" %}
+                      </li>
+                      <li>
+                          {% include "wagtailadmin/pages/_preview_button_on_edit.html" with icon=1 label="Very long fake preview mode to test variable width" %}
+                      </li>
+                      {% comment %}
+                      {% endcomment %}
+                      {% for mode_name, mode_display_name in preview_modes %}
+                          <li>
+                              {% include "wagtailadmin/pages/_preview_button_on_create.html" with icon=1 mode=mode_name label=mode_display_name %}
+                          </li>
+                      {% endfor %}
+                    {% else %}
+                      <li>
+                        {% include "wagtailadmin/pages/_preview_button_on_create.html" with label=preview_label icon=1 %}
+                      </li>
+                    {% endif %}
+
+                    {% if parent_page_perms.can_publish and not page.locked %}
+                      <li class="spacer"></li>
+                      <li><input type="submit" name="action-submit" value="{% trans 'Submit for moderation' %}" class="button" /></li>
+                    {% endif %}
+
+                  </ul>
+              </div>
+            </li>
+
+            <li class="meta hidesmall">
+                <p class="modified">
+                  &nbsp;
+                </p>
+            </li>
+
+                {% comment %}
                 <li class="actions">
                     <div class="dropdown dropup dropdown-button match-width">
                         <button type="submit" class="button action-save button-longrunning" tabindex="3" data-clicked-text="{% trans 'Saving...' %}"><span class="icon icon-spinner"></span><em>{% trans 'Save draft' %}</em></button>
@@ -39,6 +117,7 @@
                         </ul>
                     </div>
                 </li>
+
 
                 <li class="actions preview">
                     {% trans 'Preview' as preview_label %}
@@ -58,6 +137,7 @@
                         {% include "wagtailadmin/pages/_preview_button_on_create.html" with label=preview_label icon=1 %}
                     {% endif %}
                 </li>
+                {% endcomment %}
             </ul>
         </footer>
     </form>

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/edit.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/edit.html
@@ -41,6 +41,13 @@
               .actions.variable {
                 width: auto;
               }
+              .actions.variable .dropdown ul li a,
+              .actions.variable .dropdown ul li .button {
+                padding-right: 1em;
+                max-width: 18em;
+                overflow: hidden;
+                text-overflow: ellipsis;
+              }
               .dropdown.dropdown-button.moreactions {
                   width: 3em;
                   height: 3em;
@@ -50,7 +57,7 @@
                 left: auto;
                 right: -1em;
                 bottom: 3.4em;
-                width: 15em;
+                min-width: 15em;
                 border-radius: 0.5em;
               }
               .dropdown.moreactions.open ul li .noborder {
@@ -93,11 +100,19 @@
                 .hidesmall {
                   display: inline-block;
                 }
+                .actions.variable .dropdown ul li a,
+                .actions.variable .dropdown ul li .button {
+                  max-width: 22em;
+                }
               }
 
               @media screen and (min-width: 90em) {
                 .onlybig {
                   display: inline-block;
+                }
+                .actions.variable .dropdown ul li a,
+                .actions.variable .dropdown ul li .button {
+                  max-width: 30em;
                 }
               }
             </style>
@@ -113,7 +128,7 @@
               </li>
               {% if page_perms.can_publish %}
                 <li class="actions variable">
-                  <button type="submit" name="action-publish" value="action-publish" class="button button-longrunning yes {% if is_revision %}warning{% endif %}"
+                  <button type="submit" name="action-publish" value="action-publish" class="button button-longrunning {% if not page.locked %} yes{% endif %} {% if is_revision %}warning{% endif %}"
                   tabindex="3" data-clicked-text="{% trans 'Publishing...' %}" {% if page.locked %}disabled {% endif %}><span
                   class="icon icon-spinner"></span><em>
                     <i class="icon icon-tick"></i>
@@ -126,12 +141,23 @@
               {% endif %}
 
               {% trans 'Preview' as preview_label %}
+              {% comment %}
               {% if preview_modes|length > 1 %}
-                <li class="actions preview">
-                      <div class="dropdown dropup dropdown-button match-width">
+                <li class="actions preview variable">
+                      <div class="dropdown dropup dropdown-button xmatch-width">
                           {% include "wagtailadmin/pages/_preview_button_on_edit.html" with label=preview_label icon=1 %}
                           <div class="dropdown-toggle icon icon-arrow-up"></div>
                           <ul role="menu">
+                            <!-- dummy preview modes -->
+                            <li>
+                                {% include "wagtailadmin/pages/_preview_button_on_edit.html" with  label="Fake mode 1" %}
+                            </li>
+                            <li>
+                                {% include "wagtailadmin/pages/_preview_button_on_edit.html" with  label="Fake" %}
+                            </li>
+                            <li>
+                                {% include "wagtailadmin/pages/_preview_button_on_edit.html" with  label="Fake newsletter for fun" %}
+                            </li>
                               {% for mode_name, mode_display_name in preview_modes %}
                                   <li>
                                       {% include "wagtailadmin/pages/_preview_button_on_edit.html" with mode=mode_name label=mode_display_name %}
@@ -141,18 +167,24 @@
                       </div>
                 </li>
               {% else %}
-                <li class="actions preview variable">
-                  {% include "wagtailadmin/pages/_preview_button_on_edit.html" with label=preview_label icon=1 %}
-                </li>
-              {% endif %}
-              {% if not page.locked %}
-                <li class="actions variable">
-                  <div class="dropdown dropup dropdown-button moreactions {% if is_revision %}warning{% endif %}">
 
-                      <div class="dropdown-toggle xicon xicon-arrow-up">
-                        &bull;&bull;&bull;
-                      </div>
-                      <ul role="menu">
+
+              {% endif %}
+              {% endcomment %}
+
+              <li class="actions preview variable" title="{{ preview_label }}">
+                {% include "wagtailadmin/pages/_preview_button_on_edit.html" with label=preview_label icon=2 %}
+              </li>
+
+
+              <li class="actions variable">
+                <div class="dropdown dropup dropdown-button moreactions {% if is_revision %}warning{% endif %}">
+
+                    <div class="dropdown-toggle xicon xicon-arrow-up" title="{% trans "More actions..." %}">
+                      &bull;&bull;&bull;
+                    </div>
+                    <ul role="menu">
+                      {% if not page.locked %}
                         {% if not is_revision  %}
                           {% if page_perms.can_delete %}
                               <li class=""><a href="{% url 'wagtailadmin_pages:delete' page.id %}" class="shortcut button button-secondary noborder no">
@@ -167,26 +199,52 @@
 
                           {% endif %}
 
-
                           {% if page_perms.can_delete or page_perms.can_unpublish  %}
                             <li class="spacer"></li>
                           {% endif %}
-
                         {% endif %}
+                      {% endif %}
+
+                      {% if preview_modes|length > 1 %}
+                      {% comment %}
+                      {% if not preview_modes|length > 1 %}
+
+                        <!-- dummy preview modes -->
                         <li>
-                          <a href="{% url 'wagtailadmin_pages:revisions_index' page.id %}" class="xunderlined">
-                            <span class="icon icon-time"></span>
-                            {% trans 'Revisions' %}</a>
+                            {% include "wagtailadmin/pages/_preview_button_on_edit.html" with icon=1 label="Preview mode 1" %}
                         </li>
-                        {% if page_perms.can_publish and not is_revision %}
-                          <li class="spacer"></li>
-                          <li><input type="submit" name="action-submit" value="{% trans 'Submit for moderation' %}" class="button" /></li>
-                        {% endif %}
+                        <li>
+                            {% include "wagtailadmin/pages/_preview_button_on_edit.html" with icon=1 label="Preview 2" %}
+                        </li>
+                        <li>
+                            {% include "wagtailadmin/pages/_preview_button_on_edit.html" with icon=1 label="Very long fake preview mode to test variable width" %}
+                        </li>
+                        {% comment %}
+                        {% endcomment %}
+                        {% for mode_name, mode_display_name in preview_modes %}
+                            <li>
+                                {% include "wagtailadmin/pages/_preview_button_on_edit.html" with icon=1 mode=mode_name label=mode_display_name %}
+                            </li>
+                        {% endfor %}
+                        <li class="spacer"></li>
+                      {% endif %}
 
-                      </ul>
-                  </div>
-                </li>
-              {% endif %}
+
+
+
+                      <li>
+                        <a href="{% url 'wagtailadmin_pages:revisions_index' page.id %}" class="xunderlined">
+                          <span class="icon icon-time"></span>
+                          {% trans 'Revisions' %}</a>
+                      </li>
+                      {% if page_perms.can_publish and not is_revision and not page.locked %}
+                        <li class="spacer"></li>
+                        <li><input type="submit" name="action-submit" value="{% trans 'Submit for moderation' %}" class="button" /></li>
+                      {% endif %}
+
+                    </ul>
+                </div>
+              </li>
               <li class="meta">
                   <p class="modified">
                       {% if page.get_latest_revision %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/edit.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/edit.html
@@ -35,7 +35,180 @@
         {% endif %}
 
         <footer>
+          <div class="">
+
+            <style media="screen">
+              .actions.variable {
+                width: auto;
+              }
+              .dropdown.dropdown-button.moreactions {
+                  width: 3em;
+                  height: 3em;
+
+              }
+              .dropdown.moreactions.open ul {
+                left: auto;
+                right: -1em;
+                bottom: 3.4em;
+                width: 15em;
+                border-radius: 0.5em;
+              }
+              .dropdown.moreactions.open ul li .noborder {
+                border: 0;
+                color: #fff;
+              }
+              .dropdown.moreactions.open ul li.spacer {
+                border-bottom-width: 4px;
+              }
+              .dropdown.dropdown-button.moreactions .dropdown-toggle {
+                border-radius: 0.5em;
+                border: 0;
+                width: 3em;
+                height: 2.4em;
+                line-height: 2.4em;
+                padding: 0;
+                text-align: center;
+              }
+              .dropdown.dropup.dropdown-button.moreactions.open .dropdown-toggle {
+                border-bottom-left-radius: 0.5em;
+                border-bottom-right-radius: 0.5em;
+                margin-top: -1em;
+                padding-top: 1em;
+              }
+              .hidesmall {
+                display: none;
+              }
+              .onlybig {
+                display: none;
+              }
+              @media screen and (min-width: 50em) {
+                .dropdown.moreactions.open ul {
+                  bottom: 4em;
+                  right: -6em;
+                }
+                .dropdown.dropdown-button.moreactions .dropdown-toggle {
+                  height: 3em;
+                  line-height: 3em;
+                }
+                .hidesmall {
+                  display: inline-block;
+                }
+              }
+
+              @media screen and (min-width: 90em) {
+                .onlybig {
+                  display: inline-block;
+                }
+              }
+            </style>
+
+
             <ul>
+              <li class="actions variable">
+                <button type="submit" class="button action-save button-longrunning {% if is_revision %}warning{% endif %}" tabindex="3"
+                data-clicked-text="{% trans 'Saving...' %}" {% if page.locked %}disabled {% endif %}>
+                <span class="icon icon-spinner"></span><em>
+                  {% if page.locked %}{% trans 'Page locked' %}{% else %}{% if is_revision %}{% trans 'Replace current draft' %}{% else %}{% trans 'Save draft' %}{% endif %}{% endif %}
+                </em></button>
+              </li>
+              {% if page_perms.can_publish %}
+                <li class="actions variable">
+                  <button type="submit" name="action-publish" value="action-publish" class="button button-longrunning yes {% if is_revision %}warning{% endif %}"
+                  tabindex="3" data-clicked-text="{% trans 'Publishing...' %}" {% if page.locked %}disabled {% endif %}><span
+                  class="icon icon-spinner"></span><em>
+                    <i class="icon icon-tick"></i>
+                    {% if is_revision %}{% trans 'Publish this revision' %}{% else %}<b class="hidesmall">{% trans 'Publish' %}</b>{% endif %}</em></button>
+                </li>
+              {% elif not is_revision %}
+                <li class="actions variable">
+                    <input type="submit" name="action-submit" value="{% trans 'Submit for moderation' %}" class="button" />
+                </li>
+              {% endif %}
+
+              {% trans 'Preview' as preview_label %}
+              {% if preview_modes|length > 1 %}
+                <li class="actions preview">
+                      <div class="dropdown dropup dropdown-button match-width">
+                          {% include "wagtailadmin/pages/_preview_button_on_edit.html" with label=preview_label icon=1 %}
+                          <div class="dropdown-toggle icon icon-arrow-up"></div>
+                          <ul role="menu">
+                              {% for mode_name, mode_display_name in preview_modes %}
+                                  <li>
+                                      {% include "wagtailadmin/pages/_preview_button_on_edit.html" with mode=mode_name label=mode_display_name %}
+                                  </li>
+                              {% endfor %}
+                          </ul>
+                      </div>
+                </li>
+              {% else %}
+                <li class="actions preview variable">
+                  {% include "wagtailadmin/pages/_preview_button_on_edit.html" with label=preview_label icon=1 %}
+                </li>
+              {% endif %}
+              {% if not page.locked %}
+                <li class="actions variable">
+                  <div class="dropdown dropup dropdown-button moreactions {% if is_revision %}warning{% endif %}">
+
+                      <div class="dropdown-toggle xicon xicon-arrow-up">
+                        &bull;&bull;&bull;
+                      </div>
+                      <ul role="menu">
+                        {% if not is_revision  %}
+                          {% if page_perms.can_delete %}
+                              <li class=""><a href="{% url 'wagtailadmin_pages:delete' page.id %}" class="shortcut button button-secondary noborder no">
+                                <span class="icon icon-bin"></span>
+                                {% trans 'Delete' %}</a></li>
+
+                          {% endif %}
+                          {% if page_perms.can_unpublish %}
+                              <li class=""><a href="{% url 'wagtailadmin_pages:unpublish' page.id %}" class="button button-secondary noborder warning">
+                                <span class="icon icon-cross"></span>
+                                {% trans 'Unpublish' %}</a></li>
+
+                          {% endif %}
+
+
+                          {% if page_perms.can_delete or page_perms.can_unpublish  %}
+                            <li class="spacer"></li>
+                          {% endif %}
+
+                        {% endif %}
+                        <li>
+                          <a href="{% url 'wagtailadmin_pages:revisions_index' page.id %}" class="xunderlined">
+                            <span class="icon icon-time"></span>
+                            {% trans 'Revisions' %}</a>
+                        </li>
+                        {% if page_perms.can_publish and not is_revision %}
+                          <li class="spacer"></li>
+                          <li><input type="submit" name="action-submit" value="{% trans 'Submit for moderation' %}" class="button" /></li>
+                        {% endif %}
+
+                      </ul>
+                  </div>
+                </li>
+              {% endif %}
+              <li class="meta">
+                  <p class="modified">
+                      {% if page.get_latest_revision %}
+                          {% blocktrans with last_mod=page.get_latest_revision.created_at %}Last modified: {{ last_mod }}{% endblocktrans %}
+                          {% if page.get_latest_revision.user %}
+                              <span class="onlybig">
+                              {% blocktrans with modified_by=page.get_latest_revision.user.get_full_name|default:page.get_latest_revision.user.get_username %}by {{ modified_by }}{% endblocktrans %}
+                              </span>
+                              {% if page.get_latest_revision.user.email %}
+                                  <span class="avatar small icon icon-user"><img src="{% gravatar_url page.get_latest_revision.user.email 25 %}" /></span>
+                              {% endif %}
+                          {% endif %}
+                      {% endif %}
+                  </p>
+              </li>
+            </ul>
+          </div>
+          {% comment %}
+          {% endcomment %}
+
+          {% comment %}
+            <ul style="clear: both; padding-top: 2em;">
                 <li class="actions">
                     <div class="dropdown dropup dropdown-button match-width {% if is_revision %}warning{% endif %}">
                         <button type="submit" class="button action-save button-longrunning {% if is_revision %}warning{% endif %}" tabindex="3" data-clicked-text="{% trans 'Saving...' %}" {% if page.locked %}disabled {% endif %}><span class="icon icon-spinner"></span><em>{% if page.locked %}{% trans 'Page locked' %}{% else %}{% if is_revision %}{% trans 'Replace current draft' %}{% else %}{% trans 'Save draft' %}{% endif %}{% endif %}</em></button>
@@ -96,6 +269,9 @@
                     </p>
                 </li>
             </ul>
+            {% comment %}
+
+            {% endcomment %}
         </footer>
     </form>
 

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/edit.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/edit.html
@@ -50,8 +50,8 @@
               }
               .dropdown.dropdown-button.moreactions {
                   width: 3em;
-                  height: 3em;
-
+                  height: 2.4em;
+                  font-size: 0.9em;
               }
               .dropdown.moreactions.open ul {
                 left: auto;
@@ -68,7 +68,7 @@
                 border-bottom-width: 4px;
               }
               .dropdown.dropdown-button.moreactions .dropdown-toggle {
-                border-radius: 0.5em;
+                border-radius: 3px;
                 border: 0;
                 width: 3em;
                 height: 2.4em;
@@ -77,8 +77,8 @@
                 text-align: center;
               }
               .dropdown.dropup.dropdown-button.moreactions.open .dropdown-toggle {
-                border-bottom-left-radius: 0.5em;
-                border-bottom-right-radius: 0.5em;
+                border-bottom-left-radius: 3px;
+                border-bottom-right-radius: 3px;
                 margin-top: -1em;
                 padding-top: 1em;
               }
@@ -92,6 +92,10 @@
                 .dropdown.moreactions.open ul {
                   bottom: 4em;
                   right: -6em;
+                }
+                .dropdown.dropdown-button.moreactions {
+                    height: 3em;
+                    font-size: 0.95em;
                 }
                 .dropdown.dropdown-button.moreactions .dropdown-toggle {
                   height: 3em;
@@ -123,7 +127,9 @@
                 <button type="submit" class="button action-save button-longrunning {% if is_revision %}warning{% endif %}" tabindex="3"
                 data-clicked-text="{% trans 'Saving...' %}" {% if page.locked %}disabled {% endif %}>
                 <span class="icon icon-spinner"></span><em>
-                  {% if page.locked %}{% trans 'Page locked' %}{% else %}{% if is_revision %}{% trans 'Replace current draft' %}{% else %}{% trans 'Save draft' %}{% endif %}{% endif %}
+                  {% if page.locked %}
+                  <b class="icon icon-locked"></b>
+                  <b class="hidesmall">{% trans 'Page locked' %}</b>{% else %}{% if is_revision %}{% trans 'Replace current draft' %}{% else %}{% trans 'Save draft' %}{% endif %}{% endif %}
                 </em></button>
               </li>
               {% if page_perms.can_publish %}
@@ -134,9 +140,11 @@
                     <i class="icon icon-tick"></i>
                     {% if is_revision %}{% trans 'Publish this revision' %}{% else %}<b class="hidesmall">{% trans 'Publish' %}</b>{% endif %}</em></button>
                 </li>
-              {% elif not is_revision %}
+              {% elif not is_revision and not page.locked %}
                 <li class="actions variable">
-                    <input type="submit" name="action-submit" value="{% trans 'Submit for moderation' %}" class="button" />
+                    <button type="submit" name="action-submit" value="{% trans 'Submit for moderation' %}" title="{% trans 'Submit for moderation' %}" class="button icon icon-mail yes" >
+                      <b class="hidesmall">{% trans 'Submit for moderation' %}</b>
+                    </button>
                 </li>
               {% endif %}
 
@@ -180,7 +188,7 @@
               <li class="actions variable">
                 <div class="dropdown dropup dropdown-button moreactions {% if is_revision %}warning{% endif %}">
 
-                    <div class="dropdown-toggle xicon xicon-arrow-up" title="{% trans "More actions..." %}">
+                    <div class="dropdown-toggle" title="{% trans "More actions..." %}">
                       &bull;&bull;&bull;
                     </div>
                     <ul role="menu">
@@ -208,7 +216,7 @@
                       {% if preview_modes|length > 1 %}
                       {% comment %}
                       {% if not preview_modes|length > 1 %}
-
+                      
                         <!-- dummy preview modes -->
                         <li>
                             {% include "wagtailadmin/pages/_preview_button_on_edit.html" with icon=1 label="Preview mode 1" %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/edit.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/edit.html
@@ -36,113 +36,31 @@
 
         <footer>
           <div class="">
+            {% include "wagtailadmin/pages/_temp_style.html" %}
 
-            <style media="screen">
-              .actions.variable {
-                width: auto;
-              }
-              .actions.variable .dropdown ul li a,
-              .actions.variable .dropdown ul li .button {
-                padding-right: 1em;
-                max-width: 18em;
-                overflow: hidden;
-                text-overflow: ellipsis;
-              }
-              .dropdown.dropdown-button.moreactions {
-                  width: 3em;
-                  height: 2.4em;
-                  font-size: 0.9em;
-              }
-              .dropdown.moreactions.open ul {
-                left: auto;
-                right: -1em;
-                bottom: 3.4em;
-                min-width: 15em;
-                border-radius: 0.5em;
-              }
-              .dropdown.moreactions.open ul li .noborder {
-                border: 0;
-                color: #fff;
-              }
-              .dropdown.moreactions.open ul li.spacer {
-                border-bottom-width: 4px;
-              }
-              .dropdown.dropdown-button.moreactions .dropdown-toggle {
-                border-radius: 3px;
-                border: 0;
-                width: 3em;
-                height: 2.4em;
-                line-height: 2.4em;
-                padding: 0;
-                text-align: center;
-              }
-              .dropdown.dropup.dropdown-button.moreactions.open .dropdown-toggle {
-                border-bottom-left-radius: 3px;
-                border-bottom-right-radius: 3px;
-                margin-top: -1em;
-                padding-top: 1em;
-              }
-              .hidesmall {
-                display: none;
-              }
-              .onlybig {
-                display: none;
-              }
-              @media screen and (min-width: 50em) {
-                .dropdown.moreactions.open ul {
-                  bottom: 4em;
-                  right: -6em;
-                }
-                .dropdown.dropdown-button.moreactions {
-                    height: 3em;
-                    font-size: 0.95em;
-                }
-                .dropdown.dropdown-button.moreactions .dropdown-toggle {
-                  height: 3em;
-                  line-height: 3em;
-                }
-                .hidesmall {
-                  display: inline-block;
-                }
-                .actions.variable .dropdown ul li a,
-                .actions.variable .dropdown ul li .button {
-                  max-width: 22em;
-                }
-              }
-
-              @media screen and (min-width: 90em) {
-                .onlybig {
-                  display: inline-block;
-                }
-                .actions.variable .dropdown ul li a,
-                .actions.variable .dropdown ul li .button {
-                  max-width: 30em;
-                }
-              }
-            </style>
-
-
-            <ul>
+            <ul class="spaced-flex">
               <li class="actions variable">
                 <button type="submit" class="button action-save button-longrunning {% if is_revision %}warning{% endif %}" tabindex="3"
                 data-clicked-text="{% trans 'Saving...' %}" {% if page.locked %}disabled {% endif %}>
                 <span class="icon icon-spinner"></span><em>
                   {% if page.locked %}
                   <b class="icon icon-locked"></b>
-                  <b class="hidesmall">{% trans 'Page locked' %}</b>{% else %}{% if is_revision %}{% trans 'Replace current draft' %}{% else %}{% trans 'Save draft' %}{% endif %}{% endif %}
+                  <b class="hidesmall">{% trans 'Page locked' %}</b>{% else %}
+                  <i class="icon icon-doc-full-inverse"></i>
+                  <b class="hidesmall">{% if is_revision %}{% trans 'Replace current draft' %}{% else %}{% trans 'Save draft' %}{% endif %}{% endif %}</b>
                 </em></button>
               </li>
               {% if page_perms.can_publish %}
-                <li class="actions variable">
-                  <button type="submit" name="action-publish" value="action-publish" class="button button-longrunning {% if not page.locked %} yes{% endif %} {% if is_revision %}warning{% endif %}"
+                <li class="actions variable center-button">
+                  <button type="submit" name="action-publish" value="action-publish" class="button button-longrunning {% if not page.locked %} x{% endif %} {% if is_revision %}warning{% endif %}"
                   tabindex="3" data-clicked-text="{% trans 'Publishing...' %}" {% if page.locked %}disabled {% endif %}><span
                   class="icon icon-spinner"></span><em>
-                    <i class="icon icon-tick"></i>
+                    <i class="icon icon-arrow-up-big rotate90"></i>
                     {% if is_revision %}{% trans 'Publish this revision' %}{% else %}<b class="hidesmall">{% trans 'Publish' %}</b>{% endif %}</em></button>
                 </li>
               {% elif not is_revision and not page.locked %}
-                <li class="actions variable">
-                    <button type="submit" name="action-submit" value="{% trans 'Submit for moderation' %}" title="{% trans 'Submit for moderation' %}" class="button icon icon-mail yes" >
+                <li class="actions variable center-button">
+                    <button type="submit" name="action-submit" value="{% trans 'Submit for moderation' %}" title="{% trans 'Submit for moderation' %}" class="button icon icon-mail" >
                       <b class="hidesmall">{% trans 'Submit for moderation' %}</b>
                     </button>
                 </li>
@@ -178,11 +96,11 @@
 
 
               {% endif %}
+              <li class="actions preview variable" title="{{ preview_label }}">
+              {% include "wagtailadmin/pages/_preview_button_on_edit.html" with label=preview_label icon=2 %}
+            </li>
               {% endcomment %}
 
-              <li class="actions preview variable" title="{{ preview_label }}">
-                {% include "wagtailadmin/pages/_preview_button_on_edit.html" with label=preview_label icon=2 %}
-              </li>
 
 
               <li class="actions variable">
@@ -206,7 +124,6 @@
                                 {% trans 'Unpublish' %}</a></li>
 
                           {% endif %}
-
                           {% if page_perms.can_delete or page_perms.can_unpublish  %}
                             <li class="spacer"></li>
                           {% endif %}
@@ -216,7 +133,7 @@
                       {% if preview_modes|length > 1 %}
                       {% comment %}
                       {% if not preview_modes|length > 1 %}
-                      
+
                         <!-- dummy preview modes -->
                         <li>
                             {% include "wagtailadmin/pages/_preview_button_on_edit.html" with icon=1 label="Preview mode 1" %}
@@ -234,8 +151,15 @@
                                 {% include "wagtailadmin/pages/_preview_button_on_edit.html" with icon=1 mode=mode_name label=mode_display_name %}
                             </li>
                         {% endfor %}
-                        <li class="spacer"></li>
+                      {% else %}
+                        <li>
+                          {% include "wagtailadmin/pages/_preview_button_on_edit.html" with label=preview_label icon=1 %}
+                        </li>
                       {% endif %}
+                      {% comment %}
+
+                      <li class="spacer"></li>
+                      {% endcomment %}
 
 
 


### PR DESCRIPTION
Another example of a slightly more radical approach to fixing https://github.com/wagtail/wagtail/issues/2214
implementing some of the ideas I mentioned in my comments on the less radical https://github.com/wagtail/wagtail/pull/3241 pr.

This solution is a lot more compact and responsive even though it has an additional button.

Current footer, for width comparison (note that the preview button is actually wider than it appears):
![orig](https://cloud.githubusercontent.com/assets/2144849/21424754/179847ae-c845-11e6-9948-57149a621686.png)

New footer in the same width (the preview button now doesn't have extra width since it's not a dropdown anymore; extra preview modes are shown in the common dropdown):
![wide](https://cloud.githubusercontent.com/assets/2144849/21424783/3673c81a-c845-11e6-825b-e04781d82773.png)

Some of the meta-data is hidden (and revisions link is moved to the menu), to allow narrowers screen without wrapping:
![narrow](https://cloud.githubusercontent.com/assets/2144849/21424804/5815e3ea-c845-11e6-8349-697bcccefca8.png)

The 3 direct buttons with icons (save draft, publish, preview) become icon only on smaller widths to avoid wrapping on phone sizes:
![phone](https://cloud.githubusercontent.com/assets/2144849/21424809/5bfd00ba-c845-11e6-8fce-713629630ea3.png)

Color coded (only on hover) delete and unpublish with red and yellow respectively:
![color_code_on_hover](https://cloud.githubusercontent.com/assets/2144849/21424858/b3addb22-c845-11e6-8118-7103ab8088c2.png)

The "Submit for moderation" button  replaces the "Publish" button when the user is not allowed to publish:
![cant_pub](https://cloud.githubusercontent.com/assets/2144849/21424875/d6ae9ce2-c845-11e6-927b-f3409b0e2c6d.png)
It's deliberately not color coded green like the publish button to avoid confusion.

**NOTE** The css is currently hardcoded in a `<style>` block in the template for easy development and there is a lot of commented code for reference while developing. This needs to be cleaned up and the styles must be moved to the sass files before this can be merged.
But even though this code is somewhat ugly; it *is* functional and can be checked out locally for testing.