### PR TITLE
Batch frontend cache invalidation

### DIFF
--- a/docs/reference/contrib/frontendcache.rst
+++ b/docs/reference/contrib/frontendcache.rst
@@ -149,7 +149,7 @@ Invalidating index pages
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 Pages that list other pages (such as a blog index) may need to be purged as
-well so any changes to a blog page is also reflected on the index (for example,
+well so any changes to a blog page are also reflected on the index (for example,
 a blog post was added, deleted or its title/thumbnail was changed).
 
 To purge these pages, we need to write a signal handler that listens for
@@ -180,7 +180,7 @@ This signal handler would trigger the invalidation of the index page using the
         batch.purge()
 
 
-    @receiver(page_published, sender=BlogPage):
+    @receiver(page_published, sender=BlogPage)
     def blog_published_handler(instance):
         blog_page_changed(instance)
 

--- a/wagtail/contrib/wagtailfrontendcache/backends.py
+++ b/wagtail/contrib/wagtailfrontendcache/backends.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
+from collections import defaultdict
 import logging
 import uuid
 
@@ -22,6 +23,11 @@ class PurgeRequest(Request):
 class BaseBackend(object):
     def purge(self, url):
         raise NotImplementedError
+
+    def purge_batch(self, urls):
+        # Fallback for backends that do not support batch purging
+        for url in urls:
+            self.purge(url)
 
 
 class HTTPBackend(BaseBackend):
@@ -67,7 +73,7 @@ class CloudflareBackend(BaseBackend):
         self.cloudflare_token = params.pop('TOKEN')
         self.cloudflare_zoneid = params.pop('ZONEID')
 
-    def purge(self, url):
+    def purge_batch(self, urls):
         try:
             purge_url = 'https://api.cloudflare.com/client/v4/zones/{0}/purge_cache'.format(self.cloudflare_zoneid)
 
@@ -77,7 +83,7 @@ class CloudflareBackend(BaseBackend):
                 "Content-Type": "application/json",
             }
 
-            data = {"files": [url]}
+            data = {"files": urls}
 
             response = requests.delete(
                 purge_url,
@@ -91,19 +97,19 @@ class CloudflareBackend(BaseBackend):
                 if response.status_code != 200:
                     response.raise_for_status()
                 else:
-                    logger.error("Couldn't purge '%s' from Cloudflare. Unexpected JSON parse error.", url)
+                    logger.error("Couldn't purge from Cloudflare. Unexpected JSON parse error.")
 
         except requests.exceptions.HTTPError as e:
-            logger.error("Couldn't purge '%s' from Cloudflare. HTTPError: %d %s", url, e.response.status_code, e.message)
-            return
-        except requests.exceptions.InvalidURL as e:
-            logger.error("Couldn't purge '%s' from Cloudflare. URLError: %s", url, e.message)
+            logger.error("Couldn't purge from Cloudflare. HTTPError: %d %s", e.response.status_code, e.message)
             return
 
         if response_json['success'] is False:
             error_messages = ', '.join([str(err['message']) for err in response_json['errors']])
-            logger.error("Couldn't purge '%s' from Cloudflare. Cloudflare errors '%s'", url, error_messages)
+            logger.error("Couldn't purge from Cloudflare. Cloudflare errors '%s'", error_messages)
             return
+
+    def purge(self, url):
+        self.purge_batch([url])
 
 
 class CloudfrontBackend(BaseBackend):
@@ -118,26 +124,34 @@ class CloudfrontBackend(BaseBackend):
                 "The setting 'WAGTAILFRONTENDCACHE' requires the object 'DISTRIBUTION_ID'."
             )
 
-    def purge(self, url):
-        url_parsed = urlparse(url)
-        distribution_id = None
+    def purge_batch(self, urls):
+        paths_by_distribution_id = defaultdict(list)
 
-        if isinstance(self.cloudfront_distribution_id, dict):
-            host = url_parsed.hostname
-            if host in self.cloudfront_distribution_id:
-                distribution_id = self.cloudfront_distribution_id.get(host)
+        for url in urls:
+            url_parsed = urlparse(url)
+            distribution_id = None
+
+            if isinstance(self.cloudfront_distribution_id, dict):
+                host = url_parsed.hostname
+                if host in self.cloudfront_distribution_id:
+                    distribution_id = self.cloudfront_distribution_id.get(host)
+                else:
+                    logger.info(
+                        "Couldn't purge '%s' from CloudFront. Hostname '%s' not found in the DISTRIBUTION_ID mapping",
+                        url, host)
             else:
-                logger.info(
-                    "Couldn't purge '%s' from CloudFront. Hostname '%s' not found in the DISTRIBUTION_ID mapping",
-                    url, host)
-        else:
-            distribution_id = self.cloudfront_distribution_id
+                distribution_id = self.cloudfront_distribution_id
 
-        if distribution_id:
-            path = url_parsed.path
-            self._create_invalidation(distribution_id, path)
+            if distribution_id:
+                paths_by_distribution_id[distribution_id].append(url_parsed.path)
 
