### PR TITLE
Ensure breadcrumb respects custom get_admin_display_title methods

### DIFF
--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -60,7 +60,7 @@ def explorer_breadcrumb(context, page, include_self=False):
         return {'pages': Page.objects.none()}
 
     return {
-        'pages': page.get_ancestors(inclusive=include_self).descendant_of(cca, inclusive=True)
+        'pages': page.get_ancestors(inclusive=include_self).descendant_of(cca, inclusive=True).specific()
     }
 
 

--- a/wagtail/admin/tests/test_pages_views.py
+++ b/wagtail/admin/tests/test_pages_views.py
@@ -303,6 +303,21 @@ class TestPageExplorer(TestCase, WagtailTestUtils):
         self.assertTemplateUsed(response, 'wagtailadmin/pages/index.html')
 
 
+class TestBreadcrumb(TestCase, WagtailTestUtils):
+    fixtures = ['test.json']
+
+    def test_breadcrumb_uses_specific_titles(self):
+        self.user = self.login()
+
+        # get the explorer view for a subpage of a SimplePage
+        page = Page.objects.get(url_path='/home/secret-plans/steal-underpants/')
+        response = self.client.get(reverse('wagtailadmin_explore', args=(page.id, )))
+
+        # The breadcrumb should pick up SimplePage's overridden get_admin_display_title method
+        expected_url = reverse('wagtailadmin_explore', args=(Page.objects.get(url_path='/home/secret-plans/').id, ))
+        self.assertContains(response, """<li><a href="%s">Secret plans (simple page)</a></li>""" % expected_url)
+
+
 class TestPageExplorerSignposting(TestCase, WagtailTestUtils):
     fixtures = ['test.json']
 


### PR DESCRIPTION
Fixes #4353.

Have gone with a slightly revised approach to #4354 / #4368 - calling `specific()` on the queryset is marginally more efficient as it allows multiple pages of the same type to be fetched in the same query, and generally it's neater to have the `specific` call as early as possible in the workflow. Test added.