### PR TITLE
Improve password reset error messages - fix #4097

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/account/password_reset/confirm.html
+++ b/wagtail/admin/templates/wagtailadmin/account/password_reset/confirm.html
@@ -4,46 +4,46 @@
 {% block bodyclass %}login{% endblock %}
 
 {% block extra_css %}
-{{ block.super }}
+    {{ block.super }}
 
-<link rel="stylesheet" href="{% static 'wagtailadmin/css/layouts/login.css' %}" type="text/css" />
+    <link rel="stylesheet" href="{% static 'wagtailadmin/css/layouts/login.css' %}" type="text/css" />
 {% endblock %}
 
 {% block furniture %}
-<div class="content-wrapper">
+    <div class="content-wrapper">
 
-    {% if form.errors %}
-    <div class="messages">
-        <ul>
+      {% if form.errors %}
+        <div class="messages">
+          <ul>
             <li class="error">{% trans 'Password reset failed. Please see the errors below.' %}</li>
-        </ul>
-        {{ form.non_field_errors }}
+          </ul>
+          {{ form.non_field_errors }}
+        </div>
+      {% endif %}
+
+        <form method="post" novalidate>
+            {% csrf_token %}
+            <h1>{% trans "Set your new password" %}</h1>
+
+            <ul class="fields">
+                <li>
+                  <div class="field">
+                      {{ form.new_password1.label_tag }}
+                      {{ form.new_password1 }}
+                      {{ form.errors.new_password1 }}
+                  </div>
+                </li>
+                <li>
+                  <div class="field">
+                      {{ form.new_password2.label_tag }}
+                      {{ form.new_password2 }}
+                      {{ form.errors.new_password2 }}
+                  </div>
+                </li>
+                <li class="submit">
+                    <input type="submit" value="{% trans 'Reset password' %}" class="button" />
+                </li>
+            </ul>
+        </form>
     </div>
-    {% endif %}
-
-    <form method="post" novalidate>
-        {% csrf_token %}
-        <h1>{% trans "Set your new password" %}</h1>
-
-        <ul class="fields">
-            <li>
-                <div class="field">
-                    {{ form.new_password1.label_tag }}
-                    {{ form.new_password1 }}
-                    {{ form.errors.new_password1 }}
-                </div>
-            </li>
-            <li>
-                <div class="field">
-                    {{ form.new_password2.label_tag }}
-                    {{ form.new_password2 }}
-                    {{ form.errors.new_password2 }}
-                </div>
-            </li>
-            <li class="submit">
-                <input type="submit" value="{% trans 'Reset password' %}" class="button" />
-            </li>
-        </ul>
-    </form>
-</div>
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/account/password_reset/confirm.html
+++ b/wagtail/admin/templates/wagtailadmin/account/password_reset/confirm.html
@@ -4,43 +4,46 @@
 {% block bodyclass %}login{% endblock %}
 
 {% block extra_css %}
-    {{ block.super }}
+{{ block.super }}
 
-    <link rel="stylesheet" href="{% static 'wagtailadmin/css/layouts/login.css' %}" type="text/css" />
+<link rel="stylesheet" href="{% static 'wagtailadmin/css/layouts/login.css' %}" type="text/css" />
 {% endblock %}
 
 {% block furniture %}
-    <div class="content-wrapper">
+<div class="content-wrapper">
 
-        {% if form.errors %}
-            <div class="messages">
-                <ul>
-                    <li class="error">{% trans "The passwords do not match. Please try again." %}</li>
-                </ul>
-            </div>
-        {% endif %}
-
-        <form method="post" novalidate>
-            {% csrf_token %}
-            <h1>{% trans "Set your new password" %}</h1>
-
-            <ul class="fields">
-                <li>
-                  <div class="field">
-                      {{ form.new_password1.label_tag }}
-                      {{ form.new_password1 }}
-                  </div>
-                </li>
-                <li>
-                  <div class="field">
-                      {{ form.new_password2.label_tag }}
-                      {{ form.new_password2 }}
-                  </div>
-                </li>
-                <li class="submit">
-                    <input type="submit" value="{% trans 'Reset password' %}" class="button" />
-                </li>
-            </ul>
-        </form>
+    {% if form.errors %}
+    <div class="messages">
+        <ul>
+            <li class="error">{% trans 'Password reset failed. Please see the errors below.' %}</li>
+        </ul>
+        {{ form.non_field_errors }}
     </div>
