### PR TITLE
Use render_basic for StructBlocks

### DIFF
--- a/wagtail/wagtailadmin/templates/wagtailadmin/blocks/struct.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/blocks/struct.html
@@ -1,6 +1,0 @@
-<dl>
-    {% for key, val in self.items %}
-        <dt>{{ key }}</dt>
-        <dd>{{ val }}</dd>
-    {% endfor %}
-</dl>

--- a/wagtail/wagtailcore/blocks/struct_block.py
+++ b/wagtail/wagtailcore/blocks/struct_block.py
@@ -11,6 +11,7 @@ from django.template.loader import render_to_string
 from django.utils import six
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.functional import cached_property
+from django.utils.html import format_html, format_html_join
 
 from .base import Block, DeclarativeSubBlocksMetaclass
 from .utils import js_dict
@@ -175,9 +176,12 @@ class BaseStructBlock(Block):
 
         return errors
 
+    def render_basic(self, value, context=None):
+        return format_html('<dl>\n{}\n</dl>', format_html_join(
+            '\n', '    <dt>{}</dt>\n    <dd>{}</dd>', value.items()))
+
     class Meta:
         default = {}
-        template = "wagtailadmin/blocks/struct.html"
         form_classname = 'struct-block'
         form_template = 'wagtailadmin/block_forms/struct.html'
         # No icon specified here, because that depends on the purpose that the


### PR DESCRIPTION
Having a StructBlock rendered via a template was inconsistent with other blocks, It also meant that overriding `render_basic()` in a child class did nothing, again unlike all other blocks. Providing a `render_basic()` is useful for block libraries, where a `render_basic()` provides a very minimal implementation with the expectation that developers will provide their own rendering via a template.

TableBlock is the only other block with a template, but I think that one is legitimate.