### PR TITLE
Tutorial should refer to 'Pages', not 'Explorer'

### DIFF
--- a/docs/getting_started/tutorial.rst
+++ b/docs/getting_started/tutorial.rst
@@ -90,7 +90,7 @@ Run ``python manage.py makemigrations``, then
 changes. You must run the above commands each time you make changes to
 the model definition.
 
-You can now edit the homepage within the Wagtail admin area (go to Explorer, Homepage, then Edit) to see the new body field. Enter some text into the body field, and publish the page.
+You can now edit the homepage within the Wagtail admin area (go to Pages, Homepage, then Edit) to see the new body field. Enter some text into the body field, and publish the page.
 
 The page template now needs to be updated to reflect the changes made
 to the model. Wagtail uses normal Django templates to render each page


### PR DESCRIPTION
The tutorial still refers to 'Explorer', but the menu label was changed to 'Pages' when the React explorer was introduced.