### PR TITLE
Remove Django <1.11 fallback code

### DIFF
--- a/docs/advanced_topics/customisation/admin_templates.rst
+++ b/docs/advanced_topics/customisation/admin_templates.rst
@@ -4,9 +4,6 @@ Customising admin templates
 
 In your projects with Wagtail, you may wish to replace elements such as the Wagtail logo within the admin interface with your own branding. This can be done through Django's template inheritance mechanism.
 
-.. note::
-   Using ``{% extends %}`` in this way on a template you're currently overriding is only supported in Django 1.9 and above. On Django 1.8, you will need to use `django-overextends <https://github.com/stephenmcd/django-overextends>`_ instead.
-
 You need to create a ``templates/wagtailadmin/`` folder within one of your apps - this may be an existing one, or a new one created for this purpose, for example, ``dashboard``. This app must be registered in ``INSTALLED_APPS`` before ``wagtail.wagtailadmin``:
 
 .. code-block:: python

--- a/docs/advanced_topics/customisation/custom_user_models.rst
+++ b/docs/advanced_topics/customisation/custom_user_models.rst
@@ -59,9 +59,6 @@ Template create.html:
       {% include "wagtailadmin/shared/field_as_li.html" with field=form.status %}
   {% endblock extra_fields %}
 
-.. note::
-   Using ``{% extends %}`` in this way on a template you're currently overriding is only supported in Django 1.9 and above. On Django 1.8, you will need to use `django-overextends <https://github.com/stephenmcd/django-overextends>`_ instead.
-
 Template edit.html:
 
 .. code-block:: html+django

--- a/docs/advanced_topics/jinja2.rst
+++ b/docs/advanced_topics/jinja2.rst
@@ -13,7 +13,7 @@ Configuring Django
 
     Jinja2 tags were moved from "templatetags" into "jinja2tags" to separate them from Django template tags.
 
-Django needs to be configured to support Jinja2 templates. As the Wagtail admin is written using regular Django templates, Django has to be configured to use both templating engines. Wagtail supports the Jinja2 backend that ships with Django 1.8 and above. Add the following configuration to the ``TEMPLATES`` setting for your app:
+Django needs to be configured to support Jinja2 templates. As the Wagtail admin is written using regular Django templates, Django has to be configured to use both templating engines. Add the following configuration to the ``TEMPLATES`` setting for your app:
 
 .. code-block:: python
 

--- a/docs/advanced_topics/settings.rst
+++ b/docs/advanced_topics/settings.rst
@@ -345,7 +345,7 @@ Unicode Page Slugs
 
   WAGTAIL_ALLOW_UNICODE_SLUGS = True
 
-By default, page slugs can contain any alphanumeric characters, including non-Latin alphabets (except on Django 1.8, where only ASCII characters are supported). Set this to False to limit slugs to ASCII characters.
+By default, page slugs can contain any alphanumeric characters, including non-Latin alphabets. Set this to False to limit slugs to ASCII characters.
 
 .. _WAGTAIL_AUTO_UPDATE_PREVIEW:
 

--- a/docs/getting_started/integrating_into_django.rst
+++ b/docs/getting_started/integrating_into_django.rst
@@ -5,7 +5,7 @@ Integrating Wagtail into a Django project
 
 Wagtail provides the ``wagtail start`` command and project template to get you started with a new Wagtail project as quickly as possible, but it's easy to integrate Wagtail into an existing Django project too.
 
-Wagtail is currently compatible with Django 1.8, 1.10 and 1.11. First, install the ``wagtail`` package from PyPI:
+Wagtail is currently compatible with Django 1.11. First, install the ``wagtail`` package from PyPI:
 
 .. code-block:: console
 

--- a/docs/reference/contrib/postgres_search.rst
+++ b/docs/reference/contrib/postgres_search.rst
@@ -9,7 +9,6 @@ This contrib module provides a search engine backend for Wagtail using
 
 .. warning::
 
-    | You need to use Django 1.10 or more to be able to use this backend.
     | You can only use this module to index data from a PostgreSQL database.
 
 **Features**:

--- a/wagtail/utils/urlpatterns.py
+++ b/wagtail/utils/urlpatterns.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import, unicode_literals
 from functools import update_wrapper
