### PR TITLE
Process CSS with cssnano in development build

### DIFF
--- a/gulpfile.js/tasks/styles.js
+++ b/gulpfile.js/tasks/styles.js
@@ -40,7 +40,7 @@ gulp.task('styles:css', function() {
     });
 
     return gulp.src(sources, {base: '.'})
-        .pipe(config.isProduction ? cssnano(cssnanoConfig) : gutil.noop())
+        .pipe(cssnano(cssnanoConfig))
         .pipe(autoprefixer(autoprefixerConfig))
         .pipe(renameSrcToDest())
         .pipe(size({ title: 'Vendor CSS' }))
@@ -66,7 +66,7 @@ gulp.task('styles:sass', function () {
             includePaths: includePaths,
             outputStyle: 'expanded'
         }).on('error', sass.logError))
-        .pipe(config.isProduction ? cssnano(cssnanoConfig) : gutil.noop())
+        .pipe(cssnano(cssnanoConfig))
         .pipe(autoprefixer(autoprefixerConfig))
         .pipe(size({ title: 'Wagtail CSS' }))
         .pipe(config.isProduction ? gutil.noop() : sourcemaps.write())


### PR DESCRIPTION
Follow-up to https://github.com/wagtail/wagtail/issues/3944#issuecomment-342874112, #3944. cssnano will now process the CSS in dev mode too, hopefully reducing the risk of it introducing issues that then go unnoticed.

Source maps still work as expected so this doesn't change the debug-ability of stylesheets. The compilation task is a bit slower (2-3x slower, ±2-3s on my 2015 MBP) but that sounds acceptable.