### PR TITLE
HTML col element has to be inside a colgroup

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/home/pages_for_moderation.html
+++ b/wagtail/admin/templates/wagtailadmin/home/pages_for_moderation.html
@@ -4,10 +4,12 @@
         <section>
             <h2>{% trans 'Pages awaiting moderation' %}</h2>
             <table class="listing">
-                <col />
-                <col width="30%"/>
-                <col width="15%"/>
-                <col width="15%"/>
+                <colgroup>
+                    <col />
+                    <col width="30%"/>
+                    <col width="15%"/>
+                    <col width="15%"/>
+                </colgroup>
                 <thead>
                     <tr>
                         <th class="title">{% trans "Title" %}</th>

--- a/wagtail/admin/templates/wagtailadmin/home/recent_edits.html
+++ b/wagtail/admin/templates/wagtailadmin/home/recent_edits.html
@@ -4,9 +4,11 @@
         <section>
             <h2>{% trans "Your most recent edits" %}</h2>
             <table class="listing listing-page">
-                <col />
-                <col width="15%"/>
-                <col width="15%"/>
+                <colgroup>
+                    <col />
+                    <col width="15%"/>
+                    <col width="15%"/>
+                </colgroup>
                 <thead>
                     <tr>
                         <th class="title">{% trans "Title" %}</th>

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_list.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_list.html
@@ -2,17 +2,19 @@
 {% load l10n %}
 {% load wagtailadmin_tags %}
 <table class="listing {% if full_width %}full-width{% endif %} {% block table_classname %}{% endblock %}">
-    {% if show_ordering_column %}
-        <col width="65px" />
-    {% endif %}
-    <col />
-    {% if show_parent %}
+    <colgroup>
+        {% if show_ordering_column %}
+            <col width="65px" />
+        {% endif %}
         <col />
