### PR TITLE
Fix using modeladmin_register as a decorator

### DIFF
--- a/wagtail/contrib/modeladmin/options.py
+++ b/wagtail/contrib/modeladmin/options.py
@@ -593,3 +593,4 @@ def modeladmin_register(modeladmin_class):
     """
     instance = modeladmin_class()
     instance.register_with_wagtail()
+    return modeladmin_class


### PR DESCRIPTION
Using `modeladmin_register` as a decorator worked, and the ModelAdmin subclass was registered successfully, but as `modeladmin_register` did not return the ModelAdmin subclass, the decorated class would be `None`. Returning the class prevents this issue, so `modeladmin_register` will now work as expected as a decorator.