### PR TITLE
Postgres_search simplification.

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -33,7 +33,7 @@ def pytest_configure(config):
         pass
 
     if config.getoption('postgres'):
-        os.environ['DATABASE_ENGINE'] = 'django.db.backends.postgresql_psycopg2'
+        os.environ['DATABASE_ENGINE'] = 'django.db.backends.postgresql'
 
     # Setup django after processing the pytest arguments so that the env
     # variables are available in the settings

--- a/docs/advanced_topics/settings.rst
+++ b/docs/advanced_topics/settings.rst
@@ -558,7 +558,7 @@ These two files should reside in your project directory (``myproject/myproject/`
 
   DATABASES = {
       'default': {
-          'ENGINE': 'django.db.backends.postgresql_psycopg2',
+          'ENGINE': 'django.db.backends.postgresql',
           'NAME': 'myprojectdb',
           'USER': 'postgres',
           'PASSWORD': '',

--- a/runtests.py
+++ b/runtests.py
@@ -47,7 +47,7 @@ def runtests():
         pass
 
     if args.postgres:
-        os.environ['DATABASE_ENGINE'] = 'django.db.backends.postgresql_psycopg2'
+        os.environ['DATABASE_ENGINE'] = 'django.db.backends.postgresql'
 
     if args.elasticsearch:
         os.environ.setdefault('ELASTICSEARCH_URL', 'http://localhost:9200')

--- a/wagtail/contrib/postgres_search/backend.py
+++ b/wagtail/contrib/postgres_search/backend.py
@@ -168,10 +168,10 @@ class Index(object):
             obj._object_id = force_text(obj.pk)
             obj._body_ = self.prepare_body(obj)
         connection = connections[self.db_alias]
-        # if connection.pg_version >= 90500:  # PostgreSQL >= 9.5
-        #     self.add_items_upsert(connection, content_type_pk, objs, config)
-        # else:
-        self.add_items_update_then_create(content_type_pk, objs, config)
+        if connection.pg_version >= 90500:  # PostgreSQL >= 9.5
+            self.add_items_upsert(connection, content_type_pk, objs, config)
+        else:
+            self.add_items_update_then_create(content_type_pk, objs, config)
 
     def __str__(self):
         return self.name
@@ -331,7 +331,7 @@ class PostgresSearchBackend(BaseSearchBackend):
             self.get_index_for_object(obj_list[0]).add_items(model, obj_list)
 
     def delete(self, obj):
-        obj.index_entries.delete()
+        obj.index_entries.all().delete()
 
 
 SearchBackend = PostgresSearchBackend

--- a/wagtail/contrib/postgres_search/backend.py
+++ b/wagtail/contrib/postgres_search/backend.py
@@ -16,7 +16,7 @@ from wagtail.wagtailsearch.index import RelatedFields, SearchField
 
 from .models import IndexEntry
 from .utils import (
-    ADD, AND, OR, WEIGHTS_VALUES, get_content_types_pks, get_descendants_content_types_pks,
+    ADD, AND, OR, WEIGHTS_VALUES, get_content_types_pk, get_descendants_content_types_pks,
     get_postgresql_connections, get_weight, keyword_split, unidecode)
 
 
@@ -162,7 +162,7 @@ class Index(object):
         index_entries.bulk_create(to_be_created)
 
     def add_items(self, model, objs):
-        content_type_pk = get_content_types_pks(model)
+        content_type_pk = get_content_types_pk(model)
         config = self.get_config()
         for obj in objs:
             obj._object_id = force_text(obj.pk)

--- a/wagtail/contrib/postgres_search/backend.py
+++ b/wagtail/contrib/postgres_search/backend.py
@@ -212,11 +212,11 @@ class PostgresSearchQuery(BaseSearchQuery):
             queryset = queryset.annotate(
                 _rank_=SearchRank(F('_search_'), search_query,
                                   weights=WEIGHTS_VALUES)
-            ).order_by('-_rank_')
+            ).order_by('-_rank_', '-pk')
+        elif not queryset.query.order_by:
+            # Adds a default ordering to avoid issue #3729.
+            queryset = queryset.order_by('-pk')
         return queryset[start:stop]
-
-    def search_count(self, config):
-        return self.search(config, None, None).count()
 
 
 class PostgresSearchResults(BaseSearchResults):
@@ -230,7 +230,7 @@ class PostgresSearchResults(BaseSearchResults):
                                       self.start, self.stop))
 
     def _do_count(self):
-        return self.query.search_count(self.get_config())
+        return self.query.search(self.get_config(), None, None).count()
 
 
 class PostgresSearchRebuilder:

--- a/wagtail/contrib/postgres_search/backend.py
+++ b/wagtail/contrib/postgres_search/backend.py
@@ -16,8 +16,8 @@ from wagtail.wagtailsearch.index import RelatedFields, SearchField
 
 from .models import IndexEntry
 from .utils import (
-    ADD, AND, OR, WEIGHTS_VALUES, get_content_types_pks, get_postgresql_connections, get_weight,
-    keyword_split, unidecode, get_descendants_content_types_pks)
+    ADD, AND, OR, WEIGHTS_VALUES, get_content_types_pks, get_descendants_content_types_pks,
+    get_postgresql_connections, get_weight, keyword_split, unidecode)
 
 
 # TODO: Add autocomplete.

--- a/wagtail/contrib/postgres_search/backend.py
+++ b/wagtail/contrib/postgres_search/backend.py
@@ -168,10 +168,10 @@ class Index(object):
             obj._object_id = force_text(obj.pk)
             obj._body_ = self.prepare_body(obj)
         connection = connections[self.db_alias]
-        if connection.pg_version >= 90500:  # PostgreSQL >= 9.5
-            self.add_items_upsert(connection, content_type_pk, objs, config)
-        else:
-            self.add_items_update_then_create(content_type_pk, objs, config)
+        # if connection.pg_version >= 90500:  # PostgreSQL >= 9.5
+        #     self.add_items_upsert(connection, content_type_pk, objs, config)
+        # else:
+        self.add_items_update_then_create(content_type_pk, objs, config)
 
     def __str__(self):
         return self.name

--- a/wagtail/contrib/postgres_search/backend.py
+++ b/wagtail/contrib/postgres_search/backend.py
@@ -124,9 +124,8 @@ class Index(object):
         ids_and_objs = {}
         for obj in objs:
             obj._search_vector = (
-                ADD([
-                    SearchVector(Value(text), weight=weight, config=config)
-                    for text, weight in obj._body_])
+                ADD([SearchVector(Value(text), weight=weight, config=config)
+                     for text, weight in obj._body_])
                 if obj._body_ else SearchVector(Value('')))
             ids_and_objs[obj._object_id] = obj
         index_entries = IndexEntry._default_manager.using(self.db_alias)

--- a/wagtail/contrib/postgres_search/migrations/0001_initial.py
+++ b/wagtail/contrib/postgres_search/migrations/0001_initial.py
@@ -44,5 +44,11 @@ class Migration(migrations.Migration):
             'CREATE INDEX {0}_body_search ON {0} '
             'USING GIN(body_search);'.format(table),
             'DROP INDEX {}_body_search;'.format(table),
+            state_operations=[migrations.AddIndex(
+                model_name='indexentry',
+                index=django.contrib.postgres.indexes.GinIndex(
+                    fields=['body_search'],
+                    name='postgres_se_body_se_70ba1a_gin'),
+            )],
         ),
     ]

--- a/wagtail/contrib/postgres_search/models.py
+++ b/wagtail/contrib/postgres_search/models.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, unicode_literals
 from django.apps import apps
 from django.contrib.contenttypes.fields import GenericForeignKey, GenericRelation
 from django.contrib.contenttypes.models import ContentType
+from django.contrib.postgres.indexes import GinIndex
 from django.contrib.postgres.search import SearchVectorField
 from django.db.models import CASCADE, ForeignKey, Model, TextField
 from django.db.models.functions import Cast
@@ -53,7 +54,7 @@ class IndexEntry(Model):
         unique_together = ('content_type', 'object_id')
         verbose_name = _('index entry')
         verbose_name_plural = _('index entries')
-        # TODO: Move here the GIN index from the migration.
+        indexes = [GinIndex(['body_search'])]
 
     def __str__(self):
         return '%s: %s' % (self.content_type.name, self.content_object)

--- a/wagtail/contrib/postgres_search/models.py
+++ b/wagtail/contrib/postgres_search/models.py
@@ -4,8 +4,7 @@ from django.apps import apps
 from django.contrib.contenttypes.fields import GenericForeignKey, GenericRelation
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.postgres.search import SearchVectorField
-from django.db.models import (
-    CASCADE, ForeignKey, Model, TextField)
+from django.db.models import CASCADE, ForeignKey, Model, TextField
 from django.db.models.functions import Cast
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _

--- a/wagtail/contrib/postgres_search/models.py
+++ b/wagtail/contrib/postgres_search/models.py
@@ -10,7 +10,7 @@ from django.db.models.functions import Cast
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 
-from ...wagtailsearch.index import Indexed
+from ...wagtailsearch.index import class_is_indexed
 from .utils import get_descendants_content_types_pks
 
 
@@ -66,6 +66,6 @@ class IndexEntry(Model):
     @classmethod
     def add_generic_relations(cls):
         for model in apps.get_models():
-            if issubclass(model, Indexed):
+            if class_is_indexed(model):
                 TextIDGenericRelation(cls).contribute_to_class(model,
                                                                'index_entries')

--- a/wagtail/contrib/postgres_search/models.py
+++ b/wagtail/contrib/postgres_search/models.py
@@ -1,50 +1,43 @@
 from __future__ import absolute_import, unicode_literals
 
-from django.contrib.contenttypes.fields import GenericForeignKey
+from django.apps import apps
+from django.contrib.contenttypes.fields import GenericForeignKey, GenericRelation
 from django.contrib.contenttypes.models import ContentType
-from django.contrib.postgres.search import SearchRank, SearchVectorField
+from django.contrib.postgres.search import SearchVectorField
 from django.db.models import (
-    CASCADE, AutoField, BigAutoField, BigIntegerField, F, ForeignKey, IntegerField, Model, QuerySet,
-    TextField)
+    CASCADE, ForeignKey, Model, TextField)
 from django.db.models.functions import Cast
-from django.utils.encoding import force_text, python_2_unicode_compatible
+from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 
-from .utils import WEIGHTS_VALUES, get_descendants_content_types_pks
+from ...wagtailsearch.index import Indexed
+from .utils import get_descendants_content_types_pks
 
 
-class IndexQuerySet(QuerySet):
-    def for_models(self, *models):
-        if not models:
-            return self.none()
-        return self.filter(
-            content_type_id__in=get_descendants_content_types_pks(models,
-                                                                  self._db))
+class TextIDGenericRelation(GenericRelation):
+    def get_content_type_lookup(self, alias, remote_alias):
+        field = self.remote_field.model._meta.get_field(
+            self.content_type_field_name)
+        return field.get_lookup('in')(
+            field.get_col(remote_alias),
+            get_descendants_content_types_pks(self.model))
 
-    def for_object(self, obj):
-        db_alias = obj._state.db
-        return (self.using(db_alias).for_models(obj._meta.model)
-                .filter(object_id=force_text(obj.pk)))
+    def get_object_id_lookup(self, alias, remote_alias):
+        from_field = self.remote_field.model._meta.get_field(
+            self.object_id_field_name)
+        to_field = self.model._meta.pk
+        return from_field.get_lookup('exact')(
+            from_field.get_col(remote_alias),
+            Cast(to_field.get_col(alias), from_field))
 
-    def add_rank(self, search_query):
-        return self.annotate(
-            rank=SearchRank(
-                F('body_search'), search_query,
-                weights='{' + ','.join(map(str, WEIGHTS_VALUES)) + '}'))
+    def get_extra_restriction(self, where_class, alias, remote_alias):
+        cond = where_class()
+        cond.add(self.get_content_type_lookup(alias, remote_alias), 'AND')
+        cond.add(self.get_object_id_lookup(alias, remote_alias), 'AND')
+        return cond
 
-    def rank(self, search_query):
-        return self.add_rank(search_query).order_by('-rank')
-
-    def annotate_typed_pk(self):
-        cast_field = self.model._meta.pk
-        if isinstance(cast_field, BigAutoField):
-            cast_field = BigIntegerField()
-        elif isinstance(cast_field, AutoField):
-            cast_field = IntegerField()
-        return self.annotate(typed_pk=Cast('object_id', cast_field))
-
-    def pks(self):
-        return self.annotate_typed_pk().values_list('typed_pk', flat=True)
+    def resolve_related_fields(self):
+        return []
 
 
 @python_2_unicode_compatible
@@ -56,8 +49,6 @@ class IndexEntry(Model):
 
     # TODO: Add per-object boosting.
     body_search = SearchVectorField()
-
-    objects = IndexQuerySet.as_manager()
 
     class Meta:
         unique_together = ('content_type', 'object_id')
@@ -71,3 +62,10 @@ class IndexEntry(Model):
     @property
     def model(self):
         return self.content_type.model
+
+    @classmethod
+    def add_generic_relations(cls):
+        for model in apps.get_models():
+            if issubclass(model, Indexed):
+                TextIDGenericRelation(cls).contribute_to_class(model,
+                                                               'index_entries')

--- a/wagtail/contrib/postgres_search/utils.py
+++ b/wagtail/contrib/postgres_search/utils.py
@@ -60,17 +60,16 @@ def get_descendant_models(model):
     return descendant_models
 
 
-def get_descendants_content_types_pks(models, db_alias):
+def get_descendants_content_types_pks(model):
     return get_content_types_pks(
-        tuple(descendant_model for model in models
-              for descendant_model in get_descendant_models(model)), db_alias)
+        tuple(descendant_model
+              for descendant_model in get_descendant_models(model)))
 
 
-def get_content_types_pks(models, db_alias):
+def get_content_types_pks(model):
     # We import it locally because this file is loaded before apps are ready.
     from django.contrib.contenttypes.models import ContentType
-    content_types_dict = ContentType.objects.db_manager(db_alias).get_for_models(*models)
-    return [ct.pk for ct in content_types_dict.values()]
+    return ContentType.objects.get_for_model(model).pk
 
 
 def get_search_fields(search_fields):

--- a/wagtail/contrib/postgres_search/utils.py
+++ b/wagtail/contrib/postgres_search/utils.py
@@ -61,12 +61,13 @@ def get_descendant_models(model):
 
 
 def get_descendants_content_types_pks(model):
-    return get_content_types_pks(
-        tuple(descendant_model
-              for descendant_model in get_descendant_models(model)))
+    from django.contrib.contenttypes.models import ContentType
+    return [ct.pk for ct in
+            ContentType.objects.get_for_models(*get_descendant_models(model))
+            .values()]
 
 
-def get_content_types_pks(model):
+def get_content_types_pk(model):
     # We import it locally because this file is loaded before apps are ready.
     from django.contrib.contenttypes.models import ContentType
     return ContentType.objects.get_for_model(model).pk


### PR DESCRIPTION
The main goal of this work was to find an elegant way to preserves the original queryset order when using `order_by_relevance=False`.

It’s now done, and thanks to this, I could also remove the existing raw `SELECT` queries.
I had to create a related lookup and manager by inheriting from `GenericRelation` as we use a generic foreign key between `IndexEntry` and indexed models. So now, each model inheriting from `Indexed` also gets an `index_entries` manager and the corresponding QuerySet accessor.

There are two reasons why I had to create a custom `GenericRelation`:
- First of all, I faced [a Django issue](https://code.djangoproject.com/ticket/16055) that was preventing the related accessor from working due to our text `object_id`. Unfortunately, due to [these lines](https://github.com/django/django/blob/01d440fa1e6b5c62acfa8b3fde43dfa1505f93c6/django/db/models/sql/datastructures.py#L73-L79) of the ORM, we can’t cast the column of a `JOIN` condition. But luckily, there is just below a nice `get_extra_condition` method used to get an additional `JOIN` condition. This feature is originally used by `GenericRelation` to filter by content type. So I removed the original `JOIN` condition by overriding `resolve_related_fields`, and I put it instead in `get_extra_restriction`.
- I also had to filter by multiple content types instead of just the content type of the model requested. When we do `Page.objects.search('hello')`, we have to search across fields on the `Page` model, but also on those of the children types. So to do that, I created an `IN` lookup to filter content type across all descendant content types instead of just one.