### PR TITLE
Add parent_page argument in page forms even in GET requests

### DIFF
--- a/wagtail/wagtailadmin/views/pages.py
+++ b/wagtail/wagtailadmin/views/pages.py
@@ -276,7 +276,7 @@ def create(request, content_type_app_name, content_type_model_name, parent_page_
             has_unsaved_changes = True
     else:
         signals.init_new_page.send(sender=create, page=page, parent=parent_page)
-        form = form_class(instance=page)
+        form = form_class(instance=page, parent_page=parent_page)
         edit_handler = edit_handler_class(instance=page, form=form)
         has_unsaved_changes = False
 
@@ -479,7 +479,7 @@ def edit(request, page_id):
             )
             has_unsaved_changes = True
     else:
-        form = form_class(instance=page)
+        form = form_class(instance=page, parent_page=parent)
         edit_handler = edit_handler_class(instance=page, form=form)
         has_unsaved_changes = False
 


### PR DESCRIPTION
This allows a new page to inherit values from its parent page by overriding `base_form_class`, or to modify the form based on some conditions of its parent.

In my specific case, I am trying to automatically inherit the language of the parent page for all subpages created underneath it.