### PR TITLE
Slugurl dead code

### DIFF
--- a/wagtail/core/templatetags/wagtailcore_tags.py
+++ b/wagtail/core/templatetags/wagtailcore_tags.py
@@ -40,14 +40,6 @@ def slugurl(context, slug):
     else:
         return None
 
-    try:
-        current_site = context['request'].site
-    except (KeyError, AttributeError):
-        # request.site not available in the current context; fall back on page.url
-        return page.url
-
-    return page.relative_url(current_site)
-
 
 @register.simple_tag
 def wagtail_version():

--- a/wagtail/core/templatetags/wagtailcore_tags.py
+++ b/wagtail/core/templatetags/wagtailcore_tags.py
@@ -37,8 +37,6 @@ def slugurl(context, slug):
     if page:
         # call pageurl() instead of page.relative_url() here so we get the ``accepts_kwarg`` logic
         return pageurl(context, page)
-    else:
-        return None
 
 
 @register.simple_tag

--- a/wagtail/core/tests/test_jinja2.py
+++ b/wagtail/core/tests/test_jinja2.py
@@ -45,6 +45,10 @@ class TestCoreGlobalsAndFilters(TestCase):
             self.render('{{ slugurl(page.slug) }}', {'page': page}),
             page.url)
 
+    def test_bad_slugurl(self):
+        self.assertEqual(
+            self.render('{{ slugurl("bad-slug-doesnt-exist") }}', {}), 'None')
+
     def test_wagtail_version(self):
         self.assertEqual(
             self.render('{{ wagtail_version() }}'),

--- a/wagtail/core/tests/tests.py
+++ b/wagtail/core/tests/tests.py
@@ -48,6 +48,17 @@ class TestPageUrlTags(TestCase):
         result = tpl.render(template.Context({'request': HttpRequest()}))
         self.assertIn('<a href="/events/">Events</a>', result)
 
+    def test_bad_slugurl(self):
+        tpl = template.Template('''{% load wagtailcore_tags %}<a href="{% slugurl 'bad-slug-doesnt-exist' %}">Events</a>''')
+
+        # no 'request' object in context
+        result = tpl.render(template.Context({}))
+        self.assertIn('<a href="None">Events</a>', result)
+
+        # 'request' object in context, but no 'site' attribute
+        result = tpl.render(template.Context({'request': HttpRequest()}))
+        self.assertIn('<a href="None">Events</a>', result)
+
 
 class TestSiteRootPathsCache(TestCase):
     fixtures = ['test.json']


### PR DESCRIPTION
Unless I am misunderstanding something everything after the if-else block testing for a page object from a slug is unreachable. So I've removed it, the unnecessary `return None`, and added tests to confirm that the slug not existing case still performs the same as before the changes.

* I think test results are as expected for current master branch, but there were a large number of RemovedInDjango21Warning and DeprecationWarning in the output:
    Ran 2951 tests in 165.442s
    OK (skipped=188, expected failures=8)
* I think lint results are as expected for the current master branch:
    90 ERROR:  Imports are incorrectly sorted.
* Existing test coverage lacked tests for the failure case. I've added some for slugurl in wagtail.core.tests.test_jinja2 and wagtail.core.tests.tests
* No Documentation changes are needed in my opinion.
