### PR TITLE
oEmbed: Add support of Facebook

### DIFF
--- a/wagtail/wagtailembeds/oembed_providers.py
+++ b/wagtail/wagtailembeds/oembed_providers.py
@@ -82,6 +82,22 @@ OEMBED_ENDPOINTS = {
         "^http://instagr\\.am/p/.+$",
         "^http[s]?://(?:www\\.)?instagram\\.com/p/.+$"
     ],
+    "https://www.facebook.com/plugins/video/oembed.{format}": [
+        "^https://(?:www\\.)?facebook\\.com/.+/videos/.+$",
+        "^https://(?:www\\.)?facebook\\.com/video\\.php\\?(?:v|id)=.+$",
+    ],
+    "https://www.facebook.com/plugins/post/oembed.{format}": [
+        "^https://(?:www\\.)?facebook\\.com/.+/(?:posts|activity)/.+$",
+        "^https://(?:www\\.)?facebook\\.com/photo\\.php\\?fbid=.+$",
+        "^https://(?:www\\.)?facebook\\.com/(?:photos|questions)/.+$",
+        "^https://(?:www\\.)?facebook\\.com/permalink\\.php\\?story_fbid=.+$",
+        "^https://(?:www\\.)?facebook\\.com/media/set/?\\?set=.+$",
+        "^https://(?:www\\.)?facebook\\.com/notes/.+/.+/.+$",
+
+        # At the moment, not documented on https://developers.facebook.com/docs/plugins/oembed-endpoints
+        # Works for posts with a single photo
+        "^https://(?:www\\.)?facebook\\.com/.+/photos/.+$",
+    ],
     "https://www.slideshare.net/api/oembed/2": [
         "^http://www\\.slideshare\\.net/.+$"
     ],

--- a/wagtail/wagtailembeds/oembed_providers.py
+++ b/wagtail/wagtailembeds/oembed_providers.py
@@ -83,20 +83,20 @@ OEMBED_ENDPOINTS = {
         "^http[s]?://(?:www\\.)?instagram\\.com/p/.+$"
     ],
     "https://www.facebook.com/plugins/video/oembed.{format}": [
-        "^https://(?:www\\.)?facebook\\.com/.+/videos/.+$",
+        "^https://(?:www\\.)?facebook\\.com/.+?/videos/.+$",
         "^https://(?:www\\.)?facebook\\.com/video\\.php\\?(?:v|id)=.+$",
     ],
     "https://www.facebook.com/plugins/post/oembed.{format}": [
-        "^https://(?:www\\.)?facebook\\.com/.+/(?:posts|activity)/.+$",
+        "^https://(?:www\\.)?facebook\\.com/.+?/(?:posts|activity)/.+$",
         "^https://(?:www\\.)?facebook\\.com/photo\\.php\\?fbid=.+$",
         "^https://(?:www\\.)?facebook\\.com/(?:photos|questions)/.+$",
         "^https://(?:www\\.)?facebook\\.com/permalink\\.php\\?story_fbid=.+$",
         "^https://(?:www\\.)?facebook\\.com/media/set/?\\?set=.+$",
-        "^https://(?:www\\.)?facebook\\.com/notes/.+/.+/.+$",
+        "^https://(?:www\\.)?facebook\\.com/notes/.+?/.+?/.+$",
 
         # At the moment, not documented on https://developers.facebook.com/docs/plugins/oembed-endpoints
         # Works for posts with a single photo
-        "^https://(?:www\\.)?facebook\\.com/.+/photos/.+$",
+        "^https://(?:www\\.)?facebook\\.com/.+?/photos/.+$",
     ],
     "https://www.slideshare.net/api/oembed/2": [
         "^http://www\\.slideshare\\.net/.+$"


### PR DESCRIPTION
Fixes #3532

It looks like [Facebook's documentation](https://developers.facebook.com/docs/plugins/oembed-endpoints) a bit outdated.

The following patterns work:
```
# https://www.facebook.com/{page-name}/posts/{post-id}
https://www.facebook.com/VICE/posts/1634649483234970

# https://www.facebook.com/{username}/posts/{post-id}
https://www.facebook.com/m1kola/posts/10206566537760498

# https://www.facebook.com/photo.php?fbid={photo-id}
https://www.facebook.com/photo.php?fbid=10206529931045353&set=a.10204334520601464.1073741828.1782978439&type=3&theater

# https://www.facebook.com/notes/{username}/{note-url}/{note-id}
https://www.facebook.com/notes/shopee/makingmemories/1920792534839731/

# https://www.facebook.com/media/set?set={set-id}
https://www.facebook.com/media/set/?set=oa.1281459648537254&type=1

# https://www.facebook.com/{page-name}/videos/{video-id}/
https://www.facebook.com/1000crossroadsoflife/videos/1139992489461304/

# https://www.facebook.com/video.php?v={video-id}
https://www.facebook.com/video.php?v=1139992489461304
```

This one is not documented, but works too
```
# https://www.facebook.com/{page-name}/photos/{photo-id}
https://www.facebook.com/VICE/photos/rpp.167115176655082/1606848842681701/?type=3&theater
```

The following urls documented, but do not work:
```
# https://www.facebook.com/permalink.php?story_fbid={post-id}
https://www.facebook.com/permalink.php?story_fbid=1654663101215266&id=100000147754279

# https://www.facebook.com/{username}/videos/{video-id}/
https://www.facebook.com/natallia.ku/videos/10212852498933525/

# https://www.facebook.com/video.php?id={video-id}
https://www.facebook.com/video.php?id=1139992489461304
```

I haven't managed to find examples for the following patterns:
```
# https://www.facebook.com/{username}/activity/{activity-id}
# https://www.facebook.com/photos/{photo-id}
# https://www.facebook.com/questions/{question-id}
```