### PR TITLE
Couple of CSS tweaks for nested StructBlocks.

### DIFF
--- a/wagtail/admin/static_src/wagtailadmin/scss/components/_streamfield.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/components/_streamfield.scss
@@ -26,6 +26,13 @@ li.sequence-member {
         opacity: 1;
     }
 
+    .struct-block .object-help {
+        float: right;
+        margin-top: 0;
+        padding: 0;
+        width: auto;
+    }
+
     .struct-block .fields {
         @include column(10);
         padding-left: 0;
@@ -33,7 +40,7 @@ li.sequence-member {
     }
 
     .struct-block .sequence-container {
-        @include column(9);
+        @include column(10);
         padding-left: 0;
         padding-right: 0;
 
@@ -61,6 +68,10 @@ li.sequence-member {
 
         .sequence-member {
             border: 0;
+
+            .struct-block .fields {
+                width: 100%;
+            }
         }
 
         // sequences within sequences, such as a ListBlock within StructBlock


### PR DESCRIPTION
This just tries to make the layout for nested blocks slightly better. There are several tickets addressing major redesign (#2325 seems dead, #3942 was moved to 2.1 milestone, #2305 seems dead), but they all seem to be years old with little hope of immediate fixes. I just want this UI to be slightly better so my editors don't spend all their time complaining about the UI instead of writing content.

This is just a style change, so no python was modified to need testing or linting. They still look as expected for the current master branch.

This is what the UI for tested StructBlocks looked like before:
<img width="1500" alt="nested structblocks-before" src="https://user-images.githubusercontent.com/710553/35407724-e74cf4e8-01da-11e8-8c29-3c2e5bbbd964.png">

This is what it looks like after:
<img width="1492" alt="nested structblocks-after" src="https://user-images.githubusercontent.com/710553/35407757-fa0e895c-01da-11e8-9cc9-b83990673aa9.png">

This is the whole form from before:
![nested-before](https://user-images.githubusercontent.com/710553/35407781-02700738-01db-11e8-9c4a-16784bae1ae6.png)

And this is after:
![nested-after](https://user-images.githubusercontent.com/710553/35407844-23720ac6-01db-11e8-8e74-67f34cc6f669.png)

It's not perfect, but it is at least better for now.

