### PR TITLE
Make can_add_subpage check for can_create_at.

### DIFF
--- a/wagtail/admin/views/pages.py
+++ b/wagtail/admin/views/pages.py
@@ -109,8 +109,7 @@ def add_subpage(request, parent_page_id):
 
     page_types = [
         (model.get_verbose_name(), model._meta.app_label, model._meta.model_name)
-        for model in type(parent_page).creatable_subpage_models()
-        if model.can_create_at(parent_page)
+        for model in parent_page.creatable_subpage_models()
     ]
     # sort by lower-cased version of verbose name
     page_types.sort(key=lambda page_type: page_type[0].lower())
@@ -170,11 +169,8 @@ def create(request, content_type_app_name, content_type_model_name, parent_page_
     if not issubclass(page_class, Page):
         raise Http404
 
-    # page must be in the list of allowed subpage types for this parent ID
+    # page must be in the list of allowed subpage types for this parent
     if page_class not in parent_page.creatable_subpage_models():
-        raise PermissionDenied
-
-    if not page_class.can_create_at(parent_page):
         raise PermissionDenied
 
     for fn in hooks.get_hooks('before_create_page'):

--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -959,7 +959,9 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
 
         See also: :func:`Page.can_create_at` and :func:`Page.can_move_to`
         """
-        return cls in parent.specific_class.allowed_subpage_models()
+        specific_class = parent.specific_class
+        return (specific_class is not None
+                and cls in specific_class.allowed_subpage_models())
 
     @classmethod
     def can_create_at(cls, parent):

--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -960,8 +960,8 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
         See also: :func:`Page.can_create_at` and :func:`Page.can_move_to`
         """
         specific_class = parent.specific_class
-        return (specific_class is not None
-                and cls in specific_class.allowed_subpage_models())
+        return (specific_class is not None and
+                cls in specific_class.allowed_subpage_models())
 
     @classmethod
     def can_create_at(cls, parent):
@@ -1752,8 +1752,8 @@ class PagePermissionTester:
         does not allow subpages at all.)
         """
         return (self.user.is_active and
-                (self.user.is_superuser or ('publish' in self.permissions))
-                and self.page.specific.creatable_subpage_models())
+                (self.user.is_superuser or ('publish' in self.permissions)) and
+                self.page.specific.creatable_subpage_models())
 
     def can_reorder_children(self):
         """

--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -948,7 +948,7 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
         """
         return [
             page_model for page_model in self.allowed_subpage_models()
-            if page_model.is_creatable and page_model.can_create_at(self)
+            if page_model.can_create_at(self)
         ]
 
     @classmethod
@@ -1667,11 +1667,9 @@ class PagePermissionTester:
             )
 
     def can_add_subpage(self):
-        if not self.user.is_active:
-            return False
-        if not self.page.specific.creatable_subpage_models():
-            return False
-        return self.user.is_superuser or ('add' in self.permissions)
+        return (self.user.is_active and
+                (self.user.is_superuser or 'add' in self.permissions) and
+                self.page.specific.creatable_subpage_models())
 
     def can_edit(self):
         if not self.user.is_active:
@@ -1753,12 +1751,9 @@ class PagePermissionTester:
         to be able to publish root itself. (Also, can_publish_subpage returns false if the page
         does not allow subpages at all.)
         """
-        if not self.user.is_active:
-            return False
-        if not self.page.specific.creatable_subpage_models():
-            return False
-
-        return self.user.is_superuser or ('publish' in self.permissions)
+        return (self.user.is_active and
+                (self.user.is_superuser or ('publish' in self.permissions))
+                and self.page.specific.creatable_subpage_models())
 
     def can_reorder_children(self):
         """


### PR DESCRIPTION
In order to display the “Add subpage” in the admin & front-end userbar, Wagtail currently checks only using class methods and without using `Page.can_create_at` or `Page.can_exist_under`. This pull request fixes this.

### Use case
If you like overriding `Page.can_exist_under` to guide users – for example to prevent users from adding more than a contact page inside the home page – you often end up with cases where no sub-page can be added to a given page, even though `subpage_types` & `parent_page_types` allow it. The “Add subpage” button stays visible, and you end up on this misleading and frustrating view:
![image](https://user-images.githubusercontent.com/1119169/34622919-64107338-f24f-11e7-911e-aca810b520f0.png)

With this pull request, the available sub-page models now takes `Page.can_create_at` into account (and therefore `Page.can_exist_under`). It’s therefore impossible to reach an empty type selection page, a 403 error is raised instead.