### PR TITLE
Implement RFC18 meta fields changes

### DIFF
--- a/client/src/components/Explorer/ExplorerHeader.js
+++ b/client/src/components/Explorer/ExplorerHeader.js
@@ -14,7 +14,7 @@ const ExplorerHeader = ({ page, depth, onClick }) => {
 
   return (
     <Button
-      href={page.id ? `${ADMIN_URLS.PAGES}${page.id}/` : ADMIN_URLS.PAGES}
+      href={page.meta.id ? `${ADMIN_URLS.PAGES}${page.meta.id}/` : ADMIN_URLS.PAGES}
       className="c-explorer__header"
       onClick={onClick}
     >

--- a/client/src/components/Explorer/ExplorerHeader.test.js
+++ b/client/src/components/Explorer/ExplorerHeader.test.js
@@ -24,7 +24,7 @@ describe('ExplorerHeader', () => {
   });
 
   it('#page', () => {
-    expect(shallow(<ExplorerHeader {...mockProps} page={{ id: 'a', title: 'test' }} />)).toMatchSnapshot();
+    expect(shallow(<ExplorerHeader {...mockProps} page={{ meta: { id: 'a' }, title: 'test' }} />)).toMatchSnapshot();
   });
 
   it('#onClick', () => {

--- a/client/src/components/Explorer/ExplorerItem.js
+++ b/client/src/components/Explorer/ExplorerItem.js
@@ -24,7 +24,8 @@ const nextIcon = (
  * and information depending on the metadata of the page.
  */
 const ExplorerItem = ({ item, onClick }) => {
-  const { id, title, meta } = item;
+  const { title, meta } = item;
+  const { id } = meta;
   const hasChildren = meta.children.count > 0;
   const isPublished = meta.status.live && !meta.status.has_unpublished_changes;
 

--- a/client/src/components/Explorer/ExplorerItem.test.js
+++ b/client/src/components/Explorer/ExplorerItem.test.js
@@ -5,9 +5,9 @@ import ExplorerItem from './ExplorerItem';
 
 const mockProps = {
   item: {
-    id: 5,
     title: 'test',
     meta: {
+      id: 5,
       latest_revision_created_at: null,
       status: {
         live: true,

--- a/client/src/components/Explorer/ExplorerPanel.test.js
+++ b/client/src/components/Explorer/ExplorerPanel.test.js
@@ -57,8 +57,8 @@ describe('ExplorerPanel', () => {
         {...mockProps}
         page={{ children: { items: [1, 2] } }}
         nodes={{
-          1: { id: 1, title: 'Test', meta: { status: {}, type: 'test' } },
-          2: { id: 2, title: 'Foo', meta: { status: {}, type: 'foo' } },
+          1: { title: 'Test', meta: { id: 1, status: {}, type: 'test' } },
+          2: { title: 'Foo', meta: { id: 2, status: {}, type: 'foo' } },
         }}
       />
     ))).toMatchSnapshot();
@@ -103,7 +103,7 @@ describe('ExplorerPanel', () => {
           {...mockProps}
           path={[1]}
           page={{ children: { items: [1] } }}
-          nodes={{ 1: { id: 1, title: 'Test', meta: { status: {}, type: 'test' } } }}
+          nodes={{ 1: { title: 'Test', meta: { id: 1, status: {}, type: 'test' } } }}
         />
       )).find('ExplorerItem').prop('onClick')({
         preventDefault() {},

--- a/client/src/components/Explorer/PageCount.js
+++ b/client/src/components/Explorer/PageCount.js
@@ -9,7 +9,7 @@ const PageCount = ({ page }) => {
 
   return (
     <a
-      href={`${ADMIN_URLS.PAGES}${page.id}/`}
+      href={`${ADMIN_URLS.PAGES}${page.meta.id}/`}
       className="c-explorer__see-more"
       tabIndex={0}
     >

--- a/client/src/components/Explorer/reducers/nodes.js
+++ b/client/src/components/Explorer/reducers/nodes.js
@@ -33,7 +33,7 @@ const node = (state = defaultPageState, { type, payload }) => {
       isFetching: false,
       isError: false,
       children: {
-        items: state.children.items.slice().concat(payload.items.map(item => item.id)),
+        items: state.children.items.slice().concat(payload.items.map(item => item.meta.id)),
         count: payload.meta.total_count,
       },
     });
@@ -75,7 +75,7 @@ export default function nodes(state = defaultState, { type, payload }) {
     });
 
     payload.items.forEach((item) => {
-      newState[item.id] = Object.assign({}, defaultPageState, item);
+      newState[item.meta.id] = Object.assign({}, defaultPageState, item);
     });
 
     return newState;

--- a/client/src/components/Explorer/reducers/nodes.test.js
+++ b/client/src/components/Explorer/reducers/nodes.test.js
@@ -39,9 +39,9 @@ describe('nodes', () => {
       payload: {
         id: 1,
         items: [
-          { id: 3 },
-          { id: 4 },
-          { id: 5 },
+          { meta: { id: 3 } },
+          { meta: { id: 4 } },
+          { meta: { id: 5 } },
         ],
         meta: {
           total_count: 3,

--- a/wagtail/api/v3/apps.py
+++ b/wagtail/api/v3/apps.py
@@ -1,0 +1,20 @@
+from __future__ import absolute_import, unicode_literals
+
+from django.apps import AppConfig, apps
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+
+
+class WagtailAPIV3AppConfig(AppConfig):
+    name = 'wagtail.api.v3'
+    label = 'wagtailapi_v3'
+    verbose_name = "Wagtail API v3"
+
+    def ready(self):
+        # Install cache purging signal handlers
+        if getattr(settings, 'WAGTAILAPI_USE_FRONTENDCACHE', False):
+            if apps.is_installed('wagtail.contrib.wagtailfrontendcache'):
+                from wagtail.api.v3.signal_handlers import register_signal_handlers
+                register_signal_handlers()
+            else:
+                raise ImproperlyConfigured("The setting 'WAGTAILAPI_USE_FRONTENDCACHE' is True but 'wagtail.contrib.wagtailfrontendcache' is not in INSTALLED_APPS.")

--- a/wagtail/api/v3/endpoints.py
+++ b/wagtail/api/v3/endpoints.py
@@ -1,0 +1,412 @@
+from __future__ import absolute_import, unicode_literals
+
+from collections import OrderedDict
+
+from django.apps import apps
+from django.conf.urls import url
+from django.core.exceptions import FieldDoesNotExist
+from django.core.urlresolvers import reverse
+from django.http import Http404
+from modelcluster.fields import ParentalKey
+from rest_framework import status
+from rest_framework.renderers import BrowsableAPIRenderer, JSONRenderer
+from rest_framework.response import Response
+from rest_framework.viewsets import GenericViewSet
+
+from wagtail.api import APIField
+from wagtail.wagtailcore.models import Page
+
+from .filters import (
+    FieldsFilter, OrderingFilter, RestrictedChildOfFilter, RestrictedDescendantOfFilter,
+    SearchFilter)
+from .pagination import WagtailPagination
+from .serializers import BaseSerializer, PageSerializer, get_serializer_class
+from .utils import (
+    BadRequestError, filter_page_type, page_models_from_string, parse_fields_parameter)
+
+
+class BaseAPIEndpoint(GenericViewSet):
+    renderer_classes = [JSONRenderer]
+
+    # The BrowsableAPIRenderer requires rest_framework to be installed
+    # Remove this check in Wagtail 1.4 as rest_framework will be required
+    # RemovedInWagtail14Warning
+    if apps.is_installed('rest_framework'):
+        renderer_classes.append(BrowsableAPIRenderer)
+
+    pagination_class = WagtailPagination
+    base_serializer_class = BaseSerializer
+    filter_backends = []
+    model = None  # Set on subclass
+
+    known_query_parameters = frozenset([
+        'limit',
+        'offset',
+        'fields',
+        'order',
+        'search',
+        'search_operator',
+
+        # Used by jQuery for cache-busting. See #1671
+        '_',
+
+        # Required by BrowsableAPIRenderer
+        'format',
+    ])
+    body_fields = ['id']
+    meta_fields = ['type', 'detail_url']
+    listing_default_fields = ['id', 'type', 'detail_url']
+    nested_default_fields = ['id', 'type', 'detail_url']
+    detail_only_fields = []
+    name = None  # Set on subclass.
+
+    def __init__(self, *args, **kwargs):
+        super(BaseAPIEndpoint, self).__init__(*args, **kwargs)
+
+        # seen_types is a mapping of type name strings (format: "app_label.ModelName")
+        # to model classes. When an object is serialised in the API, its model
+        # is added to this mapping. This is used by the Admin API which appends a
+        # summary of the used types to the response.
+        self.seen_types = OrderedDict()
+
+    def get_queryset(self):
+        return self.model.objects.all().order_by('id')
+
+    def listing_view(self, request):
+        queryset = self.get_queryset()
+        self.check_query_parameters(queryset)
+        queryset = self.filter_queryset(queryset)
+        queryset = self.paginate_queryset(queryset)
+        serializer = self.get_serializer(queryset, many=True)
+        return self.get_paginated_response(serializer.data)
+
+    def detail_view(self, request, pk):
+        instance = self.get_object()
+        serializer = self.get_serializer(instance)
+        return Response(serializer.data)
+
+    def handle_exception(self, exc):
+        if isinstance(exc, Http404):
+            data = {'message': str(exc)}
+            return Response(data, status=status.HTTP_404_NOT_FOUND)
+        elif isinstance(exc, BadRequestError):
+            data = {'message': str(exc)}
+            return Response(data, status=status.HTTP_400_BAD_REQUEST)
+        return super(BaseAPIEndpoint, self).handle_exception(exc)
+
+    @classmethod
+    def _convert_api_fields(cls, fields):
+        return [field if isinstance(field, APIField) else APIField(field)
+                for field in fields]
+
+    @classmethod
+    def get_body_fields(cls, model):
+        return cls._convert_api_fields(cls.body_fields + list(getattr(model, 'api_fields', ())))
+
+    @classmethod
+    def get_body_fields_names(cls, model):
+        return [field.name for field in cls.get_body_fields(model)]
+
+    @classmethod
+    def get_meta_fields(cls, model):
+        return cls._convert_api_fields(cls.meta_fields + list(getattr(model, 'api_meta_fields', ())))
+
+    @classmethod
+    def get_meta_fields_names(cls, model):
+        return [field.name for field in cls.get_meta_fields(model)]
+
+    @classmethod
+    def get_field_serializer_overrides(cls, model):
+        return {field.name: field.serializer
+                for field in cls.get_body_fields(model) + cls.get_meta_fields(model)
+                if field.serializer is not None}
+
+    @classmethod
+    def get_available_fields(cls, model, db_fields_only=False):
+        """
+        Returns a list of all the fields that can be used in the API for the
+        specified model class.
+
+        Setting db_fields_only to True will remove all fields that do not have
+        an underlying column in the database (eg, type/detail_url and any custom
+        fields that are callables)
+        """
+        fields = cls.get_body_fields_names(model) + cls.get_meta_fields_names(model)
+
+        if db_fields_only:
+            # Get list of available database fields then remove any fields in our
+            # list that isn't a database field
+            database_fields = set()
+            for field in model._meta.get_fields():
+                database_fields.add(field.name)
+
+                if hasattr(field, 'attname'):
+                    database_fields.add(field.attname)
+
+            fields = [field for field in fields if field in database_fields]
+
+        return fields
+
+    @classmethod
+    def get_detail_default_fields(cls, model):
+        return cls.get_available_fields(model)
+
+    @classmethod
+    def get_listing_default_fields(cls, model):
+        return cls.listing_default_fields[:]
+
+    @classmethod
+    def get_nested_default_fields(cls, model):
+        return cls.nested_default_fields[:]
+
+    def check_query_parameters(self, queryset):
+        """
+        Ensure that only valid query paramters are included in the URL.
+        """
+        query_parameters = set(self.request.GET.keys())
+
+        # All query paramters must be either a database field or an operation
+        allowed_query_parameters = set(self.get_available_fields(queryset.model, db_fields_only=True)).union(self.known_query_parameters)
+        unknown_parameters = query_parameters - allowed_query_parameters
+        if unknown_parameters:
+            raise BadRequestError("query parameter is not an operation or a recognised field: %s" % ', '.join(sorted(unknown_parameters)))
+
+    @classmethod
+    def _get_serializer_class(cls, router, model, fields_config, show_details=False, nested=False):
+        # Get all available fields
+        body_fields = cls.get_body_fields_names(model)
+        meta_fields = cls.get_meta_fields_names(model)
+        all_fields = body_fields + meta_fields
+
+        # Remove any duplicates
+        all_fields = list(OrderedDict.fromkeys(all_fields))
+
+        if not show_details:
+            # Remove detail only fields
+            for field in cls.detail_only_fields:
+                try:
+                    all_fields.remove(field)
+                except KeyError:
+                    pass
+
+        # Get list of configured fields
+        if show_details:
+            fields = set(cls.get_detail_default_fields(model))
+        elif nested:
+            fields = set(cls.get_nested_default_fields(model))
+        else:
+            fields = set(cls.get_listing_default_fields(model))
+
+        # If first field is '*' start with all fields
+        # If first field is '_' start with no fields
+        if fields_config and fields_config[0][0] == '*':
+            fields = set(all_fields)
+            fields_config = fields_config[1:]
+        elif fields_config and fields_config[0][0] == '_':
+            fields = set()
+            fields_config = fields_config[1:]
+
+        mentioned_fields = set()
+        sub_fields = {}
+
+        for field_name, negated, field_sub_fields in fields_config:
+            if negated:
+                try:
+                    fields.remove(field_name)
+                except KeyError:
+                    pass
+            else:
+                fields.add(field_name)
+                if field_sub_fields:
+                    sub_fields[field_name] = field_sub_fields
+
+            mentioned_fields.add(field_name)
+
+        unknown_fields = mentioned_fields - set(all_fields)
+
+        if unknown_fields:
+            raise BadRequestError("unknown fields: %s" % ', '.join(sorted(unknown_fields)))
+
+        # Build nested serialisers
+        child_serializer_classes = {}
+
+        for field_name in fields:
+            try:
+                django_field = model._meta.get_field(field_name)
+            except FieldDoesNotExist:
+                django_field = None
+
+            if django_field and django_field.is_relation:
+                child_sub_fields = sub_fields.get(field_name, [])
+
+                # Inline (aka "child") models should display all fields by default
+                if isinstance(getattr(django_field, 'field', None), ParentalKey):
+                    if not child_sub_fields or child_sub_fields[0][0] not in ['*', '_']:
+                        child_sub_fields = list(child_sub_fields)
+                        child_sub_fields.insert(0, ('*', False, None))
+
+                # Get a serializer class for the related object
+                child_model = django_field.related_model
+                child_endpoint_class = router.get_model_endpoint(child_model)
+                child_endpoint_class = child_endpoint_class[1] if child_endpoint_class else BaseAPIEndpoint
+                child_serializer_classes[field_name] = child_endpoint_class._get_serializer_class(router, child_model, child_sub_fields, nested=True)
+
+            else:
+                if field_name in sub_fields:
+                    # Sub fields were given for a non-related field
+                    raise BadRequestError("'%s' does not support nested fields" % field_name)
+
+        # Reorder fields so it matches the order of all_fields
+        fields = [field for field in all_fields if field in fields]
+
+        field_serializer_overrides = {field[0]: field[1] for field in cls.get_field_serializer_overrides(model).items() if field[0] in fields}
+        return get_serializer_class(
+            model,
+            fields,
+            meta_fields=meta_fields,
+            field_serializer_overrides=field_serializer_overrides,
+            child_serializer_classes=child_serializer_classes,
+            base=cls.base_serializer_class
+        )
+
+    def get_serializer_class(self):
+        request = self.request
+
+        # Get model
+        if self.action == 'listing_view':
+            model = self.get_queryset().model
+        else:
+            model = type(self.get_object())
+
+        # Fields
+        if 'fields' in request.GET:
+            try:
+                fields_config = parse_fields_parameter(request.GET['fields'])
+            except ValueError as e:
+                raise BadRequestError("fields error: %s" % str(e))
+        else:
+            # Use default fields
+            fields_config = []
+
+        # Allow "detail_only" (eg parent) fields on detail view
+        if self.action == 'listing_view':
+            show_details = False
+        else:
+            show_details = True
+
+        return self._get_serializer_class(self.request.wagtailapi_router, model, fields_config, show_details=show_details)
+
+    def get_serializer_context(self):
+        """
+        The serialization context differs between listing and detail views.
+        """
+        return {
+            'request': self.request,
+            'view': self,
+            'router': self.request.wagtailapi_router
+        }
+
+    def get_renderer_context(self):
+        context = super(BaseAPIEndpoint, self).get_renderer_context()
+        context['indent'] = 4
+        return context
+
+    @classmethod
+    def get_urlpatterns(cls):
+        """
+        This returns a list of URL patterns for the endpoint
+        """
+        return [
+            url(r'^$', cls.as_view({'get': 'listing_view'}), name='listing'),
+            url(r'^(?P<pk>\d+)/$', cls.as_view({'get': 'detail_view'}), name='detail'),
+        ]
+
+    @classmethod
+    def get_model_listing_urlpath(cls, model, namespace=''):
+        if namespace:
+            url_name = namespace + ':listing'
+        else:
+            url_name = 'listing'
+
+        return reverse(url_name)
+
+    @classmethod
+    def get_object_detail_urlpath(cls, model, pk, namespace=''):
+        if namespace:
+            url_name = namespace + ':detail'
+        else:
+            url_name = 'detail'
+
+        return reverse(url_name, args=(pk, ))
+
+
+class PagesAPIEndpoint(BaseAPIEndpoint):
+    base_serializer_class = PageSerializer
+    filter_backends = [
+        FieldsFilter,
+        RestrictedChildOfFilter,
+        RestrictedDescendantOfFilter,
+        OrderingFilter,
+        SearchFilter
+    ]
+    known_query_parameters = BaseAPIEndpoint.known_query_parameters.union([
+        'type',
+        'child_of',
+        'descendant_of',
+    ])
+    body_fields = BaseAPIEndpoint.body_fields + [
+        'title',
+    ]
+    meta_fields = BaseAPIEndpoint.meta_fields + [
+        'html_url',
+        'slug',
+        'show_in_menus',
+        'seo_title',
+        'search_description',
+        'first_published_at',
+        'parent',
+    ]
+    listing_default_fields = BaseAPIEndpoint.listing_default_fields + [
+        'title',
+        'html_url',
+        'slug',
+        'first_published_at',
+    ]
+    nested_default_fields = BaseAPIEndpoint.nested_default_fields + [
+        'title',
+    ]
+    detail_only_fields = ['parent']
+    name = 'pages'
+    model = Page
+
+    def get_queryset(self):
+        request = self.request
+
+        # Allow pages to be filtered to a specific type
+        try:
+            models = page_models_from_string(request.GET.get('type', 'wagtailcore.Page'))
+        except (LookupError, ValueError):
+            raise BadRequestError("type doesn't exist")
+
+        if not models:
+            models = [Page]
+
+        if len(models) == 1:
+            queryset = models[0].objects.all()
+        else:
+            queryset = Page.objects.all()
+
+            # Filter pages by specified models
+            queryset = filter_page_type(queryset, models)
+
+        # Get live pages that are not in a private section
+        queryset = queryset.public().live()
+
+        # Filter by site
+        queryset = queryset.descendant_of(request.site.root_page, inclusive=True)
+
+        return queryset
+
+    def get_object(self):
+        base = super(PagesAPIEndpoint, self).get_object()
+        return base.specific

--- a/wagtail/api/v3/endpoints.py
+++ b/wagtail/api/v3/endpoints.py
@@ -53,8 +53,8 @@ class BaseAPIEndpoint(GenericViewSet):
         # Required by BrowsableAPIRenderer
         'format',
     ])
-    body_fields = ['id']
-    meta_fields = ['type', 'detail_url']
+    body_fields = []
+    meta_fields = ['id', 'type', 'detail_url']
     listing_default_fields = ['id', 'type', 'detail_url']
     nested_default_fields = ['id', 'type', 'detail_url']
     detail_only_fields = []
@@ -356,13 +356,13 @@ class PagesAPIEndpoint(BaseAPIEndpoint):
     ])
     body_fields = BaseAPIEndpoint.body_fields + [
         'title',
-    ]
-    meta_fields = BaseAPIEndpoint.meta_fields + [
-        'html_url',
         'slug',
         'show_in_menus',
         'seo_title',
         'search_description',
+    ]
+    meta_fields = BaseAPIEndpoint.meta_fields + [
+        'html_url',
         'first_published_at',
         'parent',
     ]

--- a/wagtail/api/v3/filters.py
+++ b/wagtail/api/v3/filters.py
@@ -1,0 +1,214 @@
+from __future__ import absolute_import, unicode_literals
+
+from django.conf import settings
+from django.db import models
+from rest_framework.filters import BaseFilterBackend
+from taggit.managers import TaggableManager
+
+from wagtail.wagtailcore.models import Page
+from wagtail.wagtailsearch.backends import get_search_backend
+
+from .utils import BadRequestError, pages_for_site, parse_boolean
+
+
+class FieldsFilter(BaseFilterBackend):
+    def filter_queryset(self, request, queryset, view):
+        """
+        This performs field level filtering on the result set
+        Eg: ?title=James Joyce
+        """
+        fields = set(view.get_available_fields(queryset.model, db_fields_only=True))
+
+        for field_name, value in request.GET.items():
+            if field_name in fields:
+                try:
+                    field = queryset.model._meta.get_field(field_name)
+                except LookupError:
+                    field = None
+
+                # Convert value into python
+                try:
+                    if isinstance(field, (models.BooleanField, models.NullBooleanField)):
+                        value = parse_boolean(value)
+                    elif isinstance(field, (models.IntegerField, models.AutoField)):
+                        value = int(value)
+                except ValueError as e:
+                    raise BadRequestError("field filter error. '%s' is not a valid value for %s (%s)" % (
+                        value,
+                        field_name,
+                        str(e)
+                    ))
+
+                if isinstance(field, TaggableManager):
+                    for tag in value.split(','):
+                        queryset = queryset.filter(**{field_name + '__name': tag})
+
+                    # Stick a message on the queryset to indicate that tag filtering has been performed
+                    # This will let the do_search method know that it must raise an error as searching
+                    # and tag filtering at the same time is not supported
+                    queryset._filtered_by_tag = True
+                else:
+                    queryset = queryset.filter(**{field_name: value})
+
+        return queryset
+
+
+class OrderingFilter(BaseFilterBackend):
+    def filter_queryset(self, request, queryset, view):
+        """
+        This applies ordering to the result set
+        Eg: ?order=title
+
+        It also supports reverse ordering
+        Eg: ?order=-title
+
+        And random ordering
+        Eg: ?order=random
+        """
+        if 'order' in request.GET:
+            order_by = request.GET['order']
+
+            # Random ordering
+            if order_by == 'random':
+                # Prevent ordering by random with offset
+                if 'offset' in request.GET:
+                    raise BadRequestError("random ordering with offset is not supported")
+
+                return queryset.order_by('?')
+
+            # Check if reverse ordering is set
+            if order_by.startswith('-'):
+                reverse_order = True
+                order_by = order_by[1:]
+            else:
+                reverse_order = False
+
+            # Add ordering
+            if order_by in view.get_available_fields(queryset.model):
+                queryset = queryset.order_by(order_by)
+            else:
+                # Unknown field
+                raise BadRequestError("cannot order by '%s' (unknown field)" % order_by)
+
+            # Reverse order
+            if reverse_order:
+                queryset = queryset.reverse()
+
+        return queryset
+
+
+class SearchFilter(BaseFilterBackend):
+    def filter_queryset(self, request, queryset, view):
+        """
+        This performs a full-text search on the result set
+        Eg: ?search=James Joyce
+        """
+        search_enabled = getattr(settings, 'WAGTAILAPI_SEARCH_ENABLED', True)
+
+        if 'search' in request.GET:
+            if not search_enabled:
+                raise BadRequestError("search is disabled")
+
+            # Searching and filtering by tag at the same time is not supported
+            if getattr(queryset, '_filtered_by_tag', False):
+                raise BadRequestError("filtering by tag with a search query is not supported")
+
+            search_query = request.GET['search']
+            search_operator = request.GET.get('search_operator', None)
+            order_by_relevance = 'order' not in request.GET
+
+            sb = get_search_backend()
+            queryset = sb.search(search_query, queryset, operator=search_operator, order_by_relevance=order_by_relevance)
+
+        return queryset
+
+
+class ChildOfFilter(BaseFilterBackend):
+    """
+    Implements the ?child_of filter used to filter the results to only contain
+    pages that are direct children of the specified page.
+    """
+    def get_root_page(self, request):
+        return Page.get_first_root_node()
+
+    def get_page_by_id(self, request, page_id):
+        return Page.objects.get(id=page_id)
+
+    def filter_queryset(self, request, queryset, view):
+        if 'child_of' in request.GET:
+            try:
+                parent_page_id = int(request.GET['child_of'])
+                assert parent_page_id >= 0
+
+                parent_page = self.get_page_by_id(request, parent_page_id)
+            except (ValueError, AssertionError):
+                if request.GET['child_of'] == 'root':
+                    parent_page = self.get_root_page(request)
+                else:
+                    raise BadRequestError("child_of must be a positive integer")
+            except Page.DoesNotExist:
+                raise BadRequestError("parent page doesn't exist")
+
+            queryset = queryset.child_of(parent_page)
+            queryset._filtered_by_child_of = True
+
+        return queryset
+
+
+class RestrictedChildOfFilter(ChildOfFilter):
+    """
+    A restricted version of ChildOfFilter that only allows pages in the current
+    site to be specified.
+    """
+    def get_root_page(self, request):
+        return request.site.root_page
+
+    def get_page_by_id(self, request, page_id):
+        site_pages = pages_for_site(request.site)
+        return site_pages.get(id=page_id)
+
+
+class DescendantOfFilter(BaseFilterBackend):
+    """
+    Implements the ?decendant_of filter which limits the set of pages to a
+    particular branch of the page tree.
+    """
+    def get_root_page(self, request):
+        return Page.get_first_root_node()
+
+    def get_page_by_id(self, request, page_id):
+        return Page.objects.get(id=page_id)
+
+    def filter_queryset(self, request, queryset, view):
+        if 'descendant_of' in request.GET:
+            if getattr(queryset, '_filtered_by_child_of', False):
+                raise BadRequestError("filtering by descendant_of with child_of is not supported")
+            try:
+                parent_page_id = int(request.GET['descendant_of'])
+                assert parent_page_id >= 0
+
+                parent_page = self.get_page_by_id(request, parent_page_id)
+            except (ValueError, AssertionError):
+                if request.GET['descendant_of'] == 'root':
+                    parent_page = self.get_root_page(request)
+                else:
+                    raise BadRequestError("descendant_of must be a positive integer")
+            except Page.DoesNotExist:
+                raise BadRequestError("ancestor page doesn't exist")
+
+            queryset = queryset.descendant_of(parent_page)
+
+        return queryset
+
+
+class RestrictedDescendantOfFilter(DescendantOfFilter):
+    """
+    A restricted version of DecendantOfFilter that only allows pages in the current
+    site to be specified.
+    """
+    def get_root_page(self, request):
+        return request.site.root_page
+
+    def get_page_by_id(self, request, page_id):
+        site_pages = pages_for_site(request.site)
+        return site_pages.get(id=page_id)

--- a/wagtail/api/v3/pagination.py
+++ b/wagtail/api/v3/pagination.py
@@ -1,0 +1,46 @@
+from __future__ import absolute_import, unicode_literals
+
+from collections import OrderedDict
+
+from django.conf import settings
+from rest_framework.pagination import BasePagination
+from rest_framework.response import Response
+
+from .utils import BadRequestError
+
+
+class WagtailPagination(BasePagination):
+    def paginate_queryset(self, queryset, request, view=None):
+        limit_max = getattr(settings, 'WAGTAILAPI_LIMIT_MAX', 20)
+
+        try:
+            offset = int(request.GET.get('offset', 0))
+            assert offset >= 0
+        except (ValueError, AssertionError):
+            raise BadRequestError("offset must be a positive integer")
+
+        try:
+            limit = int(request.GET.get('limit', min(20, limit_max)))
+
+            if limit > limit_max:
+                raise BadRequestError("limit cannot be higher than %d" % limit_max)
+
+            assert limit >= 0
+        except (ValueError, AssertionError):
+            raise BadRequestError("limit must be a positive integer")
+
+        start = offset
+        stop = offset + limit
+
+        self.view = view
+        self.total_count = queryset.count()
+        return queryset[start:stop]
+
+    def get_paginated_response(self, data):
+        data = OrderedDict([
+            ('meta', OrderedDict([
+                ('total_count', self.total_count),
+            ])),
+            ('items', data),
+        ])
+        return Response(data)

--- a/wagtail/api/v3/router.py
+++ b/wagtail/api/v3/router.py
@@ -1,0 +1,92 @@
+from __future__ import absolute_import, unicode_literals
+
+import functools
+
+from django.conf.urls import include, url
+
+from wagtail.utils.urlpatterns import decorate_urlpatterns
+
+
+class WagtailAPIRouter(object):
+    """
+    A class that provides routing and cross-linking for a collection
+    of API endpoints
+    """
+    def __init__(self, url_namespace):
+        self.url_namespace = url_namespace
+        self._endpoints = {}
+
+    def register_endpoint(self, name, class_):
+        self._endpoints[name] = class_
+
+    def get_model_endpoint(self, model):
+        """
+        Finds the endpoint in the API that represents a model
+
+        Returns a (name, endpoint_class) tuple. Or None if an
+        endpoint is not found.
+        """
+        for name, class_ in self._endpoints.items():
+            if issubclass(model, class_.model):
+                return name, class_
+
+    def get_model_listing_urlpath(self, model):
+        """
+        Returns a URL path (excluding scheme and hostname) to the listing
+        page of a model
+
+        Returns None if the model is not represented by any endpoints.
+        """
+        endpoint = self.get_model_endpoint(model)
+
+        if endpoint:
+            endpoint_name, endpoint_class = endpoint[0], endpoint[1]
+            url_namespace = self.url_namespace + ':' + endpoint_name
+            return endpoint_class.get_model_listing_urlpath(model, namespace=url_namespace)
+
+    def get_object_detail_urlpath(self, model, pk):
+        """
+        Returns a URL path (excluding scheme and hostname) to the detail
+        page of an object.
+
+        Returns None if the object is not represented by any endpoints.
+        """
+        endpoint = self.get_model_endpoint(model)
+
+        if endpoint:
+            endpoint_name, endpoint_class = endpoint[0], endpoint[1]
+            url_namespace = self.url_namespace + ':' + endpoint_name
+            return endpoint_class.get_object_detail_urlpath(model, pk, namespace=url_namespace)
+
+    def wrap_view(self, func):
+        @functools.wraps(func)
+        def wrapped(request, *args, **kwargs):
+            request.wagtailapi_router = self
+            return func(request, *args, **kwargs)
+
+        return wrapped
+
+    def get_urlpatterns(self):
+        urlpatterns = []
+
+        for name, class_ in self._endpoints.items():
+            pattern = url(
+                r'^{}/'.format(name),
+                include(class_.get_urlpatterns(), namespace=name)
+            )
+            urlpatterns.append(pattern)
+
+        decorate_urlpatterns(urlpatterns, self.wrap_view)
+
+        return urlpatterns
+
+    @property
+    def urls(self):
+        """
+        A shortcut to allow quick registration of the API in a URLconf.
+
+        Use with Django's include() function:
+
+            url(r'api/', include(myapi.urls)),
+        """
+        return self.get_urlpatterns(), self.url_namespace, self.url_namespace

--- a/wagtail/api/v3/serializers.py
+++ b/wagtail/api/v3/serializers.py
@@ -1,0 +1,356 @@
+from __future__ import absolute_import, unicode_literals
+
+from collections import OrderedDict
+
+from django.core.urlresolvers import NoReverseMatch
+from modelcluster.models import get_all_child_relations
+from rest_framework import relations, serializers
+from rest_framework.fields import Field, SkipField
+from taggit.managers import _TaggableManager
+
+from wagtail.wagtailcore import fields as wagtailcore_fields
+
+from .utils import get_full_url, pages_for_site
+
+
+def get_object_detail_url(context, model, pk):
+    url_path = context['router'].get_object_detail_urlpath(model, pk)
+
+    if url_path:
+        return get_full_url(context['request'], url_path)
+
+
+class TypeField(Field):
+    """
+    Serializes the "type" field of each object.
+
+    Example:
+    "type": "wagtailimages.Image"
+    """
+    def get_attribute(self, instance):
+        return instance
+
+    def to_representation(self, obj):
+        name = type(obj)._meta.app_label + '.' + type(obj).__name__
+        self.context['view'].seen_types[name] = type(obj)
+        return name
+
+
+class DetailUrlField(Field):
+    """
+    Serializes the "detail_url" field of each object.
+
+    Example:
+    "detail_url": "http://api.example.com/v1/images/1/"
+    """
+    def get_attribute(self, instance):
+        url = get_object_detail_url(self.context, type(instance), instance.pk)
+
+        if url:
+            return url
+        else:
+            # Hide the detail_url field if the object doesn't have an endpoint
+            raise SkipField
+
+    def to_representation(self, url):
+        return url
+
+
+class PageHtmlUrlField(Field):
+    """
+    Serializes the "html_url" field for pages.
+
+    Example:
+    "html_url": "http://www.example.com/blog/blog-post/"
+    """
+    def get_attribute(self, instance):
+        return instance
+
+    def to_representation(self, page):
+        try:
+            return page.full_url
+        except NoReverseMatch:
+            return None
+
+
+class PageTypeField(Field):
+    """
+    Serializes the "type" field for pages.
+
+    This takes into account the fact that we sometimes may not have the "specific"
+    page object by calling "page.specific_class" instead of looking at the object's
+    type.
+
+    Example:
+    "type": "blog.BlogPage"
+    """
+    def get_attribute(self, instance):
+        return instance
+
+    def to_representation(self, page):
+        name = page.specific_class._meta.app_label + '.' + page.specific_class.__name__
+        self.context['view'].seen_types[name] = page.specific_class
+        return name
+
+
+class RelatedField(relations.RelatedField):
+    """
+    Serializes related objects (eg, foreign keys).
+
+    Example:
+
+    "feed_image": {
+        "id": 1,
+        "meta": {
+            "type": "wagtailimages.Image",
+            "detail_url": "http://api.example.com/v1/images/1/"
+        }
+    }
+    """
+    def __init__(self, *args, **kwargs):
+        self.serializer_class = kwargs.pop('serializer_class')
+        super(RelatedField, self).__init__(*args, **kwargs)
+
+    def to_representation(self, value):
+        serializer = self.serializer_class(context=self.context)
+        return serializer.to_representation(value)
+
+
+class PageParentField(relations.RelatedField):
+    """
+    Serializes the "parent" field on Page objects.
+
+    Pages don't have a "parent" field so some extra logic is needed to find the
+    parent page. That logic is implemented in this class.
+
+    The representation is the same as the RelatedField class.
+    """
+    def get_attribute(self, instance):
+        parent = instance.get_parent()
+
+        site_pages = pages_for_site(self.context['request'].site)
+        if site_pages.filter(id=parent.id).exists():
+            return parent
+
+    def to_representation(self, value):
+        serializer_class = get_serializer_class(value.__class__, ['id', 'type', 'detail_url', 'html_url', 'title'], meta_fields=['type', 'detail_url', 'html_url'], base=PageSerializer)
+        serializer = serializer_class(context=self.context)
+        return serializer.to_representation(value)
+
+
+class ChildRelationField(Field):
+    """
+    Serializes child relations.
+
+    Child relations are any model that is related to a Page using a ParentalKey.
+    They are used for repeated fields on a page such as carousel items or related
+    links.
+
+    Child objects are part of the pages content so we nest them. The relation is
+    represented as a list of objects.
+
+    Example:
+
+    "carousel_items": [
+        {
+            "id": 1,
+            "meta": {
+                "type": "demo.MyCarouselItem"
+            },
+            "title": "First carousel item",
+            "image": {
+                "id": 1,
+                "meta": {
+                    "type": "wagtailimages.Image",
+                    "detail_url": "http://api.example.com/v1/images/1/"
+                }
+            }
+        },
+        {
+            "id": 2,
+            "meta": {
+                "type": "demo.MyCarouselItem"
+            },
+            "title": "Second carousel item (no image)",
+            "image": null
+        }
+    ]
+    """
+    def __init__(self, *args, **kwargs):
+        self.serializer_class = kwargs.pop('serializer_class')
+        super(ChildRelationField, self).__init__(*args, **kwargs)
+
+    def to_representation(self, value):
+        serializer = self.serializer_class(context=self.context)
+
+        return [
+            serializer.to_representation(child_object)
+            for child_object in value.all()
+        ]
+
+
+class StreamField(Field):
+    """
+    Serializes StreamField values.
+
+    Stream fields are stored in JSON format in the database. We reuse that in
+    the API.
+
+    Example:
+
+    "body": [
+        {
+            "type": "heading",
+            "value": {
+                "text": "Hello world!",
+                "size": "h1"
+            }
+        },
+        {
+            "type": "paragraph",
+            "value": "Some content"
+        }
+        {
+            "type": "image",
+            "value": 1
+        }
+    ]
+
+    Where "heading" is a struct block containing "text" and "size" fields, and
+    "paragraph" is a simple text block.
+
+    Note that foreign keys are represented slightly differently in stream fields
+    to other parts of the API. In stream fields, a foreign key is represented
+    by an integer (the ID of the related object) but elsewhere in the API,
+    foreign objects are nested objects with id and meta as attributes.
+    """
+    def to_representation(self, value):
+        return value.stream_block.get_api_representation(value, self.context)
+
+
+class TagsField(Field):
+    """
+    Serializes django-taggit TaggableManager fields.
+
+    These fields are a common way to link tags to objects in Wagtail. The API
+    serializes these as a list of strings taken from the name attribute of each
+    tag.
+
+    Example:
+
+    "tags": ["bird", "wagtail"]
+    """
+    def to_representation(self, value):
+        return list(value.all().order_by('name').values_list('name', flat=True))
+
+
+class BaseSerializer(serializers.ModelSerializer):
+    # Add StreamField to serializer_field_mapping
+    serializer_field_mapping = serializers.ModelSerializer.serializer_field_mapping.copy()
+    serializer_field_mapping.update({
+        wagtailcore_fields.StreamField: StreamField,
+    })
+    serializer_related_field = RelatedField
+
+    # Meta fields
+    type = TypeField(read_only=True)
+    detail_url = DetailUrlField(read_only=True)
+
+    def to_representation(self, instance):
+        data = OrderedDict()
+        fields = [field for field in self.fields.values() if not field.write_only]
+
+        # Split meta fields from core fields
+        meta_fields = [field for field in fields if field.field_name in self.meta_fields]
+        fields = [field for field in fields if field.field_name not in self.meta_fields]
+
+        # Make sure id is always first. This will be filled in later
+        if 'id' in [field.field_name for field in fields]:
+            data['id'] = None
+
+        # Serialise meta fields
+        meta = OrderedDict()
+        for field in meta_fields:
+            try:
+                attribute = field.get_attribute(instance)
+            except SkipField:
+                continue
+
+            if attribute is None:
+                # We skip `to_representation` for `None` values so that
+                # fields do not have to explicitly deal with that case.
+                meta[field.field_name] = None
+            else:
+                meta[field.field_name] = field.to_representation(attribute)
+
+        if meta:
+            data['meta'] = meta
+
+        # Serialise core fields
+        for field in fields:
+            try:
+                attribute = field.get_attribute(instance)
+            except SkipField:
+                continue
+
+            if attribute is None:
+                # We skip `to_representation` for `None` values so that
+                # fields do not have to explicitly deal with that case.
+                data[field.field_name] = None
+            else:
+                data[field.field_name] = field.to_representation(attribute)
+
+        return data
+
+    def build_property_field(self, field_name, model_class):
+        # TaggableManager is not a Django field so it gets treated as a property
+        field = getattr(model_class, field_name)
+        if isinstance(field, _TaggableManager):
+            return TagsField, {}
+
+        return super(BaseSerializer, self).build_property_field(field_name, model_class)
+
+    def build_relational_field(self, field_name, relation_info):
+        field_class, field_kwargs = super(BaseSerializer, self).build_relational_field(field_name, relation_info)
+        field_kwargs['serializer_class'] = self.child_serializer_classes[field_name]
+        return field_class, field_kwargs
+
+
+class PageSerializer(BaseSerializer):
+    type = PageTypeField(read_only=True)
+    html_url = PageHtmlUrlField(read_only=True)
+    parent = PageParentField(read_only=True)
+
+    def build_relational_field(self, field_name, relation_info):
+        # Find all relation fields that point to child class and make them use
+        # the ChildRelationField class.
+        if relation_info.to_many:
+            model = getattr(self.Meta, 'model')
+            child_relations = {
+                child_relation.field.rel.related_name: child_relation.related_model
+                for child_relation in get_all_child_relations(model)
+            }
+
+            if field_name in child_relations and field_name in self.child_serializer_classes:
+                return ChildRelationField, {'serializer_class': self.child_serializer_classes[field_name]}
+
+        return super(PageSerializer, self).build_relational_field(field_name, relation_info)
+
+
+def get_serializer_class(model, field_names, meta_fields, field_serializer_overrides=None, child_serializer_classes=None, base=BaseSerializer):
+    model_ = model
+
+    class Meta:
+        model = model_
+        fields = list(field_names)
+
+    attrs = {
+        'Meta': Meta,
+        'meta_fields': list(meta_fields),
+        'child_serializer_classes': child_serializer_classes or {},
+    }
+
+    if field_serializer_overrides:
+        attrs.update(field_serializer_overrides)
+
+    return type(str(model_.__name__ + 'Serializer'), (base, ), attrs)

--- a/wagtail/api/v3/serializers.py
+++ b/wagtail/api/v3/serializers.py
@@ -133,7 +133,7 @@ class PageParentField(relations.RelatedField):
             return parent
 
     def to_representation(self, value):
-        serializer_class = get_serializer_class(value.__class__, ['id', 'type', 'detail_url', 'html_url', 'title'], meta_fields=['type', 'detail_url', 'html_url'], base=PageSerializer)
+        serializer_class = get_serializer_class(value.__class__, ['id', 'type', 'detail_url', 'html_url', 'title', 'slug'], meta_fields=['id', 'type', 'detail_url', 'html_url'], base=PageSerializer)
         serializer = serializer_class(context=self.context)
         return serializer.to_representation(value)
 
@@ -263,10 +263,6 @@ class BaseSerializer(serializers.ModelSerializer):
         # Split meta fields from core fields
         meta_fields = [field for field in fields if field.field_name in self.meta_fields]
         fields = [field for field in fields if field.field_name not in self.meta_fields]
-
-        # Make sure id is always first. This will be filled in later
-        if 'id' in [field.field_name for field in fields]:
-            data['id'] = None
 
         # Serialise meta fields
         meta = OrderedDict()

--- a/wagtail/api/v3/signal_handlers.py
+++ b/wagtail/api/v3/signal_handlers.py
@@ -1,0 +1,57 @@
+from __future__ import absolute_import, unicode_literals
+
+from django.core.urlresolvers import reverse
+from django.db.models.signals import post_delete, post_save
+
+from wagtail.contrib.wagtailfrontendcache.utils import purge_url_from_cache
+from wagtail.wagtailcore.models import get_page_models
+from wagtail.wagtailcore.signals import page_published, page_unpublished
+from wagtail.wagtaildocs.models import get_document_model
+from wagtail.wagtailimages import get_image_model
+
+from .utils import get_base_url
+
+
+def purge_page_from_cache(instance, **kwargs):
+    base_url = get_base_url()
+    purge_url_from_cache(base_url + reverse('wagtailapi_v3:pages:detail', args=(instance.id, )))
+
+
+def purge_image_from_cache(instance, **kwargs):
+    if not kwargs.get('created', False):
+        base_url = get_base_url()
+        purge_url_from_cache(base_url + reverse('wagtailapi_v3:images:detail', args=(instance.id, )))
+
+
+def purge_document_from_cache(instance, **kwargs):
+    if not kwargs.get('created', False):
+        base_url = get_base_url()
+        purge_url_from_cache(base_url + reverse('wagtailapi_v3:documents:detail', args=(instance.id, )))
+
+
+def register_signal_handlers():
+    Image = get_image_model()
+    Document = get_document_model()
+
+    for model in get_page_models():
+        page_published.connect(purge_page_from_cache, sender=model)
+        page_unpublished.connect(purge_page_from_cache, sender=model)
+
+    post_save.connect(purge_image_from_cache, sender=Image)
+    post_delete.connect(purge_image_from_cache, sender=Image)
+    post_save.connect(purge_document_from_cache, sender=Document)
+    post_delete.connect(purge_document_from_cache, sender=Document)
+
+
+def unregister_signal_handlers():
+    Image = get_image_model()
+    Document = get_document_model()
+
+    for model in get_page_models():
+        page_published.disconnect(purge_page_from_cache, sender=model)
+        page_unpublished.disconnect(purge_page_from_cache, sender=model)
+
+    post_save.disconnect(purge_image_from_cache, sender=Image)
+    post_delete.disconnect(purge_image_from_cache, sender=Image)
+    post_save.disconnect(purge_document_from_cache, sender=Document)
+    post_delete.disconnect(purge_document_from_cache, sender=Document)

--- a/wagtail/api/v3/tests/test_documents.py
+++ b/wagtail/api/v3/tests/test_documents.py
@@ -1,0 +1,513 @@
+from __future__ import absolute_import, unicode_literals
+
+import json
+
+import mock
+from django.core.urlresolvers import reverse
+from django.test import TestCase
+from django.test.utils import override_settings
+
+from wagtail.api.v3 import signal_handlers
+from wagtail.wagtaildocs.models import get_document_model
+
+
+class TestDocumentListing(TestCase):
+    fixtures = ['demosite.json']
+
+    def get_response(self, **params):
+        return self.client.get(reverse('wagtailapi_v3:documents:listing'), params)
+
+    def get_document_id_list(self, content):
+        return [document['id'] for document in content['items']]
+
+
+    # BASIC TESTS
+
+    def test_basic(self):
+        response = self.get_response()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response['Content-type'], 'application/json')
+
+        # Will crash if the JSON is invalid
+        content = json.loads(response.content.decode('UTF-8'))
+
+        # Check that the meta section is there
+        self.assertIn('meta', content)
+        self.assertIsInstance(content['meta'], dict)
+
+        # Check that the total count is there and correct
+        self.assertIn('total_count', content['meta'])
+        self.assertIsInstance(content['meta']['total_count'], int)
+        self.assertEqual(content['meta']['total_count'], get_document_model().objects.count())
+
+        # Check that the items section is there
+        self.assertIn('items', content)
+        self.assertIsInstance(content['items'], list)
+
+        # Check that each document has a meta section with type and detail_url attributes
+        for document in content['items']:
+            self.assertIn('meta', document)
+            self.assertIsInstance(document['meta'], dict)
+            self.assertEqual(set(document['meta'].keys()), {'type', 'detail_url', 'download_url', 'tags'})
+
+            # Type should always be wagtaildocs.Document
+            self.assertEqual(document['meta']['type'], 'wagtaildocs.Document')
+
+            # Check detail_url
+            self.assertEqual(document['meta']['detail_url'], 'http://localhost/api/v3beta/documents/%d/' % document['id'])
+
+            # Check download_url
+            self.assertTrue(document['meta']['download_url'].startswith('http://localhost/documents/%d/' % document['id']))
+
+
+    # FIELDS
+
+    def test_fields_default(self):
+        response = self.get_response()
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for document in content['items']:
+            self.assertEqual(set(document.keys()), {'id', 'meta', 'title'})
+            self.assertEqual(set(document['meta'].keys()), {'type', 'detail_url', 'download_url', 'tags'})
+
+    def test_fields(self):
+        response = self.get_response(fields='title')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for document in content['items']:
+            self.assertEqual(set(document.keys()), {'id', 'meta', 'title'})
+            self.assertEqual(set(document['meta'].keys()), {'type', 'detail_url', 'download_url', 'tags'})
+
+    def test_remove_fields(self):
+        response = self.get_response(fields='-title')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for document in content['items']:
+            self.assertEqual(set(document.keys()), {'id', 'meta'})
+
+    def test_remove_meta_fields(self):
+        response = self.get_response(fields='-download_url')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for document in content['items']:
+            self.assertEqual(set(document.keys()), {'id', 'meta', 'title'})
+            self.assertEqual(set(document['meta'].keys()), {'type', 'detail_url', 'tags'})
+
+    def test_remove_all_meta_fields(self):
+        response = self.get_response(fields='-type,-detail_url,-tags,-download_url')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for document in content['items']:
+            self.assertEqual(set(document.keys()), {'id', 'title'})
+
+    def test_remove_id_field(self):
+        response = self.get_response(fields='-id')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for document in content['items']:
+            self.assertEqual(set(document.keys()), {'meta', 'title'})
+
+    def test_all_fields(self):
+        response = self.get_response(fields='*')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for document in content['items']:
+            self.assertEqual(set(document.keys()), {'id', 'meta', 'title'})
+            self.assertEqual(set(document['meta'].keys()), {'type', 'detail_url', 'tags', 'download_url'})
+
+    def test_all_fields_then_remove_something(self):
+        response = self.get_response(fields='*,-title,-download_url')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for document in content['items']:
+            self.assertEqual(set(document.keys()), {'id', 'meta'})
+            self.assertEqual(set(document['meta'].keys()), {'type', 'detail_url', 'tags'})
+
+    def test_fields_tags(self):
+        response = self.get_response(fields='tags')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for document in content['items']:
+            self.assertIsInstance(document['meta']['tags'], list)
+
+    def test_star_in_wrong_position_gives_error(self):
+        response = self.get_response(fields='title,*')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "fields error: '*' must be in the first position"})
+
+    def test_fields_which_are_not_in_api_fields_gives_error(self):
+        response = self.get_response(fields='uploaded_by_user')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "unknown fields: uploaded_by_user"})
+
+    def test_fields_unknown_field_gives_error(self):
+        response = self.get_response(fields='123,title,abc')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "unknown fields: 123, abc"})
+
+    def test_fields_remove_unknown_field_gives_error(self):
+        response = self.get_response(fields='-123,-title,-abc')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "unknown fields: 123, abc"})
+
+
+    # FILTERING
+
+    def test_filtering_exact_filter(self):
+        response = self.get_response(title='James Joyce')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        document_id_list = self.get_document_id_list(content)
+        self.assertEqual(document_id_list, [2])
+
+    def test_filtering_on_id(self):
+        response = self.get_response(id=10)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        document_id_list = self.get_document_id_list(content)
+        self.assertEqual(document_id_list, [10])
+
+    def test_filtering_tags(self):
+        get_document_model().objects.get(id=3).tags.add('test')
+
+        response = self.get_response(tags='test')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        document_id_list = self.get_document_id_list(content)
+        self.assertEqual(document_id_list, [3])
+
+    def test_filtering_unknown_field_gives_error(self):
+        response = self.get_response(not_a_field='abc')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "query parameter is not an operation or a recognised field: not_a_field"})
+
+
+    # ORDERING
+
+    def test_ordering_by_title(self):
+        response = self.get_response(order='title')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        document_id_list = self.get_document_id_list(content)
+        self.assertEqual(document_id_list, [3, 12, 10, 2, 7, 8, 5, 4, 1, 11, 9, 6])
+
+    def test_ordering_by_title_backwards(self):
+        response = self.get_response(order='-title')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        document_id_list = self.get_document_id_list(content)
+        self.assertEqual(document_id_list, [6, 9, 11, 1, 4, 5, 8, 7, 2, 10, 12, 3])
+
+    def test_ordering_by_random(self):
+        response_1 = self.get_response(order='random')
+        content_1 = json.loads(response_1.content.decode('UTF-8'))
+        document_id_list_1 = self.get_document_id_list(content_1)
+
+        response_2 = self.get_response(order='random')
+        content_2 = json.loads(response_2.content.decode('UTF-8'))
+        document_id_list_2 = self.get_document_id_list(content_2)
+
+        self.assertNotEqual(document_id_list_1, document_id_list_2)
+
+    def test_ordering_by_random_backwards_gives_error(self):
+        response = self.get_response(order='-random')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "cannot order by 'random' (unknown field)"})
+
+    def test_ordering_by_random_with_offset_gives_error(self):
+        response = self.get_response(order='random', offset=10)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "random ordering with offset is not supported"})
+
+    def test_ordering_by_unknown_field_gives_error(self):
+        response = self.get_response(order='not_a_field')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "cannot order by 'not_a_field' (unknown field)"})
+
+
+    # LIMIT
+
+    def test_limit_only_two_items_returned(self):
+        response = self.get_response(limit=2)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(len(content['items']), 2)
+
+    def test_limit_total_count(self):
+        response = self.get_response(limit=2)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        # The total count must not be affected by "limit"
+        self.assertEqual(content['meta']['total_count'], get_document_model().objects.count())
+
+    def test_limit_not_integer_gives_error(self):
+        response = self.get_response(limit='abc')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "limit must be a positive integer"})
+
+    def test_limit_too_high_gives_error(self):
+        response = self.get_response(limit=1000)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "limit cannot be higher than 20"})
+
+    @override_settings(WAGTAILAPI_LIMIT_MAX=10)
+    def test_limit_maximum_can_be_changed(self):
+        response = self.get_response(limit=20)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "limit cannot be higher than 10"})
+
+    @override_settings(WAGTAILAPI_LIMIT_MAX=2)
+    def test_limit_default_changes_with_max(self):
+        # The default limit is 20. If WAGTAILAPI_LIMIT_MAX is less than that,
+        # the default should change accordingly.
+        response = self.get_response()
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(len(content['items']), 2)
+
+
+    # OFFSET
+
+    def test_offset_5_usually_appears_5th_in_list(self):
+        response = self.get_response()
+        content = json.loads(response.content.decode('UTF-8'))
+        document_id_list = self.get_document_id_list(content)
+        self.assertEqual(document_id_list.index(5), 4)
+
+    def test_offset_5_moves_after_offset(self):
+        response = self.get_response(offset=4)
+        content = json.loads(response.content.decode('UTF-8'))
+        document_id_list = self.get_document_id_list(content)
+        self.assertEqual(document_id_list.index(5), 0)
+
+    def test_offset_total_count(self):
+        response = self.get_response(offset=10)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        # The total count must not be affected by "offset"
+        self.assertEqual(content['meta']['total_count'], get_document_model().objects.count())
+
+    def test_offset_not_integer_gives_error(self):
+        response = self.get_response(offset='abc')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "offset must be a positive integer"})
+
+
+    # SEARCH
+
+    def test_search_for_james_joyce(self):
+        response = self.get_response(search='james')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        document_id_list = self.get_document_id_list(content)
+
+        self.assertEqual(set(document_id_list), set([2]))
+
+    def test_search_with_order(self):
+        response = self.get_response(search='james', order='title')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        document_id_list = self.get_document_id_list(content)
+
+        self.assertEqual(document_id_list, [2])
+
+    @override_settings(WAGTAILAPI_SEARCH_ENABLED=False)
+    def test_search_when_disabled_gives_error(self):
+        response = self.get_response(search='james')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "search is disabled"})
+
+    def test_search_when_filtering_by_tag_gives_error(self):
+        response = self.get_response(search='james', tags='wagtail')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "filtering by tag with a search query is not supported"})
+
+
+class TestDocumentDetail(TestCase):
+    fixtures = ['demosite.json']
+
+    def get_response(self, image_id, **params):
+        return self.client.get(reverse('wagtailapi_v3:documents:detail', args=(image_id, )), params)
+
+    def test_basic(self):
+        response = self.get_response(1)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response['Content-type'], 'application/json')
+
+        # Will crash if the JSON is invalid
+        content = json.loads(response.content.decode('UTF-8'))
+
+        # Check the id field
+        self.assertIn('id', content)
+        self.assertEqual(content['id'], 1)
+
+        # Check that the meta section is there
+        self.assertIn('meta', content)
+        self.assertIsInstance(content['meta'], dict)
+
+        # Check the meta type
+        self.assertIn('type', content['meta'])
+        self.assertEqual(content['meta']['type'], 'wagtaildocs.Document')
+
+        # Check the meta detail_url
+        self.assertIn('detail_url', content['meta'])
+        self.assertEqual(content['meta']['detail_url'], 'http://localhost/api/v3beta/documents/1/')
+
+        # Check the meta download_url
+        self.assertIn('download_url', content['meta'])
+        self.assertEqual(content['meta']['download_url'], 'http://localhost/documents/1/wagtail_by_markyharky.jpg')
+
+        # Check the title field
+        self.assertIn('title', content)
+        self.assertEqual(content['title'], "Wagtail by mark Harkin")
+
+        # Check the tags field
+        self.assertIn('tags', content['meta'])
+        self.assertEqual(content['meta']['tags'], [])
+
+    def test_tags(self):
+        get_document_model().objects.get(id=1).tags.add('hello')
+        get_document_model().objects.get(id=1).tags.add('world')
+
+        response = self.get_response(1)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertIn('tags', content['meta'])
+        self.assertEqual(content['meta']['tags'], ['hello', 'world'])
+
+    @override_settings(WAGTAILAPI_BASE_URL='http://api.example.com/')
+    def test_download_url_with_custom_base_url(self):
+        response = self.get_response(1)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertIn('download_url', content['meta'])
+        self.assertEqual(content['meta']['download_url'], 'http://api.example.com/documents/1/wagtail_by_markyharky.jpg')
+
+    # FIELDS
+
+    def test_remove_fields(self):
+        response = self.get_response(2, fields='-title')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertIn('id', set(content.keys()))
+        self.assertNotIn('title', set(content.keys()))
+
+    def test_remove_meta_fields(self):
+        response = self.get_response(2, fields='-download_url')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertIn('detail_url', set(content['meta'].keys()))
+        self.assertNotIn('download_url', set(content['meta'].keys()))
+
+    def test_remove_id_field(self):
+        response = self.get_response(2, fields='-id')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertIn('title', set(content.keys()))
+        self.assertNotIn('id', set(content.keys()))
+
+    def test_remove_all_fields(self):
+        response = self.get_response(2, fields='_,id,type')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(set(content.keys()), {'id', 'meta'})
+        self.assertEqual(set(content['meta'].keys()), {'type'})
+
+    def test_star_in_wrong_position_gives_error(self):
+        response = self.get_response(2, fields='title,*')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "fields error: '*' must be in the first position"})
+
+    def test_fields_which_are_not_in_api_fields_gives_error(self):
+        response = self.get_response(2, fields='path')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "unknown fields: path"})
+
+    def test_fields_unknown_field_gives_error(self):
+        response = self.get_response(2, fields='123,title,abc')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "unknown fields: 123, abc"})
+
+    def test_fields_remove_unknown_field_gives_error(self):
+        response = self.get_response(2, fields='-123,-title,-abc')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "unknown fields: 123, abc"})
+
+    def test_nested_fields_on_non_relational_field_gives_error(self):
+        response = self.get_response(2, fields='title(foo,bar)')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "'title' does not support nested fields"})
+
+
+@override_settings(
+    WAGTAILFRONTENDCACHE={
+        'varnish': {
+            'BACKEND': 'wagtail.contrib.wagtailfrontendcache.backends.HTTPBackend',
+            'LOCATION': 'http://localhost:8000',
+        },
+    },
+    WAGTAILAPI_BASE_URL='http://api.example.com',
+)
+@mock.patch('wagtail.contrib.wagtailfrontendcache.backends.HTTPBackend.purge')
+class TestDocumentCacheInvalidation(TestCase):
+    fixtures = ['demosite.json']
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestDocumentCacheInvalidation, cls).setUpClass()
+        signal_handlers.register_signal_handlers()
+
+    @classmethod
+    def tearDownClass(cls):
+        super(TestDocumentCacheInvalidation, cls).tearDownClass()
+        signal_handlers.unregister_signal_handlers()
+
+    def test_resave_document_purges(self, purge):
+        get_document_model().objects.get(id=5).save()
+
+        purge.assert_any_call('http://api.example.com/api/v3beta/documents/5/')
+
+    def test_delete_document_purges(self, purge):
+        get_document_model().objects.get(id=5).delete()
+
+        purge.assert_any_call('http://api.example.com/api/v3beta/documents/5/')

