### PR TITLE
Allow navigation from page usage/search results

### DIFF
--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/index.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/index.html
@@ -14,7 +14,7 @@
         {% csrf_token %}
 
         {% page_permissions parent_page as parent_page_perms %}
-        {% include "wagtailadmin/pages/listing/_list_explore.html" with sortable=1 allow_navigation=1 full_width=1 show_ordering_column=1 parent_page=parent_page orderable=parent_page_perms.can_reorder_children %}
+        {% include "wagtailadmin/pages/listing/_list_explore.html" with sortable=1 full_width=1 show_ordering_column=1 parent_page=parent_page orderable=parent_page_perms.can_reorder_children %}
 
         {% if do_paginate %}
             {% url 'wagtailadmin_explore' parent_page.id as pagination_base_url %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/listing/_navigation_explore.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/listing/_navigation_explore.html
@@ -4,12 +4,10 @@
 Navigation controls for the page listing in 'explore' mode
 {% endcomment %}
 
-<td class="{% if allow_navigation %}{% if page.is_navigable %}children{% else %}no-children{% endif %}{% endif %}">
-    {% if allow_navigation %}
-        {% if page.is_navigable %}
-            <a href="{% url 'wagtailadmin_explore' page.id %}" class="icon text-replace icon-arrow-right" title="{% blocktrans with title=page.get_admin_display_title %}Explore child pages of '{{ title }}'{% endblocktrans %}">{% trans "Explore" %}</a>
-        {% elif page_perms.can_add_subpage %}
-            <a href="{% url 'wagtailadmin_pages:add_subpage' page.id %}" class="icon text-replace icon-plus-inverse" title="{% blocktrans with title=page.get_admin_display_title %}Add a child page to '{{ title }}'{% endblocktrans %}">{% trans 'Add child page' %}</a>
-        {% endif %}
+<td class="{% if page.is_navigable %}children{% else %}no-children{% endif %}">
+    {% if page.is_navigable %}
+        <a href="{% url 'wagtailadmin_explore' page.id %}" class="icon text-replace icon-arrow-right" title="{% blocktrans with title=page.get_admin_display_title %}Explore child pages of '{{ title }}'{% endblocktrans %}">{% trans "Explore" %}</a>
+    {% elif page_perms.can_add_subpage %}
+        <a href="{% url 'wagtailadmin_pages:add_subpage' page.id %}" class="icon text-replace icon-plus-inverse" title="{% blocktrans with title=page.get_admin_display_title %}Add a child page to '{{ title }}'{% endblocktrans %}">{% trans 'Add child page' %}</a>
     {% endif %}
 </td>

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/search_results.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/search_results.html
@@ -11,7 +11,7 @@
 
         {% search_other %}
 
-        {% include "wagtailadmin/pages/listing/_list_explore.html" with show_parent=1 allow_navigation=0 %}
+        {% include "wagtailadmin/pages/listing/_list_explore.html" with show_parent=1 %}
 
         {% url 'wagtailadmin_pages:search' as pagination_base_url %}
         {% paginate pages base_url=pagination_base_url %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/usage_results.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/usage_results.html
@@ -1,7 +1,7 @@
 {% load i18n wagtailadmin_tags %}
 <div class="nice-padding">
     {% if pages %}
-        {% include "wagtailadmin/pages/listing/_list_explore.html" with show_parent=1 allow_navigation=0 %}
+        {% include "wagtailadmin/pages/listing/_list_explore.html" with show_parent=1 %}
 
         {% url 'wagtailadmin_pages:type_use' app_name content_type.model as pagination_base_url %}
         {% paginate pages base_url=pagination_base_url %}


### PR DESCRIPTION
Remove the allow_navigation flag from the 'explore' page listing, and have navigation always enabled - there's no good reason to leave it out, and people have asked for it. Fixes #952