### PR TITLE
Update Travis config to work with on Trusty architecture

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 cache: pip
+dist: trusty
 
 # Use container-based infrastructure
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,8 +51,9 @@ matrix:
      python: 3.5
    - env: TOXENV=py35-dj110-mysql-noelasticsearch
      python: 3.5
-   - env: TOXENV=py35-dj110-postgres-elasticsearch
+   - env: TOXENV=py35-dj110-postgres-elasticsearch INSTALL_ELASTICSEARCH1=yes
      python: 3.5
+     sudo: true
    - env: TOXENV=py35-dj110-postgres-elasticsearch2 INSTALL_ELASTICSEARCH2=yes
      python: 3.5
      sudo: true
@@ -61,16 +62,18 @@ matrix:
      sudo: true
    - env: TOXENV=py35-dj111-postgres-noelasticsearch
      python: 3.5
-   - env: TOXENV=py35-dj111-postgres-elasticsearch
+   - env: TOXENV=py35-dj111-postgres-elasticsearch INSTALL_ELASTICSEARCH1=yes
      python: 3.5
+     sudo: true
    - env: TOXENV=py36-dj111-sqlite-noelasticsearch
      python: 3.6
    - env: TOXENV=py36-dj111-postgres-noelasticsearch
      python: 3.6
    - env: TOXENV=py36-dj111-mysql-noelasticsearch
      python: 3.6
-   - env: TOXENV=py36-dj111-postgres-elasticsearch
+   - env: TOXENV=py36-dj111-postgres-elasticsearch INSTALL_ELASTICSEARCH1=yes
      python: 3.6
+     sudo: true
    - env: TOXENV=py36-dj111-postgres-elasticsearch2 INSTALL_ELASTICSEARCH2=yes
      python: 3.6
      sudo: true
@@ -81,11 +84,11 @@ matrix:
     # Ignore failures on Elasticsearch tests because ES on Travis is intermittently flaky;
     - env: TOXENV=py27-dj110-mysql-elasticsearch5 INSTALL_ELASTICSEARCH5=yes
     - env: TOXENV=py27-dj111-postgres-elasticsearch5 INSTALL_ELASTICSEARCH5=yes
-    - env: TOXENV=py35-dj110-postgres-elasticsearch
+    - env: TOXENV=py35-dj110-postgres-elasticsearch INSTALL_ELASTICSEARCH1=yes
     - env: TOXENV=py35-dj110-postgres-elasticsearch2 INSTALL_ELASTICSEARCH2=yes
     - env: TOXENV=py35-dj110-postgres-elasticsearch5 INSTALL_ELASTICSEARCH5=yes
-    - env: TOXENV=py35-dj111-postgres-elasticsearch
-    - env: TOXENV=py36-dj111-postgres-elasticsearch
+    - env: TOXENV=py35-dj111-postgres-elasticsearch INSTALL_ELASTICSEARCH1=yes
+    - env: TOXENV=py36-dj111-postgres-elasticsearch INSTALL_ELASTICSEARCH1=yes
     - env: TOXENV=py36-dj111-postgres-elasticsearch2 INSTALL_ELASTICSEARCH2=yes
     - env: TOXENV=py36-dj111-postgres-elasticsearch5 INSTALL_ELASTICSEARCH5=yes
 
@@ -96,6 +99,7 @@ services:
 # Package installation
 install:
   - pip install tox codecov
+  - 'if [[ -n "$INSTALL_ELASTICSEARCH1" ]]; then ./scripts/travis/install_elasticsearch1.sh; fi'
   - 'if [[ -n "$INSTALL_ELASTICSEARCH2" ]]; then ./scripts/travis/install_elasticsearch2.sh; fi'
   - 'if [[ -n "$INSTALL_ELASTICSEARCH5" ]]; then ./scripts/travis/install_elasticsearch5.sh; fi'
 

--- a/scripts/travis/install_elasticsearch1.sh
+++ b/scripts/travis/install_elasticsearch1.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+curl -O https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.7.6.deb && sudo dpkg -i --force-confnew elasticsearch-1.7.6.deb && sudo service elasticsearch restart

--- a/scripts/travis/install_elasticsearch2.sh
+++ b/scripts/travis/install_elasticsearch2.sh
@@ -1,7 +1,3 @@
 #!/bin/bash
 
-sudo apt-get autoremove --purge elasticsearch
-wget -qO - https://packages.elastic.co/GPG-KEY-elasticsearch | sudo apt-key add -
-echo "deb http://packages.elastic.co/elasticsearch/2.x/debian stable main" | sudo tee -a /etc/apt/sources.list.d/elk.list
-sudo apt-get update && sudo apt-get install elasticsearch -y
-sudo service elasticsearch start
+curl -O https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/deb/elasticsearch/2.4.6/elasticsearch-2.4.6.deb && sudo dpkg -i --force-confnew elasticsearch-2.4.6.deb && sudo service elasticsearch restart

--- a/scripts/travis/install_elasticsearch5.sh
+++ b/scripts/travis/install_elasticsearch5.sh
@@ -1,8 +1,3 @@
 #!/bin/bash
 
-sudo sysctl -w vm.max_map_count=262144
-
-sudo apt-get autoremove --purge elasticsearch
-wget -P /tmp/ https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.3.3.deb
-sudo dpkg -i /tmp/elasticsearch-5.3.3.deb
-sudo service elasticsearch start
+curl -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.3.3.deb && sudo dpkg -i --force-confnew elasticsearch-5.3.3.deb && sudo service elasticsearch restart

--- a/wagtail/tests/settings.py
+++ b/wagtail/tests/settings.py
@@ -34,6 +34,12 @@ if DATABASES['default']['ENGINE'] == 'sql_server.pyodbc':
     }
 
 
+# explicitly set charset / collation to utf8 on mysql
+if DATABASES['default']['ENGINE'] == 'django.db.backends.mysql':
+    DATABASES['default']['TEST']['CHARSET'] = 'utf8'
+    DATABASES['default']['TEST']['COLLATION'] = 'utf8_general_ci'
+
+
 SECRET_KEY = 'not needed'
 
 ROOT_URLCONF = 'wagtail.tests.urls'


### PR DESCRIPTION
[As of July 19th](https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming) Travis now runs builds on Ubuntu Trusty unless otherwise specified. This requires the following fixes:

* MySQL requires explicit encoding / collation settings (because they unhelpfully default to Latin/Swedish)
* The default version of elasticsearch seems to be one of the [broken](https://github.com/elastic/elasticsearch/issues/24644) 5.x releases, so we have to install explicit versions for all of 1.x, 2.x and 5.x. (On the plus side, the installation scripts are simpler now...)