### PR TITLE
Dj1.11 - fix tests to compare HTML semantically

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,19 +61,23 @@ matrix:
      sudo: true
    - env: TOXENV=py35-dj110head-postgres-noelasticsearch
      python: 3.5
-   - env: TOXENV=py35-dj111-sqlite-noelasticsearch
-     python: 3.5
    - env: TOXENV=py35-dj111-postgres-noelasticsearch
-     python: 3.5
-   - env: TOXENV=py35-dj111-mysql-noelasticsearch
      python: 3.5
    - env: TOXENV=py35-dj111-postgres-elasticsearch
      python: 3.5
-   - env: TOXENV=py35-dj111-postgres-elasticsearch2 INSTALL_ELASTICSEARCH2=yes
-     python: 3.5
+   - env: TOXENV=py36-dj111-sqlite-noelasticsearch
+     python: 3.6
+   - env: TOXENV=py36-dj111-postgres-noelasticsearch
+     python: 3.6
+   - env: TOXENV=py36-dj111-mysql-noelasticsearch
+     python: 3.6
+   - env: TOXENV=py36-dj111-postgres-elasticsearch
+     python: 3.6
+   - env: TOXENV=py36-dj111-postgres-elasticsearch2 INSTALL_ELASTICSEARCH2=yes
+     python: 3.6
      sudo: true
-   - env: TOXENV=py35-dj111-postgres-elasticsearch5 INSTALL_ELASTICSEARCH5=yes
-     python: 3.5
+   - env: TOXENV=py36-dj111-postgres-elasticsearch5 INSTALL_ELASTICSEARCH5=yes
+     python: 3.6
      sudo: true
   allow_failures:
     # Ignore failures on Elasticsearch tests because ES on Travis is intermittently flaky;
@@ -86,12 +90,14 @@ matrix:
     - env: TOXENV=py35-dj110-postgres-elasticsearch
     - env: TOXENV=py35-dj110-postgres-elasticsearch2 INSTALL_ELASTICSEARCH2=yes
     - env: TOXENV=py35-dj110-postgres-elasticsearch5 INSTALL_ELASTICSEARCH5=yes
-    - env: TOXENV=py35-dj111-sqlite-noelasticsearch
     - env: TOXENV=py35-dj111-postgres-noelasticsearch
-    - env: TOXENV=py35-dj111-mysql-noelasticsearch
     - env: TOXENV=py35-dj111-postgres-elasticsearch
-    - env: TOXENV=py35-dj111-postgres-elasticsearch2 INSTALL_ELASTICSEARCH2=yes
-    - env: TOXENV=py35-dj111-postgres-elasticsearch5 INSTALL_ELASTICSEARCH5=yes
+    - env: TOXENV=py36-dj111-sqlite-noelasticsearch
+    - env: TOXENV=py36-dj111-postgres-noelasticsearch
+    - env: TOXENV=py36-dj111-mysql-noelasticsearch
+    - env: TOXENV=py36-dj111-postgres-elasticsearch
+    - env: TOXENV=py36-dj111-postgres-elasticsearch2 INSTALL_ELASTICSEARCH2=yes
+    - env: TOXENV=py36-dj111-postgres-elasticsearch5 INSTALL_ELASTICSEARCH5=yes
 
 # Services
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -76,6 +76,8 @@ matrix:
      python: 3.5
      sudo: true
   allow_failures:
+    # Ignore failures on Elasticsearch tests because ES on Travis is intermittently flaky;
+    # ignore failures on Django 1.11 because we're still working on supporting it
     - env: TOXENV=py27-dj110-mysql-elasticsearch5 INSTALL_ELASTICSEARCH5=yes
     - env: TOXENV=py27-dj111-sqlite-noelasticsearch
     - env: TOXENV=py27-dj111-postgres-noelasticsearch

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,15 @@ matrix:
    - env: TOXENV=py27-dj110-mysql-elasticsearch5 INSTALL_ELASTICSEARCH5=yes
      python: 2.7
      sudo: true
+   - env: TOXENV=py27-dj111-sqlite-noelasticsearch
+     python: 2.7
+   - env: TOXENV=py27-dj111-postgres-noelasticsearch
+     python: 2.7
+   - env: TOXENV=py27-dj111-mysql-noelasticsearch
+     python: 2.7
+   - env: TOXENV=py27-dj111-postgres-elasticsearch5 INSTALL_ELASTICSEARCH5=yes
+     python: 2.7
+     sudo: true
    - env: TOXENV=py34-dj110-postgres-noelasticsearch
      python: 3.4
    - env: TOXENV=py34-dj110-sqlite-noelasticsearch
@@ -52,11 +61,35 @@ matrix:
      sudo: true
    - env: TOXENV=py35-dj110head-postgres-noelasticsearch
      python: 3.5
+   - env: TOXENV=py35-dj111-sqlite-noelasticsearch
+     python: 3.5
+   - env: TOXENV=py35-dj111-postgres-noelasticsearch
+     python: 3.5
+   - env: TOXENV=py35-dj111-mysql-noelasticsearch
+     python: 3.5
+   - env: TOXENV=py35-dj111-postgres-elasticsearch
+     python: 3.5
+   - env: TOXENV=py35-dj111-postgres-elasticsearch2 INSTALL_ELASTICSEARCH2=yes
+     python: 3.5
+     sudo: true
+   - env: TOXENV=py35-dj111-postgres-elasticsearch5 INSTALL_ELASTICSEARCH5=yes
+     python: 3.5
+     sudo: true
   allow_failures:
+    - env: TOXENV=py27-dj110-mysql-elasticsearch5 INSTALL_ELASTICSEARCH5=yes
+    - env: TOXENV=py27-dj111-sqlite-noelasticsearch
+    - env: TOXENV=py27-dj111-postgres-noelasticsearch
+    - env: TOXENV=py27-dj111-mysql-noelasticsearch
+    - env: TOXENV=py27-dj111-postgres-elasticsearch5 INSTALL_ELASTICSEARCH5=yes
     - env: TOXENV=py35-dj110-postgres-elasticsearch
     - env: TOXENV=py35-dj110-postgres-elasticsearch2 INSTALL_ELASTICSEARCH2=yes
-    - env: TOXENV=py27-dj110-mysql-elasticsearch5 INSTALL_ELASTICSEARCH5=yes
     - env: TOXENV=py35-dj110-postgres-elasticsearch5 INSTALL_ELASTICSEARCH5=yes
+    - env: TOXENV=py35-dj111-sqlite-noelasticsearch
+    - env: TOXENV=py35-dj111-postgres-noelasticsearch
+    - env: TOXENV=py35-dj111-mysql-noelasticsearch
+    - env: TOXENV=py35-dj111-postgres-elasticsearch
+    - env: TOXENV=py35-dj111-postgres-elasticsearch2 INSTALL_ELASTICSEARCH2=yes
+    - env: TOXENV=py35-dj111-postgres-elasticsearch5 INSTALL_ELASTICSEARCH5=yes
 
 # Services
 services:

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ deps =
     dj18: Django>=1.8.1,<1.9
     dj110: Django>=1.10a1,<1.11
     dj110head: git+https://github.com/django/django.git@stable/1.10.x#egg=Django
-    dj111: Django>=1.11b1,<1.12
+    dj111: Django>=1.11b1,<2.0
     postgres: psycopg2>=2.6
     mysql: mysqlclient==1.3.6
     elasticsearch: elasticsearch>=1,<2

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 skipsdist = True
 usedevelop = True
 