-from django import VERSION as DJANGO_VERSION
 
 
 def decorate_urlpatterns(urlpatterns, decorator):
@@ -11,25 +10,7 @@ def decorate_urlpatterns(urlpatterns, decorator):
             # contained in it
             decorate_urlpatterns(pattern.url_patterns, decorator)
 
-        if DJANGO_VERSION < (1, 10):
-            # Prior to Django 1.10, RegexURLPattern accepted both strings and callables as
-            # the callback parameter; `callback` is a property that consistently returns it as
-            # a callable.
-            #
-            # * if RegexURLPattern was given a string, _callback will be None, and will be
-            #   populated on the first call to the `callback` property
-            # * if RegexURLPattern was given a callable, _callback will be set to that callable,
-            #   and the `callback` property will return it
-            #
-            # In either case, we wrap the result of `callback` and write it back to `_callback`,
-            # so that future calls to `callback` will return our wrapped version.
-
-            if hasattr(pattern, '_callback'):
-                pattern._callback = update_wrapper(decorator(pattern.callback), pattern.callback)
-        else:
-            # In Django 1.10 and above, RegexURLPattern only accepts a callable as the callback
-            # parameter; this is directly accessible as the `callback` attribute.
-            if getattr(pattern, 'callback', None):
-                pattern.callback = update_wrapper(decorator(pattern.callback), pattern.callback)
+        if getattr(pattern, 'callback', None):
+            pattern.callback = update_wrapper(decorator(pattern.callback), pattern.callback)
 
     return urlpatterns

--- a/wagtail/wagtailadmin/tests/test_pages_views.py
+++ b/wagtail/wagtailadmin/tests/test_pages_views.py
@@ -1161,14 +1161,7 @@ class TestPageEdit(TestCase, WagtailTestUtils):
         # Check the new file exists
         file_page = FilePage.objects.get()
 
-        # In Django < 1.10 the file_field.name starts with ./ whereas in 1.10 it is the basename;
-        # we test against os.path.basename(file_page.file_field.name) so that both possibilities
-        # are handled. os.path.basename can be removed when support for Django <= 1.9 is dropped.
-
-        # (hello, future person grepping for the string `if DJANGO_VERSION < (1, 10)`)
-
-        self.assertEqual(os.path.basename(file_page.file_field.name),
-                         os.path.basename(file_upload.name))
+        self.assertEqual(file_page.file_field.name, file_upload.name)
         self.assertTrue(os.path.exists(file_page.file_field.path))
         self.assertEqual(file_page.file_field.read(), b"A new file")
 
@@ -1196,16 +1189,9 @@ class TestPageEdit(TestCase, WagtailTestUtils):
         # Publish the draft just created
         FilePage.objects.get().get_latest_revision().publish()
 
-        # In Django < 1.10 the file_field.name starts with ./ whereas in 1.10 it is the basename;
-        # we test against os.path.basename(file_page.file_field.name) so that both possibilities
-        # are handled. os.path.basename can be removed when support for Django <= 1.9 is dropped.
-
-        # (hello, future person grepping for the string `if DJANGO_VERSION < (1, 10)`)
-
         # Get the file page, check the file is set
         file_page = FilePage.objects.get()
-        self.assertEqual(os.path.basename(file_page.file_field.name),
-                         os.path.basename(file_upload.name))
+        self.assertEqual(file_page.file_field.name, file_upload.name)
         self.assertTrue(os.path.exists(file_page.file_field.path))
         self.assertEqual(file_page.file_field.read(), b"A new file")
 

--- a/wagtail/wagtailadmin/tests/test_pages_views.py
+++ b/wagtail/wagtailadmin/tests/test_pages_views.py
@@ -3957,11 +3957,9 @@ class TestRecentEditsPanel(TestCase, WagtailTestUtils):
 
 class TestIssue2994(TestCase, WagtailTestUtils):
     """
-    When submitting the add/edit page form, Django 1.10.1 fails to update StreamFields
-    that have a default value, because it notices the lack of postdata field
-    with a name exactly matching the field name and wrongly assumes that the field has
-    been omitted from the form. To avoid this in Django 1.10.1, we need to set
-    dont_use_model_field_default_for_empty_data=True on the widget; in Django >=1.10.2,
+    In contrast to most "standard" form fields, StreamField form widgets generally won't
+    provide a postdata field with a name exactly matching the field name. To prevent Django
+    from wrongly interpreting this as the field being omitted from the form,
     we need to provide a custom value_omitted_from_data method.
     """
     def setUp(self):

