### PR TITLE
Bug fix: Correct positional argument order for a couple of ModelAdmin methods

### DIFF
--- a/wagtail/contrib/modeladmin/templatetags/modeladmin_tags.py
+++ b/wagtail/contrib/modeladmin/templatetags/modeladmin_tags.py
@@ -71,12 +71,12 @@ def items_for_result(view, result):
         if force_text(result_repr) == '':
             result_repr = mark_safe('&nbsp;')
         row_classes.extend(
-            modeladmin.get_extra_class_names_for_field_col(field_name, result))
-        row_attrs_dict = modeladmin.get_extra_attrs_for_field_col(
-            field_name, result)
-        row_attrs_dict['class'] = ' ' . join(row_classes)
-        row_attrs = flatatt(row_attrs_dict)
-        yield format_html('<td{}>{}</td>', row_attrs, result_repr)
+            modeladmin.get_extra_class_names_for_field_col(result, field_name)
+        )
+        row_attrs = modeladmin.get_extra_attrs_for_field_col(result, field_name)
+        row_attrs['class'] = ' ' . join(row_classes)
+        row_attrs_flat = flatatt(row_attrs)
+        yield format_html('<td{}>{}</td>', row_attrs_flat, result_repr)
 
 
 def results(view, object_list):

--- a/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
+++ b/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
@@ -10,7 +10,7 @@ from wagtail.wagtailimages.models import Image
 from wagtail.wagtailimages.tests.utils import get_test_image_file
 
 
-class TestIndexView(TestCase, WagtailTestUtils):
+class TestBookIndexView(TestCase, WagtailTestUtils):
     fixtures = ['modeladmintest_test.json']
 
     def setUp(self):
@@ -47,7 +47,7 @@ class TestIndexView(TestCase, WagtailTestUtils):
         self.assertContains(response, 'data-object-pk="3"')
 
         # There should be two odd rows and two even ones, and 'book' should be
-        # add to the `class` attribute for every one.
+        # added to the `class` attribute for every one.
         self.assertContains(response, 'class="book odd"', count=2)
         self.assertContains(response, 'class="book even"', count=2)
 
@@ -96,6 +96,32 @@ class TestIndexView(TestCase, WagtailTestUtils):
 
         # There are four books in the test data
         self.assertEqual(response.context['result_count'], 4)
+
+
+class TestAuthorIndexView(TestCase, WagtailTestUtils):
+    fixtures = ['modeladmintest_test.json']
+
+    def setUp(self):
+        self.login()
+
+    def get(self, **params):
+        return self.client.get('/admin/modeladmintest/author/', params)
+
+    def test_col_extra_class_names(self):
+        response = self.get()
+        self.assertEqual(response.status_code, 200)
+        test_html = """
+            <td class="field-first_book for-author-1">The Lord of the Rings</td>
+        """
+        self.assertContains(response, test_html, html=True)
+
+    def test_col_extra_attributes(self):
+        response = self.get()
+        self.assertEqual(response.status_code, 200)
+        test_html = """
+            <td class="field-last_book" data-for_author="1">The Hobbit</td>
+        """
+        self.assertContains(response, test_html, html=True)
 
 
 class TestCreateView(TestCase, WagtailTestUtils):

--- a/wagtail/tests/modeladmintest/models.py
+++ b/wagtail/tests/modeladmintest/models.py
@@ -15,6 +15,13 @@ class Author(models.Model):
     def __str__(self):
         return self.name
 
+    def first_book(self):
+        # For testing use of object methods in list_display
+        book = self.book_set.first()
+        if book:
+            return book.title
+        return ''
+
 
 @python_2_unicode_compatible
 class Book(models.Model, index.Indexed):

--- a/wagtail/tests/modeladmintest/wagtail_hooks.py
+++ b/wagtail/tests/modeladmintest/wagtail_hooks.py
@@ -12,11 +12,34 @@ from .models import Author, Book, Publisher, Token, VenuePage
 class AuthorModelAdmin(ModelAdmin):
     model = Author
     menu_order = 200
-    list_display = ('name', 'date_of_birth')
+    list_display = ('name', 'first_book', 'last_book', 'date_of_birth')
     list_filter = ('date_of_birth', )
     search_fields = ('name', )
     inspect_view_enabled = True
     inspect_view_fields = ('name', )
+
+    def last_book(self, obj):
+        # For testing use of modeladmin methods in list_display
+        book = obj.book_set.last()
+        if book:
+            return book.title
+        return ''
+
+    def get_extra_class_names_for_field_col(self, obj, field_name):
+        class_names = super(
+            AuthorModelAdmin, self
+        ).get_extra_class_names_for_field_col(field_name, obj)
+        if field_name == 'first_book':
+            class_names.append('for-author-%s' % obj.pk)
+        return class_names
+
+    def get_extra_attrs_for_field_col(self, obj, field_name):
+        attrs = super(AuthorModelAdmin, self).get_extra_attrs_for_field_col(
+            field_name, obj
+        )
+        if field_name == 'last_book':
+            attrs['data-for_author'] = obj.id
+        return attrs
 
 
 class BookModelAdmin(ThumbnailMixin, ModelAdmin):


### PR DESCRIPTION
The `get_class_names_for_field_col()` and `get_extra_attrs_for_field_col()` methods are both provided with the `obj` and `field_name` positional arguments in the wrong order from `items_for_result()` in the template tags. The order should be: `obj`, `field_name` (as used on the ModelAdmin method itself, and as shown in the method explanation / accompanying code example in the docs).

This PR fixes that issue, and adds some more customisation examples to the test app to show these and a couple of other methods working properly.