### PR TITLE
[fix] wagtailcore.query.specific_iterator: check if value is present

### DIFF
--- a/wagtail/wagtailcore/query.py
+++ b/wagtail/wagtailcore/query.py
@@ -384,7 +384,10 @@ def specific_iterator(qs):
 
     # Yield all of the pages, in the order they occurred in the original query.
     for pk, content_type in pks_and_types:
-        yield pages_by_type[content_type][pk]
+        try:
+            yield pages_by_type[content_type][pk]
+        except KeyError:
+            continue
 
 
 # Django 1.9 changed how extending QuerySets with different iterators behaved


### PR DESCRIPTION
**Warning** This PR aim to be merged on `stable/1.12.x` branch

## Description

[wagtailcore.query.specific_iterator](https://github.com/wagtail/wagtail/blob/stable/1.12.x/wagtail/wagtailcore/query.py#L360) should, IMHO, check if pk is present in `pages_by_type[content_type]` before returning the value.

We've got a use case where we limit platform's features by returning empty query set for models implied in disabled features, this is done at the model manager level.

This check prevent `specific_iterator` raising `KeyError` while generating sitemap for example.

IMHO, using get method on dictionary keys is a good practice.

Let me know your through.

## Q/A

* Do the tests still pass?

Yes

* Does the code comply with the style guide? (Run `make lint` from the Wagtail root)

Yes

* For Python changes: Have you added tests to cover the new/fixed behaviour?

Not ATM, let me know if you want a test for a simple fix like that.

* For new features: Has the documentation been updated accordingly?

It's not a new feature.