### PR TITLE
Convert password reset to class based views

### DIFF
--- a/wagtail/admin/tests/test_account_management.py
+++ b/wagtail/admin/tests/test_account_management.py
@@ -1,3 +1,4 @@
+from django.contrib.auth import views as auth_views
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group, Permission
 from django.contrib.auth.tokens import PasswordResetTokenGenerator
@@ -555,7 +556,14 @@ class TestPasswordReset(TestCase, WagtailTestUtils):
         self.password_reset_uid = force_text(urlsafe_base64_encode(force_bytes(self.user.pk)))
 
         # Create url_args
-        self.url_kwargs = dict(uidb64=self.password_reset_uid, token=self.password_reset_token)
+        self.url_kwargs = dict(uidb64=self.password_reset_uid, token=auth_views.INTERNAL_RESET_URL_TOKEN)
+
+        # Add token to session object
+        s = self.client.session
+        s.update({
+            auth_views.INTERNAL_RESET_SESSION_TOKEN: self.password_reset_token,
+        })
+        s.save()
 
     def test_password_reset_confirm_view(self):
         """

--- a/wagtail/admin/urls/password_reset.py
+++ b/wagtail/admin/urls/password_reset.py
@@ -1,33 +1,19 @@
 from django.conf.urls import url
 
-from wagtail.admin.forms import PasswordResetForm
 from wagtail.admin.views import account
 
 urlpatterns = [
     url(
-        r'^$', account.password_reset, {
-            'template_name': 'wagtailadmin/account/password_reset/form.html',
-            'email_template_name': 'wagtailadmin/account/password_reset/email.txt',
-            'subject_template_name': 'wagtailadmin/account/password_reset/email_subject.txt',
-            'password_reset_form': PasswordResetForm,
-            'post_reset_redirect': 'wagtailadmin_password_reset_done',
-        }, name='wagtailadmin_password_reset'
+        r'^$', account.PasswordResetView.as_view(), name='wagtailadmin_password_reset'
     ),
     url(
-        r'^done/$', account.password_reset_done, {
-            'template_name': 'wagtailadmin/account/password_reset/done.html'
-        }, name='wagtailadmin_password_reset_done'
+        r'^done/$', account.PasswordResetDoneView.as_view(), name='wagtailadmin_password_reset_done'
     ),
     url(
         r'^confirm/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})/$',
-        account.password_reset_confirm, {
-            'template_name': 'wagtailadmin/account/password_reset/confirm.html',
-            'post_reset_redirect': 'wagtailadmin_password_reset_complete',
-        }, name='wagtailadmin_password_reset_confirm',
+        account.PasswordResetConfirmView.as_view(), name='wagtailadmin_password_reset_confirm',
     ),
     url(
-        r'^complete/$', account.password_reset_complete, {
-            'template_name': 'wagtailadmin/account/password_reset/complete.html'
-        }, name='wagtailadmin_password_reset_complete'
+        r'^complete/$', account.PasswordResetCompleteView.as_view(), name='wagtailadmin_password_reset_complete'
     ),
 ]


### PR DESCRIPTION
The function based auth views were deprecated in Django 1.11. This PR replaces the password reset views with the class based versions.