### PR TITLE
Allow specifying a project_template in "wagtail start"-comment

### DIFF
--- a/wagtail/bin/wagtail.py
+++ b/wagtail/bin/wagtail.py
@@ -7,14 +7,14 @@ from optparse import OptionParser
 from django.core.management import ManagementUtility
 
 
-def create_project(parser, options, args):
+def create_project(parser, options, arguments):
     # Validate args
-    if len(args) < 2:
+    if len(arguments) < 2:
         parser.error("Please specify a name for your Wagtail installation")
-    elif len(args) > 2:
+    elif len(arguments) > 2:
         parser.error("Too many arguments")
 
-    project_name = args[1]
+    project_name = arguments[1]
 
     if options.destination:
         destination_dir = options.destination
@@ -74,17 +74,17 @@ def main():
     parser = OptionParser(usage="Usage: %prog start project_name [--destination=<destination_directory>] [--template=<template_path>]")
     parser.add_option("--destination", dest="destination", help="Set destination directory")
     parser.add_option("--template", dest="template", help="Specify a custom template")
-    (options, pargs) = parser.parse_args()
+    (options, arguments) = parser.parse_args()
 
     # Find command
     try:
-        command = pargs[0]
+        command = arguments[0]
     except IndexError:
         parser.print_help()
         return
 
     if command in COMMANDS:
-        COMMANDS[command](parser, options, pargs)
+        COMMANDS[command](parser, options, arguments)
     else:
         parser.error("Unrecognised command: " + command)
 

--- a/wagtail/bin/wagtail.py
+++ b/wagtail/bin/wagtail.py
@@ -11,14 +11,20 @@ def create_project(parser, options, args):
     # Validate args
     if len(args) < 2:
         parser.error("Please specify a name for your Wagtail installation")
-    elif len(args) > 3:
+    elif len(args) > 2:
         parser.error("Too many arguments")
 
     project_name = args[1]
-    try:
-        dest_dir = args[2]
-    except IndexError:
-        dest_dir = None
+
+    if options.destination:
+        destination_dir = options.destination
+    else:
+        destination_dir = None
+
+    if options.template:
+        project_template = options.template
+    else:
+        project_template = None
 
     # Make sure given name is not already in use by another python package/module.
     try:
@@ -30,14 +36,17 @@ def create_project(parser, options, args):
                      "Python module and cannot be used as a project "
                      "name. Please try another name." % project_name)
 
-    print("Creating a Wagtail project called %(project_name)s" % {'project_name': project_name})  # noqa
+    if project_template:
+        print("Creating a Wagtail project called %(project_name)s using template from %(project_template)s" % {'project_name': project_name, 'project_template': project_template})  # noqa
+    else:
+        print("Creating a Wagtail project called %(project_name)s" % {'project_name': project_name})  # noqa
 
     # Create the project from the Wagtail template using startapp
 
     # First find the path to Wagtail
     import wagtail
     wagtail_path = os.path.dirname(wagtail.__file__)
-    template_path = os.path.join(wagtail_path, 'project_template')
+    template_path = os.path.join(wagtail_path, 'project_template' if project_template is None else project_template)
 
     # Call django-admin startproject
     utility_args = ['django-admin.py',
@@ -46,8 +55,8 @@ def create_project(parser, options, args):
                     '--ext=html,rst',
                     project_name]
 
-    if dest_dir:
-        utility_args.append(dest_dir)
+    if destination_dir:
+        utility_args.append(destination_dir)
 
     utility = ManagementUtility(utility_args)
     utility.execute()
@@ -62,18 +71,20 @@ COMMANDS = {
 
 def main():
     # Parse options
-    parser = OptionParser(usage="Usage: %prog start project_name [directory]")
-    (options, args) = parser.parse_args()
+    parser = OptionParser(usage="Usage: %prog start project_name [--destination=<destination_directory>] [--template=<template_path>]")
+    parser.add_option("--destination", dest="destination", help="Set destination directory")
+    parser.add_option("--template", dest="template", help="Specify a custom template")
+    (options, pargs) = parser.parse_args()
 
     # Find command
     try:
-        command = args[0]
+        command = pargs[0]
     except IndexError:
         parser.print_help()
         return
 
     if command in COMMANDS:
-        COMMANDS[command](parser, options, args)
+        COMMANDS[command](parser, options, pargs)
     else:
         parser.error("Unrecognised command: " + command)
 


### PR DESCRIPTION
Added the option to specify a custom project_template to the "wagtail start"-command. Also renamed the optional directory to destination and make it be an option and not an arg. 