--- a/wagtail/wagtailcore/blocks/base.py
+++ b/wagtail/wagtailcore/blocks/base.py
@@ -487,11 +487,6 @@ class DeclarativeSubBlocksMetaclass(BaseBlock):
 class BlockWidget(forms.Widget):
     """Wraps a block object as a widget so that it can be incorporated into a Django form"""
 
-    # Flag used by Django 1.10.1 (only) to indicate that this widget will not necessarily submit
-    # a postdata item with a name that matches the field name -
-    # see https://github.com/django/django/pull/7068, https://github.com/wagtail/wagtail/issues/2994
-    dont_use_model_field_default_for_empty_data = True
-
     def __init__(self, block_def, attrs=None):
         super(BlockWidget, self).__init__(attrs=attrs)
         self.block_def = block_def

--- a/wagtail/wagtailcore/migrations/0001_squashed_0016_change_page_url_path_to_text_field.py
+++ b/wagtail/wagtailcore/migrations/0001_squashed_0016_change_page_url_path_to_text_field.py
@@ -2,7 +2,6 @@
 from __future__ import unicode_literals
 
 import django.db.models.deletion
-from django import VERSION as DJANGO_VERSION
 from django.conf import settings
 from django.db import migrations, models
 
@@ -19,8 +18,7 @@ def initial_data(apps, schema_editor):
     # Create page content type
     page_content_type, created = ContentType.objects.get_or_create(
         model='page',
-        app_label='wagtailcore',
-        defaults={'name': 'page'} if DJANGO_VERSION < (1, 8) else {}
+        app_label='wagtailcore'
     )
 
     # Create root page

--- a/wagtail/wagtailcore/migrations/0002_initial_data.py
+++ b/wagtail/wagtailcore/migrations/0002_initial_data.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from django import VERSION as DJANGO_VERSION
 from django.db import migrations
 
 
@@ -15,8 +14,7 @@ def initial_data(apps, schema_editor):
     # Create page content type
     page_content_type, created = ContentType.objects.get_or_create(
         model='page',
-        app_label='wagtailcore',
-        defaults={'name': 'page'} if DJANGO_VERSION < (1, 8) else {}
+        app_label='wagtailcore'
     )
 
     # Create root page

--- a/wagtail/wagtailcore/migrations/0029_unicode_slugfield_dj19.py
+++ b/wagtail/wagtailcore/migrations/0029_unicode_slugfield_dj19.py
@@ -3,7 +3,6 @@
 from __future__ import unicode_literals
 
 from django.db import migrations, models
-from django import VERSION as DJANGO_VERSION
 
 
 class Migration(migrations.Migration):
@@ -12,12 +11,10 @@ class Migration(migrations.Migration):
         ('wagtailcore', '0028_merge'),
     ]
 
-    operations = []
-    if DJANGO_VERSION >= (1, 9):
-        operations += [
-            migrations.AlterField(
-                model_name='page',
-                name='slug',
-                field=models.SlugField(allow_unicode=True, help_text='The name of the page as it will appear in URLs e.g http://domain.com/blog/[my-slug]/', max_length=255, verbose_name='slug'),
-            ),
-        ]
+    operations = [
+        migrations.AlterField(
+            model_name='page',
+            name='slug',
+            field=models.SlugField(allow_unicode=True, help_text='The name of the page as it will appear in URLs e.g http://domain.com/blog/[my-slug]/', max_length=255, verbose_name='slug'),
+        ),
+    ]

--- a/wagtail/wagtailcore/query.py
+++ b/wagtail/wagtailcore/query.py
@@ -3,11 +3,11 @@ from __future__ import absolute_import, unicode_literals
 import posixpath
 from collections import defaultdict
 
