### PR TITLE
Add after/before_copy_page hooks, test and docs

### DIFF
--- a/docs/reference/hooks.rst
+++ b/docs/reference/hooks.rst
@@ -453,6 +453,24 @@ Hooks for customising the way users are directed through the process of creating
   Uses the same behavior as ``before_create_page``.
 
 
+.. _after_copy_page:
+
+``after_copy_page``
+~~~~~~~~~~~~~~~~~~~
+
+  Do something with a ``Page`` object after it has been copied pasing in the request, page object and the new copied page. Uses the same behavior as ``after_create_page``.
+
+
+.. _before_copy_page:
+
+``before_copy_page``
+~~~~~~~~~~~~~~~~~~~~~
+
+  Called at the beginning of the "copy page" view passing in the request and the page object.
+
+  Uses the same behavior as ``before_create_page``.
+
+
 .. _construct_wagtail_userbar:
 
 ``construct_wagtail_userbar``

--- a/wagtail/wagtailadmin/tests/test_pages_views.py
+++ b/wagtail/wagtailadmin/tests/test_pages_views.py
@@ -2300,6 +2300,62 @@ class TestPageCopy(TestCase, WagtailTestUtils):
         # treebeard should report no consistency problems with the tree
         self.assertFalse(any(Page.find_problems()), 'treebeard found consistency problems')
 
+    def test_before_copy_page_hook(self):
+        def hook_func(request, page):
+            self.assertIsInstance(request, HttpRequest)
+            self.assertIsInstance(page.specific, SimplePage)
+
+            return HttpResponse("Overridden!")
+
+        with self.register_hook('before_copy_page', hook_func):
+            response = self.client.get(reverse('wagtailadmin_pages:copy', args=(self.test_page.id,)))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, b"Overridden!")
+
+    def test_before_copy_page_hook_post(self):
+        def hook_func(request, page):
+            self.assertIsInstance(request, HttpRequest)
+            self.assertIsInstance(page.specific, SimplePage)
+
+            return HttpResponse("Overridden!")
+
+        with self.register_hook('before_copy_page', hook_func):
+            post_data = {
+                'new_title': "Hello world 2",
+                'new_slug': 'hello-world-2',
+                'new_parent_page': str(self.root_page.id),
+                'copy_subpages': False,
+                'publish_copies': False,
+            }
+            response = self.client.post(reverse('wagtailadmin_pages:copy', args=(self.test_page.id,)), post_data)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, b"Overridden!")
+
+    def test_after_copy_page_hook(self):
+        def hook_func(request, page, new_page):
+            self.assertIsInstance(request, HttpRequest)
+            self.assertIsInstance(page.specific, SimplePage)
+            self.assertIsInstance(new_page.specific, SimplePage)
+
+            return HttpResponse("Overridden!")
+
+        with self.register_hook('after_copy_page', hook_func):
+            post_data = {
+                'new_title': "Hello world 2",
+                'new_slug': 'hello-world-2',
+                'new_parent_page': str(self.root_page.id),
+                'copy_subpages': False,
+                'publish_copies': False,
+            }
+            response = self.client.post(reverse('wagtailadmin_pages:copy', args=(self.test_page.id,)), post_data)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, b"Overridden!")
+
+
+
 
 class TestPageUnpublish(TestCase, WagtailTestUtils):
     def setUp(self):

--- a/wagtail/wagtailadmin/views/pages.py
+++ b/wagtail/wagtailadmin/views/pages.py
@@ -809,6 +809,11 @@ def copy(request, page_id):
 
     next_url = get_valid_next_url_from_request(request)
 
+    for fn in hooks.get_hooks('before_copy_page'):
+        result = fn(request, page)
+        if hasattr(result, 'status_code'):
+            return result
+
     # Check if user is submitting
     if request.method == 'POST':
         # Prefill parent_page in case the form is invalid (as prepopulated value for the form field,
@@ -838,6 +843,11 @@ def copy(request, page_id):
                 keep_live=(can_publish and form.cleaned_data.get('publish_copies')),
                 user=request.user,
             )
+
+            for fn in hooks.get_hooks('after_copy_page'):
+                result = fn(request, page, new_page)
+                if hasattr(result, 'status_code'):
+                    return result
 
             # Give a success message back to the user
             if form.cleaned_data.get('copy_subpages'):

--- a/wagtail/wagtailadmin/views/pages.py
+++ b/wagtail/wagtailadmin/views/pages.py
@@ -844,11 +844,6 @@ def copy(request, page_id):
                 user=request.user,
             )
 
-            for fn in hooks.get_hooks('after_copy_page'):
-                result = fn(request, page, new_page)
-                if hasattr(result, 'status_code'):
-                    return result
-
             # Give a success message back to the user
             if form.cleaned_data.get('copy_subpages'):
                 messages.success(
@@ -857,6 +852,11 @@ def copy(request, page_id):
                 )
             else:
                 messages.success(request, _("Page '{0}' copied.").format(page.get_admin_display_title()))
+
+            for fn in hooks.get_hooks('after_copy_page'):
+                result = fn(request, page, new_page)
+                if hasattr(result, 'status_code'):
+                    return result
 
             # Redirect to explore of parent page
             if next_url:


### PR DESCRIPTION
#3246 

Add's documentation, tests and hook for `before_copy_page` and `after_copy_page`. I'm not totally sure about the parameters passed to the hook but I'm passing request and page to before_copy_page and request, page, new_page to after_copy_page.

What do you guys think? 