### PR TITLE
Exception str to guide about missing Page instance inheritors

### DIFF
--- a/wagtail/wagtailcore/models.py
+++ b/wagtail/wagtailcore/models.py
@@ -721,7 +721,10 @@ class Page(six.with_metaclass(PageBase, AbstractPage, index.Indexed, Clusterable
             if commit:
                 self.save()
 
-            page_unpublished.send(sender=self.specific_class, instance=self.specific)
+            try:
+                page_unpublished.send(sender=self.specific_class, instance=self.specific)
+            except self.specific_class.DoesNotExist:
+                logger.warning("No specific inheritor when unpublishing: \"%s\" id=%d", self.title, self.id)
 
             logger.info("Page unpublished: \"%s\" id=%d", self.title, self.id)
 


### PR DESCRIPTION
Thanks for making Wagtail! :tada: 

I found that there's still some missing guidance after #3567. It's a modified version of #3554. To reproduce this error and make the main `/wagtail` (or `/admin`) view crash:

![image](https://user-images.githubusercontent.com/374612/33808538-9f044f08-dde8-11e7-8df0-99e2c7880a41.png)

1. Create a `MyPage` instance (some model inheriting from `Page` and then an instance of that model)
1. Remove the instance of `MyPage`, but not the parent `Page` object. On method is to migrate backwards and forwards again.

Exception after this PR:

![image](https://user-images.githubusercontent.com/374612/33808817-ccccd870-ddec-11e7-8cfc-6d614b46a67f.png)
