### PR TITLE
Eliminate Django templating from modal-workflow javascript

### DIFF
--- a/wagtail/admin/modal_workflow.py
+++ b/wagtail/admin/modal_workflow.py
@@ -4,7 +4,7 @@ from django.http import HttpResponse
 from django.template.loader import render_to_string
 
 
-def render_modal_workflow(request, html_template, js_template, template_vars=None):
+def render_modal_workflow(request, html_template, js_template, template_vars=None, json_data=None):
     """"
     Render a response consisting of an HTML chunk and a JS onload chunk
     in the format required by the modal-workflow framework.
@@ -18,6 +18,10 @@ def render_modal_workflow(request, html_template, js_template, template_vars=Non
     if js_template:
         js = render_to_string(js_template, template_vars or {}, request=request)
         response_keyvars.append("'onload': %s" % js)
+
+    if json_data:
+        for key, val in json_data.items():
+            response_keyvars.append("%s: %s" % (json.dumps(key), json.dumps(val)))
 
     response_text = "{%s}" % ','.join(response_keyvars)
 

--- a/wagtail/admin/static_src/wagtailadmin/js/modal-workflow.js
+++ b/wagtail/admin/static_src/wagtailadmin/js/modal-workflow.js
@@ -59,14 +59,15 @@ function ModalWorkflow(opts) {
 
     self.loadBody = function(response) {
         if (response.html) {
-            // if the response is html
+            // if response contains an 'html' item, replace modal body with it
             self.body.html(response.html);
             container.modal('show');
         }
 
         if (response.onload) {
-            // if the response is a function
-            response.onload(self);
+            // if response contains an 'onload' funtion, call it
+            // (passing this modal object and the full response data)
+            response.onload(self, response);
         }
     };
 

--- a/wagtail/admin/templates/wagtailadmin/chooser/browse.js
+++ b/wagtail/admin/templates/wagtailadmin/chooser/browse.js
@@ -1,4 +1,4 @@
-function(modal) {
+function(modal, jsonData) {
     /* Set up link-types links to open in the modal */
     $('.link-types a', modal.body).on('click', function() {
         modal.loadUrl(this.href);
@@ -80,7 +80,7 @@ function(modal) {
         /* Set up behaviour of choose-page links, to pass control back to the calling page */
         $('a.choose-page', modal.body).on('click', function() {
             var pageData = $(this).data();
-            pageData.parentId = {{ parent_page.id }};
+            pageData.parentId = jsonData['parent_page_id'];
             modal.respond('pageChosen', $(this).data());
             modal.close();
 

--- a/wagtail/admin/templates/wagtailadmin/chooser/external_link_chosen.js
+++ b/wagtail/admin/templates/wagtailadmin/chooser/external_link_chosen.js
@@ -1,4 +1,4 @@
-function(modal) {
-    modal.respond('pageChosen', {{ result_json|safe }});
+function(modal, jsonData) {
+    modal.respond('pageChosen', jsonData['result']);
     modal.close();
 }

--- a/wagtail/admin/templates/wagtailadmin/collection_privacy/set_privacy_done.js
+++ b/wagtail/admin/templates/wagtailadmin/collection_privacy/set_privacy_done.js
@@ -1,4 +1,4 @@
-function(modal) {
-    modal.respond('setPermission', {% if is_public %}true{% else %}false{% endif %});
+function(modal, jsonData) {
+    modal.respond('setPermission', jsonData['is_public']);
     modal.close();
 }

--- a/wagtail/admin/templates/wagtailadmin/page_privacy/set_privacy_done.js
+++ b/wagtail/admin/templates/wagtailadmin/page_privacy/set_privacy_done.js
@@ -1,4 +1,4 @@
-function(modal) {
-    modal.respond('setPermission', {% if is_public %}true{% else %}false{% endif %});
+function(modal, jsonData) {
+    modal.respond('setPermission', jsonData['is_public']);
     modal.close();
 }

--- a/wagtail/admin/tests/test_privacy.py
+++ b/wagtail/admin/tests/test_privacy.py
@@ -108,7 +108,7 @@ class TestSetPrivacyView(TestCase, WagtailTestUtils):
 
         # Check response
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, "modal.respond('setPermission', false);")
+        self.assertContains(response, '"is_public": false')
 
         # Check that a page restriction has been created
         self.assertTrue(PageViewRestriction.objects.filter(page=self.public_page).exists())
@@ -154,7 +154,7 @@ class TestSetPrivacyView(TestCase, WagtailTestUtils):
 
         # Check response
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, "modal.respond('setPermission', true);")
+        self.assertContains(response, '"is_public": true')
 
         # Check that the page restriction has been deleted
         self.assertFalse(PageViewRestriction.objects.filter(page=self.private_page).exists())
@@ -188,7 +188,7 @@ class TestSetPrivacyView(TestCase, WagtailTestUtils):
 
         # Check response
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, "modal.respond('setPermission', false);")
+        self.assertContains(response, '"is_public": false')
 
         # Check that a page restriction has been created
         self.assertTrue(PageViewRestriction.objects.filter(page=self.public_page).exists())
@@ -237,7 +237,7 @@ class TestSetPrivacyView(TestCase, WagtailTestUtils):
 
         # Check response
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, "modal.respond('setPermission', true);")
+        self.assertContains(response, '"is_public": true')
 
         # Check that the page restriction has been deleted
         self.assertFalse(PageViewRestriction.objects.filter(page=self.private_page).exists())

--- a/wagtail/admin/views/chooser.py
+++ b/wagtail/admin/views/chooser.py
@@ -1,5 +1,3 @@
-import json
-
 from django.http import Http404
 from django.shortcuts import get_object_or_404, render
 
@@ -124,18 +122,21 @@ def browse(request, parent_page_id=None):
         page.can_descend = page.get_children_count()
 
     # Render
+    context = shared_context(request, {
+        'parent_page': parent_page,
+        'parent_page_id': parent_page.pk,
+        'pages': pages,
+        'search_form': SearchForm(),
+        'page_type_string': page_type_string,
+        'page_type_names': [desired_class.get_verbose_name() for desired_class in desired_classes],
+        'page_types_restricted': (page_type_string != 'wagtailcore.page')
+    })
+
     return render_modal_workflow(
         request,
         'wagtailadmin/chooser/browse.html', 'wagtailadmin/chooser/browse.js',
-        shared_context(request, {
-            'parent_page': parent_page,
-            'parent_page_id': parent_page.pk,
-            'pages': pages,
-            'search_form': SearchForm(),
-            'page_type_string': page_type_string,
-            'page_type_names': [desired_class.get_verbose_name() for desired_class in desired_classes],
-            'page_types_restricted': (page_type_string != 'wagtailcore.page')
-        })
+        context,
+        json_data={'parent_page_id': context['parent_page_id']},
     )
 
 
@@ -203,9 +204,7 @@ def external_link(request):
             return render_modal_workflow(
                 request,
                 None, 'wagtailadmin/chooser/external_link_chosen.js',
-                {
-                    'result_json': json.dumps(result),
-                }
+                None, json_data={'result': result}
             )
     else:
         form = ExternalLinkChooserForm(initial=initial_data)
@@ -240,9 +239,7 @@ def email_link(request):
             return render_modal_workflow(
                 request,
                 None, 'wagtailadmin/chooser/external_link_chosen.js',
-                {
-                    'result_json': json.dumps(result),
-                }
+                None, json_data={'result': result}
             )
     else:
         form = EmailLinkChooserForm(initial=initial_data)

--- a/wagtail/admin/views/collection_privacy.py
+++ b/wagtail/admin/views/collection_privacy.py
@@ -34,7 +34,8 @@ def set_privacy(request, collection_id):
                 form.save()
 
             return render_modal_workflow(
-                request, None, 'wagtailadmin/collection_privacy/set_privacy_done.js', {
+                request, None, 'wagtailadmin/collection_privacy/set_privacy_done.js',
+                None, json_data={
                     'is_public': (form.cleaned_data['restriction_type'] == 'none')
                 }
             )

--- a/wagtail/admin/views/page_privacy.py
+++ b/wagtail/admin/views/page_privacy.py
@@ -34,7 +34,8 @@ def set_privacy(request, page_id):
                 form.save()
 
             return render_modal_workflow(
-                request, None, 'wagtailadmin/page_privacy/set_privacy_done.js', {
+                request, None, 'wagtailadmin/page_privacy/set_privacy_done.js',
+                None, json_data={
                     'is_public': (form.cleaned_data['restriction_type'] == 'none')
                 }
             )

--- a/wagtail/documents/templates/wagtaildocs/chooser/chooser.js
+++ b/wagtail/documents/templates/wagtaildocs/chooser/chooser.js
@@ -1,5 +1,4 @@
-{% load i18n %}
-function(modal) {
+function(modal, jsonData) {
     function ajaxifyLinks (context) {
         $('a.document-choice', context).on('click', function() {
             modal.loadUrl(this.href);
@@ -63,12 +62,10 @@ function(modal) {
                 modal.loadResponseText(response);
             },
             error: function(response, textStatus, errorThrown) {
-                {% trans "Server Error" as error_label %}
-                {% trans "Report this error to your webmaster with the following information:" as error_message %}
-                message = '{{ error_message|escapejs }}<br />' + errorThrown + ' - ' + response.status;
+                message = jsonData['error_message'] + '<br />' + errorThrown + ' - ' + response.status;
                 $('#upload').append(
                     '<div class="help-block help-critical">' +
-                    '<strong>{{ error_label|escapejs }}: </strong>' + message + '</div>');
+                    '<strong>' + jsonData['error_label'] + ': </strong>' + message + '</div>');
             }
         });
 
@@ -85,8 +82,7 @@ function(modal) {
 
     $('#collection_chooser_collection_id').on('change', search);
 
-    {% url 'wagtailadmin_tag_autocomplete' as autocomplete_url %}
     $('#id_tags', modal.body).tagit({
-        autocomplete: {source: "{{ autocomplete_url|addslashes }}"}
+        autocomplete: {source: jsonData['tag_autocomplete_url']}
     });
 }

--- a/wagtail/documents/templates/wagtaildocs/chooser/document_chosen.js
+++ b/wagtail/documents/templates/wagtaildocs/chooser/document_chosen.js
@@ -1,4 +1,4 @@
-function(modal) {
-    modal.respond('documentChosen', {{ document_json|safe }});
+function(modal, jsonData) {
+    modal.respond('documentChosen', jsonData['result']);
     modal.close();
 }

--- a/wagtail/documents/views/chooser.py
+++ b/wagtail/documents/views/chooser.py
@@ -1,7 +1,6 @@
-import json
-
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
+from django.utils.translation import ugettext as _
 
 from wagtail.admin.forms import SearchForm
 from wagtail.admin.modal_workflow import render_modal_workflow
@@ -17,19 +16,28 @@ from wagtail.utils.pagination import paginate
 permission_checker = PermissionPolicyChecker(permission_policy)
 
 
-def get_document_json(document):
+def get_chooser_context():
+    """construct context variables needed by the chooser JS"""
+    return {
+        'error_label': _("Server Error"),
+        'error_message': _("Report this error to your webmaster with the following information:"),
+        'tag_autocomplete_url': reverse('wagtailadmin_tag_autocomplete'),
+    }
+
+
+def get_document_result_data(document):
     """
