### PR TITLE
Make it possible to run migrations backwards

### DIFF
--- a/wagtail/wagtailcore/migrations/0040_page_draft_title.py
+++ b/wagtail/wagtailcore/migrations/0040_page_draft_title.py
@@ -25,5 +25,5 @@ class Migration(migrations.Migration):
             field=models.CharField(default='', editable=False, max_length=255),
             preserve_default=False,
         ),
-        migrations.RunPython(draft_title),
+        migrations.RunPython(draft_title, migrations.RunPython.noop),
     ]


### PR DESCRIPTION
This will allow to run migrations backwards instead of raising
```
django.db.migrations.exceptions.IrreversibleError: Operation <RunPython <function draft_title at 0x7f602143dc80>> in wagtailcore.0040_page_draft_title is not reversible
```