### PR TITLE
Add admin_display_title to admin API (for 1.11.1)

### DIFF
--- a/client/src/components/Explorer/ExplorerHeader.js
+++ b/client/src/components/Explorer/ExplorerHeader.js
@@ -20,7 +20,7 @@ const ExplorerHeader = ({ page, depth, onClick }) => {
     >
       <div className="c-explorer__header__inner">
         <Icon name={isRoot ? 'home' : 'arrow-left'} />
-        <span>{page.title || STRINGS.PAGES}</span>
+        <span>{page.admin_display_title || STRINGS.PAGES}</span>
       </div>
     </Button>
   );
@@ -29,7 +29,7 @@ const ExplorerHeader = ({ page, depth, onClick }) => {
 ExplorerHeader.propTypes = {
   page: PropTypes.shape({
     id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-    title: PropTypes.string,
+    admin_display_title: PropTypes.string,
   }).isRequired,
   depth: PropTypes.number.isRequired,
   onClick: PropTypes.func.isRequired,

--- a/client/src/components/Explorer/ExplorerHeader.test.js
+++ b/client/src/components/Explorer/ExplorerHeader.test.js
@@ -24,7 +24,7 @@ describe('ExplorerHeader', () => {
   });
 
   it('#page', () => {
-    expect(shallow(<ExplorerHeader {...mockProps} page={{ id: 'a', title: 'test' }} />)).toMatchSnapshot();
+    expect(shallow(<ExplorerHeader {...mockProps} page={{ id: 'a', admin_display_title: 'test' }} />)).toMatchSnapshot();
   });
 
   it('#onClick', () => {

--- a/client/src/components/Explorer/ExplorerHeader.test.js
+++ b/client/src/components/Explorer/ExplorerHeader.test.js
@@ -24,7 +24,8 @@ describe('ExplorerHeader', () => {
   });
 
   it('#page', () => {
-    expect(shallow(<ExplorerHeader {...mockProps} page={{ id: 'a', admin_display_title: 'test' }} />)).toMatchSnapshot();
+    const wrapper = shallow(<ExplorerHeader {...mockProps} page={{ id: 'a', admin_display_title: 'test' }} />);
+    expect(wrapper).toMatchSnapshot();
   });
 
   it('#onClick', () => {

--- a/client/src/components/Explorer/ExplorerItem.js
+++ b/client/src/components/Explorer/ExplorerItem.js
@@ -24,7 +24,7 @@ const nextIcon = (
  * and information depending on the metadata of the page.
  */
 const ExplorerItem = ({ item, onClick }) => {
-  const { id, title, meta } = item;
+  const { id, admin_display_title: title, meta } = item;
   const hasChildren = meta.children.count > 0;
   const isPublished = meta.status.live && !meta.status.has_unpublished_changes;
 
@@ -64,7 +64,7 @@ const ExplorerItem = ({ item, onClick }) => {
 ExplorerItem.propTypes = {
   item: PropTypes.shape({
     id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
-    title: PropTypes.string.isRequired,
+    admin_display_title: PropTypes.string.isRequired,
     meta: PropTypes.shape({
       status: PropTypes.object.isRequired,
     }).isRequired,

--- a/client/src/components/Explorer/ExplorerItem.test.js
+++ b/client/src/components/Explorer/ExplorerItem.test.js
@@ -6,7 +6,7 @@ import ExplorerItem from './ExplorerItem';
 const mockProps = {
   item: {
     id: 5,
-    title: 'test',
+    admin_display_title: 'test',
     meta: {
       latest_revision_created_at: null,
       status: {

--- a/client/src/components/Explorer/ExplorerPanel.test.js
+++ b/client/src/components/Explorer/ExplorerPanel.test.js
@@ -57,8 +57,8 @@ describe('ExplorerPanel', () => {
         {...mockProps}
         page={{ children: { items: [1, 2] } }}
         nodes={{
-          1: { id: 1, title: 'Test', meta: { status: {}, type: 'test' } },
-          2: { id: 2, title: 'Foo', meta: { status: {}, type: 'foo' } },
+          1: { id: 1, admin_display_title: 'Test', meta: { status: {}, type: 'test' } },
+          2: { id: 2, admin_display_title: 'Foo', meta: { status: {}, type: 'foo' } },
         }}
       />
     ))).toMatchSnapshot();
@@ -103,7 +103,7 @@ describe('ExplorerPanel', () => {
           {...mockProps}
           path={[1]}
           page={{ children: { items: [1] } }}
-          nodes={{ 1: { id: 1, title: 'Test', meta: { status: {}, type: 'test' } } }}
+          nodes={{ 1: { id: 1, admin_display_title: 'Test', meta: { status: {}, type: 'test' } } }}
         />
       )).find('ExplorerItem').prop('onClick')({
         preventDefault() {},

--- a/client/src/components/Explorer/PageCount.test.js
+++ b/client/src/components/Explorer/PageCount.test.js
@@ -26,10 +26,4 @@ describe('PageCount', () => {
     props.page.children.count = 5;
     expect(shallow(<PageCount {...props} />)).toMatchSnapshot();
   });
-
-  it('#title', () => {
-    const props = Object.assign({}, mockProps);
-    props.page.title = 'This is an example';
-    expect(shallow(<PageCount {...props} />)).toMatchSnapshot();
-  });
 });

--- a/client/src/components/Explorer/__snapshots__/ExplorerPanel.test.js.snap
+++ b/client/src/components/Explorer/__snapshots__/ExplorerPanel.test.js.snap
@@ -190,12 +190,12 @@ exports[`ExplorerPanel #items 1`] = `
           <ExplorerItem
             item={
               Object {
+                "admin_display_title": "Test",
                 "id": 1,
                 "meta": Object {
                   "status": Object {},
                   "type": "test",
                 },
-                "title": "Test",
               }
             }
             onClick={[Function]}
@@ -203,12 +203,12 @@ exports[`ExplorerPanel #items 1`] = `
           <ExplorerItem
             item={
               Object {
+                "admin_display_title": "Foo",
                 "id": 2,
                 "meta": Object {
                   "status": Object {},
                   "type": "foo",
                 },
-                "title": "Foo",
               }
             }
             onClick={[Function]}

--- a/client/src/components/Explorer/__snapshots__/PageCount.test.js.snap
+++ b/client/src/components/Explorer/__snapshots__/PageCount.test.js.snap
@@ -1,23 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`PageCount #title 1`] = `
-<a
-  className="c-explorer__see-more"
-  href="/admin/pages/1/"
-  tabIndex={0}
->
-  See all
-  <span>
-     5 pages
-  </span>
-  <Icon
-    className={null}
-    name="arrow-right"
-    title={null}
-  />
-</a>
-`;
-
 exports[`PageCount plural 1`] = `
 <a
   className="c-explorer__see-more"

--- a/wagtail/tests/testapp/models.py
+++ b/wagtail/tests/testapp/models.py
@@ -305,6 +305,9 @@ class SingleEventPage(EventPage):
             # fall back to default routing rules
             return super(SingleEventPage, self).route(request, path_components)
 
+    def get_admin_display_title(self):
+        return "%s (single event)" % super(SingleEventPage, self).get_admin_display_title()
+
 
 SingleEventPage.content_panels = [FieldPanel('excerpt')] + EventPage.content_panels
 

--- a/wagtail/wagtailadmin/api/endpoints.py
+++ b/wagtail/wagtailadmin/api/endpoints.py
@@ -34,10 +34,15 @@ class PagesAdminAPIEndpoint(PagesAPIEndpoint):
         'parent',
     ]
 
+    body_fields = PagesAPIEndpoint.body_fields + [
+        'admin_display_title',
+    ]
+
     listing_default_fields = PagesAPIEndpoint.listing_default_fields + [
         'latest_revision_created_at',
         'status',
         'children',
+        'admin_display_title',
     ]
 
     # Allow the parent field to appear on listings
@@ -69,7 +74,7 @@ class PagesAdminAPIEndpoint(PagesAPIEndpoint):
 
         # Hide root page
         # TODO: Add "include_root" flag
-        queryset = queryset.exclude(depth=1)
+        queryset = queryset.exclude(depth=1).specific()
 
         return queryset
 

--- a/wagtail/wagtailadmin/api/serializers.py
+++ b/wagtail/wagtailadmin/api/serializers.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, unicode_literals
 
 from collections import OrderedDict
 
-from rest_framework.fields import Field
+from rest_framework.fields import Field, ReadOnlyField
 
 from wagtail.api.v2.serializers import PageSerializer
 from wagtail.api.v2.utils import get_full_url
@@ -82,3 +82,4 @@ class AdminPageSerializer(PageSerializer):
     status = PageStatusField(read_only=True)
     children = PageChildrenField(read_only=True)
     descendants = PageDescendantsField(read_only=True)
+    admin_display_title = ReadOnlyField(source='get_admin_display_title')

--- a/wagtail/wagtailadmin/tests/api/test_pages.py
+++ b/wagtail/wagtailadmin/tests/api/test_pages.py
@@ -673,3 +673,30 @@ class TestAdminPageDetailWithStreamField(AdminAPITestCase):
         # ForeignKeys in a StreamField shouldn't be translated into dictionary representation
         self.assertEqual(content['body'][0]['type'], 'image')
         self.assertEqual(content['body'][0]['value'], 1)
+
+
+class TestCustomAdminDisplayTitle(AdminAPITestCase):
+    fixtures = ['test.json']
+
+    def setUp(self):
+        super(TestCustomAdminDisplayTitle, self).setUp()
+
+        self.event_page = Page.objects.get(url_path='/home/events/saint-patrick/')
+
+    def test_custom_admin_display_title_shown_on_detail_page(self):
+        api_url = reverse('wagtailadmin_api_v1:pages:detail', args=(self.event_page.id, ))
+        response = self.client.get(api_url)
+        content = json.loads(response.content.decode('utf-8'))
+
+        self.assertEqual(content['title'], "Saint Patrick")
+        self.assertEqual(content['admin_display_title'], "Saint Patrick (single event)")
+
+    def test_custom_admin_display_title_shown_on_listing(self):
+        api_url = reverse('wagtailadmin_api_v1:pages:listing')
+        response = self.client.get(api_url)
+        content = json.loads(response.content.decode('utf-8'))
+
+        matching_items = [item for item in content['items'] if item['id'] == self.event_page.id]
+        self.assertEqual(1, len(matching_items))
+        self.assertEqual(matching_items[0]['title'], "Saint Patrick")
+        self.assertEqual(matching_items[0]['admin_display_title'], "Saint Patrick (single event)")

--- a/wagtail/wagtailadmin/tests/test_pages_views.py
+++ b/wagtail/wagtailadmin/tests/test_pages_views.py
@@ -250,6 +250,22 @@ class TestPageExplorer(TestCase, WagtailTestUtils):
 
         self.assertContains(response, '/new-event/pointless-suffix/')
 
+    def test_listing_uses_admin_display_title(self):
+        # SingleEventPage has a custom get_admin_display_title method; explorer should
+        # show the custom title rather than the basic database one
+        self.new_event = SingleEventPage(
+            title="New event",
+            location='the moon', audience='public',
+            cost='free', date_from='2001-01-01',
+            latest_revision_created_at=local_datetime(2016, 1, 1)
+        )
+        self.root_page.add_child(instance=self.new_event)
+        response = self.client.get(reverse('wagtailadmin_explore', args=(self.root_page.id, )))
+        self.assertContains(response, 'New event (single event)')
+
+        response = self.client.get(reverse('wagtailadmin_explore', args=(self.new_event.id, )))
+        self.assertContains(response, 'New event (single event)')
+
     def test_parent_page_is_specific(self):
         response = self.client.get(reverse('wagtailadmin_explore', args=(self.child_page.id, )))
         self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
First step of fixing #3689. The remaining step is to update the explorer to use the new field - I haven't tackled this because hacking on React code currently makes me feel like http://i1.kym-cdn.com/photos/images/newsfeed/000/234/765/b7e.jpg . (I could flail around changing stuff until I arrive at something that looks plausible and seems to work, and that's not what we really want in a bugfix release...)

This PR targets 1.11.1 - porting it to 1.12 will need more attention to work alongside #3285 (in particular, the change proposed in https://github.com/wagtail/wagtail/pull/3285#issuecomment-313178440 needs applying in order for `test_listing_uses_admin_display_title` to pass)