### PR TITLE
Add an option to disable comma on tag input (#2056)

### DIFF
--- a/wagtail/admin/static_src/wagtailadmin/js/core.js
+++ b/wagtail/admin/static_src/wagtailadmin/js/core.js
@@ -21,7 +21,7 @@ function escapeHtml(text) {
     });
 }
 
-function initTagField(id, autocompleteUrl, allowSpaces) {
+function initTagField(id, autocompleteUrl, allowSpaces, disableComma) {
     $('#' + id).tagit({
         autocomplete: {source: autocompleteUrl},
         preprocessTag: function(val) {
@@ -34,7 +34,8 @@ function initTagField(id, autocompleteUrl, allowSpaces) {
             return val;
         },
 
-        allowSpaces: allowSpaces
+        allowSpaces: allowSpaces,
+        disableComma: disableComma
     });
 }
 

--- a/wagtail/admin/static_src/wagtailadmin/js/vendor/tag-it.js
+++ b/wagtail/admin/static_src/wagtailadmin/js/vendor/tag-it.js
@@ -51,6 +51,9 @@
             // When enabled, quotes are unneccesary for inputting multi-word tags.
             allowSpaces: false,
 
+            // When enabled, commas are no longer treated as tag tokenizer
+            disableComma: false,
+
             // The below options are for using a single field instead of several
             // for our form values.
             //
@@ -241,7 +244,7 @@
                     // Tab will also create a tag, unless the tag input is empty,
                     // in which case it isn't caught.
                     if (
-                        event.which === $.ui.keyCode.COMMA ||
+                        (event.which === $.ui.keyCode.COMMA && that.options.disableComma === false) ||
                         event.which === $.ui.keyCode.ENTER ||
                         (
                             event.which == $.ui.keyCode.TAB &&

--- a/wagtail/admin/widgets.py
+++ b/wagtail/admin/widgets.py
@@ -83,10 +83,11 @@ class AdminDateTimeInput(WidgetWithScript, widgets.DateTimeInput):
 
 class AdminTagWidget(WidgetWithScript, TagWidget):
     def render_js_init(self, id_, name, value):
-        return "initTagField({0}, {1}, {2});".format(
+        return "initTagField({0}, {1}, {2}, {3});".format(
             json.dumps(id_),
             json.dumps(reverse('wagtailadmin_tag_autocomplete')),
             'true' if getattr(settings, 'TAG_SPACES_ALLOWED', True) else 'false',
+            'false' if not getattr(settings, 'TAG_DISABLE_COMMA', False) else 'true',
         )
 
 


### PR DESCRIPTION
Here's an option to disable COMMA when entering tags. It is mainly to be able to use the UI with Cyrillic layout, but as a side-effect allows for tags with commas in them.