### PR TITLE
Cleanup for the `Block.__eq__` method

### DIFF
--- a/wagtail/core/blocks/base.py
+++ b/wagtail/core/blocks/base.py
@@ -358,19 +358,19 @@ class Block(metaclass=BaseBlock):
 
     def __eq__(self, other):
         """
-        The deep_deconstruct method in django.db.migrations.autodetector.MigrationAutodetector does not
-        recurse into arbitrary lists and dicts. As a result, when it is passed a field such as:
-            StreamField([
-                ('heading', CharBlock()),
-            ])
-        the CharBlock object will be left in its constructed form. This causes problems when
-        MigrationAutodetector compares two separate instances of the StreamField from different project
-        states: since the CharBlocks are different objects, it will report a change where there isn't one.
+        Implement equality on block objects so that two blocks with matching definitions are considered
+        equal. (Block objects are intended to be immutable with the exception of set_name(), so here
+        'matching definitions' means that both the 'name' property and the constructor args/kwargs - as
+        captured in _constructor_args - are equal on both blocks.)
 
-        To prevent this, we implement the equality operator on Block instances such that the two CharBlocks
-        are reported as equal. Since block objects are intended to be immutable with the exception of
-        set_name(), it is sufficient to compare the 'name' property and the constructor args/kwargs of the
-        two block objects. The 'deconstruct' method provides a convenient way to access the latter.
+        This was originally necessary as a workaround for https://code.djangoproject.com/ticket/24340
+        in Django <1.9; the deep_deconstruct function used to detect changes for migrations did not
+        recurse into the block lists, and left them as Block instances. This __eq__ method therefore
+        came into play when identifying changes within migrations.
+
+        As of Django >=1.9, this *probably* isn't required any more. However, it may be useful in
+        future as a way of identifying blocks that can be re-used within StreamField definitions
+        (https://github.com/wagtail/wagtail/issues/4298#issuecomment-367656028).
         """
 
         if not isinstance(other, Block):

--- a/wagtail/core/blocks/stream_block.py
+++ b/wagtail/core/blocks/stream_block.py
@@ -298,7 +298,7 @@ class BaseStreamBlock(Block):
         to a custom subclass in the user's models.py that may or may not stick around.
         """
         path = 'wagtail.core.blocks.StreamBlock'
-        args = [self.child_blocks.items()]
+        args = [list(self.child_blocks.items())]
         kwargs = self._constructor_kwargs
         return (path, args, kwargs)
 

--- a/wagtail/core/blocks/struct_block.py
+++ b/wagtail/core/blocks/struct_block.py
@@ -183,7 +183,7 @@ class BaseStructBlock(Block):
         to a custom subclass in the user's models.py that may or may not stick around.
         """
         path = 'wagtail.core.blocks.StructBlock'
-        args = [self.child_blocks.items()]
+        args = [list(self.child_blocks.items())]
         kwargs = self._constructor_kwargs
         return (path, args, kwargs)
 

--- a/wagtail/core/fields.py
+++ b/wagtail/core/fields.py
@@ -56,7 +56,7 @@ class StreamField(models.Field):
 
     def deconstruct(self):
         name, path, _, kwargs = super().deconstruct()
-        block_types = self.stream_block.child_blocks.items()
+        block_types = list(self.stream_block.child_blocks.items())
         args = [block_types]
         return name, path, args, kwargs
 

--- a/wagtail/core/tests/test_blocks.py
+++ b/wagtail/core/tests/test_blocks.py
@@ -3010,7 +3010,7 @@ class TestSystemCheck(TestCase):
         self.assertEqual(errors[0].obj, failing_block_1)
         self.assertEqual(errors[1].id, 'wagtailcore.E001')
         self.assertEqual(errors[1].hint, "Block names cannot contain spaces")
-        self.assertEqual(errors[0].obj, failing_block_2)
+        self.assertEqual(errors[1].obj, failing_block_2)
 
 
 class TestTemplateRendering(TestCase):


### PR DESCRIPTION
A bit of cleanup that doesn't do very much by itself, but takes us a few baby steps towards https://github.com/wagtail/wagtail/issues/4298#issuecomment-367656028 (which I'm probably not going to get round to this week, so I didn't want to leave these commits in limbo).

TLDR: when StreamField was first implemented, we had to implement the equality operator on Block to work around [a Django bug](https://code.djangoproject.com/ticket/24340) that broke the `makemigrations` change detection logic. In theory, this code _should_ have been redundant ever since Django 1.9, but: A) it wasn't, due to a couple of silly oversights; and B) the docstring for `__eq__` still referred to that long-fixed bug.