### PR TITLE
Fix Help Text Overlaping StreamField Within Streamfield

### DIFF
--- a/wagtail/admin/static_src/wagtailadmin/scss/components/_icons.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/components/_icons.scss
@@ -135,3 +135,23 @@
     display: inline-block;
     line-height: 1;
 }
+
+// CSS-only circled question mark.
+// <span class="icon-help-inverse" aria-hidden="true"></span>
+.icon-help-inverse {
+    &:before {
+        border-radius: 100%;
+        display: block;
+        float: left;
+        content: '?';
+        border: 1px solid $color-grey-2;
+        color: $color-grey-2;
+        height: 15px;
+        width: 15px;
+        line-height: 15px;
+        text-align: center;
+        font-size: 1.1em;
+        margin-left: -2em;
+        margin-top: 0.3em;
+    }
+}

--- a/wagtail/admin/static_src/wagtailadmin/scss/components/_icons.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/components/_icons.scss
@@ -139,19 +139,18 @@
 // CSS-only circled question mark.
 // <span class="icon-help-inverse" aria-hidden="true"></span>
 .icon-help-inverse {
+    $size: 15px;
+
     &:before {
-        border-radius: 100%;
-        display: block;
-        float: left;
         content: '?';
-        border: 1px solid $color-grey-2;
-        color: $color-grey-2;
-        height: 15px;
-        width: 15px;
-        line-height: 15px;
-        text-align: center;
+        display: inline-block;
+        width: $size;
+        height: $size;
+        line-height: $size;
         font-size: 1.1em;
-        margin-left: -2em;
-        margin-top: 0.3em;
+        text-align: center;
+        border-radius: 100%;
+        color: $color-grey-2;
+        border: 1px solid currentColor;
     }
 }

--- a/wagtail/admin/static_src/wagtailadmin/scss/components/_streamfield.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/components/_streamfield.scss
@@ -22,10 +22,6 @@ li.sequence-member {
         }
     }
 
-    &:hover .object-help {
-        opacity: 1;
-    }
-
     .struct-block .fields {
         @include column(10);
         padding-left: 0;
@@ -85,6 +81,14 @@ li.sequence-member {
 
     .fields > li {
         position: relative;
+    }
+}
+
+.sequence-member__help {
+    opacity: 0;
+
+    .sequence-member:hover & {
+        opacity: 1;
     }
 }
 

--- a/wagtail/admin/static_src/wagtailadmin/scss/components/_streamfield.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/components/_streamfield.scss
@@ -90,6 +90,10 @@ li.sequence-member {
     .sequence-member:hover & {
         opacity: 1;
     }
+
+    .icon-help-inverse {
+        margin-right: 0.5em;
+    }
 }
 
 // Image chooser as direct descendant of top-level streamfield has special display

--- a/wagtail/admin/static_src/wagtailadmin/scss/components/_streamfield.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/components/_streamfield.scss
@@ -396,9 +396,3 @@ li.sequence-member {
         opacity: 1;
     }
 }
-
-@media screen and (min-width: $breakpoint-mobile) {
-    .object li.sequence-member:hover .object-help {
-        opacity: 1;
-    }
-}

--- a/wagtail/admin/static_src/wagtailadmin/scss/components/_streamfield.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/components/_streamfield.scss
@@ -220,10 +220,6 @@ li.sequence-member {
     height: auto;
 }
 
