### PR TITLE
Replaceable login form

### DIFF
--- a/docs/advanced_topics/settings.rst
+++ b/docs/advanced_topics/settings.rst
@@ -224,6 +224,13 @@ Dashboard
 This setting lets you change the number of items shown at 'Your most recent edits' on the dashboard.
 
 
+.. code-block:: python
+
+  WAGTAILADMIN_USER_LOGIN_FORM = 'users.forms.LoginForm'
+
+Allows the default ``LoginForm`` to be extended with extra fields.
+
+
 Images
 ------
 

--- a/wagtail/admin/forms.py
+++ b/wagtail/admin/forms.py
@@ -80,9 +80,11 @@ class LoginForm(AuthenticationForm):
         self.fields['username'].widget.attrs['placeholder'] = (
             ugettext_lazy("Enter your %s") % self.username_field.verbose_name)
 
-    @cached_property
+    @property
     def extra_fields(self):
-        return set(self.fields.keys()) - set(['username', 'password'])
+        for field_name, field in self.fields.items():
+            if field_name not in ['username', 'password']:
+                yield field_name, field
 
 
 class PasswordResetForm(PasswordResetForm):
@@ -128,20 +130,12 @@ class CopyForm(forms.Form):
         self.user = kwargs.pop('user', None)
         can_publish = kwargs.pop('can_publish')
 
-
-<< << << < HEAD
         super().__init__(*args, **kwargs)
         self.fields['new_title'] = forms.CharField(
             initial=self.page.title, label=_("New title"))
         self.fields['new_slug'] = forms.SlugField(
             initial=self.page.slug, label=_("New slug"))
-== == == =
-        super(CopyForm, self).__init__(*args, **kwargs)
-        self.fields['new_title'] = forms.CharField(
-            initial=self.page.title, label=_("New title"))
-        self.fields['new_slug'] = forms.SlugField(
-            initial=self.page.slug, label=_("New slug"))
->>>>>> > Update form to identify all the ``extra_fields``
+
         self.fields['new_parent_page'] = forms.ModelChoiceField(
             initial=self.page.get_parent(),
             queryset=Page.objects.all(),
@@ -340,12 +334,7 @@ class WagtailAdminPageForm(WagtailAdminModelForm):
         exclude = ['content_type', 'path', 'depth', 'numchild']
 
     def __init__(self, data=None, files=None, parent_page=None, *args, **kwargs):
-<<<<<<< HEAD
         super().__init__(data, files, *args, **kwargs)
-=======
-        super(WagtailAdminPageForm, self).__init__(
-            data, files, *args, **kwargs)
->>>>>>> Update form to identify all the ``extra_fields``
         self.parent_page = parent_page
 
     def clean(self):
@@ -479,12 +468,7 @@ class BaseGroupCollectionMemberPermissionFormSet(forms.BaseFormSet):
 
     @property
     def empty_form(self):
-<<<<<<< HEAD
         empty_form = super().empty_form
-=======
-        empty_form = super(
-            BaseGroupCollectionMemberPermissionFormSet, self).empty_form
->>>>>>> Update form to identify all the ``extra_fields``
         empty_form.fields['DELETE'].widget = forms.HiddenInput()
         return empty_form
 

--- a/wagtail/admin/forms.py
+++ b/wagtail/admin/forms.py
@@ -49,8 +49,7 @@ class SearchForm(forms.Form):
         super().__init__(*args, **kwargs)
         self.fields['q'].widget.attrs = {'placeholder': placeholder}
 
-    q = forms.CharField(label=ugettext_lazy(
-        "Search term"), widget=forms.TextInput())
+    q = forms.CharField(label=ugettext_lazy("Search term"), widget=forms.TextInput())
 
 
 class ExternalLinkChooserForm(forms.Form):
@@ -75,7 +74,7 @@ class LoginForm(AuthenticationForm):
     )
 
     def __init__(self, request=None, *args, **kwargs):