-    {% endif %}
-    <col width="12%" />
-    <col width="12%" />
-    <col width="12%" />
-    <col width="10%" />
+        {% if show_parent %}
+            <col />
+        {% endif %}
+        <col width="12%" />
+        <col width="12%" />
+        <col width="12%" />
+        <col width="10%" />
+    </colgroup>
     <thead>
         {% block pre_parent_page_headers %}
         {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/pages/revisions/compare.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/revisions/compare.html
@@ -16,8 +16,10 @@
 
 
         <table class="listing">
-            <col width="15%" />
-            <col />
+            <colgroup>
+                <col width="15%" />
+                <col />
+            </colgroup>
 
             <thead>
                 <tr>

--- a/wagtail/admin/templates/wagtailadmin/pages/revisions/list.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/revisions/list.html
@@ -2,8 +2,9 @@
 {% load l10n %}
 
 <table class="listing">
-    <col width="100%" />
-
+    <colgroup>
+        <col width="100%" />
+    </colgroup>
     <thead>
         <tr>
             <th><a href="{% url 'wagtailadmin_pages:revisions_index' page.id %}?ordering={% if ordering == "created_at" %}-{% endif %}created_at" class="icon icon-arrow-{% if ordering == "created_at" %}up-after{% elif ordering == "-created_at" %}down-after{% else %}down-after{% endif %} {% if ordering == "created_at" or ordering == "-created_at" %}teal{% endif %}">{% trans 'Revision date' %}</a></th>

--- a/wagtail/admin/templates/wagtailadmin/permissions/includes/collection_member_permissions_formset.html
+++ b/wagtail/admin/templates/wagtailadmin/permissions/includes/collection_member_permissions_formset.html
@@ -12,11 +12,13 @@
 {% endif %}
 
 <table class="listing">
-    <col />
-    {% for i in formset.permission_types %}
-        <col width="15%" />
-    {% endfor %}
-    <col />
+    <colgroup>
+        <col />
+        {% for i in formset.permission_types %}
+            <col width="15%" />
+        {% endfor %}
+        <col />
+    </colgroup>
     <thead>
         <tr>
             <th>{% trans "Collection" %}</th>

--- a/wagtail/contrib/forms/templates/wagtailforms/list_forms.html
+++ b/wagtail/contrib/forms/templates/wagtailforms/list_forms.html
@@ -1,7 +1,9 @@
 {% load i18n %}
 <table class="listing">
-    <col width="50%"/>
-    <col width="50%"/>
+    <colgroup>
+        <col width="50%"/>
+        <col width="50%"/>
+    </colgroup>
     <thead>
         <tr>
             <th class="title">{% trans "Title" %}</th>

--- a/wagtail/contrib/forms/templates/wagtailforms/list_submissions.html
+++ b/wagtail/contrib/forms/templates/wagtailforms/list_submissions.html
@@ -1,9 +1,11 @@
 {% load i18n %}
 <div class="overflow">
 <table class="listing">
-    <col />
-    <col />
-    <col />
+    <colgroup>
+        <col />
+        <col />
+        <col />
+    </colgroup>
     <thead>
         <tr>
             <th colspan="{{ data_fields_with_ordering|length|add:1 }}">

--- a/wagtail/contrib/redirects/templates/wagtailredirects/list.html
+++ b/wagtail/contrib/redirects/templates/wagtailredirects/list.html
@@ -1,9 +1,11 @@
 {% load i18n %}
 <table class="listing">
-    <col width="35%"/>
-    <col width="30%"/>
-    <col width="25%"/>
-    <col />
+    <colgroup>
+        <col width="35%"/>
+        <col width="30%"/>
+        <col width="25%"/>
+        <col />
+    </colgroup>
     <thead>
         <tr>
             <th class="title">

--- a/wagtail/contrib/search_promotions/templates/wagtailsearchpromotions/list.html
+++ b/wagtail/contrib/search_promotions/templates/wagtailsearchpromotions/list.html
@@ -1,8 +1,10 @@
 {% load i18n %}
 <table class="listing">
-    <col width="40%" />
-    <col width="40%"/>
-    <col />
+    <colgroup>
+        <col width="40%" />
+        <col width="40%"/>
+        <col />
+    </colgroup>
     <thead>
         <tr>
             <th class="title">{% trans "Search term(s)" %}</th>

--- a/wagtail/documents/templates/wagtaildocs/documents/list.html
+++ b/wagtail/documents/templates/wagtaildocs/documents/list.html
@@ -1,8 +1,10 @@
 {% load i18n %}
 <table class="listing">
-    <col />
-    <col  />
-    <col width="16%" />
+    <colgroup>
+        <col />
+        <col  />
+        <col width="16%" />
+    </colgroup>
     <thead>
         <tr class="table-headers">
             <th>

--- a/wagtail/documents/templates/wagtaildocs/documents/usage.html
+++ b/wagtail/documents/templates/wagtaildocs/documents/usage.html
@@ -7,10 +7,12 @@
 
     <div class="nice-padding">
         <table class="listing">
-            <col />
-            <col width="30%"/>
-            <col width="15%"/>
-            <col width="15%"/>
+            <colgroup>
+                <col />
+                <col width="30%"/>
+                <col width="15%"/>
+                <col width="15%"/>
+            </colgroup>
             <thead>
                 <tr>
                     <th class="title">{% trans "Title" %}</th>

--- a/wagtail/images/templates/wagtailimages/images/usage.html
+++ b/wagtail/images/templates/wagtailimages/images/usage.html
@@ -7,10 +7,12 @@
 
     <div class="nice-padding">
         <table class="listing">
-            <col />
-            <col width="30%"/>
-            <col width="15%"/>
-            <col width="15%"/>
+            <colgroup>
+                <col />
+                <col width="30%"/>
+                <col width="15%"/>
+                <col width="15%"/>
+            </colgroup>
             <thead>
                 <tr>
                     <th class="title">{% trans "Title" %}</th>

--- a/wagtail/search/templates/wagtailsearch/queries/chooser/results.html
+++ b/wagtail/search/templates/wagtailsearch/queries/chooser/results.html
@@ -2,8 +2,10 @@
 {% load l10n %}
 {% load wagtailadmin_tags %}
 <table class="listing chooser">
-    <col width="50%"/>
-    <col width="50%"/>
+    <colgroup>
+        <col width="50%"/>
+        <col width="50%"/>
+    </colgroup>
     <thead>
         <tr>
             <th class="title">{% trans "Terms" %}</th>

--- a/wagtail/snippets/templates/wagtailsnippets/snippets/list.html
+++ b/wagtail/snippets/templates/wagtailsnippets/snippets/list.html
@@ -1,8 +1,10 @@
 {% load i18n %}
 <table class="listing">
-    <col />
-    <col  />
-    <col width="16%" />
+    <colgroup>
+        <col />
+        <col  />
+        <col width="16%" />
+    </colgroup>
     <thead>
         <tr class="table-headers">
             <th>{% trans "Title" %}</th>

--- a/wagtail/snippets/templates/wagtailsnippets/snippets/usage.html
+++ b/wagtail/snippets/templates/wagtailsnippets/snippets/usage.html
@@ -7,10 +7,12 @@
 
     <div class="nice-padding">
         <table class="listing">
-            <col />
-            <col width="30%"/>
-            <col width="15%"/>
-            <col width="15%"/>
+            <colgroup>
+                <col />
+                <col width="30%"/>
+                <col width="15%"/>
+                <col width="15%"/>
+            </colgroup>
             <thead>
                 <tr>
                     <th class="title">{% trans "Title" %}</th>

--- a/wagtail/users/templates/wagtailusers/groups/includes/formatted_permissions.html
+++ b/wagtail/users/templates/wagtailusers/groups/includes/formatted_permissions.html
@@ -2,10 +2,12 @@
 
 <h2>{% trans "Object permissions" %}</h2>
 <table class="listing">
-    <col />
-    <col width="15%" />
-    <col width="15%" />
-    <col width="15%" />
+    <colgroup>
+        <col />
+        <col width="15%" />
+        <col width="15%" />
+        <col width="15%" />
+    </colgroup>
     <thead>
         <tr>
             <th>{% trans "Name" %}</th>
@@ -34,8 +36,10 @@
 
 <h2>{% trans "Other permissions" %}</h2>
 <table class="listing">
-    <col />
-    <col width="45%" />
+    <colgroup>
+        <col />
+        <col width="45%" />
+    </colgroup>
     <thead>
         <tr>
             <th>{% trans "Name" %}</th>

--- a/wagtail/users/templates/wagtailusers/groups/includes/page_permissions_formset.html
+++ b/wagtail/users/templates/wagtailusers/groups/includes/page_permissions_formset.html
@@ -12,11 +12,13 @@
 {% endif %}
 
 <table class="listing page-permissions-listing">
-    <col />
-    {% for i in formset.permission_types %}
-        <col width="15%" />
-    {% endfor %}
-    <col />
+    <colgroup>
+        <col />
+        {% for i in formset.permission_types %}
+            <col width="15%" />
+        {% endfor %}
+        <col />
+    </colgroup>
     <thead>
         <tr>
             <th>{% trans "Page" %}</th>


### PR DESCRIPTION
I believe the `colgroup` tag needs to the parent of `col`-tags. The `width`-attribute of the col-tags is deprecated in HTML5. Should a ticket be created for it?

https://html.spec.whatwg.org/multipage/tables.html#the-colgroup-element
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/colgroup