### PR TITLE
[RFC] Replace chooser panels with generic ChooserPanel class and registry

### DIFF
--- a/wagtail/wagtailadmin/choosers.py
+++ b/wagtail/wagtailadmin/choosers.py
@@ -1,0 +1,20 @@
+from __future__ import absolute_import, unicode_literals
+
+
+class ChooserRegistry(object):
+    def __init__(self):
+        self._default_widget = None
+        self._widgets = {}
+
+    def register_default_widget(self, widget_cls):
+        self._default_widget = widget_cls
+
+    def register_widget(self, model, widget_cls):
+        self._widgets[model] = widget_cls
+
+    def get_widget(self, model):
+        # TODO check parent models
+        return self._widgets.get(model, self._default_widget)
+
+
+choosers = ChooserRegistry()

--- a/wagtail/wagtaildocs/wagtail_hooks.py
+++ b/wagtail/wagtaildocs/wagtail_hooks.py
@@ -7,6 +7,7 @@ from django.utils.html import format_html, format_html_join
 from django.utils.translation import ugettext_lazy as _
 from django.utils.translation import ungettext
 
+from wagtail.wagtailadmin.choosers import choosers
 from wagtail.wagtailadmin.menu import MenuItem
 from wagtail.wagtailadmin.search import SearchArea
 from wagtail.wagtailadmin.site_summary import SummaryItem
@@ -17,6 +18,10 @@ from wagtail.wagtaildocs.forms import GroupDocumentPermissionFormSet
 from wagtail.wagtaildocs.models import get_document_model
 from wagtail.wagtaildocs.permissions import permission_policy
 from wagtail.wagtaildocs.rich_text import DocumentLinkHandler
+from wagtail.wagtaildocs.widgets import AdminDocumentChooser
+
+
+choosers.register_widget(get_document_model(), AdminDocumentChooser)
 
 
 @hooks.register('register_admin_urls')

--- a/wagtail/wagtailimages/wagtail_hooks.py
+++ b/wagtail/wagtailimages/wagtail_hooks.py
@@ -7,6 +7,7 @@ from django.utils.html import format_html, format_html_join
 from django.utils.translation import ugettext_lazy as _
 from django.utils.translation import ungettext
 
+from wagtail.wagtailadmin.choosers import choosers
 from wagtail.wagtailadmin.menu import MenuItem
 from wagtail.wagtailadmin.search import SearchArea
 from wagtail.wagtailadmin.site_summary import SummaryItem
@@ -16,6 +17,10 @@ from wagtail.wagtailimages.api.admin.endpoints import ImagesAdminAPIEndpoint
 from wagtail.wagtailimages.forms import GroupImagePermissionFormSet
 from wagtail.wagtailimages.permissions import permission_policy
 from wagtail.wagtailimages.rich_text import ImageEmbedHandler
+from wagtail.wagtailimages.widgets import AdminImageChooser
+
+
+choosers.register_widget(get_image_model(), AdminImageChooser)
 
 
 @hooks.register('register_admin_urls')

--- a/wagtail/wagtailsnippets/wagtail_hooks.py
+++ b/wagtail/wagtailsnippets/wagtail_hooks.py
@@ -8,11 +8,17 @@ from django.core import urlresolvers
 from django.utils.html import format_html
 from django.utils.translation import ugettext_lazy as _
 
+from wagtail.wagtailadmin.choosers import choosers
 from wagtail.wagtailadmin.menu import MenuItem
 from wagtail.wagtailcore import hooks
 from wagtail.wagtailsnippets import urls
 from wagtail.wagtailsnippets.models import get_snippet_models
 from wagtail.wagtailsnippets.permissions import user_can_edit_snippets
+from wagtail.wagtailsnippets.widgets import AdminSnippetChooser
+
+
+for model in get_snippet_models():
+    choosers.register_widget(model, AdminSnippetChooser)
 
 
 @hooks.register('register_admin_urls')


### PR DESCRIPTION
This pull request contains a proof of concept of an idea I had to simplify Wagtail chooser panels a bit.

We currently have ``*ChooserPanel`` and ``*AdminChooser`` classes for every model in Wagtail and the ``*ChooserPanel`` class is usually the same.

This pull request replaces the indivudal ``*ChooserPanel``  classes (eg ``ImageChooserPanel``, ``DocumentChooserPanel``)  with a single ``ChooserPanel`` class. This class looks up from a registry of widgets to find the correct one for the model.

Some advantages of this approach:
 - Only need to import one edit handler
 - Chooser widgets can be replaced with custom ones
 - Choosers for custom models can be registered without having to be a snippet
 - A global default chooser can be registered (useful for third-party apps that implement a generic model chooser)

I haven't yet ported ``PageChooserPanel`` to the new way since it requires some logic to be moved from the panel to the widget.