### PR TITLE
POC implementation of the StreamField prefetcher

### DIFF
--- a/wagtail/core/blocks/base.py
+++ b/wagtail/core/blocks/base.py
@@ -191,7 +191,7 @@ class Block(metaclass=BaseBlock):
         """
         return value
 
-    def to_python(self, value):
+    def to_python(self, value, strategy=None):
         """
         Convert 'value' from a simple (JSON-serialisable) value to a (possibly complex) Python value to be
         used in the rest of the block API and within front-end templates . In simple cases this might be
@@ -207,6 +207,9 @@ class Block(metaclass=BaseBlock):
         The reverse of to_python; convert the python value into JSON-serialisable form.
         """
         return value
+
+    def get_prefetch_info(self, value):
+        return
 
     def get_context(self, value, parent_context=None):
         """

--- a/wagtail/core/blocks/list_block.py
+++ b/wagtail/core/blocks/list_block.py
@@ -127,12 +127,20 @@ class ListBlock(Block):
 
         return result
 
-    def to_python(self, value):
+    def to_python(self, value, strategy=None):
         # recursively call to_python on children and return as a list
         return [
-            self.child_block.to_python(item)
+            self.child_block.to_python(item, strategy)
             for item in value
         ]
+
+    def get_prefetch_info(self, value):
+        result = []
+        for item in value:
+            rv = self.child_block.get_prefetch_info(item)
+            if rv:
+                result.extend(rv)
+        return result
 
     def get_prep_value(self, value):
         # recursively call get_prep_value on children and return as a list


### PR DESCRIPTION
So this is a first pass at implementing prefetching of objects to make Wagtail significantly faster by reducing the number of queries required. A standalone poc implementation of which I did a lightning talk at Wagtail Space 2018 is available at https://gist.github.com/mvantellingen/daebda6abbaa9a5ed0888f886a77fcf0

It's not in a merge-able state due to the fact that it misses tests, documentation updates, etc. I would first like some feedback on this before I spend time on it. The earlier implemention of bulk prefetching can be removed with this change.

The idea is that on accessing a StreamField it first collects all the related models and primary keys reference and then does an in_bulk() call for each model. A data object is then passed to each get_python() call so that the block can re-use already loaded data objects.
