### PR TITLE
Pass parent context to get context as discussed in #2786

### DIFF
--- a/wagtail/tests/testapp/blocks.py
+++ b/wagtail/tests/testapp/blocks.py
@@ -7,9 +7,9 @@ class LinkBlock(blocks.StructBlock):
     title = blocks.CharBlock()
     url = blocks.URLBlock()
 
-    def get_context(self, value):
-        context = super(LinkBlock, self).get_context(value)
-        context['classname'] = 'important' if value['title'] == 'Torchbox' else 'normal'
+    def get_context(self, value, parent_context=None):
+        context = super(LinkBlock, self).get_context(value, parent_context)
+        context['classname'] = parent_context['classname'] if value['title'] == 'Torchbox' else 'normal'
         return context
 
     def get_form_context(self, value, prefix='', errors=None):

--- a/wagtail/wagtailcore/blocks/base.py
+++ b/wagtail/wagtailcore/blocks/base.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 
-import warnings
 import collections
+import warnings
 from importlib import import_module
 
 from django import forms

--- a/wagtail/wagtailcore/blocks/base.py
+++ b/wagtail/wagtailcore/blocks/base.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
+import warnings
 import collections
 from importlib import import_module
 
@@ -15,7 +16,8 @@ from django.utils.text import capfirst
 # unicode_literals ensures that any render / __str__ methods returning HTML via calls to mark_safe / format_html
 # return a SafeText, not SafeBytes; necessary so that it doesn't get re-encoded when the template engine
 # calls force_text, which would cause it to lose its 'safe' flag
-
+from wagtail.utils.deprecation import RemovedInWagtail111Warning
+from wagtail.wagtailcore.blocks.utils import accepts_kwarg
 
 __all__ = ['BaseBlock', 'Block', 'BoundBlock', 'DeclarativeSubBlocksMetaclass', 'BlockWidget', 'BlockField']
 
@@ -211,15 +213,18 @@ class Block(six.with_metaclass(BaseBlock, object)):
         """
         return value
 
-    def get_context(self, value):
+    def get_context(self, value, parent_context=None):
         """
-        Return a dict of context variables (derived from the block value, or otherwise)
-        to be added to the template context when rendering this value through a template.
+        Return a dict of context variables (derived from the block value and combined with the parent_context)
+        to be used as the template context when rendering this value through a template.
         """
-        return {
+
+        context = parent_context or {}
+        context.update({
             'self': value,
             self.TEMPLATE_VAR: value,
-        }
+        })
+        return context
 
     def render(self, value, context=None):
         """
@@ -231,11 +236,23 @@ class Block(six.with_metaclass(BaseBlock, object)):
         if not template:
             return self.render_basic(value, context=context)
 
+        if not accepts_kwarg(self.get_context, 'parent_context'):
+            class_with_render_method = next(
+                (cls for cls in type(self).__mro__ if 'get_context' in cls.__dict__),
+                type(self)
+            )
+            warnings.warn(
+                "The get_context method on %s needs to be updated to accept an optional 'parent_context' "
+                "keyword argument" % class_with_render_method,
+                category=RemovedInWagtail111Warning
+            )
+            new_context = self.get_context(value)
+            return mark_safe(render_to_string(template, new_context))
+
         if context is None:
             new_context = self.get_context(value)
         else:
-            new_context = dict(context)
-            new_context.update(self.get_context(value))
+            new_context = self.get_context(value, parent_context=dict(context))
 
         return mark_safe(render_to_string(template, new_context))
 

--- a/wagtail/wagtailcore/blocks/base.py
+++ b/wagtail/wagtailcore/blocks/base.py
@@ -246,7 +246,8 @@ class Block(six.with_metaclass(BaseBlock, object)):
                 "keyword argument" % class_with_render_method,
                 category=RemovedInWagtail111Warning
             )
-            new_context = self.get_context(value)
+            new_context = context
+            new_context.update(self.get_context(value))
             return mark_safe(render_to_string(template, new_context))
 
         if context is None:

--- a/wagtail/wagtailcore/blocks/utils.py
+++ b/wagtail/wagtailcore/blocks/utils.py
@@ -1,7 +1,8 @@
 from __future__ import absolute_import, unicode_literals
 
 import re
-
+import inspect
+import sys
 
 # helpers for Javascript expression formatting
 
@@ -23,3 +24,20 @@ def js_dict(d):
         for (k, v) in d.items()
     ]
     return "{\n%s\n}" % ',\n'.join(dict_items)