-from django import VERSION as DJANGO_VERSION
 from django.apps import apps
 from django.contrib.contenttypes.models import ContentType
 from django.db.models import CharField, Q
 from django.db.models.functions import Length, Substr
+from django.db.models.query import BaseIterable
 from treebeard.mp_tree import MP_NodeQuerySet
 
 from wagtail.wagtailsearch.queryset import SearchableQuerySetMixin
@@ -343,12 +343,9 @@ class PageQuerySet(SearchableQuerySetMixin, TreeQuerySet):
         This efficiently gets all the specific pages for the queryset, using
         the minimum number of queries.
         """
-        if DJANGO_VERSION >= (1, 9):
-            clone = self._clone()
-            clone._iterable_class = SpecificIterable
-            return clone
-        else:
-            return self._clone(klass=SpecificQuerySet)
+        clone = self._clone()
+        clone._iterable_class = SpecificIterable
+        return clone
 
     def in_site(self, site):
         """
@@ -387,17 +384,6 @@ def specific_iterator(qs):
         yield pages_by_type[content_type][pk]
 
 
-# Django 1.9 changed how extending QuerySets with different iterators behaved
-# considerably, in a way that is not easily compatible between the two versions
-if DJANGO_VERSION >= (1, 9):
-    from django.db.models.query import BaseIterable
-
-    class SpecificIterable(BaseIterable):
-        def __iter__(self):
-            return specific_iterator(self.queryset)
-
-else:
-    from django.db.models.query import QuerySet
-
-    class SpecificQuerySet(QuerySet):
-        iterator = specific_iterator
+class SpecificIterable(BaseIterable):
+    def __iter__(self):
+        return specific_iterator(self.queryset)

--- a/wagtail/wagtaildocs/migrations/0002_initial_data.py
+++ b/wagtail/wagtaildocs/migrations/0002_initial_data.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from django import VERSION as DJANGO_VERSION
 from django.db import migrations
 
 
@@ -13,8 +12,7 @@ def add_document_permissions_to_admin_groups(apps, schema_editor):
     # Get document permissions
     document_content_type, _created = ContentType.objects.get_or_create(
         model='document',
-        app_label='wagtaildocs',
-        defaults={'name': 'document'} if DJANGO_VERSION < (1, 8) else {}
+        app_label='wagtaildocs'
     )
 
     add_document_permission, _created = Permission.objects.get_or_create(

--- a/wagtail/wagtaildocs/signal_handlers.py
+++ b/wagtail/wagtaildocs/signal_handlers.py
@@ -1,24 +1,14 @@
 from __future__ import absolute_import, unicode_literals
 
-from django import VERSION as DJANGO_VERSION
 from django.db import transaction
 from django.db.models.signals import post_delete
 
 from wagtail.wagtaildocs.models import get_document_model
 
 
-TRANSACTION_ON_COMMIT_AVAILABLE = (1, 8) < DJANGO_VERSION[:2]
-if TRANSACTION_ON_COMMIT_AVAILABLE:
-    def on_commit_handler(f):
-        return transaction.on_commit(f)
-else:
-    def on_commit_handler(f):
-        return f()
-
-
 def post_delete_file_cleanup(instance, **kwargs):
     # Pass false so FileField doesn't save the model.
-    on_commit_handler(lambda: instance.file.delete(False))
+    transaction.on_commit(lambda: instance.file.delete(False))
 
 
 def register_signal_handlers():

--- a/wagtail/wagtaildocs/tests/test_models.py
+++ b/wagtail/wagtaildocs/tests/test_models.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, unicode_literals
 
-import unittest
-
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group, Permission
 from django.core.files.base import ContentFile
@@ -131,29 +129,12 @@ class TestFilesDeletedForDefaultModels(TransactionTestCase):
             numchild=0,
         )
 
-    def test_oncommit_available(self):
-        self.assertEqual(hasattr(transaction, 'on_commit'), signal_handlers.TRANSACTION_ON_COMMIT_AVAILABLE)
-
-    @unittest.skipUnless(signal_handlers.TRANSACTION_ON_COMMIT_AVAILABLE, 'is required for this test')
     def test_document_file_deleted_oncommit(self):
         with transaction.atomic():
             document = get_document_model().objects.create(title="Test Image", file=get_test_image_file())
             self.assertTrue(document.file.storage.exists(document.file.name))
             document.delete()
             self.assertTrue(document.file.storage.exists(document.file.name))
