### PR TITLE
Node tooling cleanup

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,7 +1,0 @@
-{
-  "presets": [
-    "es2015",
-    "react"
-  ],
-  "plugins": ["lodash"]
-}

--- a/client/src/components/Explorer/__snapshots__/actions.test.js.snap
+++ b/client/src/components/Explorer/__snapshots__/actions.test.js.snap
@@ -31,6 +31,7 @@ Array [
 exports[`actions toggleExplorer close 1`] = `
 Array [
   Object {
+    "payload": undefined,
     "type": "CLOSE_EXPLORER",
   },
 ]

--- a/client/src/components/Explorer/actions.js
+++ b/client/src/components/Explorer/actions.js
@@ -1,6 +1,5 @@
-import { createAction } from 'redux-actions';
-
 import * as admin from '../../api/admin';
+import { createAction } from '../../utils/actions';
 import { MAX_EXPLORER_PAGES } from '../../config/wagtailConfig';
 
 const getPageStart = createAction('GET_PAGE_START');

--- a/client/src/utils/actions.js
+++ b/client/src/utils/actions.js
@@ -1,0 +1,25 @@
+const identity = func => func;
+
+// Stolen from the following project (had a 18kb footprint at the time).
+// https://github.com/acdlite/redux-actions/blob/79c68635fb1524c1b1cf8e2398d4b099b53ca8de/src/createAction.js
+export function createAction(type, actionCreator, metaCreator) {
+  const finalActionCreator = typeof actionCreator === 'function' ? actionCreator : identity;
+
+  return (...args) => {
+    const action = {
+      type,
+      payload: finalActionCreator(...args),
+    };
+
+    if (action.payload instanceof Error) {
+      // Handle FSA errors where the payload is an Error object. Set error.
+      action.error = true;
+    }
+
+    if (typeof metaCreator === 'function') {
+      action.meta = metaCreator(...args);
+    }
+
+    return action;
+  };
+}

--- a/client/src/utils/polyfills.js
+++ b/client/src/utils/polyfills.js
@@ -1,3 +1,21 @@
-import 'babel-polyfill';
+/* eslint-disable global-require */
 
-import 'whatwg-fetch';
+/**
+ * Polyfills for Wagtail's admin.
+ * Heavily inspired from https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/config/polyfills.js.
+ */
+
+if (typeof Promise === 'undefined') {
+  // Rejection tracking prevents a common issue where React gets into an
+  // inconsistent state due to an error, but it gets swallowed by a Promise,
+  // and the user has no idea what causes React's erratic future behavior.
+  require('promise/lib/rejection-tracking').enable();
+  window.Promise = require('promise/lib/es6-extensions.js');
+}
+
+// fetch() polyfill for making API calls.
+require('whatwg-fetch');
+
+// Object.assign() is commonly used with React.
+// It will use the native implementation if it's present and isn't buggy.
+Object.assign = require('object-assign');

--- a/client/src/utils/polyfills.js
+++ b/client/src/utils/polyfills.js
@@ -1,0 +1,3 @@
+import 'babel-polyfill';
+
+import 'whatwg-fetch';

--- a/client/webpack/base.config.js
+++ b/client/webpack/base.config.js
@@ -60,6 +60,8 @@ module.exports = function exports() {
       reasons: false,
       // Add webpack version information
       version: false,
+      // Set the maximum number of modules to be shown
+      maxModules: 0,
     },
     // Some libraries import Node modules but don't use them in the browser.
     // Tell Webpack to provide empty mocks for them so importing them works.

--- a/client/webpack/base.config.js
+++ b/client/webpack/base.config.js
@@ -61,5 +61,12 @@ module.exports = function exports() {
       // Add webpack version information
       version: false,
     },
+    // Some libraries import Node modules but don't use them in the browser.
+    // Tell Webpack to provide empty mocks for them so importing them works.
+    node: {
+      fs: 'empty',
+      net: 'empty',
+      tls: 'empty',
+    },
   };
 };

--- a/client/webpack/base.config.js
+++ b/client/webpack/base.config.js
@@ -14,7 +14,9 @@ const isVendorModule = (module) => {
 module.exports = function exports() {
   const entry = {
     // Create a vendor chunk that will contain polyfills, and all third-party dependencies.
-    vendor: ['whatwg-fetch', 'babel-polyfill'],
+    vendor: [
+      './client/src/utils/polyfills.js',
+    ],
   };
 
   entry[getOutputPath('wagtailadmin', 'wagtailadmin')] = getEntryPath('wagtailadmin', 'wagtailadmin.entry.js');

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3552,6 +3552,16 @@
         }
       }
     },
+    "core-js": {
+      "version": "1.2.7",
+      "from": "core-js@^1.0.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz"
+    },
+    "encoding": {
+      "version": "0.1.12",
+      "from": "encoding@^0.1.11",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz"
+    },
     "enzyme": {
       "version": "2.8.2",
       "from": "https://registry.npmjs.org/enzyme/-/enzyme-2.8.2.tgz",
@@ -5870,6 +5880,11 @@
           }
         }
       }
+    },
+    "fbjs": {
+      "version": "0.8.12",
+      "from": "fbjs@^0.8.4",
+      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.12.tgz"
     },
     "focus-trap-react": {
       "version": "3.0.3",
@@ -10318,6 +10333,21 @@
         }
       }
     },
+    "iconv-lite": {
+      "version": "0.4.17",
+      "from": "iconv-lite@~0.4.13",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.17.tgz"
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "from": "is-stream@^1.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz"
+    },
+    "isomorphic-fetch": {
+      "version": "2.2.1",
+      "from": "isomorphic-fetch@^2.1.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz"
+    },
     "jest": {
       "version": "20.0.4",
       "from": "https://registry.npmjs.org/jest/-/jest-20.0.4.tgz",
@@ -12694,15 +12724,30 @@
         }
       }
     },
+    "js-tokens": {
+      "version": "3.0.1",
+      "from": "js-tokens@^3.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
+    },
     "lodash": {
       "version": "4.17.4",
       "from": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
     },
+    "loose-envify": {
+      "version": "1.3.1",
+      "from": "loose-envify@^1.0.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz"
+    },
     "mustache": {
       "version": "2.3.0",
       "from": "https://registry.npmjs.org/mustache/-/mustache-2.3.0.tgz",
       "resolved": "https://registry.npmjs.org/mustache/-/mustache-2.3.0.tgz"
+    },
+    "node-fetch": {
+      "version": "1.7.1",
+      "from": "node-fetch@^1.0.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.1.tgz"
     },
     "object-assign": {
       "version": "4.1.1",
@@ -12898,6 +12943,11 @@
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
         }
       }
+    },
+    "react-addons-perf": {
+      "version": "15.4.2",
+      "from": "react-addons-perf@^15.4.2",
+      "resolved": "https://registry.npmjs.org/react-addons-perf/-/react-addons-perf-15.4.2.tgz"
     },
     "react-dom": {
       "version": "15.5.4",
@@ -13267,6 +13317,16 @@
       "version": "0.3.1",
       "from": "https://registry.npmjs.org/require-dir/-/require-dir-0.3.1.tgz",
       "resolved": "https://registry.npmjs.org/require-dir/-/require-dir-0.3.1.tgz"
+    },
+    "setimmediate": {
+      "version": "1.0.5",
+      "from": "setimmediate@^1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz"
+    },
+    "ua-parser-js": {
+      "version": "0.7.12",
+      "from": "ua-parser-js@^0.7.9",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.12.tgz"
     },
     "webpack": {
       "version": "2.6.1",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2,245 +2,97 @@
   "name": "wagtail",
   "version": "1.0.0",
   "dependencies": {
-    "babel-cli": {
-      "version": "6.24.1",
-      "from": "babel-cli@6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-cli/-/babel-cli-6.24.1.tgz",
-      "dependencies": {
-        "babel-register": {
-          "version": "6.24.1",
-          "from": "babel-register@>=6.24.1 <7.0.0",
-          "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.24.1.tgz",
-          "dependencies": {
-            "core-js": {
-              "version": "2.4.1",
-              "from": "core-js@>=2.4.0 <3.0.0",
-              "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
-            },
-            "home-or-tmp": {
-              "version": "2.0.0",
-              "from": "home-or-tmp@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
-              "dependencies": {
-                "os-homedir": {
-                  "version": "1.0.2",
-                  "from": "os-homedir@>=1.0.0 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
-                },
-                "os-tmpdir": {
-                  "version": "1.0.2",
-                  "from": "os-tmpdir@>=1.0.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
-                }
-              }
-            },
-            "mkdirp": {
-              "version": "0.5.1",
-              "from": "mkdirp@>=0.5.1 <0.6.0",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-              "dependencies": {
-                "minimist": {
-                  "version": "0.0.8",
-                  "from": "minimist@0.0.8",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-                }
-              }
-            },
-            "source-map-support": {
-              "version": "0.4.15",
-              "from": "source-map-support@>=0.4.2 <0.5.0",
-              "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.15.tgz"
-            }
-          }
-        },
-        "babel-runtime": {
-          "version": "6.23.0",
-          "from": "babel-runtime@>=6.22.0 <7.0.0",
-          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-          "dependencies": {
-            "core-js": {
-              "version": "2.4.1",
-              "from": "core-js@>=2.4.0 <3.0.0",
-              "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
-            },
-            "regenerator-runtime": {
-              "version": "0.10.5",
-              "from": "regenerator-runtime@>=0.10.0 <0.11.0",
-              "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
-            }
-          }
-        },
-        "commander": {
-          "version": "2.9.0",
-          "from": "commander@>=2.8.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-          "dependencies": {
-            "graceful-readlink": {
-              "version": "1.0.1",
-              "from": "graceful-readlink@>=1.0.0",
-              "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
-            }
-          }
-        },
-        "convert-source-map": {
-          "version": "1.5.0",
-          "from": "convert-source-map@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz"
-        },
-        "fs-readdir-recursive": {
-          "version": "1.0.0",
-          "from": "fs-readdir-recursive@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.0.0.tgz"
-        },
-        "output-file-sync": {
-          "version": "1.1.2",
-          "from": "output-file-sync@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.2.tgz",
-          "dependencies": {
-            "graceful-fs": {
-              "version": "4.1.11",
-              "from": "graceful-fs@>=4.1.4 <5.0.0",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
-            },
-            "mkdirp": {
-              "version": "0.5.1",
-              "from": "mkdirp@>=0.5.1 <0.6.0",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-              "dependencies": {
-                "minimist": {
-                  "version": "0.0.8",
-                  "from": "minimist@0.0.8",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-                }
-              }
-            },
-            "object-assign": {
-              "version": "4.1.1",
-              "from": "object-assign@>=4.1.0 <5.0.0",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
-            }
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "from": "path-is-absolute@>=1.0.0 <2.0.0",
-          "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
-        },
-        "slash": {
-          "version": "1.0.0",
-          "from": "slash@>=1.0.0 <2.0.0",
-          "resolved": "http://registry.npmjs.org/slash/-/slash-1.0.0.tgz"
-        },
-        "source-map": {
-          "version": "0.5.6",
-          "from": "source-map@>=0.5.0 <0.6.0",
-          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
-        },
-        "v8flags": {
-          "version": "2.1.1",
-          "from": "v8flags@>=2.0.10 <3.0.0",
-          "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
-          "dependencies": {
-            "user-home": {
-              "version": "1.1.1",
-              "from": "user-home@>=1.1.1 <2.0.0",
-              "resolved": "http://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
-            }
-          }
-        }
-      }
-    },
     "babel-core": {
       "version": "6.24.1",
-      "from": "babel-core@6.24.1",
+      "from": "https://registry.npmjs.org/babel-core/-/babel-core-6.24.1.tgz",
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.24.1.tgz",
       "dependencies": {
         "babel-code-frame": {
           "version": "6.22.0",
-          "from": "babel-code-frame@>=6.22.0 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
           "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
           "dependencies": {
             "chalk": {
               "version": "1.1.3",
-              "from": "chalk@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
               "dependencies": {
                 "ansi-styles": {
                   "version": "2.2.1",
-                  "from": "ansi-styles@>=2.2.1 <3.0.0",
+                  "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
                 },
                 "escape-string-regexp": {
                   "version": "1.0.5",
-                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                 },
                 "has-ansi": {
                   "version": "2.0.0",
-                  "from": "has-ansi@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.1.1",
-                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "3.0.1",
-                  "from": "strip-ansi@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.1.1",
-                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
                     }
                   }
                 },
                 "supports-color": {
                   "version": "2.0.0",
-                  "from": "supports-color@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                 }
               }
             },
             "esutils": {
               "version": "2.0.2",
-              "from": "esutils@>=2.0.2 <3.0.0",
+              "from": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
               "resolved": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
             },
             "js-tokens": {
               "version": "3.0.1",
-              "from": "js-tokens@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
               "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
             }
           }
         },
         "babel-generator": {
           "version": "6.24.1",
-          "from": "babel-generator@>=6.24.1 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.24.1.tgz",
           "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.24.1.tgz",
           "dependencies": {
             "detect-indent": {
               "version": "4.0.0",
-              "from": "detect-indent@>=4.0.0 <5.0.0",
+              "from": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
               "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
               "dependencies": {
                 "repeating": {
                   "version": "2.0.1",
-                  "from": "repeating@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
                   "dependencies": {
                     "is-finite": {
                       "version": "1.0.2",
-                      "from": "is-finite@>=1.0.0 <2.0.0",
+                      "from": "http://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
                       "resolved": "http://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
                       "dependencies": {
                         "number-is-nan": {
                           "version": "1.0.1",
-                          "from": "number-is-nan@>=1.0.0 <2.0.0",
+                          "from": "http://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
                           "resolved": "http://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
                         }
                       }
@@ -251,117 +103,117 @@
             },
             "jsesc": {
               "version": "1.3.0",
-              "from": "jsesc@>=1.3.0 <2.0.0",
+              "from": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
               "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz"
             },
             "trim-right": {
               "version": "1.0.1",
-              "from": "trim-right@>=1.0.1 <2.0.0",
+              "from": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz"
             }
           }
         },
         "babel-helpers": {
           "version": "6.24.1",
-          "from": "babel-helpers@>=6.24.1 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
           "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz"
         },
         "babel-messages": {
           "version": "6.23.0",
-          "from": "babel-messages@>=6.23.0 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
           "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
         },
         "babel-template": {
           "version": "6.24.1",
-          "from": "babel-template@>=6.24.1 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-template/-/babel-template-6.24.1.tgz",
           "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.24.1.tgz"
         },
         "babel-runtime": {
           "version": "6.23.0",
-          "from": "babel-runtime@>=6.22.0 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
           "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
           "dependencies": {
             "core-js": {
               "version": "2.4.1",
-              "from": "core-js@>=2.4.0 <3.0.0",
+              "from": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
               "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
             },
             "regenerator-runtime": {
               "version": "0.10.5",
-              "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+              "from": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
               "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
             }
           }
         },
         "babel-register": {
           "version": "6.24.1",
-          "from": "babel-register@>=6.24.1 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-register/-/babel-register-6.24.1.tgz",
           "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.24.1.tgz",
           "dependencies": {
             "core-js": {
               "version": "2.4.1",
-              "from": "core-js@>=2.4.0 <3.0.0",
+              "from": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
               "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
             },
             "home-or-tmp": {
               "version": "2.0.0",
-              "from": "home-or-tmp@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
               "dependencies": {
                 "os-homedir": {
                   "version": "1.0.2",
-                  "from": "os-homedir@>=1.0.0 <2.0.0",
+                  "from": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
                   "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
                 },
                 "os-tmpdir": {
                   "version": "1.0.2",
-                  "from": "os-tmpdir@>=1.0.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
                 }
               }
             },
             "mkdirp": {
               "version": "0.5.1",
-              "from": "mkdirp@>=0.5.1 <0.6.0",
+              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
               "dependencies": {
                 "minimist": {
                   "version": "0.0.8",
-                  "from": "minimist@0.0.8",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                 }
               }
             },
             "source-map-support": {
               "version": "0.4.15",
-              "from": "source-map-support@>=0.4.2 <0.5.0",
+              "from": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.15.tgz",
               "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.15.tgz"
             }
           }
         },
         "babel-traverse": {
           "version": "6.24.1",
-          "from": "babel-traverse@>=6.24.1 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.24.1.tgz",
           "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.24.1.tgz",
           "dependencies": {
             "globals": {
               "version": "9.17.0",
-              "from": "globals@>=9.0.0 <10.0.0",
+              "from": "https://registry.npmjs.org/globals/-/globals-9.17.0.tgz",
               "resolved": "https://registry.npmjs.org/globals/-/globals-9.17.0.tgz"
             },
             "invariant": {
               "version": "2.2.2",
-              "from": "invariant@>=2.2.0 <3.0.0",
+              "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
               "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
               "dependencies": {
                 "loose-envify": {
                   "version": "1.3.1",
-                  "from": "loose-envify@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
                   "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
                   "dependencies": {
                     "js-tokens": {
                       "version": "3.0.1",
-                      "from": "js-tokens@>=3.0.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
                     }
                   }
@@ -372,66 +224,66 @@
         },
         "babel-types": {
           "version": "6.24.1",
-          "from": "babel-types@>=6.24.1 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
           "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
           "dependencies": {
             "esutils": {
               "version": "2.0.2",
-              "from": "esutils@>=2.0.2 <3.0.0",
+              "from": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
               "resolved": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
             },
             "to-fast-properties": {
               "version": "1.0.3",
-              "from": "to-fast-properties@>=1.0.1 <2.0.0",
+              "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
               "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
             }
           }
         },
         "babylon": {
           "version": "6.17.2",
-          "from": "babylon@>=6.11.0 <7.0.0",
+          "from": "https://registry.npmjs.org/babylon/-/babylon-6.17.2.tgz",
           "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.2.tgz"
         },
         "convert-source-map": {
           "version": "1.5.0",
-          "from": "convert-source-map@>=1.1.0 <2.0.0",
+          "from": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
           "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz"
         },
         "debug": {
           "version": "2.6.8",
-          "from": "debug@>=2.1.1 <3.0.0",
+          "from": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
           "dependencies": {
             "ms": {
               "version": "2.0.0",
-              "from": "ms@2.0.0",
+              "from": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
             }
           }
         },
         "json5": {
           "version": "0.5.1",
-          "from": "json5@>=0.5.0 <0.6.0",
+          "from": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
           "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz"
         },
         "minimatch": {
           "version": "3.0.4",
-          "from": "minimatch@>=3.0.2 <4.0.0",
+          "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "dependencies": {
             "brace-expansion": {
               "version": "1.1.7",
-              "from": "brace-expansion@>=1.1.7 <2.0.0",
+              "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
               "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
               "dependencies": {
                 "balanced-match": {
                   "version": "0.4.2",
-                  "from": "balanced-match@>=0.4.1 <0.5.0",
+                  "from": "http://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
                   "resolved": "http://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
                 },
                 "concat-map": {
                   "version": "0.0.1",
-                  "from": "concat-map@0.0.1",
+                  "from": "http://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                   "resolved": "http://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                 }
               }
@@ -440,22 +292,22 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "from": "path-is-absolute@>=1.0.0 <2.0.0",
+          "from": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
           "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
         },
         "private": {
           "version": "0.1.7",
-          "from": "private@>=0.1.6 <0.2.0",
+          "from": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
           "resolved": "https://registry.npmjs.org/private/-/private-0.1.7.tgz"
         },
         "slash": {
           "version": "1.0.0",
-          "from": "slash@>=1.0.0 <2.0.0",
+          "from": "http://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
           "resolved": "http://registry.npmjs.org/slash/-/slash-1.0.0.tgz"
         },
         "source-map": {
           "version": "0.5.6",
-          "from": "source-map@>=0.5.0 <0.6.0",
+          "from": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
           "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
         }
       }
@@ -1202,42 +1054,42 @@
     },
     "babel-loader": {
       "version": "7.0.0",
-      "from": "babel-loader@7.0.0",
+      "from": "https://registry.npmjs.org/babel-loader/-/babel-loader-7.0.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-7.0.0.tgz",
       "dependencies": {
         "find-cache-dir": {
           "version": "0.1.1",
-          "from": "find-cache-dir@>=0.1.1 <0.2.0",
+          "from": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
           "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
           "dependencies": {
             "commondir": {
               "version": "1.0.1",
-              "from": "commondir@>=1.0.1 <2.0.0",
+              "from": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz"
             },
             "pkg-dir": {
               "version": "1.0.0",
-              "from": "pkg-dir@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
               "dependencies": {
                 "find-up": {
                   "version": "1.1.2",
-                  "from": "find-up@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
                   "dependencies": {
                     "path-exists": {
                       "version": "2.1.0",
-                      "from": "path-exists@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
                     },
                     "pinkie-promise": {
                       "version": "2.0.1",
-                      "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                       "dependencies": {
                         "pinkie": {
                           "version": "2.0.4",
-                          "from": "pinkie@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
                           "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                         }
                       }
@@ -1250,34 +1102,34 @@
         },
         "loader-utils": {
           "version": "1.1.0",
-          "from": "loader-utils@>=1.0.2 <2.0.0",
+          "from": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
           "dependencies": {
             "big.js": {
               "version": "3.1.3",
-              "from": "big.js@>=3.1.3 <4.0.0",
+              "from": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
               "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
             },
             "emojis-list": {
               "version": "2.1.0",
-              "from": "emojis-list@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
               "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz"
             },
             "json5": {
               "version": "0.5.1",
-              "from": "json5@>=0.5.0 <0.6.0",
+              "from": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
               "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz"
             }
           }
         },
         "mkdirp": {
           "version": "0.5.1",
-          "from": "mkdirp@>=0.5.1 <0.6.0",
+          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "from": "minimist@0.0.8",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
             }
           }
@@ -1289,51 +1141,29 @@
       "from": "https://registry.npmjs.org/babel-plugin-lodash/-/babel-plugin-lodash-3.2.11.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-lodash/-/babel-plugin-lodash-3.2.11.tgz"
     },
-    "babel-polyfill": {
-      "version": "6.23.0",
-      "from": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.23.0.tgz",
-      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.23.0.tgz",
-      "dependencies": {
-        "core-js": {
-          "version": "2.4.1",
-          "from": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
-          "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
-        },
-        "babel-runtime": {
-          "version": "6.23.0",
-          "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
-        },
-        "regenerator-runtime": {
-          "version": "0.10.3",
-          "from": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.3.tgz",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.3.tgz"
-        }
-      }
-    },
     "babel-preset-es2015": {
       "version": "6.24.1",
-      "from": "babel-preset-es2015@6.24.1",
+      "from": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
       "resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
       "dependencies": {
         "babel-plugin-check-es2015-constants": {
           "version": "6.22.0",
-          "from": "babel-plugin-check-es2015-constants@>=6.22.0 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
           "dependencies": {
             "babel-runtime": {
               "version": "6.23.0",
-              "from": "babel-runtime@>=6.22.0 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
               "dependencies": {
                 "core-js": {
                   "version": "2.4.1",
-                  "from": "core-js@>=2.4.0 <3.0.0",
+                  "from": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
                   "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
                 },
                 "regenerator-runtime": {
                   "version": "0.10.5",
-                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
                   "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
                 }
               }
@@ -1342,22 +1172,22 @@
         },
         "babel-plugin-transform-es2015-arrow-functions": {
           "version": "6.22.0",
-          "from": "babel-plugin-transform-es2015-arrow-functions@>=6.22.0 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
           "dependencies": {
             "babel-runtime": {
               "version": "6.23.0",
-              "from": "babel-runtime@>=6.22.0 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
               "dependencies": {
                 "core-js": {
                   "version": "2.4.1",
-                  "from": "core-js@>=2.4.0 <3.0.0",
+                  "from": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
                   "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
                 },
                 "regenerator-runtime": {
                   "version": "0.10.5",
-                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
                   "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
                 }
               }
@@ -1366,22 +1196,22 @@
         },
         "babel-plugin-transform-es2015-block-scoped-functions": {
           "version": "6.22.0",
-          "from": "babel-plugin-transform-es2015-block-scoped-functions@>=6.22.0 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
           "dependencies": {
             "babel-runtime": {
               "version": "6.23.0",
-              "from": "babel-runtime@>=6.22.0 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
               "dependencies": {
                 "core-js": {
                   "version": "2.4.1",
-                  "from": "core-js@>=2.4.0 <3.0.0",
+                  "from": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
                   "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
                 },
                 "regenerator-runtime": {
                   "version": "0.10.5",
-                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
                   "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
                 }
               }
@@ -1390,117 +1220,117 @@
         },
         "babel-plugin-transform-es2015-block-scoping": {
           "version": "6.24.1",
-          "from": "babel-plugin-transform-es2015-block-scoping@>=6.24.1 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.24.1.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.24.1.tgz",
           "dependencies": {
             "babel-traverse": {
               "version": "6.24.1",
-              "from": "babel-traverse@>=6.24.1 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.24.1.tgz",
               "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.24.1.tgz",
               "dependencies": {
                 "babel-code-frame": {
                   "version": "6.22.0",
-                  "from": "babel-code-frame@>=6.22.0 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
                   "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
                   "dependencies": {
                     "chalk": {
                       "version": "1.1.3",
-                      "from": "chalk@>=1.1.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                       "dependencies": {
                         "ansi-styles": {
                           "version": "2.2.1",
-                          "from": "ansi-styles@>=2.2.1 <3.0.0",
+                          "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
                           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
                         },
                         "escape-string-regexp": {
                           "version": "1.0.5",
-                          "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                          "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
                           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                         },
                         "has-ansi": {
                           "version": "2.0.0",
-                          "from": "has-ansi@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                           "dependencies": {
                             "ansi-regex": {
                               "version": "2.1.1",
-                              "from": "ansi-regex@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
                               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
                             }
                           }
                         },
                         "strip-ansi": {
                           "version": "3.0.1",
-                          "from": "strip-ansi@>=3.0.0 <4.0.0",
+                          "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                           "dependencies": {
                             "ansi-regex": {
                               "version": "2.1.1",
-                              "from": "ansi-regex@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
                               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
                             }
                           }
                         },
                         "supports-color": {
                           "version": "2.0.0",
-                          "from": "supports-color@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                         }
                       }
                     },
                     "esutils": {
                       "version": "2.0.2",
-                      "from": "esutils@>=2.0.2 <3.0.0",
+                      "from": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
                       "resolved": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
                     },
                     "js-tokens": {
                       "version": "3.0.1",
-                      "from": "js-tokens@>=3.0.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
                     }
                   }
                 },
                 "babel-messages": {
                   "version": "6.23.0",
-                  "from": "babel-messages@>=6.23.0 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
                   "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
                 },
                 "babylon": {
                   "version": "6.17.2",
-                  "from": "babylon@>=6.15.0 <7.0.0",
+                  "from": "https://registry.npmjs.org/babylon/-/babylon-6.17.2.tgz",
                   "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.2.tgz"
                 },
                 "debug": {
                   "version": "2.6.8",
-                  "from": "debug@>=2.2.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
                   "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
                   "dependencies": {
                     "ms": {
                       "version": "2.0.0",
-                      "from": "ms@2.0.0",
+                      "from": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
                     }
                   }
                 },
                 "globals": {
                   "version": "9.17.0",
-                  "from": "globals@>=9.0.0 <10.0.0",
+                  "from": "https://registry.npmjs.org/globals/-/globals-9.17.0.tgz",
                   "resolved": "https://registry.npmjs.org/globals/-/globals-9.17.0.tgz"
                 },
                 "invariant": {
                   "version": "2.2.2",
-                  "from": "invariant@>=2.2.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
                   "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
                   "dependencies": {
                     "loose-envify": {
                       "version": "1.3.1",
-                      "from": "loose-envify@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
                       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
                       "dependencies": {
                         "js-tokens": {
                           "version": "3.0.1",
-                          "from": "js-tokens@>=3.0.0 <4.0.0",
+                          "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
                         }
                       }
@@ -1511,46 +1341,46 @@
             },
             "babel-types": {
               "version": "6.24.1",
-              "from": "babel-types@>=6.24.1 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
               "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
               "dependencies": {
                 "esutils": {
                   "version": "2.0.2",
-                  "from": "esutils@>=2.0.2 <3.0.0",
+                  "from": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
                   "resolved": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
                 },
                 "to-fast-properties": {
                   "version": "1.0.3",
-                  "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
                 }
               }
             },
             "babel-template": {
               "version": "6.24.1",
-              "from": "babel-template@>=6.24.1 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-template/-/babel-template-6.24.1.tgz",
               "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.24.1.tgz",
               "dependencies": {
                 "babylon": {
                   "version": "6.17.2",
-                  "from": "babylon@>=6.11.0 <7.0.0",
+                  "from": "https://registry.npmjs.org/babylon/-/babylon-6.17.2.tgz",
                   "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.2.tgz"
                 }
               }
             },
             "babel-runtime": {
               "version": "6.23.0",
-              "from": "babel-runtime@>=6.22.0 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
               "dependencies": {
                 "core-js": {
                   "version": "2.4.1",
-                  "from": "core-js@>=2.4.0 <3.0.0",
+                  "from": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
                   "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
                 },
                 "regenerator-runtime": {
                   "version": "0.10.5",
-                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
                   "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
                 }
               }
@@ -1559,146 +1389,146 @@
         },
         "babel-plugin-transform-es2015-classes": {
           "version": "6.24.1",
-          "from": "babel-plugin-transform-es2015-classes@>=6.24.1 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
           "dependencies": {
             "babel-helper-optimise-call-expression": {
               "version": "6.24.1",
-              "from": "babel-helper-optimise-call-expression@>=6.24.1 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
               "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz"
             },
             "babel-helper-function-name": {
               "version": "6.24.1",
-              "from": "babel-helper-function-name@>=6.24.1 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
               "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
               "dependencies": {
                 "babel-helper-get-function-arity": {
                   "version": "6.24.1",
-                  "from": "babel-helper-get-function-arity@>=6.24.1 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
                   "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz"
                 }
               }
             },
             "babel-helper-replace-supers": {
               "version": "6.24.1",
-              "from": "babel-helper-replace-supers@>=6.24.1 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
               "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz"
             },
             "babel-template": {
               "version": "6.24.1",
-              "from": "babel-template@>=6.24.1 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-template/-/babel-template-6.24.1.tgz",
               "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.24.1.tgz",
               "dependencies": {
                 "babylon": {
                   "version": "6.17.2",
-                  "from": "babylon@>=6.11.0 <7.0.0",
+                  "from": "https://registry.npmjs.org/babylon/-/babylon-6.17.2.tgz",
                   "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.2.tgz"
                 }
               }
             },
             "babel-traverse": {
               "version": "6.24.1",
-              "from": "babel-traverse@>=6.24.1 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.24.1.tgz",
               "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.24.1.tgz",
               "dependencies": {
                 "babel-code-frame": {
                   "version": "6.22.0",
-                  "from": "babel-code-frame@>=6.22.0 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
                   "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
                   "dependencies": {
                     "chalk": {
                       "version": "1.1.3",
-                      "from": "chalk@>=1.1.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                       "dependencies": {
                         "ansi-styles": {
                           "version": "2.2.1",
-                          "from": "ansi-styles@>=2.2.1 <3.0.0",
+                          "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
                           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
                         },
                         "escape-string-regexp": {
                           "version": "1.0.5",
-                          "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                          "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
                           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                         },
                         "has-ansi": {
                           "version": "2.0.0",
-                          "from": "has-ansi@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                           "dependencies": {
                             "ansi-regex": {
                               "version": "2.1.1",
-                              "from": "ansi-regex@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
                               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
                             }
                           }
                         },
                         "strip-ansi": {
                           "version": "3.0.1",
-                          "from": "strip-ansi@>=3.0.0 <4.0.0",
+                          "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                           "dependencies": {
                             "ansi-regex": {
                               "version": "2.1.1",
-                              "from": "ansi-regex@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
                               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
                             }
                           }
                         },
                         "supports-color": {
                           "version": "2.0.0",
-                          "from": "supports-color@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                         }
                       }
                     },
                     "esutils": {
                       "version": "2.0.2",
-                      "from": "esutils@>=2.0.2 <3.0.0",
+                      "from": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
                       "resolved": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
                     },
                     "js-tokens": {
                       "version": "3.0.1",
-                      "from": "js-tokens@>=3.0.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
                     }
                   }
                 },
                 "babylon": {
                   "version": "6.17.2",
-                  "from": "babylon@>=6.15.0 <7.0.0",
+                  "from": "https://registry.npmjs.org/babylon/-/babylon-6.17.2.tgz",
                   "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.2.tgz"
                 },
                 "debug": {
                   "version": "2.6.8",
-                  "from": "debug@>=2.2.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
                   "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
                   "dependencies": {
                     "ms": {
                       "version": "2.0.0",
-                      "from": "ms@2.0.0",
+                      "from": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
                     }
                   }
                 },
                 "globals": {
                   "version": "9.17.0",
-                  "from": "globals@>=9.0.0 <10.0.0",
+                  "from": "https://registry.npmjs.org/globals/-/globals-9.17.0.tgz",
                   "resolved": "https://registry.npmjs.org/globals/-/globals-9.17.0.tgz"
                 },
                 "invariant": {
                   "version": "2.2.2",
-                  "from": "invariant@>=2.2.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
                   "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
                   "dependencies": {
                     "loose-envify": {
                       "version": "1.3.1",
-                      "from": "loose-envify@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
                       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
                       "dependencies": {
                         "js-tokens": {
                           "version": "3.0.1",
-                          "from": "js-tokens@>=3.0.0 <4.0.0",
+                          "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
                         }
                       }
@@ -1709,44 +1539,44 @@
             },
             "babel-helper-define-map": {
               "version": "6.24.1",
-              "from": "babel-helper-define-map@>=6.24.1 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.24.1.tgz",
               "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.24.1.tgz"
             },
             "babel-messages": {
               "version": "6.23.0",
-              "from": "babel-messages@>=6.23.0 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
               "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
             },
             "babel-runtime": {
               "version": "6.23.0",
-              "from": "babel-runtime@>=6.22.0 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
               "dependencies": {
                 "core-js": {
                   "version": "2.4.1",
-                  "from": "core-js@>=2.4.0 <3.0.0",
+                  "from": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
                   "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
                 },
                 "regenerator-runtime": {
                   "version": "0.10.5",
-                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
                   "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
                 }
               }
             },
             "babel-types": {
               "version": "6.24.1",
-              "from": "babel-types@>=6.24.1 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
               "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
               "dependencies": {
                 "esutils": {
                   "version": "2.0.2",
-                  "from": "esutils@>=2.0.2 <3.0.0",
+                  "from": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
                   "resolved": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
                 },
                 "to-fast-properties": {
                   "version": "1.0.3",
-                  "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
                 }
               }
@@ -1755,122 +1585,122 @@
         },
         "babel-plugin-transform-es2015-computed-properties": {
           "version": "6.24.1",
-          "from": "babel-plugin-transform-es2015-computed-properties@>=6.24.1 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
           "dependencies": {
             "babel-template": {
               "version": "6.24.1",
-              "from": "babel-template@>=6.24.1 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-template/-/babel-template-6.24.1.tgz",
               "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.24.1.tgz",
               "dependencies": {
                 "babylon": {
                   "version": "6.17.2",
-                  "from": "babylon@>=6.11.0 <7.0.0",
+                  "from": "https://registry.npmjs.org/babylon/-/babylon-6.17.2.tgz",
                   "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.2.tgz"
                 },
                 "babel-traverse": {
                   "version": "6.24.1",
-                  "from": "babel-traverse@>=6.24.1 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.24.1.tgz",
                   "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.24.1.tgz",
                   "dependencies": {
                     "babel-code-frame": {
                       "version": "6.22.0",
-                      "from": "babel-code-frame@>=6.22.0 <7.0.0",
+                      "from": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
                       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
                       "dependencies": {
                         "chalk": {
                           "version": "1.1.3",
-                          "from": "chalk@>=1.1.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                           "dependencies": {
                             "ansi-styles": {
                               "version": "2.2.1",
-                              "from": "ansi-styles@>=2.2.1 <3.0.0",
+                              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
                               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
                             },
                             "escape-string-regexp": {
                               "version": "1.0.5",
-                              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
                               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                             },
                             "has-ansi": {
                               "version": "2.0.0",
-                              "from": "has-ansi@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                               "dependencies": {
                                 "ansi-regex": {
                                   "version": "2.1.1",
-                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
                                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
                                 }
                               }
                             },
                             "strip-ansi": {
                               "version": "3.0.1",
-                              "from": "strip-ansi@>=3.0.0 <4.0.0",
+                              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                               "dependencies": {
                                 "ansi-regex": {
                                   "version": "2.1.1",
-                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
                                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
                                 }
                               }
                             },
                             "supports-color": {
                               "version": "2.0.0",
-                              "from": "supports-color@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                             }
                           }
                         },
                         "esutils": {
                           "version": "2.0.2",
-                          "from": "esutils@>=2.0.2 <3.0.0",
+                          "from": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
                           "resolved": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
                         },
                         "js-tokens": {
                           "version": "3.0.1",
-                          "from": "js-tokens@>=3.0.0 <4.0.0",
+                          "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
                         }
                       }
                     },
                     "babel-messages": {
                       "version": "6.23.0",
-                      "from": "babel-messages@>=6.23.0 <7.0.0",
+                      "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
                       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
                     },
                     "debug": {
                       "version": "2.6.8",
-                      "from": "debug@>=2.2.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
                       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
                       "dependencies": {
                         "ms": {
                           "version": "2.0.0",
-                          "from": "ms@2.0.0",
+                          "from": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
                         }
                       }
                     },
                     "globals": {
                       "version": "9.17.0",
-                      "from": "globals@>=9.0.0 <10.0.0",
+                      "from": "https://registry.npmjs.org/globals/-/globals-9.17.0.tgz",
                       "resolved": "https://registry.npmjs.org/globals/-/globals-9.17.0.tgz"
                     },
                     "invariant": {
                       "version": "2.2.2",
-                      "from": "invariant@>=2.2.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
                       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
                       "dependencies": {
                         "loose-envify": {
                           "version": "1.3.1",
-                          "from": "loose-envify@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
                           "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
                           "dependencies": {
                             "js-tokens": {
                               "version": "3.0.1",
-                              "from": "js-tokens@>=3.0.0 <4.0.0",
+                              "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
                             }
                           }
@@ -1881,17 +1711,17 @@
                 },
                 "babel-types": {
                   "version": "6.24.1",
-                  "from": "babel-types@>=6.24.1 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
                   "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
                   "dependencies": {
                     "esutils": {
                       "version": "2.0.2",
-                      "from": "esutils@>=2.0.2 <3.0.0",
+                      "from": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
                       "resolved": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
                     },
                     "to-fast-properties": {
                       "version": "1.0.3",
-                      "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                      "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
                       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
                     }
                   }
@@ -1900,17 +1730,17 @@
             },
             "babel-runtime": {
               "version": "6.23.0",
-              "from": "babel-runtime@>=6.22.0 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
               "dependencies": {
                 "core-js": {
                   "version": "2.4.1",
-                  "from": "core-js@>=2.4.0 <3.0.0",
+                  "from": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
                   "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
                 },
                 "regenerator-runtime": {
                   "version": "0.10.5",
-                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
                   "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
                 }
               }
@@ -1919,22 +1749,22 @@
         },
         "babel-plugin-transform-es2015-destructuring": {
           "version": "6.23.0",
-          "from": "babel-plugin-transform-es2015-destructuring@>=6.22.0 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
           "dependencies": {
             "babel-runtime": {
               "version": "6.23.0",
-              "from": "babel-runtime@>=6.22.0 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
               "dependencies": {
                 "core-js": {
                   "version": "2.4.1",
-                  "from": "core-js@>=2.4.0 <3.0.0",
+                  "from": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
                   "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
                 },
                 "regenerator-runtime": {
                   "version": "0.10.5",
-                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
                   "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
                 }
               }
@@ -1943,39 +1773,39 @@
         },
         "babel-plugin-transform-es2015-duplicate-keys": {
           "version": "6.24.1",
-          "from": "babel-plugin-transform-es2015-duplicate-keys@>=6.24.1 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
           "dependencies": {
             "babel-runtime": {
               "version": "6.23.0",
-              "from": "babel-runtime@>=6.22.0 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
               "dependencies": {
                 "core-js": {
                   "version": "2.4.1",
-                  "from": "core-js@>=2.4.0 <3.0.0",
+                  "from": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
                   "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
                 },
                 "regenerator-runtime": {
                   "version": "0.10.5",
-                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
                   "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
                 }
               }
             },
             "babel-types": {
               "version": "6.24.1",
-              "from": "babel-types@>=6.24.1 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
               "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
               "dependencies": {
                 "esutils": {
                   "version": "2.0.2",
-                  "from": "esutils@>=2.0.2 <3.0.0",
+                  "from": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
                   "resolved": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
                 },
                 "to-fast-properties": {
                   "version": "1.0.3",
-                  "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
                 }
               }
@@ -1984,22 +1814,22 @@
         },
         "babel-plugin-transform-es2015-for-of": {
           "version": "6.23.0",
-          "from": "babel-plugin-transform-es2015-for-of@>=6.22.0 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
           "dependencies": {
             "babel-runtime": {
               "version": "6.23.0",
-              "from": "babel-runtime@>=6.22.0 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
               "dependencies": {
                 "core-js": {
                   "version": "2.4.1",
-                  "from": "core-js@>=2.4.0 <3.0.0",
+                  "from": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
                   "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
                 },
                 "regenerator-runtime": {
                   "version": "0.10.5",
-                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
                   "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
                 }
               }
@@ -2008,122 +1838,122 @@
         },
         "babel-plugin-transform-es2015-function-name": {
           "version": "6.24.1",
-          "from": "babel-plugin-transform-es2015-function-name@>=6.24.1 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
           "dependencies": {
             "babel-helper-function-name": {
               "version": "6.24.1",
-              "from": "babel-helper-function-name@>=6.24.1 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
               "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
               "dependencies": {
                 "babel-traverse": {
                   "version": "6.24.1",
-                  "from": "babel-traverse@>=6.24.1 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.24.1.tgz",
                   "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.24.1.tgz",
                   "dependencies": {
                     "babel-code-frame": {
                       "version": "6.22.0",
-                      "from": "babel-code-frame@>=6.22.0 <7.0.0",
+                      "from": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
                       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
                       "dependencies": {
                         "chalk": {
                           "version": "1.1.3",
-                          "from": "chalk@>=1.1.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                           "dependencies": {
                             "ansi-styles": {
                               "version": "2.2.1",
-                              "from": "ansi-styles@>=2.2.1 <3.0.0",
+                              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
                               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
                             },
                             "escape-string-regexp": {
                               "version": "1.0.5",
-                              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
                               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                             },
                             "has-ansi": {
                               "version": "2.0.0",
-                              "from": "has-ansi@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                               "dependencies": {
                                 "ansi-regex": {
                                   "version": "2.1.1",
-                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
                                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
                                 }
                               }
                             },
                             "strip-ansi": {
                               "version": "3.0.1",
-                              "from": "strip-ansi@>=3.0.0 <4.0.0",
+                              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                               "dependencies": {
                                 "ansi-regex": {
                                   "version": "2.1.1",
-                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
                                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
                                 }
                               }
                             },
                             "supports-color": {
                               "version": "2.0.0",
-                              "from": "supports-color@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                             }
                           }
                         },
                         "esutils": {
                           "version": "2.0.2",
-                          "from": "esutils@>=2.0.2 <3.0.0",
+                          "from": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
                           "resolved": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
                         },
                         "js-tokens": {
                           "version": "3.0.1",
-                          "from": "js-tokens@>=3.0.0 <4.0.0",
+                          "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
                         }
                       }
                     },
                     "babel-messages": {
                       "version": "6.23.0",
-                      "from": "babel-messages@>=6.23.0 <7.0.0",
+                      "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
                       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
                     },
                     "babylon": {
                       "version": "6.17.2",
-                      "from": "babylon@>=6.15.0 <7.0.0",
+                      "from": "https://registry.npmjs.org/babylon/-/babylon-6.17.2.tgz",
                       "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.2.tgz"
                     },
                     "debug": {
                       "version": "2.6.8",
-                      "from": "debug@>=2.2.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
                       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
                       "dependencies": {
                         "ms": {
                           "version": "2.0.0",
-                          "from": "ms@2.0.0",
+                          "from": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
                         }
                       }
                     },
                     "globals": {
                       "version": "9.17.0",
-                      "from": "globals@>=9.0.0 <10.0.0",
+                      "from": "https://registry.npmjs.org/globals/-/globals-9.17.0.tgz",
                       "resolved": "https://registry.npmjs.org/globals/-/globals-9.17.0.tgz"
                     },
                     "invariant": {
                       "version": "2.2.2",
-                      "from": "invariant@>=2.2.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
                       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
                       "dependencies": {
                         "loose-envify": {
                           "version": "1.3.1",
-                          "from": "loose-envify@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
                           "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
                           "dependencies": {
                             "js-tokens": {
                               "version": "3.0.1",
-                              "from": "js-tokens@>=3.0.0 <4.0.0",
+                              "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
                             }
                           }
@@ -2134,17 +1964,17 @@
                 },
                 "babel-helper-get-function-arity": {
                   "version": "6.24.1",
-                  "from": "babel-helper-get-function-arity@>=6.24.1 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
                   "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz"
                 },
                 "babel-template": {
                   "version": "6.24.1",
-                  "from": "babel-template@>=6.24.1 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-template/-/babel-template-6.24.1.tgz",
                   "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.24.1.tgz",
                   "dependencies": {
                     "babylon": {
                       "version": "6.17.2",
-                      "from": "babylon@>=6.11.0 <7.0.0",
+                      "from": "https://registry.npmjs.org/babylon/-/babylon-6.17.2.tgz",
                       "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.2.tgz"
                     }
                   }
@@ -2153,34 +1983,34 @@
             },
             "babel-types": {
               "version": "6.24.1",
-              "from": "babel-types@>=6.24.1 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
               "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
               "dependencies": {
                 "esutils": {
                   "version": "2.0.2",
-                  "from": "esutils@>=2.0.2 <3.0.0",
+                  "from": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
                   "resolved": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
                 },
                 "to-fast-properties": {
                   "version": "1.0.3",
-                  "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
                 }
               }
             },
             "babel-runtime": {
               "version": "6.23.0",
-              "from": "babel-runtime@>=6.22.0 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
               "dependencies": {
                 "core-js": {
                   "version": "2.4.1",
-                  "from": "core-js@>=2.4.0 <3.0.0",
+                  "from": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
                   "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
                 },
                 "regenerator-runtime": {
                   "version": "0.10.5",
-                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
                   "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
                 }
               }
@@ -2189,22 +2019,22 @@
         },
         "babel-plugin-transform-es2015-literals": {
           "version": "6.22.0",
-          "from": "babel-plugin-transform-es2015-literals@>=6.22.0 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
           "dependencies": {
             "babel-runtime": {
               "version": "6.23.0",
-              "from": "babel-runtime@>=6.22.0 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
               "dependencies": {
                 "core-js": {
                   "version": "2.4.1",
-                  "from": "core-js@>=2.4.0 <3.0.0",
+                  "from": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
                   "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
                 },
                 "regenerator-runtime": {
                   "version": "0.10.5",
-                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
                   "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
                 }
               }
@@ -2213,122 +2043,122 @@
         },
         "babel-plugin-transform-es2015-modules-amd": {
           "version": "6.24.1",
-          "from": "babel-plugin-transform-es2015-modules-amd@>=6.24.1 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
           "dependencies": {
             "babel-template": {
               "version": "6.24.1",
-              "from": "babel-template@>=6.24.1 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-template/-/babel-template-6.24.1.tgz",
               "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.24.1.tgz",
               "dependencies": {
                 "babylon": {
                   "version": "6.17.2",
-                  "from": "babylon@>=6.11.0 <7.0.0",
+                  "from": "https://registry.npmjs.org/babylon/-/babylon-6.17.2.tgz",
                   "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.2.tgz"
                 },
                 "babel-traverse": {
                   "version": "6.24.1",
-                  "from": "babel-traverse@>=6.24.1 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.24.1.tgz",
                   "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.24.1.tgz",
                   "dependencies": {
                     "babel-code-frame": {
                       "version": "6.22.0",
-                      "from": "babel-code-frame@>=6.22.0 <7.0.0",
+                      "from": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
                       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
                       "dependencies": {
                         "chalk": {
                           "version": "1.1.3",
-                          "from": "chalk@>=1.1.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                           "dependencies": {
                             "ansi-styles": {
                               "version": "2.2.1",
-                              "from": "ansi-styles@>=2.2.1 <3.0.0",
+                              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
                               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
                             },
                             "escape-string-regexp": {
                               "version": "1.0.5",
-                              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
                               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                             },
                             "has-ansi": {
                               "version": "2.0.0",
-                              "from": "has-ansi@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                               "dependencies": {
                                 "ansi-regex": {
                                   "version": "2.1.1",
-                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
                                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
                                 }
                               }
                             },
                             "strip-ansi": {
                               "version": "3.0.1",
-                              "from": "strip-ansi@>=3.0.0 <4.0.0",
+                              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                               "dependencies": {
                                 "ansi-regex": {
                                   "version": "2.1.1",
-                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
                                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
                                 }
                               }
                             },
                             "supports-color": {
                               "version": "2.0.0",
-                              "from": "supports-color@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                             }
                           }
                         },
                         "esutils": {
                           "version": "2.0.2",
-                          "from": "esutils@>=2.0.2 <3.0.0",
+                          "from": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
                           "resolved": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
                         },
                         "js-tokens": {
                           "version": "3.0.1",
-                          "from": "js-tokens@>=3.0.0 <4.0.0",
+                          "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
                         }
                       }
                     },
                     "babel-messages": {
                       "version": "6.23.0",
-                      "from": "babel-messages@>=6.23.0 <7.0.0",
+                      "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
                       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
                     },
                     "debug": {
                       "version": "2.6.8",
-                      "from": "debug@>=2.2.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
                       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
                       "dependencies": {
                         "ms": {
                           "version": "2.0.0",
-                          "from": "ms@2.0.0",
+                          "from": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
                         }
                       }
                     },
                     "globals": {
                       "version": "9.17.0",
-                      "from": "globals@>=9.0.0 <10.0.0",
+                      "from": "https://registry.npmjs.org/globals/-/globals-9.17.0.tgz",
                       "resolved": "https://registry.npmjs.org/globals/-/globals-9.17.0.tgz"
                     },
                     "invariant": {
                       "version": "2.2.2",
-                      "from": "invariant@>=2.2.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
                       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
                       "dependencies": {
                         "loose-envify": {
                           "version": "1.3.1",
-                          "from": "loose-envify@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
                           "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
                           "dependencies": {
                             "js-tokens": {
                               "version": "3.0.1",
-                              "from": "js-tokens@>=3.0.0 <4.0.0",
+                              "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
                             }
                           }
@@ -2339,17 +2169,17 @@
                 },
                 "babel-types": {
                   "version": "6.24.1",
-                  "from": "babel-types@>=6.24.1 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
                   "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
                   "dependencies": {
                     "esutils": {
                       "version": "2.0.2",
-                      "from": "esutils@>=2.0.2 <3.0.0",
+                      "from": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
                       "resolved": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
                     },
                     "to-fast-properties": {
                       "version": "1.0.3",
-                      "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                      "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
                       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
                     }
                   }
@@ -2358,17 +2188,17 @@
             },
             "babel-runtime": {
               "version": "6.23.0",
-              "from": "babel-runtime@>=6.22.0 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
               "dependencies": {
                 "core-js": {
                   "version": "2.4.1",
-                  "from": "core-js@>=2.4.0 <3.0.0",
+                  "from": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
                   "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
                 },
                 "regenerator-runtime": {
                   "version": "0.10.5",
-                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
                   "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
                 }
               }
@@ -2377,156 +2207,156 @@
         },
         "babel-plugin-transform-es2015-modules-commonjs": {
           "version": "6.24.1",
-          "from": "babel-plugin-transform-es2015-modules-commonjs@>=6.24.1 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.24.1.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.24.1.tgz",
           "dependencies": {
             "babel-types": {
               "version": "6.24.1",
-              "from": "babel-types@>=6.24.1 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
               "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
               "dependencies": {
                 "esutils": {
                   "version": "2.0.2",
-                  "from": "esutils@>=2.0.2 <3.0.0",
+                  "from": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
                   "resolved": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
                 },
                 "to-fast-properties": {
                   "version": "1.0.3",
-                  "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
                 }
               }
             },
             "babel-runtime": {
               "version": "6.23.0",
-              "from": "babel-runtime@>=6.22.0 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
               "dependencies": {
                 "core-js": {
                   "version": "2.4.1",
-                  "from": "core-js@>=2.4.0 <3.0.0",
+                  "from": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
                   "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
                 },
                 "regenerator-runtime": {
                   "version": "0.10.5",
-                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
                   "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
                 }
               }
             },
             "babel-template": {
               "version": "6.24.1",
-              "from": "babel-template@>=6.24.1 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-template/-/babel-template-6.24.1.tgz",
               "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.24.1.tgz",
               "dependencies": {
                 "babylon": {
                   "version": "6.17.2",
-                  "from": "babylon@>=6.11.0 <7.0.0",
+                  "from": "https://registry.npmjs.org/babylon/-/babylon-6.17.2.tgz",
                   "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.2.tgz"
                 },
                 "babel-traverse": {
                   "version": "6.24.1",
-                  "from": "babel-traverse@>=6.24.1 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.24.1.tgz",
                   "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.24.1.tgz",
                   "dependencies": {
                     "babel-code-frame": {
                       "version": "6.22.0",
-                      "from": "babel-code-frame@>=6.22.0 <7.0.0",
+                      "from": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
                       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
                       "dependencies": {
                         "chalk": {
                           "version": "1.1.3",
-                          "from": "chalk@>=1.1.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                           "dependencies": {
                             "ansi-styles": {
                               "version": "2.2.1",
-                              "from": "ansi-styles@>=2.2.1 <3.0.0",
+                              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
                               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
                             },
                             "escape-string-regexp": {
                               "version": "1.0.5",
-                              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
                               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                             },
                             "has-ansi": {
                               "version": "2.0.0",
-                              "from": "has-ansi@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                               "dependencies": {
                                 "ansi-regex": {
                                   "version": "2.1.1",
-                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
                                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
                                 }
                               }
                             },
                             "strip-ansi": {
                               "version": "3.0.1",
-                              "from": "strip-ansi@>=3.0.0 <4.0.0",
+                              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                               "dependencies": {
                                 "ansi-regex": {
                                   "version": "2.1.1",
-                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
                                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
                                 }
                               }
                             },
                             "supports-color": {
                               "version": "2.0.0",
-                              "from": "supports-color@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                             }
                           }
                         },
                         "esutils": {
                           "version": "2.0.2",
-                          "from": "esutils@>=2.0.2 <3.0.0",
+                          "from": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
                           "resolved": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
                         },
                         "js-tokens": {
                           "version": "3.0.1",
-                          "from": "js-tokens@>=3.0.0 <4.0.0",
+                          "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
                         }
                       }
                     },
                     "babel-messages": {
                       "version": "6.23.0",
-                      "from": "babel-messages@>=6.23.0 <7.0.0",
+                      "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
                       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
                     },
                     "debug": {
                       "version": "2.6.8",
-                      "from": "debug@>=2.2.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
                       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
                       "dependencies": {
                         "ms": {
                           "version": "2.0.0",
-                          "from": "ms@2.0.0",
+                          "from": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
                         }
                       }
                     },
                     "globals": {
                       "version": "9.17.0",
-                      "from": "globals@>=9.0.0 <10.0.0",
+                      "from": "https://registry.npmjs.org/globals/-/globals-9.17.0.tgz",
                       "resolved": "https://registry.npmjs.org/globals/-/globals-9.17.0.tgz"
                     },
                     "invariant": {
                       "version": "2.2.2",
-                      "from": "invariant@>=2.2.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
                       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
                       "dependencies": {
                         "loose-envify": {
                           "version": "1.3.1",
-                          "from": "loose-envify@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
                           "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
                           "dependencies": {
                             "js-tokens": {
                               "version": "3.0.1",
-                              "from": "js-tokens@>=3.0.0 <4.0.0",
+                              "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
                             }
                           }
@@ -2539,129 +2369,129 @@
             },
             "babel-plugin-transform-strict-mode": {
               "version": "6.24.1",
-              "from": "babel-plugin-transform-strict-mode@>=6.24.1 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
               "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz"
             }
           }
         },
         "babel-plugin-transform-es2015-modules-systemjs": {
           "version": "6.24.1",
-          "from": "babel-plugin-transform-es2015-modules-systemjs@>=6.24.1 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
           "dependencies": {
             "babel-template": {
               "version": "6.24.1",
-              "from": "babel-template@>=6.24.1 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-template/-/babel-template-6.24.1.tgz",
               "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.24.1.tgz",
               "dependencies": {
                 "babylon": {
                   "version": "6.17.2",
-                  "from": "babylon@>=6.11.0 <7.0.0",
+                  "from": "https://registry.npmjs.org/babylon/-/babylon-6.17.2.tgz",
                   "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.2.tgz"
                 },
                 "babel-traverse": {
                   "version": "6.24.1",
-                  "from": "babel-traverse@>=6.24.1 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.24.1.tgz",
                   "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.24.1.tgz",
                   "dependencies": {
                     "babel-code-frame": {
                       "version": "6.22.0",
-                      "from": "babel-code-frame@>=6.22.0 <7.0.0",
+                      "from": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
                       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
                       "dependencies": {
                         "chalk": {
                           "version": "1.1.3",
-                          "from": "chalk@>=1.1.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                           "dependencies": {
                             "ansi-styles": {
                               "version": "2.2.1",
-                              "from": "ansi-styles@>=2.2.1 <3.0.0",
+                              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
                               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
                             },
                             "escape-string-regexp": {
                               "version": "1.0.5",
-                              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
                               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                             },
                             "has-ansi": {
                               "version": "2.0.0",
-                              "from": "has-ansi@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                               "dependencies": {
                                 "ansi-regex": {
                                   "version": "2.1.1",
-                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
                                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
                                 }
                               }
                             },
                             "strip-ansi": {
                               "version": "3.0.1",
-                              "from": "strip-ansi@>=3.0.0 <4.0.0",
+                              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                               "dependencies": {
                                 "ansi-regex": {
                                   "version": "2.1.1",
-                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
                                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
                                 }
                               }
                             },
                             "supports-color": {
                               "version": "2.0.0",
-                              "from": "supports-color@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                             }
                           }
                         },
                         "esutils": {
                           "version": "2.0.2",
-                          "from": "esutils@>=2.0.2 <3.0.0",
+                          "from": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
                           "resolved": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
                         },
                         "js-tokens": {
                           "version": "3.0.1",
-                          "from": "js-tokens@>=3.0.0 <4.0.0",
+                          "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
                         }
                       }
                     },
                     "babel-messages": {
                       "version": "6.23.0",
-                      "from": "babel-messages@>=6.23.0 <7.0.0",
+                      "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
                       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
                     },
                     "debug": {
                       "version": "2.6.8",
-                      "from": "debug@>=2.2.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
                       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
                       "dependencies": {
                         "ms": {
                           "version": "2.0.0",
-                          "from": "ms@2.0.0",
+                          "from": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
                         }
                       }
                     },
                     "globals": {
                       "version": "9.17.0",
-                      "from": "globals@>=9.0.0 <10.0.0",
+                      "from": "https://registry.npmjs.org/globals/-/globals-9.17.0.tgz",
                       "resolved": "https://registry.npmjs.org/globals/-/globals-9.17.0.tgz"
                     },
                     "invariant": {
                       "version": "2.2.2",
-                      "from": "invariant@>=2.2.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
                       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
                       "dependencies": {
                         "loose-envify": {
                           "version": "1.3.1",
-                          "from": "loose-envify@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
                           "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
                           "dependencies": {
                             "js-tokens": {
                               "version": "3.0.1",
-                              "from": "js-tokens@>=3.0.0 <4.0.0",
+                              "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
                             }
                           }
@@ -2672,17 +2502,17 @@
                 },
                 "babel-types": {
                   "version": "6.24.1",
-                  "from": "babel-types@>=6.24.1 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
                   "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
                   "dependencies": {
                     "esutils": {
                       "version": "2.0.2",
-                      "from": "esutils@>=2.0.2 <3.0.0",
+                      "from": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
                       "resolved": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
                     },
                     "to-fast-properties": {
                       "version": "1.0.3",
-                      "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                      "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
                       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
                     }
                   }
@@ -2691,22 +2521,22 @@
             },
             "babel-helper-hoist-variables": {
               "version": "6.24.1",
-              "from": "babel-helper-hoist-variables@>=6.24.1 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
               "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
               "dependencies": {
                 "babel-types": {
                   "version": "6.24.1",
-                  "from": "babel-types@>=6.24.1 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
                   "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
                   "dependencies": {
                     "esutils": {
                       "version": "2.0.2",
-                      "from": "esutils@>=2.0.2 <3.0.0",
+                      "from": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
                       "resolved": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
                     },
                     "to-fast-properties": {
                       "version": "1.0.3",
-                      "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                      "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
                       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
                     }
                   }
@@ -2715,17 +2545,17 @@
             },
             "babel-runtime": {
               "version": "6.23.0",
-              "from": "babel-runtime@>=6.22.0 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
               "dependencies": {
                 "core-js": {
                   "version": "2.4.1",
-                  "from": "core-js@>=2.4.0 <3.0.0",
+                  "from": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
                   "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
                 },
                 "regenerator-runtime": {
                   "version": "0.10.5",
-                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
                   "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
                 }
               }
@@ -2734,122 +2564,122 @@
         },
         "babel-plugin-transform-es2015-modules-umd": {
           "version": "6.24.1",
-          "from": "babel-plugin-transform-es2015-modules-umd@>=6.24.1 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
           "dependencies": {
             "babel-template": {
               "version": "6.24.1",
-              "from": "babel-template@>=6.24.1 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-template/-/babel-template-6.24.1.tgz",
               "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.24.1.tgz",
               "dependencies": {
                 "babylon": {
                   "version": "6.17.2",
-                  "from": "babylon@>=6.11.0 <7.0.0",
+                  "from": "https://registry.npmjs.org/babylon/-/babylon-6.17.2.tgz",
                   "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.2.tgz"
                 },
                 "babel-traverse": {
                   "version": "6.24.1",
-                  "from": "babel-traverse@>=6.24.1 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.24.1.tgz",
                   "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.24.1.tgz",
                   "dependencies": {
                     "babel-code-frame": {
                       "version": "6.22.0",
-                      "from": "babel-code-frame@>=6.22.0 <7.0.0",
+                      "from": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
                       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
                       "dependencies": {
                         "chalk": {
                           "version": "1.1.3",
-                          "from": "chalk@>=1.1.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                           "dependencies": {
                             "ansi-styles": {
                               "version": "2.2.1",
-                              "from": "ansi-styles@>=2.2.1 <3.0.0",
+                              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
                               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
                             },
                             "escape-string-regexp": {
                               "version": "1.0.5",
-                              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
                               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                             },
                             "has-ansi": {
                               "version": "2.0.0",
-                              "from": "has-ansi@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                               "dependencies": {
                                 "ansi-regex": {
                                   "version": "2.1.1",
-                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
                                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
                                 }
                               }
                             },
                             "strip-ansi": {
                               "version": "3.0.1",
-                              "from": "strip-ansi@>=3.0.0 <4.0.0",
+                              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                               "dependencies": {
                                 "ansi-regex": {
                                   "version": "2.1.1",
-                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
                                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
                                 }
                               }
                             },
                             "supports-color": {
                               "version": "2.0.0",
-                              "from": "supports-color@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                             }
                           }
                         },
                         "esutils": {
                           "version": "2.0.2",
-                          "from": "esutils@>=2.0.2 <3.0.0",
+                          "from": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
                           "resolved": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
                         },
                         "js-tokens": {
                           "version": "3.0.1",
-                          "from": "js-tokens@>=3.0.0 <4.0.0",
+                          "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
                         }
                       }
                     },
                     "babel-messages": {
                       "version": "6.23.0",
-                      "from": "babel-messages@>=6.23.0 <7.0.0",
+                      "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
                       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
                     },
                     "debug": {
                       "version": "2.6.8",
-                      "from": "debug@>=2.2.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
                       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
                       "dependencies": {
                         "ms": {
                           "version": "2.0.0",
-                          "from": "ms@2.0.0",
+                          "from": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
                         }
                       }
                     },
                     "globals": {
                       "version": "9.17.0",
-                      "from": "globals@>=9.0.0 <10.0.0",
+                      "from": "https://registry.npmjs.org/globals/-/globals-9.17.0.tgz",
                       "resolved": "https://registry.npmjs.org/globals/-/globals-9.17.0.tgz"
                     },
                     "invariant": {
                       "version": "2.2.2",
-                      "from": "invariant@>=2.2.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
                       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
                       "dependencies": {
                         "loose-envify": {
                           "version": "1.3.1",
-                          "from": "loose-envify@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
                           "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
                           "dependencies": {
                             "js-tokens": {
                               "version": "3.0.1",
-                              "from": "js-tokens@>=3.0.0 <4.0.0",
+                              "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
                             }
                           }
@@ -2860,17 +2690,17 @@
                 },
                 "babel-types": {
                   "version": "6.24.1",
-                  "from": "babel-types@>=6.24.1 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
                   "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
                   "dependencies": {
                     "esutils": {
                       "version": "2.0.2",
-                      "from": "esutils@>=2.0.2 <3.0.0",
+                      "from": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
                       "resolved": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
                     },
                     "to-fast-properties": {
                       "version": "1.0.3",
-                      "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                      "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
                       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
                     }
                   }
@@ -2879,17 +2709,17 @@
             },
             "babel-runtime": {
               "version": "6.23.0",
-              "from": "babel-runtime@>=6.22.0 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
               "dependencies": {
                 "core-js": {
                   "version": "2.4.1",
-                  "from": "core-js@>=2.4.0 <3.0.0",
+                  "from": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
                   "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
                 },
                 "regenerator-runtime": {
                   "version": "0.10.5",
-                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
                   "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
                 }
               }
@@ -2898,122 +2728,122 @@
         },
         "babel-plugin-transform-es2015-object-super": {
           "version": "6.24.1",
-          "from": "babel-plugin-transform-es2015-object-super@>=6.24.1 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
           "dependencies": {
             "babel-helper-replace-supers": {
               "version": "6.24.1",
-              "from": "babel-helper-replace-supers@>=6.24.1 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
               "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
               "dependencies": {
                 "babel-helper-optimise-call-expression": {
                   "version": "6.24.1",
-                  "from": "babel-helper-optimise-call-expression@>=6.24.1 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
                   "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz"
                 },
                 "babel-traverse": {
                   "version": "6.24.1",
-                  "from": "babel-traverse@>=6.24.1 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.24.1.tgz",
                   "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.24.1.tgz",
                   "dependencies": {
                     "babel-code-frame": {
                       "version": "6.22.0",
-                      "from": "babel-code-frame@>=6.22.0 <7.0.0",
+                      "from": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
                       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
                       "dependencies": {
                         "chalk": {
                           "version": "1.1.3",
-                          "from": "chalk@>=1.1.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                           "dependencies": {
                             "ansi-styles": {
                               "version": "2.2.1",
-                              "from": "ansi-styles@>=2.2.1 <3.0.0",
+                              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
                               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
                             },
                             "escape-string-regexp": {
                               "version": "1.0.5",
-                              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
                               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                             },
                             "has-ansi": {
                               "version": "2.0.0",
-                              "from": "has-ansi@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                               "dependencies": {
                                 "ansi-regex": {
                                   "version": "2.1.1",
-                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
                                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
                                 }
                               }
                             },
                             "strip-ansi": {
                               "version": "3.0.1",
-                              "from": "strip-ansi@>=3.0.0 <4.0.0",
+                              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                               "dependencies": {
                                 "ansi-regex": {
                                   "version": "2.1.1",
-                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
                                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
                                 }
                               }
                             },
                             "supports-color": {
                               "version": "2.0.0",
-                              "from": "supports-color@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                             }
                           }
                         },
                         "esutils": {
                           "version": "2.0.2",
-                          "from": "esutils@>=2.0.2 <3.0.0",
+                          "from": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
                           "resolved": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
                         },
                         "js-tokens": {
                           "version": "3.0.1",
-                          "from": "js-tokens@>=3.0.0 <4.0.0",
+                          "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
                         }
                       }
                     },
                     "babylon": {
                       "version": "6.17.2",
-                      "from": "babylon@>=6.15.0 <7.0.0",
+                      "from": "https://registry.npmjs.org/babylon/-/babylon-6.17.2.tgz",
                       "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.2.tgz"
                     },
                     "debug": {
                       "version": "2.6.8",
-                      "from": "debug@>=2.2.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
                       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
                       "dependencies": {
                         "ms": {
                           "version": "2.0.0",
-                          "from": "ms@2.0.0",
+                          "from": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
                         }
                       }
                     },
                     "globals": {
                       "version": "9.17.0",
-                      "from": "globals@>=9.0.0 <10.0.0",
+                      "from": "https://registry.npmjs.org/globals/-/globals-9.17.0.tgz",
                       "resolved": "https://registry.npmjs.org/globals/-/globals-9.17.0.tgz"
                     },
                     "invariant": {
                       "version": "2.2.2",
-                      "from": "invariant@>=2.2.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
                       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
                       "dependencies": {
                         "loose-envify": {
                           "version": "1.3.1",
-                          "from": "loose-envify@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
                           "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
                           "dependencies": {
                             "js-tokens": {
                               "version": "3.0.1",
-                              "from": "js-tokens@>=3.0.0 <4.0.0",
+                              "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
                             }
                           }
@@ -3024,34 +2854,34 @@
                 },
                 "babel-messages": {
                   "version": "6.23.0",
-                  "from": "babel-messages@>=6.23.0 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
                   "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
                 },
                 "babel-template": {
                   "version": "6.24.1",
-                  "from": "babel-template@>=6.24.1 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-template/-/babel-template-6.24.1.tgz",
                   "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.24.1.tgz",
                   "dependencies": {
                     "babylon": {
                       "version": "6.17.2",
-                      "from": "babylon@>=6.11.0 <7.0.0",
+                      "from": "https://registry.npmjs.org/babylon/-/babylon-6.17.2.tgz",
                       "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.2.tgz"
                     }
                   }
                 },
                 "babel-types": {
                   "version": "6.24.1",
-                  "from": "babel-types@>=6.24.1 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
                   "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
                   "dependencies": {
                     "esutils": {
                       "version": "2.0.2",
-                      "from": "esutils@>=2.0.2 <3.0.0",
+                      "from": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
                       "resolved": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
                     },
                     "to-fast-properties": {
                       "version": "1.0.3",
-                      "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                      "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
                       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
                     }
                   }
@@ -3060,17 +2890,17 @@
             },
             "babel-runtime": {
               "version": "6.23.0",
-              "from": "babel-runtime@>=6.22.0 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
               "dependencies": {
                 "core-js": {
                   "version": "2.4.1",
-                  "from": "core-js@>=2.4.0 <3.0.0",
+                  "from": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
                   "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
                 },
                 "regenerator-runtime": {
                   "version": "0.10.5",
-                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
                   "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
                 }
               }
@@ -3079,117 +2909,117 @@
         },
         "babel-plugin-transform-es2015-parameters": {
           "version": "6.24.1",
-          "from": "babel-plugin-transform-es2015-parameters@>=6.24.1 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
           "dependencies": {
             "babel-traverse": {
               "version": "6.24.1",
-              "from": "babel-traverse@>=6.24.1 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.24.1.tgz",
               "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.24.1.tgz",
               "dependencies": {
                 "babel-code-frame": {
                   "version": "6.22.0",
-                  "from": "babel-code-frame@>=6.22.0 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
                   "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
                   "dependencies": {
                     "chalk": {
                       "version": "1.1.3",
-                      "from": "chalk@>=1.1.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                       "dependencies": {
                         "ansi-styles": {
                           "version": "2.2.1",
-                          "from": "ansi-styles@>=2.2.1 <3.0.0",
+                          "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
                           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
                         },
                         "escape-string-regexp": {
                           "version": "1.0.5",
-                          "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                          "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
                           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                         },
                         "has-ansi": {
                           "version": "2.0.0",
-                          "from": "has-ansi@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                           "dependencies": {
                             "ansi-regex": {
                               "version": "2.1.1",
-                              "from": "ansi-regex@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
                               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
                             }
                           }
                         },
                         "strip-ansi": {
                           "version": "3.0.1",
-                          "from": "strip-ansi@>=3.0.0 <4.0.0",
+                          "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                           "dependencies": {
                             "ansi-regex": {
                               "version": "2.1.1",
-                              "from": "ansi-regex@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
                               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
                             }
                           }
                         },
                         "supports-color": {
                           "version": "2.0.0",
-                          "from": "supports-color@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                         }
                       }
                     },
                     "esutils": {
                       "version": "2.0.2",
-                      "from": "esutils@>=2.0.2 <3.0.0",
+                      "from": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
                       "resolved": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
                     },
                     "js-tokens": {
                       "version": "3.0.1",
-                      "from": "js-tokens@>=3.0.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
                     }
                   }
                 },
                 "babel-messages": {
                   "version": "6.23.0",
-                  "from": "babel-messages@>=6.23.0 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
                   "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
                 },
                 "babylon": {
                   "version": "6.17.2",
-                  "from": "babylon@>=6.15.0 <7.0.0",
+                  "from": "https://registry.npmjs.org/babylon/-/babylon-6.17.2.tgz",
                   "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.2.tgz"
                 },
                 "debug": {
                   "version": "2.6.8",
-                  "from": "debug@>=2.2.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
                   "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
                   "dependencies": {
                     "ms": {
                       "version": "2.0.0",
-                      "from": "ms@2.0.0",
+                      "from": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
                     }
                   }
                 },
                 "globals": {
                   "version": "9.17.0",
-                  "from": "globals@>=9.0.0 <10.0.0",
+                  "from": "https://registry.npmjs.org/globals/-/globals-9.17.0.tgz",
                   "resolved": "https://registry.npmjs.org/globals/-/globals-9.17.0.tgz"
                 },
                 "invariant": {
                   "version": "2.2.2",
-                  "from": "invariant@>=2.2.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
                   "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
                   "dependencies": {
                     "loose-envify": {
                       "version": "1.3.1",
-                      "from": "loose-envify@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
                       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
                       "dependencies": {
                         "js-tokens": {
                           "version": "3.0.1",
-                          "from": "js-tokens@>=3.0.0 <4.0.0",
+                          "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
                         }
                       }
@@ -3200,63 +3030,63 @@
             },
             "babel-helper-call-delegate": {
               "version": "6.24.1",
-              "from": "babel-helper-call-delegate@>=6.24.1 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
               "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
               "dependencies": {
                 "babel-helper-hoist-variables": {
                   "version": "6.24.1",
-                  "from": "babel-helper-hoist-variables@>=6.24.1 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
                   "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz"
                 }
               }
             },
             "babel-helper-get-function-arity": {
               "version": "6.24.1",
-              "from": "babel-helper-get-function-arity@>=6.24.1 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
               "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz"
             },
             "babel-template": {
               "version": "6.24.1",
-              "from": "babel-template@>=6.24.1 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-template/-/babel-template-6.24.1.tgz",
               "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.24.1.tgz",
               "dependencies": {
                 "babylon": {
                   "version": "6.17.2",
-                  "from": "babylon@>=6.11.0 <7.0.0",
+                  "from": "https://registry.npmjs.org/babylon/-/babylon-6.17.2.tgz",
                   "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.2.tgz"
                 }
               }
             },
             "babel-types": {
               "version": "6.24.1",
-              "from": "babel-types@>=6.24.1 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
               "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
               "dependencies": {
                 "esutils": {
                   "version": "2.0.2",
-                  "from": "esutils@>=2.0.2 <3.0.0",
+                  "from": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
                   "resolved": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
                 },
                 "to-fast-properties": {
                   "version": "1.0.3",
-                  "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
                 }
               }
             },
             "babel-runtime": {
               "version": "6.23.0",
-              "from": "babel-runtime@>=6.22.0 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
               "dependencies": {
                 "core-js": {
                   "version": "2.4.1",
-                  "from": "core-js@>=2.4.0 <3.0.0",
+                  "from": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
                   "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
                 },
                 "regenerator-runtime": {
                   "version": "0.10.5",
-                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
                   "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
                 }
               }
@@ -3265,39 +3095,39 @@
         },
         "babel-plugin-transform-es2015-shorthand-properties": {
           "version": "6.24.1",
-          "from": "babel-plugin-transform-es2015-shorthand-properties@>=6.24.1 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
           "dependencies": {
             "babel-types": {
               "version": "6.24.1",
-              "from": "babel-types@>=6.24.1 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
               "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
               "dependencies": {
                 "esutils": {
                   "version": "2.0.2",
-                  "from": "esutils@>=2.0.2 <3.0.0",
+                  "from": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
                   "resolved": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
                 },
                 "to-fast-properties": {
                   "version": "1.0.3",
-                  "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
                 }
               }
             },
             "babel-runtime": {
               "version": "6.23.0",
-              "from": "babel-runtime@>=6.22.0 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
               "dependencies": {
                 "core-js": {
                   "version": "2.4.1",
-                  "from": "core-js@>=2.4.0 <3.0.0",
+                  "from": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
                   "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
                 },
                 "regenerator-runtime": {
                   "version": "0.10.5",
-                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
                   "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
                 }
               }
@@ -3306,22 +3136,22 @@
         },
         "babel-plugin-transform-es2015-spread": {
           "version": "6.22.0",
-          "from": "babel-plugin-transform-es2015-spread@>=6.22.0 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
           "dependencies": {
             "babel-runtime": {
               "version": "6.23.0",
-              "from": "babel-runtime@>=6.22.0 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
               "dependencies": {
                 "core-js": {
                   "version": "2.4.1",
-                  "from": "core-js@>=2.4.0 <3.0.0",
+                  "from": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
                   "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
                 },
                 "regenerator-runtime": {
                   "version": "0.10.5",
-                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
                   "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
                 }
               }
@@ -3330,44 +3160,44 @@
         },
         "babel-plugin-transform-es2015-sticky-regex": {
           "version": "6.24.1",
-          "from": "babel-plugin-transform-es2015-sticky-regex@>=6.24.1 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
           "dependencies": {
             "babel-helper-regex": {
               "version": "6.24.1",
-              "from": "babel-helper-regex@>=6.24.1 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.24.1.tgz",
               "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.24.1.tgz"
             },
             "babel-types": {
               "version": "6.24.1",
-              "from": "babel-types@>=6.24.1 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
               "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
               "dependencies": {
                 "esutils": {
                   "version": "2.0.2",
-                  "from": "esutils@>=2.0.2 <3.0.0",
+                  "from": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
                   "resolved": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
                 },
                 "to-fast-properties": {
                   "version": "1.0.3",
-                  "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
                 }
               }
             },
             "babel-runtime": {
               "version": "6.23.0",
-              "from": "babel-runtime@>=6.22.0 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
               "dependencies": {
                 "core-js": {
                   "version": "2.4.1",
-                  "from": "core-js@>=2.4.0 <3.0.0",
+                  "from": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
                   "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
                 },
                 "regenerator-runtime": {
                   "version": "0.10.5",
-                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
                   "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
                 }
               }
@@ -3376,22 +3206,22 @@
         },
         "babel-plugin-transform-es2015-template-literals": {
           "version": "6.22.0",
-          "from": "babel-plugin-transform-es2015-template-literals@>=6.22.0 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
           "dependencies": {
             "babel-runtime": {
               "version": "6.23.0",
-              "from": "babel-runtime@>=6.22.0 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
               "dependencies": {
                 "core-js": {
                   "version": "2.4.1",
-                  "from": "core-js@>=2.4.0 <3.0.0",
+                  "from": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
                   "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
                 },
                 "regenerator-runtime": {
                   "version": "0.10.5",
-                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
                   "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
                 }
               }
@@ -3400,22 +3230,22 @@
         },
         "babel-plugin-transform-es2015-typeof-symbol": {
           "version": "6.23.0",
-          "from": "babel-plugin-transform-es2015-typeof-symbol@>=6.22.0 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
           "dependencies": {
             "babel-runtime": {
               "version": "6.23.0",
-              "from": "babel-runtime@>=6.22.0 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
               "dependencies": {
                 "core-js": {
                   "version": "2.4.1",
-                  "from": "core-js@>=2.4.0 <3.0.0",
+                  "from": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
                   "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
                 },
                 "regenerator-runtime": {
                   "version": "0.10.5",
-                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
                   "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
                 }
               }
@@ -3424,27 +3254,27 @@
         },
         "babel-plugin-transform-es2015-unicode-regex": {
           "version": "6.24.1",
-          "from": "babel-plugin-transform-es2015-unicode-regex@>=6.24.1 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
           "dependencies": {
             "babel-helper-regex": {
               "version": "6.24.1",
-              "from": "babel-helper-regex@>=6.24.1 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.24.1.tgz",
               "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.24.1.tgz",
               "dependencies": {
                 "babel-types": {
                   "version": "6.24.1",
-                  "from": "babel-types@>=6.24.1 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
                   "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
                   "dependencies": {
                     "esutils": {
                       "version": "2.0.2",
-                      "from": "esutils@>=2.0.2 <3.0.0",
+                      "from": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
                       "resolved": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
                     },
                     "to-fast-properties": {
                       "version": "1.0.3",
-                      "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                      "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
                       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
                     }
                   }
@@ -3453,44 +3283,44 @@
             },
             "babel-runtime": {
               "version": "6.23.0",
-              "from": "babel-runtime@>=6.22.0 <7.0.0",
+              "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
               "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
               "dependencies": {
                 "core-js": {
                   "version": "2.4.1",
-                  "from": "core-js@>=2.4.0 <3.0.0",
+                  "from": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
                   "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
                 },
                 "regenerator-runtime": {
                   "version": "0.10.5",
-                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
                   "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
                 }
               }
             },
             "regexpu-core": {
               "version": "2.0.0",
-              "from": "regexpu-core@>=2.0.0 <3.0.0",
+              "from": "http://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
               "resolved": "http://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
               "dependencies": {
                 "regenerate": {
                   "version": "1.3.2",
-                  "from": "regenerate@>=1.2.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
                   "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz"
                 },
                 "regjsgen": {
                   "version": "0.2.0",
-                  "from": "regjsgen@>=0.2.0 <0.3.0",
+                  "from": "http://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
                   "resolved": "http://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz"
                 },
                 "regjsparser": {
                   "version": "0.1.5",
-                  "from": "regjsparser@>=0.1.4 <0.2.0",
+                  "from": "http://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
                   "resolved": "http://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
                   "dependencies": {
                     "jsesc": {
                       "version": "0.5.0",
-                      "from": "jsesc@>=0.5.0 <0.6.0",
+                      "from": "http://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
                       "resolved": "http://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
                     }
                   }
@@ -3501,51 +3331,51 @@
         },
         "babel-plugin-transform-regenerator": {
           "version": "6.24.1",
-          "from": "babel-plugin-transform-regenerator@>=6.24.1 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.24.1.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.24.1.tgz",
           "dependencies": {
             "regenerator-transform": {
               "version": "0.9.11",
-              "from": "regenerator-transform@0.9.11",
+              "from": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.9.11.tgz",
               "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.9.11.tgz",
               "dependencies": {
                 "babel-runtime": {
                   "version": "6.23.0",
-                  "from": "babel-runtime@>=6.18.0 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
                   "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
                   "dependencies": {
                     "core-js": {
                       "version": "2.4.1",
-                      "from": "core-js@>=2.4.0 <3.0.0",
+                      "from": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
                       "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
                     },
                     "regenerator-runtime": {
                       "version": "0.10.5",
-                      "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+                      "from": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
                       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
                     }
                   }
                 },
                 "babel-types": {
                   "version": "6.24.1",
-                  "from": "babel-types@>=6.19.0 <7.0.0",
+                  "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
                   "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
                   "dependencies": {
                     "esutils": {
                       "version": "2.0.2",
-                      "from": "esutils@>=2.0.2 <3.0.0",
+                      "from": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
                       "resolved": "http://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
                     },
                     "to-fast-properties": {
                       "version": "1.0.3",
-                      "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                      "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
                       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
                     }
                   }
                 },
                 "private": {
                   "version": "0.1.7",
-                  "from": "private@>=0.1.6 <0.2.0",
+                  "from": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
                   "resolved": "https://registry.npmjs.org/private/-/private-0.1.7.tgz"
                 }
               }
@@ -6038,40 +5868,6 @@
               "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
             }
           }
-        }
-      }
-    },
-    "exports-loader": {
-      "version": "0.6.4",
-      "from": "exports-loader@0.6.4",
-      "resolved": "https://registry.npmjs.org/exports-loader/-/exports-loader-0.6.4.tgz",
-      "dependencies": {
-        "loader-utils": {
-          "version": "1.1.0",
-          "from": "loader-utils@>=1.0.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
-          "dependencies": {
-            "big.js": {
-              "version": "3.1.3",
-              "from": "big.js@>=3.1.3 <4.0.0",
-              "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
-            },
-            "emojis-list": {
-              "version": "2.1.0",
-              "from": "emojis-list@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz"
-            },
-            "json5": {
-              "version": "0.5.1",
-              "from": "json5@>=0.5.0 <0.6.0",
-              "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz"
-            }
-          }
-        },
-        "source-map": {
-          "version": "0.5.6",
-          "from": "source-map@>=0.5.6 <0.6.0",
-          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
         }
       }
     },
@@ -10522,40 +10318,6 @@
         }
       }
     },
-    "imports-loader": {
-      "version": "0.7.1",
-      "from": "imports-loader@0.7.1",
-      "resolved": "https://registry.npmjs.org/imports-loader/-/imports-loader-0.7.1.tgz",
-      "dependencies": {
-        "loader-utils": {
-          "version": "1.1.0",
-          "from": "loader-utils@>=1.0.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
-          "dependencies": {
-            "big.js": {
-              "version": "3.1.3",
-              "from": "big.js@>=3.1.3 <4.0.0",
-              "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
-            },
-            "emojis-list": {
-              "version": "2.1.0",
-              "from": "emojis-list@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz"
-            },
-            "json5": {
-              "version": "0.5.1",
-              "from": "json5@>=0.5.0 <0.6.0",
-              "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz"
-            }
-          }
-        },
-        "source-map": {
-          "version": "0.5.6",
-          "from": "source-map@>=0.5.6 <0.6.0",
-          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
-        }
-      }
-    },
     "jest": {
       "version": "20.0.4",
       "from": "https://registry.npmjs.org/jest/-/jest-20.0.4.tgz",
@@ -12942,6 +12704,23 @@
       "from": "https://registry.npmjs.org/mustache/-/mustache-2.3.0.tgz",
       "resolved": "https://registry.npmjs.org/mustache/-/mustache-2.3.0.tgz"
     },
+    "object-assign": {
+      "version": "4.1.1",
+      "from": "object-assign@>=4.0.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+    },
+    "promise": {
+      "version": "7.1.1",
+      "from": "promise@>=7.0.0 <8.0.0",
+      "resolved": "http://registry.npmjs.org/promise/-/promise-7.1.1.tgz",
+      "dependencies": {
+        "asap": {
+          "version": "2.0.5",
+          "from": "asap@>=2.0.3 <2.1.0",
+          "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.5.tgz"
+        }
+      }
+    },
     "prop-types": {
       "version": "15.5.10",
       "from": "https://registry.npmjs.org/prop-types/-/prop-types-15.5.10.tgz",
@@ -13110,95 +12889,6 @@
               "version": "3.0.1",
               "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
               "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
-            }
-          }
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
-        }
-      }
-    },
-    "react-addons-test-utils": {
-      "version": "15.4.2",
-      "from": "https://registry.npmjs.org/react-addons-test-utils/-/react-addons-test-utils-15.4.2.tgz",
-      "resolved": "https://registry.npmjs.org/react-addons-test-utils/-/react-addons-test-utils-15.4.2.tgz",
-      "dependencies": {
-        "fbjs": {
-          "version": "0.8.9",
-          "from": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.9.tgz",
-          "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.9.tgz",
-          "dependencies": {
-            "core-js": {
-              "version": "1.2.7",
-              "from": "http://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-              "resolved": "http://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz"
-            },
-            "isomorphic-fetch": {
-              "version": "2.2.1",
-              "from": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-              "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-              "dependencies": {
-                "node-fetch": {
-                  "version": "1.6.3",
-                  "from": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.6.3.tgz",
-                  "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.6.3.tgz",
-                  "dependencies": {
-                    "encoding": {
-                      "version": "0.1.12",
-                      "from": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-                      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-                      "dependencies": {
-                        "iconv-lite": {
-                          "version": "0.4.15",
-                          "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.15.tgz",
-                          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.15.tgz"
-                        }
-                      }
-                    },
-                    "is-stream": {
-                      "version": "1.1.0",
-                      "from": "http://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-                      "resolved": "http://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "loose-envify": {
-              "version": "1.3.1",
-              "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-              "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-              "dependencies": {
-                "js-tokens": {
-                  "version": "3.0.1",
-                  "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
-                }
-              }
-            },
-            "promise": {
-              "version": "7.1.1",
-              "from": "http://registry.npmjs.org/promise/-/promise-7.1.1.tgz",
-              "resolved": "http://registry.npmjs.org/promise/-/promise-7.1.1.tgz",
-              "dependencies": {
-                "asap": {
-                  "version": "2.0.5",
-                  "from": "https://registry.npmjs.org/asap/-/asap-2.0.5.tgz",
-                  "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.5.tgz"
-                }
-              }
-            },
-            "setimmediate": {
-              "version": "1.0.5",
-              "from": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-              "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz"
-            },
-            "ua-parser-js": {
-              "version": "0.7.12",
-              "from": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.12.tgz",
-              "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.12.tgz"
             }
           }
         },
@@ -13563,42 +13253,6 @@
         }
       }
     },
-    "redux-actions": {
-      "version": "2.0.3",
-      "from": "https://registry.npmjs.org/redux-actions/-/redux-actions-2.0.3.tgz",
-      "resolved": "https://registry.npmjs.org/redux-actions/-/redux-actions-2.0.3.tgz",
-      "dependencies": {
-        "invariant": {
-          "version": "2.2.2",
-          "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-          "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-          "dependencies": {
-            "loose-envify": {
-              "version": "1.3.1",
-              "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-              "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-              "dependencies": {
-                "js-tokens": {
-                  "version": "3.0.1",
-                  "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
-                }
-              }
-            }
-          }
-        },
-        "lodash-es": {
-          "version": "4.17.4",
-          "from": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.4.tgz",
-          "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.4.tgz"
-        },
-        "reduce-reducers": {
-          "version": "0.1.2",
-          "from": "https://registry.npmjs.org/reduce-reducers/-/reduce-reducers-0.1.2.tgz",
-          "resolved": "https://registry.npmjs.org/reduce-reducers/-/reduce-reducers-0.1.2.tgz"
-        }
-      }
-    },
     "redux-mock-store": {
       "version": "1.2.2",
       "from": "https://registry.npmjs.org/redux-mock-store/-/redux-mock-store-1.2.2.tgz",
@@ -13616,44 +13270,44 @@
     },
     "webpack": {
       "version": "2.6.1",
-      "from": "webpack@2.6.1",
+      "from": "https://registry.npmjs.org/webpack/-/webpack-2.6.1.tgz",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-2.6.1.tgz",
       "dependencies": {
         "acorn": {
           "version": "5.0.3",
-          "from": "acorn@>=5.0.0 <6.0.0",
+          "from": "https://registry.npmjs.org/acorn/-/acorn-5.0.3.tgz",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.0.3.tgz"
         },
         "acorn-dynamic-import": {
           "version": "2.0.2",
-          "from": "acorn-dynamic-import@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz",
           "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz",
           "dependencies": {
             "acorn": {
               "version": "4.0.13",
-              "from": "acorn@>=4.0.3 <5.0.0",
+              "from": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
               "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz"
             }
           }
         },
         "ajv": {
           "version": "4.11.8",
-          "from": "ajv@>=4.7.0 <5.0.0",
+          "from": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
           "dependencies": {
             "co": {
               "version": "4.6.0",
-              "from": "co@>=4.6.0 <5.0.0",
+              "from": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
               "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz"
             },
             "json-stable-stringify": {
               "version": "1.0.1",
-              "from": "json-stable-stringify@>=1.0.1 <2.0.0",
+              "from": "http://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
               "resolved": "http://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
               "dependencies": {
                 "jsonify": {
                   "version": "0.0.0",
-                  "from": "jsonify@>=0.0.0 <0.1.0",
+                  "from": "http://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
                   "resolved": "http://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
                 }
               }
@@ -13662,128 +13316,128 @@
         },
         "ajv-keywords": {
           "version": "1.5.1",
-          "from": "ajv-keywords@>=1.1.1 <2.0.0",
+          "from": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
           "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz"
         },
         "async": {
           "version": "2.4.1",
-          "from": "async@>=2.1.2 <3.0.0",
+          "from": "https://registry.npmjs.org/async/-/async-2.4.1.tgz",
           "resolved": "https://registry.npmjs.org/async/-/async-2.4.1.tgz"
         },
         "enhanced-resolve": {
           "version": "3.1.0",
-          "from": "enhanced-resolve@>=3.0.0 <4.0.0",
+          "from": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.1.0.tgz",
           "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.1.0.tgz",
           "dependencies": {
             "graceful-fs": {
               "version": "4.1.11",
-              "from": "graceful-fs@>=4.1.2 <5.0.0",
+              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
             },
             "object-assign": {
               "version": "4.1.1",
-              "from": "object-assign@>=4.0.1 <5.0.0",
+              "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
               "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
             }
           }
         },
         "interpret": {
           "version": "1.0.3",
-          "from": "interpret@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz",
           "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz"
         },
         "json-loader": {
           "version": "0.5.4",
-          "from": "json-loader@>=0.5.4 <0.6.0",
+          "from": "https://registry.npmjs.org/json-loader/-/json-loader-0.5.4.tgz",
           "resolved": "https://registry.npmjs.org/json-loader/-/json-loader-0.5.4.tgz"
         },
         "json5": {
           "version": "0.5.1",
-          "from": "json5@>=0.5.1 <0.6.0",
+          "from": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
           "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz"
         },
         "loader-runner": {
           "version": "2.3.0",
-          "from": "loader-runner@>=2.3.0 <3.0.0",
+          "from": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.3.0.tgz",
           "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.3.0.tgz"
         },
         "loader-utils": {
           "version": "0.2.17",
-          "from": "loader-utils@>=0.2.16 <0.3.0",
+          "from": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
           "dependencies": {
             "big.js": {
               "version": "3.1.3",
-              "from": "big.js@>=3.1.3 <4.0.0",
+              "from": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
               "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
             },
             "emojis-list": {
               "version": "2.1.0",
-              "from": "emojis-list@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
               "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz"
             },
             "object-assign": {
               "version": "4.1.1",
-              "from": "object-assign@>=4.0.1 <5.0.0",
+              "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
               "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
             }
           }
         },
         "memory-fs": {
           "version": "0.4.1",
-          "from": "memory-fs@>=0.4.1 <0.5.0",
+          "from": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
           "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
           "dependencies": {
             "errno": {
               "version": "0.1.4",
-              "from": "errno@>=0.1.3 <0.2.0",
+              "from": "http://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
               "resolved": "http://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
               "dependencies": {
                 "prr": {
                   "version": "0.0.0",
-                  "from": "prr@>=0.0.0 <0.1.0",
+                  "from": "http://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
                   "resolved": "http://registry.npmjs.org/prr/-/prr-0.0.0.tgz"
                 }
               }
             },
             "readable-stream": {
               "version": "2.2.10",
-              "from": "readable-stream@>=2.0.1 <3.0.0",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.10.tgz",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.10.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "from": "http://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                   "resolved": "http://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                 },
                 "inherits": {
                   "version": "2.0.3",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "http://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
                   "resolved": "http://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                 },
                 "isarray": {
                   "version": "1.0.0",
-                  "from": "isarray@>=1.0.0 <1.1.0",
+                  "from": "http://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
                   "resolved": "http://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                 },
                 "process-nextick-args": {
                   "version": "1.0.7",
-                  "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                  "from": "http://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
                   "resolved": "http://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
                 },
                 "safe-buffer": {
                   "version": "5.1.0",
-                  "from": "safe-buffer@>=5.0.1 <6.0.0",
+                  "from": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.0.tgz"
                 },
                 "string_decoder": {
                   "version": "1.0.1",
-                  "from": "string_decoder@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz"
                 },
                 "util-deprecate": {
                   "version": "1.0.2",
-                  "from": "util-deprecate@>=1.0.1 <1.1.0",
+                  "from": "http://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
                   "resolved": "http://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                 }
               }
@@ -13792,122 +13446,122 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "from": "mkdirp@>=0.5.0 <0.6.0",
+          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "from": "minimist@0.0.8",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
             }
           }
         },
         "node-libs-browser": {
           "version": "2.0.0",
-          "from": "node-libs-browser@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.0.0.tgz",
           "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.0.0.tgz",
           "dependencies": {
             "assert": {
               "version": "1.4.1",
-              "from": "assert@>=1.1.1 <2.0.0",
+              "from": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
               "resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz"
             },
             "browserify-zlib": {
               "version": "0.1.4",
-              "from": "browserify-zlib@>=0.1.4 <0.2.0",
+              "from": "http://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
               "resolved": "http://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
               "dependencies": {
                 "pako": {
                   "version": "0.2.9",
-                  "from": "pako@>=0.2.0 <0.3.0",
+                  "from": "http://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
                   "resolved": "http://registry.npmjs.org/pako/-/pako-0.2.9.tgz"
                 }
               }
             },
             "buffer": {
               "version": "4.9.1",
-              "from": "buffer@>=4.3.0 <5.0.0",
+              "from": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
               "resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
               "dependencies": {
                 "base64-js": {
                   "version": "1.2.0",
-                  "from": "base64-js@>=1.0.2 <2.0.0",
+                  "from": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.0.tgz"
                 },
                 "ieee754": {
                   "version": "1.1.8",
-                  "from": "ieee754@>=1.1.4 <2.0.0",
+                  "from": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
                   "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz"
                 },
                 "isarray": {
                   "version": "1.0.0",
-                  "from": "isarray@>=1.0.0 <2.0.0",
+                  "from": "http://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
                   "resolved": "http://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                 }
               }
             },
             "console-browserify": {
               "version": "1.1.0",
-              "from": "console-browserify@>=1.1.0 <2.0.0",
+              "from": "http://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
               "resolved": "http://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
               "dependencies": {
                 "date-now": {
                   "version": "0.1.4",
-                  "from": "date-now@>=0.1.4 <0.2.0",
+                  "from": "http://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
                   "resolved": "http://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
                 }
               }
             },
             "constants-browserify": {
               "version": "1.0.0",
-              "from": "constants-browserify@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz"
             },
             "crypto-browserify": {
               "version": "3.11.0",
-              "from": "crypto-browserify@>=3.11.0 <4.0.0",
+              "from": "http://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.0.tgz",
               "resolved": "http://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.0.tgz",
               "dependencies": {
                 "browserify-cipher": {
                   "version": "1.0.0",
-                  "from": "browserify-cipher@>=1.0.0 <2.0.0",
+                  "from": "http://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz",
                   "resolved": "http://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz",
                   "dependencies": {
                     "browserify-aes": {
                       "version": "1.0.6",
-                      "from": "browserify-aes@>=1.0.4 <2.0.0",
+                      "from": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.6.tgz",
                       "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.6.tgz",
                       "dependencies": {
                         "buffer-xor": {
                           "version": "1.0.3",
-                          "from": "buffer-xor@>=1.0.2 <2.0.0",
+                          "from": "http://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
                           "resolved": "http://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz"
                         },
                         "cipher-base": {
                           "version": "1.0.3",
-                          "from": "cipher-base@>=1.0.0 <2.0.0",
+                          "from": "http://registry.npmjs.org/cipher-base/-/cipher-base-1.0.3.tgz",
                           "resolved": "http://registry.npmjs.org/cipher-base/-/cipher-base-1.0.3.tgz"
                         }
                       }
                     },
                     "browserify-des": {
                       "version": "1.0.0",
-                      "from": "browserify-des@>=1.0.0 <2.0.0",
+                      "from": "http://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz",
                       "resolved": "http://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz",
                       "dependencies": {
                         "cipher-base": {
                           "version": "1.0.3",
-                          "from": "cipher-base@>=1.0.1 <2.0.0",
+                          "from": "http://registry.npmjs.org/cipher-base/-/cipher-base-1.0.3.tgz",
                           "resolved": "http://registry.npmjs.org/cipher-base/-/cipher-base-1.0.3.tgz"
                         },
                         "des.js": {
                           "version": "1.0.0",
-                          "from": "des.js@>=1.0.0 <2.0.0",
+                          "from": "http://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
                           "resolved": "http://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
                           "dependencies": {
                             "minimalistic-assert": {
                               "version": "1.0.0",
-                              "from": "minimalistic-assert@>=1.0.0 <2.0.0",
+                              "from": "http://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
                               "resolved": "http://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
                             }
                           }
@@ -13916,95 +13570,95 @@
                     },
                     "evp_bytestokey": {
                       "version": "1.0.0",
-                      "from": "evp_bytestokey@>=1.0.0 <2.0.0",
+                      "from": "http://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz",
                       "resolved": "http://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz"
                     }
                   }
                 },
                 "browserify-sign": {
                   "version": "4.0.4",
-                  "from": "browserify-sign@>=4.0.0 <5.0.0",
+                  "from": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
                   "dependencies": {
                     "bn.js": {
                       "version": "4.11.6",
-                      "from": "bn.js@>=4.1.1 <5.0.0",
+                      "from": "http://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
                       "resolved": "http://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz"
                     },
                     "browserify-rsa": {
                       "version": "4.0.1",
-                      "from": "browserify-rsa@>=4.0.0 <5.0.0",
+                      "from": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
                       "resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz"
                     },
                     "elliptic": {
                       "version": "6.4.0",
-                      "from": "elliptic@>=6.0.0 <7.0.0",
+                      "from": "http://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
                       "resolved": "http://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
                       "dependencies": {
                         "brorand": {
                           "version": "1.1.0",
-                          "from": "brorand@>=1.0.1 <2.0.0",
+                          "from": "http://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
                           "resolved": "http://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz"
                         },
                         "hash.js": {
                           "version": "1.0.3",
-                          "from": "hash.js@>=1.0.0 <2.0.0",
+                          "from": "http://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz",
                           "resolved": "http://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz"
                         },
                         "hmac-drbg": {
                           "version": "1.0.1",
-                          "from": "hmac-drbg@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz"
                         },
                         "minimalistic-assert": {
                           "version": "1.0.0",
-                          "from": "minimalistic-assert@>=1.0.0 <2.0.0",
+                          "from": "http://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
                           "resolved": "http://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
                         },
                         "minimalistic-crypto-utils": {
                           "version": "1.0.1",
-                          "from": "minimalistic-crypto-utils@>=1.0.0 <2.0.0",
+                          "from": "http://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
                           "resolved": "http://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz"
                         }
                       }
                     },
                     "parse-asn1": {
                       "version": "5.1.0",
-                      "from": "parse-asn1@>=5.0.0 <6.0.0",
+                      "from": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
                       "dependencies": {
                         "asn1.js": {
                           "version": "4.9.1",
-                          "from": "asn1.js@>=4.0.0 <5.0.0",
+                          "from": "http://registry.npmjs.org/asn1.js/-/asn1.js-4.9.1.tgz",
                           "resolved": "http://registry.npmjs.org/asn1.js/-/asn1.js-4.9.1.tgz",
                           "dependencies": {
                             "minimalistic-assert": {
                               "version": "1.0.0",
-                              "from": "minimalistic-assert@>=1.0.0 <2.0.0",
+                              "from": "http://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
                               "resolved": "http://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
                             }
                           }
                         },
                         "browserify-aes": {
                           "version": "1.0.6",
-                          "from": "browserify-aes@>=1.0.0 <2.0.0",
+                          "from": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.6.tgz",
                           "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.6.tgz",
                           "dependencies": {
                             "buffer-xor": {
                               "version": "1.0.3",
-                              "from": "buffer-xor@>=1.0.2 <2.0.0",
+                              "from": "http://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
                               "resolved": "http://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz"
                             },
                             "cipher-base": {
                               "version": "1.0.3",
-                              "from": "cipher-base@>=1.0.0 <2.0.0",
+                              "from": "http://registry.npmjs.org/cipher-base/-/cipher-base-1.0.3.tgz",
                               "resolved": "http://registry.npmjs.org/cipher-base/-/cipher-base-1.0.3.tgz"
                             }
                           }
                         },
                         "evp_bytestokey": {
                           "version": "1.0.0",
-                          "from": "evp_bytestokey@>=1.0.0 <2.0.0",
+                          "from": "http://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz",
                           "resolved": "http://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz"
                         }
                       }
@@ -14013,42 +13667,42 @@
                 },
                 "create-ecdh": {
                   "version": "4.0.0",
-                  "from": "create-ecdh@>=4.0.0 <5.0.0",
+                  "from": "http://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
                   "resolved": "http://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
                   "dependencies": {
                     "bn.js": {
                       "version": "4.11.6",
-                      "from": "bn.js@>=4.1.0 <5.0.0",
+                      "from": "http://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
                       "resolved": "http://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz"
                     },
                     "elliptic": {
                       "version": "6.4.0",
-                      "from": "elliptic@>=6.0.0 <7.0.0",
+                      "from": "http://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
                       "resolved": "http://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
                       "dependencies": {
                         "brorand": {
                           "version": "1.1.0",
-                          "from": "brorand@>=1.0.1 <2.0.0",
+                          "from": "http://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
                           "resolved": "http://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz"
                         },
                         "hash.js": {
                           "version": "1.0.3",
-                          "from": "hash.js@>=1.0.0 <2.0.0",
+                          "from": "http://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz",
                           "resolved": "http://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz"
                         },
                         "hmac-drbg": {
                           "version": "1.0.1",
-                          "from": "hmac-drbg@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz"
                         },
                         "minimalistic-assert": {
                           "version": "1.0.0",
-                          "from": "minimalistic-assert@>=1.0.0 <2.0.0",
+                          "from": "http://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
                           "resolved": "http://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
                         },
                         "minimalistic-crypto-utils": {
                           "version": "1.0.1",
-                          "from": "minimalistic-crypto-utils@>=1.0.0 <2.0.0",
+                          "from": "http://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
                           "resolved": "http://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz"
                         }
                       }
@@ -14057,85 +13711,85 @@
                 },
                 "create-hash": {
                   "version": "1.1.3",
-                  "from": "create-hash@>=1.1.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
                   "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
                   "dependencies": {
                     "cipher-base": {
                       "version": "1.0.3",
-                      "from": "cipher-base@>=1.0.1 <2.0.0",
+                      "from": "http://registry.npmjs.org/cipher-base/-/cipher-base-1.0.3.tgz",
                       "resolved": "http://registry.npmjs.org/cipher-base/-/cipher-base-1.0.3.tgz"
                     },
                     "ripemd160": {
                       "version": "2.0.1",
-                      "from": "ripemd160@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
                       "dependencies": {
                         "hash-base": {
                           "version": "2.0.2",
-                          "from": "hash-base@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz"
                         }
                       }
                     },
                     "sha.js": {
                       "version": "2.4.8",
-                      "from": "sha.js@>=2.4.0 <3.0.0",
+                      "from": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.8.tgz",
                       "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.8.tgz"
                     }
                   }
                 },
                 "create-hmac": {
                   "version": "1.1.6",
-                  "from": "create-hmac@>=1.1.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.6.tgz",
                   "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.6.tgz",
                   "dependencies": {
                     "cipher-base": {
                       "version": "1.0.3",
-                      "from": "cipher-base@>=1.0.3 <2.0.0",
+                      "from": "http://registry.npmjs.org/cipher-base/-/cipher-base-1.0.3.tgz",
                       "resolved": "http://registry.npmjs.org/cipher-base/-/cipher-base-1.0.3.tgz"
                     },
                     "ripemd160": {
                       "version": "2.0.1",
-                      "from": "ripemd160@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
                       "dependencies": {
                         "hash-base": {
                           "version": "2.0.2",
-                          "from": "hash-base@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz"
                         }
                       }
                     },
                     "safe-buffer": {
                       "version": "5.1.0",
-                      "from": "safe-buffer@>=5.0.1 <6.0.0",
+                      "from": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.0.tgz"
                     },
                     "sha.js": {
                       "version": "2.4.8",
-                      "from": "sha.js@>=2.4.8 <3.0.0",
+                      "from": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.8.tgz",
                       "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.8.tgz"
                     }
                   }
                 },
                 "diffie-hellman": {
                   "version": "5.0.2",
-                  "from": "diffie-hellman@>=5.0.0 <6.0.0",
+                  "from": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz",
                   "resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz",
                   "dependencies": {
                     "bn.js": {
                       "version": "4.11.6",
-                      "from": "bn.js@>=4.1.0 <5.0.0",
+                      "from": "http://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
                       "resolved": "http://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz"
                     },
                     "miller-rabin": {
                       "version": "4.0.0",
-                      "from": "miller-rabin@>=4.0.0 <5.0.0",
+                      "from": "http://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.0.tgz",
                       "resolved": "http://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.0.tgz",
                       "dependencies": {
                         "brorand": {
                           "version": "1.1.0",
-                          "from": "brorand@>=1.0.1 <2.0.0",
+                          "from": "http://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
                           "resolved": "http://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz"
                         }
                       }
@@ -14144,90 +13798,90 @@
                 },
                 "inherits": {
                   "version": "2.0.3",
-                  "from": "inherits@>=2.0.1 <3.0.0",
+                  "from": "http://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
                   "resolved": "http://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                 },
                 "pbkdf2": {
                   "version": "3.0.12",
-                  "from": "pbkdf2@>=3.0.3 <4.0.0",
+                  "from": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.12.tgz",
                   "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.12.tgz",
                   "dependencies": {
                     "ripemd160": {
                       "version": "2.0.1",
-                      "from": "ripemd160@>=2.0.1 <3.0.0",
+                      "from": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
                       "dependencies": {
                         "hash-base": {
                           "version": "2.0.2",
-                          "from": "hash-base@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz"
                         }
                       }
                     },
                     "safe-buffer": {
                       "version": "5.1.0",
-                      "from": "safe-buffer@>=5.0.1 <6.0.0",
+                      "from": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.0.tgz"
                     },
                     "sha.js": {
                       "version": "2.4.8",
-                      "from": "sha.js@>=2.4.8 <3.0.0",
+                      "from": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.8.tgz",
                       "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.8.tgz"
                     }
                   }
                 },
                 "public-encrypt": {
                   "version": "4.0.0",
-                  "from": "public-encrypt@>=4.0.0 <5.0.0",
+                  "from": "http://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz",
                   "resolved": "http://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz",
                   "dependencies": {
                     "bn.js": {
                       "version": "4.11.6",
-                      "from": "bn.js@>=4.1.0 <5.0.0",
+                      "from": "http://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
                       "resolved": "http://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz"
                     },
                     "browserify-rsa": {
                       "version": "4.0.1",
-                      "from": "browserify-rsa@>=4.0.0 <5.0.0",
+                      "from": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
                       "resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz"
                     },
                     "parse-asn1": {
                       "version": "5.1.0",
-                      "from": "parse-asn1@>=5.0.0 <6.0.0",
+                      "from": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
                       "dependencies": {
                         "asn1.js": {
                           "version": "4.9.1",
-                          "from": "asn1.js@>=4.0.0 <5.0.0",
+                          "from": "http://registry.npmjs.org/asn1.js/-/asn1.js-4.9.1.tgz",
                           "resolved": "http://registry.npmjs.org/asn1.js/-/asn1.js-4.9.1.tgz",
                           "dependencies": {
                             "minimalistic-assert": {
                               "version": "1.0.0",
-                              "from": "minimalistic-assert@>=1.0.0 <2.0.0",
+                              "from": "http://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
                               "resolved": "http://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
                             }
                           }
                         },
                         "browserify-aes": {
                           "version": "1.0.6",
-                          "from": "browserify-aes@>=1.0.0 <2.0.0",
+                          "from": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.6.tgz",
                           "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.6.tgz",
                           "dependencies": {
                             "buffer-xor": {
                               "version": "1.0.3",
-                              "from": "buffer-xor@>=1.0.2 <2.0.0",
+                              "from": "http://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
                               "resolved": "http://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz"
                             },
                             "cipher-base": {
                               "version": "1.0.3",
-                              "from": "cipher-base@>=1.0.0 <2.0.0",
+                              "from": "http://registry.npmjs.org/cipher-base/-/cipher-base-1.0.3.tgz",
                               "resolved": "http://registry.npmjs.org/cipher-base/-/cipher-base-1.0.3.tgz"
                             }
                           }
                         },
                         "evp_bytestokey": {
                           "version": "1.0.0",
-                          "from": "evp_bytestokey@>=1.0.0 <2.0.0",
+                          "from": "http://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz",
                           "resolved": "http://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz"
                         }
                       }
@@ -14236,12 +13890,12 @@
                 },
                 "randombytes": {
                   "version": "2.0.4",
-                  "from": "randombytes@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.4.tgz",
                   "dependencies": {
                     "safe-buffer": {
                       "version": "5.1.0",
-                      "from": "safe-buffer@>=5.0.1 <6.0.0",
+                      "from": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.0.tgz"
                     }
                   }
@@ -14250,184 +13904,184 @@
             },
             "domain-browser": {
               "version": "1.1.7",
-              "from": "domain-browser@>=1.1.1 <2.0.0",
+              "from": "http://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
               "resolved": "http://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz"
             },
             "events": {
               "version": "1.1.1",
-              "from": "events@>=1.0.0 <2.0.0",
+              "from": "http://registry.npmjs.org/events/-/events-1.1.1.tgz",
               "resolved": "http://registry.npmjs.org/events/-/events-1.1.1.tgz"
             },
             "https-browserify": {
               "version": "0.0.1",
-              "from": "https-browserify@0.0.1",
+              "from": "http://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz",
               "resolved": "http://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz"
             },
             "os-browserify": {
               "version": "0.2.1",
-              "from": "os-browserify@>=0.2.0 <0.3.0",
+              "from": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.2.1.tgz",
               "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.2.1.tgz"
             },
             "path-browserify": {
               "version": "0.0.0",
-              "from": "path-browserify@0.0.0",
+              "from": "http://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
               "resolved": "http://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz"
             },
             "process": {
               "version": "0.11.10",
-              "from": "process@>=0.11.0 <0.12.0",
+              "from": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
               "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz"
             },
             "punycode": {
               "version": "1.4.1",
-              "from": "punycode@>=1.2.4 <2.0.0",
+              "from": "http://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
               "resolved": "http://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
             },
             "querystring-es3": {
               "version": "0.2.1",
-              "from": "querystring-es3@>=0.2.0 <0.3.0",
+              "from": "http://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
               "resolved": "http://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz"
             },
             "readable-stream": {
               "version": "2.2.10",
-              "from": "readable-stream@>=2.0.5 <3.0.0",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.10.tgz",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.10.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "from": "http://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                   "resolved": "http://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                 },
                 "inherits": {
                   "version": "2.0.3",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "http://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
                   "resolved": "http://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                 },
                 "isarray": {
                   "version": "1.0.0",
-                  "from": "isarray@>=1.0.0 <1.1.0",
+                  "from": "http://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
                   "resolved": "http://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                 },
                 "process-nextick-args": {
                   "version": "1.0.7",
-                  "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                  "from": "http://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
                   "resolved": "http://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
                 },
                 "safe-buffer": {
                   "version": "5.1.0",
-                  "from": "safe-buffer@>=5.0.1 <6.0.0",
+                  "from": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.0.tgz"
                 },
                 "string_decoder": {
                   "version": "1.0.1",
-                  "from": "string_decoder@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz"
                 },
                 "util-deprecate": {
                   "version": "1.0.2",
-                  "from": "util-deprecate@>=1.0.1 <1.1.0",
+                  "from": "http://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
                   "resolved": "http://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                 }
               }
             },
             "stream-browserify": {
               "version": "2.0.1",
-              "from": "stream-browserify@>=2.0.1 <3.0.0",
+              "from": "http://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
               "resolved": "http://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.3",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "http://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
                   "resolved": "http://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                 }
               }
             },
             "stream-http": {
               "version": "2.7.1",
-              "from": "stream-http@>=2.3.1 <3.0.0",
+              "from": "https://registry.npmjs.org/stream-http/-/stream-http-2.7.1.tgz",
               "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.7.1.tgz",
               "dependencies": {
                 "builtin-status-codes": {
                   "version": "3.0.0",
-                  "from": "builtin-status-codes@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz"
                 },
                 "inherits": {
                   "version": "2.0.3",
-                  "from": "inherits@>=2.0.1 <3.0.0",
+                  "from": "http://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
                   "resolved": "http://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                 },
                 "to-arraybuffer": {
                   "version": "1.0.1",
-                  "from": "to-arraybuffer@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz"
                 },
                 "xtend": {
                   "version": "4.0.1",
-                  "from": "xtend@>=4.0.0 <5.0.0",
+                  "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                 }
               }
             },
             "string_decoder": {
               "version": "0.10.31",
-              "from": "string_decoder@>=0.10.25 <0.11.0",
+              "from": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
               "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
             },
             "timers-browserify": {
               "version": "2.0.2",
-              "from": "timers-browserify@>=2.0.2 <3.0.0",
+              "from": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.2.tgz",
               "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.2.tgz",
               "dependencies": {
                 "setimmediate": {
                   "version": "1.0.5",
-                  "from": "setimmediate@>=1.0.4 <2.0.0",
+                  "from": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
                   "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz"
                 }
               }
             },
             "tty-browserify": {
               "version": "0.0.0",
-              "from": "tty-browserify@0.0.0",
+              "from": "http://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
               "resolved": "http://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz"
             },
             "url": {
               "version": "0.11.0",
-              "from": "url@>=0.11.0 <0.12.0",
+              "from": "http://registry.npmjs.org/url/-/url-0.11.0.tgz",
               "resolved": "http://registry.npmjs.org/url/-/url-0.11.0.tgz",
               "dependencies": {
                 "punycode": {
                   "version": "1.3.2",
-                  "from": "punycode@1.3.2",
+                  "from": "http://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
                   "resolved": "http://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
                 },
                 "querystring": {
                   "version": "0.2.0",
-                  "from": "querystring@0.2.0",
+                  "from": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
                 }
               }
             },
             "util": {
               "version": "0.10.3",
-              "from": "util@>=0.10.3 <0.11.0",
+              "from": "http://registry.npmjs.org/util/-/util-0.10.3.tgz",
               "resolved": "http://registry.npmjs.org/util/-/util-0.10.3.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@2.0.1",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "vm-browserify": {
               "version": "0.0.4",
-              "from": "vm-browserify@0.0.4",
+              "from": "http://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
               "resolved": "http://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
               "dependencies": {
                 "indexof": {
                   "version": "0.0.1",
-                  "from": "indexof@0.0.1",
+                  "from": "http://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
                   "resolved": "http://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
                 }
               }
@@ -14436,117 +14090,117 @@
         },
         "source-map": {
           "version": "0.5.6",
-          "from": "source-map@>=0.5.3 <0.6.0",
+          "from": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
           "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
         },
         "supports-color": {
           "version": "3.2.3",
-          "from": "supports-color@>=3.1.0 <4.0.0",
+          "from": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "dependencies": {
             "has-flag": {
               "version": "1.0.0",
-              "from": "has-flag@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
             }
           }
         },
         "tapable": {
           "version": "0.2.6",
-          "from": "tapable@>=0.2.5 <0.3.0",
+          "from": "https://registry.npmjs.org/tapable/-/tapable-0.2.6.tgz",
           "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.2.6.tgz"
         },
         "uglify-js": {
           "version": "2.8.28",
-          "from": "uglify-js@>=2.8.27 <3.0.0",
+          "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.28.tgz",
           "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.28.tgz",
           "dependencies": {
             "yargs": {
               "version": "3.10.0",
-              "from": "yargs@>=3.10.0 <3.11.0",
+              "from": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
               "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
               "dependencies": {
                 "camelcase": {
                   "version": "1.2.1",
-                  "from": "camelcase@>=1.0.2 <2.0.0",
+                  "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
                 },
                 "cliui": {
                   "version": "2.1.0",
-                  "from": "cliui@>=2.1.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
                   "dependencies": {
                     "center-align": {
                       "version": "0.1.3",
-                      "from": "center-align@>=0.1.1 <0.2.0",
+                      "from": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
                       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
                       "dependencies": {
                         "align-text": {
                           "version": "0.1.4",
-                          "from": "align-text@>=0.1.1 <0.2.0",
+                          "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                           "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                           "dependencies": {
                             "kind-of": {
                               "version": "3.2.2",
-                              "from": "kind-of@>=3.0.2 <4.0.0",
+                              "from": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                               "dependencies": {
                                 "is-buffer": {
                                   "version": "1.1.5",
-                                  "from": "is-buffer@>=1.1.5 <2.0.0",
+                                  "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
                                   "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
                                 }
                               }
                             },
                             "longest": {
                               "version": "1.0.1",
-                              "from": "longest@>=1.0.1 <2.0.0",
+                              "from": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
                             },
                             "repeat-string": {
                               "version": "1.6.1",
-                              "from": "repeat-string@>=1.5.2 <2.0.0",
+                              "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
                               "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
                             }
                           }
                         },
                         "lazy-cache": {
                           "version": "1.0.4",
-                          "from": "lazy-cache@>=1.0.3 <2.0.0",
+                          "from": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
                           "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
                         }
                       }
                     },
                     "right-align": {
                       "version": "0.1.3",
-                      "from": "right-align@>=0.1.1 <0.2.0",
+                      "from": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
                       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
                       "dependencies": {
                         "align-text": {
                           "version": "0.1.4",
-                          "from": "align-text@>=0.1.1 <0.2.0",
+                          "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                           "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                           "dependencies": {
                             "kind-of": {
                               "version": "3.2.2",
-                              "from": "kind-of@>=3.0.2 <4.0.0",
+                              "from": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                               "dependencies": {
                                 "is-buffer": {
                                   "version": "1.1.5",
-                                  "from": "is-buffer@>=1.1.5 <2.0.0",
+                                  "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
                                   "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
                                 }
                               }
                             },
                             "longest": {
                               "version": "1.0.1",
-                              "from": "longest@>=1.0.1 <2.0.0",
+                              "from": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
                             },
                             "repeat-string": {
                               "version": "1.6.1",
-                              "from": "repeat-string@>=1.5.2 <2.0.0",
+                              "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
                               "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
                             }
                           }
@@ -14555,19 +14209,19 @@
                     },
                     "wordwrap": {
                       "version": "0.0.2",
-                      "from": "wordwrap@0.0.2",
+                      "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                     }
                   }
                 },
                 "decamelize": {
                   "version": "1.2.0",
-                  "from": "decamelize@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
                 },
                 "window-size": {
                   "version": "0.1.0",
-                  "from": "window-size@0.1.0",
+                  "from": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
                 }
               }
@@ -14576,86 +14230,86 @@
         },
         "watchpack": {
           "version": "1.3.1",
-          "from": "watchpack@>=1.3.1 <2.0.0",
+          "from": "https://registry.npmjs.org/watchpack/-/watchpack-1.3.1.tgz",
           "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.3.1.tgz",
           "dependencies": {
             "chokidar": {
               "version": "1.7.0",
-              "from": "chokidar@>=1.4.3 <2.0.0",
+              "from": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
               "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
               "dependencies": {
                 "anymatch": {
                   "version": "1.3.0",
-                  "from": "anymatch@>=1.3.0 <2.0.0",
+                  "from": "http://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
                   "resolved": "http://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
                   "dependencies": {
                     "arrify": {
                       "version": "1.0.1",
-                      "from": "arrify@>=1.0.0 <2.0.0",
+                      "from": "http://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
                       "resolved": "http://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
                     },
                     "micromatch": {
                       "version": "2.3.11",
-                      "from": "micromatch@>=2.1.5 <3.0.0",
+                      "from": "http://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
                       "resolved": "http://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
                       "dependencies": {
                         "arr-diff": {
                           "version": "2.0.0",
-                          "from": "arr-diff@>=2.0.0 <3.0.0",
+                          "from": "http://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
                           "resolved": "http://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
                           "dependencies": {
                             "arr-flatten": {
                               "version": "1.0.3",
-                              "from": "arr-flatten@>=1.0.1 <2.0.0",
+                              "from": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.3.tgz",
                               "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.3.tgz"
                             }
                           }
                         },
                         "array-unique": {
                           "version": "0.2.1",
-                          "from": "array-unique@>=0.2.1 <0.3.0",
+                          "from": "http://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
                           "resolved": "http://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
                         },
                         "braces": {
                           "version": "1.8.5",
-                          "from": "braces@>=1.8.2 <2.0.0",
+                          "from": "http://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
                           "resolved": "http://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
                           "dependencies": {
                             "expand-range": {
                               "version": "1.8.2",
-                              "from": "expand-range@>=1.8.1 <2.0.0",
+                              "from": "http://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
                               "resolved": "http://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
                               "dependencies": {
                                 "fill-range": {
                                   "version": "2.2.3",
-                                  "from": "fill-range@>=2.1.0 <3.0.0",
+                                  "from": "http://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
                                   "resolved": "http://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
                                   "dependencies": {
                                     "is-number": {
                                       "version": "2.1.0",
-                                      "from": "is-number@>=2.1.0 <3.0.0",
+                                      "from": "http://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
                                       "resolved": "http://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz"
                                     },
                                     "isobject": {
                                       "version": "2.1.0",
-                                      "from": "isobject@>=2.0.0 <3.0.0",
+                                      "from": "http://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
                                       "resolved": "http://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
                                       "dependencies": {
                                         "isarray": {
                                           "version": "1.0.0",
-                                          "from": "isarray@1.0.0",
+                                          "from": "http://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
                                           "resolved": "http://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                                         }
                                       }
                                     },
                                     "randomatic": {
                                       "version": "1.1.6",
-                                      "from": "randomatic@>=1.1.3 <2.0.0",
+                                      "from": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.6.tgz",
                                       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.6.tgz"
                                     },
                                     "repeat-string": {
                                       "version": "1.6.1",
-                                      "from": "repeat-string@>=1.5.2 <2.0.0",
+                                      "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
                                       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
                                     }
                                   }
@@ -14664,121 +14318,121 @@
                             },
                             "preserve": {
                               "version": "0.2.0",
-                              "from": "preserve@>=0.2.0 <0.3.0",
+                              "from": "http://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
                               "resolved": "http://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
                             },
                             "repeat-element": {
                               "version": "1.1.2",
-                              "from": "repeat-element@>=1.1.2 <2.0.0",
+                              "from": "http://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
                               "resolved": "http://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
                             }
                           }
                         },
                         "expand-brackets": {
                           "version": "0.1.5",
-                          "from": "expand-brackets@>=0.1.4 <0.2.0",
+                          "from": "http://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
                           "resolved": "http://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
                           "dependencies": {
                             "is-posix-bracket": {
                               "version": "0.1.1",
-                              "from": "is-posix-bracket@>=0.1.0 <0.2.0",
+                              "from": "http://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
                               "resolved": "http://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz"
                             }
                           }
                         },
                         "extglob": {
                           "version": "0.3.2",
-                          "from": "extglob@>=0.3.1 <0.4.0",
+                          "from": "http://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
                           "resolved": "http://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz"
                         },
                         "filename-regex": {
                           "version": "2.0.1",
-                          "from": "filename-regex@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz"
                         },
                         "is-extglob": {
                           "version": "1.0.0",
-                          "from": "is-extglob@>=1.0.0 <2.0.0",
+                          "from": "http://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
                           "resolved": "http://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
                         },
                         "kind-of": {
                           "version": "3.2.2",
-                          "from": "kind-of@>=3.0.2 <4.0.0",
+                          "from": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                           "dependencies": {
                             "is-buffer": {
                               "version": "1.1.5",
-                              "from": "is-buffer@>=1.1.5 <2.0.0",
+                              "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
                               "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
                             }
                           }
                         },
                         "normalize-path": {
                           "version": "2.1.1",
-                          "from": "normalize-path@>=2.0.1 <3.0.0",
+                          "from": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
                           "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
                           "dependencies": {
                             "remove-trailing-separator": {
                               "version": "1.0.1",
-                              "from": "remove-trailing-separator@>=1.0.1 <2.0.0",
+                              "from": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.1.tgz"
                             }
                           }
                         },
                         "object.omit": {
                           "version": "2.0.1",
-                          "from": "object.omit@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
                           "dependencies": {
                             "for-own": {
                               "version": "0.1.5",
-                              "from": "for-own@>=0.1.4 <0.2.0",
+                              "from": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
                               "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
                               "dependencies": {
                                 "for-in": {
                                   "version": "1.0.2",
-                                  "from": "for-in@>=1.0.1 <2.0.0",
+                                  "from": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
                                   "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz"
                                 }
                               }
                             },
                             "is-extendable": {
                               "version": "0.1.1",
-                              "from": "is-extendable@>=0.1.1 <0.2.0",
+                              "from": "http://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
                               "resolved": "http://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
                             }
                           }
                         },
                         "parse-glob": {
                           "version": "3.0.4",
-                          "from": "parse-glob@>=3.0.4 <4.0.0",
+                          "from": "http://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
                           "resolved": "http://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
                           "dependencies": {
                             "glob-base": {
                               "version": "0.3.0",
-                              "from": "glob-base@>=0.3.0 <0.4.0",
+                              "from": "http://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
                               "resolved": "http://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz"
                             },
                             "is-dotfile": {
                               "version": "1.0.3",
-                              "from": "is-dotfile@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
                               "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz"
                             }
                           }
                         },
                         "regex-cache": {
                           "version": "0.4.3",
-                          "from": "regex-cache@>=0.4.2 <0.5.0",
+                          "from": "http://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
                           "resolved": "http://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
                           "dependencies": {
                             "is-equal-shallow": {
                               "version": "0.1.3",
-                              "from": "is-equal-shallow@>=0.1.3 <0.2.0",
+                              "from": "http://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
                               "resolved": "http://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
                             },
                             "is-primitive": {
                               "version": "2.0.0",
-                              "from": "is-primitive@>=2.0.0 <3.0.0",
+                              "from": "http://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
                               "resolved": "http://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
                             }
                           }
@@ -14789,71 +14443,71 @@
                 },
                 "async-each": {
                   "version": "1.0.1",
-                  "from": "async-each@>=1.0.0 <2.0.0",
+                  "from": "http://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
                   "resolved": "http://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz"
                 },
                 "glob-parent": {
                   "version": "2.0.0",
-                  "from": "glob-parent@>=2.0.0 <3.0.0",
+                  "from": "http://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
                   "resolved": "http://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz"
                 },
                 "inherits": {
                   "version": "2.0.3",
-                  "from": "inherits@>=2.0.1 <3.0.0",
+                  "from": "http://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
                   "resolved": "http://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                 },
                 "is-binary-path": {
                   "version": "1.0.1",
-                  "from": "is-binary-path@>=1.0.0 <2.0.0",
+                  "from": "http://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
                   "resolved": "http://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
                   "dependencies": {
                     "binary-extensions": {
                       "version": "1.8.0",
-                      "from": "binary-extensions@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.8.0.tgz",
                       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.8.0.tgz"
                     }
                   }
                 },
                 "is-glob": {
                   "version": "2.0.1",
-                  "from": "is-glob@>=2.0.0 <3.0.0",
+                  "from": "http://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
                   "resolved": "http://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
                   "dependencies": {
                     "is-extglob": {
                       "version": "1.0.0",
-                      "from": "is-extglob@>=1.0.0 <2.0.0",
+                      "from": "http://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
                       "resolved": "http://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
                     }
                   }
                 },
                 "path-is-absolute": {
                   "version": "1.0.1",
-                  "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                  "from": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
                   "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
                 },
                 "readdirp": {
                   "version": "2.1.0",
-                  "from": "readdirp@>=2.0.0 <3.0.0",
+                  "from": "http://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
                   "resolved": "http://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
                   "dependencies": {
                     "minimatch": {
                       "version": "3.0.4",
-                      "from": "minimatch@>=3.0.2 <4.0.0",
+                      "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
                       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
                       "dependencies": {
                         "brace-expansion": {
                           "version": "1.1.7",
-                          "from": "brace-expansion@>=1.1.7 <2.0.0",
+                          "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
                           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
                           "dependencies": {
                             "balanced-match": {
                               "version": "0.4.2",
-                              "from": "balanced-match@>=0.4.1 <0.5.0",
+                              "from": "http://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
                               "resolved": "http://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
                             },
                             "concat-map": {
                               "version": "0.0.1",
-                              "from": "concat-map@0.0.1",
+                              "from": "http://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                               "resolved": "http://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                             }
                           }
@@ -14862,44 +14516,44 @@
                     },
                     "readable-stream": {
                       "version": "2.2.10",
-                      "from": "readable-stream@>=2.0.2 <3.0.0",
+                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.10.tgz",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.10.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2",
-                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "from": "http://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                           "resolved": "http://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                         },
                         "isarray": {
                           "version": "1.0.0",
-                          "from": "isarray@>=1.0.0 <1.1.0",
+                          "from": "http://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
                           "resolved": "http://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                         },
                         "process-nextick-args": {
                           "version": "1.0.7",
-                          "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                          "from": "http://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
                           "resolved": "http://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
                         },
                         "safe-buffer": {
                           "version": "5.1.0",
-                          "from": "safe-buffer@>=5.0.1 <6.0.0",
+                          "from": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.0.tgz"
                         },
                         "string_decoder": {
                           "version": "1.0.1",
-                          "from": "string_decoder@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz"
                         },
                         "util-deprecate": {
                           "version": "1.0.2",
-                          "from": "util-deprecate@>=1.0.1 <1.1.0",
+                          "from": "http://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
                           "resolved": "http://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                         }
                       }
                     },
                     "set-immediate-shim": {
                       "version": "1.0.1",
-                      "from": "set-immediate-shim@>=1.0.1 <2.0.0",
+                      "from": "http://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
                       "resolved": "http://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz"
                     }
                   }
@@ -14908,80 +14562,80 @@
             },
             "graceful-fs": {
               "version": "4.1.11",
-              "from": "graceful-fs@>=4.1.2 <5.0.0",
+              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
             }
           }
         },
         "webpack-sources": {
           "version": "0.2.3",
-          "from": "webpack-sources@>=0.2.3 <0.3.0",
+          "from": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-0.2.3.tgz",
           "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-0.2.3.tgz",
           "dependencies": {
             "source-list-map": {
               "version": "1.1.2",
-              "from": "source-list-map@>=1.1.1 <2.0.0",
+              "from": "https://registry.npmjs.org/source-list-map/-/source-list-map-1.1.2.tgz",
               "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-1.1.2.tgz"
             }
           }
         },
         "yargs": {
           "version": "6.6.0",
-          "from": "yargs@>=6.0.0 <7.0.0",
+          "from": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
           "dependencies": {
             "camelcase": {
               "version": "3.0.0",
-              "from": "camelcase@>=3.0.0 <4.0.0",
+              "from": "http://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
               "resolved": "http://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz"
             },
             "cliui": {
               "version": "3.2.0",
-              "from": "cliui@>=3.2.0 <4.0.0",
+              "from": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
               "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
               "dependencies": {
                 "strip-ansi": {
                   "version": "3.0.1",
-                  "from": "strip-ansi@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.1.1",
-                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
                     }
                   }
                 },
                 "wrap-ansi": {
                   "version": "2.1.0",
-                  "from": "wrap-ansi@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz"
                 }
               }
             },
             "decamelize": {
               "version": "1.2.0",
-              "from": "decamelize@>=1.1.1 <2.0.0",
+              "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
               "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
             },
             "get-caller-file": {
               "version": "1.0.2",
-              "from": "get-caller-file@>=1.0.1 <2.0.0",
+              "from": "http://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
               "resolved": "http://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz"
             },
             "os-locale": {
               "version": "1.4.0",
-              "from": "os-locale@>=1.4.0 <2.0.0",
+              "from": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
               "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
               "dependencies": {
                 "lcid": {
                   "version": "1.0.0",
-                  "from": "lcid@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
                   "dependencies": {
                     "invert-kv": {
                       "version": "1.0.0",
-                      "from": "invert-kv@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
                     }
                   }
@@ -14990,27 +14644,27 @@
             },
             "read-pkg-up": {
               "version": "1.0.1",
-              "from": "read-pkg-up@>=1.0.1 <2.0.0",
+              "from": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
               "dependencies": {
                 "find-up": {
                   "version": "1.1.2",
-                  "from": "find-up@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
                   "dependencies": {
                     "path-exists": {
                       "version": "2.1.0",
-                      "from": "path-exists@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
                     },
                     "pinkie-promise": {
                       "version": "2.0.1",
-                      "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                       "dependencies": {
                         "pinkie": {
                           "version": "2.0.4",
-                          "from": "pinkie@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
                           "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                         }
                       }
@@ -15019,32 +14673,32 @@
                 },
                 "read-pkg": {
                   "version": "1.1.0",
-                  "from": "read-pkg@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
                   "dependencies": {
                     "load-json-file": {
                       "version": "1.1.0",
-                      "from": "load-json-file@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
                       "dependencies": {
                         "graceful-fs": {
                           "version": "4.1.11",
-                          "from": "graceful-fs@>=4.1.2 <5.0.0",
+                          "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
                           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
                         },
                         "parse-json": {
                           "version": "2.2.0",
-                          "from": "parse-json@>=2.2.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
                           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
                           "dependencies": {
                             "error-ex": {
                               "version": "1.3.1",
-                              "from": "error-ex@>=1.2.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
                               "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
                               "dependencies": {
                                 "is-arrayish": {
                                   "version": "0.2.1",
-                                  "from": "is-arrayish@>=0.2.1 <0.3.0",
+                                  "from": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
                                   "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
                                 }
                               }
@@ -15053,29 +14707,29 @@
                         },
                         "pify": {
                           "version": "2.3.0",
-                          "from": "pify@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
                           "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
                         },
                         "pinkie-promise": {
                           "version": "2.0.1",
-                          "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                           "dependencies": {
                             "pinkie": {
                               "version": "2.0.4",
-                              "from": "pinkie@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
                               "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                             }
                           }
                         },
                         "strip-bom": {
                           "version": "2.0.0",
-                          "from": "strip-bom@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
                           "dependencies": {
                             "is-utf8": {
                               "version": "0.2.1",
-                              "from": "is-utf8@>=0.2.0 <0.3.0",
+                              "from": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
                               "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
                             }
                           }
@@ -15084,51 +14738,51 @@
                     },
                     "normalize-package-data": {
                       "version": "2.3.8",
-                      "from": "normalize-package-data@>=2.3.2 <3.0.0",
+                      "from": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.8.tgz",
                       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.8.tgz",
                       "dependencies": {
                         "hosted-git-info": {
                           "version": "2.4.2",
-                          "from": "hosted-git-info@>=2.1.4 <3.0.0",
+                          "from": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.4.2.tgz",
                           "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.4.2.tgz"
                         },
                         "is-builtin-module": {
                           "version": "1.0.0",
-                          "from": "is-builtin-module@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
                           "dependencies": {
                             "builtin-modules": {
                               "version": "1.1.1",
-                              "from": "builtin-modules@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
                               "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
                             }
                           }
                         },
                         "semver": {
                           "version": "5.3.0",
-                          "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0",
+                          "from": "http://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
                           "resolved": "http://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
                         },
                         "validate-npm-package-license": {
                           "version": "3.0.1",
-                          "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
+                          "from": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
                           "dependencies": {
                             "spdx-correct": {
                               "version": "1.0.2",
-                              "from": "spdx-correct@>=1.0.0 <1.1.0",
+                              "from": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
                               "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
                               "dependencies": {
                                 "spdx-license-ids": {
                                   "version": "1.2.2",
-                                  "from": "spdx-license-ids@>=1.0.2 <2.0.0",
+                                  "from": "http://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
                                   "resolved": "http://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz"
                                 }
                               }
                             },
                             "spdx-expression-parse": {
                               "version": "1.0.4",
-                              "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
+                              "from": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
                               "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz"
                             }
                           }
@@ -15137,27 +14791,27 @@
                     },
                     "path-type": {
                       "version": "1.1.0",
-                      "from": "path-type@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
                       "dependencies": {
                         "graceful-fs": {
                           "version": "4.1.11",
-                          "from": "graceful-fs@>=4.1.2 <5.0.0",
+                          "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
                           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
                         },
                         "pify": {
                           "version": "2.3.0",
-                          "from": "pify@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
                           "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
                         },
                         "pinkie-promise": {
                           "version": "2.0.1",
-                          "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                           "dependencies": {
                             "pinkie": {
                               "version": "2.0.4",
-                              "from": "pinkie@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
                               "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                             }
                           }
@@ -15170,49 +14824,49 @@
             },
             "require-directory": {
               "version": "2.1.1",
-              "from": "require-directory@>=2.1.1 <3.0.0",
+              "from": "http://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
               "resolved": "http://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz"
             },
             "require-main-filename": {
               "version": "1.0.1",
-              "from": "require-main-filename@>=1.0.1 <2.0.0",
+              "from": "http://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
               "resolved": "http://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz"
             },
             "set-blocking": {
               "version": "2.0.0",
-              "from": "set-blocking@>=2.0.0 <3.0.0",
+              "from": "http://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
               "resolved": "http://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz"
             },
             "string-width": {
               "version": "1.0.2",
-              "from": "string-width@>=1.0.2 <2.0.0",
+              "from": "http://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
               "resolved": "http://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
               "dependencies": {
                 "code-point-at": {
                   "version": "1.1.0",
-                  "from": "code-point-at@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz"
                 },
                 "is-fullwidth-code-point": {
                   "version": "1.0.0",
-                  "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
                   "dependencies": {
                     "number-is-nan": {
                       "version": "1.0.1",
-                      "from": "number-is-nan@>=1.0.0 <2.0.0",
+                      "from": "http://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
                       "resolved": "http://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "3.0.1",
-                  "from": "strip-ansi@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.1.1",
-                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
                     }
                   }
@@ -15221,17 +14875,17 @@
             },
             "which-module": {
               "version": "1.0.0",
-              "from": "which-module@>=1.0.0 <2.0.0",
+              "from": "http://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
               "resolved": "http://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz"
             },
             "y18n": {
               "version": "3.2.1",
-              "from": "y18n@>=3.2.1 <4.0.0",
+              "from": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
               "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz"
             },
             "yargs-parser": {
               "version": "4.2.1",
-              "from": "yargs-parser@>=4.2.0 <5.0.0",
+              "from": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
               "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz"
             }
           }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     ]
   },
   "devDependencies": {
-    "babel-cli": "^6.24.1",
     "babel-core": "^6.24.1",
     "babel-jest": "^20.0.3",
     "babel-loader": "^7.0.0",
@@ -40,14 +39,12 @@
     "eslint-plugin-import": "^1.8.1",
     "eslint-plugin-jsx-a11y": "^1.5.3",
     "eslint-plugin-react": "^5.2.2",
-    "exports-loader": "^0.6.4",
     "gulp": "~3.8.11",
     "gulp-autoprefixer": "~3.0.2",
     "gulp-rename": "^1.2.2",
     "gulp-sass": "~2.3.1",
     "gulp-sourcemaps": "~1.5.2",
     "gulp-util": "~2.2.14",
-    "imports-loader": "^0.7.1",
     "jest": "^20.0.4",
     "mustache": "^2.2.1",
     "react-addons-perf": "^15.4.2",

--- a/package.json
+++ b/package.json
@@ -6,13 +6,6 @@
   "engines": {
     "node": ">= 4"
   },
-  "browser": {},
-  "browserify": {
-    "transform": [
-      "browserify-shim"
-    ]
-  },
-  "browserify-shim": {},
   "jest": {
     "setupFiles": [
       "./client/tests/stubs.js",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "babel-jest": "^20.0.3",
     "babel-loader": "^7.0.0",
     "babel-plugin-lodash": "^3.2.11",
-    "babel-polyfill": "^6.22.0",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-react": "^6.24.1",
     "enzyme": "^2.8.2",
@@ -61,6 +60,8 @@
   "dependencies": {
     "focus-trap-react": "^3.0.3",
     "lodash": "^4.17.4",
+    "object-assign": "^4.1.1",
+    "promise": "^7.1.1",
     "prop-types": "^15.5.10",
     "react": "^15.5.4",
     "react-dom": "^15.5.4",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "whatwg-fetch": "^2.0.2"
   },
   "scripts": {
-    "postinstall": "cd ./client; npm install; cd ..",
+    "postinstall": "npm --prefix client install",
     "build": "gulp build; webpack --config ./client/webpack/prod.config.js",
     "watch": "webpack --config ./client/webpack/dev.config.js & gulp watch",
     "start": "npm run watch",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "jest": "^20.0.4",
     "mustache": "^2.2.1",
     "react-addons-perf": "^15.4.2",
-    "react-addons-test-utils": "^15.4.2",
     "react-test-renderer": "^15.5.4",
     "redux-mock-store": "^1.2.2",
     "require-dir": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "react-redux": "^5.0.5",
     "react-transition-group": "^1.1.3",
     "redux": "^3.6.0",
-    "redux-actions": "^2.0.3",
     "redux-thunk": "^2.2.0",
     "whatwg-fetch": "^2.0.2"
   },

--- a/package.json
+++ b/package.json
@@ -6,6 +6,15 @@
   "engines": {
     "node": ">= 4"
   },
+  "babel": {
+    "presets": [
+      "es2015",
+      "react"
+    ],
+    "plugins": [
+      "lodash"
+    ]
+  },
   "jest": {
     "setupFiles": [
       "./client/tests/stubs.js",


### PR DESCRIPTION
Part of tidying up before releasing the new explorer in #3607.

I'd have liked to update to `babel-preset-env`, but it requires Node 6 / npm 3, so this will have to wait.

This PR removes about ± 100kb from the gzipped bundle size 🎉.