### PR TITLE
Remove double-escaping of PKs in modeladmin URLs (rebase of #2722)

### DIFF
--- a/wagtail/contrib/modeladmin/helpers/button.py
+++ b/wagtail/contrib/modeladmin/helpers/button.py
@@ -54,7 +54,7 @@ class ButtonHelper(object):
         classnames = self.inspect_button_classnames + classnames_add
         cn = self.finalise_classname(classnames, classnames_exclude)
         return {
-            'url': self.url_helper.get_action_url('inspect', pk),
+            'url': self.url_helper.get_action_url('inspect', quote(pk)),
             'label': _('Inspect'),
             'classname': cn,
             'title': _('Inspect this %s') % self.verbose_name,
@@ -68,7 +68,7 @@ class ButtonHelper(object):
         classnames = self.edit_button_classnames + classnames_add
         cn = self.finalise_classname(classnames, classnames_exclude)
         return {
-            'url': self.url_helper.get_action_url('edit', pk),
+            'url': self.url_helper.get_action_url('edit', quote(pk)),
             'label': _('Edit'),
             'classname': cn,
             'title': _('Edit this %s') % self.verbose_name,
@@ -82,7 +82,7 @@ class ButtonHelper(object):
         classnames = self.delete_button_classnames + classnames_add
         cn = self.finalise_classname(classnames, classnames_exclude)
         return {
-            'url': self.url_helper.get_action_url('delete', pk),
+            'url': self.url_helper.get_action_url('delete', quote(pk)),
             'label': _('Delete'),
             'classname': cn,
             'title': _('Delete this %s') % self.verbose_name,
@@ -98,7 +98,7 @@ class ButtonHelper(object):
             classnames_exclude = []
         ph = self.permission_helper
         usr = self.request.user
-        pk = quote(getattr(obj, self.opts.pk.attname))
+        pk = getattr(obj, self.opts.pk.attname)
         btns = []
         if('inspect' not in exclude and ph.user_can_inspect_obj(usr, obj)):
             btns.append(
@@ -128,7 +128,7 @@ class PageButtonHelper(ButtonHelper):
         classnames = self.unpublish_button_classnames + classnames_add
         cn = self.finalise_classname(classnames, classnames_exclude)
         return {
-            'url': self.url_helper.get_action_url('unpublish', pk),
+            'url': self.url_helper.get_action_url('unpublish', quote(pk)),
             'label': _('Unpublish'),
             'classname': cn,
             'title': _('Unpublish this %s') % self.verbose_name,
@@ -142,7 +142,7 @@ class PageButtonHelper(ButtonHelper):
         classnames = self.copy_button_classnames + classnames_add
         cn = self.finalise_classname(classnames, classnames_exclude)
         return {
-            'url': self.url_helper.get_action_url('copy', pk),
+            'url': self.url_helper.get_action_url('copy', quote(pk)),
             'label': _('Copy'),
             'classname': cn,
             'title': _('Copy this %s') % self.verbose_name,
@@ -158,7 +158,7 @@ class PageButtonHelper(ButtonHelper):
             classnames_exclude = []
         ph = self.permission_helper
         usr = self.request.user
-        pk = quote(getattr(obj, self.opts.pk.attname))
+        pk = getattr(obj, self.opts.pk.attname)
         btns = []
         if('inspect' not in exclude and ph.user_can_inspect_obj(usr, obj)):
             btns.append(

--- a/wagtail/contrib/modeladmin/helpers/button.py
+++ b/wagtail/contrib/modeladmin/helpers/button.py
@@ -54,7 +54,7 @@ class ButtonHelper(object):
         classnames = self.inspect_button_classnames + classnames_add
         cn = self.finalise_classname(classnames, classnames_exclude)
         return {
-            'url': self.url_helper.get_action_url('inspect', quote(pk)),
+            'url': self.url_helper.get_action_url('inspect', pk),
             'label': _('Inspect'),
             'classname': cn,
             'title': _('Inspect this %s') % self.verbose_name,
@@ -68,7 +68,7 @@ class ButtonHelper(object):
         classnames = self.edit_button_classnames + classnames_add
         cn = self.finalise_classname(classnames, classnames_exclude)
         return {
-            'url': self.url_helper.get_action_url('edit', quote(pk)),
+            'url': self.url_helper.get_action_url('edit', pk),
             'label': _('Edit'),
             'classname': cn,
             'title': _('Edit this %s') % self.verbose_name,
@@ -82,7 +82,7 @@ class ButtonHelper(object):
         classnames = self.delete_button_classnames + classnames_add
         cn = self.finalise_classname(classnames, classnames_exclude)
         return {
-            'url': self.url_helper.get_action_url('delete', quote(pk)),
+            'url': self.url_helper.get_action_url('delete', pk),
             'label': _('Delete'),
             'classname': cn,
             'title': _('Delete this %s') % self.verbose_name,
@@ -128,7 +128,7 @@ class PageButtonHelper(ButtonHelper):
         classnames = self.unpublish_button_classnames + classnames_add
         cn = self.finalise_classname(classnames, classnames_exclude)
         return {
-            'url': self.url_helper.get_action_url('unpublish', quote(pk)),
+            'url': self.url_helper.get_action_url('unpublish', pk),
             'label': _('Unpublish'),
             'classname': cn,
             'title': _('Unpublish this %s') % self.verbose_name,
@@ -142,7 +142,7 @@ class PageButtonHelper(ButtonHelper):
         classnames = self.copy_button_classnames + classnames_add
         cn = self.finalise_classname(classnames, classnames_exclude)
         return {
-            'url': self.url_helper.get_action_url('copy', quote(pk)),
+            'url': self.url_helper.get_action_url('copy', pk),
             'label': _('Copy'),
             'classname': cn,
             'title': _('Copy this %s') % self.verbose_name,

--- a/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
+++ b/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
@@ -477,8 +477,13 @@ class TestQuoting(TestCase, WagtailTestUtils):
 
     def test_action_links(self):
         response = self.client.get('/admin/modeladmintest/token/')
-        soup = BeautifulSoup(response.content, 'html.parser')
-        action_links = soup.find_all(href=re.compile('/admin/modeladmintest/token/'))
-        for link in action_links:
-            link_response = self.client.get(link['href'])
-            self.assertEqual(link_response.status_code, self.expected_status_code)
+
+        self.assertContains(response, 'href="/admin/modeladmintest/token/edit/RegularName/"')
+        self.assertContains(response, 'href="/admin/modeladmintest/token/delete/RegularName/"')
+        self.assertContains(response, 'href="/admin/modeladmintest/token/edit/Irregular_5FName/"')
+        self.assertContains(response, 'href="/admin/modeladmintest/token/delete/Irregular_5FName/"')
+
+        response = self.client.get('/admin/modeladmintest/token/edit/Irregular_5FName/')
+        self.assertEqual(response.status_code, 200)
+        response = self.client.get('/admin/modeladmintest/token/delete/Irregular_5FName/')
+        self.assertEqual(response.status_code, 200)

--- a/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
+++ b/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
@@ -1,8 +1,5 @@
 from __future__ import absolute_import, unicode_literals
 
-import re
-
-from bs4 import BeautifulSoup
 import mock
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group


### PR DESCRIPTION
Rebase of #2722, with some fixes:

* The test now explicitly checks for the expected URLs. Simply testing "all links return 200 responses" is too indirect, since (for example) that would be satisfied by no links at all;
* Stylistically it's better to remove the *other* `quote` operation. The responsibility for quoting the PK should lie with the method that inserts the PK into the URL - the caller of `edit_button` etc shouldn't have to know or care what happens to the PK it passes (and if `edit_button` was expecting a pre-quoted ID, we'd need to indicate that in the method signature by calling the parameter something like `quoted_pk` rather than `pk`).