### PR TITLE
Allow custom field classes to be used in api_fields

### DIFF
--- a/docs/advanced_topics/api/v2/configuration.rst
+++ b/docs/advanced_topics/api/v2/configuration.rst
@@ -147,8 +147,8 @@ Custom serialisers
 .. versionadded: 1.10
 
 Serialisers_ are used to convert the database representation of a model into
-something that can be sent over the wire in JSON format. You can override the
-serialiser for any field using the ``serializer`` keyword argument:
+JSON format. You can override the serialiser for any field using the
+``serializer`` keyword argument:
 
 .. code-block:: python
 
@@ -182,8 +182,7 @@ to add API fields that have a different field name or no underlying field at all
             ...
         ]
 
-This adds two fields to the API for the same underlying database field
-(other fields omitted for brevity):
+This adds two fields to the API (other fields omitted for brevity):
 
 .. code-block:: json
 
@@ -223,7 +222,7 @@ For example:
             ...
         ]
 
-This would add the following to the reponse:
+This would add the following to the JSON:
 
 .. code-block:: json
 

--- a/wagtail/api/__init__.py
+++ b/wagtail/api/__init__.py
@@ -1,1 +1,4 @@
+from .conf import APIField  # noqa
+
+
 default_app_config = 'wagtail.api.apps.WagtailAPIAppConfig'

--- a/wagtail/api/conf.py
+++ b/wagtail/api/conf.py
@@ -1,0 +1,13 @@
+from __future__ import absolute_import, unicode_literals
+
+
+class APIField(object):
+    def __init__(self, name, serializer=None):
+        self.name = name
+        self.serializer = serializer
+
+    def __hash__(self):
+        return hash(self.name)
+
+    def __repr__(self):
+        return '<APIField {}>'.format(self.name)

--- a/wagtail/api/v2/endpoints.py
+++ b/wagtail/api/v2/endpoints.py
@@ -95,56 +95,31 @@ class BaseAPIEndpoint(GenericViewSet):
         return super(BaseAPIEndpoint, self).handle_exception(exc)
 
     @classmethod
+    def _convert_api_fields(cls, fields):
+        return [field if isinstance(field, APIField) else APIField(field)
+                for field in fields]
+
+    @classmethod
     def get_body_fields(cls, model):
-        """
-        This returns a list of field names that are allowed to
-        be used in the API (excluding the id field)
-        """
-        fields = cls.body_fields[:]
+        return cls._convert_api_fields(cls.body_fields + list(getattr(model, 'api_fields', ())))
 
-        if hasattr(model, 'api_fields'):
-            fields.extend([
-                field.name if isinstance(field, APIField) else field
-                for field in model.api_fields
-            ])
-
-        return fields
+    @classmethod
+    def get_body_fields_names(cls, model):
+        return [field.name for field in cls.get_body_fields(model)]
 
     @classmethod
     def get_meta_fields(cls, model):
-        """
-        This returns a list of field names that are allowed to
-        be used in the meta section in the API (excluding type and detail_url).
-        """
-        meta_fields = cls.meta_fields[:]
+        return cls._convert_api_fields(cls.meta_fields + list(getattr(model, 'api_meta_fields', ())))
 
-        if hasattr(model, 'api_meta_fields'):
-            meta_fields.extend([
-                field.name if isinstance(field, APIField) else field
-                for field in model.api_meta_fields
-            ])
-
-        return meta_fields
+    @classmethod
+    def get_meta_fields_names(cls, model):
+        return [field.name for field in cls.get_meta_fields(model)]
 
     @classmethod
     def get_field_serializer_overrides(cls, model):
-        serializers = {}
-
-        if hasattr(model, 'api_fields'):
-            serializers.update({
-                field.name: field.serializer
-                for field in model.api_fields
-                if isinstance(field, APIField) and field.serializer is not None
-            })
-
-        if hasattr(model, 'api_meta_fields'):
-            serializers.update({
-                field.name: field.serializer
-                for field in model.api_meta_fields
-                if isinstance(field, APIField) and field.serializer is not None
-            })
-
-        return serializers
+        return {field.name: field.serializer
+                for field in cls.get_body_fields(model) + cls.get_meta_fields(model)
+                if field.serializer is not None}
 
     @classmethod
     def get_available_fields(cls, model, db_fields_only=False):
