### PR TITLE
Handle missing page model in PageTypeField API serializer

### DIFF
--- a/wagtail/api/v2/serializers.py
+++ b/wagtail/api/v2/serializers.py
@@ -79,6 +79,8 @@ class PageTypeField(Field):
         return instance
 
     def to_representation(self, page):
+        if page.specific_class is None:
+            return None
         name = page.specific_class._meta.app_label + '.' + page.specific_class.__name__
         self.context['view'].seen_types[name] = page.specific_class
         return name

--- a/wagtail/api/v2/tests/test_pages.py
+++ b/wagtail/api/v2/tests/test_pages.py
@@ -80,12 +80,12 @@ class TestPageListing(TestCase):
         response = self.get_response()
         content = json.loads(response.content.decode('UTF-8'))
         self.assertEqual(content['meta']['total_count'], new_total_count)
-    
+
     def test_page_listing_with_missing_page_model(self):
         # Create a ContentType that doesn't correspond to a real model
         missing_page_content_type = ContentType.objects.create(app_label='tests', model='missingpage')
-        
-        # Turn a BlogEntryPage into this
+
+        # Turn a BlogEntryPage into this content_type
         models.BlogEntryPage.objects.filter(id=16).update(content_type=missing_page_content_type)
 
         # get page listing with missing model
@@ -916,12 +916,12 @@ class TestPageDetail(TestCase):
 
         self.assertIn('related_links', content)
         self.assertEqual(content['feed_image'], None)
-    
+
     def test_page_with_missing_page_model(self):
         # Create a ContentType that doesn't correspond to a real model
         missing_page_content_type = ContentType.objects.create(app_label='tests', model='missingpage')
-        
-        # Turn a BlogEntryPage into this
+
+        # Turn a BlogEntryPage into this content_type
         models.BlogEntryPage.objects.filter(id=16).update(content_type=missing_page_content_type)
 
         # get missing model page

--- a/wagtail/api/v2/tests/test_pages.py
+++ b/wagtail/api/v2/tests/test_pages.py
@@ -1,7 +1,8 @@
 import collections
 import json
-
 import mock
+
+from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase
 from django.test.utils import override_settings
 from django.urls import reverse
@@ -79,6 +80,17 @@ class TestPageListing(TestCase):
         response = self.get_response()
         content = json.loads(response.content.decode('UTF-8'))
         self.assertEqual(content['meta']['total_count'], new_total_count)
+    
+    def test_page_listing_with_missing_page_model(self):
+        # Create a ContentType that doesn't correspond to a real model
+        missing_page_content_type = ContentType.objects.create(app_label='tests', model='missingpage')
+        
+        # Turn a BlogEntryPage into this
+        models.BlogEntryPage.objects.filter(id=16).update(content_type=missing_page_content_type)
+
+        # get page listing with missing model
+        response = self.get_response()
+        self.assertEqual(response.status_code, 200)
 
     # TYPE FILTER
 
@@ -904,6 +916,17 @@ class TestPageDetail(TestCase):
 
         self.assertIn('related_links', content)
         self.assertEqual(content['feed_image'], None)
+    
+    def test_page_with_missing_page_model(self):
+        # Create a ContentType that doesn't correspond to a real model
+        missing_page_content_type = ContentType.objects.create(app_label='tests', model='missingpage')
+        
+        # Turn a BlogEntryPage into this
+        models.BlogEntryPage.objects.filter(id=16).update(content_type=missing_page_content_type)
+
+        # get missing model page
+        response = self.get_response(16)
+        self.assertEqual(response.status_code, 200)
 
     # FIELDS
 


### PR DESCRIPTION
Fixes #4592 

Checks:
* Do the tests still pass? Yes
* Does the code comply with the style guide? Yes
* For Python changes: Have you added tests to cover the new/fixed behaviour? Yes
* For front-end changes: Did you test on all of Wagtail’s supported browsers? N/A
* For new features: Has the documentation been updated accordingly? N/A