--- a/wagtail/api/v3/tests/test_images.py
+++ b/wagtail/api/v3/tests/test_images.py
@@ -1,0 +1,507 @@
+from __future__ import absolute_import, unicode_literals
+
+import json
+
+import mock
+from django.core.urlresolvers import reverse
+from django.test import TestCase
+from django.test.utils import override_settings
+
+from wagtail.api.v3 import signal_handlers
+from wagtail.wagtailimages import get_image_model
+
+
+class TestImageListing(TestCase):
+    fixtures = ['demosite.json']
+
+    def get_response(self, **params):
+        return self.client.get(reverse('wagtailapi_v3:images:listing'), params)
+
+    def get_image_id_list(self, content):
+        return [image['id'] for image in content['items']]
+
+
+    # BASIC TESTS
+
+    def test_basic(self):
+        response = self.get_response()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response['Content-type'], 'application/json')
+
+        # Will crash if the JSON is invalid
+        content = json.loads(response.content.decode('UTF-8'))
+
+        # Check that the meta section is there
+        self.assertIn('meta', content)
+        self.assertIsInstance(content['meta'], dict)
+
+        # Check that the total count is there and correct
+        self.assertIn('total_count', content['meta'])
+        self.assertIsInstance(content['meta']['total_count'], int)
+        self.assertEqual(content['meta']['total_count'], get_image_model().objects.count())
+
+        # Check that the items section is there
+        self.assertIn('items', content)
+        self.assertIsInstance(content['items'], list)
+
+        # Check that each image has a meta section with type and detail_url attributes
+        for image in content['items']:
+            self.assertIn('meta', image)
+            self.assertIsInstance(image['meta'], dict)
+            self.assertEqual(set(image['meta'].keys()), {'type', 'detail_url', 'tags'})
+
+            # Type should always be wagtailimages.Image
+            self.assertEqual(image['meta']['type'], 'wagtailimages.Image')
+
+            # Check detail url
+            self.assertEqual(image['meta']['detail_url'], 'http://localhost/api/v3beta/images/%d/' % image['id'])
+
+
+    #  FIELDS
+
+    def test_fields_default(self):
+        response = self.get_response()
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for image in content['items']:
+            self.assertEqual(set(image.keys()), {'id', 'meta', 'title'})
+            self.assertEqual(set(image['meta'].keys()), {'type', 'detail_url', 'tags'})
+
+    def test_fields(self):
+        response = self.get_response(fields='width,height')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for image in content['items']:
+            self.assertEqual(set(image.keys()), {'id', 'meta', 'title', 'width', 'height'})
+            self.assertEqual(set(image['meta'].keys()), {'type', 'detail_url', 'tags'})
+
+    def test_remove_fields(self):
+        response = self.get_response(fields='-title')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for image in content['items']:
+            self.assertEqual(set(image.keys()), {'id', 'meta'})
+
+    def test_remove_meta_fields(self):
+        response = self.get_response(fields='-tags')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for image in content['items']:
+            self.assertEqual(set(image.keys()), {'id', 'meta', 'title'})
+            self.assertEqual(set(image['meta'].keys()), {'type', 'detail_url'})
+
+    def test_remove_all_meta_fields(self):
+        response = self.get_response(fields='-type,-detail_url,-tags')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for image in content['items']:
+            self.assertEqual(set(image.keys()), {'id', 'title'})
+
+    def test_remove_id_field(self):
+        response = self.get_response(fields='-id')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for image in content['items']:
+            self.assertEqual(set(image.keys()), {'meta', 'title'})
+
+    def test_all_fields(self):
+        response = self.get_response(fields='*')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for image in content['items']:
+            self.assertEqual(set(image.keys()), {'id', 'meta', 'title', 'width', 'height'})
+            self.assertEqual(set(image['meta'].keys()), {'type', 'detail_url', 'tags'})
+
+    def test_all_fields_then_remove_something(self):
+        response = self.get_response(fields='*,-title,-tags')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for image in content['items']:
+            self.assertEqual(set(image.keys()), {'id', 'meta', 'width', 'height'})
+            self.assertEqual(set(image['meta'].keys()), {'type', 'detail_url'})
+
+    def test_fields_tags(self):
+        response = self.get_response(fields='tags')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for image in content['items']:
+            self.assertEqual(set(image.keys()), {'id', 'meta', 'title'})
+            self.assertEqual(set(image['meta'].keys()), {'type', 'detail_url', 'tags'})
+            self.assertIsInstance(image['meta']['tags'], list)
+
+    def test_star_in_wrong_position_gives_error(self):
+        response = self.get_response(fields='title,*')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "fields error: '*' must be in the first position"})
+
+    def test_fields_which_are_not_in_api_fields_gives_error(self):
+        response = self.get_response(fields='uploaded_by_user')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "unknown fields: uploaded_by_user"})
+
+    def test_fields_unknown_field_gives_error(self):
+        response = self.get_response(fields='123,title,abc')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "unknown fields: 123, abc"})
+
+    def test_fields_remove_unknown_field_gives_error(self):
+        response = self.get_response(fields='-123,-title,-abc')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "unknown fields: 123, abc"})
+
+
+    # FILTERING
+
+    def test_filtering_exact_filter(self):
+        response = self.get_response(title='James Joyce')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        image_id_list = self.get_image_id_list(content)
+        self.assertEqual(image_id_list, [5])
+
+    def test_filtering_on_id(self):
+        response = self.get_response(id=10)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        image_id_list = self.get_image_id_list(content)
+        self.assertEqual(image_id_list, [10])
+
+    def test_filtering_tags(self):
+        get_image_model().objects.get(id=6).tags.add('test')
+
+        response = self.get_response(tags='test')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        image_id_list = self.get_image_id_list(content)
+        self.assertEqual(image_id_list, [6])
+
+    def test_filtering_unknown_field_gives_error(self):
+        response = self.get_response(not_a_field='abc')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "query parameter is not an operation or a recognised field: not_a_field"})
+
+
+    # ORDERING
+
+    def test_ordering_by_title(self):
+        response = self.get_response(order='title')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        image_id_list = self.get_image_id_list(content)
+        self.assertEqual(image_id_list, [6, 15, 13, 5, 10, 11, 8, 7, 4, 14, 12, 9])
+
+    def test_ordering_by_title_backwards(self):
+        response = self.get_response(order='-title')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        image_id_list = self.get_image_id_list(content)
+        self.assertEqual(image_id_list, [9, 12, 14, 4, 7, 8, 11, 10, 5, 13, 15, 6])
+
+    def test_ordering_by_random(self):
+        response_1 = self.get_response(order='random')
+        content_1 = json.loads(response_1.content.decode('UTF-8'))
+        image_id_list_1 = self.get_image_id_list(content_1)
+
+        response_2 = self.get_response(order='random')
+        content_2 = json.loads(response_2.content.decode('UTF-8'))
+        image_id_list_2 = self.get_image_id_list(content_2)
+
+        self.assertNotEqual(image_id_list_1, image_id_list_2)
+
+    def test_ordering_by_random_backwards_gives_error(self):
+        response = self.get_response(order='-random')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "cannot order by 'random' (unknown field)"})
+
+    def test_ordering_by_random_with_offset_gives_error(self):
+        response = self.get_response(order='random', offset=10)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "random ordering with offset is not supported"})
+
+    def test_ordering_by_unknown_field_gives_error(self):
+        response = self.get_response(order='not_a_field')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "cannot order by 'not_a_field' (unknown field)"})
+
+
+    # LIMIT
+
+    def test_limit_only_two_items_returned(self):
+        response = self.get_response(limit=2)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(len(content['items']), 2)
+
+    def test_limit_total_count(self):
+        response = self.get_response(limit=2)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        # The total count must not be affected by "limit"
+        self.assertEqual(content['meta']['total_count'], get_image_model().objects.count())
+
+    def test_limit_not_integer_gives_error(self):
+        response = self.get_response(limit='abc')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "limit must be a positive integer"})
+
+    def test_limit_too_high_gives_error(self):
+        response = self.get_response(limit=1000)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "limit cannot be higher than 20"})
+
+    @override_settings(WAGTAILAPI_LIMIT_MAX=10)
+    def test_limit_maximum_can_be_changed(self):
+        response = self.get_response(limit=20)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "limit cannot be higher than 10"})
+
+    @override_settings(WAGTAILAPI_LIMIT_MAX=2)
+    def test_limit_default_changes_with_max(self):
+        # The default limit is 20. If WAGTAILAPI_LIMIT_MAX is less than that,
+        # the default should change accordingly.
+        response = self.get_response()
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(len(content['items']), 2)
+
+
+    # OFFSET
+
+    def test_offset_10_usually_appears_7th_in_list(self):
+        response = self.get_response()
+        content = json.loads(response.content.decode('UTF-8'))
+        image_id_list = self.get_image_id_list(content)
+        self.assertEqual(image_id_list.index(10), 6)
+
+    def test_offset_10_moves_after_offset(self):
+        response = self.get_response(offset=4)
+        content = json.loads(response.content.decode('UTF-8'))
+        image_id_list = self.get_image_id_list(content)
+        self.assertEqual(image_id_list.index(10), 2)
+
+    def test_offset_total_count(self):
+        response = self.get_response(offset=10)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        # The total count must not be affected by "offset"
+        self.assertEqual(content['meta']['total_count'], get_image_model().objects.count())
+
+    def test_offset_not_integer_gives_error(self):
+        response = self.get_response(offset='abc')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "offset must be a positive integer"})
+
+
+    # SEARCH
+
+    def test_search_for_james_joyce(self):
+        response = self.get_response(search='james')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        image_id_list = self.get_image_id_list(content)
+
+        self.assertEqual(set(image_id_list), set([5]))
+
+    def test_search_with_order(self):
+        response = self.get_response(search='james', order='title')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        image_id_list = self.get_image_id_list(content)
+
+        self.assertEqual(image_id_list, [5])
+
+    @override_settings(WAGTAILAPI_SEARCH_ENABLED=False)
+    def test_search_when_disabled_gives_error(self):
+        response = self.get_response(search='james')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "search is disabled"})
+
+    def test_search_when_filtering_by_tag_gives_error(self):
+        response = self.get_response(search='james', tags='wagtail')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "filtering by tag with a search query is not supported"})
+
+
+class TestImageDetail(TestCase):
+    fixtures = ['demosite.json']
+
+    def get_response(self, image_id, **params):
+        return self.client.get(reverse('wagtailapi_v3:images:detail', args=(image_id, )), params)
+
+    def test_basic(self):
+        response = self.get_response(5)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response['Content-type'], 'application/json')
+
+        # Will crash if the JSON is invalid
+        content = json.loads(response.content.decode('UTF-8'))
+
+        # Check the id field
+        self.assertIn('id', content)
+        self.assertEqual(content['id'], 5)
+
+        # Check that the meta section is there
+        self.assertIn('meta', content)
+        self.assertIsInstance(content['meta'], dict)
+
+        # Check the meta type
+        self.assertIn('type', content['meta'])
+        self.assertEqual(content['meta']['type'], 'wagtailimages.Image')
+
+        # Check the meta detail_url
+        self.assertIn('detail_url', content['meta'])
+        self.assertEqual(content['meta']['detail_url'], 'http://localhost/api/v3beta/images/5/')
+
+        # Check the title field
+        self.assertIn('title', content)
+        self.assertEqual(content['title'], "James Joyce")
+
+        # Check the width and height fields
+        self.assertIn('width', content)
+        self.assertIn('height', content)
+        self.assertEqual(content['width'], 500)
+        self.assertEqual(content['height'], 392)
+
+        # Check the tags field
+        self.assertIn('tags', content['meta'])
+        self.assertEqual(content['meta']['tags'], [])
+
+    def test_tags(self):
+        image = get_image_model().objects.get(id=5)
+        image.tags.add('hello')
+        image.tags.add('world')
+
+        response = self.get_response(5)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertIn('tags', content['meta'])
+        self.assertEqual(content['meta']['tags'], ['hello', 'world'])
+
+    # FIELDS
+
+    def test_remove_fields(self):
+        response = self.get_response(5, fields='-title')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertIn('id', set(content.keys()))
+        self.assertNotIn('title', set(content.keys()))
+
+    def test_remove_meta_fields(self):
+        response = self.get_response(5, fields='-type')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertIn('detail_url', set(content['meta'].keys()))
+        self.assertNotIn('type', set(content['meta'].keys()))
+
+    def test_remove_id_field(self):
+        response = self.get_response(5, fields='-id')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertIn('title', set(content.keys()))
+        self.assertNotIn('id', set(content.keys()))
+
+    def test_remove_all_fields(self):
+        response = self.get_response(5, fields='_,id,type')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(set(content.keys()), {'id', 'meta'})
+        self.assertEqual(set(content['meta'].keys()), {'type'})
+
+    def test_star_in_wrong_position_gives_error(self):
+        response = self.get_response(5, fields='title,*')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "fields error: '*' must be in the first position"})
+
+    def test_fields_which_are_not_in_api_fields_gives_error(self):
+        response = self.get_response(5, fields='path')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "unknown fields: path"})
+
+    def test_fields_unknown_field_gives_error(self):
+        response = self.get_response(5, fields='123,title,abc')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "unknown fields: 123, abc"})
+
+    def test_fields_remove_unknown_field_gives_error(self):
+        response = self.get_response(5, fields='-123,-title,-abc')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "unknown fields: 123, abc"})
+
+    def test_nested_fields_on_non_relational_field_gives_error(self):
+        response = self.get_response(5, fields='title(foo,bar)')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "'title' does not support nested fields"})
+
+
+@override_settings(
+    WAGTAILFRONTENDCACHE={
+        'varnish': {
+            'BACKEND': 'wagtail.contrib.wagtailfrontendcache.backends.HTTPBackend',
+            'LOCATION': 'http://localhost:8000',
+        },
+    },
+    WAGTAILAPI_BASE_URL='http://api.example.com',
+)
+@mock.patch('wagtail.contrib.wagtailfrontendcache.backends.HTTPBackend.purge')
+class TestImageCacheInvalidation(TestCase):
+    fixtures = ['demosite.json']
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestImageCacheInvalidation, cls).setUpClass()
+        signal_handlers.register_signal_handlers()
+
+    @classmethod
+    def tearDownClass(cls):
+        super(TestImageCacheInvalidation, cls).tearDownClass()
+        signal_handlers.unregister_signal_handlers()
+
+    def test_resave_image_purges(self, purge):
+        get_image_model().objects.get(id=5).save()
+
+        purge.assert_any_call('http://api.example.com/api/v3beta/images/5/')
+
+    def test_delete_image_purges(self, purge):
+        get_image_model().objects.get(id=5).delete()
+
+        purge.assert_any_call('http://api.example.com/api/v3beta/images/5/')

