### PR TITLE
in Page reference docs, don't tell people to consult source code

### DIFF
--- a/docs/reference/pages/model_reference.rst
+++ b/docs/reference/pages/model_reference.rst
@@ -85,7 +85,7 @@ Database fields
 Methods and properties
 ~~~~~~~~~~~~~~~~~~~~~~
 
-In addition to the model fields provided, ``Page`` has many properties and methods that you may wish to reference, use, or override in creating your own models. Those listed here are relatively straightforward to use, but consult the Wagtail source code for a full view of what's possible.
+In addition to the model fields provided, ``Page`` has many properties and methods that you may wish to reference, use, or override in creating your own models.
 
 .. class:: Page
 


### PR DESCRIPTION
Stylistically this sentence is somewhat content-free (if the API is really "relatively straightforward", users can see that for themselves rather than us informing them of that fact...), and we don't want to encourage people to use undocumented methods (because we can't guarantee that the API for them will remain stable).