### PR TITLE
Custom DRF serializers in API

### DIFF
--- a/wagtail/api/v2/endpoints.py
+++ b/wagtail/api/v2/endpoints.py
@@ -103,6 +103,10 @@ class BaseAPIEndpoint(GenericViewSet):
 
     @classmethod
     def generate_base_serializer_class(cls, model, base_serializer_class):
+        """
+        Generates a DRF serializer for page types that still use the old api_fields
+        style config.
+        """
         model_ = model
         custom_fields = getattr(model, 'api_fields', [])
 
@@ -116,6 +120,10 @@ class BaseAPIEndpoint(GenericViewSet):
 
     @classmethod
     def get_base_serializer_class(cls, model):
+        """
+        Gets the base serializer class for this model. A new serializer class will be
+        derived from this at runtime to only include the fields that the user has specified.
+        """
         if cls.base_serializer_class is not None:
             return cls.generate_base_serializer_class(model, cls.base_serializer_class)
         elif hasattr(model, 'serializer_class'):

--- a/wagtail/api/v2/serializers.py
+++ b/wagtail/api/v2/serializers.py
@@ -313,6 +313,32 @@ class BaseSerializer(serializers.ModelSerializer):
         field_kwargs['serializer_class'] = self.child_serializer_classes[field_name]
         return field_class, field_kwargs
 
+    class Meta:
+        fields = [
+            'id',
+            'type',
+            'detail_url',
+        ]
+
+        meta_fields = [
+            'type',
+            'detail_url',
+        ]
+
+        listing_default_fields = [
+            'id',
+            'type',
+            'detail_url',
+        ]
+
+        nested_default_fields = [
+            'id',
+            'type',
+            'detail_url',
+        ]
+
+        detail_only_fields = []
+
 
 class PageSerializer(BaseSerializer):
     type = PageTypeField(read_only=True)
@@ -333,6 +359,43 @@ class PageSerializer(BaseSerializer):
                 return ChildRelationField, {'serializer_class': self.child_serializer_classes[field_name]}
 
         return super(PageSerializer, self).build_relational_field(field_name, relation_info)
+
+    class Meta:
+        fields = BaseSerializer.Meta.fields + [
+            'html_url',
+            'slug',
+            'show_in_menus',
+            'seo_title',
+            'search_description',
+            'first_published_at',
+            'parent',
+            'title',
+        ]
+
+        meta_fields = BaseSerializer.Meta.meta_fields + [
+            'html_url',
+            'slug',
+            'show_in_menus',
+            'seo_title',
+            'search_description',
+            'first_published_at',
+            'parent',
+        ]
+
+        listing_default_fields = BaseSerializer.Meta.listing_default_fields + [
+            'title',
+            'html_url',
+            'slug',
+            'first_published_at',
+        ]
+
+        nested_default_fields = BaseSerializer.Meta.nested_default_fields + [
+            'title',
+        ]
+
+        detail_only_fields = BaseSerializer.Meta.detail_only_fields + [
+            'parent',
+        ]
 
 
 def get_serializer_class(model_, fields_, meta_fields, child_serializer_classes=None, base=BaseSerializer):

--- a/wagtail/api/v2/serializers.py
+++ b/wagtail/api/v2/serializers.py
@@ -133,6 +133,9 @@ class PageParentField(relations.RelatedField):
             return parent
 
     def to_representation(self, value):
+        if value is None:
+            return None
+
         serializer_class = get_serializer_class(value.__class__, ['id', 'type', 'detail_url', 'html_url', 'title'], meta_fields=['type', 'detail_url', 'html_url'], base=PageSerializer)
         serializer = serializer_class(context=self.context)
         return serializer.to_representation(value)
@@ -276,12 +279,7 @@ class BaseSerializer(serializers.ModelSerializer):
             except SkipField:
                 continue
 
-            if attribute is None:
-                # We skip `to_representation` for `None` values so that
-                # fields do not have to explicitly deal with that case.
-                meta[field.field_name] = None
-            else:
-                meta[field.field_name] = field.to_representation(attribute)
+            meta[field.field_name] = field.to_representation(attribute)
 
         if meta:
             data['meta'] = meta

--- a/wagtail/wagtailadmin/api/endpoints.py
+++ b/wagtail/wagtailadmin/api/endpoints.py
@@ -26,23 +26,6 @@ class PagesAdminAPIEndpoint(PagesAPIEndpoint):
         SearchFilter,
     ]
 
