### PR TITLE
Add a title attribute to the image displayed in an ImageChooserBlock

### DIFF
--- a/wagtail/images/templates/wagtailimages/widgets/image_chooser.html
+++ b/wagtail/images/templates/wagtailimages/widgets/image_chooser.html
@@ -6,7 +6,7 @@
 {% block chosen_state_view %}
     <div class="preview-image">
         {% if image %}
-            {% image image max-165x165 class="show-transparency" %}
+            {% image image max-165x165 class="show-transparency" title=image.title %}
         {% else %}
             <img>
         {% endif %}


### PR DESCRIPTION
I've run into a small usability issue when using `ImageChooserBlock`, which is that after selecting an image there is no way to determine the title of the image without hitting "Edit this image" and viewing the full image in another tab.

I think it would be helpful if the title of the chosen image was available so that the editor has that additional contextual information close at hand.

This patch adds a title attribute to the image, so that hovering over it will display the title of the image (e.g.,):
![image](https://user-images.githubusercontent.com/160227/41533523-af3fd684-7303-11e8-9287-7dff3c0d54fd.png)

A title isn't super salient obviously. You could argue that it should be even more obvious - e.g., the title printed below the image, but I went with a title as it will not affect the appearance of the block at all. I'm open to feedback/suggestions and happy to amend the PR accordingly.