### PR TITLE
Use runInBand to make Jest tests faster in CI env

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -14,4 +14,4 @@ test:
     - npm run lint
     - scss-lint
     - python -u runtests.py
-    - npm run test:unit:coverage
+    - npm run test:unit:coverage -- --runInBand


### PR DESCRIPTION
See https://facebook.github.io/jest/docs/troubleshooting.html#tests-are-extremely-slow-on-docker-and-or-continuous-integration-ci-server for further details.