### PR TITLE
Fixing search url for django 1.10 and above.

### DIFF
--- a/docs/advanced_topics/i18n/index.rst
+++ b/docs/advanced_topics/i18n/index.rst
@@ -90,7 +90,7 @@ This feature is enabled through the project's root URL configuration. Just put t
     from wagtail.admin import urls as wagtailadmin_urls
     from wagtail.documents import urls as wagtaildocs_urls
     from wagtail.core import urls as wagtail_urls
-
+    from search import views as search_views
 
     urlpatterns = [
         url(r'^django-admin/', include(admin.site.urls)),
@@ -103,7 +103,7 @@ This feature is enabled through the project's root URL configuration. Just put t
     urlpatterns += i18n_patterns(
         # These URLs will have /<language_code>/ appended to the beginning
 
-        url(r'^search/$', 'search.views.search', name='search'),
+        url(r'^search/$', search_views.search, name='search'),
 
         url(r'', include(wagtail_urls)),
     )


### PR DESCRIPTION
For django 1.10 and above the search url will fail with a TypeError since there is no support for views as string inside urlpatterns, It will raise:

```
TypeError('view must be a callable or a list/tuple in the case of include().')
TypeError: view must be a callable or a list/tuple in the case of include().
```

Thanks for contributing to Wagtail! 🎉

Before submitting, please review the contributor guidelines <http://docs.wagtail.io/en/latest/contributing/index.html> and check the following:

* Do the tests still pass? (http://docs.wagtail.io/en/latest/contributing/developing.html#testing)
* Does the code comply with the style guide? (Run `make lint` from the Wagtail root)
* For Python changes: Have you added tests to cover the new/fixed behaviour?
* For new features: Has the documentation been updated accordingly?
