### PR TITLE
Fix: Select of "Popular search terms" work only on the first page.

### DIFF
--- a/wagtail/wagtailsearch/templates/wagtailsearch/queries/chooser/chooser.js
+++ b/wagtail/wagtailsearch/templates/wagtailsearch/queries/chooser/chooser.js
@@ -1,9 +1,7 @@
 function(modal) {
     function ajaxifyLinks (context) {
-        $('.listing a', context).click(function() {
-            modal.loadUrl(this.href);
-            return false;
-        });
+
+        $('.listing a.choose-query', context).click(chooseQuery);
 
         $('.pagination a', context).click(function() {
             var page = this.getAttribute("data-page");
@@ -42,17 +40,16 @@ function(modal) {
         });
         return false;
     }
-
-    ajaxifyLinks(modal.body);
-
-    $('form.query-search', modal.body).submit(search);
-
-    $('a.choose-query', modal.body).click(function() {
+    function chooseQuery() {
         modal.respond('queryChosen', $(this).data());
         modal.close();
 
         return false;
-    });
+    }
+
+    ajaxifyLinks(modal.body);
+
+    $('form.query-search', modal.body).submit(search);
 
     $('#id_q').on('input', function() {
         clearTimeout($.data(this, 'timer'));


### PR DESCRIPTION
This PR fixes the issue belonging to #3384. For some reason it had an Ajax callback when clicking on query terms in the modal listing. But the response was not adding any additional functionality, it was only throwing an `eval` error since the it isn't the correct response the `ModalWorkflow` was expecting.

I removed the listening for `modal.loadUrl` and bound it to the method to select the query and close the modal.