### PR TITLE
Fix copy-paste between editors losing formatting/content #4432

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2619,23 +2619,23 @@
       }
     },
     "draftail": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/draftail/-/draftail-0.17.1.tgz",
-      "integrity": "sha512-Yjs38vfGc+0jaT8Oe9HyRyWS/L/uJEnsW0A4IO5qD1XExbc3uVHSfEa+/ozsFC1vHTFKGDX5ixSkKPxCNTmp7A==",
+      "version": "0.17.2",
+      "resolved": "https://registry.npmjs.org/draftail/-/draftail-0.17.2.tgz",
+      "integrity": "sha512-SPmd9k9cMH/4UmXK6F7uRx1sCtebcO2qFXjXA1R6BaR9gpCqfcKefxVZbgJ9RELpZ28xvNtTEjdtJqzUI1UPaw==",
       "requires": {
-        "draftjs-conductor": "0.1.0",
-        "draftjs-filters": "0.7.0"
+        "draftjs-conductor": "0.2.1",
+        "draftjs-filters": "1.0.0"
       }
     },
     "draftjs-conductor": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/draftjs-conductor/-/draftjs-conductor-0.1.0.tgz",
-      "integrity": "sha512-PwQsqxICL2ALBg2vdLnP5yzrZBMBTgISZP8EHyNAj2epDKML74pKq5dYEqEkvnta1/XXw4zR/wfhp1Cp4aLhIg=="
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/draftjs-conductor/-/draftjs-conductor-0.2.1.tgz",
+      "integrity": "sha512-oazG/8otKjTZ1OdAA0BDaYiRsi4tJd0UmNjtIFebaqWUryyr76JyA2j/trFejEHQuNnSHjjeci4s9Jn4sxXPEA=="
     },
     "draftjs-filters": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/draftjs-filters/-/draftjs-filters-0.7.0.tgz",
-      "integrity": "sha512-gNJB4bCPM7UNOzSkbVBj0OjxvNLlBeBmMsmfN6+UF311Ne7Yq76rXc1ibRIRWUSdOMWs+H8UZqYWmJW7mWsQ5g=="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/draftjs-filters/-/draftjs-filters-1.0.0.tgz",
+      "integrity": "sha512-OUXPZs/tYqge4BzPjA2+kiB0xcqxh4afPXq7c23YfRNrZM/tzRf8Ft2CXxOxR4j17xdBadD0qO0DXii0xFm6Rg=="
     },
     "duplexer": {
       "version": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
   "dependencies": {
     "core-js": "^2.5.3",
     "draft-js": "0.10.5",
-    "draftail": "^0.17.1",
+    "draftail": "^0.17.2",
     "element-closest": "^2.0.2",
     "focus-trap-react": "^3.1.0",
     "prop-types": "^15.6.0",


### PR DESCRIPTION
Fixes #4432. This pull request has been made possible by the backing of my [Patreon patrons](https://www.patreon.com/thibaud_colas).

The current copy-paste behavior is a mixture of the browser's default copy behavior, and the Draft.js paste processing.

With this Draftail update, we now override the defaults for both copy and paste between editors:

- Copy should fill the clipboard with the same markup as before, except with a serialised version of the Draft.js content included, and with less inline styles (can lead to some discrepancies in how word processors receive the pasted content)
- Paste should work the same in all scenarios, except when the content comes from a Draftail editor. There, it will insert the Draft.js content directly instead of its HTML representation.

![draftail-copy-paste-4432](https://user-images.githubusercontent.com/877585/40942274-5eca06e6-6856-11e8-9268-2bfacaafe58d.gif)


Tested in: 

- [x] Windows 10, IE11 (no support, default "plain text" behavior)
- [x] Windows 10, Edge 17
- [x] macOS 10.13, Firefox latest
- [x] macOS 10.13, Chrome latest
- [x] macOS 10.13, Safari latest
- [x] iOS 11.3 Safari
- [x] Android Chrome 7.1

---

This fixes quite a few of the known issues with Draft.js (#4274), see the potential diff over at https://github.com/springload/draftail/issues/147#issuecomment-394202357. I'll update the list myself once this PR is merged.

The underlying code changes are:

- https://github.com/thibaudcolas/draftjs-conductor/pull/2 (new copy-paste processing)
- https://github.com/thibaudcolas/draftjs-conductor/pull/3 (bug fix)
- https://github.com/springload/draftail/pull/155 (integration into the editor)