### PR TITLE
[WIP] Core API Schemas support

### DIFF
--- a/wagtail/api/v2/endpoints.py
+++ b/wagtail/api/v2/endpoints.py
@@ -72,7 +72,7 @@ class BaseAPIEndpoint(GenericViewSet):
     def get_queryset(self):
         return self.model.objects.all().order_by('id')
 
-    def listing_view(self, request):
+    def list(self, request):
         queryset = self.get_queryset()
         self.check_query_parameters(queryset)
         queryset = self.filter_queryset(queryset)
@@ -80,7 +80,7 @@ class BaseAPIEndpoint(GenericViewSet):
         serializer = self.get_serializer(queryset, many=True)
         return self.get_paginated_response(serializer.data)
 
-    def detail_view(self, request, pk):
+    def retrieve(self, request, pk):
         instance = self.get_object()
         serializer = self.get_serializer(instance)
         return Response(serializer.data)
@@ -273,7 +273,7 @@ class BaseAPIEndpoint(GenericViewSet):
         request = self.request
 
         # Get model
-        if self.action == 'listing_view':
+        if self.action == 'list':
             model = self.get_queryset().model
         else:
             model = type(self.get_object())
@@ -289,7 +289,7 @@ class BaseAPIEndpoint(GenericViewSet):
             fields_config = []
 
         # Allow "detail_only" (eg parent) fields on detail view
-        if self.action == 'listing_view':
+        if self.action == 'list':
             show_details = False
         else:
             show_details = True
