### PR TITLE
Move chooser widget JS into widget form media

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/generic/create.html
+++ b/wagtail/admin/templates/wagtailadmin/generic/create.html
@@ -26,3 +26,13 @@
         </div>
     </form>
 {% endblock %}
+
+{% block extra_js %}
+    {{ block.super }}
+    {{ form.media.js }}
+{% endblock %}
+
+{% block extra_css %}
+    {{ block.super }}
+    {{ form.media.css }}
+{% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/generic/edit.html
+++ b/wagtail/admin/templates/wagtailadmin/generic/edit.html
@@ -33,3 +33,13 @@
         </form>
     </div>
 {% endblock %}
+
+{% block extra_js %}
+    {{ block.super }}
+    {{ form.media.js }}
+{% endblock %}
+
+{% block extra_css %}
+    {{ block.super }}
+    {{ form.media.css }}
+{% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/pages/_editor_css.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/_editor_css.html
@@ -7,5 +7,3 @@
 <link rel="stylesheet" href="{% static 'wagtailadmin/css/layouts/page-editor.css' %}" />
 
 {% hook_output 'insert_editor_css' %}
-
-{{ edit_handler.form.media.css }}

--- a/wagtail/admin/templates/wagtailadmin/pages/_editor_js.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/_editor_js.html
@@ -19,7 +19,6 @@
 <script src="{% static 'wagtailadmin/js/expanding_formset.js' %}"></script>
 <script src="{% static 'wagtailadmin/js/modal-workflow.js' %}"></script>
 <script src="{% static 'wagtailadmin/js/page-editor.js' %}"></script>
-<script src="{% static 'wagtailadmin/js/page-chooser.js' %}"></script>
 <script src="{% static 'wagtailadmin/js/vendor/xregexp.min.js' %}"></script>
 <script src="{% static 'wagtailadmin/js/vendor/urlify.js' %}"></script>
 <script src="{% static 'wagtailadmin/js/privacy-switch.js' %}"></script>

--- a/wagtail/admin/templates/wagtailadmin/pages/_editor_js.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/_editor_js.html
@@ -28,13 +28,3 @@
 {% hook_output 'insert_editor_js' %}
 
 {% include "wagtailadmin/shared/datetimepicker_translations.html" %}
-
-{% comment %}
-    Additional js from widgets media. Allows for custom widgets in admin panel.
-{% endcomment %}
-{{ edit_handler.form.media.js }}
-
-{% comment %}
-    Additional HTML code that edit handlers define through 'html_declarations'. (Technically this isn't Javascript, but it will generally be data that exists for Javascript to work with...)
-{% endcomment %}
-{{ edit_handler.html_declarations }}

--- a/wagtail/admin/templates/wagtailadmin/pages/copy.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/copy.html
@@ -32,4 +32,10 @@
 {% block extra_js %}
     {{ block.super }}
     {% include "wagtailadmin/pages/_editor_js.html" %}
+    {{ form.media.js }}
+{% endblock %}
+
+{% block extra_css %}
+    {{ block.super }}
+    {{ form.media.css }}
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/pages/create.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/create.html
@@ -70,10 +70,22 @@
 {% block extra_css %}
     {{ block.super }}
     {% include "wagtailadmin/pages/_editor_css.html" %}
+    {{ edit_handler.form.media.css }}
 {% endblock %}
+
 {% block extra_js %}
     {{ block.super }}
     {% include "wagtailadmin/pages/_editor_js.html" %}
+
+    {% comment %}
+        Additional js from widgets media. Allows for custom widgets in admin panel.
+    {% endcomment %}
+    {{ edit_handler.form.media.js }}
+
+    {% comment %}
+        Additional HTML code that edit handlers define through 'html_declarations'. (Technically this isn't Javascript, but it will generally be data that exists for Javascript to work with...)
+    {% endcomment %}
+    {{ edit_handler.html_declarations }}
 
     <script>
         $(function(){

--- a/wagtail/admin/templates/wagtailadmin/pages/edit.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/edit.html
@@ -105,10 +105,22 @@
 {% block extra_css %}
     {{ block.super }}
     {% include "wagtailadmin/pages/_editor_css.html" %}
+    {{ edit_handler.form.media.css }}
 {% endblock %}
+
 {% block extra_js %}
     {{ block.super }}
     {% include "wagtailadmin/pages/_editor_js.html" %}
+
+    {% comment %}
+        Additional js from widgets media. Allows for custom widgets in admin panel.
+    {% endcomment %}
+    {{ edit_handler.form.media.js }}
+
+    {% comment %}
+        Additional HTML code that edit handlers define through 'html_declarations'. (Technically this isn't Javascript, but it will generally be data that exists for Javascript to work with...)
+    {% endcomment %}
+    {{ edit_handler.html_declarations }}
 
     <script>
         $(function() {

--- a/wagtail/admin/widgets.py
+++ b/wagtail/admin/widgets.py
@@ -212,6 +212,9 @@ class AdminPageChooser(AdminChooser):
             user_perms=json.dumps(self.user_perms),
         )
 
+    class Media:
+        js = ['wagtailadmin/js/page-chooser.js']
+
 
 @total_ordering
 class Button:

--- a/wagtail/contrib/modeladmin/templates/modeladmin/choose_parent.html
+++ b/wagtail/contrib/modeladmin/templates/modeladmin/choose_parent.html
@@ -5,12 +5,14 @@
 
 {% block extra_css %}
     {% include "wagtailadmin/pages/_editor_css.html" %}
+    {{ form.media.css }}
     <link rel="stylesheet" href="{% static 'wagtailmodeladmin/css/choose_parent_page.css' %}" type="text/css"/>
     <link rel="stylesheet" href="{% static 'wagtailmodeladmin/css/breadcrumbs_page.css' %}" type="text/css"/>
 {% endblock %}
 
 {% block extra_js %}
     {% include "wagtailadmin/pages/_editor_js.html" %}
+    {{ form.media.js }}
 {% endblock %}
 
 

--- a/wagtail/contrib/modeladmin/templates/modeladmin/create.html
+++ b/wagtail/contrib/modeladmin/templates/modeladmin/create.html
@@ -5,11 +5,16 @@
 
 {% block extra_css %}
     {% include "wagtailadmin/pages/_editor_css.html" %}
+    {{ edit_handler.form.media.css }}
+
     {{ view.media.css }}
 {% endblock %}
 
 {% block extra_js %}
     {% include "wagtailadmin/pages/_editor_js.html" %}
+    {{ edit_handler.form.media.js }}
+    {{ edit_handler.html_declarations }}
+
     {{ view.media.js }}
 {% endblock %}
 

--- a/wagtail/contrib/redirects/templates/wagtailredirects/add.html
+++ b/wagtail/contrib/redirects/templates/wagtailredirects/add.html
@@ -34,4 +34,10 @@
 {% block extra_js %}
     {{ block.super }}
     {% include "wagtailadmin/pages/_editor_js.html" %}
+    {{ form.media.js }}
+{% endblock %}
+
+{% block extra_css %}
+    {{ block.super }}
+    {{ form.media.css }}
 {% endblock %}

--- a/wagtail/contrib/redirects/templates/wagtailredirects/edit.html
+++ b/wagtail/contrib/redirects/templates/wagtailredirects/edit.html
@@ -37,4 +37,10 @@
 {% block extra_js %}
     {{ block.super }}
     {% include "wagtailadmin/pages/_editor_js.html" %}
+    {{ form.media.js }}
+{% endblock %}
+
+{% block extra_css %}
+    {{ block.super }}
+    {{ form.media.css }}
 {% endblock %}

--- a/wagtail/contrib/search_promotions/templates/wagtailsearchpromotions/add.html
+++ b/wagtail/contrib/search_promotions/templates/wagtailsearchpromotions/add.html
@@ -34,10 +34,12 @@
 {% block extra_css %}
     {{ block.super }}
     {% include "wagtailadmin/pages/_editor_css.html" %}
+    {{ form_media.css }}
 {% endblock %}
 {% block extra_js %}
     {{ block.super }}
     {% include "wagtailadmin/pages/_editor_js.html" %}
+    {{ form_media.js }}
 
     <script type="text/javascript">
         {% include "wagtailsearchpromotions/includes/searchpromotions_formset.js" with formset=searchpicks_formset only %}

--- a/wagtail/contrib/search_promotions/templates/wagtailsearchpromotions/edit.html
+++ b/wagtail/contrib/search_promotions/templates/wagtailsearchpromotions/edit.html
@@ -26,10 +26,12 @@
 {% block extra_css %}
     {{ block.super }}
     {% include "wagtailadmin/pages/_editor_css.html" %}
+    {{ form_media.css }}
 {% endblock %}
 {% block extra_js %}
     {{ block.super }}
     {% include "wagtailadmin/pages/_editor_js.html" %}
+    {{ form_media.js }}
 
     <script type="text/javascript">
         {% include "wagtailsearchpromotions/includes/searchpromotions_formset.js" with formset=searchpicks_formset only  %}

--- a/wagtail/contrib/search_promotions/views.py
+++ b/wagtail/contrib/search_promotions/views.py
@@ -100,6 +100,7 @@ def add(request):
     return render(request, 'wagtailsearchpromotions/add.html', {
         'query_form': query_form,
         'searchpicks_formset': searchpicks_formset,
+        'form_media': query_form.media + searchpicks_formset.media,
     })
 
 
@@ -138,6 +139,7 @@ def edit(request, query_id):
         'query_form': query_form,
         'searchpicks_formset': searchpicks_formset,
         'query': query,
+        'form_media': query_form.media + searchpicks_formset.media,
     })
 
 

--- a/wagtail/contrib/settings/templates/wagtailsettings/edit.html
+++ b/wagtail/contrib/settings/templates/wagtailsettings/edit.html
@@ -43,9 +43,12 @@
 
 {% block extra_css %}
     {% include "wagtailadmin/pages/_editor_css.html" %}
+    {{ edit_handler.form.media.css }}
     {{ site_switcher.media.css }}
 {% endblock %}
 {% block extra_js %}
     {% include "wagtailadmin/pages/_editor_js.html" %}
+    {{ edit_handler.form.media.js }}
+    {{ edit_handler.html_declarations }}
     {{ site_switcher.media.js }}
 {% endblock %}

--- a/wagtail/documents/wagtail_hooks.py
+++ b/wagtail/documents/wagtail_hooks.py
@@ -1,9 +1,8 @@
 from django.conf import settings
 from django.conf.urls import include, url
-from django.contrib.staticfiles.templatetags.staticfiles import static
 from django.template.response import TemplateResponse
 from django.urls import reverse
-from django.utils.html import format_html, format_html_join
+from django.utils.html import format_html
 from django.utils.translation import ugettext_lazy as _
 from django.utils.translation import ugettext, ungettext
 
@@ -57,14 +56,7 @@ def register_documents_menu_item():
 
 @hooks.register('insert_editor_js')
 def editor_js():
-    js_files = [
-        static('wagtaildocs/js/document-chooser.js'),
-    ]
-    js_includes = format_html_join(
-        '\n', '<script src="{0}"></script>',
-        ((filename, ) for filename in js_files)
-    )
-    return js_includes + format_html(
+    return format_html(
         """
         <script>
             window.chooserUrls.documentChooser = '{0}';

--- a/wagtail/documents/widgets.py
+++ b/wagtail/documents/widgets.py
@@ -30,3 +30,6 @@ class AdminDocumentChooser(AdminChooser):
 
     def render_js_init(self, id_, name, value):
         return "createDocumentChooser({0});".format(json.dumps(id_))
+
+    class Media:
+        js = ['wagtaildocs/js/document-chooser.js']

--- a/wagtail/images/wagtail_hooks.py
+++ b/wagtail/images/wagtail_hooks.py
@@ -1,7 +1,6 @@
 from django.conf.urls import include, url
-from django.contrib.staticfiles.templatetags.staticfiles import static
 from django.urls import reverse
-from django.utils.html import format_html, format_html_join
+from django.utils.html import format_html
 from django.utils.translation import ugettext_lazy as _
 from django.utils.translation import ugettext, ungettext
 
@@ -48,14 +47,7 @@ def register_images_menu_item():
 
 @hooks.register('insert_editor_js')
 def editor_js():
-    js_files = [
-        static('wagtailimages/js/image-chooser.js'),
-    ]
-    js_includes = format_html_join(
-        '\n', '<script src="{0}"></script>',
-        ((filename, ) for filename in js_files)
-    )
-    return js_includes + format_html(
+    return format_html(
         """
         <script>
             window.chooserUrls.imageChooser = '{0}';

--- a/wagtail/images/widgets.py
+++ b/wagtail/images/widgets.py
@@ -30,3 +30,6 @@ class AdminImageChooser(AdminChooser):
 
     def render_js_init(self, id_, name, value):
         return "createImageChooser({0});".format(json.dumps(id_))
+
+    class Media:
+        js = ['wagtailimages/js/image-chooser.js']

--- a/wagtail/snippets/templates/wagtailsnippets/snippets/create.html
+++ b/wagtail/snippets/templates/wagtailsnippets/snippets/create.html
@@ -27,8 +27,11 @@
 {% block extra_css %}
     {{ block.super }}
     {% include "wagtailadmin/pages/_editor_css.html" %}
+    {{ edit_handler.form.media.css }}
 {% endblock %}
 {% block extra_js %}
     {{ block.super }}
     {% include "wagtailadmin/pages/_editor_js.html" %}
+    {{ edit_handler.form.media.js }}
+    {{ edit_handler.html_declarations }}
 {% endblock %}

--- a/wagtail/snippets/templates/wagtailsnippets/snippets/edit.html
+++ b/wagtail/snippets/templates/wagtailsnippets/snippets/edit.html
@@ -52,8 +52,11 @@
 {% block extra_css %}
     {{ block.super }}
     {% include "wagtailadmin/pages/_editor_css.html" %}
+    {{ edit_handler.form.media.css }}
 {% endblock %}
 {% block extra_js %}
     {{ block.super }}
     {% include "wagtailadmin/pages/_editor_js.html" %}
+    {{ edit_handler.form.media.js }}
+    {{ edit_handler.html_declarations }}
 {% endblock %}

--- a/wagtail/snippets/wagtail_hooks.py
+++ b/wagtail/snippets/wagtail_hooks.py
@@ -1,7 +1,6 @@
 from django.conf.urls import include, url
 from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
-from django.contrib.staticfiles.templatetags.staticfiles import static
 from django.urls import reverse
 from django.utils.html import format_html
 from django.utils.translation import ugettext_lazy as _
@@ -39,10 +38,8 @@ def register_snippets_menu_item():
 def editor_js():
     return format_html(
         """
-            <script src="{0}"></script>
-            <script>window.chooserUrls.snippetChooser = '{1}';</script>
+            <script>window.chooserUrls.snippetChooser = '{0}';</script>
         """,
-        static('wagtailsnippets/js/snippet-chooser.js'),
         reverse('wagtailsnippets:choose_generic')
     )
 

--- a/wagtail/snippets/widgets.py
+++ b/wagtail/snippets/widgets.py
@@ -39,3 +39,6 @@ class AdminSnippetChooser(AdminChooser):
             model=json.dumps('{app}/{model}'.format(
                 app=model._meta.app_label,
                 model=model._meta.model_name)))
+
+    class Media:
+        js = ['wagtailsnippets/js/snippet-chooser.js']

--- a/wagtail/users/templates/wagtailusers/groups/create.html
+++ b/wagtail/users/templates/wagtailusers/groups/create.html
@@ -7,6 +7,7 @@
     {{ block.super }}
 
     <link rel="stylesheet" href="{% static 'wagtailusers/css/groups_edit.css' %}" type="text/css" />
+    {{ form_media.css }}
 {% endblock %}
 
 {% block content %}

--- a/wagtail/users/templates/wagtailusers/groups/edit.html
+++ b/wagtail/users/templates/wagtailusers/groups/edit.html
@@ -7,6 +7,7 @@
     {{ block.super }}
 
     <link rel="stylesheet" href="{% static 'wagtailusers/css/groups_edit.css' %}" type="text/css" />
+    {{ form_media.css }}
 {% endblock %}
 
 {% block content %}

--- a/wagtail/users/templates/wagtailusers/groups/includes/group_form_js.html
+++ b/wagtail/users/templates/wagtailusers/groups/includes/group_form_js.html
@@ -9,3 +9,5 @@
 <script src="{% static 'wagtailadmin/js/expanding_formset.js' %}"></script>
 <script src="{% static 'wagtailadmin/js/modal-workflow.js' %}"></script>
 <script src="{% static 'wagtailusers/js/group-form.js' %}"></script>
+
+{{ form_media.js }}

--- a/wagtail/users/templates/wagtailusers/groups/includes/group_form_js.html
+++ b/wagtail/users/templates/wagtailusers/groups/includes/group_form_js.html
@@ -5,7 +5,6 @@
     };
 </script>
 
-<script src="{% static 'wagtailadmin/js/page-chooser.js' %}"></script>
 <script src="{% static 'wagtailadmin/js/expanding_formset.js' %}"></script>
 <script src="{% static 'wagtailadmin/js/modal-workflow.js' %}"></script>
 <script src="{% static 'wagtailusers/js/group-form.js' %}"></script>

--- a/wagtail/users/views/groups.py
+++ b/wagtail/users/views/groups.py
@@ -89,6 +89,17 @@ class CreateView(PermissionPanelFormsMixin, generic.CreateView):
         else:
             return self.form_invalid(form)
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+
+        # add a 'form_media' variable for the collected js/css media from the form and all formsets
+        form_media = context['form'].media
+        for panel in context['permission_panels']:
+            form_media += panel.media
+        context['form_media'] = form_media
+
+        return context
+
 
 class EditView(PermissionPanelFormsMixin, generic.EditView):
     success_message = _("Group '{0}' updated.")
@@ -115,6 +126,17 @@ class EditView(PermissionPanelFormsMixin, generic.EditView):
             return response
         else:
             return self.form_invalid(form)
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+
+        # add a 'form_media' variable for the collected js/css media from the form and all formsets
+        form_media = context['form'].media
+        for panel in context['permission_panels']:
+            form_media += panel.media
+        context['form_media'] = form_media
+
+        return context
 
 
 class DeleteView(generic.DeleteView):


### PR DESCRIPTION
Yet another step towards eliminating eval() from modal-workflow (#4335), as well as reducing dependence on _editor_js.html on non-editor views (#2936).

Currently, if you want to use chooser widgets such as `AdminPageChooser` on a form, you need to import the relevant JS include for that chooser (`page-chooser.js`, `image-chooser.js` etc), which usually entails "include `_editor_js.html` and hope for the best". With this change in place, the rule becomes "just make sure you're including [form media](https://docs.djangoproject.com/en/2.0/topics/forms/media/) on the template".

(Well, nearly. You still need to include modal-workflow.js and the code snippet that populates `window.chooserUrls` - but it's a step in the right direction...)

This also means that wagtaildocs, wagtailimages etc don't have to do as much work in the `insert_editor_js` hook.

The plan is that by having a standard consistent way to import the JS for these widgets, they won't break when we add a new JS dependency (namely, the chooser modal code that currently gets served up within AJAX responses).