### PR TITLE
Fix for editing document file

### DIFF
--- a/wagtail/documents/views/documents.py
+++ b/wagtail/documents/views/documents.py
@@ -127,12 +127,13 @@ def edit(request, document_id):
         original_file = doc.file
         form = DocumentForm(request.POST, request.FILES, instance=doc, user=request.user)
         if form.is_valid():
-            doc = form.save()
             if 'file' in form.changed_data:
                 # if providing a new document file, delete the old one.
                 # NB Doing this via original_file.delete() clears the file field,
                 # which definitely isn't what we want...
                 original_file.storage.delete(original_file.name)
+            # save new document file
+            doc = form.save()
 
             # Reindex the document to make sure all tags are indexed
             search_index.insert_or_update_object(doc)


### PR DESCRIPTION
When you edit document and upload a file with the same filename - file gets removed from storage after uploading.

Thanks for contributing to Wagtail! 🎉

Before submitting, please review the contributor guidelines <http://docs.wagtail.io/en/latest/contributing/index.html> and check the following:

* Do the tests still pass? (http://docs.wagtail.io/en/latest/contributing/developing.html#testing)
* Does the code comply with the style guide? (Run `make lint` from the Wagtail root)
* For Python changes: Have you added tests to cover the new/fixed behaviour?
* For front-end changes: Did you test on all of Wagtail’s supported browsers? **Please list the exact versions you tested**.
* For new features: Has the documentation been updated accordingly?
