### PR TITLE
Disable codecov's require_ci_to_pass mode

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,5 @@
 codecov:
   notify:
     after_n_builds: 10
+    require_ci_to_pass: no
 comment: off


### PR DESCRIPTION
despite our attempts to fix it with the `after_n_builds` setting, it's still showing spurious fluctuations due to sometimes running elasticsearch tests and sometimes not