-envlist = py{27,34,35}-dj{18,110,110head,dj11}-{sqlite,postgres,mysql}-{elasticsearch5,elasticsearch2,elasticsearch,noelasticsearch},
+envlist = py{27,34,35}-dj{18,110,110head,111}-{sqlite,postgres,mysql}-{elasticsearch5,elasticsearch2,elasticsearch,noelasticsearch},
           flake8
 
 [testenv]
@@ -25,7 +25,7 @@ deps =
     dj18: Django>=1.8.1,<1.9
     dj110: Django>=1.10a1,<1.11
     dj110head: git+https://github.com/django/django.git@stable/1.10.x#egg=Django
-    dj11: Django>=1.11b1,<1.12
+    dj111: Django>=1.11b1,<1.12
     postgres: psycopg2>=2.6
     mysql: mysqlclient==1.3.6
     elasticsearch: elasticsearch>=1,<2

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,8 @@
 skipsdist = True
 usedevelop = True
 
-envlist = py{27,34,35}-dj{18,110,110head,111}-{sqlite,postgres,mysql}-{elasticsearch5,elasticsearch2,elasticsearch,noelasticsearch},
+envlist = py{27,34,35}-dj{18,110,110head}-{sqlite,postgres,mysql}-{elasticsearch5,elasticsearch2,elasticsearch,noelasticsearch},
+          py{27,34,35,36}-dj111-{sqlite,postgres,mysql}-{elasticsearch5,elasticsearch2,elasticsearch,noelasticsearch},
           flake8
 
 [testenv]
@@ -17,6 +18,7 @@ basepython =
     py27: python2.7
     py34: python3.4
     py35: python3.5
+    py36: python3.6
 
 deps =
     django-sendfile==0.3.6

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,7 @@
 skipsdist = True
 usedevelop = True
 
-envlist = py{27,34,35}-dj18-{sqlite,postgres,mysql}-{elasticsearch5,elasticsearch2,elasticsearch,noelasticsearch},
-          py{27,34,35}-dj{110,110head}-{sqlite,postgres,mysql}-{elasticsearch5,elasticsearch2,elasticsearch,noelasticsearch},
+envlist = py{27,34,35}-dj{18,110,110head,dj11}-{sqlite,postgres,mysql}-{elasticsearch5,elasticsearch2,elasticsearch,noelasticsearch},
           flake8
 
 [testenv]
@@ -26,6 +25,7 @@ deps =
     dj18: Django>=1.8.1,<1.9
     dj110: Django>=1.10a1,<1.11
     dj110head: git+https://github.com/django/django.git@stable/1.10.x#egg=Django
+    dj11: Django>=1.11b1,<1.12
     postgres: psycopg2>=2.6
     mysql: mysqlclient==1.3.6
     elasticsearch: elasticsearch>=1,<2

--- a/wagtail/tests/utils.py
+++ b/wagtail/tests/utils.py
@@ -156,6 +156,9 @@ class WagtailTestUtils(object):
         else:
             self.assertTrue(real_count != 0, msg_prefix + "Couldn't find '%s' in response" % needle)
 
