### PR TITLE
Navigate tabs

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,7 @@ Changelog
 2.1 (xx.xx.xxxx) - IN DEVELOPMENT
 ~~~~~~~~~~~~~~~~
 
+ * Persist tab hash in URL to allow direct navigation to tabs in the admin interface (Ben Weatherman)
  * Fix: Status button on 'edit page' now links to the correct URL when live and draft slug differ (LB (Ben Johnston))
  * Fix: Image title text in the gallery and in the chooser now wraps for long filenames (LB (Ben Johnston), Luiz Boaretto)
 

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -273,6 +273,7 @@ Contributors
 * Mary Kate Fain
 * Dário Marcelino
 * Dave Bell
+* Ben Weatherman
 
 Translators
 ===========

--- a/docs/releases/2.1.rst
+++ b/docs/releases/2.1.rst
@@ -14,6 +14,7 @@ What's new
 Other features
 ~~~~~~~~~~~~~~
 
+* Persist tab hash in URL to allow direct navigation to tabs in the admin interface (Ben Weatherman)
 
 Bug fixes
 ~~~~~~~~~

--- a/wagtail/admin/static_src/wagtailadmin/js/core.js
+++ b/wagtail/admin/static_src/wagtailadmin/js/core.js
@@ -79,10 +79,6 @@ $(function() {
     // Add class to the body from which transitions may be hung so they don't appear to transition as the page loads
     $('body').addClass('ready');
 
-    if (window.location.hash) {
-        $(`a[href='${window.location.hash}']`).tab('show');
-    }
-
     // Enable toggle to open/close nav
     $(document).on('click', '#nav-toggle', function() {
         $('body').toggleClass('nav-open');
@@ -177,10 +173,14 @@ $(function() {
     });
 
     /* tabs */
+    if (window.location.hash) {
+      $('a[href="' + window.location.hash + '"]').tab('show');
+    }
+
     $(document).on('click', '.tab-nav a', function(e) {
-        e.preventDefault();
-        $(this).tab('show');
-        history.pushState(null, null, $(this).attr('href'));
+      e.preventDefault();
+      $(this).tab('show');
+      window.history.replaceState(null, null, $(this).attr('href'));
     });
 
     $(document).on('click', '.tab-toggle', function(e) {

--- a/wagtail/admin/static_src/wagtailadmin/js/core.js
+++ b/wagtail/admin/static_src/wagtailadmin/js/core.js
@@ -79,6 +79,10 @@ $(function() {
     // Add class to the body from which transitions may be hung so they don't appear to transition as the page loads
     $('body').addClass('ready');
 
+    if (window.location.hash) {
+        $(`a[href='${window.location.hash}']`).tab('show');
+    }
+
     // Enable toggle to open/close nav
     $(document).on('click', '#nav-toggle', function() {
         $('body').toggleClass('nav-open');
@@ -176,6 +180,7 @@ $(function() {
     $(document).on('click', '.tab-nav a', function(e) {
         e.preventDefault();
         $(this).tab('show');
+        history.pushState(null, null, $(this).attr('href'));
     });
 
     $(document).on('click', '.tab-toggle', function(e) {


### PR DESCRIPTION
Save the hash when clicking on a tab and select the tab if loading a page with a hash in it. This allows for giving direct links to a specific tab.

![tabs](https://user-images.githubusercontent.com/272675/35627540-c8e22f36-065e-11e8-848e-78924335a146.gif)

Fixes wagtail/wagtail#4111