### PR TITLE
Fix #3443 - don't use "!important" on animated properties on userbar items

### DIFF
--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/userbar.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/userbar.scss
@@ -330,6 +330,6 @@ $positions: (
 // Active state for the list items comes last.
 
 .#{$namespace}-userbar.is-active .#{$namespace}-userbar__item {
-    transform: translateY(0) !important;
-    opacity: 1 !important;
+    transform: translateY(0);
+    opacity: 1;
 }


### PR DESCRIPTION
They don't seem to be necessary (the .is-active properties surely have higher specificity than the ones that set initial state), and they cause a rendering bug on Firefox 52. Fixes #3443