### PR TITLE
Reinstate isort

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -11,7 +11,7 @@ dependencies:
 test:
   override:
     - flake8 wagtail
-#    - isort --check-only --diff --recursive wagtail
+    - isort --check-only --diff --recursive wagtail
     - npm run lint:js
     - npm run lint:css
     - python -u runtests.py

--- a/wagtail/admin/edit_handlers.py
+++ b/wagtail/admin/edit_handlers.py
@@ -11,11 +11,11 @@ from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy
 from taggit.managers import TaggableManager
 
-from wagtail.utils.decorators import cached_classmethod
 from wagtail.admin import compare, widgets
 from wagtail.core.fields import RichTextField
 from wagtail.core.models import Page
 from wagtail.core.utils import camelcase_to_underscore, resolve_model_string
+from wagtail.utils.decorators import cached_classmethod
 
 # DIRECT_FORM_FIELD_OVERRIDES, FORM_FIELD_OVERRIDES are imported for backwards
 # compatibility, as people are likely importing them from here and then

--- a/wagtail/admin/rich_text/converters/contentstate_models.py
+++ b/wagtail/admin/rich_text/converters/contentstate_models.py
@@ -2,7 +2,6 @@ import json
 import random
 import string
 
-
 ALPHANUM = string.ascii_lowercase + string.digits
 
 

--- a/wagtail/admin/rich_text/converters/editor_html.py
+++ b/wagtail/admin/rich_text/converters/editor_html.py
@@ -5,7 +5,7 @@ from django.utils.functional import cached_property
 from wagtail.core import hooks
 from wagtail.core.rich_text import features as feature_registry
 from wagtail.core.rich_text.rewriters import EmbedRewriter, LinkRewriter, MultiRuleRewriter
-from wagtail.core.whitelist import allow_without_attributes, Whitelister
+from wagtail.core.whitelist import Whitelister, allow_without_attributes
 from wagtail.utils.deprecation import RemovedInWagtail22Warning
 
 

--- a/wagtail/admin/rich_text/converters/html_ruleset.py
+++ b/wagtail/admin/rich_text/converters/html_ruleset.py
@@ -1,5 +1,5 @@
-from collections import Mapping
 import re
+from collections import Mapping
 
 ELEMENT_SELECTOR = re.compile(r'^([\w-]+)$')
 ELEMENT_WITH_ATTR_SELECTOR = re.compile(r'^([\w-]+)\[([\w-]+)\]$')

--- a/wagtail/admin/rich_text/converters/html_to_contentstate.py
+++ b/wagtail/admin/rich_text/converters/html_to_contentstate.py
@@ -1,13 +1,11 @@
-from html.parser import HTMLParser
 import re
+from html.parser import HTMLParser
 
 from wagtail.admin.rich_text.converters.contentstate_models import (
-    Block, ContentState, Entity, EntityRange, InlineStyleRange
-)
+    Block, ContentState, Entity, EntityRange, InlineStyleRange)
 from wagtail.admin.rich_text.converters.html_ruleset import HTMLRuleset
-from wagtail.core.rich_text import features as feature_registry
 from wagtail.core.models import Page
-
+from wagtail.core.rich_text import features as feature_registry
 
 # constants to keep track of what to do with leading whitespace on the next text node we encounter
 STRIP_WHITESPACE = 0

--- a/wagtail/admin/rich_text/editors/hallo.py
+++ b/wagtail/admin/rich_text/editors/hallo.py
@@ -1,5 +1,5 @@
-from collections import OrderedDict
 import json
+from collections import OrderedDict
 
 from django.forms import Media, widgets
 

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -10,7 +10,6 @@ from django.template.loader import render_to_string
 from django.utils.html import conditional_escape
 from django.utils.safestring import mark_safe
 
-from wagtail.utils.pagination import DEFAULT_PAGE_KEY, replace_page_in_query
 from wagtail.admin.menu import admin_menu
 from wagtail.admin.navigation import get_explorable_root_page
 from wagtail.admin.search import admin_search_areas
@@ -19,6 +18,7 @@ from wagtail.core.models import (
     CollectionViewRestriction, Page, PageViewRestriction, UserPagePermissionsProxy)
 from wagtail.core.utils import cautious_slugify as _cautious_slugify
 from wagtail.core.utils import camelcase_to_underscore, escape_script
+from wagtail.utils.pagination import DEFAULT_PAGE_KEY, replace_page_in_query
 
 register = template.Library()
 

--- a/wagtail/admin/tests/api/test_pages.py
+++ b/wagtail/admin/tests/api/test_pages.py
@@ -6,9 +6,9 @@ from django.urls import reverse
 from django.utils import timezone
 
 from wagtail.api.v2.tests.test_pages import TestPageDetail, TestPageListing
+from wagtail.core.models import Page
 from wagtail.tests.demosite import models
 from wagtail.tests.testapp.models import SimplePage, StreamPage
-from wagtail.core.models import Page
 
 from .utils import AdminAPITestCase
 

--- a/wagtail/admin/tests/test_account_management.py
+++ b/wagtail/admin/tests/test_account_management.py
@@ -5,9 +5,8 @@ from django.core import mail
 from django.test import TestCase, override_settings
 from django.urls import reverse
 
+from wagtail.admin.utils import WAGTAILADMIN_PROVIDED_LANGUAGES, get_available_admin_languages
 from wagtail.tests.utils import WagtailTestUtils
-from wagtail.admin.utils import (
-    WAGTAILADMIN_PROVIDED_LANGUAGES, get_available_admin_languages)
 from wagtail.users.models import UserProfile
 
 

--- a/wagtail/admin/tests/test_admin_search.py
+++ b/wagtail/admin/tests/test_admin_search.py
@@ -6,9 +6,9 @@ from django.template import Context, Template
 from django.test import RequestFactory, TestCase
 from django.urls import reverse
 
-from wagtail.tests.utils import WagtailTestUtils
 from wagtail.admin.utils import user_has_any_page_permission
 from wagtail.core.models import Site
+from wagtail.tests.utils import WagtailTestUtils
 
 
 class BaseSearchAreaTestCase(WagtailTestUtils, TestCase):

--- a/wagtail/admin/tests/test_buttons_hooks.py
+++ b/wagtail/admin/tests/test_buttons_hooks.py
@@ -1,10 +1,10 @@
 from django.test import TestCase
 from django.urls import reverse
 
-from wagtail.tests.utils import WagtailTestUtils
 from wagtail.admin import widgets as wagtailadmin_widgets
 from wagtail.core import hooks
 from wagtail.core.models import Page
+from wagtail.tests.utils import WagtailTestUtils
 
 
 class TestButtonsHooks(TestCase, WagtailTestUtils):

--- a/wagtail/admin/tests/test_collections_views.py
+++ b/wagtail/admin/tests/test_collections_views.py
@@ -1,9 +1,9 @@
 from django.test import TestCase
 from django.urls import reverse
 
-from wagtail.tests.utils import WagtailTestUtils
 from wagtail.core.models import Collection
 from wagtail.documents.models import Document
+from wagtail.tests.utils import WagtailTestUtils
 
 
 class TestCollectionsIndexView(TestCase, WagtailTestUtils):

--- a/wagtail/admin/tests/test_compare.py
+++ b/wagtail/admin/tests/test_compare.py
@@ -9,8 +9,8 @@ from wagtail.core.blocks import StreamValue
 from wagtail.images import get_image_model
 from wagtail.images.tests.utils import get_test_image_file
 from wagtail.tests.testapp.models import (
-    EventCategory, EventPage, EventPageSpeaker, HeadCountRelatedModelUsingPK,
-    SimplePage, StreamPage, TaggedPage)
+    EventCategory, EventPage, EventPageSpeaker, HeadCountRelatedModelUsingPK, SimplePage,
+    StreamPage, TaggedPage)
 
 
 class TestFieldComparison(TestCase):

--- a/wagtail/admin/tests/test_contentstate.py
+++ b/wagtail/admin/tests/test_contentstate.py
@@ -1,7 +1,7 @@
 import json
-from mock import patch
 
 from django.test import TestCase
+from mock import patch
 
 from wagtail.admin.rich_text.converters.contentstate import ContentstateConverter
 from wagtail.embeds.models import Embed

--- a/wagtail/admin/tests/test_edit_handlers.py
+++ b/wagtail/admin/tests/test_edit_handlers.py
@@ -6,10 +6,6 @@ from django.core import checks
 from django.core.exceptions import FieldDoesNotExist, ImproperlyConfigured
 from django.test import TestCase, override_settings
 
-from wagtail.tests.testapp.forms import ValidatedPageForm
-from wagtail.tests.testapp.models import (
-    EventPage, EventPageChooserModel, EventPageSpeaker, PageChooserModel, SimplePage, ValidatedPage)
-from wagtail.tests.utils import WagtailTestUtils
 from wagtail.admin.edit_handlers import (
     FieldPanel, FieldRowPanel, InlinePanel, ObjectList, PageChooserPanel, RichTextFieldPanel,
     TabbedInterface, extract_panel_definitions_from_model_class, get_form_for_model)
@@ -18,6 +14,10 @@ from wagtail.admin.rich_text import DraftailRichTextArea
 from wagtail.admin.widgets import AdminAutoHeightTextInput, AdminDateInput, AdminPageChooser
 from wagtail.core.models import Page, Site
 from wagtail.images.edit_handlers import ImageChooserPanel
