### PR TITLE
Improve Dockerfile in the project template

### DIFF
--- a/wagtail/project_template/Dockerfile
+++ b/wagtail/project_template/Dockerfile
@@ -1,21 +1,38 @@
-FROM python:3.6
+FROM python:3.6-stretch
 LABEL maintainer="hello@wagtail.io"
 
-ENV PYTHONUNBUFFERED 1
-ENV DJANGO_ENV dev
+WORKDIR /app
 
-COPY ./requirements.txt /code/requirements.txt
-RUN pip install -r /code/requirements.txt
-RUN pip install gunicorn
+ENV PYTHONUNBUFFERED=1 \
+    # Use production settings as default for the runtime.
+    DJANGO_SETTINGS_MODULE={{ project_name }}.settings.production \
+    # Set the PYTHONPATH so django-admin can be used.
+    PYTHONPATH=/app \
+    # Set Gunicorn's workers to 2 and its port to 8000 as default.
+    WEB_CONCURRENCY=2 \
+    PORT=8000 \
+    GUNICORN_CMD_ARGS="--access-logfile -"
 
-COPY . /code/
-WORKDIR /code/
+# Expose Gunicorn's port outside of the container.
+EXPOSE 8000
 
-RUN python manage.py migrate
+# Install the application server - Gunicorn.
+RUN pip install "gunicorn>=19.8,<19.9"
 
+# Install your application's required dependencies.
+COPY requirements.txt .
+RUN pip install -r requirements.txt
+
+# Don't use the root user.
 RUN useradd wagtail
-RUN chown -R wagtail /code
+RUN chown -R wagtail .
 USER wagtail
 
-EXPOSE 8000
-CMD exec gunicorn {{ project_name }}.wsgi:application --bind 0.0.0.0:8000 --workers 3
+# Copy your application's files.
+COPY . .
+
+# Collect static assets.
+RUN SECRET_KEY=none django-admin collectstatic --noinput --clear
+
+# Migrate the database and start the server.
+CMD exec sh -xec "django-admin migrate --noinput && gunicorn {{ project_name }}.wsgi:application"

--- a/wagtail/project_template/project_name/settings/base.py
+++ b/wagtail/project_template/project_name/settings/base.py
@@ -21,6 +21,16 @@ BASE_DIR = os.path.dirname(PROJECT_DIR)
 # See https://docs.djangoproject.com/en/{{ docs_version }}/howto/deployment/checklist/
 
 
+# Read secret key from the "SECRET_KEY" environment variable.
+if 'SECRET_KEY' in os.environ:
+    SECRET_KEY = os.environ['SECRET_KEY']
+
+
+# Read allowed hosts list from the "ALLOWED_HOSTS" environment variable.
+if 'ALLOWED_HOSTS' in os.environ:
+    ALLOWED_HOSTS = os.environ['ALLOWED_HOSTS'].split(',')
+
+
 # Application definition
 
 INSTALLED_APPS = [


### PR DESCRIPTION
I've updated a couple of things in the Dockerfile in the project template.

* It had a probable mistake of running `django-admin migrate` command during the build-phase which only may make sense for SQLite, but is probably an anti-pattern anyway. Moved that to the `CMD` so it runs on the container start.
* Pinned Gunicorn version.
* Configuring Gunicorn with environment variables rather than in-line arguments. Makes it more readable and more flexible for the user since they can override defaults when running the image.
  * Also using `PORT` variable makes it compatible with Heroku since that's what they set [1].
* Set default settings to production.
* Set `PYTHONPATH` to the application directory so `django-admin` works.
* Change main directory from `/code` to `/app` since that is, in my opinion, more widely used and is shorter. :stuck_out_tongue_closed_eyes: 
* Added collecting static during the build time as opposed to not collecting it at all.

I've added two settings that are read from the environment - `SECRET_KEY` and `ALLOWED_HOSTS`.

[1] https://devcenter.heroku.com/articles/runtime-principles#web-servers