### PR TITLE
BASE_URL changed to WAGTAILADMIN_BASE_URL

### DIFF
--- a/docs/advanced_topics/settings.rst
+++ b/docs/advanced_topics/settings.rst
@@ -662,6 +662,10 @@ These two files should reside in your project directory (``myproject/myproject/`
   # which welcomes users upon login to the Wagtail admin.
   WAGTAIL_SITE_NAME = 'My Project'
 
+  # This is the base url (protocal and domain) used by the Wagtail admin.
+  # Previously this (undocumented) setting was named BASE_URL
+  WAGTAILADMIN_BASE_URL = 'http://mysite.com'
+
   # Override the search results template for wagtailsearch
   # WAGTAILSEARCH_RESULTS_TEMPLATE = 'myapp/search_results.html'
   # WAGTAILSEARCH_RESULTS_TEMPLATE_AJAX = 'myapp/includes/search_listing.html'

--- a/docs/getting_started/integrating_into_django.rst
+++ b/docs/getting_started/integrating_into_django.rst
@@ -54,6 +54,14 @@ Add a ``WAGTAIL_SITE_NAME`` - this will be displayed on the main dashboard of th
 
     WAGTAIL_SITE_NAME = 'My Example Site'
 
+You can configure the base url (protocol and domain) to be used in the Wagtail admin with the setting ``WAGTAILADMIN_BASE_URL``.
+If not set, there are two fallbacks: request.site.root_url if available, then building a URL from the request object (via ``request.get_host()``.
+This setting was previously named ``BASE_URL``; This is still supported but not preferred.
+
+.. code-block:: python
+
+    WAGTAILADMIN_BASE_URL = 'http://mysite.com'
+
 Various other settings are available to configure Wagtail's behaviour - see :doc:`/advanced_topics/settings`.
 
 URL configuration

--- a/wagtail/project_template/project_name/settings/base.py
+++ b/wagtail/project_template/project_name/settings/base.py
@@ -139,4 +139,4 @@ WAGTAIL_SITE_NAME = "{{ project_name }}"
 
 # Base URL to use when referring to full URLs within the Wagtail admin backend -
 # e.g. in notification emails. Don't include '/admin' or a trailing slash
-BASE_URL = 'http://example.com'
+WAGTAILADMIN_BASE_URL = 'http://example.com'

--- a/wagtail/wagtailadmin/templates/wagtailadmin/notifications/base.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/notifications/base.html
@@ -1,4 +1,7 @@
-{% load i18n staticfiles %}
+{% load i18n staticfiles wagtailadmin_tags %}
+
+{% get_base_url as base_url %}
+
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
@@ -86,7 +89,7 @@ body[yahoo] .text {
 <table width="600" border="0" align="center" class="mobile" cellspacing="0" cellpadding="0">
   <tr>
     <td>
-    	{% block branding_logo %}<img width="100%" border="0" style="display: block;" alt="" src="{{ settings.BASE_URL }}{% static 'wagtailadmin/images/email-header.jpg' %}" />{% endblock %}
+    	{% block branding_logo %}<img width="100%" border="0" style="display: block;" alt="" src="{{ base_url }}{% static 'wagtailadmin/images/email-header.jpg' %}" />{% endblock %}
     </td>
   </tr>
 </table>
@@ -114,7 +117,7 @@ body[yahoo] .text {
                 {% block content %}
                 {% endblock %}
 
-                <div style="font-size: 10px; margin-top: 20px;">{% trans "Edit your notification preferences here:" %} <a href="{{ settings.BASE_URL }}{% url 'wagtailadmin_account_notification_preferences' %}">{{ settings.BASE_URL }}{% url 'wagtailadmin_account_notification_preferences' %}</a></div>
+                <div style="font-size: 10px; margin-top: 20px;">{% trans "Edit your notification preferences here:" %} <a href="{{ base_url }}{% url 'wagtailadmin_account_notification_preferences' %}">{{ base_url }}{% url 'wagtailadmin_account_notification_preferences' %}</a></div>
               </td>
             </tr>
           </table></td>

--- a/wagtail/wagtailadmin/templates/wagtailadmin/notifications/base.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/notifications/base.html
@@ -1,6 +1,6 @@
 {% load i18n staticfiles wagtailadmin_tags %}
 
-{% get_base_url as base_url %}
+{% base_url_setting as base_url %}
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">

--- a/wagtail/wagtailadmin/templates/wagtailadmin/notifications/base.txt
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/notifications/base.txt
@@ -1,4 +1,5 @@
-{% load i18n %}
+{% load i18n wagtailadmin_tags %}
+
 
 {% block greeting %}
 {% blocktrans with username=user.get_short_name|default:user.get_username %}Hello {{ username }},{% endblocktrans %}
@@ -7,5 +8,5 @@
 {% block content %}
 {% endblock %}
 
-
-{% trans "Edit your notification preferences here:" %} {{ settings.BASE_URL }}{% url 'wagtailadmin_account_notification_preferences' %}
+{% get_base_url as base_url %]
+{% trans "Edit your notification preferences here:" %} {{ base_url }}{% url 'wagtailadmin_account_notification_preferences' %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/notifications/base.txt
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/notifications/base.txt
@@ -8,5 +8,5 @@
 {% block content %}
 {% endblock %}
 
-{% get_base_url as base_url %]
+{% base_url_setting as base_url %]
 {% trans "Edit your notification preferences here:" %} {{ base_url }}{% url 'wagtailadmin_account_notification_preferences' %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/notifications/rejected.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/notifications/rejected.html
@@ -2,7 +2,7 @@
 {% load i18n wagtailadmin_tags %}
 
 {% block content %}
-    {% get_base_url as base_url %}
+    {% base_url_setting as base_url %}
     <p>{% blocktrans with title=revision.page.get_admin_display_title|safe %}The page "{{ title }}" has been rejected.{% endblocktrans %}</p>
     <p>{% trans "You can edit the page here:"%} <a href="{{ base_url }}{% url 'wagtailadmin_pages:edit' revision.page.id %}">{{ base_url }}{% url 'wagtailadmin_pages:edit' revision.page.id %}</a></p>
 {% endblock %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/notifications/rejected.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/notifications/rejected.html
@@ -1,7 +1,8 @@
 {% extends 'wagtailadmin/notifications/base.html' %}
-{% load i18n %}
+{% load i18n wagtailadmin_tags %}
 
 {% block content %}
+    {% get_base_url as base_url %}
     <p>{% blocktrans with title=revision.page.get_admin_display_title|safe %}The page "{{ title }}" has been rejected.{% endblocktrans %}</p>
-    <p>{% trans "You can edit the page here:"%} <a href="{{ settings.BASE_URL }}{% url 'wagtailadmin_pages:edit' revision.page.id %}">{{ settings.BASE_URL }}{% url 'wagtailadmin_pages:edit' revision.page.id %}</a></p>
+    <p>{% trans "You can edit the page here:"%} <a href="{{ base_url }}{% url 'wagtailadmin_pages:edit' revision.page.id %}">{{ base_url }}{% url 'wagtailadmin_pages:edit' revision.page.id %}</a></p>
 {% endblock %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/notifications/rejected.txt
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/notifications/rejected.txt
@@ -2,7 +2,7 @@
 {% load i18n wagtailadmin_tags %}
 
 {% block content %}
-{% get_base_url as base_url %}
+{% base_url_setting as base_url %}
 {% blocktrans with title=revision.page.get_admin_display_title|safe %}The page "{{ title }}" has been rejected.{% endblocktrans %}
 
 {% trans "You can edit the page here:"%} {{ base_url }}{% url 'wagtailadmin_pages:edit' revision.page.id %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/notifications/rejected.txt
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/notifications/rejected.txt
@@ -1,8 +1,9 @@
 {% extends 'wagtailadmin/notifications/base.txt' %}
-{% load i18n %}
+{% load i18n wagtailadmin_tags %}
 
 {% block content %}
+{% get_base_url as base_url %}
 {% blocktrans with title=revision.page.get_admin_display_title|safe %}The page "{{ title }}" has been rejected.{% endblocktrans %}
 
-{% trans "You can edit the page here:"%} {{ settings.BASE_URL }}{% url 'wagtailadmin_pages:edit' revision.page.id %}
+{% trans "You can edit the page here:"%} {{ base_url }}{% url 'wagtailadmin_pages:edit' revision.page.id %}
 {% endblock %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/notifications/submitted.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/notifications/submitted.html
@@ -3,7 +3,7 @@
 {% load i18n wagtailadmin_tags %}
 
 {% block content %}
-    {% get_base_url as base_url %}
+    {% base_url_setting as base_url %}
     <p>{% blocktrans with page=revision.page|safe editor=revision.user.get_full_name|default:revision.user.get_username %}The page "{{ page }}" has been submitted for moderation by {{ editor }}.{% endblocktrans %}</p>
 
     <p>

--- a/wagtail/wagtailadmin/templates/wagtailadmin/notifications/submitted.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/notifications/submitted.html
@@ -1,12 +1,13 @@
 {% extends 'wagtailadmin/notifications/base.html' %}
 
-{% load i18n %}
+{% load i18n wagtailadmin_tags %}
 
 {% block content %}
+    {% get_base_url as base_url %}
     <p>{% blocktrans with page=revision.page|safe editor=revision.user.get_full_name|default:revision.user.get_username %}The page "{{ page }}" has been submitted for moderation by {{ editor }}.{% endblocktrans %}</p>
 
     <p>
-        {% trans "You can preview the page here:" %} <a href="{{ settings.BASE_URL }}{% url 'wagtailadmin_pages:preview_for_moderation' revision.id %}">{{ settings.BASE_URL }}{% url 'wagtailadmin_pages:preview_for_moderation' revision.id %}</a><br/>
-        {% trans "You can edit the page here:" %} <a href="{{ settings.BASE_URL }}{% url 'wagtailadmin_pages:edit' revision.page.id %}">{{ settings.BASE_URL }}{% url 'wagtailadmin_pages:edit' revision.page.id %}</a>
+        {% trans "You can preview the page here:" %} <a href="{{ base_url }}{% url 'wagtailadmin_pages:preview_for_moderation' revision.id %}">{{ base_url }}{% url 'wagtailadmin_pages:preview_for_moderation' revision.id %}</a><br/>
+        {% trans "You can edit the page here:" %} <a href="{{ base_url }}{% url 'wagtailadmin_pages:edit' revision.page.id %}">{{ base_url }}{% url 'wagtailadmin_pages:edit' revision.page.id %}</a>
     </p>
 {% endblock %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/notifications/submitted.txt
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/notifications/submitted.txt
@@ -1,9 +1,11 @@
 {% extends 'wagtailadmin/notifications/base.txt' %}
 {% load i18n %}
+{% load wagtailadmin_tags %}
 
 {% block content %}
+{% base_url_setting as base_url %}
 {% blocktrans with page=revision.page|safe editor=revision.user.get_full_name|default:revision.user.get_username %}The page "{{ page }}" has been submitted for moderation by {{ editor }}.{% endblocktrans %}
 
-{% trans "You can preview the page here:" %} {{ settings.BASE_URL }}{% url 'wagtailadmin_pages:preview_for_moderation' revision.id %}
-{% trans "You can edit the page here:" %} {{ settings.BASE_URL }}{% url 'wagtailadmin_pages:edit' revision.page.id %}
+{% trans "You can preview the page here:" %} {{ base_url }}{% url 'wagtailadmin_pages:preview_for_moderation' revision.id %}
+{% trans "You can edit the page here:" %} {{ base_url }}{% url 'wagtailadmin_pages:edit' revision.page.id %}
 {% endblock %}


### PR DESCRIPTION
Fix for issue #3248. 

BASE_URL setting renamed to WAGTAILADMIN_BASE_URL. 
Templates/documentation updated; backward compatible for BASE_URL.
If no setting defined, wagtail/wagtailadmin/templatetags/wagtailadmin_tags/base_url_setting does the following: 

- If available, use request.site.root_url
- If not, fallback to building scheme based on request.is_secure() and domain from request.get_host()