### PR TITLE
Fix mobile nav menu height

### DIFF
--- a/wagtail/wagtailadmin/static_src/wagtailadmin/js/core.js
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/js/core.js
@@ -97,7 +97,7 @@ $(function() {
 
     // Resize nav to fit height of content. This is an unimportant bell/whistle to make it look nice
     var fitNav = function() {
-        $('.nav-wrapper').css('min-height', $('.content').height() + 51); // 51 = height of footer
+        $('.nav-wrapper').css('min-height', $('.content').outerHeight()); // include padding/margin in height
         $('.nav-main').each(function() {
             var thisHeight = $(this).height();
             var footerHeight = $('#footer', $(this)).height();
@@ -106,7 +106,7 @@ $(function() {
 
     fitNav();
 
-    $(window).resize(function() {
+    $(document).resize(function() {
         fitNav();
     });
 

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/js/core.js
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/js/core.js
@@ -95,9 +95,9 @@ $(function() {
         $(this).find('em').toggleClass('icon-arrow-down-after icon-arrow-up-after');
     });
 
-    // Resize nav to fit height of document. This is an unimportant bell/whistle to make it look nice
+    // Resize nav to fit height of content. This is an unimportant bell/whistle to make it look nice
     var fitNav = function() {
-        $('.nav-wrapper').css('min-height', $(document).height());
+        $('.nav-wrapper').css('min-height', $('.content').height() + 64); // 64 = height of footer
         $('.nav-main').each(function() {
             var thisHeight = $(this).height();
             var footerHeight = $('#footer', $(this)).height();

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/js/core.js
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/js/core.js
@@ -97,7 +97,7 @@ $(function() {
 
     // Resize nav to fit height of window. This is an unimportant bell/whistle to make it look nice
     var fitNav = function() {
-        $('.nav-wrapper').css('min-height', $(window).height());
+        $('.nav-wrapper').css('min-height', $(document).height());
         $('.nav-main').each(function() {
             var thisHeight = $(this).height();
             var footerHeight = $('#footer', $(this)).height();

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/js/core.js
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/js/core.js
@@ -95,7 +95,7 @@ $(function() {
         $(this).find('em').toggleClass('icon-arrow-down-after icon-arrow-up-after');
     });
 
-    // Resize nav to fit height of window. This is an unimportant bell/whistle to make it look nice
+    // Resize nav to fit height of document. This is an unimportant bell/whistle to make it look nice
     var fitNav = function() {
         $('.nav-wrapper').css('min-height', $(document).height());
         $('.nav-main').each(function() {

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/js/core.js
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/js/core.js
@@ -97,7 +97,7 @@ $(function() {
 
     // Resize nav to fit height of content. This is an unimportant bell/whistle to make it look nice
     var fitNav = function() {
-        $('.nav-wrapper').css('min-height', $('.content').height() + 64); // 64 = height of footer
+        $('.nav-wrapper').css('min-height', $('.content').height() + 50); // 50 = height of footer
         $('.nav-main').each(function() {
             var thisHeight = $(this).height();
             var footerHeight = $('#footer', $(this)).height();

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/js/core.js
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/js/core.js
@@ -97,7 +97,7 @@ $(function() {
 
     // Resize nav to fit height of content. This is an unimportant bell/whistle to make it look nice
     var fitNav = function() {
-        $('.nav-wrapper').css('min-height', $('.content').height() + 50); // 50 = height of footer
+        $('.nav-wrapper').css('min-height', $('.content').height() + 51); // 51 = height of footer
         $('.nav-main').each(function() {
             var thisHeight = $(this).height();
             var footerHeight = $('#footer', $(this)).height();

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/js/core.js
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/js/core.js
@@ -103,12 +103,20 @@ $(function() {
             var footerHeight = $('#footer', $(this)).height();
         });
     };
-
     fitNav();
 
-    $(document).resize(function() {
-        fitNav();
-    });
+    // there's no native listener in jQuery for div height changes, so we must make our own:
+    function checkForContentResize() {
+        var exContentHeight = 0;
+
+        setInterval(function() {
+            if ($('.content').outerHeight() != exContentHeight) {
+                fitNav();
+                exContentHeight = $('.content').outerHeight();
+            }
+        }, 200);
+    }
+    checkForContentResize();
 
     // Logo interactivity
     function initLogo() {


### PR DESCRIPTION
Fixes #3721. Currently the menu's height is set to match the viewport height; by setting it to use the content height instead, the nav menu looks much cleaner when you scroll past it on mobile.

![image](https://user-images.githubusercontent.com/14837124/29875838-032ee160-8d93-11e7-8ff6-989bdde688c8.png)

Before you would see an area of nothing beneath the menu until the end of the page. 

Tested on latest Firefox, Chrome and mobile Safari.

(Also seems to have inadvertently fixed #3707)