### PR TITLE
Update writing_templates.rst

### DIFF
--- a/docs/topics/writing_templates.rst
+++ b/docs/topics/writing_templates.rst
@@ -176,7 +176,7 @@ Takes any ``slug`` as defined in a page's "Promote" tab and returns the URL for 
 
     {% load wagtailcore_tags %}
     ...
-    <a href="{% slugurl page.your_slug %}">
+    <a href="{% slugurl 'your_slug' %}">
 
 
 .. _static_tag:


### PR DESCRIPTION
Since page.your_slug normally results in None, I think using a quoted slug would a better example.

Thanks for contributing to Wagtail! 🎉

Before submitting, please review the contributor guidelines <http://docs.wagtail.io/en/latest/contributing/index.html> and check the following:

* Do the tests still pass? (http://docs.wagtail.io/en/latest/contributing/developing.html#testing)
* Does the code comply with the style guide? (Run `make lint` from the Wagtail root)
* For Python changes: Have you added tests to cover the new/fixed behaviour?
* For new features: Has the documentation been updated accordingly?
