### PR TITLE
Comment Dockerfile, add docker-compose.yml

### DIFF
--- a/wagtail/project_template/Dockerfile
+++ b/wagtail/project_template/Dockerfile
@@ -1,18 +1,22 @@
 FROM python:3.6
-LABEL maintainer="hello@wagtail.io"
+# Uncomment the line below and replace your email address
+# LABEL maintainer="your@email.com"
 
+# Enables manage.py output to be visible when using Docker
 ENV PYTHONUNBUFFERED 1
-ENV DJANGO_ENV dev
 
+# Install requirements
+# Copying in requirements.txt separately speeds up subsequent builds
 COPY ./requirements.txt /code/requirements.txt
 RUN pip install -r /code/requirements.txt
+# gunicorn is a deployment choice so it doesn't belong in requirements.txt
 RUN pip install gunicorn
 
-COPY . /code/
-WORKDIR /code/
+# Copy our project files into the image
+COPY . /code
+WORKDIR /code
 
-RUN python manage.py migrate
-
+# Run wagtail as a non-root user
 RUN useradd wagtail
 RUN chown -R wagtail /code
 USER wagtail

--- a/wagtail/project_template/docker-compose.yml
+++ b/wagtail/project_template/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3'
+
+services:
+  db:
+    image: postgres:10-alpine
+  web:
+    build: .
+    command: python manage.py runserver 0.0.0.0:8000
+    volumes:
+      - .:/code
+    ports:
+      - "8000:8000"
+    environment:
+      - DATABASE_URL=postgres://postgres@db:5432/postgres
+    depends_on:
+      - db

--- a/wagtail/project_template/project_name/settings/base.py
+++ b/wagtail/project_template/project_name/settings/base.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/{{ docs_version }}/ref/settings/
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 import os
+import dj_database_url
 
 PROJECT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 BASE_DIR = os.path.dirname(PROJECT_DIR)
@@ -89,12 +90,17 @@ WSGI_APPLICATION = '{{ project_name }}.wsgi.application'
 # Database
 # https://docs.djangoproject.com/en/{{ docs_version }}/ref/settings/#databases
 
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
+if 'DATABASE_URL' in os.environ:
+    DATABASES = {
+        'default': dj_database_url.config(conn_max_age=600)
     }
-}
+else:
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.sqlite3',
+            'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
+        }
+    }
 
 
 # Password validation

--- a/wagtail/project_template/requirements.txt
+++ b/wagtail/project_template/requirements.txt
@@ -1,2 +1,3 @@
 Django>=2.0,<2.1
 wagtail==2.1a0
+dj-database-url==0.4.2


### PR DESCRIPTION
First off, I changed the Dockerfile a little. Mostly I added comments. I also removed some lines:

```
ENV DJANGO_ENV dev
```
This doesn't appear to do anything. Also, I use a single Docker image for production and development and just switch between them by setting `DJANGO_SETTINGS_MODULE`, so it seems counterintuitive to declare this a development only file?

```
RUN python manage.py migrate
```
I don't think this command should be in the Dockerfile. The main reason being that it doesn't affect the built image at all, it affects the database. If you try building the image and no database is attached, the image will refuse to build because it errors out on this command. Instead, this should be run inside of the image after it's built with something like `docker run --rm wagtail python manage.py migrate`.

I also removed trailing slashes from `/code/` because they aren't needed (Docker docs doesn't use them) and they were used inconsistently.

I commented out the maintainer email because the image will build fine without it, and it seems better to build an image without a maintainer email than to build one with a placeholder email.

Next up, docker-compose. I added a file here that lets you simply `docker-compose up` to run your project locally. I did add `dj-database-url` and edit the settings. If you don't want `dj-database-url`, we could set each value distinctly, but this makes it easier and makes it Heroku-ready. The main benefit of all this is that the user can run postgres locally without a bunch of messing around.