### PR TITLE
Eliminate references to wagtaildemo from the docs

### DIFF
--- a/docs/advanced_topics/settings.rst
+++ b/docs/advanced_topics/settings.rst
@@ -552,7 +552,7 @@ These two files should reside in your project directory (``myproject/myproject/`
       },
   ]
 
-  WSGI_APPLICATION = 'wagtaildemo.wsgi.application'
+  WSGI_APPLICATION = 'myproject.wsgi.application'
 
   # Database
 

--- a/docs/contributing/developing.rst
+++ b/docs/contributing/developing.rst
@@ -5,7 +5,7 @@ Development
 
 Setting up a local copy of `the Wagtail git repository <https://github.com/wagtail/wagtail>`_ is slightly more involved than running a release package of Wagtail, as it requires `Node.js <https://nodejs.org/>`_ and NPM for building Javascript and CSS assets. (This is not required when running a release version, as the compiled assets are included in the release package.)
 
-If you're happy to develop on a virtual machine, the `vagrant-wagtail-develop <https://github.com/wagtail/vagrant-wagtail-develop>`_ setup script is the fastest way to get up and running. This will provide you with a running instance of the `Wagtail demo site <https://github.com/wagtail/wagtaildemo/>`_, with the Wagtail and wagtaildemo codebases available as shared folders for editing on your host machine.
+If you're happy to develop on a virtual machine, the `vagrant-wagtail-develop <https://github.com/wagtail/vagrant-wagtail-develop>`_ setup script is the fastest way to get up and running. This will provide you with a running instance of the `Wagtail Bakery demo site <https://github.com/wagtail/bakerydemo/>`_, with the Wagtail and bakerydemo codebases available as shared folders for editing on your host machine.
 
 (Build scripts for other platforms would be very much welcomed - if you create one, please let us know via the `Wagtail Developers group <https://groups.google.com/forum/#!forum/wagtail-developers>`_!)
 
@@ -51,7 +51,7 @@ Compile the assets:
 
     $ npm run build
 
-Any Wagtail sites you start up in this virtualenv will now run against this development instance of Wagtail. We recommend using the `Wagtail demo site <https://github.com/wagtail/wagtaildemo/>`_ as a basis for developing Wagtail.
+Any Wagtail sites you start up in this virtualenv will now run against this development instance of Wagtail. We recommend using the `Wagtail Bakery demo site <https://github.com/wagtail/bakerydemo/>`_ as a basis for developing Wagtail.
 
 .. _testing:
 

--- a/docs/getting_started/demo_site.rst
+++ b/docs/getting_started/demo_site.rst
@@ -3,6 +3,6 @@ Demo site
 =========
 
 
-To create a new site on Wagtail we recommend the ``wagtail start`` command in :doc:`index`, however a demo site exists containing example page types and models. We also recommend you use the demo site for testing during development of Wagtail itself.
+To create a new site on Wagtail we recommend the ``wagtail start`` command in :doc:`index`; however, a demo site, The Wagtail Bakery, exists containing example page types and models. We also recommend you use the demo site for testing during development of Wagtail itself.
 
-The repo and installation instructions can be found here: `https://github.com/wagtail/wagtaildemo <https://github.com/wagtail/wagtaildemo>`_
+The repo and installation instructions can be found here: `https://github.com/wagtail/bakerydemo <https://github.com/wagtail/bakerydemo>`_

--- a/docs/topics/snippets.rst
+++ b/docs/topics/snippets.rst
@@ -11,7 +11,7 @@ Snippets lack many of the features of pages, such as being orderable in the Wagt
 Snippet Models
 --------------
 
-Here's an example snippet from the Wagtail demo website:
+Here's an example snippet model:
 
 .. code-block:: python
 
@@ -46,14 +46,14 @@ Including Snippets in Template Tags
 
 The simplest way to make your snippets available to templates is with a template tag. This is mostly done with vanilla Django, so perhaps reviewing Django's documentation for `django custom template tags`_ will be more helpful. We'll go over the basics, though, and point out any considerations to make for Wagtail.
 
-First, add a new python file to a ``templatetags`` folder within your app. The demo website, for instance uses the path ``wagtaildemo/demo/templatetags/demo_tags.py``. We'll need to load some Django modules and our app's models, and ready the ``register`` decorator:
+First, add a new python file to a ``templatetags`` folder within your app - for example, ``myproject/demo/templatetags/demo_tags.py``. We'll need to load some Django modules and our app's models, and ready the ``register`` decorator:
 
 .. _django custom template tags: https://docs.djangoproject.com/en/dev/howto/custom-template-tags/
 
 .. code-block:: python
 
   from django import template
-  from demo.models import *
+  from demo.models import Advert
 
   register = template.Library()
 


### PR DESCRIPTION
bakerydemo is now our preferred demo site and the one which will be updated for Wagtail 2.x / Django 2.x.