### PR TITLE
Add a meaningful error message for invalid arguments to pageurl

### DIFF
--- a/wagtail/core/templatetags/wagtailcore_tags.py
+++ b/wagtail/core/templatetags/wagtailcore_tags.py
@@ -16,6 +16,9 @@ def pageurl(context, page):
     Outputs a page's URL as relative (/foo/bar/) if it's within the same site as the
     current page, or absolute (http://example.com/foo/bar/) if not.
     """
+    if not hasattr(page, 'relative_url'):
+        raise ValueError("pageurl tag expected a Page object, got %r" % page)
+
     try:
         current_site = context['request'].site
     except (KeyError, AttributeError):

--- a/wagtail/core/tests/tests.py
+++ b/wagtail/core/tests/tests.py
@@ -37,6 +37,12 @@ class TestPageUrlTags(TestCase):
         result = tpl.render(template.Context({'page': page, 'request': HttpRequest()}))
         self.assertIn('<a href="/events/">Events</a>', result)
 
+    def test_bad_pageurl(self):
+        tpl = template.Template('''{% load wagtailcore_tags %}<a href="{% pageurl page %}">{{ page.title }}</a>''')
+
+        with self.assertRaisesRegex(ValueError, "pageurl tag expected a Page object, got None"):
+            tpl.render(template.Context({'page': None}))
+
     def test_slugurl_without_request_in_context(self):
         tpl = template.Template('''{% load wagtailcore_tags %}<a href="{% slugurl 'events' %}">Events</a>''')
 


### PR DESCRIPTION
As suggested by @BertrandBordage on https://github.com/wagtail/wagtail/issues/4141#issuecomment-352208938, raise a more meaningful error message when the `pageurl` tag is passed a non-Page value, to make it clear that this is user error, not a Wagtail bug.