### PR TITLE
Fix annotate_score followed by slice

### DIFF
--- a/wagtail/wagtailsearch/backends/base.py
+++ b/wagtail/wagtailsearch/backends/base.py
@@ -124,6 +124,7 @@ class BaseSearchResults(object):
         new = klass(self.backend, self.query, prefetch_related=self.prefetch_related)
         new.start = self.start
         new.stop = self.stop
+        new._score_field = self._score_field
         return new
 
     def _do_search(self):

--- a/wagtail/wagtailsearch/tests/test_elasticsearch_backend.py
+++ b/wagtail/wagtailsearch/tests/test_elasticsearch_backend.py
@@ -254,6 +254,13 @@ class TestElasticsearchSearchBackend(BackendTests, TestCase):
         for result in results:
             self.assertIsInstance(result._score, float)
 
+    def test_annotate_score_with_slice(self):
+        # #3431 - Annotate score wasn't being passed to new queryset when slicing
+        results = self.backend.search("Hello", models.SearchTest).annotate_score('_score')[:10]
+
+        for result in results:
+            self.assertIsInstance(result._score, float)
+
 
 class TestElasticsearchSearchQuery(TestCase):
     def assertDictEqual(self, a, b):


### PR DESCRIPTION
This fixes the bug reported by @nimasmi in https://github.com/wagtail/wagtail/issues/3431#issuecomment-288051751

Slicing creates a new SearchResults object but the ``score_field`` (set by ``.annotate_score()`` wasn't being passed along to the new SearchResults causing the score to not be annotated.