+
+
+def accepts_kwarg(func, kwarg):
+    """
+    Determine whether the callable `func` has a signature that accepts the keyword argument `kwarg`
+    """
+    if sys.version_info >= (3, 3):
+        signature = inspect.signature(func)
+        try:
+            signature.bind_partial(**{kwarg: None})
+            return True
+        except TypeError:
+            return False
+    else:
+        # Fall back on inspect.getargspec, available on Python 2.7 but deprecated since 3.5
+        argspec = inspect.getargspec(func)
+        return (kwarg in argspec.args) or (argspec.keywords is not None)

--- a/wagtail/wagtailcore/blocks/utils.py
+++ b/wagtail/wagtailcore/blocks/utils.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 
-import re
 import inspect
+import re
 import sys
 
 # helpers for Javascript expression formatting

--- a/wagtail/wagtailcore/tests/test_blocks.py
+++ b/wagtail/wagtailcore/tests/test_blocks.py
@@ -82,7 +82,7 @@ class TestFieldBlock(unittest.TestCase):
 
         self.assertEqual(len(ws), 1)
         self.assertIs(ws[0].category, RemovedInWagtail111Warning)
-        self.assertEqual(html, '<h1>Bonjour le monde!</h1>')
+        self.assertEqual(html, '<h1 lang="fr">Bonjour le monde!</h1>')
 
     def test_charfield_render_form(self):
         block = blocks.CharBlock()

--- a/wagtail/wagtailcore/tests/test_blocks.py
+++ b/wagtail/wagtailcore/tests/test_blocks.py
@@ -5,6 +5,7 @@ import base64
 import collections
 import json
 import unittest
+import warnings
 from decimal import Decimal
 
 # non-standard import name for ugettext_lazy, to prevent strings from being picked up for translation
@@ -21,6 +22,7 @@ from django.utils.translation import ugettext_lazy as __
 from wagtail.tests.testapp.blocks import LinkBlock as CustomLinkBlock
 from wagtail.tests.testapp.blocks import SectionBlock
 from wagtail.tests.testapp.models import SimplePage
+from wagtail.utils.deprecation import RemovedInWagtail111Warning
 from wagtail.wagtailcore import blocks
 from wagtail.wagtailcore.models import Page
 from wagtail.wagtailcore.rich_text import RichText
@@ -37,6 +39,17 @@ class FooStreamBlock(blocks.StreamBlock):
         return value
 
 
+class NoExtraContextCharBlock(blocks.CharBlock):
+    def get_context(self, value):
+        return super(blocks.CharBlock, self).get_context(value)
+
+
+class ContextCharBlock(blocks.CharBlock):
+    def get_context(self, value, parent_context=None):
+        value = str(value).upper()
+        return super(blocks.CharBlock, self).get_context(value, parent_context)
+
+
 class TestFieldBlock(unittest.TestCase):
     def test_charfield_render(self):
         block = blocks.CharBlock()
@@ -51,12 +64,25 @@ class TestFieldBlock(unittest.TestCase):
         self.assertEqual(html, '<h1>Hello world!</h1>')
 
     def test_charfield_render_with_template_with_extra_context(self):
-        block = blocks.CharBlock(template='tests/blocks/heading_block.html')
+        block = ContextCharBlock(template='tests/blocks/heading_block.html')
         html = block.render("Bonjour le monde!", context={
             'language': 'fr',
         })
 
-        self.assertEqual(html, '<h1 lang="fr">Bonjour le monde!</h1>')
+        self.assertEqual(html, '<h1 lang="fr">BONJOUR LE MONDE!</h1>')
+
+    def test_charfield_render_with_legacy_get_context(self):
+        block = NoExtraContextCharBlock(template='tests/blocks/heading_block.html')
+        with warnings.catch_warnings(record=True) as ws:
+            warnings.simplefilter('always')
+
+            html = block.render("Bonjour le monde!", context={
+                'language': 'fr',
+            })
+
+        self.assertEqual(len(ws), 1)
+        self.assertIs(ws[0].category, RemovedInWagtail111Warning)
+        self.assertEqual(html, '<h1>Bonjour le monde!</h1>')
 
     def test_charfield_render_form(self):
         block = blocks.CharBlock()
@@ -2361,7 +2387,8 @@ class TestTemplateRendering(TestCase):
     def test_render_with_custom_context(self):
         block = CustomLinkBlock()
         value = block.to_python({'title': 'Torchbox', 'url': 'http://torchbox.com/'})
-        result = block.render(value)
+        context = {'classname': 'important'}
+        result = block.render(value, context)
 
         self.assertEqual(result, '<a href="http://torchbox.com/" class="important">Torchbox</a>')
 


### PR DESCRIPTION
Added parent_context to get_context according to discussion in https://github.com/wagtail/wagtail/pull/3032 , https://github.com/wagtail/wagtail/pull/2786 and https://github.com/ipmb/wagtail/pull/1

Legacy handling is added so whenever a block with a get_context without parent_context is rendered it throws a deprecation warning 

Tests is added to test the new functionalities.
