### PR TITLE
Sitemap: Fix to tolerate sites where all pages are private

### DIFF
--- a/wagtail/contrib/wagtailsitemaps/sitemap_generator.py
+++ b/wagtail/contrib/wagtailsitemaps/sitemap_generator.py
@@ -35,6 +35,7 @@ class Sitemap(DjangoSitemap):
                 urls.append(url_info)
                 last_mods.add(url_info.get('lastmod'))
 
-        if None not in last_mods:
+        # last_mods might be empty if the whole site is private
+        if last_mods and None not in last_mods:
             self.latest_lastmod = max(last_mods)
         return urls


### PR DESCRIPTION
When all pages on a site is private, the `last_mods` set will be empty
causing a crash when trying to get the max value from it.
This fix adds a test that the set is truthy (not empty) before calling
max.

Without this fix the sitemaps view wil crash when all pages on the site are private.
Whith this fix applied, the sitemap will be an empty sitemap as expected:

`<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"></urlset>`
