### PR TITLE
Custom fields on custom Document models now appear on multi-upload form.

### DIFF
--- a/wagtail/wagtaildocs/forms.py
+++ b/wagtail/wagtaildocs/forms.py
@@ -38,7 +38,7 @@ def get_document_multi_form(model):
     return modelform_factory(
         model,
         form=BaseDocumentForm,
-        fields=['title', 'collection', 'tags'],
+        fields=[field for field in model.admin_form_fields if field != 'file'],
         widgets={
             'tags': widgets.AdminTagWidget,
             'file': forms.FileInput()


### PR DESCRIPTION
As I mentioned in #3921, the original function using a fixed set of field names means that no matter what you set on `CustomDocument.admin_form_fields`, you'll never see your additions in the multi-upload form (the one at /admin/documents/multiple/add/). This change fixes that problem.