### PR TITLE
Fix Wagtail 2.0 Paths

### DIFF
--- a/docs/reference/contrib/forms/customisation.rst
+++ b/docs/reference/contrib/forms/customisation.rst
@@ -563,7 +563,7 @@ Finally, we add a URL param of `id` based on the ``form_submission`` if it exist
 .. code-block:: python
 
     from django.shortcuts import redirect
-    from wagtail.wagtailadmin.edit_handlers import (
+    from wagtail.admin.edit_handlers import (
         FieldPanel, FieldRowPanel, InlinePanel, MultiFieldPanel, PageChooserPanel)
     from wagtail.contrib.forms.models import AbstractEmailForm
 

--- a/wagtail/admin/rich_text/editors/draftail/features.py
+++ b/wagtail/admin/rich_text/editors/draftail/features.py
@@ -1,5 +1,5 @@
 # Feature objects: these are mapped to feature identifiers within the rich text
-# feature registry (wagtail.wagtailcore.rich_text.features). Each one implements
+# feature registry (wagtail.core.rich_text.features). Each one implements
 # a `construct_options` method which modifies an options dict as appropriate to
 # enable that feature.
 

--- a/wagtail/search/tests/test_page_search.py
+++ b/wagtail/search/tests/test_page_search.py
@@ -3,8 +3,8 @@ from __future__ import absolute_import, unicode_literals
 from django.conf import settings
 from django.test import TestCase
 
-from wagtail.wagtailcore.models import Page
-from wagtail.wagtailsearch.backends import get_search_backend
+from wagtail.core.models import Page
+from wagtail.search.backends import get_search_backend
 
 
 class PageSearchTests(object):

--- a/wagtail/search/views/frontend.py
+++ b/wagtail/search/views/frontend.py
@@ -24,7 +24,7 @@ def search(
 
     warnings.warn(
         "Wagtail's builtin search view "
-        "(wagtail.wagtailsearch.views.frontend.search) is deprecated and will "
+        "(wagtail.search.views.frontend.search) is deprecated and will "
         "be removed in a future release",
         category=RemovedInWagtail22Warning
     )


### PR DESCRIPTION
While upgrading some plugins to Wagtail 2.0, I accidentally run the `wagtail updatemodulepaths` against my virtual environment and realised that some files were updated too.

Also for some reasons, `wagtail/wagtailsearch/tests/test_page_search.py` ended up not being moved to `wagtail/search`.

Edit: Also used `grep -RF --exclude-dir=releases wagtail.wagtail ./docs/` to check the documentation.