### PR TITLE
Point people to Stack Overflow for support queries in preference to the Google group

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ documentation, translations or just feature requests.
 The [issue tracker](https://github.com/wagtail/wagtail/issues) is
 the preferred channel for [bug reports](#bugs), [features requests](#features)
 and [submitting pull requests](#pull-requests). Please don't use the issue tracker
-for support - use our [Wagtail support group](https://groups.google.com/forum/#!forum/wagtail).
+for support - use [the 'wagtail' tag on Stack Overflow](http://stackoverflow.com/questions/tagged/wagtail) (preferred) or our [Wagtail support group](https://groups.google.com/forum/#!forum/wagtail).
 
 ## New code
 

--- a/README.rst
+++ b/README.rst
@@ -62,7 +62,9 @@ Documentation
 
 Community Support
 ~~~~~~~~~~~~~~~~~
-Ask your questions on our `Wagtail support group <https://groups.google.com/forum/#!forum/wagtail>`_.
+There is an active community of Wagtail users and developers responding to questions on `Stack Overflow <http://stackoverflow.com/questions/tagged/wagtail>`_. When posting questions, please read Stack Overflow's advice on `how to ask questions <http://stackoverflow.com/help/how-to-ask>`_ and remember to tag your question with "wagtail".
+
+For topics and discussions that do not fit Stack Overflow's question-and-answer format, there is also a `Wagtail Support mailing list <https://groups.google.com/forum/#!forum/wagtail>`_.
 
 Commercial Support
 ~~~~~~~~~~~~~~~~~~

--- a/docs/contributing/issue_tracking.rst
+++ b/docs/contributing/issue_tracking.rst
@@ -8,7 +8,7 @@ Issues
 
 An issue must always correspond to a specific action with a well-defined completion state: fixing a bug, adding a new feature, updating documentation, cleaning up code. Open-ended issues where the end result is not immediately clear ("come up with a way of doing translations") are fine, as long as there's a clear way to progress the issue and identify when it has been completed (not e.g. "make rich text fields suck less").
 
-Do not use issues for support queries or other questions ("How do I do X?" - although "Implement a way of doing X" or "Document how to do X" could well be valid issues). These should go on the `Wagtail Support Google group <https://groups.google.com/forum/#!forum/wagtail>`_.
+Do not use issues for support queries or other questions ("How do I do X?" - although "Implement a way of doing X" or "Document how to do X" could well be valid issues). These should be asked on `Stack Overflow <http://stackoverflow.com/questions/tagged/wagtail>`_, or for discussions that do not fit Stack Overflow's question-and-answer format, the `Wagtail Support Google group <https://groups.google.com/forum/#!forum/wagtail>`_.
 
 As soon as a ticket is opened - ideally within one day - a member of the core team will give it an initial classification, by either closing it as invalid or assigning it to a milestone. Don't be discouraged if you feel that your ticket has been given a lower priority than it deserves - this decision isn't permanent. We will consider all feedback, and reassign or reopen tickets where appropriate.
 

--- a/docs/support.rst
+++ b/docs/support.rst
@@ -1,10 +1,15 @@
 Support
 -------
 
+Stack Overflow
+~~~~~~~~~~~~~~
+
+`Stack Overflow <http://stackoverflow.com/questions/tagged/wagtail>`_ is the best place to find answers to your questions about working with Wagtail - there is an active community of Wagtail users and developers responding to questions there. When posting questions, please read Stack Overflow's advice on `how to ask questions <http://stackoverflow.com/help/how-to-ask>`_ and remember to tag your question with "wagtail".
+
 Mailing list
 ~~~~~~~~~~~~
 
-If you have general questions about Wagtail, or you're looking for help on how to do something that these documents don't cover, join the mailing list at `groups.google.com/d/forum/wagtail <https://groups.google.com/d/forum/wagtail>`_.
+For topics and discussions that do not fit Stack Overflow's question-and-answer format, there is a Wagtail Support mailing list at `groups.google.com/d/forum/wagtail <https://groups.google.com/d/forum/wagtail>`_.
 
 Issues
 ~~~~~~


### PR DESCRIPTION
We plan to put additional resources into support on Stack Overflow, based on feedback at https://twitter.com/WagtailCMS/status/801384753589080064