### PR TITLE
Add guideline on the use of British vs American English

### DIFF
--- a/docs/contributing/general_guidelines.rst
+++ b/docs/contributing/general_guidelines.rst
@@ -1,0 +1,7 @@
+General coding guidelines
+=========================
+
+Language
+~~~~~~~~
+
+British English is preferred for user-facing text; this text should also be marked for translation (using the ``django.utils.translation.gettext`` function and ``{% trans %}`` template tag, for example). However, identifiers within code should use American English if the British or international spelling would conflict with built-in language keywords; for example, CSS code should consistently use the spelling ``color`` to avoid inconsistencies like ``background-color: $colour-red``.

--- a/docs/contributing/index.rst
+++ b/docs/contributing/index.rst
@@ -46,6 +46,7 @@ More information
     :maxdepth: 2
 
     styleguide
+    general_guidelines
     python_guidelines
     css_guidelines
     javascript_guidelines


### PR DESCRIPTION
Following discussion at core team meeting and on #4628. This section seems a bit lonely on its own page, but there didn't seem to be a suitable existing place to put it - suggestions for other things to go in "general coding guidelines" welcome!