-        super(LoginForm, self).__init__(request=request, *args, **kwargs)
+        super().__init__(request=request, *args, **kwargs)
         self.fields['username'].widget.attrs['placeholder'] = (
             ugettext_lazy("Enter your %s") % self.username_field.verbose_name)
 
@@ -87,8 +86,7 @@ class LoginForm(AuthenticationForm):
 
 
 class PasswordResetForm(PasswordResetForm):
-    email = forms.EmailField(label=ugettext_lazy(
-        "Enter your email address to reset your password"), max_length=254)
+    email = forms.EmailField(label=ugettext_lazy("Enter your email address to reset your password"), max_length=254)
 
     def clean(self):
         cleaned_data = super().clean()
@@ -98,8 +96,7 @@ class PasswordResetForm(PasswordResetForm):
         email = cleaned_data.get('email')
         if not email:
             raise forms.ValidationError(_("Please fill your email address."))
-        active_users = UserModel._default_manager.filter(
-            email__iexact=email, is_active=True)
+        active_users = UserModel._default_manager.filter(email__iexact=email, is_active=True)
 
         if active_users.exists():
             # Check if all users of the email address are LDAP users (and give an error if they are)
@@ -116,8 +113,7 @@ class PasswordResetForm(PasswordResetForm):
                 )
         else:
             # No user accounts exist
-            raise forms.ValidationError(
-                _("This email address is not recognised."))
+            raise forms.ValidationError(_("This email address is not recognised."))
 
         return cleaned_data
 
@@ -128,18 +124,13 @@ class CopyForm(forms.Form):
         self.page = kwargs.pop('page')
         self.user = kwargs.pop('user', None)
         can_publish = kwargs.pop('can_publish')
-
         super().__init__(*args, **kwargs)
-        self.fields['new_title'] = forms.CharField(
-            initial=self.page.title, label=_("New title"))
-        self.fields['new_slug'] = forms.SlugField(
-            initial=self.page.slug, label=_("New slug"))
-
+        self.fields['new_title'] = forms.CharField(initial=self.page.title, label=_("New title"))
+        self.fields['new_slug'] = forms.SlugField(initial=self.page.slug, label=_("New slug"))
         self.fields['new_parent_page'] = forms.ModelChoiceField(
             initial=self.page.get_parent(),
             queryset=Page.objects.all(),
-            widget=widgets.AdminPageChooser(
-                can_choose_root=True, user_perms='copy_to'),
+            widget=widgets.AdminPageChooser(can_choose_root=True, user_perms='copy_to'),
             label=_("New parent page"),
             help_text=_("This copy will be a child of this given parent page.")
         )
@@ -159,8 +150,7 @@ class CopyForm(forms.Form):
                 # In the specific case that there are no subpages, customise the field label and help text
                 if subpage_count == 0:
                     label = _("Publish copied page")
