### PR TITLE
Rename 'Explorer' to 'Pages' [WIP]

### DIFF
--- a/wagtail/wagtailadmin/wagtail_hooks.py
+++ b/wagtail/wagtailadmin/wagtail_hooks.py
@@ -21,7 +21,7 @@ class ExplorerMenuItem(MenuItem):
 @hooks.register('register_admin_menu_item')
 def register_explorer_menu_item():
     return ExplorerMenuItem(
-        _('Explorer'), reverse('wagtailadmin_explore_root'),
+        _('Pages'), reverse('wagtailadmin_explore_root'),
         name='explorer',
         classnames='icon icon-folder-open-inverse dl-trigger',
         attrs={'data-explorer-menu-url': reverse('wagtailadmin_explorer_nav')},


### PR DESCRIPTION
Posting here for discussion / approval.

Feedback from user testing at NHS.UK suggests this label is more obvious to new users. We don't believe it will confuse existing users too much.

This implementation may need to be updated for #3012.

- [x] Change menu label
- [ ] ~~Update translations (note the existing translations for 'Explorer' will probably not be a good fit for 'Pages')~~ I don't think this will be necessary, since we already have [translations for "Pages"](https://github.com/wagtail/wagtail/blob/master/wagtail/wagtailadmin/locale/fr/LC_MESSAGES/django.po#L1165)
- [ ] Update documentation