### PR TITLE
[WIP] Add more Draftail extension APIs for advanced extensions

### DIFF
--- a/client/src/components/Draftail/index.js
+++ b/client/src/components/Draftail/index.js
@@ -19,13 +19,25 @@ import EditorFallback from './EditorFallback/EditorFallback';
 const BR_ICON = 'M.436 633.471l296.897-296.898v241.823h616.586V94.117h109.517v593.796H297.333v242.456z';
 
 /**
- * Registry for client-side code of Draftail plugins.
+ * Registry for client-side code of Draftail extensions.
  */
 const PLUGINS = {};
+const DECORATORS = [];
+const CONTROLS = [];
 
 const registerPlugin = (plugin) => {
   PLUGINS[plugin.type] = plugin;
   return PLUGINS;
+};
+
+const registerDecorator = (decorator) => {
+  DECORATORS.push(decorator);
+  return DECORATORS;
+};
+
+const registerControl = (control) => {
+  CONTROLS.push(control);
+  return CONTROLS;
 };
 
 /**
@@ -112,6 +124,8 @@ const initEditor = (selector, options, currentScript) => {
         inlineStyles={inlineStyles.map(wrapWagtailIcon)}
         entityTypes={entityTypes}
         enableHorizontalRule={enableHorizontalRule}
+        decorators={DECORATORS}
+        controls={CONTROLS}
       />
     </EditorFallback>
   );
@@ -119,7 +133,11 @@ const initEditor = (selector, options, currentScript) => {
   ReactDOM.render(editor, editorWrapper);
 };
 
-export default {
+const draftail = {
   initEditor,
   registerPlugin,
+  registerDecorator,
+  registerControl,
 };
+
+export default draftail;

--- a/client/src/components/Draftail/index.test.js
+++ b/client/src/components/Draftail/index.test.js
@@ -133,6 +133,29 @@ describe('Draftail', () => {
     });
   });
 
+  describe('#registerDecorator', () => {
+    it('works', () => {
+      const decorator = {
+        component: () => {},
+        strategy: () => {},
+      };
+
+      expect(draftail.registerDecorator(decorator)).toEqual([
+        decorator,
+      ]);
+    });
+  });
+
+  describe('#registerControl', () => {
+    it('works', () => {
+      const control = () => {};
+
+      expect(draftail.registerControl(control)).toEqual([
+        control,
+      ]);
+    });
+  });
+
   it('#ModalWorkflowSource', () => expect(ModalWorkflowSource).toBeDefined());
   it('#Link', () => expect(Link).toBeDefined());
   it('#Document', () => expect(Document).toBeDefined());

--- a/docs/advanced_topics/customisation/extending_draftail.rst
+++ b/docs/advanced_topics/customisation/extending_draftail.rst
@@ -1,9 +1,9 @@
 Extending the Draftail Editor
 =============================
 
-Wagtail’s rich text editor is built with `Draftail <https://github.com/springload/draftail>`_, and its functionality can be extended through plugins.
+Wagtail’s rich text editor is built with `Draftail <https://github.com/springload/draftail>`_, and its formatting can be extended through plugins.
 
-Plugins come in three types:
+Formatting plugins come in three types:
 
 * Inline styles – To format a portion of a line, eg. ``bold``, ``italic``, ``monospace``.
 * Blocks – To indicate the structure of the content, eg. ``blockquote``, ``ol``.
@@ -335,11 +335,42 @@ To fully complete the demo, we can add a bit of JavaScript to the front-end in o
 
 Custom block entities can also be created (have a look at the separate `Draftail <https://github.com/springload/draftail>`_ documentation), but these are not detailed here since :ref:`StreamField <streamfield>` is the go-to way to create block-level rich text in Wagtail.
 
+Extending the editor beyond content formats
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. warning::
+    The following APIs are meant for third-party packages extending the editor. They are very advanced and assume `Draft.js <https://draftjs.org/>`_ knowledge.
+
 Integration of the Draftail widgets
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-----------------------------------
 
 To further customise how the Draftail widgets are integrated into the UI, there are additional extension points for CSS and JS:
 
 * In JavaScript, use the ``[data-draftail-input]`` attribute selector to target the input which contains the data, and ``[data-draftail-editor-wrapper]`` for the element which wraps the editor.
 * The editor instance is bound on the input field for imperative access. Use ``document.querySelector('[data-draftail-input]').draftailEditor``.
 * In CSS, use the classes prefixed with ``Draftail-``.
+
+Custom decorators
+-----------------
+
+Draftail supports registering `decorators <https://draftjs.org/docs/advanced-topics-decorators.html#compositedecorator>`_ with a custom ``component`` and ``strategy``.
+
+.. code-block:: javascript
+
+    window.draftail.registerDecorator({
+        component: HashtagSpan,
+        strategy: hashtagStrategy,
+    });
+
+This can be useful to build spellcheck features, syntax highlighting, autocompletion, or any other editing aid or IME-like interface.
+
+Custom toolbar controls
+-----------------------
+
+You can also register custom `toolbar controls <https://github.com/springload/draftail#other-controls>`_, which have full read/write access to the editor state.
+
+.. code-block:: javascript
+
+    window.draftail.registerControl(ReadingTime);
+
+Those custom controls can display metrics about the content (eg. reading time or readability), or provide advanced features like “paste from Word”, “clear all formatting”, and the likes.


### PR DESCRIPTION
Supersedes #4315.

This adds new extension APIs for Draftail which make it possible to build more advanced extensions.

- [Draftail controls](https://github.com/springload/draftail/#other-controls) – a poor name for anything and everything that extends Draftail but doesn't directly map to a rich text format (eg. a "character count" display, or a "clear all formatting" toolbar button). The plugins over at https://github.com/vixdigital/draftail-plugins are good examples.
- [Draft.js decorators](https://github.com/springload/draftail/#custom-text-decorators) – to build syntax highlighting, or spellcheck, or any other text pattern matching and highlighting.