### PR TITLE
Django 2.0 fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ matrix:
      python: 3.4
    - env: TOXENV=py34-dj111-sqlite-noelasticsearch
      python: 3.4
+   - env: TOXENV=py34-dj20-mysql-noelasticsearch
+     python: 3.4
    - env: TOXENV=py35-dj111-postgres-noelasticsearch
      python: 3.5
    - env: TOXENV=py35-dj111-mysql-noelasticsearch
@@ -25,6 +27,8 @@ matrix:
    - env: TOXENV=py35-dj111-postgres-elasticsearch2 INSTALL_ELASTICSEARCH2=yes
      python: 3.5
      sudo: true
+   - env: TOXENV=py35-dj20-sqlite-noelasticsearch
+     python: 3.5
    - env: TOXENV=py36-dj111-sqlite-noelasticsearch
      python: 3.6
    - env: TOXENV=py36-dj111-postgres-noelasticsearch
@@ -36,6 +40,9 @@ matrix:
    - env: TOXENV=py36-dj111-postgres-elasticsearch2 INSTALL_ELASTICSEARCH2=yes
      python: 3.6
      sudo: true
+   - env: TOXENV=py36-dj20-sqlite-elasticsearch2 INSTALL_ELASTICSEARCH2=yes
+     python: 3.6
+     sudo: true
    - env: TOXENV=py36-dj111-postgres-elasticsearch5 INSTALL_ELASTICSEARCH5=yes
      python: 3.6
      sudo: true
@@ -43,10 +50,10 @@ matrix:
      python: 3.6
      sudo: true
   allow_failures:
-    - env: TOXENV=py36-dj20-postgres-noelasticsearch
     # Ignore failures on Elasticsearch tests because ES on Travis is intermittently flaky
     - env: TOXENV=py35-dj111-postgres-elasticsearch2 INSTALL_ELASTICSEARCH2=yes
     - env: TOXENV=py36-dj111-postgres-elasticsearch2 INSTALL_ELASTICSEARCH2=yes
+    - env: TOXENV=py36-dj20-sqlite-elasticsearch2 INSTALL_ELASTICSEARCH2=yes
     - env: TOXENV=py36-dj111-postgres-elasticsearch5 INSTALL_ELASTICSEARCH5=yes
     - env: TOXENV=py36-dj20-postgres-elasticsearch5 INSTALL_ELASTICSEARCH5=yes
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,17 +31,24 @@ matrix:
      python: 3.6
    - env: TOXENV=py36-dj111-mysql-noelasticsearch
      python: 3.6
+   - env: TOXENV=py36-dj20-postgres-noelasticsearch
+     python: 3.6
    - env: TOXENV=py36-dj111-postgres-elasticsearch2 INSTALL_ELASTICSEARCH2=yes
      python: 3.6
      sudo: true
    - env: TOXENV=py36-dj111-postgres-elasticsearch5 INSTALL_ELASTICSEARCH5=yes
      python: 3.6
      sudo: true
+   - env: TOXENV=py36-dj20-postgres-elasticsearch5 INSTALL_ELASTICSEARCH5=yes
+     python: 3.6
+     sudo: true
   allow_failures:
+    - env: TOXENV=py36-dj20-postgres-noelasticsearch
     # Ignore failures on Elasticsearch tests because ES on Travis is intermittently flaky
     - env: TOXENV=py35-dj111-postgres-elasticsearch2 INSTALL_ELASTICSEARCH2=yes
     - env: TOXENV=py36-dj111-postgres-elasticsearch2 INSTALL_ELASTICSEARCH2=yes
     - env: TOXENV=py36-dj111-postgres-elasticsearch5 INSTALL_ELASTICSEARCH5=yes
+    - env: TOXENV=py36-dj20-postgres-elasticsearch5 INSTALL_ELASTICSEARCH5=yes
 
 # Services
 services:

