### PR TITLE
Prevent explorer view crashing when page models are missing

### DIFF
--- a/wagtail/wagtailadmin/tests/test_pages_views.py
+++ b/wagtail/wagtailadmin/tests/test_pages_views.py
@@ -9,6 +9,7 @@ import mock
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group, Permission
+from django.contrib.contenttypes.models import ContentType
 from django.contrib.messages import constants as message_constants
 from django.core import mail, paginator
 from django.core.files.base import ContentFile
@@ -266,6 +267,22 @@ class TestPageExplorer(TestCase, WagtailTestUtils):
             admin)
         self.assertRedirects(
             self.client.get(reverse('wagtailadmin_explore_root')), admin)
+
+    def test_explore_with_missing_page_model(self):
+        # Create a ContentType that doesn't correspond to a real model
+        missing_page_content_type = ContentType.objects.create(app_label='tests', model='missingpage')
+        # Turn /home/old-page/ into this content type
+        Page.objects.filter(id=self.old_page.id).update(content_type=missing_page_content_type)
+
+        # try to browse the the listing that contains the missing model
+        response = self.client.get(reverse('wagtailadmin_explore', args=(self.root_page.id, )))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'wagtailadmin/pages/index.html')
+
+        # try to browse into the page itself
+        response = self.client.get(reverse('wagtailadmin_explore', args=(self.old_page.id, )))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'wagtailadmin/pages/index.html')
 
 
 class TestPageExplorerSignposting(TestCase, WagtailTestUtils):

--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -1615,7 +1615,8 @@ class PagePermissionTester(object):
     def can_add_subpage(self):
         if not self.user.is_active:
             return False
-        if not self.page.specific_class.creatable_subpage_models():
+        specific_class = self.page.specific_class
+        if specific_class is None or not specific_class.creatable_subpage_models():
             return False
         return self.user.is_superuser or ('add' in self.permissions)
 
@@ -1701,7 +1702,8 @@ class PagePermissionTester(object):
         """
         if not self.user.is_active:
             return False
-        if not self.page.specific_class.creatable_subpage_models():
+        specific_class = self.page.specific_class
+        if specific_class is None or not specific_class.creatable_subpage_models():
             return False
 
         return self.user.is_superuser or ('publish' in self.permissions)

--- a/wagtail/wagtailcore/query.py
+++ b/wagtail/wagtailcore/query.py
@@ -376,7 +376,9 @@ def specific_iterator(qs):
     # Get the specific instances of all pages, one model class at a time.
     pages_by_type = {}
     for content_type, pks in pks_by_type.items():
-        model = content_types[content_type].model_class()
+        # look up model class for this content type, falling back on the original
+        # model (i.e. Page) if the more specific one is missing
+        model = content_types[content_type].model_class() or qs.model
         pages = model.objects.filter(pk__in=pks)
         pages_by_type[content_type] = {page.pk: page for page in pages}
 


### PR DESCRIPTION
Fixes #3567 

Ensures that if a page model definition is missing (e.g. because it was removed from the project without first deleting all existing pages of that type) the explorer is still usable. We don't guarantee that the page will actually behave sensibly beyond that, but now at least the admin still holds up for long enough for you to delete the offending page.