### PR TITLE
Fix explorer item link behaviour

### DIFF
--- a/client/src/components/Explorer/ExplorerItem.js
+++ b/client/src/components/Explorer/ExplorerItem.js
@@ -53,6 +53,7 @@ const ExplorerItem = ({ item, onClick }) => {
         <Button
           className="c-explorer__item__action"
           onClick={onClick}
+          href={`${ADMIN_URLS.PAGES}${id}/`}
         >
           {nextIcon}
         </Button>

--- a/client/src/components/Explorer/__snapshots__/ExplorerItem.test.js.snap
+++ b/client/src/components/Explorer/__snapshots__/ExplorerItem.test.js.snap
@@ -44,7 +44,7 @@ exports[`ExplorerItem children 1`] = `
   <Button
     accessibleLabel={null}
     className="c-explorer__item__action"
-    href="#"
+    href="/admin/pages/5/"
     icon=""
     isLoading={false}
     onClick={[Function]}
@@ -156,7 +156,7 @@ exports[`ExplorerItem should show a publication status if not live 1`] = `
   <Button
     accessibleLabel={null}
     className="c-explorer__item__action"
-    href="#"
+    href="/admin/pages/5/"
     icon=""
     isLoading={false}
     onClick={[Function]}
@@ -229,7 +229,7 @@ exports[`ExplorerItem should show a publication status with unpublished changes 
   <Button
     accessibleLabel={null}
     className="c-explorer__item__action"
-    href="#"
+    href="/admin/pages/5/"
     icon=""
     isLoading={false}
     onClick={[Function]}


### PR DESCRIPTION
Closes #3760 

Adds a href prop to the right arrow Button in ExplorerItem. Opening this
link manually (such as Open Link in New Tab) will now take the user to
the deeper page list. Before this commit this button erroneously had no
href and thus would only take them to the current page.

Tested in:
- [x] macOS Chrome 59
- [x] Safari 10
- [x] macOS Firefox 54