### PR TITLE
Add on_delete argument to documentation

### DIFF
--- a/docs/advanced_topics/api/v2/configuration.rst
+++ b/docs/advanced_topics/api/v2/configuration.rst
@@ -114,7 +114,7 @@ For example:
     from wagtail.api import APIField
 
     class BlogPageAuthor(Orderable):
-        page = models.ForeignKey('blog.BlogPage', related_name='authors')
+        page = models.ForeignKey('blog.BlogPage', on_delete=models.CASCADE, related_name='authors')
         name = models.CharField(max_length=255)
 
         api_fields = [
@@ -125,7 +125,7 @@ For example:
     class BlogPage(Page):
         published_date = models.DateTimeField()
         body = RichTextField()
-        feed_image = models.ForeignKey('wagtailimages.Image', ...)
+        feed_image = models.ForeignKey('wagtailimages.Image', on_delete=models.CASCADE, ...)
         private_field = models.CharField(max_length=255)
 
         # Export fields over the API

--- a/docs/advanced_topics/i18n/index.rst
+++ b/docs/advanced_topics/i18n/index.rst
@@ -143,7 +143,7 @@ For each field you would like to be translatable, duplicate it for every languag
         body_fr = StreamField(...)
 
         # Language-independent fields don't need to be duplicated
-        thumbnail_image = models.ForeignKey('wagtailimages.image', ...)
+        thumbnail_image = models.ForeignKey('wagtailimages.image', on_delete=models.CASCADE, ...)
 
 .. note::
 

--- a/docs/advanced_topics/images/custom_image_model.rst
+++ b/docs/advanced_topics/images/custom_image_model.rst
@@ -39,7 +39,7 @@ Here's an example:
 
 
     class CustomRendition(AbstractRendition):
-        image = models.ForeignKey(CustomImage, related_name='renditions')
+        image = models.ForeignKey(CustomImage, on_delete=models.CASCADE, related_name='renditions')
 
         class Meta:
             unique_together = (

--- a/docs/getting_started/tutorial.rst
+++ b/docs/getting_started/tutorial.rst
@@ -436,7 +436,7 @@ Add a new ``BlogPageGalleryImage`` model to ``models.py``:
 
 
     class BlogPageGalleryImage(Orderable):
-        page = ParentalKey(BlogPage, related_name='gallery_images')
+        page = ParentalKey(BlogPage, on_delete=models.CASCADE, related_name='gallery_images')
         image = models.ForeignKey(
             'wagtailimages.Image', on_delete=models.CASCADE, related_name='+'
         )

--- a/docs/reference/contrib/forms/customisation.rst
+++ b/docs/reference/contrib/forms/customisation.rst
@@ -23,7 +23,7 @@ You can do this as shown below.
 
 
     class FormField(AbstractFormField):
-        page = ParentalKey('FormPage', related_name='custom_form_fields')
+        page = ParentalKey('FormPage', on_delete=models.CASCADE, related_name='custom_form_fields')
 
 
     class FormPage(AbstractEmailForm):
@@ -74,7 +74,7 @@ Example:
 
 
     class FormField(AbstractFormField):
-        page = ParentalKey('FormPage', related_name='form_fields')
+        page = ParentalKey('FormPage', on_delete=models.CASCADE, related_name='form_fields')
 
 
     class FormPage(AbstractEmailForm):
@@ -135,7 +135,7 @@ The following example shows how to add a username to the CSV export:
 
 
     class FormField(AbstractFormField):
-        page = ParentalKey('FormPage', related_name='form_fields')
+        page = ParentalKey('FormPage', on_delete=models.CASCADE, related_name='form_fields')
 
 
     class FormPage(AbstractEmailForm):
@@ -213,7 +213,7 @@ Example:
 
 
     class FormField(AbstractFormField):
-        page = ParentalKey('FormPage', related_name='form_fields')
+        page = ParentalKey('FormPage', on_delete=models.CASCADE, related_name='form_fields')
 
 
     class FormPage(AbstractEmailForm):
@@ -309,7 +309,7 @@ The following example shows how to create a multi-step form.
 
 
     class FormField(AbstractFormField):
-        page = ParentalKey('FormPage', related_name='form_fields')
+        page = ParentalKey('FormPage', on_delete=models.CASCADE, related_name='form_fields')
 
 
     class FormPage(AbstractEmailForm):
@@ -455,7 +455,7 @@ First, you need to collect results as shown below:
 
 
     class FormField(AbstractFormField):
-        page = ParentalKey('FormPage', related_name='form_fields')
+        page = ParentalKey('FormPage', on_delete=models.CASCADE, related_name='form_fields')
 
 
     class FormPage(AbstractEmailForm):

--- a/docs/reference/contrib/forms/index.rst
+++ b/docs/reference/contrib/forms/index.rst
@@ -38,7 +38,7 @@ Within the ``models.py`` of one of your apps, create a model that extends ``wagt
 
 
     class FormField(AbstractFormField):
-        page = ParentalKey('FormPage', related_name='form_fields')
+        page = ParentalKey('FormPage', on_delete=models.CASCADE, related_name='form_fields')
 
 
     class FormPage(AbstractEmailForm):

--- a/docs/reference/pages/model_recipes.rst
+++ b/docs/reference/pages/model_recipes.rst
@@ -150,7 +150,7 @@ Using an example from the Wagtail demo site, here's what the tag model and the r
     from taggit.models import TaggedItemBase
 
     class BlogPageTag(TaggedItemBase):
-        content_object = ParentalKey('demo.BlogPage', related_name='tagged_items')
+        content_object = ParentalKey('demo.BlogPage', on_delete=models.CASCADE, related_name='tagged_items')
 
     class BlogPage(Page):
         ...

--- a/docs/reference/pages/panels.rst
+++ b/docs/reference/pages/panels.rst
@@ -318,7 +318,7 @@ Let's look at the example of adding related links to a :class:`~wagtail.core.mod
   # Orderable helper class, and what amounts to a ForeignKey link
   # to the model we want to add related links to (BookPage)
   class BookPageRelatedLinks(Orderable, RelatedLink):
-      page = ParentalKey('demo.BookPage', related_name='related_links')
+      page = ParentalKey('demo.BookPage', on_delete=models.CASCADE, related_name='related_links')
 
   class BookPage(Page):
     # ...

--- a/docs/releases/2.0.rst
+++ b/docs/releases/2.0.rst
@@ -72,6 +72,12 @@ Removed support for Python 2.7, Django 1.8 and Django 1.10
 Python 2.7, Django 1.8 and Django 1.10 are no longer supported in this release. You are advised to upgrade your project to Python 3 and Django 1.11 before upgrading to Wagtail 2.0.
 
 
+Added support for Django 2.0
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Before upgrading to Django 2.0, you are advised to review the `release notes <https://docs.djangoproject.com/en/2.0/releases/2.0/>`_, especially the `backwards incompatible changes <https://docs.djangoproject.com/en/2.0/releases/2.0/#backwards-incompatible-changes-in-2-0>`_ and `removed features <https://docs.djangoproject.com/en/2.0/releases/2.0/#features-removed-in-2-0>`_.
+
+
 Wagtail module path updates
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/topics/pages.rst
+++ b/docs/topics/pages.rst
@@ -77,7 +77,7 @@ This example represents a typical blog post:
 
 
     class BlogPageRelatedLink(Orderable):
-        page = ParentalKey(BlogPage, related_name='related_links')
+        page = ParentalKey(BlogPage, on_delete=models.CASCADE, related_name='related_links')
         name = models.CharField(max_length=255)
         url = models.URLField()
 
@@ -384,7 +384,7 @@ For example, the following inline model can be used to add related links (a list
 
 
     class BlogPageRelatedLink(Orderable):
-        page = ParentalKey(BlogPage, related_name='related_links')
+        page = ParentalKey(BlogPage, on_delete=models.CASCADE, related_name='related_links')
         name = models.CharField(max_length=255)
         url = models.URLField()
 

--- a/docs/topics/search/indexing.rst
+++ b/docs/topics/search/indexing.rst
@@ -219,7 +219,7 @@ To do this, inherit from ``index.Indexed`` and add some ``search_fields`` to the
     class Book(index.Indexed, models.Model):
         title = models.CharField(max_length=255)
         genre = models.CharField(max_length=255, choices=GENRE_CHOICES)
-        author = models.ForeignKey(Author)
+        author = models.ForeignKey(Author, on_delete=models.CASCADE)
         published_date = models.DateTimeField()
 
         search_fields = [

--- a/docs/topics/snippets.rst
+++ b/docs/topics/snippets.rst
@@ -137,8 +137,8 @@ To attach multiple adverts to a page, the ``SnippetChooserPanel`` can be placed 
   ...
 
   class BookPageAdvertPlacement(Orderable, models.Model):
-      page = ParentalKey('demo.BookPage', related_name='advert_placements')
-      advert = models.ForeignKey('demo.Advert', related_name='+')
+      page = ParentalKey('demo.BookPage', on_delete=models.CASCADE, related_name='advert_placements')
+      advert = models.ForeignKey('demo.Advert', on_delete=models.CASCADE, related_name='+')
 
       class Meta:
           verbose_name = "advert placement"
@@ -218,7 +218,7 @@ Adding tags to snippets is very similar to adding tags to pages. The only differ
     from taggit.managers import TaggableManager
 
     class AdvertTag(TaggedItemBase):
-        content_object = ParentalKey('demo.Advert', related_name='tagged_items')
+        content_object = ParentalKey('demo.Advert', on_delete=models.CASCADE, related_name='tagged_items')
 
     @register_snippet
     class Advert(ClusterableModel):


### PR DESCRIPTION
This adds the `on_delete` argument to every instance of `ParentalKey` and `ForeignKey` where it was not already set, in Documentation only.

I have set to the previous default which is `on_delete=models.CASCADE`.

I have also added a section in the 2.0 Release notes about Django 2.0 support as it would be good to remind those doing the Django upgrade also that there are specific requirements for that. We may not need this, so let me know if it is overkill.

It would be good for someone to look over these docs changes as there may be cases where we would not want CASCADE set for some reason in the examples.

Closes #4126