### PR TITLE
Fix inconsistent order of heading features with HalloJS

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -37,6 +37,7 @@ Changelog
  * Fix: Localization of image and apps verbose names
  * Fix: Draftail editor no longer crashes after deleting image/embed using DEL key (Thibaud Colas)
  * Fix: Breadcrumb navigation now respects custom `get_admin_display_title` methods (Arthur Holzner, Wietze Helmantel, Matt Westcott)
+ * Fix: Inconsistent order of heading features when adding h1, h5 or h6 as default feature for Hallo RichText editor (Loic Teixeira)
 
 
 2.0.1 (xx.xx.xxxx) - IN DEVELOPMENT

--- a/docs/releases/2.1.rst
+++ b/docs/releases/2.1.rst
@@ -55,6 +55,7 @@ Bug fixes
  * Localization of image and apps verbose names
  * Draftail editor no longer crashes after deleting image/embed using DEL key (Thibaud Colas)
  * Breadcrumb navigation now respects custom ``get_admin_display_title`` methods (Arthur Holzner, Wietze Helmantel, Matt Westcott)
+ * Inconsistent order of heading features when adding h1, h5 or h6 as default feature for Hallo RichText editor (Loic Teixeira)
 
 
 Upgrade considerations

--- a/wagtail/admin/rich_text/editors/hallo.py
+++ b/wagtail/admin/rich_text/editors/hallo.py
@@ -41,9 +41,11 @@ class HalloFormatPlugin(HalloPlugin):
 
 
 class HalloHeadingPlugin(HalloPlugin):
+    default_order = 20
+
     def __init__(self, **kwargs):
         kwargs.setdefault('name', 'halloheadings')
-        kwargs.setdefault('order', 20)
+        kwargs.setdefault('order', self.default_order)
         self.element = kwargs.pop('element')
         super().__init__(**kwargs)
 

--- a/wagtail/admin/tests/test_rich_text.py
+++ b/wagtail/admin/tests/test_rich_text.py
@@ -8,8 +8,9 @@ from wagtail.admin.rich_text import (
     DraftailRichTextArea, HalloRichTextArea, get_rich_text_editor_widget)
 from wagtail.core.blocks import RichTextBlock
 from wagtail.core.models import Page, get_page_models
-from wagtail.core.rich_text import RichText, features as feature_registry
 from wagtail.tests.testapp.models import SingleEventPage
+from wagtail.core.rich_text import features as feature_registry
+from wagtail.core.rich_text import RichText
 from wagtail.tests.testapp.rich_text import CustomRichTextArea
 from wagtail.tests.utils import WagtailTestUtils
 

--- a/wagtail/admin/tests/test_rich_text.py
+++ b/wagtail/admin/tests/test_rich_text.py
@@ -6,6 +6,7 @@ from django.urls import reverse
 
 from wagtail.admin.rich_text import (
     DraftailRichTextArea, HalloRichTextArea, get_rich_text_editor_widget)
+from wagtail.core import hooks
 from wagtail.core.blocks import RichTextBlock
 from wagtail.core.models import Page, get_page_models
 from wagtail.core.rich_text import RichText
