### PR TITLE
Strip NULL characters when normalizing paths

### DIFF
--- a/wagtail/contrib/redirects/models.py
+++ b/wagtail/contrib/redirects/models.py
@@ -71,8 +71,12 @@ class Redirect(models.Model):
         parameters_components = parameters.split(';')
         parameters = ';'.join(sorted(parameters_components))
 
-        # Query string components must be sorted alphabetically
         query_string = url_parsed[4]
+
+        # Strip Unicode NULLs (U+0000) for safety and Postgres compatibility
+        query_string = query_string.replace('%00', '')
+
+        # Query string components must be sorted alphabetically
         query_string_components = query_string.split('&')
         query_string = '&'.join(sorted(query_string_components))
 

--- a/wagtail/contrib/redirects/tests.py
+++ b/wagtail/contrib/redirects/tests.py
@@ -78,6 +78,8 @@ class TestRedirects(TestCase):
 
         self.assertEqual('/', normalise_path('/'))  # '/' should stay '/'
 
+        self.assertEqual('/foo?bar=baz', normalise_path('/foo?bar=baz%00'))  # Strip NULLs
+
         # Normalise some rubbish to make sure it doesn't crash
         normalise_path('This is not a URL')
         normalise_path('//////hello/world')


### PR DESCRIPTION
(see related issue https://github.com/wagtail/wagtail/issues/4496)

After migrating a Wagtail-based site from MySQL to Postgres, we noticed that malicious requests to the site that included percent-encoded Unicode NULLs (`%00`) raised a `ValueError` exception that we hadn't seen when using MySQL: `A string literal cannot contain NUL (0x00) characters.` This may relate to `psycopg2`'s decision to raise an exception in these situations, as discussed here: https://github.com/psycopg/psycopg2/issues/420

While newer versions of Django [appear to provide some field validation](https://docs.djangoproject.com/en/2.0/ref/validators/#prohibitnullcharactersvalidator) that addresses these null chars, it doesn't look like Wagtail's redirect middleware is making use of those validators, and so it seemed reasonable to clean these chars in the context of _normalizing_ the paths before looking in the db for corresponding redirects – especially since a quick investigation on the internet suggests that `U+0000` in URLs can be used as a means of attack, and also since RFC 3986 says:

> 
>    Note, however, that the "%00" percent-encoding (NUL) may require
>    special handling and should be rejected if the application is not
>    expecting to receive raw data within a component.
> 

Thanks for considering this patch.

cc: @chosak 