### PR TITLE
#3838 - Fixes document chooser messages

### DIFF
--- a/wagtail/wagtaildocs/templates/wagtaildocs/chooser/results.html
+++ b/wagtail/wagtaildocs/templates/wagtaildocs/chooser/results.html
@@ -16,5 +16,10 @@
 
     {% include "wagtailadmin/shared/pagination_nav.html" with items=documents is_ajax=1 %}
 {% else %}
-    <p>{% blocktrans %}Sorry, no documents match "<em>{{ query_string }}</em>"{% endblocktrans %}</p>
+    {% if saved_documents %}
+        <p>{% blocktrans %}Sorry, no documents match "<em>{{ query_string }}</em>"{% endblocktrans %}</p>
+    {% else %}
+        {% url 'wagtaildocs:add_multiple' as wagtaildocs_add_document_url %}
+        <p>{% blocktrans %}You haven't uploaded any documents. Why not <a href="{{ wagtaildocs_add_document_url }}">upload one now</a>?{% endblocktrans %}</p>
+    {% endif %}
 {% endif %}

--- a/wagtail/wagtaildocs/views/chooser.py
+++ b/wagtail/wagtaildocs/views/chooser.py
@@ -49,6 +49,7 @@ def chooser(request):
         documents = hook(documents, request)
 
     q = None
+    saved_documents = Document.objects.all()
     if 'q' in request.GET or 'p' in request.GET or 'collection_id' in request.GET:
 
         collection_id = request.GET.get('collection_id')
@@ -72,6 +73,7 @@ def chooser(request):
             'documents': documents,
             'query_string': q,
             'is_searching': is_searching,
+            'saved_documents': saved_documents,
         })
     else:
         searchform = SearchForm()


### PR DESCRIPTION
It think this solves #3838 

If the description below is too confusing I can try to edit it.

My first approach was adding an "if condition" to the "else" in order to show the "Sorry, no documents match" message only if the user made a search, although this message would still show up if the user made a search and there were no documents uploaded in his account.
```
{% load i18n %}
{% if documents %}
    {% if is_searching %}
        <h2>
        {% blocktrans count counter=documents.paginator.count %}
            There is one match
        {% plural %}
            There are {{ counter }} matches
        {% endblocktrans %}
        </h2>
    {% else %}
        <h2>{% trans "Latest documents" %}</h2>
    {% endif %}

    {% include "wagtaildocs/documents/list.html" with choosing=1 %}

    {% include "wagtailadmin/shared/pagination_nav.html" with items=documents is_ajax=1 %}
{% else %}
    {% if is_searching %}
        <p>{% blocktrans %}Sorry, no documents match "<em>{{ query_string }}</em>"{% endblocktrans %}</p>
    {% else %}
        {% url 'wagtaildocs:add_multiple' as wagtaildocs_add_document_url %}
        <p>{% blocktrans %}You haven't uploaded any documents. Why not <a href="{{ wagtaildocs_add_document_url }}">upload one now</a>?{% endblocktrans %}</p>
    {% endif %}
{% endif %}
```

In the chooser.py file I have noticed that when a user searched for a document in the chooser panel it changed filtered the "document" variable for that querry so even if the user had some documents uploaded to his account you woudnt be able to use the "document" variable in the template file to differentiate the scenario where the user has documents, but none of these documents match with his search to the scenario where the user has no documents.So in the chooser.py file I have created a new variable called "saved_document" which as the "document" variable contains the uploaded documents by the user, but it is not filtered when the user makes a search.I have used the "saved_document" variable to differentiate between the two scenarios listed above in the results.html file.