-    meta_fields = PagesAPIEndpoint.meta_fields + [
-        'latest_revision_created_at',
-        'status',
-        'children',
-        'descendants',
-        'parent',
-    ]
-
-    listing_default_fields = PagesAPIEndpoint.listing_default_fields + [
-        'latest_revision_created_at',
-        'status',
-        'children',
-    ]
-
-    # Allow the parent field to appear on listings
-    detail_only_fields = []
-
     known_query_parameters = PagesAPIEndpoint.known_query_parameters.union([
         'has_children'
     ])

--- a/wagtail/wagtailadmin/api/serializers.py
+++ b/wagtail/wagtailadmin/api/serializers.py
@@ -82,3 +82,28 @@ class AdminPageSerializer(PageSerializer):
     status = PageStatusField(read_only=True)
     children = PageChildrenField(read_only=True)
     descendants = PageDescendantsField(read_only=True)
+
+    class Meta(PageSerializer.Meta):
+        fields = PageSerializer.Meta.fields + [
+            'latest_revision_created_at',
+            'status',
+            'children',
+            'descendants',
+        ]
+
+        meta_fields = PageSerializer.Meta.meta_fields + [
+            'latest_revision_created_at',
+            'status',
+            'children',
+            'descendants',
+            'parent',
+        ]
+
+        listing_default_fields = PageSerializer.Meta.listing_default_fields + [
+            'latest_revision_created_at',
+            'status',
+            'children',
+        ]
+
+        # Allow the parent field to appear on listings
+        detail_only_fields = []

--- a/wagtail/wagtaildocs/api/v2/endpoints.py
+++ b/wagtail/wagtaildocs/api/v2/endpoints.py
@@ -10,9 +10,5 @@ from .serializers import DocumentSerializer
 class DocumentsAPIEndpoint(BaseAPIEndpoint):
     default_base_serializer_class = DocumentSerializer
     filter_backends = [FieldsFilter, OrderingFilter, SearchFilter]
-    body_fields = BaseAPIEndpoint.body_fields + ['title']
-    meta_fields = BaseAPIEndpoint.meta_fields + ['tags', 'download_url']
-    listing_default_fields = BaseAPIEndpoint.listing_default_fields + ['title', 'tags', 'download_url']
-    nested_default_fields = BaseAPIEndpoint.nested_default_fields + ['title', 'download_url']
     name = 'documents'
     model = get_document_model()

--- a/wagtail/wagtaildocs/api/v2/endpoints.py
+++ b/wagtail/wagtaildocs/api/v2/endpoints.py
@@ -8,7 +8,7 @@ from .serializers import DocumentSerializer
 
 
 class DocumentsAPIEndpoint(BaseAPIEndpoint):
-    base_serializer_class = DocumentSerializer
+    default_base_serializer_class = DocumentSerializer
     filter_backends = [FieldsFilter, OrderingFilter, SearchFilter]
     body_fields = BaseAPIEndpoint.body_fields + ['title']
     meta_fields = BaseAPIEndpoint.meta_fields + ['tags', 'download_url']

--- a/wagtail/wagtaildocs/api/v2/serializers.py
+++ b/wagtail/wagtaildocs/api/v2/serializers.py
@@ -22,3 +22,10 @@ class DocumentDownloadUrlField(Field):
 
 class DocumentSerializer(BaseSerializer):
     download_url = DocumentDownloadUrlField(read_only=True)
+
+    class Meta(BaseSerializer.Meta):
+        fields = BaseSerializer.Meta.fields + ['title', 'tags', 'download_url']
+        meta_fields = BaseSerializer.Meta.meta_fields + ['tags', 'download_url']
+
+        listing_default_fields = BaseSerializer.Meta.listing_default_fields + ['title', 'tags', 'download_url']
+        nested_default_fields = BaseSerializer.Meta.nested_default_fields + ['title', 'download_url']

--- a/wagtail/wagtailimages/api/admin/endpoints.py
+++ b/wagtail/wagtailimages/api/admin/endpoints.py
@@ -6,13 +6,3 @@ from .serializers import AdminImageSerializer
 
 class ImagesAdminAPIEndpoint(ImagesAPIEndpoint):
     base_serializer_class = AdminImageSerializer
