### PR TITLE
Remove outdated X-UA-Compatible meta from admin template

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/skeleton.html
+++ b/wagtail/admin/templates/wagtailadmin/skeleton.html
@@ -3,7 +3,6 @@
 <html class="no-js" lang="{{ LANGUAGE_CODE|default:"en-gb" }}">
 <head>
     <meta charset="utf-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
     <title>Wagtail - {% block titletag %}{% endblock %}</title>
     <meta name="description" content="" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />


### PR DESCRIPTION
This meta is useless since Wagtail dropped support for IE8-9-10. Starting with IE11, edge mode is the default. The chrome=1 part is for Chrome Frame, which was only available until 2014, for IE6-9.

See also #4355.