### PR TITLE
Various "Usage Information" improvements

### DIFF
--- a/docs/advanced_topics/settings.rst
+++ b/docs/advanced_topics/settings.rst
@@ -394,9 +394,13 @@ Usage for images, documents and snippets
 
     WAGTAIL_USAGE_COUNT_ENABLED = True
 
-When enabled Wagtail shows where a particular image, document or snippet is being used on your site (disabled by default). A link will appear on the edit page showing you which pages they have been used on.
+When enabled Wagtail shows where a particular image, document or snippet is being used on your site.
+This is disabled by default because it generates a query which may run slowly on sites with large numbers of pages.
 
-This link is also shown on the delete page, above the "Delete" button.
+A link will appear on the edit page (in the rightmost column) showing you how many times the item is used.
+Clicking this link takes you to the "Usage" page, which shows you where the snippet, document or image is used.
+
+The link is also shown on the delete page, above the "Delete" button.
 
 .. note::
 

--- a/wagtail/wagtailadmin/templates/wagtailadmin/shared/header.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/shared/header.html
@@ -1,4 +1,4 @@
-{% load i18n wagtailadmin_tags %}
+{% load i18n %}
 {% comment %}
 
     Variables accepted by this template:
@@ -36,12 +36,6 @@
             {% endif %}
         </div>
         <div class="right">
-            {% usage_count_enabled as uc_enabled %}
-            {% if uc_enabled and usage_object %}
-                <div class="usagecount">
-                    <a href="{{ usage_object.usage_url }}">{% blocktrans count usage_count=usage_object.get_usage.count %}Used {{ usage_count }} time{% plural %}Used {{ usage_count }} times{% endblocktrans %}</a>
-                </div>
-            {% endif %}
             {% if add_link %}
                 <div class="addbutton">
                     <a href="{% url add_link %}" class="button bicolor icon icon-plus">{{ add_text }}</a>

--- a/wagtail/wagtaildocs/templates/wagtaildocs/documents/confirm_delete.html
+++ b/wagtail/wagtaildocs/templates/wagtaildocs/documents/confirm_delete.html
@@ -1,11 +1,19 @@
 {% extends "wagtailadmin/base.html" %}
-{% load i18n %}
+{% load wagtailadmin_tags i18n %}
 {% block titletag %}{% blocktrans with title=document.title %}Delete {{ title }}{% endblocktrans %}{% endblock %}
 {% block content %}
     {% trans "Delete document" as del_str %}
     {% include "wagtailadmin/shared/header.html" with title=del_str subtitle=document.title icon="doc-full-inverse" %}
 
     <div class="nice-padding">
+
+        {% usage_count_enabled as uc_enabled %}
+        {% if uc_enabled %}
+            <div class="usagecount">
+                <a href="{{ document.usage_url }}">{% blocktrans count usage_count=document.get_usage.count %}Used {{ usage_count }} time{% plural %}Used {{ usage_count }} times{% endblocktrans %}</a>
+            </div>
+        {% endif %}
+
         <p>{% trans "Are you sure you want to delete this document?" %}</p>
         <form action="{% url 'wagtaildocs:delete' document.id %}" method="POST">
             {% csrf_token %}

--- a/wagtail/wagtaildocs/templates/wagtaildocs/documents/edit.html
+++ b/wagtail/wagtaildocs/templates/wagtaildocs/documents/edit.html
@@ -1,6 +1,6 @@
 {% extends "wagtailadmin/base.html" %}
 {% load i18n %}
-{% load wagtailimages_tags %}
+{% load wagtailimages_tags wagtailadmin_tags %}
 {% block titletag %}{% blocktrans with title=document.title %}Editing {{ title }}{% endblocktrans %}{% endblock %}
 
 {% block extra_js %}
@@ -18,7 +18,7 @@
 
 {% block content %}
     {% trans "Editing" as editing_str %}
-    {% include "wagtailadmin/shared/header.html" with title=editing_str subtitle=document.title icon="doc-full-inverse" usage_object=document %}
+    {% include "wagtailadmin/shared/header.html" with title=editing_str subtitle=document.title icon="doc-full-inverse" %}
 
     <div class="row row-flush nice-padding">
 