+    {% endif %}
+
+    <form method="post" novalidate>
+        {% csrf_token %}
+        <h1>{% trans "Set your new password" %}</h1>
+
+        <ul class="fields">
+            <li>
+                <div class="field">
+                    {{ form.new_password1.label_tag }}
+                    {{ form.new_password1 }}
+                    {{ form.errors.new_password1 }}
+                </div>
+            </li>
+            <li>
+                <div class="field">
+                    {{ form.new_password2.label_tag }}
+                    {{ form.new_password2 }}
+                    {{ form.errors.new_password2 }}
+                </div>
+            </li>
+            <li class="submit">
+                <input type="submit" value="{% trans 'Reset password' %}" class="button" />
+            </li>
+        </ul>
+    </form>
+</div>
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/account/password_reset/confirm.html
+++ b/wagtail/admin/templates/wagtailadmin/account/password_reset/confirm.html
@@ -21,22 +21,28 @@
                     <div class="field">
                         {{ form.new_password1.label_tag }}
                         {{ form.new_password1 }}
-                        <div class="help-block help-critical">
-                          {% for error in form.new_password1.errors %}
-                            <p class="error">{{ error }}</p>
-                          {% endfor %}
-                        </div>
+
+                        {% if form.new_password1.errors %}
+                          <div class="help-block help-critical">
+                            {% for error in form.new_password1.errors %}
+                              <p class="error">{{ error }}</p>
+                            {% endfor %}
+                          </div>
+                        {% endif %}
                     </div>
                 </li>
                 <li>
                     <div class="field">
                         {{ form.new_password2.label_tag }}
                         {{ form.new_password2 }}
-                        <div class="help-block help-critical">
-                          {% for error in form.new_password2.errors %}
-                            <p class="error">{{ error }}</p>
-                          {% endfor %}
-                        </div>
+
+                        {% if form.new_password2.errors %}
+                          <div class="help-block help-critical">
+                            {% for error in form.new_password2.errors %}
+                              <p class="error">{{ error }}</p>
+                            {% endfor %}
+                          </div>
+                        {% endif %}
                     </div>
                 </li>
                 <li class="submit">

--- a/wagtail/admin/templates/wagtailadmin/account/password_reset/confirm.html
+++ b/wagtail/admin/templates/wagtailadmin/account/password_reset/confirm.html
@@ -12,33 +12,32 @@
 {% block furniture %}
     <div class="content-wrapper">
 
-      {% if form.errors %}
-        <div class="messages">
-          <ul>
-            <li class="error">{% trans 'Password reset failed. Please see the errors below.' %}</li>
-          </ul>
-          {{ form.non_field_errors }}
-        </div>
-      {% endif %}
-
         <form method="post" novalidate>
             {% csrf_token %}
             <h1>{% trans "Set your new password" %}</h1>
 
             <ul class="fields">
                 <li>
-                  <div class="field">
-                      {{ form.new_password1.label_tag }}
-                      {{ form.new_password1 }}
-                      {{ form.errors.new_password1 }}
-                  </div>
+                    <div class="field">
+                        {{ form.new_password1.label_tag }}
+                        {{ form.new_password1 }}
+                        <div class="help-block help-critical">
+                          {% for error in form.new_password1.errors %}
+                            <p class="error">{{ error }}</p>
+                          {% endfor %}
+                        </div>
+                    </div>
                 </li>
                 <li>
-                  <div class="field">
-                      {{ form.new_password2.label_tag }}
-                      {{ form.new_password2 }}
-                      {{ form.errors.new_password2 }}
-                  </div>
+                    <div class="field">
+                        {{ form.new_password2.label_tag }}
+                        {{ form.new_password2 }}
+                        <div class="help-block help-critical">
+                          {% for error in form.new_password2.errors %}
+                            <p class="error">{{ error }}</p>
+                          {% endfor %}
+                        </div>
+                    </div>
                 </li>
                 <li class="submit">
                     <input type="submit" value="{% trans 'Reset password' %}" class="button" />


### PR DESCRIPTION
Fixes #4097

The error messages are coming from django and are bound to fields (e.g. 'This field is required'). Therefor I put them next to the fields. 

Together with @jjanssen we came to this style, although she mentions that the general style for these forms should be improved soon.
![issue-4097](https://user-images.githubusercontent.com/12407502/37459564-ce00900a-2848-11e8-9ac7-ebe2d3e2d9a4.png)
