### PR TITLE
Also show link to image usage on confirm_delete page

### DIFF
--- a/docs/advanced_topics/settings.rst
+++ b/docs/advanced_topics/settings.rst
@@ -396,6 +396,8 @@ Usage for images, documents and snippets
 
 When enabled Wagtail shows where a particular image, document or snippet is being used on your site (disabled by default). A link will appear on the edit page showing you which pages they have been used on.
 
+This link is also shown on the delete page, above the "Delete" button.
+
 .. note::
 
     The usage count only applies to direct (database) references. Using documents, images and snippets within StreamFields or rich text fields will not be taken into account.

--- a/wagtail/wagtailadmin/locale/ca/LC_MESSAGES/django.po
+++ b/wagtail/wagtailadmin/locale/ca/LC_MESSAGES/django.po
@@ -1005,10 +1005,10 @@ msgid "Sat"
 msgstr "Ds"
 
 #, python-format
-msgid "Used %(useage_count)s time"
-msgid_plural "Used %(useage_count)s times"
-msgstr[0] "Utilitzat %(useage_count)s vegada"
-msgstr[1] "Utilitzat %(useage_count)s vegades"
+msgid "Used %(usage_count)s time"
+msgid_plural "Used %(usage_count)s times"
+msgstr[0] "Utilitzat %(usage_count)s vegada"
+msgstr[1] "Utilitzat %(usage_count)s vegades"
 
 msgid "Edit your account"
 msgstr "Modifica el teu compte d'usuari"

--- a/wagtail/wagtailadmin/locale/cs/LC_MESSAGES/django.po
+++ b/wagtail/wagtailadmin/locale/cs/LC_MESSAGES/django.po
@@ -694,11 +694,11 @@ msgid "Sat"
 msgstr "so"
 
 #, python-format
-msgid "Used %(useage_count)s time"
-msgid_plural "Used %(useage_count)s times"
-msgstr[0] "Použito %(useage_count)s-krát"
-msgstr[1] "Použito %(useage_count)s-krát"
-msgstr[2] "Použito %(useage_count)s-krát"
+msgid "Used %(usage_count)s time"
+msgid_plural "Used %(usage_count)s times"
+msgstr[0] "Použito %(usage_count)s-krát"
+msgstr[1] "Použito %(usage_count)s-krát"
+msgstr[2] "Použito %(usage_count)s-krát"
 
 msgid "Log out"
 msgstr "Odhlásit"

--- a/wagtail/wagtailadmin/locale/de/LC_MESSAGES/django.po
+++ b/wagtail/wagtailadmin/locale/de/LC_MESSAGES/django.po
@@ -1113,10 +1113,10 @@ msgid "Sat"
 msgstr "Sa"
 
 #, python-format
-msgid "Used %(useage_count)s time"
-msgid_plural "Used %(useage_count)s times"
-msgstr[0] "%(useage_count)s mal benutzt"
-msgstr[1] "%(useage_count)s mal benutzt"
+msgid "Used %(usage_count)s time"
+msgid_plural "Used %(usage_count)s times"
+msgstr[0] "%(usage_count)s mal benutzt"
+msgstr[1] "%(usage_count)s mal benutzt"
 
 msgid "Edit your account"
 msgstr "Bearbeiten Sie Ihr Konto"

--- a/wagtail/wagtailadmin/locale/el/LC_MESSAGES/django.po
+++ b/wagtail/wagtailadmin/locale/el/LC_MESSAGES/django.po
@@ -1006,10 +1006,10 @@ msgid "Sat"
 msgstr "Σαβ"
 
 #, python-format
-msgid "Used %(useage_count)s time"
-msgid_plural "Used %(useage_count)s times"
-msgstr[0] "Χρησιμοποιήθηκε %(useage_count)s φορά"
-msgstr[1] "Χρησιμοποιήθηκε %(useage_count)s φορές"
+msgid "Used %(usage_count)s time"
+msgid_plural "Used %(usage_count)s times"
+msgstr[0] "Χρησιμοποιήθηκε %(usage_count)s φορά"
+msgstr[1] "Χρησιμοποιήθηκε %(usage_count)s φορές"
 
 msgid "Edit your account"
 msgstr "Επεξεργαστείτε το λογαριασμό σας"

