### PR TITLE
Add site variables to template context

### DIFF
--- a/docs/advanced_topics/customisation/admin_templates.rst
+++ b/docs/advanced_topics/customisation/admin_templates.rst
@@ -79,6 +79,32 @@ To replace the welcome message on the dashboard, create a template file ``dashbo
 
     {% block branding_welcome %}Welcome to Frank's Site{% endblock %}
 
+Specifying a site or page in the branding
+=========================================
+
+The admin interface has a number of variables available to the renderer context that can be used to customize the branding in the admin page. These can be useful for customizing the dashboard on a multitenanted Wagtail installation:
+
+``root_page``
+-------------
+Returns the highest explorable page object for the currently logged in user. If the user has no explore rights, this will default to ``None``.
+
+``root_site``
+-------------
+Returns the name on the site record for the above root page.
+
+
+``site_name``
+-------------
+Returns the value of ``root_site``, unless it evaluates to ``None``. In that case, it will return the value of ``settings.WAGTAIL_SITE_NAME``.
+
+To use these variables, create a template file ``dashboard/templates/wagtailadmin/home.html``, just as if you were overriding one of the template blocks in the dashboard, and use them as you would any other Django template variable:
+
+.. code-block:: html+django
+
+    {% extends "wagtailadmin/home.html" %}
+
+    {% block branding_welcome %}Welcome to the Admin Homepage for {{ root_site }}{% endblock %}
+
 Extending the login form
 ========================
 

--- a/wagtail/wagtailadmin/navigation.py
+++ b/wagtail/wagtailadmin/navigation.py
@@ -16,11 +16,16 @@ def get_pages_with_direct_explore_permission(user):
             group_permissions__permission_type__in=['add', 'edit', 'publish', 'lock']
         )
 
+
 def get_explorable_root_page(user):
     # Get the highest common explorable ancestor for the given user
-    return get_pages_with_direct_explore_permission(user).first_common_ancestor(
-        include_self=True,
-        strict=True)
+    pages = get_pages_with_direct_explore_permission(user)
+    if pages:
+        return pages.first_common_ancestor(
+            include_self=True,
+            strict=True)
+    else:
+        return None
 
 
 def get_navigation_menu_items(user):

--- a/wagtail/wagtailadmin/navigation.py
+++ b/wagtail/wagtailadmin/navigation.py
@@ -16,6 +16,12 @@ def get_pages_with_direct_explore_permission(user):
             group_permissions__permission_type__in=['add', 'edit', 'publish', 'lock']
         )
 
+def get_explorable_root_page(user):
+    # Get the highest common explorable ancestor for the given user
+    return get_pages_with_direct_explore_permission(user).first_common_ancestor(
+        include_self=True,
+        strict=True)
+
 
 def get_navigation_menu_items(user):
     # Get all pages that the user has direct add/edit/publish/lock permission on

--- a/wagtail/wagtailadmin/navigation.py
+++ b/wagtail/wagtailadmin/navigation.py
@@ -18,7 +18,8 @@ def get_pages_with_direct_explore_permission(user):
 
 
 def get_explorable_root_page(user):