+from wagtail.tests.testapp.forms import ValidatedPageForm
+from wagtail.tests.testapp.models import (
+    EventPage, EventPageChooserModel, EventPageSpeaker, PageChooserModel, SimplePage, ValidatedPage)
+from wagtail.tests.utils import WagtailTestUtils
 
 
 class TestGetFormForModel(TestCase):

--- a/wagtail/admin/tests/test_navigation.py
+++ b/wagtail/admin/tests/test_navigation.py
@@ -3,9 +3,9 @@
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 
-from wagtail.tests.utils import WagtailTestUtils
 from wagtail.admin.navigation import (
     get_explorable_root_page, get_pages_with_direct_explore_permission)
+from wagtail.tests.utils import WagtailTestUtils
 
 
 class TestExplorablePages(TestCase, WagtailTestUtils):

--- a/wagtail/admin/tests/test_page_chooser.py
+++ b/wagtail/admin/tests/test_page_chooser.py
@@ -3,10 +3,10 @@ from django.test import TestCase
 from django.urls import reverse
 from django.utils.http import urlencode
 
-from wagtail.tests.testapp.models import EventIndex, EventPage, SimplePage, SingleEventPage
-from wagtail.tests.utils import WagtailTestUtils
 from wagtail.admin.views.chooser import can_choose_page
 from wagtail.core.models import Page, UserPagePermissionsProxy
+from wagtail.tests.testapp.models import EventIndex, EventPage, SimplePage, SingleEventPage
+from wagtail.tests.utils import WagtailTestUtils
 
 
 class TestChooserBrowse(TestCase, WagtailTestUtils):

--- a/wagtail/admin/tests/test_pages_views.py
+++ b/wagtail/admin/tests/test_pages_views.py
@@ -19,17 +19,17 @@ from django.utils import formats, timezone
 from django.utils.dateparse import parse_date
 from freezegun import freeze_time
 
+from wagtail.admin.views.home import RecentEditsPanel
+from wagtail.admin.views.pages import PreviewOnEdit
+from wagtail.core.models import GroupPagePermission, Page, PageRevision, Site
+from wagtail.core.signals import page_published, page_unpublished
+from wagtail.search.index import SearchField
 from wagtail.tests.testapp.models import (
     EVENT_AUDIENCE_CHOICES, Advert, AdvertPlacement, BusinessChild, BusinessIndex, BusinessSubIndex,
     DefaultStreamPage, EventCategory, EventPage, EventPageCarouselItem, FilePage,
     ManyToManyBlogPage, SimplePage, SingleEventPage, SingletonPage, StandardChild, StandardIndex,
     TaggedPage)
 from wagtail.tests.utils import WagtailTestUtils
-from wagtail.admin.views.home import RecentEditsPanel
-from wagtail.admin.views.pages import PreviewOnEdit
-from wagtail.core.models import GroupPagePermission, Page, PageRevision, Site
-from wagtail.core.signals import page_published, page_unpublished
-from wagtail.search.index import SearchField
 from wagtail.users.models import UserProfile
 
 

--- a/wagtail/admin/tests/test_privacy.py
+++ b/wagtail/admin/tests/test_privacy.py
@@ -2,9 +2,9 @@ from django.contrib.auth.models import Group
 from django.test import TestCase
 from django.urls import reverse
 
+from wagtail.core.models import Page, PageViewRestriction
 from wagtail.tests.testapp.models import SimplePage
 from wagtail.tests.utils import WagtailTestUtils
-from wagtail.core.models import Page, PageViewRestriction
 
 
 class TestSetPrivacyView(TestCase, WagtailTestUtils):

--- a/wagtail/admin/tests/test_rich_text.py
+++ b/wagtail/admin/tests/test_rich_text.py
@@ -1,17 +1,17 @@
 from bs4 import BeautifulSoup
-
 from django.conf import settings
 from django.test import TestCase
 from django.test.utils import override_settings
 from django.urls import reverse
 
-from wagtail.tests.testapp.models import SingleEventPage
-from wagtail.tests.testapp.rich_text import CustomRichTextArea
-from wagtail.tests.utils import WagtailTestUtils
-from wagtail.admin.rich_text import DraftailRichTextArea, HalloRichTextArea, get_rich_text_editor_widget
+from wagtail.admin.rich_text import (
+    DraftailRichTextArea, HalloRichTextArea, get_rich_text_editor_widget)
 from wagtail.core.blocks import RichTextBlock
 from wagtail.core.models import Page, get_page_models
 from wagtail.core.rich_text import RichText
+from wagtail.tests.testapp.models import SingleEventPage
+from wagtail.tests.testapp.rich_text import CustomRichTextArea
+from wagtail.tests.utils import WagtailTestUtils
 
 
 class BaseRichTextEditHandlerTestCase(TestCase):

--- a/wagtail/admin/tests/test_userbar.py
+++ b/wagtail/admin/tests/test_userbar.py
@@ -5,9 +5,9 @@ from django.test import TestCase
 from django.test.client import RequestFactory
 from django.urls import reverse
 
+from wagtail.core.models import PAGE_TEMPLATE_VAR, Page, Site
 from wagtail.tests.testapp.models import BusinessChild, BusinessIndex
 from wagtail.tests.utils import WagtailTestUtils
-from wagtail.core.models import PAGE_TEMPLATE_VAR, Page, Site
 
 
 class TestUserbarTag(TestCase):

--- a/wagtail/admin/tests/test_widgets.py
+++ b/wagtail/admin/tests/test_widgets.py
@@ -1,9 +1,9 @@
 from django.test import TestCase
 from django.test.utils import override_settings
 
-from wagtail.tests.testapp.models import EventPage, SimplePage
 from wagtail.admin import widgets
 from wagtail.core.models import Page
+from wagtail.tests.testapp.models import EventPage, SimplePage
 
 
 class TestAdminPageChooserWidget(TestCase):

--- a/wagtail/admin/tests/tests.py
+++ b/wagtail/admin/tests/tests.py
@@ -10,11 +10,11 @@ from django.urls import reverse, reverse_lazy
 from django.utils.translation import ugettext_lazy as _
 from taggit.models import Tag
 
-from wagtail.tests.utils import WagtailTestUtils
 from wagtail.admin.menu import MenuItem
 from wagtail.admin.site_summary import PagesSummaryItem
 from wagtail.admin.utils import send_mail, user_has_any_page_permission
 from wagtail.core.models import Page, Site
+from wagtail.tests.utils import WagtailTestUtils
 
 
 class TestHome(TestCase, WagtailTestUtils):

--- a/wagtail/admin/views/chooser.py
+++ b/wagtail/admin/views/chooser.py
@@ -3,12 +3,12 @@ import json
 from django.http import Http404
 from django.shortcuts import get_object_or_404, render
 
-from wagtail.utils.pagination import paginate
 from wagtail.admin.forms import EmailLinkChooserForm, ExternalLinkChooserForm, SearchForm
 from wagtail.admin.modal_workflow import render_modal_workflow
 from wagtail.core import hooks
 from wagtail.core.models import Page, UserPagePermissionsProxy
 from wagtail.core.utils import resolve_model_string
+from wagtail.utils.pagination import paginate
 
 
 def shared_context(request, extra_context=None):

--- a/wagtail/admin/views/pages.py
+++ b/wagtail/admin/views/pages.py
@@ -16,13 +16,12 @@ from django.views.decorators.http import require_GET, require_POST
 from django.views.decorators.vary import vary_on_headers
 from django.views.generic import View
 
-from wagtail.utils.pagination import paginate
 from wagtail.admin import messages, signals
 from wagtail.admin.forms import CopyForm, SearchForm
-from wagtail.admin.utils import (
-    send_notification, user_has_any_page_permission, user_passes_test)
+from wagtail.admin.utils import send_notification, user_has_any_page_permission, user_passes_test
 from wagtail.core import hooks
 from wagtail.core.models import Page, PageRevision, UserPagePermissionsProxy
+from wagtail.utils.pagination import paginate
 
 
 def get_valid_next_url_from_request(request):

--- a/wagtail/admin/wagtail_hooks.py
+++ b/wagtail/admin/wagtail_hooks.py
@@ -2,9 +2,9 @@ from django.contrib.auth.models import Permission
 from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
 from django.utils.translation import ugettext
-
 from draftjs_exporter.dom import DOM
 
