### PR TITLE
Remove assert statements from Wagtail API

### DIFF
--- a/wagtail/api/v2/filters.py
+++ b/wagtail/api/v2/filters.py
@@ -143,10 +143,11 @@ class ChildOfFilter(BaseFilterBackend):
         if 'child_of' in request.GET:
             try:
                 parent_page_id = int(request.GET['child_of'])
-                assert parent_page_id >= 0
+                if parent_page_id < 0:
+                    raise ValueError()
 
                 parent_page = self.get_page_by_id(request, parent_page_id)
-            except (ValueError, AssertionError):
+            except ValueError:
                 if request.GET['child_of'] == 'root':
                     parent_page = self.get_root_page(request)
                 else:

--- a/wagtail/api/v2/filters.py
+++ b/wagtail/api/v2/filters.py
@@ -191,10 +191,11 @@ class DescendantOfFilter(BaseFilterBackend):
                 raise BadRequestError("filtering by descendant_of with child_of is not supported")
             try:
                 parent_page_id = int(request.GET['descendant_of'])
-                assert parent_page_id >= 0
+                if parent_page_id < 0:
+                    raise ValueError()
 
                 parent_page = self.get_page_by_id(request, parent_page_id)
-            except (ValueError, AssertionError):
+            except ValueError:
                 if request.GET['descendant_of'] == 'root':
                     parent_page = self.get_root_page(request)
                 else:

--- a/wagtail/api/v2/pagination.py
+++ b/wagtail/api/v2/pagination.py
@@ -13,20 +13,22 @@ class WagtailPagination(BasePagination):
 
         try:
             offset = int(request.GET.get('offset', 0))
-            assert offset >= 0
-        except (ValueError, AssertionError):
+            if offset < 0:
+                raise ValueError()
+        except ValueError:
             raise BadRequestError("offset must be a positive integer")
 
         try:
             limit_default = 20 if not limit_max else min(20, limit_max)
             limit = int(request.GET.get('limit', limit_default))
-
-            if limit_max and limit > limit_max:
-                raise BadRequestError("limit cannot be higher than %d" % limit_max)
-
-            assert limit >= 0
-        except (ValueError, AssertionError):
+            if limit < 0:
+                raise ValueError()
+        except ValueError:
             raise BadRequestError("limit must be a positive integer")
+
+        if limit_max and limit > limit_max:
+            raise BadRequestError(
+                "limit cannot be higher than %d" % limit_max)
 
         start = offset
         stop = offset + limit


### PR DESCRIPTION
This PR fixes #4186:

> There's a few places in Wagtail API where we used assert statements to check parameters. These statements are removed when Python optimisations are enabled so we should replace these.

This PR is best reviewed commit by commit. The asserts have been removed and tests have been added for the filters which have been changed.

