### PR TITLE
oEmbed: Add support of Tumblr

### DIFF
--- a/wagtail/wagtailembeds/oembed_providers.py
+++ b/wagtail/wagtailembeds/oembed_providers.py
@@ -302,7 +302,7 @@ OEMBED_ENDPOINTS = {
         "^http(?:s)?://(?:www\\.)?issuu\\.com/[^#?/]+/docs/.+$"
     ],
     "https://www.tumblr.com/oembed/1.0": [
-        "^http(?:s)?://.+.tumblr.com/post/.+$",
+        "^http(?:s)?://.+\\.tumblr\\.com/post/.+$",
     ]
 }
 

--- a/wagtail/wagtailembeds/oembed_providers.py
+++ b/wagtail/wagtailembeds/oembed_providers.py
@@ -301,6 +301,9 @@ OEMBED_ENDPOINTS = {
     "http://issuu.com/oembed": [
         "^http(?:s)?://(?:www\\.)?issuu\\.com/[^#?/]+/docs/.+$"
     ],
+    "https://www.tumblr.com/oembed/1.0": [
+        "^http(?:s)?://.+.tumblr.com/post/.+$",
+    ]
 }
 
 

--- a/wagtail/wagtailembeds/oembed_providers.py
+++ b/wagtail/wagtailembeds/oembed_providers.py
@@ -302,7 +302,7 @@ OEMBED_ENDPOINTS = {
         "^http(?:s)?://(?:www\\.)?issuu\\.com/[^#?/]+/docs/.+$"
     ],
     "https://www.tumblr.com/oembed/1.0": [
-        "^http(?:s)?://.+\\.tumblr\\.com/post/.+$",
+        "^http(?:s)?://.+?\\.tumblr\\.com/post/.+$",
     ]
 }
 


### PR DESCRIPTION
Tumblr allows to embed posts using oEmbed standard. See [Tumblr API](https://www.tumblr.com/docs/en/api/v2).