### PR TITLE
#663 add icon to site root pages in explorer listing

### DIFF
--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/listing/_page_title_explore.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/listing/_page_title_explore.html
@@ -3,6 +3,12 @@
 {# The title field for a page in the page listing, when in 'explore' mode #}
 
 <h2>
+    {% if page.sites_rooted_here.exists %}
+        {% if perms.wagtailcore.add_site or perms.wagtailcore.change_site or perms.wagtailcore.delete_site %}
+            <a href="{% url 'wagtailsites:index' %}" class="icon icon-site" title="Sites menu"></a>
+        {% endif %}
+    {% endif %}
+
     {% if page_perms.can_edit %}
         <a href="{% url 'wagtailadmin_pages:edit' page.id %}" title="{% trans 'Edit this page' %}">{{ page.get_admin_display_title }}</a>
     {% else %}

--- a/wagtail/wagtailadmin/views/pages.py
+++ b/wagtail/wagtailadmin/views/pages.py
@@ -42,7 +42,7 @@ def index(request, parent_page_id=None):
     else:
         parent_page = Page.get_first_root_node().specific
 
-    pages = parent_page.get_children().prefetch_related('content_type')
+    pages = parent_page.get_children().prefetch_related('content_type', 'sites_rooted_here')
 
     # Get page ordering
     ordering = request.GET.get('ordering', '-latest_revision_created_at')


### PR DESCRIPTION
Addresses #663.

I've made the icon be a link to the sites index page, rather than the specific site edit page (in case the page is a root of multiple sites). You may think it confusing that it's a link adjacent to the title, which takes you to the page edit view, in which case we could remove the link aspect.