### PR TITLE
4417 Fix link to admin home

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/404.html
+++ b/wagtail/admin/templates/wagtailadmin/404.html
@@ -26,7 +26,7 @@
                     {% trans "The requested page could not be found." %}
                 </p>
 
-                <a class="page404__button button" href="/admin/">{% trans "Go to Wagtail admin" %}</a>
+                <a class="page404__button button" href="{% url 'wagtailadmin_home' %}">{% trans "Go to Wagtail admin" %}</a>
             </div>
         </div>
     </div>


### PR DESCRIPTION
refs #4417

The admin 404 page link to /admin/ was hardcoded.