### PR TITLE
Improvements to search view in admin

### DIFF
--- a/docs/topics/search/searching.rst
+++ b/docs/topics/search/searching.rst
@@ -97,6 +97,29 @@ This can be limited to a certain set of fields by using the ``fields`` keyword a
     >>> EventPage.objects.search("Event", fields=["title"])
     [<EventPage: Event 1>, <EventPage: Event 2>]
 
+Faceted search
+--------------
+
+Wagtail supports faceted search which is kind of filtering based on a taxonomy
+field (such as category or page type).
+
+The ``.facet(field_name)`` method returns an ``OrderedDict``. The keys are the
+the IDs of the related objects that have been referenced by the field and the
+values are number of references to each ID. The results are ordered by number
+of references descending.
+
+For example, to find the most common page types in the search results:
+
+.. code-block::python
+
+    >>> Page.objects.search("Test").facet("content_type_id")
+
+    # Note: The keys correspond to the ID of a ContentType object, the values are the
+    # number of pages returned for that type
+    OrderedDict([
+        ('2', 4),  # 4 pages have content_type_id == 2
+        ('1', 2),  # 2 pages have content_type_id == 1
+    ])
 
 Changing search behaviour
 -------------------------

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_table_headers_explore.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_table_headers_explore.html
@@ -1,4 +1,4 @@
-{% load i18n %}
+{% load i18n wagtailadmin_tags %}
 
 {% comment %}
 
@@ -29,7 +29,7 @@ ordering: the current sort parameter
     {% endif %}
     <th class="title">
         {% if sortable %}
-            <a href="{% url 'wagtailadmin_explore' parent_page.id %}?ordering={% if ordering == 'title' %}-{% endif %}title" class="icon icon-arrow-{% if ordering == 'title' %}down-after{% elif ordering == '-title' %}up-after{% else %}down-after{% endif %} {% if ordering == 'title' or ordering == '-title' %}teal{% endif %}">
+            <a href="{% if ordering == 'title' %}{% querystring ordering='-title' %}{% else %}{% querystring ordering='title' %}{% endif %}" class="icon icon-arrow-{% if ordering == 'title' %}down-after{% elif ordering == '-title' %}up-after{% else %}down-after{% endif %} {% if ordering == 'title' or ordering == '-title' %}teal{% endif %}">
                 {% trans 'Title' %}
             </a>
         {% else %}
@@ -41,7 +41,7 @@ ordering: the current sort parameter
     {% endif %}
      <th class="updated">
         {% if sortable %}
-            <a href="{% url 'wagtailadmin_explore' parent_page.id %}?ordering={% if ordering == 'latest_revision_created_at' %}-{% endif %}latest_revision_created_at" class="icon icon-arrow-{% if ordering == '-latest_revision_created_at' %}up-after{% else %}down-after{% endif %} {% if ordering == 'latest_revision_created_at' or ordering == '-latest_revision_created_at' %}teal {% endif %}">
+            <a href="{% if ordering == 'latest_revision_created_at' %}{% querystring ordering='-latest_revision_created_at' %}{% else %}{% querystring ordering='latest_revision_created_at' %}{% endif %}" class="icon icon-arrow-{% if ordering == '-latest_revision_created_at' %}up-after{% else %}down-after{% endif %} {% if ordering == 'latest_revision_created_at' or ordering == '-latest_revision_created_at' %}teal {% endif %}">
                 {% trans 'Updated' %}
             </a>
         {% else %}
@@ -49,8 +49,8 @@ ordering: the current sort parameter
         {% endif %}
     </th>
     <th class="type">
-        {% if sortable %}
-            <a href="{% url 'wagtailadmin_explore' parent_page.id %}?ordering={% if ordering == 'content_type' %}-{% endif %}content_type" class="icon icon-arrow-{% if ordering == '-content_type' %}up-after{% else %}down-after{% endif %} {% if ordering == 'content_type' or ordering == '-content_type' %}teal {% endif %}">
+        {% if sortable and not not_sortable_by_type %}
+            <a href="{% if ordering == 'content_type' %}{% querystring ordering='-content_type' %}{% else %}{% querystring ordering='content_type' %}{% endif %}" class="icon icon-arrow-{% if ordering == '-content_type' %}up-after{% else %}down-after{% endif %} {% if ordering == 'content_type' or ordering == '-content_type' %}teal {% endif %}">
                 {% trans 'Type' %}
             </a>
         {% else %}
