### PR TITLE
Prevent navigation to pages outside user explorable root

### DIFF
--- a/wagtail/admin/tests/test_pages_views.py
+++ b/wagtail/admin/tests/test_pages_views.py
@@ -361,25 +361,21 @@ class TestPageExplorerSignposting(TestCase, WagtailTestUtils):
     def test_nonadmin_at_root(self):
         self.assertTrue(self.client.login(username='siteeditor', password='password'))
         response = self.client.get(reverse('wagtailadmin_explore_root'))
-        self.assertEqual(response.status_code, 200)
-        # Non-admin should get a simple "create pages as children of the homepage" prompt
-        self.assertContains(
-            response,
-            "Pages created here will not be accessible at any URL. "
-            "To add pages to an existing site, create them as children of the homepage."
+
+        # Non-admins should be redirected to their explorable root.
+        self.assertEqual(
+            (response.status_code, response['Location']),
+            (302, reverse('wagtailadmin_explore', args=(self.site_page.pk, )))
         )
 
     def test_nonadmin_at_non_site_page(self):
         self.assertTrue(self.client.login(username='siteeditor', password='password'))
         response = self.client.get(reverse('wagtailadmin_explore', args=(self.no_site_page.id, )))
-        self.assertEqual(response.status_code, 200)
-        # Non-admin should get a warning about unroutable pages
-        self.assertContains(
-            response,
-            (
-                "There is no site record for this location. "
-                "Pages created here will not be accessible at any URL."
-            )
+
+        # Non-admins should be redirected to their explorable root.
+        self.assertEqual(
+            (response.status_code, response['Location']),
+            (302, reverse('wagtailadmin_explore', args=(self.site_page.pk, )))
         )
 
     def test_nonadmin_at_site_page(self):

--- a/wagtail/admin/views/pages.py
+++ b/wagtail/admin/views/pages.py
@@ -19,6 +19,7 @@ from django.views.generic import View
 from wagtail.utils.pagination import paginate
 from wagtail.admin import messages, signals
 from wagtail.admin.forms import CopyForm, SearchForm
+from wagtail.admin.navigation import get_explorable_root_page
 from wagtail.admin.utils import (
     send_notification, user_has_any_page_permission, user_passes_test)
 from wagtail.core import hooks
@@ -35,9 +36,22 @@ def get_valid_next_url_from_request(request):
 @user_passes_test(user_has_any_page_permission)
 def index(request, parent_page_id=None):
     if parent_page_id:
-        parent_page = get_object_or_404(Page, id=parent_page_id).specific
+        parent_page = get_object_or_404(Page, id=parent_page_id)
     else:
-        parent_page = Page.get_first_root_node().specific
+        parent_page = Page.get_first_root_node()
+
+    # This will always succeed because of the @user_passes_test above.
+    root_page = get_explorable_root_page(request.user)
+
+    # If this page isn't a descendant of the user's explorable root page,
+    # then redirect to that explorable root page instead.
+    if not (
+        parent_page.pk == root_page.pk or
+        parent_page.is_descendant_of(root_page)
+    ):
+        return redirect('wagtailadmin_explore', root_page.pk)
+
+    parent_page = parent_page.specific
 
     pages = parent_page.get_children().prefetch_related('content_type', 'sites_rooted_here')
 


### PR DESCRIPTION
This change prevents non-admins from navigating around the Wagtail page tree for pages that lie outside of their explorable root. Currently, non-admins can hit any page in the tree using a URL like `/admin/pages/123/` even if they don't have any permissions over that page or its part of the page tree.

This change adds a (temporary) redirect to requests like this, so that users may not navigate to parts of the tree that lie outside outside of their explorable site root, as determined by the page privileges they have. If they try to hit a URL like the one above, they get redirected to their explorable site root navigation page instead.

Relevant unit tests have been modified to incorporate this change.

This PR addresses part of #3616. It partially incorporates some of the changes in #2463, but, like #4206, leaves some existing issues with non-admin page navigation; for example, users can still copy or see revisions on pages they shouldn't have permissions over.