### PR TITLE
Remove Python 2 from CI and docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,32 +14,8 @@ addons:
 
 matrix:
   include:
-   - env: TOXENV=py27-dj18-postgres-noelasticsearch
-     python: 2.7
-   - env: TOXENV=py27-dj18-mysql-noelasticsearch
-     python: 2.7
-   - env: TOXENV=py27-dj18-sqlite-noelasticsearch
-     python: 2.7
    - env: TOXENV=py35-dj18-postgres-noelasticsearch
      python: 3.5
-   - env: TOXENV=py27-dj110-sqlite-noelasticsearch
-     python: 2.7
-   - env: TOXENV=py27-dj110-postgres-noelasticsearch
-     python: 2.7
-   - env: TOXENV=py27-dj110-mysql-noelasticsearch
-     python: 2.7
-   - env: TOXENV=py27-dj110-mysql-elasticsearch5 INSTALL_ELASTICSEARCH5=yes
-     python: 2.7
-     sudo: true
-   - env: TOXENV=py27-dj111-sqlite-noelasticsearch
-     python: 2.7
-   - env: TOXENV=py27-dj111-postgres-noelasticsearch
-     python: 2.7
-   - env: TOXENV=py27-dj111-mysql-noelasticsearch
-     python: 2.7
-   - env: TOXENV=py27-dj111-postgres-elasticsearch5 INSTALL_ELASTICSEARCH5=yes
-     python: 2.7
-     sudo: true
    - env: TOXENV=py34-dj110-postgres-noelasticsearch
      python: 3.4
    - env: TOXENV=py34-dj110-sqlite-noelasticsearch
@@ -83,8 +59,6 @@ matrix:
      sudo: true
   allow_failures:
     # Ignore failures on Elasticsearch tests because ES on Travis is intermittently flaky;
-    - env: TOXENV=py27-dj110-mysql-elasticsearch5 INSTALL_ELASTICSEARCH5=yes
-    - env: TOXENV=py27-dj111-postgres-elasticsearch5 INSTALL_ELASTICSEARCH5=yes
     - env: TOXENV=py35-dj110-postgres-elasticsearch INSTALL_ELASTICSEARCH1=yes
     - env: TOXENV=py35-dj110-postgres-elasticsearch2 INSTALL_ELASTICSEARCH2=yes
     - env: TOXENV=py35-dj110-postgres-elasticsearch5 INSTALL_ELASTICSEARCH5=yes

--- a/README.rst
+++ b/README.rst
@@ -80,7 +80,7 @@ We thank `BrowserStack <https://www.browserstack.com/>`_, who provide the projec
 
 Compatibility
 ~~~~~~~~~~~~~
-Wagtail supports Django 1.8.x, 1.10.x and 1.11.x, on Python 2.7, 3.4, 3.5 and 3.6. Supported database backends are PostgreSQL, MySQL and SQLite.
+Wagtail supports Django 1.8.x, 1.10.x and 1.11.x, on Python 3.4, 3.5 and 3.6. Supported database backends are PostgreSQL, MySQL and SQLite.
 
 Contributing
 ~~~~~~~~~~~~

--- a/docs/contributing/python_guidelines.rst
+++ b/docs/contributing/python_guidelines.rst
@@ -10,12 +10,6 @@ You might want to configure the flake8 linter in your editor/IDE to use the conf
 
 In addition, import lines should be sorted according to `isort <http://timothycrosley.github.io/isort/>`_ 4.2.5 rules. If you have installed Wagtail's testing dependencies (``pip install -e .[testing]``), you can check your code by running ``make lint``.
 
-
-Python 2 and 3 compatibility
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-All contributions should support Python 2 and 3 and we recommend using the `six <https://pythonhosted.org/six/>`_ compatibility library (use the version bundled with Django, ``django.utils.six``).
-
 Django compatibility
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/getting_started/index.rst
+++ b/docs/getting_started/index.rst
@@ -4,7 +4,7 @@ Getting started
 Wagtail is built on the `Django web framework <https://www.djangoproject.com/>`_, so this document assumes you've already got the essentials installed. But if not, those essentials are:
 
  * `Python <https://www.python.org/downloads/>`_
- * `pip <https://pip.pypa.io/en/latest/installing.html>`_ (Note that pip is included by default with Python 2.7.9 and later and Python 3.4 and later)
+ * `pip <https://pip.pypa.io/en/latest/installing.html>`_ (Note that pip is included by default with Python 3.4 and later)
 
 We'd also recommend Virtualenv, which provides isolated Python environments:
 

--- a/setup.py
+++ b/setup.py
@@ -81,8 +81,6 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 skipsdist = True
 usedevelop = True
 
-envlist = py{27,34,35}-dj{18,110}-{sqlite,postgres,mysql,mssql}-{elasticsearch5,elasticsearch2,elasticsearch,noelasticsearch},
-          py{27,34,35,36}-dj111-{sqlite,postgres,mysql}-{elasticsearch5,elasticsearch2,elasticsearch,noelasticsearch},
+envlist = py{34,35}-dj{18,110}-{sqlite,postgres,mysql,mssql}-{elasticsearch5,elasticsearch2,elasticsearch,noelasticsearch},
+          py{34,35,36}-dj111-{sqlite,postgres,mysql}-{elasticsearch5,elasticsearch2,elasticsearch,noelasticsearch},
           flake8
 
 [flake8]
@@ -34,7 +34,6 @@ commands =
     noelasticsearch: coverage run runtests.py
 
 basepython =
-    py27: python2.7
     py34: python3.4
     py35: python3.5
     py36: python3.6


### PR DESCRIPTION
Ref #3917 

This removes every reference to Python 2 support I could find in the docs, and also removes from Travis CI configuration as well.