-    def _create_invalidation(self, distribution_id, path):
+        for distribution_id, paths in paths_by_distribution_id.items():
+            self._create_invalidation(distribution_id, paths)
+
+    def purge(self, url):
+        self.purge_batch([url])
+
+    def _create_invalidation(self, distribution_id, paths):
         import botocore
 
         try:
@@ -145,15 +159,13 @@ class CloudfrontBackend(BaseBackend):
                 DistributionId=distribution_id,
                 InvalidationBatch={
                     'Paths': {
-                        'Quantity': 1,
-                        'Items': [
-                            path,
-                        ]
+                        'Quantity': len(paths),
+                        'Items': paths
                     },
                     'CallerReference': str(uuid.uuid4())
                 }
             )
         except botocore.exceptions.ClientError as e:
             logger.error(
-                "Couldn't purge '%s' from CloudFront. ClientError: %s %s", path, e.response['Error']['Code'],
+                "Couldn't purge from CloudFront. ClientError: %s %s", e.response['Error']['Code'],
                 e.response['Error']['Message'])

--- a/wagtail/contrib/wagtailfrontendcache/backends.py
+++ b/wagtail/contrib/wagtailfrontendcache/backends.py
@@ -1,8 +1,8 @@
 from __future__ import absolute_import, unicode_literals
 
-from collections import defaultdict
 import logging
 import uuid
+from collections import defaultdict
 
 import requests
 from django.core.exceptions import ImproperlyConfigured

--- a/wagtail/contrib/wagtailfrontendcache/tests.py
+++ b/wagtail/contrib/wagtailfrontendcache/tests.py
@@ -83,7 +83,7 @@ class TestBackendConfiguration(TestCase):
         backends.get('cloudfront').purge('http://www.wagtail.io/home/events/christmas/')
         backends.get('cloudfront').purge('http://torchbox.com/blog/')
 