--- a/wagtail/wagtailadmin/locale/en/LC_MESSAGES/django.po
+++ b/wagtail/wagtailadmin/locale/en/LC_MESSAGES/django.po
@@ -1357,8 +1357,8 @@ msgstr ""
 
 #: templates/wagtailadmin/shared/header.html:42
 #, python-format
-msgid "Used %(useage_count)s time"
-msgid_plural "Used %(useage_count)s times"
+msgid "Used %(usage_count)s time"
+msgid_plural "Used %(usage_count)s times"
 msgstr[0] ""
 msgstr[1] ""
 

--- a/wagtail/wagtailadmin/locale/es/LC_MESSAGES/django.po
+++ b/wagtail/wagtailadmin/locale/es/LC_MESSAGES/django.po
@@ -1092,10 +1092,10 @@ msgid "Sat"
 msgstr "Sáb"
 
 #, python-format
-msgid "Used %(useage_count)s time"
-msgid_plural "Used %(useage_count)s times"
-msgstr[0] "Utilizado  %(useage_count)s vez"
-msgstr[1] "Utilizado %(useage_count)s veces"
+msgid "Used %(usage_count)s time"
+msgid_plural "Used %(usage_count)s times"
+msgstr[0] "Utilizado  %(usage_count)s vez"
+msgstr[1] "Utilizado %(usage_count)s veces"
 
 msgid "Edit your account"
 msgstr "Editar tu cuenta"

--- a/wagtail/wagtailadmin/locale/fa/LC_MESSAGES/django.po
+++ b/wagtail/wagtailadmin/locale/fa/LC_MESSAGES/django.po
@@ -1015,9 +1015,9 @@ msgid "Sat"
 msgstr "شنبه"
 
 #, python-format
-msgid "Used %(useage_count)s time"
-msgid_plural "Used %(useage_count)s times"
-msgstr[0] "%(useage_count)s بار استفاده شد"
+msgid "Used %(usage_count)s time"
+msgid_plural "Used %(usage_count)s times"
+msgstr[0] "%(usage_count)s بار استفاده شد"
 
 msgid "Edit your account"
 msgstr "ویرایش حساب شما"

--- a/wagtail/wagtailadmin/locale/fi/LC_MESSAGES/django.po
+++ b/wagtail/wagtailadmin/locale/fi/LC_MESSAGES/django.po
@@ -924,10 +924,10 @@ msgid "Sat"
 msgstr "La"
 
 #, python-format
-msgid "Used %(useage_count)s time"
-msgid_plural "Used %(useage_count)s times"
-msgstr[0] "Käytetty %(useage_count)s kerran"
-msgstr[1] "Käytetty %(useage_count)s kertaa"
+msgid "Used %(usage_count)s time"
+msgid_plural "Used %(usage_count)s times"
+msgstr[0] "Käytetty %(usage_count)s kerran"
+msgstr[1] "Käytetty %(usage_count)s kertaa"
 
 msgid "Edit your account"
 msgstr "Muokkaa tiliäsi"

--- a/wagtail/wagtailadmin/locale/fr/LC_MESSAGES/django.po
+++ b/wagtail/wagtailadmin/locale/fr/LC_MESSAGES/django.po
@@ -1082,10 +1082,10 @@ msgid "Sat"
 msgstr "Sam"
 
 #, python-format
-msgid "Used %(useage_count)s time"
-msgid_plural "Used %(useage_count)s times"
-msgstr[0] "Utilisé %(useage_count)s fois"
-msgstr[1] "Utilisé %(useage_count)s fois"
+msgid "Used %(usage_count)s time"
+msgid_plural "Used %(usage_count)s times"
+msgstr[0] "Utilisé %(usage_count)s fois"
+msgstr[1] "Utilisé %(usage_count)s fois"
 
 msgid "Edit your account"
 msgstr "Modifiez votre compte"

