### PR TITLE
Fixes ticket #2251. Implemented is_multipart on EditHandler

### DIFF
--- a/wagtail/wagtailadmin/edit_handlers.py
+++ b/wagtail/wagtailadmin/edit_handlers.py
@@ -163,6 +163,19 @@ class EditHandler(object):
         """
         return ""
 
+    def is_multipart(self):
+        """ Checks form's *and* formsets' is_multipart method """
+        multipart = False
+        if self.form.is_multipart():
+            multipart = True
+        else:
+            for k in self.form.formsets.keys():
+                if self.form.formsets[k].is_multipart():
+                    multipart = True
+                    break
+
+        return multipart
+
     def render_as_object(self):
         """
         Render this object as it should appear within an ObjectList. Should not

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/create.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/create.html
@@ -18,7 +18,7 @@
         </div>
     </header>
 
-    <form id="page-edit-form" action="{% url 'wagtailadmin_pages:add' content_type.app_label content_type.model parent_page.id %}" method="POST" novalidate{% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>
+    <form id="page-edit-form" action="{% url 'wagtailadmin_pages:add' content_type.app_label content_type.model parent_page.id %}" method="POST" novalidate{% if edit_handler.is_multipart %} enctype="multipart/form-data"{% endif %}>
         {% csrf_token %}
         <input type="hidden" name="next" value="{{ next }}">
         {{ edit_handler.render_form_content }}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/edit.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/edit.html
@@ -25,7 +25,7 @@
         </div>
     </header>
 
-    <form id="page-edit-form" action="{% url 'wagtailadmin_pages:edit' page.id %}" method="POST" novalidate{% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>
+    <form id="page-edit-form" action="{% url 'wagtailadmin_pages:edit' page.id %}" method="POST" novalidate{% if edit_handler.is_multipart %} enctype="multipart/form-data"{% endif %}>
         {% csrf_token %}
 
         <input type="hidden" name="next" value="{{ next }}">

--- a/wagtail/wagtailadmin/tests/test_edit_handlers.py
+++ b/wagtail/wagtailadmin/tests/test_edit_handlers.py
@@ -800,3 +800,36 @@ class TestInlinePanel(TestCase, WagtailTestUtils):
         with self.ignore_deprecation_warnings():
             self.assertRaises(TypeError, lambda: InlinePanel(label="Speakers"))
             self.assertRaises(TypeError, lambda: InlinePanel(EventPage, 'speakers', label="Speakers", bacon="chunky"))
+
+    def test_is_multipart(self):
+        """
+        Check whether is_multipart returns True when an InlinePanel contains
+        a FileInput and False otherwise
+        """
+        SpeakerObjectList = ObjectList([
+            InlinePanel('speakers', label="Speakers", panels=[
+                FieldPanel('first_name', widget=forms.FileInput),
+            ]),
+        ]).bind_to_model(EventPage)
+        SpeakerInlinePanel = SpeakerObjectList.children[0]
+        EventPageForm = SpeakerObjectList.get_form_class(EventPage)
+
+        event_page = EventPage.objects.get(slug='christmas')
+        form = EventPageForm(instance=event_page)
+        panel = SpeakerInlinePanel(instance=event_page, form=form)
+
+        self.assertTrue(panel.is_multipart())
+
+        SpeakerObjectList = ObjectList([
+            InlinePanel('speakers', label="Speakers", panels=[
+                FieldPanel('first_name', widget=forms.Textarea),
+            ]),
+        ]).bind_to_model(EventPage)
+        SpeakerInlinePanel = SpeakerObjectList.children[0]
+        EventPageForm = SpeakerObjectList.get_form_class(EventPage)
+
+        event_page = EventPage.objects.get(slug='christmas')
+        form = EventPageForm(instance=event_page)
+        panel = SpeakerInlinePanel(instance=event_page, form=form)
+
+        self.assertFalse(panel.is_multipart())


### PR DESCRIPTION
A form's enctype attribute was not set to "multipart/form-data" when an InlinePanel contained a FileInput field. This fix solves the issue.