### PR TITLE
Fetch search results with scroll API

### DIFF
--- a/wagtail/wagtailsearch/backends/base.py
+++ b/wagtail/wagtailsearch/backends/base.py
@@ -135,7 +135,7 @@ class BaseSearchResults(object):
 
     def results(self):
         if self._results_cache is None:
-            self._results_cache = self._do_search()
+            self._results_cache = list(self._do_search())
         return self._results_cache
 
     def count(self):

--- a/wagtail/wagtailsearch/backends/db.py
+++ b/wagtail/wagtailsearch/backends/db.py
@@ -79,7 +79,7 @@ class DatabaseSearchResults(BaseSearchResults):
         if self._score_field:
             queryset = queryset.annotate(**{self._score_field: Value(None, output_field=models.FloatField())})
 
-        return queryset
+        return queryset.iterator()
 
     def _do_count(self):
         return self.get_queryset().count()

--- a/wagtail/wagtailsearch/tests/elasticsearch_common_tests.py
+++ b/wagtail/wagtailsearch/tests/elasticsearch_common_tests.py
@@ -157,3 +157,17 @@ class ElasticsearchCommonSearchBackendTests(object):
 
         results = self.backend.search(None, models.Book)[10:120]
         self.assertEqual(len(results), 110)
+
+    def test_slice_to_next_page(self):
+        # ES scroll API doesn't support offset. The implementation has an optimisation
+        # which will skip the first page if the first result is on the second page
+        books = []
+        for i in range(150):
+            books.append(models.Book.objects.create(title="Book {}".format(i), publication_date=date(2017, 10, 21), number_of_pages=i))
+
+        index = self.backend.get_index_for_model(models.Book)
+        index.add_items(models.Book, books)
+        index.refresh()
+
+        results = self.backend.search(None, models.Book)[110:]
+        self.assertEqual(len(results), 53)

--- a/wagtail/wagtailsearch/tests/test_elasticsearch2_backend.py
+++ b/wagtail/wagtailsearch/tests/test_elasticsearch2_backend.py
@@ -384,7 +384,6 @@ class TestElasticsearch2SearchResults(TestCase):
         list(results)  # Performs search
 
         search.assert_any_call(
-            from_=0,
             body={'query': 'QUERY'},
             _source=False,
             fields='pk',

--- a/wagtail/wagtailsearch/tests/test_elasticsearch2_backend.py
+++ b/wagtail/wagtailsearch/tests/test_elasticsearch2_backend.py
@@ -21,12 +21,6 @@ from .test_backends import BackendTests
 class TestElasticsearch2SearchBackend(BackendTests, ElasticsearchCommonSearchBackendTests, TestCase):
     backend_path = 'wagtail.wagtailsearch.backends.elasticsearch2'
 
-    # TODO: we have to put [:100] on the end of the query due to issue #3431
-    def test_search_all(self):
-        # Searches on None should return everything in the index
-        results = self.backend.search(None, models.Book)[:100]
-        self.assertSetEqual(set(results), set(models.Book.objects.all()))
-
     # Broken
     @unittest.expectedFailure
     def test_filter_in_values_list_subquery(self):
@@ -41,20 +35,6 @@ class TestElasticsearch2SearchBackend(BackendTests, ElasticsearchCommonSearchBac
     @unittest.expectedFailure
     def test_delete(self):
         super(TestElasticsearch2SearchBackend, self).test_delete()
-
-    def test_more_than_ten_results(self):
-        # #3431 reported that Elasticsearch only sends back 10 results if the results set is not sliced
-        for i in range(20):
-            a = models.SearchTest()
-            a.title = "Hello World {}".format(i)
-            a.save()
-            self.backend.add(a)
-
-        self.refresh_index()
-
-        results = self.backend.search("Hello", models.SearchTest)
-
-        self.assertEqual(len(results), 23)
 
 
 class TestElasticsearch2SearchQuery(TestCase):

--- a/wagtail/wagtailsearch/tests/test_elasticsearch2_backend.py
+++ b/wagtail/wagtailsearch/tests/test_elasticsearch2_backend.py
@@ -427,7 +427,6 @@ class TestElasticsearch2SearchResults(TestCase):
             _source=False,
             fields='pk',
             index='wagtail__searchtests_book',
-            scroll='2m',
             size=1
         )
 
@@ -444,7 +443,6 @@ class TestElasticsearch2SearchResults(TestCase):
             _source=False,
             fields='pk',
             index='wagtail__searchtests_book',
-            scroll='2m',
             size=3
         )
 
