### PR TITLE
Implemented facet() method on search results

### DIFF
--- a/docs/topics/search/searching.rst
+++ b/docs/topics/search/searching.rst
@@ -97,6 +97,29 @@ This can be limited to a certain set of fields by using the ``fields`` keyword a
     >>> EventPage.objects.search("Event", fields=["title"])
     [<EventPage: Event 1>, <EventPage: Event 2>]
 
+Faceted search
+--------------
+
+Wagtail supports faceted search which is kind of filtering based on a taxonomy
+field (such as category or page type).
+
+The ``.facet(field_name)`` method returns an ``OrderedDict``. The keys are the
+the IDs of the related objects that have been referenced by the field and the
+values are number of references to each ID. The results are ordered by number
+of references descending.
+
+For example, to find the most common page types in the search results:
+
+.. code-block::python
+
+    >>> Page.objects.search("Test").facet("content_type_id")
+
+    # Note: The keys correspond to the ID of a ContentType object, the values are the
+    # number of pages returned for that type
+    OrderedDict([
+        ('2', 4),  # 4 pages have content_type_id == 2
+        ('1', 2),  # 2 pages have content_type_id == 1
+    ])
 
 Changing search behaviour
 -------------------------

--- a/wagtail/search/backends/base.py
+++ b/wagtail/search/backends/base.py
@@ -164,6 +164,8 @@ class BaseSearchQueryCompiler:
 
 
 class BaseSearchResults:
+    supports_facet = False
+
     def __init__(self, backend, query_compiler, prefetch_related=None):
         self.backend = backend
         self.query_compiler = query_compiler
@@ -253,6 +255,9 @@ class BaseSearchResults:
         clone = self._clone()
         clone._score_field = field_name
         return clone
+
+    def facet(self, field_name):
+        raise NotImplementedError("This search backend does not support faceting")
 
 
 class EmptySearchResults(BaseSearchResults):

--- a/wagtail/search/backends/elasticsearch2.py
+++ b/wagtail/search/backends/elasticsearch2.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict
 import copy
 import json
 import warnings
@@ -595,6 +596,37 @@ class Elasticsearch2SearchQueryCompiler(BaseSearchQueryCompiler):
 
 class Elasticsearch2SearchResults(BaseSearchResults):
     fields_param_name = 'fields'
+    supports_facet = True
+
+    def facet(self, field_name):
+        # Get field
+        field = self.query_compiler._get_filterable_field(field_name)
+        if field is None:
+            pass  # TODO: Error
+
+        # Build body
+        body = self._get_es_body()
+        column_name = self.query_compiler.mapping.get_field_column_name(field)
+
+        body['aggregations'] = {
+            field_name: {
+                'terms': {
+                    'field': column_name,
+                }
+            }
+        }
+
+        # Send to Elasticsearch
+        response = self.backend.es.search(
+            index=self.backend.get_index_for_model(self.query_compiler.queryset.model).name,
+            body=body,
+            size=0,
+        )
+
+        return OrderedDict([
+            (bucket['key'], bucket['doc_count'])
+            for bucket in response['aggregations'][field_name]['buckets']
+        ])
 
     def _get_es_body(self, for_count=False):
         body = {

--- a/wagtail/search/tests/test_backends.py
+++ b/wagtail/search/tests/test_backends.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 
 import unittest
+from collections import OrderedDict
 from datetime import date
 from io import StringIO
 
@@ -8,6 +9,7 @@ from django.conf import settings
 from django.core import management
 from django.test import TestCase
 from django.test.utils import override_settings
+from taggit.models import Tag
 
 from wagtail.search.backends import (
     InvalidSearchBackendError, get_search_backend, get_search_backends)
@@ -380,6 +382,34 @@ class BackendTests(WagtailTestUtils):
             "The Return of the King",
             "A Game of Thrones"
         ])
+
+    # FACET TESTS
+
+    def test_facet(self):
+        results = self.backend.search(MATCH_ALL, models.ProgrammingGuide).facet('programming_language')
+
+        self.assertEqual(results, OrderedDict([('js', 2), ('py', 2), ('rs', 1)]))
+
+    def test_facet_tags(self):
+        # The test data doesn't contain any tags, add some
+        FANTASY_BOOKS = [1, 2, 3, 4, 5, 6, 7]
+        SCIFI_BOOKS = [10]
+        for book_id in FANTASY_BOOKS:
+            models.Book.objects.get(id=book_id).tags.add('Fantasy')
+        for book_id in SCIFI_BOOKS:
+            models.Book.objects.get(id=book_id).tags.add('Science Fiction')
+
+        fantasy_tag = Tag.objects.get(name='Fantasy')
+        scifi_tag = Tag.objects.get(name='Science Fiction')
+
+        results = self.backend.search(MATCH_ALL, models.Book).facet('tags')
+
+        self.assertEqual(results, OrderedDict([
+            (fantasy_tag.id, 7),
+            (None, 5),
+            (scifi_tag.id, 1),
+        ]))
+
 
     # MISC TESTS
 


### PR DESCRIPTION
This PR implements a ``facet()`` method on the ``SearchResults`` class for all search backends. It takes a field name and returns an ordered dict containing all the values of that field with the number of results that contain each value (in descending order).