### PR TITLE
Use specific page when populating href

### DIFF
--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/listing/_page_title_choose.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/listing/_page_title_choose.html
@@ -6,9 +6,7 @@ Expects a variable 'page', the page instance.
 
 <h2>
     {% if page.can_choose %}
-        {% with page=page.specific %}
-            <a class="choose-page" href="#{{ page.id }}" data-id="{{ page.id }}" data-title="{{ page.get_admin_display_title }}" data-url="{{ page.url }}" data-parent-id="{{ page.get_parent.id }}" data-edit-url="{% url 'wagtailadmin_pages:edit' page.id %}">{{ page.get_admin_display_title }}</a>
-        {% endwith %}
+        <a class="choose-page" href="#{{ page.id }}" data-id="{{ page.id }}" data-title="{{ page.get_admin_display_title }}" data-url="{{ page.url }}" data-parent-id="{{ page.get_parent.id }}" data-edit-url="{% url 'wagtailadmin_pages:edit' page.id %}">{{ page.get_admin_display_title }}</a>
     {% else %}
         {{ page.get_admin_display_title }}
     {% endif %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/listing/_page_title_choose.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/listing/_page_title_choose.html
@@ -6,7 +6,9 @@ Expects a variable 'page', the page instance.
 
 <h2>
     {% if page.can_choose %}
-        <a class="choose-page" href="#{{ page.id }}" data-id="{{ page.id }}" data-title="{{ page.get_admin_display_title }}" data-url="{{ page.url }}" data-parent-id="{{ page.get_parent.id }}" data-edit-url="{% url 'wagtailadmin_pages:edit' page.id %}">{{ page.get_admin_display_title }}</a>
+        {% with page=page.specific %}
+            <a class="choose-page" href="#{{ page.id }}" data-id="{{ page.id }}" data-title="{{ page.get_admin_display_title }}" data-url="{{ page.url }}" data-parent-id="{{ page.get_parent.id }}" data-edit-url="{% url 'wagtailadmin_pages:edit' page.id %}">{{ page.get_admin_display_title }}</a>
+        {% endwith %}
     {% else %}
         {{ page.get_admin_display_title }}
     {% endif %}

--- a/wagtail/wagtailadmin/tests/test_page_chooser.py
+++ b/wagtail/wagtailadmin/tests/test_page_chooser.py
@@ -4,7 +4,7 @@ from django.core.urlresolvers import reverse
 from django.test import TestCase
 from django.utils.http import urlencode
 
-from wagtail.tests.testapp.models import EventIndex, EventPage, SimplePage
+from wagtail.tests.testapp.models import EventIndex, EventPage, SimplePage, SingleEventPage
 from wagtail.tests.utils import WagtailTestUtils
 from wagtail.wagtailcore.models import Page
 
@@ -131,6 +131,27 @@ class TestChooserBrowseChild(TestCase, WagtailTestUtils):
         self.assertIn(event_index_page.id, pages)
         self.assertFalse(pages[event_index_page.id].can_choose)
         self.assertTrue(pages[event_index_page.id].can_descend)
+
+    def test_with_url_extended_page_type(self):
+        # Add a page that overrides the url path
+        single_event_page = SingleEventPage(
+            title="foo",
+            location='the moon', audience='public',
+            cost='free', date_from='2001-01-01',
+        )
+        self.root_page.add_child(instance=single_event_page)
+
+        # Send request
+        response = self.get()
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'wagtailadmin/chooser/browse.html')
+
+        page_urls = [
+            page.url
+            for page in response.context['pages']
+        ]
+
+        self.assertIn('/foo/pointless-suffix/', page_urls)
 
     def test_with_blank_page_type(self):
         # a blank page_type parameter should be equivalent to an absent parameter

--- a/wagtail/wagtailadmin/views/chooser.py
+++ b/wagtail/wagtailadmin/views/chooser.py
@@ -74,7 +74,7 @@ def browse(request, parent_page_id=None):
         parent_page = all_desired_pages.first_common_ancestor()
 
     # Get children of parent page
-    pages = parent_page.get_children()
+    pages = parent_page.get_children().specific()
 
     # allow hooks to modify the queryset
     for hook in hooks.get_hooks('construct_page_chooser_queryset'):

--- a/wagtail/wagtailcore/rich_text.py
+++ b/wagtail/wagtailcore/rich_text.py
@@ -47,7 +47,7 @@ class PageLinkHandler(object):
             else:
                 editor_attrs = ''
 
-            return '<a %shref="%s">' % (editor_attrs, escape(page.url))
+            return '<a %shref="%s">' % (editor_attrs, escape(page.specific.url))
         except Page.DoesNotExist:
             return "<a>"
 


### PR DESCRIPTION
This PR addresses an issue with RichText internal links that use a Model inheriting from Page that overrides the url function.

The issue has been reported here too: https://github.com/wagtail/wagtail/issues/3164
