### PR TITLE
speed up tests

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -11,6 +11,7 @@ Changelog
  * The homepage created in the project template is now titled "Home" rather than "Homepage" (Karl Hobley)
  * Signal receivers for custom `Image` and `Rendition` models are connected automatically (Mike Dingjan)
  * `PageChooserBlock` can now accept a list/tuple of page models as `target_model` (Mikalai Radchuk)
+ * Styling tweaks for the ModelAdmin's `IndexView` to be more inline with the Wagtail styleguide (Andy Babic)
  * Fix: Marked 'Date from' / 'Date to' strings in wagtailforms for translation (Vorlif)
  * Fix: Unreliable preview is now reliable by always opening in a new window (Kjartan Sverrisson)
  * Fix: Fixed placement of `{{ block.super }}` in `snippets/type_index.html` (LB (Ben Johnston))

--- a/docs/releases/1.10.rst
+++ b/docs/releases/1.10.rst
@@ -21,6 +21,7 @@ Other features
  * The homepage created in the project template is now titled "Home" rather than "Homepage" (Karl Hobley)
  * Signal receivers for custom ``Image`` and ``Rendition`` models are connected automatically (Mike Dingjan)
  * ``PageChooserBlock`` can now accept a list/tuple of page models as ``target_model`` (Mikalai Radchuk)
+ * Styling tweaks for the ModelAdmin's ``IndexView`` to be more inline with the Wagtail styleguide (Andy Babic)
 
 
 Bug fixes

--- a/wagtail/contrib/modeladmin/static_src/wagtailmodeladmin/scss/index.scss
+++ b/wagtail/contrib/modeladmin/static_src/wagtailmodeladmin/scss/index.scss
@@ -1,28 +1,41 @@
+@import 'wagtailadmin/scss/variables';
+
 .content header {
     margin-bottom: 0;
 }
 
 
 .result-list {
-    padding: 0 15px;
+    margin-bottom: 0;
+}
 
-    table {
-        margin-bottom: 0;
-    }
+.listing {
 
-    body th {
-        background-color: transparent;
-        text-align: left;
-        padding: 1.2em 1em;
-    }
-
-    tbody tr:hover ul.actions {
-        visibility: visible;
-    }
-
-    tbody td,
-    tbody th {
+    td,
+    th {
         vertical-align: top;
+    }
+
+    thead th.sorted a {
+        color: $color-teal;
+    }
+
+    tbody {
+        overflow: auto;
+
+        tr:hover ul.actions {
+            visibility: visible;
+        }
+
+        tr > td { 
+            background-color: inherit;
+            
+            a.edit-obj { 
+                color: inherit;
+                font-weight: 600; 
+            }
+        }
+
     }
 }
 
@@ -133,14 +146,18 @@ p.no-results {
 
     .result-list {
         padding: 0 1.5% 0 0;
-    }
 
-    .result-list tbody th:first-child {
-        padding-left: 50px;
-    }
+        &.col12 {
+            padding-right: 0;
 
-    .result-list.col12 tbody td:last-child {
-        padding-right: 50px;
+            tbody td:last-child {
+                padding-right: 50px;
+            }
+        }
+
+        tbody th:first-child {
+            padding-left: 50px;
+        }
     }
 
     div.pagination {

--- a/wagtail/contrib/modeladmin/templates/modeladmin/includes/result_list.html
+++ b/wagtail/contrib/modeladmin/templates/modeladmin/includes/result_list.html
@@ -5,7 +5,7 @@
         <tr>
             {% for header in result_headers %}
             <th scope="col" {{ header.class_attrib }}>
-                {% if header.sortable %}<a href="{{ header.url_primary }}" class="teal icon {% if header.ascending %}icon-arrow-up-after{% else %}icon-arrow-down-after{% endif %}">{% endif %}
+                {% if header.sortable %}<a href="{{ header.url_primary }}" class="icon {% if header.ascending %}icon-arrow-up-after{% else %}icon-arrow-down-after{% endif %}">{% endif %}
                 {{ header.text|capfirst }}
                 {% if header.sortable %}</a>{% endif %}
            </th>

--- a/wagtail/tests/settings.py
+++ b/wagtail/tests/settings.py
@@ -1,9 +1,11 @@
 from __future__ import absolute_import, unicode_literals
 
 import os
-
+import logging
 import django
 
+logging.disable(logging.CRITICAL)
+DEBUG = False
 WAGTAIL_ROOT = os.path.dirname(os.path.dirname(__file__))
 STATIC_ROOT = os.path.join(WAGTAIL_ROOT, 'tests', 'test-static')
 MEDIA_ROOT = os.path.join(WAGTAIL_ROOT, 'tests', 'test-media')
@@ -54,7 +56,7 @@ TEMPLATES = [
                 'wagtail.tests.context_processors.do_not_use_static_url',
                 'wagtail.contrib.settings.context_processors.settings',
             ],
-            'debug': True,
+            'debug': False,
         },
     },
     {

--- a/wagtail/tests/settings.py
+++ b/wagtail/tests/settings.py
@@ -1,10 +1,8 @@
 from __future__ import absolute_import, unicode_literals
 
-import logging
 import os
 import django
 
-logging.disable(logging.CRITICAL)
 DEBUG = False
 WAGTAIL_ROOT = os.path.dirname(os.path.dirname(__file__))
 STATIC_ROOT = os.path.join(WAGTAIL_ROOT, 'tests', 'test-static')

--- a/wagtail/tests/settings.py
+++ b/wagtail/tests/settings.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 
-import os
 import logging
+import os
 import django
 
 logging.disable(logging.CRITICAL)


### PR DESCRIPTION
Trying to speedup tests.
Added some common patterns in Django to speed up them.

I was also trying to ``parallel`` them but since using inside a vm with 1 core..no gain ;)

Before: ``Ran 2704 tests in 505.227s``
After:  ``Ran 2704 tests in 469.659s``