### PR TITLE
Improve the range of wagtailadmin urls that `PageAdminURLHelper` can return for a page

### DIFF
--- a/wagtail/contrib/modeladmin/helpers/url.py
+++ b/wagtail/contrib/modeladmin/helpers/url.py
@@ -48,7 +48,10 @@ class AdminURLHelper(object):
 class PageAdminURLHelper(AdminURLHelper):
 
     def get_action_url(self, action, *args, **kwargs):
-        if action in ('add', 'edit', 'delete', 'unpublish', 'copy'):
+        if action in (
+            'add', 'edit', 'delete', 'copy', 'move', 'preview', 'view_draft',
+            'unpublish', 'revisions_index', 'add_subpage'
+        ):
             url_name = 'wagtailadmin_pages:%s' % action
             target_url = reverse(url_name, args=args, kwargs=kwargs)
             return '%s?next=%s' % (target_url, urlquote(self.index_url))


### PR DESCRIPTION
Another small part of a larger piece of work I'm doing on ButtonHelper #2758.

Currently, the `PageAdminURLHelper` class only returns urls for a limited set of wagtailadmin views, because that's all that is needed currently. However, when you take `PageAdminURLHelper` as a separate component (which all the helpers are), there's no reason why it shouldn't return other/all URLs related to a specific page instance (even if the `next` get parameter isn't respected in all of them).

I've built some custom admin views on a client project recently too, where this functionality would have been helpful.