### PR TITLE
Fix userbar transition on Firefox 52

### DIFF
--- a/wagtail/wagtailadmin/static_src/wagtailadmin/js/userbar.js
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/js/userbar.js
@@ -4,7 +4,8 @@ document.addEventListener('DOMContentLoaded', function userBar(e) {
     var userbar = document.querySelector('[data-wagtail-userbar]');
     var trigger = userbar.querySelector('[data-wagtail-userbar-trigger]');
     var list = userbar.querySelector('.wagtail-userbar-items');
-    var className = 'is-active';
+    var activeClassName = 'is-active';
+    var openedClassName = 'is-opened';
     var hasTouch = 'ontouchstart' in window;
     var clickEvent = 'click';
 
@@ -32,20 +33,28 @@ document.addEventListener('DOMContentLoaded', function userBar(e) {
     window.addEventListener('pageshow', hideUserbar, false);
 
     function showUserbar(e) {
-        userbar.classList.add(className);
+        userbar.classList.add(activeClassName);
+        setTimeout(function() {
+            /* need to start opening animation slightly after visibility has been set,
+            to avoid a Firefox 52 bug: https://github.com/wagtail/wagtail/issues/3443 */
+            userbar.classList.add(openedClassName);
+        }, 50);
         list.addEventListener(clickEvent, sandboxClick, false);
         window.addEventListener(clickEvent, clickOutside, false);
     }
 
     function hideUserbar(e) {
-        userbar.classList.remove(className);
+        userbar.classList.remove(openedClassName);
+        setTimeout(function() {
+            userbar.classList.remove(activeClassName);
+        }, 50);
         list.addEventListener(clickEvent, sandboxClick, false);
         window.removeEventListener(clickEvent, clickOutside, false);
     }
 
     function toggleUserbar(e) {
         e.stopPropagation();
-        if (userbar.classList.contains(className)) {
+        if (userbar.classList.contains(activeClassName)) {
             hideUserbar();
         } else {
             showUserbar();

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/userbar.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/userbar.scss
@@ -166,7 +166,7 @@ $positions: (
         transition-duration: .15s;
         transition-timing-function: cubic-bezier(.55, 0, .1, 1);
 
-        .#{$namespace}-userbar.is-active & {
+        .#{$namespace}-userbar.is-opened & {
             opacity: 1;
             transform: translateY(0);
             transition-delay: .3s;
@@ -303,7 +303,7 @@ $positions: (
             }
         }
 
-        &.is-active .#{$namespace}-userbar__item {
+        &.is-opened .#{$namespace}-userbar__item {
             @for $i from 1 through $max-items {
 
                 @if $vertical == 'bottom' {
@@ -329,7 +329,7 @@ $positions: (
 
 // Active state for the list items comes last.
 
-.#{$namespace}-userbar.is-active .#{$namespace}-userbar__item {
+.#{$namespace}-userbar.is-opened .#{$namespace}-userbar__item {
     transform: translateY(0) !important;
     opacity: 1 !important;
 }


### PR DESCRIPTION
Fixes #3443. Make the transition animation happen slightly after visibility has been set, so that it doesn't revert to the original invisible style after the transition has completed.

Really hoping that someone can find a less hacky solution than this, because this is horrible :-( The only way I could find to prevent the list items from jumping back to the original `visibility: hidden` style was to trigger the animation a few milliseconds after the `visibility: visibility` style is applied. 50ms seems to be enough to consistently work on my machine - 10ms isn't enough.