### PR TITLE
Update model_reference.rst to include get_parent

### DIFF
--- a/docs/reference/pages/model_reference.rst
+++ b/docs/reference/pages/model_reference.rst
@@ -116,6 +116,8 @@ In addition to the model fields provided, ``Page`` has many properties and metho
     .. autoattribute:: preview_modes
 
     .. automethod:: serve_preview
+    
+    .. automethod:: get_parent
 
     .. automethod:: get_ancestors
 


### PR DESCRIPTION
I did not view the source for the `Page` model and thought there was no way to get a page's immediate parent. There is. Including it here in the docs like the other methods.