### PR TITLE
update django requirement in setup.py to allow django 1.11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ except ImportError:
 
 
 install_requires = [
-    "Django>=1.8.1,<1.11",
+    "Django>=1.8.1,<1.12",
     "django-modelcluster>=3.1,<4.0",
     "django-taggit>=0.20,<1.0",
     "django-treebeard>=3.0,<5.0",

--- a/wagtail/project_template/requirements.txt
+++ b/wagtail/project_template/requirements.txt
@@ -1,2 +1,2 @@
-Django>=1.10,<1.11
+Django>=1.10,<1.12
 wagtail==1.10rc1


### PR DESCRIPTION
note that even though the next planned django version is 2.0, I still put the requirement as < 1.12 since that seems more conservative and should work for 2.0 as well as for the very unlikely chance we get a 1.12.