### PR TITLE
Document pep8 issues to ignore

### DIFF
--- a/docs/contributing/python_guidelines.rst
+++ b/docs/contributing/python_guidelines.rst
@@ -4,7 +4,11 @@ Python coding guidelines
 PEP8
 ~~~~
 
-We ask that all Python contributions adhere to the `PEP8 <http://www.python.org/dev/peps/pep-0008/>`_ style guide, apart from the restriction on line length (E501). In addition, import lines should be sorted according to `isort <http://timothycrosley.github.io/isort/>`_ rules. If you have installed Wagtail's testing dependencies (``pip install -e .[testing]``), you can check your code by running ``make lint``.
+We ask that all Python contributions adhere to the `PEP8 <http://www.python.org/dev/peps/pep-0008/>`_ style guide, apart from the restriction on line length (E501) and some minor docstring-related issues.
+The list of PEP8 violations to ignore is in the ``tox.ini`` file, under the ``[flake8]`` header.
+You might want to configure the flake8 linter in your editor/IDE to use the configuration in this file.
+
+In addition, import lines should be sorted according to `isort <http://timothycrosley.github.io/isort/>`_ rules. If you have installed Wagtail's testing dependencies (``pip install -e .[testing]``), you can check your code by running ``make lint``.
 
 
 Python 2 and 3 compatibility

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,25 @@ envlist = py{27,34,35}-dj{18,110,110head}-{sqlite,postgres,mysql}-{elasticsearch
           py{27,34,35,36}-dj111-{sqlite,postgres,mysql}-{elasticsearch5,elasticsearch2,elasticsearch,noelasticsearch},
           flake8
 
+[flake8]
+# D100: Missing docstring in public module
+# D101: Missing docstring in public class
+# D102: Missing docstring in public method
+# D103: Missing docstring in public function
+# D105: Missing docstring in magic method
+# D200: One-line docstring should fit on one line with quotes
+# D202: No blank lines allowed after function docstring
+# D204: 1 blank line required after docstring
+# D205: 1 blank line required between summary line and description
+# D209: Multi-line docstring cloasing quotes should be on a separate line
+# D400: First line should end with a period
+# D401: First line should be in imperative mood
+# E303: Too many blank lines
+# E501: Line too long
+# N805: First argument of a method should be named 'self'
+# N806: Variable in function should be lowercase
+ignore = D100,D101,D102,D103,D105,D200,D202,D204,D205,D209,D400,D401,E303,E501,N805,N806
+
 [testenv]
 install_command = pip install -e ".[testing]" -U {opts} {packages}
 commands =


### PR DESCRIPTION
As it turns out, E501 is not the only pep8 violation we have in our Python files currently. In order for my linter (flake8lint on SublimeText) to stop moaning, i had to ignore:
- D100: Missing docstring in public module
- D101: Missing docstring in public class
- D102: Missing docstring in public method
- D103: Missing docstring in public function
- D105: Missing docstring in magic method
- D200: One-line docstring should fit on one line with quotes
- D202: No blank lines allowed after function docstring
- D204: 1 blank line required after docstring
- D205: 1 blank line required between summary line and description
- D209: Multi-line docstring cloasing quotes should be on a separate line
- D400: First line should en with a period
- D401: First line should be in imperative mood
- E303: Too many blank lines
- E501: Line too long
- N805: First argument of a method should be named 'self'
- N806: Variable in function should be lowercase

I've added this list to `tox.ini` and documented that. Advantages:

- explicitly list all accepted violations
- can be used by editor/IDE flake8 linter as configuration file  


 
[V] Do the tests still pass? (http://docs.wagtail.io/en/latest/contributing/developing.html#testing)
[V] Does the code comply with the style guide? (Run `make lint` from the Wagtail root)
[-] (not relevant) For Python changes: Have you added tests to cover the new/fixed behaviour?
[-] (not relevant) For new features: Has the documentation been updated accordingly?
