### PR TITLE
Add error handling component to Draftail

### DIFF
--- a/client/src/components/Draftail/Draftail.scss
+++ b/client/src/components/Draftail/Draftail.scss
@@ -17,6 +17,7 @@ $draftail-editor-font-family: $font-serif;
 @import '../../../../node_modules/draftail/lib/index';
 
 @import './Tooltip/Tooltip';
+@import './EditorFallback/EditorFallback';
 
 @import './decorators/TooltipEntity';
 

--- a/client/src/components/Draftail/EditorFallback/EditorFallback.js
+++ b/client/src/components/Draftail/EditorFallback/EditorFallback.js
@@ -61,11 +61,31 @@ class EditorFallback extends PureComponent {
   renderError() {
     const { field } = this.props;
     const { error, info, reloads, showContent, showError } = this.state;
-    const content = field.rawContentState && convertFromRaw(field.rawContentState).getPlainText();
+    const content =
+      field.rawContentState &&
+      convertFromRaw(field.rawContentState).getPlainText();
 
     return (
       <div className="Draftail-Editor">
         <div className="Draftail-Toolbar">
+          {content && (
+            <button
+              type="button"
+              className="Draftail-ToolbarButton"
+              onClick={this.toggleContent}
+            >
+              {STRINGS.SHOW_LATEST_CONTENT}
+            </button>
+          )}
+
+          <button
+            type="button"
+            className="Draftail-ToolbarButton"
+            onClick={this.toggleError}
+          >
+            {'Show error'}
+          </button>
+
           {/* At first we propose reloading the editor. If it still crashes, reload the whole page. */}
           {reloads < MAX_EDITOR_RELOADS ? (
             <button
@@ -82,24 +102,6 @@ class EditorFallback extends PureComponent {
               onClick={() => window.location.reload(false)}
             >
               {STRINGS.RELOAD_PAGE}
-            </button>
-          )}
-
-          <button
-            type="button"
-            className="Draftail-ToolbarButton"
-            onClick={this.toggleError}
-          >
-            {'Show error'}
-          </button>
-
-          {content && (
-            <button
-              type="button"
-              className="Draftail-ToolbarButton"
-              onClick={this.toggleContent}
-            >
-              {STRINGS.SHOW_LATEST_CONTENT}
             </button>
           )}
         </div>
@@ -120,7 +122,7 @@ class EditorFallback extends PureComponent {
         {showError && (
           <pre className="help-block help-critical">
             <code className="EditorFallback__error">
-            {`${error.stack}\n${info.componentStack}`}
+              {`${error.stack}\n${info.componentStack}`}
             </code>
           </pre>
         )}

--- a/client/src/components/Draftail/EditorFallback/EditorFallback.js
+++ b/client/src/components/Draftail/EditorFallback/EditorFallback.js
@@ -138,6 +138,7 @@ class EditorFallback extends PureComponent {
 
 EditorFallback.propTypes = {
   children: PropTypes.node.isRequired,
+  field: PropTypes.object.isRequired,
 };
 
 export default EditorFallback;

--- a/client/src/components/Draftail/EditorFallback/EditorFallback.js
+++ b/client/src/components/Draftail/EditorFallback/EditorFallback.js
@@ -107,25 +107,28 @@ class EditorFallback extends PureComponent {
         </div>
 
         <div className="DraftEditor-root">
-          <div className="public-DraftEditorPlaceholder-inner">
-            {STRINGS.EDITOR_CRASH}
+          <div className="public-DraftEditor-content">
+            <div className="public-DraftEditorPlaceholder-inner">
+              {STRINGS.EDITOR_CRASH}
+
+              {showContent && (
+                <textarea
+                  className="EditorFallback__textarea"
+                  value={content}
+                  readOnly
+                />
+              )}
+
+              {showError && (
+                <pre className="help-block help-critical">
+                  <code className="EditorFallback__error">
+                    {`${error.stack}\n${info.componentStack}`}
+                  </code>
+                </pre>
+              )}
+            </div>
           </div>
         </div>
-
-        {showContent && (
-          <textarea
-            className="EditorFallback__textarea"
-            value={content}
-            readOnly
-          />
-        )}
-        {showError && (
-          <pre className="help-block help-critical">
-            <code className="EditorFallback__error">
-              {`${error.stack}\n${info.componentStack}`}
-            </code>
-          </pre>
-        )}
       </div>
     );
   }

--- a/client/src/components/Draftail/EditorFallback/EditorFallback.js
+++ b/client/src/components/Draftail/EditorFallback/EditorFallback.js
@@ -14,21 +14,24 @@ class EditorFallback extends PureComponent {
 
     this.state = {
       error: null,
+      info: null,
       reloads: 0,
-      isContentShown: false,
+      showContent: false,
+      showError: false,
       initialContent: field.value,
     };
 
     this.renderError = this.renderError.bind(this);
     this.toggleContent = this.toggleContent.bind(this);
+    this.toggleError = this.toggleError.bind(this);
     this.onReloadEditor = this.onReloadEditor.bind(this);
   }
 
-  componentDidCatch(error) {
+  componentDidCatch(error, info) {
     const { field } = this.props;
     const { initialContent } = this.state;
 
-    this.setState({ error });
+    this.setState({ error, info });
 
     field.value = initialContent;
   }
@@ -38,18 +41,26 @@ class EditorFallback extends PureComponent {
 
     this.setState({
       error: null,
+      info: null,
       reloads: reloads + 1,
+      showContent: false,
+      showError: false,
     });
   }
 
   toggleContent() {
-    const { isContentShown } = this.state;
-    this.setState({ isContentShown: !isContentShown });
+    const { showContent } = this.state;
+    this.setState({ showContent: !showContent });
+  }
+
+  toggleError() {
+    const { showError } = this.state;
+    this.setState({ showError: !showError });
   }
 
   renderError() {
     const { field } = this.props;
-    const { reloads, isContentShown } = this.state;
+    const { error, info, reloads, showContent, showError } = this.state;
     const content = field.rawContentState && convertFromRaw(field.rawContentState).getPlainText();
 
     return (
@@ -74,6 +85,14 @@ class EditorFallback extends PureComponent {
             </button>
           )}
 
+          <button
+            type="button"
+            className="Draftail-ToolbarButton"
+            onClick={this.toggleError}
+          >
+            {'Show error'}
+          </button>
+
           {content && (
             <button
               type="button"
@@ -84,17 +103,26 @@ class EditorFallback extends PureComponent {
             </button>
           )}
         </div>
+
         <div className="DraftEditor-root">
           <div className="public-DraftEditorPlaceholder-inner">
             {STRINGS.EDITOR_CRASH}
           </div>
         </div>
-        {isContentShown && (
+
+        {showContent && (
           <textarea
             className="EditorFallback__textarea"
             value={content}
             readOnly
           />
+        )}
+        {showError && (
+          <pre className="help-block help-critical">
+            <code className="EditorFallback__error">
+            {`${error.stack}\n${info.componentStack}`}
+            </code>
+          </pre>
         )}
       </div>
     );

--- a/client/src/components/Draftail/EditorFallback/EditorFallback.js
+++ b/client/src/components/Draftail/EditorFallback/EditorFallback.js
@@ -83,7 +83,7 @@ class EditorFallback extends PureComponent {
             className="Draftail-ToolbarButton"
             onClick={this.toggleError}
           >
-            {'Show error'}
+            {STRINGS.SHOW_ERROR}
           </button>
 
           {/* At first we propose reloading the editor. If it still crashes, reload the whole page. */}
@@ -122,7 +122,7 @@ class EditorFallback extends PureComponent {
               {showError && (
                 <pre className="help-block help-critical">
                   <code className="EditorFallback__error">
-                    {`${error.stack}\n${info.componentStack}`}
+                    {`${error.name}: ${error.message}\n\n${error.stack}\n${info.componentStack}`}
                   </code>
                 </pre>
               )}

--- a/client/src/components/Draftail/EditorFallback/EditorFallback.js
+++ b/client/src/components/Draftail/EditorFallback/EditorFallback.js
@@ -1,0 +1,86 @@
+import PropTypes from 'prop-types';
+import React, { PureComponent } from 'react';
+import { convertFromRaw } from 'draft-js';
+
+import { STRINGS } from '../../../config/wagtailConfig';
+
+class EditorFallback extends PureComponent {
+  constructor(props) {
+    super(props);
+
+    const { field } = props;
+
+    this.state = {
+      error: null,
+      isContentShown: false,
+      initialContent: field.value,
+    };
+
+    this.renderError = this.renderError.bind(this);
+    this.toggleContent = this.toggleContent.bind(this);
+  }
+
+  componentDidCatch(error) {
+    const { field } = this.props;
+    const { initialContent } = this.state;
+
+    this.setState({ error });
+
+    field.value = initialContent;
+  }
+
+  toggleContent() {
+    const { isContentShown } = this.state;
+    this.setState({ isContentShown: !isContentShown });
+  }
+
+  renderError() {
+    const { field } = this.props;
+    const { isContentShown } = this.state;
+    const content = field.rawContentState && convertFromRaw(field.rawContentState).getPlainText();
+
+    return (
+      <div className="Draftail-Editor">
+        <div className="Draftail-Toolbar">
+          <button
+            type="button"
+            className="Draftail-ToolbarButton"
+            onClick={() => window.location.reload(false)}
+          >
+            {STRINGS.RELOAD_PAGE}
+          </button>
+          {content && (
+            <button
+              type="button"
+              className="Draftail-ToolbarButton"
+              onClick={this.toggleContent}
+            >
+              {STRINGS.SHOW_LATEST_CONTENT}
+            </button>
+          )}
+        </div>
+        <div className="DraftEditor-root">
+          <div className="public-DraftEditorPlaceholder-inner">
+            {STRINGS.EDITOR_CRASH}
+          </div>
+        </div>
+        {isContentShown && (
+          <textarea className="EditorFallback__textarea" value={content} readOnly />
+        )}
+      </div>
+    );
+  }
+
+  render() {
+    const { children } = this.props;
+    const { error } = this.state;
+
+    return error ? this.renderError() : children;
+  }
+}
+
+EditorFallback.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+export default EditorFallback;

--- a/client/src/components/Draftail/EditorFallback/EditorFallback.scss
+++ b/client/src/components/Draftail/EditorFallback/EditorFallback.scss
@@ -1,6 +1,19 @@
 .EditorFallback__textarea {
-    resize: vertical;
     min-height: 150px;
+    margin-top: 1rem;
+    resize: vertical;
+}
+
+// Override over-reaching styles definition for all textareas in full fields.
+@mixin wagtail-textarea-overrides {
+    padding: 1rem;
+    border-width: 1px;
+    border-radius: 6px;
+}
+
+.EditorFallback__textarea,
+.object.full .EditorFallback__textarea {
+    @include wagtail-textarea-overrides;
 }
 
 .EditorFallback__error {

--- a/client/src/components/Draftail/EditorFallback/EditorFallback.scss
+++ b/client/src/components/Draftail/EditorFallback/EditorFallback.scss
@@ -1,0 +1,4 @@
+.EditorFallback__textarea {
+    resize: vertical;
+    min-height: 150px;
+}

--- a/client/src/components/Draftail/EditorFallback/EditorFallback.scss
+++ b/client/src/components/Draftail/EditorFallback/EditorFallback.scss
@@ -2,3 +2,8 @@
     resize: vertical;
     min-height: 150px;
 }
+
+.EditorFallback__error {
+    background: none;
+    box-shadow: none;
+}

--- a/client/src/components/Draftail/EditorFallback/EditorFallback.test.js
+++ b/client/src/components/Draftail/EditorFallback/EditorFallback.test.js
@@ -1,0 +1,145 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import EditorFallback from './EditorFallback';
+
+describe('EditorFallback', () => {
+  it('works', () => {
+    expect(
+      shallow(
+        <EditorFallback field={document.createElement('input')}>
+          test
+        </EditorFallback>
+      )
+    ).toMatchSnapshot();
+  });
+
+  it('#componentDidCatch', () => {
+    const field = document.createElement('input');
+    field.value = 'test value';
+
+    const wrapper = shallow(
+      <EditorFallback field={field}>test</EditorFallback>
+    );
+
+    field.value = 'new test value';
+
+    const error = new Error('test');
+    const info = { componentStack: 'test' };
+
+    wrapper.instance().componentDidCatch(error, info);
+
+    expect(wrapper.state('error')).toBe(error);
+    expect(wrapper.state('info')).toBe(info);
+    expect(field.value).toBe('test value');
+  });
+
+  describe('#error', () => {
+    it('works', () => {
+      const wrapper = shallow(
+        <EditorFallback field={document.createElement('input')}>
+          test
+        </EditorFallback>
+      );
+
+      wrapper.setState({
+        error: new Error('test'),
+      });
+
+      expect(wrapper).toMatchSnapshot();
+    });
+
+    it('reload', () => {
+      const wrapper = shallow(
+        <EditorFallback field={document.createElement('input')}>
+          test
+        </EditorFallback>
+      );
+
+      wrapper
+        .setState({
+          error: new Error('test'),
+        })
+        .find('button')
+        .first()
+        .simulate('click');
+
+      expect(wrapper).toMatchSnapshot();
+    });
+
+    it('reload page', () => {
+      window.location.reload = jest.fn();
+
+      const wrapper = shallow(
+        <EditorFallback field={document.createElement('input')}>
+          test
+        </EditorFallback>
+      );
+
+      wrapper
+        .setState({
+          error: new Error('test'),
+          reloads: 3,
+        })
+        .find('button')
+        .first()
+        .simulate('click');
+
+      expect(window.location.reload).toHaveBeenCalled();
+    });
+
+    it('#showError', () => {
+      const wrapper = shallow(
+        <EditorFallback field={document.createElement('input')}>
+          test
+        </EditorFallback>
+      );
+
+      const error = new Error('test');
+
+      error.stack = 'test stack';
+
+      wrapper
+        .setState({
+          error: error,
+          info: { componentStack: 'test' },
+        })
+        .find('button')
+        .last()
+        .simulate('click');
+
+      expect(wrapper).toMatchSnapshot();
+    });
+
+    it('#showContent', () => {
+      const field = document.createElement('input');
+      field.rawContentState = {
+        entityMap: {},
+        blocks: [
+          {
+            key: 'a',
+            text: 'test',
+          },
+        ],
+      };
+
+      const wrapper = shallow(
+        <EditorFallback field={field}>test</EditorFallback>
+      );
+
+      const error = new Error('test');
+      error.stack = 'test stack';
+
+      wrapper
+        .setState({
+          error: error,
+          info: { componentStack: 'test' },
+        })
+        .find('button')
+        .slice(2, 3)
+        .simulate('click');
+
+      expect(wrapper).toMatchSnapshot();
+    });
+  });
+});

--- a/client/src/components/Draftail/EditorFallback/EditorFallback.test.js
+++ b/client/src/components/Draftail/EditorFallback/EditorFallback.test.js
@@ -61,7 +61,7 @@ describe('EditorFallback', () => {
           error: new Error('test'),
         })
         .find('button')
-        .first()
+        .last()
         .simulate('click');
 
       expect(wrapper).toMatchSnapshot();
@@ -82,7 +82,7 @@ describe('EditorFallback', () => {
           reloads: 3,
         })
         .find('button')
-        .first()
+        .last()
         .simulate('click');
 
       expect(window.location.reload).toHaveBeenCalled();
@@ -105,7 +105,7 @@ describe('EditorFallback', () => {
           info: { componentStack: 'test' },
         })
         .find('button')
-        .last()
+        .first()
         .simulate('click');
 
       expect(wrapper).toMatchSnapshot();
@@ -136,7 +136,7 @@ describe('EditorFallback', () => {
           info: { componentStack: 'test' },
         })
         .find('button')
-        .slice(2, 3)
+        .first()
         .simulate('click');
 
       expect(wrapper).toMatchSnapshot();

--- a/client/src/components/Draftail/EditorFallback/__snapshots__/EditorFallback.test.js.snap
+++ b/client/src/components/Draftail/EditorFallback/__snapshots__/EditorFallback.test.js.snap
@@ -12,7 +12,7 @@ exports[`EditorFallback #error #showContent 1`] = `
       onClick={[Function]}
       type="button"
     >
-      Reload the editor
+      Show latest content
     </button>
     <button
       className="Draftail-ToolbarButton"
@@ -26,7 +26,7 @@ exports[`EditorFallback #error #showContent 1`] = `
       onClick={[Function]}
       type="button"
     >
-      Show latest content
+      Reload the editor
     </button>
   </div>
   <div
@@ -58,14 +58,14 @@ exports[`EditorFallback #error #showError 1`] = `
       onClick={[Function]}
       type="button"
     >
-      Reload the editor
+      Show error
     </button>
     <button
       className="Draftail-ToolbarButton"
       onClick={[Function]}
       type="button"
     >
-      Show error
+      Reload the editor
     </button>
   </div>
   <div
@@ -104,14 +104,14 @@ exports[`EditorFallback #error works 1`] = `
       onClick={[Function]}
       type="button"
     >
-      Reload the editor
+      Show error
     </button>
     <button
       className="Draftail-ToolbarButton"
       onClick={[Function]}
       type="button"
     >
-      Show error
+      Reload the editor
     </button>
   </div>
   <div

--- a/client/src/components/Draftail/EditorFallback/__snapshots__/EditorFallback.test.js.snap
+++ b/client/src/components/Draftail/EditorFallback/__snapshots__/EditorFallback.test.js.snap
@@ -1,0 +1,129 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EditorFallback #error #showContent 1`] = `
+<div
+  className="Draftail-Editor"
+>
+  <div
+    className="Draftail-Toolbar"
+  >
+    <button
+      className="Draftail-ToolbarButton"
+      onClick={[Function]}
+      type="button"
+    >
+      Reload the editor
+    </button>
+    <button
+      className="Draftail-ToolbarButton"
+      onClick={[Function]}
+      type="button"
+    >
+      Show error
+    </button>
+    <button
+      className="Draftail-ToolbarButton"
+      onClick={[Function]}
+      type="button"
+    >
+      Show latest content
+    </button>
+  </div>
+  <div
+    className="DraftEditor-root"
+  >
+    <div
+      className="public-DraftEditorPlaceholder-inner"
+    >
+      The editor just crashed. Content has been reset to the last saved version.
+    </div>
+  </div>
+  <textarea
+    className="EditorFallback__textarea"
+    readOnly={true}
+    value="test"
+  />
+</div>
+`;
+
+exports[`EditorFallback #error #showError 1`] = `
+<div
+  className="Draftail-Editor"
+>
+  <div
+    className="Draftail-Toolbar"
+  >
+    <button
+      className="Draftail-ToolbarButton"
+      onClick={[Function]}
+      type="button"
+    >
+      Reload the editor
+    </button>
+    <button
+      className="Draftail-ToolbarButton"
+      onClick={[Function]}
+      type="button"
+    >
+      Show error
+    </button>
+  </div>
+  <div
+    className="DraftEditor-root"
+  >
+    <div
+      className="public-DraftEditorPlaceholder-inner"
+    >
+      The editor just crashed. Content has been reset to the last saved version.
+    </div>
+  </div>
+  <pre
+    className="help-block help-critical"
+  >
+    <code
+      className="EditorFallback__error"
+    >
+      test stack
+test
+    </code>
+  </pre>
+</div>
+`;
+
+exports[`EditorFallback #error reload 1`] = `"test"`;
+
+exports[`EditorFallback #error works 1`] = `
+<div
+  className="Draftail-Editor"
+>
+  <div
+    className="Draftail-Toolbar"
+  >
+    <button
+      className="Draftail-ToolbarButton"
+      onClick={[Function]}
+      type="button"
+    >
+      Reload the editor
+    </button>
+    <button
+      className="Draftail-ToolbarButton"
+      onClick={[Function]}
+      type="button"
+    >
+      Show error
+    </button>
+  </div>
+  <div
+    className="DraftEditor-root"
+  >
+    <div
+      className="public-DraftEditorPlaceholder-inner"
+    >
+      The editor just crashed. Content has been reset to the last saved version.
+    </div>
+  </div>
+</div>
+`;
+
+exports[`EditorFallback works 1`] = `"test"`;

--- a/client/src/components/Draftail/EditorFallback/__snapshots__/EditorFallback.test.js.snap
+++ b/client/src/components/Draftail/EditorFallback/__snapshots__/EditorFallback.test.js.snap
@@ -88,7 +88,9 @@ exports[`EditorFallback #error #showError 1`] = `
           <code
             className="EditorFallback__error"
           >
-            test stack
+            Error: test
+
+test stack
 test
           </code>
         </pre>

--- a/client/src/components/Draftail/EditorFallback/__snapshots__/EditorFallback.test.js.snap
+++ b/client/src/components/Draftail/EditorFallback/__snapshots__/EditorFallback.test.js.snap
@@ -33,16 +33,20 @@ exports[`EditorFallback #error #showContent 1`] = `
     className="DraftEditor-root"
   >
     <div
-      className="public-DraftEditorPlaceholder-inner"
+      className="public-DraftEditor-content"
     >
-      The editor just crashed. Content has been reset to the last saved version.
+      <div
+        className="public-DraftEditorPlaceholder-inner"
+      >
+        The editor just crashed. Content has been reset to the last saved version.
+        <textarea
+          className="EditorFallback__textarea"
+          readOnly={true}
+          value="test"
+        />
+      </div>
     </div>
   </div>
-  <textarea
-    className="EditorFallback__textarea"
-    readOnly={true}
-    value="test"
-  />
 </div>
 `;
 
@@ -72,21 +76,25 @@ exports[`EditorFallback #error #showError 1`] = `
     className="DraftEditor-root"
   >
     <div
-      className="public-DraftEditorPlaceholder-inner"
+      className="public-DraftEditor-content"
     >
-      The editor just crashed. Content has been reset to the last saved version.
+      <div
+        className="public-DraftEditorPlaceholder-inner"
+      >
+        The editor just crashed. Content has been reset to the last saved version.
+        <pre
+          className="help-block help-critical"
+        >
+          <code
+            className="EditorFallback__error"
+          >
+            test stack
+test
+          </code>
+        </pre>
+      </div>
     </div>
   </div>
-  <pre
-    className="help-block help-critical"
-  >
-    <code
-      className="EditorFallback__error"
-    >
-      test stack
-test
-    </code>
-  </pre>
 </div>
 `;
 
@@ -118,9 +126,13 @@ exports[`EditorFallback #error works 1`] = `
     className="DraftEditor-root"
   >
     <div
-      className="public-DraftEditorPlaceholder-inner"
+      className="public-DraftEditor-content"
     >
-      The editor just crashed. Content has been reset to the last saved version.
+      <div
+        className="public-DraftEditorPlaceholder-inner"
+      >
+        The editor just crashed. Content has been reset to the last saved version.
+      </div>
     </div>
   </div>
 </div>

--- a/client/src/components/Draftail/EditorFallback/__snapshots__/EditorFallback.test.js.snap
+++ b/client/src/components/Draftail/EditorFallback/__snapshots__/EditorFallback.test.js.snap
@@ -26,7 +26,7 @@ exports[`EditorFallback #error #showContent 1`] = `
       onClick={[Function]}
       type="button"
     >
-      Reload the editor
+      Reload saved content
     </button>
   </div>
   <div
@@ -69,7 +69,7 @@ exports[`EditorFallback #error #showError 1`] = `
       onClick={[Function]}
       type="button"
     >
-      Reload the editor
+      Reload saved content
     </button>
   </div>
   <div
@@ -119,7 +119,7 @@ exports[`EditorFallback #error works 1`] = `
       onClick={[Function]}
       type="button"
     >
-      Reload the editor
+      Reload saved content
     </button>
   </div>
   <div

--- a/client/src/components/Draftail/index.js
+++ b/client/src/components/Draftail/index.js
@@ -13,6 +13,8 @@ export { default as EmbedBlock } from './blocks/EmbedBlock';
 
 export { default as ModalWorkflowSource } from './sources/ModalWorkflowSource';
 
+import EditorFallback from './EditorFallback/EditorFallback';
+
 // 1024x1024 SVG path rendering of the "↵" character, that renders badly in MS Edge.
 const BR_ICON = 'M.436 633.471l296.897-296.898v241.823h616.586V94.117h109.517v593.796H297.333v242.456z';
 
@@ -61,6 +63,7 @@ const initEditor = (selector, options, currentScript) => {
   field.parentNode.appendChild(editorWrapper);
 
   const serialiseInputValue = rawContentState => {
+    field.rawContentState = rawContentState;
     field.value = JSON.stringify(rawContentState);
   };
 
@@ -80,34 +83,40 @@ const initEditor = (selector, options, currentScript) => {
   } : false;
 
   const rawContentState = JSON.parse(field.value);
+  field.rawContentState = rawContentState;
+
+  const editorRef = (ref) => {
+    // Bind editor instance to its field so it can be accessed imperatively elsewhere.
+    field.draftailEditor = ref;
+  };
 
   const editor = (
-    <DraftailEditor
-      rawContentState={rawContentState}
-      onSave={serialiseInputValue}
-      placeholder={STRINGS.WRITE_HERE}
-      spellCheck={true}
-      enableLineBreak={{
-        description: STRINGS.LINE_BREAK,
-        icon: BR_ICON,
-      }}
-      showUndoControl={{ description: STRINGS.UNDO }}
-      showRedoControl={{ description: STRINGS.REDO }}
-      maxListNesting={4}
-      // Draft.js + IE 11 presents some issues with pasting rich text. Disable rich paste there.
-      stripPastedStyles={IS_IE11}
-      {...options}
-      blockTypes={blockTypes.map(wrapWagtailIcon)}
-      inlineStyles={inlineStyles.map(wrapWagtailIcon)}
-      entityTypes={entityTypes}
-      enableHorizontalRule={enableHorizontalRule}
-    />
+    <EditorFallback field={field}>
+      <DraftailEditor
+        ref={editorRef}
+        rawContentState={rawContentState}
+        onSave={serialiseInputValue}
+        placeholder={STRINGS.WRITE_HERE}
+        spellCheck={true}
+        enableLineBreak={{
+          description: STRINGS.LINE_BREAK,
+          icon: BR_ICON,
+        }}
+        showUndoControl={{ description: STRINGS.UNDO }}
+        showRedoControl={{ description: STRINGS.REDO }}
+        maxListNesting={4}
+        // Draft.js + IE 11 presents some issues with pasting rich text. Disable rich paste there.
+        stripPastedStyles={IS_IE11}
+        {...options}
+        blockTypes={blockTypes.map(wrapWagtailIcon)}
+        inlineStyles={inlineStyles.map(wrapWagtailIcon)}
+        entityTypes={entityTypes}
+        enableHorizontalRule={enableHorizontalRule}
+      />
+    </EditorFallback>
   );
 
-  const draftailEditor = ReactDOM.render(editor, editorWrapper);
-
-  // Bind editor instance to its field so it can be accessed imperatively elsewhere.
-  field.draftailEditor = draftailEditor;
+  ReactDOM.render(editor, editorWrapper);
 };
 
 export default {

--- a/client/tests/stubs.js
+++ b/client/tests/stubs.js
@@ -37,7 +37,7 @@ global.wagtailConfig = {
     UNDO: 'Undo',
     REDO: 'Redo',
     RELOAD_PAGE: 'Reload the page',
-    RELOAD_EDITOR: 'Reload the editor',
+    RELOAD_EDITOR: 'Reload saved content',
     SHOW_LATEST_CONTENT: 'Show latest content',
     EDITOR_CRASH: 'The editor just crashed. Content has been reset to the last saved version.',
   },

--- a/client/tests/stubs.js
+++ b/client/tests/stubs.js
@@ -39,6 +39,7 @@ global.wagtailConfig = {
     RELOAD_PAGE: 'Reload the page',
     RELOAD_EDITOR: 'Reload saved content',
     SHOW_LATEST_CONTENT: 'Show latest content',
+    SHOW_ERROR: 'Show error',
     EDITOR_CRASH: 'The editor just crashed. Content has been reset to the last saved version.',
   },
 };

--- a/client/tests/stubs.js
+++ b/client/tests/stubs.js
@@ -36,6 +36,9 @@ global.wagtailConfig = {
     LINE_BREAK: 'Line break',
     UNDO: 'Undo',
     REDO: 'Redo',
+    RELOAD_PAGE: 'Reload the page',
+    SHOW_LATEST_CONTENT: 'Show latest content',
+    EDITOR_CRASH: 'The editor just crashed. Content has been reset to the last saved version.',
   },
 };
 

--- a/client/tests/stubs.js
+++ b/client/tests/stubs.js
@@ -37,6 +37,7 @@ global.wagtailConfig = {
     UNDO: 'Undo',
     REDO: 'Redo',
     RELOAD_PAGE: 'Reload the page',
+    RELOAD_EDITOR: 'Reload the editor',
     SHOW_LATEST_CONTENT: 'Show latest content',
     EDITOR_CRASH: 'The editor just crashed. Content has been reset to the last saved version.',
   },

--- a/wagtail/admin/templates/wagtailadmin/admin_base.html
+++ b/wagtail/admin/templates/wagtailadmin/admin_base.html
@@ -45,6 +45,7 @@
                 UNDO: "{% trans 'Undo' %}",
                 REDO: "{% trans 'Redo' %}",
                 RELOAD_PAGE: "{% trans 'Reload the page' %}",
+                RELOAD_EDITOR: "{% trans 'Reload the editor' %}",
                 SHOW_LATEST_CONTENT: "{% trans 'Show latest content' %}",
                 EDITOR_CRASH: "{% trans 'The editor just crashed. Content has been reset to the last saved version.' %}",
             };

--- a/wagtail/admin/templates/wagtailadmin/admin_base.html
+++ b/wagtail/admin/templates/wagtailadmin/admin_base.html
@@ -45,7 +45,7 @@
                 UNDO: "{% trans 'Undo' %}",
                 REDO: "{% trans 'Redo' %}",
                 RELOAD_PAGE: "{% trans 'Reload the page' %}",
-                RELOAD_EDITOR: "{% trans 'Reload the editor' %}",
+                RELOAD_EDITOR: "{% trans 'Reload saved content' %}",
                 SHOW_LATEST_CONTENT: "{% trans 'Show latest content' %}",
                 EDITOR_CRASH: "{% trans 'The editor just crashed. Content has been reset to the last saved version.' %}",
             };

--- a/wagtail/admin/templates/wagtailadmin/admin_base.html
+++ b/wagtail/admin/templates/wagtailadmin/admin_base.html
@@ -44,6 +44,9 @@
                 LINE_BREAK: "{% trans 'Line break' %}",
                 UNDO: "{% trans 'Undo' %}",
                 REDO: "{% trans 'Redo' %}",
+                RELOAD_PAGE: "{% trans 'Reload the page' %}",
+                SHOW_LATEST_CONTENT: "{% trans 'Show latest content' %}",
+                EDITOR_CRASH: "{% trans 'The editor just crashed. Content has been reset to the last saved version.' %}",
             };
 
             wagtailConfig.ADMIN_URLS = {

--- a/wagtail/admin/templates/wagtailadmin/admin_base.html
+++ b/wagtail/admin/templates/wagtailadmin/admin_base.html
@@ -47,6 +47,7 @@
                 RELOAD_PAGE: "{% trans 'Reload the page' %}",
                 RELOAD_EDITOR: "{% trans 'Reload saved content' %}",
                 SHOW_LATEST_CONTENT: "{% trans 'Show latest content' %}",
+                SHOW_ERROR: "{% trans 'Show error' %}",
                 EDITOR_CRASH: "{% trans 'The editor just crashed. Content has been reset to the last saved version.' %}",
             };
 


### PR DESCRIPTION
This adds a "fallback" UI when the editor crashes. Builds upon #4315 (and contains some of its commits).

When the editor crashes (eg. because of a bug in Draft.js or Draftail, or in some browser API), React will remove all of the parts of the UI that are affected by the error. This is good because users won't be interacting with a broken UI, but it's even better if we provide some sort of fallback that explains what happens.

Here is what it looks like:

![draftail-fallback-ui](https://user-images.githubusercontent.com/877585/36738196-9d5f59a0-1be5-11e8-8784-a5b46e051b8d.png)

Here is what happens when it crashes:

![draftail-fallback](https://user-images.githubusercontent.com/877585/36738230-b6765c22-1be5-11e8-81bd-575a4014e448.gif)

The "latest" content is available so users don't lose what they were typing. It's displayed as plain text in a `textarea` to reduce the risk of rendering errors. Behind the scenes, the `input` value is reset to what it was at page load, reducing the risk that error-prone / broken content will be saved.

WIP:

- [ ] Feedback on the UI and messaging would be good.
- [x] Tests are missing.

To cause a crash in the editor, put the following in the browser console (tweak the selector to pick a different editor):

```js
document.querySelector('[data-draftail-input]').draftailEditor.setState({ editorState: {}})
```