### PR TITLE
Add notification user to notification mail context

### DIFF
--- a/wagtail/wagtailadmin/utils.py
+++ b/wagtail/wagtailadmin/utils.py
@@ -174,6 +174,8 @@ def send_mail(subject, message, recipient_list, from_email=None, **kwargs):
 def send_notification(page_revision_id, notification, notification_user_id):
     # Get revision
     revision = PageRevision.objects.get(id=page_revision_id)
+    # User
+    User = get_user_model()
 
     # Get list of recipients
     if notification == 'submitted':
@@ -207,6 +209,7 @@ def send_notification(page_revision_id, notification, notification_user_id):
     context = {
         "revision": revision,
         "settings": settings,
+        "notification_user": User.objects.get(pk=notification_user_id)
     }
 
     # Send emails

--- a/wagtail/wagtailadmin/utils.py
+++ b/wagtail/wagtailadmin/utils.py
@@ -171,7 +171,7 @@ def send_mail(subject, message, recipient_list, from_email=None, **kwargs):
     return django_send_mail(subject, message, from_email, recipient_list, **kwargs)
 
 
-def send_notification(page_revision_id, notification, excluded_user_id):
+def send_notification(page_revision_id, notification, notification_user_id):
     # Get revision
     revision = PageRevision.objects.get(id=page_revision_id)
 
@@ -188,7 +188,7 @@ def send_notification(page_revision_id, notification, excluded_user_id):
     # Get list of email addresses
     email_recipients = [
         recipient for recipient in recipients
-        if recipient.email and recipient.pk != excluded_user_id and getattr(
+        if recipient.email and recipient.pk != notification_user_id and getattr(
             UserProfile.get_for_user(recipient),
             notification + '_notifications'
         )


### PR DESCRIPTION
This is not really a big change. I have only added the user that send the notification mail to the mail context. Furthermore, I have rename the `exclude_user_id` to `notification_user_id` because this is the user that start the notification action.

This makes it possible for developers to add the notification_user in the notification mail.

Like this:

> The page "{{ title }}" has been approved by {{ notification_user.username }}.

### Infos
* Do the tests still pass? Yes
* Does the code comply with the style guide? Yes
* For Python changes: Have you added tests to cover the new/fixed behaviour?
No, I think this is not relevant and I haven't found tests for this function.

I am open for improvement suggestions. :)
