### PR TITLE
Docs: How to create test fixtures for custom Page models

### DIFF
--- a/docs/advanced_topics/testing.rst
+++ b/docs/advanced_topics/testing.rst
@@ -9,10 +9,31 @@ Wagtail comes with some utilities that simplify writing tests for your site.
 .. automodule:: wagtail.tests.utils
 
 
-Fixtures for custom Page models
-===============================
+Fixtures
+========
 
-When creating customised Page models in fixtures_, you need to add both a
+Using Dumpdata
+--------------
+
+Creating test content is best done by creating content in a development environment,
+and using Django's dumpdata_ command.
+
+Note that by default `dumpdata` will represent `content type` by the `pk`
+instead of by `["app", "model"]`.
+To prevent that, use the `--natural-foreign` switch.
+
+
+Manual modification
+-------------------
+
+You could modify the dumped fixtures manually, or even write them all by hand.
+Here are a few things to be wary of.
+
+
+Custom Page models
+~~~~~~~~~~~~~~~~~~
+
+When creating customised Page models in fixtures_, you will need to add both a
 `wagtailcore.page` entry, and one for your custom Page model.
 
 Let's say you have a `website` module which defines a `Homepage(Page)` class.
@@ -37,13 +58,14 @@ You could create such a homepage in a fixture with:
       }
     ]
 
-Using Dumpdata
---------------
 
-Django's dumpdata_ command is an easy way to export content to fixtures.
+Treebeard fields
+~~~~~~~~~~~~~~~~
 
-Note that it will represent `content type` by the `pk` instead of the `["app", "model"]` you see above.
-To prevent that, use the `--natural-foreign` switch.
+Filling in the `path` / `numchild` / `depth` fields is necessary in order for tree operations like `get_parent()` to work correctly.
+`url_path` is another field that can cause errors in some uncommon cases if it isn't filled in.
+
+The `Treebeard docs`_ might help in understanding how this works.
 
 
 WagtailPageTests
@@ -143,3 +165,4 @@ Form data helpers
 
 .. _fixtures: https://docs.djangoproject.com/en/2.0/howto/initial-data/
 .. _dumpdata: https://docs.djangoproject.com/en/2.0/ref/django-admin/#django-admin-dumpdata
+.. _Treebeard docs: http://django-treebeard.readthedocs.io/en/latest/mp_tree.html

--- a/docs/advanced_topics/testing.rst
+++ b/docs/advanced_topics/testing.rst
@@ -37,6 +37,14 @@ You could create such a homepage in a fixture with:
       }
     ]
 
+Using Dumpdata
+--------------
+
+Django's dumpdata_ command is an easy way to export content to fixtures.
+
+Note that it will represent `content type` by the `pk` instead of the `["app", "model"]` you see above.
+To prevent that, use the `--natural-foreign` switch.
+
 
 WagtailPageTests
 ================
@@ -134,3 +142,4 @@ Form data helpers
    .. autofunction:: inline_formset
 
 .. _fixtures: https://docs.djangoproject.com/en/2.0/howto/initial-data/
+.. _dumpdata: https://docs.djangoproject.com/en/2.0/ref/django-admin/#django-admin-dumpdata

--- a/docs/advanced_topics/testing.rst
+++ b/docs/advanced_topics/testing.rst
@@ -8,6 +8,36 @@ Wagtail comes with some utilities that simplify writing tests for your site.
 
 .. automodule:: wagtail.tests.utils
 
+
+Fixtures for custom Page models
+===============================
+
+When creating customised Page models in fixtures_, you need to add both a
+`wagtailcore.page` entry, and one for your custom Page model.
+
+Let's say you have a `website` module which defines a `Homepage(Page)` class.
+You could create such a homepage in a fixture with:
+
+.. code-block:: json
+
+    [
+      {
+        "model": "wagtailcore.page",
+        "pk": 3,
+        "fields": {
+          "title": "My Customer's Homepage",
+          "content_type": ["website", "homepage"],
+          "depth": 2
+        }
+      },
+      {
+        "model": "website.homepage",
+        "pk": 3,
+        "fields": {}
+      }
+    ]
+
+
 WagtailPageTests
 ================
 
@@ -102,3 +132,5 @@ Form data helpers
    .. autofunction:: streamfield
 
    .. autofunction:: inline_formset
+
+.. _fixtures: https://docs.djangoproject.com/en/2.0/howto/initial-data/


### PR DESCRIPTION
I found this out after asking on the support Slack channel, where @gasman helped me out. Wrote a blog post about it (at @tomdyson s suggestion), https://www.fourdigits.nl/blog/fixtures-for-custom-page-models/. Thought it would make sense to get it in the docs. I'm open for suggestions as to improving it. (Should we mention `dumpdata` for easy fixture creation?)