### PR TITLE
Make custom PageManagers return the correct PageQuerySet subclass

### DIFF
--- a/wagtail/tests/testapp/models.py
+++ b/wagtail/tests/testapp/models.py
@@ -28,7 +28,7 @@ from wagtail.wagtailadmin.forms import WagtailAdminPageForm
 from wagtail.wagtailadmin.utils import send_mail
 from wagtail.wagtailcore.blocks import CharBlock, RichTextBlock
 from wagtail.wagtailcore.fields import RichTextField, StreamField
-from wagtail.wagtailcore.models import Orderable, Page, PageManager
+from wagtail.wagtailcore.models import Orderable, Page, PageManager, PageQuerySet
 from wagtail.wagtaildocs.edit_handlers import DocumentChooserPanel
 from wagtail.wagtailforms.models import AbstractEmailForm, AbstractFormField, AbstractFormSubmission
 from wagtail.wagtailimages.blocks import ImageChooserBlock
@@ -833,8 +833,12 @@ class CustomImageFilePath(AbstractImage):
         return os.path.join(folder_name, checksum[:3], filename)
 
 
-class CustomManager(PageManager):
-    pass
+class CustomPageQuerySet(PageQuerySet):
+    def about_spam(self):
+        return self.filter(title__contains='spam')
+
+
+CustomManager = PageManager.from_queryset(CustomPageQuerySet)
 
 
 class CustomManagerPage(Page):

--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -194,7 +194,7 @@ def get_default_page_content_type():
 
 class BasePageManager(models.Manager):
     def get_queryset(self):
-        return PageQuerySet(self.model).order_by('path')
+        return self._queryset_class(self.model).order_by('path')
 
 
 PageManager = BasePageManager.from_queryset(PageQuerySet)

--- a/wagtail/wagtailcore/tests/test_page_model.py
+++ b/wagtail/wagtailcore/tests/test_page_model.py
@@ -15,7 +15,8 @@ from django.test.utils import override_settings
 
 from wagtail.tests.testapp.models import (
     AbstractPage, Advert, BlogCategory, BlogCategoryBlogPage, BusinessChild, BusinessIndex,
-    BusinessNowherePage, BusinessSubIndex, CustomManager, CustomManagerPage, EventIndex, EventPage,
+    BusinessNowherePage, BusinessSubIndex, CustomManager, CustomManagerPage, CustomPageQuerySet,
+    EventIndex, EventPage,
     GenericSnippetPage, ManyToManyBlogPage, MTIBasePage, MTIChildPage, MyCustomPage, OneToOnePage,
     SimplePage, SingleEventPage, SingletonPage, StandardIndex, TaggedPage)
 from wagtail.tests.utils import WagtailTestUtils
@@ -1133,6 +1134,17 @@ class TestPageManager(TestCase):
         custom Manager inherits from PageManager.
         """
         self.assertIs(type(CustomManagerPage.objects), CustomManager)
+
+    def test_custom_page_queryset(self):
+        """
+        Managers that are constructed from a custom PageQuerySet
+        (via PageManager.from_queryset(CustomPageQuerySet)) should return
+        querysets of that type
+        """
+        self.assertIs(type(CustomManagerPage.objects.all()), CustomPageQuerySet)
+        self.assertIs(type(CustomManagerPage.objects.about_spam()), CustomPageQuerySet)
+        self.assertIs(type(CustomManagerPage.objects.all().about_spam()), CustomPageQuerySet)
+        self.assertIs(type(CustomManagerPage.objects.about_spam().all()), CustomPageQuerySet)
 
     def test_abstract_base_page_manager(self):
         """


### PR DESCRIPTION
As reported in https://github.com/wagtail/wagtail/issues/3250#issuecomment-284988695, custom page managers created with PageManager.from_queryset(CustomPageQuerySet) fail to return instances of CustomPageQuerySet. This breaks the EventPageQuerySet example given at http://docs.wagtail.io/en/v1.9/topics/pages.html#custom-page-managers.