### PR TITLE
Fix: Site.get_site_root_paths() preferring other sites over the default when more than one sites have the same root_page

### DIFF
--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -161,7 +161,7 @@ class Site(models.Model):
             result = [
                 (site.id, site.root_page.url_path, site.root_url)
                 for site in Site.objects.select_related('root_page').order_by(
-                    '-root_page__url_path', 'is_default_site', 'hostname')
+                    '-root_page__url_path', '-is_default_site', 'hostname')
             ]
             cache.set('wagtail_site_root_paths', result, 3600)
 

--- a/wagtail/core/tests/test_sites.py
+++ b/wagtail/core/tests/test_sites.py
@@ -122,3 +122,24 @@ class TestDefaultSite(TestCase):
         with self.assertRaises(Site.MultipleObjectsReturned):
             # If there already are multiple default sites, you're in trouble
             site.clean_fields()
+
+
+class TestGetSiteRootPaths(TestCase):
+
+    def setUp(self):
+        self.default_site = Site.objects.get(is_default=True)
+        self.abc_site = Site.objects.create(
+            hostname='abc.com', root_page=self.default_site.root_page)
+        self.def_site = Site.objects.create(
+            hostname='def.com', root_page=self.default_site.root_page)
+
+        # To show that being the default site takes priority over hostname
+        # alphabetical order
+        self.default_site.hostname = 'xyz.com'
+        self.default_site.save()
+
+    def test_result_order_when_multiple_sites_share_the_same_root_page(self):
+        result = Site.get_site_root_paths()
+        self.assertEqual(result[0], self.default_site)
+        self.assertEqual(result[1], self.abc_site)
+        self.assertEqual(result[2], self.def_site)

--- a/wagtail/core/tests/test_sites.py
+++ b/wagtail/core/tests/test_sites.py
@@ -127,7 +127,7 @@ class TestDefaultSite(TestCase):
 class TestGetSiteRootPaths(TestCase):
 
     def setUp(self):
-        self.default_site = Site.objects.get(is_default=True)
+        self.default_site = Site.objects.get()
         self.abc_site = Site.objects.create(
             hostname='abc.com', root_page=self.default_site.root_page)
         self.def_site = Site.objects.create(

--- a/wagtail/core/tests/test_sites.py
+++ b/wagtail/core/tests/test_sites.py
@@ -129,17 +129,23 @@ class TestGetSiteRootPaths(TestCase):
     def setUp(self):
         self.default_site = Site.objects.get()
         self.abc_site = Site.objects.create(
-            hostname='abc.com', root_page=self.default_site.root_page)
+            hostname='abc.com', root_page=self.default_site.root_page
+        )
         self.def_site = Site.objects.create(
-            hostname='def.com', root_page=self.default_site.root_page)
+            hostname='def.com', root_page=self.default_site.root_page
+        )
 
-        # To show that being the default site takes priority over hostname
-        # alphabetical order
+        # Changing the hostname to show that being the default site takes
+        # promotes a site over the alphabetical ordering of hostname
         self.default_site.hostname = 'xyz.com'
         self.default_site.save()
 
     def test_result_order_when_multiple_sites_share_the_same_root_page(self):
         result = Site.get_site_root_paths()
-        self.assertEqual(result[0], self.default_site)
-        self.assertEqual(result[1], self.abc_site)
-        self.assertEqual(result[2], self.def_site)
+
+        # An entry for the default site should come first
+        self.assertEqual(result[0][0], self.default_site.id)
+
+        # Followed by entries for others in 'host' alphabetical order
+        self.assertEqual(result[1][0], self.abc_site.id)
+        self.assertEqual(result[2][0], self.def_site.id)


### PR DESCRIPTION
Fixes #4612

Corrects the ordering of queryset used in Site.get_root_paths(), and adds a test to confirm that the order of items in the returned list is as expected.