### PR TITLE
Remove references to Gondor.io in documentation.

### DIFF
--- a/docs/advanced_topics/deploying.rst
+++ b/docs/advanced_topics/deploying.rst
@@ -8,11 +8,6 @@ Wagtail is straightforward to deploy on modern Linux-based distributions, but se
 
 Our current preferences are for Nginx, Gunicorn and supervisor on Debian, but Wagtail should run with any of the combinations detailed in Django's `deployment documentation <https://docs.djangoproject.com/en/dev/howto/deployment/>`_.
 
-On Gondor
-~~~~~~~~~
-
-`Gondor <https://gondor.io/>`_ specialise in Python hosting. They provide Redis and Elasticsearch, which are two of the services we recommend for high-performance production sites. Gondor have written a comprehensive tutorial on running your Wagtail site on their platform, at `gondor.io/blog/2014/02/14/how-run-wagtail-cms-gondor/ <https://gondor.io/blog/2014/02/14/how-run-wagtail-cms-gondor/>`_.
-
 On Openshift
 ~~~~~~~~~~~~
 

--- a/docs/advanced_topics/third_party_tutorials.rst
+++ b/docs/advanced_topics/third_party_tutorials.rst
@@ -22,7 +22,6 @@ Third-party tutorials
 * `Wagtail notes: managing redirects as pages <http://www.coactivate.org/projects/ejucovy/blog/2014/05/10/wagtail-notes-managing-redirects-as-pages/>`_ (10 May 2014)
 * `Wagtail notes: dynamic templates per page <http://www.coactivate.org/projects/ejucovy/blog/2014/05/10/wagtail-notes-dynamic-templates-per-page/>`_ (10 May 2014)
 * `Wagtail notes: type-constrained PageChooserPanel <http://www.coactivate.org/projects/ejucovy/blog/2014/05/09/wagtail-notes-type-constrained-pagechooserpanel/>`_ (9 May 2014)
-* `How to Run the Wagtail CMS on Gondor <https://gondor.io/blog/2014/02/14/how-run-wagtail-cms-gondor/>`_ (14 February 2014)
 
 .. tip::
 

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -12,7 +12,6 @@ embeddable
 Embedly
 formset
 frontend
-Gondor
 Gunicorn
 Heroku
 hostname


### PR DESCRIPTION
Gondor.io has been retired by Eldarion (see http://eldarion.cloud/blog/2016/04/21/goodbye-gondor-hello-kel-and-eldarion-cloud/), so the tutorial wouldn't be helpful even if it was accessible.

I don't think this change is significant enough that it needs to be added to the CHANGELOG and release notes. I did not add my name to CONTRIBUTORS in order to avoid conflicts if someone else's first pull request is merged before mine. My preferred name is "Martey Dodoo".