@@ -59,7 +59,7 @@ ordering: the current sort parameter
     </th>
     <th class="status">
         {% if sortable %}
-            <a href="{% url 'wagtailadmin_explore' parent_page.id %}?ordering={% if ordering == 'live' %}-{% endif %}live" class="icon icon-arrow-{% if ordering == '-live' %}up-after{% else %}down-after{% endif %} {% if ordering == 'live' or ordering == '-live' %}teal {% endif %}">
+            <a href="{% if ordering == 'live' %}{% querystring ordering='-live' %}{% else %}{% querystring ordering='live' %}{% endif %}" class="icon icon-arrow-{% if ordering == '-live' %}up-after{% else %}down-after{% endif %} {% if ordering == 'live' or ordering == '-live' %}teal {% endif %}">
                 {% trans 'Status' %}
             </a>
         {% else %}

--- a/wagtail/admin/templates/wagtailadmin/pages/search_results.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/search_results.html
@@ -2,7 +2,7 @@
 <div class="nice-padding">
     {% if pages %}
         <h2>
-            {% blocktrans count counter=pages.paginator.count %}
+            {% blocktrans count counter=all_pages.count %}
                 There is one matching page
             {% plural %}
                 There are {{ counter }} matching pages
@@ -11,6 +11,27 @@
 
         {% search_other %}
 
+        {% if pages.object_list.supports_facet %}
+            <nav class="listing-filter">
+                <h3 class="filter-title">{% trans "Content types" %}</h3>
+                <ul class="filter-options">
+                    {% if not selected_content_type %}
+                        <li style="background-color: #E6E6E6">All ({{ all_pages.count }})</li>
+                    {% else %}
+                        <li><a href="{% url 'wagtailadmin_pages:search' %}?q={{ query_string|urlencode }}">All ({{ all_pages.count }})</a></li>
+                    {% endif %}
+
+                    {% for content_type, count in content_types %}
+                        {% if content_type == selected_content_type %}
+                            <li style="background-color: #E6E6E6">{{ content_type.model_class.get_verbose_name }} ({{ count }})</li>
+                        {% else %}
+                            <li><a href="{% url 'wagtailadmin_pages:search' %}?q={{ query_string|urlencode }}&amp;content_type={{ content_type.app_label }}.{{ content_type.model|lower }}">{{ content_type.model_class.get_verbose_name }} ({{ count }})</a></li>
+                        {% endif %}
+                    {% endfor %}
+                </ul>
+            </nav>
+        {% endif %}
+
         {% include "wagtailadmin/pages/listing/_list_explore.html" with show_parent=1 %}
 
         {% url 'wagtailadmin_pages:search' as pagination_base_url %}
@@ -18,7 +39,7 @@
     {% else %}
         {% if query_string %}
             <h2>{% blocktrans %}Sorry, no pages match <em>"{{ query_string }}"</em>{% endblocktrans %}</h2>
-            
+
             {% search_other %}
         {% else %}
             <p>{% trans 'Enter a search term above' %}</p>

--- a/wagtail/admin/templates/wagtailadmin/pages/search_results.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/search_results.html
@@ -32,7 +32,7 @@
             </nav>
         {% endif %}
 
-        {% include "wagtailadmin/pages/listing/_list_explore.html" with show_parent=1 %}
+        {% include "wagtailadmin/pages/listing/_list_explore.html" with show_parent=1 sortable=1 not_sortable_by_type=1 %}
 
         {% url 'wagtailadmin_pages:search' as pagination_base_url %}
         {% paginate pages base_url=pagination_base_url %}

--- a/wagtail/admin/tests/test_pages_views.py
+++ b/wagtail/admin/tests/test_pages_views.py
@@ -2381,6 +2381,86 @@ class TestPageSearch(TestCase, WagtailTestUtils):
         self.user.save()
         self.assertRedirects(self.get(), '/admin/')
 
