### PR TITLE
Add icon template tag with accessibility options (PoC)

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -20,6 +20,7 @@ Changelog
  * Add request parameter to edit handlers (Rajeev J Sebastian)
  * ImageChooser now sets a default title based on filename (Coen van der Kamp)
  * Added error handling to the Draftail editor (Thibaud Colas)
+ * Add new `wagtail_icon` template tag to facilitate making admin icons accessible (Sander Tuit)
  * Fix: Status button on 'edit page' now links to the correct URL when live and draft slug differ (LB (Ben Johnston))
  * Fix: Image title text in the gallery and in the chooser now wraps for long filenames (LB (Ben Johnston), Luiz Boaretto)
  * Fix: Move image editor action buttons to the bottom of the form on mobile (Julian Gallo)

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -291,6 +291,7 @@ Contributors
 * Alejandro Garza
 * Rajeev J Sebastian
 * Coen van der Kamp
+* Sander Tuit
 
 Translators
 ===========

--- a/docs/releases/2.1.rst
+++ b/docs/releases/2.1.rst
@@ -34,6 +34,7 @@ Other features
  * Add request parameter to edit handlers (Rajeev J Sebastian)
  * ImageChooser now sets a default title based on filename (Coen van der Kamp)
  * Added error handling to the Draftail editor (Thibaud Colas)
+ * Add new `wagtail_icon` template tag to facilitate making admin icons accessible (Sander Tuit)
 
 Bug fixes
 ~~~~~~~~~

--- a/wagtail/admin/templates/wagtailadmin/shared/icon.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/icon.html
@@ -1,0 +1,2 @@
+<span class="{{ classnames }}" {% if decorative %}aria-hidden="true"{% else %}title="{{ title }}"{% endif %}></span>
+{% if show_label %}{{ title }}{% elif not decorative %}<span class="sr-only">{{ title }}</span>{% endif %}

--- a/wagtail/admin/templates/wagtailadmin/shared/wagtail_icon.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/wagtail_icon.html
@@ -1,0 +1,9 @@
+{% spaceless %}
+{# Reference implementation: components/Icon.js #}
+<span>
+    <span class="icon icon-{{ name }} {{ className }}" aria-hidden="true"></span>
+    {% if title %}
+        <span class="visuallyhidden">{{ title }}</span>
+    {% endif %}
+</span>
+{% endspaceless %}

--- a/wagtail/admin/templatetags/wagtailui_tags.py
+++ b/wagtail/admin/templatetags/wagtailui_tags.py
@@ -3,16 +3,15 @@ from django import template
 register = template.Library()
 
 
-@register.inclusion_tag("wagtailadmin/shared/icon.html",
-                        takes_context=False)
-def wagtail_icon(classnames, title='', show_label=True, decorative=True):
+@register.inclusion_tag("wagtailadmin/shared/wagtail_icon.html", takes_context=False)
+def wagtail_icon(name=None, classname='', title=None):
     """
-    Usage: {% wagtail_icon classnames title show_label decorative %}
+    Usage: {% wagtail_icon name="cogs" classname="icon--red" title="Settings" %}
 
-    The css classes necessary to show the icon are provided as a first argument.
-    The 'title' argument is optional, but recommended. When 'show_label' is True, the title is shown next to the icon.
-    When an icon is marked decorative, it is hidden for screenreaders (a11y). If 'decorative' is False, the title is
-    visible for screenreaders, regardless whether 'show_label' is True or not.
-
+    First load the tags with {% load wagtailui_tags %}
     """
-    return {'classnames': classnames, 'title': title, 'show_label': show_label, 'decorative': decorative}
+    return {
+        'name': name,
+        'classname': classname,
+        'title': title,
+    }

--- a/wagtail/admin/templatetags/wagtailui_tags.py
+++ b/wagtail/admin/templatetags/wagtailui_tags.py
@@ -1,0 +1,17 @@
+from django import template
+
+register = template.Library()
+
+
+@register.inclusion_tag("wagtailadmin/shared/icon.html",
+                        takes_context=False)
+def wagtail_icon(classnames, title='', show_label=True, decorative=True):
+    """
+    Usage: {% wagtail_icon title show_label decorative %}
+
+    The 'title' argument is optional, but recommended. When 'show_label' is True, the title is shown next to the icon.
+    When an icon is marked decorative, it is hidden for screenreaders (a11y). If 'decorative' is False, the title is
+    visible for screenreaders, regardless whether 'show_label' is True or not.
+
+    """
+    return {'classnames': classnames, 'title': title, 'show_label': show_label, 'decorative': decorative}

--- a/wagtail/admin/templatetags/wagtailui_tags.py
+++ b/wagtail/admin/templatetags/wagtailui_tags.py
@@ -7,8 +7,9 @@ register = template.Library()
                         takes_context=False)
 def wagtail_icon(classnames, title='', show_label=True, decorative=True):
     """
-    Usage: {% wagtail_icon title show_label decorative %}
+    Usage: {% wagtail_icon classnames title show_label decorative %}
 
+    The css classes necessary to show the icon are provided as a first argument.
     The 'title' argument is optional, but recommended. When 'show_label' is True, the title is shown next to the icon.
     When an icon is marked decorative, it is hidden for screenreaders (a11y). If 'decorative' is False, the title is
     visible for screenreaders, regardless whether 'show_label' is True or not.


### PR DESCRIPTION
At the moment, the admin interface has accessibility issues, as mentioned in https://github.com/wagtail/wagtail/issues/4199. One of these issues is with icons (from the icon font): these add characters to the admin when read out loud by a screenreader. Some icons don't have an accompanying label and are not accessible at all for screenreader users. 

To address these issues, icons shouldn't be defined on the enclosing element, for instance a `<a>` tag, but should be defined in their own element, for instance a `<span>`. To facilitate this, this proof-of-concept adds a template tag for icons. The template tag generates an accessible icon by default:
- When the icon is decorative only, it will be hidden from screenreaders (`aria-hidden`)
- When the icon has a (visible) label, the label will be read out loud by screenreaders
- When the icon doesn't have a visible label but is non-decorative, the text will be hidden, but will be read out loud by screenreaders. (`'class="sr-only"`)

By using a template tag, icon usage can be standardized as a re-usable 'component'. In this proof-of-concept we chose to use a separate template tag library, which can be expanded to include other UI components like buttons. By using a template tag it's also possible to change the interface icon-by-icon, which might be necessary since switching to separate `<span>`'s requires CSS changes.
