### PR TITLE
#3766 Updating to allow no limit max

### DIFF
--- a/docs/advanced_topics/api/v2/configuration.rst
+++ b/docs/advanced_topics/api/v2/configuration.rst
@@ -274,4 +274,4 @@ endpoints.
 (default: 20)
 
 This allows you to change the maximum number of results a user can request at a
-time. This applies to all endpoints.
+time. This applies to all endpoints. Set to ``None`` for no limit.

--- a/docs/reference/contrib/api/configuration.rst
+++ b/docs/reference/contrib/api/configuration.rst
@@ -18,7 +18,7 @@ Setting this to false will disable full text search. This applies to all endpoin
 
 ``WAGTAILAPI_LIMIT_MAX`` (default: 20)
 
-This allows you to change the maximum number of results a user can request at a time. This applies to all endpoints.
+This allows you to change the maximum number of results a user can request at a time. This applies to all endpoints. Set to ``None`` to remove maximum.
 
 
 Adding more fields to the pages endpoint

--- a/docs/reference/contrib/api/usage.rst
+++ b/docs/reference/contrib/api/usage.rst
@@ -417,7 +417,7 @@ Like filtering, it is also possible to order on database fields. The endpoint ac
 Pagination
 ^^^^^^^^^^
 
-Pagination is done using two query parameters called ``limit`` and ``offset``. ``limit`` sets the number of results to return and ``offset`` is the index of the first result to return. The default and maximum value for ``limit`` is ``20``. The maximum value can be changed using the ``WAGTAILAPI_LIMIT_MAX`` setting.
+Pagination is done using two query parameters called ``limit`` and ``offset``. ``limit`` sets the number of results to return and ``offset`` is the index of the first result to return. The default and maximum value for ``limit`` is ``20``. The maximum value can be changed using the ``WAGTAILAPI_LIMIT_MAX`` setting. Set ``WAGTAILAPI_LIMIT_MAX`` to ``None`` for no maximum value.
 
 .. code-block:: text
 
@@ -745,7 +745,8 @@ The images endpoint also accepts the ``order`` parameter which should be set to 
 Pagination
 ^^^^^^^^^^
 
-Pagination is done using two query parameters called ``limit`` and ``offset``. ``limit`` sets the number of results to return and ``offset`` is the index of the first result to return. The default and maximum value for ``limit`` is ``20``. The maximum value can be changed using the ``WAGTAILAPI_LIMIT_MAX`` setting.
+Pagination is done using two query parameters called ``limit`` and ``offset``. ``limit`` sets the number of results to return and ``offset`` is the index of the first result to return. The default and maximum value for ``limit`` is ``20``. The maximum value can be changed using the ``WAGTAILAPI_LIMIT_MAX`` setting. Set ``WAGTAILAPI_LIMIT_MAX`` to ``None`` for no maximum value.
+
 
 .. code-block:: text
 

--- a/wagtail/api/v2/pagination.py
+++ b/wagtail/api/v2/pagination.py
@@ -20,9 +20,10 @@ class WagtailPagination(BasePagination):
             raise BadRequestError("offset must be a positive integer")
 
         try:
-            limit = int(request.GET.get('limit', min(20, limit_max)))
+            limit_default = 20 if not limit_max else min(20, limit_max)
+            limit = int(request.GET.get('limit', limit_default))
 
-            if limit > limit_max:
+            if limit_max and limit > limit_max:
                 raise BadRequestError("limit cannot be higher than %d" % limit_max)
 
             assert limit >= 0

--- a/wagtail/api/v2/tests/test_documents.py
+++ b/wagtail/api/v2/tests/test_documents.py
@@ -271,6 +271,14 @@ class TestDocumentListing(TestCase):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(content, {'message': "limit cannot be higher than 20"})
 
+    @override_settings(WAGTAILAPI_LIMIT_MAX=None)
+    def test_limit_max_none_gives_no_errors(self):
+        response = self.get_response(limit=1000000)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(content['items']), get_document_model().objects.count())
+
     @override_settings(WAGTAILAPI_LIMIT_MAX=10)
     def test_limit_maximum_can_be_changed(self):
         response = self.get_response(limit=20)

