### PR TITLE
Fix document chooser template to account for hidden fields

### DIFF
--- a/wagtail/wagtaildocs/templates/wagtaildocs/chooser/chooser.html
+++ b/wagtail/wagtaildocs/templates/wagtaildocs/chooser/chooser.html
@@ -32,7 +32,11 @@
                 {% csrf_token %}
                 <ul class="fields">
                     {% for field in uploadform %}
-                        {% include "wagtailadmin/shared/field_as_li.html" with field=field %}
+                        {% if field.is_hidden %}
+                            {{ field }}
+                        {% else %}
+                            {% include "wagtailadmin/shared/field_as_li.html" with field=field %}
+                        {% endif %}
                     {% endfor %}
                     <li>
                         <button type="submit" class="button button-longrunning" data-clicked-text="{% trans 'Uploading...' %}"><span class="icon icon-spinner"></span><em>{% trans 'Upload' %}</em></button>


### PR DESCRIPTION
Hello,

This is a relatively minor change for consistency sake. 

We have some custom code in our project that requires us to hide the collection field in upload forms to suit some of our multi-tenant needs. I noticed that for documents specifically, the template for the upload section doesn't handle hidden fields very well, but the images chooser does. So i've made the documents template similar to the images template.