### PR TITLE
Fix 'revisions' link unnecessarily collapsing on Chrome <800px

### DIFF
--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/core.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/core.scss
@@ -172,6 +172,7 @@ footer {
 
         .meta p {
             white-space: normal;
+            width: 100%;
         }
     }
 


### PR DESCRIPTION
Seems to be a Chrome specific issue.

![image](https://user-images.githubusercontent.com/14837124/29613170-acec0d14-87fc-11e7-98d7-3302b777ec16.png)

With PR:

![image](https://user-images.githubusercontent.com/14837124/29613015-ea4a0342-87fb-11e7-90da-f799b4390e09.png)