@@ -461,7 +459,6 @@ class TestElasticsearch2SearchResults(TestCase):
             _source=False,
             fields='pk',
             index='wagtail__searchtests_book',
-            scroll='2m',
             size=10
         )
 
@@ -479,7 +476,6 @@ class TestElasticsearch2SearchResults(TestCase):
             _source=False,
             fields='pk',
             index='wagtail__searchtests_book',
-            scroll='2m',
             size=1
         )
 

--- a/wagtail/wagtailsearch/tests/test_elasticsearch2_backend.py
+++ b/wagtail/wagtailsearch/tests/test_elasticsearch2_backend.py
@@ -42,6 +42,20 @@ class TestElasticsearch2SearchBackend(BackendTests, ElasticsearchCommonSearchBac
     def test_delete(self):
         super(TestElasticsearch2SearchBackend, self).test_delete()
 
+    def test_more_than_ten_results(self):
+        # #3431 reported that Elasticsearch only sends back 10 results if the results set is not sliced
+        for i in range(20):
+            a = models.SearchTest()
+            a.title = "Hello World {}".format(i)
+            a.save()
+            self.backend.add(a)
+
+        self.refresh_index()
+
+        results = self.backend.search("Hello", models.SearchTest)
+
+        self.assertEqual(len(results), 23)
+
 
 class TestElasticsearch2SearchQuery(TestCase):
     def assertDictEqual(self, a, b):
@@ -394,7 +408,9 @@ class TestElasticsearch2SearchResults(TestCase):
             body={'query': 'QUERY'},
             _source=False,
             fields='pk',
-            index='wagtail__searchtests_book'
+            index='wagtail__searchtests_book',
+            scroll='2m',
+            size=100
         )
 
     @mock.patch('elasticsearch.Elasticsearch.search')
@@ -411,6 +427,7 @@ class TestElasticsearch2SearchResults(TestCase):
             _source=False,
             fields='pk',
             index='wagtail__searchtests_book',
+            scroll='2m',
             size=1
         )
 
@@ -427,6 +444,7 @@ class TestElasticsearch2SearchResults(TestCase):
             _source=False,
             fields='pk',
             index='wagtail__searchtests_book',
+            scroll='2m',
             size=3
         )
 
@@ -443,6 +461,7 @@ class TestElasticsearch2SearchResults(TestCase):
             _source=False,
             fields='pk',
             index='wagtail__searchtests_book',
+            scroll='2m',
             size=10
         )
 
@@ -460,6 +479,7 @@ class TestElasticsearch2SearchResults(TestCase):
             _source=False,
             fields='pk',
             index='wagtail__searchtests_book',
+            scroll='2m',
             size=1
         )
 

