### PR TITLE
Deployment docs: remove Openshift, add PythonAnywhere

### DIFF
--- a/docs/advanced_topics/deploying.rst
+++ b/docs/advanced_topics/deploying.rst
@@ -8,6 +8,11 @@ Wagtail is straightforward to deploy on modern Linux-based distributions, but se
 
 Our current preferences are for Nginx, Gunicorn and supervisor on Debian, but Wagtail should run with any of the combinations detailed in Django's `deployment documentation <https://docs.djangoproject.com/en/dev/howto/deployment/>`_.
 
+On PythonAnywhere
+~~~~~~~~~~~~~~~~~
+
+`PythonAnywhere <https://www.pythonanywhere.com/>`_ is a Platform-as-a-Service (PaaS) focused on Python hosting and development. It allows developers to quickly develop, host, and scale applications in a cloud environment. Starting with a free plan they also provide MySQL and PostgreSQL databases as well as very flexible and affordable paid plans, so there's all you need to host a Wagtail site. To get quickly up and running you may use the `wagtail-pythonanywhere-quickstart <https://github.com/texperience/wagtail-pythonanywhere-quickstart>`_.
+
 On other PAASs and IAASs
 ~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/advanced_topics/deploying.rst
+++ b/docs/advanced_topics/deploying.rst
@@ -8,11 +8,6 @@ Wagtail is straightforward to deploy on modern Linux-based distributions, but se
 
 Our current preferences are for Nginx, Gunicorn and supervisor on Debian, but Wagtail should run with any of the combinations detailed in Django's `deployment documentation <https://docs.djangoproject.com/en/dev/howto/deployment/>`_.
 
-On Openshift
-~~~~~~~~~~~~
-
-`OpenShift <https://www.openshift.com/>`_ is Red Hat's Platform-as-a-Service (PaaS) that allows developers to quickly develop, host, and scale applications in a cloud environment. With their Python, PostgreSQL and Elasticsearch cartridges there's all you need to host a Wagtail site. To get quickly up and running you may use the `wagtail-openshift-quickstart <https://github.com/texperience/wagtail-openshift-quickstart>`_.
-
 On other PAASs and IAASs
 ~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
I replaced the deployment documentation for Openshift with PythonAnywhere.

Openshift Online v2 has been sunset at September 30th, 2017 (extended for paying customers until December 31th, 2017), therefore it makes no sense to deploy a new project on this platform.

In the last few days I migrated my projects over to PythonAnywhere and it was fortunately very easy and straightforward. By the way I created a fully documented wagtail quickstart for this PaaS linked with the wagtail deployment docs (as I did for OpenShift Online v2).