### PR TITLE
Allow draftail to initialise when features are specified in the settings

### DIFF
--- a/wagtail/admin/rich_text/editors/draftail/__init__.py
+++ b/wagtail/admin/rich_text/editors/draftail/__init__.py
@@ -18,6 +18,7 @@ class DraftailRichTextArea(WidgetWithScript, widgets.HiddenInput):
     def __init__(self, *args, **kwargs):
         # note: this constructor will receive an 'options' kwarg taken from the WAGTAILADMIN_RICH_TEXT_EDITORS setting,
         # but we don't currently recognise any options from there (other than 'features', which is passed here as a separate kwarg)
+        kwargs.pop('options', None)
         self.options = {}
 
         self.features = kwargs.pop('features', None)

--- a/wagtail/admin/tests/test_rich_text.py
+++ b/wagtail/admin/tests/test_rich_text.py
@@ -379,6 +379,47 @@ class TestHalloJsWithFeaturesKwarg(BaseRichTextEditHandlerTestCase, WagtailTestU
 
 @override_settings(WAGTAILADMIN_RICH_TEXT_EDITORS={
     'default': {
+        'WIDGET': 'wagtail.admin.rich_text.DraftailRichTextArea',
+        'OPTIONS': {
+            'features': ['h2', 'image']
+        }
+
+    },
+})
+class TestDraftailWithFeatureOptions(BaseRichTextEditHandlerTestCase, WagtailTestUtils):
+
+    def setUp(self):
+        super().setUp()
+
+        # Find root page
+        self.root_page = Page.objects.get(id=2)
+
+        self.login()
+
+    def test_settings_features_option_on_rich_text_field(self):
+        response = self.client.get(reverse(
+            'wagtailadmin_pages:add', args=('tests', 'defaultrichtextfieldpage', self.root_page.id)
+        ))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, '"type": "header-two"')
+        self.assertContains(response, '"type": "IMAGE"')
+        self.assertNotContains(response, '"type": "ordered-list-item"')
+
+    def test_features_option_on_rich_text_block(self):
+        # a 'features' list passed on the RichTextBlock
+        # should override the list in OPTIONS
+        block = RichTextBlock(features=['h2', 'embed'])
+
+        form_html = block.render_form(block.to_python("<p>hello</p>"), 'body')
+
+        self.assertIn('"type": "header-two"', form_html)
+        self.assertIn('"type": "EMBED"', form_html)
+        self.assertNotIn('"type": "IMAGE""', form_html)
+        self.assertNotIn('"type": "ordered-list-item""', form_html)
+
+
+@override_settings(WAGTAILADMIN_RICH_TEXT_EDITORS={
+    'default': {
         'WIDGET': 'wagtail.admin.rich_text.HalloRichTextArea',
         'OPTIONS': {
             'features': ['blockquote', 'image']


### PR DESCRIPTION
Hallo.js pops the options from the kwargs. See:
https://github.com/wagtail/wagtail/blob/76975525f7a3757b280572165f8717cc4c13bba6/wagtail/admin/rich_text/editors/hallo.py#L87

Draftail needs to do something similar (even if not using the options) in order to prevent `__init__() got an unexpected keyword argument 'options'` when calling the super classes.