### PR TITLE
Change to verbose view {draft,live} action labels on page listings (fixes #3262)

### DIFF
--- a/wagtail/wagtailadmin/wagtail_hooks.py
+++ b/wagtail/wagtailadmin/wagtail_hooks.py
@@ -70,10 +70,10 @@ def page_listing_buttons(page, page_perms, is_parent=False):
         yield PageListingButton(_('Edit'), reverse('wagtailadmin_pages:edit', args=[page.id]),
                                 attrs={'title': _('Edit this page')}, priority=10)
     if page.has_unpublished_changes:
-        yield PageListingButton(_('Draft'), reverse('wagtailadmin_pages:view_draft', args=[page.id]),
+        yield PageListingButton(_('View draft'), reverse('wagtailadmin_pages:view_draft', args=[page.id]),
                                 attrs={'title': _('Preview draft'), 'target': '_blank'}, priority=20)
     if page.live and page.url:
-        yield PageListingButton(_('Live'), page.url, attrs={'target': "_blank", 'title': _('View live')}, priority=30)
+        yield PageListingButton(_('View live'), page.url, attrs={'target': "_blank", 'title': _('View live')}, priority=30)
     if page_perms.can_add_subpage():
         if is_parent:
             yield Button(_('Add child page'), reverse('wagtailadmin_pages:add_subpage', args=[page.id]),


### PR DESCRIPTION
Simple change for the action labels on the page listings