### PR TITLE
Add setting to disable notification to superusers -- Fixes #3969

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -259,6 +259,7 @@ Contributors
 * Patrick Woods
 * Ross Crawford-d'Heureuse
 * rifuso
+* Bruno Alla
 
 Translators
 ===========

--- a/docs/advanced_topics/settings.rst
+++ b/docs/advanced_topics/settings.rst
@@ -292,6 +292,14 @@ Email Notifications format
 
 Notification emails are sent in `text/plain` by default, change this to use HTML formatting.
 
+Email Notifications to superusers
+---------------------------------
+
+.. code-block:: python
+
+  WAGTAILADMIN_NOTIFICATION_INCLUDE_SUPERUSERS = False
+
+Notifications emails are sent to moderators and superusers by default, you can change this to exclude superusers and only email moderators.
 
 .. _update_notifications:
 

--- a/docs/advanced_topics/settings.rst
+++ b/docs/advanced_topics/settings.rst
@@ -299,7 +299,7 @@ Email Notifications to superusers
 
   WAGTAILADMIN_NOTIFICATION_INCLUDE_SUPERUSERS = False
 
-Notifications emails are sent to moderators and superusers by default, you can change this to exclude superusers and only email moderators.
+Notification emails are sent to moderators and superusers by default. You can change this to exclude superusers and only notify moderators.
 
 .. _update_notifications:
 

--- a/docs/releases/2.0.rst
+++ b/docs/releases/2.0.rst
@@ -16,6 +16,7 @@ Other features
  * Elasticsearch scroll API is now used when fetching more than 100 search results (Karl Hobley)
  * Added hidden field to the form builder (Ross Crawford-d'Heureuse)
  * Image usage count now shows on delete confirmation page when WAGTAIL_USAGE_COUNT_ENABLED is active (Kees Hink)
+ * Email notifications for content moderation may exclude superusers when disabling ``WAGTAILADMIN_NOTIFICATION_INCLUDE_SUPERUSERS`` (Bruno Alla)
 
 
 Bug fixes

--- a/wagtail/wagtailadmin/tests/test_pages_views.py
+++ b/wagtail/wagtailadmin/tests/test_pages_views.py
@@ -3188,7 +3188,7 @@ class TestNotificationPreferences(TestCase, WagtailTestUtils):
         # Should be redirected to explorer page
         self.assertEqual(response.status_code, 302)
 
-        # Check that the non-moderators superusers are not being notified
+        # Check that the non-moderator superuser is not being notified
         expected_emails = 1
         self.assertEqual(len(mail.outbox), expected_emails)
         # Use chain as the 'to' field is a list of recipients

--- a/wagtail/wagtailadmin/utils.py
+++ b/wagtail/wagtailadmin/utils.py
@@ -215,7 +215,8 @@ def send_notification(page_revision_id, notification, excluded_user_id):
     # Get list of recipients
     if notification == 'submitted':
         # Get list of publishers
-        recipients = users_with_page_permission(revision.page, 'publish')
+        include_superusers = getattr(settings, 'WAGTAILADMIN_NOTIFICATION_INCLUDE_SUPERUSERS', True)
+        recipients = users_with_page_permission(revision.page, 'publish', include_superusers)
     elif notification in ['rejected', 'approved']:
         # Get submitter
         recipients = [revision.user]


### PR DESCRIPTION
New setting `WAGTAILADMIN_NOTIFICATION_INCLUDE_SUPERUSERS`, default to `True`. When set to `False`, superusers do not receive moderation notification, only moderators do.