@@ -156,7 +131,7 @@ class BaseAPIEndpoint(GenericViewSet):
         an underlying column in the database (eg, type/detail_url and any custom
         fields that are callables)
         """
-        fields = cls.get_body_fields(model) + cls.get_meta_fields(model)
+        fields = cls.get_body_fields_names(model) + cls.get_meta_fields_names(model)
 
         if db_fields_only:
             # Get list of available database fields then remove any fields in our
@@ -199,8 +174,8 @@ class BaseAPIEndpoint(GenericViewSet):
     @classmethod
     def _get_serializer_class(cls, router, model, fields_config, show_details=False, nested=False):
         # Get all available fields
-        body_fields = cls.get_body_fields(model)
-        meta_fields = cls.get_meta_fields(model)
+        body_fields = cls.get_body_fields_names(model)
+        meta_fields = cls.get_meta_fields_names(model)
         all_fields = body_fields + meta_fields
 
         # Remove any duplicates

--- a/wagtail/api/v2/endpoints.py
+++ b/wagtail/api/v2/endpoints.py
@@ -13,6 +13,7 @@ from rest_framework.renderers import BrowsableAPIRenderer, JSONRenderer
 from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
 
+from wagtail.api import APIField
 from wagtail.wagtailcore.models import Page
 
 from .filters import (
@@ -103,7 +104,7 @@ class BaseAPIEndpoint(GenericViewSet):
 
         if hasattr(model, 'api_fields'):
             fields.extend([
-                field[0] if isinstance(field, tuple) else field
+                field.name if isinstance(field, APIField) else field
                 for field in model.api_fields
             ])
 
@@ -119,7 +120,7 @@ class BaseAPIEndpoint(GenericViewSet):
 
         if hasattr(model, 'api_meta_fields'):
             meta_fields.extend([
-                field[0] if isinstance(field, tuple) else field
+                field.name if isinstance(field, APIField) else field
                 for field in model.api_meta_fields
             ])
 
@@ -131,16 +132,16 @@ class BaseAPIEndpoint(GenericViewSet):
 
         if hasattr(model, 'api_fields'):
             configs.update({
-                field[0]: field[1]
+                field.name: field.serializer
                 for field in model.api_fields
-                if isinstance(field, tuple)
+                if isinstance(field, APIField) and field.serializer is not None
             })
 
         if hasattr(model, 'api_meta_fields'):
             configs.update({
-                field[0]: field[1]
+                field.name: field.serializer
                 for field in model.api_meta_fields
-                if isinstance(field, tuple)
+                if isinstance(field, APIField) and field.serializer is not None
             })
 
         return configs

--- a/wagtail/api/v2/endpoints.py
+++ b/wagtail/api/v2/endpoints.py
@@ -127,24 +127,24 @@ class BaseAPIEndpoint(GenericViewSet):
         return meta_fields
 
     @classmethod
-    def get_field_configs(cls, model):
-        configs = {}
+    def get_field_serializer_overrides(cls, model):
+        serializers = {}
 
         if hasattr(model, 'api_fields'):
-            configs.update({
+            serializers.update({
                 field.name: field.serializer
                 for field in model.api_fields
                 if isinstance(field, APIField) and field.serializer is not None
             })
 
         if hasattr(model, 'api_meta_fields'):
-            configs.update({
+            serializers.update({
                 field.name: field.serializer
                 for field in model.api_meta_fields
                 if isinstance(field, APIField) and field.serializer is not None
             })
 
-        return configs
+        return serializers
 
     @classmethod
     def get_available_fields(cls, model, db_fields_only=False):
@@ -284,8 +284,15 @@ class BaseAPIEndpoint(GenericViewSet):
         # Reorder fields so it matches the order of all_fields
         fields = [field for field in all_fields if field in fields]
 
-        field_configs = {field[0]: field[1] for field in cls.get_field_configs(model).items() if field[0] in fields}
-        return get_serializer_class(model, fields, meta_fields=meta_fields, field_configs=field_configs, child_serializer_classes=child_serializer_classes, base=cls.base_serializer_class)
+        field_serializer_overrides = {field[0]: field[1] for field in cls.get_field_serializer_overrides(model).items() if field[0] in fields}
+        return get_serializer_class(
+            model,
+            fields,
+            meta_fields=meta_fields,
+            field_serializer_overrides=field_serializer_overrides,
+            child_serializer_classes=child_serializer_classes,
+            base=cls.base_serializer_class
+        )
 
     def get_serializer_class(self):
         request = self.request

--- a/wagtail/api/v2/serializers.py
+++ b/wagtail/api/v2/serializers.py
@@ -337,13 +337,20 @@ class PageSerializer(BaseSerializer):
         return super(PageSerializer, self).build_relational_field(field_name, relation_info)
 
 
-def get_serializer_class(model_, fields_, meta_fields, child_serializer_classes=None, base=BaseSerializer):
+def get_serializer_class(model, field_names, meta_fields, field_configs=None, child_serializer_classes=None, base=BaseSerializer):
+    model_ = model
+
     class Meta:
         model = model_
-        fields = list(fields_)
+        fields = list(field_names)
 
-    return type(str(model_.__name__ + 'Serializer'), (base, ), {
+    attrs = {
         'Meta': Meta,
         'meta_fields': list(meta_fields),
         'child_serializer_classes': child_serializer_classes or {},
-    })
+    }
+
+    if field_configs:
+        attrs.update(field_configs)
+
+    return type(str(model_.__name__ + 'Serializer'), (base, ), attrs)

--- a/wagtail/api/v2/serializers.py
+++ b/wagtail/api/v2/serializers.py
@@ -337,7 +337,7 @@ class PageSerializer(BaseSerializer):
         return super(PageSerializer, self).build_relational_field(field_name, relation_info)
 
 
-def get_serializer_class(model, field_names, meta_fields, field_configs=None, child_serializer_classes=None, base=BaseSerializer):
+def get_serializer_class(model, field_names, meta_fields, field_serializer_overrides=None, child_serializer_classes=None, base=BaseSerializer):
     model_ = model
 
     class Meta:
@@ -350,7 +350,7 @@ def get_serializer_class(model, field_names, meta_fields, field_configs=None, ch
         'child_serializer_classes': child_serializer_classes or {},
     }
 
-    if field_configs:
-        attrs.update(field_configs)
+    if field_serializer_overrides:
+        attrs.update(field_serializer_overrides)
 
     return type(str(model_.__name__ + 'Serializer'), (base, ), attrs)

--- a/wagtail/api/v2/tests/test_pages.py
+++ b/wagtail/api/v2/tests/test_pages.py
@@ -188,7 +188,7 @@ class TestPageListing(TestCase):
         content = json.loads(response.content.decode('UTF-8'))
 
         for page in content['items']:
-            self.assertEqual(set(page.keys()), {'id', 'meta', 'title', 'date', 'related_links', 'tags', 'carousel_items', 'body', 'feed_image'})
+            self.assertEqual(set(page.keys()), {'id', 'meta', 'title', 'date', 'related_links', 'tags', 'carousel_items', 'body', 'feed_image', 'feed_image_thumbnail'})
             self.assertEqual(set(page['meta'].keys()), {'type', 'detail_url', 'show_in_menus', 'first_published_at', 'seo_title', 'slug', 'html_url', 'search_description'})
 
     def test_all_fields_then_remove_something(self):
@@ -196,7 +196,7 @@ class TestPageListing(TestCase):
         content = json.loads(response.content.decode('UTF-8'))
 
         for page in content['items']:
-            self.assertEqual(set(page.keys()), {'id', 'meta', 'related_links', 'tags', 'carousel_items', 'body', 'feed_image'})
+            self.assertEqual(set(page.keys()), {'id', 'meta', 'related_links', 'tags', 'carousel_items', 'body', 'feed_image', 'feed_image_thumbnail'})
             self.assertEqual(set(page['meta'].keys()), {'type', 'detail_url', 'show_in_menus', 'first_published_at', 'slug', 'html_url', 'search_description'})
 
     def test_remove_all_fields(self):
@@ -809,6 +809,12 @@ class TestPageDetail(TestCase):
         self.assertEqual(content['feed_image']['meta']['type'], 'wagtailimages.Image')
         self.assertEqual(content['feed_image']['meta']['detail_url'], 'http://localhost/api/v2beta/images/7/')
 
+        # Check that the feed images' thumbnail was serialised properly
+        self.assertEqual(content['feed_image_thumbnail'], {
+            # This is OK because it tells us it used ImageRenditionField to generate the output
+            'error': 'SourceImageIOError'
+        })
+
         # Check that the child relations were serialised properly
         self.assertEqual(content['related_links'], [])
         for carousel_item in content['carousel_items']:
@@ -838,6 +844,7 @@ class TestPageDetail(TestCase):
             'tags',
             'date',
             'feed_image',
+            'feed_image_thumbnail',
             'carousel_items',
             'related_links',
         ]

--- a/wagtail/contrib/wagtailapi/endpoints.py
+++ b/wagtail/contrib/wagtailapi/endpoints.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
+import warnings
 from collections import OrderedDict
 
 from django.conf.urls import url
@@ -10,6 +11,7 @@ from rest_framework.renderers import BrowsableAPIRenderer, JSONRenderer
 from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
 
+from wagtail.api import APIField
 from wagtail.wagtailcore.models import Page
 from wagtail.wagtailcore.utils import resolve_model_string
 from wagtail.wagtaildocs.models import get_document_model
@@ -80,7 +82,23 @@ class BaseAPIEndpoint(GenericViewSet):
         if hasattr(model, 'api_fields'):
             api_fields.extend(model.api_fields)
 
-        return api_fields
+        # Remove any new-style API field configs (only supported in v2)
+        def convert_api_fields(fields):
+            for field in fields:
+                if isinstance(field, APIField):
+                    warnings.warn(
+                        "class-based api_fields are not supported by the v1 API module. "
+                        "Please update the .api_fields attribute of {}.{} or update to the "
+                        "v2 API.".format(model._meta.app_label, model.__name__)
+                    )
+
+                    # Ignore fields with custom serializers
+                    if field.serializer is None:
+                        yield field.name
+                else:
+                    yield field
+
+        return list(convert_api_fields(api_fields))
 
     def check_query_parameters(self, queryset):
         """

