### PR TITLE
Replace coveralls with codecov.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -105,7 +105,7 @@ services:
 
 # Package installation
 install:
-  - pip install tox coveralls
+  - pip install tox codecov
   - 'if [[ -n "$INSTALL_ELASTICSEARCH2" ]]; then ./scripts/travis/install_elasticsearch2.sh; fi'
   - 'if [[ -n "$INSTALL_ELASTICSEARCH5" ]]; then ./scripts/travis/install_elasticsearch5.sh; fi'
 
@@ -120,7 +120,7 @@ script:
   tox
 
 after_success:
-  coveralls
+  - codecov
 
 # Who to notify about build results
 notifications:

--- a/README.rst
+++ b/README.rst
@@ -4,8 +4,9 @@
     :target: https://pypi.python.org/pypi/wagtail/
 .. image:: https://img.shields.io/pypi/v/wagtail.svg
     :target: https://pypi.python.org/pypi/wagtail/
-.. image:: https://coveralls.io/repos/github/wagtail/wagtail/badge.svg?branch=master
-    :target: https://coveralls.io/github/wagtail/wagtail?branch=master
+.. image:: http://codecov.io/github/wagtail/wagtail/coverage.svg?branch=master
+    :target: http://codecov.io/github/wagtail/wagtail?branch=master
+
 
 Wagtail CMS
 ===========


### PR DESCRIPTION
This replaces coveralls with codecov.io which provides a better overall experience.

See #3506 for more information
