### PR TITLE
Flake8 plugins

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,14 +1,10 @@
 pipeline:
-  flake8:
-    image: python:3.5
-    commands:
-      - XDG_CACHE_HOME=/drone/pip-cache pip install flake8
-      - flake8 wagtail
-  isort:
+  lint_python:
     image: python:3.5
     commands:
       - XDG_CACHE_HOME=/drone/pip-cache pip install wheel
       - XDG_CACHE_HOME=/drone/pip-cache pip install -e .[testing]
+      - flake8 wagtail
       - isort --check-only --diff --recursive wagtail
   js:
     image: node:4.2.4

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ testing_extras = [
     'flake8>=2.2.0',
     'isort>=4.2.0',
     'flake8-blind-except==0.1.1',
+    'flake8-print==2.0.2',
 ]
 
 # Documentation dependencies

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ testing_extras = [
     'coverage>=3.7.0',
     'flake8>=2.2.0',
     'isort>=4.2.0',
+    'flake8-blind-except==0.1.1',
 ]
 
 # Documentation dependencies

--- a/wagtail/bin/wagtail.py
+++ b/wagtail/bin/wagtail.py
@@ -30,7 +30,7 @@ def create_project(parser, options, args):
                      "Python module and cannot be used as a project "
                      "name. Please try another name." % project_name)
 
-    print("Creating a Wagtail project called %(project_name)s" % {'project_name': project_name})
+    print("Creating a Wagtail project called %(project_name)s" % {'project_name': project_name})  # noqa
 
     # Create the project from the Wagtail template using startapp
 
@@ -52,7 +52,7 @@ def create_project(parser, options, args):
     utility = ManagementUtility(utility_args)
     utility.execute()
 
