### PR TITLE
Enable tree shaking via Webpack 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,12 +8,25 @@
   },
   "babel": {
     "presets": [
-      "es2015",
+      [
+        "es2015",
+        {
+          "modules": false
+        }
+      ],
       "react"
     ],
     "plugins": [
       "lodash"
-    ]
+    ],
+    "env": {
+      "test": {
+        "presets": [
+          "es2015",
+          "react"
+        ]
+      }
+    }
   },
   "jest": {
     "setupFiles": [


### PR DESCRIPTION
Webpack 2 supports ES modules, which means we can turn off Babel transforming them into CommonJS modules. Practically, this means that we can do [tree shaking](https://webpack.js.org/guides/tree-shaking/) and reduce our build size without any further change.

In our build, this only shaves off 3.5kb but that's still worth taking.

NB: I also tried turning on `loose` mode and the improvement was very small, so will not do this within Wagtail for now.

Edit: not sure what I did wrong with #3651, so here is a second PR with the same changes.