### PR TITLE
Fix wrong filter button height in wagtailforms submissions listing header

### DIFF
--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_forms.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_forms.scss
@@ -1127,6 +1127,7 @@ li.inline:first-child {
     .required .field > label:after {
         display: none;
     }
+
     .button-filter {
         height: 2.71em;
         border-color: transparent;

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_forms.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_forms.scss
@@ -1127,6 +1127,10 @@ li.inline:first-child {
     .required .field > label:after {
         display: none;
     }
+    .button-filter {
+        height: 2.71em;
+        border-color: transparent;
+    }
 }
 
 // file drop zones

--- a/wagtail/wagtailforms/templates/wagtailforms/index_submissions.html
+++ b/wagtail/wagtailforms/templates/wagtailforms/index_submissions.html
@@ -99,7 +99,7 @@
                                 {% include "wagtailadmin/shared/field_as_li.html" with field=field field_classes="field-small" li_classes="col4" %}
                             {% endfor %}
                             <li class="submit col2">
-                                <button name="action" value="filter" class="button">{% trans 'Filter' %}</button>
+                                <button name="action" value="filter" class="button button-filter">{% trans 'Filter' %}</button>
                             </li>
                         </ul>
                     </div>


### PR DESCRIPTION
This PR fixes #2891 .

I've checked it on MacOS Sierra in: 
* Chrome 57.0.2987.98
* Firefox 51.0.1
* Safari 10.0.3
* IE11 on Browserstack
