### PR TITLE
Permission to move a Page should not be affected by bulk_delete.

### DIFF
--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -1712,7 +1712,7 @@ class PagePermissionTester(object):
             ('add' in self.permissions and self.page.owner_id == self.user.pk)
         )
 
-    def can_delete(self):
+    def can_delete(self, ignore_bulk=False):
         if not self.user.is_active:
             return False
         if self.page_is_root:  # root node is not a page and can never be deleted, even by superusers
@@ -1723,7 +1723,7 @@ class PagePermissionTester(object):
             return True
 
         # if the user does not have bulk_delete permission, they may only delete leaf pages
-        if 'bulk_delete' not in self.permissions and not self.page.is_leaf():
+        if 'bulk_delete' not in self.permissions and not self.page.is_leaf() and not ignore_bulk:
             return False
 
         if 'edit' in self.permissions:
@@ -1802,7 +1802,7 @@ class PagePermissionTester(object):
         As such, the permission test for 'can this be moved at all?' should be the same as for deletion.
         (Further constraints will then apply on where it can be moved *to*.)
         """
-        return self.can_delete()
+        return self.can_delete(ignore_bulk=True)
 
     def can_move_to(self, destination):
         # reject the logically impossible cases first


### PR DESCRIPTION
The `PagePermissionTester.can_move()` method simply calls `PagePermissionTester.can_delete()`. Before the bulk_delete permission was added, this was a reasonable analogue for "permission to delete", since a move is effectively a "cut and paste" operation, and you can't "cut" without permission to delete.

But bulk_delete is changes this dynamic. It was added to avoid allowing users to delete a whole lot of pages all at once by mistake, when they think they're just deleting one. However, the move/delete analogue breaks down when you're talking about moving an entire subtree, because you're *not* directly altering the children of the moved Page. They're just coming along for the ride.

This PR makes the can_move() method ignore the bulk_delete permission.

I'm not sure if this breaks any tests. This interaction between move and bulk_delete *seems* like it's unintentional, which would imply that no tests test for this. But if the tests do fail, that probably means this is intended behavior.