### PR TITLE
Fix position of action buttons in image editor on mobile

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -8,6 +8,7 @@ Changelog
  * Animate the chevron icon when opening sub-menus in the admin (Carlo Ascani)
  * Fix: Status button on 'edit page' now links to the correct URL when live and draft slug differ (LB (Ben Johnston))
  * Fix: Image title text in the gallery and in the chooser now wraps for long filenames (LB (Ben Johnston), Luiz Boaretto)
+ * Fix: Move image editor action buttons to the bottom of the form on mobile (Julian Gallo)
 
 
 2.0 (xx.xx.xxxx) - IN DEVELOPMENT

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -275,6 +275,7 @@ Contributors
 * Dave Bell
 * Ben Weatherman
 * Carlo Ascani
+* Julian Gallo
 
 Translators
 ===========

--- a/docs/releases/2.1.rst
+++ b/docs/releases/2.1.rst
@@ -22,6 +22,7 @@ Bug fixes
 
  * Status button on 'edit page' now links to the correct URL when live and draft slug differ (LB (Ben Johnston))
  * Image title text in the gallery and in the chooser now wraps for long filenames (LB (Ben Johnston), Luiz Boaretto)
+ * Fix: Move image editor action buttons to the bottom of the form on mobile (Julian Gallo)
 
 Upgrade considerations
 ======================

--- a/wagtail/images/templates/wagtailimages/images/edit.html
+++ b/wagtail/images/templates/wagtailimages/images/edit.html
@@ -33,9 +33,10 @@
 
     <div class="row row-flush nice-padding">
 
-        <div class="col5">
-            <form action="{% url 'wagtailimages:edit' image.id %}" method="POST" enctype="multipart/form-data" novalidate>
-                {% csrf_token %}
+        <form action="{% url 'wagtailimages:edit' image.id %}" method="POST" enctype="multipart/form-data" novalidate>
+            {% csrf_token %}
+
+            <div class="col5">
                 <ul class="fields">
                     {% for field in form %}
 
@@ -48,59 +49,61 @@
                         {% endif %}
 
                     {% endfor %}
-                    <li>
-                        <input type="submit" value="{% trans 'Save' %}" class="button" />
-                        {% if user_can_delete %}
-                            <a href="{% url 'wagtailimages:delete' image.id %}" class="button button-secondary no">{% trans "Delete image" %}</a>
-                        {% endif %}
-                    </li>
                 </ul>
-            </form>
-        </div>
-        <div class="col5 divider-after">
-            <h2 class="label">{% trans "Focal point (optional)" %}</h2>
-            <p>{% trans "To define this image's most important region, drag a box over the image below." %} {% if image.focal_point %}({% trans "Current focal point shown" %}){% endif %}</p>
-
-            {% image image max-800x600 as rendition %}
-
-            <div class="focal-point-chooser"
-                style="max-width: {{ rendition.width }}px; max-height: {{ rendition.height }}px;"
-                data-focal-point-x="{{ image.focal_point_x }}"
-                data-focal-point-y="{{ image.focal_point_y }}"
-                data-focal-point-width="{{ image.focal_point_width }}"
-                data-focal-point-height="{{ image.focal_point_height }}">
-
-                <img {{ rendition.attrs }} data-original-width="{{ image.width|unlocalize }}" data-original-height="{{ image.height|unlocalize }}" class="show-transparency">
-
-                <div class="current-focal-point-indicator{% if not image.has_focal_point %} hidden{% endif %}"></div>
-
             </div>
-            <br />
-            <button class="button button-secondary no remove-focal-point">{% trans "Remove focal area" %}</button>
 
-        </div>
-        <div class="col2 ">
-            {% if url_generator_enabled %}
-                <a href="{% url 'wagtailimages:url_generator' image.id %}" class="button bicolor icon icon-link">{% trans "URL Generator" %}</a>
-                <hr />
-            {% endif %}
+            <div class="col5 divider-after">
+                <h2 class="label">{% trans "Focal point (optional)" %}</h2>
+                <p>{% trans "To define this image's most important region, drag a box over the image below." %} {% if image.focal_point %}({% trans "Current focal point shown" %}){% endif %}</p>
 
-            {% image image original as original_image %}
+                {% image image max-800x600 as rendition %}
 
-            <dl>
-                <dt>{% trans "Max dimensions" %}</dt>
-                <dd>{{ original_image.width }}x{{ original_image.height }}</dd>
-                <dt>{% trans "Filesize" %}</dt>
-                <dd>{% if filesize %}{{ filesize|filesizeformat }}{% else %}{% trans "File not found" %}{% endif %}</dd>
+                <div class="focal-point-chooser"
+                    style="max-width: {{ rendition.width }}px; max-height: {{ rendition.height }}px;"
+                    data-focal-point-x="{{ image.focal_point_x }}"
+                    data-focal-point-y="{{ image.focal_point_y }}"
+                    data-focal-point-width="{{ image.focal_point_width }}"
+                    data-focal-point-height="{{ image.focal_point_height }}">
 
