### PR TITLE
Remove custom SQL statements in Page._update_descendant_url_paths

### DIFF
--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -14,8 +14,9 @@ from django.core.exceptions import ValidationError
 from django.core.handlers.base import BaseHandler
 from django.core.handlers.wsgi import WSGIRequest
 from django.core.urlresolvers import reverse
-from django.db import connection, models, transaction
-from django.db.models import Case, IntegerField, Q, When
+from django.db import models, transaction
+from django.db.models import Case, IntegerField, Q, Value, When
+from django.db.models.functions import Concat, Substr
 from django.http import Http404
 from django.template.response import TemplateResponse
 # Must be imported from Django so we get the new implementation of with_metaclass
@@ -587,32 +588,12 @@ class Page(six.with_metaclass(PageBase, AbstractPage, index.Indexed, Clusterable
         return errors
 
     def _update_descendant_url_paths(self, old_url_path, new_url_path):
-        cursor = connection.cursor()
-        if connection.vendor == 'sqlite':
-            update_statement = """
-                UPDATE wagtailcore_page
-                SET url_path = %s || substr(url_path, %s)
-                WHERE path LIKE %s AND id <> %s
-            """
-        elif connection.vendor == 'mysql':
-            update_statement = """
-                UPDATE wagtailcore_page
-                SET url_path= CONCAT(%s, substring(url_path, %s))
-                WHERE path LIKE %s AND id <> %s
-            """
-        elif connection.vendor in ('mssql', 'microsoft'):
-            update_statement = """
-                UPDATE wagtailcore_page
-                SET url_path= CONCAT(%s, (SUBSTRING(url_path, 0, %s)))
-                WHERE path LIKE %s AND id <> %s
-            """
-        else:
-            update_statement = """
-                UPDATE wagtailcore_page
-                SET url_path = %s || substring(url_path from %s)
-                WHERE path LIKE %s AND id <> %s
-            """
-        cursor.execute(update_statement, [new_url_path, len(old_url_path) + 1, self.path + '%', self.id])
+        (Page.objects
+            .filter(path__startswith=self.path)
+            .exclude(pk=self.pk)
+            .update(url_path=Concat(
+                Value(new_url_path),
+                Substr('url_path', len(old_url_path) + 1))))
 
     #: Return this page in its most specific subclassed form.
     @cached_property


### PR DESCRIPTION
Django 1.8 introduced ORM functions for Concat and Substring so use that
instead of custom SQL statements based on the connection vendor.