### PR TITLE
Rewrite modal-workflow.js to not rely on eval()

### DIFF
--- a/wagtail/admin/static_src/wagtailadmin/js/modal-workflow.js
+++ b/wagtail/admin/static_src/wagtailadmin/js/modal-workflow.js
@@ -118,8 +118,11 @@ function formJSON(data) {
 
     if (data.indexOf(onloadKey) > -1) {
         var parts = data.split(onloadKey);
-        var sourceCode = parts[1].replace(/\s*\r?\n/g, '\\n').replace(/"/g, '\\"') + 'END_OF_RESPONSE';
-        sourceCode = '"' + sourceCode.replace(/}[\s\r\n]*END_OF_RESPONSE/, '"}');
+        var sourceCode = parts[1]
+        // first, turn this into JSON-valid string data
+        sourceCode = JSON.stringify(sourceCode)  + 'END_OF_RESPONSE';
+        // then, move the quote back to befor the curly bracket.
+        sourceCode = sourceCode.replace(/}"[\s\r\n]*END_OF_RESPONSE/, '"}');
         data = parts[0] + jsonOnloadKey + sourceCode;
     }
 


### PR DESCRIPTION
This rewrite switches the `eval()` call used by the modal workflow (which will get blocked by CSP that do not specify `unsafe-eval`) to a DOM script insertion (which does not trigger CSP violation errors). It introduces a helper function that takes Wagtail's jsoneque html+js text response and performs minor rewrites to it to turn it into valid JSON, so that it can be run through `JSON.parse` rather than `eval()`.

This fix probably closes #4335 (it fixes the CSP error without being as invasive as the approached suggested early on in that issue).

> Do the tests still pass? (http://docs.wagtail.io/en/latest/contributing/developing.html#testing)

as far as I can tell, this code does not change the result of `python manage.py test`.

> Does the code comply with the style guide? (Run `make lint` from the Wagtail root)

as far as lint:js is concerned: yes.

> For front-end changes: Did you test on all of Wagtail’s supported browsers?

Tested against Chrome 65, Firefox nightly (61), and Edge (v41). I made sure to use only ES5 syntax so that things still work even on drastically older browsers.