-                {% usage_count_enabled as uc_enabled %}
-                {% if uc_enabled %}
-                    <dt>{% trans "Usage" %}</dt>
-                    <dd>
-                        <a href="{{ image.usage_url }}">{% blocktrans count usage_count=image.get_usage.count %}Used {{ usage_count }} time{% plural %}Used {{ usage_count }} times{% endblocktrans %}</a>
-                    </dd>
+                    <img {{ rendition.attrs }} data-original-width="{{ image.width|unlocalize }}" data-original-height="{{ image.height|unlocalize }}" class="show-transparency">
+
+                    <div class="current-focal-point-indicator{% if not image.has_focal_point %} hidden{% endif %}"></div>
+
+                </div>
+                <br />
+                <button class="button button-secondary no remove-focal-point">{% trans "Remove focal area" %}</button>
+            </div>
+
+            <div class="col2 ">
+                {% if url_generator_enabled %}
+                    <a href="{% url 'wagtailimages:url_generator' image.id %}" class="button bicolor icon icon-link">{% trans "URL Generator" %}</a>
+                    <hr />
                 {% endif %}
-            </dl>
-        </div>
+
+                {% image image original as original_image %}
+
+                <dl>
+                    <dt>{% trans "Max dimensions" %}</dt>
+                    <dd>{{ original_image.width }}x{{ original_image.height }}</dd>
+                    <dt>{% trans "Filesize" %}</dt>
+                    <dd>{% if filesize %}{{ filesize|filesizeformat }}{% else %}{% trans "File not found" %}{% endif %}</dd>
+
+                    {% usage_count_enabled as uc_enabled %}
+                    {% if uc_enabled %}
+                        <dt>{% trans "Usage" %}</dt>
+                        <dd>
+                            <a href="{{ image.usage_url }}">{% blocktrans count usage_count=image.get_usage.count %}Used {{ usage_count }} time{% plural %}Used {{ usage_count }} times{% endblocktrans %}</a>
+                        </dd>
+                    {% endif %}
+                </dl>
+            </div>
+
+            <div class="col5">
+                <input type="submit" value="{% trans 'Save' %}" class="button" />
+                {% if user_can_delete %}
+                    <a href="{% url 'wagtailimages:delete' image.id %}" class="button button-secondary no">{% trans "Delete image" %}</a>
+                {% endif %}
+            </div>
+        </form>
     </div>
 {% endblock %}

--- a/wagtail/images/templates/wagtailimages/images/edit.html
+++ b/wagtail/images/templates/wagtailimages/images/edit.html
@@ -31,10 +31,10 @@
     {% trans "Editing" as editing_str %}
     {% include "wagtailadmin/shared/header.html" with title=editing_str subtitle=image.title icon="image" %}
 
-    <div class="row row-flush nice-padding">
+    <form action="{% url 'wagtailimages:edit' image.id %}" method="POST" enctype="multipart/form-data" novalidate>
+        {% csrf_token %}
 
-        <form action="{% url 'wagtailimages:edit' image.id %}" method="POST" enctype="multipart/form-data" novalidate>
-            {% csrf_token %}
+        <div class="row row-flush nice-padding">
 
             <div class="col5">
                 <ul class="fields">
@@ -71,7 +71,7 @@
 
                 </div>
                 <br />
-                <button class="button button-secondary no remove-focal-point">{% trans "Remove focal area" %}</button>
+                <button class="button button-secondary no remove-focal-point" type="button">{% trans "Remove focal area" %}</button>
             </div>
 
             <div class="col2 ">
@@ -97,13 +97,16 @@
                     {% endif %}
                 </dl>
             </div>
+        </div>
 
+        <div class="row row-flush nice-padding">
             <div class="col5">
                 <input type="submit" value="{% trans 'Save' %}" class="button" />
                 {% if user_can_delete %}
                     <a href="{% url 'wagtailimages:delete' image.id %}" class="button button-secondary no">{% trans "Delete image" %}</a>
                 {% endif %}
             </div>
-        </form>
-    </div>
+        </div>
+
+    </form>
 {% endblock %}


### PR DESCRIPTION
…e view when viewing on mobile


This is a PR to address issue #3711.

My fix is to wrap the three columns on the page in the form instead of just having the form inside the first column. Since the first column is the only place with input fields and is the only form on the page, this should have any negative side effects. This also allows me to but the submit and delete buttons in their own column below the others. This doesn't change the view on the desktop view but moves those buttons to the bottom of the page when viewed in a smaller viewport.