--- a/wagtail/api/v3/tests/test_pages.py
+++ b/wagtail/api/v3/tests/test_pages.py
@@ -1,0 +1,1100 @@
+from __future__ import absolute_import, unicode_literals
+
+import collections
+import json
+
+import mock
+from django.core.urlresolvers import reverse
+from django.test import TestCase
+from django.test.utils import override_settings
+
+from wagtail.api.v3 import signal_handlers
+from wagtail.tests.demosite import models
+from wagtail.tests.testapp.models import StreamPage
+from wagtail.wagtailcore.models import Page
+
+
+def get_total_page_count():
+    # Need to take away 1 as the root page is invisible over the API
+    return Page.objects.live().public().count() - 1
+
+
+class TestPageListing(TestCase):
+    fixtures = ['demosite.json']
+
+    def get_response(self, **params):
+        return self.client.get(reverse('wagtailapi_v3:pages:listing'), params)
+
+    def get_page_id_list(self, content):
+        return [page['id'] for page in content['items']]
+
+
+    # BASIC TESTS
+
+    def test_basic(self):
+        response = self.get_response()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response['Content-type'], 'application/json')
+
+        # Will crash if the JSON is invalid
+        content = json.loads(response.content.decode('UTF-8'))
+
+        # Check that the meta section is there
+        self.assertIn('meta', content)
+        self.assertIsInstance(content['meta'], dict)
+
+        # Check that the total count is there and correct
+        self.assertIn('total_count', content['meta'])
+        self.assertIsInstance(content['meta']['total_count'], int)
+        self.assertEqual(content['meta']['total_count'], get_total_page_count())
+
+        # Check that the items section is there
+        self.assertIn('items', content)
+        self.assertIsInstance(content['items'], list)
+
+        # Check that each page has a meta section with type, detail_url, html_url, slug and first_published_at attributes
+        for page in content['items']:
+            self.assertIn('meta', page)
+            self.assertIsInstance(page['meta'], dict)
+            self.assertEqual(set(page['meta'].keys()), {'type', 'detail_url', 'html_url', 'slug', 'first_published_at'})
+
+    def test_unpublished_pages_dont_appear_in_list(self):
+        total_count = get_total_page_count()
+
+        page = models.BlogEntryPage.objects.get(id=16)
+        page.unpublish()
+
+        response = self.get_response()
+        content = json.loads(response.content.decode('UTF-8'))
+        self.assertEqual(content['meta']['total_count'], total_count - 1)
+
+    def test_private_pages_dont_appear_in_list(self):
+        total_count = get_total_page_count()
+
+        page = models.BlogIndexPage.objects.get(id=5)
+        page.view_restrictions.create(password='test')
+
+        new_total_count = get_total_page_count()
+        self.assertNotEqual(total_count, new_total_count)
+
+        response = self.get_response()
+        content = json.loads(response.content.decode('UTF-8'))
+        self.assertEqual(content['meta']['total_count'], new_total_count)
+
+    # TYPE FILTER
+
+    def test_type_filter_items_are_all_blog_entries(self):
+        response = self.get_response(type='demosite.BlogEntryPage')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for page in content['items']:
+            self.assertEqual(page['meta']['type'], 'demosite.BlogEntryPage')
+
+            # No specific fields available by default
+            self.assertEqual(set(page.keys()), {'id', 'meta', 'title'})
+
+    def test_type_filter_total_count(self):
+        response = self.get_response(type='demosite.BlogEntryPage')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        # Total count must be reduced as this filters the results
+        self.assertEqual(content['meta']['total_count'], 3)
+
+    def test_type_filter_multiple(self):
+        response = self.get_response(type='demosite.BlogEntryPage,demosite.EventPage')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        blog_page_seen = False
+        event_page_seen = False
+
+        for page in content['items']:
+            self.assertIn(page['meta']['type'], ['demosite.BlogEntryPage', 'demosite.EventPage'])
+
+            if page['meta']['type'] == 'demosite.BlogEntryPage':
+                blog_page_seen = True
+            elif page['meta']['type'] == 'demosite.EventPage':
+                event_page_seen = True
+
+            # Only generic fields available
+            self.assertEqual(set(page.keys()), {'id', 'meta', 'title'})
+
+        self.assertTrue(blog_page_seen, "No blog pages were found in the items")
+        self.assertTrue(event_page_seen, "No event pages were found in the items")
+
+    def test_non_existant_type_gives_error(self):
+        response = self.get_response(type='demosite.IDontExist')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "type doesn't exist"})
+
+    def test_non_page_type_gives_error(self):
+        response = self.get_response(type='auth.User')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "type doesn't exist"})
+
+    # FIELDS
+
+    def test_fields_default(self):
+        response = self.get_response(type='demosite.BlogEntryPage')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for page in content['items']:
+            self.assertEqual(set(page.keys()), {'id', 'meta', 'title'})
+            self.assertEqual(set(page['meta'].keys()), {'type', 'detail_url', 'html_url', 'slug', 'first_published_at'})
+
+    def test_fields(self):
+        response = self.get_response(type='demosite.BlogEntryPage', fields='title,date,feed_image')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for page in content['items']:
+            self.assertEqual(set(page.keys()), {'id', 'meta', 'title', 'date', 'feed_image'})
+
+    def test_remove_fields(self):
+        response = self.get_response(fields='-title')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for page in content['items']:
+            self.assertEqual(set(page.keys()), {'id', 'meta'})
+
+    def test_remove_meta_fields(self):
+        response = self.get_response(fields='-html_url')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for page in content['items']:
+            self.assertEqual(set(page.keys()), {'id', 'meta', 'title'})
+            self.assertEqual(set(page['meta'].keys()), {'type', 'detail_url', 'slug', 'first_published_at'})
+
+    def test_remove_all_meta_fields(self):
+        response = self.get_response(fields='-type,-detail_url,-slug,-first_published_at,-html_url')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for page in content['items']:
+            self.assertEqual(set(page.keys()), {'id', 'title'})
+
+    def test_remove_id_field(self):
+        response = self.get_response(fields='-id')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for page in content['items']:
+            self.assertEqual(set(page.keys()), {'meta', 'title'})
+
+    def test_all_fields(self):
+        response = self.get_response(type='demosite.BlogEntryPage', fields='*')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for page in content['items']:
+            self.assertEqual(set(page.keys()), {'id', 'meta', 'title', 'date', 'related_links', 'tags', 'carousel_items', 'body', 'feed_image', 'feed_image_thumbnail'})
+            self.assertEqual(set(page['meta'].keys()), {'type', 'detail_url', 'show_in_menus', 'first_published_at', 'seo_title', 'slug', 'html_url', 'search_description'})
+
+    def test_all_fields_then_remove_something(self):
+        response = self.get_response(type='demosite.BlogEntryPage', fields='*,-title,-date,-seo_title')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for page in content['items']:
+            self.assertEqual(set(page.keys()), {'id', 'meta', 'related_links', 'tags', 'carousel_items', 'body', 'feed_image', 'feed_image_thumbnail'})
+            self.assertEqual(set(page['meta'].keys()), {'type', 'detail_url', 'show_in_menus', 'first_published_at', 'slug', 'html_url', 'search_description'})
+
+    def test_remove_all_fields(self):
+        response = self.get_response(type='demosite.BlogEntryPage', fields='_,id,type')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for page in content['items']:
+            self.assertEqual(set(page.keys()), {'id', 'meta'})
+            self.assertEqual(set(page['meta'].keys()), {'type'})
+
+    def test_nested_fields(self):
+        response = self.get_response(type='demosite.BlogEntryPage', fields='feed_image(width,height)')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for page in content['items']:
+            self.assertEqual(set(page['feed_image'].keys()), {'id', 'meta', 'title', 'width', 'height'})
+
+    def test_remove_nested_fields(self):
+        response = self.get_response(type='demosite.BlogEntryPage', fields='feed_image(-title)')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for page in content['items']:
+            self.assertEqual(set(page['feed_image'].keys()), {'id', 'meta'})
+
+    def test_all_nested_fields(self):
+        response = self.get_response(type='demosite.BlogEntryPage', fields='feed_image(*)')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for page in content['items']:
+            self.assertEqual(set(page['feed_image'].keys()), {'id', 'meta', 'title', 'width', 'height'})
+
+    def test_remove_all_nested_fields(self):
+        response = self.get_response(type='demosite.BlogEntryPage', fields='feed_image(_,id)')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for page in content['items']:
+            self.assertEqual(set(page['feed_image'].keys()), {'id'})
+
+    def test_nested_nested_fields(self):
+        response = self.get_response(type='demosite.BlogEntryPage', fields='carousel_items(image(width,height))')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for page in content['items']:
+            for carousel_item in page['carousel_items']:
+                # Note: inline objects default to displaying all fields
+                self.assertEqual(set(carousel_item.keys()), {'id', 'meta', 'image', 'embed_url', 'caption', 'link'})
+                self.assertEqual(set(carousel_item['image'].keys()), {'id', 'meta', 'title', 'width', 'height'})
+
+    def test_fields_child_relation(self):
+        response = self.get_response(type='demosite.BlogEntryPage', fields='title,related_links')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for page in content['items']:
+            self.assertEqual(set(page.keys()), {'id', 'meta', 'title', 'related_links'})
+            self.assertIsInstance(page['related_links'], list)
+
+    def test_fields_foreign_key(self):
+        response = self.get_response(type='demosite.BlogEntryPage', fields='title,date,feed_image')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for page in content['items']:
+            feed_image = page['feed_image']
+
+            if feed_image is not None:
+                self.assertIsInstance(feed_image, dict)
+                self.assertEqual(set(feed_image.keys()), {'id', 'meta', 'title'})
+                self.assertIsInstance(feed_image['id'], int)
+                self.assertIsInstance(feed_image['meta'], dict)
+                self.assertEqual(set(feed_image['meta'].keys()), {'type', 'detail_url'})
+                self.assertEqual(feed_image['meta']['type'], 'wagtailimages.Image')
+                self.assertEqual(feed_image['meta']['detail_url'], 'http://localhost/api/v3beta/images/%d/' % feed_image['id'])
+
+    def test_fields_tags(self):
+        response = self.get_response(type='demosite.BlogEntryPage', fields='tags')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for page in content['items']:
+            self.assertEqual(set(page.keys()), {'id', 'meta', 'tags', 'title'})
+            self.assertIsInstance(page['tags'], list)
+
+    def test_fields_ordering(self):
+        response = self.get_response(type='demosite.BlogEntryPage', fields='date,title,feed_image,related_links')
+
+        # Will crash if the JSON is invalid
+        content = json.loads(response.content.decode('UTF-8'))
+
+        # Test field order
+        content = json.JSONDecoder(object_pairs_hook=collections.OrderedDict).decode(response.content.decode('UTF-8'))
+        field_order = [
+            'id',
+            'meta',
+            'title',
+            'date',
+            'feed_image',
+            'related_links',
+        ]
+        self.assertEqual(list(content['items'][0].keys()), field_order)
+
+    def test_star_in_wrong_position_gives_error(self):
+        response = self.get_response(fields='title,*')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "fields error: '*' must be in the first position"})
+
+    def test_unknown_nested_fields_give_error(self):
+        response = self.get_response(type='demosite.BlogEntryPage', fields='feed_image(123,title,abc)')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "unknown fields: 123, abc"})
+
+    def test_parent_field_gives_error(self):
+        # parent field isn't allowed in listings
+        response = self.get_response(fields='parent')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "unknown fields: parent"})
+
+    def test_fields_without_type_gives_error(self):
+        response = self.get_response(fields='title,related_links')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "unknown fields: related_links"})
+
+    def test_fields_which_are_not_in_api_fields_gives_error(self):
+        response = self.get_response(fields='path')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "unknown fields: path"})
+
+    def test_fields_unknown_field_gives_error(self):
+        response = self.get_response(fields='123,title,abc')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "unknown fields: 123, abc"})
+
+    def test_fields_remove_unknown_field_gives_error(self):
+        response = self.get_response(fields='-123,-title,-abc')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "unknown fields: 123, abc"})
+
+    def test_nested_fields_on_non_relational_field_gives_error(self):
+        response = self.get_response(type='demosite.BlogEntryPage', fields='title(foo,bar)')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "'title' does not support nested fields"})
+
+
+    # FILTERING
+
+    def test_filtering_exact_filter(self):
+        response = self.get_response(title='Home page')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        page_id_list = self.get_page_id_list(content)
+        self.assertEqual(page_id_list, [2])
+
+    def test_filtering_exact_filter_on_specific_field(self):
+        response = self.get_response(type='demosite.BlogEntryPage', date='2013-12-02')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        page_id_list = self.get_page_id_list(content)
+        self.assertEqual(page_id_list, [16])
+
+    def test_filtering_on_id(self):
+        response = self.get_response(id=16)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        page_id_list = self.get_page_id_list(content)
+        self.assertEqual(page_id_list, [16])
+
+    def test_filtering_on_boolean(self):
+        response = self.get_response(show_in_menus='false')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        page_id_list = self.get_page_id_list(content)
+        self.assertEqual(page_id_list, [8, 9, 16, 18, 19, 17])
+
+    def test_filtering_doesnt_work_on_specific_fields_without_type(self):
+        response = self.get_response(date='2013-12-02')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "query parameter is not an operation or a recognised field: date"})
+
+    def test_filtering_tags(self):
+        response = self.get_response(type='demosite.BlogEntryPage', tags='wagtail')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        page_id_list = self.get_page_id_list(content)
+        self.assertEqual(page_id_list, [16, 18])
+
+    def test_filtering_multiple_tags(self):
+        response = self.get_response(type='demosite.BlogEntryPage', tags='wagtail,bird')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        page_id_list = self.get_page_id_list(content)
+        self.assertEqual(page_id_list, [16])
+
+    def test_filtering_unknown_field_gives_error(self):
+        response = self.get_response(not_a_field='abc')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "query parameter is not an operation or a recognised field: not_a_field"})
+
+    def test_filtering_int_validation(self):
+        response = self.get_response(id='abc')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "field filter error. 'abc' is not a valid value for id (invalid literal for int() with base 10: 'abc')"})
+
+    def test_filtering_boolean_validation(self):
+        response = self.get_response(show_in_menus='abc')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "field filter error. 'abc' is not a valid value for show_in_menus (expected 'true' or 'false', got 'abc')"})
+
+
+    # CHILD OF FILTER
+
+    def test_child_of_filter(self):
+        response = self.get_response(child_of=5)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        page_id_list = self.get_page_id_list(content)
+        self.assertEqual(page_id_list, [16, 18, 19])
+
+    def test_child_of_root(self):
+        # "root" gets children of the homepage of the current site
+        response = self.get_response(child_of='root')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        page_id_list = self.get_page_id_list(content)
+        self.assertEqual(page_id_list, [4, 5, 6, 20, 12])
+
+    def test_child_of_with_type(self):
+        response = self.get_response(type='demosite.EventPage', child_of=5)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        page_id_list = self.get_page_id_list(content)
+        self.assertEqual(page_id_list, [])
+
+    def test_child_of_unknown_page_gives_error(self):
+        response = self.get_response(child_of=1000)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "parent page doesn't exist"})
+
+    def test_child_of_not_integer_gives_error(self):
+        response = self.get_response(child_of='abc')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "child_of must be a positive integer"})
+
+    def test_child_of_page_thats_not_in_same_site_gives_error(self):
+        # Root page is not in any site, so pretend it doesn't exist
+        response = self.get_response(child_of=1)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "parent page doesn't exist"})
+
+
+    # DESCENDANT OF FILTER
+
+    def test_descendant_of_filter(self):
+        response = self.get_response(descendant_of=6)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        page_id_list = self.get_page_id_list(content)
+        self.assertEqual(page_id_list, [10, 15, 17, 21, 22, 23])
+
+    def test_descendant_of_root(self):
+        # "root" gets decendants of the homepage of the current site
+        # Basically returns every page except the homepage
+        response = self.get_response(descendant_of='root')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        page_id_list = self.get_page_id_list(content)
+        self.assertEqual(page_id_list, [4, 8, 9, 5, 16, 18, 19, 6, 10, 15, 17, 21, 22, 23, 20, 13, 14, 12])
+
+    def test_descendant_of_with_type(self):
+        response = self.get_response(type='tests.EventPage', descendant_of=6)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        page_id_list = self.get_page_id_list(content)
+        self.assertEqual(page_id_list, [])
+
+    def test_descendant_of_unknown_page_gives_error(self):
+        response = self.get_response(descendant_of=1000)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "ancestor page doesn't exist"})
+
+    def test_descendant_of_not_integer_gives_error(self):
+        response = self.get_response(descendant_of='abc')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "descendant_of must be a positive integer"})
+
+    def test_descendant_of_page_thats_not_in_same_site_gives_error(self):
+        # Root page is not in any site, so pretend it doesn't exist
+        response = self.get_response(descendant_of=1)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "ancestor page doesn't exist"})
+
+    def test_descendant_of_when_filtering_by_child_of_gives_error(self):
+        response = self.get_response(descendant_of=6, child_of=5)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "filtering by descendant_of with child_of is not supported"})
+
+
+    # ORDERING
+
+    def test_ordering_default(self):
+        response = self.get_response()
+        content = json.loads(response.content.decode('UTF-8'))
+
+        page_id_list = self.get_page_id_list(content)
+        self.assertEqual(page_id_list, [2, 4, 8, 9, 5, 16, 18, 19, 6, 10, 15, 17, 21, 22, 23, 20, 13, 14, 12])
+
+    def test_ordering_by_title(self):
+        response = self.get_response(order='title')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        page_id_list = self.get_page_id_list(content)
+        self.assertEqual(page_id_list, [21, 22, 19, 23, 5, 16, 18, 12, 14, 8, 9, 4, 2, 13, 20, 17, 6, 10, 15])
+
+    def test_ordering_by_title_backwards(self):
+        response = self.get_response(order='-title')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        page_id_list = self.get_page_id_list(content)
+        self.assertEqual(page_id_list, [15, 10, 6, 17, 20, 13, 2, 4, 9, 8, 14, 12, 18, 16, 5, 23, 19, 22, 21])
+
+    def test_ordering_by_random(self):
+        response_1 = self.get_response(order='random')
+        content_1 = json.loads(response_1.content.decode('UTF-8'))
+        page_id_list_1 = self.get_page_id_list(content_1)
+
+        response_2 = self.get_response(order='random')
+        content_2 = json.loads(response_2.content.decode('UTF-8'))
+        page_id_list_2 = self.get_page_id_list(content_2)
+
+        self.assertNotEqual(page_id_list_1, page_id_list_2)
+
+    def test_ordering_by_random_backwards_gives_error(self):
+        response = self.get_response(order='-random')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "cannot order by 'random' (unknown field)"})
+
+    def test_ordering_by_random_with_offset_gives_error(self):
+        response = self.get_response(order='random', offset=10)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "random ordering with offset is not supported"})
+
+    def test_ordering_default_with_type(self):
+        response = self.get_response(type='demosite.BlogEntryPage')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        page_id_list = self.get_page_id_list(content)
+        self.assertEqual(page_id_list, [16, 18, 19])
+
+    def test_ordering_by_title_with_type(self):
+        response = self.get_response(type='demosite.BlogEntryPage', order='title')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        page_id_list = self.get_page_id_list(content)
+        self.assertEqual(page_id_list, [19, 16, 18])
+
+    def test_ordering_by_specific_field_with_type(self):
+        response = self.get_response(type='demosite.BlogEntryPage', order='date')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        page_id_list = self.get_page_id_list(content)
+        self.assertEqual(page_id_list, [16, 18, 19])
+
+    def test_ordering_by_unknown_field_gives_error(self):
+        response = self.get_response(order='not_a_field')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "cannot order by 'not_a_field' (unknown field)"})
+
+
+    # LIMIT
+
+    def test_limit_only_two_items_returned(self):
+        response = self.get_response(limit=2)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(len(content['items']), 2)
+
+    def test_limit_total_count(self):
+        response = self.get_response(limit=2)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        # The total count must not be affected by "limit"
+        self.assertEqual(content['meta']['total_count'], get_total_page_count())
+
+    def test_limit_not_integer_gives_error(self):
+        response = self.get_response(limit='abc')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "limit must be a positive integer"})
+
+    def test_limit_too_high_gives_error(self):
+        response = self.get_response(limit=1000)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "limit cannot be higher than 20"})
+
+    @override_settings(WAGTAILAPI_LIMIT_MAX=10)
+    def test_limit_maximum_can_be_changed(self):
+        response = self.get_response(limit=20)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "limit cannot be higher than 10"})
+
+    @override_settings(WAGTAILAPI_LIMIT_MAX=2)
+    def test_limit_default_changes_with_max(self):
+        # The default limit is 20. If WAGTAILAPI_LIMIT_MAX is less than that,
+        # the default should change accordingly.
+        response = self.get_response()
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(len(content['items']), 2)
+
+
+    # OFFSET
+
+    def test_offset_5_usually_appears_5th_in_list(self):
+        response = self.get_response()
+        content = json.loads(response.content.decode('UTF-8'))
+        page_id_list = self.get_page_id_list(content)
+        self.assertEqual(page_id_list.index(5), 4)
+
+    def test_offset_5_moves_after_offset(self):
+        response = self.get_response(offset=4)
+        content = json.loads(response.content.decode('UTF-8'))
+        page_id_list = self.get_page_id_list(content)
+        self.assertEqual(page_id_list.index(5), 0)
+
+    def test_offset_total_count(self):
+        response = self.get_response(offset=10)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        # The total count must not be affected by "offset"
+        self.assertEqual(content['meta']['total_count'], get_total_page_count())
+
+    def test_offset_not_integer_gives_error(self):
+        response = self.get_response(offset='abc')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "offset must be a positive integer"})
+
+
+    # SEARCH
+
+    def test_search_for_blog(self):
+        response = self.get_response(search='blog')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        page_id_list = self.get_page_id_list(content)
+
+        # Check that the items are the blog index and three blog pages
+        self.assertEqual(set(page_id_list), set([5, 16, 18, 19]))
+
+    def test_search_with_type(self):
+        response = self.get_response(type='demosite.BlogEntryPage', search='blog')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        page_id_list = self.get_page_id_list(content)
+
+        self.assertEqual(set(page_id_list), set([16, 18, 19]))
+
+    def test_search_with_order(self):
+        response = self.get_response(search='blog', order='title')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        page_id_list = self.get_page_id_list(content)
+
+        self.assertEqual(page_id_list, [19, 5, 16, 18])
+
+    @override_settings(WAGTAILAPI_SEARCH_ENABLED=False)
+    def test_search_when_disabled_gives_error(self):
+        response = self.get_response(search='blog')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "search is disabled"})
+
+    def test_search_when_filtering_by_tag_gives_error(self):
+        response = self.get_response(type='demosite.BlogEntryPage', search='blog', tags='wagtail')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "filtering by tag with a search query is not supported"})
+
+    def test_search_operator_and(self):
+        response = self.get_response(type='demosite.BlogEntryPage', search='blog again', search_operator='and')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        page_id_list = self.get_page_id_list(content)
+
+        self.assertEqual(set(page_id_list), set([18]))
+
+    def test_search_operator_or(self):
+        response = self.get_response(type='demosite.BlogEntryPage', search='blog again', search_operator='or')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        page_id_list = self.get_page_id_list(content)
+
+        self.assertEqual(set(page_id_list), set([16, 18, 19]))
+
+    def test_empty_searches_work(self):
+        response = self.get_response(search='')
+        content = json.loads(response.content.decode('UTF-8'))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response['Content-type'], 'application/json')
+        self.assertEqual(content['meta']['total_count'], 0)
+
+
+class TestPageDetail(TestCase):
+    fixtures = ['demosite.json']
+
+    def get_response(self, page_id, **params):
+        return self.client.get(reverse('wagtailapi_v3:pages:detail', args=(page_id, )), params)
+
+    def test_basic(self):
+        response = self.get_response(16)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response['Content-type'], 'application/json')
+
+        # Will crash if the JSON is invalid
+        content = json.loads(response.content.decode('UTF-8'))
+
+        # Check the id field
+        self.assertIn('id', content)
+        self.assertEqual(content['id'], 16)
+
+        # Check that the meta section is there
+        self.assertIn('meta', content)
+        self.assertIsInstance(content['meta'], dict)
+
+        # Check the meta type
+        self.assertIn('type', content['meta'])
+        self.assertEqual(content['meta']['type'], 'demosite.BlogEntryPage')
+
+        # Check the meta detail_url
+        self.assertIn('detail_url', content['meta'])
+        self.assertEqual(content['meta']['detail_url'], 'http://localhost/api/v3beta/pages/16/')
+
+        # Check the meta html_url
+        self.assertIn('html_url', content['meta'])
+        self.assertEqual(content['meta']['html_url'], 'http://localhost/blog-index/blog-post/')
+
+        # Check the parent field
+        self.assertIn('parent', content['meta'])
+        self.assertIsInstance(content['meta']['parent'], dict)
+        self.assertEqual(set(content['meta']['parent'].keys()), {'id', 'meta', 'title'})
+        self.assertEqual(content['meta']['parent']['id'], 5)
+        self.assertIsInstance(content['meta']['parent']['meta'], dict)
+        self.assertEqual(set(content['meta']['parent']['meta'].keys()), {'type', 'detail_url', 'html_url'})
+        self.assertEqual(content['meta']['parent']['meta']['type'], 'demosite.BlogIndexPage')
+        self.assertEqual(content['meta']['parent']['meta']['detail_url'], 'http://localhost/api/v3beta/pages/5/')
+        self.assertEqual(content['meta']['parent']['meta']['html_url'], 'http://localhost/blog-index/')
+
+        # Check that the custom fields are included
+        self.assertIn('date', content)
+        self.assertIn('body', content)
+        self.assertIn('tags', content)
+        self.assertIn('feed_image', content)
+        self.assertIn('related_links', content)
+        self.assertIn('carousel_items', content)
+
+        # Check that the date was serialised properly
+        self.assertEqual(content['date'], '2013-12-02')
+
+        # Check that the tags were serialised properly
+        self.assertEqual(content['tags'], ['bird', 'wagtail'])
+
+        # Check that the feed image was serialised properly
+        self.assertIsInstance(content['feed_image'], dict)
+        self.assertEqual(set(content['feed_image'].keys()), {'id', 'meta', 'title'})
+        self.assertEqual(content['feed_image']['id'], 7)
+        self.assertIsInstance(content['feed_image']['meta'], dict)
+        self.assertEqual(set(content['feed_image']['meta'].keys()), {'type', 'detail_url'})
+        self.assertEqual(content['feed_image']['meta']['type'], 'wagtailimages.Image')
+        self.assertEqual(content['feed_image']['meta']['detail_url'], 'http://localhost/api/v3beta/images/7/')
+
+        # Check that the feed images' thumbnail was serialised properly
+        self.assertEqual(content['feed_image_thumbnail'], {
+            # This is OK because it tells us it used ImageRenditionField to generate the output
+            'error': 'SourceImageIOError'
+        })
+
+        # Check that the child relations were serialised properly
+        self.assertEqual(content['related_links'], [])
+        for carousel_item in content['carousel_items']:
+            self.assertEqual(set(carousel_item.keys()), {'id', 'meta', 'embed_url', 'link', 'caption', 'image'})
+            self.assertEqual(set(carousel_item['meta'].keys()), {'type'})
+
+    def test_meta_parent_id_doesnt_show_root_page(self):
+        # Root page isn't in the site so don't show it if the user is looking at the home page
+        response = self.get_response(2)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertIsNone(content['meta']['parent'])
+
+    def test_field_ordering(self):
+        response = self.get_response(16)
+
+        # Will crash if the JSON is invalid
+        content = json.loads(response.content.decode('UTF-8'))
+
+        # Test field order
+        content = json.JSONDecoder(object_pairs_hook=collections.OrderedDict).decode(response.content.decode('UTF-8'))
+        field_order = [
+            'id',
+            'meta',
+            'title',
+            'body',
+            'tags',
+            'date',
+            'feed_image',
+            'feed_image_thumbnail',
+            'carousel_items',
+            'related_links',
+        ]
+        self.assertEqual(list(content.keys()), field_order)
+
+    def test_null_foreign_key(self):
+        models.BlogEntryPage.objects.filter(id=16).update(feed_image_id=None)
+
+        response = self.get_response(16)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertIn('related_links', content)
+        self.assertEqual(content['feed_image'], None)
+
+    # FIELDS
+
+    def test_remove_fields(self):
+        response = self.get_response(16, fields='-title')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertIn('id', set(content.keys()))
+        self.assertNotIn('title', set(content.keys()))
+
+    def test_remove_meta_fields(self):
+        response = self.get_response(16, fields='-html_url')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertIn('detail_url', set(content['meta'].keys()))
+        self.assertNotIn('html_url', set(content['meta'].keys()))
+
+    def test_remove_all_meta_fields(self):
+        response = self.get_response(16, fields='-type,-detail_url,-slug,-first_published_at,-html_url,-search_description,-show_in_menus,-parent,-seo_title')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertIn('id', set(content.keys()))
+        self.assertNotIn('meta', set(content.keys()))
+
+    def test_remove_id_field(self):
+        response = self.get_response(16, fields='-id')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertIn('title', set(content.keys()))
+        self.assertNotIn('id', set(content.keys()))
+
+    def test_remove_all_fields(self):
+        response = self.get_response(16, fields='_,id,type')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(set(content.keys()), {'id', 'meta'})
+        self.assertEqual(set(content['meta'].keys()), {'type'})
+
+    def test_nested_fields(self):
+        response = self.get_response(16, fields='feed_image(width,height)')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(set(content['feed_image'].keys()), {'id', 'meta', 'title', 'width', 'height'})
+
+    def test_remove_nested_fields(self):
+        response = self.get_response(16, fields='feed_image(-title)')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(set(content['feed_image'].keys()), {'id', 'meta'})
+
+    def test_all_nested_fields(self):
+        response = self.get_response(16, fields='feed_image(*)')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(set(content['feed_image'].keys()), {'id', 'meta', 'title', 'width', 'height'})
+
+    def test_remove_all_nested_fields(self):
+        response = self.get_response(16, fields='feed_image(_,id)')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(set(content['feed_image'].keys()), {'id'})
+
+    def test_nested_nested_fields(self):
+        response = self.get_response(16, fields='carousel_items(image(width,height))')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for carousel_item in content['carousel_items']:
+            # Note: inline objects default to displaying all fields
+            self.assertEqual(set(carousel_item.keys()), {'id', 'meta', 'image', 'embed_url', 'caption', 'link'})
+            self.assertEqual(set(carousel_item['image'].keys()), {'id', 'meta', 'title', 'width', 'height'})
+
+    def test_fields_child_relation_is_list(self):
+        response = self.get_response(16)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertIsInstance(content['related_links'], list)
+
+    def test_fields_foreign_key(self):
+        response = self.get_response(16)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        feed_image = content['feed_image']
+
+        self.assertIsInstance(feed_image, dict)
+        self.assertEqual(set(feed_image.keys()), {'id', 'meta', 'title'})
+        self.assertIsInstance(feed_image['id'], int)
+        self.assertIsInstance(feed_image['meta'], dict)
+        self.assertEqual(set(feed_image['meta'].keys()), {'type', 'detail_url'})
+        self.assertEqual(feed_image['meta']['type'], 'wagtailimages.Image')
+        self.assertEqual(feed_image['meta']['detail_url'], 'http://localhost/api/v3beta/images/%d/' % feed_image['id'])
+
+    def test_star_in_wrong_position_gives_error(self):
+        response = self.get_response(16, fields='title,*')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "fields error: '*' must be in the first position"})
+
+    def test_unknown_nested_fields_give_error(self):
+        response = self.get_response(16, fields='feed_image(123,title,abc)')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "unknown fields: 123, abc"})
+
+    def test_fields_which_are_not_in_api_fields_gives_error(self):
+        response = self.get_response(16, fields='path')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "unknown fields: path"})
+
+    def test_fields_unknown_field_gives_error(self):
+        response = self.get_response(16, fields='123,title,abc')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "unknown fields: 123, abc"})
+
+    def test_fields_remove_unknown_field_gives_error(self):
+        response = self.get_response(16, fields='-123,-title,-abc')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "unknown fields: 123, abc"})
+
+    def test_nested_fields_on_non_relational_field_gives_error(self):
+        response = self.get_response(16, fields='title(foo,bar)')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(content, {'message': "'title' does not support nested fields"})
+
+
+class TestPageDetailWithStreamField(TestCase):
+    fixtures = ['test.json']
+
+    def setUp(self):
+        self.homepage = Page.objects.get(url_path='/home/')
+
+    def make_stream_page(self, body):
+        stream_page = StreamPage(
+            title='stream page',
+            slug='stream-page',
+            body=body
+        )
+        return self.homepage.add_child(instance=stream_page)
+
+    def test_can_fetch_streamfield_content(self):
+        stream_page = self.make_stream_page('[{"type": "text", "value": "foo"}]')
+
+        response_url = reverse('wagtailapi_v3:pages:detail', args=(stream_page.id, ))
+        response = self.client.get(response_url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response['content-type'], 'application/json')
+
+        content = json.loads(response.content.decode('utf-8'))
+
+        self.assertIn('id', content)
+        self.assertEqual(content['id'], stream_page.id)
+        self.assertIn('body', content)
+        self.assertEqual(len(content['body']), 1)
+        self.assertEqual(content['body'][0]['type'], 'text')
+        self.assertEqual(content['body'][0]['value'], 'foo')
+        self.assertTrue(content['body'][0]['id'])
+
+    def test_image_block(self):
+        stream_page = self.make_stream_page('[{"type": "image", "value": 1}]')
+
+        response_url = reverse('wagtailapi_v3:pages:detail', args=(stream_page.id, ))
+        response = self.client.get(response_url)
+        content = json.loads(response.content.decode('utf-8'))
+
+        # ForeignKeys in a StreamField shouldn't be translated into dictionary representation
+        self.assertEqual(content['body'][0]['type'], 'image')
+        self.assertEqual(content['body'][0]['value'], 1)
+
+    def test_image_block_with_custom_get_api_representation(self):
+        stream_page = self.make_stream_page('[{"type": "image", "value": 1}]')
+
+        response_url = '{}?extended=1'.format(
+            reverse('wagtailapi_v3:pages:detail', args=(stream_page.id, ))
+        )
+        response = self.client.get(response_url)
+        content = json.loads(response.content.decode('utf-8'))
+
+        # the custom get_api_representation returns a dict of id and title for the image
+        self.assertEqual(content['body'][0]['type'], 'image')
+        self.assertEqual(content['body'][0]['value'], {'id': 1, 'title': 'A missing image'})
+
+
+@override_settings(
+    WAGTAILFRONTENDCACHE={
+        'varnish': {
+            'BACKEND': 'wagtail.contrib.wagtailfrontendcache.backends.HTTPBackend',
+            'LOCATION': 'http://localhost:8000',
+        },
+    },
+    WAGTAILAPI_BASE_URL='http://api.example.com',
+)
+@mock.patch('wagtail.contrib.wagtailfrontendcache.backends.HTTPBackend.purge')
+class TestPageCacheInvalidation(TestCase):
+    fixtures = ['demosite.json']
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestPageCacheInvalidation, cls).setUpClass()
+        signal_handlers.register_signal_handlers()
+
+    @classmethod
+    def tearDownClass(cls):
+        super(TestPageCacheInvalidation, cls).tearDownClass()
+        signal_handlers.unregister_signal_handlers()
+
+    def test_republish_page_purges(self, purge):
+        Page.objects.get(id=2).save_revision().publish()
+
+        purge.assert_any_call('http://api.example.com/api/v3beta/pages/2/')
+
+    def test_unpublish_page_purges(self, purge):
+        Page.objects.get(id=2).unpublish()
+
+        purge.assert_any_call('http://api.example.com/api/v3beta/pages/2/')
+
+    def test_delete_page_purges(self, purge):
+        Page.objects.get(id=16).delete()
+
+        purge.assert_any_call('http://api.example.com/api/v3beta/pages/16/')
+
+    def test_save_draft_doesnt_purge(self, purge):
+        Page.objects.get(id=2).save_revision()
+
+        purge.assert_not_called()

