### PR TITLE
 Prevent ampersands in embed URLs in rich text from being escaped repeatedly

### DIFF
--- a/wagtail/wagtailcore/tests/test_whitelist.py
+++ b/wagtail/wagtailcore/tests/test_whitelist.py
@@ -145,3 +145,8 @@ class TestWhitelister(TestCase):
         string = '<b>snowman Yorkshire<!--[if gte mso 10]>MS word junk<![endif]--></b>'
         cleaned_string = Whitelister.clean(string)
         self.assertEqual(cleaned_string, '<b>snowman Yorkshire</b>')
+
+    def test_quoting(self):
+        string = '<img alt="Arthur &quot;two sheds&quot; Jackson" sheds="2">'
+        cleaned_string = Whitelister.clean(string)
+        self.assertEqual(cleaned_string, '<img alt="Arthur &quot;two sheds&quot; Jackson"/>')

--- a/wagtail/wagtailembeds/rich_text.py
+++ b/wagtail/wagtailembeds/rich_text.py
@@ -25,14 +25,18 @@ class MediaEmbedHandler(object):
     @staticmethod
     def expand_db_attributes(attrs, for_editor):
         """
-        Given a dict of attributes from the <embed> tag, return the real HTML
+        Given a dict of HTML-escaped attributes from the <embed> tag, return the real HTML
         representation.
         """
+        # The URL is received here in HTML-escaped form;
+        # need to unescape it before it's valid as a URL to look up
+        unescaped_url = attrs['url'].replace('&lt;', '<').replace('&gt;', '>').replace('&quot;', '"').replace('&#39;', "'").replace('&amp;', '&')
+
         if for_editor:
             try:
-                return format.embed_to_editor_html(attrs['url'])
+                return format.embed_to_editor_html(unescaped_url)
             except EmbedException:
                 # Could be replaced with a nice error message
                 return ''
         else:
-            return format.embed_to_frontend_html(attrs['url'])
+            return format.embed_to_frontend_html(unescaped_url)

--- a/wagtail/wagtailembeds/tests.py
+++ b/wagtail/wagtailembeds/tests.py
@@ -692,6 +692,28 @@ class TestMediaEmbedHandler(TestCase):
         )
         self.assertIn('test html', result)
 
+    def test_called_with_unescaped_url(self):
+        with patch('wagtail.wagtailembeds.embeds.get_embed') as get_embed:
+            get_embed.return_value = Embed(
+                url='http://www.youtube.com/watch/',
+                max_width=None,
+                type='video',
+                html='test html',
+                title='test title',
+                author_name='test author name',
+                provider_name='test provider name',
+                thumbnail_url='htto://test/thumbnail.url',
+                width=1000,
+                height=1000,
+            )
+            result = MediaEmbedHandler.expand_db_attributes(
+                {'url': 'https://www.youtube.com/watch?v=O7D-1RG-VRk&amp;t=25'},
+                False
+            )
+            self.assertIn('test html', result)
+            get_embed.assert_called_with('https://www.youtube.com/watch?v=O7D-1RG-VRk&t=25')
+
+
     @patch('wagtail.wagtailembeds.embeds.get_embed')
     def test_expand_db_attributes_catches_embed_not_found(self, get_embed):
         get_embed.side_effect = EmbedNotFoundException

--- a/wagtail/wagtailimages/formats.py
+++ b/wagtail/wagtailimages/formats.py
@@ -18,18 +18,35 @@ class Format(object):
     def editor_attributes(self, image, alt_text):
         """
         Return string of additional attributes to go on the HTML element
-        when outputting this image within a rich text editor field
+        when outputting this image within a rich text editor field.
+
+        Assumes that the alt_text passed here is already escaped
+        (i.e. < > & appear as &lt; &gt; &amp;)
         """
         return 'data-embedtype="image" data-id="%d" data-format="%s" data-alt="%s" ' % (
             image.id, self.name, alt_text
         )
 
     def image_to_editor_html(self, image, alt_text):
