### PR TITLE
Avoid indexing unsaved field content on save(update_fields=[...]) operations

### DIFF
--- a/wagtail/wagtailsearch/signal_handlers.py
+++ b/wagtail/wagtailsearch/signal_handlers.py
@@ -5,7 +5,13 @@ from django.db.models.signals import post_delete, post_save
 from wagtail.wagtailsearch import index
 
 
-def post_save_signal_handler(instance, **kwargs):
+def post_save_signal_handler(instance, update_fields=None, **kwargs):
+    if update_fields is not None:
+        # fetch a fresh copy of instance from the database to ensure
+        # that we're not indexing any of the unsaved data contained in
+        # the fields that were not passed in update_fields
+        instance = type(instance).objects.get(pk=instance.pk)
+
     index.insert_or_update_object(instance)
 
 

--- a/wagtail/wagtailsearch/tests/test_index_functions.py
+++ b/wagtail/wagtailsearch/tests/test_index_functions.py
@@ -56,12 +56,16 @@ class TestGetIndexedInstance(TestCase):
 class TestInsertOrUpdateObject(TestCase, WagtailTestUtils):
     def test_inserts_object(self, backend):
         obj = models.SearchTest.objects.create(title="Test")
+        backend().reset_mock()
+
         index.insert_or_update_object(obj)
 
         backend().add.assert_called_with(obj)
 
     def test_doesnt_insert_unsaved_object(self, backend):
         obj = models.SearchTest(title="Test")
+        backend().reset_mock()
+
         index.insert_or_update_object(obj)
 
         self.assertFalse(backend().add.mock_calls)
@@ -72,6 +76,9 @@ class TestInsertOrUpdateObject(TestCase, WagtailTestUtils):
 
         # Convert page into a generic "Page" object and add it into the index
         unspecific_page = page.page_ptr
+
+        backend().reset_mock()
+
         index.insert_or_update_object(unspecific_page)
 
         # It should be automatically converted back to the specific version
@@ -81,6 +88,7 @@ class TestInsertOrUpdateObject(TestCase, WagtailTestUtils):
         obj = models.SearchTest.objects.create(title="Test")
 
         backend().add.side_effect = ValueError("Test")
+        backend().reset_mock()
 
         with self.assertLogs('wagtail.search.index', level='ERROR') as cm:
             index.insert_or_update_object(obj)
@@ -100,18 +108,23 @@ class TestInsertOrUpdateObject(TestCase, WagtailTestUtils):
 class TestRemoveObject(TestCase, WagtailTestUtils):
     def test_removes_object(self, backend):
         obj = models.SearchTest.objects.create(title="Test")
+        backend().reset_mock()
+
         index.remove_object(obj)
 
-        backend().add.assert_called_with(obj)
+        backend().delete.assert_called_with(obj)
 
     def test_removes_unsaved_object(self, backend):
         obj = models.SearchTest(title="Test")
+        backend().reset_mock()
+
         index.remove_object(obj)
 
         backend().delete.assert_called_with(obj)
 
     def test_catches_index_error(self, backend):
         obj = models.SearchTest.objects.create(title="Test")
+        backend().reset_mock()
 
         backend().delete.side_effect = ValueError("Test")
 

--- a/wagtail/wagtailsearch/tests/test_index_functions.py
+++ b/wagtail/wagtailsearch/tests/test_index_functions.py
@@ -166,3 +166,16 @@ class TestSignalHandlers(TestCase, WagtailTestUtils):
         backend().reset_mock()
         obj.delete()
         backend().delete.assert_called_with(obj)
+
+    def test_do_not_index_fields_omitted_from_update_fields(self, backend):
+        obj = models.SearchTest.objects.create(title="Test", content="This is the original content")
+
+        backend().reset_mock()
+        obj.title = "Updated test"
+        obj.content = "This is the updated content"
+        obj.save(update_fields=['title'])
+
+        backend().add.assert_called_once()
+        indexed_object = backend().add.call_args[0][0]
+        self.assertEqual(indexed_object.title, "Updated test")
+        self.assertEqual(indexed_object.content, "This is the original content")


### PR DESCRIPTION
Fixes #3239

Also add tests for signal handlers, and fix some issues in test_index_functions.py where the effects of signal handlers were unintentionally leaking into tests.