### PR TITLE
Update contribution documentation for core team members

### DIFF
--- a/docs/contributing/committing.rst
+++ b/docs/contributing/committing.rst
@@ -8,6 +8,9 @@ or for anyone interested in the process of getting code committed to Wagtail.
 Code should only be committed after it has been reviewed
 by at least one other reviewer or committer,
 unless the change is a small documentation change or fixing a typo.
+If additional code changes are made after the review, it is OK to commit them
+without further review if they are uncontroversial and small enough that no
+bugs are likely to be introduced.
 
 Most code contributions will be in the form of pull requests from Github.
 Pull requests should not be merged from Github, apart from small documentation fixes,
@@ -41,6 +44,8 @@ as merge commits make the commit history harder to read for small changes.
 You can fix up any small mistakes in the commits,
 such as typos and formatting, as part of the rebase.
 ``git rebase --interactive`` is an excellent tool for this job.
+
+Ideally, use this as an opportunity to squash the changes to a few commits, so each commit is making a single meaningful change (and not breaking anything). If this is not possible because of the nature of the changes, go with the least ugly.
 
 .. code-block:: console
 
@@ -119,3 +124,11 @@ The changes are ready to be pushed to ``master`` now.
     $ # Push the commits!
     $ git push upstream master
     $ git branch -d pr/xxxx
+
+When you have made a mistake
+============================
+
+It's ok! Everyone makes mistakes. If you realise that recent merged changes
+have a negative impact, create a new pull request with a revert of the changes
+and merge it without waiting for a review. The PR will serve as additional
+documentation for the changes, and will run through the CI tests.

--- a/docs/contributing/committing.rst
+++ b/docs/contributing/committing.rst
@@ -9,8 +9,8 @@ Code should only be committed after it has been reviewed
 by at least one other reviewer or committer,
 unless the change is a small documentation change or fixing a typo.
 If additional code changes are made after the review, it is OK to commit them
-without further review if they are uncontroversial and small enough that no
-bugs are likely to be introduced.
+without further review if they are uncontroversial and small enough that
+there is minimal chance of introducing new bugs.
 
 Most code contributions will be in the form of pull requests from Github.
 Pull requests should not be merged from Github, apart from small documentation fixes,
@@ -45,7 +45,11 @@ You can fix up any small mistakes in the commits,
 such as typos and formatting, as part of the rebase.
 ``git rebase --interactive`` is an excellent tool for this job.
 
-Ideally, use this as an opportunity to squash the changes to a few commits, so each commit is making a single meaningful change (and not breaking anything). If this is not possible because of the nature of the changes, go with the least ugly.
+Ideally, use this as an opportunity to squash the changes to a few commits, so
+each commit is making a single meaningful change (and not breaking anything).
+If this is not possible because of the nature of the changes, it's acceptable
+to either squash into a commit or leave all commits unsquashed,
+depending on which will be more readable in the commit history.
 
 .. code-block:: console
 

--- a/docs/contributing/issue_tracking.rst
+++ b/docs/contributing/issue_tracking.rst
@@ -10,23 +10,23 @@ An issue must always correspond to a specific action with a well-defined complet
 
 Do not use issues for support queries or other questions ("How do I do X?" - although "Implement a way of doing X" or "Document how to do X" could well be valid issues). These should be asked on `Stack Overflow <http://stackoverflow.com/questions/tagged/wagtail>`_, or for discussions that do not fit Stack Overflow's question-and-answer format, the `Wagtail Support Google group <https://groups.google.com/forum/#!forum/wagtail>`_.
 
