### PR TITLE
[WIP] Upgrade to latest Draftail, perf, a11y, and extension APIs

### DIFF
--- a/client/src/components/Draftail/index.js
+++ b/client/src/components/Draftail/index.js
@@ -17,13 +17,25 @@ export { default as ModalWorkflowSource } from './sources/ModalWorkflowSource';
 const BR_ICON = 'M.436 633.471l296.897-296.898v241.823h616.586V94.117h109.517v593.796H297.333v242.456z';
 
 /**
- * Registry for client-side code of Draftail plugins.
+ * Registry for client-side code of Draftail extensions.
  */
 const PLUGINS = {};
+const DECORATORS = [];
+const CONTROLS = [];
 
 const registerPlugin = (plugin) => {
   PLUGINS[plugin.type] = plugin;
   return PLUGINS;
+};
+
+const registerDecorator = (decorator) => {
+  DECORATORS.push(decorator);
+  return DECORATORS;
+};
+
+const registerControl = (control) => {
+  CONTROLS.push(control);
+  return CONTROLS;
 };
 
 /**
@@ -101,6 +113,8 @@ const initEditor = (selector, options, currentScript) => {
       inlineStyles={inlineStyles.map(wrapWagtailIcon)}
       entityTypes={entityTypes}
       enableHorizontalRule={enableHorizontalRule}
+      decorators={DECORATORS}
+      controls={CONTROLS}
     />
   );
 
@@ -110,7 +124,11 @@ const initEditor = (selector, options, currentScript) => {
   field.draftailEditor = draftailEditor;
 };
 
-export default {
+const draftail = {
   initEditor,
   registerPlugin,
+  registerDecorator,
+  registerControl,
 };
+
+export default draftail;

--- a/client/src/components/Draftail/index.test.js
+++ b/client/src/components/Draftail/index.test.js
@@ -133,6 +133,29 @@ describe('Draftail', () => {
     });
   });
 
+  describe('#registerDecorator', () => {
+    it('works', () => {
+      const decorator = {
+        component: () => {},
+        strategy: () => {},
+      };
+
+      expect(draftail.registerDecorator(decorator)).toEqual([
+        decorator,
+      ]);
+    });
+  });
+
+  describe('#registerControl', () => {
+    it('works', () => {
+      const control = () => {};
+
+      expect(draftail.registerControl(control)).toEqual([
+        control,
+      ]);
+    });
+  });
+
   it('#ModalWorkflowSource', () => expect(ModalWorkflowSource).toBeDefined());
   it('#Link', () => expect(Link).toBeDefined());
   it('#Document', () => expect(Document).toBeDefined());

--- a/docs/advanced_topics/customisation/extending_draftail.rst
+++ b/docs/advanced_topics/customisation/extending_draftail.rst
@@ -1,9 +1,9 @@
 Extending the Draftail Editor
 =============================
 
-Wagtail’s rich text editor is built with `Draftail <https://github.com/springload/draftail>`_, and its functionality can be extended through plugins.
+Wagtail’s rich text editor is built with `Draftail <https://github.com/springload/draftail>`_, and its formatting can be extended through plugins.
 
-Plugins come in three types:
+Formatting plugins come in three types:
 
 * Inline styles – To format a portion of a line, eg. ``bold``, ``italic``, ``monospace``.
 * Blocks – To indicate the structure of the content, eg. ``blockquote``, ``ol``.
@@ -335,11 +335,42 @@ To fully complete the demo, we can add a bit of JavaScript to the front-end in o
 
 Custom block entities can also be created (have a look at the separate `Draftail <https://github.com/springload/draftail>`_ documentation), but these are not detailed here since :ref:`StreamField <streamfield>` is the go-to way to create block-level rich text in Wagtail.
 
+Extending the editor beyond content formats
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. warning::
+    The following APIs are meant for third-party packages extending the editor. They are very advanced and assume `Draft.js <https://draftjs.org/>`_ knowledge.
+
 Integration of the Draftail widgets
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-----------------------------------
 
 To further customise how the Draftail widgets are integrated into the UI, there are additional extension points for CSS and JS:
 
 * In JavaScript, use the ``[data-draftail-input]`` attribute selector to target the input which contains the data, and ``[data-draftail-editor-wrapper]`` for the element which wraps the editor.
 * The editor instance is bound on the input field for imperative access. Use ``document.querySelector('[data-draftail-input]').draftailEditor``.
 * In CSS, use the classes prefixed with ``Draftail-``.
+
+Custom decorators
+-----------------
+
+Draftail supports registering `decorators <https://draftjs.org/docs/advanced-topics-decorators.html#compositedecorator>`_ with a custom ``component`` and ``strategy``.
+
+.. code-block:: javascript
+
+    window.draftail.registerDecorator({
+        component: HashtagSpan,
+        strategy: hashtagStrategy,
+    });
+
+This can be useful to build spellcheck features, syntax highlighting, autocompletion, or any other editing aid or IME-like interface.
+
+Custom toolbar controls
+-----------------------
+
+You can also register custom `toolbar controls <https://github.com/springload/draftail#other-controls>`_, which have full read/write access to the editor state.
+
+.. code-block:: javascript
+
+    window.draftail.registerControl(ReadingTime);
+
+Those custom controls can display metrics about the content (eg. reading time or readability), or provide advanced features like “paste from Word”, “clear all formatting”, and the likes.


### PR DESCRIPTION
Addresses the image block removal with the "Remove" button from #4296 by updating Draftail.

The new version also:

- Performs a bit better when typing in the editor.
- Addresses some accessibility issues with the editor.

While at it I also added new Draftail extension APIs. Wagtail doesn't use them but they will be useful for future extensions / extensions supporting Hallo and wishing to support Draftail. Edit: they aren't hooked up to the rich text features at the moment – not sure whether they should be, or how exactly.

~I'd like to add a few more things before this is merged:~

* ~[ ] Use the new `ariaDescribedBy` editor prop to point at the field's label, if possible.~
* ~[ ] Add error handling, and an error recovery UI, to the editor.~