### PR TITLE
Add Python 2 check to `wagtail` command

### DIFF
--- a/wagtail/bin/wagtail.py
+++ b/wagtail/bin/wagtail.py
@@ -8,6 +8,15 @@ from argparse import ArgumentParser
 from difflib import unified_diff
 
 from django.core.management import ManagementUtility
+from django.utils.six import print_  # required to avoid a syntax error on Py2 when using print(..., end='')
+
+
+CURRENT_PYTHON = sys.version_info[:2]
+REQUIRED_PYTHON = (3, 4)
+
+if CURRENT_PYTHON < REQUIRED_PYTHON:
+    sys.stderr.write("This version of Wagtail requires Python {}.{} or above - you are running {}.{}\n".format(*(REQUIRED_PYTHON + CURRENT_PYTHON)))
+    sys.exit(1)
 
 
 def pluralize(value, arg='s'):
@@ -227,7 +236,7 @@ class UpdateModulePaths(Command):
         with fileinput.FileInput(filename, inplace=True) as f:
             for original_line in f:
                 line = self._rewrite_line(original_line)
-                print(line, end='')  # NOQA
+                print_(line, end='')  # NOQA
                 if line != original_line:
                     change_count += 1
 

--- a/wagtail/bin/wagtail.py
+++ b/wagtail/bin/wagtail.py
@@ -8,7 +8,8 @@ from argparse import ArgumentParser
 from difflib import unified_diff
 
 from django.core.management import ManagementUtility
-from django.utils.six import print_  # required to avoid a syntax error on Py2 when using print(..., end='')
+# Need to use the django.utils.six version of print, to avoid a syntax error on Py2 when using print(..., end='')
+from django.utils.six import print_
 
 
 CURRENT_PYTHON = sys.version_info[:2]


### PR DESCRIPTION
Fixes #4327. Adds an explicit error message when running the `wagtail` command on Python <3.4:

    (wagtailpy2)vagrant@vagrant-ubuntu-trusty-32:~$ wagtail start foo
    This version of Wagtail requires Python 3.4 or above - you are running 2.7

Was hoping to add this to `./manage.py check` too, but for that to work we'd have to intercept Django's loading process in such a way that the check happens before loading any *.py files that are not syntactically valid Python 2, and I can't see a way of doing that reliably. In principle it looks like it ought to be possible to catch this at the point of installation too (see https://code.djangoproject.com/ticket/28878), but that looks like a bit of a can of worms - we'd need to ask a PyPI admin to retrospectively fix the metadata on the 2.0 release, and my feeling is that the possibility of screwing things up outweighs the benefit.