### PR TITLE
Auto create translators credits file

### DIFF
--- a/TRANSLATORS.rst
+++ b/TRANSLATORS.rst
@@ -1,0 +1,48 @@
+Translators
+===========
+
+* Afrikaans: Jaco du Plessis
+* Arabic: Ahmad Kiswani, Mohamed Mayla, ROGER MICHAEL ASHLEY ALLEN, alfuhigi
+* Basque: Unai Zalakain
+* Bulgarian: Lyuboslav  Petrov
+* Catalan: Antoni Aloy, David Llop, Roger Pons
+* Chinese: Leway Colin, hanfeng, lihan
+* Chinese (Simplified, China): Daniel Hwang, Feng Wang, Fred Zeng, Jian Li, Listeng, hanfeng, 沙军 祝, 飘 赵
+* Chinese (Traditional, Taiwan): Jp Shieh, gogobook, lihan
+* Croatian (Croatia): Luka Matijević
+* Czech: Ivan Pomykacz, Jiri Stepanek, Marek Turnovec
+* Danish: Asger Sørensen
+* Dutch: Arne Turpyn, Bram, Brecht Dervaux, Huib Keemink, Michael van Tellingen, Rob Moorman, Samuel Leeuwenburg, Thijs Kramer, benny_AT_it_digin.com, mahulst
+* Dutch (Netherlands): Bram, Franklin Kingma, Maarten Kling, Thijs Kramer
+* Finnish: Aarni Koskela, Eetu Häivälä, Glen Somerville, Juha Yrjölä, Niklas Jerva, Rauli L.
+* French: Adrien, André Bouatchidzé, Antonin ENFRUN, Axel Haustant, Benoît Vogel, Bertrand Bordage, Dominique PERETTI, Léo, Sebastien Andrivet, Timothy Allen, Tom Dyson, nahuel, pierre marfoure
+* Galician: fooflare
+* Georgian: André Bouatchidzé
+* German: Daniel Manser, Ettore Atalan, Henrik Kröger, Jannis, Johannes Spielmann, M0rph 3u5, Martin Löhle, Max Pfeiffer, Moritz Pfeiffer, Raphael Stolt, Tammo van Lessen, Vorlif, Wasilis Mandratzis-Walz, hpoul, karlsander, pcraston, tobias schmidt
+* Greek: George Giannoulopoulos, Wasilis Mandratzis-Walz, Yiannis Inglessis, Yiannis Inglessis, jim dal, serafeim
+* Hebrew (Israel): bjesus, lior abazon, yossi lalum
+* Hungarian: Kornel Novak Mergulhão, Laszlo Molnar
+* Icelandic (Iceland): Arnar Tumi Þorsteinsson, Kjartan Sverrisson, saevarom
+* Indonesian (Indonesia): Sutrisno Efendi, geek pantura
+* Italian: Alessio Di Stasio, Carlo Miron, Claudio Bantaloukas, Edd, Edd Baldry, Giacomo Ghizzani, andrea tagliazucchi, giammi
+* Japanese: Daigo Shitara, SHIMIZU Taku, Sangmin Ahn, 石田秀
+* Korean: Jihan Chung, Kyungil Choi
+* Latvian: Maris Serzans, Reinis Rozenbergs
+* Lithuanian: Matas Dailyda
+* Mongolian: Delgermurun Purevkhuuu, delgermurun
+* Norwegian Bokmål: Eirik Krogstad, Robin Skahjem-Eriksen, Stein Strindhaug
+* Persian: Mohammad reza Jelveh
+* Polish: Mateusz, Miłosz Miśkiewicz, utek
+* Portuguese (Brazil): Claudemiro Alves Feitosa Neto, Douglas Miranda, Gilson Filho, Gladson, Guilherme Nabanete, Joao Garcia, João Luiz Lorencetti, Luiz Boaretto, Marcio Mazza, Thiago Cangussu, Thiago Cangussu
+* Portuguese (Portugal): Douglas Miranda, Gladson, Jose Lourenco, Manuela Silva, Nuno Matos, Thiago Cangussu, Tiago Henriques
+* Romanian: Dan Braghis, zerolab
+* Russian: Alexandr, Andrey Avdey, Daniil, Eugene MechanisM, Mikalai Radchuk, Sergey Khalymon, Sergey Komarov, ajk, gsstver, Никита Викторович
+* Slovak (Slovakia): Jozef Karabelly, Stevo Backor, dellax
+* Slovenian: Mitja Pagon
+* Spanish: Daniel Chimeno, Joaquín Tita, Mauricio Baeza, Mauricio Baeza, Unai Zalakain, Yusuf (Josè) Luis, fonso, fooflare
+* Swedish: André Karlsson, Hannes Lohmander, Ludwig Kjellström, Thomas Kunambi
+* Swedish (Sweden): Jon Karlsson, Thomas Kunambi
+* Turkish: Cihad GÜNDOĞDU, Ragıp Ünal
+* Turkish (Turkey): Cihad GÜNDOĞDU, Ragıp Ünal, Saadettin Yasir AKEL, Saadettin Yasir AKEL, Yusuf (Josè) Luis
+* Ukrainian: Mykola Zamkovoi
+* Vietnamese: Luan Nguyen

