### PR TITLE
Ordered hooks

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,7 @@ Changelog
 1.10 (xx.xx.xxxx) - IN DEVELOPMENT
 ~~~~~~~~~~~~~~~~~
 
+* Hook can now be ordered (Gagaro)
 
 1.9 (xx.xx.xxxx) - IN DEVELOPMENT
 ~~~~~~~~~~~~~~~~

--- a/docs/reference/hooks.rst
+++ b/docs/reference/hooks.rst
@@ -23,6 +23,21 @@ Alternatively, ``hooks.register`` can be called as an ordinary function, passing
 
   hooks.register('name_of_hook', my_hook_function)
 
+If you need your hooks to run in a particular order, you can pass the ``order`` parameter:
+
+.. code-block:: python
+
+  @hooks.register('name_of_hook', order=1)  # This will run after every hook in the wagtail core
+  def my_hook_function(arg1, arg2...)
+      # your code here
+
+  @hooks.register('name_of_hook', order=-1)  # This will run before every hook in the wagtail core
+  def my_other_hook_function(arg1, arg2...)
+      # your code here
+
+  @hooks.register('name_of_hook', order=2)  # This will run after `my_hook_function`
+  def yet_another_hook_function(arg1, arg2...)
+      # your code here
 
 The available hooks are listed below.
 

--- a/wagtail/tests/utils.py
+++ b/wagtail/tests/utils.py
@@ -104,14 +104,14 @@ class WagtailTestUtils(object):
         return _AssertLogsContext(self, logger, level)
 
     @contextmanager
-    def register_hook(self, hook_name, fn):
+    def register_hook(self, hook_name, fn, order=0):
         from wagtail.wagtailcore import hooks
 
-        hooks.register(hook_name, fn)
+        hooks.register(hook_name, fn, order)
         try:
             yield
         finally:
-            hooks.get_hooks(hook_name).remove(fn)
+            hooks._hooks[hook_name].remove((fn, order))
 
 
 class WagtailPageTests(WagtailTestUtils, TestCase):

--- a/wagtail/wagtailcore/hooks.py
+++ b/wagtail/wagtailcore/hooks.py
@@ -1,11 +1,13 @@
 from __future__ import absolute_import, unicode_literals
 
+from operator import itemgetter
+
 from wagtail.utils.apps import get_app_submodules
 
 _hooks = {}
 
 
-def register(hook_name, fn=None):
+def register(hook_name, fn=None, order=0):
     """
     Register hook for ``hook_name``. Can be used as a decorator::
 
@@ -23,13 +25,13 @@ def register(hook_name, fn=None):
     # Pretend to be a decorator if fn is not supplied
     if fn is None:
         def decorator(fn):
-            register(hook_name, fn)
+            register(hook_name, fn, order=order)
             return fn
         return decorator
 
     if hook_name not in _hooks:
         _hooks[hook_name] = []
-    _hooks[hook_name].append(fn)
+    _hooks[hook_name].append((fn, order))
 
 
 _searched_for_hooks = False
@@ -43,5 +45,8 @@ def search_for_hooks():
 
 
 def get_hooks(hook_name):
+    """ Return the hooks function sorted by their order. """
     search_for_hooks()
-    return _hooks.get(hook_name, [])
+    hooks = _hooks.get(hook_name, [])
+    hooks = sorted(hooks, key=itemgetter(1))
+    return [hook[0] for hook in hooks]

--- a/wagtail/wagtailcore/tests/test_hooks.py
+++ b/wagtail/wagtailcore/tests/test_hooks.py
@@ -1,0 +1,38 @@
+from __future__ import absolute_import, unicode_literals
+
+from django.test import TestCase
+
+from wagtail.tests.utils import WagtailTestUtils
+from wagtail.wagtailcore import hooks
+
+
+def test_hook():
+    pass
+
+
+class TestLoginView(TestCase, WagtailTestUtils):
+    fixtures = ['test.json']
+
+    @classmethod
+    def setUpClass(cls):
+        hooks.register('test_hook_name', test_hook)
+
+    @classmethod
+    def tearDownClass(cls):
+        del hooks._hooks['test_hook_name']
+
+    def test_before_hook(self):
+        def before_hook():
+            pass
+
+        with self.register_hook('test_hook_name', before_hook, order=-1):
+            hook_fns = hooks.get_hooks('test_hook_name')
+            self.assertEqual(hook_fns, [before_hook, test_hook])
+
+    def test_after_hook(self):
+        def after_hook():
+            pass
+
+        with self.register_hook('test_hook_name', after_hook, order=1):
+            hook_fns = hooks.get_hooks('test_hook_name')
+            self.assertEqual(hook_fns, [test_hook, after_hook])


### PR DESCRIPTION
The idea is to be able to choose when the hooks are run in regards to the other ones. My issue for now is that my hook (`construct_homepage_summary_items`) is called *before* the ones in the image/doc modules.

So with this PR, we could ensure that our hook is called after:

```python
@hooks.register('construct_homepage_summary_items', order=1)
def add_another_panel(request, panels):
    [...]
```

Tell me if this is something you are willing to merge so I add tests/docs.

Another thing I'd like to do is to set the order of every hooks registered in the wagtail modules to `-1` so that the user hooks would run after the wagtail ones by default (I think this should be the expected behaviour when created custom hooks). What do you think about that?

Thanks