### PR TITLE
Allow one to extend Draftail for p and br elements

### DIFF
--- a/wagtail/admin/rich_text/converters/html_to_contentstate.py
+++ b/wagtail/admin/rich_text/converters/html_to_contentstate.py
@@ -264,15 +264,18 @@ class LineBreakHandler:
 
 class HtmlToContentStateHandler(HTMLParser):
     def __init__(self, features=()):
-        self.paragraph_handler = BlockElementHandler('unstyled')
-        self.element_handlers = HTMLRuleset({
-            'p': self.paragraph_handler,
-            'br': LineBreakHandler(),
-        })
+        self.element_handlers = HTMLRuleset()
         for feature in features:
             rule = feature_registry.get_converter_rule('contentstate', feature)
             if rule is not None:
                 self.element_handlers.add_rules(rule['from_database_format'])
+
+        # add default rules for base elements
+        self.paragraph_handler = BlockElementHandler('unstyled')
+        self.element_handlers.add_rules({
+            'p': self.paragraph_handler,
+            'br': LineBreakHandler(),
+        })
 
         super().__init__(convert_charrefs=True)
 


### PR DESCRIPTION
The converter rules for `p` and `br` elements are currently not taken into account when defining a new feature in order to extend the Draftail Editor. Some rules are added by Wagtail for those elements before adding features rules. As they only match on the tag name, they always take precedence.

This pull request moves the addition of the default rules for `p` and `br` after features ones. Thus it's possible to extend Draftail and set a class on a `p` element for example.

Let me know if it's a desired behavior to prevent such extensions. Also, let me know if I should try to add some tests for that... It's my first contribution, any feedback to improve myself is welcome! Thanks.