### PR TITLE
[WIP] Implement RFC27: search autocomplete API for Elasticsearch

### DIFF
--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -329,6 +329,7 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
 
     search_fields = [
         index.SearchField('title', partial_match=True, boost=2),
+        index.AutocompleteField('title'),
         index.FilterField('title'),
         index.FilterField('id'),
         index.FilterField('live'),

--- a/wagtail/documents/models.py
+++ b/wagtail/documents/models.py
@@ -37,9 +37,11 @@ class AbstractDocument(CollectionMember, index.Indexed, models.Model):
 
     search_fields = CollectionMember.search_fields + [
         index.SearchField('title', partial_match=True, boost=10),
+        index.AutocompleteField('title'),
         index.FilterField('title'),
         index.RelatedFields('tags', [
             index.SearchField('name', partial_match=True, boost=10),
+            index.AutocompleteField('name'),
         ]),
         index.FilterField('uploaded_by_user'),
     ]

--- a/wagtail/images/models.py
+++ b/wagtail/images/models.py
@@ -139,9 +139,11 @@ class AbstractImage(CollectionMember, index.Indexed, models.Model):
 
     search_fields = CollectionMember.search_fields + [
         index.SearchField('title', partial_match=True, boost=10),
+        index.AutocompleteField('title'),
         index.FilterField('title'),
         index.RelatedFields('tags', [
             index.SearchField('name', partial_match=True, boost=10),
+            index.AutocompleteField('name'),
         ]),
         index.FilterField('uploaded_by_user'),
     ]

--- a/wagtail/search/backends/elasticsearch2.py
+++ b/wagtail/search/backends/elasticsearch2.py
@@ -12,7 +12,7 @@ from elasticsearch.helpers import bulk
 
 from wagtail.search.backends.base import (
     BaseSearchBackend, BaseSearchQueryCompiler, BaseSearchResults)
-from wagtail.search.index import FilterField, Indexed, RelatedFields, SearchField, class_is_indexed
+from wagtail.search.index import AutocompleteField, FilterField, Indexed, RelatedFields, SearchField, class_is_indexed
 from wagtail.search.query import (
     And, Boost, Filter, Fuzzy, MatchAll, Not, Or, PlainText, Prefix, Term)
 from wagtail.utils.deprecation import RemovedInWagtail22Warning
@@ -110,6 +110,8 @@ class Elasticsearch2Mapping:
 
         if isinstance(field, FilterField):
             return prefix + field.get_attname(self.model) + '_filter'
+        elif isinstance(field, AutocompleteField):
+            return prefix + field.get_attname(self.model) + '_edgengrams'
         elif isinstance(field, SearchField):
             return prefix + field.get_attname(self.model)
         elif isinstance(field, RelatedFields):
@@ -170,6 +172,11 @@ class Elasticsearch2Mapping:
 
                 mapping['include_in_all'] = True
 
+            if isinstance(field, AutocompleteField):
+                mapping['type'] = self.text_type
+                mapping['include_in_all'] = False
+                mapping.update(self.edgengram_analyzer_config)
+
             elif isinstance(field, FilterField):
                 if mapping['type'] == 'string':
                     mapping['type'] = self.keyword_type
@@ -217,7 +224,7 @@ class Elasticsearch2Mapping:
 
     def _get_nested_document(self, fields, obj):
         doc = {}
-        partials = []
+        edgengrams = []
         model = type(obj)
         mapping = type(self)(model)
 
@@ -226,15 +233,15 @@ class Elasticsearch2Mapping:
             doc[mapping.get_field_column_name(field)] = value
 
             # Check if this field should be added into _edgengrams
-            if isinstance(field, SearchField) and field.partial_match:
-                partials.append(value)
+            if (isinstance(field, SearchField) and field.partial_match) or isinstance(field, AutocompleteField):
+                edgengrams.append(value)
 
-        return doc, partials
+        return doc, edgengrams
 
     def get_document(self, obj):
         # Build document
         doc = dict(pk=str(obj.pk), content_type=self.get_all_content_types())
-        partials = []
+        edgengrams = []
         for field in self.model.get_search_fields():
             value = field.get_value(obj)
 
@@ -245,21 +252,21 @@ class Elasticsearch2Mapping:
                     for nested_obj in value.all():
                         nested_doc, extra_edgengrams = self._get_nested_document(field.fields, nested_obj)
                         nested_docs.append(nested_doc)
-                        partials.extend(extra_edgengrams)
+                        edgengrams.extend(extra_edgengrams)
 
                     value = nested_docs
                 elif isinstance(value, models.Model):
                     value, extra_edgengrams = self._get_nested_document(field.fields, value)
-                    partials.extend(extra_edgengrams)
+                    edgengrams.extend(extra_edgengrams)
 
             doc[self.get_field_column_name(field)] = value
 
             # Check if this field should be added into _edgengrams
-            if isinstance(field, SearchField) and field.partial_match:
-                partials.append(value)
+            if (isinstance(field, SearchField) and field.partial_match) or isinstance(field, AutocompleteField):
+                edgengrams.append(value)
 
         # Add partials to document
-        doc[self.edgengrams_field_name] = partials
+        doc[self.edgengrams_field_name] = edgengrams
 
         return doc
 

--- a/wagtail/search/backends/elasticsearch2.py
+++ b/wagtail/search/backends/elasticsearch2.py
@@ -605,6 +605,42 @@ class Elasticsearch2SearchQueryCompiler(BaseSearchQueryCompiler):
     def __repr__(self):
         return json.dumps(self.get_query())
 
+class ElasticsearchAutocompleteQueryCompilerImpl:
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # Convert field names into index column names
+        # Note: this overrides Elasticsearch2SearchQueryCompiler by using autocomplete fields instead of searchbale fields
+        if self.fields:
+            fields = []
+            autocomplete_fields = {f.field_name: f for f in self.queryset.model.get_autocomplete_search_fields()}
+            for field_name in self.fields:
+                if field_name in autocomplete_fields:
+                    field_name = self.mapping.get_field_column_name(autocomplete_fields[field_name])
+
+                fields.append(field_name)
+
+            self.remapped_fields = fields
+        else:
+            self.remapped_fields = None
+
+    def get_inner_query(self):
+        fields = self.remapped_fields or [self.mapping.edgengrams_field_name]
+
+        if len(fields) == 0:
+            # No fields. Return a query that'll match nothing
+            return {
+                'bool': {
+                    'mustNot': {'match_all': {}}
+                }
+            }
+
+        return self._compile_plaintext_query(self.query, fields)
+
+
+class Elasticsearch2AutocompleteQueryCompiler(Elasticsearch2SearchQueryCompiler, ElasticsearchAutocompleteQueryCompilerImpl):
+    pass
+
 
 class Elasticsearch2SearchResults(BaseSearchResults):
     fields_param_name = 'fields'
@@ -934,6 +970,7 @@ class ElasticsearchAtomicIndexRebuilder(ElasticsearchIndexRebuilder):
 class Elasticsearch2SearchBackend(BaseSearchBackend):
     index_class = Elasticsearch2Index
     query_compiler_class = Elasticsearch2SearchQueryCompiler
+    autocomplete_query_compiler_class = Elasticsearch2AutocompleteQueryCompiler
     results_class = Elasticsearch2SearchResults
     mapping_class = Elasticsearch2Mapping
     basic_rebuilder_class = ElasticsearchIndexRebuilder

--- a/wagtail/search/backends/elasticsearch5.py
+++ b/wagtail/search/backends/elasticsearch5.py
@@ -1,6 +1,6 @@
 from .elasticsearch2 import (
     Elasticsearch2Index, Elasticsearch2Mapping, Elasticsearch2SearchBackend,
-    Elasticsearch2SearchQueryCompiler, Elasticsearch2SearchResults)
+    Elasticsearch2SearchQueryCompiler, Elasticsearch2SearchResults, ElasticsearchAutocompleteQueryCompilerImpl)
 
 
 class Elasticsearch5Mapping(Elasticsearch2Mapping):
