### PR TITLE
Update wagtail url paths for Django 2.0

### DIFF
--- a/docs/getting_started/integrating_into_django.rst
+++ b/docs/getting_started/integrating_into_django.rst
@@ -63,15 +63,17 @@ Now make the following additions to your ``urls.py`` file:
 
 .. code-block:: python
 
+    from django.urls import path, re_path, include
+
     from wagtail.admin import urls as wagtailadmin_urls
     from wagtail.documents import urls as wagtaildocs_urls
     from wagtail.core import urls as wagtail_urls
 
     urlpatterns = [
         ...
-        url(r'^cms/', include(wagtailadmin_urls)),
-        url(r'^documents/', include(wagtaildocs_urls)),
-        url(r'^pages/', include(wagtail_urls)),
+        re_path(r'^cms/', include(wagtailadmin_urls)),
+        re_path(r'^documents/', include(wagtaildocs_urls)),
+        re_path(r'^pages/', include(wagtail_urls)),
         ...
     ]
 


### PR DESCRIPTION
- `url()` is deprecated in Django 2.0 needs to be changed to `re_path()`
- show the necessary `django.url` imports for `path`, `re_path`, and `include` just in case the project does not already have them