+    def test_search_order_by_title(self):
+        root_page = Page.objects.get(id=2)
+        new_event = SingleEventPage(
+            title="Lunar event",
+            location='the moon', audience='public',
+            cost='free', date_from='2001-01-01',
+            latest_revision_created_at=local_datetime(2016, 1, 1)
+        )
+        root_page.add_child(instance=new_event)
+
+        new_event_2 = SingleEventPage(
+            title="A Lunar event",
+            location='the moon', audience='public',
+            cost='free', date_from='2001-01-01',
+            latest_revision_created_at=local_datetime(2016, 1, 1)
+        )
+        root_page.add_child(instance=new_event_2)
+
+        response = self.get({'q': 'Lunar', 'ordering': 'title'})
+        page_ids = [page.id for page in response.context['pages']]
+        self.assertEqual(page_ids, [new_event_2.id, new_event.id])
+
+        response = self.get({'q': 'Lunar', 'ordering': '-title'})
+        page_ids = [page.id for page in response.context['pages']]
+        self.assertEqual(page_ids, [new_event.id, new_event_2.id])
+
+    def test_search_order_by_updated(self):
+        root_page = Page.objects.get(id=2)
+        new_event = SingleEventPage(
+            title="Lunar event",
+            location='the moon', audience='public',
+            cost='free', date_from='2001-01-01',
+            latest_revision_created_at=local_datetime(2016, 1, 1)
+        )
+        root_page.add_child(instance=new_event)
+
+        new_event_2 = SingleEventPage(
+            title="Lunar event 2",
+            location='the moon', audience='public',
+            cost='free', date_from='2001-01-01',
+            latest_revision_created_at=local_datetime(2015, 1, 1)
+        )
+        root_page.add_child(instance=new_event_2)
+
+        response = self.get({'q': 'Lunar', 'ordering': 'latest_revision_created_at'})
+        page_ids = [page.id for page in response.context['pages']]
+        self.assertEqual(page_ids, [new_event_2.id, new_event.id])
+
+        response = self.get({'q': 'Lunar', 'ordering': '-latest_revision_created_at'})
+        page_ids = [page.id for page in response.context['pages']]
+        self.assertEqual(page_ids, [new_event.id, new_event_2.id])
+
+    def test_search_order_by_status(self):
+        root_page = Page.objects.get(id=2)
+        live_event = SingleEventPage(
+            title="Lunar event",
+            location='the moon', audience='public',
+            cost='free', date_from='2001-01-01',
+            latest_revision_created_at=local_datetime(2016, 1, 1),
+            live=True
+        )
+        root_page.add_child(instance=live_event)
+
+        draft_event = SingleEventPage(
+            title="Lunar event",
+            location='the moon', audience='public',
+            cost='free', date_from='2001-01-01',
+            latest_revision_created_at=local_datetime(2016, 1, 1),
+            live=False
+        )
+        root_page.add_child(instance=draft_event)
+
+        response = self.get({'q': 'Lunar', 'ordering': 'live'})
+        page_ids = [page.id for page in response.context['pages']]
+        self.assertEqual(page_ids, [draft_event.id, live_event.id])
+
+        response = self.get({'q': 'Lunar', 'ordering': '-live'})
+        page_ids = [page.id for page in response.context['pages']]
+        self.assertEqual(page_ids, [live_event.id, draft_event.id])
+
 
 class TestPageMove(TestCase, WagtailTestUtils):
     def setUp(self):

--- a/wagtail/admin/views/pages.py
+++ b/wagtail/admin/views/pages.py
@@ -887,7 +887,27 @@ def search(request):
     pages = all_pages = Page.objects.all().prefetch_related('content_type').specific()
     q = None
     content_types = []
-    pagination_query_params = {}
+    pagination_query_params = QueryDict({}, mutable=True)
+    ordering = None
+
+    if 'ordering' in request.GET:
+        if request.GET['ordering'] in ['title', '-title', 'latest_revision_created_at', '-latest_revision_created_at', 'live', '-live']:
+            ordering = request.GET['ordering']
+
+            if ordering == 'title':
+                pages = pages.order_by('title')
+            elif ordering == '-title':
+                pages = pages.order_by('-title')
+
+            if ordering == 'latest_revision_created_at':
+                pages = pages.order_by('latest_revision_created_at')
+            elif ordering == '-latest_revision_created_at':
+                pages = pages.order_by('-latest_revision_created_at')
+
+            if ordering == 'live':
+                pages = pages.order_by('live')
+            elif ordering == '-live':
+                pages = pages.order_by('-live')
 
     if 'content_type' in request.GET:
         pagination_query_params['content_type'] = request.GET['content_type']
