### PR TITLE
Call Field.prepare_value from FieldBlocks

### DIFF
--- a/wagtail/wagtailcore/blocks/field_block.py
+++ b/wagtail/wagtailcore/blocks/field_block.py
@@ -26,11 +26,12 @@ class FieldBlock(Block):
         return self.field.widget.id_for_label(prefix)
 
     def render_form(self, value, prefix='', errors=None):
-        widget = self.field.widget
+        field = self.field
+        widget = field.widget
 
         widget_attrs = {'id': prefix, 'placeholder': self.label}
 
-        field_value = self.value_for_form(value)
+        field_value = field.prepare_value(self.value_for_form(value))
 
         if hasattr(widget, 'render_with_errors'):
             widget_html = widget.render_with_errors(prefix, field_value, attrs=widget_attrs, errors=errors)
@@ -43,7 +44,7 @@ class FieldBlock(Block):
             'name': self.name,
             'classes': self.meta.classname,
             'widget': widget_html,
-            'field': self.field,
+            'field': field,
             'errors': errors if (not widget_has_rendered_errors) else None
         })
 


### PR DESCRIPTION
This is used by some form fields to convert from the internal Python value to the value used by a widget, much like `Block.get_prep_value` for blocks or `Field.get_prep_value` for model fields.

This is a bug fix. `prepare_value` is part of the official Django form API / workflow, Wagtail is not conforming to the forms API by not calling this method.

This method is usually called from the BoundField when it is getting a value to pass to the widget. The BoundField is bypassed here because making a BoundField requires a Form instance as well, and that starts getting tricky. This could be an issue, as fields can technically customise the BoundField for a Field, but I don't know of any that customise it such that `prepare_value` would be called in a different manner.