### PR TITLE
Allow flexible logo height in admin

### DIFF
--- a/wagtail/admin/static_src/wagtailadmin/scss/components/_main-nav.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/components/_main-nav.scss
@@ -252,6 +252,10 @@ body.explorer-open {
 
     .nav-main {
         display: none;
+
+        @include medium {
+            display: block;
+        }
     }
 }
 
@@ -438,10 +442,6 @@ body.explorer-open {
         .nav-wrapper {
             margin-left: 0;
             width: $menu-width;
-        }
-
-        .nav-main {
-            display: block;
         }
     }
 }

--- a/wagtail/admin/static_src/wagtailadmin/scss/components/_main-nav.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/components/_main-nav.scss
@@ -19,11 +19,13 @@ $footer-submenu: $submenu-color;
 }
 
 .nav-toggle.icon {
-    left: $mobile-nice-padding;
-    cursor: pointer;
     position: absolute;
+    padding-left: $mobile-nice-padding;
+    cursor: pointer;
 
     &:before {
+        position: relative;
+        top: 3px;
         font-size: 40px;
         color: $color-white;
         line-height: 40px;
@@ -200,10 +202,13 @@ $footer-submenu: $submenu-color;
     button {
         background-color: transparent;
         position: absolute;
-        top: 0; right: 0; bottom: 0;
+        top: 0;
+        right: 0;
+        bottom: 0;
         margin: auto;
         padding: 0;
-        width: 3em; height: 100%;
+        width: 3em;
+        height: 100%;
         overflow: hidden;
 
         &:before {

--- a/wagtail/admin/static_src/wagtailadmin/scss/components/_main-nav.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/components/_main-nav.scss
@@ -283,6 +283,7 @@ body.explorer-open {
 
     .nav-main {
         position: relative;
+        top: 0;
         bottom: 0;
         margin-bottom: 127px; // WARNING - magic number - the height of the .footer
         width: 100%;

--- a/wagtail/admin/static_src/wagtailadmin/scss/components/_main-nav.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/components/_main-nav.scss
@@ -19,13 +19,11 @@ $footer-submenu: $submenu-color;
 }
 
 .nav-toggle.icon {
-    position: absolute;
-    padding-left: $mobile-nice-padding;
+    left: $mobile-nice-padding;
     cursor: pointer;
+    position: absolute;
 
     &:before {
-        position: relative;
-        top: 3px;
         font-size: 40px;
         color: $color-white;
         line-height: 40px;
@@ -202,13 +200,10 @@ $footer-submenu: $submenu-color;
     button {
         background-color: transparent;
         position: absolute;
-        top: 0;
-        right: 0;
-        bottom: 0;
+        top: 0; right: 0; bottom: 0;
         margin: auto;
         padding: 0;
-        width: 3em;
-        height: 100%;
+        width: 3em; height: 100%;
         overflow: hidden;
 
         &:before {
@@ -282,8 +277,7 @@ body.explorer-open {
     }
 
     .nav-main {
-        position: absolute;
-        top: 175px; // WARNING - magic number - the height of the logo plus search box
+        position: relative;
         bottom: 0;
         margin-bottom: 127px; // WARNING - magic number - the height of the .footer
         width: 100%;


### PR DESCRIPTION
As suggested by @mainderay in #3517.

Example (imagine this is a custom logo):

![image](https://user-images.githubusercontent.com/14837124/29713028-a60c05b4-8994-11e7-8e15-0b3f6d5aa492.png)

Before you would see this:

![image](https://user-images.githubusercontent.com/14837124/29713153-3cacd35e-8995-11e7-9aa2-d446973b51ee.png)



