### PR TITLE
Don't set is_staff flag on users

### DIFF
--- a/docs/releases/1.10.rst
+++ b/docs/releases/1.10.rst
@@ -74,3 +74,9 @@ Projects using :ref:`custom image models <custom_image_model>` no longer need to
     def image_feature_detection(sender, instance, **kwargs):
         if not instance.has_focal_point():
             instance.set_focal_point(instance.get_suggested_focal_point())
+
+
+Adding / editing users through Wagtail admin no longer sets ``is_staff`` flag
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Previously, the ``is_staff`` flag (which grants access to the Django admin interface) was automatically set for superusers, and reset for other users, when creating and updating users through the Wagtail admin. This behaviour has now been removed, since Wagtail is designed to work independently of the Django admin. If you need to reinstate the old behaviour, you can set up a `pre_save signal handler <https://docs.djangoproject.com/en/1.10/ref/signals/#django.db.models.signals.pre_save>`_ on the User model to set the flag appropriately.

--- a/wagtail/wagtailusers/forms.py
+++ b/wagtail/wagtailusers/forms.py
@@ -146,9 +146,6 @@ class UserForm(UsernameForm):
         if password:
             user.set_password(password)
 
-        # Superusers can always access the admin interface.
-        user.is_staff = user.is_superuser
-
         if commit:
             user.save()
             self.save_m2m()


### PR DESCRIPTION
Wagtail doesn't routinely require access to Django admin, so it makes sense for Wagtail to not enforce an opinion on who does or doesn't get access.

Fixes #970 and #2777

(I wasn't sure if this really warranted an 'upgrade considerations' note, but technically it is a backwards-incompatible change, and people might conceivably have workflows that rely on the old behaviour, so I figure it's probably worth including.)