### PR TITLE
External link includes selected text

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -23,6 +23,7 @@ Changelog
  * Fix: Correct dropdown arrow styling in Firefox, IE11 (Janneke Janssen, Alexs Mathilda)
  * Fix: Password reset no indicates specific validation errors on certain password restrictions (Lucas Moeskops)
  * Fix: Confirmation page on page deletion now respects custom `get_admin_display_title` methods (Kim Chee Leong)
+ * Fix: Adding external link with selected text now includes text in link chooser (Tony Yates, Thibaud Colas, Alexs Mathilda)
 
 
 2.0.1 (xx.xx.xxxx) - IN DEVELOPMENT

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -284,6 +284,8 @@ Contributors
 * Kevin Chung
 * Kim Chee Leong
 * Dan Swain
+* Alexs Mathilda
+* Tony Yates
 
 Translators
 ===========

--- a/client/src/components/Draftail/DraftUtils.js
+++ b/client/src/components/Draftail/DraftUtils.js
@@ -22,24 +22,23 @@
   * See https://github.com/jpuri/draftjs-utils/blob/e81c0ae19c3b0fdef7e0c1b70d924398956be126/js/block.js#L106.
   */
   export const getSelectionText = (editorState) => {
-    let selectedText = '';
     const selection = editorState.getSelection();
     let start = selection.getAnchorOffset();
     let end = selection.getFocusOffset();
     const selectedBlocks = getSelectedBlocksList(editorState);
 
-    if (selectedBlocks.size > 0) {
-      if (selection.getIsBackward()) {
-        const temp = start;
-        start = end;
-        end = temp;
-      }
-
-      for (let i = 0; i < selectedBlocks.size; i += 1) {
-        const blockStart = i === 0 ? start : 0;
-        const blockEnd = i === (selectedBlocks.size - 1) ? end : selectedBlocks.get(i).getText().length;
-        selectedText += selectedBlocks.get(i).getText().slice(blockStart, blockEnd);
-      }
+    if (selection.getIsBackward()) {
+      const temp = start;
+      start = end;
+      end = temp;
     }
+
+    let selectedText = '';
+    for (let i = 0; i < selectedBlocks.size; i += 1) {
+      const blockStart = i === 0 ? start : 0;
+      const blockEnd = i === (selectedBlocks.size - 1) ? end : selectedBlocks.get(i).getText().length;
+      selectedText += selectedBlocks.get(i).getText().slice(blockStart, blockEnd);
+    }
+
     return selectedText;
   };

--- a/client/src/components/Draftail/DraftUtils.js
+++ b/client/src/components/Draftail/DraftUtils.js
@@ -1,0 +1,43 @@
+
+  /**
+  * Function returns collection of currently selected blocks.
+  */
+  const getSelectedBlocksList = (editorState) => {
+    const selectionState = editorState.getSelection();
+    const content = editorState.getCurrentContent();
+    const startKey = selectionState.getStartKey();
+    const endKey = selectionState.getEndKey();
+    const blockMap = content.getBlockMap();
+    const blocks =  blockMap
+      .toSeq()
+      .skipUntil((_, k) => k === startKey)
+      .takeUntil((_, k) => k === endKey)
+      .concat([[endKey, blockMap.get(endKey)]]);
+    return blocks.toList();
+  };
+
+  /**
+  * Function will return currently selected text in the editor.
+  */
+  export const getSelectionText = (editorState) => {
+    let selectedText = '';
+    const selection = editorState.getSelection();
+    let start = selection.getAnchorOffset();
+    let end = selection.getFocusOffset();
+    const selectedBlocks = getSelectedBlocksList(editorState);
+
+    if (selectedBlocks.size > 0) {
+      if (selection.getIsBackward()) {
+        const temp = start;
+        start = end;
+        end = temp;
+      }
+
+      for (let i = 0; i < selectedBlocks.size; i += 1) {
+        const blockStart = i === 0 ? start : 0;
+        const blockEnd = i === (selectedBlocks.size - 1) ? end : selectedBlocks.get(i).getText().length;
+        selectedText += selectedBlocks.get(i).getText().slice(blockStart, blockEnd);
+      }
+    }
+    return selectedText;
+  };

--- a/client/src/components/Draftail/DraftUtils.js
+++ b/client/src/components/Draftail/DraftUtils.js
@@ -1,6 +1,7 @@
 
   /**
-  * Function returns collection of currently selected blocks.
+  * Returns collection of currently selected blocks.
+  * See https://github.com/jpuri/draftjs-utils/blob/e81c0ae19c3b0fdef7e0c1b70d924398956be126/js/block.js#L19.
   */
   const getSelectedBlocksList = (editorState) => {
     const selectionState = editorState.getSelection();
@@ -17,7 +18,8 @@
   };
 
   /**
-  * Function will return currently selected text in the editor.
+  * Returns the currently selected text in the editor.
+  * See https://github.com/jpuri/draftjs-utils/blob/e81c0ae19c3b0fdef7e0c1b70d924398956be126/js/block.js#L106.
   */
   export const getSelectionText = (editorState) => {
     let selectedText = '';

--- a/client/src/components/Draftail/DraftUtils.test.js
+++ b/client/src/components/Draftail/DraftUtils.test.js
@@ -14,7 +14,6 @@ describe('DraftUtils', () => {
           {
             key: 'a',
             text: 'test1234',
-            type: 'unstyled',
           },
         ],
       });
@@ -32,27 +31,7 @@ describe('DraftUtils', () => {
     });
 
     it('empty', () => {
-      const content = convertFromRaw({
-        entityMap: {},
-        blocks: [
-          {
-            key: 'a',
-            text: 'test',
-            type: 'unstyled',
-          },
-        ],
-      });
-      let editorState = EditorState.createWithContent(content);
-
-      let selection = editorState.getSelection();
-      selection = selection.merge({
-        anchorOffset: 0,
-        focusOffset: 0,
-      });
-
-      editorState = EditorState.acceptSelection(editorState, selection);
-
-      expect(getSelectionText(editorState)).toBe('');
+      expect(getSelectionText(EditorState.createEmpty())).toBe('');
     });
 
     it('backwards', () => {
@@ -62,7 +41,6 @@ describe('DraftUtils', () => {
           {
             key: 'a',
             text: 'test1234',
-            type: 'unstyled',
           },
         ],
       });
@@ -72,7 +50,7 @@ describe('DraftUtils', () => {
       selection = selection.merge({
         anchorOffset: 8,
         focusOffset: 4,
-        isBackward: 1,
+        isBackward: true,
       });
 
       editorState = EditorState.acceptSelection(editorState, selection);
@@ -87,12 +65,10 @@ describe('DraftUtils', () => {
           {
             key: 'a',
             text: 'test1234',
-            type: 'unstyled',
           },
           {
             key: 'b',
             text: 'multiblock',
-            type: 'unstyled',
           }
         ],
       });
@@ -104,7 +80,7 @@ describe('DraftUtils', () => {
         focusKey: 'b',
         anchorOffset: 4,
         focusOffset: 5,
-        isBackward: 0,
+        isBackward: false,
       });
 
       editorState = EditorState.acceptSelection(editorState, selection);
@@ -119,12 +95,10 @@ describe('DraftUtils', () => {
           {
             key: 'a',
             text: 'test1234',
-            type: 'unstyled',
           },
           {
             key: 'b',
             text: 'multiblock',
-            type: 'unstyled',
           }
         ],
       });
@@ -136,7 +110,7 @@ describe('DraftUtils', () => {
         anchorKey: 'b',
         anchorOffset: 5,
         focusOffset: 4,
-        isBackward: 1,
+        isBackward: true,
       });
 
       editorState = EditorState.acceptSelection(editorState, selection);

--- a/client/src/components/Draftail/DraftUtils.test.js
+++ b/client/src/components/Draftail/DraftUtils.test.js
@@ -1,0 +1,147 @@
+import {
+    EditorState,
+    convertFromRaw,
+} from 'draft-js';
+
+import { getSelectionText } from './DraftUtils';
+
+describe('DraftUtils', () => {
+  describe('#getSelectionText', () => {
+    it('works', () => {
+      const content = convertFromRaw({
+        entityMap: {},
+        blocks: [
+          {
+            key: 'a',
+            text: 'test1234',
+            type: 'unstyled',
+          },
+        ],
+      });
+      let editorState = EditorState.createWithContent(content);
+
+      let selection = editorState.getSelection();
+      selection = selection.merge({
+        anchorOffset: 0,
+        focusOffset: 4,
+      });
+
+      editorState = EditorState.acceptSelection(editorState, selection);
+
+      expect(getSelectionText(editorState)).toBe('test');
+    });
+
+    it('empty', () => {
+      const content = convertFromRaw({
+        entityMap: {},
+        blocks: [
+          {
+            key: 'a',
+            text: 'test',
+            type: 'unstyled',
+          },
+        ],
+      });
+      let editorState = EditorState.createWithContent(content);
+
+      let selection = editorState.getSelection();
+      selection = selection.merge({
+        anchorOffset: 0,
+        focusOffset: 0,
+      });
+
+      editorState = EditorState.acceptSelection(editorState, selection);
+
+      expect(getSelectionText(editorState)).toBe('');
+    });
+
+    it('backwards', () => {
+      const content = convertFromRaw({
+        entityMap: {},
+        blocks: [
+          {
+            key: 'a',
+            text: 'test1234',
+            type: 'unstyled',
+          },
+        ],
+      });
+      let editorState = EditorState.createWithContent(content);
+
+      let selection = editorState.getSelection();
+      selection = selection.merge({
+        anchorOffset: 8,
+        focusOffset: 4,
+        isBackward: 1,
+      });
+
+      editorState = EditorState.acceptSelection(editorState, selection);
+
+      expect(getSelectionText(editorState)).toBe('1234');
+    });
+
+    it('multiblock', () => {
+      const content = convertFromRaw({
+        entityMap: {},
+        blocks: [
+          {
+            key: 'a',
+            text: 'test1234',
+            type: 'unstyled',
+          },
+          {
+            key: 'b',
+            text: 'multiblock',
+            type: 'unstyled',
+          }
+        ],
+      });
+      let editorState = EditorState.createWithContent(content);
+
+      let selection = editorState.getSelection();
+      selection = selection.merge({
+        anchorKey: 'a',
+        focusKey: 'b',
+        anchorOffset: 4,
+        focusOffset: 5,
+        isBackward: 0,
+      });
+
+      editorState = EditorState.acceptSelection(editorState, selection);
+
+      expect(getSelectionText(editorState)).toBe('1234multi');
+    });
+
+    it('multiblock-backwards', () => {
+      const content = convertFromRaw({
+        entityMap: {},
+        blocks: [
+          {
+            key: 'a',
+            text: 'test1234',
+            type: 'unstyled',
+          },
+          {
+            key: 'b',
+            text: 'multiblock',
+            type: 'unstyled',
+          }
+        ],
+      });
+      let editorState = EditorState.createWithContent(content);
+
+      let selection = editorState.getSelection();
+      selection = selection.merge({
+        focusKey: 'a',
+        anchorKey: 'b',
+        anchorOffset: 5,
+        focusOffset: 4,
+        isBackward: 1,
+      });
+
+      editorState = EditorState.acceptSelection(editorState, selection);
+
+      expect(getSelectionText(editorState)).toBe('1234multi');
+    });
+  });
+});

--- a/client/src/components/Draftail/sources/ModalWorkflowSource.js
+++ b/client/src/components/Draftail/sources/ModalWorkflowSource.js
@@ -81,9 +81,6 @@ export const getChooserConfig = (entityType, entity, selectedText) => {
       allow_external_link: true,
       allow_email_link: true,
       can_choose_root: 'false',
-      // This does not initialise the modal with the currently selected text.
-      // This will need to be implemented in the future.
-      // See https://github.com/jpuri/draftjs-utils/blob/e81c0ae19c3b0fdef7e0c1b70d924398956be126/js/block.js#L106.
       link_text: selectedText,
     };
 

--- a/client/src/components/Draftail/sources/ModalWorkflowSource.js
+++ b/client/src/components/Draftail/sources/ModalWorkflowSource.js
@@ -4,6 +4,7 @@ import { AtomicBlockUtils, Modifier, RichUtils, EditorState } from 'draft-js';
 import { ENTITY_TYPE } from 'draftail';
 
 import { STRINGS } from '../../../config/wagtailConfig';
+import { getSelectionText } from '../DraftUtils';
 
 const $ = global.jQuery;
 
@@ -16,54 +17,7 @@ MUTABILITY[DOCUMENT] = 'MUTABLE';
 MUTABILITY[ENTITY_TYPE.IMAGE] = 'IMMUTABLE';
 MUTABILITY[EMBED] = 'IMMUTABLE';
 
-/**
-* Function returns collection of currently selected blocks.
-*/
-const getSelectedBlocksMap = (editorState) => {
-  const selectionState = editorState.getSelection();
-  const contentState = editorState.getCurrentContent();
-  const startKey = selectionState.getStartKey();
-  const endKey = selectionState.getEndKey();
-  const blockMap = contentState.getBlockMap();
-  return blockMap
-    .toSeq()
-    .skipUntil((_, k) => k === startKey)
-    .takeUntil((_, k) => k === endKey)
-    .concat([[endKey, blockMap.get(endKey)]]);
-};
 
-/**
-* Function returns collection of currently selected blocks.
-*/
-const getSelectedBlocksList = (editorState) => {
-  const selectedBlocksList = getSelectedBlocksMap(editorState).toList();
-  return selectedBlocksList;
-};
-
-/**
-* Function will return currently selected text in the editor.
-*/
-const getSelectionText = (editorState) => {
-  let selectedText = '';
-  const currentSelection = editorState.getSelection();
-  let start = currentSelection.getAnchorOffset();
-  let end = currentSelection.getFocusOffset();
-  const selectedBlocks = getSelectedBlocksList(editorState);
-  if (selectedBlocks.size > 0) {
-    if (currentSelection.getIsBackward()) {
-      const temp = start;
-      start = end;
-      end = temp;
-    }
-    for (let i = 0; i < selectedBlocks.size; i += 1) {
-      const blockStart = i === 0 ? start : 0;
-      const blockEnd =
-        i === (selectedBlocks.size - 1) ? end : selectedBlocks.get(i).getText().length;
-      selectedText += selectedBlocks.get(i).getText().slice(blockStart, blockEnd);
-    }
-  }
-  return selectedText;
-};
 
 export const getChooserConfig = (entityType, entity, selectedText) => {
   const chooserURL = {};

--- a/client/src/components/Draftail/sources/ModalWorkflowSource.js
+++ b/client/src/components/Draftail/sources/ModalWorkflowSource.js
@@ -17,7 +17,6 @@ MUTABILITY[DOCUMENT] = 'MUTABLE';
 MUTABILITY[ENTITY_TYPE.IMAGE] = 'IMMUTABLE';
 MUTABILITY[EMBED] = 'IMMUTABLE';
 
-
 export const getChooserConfig = (entityType, entity, selectedText) => {
   const chooserURL = {};
   chooserURL[ENTITY_TYPE.IMAGE] = `${global.chooserUrls.imageChooser}?select_format=true`;

--- a/client/src/components/Draftail/sources/ModalWorkflowSource.js
+++ b/client/src/components/Draftail/sources/ModalWorkflowSource.js
@@ -18,7 +18,6 @@ MUTABILITY[ENTITY_TYPE.IMAGE] = 'IMMUTABLE';
 MUTABILITY[EMBED] = 'IMMUTABLE';
 
 
-
 export const getChooserConfig = (entityType, entity, selectedText) => {
   const chooserURL = {};
   chooserURL[ENTITY_TYPE.IMAGE] = `${global.chooserUrls.imageChooser}?select_format=true`;

--- a/client/src/components/Draftail/sources/ModalWorkflowSource.test.js
+++ b/client/src/components/Draftail/sources/ModalWorkflowSource.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 
 import ModalWorkflowSource, { getChooserConfig, filterEntityData } from './ModalWorkflowSource';
+import * as DraftUtils from '../DraftUtils';
 import { EditorState, convertFromRaw, AtomicBlockUtils, RichUtils, Modifier } from 'draft-js';
 
 global.ModalWorkflow = () => {};
@@ -9,6 +10,7 @@ global.ModalWorkflow = () => {};
 describe('ModalWorkflowSource', () => {
   beforeEach(() => {
     jest.spyOn(global, 'ModalWorkflow');
+    jest.spyOn(DraftUtils, 'getSelectionText').mockImplementation(() => '');
   });
 
   afterEach(() => {
@@ -29,21 +31,21 @@ describe('ModalWorkflowSource', () => {
 
   describe('#getChooserConfig', () => {
     it('IMAGE', () => {
-      expect(getChooserConfig({ type: 'IMAGE' })).toEqual({
+      expect(getChooserConfig({ type: 'IMAGE' }, null, '')).toEqual({
         url: '/admin/images/chooser/?select_format=true',
         urlParams: {},
       });
     });
 
     it('EMBED', () => {
-      expect(getChooserConfig({ type: 'EMBED' })).toEqual({
+      expect(getChooserConfig({ type: 'EMBED' }, null, '')).toEqual({
         url: '/admin/embeds/chooser/',
         urlParams: {},
       });
     });
 
     it('DOCUMENT', () => {
-      expect(getChooserConfig({ type: 'DOCUMENT' })).toEqual({
+      expect(getChooserConfig({ type: 'DOCUMENT' }, null, '')).toEqual({
         url: '/admin/documents/chooser/',
         urlParams: {},
       });
@@ -51,25 +53,25 @@ describe('ModalWorkflowSource', () => {
 
     describe('LINK', () => {
       it('no entity', () => {
-        expect(getChooserConfig({ type: 'LINK' })).toMatchSnapshot();
+        expect(getChooserConfig({ type: 'LINK' }, null, '')).toMatchSnapshot();
       });
 
       it('page', () => {
         expect(getChooserConfig({ type: 'LINK' }, {
           getData: () => ({ id: 1, parentId: 0 })
-        })).toMatchSnapshot();
+        }, '')).toMatchSnapshot();
       });
 
       it('mail', () => {
         expect(getChooserConfig({ type: 'LINK' }, {
           getData: () => ({ url: 'mailto:test@example.com' })
-        })).toMatchSnapshot();
+        }, '')).toMatchSnapshot();
       });
 
       it('external', () => {
         expect(getChooserConfig({ type: 'LINK' }, {
           getData: () => ({ url: 'https://www.example.com/' })
-        })).toMatchSnapshot();
+        }, '')).toMatchSnapshot();
       });
     });
   });
@@ -146,7 +148,7 @@ describe('ModalWorkflowSource', () => {
   it('#componentDidMount', () => {
     const wrapper = shallow((
       <ModalWorkflowSource
-        editorState={{}}
+        editorState={EditorState.createEmpty()}
         entityType={{}}
         entity={{}}
         onComplete={() => {}}
@@ -171,7 +173,7 @@ describe('ModalWorkflowSource', () => {
 
     const wrapper = shallow((
       <ModalWorkflowSource
-        editorState={{}}
+        editorState={EditorState.createEmpty()}
         entityType={{}}
         entity={{}}
         onComplete={() => {}}
@@ -192,7 +194,7 @@ describe('ModalWorkflowSource', () => {
   it('#componentWillUnmount', () => {
     const wrapper = shallow((
       <ModalWorkflowSource
-        editorState={{}}
+        editorState={EditorState.createEmpty()}
         entityType={{}}
         entity={{}}
         onComplete={() => {}}
@@ -335,7 +337,7 @@ describe('ModalWorkflowSource', () => {
     const onClose = jest.fn();
     const wrapper = shallow((
       <ModalWorkflowSource
-        editorState={{}}
+        editorState={EditorState.createEmpty()}
         entityType={{}}
         entity={{}}
         onComplete={() => {}}

--- a/docs/releases/2.1.rst
+++ b/docs/releases/2.1.rst
@@ -37,6 +37,7 @@ Bug fixes
  * Correct dropdown arrow styling in Firefox, IE11 (Janneke Janssen, Alexs Mathilda)
  * Password reset no indicates specific validation errors on certain password restrictions (Lucas Moeskops)
  * Confirmation page on page deletion now respects custom ``get_admin_display_title`` methods (Kim Chee Leong)
+ * Adding external link with selected text now includes text in link chooser (Tony Yates, Thibaud Colas, Alexs Mathilda)
 
 
 Upgrade considerations


### PR DESCRIPTION
As described in issue #4328 selected text wasn't populated when adding
a external link. This commit fixes that issue by borrowing from the following functions :

getSelectedBlocksMap()
getSelectedBlocksList()
getSelectedText()
from <https://github.com/jpuri/draftjs-utils/blob/e81c0ae19c3b0fdef7e0c1b70d924398956be126/js/block.js#L106>

I am not sure new tests are needed?
Tested on Firefox, Chrome, Opera and Safari

New behaviour:

![kapture 2018-03-14 at 16 12 47](https://user-images.githubusercontent.com/769623/37411331-dfa3e448-27a2-11e8-986b-f32551252a8a.gif)
