### PR TITLE
Consistently un-escape attributes passed to rich text link/embed handlers

### DIFF
--- a/wagtail/core/rich_text.py
+++ b/wagtail/core/rich_text.py
@@ -148,10 +148,11 @@ FIND_ATTRS = re.compile(r'([\w-]+)\="([^"]*)"')
 
 def extract_attrs(attr_string):
     """
-    helper method to extract tag attributes as a dict. Does not escape HTML entities!
+    helper method to extract tag attributes, as a dict of un-escaped strings
     """
     attributes = {}
     for name, val in FIND_ATTRS.findall(attr_string):
+        val = val.replace('&lt;', '<').replace('&gt;', '>').replace('&quot;', '"').replace('&amp;', '&')
         attributes[name] = val
     return attributes
 

--- a/wagtail/core/tests/test_whitelist.py
+++ b/wagtail/core/tests/test_whitelist.py
@@ -143,3 +143,8 @@ class TestWhitelister(TestCase):
         string = '<b>snowman Yorkshire<!--[if gte mso 10]>MS word junk<![endif]--></b>'
         cleaned_string = Whitelister.clean(string)
         self.assertEqual(cleaned_string, '<b>snowman Yorkshire</b>')
+
+    def test_quoting(self):
+        string = '<img alt="Arthur &quot;two sheds&quot; Jackson" sheds="2">'
+        cleaned_string = Whitelister.clean(string)
+        self.assertEqual(cleaned_string, '<img alt="Arthur &quot;two sheds&quot; Jackson"/>')

--- a/wagtail/core/whitelist.py
+++ b/wagtail/core/whitelist.py
@@ -5,6 +5,7 @@ specific rules.
 import re
 
 from bs4 import BeautifulSoup, Comment, NavigableString, Tag
+from django.utils.html import escape
 
 ALLOWED_URL_SCHEMES = ['http', 'https', 'ftp', 'mailto', 'tel']
 
@@ -96,7 +97,13 @@ class Whitelister:
         attributes"""
         doc = BeautifulSoup(html, 'html5lib')
         cls.clean_node(doc, doc)
-        return doc.decode()
+
+        # Pass strings through django.utils.html.escape when generating the final HTML.
+        # This differs from BeautifulSoup's default EntitySubstitution.substitute_html formatter
+        # in that it escapes " to &quot; as well as escaping < > & - if we don't do this, then
+        # BeautifulSoup will try to be clever and use single-quotes to wrap attribute values,
+        # which confuses our regexp-based db-HTML-to-real-HTML conversion.
+        return doc.decode(formatter=escape)
 
     @classmethod
     def clean_node(cls, doc, node):

--- a/wagtail/embeds/tests.py
+++ b/wagtail/embeds/tests.py
@@ -11,6 +11,7 @@ from mock import patch
 
 from wagtail.tests.utils import WagtailTestUtils
 from wagtail.core import blocks
+from wagtail.core.rich_text import expand_db_html
 from wagtail.embeds import oembed_providers
 from wagtail.embeds.blocks import EmbedBlock, EmbedValue
 from wagtail.embeds.embeds import get_embed
@@ -615,3 +616,22 @@ class TestMediaEmbedHandler(TestCase):
         )
 
         self.assertEqual(result, '')
+
+    @patch('wagtail.embeds.embeds.get_embed')
+    def test_expand_html_escaping_end_to_end(self, get_embed):
+        get_embed.return_value = Embed(
+            url='http://www.youtube.com/watch/',
+            max_width=None,
+            type='video',
+            html='test html',
+            title='test title',
+            author_name='test author name',
+            provider_name='test provider name',
+            thumbnail_url='htto://test/thumbnail.url',
+            width=1000,
+            height=1000,
+        )
+
+        result = expand_db_html('<p>1 2 <embed embedtype="media" url="https://www.youtube.com/watch?v=O7D-1RG-VRk&amp;t=25" /> 3 4</p>')
+        self.assertIn('test html', result)
+        get_embed.assert_called_with('https://www.youtube.com/watch?v=O7D-1RG-VRk&t=25')

--- a/wagtail/images/formats.py
+++ b/wagtail/images/formats.py
@@ -19,7 +19,7 @@ class Format:
         when outputting this image within a rich text editor field
         """
         return 'data-embedtype="image" data-id="%d" data-format="%s" data-alt="%s" ' % (
-            image.id, self.name, alt_text
+            image.id, self.name, escape(alt_text)
         )
 
     def image_to_editor_html(self, image, alt_text):