@@ -89,6 +89,10 @@ class Elasticsearch5SearchQueryCompiler(Elasticsearch2SearchQueryCompiler):
             return inner_query
 
 
+class Elasticsearch5AutocompleteQueryCompiler(Elasticsearch5SearchQueryCompiler, ElasticsearchAutocompleteQueryCompilerImpl):
+    pass
+
+
 class Elasticsearch5SearchResults(Elasticsearch2SearchResults):
     fields_param_name = 'stored_fields'
 
@@ -97,6 +101,7 @@ class Elasticsearch5SearchBackend(Elasticsearch2SearchBackend):
     mapping_class = Elasticsearch5Mapping
     index_class = Elasticsearch5Index
     query_compiler_class = Elasticsearch5SearchQueryCompiler
+    autocomplete_query_compiler_class = Elasticsearch5AutocompleteQueryCompiler
     results_class = Elasticsearch5SearchResults
 
 

--- a/wagtail/search/backends/elasticsearch6.py
+++ b/wagtail/search/backends/elasticsearch6.py
@@ -1,3 +1,4 @@
+from .elasticsearch2 import ElasticsearchAutocompleteQueryCompilerImpl
 from .elasticsearch5 import (
     Elasticsearch5Index, Elasticsearch5Mapping, Elasticsearch5SearchBackend,
     Elasticsearch5SearchQueryCompiler, Elasticsearch5SearchResults)