+    def assertNotInHTML(self, needle, haystack, msg_prefix=''):
+        self.assertInHTML(needle, haystack, count=0, msg_prefix=msg_prefix)
+
 
 class WagtailPageTests(WagtailTestUtils, TestCase):
     """

--- a/wagtail/wagtailadmin/tests/test_edit_handlers.py
+++ b/wagtail/wagtailadmin/tests/test_edit_handlers.py
@@ -695,12 +695,24 @@ class TestInlinePanel(TestCase, WagtailTestUtils):
         self.assertIn('Choose an image', result)
 
         # rendered panel must also contain hidden fields for id, DELETE and ORDER
-        self.assertIn('<input id="id_speakers-0-id" name="speakers-0-id" type="hidden"', result)
-        self.assertIn('<input id="id_speakers-0-DELETE" name="speakers-0-DELETE" type="hidden"', result)
-        self.assertIn('<input id="id_speakers-0-ORDER" name="speakers-0-ORDER" type="hidden"', result)
+        self.assertTagInHTML(
+            '<input id="id_speakers-0-id" name="speakers-0-id" type="hidden">',
+            result, allow_extra_attrs=True
+        )
+        self.assertTagInHTML(
+            '<input id="id_speakers-0-DELETE" name="speakers-0-DELETE" type="hidden">',
+            result, allow_extra_attrs=True
+        )
+        self.assertTagInHTML(
+            '<input id="id_speakers-0-ORDER" name="speakers-0-ORDER" type="hidden">',
+            result, allow_extra_attrs=True
+        )
 
         # rendered panel must contain maintenance form for the formset
-        self.assertIn('<input id="id_speakers-TOTAL_FORMS" name="speakers-TOTAL_FORMS" type="hidden"', result)
+        self.assertTagInHTML(
+            '<input id="id_speakers-TOTAL_FORMS" name="speakers-TOTAL_FORMS" type="hidden">',
+            result, allow_extra_attrs=True
+        )
 
         # rendered panel must include the JS initializer
         self.assertIn('var panel = InlinePanel({', result)
@@ -735,18 +747,30 @@ class TestInlinePanel(TestCase, WagtailTestUtils):
         self.assertNotIn('<label for="id_speakers-0-last_name">Surname:</label>', result)
 
         # test for #338: surname field should not be rendered as a 'stray' label-less field
-        self.assertNotIn('<input id="id_speakers-0-last_name"', result)
+        self.assertTagInHTML('<input id="id_speakers-0-last_name">', result, count=0, allow_extra_attrs=True)
 
         self.assertIn('<label for="id_speakers-0-image">Image:</label>', result)
         self.assertIn('Choose an image', result)
 
         # rendered panel must also contain hidden fields for id, DELETE and ORDER
-        self.assertIn('<input id="id_speakers-0-id" name="speakers-0-id" type="hidden"', result)
-        self.assertIn('<input id="id_speakers-0-DELETE" name="speakers-0-DELETE" type="hidden"', result)
-        self.assertIn('<input id="id_speakers-0-ORDER" name="speakers-0-ORDER" type="hidden"', result)
+        self.assertTagInHTML(
+            '<input id="id_speakers-0-id" name="speakers-0-id" type="hidden">',
+            result, allow_extra_attrs=True
+        )
+        self.assertTagInHTML(
+            '<input id="id_speakers-0-DELETE" name="speakers-0-DELETE" type="hidden">',
+            result, allow_extra_attrs=True
+        )
+        self.assertTagInHTML(
+            '<input id="id_speakers-0-ORDER" name="speakers-0-ORDER" type="hidden">',
+            result, allow_extra_attrs=True
+        )
 
         # rendered panel must contain maintenance form for the formset
-        self.assertIn('<input id="id_speakers-TOTAL_FORMS" name="speakers-TOTAL_FORMS" type="hidden"', result)
+        self.assertTagInHTML(
+            '<input id="id_speakers-TOTAL_FORMS" name="speakers-TOTAL_FORMS" type="hidden">',
+            result, allow_extra_attrs=True
+        )
 
         # render_js_init must provide the JS initializer
         self.assertIn('var panel = InlinePanel({', panel.render_js_init())

--- a/wagtail/wagtailadmin/tests/test_pages_views.py
+++ b/wagtail/wagtailadmin/tests/test_pages_views.py
@@ -3334,7 +3334,9 @@ class TestChildRelationsOnSuperclass(TestCase, WagtailTestUtils):
         self.assertContains(response, "id_advert_placements-TOTAL_FORMS")
         # the formset should be populated with an existing form
         self.assertContains(response, "id_advert_placements-0-advert")
-        self.assertContains(response, '<option value="1" selected="selected">test_advert</option>')
+        self.assertContains(
+            response, '<option value="1" selected="selected">test_advert</option>', html=True
+        )
 
     def test_post_edit_form(self):
         post_data = {

--- a/wagtail/wagtailadmin/tests/test_widgets.py
+++ b/wagtail/wagtailadmin/tests/test_widgets.py
@@ -26,7 +26,7 @@ class TestAdminPageChooserWidget(TestCase):
         widget = widgets.AdminPageChooser()
 
         html = widget.render_html('test', None, {})
-        self.assertIn("<input name=\"test\" type=\"hidden\" />", html)
+        self.assertInHTML("""<input name="test" type="hidden" />""", html)
 
     def test_render_js_init(self):
         widget = widgets.AdminPageChooser()
@@ -38,7 +38,7 @@ class TestAdminPageChooserWidget(TestCase):
         widget = widgets.AdminPageChooser()
 
         html = widget.render_html('test', self.child_page, {})
-        self.assertIn("<input name=\"test\" type=\"hidden\" value=\"%d\" />" % self.child_page.id, html)
+        self.assertInHTML("""<input name="test" type="hidden" value="%d" />""" % self.child_page.id, html)
 
     def test_render_js_init_with_value(self):
         widget = widgets.AdminPageChooser()

--- a/wagtail/wagtailcore/tests/test_blocks.py
+++ b/wagtail/wagtailcore/tests/test_blocks.py
@@ -50,7 +50,7 @@ class ContextCharBlock(blocks.CharBlock):
         return super(blocks.CharBlock, self).get_context(value, parent_context)
 
 
-class TestFieldBlock(unittest.TestCase):
+class TestFieldBlock(SimpleTestCase):
     def test_charfield_render(self):
         block = blocks.CharBlock()
         html = block.render("Hello world!")
@@ -100,13 +100,13 @@ class TestFieldBlock(unittest.TestCase):
         html = block.render_form("Hello world!")
 
         self.assertIn('<div class="field char_field widget-text_input">', html)
-        self.assertIn('<input id="" name="" placeholder="" type="text" value="Hello world!" />', html)
+        self.assertInHTML('<input id="" name="" placeholder="" type="text" value="Hello world!" />', html)
 
     def test_charfield_render_form_with_prefix(self):
         block = blocks.CharBlock()
         html = block.render_form("Hello world!", prefix='foo')
 
-        self.assertIn('<input id="foo" name="foo" placeholder="" type="text" value="Hello world!" />', html)
+        self.assertInHTML('<input id="foo" name="foo" placeholder="" type="text" value="Hello world!" />', html)
 
     def test_charfield_render_form_with_error(self):
         block = blocks.CharBlock()
@@ -145,7 +145,7 @@ class TestFieldBlock(unittest.TestCase):
         html = block.render_form('choice-2')
 
         self.assertIn('<div class="field choice_field widget-select">', html)
-        self.assertIn('<select id="" name="" placeholder="">', html)
+        self.assertInHTML('<select id="" name="" placeholder="">', html)
         self.assertIn('<option value="choice-1">Choice 1</option>', html)
         self.assertIn('<option value="choice-2" selected="selected">Choice 2</option>', html)
 
@@ -448,7 +448,7 @@ class TestRichTextBlock(TestCase):
         self.assertEqual(result.source, '')
 
 
-class TestChoiceBlock(unittest.TestCase):
+class TestChoiceBlock(SimpleTestCase):
     def setUp(self):
         from django.db.models.fields import BLANK_CHOICE_DASH
         self.blank_choice_dash_label = BLANK_CHOICE_DASH[0][1]
@@ -456,7 +456,7 @@ class TestChoiceBlock(unittest.TestCase):
     def test_render_required_choice_block(self):
         block = blocks.ChoiceBlock(choices=[('tea', 'Tea'), ('coffee', 'Coffee')])
         html = block.render_form('coffee', prefix='beverage')
-        self.assertIn('<select id="beverage" name="beverage" placeholder="">', html)
+        self.assertInHTML('<select id="beverage" name="beverage" placeholder="">', html)
         # blank option should still be rendered for required fields
         # (we may want it as an initial value)
         self.assertIn('<option value="">%s</option>' % self.blank_choice_dash_label, html)
@@ -466,7 +466,7 @@ class TestChoiceBlock(unittest.TestCase):
     def test_render_required_choice_block_with_default(self):
         block = blocks.ChoiceBlock(choices=[('tea', 'Tea'), ('coffee', 'Coffee')], default='tea')
         html = block.render_form('coffee', prefix='beverage')
-        self.assertIn('<select id="beverage" name="beverage" placeholder="">', html)
+        self.assertInHTML('<select id="beverage" name="beverage" placeholder="">', html)
         # blank option should NOT be rendered if default and required are set.
         self.assertNotIn('<option value="">%s</option>' % self.blank_choice_dash_label, html)
         self.assertIn('<option value="tea">Tea</option>', html)
@@ -478,7 +478,7 @@ class TestChoiceBlock(unittest.TestCase):
 
         block = blocks.ChoiceBlock(choices=callable_choices)
         html = block.render_form('coffee', prefix='beverage')
-        self.assertIn('<select id="beverage" name="beverage" placeholder="">', html)
+        self.assertInHTML('<select id="beverage" name="beverage" placeholder="">', html)
         # blank option should still be rendered for required fields
         # (we may want it as an initial value)
         self.assertIn('<option value="">%s</option>' % self.blank_choice_dash_label, html)
@@ -501,7 +501,7 @@ class TestChoiceBlock(unittest.TestCase):
     def test_render_non_required_choice_block(self):
         block = blocks.ChoiceBlock(choices=[('tea', 'Tea'), ('coffee', 'Coffee')], required=False)
         html = block.render_form('coffee', prefix='beverage')
-        self.assertIn('<select id="beverage" name="beverage" placeholder="">', html)
+        self.assertInHTML('<select id="beverage" name="beverage" placeholder="">', html)
         self.assertIn('<option value="">%s</option>' % self.blank_choice_dash_label, html)
         self.assertIn('<option value="tea">Tea</option>', html)
         self.assertIn('<option value="coffee" selected="selected">Coffee</option>', html)
@@ -512,7 +512,7 @@ class TestChoiceBlock(unittest.TestCase):
 
         block = blocks.ChoiceBlock(choices=callable_choices, required=False)
         html = block.render_form('coffee', prefix='beverage')
-        self.assertIn('<select id="beverage" name="beverage" placeholder="">', html)
+        self.assertInHTML('<select id="beverage" name="beverage" placeholder="">', html)
         self.assertIn('<option value="">%s</option>' % self.blank_choice_dash_label, html)
         self.assertIn('<option value="tea">Tea</option>', html)
         self.assertIn('<option value="coffee" selected="selected">Coffee</option>', html)
@@ -532,7 +532,7 @@ class TestChoiceBlock(unittest.TestCase):
             choices=[('tea', 'Tea'), ('coffee', 'Coffee'), ('', 'No thanks')],
             required=False)
         html = block.render_form(None, prefix='beverage')
-        self.assertIn('<select id="beverage" name="beverage" placeholder="">', html)
+        self.assertInHTML('<select id="beverage" name="beverage" placeholder="">', html)
         self.assertNotIn('<option value="">%s</option>' % self.blank_choice_dash_label, html)
         self.assertIn('<option value="" selected="selected">No thanks</option>', html)
         self.assertIn('<option value="tea">Tea</option>', html)
@@ -546,7 +546,7 @@ class TestChoiceBlock(unittest.TestCase):
             choices=callable_choices,
             required=False)
         html = block.render_form(None, prefix='beverage')
-        self.assertIn('<select id="beverage" name="beverage" placeholder="">', html)
+        self.assertInHTML('<select id="beverage" name="beverage" placeholder="">', html)
         self.assertNotIn('<option value="">%s</option>' % self.blank_choice_dash_label, html)
         self.assertIn('<option value="" selected="selected">No thanks</option>', html)
         self.assertIn('<option value="tea">Tea</option>', html)
@@ -567,14 +567,14 @@ class TestChoiceBlock(unittest.TestCase):
 
         # test rendering with the blank option selected
         html = block.render_form(None, prefix='beverage')
-        self.assertIn('<select id="beverage" name="beverage" placeholder="">', html)
+        self.assertInHTML('<select id="beverage" name="beverage" placeholder="">', html)
         self.assertIn('<option value="" selected="selected">%s</option>' % self.blank_choice_dash_label, html)
         self.assertIn('<optgroup label="Alcoholic">', html)
         self.assertIn('<option value="tea">Tea</option>', html)
 
         # test rendering with a non-blank option selected
         html = block.render_form('tea', prefix='beverage')
-        self.assertIn('<select id="beverage" name="beverage" placeholder="">', html)
+        self.assertInHTML('<select id="beverage" name="beverage" placeholder="">', html)
         self.assertIn('<option value="">%s</option>' % self.blank_choice_dash_label, html)
         self.assertIn('<optgroup label="Alcoholic">', html)
         self.assertIn('<option value="tea" selected="selected">Tea</option>', html)
@@ -598,7 +598,7 @@ class TestChoiceBlock(unittest.TestCase):
 
         # test rendering with the blank option selected
         html = block.render_form(None, prefix='beverage')
-        self.assertIn('<select id="beverage" name="beverage" placeholder="">', html)
+        self.assertInHTML('<select id="beverage" name="beverage" placeholder="">', html)
         self.assertNotIn('<option value="">%s</option>' % self.blank_choice_dash_label, html)
         self.assertNotIn('<option value="" selected="selected">%s</option>' % self.blank_choice_dash_label, html)
         self.assertIn('<optgroup label="Alcoholic">', html)
@@ -607,7 +607,7 @@ class TestChoiceBlock(unittest.TestCase):
 
         # test rendering with a non-blank option selected
         html = block.render_form('tea', prefix='beverage')
-        self.assertIn('<select id="beverage" name="beverage" placeholder="">', html)
+        self.assertInHTML('<select id="beverage" name="beverage" placeholder="">', html)
         self.assertNotIn('<option value="">%s</option>' % self.blank_choice_dash_label, html)
         self.assertNotIn('<option value="" selected="selected">%s</option>' % self.blank_choice_dash_label, html)
         self.assertIn('<optgroup label="Alcoholic">', html)
@@ -622,7 +622,7 @@ class TestChoiceBlock(unittest.TestCase):
 
         block = BeverageChoiceBlock(required=False)
         html = block.render_form('tea', prefix='beverage')
-        self.assertIn('<select id="beverage" name="beverage" placeholder="">', html)
+        self.assertInHTML('<select id="beverage" name="beverage" placeholder="">', html)
         self.assertIn('<option value="tea" selected="selected">Tea</option>', html)
 
         # subclasses of ChoiceBlock should deconstruct to a basic ChoiceBlock for migrations
@@ -1075,11 +1075,11 @@ class TestStructBlock(SimpleTestCase):
         self.assertIn('<div class="struct-block">', html)
         self.assertIn('<div class="field char_field widget-text_input fieldname-title">', html)
         self.assertIn('<label for="mylink-title">Title:</label>', html)
-        self.assertIn(
+        self.assertInHTML(
             '<input id="mylink-title" name="mylink-title" placeholder="Title" type="text" value="Wagtail site" />', html
         )
         self.assertIn('<div class="field url_field widget-url_input fieldname-link">', html)
-        self.assertIn(
+        self.assertInHTML(
             (
                 '<input id="mylink-link" name="mylink-link" placeholder="Link"'
                 ' type="url" value="http://www.wagtail.io" />'
@@ -1113,14 +1113,14 @@ class TestStructBlock(SimpleTestCase):
             'image': 10,
         }), prefix='mylink')
 
-        self.assertIn(
+        self.assertInHTML(
             (
                 '<input id="mylink-title" name="mylink-title" placeholder="Title"'
                 ' type="text" value="Wagtail site" />'
             ),
             html
         )
-        self.assertIn(
+        self.assertInHTML(
             (
                 '<input id="mylink-link" name="mylink-link" placeholder="Link" type="url"'
                 ' value="http://www.wagtail.io" />'
@@ -1139,10 +1139,10 @@ class TestStructBlock(SimpleTestCase):
         block = LinkBlock()
         html = block.render_form(block.to_python({}), prefix='mylink')
 
-        self.assertIn(
+        self.assertInHTML(
             '<input id="mylink-title" name="mylink-title" placeholder="Title" type="text" value="Torchbox" />', html
         )
-        self.assertIn(
+        self.assertInHTML(
             (
                 '<input id="mylink-link" name="mylink-link" placeholder="Link"'
                 ' type="url" value="http://www.torchbox.com" />'
@@ -1308,7 +1308,7 @@ class TestStructBlock(SimpleTestCase):
         self.assertEqual(result, """<h1 lang="fr">Bonjour</h1><div class="rich-text">monde <i>italique</i></div>""")
 
 
-class TestListBlock(unittest.TestCase):
+class TestListBlock(SimpleTestCase):
     def test_initialise_with_class(self):
         block = blocks.ListBlock(blocks.CharBlock)
 
@@ -1450,7 +1450,7 @@ class TestListBlock(unittest.TestCase):
     def test_render_form_values(self):
         html = self.render_form()
 
-        self.assertIn(
+        self.assertInHTML(
             (
                 '<input id="links-0-value-title" name="links-0-value-title" placeholder="Title"'
                 ' type="text" value="Wagtail" />'
@@ -1487,11 +1487,11 @@ class TestListBlock(unittest.TestCase):
         block = blocks.ListBlock(LinkBlock)
         html = block.html_declarations()
 
-        self.assertIn(
+        self.assertInHTML(
             '<input id="__PREFIX__-value-title" name="__PREFIX__-value-title" placeholder="Title" type="text" />',
             html
         )
-        self.assertIn(
+        self.assertInHTML(
             '<input id="__PREFIX__-value-link" name="__PREFIX__-value-link" placeholder="Link" type="url" />',
             html
         )
@@ -1504,14 +1504,14 @@ class TestListBlock(unittest.TestCase):
         block = blocks.ListBlock(LinkBlock)
         html = block.html_declarations()
 
-        self.assertIn(
+        self.assertInHTML(
             (
                 '<input id="__PREFIX__-value-title" name="__PREFIX__-value-title" placeholder="Title"'
                 ' type="text" value="Github" />'
             ),
             html
         )
-        self.assertIn(
+        self.assertInHTML(
             (
                 '<input id="__PREFIX__-value-link" name="__PREFIX__-value-link" placeholder="Link"'
                 ' type="url" value="http://www.github.com" />'
@@ -1918,21 +1918,21 @@ class TestStreamBlock(SimpleTestCase):
     def test_render_form_value_fields(self):
         html = self.render_form()
 
-        self.assertIn(
+        self.assertInHTML(
             (
                 '<input id="myarticle-0-value" name="myarticle-0-value" placeholder="Heading"'
                 ' type="text" value="My title" />'
             ),
             html
         )
-        self.assertIn(
+        self.assertInHTML(
             (
                 '<input id="myarticle-1-value" name="myarticle-1-value" placeholder="Paragraph"'
                 ' type="text" value="My first paragraph" />'
             ),
             html
         )
-        self.assertIn(
+        self.assertInHTML(
             (
                 '<input id="myarticle-2-value" name="myarticle-2-value" placeholder="Paragraph"'
                 ' type="text" value="My second paragraph" />'
@@ -2043,8 +2043,8 @@ class TestStreamBlock(SimpleTestCase):
         block = ArticleBlock()
         html = block.html_declarations()
 
-        self.assertIn('<input id="__PREFIX__-value" name="__PREFIX__-value" placeholder="Heading" type="text" />', html)
-        self.assertIn(
+        self.assertInHTML('<input id="__PREFIX__-value" name="__PREFIX__-value" placeholder="Heading" type="text" />', html)
+        self.assertInHTML(
             '<input id="__PREFIX__-value" name="__PREFIX__-value" placeholder="Paragraph" type="text" />',
             html
         )
@@ -2057,14 +2057,14 @@ class TestStreamBlock(SimpleTestCase):
         block = ArticleBlock()
         html = block.html_declarations()
 
-        self.assertIn(
+        self.assertInHTML(
             (
                 '<input id="__PREFIX__-value" name="__PREFIX__-value" placeholder="Heading"'
                 ' type="text" value="Fish found on moon" />'
             ),
             html
         )
-        self.assertIn(
+        self.assertInHTML(
             (
                 '<input id="__PREFIX__-value" name="__PREFIX__-value" placeholder="Paragraph" type="text"'
                 ' value="Lorem ipsum dolor sit amet" />'

--- a/wagtail/wagtailcore/tests/test_blocks.py
+++ b/wagtail/wagtailcore/tests/test_blocks.py
@@ -1310,7 +1310,7 @@ class TestStructBlock(SimpleTestCase):
         self.assertEqual(result, """<h1 lang="fr">Bonjour</h1><div class="rich-text">monde <i>italique</i></div>""")
 
 
-class TestListBlock(SimpleTestCase, WagtailTestUtils):
+class TestListBlock(WagtailTestUtils, SimpleTestCase):
     def test_initialise_with_class(self):
         block = blocks.ListBlock(blocks.CharBlock)
 
@@ -1632,7 +1632,7 @@ class TestListBlock(SimpleTestCase, WagtailTestUtils):
         self.assertIn('value="chocolate"', form_html)
 
 
-class TestStreamBlock(SimpleTestCase, WagtailTestUtils):
+class TestStreamBlock(WagtailTestUtils, SimpleTestCase):
     def test_initialisation(self):
         block = blocks.StreamBlock([
             ('heading', blocks.CharBlock()),

--- a/wagtail/wagtailcore/tests/test_blocks.py
+++ b/wagtail/wagtailcore/tests/test_blocks.py
@@ -1310,7 +1310,7 @@ class TestStructBlock(SimpleTestCase):
         self.assertEqual(result, """<h1 lang="fr">Bonjour</h1><div class="rich-text">monde <i>italique</i></div>""")
 
 
-class TestListBlock(SimpleTestCase):
+class TestListBlock(SimpleTestCase, WagtailTestUtils):
     def test_initialise_with_class(self):
         block = blocks.ListBlock(blocks.CharBlock)
 
@@ -1489,11 +1489,11 @@ class TestListBlock(SimpleTestCase):
         block = blocks.ListBlock(LinkBlock)
         html = block.html_declarations()
 
-        self.assertInHTML(
+        self.assertTagInTemplateScript(
             '<input id="__PREFIX__-value-title" name="__PREFIX__-value-title" placeholder="Title" type="text" />',
             html
         )
-        self.assertInHTML(
+        self.assertTagInTemplateScript(
             '<input id="__PREFIX__-value-link" name="__PREFIX__-value-link" placeholder="Link" type="url" />',
             html
         )
@@ -1506,14 +1506,14 @@ class TestListBlock(SimpleTestCase):
         block = blocks.ListBlock(LinkBlock)
         html = block.html_declarations()
 
-        self.assertInHTML(
+        self.assertTagInTemplateScript(
             (
                 '<input id="__PREFIX__-value-title" name="__PREFIX__-value-title" placeholder="Title"'
                 ' type="text" value="Github" />'
             ),
             html
         )
-        self.assertInHTML(
+        self.assertTagInTemplateScript(
             (
                 '<input id="__PREFIX__-value-link" name="__PREFIX__-value-link" placeholder="Link"'
                 ' type="url" value="http://www.github.com" />'
@@ -1632,7 +1632,7 @@ class TestListBlock(SimpleTestCase):
         self.assertIn('value="chocolate"', form_html)
 
 
-class TestStreamBlock(SimpleTestCase):
+class TestStreamBlock(SimpleTestCase, WagtailTestUtils):
     def test_initialisation(self):
         block = blocks.StreamBlock([
             ('heading', blocks.CharBlock()),
@@ -2045,8 +2045,8 @@ class TestStreamBlock(SimpleTestCase):
         block = ArticleBlock()
         html = block.html_declarations()
 
-        self.assertInHTML('<input id="__PREFIX__-value" name="__PREFIX__-value" placeholder="Heading" type="text" />', html)
-        self.assertInHTML(
+        self.assertTagInTemplateScript('<input id="__PREFIX__-value" name="__PREFIX__-value" placeholder="Heading" type="text" />', html)
+        self.assertTagInTemplateScript(
             '<input id="__PREFIX__-value" name="__PREFIX__-value" placeholder="Paragraph" type="text" />',
             html
         )
@@ -2059,14 +2059,14 @@ class TestStreamBlock(SimpleTestCase):
         block = ArticleBlock()
         html = block.html_declarations()
 
-        self.assertInHTML(
+        self.assertTagInTemplateScript(
             (
                 '<input id="__PREFIX__-value" name="__PREFIX__-value" placeholder="Heading"'
                 ' type="text" value="Fish found on moon" />'
             ),
             html
         )
-        self.assertInHTML(
+        self.assertTagInTemplateScript(
             (
                 '<input id="__PREFIX__-value" name="__PREFIX__-value" placeholder="Paragraph" type="text"'
                 ' value="Lorem ipsum dolor sit amet" />'

--- a/wagtail/wagtailcore/tests/test_blocks.py
+++ b/wagtail/wagtailcore/tests/test_blocks.py
@@ -22,6 +22,7 @@ from django.utils.translation import ugettext_lazy as __
 from wagtail.tests.testapp.blocks import LinkBlock as CustomLinkBlock
 from wagtail.tests.testapp.blocks import SectionBlock
 from wagtail.tests.testapp.models import EventPage, SimplePage
+from wagtail.tests.utils import WagtailTestUtils
 from wagtail.utils.deprecation import RemovedInWagtail111Warning
 from wagtail.wagtailcore import blocks
 from wagtail.wagtailcore.models import Page
@@ -50,7 +51,7 @@ class ContextCharBlock(blocks.CharBlock):
         return super(blocks.CharBlock, self).get_context(value, parent_context)
 
 
-class TestFieldBlock(SimpleTestCase):
+class TestFieldBlock(SimpleTestCase, WagtailTestUtils):
     def test_charfield_render(self):
         block = blocks.CharBlock()
         html = block.render("Hello world!")
@@ -145,9 +146,9 @@ class TestFieldBlock(SimpleTestCase):
         html = block.render_form('choice-2')
 
         self.assertIn('<div class="field choice_field widget-select">', html)
-        self.assertInHTML('<select id="" name="" placeholder="">', html)
-        self.assertIn('<option value="choice-1">Choice 1</option>', html)
-        self.assertIn('<option value="choice-2" selected="selected">Choice 2</option>', html)
+        self.assertTagInHTML('<select id="" name="" placeholder="">', html)
+        self.assertInHTML('<option value="choice-1">Choice 1</option>', html)
+        self.assertInHTML('<option value="choice-2" selected="selected">Choice 2</option>', html)
 
     def test_searchable_content(self):
         """
