### PR TITLE
Remove IE6-9 conditional comments from project template

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -7,6 +7,7 @@ Changelog
  * Persist tab hash in URL to allow direct navigation to tabs in the admin interface (Ben Weatherman)
  * Animate the chevron icon when opening sub-menus in the admin (Carlo Ascani)
  * Look through the target link and target page slug (in addition to the old slug) when searching for redirects in the admin (Michael Harrison)
+ * Remove support for IE6 to IE9 from project template (Samir Shah)
  * Fix: Status button on 'edit page' now links to the correct URL when live and draft slug differ (LB (Ben Johnston))
  * Fix: Image title text in the gallery and in the chooser now wraps for long filenames (LB (Ben Johnston), Luiz Boaretto)
  * Fix: Move image editor action buttons to the bottom of the form on mobile (Julian Gallo)

--- a/docs/releases/2.1.rst
+++ b/docs/releases/2.1.rst
@@ -17,6 +17,7 @@ Other features
 * Persist tab hash in URL to allow direct navigation to tabs in the admin interface (Ben Weatherman)
 * Animate the chevron icon when opening sub-menus in the admin (Carlo Ascani)
 * Look through the target link and target page slug (in addition to the old slug) when searching for redirects in the admin (Michael Harrison)
+* Remove support for IE6 to IE9 from project template (Samir Shah)
 
 Bug fixes
 ~~~~~~~~~

--- a/wagtail/project_template/project_name/templates/500.html
+++ b/wagtail/project_template/project_name/templates/500.html
@@ -1,11 +1,7 @@
 <!DOCTYPE html>
-<!--[if lt IE 7]>      <html class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>         <html class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html class="no-js"> <!--<![endif]-->
+<html class="no-js">
     <head>
         <meta charset="utf-8" />
-        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <title>Internal server error</title>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
     </head>

--- a/wagtail/project_template/project_name/templates/base.html
+++ b/wagtail/project_template/project_name/templates/base.html
@@ -4,7 +4,6 @@
 <html class="no-js">
     <head>
         <meta charset="utf-8" />
-        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <title>
             {% templatetag openblock %} block title %}
                 {% templatetag openblock %} if self.seo_title %}{% templatetag openvariable %} self.seo_title {% templatetag closevariable %}{% templatetag openblock %} else %}{% templatetag openvariable %} self.title {% templatetag closevariable %}{% templatetag openblock %} endif %}

--- a/wagtail/project_template/project_name/templates/base.html
+++ b/wagtail/project_template/project_name/templates/base.html
@@ -1,10 +1,7 @@
 {% templatetag openblock %} load static wagtailuserbar {% templatetag closeblock %}
 
 <!DOCTYPE html>
-<!--[if lt IE 7]>      <html class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>         <html class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html class="no-js"> <!--<![endif]-->
+<html class="no-js">
     <head>
         <meta charset="utf-8" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />


### PR DESCRIPTION
I'd like to propose removing the shims for IE6-9 from the project template.

The rationale for this is the same as for dropping support for EOL version of Django, etc. - i.e., these versions of Internet Explorer are no longer supported by the vendor (the last version of Windows that you cannot upgrade to use IE10 or higher was Windows XP, which reached end of life in 2014). The [Wagtail documentation itself](http://docs.wagtail.io/en/v2.0/contributing/developing.html) says that IE10 and lower are not supported.

On that basis I think that Wagtail should not include these shims by default - projects that for whatever reason still need to support these browsers can easily add them to their templates.

