### PR TITLE
Update setup.cfg to drop support of Python 2

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bdist_wheel]
-universal = 1
+python-tag = py3
 
 [flake8]
 ignore = E501,E303


### PR DESCRIPTION
In #3922 we've removed classifiers for Python 2 from the `setup.py`, but `setup.cfg` also needs to be updated: we don't need to build universal wheel anymore.

Related to #3917