-    helper function: given a document, return the json to pass back to the
+    helper function: given a document, return the json data to pass back to the
     chooser panel
     """
 
-    return json.dumps({
+    return {
         'id': document.id,
         'title': document.title,
         'url': document.url,
         'filename': document.filename,
         'edit_link': reverse('wagtaildocs:edit', args=(document.id,)),
-    })
+    }
 
 
 def chooser(request):
@@ -88,7 +96,7 @@ def chooser(request):
             'searchform': searchform,
             'collections': collections,
             'is_searching': False,
-        })
+        }, json_data=get_chooser_context())
 
 
 def document_chosen(request, document_id):
@@ -96,7 +104,7 @@ def document_chosen(request, document_id):
 
     return render_modal_workflow(
         request, None, 'wagtaildocs/chooser/document_chosen.js',
-        {'document_json': get_document_json(document)}
+        None, json_data={'result': get_document_result_data(document)}
     )
 
 
@@ -117,7 +125,7 @@ def chooser_upload(request):
 
             return render_modal_workflow(
                 request, None, 'wagtaildocs/chooser/document_chosen.js',
-                {'document_json': get_document_json(document)}
+                None, json_data={'result': get_document_result_data(document)}
             )
     else:
         form = DocumentForm(user=request.user)
@@ -126,5 +134,6 @@ def chooser_upload(request):
 
     return render_modal_workflow(
         request, 'wagtaildocs/chooser/chooser.html', 'wagtaildocs/chooser/chooser.js',
-        {'documents': documents, 'uploadform': form}
+        {'documents': documents, 'uploadform': form},
+        json_data=get_chooser_context()
     )

--- a/wagtail/embeds/templates/wagtailembeds/chooser/embed_chosen.js
+++ b/wagtail/embeds/templates/wagtailembeds/chooser/embed_chosen.js
@@ -1,4 +1,4 @@
-function(modal) {
-    modal.respond('embedChosen', '{{ embed_html|escapejs }}', {{ embed_json|safe }});
+function(modal, jsonData) {
+    modal.respond('embedChosen', jsonData['embed_html'], jsonData['embed_data']);
     modal.close();
 }

--- a/wagtail/embeds/views/chooser.py
+++ b/wagtail/embeds/views/chooser.py
@@ -1,5 +1,3 @@
-import json
-
 from django.forms.utils import ErrorList
 from django.utils.translation import ugettext as _
 
@@ -28,17 +26,17 @@ def chooser_upload(request):
             try:
                 embed_html = embed_to_editor_html(form.cleaned_data['url'])
                 embed_obj = embeds.get_embed(form.cleaned_data['url'])
-                embed_json = json.dumps({
+                embed_data = {
                     'embedType': embed_obj.type,
                     'url': embed_obj.url,
                     'providerName': embed_obj.provider_name,
                     'authorName': embed_obj.author_name,
                     'thumbnail': embed_obj.thumbnail_url,
                     'title': embed_obj.title,
-                })
+                }
                 return render_modal_workflow(
                     request, None, 'wagtailembeds/chooser/embed_chosen.js',
-                    {'embed_html': embed_html, 'embed_json': embed_json}
+                    None, json_data={'embed_html': embed_html, 'embed_data': embed_data}
                 )
             except AccessDeniedEmbedlyException:
                 error = _("There seems to be a problem with your embedly API key. Please check your settings.")

--- a/wagtail/images/templates/wagtailimages/chooser/chooser.js
+++ b/wagtail/images/templates/wagtailimages/chooser/chooser.js
@@ -1,5 +1,4 @@
-{% load i18n %}
-function(modal) {
+function(modal, jsonData) {
     var searchUrl = $('form.image-search', modal.body).attr('action');
 
     /* currentTag stores the tag currently being filtered on, so that we can
@@ -78,12 +77,10 @@ function(modal) {
                     modal.loadResponseText(response);
                 },
                 error: function(response, textStatus, errorThrown) {
-                    {% trans "Server Error" as error_label %}
-                    {% trans "Report this error to your webmaster with the following information:" as error_message %}
-                    message = '{{ error_message|escapejs }}<br />' + errorThrown + ' - ' + response.status;
+                    message = jsonData['error_message'] + '<br />' + errorThrown + ' - ' + response.status;
                     $('#upload').append(
                         '<div class="help-block help-critical">' +
-                        '<strong>{{ error_label|escapejs }}: </strong>' + message + '</div>');
+                        '<strong>' + jsonData['error_label'] + ': </strong>' + message + '</div>');
                 }
             });
         }
@@ -127,10 +124,8 @@ function(modal) {
 
     populateTitle(modal.body);
 
-    {% url 'wagtailadmin_tag_autocomplete' as autocomplete_url %}
-
     /* Add tag entry interface (with autocompletion) to the tag field of the image upload form */
     $('#id_tags', modal.body).tagit({
-        autocomplete: {source: "{{ autocomplete_url|addslashes }}"}
+        autocomplete: {source: jsonData['tag_autocomplete_url']}
     });
 }

--- a/wagtail/images/templates/wagtailimages/chooser/image_chosen.js
+++ b/wagtail/images/templates/wagtailimages/chooser/image_chosen.js
@@ -1,4 +1,4 @@
-function(modal) {
-    modal.respond('imageChosen', {{ image_json|safe }});
+function(modal, jsonData) {
+    modal.respond('imageChosen', jsonData['result']);
     modal.close();
 }

--- a/wagtail/images/tests/test_admin_views.py
+++ b/wagtail/images/tests/test_admin_views.py
@@ -661,8 +661,8 @@ class TestImageChooserSelectFormatView(TestCase, WagtailTestUtils):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response['Content-Type'], 'text/javascript')
 
-        # extract data as json from the code line: modal.respond('imageChosen', {json});
-        match = re.search(r'modal.respond\(\'imageChosen\', ([^\)]+)\);', response.content.decode())
+        # extract data as json from the 'result' field
+        match = re.search(r'"result":\s*(.*)}$', response.content.decode())
         self.assertTrue(match)
         response_json = json.loads(match.group(1))
 

--- a/wagtail/images/views/chooser.py
+++ b/wagtail/images/views/chooser.py
@@ -1,7 +1,6 @@
-import json
-
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
+from django.utils.translation import ugettext as _
 
 from wagtail.admin.forms import SearchForm
 from wagtail.admin.modal_workflow import render_modal_workflow
@@ -18,14 +17,23 @@ from wagtail.utils.pagination import paginate
 permission_checker = PermissionPolicyChecker(permission_policy)
 
 
-def get_image_json(image):
+def get_chooser_context():
+    """construct context variables needed by the chooser JS"""
+    return {
+        'error_label': _("Server Error"),
+        'error_message': _("Report this error to your webmaster with the following information:"),
+        'tag_autocomplete_url': reverse('wagtailadmin_tag_autocomplete'),
+    }
+
+
+def get_image_result_data(image):
     """
