### PR TITLE
[FIX] Some things are not indexed within the update_index command.

### DIFF
--- a/wagtail/wagtailsearch/management/commands/update_index.py
+++ b/wagtail/wagtailsearch/management/commands/update_index.py
@@ -83,7 +83,7 @@ class Command(BaseCommand):
                     self.stdout.write('{}: {}.{} '.format(backend_name, model._meta.app_label, model.__name__).ljust(35), ending='')
 
                     # Add items (1000 at a time)
-                    for chunk in self.print_iter_progress(self.queryset_chunks(model.get_indexed_objects().order_by('id'))):
+                    for chunk in self.print_iter_progress(self.queryset_chunks(model.get_indexed_objects().order_by('pk'))):
                         index.add_items(model, chunk)
                         object_count += len(chunk)
 

--- a/wagtail/wagtailsearch/management/commands/update_index.py
+++ b/wagtail/wagtailsearch/management/commands/update_index.py
@@ -83,7 +83,7 @@ class Command(BaseCommand):
                     self.stdout.write('{}: {}.{} '.format(backend_name, model._meta.app_label, model.__name__).ljust(35), ending='')
 
                     # Add items (1000 at a time)
-                    for chunk in self.print_iter_progress(self.queryset_chunks(model.get_indexed_objects())):
+                    for chunk in self.print_iter_progress(self.queryset_chunks(model.get_indexed_objects().order_by('id'))):
                         index.add_items(model, chunk)
                         object_count += len(chunk)
 


### PR DESCRIPTION
I have investigated why some random images do not appear as search results in our backend and tracked it down to this line.

The reason is that there is no default order on the database queryset and since it get's retriggered on each index-chunk, the results are somewhat random and do skip some images (or documents).

Adding a `order_by` clause fixes that.