### PR TITLE
#3281 Added _slug_is_available check to can_move_to method

### DIFF
--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -985,7 +985,8 @@ class Page(six.with_metaclass(PageBase, AbstractPage, index.Indexed, Clusterable
         Checks if this page instance can be moved to be a subpage of a parent
         page instance.
         """
-        return self.can_exist_under(parent)
+        return self._slug_is_available(
+            self.slug, parent, self) and self.can_exist_under(parent)
 
     @classmethod
     def get_verbose_name(cls):


### PR DESCRIPTION
A more elegant solution to the problem mentioned in ticket #3281. The can_move_to method now checks whether the slug is still available at the designated target.