### PR TITLE
RFC:21 Revision scheduled publishing

### DIFF
--- a/docs/editor_manual/new_pages/index.rst
+++ b/docs/editor_manual/new_pages/index.rst
@@ -18,5 +18,5 @@ Create new pages by clicking the **Add child page** button. This creates a child
    inserting_documents
    adding_multiple_items
    required_fields
-   the_promote_tab
+   Edit Page tabs <the_promote_tab>
    previewing_and_submitting_for_moderation

--- a/docs/editor_manual/new_pages/the_promote_tab.rst
+++ b/docs/editor_manual/new_pages/the_promote_tab.rst
@@ -2,7 +2,7 @@
  Edit Page tabs
 ================
 
-A common feature of the *Edit* pages for all page types is the two tabs at the top of the screen. The first, Content, is where you build the content of the page itself.
+A common feature of the *Edit* pages for all page types is the three tabs at the top of the screen. The first, *Content*, is where you build the content of the page itself.
 
 The Promote tab
 ~~~~~~~~~~~~~~~
@@ -22,8 +22,7 @@ The second, *Promote*, is where you can set all the 'metadata' (data about data!
 The Settings Tab
 ~~~~~~~~~~~~~~~~
 
-The *Settings* has two fields by default.
+The *Settings* tab has two fields by default.
 
-* **Go Live date/time:** Sets the time in which the changes should go live when published.  If you publish a page that has this field set to a time in the future it will be scheduled until the time comes.
-  See :ref:`scheduled_publishing` for more details.
-* **Expiry date/time:** Sets the time in which this page should be unpublished.
+* **Go Live date/time:** Sets the time at which the changes should go live when published. See :ref:`scheduled_publishing` for more details.
+* **Expiry date/time:** Sets the time at which this page should be unpublished.

--- a/docs/editor_manual/new_pages/the_promote_tab.rst
+++ b/docs/editor_manual/new_pages/the_promote_tab.rst
@@ -1,7 +1,11 @@
-The Promote tab
-~~~~~~~~~~~~~~~
+================
+ Edit Page tabs
+================
 
 A common feature of the *Edit* pages for all page types is the two tabs at the top of the screen. The first, Content, is where you build the content of the page itself.
+
+The Promote tab
+~~~~~~~~~~~~~~~
 
 The second, *Promote*, is where you can set all the 'metadata' (data about data!) for the page. Below is a description of all default fields in the promote tab and what they do.
 
@@ -14,3 +18,12 @@ The second, *Promote*, is where you can set all the 'metadata' (data about data!
 
 .. Note::
     You may see more fields than this in your promote tab. These are just the default fields, but you are free to add other fields to this section as necessary.
+
+The Settings Tab
+~~~~~~~~~~~~~~~~
+
+The *Settings* has two fields by default.
+
+* **Go Live date/time:** Sets the time in which the changes should go live when published.  If you publish a page that has this field set to a time in the future it will be scheduled until the time comes.
+  See :ref:`scheduled_publishing` for more details.
+* **Expiry date/time:** Sets the time in which this page should be unpublished.

--- a/docs/reference/management_commands.rst
+++ b/docs/reference/management_commands.rst
@@ -13,7 +13,7 @@ publish_scheduled_pages
 
     $ ./manage.py publish_scheduled_pages
 
-This command publishes or unpublishes pages that have had these actions scheduled by an editor. It is recommended to run this command once an hour.
+This command publishes, updates or unpublishes pages that have had these actions scheduled by an editor. It is recommended to run this command once an hour.
 
 
 .. _fixtree:

--- a/docs/reference/management_commands.rst
+++ b/docs/reference/management_commands.rst
@@ -13,7 +13,7 @@ publish_scheduled_pages
 
     $ ./manage.py publish_scheduled_pages
 
-This command publishes, updates or unpublishes pages that have had these actions scheduled by an editor. It is recommended to run this command once an hour.
+This command publishes, updates or unpublishes pages that have had these actions scheduled by an editor. We recommend running this command once an hour.
 
 
 .. _fixtree:

--- a/docs/reference/pages/theory.rst
+++ b/docs/reference/pages/theory.rst
@@ -95,3 +95,26 @@ For going beyond the basics of model definition and interrelation, it might help
     #.  A response object is returned by ``serve()`` and Django responds to the requester.
 
 You can apply custom behavior to this process by overriding ``Page`` class methods such as ``route()`` and ``serve()`` in your own models. For examples, see :ref:`model_recipes`.
+
+
+.. _scheduled_publishing:
+
+Scheduled Publishing
+~~~~~~~~~~~~~~~~~~~~
+
+Page publishing can be scheduled through the *Go live date/time* feature in the *Settings* tab of the *Edit* page. This allows you to set set up initial page publishing or a page update in advance and it will only happen at the
+scheduled time.
+In order for pages to be published at the scheduled time you should set up the :ref:`publish_scheduled_pages` management command.
+
+The basic workflow is as follows.
+
+* Scheduling a revision for a page that is not currently live schedules that page to go live when the scheduled time comes.
+* Scheduling a revision for a page that is already live schedules that revision to update the page when the time comes.
+* If page has a scheduled revision and you set another revision to publish immediately the scheduled revision will be unscheduled.
+
+The *Revisions* view for a given page will show which revision is scheduled and for when it is scheduled. A scheduled revision in teh list will also provide an *Unschedule* button to cancel it.
+
+
+ 
+
+

--- a/docs/reference/pages/theory.rst
+++ b/docs/reference/pages/theory.rst
@@ -102,17 +102,16 @@ You can apply custom behavior to this process by overriding ``Page`` class metho
 Scheduled Publishing
 ~~~~~~~~~~~~~~~~~~~~
 
-Page publishing can be scheduled through the *Go live date/time* feature in the *Settings* tab of the *Edit* page. This allows you to set set up initial page publishing or a page update in advance and it will only happen at the
-scheduled time.
+Page publishing can be scheduled through the *Go live date/time* feature in the *Settings* tab of the *Edit* page. This allows you to set set up initial page publishing or a page update in advance.
 In order for pages to be published at the scheduled time you should set up the :ref:`publish_scheduled_pages` management command.
 
-The basic workflow is as follows.
+The basic workflow is as follows:
 
-* Scheduling a revision for a page that is not currently live schedules that page to go live when the scheduled time comes.
-* Scheduling a revision for a page that is already live schedules that revision to update the page when the time comes.
-* If page has a scheduled revision and you set another revision to publish immediately the scheduled revision will be unscheduled.
+* Scheduling a revision for a page that is not currently live means that page will go live when the scheduled time comes.
+* Scheduling a revision for a page that is already live means that revision will be published when the time comes.
+* If page has a scheduled revision and you set another revision to publish immediately, the scheduled revision will be unscheduled.
 
-The *Revisions* view for a given page will show which revision is scheduled and for when it is scheduled. A scheduled revision in teh list will also provide an *Unschedule* button to cancel it.
+The *Revisions* view for a given page will show which revision is scheduled and when it is scheduled for. A scheduled revision in the list will also provide an *Unschedule* button to cancel it.
 
 
  

--- a/wagtail/admin/templates/wagtailadmin/pages/revisions/confirm_unschedule.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/revisions/confirm_unschedule.html
@@ -1,0 +1,21 @@
+{% extends "wagtailadmin/base.html" %}
+{% load i18n %}
+{% block titletag %}{% blocktrans with title=page.get_admin_display_title %}Unschedule Revision {{ revision.id }} for {{ title }}{% endblocktrans %}{% endblock %}
+{% block content %}
+    {% trans "Unschedule" as unschedule_str %}
+    {% include "wagtailadmin/shared/header.html" with title=unschedule_str subtitle=subtitle icon="doc-empty-inverse" %}
+
+    <div class="nice-padding">
+        <p>{% trans "Are you sure you want to unschedule this revision?" %}</p>
+        <form action="{% url 'wagtailadmin_pages:revisions_unschedule' page.id revision.id %}" method="POST">
+            {% csrf_token %}
+            <input type="hidden" name="next" value="{{ next }}">
+            <ul class="fields">
+                <li>
+                    <input type="submit" value="{% trans 'Yes, unschedule' %}" class="button">
+                    <a href="{% if next %}{{ next }}{% else %}{% url 'wagtailadmin_pages:revisions_index' page.id %}{% endif %}" class="button button-secondary">{% trans "No, don't unschedule" %}</a>
+                </li>
+            </ul>
+        </form>
+    </div>
+{% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/pages/revisions/list.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/revisions/list.html
@@ -36,6 +36,9 @@
                                 <li><a href="{% url 'wagtailadmin_pages:revisions_compare' page.id previous_revision.id revision.id %}" class="button button-small button-secondary">{% trans 'Compare with previous revision' %}</a></li>
                             {% endif %}
                             {% endwith %}
+			    {% if revision.approved_go_live_at %}
+				<li><a href="{% url 'wagtailadmin_pages:revisions_unschedule' page.id revision.id %}" class="button button-small button-secondary">{% trans 'Cancel scheduled publish' %}</a></li>
+			    {% endif %}
                         </ul>
                     </td>
                 </tr>

--- a/wagtail/admin/templates/wagtailadmin/pages/revisions/list.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/revisions/list.html
@@ -21,6 +21,7 @@
                             </span>
                             {% if revision == page.get_latest_revision %}({% trans 'Current draft' %}){% endif %}
                             {% if revision == page.live_revision %}({% trans 'Live version' %}){% endif %}
+			    {% if revision.approved_go_live_at %}({% trans 'Scheduled for' %} {{ revision.approved_go_live_at }}) {% endif %}
                         </h2>
 
                         <ul class="actions">

--- a/wagtail/admin/tests/test_pages_views.py
+++ b/wagtail/admin/tests/test_pages_views.py
@@ -1416,7 +1416,11 @@ class TestPageEdit(TestCase, WagtailTestUtils):
         # first_published_at should be 3 days ago.
         self.assertEqual(new_delta.days, -3)
 
-    def test_edit_post_publish_scheduled(self):
+    def test_edit_post_publish_scheduled_unpublished_page(self):
+        # Unpublish the page
+        self.child_page.live = False
+        self.child_page.save()
+
         go_live_at = timezone.now() + datetime.timedelta(days=1)
         expire_at = timezone.now() + datetime.timedelta(days=2)
         post_data = {
@@ -1449,7 +1453,11 @@ class TestPageEdit(TestCase, WagtailTestUtils):
             "A page scheduled for future publishing should have has_unpublished_changes=True"
         )
 
-    def test_edit_post_publish_now_an_already_scheduled(self):
+    def test_edit_post_publish_now_an_already_scheduled_unpublished_page(self):
+        # Unpublish the page
+        self.child_page.live = False
+        self.child_page.save()
+
         # First let's publish a page with a go_live_at in the future
         go_live_at = timezone.now() + datetime.timedelta(days=1)
         expire_at = timezone.now() + datetime.timedelta(days=2)

--- a/wagtail/admin/tests/test_pages_views.py
+++ b/wagtail/admin/tests/test_pages_views.py
@@ -1449,6 +1449,8 @@ class TestPageEdit(TestCase, WagtailTestUtils):
             "A page scheduled for future publishing should have has_unpublished_changes=True"
         )
 
+        self.assertEqual(child_page_new.status_string, "scheduled")
+
     def test_edit_post_publish_now_an_already_scheduled_unpublished_page(self):
         # Unpublish the page
         self.child_page.live = False
@@ -1472,8 +1474,10 @@ class TestPageEdit(TestCase, WagtailTestUtils):
 
         child_page_new = SimplePage.objects.get(id=self.child_page.id)
 
-        # The page should not be live anymore
+        # The page should not be live
         self.assertFalse(child_page_new.live)
+
+        self.assertEqual(child_page_new.status_string, "scheduled")
 
         # Instead a revision with approved_go_live_at should now exist
         self.assertTrue(
@@ -1531,6 +1535,8 @@ class TestPageEdit(TestCase, WagtailTestUtils):
 
         # The page should still be live
         self.assertTrue(child_page_new.live)
+
+        self.assertEqual(child_page_new.status_string, "live + scheduled")
 
         # Instead a revision with approved_go_live_at should now exist
         self.assertTrue(

--- a/wagtail/admin/tests/test_pages_views.py
+++ b/wagtail/admin/tests/test_pages_views.py
@@ -1392,8 +1392,6 @@ class TestPageEdit(TestCase, WagtailTestUtils):
 
         initial_delta = self.child_page.first_published_at - timezone.now()
 
-        go_live_at = timezone.now() + datetime.timedelta(days=1)
-        expire_at = timezone.now() + datetime.timedelta(days=2)
         first_published_at = timezone.now() - datetime.timedelta(days=2)
 
         post_data = {
@@ -1401,8 +1399,6 @@ class TestPageEdit(TestCase, WagtailTestUtils):
             'body': "Some content",
             'slug': 'hello-again-world',
             'action-publish': "Publish",
-            'go_live_at': submittable_timestamp(go_live_at),
-            'expire_at': submittable_timestamp(expire_at),
             'first_published_at': submittable_timestamp(first_published_at),
         }
         self.client.post(reverse('wagtailadmin_pages:edit', args=(self.child_page.id, )), post_data)

--- a/wagtail/admin/tests/test_pages_views.py
+++ b/wagtail/admin/tests/test_pages_views.py
@@ -389,7 +389,6 @@ class TestPageExplorerSignposting(TestCase, WagtailTestUtils):
         self.assertNotContains(response, "Pages created here will not be accessible")
 
 
-
 class TestExplorablePageVisibility(TestCase, WagtailTestUtils):
     """
     Test the way that the Explorable Pages functionality manifests within the Explorer.
@@ -3786,6 +3785,17 @@ class TestRevisions(TestCase, WagtailTestUtils):
         self.assertContains(response, "Replace current draft")
         self.assertContains(response, "Publish this revision")
 
+    def test_scheduled_revision(self):
+        self.last_christmas_revision.publish()
+        self.this_christmas_revision.approved_go_live_at = local_datetime(2014, 12, 26)
+        self.this_christmas_revision.save()
+        response = self.client.get(
+            reverse('wagtailadmin_pages:revisions_index', args=(self.christmas_event.id, ))
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'Scheduled for')
+        self.assertContains(response, formats.localize(parse_date('2014-12-26')))
+
 
 class TestCompareRevisions(TestCase, WagtailTestUtils):
     # Actual tests for the comparison classes can be found in test_compare.py
@@ -3871,6 +3881,7 @@ class TestIssue2599(TestCase, WagtailTestUtils):
     one more than numchild - however, index numbers are not reassigned on page deletion, so
     this can result in a path that collides with an existing page (which is invalid).
     """
+
     def test_issue_2599(self):
         homepage = Page.objects.get(id=2)
 
@@ -3916,6 +3927,7 @@ class TestIssue2492(TestCase, WagtailTestUtils):
     This test ensures that the specific_class url method is called
     when the 'view live' message button is created.
     """
+
     def setUp(self):
         self.root_page = Page.objects.get(id=2)
         child_page = SingleEventPage(
@@ -4080,6 +4092,7 @@ class TestInlinePanelMedia(TestCase, WagtailTestUtils):
     """
     Test that form media required by InlinePanels is correctly pulled in to the edit page
     """
+
     def test_inline_panel_media(self):
         homepage = Page.objects.get(id=2)
         self.login()
@@ -4099,6 +4112,7 @@ class TestInlineStreamField(TestCase, WagtailTestUtils):
     """
     Test that streamfields inside an inline child work
     """
+
     def test_inline_streamfield(self):
         homepage = Page.objects.get(id=2)
         self.login()
@@ -4201,6 +4215,7 @@ class TestIssue2994(TestCase, WagtailTestUtils):
     from wrongly interpreting this as the field being omitted from the form,
     we need to provide a custom value_omitted_from_data method.
     """
+
     def setUp(self):
         self.root_page = Page.objects.get(id=2)
         self.user = self.login()

--- a/wagtail/admin/tests/test_pages_views.py
+++ b/wagtail/admin/tests/test_pages_views.py
@@ -3789,12 +3789,17 @@ class TestRevisions(TestCase, WagtailTestUtils):
         self.last_christmas_revision.publish()
         self.this_christmas_revision.approved_go_live_at = local_datetime(2014, 12, 26)
         self.this_christmas_revision.save()
+        this_christmas_unschedule_url = reverse(
+            'wagtailadmin_pages:revisions_unschedule',
+            args=(self.christmas_event.id, self.this_christmas_revision.id)
+        )
         response = self.client.get(
             reverse('wagtailadmin_pages:revisions_index', args=(self.christmas_event.id, ))
         )
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'Scheduled for')
         self.assertContains(response, formats.localize(parse_date('2014-12-26')))
+        self.assertContains(response, this_christmas_unschedule_url)
 
 
 class TestCompareRevisions(TestCase, WagtailTestUtils):

--- a/wagtail/admin/urls/pages.py
+++ b/wagtail/admin/urls/pages.py
@@ -37,5 +37,6 @@ urlpatterns = [
     url(r'^(\d+)/revisions/$', pages.revisions_index, name='revisions_index'),
     url(r'^(\d+)/revisions/(\d+)/view/$', pages.revisions_view, name='revisions_view'),
     url(r'^(\d+)/revisions/(\d+)/revert/$', pages.revisions_revert, name='revisions_revert'),
+    url(r'^(\d+)/revisions/(\d+)/unschedule/$', pages.revisions_unschedule, name='revisions_unschedule'),
     url(r'^(\d+)/revisions/compare/(live|earliest|\d+)\.\.\.(live|latest|\d+)/$', pages.revisions_compare, name='revisions_compare'),
 ]

--- a/wagtail/admin/views/pages.py
+++ b/wagtail/admin/views/pages.py
@@ -335,6 +335,8 @@ def edit(request, page_id):
                 user=request.user,
                 submitted_for_moderation=is_submitting,
             )
+            # store submitted go_live_at for messgaing below
+            go_live_at = page.go_live_at
 
             # Publish
             if is_publishing:
@@ -345,7 +347,7 @@ def edit(request, page_id):
 
             # Notifications
             if is_publishing:
-                if page.go_live_at and page.go_live_at > timezone.now():
+                if go_live_at and go_live_at > timezone.now():
                     # Page has been scheduled for publishing in the future
 
                     if is_reverting:

--- a/wagtail/admin/views/pages.py
+++ b/wagtail/admin/views/pages.py
@@ -1111,3 +1111,7 @@ def revisions_compare(request, page_id, revision_id_a, revision_id_b):
         'revision_b': revision_b,
         'comparison': comparison,
     })
