### PR TITLE
Don't call `static()` when constructing HalloPlugins

### DIFF
--- a/docs/advanced_topics/customisation/page_editing_interface.rst
+++ b/docs/advanced_topics/customisation/page_editing_interface.rst
@@ -105,7 +105,7 @@ Once the plugin has been created, it should be registered as a rich text feature
             'hallo', 'blockquote',
             HalloPlugin(
                 name='halloblockquote',
-                js=[static('myapp/js/hallo-blockquote.js')],
+                js=['myapp/js/hallo-blockquote.js'],
             )
         )
 

--- a/wagtail/tests/testapp/wagtail_hooks.py
+++ b/wagtail/tests/testapp/wagtail_hooks.py
@@ -99,7 +99,7 @@ def register_blockquote_feature(features):
     features.register_editor_plugin(
         'hallo', 'blockquote', HalloPlugin(
             name='halloblockquote',
-            js=[static('testapp/js/hallo-blockquote.js')],
-            css={'all': [static('testapp/css/hallo-blockquote.css')]},
+            js=['testapp/js/hallo-blockquote.js'],
+            css={'all': ['testapp/css/hallo-blockquote.css']},
         )
     )

--- a/wagtail/wagtailadmin/rich_text.py
+++ b/wagtail/wagtailadmin/rich_text.py
@@ -4,7 +4,6 @@ import json
 from collections import OrderedDict
 
 from django.conf import settings
-from django.contrib.staticfiles.templatetags.staticfiles import static
 from django.forms import Media, widgets
 from django.utils.module_loading import import_string
 
@@ -74,7 +73,7 @@ class HalloListPlugin(HalloPlugin):
 CORE_HALLO_PLUGINS = [
     HalloPlugin(name='halloreundo', order=50),
     HalloPlugin(name='hallorequireparagraphs', js=[
-        static('wagtailadmin/js/hallo-plugins/hallo-requireparagraphs.js'),
+        'wagtailadmin/js/hallo-plugins/hallo-requireparagraphs.js',
     ]),
     HalloHeadingPlugin(element='p')
 ]
@@ -143,8 +142,8 @@ class HalloRichTextArea(WidgetWithScript, widgets.Textarea):
     @property
     def media(self):
         media = Media(js=[
-            static('wagtailadmin/js/vendor/hallo.js'),
-            static('wagtailadmin/js/hallo-bootstrap.js'),
+            'wagtailadmin/js/vendor/hallo.js',
+            'wagtailadmin/js/hallo-bootstrap.js',
         ])
 
         for plugin in self.plugins:

--- a/wagtail/wagtailadmin/wagtail_hooks.py
+++ b/wagtail/wagtailadmin/wagtail_hooks.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
 from django.contrib.auth.models import Permission
-from django.contrib.staticfiles.templatetags.staticfiles import static
 from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext_lazy as _
 
@@ -189,7 +188,7 @@ def register_core_features(features):
         'hallo', 'hr',
         HalloPlugin(
             name='hallohr',
-            js=[static('wagtailadmin/js/hallo-plugins/hallo-hr.js')],
+            js=['wagtailadmin/js/hallo-plugins/hallo-hr.js'],
             order=45,
         )
     )
@@ -199,7 +198,7 @@ def register_core_features(features):
         'hallo', 'link',
         HalloPlugin(
             name='hallowagtaillink',
-            js=[static('wagtailadmin/js/hallo-plugins/hallo-wagtaillink.js')],
+            js=['wagtailadmin/js/hallo-plugins/hallo-wagtaillink.js'],
         )
     )
     features.default_features.append('link')

--- a/wagtail/wagtaildocs/wagtail_hooks.py
+++ b/wagtail/wagtaildocs/wagtail_hooks.py
@@ -80,7 +80,7 @@ def register_embed_feature(features):
         'hallo', 'document-link',
         HalloPlugin(
             name='hallowagtaildoclink',
-            js=[static('wagtaildocs/js/hallo-plugins/hallo-wagtaildoclink.js')],
+            js=['wagtaildocs/js/hallo-plugins/hallo-wagtaildoclink.js'],
         )
     )
     features.default_features.append('document-link')

--- a/wagtail/wagtailembeds/wagtail_hooks.py
+++ b/wagtail/wagtailembeds/wagtail_hooks.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
 from django.conf.urls import include, url
-from django.contrib.staticfiles.templatetags.staticfiles import static
 from django.core import urlresolvers
 from django.utils.html import format_html
 
@@ -37,7 +36,7 @@ def register_embed_feature(features):
         'hallo', 'embed',
         HalloPlugin(
             name='hallowagtailembeds',
-            js=[static('wagtailembeds/js/hallo-plugins/hallo-wagtailembeds.js')],
+            js=['wagtailembeds/js/hallo-plugins/hallo-wagtailembeds.js'],
         )
     )
     features.default_features.append('embed')

--- a/wagtail/wagtailimages/wagtail_hooks.py
+++ b/wagtail/wagtailimages/wagtail_hooks.py
@@ -72,7 +72,7 @@ def register_image_feature(features):
         'hallo', 'image',
         HalloPlugin(
             name='hallowagtailimage',
-            js=[static('wagtailimages/js/hallo-plugins/hallo-wagtailimage.js')],
+            js=['wagtailimages/js/hallo-plugins/hallo-wagtailimage.js'],
         )
     )
     features.default_features.append('image')


### PR DESCRIPTION
This isn't necessary, since Django form media fills in static paths itself - and doing it at module level will break on startup with certain staticfiles configurations if collectstatic hasn't run yet. Fixes #3829
