### PR TITLE
Fixes the Django 1.11 ORM compatibility issue.

### DIFF
--- a/wagtail/wagtailsearch/backends/elasticsearch.py
+++ b/wagtail/wagtailsearch/backends/elasticsearch.py
@@ -278,7 +278,8 @@ class ElasticsearchSearchQuery(BaseSearchQuery):
         if lookup == 'in':
             return {
                 'terms': {
-                    column_name: list(value),
+                    column_name: (value.get_compiler(self.queryset._db)
+                                  .execute_sql()),
                 }
             }
 

--- a/wagtail/wagtailsearch/backends/elasticsearch.py
+++ b/wagtail/wagtailsearch/backends/elasticsearch.py
@@ -279,8 +279,8 @@ class ElasticsearchSearchQuery(BaseSearchQuery):
 
         if lookup == 'in':
             if isinstance(value, Query):
-                value = (value.get_compiler(self.queryset._db
-                                            or DEFAULT_DB_ALIAS)
+                db_alias = self.queryset._db or DEFAULT_DB_ALIAS
+                value = (value.get_compiler(db_alias)
                          .execute_sql(result_type=SINGLE))
             elif not isinstance(value, list):
                 value = list(value)

--- a/wagtail/wagtailsearch/backends/elasticsearch.py
+++ b/wagtail/wagtailsearch/backends/elasticsearch.py
@@ -3,7 +3,9 @@ from __future__ import absolute_import, unicode_literals
 import copy
 import json
 
-from django.db import models
+from django.db import models, DEFAULT_DB_ALIAS
+from django.db.models.sql import Query
+from django.db.models.sql.constants import SINGLE
 from django.utils.crypto import get_random_string
 from django.utils.six.moves.urllib.parse import urlparse
 from elasticsearch import Elasticsearch, NotFoundError
@@ -276,10 +278,15 @@ class ElasticsearchSearchQuery(BaseSearchQuery):
             }
 
         if lookup == 'in':
+            if isinstance(value, Query):
+                value = (value.get_compiler(self.queryset._db
+                                            or DEFAULT_DB_ALIAS)
+                         .execute_sql(result_type=SINGLE))
+            elif not isinstance(value, list):
+                value = list(value)
             return {
                 'terms': {
-                    column_name: (value.get_compiler(self.queryset._db)
-                                  .execute_sql()),
+                    column_name: value,
                 }
             }
 

--- a/wagtail/wagtailsearch/backends/elasticsearch.py
+++ b/wagtail/wagtailsearch/backends/elasticsearch.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, unicode_literals
 import copy
 import json
 
-from django.db import models, DEFAULT_DB_ALIAS
+from django.db import DEFAULT_DB_ALIAS, models
 from django.db.models.sql import Query
 from django.db.models.sql.constants import SINGLE
 from django.utils.crypto import get_random_string

--- a/wagtail/wagtailsearch/tests/test_backends.py
+++ b/wagtail/wagtailsearch/tests/test_backends.py
@@ -128,10 +128,30 @@ class BackendTests(WagtailTestUtils):
         results = self.backend.search(None, models.SearchTest, filters=dict(live=True))
         self.assertEqual(set(results), {self.testb, self.testc.searchtest_ptr})
 
-    def test_filters_with_in_lookup(self):
+    def test_filters_in_subquery(self):
         live_page_titles = models.SearchTest.objects.filter(live=True).values_list('title', flat=True)
         results = self.backend.search(None, models.SearchTest, filters=dict(title__in=live_page_titles))
         self.assertEqual(set(results), {self.testb, self.testc.searchtest_ptr})
+
+    def test_filters_in_list(self):
+        live_page_titles = ['Hello']
+        results = self.backend.search(None, models.SearchTest,
+                                      filters=dict(title__in=live_page_titles))
+        self.assertEqual(set(results), {self.testb, self.testc.searchtest_ptr})
+
+    def test_filters_in_iterable(self):
+        class CustomIterable:
+            def __init__(self, data):
+                self.data = data
+
+            def __iter__(self):
+                for item in self.data:
+                    yield item
+
+        results = self.backend.search(
+            None, models.SearchTest,
+            filters=dict(title__in=CustomIterable(['World'])))
+        self.assertEqual(set(results), {self.testd.searchtest_ptr})
 
     def test_single_result(self):
         result = self.backend.search(None, models.SearchTest)[0]


### PR DESCRIPTION
This pull request fixes the remaining issue blocking 1.11 compatibility (see #3314).
It is due to the changes done in [django/django@1bc249c](https://github.com/django/django/commit/1bc249c2a67c24fcd28436c85388eff1d826e305).