### PR TITLE
Fixes page unlock button styling.

### DIFF
--- a/wagtail/admin/static_src/wagtailadmin/scss/components/_formatters.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/components/_formatters.scss
@@ -98,7 +98,7 @@
     border: 1px solid lighten($color-grey-2, 30%);
     color: lighten($color-grey-2, 30%);
     -webkit-font-smoothing: auto;
-    line-height: 1.9em;
+    line-height: 19px;
     font-size: 0.8em;
     margin: 0 0.5em 0.5em;
     background: #fff url('#{$images-root}bg-dark-diag.svg');

--- a/wagtail/admin/static_src/wagtailadmin/scss/components/_formatters.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/components/_formatters.scss
@@ -98,6 +98,7 @@
     border: 1px solid lighten($color-grey-2, 30%);
     color: lighten($color-grey-2, 30%);
     -webkit-font-smoothing: auto;
+    line-height: 1.9em;
     font-size: 0.8em;
     margin: 0 0.5em 0.5em;
     background: #fff url('#{$images-root}bg-dark-diag.svg');
@@ -109,14 +110,14 @@
     }
 }
 
-form.status-tag:hover,
+button.status-tag:hover,
 a.status-tag:hover,
 a.status-tag.primary:hover {
     border-color: $color-teal;
     color: $color-teal;
 }
 
-form.status-tag:hover {
+button.status-tag:hover {
     border-color: $color-teal-dark;
     background-color: $color-teal-darker;
     color: $color-white;

--- a/wagtail/admin/static_src/wagtailadmin/scss/components/_formatters.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/components/_formatters.scss
@@ -108,6 +108,10 @@
         border: 1px solid $color-grey-2;
         background: #fff;
     }
+
+    &.disabled {
+        pointer-events: none;
+    }
 }
 
 button.status-tag:hover,

--- a/wagtail/admin/static_src/wagtailadmin/scss/components/_header.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/components/_header.scss
@@ -71,14 +71,6 @@ header {
         padding-bottom: 0;
     }
 
-    .button {
-        background-color: $color-teal-darker;
-
-        &:hover {
-            background-color: $color-teal-dark;
-        }
-    }
-
     label {
         @include visuallyhidden();
     }

--- a/wagtail/admin/templates/wagtailadmin/pages/_lock_switch.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/_lock_switch.html
@@ -4,28 +4,16 @@
     {% page_permissions page as page_perms %}
 {% endif %}
 
-<div class="lock-indicator {% if page.locked %}locked{% else %}unlocked{% endif %}">
+<form action="{% url page.locked|yesno:'wagtailadmin_pages:unlock,wagtailadmin_pages:lock' page.id %}" method="POST" class="lock-indicator {{ page.locked|yesno:'locked,unlocked' }}">
     {% trans "Edit lock" %}
 
-    {% if page.locked %}
-        {% if page_perms.can_lock %}
-            <form action="{% url 'wagtailadmin_pages:unlock' page.id %}" method="POST" class="status-tag primary">
-                {% csrf_token %}
-                <input type="hidden" name="next" value="{% url 'wagtailadmin_pages:edit' page.id %}">
-                <input type="submit" class="button unbutton" value="{% trans "Locked" %}">
-            </form>
+    {% csrf_token %}
+    <input type="hidden" name="next" value="{% url 'wagtailadmin_pages:edit' page.id %}" />
+    <button type="submit" class="status-tag {{ page.locked|yesno:'primary,secondary' }}{% if page_perms.can_lock %} disabled{% endif %}">
+        {% if page.locked %}
+            {% trans 'Locked' %}
         {% else %}
-            <span class="status-tag primary">Locked</span>
+            {% trans 'Unlocked' %}
         {% endif %}
-    {% else %}
-        {% if page_perms.can_lock %}
-            <form action="{% url 'wagtailadmin_pages:lock' page.id %}" method="POST" class="status-tag secondary">
-                {% csrf_token %}
-                <input type="hidden" name="next" value="{% url 'wagtailadmin_pages:edit' page.id %}">
-                <input type="submit" class="button unbutton" value="{% trans "Unlocked" %}">
-            </form>
-        {% else %}
-            <span class="status-tag secondary">Unlocked</span>
-        {% endif %}
-    {% endif %}
-</div>
+    </button>
+</form>

--- a/wagtail/admin/templates/wagtailadmin/pages/_lock_switch.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/_lock_switch.html
@@ -9,7 +9,7 @@
 
     {% csrf_token %}
     <input type="hidden" name="next" value="{% url 'wagtailadmin_pages:edit' page.id %}" />
-    <button type="submit" class="status-tag {{ page.locked|yesno:'primary,secondary' }}{% if page_perms.can_lock %} disabled{% endif %}">
+    <button type="submit" class="status-tag {{ page.locked|yesno:'primary,secondary' }}{% if not page_perms.can_lock %} disabled{% endif %}">
         {% if page.locked %}
             {% trans 'Locked' %}
         {% else %}


### PR DESCRIPTION
This pull request fixes the clickable area of the page unlock button. Before this pull request:
- we could click only on the text of the button, not on all the visible area
- the text got an ugly background on hover

## Before
![selection_007](https://user-images.githubusercontent.com/1119169/34022093-8556d424-e13d-11e7-8608-f0f7bf36d821.png)
![selection_008](https://user-images.githubusercontent.com/1119169/34022094-857a9a44-e13d-11e7-8c42-8fd79e177b3e.png)
## After
![selection_009](https://user-images.githubusercontent.com/1119169/34022095-85a2983c-e13d-11e7-8157-30351b99c86a.png)
![selection_010](https://user-images.githubusercontent.com/1119169/34022096-85c12252-e13d-11e7-90b9-432103c594b2.png)