--- a/README.rst
+++ b/README.rst
@@ -80,7 +80,7 @@ We thank `BrowserStack <https://www.browserstack.com/>`_, who provide the projec
 
 Compatibility
 ~~~~~~~~~~~~~
-Wagtail supports Django 1.11.x on Python 3.4, 3.5 and 3.6. Supported database backends are PostgreSQL, MySQL and SQLite.
+Wagtail supports Django 1.11.x and 2.0 on Python 3.4, 3.5 and 3.6. Supported database backends are PostgreSQL, MySQL and SQLite.
 
 Contributing
 ~~~~~~~~~~~~

--- a/docs/getting_started/integrating_into_django.rst
+++ b/docs/getting_started/integrating_into_django.rst
@@ -5,7 +5,7 @@ Integrating Wagtail into a Django project
 
 Wagtail provides the ``wagtail start`` command and project template to get you started with a new Wagtail project as quickly as possible, but it's easy to integrate Wagtail into an existing Django project too.
 
-Wagtail is currently compatible with Django 1.11. First, install the ``wagtail`` package from PyPI:
+Wagtail is currently compatible with Django 1.11 and 2.0. First, install the ``wagtail`` package from PyPI:
 
 .. code-block:: console
 

--- a/docs/releases/2.0.rst
+++ b/docs/releases/2.0.rst
@@ -124,3 +124,9 @@ Removed support for Elasticsearch 1.x
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Elasticsearch 1.x is no longer supported in this release. Please upgrade to a 2.x or 5.x release of Elasticsearch before upgrading to Wagtail 2.0.
+
+
+``wagtail.images.views.serve.generate_signature`` now returns a string
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``generate_signature`` function in ``wagtail.images.views.serve``, used to build URLs for the :ref:`dynamic image serve view <using_images_outside_wagtail>`, now returns a string rather than a binary string. This ensures that any existing user code that builds up the final image URL with ``reverse`` will continue to work on Django 2.0 (which no longer allows binary strings to be passed to ``reverse``). Any code that expects a binary string as the return value of ``generate_string`` - for example, calling ``decode()`` on the result - will need to be updated. (Apps that need to preserve compatibility with earlier versions of Wagtail can call ``django.utils.encoding.force_text`` instead of ``decode``.)

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ except ImportError:
 
 
 install_requires = [
-    "Django>=1.11,<1.12",
+    "Django>=1.11,<2.1",
     "django-modelcluster>=3.1,<4.0",
     "django-taggit>=0.20,<1.0",
     "django-treebeard>=3.0,<5.0",
@@ -87,6 +87,7 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Framework :: Django',
         'Framework :: Django :: 1.11',
+        'Framework :: Django :: 2.0',
         'Topic :: Internet :: WWW/HTTP :: Site Management',
     ],
     install_requires=install_requires,

--- a/tox.ini
+++ b/tox.ini
@@ -41,7 +41,7 @@ deps =
 
     dj111: Django>=1.11b1,<2.0
     dj111-mssql: django-pyodbc-azure==1.11.0.0
-    dj20: Django==2.0rc1
+    dj20: Django>=2.0,<2.1
     dj20: git+https://github.com/jdufresne/django-taggit.git@dj20
     dj20: git+https://github.com/wagtail/django-modelcluster.git
     postgres: psycopg2>=2.6

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 skipsdist = True
 usedevelop = True
 
-envlist = py{34,35,36}-dj111-{sqlite,postgres,mysql,mssql}-{elasticsearch5,elasticsearch2,noelasticsearch},
+envlist = py{34,35,36}-dj{111,20}-{sqlite,postgres,mysql,mssql}-{elasticsearch5,elasticsearch2,noelasticsearch},
 
 [flake8]
 # D100: Missing docstring in public module
@@ -41,6 +41,9 @@ deps =
 
     dj111: Django>=1.11b1,<2.0
     dj111-mssql: django-pyodbc-azure==1.11.0.0
