### PR TITLE
Clearer image tag errors + documentation

### DIFF
--- a/docs/topics/images.rst
+++ b/docs/topics/images.rst
@@ -11,6 +11,8 @@ The syntax for the tag is thus:
 
     {% image [image] [resize-rule] %}
 
+**Both the image and resize rule must be passed to the template tag.**
+
 For example:
 
 .. code-block:: html+django

--- a/wagtail/wagtailimages/templatetags/wagtailimages_tags.py
+++ b/wagtail/wagtailimages/templatetags/wagtailimages_tags.py
@@ -56,6 +56,18 @@ def image(parser, token):
         # attributes are not valid when using the 'as img' form of the tag
         is_valid = False
 
+    if len(filter_specs) == 0:
+        # there must always be at least one filter spec provided
+        is_valid = False
+
+    if len(bits) == 0:
+        # no resize rule provided eg. {% image page.image %}
+        raise template.TemplateSyntaxError(
+            "no resize rule provided. "
+            "'image' tag should be of the form {% image self.photo max-320x200 [ custom-attr=\"value\" ... ] %} "
+            "or {% image self.photo max-320x200 as img %}"
+        )
+
     if is_valid:
         return ImageNode(image_expr, '|'.join(filter_specs), attrs=attrs, output_var_name=output_var_name)
     else:

--- a/wagtail/wagtailimages/tests/tests.py
+++ b/wagtail/wagtailimages/tests/tests.py
@@ -123,6 +123,33 @@ class TestImageTag(TestCase):
             context = template.Context({'image_obj': self.image})
             temp.render(context)
 
+    def test_no_image_filter_provided(self):
+        # if image template gets the image but no filters
+        with self.assertRaises(template.TemplateSyntaxError):
+            temp = template.Template(
+                '{% load wagtailimages_tags %}{% image image_obj %}'
+            )
+            context = template.Context({'image_obj': self.image})
+            temp.render(context)
+
+    def test_no_image_filter_provided_when_using_as(self):
+        # if image template gets the image but no filters
+        with self.assertRaises(template.TemplateSyntaxError):
+            temp = template.Template(
+                '{% load wagtailimages_tags %}{% image image_obj as foo %}'
+            )
+            context = template.Context({'image_obj': self.image})
+            temp.render(context)
+
+    def test_no_image_filter_provided_but_attributes_provided(self):
+        # if image template gets the image but no filters
+        with self.assertRaises(template.TemplateSyntaxError):
+            temp = template.Template(
+                '{% load wagtailimages_tags %}{% image image_obj class="cover-image"%}'
+            )
+            context = template.Context({'image_obj': self.image})
+            temp.render(context)
+
 
 class TestMissingImage(TestCase):
     """


### PR DESCRIPTION
Closes #3993 

**important** please double check that it is ok that we will throw a template error if no filters are provided to the image tag.

I have updated the image tag to throw template errors if the tag is not formatted correctly, some items were getting through to throw a filter spec error.

* Tests have been run, linting has been checked.
* Added tests for each specific bad image tag formatting.
* Documentation update to be clearer about the requirements.