@@ -448,7 +449,7 @@ class TestRichTextBlock(TestCase):
         self.assertEqual(result.source, '')
 
 
-class TestChoiceBlock(SimpleTestCase):
+class TestChoiceBlock(SimpleTestCase, WagtailTestUtils):
     def setUp(self):
         from django.db.models.fields import BLANK_CHOICE_DASH
         self.blank_choice_dash_label = BLANK_CHOICE_DASH[0][1]
@@ -456,21 +457,21 @@ class TestChoiceBlock(SimpleTestCase):
     def test_render_required_choice_block(self):
         block = blocks.ChoiceBlock(choices=[('tea', 'Tea'), ('coffee', 'Coffee')])
         html = block.render_form('coffee', prefix='beverage')
-        self.assertInHTML('<select id="beverage" name="beverage" placeholder="">', html)
+        self.assertTagInHTML('<select id="beverage" name="beverage" placeholder="">', html)
         # blank option should still be rendered for required fields
         # (we may want it as an initial value)
         self.assertIn('<option value="">%s</option>' % self.blank_choice_dash_label, html)
         self.assertIn('<option value="tea">Tea</option>', html)
-        self.assertIn('<option value="coffee" selected="selected">Coffee</option>', html)
+        self.assertInHTML('<option value="coffee" selected="selected">Coffee</option>', html)
 
     def test_render_required_choice_block_with_default(self):
         block = blocks.ChoiceBlock(choices=[('tea', 'Tea'), ('coffee', 'Coffee')], default='tea')
         html = block.render_form('coffee', prefix='beverage')
