### PR TITLE
Wording change to have this feature appear in search results

### DIFF
--- a/docs/reference/contrib/modeladmin/index.rst
+++ b/docs/reference/contrib/modeladmin/index.rst
@@ -2,16 +2,8 @@
 ``ModelAdmin``
 =====================
 
-The ``modeladmin`` module allows you to create customisable listing
-pages for any model in your Wagtail project, and add navigation elements to the
-Wagtail admin area so that you can access them. Simply extend the
-``ModelAdmin`` class, override a few attributes to suit your needs, register
-it with Wagtail using an easy one-line ``modeladmin_register`` method
-(you can copy and paste from the examples below), and you're good to go.
-
-You can use it with any Django model (it doesn’t need to extend ``Page`` or
-be registered as a ``Snippet``), and it won’t interfere with any of the
-existing admin functionality that Wagtail provides.
+The ``modeladmin`` module allows you to add any model in your project to the Wagtail admin.  You can create customisable listing
+pages for a model, including plain Django models, and add navigation elements so that a model can be accessed directly from the Wagtail admin. Simply extend the ``ModelAdmin`` class, override a few attributes to suit your needs, register it with Wagtail using an easy one-line ``modeladmin_register`` method (you can copy and paste from the examples below), and you're good to go. This customisation doesn’t need to extend ``Page`` or be registered as a ``Snippet``, and it won’t interfere with any of the existing admin functionality that Wagtail provides.
 
 .. _modeladmin_feature_summary:
 

--- a/docs/reference/contrib/modeladmin/index.rst
+++ b/docs/reference/contrib/modeladmin/index.rst
@@ -3,7 +3,7 @@
 =====================
 
 The ``modeladmin`` module allows you to add any model in your project to the Wagtail admin.  You can create customisable listing
-pages for a model, including plain Django models, and add navigation elements so that a model can be accessed directly from the Wagtail admin. Simply extend the ``ModelAdmin`` class, override a few attributes to suit your needs, register it with Wagtail using an easy one-line ``modeladmin_register`` method (you can copy and paste from the examples below), and you're good to go. This customisation doesn’t need to extend ``Page`` or be registered as a ``Snippet``, and it won’t interfere with any of the existing admin functionality that Wagtail provides.
+pages for a model, including plain Django models, and add navigation elements so that a model can be accessed directly from the Wagtail admin. Simply extend the ``ModelAdmin`` class, override a few attributes to suit your needs, register it with Wagtail using an easy one-line ``modeladmin_register`` method (you can copy and paste from the examples below), and you're good to go. Your model doesn’t need to extend ``Page`` or be registered as a ``Snippet``, and it won’t interfere with any of the existing admin functionality that Wagtail provides.
 
 .. _modeladmin_feature_summary:
 


### PR DESCRIPTION
Searching the docs for the phrases "add django model to wagtail admin" and "add model to wagtail admin" (without the quotes) did not even yield this crucial page as one of the results.  The proposed wording puts the main idea of being able to show/edit ANY model via the Wagtail admin at the top of the document and includes wording to, hopefully, have this page appear at the top for anyone searching for how to implement this functionality.