### PR TITLE
Toggleable high contrast mode [WIP]

### DIFF
--- a/wagtail/wagtailadmin/static_src/wagtailadmin/js/core.js
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/js/core.js
@@ -169,7 +169,7 @@ $(function() {
                 'color': '#fff'
             });
 
-            $('.button, .messages, .warning, .success').css({
+            $('.button, .messages, .warning, .c-dropdown, .success').css({
                 'background-color': '#0f2828',
                 'border': '2px solid #000'
             });

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/js/core.js
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/js/core.js
@@ -173,6 +173,10 @@ $(function() {
                 'background-color': '#0f2828',
                 'border': '2px solid #000'
             });
+
+            $('.listing').css({
+                'color': '#000'
+            });
         };
     };
     applyHighContrastMode();

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/js/core.js
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/js/core.js
@@ -159,6 +159,24 @@ $(function() {
     }
     initLogo();
 
+    // HIGH CONTRAST MODE
+    function applyHighContrastMode() {
+        var useHighContrast = localStorage.getItem('useHighContrast');
+
+        if (useHighContrast == 'true') {
+            $('header, .button, .c-dropdown, .messages').css({
+                'background-color': '#246060',
+                'color': '#fff'
+            });
+
+            $('.button, .messages, .warning, .success').css({
+                'background-color': '#0f2828',
+                'border': '2px solid #000'
+            });
+        };
+    };
+    applyHighContrastMode();
+
     // Enable nice focus effects on all fields. This enables help text on hover.
     $(document).on('focus mouseover', 'input,textarea,select', function() {
         $(this).closest('.field').addClass('focused');

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/js/core.js
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/js/core.js
@@ -164,19 +164,9 @@ $(function() {
         var useHighContrast = localStorage.getItem('useHighContrast');
 
         if (useHighContrast == 'true') {
-            $('header, .button, .c-dropdown, .messages').css({
-                'background-color': '#246060',
-                'color': '#fff'
-            });
-
-            $('.button, .messages, .warning, .c-dropdown, .success').css({
-                'background-color': '#0f2828',
-                'border': '2px solid #000'
-            });
-
-            $('.listing').css({
-                'color': '#000'
-            });
+            $('body').addClass('high-contrast');
+        } else {
+            $('body').removeClass('high-contrast');
         };
     };
     applyHighContrastMode();

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/_variables.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/_variables.scss
@@ -82,3 +82,9 @@ $thumbnail-width: 130px;
 $menu-width: 180px;
 $menu-width-max: 320px;
 $mobile-nav-indent: 50px;
+
+// High contrast mode
+$color-white-hc: #fff;
+$color-black-hc: #000;
+$color-teal-hc: #246060;
+$color-teal-dark-hc: #0f2828;

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/core.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/core.scss
@@ -459,7 +459,7 @@ body {
             border: 2px solid $color-black-hc !important;
         }
 
-        .listing, .table-headers {
+        .listing, .table-headers, dt {
             color: $color-black-hc !important;
         }
 
@@ -469,10 +469,16 @@ body {
 
         .dropdown {
             .ul {
-                a {
+                li {
                     color: $color-black-hc !important;
                 }
             }
+        }
+
+        .tagit, #id_title, #id_file, #id_collection {
+            background-color: $color-white-hc !important;
+            border: 2px solid $color-black-hc !important;
+            color: $color-black-hc !important;
         }
     }
 }

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/core.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/core.scss
@@ -447,22 +447,24 @@ footer,
 // High contrast mode
 body {
     &.high-contrast {
-        header, .button, .c-dropdown, .messages, .c-dropdown__button {
+        header, .index, .breadcrumb, .button, .c-dropdown,
+        .messages, .c-dropdown__button, .tab-nav, .dropdown-toggle {
             background-color: $color-teal-hc !important; // need to remove these `!important` tags
             color: $color-white-hc !important;
         }
 
-        .button, .messages, .warning, .success, .c-dropdown, .c-dropdown__button {
+        .button, .messages, .warning, .success, .c-dropdown,
+        .c-dropdown__button, .dropdown-toggle {
             background-color: $color-teal-dark-hc !important;
             border: 2px solid $color-black-hc !important;
         }
 
-        .listing {
+        .listing, .table-headers {
             color: $color-black-hc !important;
         }
 
-        .table-headers {
-            color: $color-black-hc !important;
+        .icon, div.privacy-indicator {
+            color: $color-white-hc !important;
         }
     }
 }

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/core.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/core.scss
@@ -442,3 +442,22 @@ footer,
         z-index: 200;
     }
 }
+
+// High contrast mode
+body {
+    &.high-contrast {
+        header, .button, .c-dropdown, .messages {
+            background-color: $color-teal-hc !important; // need to remove these `!important` tags
+            color: $color-white-hc !important;
+        }
+
+        .button, .messages, .warning, .success, .c-dropdown {
+            background-color: $color-teal-dark-hc !important;
+            border: 2px solid $color-black-hc !important;
+        }
+
+        .listing {
+            color: $color-black-hc !important;
+        }
+    }
+}

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/core.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/core.scss
@@ -466,5 +466,13 @@ body {
         .icon, div.privacy-indicator {
             color: $color-white-hc !important;
         }
+
+        .dropdown {
+            .ul {
+                a {
+                    color: $color-black-hc !important;
+                }
+            }
+        }
     }
 }

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/core.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/core.scss
@@ -463,7 +463,7 @@ body {
             color: $color-black-hc !important;
         }
 
-        .icon, div.privacy-indicator {
+        .icon {
             color: $color-white-hc !important;
         }
 

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/core.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/core.scss
@@ -443,10 +443,12 @@ footer,
     }
 }
 
+
+
 // High contrast mode
 body {
     &.high-contrast {
-        header, .button, .c-dropdown, .messages {
+        header, .button, .c-dropdown, .messages, .c-dropdown__button {
             background-color: $color-teal-hc !important; // need to remove these `!important` tags
             color: $color-white-hc !important;
         }
@@ -457,6 +459,10 @@ body {
         }
 
         .listing {
+            color: $color-black-hc !important;
+        }
+
+        .table-headers {
             color: $color-black-hc !important;
         }
     }

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/core.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/core.scss
@@ -452,7 +452,7 @@ body {
             color: $color-white-hc !important;
         }
 
-        .button, .messages, .warning, .success, .c-dropdown {
+        .button, .messages, .warning, .success, .c-dropdown, .c-dropdown__button {
             background-color: $color-teal-dark-hc !important;
             border: 2px solid $color-black-hc !important;
         }

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/core.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/core.scss
@@ -444,7 +444,6 @@ footer,
 }
 
 
-
 // High contrast mode
 body {
     &.high-contrast {

--- a/wagtail/wagtailadmin/templates/wagtailadmin/account/accessibility_preferences.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/account/accessibility_preferences.html
@@ -1,0 +1,39 @@
+{% extends "wagtailadmin/base.html" %}
+{% load i18n admin_static %}
+
+{% block titletag %}{% trans "Accessibility Preferences" %}{% endblock %}
+{% block content %}
+    {% trans "Accessibility Preferences" as prefs_str %}
+    {% include "wagtailadmin/shared/header.html" with title=prefs_str %}
+
+    <div class="nice-padding">
+        <form action="{% url 'wagtailadmin_account_notification_preferences' %}" method="POST" novalidate>
+            {% csrf_token %}
+            <input id="highcontrast_toggle" type="checkbox">{% trans "Enable high contrast mode (experimental)" %}<br>
+            <input id="highcontrast_submit" type="submit" value="{% trans 'Update' %}" class="button" style="margin-top: 1.7em;" />
+        </form>
+    </div>
+{% endblock %}
+
+{% block extra_js %}
+    <script>
+        $(function() {
+            var useHighContrast = localStorage.getItem('useHighContrast');
+            if (useHighContrast == 'true') {
+                $('#highcontrast_toggle').prop('checked', true);
+            };
+
+            $('#highcontrast_submit').click(function() {
+                if ($('#highcontrast_toggle').prop('checked')) {
+                    useHighContrast = 'true';
+                    localStorage.setItem('useHighContrast', useHighContrast);
+                    window.location.reload(true); // hard refresh (ignore cache)
+                } else {
+                    useHighContrast = 'false';
+                    localStorage.setItem('useHighContrast', useHighContrast);
+                    window.location.reload(true); // hard refresh (ignore cache)
+                };
+            });
+        })
+    </script>
+{% endblock %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/account/account.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/account/account.html
@@ -51,7 +51,15 @@
                     </small>
                 </li>
             {% endif %}
+            <li class="row row-flush">
+                <div class="col6">
+                    <a href="{% url 'wagtailadmin_account_accessibility_preferences' %}" class="button button-primary">{% trans "Accessibility preferences" %}</a><text style="padding-left:15px;">{% trans "(Experimental)" %}</text>
+                </div>
 
+                <small class="col6">
+                    {% trans "Configure accessibility settings." %}
+                </small>
+            </li>
         </ul>
     </div>
 {% endblock %}

--- a/wagtail/wagtailadmin/urls/__init__.py
+++ b/wagtail/wagtailadmin/urls/__init__.py
@@ -1,10 +1,5 @@
-import functools
-
 from django.conf.urls import url, include
 from django.views.decorators.cache import cache_control
-from django.views.generic import TemplateView
-from django.http import Http404
-from django.views.defaults import page_not_found
 
 from wagtail.wagtailadmin.urls import pages as wagtailadmin_pages_urls
 from wagtail.wagtailadmin.urls import collections as wagtailadmin_collections_urls
@@ -18,8 +13,6 @@ from wagtail.wagtailadmin.decorators import require_admin_access
 
 urlpatterns = [
     url(r'^$', home.home, name='wagtailadmin_home'),
-
-    url(r'^test404/$', TemplateView.as_view(template_name='wagtailadmin/404.html')),
 
     url(r'api/', include(api_urls)),
 
@@ -85,25 +78,7 @@ urlpatterns += [
 
     # Password reset
     url(r'^password_reset/', include(wagtailadmin_password_reset_urls)),
-
-    # Default view (will show 404 page)
-    # This must be the last URL in this file!
-    url(r'^', home.default),
 ]
-
-# Hook in our own 404 handler
-def display_custom_404(view_func):
-    @functools.wraps(view_func)
-    def wrapper(request, *args, **kwargs):
-        try:
-            return view_func(request, *args, **kwargs)
-        except Http404:
-            return page_not_found(request, '', template_name='wagtailadmin/404.html')
-
-    return wrapper
-
-urlpatterns = decorate_urlpatterns(urlpatterns, display_custom_404)
-
 
 # Decorate all views with cache settings to prevent caching
 urlpatterns = decorate_urlpatterns(

--- a/wagtail/wagtailadmin/urls/__init__.py
+++ b/wagtail/wagtailadmin/urls/__init__.py
@@ -1,5 +1,10 @@
+import functools
+
 from django.conf.urls import url, include
 from django.views.decorators.cache import cache_control
+from django.views.generic import TemplateView
+from django.http import Http404
+from django.views.defaults import page_not_found
 
 from wagtail.wagtailadmin.urls import pages as wagtailadmin_pages_urls
 from wagtail.wagtailadmin.urls import collections as wagtailadmin_collections_urls
@@ -13,6 +18,8 @@ from wagtail.wagtailadmin.decorators import require_admin_access
 
 urlpatterns = [
     url(r'^$', home.home, name='wagtailadmin_home'),
+
+    url(r'^test404/$', TemplateView.as_view(template_name='wagtailadmin/404.html')),
 
     url(r'api/', include(api_urls)),
 
@@ -47,6 +54,11 @@ urlpatterns = [
         account.language_preferences,
         name='wagtailadmin_account_language_preferences'
     ),
+    url(
+        r'^account/accessibility_preferences/$',
+        account.accessibility_preferences,
+        name='wagtailadmin_account_accessibility_preferences'
+    ),
     url(r'^logout/$', account.logout, name='wagtailadmin_logout'),
 ]
 
@@ -73,7 +85,25 @@ urlpatterns += [
 
     # Password reset
     url(r'^password_reset/', include(wagtailadmin_password_reset_urls)),
+
+    # Default view (will show 404 page)
+    # This must be the last URL in this file!
+    url(r'^', home.default),
 ]
+
+# Hook in our own 404 handler
+def display_custom_404(view_func):
+    @functools.wraps(view_func)
+    def wrapper(request, *args, **kwargs):
+        try:
+            return view_func(request, *args, **kwargs)
+        except Http404:
+            return page_not_found(request, '', template_name='wagtailadmin/404.html')
+
+    return wrapper
+
+urlpatterns = decorate_urlpatterns(urlpatterns, display_custom_404)
+
 
 # Decorate all views with cache settings to prevent caching
 urlpatterns = decorate_urlpatterns(

--- a/wagtail/wagtailadmin/views/account.py
+++ b/wagtail/wagtailadmin/views/account.py
@@ -130,7 +130,7 @@ def language_preferences(request):
 
 def accessibility_preferences(request):
     if request.method == 'POST':
-        form = NotificationPreferencesForm(request.POST, instance=UserProfile.get_for_user(request.user))
+        form = NotificationPreferencesForm(request.POST, instance=UserProfile.get_for_user(request.user)) # needs to change
 
         if form.is_valid():
             form.save()

--- a/wagtail/wagtailadmin/views/account.py
+++ b/wagtail/wagtailadmin/views/account.py
@@ -128,6 +128,21 @@ def language_preferences(request):
         'form': form,
     })
 
+def accessibility_preferences(request):
+    if request.method == 'POST':
+        form = NotificationPreferencesForm(request.POST, instance=UserProfile.get_for_user(request.user))
+
+        if form.is_valid():
+            form.save()
+            messages.success(request, _("Your preferences have been updated."))
+            return redirect('wagtailadmin_account')
+    else:
+        form = PreferredLanguageForm(instance=UserProfile.get_for_user(request.user))
+
+    return render(request, 'wagtailadmin/account/accessibility_preferences.html', {
+        'form': form,
+    })
+
 
 @sensitive_post_parameters()
 @never_cache


### PR DESCRIPTION
This isn't the most efficient solution and it definitely needs some work to be completely viable, but here's my attempt at reworking #3106 using @thibaudcolas' suggestion of having a toggleable high contrast mode.

Demonstration: https://gfycat.com/ImprobableAfraidDavidstiger

To do:

- [x] ~~Find alternative approach to apply the new styling (currently using jQuery which is bad for performance)~~ Now uses CSS, but jQuery is still needed to add the class on every page load...

- [ ] Make the setting account-based, rather than applying for everyone using Wagtail on that machine

- [ ] Improve the high contrast mode to comply 100% with [WCAG 2.0 standards](https://www.w3.org/TR/WCAG20/)

- [ ] Add tests

Related: #2224, #3106, #3458.