### PR TITLE
Add on_delete to BlogPageTag model

### DIFF
--- a/docs/getting_started/tutorial.rst
+++ b/docs/getting_started/tutorial.rst
@@ -581,7 +581,11 @@ First, alter ``models.py`` once more:
 
 
     class BlogPageTag(TaggedItemBase):
-        content_object = ParentalKey('BlogPage', related_name='tagged_items')
+        content_object = ParentalKey(
+            'BlogPage',
+            related_name='tagged_items',
+            on_delete=models.CASCADE
+        )
 
 
     class BlogPage(Page):


### PR DESCRIPTION
While going through the tutorial I ran into this issue. Without the on_delete set on the BlogPageTag model the server crashes. I wasn't 100% sure which on_delete option to use, but at least this gets it up and running again! 