### PR TITLE
Provide fallback value for schema_only parameter in update_index management command

### DIFF
--- a/wagtail/wagtailsearch/management/commands/update_index.py
+++ b/wagtail/wagtailsearch/management/commands/update_index.py
@@ -117,7 +117,7 @@ class Command(BaseCommand):
 
         # Update backends
         for backend_name in backend_names:
-            self.update_backend(backend_name, schema_only=options['schema_only'])
+            self.update_backend(backend_name, schema_only=options.get('schema_only', False))
 
     def print_newline(self):
         self.stdout.write('')


### PR DESCRIPTION
Currently if management command is called from inside the code, it breaks.
`**options` kwargs dictionary doesn't necessarily have `schema_only` param and your code doesn't check if it does.

Example (this will break):
```
update_index.Command().handle(backend_name='default')
```
`update_backend` function does have a default value for `schema_only` but `handle` does not.
You do make a similar check for existence of `options['backend_name']`, I believe something similar should be done for `options['schema_only']`



