### PR TITLE
Add ability to search redirect to links

### DIFF
--- a/wagtail/contrib/redirects/tests.py
+++ b/wagtail/contrib/redirects/tests.py
@@ -291,6 +291,12 @@ class TestRedirectsIndexView(TestCase, WagtailTestUtils):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context['query_string'], "Hello")
 
+    def test_search_results(self):
+        models.Redirect.objects.create(old_path="/aaargh", redirect_link="http://torchbox.com/")
+        models.Redirect.objects.create(old_path="/torchbox", redirect_link="http://aaargh.com/")
+        response = self.get({'q': "aaargh"})
+        self.assertEqual(len(response.context['redirects']), 2)
+
     def test_pagination(self):
         pages = ['0', '1', '-1', '9999', 'Not a page']
         for page in pages:

--- a/wagtail/contrib/redirects/views.py
+++ b/wagtail/contrib/redirects/views.py
@@ -24,7 +24,7 @@ def index(request):
 
     # Search
     if query_string:
-        redirects = redirects.filter(old_path__icontains=query_string)
+        redirects = redirects.filter(old_path__icontains=query_string, redirect_link__icontains=query_string)
 
     # Ordering (A bit useless at the moment as only 'old_path' is allowed)
     if ordering not in ['old_path']:

--- a/wagtail/contrib/redirects/views.py
+++ b/wagtail/contrib/redirects/views.py
@@ -2,6 +2,7 @@ from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils.translation import ugettext as _
 from django.views.decorators.vary import vary_on_headers
+from django.db.models import Q
 
 from wagtail.admin import messages
 from wagtail.admin.forms import SearchForm
@@ -24,7 +25,9 @@ def index(request):
 
     # Search
     if query_string:
-        redirects = redirects.filter(old_path__icontains=query_string, redirect_link__icontains=query_string)
+        redirects = redirects.filter(Q(old_path__icontains=query_string) |
+                                     Q(redirect_page__url_path__icontains=query_string) |
+                                     Q(redirect_link__icontains=query_string))
 
     # Ordering (A bit useless at the moment as only 'old_path' is allowed)
     if ordering not in ['old_path']:


### PR DESCRIPTION
Currently, when you search in redirects, it only returns items based on the old path. This adds a filter to the search for the redirected to link as well.