### PR TITLE
Draftail updates, refactors, bug fixes

### DIFF
--- a/client/src/components/Draftail/Draftail.scss
+++ b/client/src/components/Draftail/Draftail.scss
@@ -88,7 +88,8 @@ $draftail-editor-font-family: $font-serif;
     }
 }
 
-.full .Draftail-Editor .public-DraftEditor-content {
+.full .Draftail-Editor .public-DraftEditor-content,
+.full .Draftail-Editor .public-DraftEditorPlaceholder-root {
     @include nice-padding;
 }
 
@@ -96,6 +97,7 @@ $draftail-editor-font-family: $font-serif;
     @include nice-margin;
 }
 
-.title .Draftail-Editor .public-DraftEditor-content {
+.title .Draftail-Editor .public-DraftEditor-content,
+.title .Draftail-Editor .public-DraftEditorPlaceholder-root {
     font-size: 2em;
 }

--- a/client/src/components/Draftail/blocks/MediaBlock.scss
+++ b/client/src/components/Draftail/blocks/MediaBlock.scss
@@ -35,6 +35,7 @@
 
     &__img {
         @include invalid-image-fallback;
+        display: block;
         width: 256px;
         height: auto;
         pointer-events: none;

--- a/client/src/components/Draftail/index.js
+++ b/client/src/components/Draftail/index.js
@@ -31,8 +31,7 @@ export const initEditor = (fieldName, options = {}) => {
   field.parentNode.appendChild(editorWrapper);
 
   const serialiseInputValue = rawContentState => {
-    // TODO Remove default {} when finishing https://github.com/springload/wagtaildraftail/issues/32.
-    field.value = JSON.stringify(rawContentState || {});
+    field.value = JSON.stringify(rawContentState);
   };
 
   let blockTypes;
@@ -62,10 +61,7 @@ export const initEditor = (fieldName, options = {}) => {
     description: STRINGS.HORIZONTAL_LINE,
   } : false;
 
-  const fieldValue = JSON.parse(field.value);
-  // TODO Remove default null when finishing https://github.com/springload/wagtaildraftail/issues/32.
-  const rawContentState =
-    fieldValue && Object.keys(fieldValue).length === 0 ? null : fieldValue;
+  const rawContentState = JSON.parse(field.value);
 
   const editor = (
     <DraftailEditor

--- a/client/src/components/Draftail/index.js
+++ b/client/src/components/Draftail/index.js
@@ -108,11 +108,7 @@ registry.registerBlocks({
 
 const draftail = Object.assign(
   {
-    initEditor: initEditor,
-    // Expose basic React methods for basic needs
-    // TODO Expose React as global as part of Wagtail vendor file instead of doing this.
-    // createClass: React.createClass,
-    // createElement: React.createElement,
+    initEditor,
   },
   registry
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -2619,17 +2619,17 @@
       }
     },
     "draftail": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/draftail/-/draftail-0.14.0.tgz",
-      "integrity": "sha512-UyfbTy/2jD07L/bfWYlAVNl5jtFxcxD4Ud73u+V2AVDkcfXHgmeWQIp+4EDDvsv6on+opjZ3slCg2QwINNhjtA==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/draftail/-/draftail-0.15.0.tgz",
+      "integrity": "sha512-PARHHGuoRs8CKiRH0w1k9Bs+a0cxnNl8jwVyuj4CahgNj5x5jN/Z2zutyjVvpdJCcdR1/A525u9jIpDszt9jOg==",
       "requires": {
-        "draftjs-filters": "0.5.0"
+        "draftjs-filters": "0.6.1"
       }
     },
     "draftjs-filters": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/draftjs-filters/-/draftjs-filters-0.5.0.tgz",
-      "integrity": "sha512-JjWH6GH1YZx2SPC0DOyoG4LmleTGLX2IJS7/6TH+yVAN5uwCPVxuADqQISG68mCTEr/PGSmmz8QJ/xg3Lp733g=="
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/draftjs-filters/-/draftjs-filters-0.6.1.tgz",
+      "integrity": "sha512-8CyUUBglLKMVLrkOn7RfRoKoslx79SPvyc5w0lCJTLii/PbHP1narEW4eSNayIvcOIVcEQgOTjv2zXrH/Yuf9A=="
     },
     "duplexer": {
       "version": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
   "dependencies": {
     "core-js": "^2.5.3",
     "draft-js": "0.10.4",
-    "draftail": "^0.14.0",
+    "draftail": "^0.15.0",
     "focus-trap-react": "^3.1.0",
     "prop-types": "^15.6.0",
     "react": "^16.2.0",

--- a/wagtail/admin/static_src/wagtailadmin/js/blocks/sequence.js
+++ b/wagtail/admin/static_src/wagtailadmin/js/blocks/sequence.js
@@ -54,7 +54,7 @@ CODE FOR SETTING UP SPECIFIC UI WIDGETS, SUCH AS DELETE BUTTONS OR MENUS, DOES N
             // focus first suitable input found
             var timeout = setTimeout(function() {
               var $input = $('.input', self.container);
-              var $firstField = $('input, textarea, .halloeditor, [data-draftail-input]', $input).first();
+              var $firstField = $('input, textarea, [data-hallo-editor], [data-draftail-input]', $input).first();
 
               if ($firstField.is('[data-draftail-input]')) {
                 $firstField.get(0).draftailEditor.focus();

--- a/wagtail/admin/static_src/wagtailadmin/js/hallo-bootstrap.js
+++ b/wagtail/admin/static_src/wagtailadmin/js/hallo-bootstrap.js
@@ -2,7 +2,7 @@
 
 function makeHalloRichTextEditable(id, plugins) {
     var input = $('#' + id);
-    var editor = $('<div class="halloeditor"></div>').html(input.val());
+    var editor = $('<div class="halloeditor" data-hallo-editor></div>').html(input.val());
     editor.insertBefore(input);
     input.hide();
 
@@ -78,7 +78,7 @@ function insertRichTextDeleteControl(elem) {
     var a = $('<a class="icon icon-cross text-replace halloembed__delete">Delete</a>');
     $(elem).addClass('halloembed').prepend(a);
     a.on('click', function() {
-        var widget = $(elem).parent('.halloeditor').data('IKS-hallo');
+        var widget = $(elem).parent('[data-hallo-editor]').data('IKS-hallo');
         $(elem).fadeOut(function() {
             $(elem).remove();
             if (widget != undefined && widget.options.editable) {
@@ -89,7 +89,7 @@ function insertRichTextDeleteControl(elem) {
 }
 
 $(function() {
-    $('.halloeditor [contenteditable="false"]').each(function() {
+    $('[data-hallo-editor] [contenteditable="false"]').each(function() {
         insertRichTextDeleteControl(this);
     });
 })

--- a/wagtail/embeds/static_src/wagtailembeds/js/hallo-plugins/hallo-wagtailembeds.js
+++ b/wagtail/embeds/static_src/wagtailembeds/js/hallo-plugins/hallo-wagtailembeds.js
@@ -25,7 +25,7 @@
                     var insertionPoint, lastSelection;
 
                     lastSelection = widget.options.editable.getSelection();
-                    insertionPoint = $(lastSelection.endContainer).parentsUntil('.halloeditor').last();
+                    insertionPoint = $(lastSelection.endContainer).parentsUntil('[data-hallo-editor]').last();
 
                     return ModalWorkflow({
                         url: window.chooserUrls.embedsChooser,

--- a/wagtail/images/static_src/wagtailimages/js/hallo-plugins/hallo-wagtailimage.js
+++ b/wagtail/images/static_src/wagtailimages/js/hallo-plugins/hallo-wagtailimage.js
@@ -23,7 +23,7 @@
                     var insertionPoint, lastSelection;
 
                     lastSelection = widget.options.editable.getSelection();
-                    insertionPoint = $(lastSelection.endContainer).parentsUntil('.halloeditor').last();
+                    insertionPoint = $(lastSelection.endContainer).parentsUntil('[data-hallo-editor]').last();
                     return ModalWorkflow({
                         url: window.chooserUrls.imageChooser + '?select_format=true',
                         responses: {


### PR DESCRIPTION
This addresses the following tasks from #4136:

- [x] Media block bottom border in Safari, Android Chrome
- [x] Placeholder misaligned in ~iOS Safari~ full-width fields
- [x] Remove default {} when finishing https://github.com/springload/wagtaildraftail/issues/32
- [x] Add `data-` attribute to Hallo editor to define documented integration point for plugins.
- [x] Automatically-generated depth styles for list items

The `draftjs-filters` transitive dependency update also fixes a nasty Draft.js design choice, which you can read about here: https://github.com/facebook/draft-js/issues/504

----

Edit: moving my other todos here, even though they may not be addressed in this PR.

# Remaining tasks

<details>

## Before merge

### UI

- [x] Improve support for custom icons
- [x] Make all entity-related components definitions in Draftail integrations rather than in core
- [x] Move tooltip outside of Draftail core.
- [x] Implement latest UI iteration based on Bristol sprint designs
- [x] Move latest version of Wagtail-only components into Wagtail
- [x] Adapt UI styles to coexist with Hallo
- [x] Review latest UI iteration within Wagtail
- [x] Post-review fixes and potential release
- ~[ ] Move nested lists styles over~
- [x] Reproduce Hallo's "focus when adding a sequence member" in sequence.js
- [x] Reproduce Hallo field styles (focus)
- [x] i18n
- [x] Toolbar icons alignment
- [x] Toolbar border radius consistency
- [x] Tooltip background color flicker
- [x] Draftail editor padding/spacing
- [x] Toolbar tooltip obstructing first lines of content
- [x] Color contrast of the 'remove' button is too low
- [x] Left and right paddings of 'edit' and 'remove' buttons should match the 'save draft' button. The button paddings do not collapse right on mobile viewport
- [x] Support absence of data on Link
- [x] Support absence of data on Document
- [x] Support absence of data on Image
- [x] Support absence of data on Embed

### Build

- [x] Expose Wagtail dependencies as globals
- [x] Ensure Draft.js vendor deps are only loaded when Draftail is.

### Entities 

- [x] Updating image alt text / alignment through the inline form is laggy - changes only get committed to the underlying contentstate data when the rich text field is refocused, and only propagate back to the form after an edit is made to the rich text
- [x] Make sure sources handle creation & edit (link, document)
- [x] Make sure sources handle creation & edit (image, embed). Edit: Considering removing the "Edit" button for now.
- [x] Investigate scroll on focus
- [x] Handle link text in link source (`prefer_this_title_as_link_text: true`, `title: "text"`)
- [x] Make sure image formats are configurable via image chooser
- [x] Handle server errors without locking the editor

### Other

- [x] Finish first draft of styling/theming API
- [x] Link icon check based on `mailto` `startsWith`
- [x] Finish rich text copy-paste filtering https://github.com/springload/draftail/issues/123
- [x] Replace constants / hard-coded strings in wagtail_hooks, rich_text, contentstate.py

### Testing

- [x] Cross-browser test within Wagtail
- [x] More tests on mobile devices, in Wagtail
- [x] Check pasting from Hallo to Draftail
- [x] Check pasting from more recent versions of Word https://github.com/springload/draftail/issues/123

### Nice to haves

- ~[ ] Add CSS linting to Draftail https://github.com/springload/draftail/issues/126~
- [x] Fix block type reset annoyance https://github.com/springload/draftail/issues/105
- ~[ ] Automated integration tests https://github.com/springload/draftail/issues/12~

### Cleanup

- [x] Make editor `font-family` and `font-size` overridable via Sass variable
- [x] Remove unused Sass variables
- [x] Namespace variables and mixins
- [x] Stop loading Hallo CSS even if Hallo isn't loaded
- [x] `user-select: none;` on button labels
- ~[ ] Move block spacing styles to Draftail~
- [x] Add unknown attribute (`id`) filter to Draft.js filters
- [x] Refactor sources composition over inheritance

### Decisions

- [x] (soft) line break – enabled or disabled by default?
- [x] undo redo controls displayed in toolbar?

</details>

### Bugs

- [ ] The background colour flickers when the link edit takes focus
- [x] Filter pasted `tel` links. Ideally, turn pasted link filtering into a [real whitelist](https://github.com/wagtail/wagtail/pull/4136#discussion_r163582141).

### Cross-browser bugs

- [x] Media block bottom border in Safari, Android Chrome
- [ ] Toolbar buttons spacing & alignment in Firefox, Safari
- [x] Line break button renders badly in Edge
- [ ] Editor crash when inserting new link, document, image embed in IE11 (specific to Wagtail)
- [ ] Toolbar does not move in Safari
- [x] Placeholder misaligned in ~iOS Safari~ full-width fields

## After merge

### Bugs

- [ ] No-break text overflow
- [ ] Prevent toolbar from obstructing last block

### Refactorings

- [x] Remove default {} when finishing https://github.com/springload/wagtaildraftail/issues/32
- [x] Fix silly `ugettext_lazy` serialisation
- [x] Add `data-` attribute to Hallo editor to define documented integration point for plugins.

### Documentation

- [ ] Usage
- [ ] Extension (of Hallo too)
- [x] Draft.js known issues https://github.com/springload/draftail/issues/138
- [ ] Release notes

### Postponed

- [ ] Support tooltip rendering top-right when necessary (depending on available space).
- [ ] Distinguish between internal and external links in the editor by using different icons.
- [ ] Finish "Edit" flow for images and embeds #2674.
- [ ] Remove image fails after having edited the `alt`.
- [ ] "Link text" field in page chooser should be pre-filled with text
- [ ] Opening up a dialog (eg. new link, document, image) causes the editable text area to go white, then the dialog loads. However, on a slow connection (mine right now), this may take up to two seconds or more. The text going white and becoming non-editable is a bit confusing - it might be good to add a loading indicator? Or maybe the screen should go darker straight away (ie. before the modal response returns). My connection is quite slow so not sure what the best way around this is. **Should be addressed in the choosers, rather than the editor**.
- [ ] Minor nitpick: If you have a lot of content in the editor (say two pages worth), and you are editing something towards the end of the content, then you clear that content. Your scroll position is kept to further down the editor page, and the draftail editor essentially disappears. This may not be worth solving - but wanted to mention it.
- [ ] Editor behavior when image / embed / link / document don't have data defined (remove the entity/block?)
- [ ] Order of the entities in the toolbar

### Tests

- [ ] 100% unit test coverage
- [ ] Troubleshoot ContentState conversion bug for "HTML-sanitised" text.
- [ ] Hunt for more content conversion issues

### Nice to haves

- [ ] Image entity alt text save on "Enter"
- [ ] External/email link chooser isn't initialised with currently selected text
- [x] Automatically-generated depth styles for list items
- [ ] (After React 16 upgrade has been merged) Add error boundary around editor component
- [x] i18n for horizontal line, line break, undo-redo
- [ ] Re-check known issue https://github.com/springload/draftail/issues/108
- [x] `LinkElementHandler` -> `InlineEntityElementHandler` with configurable `mutability`.

### Cleanup

- [ ] Change all Draftail code to 2-space indent to match Wagtail
- [ ] Move Hallo JS code to a Webpack entry as well, and clean up code.
- [ ] Move modal workflow code to Webpack (and cleanup).
- [ ] Fix / remove / adapt class names defined for image formats
- [x] Remove unused `.richtext-image img`, `.richtext-image figcaption`
- [ ] Default max list nesting, and configurability

### Other bugs

- [ ] `cursor: pointer;` on form-field `.add` `p`.
- ~[ ] Using a custom serif font makes the text flicker when loading bold / italic variants~
- [x] `LOADING: "{% trans 'Loading...' %}",` translation not using ellipsis char. #4218 
