### PR TITLE
Validates EmbedBlock URLs against providers.

### DIFF
--- a/wagtail/embeds/blocks.py
+++ b/wagtail/embeds/blocks.py
@@ -1,4 +1,5 @@
 from django.core.exceptions import ValidationError
+from django.utils.functional import cached_property
 from django.utils.translation import ugettext_lazy as _
 
 from wagtail.core import blocks
@@ -15,7 +16,10 @@ class EmbedValue:
     """
     def __init__(self, url):
         self.url = url
-        self.html = embed_to_frontend_html(url)
+
+    @cached_property
+    def html(self):
+        return embed_to_frontend_html(self.url)
 
     def __str__(self):
         return self.html

--- a/wagtail/embeds/blocks.py
+++ b/wagtail/embeds/blocks.py
@@ -1,3 +1,6 @@
+from django.core.exceptions import ValidationError
+from django.utils.translation import ugettext_lazy as _
+
 from wagtail.core import blocks
 from wagtail.embeds.format import embed_to_frontend_html
 
@@ -12,9 +15,10 @@ class EmbedValue:
     """
     def __init__(self, url):
         self.url = url
+        self.html = embed_to_frontend_html(url)
 
     def __str__(self):
-        return embed_to_frontend_html(self.url)
+        return self.html
 
 
 class EmbedBlock(blocks.URLBlock):
@@ -56,6 +60,11 @@ class EmbedBlock(blocks.URLBlock):
             return None
         else:
             return EmbedValue(value)
+
+    def clean(self, value):
+        if isinstance(value, EmbedValue) and not value.html:
+            raise ValidationError(_('Please enter a valid URL'))
+        return super().clean(value)
 
     class Meta:
         icon = "media"

--- a/wagtail/embeds/tests.py
+++ b/wagtail/embeds/tests.py
@@ -512,25 +512,42 @@ class TestEmbedBlock(TestCase):
         self.assertIsInstance(block5.get_default(), EmbedValue)
         self.assertEqual(block5.get_default().url, 'http://www.example.com/foo')
 
-    def test_clean(self):
-        required_block = EmbedBlock()
-        nonrequired_block = EmbedBlock(required=False)
+    def test_clean_required(self):
+        block = EmbedBlock()
 
-        # a valid EmbedValue should return the same value on clean
-        cleaned_value = required_block.clean(EmbedValue('http://www.example.com/foo'))
+        cleaned_value = block.clean(
+            EmbedValue('https://www.youtube.com/watch?v=_U79Wc965vw'))
         self.assertIsInstance(cleaned_value, EmbedValue)
-        self.assertEqual(cleaned_value.url, 'http://www.example.com/foo')
+        self.assertEqual(cleaned_value.url,
+                         'https://www.youtube.com/watch?v=_U79Wc965vw')
 
-        cleaned_value = nonrequired_block.clean(EmbedValue('http://www.example.com/foo'))
+        with self.assertRaisesMessage(ValidationError, ''):
+            block.clean(None)
+
+    def test_clean_non_required(self):
+        block = EmbedBlock(required=False)
+
+        cleaned_value = block.clean(
+            EmbedValue('https://www.youtube.com/watch?v=_U79Wc965vw'))
         self.assertIsInstance(cleaned_value, EmbedValue)
-        self.assertEqual(cleaned_value.url, 'http://www.example.com/foo')
+        self.assertEqual(cleaned_value.url,
+                         'https://www.youtube.com/watch?v=_U79Wc965vw')
 
-        # None should only be accepted for nonrequired blocks
-        cleaned_value = nonrequired_block.clean(None)
-        self.assertEqual(cleaned_value, None)
+        cleaned_value = block.clean(None)
+        self.assertIsNone(cleaned_value)
+
+    def test_clean_invalid_url(self):
+        non_required_block = EmbedBlock(required=False)
 
         with self.assertRaises(ValidationError):
-            required_block.clean(None)
+            non_required_block.clean(
+                EmbedValue('http://no-oembed-here.com/something'))
+
+        required_block = EmbedBlock()
+
+        with self.assertRaises(ValidationError):
+            required_block.clean(
+                EmbedValue('http://no-oembed-here.com/something'))
 
 
 class TestMediaEmbedHandler(TestCase):


### PR DESCRIPTION
Currently, `EmbedBlock` accepts any URL, even when no provider is related.

With this pull request, not only `EmbedBlock` checks that the URL is valid, but it also checks whether it corresponds to existing data on the third-party site by fetching data on validation instead of doing it on front-end rendering.

As a side effect, this speeds up the first front-end page load after an `EmbedBlock` value change.