-        _create_invalidation.assert_called_once_with('frontend', '/home/events/christmas/')
+        _create_invalidation.assert_called_once_with('frontend', ['/home/events/christmas/'])
 
     def test_multiple(self):
         backends = get_backends(backend_settings={

--- a/wagtail/contrib/wagtailfrontendcache/tests.py
+++ b/wagtail/contrib/wagtailfrontendcache/tests.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
 import mock
-
 from django.core.exceptions import ImproperlyConfigured
 from django.test import TestCase
 from django.test.utils import override_settings
@@ -12,7 +11,9 @@ from wagtail.contrib.wagtailfrontendcache.utils import get_backends
 from wagtail.tests.testapp.models import EventIndex
 from wagtail.wagtailcore.models import Page
 
-from .utils import purge_url_from_cache, purge_urls_from_cache, purge_page_from_cache, purge_pages_from_cache, PurgeBatch
+from .utils import (
+    PurgeBatch, purge_page_from_cache, purge_pages_from_cache, purge_url_from_cache,
+    purge_urls_from_cache)
 
 
 class TestBackendConfiguration(TestCase):

--- a/wagtail/contrib/wagtailfrontendcache/utils.py
+++ b/wagtail/contrib/wagtailfrontendcache/utils.py
@@ -75,15 +75,13 @@ def _get_page_cached_urls(page):
         return []
 
     return [
-        page_url + path[1:]
+        page_url + path.lstrip('/')
         for path in page.specific.get_cached_paths()
     ]
 
 
 def purge_page_from_cache(page, backend_settings=None, backends=None):
-    urls = _get_page_cached_urls(page)
-
-    purge_urls_from_cache(urls, backend_settings, backends)
+    purge_pages_from_cache([page], backend_settings=backend_settings, backends=backends)
 
 
 def purge_pages_from_cache(pages, backend_settings=None, backends=None):
@@ -91,7 +89,8 @@ def purge_pages_from_cache(pages, backend_settings=None, backends=None):
     for page in pages:
         urls.extend(_get_page_cached_urls(page))
 
-    purge_urls_from_cache(urls, backend_settings, backends)
+    if urls:
+        purge_urls_from_cache(urls, backend_settings, backends)
 
 
 class PurgeBatch(object):
@@ -135,5 +134,15 @@ class PurgeBatch(object):
             self.add_page(page)
 
     def purge(self, backend_settings=None, backends=None):
-        """Performs the purge of all the URLs in this batch"""
+        """
+        Performs the purge of all the URLs in this batch
+
+        This method takes two optional keyword arguments: backend_settings and backends
+
+        - backend_settings can be used to override the WAGTAILFRONTENDCACHE setting for
+          just this call
+
+        - backends can be set to a list of backend names. When set, the invalidation request
+          will only be sent to these backends
+        """
         purge_urls_from_cache(self.urls, backend_settings, backends)

--- a/wagtail/contrib/wagtailfrontendcache/utils.py
+++ b/wagtail/contrib/wagtailfrontendcache/utils.py
@@ -92,3 +92,48 @@ def purge_pages_from_cache(pages, backend_settings=None, backends=None):
         urls.extend(_get_page_cached_urls(page))
 
     purge_urls_from_cache(urls, backend_settings, backends)
+
+
+class PurgeBatch(object):
+    """Represents a list of URLs to be purged in a single request"""
+    def __init__(self, urls=None):
+        self.urls = []
+
+        if urls is not None:
+            self.add_urls(urls)
+
+    def add_url(self, url):
+        """Adds a single URL"""
+        self.urls.append(url)
+
+    def add_urls(self, urls):
+        """
+        Adds multiple URLs from an iterable
+
+        This is equivalent to running ``.add_url(url)`` on each URL
+        individually
+        """
+        self.urls.extend(urls)
+
+    def add_page(self, page):
+        """
+        Adds all URLs for the specified page
+
+        This combines the page's full URL with each path that is returned by
+        the page's `.get_cached_paths` method
+        """
+        self.add_urls(_get_page_cached_urls(page))
+
+    def add_pages(self, pages):
+        """
+        Adds multiple pages from a QuerySet or an iterable
+
+        This is equivalent to running ``.add_page(page)`` on each page
+        individually
+        """
+        for page in pages:
+            self.add_page(page)
+
+    def purge(self, backend_settings=None, backends=None):
+        """Performs the purge of all the URLs in this batch"""
+        purge_urls_from_cache(self.urls, backend_settings, backends)

--- a/wagtail/contrib/wagtailfrontendcache/utils.py
+++ b/wagtail/contrib/wagtailfrontendcache/utils.py
@@ -69,14 +69,26 @@ def purge_urls_from_cache(urls, backend_settings=None, backends=None):
         backend.purge_batch(urls)
 
 
-def purge_page_from_cache(page, backend_settings=None, backends=None):
+def _get_page_cached_urls(page):
     page_url = page.full_url
     if page_url is None:  # nothing to be done if the page has no routable URL
-        return
+        return []
 
-    # Purge cached paths from cache
-    urls = [
+    return [
         page_url + path[1:]
         for path in page.specific.get_cached_paths()
     ]
+
+
+def purge_page_from_cache(page, backend_settings=None, backends=None):
+    urls = _get_page_cached_urls(page)
+
+    purge_urls_from_cache(urls, backend_settings, backends)
+
+
+def purge_pages_from_cache(pages, backend_settings=None, backends=None):
+    urls = []
+    for page in pages:
+        urls.extend(_get_page_cached_urls(page))
+
     purge_urls_from_cache(urls, backend_settings, backends)

--- a/wagtail/contrib/wagtailfrontendcache/utils.py
+++ b/wagtail/contrib/wagtailfrontendcache/utils.py
@@ -56,9 +56,17 @@ def get_backends(backend_settings=None, backends=None):
 
 
 def purge_url_from_cache(url, backend_settings=None, backends=None):
-    for backend_name, backend in get_backends(backend_settings=backend_settings, backends=backends).items():
+    for backend_name, backend in get_backends(backend_settings, backends).items():
         logger.info("[%s] Purging URL: %s", backend_name, url)
         backend.purge(url)
+
+
+def purge_urls_from_cache(urls, backend_settings=None, backends=None):
+    for backend_name, backend in get_backends(backend_settings, backends).items():
+        for url in urls:
+            logger.info("[%s] Purging URL: %s", backend_name, url)
+
+        backend.purge_batch(urls)
 
 
 def purge_page_from_cache(page, backend_settings=None, backends=None):
@@ -66,8 +74,9 @@ def purge_page_from_cache(page, backend_settings=None, backends=None):
     if page_url is None:  # nothing to be done if the page has no routable URL
         return
 
-    for backend_name, backend in get_backends(backend_settings=backend_settings, backends=backends).items():
-        # Purge cached paths from cache
-        for path in page.specific.get_cached_paths():
-            logger.info("[%s] Purging URL: %s", backend_name, page_url + path[1:])
-            backend.purge(page_url + path[1:])
+    # Purge cached paths from cache
+    urls = [
+        page_url + path[1:]
+        for path in page.specific.get_cached_paths()
+    ]
+    purge_urls_from_cache(urls, backend_settings, backends)

--- a/wagtail/tests/testapp/models.py
+++ b/wagtail/tests/testapp/models.py
@@ -368,6 +368,11 @@ class EventIndex(Page):
             }
         ]
 
+    def get_cached_paths(self):
+        return super(EventIndex, self).get_cached_paths() + [
+            '/past/'
+        ]
+
 
 EventIndex.content_panels = [
     FieldPanel('title', classname="full title"),


### PR DESCRIPTION
This PR implements the first half of [RFC 20](https://github.com/wagtail/rfcs/issues/20). Allowing URLs to be invalidated from the frontend cache in batches rather than one at a time. This should give a performance boost for invalidating URLs in external services like CloudFront and CloudFlare as these support batch invalidation.

In its current form, only users who use ``purge_page_from_cache`` on pages that have a lot of cached URLs will see an automatic performance benefit and some users may be able to rewrite their invalidation logic using the new ``PurgeBatch`` class to improve performance as well. But as this logic is often dotted around in many signal handlers, it's still difficult to write something that'll invalidate everything that needs to be invalidated in a single batch.

The solution to that is to allow the invalidation API to be configured as asynchronous, which will allow Wagtail to automatically group requests into larger batches and submit them in the background. This will come in a future pull request.

Fixes #3750