--- a/wagtail/tests/demosite/models.py
+++ b/wagtail/tests/demosite/models.py
@@ -7,16 +7,16 @@ from modelcluster.contrib.taggit import ClusterTaggableManager
 from modelcluster.fields import ParentalKey
 from taggit.models import TaggedItemBase
 
+from wagtail.api import APIField
 from wagtail.utils.pagination import paginate
 from wagtail.wagtailadmin.edit_handlers import (
     FieldPanel, InlinePanel, MultiFieldPanel, PageChooserPanel)
 from wagtail.wagtailcore.fields import RichTextField
 from wagtail.wagtailcore.models import Orderable, Page
 from wagtail.wagtaildocs.edit_handlers import DocumentChooserPanel
+from wagtail.wagtailimages.api.fields import ImageRenditionField
 from wagtail.wagtailimages.edit_handlers import ImageChooserPanel
 from wagtail.wagtailsearch import index
-
-from wagtail.wagtailimages.api.fields import ImageRenditionField
 
 
 # ABSTRACT MODELS
@@ -278,13 +278,13 @@ class BlogEntryPage(Page):
     )
 
     api_fields = (
-        'body',
-        'tags',
-        'date',
-        'feed_image',
-        ('feed_image_thumbnail', ImageRenditionField('fill-300x300', source='feed_image')),
-        'carousel_items',
-        'related_links',
+        APIField('body'),
+        APIField('tags'),
+        APIField('date'),
+        APIField('feed_image'),
+        APIField('feed_image_thumbnail', serializer=ImageRenditionField('fill-300x300', source='feed_image')),
+        APIField('carousel_items'),
+        APIField('related_links'),
     )
 
     search_fields = Page.search_fields + [

--- a/wagtail/tests/demosite/models.py
+++ b/wagtail/tests/demosite/models.py
@@ -16,6 +16,8 @@ from wagtail.wagtaildocs.edit_handlers import DocumentChooserPanel
 from wagtail.wagtailimages.edit_handlers import ImageChooserPanel
 from wagtail.wagtailsearch import index
 
+from wagtail.wagtailimages.api.fields import ImageRenditionField
+
 
 # ABSTRACT MODELS
 # =============================
@@ -280,6 +282,7 @@ class BlogEntryPage(Page):
         'tags',
         'date',
         'feed_image',
+        ('feed_image_thumbnail', ImageRenditionField('fill-300x300', source='feed_image')),
         'carousel_items',
         'related_links',
     )

