### PR TITLE
Cleanup/3441 snippet modeladmin validation error helper

### DIFF
--- a/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
+++ b/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
@@ -179,6 +179,8 @@ class TestCreateView(TestCase, WagtailTestUtils):
 
         # Check that a form error was raised
         self.assertFormError(response, 'form', 'title', "This field is required.")
+        self.assertContains(response, """<p class="error-message"><span>This field is required.</span></p>""",
+                            count=1, html=True)
 
     def test_exclude_passed_to_extract_panel_definitions(self):
         path_to_form_fields_exclude_property = 'wagtail.contrib.modeladmin.options.ModelAdmin.form_fields_exclude'
@@ -305,6 +307,8 @@ class TestEditView(TestCase, WagtailTestUtils):
 
         # Check that a form error was raised
         self.assertFormError(response, 'form', 'title', "This field is required.")
+        self.assertContains(response, """<p class="error-message"><span>This field is required.</span></p>""",
+                            count=1, html=True)
 
     def test_exclude_passed_to_extract_panel_definitions(self):
         path_to_form_fields_exclude_property = 'wagtail.contrib.modeladmin.options.ModelAdmin.form_fields_exclude'

--- a/wagtail/contrib/modeladmin/views.py
+++ b/wagtail/contrib/modeladmin/views.py
@@ -170,6 +170,9 @@ class ModelFormView(WMABaseView, FormView):
         return redirect(self.get_success_url())
 
     def form_invalid(self, form):
+        messages.validation_error(
+            self.request, self.get_error_message(), form
+        )
         messages.error(self.request, self.get_error_message())
         return self.render_to_response(self.get_context_data())
 

--- a/wagtail/contrib/modeladmin/views.py
+++ b/wagtail/contrib/modeladmin/views.py
@@ -173,7 +173,6 @@ class ModelFormView(WMABaseView, FormView):
         messages.validation_error(
             self.request, self.get_error_message(), form
         )
-        messages.error(self.request, self.get_error_message())
         return self.render_to_response(self.get_context_data())
 
 

--- a/wagtail/contrib/settings/tests/test_admin.py
+++ b/wagtail/contrib/settings/tests/test_admin.py
@@ -72,7 +72,9 @@ class TestSettingCreateView(BaseTestSettingView):
     def test_edit_invalid(self):
         response = self.post(post_data={'foo': 'bar'})
         self.assertContains(response, "The setting could not be saved due to errors.")
-        self.assertContains(response, "This field is required.")
+        self.assertContains(response, """<p class="error-message"><span>This field is required.</span></p>""",
+                            count=2, html=True)
+        self.assertContains(response, "This field is required", count=2)
 
     def test_edit(self):
         response = self.post(post_data={'title': 'Edited site title',
@@ -115,7 +117,9 @@ class TestSettingEditView(BaseTestSettingView):
     def test_edit_invalid(self):
         response = self.post(post_data={'foo': 'bar'})
         self.assertContains(response, "The setting could not be saved due to errors.")
-        self.assertContains(response, "This field is required.")
+        self.assertContains(response, """<p class="error-message"><span>This field is required.</span></p>""",
+                            count=2, html=True)
+        self.assertContains(response, "This field is required", count=2)
 
     def test_edit(self):
         response = self.post(post_data={'title': 'Edited site title',

--- a/wagtail/contrib/settings/views.py
+++ b/wagtail/contrib/settings/views.py
@@ -69,7 +69,9 @@ def edit(request, app_name, model_name, site_pk):
             )
             return redirect('wagtailsettings:edit', app_name, model_name, site.pk)
         else:
-            messages.error(request, _("The setting could not be saved due to errors."))
+            messages.validation_error(
+                request, _("The setting could not be saved due to errors."), form
+            )
             edit_handler = edit_handler.bind_to_instance(
                 instance=instance, form=form)
     else:

--- a/wagtail/snippets/tests.py
+++ b/wagtail/snippets/tests.py
@@ -182,7 +182,9 @@ class TestSnippetCreateView(TestCase, WagtailTestUtils):
     def test_create_invalid(self):
         response = self.post(post_data={'foo': 'bar'})
         self.assertContains(response, "The snippet could not be created due to errors.")
-        self.assertContains(response, "This field is required.")
+        self.assertContains(response, """<p class="error-message"><span>This field is required.</span></p>""",
+                            count=1, html=True)
+        self.assertContains(response, "This field is required", count=1)
 
     def test_create(self):
         response = self.post(post_data={'text': 'test_advert',
@@ -264,7 +266,9 @@ class TestSnippetEditView(BaseTestSnippetEditView):
     def test_edit_invalid(self):
         response = self.post(post_data={'foo': 'bar'})
         self.assertContains(response, "The snippet could not be saved due to errors.")
-        self.assertContains(response, "This field is required.")
+        self.assertContains(response, """<p class="error-message"><span>This field is required.</span></p>""",
+                            count=1, html=True)
+        self.assertContains(response, "This field is required", count=1)
 
     def test_edit(self):
         response = self.post(post_data={'text': 'edited_test_advert',

--- a/wagtail/snippets/views/snippets.py
+++ b/wagtail/snippets/views/snippets.py
@@ -151,7 +151,9 @@ def create(request, app_label, model_name):
             )
             return redirect('wagtailsnippets:list', app_label, model_name)
         else:
-            messages.error(request, _("The snippet could not be created due to errors."))
+            messages.validation_error(
+                request, _("The snippet could not be created due to errors."), form
+            )
             edit_handler = edit_handler.bind_to_instance(instance=instance,
                                                          form=form)
     else:
@@ -197,7 +199,9 @@ def edit(request, app_label, model_name, pk):
             )
             return redirect('wagtailsnippets:list', app_label, model_name)
         else:
-            messages.error(request, _("The snippet could not be saved due to errors."))
+            messages.validation_error(
+                request, _("The snippet could not be saved due to errors."), form
+            )
             edit_handler = edit_handler.bind_to_instance(instance=instance,
                                                          form=form)
     else:


### PR DESCRIPTION
Cleanup tasks for #3441 

Added the validation_message funtion to:

- Snippets

- Modeladmin

- `contrib.settings`

Also updated the tests that run through this code