### PR TITLE
Expand the documentation on the EntityFeature  method

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -15,6 +15,7 @@ Changelog
  * Added `defer` flag to `PageQuerySet.specific` (Karl Hobley)
  * Snippets can now be deleted from the listing view (LB (Ben Johnston))
  * Increased max length of redirect URL field to 255 (Michael Harrison)
+ * Added documentation for new JS/CSS media files association with Draftail feature definitions (Ed Henderson)
  * Fix: Handle all exceptions from `Image.get_file_size` (Andrew Plummer)
  * Fix: Fix display of breadcrumbs in ModelAdmin (LB (Ben Johnston))
  * Fix: Remove duplicate border radius of avatars (Benjamin Thurm)

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -303,6 +303,7 @@ Contributors
 * Andrew Plummer
 * Dmitry Vasilev
 * Benjamin Thurm
+* Ed Henderson
 
 Translators
 ===========

--- a/docs/advanced_topics/customisation/extending_draftail.rst
+++ b/docs/advanced_topics/customisation/extending_draftail.rst
@@ -196,7 +196,7 @@ In order to achieve this, we start with registering the rich text feature like f
 
 The ``js`` and ``css`` keyword arguments on ``EntityFeature`` can be used to specify additional
 JS and CSS files to load when this feature is active. Both are optional. Their values are added to a ``Media`` object. More documentation on these objects
-is available in the `Django Form Assets documentation <https://docs.djangoproject.com/en/stable/topics/files/>`_
+is available in the `Django Form Assets documentation <https://docs.djangoproject.com/en/stable/topics/forms/media/>`_.
 
 Since entities hold data, the conversion to/from database format is more complicated. We have to create the two handlers:
 

--- a/docs/advanced_topics/customisation/extending_draftail.rst
+++ b/docs/advanced_topics/customisation/extending_draftail.rst
@@ -178,6 +178,10 @@ In order to achieve this, we start with registering the rich text feature like f
         The js argument is a list of javascript files, ideally local to the project.
         The css agument is a dict, where each key is the 'medium' type, and the value is a list of
         .css files to include.
+
+        The js and css values are added to a Media object. More documentation on these objects
+        is available here:
+            https://docs.djangoproject.com/en/2.0/topics/forms/media/
         """
         feature_name = 'stock'
         type_ = 'STOCK'

--- a/docs/advanced_topics/customisation/extending_draftail.rst
+++ b/docs/advanced_topics/customisation/extending_draftail.rst
@@ -195,7 +195,7 @@ In order to achieve this, we start with registering the rich text feature like f
         })
 
 The ``js`` and ``css`` keyword arguments on ``EntityFeature`` can be used to specify additional
-JS and CSS files to load when this feature is active. Both are optional. Their values are added to a ``Media`` object. More documentation on these objects
+JS and CSS files to load when this feature is active. Both are optional. Their values are added to a ``Media`` object, more documentation on these objects
 is available in the `Django Form Assets documentation <https://docs.djangoproject.com/en/stable/topics/forms/media/>`_.
 
 Since entities hold data, the conversion to/from database format is more complicated. We have to create the two handlers:

--- a/docs/advanced_topics/customisation/extending_draftail.rst
+++ b/docs/advanced_topics/customisation/extending_draftail.rst
@@ -170,18 +170,6 @@ In order to achieve this, we start with registering the rich text feature like f
         """
         Registering the `stock` feature, which uses the `STOCK` Draft.js entity type,
         and is stored as HTML with a `<span data-stock>` tag.
-
-        The js and css keyword arguments on EntityFeature can be used to specify additional
-        Javascript and CSS files to load when this feature is active. Both are optional and will
-        default to an empty list or dict respectively.
-
-        The js argument is a list of javascript files, ideally local to the project.
-        The css agument is a dict, where each key is the 'medium' type, and the value is a list of
-        .css files to include.
-
-        The js and css values are added to a Media object. More documentation on these objects
-        is available here:
-            https://docs.djangoproject.com/en/2.0/topics/forms/media/
         """
         feature_name = 'stock'
         type_ = 'STOCK'
@@ -195,8 +183,8 @@ In order to achieve this, we start with registering the rich text feature like f
         features.register_editor_plugin(
             'draftail', feature_name, draftail_features.EntityFeature(
                 control,
-                js=['stock.js']  # Additional JS to be loaded when this feature is active
-                css={'all': ['stock.css']} # Additional CSS to be loaded when this feature is active
+                js=['stock.js']
+                css={'all': ['stock.css']}
             )
         )
 
@@ -205,6 +193,10 @@ In order to achieve this, we start with registering the rich text feature like f
             'from_database_format': {'span[data-stock]': StockEntityElementHandler(type_)},
             'to_database_format': {'entity_decorators': {type_: stock_entity_decorator}},
         })
+
+The ``js`` and ``css`` keyword arguments on ``EntityFeature`` can be used to specify additional
+JS and CSS files to load when this feature is active. Both are optional. Their values are added to a ``Media`` object. More documentation on these objects
+is available in the `Django Form Assets documentation <https://docs.djangoproject.com/en/stable/topics/files/>`_
 
 Since entities hold data, the conversion to/from database format is more complicated. We have to create the two handlers:
 

--- a/docs/advanced_topics/customisation/extending_draftail.rst
+++ b/docs/advanced_topics/customisation/extending_draftail.rst
@@ -170,6 +170,14 @@ In order to achieve this, we start with registering the rich text feature like f
         """
         Registering the `stock` feature, which uses the `STOCK` Draft.js entity type,
         and is stored as HTML with a `<span data-stock>` tag.
+
+        The js and css keyword arguments on EntityFeature can be used to specify additional
+        Javascript and CSS files to load when this feature is active. Both are optional and will
+        default to an empty list or dict respectively.
+
+        The js argument is a list of javascript files, ideally local to the project.
+        The css agument is a dict, where each key is the 'medium' type, and the value is a list of
+        .css files to include.
         """
         feature_name = 'stock'
         type_ = 'STOCK'
@@ -184,6 +192,7 @@ In order to achieve this, we start with registering the rich text feature like f
             'draftail', feature_name, draftail_features.EntityFeature(
                 control,
                 js=['stock.js']  # Additional JS to be loaded when this feature is active
+                css={'all': ['stock.css']} # Additional CSS to be loaded when this feature is active
             )
         )
 

--- a/docs/releases/2.2.rst
+++ b/docs/releases/2.2.rst
@@ -24,6 +24,7 @@ Other features
  * Added ``defer`` flag to ``PageQuerySet.specific`` (Karl Hobley)
  * Snippets can now be deleted from the listing view (LB (Ben Johnston))
  * Increased max length of redirect URL field to 255 (Michael Harrison)
+ * Added documentation for new JS/CSS media files association with Draftail feature definitions (Ed Henderson)
 
 Bug fixes
 ~~~~~~~~~


### PR DESCRIPTION
This is just an update to the documentation.
I found that the css keyword argument was not documented, and it differs from the js argument. This PR could be a little better if I know what the possible values for 'medium' are, but I at least documented that the css= argument needs to be a dict, and that 'all' is one value that works.
