### PR TITLE
[WIP] Allow to use panels in a custom document model

### DIFF
--- a/wagtail/wagtaildocs/forms.py
+++ b/wagtail/wagtaildocs/forms.py
@@ -6,7 +6,8 @@ from django.utils.lru_cache import lru_cache
 from django.utils.translation import ugettext_lazy as _
 
 from wagtail.wagtailadmin import widgets
-from wagtail.wagtailadmin.edit_handlers import extract_panel_definitions_from_model_class, ObjectList
+from wagtail.wagtailadmin.edit_handlers import (
+    ObjectList, extract_panel_definitions_from_model_class)
 from wagtail.wagtailadmin.forms import (
     BaseCollectionMemberForm, collection_member_permission_formset_factory)
 from wagtail.wagtaildocs.models import Document

--- a/wagtail/wagtaildocs/forms.py
+++ b/wagtail/wagtaildocs/forms.py
@@ -20,19 +20,24 @@ class BaseDocumentForm(BaseCollectionMemberForm):
 
 @lru_cache()
 def get_document_edit_handler(model):
+    # TODO: Add a check that edit_handler contains panel for the collection field
+    # TODO: Add a check that form is subclass of the BaseDocumentForm class
+
     if hasattr(model, 'edit_handler'):
         # use the edit handler specified on the document class
         edit_handler = model.edit_handler
     else:
         panels = extract_panel_definitions_from_model_class(model)
-        edit_handler = ObjectList(panels, base_form_class=BaseDocumentForm)
+        edit_handler = ObjectList(panels)
+
+    # TODO: We need a better solution for model.edit_handler
+    if edit_handler.base_form_class is None:
+        edit_handler.base_form_class = BaseDocumentForm
 
     return edit_handler.bind_to_model(model)
 
 
 def get_document_form(model):
-    # TODO: Add a check that edit_handler contains panel for the collection field
-    # TODO: Add a check that form is subclass of the BaseDocumentForm class
     edit_handler_class = get_document_edit_handler(model)
     return edit_handler_class.get_form_class(model)
 

--- a/wagtail/wagtaildocs/models.py
+++ b/wagtail/wagtaildocs/models.py
@@ -2,6 +2,8 @@ from __future__ import absolute_import, unicode_literals
 
 import os.path
 
+from django import forms
+
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.core.urlresolvers import reverse
@@ -11,6 +13,8 @@ from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 from taggit.managers import TaggableManager
 
+from wagtail.wagtailadmin import widgets
+from wagtail.wagtailadmin.edit_handlers import FieldPanel
 from wagtail.wagtailadmin.utils import get_object_usage
 from wagtail.wagtailcore.models import CollectionMember
 from wagtail.wagtailsearch import index
@@ -80,12 +84,21 @@ class AbstractDocument(CollectionMember, index.Indexed, models.Model):
 
 
 class Document(AbstractDocument):
+    # TODO: Add a deprecation warning or remove, if there are no mentions in docs
+    # TODO: Add a note to upgrade consideration section for custom document models
     admin_form_fields = (
         'title',
         'file',
         'collection',
         'tags'
     )
+
+    panels = [
+        FieldPanel('title'),
+        FieldPanel('file', widget=forms.FileInput()),
+        FieldPanel('collection'),
+        FieldPanel('tags', widget=widgets.AdminTagWidget),
+    ]
 
 
 def get_document_model():

--- a/wagtail/wagtaildocs/models.py
+++ b/wagtail/wagtaildocs/models.py
@@ -14,7 +14,7 @@ from django.utils.translation import ugettext_lazy as _
 from taggit.managers import TaggableManager
 
 from wagtail.wagtailadmin import widgets
-from wagtail.wagtailadmin.edit_handlers import FieldPanel
+from wagtail.wagtailadmin.edit_handlers import FieldPanel, TabbedInterface, ObjectList
 from wagtail.wagtailadmin.utils import get_object_usage
 from wagtail.wagtailcore.models import CollectionMember
 from wagtail.wagtailsearch import index

