### PR TITLE
Handle ValueError in case the form send '' instead of int for ChooserBlock

### DIFF
--- a/wagtail/core/blocks/field_block.py
+++ b/wagtail/core/blocks/field_block.py
@@ -571,7 +571,7 @@ class ChooserBlock(FieldBlock):
         else:
             try:
                 return self.target_model.objects.get(pk=value)
-            except self.target_model.DoesNotExist:
+            except (self.target_model.DoesNotExist, ValueError):
                 return None
 
     def clean(self, value):


### PR DESCRIPTION
I encountered an issue while extending `ChooserBlock` to work with a Django model. As mentioned in Issue #1806 `SnippetChooserBlock` is the recommended method. I am not sure if this should go into Wagtail core so thought to get the views from core developers.

The following code works fine but when no service is selected Instead of giving `Validation error: Field required` got Server error `ValueError: invalid literal for int() with base 10:`.

```python
class ServiceChooserBlock(blocks.ChooserBlock):
     target_model = Service
     widget = forms.Select
```

On looking into the code, `value_from_form ` is the function which takes value from the form. When no service is selected, the value sent by form is `''` which breaks here 

```python
return self.target_model.objects.get(pk=value)
```