### PR TITLE
Fix 'Add user' button label escaping

### DIFF
--- a/wagtail/users/templates/wagtailusers/users/create.html
+++ b/wagtail/users/templates/wagtailusers/users/create.html
@@ -40,7 +40,7 @@
                 <ul class="fields">
                     {% include "wagtailadmin/shared/field_as_li.html" with field=form.is_superuser %}
                     {% include "wagtailadmin/shared/field_as_li.html" with field=form.groups %}
-                    <li><input type="submit" value='{% trans "Add user" %}' class="button" /></li>
+                    <li><input type="submit" value='{% trans "Add user" as add_user_button_label %}{{ add_user_button_label|force_escape }}' class="button" /></li>
                 </ul>
             </section>
         </div>

--- a/wagtail/users/templates/wagtailusers/users/create.html
+++ b/wagtail/users/templates/wagtailusers/users/create.html
@@ -40,7 +40,7 @@
                 <ul class="fields">
                     {% include "wagtailadmin/shared/field_as_li.html" with field=form.is_superuser %}
                     {% include "wagtailadmin/shared/field_as_li.html" with field=form.groups %}
-                    <li><input type="submit" value='{% trans "Add user" as add_user_button_label %}{{ add_user_button_label|force_escape }}' class="button" /></li>
+                    <li><button class="button">{% trans "Add user" %}</button></li>
                 </ul>
             </section>
         </div>


### PR DESCRIPTION
Prevent wrong button labelling due to quotes in translated label
Fixes issue #4455
