### PR TITLE
Fix Draftail initialising on the wrong elt – fix #4295

### DIFF
--- a/client/src/components/Draftail/index.js
+++ b/client/src/components/Draftail/index.js
@@ -43,11 +43,14 @@ export const wrapWagtailIcon = type => {
 
 /**
  * Initialises the DraftailEditor for a given field.
- * @param {string} fieldName
+ * @param {string} selector
  * @param {Object} options
+ * @param {Element} currentScript
  */
-const initEditor = (fieldName, options) => {
-  const field = document.querySelector(`[name="${fieldName}"]`);
+const initEditor = (selector, options, currentScript) => {
+  // document.currentScript is not available in IE11. Use a fallback instead.
+  const context = currentScript ? currentScript.parentNode : document.body;
+  const field = context.querySelector(selector);
 
   const editorWrapper = document.createElement('div');
   editorWrapper.className = 'Draftail-Editor__wrapper';

--- a/wagtail/admin/rich_text/editors/draftail/__init__.py
+++ b/wagtail/admin/rich_text/editors/draftail/__init__.py
@@ -52,8 +52,8 @@ class DraftailRichTextArea(WidgetWithScript, widgets.HiddenInput):
         return super().render(name, translated_value, attrs)
 
     def render_js_init(self, id_, name, value):
-        return "window.draftail.initEditor('{name}', {opts})".format(
-            name=name, opts=json.dumps(self.options))
+        return "window.draftail.initEditor('#{id}', {opts}, document.currentScript)".format(
+            id=id_, opts=json.dumps(self.options))
 
     def value_from_datadict(self, data, files, name):
         original_value = super().value_from_datadict(data, files, name)

--- a/wagtail/admin/tests/test_rich_text.py
+++ b/wagtail/admin/tests/test_rich_text.py
@@ -102,7 +102,7 @@ class TestDefaultRichText(BaseRichTextEditHandlerTestCase, WagtailTestUtils):
         self.assertEqual(response.status_code, 200)
 
         # Check that draftail (default editor) initialisation is applied
-        self.assertContains(response, "window.draftail.initEditor('body',")
+        self.assertContains(response, "window.draftail.initEditor('#id_body',")
 
         # check that media for draftail is being imported
         self.assertContains(response, 'wagtailadmin/js/draftail.js')
@@ -121,7 +121,7 @@ class TestDefaultRichText(BaseRichTextEditHandlerTestCase, WagtailTestUtils):
         self.assertEqual(response.status_code, 200)
 
         # Check that draftail (default editor) initialisation is applied
-        self.assertContains(response, "window.draftail.initEditor('__PREFIX__-value',")
+        self.assertContains(response, "window.draftail.initEditor('#__PREFIX__-value',")
 
         # check that media for draftail is being imported
         self.assertContains(response, 'wagtailadmin/js/draftail.js')


### PR DESCRIPTION
Fixes #4295. Compared to the previous implementation,

- The field's `id` attribute is used, not name.
- For all browsers except IE11, the field is targeted within the parent of the calling script via `document.currentScript.parentNode`.
- For IE11, the field is targeted within the page `<body>`.

I have added unit tests for a few conflicting scenarios, and tested manually in Chrome/FF/Safari on macOS 10.13, IE11, MS Edge, Android Chrome, iOS Safari.