### PR TITLE
4412 Position modeladmin title

### DIFF
--- a/wagtail/contrib/modeladmin/templates/modeladmin/index.html
+++ b/wagtail/contrib/modeladmin/templates/modeladmin/index.html
@@ -15,7 +15,7 @@
 {% block content %}
     {% block header %}
         <header class="nice-padding hasform">
-            <div class="row">
+            <div class="row header-title">
                 <div class="left">
                     <div class="col">
                         {% block h1 %}<h1 {% if view.header_icon %}class="icon icon-{{ view.header_icon }}"{% endif %}>{{ view.get_page_title }}<span></span></h1>{% endblock %}


### PR DESCRIPTION
Refs #4412 

`header-title` will position the title, fixing the overlap.

The same classname is used in other wagtail admin pages.

<img width="790" alt="overlap be gone" src="https://user-images.githubusercontent.com/1969342/37856077-ba02f6b4-2ef2-11e8-94f5-f2a806578d48.png">