--- a/wagtail/api/v3/tests/tests.py
+++ b/wagtail/api/v3/tests/tests.py
@@ -1,0 +1,276 @@
+from __future__ import absolute_import, unicode_literals
+
+from unittest import TestCase
+
+from ..utils import FieldsParameterParseError, parse_boolean, parse_fields_parameter
+
+
+class TestParseFieldsParameter(TestCase):
+    # GOOD STUFF
+
+    def test_valid_single_field(self):
+        parsed = parse_fields_parameter('test')
+
+        self.assertEqual(parsed, [
+            ('test', False, None),
+        ])
+
+    def test_valid_multiple_fields(self):
+        parsed = parse_fields_parameter('test,another_test')
+
+        self.assertEqual(parsed, [
+            ('test', False, None),
+            ('another_test', False, None),
+        ])
+
+    def test_valid_negated_field(self):
+        parsed = parse_fields_parameter('-test')
+
+        self.assertEqual(parsed, [
+            ('test', True, None),
+        ])
+
+    def test_valid_nested_fields(self):
+        parsed = parse_fields_parameter('test(foo,bar)')
+
+        self.assertEqual(parsed, [
+            ('test', False, [
+                ('foo', False, None),
+                ('bar', False, None),
+            ]),
+        ])
+
+    def test_valid_star_field(self):
+        parsed = parse_fields_parameter('*,-test')
+
+        self.assertEqual(parsed, [
+            ('*', False, None),
+            ('test', True, None),
+        ])
+
+    def test_valid_star_with_additional_field(self):
+        # Note: '*,test' is not allowed but '*,test(foo)' is
+        parsed = parse_fields_parameter('*,test(foo)')
+
+        self.assertEqual(parsed, [
+            ('*', False, None),
+            ('test', False, [
+                ('foo', False, None),
+            ]),
+        ])
+
+    def test_valid_underscore_field(self):
+        parsed = parse_fields_parameter('_,test')
+
+        self.assertEqual(parsed, [
+            ('_', False, None),
+            ('test', False, None),
+        ])
+
+    def test_valid_field_with_underscore_in_middle(self):
+        parsed = parse_fields_parameter('a_test')
+
+        self.assertEqual(parsed, [
+            ('a_test', False, None),
+        ])
+
+    def test_valid_negated_field_with_underscore_in_middle(self):
+        parsed = parse_fields_parameter('-a_test')
+
+        self.assertEqual(parsed, [
+            ('a_test', True, None),
+        ])
+
+    def test_valid_field_with_underscore_at_beginning(self):
+        parsed = parse_fields_parameter('_test')
+
+        self.assertEqual(parsed, [
+            ('_test', False, None),
+        ])
+
+    def test_valid_field_with_underscore_at_end(self):
+        parsed = parse_fields_parameter('test_')
+
+        self.assertEqual(parsed, [
+            ('test_', False, None),
+        ])
+
+
+    # BAD STUFF
+
+    def test_invalid_char(self):
+        with self.assertRaises(FieldsParameterParseError) as e:
+            parse_fields_parameter('test#')
+
+        self.assertEqual(str(e.exception), "unexpected char '#' at position 4")
+
+    def test_invalid_whitespace_before_identifier(self):
+        with self.assertRaises(FieldsParameterParseError) as e:
+            parse_fields_parameter(' test')
+
+        self.assertEqual(str(e.exception), "unexpected whitespace at position 0")
+
+    def test_invalid_whitespace_after_identifier(self):
+        with self.assertRaises(FieldsParameterParseError) as e:
+            parse_fields_parameter('test ')
+
+        self.assertEqual(str(e.exception), "unexpected whitespace at position 4")
+
+    def test_invalid_whitespace_after_comma(self):
+        with self.assertRaises(FieldsParameterParseError) as e:
+            parse_fields_parameter('test, test')
+
+        self.assertEqual(str(e.exception), "unexpected whitespace at position 5")
+
+    def test_invalid_whitespace_before_comma(self):
+        with self.assertRaises(FieldsParameterParseError) as e:
+            parse_fields_parameter('test ,test')
+
+        self.assertEqual(str(e.exception), "unexpected whitespace at position 4")
+
+    def test_invalid_unexpected_negation_operator(self):
+        with self.assertRaises(FieldsParameterParseError) as e:
+            parse_fields_parameter('test-')
+
+        self.assertEqual(str(e.exception), "unexpected char '-' at position 4")
+
+    def test_invalid_unexpected_open_bracket(self):
+        with self.assertRaises(FieldsParameterParseError) as e:
+            parse_fields_parameter('test,(foo)')
+
+        self.assertEqual(str(e.exception), "unexpected char '(' at position 5")
+
+    def test_invalid_unexpected_close_bracket(self):
+        with self.assertRaises(FieldsParameterParseError) as e:
+            parse_fields_parameter('test)')
+
+        self.assertEqual(str(e.exception), "unexpected char ')' at position 4")
+
+    def test_invalid_unexpected_comma_in_middle(self):
+        with self.assertRaises(FieldsParameterParseError) as e:
+            parse_fields_parameter('test,,foo')
+
+        self.assertEqual(str(e.exception), "unexpected char ',' at position 5")
+
+    def test_invalid_unexpected_comma_at_end(self):
+        with self.assertRaises(FieldsParameterParseError) as e:
+            parse_fields_parameter('test,foo,')
+
+        self.assertEqual(str(e.exception), "unexpected char ',' at position 9")
+
+    def test_invalid_unclosed_bracket(self):
+        with self.assertRaises(FieldsParameterParseError) as e:
+            parse_fields_parameter('test(foo')
+
+        self.assertEqual(str(e.exception), "unexpected end of input (did you miss out a close bracket?)")
+
+    def test_invalid_subfields_on_negated_field(self):
+        with self.assertRaises(FieldsParameterParseError) as e:
+            parse_fields_parameter('-test(foo)')
+
+        self.assertEqual(str(e.exception), "unexpected char '(' at position 5")
+
+    def test_invalid_star_field_in_wrong_position(self):
+        with self.assertRaises(FieldsParameterParseError) as e:
+            parse_fields_parameter('test,*')
+
+        self.assertEqual(str(e.exception), "'*' must be in the first position")
+
+    def test_invalid_negated_star(self):
+        with self.assertRaises(FieldsParameterParseError) as e:
+            parse_fields_parameter('-*')
+
+        self.assertEqual(str(e.exception), "'*' cannot be negated")
+
+    def test_invalid_star_with_nesting(self):
+        with self.assertRaises(FieldsParameterParseError) as e:
+            parse_fields_parameter('*(foo,bar)')
+
+        self.assertEqual(str(e.exception), "unexpected char '(' at position 1")
+
+    def test_invalid_star_with_chars_after(self):
+        with self.assertRaises(FieldsParameterParseError) as e:
+            parse_fields_parameter('*foo')
+
+        self.assertEqual(str(e.exception), "unexpected char 'f' at position 1")
+
+    def test_invalid_star_with_chars_before(self):
+        with self.assertRaises(FieldsParameterParseError) as e:
+            parse_fields_parameter('foo*')
+
+        self.assertEqual(str(e.exception), "unexpected char '*' at position 3")
+
+    def test_invalid_star_with_additional_field(self):
+        with self.assertRaises(FieldsParameterParseError) as e:
+            parse_fields_parameter('*,foo')
+
+        self.assertEqual(str(e.exception), "additional fields with '*' doesn't make sense")
+
+    def test_invalid_underscore_in_wrong_position(self):
+        with self.assertRaises(FieldsParameterParseError) as e:
+            parse_fields_parameter('test,_')
+
+        self.assertEqual(str(e.exception), "'_' must be in the first position")
+
+    def test_invalid_negated_underscore(self):
+        with self.assertRaises(FieldsParameterParseError) as e:
+            parse_fields_parameter('-_')
+
+        self.assertEqual(str(e.exception), "'_' cannot be negated")
+
+    def test_invalid_underscore_with_nesting(self):
+        with self.assertRaises(FieldsParameterParseError) as e:
+            parse_fields_parameter('_(foo,bar)')
+
+        self.assertEqual(str(e.exception), "unexpected char '(' at position 1")
+
+    def test_invalid_underscore_with_negated_field(self):
+        with self.assertRaises(FieldsParameterParseError) as e:
+            parse_fields_parameter('_,-foo')
+
+        self.assertEqual(str(e.exception), "negated fields with '_' doesn't make sense")
+
+    def test_invalid_star_and_underscore(self):
+        with self.assertRaises(FieldsParameterParseError) as e:
+            parse_fields_parameter('*,_')
+
+        self.assertEqual(str(e.exception), "'_' must be in the first position")
+
+
+class TestParseBoolean(TestCase):
+    # GOOD STUFF
+
+    def test_valid_true(self):
+        parsed = parse_boolean('true')
+
+        self.assertEqual(parsed, True)
+
+    def test_valid_false(self):
+        parsed = parse_boolean('false')
+
+        self.assertEqual(parsed, False)
+
+    def test_valid_1(self):
+        parsed = parse_boolean('1')
+
+        self.assertEqual(parsed, True)
+
+    def test_valid_0(self):
+        parsed = parse_boolean('0')
+
+        self.assertEqual(parsed, False)
+
+
+    # BAD STUFF
+
+    def test_invalid(self):
+        with self.assertRaises(ValueError) as e:
+            parse_boolean('foo')
+
+        self.assertEqual(str(e.exception), "expected 'true' or 'false', got 'foo'")
+
+    def test_invalid_integer(self):
+        with self.assertRaises(ValueError) as e:
+            parse_boolean('2')
+
+        self.assertEqual(str(e.exception), "expected 'true' or 'false', got '2'")

