### PR TITLE
Set codecov after_n_builds to 10 as a test

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,1 +1,4 @@
+codecov:
+  notify:
+    after_n_builds: 10
 comment: off


### PR DESCRIPTION
This should fix the issue that codecov reported a coverage percentage
which didn't take all builds into account (due to cancellation)

There are currently 29 travis builds so 10 should be a safe number