### PR TITLE
Allow users to unset their preferred language

### DIFF
--- a/wagtail/wagtailadmin/tests/test_account_management.py
+++ b/wagtail/wagtailadmin/tests/test_account_management.py
@@ -327,13 +327,28 @@ class TestAccountSection(TestCase, WagtailTestUtils):
         }
         response = self.client.post(reverse('wagtailadmin_account_language_preferences'), post_data)
 
-        # Check that the user was redirected to the account language preferences page
-        self.assertEqual(response.status_code, 200)
+        # Check that the user was redirected to the account page
+        self.assertRedirects(response, reverse('wagtailadmin_account'))
 
         profile = UserProfile.get_for_user(get_user_model().objects.get(pk=self.user.pk))
 
         # Check that the language preferences are stored
         self.assertEqual(profile.preferred_language, 'es')
+
+    def test_unset_language_preferences(self):
+        # Post new values to the language preferences page
+        post_data = {
+            'preferred_language': ''
+        }
+        response = self.client.post(reverse('wagtailadmin_account_language_preferences'), post_data)
+
+        # Check that the user was redirected to the account page
+        self.assertRedirects(response, reverse('wagtailadmin_account'))
+
+        profile = UserProfile.get_for_user(get_user_model().objects.get(pk=self.user.pk))
+
+        # Check that the language preferences are stored
+        self.assertEqual(profile.preferred_language, '')
 
     @override_settings(WAGTAILADMIN_PERMITTED_LANGUAGES=[('en', 'English'), ('es', 'Spanish')])
     def test_available_admin_languages_with_permitted_languages(self):

--- a/wagtail/wagtailadmin/views/account.py
+++ b/wagtail/wagtailadmin/views/account.py
@@ -95,7 +95,7 @@ def notification_preferences(request):
 
         if form.is_valid():
             form.save()
-            messages.success(request, _("Your preferences have been updated successfully!"))
+            messages.success(request, _("Your preferences have been updated."))
             return redirect('wagtailadmin_account')
     else:
         form = NotificationPreferencesForm(instance=UserProfile.get_for_user(request.user))

--- a/wagtail/wagtailadmin/views/account.py
+++ b/wagtail/wagtailadmin/views/account.py
@@ -117,8 +117,10 @@ def language_preferences(request):
         if form.is_valid():
             user_profile = form.save()
             # This will set the language only for this request/thread
-            activate(user_profile.preferred_language)
+            # (so that the 'success' messages is in the right language)
+            activate(user_profile.get_preferred_language())
             messages.success(request, _("Your preferences have been updated."))
+            return redirect('wagtailadmin_account')
     else:
         form = PreferredLanguageForm(instance=UserProfile.get_for_user(request.user))
 

--- a/wagtail/wagtailusers/forms.py
+++ b/wagtail/wagtailusers/forms.py
@@ -8,6 +8,7 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group, Permission
 from django.db import transaction
+from django.db.models.fields import BLANK_CHOICE_DASH
 from django.template.loader import render_to_string
 from django.utils.html import mark_safe
 from django.utils.translation import ugettext_lazy as _
@@ -357,7 +358,8 @@ class NotificationPreferencesForm(forms.ModelForm):
 
 class PreferredLanguageForm(forms.ModelForm):
     preferred_language = forms.ChoiceField(
-        choices=lambda: sorted(get_available_admin_languages(), key=lambda l: l[1])
+        required=False,
+        choices=lambda: sorted(BLANK_CHOICE_DASH + get_available_admin_languages(), key=lambda l: l[1])
     )
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
Fixes #3560, along with some related behavioural tweaks: submitting the form now redirects back to the account index, and the success message for the notification preferences page has been changed to 'Your preferences have been updated.' for consistency.

NB This will need to be merged/cherry-picked into both master and stable/1.10.x