### PR TITLE
#510 Add Page type to PageChooser button label

### DIFF
--- a/wagtail/wagtailadmin/widgets.py
+++ b/wagtail/wagtailadmin/widgets.py
@@ -138,7 +138,10 @@ class AdminPageChooser(AdminChooser):
         super(AdminPageChooser, self).__init__(**kwargs)
 
         if target_models:
-            self.choose_one_text += ' (' + ', '.join([model._meta.verbose_name.title() for model in target_models]) + ')'
+            models = ', '.join([model._meta.verbose_name.title() for model in target_models if model._meta.verbose_name.title() != 'Page'])
+            if models:
+                self.choose_one_text += ' (' + models + ')'
+
         self.target_models = list(target_models or [Page])
         self.can_choose_root = can_choose_root
 

--- a/wagtail/wagtailadmin/widgets.py
+++ b/wagtail/wagtailadmin/widgets.py
@@ -138,7 +138,8 @@ class AdminPageChooser(AdminChooser):
         super(AdminPageChooser, self).__init__(**kwargs)
 
         if target_models:
-            self.choose_one_text += ' (' + ', '.join([model._meta.model_name for model in target_models]) + ')'
+            # import pdb; pdb.set_trace()
+            self.choose_one_text += ' (' + ', '.join([model._meta.verbose_name.title() for model in target_models]) + ')'
         self.target_models = list(target_models or [Page])
         self.can_choose_root = can_choose_root
 

--- a/wagtail/wagtailadmin/widgets.py
+++ b/wagtail/wagtailadmin/widgets.py
@@ -138,7 +138,6 @@ class AdminPageChooser(AdminChooser):
         super(AdminPageChooser, self).__init__(**kwargs)
 
         if target_models:
-            # import pdb; pdb.set_trace()
             self.choose_one_text += ' (' + ', '.join([model._meta.verbose_name.title() for model in target_models]) + ')'
         self.target_models = list(target_models or [Page])
         self.can_choose_root = can_choose_root

--- a/wagtail/wagtailadmin/widgets.py
+++ b/wagtail/wagtailadmin/widgets.py
@@ -137,6 +137,8 @@ class AdminPageChooser(AdminChooser):
     def __init__(self, target_models=None, can_choose_root=False, **kwargs):
         super(AdminPageChooser, self).__init__(**kwargs)
 
+        if target_models:
+            self.choose_one_text += ' (' + (', ').join([model._meta.model_name for model in target_models]) + ')'
         self.target_models = list(target_models or [Page])
         self.can_choose_root = can_choose_root
 

--- a/wagtail/wagtailadmin/widgets.py
+++ b/wagtail/wagtailadmin/widgets.py
@@ -138,7 +138,7 @@ class AdminPageChooser(AdminChooser):
         super(AdminPageChooser, self).__init__(**kwargs)
 
         if target_models:
-            self.choose_one_text += ' (' + (', ').join([model._meta.model_name for model in target_models]) + ')'
+            self.choose_one_text += ' (' + ', '.join([model._meta.model_name for model in target_models]) + ')'
         self.target_models = list(target_models or [Page])
         self.can_choose_root = can_choose_root
 


### PR DESCRIPTION
This should fix https://github.com/wagtail/wagtail/issues/510

As the original issue did not take into account that it is possible to specify more than one page type I chose to put all page types in parenthesis (which can actually lead to a pretty large button I guess :/).