### PR TITLE
Title not displaying page name

### DIFF
--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/confirm_move.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/confirm_move.html
@@ -1,6 +1,6 @@
 {% extends "wagtailadmin/base.html" %}
 {% load i18n %}
-{% block titletag %}{% blocktrans with title=page.get_admin_display_title %}Move {{ title }}{% endblocktrans %}{% endblock %}
+{% block titletag %}{% blocktrans with title=page_to_move.get_admin_display_title %}Move {{ title }}{% endblocktrans %}{% endblock %}
 {% block content %}
     {% trans "Move" as move_str %}
     {% include "wagtailadmin/shared/header.html" with title=move_str subtitle=page_to_move.get_admin_display_title icon="doc-empty-inverse" %}


### PR DESCRIPTION
The confirm move page was not displaying the correct title for the page.

The `page` context variable does not exist for that view.