### PR TITLE
Updating Sphinx and other doc dep versions

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -8,7 +8,7 @@ pipeline:
     image: python:3.5
     commands:
       - XDG_CACHE_HOME=/drone/pip-cache pip install wheel
-      - XDG_CACHE_HOME=/drone/pip-cache pip install -e .[testing,docs]
+      - XDG_CACHE_HOME=/drone/pip-cache pip install -e .[testing]
       - isort --check-only --diff --recursive wagtail
   js:
     image: node:4.2.4
@@ -24,7 +24,7 @@ pipeline:
     image: python:3.5
     commands:
       - XDG_CACHE_HOME=/drone/pip-cache pip install wheel
-      - XDG_CACHE_HOME=/drone/pip-cache pip install -e .[testing,docs]
+      - XDG_CACHE_HOME=/drone/pip-cache pip install -e .[testing]
       - python -u runtests.py
 
 cache:

--- a/setup.py
+++ b/setup.py
@@ -53,11 +53,11 @@ testing_extras = [
 
 # Documentation dependencies
 documentation_extras = [
-    'pyenchant==1.6.6',
+    'pyenchant==1.6.8',
     'sphinxcontrib-spelling>=2.3.0',
-    'Sphinx>=1.3.1',
-    'sphinx-autobuild>=0.5.2',
-    'sphinx_rtd_theme>=0.1.8',
+    'Sphinx>=1.5.2',
+    'sphinx-autobuild>=0.6.0',
+    'sphinx_rtd_theme>=0.1.9',
 ]
 
 setup(


### PR DESCRIPTION
On OSX, I tried a fresh install and came across the following error when attempting to build the docs via `make html`:

<img width="976" alt="screen shot 2017-02-17 at 10 23 36 pm" src="https://cloud.githubusercontent.com/assets/281961/23089930/dbcede34-f55f-11e6-825e-5c864fd3fd7f.png">

Updating the documentation libraries fixes the issue.

