### PR TITLE
Add exclude_fields to ModelAdmin and ModelFormView, tests and doc

### DIFF
--- a/docs/reference/contrib/modeladmin/create_edit_delete_views.rst
+++ b/docs/reference/contrib/modeladmin/create_edit_delete_views.rst
@@ -150,3 +150,12 @@ See the following part of the docs to find out more:
 
 See the following part of the docs to find out more:
 :ref:`modeladmin_overriding_views`
+
+.. _modeladmin_exclude_fields:
+
+-----------------------------------
+``ModelAdmin.exclude_fields``
+-----------------------------------
+
+**Expected value**: An array of Model fields to be excluded from Create/Edit pages.
+

--- a/docs/reference/contrib/modeladmin/create_edit_delete_views.rst
+++ b/docs/reference/contrib/modeladmin/create_edit_delete_views.rst
@@ -151,11 +151,16 @@ See the following part of the docs to find out more:
 See the following part of the docs to find out more:
 :ref:`modeladmin_overriding_views`
 
-.. _modeladmin_exclude_fields:
+.. _modeladmin_form_fields_exclude:
 
 -----------------------------------
-``ModelAdmin.exclude_fields``
+``ModelAdmin.form_fields_exclude``
 -----------------------------------
 
-**Expected value**: An array of Model fields to be excluded from Create/Edit pages.
+**Expected value**: A list or tuple of fields names
 
+When using CreateView or EditView to create or update model instances, this
+value will be passed to the edit form, so that any named fields will be
+excluded from the form. This is particularly useful when registering ModelAdmin
+classes for models from third-party apps, where defining panel configurations
+on the Model itself is more complicated.

--- a/wagtail/contrib/modeladmin/options.py
+++ b/wagtail/contrib/modeladmin/options.py
@@ -142,6 +142,7 @@ class ModelAdmin(WagtailRegisterable):
     inspect_view_extra_js = []
     form_view_extra_css = []
     form_view_extra_js = []
+    exclude_fields = []
 
     def __init__(self, parent=None):
         """

--- a/wagtail/contrib/modeladmin/options.py
+++ b/wagtail/contrib/modeladmin/options.py
@@ -142,7 +142,7 @@ class ModelAdmin(WagtailRegisterable):
     inspect_view_extra_js = []
     form_view_extra_css = []
     form_view_extra_js = []
-    exclude_fields = []
+    form_fields_exclude = []
 
     def __init__(self, parent=None):
         """
@@ -159,6 +159,11 @@ class ModelAdmin(WagtailRegisterable):
             self.model, self.inspect_view_enabled)
         self.url_helper = self.get_url_helper_class()(self.model)
 
+    def get_form_fields_exclude(self, request):
+        """
+        Returns a list or tuple of fields names to be excluded from Create/Edit pages.
+        """
+        return self.form_fields_exclude
 
     def get_permission_helper_class(self):
         """

--- a/wagtail/contrib/modeladmin/options.py
+++ b/wagtail/contrib/modeladmin/options.py
@@ -159,12 +159,6 @@ class ModelAdmin(WagtailRegisterable):
             self.model, self.inspect_view_enabled)
         self.url_helper = self.get_url_helper_class()(self.model)
 
-    def get_form_fields_exclude(self, request):
-        """
-        Returns a list or tuple of fields names to be excluded from Create/Edit pages.
-        """
-        return self.form_fields_exclude
-
     def get_permission_helper_class(self):
         """
         Returns a permission_helper class to help with permission-based logic
