### PR TITLE
Class based views for Form builder admin views

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -7,6 +7,7 @@ Changelog
  * Custom document model is now documented (Emily Horsman)
  * Use minified versions of CSS in the admin by adding minification to the front-end tooling (Vincent Audebert, Thibaud Colas)
  * Wagtailforms serve view now passes `request.FILES`, for use in custom form handlers (LB (Ben Johnston))
+ * Wagtailforms admin views are now class based to allow proper extending and overrides (Johan Arensman)
  * Fix: "Open Link in New Tab" on a right arrow in page explorer should open page list (Emily Horsman)
  * Fix: Using `order_by_relevance=False` when searching with PostgreSQL now works (Mitchel Cabuloy)
  * Fix: Inline panel first and last sorting arrows correctly hidden in non-default tabs (Matt Westcott)

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -253,6 +253,7 @@ Contributors
 * jcronyn
 * Ben Sturmfels
 * Anselm Bradford
+* Johan Arensman
 
 Translators
 ===========

--- a/wagtail/wagtailforms/templates/wagtailforms/index_submissions.html
+++ b/wagtail/wagtailforms/templates/wagtailforms/index_submissions.html
@@ -115,7 +115,7 @@
             <form action="{% url 'wagtailforms:delete_submissions' form_page.id %}" method="get">
                 {% include "wagtailforms/list_submissions.html" %}
 
