### PR TITLE
Add a new hook 'register_account_menu_item'

### DIFF
--- a/docs/reference/hooks.rst
+++ b/docs/reference/hooks.rst
@@ -120,6 +120,33 @@ Hooks for building new areas of the admin interface (alongside pages, images, do
 ``url`` (optional)
   A URL to an index page that lists the objects being described.
 
+.. _register_account_menu_item:
+
+``register_account_menu_item``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+  Add an item to the My Account page within the Wagtail admin. The callable
+  for this hook should return a dict with values for the keys ``url``,
+  ``label`` and ``help_text``. For example:
+
+  .. code-block:: python
+
+    from django.utils.translation import ugettext_lazy as _
+    from wagtail.core import hooks
+
+    @hooks.register('register_account_menu_item')
+    def register_account_set_gravatar(request):
+        return {
+            'url': 'https://gravatar.com/emails/',
+            'label': _('Set gravatar'),
+            'help_text': _(
+                "Your avatar image is provided by Gravatar and is connected to "
+                "your email address. With a Gravatar account you can set an "
+                "avatar for any number of other email addresses you use."
+            )
+        }
+
+
 
 .. _register_admin_menu_item:
 

--- a/wagtail/admin/templates/wagtailadmin/account/account.html
+++ b/wagtail/admin/templates/wagtailadmin/account/account.html
@@ -8,50 +8,14 @@
 
     <div class="nice-padding">
         <ul class="listing">
-            <li class="row row-flush">
-                <div class="col6">
-                    <a href="https://gravatar.com/emails/" class="button button-primary">{% trans "Set gravatar" %}</a>
-                </div>
-
-                <small class="col6">
-                    {% trans "Your avatar image is provided by Gravatar and is connected to your email address. With a Gravatar account you can set an avatar for any number of other email addresses you use." %}
-                </small>
-
-            </li>
-            {% if show_change_password %}
+            {% for item in items %}
                 <li class="row row-flush">
                     <div class="col6">
-                        <a href="{% url 'wagtailadmin_account_change_password' %}" class="button button-primary">{% trans "Change password" %}</a>
+                        <a href="{{ item.url }}" class="button button-primary">{{ item.label }}</a>
                     </div>
-
-                    <small class="col6">
-                        {% trans "Change the password you use to log in." %}
-                    </small>
+                    <small class="col6">{{ item.help_text }}</small>
                 </li>
-            {% endif %}
-            {% if show_notification_preferences %}
-                <li class="row row-flush">
-                    <div class="col6">
-                        <a href="{% url 'wagtailadmin_account_notification_preferences' %}" class="button button-primary">{% trans "Notification preferences" %}</a>
-                    </div>
-
-                    <small class="col6">
-                        {% trans "Choose which email notifications to receive." %}
-                    </small>
-                </li>
-            {% endif %}
-            {% if show_preferred_language_preferences %}
-                <li class="row row-flush">
-                    <div class="col6">
-                        <a href="{% url 'wagtailadmin_account_language_preferences' %}" class="button button-primary">{% trans "Language preferences" %}</a>
-                    </div>
-
-                    <small class="col6">
-                        {% trans "Choose the language you want to use here." %}
-                    </small>
-                </li>
-            {% endif %}
-
+            {% endfor %}
         </ul>
     </div>
 {% endblock %}

--- a/wagtail/admin/tests/test_account_management.py
+++ b/wagtail/admin/tests/test_account_management.py
@@ -413,9 +413,12 @@ class TestAccountManagementForAdminOnlyUser(TestCase, WagtailTestUtils):
         Test that the user is not even shown the link to the notification
         preferences view
         """
+        expected_url = reverse('wagtailadmin_account_notification_preferences')
+
         response = self.client.get(reverse('wagtailadmin_account'))
-        self.assertEqual(response.context['show_notification_preferences'], False)
-        self.assertNotContains(response, reverse('wagtailadmin_account_notification_preferences'))
+        account_urls = [item['url'] for item in response.context['items']]
+        self.assertFalse(expected_url in account_urls)
+        self.assertNotContains(response, expected_url)
         # safety check that checking for absence/presence of urls works
         self.assertContains(response, reverse('wagtailadmin_home'))
 

--- a/wagtail/admin/wagtail_hooks.py
+++ b/wagtail/admin/wagtail_hooks.py
@@ -15,10 +15,12 @@ from wagtail.admin.rich_text.converters.html_to_contentstate import (
     BlockElementHandler, ExternalLinkElementHandler, HorizontalRuleHandler,
     InlineStyleElementHandler, ListElementHandler, ListItemElementHandler, PageLinkElementHandler)
 from wagtail.admin.search import SearchArea
-from wagtail.admin.utils import user_has_any_page_permission
+from wagtail.admin.utils import get_available_admin_languages, user_has_any_page_permission
+from wagtail.admin.views.account import password_management_enabled
 from wagtail.admin.viewsets import viewsets
 from wagtail.admin.widgets import Button, ButtonWithDropdownFromHook, PageListingButton
 from wagtail.core import hooks
+from wagtail.core.models import UserPagePermissionsProxy
 from wagtail.core.permissions import collection_permission_policy
 from wagtail.core.rich_text.pages import PageLinkHandler
 from wagtail.core.whitelist import allow_without_attributes, attribute_rule, check_url
@@ -187,6 +189,50 @@ def page_listing_more_buttons(page, page_perms, is_parent=False):
 def register_viewsets_urls():
     viewsets.populate()
     return viewsets.get_urlpatterns()
+
+
+@hooks.register('register_account_menu_item')
+def register_account_set_gravatar(request):
+    return {
+        'url': 'https://gravatar.com/emails/',
+        'label': _('Set gravatar'),
+        'help_text': _(
+            "Your avatar image is provided by Gravatar and is connected to "
+            "your email address. With a Gravatar account you can set an "
+            "avatar for any number of other email addresses you use."
+        )
+    }
+
+
+@hooks.register('register_account_menu_item')
+def register_account_change_password(request):
+    if password_management_enabled() and request.user.has_usable_password():
+        return {
+            'url': reverse('wagtailadmin_account_change_password'),
+            'label': _('Change password'),
+            'help_text': _('Change the password you use to log in.'),
+        }
+
+
+@hooks.register('register_account_menu_item')
+def register_account_notification_preferences(request):
+    user_perms = UserPagePermissionsProxy(request.user)
+    if user_perms.can_edit_pages() or user_perms.can_publish_pages():
+        return {
+            'url': reverse('wagtailadmin_account_notification_preferences'),
+            'label': _('Notification preferences'),
+            'help_text': _('Choose which email notifications to receive.'),
+        }
+
+
+@hooks.register('register_account_menu_item')
+def register_account_preferred_language_preferences(request):
+    if len(get_available_admin_languages()) > 1:
+        return {
+            'url': reverse('wagtailadmin_account_language_preferences'),
+            'label': _('Language preferences'),
+            'help_text': _('Choose the language you want to use here.'),
+        }
 
 
 @hooks.register('register_rich_text_features')


### PR DESCRIPTION
This new hook makes it easier for third party apps to add new buttons on the 'my account' page in the Wagtail admin. Existing buttons are converted to the new hooks to make the code consistent.

An real world use case is the wagtail-2fa project (https://github.com/labd/wagtail-2fa) for which we currently need to override the complete template

This PR needs a few tests before merging, but before putting time into that I would love to get some feedback on this.