### PR TITLE
Create raw SQL for SQL Server to be able to display recent edits (on 1.9.x)

### DIFF
--- a/wagtail/wagtailadmin/views/home.py
+++ b/wagtail/wagtailadmin/views/home.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 
 from django.conf import settings
+from django.db import connection
 from django.shortcuts import render
 from django.template.loader import render_to_string
 
@@ -49,14 +50,34 @@ class RecentEditsPanel(object):
     def __init__(self, request):
         self.request = request
         # Last n edited pages
-        last_edits = PageRevision.objects.raw(
-            """
-            SELECT wp.* FROM
-                wagtailcore_pagerevision wp JOIN (
-                    SELECT max(created_at) AS max_created_at, page_id FROM
-                        wagtailcore_pagerevision WHERE user_id = %s GROUP BY page_id ORDER BY max_created_at DESC LIMIT %s
-                ) AS max_rev ON max_rev.max_created_at = wp.created_at ORDER BY wp.created_at DESC
-             """, [self.request.user.pk, 5])
+        if connection.vendor in ('mssql', 'microsoft'):
+            # This is a hack for SQL Server. We should be able to replace this raw
+            # SQL with an ORM query in Django 1.11, as it supports sub-selects.
+            cursor = connection.cursor()
+            last_edits = cursor.execute(
+                """
+                SELECT wp.* FROM
+                    wagtailcore_pagerevision wp INNER JOIN (
+                        SELECT TOP 5 max(created_at) AS max_created_at, page_id
+                        FROM wagtailcore_pagerevision
+                        WHERE user_id = %s
+                        GROUP BY page_id
+                        ORDER BY max_created_at DESC
+                    ) AS max_rev ON max_rev.max_created_at = wp.created_at ORDER BY wp.created_at DESC
+                 """, [self.request.user.pk])
+        else:
+            last_edits = PageRevision.objects.raw(
+                """
+                SELECT wp.* FROM
+                    wagtailcore_pagerevision wp JOIN (
+                        SELECT max(created_at) AS max_created_at, page_id
+                        FROM wagtailcore_pagerevision
+                        WHERE user_id = %s
+                        GROUP BY page_id
+                        ORDER BY max_created_at DESC
+                        LIMIT %s
+                    ) AS max_rev ON max_rev.max_created_at = wp.created_at ORDER BY wp.created_at DESC
+                 """, [self.request.user.pk, 5])
         last_edits = list(last_edits)
         page_keys = [pr.page.pk for pr in last_edits]
         specific_pages = Page.objects.filter(pk__in=page_keys).specific()


### PR DESCRIPTION
This creates corresponding raw SQL for a subselect to maintain SQL Server compatibility.

SQL Server does not support the LIMIT keyword. This should be considered a temporary fix until Django 1.11 subselects are available!
