### PR TITLE
Fix 3997 Document / Image search on query change only

### DIFF
--- a/wagtail/wagtailadmin/static_src/wagtailadmin/js/core.js
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/js/core.js
@@ -219,7 +219,7 @@ $(function() {
         var searchCurrentIndex = 0;
         var searchNextIndex = 0;
 
-        $(window.headerSearch.termInput).on('keyup cut paste', function() {
+        $(window.headerSearch.termInput).on('keyup cut paste change', function() {
             clearTimeout($.data(this, 'timer'));
             var wait = setTimeout(search, 200);
             $(this).data('timer', wait);

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/js/core.js
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/js/core.js
@@ -251,18 +251,18 @@ $(function() {
                     },
                     complete: function() {
                         $(window.headerSearch.termInput).parent().removeClass(workingClasses);
-                      }
+                    }
                 });
             }
-      };
+        };
 
-      getURLParam = function(name) {
-          var results = new RegExp('[\?&]' + name + '=([^]*)').exec(window.location.search);
-          if (results) {
-              return results[1];
-          }
-          return '';
-      }
+        getURLParam = function(name) {
+            var results = new RegExp('[\?&]' + name + '=([^]*)').exec(window.location.search);
+            if (results) {
+                return results[1];
+            }
+            return '';
+        }
 
     }
 

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/js/core.js
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/js/core.js
@@ -231,26 +231,40 @@ $(function() {
         function search() {
             var workingClasses = 'icon-spinner';
 
-            $(window.headerSearch.termInput).parent().addClass(workingClasses);
-            searchNextIndex++;
-            var index = searchNextIndex;
-            $.ajax({
-                url: window.headerSearch.url,
-                data: {q: $(window.headerSearch.termInput).val()},
-                success: function(data, status) {
-                    if (index > searchCurrentIndex) {
-                        searchCurrentIndex = index;
-                        $(window.headerSearch.targetOutput).html(data).slideDown(800);
-                        window.history.pushState(null, 'Search results', '?q=' + $(window.headerSearch.termInput).val());
-                    }
-                },
+            var newQuery = $(window.headerSearch.termInput).val();
+            var currentQuery = getURLParam('q');
+            if (! currentQuery) { currentQuery = ""; }
+            // only do the query if it has changed for trimmed queries
+            // eg. " " === "" and "firstword " ==== "firstword"
+            if (currentQuery.trim() !== newQuery.trim()) {
+                $(window.headerSearch.termInput).parent().addClass(workingClasses);
+                searchNextIndex++;
+                var index = searchNextIndex;
+                $.ajax({
+                    url: window.headerSearch.url,
+                    data: {q: newQuery},
+                    success: function(data, status) {
+                        if (index > searchCurrentIndex) {
+                            searchCurrentIndex = index;
+                            $(window.headerSearch.targetOutput).html(data).slideDown(800);
+                            window.history.pushState(null, 'Search results', '?q=' + newQuery);
+                        }
+                    },
+                    complete: function() {
+                        $(window.headerSearch.termInput).parent().removeClass(workingClasses);
+                      }
+                });
+            }
 
-                complete: function() {
-                    $(window.headerSearch.termInput).parent().removeClass(workingClasses);
+            getURLParam = function(name) {
+                var results = new RegExp('[\?&]' + name + '=([^]*)').exec(window.location.href);
+                if (results == null) {
+                    return null;
+                } else {
+                    return results[1] || null;
                 }
-            });
+
         }
-    }
 
     /* Functions that need to run/rerun when active tabs are changed */
     $(document).on('shown.bs.tab', function(e) {

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/js/core.js
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/js/core.js
@@ -255,16 +255,18 @@ $(function() {
                       }
                 });
             }
+      };
 
-            getURLParam = function(name) {
-                var results = new RegExp('[\?&]' + name + '=([^]*)').exec(window.location.href);
-                if (results == null) {
-                    return null;
-                } else {
-                    return results[1] || null;
-                }
+      getURLParam = function(name) {
+          var results = new RegExp('[\?&]' + name + '=([^]*)').exec(window.location.href);
+          if (results == null) {
+              return null;
+          } else {
+              return results[1] || null;
+          }
+      };
 
-        }
+    }
 
     /* Functions that need to run/rerun when active tabs are changed */
     $(document).on('shown.bs.tab', function(e) {

--- a/wagtail/wagtailadmin/static_src/wagtailadmin/js/core.js
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/js/core.js
@@ -233,7 +233,6 @@ $(function() {
 
             var newQuery = $(window.headerSearch.termInput).val();
             var currentQuery = getURLParam('q');
-            if (! currentQuery) { currentQuery = ""; }
             // only do the query if it has changed for trimmed queries
             // eg. " " === "" and "firstword " ==== "firstword"
             if (currentQuery.trim() !== newQuery.trim()) {
@@ -258,13 +257,12 @@ $(function() {
       };
 
       getURLParam = function(name) {
-          var results = new RegExp('[\?&]' + name + '=([^]*)').exec(window.location.href);
-          if (results == null) {
-              return null;
-          } else {
-              return results[1] || null;
+          var results = new RegExp('[\?&]' + name + '=([^]*)').exec(window.location.search);
+          if (results) {
+              return results[1];
           }
-      };
+          return '';
+      }
 
     }
 


### PR DESCRIPTION
Fixes #3997 by ensuring that a new ajax search query (+ history push state) only triggers when the search query actually changes. eg pressing the 'up' key does not change the query but adding a letter does.

Also, added the search function to trigger on input change, I noticed that if you select a value from the browser auto-fill.

JS linting run, tested on Chrome 62, Firefox 48.0.2 and Safari 11.0.1 all on macOS 10.12.6