-    # Get the highest common explorable ancestor for the given user
+    # Get the highest common explorable ancestor for the given user. If the user
+    # has no permissions over any pages, this method will return None.
     pages = get_pages_with_direct_explore_permission(user)
     if pages:
         return pages.first_common_ancestor(

--- a/wagtail/wagtailadmin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/wagtailadmin/templatetags/wagtailadmin_tags.py
@@ -60,9 +60,8 @@ def explorer_breadcrumb(context, page, include_self=False):
 
     # find the closest common ancestor of the pages that this user has direct explore permission
     # (i.e. add/edit/publish/lock) over; this will be the root of the breadcrumb
-    try:
-        cca = get_explorable_root_page(user)
-    except Page.DoesNotExist:
+    cca = get_explorable_root_page(user)
+    if not cca:
         return {'pages': Page.objects.none()}
 
     return {

--- a/wagtail/wagtailadmin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/wagtailadmin/templatetags/wagtailadmin_tags.py
@@ -14,7 +14,7 @@ from django.utils.safestring import mark_safe
 from wagtail.utils.pagination import DEFAULT_PAGE_KEY, replace_page_in_query
 from wagtail.wagtailadmin.menu import admin_menu
 from wagtail.wagtailadmin.navigation import (
-    get_navigation_menu_items, get_pages_with_direct_explore_permission)
+    get_navigation_menu_items, get_explorable_root_page)
 from wagtail.wagtailadmin.search import admin_search_areas
 from wagtail.wagtailcore import hooks
 from wagtail.wagtailcore.models import Page, PageViewRestriction, UserPagePermissionsProxy
@@ -62,9 +62,7 @@ def explorer_breadcrumb(context, page, include_self=False):
     # find the closest common ancestor of the pages that this user has direct explore permission
     # (i.e. add/edit/publish/lock) over; this will be the root of the breadcrumb
     try:
-        cca = get_pages_with_direct_explore_permission(user).first_common_ancestor(
-            include_self=True, strict=True
-        )
+        cca = get_explorable_root_page(user)
     except Page.DoesNotExist:
         return {'pages': Page.objects.none()}
 

--- a/wagtail/wagtailadmin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/wagtailadmin/templatetags/wagtailadmin_tags.py
@@ -13,8 +13,7 @@ from django.utils.safestring import mark_safe
 
 from wagtail.utils.pagination import DEFAULT_PAGE_KEY, replace_page_in_query
 from wagtail.wagtailadmin.menu import admin_menu
-from wagtail.wagtailadmin.navigation import (
-    get_navigation_menu_items, get_explorable_root_page)
+from wagtail.wagtailadmin.navigation import get_explorable_root_page, get_navigation_menu_items
 from wagtail.wagtailadmin.search import admin_search_areas
 from wagtail.wagtailcore import hooks
 from wagtail.wagtailcore.models import Page, PageViewRestriction, UserPagePermissionsProxy

--- a/wagtail/wagtailadmin/tests/test_pages_views.py
+++ b/wagtail/wagtailadmin/tests/test_pages_views.py
@@ -407,6 +407,21 @@ class TestExplorablePageVisibility(TestCase, WagtailTestUtils):
         # The page title shouldn't appear because it's the "home" breadcrumb.
         self.assertNotContains(response, "Welcome to example.com!")
 
+    def test_admin_home_page_changes_with_permissions(self):
+        self.assertTrue(self.client.login(username='bob', password='password'))
+        response = self.client.get(reverse('wagtailadmin_home'))
+        self.assertEqual(response.status_code, 200)
+        # Bob should only see the welcome for example.com, not testserver
+        self.assertContains(response, "Welcome to the example.com Wagtail CMS")
+        self.assertNotContains(response, "testserver")
+
+    def test_breadcrumb_with_no_user_permissions(self):
+        self.assertTrue(self.client.login(username='mary', password='password'))
+        response = self.client.get(reverse('wagtailadmin_home'))
+        self.assertEqual(response.status_code, 200)
+        # Since Mary has no page permissions, she should not see the breadcrumb
+        self.assertNotContains(response, """<li class="home"><a href="/admin/pages/4/" class="icon icon-home text-replace">Home</a></li>""")
+
 
 class TestPageCreation(TestCase, WagtailTestUtils):
     def setUp(self):

--- a/wagtail/wagtailadmin/views/home.py
+++ b/wagtail/wagtailadmin/views/home.py
@@ -89,8 +89,9 @@ def home(request):
     else:
         root_site = None
 
+    real_site_name = None
     if root_site:
-        real_site_name = root_site.site_name else root_site.hostname
+        real_site_name = root_site.site_name if root_site.site_name else root_site.hostname
 
     return render(request, "wagtailadmin/home.html", {
         'root_page': root_page,

--- a/wagtail/wagtailadmin/views/home.py
+++ b/wagtail/wagtailadmin/views/home.py
@@ -89,10 +89,13 @@ def home(request):
     else:
         root_site = None
 
+    if root_site:
+        real_site_name = root_site.site_name else root_site.hostname
+
     return render(request, "wagtailadmin/home.html", {
         'root_page': root_page,
         'root_site': root_site,
-        'site_name': root_site.site_name if root_site is not None else settings.WAGTAIL_SITE_NAME,
+        'site_name': real_site_name if real_site_name else settings.WAGTAIL_SITE_NAME,
         'panels': sorted(panels, key=lambda p: p.order),
         'user': request.user
     })

--- a/wagtail/wagtailadmin/views/home.py
+++ b/wagtail/wagtailadmin/views/home.py
@@ -4,8 +4,8 @@ from django.conf import settings
 from django.shortcuts import render
 from django.template.loader import render_to_string
 
-from wagtail.wagtailadmin.site_summary import SiteSummaryPanel
 from wagtail.wagtailadmin.navigation import get_explorable_root_page
+from wagtail.wagtailadmin.site_summary import SiteSummaryPanel
 from wagtail.wagtailcore import hooks
 from wagtail.wagtailcore.models import Page, PageRevision, UserPagePermissionsProxy
 
@@ -84,7 +84,10 @@ def home(request):
         fn(request, panels)
 
     root_page = get_explorable_root_page(request.user)
-    root_site = root_page.get_site()
+    if root_page:
+        root_site = root_page.get_site()
+    else:
+        root_site = None
 
     return render(request, "wagtailadmin/home.html", {
         'root_page': root_page,

--- a/wagtail/wagtailadmin/views/home.py
+++ b/wagtail/wagtailadmin/views/home.py
@@ -5,6 +5,7 @@ from django.shortcuts import render
 from django.template.loader import render_to_string
 
 from wagtail.wagtailadmin.site_summary import SiteSummaryPanel
+from wagtail.wagtailadmin.navigation import get_explorable_root_page
 from wagtail.wagtailcore import hooks
 from wagtail.wagtailcore.models import Page, PageRevision, UserPagePermissionsProxy
 
@@ -82,8 +83,13 @@ def home(request):
     for fn in hooks.get_hooks('construct_homepage_panels'):
         fn(request, panels)
 
+    root_page = get_explorable_root_page(request.user)
+    root_site = root_page.get_site()
+
     return render(request, "wagtailadmin/home.html", {
-        'site_name': settings.WAGTAIL_SITE_NAME,
+        'root_page': root_page,
+        'root_site': root_site,
+        'site_name': root_site.site_name if root_site is not None else settings.WAGTAIL_SITE_NAME,
         'panels': sorted(panels, key=lambda p: p.order),
         'user': request.user
     })


### PR DESCRIPTION
Continuation of #3223.

Add some data to the context of the home renderer so developers are able to alter the admin homepage based on the site record and level of permission on the given page. 

Also added a convenience function in wagtailadmin/navigation.py to retrieve the highest explorable page for a given user. 
