### PR TITLE
Allow default JS options to be overwritten for TableBlocks

### DIFF
--- a/wagtail/contrib/table_block/static/table_block/js/table.js
+++ b/wagtail/contrib/table_block/static/table_block/js/table.js
@@ -8,6 +8,7 @@ function initTable(id, tableOptions) {
     var tableHeaderCheckbox = $('#' + tableHeaderCheckboxId);
     var colHeaderCheckbox = $('#' + colHeaderCheckboxId);
     var hot;
+    var defaultOptions;
     var finalOptions = {};
     var persist;
     var cellEvent;
@@ -43,18 +44,7 @@ function initTable(id, tableOptions) {
         // do nothing
     }
 
-    for (var key in tableOptions) {
-        if (tableOptions.hasOwnProperty(key)) {
-            finalOptions[key] = tableOptions[key];
-        }
-    }
-
     if (dataForForm !== null) {
-        if (dataForForm.hasOwnProperty('data')) {
-            // Overrides default value from tableOptions (if given) with value from database
-            finalOptions.data = dataForForm.data;
-        }
-
         if (dataForForm.hasOwnProperty('first_row_is_table_header')) {
             tableHeaderCheckbox.prop('checked', dataForForm.first_row_is_table_header);
         }
@@ -102,25 +92,40 @@ function initTable(id, tableOptions) {
     colHeaderCheckbox.change(function() {
         persist();
     });
-    
-    finalOptions.afterChange = cellEvent;
-    finalOptions.afterCreateCol = structureEvent;
-    finalOptions.afterCreateRow = structureEvent;
-    finalOptions.afterRemoveCol = structureEvent;
-    finalOptions.afterRemoveRow = structureEvent;
-    finalOptions.contextMenu = [
-        'row_above',
-        'row_below',
-        '---------',
-        'col_left',
-        'col_right',
-        '---------',
-        'remove_row',
-        'remove_col',
-        '---------',
-        'undo',
-        'redo'
-    ];
+
+    defaultOptions = {
+        afterChange: cellEvent,
+        afterCreateCol: structureEvent,
+        afterCreateRow: structureEvent,
+        afterRemoveCol: structureEvent,
+        afterRemoveRow: structureEvent,
+        contextMenu: [
+            'row_above',
+            'row_below',
+            '---------',
+            'col_left',
+            'col_right',
+            '---------',
+            'remove_row',
+            'remove_col',
+            '---------',
+            'undo',
+            'redo'
+        ]
+    };
+
+    if (dataForForm !== null && dataForForm.hasOwnProperty('data')) {
+        // Overrides default value from tableOptions (if given) with value from database
+        defaultOptions.data = dataForForm.data;
+    }
+
+    Object.keys(defaultOptions).forEach(function (key) {
+        finalOptions[key] = defaultOptions[key];
+    });
+    Object.keys(tableOptions).forEach(function (key) {
+        finalOptions[key] = tableOptions[key];
+    });
+
     hot = new Handsontable(document.getElementById(containerId), finalOptions);
     hot.render(); // Call to render removes 'null' literals from empty cells
 


### PR DESCRIPTION
Currently, default options are written on top of user options. This PR switch things around, allowing the user options to overwrite default options.

Note: It allows the user to overwrite any defaults, including the callback for different events. While it will be pretty hard to provide a JS function from Python, this at least allows to remove the callback.