### PR TITLE
Change wagtailimages.Image on_delete CASCADE to SET_NULL in docs

### DIFF
--- a/docs/advanced_topics/api/v2/configuration.rst
+++ b/docs/advanced_topics/api/v2/configuration.rst
@@ -125,7 +125,7 @@ For example:
     class BlogPage(Page):
         published_date = models.DateTimeField()
         body = RichTextField()
-        feed_image = models.ForeignKey('wagtailimages.Image', on_delete=models.CASCADE, ...)
+        feed_image = models.ForeignKey('wagtailimages.Image', on_delete=models.SET_NULL, null=True, ...)
         private_field = models.CharField(max_length=255)
 
         # Export fields over the API

--- a/docs/advanced_topics/i18n/index.rst
+++ b/docs/advanced_topics/i18n/index.rst
@@ -143,7 +143,7 @@ For each field you would like to be translatable, duplicate it for every languag
         body_fr = StreamField(...)
 
         # Language-independent fields don't need to be duplicated
-        thumbnail_image = models.ForeignKey('wagtailimages.image', on_delete=models.CASCADE, ...)
+        thumbnail_image = models.ForeignKey('wagtailimages.Image', on_delete=models.SET_NULL, null=True, ...)
 
 .. note::
 


### PR DESCRIPTION
On the latest Wagtail, it looks like you can't set `on_delete=CASCADE` anymore for ForeignKey's to wagtailimages.Image. This Wagtail-specific error now recommends using SET_NULL or PROTECT:

```
WARNINGS:
events.EventPage.image: (wagtailcore.W001) Field hasn't specified on_delete action
	HINT: Set on_delete=models.SET_NULL and make sure the field is nullable or set on_delete=models.PROTECT. Wagtail does not allow simple database CASCADE because it will corrupt its tree storage.
```

This PR changes all instances of `on_delete=CASCADE` to `on_delete=SET_NULL, null=True` in the docs.