### PR TITLE
Update documentation to reflect specific behavior of form_classname

### DIFF
--- a/docs/topics/streamfield.rst
+++ b/docs/topics/streamfield.rst
@@ -792,6 +792,9 @@ To customise the styling of a ``StructBlock`` as it appears in the page editor, 
 
 You can then provide custom CSS for this block, targeted at the specified classname, by using the :ref:`insert_editor_css` hook.
 
+.. Note::
+    Wagtail's editor styling has some built in styling for the `struct-block` class and other related elements. If you specify a value for `form_classname`, it will overwrite the classes that are already applied to `StructBlock`, so you must remember to specify the `struct-block` as well.
+
 For more extensive customisations that require changes to the HTML markup as well, you can override the ``form_template`` attribute in ``Meta`` to specify your own template path. The following variables are available on this template:
 
 ``children``


### PR DESCRIPTION
Hello,

I'm doing some work with custom StructBlock styling and javascript, and I noticed that if you specify a value for the otherwise blank `form_classname` meta attribute, it will overwrite the css classes already on the block rather than append them. In my opinion, this is a somewhat unexpected behavior, even if it is intentional. Therefore, I've added a small note to the documentation to reflect this behavior.

Please let me know if there are any issues! 