### PR TITLE
Improve consistency of ModelAdmin's view initialisation methods (attempt 3)

### DIFF
--- a/wagtail/contrib/modeladmin/options.py
+++ b/wagtail/contrib/modeladmin/options.py
@@ -306,28 +306,26 @@ class ModelAdmin(WagtailRegisterable):
             return found_fields
         return self.inspect_view_fields
 
-    def index_view(self, request):
+    def index_view(self, request, **kwargs):
         """
         Instantiates a class-based view to provide listing functionality for
         the assigned model. The view class used can be overridden by changing
         the 'index_view_class' attribute.
         """
-        kwargs = {'model_admin': self}
-        view_class = self.index_view_class
-        return view_class.as_view(**kwargs)(request)
+        view = self.index_view_class.as_view(model_admin=self)
+        return view(request, **kwargs)
 
-    def create_view(self, request):
+    def create_view(self, request, **kwargs):
         """
         Instantiates a class-based view to provide 'creation' functionality for
         the assigned model, or redirect to Wagtail's create view if the
         assigned model extends 'Page'. The view class used can be overridden by
         changing the 'create_view_class' attribute.
         """
-        kwargs = {'model_admin': self}
-        view_class = self.create_view_class
-        return view_class.as_view(**kwargs)(request)
+        view = self.create_view_class.as_view(model_admin=self)
+        return view(request, **kwargs)
 
-    def choose_parent_view(self, request):
+    def choose_parent_view(self, request, **kwargs):
         """
         Instantiates a class-based view to allows a parent page to be chosen
         for a new object, where the assigned model extends Wagtail's Page
@@ -335,42 +333,37 @@ class ModelAdmin(WagtailRegisterable):
         The view class used can be overridden by changing the
         'choose_parent_view_class' attribute.
         """
-        kwargs = {'model_admin': self}
-        view_class = self.choose_parent_view_class
-        return view_class.as_view(**kwargs)(request)
+        view = self.choose_parent_view_class.as_view(model_admin=self)
+        return view(request, **kwargs)
 
-    def inspect_view(self, request, instance_pk):
+    def inspect_view(self, request, **kwargs):
         """
         Instantiates a class-based view to provide 'inspect' functionality for
         the assigned model. The view class used can be overridden by changing
         the 'inspect_view_class' attribute.
         """
-        kwargs = {'model_admin': self, 'instance_pk': instance_pk}
-        view_class = self.inspect_view_class
-        return view_class.as_view(**kwargs)(request)
+        view = self.inspect_view_class.as_view(model_admin=self)
+        return view(request, **kwargs)
 
-    def edit_view(self, request, instance_pk):
+    def edit_view(self, request, **kwargs):
         """
         Instantiates a class-based view to provide 'edit' functionality for the
         assigned model, or redirect to Wagtail's edit view if the assinged
         model extends 'Page'. The view class used can be overridden by changing
         the  'edit_view_class' attribute.
         """
-        kwargs = {'model_admin': self, 'instance_pk': instance_pk}
-        view_class = self.edit_view_class
-        return view_class.as_view(**kwargs)(request)
+        view = self.edit_view_class.as_view(model_admin=self)
+        return view(request, **kwargs)
 
-    def delete_view(self, request, instance_pk):
+    def delete_view(self, request, **kwargs):
         """
         Instantiates a class-based view to provide 'delete confirmation'
         functionality for the assigned model, or redirect to Wagtail's delete
         confirmation view if the assinged model extends 'Page'. The view class
-        used can be overridden by changing the 'delete_view_class'
-        attribute.
+        used can be overridden by changing the 'delete_view_class' attribute.
         """
-        kwargs = {'model_admin': self, 'instance_pk': instance_pk}
-        view_class = self.delete_view_class
-        return view_class.as_view(**kwargs)(request)
+        view = self.delete_view_class.as_view(model_admin=self)
+        return view(request, **kwargs)
 
     def get_templates(self, action='index'):
         """

--- a/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
+++ b/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
@@ -491,20 +491,33 @@ class TestQuoting(TestCase, WagtailTestUtils):
         self.assertEqual(response.status_code, 200)
 
 
-class TestCustomCopyView(TestCase, WagtailTestUtils):
+class TestCustomBookModelAdminViews(TestCase, WagtailTestUtils):
     fixtures = ['modeladmintest_test.json']
 
     def setUp(self):
         self.login()
 
-    def test_new_view_init_style(self):
+    def test_old_view_init_style(self):
         """
