### PR TITLE
Add missing appconfs for settings, table_block and sites

### DIFF
--- a/wagtail/api/__init__.py
+++ b/wagtail/api/__init__.py
@@ -1,4 +1,1 @@
 from .conf import APIField  # noqa
-
-
-default_app_config = 'wagtail.api.apps.WagtailAPIAppConfig'

--- a/wagtail/api/v2/__init__.py
+++ b/wagtail/api/v2/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'wagtail.api.v2.apps.WagtailAPIV2AppConfig'

--- a/wagtail/contrib/modeladmin/__init__.py
+++ b/wagtail/contrib/modeladmin/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'wagtail.contrib.modeladmin.apps.WagtailModelAdminAppConfig'

--- a/wagtail/contrib/modeladmin/apps.py
+++ b/wagtail/contrib/modeladmin/apps.py
@@ -1,0 +1,7 @@
+from django.apps import AppConfig
+
+
+class WagtailModelAdminAppConfig(AppConfig):
+    name = 'wagtail.contrib.modeladmin'
+    label = 'wagtailmodeladmin'
+    verbose_name = "Wagtail ModelAdmin"

--- a/wagtail/contrib/settings/__init__.py
+++ b/wagtail/contrib/settings/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'wagtail.contrib.settings.apps.WagtailSettingsAppConfig'

--- a/wagtail/contrib/table_block/__init__.py
+++ b/wagtail/contrib/table_block/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'wagtail.contrib.table_block.apps.WagtailTableBlockAppConfig'

--- a/wagtail/contrib/table_block/apps.py
+++ b/wagtail/contrib/table_block/apps.py
@@ -1,0 +1,7 @@
+from django.apps import AppConfig
+
+
+class WagtailTableBlockAppConfig(AppConfig):
+    name = 'wagtail.contrib.table_block'
+    label = 'wagtailtableblock'
+    verbose_name = "Wagtail table block"

--- a/wagtail/sites/__init__.py
+++ b/wagtail/sites/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'wagtail.sites.apps.WagtailSitesAppConfig'

--- a/wagtail/sites/apps.py
+++ b/wagtail/sites/apps.py
@@ -1,0 +1,7 @@
+from django.apps import AppConfig
+
+
+class WagtailSitesAppConfig(AppConfig):
+    name = 'wagtail.sites'
+    label = 'wagtailsites'
+    verbose_name = "Wagtail sites"


### PR DESCRIPTION
A few of our apps are currently missing appconfs (or don't have it hooked up as `default_app_config`). This is especially important for `wagtail.sites` because the missing appconf causes it to be given the label `sites`, which clashes with `django.contrib.sites`.