### PR TITLE
Clarify "Steps to reproduce" in new issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -6,11 +6,11 @@ A summary of the issue.
 
 ### Steps to Reproduce
 
+It's essential that you provide enough information for someone else to replicate the problem you're seeing. Simply describing something that's broken on your current project is not enough!
+
 1. (for example) Start a new project with `wagtail start myproject`
 2. Edit models.py as follows...
 3. ...
-
-(It's essential that you provide enough information for someone else to replicate the problem you're seeing. Simply describing something that's broken on your current project is not enough!)
 
 Any other relevant information. For example, why do you consider this a bug and what did you expect to happen instead?
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -17,6 +17,6 @@ Any other relevant information. For example, why do you consider this a bug and 
 ### Technical details
 
 * Python version: Run `python --version`.
-* Django version: Look in your requirements.txt, or run `pip list | grep -i django`.
-* Wagtail version: Hover over the Wagtail bird in the admin, or run `pip list | grep -i wagtail`.
+* Django version: Look in your requirements.txt, or run `pip show django | grep Version`.
+* Wagtail version: Hover over the Wagtail bird in the admin, or run `pip show wagtail | grep Version:`.
 * Browser version: You can use http://www.whatsmybrowser.org/ to find this out.

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -6,8 +6,11 @@ A summary of the issue.
 
 ### Steps to Reproduce
 
-1. This is the first step
-2. This is the second step, etc.
+1. (for example) Start a new project with `wagtail start myproject`
+2. Edit models.py as follows...
+3. ...
+
+(It's essential that you provide enough information for someone else to replicate the problem you're seeing. Simply describing something that's broken on your current project is not enough!)
 
 Any other relevant information. For example, why do you consider this a bug and what did you expect to happen instead?
 
@@ -15,5 +18,5 @@ Any other relevant information. For example, why do you consider this a bug and 
 
 * Python version: Run `python --version`.
 * Django version: Look in your requirements.txt, or run `pip list | grep -i django`.
-* Wagtail version: Hover over the Wagtail bird in the admin, or look in the Settings menu, look in your requirements.txt, or run `pip list | grep -i wagtail`.
+* Wagtail version: Hover over the Wagtail bird in the admin, or run `pip list | grep -i wagtail`.
 * Browser version: You can use http://www.whatsmybrowser.org/ to find this out.


### PR DESCRIPTION
Bug reporters are frequently not making the connection that "Steps to reproduce" means "steps for someone else to independently reproduce this bug", not "steps that I go through on my project to see this bug". Added some example text to gently steer people towards the level of detail we want...

Also trimmed down the "Wagtail version" item under "Technical details", since we don't really need to tell people four different ways to do the same thing. (We don't want people to mentally tune this text out, so I think it's a good habit to remove something for every new thing we add)
