### PR TITLE
Extendable sitemap generator

### DIFF
--- a/docs/reference/contrib/sitemaps.rst
+++ b/docs/reference/contrib/sitemaps.rst
@@ -87,7 +87,7 @@ Each dictionary can contain the following:
 You can add more but you will need to override the ``wagtailsitemaps/sitemap.xml`` template in order for them to be displayed in the sitemap, extending the ``Sitemap`` generator is also an option.
 
 .. note::
-    As of Wagtail 1.10 it's possible to extend te existing ``Sitemap`` generator class. this can be done by setting ``WAGTAILSITEMAPS_GENERATOR`` to your own implementation of the ``Sitemap`` object. This can be used to implement multi language sitemaps for example.
+    As of Wagtail 1.10 it's possible to extend the existing ``Sitemap`` generator class. this can be done by setting ``WAGTAILSITEMAPS_GENERATOR`` to your own implementation of the ``Sitemap`` object. This can be done used to implement multi language sitemaps, for example.
 
 
 Cache

--- a/docs/reference/contrib/sitemaps.rst
+++ b/docs/reference/contrib/sitemaps.rst
@@ -84,7 +84,10 @@ Each dictionary can contain the following:
  - **changefreq**
  - **priority**
 
-You can add more but you will need to override the ``wagtailsitemaps/sitemap.xml`` template in order for them to be displayed in the sitemap.
+You can add more but you will need to override the ``wagtailsitemaps/sitemap.xml`` template in order for them to be displayed in the sitemap, extending the ``Sitemap`` generator is also an option.
+
+.. note::
+    As of Wagtail 1.10 it's possible to extend te existing ``Sitemap`` generator class. this can be done by setting ``WAGTAILSITEMAPS_GENERATOR`` to your own implementation of the ``Sitemap`` object. This can be used to implement multi language sitemaps for example.
 
 
 Cache

--- a/wagtail/contrib/wagtailsitemaps/tests.py
+++ b/wagtail/contrib/wagtailsitemaps/tests.py
@@ -122,7 +122,7 @@ class TestGetGeneratorClass(TestCase):
 
     @override_settings(WAGTAILSITEMAPS_GENERATOR='wagtail.tests.testapp.sitemap_generator.CustomSitemap')
     def get_custom_generator(self):
-        self.assertEqual(get_generator_class(), CustomSitemap)
+        self.assertRaises(get_generator_class(), ImportError)
 
     @override_settings(WAGTAILSITEMAPS_GENERATOR='path.to.nonexistent.SitemapGenerator')
     def get_nonexistent_generator(self):

--- a/wagtail/contrib/wagtailsitemaps/tests.py
+++ b/wagtail/contrib/wagtailsitemaps/tests.py
@@ -1,12 +1,14 @@
 from __future__ import absolute_import, unicode_literals
 
 from django.core.cache import cache
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 from wagtail.tests.testapp.models import EventIndex, SimplePage
+from wagtail.tests.testapp.sitemap_generator import CustomSitemap
 from wagtail.wagtailcore.models import Page, PageViewRestriction, Site
 
 from .sitemap_generator import Sitemap
+from .views import get_generator_class
 
 
 class TestSitemapGenerator(TestCase):
@@ -111,3 +113,17 @@ class TestSitemapView(TestCase):
 
         # Check that the content is the same
         self.assertEqual(first_response.content, second_response.content)
+
+
+class TestGetGeneratorClass(TestCase):
+
+    def get_default_generator(self):
+        self.assertEqual(get_generator_class(), Sitemap)
+
+    @override_settings(WAGTAILSITEMAPS_GENERATOR='wagtail.tests.testapp.sitemap_generator.CustomSitemap')
+    def get_custom_generator(self):
+        self.assertEqual(get_generator_class(), CustomSitemap)
+
+    @override_settings(WAGTAILSITEMAPS_GENERATOR='path.to.nonexistent.SitemapGenerator')
+    def get_nonexistent_generator(self):
+        self.assertEqual(get_generator_class(), Sitemap)

--- a/wagtail/contrib/wagtailsitemaps/tests.py
+++ b/wagtail/contrib/wagtailsitemaps/tests.py
@@ -122,8 +122,9 @@ class TestGetGeneratorClass(TestCase):
 
     @override_settings(WAGTAILSITEMAPS_GENERATOR='wagtail.tests.testapp.sitemap_generator.CustomSitemap')
     def get_custom_generator(self):
-        self.assertRaises(get_generator_class(), ImportError)
+        self.assertEqual(get_generator_class(), CustomSitemap)
 
     @override_settings(WAGTAILSITEMAPS_GENERATOR='path.to.nonexistent.SitemapGenerator')
     def get_nonexistent_generator(self):
-        self.assertEqual(get_generator_class(), Sitemap)
+        with self.assertRaises(ImportError):
+            get_generator_class()

--- a/wagtail/contrib/wagtailsitemaps/views.py
+++ b/wagtail/contrib/wagtailsitemaps/views.py
@@ -10,12 +10,7 @@ DEFAULT_GENERATOR = 'wagtail.contrib.wagtailsitemaps.sitemap_generator.Sitemap'
 
 def get_generator_class():
     generator_class = getattr(settings, 'WAGTAILSITEMAPS_GENERATOR', DEFAULT_GENERATOR)
-    try:
-        Sitemap = import_string(generator_class)
-    except ImportError:
-        Sitemap = import_string(DEFAULT_GENERATOR)
-
-    return Sitemap
+    return import_string(generator_class)
 
 
 def sitemap(request):

--- a/wagtail/contrib/wagtailsitemaps/views.py
+++ b/wagtail/contrib/wagtailsitemaps/views.py
@@ -3,8 +3,19 @@ from __future__ import absolute_import, unicode_literals
 from django.conf import settings
 from django.core.cache import cache
 from django.http import HttpResponse
+from django.utils.module_loading import import_string
 
-from .sitemap_generator import Sitemap
+DEFAULT_GENERATOR = 'wagtail.contrib.wagtailsitemaps.sitemap_generator.Sitemap'
+
+
+def get_generator_class():
+    generator_class = getattr(settings, 'WAGTAILSITEMAPS_GENERATOR', DEFAULT_GENERATOR)
+    try:
+        Sitemap = import_string(generator_class)
+    except ImportError:
+        Sitemap = import_string(DEFAULT_GENERATOR)
+
+    return Sitemap
 
 
 def sitemap(request):
@@ -12,6 +23,9 @@ def sitemap(request):
     sitemap_xml = cache.get(cache_key)
 
     if not sitemap_xml:
+        # Get Sitemap generator class
+        Sitemap = get_generator_class()
+
         # Rerender sitemap
         sitemap = Sitemap(request.site)
         sitemap_xml = sitemap.render()

--- a/wagtail/tests/testapp/sitemap_generator.py
+++ b/wagtail/tests/testapp/sitemap_generator.py
@@ -1,0 +1,5 @@
+from wagtail.contrib.wagtailsitemaps.sitemap_generator import Sitemap
+
+
+class CustomSitemap(Sitemap):
+    pass

--- a/wagtail/tests/testapp/sitemap_generator.py
+++ b/wagtail/tests/testapp/sitemap_generator.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from wagtail.contrib.wagtailsitemaps.sitemap_generator import Sitemap
 
 


### PR DESCRIPTION
Allow the generator class of the ``wagtail.contrib.wagtailsitemaps`` module to be customized. A customized generator class allows the user to implement their own sitemap.xml generator which makes it possible to create for example a multi-language sitemap. Also excluding pages from the sitemap should be easier.

Solves: #833 , #2657 and #1196 