@@ -47,11 +48,15 @@ class Elasticsearch6SearchQueryCompiler(Elasticsearch5SearchQueryCompiler):
 class Elasticsearch6SearchResults(Elasticsearch5SearchResults):
     pass
 
+class Elasticsearch6AutocompleteQueryCompiler(Elasticsearch5SearchQueryCompiler, ElasticsearchAutocompleteQueryCompilerImpl):
+    pass
+
 
 class Elasticsearch6SearchBackend(Elasticsearch5SearchBackend):
     mapping_class = Elasticsearch6Mapping
     index_class = Elasticsearch6Index
     query_compiler_class = Elasticsearch6SearchQueryCompiler
+    autocomplete_query_compiler_class = Elasticsearch6AutocompleteQueryCompiler
     results_class = Elasticsearch6SearchResults
 
 

--- a/wagtail/search/index.py
+++ b/wagtail/search/index.py
@@ -61,6 +61,13 @@ class Indexed:
         ]
 
     @classmethod
+    def get_autocomplete_search_fields(cls):
+        return [
+            field for field in cls.get_search_fields()
+            if isinstance(field, AutocompleteField)
+        ]
+
+    @classmethod
     def get_filterable_search_fields(cls):
         return [
             field for field in cls.get_search_fields()

--- a/wagtail/search/index.py
+++ b/wagtail/search/index.py
@@ -222,6 +222,10 @@ class SearchField(BaseField):
         self.partial_match = partial_match
 
 
+class AutocompleteField(BaseField):
+    pass
+
+
 class FilterField(BaseField):
     pass
 

--- a/wagtail/search/queryset.py
+++ b/wagtail/search/queryset.py
@@ -10,3 +10,12 @@ class SearchableQuerySetMixin:
         search_backend = get_search_backend(backend)
         return search_backend.search(query, self, fields=fields,
                                      operator=operator, order_by_relevance=order_by_relevance)
+
+    def autocomplete(self, query, fields=None,
+               operator=None, order_by_relevance=True, backend='default'):
+        """
+        This runs an autocomplete query on all the items in the QuerySet
+        """
+        search_backend = get_search_backend(backend)
+        return search_backend.autocomplete(query, self, fields=fields,
+                                     operator=operator, order_by_relevance=order_by_relevance)

--- a/wagtail/search/tests/test_elasticsearch2_backend.py
+++ b/wagtail/search/tests/test_elasticsearch2_backend.py
@@ -522,6 +522,7 @@ class TestElasticsearch2Mapping(TestCase):
                     'content_type': {'index': 'not_analyzed', 'type': 'string', 'include_in_all': False},
                     '_partials': {'analyzer': 'edgengram_analyzer', 'search_analyzer': 'standard', 'include_in_all': False, 'type': 'string'},
                     'title': {'type': 'string', 'boost': 2.0, 'include_in_all': True, 'analyzer': 'edgengram_analyzer', 'search_analyzer': 'standard'},
+                    'title_edgengrams': {'type': 'string', 'include_in_all': False, 'analyzer': 'edgengram_analyzer', 'search_analyzer': 'standard'},
                     'title_filter': {'index': 'not_analyzed', 'type': 'string', 'include_in_all': False},
                     'authors': {
                         'type': 'nested',
@@ -560,8 +561,9 @@ class TestElasticsearch2Mapping(TestCase):
         expected_result = {
             'pk': '4',
             'content_type': ["searchtests.Book"],
-            '_partials': ['The Fellowship of the Ring'],
+            '_partials': ['The Fellowship of the Ring', 'The Fellowship of the Ring'],
             'title': 'The Fellowship of the Ring',
+            'title_edgengrams': 'The Fellowship of the Ring',
             'title_filter': 'The Fellowship of the Ring',
             'authors': [
                 {
@@ -623,6 +625,7 @@ class TestElasticsearch2MappingInheritance(TestCase):
                     'content_type': {'index': 'not_analyzed', 'type': 'string', 'include_in_all': False},
                     '_partials': {'analyzer': 'edgengram_analyzer', 'search_analyzer': 'standard', 'include_in_all': False, 'type': 'string'},
                     'title': {'type': 'string', 'boost': 2.0, 'include_in_all': True, 'analyzer': 'edgengram_analyzer', 'search_analyzer': 'standard'},
+                    'title_edgengrams': {'type': 'string', 'include_in_all': False, 'analyzer': 'edgengram_analyzer', 'search_analyzer': 'standard'},
                     'title_filter': {'index': 'not_analyzed', 'type': 'string', 'include_in_all': False},
                     'authors': {
                         'type': 'nested',
@@ -685,11 +688,12 @@ class TestElasticsearch2MappingInheritance(TestCase):
 
             # Changed
             'content_type': ["searchtests.Novel", "searchtests.Book"],
-            '_partials': ['Middle Earth', 'The Fellowship of the Ring'],
+            '_partials': ['Middle Earth', 'The Fellowship of the Ring', 'The Fellowship of the Ring'],
 
             # Inherited
             'pk': '4',
             'title': 'The Fellowship of the Ring',
+            'title_edgengrams': 'The Fellowship of the Ring',
             'title_filter': 'The Fellowship of the Ring',
             'authors': [
                 {

--- a/wagtail/search/tests/test_elasticsearch5_backend.py
+++ b/wagtail/search/tests/test_elasticsearch5_backend.py
@@ -523,6 +523,7 @@ class TestElasticsearch5Mapping(TestCase):
                     'content_type': {'type': 'keyword', 'include_in_all': False},
                     '_partials': {'analyzer': 'edgengram_analyzer', 'search_analyzer': 'standard', 'include_in_all': False, 'type': 'text'},
                     'title': {'type': 'text', 'boost': 2.0, 'include_in_all': True, 'analyzer': 'edgengram_analyzer', 'search_analyzer': 'standard'},
+                    'title_edgengrams': {'type': 'text', 'include_in_all': False, 'analyzer': 'edgengram_analyzer', 'search_analyzer': 'standard'},
                     'title_filter': {'type': 'keyword', 'include_in_all': False},
                     'authors': {
                         'type': 'nested',
@@ -561,8 +562,9 @@ class TestElasticsearch5Mapping(TestCase):
         expected_result = {
             'pk': '4',
             'content_type': ["searchtests.Book"],
-            '_partials': ['The Fellowship of the Ring'],
+            '_partials': ['The Fellowship of the Ring', 'The Fellowship of the Ring'],
             'title': 'The Fellowship of the Ring',
+            'title_edgengrams': 'The Fellowship of the Ring',
             'title_filter': 'The Fellowship of the Ring',
             'authors': [
                 {
@@ -624,6 +626,7 @@ class TestElasticsearch5MappingInheritance(TestCase):
                     'content_type': {'type': 'keyword', 'include_in_all': False},
                     '_partials': {'analyzer': 'edgengram_analyzer', 'search_analyzer': 'standard', 'include_in_all': False, 'type': 'text'},
                     'title': {'type': 'text', 'boost': 2.0, 'include_in_all': True, 'analyzer': 'edgengram_analyzer', 'search_analyzer': 'standard'},
+                    'title_edgengrams': {'type': 'text', 'include_in_all': False, 'analyzer': 'edgengram_analyzer', 'search_analyzer': 'standard'},
                     'title_filter': {'type': 'keyword', 'include_in_all': False},
                     'authors': {
                         'type': 'nested',
@@ -686,11 +689,12 @@ class TestElasticsearch5MappingInheritance(TestCase):
 
             # Changed
             'content_type': ["searchtests.Novel", "searchtests.Book"],
-            '_partials': ['Middle Earth', 'The Fellowship of the Ring'],
+            '_partials': ['Middle Earth', 'The Fellowship of the Ring', 'The Fellowship of the Ring'],
 
             # Inherited
             'pk': '4',
             'title': 'The Fellowship of the Ring',
+            'title_edgengrams': 'The Fellowship of the Ring',
             'title_filter': 'The Fellowship of the Ring',
             'authors': [
                 {

--- a/wagtail/search/tests/test_elasticsearch6_backend.py
+++ b/wagtail/search/tests/test_elasticsearch6_backend.py
@@ -524,6 +524,7 @@ class TestElasticsearch6Mapping(TestCase):
                     '_all_text': {'type': 'text'},
                     '_edgengrams': {'analyzer': 'edgengram_analyzer', 'search_analyzer': 'standard', 'type': 'text'},
                     'title': {'type': 'text', 'boost': 2.0, 'copy_to': '_all_text', 'analyzer': 'edgengram_analyzer', 'search_analyzer': 'standard'},
+                    'title_edgengrams': {'type': 'text', 'analyzer': 'edgengram_analyzer', 'search_analyzer': 'standard'},
                     'title_filter': {'type': 'keyword'},
                     'authors': {
                         'type': 'nested',
@@ -562,8 +563,9 @@ class TestElasticsearch6Mapping(TestCase):
         expected_result = {
             'pk': '4',
             'content_type': ["searchtests.Book"],
-            '_edgengrams': ['The Fellowship of the Ring'],
+            '_edgengrams': ['The Fellowship of the Ring', 'The Fellowship of the Ring'],
             'title': 'The Fellowship of the Ring',
+            'title_edgengrams': 'The Fellowship of the Ring',
             'title_filter': 'The Fellowship of the Ring',
             'authors': [
                 {
@@ -626,6 +628,7 @@ class TestElasticsearch6MappingInheritance(TestCase):
                     '_all_text': {'type': 'text'},
                     '_edgengrams': {'analyzer': 'edgengram_analyzer', 'search_analyzer': 'standard', 'type': 'text'},
                     'title': {'type': 'text', 'boost': 2.0, 'copy_to': '_all_text', 'analyzer': 'edgengram_analyzer', 'search_analyzer': 'standard'},
+                    'title_edgengrams': {'type': 'text', 'analyzer': 'edgengram_analyzer', 'search_analyzer': 'standard'},
                     'title_filter': {'type': 'keyword'},
                     'authors': {
                         'type': 'nested',
@@ -688,11 +691,12 @@ class TestElasticsearch6MappingInheritance(TestCase):
 
             # Changed
             'content_type': ["searchtests.Novel", "searchtests.Book"],
-            '_edgengrams': ['Middle Earth', 'The Fellowship of the Ring'],
+            '_edgengrams': ['Middle Earth', 'The Fellowship of the Ring', 'The Fellowship of the Ring'],
 
             # Inherited
             'pk': '4',
             'title': 'The Fellowship of the Ring',
+            'title_edgengrams': 'The Fellowship of the Ring',
             'title_filter': 'The Fellowship of the Ring',
             'authors': [
                 {

--- a/wagtail/tests/search/models.py
+++ b/wagtail/tests/search/models.py
@@ -26,6 +26,7 @@ class Book(index.Indexed, models.Model):
 
     search_fields = [
         index.SearchField('title', partial_match=True, boost=2.0),
+        index.AutocompleteField('title'),
         index.FilterField('title'),
         index.RelatedFields('authors', Author.search_fields),
         index.FilterField('publication_date'),


### PR DESCRIPTION
This PR makes a start on the new autocomplete API specified in [RFC 27](https://github.com/wagtail/rfcs/pull/27).

TODO:
 - [ ] ``partial_match`` argument on ``.search()``
 - [ ] Tests