### PR TITLE
Removed use of six

### DIFF
--- a/wagtail/tests/utils.py
+++ b/wagtail/tests/utils.py
@@ -43,9 +43,6 @@ class WagtailTestUtils(object):
 
         return user
 
-    def assertRegex(self, *args, **kwargs):
-        six.assertRegex(self, *args, **kwargs)
-
     @staticmethod
     @contextmanager
     def ignore_deprecation_warnings():

--- a/wagtail/tests/utils.py
+++ b/wagtail/tests/utils.py
@@ -8,7 +8,6 @@ from django.contrib.auth import get_user_model
 from django.test import TestCase
 from django.test.testcases import assert_and_parse_html
 from django.urls import reverse
-from django.utils import six
 from django.utils.text import slugify
 
 from wagtail.tests.assert_logs import _AssertLogsContext

--- a/wagtail/wagtailadmin/forms.py
+++ b/wagtail/wagtailadmin/forms.py
@@ -12,7 +12,6 @@ from django.db import models, transaction
 from django.forms.widgets import TextInput
 from django.template.loader import render_to_string
 from django.utils import timezone
-from django.utils.six import with_metaclass
 from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_lazy, ungettext
 from modelcluster.forms import ClusterForm, ClusterFormMetaclass
@@ -293,7 +292,7 @@ class WagtailAdminModelFormMetaclass(ClusterFormMetaclass):
         return new_class
 
 
-class WagtailAdminModelForm(with_metaclass(WagtailAdminModelFormMetaclass, ClusterForm)):
+class WagtailAdminModelForm(ClusterForm, metaclass=WagtailAdminModelFormMetaclass):
     @property
     def media(self):
         # Include media from formsets forms. This allow StreamField in InlinePanel for example.

--- a/wagtail/wagtailadmin/menu.py
+++ b/wagtail/wagtailadmin/menu.py
@@ -5,13 +5,12 @@ from django.forms import Media, MediaDefiningClass
 from django.forms.utils import flatatt
 from django.template.loader import render_to_string
 from django.utils.safestring import mark_safe
-from django.utils.six import with_metaclass
 from django.utils.text import slugify
 
 from wagtail.wagtailcore import hooks
 
 
-class MenuItem(with_metaclass(MediaDefiningClass)):
+class MenuItem(metaclass=MediaDefiningClass):
     template = 'wagtailadmin/shared/menu_item.html'
 
     def __init__(self, label, url, name=None, classnames='', attrs=None, order=1000):

--- a/wagtail/wagtailadmin/search.py
+++ b/wagtail/wagtailadmin/search.py
@@ -5,7 +5,6 @@ from django.forms.utils import flatatt
 from django.template.loader import render_to_string
 from django.utils.functional import cached_property, total_ordering
 from django.utils.safestring import mark_safe
-from django.utils.six import with_metaclass
 from django.utils.text import slugify
 
 from wagtail.wagtailadmin.forms import SearchForm
@@ -13,7 +12,7 @@ from wagtail.wagtailcore import hooks
 
 
 @total_ordering
-class SearchArea(with_metaclass(MediaDefiningClass)):
+class SearchArea(metaclass=MediaDefiningClass):
     template = 'wagtailadmin/shared/search_area.html'
 
     def __init__(self, label, url, name=None, classnames='', attrs=None, order=1000):

--- a/wagtail/wagtailcore/blocks/base.py
+++ b/wagtail/wagtailcore/blocks/base.py
@@ -7,7 +7,6 @@ from django import forms
 from django.core import checks
 from django.core.exceptions import ImproperlyConfigured
 from django.template.loader import render_to_string
-from django.utils import six
 from django.utils.encoding import force_text
 from django.utils.safestring import mark_safe
 from django.utils.text import capfirst
@@ -39,7 +38,7 @@ class BaseBlock(type):
         return cls
 
 
-class Block(six.with_metaclass(BaseBlock, object)):
+class Block(metaclass=BaseBlock):
     name = ''
     creation_counter = 0
 