--- a/wagtail/wagtailadmin/locale/gl/LC_MESSAGES/django.po
+++ b/wagtail/wagtailadmin/locale/gl/LC_MESSAGES/django.po
@@ -891,10 +891,10 @@ msgid "Sat"
 msgstr "Sa"
 
 #, python-format
-msgid "Used %(useage_count)s time"
-msgid_plural "Used %(useage_count)s times"
-msgstr[0] "Usado %(useage_count)s vez"
-msgstr[1] "Usado %(useage_count)s veces"
+msgid "Used %(usage_count)s time"
+msgid_plural "Used %(usage_count)s times"
+msgstr[0] "Usado %(usage_count)s vez"
+msgstr[1] "Usado %(usage_count)s veces"
 
 msgid "Edit your account"
 msgstr "Editar a túa conta"

--- a/wagtail/wagtailadmin/locale/he_IL/LC_MESSAGES/django.po
+++ b/wagtail/wagtailadmin/locale/he_IL/LC_MESSAGES/django.po
@@ -638,10 +638,10 @@ msgid "Sat"
 msgstr "שבת"
 
 #, python-format
-msgid "Used %(useage_count)s time"
-msgid_plural "Used %(useage_count)s times"
-msgstr[0] "היה בשימוש פעם %(useage_count)s"
-msgstr[1] "היה בשימוש %(useage_count)s פעמים"
+msgid "Used %(usage_count)s time"
+msgid_plural "Used %(usage_count)s times"
+msgstr[0] "היה בשימוש פעם %(usage_count)s"
+msgstr[1] "היה בשימוש %(usage_count)s פעמים"
 
 msgid "Edit your account"
 msgstr "ערכו את חשבונכם"

--- a/wagtail/wagtailadmin/locale/id_ID/LC_MESSAGES/django.po
+++ b/wagtail/wagtailadmin/locale/id_ID/LC_MESSAGES/django.po
@@ -1065,9 +1065,9 @@ msgid "Sat"
 msgstr "Sab"
 
 #, python-format
-msgid "Used %(useage_count)s time"
-msgid_plural "Used %(useage_count)s times"
-msgstr[0] "Digunakan %(useage_count)s kali"
+msgid "Used %(usage_count)s time"
+msgid_plural "Used %(usage_count)s times"
+msgstr[0] "Digunakan %(usage_count)s kali"
 
 msgid "Edit your account"
 msgstr "Ubah akun Anda"

--- a/wagtail/wagtailadmin/locale/is_IS/LC_MESSAGES/django.po
+++ b/wagtail/wagtailadmin/locale/is_IS/LC_MESSAGES/django.po
@@ -1041,10 +1041,10 @@ msgid "Sat"
 msgstr "Lau"
 
 #, python-format
-msgid "Used %(useage_count)s time"
-msgid_plural "Used %(useage_count)s times"
-msgstr[0] "Notað %(useage_count)s sinni"
-msgstr[1] "Notað %(useage_count)s sinnum"
+msgid "Used %(usage_count)s time"
+msgid_plural "Used %(usage_count)s times"
+msgstr[0] "Notað %(usage_count)s sinni"
+msgstr[1] "Notað %(usage_count)s sinnum"
 
 msgid "Edit your account"
 msgstr "Breyta reikningnum þínum"

--- a/wagtail/wagtailadmin/locale/it/LC_MESSAGES/django.po
+++ b/wagtail/wagtailadmin/locale/it/LC_MESSAGES/django.po
@@ -1089,10 +1089,10 @@ msgid "Sat"
 msgstr "Sab"
 
 #, python-format
