### PR TITLE
Fix focal area removal not working in IE11 and MS Edge. Fix #4284

### DIFF
--- a/wagtail/images/static_src/wagtailimages/js/focal-point-chooser.js
+++ b/wagtail/images/static_src/wagtailimages/js/focal-point-chooser.js
@@ -80,10 +80,10 @@ $(function() {
         $image.removeAttr('style');
         $('.jcrop-holder').remove();
         $('.current-focal-point-indicator').remove();
-        fields.x.removeAttr('value');
-        fields.y.removeAttr('value');
-        fields.width.removeAttr('value');
-        fields.height.removeAttr('value');
+        fields.x.val('');
+        fields.y.val('');
+        fields.width.val('');
+        fields.height.val('');
         setupJcrop.apply(this, params);
     });
 });


### PR DESCRIPTION
Fixes #4284. I'm not entirely sure why the previous approach didn't work in IE11 and Edge, but that one does.

Steps to test this:

1. Open the image editor.
2. Add a focal area, hit "Save", go to the editor again, see the focal area is there.
3. Click "Remove focal area". See the image crop mask disappear.
4. Hit "Save", go to the editor again, see whether the focal area is still there.

Tested in IE11, MS Edge 16, latest Chrome/FF/Safari on macOS 10.13, Android Chrome 7, iOS Safari 10

Edit: changes are JS-only so I killed the Travis build.