### PR TITLE
Hide wagtail icon from printed page representation.

### DIFF
--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/userbar.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/userbar.scss
@@ -86,6 +86,13 @@ $positions: (
 }
 
 
+@media print {
+    .#{$namespace}-userbar {
+        display: none;
+    }
+}
+
+
 .#{$namespace}-userbar {
     position: fixed;
     z-index: 9999;


### PR DESCRIPTION
I have added a new CSS rule to hide wagtail bird from printed wagtail pages.