### PR TITLE
Ensure redirect middleware preserves query strings

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -59,6 +59,7 @@ Changelog
  * Fix: Stop revision comparison view from crashing when non-model FieldPanels are in use (LB (Ben Johnston))
  * Fix: Ordering in the page explorer now respects custom `get_admin_display_title` methods when sorting <100 pages (Matt Westcott)
  * Fix: Use index-specific Elasticsearch endpoints for bulk insertion, for compatibility with providers that lock down the root endpoint (Karl Hobley)
+* Fix: Ensure redirect middleware preserves querystrings (Matt Segal)
 
 
 2.0.2 (xx.xx.xxxx) - IN DEVELOPMENT

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -298,6 +298,7 @@ Contributors
 * Harm Zeinstra
 * David Moore
 * Pierre Geier
+* Matt Segal
 
 Translators
 ===========

--- a/wagtail/contrib/redirects/middleware.py
+++ b/wagtail/contrib/redirects/middleware.py
@@ -54,7 +54,14 @@ class RedirectMiddleware(MiddlewareMixin):
             if redirect is None:
                 return response
 
+        # Add the querystring back onto the redirect URL if the redirect
+        # does not specify a querystring already.
+        redirect_url = redirect.link
+        redirect_querystring = urlparse(redirect_url).query
+        if not redirect_querystring and request.META['QUERY_STRING']:
+            redirect_url = '{}?{}'.format(redirect_url, request.META['QUERY_STRING'])
+
         if redirect.is_permanent:
-            return http.HttpResponsePermanentRedirect(redirect.link)
+            return http.HttpResponsePermanentRedirect(redirect_url)
         else:
-            return http.HttpResponseRedirect(redirect.link)
+            return http.HttpResponseRedirect(redirect_url)

--- a/wagtail/contrib/redirects/middleware.py
+++ b/wagtail/contrib/redirects/middleware.py
@@ -41,7 +41,13 @@ def append_querystring(redirect, request_qs):
     }
 
     # Construct a new querystring, combining those in the redirect target and the pass-through params.
-    new_qs_params = {**redirect_qs_params, **pass_through_params}
+    new_qs_params = {**redirect_qs_params}
+    for key, val in pass_through_params.items():
+        try:
+            new_qs_params[key] += val
+        except KeyError:
+            new_qs_params[key] = val
+
     new_qs = urlencode(new_qs_params, doseq=True)
     if new_qs:
         # Replace the original requested querystring with the new one

--- a/wagtail/contrib/redirects/middleware.py
+++ b/wagtail/contrib/redirects/middleware.py
@@ -58,7 +58,7 @@ class RedirectMiddleware(MiddlewareMixin):
         # does not specify a querystring already.
         redirect_url = redirect.link
         redirect_querystring = urlparse(redirect_url).query
-        if not redirect_querystring and request.META['QUERY_STRING']:
+        if not redirect_querystring and request.META.get('QUERY_STRING'):
             redirect_url = '{}?{}'.format(redirect_url, request.META['QUERY_STRING'])
 
         if redirect.is_permanent:

--- a/wagtail/contrib/redirects/tests.py
+++ b/wagtail/contrib/redirects/tests.py
@@ -201,6 +201,26 @@ class TestRedirects(TestCase):
         response = self.client.get(visit_url)
         self.assertRedirects(response, redirect_url, status_code=301, fetch_redirect_response=False)
 
+    def test_redirect_querystring_handles_key_conflicts_with_different_values(self):
+        from_url = '/old-path'
+        to_url = '/new-path?key=val1'
+        visit_url = '/old-path/?key=val2'
+        redirect_url = '/new-path?key=val1&key=val2'
+
+        models.Redirect.objects.create(old_path=from_url, redirect_link=to_url)
+        response = self.client.get(visit_url)
+        self.assertRedirects(response, redirect_url, status_code=301, fetch_redirect_response=False)
+
+    def test_redirect_querystring_handles_key_conflicts_with_same_values(self):
+        from_url = '/old-path'
+        to_url = '/new-path?key=val'
+        visit_url = '/old-path/?key=val'
+        redirect_url = '/new-path?key=val&key=val'
+
+        models.Redirect.objects.create(old_path=from_url, redirect_link=to_url)
+        response = self.client.get(visit_url)
+        self.assertRedirects(response, redirect_url, status_code=301, fetch_redirect_response=False)
+
     def test_redirect_to_page(self):
         christmas_page = Page.objects.get(url_path='/home/events/christmas/')
         models.Redirect.objects.create(old_path='/xmas', redirect_page=christmas_page)

--- a/wagtail/contrib/redirects/tests.py
+++ b/wagtail/contrib/redirects/tests.py
@@ -129,8 +129,8 @@ class TestRedirects(TestCase):
         visit_url = '/old-path/?foo=Bar'
         redirect_url = '/new-path-a'
 
