### PR TITLE
Fix Sass linting

### DIFF
--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -2,7 +2,9 @@
 # SpaceBeforeBrace: search "([^\ ])\{" replace "$1 {"
 # SpaceAfterPropertyColon: search "([^\&]):([^\ \n]*);" replace "$1: $2;"
 
-scss_files: 'wagtail/**/static_src/**/scss/**/*.scss'
+scss_files:
+- wagtail/**/static_src/**/scss/**/*.scss
+- client/**/*.scss
 
 linters:
     BorderZero:

--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -85,6 +85,9 @@ linters:
     NestingDepth:
         max_depth: 5
 
+    PseudoElement:
+        enabled: false
+
     SelectorDepth:
         enabled: false
 

--- a/circle.yml
+++ b/circle.yml
@@ -5,7 +5,7 @@ machine:
 dependencies:
   pre:
     - pip install -e .[testing]
-    - gem install scss-lint
+    - gem install scss_lint
 
 test:
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -11,8 +11,8 @@ test:
   override:
     - flake8 wagtail
     - isort --check-only --diff --recursive wagtail
-    - npm run lint
-    - scss-lint
+    - npm run lint:js
+    - npm run lint:css
     - python -u runtests.py
     - npm run test:unit:coverage -- --runInBand
     - npm run build

--- a/client/scss/styles.scss
+++ b/client/scss/styles.scss
@@ -2,7 +2,6 @@
 // Wagtail CMS main stylesheet
 // =============================================================================
 
-
 @import 'tools.breakpoints';
 @import 'objects';
 @import 'components';

--- a/client/src/components/Explorer/Explorer.scss
+++ b/client/src/components/Explorer/Explorer.scss
@@ -1,8 +1,10 @@
-$c-explorer-bg: #4C4E4D;
+// scss-lint:disable DeclarationOrder
+
+$c-explorer-bg: #4c4e4d;
 $c-explorer-bg-dark: $color-grey-1;
-$c-explorer-bg-active: rgba(0,0,0,0.425);
+$c-explorer-bg-active: rgba(0, 0, 0, 0.425);
 $c-explorer-secondary: #a5a5a5;
-$c-explorer-easing: cubic-bezier(0.075, 0.820, 0.165, 1.000);
+$c-explorer-easing: cubic-bezier(0.075, 0.82, 0.165, 1);
 $menu-footer-height: 50px;
 
 @import 'ExplorerItem';
