### PR TITLE
Search fixes cherry picking

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -40,6 +40,9 @@ Changelog
  * Fix: Project template now has password validators enabled by default (Matt Westcott)
  * Fix: Alignment options correctly removed from `TableBlock` context menu (LB (Ben Johnston))
  * Fix: Fix support of `ATOMIC_REBUILD` for projects with Elasticsearch client >=1.7.0 (Mikalai Radchuk)
+ * Fix: Fixed error on Elasticsearch backend when passing a queryset as an `__in` filter (Karl Hobley, Matt Westcott)
+ * Fix: `__isnull` filters no longer fail on Elasticsearch 5 (Karl Hobley)
+ * Fix: Prevented intermittent failures on Postgres search backend when a field is defined as both a `SearchField` and a `FilterField` (Matt Westcott)
 
 
 1.13.1 (17.11.2017)

--- a/docs/releases/2.0.rst
+++ b/docs/releases/2.0.rst
@@ -58,6 +58,9 @@ Bug fixes
  * Project template now has password validators enabled by default (Matt Westcott)
  * Alignment options correctly removed from ``TableBlock`` context menu (LB (Ben Johnston))
  * Fix support of ``ATOMIC_REBUILD`` for projects with Elasticsearch client ``>=1.7.0`` (Mikalai Radchuk)
+ * Fixed error on Elasticsearch backend when passing a queryset as an ``__in`` filter (Karl Hobley, Matt Westcott)
+ * ``__isnull`` filters no longer fail on Elasticsearch 5 (Karl Hobley)
+ * Prevented intermittent failures on Postgres search backend when a field is defined as both a ``SearchField`` and a ``FilterField`` (Matt Westcott)
 
 
 Upgrade considerations

--- a/wagtail/contrib/postgres_search/backend.py
+++ b/wagtail/contrib/postgres_search/backend.py
@@ -169,7 +169,7 @@ class PostgresSearchQuery(BaseSearchQuery):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.search_fields = self.queryset.model.get_search_fields()
+        self.search_fields = self.queryset.model.get_searchable_search_fields()
 
     def get_search_query(self, config):
         combine = OR if self.operator == 'or' else AND

