### PR TITLE
Avatar transparency fix

### DIFF
--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_formatters.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_formatters.scss
@@ -1,4 +1,4 @@
-// user avatars, with fallback to placeholder graphic if no gravatar exists
+// user avatars
 .avatar {
     border-radius: 100%;
     position: relative;
@@ -19,36 +19,11 @@
         border: 0;
     }
 
-    &:before {
-        border-radius: 100%;
-        color: $color-grey-3;
-        border: 2px solid $color-grey-3;
-        text-align: center;
-        display: inline-block;
-        width: 42px;
-        height: 42px;
-        line-height: 42px;
-        margin: 2px 0 0;
-        z-index: 1;
-        left: 0;
-        font-size: 22px;
-    }
-
     &.small {
         vertical-align: middle;
         margin: 0 0.5em;
         width: 25px;
         height: 25px;
-
-        &:before {
-            margin: 0;
-            width: 22px;
-            height: 22px;
-            line-height: 22px;
-            border-width: 1px;
-            font-size: 14px;
-            text-indent: 0.1em;
-        }
     }
 
     &.square {
@@ -61,11 +36,6 @@
         &:before {
             border-radius: 0;
         }
-    }
-
-    &.avatar-on-dark:before {
-        color: $color-grey-2;
-        border-color: $color-grey-2; 
     }
 }
 

--- a/wagtail/wagtailadmin/templates/wagtailadmin/home.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/home.html
@@ -12,11 +12,9 @@
 {% block content %}
     <header class="merged nice-padding">
         <div class="row row-flush">
-            {% if user.email %}
-                <div class="col1">
-                    <div class="avatar"><img src="{% gravatar_url user.email %}" alt="" /></div>
-                </div>
-            {% endif %}
+            <div class="col1">
+                <div class="avatar"><img src="{% gravatar_url user.email %}" alt="" /></div>
+            </div>
             <div class="col9">
                 <h1>{% block branding_welcome %}{% blocktrans %}Welcome to the {{ site_name }} Wagtail CMS{% endblocktrans %}{% endblock %}</h1>
                 <h2>{{ user.get_full_name|default:user.get_username }}</h2>

--- a/wagtail/wagtailadmin/templates/wagtailadmin/home.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/home.html
@@ -14,7 +14,7 @@
         <div class="row row-flush">
             {% if user.email %}
                 <div class="col1">
-                    <div class="avatar icon icon-user"><img src="{% gravatar_url user.email %}" /></div>
+                    <div class="avatar"><img src="{% gravatar_url user.email %}" alt="" /></div>
                 </div>
             {% endif %}
             <div class="col9">

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/edit.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/edit.html
@@ -88,9 +88,7 @@
                             {% blocktrans with last_mod=page.get_latest_revision.created_at %}Last modified: {{ last_mod }}{% endblocktrans %}
                             {% if page.get_latest_revision.user %}
                                 {% blocktrans with modified_by=page.get_latest_revision.user.get_full_name|default:page.get_latest_revision.user.get_username %}by {{ modified_by }}{% endblocktrans %}
-                                {% if page.get_latest_revision.user.email %}
-                                    <span class="avatar small icon icon-user"><img src="{% gravatar_url page.get_latest_revision.user.email 25 %}" /></span>
-                                {% endif %}
+                                <span class="avatar small"><img src="{% gravatar_url page.get_latest_revision.user.email 25 %}" /></span>
                             {% endif %}
                             <a href="{% url 'wagtailadmin_pages:revisions_index' page.id %}" class="underlined">{% trans 'Revisions' %}</a>
                         {% endif %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/revisions/list.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/revisions/list.html
@@ -14,7 +14,7 @@
             {% for revision in revisions %}
                 <tr {% if revision == page.get_latest_revision %}class="index"{% endif %}>
                     <td class="title">
-                        <h2><a href="{% url 'wagtailadmin_pages:revisions_revert' page.id revision.id %}">{{ revision.created_at }}</a> <span class="unbold">{% trans 'by' context 'points to a user who created a revision' %}<span class="avatar small icon icon-user"><img src="{% gravatar_url revision.user.email 25 %}" /></span>{{ revision.user }}</span> {% if revision == page.get_latest_revision %}({% trans 'Current draft' %}){% endif %}</h2>
+                        <h2><a href="{% url 'wagtailadmin_pages:revisions_revert' page.id revision.id %}">{{ revision.created_at }}</a> <span class="unbold">{% trans 'by' context 'points to a user who created a revision' %}<span class="avatar small"><img src="{% gravatar_url revision.user.email 25 %}" /></span>{{ revision.user }}</span> {% if revision == page.get_latest_revision %}({% trans 'Current draft' %}){% endif %}</h2>
 
                         <ul class="actions">
                             <li><a href="{% url 'wagtailadmin_pages:revisions_view' page.id revision.id %}" class="button button-small button-secondary" target="_blank">{% trans 'Preview' %}</a></li>

--- a/wagtail/wagtailadmin/templates/wagtailadmin/shared/main_nav.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/shared/main_nav.html
@@ -6,7 +6,7 @@
 
         <li class="footer" id="footer">
             <div class="account" id="account-settings" title="{% trans 'Edit your account' %}">
-                <span class="avatar square avatar-on-dark icon icon-user">
+                <span class="avatar square avatar-on-dark">
                     {% if request.user.email %}
                     <img src="{% gravatar_url request.user.email 25 %}" />
                     {% endif %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/shared/main_nav.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/shared/main_nav.html
@@ -7,9 +7,7 @@
         <li class="footer" id="footer">
             <div class="account" id="account-settings" title="{% trans 'Edit your account' %}">
                 <span class="avatar square avatar-on-dark">
-                    {% if request.user.email %}
                     <img src="{% gravatar_url request.user.email 25 %}" />
-                    {% endif %}
                 </span>
                 <em class="icon icon-arrow-up-after">{{ request.user.first_name|default:request.user.get_username }}</em>
             </div>

--- a/wagtail/wagtailadmin/templates/wagtailadmin/shared/user_avatar.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/shared/user_avatar.html
@@ -1,6 +1,6 @@
 {% load gravatar %}
 
-<span class="avatar small icon icon-user">
+<span class="avatar small">
     <img src="{% gravatar_url user.email 25 %}" />
 </span>
 

--- a/wagtail/wagtailadmin/templatetags/gravatar.py
+++ b/wagtail/wagtailadmin/templatetags/gravatar.py
@@ -28,7 +28,7 @@ class GravatarUrlNode(template.Node):
         except template.VariableDoesNotExist:
             return ''
 
-        default = "blank"
+        default = "mm"
         size = int(self.size) * 2  # requested at retina size by default and scaled down at point of use with css
 
         gravatar_url = "//www.gravatar.com/avatar/{hash}?{params}".format(


### PR DESCRIPTION
Refs: #3291

Gravatar returns a blank transparent image by default if the gravatar it self does not exists.
We changed the default avatar URL to mystery man (mm).

This looks like this: 

![before-after1](https://cloud.githubusercontent.com/assets/1274867/24206861/cc6b21d0-0f1f-11e7-8996-e3c7f898c4c9.png)
![before-after2](https://cloud.githubusercontent.com/assets/1274867/24206862/cc6f057a-0f1f-11e7-8da8-b65b70a02fc0.png)