--- a/wagtail/wagtailadmin/tests/api/test_pages.py
+++ b/wagtail/wagtailadmin/tests/api/test_pages.py
@@ -138,7 +138,7 @@ class TestAdminPageListing(AdminAPITestCase, TestPageListing):
         content = json.loads(response.content.decode('UTF-8'))
 
         for page in content['items']:
-            self.assertEqual(set(page.keys()), {'id', 'meta', 'title', 'date', 'related_links', 'tags', 'carousel_items', 'body', 'feed_image'})
+            self.assertEqual(set(page.keys()), {'id', 'meta', 'title', 'date', 'related_links', 'tags', 'carousel_items', 'body', 'feed_image', 'feed_image_thumbnail'})
             self.assertEqual(set(page['meta'].keys()), {'type', 'detail_url', 'show_in_menus', 'first_published_at', 'seo_title', 'slug', 'parent', 'html_url', 'search_description', 'children', 'descendants', 'status', 'latest_revision_created_at'})
 
     def test_all_fields_then_remove_something(self):
@@ -146,7 +146,7 @@ class TestAdminPageListing(AdminAPITestCase, TestPageListing):
         content = json.loads(response.content.decode('UTF-8'))
 
         for page in content['items']:
-            self.assertEqual(set(page.keys()), {'id', 'meta', 'related_links', 'tags', 'carousel_items', 'body', 'feed_image'})
+            self.assertEqual(set(page.keys()), {'id', 'meta', 'related_links', 'tags', 'carousel_items', 'body', 'feed_image', 'feed_image_thumbnail'})
             self.assertEqual(set(page['meta'].keys()), {'type', 'detail_url', 'show_in_menus', 'first_published_at', 'slug', 'parent', 'html_url', 'search_description', 'children', 'descendants', 'latest_revision_created_at'})
 
     def test_all_nested_fields(self):