--- a/wagtail/wagtailsearch/tests/test_elasticsearch5_backend.py
+++ b/wagtail/wagtailsearch/tests/test_elasticsearch5_backend.py
@@ -388,7 +388,6 @@ class TestElasticsearch5SearchResults(TestCase):
         list(results)  # Performs search
 
         search.assert_any_call(
-            from_=0,
             body={'query': 'QUERY'},
             _source=False,
             stored_fields='pk',

--- a/wagtail/wagtailsearch/tests/test_elasticsearch5_backend.py
+++ b/wagtail/wagtailsearch/tests/test_elasticsearch5_backend.py
@@ -20,12 +20,6 @@ from .test_backends import BackendTests
 class TestElasticsearch5SearchBackend(BackendTests, ElasticsearchCommonSearchBackendTests, TestCase):
     backend_path = 'wagtail.wagtailsearch.backends.elasticsearch5'
 
-    # TODO: we have to put [:100] on the end of the query due to issue #3431
-    def test_search_all(self):
-        # Searches on None should return everything in the index
-        results = self.backend.search(None, models.Book)[:100]
-        self.assertSetEqual(set(results), set(models.Book.objects.all()))
-
     # Broken
     @unittest.expectedFailure
     def test_filter_isnull_true(self):
@@ -45,20 +39,6 @@ class TestElasticsearch5SearchBackend(BackendTests, ElasticsearchCommonSearchBac
     @unittest.expectedFailure
     def test_delete(self):
         super(TestElasticsearch5SearchBackend, self).test_delete()
-
-    def test_more_than_ten_results(self):
-        # #3431 reported that Elasticsearch only sends back 10 results if the results set is not sliced
-        for i in range(20):
-            a = models.SearchTest()
-            a.title = "Hello World {}".format(i)
-            a.save()
-            self.backend.add(a)
-
-        self.refresh_index()
-
-        results = self.backend.search("Hello", models.SearchTest)
-
-        self.assertEqual(len(results), 23)
 
 
 class TestElasticsearch5SearchQuery(TestCase):

--- a/wagtail/wagtailsearch/tests/test_elasticsearch5_backend.py
+++ b/wagtail/wagtailsearch/tests/test_elasticsearch5_backend.py
@@ -46,6 +46,20 @@ class TestElasticsearch5SearchBackend(BackendTests, ElasticsearchCommonSearchBac
     def test_delete(self):
         super(TestElasticsearch5SearchBackend, self).test_delete()
 
+    def test_more_than_ten_results(self):
+        # #3431 reported that Elasticsearch only sends back 10 results if the results set is not sliced
+        for i in range(20):
+            a = models.SearchTest()
+            a.title = "Hello World {}".format(i)
+            a.save()
+            self.backend.add(a)
+
+        self.refresh_index()
+
+        results = self.backend.search("Hello", models.SearchTest)
+
+        self.assertEqual(len(results), 23)
+
 
 class TestElasticsearch5SearchQuery(TestCase):
     def assertDictEqual(self, a, b):
@@ -398,7 +412,9 @@ class TestElasticsearch5SearchResults(TestCase):
             body={'query': 'QUERY'},
             _source=False,
             stored_fields='pk',
-            index='wagtail__searchtests_book'
+            index='wagtail__searchtests_book',
+            scroll='2m',
+            size=100
         )
 
     @mock.patch('elasticsearch.Elasticsearch.search')
@@ -415,6 +431,7 @@ class TestElasticsearch5SearchResults(TestCase):
             _source=False,
             stored_fields='pk',
             index='wagtail__searchtests_book',
+            scroll='2m',
             size=1
         )
 
@@ -431,6 +448,7 @@ class TestElasticsearch5SearchResults(TestCase):
             _source=False,
             stored_fields='pk',
             index='wagtail__searchtests_book',
+            scroll='2m',
             size=3
         )
 
@@ -447,6 +465,7 @@ class TestElasticsearch5SearchResults(TestCase):
             _source=False,
             stored_fields='pk',
             index='wagtail__searchtests_book',
+            scroll='2m',
             size=10
         )
 
@@ -464,6 +483,7 @@ class TestElasticsearch5SearchResults(TestCase):
             _source=False,
             stored_fields='pk',
             index='wagtail__searchtests_book',
+            scroll='2m',
             size=1
         )
 

--- a/wagtail/wagtailsearch/tests/test_elasticsearch5_backend.py
+++ b/wagtail/wagtailsearch/tests/test_elasticsearch5_backend.py
@@ -431,7 +431,6 @@ class TestElasticsearch5SearchResults(TestCase):
             _source=False,
             stored_fields='pk',
             index='wagtail__searchtests_book',
-            scroll='2m',
             size=1
         )
 
@@ -448,7 +447,6 @@ class TestElasticsearch5SearchResults(TestCase):
             _source=False,
             stored_fields='pk',
             index='wagtail__searchtests_book',
-            scroll='2m',
             size=3
         )
 
@@ -465,7 +463,6 @@ class TestElasticsearch5SearchResults(TestCase):
             _source=False,
             stored_fields='pk',
             index='wagtail__searchtests_book',
-            scroll='2m',
             size=10
         )
 
@@ -483,7 +480,6 @@ class TestElasticsearch5SearchResults(TestCase):
             _source=False,
             stored_fields='pk',
             index='wagtail__searchtests_book',
-            scroll='2m',
             size=1
         )
 

--- a/wagtail/wagtailsearch/tests/test_elasticsearch_backend.py
+++ b/wagtail/wagtailsearch/tests/test_elasticsearch_backend.py
@@ -385,7 +385,6 @@ class TestElasticsearchSearchResults(TestCase):
         list(results)  # Performs search
 
         search.assert_any_call(
-            from_=0,
             body={'query': 'QUERY'},
             _source=False,
             fields='pk',

--- a/wagtail/wagtailsearch/tests/test_elasticsearch_backend.py
+++ b/wagtail/wagtailsearch/tests/test_elasticsearch_backend.py
@@ -428,7 +428,6 @@ class TestElasticsearchSearchResults(TestCase):
             _source=False,
             fields='pk',
             index='wagtail',
-            scroll='2m',
             size=1
         )
 
@@ -445,7 +444,6 @@ class TestElasticsearchSearchResults(TestCase):
             _source=False,
             fields='pk',
             index='wagtail',