@@ -317,8 +317,8 @@ class BaseAPIEndpoint(GenericViewSet):
         This returns a list of URL patterns for the endpoint
         """
         return [
-            url(r'^$', cls.as_view({'get': 'listing_view'}), name='listing'),
-            url(r'^(?P<pk>\d+)/$', cls.as_view({'get': 'detail_view'}), name='detail'),
+            url(r'^$', cls.as_view({'get': 'list'}), name='listing'),
+            url(r'^(?P<pk>\d+)/$', cls.as_view({'get': 'retrieve'}), name='detail'),
         ]
 
     @classmethod

--- a/wagtail/api/v2/filters.py
+++ b/wagtail/api/v2/filters.py
@@ -55,6 +55,26 @@ class FieldsFilter(BaseFilterBackend):
 
         return queryset
 
+    def get_schema_fields(self, view):
+        assert coreapi is not None, 'coreapi must be installed to use `get_schema_fields()`'
+        assert coreschema is not None, 'coreschema must be installed to use `get_schema_fields()`'
+
+        if not view.model:
+            return []
+
+        fields_list = []
+        fields = set(view.get_available_fields(view.model, db_fields_only=True))
+
+        for field in fields:
+            fields_list.append(coreapi.Field(
+                name=field,
+                required=False,
+                location='query',
+                schema=coreschema.String()
+            ))
+
+        return fields_list
+
 
 class OrderingFilter(BaseFilterBackend):
     ordering_param = 'order'

--- a/wagtail/api/v2/filters.py
+++ b/wagtail/api/v2/filters.py
@@ -7,11 +7,11 @@ from django.utils.translation import ugettext_lazy as _
 from rest_framework.filters import BaseFilterBackend
 from taggit.managers import TaggableManager
 
+from wagtail.utils.compat import coreapi, coreschema
 from wagtail.wagtailcore.models import Page
 from wagtail.wagtailsearch.backends import get_search_backend
-from wagtail.utils.compat import coreapi, coreschema
 
-from .utils import BadRequestError, pages_for_site, parse_boolean, field_to_schema
+from .utils import BadRequestError, field_to_schema, pages_for_site, parse_boolean
 
 
 class FieldsFilter(BaseFilterBackend):

--- a/wagtail/api/v2/filters.py
+++ b/wagtail/api/v2/filters.py
@@ -66,6 +66,7 @@ class FieldsFilter(BaseFilterBackend):
         fields = set(view.get_available_fields(view.model, db_fields_only=True))
 
         for field in fields:
+            # TODO: use more specific schema class (e.g. models.BooleanField -> coreschema.Boolean)
             fields_list.append(coreapi.Field(
                 name=field,
                 required=False,
@@ -243,7 +244,7 @@ class ChildOfFilter(BaseFilterBackend):
                 name=self.child_of_param,
                 required=False,
                 location='query',
-                schema=coreschema.String(
+                schema=coreschema.Integer(
                     title=force_text(self.child_of_title),
                     description=force_text(self.child_of_description)
                 )
@@ -312,7 +313,7 @@ class DescendantOfFilter(BaseFilterBackend):
                 name=self.descendant_of_param,
                 required=False,
                 location='query',
-                schema=coreschema.String(
+                schema=coreschema.Integer(
                     title=force_text(self.descendant_of_title),
                     description=force_text(self.descendant_of_description)
                 )

--- a/wagtail/api/v2/pagination.py
+++ b/wagtail/api/v2/pagination.py
@@ -65,7 +65,7 @@ class WagtailPagination(BasePagination):
                 name=self.offset_param,
                 required=False,
                 location='query',
-                schema=coreschema.String(
+                schema=coreschema.Integer(
                     title=force_text(self.offset_title),
                     description=force_text(self.offset_description)
                 )
@@ -74,7 +74,7 @@ class WagtailPagination(BasePagination):
                 name=self.limit_param,
                 required=False,
                 location='query',
-                schema=coreschema.String(
+                schema=coreschema.Integer(
                     title=force_text(self.limit_title),
                     description=force_text(self.limit_description)
                 )

--- a/wagtail/api/v2/pagination.py
+++ b/wagtail/api/v2/pagination.py
@@ -3,31 +3,43 @@ from __future__ import absolute_import, unicode_literals
 from collections import OrderedDict
 
 from django.conf import settings
+from django.utils.encoding import force_text
+from django.utils.translation import ugettext_lazy as _
 from rest_framework.pagination import BasePagination
 from rest_framework.response import Response
+
+from wagtail.utils.compat import coreapi, coreschema
 
 from .utils import BadRequestError
 
 
 class WagtailPagination(BasePagination):
+    offset_param = 'offset'
+    offset_title = _('Offset')
+    offset_description = _('Pagination offset.')
+
+    limit_param = 'limit'
+    limit_title = _('Limit')
+    limit_description = _('Pagination limit.')
+
     def paginate_queryset(self, queryset, request, view=None):
         limit_max = getattr(settings, 'WAGTAILAPI_LIMIT_MAX', 20)
 
         try:
-            offset = int(request.GET.get('offset', 0))
+            offset = int(request.GET.get(self.offset_param, 0))
             assert offset >= 0
         except (ValueError, AssertionError):
-            raise BadRequestError("offset must be a positive integer")
+            raise BadRequestError("{} must be a positive integer".format(self.offset_param))
 
         try:
-            limit = int(request.GET.get('limit', min(20, limit_max)))
+            limit = int(request.GET.get(self.limit_param, min(20, limit_max)))
 
             if limit > limit_max:
-                raise BadRequestError("limit cannot be higher than %d" % limit_max)
+                raise BadRequestError("{} cannot be higher than {:d}".format(self.limit_param, limit_max))
 
             assert limit >= 0
         except (ValueError, AssertionError):
-            raise BadRequestError("limit must be a positive integer")
+            raise BadRequestError("{} must be a positive integer".format(self.limit_param))
 
         start = offset
         stop = offset + limit
@@ -44,3 +56,27 @@ class WagtailPagination(BasePagination):
             ('items', data),
         ])
         return Response(data)
+
+    def get_schema_fields(self, view):
+        assert coreapi is not None, 'coreapi must be installed to use `get_schema_fields()`'
+        assert coreschema is not None, 'coreschema must be installed to use `get_schema_fields()`'
+        return [
+            coreapi.Field(
+                name=self.offset_param,
+                required=False,
+                location='query',
+                schema=coreschema.String(
+                    title=force_text(self.offset_title),
+                    description=force_text(self.offset_description)
+                )
+            ),
+            coreapi.Field(
+                name=self.limit_param,
+                required=False,
+                location='query',
+                schema=coreschema.String(
+                    title=force_text(self.limit_title),
+                    description=force_text(self.limit_description)
+                )
+            ),
+        ]

--- a/wagtail/api/v2/utils.py
+++ b/wagtail/api/v2/utils.py
@@ -5,9 +5,9 @@ from django.db import models
 from django.utils.encoding import force_text
 from django.utils.six.moves.urllib.parse import urlparse
 
+from wagtail.utils.compat import coreschema
 from wagtail.wagtailcore.models import Page
 from wagtail.wagtailcore.utils import resolve_model_string
-from wagtail.utils.compat import coreschema
 
 
 class BadRequestError(Exception):

--- a/wagtail/contrib/wagtailapi/endpoints.py
+++ b/wagtail/contrib/wagtailapi/endpoints.py
@@ -50,7 +50,7 @@ class BaseAPIEndpoint(GenericViewSet):
     def get_queryset(self):
         return self.model.objects.all().order_by('id')
 
-    def listing_view(self, request):
+    def list(self, request):
         queryset = self.get_queryset()
         self.check_query_parameters(queryset)
         queryset = self.filter_queryset(queryset)
@@ -58,7 +58,7 @@ class BaseAPIEndpoint(GenericViewSet):
         serializer = self.get_serializer(queryset, many=True)
         return self.get_paginated_response(serializer.data)
 
-    def detail_view(self, request, pk):
+    def retrieve(self, request, pk):
         instance = self.get_object()
         serializer = self.get_serializer(instance)
         return Response(serializer.data)
@@ -121,7 +121,7 @@ class BaseAPIEndpoint(GenericViewSet):
         request = self.request
 
         # Get model
-        if self.action == 'listing_view':
+        if self.action == 'list':
             model = self.get_queryset().model
         else:
             model = type(self.get_object())
@@ -131,7 +131,7 @@ class BaseAPIEndpoint(GenericViewSet):
         # Removes any duplicates in case the developer put "title" in api_fields
         all_fields = list(OrderedDict.fromkeys(all_fields))
 
-        if self.action == 'listing_view':
+        if self.action == 'list':
             # Listing views just show the title field and any other allowed field the user specified
             if 'fields' in request.GET:
                 fields = set(request.GET['fields'].split(','))
@@ -168,7 +168,7 @@ class BaseAPIEndpoint(GenericViewSet):
             'router': self.request.wagtailapi_router
         }
 
-        if self.action == 'detail_view':
+        if self.action == 'retrieve':
             context['show_details'] = True
 
         return context
@@ -184,8 +184,8 @@ class BaseAPIEndpoint(GenericViewSet):
         This returns a list of URL patterns for the endpoint
         """
         return [
-            url(r'^$', cls.as_view({'get': 'listing_view'}), name='listing'),
-            url(r'^(?P<pk>\d+)/$', cls.as_view({'get': 'detail_view'}), name='detail'),
+            url(r'^$', cls.as_view({'get': 'list'}), name='listing'),
+            url(r'^(?P<pk>\d+)/$', cls.as_view({'get': 'retrieve'}), name='detail'),
         ]
 
     @classmethod