-As soon as a ticket is opened - ideally within one day - a member of the core team will give it an initial classification, by either closing it as invalid or assigning it to a milestone. Don't be discouraged if you feel that your ticket has been given a lower priority than it deserves - this decision isn't permanent. We will consider all feedback, and reassign or reopen tickets where appropriate.
+As soon as a ticket is opened - ideally within one day - any member of the core team can give it an initial classification, by either closing it as invalid or assigning it to a milestone. Don't be discouraged if you feel that your ticket has been given a lower priority than it deserves - this decision isn't permanent. We will consider all feedback, and reassign or reopen tickets where appropriate.
 
 (From the other side, this means that the core team member doing the classification should feel free to make bold unilateral decisions - there's no need to seek consensus first. If they make the wrong judgment call, that can always be reversed later.)
 
 The possible milestones that it might be assigned to are as follows:
 
 * **invalid** (closed): this issue doesn't identify a specific action to be taken, or the action is not one that we want to take. For example - a bug report for something that's working as designed, or a feature request for something that's actively harmful.
-* **some-day**: the issue is accepted as valid (i.e. it's a bug report for a legitimate bug, or a useful feature request) but not deemed a priority to work on (in the opinion of the core team). For example - a bug that's only cosmetic, or a feature that would be kind of neat but not really essential. Feel free to take it on!
-* **real-soon-now**: the issue is considered important by the core team (roughly speaking: it's a bug or missing feature that's causing headaches for people) but isn't necessarily going to be completed on any set timescale. Feel free to take it on!
-* A specific version number: the issue is important enough that it needs to be fixed in this version.
+* **some-day**: the issue is accepted as valid (i.e. it's a bug report for a legitimate bug, or a useful feature request) but not deemed a priority to work on (in the opinion of the core team). For example - a bug that's only cosmetic, or a feature that would be kind of neat but not really essential. There are no resources allocated to it, feel free to take it on!
+* **real-soon-now**: the issue is considered important by the core team (roughly speaking: it's a bug or missing feature that's causing headaches for people) but isn't necessarily going to be completed on any set timescale. There are no resources allocated to it, feel free to take it on!
+* A specific version number (eg. **1.6**): the issue is important enough that it needs to be fixed in this version. There are resources allocated and/or plans to work on the issue in the given version.
 
 On some occasions it may take longer for the core team to classify an issue into a milestone. For example:
 
 * It may require a non-trivial amount of work to confirm the presence of a bug. In this case, feedback and further details from other contributors, whether or not they can replicate the bug, would be particularly welcomed.
 * It may require further discussion to decide whether the proposal is a good idea or not - if so, it will be tagged "design decision needed".
 
-We will endeavour to make sure that issues don't remain in this state for prolonged periods. Issues and PRs tagged "design decision needed" will be revisited regularly and discussed with at least two core contributors - we aim to review each ticket at least once per release cycle (= 6 weeks).
+We will endeavour to make sure that issues don't remain in this state for prolonged periods. Issues and PRs tagged "design decision needed" will be revisited regularly and discussed with at least two core contributors - we aim to review each ticket at least once per release cycle (= 6 weeks) as part of core team meetings.
 
 Pull requests
 -------------

--- a/docs/contributing/issue_tracking.rst
+++ b/docs/contributing/issue_tracking.rst
@@ -35,6 +35,10 @@ As with issues, the core team will classify pull requests as soon as they are op
 
 Subsequently (ideally within a week or two, but possibly longer for larger submissions) a core team member will merge it if it is ready to be merged, or tag it as requiring further work ('needs work' / 'needs tests' / 'needs docs'). In the latter case, they may also reassign it to a later milestone ('real-soon-now' or 'some-day'). Pull requests that require further work are handled and prioritised in the same way as issues - anyone is welcome to pick one up from the backlog, whether or not they were the original committer.
 
+Rebasing / squashing of pull requests is welcome, but not essential. When doing so, do not squash commits that need reviewing into previous ones and make sure to preserve the sequence of changes. To fix mistakes in earlier commits, use ``git commit --fixup`` so that the final merge can be done with ``git rebase -i --autosquash``.
+
+Core team members working on Wagtail are expected to go through the same process with their own fork of the project.
+
 Release schedule
 ----------------
 

--- a/docs/contributing/issue_tracking.rst
+++ b/docs/contributing/issue_tracking.rst
@@ -26,12 +26,15 @@ On some occasions it may take longer for the core team to classify an issue into
 * It may require a non-trivial amount of work to confirm the presence of a bug. In this case, feedback and further details from other contributors, whether or not they can replicate the bug, would be particularly welcomed.
 * It may require further discussion to decide whether the proposal is a good idea or not - if so, it will be tagged "design decision needed".
 
-We will endeavour to make sure that issues don't remain in this state for prolonged periods. Issues and PRs tagged "design decision needed" will be revisited regularly and discussed with at least two core contributors - we aim to review each ticket at least once per release cycle (= 6 weeks) as part of core team meetings.
+We will endeavour to make sure that issues don't remain in this state for prolonged periods. Issues and PRs tagged "design decision needed" will be revisited regularly and discussed with at least two core contributors - we aim to review each ticket at least once per release cycle (= 6 weeks) as part of weekly core team meetings (2-3 a week).
 
 Pull requests
 -------------
 
-As with issues, the core team will classify pull requests as soon as they are opened, usually within one day. Unless the change is invalid or particularly contentious (in which case it will be closed or marked as "design decision needed"), it will generally be classified under the next applicable version - the next minor release for new features, or the next patch release for bugfixes - and marked as 'Needs review'. All contributors, core and non-core, are invited to offer feedback on the pull request.
+As with issues, the core team will classify pull requests as soon as they are opened, usually within one day. Unless the change is invalid or particularly contentious (in which case it will be closed or marked as "design decision needed"), it will generally be classified under the next applicable version - the next minor release for new features, or the next patch release for bugfixes - and marked as 'Needs review'.
+
+* All contributors, core and non-core, are invited to offer feedback on the pull request.
+* Core team members are invited to assign themselves to the pull request for review.
 
 Subsequently (ideally within a week or two, but possibly longer for larger submissions) a core team member will merge it if it is ready to be merged, or tag it as requiring further work ('needs work' / 'needs tests' / 'needs docs'). In the latter case, they may also reassign it to a later milestone ('real-soon-now' or 'some-day'). Pull requests that require further work are handled and prioritised in the same way as issues - anyone is welcome to pick one up from the backlog, whether or not they were the original committer.
 

--- a/docs/contributing/issue_tracking.rst
+++ b/docs/contributing/issue_tracking.rst
@@ -10,15 +10,15 @@ An issue must always correspond to a specific action with a well-defined complet
 
 Do not use issues for support queries or other questions ("How do I do X?" - although "Implement a way of doing X" or "Document how to do X" could well be valid issues). These should be asked on `Stack Overflow <http://stackoverflow.com/questions/tagged/wagtail>`_, or for discussions that do not fit Stack Overflow's question-and-answer format, the `Wagtail Support Google group <https://groups.google.com/forum/#!forum/wagtail>`_.
 
-As soon as a ticket is opened - ideally within one day - any member of the core team can give it an initial classification, by either closing it as invalid or assigning it to a milestone. Don't be discouraged if you feel that your ticket has been given a lower priority than it deserves - this decision isn't permanent. We will consider all feedback, and reassign or reopen tickets where appropriate.
+As soon as a ticket is opened - ideally within one day - a member of the core team will give it an initial classification, by either closing it as invalid or assigning it to a milestone. Don't be discouraged if you feel that your ticket has been given a lower priority than it deserves - this decision isn't permanent. We will consider all feedback, and reassign or reopen tickets where appropriate.
 
 (From the other side, this means that the core team member doing the classification should feel free to make bold unilateral decisions - there's no need to seek consensus first. If they make the wrong judgment call, that can always be reversed later.)
 
 The possible milestones that it might be assigned to are as follows:
 
 * **invalid** (closed): this issue doesn't identify a specific action to be taken, or the action is not one that we want to take. For example - a bug report for something that's working as designed, or a feature request for something that's actively harmful.
-* **some-day**: the issue is accepted as valid (i.e. it's a bug report for a legitimate bug, or a useful feature request) but not deemed a priority to work on (in the opinion of the core team). For example - a bug that's only cosmetic, or a feature that would be kind of neat but not really essential. There are no resources allocated to it, feel free to take it on!
-* **real-soon-now**: the issue is considered important by the core team (roughly speaking: it's a bug or missing feature that's causing headaches for people) but isn't necessarily going to be completed on any set timescale. There are no resources allocated to it, feel free to take it on!
+* **some-day**: the issue is accepted as valid (i.e. it's a bug report for a legitimate bug, or a useful feature request) but not deemed a priority to work on (in the opinion of the core team). For example - a bug that's only cosmetic, or a feature that would be kind of neat but not really essential. There are no resources allocated to it - feel free to take it on!
+* **real-soon-now**: the issue is considered important by the core team (roughly speaking: it's a bug or missing feature that's causing headaches for people) but isn't necessarily going to be completed on any set timescale. There are no resources allocated to it - feel free to take it on!
 * A specific version number (eg. **1.6**): the issue is important enough that it needs to be fixed in this version. There are resources allocated and/or plans to work on the issue in the given version.
 
 On some occasions it may take longer for the core team to classify an issue into a milestone. For example:
@@ -26,7 +26,7 @@ On some occasions it may take longer for the core team to classify an issue into
 * It may require a non-trivial amount of work to confirm the presence of a bug. In this case, feedback and further details from other contributors, whether or not they can replicate the bug, would be particularly welcomed.
 * It may require further discussion to decide whether the proposal is a good idea or not - if so, it will be tagged "design decision needed".
 
-We will endeavour to make sure that issues don't remain in this state for prolonged periods. Issues and PRs tagged "design decision needed" will be revisited regularly and discussed with at least two core contributors - we aim to review each ticket at least once per release cycle (= 6 weeks) as part of weekly core team meetings (2-3 a week).
+We will endeavour to make sure that issues don't remain in this state for prolonged periods. Issues and PRs tagged "design decision needed" will be revisited regularly and discussed with at least two core contributors - we aim to review each ticket at least once per release cycle (= 6 weeks) as part of weekly core team meetings.
 
 Pull requests
 -------------


### PR DESCRIPTION
Here are changes to reflect the clarifications and suggestions discussed during the last core team meeting.

I tried to update the existing guidelines as much as possible instead of creating separate section(s).

At first I didn't realise the issue tracking documentation was in the Wagtail docs – I thought it was in https://github.com/wagtail/wagtail/wiki/Issue-tracking-process. I think this page should be deleted if it is superseded by the Wagtail docs (as with all of the wiki?).