### PR TITLE
use https://docs.djangoproject.com/en/1.11...

### DIFF
--- a/docs/getting_started/tutorial.rst
+++ b/docs/getting_started/tutorial.rst
@@ -81,7 +81,7 @@ Edit ``home/models.py`` as follows, to add a ``body`` field to the model:
             FieldPanel('body', classname="full"),
         ]
 
-``body`` is defined as ``RichTextField``, a special Wagtail field. You 
+``body`` is defined as ``RichTextField``, a special Wagtail field. You
 can use any of the `Django core fields <https://docs.djangoproject.com/en/1.11/ref/models/fields/>`__. ``content_panels`` define the
 capabilities and the layout of the editing interface. :doc:`More on creating Page models. <../topics/pages>`
 

--- a/docs/getting_started/tutorial.rst
+++ b/docs/getting_started/tutorial.rst
@@ -81,7 +81,8 @@ Edit ``home/models.py`` as follows, to add a ``body`` field to the model:
             FieldPanel('body', classname="full"),
         ]
 
-``body`` is defined as ``RichTextField``, a special Wagtail field. You can use any of the `Django core fields <https://docs.djangoproject.com/en/1.11/ref/models/fields/>`__. ``content_panels`` define the
+``body`` is defined as ``RichTextField``, a special Wagtail field. You 
+can use any of the `Django core fields <https://docs.djangoproject.com/en/1.11/ref/models/fields/>`__. ``content_panels`` define the
 capabilities and the layout of the editing interface. :doc:`More on creating Page models. <../topics/pages>`
 
 Run ``python manage.py makemigrations``, then

--- a/docs/getting_started/tutorial.rst
+++ b/docs/getting_started/tutorial.rst
@@ -81,7 +81,7 @@ Edit ``home/models.py`` as follows, to add a ``body`` field to the model:
             FieldPanel('body', classname="full"),
         ]
 
-``body`` is defined as ``RichTextField``, a special Wagtail field. You
+``body`` is defined as ``RichTextField``, a special Wagtail field. You can use any of the `Django core fields <https://docs.djangoproject.com/en/1.11/ref/models/fields/>`__. ``content_panels`` define the
 capabilities and the layout of the editing interface. :doc:`More on creating Page models. <../topics/pages>`
 
 Run ``python manage.py makemigrations``, then

--- a/docs/getting_started/tutorial.rst
+++ b/docs/getting_started/tutorial.rst
@@ -82,7 +82,6 @@ Edit ``home/models.py`` as follows, to add a ``body`` field to the model:
         ]
 
 ``body`` is defined as ``RichTextField``, a special Wagtail field. You
-can use any of the `Django core fields <https://docs.djangoproject.com/en/1.8/ref/models/fields/>`__. ``content_panels`` define the
 capabilities and the layout of the editing interface. :doc:`More on creating Page models. <../topics/pages>`
 
 Run ``python manage.py makemigrations``, then
@@ -97,7 +96,7 @@ to the model. Wagtail uses normal Django templates to render each page
 type. By default, it will look for a template filename formed from the app and model name,
 separating capital letters with underscores (e.g. HomePage within the 'home' app becomes
 ``home/home_page.html``). This template file can exist in any location recognised by
-`Django's template rules <https://docs.djangoproject.com/en/1.10/intro/tutorial03/#write-views-that-actually-do-something>`__; conventionally it is placed under a ``templates`` folder within the app.
+`Django's template rules <https://docs.djangoproject.com/en/1.11/intro/tutorial03/#write-views-that-actually-do-something>`__; conventionally it is placed under a ``templates`` folder within the app.
 
 Edit ``home/templates/home/home_page.html`` to contain the following:
 


### PR DESCRIPTION
Thanks for contributing to Wagtail! 🎉

Updating link as wagtail uses 1.11 now 

here is my requirements.txt 

```
$ cat requirements.txt 
beautifulsoup4==4.6.0
certifi==2017.11.5
chardet==3.0.4
Django==1.11.9
django-modelcluster==3.1
django-taggit==0.22.2
django-treebeard==4.2.0
djangorestframework==3.6.4
html5lib==0.999999999
idna==2.6
Pillow==5.0.0
pkg-resources==0.0.0
pytz==2017.3
requests==2.18.4
six==1.11.0
Unidecode==1.0.22
urllib3==1.22
wagtail==1.13.1
webencodings==0.5.1
Willow==1.0
```

Do you use a more automated approach to updating these links? Sorry if you do and please feel free to reject this pull request. 

Before submitting, please review the contributor guidelines <http://docs.wagtail.io/en/latest/contributing/index.html> and check the following:

* Do the tests still pass? (http://docs.wagtail.io/en/latest/contributing/developing.html#testing)
* Does the code comply with the style guide? (Run `make lint` from the Wagtail root)
* For Python changes: Have you added tests to cover the new/fixed behaviour?
* For new features: Has the documentation been updated accordingly?
