### PR TITLE
Add `wagtail updatemodulepaths` command to update imports for Wagtail 2.x

### DIFF
--- a/docs/releases/2.0.rst
+++ b/docs/releases/2.0.rst
@@ -125,7 +125,21 @@ Before upgrading to Django 2.0, you are advised to review the `release notes <ht
 Wagtail module path updates
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Many of the module paths within Wagtail have been reorganised:
+Many of the module paths within Wagtail have been reorganised to reduce duplication - for example, ``wagtail.wagtailcore.models`` is now ``wagtail.core.models``. As a result, ``import`` lines and other references to Wagtail modules will need to be updated when you upgrade to Wagtail 2.0. A new command has been added to assist with this - from the root of your project's code base:
+
+   .. code-block:: console
+
+       $ wagtail updatemodulepaths
+
+Or, to run from a different location:
+
+   .. code-block:: console
+
+       $ wagtail updatemodulepaths /path/to/project
+
+You are advised to take a backup of your project codebase before running this command. The command will perform a search-and-replace over all \*.py files for the affected module paths; while this should catch the vast majority of module references, it will not be able to fix instances that do not use the dotted path directly, such as ``from wagtail import wagtailcore``.
+
+The full list of modules to be renamed is as follows:
 
 +-----------------------------------------+-----------------------------------+-----------------------------------+
 | Old name                                | New name                          | Notes                             |
@@ -165,7 +179,7 @@ Many of the module paths within Wagtail have been reorganised:
 | wagtail.contrib.wagtailstyleguide       | wagtail.contrib.styleguide        |                                   |
 +-----------------------------------------+-----------------------------------+-----------------------------------+
 
-References to these module paths within your Wagtail project need to be updated when you upgrade to Wagtail 2.0. This includes:
+Places these should be updated include:
 
 * ``import`` lines
 * Paths specified in settings, such as ``INSTALLED_APPS``, ``MIDDLEWARE`` and ``WAGTAILSEARCH_BACKENDS``

--- a/docs/releases/2.0.rst
+++ b/docs/releases/2.0.rst
@@ -129,12 +129,16 @@ Many of the module paths within Wagtail have been reorganised to reduce duplicat
 
    .. code-block:: console
 
-       $ wagtail updatemodulepaths
+       $ wagtail updatemodulepaths --list  # list the files to be changed without updating them
+       $ wagtail updatemodulepaths --diff  # show the changes to be made, without updating files
+       $ wagtail updatemodulepaths  # actually update the files
 
 Or, to run from a different location:
 
    .. code-block:: console
 
+       $ wagtail updatemodulepaths /path/to/project --list
+       $ wagtail updatemodulepaths /path/to/project --diff
        $ wagtail updatemodulepaths /path/to/project
 
 You are advised to take a backup of your project codebase before running this command. The command will perform a search-and-replace over all \*.py files for the affected module paths; while this should catch the vast majority of module references, it will not be able to fix instances that do not use the dotted path directly, such as ``from wagtail import wagtailcore``.

--- a/wagtail/bin/wagtail.py
+++ b/wagtail/bin/wagtail.py
@@ -2,42 +2,59 @@
 import fileinput
 import os
 import re
-from optparse import OptionParser
+import sys
+from argparse import ArgumentParser
 
 from django.core.management import ManagementUtility
 
 
 class Command:
     description = None
-    usage = None
+
+    def create_parser(self, command_name=None):
+        if command_name is None:
+            prog = None
+        else:
+            # hack the prog name as reported to ArgumentParser to include the command
+            prog = "%s %s" % (prog_name(), command_name)
+
+        parser = ArgumentParser(
+            description=getattr(self, 'description', None), add_help=False, prog=prog
+        )
+        self.add_arguments(parser)
+        return parser
+
+    def add_arguments(self, parser):
+        pass
+
+    def print_help(self, command_name):
+        parser = self.create_parser(command_name=command_name)
+        parser.print_help()
+
+    def execute(self, argv):
+        parser = self.create_parser()
+        options = parser.parse_args(sys.argv[2:])
+        options_dict = vars(options)
+        self.run(**options_dict)
 
 
 class CreateProject(Command):
     description = "Creates the directory structure for a new Wagtail project."
-    usage = "Usage: %prog start project_name [directory]"
 
-    def run(self, parser, options, args):
-        # Validate args
-        if len(args) < 2:
-            parser.error("Please specify a name for your Wagtail installation")
-        elif len(args) > 3:
-            parser.error("Too many arguments")
+    def add_arguments(self, parser):
+        parser.add_argument('project_name', help="Name for your Wagtail project")
+        parser.add_argument('dest_dir', nargs='?', help="Destination directory inside which to create the project")
 
-        project_name = args[1]
-        try:
-            dest_dir = args[2]
-        except IndexError:
-            dest_dir = None
-
+    def run(self, project_name=None, dest_dir=None):
         # Make sure given name is not already in use by another python package/module.
         try:
             __import__(project_name)
         except ImportError:
             pass
         else:
-            parser.error("'%s' conflicts with the name of an existing "
-                         "Python module and cannot be used as a project "
-                         "name. Please try another name." % project_name)
+            sys.exit("'%s' conflicts with the name of an existing "
+                     "Python module and cannot be used as a project "
+                     "name. Please try another name." % project_name)
 
         print("Creating a Wagtail project called %(project_name)s" % {'project_name': project_name})  # noqa
 
@@ -66,7 +83,6 @@ class CreateProject(Command):
 
 class UpdateModulePaths(Command):
     description = "Update a Wagtail project tree to use Wagtail 2.x module paths"
-    usage = "Usage: %prog updatemodulepaths [root-path]"
 
     REPLACEMENTS = [
         (re.compile(r'\bwagtail\.wagtailcore\b'), 'wagtail.core'),
@@ -87,14 +103,11 @@ class UpdateModulePaths(Command):
         (re.compile(r'\bwagtail\.contrib\.wagtailstyleguide\b'), 'wagtail.contrib.styleguide'),
     ]
 
-    def run(self, parser, options, args):
-        # Validate args
-        if len(args) > 2:
-            parser.error("Too many arguments")
+    def add_arguments(self, parser):
+        parser.add_argument('root_path', nargs='?', help="Path to your project's root")
 
-        try:
-            root_path = args[1]
-        except IndexError:
+    def run(self, root_path=None):
+        if root_path is None:
             root_path = os.getcwd()
 
         checked_count = 0
@@ -135,36 +148,53 @@ COMMANDS = {
 }
 
 
+def prog_name():
+    return os.path.basename(sys.argv[0])
+
+
+def help_index():
+    print("Type '%s help <subcommand>' for help on a specific subcommand.\n" % prog_name())  # NOQA
+    print("Available subcommands:\n")  # NOQA
+    for name, cmd in sorted(COMMANDS.items()):
+        print("    %s%s" % (name.ljust(20), cmd.description))  # NOQA
+
+
+def unknown_command(command):
+    print("Unknown command: '%s'" % command)  # NOQA
+    print("Type '%s help' for usage." % prog_name())  # NOQA
+    sys.exit(1)
+
+
 def main():
-    # Set up usage string
-    command_descriptions = '\n'.join([
-        "    %s%s" % (name.ljust(20), cmd.description)
-        for name, cmd in sorted(COMMANDS.items())
-        if cmd.description is not None
-    ])
-    usage = (
-        "Usage: %prog <command> [command-options]\n\nAvailable commands:\n\n" +
-        command_descriptions
-    )
-
-    # Parse options
-    parser = OptionParser(usage=usage)
-    (options, args) = parser.parse_args()
-
-    # Find command
     try:
-        command = args[0]
+        command_name = sys.argv[1]
     except IndexError:
-        parser.print_help()
+        help_index()
         return
 
-    if command in COMMANDS:
-        command = COMMANDS[command]
-        if command.usage is not None:
-            parser.set_usage(command.usage)
-        command.run(parser, options, args)
-    else:
-        parser.error("Unrecognised command: " + command)
+    if command_name == 'help':
+        try:
+            help_command_name = sys.argv[2]
+        except IndexError:
+            help_index()
+            return
+
+        try:
+            command = COMMANDS[help_command_name]
+        except KeyError:
+            unknown_command(help_command_name)
+            return
+
+        command.print_help(help_command_name)
+        return
+
+    try:
+        command = COMMANDS[command_name]
+    except KeyError:
+        unknown_command(command_name)
+        return
+
+    command.execute(sys.argv)
 
 
 if __name__ == "__main__":

--- a/wagtail/bin/wagtail.py
+++ b/wagtail/bin/wagtail.py
@@ -133,17 +133,18 @@ class UpdateModulePaths(Command):
                     continue
 
                 path = os.path.join(dirpath, filename)
+                relative_path = os.path.relpath(path, start=root_path)
                 checked_file_count += 1
 
                 if diff:
-                    change_count = self._show_diff(path)
+                    change_count = self._show_diff(path, relative_path=relative_path)
                 else:
                     if list_files:
                         change_count = self._count_changes(path)
                     else:  # actually update
                         change_count = self._rewrite_file(path)
                     if change_count:
-                        print("%s - %d %s" % (path, change_count, 'change' if change_count == 1 else 'changes'))  # NOQA
+                        print("%s - %d %s" % (relative_path, change_count, 'change' if change_count == 1 else 'changes'))  # NOQA
 
                 if change_count:
                     changed_file_count += 1
@@ -158,7 +159,7 @@ class UpdateModulePaths(Command):
             line = re.sub(pattern, repl, line)
         return line
 
-    def _show_diff(self, filename):
+    def _show_diff(self, filename, relative_path=None):
         change_count = 0
         original = []
         updated = []
@@ -173,8 +174,10 @@ class UpdateModulePaths(Command):
                     change_count += 1
 
         if change_count:
+            relative_path = relative_path or filename
+
             sys.stdout.writelines(unified_diff(
-                original, updated, fromfile="%s:before" % filename, tofile="%s:after" % filename
+                original, updated, fromfile="%s:before" % relative_path, tofile="%s:after" % relative_path
             ))
 
         return change_count

--- a/wagtail/bin/wagtail.py
+++ b/wagtail/bin/wagtail.py
@@ -10,6 +10,10 @@ from difflib import unified_diff
 from django.core.management import ManagementUtility
 
 
+def pluralize(value, arg='s'):
+    return '' if value == 1 else arg
+
+
 class Command:
     description = None
 
@@ -157,15 +161,25 @@ class UpdateModulePaths(Command):
                     else:  # actually update
                         change_count = self._rewrite_file(path)
                     if change_count:
-                        print("%s - %d %s" % (relative_path, change_count, 'change' if change_count == 1 else 'changes'))  # NOQA
+                        print("%s - %d change%s" % (relative_path, change_count, pluralize(change_count)))  # NOQA
 
                 if change_count:
                     changed_file_count += 1
 
         if diff or list_files:
-            print("\nChecked %d .py files, %d files to update." % (checked_file_count, changed_file_count))  # NOQA
+            print(
+                "\nChecked %d .py file%s, %d file%s to update." % (
+                    checked_file_count, pluralize(checked_file_count),
+                    changed_file_count, pluralize(changed_file_count)
+                )
+            )  # NOQA
         else:
-            print("\nChecked %d .py files, %d files updated." % (checked_file_count, changed_file_count))  # NOQA
+            print(
+                "\nChecked %d .py file%s, %d file%s updated." % (
+                    checked_file_count, pluralize(checked_file_count),
+                    changed_file_count, pluralize(changed_file_count)
+                )
+            )  # NOQA
 
     def _rewrite_line(self, line):
         for pattern, repl in self.REPLACEMENTS:

--- a/wagtail/bin/wagtail.py
+++ b/wagtail/bin/wagtail.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import fileinput
+import fnmatch
 import os
 import re
 import sys
@@ -108,10 +109,17 @@ class UpdateModulePaths(Command):
         parser.add_argument('root_path', nargs='?', help="Path to your project's root")
         parser.add_argument('--list', action='store_true', dest='list_files', help="Show the list of files to change, without modifying them")
         parser.add_argument('--diff', action='store_true', help="Show the changes that would be made, without modifying the files")
+        parser.add_argument(
+            '--ignore-file', action='append', dest='ignored_patterns', metavar='NAME',
+            help="Ignore files with this name (supports wildcards)"
+        )
 
-    def run(self, root_path=None, list_files=False, diff=False):
+    def run(self, root_path=None, list_files=False, diff=False, ignored_patterns=None):
         if root_path is None:
             root_path = os.getcwd()
+
+        if ignored_patterns is None:
+            ignored_patterns = []
 
         checked_file_count = 0
         changed_file_count = 0
@@ -119,6 +127,9 @@ class UpdateModulePaths(Command):
         for (dirpath, dirnames, filenames) in os.walk(root_path):
             for filename in filenames:
                 if not filename.lower().endswith('.py'):
+                    continue
+
+                if any(fnmatch.fnmatch(filename, pattern) for pattern in ignored_patterns):
                     continue
 
                 path = os.path.join(dirpath, filename)


### PR DESCRIPTION
Adds a `wagtail updatemodulepaths [/path/to/project]` that can be run over a project codebase to convert all module path references to the new Wagtail 2.x versions (e.g. `wagtail.wagtailcore` -> `wagtail.core`).

The command simply runs a search-and-replace for the full dotted path over all *.py files, which seems to be robust enough to catch the references that need changing (imports, INSTALLED_APPS, references in migrations) without any false positives (database table names, `{% load wagtailcore_tags %}` etc). When testing on bakerydemo it just misses one reference, in app.json - I figured it was better to be conservative and only check *.py files, so that we aren't running rampant over media folders, `node_modules` and so on.

It's not hard to think of edge cases it'll fail on (`from wagtail import wagtailcore`, `INSTALLED_APPS = ['wagtail.' + 'wagtailcore']`...) but I can't see those coming up in real-world code. Have added appropriate disclaimers to the release notes, though.