-        self.assertFalse(document.file.storage.exists(document.file.name))
-
-    @unittest.skipIf(signal_handlers.TRANSACTION_ON_COMMIT_AVAILABLE, 'duplicate')
-    def test_document_file_deleted(self):
-        '''
-            this test duplicates `test_image_file_deleted_oncommit` for
-            django 1.8 support and can be removed once django 1.8 is no longer
-            supported
-        '''
-        with transaction.atomic():
-            document = get_document_model().objects.create(title="Test Image", file=get_test_image_file())
-            self.assertTrue(document.file.storage.exists(document.file.name))
-            document.delete()
         self.assertFalse(document.file.storage.exists(document.file.name))
 
 

--- a/wagtail/wagtailimages/fields.py
+++ b/wagtail/wagtailimages/fields.py
@@ -7,7 +7,6 @@ from django.core.exceptions import ValidationError
 from django.forms.fields import ImageField
 from django.template.defaultfilters import filesizeformat
 from django.utils.translation import ugettext_lazy as _
-from PIL import Image
 
 ALLOWED_EXTENSIONS = ['gif', 'jpg', 'jpeg', 'png']
 SUPPORTED_FORMATS_TEXT = _("GIF, JPEG, PNG")
@@ -60,31 +59,11 @@ class WagtailImageField(ImageField):
         if extension not in ALLOWED_EXTENSIONS:
             raise ValidationError(self.error_messages['invalid_image'], code='invalid_image')
 
-        if hasattr(f, 'image'):
-            # Django 1.8 annotates the file object with the PIL image
-            image = f.image
-        elif not f.closed:
-            # Open image file
-            file_position = f.tell()
-            f.seek(0)
-
-            try:
-                image = Image.open(f)
-            except IOError:
-                # Uploaded file is not even an image file (or corrupted)
-                raise ValidationError(self.error_messages['invalid_image_known_format'],
-                                      code='invalid_image_known_format')
-
-            f.seek(file_position)
-        else:
-            # Couldn't get the PIL image, skip checking the internal file format
-            return
-
         image_format = extension.upper()
         if image_format == 'JPG':
             image_format = 'JPEG'
 
-        internal_image_format = image.format.upper()
+        internal_image_format = f.image.format.upper()
         if internal_image_format == 'MPO':
             internal_image_format = 'JPEG'
 

--- a/wagtail/wagtailimages/migrations/0002_initial_data.py
+++ b/wagtail/wagtailimages/migrations/0002_initial_data.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from django import VERSION as DJANGO_VERSION
 from django.db import migrations
 
 
@@ -13,8 +12,7 @@ def add_image_permissions_to_admin_groups(apps, schema_editor):
     # Get image permissions
     image_content_type, _created = ContentType.objects.get_or_create(
         model='image',
-        app_label='wagtailimages',
-        defaults={'name': 'image'} if DJANGO_VERSION < (1, 8) else {}
+        app_label='wagtailimages'
     )
 
     add_image_permission, _created = Permission.objects.get_or_create(

--- a/wagtail/wagtailimages/signal_handlers.py
+++ b/wagtail/wagtailimages/signal_handlers.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import, unicode_literals
 
-from django import VERSION as DJANGO_VERSION
 from django.conf import settings
 from django.db import transaction
 from django.db.models.signals import post_delete, pre_save
@@ -8,18 +7,9 @@ from django.db.models.signals import post_delete, pre_save
 from wagtail.wagtailimages import get_image_model
 
 
-TRANSACTION_ON_COMMIT_AVAILABLE = (1, 8) < DJANGO_VERSION[:2]
-if TRANSACTION_ON_COMMIT_AVAILABLE:
-    def on_commit_handler(f):
-        return transaction.on_commit(f)
-else:
-    def on_commit_handler(f):
-        return f()
-
-
 def post_delete_file_cleanup(instance, **kwargs):
     # Pass false so FileField doesn't save the model.
-    on_commit_handler(lambda: instance.file.delete(False))
+    transaction.on_commit(lambda: instance.file.delete(False))
 
 
 def pre_save_image_feature_detection(instance, **kwargs):

--- a/wagtail/wagtailimages/tests/test_admin_views.py
+++ b/wagtail/wagtailimages/tests/test_admin_views.py
@@ -17,7 +17,6 @@ from wagtail.wagtailimages.views.serve import generate_signature
 from .utils import Image, get_test_image_file
 
 # Get the chars that Django considers safe to leave unescaped in a URL
-# This list changed in Django 1.8:  https://github.com/django/django/commit/e167e96cfea670422ca75d0b35fe7c4195f25b63
 urlquote_safechars = RFC3986_SUBDELIMS + str('/~:@')
 
 

--- a/wagtail/wagtailimages/tests/test_signal_handlers.py
+++ b/wagtail/wagtailimages/tests/test_signal_handlers.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, unicode_literals
 
-import unittest
-
 from django.db import transaction
 from django.test import TransactionTestCase, override_settings
 
@@ -36,10 +34,6 @@ class TestFilesDeletedForDefaultModels(TransactionTestCase):
             numchild=0,
         )
 
