### PR TITLE
Forms: redirect with GET param on submit

### DIFF
--- a/wagtail/tests/testapp/models.py
+++ b/wagtail/tests/testapp/models.py
@@ -482,7 +482,7 @@ class FormPageWithCustomSubmission(AbstractEmailForm):
             send_mail(self.subject, content, addresses, self.from_address,)
 
     def serve(self, request, *args, **kwargs):
-        if self.get_submission_class().objects.filter(page=self, user__pk=request.user.pk).exists():
+        if not request.GET.get('success') and self.get_submission_class().objects.filter(page=self, user__pk=request.user.pk).exists():
             return render(
                 request,
                 self.template,

--- a/wagtail/wagtailforms/models.py
+++ b/wagtail/wagtailforms/models.py
@@ -260,20 +260,28 @@ class AbstractForm(Page):
             page=self,
         )
 
+    def render_landing_page(self, request, *args, **kwargs):
+        """
+        Renders the landing page.
+
+        You can override this method to return a different HttpResponse as
+        landing page. E.g. you could return a redirect to a separate page.
+        """
+        # TODO: It is much better to redirect to it
+        return render(
+            request,
+            self.get_landing_page_template(request),
+            self.get_context(request)
+        )
+
     def serve(self, request, *args, **kwargs):
         if request.method == 'POST':
             form = self.get_form(request.POST, request.FILES, page=self, user=request.user)
 
             if form.is_valid():
                 self.process_form_submission(form)
-
-                # render the landing_page
-                # TODO: It is much better to redirect to it
-                return render(
-                    request,
-                    self.get_landing_page_template(request),
-                    self.get_context(request)
-                )
+                # Forwarding args and kwargs just in case for flexibility
+                return self.render_landing_page(request, *args, **kwargs)
         else:
             form = self.get_form(page=self, user=request.user)
 

--- a/wagtail/wagtailforms/models.py
+++ b/wagtail/wagtailforms/models.py
@@ -6,7 +6,7 @@ import os
 from django.contrib.contenttypes.models import ContentType
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db import models
-from django.shortcuts import render, redirect
+from django.shortcuts import redirect, render
 from django.utils.text import slugify
 from django.utils.translation import ugettext_lazy as _
 from unidecode import unidecode

--- a/wagtail/wagtailforms/models.py
+++ b/wagtail/wagtailforms/models.py
@@ -6,7 +6,7 @@ import os
 from django.contrib.contenttypes.models import ContentType
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db import models
-from django.shortcuts import render
+from django.shortcuts import render, redirect
 from django.utils.text import slugify
 from django.utils.translation import ugettext_lazy as _
 from unidecode import unidecode
