### PR TITLE
Fix #3240 - Copying recursive tree branch to itself.

### DIFF
--- a/wagtail/wagtailadmin/tests/test_pages_views.py
+++ b/wagtail/wagtailadmin/tests/test_pages_views.py
@@ -2198,6 +2198,19 @@ class TestPageCopy(TestCase, WagtailTestUtils):
             "This slug is already in use within the context of its parent page \"Welcome to your new Wagtail site!\""
         )
 
+    def test_page_copy_post_and_subpages_to_same_tree_branch(self):
+        # This tests the existing slug checking on page copy when changing the parent page
+
+        # Attempt to copy the page and changed the parent page
+        post_data = {
+            'new_title': "Hello world 2",
+            'new_slug': 'hello-world',
+            'new_parent_page': str(self.test_child_page.id),
+            'copy_subpages': True,
+        }
+        response = self.client.post(reverse('wagtailadmin_pages:copy', args=(self.test_page.id,)), post_data)
+        self.assertEqual(response.status_code, 403)
+
     def test_page_copy_post_existing_slug_to_another_parent_page(self):
         # This tests the existing slug checking on page copy when changing the parent page
 

--- a/wagtail/wagtailadmin/views/pages.py
+++ b/wagtail/wagtailadmin/views/pages.py
@@ -820,8 +820,8 @@ def copy(request, page_id):
             if form.cleaned_data['new_parent_page']:
                 parent_page = form.cleaned_data['new_parent_page']
 
-            # Make sure this user has permission to add subpages on the parent
-            if not parent_page.permissions_for_user(request.user).can_add_subpage():
+            if not page.permissions_for_user(request.user).can_copy_to(
+                parent_page, form.cleaned_data.get('copy_subpages')):
                 raise PermissionDenied
 
             # Re-check if the user has permission to publish subpages on the new parent

--- a/wagtail/wagtailadmin/views/pages.py
+++ b/wagtail/wagtailadmin/views/pages.py
@@ -820,8 +820,8 @@ def copy(request, page_id):
             if form.cleaned_data['new_parent_page']:
                 parent_page = form.cleaned_data['new_parent_page']
 
-            if not page.permissions_for_user(request.user).can_copy_to(
-                parent_page, form.cleaned_data.get('copy_subpages')):
+            if not page.permissions_for_user(request.user).can_copy_to(parent_page,
+                                                                       form.cleaned_data.get('copy_subpages')):
                 raise PermissionDenied
 
             # Re-check if the user has permission to publish subpages on the new parent