+        """
+        Return the HTML representation of the given image
+        as it should be rendered within a rich text editor field.
+
+        Assumes that the alt_text passed here is already escaped
+        (i.e. < > & appear as &lt; &gt; &amp;)
+        """
         return self.image_to_html(
             image, alt_text, self.editor_attributes(image, alt_text)
         )
 
     def image_to_html(self, image, alt_text, extra_attributes=''):
+        """
+        Return the HTML representation of the given image
+        as it should be rendered on a site front-end.
+
+        Assumes that the alt_text passed here is already escaped
+        (i.e. < > & appear as &lt; &gt; &amp;)
+        """
         rendition = get_rendition_or_not_found(image, self.filter_spec)
 
         if self.classnames:

--- a/wagtail/wagtailimages/rich_text.py
+++ b/wagtail/wagtailimages/rich_text.py
@@ -39,6 +39,6 @@ class ImageEmbedHandler(object):
         image_format = get_image_format(attrs['format'])
 
         if for_editor:
-            return image_format.image_to_editor_html(image, attrs['alt'])
+            return image_format.image_to_editor_html(image, attrs.get('alt', ''))
         else:
-            return image_format.image_to_html(image, attrs['alt'])
+            return image_format.image_to_html(image, attrs.get('alt', ''))

--- a/wagtail/wagtailimages/rich_text.py
+++ b/wagtail/wagtailimages/rich_text.py
@@ -27,8 +27,8 @@ class ImageEmbedHandler(object):
     @staticmethod
     def expand_db_attributes(attrs, for_editor):
         """
-        Given a dict of attributes from the <embed> tag, return the real HTML
-        representation.
+        Given a dict of attributes from the <embed> tag (with < > & escaped as &lt; &gt; &amp;),
+        return the real HTML representation.
         """
         Image = get_image_model()
         try:

--- a/wagtail/wagtailimages/tests/test_rich_text.py
+++ b/wagtail/wagtailimages/tests/test_rich_text.py
@@ -38,6 +38,16 @@ class TestImageEmbedHandler(TestCase):
         )
         self.assertIn('<img class="richtext-image left"', result)
 
+    def test_expand_db_attributes_leaves_quoting_intact(self):
+        Image.objects.create(id=1, title='Test', file=get_test_image_file())
+        result = ImageEmbedHandler.expand_db_attributes(
+            {'id': 1,
+             'alt': 'Arthur &quot;two sheds&quot; Jackson',
+             'format': 'left'},
+            False
+        )
+        self.assertIn('alt="Arthur &quot;two sheds&quot; Jackson"', result)
+
     def test_expand_db_attributes_for_editor(self):
         Image.objects.create(id=1, title='Test', file=get_test_image_file())
         result = ImageEmbedHandler.expand_db_attributes(
@@ -50,3 +60,17 @@ class TestImageEmbedHandler(TestCase):
             '<img data-embedtype="image" data-id="1" data-format="left" '
             'data-alt="test-alt" class="richtext-image left"', result
         )
+
+    def test_expand_db_attributes_for_editor_leaves_quoting_intact(self):
+        Image.objects.create(id=1, title='Test', file=get_test_image_file())
+        result = ImageEmbedHandler.expand_db_attributes(
+            {'id': 1,
+             'alt': 'Arthur &quot;two sheds&quot; Jackson',
+             'format': 'left'},
+            True
+        )
+        self.assertIn(
+            '<img data-embedtype="image" data-id="1" data-format="left" '
+            'data-alt="Arthur &quot;two sheds&quot; Jackson" class="richtext-image left"', result
+        )
+        self.assertIn('alt="Arthur &quot;two sheds&quot; Jackson"', result)

--- a/wagtail/wagtailimages/tests/test_rich_text.py
+++ b/wagtail/wagtailimages/tests/test_rich_text.py
@@ -38,6 +38,16 @@ class TestImageEmbedHandler(TestCase):
         )
         self.assertIn('<img class="richtext-image left"', result)
 
