### PR TITLE
Revert #3501

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -45,7 +45,6 @@ Changelog
  * Fix: Default avatar no longer visible when using a transparent gravatar image (Thijs Kramer)
  * Fix: Scrolling within the datetime picker is now usable again for touchpads (Ralph Jacobs)
  * Fix: List-based fields within form builder form submissions are now displayed as comma-separated strings rather than as Python lists (Christine Ho, Matt Westcott)
- * Fix: Ensure that page editor forms are submitted as multipart when file fields exist in InlinePanels (Wietze Helmantel)
  * Fix: The page type usage listing now have a translatable page title (Ramon de Jezus)
  * Fix: Styles for submission filtering form now have a consistent height. (Thijs Kramer)
  * Fix: Custom user models with a primary key type requiring `get_db_prep_value` conversion are now supported (thenewguy)

--- a/docs/releases/1.10.rst
+++ b/docs/releases/1.10.rst
@@ -57,7 +57,6 @@ Bug fixes
  * Default avatar no longer visible when using a transparent gravatar image (Thijs Kramer)
  * Scrolling within the datetime picker is now usable again for touchpads (Ralph Jacobs)
  * List-based fields within form builder form submissions are now displayed as comma-separated strings rather than as Python lists (Christine Ho, Matt Westcott)
- * Ensure that page editor forms are submitted as multipart when file fields exist in InlinePanels (Wietze Helmantel)
  * The page type usage listing now have a translatable page title (Ramon de Jezus)
  * Styles for submission filtering form now have a consistent height. (Thijs Kramer)
 

--- a/wagtail/wagtailadmin/edit_handlers.py
+++ b/wagtail/wagtailadmin/edit_handlers.py
@@ -163,19 +163,6 @@ class EditHandler(object):
         """
         return ""
 
-    def is_multipart(self):
-        """ Checks form's *and* formsets' is_multipart method """
-        multipart = False
-        if self.form.is_multipart():
-            multipart = True
-        else:
-            for k in self.form.formsets.keys():
-                if self.form.formsets[k].is_multipart():
-                    multipart = True
-                    break
-
-        return multipart
-
     def render_as_object(self):
         """
         Render this object as it should appear within an ObjectList. Should not

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/create.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/create.html
@@ -18,7 +18,7 @@
         </div>
     </header>
 
-    <form id="page-edit-form" action="{% url 'wagtailadmin_pages:add' content_type.app_label content_type.model parent_page.id %}" method="POST" novalidate{% if edit_handler.is_multipart %} enctype="multipart/form-data"{% endif %}>
+    <form id="page-edit-form" action="{% url 'wagtailadmin_pages:add' content_type.app_label content_type.model parent_page.id %}" method="POST" novalidate{% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>
         {% csrf_token %}
         <input type="hidden" name="next" value="{{ next }}">
         {{ edit_handler.render_form_content }}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/edit.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/edit.html
@@ -26,7 +26,7 @@
         </div>
     </header>
 
-    <form id="page-edit-form" action="{% url 'wagtailadmin_pages:edit' page.id %}" method="POST" novalidate{% if edit_handler.is_multipart %} enctype="multipart/form-data"{% endif %}>
+    <form id="page-edit-form" action="{% url 'wagtailadmin_pages:edit' page.id %}" method="POST" novalidate{% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>
         {% csrf_token %}
 
         <input type="hidden" name="next" value="{{ next }}">

--- a/wagtail/wagtailadmin/tests/test_edit_handlers.py
+++ b/wagtail/wagtailadmin/tests/test_edit_handlers.py
@@ -802,36 +802,3 @@ class TestInlinePanel(TestCase, WagtailTestUtils):
         with self.ignore_deprecation_warnings():
             self.assertRaises(TypeError, lambda: InlinePanel(label="Speakers"))
             self.assertRaises(TypeError, lambda: InlinePanel(EventPage, 'speakers', label="Speakers", bacon="chunky"))
-
-    def test_is_multipart(self):
-        """
-        Check whether is_multipart returns True when an InlinePanel contains
-        a FileInput and False otherwise
-        """
-        SpeakerObjectList = ObjectList([
-            InlinePanel('speakers', label="Speakers", panels=[
-                FieldPanel('first_name', widget=forms.FileInput),
-            ]),
-        ]).bind_to_model(EventPage)
-        SpeakerInlinePanel = SpeakerObjectList.children[0]
-        EventPageForm = SpeakerObjectList.get_form_class(EventPage)
-
-        event_page = EventPage.objects.get(slug='christmas')
-        form = EventPageForm(instance=event_page)
-        panel = SpeakerInlinePanel(instance=event_page, form=form)
-
-        self.assertTrue(panel.is_multipart())
-
-        SpeakerObjectList = ObjectList([
-            InlinePanel('speakers', label="Speakers", panels=[
-                FieldPanel('first_name', widget=forms.Textarea),
-            ]),
-        ]).bind_to_model(EventPage)
-        SpeakerInlinePanel = SpeakerObjectList.children[0]
-        EventPageForm = SpeakerObjectList.get_form_class(EventPage)
-
-        event_page = EventPage.objects.get(slug='christmas')
-        form = EventPageForm(instance=event_page)
-        panel = SpeakerInlinePanel(instance=event_page, form=form)
-
-        self.assertFalse(panel.is_multipart())


### PR DESCRIPTION
See https://github.com/wagtail/wagtail/pull/3501#issuecomment-290380892 - this change wrongly assumes that edit handlers will always be used with a ClusterForm, and a fix isn't required here anyway because it was fixed separately as https://github.com/wagtail/django-modelcluster/pull/73.

This reverts commit a6bb67f75d588416f34d2884b9cb0ecb0f96e36d.
