### PR TITLE
Remove duplicate translations

### DIFF
--- a/scripts/find-duplicates.py
+++ b/scripts/find-duplicates.py
@@ -1,0 +1,48 @@
+"""
+Utility script to find strings marked for translation that are
+in the form:
+'Change Password' -> 'change password'
+In order to minimize translation efforts, only one should be used.
+It uses babel instead more standard 'polib' because it's used in another script.
+"""
+from __future__ import print_function
+
+import glob
+from babel.messages.pofile import read_po
+
+
+def check(mess, othermess):
+    return mess.id.lower() == othermess.id.lower()
+
+
+def find_duplicates_in_file(filepath):
+    fileobj = open(filepath)
+    catalog = read_po(fileobj)
+
+    already_found = []
+    for mess in catalog:
+        for othermess in catalog:
+            # Tuples are plurals, we only consider single translations
+            if isinstance(mess.id, str) and isinstance(othermess.id, str):
+                if mess.id != othermess.id and check(mess, othermess) and mess.id.lower() not in already_found:
+                    already_found.append(mess.id.lower())
+                    yield mess, othermess
+                    break
+
+
+def print_output(message, othermessage):
+    print("'{}' --> {} \n {} --> {}.\n -----".format(
+        message.id, message.locations,
+        othermessage.id, othermessage.locations
+    ))
+
+if __name__ == "__main__":
+    translations_paths = glob.glob('../wagtail/*/LOCALE/en/LC_MESSAGES/*.po')
+
+    for filepath in translations_paths:
+        for message, othermessage in find_duplicates_in_file(filepath):
+            if message:
+                print(filepath)
+                print_output(message, othermessage)
+
+

--- a/wagtail/wagtailadmin/templates/wagtailadmin/account/change_password.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/account/change_password.html
@@ -15,7 +15,7 @@
                         {% include "wagtailadmin/shared/field_as_li.html" with field=field %}
                     {% endfor %}
                 </ul>
-                <input type="submit" value="{% trans 'Change Password' %}" class="button" />
+                <input type="submit" value="{% trans 'Change password' %}" class="button" />
             </form>
         {% else %}
             <p>{% trans "Your password can't be changed here. Please contact a site administrator." %}</p>

--- a/wagtail/wagtailadmin/templates/wagtailadmin/account/notification_preferences.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/account/notification_preferences.html
@@ -1,9 +1,9 @@
 {% extends "wagtailadmin/base.html" %}
 {% load i18n %}
 
-{% block titletag %}{% trans "Notification Preferences" %}{% endblock %}
+{% block titletag %}{% trans "Notification preferences" %}{% endblock %}
 {% block content %}
-    {% trans "Notification Preferences" as prefs_str %}
+    {% trans "Notification preferences" as prefs_str %}
     {% include "wagtailadmin/shared/header.html" with title=prefs_str %}
 
     <div class="nice-padding">

--- a/wagtail/wagtailcore/forms.py
+++ b/wagtail/wagtailcore/forms.py
@@ -6,7 +6,7 @@ from django.utils.translation import ugettext_lazy
 
 
 class PasswordPageViewRestrictionForm(forms.Form):
-    password = forms.CharField(label=ugettext_lazy("Password"), widget=forms.PasswordInput)
+    password = forms.CharField(label=ugettext_lazy("password"), widget=forms.PasswordInput)
     return_url = forms.CharField(widget=forms.HiddenInput)
 
     def __init__(self, *args, **kwargs):

--- a/wagtail/wagtaildocs/templates/wagtaildocs/documents/list.html
+++ b/wagtail/wagtaildocs/templates/wagtaildocs/documents/list.html
@@ -8,13 +8,13 @@
             <th>
                 {% if not is_searching %}
                     <a href="{% url 'wagtaildocs:index' %}{% if not ordering == "title" %}?ordering=title{% endif %}" class="icon icon-arrow-down-after {% if  ordering == "title" %}teal{% endif %}">
-                        {% trans "title" %}
+                        {% trans "title"|capfirst %}
                     </a>
                 {% else %}
-                    {% trans "title" %}
+                    {% trans "title"|capfirst %}
                 {% endif %}
             </th>
-            <th>{% trans "file" %}</th>
+            <th>{% trans "file"|capfirst %}</th>
             <th>
                 {% if not is_searching %}
                     <a href="{% url 'wagtaildocs:index' %}{% if not ordering == "-created_at" %}?ordering=-created_at{% endif %}" class="icon icon-arrow-down-after {% if  ordering == "-created_at" %}teal{% endif %}">

--- a/wagtail/wagtaildocs/templates/wagtaildocs/documents/list.html
+++ b/wagtail/wagtaildocs/templates/wagtaildocs/documents/list.html
@@ -8,13 +8,13 @@
             <th>
                 {% if not is_searching %}
                     <a href="{% url 'wagtaildocs:index' %}{% if not ordering == "title" %}?ordering=title{% endif %}" class="icon icon-arrow-down-after {% if  ordering == "title" %}teal{% endif %}">
-                        {% trans "Title" %}
+                        {% trans "title" %}
                     </a>
                 {% else %}
-                    {% trans "Title" %}
+                    {% trans "title" %}
                 {% endif %}
             </th>
-            <th>{% trans "File" %}</th>
+            <th>{% trans "file" %}</th>
             <th>
                 {% if not is_searching %}
                     <a href="{% url 'wagtaildocs:index' %}{% if not ordering == "-created_at" %}?ordering=-created_at{% endif %}" class="icon icon-arrow-down-after {% if  ordering == "-created_at" %}teal{% endif %}">