--- a/wagtail/api/v3/utils.py
+++ b/wagtail/api/v3/utils.py
@@ -1,0 +1,235 @@
+from __future__ import absolute_import, unicode_literals
+
+from django.conf import settings
+from django.utils.six.moves.urllib.parse import urlparse
+
+from wagtail.wagtailcore.models import Page
+from wagtail.wagtailcore.utils import resolve_model_string
+
+
+class BadRequestError(Exception):
+    pass
+
+
+def get_base_url(request=None):
+    base_url = getattr(settings, 'WAGTAILAPI_BASE_URL', request.site.root_url if request else None)
+
+    if base_url:
+        # We only want the scheme and netloc
+        base_url_parsed = urlparse(base_url)
+
+        return base_url_parsed.scheme + '://' + base_url_parsed.netloc
+
+
+def get_full_url(request, path):
+    base_url = get_base_url(request) or ''
+    return base_url + path
+
+
+def pages_for_site(site):
+    pages = Page.objects.public().live()
+    pages = pages.descendant_of(site.root_page, inclusive=True)
+    return pages
+
+
+def page_models_from_string(string):
+    page_models = []
+
+    for sub_string in string.split(','):
+        page_model = resolve_model_string(sub_string)
+
+        if not issubclass(page_model, Page):
+            raise ValueError("Model is not a page")
+
+        page_models.append(page_model)
+
+    return tuple(page_models)
+
+
+def filter_page_type(queryset, page_models):
+    qs = queryset.none()
+
+    for model in page_models:
+        qs |= queryset.type(model)
+
+    return qs
+
+
+class FieldsParameterParseError(ValueError):
+    pass
+
+
+def parse_fields_parameter(fields_str):
+    """
+    Parses the ?fields= GET parameter. As this parameter is supposed to be used
+    by developers, the syntax is quite tight (eg, not allowing any whitespace).
+    Having a strict syntax allows us to extend the it at a later date with less
+    chance of breaking anyone's code.
+
+    This function takes a string and returns a list of tuples representing each
+    top-level field. Each tuple contains three items:
+     - The name of the field (string)
+     - Whether the field has been negated (boolean)
+     - A list of nested fields if there are any, None otherwise
+
+    Some examples of how this function works:
+
+    >>> parse_fields_parameter("foo")
+    [
+        ('foo', False, None),
+    ]
+
+    >>> parse_fields_parameter("foo,bar")
+    [
+        ('foo', False, None),
+        ('bar', False, None),
+    ]
+
+    >>> parse_fields_parameter("-foo")
+    [
+        ('foo', True, None),
+    ]
+
+    >>> parse_fields_parameter("foo(bar,baz)")
+    [
+        ('foo', False, [
+            ('bar', False, None),
+            ('baz', False, None),
+        ]),
+    ]
+
+    It raises a FieldsParameterParseError (subclass of ValueError) if it
+    encounters a syntax error
+    """
+
+    def get_position(current_str):
+        return len(fields_str) - len(current_str)
+
+    def parse_field_identifier(fields_str):
+        first_char = True
+        negated = False
+        ident = ""
+
+        while fields_str:
+            char = fields_str[0]
+
+            if char in ['(', ')', ',']:
+                if not ident:
+                    raise FieldsParameterParseError("unexpected char '%s' at position %d" % (char, get_position(fields_str)))
+
+                if ident in ['*', '_'] and char == '(':
+                    # * and _ cannot have nested fields
+                    raise FieldsParameterParseError("unexpected char '%s' at position %d" % (char, get_position(fields_str)))
+
+                return ident, negated, fields_str
+
+            elif char == '-':
+                if not first_char:
+                    raise FieldsParameterParseError("unexpected char '%s' at position %d" % (char, get_position(fields_str)))
+
+                negated = True
+
+            elif char in ['*', '_']:
+                if ident and char == '*':
+                    raise FieldsParameterParseError("unexpected char '%s' at position %d" % (char, get_position(fields_str)))
+
+                ident += char
+
+            elif char.isalnum() or char == '_':
+                if ident == '*':
+                    # * can only be on its own
+                    raise FieldsParameterParseError("unexpected char '%s' at position %d" % (char, get_position(fields_str)))
+
+                ident += char
+
+            elif char.isspace():
+                raise FieldsParameterParseError("unexpected whitespace at position %d" % get_position(fields_str))
+            else:
+                raise FieldsParameterParseError("unexpected char '%s' at position %d" % (char, get_position(fields_str)))
+
+            first_char = False
+            fields_str = fields_str[1:]
+
+        return ident, negated, fields_str
+
+    def parse_fields(fields_str, expect_close_bracket=False):
+        first_ident = None
+        is_first = True
+        fields = []
+
+        while fields_str:
+            sub_fields = None
+            ident, negated, fields_str = parse_field_identifier(fields_str)
+
+            # Some checks specific to '*' and '_'
+            if ident in ['*', '_']:
+                if not is_first:
+                    raise FieldsParameterParseError("'%s' must be in the first position" % ident)
+
+                if negated:
+                    raise FieldsParameterParseError("'%s' cannot be negated" % ident)
+
+            if fields_str and fields_str[0] == '(':
+                if negated:
+                    # Negated fields cannot contain subfields
+                    raise FieldsParameterParseError("unexpected char '(' at position %d" % get_position(fields_str))
+
+                sub_fields, fields_str = parse_fields(fields_str[1:], expect_close_bracket=True)
+
+            if is_first:
+                first_ident = ident
+            else:
+                # Negated fields can't be used with '_'
+                if first_ident == '_' and negated:
+                    # _,foo is allowed but _,-foo is not
+                    raise FieldsParameterParseError("negated fields with '_' doesn't make sense")
+
+                # Additional fields without sub fields can't be used with '*'
+                if first_ident == '*' and not negated and not sub_fields:
+                    # *,foo(bar) and *,-foo are allowed but *,foo is not
+                    raise FieldsParameterParseError("additional fields with '*' doesn't make sense")
+
+            fields.append((ident, negated, sub_fields))
+
+            if fields_str and fields_str[0] == ')':
+                if not expect_close_bracket:
+                    raise FieldsParameterParseError("unexpected char ')' at position %d" % get_position(fields_str))
+
+                return fields, fields_str[1:]
+
+            if fields_str and fields_str[0] == ',':
+                fields_str = fields_str[1:]
+
+                # A comma can not exist immediately before another comma or the end of the string
+                if not fields_str or fields_str[0] == ',':
+                    raise FieldsParameterParseError("unexpected char ',' at position %d" % get_position(fields_str))
+
+            is_first = False
+
+        if expect_close_bracket:
+            # This parser should've exited with a close bracket but instead we
+            # hit the end of the input. Raise an error
+            raise FieldsParameterParseError("unexpected end of input (did you miss out a close bracket?)")
+
+        return fields, fields_str
+
+    fields, _ = parse_fields(fields_str)
+
+    return fields
+
+
+def parse_boolean(value):
+    """
+    Parses strings into booleans using the following mapping (case-sensitive):
+
+    'true'   => True
+    'false'  => False
+    '1'      => True
+    '0'      => False
+    """
+    if value in ['true', '1']:
+        return True
+    elif value in ['false', '0']:
+        return False
+    else:
+        raise ValueError("expected 'true' or 'false', got '%s'" % value)

