### PR TITLE
Fix mobile explorer scrolling issue

### DIFF
--- a/client/src/api/admin.js
+++ b/client/src/api/admin.js
@@ -24,7 +24,6 @@ export const getPageChildren = (id, options = {}) => {
     url += `&offset=${options.offset}`;
   }
 
-  // TODO To remove once we are done testing this.
   url += ADMIN_API.EXTRA_CHILDREN_PARAMETERS;
 
   return get(url);

--- a/client/src/components/Explorer/Explorer.scss
+++ b/client/src/components/Explorer/Explorer.scss
@@ -7,8 +7,15 @@ $menu-footer-height: 50px;
 
 @import 'ExplorerItem';
 
+.explorer__wrapper {
+    flex: 1;
+    display: flex;
+}
+
 .explorer {
     width: 100%;
+    display: flex;
+    flex-direction: column;
     position: relative;
     top: 0;
     left: 0;
@@ -17,6 +24,7 @@ $menu-footer-height: 50px;
 
     @include medium {
         width: 485px;
+        height: 100vh;
         position: fixed;
         top: 0;
         left: $menu-width;
@@ -46,7 +54,7 @@ $menu-footer-height: 50px;
 .c-explorer {
     position: relative;
     overflow: hidden;
-    height: 100vh;
+    flex: 1;
     background: $c-explorer-bg;
 
     @include medium {

--- a/client/src/components/Explorer/Explorer.scss
+++ b/client/src/components/Explorer/Explorer.scss
@@ -7,54 +7,34 @@ $menu-footer-height: 50px;
 
 @import 'ExplorerItem';
 
+.explorer__wrapper,
+.explorer__wrapper * {
+    box-sizing: border-box;
+}
+
 .explorer__wrapper {
-    flex: 1;
     display: flex;
+    flex: 1;
 }
 
 .explorer {
     width: 100%;
     display: flex;
     flex-direction: column;
-    position: relative;
-    top: 0;
-    left: 0;
-    font-size: 1em;
-    z-index: 500;
 
     @include medium {
         width: 485px;
         height: 100vh;
         position: fixed;
-        top: 0;
+        z-index: 500;
         left: $menu-width;
-
-        &:before {
-            display: none;
-        }
-
-        &:after {
-            content: '';
-            width: calc(100% - 2px);
-            height: 100%;
-            position: absolute;
-            top: 0;
-            right: 0;
-            z-index: -1;
-            box-shadow: 0 0 2px rgba(255, 255, 255, 0.9);
-        }
     }
 }
 
-.c-explorer,
-.c-explorer * {
-    box-sizing: border-box;
-}
-
 .c-explorer {
+    flex: 1;
     position: relative;
     overflow: hidden;
-    flex: 1;
     background: $c-explorer-bg;
 
     @include medium {

--- a/client/src/components/Explorer/ExplorerPanel.test.js
+++ b/client/src/components/Explorer/ExplorerPanel.test.js
@@ -156,25 +156,25 @@ describe('ExplorerPanel', () => {
     });
 
     it('triggers onClose when click is outside', () => {
-      document.body.innerHTML = '<div data-explorer-menu-item></div><div data-explorer-menu></div><div id="target"></div>';
+      document.body.innerHTML = '<div data-explorer-menu-item></div><div data-explorer-menu></div><div id="t"></div>';
       wrapper.instance().clickOutside({
-        target: document.querySelector('#target'),
+        target: document.querySelector('#t'),
       });
       expect(mockProps.onClose).toHaveBeenCalled();
     });
 
     it('does not trigger onClose when click is inside', () => {
-      document.body.innerHTML = '<div data-explorer-menu-item></div><div data-explorer-menu><div id="target"></div></div>';
+      document.body.innerHTML = '<div data-explorer-menu-item></div><div data-explorer-menu><div id="t"></div></div>';
       wrapper.instance().clickOutside({
-        target: document.querySelector('#target'),
+        target: document.querySelector('#t'),
       });
       expect(mockProps.onClose).not.toHaveBeenCalled();
     });
 
     it('pauses focus trap inside toggle', () => {
-      document.body.innerHTML = '<div data-explorer-menu-item><div id="target"></div></div><div data-explorer-menu></div>';
+      document.body.innerHTML = '<div data-explorer-menu-item><div id="t"></div></div><div data-explorer-menu></div>';
       wrapper.instance().clickOutside({
-        target: document.querySelector('#target'),
+        target: document.querySelector('#t'),
       });
       expect(wrapper.state('paused')).toEqual(true);
     });

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_main-nav.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_main-nav.scss
@@ -8,8 +8,9 @@ $footer-submenu: $submenu-color;
     margin-left: -$menu-width;
     width: $menu-width;
     float: left;
+    display: flex;
+    flex-direction: column;
     height: 100%;
-    min-height: 800px;
     background: $color-grey-1;
 
     .inner {

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/core.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/core.scss
@@ -81,7 +81,6 @@ body {
 .wrapper {
     @include clearfix();
     height: 100vh;
-    min-height: 800px;
     transition: transform 0.2s ease;
 }
 

--- a/wagtail/wagtailadmin/templates/wagtailadmin/base.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/base.html
@@ -13,9 +13,9 @@
 
             {% menu_search %}
             {% main_nav %}
-        </div>
 
-        <div data-explorer-menu></div>
+        </div>
+        <div class="explorer__wrapper" data-explorer-menu></div>
     </div>
 
     <div class="content-wrapper">


### PR DESCRIPTION
This is the last issue I wanted to fix before the explorer is released. On small screens, the bottom of the scrollable list wouldn't be readily accessible by scrolling within the explorer – users had to navigate two scrolling contexts.

There is one remaining issue – Wagtail doesn't prevent the page from scrolling when its menu / explorer is open on mobile, which means users may still get lost between the two scrolling areas. This also means that browsers with floating UIs (Mobile Safari's top and bottom browser chrome, Android Chrome's top browser chrome) are likely to crop some of the explorer items behind view. To fix that one-last-thing would require quite a big refactor of the CSS for the navigation, so I'll leave this as a future enhancement.

(I also took this PR as an opportunity to do a bit more refactoring, and fix the linting warnings)

## Tested on

- Browser	Device/OS	Version(s)
- [x] - Mobile Safari	iOS Phone	10
- [x] - Mobile Safari	iOS Phone	9
- [x] - Mobile Safari	iOS Tablet	10
- [x] - Mobile Safari	iOS Tablet	9
- [x] - Chrome	Android	56
- [x] - Chrome	Android	55
- [x] - IE	Desktop	11
- [x] - Chrome	Desktop	56
- [x] - Chrome	Desktop	55
- [x] - MS Edge	Desktop	15
- [x] - MS Edge	Desktop	14
- [x] - Firefox	Desktop	52
- [x] - Firefox ESR	Desktop	45.8
- [x] - Safari	macOS	10.1
- [x] - Safari	macOS	9.1