### PR TITLE
redirect to change form if page has no subpage_types

### DIFF
--- a/wagtail/admin/tests/test_pages_views.py
+++ b/wagtail/admin/tests/test_pages_views.py
@@ -3158,12 +3158,12 @@ class TestSubpageBusinessRules(TestCase, WagtailTestUtils):
         self.assertContains(response, BusinessChild.get_verbose_name())
 
     def test_business_child_subpage(self):
-        add_subpage_url = reverse('wagtailadmin_pages:add_subpage', args=(self.business_child.id, ))
+        edit_page_url = reverse('wagtailadmin_pages:edit', args=(self.business_child.id, ))
 
-        # explorer should not contain a link to 'add child page', as this page doesn't accept subpages
+        # explorer should redirect to edit view if the page doesn't accept subpages
         response = self.client.get(reverse('wagtailadmin_explore', args=(self.business_child.id, )))
-        self.assertEqual(response.status_code, 200)
-        self.assertNotContains(response, add_subpage_url)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, edit_page_url)
 
         # this also means that fetching add_subpage is blocked at the permission-check level
         response = self.client.get(reverse('wagtailadmin_pages:add_subpage', args=(self.business_child.id, )))

--- a/wagtail/admin/views/pages.py
+++ b/wagtail/admin/views/pages.py
@@ -38,7 +38,7 @@ def index(request, parent_page_id=None):
     else:
         parent_page = Page.get_first_root_node().specific
 
-    if getattr(parent_page, 'subpage_types', None) == []: # this page type was set as a leaf node in user-land
+    if getattr(parent_page, 'subpage_types', None) == []:  # this page type was set as a leaf node in user-land
         target_url = reverse('wagtailadmin_pages:edit', args=[parent_page_id])
         return redirect(target_url)
 

--- a/wagtail/admin/views/pages.py
+++ b/wagtail/admin/views/pages.py
@@ -38,6 +38,10 @@ def index(request, parent_page_id=None):
     else:
         parent_page = Page.get_first_root_node().specific
 
+    if getattr(parent_page, 'subpage_types', None) == []: # this page type was set as a leaf node in user-land
+        target_url = reverse('wagtailadmin_pages:edit', args=[parent_page_id])
+        return redirect(target_url)
+
     pages = parent_page.get_children().prefetch_related('content_type', 'sites_rooted_here')
 
     # Get page ordering


### PR DESCRIPTION
The admin UX is a little weird in the explore menu for leaf nodes. If a leaf node doesn't have any children (think `BlogIndex -> BlogEntry`), clicking on the title brings up an empty explore menu. This the case even if a model has its `subpage_types` explicitly set to an empty list.

This patch checks if the retrieve `parent_page` has its `subpage_types` set and if it has been explicitly set to an empty list [as per the docs](http://docs.wagtail.io/en/stable/topics/pages.html#an-example-wagtail-page-model), then redirect the user to the edit page for that instance.

I think this matches the expectation for admin users who see a leaf node's title in the explore menu and assume that it will take them to the change form for that instance.

Happy to add tests, documentation, and changelog updates if this kind of edit is desired.