-                {% include "wagtailadmin/shared/pagination_nav.html" with items=submissions is_searching=False linkurl='-' %}
+                {% include "wagtailadmin/shared/pagination_nav.html" with items=page_obj is_searching=False linkurl='-' %}
                 {# Here we pass an invalid non-empty URL name as linkurl to generate pagination links with the URL path omitted #}
             </form>
         {% else %}

--- a/wagtail/wagtailforms/templates/wagtailforms/results_forms.html
+++ b/wagtail/wagtailforms/templates/wagtailforms/results_forms.html
@@ -2,7 +2,7 @@
 {% if form_pages %}
     {% include "wagtailforms/list_forms.html" %}
 
-    {% include "wagtailadmin/shared/pagination_nav.html" with items=form_pages linkurl="wagtailforms:index" %}
+    {% include "wagtailadmin/shared/pagination_nav.html" with items=page_obj linkurl="wagtailforms:index" %}
 {% else %}
     <p>{% trans "No form pages have been created." %}</p>
 {% endif %}

--- a/wagtail/wagtailforms/tests/test_views.py
+++ b/wagtail/wagtailforms/tests/test_views.py
@@ -90,7 +90,7 @@ class TestFormsIndex(TestCase, WagtailTestUtils):
         self.assertTemplateUsed(response, 'wagtailforms/index.html')
 
         # Check that we got the correct page
-        self.assertEqual(response.context['form_pages'].number, 2)
+        self.assertEqual(response.context['page_obj'].number, 2)
 
     def test_forms_index_pagination_invalid(self):
         # Create some more form pages to make pagination kick in
@@ -104,7 +104,7 @@ class TestFormsIndex(TestCase, WagtailTestUtils):
         self.assertTemplateUsed(response, 'wagtailforms/index.html')
 
         # Check that it got page one
-        self.assertEqual(response.context['form_pages'].number, 1)
+        self.assertEqual(response.context['page_obj'].number, 1)
 
     def test_forms_index_pagination_out_of_range(self):
         # Create some more form pages to make pagination kick in
@@ -272,7 +272,7 @@ class TestFormsSubmissionsList(TestCase, WagtailTestUtils):
         self.assertTemplateUsed(response, 'wagtailforms/index_submissions.html')
 
         # Check that we got the correct page
-        self.assertEqual(response.context['submissions'].number, 2)
+        self.assertEqual(response.context['page_obj'].number, 2)
 
     def test_list_submissions_pagination_invalid(self):
         self.make_list_submissions()
@@ -730,7 +730,7 @@ class TestCustomFormsSubmissionsList(TestCase, WagtailTestUtils):
         self.assertTemplateUsed(response, 'wagtailforms/index_submissions.html')
 
         # Check that we got the correct page
-        self.assertEqual(response.context['submissions'].number, 2)
+        self.assertEqual(response.context['page_obj'].number, 2)
 
         # CustomFormPageSubmission have custom field. This field should appear in the listing
         self.assertContains(response, '<th>Username</th>', html=True)

--- a/wagtail/wagtailforms/urls.py
+++ b/wagtail/wagtailforms/urls.py
@@ -5,7 +5,7 @@ from django.conf.urls import url
 from wagtail.wagtailforms import views
 
 urlpatterns = [
-    url(r'^$', views.index, name='index'),
-    url(r'^submissions/(\d+)/$', views.list_submissions, name='list_submissions'),
-    url(r'^submissions/(\d+)/delete/$', views.delete_submissions, name='delete_submissions')
+    url(r'^$', views.ListFormPages.as_view(), name='index'),
+    url(r'^submissions/(?P<page_id>\d+)/$', views.ListSubmissions.as_view(), name='list_submissions'),
+    url(r'^submissions/(?P<page_id>\d+)/delete/$', views.DeleteSubmissions.as_view(), name='delete_submissions')
 ]

--- a/wagtail/wagtailforms/views.py
+++ b/wagtail/wagtailforms/views.py
@@ -3,12 +3,12 @@ from __future__ import absolute_import, unicode_literals
 import csv
 import datetime
 
-from django.views.generic import ListView, TemplateView
 from django.core.exceptions import PermissionDenied
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404, redirect
 from django.utils.encoding import smart_str
 from django.utils.translation import ungettext
+from django.views.generic import ListView, TemplateView
 
 from wagtail.wagtailadmin import messages
 from wagtail.wagtailcore.models import Page

--- a/wagtail/wagtailforms/views.py
+++ b/wagtail/wagtailforms/views.py
@@ -3,103 +3,162 @@ from __future__ import absolute_import, unicode_literals
 import csv
 import datetime
 
+from django.views.generic import ListView, TemplateView
 from django.core.exceptions import PermissionDenied
 from django.http import HttpResponse
-from django.shortcuts import get_object_or_404, redirect, render
+from django.shortcuts import get_object_or_404, redirect
 from django.utils.encoding import smart_str
 from django.utils.translation import ungettext
 
-from wagtail.utils.pagination import paginate
 from wagtail.wagtailadmin import messages
 from wagtail.wagtailcore.models import Page
 from wagtail.wagtailforms.forms import SelectDateForm
 from wagtail.wagtailforms.models import get_forms_for_user
 
 
-def index(request):
-    form_pages = get_forms_for_user(request.user)
+class ListFormPages(ListView):
+    """ Lists the available form pages for the current user. """
+    template_name = 'wagtailforms/index.html'
+    context_object_name = 'form_pages'
+    paginate_by = 20
+    page_kwarg = 'p'
 
-    paginator, form_pages = paginate(request, form_pages)
-
-    return render(request, 'wagtailforms/index.html', {
-        'form_pages': form_pages,
-    })
+    def get_queryset(self):
+        return get_forms_for_user(self.request.user)
 
 
-def delete_submissions(request, page_id):
-    if not get_forms_for_user(request.user).filter(id=page_id).exists():
-        raise PermissionDenied
+class DeleteSubmissions(TemplateView):
+    """ Delete the selected submissions """
+    template_name = 'wagtailforms/confirm_delete.html'
 
-    page = get_object_or_404(Page, id=page_id).specific
+    page = None
+    submissions = None
 
-    # Get submissions
-    submission_ids = request.GET.getlist('selected-submissions')
-    submissions = page.get_submission_class()._default_manager.filter(id__in=submission_ids)
+    success_url = 'wagtailforms:list_submissions'
 
-    if request.method == 'POST':
+    def get_queryset(self):
+        """ Returns a queryset for the selected submissions """
+        submission_ids = self.request.GET.getlist('selected-submissions')
+        return self.page.get_submission_class()._default_manager.filter(id__in=submission_ids)
+
+    def handle_delete(self, submissions):
+        """ Deletes the given queryset """
         count = submissions.count()
         submissions.delete()
 
         messages.success(
-            request,
+            self.request,
             ungettext(
-                "One submission has been deleted.",
-                "%(count)d submissions have been deleted.",
+                'One submission has been deleted.',
+                '%(count)d submissions have been deleted.',
                 count
             ) % {
                 'count': count,
             }
         )
 
-        return redirect('wagtailforms:list_submissions', page_id)
+    def get_success_url(self):
+        """ Returns the success URL to redirect to after a successful deletion """
+        return self.success_url
 
-    return render(request, 'wagtailforms/confirm_delete.html', {
-        'page': page,
-        'submissions': submissions,
-    })
+    def dispatch(self, request, *args, **kwargs):
+        """ Check permissions, set the page, set submissions, handle delete """
+        page_id = kwargs.get('page_id')
+
+        if not get_forms_for_user(self.request.user).filter(id=page_id).exists():
+            raise PermissionDenied
+
+        self.page = get_object_or_404(Page, id=page_id).specific
+
+        self.submissions = self.get_queryset()
+
+        if self.request.method == 'POST':
+            self.handle_delete(self.submissions)
+
+            return redirect(self.get_success_url(), page_id)
+
+        return super(DeleteSubmissions, self).dispatch(request, *args, **kwargs)
+
+    def get_context_data(self, **kwargs):
+        context = super(DeleteSubmissions, self).get_context_data(**kwargs)
+
+        context.update({
+            'page': self.page,
+            'submissions': self.submissions,
+        })
+
+        return context
 
 
-def list_submissions(request, page_id):
-    if not get_forms_for_user(request.user).filter(id=page_id).exists():
-        raise PermissionDenied
+class ListSubmissions(ListView):
+    """ Lists submissions for the provided page """
+    template_name = 'wagtailforms/index_submissions.html'
+    context_object_name = 'submissions'
+    paginate_by = 20
+    page_kwarg = 'p'
 
-    form_page = get_object_or_404(Page, id=page_id).specific
-    form_submission_class = form_page.get_submission_class()
+    form_page = None
+    select_date_form = None
 
-    data_fields = form_page.get_data_fields()
+    def dispatch(self, request, *args, **kwargs):
+        """ Check permissions and set the form page """
+        page_id = self.kwargs.get('page_id')
 
-    submissions = form_submission_class.objects.filter(page=form_page).order_by('submit_time')
-    data_headings = [label for name, label in data_fields]
+        if not get_forms_for_user(self.request.user).filter(id=page_id).exists():
+            raise PermissionDenied
 
-    select_date_form = SelectDateForm(request.GET)
-    if select_date_form.is_valid():
-        date_from = select_date_form.cleaned_data.get('date_from')
-        date_to = select_date_form.cleaned_data.get('date_to')
-        # careful: date_to should be increased by 1 day since the submit_time
-        # is a time so it will always be greater
-        if date_to:
-            date_to += datetime.timedelta(days=1)
-        if date_from and date_to:
-            submissions = submissions.filter(submit_time__range=[date_from, date_to])
-        elif date_from and not date_to:
-            submissions = submissions.filter(submit_time__gte=date_from)
-        elif not date_from and date_to:
-            submissions = submissions.filter(submit_time__lte=date_to)
+        self.form_page = get_object_or_404(Page, id=page_id).specific
 
-    if request.GET.get('action') == 'CSV':
-        # return a CSV instead
+        return super(ListSubmissions, self).dispatch(request, *args, **kwargs)
+
+    def get_queryset(self):
+        """ Returns the form submissions queryset and applies filter_queryset() """
+        form_submission_class = self.form_page.get_submission_class()
+
+        submissions = form_submission_class.objects.filter(page=self.form_page).order_by('submit_time')
+
+        return self.filter_queryset(submissions)
+
+    def filter_queryset(self, submissions):
+        """ Filters the given queryset using the SelectDateForm """
+        self.select_date_form = SelectDateForm(self.request.GET)
+
+        if self.select_date_form.is_valid():
+            date_from = self.select_date_form.cleaned_data.get('date_from')
+            date_to = self.select_date_form.cleaned_data.get('date_to')
+            # careful: date_to should be increased by 1 day since the submit_time
+            # is a time so it will always be greater
+            if date_to:
+                date_to += datetime.timedelta(days=1)
+            if date_from and date_to:
+                submissions = submissions.filter(submit_time__range=[date_from, date_to])
+            elif date_from and not date_to:
+                submissions = submissions.filter(submit_time__gte=date_from)
+            elif not date_from and date_to:
+                submissions = submissions.filter(submit_time__lte=date_to)
+
+        return submissions
+
+    def get_csv_filename(self):
+        """ Returns the filename for the generated CSV file """
+        return 'export-{}.csv'.format(
+            datetime.datetime.today().strftime('%Y-%m-%d')
+        )
+
+    def get_csv_response(self, context):
+        """ Returns a CSV response """
         response = HttpResponse(content_type='text/csv; charset=utf-8')
-        response['Content-Disposition'] = 'attachment;filename=export.csv'
+        response['Content-Disposition'] = 'attachment;filename={}'.format(self.get_csv_filename())
 
         # Prevents UnicodeEncodeError for labels with non-ansi symbols
-        data_headings = [smart_str(label) for label in data_headings]
+        data_headings = [smart_str(label) for label in context['data_headings']]
 
         writer = csv.writer(response)
         writer.writerow(data_headings)
-        for s in submissions:
+        for s in context[self.context_object_name]:
             data_row = []
             form_data = s.get_data()
-            for name, label in data_fields:
+            for name, label in context['data_fields']:
                 val = form_data.get(name)
                 if isinstance(val, list):
                     val = ', '.join(val)
@@ -107,26 +166,38 @@ def list_submissions(request, page_id):
             writer.writerow(data_row)
         return response
 
-    paginator, submissions = paginate(request, submissions)
+    def render_to_response(self, context, **response_kwargs):
+        if self.request.GET.get('action') == 'CSV':
+            return self.get_csv_response(context)
+        return super(ListSubmissions, self).render_to_response(context, **response_kwargs)
 
-    data_rows = []
-    for s in submissions:
-        form_data = s.get_data()
-        data_row = []
-        for name, label in data_fields:
-            val = form_data.get(name)
-            if isinstance(val, list):
-                val = ', '.join(val)
-            data_row.append(val)
-        data_rows.append({
-            "model_id": s.id,
-            "fields": data_row
+    def get_context_data(self, **kwargs):
+        context = super(ListSubmissions, self).get_context_data(**kwargs)
+
+        data_fields = self.form_page.get_data_fields()
+        data_headings = [label for name, label in data_fields]
+
+        if self.request.GET.get('action') != 'CSV':
+            data_rows = []
+            for s in context[self.context_object_name]:
+                form_data = s.get_data()
+                data_row = []
+                for name, label in data_fields:
+                    val = form_data.get(name)
+                    if isinstance(val, list):
+                        val = ', '.join(val)
+                    data_row.append(val)
+                data_rows.append({
+                    'model_id': s.id,
+                    'fields': data_row
+                })
+            context['data_rows'] = data_rows
+
+        context.update({
+            'form_page': self.form_page,
+            'select_date_form': self.select_date_form,
+            'data_headings': data_headings,
+            'data_fields': data_fields
         })
 
-    return render(request, 'wagtailforms/index_submissions.html', {
-        'form_page': form_page,
-        'select_date_form': select_date_form,
-        'submissions': submissions,
-        'data_headings': data_headings,
-        'data_rows': data_rows
-    })
+        return context


### PR DESCRIPTION
Converted the `index`, `delete_submissions` and `list_submissions` function views to proper class based views. Extracted several getters and setters to allow easy extending and overrides.

At this moment there are still some tests failing. These test assert that non-existing or invalid pagination links should still result in a 200 status code and display page 1. This is very different from the behaviour of Django's `ListView`. My question is: should this behaviour be kept or can I change the tests to match Django's `ListView` behaviour (throwing a 404 in these situations).

In my personal opinion, differentiating that much from Django's behaviour is not worth it but I'll leave that to the experts ;-)

Greetings,
Johan Arensman

PS: Just found that #3812 was also fixed with this PR.
