### PR TITLE
Use Page subclass get_admin_display_title() in admin search views.

### DIFF
--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/listing/_page_title_choose.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/listing/_page_title_choose.html
@@ -8,9 +8,9 @@ Expects a variable 'page', the page instance.
 
 <h2>
     {% if page.can_choose %}
-        <a class="choose-page" href="#{{ page.id|unlocalize }}" data-id="{{ page.id|unlocalize }}" data-title="{{ page.get_admin_display_title }}" data-url="{{ page.url }}" data-parent-id="{{ page.get_parent.id|unlocalize }}" data-edit-url="{% url 'wagtailadmin_pages:edit' page.id %}">{{ page.get_admin_display_title }}</a>
+        <a class="choose-page" href="#{{ page.id|unlocalize }}" data-id="{{ page.id|unlocalize }}" data-title="{{ page.specific.get_admin_display_title }}" data-url="{{ page.url }}" data-parent-id="{{ page.get_parent.id|unlocalize }}" data-edit-url="{% url 'wagtailadmin_pages:edit' page.id %}">{{ page.specific.get_admin_display_title }}</a>
     {% else %}
-        {{ page.get_admin_display_title }}
+        {{ page.specific.get_admin_display_title }}
     {% endif %}
 
     {% include "wagtailadmin/pages/listing/_privacy_indicator.html" with page=page %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/listing/_page_title_explore.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/listing/_page_title_explore.html
@@ -10,9 +10,9 @@
     {% endif %}
 
     {% if page_perms.can_edit %}
-        <a href="{% url 'wagtailadmin_pages:edit' page.id %}" title="{% trans 'Edit this page' %}">{{ page.get_admin_display_title }}</a>
+        <a href="{% url 'wagtailadmin_pages:edit' page.id %}" title="{% trans 'Edit this page' %}">{{ page.specific.get_admin_display_title }}</a>
     {% else %}
-        {{ page.get_admin_display_title }}
+        {{ page.specific.get_admin_display_title }}
     {% endif %}
 
     {% include "wagtailadmin/pages/listing/_privacy_indicator.html" with page=page %}

--- a/wagtail/wagtailadmin/views/chooser.py
+++ b/wagtail/wagtailadmin/views/chooser.py
@@ -161,6 +161,7 @@ def search(request, parent_page_id=None):
             depth=1  # never include root
         )
         pages = filter_page_type(pages, desired_classes)
+        pages = pages.specific()
         pages = pages.search(search_form.cleaned_data['q'], fields=['title'])
     else:
         pages = pages.none()

--- a/wagtail/wagtailadmin/views/pages.py
+++ b/wagtail/wagtailadmin/views/pages.py
@@ -874,7 +874,7 @@ def search(request):
         if form.is_valid():
             q = form.cleaned_data['q']
 
-            pages = Page.objects.all().prefetch_related('content_type').search(q)
+            pages = Page.objects.all().prefetch_related('content_type').specific().search(q)
             paginator, pages = paginate(request, pages)
     else:
         form = SearchForm()


### PR DESCRIPTION
The template changes force the most specific ``get_admin_display_title`` method
to be used across all page explorer lists and page choosers in the admin. The
view changes should reduce the performance hit in the case of the search views.

Relates to #3793