### PR TITLE
Makes `PageChooserPanel` search in all fields.

### DIFF
--- a/wagtail/wagtailadmin/views/chooser.py
+++ b/wagtail/wagtailadmin/views/chooser.py
@@ -162,7 +162,7 @@ def search(request, parent_page_id=None):
         )
         pages = filter_page_type(pages, desired_classes)
         pages = pages.specific()
-        pages = pages.search(search_form.cleaned_data['q'], fields=['title'])
+        pages = pages.search(search_form.cleaned_data['q'])
     else:
         pages = pages.none()
 


### PR DESCRIPTION
The current behaviour is inconsistent with [images](https://github.com/wagtail/wagtail/blob/master/wagtail/wagtailimages/views/chooser.py#L72) and [documents](https://github.com/wagtail/wagtail/blob/master/wagtail/wagtaildocs/views/chooser.py#L62).

It’s particularly blocking for sites with a ton of pages where user prefer to search (for example), by primary key.