+import wagtail.admin.rich_text.editors.draftail.features as draftail_features
 from wagtail.admin.menu import MenuItem, SubmenuMenuItem, settings_menu
 from wagtail.admin.navigation import get_explorable_root_page
 from wagtail.admin.rich_text import (
@@ -12,10 +12,8 @@ from wagtail.admin.rich_text import (
 from wagtail.admin.rich_text.converters.contentstate import link_entity
 from wagtail.admin.rich_text.converters.editor_html import LinkTypeRule, WhitelistRule
 from wagtail.admin.rich_text.converters.html_to_contentstate import (
-    BlockElementHandler, ExternalLinkElementHandler, HorizontalRuleHandler, InlineStyleElementHandler,
-    ListElementHandler, ListItemElementHandler, PageLinkElementHandler
-)
-import wagtail.admin.rich_text.editors.draftail.features as draftail_features
+    BlockElementHandler, ExternalLinkElementHandler, HorizontalRuleHandler,
+    InlineStyleElementHandler, ListElementHandler, ListItemElementHandler, PageLinkElementHandler)
 from wagtail.admin.search import SearchArea
 from wagtail.admin.utils import user_has_any_page_permission
 from wagtail.admin.viewsets import viewsets

--- a/wagtail/admin/widgets.py
+++ b/wagtail/admin/widgets.py
@@ -13,10 +13,10 @@ from django.utils.html import format_html
 from django.utils.translation import ugettext_lazy as _
 from taggit.forms import TagWidget
 
-from wagtail.utils.widgets import WidgetWithScript
 from wagtail.admin.datetimepicker import to_datetimepicker_format
 from wagtail.core import hooks
 from wagtail.core.models import Page
+from wagtail.utils.widgets import WidgetWithScript
 
 DEFAULT_DATE_FORMAT = '%Y-%m-%d'
 DEFAULT_DATETIME_FORMAT = '%Y-%m-%d %H:%M'

--- a/wagtail/api/v2/tests/test_pages.py
+++ b/wagtail/api/v2/tests/test_pages.py
@@ -7,9 +7,9 @@ from django.test.utils import override_settings
 from django.urls import reverse
 
 from wagtail.api.v2 import signal_handlers
+from wagtail.core.models import Page, Site
 from wagtail.tests.demosite import models
 from wagtail.tests.testapp.models import StreamPage
-from wagtail.core.models import Page, Site
 
 
 def get_total_page_count():

--- a/wagtail/contrib/forms/models.py
+++ b/wagtail/contrib/forms/models.py
@@ -15,8 +15,6 @@ from wagtail.core.models import Orderable, Page
 from .forms import FormBuilder, WagtailAdminFormPageForm
 from .views import SubmissionsListView
 
-
-
 FORM_FIELD_CHOICES = (
     ('singleline', _('Single line text')),
     ('multiline', _('Multi-line text')),

--- a/wagtail/contrib/forms/tests/test_models.py
+++ b/wagtail/contrib/forms/tests/test_models.py
@@ -9,7 +9,8 @@ from wagtail.contrib.forms.tests.utils import (
     make_form_page, make_form_page_with_custom_submission, make_form_page_with_redirect)
 from wagtail.core.models import Page
 from wagtail.tests.testapp.models import (
-    CustomFormPageSubmission, ExtendedFormField, FormField, FormPageWithCustomFormBuilder, JadeFormPage)
+    CustomFormPageSubmission, ExtendedFormField, FormField, FormPageWithCustomFormBuilder,
+    JadeFormPage)
 from wagtail.tests.utils import WagtailTestUtils
 
 

--- a/wagtail/contrib/forms/urls.py
+++ b/wagtail/contrib/forms/urls.py
@@ -1,6 +1,7 @@
 from django.conf.urls import url
 
-from wagtail.contrib.forms.views import DeleteSubmissionsView, FormPagesListView, get_submissions_list_view
+from wagtail.contrib.forms.views import (
+    DeleteSubmissionsView, FormPagesListView, get_submissions_list_view)
 
 app_name = 'wagtailforms'
 urlpatterns = [

--- a/wagtail/contrib/forms/utils.py
+++ b/wagtail/contrib/forms/utils.py
@@ -3,7 +3,6 @@ from django.contrib.contenttypes.models import ContentType
 from wagtail.core import hooks
 from wagtail.core.models import UserPagePermissionsProxy, get_page_models
 
-
 _FORM_CONTENT_TYPES = None
 
 

--- a/wagtail/contrib/frontend_cache/tests.py
+++ b/wagtail/contrib/frontend_cache/tests.py
@@ -6,8 +6,8 @@ from django.test.utils import override_settings
 from wagtail.contrib.frontend_cache.backends import (
     BaseBackend, CloudflareBackend, CloudfrontBackend, HTTPBackend)
 from wagtail.contrib.frontend_cache.utils import get_backends
-from wagtail.tests.testapp.models import EventIndex
 from wagtail.core.models import Page
+from wagtail.tests.testapp.models import EventIndex
 
 from .utils import (
     PurgeBatch, purge_page_from_cache, purge_pages_from_cache, purge_url_from_cache,

--- a/wagtail/contrib/modeladmin/tests/test_page_modeladmin.py
+++ b/wagtail/contrib/modeladmin/tests/test_page_modeladmin.py
@@ -2,9 +2,9 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group, Permission
 from django.test import TestCase
 
+from wagtail.core.models import GroupPagePermission, Page
 from wagtail.tests.testapp.models import BusinessIndex, EventCategory, EventPage
 from wagtail.tests.utils import WagtailTestUtils
-from wagtail.core.models import GroupPagePermission, Page
 
 
 class TestIndexView(TestCase, WagtailTestUtils):

--- a/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
+++ b/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
@@ -3,10 +3,10 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group
 from django.test import TestCase
 
-from wagtail.tests.modeladmintest.models import Author, Book, Publisher, Token
-from wagtail.tests.utils import WagtailTestUtils
 from wagtail.images.models import Image
 from wagtail.images.tests.utils import get_test_image_file
+from wagtail.tests.modeladmintest.models import Author, Book, Publisher, Token
+from wagtail.tests.utils import WagtailTestUtils
 
 
 class TestBookIndexView(TestCase, WagtailTestUtils):

--- a/wagtail/contrib/modeladmin/views.py
+++ b/wagtail/contrib/modeladmin/views.py
@@ -29,8 +29,7 @@ from django.views.generic import TemplateView
 from django.views.generic.edit import FormView
 
 from wagtail.admin import messages
-from wagtail.admin.edit_handlers import (
-    ObjectList, extract_panel_definitions_from_model_class)
+from wagtail.admin.edit_handlers import ObjectList, extract_panel_definitions_from_model_class
 
 from .forms import ParentChooserForm
 

--- a/wagtail/contrib/postgres_search/backend.py
+++ b/wagtail/contrib/postgres_search/backend.py
@@ -3,7 +3,7 @@ from warnings import warn
 from django.contrib.postgres.search import SearchQuery as PostgresSearchQuery
 from django.contrib.postgres.search import SearchRank, SearchVector
 from django.db import DEFAULT_DB_ALIAS, NotSupportedError, connections, transaction
-from django.db.models import F, Manager, TextField, Value, Q
+from django.db.models import F, Manager, Q, TextField, Value
 from django.db.models.constants import LOOKUP_SEP
 from django.db.models.functions import Cast
 from django.utils.encoding import force_text

--- a/wagtail/contrib/postgres_search/models.py
+++ b/wagtail/contrib/postgres_search/models.py
@@ -8,6 +8,7 @@ from django.db.models.functions import Cast
 from django.utils.translation import ugettext_lazy as _
 
 from wagtail.search.index import class_is_indexed
+
 from .utils import get_descendants_content_types_pks
 
 

--- a/wagtail/contrib/redirects/forms.py
+++ b/wagtail/contrib/redirects/forms.py
@@ -2,8 +2,8 @@ from django import forms
 from django.utils.translation import ugettext_lazy as _
 
 from wagtail.admin.widgets import AdminPageChooser
-from wagtail.core.models import Site
 from wagtail.contrib.redirects.models import Redirect
+from wagtail.core.models import Site
 
 
 class RedirectForm(forms.ModelForm):

--- a/wagtail/contrib/redirects/permissions.py
+++ b/wagtail/contrib/redirects/permissions.py
@@ -1,4 +1,4 @@
-from wagtail.core.permission_policies import ModelPermissionPolicy
 from wagtail.contrib.redirects.models import Redirect
+from wagtail.core.permission_policies import ModelPermissionPolicy
 
 permission_policy = ModelPermissionPolicy(Redirect)

--- a/wagtail/contrib/redirects/tests.py
+++ b/wagtail/contrib/redirects/tests.py
@@ -2,9 +2,9 @@
 from django.test import TestCase, override_settings
 from django.urls import reverse
 
-from wagtail.tests.utils import WagtailTestUtils
-from wagtail.core.models import Page, Site
 from wagtail.contrib.redirects import models
+from wagtail.core.models import Page, Site
+from wagtail.tests.utils import WagtailTestUtils
 
 
 @override_settings(ALLOWED_HOSTS=['testserver', 'localhost', 'test.example.com', 'other.example.com'])

--- a/wagtail/contrib/redirects/views.py
+++ b/wagtail/contrib/redirects/views.py
@@ -3,13 +3,13 @@ from django.urls import reverse
 from django.utils.translation import ugettext as _
 from django.views.decorators.vary import vary_on_headers
 
-from wagtail.utils.pagination import paginate
 from wagtail.admin import messages
 from wagtail.admin.forms import SearchForm
 from wagtail.admin.utils import PermissionPolicyChecker, permission_denied
 from wagtail.contrib.redirects import models
 from wagtail.contrib.redirects.forms import RedirectForm
 from wagtail.contrib.redirects.permissions import permission_policy
+from wagtail.utils.pagination import paginate
 
 permission_checker = PermissionPolicyChecker(permission_policy)
 

--- a/wagtail/contrib/redirects/wagtail_hooks.py
+++ b/wagtail/contrib/redirects/wagtail_hooks.py
@@ -4,9 +4,9 @@ from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
 
 from wagtail.admin.menu import MenuItem
-from wagtail.core import hooks
 from wagtail.contrib.redirects import urls
 from wagtail.contrib.redirects.permissions import permission_policy
+from wagtail.core import hooks
 
 
 @hooks.register('register_admin_urls')

--- a/wagtail/contrib/routable_page/tests.py
+++ b/wagtail/contrib/routable_page/tests.py
@@ -2,11 +2,10 @@ import mock
 from django.test import RequestFactory, TestCase
 from django.urls.exceptions import NoReverseMatch
 
-from wagtail.contrib.routable_page.templatetags.wagtailroutablepage_tags import \
-    routablepageurl
+from wagtail.contrib.routable_page.templatetags.wagtailroutablepage_tags import routablepageurl
+from wagtail.core.models import Page, Site
 from wagtail.tests.routablepage.models import (
     RoutablePageTest, RoutablePageWithOverriddenIndexRouteTest)
-from wagtail.core.models import Page, Site
 
 
 class TestRoutablePage(TestCase):

--- a/wagtail/contrib/search_promotions/forms.py
+++ b/wagtail/contrib/search_promotions/forms.py
@@ -2,8 +2,8 @@ from django import forms
 from django.forms.models import inlineformset_factory
 from django.utils.translation import ugettext_lazy as _
 
-from wagtail.contrib.search_promotions.models import SearchPromotion
 from wagtail.admin.widgets import AdminPageChooser
+from wagtail.contrib.search_promotions.models import SearchPromotion
 from wagtail.search.models import Query
 
 

--- a/wagtail/contrib/search_promotions/tests.py
+++ b/wagtail/contrib/search_promotions/tests.py
@@ -4,8 +4,8 @@ from django.urls import reverse
 from wagtail.contrib.search_promotions.models import SearchPromotion
 from wagtail.contrib.search_promotions.templatetags.wagtailsearchpromotions_tags import \
     get_search_promotions
-from wagtail.tests.utils import WagtailTestUtils
 from wagtail.search.models import Query
+from wagtail.tests.utils import WagtailTestUtils
 
 
 class TestSearchPromotions(TestCase):

--- a/wagtail/contrib/search_promotions/views.py
+++ b/wagtail/contrib/search_promotions/views.py
@@ -3,13 +3,13 @@ from django.urls import reverse
 from django.utils.translation import ugettext as _
 from django.views.decorators.vary import vary_on_headers
 
-from wagtail.contrib.search_promotions import forms
-from wagtail.utils.pagination import paginate
 from wagtail.admin import messages
 from wagtail.admin.forms import SearchForm
 from wagtail.admin.utils import any_permission_required, permission_required
+from wagtail.contrib.search_promotions import forms
 from wagtail.search import forms as search_forms
 from wagtail.search.models import Query
+from wagtail.utils.pagination import paginate
 
 
 @any_permission_required(

--- a/wagtail/contrib/search_promotions/wagtail_hooks.py
+++ b/wagtail/contrib/search_promotions/wagtail_hooks.py
@@ -3,8 +3,8 @@ from django.contrib.auth.models import Permission
 from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
 
-from wagtail.contrib.search_promotions import admin_urls
 from wagtail.admin.menu import MenuItem
+from wagtail.contrib.search_promotions import admin_urls
 from wagtail.core import hooks
 
 

--- a/wagtail/contrib/settings/tests/test_admin.py
+++ b/wagtail/contrib/settings/tests/test_admin.py
@@ -4,14 +4,14 @@ from django.test import TestCase, override_settings
 from django.urls import reverse
 from django.utils.text import capfirst
 
+from wagtail.admin.edit_handlers import FieldPanel, ObjectList, TabbedInterface
 from wagtail.contrib.settings.registry import SettingMenuItem
 from wagtail.contrib.settings.views import get_setting_edit_handler
+from wagtail.core import hooks
+from wagtail.core.models import Page, Site
 from wagtail.tests.testapp.models import (
     FileUploadSetting, IconSetting, PanelSettings, TabbedSettings, TestSetting)
 from wagtail.tests.utils import WagtailTestUtils
-from wagtail.admin.edit_handlers import FieldPanel, ObjectList, TabbedInterface
-from wagtail.core import hooks
-from wagtail.core.models import Page, Site
 
 
 class TestSettingMenu(TestCase, WagtailTestUtils):

--- a/wagtail/contrib/settings/tests/test_templates.py
+++ b/wagtail/contrib/settings/tests/test_templates.py
@@ -1,9 +1,9 @@
 from django.template import Context, RequestContext, Template, engines
 from django.test import TestCase
 
+from wagtail.core.models import Page, Site
 from wagtail.tests.testapp.models import TestSetting
 from wagtail.tests.utils import WagtailTestUtils
-from wagtail.core.models import Page, Site
 
 
 class TemplateTestCase(TestCase, WagtailTestUtils):

--- a/wagtail/contrib/sitemaps/tests.py
+++ b/wagtail/contrib/sitemaps/tests.py
@@ -4,8 +4,8 @@ import pytz
 from django.contrib.sites.shortcuts import get_current_site
 from django.test import RequestFactory, TestCase
 
-from wagtail.tests.testapp.models import EventIndex, SimplePage
 from wagtail.core.models import Page, PageViewRestriction, Site
+from wagtail.tests.testapp.models import EventIndex, SimplePage
 
 from .sitemap_generator import Sitemap
 

--- a/wagtail/contrib/table_block/blocks.py
+++ b/wagtail/contrib/table_block/blocks.py
@@ -8,7 +8,6 @@ from django.utils.functional import cached_property
 from wagtail.core.blocks import FieldBlock
 from wagtail.utils.widgets import WidgetWithScript
 
-
 DEFAULT_TABLE_OPTIONS = {
     'minSpareRows': 0,
     'startRows': 3,

--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -29,8 +29,7 @@ from wagtail.core.query import PageQuerySet, TreeQuerySet
 from wagtail.core.signals import page_published, page_unpublished
 from wagtail.core.sites import get_site_for_hostname
 from wagtail.core.url_routing import RouteResult
-from wagtail.core.utils import (
-    WAGTAIL_APPEND_SLASH, camelcase_to_underscore, resolve_model_string)
+from wagtail.core.utils import WAGTAIL_APPEND_SLASH, camelcase_to_underscore, resolve_model_string
 from wagtail.search import index
 
 logger = logging.getLogger('wagtail.core')

--- a/wagtail/core/rich_text/rewriters.py
+++ b/wagtail/core/rich_text/rewriters.py
@@ -4,7 +4,6 @@ Utility classes for rewriting elements of HTML-like strings
 
 import re
 
-
 FIND_A_TAG = re.compile(r'<a(\b[^>]*)>')
 FIND_EMBED_TAG = re.compile(r'<embed(\b[^>]*)/>')
 FIND_ATTRS = re.compile(r'([\w-]+)\="([^"]*)"')

--- a/wagtail/core/tests/test_hooks.py
+++ b/wagtail/core/tests/test_hooks.py
@@ -1,7 +1,7 @@
 from django.test import TestCase
 
-from wagtail.tests.utils import WagtailTestUtils
 from wagtail.core import hooks
+from wagtail.tests.utils import WagtailTestUtils
 
 
 def test_hook():

--- a/wagtail/core/tests/test_jinja2.py
+++ b/wagtail/core/tests/test_jinja2.py
@@ -3,9 +3,9 @@ from django.template.loader import render_to_string
 from django.test import TestCase
 
 from wagtail import __version__
-from wagtail.tests.testapp.blocks import SectionBlock
 from wagtail.core import blocks
 from wagtail.core.models import Page, Site
+from wagtail.tests.testapp.blocks import SectionBlock
 
 
 class TestCoreGlobalsAndFilters(TestCase):

--- a/wagtail/core/tests/test_management_commands.py
+++ b/wagtail/core/tests/test_management_commands.py
@@ -6,9 +6,9 @@ from django.db import models
 from django.test import TestCase
 from django.utils import timezone
 
-from wagtail.tests.testapp.models import EventPage, SimplePage
 from wagtail.core.models import Page, PageRevision
 from wagtail.core.signals import page_published, page_unpublished
+from wagtail.tests.testapp.models import EventPage, SimplePage
 
 
 class TestFixTreeCommand(TestCase):

--- a/wagtail/core/tests/test_page_model.py
+++ b/wagtail/core/tests/test_page_model.py
@@ -12,15 +12,14 @@ from django.test.client import RequestFactory
 from django.test.utils import override_settings
 from freezegun import freeze_time
 
-from wagtail.tests.testapp.models import (
-    AbstractPage, Advert, AlwaysShowInMenusPage, BlogCategory, BlogCategoryBlogPage,
-    BusinessChild, BusinessIndex, BusinessNowherePage, BusinessSubIndex, CustomManager,
-    CustomManagerPage, CustomPageQuerySet, EventIndex, EventPage, GenericSnippetPage,
-    ManyToManyBlogPage, MTIBasePage, MTIChildPage, MyCustomPage, OneToOnePage,
-    PageWithExcludedCopyField, SimplePage, SingleEventPage, SingletonPage,
-    StandardIndex, TaggedPage)
-from wagtail.tests.utils import WagtailTestUtils
 from wagtail.core.models import Page, PageManager, Site, get_page_models
+from wagtail.tests.testapp.models import (
+    AbstractPage, Advert, AlwaysShowInMenusPage, BlogCategory, BlogCategoryBlogPage, BusinessChild,
+    BusinessIndex, BusinessNowherePage, BusinessSubIndex, CustomManager, CustomManagerPage,
+    CustomPageQuerySet, EventIndex, EventPage, GenericSnippetPage, ManyToManyBlogPage, MTIBasePage,
+    MTIChildPage, MyCustomPage, OneToOnePage, PageWithExcludedCopyField, SimplePage,
+    SingleEventPage, SingletonPage, StandardIndex, TaggedPage)
+from wagtail.tests.utils import WagtailTestUtils
 
 
 def get_ct(model):

--- a/wagtail/core/tests/test_page_permissions.py
+++ b/wagtail/core/tests/test_page_permissions.py
@@ -2,8 +2,8 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group
 from django.test import TestCase
 
-from wagtail.tests.testapp.models import BusinessSubIndex, EventIndex, EventPage
 from wagtail.core.models import GroupPagePermission, Page, UserPagePermissionsProxy
+from wagtail.tests.testapp.models import BusinessSubIndex, EventIndex, EventPage
 
 
 class TestPagePermission(TestCase):

--- a/wagtail/core/tests/test_page_queryset.py
+++ b/wagtail/core/tests/test_page_queryset.py
@@ -1,10 +1,10 @@
 from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase
 
-from wagtail.tests.testapp.models import EventPage, SimplePage, SingleEventPage
 from wagtail.core.models import Page, PageViewRestriction, Site
 from wagtail.core.signals import page_unpublished
 from wagtail.search.query import MATCH_ALL
+from wagtail.tests.testapp.models import EventPage, SimplePage, SingleEventPage
 
 
 class TestPageQuerySet(TestCase):

--- a/wagtail/core/tests/test_streamfield.py
+++ b/wagtail/core/tests/test_streamfield.py
@@ -7,13 +7,13 @@ from django.template import Context, Template, engines
 from django.test import TestCase
 from django.utils.safestring import SafeText
 
-from wagtail.tests.testapp.models import StreamModel
 from wagtail.core import blocks
 from wagtail.core.blocks import StreamValue
 from wagtail.core.fields import StreamField
 from wagtail.core.rich_text import RichText
 from wagtail.images.models import Image
 from wagtail.images.tests.utils import get_test_image_file
+from wagtail.tests.testapp.models import StreamModel
 
 
 class TestLazyStreamField(TestCase):

--- a/wagtail/core/tests/test_tests.py
+++ b/wagtail/core/tests/test_tests.py
@@ -1,10 +1,10 @@
 from django.test import TestCase
 
+from wagtail.core.models import PAGE_MODEL_CLASSES, Page, Site
 from wagtail.tests.testapp.models import (
     BusinessChild, BusinessIndex, BusinessNowherePage, BusinessSubIndex, EventIndex, EventPage,
     SimplePage, StreamPage)
 from wagtail.tests.utils import WagtailPageTests, WagtailTestUtils
-from wagtail.core.models import PAGE_MODEL_CLASSES, Page, Site
 
 
 class TestAssertTagInHTML(WagtailTestUtils, TestCase):

--- a/wagtail/core/tests/test_views.py
+++ b/wagtail/core/tests/test_views.py
@@ -1,8 +1,8 @@
 from django.test import TestCase
 from django.urls import reverse
 
-from wagtail.tests.utils import WagtailTestUtils
 from wagtail.core.models import Page
+from wagtail.tests.utils import WagtailTestUtils
 
 
 class TestLoginView(TestCase, WagtailTestUtils):

--- a/wagtail/core/tests/test_whitelist.py
+++ b/wagtail/core/tests/test_whitelist.py
@@ -1,8 +1,7 @@
 from bs4 import BeautifulSoup
 from django.test import TestCase
 
-from wagtail.core.whitelist import (
-    Whitelister, allow_without_attributes, attribute_rule, check_url)
+from wagtail.core.whitelist import Whitelister, allow_without_attributes, attribute_rule, check_url
 
 
 class TestCheckUrl(TestCase):

--- a/wagtail/core/tests/tests.py
+++ b/wagtail/core/tests/tests.py
@@ -4,10 +4,10 @@ from django.http import HttpRequest
 from django.test import TestCase
 from django.utils.safestring import SafeText
 
-from wagtail.tests.testapp.models import SimplePage
 from wagtail.core.models import Page, Site
 from wagtail.core.templatetags.wagtailcore_tags import richtext
 from wagtail.core.utils import resolve_model_string
+from wagtail.tests.testapp.models import SimplePage
 
 
 class TestPageUrlTags(TestCase):

--- a/wagtail/documents/tests/test_admin_views.py
+++ b/wagtail/documents/tests/test_admin_views.py
@@ -9,10 +9,10 @@ from django.test.utils import override_settings
 from django.urls import reverse
 from django.utils.six import b
 
-from wagtail.tests.testapp.models import EventPage, EventPageRelatedLink
-from wagtail.tests.utils import WagtailTestUtils
 from wagtail.core.models import Collection, GroupCollectionPermission, Page
 from wagtail.documents import models
+from wagtail.tests.testapp.models import EventPage, EventPageRelatedLink
+from wagtail.tests.utils import WagtailTestUtils
 
 
 class TestDocumentIndexView(TestCase, WagtailTestUtils):

--- a/wagtail/documents/tests/test_search.py
+++ b/wagtail/documents/tests/test_search.py
@@ -6,8 +6,8 @@ from django.test.utils import override_settings
 from django.urls import reverse
 from django.utils.six import b
 
-from wagtail.tests.utils import WagtailTestUtils
 from wagtail.documents import models
+from wagtail.tests.utils import WagtailTestUtils
 
 
 @override_settings(_WAGTAILSEARCH_FORCE_AUTO_UPDATE=['elasticsearch'])

--- a/wagtail/documents/tests/test_views.py
+++ b/wagtail/documents/tests/test_views.py
@@ -9,8 +9,8 @@ from django.test import TestCase
 from django.test.utils import override_settings
 from django.urls import reverse
 
-from wagtail.tests.utils import WagtailTestUtils
 from wagtail.documents import models
+from wagtail.tests.utils import WagtailTestUtils
 
 
 class TestEditView(TestCase, WagtailTestUtils):

--- a/wagtail/documents/views/chooser.py
+++ b/wagtail/documents/views/chooser.py
@@ -3,7 +3,6 @@ import json
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
 
-from wagtail.utils.pagination import paginate
 from wagtail.admin.forms import SearchForm
 from wagtail.admin.modal_workflow import render_modal_workflow
 from wagtail.admin.utils import PermissionPolicyChecker
@@ -13,6 +12,7 @@ from wagtail.documents.forms import get_document_form
 from wagtail.documents.models import get_document_model
 from wagtail.documents.permissions import permission_policy
 from wagtail.search import index as search_index
+from wagtail.utils.pagination import paginate
 
 permission_checker = PermissionPolicyChecker(permission_policy)
 

--- a/wagtail/documents/views/documents.py
+++ b/wagtail/documents/views/documents.py
@@ -3,16 +3,15 @@ from django.urls import reverse
 from django.utils.translation import ugettext as _
 from django.views.decorators.vary import vary_on_headers
 
-from wagtail.utils.pagination import paginate
 from wagtail.admin import messages
 from wagtail.admin.forms import SearchForm
-from wagtail.admin.utils import (
-    PermissionPolicyChecker, permission_denied, popular_tags_for_model)
+from wagtail.admin.utils import PermissionPolicyChecker, permission_denied, popular_tags_for_model
 from wagtail.core.models import Collection
 from wagtail.documents.forms import get_document_form
 from wagtail.documents.models import get_document_model
 from wagtail.documents.permissions import permission_policy
 from wagtail.search import index as search_index
+from wagtail.utils.pagination import paginate
 
 permission_checker = PermissionPolicyChecker(permission_policy)
 

--- a/wagtail/documents/views/serve.py
+++ b/wagtail/documents/views/serve.py
@@ -6,12 +6,12 @@ from django.shortcuts import get_object_or_404, redirect
 from django.template.response import TemplateResponse
 from django.urls import reverse
 
-from wagtail.utils import sendfile_streaming_backend
-from wagtail.utils.sendfile import sendfile
 from wagtail.core import hooks
 from wagtail.core.forms import PasswordViewRestrictionForm
 from wagtail.core.models import CollectionViewRestriction
 from wagtail.documents.models import document_served, get_document_model
+from wagtail.utils import sendfile_streaming_backend
+from wagtail.utils.sendfile import sendfile
 
 
 def serve(request, document_id, document_filename):

--- a/wagtail/documents/wagtail_hooks.py
+++ b/wagtail/documents/wagtail_hooks.py
@@ -5,11 +5,11 @@ from django.template.response import TemplateResponse
 from django.urls import reverse
 from django.utils.html import format_html, format_html_join
 from django.utils.translation import ugettext_lazy as _
-from django.utils.translation import ungettext, ugettext
+from django.utils.translation import ugettext, ungettext
 
+import wagtail.admin.rich_text.editors.draftail.features as draftail_features
 from wagtail.admin.menu import MenuItem
 from wagtail.admin.rich_text import HalloPlugin
-import wagtail.admin.rich_text.editors.draftail.features as draftail_features
 from wagtail.admin.search import SearchArea
 from wagtail.admin.site_summary import SummaryItem
 from wagtail.core import hooks
@@ -21,8 +21,8 @@ from wagtail.documents.forms import GroupDocumentPermissionFormSet
 from wagtail.documents.models import get_document_model
 from wagtail.documents.permissions import permission_policy
 from wagtail.documents.rich_text import (
-    ContentstateDocumentLinkConversionRule, document_linktype_handler, EditorHTMLDocumentLinkConversionRule
-)
+    ContentstateDocumentLinkConversionRule, EditorHTMLDocumentLinkConversionRule,
+    document_linktype_handler)
 
 
 @hooks.register('register_admin_urls')

--- a/wagtail/embeds/finders/oembed.py
+++ b/wagtail/embeds/finders/oembed.py
@@ -1,6 +1,5 @@
 import json
 import re
-
 from urllib import request as urllib_request
 from urllib.error import URLError
 from urllib.parse import urlencode

--- a/wagtail/embeds/tests.py
+++ b/wagtail/embeds/tests.py
@@ -9,14 +9,12 @@ from django.test import TestCase, override_settings
 from django.urls import reverse
 from mock import patch
 
-from wagtail.tests.utils import WagtailTestUtils
 from wagtail.core import blocks
 from wagtail.core.rich_text import expand_db_html
 from wagtail.embeds import oembed_providers
 from wagtail.embeds.blocks import EmbedBlock, EmbedValue
 from wagtail.embeds.embeds import get_embed
-from wagtail.embeds.exceptions import (
-    EmbedNotFoundException, EmbedUnsupportedProviderException)
+from wagtail.embeds.exceptions import EmbedNotFoundException, EmbedUnsupportedProviderException
 from wagtail.embeds.finders import get_finders
 from wagtail.embeds.finders.embedly import EmbedlyFinder as EmbedlyFinder
 from wagtail.embeds.finders.embedly import AccessDeniedEmbedlyException, EmbedlyException
@@ -24,6 +22,7 @@ from wagtail.embeds.finders.oembed import OEmbedFinder as OEmbedFinder
 from wagtail.embeds.models import Embed
 from wagtail.embeds.rich_text import MediaEmbedHandler, media_embedtype_handler
 from wagtail.embeds.templatetags.wagtailembeds_tags import embed_tag
+from wagtail.tests.utils import WagtailTestUtils
 
 try:
     import embedly  # noqa

--- a/wagtail/embeds/views/chooser.py
+++ b/wagtail/embeds/views/chooser.py
@@ -5,8 +5,7 @@ from django.utils.translation import ugettext as _
 
 from wagtail.admin.modal_workflow import render_modal_workflow
 from wagtail.embeds import embeds
-from wagtail.embeds.exceptions import (
-    EmbedNotFoundException, EmbedUnsupportedProviderException)
+from wagtail.embeds.exceptions import EmbedNotFoundException, EmbedUnsupportedProviderException
 from wagtail.embeds.finders.embedly import AccessDeniedEmbedlyException, EmbedlyException
 from wagtail.embeds.format import embed_to_editor_html
 from wagtail.embeds.forms import EmbedForm

--- a/wagtail/embeds/wagtail_hooks.py
+++ b/wagtail/embeds/wagtail_hooks.py
@@ -3,13 +3,12 @@ from django.urls import reverse
 from django.utils.html import format_html
 from django.utils.translation import ugettext as _
 
-from wagtail.admin.rich_text import HalloPlugin
 import wagtail.admin.rich_text.editors.draftail.features as draftail_features
+from wagtail.admin.rich_text import HalloPlugin
 from wagtail.core import hooks
 from wagtail.embeds import urls
 from wagtail.embeds.rich_text import (
-    ContentstateMediaConversionRule, EditorHTMLEmbedConversionRule, media_embedtype_handler
-)
+    ContentstateMediaConversionRule, EditorHTMLEmbedConversionRule, media_embedtype_handler)
 
 
 @hooks.register('register_admin_urls')

--- a/wagtail/images/checks.py
+++ b/wagtail/images/checks.py
@@ -1,5 +1,5 @@
-from functools import lru_cache
 import os
+from functools import lru_cache
 
 from django.core.checks import Warning, register
 from willow.image import Image

--- a/wagtail/images/models.py
+++ b/wagtail/images/models.py
@@ -9,7 +9,6 @@ from django.core import checks
 from django.core.files import File
 from django.db import models
 from django.forms.utils import flatatt
-
 from django.urls import reverse
 from django.utils.functional import cached_property
 from django.utils.safestring import mark_safe

--- a/wagtail/images/tests/test_admin_views.py
+++ b/wagtail/images/tests/test_admin_views.py
@@ -9,9 +9,9 @@ from django.test import TestCase, override_settings
 from django.urls import reverse
 from django.utils.http import RFC3986_SUBDELIMS, urlquote
 
-from wagtail.tests.utils import WagtailTestUtils
 from wagtail.core.models import Collection, GroupCollectionPermission
 from wagtail.images.views.serve import generate_signature
+from wagtail.tests.utils import WagtailTestUtils
 
 from .utils import Image, get_test_image_file
 

--- a/wagtail/images/tests/test_models.py
+++ b/wagtail/images/tests/test_models.py
@@ -9,11 +9,11 @@ from django.test.utils import override_settings
 from django.urls import reverse
 from willow.image import Image as WillowImage
 
-from wagtail.tests.testapp.models import EventPage, EventPageCarouselItem
-from wagtail.tests.utils import WagtailTestUtils
 from wagtail.core.models import Collection, GroupCollectionPermission, Page
 from wagtail.images.models import Rendition, SourceImageIOError
 from wagtail.images.rect import Rect
+from wagtail.tests.testapp.models import EventPage, EventPageCarouselItem
+from wagtail.tests.utils import WagtailTestUtils
 
 from .utils import Image, get_test_image_file
 

--- a/wagtail/images/tests/tests.py
+++ b/wagtail/images/tests/tests.py
@@ -9,8 +9,6 @@ from django.urls import reverse
 from mock import MagicMock
 from taggit.forms import TagField, TagWidget
 
-from wagtail.tests.testapp.models import CustomImage, CustomImageFilePath
-from wagtail.tests.utils import WagtailTestUtils
 from wagtail.images import get_image_model, get_image_model_string
 from wagtail.images.fields import WagtailImageField
 from wagtail.images.formats import Format, get_image_format, register_image_format
@@ -18,6 +16,8 @@ from wagtail.images.forms import get_image_form
 from wagtail.images.models import Image as WagtailImage
 from wagtail.images.rect import Rect, Vector
 from wagtail.images.views.serve import ServeView, generate_signature, verify_signature
+from wagtail.tests.testapp.models import CustomImage, CustomImageFilePath
+from wagtail.tests.utils import WagtailTestUtils
 
 from .utils import Image, get_test_image_file
 

--- a/wagtail/images/tests/urls.py
+++ b/wagtail/images/tests/urls.py
@@ -1,7 +1,7 @@
 from django.conf.urls import url
 
-from wagtail.tests import dummy_sendfile_backend
 from wagtail.images.views.serve import SendFileView, ServeView
+from wagtail.tests import dummy_sendfile_backend
 
 urlpatterns = [
     url(r'^actions/serve/(.*)/(\d*)/(.*)/[^/]*', ServeView.as_view(action='serve'), name='wagtailimages_serve_action_serve'),

--- a/wagtail/images/views/chooser.py
+++ b/wagtail/images/views/chooser.py
@@ -3,7 +3,6 @@ import json
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
 
-from wagtail.utils.pagination import paginate
 from wagtail.admin.forms import SearchForm
 from wagtail.admin.modal_workflow import render_modal_workflow
 from wagtail.admin.utils import PermissionPolicyChecker, popular_tags_for_model
@@ -14,6 +13,7 @@ from wagtail.images.formats import get_image_format
 from wagtail.images.forms import ImageInsertionForm, get_image_form
 from wagtail.images.permissions import permission_policy
 from wagtail.search import index as search_index
+from wagtail.utils.pagination import paginate
 
 permission_checker = PermissionPolicyChecker(permission_policy)
 

--- a/wagtail/images/views/images.py
+++ b/wagtail/images/views/images.py
@@ -7,11 +7,9 @@ from django.urls.exceptions import NoReverseMatch
 from django.utils.translation import ugettext as _
 from django.views.decorators.vary import vary_on_headers
 
-from wagtail.utils.pagination import paginate
 from wagtail.admin import messages
 from wagtail.admin.forms import SearchForm
-from wagtail.admin.utils import (
-    PermissionPolicyChecker, permission_denied, popular_tags_for_model)
+from wagtail.admin.utils import PermissionPolicyChecker, permission_denied, popular_tags_for_model
 from wagtail.core.models import Collection, Site
 from wagtail.images import get_image_model
 from wagtail.images.exceptions import InvalidFilterSpecError
@@ -20,6 +18,7 @@ from wagtail.images.models import Filter
 from wagtail.images.permissions import permission_policy
 from wagtail.images.views.serve import generate_signature
 from wagtail.search import index as search_index
+from wagtail.utils.pagination import paginate
 
 permission_checker = PermissionPolicyChecker(permission_policy)
 

--- a/wagtail/images/views/serve.py
+++ b/wagtail/images/views/serve.py
@@ -12,10 +12,10 @@ from django.utils.decorators import classonlymethod
 from django.utils.encoding import force_text
 from django.views.generic import View
 
-from wagtail.utils.sendfile import sendfile
 from wagtail.images import get_image_model
 from wagtail.images.exceptions import InvalidFilterSpecError
 from wagtail.images.models import SourceImageIOError
+from wagtail.utils.sendfile import sendfile
 
 
 def generate_signature(image_id, filter_spec, key=None):

--- a/wagtail/images/wagtail_hooks.py
+++ b/wagtail/images/wagtail_hooks.py
@@ -3,11 +3,11 @@ from django.contrib.staticfiles.templatetags.staticfiles import static
 from django.urls import reverse
 from django.utils.html import format_html, format_html_join
 from django.utils.translation import ugettext_lazy as _
-from django.utils.translation import ungettext, ugettext
+from django.utils.translation import ugettext, ungettext
 
+import wagtail.admin.rich_text.editors.draftail.features as draftail_features
 from wagtail.admin.menu import MenuItem
 from wagtail.admin.rich_text import HalloPlugin
-import wagtail.admin.rich_text.editors.draftail.features as draftail_features
 from wagtail.admin.search import SearchArea
 from wagtail.admin.site_summary import SummaryItem
 from wagtail.core import hooks
@@ -16,8 +16,7 @@ from wagtail.images.api.admin.endpoints import ImagesAdminAPIEndpoint
 from wagtail.images.forms import GroupImagePermissionFormSet
 from wagtail.images.permissions import permission_policy
 from wagtail.images.rich_text import (
-    ContentstateImageConversionRule, EditorHTMLImageConversionRule, image_embedtype_handler
-)
+    ContentstateImageConversionRule, EditorHTMLImageConversionRule, image_embedtype_handler)
 
 
 @hooks.register('register_admin_urls')

--- a/wagtail/search/backends/base.py
+++ b/wagtail/search/backends/base.py
@@ -1,7 +1,6 @@
 
-from warnings import warn
-
 import warnings
+from warnings import warn
 
 from django.db.models.lookups import Lookup
 from django.db.models.query import QuerySet

--- a/wagtail/search/backends/elasticsearch2.py
+++ b/wagtail/search/backends/elasticsearch2.py
@@ -1,7 +1,7 @@
 import copy
 import json
-from urllib.parse import urlparse
 import warnings
+from urllib.parse import urlparse
 
 from django.db import DEFAULT_DB_ALIAS, models
 from django.db.models.sql import Query
@@ -10,13 +10,13 @@ from django.utils.crypto import get_random_string
 from elasticsearch import Elasticsearch, NotFoundError
 from elasticsearch.helpers import bulk
 
-from wagtail.utils.deprecation import RemovedInWagtail22Warning
-from wagtail.utils.utils import deep_update
 from wagtail.search.backends.base import (
     BaseSearchBackend, BaseSearchQueryCompiler, BaseSearchResults)
-from wagtail.search.index import (
-    FilterField, Indexed, RelatedFields, SearchField, class_is_indexed)
-from wagtail.search.query import MatchAll, Term, Prefix, Fuzzy, And, Or, Not, PlainText, Filter, Boost
+from wagtail.search.index import FilterField, Indexed, RelatedFields, SearchField, class_is_indexed
+from wagtail.search.query import (
+    And, Boost, Filter, Fuzzy, MatchAll, Not, Or, PlainText, Prefix, Term)
+from wagtail.utils.deprecation import RemovedInWagtail22Warning
+from wagtail.utils.utils import deep_update
 
 
 def get_model_root(model):

--- a/wagtail/search/queryset.py
+++ b/wagtail/search/queryset.py
@@ -1,7 +1,6 @@
 from wagtail.search.backends import get_search_backend
 
 
-
 class SearchableQuerySetMixin:
     def search(self, query, fields=None,
                operator=None, order_by_relevance=True, backend='default'):

--- a/wagtail/search/tests/elasticsearch_common_tests.py
+++ b/wagtail/search/tests/elasticsearch_common_tests.py
@@ -3,9 +3,9 @@ from io import StringIO
 
 from django.core import management
 
-from wagtail.tests.search import models
 from wagtail.search.query import MATCH_ALL
 from wagtail.search.tests.test_backends import BackendTests
+from wagtail.tests.search import models
 
 
 class ElasticsearchCommonSearchBackendTests(BackendTests):

--- a/wagtail/search/tests/test_backends.py
+++ b/wagtail/search/tests/test_backends.py
@@ -9,13 +9,13 @@ from django.core import management
 from django.test import TestCase
 from django.test.utils import override_settings
 
-from wagtail.tests.search import models
-from wagtail.tests.utils import WagtailTestUtils
 from wagtail.search.backends import (
     InvalidSearchBackendError, get_search_backend, get_search_backends)
 from wagtail.search.backends.base import FieldError
 from wagtail.search.backends.db import DatabaseSearchBackend
 from wagtail.search.query import MATCH_ALL, And, Boost, Filter, Not, Or, PlainText, Term
+from wagtail.tests.search import models
+from wagtail.tests.utils import WagtailTestUtils
 
 
 class BackendTests(WagtailTestUtils):

--- a/wagtail/search/tests/test_elasticsearch2_backend.py
+++ b/wagtail/search/tests/test_elasticsearch2_backend.py
@@ -7,10 +7,9 @@ from django.db.models import Q
 from django.test import TestCase
 from elasticsearch.serializer import JSONSerializer
 
-from wagtail.tests.search import models
-from wagtail.search.backends.elasticsearch2 import (
-    Elasticsearch2SearchBackend, get_model_root)
+from wagtail.search.backends.elasticsearch2 import Elasticsearch2SearchBackend, get_model_root
 from wagtail.search.query import MATCH_ALL
+from wagtail.tests.search import models
 
 from .elasticsearch_common_tests import ElasticsearchCommonSearchBackendTests
 

--- a/wagtail/search/tests/test_elasticsearch5_backend.py
+++ b/wagtail/search/tests/test_elasticsearch5_backend.py
@@ -7,9 +7,9 @@ from django.db.models import Q
 from django.test import TestCase
 from elasticsearch.serializer import JSONSerializer
 
-from wagtail.tests.search import models
 from wagtail.search.backends.elasticsearch5 import Elasticsearch5SearchBackend
 from wagtail.search.query import MATCH_ALL
+from wagtail.tests.search import models
 
 from .elasticsearch_common_tests import ElasticsearchCommonSearchBackendTests
 

--- a/wagtail/search/tests/test_frontend.py
+++ b/wagtail/search/tests/test_frontend.py
@@ -2,9 +2,9 @@ from django.core import paginator
 from django.test import TestCase
 from django.urls import reverse
 
-from wagtail.tests.testapp.models import EventPage
 from wagtail.core.models import Page
 from wagtail.search.models import Query
+from wagtail.tests.testapp.models import EventPage
 
 
 class TestSearchView(TestCase):

--- a/wagtail/search/tests/test_index_functions.py
+++ b/wagtail/search/tests/test_index_functions.py
@@ -3,11 +3,11 @@ from datetime import date
 import mock
 from django.test import TestCase, override_settings
 
+from wagtail.core.models import Page
+from wagtail.search import index
 from wagtail.tests.search import models
 from wagtail.tests.testapp.models import SimplePage
 from wagtail.tests.utils import WagtailTestUtils
-from wagtail.core.models import Page
-from wagtail.search import index
 
 
 class TestGetIndexedInstance(TestCase):

--- a/wagtail/search/tests/test_indexed_class.py
+++ b/wagtail/search/tests/test_indexed_class.py
@@ -3,8 +3,8 @@ from contextlib import contextmanager
 from django.core import checks
 from django.test import TestCase
 
-from wagtail.tests.search import models
 from wagtail.search import index
+from wagtail.tests.search import models
 
 
 @contextmanager

--- a/wagtail/search/tests/test_queries.py
+++ b/wagtail/search/tests/test_queries.py
@@ -5,9 +5,9 @@ from django.core import management
 from django.test import SimpleTestCase, TestCase
 
 from wagtail.contrib.search_promotions.models import SearchPromotion
-from wagtail.tests.utils import WagtailTestUtils
 from wagtail.search import models
 from wagtail.search.utils import normalise_query_string, separate_filters_from_query
+from wagtail.tests.utils import WagtailTestUtils
 
 
 class TestHitCounter(TestCase):

--- a/wagtail/search/tests/test_related_fields.py
+++ b/wagtail/search/tests/test_related_fields.py
@@ -1,8 +1,8 @@
 from django.test import TestCase
 
+from wagtail.search import index
 from wagtail.tests.search.models import Book, Novel
 from wagtail.tests.testapp.models import Advert, ManyToManyBlogPage
-from wagtail.search import index
 
 
 class TestSelectOnQuerySet(TestCase):

--- a/wagtail/search/views/queries.py
+++ b/wagtail/search/views/queries.py
@@ -1,10 +1,10 @@
 from django.shortcuts import render
 
-from wagtail.utils.pagination import paginate
 from wagtail.admin.forms import SearchForm
 from wagtail.admin.modal_workflow import render_modal_workflow
 from wagtail.search import models
 from wagtail.search.utils import normalise_query_string
+from wagtail.utils.pagination import paginate
 
 
 def chooser(request, get_results=False):

--- a/wagtail/sites/tests.py
+++ b/wagtail/sites/tests.py
@@ -3,8 +3,8 @@ from django.contrib.auth.models import Permission
 from django.test import TestCase
 from django.urls import reverse
 
-from wagtail.tests.utils import WagtailTestUtils
 from wagtail.core.models import Page, Site
+from wagtail.tests.utils import WagtailTestUtils
 
 
 class TestSiteIndexView(TestCase, WagtailTestUtils):

--- a/wagtail/snippets/tests.py
+++ b/wagtail/snippets/tests.py
@@ -9,6 +9,12 @@ from django.test.utils import override_settings
 from django.urls import reverse
 from taggit.models import Tag
 
+from wagtail.admin.forms import WagtailAdminModelForm
+from wagtail.core.models import Page
+from wagtail.snippets.blocks import SnippetChooserBlock
+from wagtail.snippets.edit_handlers import SnippetChooserPanel
+from wagtail.snippets.models import SNIPPET_MODELS, register_snippet
+from wagtail.snippets.views.snippets import get_snippet_edit_handler
 from wagtail.tests.snippets.forms import FancySnippetForm
 from wagtail.tests.snippets.models import (
     AlphaSnippet, FancySnippet, FileUploadSnippet, RegisterDecorator, RegisterFunction,
@@ -17,12 +23,6 @@ from wagtail.tests.testapp.models import (
     Advert, AdvertWithCustomPrimaryKey, AdvertWithTabbedInterface, SnippetChooserModel,
     SnippetChooserModelWithCustomPrimaryKey)
 from wagtail.tests.utils import WagtailTestUtils
-from wagtail.admin.forms import WagtailAdminModelForm
-from wagtail.core.models import Page
-from wagtail.snippets.blocks import SnippetChooserBlock
-from wagtail.snippets.edit_handlers import SnippetChooserPanel
-from wagtail.snippets.models import SNIPPET_MODELS, register_snippet
-from wagtail.snippets.views.snippets import get_snippet_edit_handler
 
 
 class TestSnippetIndexView(TestCase, WagtailTestUtils):

--- a/wagtail/snippets/views/chooser.py
+++ b/wagtail/snippets/views/chooser.py
@@ -5,12 +5,12 @@ from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
 from django.utils.translation import ugettext as _
 
-from wagtail.utils.pagination import paginate
 from wagtail.admin.forms import SearchForm
 from wagtail.admin.modal_workflow import render_modal_workflow
 from wagtail.search.backends import get_search_backend
 from wagtail.search.index import class_is_indexed
 from wagtail.snippets.views.snippets import get_snippet_model_from_url_params
+from wagtail.utils.pagination import paginate
 
 
 def choose(request, app_label, model_name):

--- a/wagtail/snippets/views/snippets.py
+++ b/wagtail/snippets/views/snippets.py
@@ -6,16 +6,15 @@ from django.urls import reverse
 from django.utils.text import capfirst
 from django.utils.translation import ugettext as _
 
-from wagtail.utils.pagination import paginate
 from wagtail.admin import messages
-from wagtail.admin.edit_handlers import (
-    ObjectList, extract_panel_definitions_from_model_class)
+from wagtail.admin.edit_handlers import ObjectList, extract_panel_definitions_from_model_class
 from wagtail.admin.forms import SearchForm
 from wagtail.admin.utils import permission_denied
 from wagtail.search.backends import get_search_backend
 from wagtail.search.index import class_is_indexed
 from wagtail.snippets.models import get_snippet_models
 from wagtail.snippets.permissions import get_permission_name, user_can_edit_snippet_type
+from wagtail.utils.pagination import paginate
 
 
 # == Helper functions ==

--- a/wagtail/tests/demosite/models.py
+++ b/wagtail/tests/demosite/models.py
@@ -5,16 +5,15 @@ from modelcluster.contrib.taggit import ClusterTaggableManager
 from modelcluster.fields import ParentalKey
 from taggit.models import TaggedItemBase
 
+from wagtail.admin.edit_handlers import FieldPanel, InlinePanel, MultiFieldPanel, PageChooserPanel
 from wagtail.api import APIField
-from wagtail.utils.pagination import paginate
-from wagtail.admin.edit_handlers import (
-    FieldPanel, InlinePanel, MultiFieldPanel, PageChooserPanel)
 from wagtail.core.fields import RichTextField
 from wagtail.core.models import Orderable, Page
 from wagtail.documents.edit_handlers import DocumentChooserPanel
 from wagtail.images.api.fields import ImageRenditionField
 from wagtail.images.edit_handlers import ImageChooserPanel
 from wagtail.search import index
+from wagtail.utils.pagination import paginate
 
 
 # ABSTRACT MODELS

--- a/wagtail/tests/testapp/models.py
+++ b/wagtail/tests/testapp/models.py
@@ -18,13 +18,13 @@ from taggit.managers import TaggableManager
 from taggit.models import TaggedItemBase
 
 from wagtail.admin.edit_handlers import (
-    FieldPanel, InlinePanel, MultiFieldPanel, ObjectList, PageChooserPanel,
-    StreamFieldPanel, TabbedInterface)
+    FieldPanel, InlinePanel, MultiFieldPanel, ObjectList, PageChooserPanel, StreamFieldPanel,
+    TabbedInterface)
 from wagtail.admin.forms import WagtailAdminPageForm
 from wagtail.admin.utils import send_mail
 from wagtail.contrib.forms.forms import FormBuilder
 from wagtail.contrib.forms.models import (
-    AbstractEmailForm, AbstractFormField, AbstractFormSubmission, FORM_FIELD_CHOICES)
+    FORM_FIELD_CHOICES, AbstractEmailForm, AbstractFormField, AbstractFormSubmission)
 from wagtail.contrib.settings.models import BaseSetting, register_setting
 from wagtail.contrib.table_block.blocks import TableBlock
 from wagtail.core.blocks import CharBlock, RichTextBlock
@@ -41,7 +41,6 @@ from wagtail.snippets.models import register_snippet
 
 from .forms import ValidatedPageForm
 from .views import CustomSubmissionsListView
-
 
 EVENT_AUDIENCE_CHOICES = (
     ('public', "Public"),

--- a/wagtail/tests/testapp/rich_text.py
+++ b/wagtail/tests/testapp/rich_text.py
@@ -2,8 +2,8 @@ import json
 
 from django.forms import Media, widgets
 
-from wagtail.utils.widgets import WidgetWithScript
 from wagtail.admin.edit_handlers import RichTextFieldPanel
+from wagtail.utils.widgets import WidgetWithScript
 
 
 class CustomRichTextArea(WidgetWithScript, widgets.Textarea):

--- a/wagtail/tests/urls.py
+++ b/wagtail/tests/urls.py
@@ -1,11 +1,10 @@
 from django.conf.urls import include, url
 
+from wagtail.admin import urls as wagtailadmin_urls
 from wagtail.api.v2.endpoints import PagesAPIEndpoint
 from wagtail.api.v2.router import WagtailAPIRouter
 from wagtail.contrib.sitemaps import views as sitemaps_views
 from wagtail.contrib.sitemaps import Sitemap
-from wagtail.tests.testapp import urls as testapp_urls
-from wagtail.admin import urls as wagtailadmin_urls
 from wagtail.core import urls as wagtail_urls
 from wagtail.documents import urls as wagtaildocs_urls
 from wagtail.documents.api.v2.endpoints import DocumentsAPIEndpoint
@@ -13,6 +12,7 @@ from wagtail.images import urls as wagtailimages_urls
 from wagtail.images.api.v2.endpoints import ImagesAPIEndpoint
 from wagtail.images.tests import urls as wagtailimages_test_urls
 from wagtail.search import urls as wagtailsearch_urls
+from wagtail.tests.testapp import urls as testapp_urls
 
 api_router = WagtailAPIRouter('wagtailapi_v2')
 api_router.register_endpoint('pages', PagesAPIEndpoint)

--- a/wagtail/users/tests.py
+++ b/wagtail/users/tests.py
@@ -7,11 +7,10 @@ from django.http import HttpRequest, HttpResponse
 from django.test import TestCase, override_settings
 from django.urls import reverse
 
-from wagtail.tests.utils import WagtailTestUtils
 from wagtail.core import hooks
 from wagtail.core.compat import AUTH_USER_APP_LABEL, AUTH_USER_MODEL_NAME
-from wagtail.core.models import (
-    Collection, GroupCollectionPermission, GroupPagePermission, Page)
+from wagtail.core.models import Collection, GroupCollectionPermission, GroupPagePermission, Page
+from wagtail.tests.utils import WagtailTestUtils
 from wagtail.users.forms import UserCreationForm, UserEditForm
 from wagtail.users.models import UserProfile
 from wagtail.users.views.users import get_user_creation_form, get_user_edit_form

--- a/wagtail/users/views/users.py
+++ b/wagtail/users/views/users.py
@@ -6,16 +6,15 @@ from django.urls import reverse
 from django.utils.translation import ugettext as _
 from django.views.decorators.vary import vary_on_headers
 
-from wagtail.utils.loading import get_custom_form
-from wagtail.utils.pagination import paginate
 from wagtail.admin import messages
 from wagtail.admin.forms import SearchForm
-from wagtail.admin.utils import (
-    any_permission_required, permission_denied, permission_required)
+from wagtail.admin.utils import any_permission_required, permission_denied, permission_required
 from wagtail.core import hooks
 from wagtail.core.compat import AUTH_USER_APP_LABEL, AUTH_USER_MODEL_NAME
 from wagtail.users.forms import UserCreationForm, UserEditForm
 from wagtail.users.utils import user_can_delete_user
+from wagtail.utils.loading import get_custom_form
+from wagtail.utils.pagination import paginate
 
 User = get_user_model()
 


### PR DESCRIPTION
isort was disabled to avoid CI noise and merge conflicts following the renaming of Wagtail's module paths. Now that the last major merge of 2.0 has (hopefully) taken place, it's time to reinstate it.