--- a/wagtail/api/v2/tests/test_images.py
+++ b/wagtail/api/v2/tests/test_images.py
@@ -270,6 +270,14 @@ class TestImageListing(TestCase):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(content, {'message': "limit cannot be higher than 20"})
 
+    @override_settings(WAGTAILAPI_LIMIT_MAX=None)
+    def test_limit_max_none_gives_no_errors(self):
+        response = self.get_response(limit=1000000)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(content['items']), get_image_model().objects.count())
+
     @override_settings(WAGTAILAPI_LIMIT_MAX=10)
     def test_limit_maximum_can_be_changed(self):
         response = self.get_response(limit=20)

--- a/wagtail/api/v2/tests/test_pages.py
+++ b/wagtail/api/v2/tests/test_pages.py
@@ -633,6 +633,14 @@ class TestPageListing(TestCase):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(content, {'message': "limit cannot be higher than 20"})
 
+    @override_settings(WAGTAILAPI_LIMIT_MAX=None)
+    def test_limit_max_none_gives_no_errors(self):
+        response = self.get_response(limit=1000000)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(content['items']), get_total_page_count())
+
     @override_settings(WAGTAILAPI_LIMIT_MAX=10)
     def test_limit_maximum_can_be_changed(self):
         response = self.get_response(limit=20)

--- a/wagtail/contrib/wagtailapi/pagination.py
+++ b/wagtail/contrib/wagtailapi/pagination.py
@@ -20,9 +20,10 @@ class WagtailPagination(BasePagination):
             raise BadRequestError("offset must be a positive integer")
 
         try:
-            limit = int(request.GET.get('limit', min(20, limit_max)))
+            limit_default = 20 if not limit_max else min(20, limit_max)
+            limit = int(request.GET.get('limit', limit_default))
 
-            if limit > limit_max:
+            if limit_max and limit > limit_max:
                 raise BadRequestError("limit cannot be higher than %d" % limit_max)
 
             assert limit >= 0

--- a/wagtail/contrib/wagtailapi/tests/test_documents.py
+++ b/wagtail/contrib/wagtailapi/tests/test_documents.py
@@ -207,6 +207,14 @@ class TestDocumentListing(TestCase):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(content, {'message': "limit cannot be higher than 20"})
 
+    @override_settings(WAGTAILAPI_LIMIT_MAX=None)
+    def test_limit_max_none_gives_no_errors(self):
+        response = self.get_response(limit=1000000)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(content['documents']), get_document_model().objects.count())
+
     @override_settings(WAGTAILAPI_LIMIT_MAX=10)
     def test_limit_maximum_can_be_changed(self):
         response = self.get_response(limit=20)

--- a/wagtail/contrib/wagtailapi/tests/test_images.py
+++ b/wagtail/contrib/wagtailapi/tests/test_images.py
@@ -208,6 +208,14 @@ class TestImageListing(TestCase):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(content, {'message': "limit cannot be higher than 20"})
 
+    @override_settings(WAGTAILAPI_LIMIT_MAX=None)
+    def test_limit_max_none_gives_no_errors(self):
+        response = self.get_response(limit=1000000)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(content['images']), get_image_model().objects.count())
+
     @override_settings(WAGTAILAPI_LIMIT_MAX=10)
     def test_limit_maximum_can_be_changed(self):
         response = self.get_response(limit=20)

--- a/wagtail/contrib/wagtailapi/tests/test_pages.py
+++ b/wagtail/contrib/wagtailapi/tests/test_pages.py
@@ -446,6 +446,14 @@ class TestPageListing(TestCase):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(content, {'message': "limit cannot be higher than 20"})
 
+    @override_settings(WAGTAILAPI_LIMIT_MAX=None)
+    def test_limit_max_none_gives_no_errors(self):
+        response = self.get_response(limit=1000000)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(content['pages']), get_total_page_count())
+
     @override_settings(WAGTAILAPI_LIMIT_MAX=10)
     def test_limit_maximum_can_be_changed(self):
         response = self.get_response(limit=20)


### PR DESCRIPTION
This PR Updates the pagination code to allow setting the `WAGTAILAPI_LIMIT_MAX` to `None`. New tests have been added to cover this case and no existing tests were negatively affected.

Code complies with style guide to the best of my knowledge and documentation has been updated to reflect configuration options.