### PR TITLE
Exclude the error messages from the count of inline panel elements

### DIFF
--- a/wagtail/admin/static_src/wagtailadmin/js/page-editor.js
+++ b/wagtail/admin/static_src/wagtailadmin/js/page-editor.js
@@ -188,7 +188,7 @@ function InlinePanel(opts) {
 
     self.updateAddButtonState = function() {
         if (opts.maxForms) {
-            var forms = $('> li', self.formsUl).not('.deleted');
+            var forms = $('> li', self.formsUl).not('.deleted').not('.error-message');
             var addButton = $('#' + opts.formsetPrefix + '-ADD');
 
             if (forms.length >= opts.maxForms) {


### PR DESCRIPTION
When error messages are added to inline panels they are counted the same as an inline panel child element for purposes of calculating the maximum number of elements for that panel. 

This PR excludes `.error-message` from the count.

see: https://github.com/wagtail/wagtail/blob/5300b01fc4b797e355e1d08b6805b5ce5f8c45bd/wagtail/admin/templates/wagtailadmin/edit_handlers/inline_panel.html#L6-L18