--- a/wagtail/wagtaildocs/templates/wagtaildocs/documents/usage.html
+++ b/wagtail/wagtaildocs/templates/wagtaildocs/documents/usage.html
@@ -13,7 +13,7 @@
             <col width="15%"/>
             <thead>
                 <tr>
-                    <th class="title">{% trans "Title" %}</th>
+                    <th class="title">{% trans "title" %}</th>
                     <th>{% trans "Parent" %}</th>
                     <th>{% trans "Type" %}</th>
                     <th>{% trans "Status" %}</th>

--- a/wagtail/wagtaildocs/templates/wagtaildocs/documents/usage.html
+++ b/wagtail/wagtaildocs/templates/wagtaildocs/documents/usage.html
@@ -13,7 +13,7 @@
             <col width="15%"/>
             <thead>
                 <tr>
-                    <th class="title">{% trans "title" %}</th>
+                    <th class="title">{% trans "title"|capfirst %}</th>
                     <th>{% trans "Parent" %}</th>
                     <th>{% trans "Type" %}</th>
                     <th>{% trans "Status" %}</th>

--- a/wagtail/wagtailforms/templates/wagtailforms/list_submissions.html
+++ b/wagtail/wagtailforms/templates/wagtailforms/list_submissions.html
@@ -7,7 +7,7 @@
     <thead>
         <tr>
             <th colspan="{{ data_headings|length|add:1 }}">
-                <button class="button no" id="delete-submissions" style="visibility: hidden">Delete selected submissions</button>
+                <button class="button no" id="delete-submissions" style="visibility: hidden">{% trans "Delete selected submissions" %}</button>
             </th>
         </tr>
         <tr>

--- a/wagtail/wagtailimages/forms.py
+++ b/wagtail/wagtailimages/forms.py
@@ -79,8 +79,8 @@ class URLGeneratorForm(forms.Form):
             ('fill', _("Resize to fill")),
         ),
     )
-    width = forms.IntegerField(_("Width"), min_value=0)
-    height = forms.IntegerField(_("Height"), min_value=0)
+    width = forms.IntegerField(_("width"), min_value=0)
+    height = forms.IntegerField(_("height"), min_value=0)
     closeness = forms.IntegerField(_("Closeness"), min_value=0, initial=0)
 
 

--- a/wagtail/wagtailimages/templates/wagtailimages/images/usage.html
+++ b/wagtail/wagtailimages/templates/wagtailimages/images/usage.html
@@ -13,7 +13,7 @@
             <col width="15%"/>
             <thead>
                 <tr>
-                    <th class="title">{% trans "Title" %}</th>
+                    <th class="title">{% trans "title" %}</th>
                     <th>{% trans "Parent" %}</th>
                     <th>{% trans "Type" %}</th>
                     <th>{% trans "Status" %}</th>

--- a/wagtail/wagtailimages/templates/wagtailimages/images/usage.html
+++ b/wagtail/wagtailimages/templates/wagtailimages/images/usage.html
@@ -13,7 +13,7 @@
             <col width="15%"/>
             <thead>
                 <tr>
-                    <th class="title">{% trans "title" %}</th>
+                    <th class="title">{% trans "title"|capfirst %}</th>
                     <th>{% trans "Parent" %}</th>
                     <th>{% trans "Type" %}</th>
                     <th>{% trans "Status" %}</th>

--- a/wagtail/wagtailredirects/templates/wagtailredirects/list.html
+++ b/wagtail/wagtailredirects/templates/wagtailredirects/list.html
@@ -15,7 +15,7 @@
                     {% trans "From" %}
                 {% endif %}
             </th>
-            <th>{% trans "Site" %}</th>
+            <th>{% trans "site" %}</th>
             <th>{% trans "To" %}</th>
             <th class="type">{% trans "Type" %}</th>
         </tr>

--- a/wagtail/wagtailredirects/templates/wagtailredirects/list.html
+++ b/wagtail/wagtailredirects/templates/wagtailredirects/list.html
@@ -15,7 +15,7 @@
                     {% trans "From" %}
                 {% endif %}
             </th>
-            <th>{% trans "site" %}</th>
+            <th>{% trans "site"|capfirst %}</th>
             <th>{% trans "To" %}</th>
             <th class="type">{% trans "Type" %}</th>
         </tr>

--- a/wagtail/wagtailusers/wagtail_hooks.py
+++ b/wagtail/wagtailusers/wagtail_hooks.py
@@ -63,7 +63,7 @@ class GroupsMenuItem(MenuItem):
 @hooks.register('register_settings_menu_item')
 def register_groups_menu_item():
     return GroupsMenuItem(
-        _('Groups'),
+        _('groups'),
         urlresolvers.reverse('wagtailusers_groups:index'),
         classnames='icon icon-group',
         order=601

--- a/wagtail/wagtailusers/wagtail_hooks.py
+++ b/wagtail/wagtailusers/wagtail_hooks.py
@@ -63,7 +63,7 @@ class GroupsMenuItem(MenuItem):
 @hooks.register('register_settings_menu_item')
 def register_groups_menu_item():
     return GroupsMenuItem(
-        _('groups'),
+        _('groups').title(),
         urlresolvers.reverse('wagtailusers_groups:index'),
         classnames='icon icon-group',
         order=601


### PR DESCRIPTION
While translating to new language, I've found several strings as:
"Groups"
"groups"

"Change password"
"change Password"

So I added a new utility script to find these strings in the translation files and then I've manually changed those values.
Just in case you find it useful to add it to the source code.
At first I thought there were a lot of them, but I was wrong :)


