### PR TITLE
Prevents field help text returning as unsafe text

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/shared/field.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/field.html
@@ -11,7 +11,7 @@
             <span></span>
         </div>
         {% if show_help_text|default_if_none:True and field.help_text %}
-            <p class="help">{{ field.help_text }}</p>
+            <p class="help">{{ field.help_text|safe }}</p>
         {% endif %}
 
         {% if field|has_unrendered_errors %}


### PR DESCRIPTION
Change Password page you see code instead of HTML formatted text.

![captura de tela 2018-02-01 as 10 13 56](https://user-images.githubusercontent.com/32047234/35681169-55a48644-073b-11e8-9168-96215faafaeb.png)

Python version: 3.6.4
Django version: 2.0.1
 Wagtail version: 2.0b1