@@ -130,7 +132,7 @@ $menu-footer-height: 50px;
 .c-explorer__see-more {
     display: block;
     padding: 1em;
-    background: rgba(0,0,0,0.3);
+    background: rgba(0, 0, 0, 0.3);
     color: $color-white;
 
     &:focus {

--- a/client/src/components/Explorer/ExplorerItem.scss
+++ b/client/src/components/Explorer/ExplorerItem.scss
@@ -1,3 +1,5 @@
+// scss-lint:disable DeclarationOrder
+
 .c-explorer__item {
     display: flex;
     flex-flow: row nowrap;
@@ -73,7 +75,7 @@
         color: $color-white;
     }
 
-    .icon:before {
+    .icon::before {
         margin-right: 0;
     }
 }

--- a/client/src/components/LoadingSpinner/LoadingSpinner.scss
+++ b/client/src/components/LoadingSpinner/LoadingSpinner.scss
@@ -1,4 +1,4 @@
-.c-spinner:after {
+.c-spinner::after {
     display: inline-block;
     animation: spin 0.5s infinite linear;
     line-height: 1;

--- a/docs/contributing/css_guidelines.rst
+++ b/docs/contributing/css_guidelines.rst
@@ -35,13 +35,13 @@ automatically recompiling when any changes are observed, by running:
 Linting SCSS
 ~~~~~~~~~~~~
 
-Wagtail uses the "scss-lint" Ruby Gem for linting.
+Wagtail uses the "scss_lint" Ruby Gem for linting.
 
 Install it thus:
 
 .. code-block:: console
 
-    $ gem install scss-lint
+    $ gem install scss_lint
 
 
 Then run the linter from the wagtail project root:

--- a/docs/contributing/css_guidelines.rst
+++ b/docs/contributing/css_guidelines.rst
@@ -48,7 +48,7 @@ Then run the linter from the wagtail project root:
 
 .. code-block:: console
 
-    $ scss-lint
+    $ npm run lint:css
 
 The linter is configured to check your code for adherance to the guidelines below, plus a little more.
 

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "watch": "webpack --config ./client/webpack/dev.config.js & gulp watch",
     "start": "npm run watch",
     "lint:js": "eslint --max-warnings 16 ./client",
+    "lint:css": "scss-lint",
     "lint": "npm run lint:js",
     "test": "npm run test:unit",
     "test:unit": "jest",

--- a/wagtail/contrib/modeladmin/static_src/wagtailmodeladmin/scss/index.scss
+++ b/wagtail/contrib/modeladmin/static_src/wagtailmodeladmin/scss/index.scss
@@ -27,12 +27,12 @@
             visibility: visible;
         }
 
-        tr > td { 
+        tr > td {
             background-color: inherit;
-            
-            a.edit-obj { 
+
+            a.edit-obj {
                 color: inherit;
-                font-weight: 600; 
+                font-weight: 600;
             }
         }
 

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/_grid.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/_grid.scss
@@ -1,5 +1,5 @@
 // Utility variable - you should never need to modify this
-$padding: $grid-gutter-width*0.5;
+$padding: $grid-gutter-width * 0.5;
 
 // Our row container
 @mixin row($padding: 0) {
@@ -22,32 +22,32 @@ $padding: $grid-gutter-width*0.5;
     box-sizing: border-box;
     display: inline;
     float: left;
-    width: 100%*($x / $grid-columns);
+    width: 100% * ($x / $grid-columns);
     padding-right: $padding;
     padding-left: $padding;
 }
 
 @mixin table-column($x, $padding: $padding, $grid-columns: $grid-columns) {
     box-sizing: border-box;
-    width: 100%*($x / $grid-columns);
+    width: 100% * ($x / $grid-columns);
 }
 
 // Push adds left padding
 @mixin push($offset: 1, $grid-columns: $grid-columns) {
-    margin-left: 100%*($offset / $grid-columns);
+    margin-left: 100% * ($offset / $grid-columns);
 }
 
 @mixin push-padding($offset: 1, $grid-columns: $grid-columns) {
-    padding-left: 100%*($offset / $grid-columns);
+    padding-left: 100% * ($offset / $grid-columns);
 }
 
 // Pull adds right padding
 @mixin pull($offset: 1, $grid-columns: $grid-columns) {
-    margin-right: 100%*($offset / $grid-columns);
+    margin-right: 100% * ($offset / $grid-columns);
 }
 
 @mixin pull-padding($offset: 1, $grid-columns: $grid-columns) {
-    padding-right: 100%*($offset / $grid-columns);
+    padding-right: 100% * ($offset / $grid-columns);
 }
 
 // only used in places where padding not applied to same elements as row or row-flush

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_datetimepicker.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_datetimepicker.scss
@@ -26,7 +26,7 @@
         border: 0;
     }
 
-    .xdsoft_datepicker, 
+    .xdsoft_datepicker,
     .xdsoft_timepicker {
         display: none;
 
@@ -50,8 +50,8 @@
         text-align: center;
     }
 
-    .xdsoft_next, 
-    .xdsoft_prev, 
+    .xdsoft_next,
+    .xdsoft_prev,
     .xdsoft_today_button {
         background-color: transparent;
         cursor: pointer;

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_formatters.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_formatters.scss
@@ -45,7 +45,7 @@
     background-color: #ccc;
     padding: 5px;
 
-    h3, 
+    h3,
     p {
         margin: 0;
     }
@@ -123,7 +123,7 @@ form.status-tag:hover {
 }
 
 .privacy-indicator {
-    .label-private, 
+    .label-private,
     .label-public {
         &:before {
             font-size: 1.5em;
@@ -132,7 +132,7 @@ form.status-tag:hover {
     }
 
     &.public {
-        .label-private { 
+        .label-private {
             display: none;
         }
     }
@@ -187,7 +187,7 @@ a.tag:hover {
     &.loading {
         position: relative;
 
-        &:before, 
+        &:before,
         &:after {
             position: absolute;
             display: block;
@@ -195,7 +195,7 @@ a.tag:hover {
 
         &:before {
             content: '';
-            top: -5px; 
+            top: -5px;
             left: -5px;
             bottom: -5px;
             right: -5px;

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_indicator.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_indicator.scss
@@ -44,7 +44,7 @@ $c-indicator-margin: .25rem;
 
     &:before {
         content: '';
-        width: $c-indicator-size/2;
+        width: $c-indicator-size / 2;
         height: $c-indicator-size;
         position: absolute;
         top: 0;

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_main-nav.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_main-nav.scss
@@ -186,10 +186,13 @@ $footer-submenu: $submenu-color;
     button {
         background-color: transparent;
         position: absolute;
-        top: 0; right: 0; bottom: 0;
+        top: 0;
+        right: 0;
+        bottom: 0;
         margin: auto;
         padding: 0;
-        width: 3em; height: 100%;
+        width: 3em;
+        height: 100%;
         overflow: hidden;
 
         &:before {

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_messages.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_messages.scss
@@ -1,4 +1,4 @@
-// Messages are specific to Django's 'Messaging' system which adds messages into the session, 
+// Messages are specific to Django's 'Messaging' system which adds messages into the session,
 // for display on the next page visited. These appear as an animated banner at the top of the page.
 //
 // For inline help text, see typography.scss

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_modals.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_modals.scss
@@ -3,7 +3,7 @@ $zindex-modal-background: 500;
 .fade {
     @include transition(opacity .15s linear);
     opacity: 0;
-    
+
     &.in {
         opacity: 1;
     }
@@ -76,7 +76,7 @@ $zindex-modal-background: 500;
     left: 0;
     z-index: ($zindex-modal-background - 10);
     background-color: $color-black;
-    
+
     // Fade for backdrop
     &.fade { opacity: 0; }
     &.in { opacity: 0.5; }

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_progressbar.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_progressbar.scss
@@ -7,7 +7,7 @@
     &.active {
         @include transition(opacity 0.3s ease);
         opacity: 1;
-    } 
+    }
 
     .bar {
         @include transition(width 0.3s ease);

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_streamfield.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_streamfield.scss
@@ -41,8 +41,8 @@ li.sequence-member {
             padding: 1.5em 0;
         }
     }
-    
-    // Copied from page-editor.scss    
+
+    // Copied from page-editor.scss
     .struct-block li.required > label:after {
         content: '*';
         color: $color-red;
@@ -131,12 +131,12 @@ li.sequence-member {
 }
 
 
-// This horridly specific selector ensures text inputs, rich text fields and textareas 
+// This horridly specific selector ensures text inputs, rich text fields and textareas
 // that are direct children of highest level sequence should be borderless and full-width
 .block_field > .field-content > .input > .sequence-container > .sequence-container-inner > .sequence > .sequence-member > .sequence-member-inner {
     > .widget-text_input input,
     > .widget-hallo_rich_text_area .richtext,
-    > .widget-textarea textarea { 
+    > .widget-textarea textarea {
         border: 0;
         padding: 0;
         background-color: transparent;
@@ -153,7 +153,7 @@ li.sequence-member {
     opacity: 0;
     visibility: hidden;
     position: absolute;
-    top: -30px; 
+    top: -30px;
     right: 0;
     z-index: 1;
     overflow: visible;
@@ -201,7 +201,7 @@ li.sequence-member {
 
     .disabled {
         display: none;
-    }       
+    }
 }
 
 // list controls are slightly different as they require closer proximity to their associated fields
@@ -219,7 +219,7 @@ li.sequence-member {
     margin-top: 1.5em;
 }
 
-// Menu of other blocks to be added at each position 
+// Menu of other blocks to be added at each position
 .stream-menu {
     @include transition(all 0.2s ease);
     box-shadow: inset 0 0 45px rgba(0, 0, 0, 0.3);

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_tabs.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_tabs.scss
@@ -97,7 +97,7 @@
 
 @media screen and (min-width: $breakpoint-mobile) {
     .tab-nav {
-        // For cases where tab-nav should merge with header 
+        // For cases where tab-nav should merge with header
         &.merged {
             background-color: $color-header-bg;
         }

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_tooltips.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_tooltips.scss
@@ -7,13 +7,11 @@
     font-size: 12px;
     line-height: 1.4;
     opacity: 0;
-    filter: alpha(opacity=0);
     visibility: visible;
 }
 
 .tooltip.in {
     opacity: 0.9;
-    filter: alpha(opacity=90);
 }
 
 .tooltip.top {

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/layouts/login.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/layouts/login.scss
@@ -5,8 +5,8 @@
 // overrides default nice padding defined in variables.scss
 $desktop-nice-padding: 100px;
 
-html, 
-body, 
+html,
+body,
 .content-wrapper {
     background-color: $color-grey-1;
     color: $color-grey-3;
@@ -102,7 +102,7 @@ form {
 
         .iconfield .input:before {
             display: none;
-        }   
+        }
 
     // Special full-width, one-off fields i.e a single text or textarea input
     .full input {

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/panels/rich-text.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/panels/rich-text.scss
@@ -19,7 +19,7 @@
     margin-left: $mobile-nice-padding;
 }
 
-// stream-field is added to hallotoolbar when invoked on a field within a stream-field 
+// stream-field is added to hallotoolbar when invoked on a field within a stream-field
 .hallotoolbar.stream-field {
     margin-top: -1em;
     margin-left: 0;
@@ -146,11 +146,11 @@
         border-left: 0;
     }
 
-    
+
     // These styles correspond to the image formats defined in wagtailimages/formats.py,
     // so that images displayed in the rich text field receive more or less the same
     // styling that they would receive on the site front-end.
-    // 
+    //
     // Wagtail installations that define their own image formats (in a myapp.image_formats module)
     // should ideally use the insert_editor_css hook to pass in their own custom CSS to have those
     // images render within the rich text area in the same styles that would appear on the front-end.


### PR DESCRIPTION
The [scss-lint](https://github.com/brigade/scss-lint) gem was renamed ± two years ago to `scss_lint`, so we were (not) using a version that didn't work and failed to raise any linting errors.

Wagtail's front-end codebase is horrible to maintain, we badly need this linting in place – this PR includes some manual linting fixes, some done with Prettier, some extra configuration, and a `npm run lint:css` wrapper so people don't have to remember what linting tool(s) we are using, and we can transition to another one (#3516) some time soon.