### PR TITLE
Add classname to sequence blocks (ListBlock & StreamBlock)

### DIFF
--- a/wagtail/wagtailadmin/templates/wagtailadmin/block_forms/list.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/block_forms/list.html
@@ -1,7 +1,7 @@
 {% extends "wagtailadmin/block_forms/sequence.html" %}
 {% load i18n %}
 
-{% block sequence_type_class %}list{% endblock %}
+{% block sequence_type_class %}list{% if classes %} {{ classes }}{% endif %}{% endblock %}
 
 {% block header %}
     {% if help_text %}

--- a/wagtail/wagtailadmin/templates/wagtailadmin/block_forms/stream.html
+++ b/wagtail/wagtailadmin/templates/wagtailadmin/block_forms/stream.html
@@ -1,6 +1,6 @@
 {% extends "wagtailadmin/block_forms/sequence.html" %}
 
-{% block sequence_type_class %}stream{% endblock %}
+{% block sequence_type_class %}stream{% if classes %} {{ classes }}{% endif %}{% endblock %}
 
 {% block header %}
     {% if list_members_html %}

--- a/wagtail/wagtailcore/blocks/list_block.py
+++ b/wagtail/wagtailcore/blocks/list_block.py
@@ -90,6 +90,7 @@ class ListBlock(Block):
             'help_text': getattr(self.meta, 'help_text', None),
             'prefix': prefix,
             'list_members_html': list_members_html,
+            'classes': self.meta.classname,
         })
 
     def value_from_datadict(self, data, files, prefix):

--- a/wagtail/wagtailcore/blocks/stream_block.py
+++ b/wagtail/wagtailcore/blocks/stream_block.py
@@ -145,6 +145,7 @@ class BaseStreamBlock(Block):
             'child_blocks': sorted(self.child_blocks.values(), key=lambda child_block: child_block.meta.group),
             'header_menu_prefix': '%s-before' % prefix,
             'block_errors': error_dict.get(NON_FIELD_ERRORS),
+            'classes': self.meta.classname,
         })
 
     def value_from_datadict(self, data, files, prefix):

--- a/wagtail/wagtailcore/tests/test_blocks.py
+++ b/wagtail/wagtailcore/tests/test_blocks.py
@@ -1670,6 +1670,32 @@ class TestListBlock(WagtailTestUtils, SimpleTestCase):
         )
         self.assertIn('value="chocolate"', form_html)
 
+    def render_form_with_classname(self, classname):
+        class LinkBlock(blocks.StructBlock):
+            title = blocks.CharBlock()
+            link = blocks.URLBlock()
+
+        block = blocks.ListBlock(LinkBlock, classname=classname)
+
+        html = block.render_form([
+            {
+                'title': "Wagtail",
+                'link': 'http://www.wagtail.io',
+            },
+            {
+                'title': "Django",
+                'link': 'http://www.djangoproject.com',
+            },
+        ], prefix='links')
+
+        return html
+
+    def test_render_with_classname(self):
+        html = self.render_form_with_classname('special-list-class')
+        print(html)
+        # class should exist 2 times, once for template, once for actual
+        self.assertEqual(html.count('special-list-class'), 1)
+
 
 class TestStreamBlock(WagtailTestUtils, SimpleTestCase):
     def test_initialisation(self):


### PR DESCRIPTION
This is just a proof of concept to potentially resolve #4042 - this adds the `classname` classes to the templates for `ListBlock` and `StreamBlock`.

I would love some feedback on this.

* Tests added for ListBlock only, can add others if this is the way we want to resolve this.
* Not sure if we need to revise docs as `classname` is used in many examples in streamfield docs
* Linting has been run