### PR TITLE
Fixed RuntimeError: dictionary changed size during iteration

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ testing_extras = [
     'elasticsearch>=1.0.0,<3.0',
     'Jinja2>=2.8,<3.0',
     'boto3>=1.4,<1.5',
+    'freezegun>=0.3.8',
 
     # For coverage and PEP8 linting
     'coverage>=3.7.0',

--- a/wagtail/wagtailadmin/views/pages.py
+++ b/wagtail/wagtailadmin/views/pages.py
@@ -562,13 +562,12 @@ class PreviewOnEdit(View):
 
     def remove_old_preview_data(self):
         expiration = time() - self.preview_expiration_timeout
-        for k, v in self.request.session.items():
-            if not k.startswith(self.session_key_prefix):
-                continue
-            post_data, timestamp = v
-            if timestamp < expiration:
-                # Removes the session key gracefully
-                self.request.session.pop(k)
+        expired_keys = [
+            k for k, v in self.request.session.items()
+            if k.startswith(self.session_key_prefix) and v[1] < expiration]
+        # Removes the session key gracefully
+        for k in expired_keys:
+            self.request.session.pop(k)
 
     @property
     def session_key(self):


### PR DESCRIPTION
Hi,

I noticed this RunTimeError in our logs raised in ```PreviewOnEdit.remove_old_preview_data```, introduced in wagtail 1.10. The exception will always occur if any old data is found in the session. It's a fairly simple fix, rather than mutating the session directly in the loop I use a comprehension to collect the keys to be removed.

As there wasn't an existing test to catch this I though I'd take a stab at adding one. To accomplish this, I needed to add freezegun to the test dependencies list.

Thanks!