-msgid "Used %(useage_count)s time"
-msgid_plural "Used %(useage_count)s times"
-msgstr[0] " Usato %(useage_count)s volta"
-msgstr[1] "Usato %(useage_count)s volte"
+msgid "Used %(usage_count)s time"
+msgid_plural "Used %(usage_count)s times"
+msgstr[0] " Usato %(usage_count)s volta"
+msgstr[1] "Usato %(usage_count)s volte"
 
 msgid "Edit your account"
 msgstr "Modifica il tuo account"

--- a/wagtail/wagtailadmin/locale/ja/LC_MESSAGES/django.po
+++ b/wagtail/wagtailadmin/locale/ja/LC_MESSAGES/django.po
@@ -765,9 +765,9 @@ msgid "Sat"
 msgstr "土曜"
 
 #, python-format
-msgid "Used %(useage_count)s time"
-msgid_plural "Used %(useage_count)s times"
-msgstr[0] "%(useage_count)s回使用"
+msgid "Used %(usage_count)s time"
+msgid_plural "Used %(usage_count)s times"
+msgstr[0] "%(usage_count)s回使用"
 
 msgid "Edit your account"
 msgstr "アカウント設定"

--- a/wagtail/wagtailadmin/locale/ko/LC_MESSAGES/django.po
+++ b/wagtail/wagtailadmin/locale/ko/LC_MESSAGES/django.po
@@ -1010,9 +1010,9 @@ msgid "Sat"
 msgstr "토요일"
 
 #, python-format
-msgid "Used %(useage_count)s time"
-msgid_plural "Used %(useage_count)s times"
-msgstr[0] "%(useage_count)s 번 사용"
+msgid "Used %(usage_count)s time"
+msgid_plural "Used %(usage_count)s times"
+msgstr[0] "%(usage_count)s 번 사용"
 
 msgid "Edit your account"
 msgstr "당신의 계정 변경"

--- a/wagtail/wagtailadmin/locale/lt/LC_MESSAGES/django.po
+++ b/wagtail/wagtailadmin/locale/lt/LC_MESSAGES/django.po
@@ -1085,11 +1085,11 @@ msgid "Sat"
 msgstr "Šeš"
 
 #, python-format
-msgid "Used %(useage_count)s time"
-msgid_plural "Used %(useage_count)s times"
-msgstr[0] "Panaudota %(useage_count)s kartą"
-msgstr[1] "Panaudota %(useage_count)s kartus"
-msgstr[2] "Panaudota %(useage_count)s kartų"
+msgid "Used %(usage_count)s time"
+msgid_plural "Used %(usage_count)s times"
+msgstr[0] "Panaudota %(usage_count)s kartą"
+msgstr[1] "Panaudota %(usage_count)s kartus"
+msgstr[2] "Panaudota %(usage_count)s kartų"
 
 msgid "Edit your account"
 msgstr "Redaguoti savo vartotoją"

--- a/wagtail/wagtailadmin/locale/lv/LC_MESSAGES/django.po
+++ b/wagtail/wagtailadmin/locale/lv/LC_MESSAGES/django.po
@@ -691,11 +691,11 @@ msgid "Sat"
 msgstr "S"
 
 #, python-format
-msgid "Used %(useage_count)s time"
-msgid_plural "Used %(useage_count)s times"
-msgstr[0] "Lietots %(useage_count)s reizi"
-msgstr[1] "Lietots %(useage_count)s reizi"
-msgstr[2] "Lietots %(useage_count)s reizes"
+msgid "Used %(usage_count)s time"
+msgid_plural "Used %(usage_count)s times"
+msgstr[0] "Lietots %(usage_count)s reizi"
+msgstr[1] "Lietots %(usage_count)s reizi"
+msgstr[2] "Lietots %(usage_count)s reizes"
 
 msgid "Edit your account"
 msgstr "Mainīt konta iestatījumus"

--- a/wagtail/wagtailadmin/locale/nb/LC_MESSAGES/django.po
+++ b/wagtail/wagtailadmin/locale/nb/LC_MESSAGES/django.po
@@ -1072,10 +1072,10 @@ msgid "Sat"
 msgstr "Lør"
 
 #, python-format
