### PR TITLE
Add appyveyor config

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,20 @@
+services:
+  - mssql2016
+
+environment:
+  matrix:
+    - TOXENV: py27-dj18-sqlite-noelasticsearch
+    - TOXENV: py27-dj110-sqlite-noelasticsearch
+    - TOXENV: py35-dj18-sqlite-noelasticsearch
+    - TOXENV: py35-dj110-sqlite-noelasticsearch
+
+matrix:
+  fast_finish: true
+
+install:
+  - C:\Python36\python -m pip install tox
+
+build: false  # Not a C# project
+
+test_script:
+  - C:\Python36\scripts\tox

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 skipsdist = True
 usedevelop = True
 
-envlist = py{27,34,35}-dj{18,110,110head}-{sqlite,postgres,mysql}-{elasticsearch5,elasticsearch2,elasticsearch,noelasticsearch},
+envlist = py{27,34,35}-dj{18,110,110head}-{sqlite,postgres,mysql,mssql}-{elasticsearch5,elasticsearch2,elasticsearch,noelasticsearch},
           py{27,34,35,36}-dj111-{sqlite,postgres,mysql}-{elasticsearch5,elasticsearch2,elasticsearch,noelasticsearch},
           flake8
 
@@ -47,6 +47,9 @@ deps =
     dj110: Django>=1.10a1,<1.11
     dj110head: git+https://github.com/django/django.git@stable/1.10.x#egg=Django
     dj111: Django>=1.11b1,<2.0
+    dj18-mssql: django-pyodbc-azure==1.8.13.0
+    dj19-mssql: django-pyodbc-azure==1.9.6.0
+    dj110-mssql: django-pyodbc-azure==1.10.4.0
     postgres: psycopg2>=2.6
     mysql: mysqlclient==1.3.6
     elasticsearch: elasticsearch>=1,<2
@@ -58,9 +61,16 @@ setenv =
     postgres: DATABASE_ENGINE=django.db.backends.postgresql_psycopg2
 
     mysql: DATABASE_ENGINE=django.db.backends.mysql
-    mysql: DATABASE_USER=wagtail
     mysql: DATABASE_HOST=localhost
     mysql: DATABASE_USER=root
+
+    # Specific for Appveyor, see:
+    # https://www.appveyor.com/docs/services-databases/#sql-server-2016
+    mssql: DATABASE_ENGINE=sql_server.pyodbc
+    mssql: DATABASE_HOST=(local)\SQL2016
+    mssql: DATABASE_NAME=master
+    mssql: DATABASE_USER=sa
+    mssql: DATABASE_PASS=Password12!
 
 [testenv:flake8]
 basepython=python3.4

--- a/wagtail/tests/settings.py
+++ b/wagtail/tests/settings.py
@@ -26,6 +26,13 @@ DATABASES = {
     }
 }
 
+# Add extra options when mssql is used (on for example appveyor)
+if DATABASES['default']['ENGINE'] == 'sql_server.pyodbc':
+    DATABASES['default']['OPTIONS'] = {
+        'driver': 'SQL Server Native Client 11.0',
+        'MARS_Connection': 'True',
+    }
+
 
 SECRET_KEY = 'not needed'
 

--- a/wagtail/wagtaildocs/tests.py
+++ b/wagtail/wagtaildocs/tests.py
@@ -1143,7 +1143,7 @@ class TestServeViewWithSendfile(TestCase):
         response = self.get()
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response['X-Sendfile'], os.path.join(settings.MEDIA_ROOT, self.document.file.name))
+        self.assertEqual(response['X-Sendfile'], self.document.file.path)
 
     @unittest.skipIf(
         django.VERSION < (1, 9), "Fails on Django 1.8"


### PR DESCRIPTION
This commit does add settings for using mssql on appveyor
but there are still some issues with timeouts. For now only
the sqlite build is enabled.

Note that the build currently (correctly) fails on windows