### PR TITLE
Link to the full Elasticsearch setup docs from the Performance page

### DIFF
--- a/docs/advanced_topics/performance.rst
+++ b/docs/advanced_topics/performance.rst
@@ -33,28 +33,7 @@ Search
 
 Wagtail has strong support for `Elasticsearch <http://www.elasticsearch.org/>`_ - both in the editor interface and for users of your site - but can fall back to a database search if Elasticsearch isn't present. Elasticsearch is faster and more powerful than the Django ORM for text search, so we recommend installing it or using a hosted service like `Searchly <http://www.searchly.com/>`_.
 
-Once the Elasticsearch server is installed and running. Install the ``elasticsearch`` Python module with:
-
-.. code-block:: console
-
-    $ pip install elasticsearch
-
-then add the following to your settings:
-
-.. code-block:: python
-
-    WAGTAILSEARCH_BACKENDS = {
-        'default': {
-            'BACKEND': 'wagtail.wagtailsearch.backends.elasticsearch',
-            'INDEX': '{{ project_name }}',
-        },
-    }
-
-Once Elasticsearch is configured, you can index any existing content you may have:
-
-.. code-block:: console
-
-    $ ./manage.py update_index
+For details on configuring Wagtail for Elasticsearch, see :ref:`wagtailsearch_backends_elasticsearch`.
 
 
 Database


### PR DESCRIPTION
The brief Elasticsearch setup instructions given on the Performance page are difficult for a new user to follow, because they don't go into enough detail to cover the typical gotchas (e.g. the need to match ES and Python library versions, and the fact that you don't literally type `{{ project_name }}`) - see http://stackoverflow.com/questions/42841110/unable-to-set-up-elasticsearch-for-wagtail. We should point to the full docs instead.