@@ -413,6 +413,7 @@ class TestAdminPageDetail(AdminAPITestCase, TestPageDetail):
             'tags',
             'date',
             'feed_image',
+            'feed_image_thumbnail',
             'carousel_items',
             'related_links',
             '__types',

--- a/wagtail/wagtailimages/api/admin/serializers.py
+++ b/wagtail/wagtailimages/api/admin/serializers.py
@@ -31,9 +31,6 @@ class ImageRenditionField(Field):
         self.filter_spec = filter_spec
         super(ImageRenditionField, self).__init__(*args, **kwargs)
 
-    def get_attribute(self, instance):
-        return instance
-
     def to_representation(self, image):
         try:
             thumbnail = image.get_rendition(self.filter_spec)
@@ -50,4 +47,4 @@ class ImageRenditionField(Field):
 
 
 class AdminImageSerializer(ImageSerializer):
-    thumbnail = ImageRenditionField('max-165x165', read_only=True)
+    thumbnail = ImageRenditionField('max-165x165', source='*', read_only=True)

--- a/wagtail/wagtailimages/api/admin/serializers.py
+++ b/wagtail/wagtailimages/api/admin/serializers.py
@@ -1,49 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 
-from collections import OrderedDict
-
-from rest_framework.fields import Field
-
-from ...models import SourceImageIOError
+from ..fields import ImageRenditionField
 from ..v2.serializers import ImageSerializer
