### PR TITLE
Fix reorder past a deleted item

### DIFF
--- a/wagtail/wagtailadmin/static_src/wagtailadmin/js/page-editor.js
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/js/page-editor.js
@@ -132,7 +132,7 @@ function InlinePanel(opts) {
                 var currentChildOrder = currentChildOrderElem.val();
 
                 /* find the previous visible 'inline_child' li before this one */
-                var prevChild = currentChild.prev(':visible');
+                var prevChild = currentChild.prevAll(':not(.deleted)').first();
                 if (!prevChild.length) return;
                 var prevChildOrderElem = prevChild.find('input[name$="-ORDER"]');
                 var prevChildOrder = prevChildOrderElem.val();
@@ -153,7 +153,7 @@ function InlinePanel(opts) {
                 var currentChildOrder = currentChildOrderElem.val();
 
                 /* find the next visible 'inline_child' li after this one */
-                var nextChild = currentChild.next(':visible');
+                var nextChild = currentChild.nextAll(':not(.deleted)').first();
                 if (!nextChild.length) return;
                 var nextChildOrderElem = nextChild.find('input[name$="-ORDER"]');
                 var nextChildOrder = nextChildOrderElem.val();


### PR DESCRIPTION
Fixes #2624 which also effects inline panels since it is referring to ``page-editor.js``

It turns out `currentChild.prev(':visible')`/`currentChild.next(':visible')` do not take `display: none;` into [consideration when checking for visibility](https://api.jquery.com/visible-selector/), which is applied by when pressing delete. Since the click event also applies the `.delete` class if have added the check for that, rather than `:visible`.

Ideally it would have been nice to use `prevUntil` or `nextUntil` as far as traversing goes, but unfortunately a syntax like `prevUntil(':not(.deleted)')` is not possible.