### PR TITLE
Fix 500 errors when indexing fails on models with non-ASCII characters in their representations

### DIFF
--- a/wagtail/wagtailsearch/index.py
+++ b/wagtail/wagtailsearch/index.py
@@ -152,7 +152,8 @@ def insert_or_update_object(instance):
                 # Catch and log all errors
                 logger.exception(
                     "Exception raised while adding %s into the '%s' search backend",
-                    six.text_type(repr(indexed_instance), 'utf-8'), backend_name
+                    unicode(repr(indexed_instance), 'utf-8') if six.PY2 else repr(indexed_instance),
+                    backend_name,
                 )
 
 
@@ -167,7 +168,8 @@ def remove_object(instance):
                 # Catch and log all errors
                 logger.exception(
                     "Exception raised while deleting %s from the '%s' search backend",
-                    six.text_type(repr(indexed_instance), 'utf-8'), backend_name
+                    unicode(repr(indexed_instance), 'utf-8') if six.PY2 else repr(indexed_instance),
+                    backend_name,
                 )
 
 

--- a/wagtail/wagtailsearch/index.py
+++ b/wagtail/wagtailsearch/index.py
@@ -8,6 +8,7 @@ from django.core import checks
 from django.db import models
 from django.db.models.fields import FieldDoesNotExist
 from django.db.models.fields.related import ForeignObjectRel, OneToOneRel, RelatedField
+from django.utils import six
 
 from wagtail.wagtailsearch.backends import get_search_backends_with_name
 
@@ -151,7 +152,7 @@ def insert_or_update_object(instance):
                 # Catch and log all errors
                 logger.exception(
                     "Exception raised while adding %s into the '%s' search backend",
-                    unicode(repr(indexed_instance), 'utf-8'), backend_name
+                    six.text_type(repr(indexed_instance), 'utf-8'), backend_name
                 )
 
 
@@ -166,7 +167,7 @@ def remove_object(instance):
                 # Catch and log all errors
                 logger.exception(
                     "Exception raised while deleting %s from the '%s' search backend",
-                    unicode(repr(indexed_instance), 'utf-8'), backend_name
+                    six.text_type(repr(indexed_instance), 'utf-8'), backend_name
                 )
 
 

--- a/wagtail/wagtailsearch/index.py
+++ b/wagtail/wagtailsearch/index.py
@@ -149,7 +149,10 @@ def insert_or_update_object(instance):
                 backend.add(indexed_instance)
             except Exception:
                 # Catch and log all errors
-                logger.exception("Exception raised while adding %r into the '%s' search backend", indexed_instance, backend_name)
+                logger.exception(
+                    "Exception raised while adding %s into the '%s' search backend",
+                    unicode(repr(indexed_instance), 'utf-8'), backend_name
+                )
 
 
 def remove_object(instance):
@@ -161,7 +164,10 @@ def remove_object(instance):
                 backend.delete(indexed_instance)
             except Exception:
                 # Catch and log all errors
-                logger.exception("Exception raised while deleting %r from the '%s' search backend", indexed_instance, backend_name)
+                logger.exception(
+                    "Exception raised while deleting %s from the '%s' search backend",
+                    unicode(repr(indexed_instance), 'utf-8'), backend_name
+                )
 
 
 class BaseField(object):


### PR DESCRIPTION
When adding a model instance to the search index fails for whatever reason, Wagtail logs an exception, constructing the message using `u'%r' % instance` (the `u` is implied by `from __future__ import unicode_literals`). This throws a `UnicodeDecodeError` when the string representation of the instance contains non-ASCII characters.

For example, take an Image instance called `image` with a title of "à":
```
>>> unicode(image)
u'\xe0'
>>> repr(image)
'<Image: \xc3\xa0>'
```
This cannot be substituted into a `unicode` string using `%r`:
```
>>> '%r' % image
'<Image: \xc3\xa0>'
>>> u'%r' % image
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3...
```
Because it's the equivalent of:
```
>>> u'%s' % '\xc3\xa0'
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3..
```
This change fixes the issue while maintaing the `repr`-like representation by decoding the `repr`-generated string using UTF-8 before substituting it using `%s`:
```
>>> u'%s' % unicode(repr(image), 'utf-8')
u'<Image: \xe0>'
```

I've checked other instances of `%r` usage in the project, and none of them have this issue, since they dont try to substitute a model instance using `%r`.

Also note that this issue does not occur with Python 3, so it's not something that should be merged into the 2.x branch.