### PR TITLE
Stop breadcrumb home icon from showing as ellipsis in Chrome

### DIFF
--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/core.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/core.scss
@@ -246,6 +246,7 @@ footer {
                 text-align: center;
                 width: 3em;
                 font-size: 1em;
+                text-overflow: clip;
 
                 &:before {
                     font-size: 1.15rem;


### PR DESCRIPTION
before:
![screen shot 2017-09-22 at 12 29 20](https://user-images.githubusercontent.com/85097/30742919-5d04613a-9f93-11e7-8a36-bfde2f0c3ef7.png)

after:
![screen shot 2017-09-22 at 12 29 56](https://user-images.githubusercontent.com/85097/30742924-61d889b6-9f93-11e7-9819-2c763adfafc5.png)
