### PR TITLE
Allow specifying js/css imports against Draftail features

### DIFF
--- a/docs/advanced_topics/customisation/extending_draftail.rst
+++ b/docs/advanced_topics/customisation/extending_draftail.rst
@@ -177,7 +177,10 @@ In order to achieve this, we start with registering the rich text feature like f
         }
 
         features.register_editor_plugin(
-            'draftail', feature_name, draftail_features.EntityFeature(control)
+            'draftail', feature_name, draftail_features.EntityFeature(
+                control,
+                js=['stock.js']  # Additional JS to be loaded when this feature is active
+            )
         )
 
         features.register_converter_rule('contentstate', feature_name, {
@@ -220,26 +223,7 @@ Since entities hold data, the conversion to/from database format is more complic
 
 Note how they both do similar conversions, but use different APIs. ``to_database_format`` is built with the `Draft.js exporter <https://github.com/springload/draftjs_exporter>`_ components API, whereas ``from_database_format`` uses a Wagtail API.
 
-The next step is to add JavaScript to define how the entities are created (the ``source``), and how they are displayed (the ``decorator``). First, we load the JS file which will contain those components:
-
-.. code-block:: python
-
-    from django.utils.html import format_html_join
-    from django.conf import settings
-
-    @hooks.register('insert_editor_js')
-    def stock_editor_js():
-        js_files = [
-            # We require this file here to make sure it is loaded before stock.js.
-            'wagtailadmin/js/draftail.js',
-            'stock.js',
-        ]
-        js_includes = format_html_join('\n', '<script src="{0}{1}"></script>',
-            ((settings.STATIC_URL, filename) for filename in js_files)
-        )
-        return js_includes
-
-We define the source component:
+The next step is to add JavaScript to define how the entities are created (the ``source``), and how they are displayed (the ``decorator``). Within ``stock.js``, we define the source component:
 
 .. code-block:: javascript
 

--- a/wagtail/admin/rich_text/editors/draftail/__init__.py
+++ b/wagtail/admin/rich_text/editors/draftail/__init__.py
@@ -21,6 +21,12 @@ class DraftailRichTextArea(WidgetWithScript, widgets.HiddenInput):
         kwargs.pop('options', None)
         self.options = {}
 
+        self._media = Media(js=[
+            'wagtailadmin/js/draftail.js',
+        ], css={
+            'all': ['wagtailadmin/css/panels/draftail.css']
+        })
+
         self.features = kwargs.pop('features', None)
         if self.features is None:
             self.features = feature_registry.get_default_features()
@@ -29,6 +35,7 @@ class DraftailRichTextArea(WidgetWithScript, widgets.HiddenInput):
             plugin = feature_registry.get_editor_plugin('draftail', feature)
             if plugin:
                 plugin.construct_options(self.options)
+                self._media += plugin.media
 
         self.converter = ContentstateConverter(self.features)
 
@@ -64,8 +71,4 @@ class DraftailRichTextArea(WidgetWithScript, widgets.HiddenInput):
 
     @property
     def media(self):
-        return Media(js=[
-            'wagtailadmin/js/draftail.js',
-        ], css={
-            'all': ['wagtailadmin/css/panels/draftail.css']
-        })
+        return self._media

--- a/wagtail/admin/rich_text/editors/draftail/features.py
+++ b/wagtail/admin/rich_text/editors/draftail/features.py
@@ -1,27 +1,45 @@
+from django.forms import Media
+
 # Feature objects: these are mapped to feature identifiers within the rich text
 # feature registry (wagtail.core.rich_text.features). Each one implements
 # a `construct_options` method which modifies an options dict as appropriate to
 # enable that feature.
 
+# Additionally, a Feature object defines a media property
+# (https://docs.djangoproject.com/en/stable/topics/forms/media/) to specify css/js
+# files to import when the feature is active.
 
-class BooleanFeature:
+
+class Feature:
+    def __init__(self, js=None, css=None):
+        self.js = js
+        self.css = css
+
+    @property
+    def media(self):
+        return Media(js=self.js, css=self.css)
+
+
+class BooleanFeature(Feature):
     """
     A feature which is enabled by a boolean flag at the top level of
     the options dict
     """
-    def __init__(self, option_name):
+    def __init__(self, option_name, **kwargs):
+        super().__init__(**kwargs)
         self.option_name = option_name
 
     def construct_options(self, options):
         options[self.option_name] = True
 
 
-class ListFeature:
+class ListFeature(Feature):
     """
     Abstract class for features that are defined in a list within the options dict.
     Subclasses must define option_name
     """
-    def __init__(self, data):
+    def __init__(self, data, **kwargs):
+        super().__init__(**kwargs)
         self.data = data
 
     def construct_options(self, options):

--- a/wagtail/admin/tests/test_rich_text.py
+++ b/wagtail/admin/tests/test_rich_text.py
@@ -108,6 +108,10 @@ class TestDefaultRichText(BaseRichTextEditHandlerTestCase, WagtailTestUtils):
         # check that media for draftail is being imported
         self.assertContains(response, 'wagtailadmin/js/draftail.js')
 
+        # check that media for non-active features is not being imported
+        self.assertNotContains(response, 'testapp/js/draftail-blockquote.js')
+        self.assertNotContains(response, 'testapp/css/draftail-blockquote.css')
+
     @override_settings()  # create temporary copy of settings so we can remove WAGTAILADMIN_RICH_TEXT_EDITORS
     def test_default_editor_in_rich_text_block(self):
         # Simulate the absence of a setting
@@ -126,6 +130,10 @@ class TestDefaultRichText(BaseRichTextEditHandlerTestCase, WagtailTestUtils):
 
         # check that media for draftail is being imported
         self.assertContains(response, 'wagtailadmin/js/draftail.js')
+
+        # check that media for non-active features is not being imported
+        self.assertNotContains(response, 'testapp/js/draftail-blockquote.js')
+        self.assertNotContains(response, 'testapp/css/draftail-blockquote.css')
 
 
 @override_settings(WAGTAILADMIN_RICH_TEXT_EDITORS={
@@ -171,6 +179,43 @@ class TestHalloRichText(BaseRichTextEditHandlerTestCase, WagtailTestUtils):
         # check that media for the default hallo features (but not others) is being imported
         self.assertContains(response, 'wagtaildocs/js/hallo-plugins/hallo-wagtaildoclink.js')
         self.assertNotContains(response, 'testapp/js/hallo-blockquote.js')
+
+
+@override_settings(WAGTAILADMIN_RICH_TEXT_EDITORS={
+    'default': {
+        'WIDGET': 'wagtail.admin.rich_text.DraftailRichTextArea',
+        'OPTIONS': {'features': ['h2', 'blockquote']}
+    },
+})
+class TestDraftailFeatureMedia(BaseRichTextEditHandlerTestCase, WagtailTestUtils):
+    """
+    Features that define additional js/css imports (blockquote, in this case) should
+    have those loaded on the page
+    """
+    def setUp(self):
+        super().setUp()
+        # Find root page
+        self.root_page = Page.objects.get(id=2)
+
+        self.login()
+
+    def test_feature_media_on_rich_text_field(self):
+        response = self.client.get(reverse(
+            'wagtailadmin_pages:add', args=('tests', 'defaultrichtextfieldpage', self.root_page.id)
+        ))
+
+        self.assertContains(response, 'wagtailadmin/js/draftail.js')
+        self.assertContains(response, 'testapp/js/draftail-blockquote.js')
+        self.assertContains(response, 'testapp/css/draftail-blockquote.css')
+
+    def test_feature_media_on_rich_text_block(self):
+        response = self.client.get(reverse(
+            'wagtailadmin_pages:add', args=('tests', 'defaultrichblockfieldpage', self.root_page.id)
+        ))
+
+        self.assertContains(response, 'wagtailadmin/js/draftail.js')
+        self.assertContains(response, 'testapp/js/draftail-blockquote.js')
+        self.assertContains(response, 'testapp/css/draftail-blockquote.css')
 
 
 @override_settings(WAGTAILADMIN_RICH_TEXT_EDITORS={

--- a/wagtail/tests/testapp/wagtail_hooks.py
+++ b/wagtail/tests/testapp/wagtail_hooks.py
@@ -2,6 +2,7 @@ from django import forms
 from django.contrib.staticfiles.templatetags.staticfiles import static
 from django.http import HttpResponse
 
+import wagtail.admin.rich_text.editors.draftail.features as draftail_features
 from wagtail.admin.menu import MenuItem
 from wagtail.admin.rich_text import HalloPlugin
 from wagtail.admin.search import SearchArea
@@ -86,6 +87,7 @@ def hide_hidden_pages(parent_page, pages, request):
 
 
 # register 'blockquote' as a rich text feature supported by a hallo.js plugin
+# and a Draftail feature
 @hooks.register('register_rich_text_features')
 def register_blockquote_feature(features):
     features.register_editor_plugin(
@@ -93,5 +95,12 @@ def register_blockquote_feature(features):
             name='halloblockquote',
             js=['testapp/js/hallo-blockquote.js'],
             css={'all': ['testapp/css/hallo-blockquote.css']},
+        )
+    )
+    features.register_editor_plugin(
+        'draftail', 'blockquote', draftail_features.EntityFeature(
+            {},
+            js=['testapp/js/draftail-blockquote.js'],
+            css={'all': ['testapp/css/draftail-blockquote.css']},
         )
     )


### PR DESCRIPTION
Hook up [Django form media](https://docs.djangoproject.com/en/2.0/topics/forms/media/) to Draftail feature definitions, so that additional js/css imports can be inserted whenever a feature is active.

Besides making third-party draftail add-ons simpler to write (no need to set up an `insert_editor_js` hook any more), this is also a necessary step towards refactoring modal-workflow so that it doesn't rely on pushing JS down the wire in AJAX responses (#4566) - that JS is going to exist in static files within wagtailimages / wagtaildocs etc instead, and so we need a clean way to pull those files in so that Draftail can continue to use the chooser modals.