@@ -37,7 +37,7 @@ class Format:
 
         return '<img %s%ssrc="%s" width="%d" height="%d" alt="%s">' % (
             extra_attributes, class_attr,
-            escape(rendition.url), rendition.width, rendition.height, alt_text
+            escape(rendition.url), rendition.width, rendition.height, escape(alt_text)
         )
 
 

--- a/wagtail/images/rich_text.py
+++ b/wagtail/images/rich_text.py
@@ -37,6 +37,6 @@ class ImageEmbedHandler:
         image_format = get_image_format(attrs['format'])
 
         if for_editor:
-            return image_format.image_to_editor_html(image, attrs['alt'])
+            return image_format.image_to_editor_html(image, attrs.get('alt', ''))
         else:
-            return image_format.image_to_html(image, attrs['alt'])
+            return image_format.image_to_html(image, attrs.get('alt', ''))

--- a/wagtail/images/tests/test_admin_views.py
+++ b/wagtail/images/tests/test_admin_views.py
@@ -1,4 +1,5 @@
 import json
+import re
 
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group, Permission
@@ -620,6 +621,9 @@ class TestImageChooserSelectFormatView(TestCase, WagtailTestUtils):
     def get(self, params={}):
         return self.client.get(reverse('wagtailimages:chooser_select_format', args=(self.image.id,)), params)
 
+    def post(self, post_data={}):
+        return self.client.post(reverse('wagtailimages:chooser_select_format', args=(self.image.id,)), post_data)
+
     def test_simple(self):
         response = self.get()
         self.assertEqual(response.status_code, 200)
@@ -630,6 +634,23 @@ class TestImageChooserSelectFormatView(TestCase, WagtailTestUtils):
         response = self.get(params={'alt_text': "some previous alt text"})
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'value=\\"some previous alt text\\"')
+
+    def test_post_response(self):
+        response = self.post({'format': 'left', 'alt_text': 'Arthur "two sheds" Jackson'})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response['Content-Type'], 'text/javascript')
+
+        # extract data as json from the code line: modal.respond('imageChosen', {json});
+        match = re.search(r'modal.respond\(\'imageChosen\', ([^\)]+)\);', response.content.decode())
+        self.assertTrue(match)
+        response_json = json.loads(match.group(1))
+
+        self.assertEqual(response_json['id'], self.image.id)
+        self.assertEqual(response_json['title'], "Test image")
+        self.assertEqual(response_json['format'], 'left')
+        self.assertEqual(response_json['alt'], 'Arthur "two sheds" Jackson')
+        self.assertIn('alt="Arthur &quot;two sheds&quot; Jackson"', response_json['html'])
 
 
 class TestImageChooserUploadView(TestCase, WagtailTestUtils):

--- a/wagtail/images/tests/test_rich_text.py
+++ b/wagtail/images/tests/test_rich_text.py
@@ -36,6 +36,16 @@ class TestImageEmbedHandler(TestCase):
         )
         self.assertIn('<img class="richtext-image left"', result)
 
+    def test_expand_db_attributes_escapes_alt_text(self):
+        Image.objects.create(id=1, title='Test', file=get_test_image_file())
+        result = ImageEmbedHandler.expand_db_attributes(
+            {'id': 1,
+             'alt': 'Arthur "two sheds" Jackson',
+             'format': 'left'},
+            False
+        )
+        self.assertIn('alt="Arthur &quot;two sheds&quot; Jackson"', result)
+
     def test_expand_db_attributes_for_editor(self):
         Image.objects.create(id=1, title='Test', file=get_test_image_file())
         result = ImageEmbedHandler.expand_db_attributes(
@@ -48,3 +58,17 @@ class TestImageEmbedHandler(TestCase):
             '<img data-embedtype="image" data-id="1" data-format="left" '
             'data-alt="test-alt" class="richtext-image left"', result
         )
+
+    def test_expand_db_attributes_for_editor_escapes_alt_text(self):
+        Image.objects.create(id=1, title='Test', file=get_test_image_file())
+        result = ImageEmbedHandler.expand_db_attributes(
+            {'id': 1,
+             'alt': 'Arthur "two sheds" Jackson',
+             'format': 'left'},
+            True
+        )
+        self.assertIn(
+            '<img data-embedtype="image" data-id="1" data-format="left" '
+            'data-alt="Arthur &quot;two sheds&quot; Jackson" class="richtext-image left"', result
+        )
+        self.assertIn('alt="Arthur &quot;two sheds&quot; Jackson"', result)