+    dj20: Django==2.0rc1
+    dj20: git+https://github.com/jdufresne/django-taggit.git@dj20
+    dj20: git+https://github.com/wagtail/django-modelcluster.git
     postgres: psycopg2>=2.6
     mysql: mysqlclient==1.3.6
     elasticsearch2: elasticsearch>=2,<3

--- a/wagtail/admin/tests/test_account_management.py
+++ b/wagtail/admin/tests/test_account_management.py
@@ -500,7 +500,7 @@ class TestPasswordReset(TestCase, WagtailTestUtils):
         self.assertEqual(len(mail.outbox), 0)
 
     def setup_password_reset_confirm_tests(self):
-        from django.utils.encoding import force_bytes
+        from django.utils.encoding import force_bytes, force_text
         from django.utils.http import urlsafe_base64_encode
 
         # Get user
@@ -510,7 +510,7 @@ class TestPasswordReset(TestCase, WagtailTestUtils):
         self.password_reset_token = PasswordResetTokenGenerator().make_token(self.user)
 
         # Generate a password reset uid
-        self.password_reset_uid = urlsafe_base64_encode(force_bytes(self.user.pk))
+        self.password_reset_uid = force_text(urlsafe_base64_encode(force_bytes(self.user.pk)))
 
         # Create url_args
         self.url_kwargs = dict(uidb64=self.password_reset_uid, token=self.password_reset_token)

--- a/wagtail/contrib/postgres_search/models.py
+++ b/wagtail/contrib/postgres_search/models.py
@@ -50,7 +50,7 @@ class IndexEntry(Model):
         unique_together = ('content_type', 'object_id')
         verbose_name = _('index entry')
         verbose_name_plural = _('index entries')
-        indexes = [GinIndex(['body_search'])]
+        indexes = [GinIndex(fields=['body_search'])]
 
     def __str__(self):
         return '%s: %s' % (self.content_type.name, self.content_object)

--- a/wagtail/contrib/routable_page/models.py
+++ b/wagtail/contrib/routable_page/models.py
@@ -1,10 +1,17 @@
+import django
 from django.conf.urls import url
 from django.http import Http404
 from django.template.response import TemplateResponse
-from django.urls.resolvers import RegexURLResolver
 
 from wagtail.core.models import Page
 from wagtail.core.url_routing import RouteResult
+
+if django.VERSION >= (2, 0):
+    from django.urls import URLResolver
+    from django.urls.resolvers import RegexPattern
+else:
+    from django.urls.resolvers import RegexURLResolver
+
 
 _creation_counter = 0
 
@@ -69,7 +76,10 @@ class RoutablePageMixin:
     def get_resolver(cls):
         if '_routablepage_urlresolver' not in cls.__dict__:
             subpage_urls = cls.get_subpage_urls()
-            cls._routablepage_urlresolver = RegexURLResolver(r'^/', subpage_urls)
+            if django.VERSION >= (2, 0):
+                cls._routablepage_urlresolver = URLResolver(RegexPattern(r'^/'), subpage_urls)
+            else:  # Django 1.11 fallback
+                cls._routablepage_urlresolver = RegexURLResolver(r'^/', subpage_urls)
 
         return cls._routablepage_urlresolver
 

--- a/wagtail/core/blocks/field_block.py
+++ b/wagtail/core/blocks/field_block.py
@@ -512,11 +512,11 @@ class RawHTMLBlock(FieldBlock):
     def get_prep_value(self, value):
         # explicitly convert to a plain string, just in case we're using some serialisation method
         # that doesn't cope with SafeText values correctly
-        return str(value)
+        return str(value) + ''
 
     def value_for_form(self, value):
         # need to explicitly mark as unsafe, or it'll output unescaped HTML in the textarea
-        return str(value)
+        return str(value) + ''
 
     def value_from_form(self, value):
         return mark_safe(value)

