### PR TITLE
Prevent self demotion

### DIFF
--- a/wagtail/wagtailusers/views/users.py
+++ b/wagtail/wagtailusers/views/users.py
@@ -157,6 +157,11 @@ def edit(request, user_id):
     else:
         form = get_user_edit_form()(instance=user)
 
+    # If you're not allowed to delete a user,
+    # you should not be able to deactivate or demote them either:
+    form.fields['is_active'].widget.attrs['disabled'] = not can_delete
+    form.fields['is_superuser'].widget.attrs['disabled'] = not can_delete
+
     return render(request, 'wagtailusers/users/edit.html', {
         'user': user,
         'form': form,


### PR DESCRIPTION
Fix for #3244

Disable checkboxes for is_active and is_superuser when `can_delete` is false, thus preventing admins from accidentally deactivating themselves or  "demoting" themselves to non-admin.  (Admins are are already prevented from *deleting* themselves)