### PR TITLE
Add Draftail init fallback for StreamField/InlinePanel templated fields. Fix #4295 (again)

### DIFF
--- a/client/src/components/Draftail/index.js
+++ b/client/src/components/Draftail/index.js
@@ -50,7 +50,9 @@ export const wrapWagtailIcon = type => {
 const initEditor = (selector, options, currentScript) => {
   // document.currentScript is not available in IE11. Use a fallback instead.
   const context = currentScript ? currentScript.parentNode : document.body;
-  const field = context.querySelector(selector);
+  // If the field is not in the current context, look for it in the whole body.
+  // Fallback for sequence.js jQuery eval-ed scripts running in document.head.
+  const field = context.querySelector(selector) || document.body.querySelector(selector);
 
   const editorWrapper = document.createElement('div');
   editorWrapper.className = 'Draftail-Editor__wrapper';

--- a/client/src/components/Draftail/index.test.js
+++ b/client/src/components/Draftail/index.test.js
@@ -88,6 +88,18 @@ describe('Draftail', () => {
 
         expect(document.querySelector('[name="last"]').draftailEditor).toBeDefined();
       });
+
+      it('uses fallback document.body when currentScript context is wrong', () => {
+        window.draftail = draftail;
+        document.body.innerHTML = `
+        <input id="description" value="null" />
+          <div>
+          <script>window.draftail.initEditor('#description', {}, document.currentScript);</script>
+          </div>
+        `;
+
+        expect(document.querySelector('#description').draftailEditor).toBeDefined();
+      });
     });
   });
 


### PR DESCRIPTION
Fixes the case of StreamField and InlinePanel rich text fields not initialising: https://github.com/wagtail/wagtail/issues/4295#issuecomment-367780336 (sorry about that @gasman, I thought I would have tested that but apparently not).

I hesitated to simply remove the `document.currentScript` extra check, but I think it will prevent errors down the line. Instead I added a fallback to look for fields in the whole `<body>` if the script context isn't helpful.

Edit: tested in Chrome/FF/Safari on macOS 10.13, IE11, MS Edge, Android Chrome, iOS Safari, but only in StreamField, not inline panels.