### PR TITLE
Draftail updates, refactors, bug fixes 3

### DIFF
--- a/client/src/components/Draftail/Draftail.scss
+++ b/client/src/components/Draftail/Draftail.scss
@@ -71,6 +71,11 @@ $draftail-editor-font-family: $font-serif;
 
 .Draftail-Editor {
     border-radius: 0;
+
+    &__wrapper {
+        // Ensure elements within the editor are positioned according to this container.
+        position: relative;
+    }
 }
 
 // When in a .full container, the editor has a specific appearance

--- a/client/src/components/Draftail/Draftail.scss
+++ b/client/src/components/Draftail/Draftail.scss
@@ -65,10 +65,6 @@ $draftail-editor-font-family: $font-serif;
     }
 }
 
-.Draftail-Toolbar {
-    display: inline-block;
-}
-
 .Draftail-Editor {
     border-radius: 0;
 

--- a/client/src/components/Draftail/__snapshots__/index.test.js.snap
+++ b/client/src/components/Draftail/__snapshots__/index.test.js.snap
@@ -12,6 +12,7 @@ Object {
   },
   "enableLineBreak": Object {
     "description": "Line break",
+    "icon": "M.436 633.471l296.897-296.898v241.823h616.586V94.117h109.517v593.796H297.333v242.456z",
   },
   "entityTypes": Array [
     Object {

--- a/client/src/components/Draftail/blocks/MediaBlock.test.js
+++ b/client/src/components/Draftail/blocks/MediaBlock.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 
 import MediaBlock from '../blocks/MediaBlock';
 
@@ -49,10 +49,16 @@ describe('MediaBlock', () => {
   });
 
   describe('tooltip', () => {
+    let target;
     let wrapper;
 
     beforeEach(() => {
-      wrapper = shallow(
+      target = document.createElement('div');
+      target.setAttribute('data-draftail-trigger', true);
+      document.body.appendChild(target);
+      document.body.setAttribute('data-draftail-editor-wrapper', true);
+
+      wrapper = mount(
         <MediaBlock
           src="example.png"
           alt=""
@@ -67,28 +73,32 @@ describe('MediaBlock', () => {
             },
           }}
         >
-          Test
+          <div id="test">Test</div>
         </MediaBlock>
       );
     });
 
     it('opens', () => {
-      const target = document.createElement('div');
-      document.body.appendChild(target);
-
-      wrapper.simulate('mouseup', { target });
+      wrapper.simulate('click', { target });
 
       expect(
         wrapper
           .find('Portal')
-          .dive()
           .instance().portal
       ).toMatchSnapshot();
     });
 
+    it('click in tooltip', () => {
+      wrapper.simulate('click', { target });
+
+      jest.spyOn(target, 'getBoundingClientRect');
+
+      wrapper.simulate('click', { target: document.querySelector('#test') });
+
+      expect(target.getBoundingClientRect).not.toHaveBeenCalled();
+    });
+
     it('large viewport', () => {
-      const target = document.createElement('div');
-      document.body.appendChild(target);
       target.getBoundingClientRect = () => ({
         top: 0,
         left: 0,
@@ -96,26 +106,22 @@ describe('MediaBlock', () => {
         height: 0,
       });
 
-      wrapper.simulate('mouseup', { target });
+      wrapper.simulate('click', { target });
 
       expect(
         wrapper
           .find('Portal')
-          .dive()
           .instance()
           .portal.querySelector('.Tooltip').className
       ).toBe('Tooltip Tooltip--left');
     });
 
     it('closes', () => {
-      const target = document.createElement('div');
-      document.body.appendChild(target);
-
       jest.spyOn(target, 'getBoundingClientRect');
 
       expect(wrapper.state('showTooltipAt')).toBe(null);
 
-      wrapper.simulate('mouseup', { target });
+      wrapper.simulate('click', { target });
 
       expect(wrapper.state('showTooltipAt')).toMatchObject({
         top: 0,

--- a/client/src/components/Draftail/blocks/__snapshots__/MediaBlock.test.js.snap
+++ b/client/src/components/Draftail/blocks/__snapshots__/MediaBlock.test.js.snap
@@ -3,7 +3,8 @@
 exports[`MediaBlock no data 1`] = `
 <button
   className="MediaBlock"
-  onMouseUp={[Function]}
+  data-draftail-trigger={true}
+  onClick={[Function]}
   tabIndex={-1}
   type="button"
 >
@@ -29,7 +30,8 @@ exports[`MediaBlock no data 1`] = `
 exports[`MediaBlock renders 1`] = `
 <button
   className="MediaBlock"
-  onMouseUp={[Function]}
+  data-draftail-trigger={true}
+  onClick={[Function]}
   tabIndex={-1}
   type="button"
 >
@@ -54,14 +56,16 @@ exports[`MediaBlock renders 1`] = `
 
 exports[`MediaBlock tooltip opens 1`] = `
 <div>
-  <div>
+  <div
+    class="Tooltip Tooltip--top-left"
+    role="tooltip"
+    style="top: 0px; left: 0px;"
+  >
     <div
-      class="Tooltip Tooltip--top-left"
-      role="tooltip"
-      style="top: 0px; left: 0px;"
+      style="max-width: 300px;"
     >
       <div
-        style="max-width: 300px;"
+        id="test"
       >
         Test
       </div>

--- a/client/src/components/Draftail/decorators/TooltipEntity.js
+++ b/client/src/components/Draftail/decorators/TooltipEntity.js
@@ -22,13 +22,49 @@ class TooltipEntity extends Component {
       showTooltipAt: null,
     };
 
+    this.onEdit = this.onEdit.bind(this);
+    this.onRemove = this.onRemove.bind(this);
     this.openTooltip = this.openTooltip.bind(this);
     this.closeTooltip = this.closeTooltip.bind(this);
   }
 
+  onEdit(e) {
+    const { onEdit, entityKey } = this.props;
+
+    e.preventDefault();
+    e.stopPropagation();
+    onEdit(entityKey);
+  }
+
+  onRemove(e) {
+    const { onRemove, entityKey } = this.props;
+
+    e.preventDefault();
+    e.stopPropagation();
+    onRemove(entityKey);
+  }
+
   openTooltip(e) {
-    const trigger = e.target;
-    this.setState({ showTooltipAt: trigger.getBoundingClientRect() });
+    const trigger = e.target.closest('[data-draftail-trigger]');
+
+    // Click is within the tooltip.
+    if (!trigger) {
+      return;
+    }
+
+    const container = trigger.closest('[data-draftail-editor-wrapper]');
+    const containerRect = container.getBoundingClientRect();
+    const rect = trigger.getBoundingClientRect();
+
+    this.setState({
+      showTooltipAt: {
+        container: container,
+        top: rect.top - containerRect.top - (document.documentElement.scrollTop || document.body.scrollTop),
+        left: rect.left - containerRect.left - (document.documentElement.scrollLeft || document.body.scrollLeft),
+        width: rect.width,
+        height: rect.height,
+      },
+    });
   }
 
   closeTooltip() {
@@ -37,10 +73,7 @@ class TooltipEntity extends Component {
 
   render() {
     const {
-      entityKey,
       children,
-      onEdit,
-      onRemove,
       icon,
       label,
       url,
@@ -50,11 +83,18 @@ class TooltipEntity extends Component {
     // Contrary to what JSX A11Y says, this should be a button but it shouldn't be focusable.
     /* eslint-disable springload/jsx-a11y/interactive-supports-focus */
     return (
-      <a role="button" onMouseUp={this.openTooltip} className="TooltipEntity">
+      <a
+        role="button"
+        // Use onMouseUp to preserve focus in the text even after clicking.
+        onMouseUp={this.openTooltip}
+        className="TooltipEntity"
+        data-draftail-trigger
+      >
         <Icon icon={icon} className="TooltipEntity__icon" />
         {children}
         {showTooltipAt && (
           <Portal
+            node={showTooltipAt.container}
             onClose={this.closeTooltip}
             closeOnClick
             closeOnType
@@ -75,14 +115,14 @@ class TooltipEntity extends Component {
 
               <button
                 className="button Tooltip__button"
-                onClick={onEdit.bind(null, entityKey)}
+                onClick={this.onEdit}
               >
                 Edit
               </button>
 
               <button
                 className="button button-secondary no Tooltip__button"
-                onClick={onRemove.bind(null, entityKey)}
+                onClick={this.onRemove}
               >
                 Remove
               </button>

--- a/client/src/components/Draftail/decorators/TooltipEntity.test.js
+++ b/client/src/components/Draftail/decorators/TooltipEntity.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow, mount } from 'enzyme';
+import { shallow } from 'enzyme';
 
 import TooltipEntity from './TooltipEntity';
 

--- a/client/src/components/Draftail/decorators/TooltipEntity.test.js
+++ b/client/src/components/Draftail/decorators/TooltipEntity.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 
 import TooltipEntity from './TooltipEntity';
 
@@ -51,8 +51,13 @@ describe('TooltipEntity', () => {
       </TooltipEntity>
     ));
 
+    const target = document.createElement('div');
+    target.setAttribute('data-draftail-trigger', true);
+    document.body.appendChild(target);
+    document.body.setAttribute('data-draftail-editor-wrapper', true);
+
     wrapper.find('.TooltipEntity').simulate('mouseup', {
-      target: document.createElement('div'),
+      target: target,
     });
 
     expect(wrapper).toMatchSnapshot();
@@ -81,5 +86,47 @@ describe('TooltipEntity', () => {
     expect(wrapper.state()).toEqual({
       showTooltipAt: null,
     });
+  });
+
+  it('#onEdit', () => {
+    const onEdit = jest.fn();
+
+    const wrapper = shallow((
+      <TooltipEntity
+        entityKey="1"
+        onEdit={onEdit}
+        onRemove={() => {}}
+        icon="#icon-test"
+        url="https://www.example.com/"
+        label="www.example.com"
+      >
+        test
+      </TooltipEntity>
+    ));
+
+    wrapper.instance().onEdit(new Event('click'));
+
+    expect(onEdit).toHaveBeenCalled();
+  });
+
+  it('#onRemove', () => {
+    const onRemove = jest.fn();
+
+    const wrapper = shallow((
+      <TooltipEntity
+        entityKey="1"
+        onEdit={() => {}}
+        onRemove={onRemove}
+        icon="#icon-test"
+        url="https://www.example.com/"
+        label="www.example.com"
+      >
+        test
+      </TooltipEntity>
+    ));
+
+    wrapper.instance().onRemove(new Event('click'));
+
+    expect(onRemove).toHaveBeenCalled();
   });
 });

--- a/client/src/components/Draftail/decorators/__snapshots__/TooltipEntity.test.js.snap
+++ b/client/src/components/Draftail/decorators/__snapshots__/TooltipEntity.test.js.snap
@@ -3,6 +3,7 @@
 exports[`TooltipEntity #openTooltip 1`] = `
 <a
   className="TooltipEntity"
+  data-draftail-trigger={true}
   onMouseUp={[Function]}
   role="button"
 >
@@ -16,16 +17,30 @@ exports[`TooltipEntity #openTooltip 1`] = `
     closeOnClick={true}
     closeOnResize={true}
     closeOnType={true}
+    node={
+      <body
+        data-draftail-editor-wrapper="true"
+      >
+        <div
+          data-draftail-trigger="true"
+        />
+      </body>
+    }
     onClose={[Function]}
   >
     <Tooltip
       direction="top"
       target={
         Object {
-          "bottom": 0,
+          "container": <body
+            data-draftail-editor-wrapper="true"
+          >
+            <div
+              data-draftail-trigger="true"
+            />
+          </body>,
           "height": 0,
           "left": 0,
-          "right": 0,
           "top": 0,
           "width": 0,
         }
@@ -60,6 +75,7 @@ exports[`TooltipEntity #openTooltip 1`] = `
 exports[`TooltipEntity works 1`] = `
 <a
   className="TooltipEntity"
+  data-draftail-trigger={true}
   onMouseUp={[Function]}
   role="button"
 >

--- a/client/src/components/Draftail/index.js
+++ b/client/src/components/Draftail/index.js
@@ -13,6 +13,9 @@ export { default as EmbedBlock } from './blocks/EmbedBlock';
 
 export { default as ModalWorkflowSource } from './sources/ModalWorkflowSource';
 
+// 1024x1024 SVG path rendering of the "↵" character, that renders badly in MS Edge.
+const BR_ICON = 'M.436 633.471l296.897-296.898v241.823h616.586V94.117h109.517v593.796H297.333v242.456z';
+
 /**
  * Registry for client-side code of Draftail plugins.
  */
@@ -79,7 +82,10 @@ const initEditor = (fieldName, options) => {
       onSave={serialiseInputValue}
       placeholder={STRINGS.WRITE_HERE}
       spellCheck={true}
-      enableLineBreak={{ description: STRINGS.LINE_BREAK }}
+      enableLineBreak={{
+        description: STRINGS.LINE_BREAK,
+        icon: BR_ICON,
+      }}
       showUndoControl={{ description: STRINGS.UNDO }}
       showRedoControl={{ description: STRINGS.REDO }}
       maxListNesting={4}

--- a/client/src/components/Draftail/index.js
+++ b/client/src/components/Draftail/index.js
@@ -45,7 +45,11 @@ export const wrapWagtailIcon = type => {
  */
 const initEditor = (fieldName, options) => {
   const field = document.querySelector(`[name="${fieldName}"]`);
+
   const editorWrapper = document.createElement('div');
+  editorWrapper.className = 'Draftail-Editor__wrapper';
+  editorWrapper.setAttribute('data-draftail-editor-wrapper', true);
+
   field.parentNode.appendChild(editorWrapper);
 
   const serialiseInputValue = rawContentState => {

--- a/client/src/components/Draftail/sources/ModalWorkflowSource.js
+++ b/client/src/components/Draftail/sources/ModalWorkflowSource.js
@@ -119,7 +119,7 @@ class ModalWorkflowSource extends Component {
     $(document.body).on('hidden.bs.modal', this.onClose);
 
     // eslint-disable-next-line new-cap
-    global.ModalWorkflow({
+    this.workflow = global.ModalWorkflow({
       url,
       urlParams,
       responses: {
@@ -138,6 +138,8 @@ class ModalWorkflowSource extends Component {
   }
 
   componentWillUnmount() {
+    this.workflow = null;
+
     $(document.body).off('hidden.bs.modal', this.onClose);
   }
 
@@ -171,6 +173,11 @@ class ModalWorkflowSource extends Component {
         nextState = RichUtils.toggleLink(editorState, selection, entityKey);
       }
     }
+
+    // IE11 crashes when rendering the new entity in contenteditable if the modal is still open.
+    // Other browsers do not mind. This is probably a focus management problem.
+    // From the user's perspective, this is all happening too fast to notice either way.
+    this.workflow.close();
 
     onComplete(nextState);
   }

--- a/client/src/components/Draftail/sources/ModalWorkflowSource.test.js
+++ b/client/src/components/Draftail/sources/ModalWorkflowSource.test.js
@@ -210,6 +210,7 @@ describe('ModalWorkflowSource', () => {
       jest.spyOn(RichUtils, 'toggleLink');
 
       const onComplete = jest.fn();
+      const close = jest.fn();
 
       let editorState = EditorState.createWithContent(convertFromRaw({
         entityMap: {},
@@ -235,10 +236,12 @@ describe('ModalWorkflowSource', () => {
         />
       ));
 
+      wrapper.instance().workflow = { close };
       wrapper.instance().onChosen({});
 
       expect(onComplete).toHaveBeenCalled();
       expect(RichUtils.toggleLink).toHaveBeenCalled();
+      expect(close).toHaveBeenCalled();
 
       RichUtils.toggleLink.mockRestore();
     });
@@ -247,6 +250,7 @@ describe('ModalWorkflowSource', () => {
       jest.spyOn(AtomicBlockUtils, 'insertAtomicBlock');
 
       const onComplete = jest.fn();
+      const close = jest.fn();
 
       let editorState = EditorState.createWithContent(convertFromRaw({
         entityMap: {},
@@ -274,10 +278,12 @@ describe('ModalWorkflowSource', () => {
         />
       ));
 
+      wrapper.instance().workflow = { close };
       wrapper.instance().onChosen({});
 
       expect(onComplete).toHaveBeenCalled();
       expect(AtomicBlockUtils.insertAtomicBlock).toHaveBeenCalled();
+      expect(close).toHaveBeenCalled();
 
       AtomicBlockUtils.insertAtomicBlock.mockRestore();
     });
@@ -286,6 +292,7 @@ describe('ModalWorkflowSource', () => {
       jest.spyOn(Modifier, 'replaceText');
 
       const onComplete = jest.fn();
+      const close = jest.fn();
 
       let editorState = EditorState.createWithContent(convertFromRaw({
         entityMap: {},
@@ -310,6 +317,7 @@ describe('ModalWorkflowSource', () => {
         />
       ));
 
+      wrapper.instance().workflow = { close };
       wrapper.instance().onChosen({
         url: 'example.com',
         prefer_this_title_as_link_text: true,
@@ -317,6 +325,7 @@ describe('ModalWorkflowSource', () => {
 
       expect(onComplete).toHaveBeenCalled();
       expect(Modifier.replaceText).toHaveBeenCalled();
+      expect(close).toHaveBeenCalled();
 
       Modifier.replaceText.mockRestore();
     });

--- a/client/src/components/Portal/Portal.js
+++ b/client/src/components/Portal/Portal.js
@@ -1,10 +1,17 @@
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
-import ReactDOM from 'react-dom';
+import { Component } from 'react';
+import { createPortal } from 'react-dom';
 
+/**
+ * A Portal component which automatically closes itself
+ * when certain events happen outside.
+ * See https://reactjs.org/docs/portals.html.
+ */
 class Portal extends Component {
   constructor(props) {
     super(props);
+
+    this.portal = document.createElement('div');
 
     this.onCloseEvent = this.onCloseEvent.bind(this);
   }
@@ -18,40 +25,27 @@ class Portal extends Component {
   }
 
   componentDidMount() {
-    const { onClose, closeOnClick, closeOnType, closeOnResize } = this.props;
+    const { node, onClose, closeOnClick, closeOnType, closeOnResize } = this.props;
 
-    if (!this.portal) {
-      this.portal = document.createElement('div');
-      document.body.appendChild(this.portal);
+    node.appendChild(this.portal);
 
-      if (onClose) {
-        if (closeOnClick) {
-          document.addEventListener('mouseup', this.onCloseEvent);
-        }
-
-        if (closeOnType) {
-          document.addEventListener('keyup', this.onCloseEvent);
-        }
-
-        if (closeOnResize) {
-          window.addEventListener('resize', onClose);
-        }
-      }
+    if (closeOnClick) {
+      document.addEventListener('mouseup', this.onCloseEvent);
     }
 
-    this.componentDidUpdate();
-  }
+    if (closeOnType) {
+      document.addEventListener('keyup', this.onCloseEvent);
+    }
 
-  componentDidUpdate() {
-    const { children } = this.props;
-
-    ReactDOM.render(<div>{children}</div>, this.portal);
+    if (closeOnResize) {
+      window.addEventListener('resize', onClose);
+    }
   }
 
   componentWillUnmount() {
-    const { onClose } = this.props;
+    const { node, onClose } = this.props;
 
-    document.body.removeChild(this.portal);
+    node.removeChild(this.portal);
 
     document.removeEventListener('mouseup', this.onCloseEvent);
     document.removeEventListener('keyup', this.onCloseEvent);
@@ -59,12 +53,15 @@ class Portal extends Component {
   }
 
   render() {
-    return null;
+    const { children } = this.props;
+
+    return createPortal(children, this.portal);
   }
 }
 
 Portal.propTypes = {
-  onClose: PropTypes.func,
+  onClose: PropTypes.func.isRequired,
+  node: PropTypes.instanceOf(Element),
   children: PropTypes.node,
   closeOnClick: PropTypes.bool,
   closeOnType: PropTypes.bool,
@@ -72,7 +69,7 @@ Portal.propTypes = {
 };
 
 Portal.defaultProps = {
-  onClose: null,
+  node: document.body,
   children: null,
   closeOnClick: false,
   closeOnType: false,

--- a/client/src/components/Portal/Portal.test.js
+++ b/client/src/components/Portal/Portal.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import Portal from './Portal';
 
 const func = expect.any(Function);
@@ -10,26 +10,20 @@ describe('Portal', () => {
   });
 
   it('empty', () => {
-    expect(shallow(<Portal />)).toMatchSnapshot();
+    expect(mount(<Portal onClose={() => {}} />)).toMatchSnapshot();
   });
 
   it('#children', () => {
-    expect(shallow(<Portal>Test!</Portal>)).toMatchSnapshot();
+    expect(mount(<Portal onClose={() => {}}>Test!</Portal>)).toMatchSnapshot();
   });
 
   it('component lifecycle', () => {
     document.removeEventListener = jest.fn();
     window.removeEventListener = jest.fn();
 
-    const wrapper = shallow(<Portal onClose={() => {}}>Test!</Portal>);
-
-    wrapper.instance().componentDidMount();
+    const wrapper = mount(<Portal onClose={() => {}}>Test!</Portal>);
 
     expect(document.body.innerHTML).toMatchSnapshot();
-
-    expect(wrapper.instance().portal).toBe(document.body.children[0]);
-
-    wrapper.instance().componentDidMount();
 
     wrapper.instance().componentWillUnmount();
 
@@ -81,14 +75,14 @@ describe('Portal', () => {
           Test!
         </Portal>
       );
-      expect(window.addEventListener).toHaveBeenCalledWith('error', func);
+      expect(window.addEventListener).toHaveBeenCalledWith('resize', func);
     });
   });
 
   describe('onCloseEvent', () => {
-    it('shouldClose', () => {
+    it('should close', () => {
       const onClose = jest.fn();
-      const wrapper = shallow(<Portal onClose={onClose}>Test!</Portal>);
+      const wrapper = mount(<Portal onClose={onClose}>Test!</Portal>);
       const target = document.createElement('div');
 
       wrapper.instance().onCloseEvent({ target });
@@ -96,9 +90,9 @@ describe('Portal', () => {
       expect(onClose).toHaveBeenCalled();
     });
 
-    it('not shouldClose', () => {
+    it('not should close', () => {
       const onClose = jest.fn();
-      const wrapper = shallow(
+      const wrapper = mount(
         <Portal onClose={onClose}>
           <div id="test">Test</div>
         </Portal>

--- a/client/src/components/Portal/__snapshots__/Portal.test.js.snap
+++ b/client/src/components/Portal/__snapshots__/Portal.test.js.snap
@@ -1,7 +1,35 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Portal #children 1`] = `""`;
+exports[`Portal #children 1`] = `
+<Portal
+  closeOnClick={false}
+  closeOnResize={false}
+  closeOnType={false}
+  node={
+    <body>
+      <div>
+        Test!
+      </div>
+    </body>
+  }
+  onClose={[Function]}
+>
+  Test!
+</Portal>
+`;
 
-exports[`Portal component lifecycle 1`] = `"<div><div>Test!</div></div>"`;
+exports[`Portal component lifecycle 1`] = `"<div>Test!</div>"`;
 
-exports[`Portal empty 1`] = `""`;
+exports[`Portal empty 1`] = `
+<Portal
+  closeOnClick={false}
+  closeOnResize={false}
+  closeOnType={false}
+  node={
+    <body>
+      <div />
+    </body>
+  }
+  onClose={[Function]}
+/>
+`;

--- a/client/src/utils/polyfills.js
+++ b/client/src/utils/polyfills.js
@@ -2,5 +2,9 @@
  * Polyfills for Wagtail's admin.
  */
 
+// IE11.
 import 'core-js/shim';
+// IE11, old iOS Safari.
 import 'whatwg-fetch';
+// IE11.
+import 'element-closest';

--- a/client/tests/stubs.js
+++ b/client/tests/stubs.js
@@ -3,6 +3,7 @@
  * Those variables usually come from the back-end via templates.
  * See /wagtailadmin/templates/wagtailadmin/admin_base.html.
  */
+import 'element-closest';
 
 global.wagtailConfig = {
   ADMIN_API: {

--- a/docs/advanced_topics/customisation/extending_draftail.rst
+++ b/docs/advanced_topics/customisation/extending_draftail.rst
@@ -334,3 +334,12 @@ To fully complete the demo, we can add a bit of JavaScript to the front-end in o
 ----
 
 Custom block entities can also be created (have a look at the separate `Draftail <https://github.com/springload/draftail>`_ documentation), but these are not detailed here since :ref:`StreamField <streamfield>` is the go-to way to create block-level rich text in Wagtail.
+
+Integration of the Draftail widgets
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To further customise how the Draftail widgets are integrated into the UI, there are additional extension points for CSS and JS:
+
+* In JavaScript, use the ``[data-draftail-input]`` attribute selector to target the input which contains the data, and ``[data-draftail-editor-wrapper]`` for the element which wraps the editor.
+* The editor instance is bound on the input field for imperative access. Use ``document.querySelector('[data-draftail-input]').draftailEditor``.
+* In CSS, use the classes prefixed with ``Draftail-``.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2688,6 +2688,11 @@
       "integrity": "sha1-elgja5VGjD52YAkTSFItZddzazY=",
       "dev": true
     },
+    "element-closest": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/element-closest/-/element-closest-2.0.2.tgz",
+      "integrity": "sha1-cqdAoQdFM4LijfnOXbtajfD5Zuw="
+    },
     "elliptic": {
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "core-js": "^2.5.3",
     "draft-js": "0.10.5",
     "draftail": "^0.16.0",
+    "element-closest": "^2.0.2",
     "focus-trap-react": "^3.1.0",
     "prop-types": "^15.6.0",
     "react": "^16.2.0",


### PR DESCRIPTION
Follow-up to #4229. Should be the last one. Should be part of the 2.0 release. Addresses the following:

- [x] The background colour flickers when the link edit takes focus
- [x] Editor crash when inserting new link, document, image embed in IE11 (specific to Wagtail)
- [x] Toolbar does not stick in Safari

Also:

- Adds missing docs to customise Draftail's widgets in JS and CSS.
- Fix line break icon rendering in MS Edge.

If I have time, I'd also like to tackle the following, although this could be in a separate PR:

- [ ] Add error boundary around editor component, so that editor crashes are handled gracefully

# Other tasks

<details>

### Postponed

- [ ] Support tooltip rendering top-right when necessary (depending on available space).
- [ ] Distinguish between internal and external links in the editor by using different icons.
- [ ] Order of the controls in the toolbar
- [ ] "Link text" field in page chooser should be pre-filled with text
- [ ] Opening up a dialog (eg. new link, document, image) causes the editable text area to go white, then the dialog loads. However, on a slow connection (mine right now), this may take up to two seconds or more. The text going white and becoming non-editable is a bit confusing - it might be good to add a loading indicator? Or maybe the screen should go darker straight away (ie. before the modal response returns). My connection is quite slow so not sure what the best way around this is. **Should be addressed in the choosers, rather than the editor**.
- [ ] Minor nitpick: If you have a lot of content in the editor (say two pages worth), and you are editing something towards the end of the content, then you clear that content. Your scroll position is kept to further down the editor page, and the draftail editor essentially disappears. This may not be worth solving - but wanted to mention it.

### Cleanup

- [ ] Default max list nesting, and configurability
- [ ] Decorators configurability

### Other bugs

- [ ] `cursor: pointer;` on form-field `.add` `p`.

# Fixed

### Documentation

- [x] Usage
- [x] Extending Draftail docs
- [x] Update editor guide
- [x] Extending Hallo docs update
- [x] Draftail known issues https://github.com/springload/draftail/issues/138
- [x] Release notes

### UI

- [x] Improve support for custom icons
- [x] Make all entity-related components definitions in Draftail integrations rather than in core
- [x] Move tooltip outside of Draftail core.
- [x] Implement latest UI iteration based on Bristol sprint designs
- [x] Move latest version of Wagtail-only components into Wagtail
- [x] Adapt UI styles to coexist with Hallo
- [x] Review latest UI iteration within Wagtail
- [x] Post-review fixes and potential release
- ~[ ] Move nested lists styles over~
- [x] Reproduce Hallo's "focus when adding a sequence member" in sequence.js
- [x] Reproduce Hallo field styles (focus)
- [x] i18n
- [x] Toolbar icons alignment
- [x] Toolbar border radius consistency
- [x] Tooltip background color flicker
- [x] Draftail editor padding/spacing
- [x] Toolbar tooltip obstructing first lines of content
- [x] Color contrast of the 'remove' button is too low
- [x] Left and right paddings of 'edit' and 'remove' buttons should match the 'save draft' button. The button paddings do not collapse right on mobile viewport
- [x] Support absence of data on Link
- [x] Support absence of data on Document
- [x] Support absence of data on Image
- [x] Support absence of data on Embed

### Build

- [x] Expose Wagtail dependencies as globals
- [x] Ensure Draft.js vendor deps are only loaded when Draftail is.

### Entities 

- [x] Updating image alt text / alignment through the inline form is laggy - changes only get committed to the underlying contentstate data when the rich text field is refocused, and only propagate back to the form after an edit is made to the rich text
- [x] Make sure sources handle creation & edit (link, document)
- [x] Make sure sources handle creation & edit (image, embed). Edit: Considering removing the "Edit" button for now.
- [x] Investigate scroll on focus
- [x] Handle link text in link source (`prefer_this_title_as_link_text: true`, `title: "text"`)
- [x] Make sure image formats are configurable via image chooser
- [x] Handle server errors without locking the editor

### Other

- [x] Finish first draft of styling/theming API
- [x] Link icon check based on `mailto` `startsWith`
- [x] Finish rich text copy-paste filtering https://github.com/springload/draftail/issues/123
- [x] Replace constants / hard-coded strings in wagtail_hooks, rich_text, contentstate.py
- [x] Filter pasted `tel` links. Ideally, turn pasted link filtering into a [real whitelist](https://github.com/wagtail/wagtail/pull/4136#discussion_r163582141).
- ~[ ] Editor behavior when image / embed / link / document don't have data defined (remove the entity/block?)~

### Bugs

- ~[ ] No-break text overflow~
- ~[ ] Prevent toolbar from obstructing last block~
- [x] Impossible to use SVG icons from within Wagtail
- [x] Toolbar buttons spacing & alignment in Firefox, Safari
- [x] The background colour flickers when the link edit takes focus
- [x] Toolbar does not stick in Safari

### Testing

- [x] Cross-browser test within Wagtail
- [x] More tests on mobile devices, in Wagtail
- [x] Check pasting from Hallo to Draftail
- [x] Check pasting from more recent versions of Word https://github.com/springload/draftail/issues/123
- [x] 100% unit test coverage
- ~[ ] Troubleshoot ContentState conversion bug for "HTML-sanitised" text.~

### Nice to haves

- ~[ ] Add CSS linting to Draftail https://github.com/springload/draftail/issues/126~
- [x] Fix block type reset annoyance https://github.com/springload/draftail/issues/105
- ~[ ] Automated integration tests https://github.com/springload/draftail/issues/12~
- [x] i18n for horizontal line, line break, undo-redo
- [x] Re-check known issue https://github.com/springload/draftail/issues/108
- [x] `LinkElementHandler` -> `InlineEntityElementHandler` with configurable `mutability`.
- [x] Automatically-generated depth styles for list items

### Refactorings

- [x] Remove default {} when finishing https://github.com/springload/wagtaildraftail/issues/32
- [x] Fix silly `ugettext_lazy` serialisation
- [x] Add `data-` attribute to Hallo editor to define documented integration point for plugins.
- [x] Make editor `font-family` and `font-size` overridable via Sass variable
- [x] Remove unused Sass variables
- [x] Namespace variables and mixins
- [x] Stop loading Hallo CSS even if Hallo isn't loaded
- [x] `user-select: none;` on button labels
- ~[ ] Move block spacing styles to Draftail~
- [x] Add unknown attribute (`id`) filter to Draft.js filters
- [x] Refactor sources composition over inheritance
- [x] Remove unused `.richtext-image img`, `.richtext-image figcaption`
- ~[ ] Move Hallo JS code to a Webpack entry as well, and clean up code.~
- ~[ ] Move modal workflow code to Webpack (and cleanup).~

### Decisions

- [x] (soft) line break – enabled or disabled by default?
- [x] undo redo controls displayed in toolbar?

### Cross-browser bugs

- [x] Media block bottom border in Safari, Android Chrome
- [x] Line break button renders badly in Edge
- [x] Placeholder misaligned in ~iOS Safari~ full-width fields

### Other bugs

- ~[ ] Using a custom serif font makes the text flicker when loading bold / italic variants~
- [x] `LOADING: "{% trans 'Loading...' %}",` translation not using ellipsis char. #4218 

</details>
