### PR TITLE
Backslash is not necessary when multi-line expression is parenthesized.

### DIFF
--- a/docs/reference/hooks.rst
+++ b/docs/reference/hooks.rst
@@ -163,15 +163,15 @@ Hooks for building new areas of the admin interface (alongside pages, images, do
 
     from wagtail.wagtailcore import hooks
 
-    def admin_view( request ):
-      return HttpResponse( \
-        "I have approximate knowledge of many things!", \
+    def admin_view(request):
+      return HttpResponse(
+        "I have approximate knowledge of many things!",
         content_type="text/plain")
 
     @hooks.register('register_admin_urls')
     def urlconf_time():
       return [
-        url(r'^how_did_you_almost_know_my_name/$', admin_view, name='frank' ),
+        url(r'^how_did_you_almost_know_my_name/$', admin_view, name='frank'),
       ]
 
 


### PR DESCRIPTION
Thanks for contributing to Wagtail! 🎉

Before submitting, please review the contributor guidelines <http://docs.wagtail.io/en/latest/contributing/index.html> and check the following:

* Do the tests still pass? (http://docs.wagtail.io/en/latest/contributing/developing.html#testing)
* Does the code comply with the style guide? (Run `make lint` from the Wagtail root)
* For Python changes: Have you added tests to cover the new/fixed behaviour?
* For new features: Has the documentation been updated accordingly?
