### PR TITLE
Simplified Content-Encoding in response in utils/sendfile.py

### DIFF
--- a/wagtail/utils/sendfile.py
+++ b/wagtail/utils/sendfile.py
@@ -86,9 +86,6 @@ def sendfile(request, filename, attachment=False, attachment_filename=None, mime
 
     response['Content-length'] = os.path.getsize(filename)
     response['Content-Type'] = mimetype
-    if not encoding:
-        encoding = guessed_encoding
-    if encoding:
-        response['Content-Encoding'] = encoding
+    response['Content-Encoding'] = encoding or guessed_encoding
 
     return response


### PR DESCRIPTION
The coverage report hints that `if encoding` is always true. No validation is performed on the content-type, so `encoding or guessed_encoding` is what it performed already (at least that's how I read the code).