### PR TITLE
Minor style tweaks for modeladmin's IndexView

### DIFF
--- a/wagtail/contrib/modeladmin/static_src/wagtailmodeladmin/scss/index.scss
+++ b/wagtail/contrib/modeladmin/static_src/wagtailmodeladmin/scss/index.scss
@@ -1,28 +1,41 @@
+@import 'wagtailadmin/scss/variables';
+
 .content header {
     margin-bottom: 0;
 }
 
 
 .result-list {
-    padding: 0 15px;
+    margin-bottom: 0;
+}
 
-    table {
-        margin-bottom: 0;
-    }
+.listing {
 
-    body th {
-        background-color: transparent;
-        text-align: left;
-        padding: 1.2em 1em;
-    }
-
-    tbody tr:hover ul.actions {
-        visibility: visible;
-    }
-
-    tbody td,
-    tbody th {
+    td,
+    th {
         vertical-align: top;
+    }
+
+    thead th.sorted a {
+        color: $color-teal;
+    }
+
+    tbody {
+        overflow: auto;
+
+        tr:hover ul.actions {
+            visibility: visible;
+        }
+
+        tr > td { 
+            background-color: inherit;
+            
+            a.edit-obj { 
+                color: inherit;
+                font-weight: 600; 
+            }
+        }
+
     }
 }
 
@@ -133,14 +146,18 @@ p.no-results {
 
     .result-list {
         padding: 0 1.5% 0 0;
-    }
 
-    .result-list tbody th:first-child {
-        padding-left: 50px;
-    }
+        &.col12 {
+            padding-right: 0;
 
-    .result-list.col12 tbody td:last-child {
-        padding-right: 50px;
+            tbody td:last-child {
+                padding-right: 50px;
+            }
+        }
+
+        tbody th:first-child {
+            padding-left: 50px;
+        }
     }
 
     div.pagination {

--- a/wagtail/contrib/modeladmin/templates/modeladmin/includes/result_list.html
+++ b/wagtail/contrib/modeladmin/templates/modeladmin/includes/result_list.html
@@ -5,7 +5,7 @@
         <tr>
             {% for header in result_headers %}
             <th scope="col" {{ header.class_attrib }}>
-                {% if header.sortable %}<a href="{{ header.url_primary }}" class="teal icon {% if header.ascending %}icon-arrow-up-after{% else %}icon-arrow-down-after{% endif %}">{% endif %}
+                {% if header.sortable %}<a href="{{ header.url_primary }}" class="icon {% if header.ascending %}icon-arrow-up-after{% else %}icon-arrow-down-after{% endif %}">{% endif %}
                 {{ header.text|capfirst }}
                 {% if header.sortable %}</a>{% endif %}
            </th>


### PR DESCRIPTION
This is a part recreation of #3074, just focussing on getting a few styles fixed and improving consistency with other parts of the CMS. I'm hoping this will help with review/approval. I'll work on reimplementing the other changes from #3074 as a separate PR later, once all the outstanding modeladmin PRs are merged and over with.

Here are the aims of this particular PR:

- Removes unnecessary right padding from result list on desktop, when there are no filters to display, and the listing should be full width.
- Removes unnecessary left/right padding from result list on mobile (the table cells have padding of their own)
- In order to be more consistent with the Explorer list view, only make orderable column header links 'teal' if the listing is currently ordered by that field
- Better use of hierarchy in scss to improve readability