### PR TITLE
Add WAGTAILUSERS_PASSWORD_ENABLED and WAGTAILUSERS_PASSWORD_REQUIRED settings

### DIFF
--- a/docs/advanced_topics/settings.rst
+++ b/docs/advanced_topics/settings.rst
@@ -262,6 +262,18 @@ This specifies whether users are allowed to change their passwords (enabled by d
 
 This specifies whether users are allowed to reset their passwords. Defaults to the same as ``WAGTAIL_PASSWORD_MANAGEMENT_ENABLED``.
 
+.. code-block:: python
+
+  WAGTAILUSERS_PASSWORD_ENABLED = True
+
+This specifies whether password fields are shown when creating or editing users through Settings -> Users (enabled by default). Set this to False (along with ``WAGTAIL_PASSWORD_MANAGEMENT_ENABLED`` and ``WAGTAIL_PASSWORD_RESET_ENABLED``) if your users are authenticated through an external system such as LDAP.
+
+.. code-block:: python
+
+  WAGTAILUSERS_PASSWORD_REQUIRED = True
+
+This specifies whether password is a required field when creating a new user. True by default; ignored if ``WAGTAILUSERS_PASSWORD_ENABLED`` is false. If this is set to False, and the password field is left blank when creating a user, then that user will have no usable password, and will not be able to log in unless an alternative authentication system such as LDAP is set up.
+
 
 Email Notifications
 -------------------

--- a/wagtail/wagtailusers/templates/wagtailusers/users/create.html
+++ b/wagtail/wagtailusers/templates/wagtailusers/users/create.html
@@ -25,8 +25,12 @@
                         {% include "wagtailadmin/shared/field_as_li.html" with field=form.first_name %}
                         {% include "wagtailadmin/shared/field_as_li.html" with field=form.last_name %}
                         {% block extra_fields %}{% endblock extra_fields %}
-                        {% include "wagtailadmin/shared/field_as_li.html" with field=form.password1 %}
-                        {% include "wagtailadmin/shared/field_as_li.html" with field=form.password2 %}
+                        {% if form.password1 %}
+                            {% include "wagtailadmin/shared/field_as_li.html" with field=form.password1 %}
+                        {% endif %}
+                        {% if form.password2 %}
+                            {% include "wagtailadmin/shared/field_as_li.html" with field=form.password2 %}
+                        {% endif %}
                     {% endblock fields %}
 
                     <li><a href="#roles" class="button lowpriority tab-toggle icon icon-arrow-right-after">{% trans "Roles" %}</a></li>

--- a/wagtail/wagtailusers/templates/wagtailusers/users/edit.html
+++ b/wagtail/wagtailusers/templates/wagtailusers/users/edit.html
@@ -26,8 +26,12 @@
                         {% include "wagtailadmin/shared/field_as_li.html" with field=form.first_name %}
                         {% include "wagtailadmin/shared/field_as_li.html" with field=form.last_name %}
                         {% block extra_fields %}{% endblock extra_fields %}
-                        {% include "wagtailadmin/shared/field_as_li.html" with field=form.password1 %}
-                        {% include "wagtailadmin/shared/field_as_li.html" with field=form.password2 %}
+                        {% if form.password1 %}
+                            {% include "wagtailadmin/shared/field_as_li.html" with field=form.password1 %}
+                        {% endif %}
+                        {% if form.password2 %}
+                            {% include "wagtailadmin/shared/field_as_li.html" with field=form.password2 %}
+                        {% endif %}
                         {% if form.is_active %}
                             {% include "wagtailadmin/shared/field_as_li.html" with field=form.is_active %}
                         {% endif %}


### PR DESCRIPTION
Fixes #3706. These options restore the ability to create users with no password set on the Django side, for setups where authentication is managed externally (e.g. LDAP) - this was inadvertently dropped in Wagtail 1.10 when the form validation was tightened up (#3007). Additionally, the password fields can now be removed entirely, to enforce the use of an external auth setup.