### PR TITLE
Allow any host in development

### DIFF
--- a/wagtail/project_template/project_name/settings/dev.py
+++ b/wagtail/project_template/project_name/settings/dev.py
@@ -6,6 +6,8 @@ DEBUG = True
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = '{{ secret_key }}'
 
+# SECURITY WARNING: define the correct hosts in production!
+ALLOWED_HOSTS = ['*'] 
 
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 


### PR DESCRIPTION
Updates the project template so the `dev` settings allow any host. Like `DEBUG = True`, this is an insecure but convenient default, appropriate for developer environments. 

Note `ALLOWED_HOSTS` is a required setting when `DEBUG = False`. In production it should be set to the specific host value.