### PR TITLE
Add Codecov integration to CircleCI to track JS test coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,7 +78,7 @@ script:
   tox
 
 after_success:
-  - codecov
+  - codecov -F backend
 
 # Who to notify about build results
 notifications:

--- a/circle.yml
+++ b/circle.yml
@@ -17,3 +17,5 @@ test:
     - python -u runtests.py
     - npm run test:unit:coverage -- --runInBand
     - npm run dist
+  post:
+    - bash <(curl -s https://codecov.io/bash)

--- a/circle.yml
+++ b/circle.yml
@@ -18,4 +18,4 @@ test:
     - npm run test:unit:coverage -- --runInBand
     - npm run dist
   post:
-    - bash <(curl -s https://codecov.io/bash)
+    - bash <(curl -s https://codecov.io/bash) -F frontend


### PR DESCRIPTION
We calculate JS test coverage on every CI build, but don't actually send it to Codecov. This will motivate us to reach a higher coverage there as well.

I tried to use Codecov [flags](https://docs.codecov.io/docs/flags), which allow us to retain some separation between the two test suites (#frontend, #backend tags) but it's the first time I use this so not entirely sure how best to leverage it.