### PR TITLE
4391 Add invalid password reset link error message

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -11,6 +11,7 @@ Changelog
  * Remove outdated X-UA-Compatible meta from admin template  (Thibaud Colas)
  * Add JavaScript source maps in production build for packaged Wagtail (Thibaud Colas)
  * Removed `assert` statements from Wagtail API (Kim Chee Leong)
+ * Add invalid password reset link error message (Coen van der Kamp)
  * Fix: Status button on 'edit page' now links to the correct URL when live and draft slug differ (LB (Ben Johnston))
  * Fix: Image title text in the gallery and in the chooser now wraps for long filenames (LB (Ben Johnston), Luiz Boaretto)
  * Fix: Move image editor action buttons to the bottom of the form on mobile (Julian Gallo)

--- a/wagtail/admin/templates/wagtailadmin/account/password_reset/confirm.html
+++ b/wagtail/admin/templates/wagtailadmin/account/password_reset/confirm.html
@@ -11,6 +11,14 @@
 
 {% block furniture %}
     <div class="content-wrapper">
+    {% if validlink %}
+        {% if form.errors %}
+            <div class="messages">
+                <ul>
+                    <li class="error">{% trans "The passwords do not match. Please try again." %}</li>
+                </ul>
+            </div>
+        {% endif %}
 
         <form method="post" novalidate>
             {% csrf_token %}
@@ -50,5 +58,16 @@
                 </li>
             </ul>
         </form>
+    {% else %}
+        <h1>{% trans "Invalid password reset link" %}</h1>
+        <div class="messages">
+            <ul>
+                <li class="error">
+                    {% trans "The password reset link was invalid, possibly because it has already been used. Please request a new password reset." %}
+                </li>
+            </ul>
+        </div>
+    {% endif %}
+
     </div>
 {% endblock %}

--- a/wagtail/admin/tests/test_account_management.py
+++ b/wagtail/admin/tests/test_account_management.py
@@ -511,6 +511,25 @@ class TestPasswordReset(TestCase, WagtailTestUtils):
         # Create url_args
         self.url_kwargs = dict(uidb64=self.password_reset_uid, token=self.password_reset_token)
 
+    def test_password_reset_confirm_view_invalid_link(self):
+        """
+        This tests that the password reset view shows an error message if the link is invalid
+        """
+        self.setup_password_reset_confirm_tests()
+
+        # Create invalid url_args
+        self.url_kwargs = dict(uidb64=self.password_reset_uid, token="invalid-token")
+
+        # Get password reset confirm page
+        response = self.client.get(reverse('wagtailadmin_password_reset_confirm', kwargs=self.url_kwargs))
+
+        # Check that the user received a password confirm done page
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'wagtailadmin/account/password_reset/confirm.html')
+        self.assertFalse(response.context['validlink'])
+        self.assertContains(response, 'The password reset link was invalid, possibly because it has already '
+                                      'been used. Please request a new password reset.')
+
     def test_password_reset_confirm_view(self):
         """
         This tests that the password reset confirm view returns a password reset confirm page


### PR DESCRIPTION
@jjanssen,

The Wagtail `password_reset_confirm` view is just a small wrapper around Django `password_reset_confirm`. It has `validlink` var in the context. I used it to display the error message, in the same way this is done in Django itself.

I'm not a native speaker. But shouldn't 'The password reset link was invalid' read 'The password reset link is invalid'? The link was and _still is_ invalid.

* Do the tests still pass? YES
* Does the code comply with the style guide? YES
* For Python changes: Have you added tests to cover the new/fixed behaviour? YES
* For front-end changes: Did you test on all of Wagtail’s supported browsers? Not required
* For new features: Has the documentation been updated accordingly? Not required