### PR TITLE
POC: Make get object usage also work on streamfields

### DIFF
--- a/docs/advanced_topics/settings.rst
+++ b/docs/advanced_topics/settings.rst
@@ -402,6 +402,15 @@ This link is also shown on the delete page, above the "Delete" button.
 
     The usage count only applies to direct (database) references. Using documents, images and snippets within StreamFields or rich text fields will not be taken into account.
 
+.. code-block:: python
+
+    IMAGE_USAGE_SEARCHES_STREAMFIELDS = True
+
+When enabled, Wagtail image usage will also search StreamField content.
+
+This is disabled by default, because it uses a database query that would take very long on sites with many pages.
+
+
 Date and DateTime inputs
 ------------------------
 

--- a/wagtail/wagtailadmin/utils.py
+++ b/wagtail/wagtailadmin/utils.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, unicode_literals
 
+import inspect
 import logging
 from functools import wraps
 
@@ -16,6 +17,7 @@ from django.utils.translation import ugettext as _
 from django.utils.translation import override, ugettext_lazy
 from modelcluster.fields import ParentalKey
 from taggit.models import Tag
+import django.apps
 
 from wagtail.wagtailcore.models import GroupPagePermission, Page, PageRevision
 from wagtail.wagtailusers.models import UserProfile
@@ -173,6 +175,13 @@ def any_permission_required(*perms):
         return False
 
     return user_passes_test(test)
+
+
+def get_page_models():
+    """List all models subclassing Wagtail Page."""
+    for model in django.apps.apps.get_models():
+        if Page in inspect.getmro(Page):
+            yield model
 
 
 class PermissionPolicyChecker(object):

--- a/wagtail/wagtailadmin/utils.py
+++ b/wagtail/wagtailadmin/utils.py
@@ -55,7 +55,7 @@ def get_available_admin_languages():
 
 
 def get_object_usage(obj):
-    "Returns a queryset of pages that link to a particular object"
+    """Returns a queryset of pages that link to a particular object"""
 
     pages = Page.objects.none()
 

--- a/wagtail/wagtailimages/models.py
+++ b/wagtail/wagtailimages/models.py
@@ -247,7 +247,7 @@ class AbstractImage(CollectionMember, index.Indexed, models.Model):
 
     @classmethod
     def get_rendition_model(cls):
-        """ Get the Rendition model for this Image model """
+        """Get the Rendition model for this Image model."""
         return cls.renditions.rel.related_model
 
     def get_rendition(self, filter):


### PR DESCRIPTION
This is a proof of concept to show how one could make Image usage also take into account images that are used in StreamFields. As mentioned in https://github.com/wagtail/wagtail/issues/3886, this is currently not the case.

To see it in action, use the Wagtail Bakery demo site:

- Add `IMAGE_USAGE_SEARCHES_STREAMFIELDS = True` to your settings
- Find an image that is used in a "HOME CONTENT BLOCK" section StreamField
- You'll see that with the setting on, the image usage count is 1 and the usage page contains a links to the homepage. 

This is done by madifying the Image models `get_usage()` method, so installation could be quite simple. 

The proper way to implement this would likely be to create an extra package with a Mixin class, and tell developers that if they want their images listed in this manner, they need to subclass that and use a proxy model. (Using StreamFields is for developers anyway, right?)
