### PR TITLE
Pass index name in URL to Bulk API

### DIFF
--- a/wagtail/search/backends/elasticsearch2.py
+++ b/wagtail/search/backends/elasticsearch2.py
@@ -806,7 +806,6 @@ class Elasticsearch2Index:
         for item in items:
             # Create the action
             action = {
-                '_index': self.name,
                 '_type': doc_type,
                 '_id': mapping.get_document_id(item),
             }
@@ -814,7 +813,7 @@ class Elasticsearch2Index:
             actions.append(action)
 
         # Run the actions
-        bulk(self.es, actions)
+        bulk(self.es, actions, index=self.name)
 
     def delete_item(self, item):
         # Make sure the object can be indexed


### PR DESCRIPTION
We currently index all items in Elasticsearch using the root bulk API (at ``/_bulk``). This API is to allow inserting into multiple indices at once. However, Wagtail inserts into one index at a time so this is not needed.

If we pass the index name as a parameter in the call to ``bulk()``, the index-specific bulk API will be used instead (at ``/<index name>/_bulk``.

The advantage of this change is it makes it possible to implement access control by checking the URL an application is using. This is required in order for the Bulk API to work on certain hosts (such as Divio).