### PR TITLE
Fix: block.super should be outside script tags in type_index.html

### DIFF
--- a/wagtail/__init__.py
+++ b/wagtail/__init__.py
@@ -4,7 +4,7 @@ from wagtail.utils.version import get_semver_version, get_version
 
 # major.minor.patch.release.number
 # release must be one of alpha, beta, rc, or final
-VERSION = (1, 9, 0, 'alpha', 0)
+VERSION = (1, 9, 0, 'rc', 1)
 
 __version__ = get_version(VERSION)
 

--- a/wagtail/project_template/requirements.txt
+++ b/wagtail/project_template/requirements.txt
@@ -1,2 +1,2 @@
 Django>=1.10,<1.11
-wagtail==1.9a0
+wagtail==1.9rc1

--- a/wagtail/wagtailcore/blocks/base.py
+++ b/wagtail/wagtailcore/blocks/base.py
@@ -246,7 +246,7 @@ class Block(six.with_metaclass(BaseBlock, object)):
                 "keyword argument" % class_with_render_method,
                 category=RemovedInWagtail111Warning
             )
-            new_context = context
+            new_context = context or {}
             new_context.update(self.get_context(value))
             return mark_safe(render_to_string(template, new_context))
 

--- a/wagtail/wagtailcore/tests/test_blocks.py
+++ b/wagtail/wagtailcore/tests/test_blocks.py
@@ -84,6 +84,17 @@ class TestFieldBlock(unittest.TestCase):
         self.assertIs(ws[0].category, RemovedInWagtail111Warning)
         self.assertEqual(html, '<h1 lang="fr">Bonjour le monde!</h1>')
 
+    def test_charfield_render_with_legacy_get_context_none(self):
+        block = NoExtraContextCharBlock(template='tests/blocks/heading_block.html')
+        with warnings.catch_warnings(record=True) as ws:
+            warnings.simplefilter('always')
+
+            html = block.render("Bonjour le monde!")
+
+        self.assertEqual(len(ws), 1)
+        self.assertIs(ws[0].category, RemovedInWagtail111Warning)
+        self.assertEqual(html, '<h1>Bonjour le monde!</h1>')
+
     def test_charfield_render_form(self):
         block = blocks.CharBlock()
         html = block.render_form("Hello world!")

--- a/wagtail/wagtailsnippets/templates/wagtailsnippets/snippets/type_index.html
+++ b/wagtail/wagtailsnippets/templates/wagtailsnippets/snippets/type_index.html
@@ -3,8 +3,8 @@
 {% block titletag %}{% blocktrans with snippet_type_name_plural=model_opts.verbose_name_plural|capfirst %}Snippets {{ snippet_type_name_plural }}{% endblocktrans %}{% endblock %}
 
 {% block extra_js %}
+    {{ block.super }}
     <script>
-        {{ block.super }}
         window.headerSearch = {
             url: "{% url 'wagtailsnippets:list' model_opts.app_label model_opts.model_name %}",
             termInput: "#id_q",


### PR DESCRIPTION
When using `extra_js` on extending wagtailadmin/base.html all other instances of block.super are located outside script tags, except this one.