### PR TITLE
Embed Docs: fix broken link

### DIFF
--- a/docs/advanced_topics/embeds.rst
+++ b/docs/advanced_topics/embeds.rst
@@ -117,7 +117,7 @@ provider using the oEmbed protocol. Wagtail has a built-in list of providers
 which are all enabled by default. You can find that provider list at the
 following link:
 
-https://github.com/wagtail/wagtail/blob/master/wagtail/wagtailembeds/oembed_providers.py
+https://github.com/wagtail/wagtail/blob/master/wagtail/embeds/oembed_providers.py
 
 .. _customising_embed_providers:
 


### PR DESCRIPTION
Fix broken url in Embedded content docs.