### PR TITLE
Fixed document deletion issue appears when user upload exact same document in edit view

### DIFF
--- a/wagtail/documents/tests/test_views.py
+++ b/wagtail/documents/tests/test_views.py
@@ -40,9 +40,12 @@ class TestEditView(TestCase, WagtailTestUtils):
         })
         self.assertRedirects(response, reverse('wagtaildocs:index'))
         self.update_from_db()
-        self.assertFalse(self.storage.exists(old_file.name))
+        # since user has reupload document with same name, Thats why asserting document name remain same
+        self.assertEqual(old_file.name, self.document.file.name)
         self.assertTrue(self.storage.exists(self.document.file.name))
-        self.assertNotEqual(self.document.file.name, 'documents/' + new_name)
+        # because of same document name you are seeing file name matches 'documents/' + new_name
+        # where new_name is equal to old_name
+        self.assertEqual(self.document.file.name, 'documents/' + new_name)
         self.assertEqual(self.document.file.read(),
                          b'An updated test content.')
 

--- a/wagtail/documents/views/documents.py
+++ b/wagtail/documents/views/documents.py
@@ -127,13 +127,13 @@ def edit(request, document_id):
         original_file = doc.file
         form = DocumentForm(request.POST, request.FILES, instance=doc, user=request.user)
         if form.is_valid():
-            doc = form.save()
             if 'file' in form.changed_data:
                 # if providing a new document file, delete the old one.
                 # NB Doing this via original_file.delete() clears the file field,
                 # which definitely isn't what we want...
                 original_file.storage.delete(original_file.name)
 
+            doc = form.save()
             # Reindex the document to make sure all tags are indexed
             search_index.insert_or_update_object(doc)
 


### PR DESCRIPTION
#### What are the relevant tickets?
https://github.com/mitodl/micromasters/issues/3943
https://github.com/wagtail/wagtail/issues/4512

#### What's this PR do?
it fixes an issue which appears when user re uploads exact same file on edit file. App was delete that file all together which was casing issue/exception mention on #4512

#### How should this be manually tested?
1. Login as admin (super user)
2. Go to documents and add a document lets say `x.pdf`
3. After uploading document go back to document listing page
4. Select the document from list that you just added
5. On edit page upload same document (exact same document) and press save
6. You will be navigate to the document listing page
7. Click edit on header notification or click same document that you just update

##### Expected behaviour:
- User should be able to download file that we just reupload.
- User should be able to open edit document view page.

##### Actual behaviour:
App is crashing on edit view page or downloading file.

@pdpinch 

#### Screenshots (if appropriate)
<img width="1173" alt="screen shot 2018-04-30 at 1 55 25 pm" src="https://user-images.githubusercontent.com/10431250/39420485-2b1ce4e2-4c7e-11e8-8489-6a56a31304d4.png">


