### PR TITLE
Fix a regression when overriding Block.get_context()

### DIFF
--- a/wagtail/wagtailcore/blocks/base.py
+++ b/wagtail/wagtailcore/blocks/base.py
@@ -246,7 +246,7 @@ class Block(six.with_metaclass(BaseBlock, object)):
                 "keyword argument" % class_with_render_method,
                 category=RemovedInWagtail111Warning
             )
-            new_context = context
+            new_context = context or {}
             new_context.update(self.get_context(value))
             return mark_safe(render_to_string(template, new_context))
 

--- a/wagtail/wagtailcore/tests/test_blocks.py
+++ b/wagtail/wagtailcore/tests/test_blocks.py
@@ -84,6 +84,17 @@ class TestFieldBlock(unittest.TestCase):
         self.assertIs(ws[0].category, RemovedInWagtail111Warning)
         self.assertEqual(html, '<h1 lang="fr">Bonjour le monde!</h1>')
 
+    def test_charfield_render_with_legacy_get_context_none(self):
+        block = NoExtraContextCharBlock(template='tests/blocks/heading_block.html')
+        with warnings.catch_warnings(record=True) as ws:
+            warnings.simplefilter('always')
+
+            html = block.render("Bonjour le monde!")
+
+        self.assertEqual(len(ws), 1)
+        self.assertIs(ws[0].category, RemovedInWagtail111Warning)
+        self.assertEqual(html, '<h1>Bonjour le monde!</h1>')
+
     def test_charfield_render_form(self):
         block = blocks.CharBlock()
         html = block.render_form("Hello world!")


### PR DESCRIPTION
If ``Block.get_context()`` was overriden without accepting the
``parent_context`` kwarg the fallback handling threw an exception if
``context`` was None.

See #3346 