@@ -49,6 +49,14 @@
                 {% if document.file %}
                     <dt>{% trans "Filesize" %}</dt>
                     <dd>{% if filesize %}{{ filesize|filesizeformat }}{% else %}{% trans "File not found" %}{% endif %}</dd>
+                {% endif %}
+
+                {% usage_count_enabled as uc_enabled %}
+                {% if uc_enabled %}
+                    <dt>{% trans "Usage" %}</dt>
+                    <dd>
+                        <a href="{{ image.usage_url }}">{% blocktrans count usage_count=document.get_usage.count %}Used {{ usage_count }} time{% plural %}Used {{ usage_count }} times{% endblocktrans %}</a>
+                    </dd>
                 {% endif %}
             </dl>
         </div>

--- a/wagtail/wagtaildocs/tests/test_admin_views.py
+++ b/wagtail/wagtaildocs/tests/test_admin_views.py
@@ -296,6 +296,13 @@ class TestDocumentDeleteView(TestCase, WagtailTestUtils):
         # Document should be deleted
         self.assertFalse(models.Document.objects.filter(id=self.document.id).exists())
 
+    @override_settings(WAGTAIL_USAGE_COUNT_ENABLED=True)
+    def test_usage_link(self):
+        response = self.client.get(reverse('wagtaildocs:delete', args=(self.document.id,)))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'wagtaildocs/documents/confirm_delete.html')
+        self.assertIn('Used 0 times', str(response.content))
+
 
 class TestMultipleDocumentUploader(TestCase, WagtailTestUtils):
     """

--- a/wagtail/wagtailimages/templates/wagtailimages/images/edit.html
+++ b/wagtail/wagtailimages/templates/wagtailimages/images/edit.html
@@ -1,5 +1,5 @@
 {% extends "wagtailadmin/base.html" %}
-{% load wagtailimages_tags staticfiles i18n l10n %}
+{% load wagtailimages_tags wagtailadmin_tags staticfiles i18n l10n %}
 {% block titletag %}{% blocktrans with title=image.title %}Editing image {{ title }}{% endblocktrans %}{% endblock %}
 {% block extra_css %}
     {{ block.super }}
@@ -29,7 +29,7 @@
 
 {% block content %}
     {% trans "Editing" as editing_str %}
-    {% include "wagtailadmin/shared/header.html" with title=editing_str subtitle=image.title icon="image" usage_object=image %}
+    {% include "wagtailadmin/shared/header.html" with title=editing_str subtitle=image.title icon="image" %}
 
     <div class="row row-flush nice-padding">
 
@@ -92,6 +92,14 @@
                 <dd>{{ original_image.width }}x{{ original_image.height }}</dd>
                 <dt>{% trans "Filesize" %}</dt>
                 <dd>{% if filesize %}{{ filesize|filesizeformat }}{% else %}{% trans "File not found" %}{% endif %}</dd>
+
+                {% usage_count_enabled as uc_enabled %}
+                {% if uc_enabled %}
+                    <dt>{% trans "Usage" %}</dt>
+                    <dd>
+                        <a href="{{ image.usage_url }}">{% blocktrans count usage_count=image.get_usage.count %}Used {{ usage_count }} time{% plural %}Used {{ usage_count }} times{% endblocktrans %}</a>
+                    </dd>
+                {% endif %}
             </dl>
         </div>
     </div>

--- a/wagtail/wagtailsnippets/templates/wagtailsnippets/snippets/confirm_delete.html
+++ b/wagtail/wagtailsnippets/templates/wagtailsnippets/snippets/confirm_delete.html
@@ -1,11 +1,18 @@
 {% extends "wagtailadmin/base.html" %}
-{% load i18n %}
+{% load wagtailadmin_tags i18n %}
 {% block titletag %}{% blocktrans with snippet_type_name=model_opts.verbose_name %}Delete {{ snippet_type_name }} - {{ instance }}{% endblocktrans %}{% endblock %}
 {% block content %}
     {% trans "Delete" as delete_str %}
     {% include "wagtailadmin/shared/header.html" with title=delete_str subtitle=instance icon="snippet" %}
 
     <div class="nice-padding">
+        {% usage_count_enabled as uc_enabled %}
+        {% if uc_enabled %}
+            <div class="usagecount">
+                <a href="{{ instance.usage_url }}">{% blocktrans count usage_count=instance.get_usage.count %}Used {{ usage_count }} time{% plural %}Used {{ usage_count }} times{% endblocktrans %}</a>
+            </div>
+        {% endif %}
+
         <p>{% blocktrans with snippet_type_name=model_opts.verbose_name %}Are you sure you want to delete this {{ snippet_type_name }}?{% endblocktrans %}</p>
         <form action="{% url 'wagtailsnippets:delete' model_opts.app_label model_opts.model_name instance.id %}" method="POST">
             {% csrf_token %}

--- a/wagtail/wagtailsnippets/templates/wagtailsnippets/snippets/edit.html
+++ b/wagtail/wagtailsnippets/templates/wagtailsnippets/snippets/edit.html
@@ -7,25 +7,28 @@
 
     <div class="row row-flush">
 
+        {% usage_count_enabled as uc_enabled %}
+        {% if uc_enabled %}
         <div class="col10 divider-after">
+        {% else %}
+        <div class="col12">
+        {% endif %}
             <form action="{% url 'wagtailsnippets:edit' model_opts.app_label model_opts.model_name instance.id %}" method="POST" novalidate{% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>
                 {% csrf_token %}
                 {{ edit_handler.render_form_content }}
             </form>
         </div>
 
+        {% if uc_enabled %}
         <div class="col2 ">
             <dl>
-                {% usage_count_enabled as uc_enabled %}
-                {% if uc_enabled %}
                     <dt>{% trans "Usage" %}</dt>
                     <dd>
                         <a href="{{ instance.usage_url }}">{% blocktrans count usage_count=instance.get_usage.count %}Used {{ usage_count }} time{% plural %}Used {{ usage_count }} times{% endblocktrans %}</a>
                     </dd>
-                {% endif %}
             </dl>
         </div>
-
+        {% endif %}
     </div>
 
     <footer>

--- a/wagtail/wagtailsnippets/templates/wagtailsnippets/snippets/edit.html
+++ b/wagtail/wagtailsnippets/templates/wagtailsnippets/snippets/edit.html
@@ -1,30 +1,48 @@
 {% extends "wagtailadmin/base.html" %}
-{% load i18n %}
+{% load wagtailadmin_tags i18n %}
 {% block titletag %}{% blocktrans with snippet_type_name=model_opts.verbose_name %}Editing {{ snippet_type_name }} - {{ instance }}{% endblocktrans %}{% endblock %}
 {% block content %}
     {% trans "Editing" as editing_str %}
-    {% include "wagtailadmin/shared/header.html" with title=editing_str subtitle=instance icon="snippet" usage_object=instance tabbed=1 merged=1 %}
+    {% include "wagtailadmin/shared/header.html" with title=editing_str subtitle=instance icon="snippet" tabbed=1 %}
 
-    <form action="{% url 'wagtailsnippets:edit' model_opts.app_label model_opts.model_name instance.id %}" method="POST" novalidate{% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>
-        {% csrf_token %}
-        {{ edit_handler.render_form_content }}
+    <div class="row row-flush nice-padding">
 
-        <footer>
-            <ul>
-                <li class="actions">
-                    <div class="dropdown dropup dropdown-button match-width">
-                        <button type="submit" class="button action-save button-longrunning" tabindex="3" data-clicked-text="{% trans 'Saving...' %}" {% if page.locked %}disabled {% endif %}>
-                            <span class="icon icon-spinner"></span><em>{% trans 'Save' %}</em>
-                        </button>
-                        <div class="dropdown-toggle icon icon-arrow-up"></div>
-                        <ul role="menu">
-                            <li><a href="{% url 'wagtailsnippets:delete' model_opts.app_label model_opts.model_name instance.id %}" class="shortcut">{% trans "Delete" %}</a></li>
-                        </ul>
-                    </div>
-                </li>
-            </ul>
-        </footer>
-    </form>
+        <div class="col10 divider-after">
+            <form action="{% url 'wagtailsnippets:edit' model_opts.app_label model_opts.model_name instance.id %}" method="POST" novalidate{% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>
+                {% csrf_token %}
+                {{ edit_handler.render_form_content }}
+            </form>
+        </div>
+
+        <div class="col2 ">
+            <dl>
+                {% usage_count_enabled as uc_enabled %}
+                {% if uc_enabled %}
+                    <dt>{% trans "Usage" %}</dt>
+                    <dd>
+                        <a href="{{ instance.usage_url }}">{% blocktrans count usage_count=instance.get_usage.count %}Used {{ usage_count }} time{% plural %}Used {{ usage_count }} times{% endblocktrans %}</a>
+                    </dd>
+                {% endif %}
+            </dl>
+        </div>
+
+    </div>
+
+    <footer>
+        <ul>
+            <li class="actions">
+                <div class="dropdown dropup dropdown-button match-width">
+                    <button type="submit" class="button action-save button-longrunning" tabindex="3" data-clicked-text="{% trans 'Saving...' %}" {% if page.locked %}disabled {% endif %}>
+                        <span class="icon icon-spinner"></span><em>{% trans 'Save' %}</em>
+                    </button>
+                    <div class="dropdown-toggle icon icon-arrow-up"></div>
+                    <ul role="menu">
+                        <li><a href="{% url 'wagtailsnippets:delete' model_opts.app_label model_opts.model_name instance.id %}" class="shortcut">{% trans "Delete" %}</a></li>
+                    </ul>
+                </div>
+            </li>
+        </ul>
+    </footer>
 
 {% endblock %}
 

--- a/wagtail/wagtailsnippets/templates/wagtailsnippets/snippets/edit.html
+++ b/wagtail/wagtailsnippets/templates/wagtailsnippets/snippets/edit.html
@@ -5,7 +5,7 @@
     {% trans "Editing" as editing_str %}
     {% include "wagtailadmin/shared/header.html" with title=editing_str subtitle=instance icon="snippet" tabbed=1 %}
 
-    <div class="row row-flush nice-padding">
+    <div class="row row-flush">
 
         <div class="col10 divider-after">
             <form action="{% url 'wagtailsnippets:edit' model_opts.app_label model_opts.model_name instance.id %}" method="POST" novalidate{% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>

--- a/wagtail/wagtailsnippets/tests.py
+++ b/wagtail/wagtailsnippets/tests.py
@@ -352,6 +352,13 @@ class TestSnippetDelete(TestCase, WagtailTestUtils):
         # Check that the page is gone
         self.assertEqual(Advert.objects.filter(text='test_advert').count(), 0)
 
+    @override_settings(WAGTAIL_USAGE_COUNT_ENABLED=True)
+    def test_usage_link(self):
+        response = self.client.get(reverse('wagtailsnippets:delete', args=('tests', 'advert', self.test_snippet.id, )))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'wagtailsnippets/snippets/confirm_delete.html')
+        self.assertIn('Used 2 times', str(response.content))
+
 
 class TestSnippetChooserPanel(TestCase, WagtailTestUtils):
     fixtures = ['test.json']


### PR DESCRIPTION
UI improvements from https://github.com/wagtail/wagtail/issues/3886

## Move Usage Information link to (Documents, Images) to sidebar

Olly and i noticed the location of "Used N times" (on Documents and Images) in the header is a bit odd. The side bar ("Meta" info) makes more sense, so let's put it there.

## Also show the Usage Info on the Delete form of Documents and Snippets

If it makes sense for images, it makes sense for Docs and Snippets, too.

## Self-certification

- [x] Do the tests still pass? (http://docs.wagtail.io/en/latest/contributing/developing.html#testing)
- [x] Does the code comply with the style guide? (Run `make lint` from the Wagtail root)
- [x] For -Python- *template* changes: Have you added tests to cover the new/fixed behaviour?
- [x] For new features: Has the documentation been updated accordingly?
