### PR TITLE
Try to fix Appveyor test failure on document filenames

### DIFF
--- a/wagtail/wagtaildocs/tests/test_models.py
+++ b/wagtail/wagtaildocs/tests/test_models.py
@@ -78,21 +78,16 @@ class TestDocumentPermissions(TestCase):
 
 
 class TestDocumentFilenameProperties(TestCase):
-    def setUp(self):
+    def test_filename(self):
         self.document = models.Document(title="Test document")
         self.document.file.save('example.doc', ContentFile("A boring example document"))
-
         self.extensionless_document = models.Document(title="Test document")
         self.extensionless_document.file.save('example', ContentFile("A boring example document"))
 
-    def test_filename(self):
         self.assertEqual('example.doc', self.document.filename)
         self.assertEqual('example', self.extensionless_document.filename)
-
-    def test_file_extension(self):
         self.assertEqual('doc', self.document.file_extension)
         self.assertEqual('', self.extensionless_document.file_extension)
 
-    def tearDown(self):
         self.document.delete()
         self.extensionless_document.delete()

--- a/wagtail/wagtaildocs/tests/test_serve_view.py
+++ b/wagtail/wagtaildocs/tests/test_serve_view.py
@@ -16,21 +16,12 @@ from wagtail.wagtaildocs import models
 
 
 class TestServeView(TestCase):
-    def __init__(self, *args, **kwargs):
-        super(TestServeView, self).__init__(*args, **kwargs)
-        self.doc_index = 0
-
     def setUp(self):
-        # use a new filename for each test, to prevent failures on flaky filesystems
-        # that can't delete fast enough
-        self.doc_index += 1
         self.document = models.Document(title="Test document")
-        self.document.file.save(
-            'example%d.doc' % self.doc_index,
-            ContentFile("A boring example document")
-        )
+        self.document.file.save('example.doc', ContentFile("A boring example document"))
 
     def tearDown(self):
+        self.document.file.close()
         self.document.delete()
 
     def get(self):
@@ -80,10 +71,6 @@ class TestServeView(TestCase):
 
 
 class TestServeViewWithSendfile(TestCase):
-    def __init__(self, *args, **kwargs):
-        super(TestServeViewWithSendfile, self).__init__(*args, **kwargs)
-        self.doc_index = 0
-
     def setUp(self):
         # Import using a try-catch block to prevent crashes if the
         # django-sendfile module is not installed
@@ -92,16 +79,11 @@ class TestServeViewWithSendfile(TestCase):
         except ImportError:
             raise unittest.SkipTest("django-sendfile not installed")
 
-        # use a new filename for each test, to prevent failures on flaky filesystems
-        # that can't delete fast enough
-        self.doc_index += 1
         self.document = models.Document(title="Test document")
-        self.document.file.save(
-            'example%d.doc' % self.doc_index,
-            ContentFile("A boring example document")
-        )
+        self.document.file.save('example.doc', ContentFile("A boring example document"))
 
     def tearDown(self):
+        self.document.file.close()
         self.document.delete()
 
     def get(self):

--- a/wagtail/wagtaildocs/tests/test_serve_view.py
+++ b/wagtail/wagtaildocs/tests/test_serve_view.py
@@ -16,9 +16,19 @@ from wagtail.wagtaildocs import models
 
 
 class TestServeView(TestCase):
+    def __init__(self, *args, **kwargs):
+        super(TestServeView, self).__init__(*args, **kwargs)
+        self.doc_index = 0
+
     def setUp(self):
+        # use a new filename for each test, to prevent failures on flaky filesystems
+        # that can't delete fast enough
+        self.doc_index += 1
         self.document = models.Document(title="Test document")
-        self.document.file.save('example.doc', ContentFile("A boring example document"))
+        self.document.file.save(
+            'example%d.doc' % self.doc_index,
+            ContentFile("A boring example document")
+        )
 
     def tearDown(self):
         self.document.delete()
@@ -70,6 +80,10 @@ class TestServeView(TestCase):
 
 
 class TestServeViewWithSendfile(TestCase):
+    def __init__(self, *args, **kwargs):
+        super(TestServeViewWithSendfile, self).__init__(*args, **kwargs)
+        self.doc_index = 0
+
     def setUp(self):
         # Import using a try-catch block to prevent crashes if the
         # django-sendfile module is not installed
@@ -78,8 +92,14 @@ class TestServeViewWithSendfile(TestCase):
         except ImportError:
             raise unittest.SkipTest("django-sendfile not installed")
 
+        # use a new filename for each test, to prevent failures on flaky filesystems
+        # that can't delete fast enough
+        self.doc_index += 1
         self.document = models.Document(title="Test document")
-        self.document.file.save('example.doc', ContentFile("A boring example document"))
+        self.document.file.save(
+            'example%d.doc' % self.doc_index,
+            ContentFile("A boring example document")
+        )
 
     def tearDown(self):
         self.document.delete()

--- a/wagtail/wagtaildocs/tests/test_serve_view.py
+++ b/wagtail/wagtaildocs/tests/test_serve_view.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 
 import os.path
+import time
 import unittest
 
 import django
@@ -22,6 +23,7 @@ class TestServeView(TestCase):
 
     def tearDown(self):
         self.document.file.close()
+        time.sleep(1)
         self.document.delete()
 
     def get(self):
@@ -84,6 +86,7 @@ class TestServeViewWithSendfile(TestCase):
 
     def tearDown(self):
         self.document.file.close()
+        time.sleep(1)
         self.document.delete()
 
     def get(self):


### PR DESCRIPTION
Move document filename tests into a single test method, to try and prevent race condition on Appveyor