### PR TITLE
Fix deprecated Chinese language code

### DIFF
--- a/wagtail/wagtailadmin/utils.py
+++ b/wagtail/wagtailadmin/utils.py
@@ -45,7 +45,7 @@ WAGTAILADMIN_PROVIDED_LANGUAGES = [
     ('pt-pt', ugettext_lazy('Portuguese')),
     ('ro', ugettext_lazy('Romanian')),
     ('ru', ugettext_lazy('Russian')),
-    ('zh-cn', ugettext_lazy('Chinese (China)')),
+    ('zh-hans', ugettext_lazy('Chinese (Simplified)')),
 ]
 
 


### PR DESCRIPTION
Fixes #3668:

> https://code.djangoproject.com/ticket/18419

> This is because Traditional Chinese is not used only by Taiwan (tw) but also Honk Kong (hk), and Simplified Chinese is not only used in China (cn) but also Singapore (sg) and Malaysia. A new standard is to use "zh_Hant" for Traditional Chinese and "zh_Hans" for Simplified Chinese to eliminate the confusion of the content is not just for people lived in China or Taiwan.

Also changed the language name from 'Chinese (China)' to 'Chinese (Simplified)' to reflect on this change. Note that this will require translations to be added for the text 'Chinese (Simplified)'.