### PR TITLE
Remove duplicate border radius of avatars

### DIFF
--- a/wagtail/admin/static_src/wagtailadmin/scss/components/_formatters.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/components/_formatters.scss
@@ -10,7 +10,6 @@
     height: 50px;
 
     img {
-        border-radius: 100%;
         position: absolute;
         z-index: 2;
         top: 0;
@@ -28,10 +27,6 @@
 
     &.square {
         border-radius: 0;
-
-        img {
-            border-radius: 0;
-        }
 
         &:before {
             border-radius: 0;


### PR DESCRIPTION
Avatar images may look a bit wonky as the border radius is applied twice - to the `img`-tag as well as to the surrounding `span`.

Tested with the following:

* Safari 11.1.1
* Firefox 60.0.2
* Chrome 67.0.3396.87

**Before**:

![bildschirmfoto 2018-06-14 um 10 27 53](https://user-images.githubusercontent.com/1186959/41400918-b3b223f4-6fbe-11e8-8ae2-1064193e726f.png)

![bildschirmfoto 2018-06-14 um 10 35 36](https://user-images.githubusercontent.com/1186959/41400931-b97765e2-6fbe-11e8-99b6-f4f69f01acaa.png)

**After**:

![bildschirmfoto 2018-06-14 um 10 28 06](https://user-images.githubusercontent.com/1186959/41400941-c46e0f32-6fbe-11e8-8cad-cb7acaccf9d3.png)

![bildschirmfoto 2018-06-14 um 10 35 27](https://user-images.githubusercontent.com/1186959/41400951-cb91bfac-6fbe-11e8-8f1d-345e77318009.png)