-        self.assertInHTML('<select id="beverage" name="beverage" placeholder="">', html)
+        self.assertTagInHTML('<select id="beverage" name="beverage" placeholder="">', html)
         # blank option should NOT be rendered if default and required are set.
         self.assertNotIn('<option value="">%s</option>' % self.blank_choice_dash_label, html)
         self.assertIn('<option value="tea">Tea</option>', html)
-        self.assertIn('<option value="coffee" selected="selected">Coffee</option>', html)
+        self.assertInHTML('<option value="coffee" selected="selected">Coffee</option>', html)
 
     def test_render_required_choice_block_with_callable_choices(self):
         def callable_choices():
@@ -478,12 +479,12 @@ class TestChoiceBlock(SimpleTestCase):
 
         block = blocks.ChoiceBlock(choices=callable_choices)
         html = block.render_form('coffee', prefix='beverage')
-        self.assertInHTML('<select id="beverage" name="beverage" placeholder="">', html)
+        self.assertTagInHTML('<select id="beverage" name="beverage" placeholder="">', html)
         # blank option should still be rendered for required fields
         # (we may want it as an initial value)
         self.assertIn('<option value="">%s</option>' % self.blank_choice_dash_label, html)
         self.assertIn('<option value="tea">Tea</option>', html)
-        self.assertIn('<option value="coffee" selected="selected">Coffee</option>', html)
+        self.assertInHTML('<option value="coffee" selected="selected">Coffee</option>', html)
 
     def test_validate_required_choice_block(self):
         block = blocks.ChoiceBlock(choices=[('tea', 'Tea'), ('coffee', 'Coffee')])
