### PR TITLE
Adds a `get_action_url_for_obj` method to AdminURLHelper

### DIFF
--- a/wagtail/contrib/modeladmin/helpers/url.py
+++ b/wagtail/contrib/modeladmin/helpers/url.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
+from django.contrib.admin.utils import quote
 from django.core.urlresolvers import reverse
 from django.utils.functional import cached_property
 from django.utils.http import urlquote
@@ -35,6 +36,12 @@ class AdminURLHelper(object):
             return reverse(self.get_action_url_name(action))
         url_name = self.get_action_url_name(action)
         return reverse(url_name, args=args, kwargs=kwargs)
+
+    def get_action_url_for_obj(self, action, obj, *args, **kwargs):
+        if obj is None:
+            return self.get_action_url(action, *args, **kwargs)
+        args = (quote(getattr(obj, self.opts.pk.attname)),) + args
+        return self.get_action_url(action, *args, **kwargs)
 
     @cached_property
     def index_url(self):

--- a/wagtail/contrib/modeladmin/views.py
+++ b/wagtail/contrib/modeladmin/views.py
@@ -155,7 +155,7 @@ class ModelFormView(WMABaseView, FormView):
             model_name=capfirst(self.opts.verbose_name), instance=instance)
 
     def get_success_message_buttons(self, instance):
-        button_url = self.url_helper.get_action_url('edit', quote(instance.pk))
+        button_url = self.url_helper.get_action_url_for_obj('edit', instance)
         return [
             messages.button(button_url, _('Edit'))
         ]
@@ -198,11 +198,11 @@ class InstanceSpecificView(WMABaseView):
 
     @cached_property
     def edit_url(self):
-        return self.url_helper.get_action_url('edit', self.pk_quoted)
+        return self.url_helper.get_action_url_for_obj('edit', self.instance)
 
     @cached_property
     def delete_url(self):
-        return self.url_helper.get_action_url('delete', self.pk_quoted)
+        return self.url_helper.get_action_url_for_obj('delete', self.instance)
 
     def get_context_data(self, **kwargs):
         context = {'instance': self.instance}
@@ -699,7 +699,7 @@ class EditView(ModelFormView, InstanceSpecificView):
     def dispatch(self, request, *args, **kwargs):
         if self.is_pagemodel:
             return redirect(
-                self.url_helper.get_action_url('edit', self.pk_quoted)
+                self.url_helper.get_action_url_for_obj('edit', self.instance)
             )
         return super(EditView, self).dispatch(request, *args, **kwargs)
 
@@ -775,7 +775,7 @@ class DeleteView(InstanceSpecificView):
             raise PermissionDenied
         if self.is_pagemodel:
             return redirect(
-                self.url_helper.get_action_url('delete', self.pk_quoted)
+                self.url_helper.get_action_url_for_obj('delete', self.instance)
             )
         return super(DeleteView, self).dispatch(request, *args, **kwargs)
 


### PR DESCRIPTION
This is a small part of a larger piece of work I'm doing on ButtonHelper #2758, where I'm calling on AdminURLHelper a little more, and it's becoming untidy to keep ensuring a 'quoted' version of an object's primary key is available to pass to `get_action_url`. Even without the rest of the changes, I'd still consider this a useful change that removes some of the 'special case' code from the views in `contrib.modeladmin`, which will undoubtedly help when it comes to refactoring on wagtailadmin's generic views / viewsets.

- Adds a `get_action_url_for_obj` method to AdminURLHelper that will extract and quote a primary key from an object and provide it (as the first item) to `get_action_url` along with any other supplied args or keyword args
- Updates various view methods to make use of the new method, instead of having to pass in an unquoted primary key to `get_action_url`

NOTE: I would recommend deprecating the `pk_quoted` attribute on `InstanceSpecificView`, but I would rather do that separately after #3650 and this have been merged.