### PR TITLE
Display non_field_errors in the page editor

### DIFF
--- a/wagtail/tests/testapp/models.py
+++ b/wagtail/tests/testapp/models.py
@@ -7,6 +7,7 @@ import os
 from django.conf import settings
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
+from django.core.exceptions import ValidationError
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db import models
@@ -205,6 +206,22 @@ class EventCategory(models.Model):
         return self.name
 
 
+# Override the standard WagtailAdminPageForm to add validation on start/end dates
+# that appears as a non-field error
+
+class EventPageForm(WagtailAdminPageForm):
+    def clean(self):
+        cleaned_data = super(EventPageForm, self).clean()
+
+        # Make sure that the event starts before it ends
+        start_date = cleaned_data['date_from']
+        end_date = cleaned_data['date_to']
+        if start_date and end_date and start_date > end_date:
+            raise ValidationError('The end date must be after the start date')
+
+        return cleaned_data
+
+
 class EventPage(Page):
     date_from = models.DateField("Start date", null=True)
     date_to = models.DateField(
@@ -236,6 +253,7 @@ class EventPage(Page):
     ]
 
     password_required_template = 'tests/event_page_password_required.html'
+    base_form_class = EventPageForm
 
 
 EventPage.content_panels = [

--- a/wagtail/wagtailadmin/messages.py
+++ b/wagtail/wagtailadmin/messages.py
@@ -6,10 +6,11 @@ from django.template.loader import render_to_string
 from django.utils.html import format_html, format_html_join
 
 
-def render(message, buttons):
+def render(message, buttons, detail=''):
     return render_to_string('wagtailadmin/shared/messages.html', {
         'message': message,
         'buttons': buttons,
+        'detail': detail,
     })
 
 
@@ -37,7 +38,7 @@ def validation_error(request, message, form, buttons=None):
     if not form.non_field_errors():
         # just output the generic "there were validation errors" message, and leave
         # the per-field highlighting to do the rest
-        full_message = message
+        detail = ''
     else:
         # display the full list of field and non-field validation errors
         all_errors = []
@@ -55,9 +56,9 @@ def validation_error(request, message, form, buttons=None):
                 all_errors.append(prefix + error)
 
         errors_html = format_html_join('\n', '<li>{}</li>', ((e,) for e in all_errors))
-        full_message = format_html("""{} <ul class="errorlist">{}</ul>""", message, errors_html)
+        detail = format_html("""<ul class="errorlist">{}</ul>""", errors_html)
 
-    return messages.error(request, render(full_message, buttons))
+    return messages.error(request, render(message, buttons, detail=detail))
 
 
 def button(url, text, new_window=False):

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/_mixins.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/_mixins.scss
@@ -30,6 +30,22 @@
     }
 }
 
+@mixin unlistimmediate() {
+    /* remove list styles, but only for the immediate element - allow nested lists inside it
+    to keep the default style */
+
+    margin-top: 0;
+    margin-bottom: 0;
+    padding-left: 0;
+    list-style-type: none;
+    font-style: normal;
+
+    > li {
+        list-style-type: none;
+        font-style: normal;
+    }
+}
+
 @mixin transition($transition...) {
     body.ready & {
         transition: $transition;

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_messages.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_messages.scss
@@ -12,14 +12,14 @@
         margin-left: 1em;
     }
 
-    ul {
-        @include unlist();
+    > ul {
+        @include unlistimmediate();
         position: relative;
         top: -100px;
         opacity: 0;
     }
 
-    li {
+    > ul > li {
         // @include nice-padding;
         padding-top: 1.6em;
         padding-right: 3em;
@@ -28,7 +28,7 @@
         color: $color-white;
     }
 
-    li:before {
+    > ul > li:before {
         margin-right: 0.5em;
         font-size: 1.5em;
         vertical-align: middle;
@@ -76,22 +76,26 @@
             color: $color-white;
         }
     }
+
+    .errorlist {
+        margin: 0.5em 0 0 1em;
+    }
 }
 
-.messages.new ul {
+.messages.new > ul {
     transition: none;
     top: -100px;
 }
 
-.ready .messages ul,
-.messages.appear ul {
+.ready .messages > ul,
+.messages.appear > ul {
     transition: top 0.5s ease, opacity 0.5s ease, max-height 1.2s ease;
     opacity: 1;
     top: 0;
 }
 
 @media screen and (min-width: $breakpoint-mobile) {
-    .messages ul li {
+    .messages > ul > li {
         padding-left: 1.6em;
         padding-right: 3em;
     }

--- a/wagtail/wagtailadmin/templates/wagtailadmin/shared/messages.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/shared/messages.html
@@ -7,3 +7,5 @@
         {% endfor %}
     </span>
 {% endif %}
+
+{{ detail }}

--- a/wagtail/wagtailadmin/views/pages.py
+++ b/wagtail/wagtailadmin/views/pages.py
@@ -269,7 +269,9 @@ def create(request, content_type_app_name, content_type_model_name, parent_page_
                     target_url += '?next=%s' % urlquote(next_url)
                 return redirect(target_url)
         else:
-            messages.error(request, _("The page could not be created due to validation errors"))
+            messages.validation_error(
+                request, _("The page could not be created due to validation errors"), form
+            )
             edit_handler = edit_handler_class(instance=page, form=form)
             has_unsaved_changes = True
     else:
@@ -462,7 +464,9 @@ def edit(request, page_id):
             if page.locked:
                 messages.error(request, _("The page could not be saved as it is locked"))
             else:
-                messages.error(request, _("The page could not be saved due to validation errors"))
+                messages.validation_error(
+                    request, _("The page could not be saved due to validation errors"), form
+                )
 
             edit_handler = edit_handler_class(instance=page, form=form)
             errors_debug = (


### PR DESCRIPTION
Fixes #536

Adds a `validation_error` helper to the `wagtail.wagtailadmin.messages` module to handle form validation errors as a special case of the standard `error` notification type, and update the page add/edit views to use it. The new helper works according to the following logic:

* If all of the form's errors are associated with fields, just show the generic "could not be saved due to validation errors" and leave the specific errors to be displayed inline in the form, as per the current behaviour
* If there are any non-field errors, show all errors (both field and non-field) as a list inside the error message banner. As mentioned in https://github.com/wagtail/wagtail/issues/536#issuecomment-52466885, showing the field errors here (in addition to displaying them alongside the fields) ensures that the non-field errors aren't given extra prominence.

For testing purposes, the new validation added in wagtail/tests/testapp/models.py can also be copied into wagtaildemo's EventPage definition.

(Aside: Django's default `form.errors.as_ul()` rendering of validation errors is rubbish. It displays the internal field names instead of the friendly labels, including `__all__` for non-field errors...)