### PR TITLE
Fix issues with 'Customising generated forms'

### DIFF
--- a/docs/advanced_topics/customisation/page_editing_interface.rst
+++ b/docs/advanced_topics/customisation/page_editing_interface.rst
@@ -194,6 +194,7 @@ or to add custom validation logic for your models:
 .. code-block:: python
 
     from django import forms
+    import geocoder  # not in Wagtail, for example only - http://geocoder.readthedocs.io/
     from wagtail.wagtailadmin.edit_handlers import FieldPanel
     from wagtail.wagtailadmin.forms import WagtailAdminPageForm
     from wagtail.wagtailcore.models import Page
@@ -220,7 +221,7 @@ or to add custom validation logic for your models:
             page.duration = (page.end_date - page.start_date).days
 
             # Fetch the location by geocoding the address
-            page.location = geocoder.get_coordinates(self.cleaned_data['address'])
+            page.location = geocoder.arcgis(self.cleaned_data['address'])
 
             if commit:
                 page.save()
@@ -231,9 +232,10 @@ or to add custom validation logic for your models:
         start_date = models.DateField()
         end_date = models.DateField()
         duration = models.IntegerField()
-        location = models.CharField()
+        location = models.CharField(max_length=255)
 
         content_panels = [
+            FieldPanel('title'),
             FieldPanel('start_date'),
             FieldPanel('end_date'),
             FieldPanel('address'),


### PR DESCRIPTION
The 'Customising generated forms' example contains a few issues that might confuse those who are copy/pasting the code.

1. No reference to the `geocode` library and where it comes from, added imports and revised API usage
2. `location = models.CharField()` requires the `max_length` attribute set
3. `FieldPanel('title')` added to content panels, otherwise testing this out causes error because no title or slug exists

These issues were flagged in #3737