-
-    body_fields = ImagesAPIEndpoint.body_fields + [
-        'thumbnail',
-    ]
-
-    listing_default_fields = ImagesAPIEndpoint.listing_default_fields + [
-        'width',
-        'height',
-        'thumbnail',
-    ]

--- a/wagtail/wagtailimages/api/admin/serializers.py
+++ b/wagtail/wagtailimages/api/admin/serializers.py
@@ -31,9 +31,6 @@ class ImageRenditionField(Field):
         self.filter_spec = filter_spec
         super(ImageRenditionField, self).__init__(*args, **kwargs)
 
-    def get_attribute(self, instance):
-        return instance
-
     def to_representation(self, image):
         try:
             thumbnail = image.get_rendition(self.filter_spec)
@@ -50,4 +47,4 @@ class ImageRenditionField(Field):
 
 
 class AdminImageSerializer(ImageSerializer):
-    thumbnail = ImageRenditionField('max-165x165', read_only=True)
+    thumbnail = ImageRenditionField('max-165x165', source='*', read_only=True)

--- a/wagtail/wagtailimages/api/admin/serializers.py
+++ b/wagtail/wagtailimages/api/admin/serializers.py
@@ -6,3 +6,11 @@ from ..v2.serializers import ImageSerializer
 
 class AdminImageSerializer(ImageSerializer):
     thumbnail = ImageRenditionField('max-165x165', source='*', read_only=True)
+
+    class Meta(ImageSerializer.Meta):
+        fields = ImageSerializer.Meta.fields + ['thumbnail']
+        listing_default_fields = ImageSerializer.Meta.listing_default_fields + [
+            'width',
+            'height',
+            'thumbnail',
+        ]

--- a/wagtail/wagtailimages/api/admin/serializers.py
+++ b/wagtail/wagtailimages/api/admin/serializers.py
@@ -1,49 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 
-from collections import OrderedDict
-
-from rest_framework.fields import Field
-
-from ...models import SourceImageIOError
+from ..fields import ImageRenditionField
 from ..v2.serializers import ImageSerializer
-
-
-class ImageRenditionField(Field):
-    """
-    A field that generates a rendition with the specified filter spec, and serialises
-    details of that rendition.
-
-    Example:
-    "thumbnail": {
-        "url": "/media/images/myimage.max-165x165.jpg",
-        "width": 165,
-        "height": 100
-    }
-
-    If there is an error with the source image. The dict will only contain a single
-    key, "error", indicating this error:
-
-    "thumbnail": {
-        "error": "SourceImageIOError"
-    }
-    """
-    def __init__(self, filter_spec, *args, **kwargs):
-        self.filter_spec = filter_spec
-        super(ImageRenditionField, self).__init__(*args, **kwargs)
-
-    def to_representation(self, image):
-        try:
-            thumbnail = image.get_rendition(self.filter_spec)
-
-            return OrderedDict([
-                ('url', thumbnail.url),
-                ('width', thumbnail.width),
-                ('height', thumbnail.height),
-            ])
-        except SourceImageIOError:
-            return OrderedDict([
-                ('error', 'SourceImageIOError'),
-            ])
 
 
 class AdminImageSerializer(ImageSerializer):

--- a/wagtail/wagtailimages/api/fields.py
+++ b/wagtail/wagtailimages/api/fields.py
@@ -1,0 +1,45 @@
+from __future__ import absolute_import, unicode_literals
+
+from collections import OrderedDict
+
+from rest_framework.fields import Field
+
+from ..models import SourceImageIOError
+
+
+class ImageRenditionField(Field):
+    """
+    A field that generates a rendition with the specified filter spec, and serialises
+    details of that rendition.
+
+    Example:
+    "thumbnail": {
+        "url": "/media/images/myimage.max-165x165.jpg",
+        "width": 165,
+        "height": 100
+    }
+
+    If there is an error with the source image. The dict will only contain a single
+    key, "error", indicating this error:
+
+    "thumbnail": {
+        "error": "SourceImageIOError"
+    }
+    """
+    def __init__(self, filter_spec, *args, **kwargs):
+        self.filter_spec = filter_spec
+        super(ImageRenditionField, self).__init__(*args, **kwargs)
+
+    def to_representation(self, image):
+        try:
+            thumbnail = image.get_rendition(self.filter_spec)
+
+            return OrderedDict([
+                ('url', thumbnail.url),
+                ('width', thumbnail.width),
+                ('height', thumbnail.height),
+            ])
+        except SourceImageIOError:
+            return OrderedDict([
+                ('error', 'SourceImageIOError'),
+            ])

