### PR TITLE
Fix bug when deleting object from DeleteView with protected OneToOneField

### DIFF
--- a/wagtail/contrib/modeladmin/views.py
+++ b/wagtail/contrib/modeladmin/views.py
@@ -801,9 +801,12 @@ class DeleteView(InstanceSpecificView):
                 obj.field, ManyToManyField))
             for rel in fields:
                 if rel.on_delete == models.PROTECT:
-                    qs = getattr(self.instance, rel.get_accessor_name())
-                    for obj in qs.all():
-                        linked_objects.append(obj)
+                    val = getattr(self.instance, rel.get_accessor_name())
+                    if isinstance(val, models.Manager):
+                        for obj in val.all():
+                            linked_objects.append(obj)
+                    else:
+                        linked_objects.append(val)
             context = self.get_context_data(
                 protected_error=True,
                 linked_objects=linked_objects


### PR DESCRIPTION
`DeleteView.post()` is raising an unhandled AttributeError when attempting to surface related object information for instances of some models.

Not every accessor descriptor is a Manager with an `all()` method. Consider this case:

```
class Member(models.Model):
    user = models.OneToOneField(User, on_delete=models.PROTECT)
```

In the case of objects with a OneToOneField with `on_delete=models.PROTECT`, the accessor value is the related object itself rather than a Manager that retrieves objects.

In `modeladmin.DeleteView`, this case was producing an unhandled AttributeError in the post.