@@ -304,6 +298,12 @@ class ModelAdmin(WagtailRegisterable):
         Must always return a dictionary.
         """
         return {}
+
+    def get_form_fields_exclude(self, request):
+        """
+        Returns a list or tuple of fields names to be excluded from Create/Edit pages.
+        """
+        return self.form_fields_exclude
 
     def get_index_view_extra_css(self):
         css = ['wagtailmodeladmin/css/index.css']

--- a/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
+++ b/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
@@ -9,6 +9,8 @@ from wagtail.tests.utils import WagtailTestUtils
 from wagtail.wagtailimages.models import Image
 from wagtail.wagtailimages.tests.utils import get_test_image_file
 
+import mock
+
 
 class TestIndexView(TestCase, WagtailTestUtils):
     fixtures = ['modeladmintest_test.json']
@@ -155,6 +157,16 @@ class TestCreateView(TestCase, WagtailTestUtils):
         # Check that a form error was raised
         self.assertFormError(response, 'form', 'title', "This field is required.")
 
+    def test_exclude_passed_to_extract_panel_definitions(self):
+        path_to_exclude_fields_property = 'wagtail.contrib.modeladmin.options.ModelAdmin.exclude_fields'
+        with mock.patch('wagtail.contrib.modeladmin.views.extract_panel_definitions_from_model_class') as m:
+            with mock.patch(path_to_exclude_fields_property, new_callable=mock.PropertyMock) as mock_exclude_fields:
+                mock_exclude_fields.return_value = ['123']
+
+                self.get()
+                mock_exclude_fields.assert_called()
+                m.assert_called_with(Book, exclude=mock_exclude_fields.return_value)
+
 
 class TestInspectView(TestCase, WagtailTestUtils):
     fixtures = ['modeladmintest_test.json']
@@ -270,6 +282,16 @@ class TestEditView(TestCase, WagtailTestUtils):
 
         # Check that a form error was raised
         self.assertFormError(response, 'form', 'title', "This field is required.")
+
+    def test_exclude_passed_to_extract_panel_definitions(self):
+        path_to_exclude_fields_property = 'wagtail.contrib.modeladmin.options.ModelAdmin.exclude_fields'
+        with mock.patch('wagtail.contrib.modeladmin.views.extract_panel_definitions_from_model_class') as m:
+            with mock.patch(path_to_exclude_fields_property, new_callable=mock.PropertyMock) as mock_exclude_fields:
+                mock_exclude_fields.return_value = ['123']
+
+                self.get(1)
+                mock_exclude_fields.assert_called()
+                m.assert_called_with(Book, exclude=mock_exclude_fields.return_value)
 
 
 class TestPageSpecificViews(TestCase, WagtailTestUtils):

--- a/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
+++ b/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
@@ -157,14 +157,14 @@ class TestCreateView(TestCase, WagtailTestUtils):
         self.assertFormError(response, 'form', 'title', "This field is required.")
 
     def test_exclude_passed_to_extract_panel_definitions(self):
-        path_to_exclude_fields_property = 'wagtail.contrib.modeladmin.options.ModelAdmin.exclude_fields'
+        path_to_form_fields_exclude_property = 'wagtail.contrib.modeladmin.options.ModelAdmin.form_fields_exclude'
         with mock.patch('wagtail.contrib.modeladmin.views.extract_panel_definitions_from_model_class') as m:
-            with mock.patch(path_to_exclude_fields_property, new_callable=mock.PropertyMock) as mock_exclude_fields:
-                mock_exclude_fields.return_value = ['123']
+            with mock.patch(path_to_form_fields_exclude_property, new_callable=mock.PropertyMock) as mock_form_fields_exclude:
+                mock_form_fields_exclude.return_value = ['123']
 
                 self.get()
-                mock_exclude_fields.assert_called()
-                m.assert_called_with(Book, exclude=mock_exclude_fields.return_value)
+                mock_form_fields_exclude.assert_called()
+                m.assert_called_with(Book, exclude=mock_form_fields_exclude.return_value)
 
 
 class TestInspectView(TestCase, WagtailTestUtils):
@@ -283,14 +283,14 @@ class TestEditView(TestCase, WagtailTestUtils):
         self.assertFormError(response, 'form', 'title', "This field is required.")
 
     def test_exclude_passed_to_extract_panel_definitions(self):
-        path_to_exclude_fields_property = 'wagtail.contrib.modeladmin.options.ModelAdmin.exclude_fields'
+        path_to_form_fields_exclude_property = 'wagtail.contrib.modeladmin.options.ModelAdmin.form_fields_exclude'
         with mock.patch('wagtail.contrib.modeladmin.views.extract_panel_definitions_from_model_class') as m:
-            with mock.patch(path_to_exclude_fields_property, new_callable=mock.PropertyMock) as mock_exclude_fields:
-                mock_exclude_fields.return_value = ['123']
+            with mock.patch(path_to_form_fields_exclude_property, new_callable=mock.PropertyMock) as mock_form_fields_exclude:
+                mock_form_fields_exclude.return_value = ['123']
 
                 self.get(1)
-                mock_exclude_fields.assert_called()
-                m.assert_called_with(Book, exclude=mock_exclude_fields.return_value)
+                mock_form_fields_exclude.assert_called()
+                m.assert_called_with(Book, exclude=mock_form_fields_exclude.return_value)
 
 
 class TestPageSpecificViews(TestCase, WagtailTestUtils):

--- a/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
+++ b/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
+import mock
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group
 from django.test import TestCase
@@ -8,8 +9,6 @@ from wagtail.tests.modeladmintest.models import Author, Book, Publisher
 from wagtail.tests.utils import WagtailTestUtils
 from wagtail.wagtailimages.models import Image
 from wagtail.wagtailimages.tests.utils import get_test_image_file
-
-import mock
 
 
 class TestIndexView(TestCase, WagtailTestUtils):

--- a/wagtail/contrib/modeladmin/views.py
+++ b/wagtail/contrib/modeladmin/views.py
@@ -115,7 +115,8 @@ class ModelFormView(WMABaseView, FormView):
         if hasattr(self.model, 'edit_handler'):
             edit_handler = self.model.edit_handler
         else:
-            panels = extract_panel_definitions_from_model_class(self.model, exclude=self.model_admin.exclude_fields)
+            fields_to_exclude = self.model_admin.get_form_fields_exclude(request=self.request)
+            panels = extract_panel_definitions_from_model_class(self.model, exclude=fields_to_exclude)
             edit_handler = ObjectList(panels)
         return edit_handler.bind_to_model(self.model)
 

--- a/wagtail/contrib/modeladmin/views.py
+++ b/wagtail/contrib/modeladmin/views.py
@@ -115,7 +115,7 @@ class ModelFormView(WMABaseView, FormView):
         if hasattr(self.model, 'edit_handler'):
             edit_handler = self.model.edit_handler
         else:
-            panels = extract_panel_definitions_from_model_class(self.model)
+            panels = extract_panel_definitions_from_model_class(self.model, exclude=self.model_admin.exclude_fields)
             edit_handler = ObjectList(panels)
         return edit_handler.bind_to_model(self.model)
 


### PR DESCRIPTION
Refers: #2759 

Do you want to use `exclude` for the field name directly instead? I have used `exclude_fields` to be more explicit because there are a lot of different ModelAdmin properties. 

