### PR TITLE
Ensure example.doc is deleted on TestServeView teardown

### DIFF
--- a/wagtail/wagtaildocs/tests/test_views.py
+++ b/wagtail/wagtaildocs/tests/test_views.py
@@ -77,7 +77,9 @@ class TestServeView(TestCase):
         self.document.file.save('example.doc', ContentFile("A boring example document"))
 
     def tearDown(self):
-        self.document.delete()
+        # delete the FieldFile directly because the TestCase does not commit
+        # transactions to trigger transaction.on_commit() in the signal handler
+        self.document.file.delete()
 
     def get(self):
         return self.client.get(reverse('wagtaildocs_serve', args=(self.document.id, self.document.filename)))


### PR DESCRIPTION
Fix test breakage against Elasticsearch/Python 2.7 (e.g. https://travis-ci.org/wagtail/wagtail/builds/282769711) that was presumably triggered by #3821