### PR TITLE
Make installing deps more stable

### DIFF
--- a/docs/contributing/developing.rst
+++ b/docs/contributing/developing.rst
@@ -31,7 +31,7 @@ With your preferred virtualenv activated, install the Wagtail package in develop
 
 .. code-block:: console
 
-    $ pip install -e .[testing,docs] -U
+    $ pip install -e '.[testing,docs]' -U
 
 Install Node through nvm (optional):
 


### PR DESCRIPTION
The old syntax works with bash, but not with zsh. The new syntax works with both.