### PR TITLE
Make user search in admin search multiple fields

### DIFF
--- a/wagtail/wagtailusers/tests.py
+++ b/wagtail/wagtailusers/tests.py
@@ -76,7 +76,9 @@ class TestUserIndexView(TestCase, WagtailTestUtils):
         self.test_user = get_user_model().objects.create_user(
             username='testuser',
             email='testuser@email.com',
-            password='password'
+            password='password',
+            first_name='First Name',
+            last_name='Last Name'
         )
         self.login()
 
@@ -101,6 +103,18 @@ class TestUserIndexView(TestCase, WagtailTestUtils):
         response = self.get({'q': "Hello"})
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context['query_string'], "Hello")
+
+    def test_search_query_one_field(self):
+        response = self.get({'q': "first name"})
+        self.assertEqual(response.status_code, 200)
+        results = response.context['users'].object_list
+        self.assertIn(self.test_user, results)
+
+    def test_search_query_multiple_fields(self):
+        response = self.get({'q': "first name last name"})
+        self.assertEqual(response.status_code, 200)
+        results = response.context['users'].object_list
+        self.assertIn(self.test_user, results)
 
     def test_pagination(self):
         pages = ['0', '1', '-1', '9999', 'Not a page']

--- a/wagtail/wagtailusers/views/users.py
+++ b/wagtail/wagtailusers/views/users.py
@@ -70,17 +70,18 @@ def index(request):
             is_searching = True
             conditions = Q()
 
-            if 'username' in model_fields:
-                conditions |= Q(username__icontains=q)
+            for term in q.split():
+                if 'username' in model_fields:
+                    conditions |= Q(username__icontains=term)
 
-            if 'first_name' in model_fields:
-                conditions |= Q(first_name__icontains=q)
+                if 'first_name' in model_fields:
+                    conditions |= Q(first_name__icontains=term)
 
-            if 'last_name' in model_fields:
-                conditions |= Q(last_name__icontains=q)
+                if 'last_name' in model_fields:
+                    conditions |= Q(last_name__icontains=term)
 
-            if 'email' in model_fields:
-                conditions |= Q(email__icontains=q)
+                if 'email' in model_fields:
+                    conditions |= Q(email__icontains=term)
 
             users = User.objects.filter(conditions)
     else:


### PR DESCRIPTION
When searching for users in the admin, queries across multiple fields wouldn't work.  For example, if you had a user with first name John and last name Smith "John" would match, "Smith" would match, but "John Smith" returns no results.