-msgid "Used %(useage_count)s time"
-msgid_plural "Used %(useage_count)s times"
-msgstr[0] "Brukt %(useage_count)s gang"
-msgstr[1] "Brukt %(useage_count)s ganger"
+msgid "Used %(usage_count)s time"
+msgid_plural "Used %(usage_count)s times"
+msgstr[0] "Brukt %(usage_count)s gang"
+msgstr[1] "Brukt %(usage_count)s ganger"
 
 msgid "Edit your account"
 msgstr "Endre din konto"

--- a/wagtail/wagtailadmin/locale/nl/LC_MESSAGES/django.po
+++ b/wagtail/wagtailadmin/locale/nl/LC_MESSAGES/django.po
@@ -797,10 +797,10 @@ msgid "Sat"
 msgstr "Za"
 
 #, python-format
-msgid "Used %(useage_count)s time"
-msgid_plural "Used %(useage_count)s times"
-msgstr[0] "%(useage_count)s keer gebruikt"
-msgstr[1] "%(useage_count)s keer gebruikt"
+msgid "Used %(usage_count)s time"
+msgid_plural "Used %(usage_count)s times"
+msgstr[0] "%(usage_count)s keer gebruikt"
+msgstr[1] "%(usage_count)s keer gebruikt"
 
 msgid "Edit your account"
 msgstr "Bewerk uw account"

--- a/wagtail/wagtailadmin/locale/nl_NL/LC_MESSAGES/django.po
+++ b/wagtail/wagtailadmin/locale/nl_NL/LC_MESSAGES/django.po
@@ -1087,10 +1087,10 @@ msgid "Sat"
 msgstr "Za"
 
 #, python-format
-msgid "Used %(useage_count)s time"
-msgid_plural "Used %(useage_count)s times"
-msgstr[0] "%(useage_count)s keer gebruikt"
-msgstr[1] "%(useage_count)s keer gebruikt"
+msgid "Used %(usage_count)s time"
+msgid_plural "Used %(usage_count)s times"
+msgstr[0] "%(usage_count)s keer gebruikt"
+msgstr[1] "%(usage_count)s keer gebruikt"
 
 msgid "Edit your account"
 msgstr "Wijzig uw account"

--- a/wagtail/wagtailadmin/locale/pl/LC_MESSAGES/django.po
+++ b/wagtail/wagtailadmin/locale/pl/LC_MESSAGES/django.po
@@ -1134,12 +1134,12 @@ msgid "Sat"
 msgstr "Sob"
 
 #, python-format
-msgid "Used %(useage_count)s time"
-msgid_plural "Used %(useage_count)s times"
-msgstr[0] "Użyto %(useage_count)s raz"
-msgstr[1] "Użyto %(useage_count)s razy"
-msgstr[2] "Użyto %(useage_count)s razy"
-msgstr[3] "Użyto %(useage_count)s razy"
+msgid "Used %(usage_count)s time"
+msgid_plural "Used %(usage_count)s times"
+msgstr[0] "Użyto %(usage_count)s raz"
+msgstr[1] "Użyto %(usage_count)s razy"
+msgstr[2] "Użyto %(usage_count)s razy"
+msgstr[3] "Użyto %(usage_count)s razy"
 
 msgid "Edit your account"
 msgstr "Edytuj swoje konto"

--- a/wagtail/wagtailadmin/locale/pt_BR/LC_MESSAGES/django.po
+++ b/wagtail/wagtailadmin/locale/pt_BR/LC_MESSAGES/django.po
@@ -1086,10 +1086,10 @@ msgid "Sat"
 msgstr "Sáb"
 
 #, python-format
-msgid "Used %(useage_count)s time"
-msgid_plural "Used %(useage_count)s times"
-msgstr[0] "Usado %(useage_count)s vez"
-msgstr[1] "Usado %(useage_count)s vezes"
+msgid "Used %(usage_count)s time"
+msgid_plural "Used %(usage_count)s times"
+msgstr[0] "Usado %(usage_count)s vez"
+msgstr[1] "Usado %(usage_count)s vezes"
 
 msgid "Edit your account"
 msgstr "Edite sua conta"

