### PR TITLE
Reinstate error reporting on image upload

### DIFF
--- a/wagtail/images/templates/wagtailimages/chooser/chooser.js
+++ b/wagtail/images/templates/wagtailimages/chooser/chooser.js
@@ -76,6 +76,14 @@ function(modal) {
                 dataType: 'text',
                 success: function(response){
                     modal.loadResponseText(response);
+                },
+                error: function(response, textStatus, errorThrown) {
+                    {% trans "Server Error" as error_label %}
+                    {% trans "Report this error to your webmaster with the following information:" as error_message %}
+                    message = '{{ error_message|escapejs }}<br />' + errorThrown + ' - ' + response.status;
+                    $('#upload').append(
+                        '<div class="help-block help-critical">' +
+                        '<strong>{{ error_label|escapejs }}: </strong>' + message + '</div>');
                 }
             });
         }


### PR DESCRIPTION
As reported at https://github.com/wagtail/wagtail/issues/616#issuecomment-353748780, reporting of HTTP errors when uploading images within the image chooser (as added in #2167) no longer occurs in recent Wagtail releases. It seems this was inadvertently dropped in #2538 - re-adding it here.