### PR TITLE
Make ordering Page search by title work on 1.12.x

### DIFF
--- a/wagtail/contrib/postgres_search/backend.py
+++ b/wagtail/contrib/postgres_search/backend.py
@@ -180,7 +180,7 @@ class PostgresSearchQuery(BaseSearchQuery):
 
     def __init__(self, *args, **kwargs):
         super(PostgresSearchQuery, self).__init__(*args, **kwargs)
-        self.search_fields = self.queryset.model.get_search_fields()
+        self.search_fields = self.queryset.model.get_searchable_search_fields()
 
     def get_search_query(self, config):
         combine = OR if self.operator == 'or' else AND

--- a/wagtail/contrib/postgres_search/backend.py
+++ b/wagtail/contrib/postgres_search/backend.py
@@ -246,11 +246,15 @@ class PostgresSearchQuery(BaseSearchQuery):
 
     def search_in_index(self, queryset, search_query, start, stop):
         index_entries = self.get_in_index_queryset(queryset, search_query)
+        order_sql = ''
+        values = ['typed_pk']
         if self.order_by_relevance:
             index_entries = index_entries.rank(search_query)
+            values.append('rank')
+            order_sql = 'ORDER BY index_entry.rank DESC'
         index_sql, index_params = get_sql(
             index_entries.annotate_typed_pk()
-            .values('typed_pk', 'rank')
+            .values(*values)
         )
         model_sql, model_params = get_sql(queryset)
         model = queryset.model
@@ -258,9 +262,9 @@ class PostgresSearchQuery(BaseSearchQuery):
             SELECT obj.*
             FROM (%s) AS index_entry
             INNER JOIN (%s) AS obj ON obj."%s" = index_entry.typed_pk
-            ORDER BY index_entry.rank DESC
+            %s
             OFFSET %%s LIMIT %%s;
-            """ % (index_sql, model_sql, get_pk_column(model))
+            """ % (index_sql, model_sql, get_pk_column(model), order_sql)
         limits = (start, None if stop is None else stop - start)
         return model._default_manager.using(get_db_alias(queryset)).raw(
             sql, index_params + model_params + limits)

--- a/wagtail/contrib/postgres_search/backend.py
+++ b/wagtail/contrib/postgres_search/backend.py
@@ -266,9 +266,12 @@ class PostgresSearchQuery(BaseSearchQuery):
             sql, index_params + model_params + limits)
 
     def search_in_fields(self, queryset, search_query, start, stop):
+        # Due to a Django bug, arrays are not automatically converted here.
+        converted_weights = '{' + ','.join(map(str, WEIGHTS_VALUES)) + '}'
+
         return (self.get_in_fields_queryset(queryset, search_query)
                 .annotate(_rank_=SearchRank(F('_search_'), search_query,
-                                            weights=WEIGHTS_VALUES))
+                                            weights=converted_weights))
                 .order_by('-_rank_'))[start:stop]
 
     def search(self, config, start, stop):

--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -351,6 +351,7 @@ class Page(six.with_metaclass(PageBase, AbstractPage, index.Indexed, Clusterable
 
     search_fields = [
         index.SearchField('title', partial_match=True, boost=2),
+        index.FilterField('title'),
         index.FilterField('id'),
         index.FilterField('live'),
         index.FilterField('owner'),

--- a/wagtail/wagtaildocs/models.py
+++ b/wagtail/wagtaildocs/models.py
@@ -41,6 +41,7 @@ class AbstractDocument(CollectionMember, index.Indexed, models.Model):
 
     search_fields = CollectionMember.search_fields + [
         index.SearchField('title', partial_match=True, boost=10),
+        index.FilterField('title'),
         index.RelatedFields('tags', [
             index.SearchField('name', partial_match=True, boost=10),
         ]),

--- a/wagtail/wagtailimages/models.py
+++ b/wagtail/wagtailimages/models.py
@@ -140,6 +140,7 @@ class AbstractImage(CollectionMember, index.Indexed, models.Model):
 
     search_fields = CollectionMember.search_fields + [
         index.SearchField('title', partial_match=True, boost=10),
+        index.FilterField('title'),
         index.RelatedFields('tags', [
             index.SearchField('name', partial_match=True, boost=10),
         ]),

--- a/wagtail/wagtailsearch/tests/test_page_search.py
+++ b/wagtail/wagtailsearch/tests/test_page_search.py
@@ -34,6 +34,9 @@ class PageSearchTests(object):
         if index:
             index.refresh()
 
+    def test_order_by_title(self):
+        list(Page.objects.order_by('title').search('blah', order_by_relevance=False, backend=self.backend_name))
+
     def test_search_specific_queryset(self):
         list(Page.objects.specific().search('bread', backend=self.backend_name))
 

--- a/wagtail/wagtailsearch/tests/test_page_search.py
+++ b/wagtail/wagtailsearch/tests/test_page_search.py
@@ -1,0 +1,46 @@
+from __future__ import absolute_import, unicode_literals
+
+from django.conf import settings
+from django.test import TestCase
+
+from wagtail.wagtailcore.models import Page
+from wagtail.wagtailsearch.backends import get_search_backend
+
+
+class PageSearchTests(object):
+    # A TestCase with this class mixed in will be dynamically created
+    # for each search backend defined in WAGTAILSEARCH_BACKENDS, with the backend name available
+    # as self.backend_name
+
+    fixtures = ['test.json']
+
+    def setUp(self):
+        self.backend = get_search_backend(self.backend_name)
+        self.reset_index()
+        for page in Page.objects.all():
+            self.backend.add(page)
+        self.refresh_index()
+
+    def reset_index(self):
+        if self.backend.rebuilder_class:
+            index = self.backend.get_index_for_model(Page)
+            rebuilder = self.backend.rebuilder_class(index)
+            index = rebuilder.start()
+            index.add_model(Page)
+            rebuilder.finish()
+
+    def refresh_index(self):
+        index = self.backend.get_index_for_model(Page)
+        if index:
+            index.refresh()
+
+    def test_search_specific_queryset(self):
+        list(Page.objects.specific().search('bread', backend=self.backend_name))
+
+    def test_search_specific_queryset_with_fields(self):
+        list(Page.objects.specific().search('bread', fields=['title'], backend=self.backend_name))
+
+
+for backend_name in settings.WAGTAILSEARCH_BACKENDS.keys():
+    test_name = str("Test%sBackend" % backend_name.title())
+    globals()[test_name] = type(test_name, (PageSearchTests, TestCase,), {'backend_name': backend_name})


### PR DESCRIPTION
Multiple issues prevent `Page.objects.order_by('title').search('blah', order_by_relevance=False)` from working on Wagtail 1.12.x:

* #3725 (broken `order_by_relevance` on Postgres, fixed in #3726 and backported here)
* 'title' is not defined as a `FilterField` - fixed as part of #3957 and cherry-picked here

Since the original test from #3726 seems to have been the one that set off a snowball effect of broken search tests that (I think) was only properly resolved at the Bristol sprint, I've skipped those commits and added a new test as part of the test_page_search module introduced in #4018.