### PR TITLE
Remove extra space in variable icons SCSS.

### DIFF
--- a/wagtail/admin/static_src/wagtailadmin/scss/_variables-icons.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/_variables-icons.scss
@@ -67,7 +67,7 @@ $icons: (
     'warning': '!',
     'form': '$',
     'site': '@',
-    'placeholder': ' {',
+    'placeholder': '{',
     'pilcrow': '\e600',
     'title': '\f034',
     'code': '\e601',


### PR DESCRIPTION
I found an extra space in the scss when extracting a list of usable icons bundled with Wagtail with regex.
