### PR TITLE
Defer specific fields in explorer 

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -20,6 +20,7 @@ def make_parser():
     parser.add_argument('--elasticsearch', action='store_true')
     parser.add_argument('--elasticsearch2', action='store_true')
     parser.add_argument('--elasticsearch5', action='store_true')
+    parser.add_argument('--bench', action='store_true')
     parser.add_argument('rest', nargs='*')
     return parser
 
@@ -66,7 +67,15 @@ def runtests():
         # forcibly delete the ELASTICSEARCH_URL setting to skip those tests
         del os.environ['ELASTICSEARCH_URL']
 
-    argv = [sys.argv[0], 'test'] + args.rest
+    if args.bench:
+        benchmarks = [
+            'wagtail.wagtailadmin.tests.benches',
+        ]
+
+        argv = [sys.argv[0], 'test', '-v2'] + benchmarks + args.rest
+    else:
+        argv = [sys.argv[0], 'test'] + args.rest
+
     try:
         execute_from_command_line(argv)
     finally:

--- a/wagtail/tests/benchmark.py
+++ b/wagtail/tests/benchmark.py
@@ -1,0 +1,29 @@
+from __future__ import absolute_import, unicode_literals
+
+import time
+import tracemalloc
+
+from django.test import TestCase
+
+
+class Benchmark(TestCase):
+    repeat = 10
+
+    def test(self):
+        timings = []
+        memory_usage = []
+        tracemalloc.start()
+
+        for i in range(self.repeat):
+            before_memory = tracemalloc.take_snapshot()
+            start_time = time.time()
+
+            self.bench()
+
+            end_time = time.time()
+            after_memory = tracemalloc.take_snapshot()
+            timings.append(end_time - start_time)
+            memory_usage.append(sum([t.size for t in after_memory.compare_to(before_memory, 'filename')]))
+
+        print("time min:", min(timings), "max:", max(timings), "avg:", sum(timings) / len(timings))
+        print("memory min:", min(memory_usage), "max:", max(memory_usage), "avg:", sum(memory_usage) / len(memory_usage))

--- a/wagtail/wagtailadmin/tests/benches.py
+++ b/wagtail/wagtailadmin/tests/benches.py
@@ -1,0 +1,85 @@
+from __future__ import absolute_import, unicode_literals
+
+from django.core.urlresolvers import reverse
+from django.utils import timezone
+
+from wagtail.tests.benchmark import Benchmark
+from wagtail.tests.testapp.models import SingleEventPage, StreamPage
+from wagtail.tests.utils import WagtailTestUtils
+from wagtail.wagtailcore.models import Page, Site
+
+
+class BenchPageExplorerWith50LargePages(Benchmark, WagtailTestUtils):
+    """
+    Creates 50 pages with large body content and benches the explorer.
+    This will be slow if the body content is being loaded from the database.
+    """
+
+    def setUp(self):
+        self.root_page = Page.objects.get(id=1)
+
+        # Add a site so the URLs render correctly
+        Site.objects.create(is_default_site=True, root_page=self.root_page)
+
+        # Create a large piece of body text
+        body = '[' + ','.join(['{"type": "text", "value": "%s"}' % ('foo' * 2000)] * 100) + ']'
+
+        # Create 50 simple pages with long content fields
+        for i in range(50):
+            self.root_page.add_child(instance=StreamPage(
+                title="Page {}".format(i + 1),
+                slug=str(i + 1),
+                body=body,
+            ))
+
+        self.login()
+
+    def bench(self):
+        response = self.client.get(reverse('wagtailadmin_explore', args=(self.root_page.id, )))
+
+        # Check the response was good
+        self.assertEqual(response.status_code, 200)
+
+        # Check every single page was rendered
+        self.assertContains(response, "Page 1")
+        self.assertContains(response, "Page 49")
+
+
+class BenchPageExplorerWithCustomURLPages(Benchmark, WagtailTestUtils):
+    """
+    Creates 50 pages of a class with a customised the .url property.
+    This will check how long it takes to generate URLs for all of these
+    pages.
+    """
+
+    def setUp(self):
+        self.root_page = Page.objects.get(id=1)
+
+        # Add a site so the URLs render correctly
+        Site.objects.create(is_default_site=True, root_page=self.root_page)
+
+        # Create 50 blog pages
+        for i in range(50):
+            self.root_page.add_child(instance=SingleEventPage(
+                title="Event {}".format(i + 1),
+                slug=str(i + 1),
+                date_from=timezone.now(),
+                audience="public",
+                location="reykjavik",
+                cost="cost",
+            ))
+
+        self.login()
+
+    def bench(self):
+        response = self.client.get(reverse('wagtailadmin_explore', args=(self.root_page.id, )))
+
+        # Check the response was good
+        self.assertEqual(response.status_code, 200)
+
+        # Check every single page was rendered
+        self.assertContains(response, "Event 1")
+        self.assertContains(response, "Event 49")
+
+        # Check the URLs were rendered correctly
+        self.assertContains(response, 'a href="http:///49/pointless-suffix/"')

--- a/wagtail/wagtailadmin/views/pages.py
+++ b/wagtail/wagtailadmin/views/pages.py
@@ -84,7 +84,7 @@ def index(request, parent_page_id=None):
         # Retrieve pages in their most specific form.
         # Only do this for paginated listings, as this could potentially be a
         # very expensive operation when performed on a large queryset.
-        pages = pages.specific()
+        pages = pages.specific(defer=True)
 
     # allow hooks to modify the queryset
     for hook in hooks.get_hooks('construct_explorer_page_queryset'):


### PR DESCRIPTION
This pull request improves memory usage and (slightly) improves performance of the Explorer view.

We're currently fetching all specific fields of the pages that are being displayed in the explorer. This is wasteful because these fields are usually not used and can be quite large. On a site, we have been getting OOM errors because Wagtail pulling in all the field data (and the pages are quite large).

We're pulling in these fields because the URL generation logic can be customised and we want to display the correct URL in the admin. This use-case is quite rare though and users doing this will suffer a (minor) performance hit by this change (see benchmark below).

This also introduces a very rudimentary benchmarking tool, based on Django tests. This measures the time and memory usage of a view and is useful to testing performance improvements like this.

Benchmark:

BEFORE

```
test (wagtail.wagtailadmin.tests.benches.BenchPageExplorerWith50LargePages)
time min: 0.9661133289337158 max: 1.2755255699157715 avg: 1.0499631881713867
memory min: 44227595 max: 44694417 avg: 44365930.1
```

```
test (wagtail.wagtailadmin.tests.benches.BenchPageExplorerWithCustomURLPages)
time min: 0.7922754287719727 max: 0.851860523223877 avg: 0.8272997617721558
memory min: 13315100 max: 13570529 avg: 13380374.5
```

AFTER

```
test (wagtail.wagtailadmin.tests.benches.BenchPageExplorerWith50LargePages)
time min: 0.8060946464538574 max: 1.2400388717651367 avg: 0.8822282314300537
memory min: 13080452 max: 13547158 avg: 13236624.9
```

```
test (wagtail.wagtailadmin.tests.benches.BenchPageExplorerWithCustomURLPages)
time min: 0.8017115592956543 max: 0.9074203968048096 avg: 0.8303963422775269
memory min: 13276127 max: 13520267 avg: 13348108.5
```

In summary:

 - When displaying 50 "large" pages (600KB of streamfield content) the memory usage is quartered and performance is ~10% faster (200ms saving).
 - When displaying 50 pages with customised URLs 10ms is added on the request time, but memory usage is a tiny bit improved.