-        redirect_a = models.Redirect.objects.create(old_path=from_url_a, redirect_link=to_url_a)
-        redirect_b = models.Redirect.objects.create(old_path=from_url_b, redirect_link=to_url_b)
+        models.Redirect.objects.create(old_path=from_url_a, redirect_link=to_url_a)
+        models.Redirect.objects.create(old_path=from_url_b, redirect_link=to_url_b)
         response = self.client.get(visit_url)
         self.assertRedirects(response, redirect_url, status_code=301, fetch_redirect_response=False)
 
@@ -144,8 +144,8 @@ class TestRedirects(TestCase):
         visit_url = '/old-path/?foo=Bar&baz=1'
         redirect_url = '/new-path-b?foo=Bar&baz=1'
 
-        redirect_a = models.Redirect.objects.create(old_path=from_url_a, redirect_link=to_url_a)
-        redirect_b = models.Redirect.objects.create(old_path=from_url_b, redirect_link=to_url_b)
+        models.Redirect.objects.create(old_path=from_url_a, redirect_link=to_url_a)
+        models.Redirect.objects.create(old_path=from_url_b, redirect_link=to_url_b)
         response = self.client.get(visit_url)
         self.assertRedirects(response, redirect_url, status_code=301, fetch_redirect_response=False)
 
@@ -158,7 +158,7 @@ class TestRedirects(TestCase):
         visit_url = '/old-path/?key=val'
         redirect_url = '/new-path?key=val'
 
-        redirect = models.Redirect.objects.create(old_path=from_url, redirect_link=to_url)
+        models.Redirect.objects.create(old_path=from_url, redirect_link=to_url)
         response = self.client.get(visit_url)
         self.assertRedirects(response, redirect_url, status_code=301, fetch_redirect_response=False)
 
@@ -171,7 +171,7 @@ class TestRedirects(TestCase):
         visit_url = '/old-path/?key=val'
         redirect_url = '/new-path'
 
-        redirect = models.Redirect.objects.create(old_path=from_url, redirect_link=to_url)
+        models.Redirect.objects.create(old_path=from_url, redirect_link=to_url)
         response = self.client.get(visit_url)
         self.assertRedirects(response, redirect_url, status_code=301, fetch_redirect_response=False)
 
@@ -184,7 +184,7 @@ class TestRedirects(TestCase):
         visit_url = '/old-path/?key2=val2'
         redirect_url = '/new-path?key1=val1&key2=val2'
 
-        redirect = models.Redirect.objects.create(old_path=from_url, redirect_link=to_url)
+        models.Redirect.objects.create(old_path=from_url, redirect_link=to_url)
         response = self.client.get(visit_url)
         self.assertRedirects(response, redirect_url, status_code=301, fetch_redirect_response=False)
 
@@ -197,7 +197,7 @@ class TestRedirects(TestCase):
         visit_url = '/old-path/?key1=val1'
         redirect_url = '/new-path?key2=val2'
 
-        redirect = models.Redirect.objects.create(old_path=from_url, redirect_link=to_url)
+        models.Redirect.objects.create(old_path=from_url, redirect_link=to_url)
         response = self.client.get(visit_url)
         self.assertRedirects(response, redirect_url, status_code=301, fetch_redirect_response=False)
 


### PR DESCRIPTION
This PR intends to resolve an issue (https://github.com/wagtail/wagtail/issues/4414) where Wagtail's RedirectMiddleware does not preserve querystring parameters. I believe that querystrings should be preserved on redirect.

Tests and linting pass locally.

My only concern with this PR is that prior authors of the redirect middleware were aware of the behaviour that I'm trying to fix. 

Looking at this relevant past issue (https://github.com/wagtail/wagtail/issues/647), I believe that my change doesn't conflict with the intent of the established logic, which stripped the querystring parameters to ensure that we can match a redirect with no params. My change preserves that behaviour.

**Acceptance Criteria**

* [ ] Querystring parameters stripped from request before matching
* [ ] Querystring parameters passed through to the redirect target
* [ ] If there are querystring parameters already specified in the `redirect_link`, then they override any params passed through in the original request

Eg. established behavior

```
old_path        /redirectme
redirect_link   /target?foo=1

request         /redirectme/
response        /target/?foo=1
```

My change intends to preserve this behaviour, but also handle this case

```
old_path        /redirectme
redirect_link   /target

request         /redirectme/?foo=1
response        /target/?foo=1
```

There's also this tricky corner case, where I default to the respecting the `redirect_link` 

```
old_path        /redirectme
redirect_link   /target?foo=1

request         /redirectme/?foo=2
response        /target/?foo=1
```