-        The BookModelAdmin class has a custom edit view implemented with a
-        method `old_style_edit_view`, which initialises a view by passing
-        `instance_pk` as a keyword argument to `EditView.as_view()` (now
-        deprecated) instead of passing it to dispatch(). This test will
-        ensures it that method still works until support is removed completely
+        The 'old_style_edit_view()' method on BookModelAdmin initialises
+        EditView by passing `instance_pk` as a keyword argument to `as_view()`
+        (now deprecated) instead of passing it to the view method returned by
+        'as_view'. This test ensures that method still works until support is
+        dropped in wagtail 1.13
         """
         response = self.client.get('/admin/modeladmintest/book/edit_old/1/')
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context['instance'], Book.objects.get(id=1))
+
+    def test_custom_edit_view(self):
+        """
+        The 'custom_edit_view()' method uses 'CustomEditView', which overrides
+        'self.instance_pk', 'self.pk_quoted' and 'self.instance', which is
+        now deprecated. This test ensures setting of those attributes still
+        works until support is dropped in wagtail 1.13
+        """
+        response = self.client.get('/admin/modeladmintest/book/edit_custom/1/')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context['view'].instance_pk, -9999)
+        self.assertEqual(response.context['view'].pk_quoted, 9999)
+        self.assertEqual(response.context['instance'], Book.objects.get(id=3))

--- a/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
+++ b/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
@@ -465,7 +465,6 @@ class TestEditorAccess(TestCase):
 
 class TestQuoting(TestCase, WagtailTestUtils):
     fixtures = ['modeladmintest_test.json']
-    expected_status_code = 200
 
     def setUp(self):
         self.login()
@@ -484,3 +483,28 @@ class TestQuoting(TestCase, WagtailTestUtils):
         self.assertEqual(response.status_code, 200)
         response = self.client.get('/admin/modeladmintest/token/delete/Irregular_5FName/')
         self.assertEqual(response.status_code, 200)
+
+    def test_instance_specific_pk_quoting(self):
+        response = self.client.get('/admin/modeladmintest/token/edit/Irregular_5FName/')
+        edit_url = response.context['view'].edit_url
+        response = self.client.get(edit_url)
+        self.assertEqual(response.status_code, 200)
+
+
+class TestCustomCopyView(TestCase, WagtailTestUtils):
+    fixtures = ['modeladmintest_test.json']
+
+    def setUp(self):
+        self.login()
+
+    def test_new_view_init_style(self):
+        """
+        The BookModelAdmin class has a custom edit view implemented with a
+        method `old_style_edit_view`, which initialises a view by passing
+        `instance_pk` as a keyword argument to `EditView.as_view()` (now
+        deprecated) instead of passing it to dispatch(). This test will
+        ensures it that method still works until support is removed completely
+        """
+        response = self.client.get('/admin/modeladmintest/book/edit_old/1/')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context['instance'], Book.objects.get(id=1))

--- a/wagtail/contrib/modeladmin/views.py
+++ b/wagtail/contrib/modeladmin/views.py
@@ -197,12 +197,14 @@ class InstanceSpecificView(WMABaseView):
         super(InstanceSpecificView, self).__init__(*args, **kwargs)
 
     @property
-    def pk_quoted(self):
-        return self.kwargs.get(self.pk_url_kwarg, self.instance_pk_init)
+    def instance_pk(self):
+        return unquote(
+            self.kwargs.get(self.pk_url_kwarg, self.instance_pk_init)
+        )
 
     @property
-    def instance_pk(self):
-        return unquote(self.pk_quoted)
+    def pk_quoted(self):
+        return quote(self.instance_pk)
 
     @cached_property
     def instance(self):

--- a/wagtail/contrib/modeladmin/views.py
+++ b/wagtail/contrib/modeladmin/views.py
@@ -233,7 +233,7 @@ class InstanceSpecificView(WMABaseView):
         repeat database queries
         """
         if hasattr(self, '_set_instance'):
-            return self._developer_instance
+            return self._set_instance
         if hasattr(self, '_fetched_instance'):
             return self._fetched_instance
         self._fetched_instance = self.get_model_instance()
@@ -243,7 +243,7 @@ class InstanceSpecificView(WMABaseView):
     def instance(self, value):
         warnings.warn(
             "Setting of 'self.instance' is deprecated. You should look at "
-            "overriding the 'get_model_instance()' method instead" %
+            "overriding the 'get_model_instance()' method on '%s' instead" %
             self.__class__.__name__, category=RemovedInWagtail113Warning
         )
         self._set_instance = value