--- a/wagtail/wagtailadmin/locale/pt_PT/LC_MESSAGES/django.po
+++ b/wagtail/wagtailadmin/locale/pt_PT/LC_MESSAGES/django.po
@@ -932,10 +932,10 @@ msgid "Sat"
 msgstr "Sáb"
 
 #, python-format
-msgid "Used %(useage_count)s time"
-msgid_plural "Used %(useage_count)s times"
-msgstr[0] "Usado %(useage_count)s vez"
-msgstr[1] "%(useage_count)s utilizações"
+msgid "Used %(usage_count)s time"
+msgid_plural "Used %(usage_count)s times"
+msgstr[0] "Usado %(usage_count)s vez"
+msgstr[1] "%(usage_count)s utilizações"
 
 msgid "Edit your account"
 msgstr "Alterar a sua conta"

--- a/wagtail/wagtailadmin/locale/ro/LC_MESSAGES/django.po
+++ b/wagtail/wagtailadmin/locale/ro/LC_MESSAGES/django.po
@@ -1101,11 +1101,11 @@ msgid "Sat"
 msgstr "S"
 
 #, python-format
-msgid "Used %(useage_count)s time"
-msgid_plural "Used %(useage_count)s times"
-msgstr[0] "%(useage_count)s utilizăre"
-msgstr[1] "%(useage_count)s utilizări"
-msgstr[2] "%(useage_count)s utilizări"
+msgid "Used %(usage_count)s time"
+msgid_plural "Used %(usage_count)s times"
+msgstr[0] "%(usage_count)s utilizăre"
+msgstr[1] "%(usage_count)s utilizări"
+msgstr[2] "%(usage_count)s utilizări"
 
 msgid "Edit your account"
 msgstr "Editează contul utilizator"

--- a/wagtail/wagtailadmin/locale/ru/LC_MESSAGES/django.po
+++ b/wagtail/wagtailadmin/locale/ru/LC_MESSAGES/django.po
@@ -1162,12 +1162,12 @@ msgid "Sat"
 msgstr "Сб"
 
 #, python-format
-msgid "Used %(useage_count)s time"
-msgid_plural "Used %(useage_count)s times"
-msgstr[0] "Использовано %(useage_count)s раз"
-msgstr[1] "Использовано %(useage_count)s раз"
-msgstr[2] "Использовано %(useage_count)s раз"
-msgstr[3] "Использовано %(useage_count)s раз"
+msgid "Used %(usage_count)s time"
+msgid_plural "Used %(usage_count)s times"
+msgstr[0] "Использовано %(usage_count)s раз"
+msgstr[1] "Использовано %(usage_count)s раз"
+msgstr[2] "Использовано %(usage_count)s раз"
+msgstr[3] "Использовано %(usage_count)s раз"
 
 msgid "Edit your account"
 msgstr "Редактировать ваш аккаунт"

--- a/wagtail/wagtailadmin/locale/sk_SK/LC_MESSAGES/django.po
+++ b/wagtail/wagtailadmin/locale/sk_SK/LC_MESSAGES/django.po
@@ -822,11 +822,11 @@ msgid "Sat"
 msgstr "So"
 
 #, python-format
-msgid "Used %(useage_count)s time"
-msgid_plural "Used %(useage_count)s times"
-msgstr[0] "Použité %(useage_count)s krát"
-msgstr[1] "Použité %(useage_count)s krát"
-msgstr[2] "Použité %(useage_count)s krát"
+msgid "Used %(usage_count)s time"
+msgid_plural "Used %(usage_count)s times"
+msgstr[0] "Použité %(usage_count)s krát"
+msgstr[1] "Použité %(usage_count)s krát"
+msgstr[2] "Použité %(usage_count)s krát"
 
 msgid "Edit your account"
 msgstr "Upraviť váš účet"

