### PR TITLE
Fix modeladmin documentation typo

### DIFF
--- a/docs/reference/contrib/modeladmin/indexview.rst
+++ b/docs/reference/contrib/modeladmin/indexview.rst
@@ -200,7 +200,7 @@ A few special cases to note about ``list_display``:
 
         class PersonAdmin(ModelAdmin):
             model = Person
-            list_display = ('first_name', 'colored_name')
+            list_display = ('colored_first_name', 'last_name')
 
 
     The above will tell Wagtail to order by the ``first_name`` field when


### PR DESCRIPTION
Fix incorrect reference to a method name from the previous example.

The example that this code snippet relates to uses `colored_first_name` not `colored_name`.

I also rearranged the order / changed the second field to `last_name` as it seems more reasonable in the example context.