### PR TITLE
Added overview of collections in the Image/Document chooser templates

### DIFF
--- a/wagtail/documents/templates/wagtaildocs/documents/list.html
+++ b/wagtail/documents/templates/wagtaildocs/documents/list.html
@@ -15,6 +15,7 @@
                 {% endif %}
             </th>
             <th>{% trans "File" %}</th>
+            <th>{% trans "Collection" %}</th>
             <th>
                 {% if not is_searching %}
                     <a href="{% url 'wagtaildocs:index' %}{% if not ordering == "-created_at" %}?ordering=-created_at{% endif %}" class="icon icon-arrow-down-after {% if  ordering == "-created_at" %}teal{% endif %}">
@@ -37,6 +38,7 @@
                     {% endif %}
                 </td>
                 <td><a href="{{ doc.url }}" class="nolink" download>{{ doc.filename }}</a></td>
+                <td>{{ doc.collection.name }}</td>
                 <td><div class="human-readable-date" title="{{ doc.created_at|date:"d M Y H:i" }}">{% blocktrans with time_period=doc.created_at|timesince %}{{ time_period }} ago{% endblocktrans %}</div></td>
             </tr>
         {% endfor %}

--- a/wagtail/images/templates/wagtailimages/chooser/results.html
+++ b/wagtail/images/templates/wagtailimages/chooser/results.html
@@ -12,11 +12,11 @@
     {% else %}
         <h2>{% trans "Latest images" %}</h2>
     {% endif %}
-    
+
     <ul class="listing horiz images chooser">
         {% for image in images %}
             <li>
-                <a class="image-choice" href="{% if will_select_format %}{% url 'wagtailimages:chooser_select_format' image.id %}{% else %}{% url 'wagtailimages:image_chosen' image.id %}{% endif %}">
+                <a class="image-choice" title="{{ image.collection.name }} » {{ image.title }}" href="{% if will_select_format %}{% url 'wagtailimages:chooser_select_format' image.id %}{% else %}{% url 'wagtailimages:image_chosen' image.id %}{% endif %}">
                     <div class="image">{% image image max-165x165 class="show-transparency" %}</div>
                     <h3>{{ image.title|ellipsistrim:60 }}</h3>
                 </a>

--- a/wagtail/images/templates/wagtailimages/images/results.html
+++ b/wagtail/images/templates/wagtailimages/images/results.html
@@ -9,7 +9,7 @@
             There are {{ counter }} matches
         {% endblocktrans %}
         </h2>
-        
+
         {% search_other %}
     {% else %}
         <h2>{% trans "Latest images" %}</h2>
@@ -18,7 +18,7 @@
     <ul class="listing horiz images">
         {% for image in images %}
             <li>
-                <a class="image-choice" href="{% url 'wagtailimages:edit' image.id %}">
+                <a class="image-choice" title="{{ image.collection.name }} » {{ image.title }}" href="{% url 'wagtailimages:edit' image.id %}">
                     {% include "wagtailimages/images/results_image.html" %}
                     <h3>{{ image.title|ellipsistrim:60 }}</h3>
                 </a>
@@ -31,7 +31,7 @@
 {% else %}
     {% if is_searching %}
         <h2>{% blocktrans %}Sorry, no images match "<em>{{ query_string }}</em>"{% endblocktrans %}</h2>
-        
+
         {% search_other %}
     {% else %}
         {% url 'wagtailimages:add_multiple' as wagtailimages_add_image_url %}


### PR DESCRIPTION
According to request in https://github.com/wagtail/wagtail/issues/4162
*On the document chooser I added a new column with the name of the collection, so we can have a clear overview of where is the document stored.  (see screenshot)
*For the image chooser I thought adding the name would create too much clutter, so thought about adding it as a `title` attribute on the image container with the format `Collection » Image name` (Currently we don't have a `title` attribute)  (see screenshot)


![image](https://user-images.githubusercontent.com/3624620/37464429-927eb4b6-2858-11e8-8376-a26514fffa2d.png)
![image](https://user-images.githubusercontent.com/3624620/37465010-568e255c-285a-11e8-99a0-8c38a0b9ee56.png)

