### PR TITLE
Fix overlong index on wagtailimages.Rendition on MySQL (for 1.8.x branch)

### DIFF
--- a/wagtail/__init__.py
+++ b/wagtail/__init__.py
@@ -4,7 +4,7 @@ from wagtail.utils.version import get_semver_version, get_version
 
 # major.minor.patch.release.number
 # release must be one of alpha, beta, rc, or final
-VERSION = (1, 8, 0, 'final', 0)
+VERSION = (1, 8, 1, 'alpha', 0)
 
 __version__ = get_version(VERSION)
 

--- a/wagtail/wagtailimages/migrations/0001_initial.py
+++ b/wagtail/wagtailimages/migrations/0001_initial.py
@@ -63,7 +63,7 @@ class Migration(migrations.Migration):
                 ('file', models.ImageField(width_field='width', upload_to='images', height_field='height')),
                 ('width', models.IntegerField(editable=False)),
                 ('height', models.IntegerField(editable=False)),
-                ('focal_point_key', models.CharField(editable=False, max_length=255, null=True)),
+                ('focal_point_key', models.CharField(editable=False, max_length=16, null=True)),
                 ('filter', models.ForeignKey(on_delete=models.CASCADE, related_name='+', to='wagtailimages.Filter')),
                 ('image', models.ForeignKey(on_delete=models.CASCADE, related_name='renditions', to='wagtailimages.Image')),
             ],

--- a/wagtail/wagtailimages/migrations/0001_initial.py
+++ b/wagtail/wagtailimages/migrations/0001_initial.py
@@ -63,7 +63,7 @@ class Migration(migrations.Migration):
                 ('file', models.ImageField(width_field='width', upload_to='images', height_field='height')),
                 ('width', models.IntegerField(editable=False)),
                 ('height', models.IntegerField(editable=False)),
-                ('focal_point_key', models.CharField(editable=False, max_length=16, null=True)),
+                ('focal_point_key', models.CharField(editable=False, max_length=18, null=True)),
                 ('filter', models.ForeignKey(on_delete=models.CASCADE, related_name='+', to='wagtailimages.Filter')),
                 ('image', models.ForeignKey(on_delete=models.CASCADE, related_name='renditions', to='wagtailimages.Image')),
             ],

--- a/wagtail/wagtailimages/migrations/0004_make_focal_point_key_not_nullable.py
+++ b/wagtail/wagtailimages/migrations/0004_make_focal_point_key_not_nullable.py
@@ -44,6 +44,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='rendition',
             name='focal_point_key',
-            field=models.CharField(blank=True, default='', max_length=255, editable=False),
+            field=models.CharField(blank=True, default='', max_length=16, editable=False),
         ),
     ]

--- a/wagtail/wagtailimages/migrations/0004_make_focal_point_key_not_nullable.py
+++ b/wagtail/wagtailimages/migrations/0004_make_focal_point_key_not_nullable.py
@@ -44,6 +44,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='rendition',
             name='focal_point_key',
-            field=models.CharField(blank=True, default='', max_length=16, editable=False),
+            field=models.CharField(blank=True, default='', max_length=18, editable=False),
         ),
     ]

--- a/wagtail/wagtailimages/migrations/0016_deprecate_rendition_filter_relation.py
+++ b/wagtail/wagtailimages/migrations/0016_deprecate_rendition_filter_relation.py
@@ -35,6 +35,12 @@ class Migration(migrations.Migration):
         #   that successfully applied the old 1.8 version of this migration are consistent with
         #   other setups.
         #
+        # Since Django will optimise away any AlterField operations that appear to match
+        # the current state (according to earlier migrations) - which would cause them to be
+        # skipped on installations that ran the earlier (max_length=255) versions of the
+        # migrations - we need to make them superficially different; we do this by stepping
+        # max_length down from 18 to 17 then 16.
+        #
         # Projects with a custom image model don't have to worry about this - they'll have an existing
         # migration with the max_length=255, and will get a new migration reducing it to max_length=16
         # the next time they run makemigrations.
@@ -42,7 +48,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='rendition',
             name='focal_point_key',
-            field=models.CharField(blank=True, default='', max_length=16, editable=False),
+            field=models.CharField(blank=True, default='', max_length=17, editable=False),
         ),
 
         migrations.AlterUniqueTogether(

--- a/wagtail/wagtailimages/migrations/0016_deprecate_rendition_filter_relation.py
+++ b/wagtail/wagtailimages/migrations/0016_deprecate_rendition_filter_relation.py
@@ -17,6 +17,34 @@ class Migration(migrations.Migration):
             name='filter_spec',
             field=models.CharField(db_index=True, max_length=255),
         ),
