### PR TITLE
Filter pop-out explorer pages using 'construct_explorer_page_queryset'

### DIFF
--- a/client/src/api/admin.js
+++ b/client/src/api/admin.js
@@ -10,7 +10,7 @@ export const getPage = (id) => {
 };
 
 export const getPageChildren = (id, options = {}) => {
-  let url = `${ADMIN_API.PAGES}?child_of=${id}`;
+  let url = `${ADMIN_API.PAGES}?child_of=${id}&for_explorer=1`;
 
   if (options.fields) {
     url += `&fields=${global.encodeURIComponent(options.fields.join(','))}`;

--- a/client/src/api/admin.test.js
+++ b/client/src/api/admin.test.js
@@ -20,23 +20,23 @@ describe('admin API', () => {
   describe('getPageChildren', () => {
     it('works', () => {
       getPageChildren(3);
-      expect(client.get).toBeCalledWith(`${ADMIN_API.PAGES}?child_of=3`);
+      expect(client.get).toBeCalledWith(`${ADMIN_API.PAGES}?child_of=3&for_explorer=1`);
     });
 
     it('#fields', () => {
       getPageChildren(3, { fields: ['title', 'latest_revision_created_at'] });
       // eslint-disable-next-line max-len
-      expect(client.get).toBeCalledWith(`${ADMIN_API.PAGES}?child_of=3&fields=title%2Clatest_revision_created_at`);
+      expect(client.get).toBeCalledWith(`${ADMIN_API.PAGES}?child_of=3&for_explorer=1&fields=title%2Clatest_revision_created_at`);
     });
 
     it('#onlyWithChildren', () => {
       getPageChildren(3, { onlyWithChildren: true });
-      expect(client.get).toBeCalledWith(`${ADMIN_API.PAGES}?child_of=3&has_children=1`);
+      expect(client.get).toBeCalledWith(`${ADMIN_API.PAGES}?child_of=3&for_explorer=1&has_children=1`);
     });
 
     it('#offset', () => {
       getPageChildren(3, { offset: 5 });
-      expect(client.get).toBeCalledWith(`${ADMIN_API.PAGES}?child_of=3&offset=5`);
+      expect(client.get).toBeCalledWith(`${ADMIN_API.PAGES}?child_of=3&for_explorer=1&offset=5`);
     });
   });
 

--- a/wagtail/tests/testapp/wagtail_hooks.py
+++ b/wagtail/tests/testapp/wagtail_hooks.py
@@ -93,6 +93,12 @@ def polite_pages_only(parent_page, pages, request):
     return pages
 
 
+@hooks.register('construct_explorer_page_queryset')
+def hide_hidden_pages(parent_page, pages, request):
+    # Pages with 'hidden' in their title are hidden. Magic!
+    return pages.exclude(title__icontains='hidden')
+
+
 # register 'blockquote' as a rich text feature supported by a hallo.js plugin
 @hooks.register('register_rich_text_features')
 def register_blockquote_feature(features):

--- a/wagtail/wagtailadmin/api/endpoints.py
+++ b/wagtail/wagtailadmin/api/endpoints.py
@@ -4,7 +4,8 @@ from collections import OrderedDict
 
 from wagtail.api.v2.endpoints import PagesAPIEndpoint
 from wagtail.api.v2.filters import (
-    ChildOfFilter, DescendantOfFilter, FieldsFilter, OrderingFilter, SearchFilter)
+    ChildOfFilter, DescendantOfFilter, FieldsFilter, ForExplorerFilter, OrderingFilter,
+    SearchFilter)
 from wagtail.api.v2.utils import BadRequestError, filter_page_type, page_models_from_string
 from wagtail.wagtailcore.models import Page
 
@@ -21,6 +22,7 @@ class PagesAdminAPIEndpoint(PagesAPIEndpoint):
         FieldsFilter,
         ChildOfFilter,
         DescendantOfFilter,
+        ForExplorerFilter,
         HasChildrenFilter,
         OrderingFilter,
         SearchFilter,
@@ -49,6 +51,7 @@ class PagesAdminAPIEndpoint(PagesAPIEndpoint):
     detail_only_fields = []
 
     known_query_parameters = PagesAPIEndpoint.known_query_parameters.union([
+        'for_explorer',
         'has_children'
     ])
 


### PR DESCRIPTION
The pages listed when browsing the /admin/pages/ explorer differed from the pages listed in the new React/admin API powered pop-out explorer. The latter did not pass the queryset through the 'construct_explorer_page_queryset' hook, so pages that should have been hidden were visible. Visiting these pages in the explorer could then lead to unexpected behaviours, as hidden sections of the site became browsable.

A new `for_explorer=1` query parameter has been added to the admin API, which will pass the page queryset through the 'construct_explorer_page_queryset' hooks.