### PR TITLE
Show / hide InlinePanel arrow buttons correctly on non-default tabs

### DIFF
--- a/wagtail/wagtailadmin/static_src/wagtailadmin/js/page-editor.js
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/js/page-editor.js
@@ -187,7 +187,7 @@ function InlinePanel(opts) {
 
     self.updateMoveButtonDisabledStates = function() {
         if (opts.canOrder) {
-            var forms = self.formsUl.children('li:visible');
+            var forms = self.formsUl.children('li:not(.deleted)');
             forms.each(function(i) {
                 $('ul.controls .inline-child-move-up', this).toggleClass('disabled', i === 0).toggleClass('enabled', i !== 0);
                 $('ul.controls .inline-child-move-down', this).toggleClass('disabled', i === forms.length - 1).toggleClass('enabled', i != forms.length - 1);
@@ -210,7 +210,7 @@ function InlinePanel(opts) {
 
     self.animateSwap = function(item1, item2) {
         var parent = self.formsUl;
-        var children = parent.children('li:visible');
+        var children = parent.children('li:not(.deleted)');
 
         // Apply moving class to container (ul.multiple) so it can assist absolute positioning of it's children
         // Also set it's relatively calculated height to be an absolute one, to prevent the container collapsing while its children go absolute


### PR DESCRIPTION
Base the show/hide logic on the 'deleted' class, rather than visibility, because elements on non-default tabs are considered invisible. Fixes #3667