### PR TITLE
Added a flag in dummy_request() to inform middleware that the request is a dummy

### DIFF
--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -1273,6 +1273,9 @@ class Page(six.with_metaclass(PageBase, AbstractPage, index.Indexed, Clusterable
 
         request = WSGIRequest(dummy_values)
 
+        # Add a flag to let middleware know that this is a dummy request.
+        request.is_dummy = True
+
         # Apply middleware to the request
         # Note that Django makes sure only one of the middleware settings are
         # used in a project


### PR DESCRIPTION
This is useful for middleware that perform destructive changes in
process_response(). They rightfully expect process_response() to only get called
once per thread, but it happens twice during a Page preview when running under
Django 1.10's middleware system. This flag lets the middleware know that they
should potentially skip their destructive operations.