--- a/wagtail/tests/settings.py
+++ b/wagtail/tests/settings.py
@@ -140,6 +140,7 @@ INSTALLED_APPS = (
     'wagtail.wagtaildocs',
     'wagtail.wagtailadmin',
     'wagtail.api.v2',
+    'wagtail.api.v3',
     'wagtail.wagtailcore',
 
     'taggit',

--- a/wagtail/tests/urls.py
+++ b/wagtail/tests/urls.py
@@ -2,8 +2,10 @@ from __future__ import absolute_import, unicode_literals
 
 from django.conf.urls import include, url
 
-from wagtail.api.v2.endpoints import PagesAPIEndpoint
-from wagtail.api.v2.router import WagtailAPIRouter
+from wagtail.api.v2.endpoints import PagesAPIEndpoint as PagesAPIEndpointV2
+from wagtail.api.v2.router import WagtailAPIRouter as WagtailAPIRouterV2
+from wagtail.api.v3.endpoints import PagesAPIEndpoint as PagesAPIEndpointV3
+from wagtail.api.v3.router import WagtailAPIRouter as WagtailAPIRouterV3
 from wagtail.contrib.wagtailapi import urls as wagtailapi_urls
 from wagtail.contrib.wagtailsitemaps import views as sitemaps_views
 from wagtail.contrib.wagtailsitemaps import Sitemap
@@ -11,17 +13,25 @@ from wagtail.tests.testapp import urls as testapp_urls
 from wagtail.wagtailadmin import urls as wagtailadmin_urls
 from wagtail.wagtailcore import urls as wagtail_urls
 from wagtail.wagtaildocs import urls as wagtaildocs_urls
-from wagtail.wagtaildocs.api.v2.endpoints import DocumentsAPIEndpoint
+from wagtail.wagtaildocs.api.v2.endpoints import DocumentsAPIEndpoint as DocumentsAPIEndpointV2
+from wagtail.wagtaildocs.api.v3.endpoints import DocumentsAPIEndpoint as DocumentsAPIEndpointV3
 from wagtail.wagtailimages import urls as wagtailimages_urls
-from wagtail.wagtailimages.api.v2.endpoints import ImagesAPIEndpoint
+from wagtail.wagtailimages.api.v2.endpoints import ImagesAPIEndpoint as ImagesAPIEndpointV2
+from wagtail.wagtailimages.api.v3.endpoints import ImagesAPIEndpoint as ImagesAPIEndpointV3
 from wagtail.wagtailimages.tests import urls as wagtailimages_test_urls
 from wagtail.wagtailsearch import urls as wagtailsearch_urls
 
 
-api_router = WagtailAPIRouter('wagtailapi_v2')
-api_router.register_endpoint('pages', PagesAPIEndpoint)
-api_router.register_endpoint('images', ImagesAPIEndpoint)
-api_router.register_endpoint('documents', DocumentsAPIEndpoint)
+api_router_v2 = WagtailAPIRouterV2('wagtailapi_v2')
+api_router_v2.register_endpoint('pages', PagesAPIEndpointV2)
+api_router_v2.register_endpoint('images', ImagesAPIEndpointV2)
+api_router_v2.register_endpoint('documents', DocumentsAPIEndpointV2)
+
+
+api_router_v3 = WagtailAPIRouterV3('wagtailapi_v3')
+api_router_v3.register_endpoint('pages', PagesAPIEndpointV3)
+api_router_v3.register_endpoint('images', ImagesAPIEndpointV3)
+api_router_v3.register_endpoint('documents', DocumentsAPIEndpointV3)
 
 
 urlpatterns = [
@@ -32,7 +42,8 @@ urlpatterns = [
     url(r'^images/', include(wagtailimages_urls)),
 
     url(r'^api/', include(wagtailapi_urls)),
-    url(r'^api/v2beta/', api_router.urls),
+    url(r'^api/v2beta/', api_router_v2.urls),
+    url(r'^api/v3beta/', api_router_v3.urls),
     url(r'^sitemap\.xml$', sitemaps_views.sitemap),
 
     url(r'^sitemap-index\.xml$', sitemaps_views.index, {

--- a/wagtail/wagtailadmin/api/endpoints.py
+++ b/wagtail/wagtailadmin/api/endpoints.py
@@ -2,10 +2,10 @@ from __future__ import absolute_import, unicode_literals
 
 from collections import OrderedDict
 
-from wagtail.api.v2.endpoints import PagesAPIEndpoint
-from wagtail.api.v2.filters import (
+from wagtail.api.v3.endpoints import PagesAPIEndpoint
+from wagtail.api.v3.filters import (
     ChildOfFilter, DescendantOfFilter, FieldsFilter, OrderingFilter, SearchFilter)
-from wagtail.api.v2.utils import BadRequestError, filter_page_type, page_models_from_string
+from wagtail.api.v3.utils import BadRequestError, filter_page_type, page_models_from_string
 from wagtail.wagtailcore.models import Page
 
 from .filters import HasChildrenFilter

--- a/wagtail/wagtailadmin/api/filters.py
+++ b/wagtail/wagtailadmin/api/filters.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, unicode_literals
 
 from rest_framework.filters import BaseFilterBackend
 
-from wagtail.api.v2.utils import BadRequestError, parse_boolean
+from wagtail.api.v3.utils import BadRequestError, parse_boolean
 
 
 class HasChildrenFilter(BaseFilterBackend):

--- a/wagtail/wagtailadmin/api/serializers.py
+++ b/wagtail/wagtailadmin/api/serializers.py
@@ -4,8 +4,8 @@ from collections import OrderedDict
 
 from rest_framework.fields import Field
 
-from wagtail.api.v2.serializers import PageSerializer
-from wagtail.api.v2.utils import get_full_url
+from wagtail.api.v3.serializers import PageSerializer
+from wagtail.api.v3.utils import get_full_url
 from wagtail.wagtailcore.models import Page
 
 

--- a/wagtail/wagtailadmin/api/urls.py
+++ b/wagtail/wagtailadmin/api/urls.py
@@ -2,17 +2,17 @@ from __future__ import absolute_import, unicode_literals
 
 from django.conf.urls import url
 
-from wagtail.api.v2.router import WagtailAPIRouter
+from wagtail.api.v3.router import WagtailAPIRouter
 from wagtail.wagtailcore import hooks
 
 from .endpoints import PagesAdminAPIEndpoint
 
-admin_api = WagtailAPIRouter('wagtailadmin_api_v1')
+admin_api = WagtailAPIRouter('wagtailadmin_api')
 admin_api.register_endpoint('pages', PagesAdminAPIEndpoint)
 
 for fn in hooks.get_hooks('construct_admin_api'):
     fn(admin_api)
 
 urlpatterns = [
-    url(r'^v2beta/', admin_api.urls),
+    url(r'^v3beta/', admin_api.urls),
 ]

--- a/wagtail/wagtailadmin/templates/wagtailadmin/admin_base.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/admin_base.html
@@ -19,9 +19,9 @@
         (function(document, window) {
             window.wagtailConfig = window.wagtailConfig || {};
             wagtailConfig.ADMIN_API = {
-                PAGES: '{% url "wagtailadmin_api_v1:pages:listing" %}',
-                DOCUMENTS: '{% url "wagtailadmin_api_v1:documents:listing" %}',
-                IMAGES: '{% url "wagtailadmin_api_v1:images:listing" %}',
+                PAGES: '{% url "wagtailadmin_api:pages:listing" %}',
+                DOCUMENTS: '{% url "wagtailadmin_api:documents:listing" %}',
+                IMAGES: '{% url "wagtailadmin_api:images:listing" %}',
                 {# // Use this to add an extra query string on all API requests. #}
                 {# // Example value: '&order=-id' #}
                 EXTRA_CHILDREN_PARAMETERS: '',

--- a/wagtail/wagtailadmin/tests/api/test_documents.py
+++ b/wagtail/wagtailadmin/tests/api/test_documents.py
@@ -4,7 +4,7 @@ import json
 
 from django.core.urlresolvers import reverse
 
-from wagtail.api.v2.tests.test_documents import TestDocumentDetail, TestDocumentListing
+from wagtail.api.v3.tests.test_documents import TestDocumentDetail, TestDocumentListing
 from wagtail.wagtaildocs.models import Document
 
 from .utils import AdminAPITestCase
@@ -14,7 +14,7 @@ class TestAdminDocumentListing(AdminAPITestCase, TestDocumentListing):
     fixtures = ['demosite.json']
 
     def get_response(self, **params):
-        return self.client.get(reverse('wagtailadmin_api_v1:documents:listing'), params)
+        return self.client.get(reverse('wagtailadmin_api:documents:listing'), params)
 
     def get_document_id_list(self, content):
         return [document['id'] for document in content['items']]
@@ -54,7 +54,7 @@ class TestAdminDocumentListing(AdminAPITestCase, TestDocumentListing):
             self.assertEqual(document['meta']['type'], 'wagtaildocs.Document')
 
             # Check detail_url
-            self.assertEqual(document['meta']['detail_url'], 'http://localhost/admin/api/v2beta/documents/%d/' % document['id'])
+            self.assertEqual(document['meta']['detail_url'], 'http://localhost/admin/api/v3beta/documents/%d/' % document['id'])
 
             # Check download_url
             self.assertTrue(document['meta']['download_url'].startswith('http://localhost/documents/%d/' % document['id']))
@@ -75,7 +75,7 @@ class TestAdminDocumentDetail(AdminAPITestCase, TestDocumentDetail):
     fixtures = ['demosite.json']
 
     def get_response(self, image_id, **params):
-        return self.client.get(reverse('wagtailadmin_api_v1:documents:detail', args=(image_id, )), params)
+        return self.client.get(reverse('wagtailadmin_api:documents:detail', args=(image_id, )), params)
 
     def test_basic(self):
         response = self.get_response(1)
@@ -100,7 +100,7 @@ class TestAdminDocumentDetail(AdminAPITestCase, TestDocumentDetail):
 
         # Check the meta detail_url
         self.assertIn('detail_url', content['meta'])
-        self.assertEqual(content['meta']['detail_url'], 'http://localhost/admin/api/v2beta/documents/1/')
+        self.assertEqual(content['meta']['detail_url'], 'http://localhost/admin/api/v3beta/documents/1/')
 
         # Check the meta download_url
         self.assertIn('download_url', content['meta'])

--- a/wagtail/wagtailadmin/tests/api/test_documents.py
+++ b/wagtail/wagtailadmin/tests/api/test_documents.py
@@ -17,7 +17,7 @@ class TestAdminDocumentListing(AdminAPITestCase, TestDocumentListing):
         return self.client.get(reverse('wagtailadmin_api:documents:listing'), params)
 
     def get_document_id_list(self, content):
-        return [document['id'] for document in content['items']]
+        return [document['meta']['id'] for document in content['items']]
 
 
     # BASIC TESTS
@@ -48,16 +48,16 @@ class TestAdminDocumentListing(AdminAPITestCase, TestDocumentListing):
         for document in content['items']:
             self.assertIn('meta', document)
             self.assertIsInstance(document['meta'], dict)
-            self.assertEqual(set(document['meta'].keys()), {'type', 'detail_url', 'download_url', 'tags'})
+            self.assertEqual(set(document['meta'].keys()), {'id', 'type', 'detail_url', 'download_url'})
 
             # Type should always be wagtaildocs.Document
             self.assertEqual(document['meta']['type'], 'wagtaildocs.Document')
 
             # Check detail_url
-            self.assertEqual(document['meta']['detail_url'], 'http://localhost/admin/api/v3beta/documents/%d/' % document['id'])
+            self.assertEqual(document['meta']['detail_url'], 'http://localhost/admin/api/v3beta/documents/%d/' % document['meta']['id'])
 
             # Check download_url
-            self.assertTrue(document['meta']['download_url'].startswith('http://localhost/documents/%d/' % document['id']))
+            self.assertTrue(document['meta']['download_url'].startswith('http://localhost/documents/%d/' % document['meta']['id']))
 
 
     # FIELDS
@@ -67,8 +67,8 @@ class TestAdminDocumentListing(AdminAPITestCase, TestDocumentListing):
         content = json.loads(response.content.decode('UTF-8'))
 
         for document in content['items']:
-            self.assertEqual(set(document.keys()), {'id', 'meta', 'title'})
-            self.assertEqual(set(document['meta'].keys()), {'type', 'detail_url', 'download_url', 'tags'})
+            self.assertEqual(set(document.keys()), {'meta', 'title', 'tags'})
+            self.assertEqual(set(document['meta'].keys()), {'id', 'type', 'detail_url', 'download_url'})
 
 
 class TestAdminDocumentDetail(AdminAPITestCase, TestDocumentDetail):
@@ -86,13 +86,11 @@ class TestAdminDocumentDetail(AdminAPITestCase, TestDocumentDetail):
         # Will crash if the JSON is invalid
         content = json.loads(response.content.decode('UTF-8'))
 
-        # Check the id field
-        self.assertIn('id', content)
-        self.assertEqual(content['id'], 1)
-
         # Check that the meta section is there
-        self.assertIn('meta', content)
         self.assertIsInstance(content['meta'], dict)
+
+        # Check the id field
+        self.assertEqual(content['meta']['id'], 1)
 
         # Check the meta type
         self.assertIn('type', content['meta'])
@@ -111,5 +109,5 @@ class TestAdminDocumentDetail(AdminAPITestCase, TestDocumentDetail):
         self.assertEqual(content['title'], "Wagtail by mark Harkin")
 
         # Check the tags field
-        self.assertIn('tags', content['meta'])
-        self.assertEqual(content['meta']['tags'], [])
+        self.assertIn('tags', content)
+        self.assertEqual(content['tags'], [])

--- a/wagtail/wagtailadmin/tests/api/test_images.py
+++ b/wagtail/wagtailadmin/tests/api/test_images.py
@@ -4,7 +4,7 @@ import json
 
 from django.core.urlresolvers import reverse
 
-from wagtail.api.v2.tests.test_images import TestImageDetail, TestImageListing
+from wagtail.api.v3.tests.test_images import TestImageDetail, TestImageListing
 from wagtail.wagtailimages import get_image_model
 from wagtail.wagtailimages.tests.utils import get_test_image_file
 
@@ -15,7 +15,7 @@ class TestAdminImageListing(AdminAPITestCase, TestImageListing):
     fixtures = ['demosite.json']
 
     def get_response(self, **params):
-        return self.client.get(reverse('wagtailadmin_api_v1:images:listing'), params)
+        return self.client.get(reverse('wagtailadmin_api:images:listing'), params)
 
     def get_image_id_list(self, content):
         return [image['id'] for image in content['items']]
@@ -55,7 +55,7 @@ class TestAdminImageListing(AdminAPITestCase, TestImageListing):
             self.assertEqual(image['meta']['type'], 'wagtailimages.Image')
 
             # Check detail url
-            self.assertEqual(image['meta']['detail_url'], 'http://localhost/admin/api/v2beta/images/%d/' % image['id'])
+            self.assertEqual(image['meta']['detail_url'], 'http://localhost/admin/api/v3beta/images/%d/' % image['id'])
 
 
     #  FIELDS
@@ -135,7 +135,7 @@ class TestAdminImageDetail(AdminAPITestCase, TestImageDetail):
     fixtures = ['demosite.json']
 
     def get_response(self, image_id, **params):
-        return self.client.get(reverse('wagtailadmin_api_v1:images:detail', args=(image_id, )), params)
+        return self.client.get(reverse('wagtailadmin_api:images:detail', args=(image_id, )), params)
 
     def test_basic(self):
         response = self.get_response(5)
@@ -160,7 +160,7 @@ class TestAdminImageDetail(AdminAPITestCase, TestImageDetail):
 
         # Check the meta detail_url
         self.assertIn('detail_url', content['meta'])
-        self.assertEqual(content['meta']['detail_url'], 'http://localhost/admin/api/v2beta/images/5/')
+        self.assertEqual(content['meta']['detail_url'], 'http://localhost/admin/api/v3beta/images/5/')
 
         # Check the thumbnail
 

--- a/wagtail/wagtailadmin/tests/api/test_images.py
+++ b/wagtail/wagtailadmin/tests/api/test_images.py
@@ -18,7 +18,7 @@ class TestAdminImageListing(AdminAPITestCase, TestImageListing):
         return self.client.get(reverse('wagtailadmin_api:images:listing'), params)
 
     def get_image_id_list(self, content):
-        return [image['id'] for image in content['items']]
+        return [image['meta']['id'] for image in content['items']]
 
 
     # BASIC TESTS
@@ -49,13 +49,13 @@ class TestAdminImageListing(AdminAPITestCase, TestImageListing):
         for image in content['items']:
             self.assertIn('meta', image)
             self.assertIsInstance(image['meta'], dict)
-            self.assertEqual(set(image['meta'].keys()), {'type', 'detail_url', 'tags'})
+            self.assertEqual(set(image['meta'].keys()), {'id', 'type', 'detail_url'})
 
             # Type should always be wagtailimages.Image
             self.assertEqual(image['meta']['type'], 'wagtailimages.Image')
 
             # Check detail url
-            self.assertEqual(image['meta']['detail_url'], 'http://localhost/admin/api/v3beta/images/%d/' % image['id'])
+            self.assertEqual(image['meta']['detail_url'], 'http://localhost/admin/api/v3beta/images/%d/' % image['meta']['id'])
 
 
     #  FIELDS
@@ -65,70 +65,61 @@ class TestAdminImageListing(AdminAPITestCase, TestImageListing):
         content = json.loads(response.content.decode('UTF-8'))
 
         for image in content['items']:
-            self.assertEqual(set(image.keys()), {'id', 'meta', 'title', 'width', 'height', 'thumbnail'})
-            self.assertEqual(set(image['meta'].keys()), {'type', 'detail_url', 'tags'})
+            self.assertEqual(set(image.keys()), {'meta', 'title', 'tags', 'width', 'height', 'thumbnail'})
+            self.assertEqual(set(image['meta'].keys()), {'id', 'type', 'detail_url'})
 
     def test_fields(self):
         response = self.get_response(fields='width,height')
         content = json.loads(response.content.decode('UTF-8'))
 
         for image in content['items']:
-            self.assertEqual(set(image.keys()), {'id', 'meta', 'title', 'width', 'height', 'thumbnail'})
-            self.assertEqual(set(image['meta'].keys()), {'type', 'detail_url', 'tags'})
+            self.assertEqual(set(image.keys()), {'meta', 'title', 'tags', 'width', 'height', 'thumbnail'})
+            self.assertEqual(set(image['meta'].keys()), {'id', 'type', 'detail_url'})
 
     def test_remove_fields(self):
         response = self.get_response(fields='-title')
         content = json.loads(response.content.decode('UTF-8'))
 
         for image in content['items']:
-            self.assertEqual(set(image.keys()), {'id', 'meta', 'width', 'height', 'thumbnail'})
+            self.assertEqual(set(image.keys()), {'meta', 'tags', 'width', 'height', 'thumbnail'})
 
     def test_remove_meta_fields(self):
-        response = self.get_response(fields='-tags')
+        response = self.get_response(fields='-type')
         content = json.loads(response.content.decode('UTF-8'))
 
         for image in content['items']:
-            self.assertEqual(set(image.keys()), {'id', 'meta', 'title', 'width', 'height', 'thumbnail'})
-            self.assertEqual(set(image['meta'].keys()), {'type', 'detail_url'})
+            self.assertEqual(set(image.keys()), {'meta', 'tags', 'title', 'width', 'height', 'thumbnail'})
+            self.assertEqual(set(image['meta'].keys()), {'id', 'detail_url'})
 
     def test_remove_all_meta_fields(self):
-        response = self.get_response(fields='-type,-detail_url,-tags')
+        response = self.get_response(fields='-id,-type,-detail_url')
         content = json.loads(response.content.decode('UTF-8'))
 
         for image in content['items']:
-            self.assertEqual(set(image.keys()), {'id', 'title', 'width', 'height', 'thumbnail'})
-
-    def test_remove_id_field(self):
-        response = self.get_response(fields='-id')
-        content = json.loads(response.content.decode('UTF-8'))
-
-        for image in content['items']:
-            self.assertEqual(set(image.keys()), {'meta', 'title', 'width', 'height', 'thumbnail'})
+            self.assertEqual(set(image.keys()), {'title', 'tags', 'width', 'height', 'thumbnail'})
 
     def test_all_fields(self):
         response = self.get_response(fields='*')
         content = json.loads(response.content.decode('UTF-8'))
 
         for image in content['items']:
-            self.assertEqual(set(image.keys()), {'id', 'meta', 'title', 'width', 'height', 'thumbnail'})
-            self.assertEqual(set(image['meta'].keys()), {'type', 'detail_url', 'tags'})
+            self.assertEqual(set(image.keys()), {'meta', 'title', 'tags', 'width', 'height', 'thumbnail'})
+            self.assertEqual(set(image['meta'].keys()), {'id', 'type', 'detail_url'})
 
     def test_all_fields_then_remove_something(self):
-        response = self.get_response(fields='*,-title,-tags')
+        response = self.get_response(fields='*,-title,-tags,-type')
         content = json.loads(response.content.decode('UTF-8'))
 
         for image in content['items']:
-            self.assertEqual(set(image.keys()), {'id', 'meta', 'width', 'height', 'thumbnail'})
-            self.assertEqual(set(image['meta'].keys()), {'type', 'detail_url'})
+            self.assertEqual(set(image.keys()), {'meta', 'width', 'height', 'thumbnail'})
+            self.assertEqual(set(image['meta'].keys()), {'id', 'detail_url'})
 
     def test_fields_tags(self):
         response = self.get_response(fields='tags')
         content = json.loads(response.content.decode('UTF-8'))
 
         for image in content['items']:
-            self.assertEqual(set(image.keys()), {'id', 'meta', 'title', 'width', 'height', 'thumbnail'})
-            self.assertEqual(set(image['meta'].keys()), {'type', 'detail_url', 'tags'})
-            self.assertIsInstance(image['meta']['tags'], list)
+            self.assertIsInstance(image['tags'], list)
 
 
 class TestAdminImageDetail(AdminAPITestCase, TestImageDetail):
@@ -146,42 +137,33 @@ class TestAdminImageDetail(AdminAPITestCase, TestImageDetail):
         # Will crash if the JSON is invalid
         content = json.loads(response.content.decode('UTF-8'))
 
-        # Check the id field
-        self.assertIn('id', content)
-        self.assertEqual(content['id'], 5)
-
         # Check that the meta section is there
-        self.assertIn('meta', content)
         self.assertIsInstance(content['meta'], dict)
 
+        # Check the id field
+        self.assertEqual(content['meta']['id'], 5)
+
         # Check the meta type
-        self.assertIn('type', content['meta'])
         self.assertEqual(content['meta']['type'], 'wagtailimages.Image')
 
         # Check the meta detail_url
-        self.assertIn('detail_url', content['meta'])
         self.assertEqual(content['meta']['detail_url'], 'http://localhost/admin/api/v3beta/images/5/')
 
         # Check the thumbnail
 
         # Note: This is None because the source image doesn't exist
         #       See test_thumbnail below for working example
-        self.assertIn('thumbnail', content)
         self.assertEqual(content['thumbnail'], {'error': 'SourceImageIOError'})
 
         # Check the title field
-        self.assertIn('title', content)
         self.assertEqual(content['title'], "James Joyce")
 
+        # Check the tags field
+        self.assertEqual(content['tags'], [])
+
         # Check the width and height fields
-        self.assertIn('width', content)
-        self.assertIn('height', content)
         self.assertEqual(content['width'], 500)
         self.assertEqual(content['height'], 392)
-
-        # Check the tags field
-        self.assertIn('tags', content['meta'])
-        self.assertEqual(content['meta']['tags'], [])
 
     def test_thumbnail(self):
         # Add a new image with source file

--- a/wagtail/wagtailadmin/tests/api/test_pages.py
+++ b/wagtail/wagtailadmin/tests/api/test_pages.py
@@ -27,7 +27,7 @@ class TestAdminPageListing(AdminAPITestCase, TestPageListing):
         return self.client.get(reverse('wagtailadmin_api:pages:listing'), params)
 
     def get_page_id_list(self, content):
-        return [page['id'] for page in content['items']]
+        return [page['meta']['id'] for page in content['items']]
 
 
     # BASIC TESTS
@@ -42,23 +42,19 @@ class TestAdminPageListing(AdminAPITestCase, TestPageListing):
         content = json.loads(response.content.decode('UTF-8'))
 
         # Check that the meta section is there
-        self.assertIn('meta', content)
         self.assertIsInstance(content['meta'], dict)
 
         # Check that the total count is there and correct
-        self.assertIn('total_count', content['meta'])
         self.assertIsInstance(content['meta']['total_count'], int)
         self.assertEqual(content['meta']['total_count'], get_total_page_count())
 
         # Check that the items section is there
-        self.assertIn('items', content)
         self.assertIsInstance(content['items'], list)
 
         # Check that each page has a meta section with type, detail_url, html_url, status and children attributes
         for page in content['items']:
-            self.assertIn('meta', page)
             self.assertIsInstance(page['meta'], dict)
-            self.assertEqual(set(page['meta'].keys()), {'type', 'detail_url', 'html_url', 'status', 'children', 'slug', 'first_published_at', 'latest_revision_created_at'})
+            self.assertEqual(set(page['meta'].keys()), {'id', 'type', 'detail_url', 'html_url', 'status', 'children', 'first_published_at', 'latest_revision_created_at'})
 
         # Check the type info
         self.assertIsInstance(content['__types'], dict)
@@ -115,46 +111,55 @@ class TestAdminPageListing(AdminAPITestCase, TestPageListing):
         content = json.loads(response.content.decode('UTF-8'))
 
         for page in content['items']:
-            self.assertEqual(set(page.keys()), {'id', 'meta', 'title'})
-            self.assertEqual(set(page['meta'].keys()), {'type', 'detail_url', 'html_url', 'children', 'status', 'slug', 'first_published_at', 'latest_revision_created_at'})
+            self.assertEqual(set(page.keys()), {'meta', 'title', 'slug'})
+            self.assertEqual(set(page['meta'].keys()), {'id', 'type', 'detail_url', 'html_url', 'children', 'status', 'first_published_at', 'latest_revision_created_at'})
+
+    def test_fields(self):
+        response = self.get_response(type='demosite.BlogEntryPage', fields='title,date,feed_image')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for page in content['items']:
+            self.assertEqual(set(page.keys()), {'meta', 'title', 'slug', 'date', 'feed_image'})
+            self.assertEqual(set(page['meta'].keys()), {'id', 'type', 'detail_url', 'html_url', 'first_published_at', 'children', 'status', 'latest_revision_created_at'})
 
     def test_remove_meta_fields(self):
         response = self.get_response(fields='-html_url')
         content = json.loads(response.content.decode('UTF-8'))
 
         for page in content['items']:
-            self.assertEqual(set(page.keys()), {'id', 'meta', 'title'})
-            self.assertEqual(set(page['meta'].keys()), {'type', 'detail_url', 'slug', 'first_published_at', 'latest_revision_created_at', 'status', 'children'})
+            self.assertEqual(set(page.keys()), {'meta', 'title', 'slug'})
+            self.assertEqual(set(page['meta'].keys()), {'id', 'type', 'detail_url', 'first_published_at', 'latest_revision_created_at', 'status', 'children'})
 
     def test_remove_all_meta_fields(self):
-        response = self.get_response(fields='-type,-detail_url,-slug,-first_published_at,-html_url,-latest_revision_created_at,-status,-children')
+        response = self.get_response(fields='-id,-type,-detail_url,-first_published_at,-html_url,-latest_revision_created_at,-status,-children')
         content = json.loads(response.content.decode('UTF-8'))
 
         for page in content['items']:
-            self.assertEqual(set(page.keys()), {'id', 'title'})
+            self.assertEqual(set(page.keys()), {'title', 'slug'})
 
     def test_all_fields(self):
         response = self.get_response(type='demosite.BlogEntryPage', fields='*')
         content = json.loads(response.content.decode('UTF-8'))
 
         for page in content['items']:
-            self.assertEqual(set(page.keys()), {'id', 'meta', 'title', 'date', 'related_links', 'tags', 'carousel_items', 'body', 'feed_image', 'feed_image_thumbnail'})
-            self.assertEqual(set(page['meta'].keys()), {'type', 'detail_url', 'show_in_menus', 'first_published_at', 'seo_title', 'slug', 'parent', 'html_url', 'search_description', 'children', 'descendants', 'status', 'latest_revision_created_at'})
+            self.assertEqual(set(page.keys()), {'meta', 'title', 'slug', 'seo_title', 'search_description', 'show_in_menus', 'date', 'related_links', 'tags', 'carousel_items', 'body', 'feed_image', 'feed_image_thumbnail'})
+            self.assertEqual(set(page['meta'].keys()), {'id', 'type', 'detail_url', 'first_published_at', 'parent', 'html_url', 'children', 'descendants', 'status', 'latest_revision_created_at'})
 
     def test_all_fields_then_remove_something(self):
         response = self.get_response(type='demosite.BlogEntryPage', fields='*,-title,-date,-seo_title,-status')
         content = json.loads(response.content.decode('UTF-8'))
 
         for page in content['items']:
-            self.assertEqual(set(page.keys()), {'id', 'meta', 'related_links', 'tags', 'carousel_items', 'body', 'feed_image', 'feed_image_thumbnail'})
-            self.assertEqual(set(page['meta'].keys()), {'type', 'detail_url', 'show_in_menus', 'first_published_at', 'slug', 'parent', 'html_url', 'search_description', 'children', 'descendants', 'latest_revision_created_at'})
+            self.assertEqual(set(page.keys()), {'meta', 'slug', 'show_in_menus', 'search_description', 'related_links', 'tags', 'carousel_items', 'body', 'feed_image', 'feed_image_thumbnail'})
+            self.assertEqual(set(page['meta'].keys()), {'id', 'type', 'detail_url', 'first_published_at', 'parent', 'html_url', 'children', 'descendants', 'latest_revision_created_at'})
 
     def test_all_nested_fields(self):
         response = self.get_response(type='demosite.BlogEntryPage', fields='feed_image(*)')
         content = json.loads(response.content.decode('UTF-8'))
 
         for page in content['items']:
-            self.assertEqual(set(page['feed_image'].keys()), {'id', 'meta', 'title', 'width', 'height', 'thumbnail'})
+            self.assertEqual(set(page['feed_image'].keys()), {'meta', 'title', 'tags', 'width', 'height', 'thumbnail'})
+            self.assertEqual(set(page['feed_image']['meta'].keys()), {'id', 'type', 'detail_url'})
 
     def test_fields_foreign_key(self):
         # Only the base the detail_url is different here from the public API
@@ -166,12 +171,12 @@ class TestAdminPageListing(AdminAPITestCase, TestPageListing):
 
             if feed_image is not None:
                 self.assertIsInstance(feed_image, dict)
-                self.assertEqual(set(feed_image.keys()), {'id', 'meta', 'title'})
-                self.assertIsInstance(feed_image['id'], int)
+                self.assertEqual(set(feed_image.keys()), {'meta', 'title'})
                 self.assertIsInstance(feed_image['meta'], dict)
-                self.assertEqual(set(feed_image['meta'].keys()), {'type', 'detail_url'})
+                self.assertEqual(set(feed_image['meta'].keys()), {'id', 'type', 'detail_url'})
+                self.assertIsInstance(feed_image['meta']['id'], int)
                 self.assertEqual(feed_image['meta']['type'], 'wagtailimages.Image')
-                self.assertEqual(feed_image['meta']['detail_url'], 'http://localhost/admin/api/v3beta/images/%d/' % feed_image['id'])
+                self.assertEqual(feed_image['meta']['detail_url'], 'http://localhost/admin/api/v3beta/images/%d/' % feed_image['meta']['id'])
 
     def test_fields_parent(self):
         response = self.get_response(type='demosite.BlogEntryPage', fields='parent')
@@ -182,13 +187,14 @@ class TestAdminPageListing(AdminAPITestCase, TestPageListing):
 
             # All blog entry pages have the same parent
             self.assertDictEqual(parent, {
-                'id': 5,
                 'meta': {
+                    'id': 5,
                     'type': 'demosite.BlogIndexPage',
                     'detail_url': 'http://localhost/admin/api/v3beta/pages/5/',
                     'html_url': 'http://localhost/blog-index/',
                 },
-                'title': "Blog index"
+                'title': "Blog index",
+                'slug': 'blog-index'
             })
 
     def test_fields_descendants(self):
@@ -199,7 +205,37 @@ class TestAdminPageListing(AdminAPITestCase, TestPageListing):
             descendants = page['meta']['descendants']
             self.assertEqual(set(descendants.keys()), {'count', 'listing_url'})
             self.assertIsInstance(descendants['count'], int)
-            self.assertEqual(descendants['listing_url'], 'http://localhost/admin/api/v3beta/pages/?descendant_of=%d' % page['id'])
+            self.assertEqual(descendants['listing_url'], 'http://localhost/admin/api/v3beta/pages/?descendant_of=%d' % page['meta']['id'])
+
+    def test_fields_ordering(self):
+        response = self.get_response(type='demosite.BlogEntryPage', fields='date,title,feed_image,related_links')
+
+        # Will crash if the JSON is invalid
+        content = json.loads(response.content.decode('UTF-8'))
+
+        # Test field order
+        content = json.JSONDecoder(object_pairs_hook=collections.OrderedDict).decode(response.content.decode('UTF-8'))
+        field_order = [
+            'meta',
+            'title',
+            'slug',
+            'date',
+            'feed_image',
+            'related_links',
+        ]
+        self.assertEqual(list(content['items'][0].keys()), field_order)
+
+        meta_field_order = [
+            'id',
+            'type',
+            'detail_url',
+            'html_url',
+            'first_published_at',
+            'latest_revision_created_at',
+            'status',
+            'children',
+        ]
+        self.assertEqual(list(content['items'][0]['meta'].keys()), meta_field_order)
 
 
     # CHILD OF FILTER
@@ -306,29 +342,22 @@ class TestAdminPageDetail(AdminAPITestCase, TestPageDetail):
         # Will crash if the JSON is invalid
         content = json.loads(response.content.decode('UTF-8'))
 
-        # Check the id field
-        self.assertIn('id', content)
-        self.assertEqual(content['id'], 16)
-
         # Check that the meta section is there
-        self.assertIn('meta', content)
         self.assertIsInstance(content['meta'], dict)
 
+        # Check the id field
+        self.assertEqual(content['meta']['id'], 16)
+
         # Check the meta type
-        self.assertIn('type', content['meta'])
         self.assertEqual(content['meta']['type'], 'demosite.BlogEntryPage')
 
         # Check the meta detail_url
-        self.assertIn('detail_url', content['meta'])
         self.assertEqual(content['meta']['detail_url'], 'http://localhost/admin/api/v3beta/pages/16/')
 
         # Check the meta html_url
-        self.assertIn('html_url', content['meta'])
         self.assertEqual(content['meta']['html_url'], 'http://localhost/blog-index/blog-post/')
 
         # Check the meta status
-
-        self.assertIn('status', content['meta'])
         self.assertEqual(content['meta']['status'], {
             'status': 'live',
             'live': True,
@@ -336,20 +365,17 @@ class TestAdminPageDetail(AdminAPITestCase, TestPageDetail):
         })
 
         # Check the meta children
-
-        self.assertIn('children', content['meta'])
         self.assertEqual(content['meta']['children'], {
             'count': 0,
             'listing_url': 'http://localhost/admin/api/v3beta/pages/?child_of=16'
         })
 
         # Check the parent field
-        self.assertIn('parent', content['meta'])
         self.assertIsInstance(content['meta']['parent'], dict)
-        self.assertEqual(set(content['meta']['parent'].keys()), {'id', 'meta', 'title'})
-        self.assertEqual(content['meta']['parent']['id'], 5)
+        self.assertEqual(set(content['meta']['parent'].keys()), {'meta', 'title', 'slug'})
         self.assertIsInstance(content['meta']['parent']['meta'], dict)
-        self.assertEqual(set(content['meta']['parent']['meta'].keys()), {'type', 'detail_url', 'html_url'})
+        self.assertEqual(set(content['meta']['parent']['meta'].keys()), {'id', 'type', 'detail_url', 'html_url'})
+        self.assertEqual(content['meta']['parent']['meta']['id'], 5)
         self.assertEqual(content['meta']['parent']['meta']['type'], 'demosite.BlogIndexPage')
         self.assertEqual(content['meta']['parent']['meta']['detail_url'], 'http://localhost/admin/api/v3beta/pages/5/')
         self.assertEqual(content['meta']['parent']['meta']['html_url'], 'http://localhost/blog-index/')
@@ -370,18 +396,18 @@ class TestAdminPageDetail(AdminAPITestCase, TestPageDetail):
 
         # Check that the feed image was serialised properly
         self.assertIsInstance(content['feed_image'], dict)
-        self.assertEqual(set(content['feed_image'].keys()), {'id', 'meta', 'title'})
-        self.assertEqual(content['feed_image']['id'], 7)
+        self.assertEqual(set(content['feed_image'].keys()), {'meta', 'title'})
         self.assertIsInstance(content['feed_image']['meta'], dict)
-        self.assertEqual(set(content['feed_image']['meta'].keys()), {'type', 'detail_url'})
+        self.assertEqual(set(content['feed_image']['meta'].keys()), {'id', 'type', 'detail_url'})
+        self.assertEqual(content['feed_image']['meta']['id'], 7)
         self.assertEqual(content['feed_image']['meta']['type'], 'wagtailimages.Image')
         self.assertEqual(content['feed_image']['meta']['detail_url'], 'http://localhost/admin/api/v3beta/images/7/')
 
         # Check that the child relations were serialised properly
         self.assertEqual(content['related_links'], [])
         for carousel_item in content['carousel_items']:
-            self.assertEqual(set(carousel_item.keys()), {'id', 'meta', 'embed_url', 'link', 'caption', 'image'})
-            self.assertEqual(set(carousel_item['meta'].keys()), {'type'})
+            self.assertEqual(set(carousel_item.keys()), {'meta', 'embed_url', 'link', 'caption', 'image'})
+            self.assertEqual(set(carousel_item['meta'].keys()), {'id', 'type'})
 
         # Check the type info
         self.assertIsInstance(content['__types'], dict)
@@ -406,9 +432,12 @@ class TestAdminPageDetail(AdminAPITestCase, TestPageDetail):
         # Test field order
         content = json.JSONDecoder(object_pairs_hook=collections.OrderedDict).decode(response.content.decode('UTF-8'))
         field_order = [
-            'id',
             'meta',
             'title',
+            'slug',
+            'show_in_menus',
+            'seo_title',
+            'search_description',
             'body',
             'tags',
             'date',
@@ -419,6 +448,20 @@ class TestAdminPageDetail(AdminAPITestCase, TestPageDetail):
             '__types',
         ]
         self.assertEqual(list(content.keys()), field_order)
+
+        meta_field_order = [
+            'id',
+            'type',
+            'detail_url',
+            'html_url',
+            'first_published_at',
+            'parent',
+            'latest_revision_created_at',
+            'status',
+            'children',
+            'descendants',
+        ]
+        self.assertEqual(list(content['meta'].keys()), meta_field_order)
 
     def test_meta_status_draft(self):
         # Unpublish the page
@@ -504,24 +547,25 @@ class TestAdminPageDetail(AdminAPITestCase, TestPageDetail):
     # FIELDS
 
     def test_remove_all_meta_fields(self):
-        response = self.get_response(16, fields='-type,-detail_url,-slug,-first_published_at,-html_url,-descendants,-latest_revision_created_at,-children,-show_in_menus,-seo_title,-parent,-status,-search_description')
+        response = self.get_response(16, fields='-id,-type,-detail_url,-first_published_at,-html_url,-descendants,-latest_revision_created_at,-children,-show_in_menus,-seo_title,-parent,-status,-search_description')
         content = json.loads(response.content.decode('UTF-8'))
 
         self.assertNotIn('meta', set(content.keys()))
-        self.assertIn('id', set(content.keys()))
+        self.assertIn('title', set(content.keys()))
 
     def test_remove_all_fields(self):
-        response = self.get_response(16, fields='_,id,type')
+        response = self.get_response(16, fields='_,id,title')
         content = json.loads(response.content.decode('UTF-8'))
 
-        self.assertEqual(set(content.keys()), {'id', 'meta', '__types'})
-        self.assertEqual(set(content['meta'].keys()), {'type'})
+        self.assertEqual(set(content.keys()), {'meta', 'title', '__types'})
+        self.assertEqual(set(content['meta'].keys()), {'id'})
 
     def test_all_nested_fields(self):
         response = self.get_response(16, fields='feed_image(*)')
         content = json.loads(response.content.decode('UTF-8'))
 
-        self.assertEqual(set(content['feed_image'].keys()), {'id', 'meta', 'title', 'width', 'height', 'thumbnail'})
+        self.assertEqual(set(content['feed_image'].keys()), {'meta', 'title', 'tags', 'width', 'height', 'thumbnail'})
+        self.assertEqual(set(content['feed_image']['meta'].keys()), {'id', 'type', 'detail_url'})
 
     def test_fields_foreign_key(self):
         response = self.get_response(16)
@@ -530,12 +574,12 @@ class TestAdminPageDetail(AdminAPITestCase, TestPageDetail):
         feed_image = content['feed_image']
 
         self.assertIsInstance(feed_image, dict)
-        self.assertEqual(set(feed_image.keys()), {'id', 'meta', 'title'})
-        self.assertIsInstance(feed_image['id'], int)
+        self.assertEqual(set(feed_image.keys()), {'meta', 'title'})
         self.assertIsInstance(feed_image['meta'], dict)
-        self.assertEqual(set(feed_image['meta'].keys()), {'type', 'detail_url'})
+        self.assertEqual(set(feed_image['meta'].keys()), {'id', 'type', 'detail_url'})
+        self.assertIsInstance(feed_image['meta']['id'], int)
         self.assertEqual(feed_image['meta']['type'], 'wagtailimages.Image')
-        self.assertEqual(feed_image['meta']['detail_url'], 'http://localhost/admin/api/v3beta/images/%d/' % feed_image['id'])
+        self.assertEqual(feed_image['meta']['detail_url'], 'http://localhost/admin/api/v3beta/images/%d/' % feed_image['meta']['id'])
 
 
 class TestAdminPageDetailWithStreamField(AdminAPITestCase):
@@ -565,8 +609,7 @@ class TestAdminPageDetailWithStreamField(AdminAPITestCase):
 
         content = json.loads(response.content.decode('utf-8'))
 
-        self.assertIn('id', content)
-        self.assertEqual(content['id'], stream_page.id)
+        self.assertEqual(content['meta']['id'], stream_page.id)
         self.assertIn('body', content)
         self.assertEqual(len(content['body']), 1)
         self.assertEqual(content['body'][0]['type'], 'text')

--- a/wagtail/wagtailadmin/tests/api/test_pages.py
+++ b/wagtail/wagtailadmin/tests/api/test_pages.py
@@ -7,7 +7,7 @@ import json
 from django.core.urlresolvers import reverse
 from django.utils import timezone
 
-from wagtail.api.v2.tests.test_pages import TestPageDetail, TestPageListing
+from wagtail.api.v3.tests.test_pages import TestPageDetail, TestPageListing
 from wagtail.tests.demosite import models
 from wagtail.tests.testapp.models import StreamPage
 from wagtail.wagtailcore.models import Page
@@ -24,7 +24,7 @@ class TestAdminPageListing(AdminAPITestCase, TestPageListing):
     fixtures = ['demosite.json']
 
     def get_response(self, **params):
-        return self.client.get(reverse('wagtailadmin_api_v1:pages:listing'), params)
+        return self.client.get(reverse('wagtailadmin_api:pages:listing'), params)
 
     def get_page_id_list(self, content):
         return [page['id'] for page in content['items']]
@@ -171,7 +171,7 @@ class TestAdminPageListing(AdminAPITestCase, TestPageListing):
                 self.assertIsInstance(feed_image['meta'], dict)
                 self.assertEqual(set(feed_image['meta'].keys()), {'type', 'detail_url'})
                 self.assertEqual(feed_image['meta']['type'], 'wagtailimages.Image')
-                self.assertEqual(feed_image['meta']['detail_url'], 'http://localhost/admin/api/v2beta/images/%d/' % feed_image['id'])
+                self.assertEqual(feed_image['meta']['detail_url'], 'http://localhost/admin/api/v3beta/images/%d/' % feed_image['id'])
 
     def test_fields_parent(self):
         response = self.get_response(type='demosite.BlogEntryPage', fields='parent')
@@ -185,7 +185,7 @@ class TestAdminPageListing(AdminAPITestCase, TestPageListing):
                 'id': 5,
                 'meta': {
                     'type': 'demosite.BlogIndexPage',
-                    'detail_url': 'http://localhost/admin/api/v2beta/pages/5/',
+                    'detail_url': 'http://localhost/admin/api/v3beta/pages/5/',
                     'html_url': 'http://localhost/blog-index/',
                 },
                 'title': "Blog index"
@@ -199,7 +199,7 @@ class TestAdminPageListing(AdminAPITestCase, TestPageListing):
             descendants = page['meta']['descendants']
             self.assertEqual(set(descendants.keys()), {'count', 'listing_url'})
             self.assertIsInstance(descendants['count'], int)
-            self.assertEqual(descendants['listing_url'], 'http://localhost/admin/api/v2beta/pages/?descendant_of=%d' % page['id'])
+            self.assertEqual(descendants['listing_url'], 'http://localhost/admin/api/v3beta/pages/?descendant_of=%d' % page['id'])
 
 
     # CHILD OF FILTER
@@ -295,7 +295,7 @@ class TestAdminPageDetail(AdminAPITestCase, TestPageDetail):
     fixtures = ['demosite.json']
 
     def get_response(self, page_id, **params):
-        return self.client.get(reverse('wagtailadmin_api_v1:pages:detail', args=(page_id, )), params)
+        return self.client.get(reverse('wagtailadmin_api:pages:detail', args=(page_id, )), params)
 
     def test_basic(self):
         response = self.get_response(16)
@@ -320,7 +320,7 @@ class TestAdminPageDetail(AdminAPITestCase, TestPageDetail):
 
         # Check the meta detail_url
         self.assertIn('detail_url', content['meta'])
-        self.assertEqual(content['meta']['detail_url'], 'http://localhost/admin/api/v2beta/pages/16/')
+        self.assertEqual(content['meta']['detail_url'], 'http://localhost/admin/api/v3beta/pages/16/')
 
         # Check the meta html_url
         self.assertIn('html_url', content['meta'])
@@ -340,7 +340,7 @@ class TestAdminPageDetail(AdminAPITestCase, TestPageDetail):
         self.assertIn('children', content['meta'])
         self.assertEqual(content['meta']['children'], {
             'count': 0,
-            'listing_url': 'http://localhost/admin/api/v2beta/pages/?child_of=16'
+            'listing_url': 'http://localhost/admin/api/v3beta/pages/?child_of=16'
         })
 
         # Check the parent field
@@ -351,7 +351,7 @@ class TestAdminPageDetail(AdminAPITestCase, TestPageDetail):
         self.assertIsInstance(content['meta']['parent']['meta'], dict)
         self.assertEqual(set(content['meta']['parent']['meta'].keys()), {'type', 'detail_url', 'html_url'})
         self.assertEqual(content['meta']['parent']['meta']['type'], 'demosite.BlogIndexPage')
-        self.assertEqual(content['meta']['parent']['meta']['detail_url'], 'http://localhost/admin/api/v2beta/pages/5/')
+        self.assertEqual(content['meta']['parent']['meta']['detail_url'], 'http://localhost/admin/api/v3beta/pages/5/')
         self.assertEqual(content['meta']['parent']['meta']['html_url'], 'http://localhost/blog-index/')
 
         # Check that the custom fields are included
@@ -375,7 +375,7 @@ class TestAdminPageDetail(AdminAPITestCase, TestPageDetail):
         self.assertIsInstance(content['feed_image']['meta'], dict)
         self.assertEqual(set(content['feed_image']['meta'].keys()), {'type', 'detail_url'})
         self.assertEqual(content['feed_image']['meta']['type'], 'wagtailimages.Image')
-        self.assertEqual(content['feed_image']['meta']['detail_url'], 'http://localhost/admin/api/v2beta/images/7/')
+        self.assertEqual(content['feed_image']['meta']['detail_url'], 'http://localhost/admin/api/v3beta/images/7/')
 
         # Check that the child relations were serialised properly
         self.assertEqual(content['related_links'], [])
@@ -487,7 +487,7 @@ class TestAdminPageDetail(AdminAPITestCase, TestPageDetail):
         self.assertIn('children', content['meta'])
         self.assertEqual(content['meta']['children'], {
             'count': 5,
-            'listing_url': 'http://localhost/admin/api/v2beta/pages/?child_of=2'
+            'listing_url': 'http://localhost/admin/api/v3beta/pages/?child_of=2'
         })
 
     def test_meta_descendants(self):
@@ -498,7 +498,7 @@ class TestAdminPageDetail(AdminAPITestCase, TestPageDetail):
         self.assertIn('descendants', content['meta'])
         self.assertEqual(content['meta']['descendants'], {
             'count': 18,
-            'listing_url': 'http://localhost/admin/api/v2beta/pages/?descendant_of=2'
+            'listing_url': 'http://localhost/admin/api/v3beta/pages/?descendant_of=2'
         })
 
     # FIELDS
@@ -535,7 +535,7 @@ class TestAdminPageDetail(AdminAPITestCase, TestPageDetail):
         self.assertIsInstance(feed_image['meta'], dict)
         self.assertEqual(set(feed_image['meta'].keys()), {'type', 'detail_url'})
         self.assertEqual(feed_image['meta']['type'], 'wagtailimages.Image')
-        self.assertEqual(feed_image['meta']['detail_url'], 'http://localhost/admin/api/v2beta/images/%d/' % feed_image['id'])
+        self.assertEqual(feed_image['meta']['detail_url'], 'http://localhost/admin/api/v3beta/images/%d/' % feed_image['id'])
 
 
 class TestAdminPageDetailWithStreamField(AdminAPITestCase):
@@ -557,7 +557,7 @@ class TestAdminPageDetailWithStreamField(AdminAPITestCase):
     def test_can_fetch_streamfield_content(self):
         stream_page = self.make_stream_page('[{"type": "text", "value": "foo"}]')
 
-        response_url = reverse('wagtailadmin_api_v1:pages:detail', args=(stream_page.id, ))
+        response_url = reverse('wagtailadmin_api:pages:detail', args=(stream_page.id, ))
         response = self.client.get(response_url)
 
         self.assertEqual(response.status_code, 200)
@@ -576,7 +576,7 @@ class TestAdminPageDetailWithStreamField(AdminAPITestCase):
     def test_image_block(self):
         stream_page = self.make_stream_page('[{"type": "image", "value": 1}]')
 
-        response_url = reverse('wagtailadmin_api_v1:pages:detail', args=(stream_page.id, ))
+        response_url = reverse('wagtailadmin_api:pages:detail', args=(stream_page.id, ))
         response = self.client.get(response_url)
         content = json.loads(response.content.decode('utf-8'))
 

--- a/wagtail/wagtaildocs/api/admin/endpoints.py
+++ b/wagtail/wagtaildocs/api/admin/endpoints.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
-from ..v2.endpoints import DocumentsAPIEndpoint
+from ..v3.endpoints import DocumentsAPIEndpoint
 
 
 class DocumentsAdminAPIEndpoint(DocumentsAPIEndpoint):

--- a/wagtail/wagtaildocs/api/v3/endpoints.py
+++ b/wagtail/wagtaildocs/api/v3/endpoints.py
@@ -1,0 +1,18 @@
+from __future__ import absolute_import, unicode_literals
+
+from wagtail.api.v3.endpoints import BaseAPIEndpoint
+from wagtail.api.v3.filters import FieldsFilter, OrderingFilter, SearchFilter
+
+from ...models import get_document_model
+from .serializers import DocumentSerializer
+
+
+class DocumentsAPIEndpoint(BaseAPIEndpoint):
+    base_serializer_class = DocumentSerializer
+    filter_backends = [FieldsFilter, OrderingFilter, SearchFilter]
+    body_fields = BaseAPIEndpoint.body_fields + ['title']
+    meta_fields = BaseAPIEndpoint.meta_fields + ['tags', 'download_url']
+    listing_default_fields = BaseAPIEndpoint.listing_default_fields + ['title', 'tags', 'download_url']
+    nested_default_fields = BaseAPIEndpoint.nested_default_fields + ['title', 'download_url']
+    name = 'documents'
+    model = get_document_model()

--- a/wagtail/wagtaildocs/api/v3/endpoints.py
+++ b/wagtail/wagtaildocs/api/v3/endpoints.py
@@ -10,8 +10,8 @@ from .serializers import DocumentSerializer
 class DocumentsAPIEndpoint(BaseAPIEndpoint):
     base_serializer_class = DocumentSerializer
     filter_backends = [FieldsFilter, OrderingFilter, SearchFilter]
-    body_fields = BaseAPIEndpoint.body_fields + ['title']
-    meta_fields = BaseAPIEndpoint.meta_fields + ['tags', 'download_url']
+    body_fields = BaseAPIEndpoint.body_fields + ['title', 'tags']
+    meta_fields = BaseAPIEndpoint.meta_fields + ['download_url']
     listing_default_fields = BaseAPIEndpoint.listing_default_fields + ['title', 'tags', 'download_url']
     nested_default_fields = BaseAPIEndpoint.nested_default_fields + ['title', 'download_url']
     name = 'documents'

--- a/wagtail/wagtaildocs/api/v3/serializers.py
+++ b/wagtail/wagtaildocs/api/v3/serializers.py
@@ -1,0 +1,24 @@
+from __future__ import absolute_import, unicode_literals
+
+from rest_framework.fields import Field
+
+from wagtail.api.v3.serializers import BaseSerializer
+from wagtail.api.v3.utils import get_full_url
+
+
+class DocumentDownloadUrlField(Field):
+    """
+    Serializes the "download_url" field for documents.
+
+    Example:
+    "download_url": "http://api.example.com/documents/1/my_document.pdf"
+    """
+    def get_attribute(self, instance):
+        return instance
+
+    def to_representation(self, document):
+        return get_full_url(self.context['request'], document.url)
+
+
+class DocumentSerializer(BaseSerializer):
+    download_url = DocumentDownloadUrlField(read_only=True)

--- a/wagtail/wagtailimages/api/admin/endpoints.py
+++ b/wagtail/wagtailimages/api/admin/endpoints.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
-from ..v2.endpoints import ImagesAPIEndpoint
+from ..v3.endpoints import ImagesAPIEndpoint
 from .serializers import AdminImageSerializer
 
 

--- a/wagtail/wagtailimages/api/admin/serializers.py
+++ b/wagtail/wagtailimages/api/admin/serializers.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 
 from ..fields import ImageRenditionField
-from ..v2.serializers import ImageSerializer
+from ..v3.serializers import ImageSerializer
 
 
 class AdminImageSerializer(ImageSerializer):

--- a/wagtail/wagtailimages/api/v3/endpoints.py
+++ b/wagtail/wagtailimages/api/v3/endpoints.py
@@ -10,8 +10,8 @@ from .serializers import ImageSerializer
 class ImagesAPIEndpoint(BaseAPIEndpoint):
     base_serializer_class = ImageSerializer
     filter_backends = [FieldsFilter, OrderingFilter, SearchFilter]
-    body_fields = BaseAPIEndpoint.body_fields + ['title', 'width', 'height']
-    meta_fields = BaseAPIEndpoint.meta_fields + ['tags']
+    body_fields = BaseAPIEndpoint.body_fields + ['title', 'tags', 'width', 'height']
+    meta_fields = BaseAPIEndpoint.meta_fields + []
     listing_default_fields = BaseAPIEndpoint.listing_default_fields + ['title', 'tags']
     nested_default_fields = BaseAPIEndpoint.nested_default_fields + ['title']
     name = 'images'

--- a/wagtail/wagtailimages/api/v3/endpoints.py
+++ b/wagtail/wagtailimages/api/v3/endpoints.py
@@ -1,0 +1,18 @@
+from __future__ import absolute_import, unicode_literals
+
+from wagtail.api.v3.endpoints import BaseAPIEndpoint
+from wagtail.api.v3.filters import FieldsFilter, OrderingFilter, SearchFilter
+
+from ... import get_image_model
+from .serializers import ImageSerializer
+
+
+class ImagesAPIEndpoint(BaseAPIEndpoint):
+    base_serializer_class = ImageSerializer
+    filter_backends = [FieldsFilter, OrderingFilter, SearchFilter]
+    body_fields = BaseAPIEndpoint.body_fields + ['title', 'width', 'height']
+    meta_fields = BaseAPIEndpoint.meta_fields + ['tags']
+    listing_default_fields = BaseAPIEndpoint.listing_default_fields + ['title', 'tags']
+    nested_default_fields = BaseAPIEndpoint.nested_default_fields + ['title']
+    name = 'images'
+    model = get_image_model()

--- a/wagtail/wagtailimages/api/v3/serializers.py
+++ b/wagtail/wagtailimages/api/v3/serializers.py
@@ -1,0 +1,7 @@
+from __future__ import absolute_import, unicode_literals
+
+from wagtail.api.v3.serializers import BaseSerializer
+
+
+class ImageSerializer(BaseSerializer):
+    pass


### PR DESCRIPTION
This commit implements the changes described in https://github.com/wagtail/rfcs/blob/master/text/018-meta-fields.md in the public API v3 and admin API.

TODO:
- [x] Check that I didn't just break the explorer
- [ ] Deprecate API v1 (as per https://github.com/wagtail/rfcs/blob/master/text/008-wagtail-api.md#stabilisation-process)