### PR TITLE
Remove SessionAuthenticationMiddleware from project template and docs.

### DIFF
--- a/docs/advanced_topics/i18n/index.rst
+++ b/docs/advanced_topics/i18n/index.rst
@@ -53,11 +53,11 @@ Enabling multiple language support
 
 Firstly, make sure the `USE_I18N <https://docs.djangoproject.com/en/1.8/ref/settings/#use-i18n>`_ Django setting is set to ``True``.
 
-To enable multi-language support, add ``django.middleware.locale.LocaleMiddleware`` to your ``MIDDLEWARE_CLASSES``:
+To enable multi-language support, add ``django.middleware.locale.LocaleMiddleware`` to your ``MIDDLEWARE``:
 
 .. code-block:: python
 
-    MIDDLEWARE_CLASSES = (
+    MIDDLEWARE = (
         ...
 
         'django.middleware.locale.LocaleMiddleware',

--- a/docs/advanced_topics/settings.rst
+++ b/docs/advanced_topics/settings.rst
@@ -28,12 +28,11 @@ Middleware (``settings.py``)
 
 .. code-block:: python
 
-  MIDDLEWARE_CLASSES = [
+  MIDDLEWARE = [
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django.middleware.security.SecurityMiddleware',
@@ -520,12 +519,11 @@ These two files should reside in your project directory (``myproject/myproject/`
   ]
 
 
-  MIDDLEWARE_CLASSES = [
+  MIDDLEWARE = [
       'django.contrib.sessions.middleware.SessionMiddleware',
       'django.middleware.common.CommonMiddleware',
       'django.middleware.csrf.CsrfViewMiddleware',
       'django.contrib.auth.middleware.AuthenticationMiddleware',
-      'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
       'django.contrib.messages.middleware.MessageMiddleware',
       'django.middleware.clickjacking.XFrameOptionsMiddleware',
       'django.middleware.security.SecurityMiddleware',

--- a/docs/getting_started/integrating_into_django.rst
+++ b/docs/getting_started/integrating_into_django.rst
@@ -35,7 +35,7 @@ In your settings file, add the following apps to ``INSTALLED_APPS``:
     'modelcluster',
     'taggit',
 
-Add the following entries to ``MIDDLEWARE_CLASSES``:
+Add the following entries to ``MIDDLEWARE``:
 
 .. code-block:: python
 

--- a/wagtail/project_template/project_name/settings/base.py
+++ b/wagtail/project_template/project_name/settings/base.py
@@ -57,7 +57,6 @@ MIDDLEWARE = [
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django.middleware.security.SecurityMiddleware',

--- a/wagtail/tests/settings.py
+++ b/wagtail/tests/settings.py
@@ -94,7 +94,6 @@ if django.VERSION >= (1, 10):
         'django.contrib.sessions.middleware.SessionMiddleware',
         'django.middleware.csrf.CsrfViewMiddleware',
         'django.contrib.auth.middleware.AuthenticationMiddleware',
-        'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
         'django.contrib.messages.middleware.MessageMiddleware',
         'django.middleware.clickjacking.XFrameOptionsMiddleware',
 


### PR DESCRIPTION
The project template assumes Django 1.11, where SessionAuthenticationMiddleware is redundant (see https://docs.djangoproject.com/en/1.11/releases/1.10/#features-removed-in-1-10). This patch removes it from the template.

Also updated the documentation to consistently refer to `MIDDLEWARE` instead of `MIDDLEWARE_CLASSES`. (There is a question about whether, in all these places, we need to remind people to use `MIDDLEWARE_CLASSES` if they are on Django 1.8 - please let me know if you think this is necessary).
