### PR TITLE
Prevent users from demoting or deactivating themself

### DIFF
--- a/wagtail/wagtailusers/forms.py
+++ b/wagtail/wagtailusers/forms.py
@@ -154,6 +154,14 @@ class UserEditForm(UsernameForm):
         help_text=_("Administrators have full access to manage any object or setting.")
     )
 
+    def __init__(self, *args, **kwargs):
+        editing_self = kwargs.pop('editing_self', False)
+        super(UserEditForm, self).__init__(*args, **kwargs)
+
+        if editing_self:
+            del self.fields["is_active"]
+            del self.fields["is_superuser"]
+
     class Meta:
         model = User
         fields = set([User.USERNAME_FIELD, "is_active"]) | standard_fields | custom_fields

--- a/wagtail/wagtailusers/templates/wagtailusers/users/edit.html
+++ b/wagtail/wagtailusers/templates/wagtailusers/users/edit.html
@@ -28,7 +28,10 @@
                         {% block extra_fields %}{% endblock extra_fields %}
                         {% include "wagtailadmin/shared/field_as_li.html" with field=form.password1 %}
                         {% include "wagtailadmin/shared/field_as_li.html" with field=form.password2 %}
-                        {% include "wagtailadmin/shared/field_as_li.html" with field=form.is_active %}
+                        {% if form.is_active %}
+                          {% include "wagtailadmin/shared/field_as_li.html" with field=form.is_active %}
+                        {% endif %}
+
                     {% endblock fields %}
                     <li>
                         <input type="submit" value="{% trans 'Save' %}" class="button" />
@@ -40,7 +43,10 @@
             </section>
             <section id="roles" class="nice-padding">
                 <ul class="fields">
-                    {% include "wagtailadmin/shared/field_as_li.html" with field=form.is_superuser %}
+                    {% if form.is_superuser %}
+                      {% include "wagtailadmin/shared/field_as_li.html" with field=form.is_superuser %}
+                    {% endif %}
+
                     {% include "wagtailadmin/shared/field_as_li.html" with field=form.groups %}
                     <li>
                         <input type="submit" value="{% trans 'Save' %}" class="button" />

--- a/wagtail/wagtailusers/views/users.py
+++ b/wagtail/wagtailusers/views/users.py
@@ -143,9 +143,10 @@ def create(request):
 def edit(request, user_id):
     user = get_object_or_404(User, pk=user_id)
     can_delete = user_can_delete_user(request.user, user)
+    editing_self = request.user == user
 
     if request.method == 'POST':
-        form = get_user_edit_form()(request.POST, request.FILES, instance=user)
+        form = get_user_edit_form()(request.POST, request.FILES, instance=user, editing_self=editing_self)
         if form.is_valid():
             user = form.save()
             messages.success(request, _("User '{0}' updated.").format(user), buttons=[
@@ -155,7 +156,7 @@ def edit(request, user_id):
         else:
             messages.error(request, _("The user could not be saved due to errors."))
     else:
-        form = get_user_edit_form()(instance=user)
+        form = get_user_edit_form()(instance=user, editing_self=editing_self)
 
     return render(request, 'wagtailusers/users/edit.html', {
         'user': user,


### PR DESCRIPTION
Remove is_active and is_superuser fields completely when editing oneself, to avoid locking oneself out.

Another fix for #3244 (replacing my first attempt #3399)
