### PR TITLE
Allow pageurl / slugurl tags to function when request.site is not available

### DIFF
--- a/wagtail/wagtailcore/templatetags/wagtailcore_tags.py
+++ b/wagtail/wagtailcore/templatetags/wagtailcore_tags.py
@@ -18,7 +18,13 @@ def pageurl(context, page):
     Outputs a page's URL as relative (/foo/bar/) if it's within the same site as the
     current page, or absolute (http://example.com/foo/bar/) if not.
     """
-    return page.relative_url(context['request'].site)
+    try:
+        current_site = context['request'].site
+    except (KeyError, AttributeError):
+        # request.site not available in the current context; fall back on page.url
+        return page.url
+
+    return page.relative_url(current_site)
 
 
 @register.simple_tag(takes_context=True)
@@ -26,10 +32,16 @@ def slugurl(context, slug):
     """Returns the URL for the page that has the given slug."""
     page = Page.objects.filter(slug=slug).first()
 
-    if page:
-        return page.relative_url(context['request'].site)
-    else:
+    if not page:
         return None
+
+    try:
+        current_site = context['request'].site
+    except (KeyError, AttributeError):
+        # request.site not available in the current context; fall back on page.url
+        return page.url
+
+    return page.relative_url(current_site)
 
 
 @register.simple_tag

--- a/wagtail/wagtailcore/tests/tests.py
+++ b/wagtail/wagtailcore/tests/tests.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import, unicode_literals
 
+from django import template
 from django.core.cache import cache
+from django.http import HttpRequest
 from django.test import TestCase
 from django.utils.safestring import SafeText
 
@@ -24,6 +26,29 @@ class TestPageUrlTags(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response,
                             '<a href="/events/">Back to events index</a>')
+
+    def test_pageurl_without_request_in_context(self):
+        page = Page.objects.get(url_path='/home/events/')
+        tpl = template.Template('''{% load wagtailcore_tags %}<a href="{% pageurl page %}">{{ page.title }}</a>''')
+
+        # no 'request' object in context
+        result = tpl.render(template.Context({'page': page}))
+        self.assertIn('<a href="/events/">Events</a>', result)
+
+        # 'request' object in context, but no 'site' attribute
+        result = tpl.render(template.Context({'page': page, 'request': HttpRequest()}))
+        self.assertIn('<a href="/events/">Events</a>', result)
+
+    def test_slugurl_without_request_in_context(self):
+        tpl = template.Template('''{% load wagtailcore_tags %}<a href="{% slugurl 'events' %}">Events</a>''')
+
+        # no 'request' object in context
+        result = tpl.render(template.Context({}))
+        self.assertIn('<a href="/events/">Events</a>', result)
+
+        # 'request' object in context, but no 'site' attribute
+        result = tpl.render(template.Context({'request': HttpRequest()}))
+        self.assertIn('<a href="/events/">Events</a>', result)
 
 
 class TestSiteRootPathsCache(TestCase):


### PR DESCRIPTION
Allow the `{% pageurl %}` and `{% slugurl %}` tags to function when the template context does not contain a `request` object (e.g. rendering a template during `str(page.body)` on a StreamField), or contains a `request` object without a `site` attribute (which can happen during the rendering of a 500 page if the error occurred before/during Wagtail's SiteMiddleware, as in #3279).

The `str(page.body)` situation is the root cause of #3352, because the 'compare revisions' view compares StreamFields based on their string representations.

(Note: @tobiasmcnulty already fixed this in #3354, but #3352 is a release blocker for 1.9 and thus needs a standalone fix...)