### PR TITLE
RegexBlock error_message typo in docs

### DIFF
--- a/docs/topics/streamfield.rst
+++ b/docs/topics/streamfield.rst
@@ -132,7 +132,7 @@ A single-line text input that validates a string against a regex expression. The
 
 .. code-block:: python
 
-    blocks.RegexBlock(regex=r'^[0-9]{3}$', error_message={
+    blocks.RegexBlock(regex=r'^[0-9]{3}$', error_messages={
         'invalid': "Not a valid library card number."
     })
 


### PR DESCRIPTION
In the documention an example had a singular error_message kwarg but it should be plural.

Thanks for contributing to Wagtail! 

Before submitting, please review the contributor guidelines <http://docs.wagtail.io/en/latest/contributing/index.html> and check the following:

* Do the tests still pass? (http://docs.wagtail.io/en/latest/contributing/developing.html#testing)
* Does the code comply with the style guide? (Run `make lint` from the Wagtail root)
* For Python changes: Have you added tests to cover the new/fixed behaviour?
* For new features: Has the documentation been updated accordingly?
