### PR TITLE
AbstractForm.process_form_submission should return the created submission instance

### DIFF
--- a/wagtail/wagtailforms/models.py
+++ b/wagtail/wagtailforms/models.py
@@ -229,7 +229,7 @@ class AbstractForm(Page):
         For example, if you want to save reference to a user.
         """
 
-        self.get_submission_class().objects.create(
+        return self.get_submission_class().objects.create(
             form_data=json.dumps(form.cleaned_data, cls=DjangoJSONEncoder),
             page=self,
         )


### PR DESCRIPTION
...otherwise ```submission``` will always be None in AbstractEmailForm.process_form_submission

```
def process_form_submission(self, form):
        submission = super(AbstractEmailForm, self).process_form_submission(form)
        if self.to_address:
            self.send_mail(form)
        return submission
```