### PR TITLE
Dj1.11 - eliminate warnings from on_delete / pagination

### DIFF
--- a/wagtail/contrib/wagtailsearchpromotions/views.py
+++ b/wagtail/contrib/wagtailsearchpromotions/views.py
@@ -24,7 +24,7 @@ def index(request):
     is_searching = False
     query_string = request.GET.get('q', "")
 
-    queries = Query.objects.filter(editors_picks__isnull=False).distinct()
+    queries = Query.objects.filter(editors_picks__isnull=False).distinct().order_by('query_string')
 
     # Search
     if query_string:

--- a/wagtail/tests/testapp/models.py
+++ b/wagtail/tests/testapp/models.py
@@ -466,7 +466,7 @@ FormPageWithCustomSubmission.content_panels = [
 
 
 class FormFieldWithCustomSubmission(AbstractFormField):
-    page = ParentalKey(FormPageWithCustomSubmission, related_name='custom_form_fields')
+    page = ParentalKey(FormPageWithCustomSubmission, on_delete=models.CASCADE, related_name='custom_form_fields')
 
 
 class CustomFormPageSubmission(AbstractFormSubmission):

--- a/wagtail/wagtailredirects/views.py
+++ b/wagtail/wagtailredirects/views.py
@@ -32,8 +32,7 @@ def index(request):
     if ordering not in ['old_path']:
         ordering = 'old_path'
 
-    if ordering != 'old_path':
-        redirects = redirects.order_by(ordering)
+    redirects = redirects.order_by(ordering)
 
     # Pagination
     paginator, redirects = paginate(request, redirects)

--- a/wagtail/wagtailsnippets/views/chooser.py
+++ b/wagtail/wagtailsnippets/views/chooser.py
@@ -20,6 +20,11 @@ def choose(request, app_label, model_name):
 
     items = model.objects.all()
 
+    # Preserve the snippet's model-level ordering if specified, but fall back on PK if not
+    # (to ensure pagination is consistent)
+    if not items.ordered:
+        items = items.order_by('pk')
+
     # Search
     is_searchable = class_is_indexed(model)
     is_searching = False

--- a/wagtail/wagtailsnippets/views/snippets.py
+++ b/wagtail/wagtailsnippets/views/snippets.py
@@ -77,6 +77,11 @@ def list(request, app_label, model_name):
 
     items = model.objects.all()
 
+    # Preserve the snippet's model-level ordering if specified, but fall back on PK if not
+    # (to ensure pagination is consistent)
+    if not items.ordered:
+        items = items.order_by('pk')
+
     # Search
     is_searchable = class_is_indexed(model)
     is_searching = False


### PR DESCRIPTION
Fixing some of the easier warnings thrown when running tests against Django 1.11:

* add a missing on_delete setting from test models
* ensure that paginated listings always have an explicit ordering