### PR TITLE
Fix the appearance of checkbox and radio in the admin

### DIFF
--- a/wagtail/admin/static_src/wagtailadmin/scss/components/_forms.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/components/_forms.scss
@@ -140,8 +140,7 @@ input[type=checkbox] {
 }
 
 input[type=radio] {
-    // stylelint-disable-next-line property-no-vendor-prefix
-    -webkit-appearance: radio;
+    appearance: radio;
     width: auto;
     position: relative;
     margin-right: 15px;
@@ -173,8 +172,7 @@ input[type=radio]:checked:before {
 }
 
 input[type=checkbox] {
-    // stylelint-disable-next-line property-no-vendor-prefix
-    -webkit-appearance: checkbox;
+    appearance: checkbox;
     width: auto;
     position: relative;
     margin-right: 15px;

--- a/wagtail/admin/static_src/wagtailadmin/scss/components/_forms.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/components/_forms.scss
@@ -873,6 +873,10 @@ li.focused > .help {
         float: none;
         padding-top: 0; // Negates padding added to label for the group of fields as a whole
     }
+
+    input + label {
+        display: inline-block;
+    }
 }
 
 .fields > li,


### PR DESCRIPTION
The appearance of all inputs is [reset](https://github.com/wagtail/wagtail/blob/35367964719dc93fb8eb79501d222e15cd148df8/wagtail/admin/static_src/wagtailadmin/scss/components/_forms.scss#L58) but only set in checkbox and radio inputs for WebKit based browsers. It results in ugly inputs in other browsers - at least in Firefox ESR 52, on Debian:

![ff-before](https://user-images.githubusercontent.com/3597194/39809353-d6359c98-5381-11e8-99c7-58e5d8022830.png)

It also moves the checkbox and radio labels next to its input. It now look like this in Firefox:

![ff-after](https://user-images.githubusercontent.com/3597194/39809506-42ff15c0-5382-11e8-907e-f5df3f07c420.png)

This is also because the checkbox and radio customization only works at least in Chromium - and Chrome... It could be nice to find another way to customize them which is inside CSS scope and follows its standards! Only the label position changes in Chrome with this PR:

![ch-after](https://user-images.githubusercontent.com/3597194/39810658-1848b3d2-5386-11e8-8403-1e49c1ce4876.png)