-.sequence-type-list .object-help {
-    margin-top: 1.5em;
-}
-
 // Menu of other blocks to be added at each position
 .stream-menu {
     @include transition(all 0.2s ease);

--- a/wagtail/admin/static_src/wagtailadmin/scss/layouts/page-editor.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/layouts/page-editor.scss
@@ -76,6 +76,12 @@ $object-title-height: 40px;
         padding-right: $grid-gutter-width / 2;
         padding-left: 3em;
         opacity: 1;
+
+        .icon-help-inverse {
+            float: left;
+            margin-left: -2em;
+            margin-top: 0.3em;
+        }
     }
 
     &:hover .object-help {

--- a/wagtail/admin/static_src/wagtailadmin/scss/layouts/page-editor.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/layouts/page-editor.scss
@@ -76,22 +76,6 @@ $object-title-height: 40px;
         padding-right: $grid-gutter-width / 2;
         padding-left: 3em;
         opacity: 1;
-
-        &:before {
-            border-radius: 100%;
-            display: block;
-            float: left;
-            content: '?';
-            border: 1px solid $color-grey-2;
-            color: $color-grey-2;
-            height: 15px;
-            width: 15px;
-            line-height: 15px;
-            text-align: center;
-            font-size: 1.1em;
-            margin-left: -2em;
-            margin-top: 0.3em;
-        }
     }
 
     &:hover .object-help {

--- a/wagtail/admin/static_src/wagtailadmin/scss/layouts/page-editor.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/layouts/page-editor.scss
@@ -175,10 +175,6 @@ $object-title-height: 40px;
 
     // Special full-width, one-off fields i.e a single text or textarea input
     &.full {
-        .object-help {
-            display: block;
-        }
-
         fieldset {
             display: block;
             float: none;

--- a/wagtail/admin/templates/wagtailadmin/block_forms/list.html
+++ b/wagtail/admin/templates/wagtailadmin/block_forms/list.html
@@ -5,7 +5,7 @@
 
 {% block header %}
     {% if help_text %}
-        <div class="object-help help">{{ help_text }}</div>
+        <div class="sequence-member__help help"><span class="icon-help-inverse" aria-hidden="true"></span>{{ help_text }}</div>
     {% endif %}
 {% endblock %}
 

--- a/wagtail/admin/templates/wagtailadmin/block_forms/struct.html
+++ b/wagtail/admin/templates/wagtailadmin/block_forms/struct.html
@@ -1,6 +1,6 @@
 <div class="{{ classname }}">
     {% if help_text %}
-        <div class="object-help help">{{ help_text }}</div>
+        <div class="sequence-member__help help"><span class="icon-help-inverse" aria-hidden="true"></span>{{ help_text }}</div>
     {% endif %}
 
     <ul class="fields">

--- a/wagtail/admin/templates/wagtailadmin/edit_handlers/object_list.html
+++ b/wagtail/admin/templates/wagtailadmin/edit_handlers/object_list.html
@@ -9,7 +9,7 @@
                 </h2>
             {% endif %}
             {% if child.help_text %}
-                <div class="object-help help">{{ child.help_text }}</div>
+                <div class="object-help help"><span class="icon-help-inverse" aria-hidden="true"></span>{{ child.help_text }}</div>
             {% endif %}
             {{ child.render_as_object }}
         </li>

--- a/wagtail/admin/tests/test_edit_handlers.py
+++ b/wagtail/admin/tests/test_edit_handlers.py
@@ -337,7 +337,7 @@ class TestObjectList(TestCase):
         self.assertInHTML('<h2><label for="id_date_from">Start date</label></h2>', result)
 
         # result should include help text for children
-        self.assertIn('<div class="object-help help">Not required if event is on a single day</div>', result)
+        self.assertIn('<div class="object-help help"><span class="icon-help-inverse" aria-hidden="true"></span>Not required if event is on a single day</div>', result)
 
         # result should contain rendered content from descendants
         self.assertIn('Abergavenny sheepdog trials</textarea>', result)

--- a/wagtail/core/tests/test_blocks.py
+++ b/wagtail/core/tests/test_blocks.py
@@ -1186,7 +1186,7 @@ class TestStructBlock(SimpleTestCase):
             'link': 'http://www.wagtail.io',
         }), prefix='mylink')
 
-        self.assertIn('<div class="object-help help">Self-promotion is encouraged</div>', html)
+        self.assertIn('<div class="sequence-member__help help"><span class="icon-help-inverse" aria-hidden="true"></span>Self-promotion is encouraged</div>', html)
 
         # check it can be overridden in the block constructor
         block = LinkBlock(help_text="Self-promotion is discouraged")
@@ -1195,7 +1195,7 @@ class TestStructBlock(SimpleTestCase):
             'link': 'http://www.wagtail.io',
         }), prefix='mylink')
 
-        self.assertIn('<div class="object-help help">Self-promotion is discouraged</div>', html)
+        self.assertIn('<div class="sequence-member__help help"><span class="icon-help-inverse" aria-hidden="true"></span>Self-promotion is discouraged</div>', html)
 
     def test_media_inheritance(self):
         class ScriptedCharBlock(blocks.CharBlock):


### PR DESCRIPTION
Fixes #4247 – regression introduced in https://github.com/wagtail/wagtail/commit/a03521f575265168da240fb5f7da106fcab2e755.

I removed some dead CSS, then split the styles in two. There are three cases I'm aware of:

- Help for full-width field, on the right.
- Help for struct block, at the top.
- Help for lists, at the top as well.

Rendering in Chrome (PR tested in Chrome/FF/Safari on macOS, IE11 & Edge16, Android & iOS):

![4247-full](https://user-images.githubusercontent.com/877585/36195214-708bed00-1175-11e8-879d-cc42ca0317f6.png)

![4247-full-mobile](https://user-images.githubusercontent.com/877585/36195218-7422f08a-1175-11e8-9334-c0e921440460.png)

![4247-streamfield](https://user-images.githubusercontent.com/877585/36195224-7779c498-1175-11e8-9198-793b374f9d2b.png)

![4247-streamfield-mobile](https://user-images.githubusercontent.com/877585/36195229-7abeea84-1175-11e8-87ff-c081d43f115e.png)
