### PR TITLE
Fixes admin dropdown arrow.

### DIFF
--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_forms.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_forms.scss
@@ -117,7 +117,6 @@ select,
         font-size: 3em;
         pointer-events: none;
         color: $color-grey-3;
-        background-color: $color-fieldset-hover;
         margin: 0 1px 1px 0;
 
         .ie & {


### PR DESCRIPTION
This has been bugging me for a while.

Before, on Chrome:
![image](https://user-images.githubusercontent.com/1119169/31938403-5a69216a-b8af-11e7-803b-3cf21f2d4a12.png)
After, on Chrome:
![image](https://user-images.githubusercontent.com/1119169/31938424-6c25ca7a-b8af-11e7-82aa-df0fbae992e4.png)
There was a useless background rule on the `select + span::after` arrow, which was sometimes overlapping with the `select` border, probably because of some non-integer pixel height.