### PR TITLE
Add JS source maps in production build for packaged Wagtail

### DIFF
--- a/client/webpack/base.config.js
+++ b/client/webpack/base.config.js
@@ -67,6 +67,10 @@ module.exports = function exports() {
         };
       }))
     },
+
+    // See https://webpack.js.org/configuration/devtool/.
+    devtool: 'source-map',
+
     stats: {
       // Add chunk information (setting this to `false` allows for a less verbose output)
       chunks: false,

--- a/client/webpack/dev.config.js
+++ b/client/webpack/dev.config.js
@@ -13,9 +13,6 @@ config.watchOptions = {
   aggregateTimeout: 300,
 };
 
-// See http://webpack.github.io/docs/configuration.html#devtool
-config.devtool = 'inline-source-map';
-
 // Set process.env.NODE_ENV to development to enable JS development aids.
 config.plugins.push(new webpack.DefinePlugin({
   'process.env': {

--- a/client/webpack/prod.config.js
+++ b/client/webpack/prod.config.js
@@ -12,6 +12,8 @@ config.plugins.push(new webpack.DefinePlugin({
 
 // See https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/config/webpack.config.prod.js.
 config.plugins.push(new webpack.optimize.UglifyJsPlugin({
+  sourceMap: true,
+
   compress: {
     screw_ie8: true,
     warnings: false


### PR DESCRIPTION
Discussed in #4295. Switches from dev-only inline source maps to external source maps for all builds.

At the moment this adds the following three files:

```
Time: 11957ms
                                                   Asset     Size  Chunks             Chunk Names
        wagtail/admin/static/wagtailadmin/js/draftail.js   247 kB       0  [emitted]  wagtail/admin/static/wagtailadmin/js/draftail
    wagtail/admin/static/wagtailadmin/js/wagtailadmin.js  56.5 kB       1  [emitted]  wagtail/admin/static/wagtailadmin/js/wagtailadmin
          wagtail/admin/static/wagtailadmin/js/vendor.js   192 kB       2  [emitted]  vendor
    wagtail/admin/static/wagtailadmin/js/draftail.js.map     2 MB       0  [emitted]  wagtail/admin/static/wagtailadmin/js/draftail
wagtail/admin/static/wagtailadmin/js/wagtailadmin.js.map   426 kB       1  [emitted]  wagtail/admin/static/wagtailadmin/js/wagtailadmin
      wagtail/admin/static/wagtailadmin/js/vendor.js.map   1.1 MB       2  [emitted]  vendor
   585 modules
```

They are quite big, but compressed it's not as bad:

```
444K	wagtail/admin/static/wagtailadmin/js/draftail.js.map.gz
280K	wagtail/admin/static/wagtailadmin/js/vendor.js.map.gz
104K	wagtail/admin/static/wagtailadmin/js/wagtailadmin.js.map.gz
```

Tested in Chrome. The source maps load only if the devtools are open AFAIK.

Edit: killed the Travis build myself.