-            scroll='2m',
             size=3
         )
 
@@ -462,7 +460,6 @@ class TestElasticsearchSearchResults(TestCase):
             _source=False,
             fields='pk',
             index='wagtail',
-            scroll='2m',
             size=10
         )
 
@@ -480,7 +477,6 @@ class TestElasticsearchSearchResults(TestCase):
             _source=False,
             fields='pk',
             index='wagtail',
-            scroll='2m',
             size=1
         )
 

--- a/wagtail/wagtailsearch/tests/test_elasticsearch_backend.py
+++ b/wagtail/wagtailsearch/tests/test_elasticsearch_backend.py
@@ -22,12 +22,6 @@ from .test_backends import BackendTests
 class TestElasticsearchSearchBackend(BackendTests, ElasticsearchCommonSearchBackendTests, TestCase):
     backend_path = 'wagtail.wagtailsearch.backends.elasticsearch'
 
-    # TODO: we have to put [:100] on the end of the query due to issue #3431
-    def test_search_all(self):
-        # Searches on None should return everything in the index
-        results = self.backend.search(None, models.Book)[:100]
-        self.assertSetEqual(set(results), set(models.Book.objects.all()))
-
     # Broken
     @unittest.expectedFailure
     def test_filter_in_values_list_subquery(self):
@@ -42,20 +36,6 @@ class TestElasticsearchSearchBackend(BackendTests, ElasticsearchCommonSearchBack
     @unittest.expectedFailure
     def test_delete(self):
         super(TestElasticsearchSearchBackend, self).test_delete()
-
-    def test_more_than_ten_results(self):
-        # #3431 reported that Elasticsearch only sends back 10 results if the results set is not sliced
-        for i in range(20):
-            a = models.SearchTest()
-            a.title = "Hello World {}".format(i)
-            a.save()
-            self.backend.add(a)
-
-        self.refresh_index()
-
-        results = self.backend.search("Hello", models.SearchTest)
-
-        self.assertEqual(len(results), 23)
 
 
 class TestElasticsearchSearchQuery(TestCase):

--- a/wagtail/wagtailsearch/tests/test_elasticsearch_backend.py
+++ b/wagtail/wagtailsearch/tests/test_elasticsearch_backend.py
@@ -43,6 +43,20 @@ class TestElasticsearchSearchBackend(BackendTests, ElasticsearchCommonSearchBack
     def test_delete(self):
         super(TestElasticsearchSearchBackend, self).test_delete()
 
+    def test_more_than_ten_results(self):
+        # #3431 reported that Elasticsearch only sends back 10 results if the results set is not sliced
+        for i in range(20):
+            a = models.SearchTest()
+            a.title = "Hello World {}".format(i)
+            a.save()
+            self.backend.add(a)
+
+        self.refresh_index()
+
+        results = self.backend.search("Hello", models.SearchTest)
+
+        self.assertEqual(len(results), 23)
+
 
 class TestElasticsearchSearchQuery(TestCase):
     def assertDictEqual(self, a, b):
@@ -395,7 +409,9 @@ class TestElasticsearchSearchResults(TestCase):
             body={'query': 'QUERY'},
             _source=False,
             fields='pk',
-            index='wagtail'
+            index='wagtail',
+            scroll='2m',
+            size=100
         )
 
     @mock.patch('elasticsearch.Elasticsearch.search')
@@ -412,6 +428,7 @@ class TestElasticsearchSearchResults(TestCase):
             _source=False,
             fields='pk',
             index='wagtail',
+            scroll='2m',
             size=1
         )
 
@@ -428,6 +445,7 @@ class TestElasticsearchSearchResults(TestCase):
             _source=False,
             fields='pk',
             index='wagtail',
+            scroll='2m',
             size=3
         )
 
@@ -444,6 +462,7 @@ class TestElasticsearchSearchResults(TestCase):
             _source=False,
             fields='pk',
             index='wagtail',
+            scroll='2m',
             size=10
         )
 
@@ -461,6 +480,7 @@ class TestElasticsearchSearchResults(TestCase):
             _source=False,
             fields='pk',
             index='wagtail',
+            scroll='2m',
             size=1
         )
 


### PR DESCRIPTION
Fixes #3431

This updates Wagtailsearch to fetch results from Elasticsearch using the [scroll API](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-scroll.html)

This loads in 100 results at a time, allowing many results to be streamed into Wagtail if needed. It also fixes the behaviour when the user hasn't specified a limit on the number of search results they need, which currently loads just 10 results.