### PR TITLE
Moving submit button back inside the form element. Fixes #4001

### DIFF
--- a/wagtail/wagtailsnippets/templates/wagtailsnippets/snippets/edit.html
+++ b/wagtail/wagtailsnippets/templates/wagtailsnippets/snippets/edit.html
@@ -16,6 +16,21 @@
             <form action="{% url 'wagtailsnippets:edit' model_opts.app_label model_opts.model_name instance.id %}" method="POST" novalidate{% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>
                 {% csrf_token %}
                 {{ edit_handler.render_form_content }}
+                <footer>
+                    <ul>
+                        <li class="actions">
+                            <div class="dropdown dropup dropdown-button match-width">
+                                <button type="submit" class="button action-save button-longrunning" tabindex="3" data-clicked-text="{% trans 'Saving...' %}" {% if page.locked %}disabled {% endif %}>
+                                    <span class="icon icon-spinner"></span><em>{% trans 'Save' %}</em>
+                                </button>
+                                <div class="dropdown-toggle icon icon-arrow-up"></div>
+                                <ul role="menu">
+                                    <li><a href="{% url 'wagtailsnippets:delete' model_opts.app_label model_opts.model_name instance.id %}" class="shortcut">{% trans "Delete" %}</a></li>
+                                </ul>
+                            </div>
+                        </li>
+                    </ul>
+                </footer>
             </form>
         </div>
 
@@ -31,21 +46,6 @@
         {% endif %}
     </div>
 
-    <footer>
-        <ul>
-            <li class="actions">
-                <div class="dropdown dropup dropdown-button match-width">
-                    <button type="submit" class="button action-save button-longrunning" tabindex="3" data-clicked-text="{% trans 'Saving...' %}" {% if page.locked %}disabled {% endif %}>
-                        <span class="icon icon-spinner"></span><em>{% trans 'Save' %}</em>
-                    </button>
-                    <div class="dropdown-toggle icon icon-arrow-up"></div>
-                    <ul role="menu">
-                        <li><a href="{% url 'wagtailsnippets:delete' model_opts.app_label model_opts.model_name instance.id %}" class="shortcut">{% trans "Delete" %}</a></li>
-                    </ul>
-                </div>
-            </li>
-        </ul>
-    </footer>
 
 {% endblock %}
 


### PR DESCRIPTION
The edit button for snippets was accidentally moved out of the form element recently. This is a fix for that.
