### PR TITLE
Fixes form submissions pagination

### DIFF
--- a/wagtail/wagtailforms/templates/wagtailforms/index_submissions.html
+++ b/wagtail/wagtailforms/templates/wagtailforms/index_submissions.html
@@ -115,7 +115,7 @@
             <form action="{% url 'wagtailforms:delete_submissions' form_page.id %}" method="get">
                 {% include "wagtailforms/list_submissions.html" %}
 
-                {% include "wagtailadmin/shared/pagination_nav.html" with items=submissions is_searching=False linkurl='-' %}
+                {% include "wagtailadmin/shared/pagination_nav.html" with items=submissions is_searching=False %}
                 {# Here we pass an invalid non-empty URL name as linkurl to generate pagination links with the URL path omitted #}
             </form>
         {% else %}


### PR DESCRIPTION
With this weird `linkurl='-'` argument, the pagination drops the active date filters.
Removing this argument fixes pagination with date filters.

I’m not sure why this argument was introduced, but I guess it could be removed everywhere else, at least when it has the `'-'` value.