+    def test_expand_db_attributes_with_missing_alt(self):
+        Image.objects.create(id=1, title='Test', file=get_test_image_file())
+        result = ImageEmbedHandler.expand_db_attributes(
+            {'id': 1,
+             'format': 'left'},
+            False
+        )
+        self.assertIn('<img class="richtext-image left"', result)
+        self.assertIn('alt=""', result)
+
     def test_expand_db_attributes_leaves_quoting_intact(self):
         Image.objects.create(id=1, title='Test', file=get_test_image_file())
         result = ImageEmbedHandler.expand_db_attributes(
@@ -59,6 +69,18 @@ class TestImageEmbedHandler(TestCase):
         self.assertIn(
             '<img data-embedtype="image" data-id="1" data-format="left" '
             'data-alt="test-alt" class="richtext-image left"', result
+        )
+
+    def test_expand_db_attributes_for_editor_with_missing_alt(self):
+        Image.objects.create(id=1, title='Test', file=get_test_image_file())
+        result = ImageEmbedHandler.expand_db_attributes(
+            {'id': 1,
+             'format': 'left'},
+            True
+        )
+        self.assertIn(
+            '<img data-embedtype="image" data-id="1" data-format="left" '
+            'data-alt="" class="richtext-image left"', result
         )
 
     def test_expand_db_attributes_for_editor_leaves_quoting_intact(self):

--- a/wagtail/wagtailimages/tests/tests.py
+++ b/wagtail/wagtailimages/tests/tests.py
@@ -184,6 +184,17 @@ class TestFormat(TestCase):
             'data-alt="test alt text" class="test classnames" src="[^"]+" width="1" height="1" alt="test alt text">',
         )
 
+    def test_image_to_editor_html_with_quoting(self):
+        result = self.format.image_to_editor_html(
+            self.image,
+            'Arthur &quot;two sheds&quot; Jackson'
+        )
+        six.assertRegex(
+            self, result,
+            '<img data-embedtype="image" data-id="0" data-format="test name" '
+            'data-alt="Arthur &quot;two sheds&quot; Jackson" class="test classnames" src="[^"]+" width="1" height="1" alt="Arthur &quot;two sheds&quot; Jackson">',
+        )
+
     def test_image_to_html_no_classnames(self):
         self.format.classnames = None
         result = self.format.image_to_html(self.image, 'test alt text')
@@ -192,6 +203,13 @@ class TestFormat(TestCase):
             '<img src="[^"]+" width="1" height="1" alt="test alt text">'
         )
         self.format.classnames = 'test classnames'
+
+    def test_image_to_html_with_quoting(self):
+        result = self.format.image_to_html(self.image, 'Arthur &quot;two sheds&quot; Jackson')
+        six.assertRegex(
+            self, result,
+            '<img class="test classnames" src="[^"]+" width="1" height="1" alt="Arthur &quot;two sheds&quot; Jackson">'
+        )
 
     def test_get_image_format(self):
         register_image_format(self.format)

--- a/wagtail/wagtailimages/views/chooser.py
+++ b/wagtail/wagtailimages/views/chooser.py
@@ -4,6 +4,7 @@ import json
 
 from django.core.urlresolvers import reverse
 from django.shortcuts import get_object_or_404, render
+from django.utils.html import escape
 
 from wagtail.utils.pagination import paginate
 from wagtail.wagtailadmin.forms import SearchForm
@@ -180,7 +181,7 @@ def chooser_select_format(request, image_id):
                     'width': preview_image.width,
                     'height': preview_image.height,
                 },
-                'html': format.image_to_editor_html(image, form.cleaned_data['alt_text']),
+                'html': format.image_to_editor_html(image, escape(form.cleaned_data['alt_text'])),
             })
 
             return render_modal_workflow(


### PR DESCRIPTION
Fixes #3126

Incorporates #3879, since we're assuming that the characters to be un-escaped should match the ones handled by django.utils.html.escape, and this is ensured by c4248e3e6485b16ed4929d69f9a83f1195d02bf4.