### PR TITLE
FIX : Update required dependency

### DIFF
--- a/docs/getting_started/index.rst
+++ b/docs/getting_started/index.rst
@@ -18,7 +18,7 @@ With the above installed, the quickest way to install Wagtail is:
 
 .. code-block:: console
 
-    $ pip install wagtail
+    $ pip install wagtail django django-core
 
 (``sudo`` may be required if installing system-wide or without virtualenv)
 


### PR DESCRIPTION
* I have added two dependancies:
 *django
 *django-core

* This is due to the fact that after installing wagtail only and trying to start the project with `wagtail start mysite` you will get the following error:
```
Traceback (most recent call last):
File "/home/vagrant/wagdev/ve/bin/wagtail", line 7, in <module>
from wagtail.bin.wagtail import main
File "/home/vagrant/wagdev/ve/local/lib/python2.7/site-packages/wagtail/bin/wagtail.py", line 7, in <module>
from django.core.management import ManagementUtility
ImportError: No module named django.core.management
```

django-core on its own does not solve this and thus why django has been included here.
It may be better to have this in a dependency file but I though this may be a good first step.

Thanks for contributing to Wagtail! 🎉

Before submitting, please review the contributor guidelines <http://docs.wagtail.io/en/latest/contributing/index.html> and check the following:

* Do the tests still pass? (http://docs.wagtail.io/en/latest/contributing/developing.html#testing)
* Does the code comply with the style guide? (Run `make lint` from the Wagtail root)
* For Python changes: Have you added tests to cover the new/fixed behaviour?
* For new features: Has the documentation been updated accordingly?
