### PR TITLE
Adds another valid AudioBoom oEmbed pattern.

### DIFF
--- a/wagtail/embeds/oembed_providers.py
+++ b/wagtail/embeds/oembed_providers.py
@@ -609,7 +609,8 @@ etsy = {
 audioboom = {
     "endpoint": "https://audioboom.com/publishing/oembed.{format}",
     "urls": [
-        "^http(?:s)?://audioboom\\.com/boos/.+$"
+        "^http(?:s)?://audioboom\\.com/boos/.+$",
+        r'^https?://audioboom\.com/posts/.+$',
     ],
 }
 


### PR DESCRIPTION
AudioBoom also allows for posts to be embedded: http://audioboom.com/publishing/oembed.json?url=https://audioboom.com/posts/3987922-let-s-talk-shakespeare-how-did-shakespeare-get-so-popular