### PR TITLE
Fixed wrong argument for datetimechooser widget

### DIFF
--- a/wagtail/wagtailadmin/static_src/wagtailadmin/js/page-editor.js
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/js/page-editor.js
@@ -86,7 +86,7 @@ function initDateTimeChooser(id, opts) {
             i18n: {
                 lang: window.dateTimePickerTranslations
             },
-            language: 'lang',
+            lang: 'lang',
             onGenerate: hideCurrent
         }, opts || {}));
     } else {


### PR DESCRIPTION
The argument for specifying the language of the DateTimeChooser is wrong, which makes it impossible to customise the language. Compare for reference the argument specification for the DateChooser and the TimeChooser :-)
