### PR TITLE
Add image permission policy to ImageChooser

### DIFF
--- a/wagtail/images/views/chooser.py
+++ b/wagtail/images/views/chooser.py
@@ -7,7 +7,6 @@ from wagtail.admin.forms import SearchForm
 from wagtail.admin.modal_workflow import render_modal_workflow
 from wagtail.admin.utils import PermissionPolicyChecker, popular_tags_for_model
 from wagtail.core import hooks
-from wagtail.core.models import Collection
 from wagtail.images import get_image_model
 from wagtail.images.formats import get_image_format
 from wagtail.images.forms import ImageInsertionForm, get_image_form
@@ -37,6 +36,7 @@ def get_image_json(image):
     })
 
 
+@permission_checker.require_any('add', 'change', 'delete')
 def chooser(request):
     Image = get_image_model()
 
@@ -46,7 +46,9 @@ def chooser(request):
     else:
         uploadform = None
 
-    images = Image.objects.order_by('-created_at')
+    images = permission_policy.instances_user_has_any_permission_for(
+        request.user, ['change', 'delete']
+    ).order_by('-created_at')
 
     # allow hooks to modify the queryset
     for hook in hooks.get_hooks('construct_image_chooser_queryset'):
@@ -88,7 +90,9 @@ def chooser(request):
     else:
         searchform = SearchForm()
 
-        collections = Collection.objects.all()
+        collections = permission_policy.collections_user_has_any_permission_for(
+            request.user, ['add', 'change']
+        )
         if len(collections) < 2:
             collections = None
 


### PR DESCRIPTION
The images and collections shown in the `Images` admin section depend on the user permissions, but the images and collections displayed in the ImageChoosers do not, as shown below.
This PR ensures that the images and collections accessible to a user are the same in both places.


On the `Images` admin section, the images depend on the user permissions (here the `test` user group has permissions for one collection only) :
![images_page](https://user-images.githubusercontent.com/36047361/40538741-c9eba8f4-6012-11e8-854c-41cf0a61a1a2.png)

On an ImageChooser, the same `test` user has access to all images and collections :
![imagechooser](https://user-images.githubusercontent.com/36047361/40538740-c9ceed04-6012-11e8-9482-6f4aa6aaff6a.png)



* Do the tests still pass? Yes
* Does the code comply with the style guide? Yes
* For Python changes: Have you added tests to cover the new/fixed behaviour? N/A
* For front-end changes: Did you test on all of Wagtail’s supported browsers? N/A
* For new features: Has the documentation been updated accordingly? N/A