--- a/scripts/get-translator-credits.py
+++ b/scripts/get-translator-credits.py
@@ -1,6 +1,8 @@
+from __future__ import print_function
 import subprocess
 import re
 from collections import defaultdict
+from io import open
 
 from babel import Locale
 
@@ -12,12 +14,12 @@ for file_listing_line in file_listing.stdout:
     filename = file_listing_line.strip()
 
     # extract locale string from filename
-    locale = re.search(r'locale/(\w+)/LC_MESSAGES', filename).group(1)
+    locale = re.search(r'locale/(\w+)/LC_MESSAGES', str(filename)).group(1)
     if locale == 'en':
         continue
 
     # read author list from each file
-    with file(filename) as f:
+    with open(filename, 'rt') as f:
         has_found_translators_heading = False
         for line in f:
             line = line.strip()
@@ -40,7 +42,7 @@ language_names = [
 language_names.sort()
 
 for (language_name, locale) in language_names:
-    print(("%s - %s" % (language_name, locale)).encode('utf-8'))
+    print(("%s - %s" % (language_name, locale)))
     print("-----")
     for author in sorted(authors_by_locale[locale]):
         print(author)

--- a/scripts/write-translators-credits.py
+++ b/scripts/write-translators-credits.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+# -*- coding: utf-8
+"""
+Write a list of translators in the TRANSLATORS_FILE file.
+"""
+from __future__ import print_function, unicode_literals
+
+import subprocess
+import re
+from collections import defaultdict
+from io import open
+
+from babel import Locale
+
+TRANSLATORS_FILE = '../TRANSLATORS.rst'
+CORE_DEVELOPERS = ['Matt Westcott', ]
+
+
+def author_name(author):
+    return re.sub('<.*?>', '', author).strip()
+
+
+def is_core_developer(author):
+    return author_name(author) in CORE_DEVELOPERS
+
+
+authors_by_locale = defaultdict(set)
+
+file_listing = subprocess.Popen('find ../wagtail -iname *.po', shell=True, stdout=subprocess.PIPE)
+
+for file_listing_line in file_listing.stdout:
+    filename = file_listing_line.strip()
+
+    # extract locale string from filename
+    locale = re.search(r'locale/(\w+)/LC_MESSAGES', str(filename)).group(1)
+    if locale == 'en':
+        continue
+
+    # read author list from each file
+    with open(filename, 'rt') as f:
+        has_found_translators_heading = False
+        for line in f:
+            line = line.strip()
+            if line.startswith('#'):
+                if has_found_translators_heading:
+                    author = re.match(r'\# (.*), [\d\-]+', line).group(1)
+                    authors_by_locale[locale].add(author)
+                elif line.startswith('# Translators:'):
+                    has_found_translators_heading = True
+            else:
+                if has_found_translators_heading:
+                    break
+                else:
+                    raise Exception("No 'Translators:' heading found in %s" % filename)
+
+language_names = [
+    (Locale.parse(locale_string).english_name, locale_string)
+    for locale_string in authors_by_locale.keys()
+]
+language_names.sort()
+
+with open(TRANSLATORS_FILE, 'w', encoding='utf-8') as f:
+    f.write('Translators\n')
+    f.write('===========\n')
+    f.write('\n')
+    for (language_name, locale) in language_names:
+        authors = [author for author in sorted(authors_by_locale[locale]) if not is_core_developer(author)]
+        f.write("* {}: {}\n".format(language_name, ', '.join([author_name(author) for author in authors])))
+


### PR DESCRIPTION
Just found myself working on a similar issue and I thought Wagtail could benefit from it.
- Make the current get-translators-credits.py py2/3 compatible.
- Create another script that writes the translators to a file.

If you think this is not useful enough, feel free to close the PR.

Note: the current ``Translators`` section in CONTRIBUTORS.md should be removed.