+
+
+def revisions_unschedule(request, revision_id):
+    pass

--- a/wagtail/admin/views/pages.py
+++ b/wagtail/admin/views/pages.py
@@ -358,11 +358,18 @@ def edit(request, page_id):
                             page.get_admin_display_title()
                         )
                     else:
-                        message = _(
-                            "Page '{0}' has been scheduled for publishing."
-                        ).format(
-                            page.get_admin_display_title()
-                        )
+                        if page.live:
+                            message = _(
+                                "Page '{0}' is live and this revision has been scheduled for publishing."
+                            ).format(
+                                page.get_admin_display_title()
+                            )
+                        else:
+                            message = _(
+                                "Page '{0}' has been scheduled for publishing."
+                            ).format(
+                                page.get_admin_display_title()
+                            )
 
                     messages.success(request, message, buttons=[
                         messages.button(

--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -995,7 +995,9 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
             else:
                 return _("draft")
         else:
-            if self.has_unpublished_changes:
+            if self.approved_schedule:
+                return _("live + scheduled")
+            elif self.has_unpublished_changes:
                 return _("live + draft")
             else:
                 return _("live")


### PR DESCRIPTION
This PR adds functionality for [Wagtail RFC 21](https://github.com/wagtail/rfcs/pull/21) allowing for scheduling revisions without unpublishing currently live pages.
