### PR TITLE
Added a `submit_buttons` block to login template

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,7 @@ Changelog
 1.9 (xx.xx.xxxx) - IN DEVELOPMENT
 ~~~~~~~~~~~~~~~~
 
+ * Added a `submit_buttons` block to login template (Gagaro)
  * Added support for many-to-many relations on page models (Thejaswi Puthraya, Matt Westcott)
  * Form builder form submissions can now be bulk-deleted (Karl Hobley)
  * `get_context` methods on StreamField blocks can now access variables from the parent context (Mikael Svensson, Peter Baumgartner)

--- a/docs/advanced_topics/customisation/admin_templates.rst
+++ b/docs/advanced_topics/customisation/admin_templates.rst
@@ -142,6 +142,20 @@ To add extra fields to the login form, override the ``fields`` block. You will n
         </li>
     {% endblock %}
 
+``submit_buttons``
+------------------
+
+To add extra buttons to the login form, override the ``submit_buttons`` block. You will need to add ``{{ block.super }}`` somewhere in your block to include the sign in button:
+
+.. code-block:: html+django
+
+    {% extends "wagtailadmin/login.html" %}
+
+    {% block submit_buttons %}
+        {{ block.super }}
+        <a href="{% url 'signup' %}"><button type="button" class="button" tabindex="4">{% trans 'Sign up' %}</button></a>
+    {% endblock %}
+
 ``login_form``
 --------------
 

--- a/wagtail/wagtailadmin/templates/wagtailadmin/login.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/login.html
@@ -66,7 +66,9 @@
                 {% endcomment %}
                 {% endblock %}
                 <li class="submit">
+                    {% block submit_buttons %}
                     <button type="submit" class="button button-longrunning" tabindex="3" data-clicked-text="{% trans 'Signing in...' %}"><span class="icon icon-spinner"></span><em>{% trans 'Sign in' %}</em></button>
+                    {% endblock %}
                 </li>
             </ul>
         {% endblock %}


### PR DESCRIPTION
Hi,

The idea behind this PR is to be able to add buttons (e.g..: Sign up) on the login page without having to copy/paste the entire form.