### PR TITLE
Use Django defaults for admin cache

### DIFF
--- a/wagtail/admin/tests/tests.py
+++ b/wagtail/admin/tests/tests.py
@@ -57,10 +57,10 @@ class TestHome(TestCase, WagtailTestUtils):
         # This tests that wagtailadmins global cache settings have been applied correctly
         response = self.client.get(reverse('wagtailadmin_home'))
 
-        self.assertIn('private', response['Cache-Control'])
         self.assertIn('no-cache', response['Cache-Control'])
         self.assertIn('no-store', response['Cache-Control'])
         self.assertIn('max-age=0', response['Cache-Control'])
+        self.assertIn('must-revalidate', response['Cache-Control'])
 
     def test_nonascii_email(self):
         # Test that non-ASCII email addresses don't break the admin; previously these would

--- a/wagtail/admin/urls/__init__.py
+++ b/wagtail/admin/urls/__init__.py
@@ -1,7 +1,7 @@
 import functools
 
 from django.conf.urls import url, include
-from django.views.decorators.cache import cache_control
+from django.views.decorators.cache import never_cache
 from django.views.generic import TemplateView
 from django.http import Http404
 from django.views.defaults import page_not_found
@@ -112,5 +112,5 @@ urlpatterns = decorate_urlpatterns(urlpatterns, display_custom_404)
 # Decorate all views with cache settings to prevent caching
 urlpatterns = decorate_urlpatterns(
     urlpatterns,
-    cache_control(private=True, no_cache=True, no_store=True, max_age=0)
+    never_cache
 )


### PR DESCRIPTION
I've noticed that the Django admin has different cache headers to the Wagtail's one. I feel like we could reuse the same headers in Wagtail and leave setting the values up to Django.

In this PR I switched to using [never_cache](https://docs.djangoproject.com/en/2.1/topics/http/decorators/#django.views.decorators.cache.never_cache) decorator as Django seems to do for their admin - https://github.com/django/django/blob/ae26e0ad2c5ee2216d8eaaaac9d7c2c7644b6ebb/django/contrib/admin/sites.py#L225

After this change headers in the admin would be changed from:

```
private, no-cache, no-store, max-age=0
```

to:

```
max-age=0, no-cache, no-store, must-revalidate
```

This improves by having only one cachability directive rather than two - I think `no-cache` is what we want to set rather than use `private` and `no-cache` at the same time. Also `must-revalidate` is missing from the admin headers too which Django adds by default to `never_cache` header. I am not sure what the obvious benefit of that is.

## Other note

The `must-revalidate` seems to be already set on the Wagtail's /admin/login/ because it's inherited from the Django's login view - https://github.com/django/django/blob/ae26e0ad2c5ee2216d8eaaaac9d7c2c7644b6ebb/django/contrib/auth/views.py#L51. We probably don't even want to set that cache headers ourselves since Django takes care of it.