### PR TITLE
Use globe instead of home icon for breadcrumb root

### DIFF
--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/core.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/core.scss
@@ -246,6 +246,7 @@ footer {
                 text-align: center;
                 width: 3em;
                 font-size: 1em;
+                text-overflow: clip;
 
                 &:before {
                     font-size: 1.15rem;

--- a/wagtail/wagtailadmin/templates/wagtailadmin/shared/breadcrumb.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/shared/breadcrumb.html
@@ -2,9 +2,12 @@
 
 <ul class="breadcrumb">
     {% for page in pages %}
-        {% if forloop.first %}
-            {# first item in breadcrumb displays as a 'home' icon in place of the title #}
-            <li class="home"><a href="{% if page.is_root %}{% url 'wagtailadmin_explore_root' %}{% else %}{% url 'wagtailadmin_explore' page.id %}{% endif %}" class="icon icon-home text-replace">{% trans 'Home' %}</a></li>
+        {% if page.is_root %}
+            {# Root section is shown as a 'site' icon in place of the title #}
+            <li class="home"><a href="{% url 'wagtailadmin_explore_root' %}" class="icon icon-site text-replace">{% trans 'Root' %}</a></li>
+        {% elif forloop.first %}
+            {# For limited-permission users whose breadcrumb starts further down from the root, the first item displays as a 'home' icon in place of the title #}
+            <li class="home"><a href="{% url 'wagtailadmin_explore' page.id %}" class="icon icon-home text-replace">{% trans 'Home' %}</a></li>
         {% else %}
             <li><a href="{% url 'wagtailadmin_explore' page.id %}">{{ page.get_admin_display_title }}</a></li>
         {% endif %}

--- a/wagtail/wagtailadmin/tests/test_pages_views.py
+++ b/wagtail/wagtailadmin/tests/test_pages_views.py
@@ -447,7 +447,7 @@ class TestExplorablePageVisibility(TestCase, WagtailTestUtils):
         self.assertEqual(response.status_code, 200)
 
         self.assertInHTML(
-            """<li class="home"><a href="/admin/pages/" class="icon icon-home text-replace">Home</a></li>""",
+            """<li class="home"><a href="/admin/pages/" class="icon icon-site text-replace">Root</a></li>""",
             str(response.content)
         )
         self.assertInHTML("""<li><a href="/admin/pages/4/">Welcome to example.com!</a></li>""", str(response.content))


### PR DESCRIPTION
One of our designers commented that it was unintuitive that the 'home' icon in the breadcrumb takes you to the root level, rather than the homepage. This is particularly true of single-site installations, where the usefulness of accessing the root level at all is unclear.

I don't think we can (or should) omit the root from the breadcrumb entirely (since you need to go there to set up a second site). I believe the real problem is that we're misusing the 'home' icon to represent the root - editors would intuitively head for the _second_ link in the breadcrumb (which will generally be labelled 'Home' or with the name of the site) when they want to go to the homepage, if it weren't for the fact that there was a big friendly 'Home' icon sending them astray. So, I think this can be fixed by changing it to an icon that doesn't have that mental association.

I propose using the globe icon instead - this will hopefully be a meaningful concept to people managing multi-site Wagtail installations, and for people who aren't, it could equally represent "the internet".

<img width="409" alt="screen shot 2017-09-25 at 18 12 19" src="https://user-images.githubusercontent.com/85097/30826834-dc24473e-a22f-11e7-8213-52bc6c26ac29.png">

Note that with this change in place, limited-permission users who don't have access to the root level will still get the 'home' icon as the first link in the breadcrumb, as before (even if their highest accessible level isn't actually a homepage, e.g. an editor who only has access to the blog section):

<img width="334" alt="screen shot 2017-09-25 at 18 31 06" src="https://user-images.githubusercontent.com/85097/30827227-5296d2c8-a231-11e7-85ad-fd0ed6303604.png">
