### PR TITLE
Update docs - run python manage.py migrate once

### DIFF
--- a/docs/reference/contrib/postgres_search.rst
+++ b/docs/reference/contrib/postgres_search.rst
@@ -63,6 +63,8 @@ Give it the alias `'default'` if you want it to be the default search backend:
         },
     }
 
+Before you can update the index with the :ref:`update_index` command, you need to run python manage.py migrate once in order to create the necessary postgres_search_indexentry table.
+
 You then need to index data inside this backend using
 the :ref:`update_index` command. You can reuse this command whenever
 you want. However, it should not be needed after a first usage since


### PR DESCRIPTION
We have to run python manage.py migrate once, in order to create the necessary tables for the postgres search backend.
Otherwise we get an error, as the insert in the table is not possible.

Thanks for contributing to Wagtail! 🎉

Before submitting, please review the contributor guidelines <http://docs.wagtail.io/en/latest/contributing/index.html> and check the following:

* Do the tests still pass? (http://docs.wagtail.io/en/latest/contributing/developing.html#testing)
* Does the code comply with the style guide? (Run `make lint` from the Wagtail root)
* For Python changes: Have you added tests to cover the new/fixed behaviour?
* For new features: Has the documentation been updated accordingly?
