### PR TITLE
Add help_text to DecimalBlock and RegexBlock

### DIFF
--- a/docs/topics/streamfield.rst
+++ b/docs/topics/streamfield.rst
@@ -122,7 +122,7 @@ DecimalBlock
 
 ``wagtail.wagtailcore.blocks.DecimalBlock``
 
-A single-line decimal input that validates that the value is a valid decimal number. The keyword arguments ``required``, ``max_value``, ``min_value``, ``max_digits`` and ``decimal_places`` are accepted.
+A single-line decimal input that validates that the value is a valid decimal number. The keyword arguments ``required``, ``help_text``, ``max_value``, ``min_value``, ``max_digits`` and ``decimal_places`` are accepted.
 
 For an example of ``DecimalBlock`` in use, see :ref:`streamfield_personblock_example`
 
@@ -139,7 +139,7 @@ A single-line text input that validates a string against a regex expression. The
         'invalid': "Not a valid library card number."
     })
 
-The keyword arguments ``regex``, ``required``, ``max_length``, ``min_length`` and ``error_messages`` are accepted.
+The keyword arguments ``regex``, ``help_text``, ``required``, ``max_length``, ``min_length`` and ``error_messages`` are accepted.
 
 URLBlock
 ~~~~~~~~

--- a/wagtail/wagtailcore/blocks/field_block.py
+++ b/wagtail/wagtailcore/blocks/field_block.py
@@ -169,10 +169,11 @@ class FloatBlock(FieldBlock):
 
 class DecimalBlock(FieldBlock):
 
-    def __init__(self, required=True, max_value=None, min_value=None,
+    def __init__(self, required=True, help_text=None, max_value=None, min_value=None,
                  max_digits=None, decimal_places=None, *args, **kwargs):
         self.field = forms.DecimalField(
             required=required,
+            help_text=help_text,
             max_value=max_value,
             min_value=min_value,
             max_digits=max_digits,
@@ -186,11 +187,12 @@ class DecimalBlock(FieldBlock):
 
 class RegexBlock(FieldBlock):
 
-    def __init__(self, regex, required=True, max_length=None, min_length=None,
+    def __init__(self, regex, required=True, help_text=None, max_length=None, min_length=None,
                  error_messages=None, *args, **kwargs):
         self.field = forms.RegexField(
             regex=regex,
             required=required,
+            help_text=help_text,
             max_length=max_length,
             min_length=min_length,
             error_messages=error_messages,


### PR DESCRIPTION
`DecimalBlock` and `RegexBlock` seem to lack `help_text` properties. This pull requests adds them and updates the documentation.