### PR TITLE
663 site root icon

### DIFF
--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/listing/_page_title_explore.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/listing/_page_title_explore.html
@@ -3,6 +3,12 @@
 {# The title field for a page in the page listing, when in 'explore' mode #}
 
 <h2>
+    {% if page.sites_rooted_here.exists %}
+        {% if perms.wagtailcore.add_site or perms.wagtailcore.change_site or perms.wagtailcore.delete_site %}
+            <a href="{% url 'wagtailsites:index' %}" class="icon icon-site" title="Sites menu"></a>
+        {% endif %}
+    {% endif %}
+
     {% if page_perms.can_edit %}
         <a href="{% url 'wagtailadmin_pages:edit' page.id %}" title="{% trans 'Edit this page' %}">{{ page.get_admin_display_title }}</a>
     {% else %}

--- a/wagtail/wagtailadmin/tests/test_pages_views.py
+++ b/wagtail/wagtailadmin/tests/test_pages_views.py
@@ -98,6 +98,18 @@ class TestPageExplorer(TestCase, WagtailTestUtils):
         self.assertEqual(Page.objects.get(id=1), response.context['parent_page'])
         self.assertTrue(response.context['pages'].paginator.object_list.filter(id=self.root_page.id).exists())
 
+    def test_explore_root_shows_icon(self):
+        response = self.client.get(reverse('wagtailadmin_explore_root'))
+        self.assertEqual(response.status_code, 200)
+
+        # Administrator (or user with add_site permission) should see the
+        # sites link with the icon-site icon
+        self.assertContains(
+            response,
+            ("""<a href="/admin/sites/" class="icon icon-site" """
+             """title="Sites menu"></a>""")
+        )
+
     def test_ordering(self):
         response = self.client.get(
             reverse('wagtailadmin_explore', args=(self.root_page.id, )),

--- a/wagtail/wagtailadmin/views/pages.py
+++ b/wagtail/wagtailadmin/views/pages.py
@@ -42,7 +42,7 @@ def index(request, parent_page_id=None):
     else:
         parent_page = Page.get_first_root_node().specific
 
-    pages = parent_page.get_children().prefetch_related('content_type')
+    pages = parent_page.get_children().prefetch_related('content_type', 'sites_rooted_here')
 
     # Get page ordering
     ordering = request.GET.get('ordering', '-latest_revision_created_at')


### PR DESCRIPTION
This PR extends https://github.com/wagtail/wagtail/pull/3439/
by adding a basic test case to check if the icon is present in the root listing view