### PR TITLE
StreamFieldPanels do not accept classname attribute

### DIFF
--- a/wagtail/wagtailadmin/edit_handlers.py
+++ b/wagtail/wagtailadmin/edit_handlers.py
@@ -854,12 +854,14 @@ class BaseStreamFieldPanel(BaseFieldPanel):
 
 
 class StreamFieldPanel(object):
-    def __init__(self, field_name):
+    def __init__(self, field_name, classname=''):
         self.field_name = field_name
+        self.classname = classname
 
     def bind_to_model(self, model):
         return type(str('_StreamFieldPanel'), (BaseStreamFieldPanel,), {
             'model': model,
             'field_name': self.field_name,
-            'block_def': model._meta.get_field(self.field_name).stream_block
+            'block_def': model._meta.get_field(self.field_name).stream_block,
+            'classname': self.classname,
         })


### PR DESCRIPTION
Is there a reason for that? :)

My actual goal was to make a StreamFieldPanel collapsible in a Page, but I also noticed that the javascript selector that allows that is quite...selective :)

```
function initCollapsibleBlocks() {
    $('.object.multi-field.collapsible').each(function() {
```

I'll pretend my StreamFieldPanel is a MultiFieldPanel for now I guess!
