### PR TITLE
Fix form submission page header class

### DIFF
--- a/wagtail/wagtailforms/templates/wagtailforms/index_submissions.html
+++ b/wagtail/wagtailforms/templates/wagtailforms/index_submissions.html
@@ -88,7 +88,7 @@
         <form action="" method="get" novalidate>
             <div class="row">
                 <div class="left">
-                    <div class="col">
+                    <div class="col header-title">
                         <h1 class="icon icon-form">
                         {% blocktrans with form_title=form_page.title|capfirst %}Form data <span>{{ form_title }}</span>{% endblocktrans %}
                         </h1>
@@ -123,3 +123,4 @@
         {% endif %}
     </div>
 {% endblock %}
+


### PR DESCRIPTION
Without this the mobile nav-menu button obstructs the header text.

![image](https://user-images.githubusercontent.com/14837124/29711021-d06d12b2-898a-11e7-9995-afce828c53b4.png)
