### PR TITLE
Use specific model implementation when deleting a page

### DIFF
--- a/wagtail/admin/tests/test_pages_views.py
+++ b/wagtail/admin/tests/test_pages_views.py
@@ -2033,6 +2033,13 @@ class TestPageDelete(TestCase, WagtailTestUtils):
         # deletion should not actually happen on GET
         self.assertTrue(SimplePage.objects.filter(id=self.child_page.id).exists())
 
+    def test_page_delete_specific_admin_title(self):
+        response = self.client.get(reverse('wagtailadmin_pages:delete', args=(self.child_page.id, )))
+        self.assertEqual(response.status_code, 200)
+
+        # The admin_display_title specific to ChildPage is shown on the delete confirmation page.
+        self.assertContains(response, self.child_page.get_admin_display_title())
+
     def test_page_delete_bad_permissions(self):
         # Remove privileges from user
         self.user.is_superuser = False

--- a/wagtail/admin/views/pages.py
+++ b/wagtail/admin/views/pages.py
@@ -517,7 +517,7 @@ def edit(request, page_id):
 
 
 def delete(request, page_id):
-    page = get_object_or_404(Page, id=page_id)
+    page = get_object_or_404(Page, id=page_id).specific
     if not page.permissions_for_user(request.user).can_delete():
         raise PermissionDenied
 

--- a/wagtail/tests/testapp/models.py
+++ b/wagtail/tests/testapp/models.py
@@ -141,6 +141,9 @@ class SimplePage(Page):
         FieldPanel('content'),
     ]
 
+    def get_admin_display_title(self):
+        return "%s (simple page)" % super().get_admin_display_title()
+
 
 # Page with Excluded Fields when copied
 class PageWithExcludedCopyField(Page):


### PR DESCRIPTION
This PR fixes #3827:

> When user wants to delete a page this page is retrieved from database as a simple Page model, not a specific instance of this pag

- Get the `specific` implementation of a model in the `delete` method
- Added test to check of the specific `admin_display_title` is shown in the delete confirmation page
