### PR TITLE
Add convenience function for testing for any existing user page permi…

### DIFF
--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -1794,6 +1794,18 @@ class PagePermissionTester(object):
             # no publishing required, so the already-tested 'add' permission is sufficient
             return True
 
+    def can_perform_action(self):
+        """
+        Convenience method for checking whether a user has any action on the page at all.
+        This is useful for shaving down systems that would otherwise need to check each of
+        these permissions explicitly like in Django templates.
+        """
+        return can_add_subpage() or \
+               can_edit() or \
+               can_delete() or \
+               can_unpublish() or \
+               can_publish()
+
 
 class PageViewRestriction(models.Model):
     NONE = 'none'

--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -1800,11 +1800,11 @@ class PagePermissionTester(object):
         This is useful for shaving down systems that would otherwise need to check each of
         these permissions explicitly like in Django templates.
         """
-        return can_add_subpage() or \
-               can_edit() or \
-               can_delete() or \
-               can_unpublish() or \
-               can_publish()
+        return self.can_add_subpage() or \
+            self.can_edit() or \
+            self.can_delete() or \
+            self.can_unpublish() or \
+            self.can_publish()
 
 
 class PageViewRestriction(models.Model):


### PR DESCRIPTION
…ssion.

Continuation of multitenant work. 

For some features, we've found it useful to be able to exclude pages from a user that the user has no actions on whatsoever (the implicit concept of 'explorability'). However, this is difficult to achieve in a template context without the code getting bloated. By adding this method, we can reduce it to one line: `{% if page_perms.can_perform_action %}`. 

I think this will be useful for other developers who may be trying to filter admin features based on user page permissions. 