### PR TITLE
Fix preview to handle multi-value keys in request.POST

### DIFF
--- a/wagtail/tests/testapp/templates/tests/event_page.html
+++ b/wagtail/tests/testapp/templates/tests/event_page.html
@@ -7,6 +7,18 @@
   {% if self.feed_image %}
       {% image self.feed_image width-200 class="feed-image" %}
   {% endif %}
+
+  {% with self.categories.all as categories %}
+    {% if categories %}
+      <ul>
+        {% for category in categories %}
+          <li>{{ category.name }}</li>
+        {% endfor %}
+      </ul>
+    {% endif %}
+  {% endwith %}
+
+  {% for category in self.categories.all
   {{ self.body|richtext }}
   <p><a href="{% slugurl 'events' %}">Back to events index</a></p>
 {% endblock %}

--- a/wagtail/wagtailadmin/tests/test_pages_views.py
+++ b/wagtail/wagtailadmin/tests/test_pages_views.py
@@ -4199,3 +4199,56 @@ class TestDraftAccess(TestCase, WagtailTestUtils):
 
         # User can view
         self.assertEqual(response.status_code, 200)
+
+
+class TestPreview(TestCase, WagtailTestUtils):
+    fixtures = ['test.json']
+
+    def setUp(self):
+        self.meetings_category = EventCategory.objects.create(name='Meetings')
+        self.parties_category = EventCategory.objects.create(name='Parties')
+        self.holidays_category = EventCategory.objects.create(name='Holidays')
+
+        self.home_page = Page.objects.get(url_path='/home/')
+
+        self.user = self.login()
+
+    def test_preview_with_m2m_field(self):
+        post_data = {
+            'title': "Beach party",
+            'slug': 'beach-party',
+            'body': "party on wayne",
+            'date_from': '2017-08-01',
+            'audience': 'public',
+            'location': 'the beach',
+            'cost': 'six squid',
+            'carousel_items-TOTAL_FORMS': 0,
+            'carousel_items-INITIAL_FORMS': 0,
+            'carousel_items-MIN_NUM_FORMS': 0,
+            'carousel_items-MAX_NUM_FORMS': 0,
+            'speakers-TOTAL_FORMS': 0,
+            'speakers-INITIAL_FORMS': 0,
+            'speakers-MIN_NUM_FORMS': 0,
+            'speakers-MAX_NUM_FORMS': 0,
+            'related_links-TOTAL_FORMS': 0,
+            'related_links-INITIAL_FORMS': 0,
+            'related_links-MIN_NUM_FORMS': 0,
+            'related_links-MAX_NUM_FORMS': 0,
+            'categories': [self.parties_category.id, self.holidays_category.id],
+        }
+        preview_url = reverse('wagtailadmin_pages:preview_on_add',
+                              args=('tests', 'eventpage', self.home_page.id))
+        response = self.client.post(preview_url, post_data)
+
+        # Check the JSON response
+        self.assertEqual(response.status_code, 200)
+        self.assertJSONEqual(response.content.decode(), {'is_valid': True})
+
+        response = self.client.get(preview_url)
+
+        # Check the HTML response
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'tests/event_page.html')
+        self.assertContains(response, "Beach party")
+        self.assertContains(response, "<li>Parties</li>")
+        self.assertContains(response, "<li>Holidays</li>")


### PR DESCRIPTION
Fixes #3564. Convert QueryDict to a plain dict when writing to session and vice versa when retrieving, so that multi-value fields are preserved.