### PR TITLE
Add ChooserBlock.get_queryset()

### DIFF
--- a/wagtail/core/blocks/field_block.py
+++ b/wagtail/core/blocks/field_block.py
@@ -545,7 +545,7 @@ class ChooserBlock(FieldBlock):
             return value
         else:
             try:
-                return self.target_model.objects.get(pk=value)
+                return self.get_queryset().get(pk=value)
             except self.target_model.DoesNotExist:
                 return None
 
@@ -554,7 +554,7 @@ class ChooserBlock(FieldBlock):
 
         The instances must be returned in the same order as the values and keep None values.
         """
-        objects = self.target_model.objects.in_bulk(values)
+        objects = self.get_queryset().in_bulk(values)
         return [objects.get(id) for id in values]  # Keeps the ordering the same as in values.
 
     def get_prep_value(self, value):
@@ -563,6 +563,9 @@ class ChooserBlock(FieldBlock):
             return None
         else:
             return value.pk
+
+    def get_queryset(self):
+        return self.target_model.objects.get_queryset()
 
     def value_from_form(self, value):
         # ModelChoiceField sometimes returns an ID, and sometimes an instance; we want the instance


### PR DESCRIPTION
By creating the queryset to be used in to_python() and bulk_to_python()
it is more easy to override it in a subclass (for example adding
.only() or a .select_related())