--- a/wagtail/images/tests/test_rich_text.py
+++ b/wagtail/images/tests/test_rich_text.py
@@ -46,6 +46,16 @@ class TestImageEmbedHandler(TestCase):
         )
         self.assertIn('alt="Arthur &quot;two sheds&quot; Jackson"', result)
 
+    def test_expand_db_attributes_with_missing_alt(self):
+        Image.objects.create(id=1, title='Test', file=get_test_image_file())
+        result = ImageEmbedHandler.expand_db_attributes(
+            {'id': 1,
+             'format': 'left'},
+            False
+        )
+        self.assertIn('<img class="richtext-image left"', result)
+        self.assertIn('alt=""', result)
+
     def test_expand_db_attributes_for_editor(self):
         Image.objects.create(id=1, title='Test', file=get_test_image_file())
         result = ImageEmbedHandler.expand_db_attributes(
@@ -72,3 +82,15 @@ class TestImageEmbedHandler(TestCase):
             'data-alt="Arthur &quot;two sheds&quot; Jackson" class="richtext-image left"', result
         )
         self.assertIn('alt="Arthur &quot;two sheds&quot; Jackson"', result)
+
+    def test_expand_db_attributes_for_editor_with_missing_alt(self):
+        Image.objects.create(id=1, title='Test', file=get_test_image_file())
+        result = ImageEmbedHandler.expand_db_attributes(
+            {'id': 1,
+             'format': 'left'},
+            True
+        )
+        self.assertIn(
+            '<img data-embedtype="image" data-id="1" data-format="left" '
+            'data-alt="" class="richtext-image left"', result
+        )

--- a/wagtail/images/tests/tests.py
+++ b/wagtail/images/tests/tests.py
@@ -208,6 +208,17 @@ class TestFormat(TestCase):
             'data-alt="test alt text" class="test classnames" src="[^"]+" width="1" height="1" alt="test alt text">',
         )
 
+    def test_image_to_editor_html_with_quoting(self):
+        result = self.format.image_to_editor_html(
+            self.image,
+            'Arthur "two sheds" Jackson'
+        )
+        self.assertRegex(
+            result,
+            '<img data-embedtype="image" data-id="0" data-format="test name" '
+            'data-alt="Arthur &quot;two sheds&quot; Jackson" class="test classnames" src="[^"]+" width="1" height="1" alt="Arthur &quot;two sheds&quot; Jackson">',
+        )
+
     def test_image_to_html_no_classnames(self):
         self.format.classnames = None
         result = self.format.image_to_html(self.image, 'test alt text')
@@ -216,6 +227,13 @@ class TestFormat(TestCase):
             '<img src="[^"]+" width="1" height="1" alt="test alt text">'
         )
         self.format.classnames = 'test classnames'
+
+    def test_image_to_html_with_quoting(self):
+        result = self.format.image_to_html(self.image, 'Arthur "two sheds" Jackson')
+        self.assertRegex(
+            result,
+            '<img class="test classnames" src="[^"]+" width="1" height="1" alt="Arthur &quot;two sheds&quot; Jackson">'
+        )
 
     def test_get_image_format(self):
         register_image_format(self.format)


### PR DESCRIPTION
Fixes #2669 and #3126; supersedes #3879 and #3882.

Previously, when converting the database representation of rich text to real HTML (for the front-end or editor), link/embed handlers received HTML-escaped versions of the attributes and were expected to leave the escaping intact in the final output. This was a horrible API which made it easy to slip up and introduce logic errors:

* wagtailembeds failed to un-escape ampersands in embed URLs before passing them to `get_embed`
* in wagtailimages, image format objects intentionally did not call `escape` on alt text since they expected to receive it in already-escaped form; unfortunately the image chooser modal failed to follow suit, and passed it an un-escaped string (which then got mangled in the HTML output).

This PR updates that API so that attributes are consistently un-escaped before handing off to those handlers (working on the reasonable assumption that the only HTML entities we'll see in our rich text data are `&lt;`, `&gt;`, `&quot;` and `&amp;`).

As a related fix, we tweak BeautifulSoup's HTML output to consistently use double-quotes for attributes, instead of trying to be clever and using single quotes to avoid `&quot;` entities. This ensures that our `FIND_ATTRS` regexp can reliably match them.