### PR TITLE
Marked text for translation

### DIFF
--- a/wagtail/wagtailadmin/templates/wagtailadmin/home/pages_for_moderation.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/home/pages_for_moderation.html
@@ -50,7 +50,7 @@
                                 {{ revision.page.content_type.model_class.get_verbose_name }}
                             </td>
                             <td valign="top">
-                                <div class="human-readable-date" title="{{ revision.created_at|date:"d M Y H:i" }}">{{ revision.created_at|timesince }} {% trans 'ago' %} </div>
+                                <div class="human-readable-date" title="{{ revision.created_at|date:"d M Y H:i" }}">{% blocktrans with time_period=revision.created_at|timesince %}{{ time_period }} ago{% endblocktrans %} </div>
                                 by {{ revision.user.get_full_name|default:revision.user.get_username }}
                             </td>
                         </tr>

--- a/wagtail/wagtailadmin/templates/wagtailadmin/home/pages_for_moderation.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/home/pages_for_moderation.html
@@ -50,7 +50,7 @@
                                 {{ revision.page.content_type.model_class.get_verbose_name }}
                             </td>
                             <td valign="top">
-                                <div class="human-readable-date" title="{{ revision.created_at|date:"d M Y H:i" }}">{{ revision.created_at|timesince }} ago </div>
+                                <div class="human-readable-date" title="{{ revision.created_at|date:"d M Y H:i" }}">{{ revision.created_at|timesince }} {% trans 'ago' %} </div>
                                 by {{ revision.user.get_full_name|default:revision.user.get_username }}
                             </td>
                         </tr>

--- a/wagtail/wagtailadmin/templates/wagtailadmin/home/recent_edits.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/home/recent_edits.html
@@ -34,7 +34,7 @@
                                     {% endif %}
                                 </ul>
                             </td>
-                            <td valign="top"><div class="human-readable-date" title="{{ revision.created_at|date:"d M Y H:i" }}">{{ revision.created_at|timesince }} {% trans 'ago' %}</div></td>
+                            <td valign="top"><div class="human-readable-date" title="{{ revision.created_at|date:"d M Y H:i" }}">{% blocktrans with time_period=revision.created_at|timesince %}{{ time_period }} ago{% endblocktrans %}</div></td>
                             <td valign="top">
                                 {% include "wagtailadmin/shared/page_status_tag.html" with page=page %}
                             </td>

--- a/wagtail/wagtailadmin/templates/wagtailadmin/home/recent_edits.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/home/recent_edits.html
@@ -34,7 +34,7 @@
                                     {% endif %}
                                 </ul>
                             </td>
-                            <td valign="top"><div class="human-readable-date" title="{{ revision.created_at|date:"d M Y H:i" }}">{{ revision.created_at|timesince }} ago</div></td>
+                            <td valign="top"><div class="human-readable-date" title="{{ revision.created_at|date:"d M Y H:i" }}">{{ revision.created_at|timesince }} {% trans 'ago' %}</div></td>
                             <td valign="top">
                                 {% include "wagtailadmin/shared/page_status_tag.html" with page=page %}
                             </td>

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/listing/_list.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/listing/_list.html
@@ -23,7 +23,7 @@
                     {% block parent_page_title %}
                     {% endblock %}
                 </td>
-                <td class="updated" valign="bottom">{% if parent_page.latest_revision_created_at %}<div class="human-readable-date" title="{{ parent_page.latest_revision_created_at|date:"d M Y H:i" }}">{{ parent_page.latest_revision_created_at|timesince }} {% trans 'ago' %}</div>{% endif %}</td>
+                <td class="updated" valign="bottom">{% if parent_page.latest_revision_created_at %}<div class="human-readable-date" title="{{ parent_page.latest_revision_created_at|date:"d M Y H:i" }}">{% blocktrans with time_period=parent_page.latest_revision_created_at|timesince %}{{ time_period }} ago{% endblocktrans %}</div>{% endif %}</td>
                 <td class="type" valign="bottom">
                     {% if not parent_page.is_root %}
                         {{ parent_page.content_type.model_class.get_verbose_name }}
@@ -62,7 +62,7 @@
                             </td>
                         {% endwith %}
                     {% endif %}