--- a/wagtail/wagtailimages/api/v2/endpoints.py
+++ b/wagtail/wagtailimages/api/v2/endpoints.py
@@ -8,7 +8,7 @@ from .serializers import ImageSerializer
 
 
 class ImagesAPIEndpoint(BaseAPIEndpoint):
-    base_serializer_class = ImageSerializer
+    default_base_serializer_class = ImageSerializer
     filter_backends = [FieldsFilter, OrderingFilter, SearchFilter]
     body_fields = BaseAPIEndpoint.body_fields + ['title', 'width', 'height']
     meta_fields = BaseAPIEndpoint.meta_fields + ['tags']

--- a/wagtail/wagtailimages/api/v2/endpoints.py
+++ b/wagtail/wagtailimages/api/v2/endpoints.py
@@ -10,9 +10,5 @@ from .serializers import ImageSerializer
 class ImagesAPIEndpoint(BaseAPIEndpoint):
     default_base_serializer_class = ImageSerializer
     filter_backends = [FieldsFilter, OrderingFilter, SearchFilter]
-    body_fields = BaseAPIEndpoint.body_fields + ['title', 'width', 'height']
-    meta_fields = BaseAPIEndpoint.meta_fields + ['tags']
-    listing_default_fields = BaseAPIEndpoint.listing_default_fields + ['title', 'tags']
-    nested_default_fields = BaseAPIEndpoint.nested_default_fields + ['title']
     name = 'images'
     model = get_image_model()

--- a/wagtail/wagtailimages/api/v2/serializers.py
+++ b/wagtail/wagtailimages/api/v2/serializers.py
@@ -4,4 +4,8 @@ from wagtail.api.v2.serializers import BaseSerializer
 
 
 class ImageSerializer(BaseSerializer):
-    pass
+    class Meta(BaseSerializer.Meta):
+        fields = BaseSerializer.Meta.fields + ['title', 'width', 'height', 'tags']
+        meta_fields = BaseSerializer.Meta.meta_fields + ['tags']
+        listing_default_fields = BaseSerializer.Meta.listing_default_fields + ['title', 'tags']
+        nested_default_fields = BaseSerializer.Meta.nested_default_fields + ['title']


### PR DESCRIPTION
This pull request makes it possible for users to define their own DRF serializers per page type. This should massively improve flexibility over the current list of field names in ``api_fields``.

This also introduces an ``ImageRenditionField`` field serializer which makes it easy to add image renditions to the API!

For example:
```python

from wagtail.api.v2.serializers import PageSerializer
from wagtail.wagtailimages.api.fields import ImageRenditionField


class BlogPageSerializer(PageSerializer):
    feed_image_thumbnail = ImageRenditionField('fill-300x300', source='feed_image')

    class Meta(PageSerializer.Meta):
        fields = PageSerializer.Meta.fields + [
            'body',
            'feed_image',
            'feed_image_thumbnail',
        ]


class BlogPage(Page):
    body = models.RichTextField()
    feed_image = models.ForeignKey('wagtailimages.Image')
    ...

    # Instead of api_fields, use a serializer class
    serializer_class = BlogPageSerializer
```

This will produce the following output (when all fields are requested):

```json
{
    "id": 10,
    "meta": {
        "type": "demo.BlogPage",
        "detail_url": "/api/v2/pages/10/"
    },
    "title": "A blog post",
    "body": "body text here...",
    "feed_image": {
        "id": 5,
        "meta": {
            "type": "wagtailimages.Image",
            "detail_url": "/api/v2/images/5/"
        },
        "title": "An image",
        "width": 1000,
        "height": 500
    },
    "feed_image_thumbnail": {
        "url": "/media/images/an-image.fill-300x300.jpg",
        "width": 300,
        "height": 300
    }
}
```

The ``api_fields`` attribute is still fully supported for now but this may introduce a backwards-incompatbility for people who have manually overridden the endpoints classes. Previously, the API fields were managed by the endpoint but they are now managed by the serializer.

TODO:
 - [ ] Serializer based configuration for inline objects
 - [ ] Tests for serializer based configuration
 - [ ] Docs for serializer based configuration
 - [ ] Tests for ``ImageRenditionField``
 - [ ] Docs for ``ImageRenditionField``
 - [ ] Write instructions for migrating from custom endpoint classes for the upgrade considerations