### PR TITLE
Use strftime for formatting datetimes in test form submissions

### DIFF
--- a/wagtail/wagtailadmin/tests/test_pages_views.py
+++ b/wagtail/wagtailadmin/tests/test_pages_views.py
@@ -38,7 +38,7 @@ def submittable_timestamp(timestamp):
     need to pass it through timezone.localtime to ensure that the client and server are in
     agreement about what the timestamp means.
     """
-    return str(timezone.localtime(timestamp)).split('.')[0]
+    return timezone.localtime(timestamp).strftime("%Y-%m-%d %H:%M")
 
 
 def local_datetime(*args):


### PR DESCRIPTION
Datetime-related tests are intermittently failing on Appveyor; the error at https://ci.appveyor.com/project/wagtail/wagtail/build/1.0.141/job/30t7t1ydh78gupie implies that this is due to invalid datetime formats being returned from submittable_timestamp. Using strftime means that we're not reliant on the return value of str(timestamp) being formatted in a specific way.