--- a/wagtail/wagtailadmin/locale/sl/LC_MESSAGES/django.po
+++ b/wagtail/wagtailadmin/locale/sl/LC_MESSAGES/django.po
@@ -797,12 +797,12 @@ msgid "Sat"
 msgstr "Sob"
 
 #, python-format
-msgid "Used %(useage_count)s time"
-msgid_plural "Used %(useage_count)s times"
-msgstr[0] "Število uporab: %(useage_count)s"
-msgstr[1] "Število uporab: %(useage_count)s"
-msgstr[2] "Število uporab: %(useage_count)s"
-msgstr[3] "Število uporab: %(useage_count)s"
+msgid "Used %(usage_count)s time"
+msgid_plural "Used %(usage_count)s times"
+msgstr[0] "Število uporab: %(usage_count)s"
+msgstr[1] "Število uporab: %(usage_count)s"
+msgstr[2] "Število uporab: %(usage_count)s"
+msgstr[3] "Število uporab: %(usage_count)s"
 
 msgid "Edit your account"
 msgstr "Uredite vaš račun"

--- a/wagtail/wagtailadmin/locale/sv/LC_MESSAGES/django.po
+++ b/wagtail/wagtailadmin/locale/sv/LC_MESSAGES/django.po
@@ -1079,10 +1079,10 @@ msgid "Sat"
 msgstr "Lör"
 
 #, python-format
-msgid "Used %(useage_count)s time"
-msgid_plural "Used %(useage_count)s times"
-msgstr[0] "Använd %(useage_count)s gång"
-msgstr[1] "Använd %(useage_count)s gånger"
+msgid "Used %(usage_count)s time"
+msgid_plural "Used %(usage_count)s times"
+msgstr[0] "Använd %(usage_count)s gång"
+msgstr[1] "Använd %(usage_count)s gånger"
 
 msgid "Edit your account"
 msgstr "Editera ditt konto"

--- a/wagtail/wagtailadmin/locale/zh_CN/LC_MESSAGES/django.po
+++ b/wagtail/wagtailadmin/locale/zh_CN/LC_MESSAGES/django.po
@@ -1012,9 +1012,9 @@ msgid "Sat"
 msgstr "周六"
 
 #, python-format
-msgid "Used %(useage_count)s time"
-msgid_plural "Used %(useage_count)s times"
-msgstr[0] "已使用%(useage_count)s次"
+msgid "Used %(usage_count)s time"
+msgid_plural "Used %(usage_count)s times"
+msgstr[0] "已使用%(usage_count)s次"
 
 msgid "Edit your account"
 msgstr "编辑账户"

--- a/wagtail/wagtailadmin/templates/wagtailadmin/shared/header.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/shared/header.html
@@ -39,7 +39,7 @@
             {% usage_count_enabled as uc_enabled %}
             {% if uc_enabled and usage_object %}
                 <div class="usagecount">
-                    <a href="{{ usage_object.usage_url }}">{% blocktrans count useage_count=usage_object.get_usage.count %}Used {{ useage_count }} time{% plural %}Used {{ useage_count }} times{% endblocktrans %}</a>
+                    <a href="{{ usage_object.usage_url }}">{% blocktrans count usage_count=usage_object.get_usage.count %}Used {{ usage_count }} time{% plural %}Used {{ usage_count }} times{% endblocktrans %}</a>
                 </div>
             {% endif %}
             {% if add_link %}

--- a/wagtail/wagtailimages/templates/wagtailimages/images/confirm_delete.html
+++ b/wagtail/wagtailimages/templates/wagtailimages/images/confirm_delete.html
@@ -1,6 +1,7 @@
 {% extends "wagtailadmin/base.html" %}
 {% load wagtailimages_tags %}
 {% load i18n %}
+{% load wagtailadmin_tags %}
 {% block titletag %}{% trans "Delete image" %}{% endblock %}
 
 {% block content %}
