### PR TITLE
Add browser support targets in contributing guidelines

### DIFF
--- a/docs/contributing/developing.rst
+++ b/docs/contributing/developing.rst
@@ -116,6 +116,35 @@ If your Elasticsearch instance is located somewhere else, you can set the
 
     $ ELASTICSEARCH_URL=http://my-elasticsearch-instance:9200 python runtests.py --elasticsearch
 
+**Browser and device support**
+
+Wagtail is meant to be used on a wide variety of devices and browsers. Supported browser / device versions include:
+
+=============  =============  =============
+Browser        Device/OS      Version(s)
+=============  =============  =============
+Mobile Safari  iOS Phone      Latest
+Mobile Safari  iOS Tablet     Latest
+Chrome         Android        Latest
+IE             Desktop        9, 10, 11
+Chrome         Desktop        Latest
+MS Edge        Desktop        Latest
+Firefox        Desktop        Latest
+Safari         macOS          Latest
+=============  =============  =============
+
+Those environments are the ones Wagtail *is tested* on. Our development standards ensure that the site is usable on other browsers **and will work on future browsers**. To test on IE, install virtual machines `made available by Microsoft <https://developer.microsoft.com/en-us/microsoft-edge/tools/vms/>`_.
+
+Unsupported browsers / devices include:
+
+=============  =============  =============
+Browser        Device/OS      Version(s)
+=============  =============  =============
+Stock browser  Android        All
+IE             Desktop        8 and below
+Safari         Windows        All
+=============  =============  =============
+
 Compiling static assets
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/contributing/developing.rst
+++ b/docs/contributing/developing.rst
@@ -123,17 +123,18 @@ Wagtail is meant to be used on a wide variety of devices and browsers. Supported
 =============  =============  =============
 Browser        Device/OS      Version(s)
 =============  =============  =============
-Mobile Safari  iOS Phone      Latest
-Mobile Safari  iOS Tablet     Latest
-Chrome         Android        Latest
-IE             Desktop        9, 10, 11
-Chrome         Desktop        Latest
-MS Edge        Desktop        Latest
+Mobile Safari  iOS Phone      Last 2
+Mobile Safari  iOS Tablet     Last 2
+Chrome         Android        Last 2
+IE             Desktop        11
+Chrome         Desktop        Last 2
+MS Edge        Desktop        Last 2
 Firefox        Desktop        Latest
-Safari         macOS          Latest
+Firefox ESR    Desktop        Latest
+Safari         macOS          Last 2
 =============  =============  =============
 
-Those environments are the ones Wagtail *is tested* on. Our development standards ensure that the site is usable on other browsers **and will work on future browsers**. To test on IE, install virtual machines `made available by Microsoft <https://developer.microsoft.com/en-us/microsoft-edge/tools/vms/>`_.
+We aim for Wagtail to work in those environments. Our development standards ensure that the site is usable on other browsers **and will work on future browsers**. To test on IE, install virtual machines `made available by Microsoft <https://developer.microsoft.com/en-us/microsoft-edge/tools/vms/>`_.
 
 Unsupported browsers / devices include:
 
@@ -141,7 +142,7 @@ Unsupported browsers / devices include:
 Browser        Device/OS      Version(s)
 =============  =============  =============
 Stock browser  Android        All
-IE             Desktop        8 and below
+IE             Desktop        10 and below
 Safari         Windows        All
 =============  =============  =============
 


### PR DESCRIPTION
This is an attempt at addressing #1724. Documented browser support targets are important so every developer knows what they are expected to test their changes against.

I would like to have feedback on both the form of this documentation, and the specific targets it sets. This is inspired from Springload's [browser support requirements](https://github.com/springload/frontend-starter-kit/tree/master/docs#browser--device-support).

- For the form, the intent is to be vague enough about "other browsers that are supported but not on the table" (Opera, Brave, etc) yet precise enough that when people test the UI, they can feel confident they have tested it "enough". 
- For the content,
  - This is using "Latest" a bit more than I would like it to. I would expect my CMS to work fine if I opened it in a version of Chrome/Firefox/Safari/Edge(/Opera) from a year ago, that said actually testing on non-latest versions requires a significantly higher amount of tooling. I don't think it's that big of a deal, but perhaps we could be a bit more conservative by adding "Latest Firefox ESR" to the list.
  - The part I'm the least comfortable with is saying "no support" for the Android stock browser, and "Latest" for Chrome Android. I know release cycles are way slower on Android, so if there were issues there it would hurt a lot of users. That said, the amount of tooling necessary to effectively test on Android Chrome / Stock browser (and old releases of it) is significant. We could be a bit more conservative by saying "Chrome Android 4+", but I'd rather not.
  - I think it's worth having separate targets for Mobile Safari tablet and phone, because both of those get tons of usage and have very different screen sizes.


