### PR TITLE
Docs - Fix syntax error in ImageRenditionField example

### DIFF
--- a/docs/advanced_topics/api/v2/configuration.rst
+++ b/docs/advanced_topics/api/v2/configuration.rst
@@ -204,7 +204,7 @@ For example:
 
 .. code-block:: python
 
-    from wagtail.wagtailimages.api.fields.ImageRenditionField
+    from wagtail.wagtailimages.api.fields import ImageRenditionField
 
     class BlogPage(Page):
         ...


### PR DESCRIPTION
This fixes a minor syntax error in the ImageRenditionField example on the api/v2/configuration docs.