### PR TITLE
Fix routablepageurl to work with WAGTAIL_APPEND_SLASH = False

### DIFF
--- a/wagtail/contrib/wagtailroutablepage/templatetags/wagtailroutablepage_tags.py
+++ b/wagtail/contrib/wagtailroutablepage/templatetags/wagtailroutablepage_tags.py
@@ -22,4 +22,6 @@ def routablepageurl(context, page, url_name, *args, **kwargs):
     request = context['request']
     base_url = page.relative_url(request.site)
     routed_url = page.reverse_subpage(url_name, args=args, kwargs=kwargs)
+    if not base_url.endswith('/'):
+        base_url += '/'
     return base_url + routed_url

--- a/wagtail/contrib/wagtailroutablepage/tests.py
+++ b/wagtail/contrib/wagtailroutablepage/tests.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
+import mock
 from django.core.urlresolvers import NoReverseMatch
 from django.test import RequestFactory, TestCase
 
@@ -185,3 +186,11 @@ class TestRoutablePageTemplateTag(TestCase):
                               'external_view', 'joe-bloggs')
 
         self.assertEqual(url, self.routable_page.url + 'external/joe-bloggs/')
+
+    def test_templatetag_reverse_external_view_without_append_slash(self):
+        with mock.patch('wagtail.wagtailcore.models.WAGTAIL_APPEND_SLASH', False):
+            url = routablepageurl(self.context, self.routable_page,
+                                  'external_view', 'joe-bloggs')
+            expected = self.routable_page.url + '/' + 'external/joe-bloggs/'
+
+        self.assertEqual(url, expected)


### PR DESCRIPTION
Currently if you have set `WAGTAIL_APPEND_SLASH = False` in your settings `{% routablepageurl %}` will not generate correct urls. Instead of `/routable-slug/child-slug/` it generates `/routable-slugchild-slug/`

~~Probably is a good idea to add some tests for that but I need some assistance. I didn't found any tests for `routablepageurl`. Probably I'm missing something.~~

I added a test but I need feedback if the approach that I'm taking is ok.