-
-
-class ImageRenditionField(Field):
-    """
-    A field that generates a rendition with the specified filter spec, and serialises
-    details of that rendition.
-
-    Example:
-    "thumbnail": {
-        "url": "/media/images/myimage.max-165x165.jpg",
-        "width": 165,
-        "height": 100
-    }
-
-    If there is an error with the source image. The dict will only contain a single
-    key, "error", indicating this error:
-
-    "thumbnail": {
-        "error": "SourceImageIOError"
-    }
-    """
-    def __init__(self, filter_spec, *args, **kwargs):
-        self.filter_spec = filter_spec
-        super(ImageRenditionField, self).__init__(*args, **kwargs)
-
-    def to_representation(self, image):
-        try:
-            thumbnail = image.get_rendition(self.filter_spec)
-
-            return OrderedDict([
-                ('url', thumbnail.url),
-                ('width', thumbnail.width),
-                ('height', thumbnail.height),
-            ])
-        except SourceImageIOError:
-            return OrderedDict([
-                ('error', 'SourceImageIOError'),
-            ])
 
 
 class AdminImageSerializer(ImageSerializer):

--- a/wagtail/wagtailimages/api/fields.py
+++ b/wagtail/wagtailimages/api/fields.py
@@ -1,0 +1,45 @@
+from __future__ import absolute_import, unicode_literals
+
+from collections import OrderedDict
+
+from rest_framework.fields import Field
+
+from ..models import SourceImageIOError
+
+
+class ImageRenditionField(Field):
+    """
+    A field that generates a rendition with the specified filter spec, and serialises
+    details of that rendition.
+
+    Example:
+    "thumbnail": {
+        "url": "/media/images/myimage.max-165x165.jpg",
+        "width": 165,
+        "height": 100
+    }
+
+    If there is an error with the source image. The dict will only contain a single
+    key, "error", indicating this error:
+
+    "thumbnail": {
+        "error": "SourceImageIOError"
+    }
+    """
+    def __init__(self, filter_spec, *args, **kwargs):
+        self.filter_spec = filter_spec
+        super(ImageRenditionField, self).__init__(*args, **kwargs)
+
+    def to_representation(self, image):
+        try:
+            thumbnail = image.get_rendition(self.filter_spec)
+
+            return OrderedDict([
+                ('url', thumbnail.url),
+                ('width', thumbnail.width),
+                ('height', thumbnail.height),
+            ])
+        except SourceImageIOError:
+            return OrderedDict([
+                ('error', 'SourceImageIOError'),
+            ])


### PR DESCRIPTION
Like #3361 this solves the issue of allowing image renditions in the API. But this version does it in a way that doesn't require overhauling the API module so it was much easier to implement and should be easier to test, document and review as well.

The change is quite simple, we now allow ``api_fields`` to contain two item tuples containing the field name and field definition. The definition can use any DRF field, serializer or custom field.

This PR also turns the internal ``ImageRenditionField`` into a public API so it can be used in model definitions.

Example:

```python
from wagtail.wagtailimages.api.fields import ImageRenditionField

class BlogPage(Page):
    body = models.RichTextField()
    feed_image = models.ForeignKey('wagtailimages.Image')
    ...

    api_fields = [
        'body',
        'feed_image',

        # Field with custom serialiser
        ('feed_image_thumbnail', ImageRenditionField('fill-300x300', source='feed_image')),
    ]
```