@@ -501,10 +502,10 @@ class TestChoiceBlock(SimpleTestCase):
     def test_render_non_required_choice_block(self):
         block = blocks.ChoiceBlock(choices=[('tea', 'Tea'), ('coffee', 'Coffee')], required=False)
         html = block.render_form('coffee', prefix='beverage')
-        self.assertInHTML('<select id="beverage" name="beverage" placeholder="">', html)
+        self.assertTagInHTML('<select id="beverage" name="beverage" placeholder="">', html)
         self.assertIn('<option value="">%s</option>' % self.blank_choice_dash_label, html)
         self.assertIn('<option value="tea">Tea</option>', html)
-        self.assertIn('<option value="coffee" selected="selected">Coffee</option>', html)
+        self.assertInHTML('<option value="coffee" selected="selected">Coffee</option>', html)
 
     def test_render_non_required_choice_block_with_callable_choices(self):
         def callable_choices():
@@ -512,10 +513,10 @@ class TestChoiceBlock(SimpleTestCase):
 
         block = blocks.ChoiceBlock(choices=callable_choices, required=False)
         html = block.render_form('coffee', prefix='beverage')
-        self.assertInHTML('<select id="beverage" name="beverage" placeholder="">', html)
+        self.assertTagInHTML('<select id="beverage" name="beverage" placeholder="">', html)
         self.assertIn('<option value="">%s</option>' % self.blank_choice_dash_label, html)
         self.assertIn('<option value="tea">Tea</option>', html)
-        self.assertIn('<option value="coffee" selected="selected">Coffee</option>', html)
+        self.assertInHTML('<option value="coffee" selected="selected">Coffee</option>', html)
 
     def test_validate_non_required_choice_block(self):
         block = blocks.ChoiceBlock(choices=[('tea', 'Tea'), ('coffee', 'Coffee')], required=False)
@@ -532,11 +533,11 @@ class TestChoiceBlock(SimpleTestCase):
             choices=[('tea', 'Tea'), ('coffee', 'Coffee'), ('', 'No thanks')],
             required=False)
         html = block.render_form(None, prefix='beverage')
-        self.assertInHTML('<select id="beverage" name="beverage" placeholder="">', html)
+        self.assertTagInHTML('<select id="beverage" name="beverage" placeholder="">', html)
         self.assertNotIn('<option value="">%s</option>' % self.blank_choice_dash_label, html)
-        self.assertIn('<option value="" selected="selected">No thanks</option>', html)
+        self.assertInHTML('<option value="" selected="selected">No thanks</option>', html)
         self.assertIn('<option value="tea">Tea</option>', html)
-        self.assertIn('<option value="coffee">Coffee</option>', html)
+        self.assertInHTML('<option value="coffee">Coffee</option>', html)
 
     def test_render_choice_block_with_existing_blank_choice_and_with_callable_choices(self):
         def callable_choices():
@@ -546,9 +547,9 @@ class TestChoiceBlock(SimpleTestCase):
             choices=callable_choices,
             required=False)
         html = block.render_form(None, prefix='beverage')
-        self.assertInHTML('<select id="beverage" name="beverage" placeholder="">', html)
+        self.assertTagInHTML('<select id="beverage" name="beverage" placeholder="">', html)
         self.assertNotIn('<option value="">%s</option>' % self.blank_choice_dash_label, html)