--- a/wagtail/core/management/commands/fixtree.py
+++ b/wagtail/core/management/commands/fixtree.py
@@ -10,6 +10,7 @@ from wagtail.core.models import Page
 
 class Command(BaseCommand):
     help = "Checks for data integrity errors on the page tree, and fixes them where possible."
+    stealth_options = ('delete_orphans',)
 
     def add_arguments(self, parser):
         parser.add_argument(

--- a/wagtail/core/tests/test_management_commands.py
+++ b/wagtail/core/tests/test_management_commands.py
@@ -114,7 +114,7 @@ class TestMovePagesCommand(TestCase):
     fixtures = ['test.json']
 
     def run_command(self, from_, to):
-        management.call_command('move_pages', str(from_), str(to), interactive=False, stdout=StringIO())
+        management.call_command('move_pages', str(from_), str(to), stdout=StringIO())
 
     def test_move_pages(self):
         # Get pages
@@ -135,7 +135,7 @@ class TestSetUrlPathsCommand(TestCase):
     fixtures = ['test.json']
 
     def run_command(self):
-        management.call_command('set_url_paths', interactive=False, stdout=StringIO())
+        management.call_command('set_url_paths', stdout=StringIO())
 
     def test_set_url_paths(self):
         self.run_command()
@@ -145,7 +145,7 @@ class TestReplaceTextCommand(TestCase):
     fixtures = ['test.json']
 
     def run_command(self, from_text, to_text):
-        management.call_command('replace_text', from_text, to_text, interactive=False, stdout=StringIO())
+        management.call_command('replace_text', from_text, to_text, stdout=StringIO())
 
     def test_replace_text(self):
         # Check that the christmas page is definitely about christmas

--- a/wagtail/images/forms.py
+++ b/wagtail/images/forms.py
@@ -77,9 +77,9 @@ class URLGeneratorForm(forms.Form):
             ('fill', _("Resize to fill")),
         ),
     )
