### PR TITLE
Forms: Optional form redirect on submit

### DIFF
--- a/wagtail/wagtailforms/models.py
+++ b/wagtail/wagtailforms/models.py
@@ -260,20 +260,28 @@ class AbstractForm(Page):
             page=self,
         )
 
+    def render_landing_page(self, request, *args, **kwargs):
+        """
+        Renders the landing page.
+
+        You can override this method to return a different HttpResponse as
+        landing page. E.g. you could return a redirect to a separate page.
+        """
+        # TODO: It is much better to redirect to it
+        return render(
+            request,
+            self.get_landing_page_template(request),
+            self.get_context(request)
+        )
+
     def serve(self, request, *args, **kwargs):
         if request.method == 'POST':
             form = self.get_form(request.POST, request.FILES, page=self, user=request.user)
 
             if form.is_valid():
                 self.process_form_submission(form)
-
-                # render the landing_page
-                # TODO: It is much better to redirect to it
-                return render(
-                    request,
-                    self.get_landing_page_template(request),
-                    self.get_context(request)
-                )
+                # Forwarding args and kwargs just in case for flexibility
+                return self.render_landing_page(request, *args, **kwargs)
         else:
             form = self.get_form(page=self, user=request.user)
 


### PR DESCRIPTION
Add an optional foreign key to a Page to the AbstractForm called receipt_page_redirect that if set will cause the form to redirect to this page instead of rendering the landing page on successful submit.

Expands on https://github.com/wagtail/wagtail/pull/4024 as a possible fix for https://github.com/wagtail/wagtail/issues/2834

_This is a "work in progress" and "request for comments" type of pull request, but I can't add labels myself._