-                    <td class="updated" valign="top">{% if page.latest_revision_created_at %}<div class="human-readable-date" title="{{ page.latest_revision_created_at|date:"d M Y H:i" }}">{{ page.latest_revision_created_at|timesince }} {% trans 'ago' %}</div>{% endif %}</td>
+                    <td class="updated" valign="top">{% if page.latest_revision_created_at %}<div class="human-readable-date" title="{{ page.latest_revision_created_at|date:"d M Y H:i" }}">{% blocktrans with time_period=page.latest_revision_created_at|timesince %}{{ time_period }} ago{% endblocktrans %}</div>{% endif %}</td>
                     <td class="type" valign="top">{{ page.content_type.model_class.get_verbose_name }}</td>
                     <td class="status" valign="top">
                         {% include "wagtailadmin/shared/page_status_tag.html" with page=page %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/listing/_list.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/listing/_list.html
@@ -23,7 +23,7 @@
                     {% block parent_page_title %}
                     {% endblock %}
                 </td>
-                <td class="updated" valign="bottom">{% if parent_page.latest_revision_created_at %}<div class="human-readable-date" title="{{ parent_page.latest_revision_created_at|date:"d M Y H:i" }}">{{ parent_page.latest_revision_created_at|timesince }} ago</div>{% endif %}</td>
+                <td class="updated" valign="bottom">{% if parent_page.latest_revision_created_at %}<div class="human-readable-date" title="{{ parent_page.latest_revision_created_at|date:"d M Y H:i" }}">{{ parent_page.latest_revision_created_at|timesince }} {% trans 'ago' %}</div>{% endif %}</td>
                 <td class="type" valign="bottom">
                     {% if not parent_page.is_root %}
                         {{ parent_page.content_type.model_class.get_verbose_name }}
@@ -62,7 +62,7 @@
                             </td>
                         {% endwith %}
                     {% endif %}
-                    <td class="updated" valign="top">{% if page.latest_revision_created_at %}<div class="human-readable-date" title="{{ page.latest_revision_created_at|date:"d M Y H:i" }}">{{ page.latest_revision_created_at|timesince }} ago</div>{% endif %}</td>
+                    <td class="updated" valign="top">{% if page.latest_revision_created_at %}<div class="human-readable-date" title="{{ page.latest_revision_created_at|date:"d M Y H:i" }}">{{ page.latest_revision_created_at|timesince }} {% trans 'ago' %}</div>{% endif %}</td>
                     <td class="type" valign="top">{{ page.content_type.model_class.get_verbose_name }}</td>
                     <td class="status" valign="top">
                         {% include "wagtailadmin/shared/page_status_tag.html" with page=page %}

--- a/wagtail/wagtaildocs/templates/wagtaildocs/documents/list.html
+++ b/wagtail/wagtaildocs/templates/wagtaildocs/documents/list.html
@@ -37,7 +37,7 @@
                     {% endif %}
                 </td>
                 <td><a href="{{ doc.url }}" class="nolink" download>{{ doc.filename }}</a></td>
-                <td><div class="human-readable-date" title="{{ doc.created_at|date:"d M Y H:i" }}">{{ doc.created_at|timesince }} ago</div></td>
+                <td><div class="human-readable-date" title="{{ doc.created_at|date:"d M Y H:i" }}">{{ doc.created_at|timesince }} {% trans 'ago' %}</div></td>
             </tr>
         {% endfor %}
     </tbody>

--- a/wagtail/wagtaildocs/templates/wagtaildocs/documents/list.html
+++ b/wagtail/wagtaildocs/templates/wagtaildocs/documents/list.html
@@ -37,7 +37,7 @@
                     {% endif %}
                 </td>
                 <td><a href="{{ doc.url }}" class="nolink" download>{{ doc.filename }}</a></td>
-                <td><div class="human-readable-date" title="{{ doc.created_at|date:"d M Y H:i" }}">{{ doc.created_at|timesince }} {% trans 'ago' %}</div></td>
+                <td><div class="human-readable-date" title="{{ doc.created_at|date:"d M Y H:i" }}">{% blocktrans with time_period=doc.created_at|timesince %}{{ time_period }} ago{% endblocktrans %}</div></td>
             </tr>
         {% endfor %}
     </tbody>


### PR DESCRIPTION
Fixes #3265

There were some hardcoded strings left in some HTML templates.