-    print("Success! %(project_name)s has been created" % {'project_name': project_name})
+    print("Success! %(project_name)s has been created" % {'project_name': project_name})  # noqa
 
 
 COMMANDS = {

--- a/wagtail/utils/setup.py
+++ b/wagtail/utils/setup.py
@@ -18,14 +18,14 @@ class assets_mixin(object):
         try:
             subprocess.check_call(['npm', 'run', 'build'])
         except (OSError, subprocess.CalledProcessError) as e:
-            print('Error compiling assets: ' + str(e))
+            print('Error compiling assets: ' + str(e))  # noqa
             raise SystemExit(1)
 
     def publish_assets(self):
         try:
             subprocess.check_call(['npm', 'publish', 'client'])
         except (OSError, subprocess.CalledProcessError) as e:
-            print('Error publishing front-end assets: ' + str(e))
+            print('Error publishing front-end assets: ' + str(e))  # noqa
             raise SystemExit(1)
 
     def bump_client_version(self):
@@ -38,7 +38,7 @@ class assets_mixin(object):
         try:
             package = json.loads(input_file.read().decode("utf-8"))
         except (ValueError) as e:
-            print('Unable to read ' + path + ' ' + e)
+            print('Unable to read ' + path + ' ' + e)  # noqa
             raise SystemExit(1)
 
         package['version'] = __semver__
@@ -49,7 +49,7 @@ class assets_mixin(object):
 
                 f.write(six.text_type(json.dumps(package, indent=2, ensure_ascii=False)))
         except (IOError) as e:
-            print('Error setting the version for front-end assets: ' + str(e))
+            print('Error setting the version for front-end assets: ' + str(e))  # noqa
             raise SystemExit(1)
 
 
@@ -82,7 +82,7 @@ class check_bdist_egg(bdist_egg):
     def run(self):
         bdist_egg.run(self)
         if not os.path.isdir(self.sentinel_dir):
-            print("\n".join([
+            print("\n".join([  # noqa
                 "************************************************************",
                 "The front end assets for Wagtail are missing.",
                 "To generate the assets, please refer to the documentation in",

--- a/wagtail/wagtailcore/management/commands/publish_scheduled_pages.py
+++ b/wagtail/wagtailcore/management/commands/publish_scheduled_pages.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 import json
 
@@ -28,7 +28,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         dryrun = False
         if options['dryrun']:
-            print("Will do a dry run.")
+            self.stdout.write("Will do a dry run.")
             dryrun = True
 
         # 1. get all expired pages with live = True
@@ -38,17 +38,17 @@ class Command(BaseCommand):
         )
         if dryrun:
             if expired_pages:
-                print("Expired pages to be deactivated:")
-                print("Expiry datetime\t\tSlug\t\tName")
-                print("---------------\t\t----\t\t----")
+                self.stdout.write("Expired pages to be deactivated:")
+                self.stdout.write("Expiry datetime\t\tSlug\t\tName")
+                self.stdout.write("---------------\t\t----\t\t----")
                 for ep in expired_pages:
-                    print("{0}\t{1}\t{2}".format(
+                    self.stdout.write("{0}\t{1}\t{2}".format(
                         ep.expire_at.strftime("%Y-%m-%d %H:%M"),
                         ep.slug,
                         ep.title
                     ))
             else:
-                print("No expired pages to be deactivated found.")
+                self.stdout.write("No expired pages to be deactivated found.")
         else:
             # Unpublish the expired pages
             # Cast to list to make sure the query is fully evaluated
@@ -63,14 +63,14 @@ class Command(BaseCommand):
             ) if revision_date_expired(r)
         ]
         if dryrun:
-            print("---------------------------------")
+            self.stdout.write("---------------------------------")
             if expired_revs:
-                print("Expired revisions to be dropped from moderation queue:")
-                print("Expiry datetime\t\tSlug\t\tName")
-                print("---------------\t\t----\t\t----")
+                self.stdout.write("Expired revisions to be dropped from moderation queue:")
+                self.stdout.write("Expiry datetime\t\tSlug\t\tName")
+                self.stdout.write("---------------\t\t----\t\t----")
                 for er in expired_revs:
                     rev_data = json.loads(er.content_json)
-                    print("{0}\t{1}\t{2}".format(
+                    self.stdout.write("{0}\t{1}\t{2}".format(
                         dateparse.parse_datetime(
                             rev_data.get('expire_at')
                         ).strftime("%Y-%m-%d %H:%M"),
@@ -78,7 +78,7 @@ class Command(BaseCommand):
                         rev_data.get('title')
                     ))
             else:
-                print("No expired revision to be dropped from moderation.")
+                self.stdout.write("No expired revision to be dropped from moderation.")
         else:
             for er in expired_revs:
                 er.submitted_for_moderation = False
@@ -89,20 +89,20 @@ class Command(BaseCommand):
             approved_go_live_at__lt=timezone.now()
         )
         if dryrun:
-            print("---------------------------------")
+            self.stdout.write("---------------------------------")
             if revs_for_publishing:
-                print("Revisions to be published:")
-                print("Go live datetime\t\tSlug\t\tName")
-                print("---------------\t\t\t----\t\t----")
+                self.stdout.write("Revisions to be published:")
+                self.stdout.write("Go live datetime\t\tSlug\t\tName")
+                self.stdout.write("---------------\t\t\t----\t\t----")
                 for rp in revs_for_publishing:
                     rev_data = json.loads(rp.content_json)
-                    print("{0}\t\t{1}\t{2}".format(
+                    self.stdout.write("{0}\t\t{1}\t{2}".format(
                         rp.approved_go_live_at.strftime("%Y-%m-%d %H:%M"),
                         rev_data.get('slug'),
                         rev_data.get('title')
                     ))
             else:
-                print("No pages to go live.")
+                self.stdout.write("No pages to go live.")
         else:
             for rp in revs_for_publishing:
                 # just run publish for the revision -- since the approved go

--- a/wagtail/wagtailimages/tests/tests.py
+++ b/wagtail/wagtailimages/tests/tests.py
@@ -27,7 +27,7 @@ from .utils import Image, get_test_image_file
 try:
     import sendfile  # noqa
     sendfile_mod = True
-except:
+except ImportError:
     sendfile_mod = False
 
 


### PR DESCRIPTION
This pull request installs a couple of flake8 plugins to perform more code-style checks on Drone:

 - ``flake8-blind-except`` - Catches ``except:`` statements that do not catch specific exception classes
 - ``flake8-print`` - Catches stray print functions. These shouldn't be used in most parts of Wagtail and leaving them in is a common mistake

I did want to enable a couple more plugins, but they raise too many errors to solve right now:
 - ``flake8-docstrings`` - Runs ``pydocstyle`` to check docstring style (PEP257)
 - ``flake8-mutable`` - Catches mutable default arguments which can cause problems (most of the errors are in tests, but there are a few in actual code that should probably be looked at)