### PR TITLE
wording Edit per #4620

### DIFF
--- a/docs/contributing/developing.rst
+++ b/docs/contributing/developing.rst
@@ -51,7 +51,7 @@ Compile the assets:
 
     $ npm run build
 
-Any Wagtail sites you start up in this virtualenv will now run against this development instance of Wagtail. We recommend using the `Wagtail Bakery demo site <https://github.com/wagtail/bakerydemo/>`_ as a basis for developing Wagtail.
+Any Wagtail sites you start up in this virtualenv will now run against this development instance of Wagtail. Before you start we recommend you have an already set up and running Wagtail site (like  `Wagtail Bakery demo site <https://github.com/wagtail/bakerydemo/>`_ ) before you get to ``pip install -e`` of the dev version of Wagtail. 
 
 .. _testing:
 


### PR DESCRIPTION
@scotchester recommended I suggest that this doc page say before you start to set up your dev version of Wagtail that you should already have bakerydemo or some other Wagtail site up and running before you get to pip install -e of the dev version of Wagtail.