--- a/wagtail/utils/compat.py
+++ b/wagtail/utils/compat.py
@@ -15,3 +15,17 @@ def user_is_anonymous(user):
         return user.is_anonymous
     else:
         return user.is_anonymous()
+
+
+# coreapi is optional
+try:
+    import coreapi
+except ImportError:
+    coreapi = None
+
+
+# coreschema is optional
+try:
+    import coreschema
+except ImportError:
+    coreschema = None

--- a/wagtail/wagtailadmin/api/endpoints.py
+++ b/wagtail/wagtailadmin/api/endpoints.py
@@ -84,12 +84,12 @@ class PagesAdminAPIEndpoint(PagesAPIEndpoint):
 
         return types
 
-    def listing_view(self, request):
-        response = super(PagesAdminAPIEndpoint, self).listing_view(request)
+    def list(self, request):
+        response = super(PagesAdminAPIEndpoint, self).list(request)
         response.data['__types'] = self.get_type_info()
         return response
 
-    def detail_view(self, request, pk):
-        response = super(PagesAdminAPIEndpoint, self).detail_view(request, pk)
+    def retrieve(self, request, pk):
+        response = super(PagesAdminAPIEndpoint, self).retrieve(request, pk)
         response.data['__types'] = self.get_type_info()
         return response


### PR DESCRIPTION
TODO:

- [ ] Make changes in endpoints
  - [x] Rename methods in endpoint
    * `listing_view` -> `list`
    * `detail_view` -> `retrieve`
  - [ ] Provide a schema for query params like `fields`, `type`, etc. See: `wagtail.api.v2.endpoints.BaseAPIEndpoint` and all child classes.
- [x] Implement the `get_schema_fields` method in the following filter backends:
  - [x] `wagtail.api.v2.filters.FieldsFilter`
  - [x] `wagtail.api.v2.filters.OrderingFilter`
  - [x] `wagtail.api.v2.filters.SearchFilter`
  - [x] `wagtail.api.v2.filters.ChildOfFilter`
  - [x] `wagtail.api.v2.filters.RestrictedChildOfFilter`
  - [x] `wagtail.api.v2.filters.DescendantOfFilter`
  - [x] `wagtail.api.v2.filters.RestrictedDescendantOfFilter`
- [x] Implement the `get_schema_fields` method in pagination classes:
  - [x] `wagtail.api.v2.pagination.WagtailPagination`
- [x] Decide if we need to implement support in API v1
  As per discussion on the Wagtail team meeting - no need in support of API v1
- [ ] Check if we need to start API v3
- [ ] Add tests

Fixes #3549