### PR TITLE
[WIP] US 2018 sprint accessibility

### DIFF
--- a/wagtail/admin/static_src/wagtailadmin/js/core.js
+++ b/wagtail/admin/static_src/wagtailadmin/js/core.js
@@ -91,7 +91,7 @@ $(function() {
 
     // Enable toggle to open/close user settings
     $(document).on('click', '#account-settings', function() {
-        $('#footer').toggleClass('footer-open');
+        $('#menu-footer').toggleClass('footer-open');
         $(this).find('em').toggleClass('icon-arrow-down-after icon-arrow-up-after');
     });
 
@@ -100,7 +100,7 @@ $(function() {
         $('.nav-wrapper').css('min-height', $(window).height());
         $('.nav-main').each(function() {
             var thisHeight = $(this).height();
-            var footerHeight = $('#footer', $(this)).height();
+            var footerHeight = $('#menu-footer', $(this)).height();
         });
     };
 

--- a/wagtail/admin/templates/wagtailadmin/base.html
+++ b/wagtail/admin/templates/wagtailadmin/base.html
@@ -38,8 +38,9 @@
             </div>
 
             <div id="nav-toggle" class="nav-toggle icon text-replace">{% trans "Menu" %}</div>
-
-            {% block content %}{% endblock %}
+            <main>
+                {% block content %}{% endblock %}
+            </main>
         </div>
     </div>
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/shared/main_nav.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/main_nav.html
@@ -1,10 +1,10 @@
 {% load wagtailadmin_tags %}
 {% load i18n %}
-<nav class="nav-main">
+<nav role="navigation" class="nav-main" aria-label="{% trans "Main navigation" %}">
     <ul>
         {{ menu_html }}
 
-        <li class="footer" id="footer">
+        <li class="footer" id="menu-footer">
             <div class="account" id="account-settings" title="{% trans 'Edit your account' %}">
                 <span class="avatar square avatar-on-dark">
                     <img src="{% avatar_url request.user size=50 %}" />
@@ -12,7 +12,7 @@
                 <em class="icon icon-arrow-up-after">{{ request.user.first_name|default:request.user.get_username }}</em>
             </div>
 
-            <ul class="footer-submenu">
+            <ul class="footer-submenu" aria-label="Account">
                 <li><a href="{% url 'wagtailadmin_account' %}" class="icon icon-user">{% trans "Account settings" %}</a></li>
                 <li><a href="{% url 'wagtailadmin_logout' %}" class="icon icon-logout">{% trans "Log out" %}</a></li>
             </ul>


### PR DESCRIPTION
This begins work on the page navigation part of https://github.com/wagtail/wagtail/issues/4199#issuecomment-358640129

It wraps the main content of the admin in a `main` button, and changes a `footer` id in the nav menu to a more semantic `menu-footer`. This will allow future work on making footer tags more accessible. (I started working on this, so hopefully it's coming soon!)

Many thanks to @marteki for helping!