@@ -909,8 +929,8 @@ def search(request):
             q = form.cleaned_data['q']
             pagination_query_params['q'] = q
 
-            all_pages = all_pages.search(q)
-            pages = pages.search(q)
+            all_pages = all_pages.search(q, order_by_relevance=not ordering, operator='and')
+            pages = pages.search(q, order_by_relevance=not ordering, operator='and')
 
             if pages.supports_facet:
                 content_types = [
@@ -930,7 +950,8 @@ def search(request):
             'query_string': q,
             'content_types': content_types,
             'selected_content_type': selected_content_type,
-            'pagination_query_params': '&'.join('{}={}'.format(*p) for p in pagination_query_params.items()),
+            'ordering': ordering,
+            'pagination_query_params': pagination_query_params.urlencode(),
         })
     else:
         return render(request, "wagtailadmin/pages/search.html", {
@@ -940,7 +961,8 @@ def search(request):
             'query_string': q,
             'content_types': content_types,
             'selected_content_type': selected_content_type,
-            'pagination_query_params': '&'.join('{}={}'.format(*p) for p in pagination_query_params.items()),
+            'ordering': ordering,
+            'pagination_query_params': pagination_query_params.urlencode(),
         })
 
 

--- a/wagtail/search/backends/base.py
+++ b/wagtail/search/backends/base.py
@@ -164,6 +164,8 @@ class BaseSearchQueryCompiler:
 
 
 class BaseSearchResults:
+    supports_facet = False
+
     def __init__(self, backend, query_compiler, prefetch_related=None):
         self.backend = backend
         self.query_compiler = query_compiler
@@ -253,6 +255,9 @@ class BaseSearchResults:
         clone = self._clone()
         clone._score_field = field_name
         return clone
+
+    def facet(self, field_name):
+        raise NotImplementedError("This search backend does not support faceting")
 
 
 class EmptySearchResults(BaseSearchResults):

--- a/wagtail/search/backends/elasticsearch2.py
+++ b/wagtail/search/backends/elasticsearch2.py
@@ -1,6 +1,7 @@
 import copy
 import json
 import warnings
+from collections import OrderedDict
 from urllib.parse import urlparse
 
 from django.db import DEFAULT_DB_ALIAS, models
@@ -595,6 +596,37 @@ class Elasticsearch2SearchQueryCompiler(BaseSearchQueryCompiler):
 
 class Elasticsearch2SearchResults(BaseSearchResults):
     fields_param_name = 'fields'
+    supports_facet = True
+
+    def facet(self, field_name):
+        # Get field
+        field = self.query_compiler._get_filterable_field(field_name)
+        if field is None:
+            pass  # TODO: Error
+
+        # Build body
+        body = self._get_es_body()
+        column_name = self.query_compiler.mapping.get_field_column_name(field)
+
+        body['aggregations'] = {
+            field_name: {
+                'terms': {
+                    'field': column_name,
+                }
+            }
+        }
+
+        # Send to Elasticsearch
+        response = self.backend.es.search(
+            index=self.backend.get_index_for_model(self.query_compiler.queryset.model).name,
+            body=body,
+            size=0,
+        )
+
+        return OrderedDict([
+            (bucket['key'], bucket['doc_count'])
+            for bucket in response['aggregations'][field_name]['buckets']
+        ])
 
     def _get_es_body(self, for_count=False):
         body = {


### PR DESCRIPTION
This PR adds the following features to the search admin view:
 
 - Search by content type (using the new facet feature introduced by https://github.com/wagtail/wagtail/pull/4508)
 - Order by title, updated at or status

![screenshot-2018-5-3 wagtail - search](https://user-images.githubusercontent.com/1093808/39761948-50559e30-52d1-11e8-91c5-ba87805a272d.png)

I'll need some help with making it look pretty.