### PR TITLE
Fix support of ATOMIC_REBUILD for projects with elasticsearch client >=1.7.0

### DIFF
--- a/wagtail/search/backends/elasticsearch2.py
+++ b/wagtail/search/backends/elasticsearch2.py
@@ -639,7 +639,7 @@ class Elasticsearch2Index:
         return self.es.indices.exists(self.name)
 
     def is_alias(self):
-        return self.es.indices.exists_alias(self.name)
+        return self.es.indices.exists_alias(name=self.name)
 
     def aliased_indices(self):
         """


### PR DESCRIPTION
We need to use the `exists_alias` method with keyword arguments.

Documentation for the `elasticsearch` client suggests to pass arguments into exists_alias
as keyword arguments: http://elasticsearch-py.readthedocs.io/en/6.0.0/api.html#elasticsearch.client.IndicesClient.exists_alias

They changed order of arguments at least once:

* https://github.com/elastic/elasticsearch-py/blob/1.6.0/elasticsearch/client/indices.py#L378
* https://github.com/elastic/elasticsearch-py/blob/1.7.0/elasticsearch/client/indices.py#L385

This is also fixes support for `ATOMIC_REBUILD` for Elastichsearch >=5.5.0,<6.0.0