### PR TITLE
A simple Dockerfile for project template

### DIFF
--- a/wagtail/project_template/Dockerfile
+++ b/wagtail/project_template/Dockerfile
@@ -13,4 +13,4 @@ WORKDIR /code/
 
 EXPOSE 8000
 CMD python manage.py migrate
-CMD exec gunicorn wagtail_docker_test.wsgi:application --bind 0.0.0.0:8000 --workers 3
+CMD exec gunicorn {{ project_name }}.wsgi:application --bind 0.0.0.0:8000 --workers 3

--- a/wagtail/project_template/Dockerfile
+++ b/wagtail/project_template/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.6
+LABEL maintainer="hello@wagtail.io"
+
+ENV PYTHONUNBUFFERED 1
+ENV DJANGO_ENV dev
+
+COPY ./requirements.txt /code/requirements.txt
+RUN pip install -r /code/requirements.txt
+RUN pip install gunicorn
+
+COPY . /code/
+WORKDIR /code/
+
+EXPOSE 8000
+CMD python manage.py migrate
+CMD exec gunicorn wagtail_docker_test.wsgi:application --bind 0.0.0.0:8000 --workers 3

--- a/wagtail/project_template/Dockerfile
+++ b/wagtail/project_template/Dockerfile
@@ -11,6 +11,11 @@ RUN pip install gunicorn
 COPY . /code/
 WORKDIR /code/
 
+RUN python manage.py migrate
+
+RUN useradd wagtail
+RUN chown -R wagtail /code
+USER wagtail
+
 EXPOSE 8000
-CMD python manage.py migrate
 CMD exec gunicorn {{ project_name }}.wsgi:application --bind 0.0.0.0:8000 --workers 3


### PR DESCRIPTION
This Dockerfile makes it easy for Wagtail developers to build and deploy containers for their sites:

```
wagtail start mysite
cd mysite
docker build -t wagtail .
docker run -p 8000:8000 wagtail
```

> For new features: Has the documentation been updated accordingly?

Not yet - I'll add documentation if other core developers agree with this approach.