--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -329,6 +329,7 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
 
     search_fields = [
         index.SearchField('title', partial_match=True, boost=2),
+        index.FilterField('title'),
         index.FilterField('id'),
         index.FilterField('live'),
         index.FilterField('owner'),

--- a/wagtail/documents/models.py
+++ b/wagtail/documents/models.py
@@ -37,6 +37,7 @@ class AbstractDocument(CollectionMember, index.Indexed, models.Model):
 
     search_fields = CollectionMember.search_fields + [
         index.SearchField('title', partial_match=True, boost=10),
+        index.FilterField('title'),
         index.RelatedFields('tags', [
             index.SearchField('name', partial_match=True, boost=10),
         ]),

--- a/wagtail/images/models.py
+++ b/wagtail/images/models.py
@@ -136,6 +136,7 @@ class AbstractImage(CollectionMember, index.Indexed, models.Model):
 
     search_fields = CollectionMember.search_fields + [
         index.SearchField('title', partial_match=True, boost=10),
+        index.FilterField('title'),
         index.RelatedFields('tags', [
             index.SearchField('name', partial_match=True, boost=10),
         ]),

--- a/wagtail/search/backends/base.py
+++ b/wagtail/search/backends/base.py
@@ -91,6 +91,27 @@ class BaseSearchQuery:
     def _get_filters_from_queryset(self):
         return self._get_filters_from_where_node(self.queryset.query.where)
 
+    def _get_order_by(self):
+        if self.order_by_relevance:
+            return
+
+        for field_name in self.queryset.query.order_by:
+            reverse = False
+
+            if field_name.startswith('-'):
+                reverse = True
+                field_name = field_name[1:]
+
+            field = self._get_filterable_field(field_name)
+
+            if field is None:
+                raise FieldError(
+                    'Cannot sort search results with field "' + field_name + '". Please add index.FilterField(\'' +
+                    field_name + '\') to ' + self.queryset.model.__name__ + '.search_fields.'
+                )
+
+            yield reverse, field
+
 
 class BaseSearchResults:
     def __init__(self, backend, query, prefetch_related=None):

--- a/wagtail/search/backends/db.py
+++ b/wagtail/search/backends/db.py
@@ -74,6 +74,9 @@ class DatabaseSearchResults(BaseSearchResults):
     def _do_search(self):
         queryset = self.get_queryset()
 
+        # Call query._get_order_by so it can raise errors if a non-indexed field is used for ordering
+        list(self.query._get_order_by())
+
         if self._score_field:
             queryset = queryset.annotate(**{self._score_field: Value(None, output_field=models.FloatField())})
 

--- a/wagtail/search/backends/elasticsearch2.py
+++ b/wagtail/search/backends/elasticsearch2.py
@@ -462,18 +462,9 @@ class Elasticsearch2SearchQuery(BaseSearchQuery):
 
         # Get queryset and make sure its ordered
         if self.queryset.ordered:
-            order_by_fields = self.queryset.query.order_by
             sort = []
 
-            for order_by_field in order_by_fields:
-                reverse = False
-                field_name = order_by_field
-
-                if order_by_field.startswith('-'):
-                    reverse = True
-                    field_name = order_by_field[1:]
-
-                field = self._get_filterable_field(field_name)
+            for reverse, field in self._get_order_by():
                 column_name = self.mapping.get_field_column_name(field)
 
                 sort.append({

--- a/wagtail/search/backends/elasticsearch2.py
+++ b/wagtail/search/backends/elasticsearch2.py
@@ -4,7 +4,7 @@ from urllib.parse import urlparse
 
 from django.db import DEFAULT_DB_ALIAS, models
 from django.db.models.sql import Query
-from django.db.models.sql.constants import SINGLE
+from django.db.models.sql.constants import MULTI
 from django.utils.crypto import get_random_string
 from elasticsearch import Elasticsearch, NotFoundError
 from elasticsearch.helpers import bulk
@@ -340,8 +340,11 @@ class Elasticsearch2SearchQuery(BaseSearchQuery):
         if lookup == 'in':
             if isinstance(value, Query):
                 db_alias = self.queryset._db or DEFAULT_DB_ALIAS
-                value = (value.get_compiler(db_alias)
-                         .execute_sql(result_type=SINGLE))
+                value = next(value.get_compiler(db_alias)
+                                  .execute_sql(result_type=MULTI))
+
+                value = [r[0] for r in value]
+
             elif not isinstance(value, list):
                 value = list(value)
             return {

--- a/wagtail/search/backends/elasticsearch2.py
+++ b/wagtail/search/backends/elasticsearch2.py
@@ -340,10 +340,8 @@ class Elasticsearch2SearchQuery(BaseSearchQuery):
         if lookup == 'in':
             if isinstance(value, Query):
                 db_alias = self.queryset._db or DEFAULT_DB_ALIAS
-                value = next(value.get_compiler(db_alias)
-                                  .execute_sql(result_type=MULTI))
-
-                value = [r[0] for r in value]
+                resultset = value.get_compiler(db_alias).execute_sql(result_type=MULTI)
+                value = [row[0] for chunk in resultset for row in chunk]
 
             elif not isinstance(value, list):
                 value = list(value)

--- a/wagtail/search/backends/elasticsearch5.py
+++ b/wagtail/search/backends/elasticsearch5.py
@@ -16,6 +16,27 @@ class Elasticsearch5Index(Elasticsearch2Index):
 class Elasticsearch5SearchQuery(Elasticsearch2SearchQuery):
     mapping_class = Elasticsearch5Mapping
 
+    def _process_lookup(self, field, lookup, value):
+        column_name = self.mapping.get_field_column_name(field)
+
+        if lookup == 'isnull':
+            query = {
+                'exists': {
+                    'field': column_name,
+                }
+            }
+
+            if value:
+                query = {
+                    'bool': {
+                        'mustNot': query
+                    }
+                }
+
+            return query
+
+        return super(Elasticsearch5SearchQuery, self)._process_lookup(field, lookup, value)
+
     def _connect_filters(self, filters, connector, negated):
         if filters:
             if len(filters) == 1:

--- a/wagtail/search/tests/test_db_backend.py
+++ b/wagtail/search/tests/test_db_backend.py
@@ -33,11 +33,6 @@ class TestDBBackend(BackendTests, TestCase):
     def test_search_callable_field(self):
         super().test_search_callable_field()
 
-    # Broken
-    @unittest.expectedFailure
-    def test_order_by_non_filterable_field(self):
-        super().test_order_by_non_filterable_field()
-
     # Doesn't support the index API used in this test
     @unittest.expectedFailure
     def test_same_rank_pages(self):

--- a/wagtail/search/tests/test_elasticsearch2_backend.py
+++ b/wagtail/search/tests/test_elasticsearch2_backend.py
@@ -21,11 +21,6 @@ class TestElasticsearch2SearchBackend(BackendTests, ElasticsearchCommonSearchBac
 
     # Broken
     @unittest.expectedFailure
-    def test_filter_in_values_list_subquery(self):
-        super(TestElasticsearch2SearchBackend, self).test_filter_in_values_list_subquery()
-
-    # Broken
-    @unittest.expectedFailure
     def test_order_by_non_filterable_field(self):
         super(TestElasticsearch2SearchBackend, self).test_order_by_non_filterable_field()
 

--- a/wagtail/search/tests/test_elasticsearch2_backend.py
+++ b/wagtail/search/tests/test_elasticsearch2_backend.py
@@ -21,11 +21,6 @@ class TestElasticsearch2SearchBackend(BackendTests, ElasticsearchCommonSearchBac
 
     # Broken
     @unittest.expectedFailure
-    def test_order_by_non_filterable_field(self):
-        super(TestElasticsearch2SearchBackend, self).test_order_by_non_filterable_field()
-
-    # Broken
-    @unittest.expectedFailure
     def test_delete(self):
         super(TestElasticsearch2SearchBackend, self).test_delete()
 

--- a/wagtail/search/tests/test_elasticsearch5_backend.py
+++ b/wagtail/search/tests/test_elasticsearch5_backend.py
@@ -20,11 +20,6 @@ class TestElasticsearch5SearchBackend(BackendTests, ElasticsearchCommonSearchBac
 
     # Broken
     @unittest.expectedFailure
-    def test_filter_isnull_true(self):
-        super(TestElasticsearch5SearchBackend, self).test_filter_isnull_true()
-
-    # Broken
-    @unittest.expectedFailure
     def test_delete(self):
         super(TestElasticsearch5SearchBackend, self).test_delete()
 
@@ -190,7 +185,7 @@ class TestElasticsearch5SearchQuery(TestCase):
         # Check it
         expected_result = {'bool': {'filter': [
             {'match': {'content_type': 'searchtests.Book'}},
-            {'missing': {'field': 'title_filter'}}
+            {'bool': {'mustNot': {'exists': {'field': 'title_filter'}}}}
         ], 'must': {'multi_match': {'query': 'Hello', 'fields': ['_all', '_partials']}}}}
         self.assertDictEqual(query.get_query(), expected_result)
 
@@ -201,7 +196,7 @@ class TestElasticsearch5SearchQuery(TestCase):
         # Check it
         expected_result = {'bool': {'filter': [
             {'match': {'content_type': 'searchtests.Book'}},
-            {'missing': {'field': 'title_filter'}}
+            {'bool': {'mustNot': {'exists': {'field': 'title_filter'}}}}
         ], 'must': {'multi_match': {'query': 'Hello', 'fields': ['_all', '_partials']}}}}
         self.assertDictEqual(query.get_query(), expected_result)
 

--- a/wagtail/search/tests/test_elasticsearch5_backend.py
+++ b/wagtail/search/tests/test_elasticsearch5_backend.py
@@ -25,11 +25,6 @@ class TestElasticsearch5SearchBackend(BackendTests, ElasticsearchCommonSearchBac
 
     # Broken
     @unittest.expectedFailure
-    def test_filter_in_values_list_subquery(self):
-        super(TestElasticsearch5SearchBackend, self).test_filter_in_values_list_subquery()
-
-    # Broken
-    @unittest.expectedFailure
     def test_order_by_non_filterable_field(self):
         super(TestElasticsearch5SearchBackend, self).test_order_by_non_filterable_field()
 

--- a/wagtail/search/tests/test_elasticsearch5_backend.py
+++ b/wagtail/search/tests/test_elasticsearch5_backend.py
@@ -25,11 +25,6 @@ class TestElasticsearch5SearchBackend(BackendTests, ElasticsearchCommonSearchBac
 
     # Broken
     @unittest.expectedFailure
-    def test_order_by_non_filterable_field(self):
-        super(TestElasticsearch5SearchBackend, self).test_order_by_non_filterable_field()
-
-    # Broken
-    @unittest.expectedFailure
     def test_delete(self):
         super(TestElasticsearch5SearchBackend, self).test_delete()
 

--- a/wagtail/tests/testapp/models.py
+++ b/wagtail/tests/testapp/models.py
@@ -263,6 +263,7 @@ class EventPage(Page):
         index.SearchField('get_audience_display'),
         index.SearchField('location'),
         index.SearchField('body'),
+        index.FilterField('url_path'),
     ]
 
     password_required_template = 'tests/event_page_password_required.html'


### PR DESCRIPTION
This cherry picks out commits that have already been reviewed in #3947 (as the backports have already been merged).