### PR TITLE
Use `django-treebeard` movenodeform form in the PageAdmin changelist in the vanilla Django admin

### DIFF
--- a/wagtail/project_template/project_name/settings/base.py
+++ b/wagtail/project_template/project_name/settings/base.py
@@ -43,6 +43,7 @@ INSTALLED_APPS = [
 
     'modelcluster',
     'taggit',
+    'treebeard',
 
     'django.contrib.admin',
     'django.contrib.auth',

--- a/wagtail/wagtailcore/admin.py
+++ b/wagtail/wagtailcore/admin.py
@@ -4,10 +4,18 @@ from django.contrib import admin
 from django.contrib.auth.admin import GroupAdmin
 from django.contrib.auth.models import Group
 
+from treebeard.admin import TreeAdmin
+from treebeard.forms import movenodeform_factory
+
 from wagtail.wagtailcore.models import GroupPagePermission, Page, Site
 
 admin.site.register(Site)
-admin.site.register(Page)
+
+# Use the Treebeard treeadmin.
+class PageAdmin(TreeAdmin):
+    form = movenodeform_factory(Page)
+
+admin.site.register(Page, PageAdmin)
 
 
 # Extend GroupAdmin to include page permissions as an inline

--- a/wagtail/wagtailcore/admin.py
+++ b/wagtail/wagtailcore/admin.py
@@ -1,9 +1,9 @@
 from __future__ import absolute_import, unicode_literals
 
+from django.apps import apps
 from django.contrib import admin
 from django.contrib.auth.admin import GroupAdmin
 from django.contrib.auth.models import Group
-from django.apps import apps
 
 from treebeard.admin import TreeAdmin
 from treebeard.forms import movenodeform_factory

--- a/wagtail/wagtailcore/admin.py
+++ b/wagtail/wagtailcore/admin.py
@@ -11,9 +11,11 @@ from wagtail.wagtailcore.models import GroupPagePermission, Page, Site
 
 admin.site.register(Site)
 
+
 # Use the Treebeard treeadmin.
 class PageAdmin(TreeAdmin):
     form = movenodeform_factory(Page)
+
 
 admin.site.register(Page, PageAdmin)
 

--- a/wagtail/wagtailcore/admin.py
+++ b/wagtail/wagtailcore/admin.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, unicode_literals
 from django.contrib import admin
 from django.contrib.auth.admin import GroupAdmin
 from django.contrib.auth.models import Group
+from django.apps import apps
 
 from treebeard.admin import TreeAdmin
 from treebeard.forms import movenodeform_factory
@@ -12,12 +13,15 @@ from wagtail.wagtailcore.models import GroupPagePermission, Page, Site
 admin.site.register(Site)
 
 
-# Use the Treebeard treeadmin.
-class PageAdmin(TreeAdmin):
-    form = movenodeform_factory(Page)
+# Use the Treebeard treeadmin form widget if installed
+# else just register the model with the vanilla changelist
+if apps.is_installed('treebeard'):
+    class PageAdmin(TreeAdmin):
+        form = movenodeform_factory(Page)
 
-
-admin.site.register(Page, PageAdmin)
+    admin.site.register(Page, PageAdmin)
+else:
+    admin.site.register(Page)
 
 
 # Extend GroupAdmin to include page permissions as an inline


### PR DESCRIPTION
Treebeard comes with a useful tree-editing form widget, let's use that rather than a less useful default changelist. 

This comes in quite handy when you want to rearrange the order and position of pages within the wagtail page tree and it makes sense to use code that's already in the library and use the vanilla django admin for it.

The old version looked like this:

![image](https://cloud.githubusercontent.com/assets/254250/22946970/2a8fb8f2-f2f1-11e6-882f-cbfdf0603063.png)

... and the change allows you to drag and drop the pages in the page tree like this:

![treebeard_admin](https://cloud.githubusercontent.com/assets/254250/22947042/6f3eafee-f2f1-11e6-8151-01740ecac636.gif)