--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -1094,10 +1094,9 @@ class Page(six.with_metaclass(PageBase, AbstractPage, index.Indexed, Clusterable
                 setattr(page_copy, field, value)
 
         if to:
-            if to != self and not to.is_descendant_of(self):
-                page_copy = to.add_child(instance=page_copy)
-            else:
-                raise Exception("You cannot copy a tree into itself")
+            if recursive and (to == self or to.is_descendant_of(self)):
+                raise Exception("You cannot copy a tree branch recursively into itself")
+            page_copy = to.add_child(instance=page_copy)
         else:
             page_copy = self.add_sibling(instance=page_copy)
 

--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -1816,6 +1816,30 @@ class PagePermissionTester(object):
             # no publishing required, so the already-tested 'add' permission is sufficient
             return True
 
+    def can_copy_to(self, destination, recursive=False):
+        # reject the logically impossible cases first
+        # recursive can't copy to the same tree otherwise it will be on infinite loop
+        if recursive and (self.page == destination or destination.is_descendant_of(self.page)):
+            return False
+
+        # shortcut the trivial 'everything' / 'nothing' permissions
+        if not self.user.is_active:
+            return False
+        if self.user.is_superuser:
+            return True
+
+        # Inspect permissions on the destination
+        destination_perms = self.user_perms.for_page(destination)
+
+        if not destination.specific_class.creatable_subpage_models():
+            return False
+
+        # we always need at least add permission in the target
+        if 'add' not in destination_perms.permissions:
+            return False
+
+        return True
+
 
 class PageViewRestriction(models.Model):
     NONE = 'none'

--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -1094,7 +1094,10 @@ class Page(six.with_metaclass(PageBase, AbstractPage, index.Indexed, Clusterable
                 setattr(page_copy, field, value)
 
         if to:
-            page_copy = to.add_child(instance=page_copy)
+            if to != self and not to.is_descendant_of(self):
+                page_copy = to.add_child(instance=page_copy)
+            else:
+                raise Exception("You cannot copy a tree into itself")
         else:
             page_copy = self.add_sibling(instance=page_copy)
 

--- a/wagtail/wagtailcore/tests/test_page_model.py
+++ b/wagtail/wagtailcore/tests/test_page_model.py
@@ -777,11 +777,8 @@ class TestCopyPage(TestCase):
         old_christmas_event = events_index.get_children().filter(slug='christmas').first().specific
         old_christmas_event.save_revision()
 
-
         with self.assertRaises(Exception) as exception:
-            # Copy it
-
-            new_events_index = events_index.copy(
+            events_index.copy(
                 recursive=True, update_attrs={'title': "New events index", 'slug': 'new-events-index'}, to=events_index
             )
         self.assertEqual(str(exception.exception), "You cannot copy a tree branch recursively into itself")

--- a/wagtail/wagtailcore/tests/test_page_model.py
+++ b/wagtail/wagtailcore/tests/test_page_model.py
@@ -784,8 +784,7 @@ class TestCopyPage(TestCase):
             new_events_index = events_index.copy(
                 recursive=True, update_attrs={'title': "New events index", 'slug': 'new-events-index'}, to=events_index
             )
-        self.assertEqual(str(exception.exception), "You cannot copy a tree into itself")
-
+        self.assertEqual(str(exception.exception), "You cannot copy a tree branch recursively into itself")
 
     def test_copy_page_updates_user(self):
         event_moderator = get_user_model().objects.get(username='eventmoderator')

--- a/wagtail/wagtailcore/tests/test_page_model.py
+++ b/wagtail/wagtailcore/tests/test_page_model.py
@@ -772,6 +772,18 @@ class TestCopyPage(TestCase):
             old_christmas_event.specific.revisions.count(), 1, "Revisions were removed from the original page"
         )
 
+    def test_copy_page_copies_recursively_to_the_same_tree(self):
+        events_index = EventIndex.objects.get(url_path='/home/events/')
+        old_christmas_event = events_index.get_children().filter(slug='christmas').first().specific
+        old_christmas_event.save_revision()
+
+        # Copy it
+        new_events_index = events_index.copy(
+            recursive=True, update_attrs={'title': "New events index", 'slug': 'new-events-index'}, to=events_index
+        )
+
+        # This test will explode :)
+
     def test_copy_page_updates_user(self):
         event_moderator = get_user_model().objects.get(username='eventmoderator')
         christmas_event = EventPage.objects.get(url_path='/home/events/christmas/')

--- a/wagtail/wagtailcore/tests/test_page_model.py
+++ b/wagtail/wagtailcore/tests/test_page_model.py
@@ -777,12 +777,15 @@ class TestCopyPage(TestCase):
         old_christmas_event = events_index.get_children().filter(slug='christmas').first().specific
         old_christmas_event.save_revision()
 
-        # Copy it
-        new_events_index = events_index.copy(
-            recursive=True, update_attrs={'title': "New events index", 'slug': 'new-events-index'}, to=events_index
-        )
 
-        # This test will explode :)
+        with self.assertRaises(Exception) as exception:
+            # Copy it
+
+            new_events_index = events_index.copy(
+                recursive=True, update_attrs={'title': "New events index", 'slug': 'new-events-index'}, to=events_index
+            )
+        self.assertEqual(str(exception.exception), "You cannot copy a tree into itself")
+
 
     def test_copy_page_updates_user(self):
         event_moderator = get_user_model().objects.get(username='eventmoderator')


### PR DESCRIPTION
Test were created on Page copy method, to avoid this error when someone uses the copy method directly, I also created the can_copy_to method which is used on the view. 

Refs: #3240 