--- a/wagtail/contrib/modeladmin/views.py
+++ b/wagtail/contrib/modeladmin/views.py
@@ -208,8 +208,8 @@ class InstanceSpecificView(WMABaseView):
         Returns an instance of self.model identified by URL parameters in the
         current request. Raises Http404 if no match is found.
         """
-        pk = self.kwargs.get(self.pk_url_kwarg, self.instance_pk)
-        queryset = self.model._default_manager.all().filter(pk=unquote(pk))
+        pk = unquote(self.pk_quoted)
+        queryset = self.model._default_manager.all().filter(pk=pk)
         try:
             # Get the single item from the filtered queryset
             obj = queryset.get()

--- a/wagtail/contrib/modeladmin/views.py
+++ b/wagtail/contrib/modeladmin/views.py
@@ -220,9 +220,7 @@ class InstanceSpecificView(WMABaseView):
 
     @property
     def pk_quoted(self):
-        return quote(
-            self.kwargs.get(self.pk_url_kwarg, self.instance_pk)
-        )
+        return self.kwargs.get(self.pk_url_kwarg, self.instance_pk)
 
     def get_page_subtitle(self):
         return self.instance
@@ -730,8 +728,10 @@ class EditView(ModelFormView, InstanceSpecificView):
 
     @method_decorator(login_required)
     def dispatch(self, request, *args, **kwargs):
-        self.instance
         if self.is_pagemodel:
+            # pre-fetch the instance to ensure potential Http404 exceptions
+            # are raised before redirecting
+            self.instance
             return redirect(
                 self.url_helper.get_action_url('edit', self.pk_quoted)
             )

--- a/wagtail/tests/modeladmintest/wagtail_hooks.py
+++ b/wagtail/tests/modeladmintest/wagtail_hooks.py
@@ -1,8 +1,10 @@
 from __future__ import absolute_import, unicode_literals
 
+from django.conf.urls import url
+
 from wagtail.contrib.modeladmin.options import (
     ModelAdmin, ModelAdminGroup, ThumbnailMixin, modeladmin_register)
-from wagtail.contrib.modeladmin.views import CreateView
+from wagtail.contrib.modeladmin.views import CreateView, EditView
 from wagtail.tests.testapp.models import BusinessChild, EventPage, SingleEventPage
 
 from .forms import PublisherModelAdminForm
@@ -58,6 +60,19 @@ class BookModelAdmin(ThumbnailMixin, ModelAdmin):
             'data-author-yob': obj.author.date_of_birth.year,
             'class': 'book',
         }
+
+    def old_style_edit_view(self, request, instance_pk):
+        """To test that passing instance_pk to `as_view` still works"""
+        view = EditView.as_view(model_admin=self, instance_pk=instance_pk)
+        return view(request)
+
+    def get_admin_urls_for_registration(self):
+        urls = super(BookModelAdmin, self).get_admin_urls_for_registration()
+        return urls + (
+            url(self.url_helper.get_action_url_pattern('edit_old'),
+                self.old_style_edit_view,
+                name=self.url_helper.get_action_url_name('edit_old')),
+        )
 
 
 class TokenModelAdmin(ModelAdmin):

--- a/wagtail/tests/modeladmintest/wagtail_hooks.py
+++ b/wagtail/tests/modeladmintest/wagtail_hooks.py
@@ -44,6 +44,15 @@ class AuthorModelAdmin(ModelAdmin):
         return attrs
 
 
+class CustomEditView(EditView):
+    def __init__(self, *args, **kwargs):
+        super(CustomEditView, self).__init__(*args, **kwargs)
+        # Deliberatley nonsensical setting of attributes
+        self.instance_pk = -9999
+        self.pk_quoted = 9999
+        self.instance = self.model.objects.get(id__exact=3)
+
+
 class BookModelAdmin(ThumbnailMixin, ModelAdmin):
     model = Book
     menu_order = 300
@@ -61,17 +70,26 @@ class BookModelAdmin(ThumbnailMixin, ModelAdmin):
             'class': 'book',
         }
 
-    def old_style_edit_view(self, request, instance_pk):
+    def old_style_init_edit_view(self, request, instance_pk):
         """To test that passing instance_pk to `as_view` still works"""
         view = EditView.as_view(model_admin=self, instance_pk=instance_pk)
         return view(request)
+
+    def custom_edit_view(self, request, **kwargs):
+        """To test that setting instance_pk, pk_quoted and instance still
+        works"""
+        view = CustomEditView.as_view(model_admin=self)
+        return view(request, **kwargs)
 
     def get_admin_urls_for_registration(self):
         urls = super(BookModelAdmin, self).get_admin_urls_for_registration()
         return urls + (
             url(self.url_helper.get_action_url_pattern('edit_old'),
-                self.old_style_edit_view,
+                self.old_style_init_edit_view,
                 name=self.url_helper.get_action_url_name('edit_old')),
+            url(self.url_helper.get_action_url_pattern('edit_custom'),
+                self.custom_edit_view,
+                name=self.url_helper.get_action_url_name('edit_custom')),
         )
 
 


### PR DESCRIPTION
Fixes #3392. Replaces #3626 

@gasman Have wrapped the view-related changes into one commit here. Changes are detailed below:

- Alter signature of `WMABaseView.__init__()` to accept and pass additional arguments to super, where `View` sets them as attributes on `self`
- Deprecate the passing of ‘instance_pk’  to `InstanceSpecificView.__init__()`
- Replace the behaviour that was previously in `__init__` and relied upon by other views, with property/cached_property methods that return the same values
- Retain `InstanceSpecificView.dispatch()`’s former behaviour of raising a 404 error when a page instance cannot be identified, before redirecting to wagtailadmin’s page edit view

I'll let the test suite finish running on these changes before committing the `ModelAdmin` method changes, so you can see that tests still pass.