### PR TITLE
Fix typo for wagtailsnippets JS

### DIFF
--- a/gulpfile.js/config.js
+++ b/gulpfile.js/config.js
@@ -27,7 +27,7 @@ var apps = [
     new App('wagtail/documents', {'appName': 'wagtaildocs'}),
     new App('wagtail/embeds', {'appName': 'wagtailembeds'}),
     new App('wagtail/images', {'appName': 'wagtailimages'}),
-    new App('wagtail/snippets', {'appName': 'wagtailimages'}),
+    new App('wagtail/snippets', {'appName': 'wagtailsnippets'}),
     new App('wagtail/users', {'appName': 'wagtailusers'}),
     new App('wagtail/contrib/styleguide', {'appName': 'wagtailstyleguide'}),
     new App('wagtail/contrib/settings', {'appName': 'wagtailsettings'}),


### PR DESCRIPTION
Currently, it's not possible to select a snippet because the JS file is not loaded, resulting in the error:
ReferenceError: createSnippetChooser is not defined

This is due to a typo in the gulp config file.