-    def test_oncommit_available(self):
-        self.assertEqual(hasattr(transaction, 'on_commit'), signal_handlers.TRANSACTION_ON_COMMIT_AVAILABLE)
-
-    @unittest.skipUnless(signal_handlers.TRANSACTION_ON_COMMIT_AVAILABLE, 'is required for this test')
     def test_image_file_deleted_oncommit(self):
         with transaction.atomic():
             image = get_image_model().objects.create(title="Test Image", file=get_test_image_file())
@@ -48,20 +42,6 @@ class TestFilesDeletedForDefaultModels(TransactionTestCase):
             self.assertTrue(image.file.storage.exists(image.file.name))
         self.assertFalse(image.file.storage.exists(image.file.name))
 
-    @unittest.skipIf(signal_handlers.TRANSACTION_ON_COMMIT_AVAILABLE, 'duplicate')
-    def test_image_file_deleted(self):
-        '''
-            this test duplicates `test_image_file_deleted_oncommit` for
-            django 1.8 support and can be removed once django 1.8 is no longer
-            supported
-        '''
-        with transaction.atomic():
-            image = get_image_model().objects.create(title="Test Image", file=get_test_image_file())
-            self.assertTrue(image.file.storage.exists(image.file.name))
-            image.delete()
-        self.assertFalse(image.file.storage.exists(image.file.name))
-
-    @unittest.skipUnless(signal_handlers.TRANSACTION_ON_COMMIT_AVAILABLE, 'is required for this test')
     def test_rendition_file_deleted_oncommit(self):
         with transaction.atomic():
             image = get_image_model().objects.create(title="Test Image", file=get_test_image_file())
@@ -69,20 +49,6 @@ class TestFilesDeletedForDefaultModels(TransactionTestCase):
             self.assertTrue(rendition.file.storage.exists(rendition.file.name))
             rendition.delete()
             self.assertTrue(rendition.file.storage.exists(rendition.file.name))
-        self.assertFalse(rendition.file.storage.exists(rendition.file.name))
-
-    @unittest.skipIf(signal_handlers.TRANSACTION_ON_COMMIT_AVAILABLE, 'duplicate')
-    def test_rendition_file_deleted(self):
-        '''
-            this test duplicates `test_rendition_file_deleted_oncommit` for
-            django 1.8 support and can be removed once django 1.8 is no longer
-            supported
-        '''
-        with transaction.atomic():
-            image = get_image_model().objects.create(title="Test Image", file=get_test_image_file())
-            rendition = image.get_rendition('original')
-            self.assertTrue(rendition.file.storage.exists(rendition.file.name))
-            rendition.delete()
         self.assertFalse(rendition.file.storage.exists(rendition.file.name))
 
 


### PR DESCRIPTION
Remove all remaining fallback code and documentation for Django <1.11 that could be found by grepping for `VERSION`, `Django 1.8`, `Django 1.9` and `Django 1.10`.