### PR TITLE
in a rich text field, only generate hyperlinks to pages that are live

### DIFF
--- a/wagtail/core/rich_text/pages.py
+++ b/wagtail/core/rich_text/pages.py
@@ -22,7 +22,7 @@ class PageLinkHandler:
     @staticmethod
     def expand_db_attributes(attrs):
         try:
-            page = Page.objects.get(id=attrs['id'])
+            page = Page.objects.get(id=attrs['id'], live=True)
 
             attrs = 'data-linktype="page" data-id="%d" ' % page.id
             parent_page = page.get_parent()


### PR DESCRIPTION
as far as i understand it, this code should respect the publication status of a page. The code already tries to gracefully handle nonexistent pages, and it seems to me that the rich text filter should behave the same way for pages that exist, but aren't live. Of course, if this is in error, feel free to close this PR

Thanks for contributing to Wagtail! 🎉

Before submitting, please review the contributor guidelines <http://docs.wagtail.io/en/latest/contributing/index.html> and check the following:

* Do the tests still pass? (http://docs.wagtail.io/en/latest/contributing/developing.html#testing)
* Does the code comply with the style guide? (Run `make lint` from the Wagtail root)
* For Python changes: Have you added tests to cover the new/fixed behaviour?
* For front-end changes: Did you test on all of Wagtail’s supported browsers? **Please list the exact versions you tested**.
* For new features: Has the documentation been updated accordingly?
