### PR TITLE
Fixes hallotoolbar misplacement within StreamField StructBlock

### DIFF
--- a/wagtail/wagtailadmin/static_src/wagtailadmin/js/hallo-bootstrap.js
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/js/hallo-bootstrap.js
@@ -27,10 +27,11 @@ function makeHalloRichTextEditable(id) {
     }
 
     var closestObj = input.closest('.object');
+    var isDeepNested = input.closest('.struct-block').length;
 
     richText.hallo({
         toolbar: 'halloToolbarFixed',
-        toolbarCssClass: (closestObj.hasClass('full')) ? 'full' : (closestObj.hasClass('stream-field')) ? 'stream-field' : '',
+        toolbarCssClass: (closestObj.hasClass('full')) ? 'full' : (closestObj.hasClass('stream-field') && !isDeepNested) ? 'stream-field' : '',
         plugins: halloPlugins
     }).bind('hallomodified', function(event, data) {
         input.val(data.content);

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/js/hallo-bootstrap.js
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/js/hallo-bootstrap.js
@@ -27,11 +27,11 @@ function makeHalloRichTextEditable(id) {
     }
 
     var closestObj = input.closest('.object');
-    var isDeepNested = input.closest('.struct-block').length;
+    var isRoot = input.closest('.struct-block').length == 0;
 
     richText.hallo({
         toolbar: 'halloToolbarFixed',
-        toolbarCssClass: (closestObj.hasClass('full')) ? 'full' : (closestObj.hasClass('stream-field') && !isDeepNested) ? 'stream-field' : '',
+        toolbarCssClass: (closestObj.hasClass('full')) ? 'full' : (closestObj.hasClass('stream-field') && isRoot) ? 'stream-field' : '',
         plugins: halloPlugins
     }).bind('hallomodified', function(event, data) {
         input.val(data.content);


### PR DESCRIPTION
Fixes #1511 which now also considers if the element is a part of a struct-block. The specific classname ``.stream-field`` pushes the HalloToolbar up for a negative margin offset. Whereas in a StructBlock it is sufficient to apply the the regular margin offset which comes along with `.hallotoolbar`

- [x] Fixed it for a `StructBlock` within a `StreamField`. 
- [x] Validated it is still working within a `StreamBlock` 
- [x] Validated the direct `RichTextField` usage on a `Page`. 
- [x] Do some cross-browser testing.

I am not completely sure if there are additional scenarios to look in to?

I'd also rather have a deep look into what's happening with `.stream-field` and `.hallotoolbar` in general so I'm not completely happy with the solution. On the other hand, this is probably good enough with #2409 in mind.

~~Also I wanted to attach a screenshot but it seems GitHub uses [S3 storage](https://twitter.com/awscloud/status/836666548311859200) for that.~~

**Update:** 
What it looks like:
![image](https://cloud.githubusercontent.com/assets/287422/23475794/ef92f18c-feb8-11e6-8069-2c39cedd89db.png)
