### PR TITLE
Don't render a StructValue's template on calls to str(value)

### DIFF
--- a/wagtail/wagtailcore/blocks/struct_block.py
+++ b/wagtail/wagtailcore/blocks/struct_block.py
@@ -9,7 +9,6 @@ from django.forms.utils import ErrorList
 from django.template.loader import render_to_string
 # Must be imported from Django so we get the new implementation of with_metaclass
 from django.utils import six
-from django.utils.encoding import python_2_unicode_compatible
 from django.utils.functional import cached_property
 from django.utils.html import format_html, format_html_join
 

--- a/wagtail/wagtailcore/blocks/struct_block.py
+++ b/wagtail/wagtailcore/blocks/struct_block.py
@@ -194,13 +194,12 @@ class StructBlock(six.with_metaclass(DeclarativeSubBlocksMetaclass, BaseStructBl
     pass
 
 
-@python_2_unicode_compatible  # provide equivalent __unicode__ and __str__ methods on Py2
 class StructValue(collections.OrderedDict):
     def __init__(self, block, *args):
         super(StructValue, self).__init__(*args)
         self.block = block
 
-    def __str__(self):
+    def __html__(self):
         return self.block.render(self)
 
     def render_as_block(self, context=None):


### PR DESCRIPTION
This is liable to cause infinite loops on debug / logging code that attempts to log the fact that it's rendered a template with this value in the context.

Fixes #2874, https://github.com/jazzband/django-debug-toolbar/issues/950

The template is now rendered on `__html__()` instead, so `{{ some_value }}` inside templates should continue to behave as before. There's potential backwards incompatibility here for anyone relying on the old behaviour of `str()`, but I can't think of any reason why you'd want the HTML representation outside of a template.