### PR TITLE
Fix snippet page's header class

### DIFF
--- a/wagtail/wagtailsnippets/templates/wagtailsnippets/snippets/type_index.html
+++ b/wagtail/wagtailsnippets/templates/wagtailsnippets/snippets/type_index.html
@@ -17,7 +17,7 @@
 
     <header class="nice-padding">
         <div class="row row-flush">
-            <div class="left col9 header-snippet">
+            <div class="left col9 header-title">
                 <h1 class="icon icon-snippet">
                 {% blocktrans with snippet_type_name_plural=model_opts.verbose_name_plural|capfirst %}Snippets <span>{{ snippet_type_name_plural }}</span>{% endblocktrans %}</h1>
 


### PR DESCRIPTION
In the snippet index page (see below), the page's header currently uses the class `header-snippet` which does not actually appear to be defined anywhere. Furthermore, it prevents #3703 from working on this page because it relies on pages using the class `header-title` for their headers (which they all do AFAIK, apart from this one).

![image](https://user-images.githubusercontent.com/14837124/28309317-e4a94780-6ba0-11e7-91dc-d4d3c3a64fe8.png)
