### PR TITLE
Fix rendering of wagtailsettings save button (#3836)

### DIFF
--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/core.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/core.scss
@@ -138,12 +138,8 @@ footer {
     }
 
     .actions {
+        width: 250px;
         margin-right: $grid-gutter-width / 2;
-        width: auto;
-
-        .dropdown {
-            width: 250px;
-        }
     }
 
     .meta {
@@ -168,12 +164,9 @@ footer {
     }
 
     @media screen and (max-width: $breakpoint-mobile) {
-        .actions {
+        .actions,
+        .preview {
             width: 100%;
-
-            .dropdown {
-                width: 100%;
-            }
         }
 
         .meta p {

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/core.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/core.scss
@@ -142,6 +142,10 @@ footer {
         margin-right: $grid-gutter-width / 2;
     }
 
+    .preview .dropdown {
+        width: 250px;
+    }
+
     .meta {
         float: right;
         text-align: right;
@@ -165,7 +169,8 @@ footer {
 
     @media screen and (max-width: $breakpoint-mobile) {
         .actions,
-        .preview {
+        .preview,
+        .preview .dropdown {
             width: 100%;
         }
 

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/create.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/create.html
@@ -41,7 +41,7 @@
                     </div>
                 </li>
 
-                <li class="actions preview">
+                <li class="preview">
                     {% trans 'Preview' as preview_label %}
                     {% if preview_modes|length > 1 %}
                         <div class="dropdown dropup dropdown-button match-width">

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/edit.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/edit.html
@@ -64,7 +64,7 @@
                     </div>
                 </li>
 
-                <li class="actions preview">
+                <li class="preview">
                     {% trans 'Preview' as preview_label %}
                     {% if preview_modes|length > 1 %}
                         <div class="dropdown dropup dropdown-button match-width">


### PR DESCRIPTION
Fixes #3836, effectively as a third attempt at fixing #3718...

* #3719 removed the `action` class from the preview button so that it wouldn't be given a 250px container, but this broke the dropdown version of the preview button (#3784) which _should_ be forced to 250px wide
* #3785 reinstated the `action` class, but moved the `width: 250px` rule so that it only applied to dropdowns; this broke the wagtailsettings save button (#3836), which isn't a dropdown but should be 250px
* this version reverts to the original fix from #3719, but adds a special case for `.preview .dropdown` to force it back to 250px.