### PR TITLE
Deprecate PageChooserBlock's `target_model` parameter in favour of `page_type`

### DIFF
--- a/docs/topics/streamfield.rst
+++ b/docs/topics/streamfield.rst
@@ -261,7 +261,7 @@ A control for selecting a page object, using Wagtail's page browser. The followi
 ``required`` (default: True)
   If true, the field cannot be left blank.
 
-``target_model`` (default: Page)
+``page_type`` (default: Page)
   Restrict choices to one or more specific page types. Accepts a page model class, model name (as a string), or a list or tuple of these.
 
 ``can_choose_root`` (default: False)

--- a/wagtail/core/blocks/field_block.py
+++ b/wagtail/core/blocks/field_block.py
@@ -1,5 +1,4 @@
 import datetime
-import warnings
 
 from django import forms
 from django.db.models.fields import BLANK_CHOICE_DASH
@@ -13,7 +12,6 @@ from django.utils.safestring import mark_safe
 
 from wagtail.core.rich_text import RichText
 from wagtail.core.utils import resolve_model_string
-from wagtail.utils.deprecation import RemovedInWagtail24Warning
 
 from .base import Block
 
@@ -597,12 +595,10 @@ class ChooserBlock(FieldBlock):
 
 class PageChooserBlock(ChooserBlock):
     def __init__(self, page_type=None, can_choose_root=False, target_model=None, **kwargs):
+        # We cannot simply deprecate 'target_model' in favour of 'page_type'
+        # as it would force developers to update their old migrations.
+        # Mapping the old 'target_model' to the new 'page_type' kwarg instead.
         if target_model:
-            warnings.warn(
-                "PageChooserBlock's `target_model` parameter is deprecated. "
-                "Please use `page_type` instead.",
-                category=RemovedInWagtail24Warning
-            )
             page_type = target_model
 
         if page_type:

--- a/wagtail/core/blocks/field_block.py
+++ b/wagtail/core/blocks/field_block.py
@@ -651,7 +651,7 @@ class PageChooserBlock(ChooserBlock):
     def deconstruct(self):
         name, args, kwargs = super().deconstruct()
 
-        if 'page_type' in kwargs:
+        if 'target_model' in kwargs or 'page_type' in kwargs:
             target_models = []
 
             for target_model in self.target_models:
@@ -660,6 +660,7 @@ class PageChooserBlock(ChooserBlock):
                     '{}.{}'.format(opts.app_label, opts.object_name)
                 )
 
+            kwargs.pop('target_model', None)
             kwargs['page_type'] = target_models
 
         return name, args, kwargs

--- a/wagtail/core/tests/test_blocks.py
+++ b/wagtail/core/tests/test_blocks.py
@@ -2690,22 +2690,22 @@ class TestPageChooserBlock(TestCase):
         self.assertIn('createPageChooser("page", ["wagtailcore.page"], null, false, null);', empty_form_html)
 
     def test_form_render_with_target_model_string(self):
-        block = blocks.PageChooserBlock(help_text="pick a page, any page", target_model='tests.SimplePage')
+        block = blocks.PageChooserBlock(help_text="pick a page, any page", page_type='tests.SimplePage')
         empty_form_html = block.render_form(None, 'page')
         self.assertIn('createPageChooser("page", ["tests.simplepage"], null, false, null);', empty_form_html)
 
     def test_form_render_with_target_model_literal(self):
-        block = blocks.PageChooserBlock(help_text="pick a page, any page", target_model=SimplePage)
+        block = blocks.PageChooserBlock(help_text="pick a page, any page", page_type=SimplePage)
         empty_form_html = block.render_form(None, 'page')
         self.assertIn('createPageChooser("page", ["tests.simplepage"], null, false, null);', empty_form_html)
 
     def test_form_render_with_target_model_multiple_strings(self):
-        block = blocks.PageChooserBlock(help_text="pick a page, any page", target_model=['tests.SimplePage', 'tests.EventPage'])
+        block = blocks.PageChooserBlock(help_text="pick a page, any page", page_type=['tests.SimplePage', 'tests.EventPage'])
         empty_form_html = block.render_form(None, 'page')
         self.assertIn('createPageChooser("page", ["tests.simplepage", "tests.eventpage"], null, false, null);', empty_form_html)
 
     def test_form_render_with_target_model_multiple_literals(self):