+
+        # New step introduced in Wagtail 1.8.1:
+        #
+        # Reduce max_length of rendition.focal_point_key to 16, from the previous value of 255
+        # which existed on Wagtail <= 1.8. MySQL has a limit of 767 (on InnoDB) or 1000 (on MyISAM)
+        # bytes; depending on the character encoding used, this limit may be reached by the
+        # original index on ['image', 'filter', 'focal_point_key'] (= 1 varchar and two FKs)
+        # or the new index on ['image', 'filter_spec', 'focal_point_key'] (= 2 varchars and one FK).
+        #
+        # To mitigate this, we reduce focal_point_key in the following places:
+        # * Retrospectively in the original migration, so that configurations that previously
+        #   failed on wagtailimages/0001_initial can now run (see #2925 / #2953);
+        # * Here, so that previously-working Wagtail <=1.7 installations that failed on the
+        #   AlterUniqueTogether below when upgrading to 1.8 can now succeed;
+        # * In the newly-added migration wagtailimages/0017, so that existing Wagtail 1.8 installations
+        #   that successfully applied the old 1.8 version of this migration are consistent with
+        #   other setups.
+        #
+        # Projects with a custom image model don't have to worry about this - they'll have an existing
+        # migration with the max_length=255, and will get a new migration reducing it to max_length=16
+        # the next time they run makemigrations.
+
+        migrations.AlterField(
+            model_name='rendition',
+            name='focal_point_key',
+            field=models.CharField(blank=True, default='', max_length=16, editable=False),
+        ),
+
         migrations.AlterUniqueTogether(
             name='rendition',
             unique_together=set([('image', 'filter_spec', 'focal_point_key')]),

--- a/wagtail/wagtailimages/migrations/0017_reduce_focal_point_key_max_length.py
+++ b/wagtail/wagtailimages/migrations/0017_reduce_focal_point_key_max_length.py
@@ -13,9 +13,9 @@ class Migration(migrations.Migration):
     operations = [
         # The Wagtail 1.8 version of migration wagtailimages/0016 did not include the
         # step to reduce focal_point_key's max_length to 16, necessary to make it work
-        # on some MySQL configurations. This migration serves only to ensure that
-        # installations upgrading from 1.8 to >=1.8.1 have this change applied; on other
-        # setups (where the current 0016 and 0017 are applied together), this is a no-op.
+        # on some MySQL configurations. This migration (added in 1.8.1) ensures that
+        # installations that were already successfully running 1.8 receive this change
+        # on upgrading to 1.8.1 or later.
         migrations.AlterField(
             model_name='rendition',
             name='focal_point_key',

--- a/wagtail/wagtailimages/migrations/0017_reduce_focal_point_key_max_length.py
+++ b/wagtail/wagtailimages/migrations/0017_reduce_focal_point_key_max_length.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('wagtailimages', '0016_deprecate_rendition_filter_relation'),
+    ]
+
+    operations = [
+        # The Wagtail 1.8 version of migration wagtailimages/0016 did not include the
+        # step to reduce focal_point_key's max_length to 16, necessary to make it work
+        # on some MySQL configurations. This migration serves only to ensure that
+        # installations upgrading from 1.8 to >=1.8.1 have this change applied; on other
+        # setups (where the current 0016 and 0017 are applied together), this is a no-op.
+        migrations.AlterField(
+            model_name='rendition',
+            name='focal_point_key',
+            field=models.CharField(blank=True, default='', max_length=16, editable=False),
+        ),
+    ]

--- a/wagtail/wagtailimages/models.py
+++ b/wagtail/wagtailimages/models.py
@@ -512,7 +512,7 @@ class AbstractRendition(models.Model):
     file = models.ImageField(upload_to=get_rendition_upload_to, width_field='width', height_field='height')
     width = models.IntegerField(editable=False)
     height = models.IntegerField(editable=False)
-    focal_point_key = models.CharField(max_length=255, blank=True, default='', editable=False)
+    focal_point_key = models.CharField(max_length=16, blank=True, default='', editable=False)
 
     @property
     def url(self):


### PR DESCRIPTION
Retrospectively reduce focal_point_key's max length from 255 to 16. Ref: #3256 and partially #2925 / #2953 

This prevents migration wagtailimages/0016 from failing on MySQL configurations that could handle the previous unique_together index ('image', 'filter', 'focal_point_key') but not the new one ('image', 'filter_spec', 'focal_point_key'). It also hopefully means one fewer failure case when using utf8mb4 encoding (which currently can't get past the initial migrations).

This PR targets the 1.8.x branch - I'll create a separate one for master / 1.9 (which also needs to renumber the existing migration wagtailimages/0017).