### PR TITLE
Make checkbox/radio alignment on Firefox consistent with Webkit

### DIFF
--- a/wagtail/admin/static_src/wagtailadmin/scss/components/_forms.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/components/_forms.scss
@@ -140,11 +140,10 @@ input[type=checkbox] {
 }
 
 input[type=radio] {
-    // stylelint-disable-next-line property-no-vendor-prefix
-    -webkit-appearance: radio;
+    height: 12px;
     width: auto;
     position: relative;
-    margin-right: 15px;
+    margin-right: 27px;
 }
 
 input[type=radio]:before {
@@ -173,11 +172,10 @@ input[type=radio]:checked:before {
 }
 
 input[type=checkbox] {
-    // stylelint-disable-next-line property-no-vendor-prefix
-    -webkit-appearance: checkbox;
+    height: 12px;
     width: auto;
     position: relative;
-    margin-right: 15px;
+    margin-right: 27px;
 }
 
 input[type=checkbox]:before {


### PR DESCRIPTION
As reported at https://github.com/wagtail/wagtail/pull/3802#issuecomment-397003833, checkboxes and radio buttons are misaligned in Firefox.

(Related: #4529)

The culprit appears to be the `-webkit-appearance` rule on these fields: on the face of it this rule seems to be pretty meaningless since we go on to hide the native widget behind the fake one, but it has the effect of making it occupy a 12x12px box only on Webkit, which then becomes the basis for the relative position of the fake element. This PR forms that 12x12 box using height and margin rules instead.