@@ -502,6 +503,30 @@ class TestHalloJsWithCustomFeatureOptions(BaseRichTextEditHandlerTestCase, Wagta
         self.assertIn('testapp/css/hallo-blockquote.css', media_html)
         # check that we're NOT importing media for the default features we're not using
         self.assertNotIn('wagtaildocs/js/hallo-plugins/hallo-wagtaildoclink.js', media_html)
+
+
+@override_settings(WAGTAILADMIN_RICH_TEXT_EDITORS={
+    'default': {
+        'WIDGET': 'wagtail.admin.rich_text.HalloRichTextArea'
+    },
+})
+class TestHalloJsHeadingOrder(BaseRichTextEditHandlerTestCase, WagtailTestUtils):
+
+    def test_heading_order(self):
+        @hooks.register('register_rich_text_features')
+        def register_headings_features(features):
+            # Headings 2-4 are already registered as default features.
+            features.default_features.append('h1')
+            features.default_features.append('h5')
+            features.default_features.append('h6')
+
+        widget = HalloRichTextArea()
+        js_init = widget.render_js_init('the_id', 'the_name', '<p>the value</p>')
+
+        expected_options = (
+            '"halloheadings": {"formatBlocks": ["p", "h1", "h2", "h3", "h4", "h5", "h6"]}'
+        )
+        self.assertIn(expected_options, js_init)
 
 
 class TestWidgetWhitelisting(TestCase, WagtailTestUtils):

--- a/wagtail/admin/tests/test_rich_text.py
+++ b/wagtail/admin/tests/test_rich_text.py
@@ -6,10 +6,9 @@ from django.urls import reverse
 
 from wagtail.admin.rich_text import (
     DraftailRichTextArea, HalloRichTextArea, get_rich_text_editor_widget)
-from wagtail.core import hooks
 from wagtail.core.blocks import RichTextBlock
 from wagtail.core.models import Page, get_page_models
-from wagtail.core.rich_text import RichText
+from wagtail.core.rich_text import RichText, features as feature_registry
 from wagtail.tests.testapp.models import SingleEventPage
 from wagtail.tests.testapp.rich_text import CustomRichTextArea
 from wagtail.tests.utils import WagtailTestUtils
@@ -513,12 +512,10 @@ class TestHalloJsWithCustomFeatureOptions(BaseRichTextEditHandlerTestCase, Wagta
 class TestHalloJsHeadingOrder(BaseRichTextEditHandlerTestCase, WagtailTestUtils):
 
     def test_heading_order(self):
-        @hooks.register('register_rich_text_features')
-        def register_headings_features(features):
-            # Headings 2-4 are already registered as default features.
-            features.default_features.append('h1')
-            features.default_features.append('h5')
-            features.default_features.append('h6')
+        # Using the `register_rich_text_features` doesn't work here,
+        # probably because the features have already been scanned at that point.
+        # Extending the registry directly instead.
+        feature_registry.default_features.extend(['h1', 'h5', 'h6'])
 
         widget = HalloRichTextArea()
         js_init = widget.render_js_init('the_id', 'the_name', '<p>the value</p>')

--- a/wagtail/admin/tests/test_rich_text.py
+++ b/wagtail/admin/tests/test_rich_text.py
@@ -8,9 +8,9 @@ from wagtail.admin.rich_text import (
     DraftailRichTextArea, HalloRichTextArea, get_rich_text_editor_widget)
 from wagtail.core.blocks import RichTextBlock
 from wagtail.core.models import Page, get_page_models
-from wagtail.tests.testapp.models import SingleEventPage
 from wagtail.core.rich_text import features as feature_registry
 from wagtail.core.rich_text import RichText
+from wagtail.tests.testapp.models import SingleEventPage
 from wagtail.tests.testapp.rich_text import CustomRichTextArea
 from wagtail.tests.utils import WagtailTestUtils
 

--- a/wagtail/admin/wagtail_hooks.py
+++ b/wagtail/admin/wagtail_hooks.py
@@ -287,9 +287,11 @@ def register_core_features(features):
         WhitelistRule('em', allow_without_attributes),
     ])
 
-    for element in ['h1', 'h2', 'h3', 'h4', 'h5', 'h6']:
+    headings_elements = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6']
+    headings_order_start = HalloHeadingPlugin.default_order + 1
+    for order, element in enumerate(headings_elements, start=headings_order_start):
         features.register_editor_plugin(
-            'hallo', element, HalloHeadingPlugin(element=element)
+            'hallo', element, HalloHeadingPlugin(element=element, order=order)
         )
         features.register_converter_rule('editorhtml', element, [
             WhitelistRule(element, allow_without_attributes)


### PR DESCRIPTION
Because [only headings 2-4 are set as default features][1] and they all have the same `order` value (the don't specify one and use the default value), when registering the other headings as default features, they won't be ordered properly. Depending on whether your app or wagtail.core comes first in `INSTALLED_APPS`, you would get `h1, h5, h6, h2, h3, h4` or `h2, h3, h4, h1, h5, h6`.

This PR registers the heading plugins with increasing `order` value so the registration order as default value doesn't matter.

[1]: https://github.com/wagtail/wagtail/blob/7841f54fe873d128d21a30cb19752c7081ec7b1a/wagtail/core/wagtail_hooks.py#L49