-    helper function: given an image, return the json to pass back to the
+    helper function: given an image, return the json data to pass back to the
     image chooser panel
     """
     preview_image = image.get_rendition('max-165x165')
 
-    return json.dumps({
+    return {
         'id': image.id,
         'edit_link': reverse('wagtailimages:edit', args=(image.id,)),
         'title': image.title,
@@ -34,7 +42,7 @@ def get_image_json(image):
             'width': preview_image.width,
             'height': preview_image.height,
         }
-    })
+    }
 
 
 def chooser(request):
@@ -103,7 +111,7 @@ def chooser(request):
             'will_select_format': request.GET.get('select_format'),
             'popular_tags': popular_tags_for_model(Image),
             'collections': collections,
-        })
+        }, json_data=get_chooser_context())
 
 
 def image_chosen(request, image_id):
@@ -111,7 +119,7 @@ def image_chosen(request, image_id):
 
     return render_modal_workflow(
         request, None, 'wagtailimages/chooser/image_chosen.js',
-        {'image_json': get_image_json(image)}
+        None, json_data={'result': get_image_result_data(image)}
     )
 
 
@@ -142,7 +150,7 @@ def chooser_upload(request):
                 # not specifying a format; return the image details now
                 return render_modal_workflow(
                     request, None, 'wagtailimages/chooser/image_chosen.js',
-                    {'image_json': get_image_json(image)}
+                    None, json_data={'result': get_image_result_data(image)}
                 )
     else:
         form = ImageForm(user=request.user)
@@ -152,7 +160,8 @@ def chooser_upload(request):
 
     return render_modal_workflow(
         request, 'wagtailimages/chooser/chooser.html', 'wagtailimages/chooser/chooser.js',
-        {'images': images, 'uploadform': form, 'searchform': searchform}
+        {'images': images, 'uploadform': form, 'searchform': searchform},
+        json_data=get_chooser_context()
     )
 
 
@@ -166,7 +175,7 @@ def chooser_select_format(request, image_id):
             format = get_image_format(form.cleaned_data['format'])
             preview_image = image.get_rendition(format.filter_spec)
 
-            image_json = json.dumps({
+            image_data = {
                 'id': image.id,
                 'title': image.title,
                 'format': format.name,
@@ -179,11 +188,11 @@ def chooser_select_format(request, image_id):
                     'height': preview_image.height,
                 },
                 'html': format.image_to_editor_html(image, form.cleaned_data['alt_text']),
-            })
+            }
 
             return render_modal_workflow(
                 request, None, 'wagtailimages/chooser/image_chosen.js',
-                {'image_json': image_json}
+                None, json_data={'result': image_data}
             )
     else:
         initial = {'alt_text': image.default_alt_text}

--- a/wagtail/snippets/templates/wagtailsnippets/chooser/chosen.js
+++ b/wagtail/snippets/templates/wagtailsnippets/chooser/chosen.js
@@ -1,4 +1,4 @@
-function(modal) {
-    modal.respond('snippetChosen', {{ snippet_json|safe }});
+function(modal, jsonData) {
+    modal.respond('snippetChosen', jsonData['result']);
     modal.close();
 }

--- a/wagtail/snippets/views/chooser.py
+++ b/wagtail/snippets/views/chooser.py
@@ -1,5 +1,3 @@
-import json
-
 from django.contrib.admin.utils import quote, unquote
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
@@ -74,17 +72,15 @@ def chosen(request, app_label, model_name, pk):
     model = get_snippet_model_from_url_params(app_label, model_name)
     item = get_object_or_404(model, pk=unquote(pk))
 
-    snippet_json = json.dumps({
+    snippet_data = {
         'id': item.pk,
         'string': str(item),
         'edit_link': reverse('wagtailsnippets:edit', args=(
             app_label, model_name, quote(item.pk)))
-    })
+    }
 
     return render_modal_workflow(
         request,
         None, 'wagtailsnippets/chooser/chosen.js',
-        {
-            'snippet_json': snippet_json,
-        }
+        None, json_data={'result': snippet_data}
     )


### PR DESCRIPTION
A first step in refactoring the modal-workflow mechanism so that it doesn't have to send arbitrary Javascript down the wire in response to AJAX requests. Related: #2936, #4335, #4357 

At the heart of this is a simple tweak to modal_workflow.py, to allow passing additional fields in the almost-but-not-quite-JSON response, alongside the standard `html` and `onload` fields. The `onload` handler can then retrieve the server-side data it needs from those fields, instead of having it interpolated into the JS code through Django template tags.

(The next step will be to move the now-static-JS `onload` handlers into the `ModalWorkflow` initialisation code, and have the AJAX responses include a simple `step` token that tells us which of those handlers to run. This bit is going to be more fiddly, due to there being multiple places that invoke the same modal - e.g. the page / link chooser is invoked by the AdminPageChooser widget and each rich text implementation - which now have to come up with a way of sharing that code.)