@@ -12,6 +13,12 @@
             {% image image max-800x600 %}
         </div>
         <div class="col6">
+            {% usage_count_enabled as uc_enabled %}
+            {% if uc_enabled %}
+                <div class="usagecount">
+                    <a href="{{ image.usage_url }}">{% blocktrans count useage_count=image.get_usage.count %}Used {{ useage_count }} time{% plural %}Used {{ useage_count }} times{% endblocktrans %}</a>
+                </div>
+            {% endif %}
             <p>{% trans "Are you sure you want to delete this image?" %}</p>
             <form action="{% url 'wagtailimages:delete' image.id %}" method="POST">
                 {% csrf_token %}

--- a/wagtail/wagtailimages/templates/wagtailimages/images/confirm_delete.html
+++ b/wagtail/wagtailimages/templates/wagtailimages/images/confirm_delete.html
@@ -16,7 +16,7 @@
             {% usage_count_enabled as uc_enabled %}
             {% if uc_enabled %}
                 <div class="usagecount">
-                    <a href="{{ image.usage_url }}">{% blocktrans count useage_count=image.get_usage.count %}Used {{ useage_count }} time{% plural %}Used {{ useage_count }} times{% endblocktrans %}</a>
+                    <a href="{{ image.usage_url }}">{% blocktrans count usage_count=image.get_usage.count %}Used {{ usage_count }} time{% plural %}Used {{ usage_count }} times{% endblocktrans %}</a>
                 </div>
             {% endif %}
             <p>{% trans "Are you sure you want to delete this image?" %}</p>

--- a/wagtail/wagtailimages/templates/wagtailimages/images/confirm_delete.html
+++ b/wagtail/wagtailimages/templates/wagtailimages/images/confirm_delete.html
@@ -1,7 +1,5 @@
 {% extends "wagtailadmin/base.html" %}
-{% load wagtailimages_tags %}
-{% load i18n %}
-{% load wagtailadmin_tags %}
+{% load wagtailimages_tags i18n wagtailadmin_tags %}
 {% block titletag %}{% trans "Delete image" %}{% endblock %}
 
 {% block content %}

--- a/wagtail/wagtailimages/tests/test_admin_views.py
+++ b/wagtail/wagtailimages/tests/test_admin_views.py
@@ -481,10 +481,12 @@ class TestImageDeleteView(TestCase, WagtailTestUtils):
     def post(self, post_data={}):
         return self.client.post(reverse('wagtailimages:delete', args=(self.image.id,)), post_data)
 
+    @override_settings(WAGTAIL_USAGE_COUNT_ENABLED=False)
     def test_simple(self):
         response = self.get()
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, 'wagtailimages/images/confirm_delete.html')
+        self.assertNotIn('Used ', str(response.content))
 
     def test_delete(self):
         response = self.post()

--- a/wagtail/wagtailimages/tests/test_admin_views.py
+++ b/wagtail/wagtailimages/tests/test_admin_views.py
@@ -488,6 +488,13 @@ class TestImageDeleteView(TestCase, WagtailTestUtils):
         self.assertTemplateUsed(response, 'wagtailimages/images/confirm_delete.html')
         self.assertNotIn('Used ', str(response.content))
 
+    @override_settings(WAGTAIL_USAGE_COUNT_ENABLED=True)
+    def test_usage_link(self):
+        response = self.get()
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'wagtailimages/images/confirm_delete.html')
+        self.assertIn('Used 0 times', str(response.content))
+
     def test_delete(self):
         response = self.post()
 


### PR DESCRIPTION
In the course of #3886, Olly and i decided it would make sense to also show the link to the image usage page on the delete form. This PR does just that.

Self-certification:

- [x] Do the tests still pass? (http://docs.wagtail.io/en/latest/contributing/developing.html#testing)
- [x] Does the code comply with the style guide? (Run `make lint` from the Wagtail root)
- [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
- [x] For new features: Has the documentation been updated accordingly?
