### PR TITLE
Update core.css

### DIFF
--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/core.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/core.scss
@@ -120,7 +120,7 @@ body {
     background: $color-white;
     border-top: 0 solid $color-grey-5; // this top border provides space for the floating logo to toggle the menu
     min-height: 100%;
-    padding-bottom: 4em;
+    padding-bottom: 10em;
     position: relative; // yuk. necessary for positions for jquery ui widgets
 }
 


### PR DESCRIPTION
Sticky footer in admin is covering the bottom form field at < 800 width breakpoint.

Increasing padding-bottom on .content div pushes the field into view.