### PR TITLE
Fix "Live" link broken when editing a page in live + draft status

### DIFF
--- a/wagtail/wagtailadmin/templates/wagtailadmin/pages/edit.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/pages/edit.html
@@ -18,8 +18,7 @@
             </div>
             <div class="right col3">
                 {% trans "Status" %}
-                {% include "wagtailadmin/shared/page_status_tag.html" with page=page %}
-
+                {% include "wagtailadmin/shared/page_status_tag.html" with page=page_for_status %}
                 {% include "wagtailadmin/pages/_privacy_switch.html" with page=page page_perms=page_perms only %}
                 {% include "wagtailadmin/pages/_lock_switch.html" %}
             </div>

--- a/wagtail/wagtailadmin/views/pages.py
+++ b/wagtail/wagtailadmin/views/pages.py
@@ -488,8 +488,15 @@ def edit(request, page_id):
 
         messages.warning(request, _("This page is currently awaiting moderation"), buttons=buttons)
 
+    # Page status needs to present the version of the page containing the correct live URL
+    if page.has_unpublished_changes:
+        page_for_status = latest_revision.page
+    else:
+        page_for_status = page
+
     return render(request, 'wagtailadmin/pages/edit.html', {
         'page': page,
+        'page_for_status': page_for_status,
         'content_type': content_type,
         'edit_handler': edit_handler,
         'errors_debug': errors_debug,


### PR DESCRIPTION
Fixes #2820 

* Fixes issue where the status link at the top right of the edit page view would show the draft (page revision) URL, not the actual page's live URL.
* Adds `page_for_status` to the context provided to the edit page view.
* Added test for this specific issue for any future regressions
* No documentation needed as this is a bug fix