-        self.assertIn('<option value="" selected="selected">No thanks</option>', html)
+        self.assertInHTML('<option value="" selected="selected">No thanks</option>', html)
         self.assertIn('<option value="tea">Tea</option>', html)
         self.assertIn('<option value="coffee">Coffee</option>', html)
 
@@ -567,17 +568,17 @@ class TestChoiceBlock(SimpleTestCase):
 
         # test rendering with the blank option selected
         html = block.render_form(None, prefix='beverage')
-        self.assertInHTML('<select id="beverage" name="beverage" placeholder="">', html)
-        self.assertIn('<option value="" selected="selected">%s</option>' % self.blank_choice_dash_label, html)
+        self.assertTagInHTML('<select id="beverage" name="beverage" placeholder="">', html)
+        self.assertInHTML('<option value="" selected="selected">%s</option>' % self.blank_choice_dash_label, html)
         self.assertIn('<optgroup label="Alcoholic">', html)
         self.assertIn('<option value="tea">Tea</option>', html)
 
         # test rendering with a non-blank option selected
         html = block.render_form('tea', prefix='beverage')
-        self.assertInHTML('<select id="beverage" name="beverage" placeholder="">', html)
+        self.assertTagInHTML('<select id="beverage" name="beverage" placeholder="">', html)
         self.assertIn('<option value="">%s</option>' % self.blank_choice_dash_label, html)
         self.assertIn('<optgroup label="Alcoholic">', html)