--- a/wagtail/wagtaildocs/templates/wagtaildocs/documents/edit.html
+++ b/wagtail/wagtaildocs/templates/wagtaildocs/documents/edit.html
@@ -1,24 +1,11 @@
 {% extends "wagtailadmin/base.html" %}
 {% load i18n %}
-{% load wagtailimages_tags %}
 {% block titletag %}{% blocktrans with title=document.title %}Editing {{ title }}{% endblocktrans %}{% endblock %}
 
-{% block extra_js %}
-    {{ block.super }}
-
-    {% url 'wagtailadmin_tag_autocomplete' as autocomplete_url %}
-    <script>
-        $(function() {
-            $('#id_tags').tagit({
-                autocomplete: {source: "{{ autocomplete_url|addslashes }}"}
-            });
-        });
-    </script>
-{% endblock %}
 
 {% block content %}
     {% trans "Editing" as editing_str %}
-    {% include "wagtailadmin/shared/header.html" with title=editing_str subtitle=document.title icon="doc-full-inverse" usage_object=document %}
+    {% include "wagtailadmin/shared/header.html" with title=editing_str subtitle=document.title icon="doc-full-inverse" usage_object=document tabbed=1 merged=1 %}
 
     <div class="row row-flush nice-padding">
 
@@ -26,13 +13,9 @@
             <form action="{% url 'wagtaildocs:edit' document.id %}" method="POST" enctype="multipart/form-data" novalidate>
                 {% csrf_token %}
                 <ul class="fields">
-                    {% for field in form %}
-                        {% if field.name == 'file' %}
-                            {% include "wagtaildocs/documents/_file_field_as_li.html" %}
-                        {% else %}
-                            {% include "wagtailadmin/shared/field_as_li.html" %}
-                        {% endif %}
-                    {% endfor %}
+
+                    {{ edit_handler.render_form_content }}
+
                     <li>
                         <input type="submit" value="{% trans 'Save' %}" class="button" />
                         {% if user_can_delete %}
@@ -51,7 +34,23 @@
             </dl>
         </div>
     </div>
+{% endblock %}
+
+{% block extra_css %}
+    {{ block.super }}
+    {% include "wagtailadmin/pages/_editor_css.html" %}
+{% endblock %}
+{% block extra_js %}
+    {{ block.super }}
+    {% include "wagtailadmin/pages/_editor_js.html" %}
 
 
-    </div>
+    {% url 'wagtailadmin_tag_autocomplete' as autocomplete_url %}
+    <script>
+        $(function() {
+            $('#id_tags').tagit({
+                autocomplete: {source: "{{ autocomplete_url|addslashes }}"}
+            });
+        });
+    </script>
 {% endblock %}

--- a/wagtail/wagtailsnippets/views/snippets.py
+++ b/wagtail/wagtailsnippets/views/snippets.py
@@ -42,7 +42,7 @@ SNIPPET_EDIT_HANDLERS = {}
 def get_snippet_edit_handler(model):
     if model not in SNIPPET_EDIT_HANDLERS:
         if hasattr(model, 'edit_handler'):
-            # use the edit handler specified on the page class
+            # use the edit handler specified on the snippet class
             edit_handler = model.edit_handler
         else:
             panels = extract_panel_definitions_from_model_class(model)


### PR DESCRIPTION
This PR will allow to use edit handlers / panels in a custom document model in a similar way to page models or snippet models.

This may be useful when you need to associate an image with a document. At the moment, you can do this, but you will not have pretty image chooser.

Another use case: you want to add additional fields (let's say many to many fields) to custom document model and want to override form widget. Right now, there is no way to override widgets.

TODO:
- [ ] Fix todos in code
- [ ] Render `edit_handler` instead of `form` in document views
  - [ ] Allow tabbed interface on the CRUD views
  - [ ] Display file field using a custom layout
  - [ ] Display save / delete buttons using drop-down
- [ ] Add tests