### PR TITLE
docs: Fix INDEX_SETTINGS in ES search backend ex.

### DIFF
--- a/docs/topics/search/backends.rst
+++ b/docs/topics/search/backends.rst
@@ -134,18 +134,17 @@ Other than ``BACKEND``, the keys are optional and default to the values shown. A
           ...,
           'INDEX_SETTINGS': {
               'settings': {
-                  'number_of_shards': 2,
-                      'index': {
-                          'analysis': {
-                              'analyzer': {
-                                  'default': {
-                                      'type': 'italian'
-                                  }
+                  'index': {
+                      'number_of_shards': 1,
+                      'analysis': {
+                          'analyzer': {
+                              'default': {
+                                  'type': 'italian'
                               }
                           }
                       }
                   }
-              },
+              }
           }
       }
 


### PR DESCRIPTION
The key `number_of_shards` lives below the `index` key.

Ref: https://www.elastic.co/guide/en/elasticsearch/reference/2.4/indices-create-index.html#create-index-settings

Also change the example value to of number_of_shards to 1, to stay below bonsai.io sandbox plan limits.

Probably fixes #3172 