### PR TITLE
Prevents accounts leak through the password reset form.

### DIFF
--- a/wagtail/admin/forms.py
+++ b/wagtail/admin/forms.py
@@ -2,7 +2,6 @@ import copy
 from itertools import groupby
 
 from django import forms
-from django.contrib.auth import get_user_model
 from django.contrib.auth.forms import AuthenticationForm, PasswordResetForm
 from django.contrib.auth.models import Group, Permission
 from django.core import validators
@@ -85,36 +84,9 @@ class LoginForm(AuthenticationForm):
 
 
 class PasswordResetForm(PasswordResetForm):
-    email = forms.EmailField(label=ugettext_lazy("Enter your email address to reset your password"), max_length=254)
-
-    def clean(self):
-        cleaned_data = super().clean()
-
-        # Find users of this email address
-        UserModel = get_user_model()
-        email = cleaned_data.get('email')
-        if not email:
-            raise forms.ValidationError(_("Please fill your email address."))
-        active_users = UserModel._default_manager.filter(email__iexact=email, is_active=True)
-
-        if active_users.exists():
-            # Check if all users of the email address are LDAP users (and give an error if they are)
-            found_non_ldap_user = False
-            for user in active_users:
-                if user.has_usable_password():
-                    found_non_ldap_user = True
-                    break
-
-            if not found_non_ldap_user:
-                # All found users are LDAP users, give error message
-                raise forms.ValidationError(
-                    _("Sorry, you cannot reset your password here as your user account is managed by another server.")
-                )
-        else:
-            # No user accounts exist
-            raise forms.ValidationError(_("This email address is not recognised."))
-
-        return cleaned_data
+    email = forms.EmailField(
+        label=ugettext_lazy("Enter your email address to reset your password"),
+        max_length=254, required=True)
 
 
 class CopyForm(forms.Form):

--- a/wagtail/admin/templates/wagtailadmin/account/password_reset/done.html
+++ b/wagtail/admin/templates/wagtailadmin/account/password_reset/done.html
@@ -12,6 +12,6 @@
 {% block furniture %}
     <div class="content-wrapper">
         <h1>{% trans "Check your email" %}</h1>
-        <p>{% trans "A link to reset your password has been emailed to you." %}</p>
+        <p>{% trans "A link to reset your password has been emailed to you if an account exists for this address." %}</p>
     </div>
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/account/password_reset/form.html
+++ b/wagtail/admin/templates/wagtailadmin/account/password_reset/form.html
@@ -30,6 +30,13 @@
                     <div class="field">
                         {{ form.email.label_tag }}
                         {{ form.email }}
+                        <div class="messages">
+                            <ul>
+                                {% for error in form.email.errors %}
+                                    <li class="error">{{ error }}</li>
+                                {% endfor %}
+                            </ul>
+                        </div>
                     </div>
                 </li>
                 <li class="submit">

--- a/wagtail/admin/tests/test_account_management.py
+++ b/wagtail/admin/tests/test_account_management.py
@@ -468,12 +468,9 @@ class TestPasswordReset(TestCase, WagtailTestUtils):
         }
         response = self.client.post(reverse('wagtailadmin_password_reset'), post_data)
 
-        # Check that the user wasn't redirected
-        self.assertEqual(response.status_code, 200)
-
-        # Check that a validation error was raised
-        self.assertTrue('__all__' in response.context['form'].errors.keys())
-        self.assertTrue("This email address is not recognised." in response.context['form'].errors['__all__'])
+        # Check that the user was redirected to the done page
+        self.assertRedirects(response,
+                             reverse('wagtailadmin_password_reset_done'))
 
         # Check that an email was not sent
         self.assertEqual(len(mail.outbox), 0)


### PR DESCRIPTION
This pull request fixes #4191.

It also displays an error on invalid e-mail submit.

Note that the message `Sorry, you cannot reset your password here as your user account is managed by another server.` is no longer displayed if the site has no user with a usable password. This is normal for two reasons:
- [as mentioned in the docs](http://docs.wagtail.io/en/v1.13.1/advanced_topics/settings.html#password-management), developers should disable password management when passwords are handled externally
- assuming that a site with unusable passwords only handles password externally is logically wrong and can mislead beginner devs