### PR TITLE
Make last_published_at filterable

### DIFF
--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -358,6 +358,7 @@ class Page(six.with_metaclass(PageBase, AbstractPage, index.Indexed, Clusterable
         index.FilterField('locked'),
         index.FilterField('show_in_menus'),
         index.FilterField('first_published_at'),
+        index.FilterField('last_published_at'),
         index.FilterField('latest_revision_created_at'),
     ]
 


### PR DESCRIPTION
This PR makes `Page.last_published_at` filterable along with `first_published_at` and other basic fields from the `Page` model.