### PR TITLE
allow chunk_size to be set in update_index

### DIFF
--- a/docs/reference/management_commands.rst
+++ b/docs/reference/management_commands.rst
@@ -80,7 +80,7 @@ For example, to update just the default backend:
 
     $ python manage.py update_index --backend default
 
-The ``--chunk_size`` option can be used to set the size of chunks that are index at a time. This defaults to
+The ``--chunk_size`` option can be used to set the size of chunks that are indexed at a time. This defaults to
 1000 but may need to be reduced for larger document sizes.
 
 Indexing the schema only

--- a/docs/reference/management_commands.rst
+++ b/docs/reference/management_commands.rst
@@ -80,6 +80,8 @@ For example, to update just the default backend:
 
     $ python manage.py update_index --backend default
 
+The ``--chunk_size`` option can be used to set the size of chunks that are index at a time. This defaults to
+1000 but may need to be reduced for larger document sizes.
 
 Indexing the schema only
 ````````````````````````

--- a/wagtail/search/management/commands/update_index.py
+++ b/wagtail/search/management/commands/update_index.py
@@ -7,6 +7,8 @@ from django.db import transaction
 from wagtail.search.backends import get_search_backend
 from wagtail.search.index import get_indexed_models
 
+DEFAULT_CHUNK_SIZE = 1000
+
 
 def group_models_by_index(backend, models):
     """
@@ -50,7 +52,7 @@ def group_models_by_index(backend, models):
 
 
 class Command(BaseCommand):
-    def update_backend(self, backend_name, schema_only, chunk_size):
+    def update_backend(self, backend_name, schema_only=False, chunk_size=DEFAULT_CHUNK_SIZE):
         self.stdout.write("Updating backend: " + backend_name)
 
         backend = get_search_backend(backend_name)
@@ -101,7 +103,7 @@ class Command(BaseCommand):
             '--schema-only', action='store_true', dest='schema_only', default=False,
             help="Prevents loading any data into the index")
         parser.add_argument(
-            '--chunk_size', action='store', dest='chunk_size', default=1000,
+            '--chunk_size', action='store', dest='chunk_size', default=DEFAULT_CHUNK_SIZE,
             help="Set the chunk size for the backend")
 
     def handle(self, **options):

--- a/wagtail/search/management/commands/update_index.py
+++ b/wagtail/search/management/commands/update_index.py
@@ -50,7 +50,7 @@ def group_models_by_index(backend, models):
 
 
 class Command(BaseCommand):
-    def update_backend(self, backend_name, schema_only=False):
+    def update_backend(self, backend_name, schema_only, chunk_size):
         self.stdout.write("Updating backend: " + backend_name)
 
         backend = get_search_backend(backend_name)
@@ -80,8 +80,8 @@ class Command(BaseCommand):
                 for model in models:
                     self.stdout.write('{}: {}.{} '.format(backend_name, model._meta.app_label, model.__name__).ljust(35), ending='')
 
-                    # Add items (1000 at a time)
-                    for chunk in self.print_iter_progress(self.queryset_chunks(model.get_indexed_objects().order_by('pk'))):
+                    # Add items (chunk_size at a time)
+                    for chunk in self.print_iter_progress(self.queryset_chunks(model.get_indexed_objects().order_by('pk'), chunk_size)):
                         index.add_items(model, chunk)
                         object_count += len(chunk)
 
@@ -100,6 +100,9 @@ class Command(BaseCommand):
         parser.add_argument(
             '--schema-only', action='store_true', dest='schema_only', default=False,
             help="Prevents loading any data into the index")
+        parser.add_argument(
+            '--chunk_size', action='store', dest='chunk_size', default=1000,
+            help="Set the chunk size for the backend")
 
     def handle(self, **options):
         # Get list of backends to index
@@ -115,7 +118,7 @@ class Command(BaseCommand):
 
         # Update backends
         for backend_name in backend_names:
-            self.update_backend(backend_name, schema_only=options.get('schema_only', False))
+            self.update_backend(backend_name, options.get('schema_only', False), options.get('chunk_size'))
 
     def print_newline(self):
         self.stdout.write('')
@@ -145,7 +148,7 @@ class Command(BaseCommand):
 
     # Atomic so the count of models doesnt change as it is iterated
     @transaction.atomic
-    def queryset_chunks(self, qs, chunk_size=1000):
+    def queryset_chunks(self, qs, chunk_size):
         """
         Yield a queryset in chunks of at most ``chunk_size``. The chunk yielded
         will be a list, not a queryset. Iterating over the chunks is done in a

--- a/wagtail/search/tests/test_backends.py
+++ b/wagtail/search/tests/test_backends.py
@@ -34,7 +34,7 @@ class BackendTests(WagtailTestUtils):
             # no conf entry found - skip tests for this backend
             raise unittest.SkipTest("No WAGTAILSEARCH_BACKENDS entry for the backend %s" % self.backend_path)
 
-        management.call_command('update_index', backend_name=self.backend_name, stdout=StringIO())
+        management.call_command('update_index', backend_name=self.backend_name, stdout=StringIO(), chunk_size=50)
 
     def assertUnsortedListEqual(self, a, b):
         """


### PR DESCRIPTION
With certain document sets the update_index command times out. Setting the chunk_size to lower than the default 1000 fixes this issue.

This change allows the chunk_size to be set as a parameter to the command.

The current tests cover this code well and this introduces no extra paths.