### PR TITLE
Reject null characters in redirect URLs

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -24,7 +24,6 @@ Changelog
  * Fix: Remove duplicate border radius of avatars (Benjamin Thurm)
  * Fix: Site.get_site_root_paths() preferring other sites over the default when some sites share the same root_page (Andy Babic)
  * Fix: Pages with missing model definitions no longer crash the API (Abdulmalik Abdulwahab)
- * Fix: Strip null characters from paths when checking for redirects (Andrew Crewdson)
  * Fix: Rich text image chooser no longer skips format selection after a validation error (Matt Westcott)
 
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -25,6 +25,7 @@ Changelog
  * Fix: Site.get_site_root_paths() preferring other sites over the default when some sites share the same root_page (Andy Babic)
  * Fix: Pages with missing model definitions no longer crash the API (Abdulmalik Abdulwahab)
  * Fix: Rich text image chooser no longer skips format selection after a validation error (Matt Westcott)
+ * Fix: Null characters in URLs no longer crash the redirect middleware on PostgreSQL (Andrew Crewdson, Matt Westcott)
 
 
 2.1.1 (xx.xx.xxxx) - IN DEVELOPMENT

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -308,6 +308,7 @@ Contributors
 * Daniele Procida
 * Catherine Farman
 * Abdulmalik Abdulwahab
+* Andrew Crewdson
 * Aram Dulyan
 
 Translators

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -308,7 +308,6 @@ Contributors
 * Daniele Procida
 * Catherine Farman
 * Abdulmalik Abdulwahab
-* Andrew Crewdson
 * Aram Dulyan
 
 Translators

--- a/docs/releases/2.2.rst
+++ b/docs/releases/2.2.rst
@@ -38,6 +38,7 @@ Bug fixes
  * Site.get_site_root_paths() preferring other sites over the default when some sites share the same root_page (Andy Babic)
  * Pages with missing model definitions no longer crash the API (Abdulmalik Abdulwahab)
  * Rich text image chooser no longer skips format selection after a validation error (Matt Westcott)
+ * Null characters in URLs no longer crash the redirect middleware on PostgreSQL (Andrew Crewdson, Matt Westcott)
 
 Upgrade considerations
 ======================

--- a/docs/releases/2.2.rst
+++ b/docs/releases/2.2.rst
@@ -37,7 +37,6 @@ Bug fixes
  * Remove duplicate border radius of avatars (Benjamin Thurm)
  * Site.get_site_root_paths() preferring other sites over the default when some sites share the same root_page (Andy Babic)
  * Pages with missing model definitions no longer crash the API (Abdulmalik Abdulwahab)
- * Strip null characters from paths when checking for redirects (Andrew Crewdson)
  * Rich text image chooser no longer skips format selection after a validation error (Matt Westcott)
 
 Upgrade considerations

--- a/wagtail/contrib/redirects/middleware.py
+++ b/wagtail/contrib/redirects/middleware.py
@@ -8,6 +8,9 @@ from wagtail.contrib.redirects import models
 
 
 def _get_redirect(request, path):
+    if '\0' in path:  # reject URLs with null characters, which crash on Postgres (#4496)
+        return None
+
     try:
         return models.Redirect.get_for_site(request.site).get(old_path=path)
     except models.Redirect.MultipleObjectsReturned:

--- a/wagtail/contrib/redirects/models.py
+++ b/wagtail/contrib/redirects/models.py
@@ -71,12 +71,8 @@ class Redirect(models.Model):
         parameters_components = parameters.split(';')
         parameters = ';'.join(sorted(parameters_components))
 
-        query_string = url_parsed[4]
-
-        # Strip Unicode NULLs (U+0000) for safety and Postgres compatibility
-        query_string = query_string.replace('%00', '')
-
         # Query string components must be sorted alphabetically
+        query_string = url_parsed[4]
         query_string_components = query_string.split('&')
         query_string = '&'.join(sorted(query_string_components))
 

--- a/wagtail/contrib/redirects/tests.py
+++ b/wagtail/contrib/redirects/tests.py
@@ -78,8 +78,6 @@ class TestRedirects(TestCase):
 
         self.assertEqual('/', normalise_path('/'))  # '/' should stay '/'
 
-        self.assertEqual('/foo?bar=baz', normalise_path('/foo?bar=baz%00'))  # Strip NULLs
-
         # Normalise some rubbish to make sure it doesn't crash
         normalise_path('This is not a URL')
         normalise_path('//////hello/world')

--- a/wagtail/contrib/redirects/tests.py
+++ b/wagtail/contrib/redirects/tests.py
@@ -273,6 +273,19 @@ class TestRedirects(TestCase):
 
         self.assertRedirects(response, '/redirectto', status_code=301, fetch_redirect_response=False)
 
+    def test_reject_null_characters(self):
+        response = self.client.get('/test%00test/')
+        self.assertEqual(response.status_code, 404)
+
+        response = self.client.get('/test\0test/')
+        self.assertEqual(response.status_code, 404)
+
+        response = self.client.get('/test/?foo=%00bar')
+        self.assertEqual(response.status_code, 404)
+
+        response = self.client.get('/test/?foo=\0bar')
+        self.assertEqual(response.status_code, 404)
+
 
 class TestRedirectsIndexView(TestCase, WagtailTestUtils):
     def setUp(self):


### PR DESCRIPTION
Revised fix for #4496, replacing #4652. Strings with null characters are now rejected immediately before performing the database lookup, so that we catch them regardless of injection method or position within the URL.