-                    help_text = _(
-                        "This page is live. Would you like to publish its copy as well?")
+                    help_text = _("This page is live. Would you like to publish its copy as well?")
                 else:
                     label = _("Publish copies")
                     help_text = ungettext(
@@ -179,14 +169,12 @@ class CopyForm(forms.Form):
         slug = cleaned_data.get('new_slug')
 
         # New parent page given in form or parent of source, if parent_page is empty
-        parent_page = cleaned_data.get(
-            'new_parent_page') or self.page.get_parent()
+        parent_page = cleaned_data.get('new_parent_page') or self.page.get_parent()
 
         # check if user is allowed to create a page at given location.
         if not parent_page.permissions_for_user(self.user).can_add_subpage():
             self._errors['new_parent_page'] = self.error_class([
-                _("You do not have permission to copy to page \"%(page_title)s\"") % {
-                    'page_title': parent_page.get_admin_display_title()}
+                _("You do not have permission to copy to page \"%(page_title)s\"") % {'page_title': parent_page.get_admin_display_title()}
             ])
 
         # Count the pages with the same slug within the context of our copy's parent page
@@ -220,15 +208,13 @@ class BaseViewRestrictionForm(forms.ModelForm):
     def clean_password(self):
         password = self.cleaned_data.get('password')
         if self.cleaned_data.get('restriction_type') == BaseViewRestriction.PASSWORD and not password:
-            raise forms.ValidationError(
-                _("This field is required."), code='invalid')
+            raise forms.ValidationError(_("This field is required."), code='invalid')
         return password
 
     def clean_groups(self):
         groups = self.cleaned_data.get('groups')
         if self.cleaned_data.get('restriction_type') == BaseViewRestriction.GROUPS and not groups:
-            raise forms.ValidationError(
-                _("Please select at least one group."), code='invalid')
+            raise forms.ValidationError(_("Please select at least one group."), code='invalid')
         return groups
 
     class Meta:
@@ -306,8 +292,7 @@ class WagtailAdminModelFormMetaclass(ClusterFormMetaclass):
         if 'formfield_callback' not in attrs or attrs['formfield_callback'] is None:
             attrs['formfield_callback'] = formfield_for_dbfield
 
-        new_class = super(WagtailAdminModelFormMetaclass,
-                          cls).__new__(cls, name, bases, attrs)
+        new_class = super(WagtailAdminModelFormMetaclass, cls).__new__(cls, name, bases, attrs)
         return new_class
 
 
@@ -343,8 +328,7 @@ class WagtailAdminPageForm(WagtailAdminModelForm):
             if not Page._slug_is_available(
                 cleaned_data['slug'], self.parent_page, self.instance
             ):
-                self.add_error('slug', forms.ValidationError(
-                    _("This slug is already in use")))
+                self.add_error('slug', forms.ValidationError(_("This slug is already in use")))
 
         # Check scheduled publishing fields
         go_live_at = cleaned_data.get('go_live_at')
@@ -359,8 +343,7 @@ class WagtailAdminPageForm(WagtailAdminModelForm):
 
         # Expire at must be in the future
         if expire_at and expire_at < timezone.now():
-            self.add_error('expire_at', forms.ValidationError(
-                _('Expiry date/time must be in the future')))
+            self.add_error('expire_at', forms.ValidationError(_('Expiry date/time must be in the future')))
 
         # Don't allow an existing first_published_at to be unset by clearing the field
         if 'first_published_at' in cleaned_data and not cleaned_data['first_published_at']:
@@ -385,7 +368,6 @@ class BaseCollectionMemberForm(forms.ModelForm):
 
     Subclasses must define a 'permission_policy' attribute.
     """
-
     def __init__(self, *args, **kwargs):
         user = kwargs.pop('user', None)
 
@@ -395,22 +377,19 @@ class BaseCollectionMemberForm(forms.ModelForm):
             self.collections = Collection.objects.all()
         else:
             self.collections = (
-                self.permission_policy.collections_user_has_permission_for(
-                    user, 'add')
+                self.permission_policy.collections_user_has_permission_for(user, 'add')
             )
 
         if self.instance.pk:
             # editing an existing document; ensure that the list of available collections
             # includes its current collection
             self.collections = (
-                self.collections | Collection.objects.filter(
-                    id=self.instance.collection_id)
+                self.collections | Collection.objects.filter(id=self.instance.collection_id)
             )
 
         if len(self.collections) == 0:
             raise Exception(
-                "Cannot construct %s for a user with no collection permissions" % type(
-                    self)
+                "Cannot construct %s for a user with no collection permissions" % type(self)
             )
         elif len(self.collections) == 1:
             # don't show collection field if only one collection is available
@@ -436,7 +415,6 @@ class BaseGroupCollectionMemberPermissionFormSet(forms.BaseFormSet):
     default_prefix - prefix to use on form fields if one is not specified in __init__
     template = template filename
     """
-
     def __init__(self, data=None, files=None, instance=None, prefix=None):
         if prefix is None:
             prefix = self.default_prefix
@@ -507,8 +485,7 @@ class BaseGroupCollectionMemberPermissionFormSet(forms.BaseFormSet):
         final_permission_records = set()
         for form in forms_to_save:
             for permission in form.cleaned_data['permissions']:
-                final_permission_records.add(
-                    (form.cleaned_data['collection'], permission))
+                final_permission_records.add((form.cleaned_data['collection'], permission))
 
         # fetch the group's existing collection permission records for this model,
         # and from that, build a list of records to be created / deleted
@@ -523,8 +500,7 @@ class BaseGroupCollectionMemberPermissionFormSet(forms.BaseFormSet):
             else:
                 permission_ids_to_delete.append(cp.id)
 
-        self.instance.collection_permissions.filter(
-            id__in=permission_ids_to_delete).delete()
+        self.instance.collection_permissions.filter(id__in=permission_ids_to_delete).delete()
 
         permissions_to_add = final_permission_records - permission_records_to_keep
         GroupCollectionPermission.objects.bulk_create([
@@ -547,8 +523,7 @@ def collection_member_permission_formset_factory(
 
     permission_queryset = Permission.objects.filter(
         content_type__app_label=model._meta.app_label,
-        codename__in=[codename for codename,
-                      short_label, long_label in permission_types]
+        codename__in=[codename for codename, short_label, long_label in permission_types]
     ).select_related('content_type')
 
     if default_prefix is None:

--- a/wagtail/admin/forms.py
+++ b/wagtail/admin/forms.py
@@ -10,7 +10,6 @@ from django.db import models, transaction
 from django.forms.widgets import TextInput
 from django.template.loader import render_to_string
 from django.utils import timezone
-from django.utils.functional import cached_property
 from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_lazy, ungettext
 from modelcluster.forms import ClusterForm, ClusterFormMetaclass

--- a/wagtail/admin/forms.py
+++ b/wagtail/admin/forms.py
@@ -66,12 +66,11 @@ class LoginForm(AuthenticationForm):
     username = forms.CharField(
         max_length=254, widget=forms.TextInput(attrs={'tabindex': '1'}))
 
-    password = forms.CharField(widget=forms.PasswordInput(
-        attrs={
+    password = forms.CharField(
+        widget=forms.PasswordInput(attrs={
             'tabindex': '2',
             'placeholder': ugettext_lazy("Enter password"),
-        })
-    )
+        }))
 
     def __init__(self, request=None, *args, **kwargs):
         super().__init__(request=request, *args, **kwargs)

--- a/wagtail/admin/templates/wagtailadmin/login.html
+++ b/wagtail/admin/templates/wagtailadmin/login.html
@@ -57,18 +57,16 @@
                     {% endif %}
                 </li>
 
-                {% for field in form %}
-                {% if field.name in form.extra_fields %}
-                <li>
-                    <div class="field">
-                        {% if field.label %}
-                        {{ field.label_tag }}
-                        {% endif %}
-                        <div class="input">{{ field }}</div>
+                {% block extra_fields %}
+                {% for field_name, field in form.extra_fields %}
+                <li class="full">
+                    {{ field.label_tag }}
+                    <div class="field iconfield">
+                        {{ field }}
                     </div>
                 </li>
-                {% endif %}
                 {% endfor %}
+                {% endblock extra_fields %}
 
                 {% comment %}
                     Removed until functionality exists

--- a/wagtail/admin/templates/wagtailadmin/login.html
+++ b/wagtail/admin/templates/wagtailadmin/login.html
@@ -56,6 +56,20 @@
                         <p class="help"><a href="{% url 'wagtailadmin_password_reset' %}">{% trans "Forgotten it?" %}</a></p>
                     {% endif %}
                 </li>
+
+                {% for field in form %}
+                {% if field.name in form.extra_fields %}
+                <li>
+                    <div class="field">
+                        {% if field.label %}
+                        {{ field.label_tag }}
+                        {% endif %}
+                        <div class="input">{{ field }}</div>
+                    </div>
+                </li>
+                {% endif %}
+                {% endfor %}
+
                 {% comment %}
                     Removed until functionality exists
                     <li class="checkbox">

--- a/wagtail/admin/tests/test_forms.py
+++ b/wagtail/admin/tests/test_forms.py
@@ -1,0 +1,18 @@
+from django.forms.fields import CharField
+from django.test import TestCase
+
+from wagtail.admin.forms import LoginForm
+
+
+class CustomLoginForm(LoginForm):
+    captcha = CharField(
+        label='Captcha', help_text="should be in extra_fields()")
+
+
+class TestLoginForm(TestCase):
+
+    def test_extra_fields(self):
+        form = CustomLoginForm()
+        self.assertEqual(list(form.extra_fields), [
+            ('captcha', form.fields['captcha'])
+        ])

--- a/wagtail/admin/views/account.py
+++ b/wagtail/admin/views/account.py
@@ -44,8 +44,7 @@ def password_reset_enabled():
 
 def account(request):
     user_perms = UserPagePermissionsProxy(request.user)
-    show_notification_preferences = user_perms.can_edit_pages(
-    ) or user_perms.can_publish_pages()
+    show_notification_preferences = user_perms.can_edit_pages() or user_perms.can_publish_pages()
 
     return render(request, 'wagtailadmin/account/account.html', {
         'show_change_password': password_management_enabled() and request.user.has_usable_password(),
@@ -68,8 +67,7 @@ def change_password(request):
                 form.save()
                 update_session_auth_hash(request, form.user)
 
-                messages.success(request, _(
-                    "Your password has been changed successfully!"))
+                messages.success(request, _("Your password has been changed successfully!"))
                 return redirect('wagtailadmin_account')
         else:
             form = PasswordChangeForm(request.user)
@@ -93,24 +91,20 @@ def _wrap_password_reset_view(view_func):
 
 password_reset = _wrap_password_reset_view(auth_views.password_reset)
 password_reset_done = _wrap_password_reset_view(auth_views.password_reset_done)
-password_reset_confirm = _wrap_password_reset_view(
-    auth_views.password_reset_confirm)
-password_reset_complete = _wrap_password_reset_view(
-    auth_views.password_reset_complete)
+password_reset_confirm = _wrap_password_reset_view(auth_views.password_reset_confirm)
+password_reset_complete = _wrap_password_reset_view(auth_views.password_reset_complete)
 
 
 def notification_preferences(request):
     if request.method == 'POST':
-        form = NotificationPreferencesForm(
-            request.POST, instance=UserProfile.get_for_user(request.user))
+        form = NotificationPreferencesForm(request.POST, instance=UserProfile.get_for_user(request.user))
 
         if form.is_valid():
             form.save()
             messages.success(request, _("Your preferences have been updated."))
             return redirect('wagtailadmin_account')
     else:
-        form = NotificationPreferencesForm(
-            instance=UserProfile.get_for_user(request.user))
+        form = NotificationPreferencesForm(instance=UserProfile.get_for_user(request.user))
 
     # quick-and-dirty catch-all in case the form has been rendered with no
     # fields, as the user has no customisable permissions
@@ -124,8 +118,7 @@ def notification_preferences(request):
 
 def language_preferences(request):
     if request.method == 'POST':
-        form = PreferredLanguageForm(
-            request.POST, instance=UserProfile.get_for_user(request.user))
+        form = PreferredLanguageForm(request.POST, instance=UserProfile.get_for_user(request.user))
 
         if form.is_valid():
             user_profile = form.save()
@@ -135,8 +128,7 @@ def language_preferences(request):
             messages.success(request, _("Your preferences have been updated."))
             return redirect('wagtailadmin_account')
     else:
-        form = PreferredLanguageForm(
-            instance=UserProfile.get_for_user(request.user))
+        form = PreferredLanguageForm(instance=UserProfile.get_for_user(request.user))
 
     return render(request, 'wagtailadmin/account/language_preferences.html', {
         'form': form,

--- a/wagtail/admin/views/account.py
+++ b/wagtail/admin/views/account.py
@@ -5,10 +5,8 @@ from django.contrib import messages
 from django.contrib.auth import views as auth_views
 from django.contrib.auth import update_session_auth_hash
 from django.contrib.auth.forms import PasswordChangeForm
-from django.core.exceptions import ImproperlyConfigured
 from django.http import Http404
 from django.shortcuts import redirect, render
-from django.utils.module_loading import import_string
 from django.utils.translation import ugettext as _
 from django.utils.translation import activate
 from django.views.decorators.cache import never_cache
@@ -19,17 +17,7 @@ from wagtail.admin.utils import get_available_admin_languages
 from wagtail.core.models import UserPagePermissionsProxy
 from wagtail.users.forms import NotificationPreferencesForm, PreferredLanguageForm
 from wagtail.users.models import UserProfile
-
-
-# Helper functions to allow customisation of the user login form
-def get_custom_form(form_setting):
-    try:
-        return import_string(getattr(settings, form_setting))
-    except ImportError:
-        raise ImproperlyConfigured(
-            "%s refers to a form '%s' that is not available" %
-            (form_setting, getattr(settings, form_setting))
-        )
+from wagtail.utils.loading import get_custom_form
 
 
 def get_user_login_form():
@@ -56,7 +44,8 @@ def password_reset_enabled():
 
 def account(request):
     user_perms = UserPagePermissionsProxy(request.user)
-    show_notification_preferences = user_perms.can_edit_pages() or user_perms.can_publish_pages()
+    show_notification_preferences = user_perms.can_edit_pages(
+    ) or user_perms.can_publish_pages()
 
     return render(request, 'wagtailadmin/account/account.html', {
         'show_change_password': password_management_enabled() and request.user.has_usable_password(),
@@ -79,7 +68,8 @@ def change_password(request):
                 form.save()
                 update_session_auth_hash(request, form.user)
 
-                messages.success(request, _("Your password has been changed successfully!"))
+                messages.success(request, _(
+                    "Your password has been changed successfully!"))
                 return redirect('wagtailadmin_account')
         else:
             form = PasswordChangeForm(request.user)
@@ -103,20 +93,24 @@ def _wrap_password_reset_view(view_func):
 
 password_reset = _wrap_password_reset_view(auth_views.password_reset)
 password_reset_done = _wrap_password_reset_view(auth_views.password_reset_done)
-password_reset_confirm = _wrap_password_reset_view(auth_views.password_reset_confirm)
-password_reset_complete = _wrap_password_reset_view(auth_views.password_reset_complete)
+password_reset_confirm = _wrap_password_reset_view(
+    auth_views.password_reset_confirm)
+password_reset_complete = _wrap_password_reset_view(
+    auth_views.password_reset_complete)
 
 
 def notification_preferences(request):
     if request.method == 'POST':
-        form = NotificationPreferencesForm(request.POST, instance=UserProfile.get_for_user(request.user))
+        form = NotificationPreferencesForm(
+            request.POST, instance=UserProfile.get_for_user(request.user))
 
         if form.is_valid():
             form.save()
             messages.success(request, _("Your preferences have been updated."))
             return redirect('wagtailadmin_account')
     else:
-        form = NotificationPreferencesForm(instance=UserProfile.get_for_user(request.user))
+        form = NotificationPreferencesForm(
+            instance=UserProfile.get_for_user(request.user))
 
     # quick-and-dirty catch-all in case the form has been rendered with no
     # fields, as the user has no customisable permissions
@@ -130,7 +124,8 @@ def notification_preferences(request):
 
 def language_preferences(request):
     if request.method == 'POST':
-        form = PreferredLanguageForm(request.POST, instance=UserProfile.get_for_user(request.user))
+        form = PreferredLanguageForm(
+            request.POST, instance=UserProfile.get_for_user(request.user))
 
         if form.is_valid():
             user_profile = form.save()
@@ -140,7 +135,8 @@ def language_preferences(request):
             messages.success(request, _("Your preferences have been updated."))
             return redirect('wagtailadmin_account')
     else:
-        form = PreferredLanguageForm(instance=UserProfile.get_for_user(request.user))
+        form = PreferredLanguageForm(
+            instance=UserProfile.get_for_user(request.user))
 
     return render(request, 'wagtailadmin/account/language_preferences.html', {
         'form': form,

--- a/wagtail/users/views/users.py
+++ b/wagtail/users/views/users.py
@@ -8,6 +8,7 @@ from django.utils.module_loading import import_string
 from django.utils.translation import ugettext as _
 from django.views.decorators.vary import vary_on_headers
 
+from wagtail.utils.loading import get_custom_form
 from wagtail.utils.pagination import paginate
 from wagtail.admin import messages
 from wagtail.admin.forms import SearchForm
@@ -28,20 +29,10 @@ change_user_perm = "{0}.change_{1}".format(AUTH_USER_APP_LABEL, AUTH_USER_MODEL_
 delete_user_perm = "{0}.delete_{1}".format(AUTH_USER_APP_LABEL, AUTH_USER_MODEL_NAME.lower())
 
 
-def get_custom_user_form(form_setting):
-    try:
-        return import_string(getattr(settings, form_setting))
-    except ImportError:
-        raise ImproperlyConfigured(
-            "%s refers to a form '%s' that is not available" %
-            (form_setting, getattr(settings, form_setting))
-        )
-
-
 def get_user_creation_form():
     form_setting = 'WAGTAIL_USER_CREATION_FORM'
     if hasattr(settings, form_setting):
-        return get_custom_user_form(form_setting)
+        return get_custom_form(form_setting)
     else:
         return UserCreationForm
 
@@ -49,7 +40,7 @@ def get_user_creation_form():
 def get_user_edit_form():
     form_setting = 'WAGTAIL_USER_EDIT_FORM'
     if hasattr(settings, form_setting):
-        return get_custom_user_form(form_setting)
+        return get_custom_form(form_setting)
     else:
         return UserEditForm
 

--- a/wagtail/users/views/users.py
+++ b/wagtail/users/views/users.py
@@ -1,10 +1,8 @@
 from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.core.exceptions import ImproperlyConfigured
 from django.db.models import Q
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
-from django.utils.module_loading import import_string
 from django.utils.translation import ugettext as _
 from django.views.decorators.vary import vary_on_headers
 

--- a/wagtail/utils/loading.py
+++ b/wagtail/utils/loading.py
@@ -1,0 +1,14 @@
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+from django.utils.module_loading import import_string
+
+
+def get_custom_form(form_setting):
+    """Return custom form class if defined and available"""
+    try:
+        return import_string(getattr(settings, form_setting))
+    except ImportError:
+        raise ImproperlyConfigured(
+            "%s refers to a form '%s' that is not available" %
+            (form_setting, getattr(settings, form_setting))
+        )

--- a/wagtail/utils/loading.py
+++ b/wagtail/utils/loading.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.module_loading import import_string

--- a/wagtail/utils/loading.py
+++ b/wagtail/utils/loading.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.module_loading import import_string


### PR DESCRIPTION
Allow developers to extend the ``LoginForm`` with their own functionality.  This is useful when implementing for example: rate limiting, captcha or 2fa.

The login template is adjusted as well to have some kind of default implementation when adding more fields to the login form.