@@ -267,7 +267,6 @@ class AbstractForm(Page):
         You can override this method to return a different HttpResponse as
         landing page. E.g. you could return a redirect to a separate page.
         """
-        # TODO: It is much better to redirect to it
         return render(
             request,
             self.get_landing_page_template(request),
@@ -280,9 +279,12 @@ class AbstractForm(Page):
 
             if form.is_valid():
                 self.process_form_submission(form)
+                return redirect(self.url + '?success=True', permanent=False)
+        else:
+            if request.GET.get('success'):
                 # Forwarding args and kwargs just in case for flexibility
                 return self.render_landing_page(request, *args, **kwargs)
-        else:
+
             form = self.get_form(page=self, user=request.user)
 
         context = self.get_context(request)

--- a/wagtail/wagtailforms/tests/test_models.py
+++ b/wagtail/wagtailforms/tests/test_models.py
@@ -34,7 +34,7 @@ class TestFormSubmission(TestCase):
             'your-email': 'bob',
             'your-message': 'hello world',
             'your-choices': ''
-        })
+        }, follow=True)
 
         # Check response
         self.assertContains(response, "Enter a valid email address.")
@@ -46,7 +46,7 @@ class TestFormSubmission(TestCase):
             'your-email': 'bob@example.com',
             'your-message': 'hello world',
             'your-choices': {'foo': '', 'bar': '', 'baz': ''}
-        })
+        }, follow=True)
 
         # Check response
         self.assertContains(response, "Thank you for your feedback.")
@@ -88,7 +88,7 @@ class TestFormSubmission(TestCase):
             'your-email': 'bob@example.com',
             'your-message': 'hello world',
             'your-choices': {'foo': 'on', 'bar': 'on', 'baz': 'on'}
-        })
+        }, follow=True)
 
         # Check response
         self.assertContains(response, "Thank you for your feedback.")
@@ -116,7 +116,7 @@ class TestFormSubmission(TestCase):
             'your-email': 'bob@example.com',
             'your-message': 'hello world',
             'your-choices': {},
-        })
+        }, follow=True)
 
         # Check response
         self.assertContains(response, "Thank you for your feedback.")
@@ -168,7 +168,7 @@ class TestFormWithCustomSubmission(TestCase, WagtailTestUtils):
             'your-email': 'bob',
             'your-message': 'hello world',
             'your-choices': ''
-        })
+        }, follow=True)
 
         # Check response
         self.assertContains(response, "Enter a valid email address.")
@@ -180,7 +180,7 @@ class TestFormWithCustomSubmission(TestCase, WagtailTestUtils):
             'your-email': 'bob@example.com',
             'your-message': 'hello world',
             'your-choices': {'foo': '', 'bar': '', 'baz': ''}
-        })
+        }, follow=True)
 
         # Check response
         self.assertContains(response, "Thank you for your patience!")
@@ -207,7 +207,7 @@ class TestFormWithCustomSubmission(TestCase, WagtailTestUtils):
             'your-email': 'bob@example.com',
             'your-message': 'hello world',
             'your-choices': {'foo': '', 'bar': '', 'baz': ''}
-        })
+        }, follow=True)
 
         # Check response
         self.assertTemplateNotUsed(response, 'tests/form_page_with_custom_submission.html')
@@ -225,7 +225,7 @@ class TestFormWithCustomSubmission(TestCase, WagtailTestUtils):
             'your-email': 'bob@example.com',
             'your-message': 'hello world',
             'your-choices': {'foo': '', 'bar': '', 'baz': ''}
-        })
+        }, follow=True)
 
         # Check response
         self.assertTemplateUsed(response, 'tests/form_page_with_custom_submission.html')
@@ -246,7 +246,7 @@ class TestFormWithCustomSubmission(TestCase, WagtailTestUtils):
             'your-email': 'bob@example.com',
             'your-message': 'こんにちは、世界',
             'your-choices': {'foo': '', 'bar': '', 'baz': ''}
-        })
+        }, follow=True)
 
         # Check the email
         self.assertEqual(len(mail.outbox), 1)
@@ -262,7 +262,7 @@ class TestFormWithCustomSubmission(TestCase, WagtailTestUtils):
             'your-email': 'bob@example.com',
             'your-message': 'hello world',
             'your-choices': {'foo': 'on', 'bar': 'on', 'baz': 'on'}
-        })
+        }, follow=True)
 
         # Check response
         self.assertContains(response, "Thank you for your patience!")
@@ -283,7 +283,7 @@ class TestFormWithCustomSubmission(TestCase, WagtailTestUtils):
             'your-email': 'bob@example.com',
             'your-message': 'hello world',
             'your-choices': {},
-        })
+        }, follow=True)
 
         # Check response
         self.assertContains(response, "Thank you for your patience!")
@@ -305,7 +305,7 @@ class TestFormSubmissionWithMultipleRecipients(TestCase):
             'your-email': 'bob@example.com',
             'your-message': 'hello world',
             'your-choices': {'foo': '', 'bar': '', 'baz': ''}
-        })
+        }, follow=True)
 
         # Check response
         self.assertContains(response, "Thank you for your feedback.")
@@ -342,7 +342,7 @@ class TestFormSubmissionWithMultipleRecipientsAndWithCustomSubmission(TestCase, 
             'your-email': 'bob@example.com',
             'your-message': 'hello world',
             'your-choices': {'foo': '', 'bar': '', 'baz': ''}
-        })
+        }, follow=True)
 
         # Check response
         self.assertContains(response, "Thank you for your patience!")
@@ -387,7 +387,7 @@ class TestIssue798(TestCase):
             'your-message': 'hello world',
             'your-choices': {'foo': '', 'bar': '', 'baz': ''},
             'your-favourite-number': '7.3',
-        })
+        }, follow=True)
 
         # Check response
         self.assertTemplateUsed(response, 'tests/form_page_landing.html')


### PR DESCRIPTION
Redirect to self with a GET param: `?success=True`.
By redirecting to a GET request with special parameter, on form submit this prevents warnings about reposting in the browser; and gives the receipt page a GET-able url which makes testing the design of the receipt page a lot less painful. This also allows conversion tracking based on the url.

This is an alternative fix for https://github.com/wagtail/wagtail/issues/2834, see also https://github.com/wagtail/wagtail/pull/4025 for an alternative/complementary fix.

### Todos:
- Maybe the success param name should be configurable or localized?
- Maye the test for the success parameter should be moved to a method? E.g. `is_landing_page` or something...
    
Note: I had to modify the model `wagtail.tests.testapp.models.FormPageWithCustomSubmission` to make the tests work. (But I figure this is fair enough, because when you override the workings of a Class to that extent you can't expect it not to break on updates sometimes.)