--- a/wagtail/wagtailcore/blocks/stream_block.py
+++ b/wagtail/wagtailcore/blocks/stream_block.py
@@ -8,8 +8,6 @@ from django.contrib.staticfiles.templatetags.staticfiles import static
 from django.core.exceptions import NON_FIELD_ERRORS, ValidationError
 from django.forms.utils import ErrorList
 from django.template.loader import render_to_string
-# Must be imported from Django so we get the new implementation of with_metaclass
-from django.utils import six
 from django.utils.html import format_html_join
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext as _
@@ -321,7 +319,7 @@ class BaseStreamBlock(Block):
         block_counts = {}
 
 
-class StreamBlock(six.with_metaclass(DeclarativeSubBlocksMetaclass, BaseStreamBlock)):
+class StreamBlock(BaseStreamBlock, metaclass=DeclarativeSubBlocksMetaclass):
     pass
 
 

--- a/wagtail/wagtailcore/blocks/struct_block.py
+++ b/wagtail/wagtailcore/blocks/struct_block.py
@@ -7,8 +7,6 @@ from django.contrib.staticfiles.templatetags.staticfiles import static
 from django.core.exceptions import ValidationError
 from django.forms.utils import ErrorList
 from django.template.loader import render_to_string
-# Must be imported from Django so we get the new implementation of with_metaclass
-from django.utils import six
 from django.utils.functional import cached_property
 from django.utils.html import format_html, format_html_join
 
@@ -189,7 +187,7 @@ class BaseStructBlock(Block):
         icon = "placeholder"
 
 
-class StructBlock(six.with_metaclass(DeclarativeSubBlocksMetaclass, BaseStructBlock)):
+class StructBlock(BaseStructBlock, metaclass=DeclarativeSubBlocksMetaclass):
     pass
 
 

--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -20,8 +20,7 @@ from django.db.models.functions import Concat, Substr
 from django.http import Http404
 from django.template.response import TemplateResponse
 from django.urls import reverse
-# Must be imported from Django so we get the new implementation of with_metaclass
-from django.utils import six, timezone
+from django.utils import timezone
 from django.utils.functional import cached_property
 from django.utils.text import capfirst, slugify
 from django.utils.translation import ugettext_lazy as _
@@ -235,7 +234,7 @@ class AbstractPage(MP_Node):
         abstract = True
 
 
-class Page(six.with_metaclass(PageBase, AbstractPage, index.Indexed, ClusterableModel)):
+class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
     title = models.CharField(
         verbose_name=_('title'),
         max_length=255,

--- a/wagtail/wagtailimages/tests/tests.py
+++ b/wagtail/wagtailimages/tests/tests.py
@@ -8,7 +8,6 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.test import TestCase, override_settings
 from django.urls import reverse
-from django.utils import six
 from mock import MagicMock
 from taggit.forms import TagField, TagWidget
 

--- a/wagtail/wagtailimages/tests/tests.py
+++ b/wagtail/wagtailimages/tests/tests.py
@@ -205,8 +205,8 @@ class TestFormat(TestCase):
             self.image,
             'test alt text'
         )
-        six.assertRegex(
-            self, result,
+        self.assertRegex(
+            result,
             '<img data-embedtype="image" data-id="0" data-format="test name" '
             'data-alt="test alt text" class="test classnames" src="[^"]+" width="1" height="1" alt="test alt text">',
         )
@@ -214,8 +214,8 @@ class TestFormat(TestCase):
     def test_image_to_html_no_classnames(self):
         self.format.classnames = None
         result = self.format.image_to_html(self.image, 'test alt text')
-        six.assertRegex(
-            self, result,
+        self.assertRegex(
+            result,
             '<img src="[^"]+" width="1" height="1" alt="test alt text">'
         )
         self.format.classnames = 'test classnames'


### PR DESCRIPTION
Per deprecation of Python 2, this seems to have been overlooked.