### PR TITLE
Honour StreamField blank flag and add StreamBlock required flag

### DIFF
--- a/wagtail/wagtailcore/fields.py
+++ b/wagtail/wagtailcore/fields.py
@@ -47,6 +47,7 @@ class StreamField(models.Field):
         else:
             self.stream_block = StreamBlock(block_types)
         super(StreamField, self).__init__(**kwargs)
+        self.stream_block._required = not self.blank
 
     def get_internal_type(self):
         return 'TextField'

--- a/wagtail/wagtailcore/tests/test_blocks.py
+++ b/wagtail/wagtailcore/tests/test_blocks.py
@@ -1697,6 +1697,37 @@ class TestStreamBlock(SimpleTestCase):
         self.assertEqual(list(block.child_blocks.keys()),
                          ['heading', 'paragraph', 'intro', 'by_line'])
 
+    def test_required_raises_an_exception_if_empty(self):
+        block = blocks.StreamBlock([('paragraph', blocks.CharBlock())], required=True)
+        value = blocks.StreamValue(block, [])
+
+        with self.assertRaises(blocks.StreamBlockValidationError):
+            block.clean(value)
+
+    def test_required_does_not_raise_an_exception_if_not_empty(self):
+        block = blocks.StreamBlock([('paragraph', blocks.CharBlock())], required=True)
+        value = block.to_python([{'type': 'paragraph', 'value': 'Hello'}])
+        try:
+            block.clean(value)
+        except blocks.StreamBlockValidationError:
+            raise self.failureException("%s was raised" % blocks.StreamBlockValidationError)
+
+    def test_not_required_does_not_raise_an_exception_if_empty(self):
+        block = blocks.StreamBlock([('paragraph', blocks.CharBlock())], required=False)
+        value = blocks.StreamValue(block, [])
+
+        try:
+            block.clean(value)
+        except blocks.StreamBlockValidationError:
+            raise self.failureException("%s was raised" % blocks.StreamBlockValidationError)
+
+    def test_required_by_default(self):
+        block = blocks.StreamBlock([('paragraph', blocks.CharBlock())])
+        value = blocks.StreamValue(block, [])
+
+        with self.assertRaises(blocks.StreamBlockValidationError):
+            block.clean(value)
+
     def render_article(self, data):
         class ArticleBlock(blocks.StreamBlock):
             heading = blocks.CharBlock()

--- a/wagtail/wagtailcore/tests/test_streamfield.py
+++ b/wagtail/wagtailcore/tests/test_streamfield.py
@@ -221,3 +221,13 @@ class TestStreamFieldJinjaRendering(TestStreamFieldRenderingBase):
         rendered = self.render('{{ instance.body }}', {
             'instance': self.instance})
         self.assertHTMLEqual(rendered, self.expected)
+
+
+class TestRequiredStreamField(TestCase):
+    def test_non_blank_field_is_required(self):
+        field = StreamField([('paragraph', blocks.CharBlock())], blank=False)
+        self.assertTrue(field.stream_block.required)
+
+    def test_blank_field_is_not_required(self):
+        field = StreamField([('paragraph', blocks.CharBlock())], blank=True)
+        self.assertFalse(field.stream_block.required)


### PR DESCRIPTION
Most of the work happens in the StreamBlock since this is what the StreamField uses under the hood (instead of duplicating the check in the `clean` method of the StreamField).

Fix #2236, although I think #2514 could be tackled in the same PR (having a field required means that the minimum number of child is 1, which is half of the work done for this other issue). Thoughts?

I haven't updated the documentation yet as I wanted to make sure you agree with the approach first.