-    width = forms.IntegerField(_("Width"), min_value=0)
-    height = forms.IntegerField(_("Height"), min_value=0)
-    closeness = forms.IntegerField(_("Closeness"), min_value=0, initial=0)
+    width = forms.IntegerField(label=_("Width"), min_value=0)
+    height = forms.IntegerField(label=_("Height"), min_value=0)
+    closeness = forms.IntegerField(label=_("Closeness"), min_value=0, initial=0)
 
 
 GroupImagePermissionFormSet = collection_member_permission_formset_factory(

--- a/wagtail/images/tests/test_admin_views.py
+++ b/wagtail/images/tests/test_admin_views.py
@@ -1065,7 +1065,7 @@ class TestGenerateURLView(TestCase, WagtailTestUtils):
         self.assertEqual(set(content_json.keys()), set(['url', 'preview_url']))
 
         expected_url = 'http://localhost/images/%(signature)s/%(image_id)d/fill-800x600/' % {
-            'signature': urlquote(generate_signature(self.image.id, 'fill-800x600').decode(), safe=urlquote_safechars),
+            'signature': urlquote(generate_signature(self.image.id, 'fill-800x600'), safe=urlquote_safechars),
             'image_id': self.image.id,
         }
         self.assertEqual(content_json['url'], expected_url)

--- a/wagtail/images/tests/tests.py
+++ b/wagtail/images/tests/tests.py
@@ -225,16 +225,16 @@ class TestFormat(TestCase):
 
 class TestSignatureGeneration(TestCase):
     def test_signature_generation(self):
-        self.assertEqual(generate_signature(100, 'fill-800x600'), b'xnZOzQyUg6pkfciqcfRJRosOrGg=')
+        self.assertEqual(generate_signature(100, 'fill-800x600'), 'xnZOzQyUg6pkfciqcfRJRosOrGg=')
 
     def test_signature_verification(self):
-        self.assertTrue(verify_signature(b'xnZOzQyUg6pkfciqcfRJRosOrGg=', 100, 'fill-800x600'))
+        self.assertTrue(verify_signature('xnZOzQyUg6pkfciqcfRJRosOrGg=', 100, 'fill-800x600'))
 
     def test_signature_changes_on_image_id(self):
-        self.assertFalse(verify_signature(b'xnZOzQyUg6pkfciqcfRJRosOrGg=', 200, 'fill-800x600'))
+        self.assertFalse(verify_signature('xnZOzQyUg6pkfciqcfRJRosOrGg=', 200, 'fill-800x600'))
 
     def test_signature_changes_on_filter_spec(self):
-        self.assertFalse(verify_signature(b'xnZOzQyUg6pkfciqcfRJRosOrGg=', 100, 'fill-800x700'))
+        self.assertFalse(verify_signature('xnZOzQyUg6pkfciqcfRJRosOrGg=', 100, 'fill-800x700'))
 
 
 class TestFrontendServeView(TestCase):

--- a/wagtail/images/views/serve.py
+++ b/wagtail/images/views/serve.py
@@ -9,6 +9,7 @@ from django.core.exceptions import ImproperlyConfigured, PermissionDenied
 from django.http import HttpResponse, HttpResponsePermanentRedirect, StreamingHttpResponse
 from django.shortcuts import get_object_or_404
 from django.utils.decorators import classonlymethod
+from django.utils.encoding import force_text
 from django.views.generic import View
 
 from wagtail.utils.sendfile import sendfile
@@ -28,11 +29,11 @@ def generate_signature(image_id, filter_spec, key=None):
     # Based on libthumbor hmac generation
     # https://github.com/thumbor/libthumbor/blob/b19dc58cf84787e08c8e397ab322e86268bb4345/libthumbor/crypto.py#L50
     url = '{}/{}/'.format(image_id, filter_spec)
-    return base64.urlsafe_b64encode(hmac.new(key, url.encode(), hashlib.sha1).digest())
+    return force_text(base64.urlsafe_b64encode(hmac.new(key, url.encode(), hashlib.sha1).digest()))
 
 
 def verify_signature(signature, image_id, filter_spec, key=None):
-    return signature == generate_signature(image_id, filter_spec, key=key)
+    return force_text(signature) == generate_signature(image_id, filter_spec, key=key)
 
 
 class ServeView(View):

--- a/wagtail/search/tests/test_backends.py
+++ b/wagtail/search/tests/test_backends.py
@@ -33,7 +33,7 @@ class BackendTests(WagtailTestUtils):
             # no conf entry found - skip tests for this backend
             raise unittest.SkipTest("No WAGTAILSEARCH_BACKENDS entry for the backend %s" % self.backend_path)
 
-        management.call_command('update_index', backend_name=self.backend_name, interactive=False, stdout=StringIO())
+        management.call_command('update_index', backend_name=self.backend_name, stdout=StringIO())
 
     def assertUnsortedListEqual(self, a, b):
         """

--- a/wagtail/search/tests/test_queries.py
+++ b/wagtail/search/tests/test_queries.py
@@ -137,7 +137,7 @@ class TestGarbageCollectCommand(TestCase):
             SearchPromotion.objects.create(query=q, page_id=1, sort_order=0, description='Test')
             promoted_querie_ids.append(q.id)
 
-        management.call_command('search_garbage_collect', interactive=False, stdout=StringIO())
+        management.call_command('search_garbage_collect', stdout=StringIO())
 
         self.assertFalse(models.Query.objects.filter(id__in=querie_ids_to_be_deleted).exists())
         self.assertFalse(models.QueryDailyHits.objects.filter(


### PR DESCRIPTION
Enough to get the test suite _running_ ~(but not succeeding...)~

All tests fixed now. Just one backwards compatibility to note - the image serve view's `generate_signature` method now returns a string instead of a bytestring, so that it's valid to pass to `reverse()`. Upgrade consideration note added.