### PR TITLE
Removing errant words in sample path/to/wagtail

### DIFF
--- a/docs/contributing/developing.rst
+++ b/docs/contributing/developing.rst
@@ -140,7 +140,7 @@ The Wagtail documentation is built by Sphinx. To install Sphinx and compile the 
 
 .. code-block:: console
 
-    $ cd /path/to/wagtail some text
+    $ cd /path/to/wagtail
     $ # Install the documentation dependencies
     $ pip install -e .[docs]
     $ # Compile the docs


### PR DESCRIPTION
Walking through the developer docs in preparation for the Sprint next week, I noticed some unnecessary words.