### PR TITLE
fix for 4146 - edit button shows correctly for moderation list

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/home/pages_for_moderation.html
+++ b/wagtail/admin/templates/wagtailadmin/home/pages_for_moderation.html
@@ -39,7 +39,9 @@
                                             <input type="submit" class="button button-small button-secondary no" value="{% trans 'Reject' %}">
                                         </form>
                                     </li>
+                                    {% if revision.can_edit %}
                                     <li><a href="{% url 'wagtailadmin_pages:edit' revision.page.id %}" class="button button-small button-secondary">{% trans 'Edit' %}</a></li>
+                                    {% endif %}
                                     <li><a href="{% url 'wagtailadmin_pages:preview_for_moderation' revision.id %}" class="button button-small button-secondary" target="_blank">{% trans 'Preview' %}</a></li>
                                 </ul>
                             </td>

--- a/wagtail/admin/views/home.py
+++ b/wagtail/admin/views/home.py
@@ -41,8 +41,7 @@ class PagesForModerationPanel:
         self.page_revisions_for_moderation = (user_perms.revisions_for_moderation()
                                               .select_related('page', 'user').order_by('-created_at'))
         for revision in self.page_revisions_for_moderation:
-            revision.can_edit = (revision.page.permissions_for_user(request.user)
-                                .can_edit())
+            revision.can_edit = (revision.page.permissions_for_user(request.user).can_edit())
 
     def render(self):
         return render_to_string('wagtailadmin/home/pages_for_moderation.html', {

--- a/wagtail/admin/views/home.py
+++ b/wagtail/admin/views/home.py
@@ -40,6 +40,9 @@ class PagesForModerationPanel:
         user_perms = UserPagePermissionsProxy(request.user)
         self.page_revisions_for_moderation = (user_perms.revisions_for_moderation()
                                               .select_related('page', 'user').order_by('-created_at'))
+        for revision in self.page_revisions_for_moderation:
+            revision.can_edit = (revision.page.permissions_for_user(request.user)
+                                .can_edit())
 
     def render(self):
         return render_to_string('wagtailadmin/home/pages_for_moderation.html', {


### PR DESCRIPTION
Hello, 
First _ever_ PR here (so, sorry if I've gone about it wrongly!)

Got issue  #4146 resolved by 
### Functionality working as intended: 

- The "edit" button doesn't appear, If an user has the "publish" permission, but doesn't have the "add" and "edit" permissions
- The "edit" button appears, if an user has the "add" and "publish" permissions and the user is owner of the page
- The "edit" button appears, if an user has the "edit" permission

I'm fairly new to the Wagtail codebase, so if there's a better way to do this without the template logic and someone can point me in the right direction i'd be happy to refactor.