-        self.assertIn('<option value="tea" selected="selected">Tea</option>', html)
+        self.assertInHTML('<option value="tea" selected="selected">Tea</option>', html)
 
     def test_named_groups_with_blank_option(self):
         block = blocks.ChoiceBlock(
@@ -598,20 +599,20 @@ class TestChoiceBlock(SimpleTestCase):
 
         # test rendering with the blank option selected
         html = block.render_form(None, prefix='beverage')
-        self.assertInHTML('<select id="beverage" name="beverage" placeholder="">', html)
+        self.assertTagInHTML('<select id="beverage" name="beverage" placeholder="">', html)
         self.assertNotIn('<option value="">%s</option>' % self.blank_choice_dash_label, html)
-        self.assertNotIn('<option value="" selected="selected">%s</option>' % self.blank_choice_dash_label, html)
+        self.assertNotInHTML('<option value="" selected="selected">%s</option>' % self.blank_choice_dash_label, html)
         self.assertIn('<optgroup label="Alcoholic">', html)
         self.assertIn('<option value="tea">Tea</option>', html)
-        self.assertIn('<option value="" selected="selected">No thanks</option>', html)
+        self.assertInHTML('<option value="" selected="selected">No thanks</option>', html)
 
         # test rendering with a non-blank option selected
         html = block.render_form('tea', prefix='beverage')
-        self.assertInHTML('<select id="beverage" name="beverage" placeholder="">', html)
+        self.assertTagInHTML('<select id="beverage" name="beverage" placeholder="">', html)
         self.assertNotIn('<option value="">%s</option>' % self.blank_choice_dash_label, html)
-        self.assertNotIn('<option value="" selected="selected">%s</option>' % self.blank_choice_dash_label, html)
+        self.assertNotInHTML('<option value="" selected="selected">%s</option>' % self.blank_choice_dash_label, html)
         self.assertIn('<optgroup label="Alcoholic">', html)
-        self.assertIn('<option value="tea" selected="selected">Tea</option>', html)
+        self.assertInHTML('<option value="tea" selected="selected">Tea</option>', html)
 
     def test_subclassing(self):
         class BeverageChoiceBlock(blocks.ChoiceBlock):
@@ -622,8 +623,8 @@ class TestChoiceBlock(SimpleTestCase):
 
         block = BeverageChoiceBlock(required=False)
         html = block.render_form('tea', prefix='beverage')
-        self.assertInHTML('<select id="beverage" name="beverage" placeholder="">', html)
-        self.assertIn('<option value="tea" selected="selected">Tea</option>', html)
+        self.assertTagInHTML('<select id="beverage" name="beverage" placeholder="">', html)
+        self.assertInHTML('<option value="tea" selected="selected">Tea</option>', html)
 
         # subclasses of ChoiceBlock should deconstruct to a basic ChoiceBlock for migrations
         self.assertEqual(
@@ -715,8 +716,9 @@ class TestChoiceBlock(SimpleTestCase):
 
         block = blocks.ChoiceBlock(choices=callable_choices, required=False)
         html = block.render_form('tea', prefix='beverage')
-        self.assertIn('<select id="beverage" name="beverage" placeholder="">', html)
-        self.assertIn('<option value="tea" selected="selected">Tea</option>', html)
+
+        self.assertTagInHTML('<select id="beverage" name="beverage" placeholder="">', html)
+        self.assertInHTML('<option value="tea" selected="selected">Tea</option>', html)
 
         self.assertEqual(
             block.deconstruct(),
@@ -1457,21 +1459,21 @@ class TestListBlock(SimpleTestCase):
             ),
             html
         )
-        self.assertIn(
+        self.assertInHTML(
             (
                 '<input id="links-0-value-link" name="links-0-value-link" placeholder="Link" type="url"'
                 ' value="http://www.wagtail.io" />'
             ),
             html
         )
-        self.assertIn(
+        self.assertInHTML(
             (
                 '<input id="links-1-value-title" name="links-1-value-title" placeholder="Title" type="text"'
                 ' value="Django" />'
             ),
             html
         )
-        self.assertIn(
+        self.assertInHTML(
             (
                 '<input id="links-1-value-link" name="links-1-value-link" placeholder="Link"'
                 ' type="url" value="http://www.djangoproject.com" />'
@@ -2256,13 +2258,13 @@ class TestPageChooserBlock(TestCase):
         block = blocks.PageChooserBlock(help_text="pick a page, any page")
 
         empty_form_html = block.render_form(None, 'page')
-        self.assertIn('<input id="page" name="page" placeholder="" type="hidden" />', empty_form_html)
+        self.assertInHTML('<input id="page" name="page" placeholder="" type="hidden" />', empty_form_html)
         self.assertIn('createPageChooser("page", ["wagtailcore.page"], null, false);', empty_form_html)
 
         christmas_page = Page.objects.get(slug='christmas')
         christmas_form_html = block.render_form(christmas_page, 'page')
         expected_html = '<input id="page" name="page" placeholder="" type="hidden" value="%d" />' % christmas_page.id
-        self.assertIn(expected_html, christmas_form_html)
+        self.assertInHTML(expected_html, christmas_form_html)
         self.assertIn("pick a page, any page", christmas_form_html)
 
     def test_form_render_with_target_model_default(self):

--- a/wagtail/wagtailcore/tests/test_blocks.py
+++ b/wagtail/wagtailcore/tests/test_blocks.py
@@ -51,7 +51,7 @@ class ContextCharBlock(blocks.CharBlock):
         return super(blocks.CharBlock, self).get_context(value, parent_context)
 
 
-class TestFieldBlock(SimpleTestCase, WagtailTestUtils):
+class TestFieldBlock(WagtailTestUtils, SimpleTestCase):
     def test_charfield_render(self):
         block = blocks.CharBlock()
         html = block.render("Hello world!")
@@ -449,7 +449,7 @@ class TestRichTextBlock(TestCase):
         self.assertEqual(result.source, '')
 
 
-class TestChoiceBlock(SimpleTestCase, WagtailTestUtils):
+class TestChoiceBlock(WagtailTestUtils, SimpleTestCase):
     def setUp(self):
         from django.db.models.fields import BLANK_CHOICE_DASH
         self.blank_choice_dash_label = BLANK_CHOICE_DASH[0][1]

--- a/wagtail/wagtailcore/tests/test_page_privacy.py
+++ b/wagtail/wagtailcore/tests/test_page_privacy.py
@@ -26,7 +26,8 @@ class TestPagePrivacy(TestCase):
         self.assertContains(response, '<form action="%s"' % submit_url)
         self.assertContains(
             response,
-            '<input id="id_return_url" name="return_url" type="hidden" value="/secret-plans/" />'
+            '<input id="id_return_url" name="return_url" type="hidden" value="/secret-plans/" />',
+            html=True
         )
 
         # posting the wrong password should redisplay the password page
@@ -60,7 +61,8 @@ class TestPagePrivacy(TestCase):
         self.assertContains(response, '<form action="%s"' % submit_url)
         self.assertContains(
             response,
-            '<input id="id_return_url" name="return_url" type="hidden" value="/secret-plans/steal-underpants/" />'
+            '<input id="id_return_url" name="return_url" type="hidden" value="/secret-plans/steal-underpants/" />',
+            html=True
         )
 
         # posting the wrong password should redisplay the password page

--- a/wagtail/wagtailcore/tests/test_tests.py
+++ b/wagtail/wagtailcore/tests/test_tests.py
@@ -29,6 +29,20 @@ class TestAssertTagInHTML(TestCase, WagtailTestUtils):
         with self.assertRaises(AssertionError):
             self.assertTagInHTML('<li lang="en" class="important really" data-extra="boom">', haystack)
 
+    def test_assert_tag_in_html_with_extra_attrs(self):
+        haystack = """<ul>
+            <li class="normal">hugh</li>
+            <li class="normal">pugh</li>
+            <li class="really important" lang="en"><em>barney</em> mcgrew</li>
+        </ul>"""
+        self.assertTagInHTML('<li class="important really">', haystack, allow_extra_attrs=True)
+        self.assertTagInHTML('<li>', haystack, count=3, allow_extra_attrs=True)
+
+        with self.assertRaises(AssertionError):
+            self.assertTagInHTML('<li class="normal" lang="en">', haystack, allow_extra_attrs=True)
+        with self.assertRaises(AssertionError):
+            self.assertTagInHTML('<li class="important really">', haystack, count=2, allow_extra_attrs=True)
+
     def test_assert_tag_in_template_script(self):
         haystack = """<html>
             <script type="text/template">

--- a/wagtail/wagtailcore/tests/test_tests.py
+++ b/wagtail/wagtailcore/tests/test_tests.py
@@ -1,12 +1,33 @@
 from __future__ import absolute_import, unicode_literals
 
+from django.test import TestCase
 from django.utils import six
 
 from wagtail.tests.testapp.models import (
     BusinessChild, BusinessIndex, BusinessNowherePage, BusinessSubIndex, EventIndex, EventPage,
     SimplePage, StreamPage)
-from wagtail.tests.utils import WagtailPageTests
+from wagtail.tests.utils import WagtailPageTests, WagtailTestUtils
 from wagtail.wagtailcore.models import PAGE_MODEL_CLASSES, Page, Site
+
+
+class TestAssertTagInHTML(TestCase, WagtailTestUtils):
+    def test_assert_tag_in_html(self):
+        haystack = """<ul>
+            <li class="normal">hugh</li>
+            <li class="normal">pugh</li>
+            <li class="really important" lang="en"><em>barney</em> mcgrew</li>
+        </ul>"""
+        self.assertTagInHTML('<li lang="en" class="important really">', haystack)
+        self.assertTagInHTML('<li class="normal">', haystack, count=2)
+
+        with self.assertRaises(AssertionError):
+            self.assertTagInHTML('<div lang="en" class="important really">', haystack)
+        with self.assertRaises(AssertionError):
+            self.assertTagInHTML('<li lang="en" class="important really">', haystack, count=2)
+        with self.assertRaises(AssertionError):
+            self.assertTagInHTML('<li lang="en" class="important">', haystack)
+        with self.assertRaises(AssertionError):
+            self.assertTagInHTML('<li lang="en" class="important really" data-extra="boom">', haystack)
 
 
 class TestWagtailPageTests(WagtailPageTests):

--- a/wagtail/wagtailcore/tests/test_tests.py
+++ b/wagtail/wagtailcore/tests/test_tests.py
@@ -29,6 +29,23 @@ class TestAssertTagInHTML(TestCase, WagtailTestUtils):
         with self.assertRaises(AssertionError):
             self.assertTagInHTML('<li lang="en" class="important really" data-extra="boom">', haystack)
 
+    def test_assert_tag_in_template_script(self):
+        haystack = """<html>
+            <script type="text/template">
+                <p class="really important">first template block</p>
+            </script>
+            <script type="text/template">
+                <p class="really important">second template block</p>
+            </script>
+            <p class="normal">not in a script tag</p>
+        </html>"""
+
+        self.assertTagInTemplateScript('<p class="important really">', haystack)
+        self.assertTagInTemplateScript('<p class="important really">', haystack, count=2)
+
+        with self.assertRaises(AssertionError):
+            self.assertTagInTemplateScript('<p class="normal">', haystack)
+
 
 class TestWagtailPageTests(WagtailPageTests):
     def setUp(self):

--- a/wagtail/wagtailcore/tests/test_tests.py
+++ b/wagtail/wagtailcore/tests/test_tests.py
@@ -10,7 +10,7 @@ from wagtail.tests.utils import WagtailPageTests, WagtailTestUtils
 from wagtail.wagtailcore.models import PAGE_MODEL_CLASSES, Page, Site
 
 
-class TestAssertTagInHTML(TestCase, WagtailTestUtils):
+class TestAssertTagInHTML(WagtailTestUtils, TestCase):
     def test_assert_tag_in_html(self):
         haystack = """<ul>
             <li class="normal">hugh</li>

--- a/wagtail/wagtailsnippets/tests.py
+++ b/wagtail/wagtailsnippets/tests.py
@@ -699,13 +699,13 @@ class TestSnippetChooserBlock(TestCase):
         block = SnippetChooserBlock(Advert, help_text="pick an advert, any advert")
 
         empty_form_html = block.render_form(None, 'advert')
-        self.assertIn('<input id="advert" name="advert" placeholder="" type="hidden" />', empty_form_html)
+        self.assertInHTML('<input id="advert" name="advert" placeholder="" type="hidden" />', empty_form_html)
         self.assertIn('createSnippetChooser("advert", "tests/advert");', empty_form_html)
 
         test_advert = Advert.objects.get(text='test_advert')
         test_advert_form_html = block.render_form(test_advert, 'advert')
         expected_html = '<input id="advert" name="advert" placeholder="" type="hidden" value="%d" />' % test_advert.id
-        self.assertIn(expected_html, test_advert_form_html)
+        self.assertInHTML(expected_html, test_advert_form_html)
         self.assertIn("pick an advert, any advert", test_advert_form_html)
 
     def test_form_response(self):


### PR DESCRIPTION
Completing the work started by @timgraham in https://github.com/wagtail/wagtail/issues/3314#issuecomment-281774365 to make tests ignore HTML attribute ordering (which changed for form fields in Django 1.11).

In some cases the old string-based assertions were doing things that aren't handled by `assertInHTML` / `assertContains(html=True)` - asserting that an HTML tag exists with unspecified content, and asserting that an HTML tag exists with possible extra attributes - so I've added new helper methods for these. (Memo to self: contribute these helpers back to Django, once the dust settles on 1.11 support...)