-        block = blocks.PageChooserBlock(help_text="pick a page, any page", target_model=[SimplePage, EventPage])
+        block = blocks.PageChooserBlock(help_text="pick a page, any page", page_type=[SimplePage, EventPage])
         empty_form_html = block.render_form(None, 'page')
         self.assertIn('createPageChooser("page", ["tests.simplepage", "tests.eventpage"], null, false, null);', empty_form_html)
 
@@ -2741,19 +2741,19 @@ class TestPageChooserBlock(TestCase):
         self.assertEqual(block.target_model, Page)
 
     def test_target_model_string(self):
-        block = blocks.PageChooserBlock(target_model='tests.SimplePage')
+        block = blocks.PageChooserBlock(page_type='tests.SimplePage')
         self.assertEqual(block.target_model, SimplePage)
 
     def test_target_model_literal(self):
-        block = blocks.PageChooserBlock(target_model=SimplePage)
+        block = blocks.PageChooserBlock(page_type=SimplePage)
         self.assertEqual(block.target_model, SimplePage)
 
     def test_target_model_multiple_strings(self):
-        block = blocks.PageChooserBlock(target_model=['tests.SimplePage', 'tests.EventPage'])
+        block = blocks.PageChooserBlock(page_type=['tests.SimplePage', 'tests.EventPage'])
         self.assertEqual(block.target_model, Page)
 
     def test_target_model_multiple_literals(self):
-        block = blocks.PageChooserBlock(target_model=[SimplePage, EventPage])
+        block = blocks.PageChooserBlock(page_type=[SimplePage, EventPage])
         self.assertEqual(block.target_model, Page)
 
     def test_deconstruct_target_model_default(self):
@@ -2763,28 +2763,28 @@ class TestPageChooserBlock(TestCase):
             (), {}))
 
     def test_deconstruct_target_model_string(self):
-        block = blocks.PageChooserBlock(target_model='tests.SimplePage')
+        block = blocks.PageChooserBlock(page_type='tests.SimplePage')
         self.assertEqual(block.deconstruct(), (
             'wagtail.core.blocks.PageChooserBlock',
-            (), {'target_model': ['tests.SimplePage']}))
+            (), {'page_type': ['tests.SimplePage']}))
 
     def test_deconstruct_target_model_literal(self):
-        block = blocks.PageChooserBlock(target_model=SimplePage)
+        block = blocks.PageChooserBlock(page_type=SimplePage)
         self.assertEqual(block.deconstruct(), (
             'wagtail.core.blocks.PageChooserBlock',
-            (), {'target_model': ['tests.SimplePage']}))
+            (), {'page_type': ['tests.SimplePage']}))
 
     def test_deconstruct_target_model_multiple_strings(self):
-        block = blocks.PageChooserBlock(target_model=['tests.SimplePage', 'tests.EventPage'])
+        block = blocks.PageChooserBlock(page_type=['tests.SimplePage', 'tests.EventPage'])
         self.assertEqual(block.deconstruct(), (
             'wagtail.core.blocks.PageChooserBlock',
-            (), {'target_model': ['tests.SimplePage', 'tests.EventPage']}))
+            (), {'page_type': ['tests.SimplePage', 'tests.EventPage']}))
 
     def test_deconstruct_target_model_multiple_literals(self):
-        block = blocks.PageChooserBlock(target_model=[SimplePage, EventPage])
+        block = blocks.PageChooserBlock(page_type=[SimplePage, EventPage])
         self.assertEqual(block.deconstruct(), (
             'wagtail.core.blocks.PageChooserBlock',
-            (), {'target_model': ['tests.SimplePage', 'tests.EventPage']}))
+            (), {'page_type': ['tests.SimplePage', 'tests.EventPage']}))
 
 
 class TestStaticBlock(unittest.TestCase):


### PR DESCRIPTION
Completes #3299.

- [X] ~~Deprecate `target_model` in favour of `page_type`~~
Allow `page_type` in addition to `target_model` (as we [need to keep](https://github.com/wagtail/wagtail/pull/4653#discussion_r198867963) `target_model` around).
- [x] Ensure it plays nice with existing migrations.
- [X] Update tests
- [x] Update documentation accordingly.