### PR TITLE
Use specific page objects on reorder listings with <100 items

### DIFF
--- a/wagtail/admin/tests/test_pages_views.py
+++ b/wagtail/admin/tests/test_pages_views.py
@@ -266,6 +266,12 @@ class TestPageExplorer(TestCase, WagtailTestUtils):
         response = self.client.get(reverse('wagtailadmin_explore', args=(self.new_event.id, )))
         self.assertContains(response, 'New event (single event)')
 
+        # Reorder view should also use specific pages
+        # (provided there are <100 pages in the listing, as this may be a significant
+        # performance hit on larger listings)
+        response = self.client.get(reverse('wagtailadmin_explore', args=(self.root_page.id, )) + '?ordering=ord')
+        self.assertContains(response, 'New event (single event)')
+
     def test_parent_page_is_specific(self):
         response = self.client.get(reverse('wagtailadmin_explore', args=(self.child_page.id, )))
         self.assertEqual(response.status_code, 200)

--- a/wagtail/admin/views/pages.py
+++ b/wagtail/admin/views/pages.py
@@ -78,10 +78,12 @@ def index(request, parent_page_id=None):
     # allow drag-and-drop reordering
     do_paginate = ordering != 'ord'
 
-    if do_paginate:
-        # Retrieve pages in their most specific form.
-        # Only do this for paginated listings, as this could potentially be a
-        # very expensive operation when performed on a large queryset.
+    if do_paginate or pages.count() < 100:
+        # Retrieve pages in their most specific form, so that custom
+        # get_admin_display_title and get_url_parts methods on subclasses are respected.
+        # However, skip this on unpaginated listings with >100 child pages as this could
+        # be a significant performance hit. (This should only happen on the reorder view,
+        # and hopefully no-one is having to do manual reordering on listings that large...)
         pages = pages.specific()
 
     # allow hooks to modify the queryset


### PR DESCRIPTION
Currently we call `specific()` on the page explorer listing, with the exception of the 'reorder' view because it is unpaginated and the performance hit of `specific()` might be unacceptable on very large querysets.

As an increasing number of people are making use of custom `get_admin_display_title` methods, they're running into this workaround, and in some cases proposing fixes that are less performant than simply adding the `specific()` - #4300, #4396.

This PR partially mitigates this by applying the `specific()` on listings of less than 100 pages. Hopefully this will fix things for the majority of users - manually ordering a section with >100 pages is going to be a pretty horrible experience either way (and is best addressed by #882...)