### PR TITLE
Bug/revisions unschedule for unpublished pages

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/pages/revisions/list.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/revisions/list.html
@@ -11,6 +11,7 @@
     </thead>
     <tbody>
         {% if revisions %}
+            {% page_permissions page as page_perms %}
             {% for revision in revisions %}
                 <tr {% if revision == page.get_latest_revision %}class="index"{% endif %}>
                     <td class="title">
@@ -36,7 +37,7 @@
                                 <li><a href="{% url 'wagtailadmin_pages:revisions_compare' page.id previous_revision.id revision.id %}" class="button button-small button-secondary">{% trans 'Compare with previous revision' %}</a></li>
                             {% endif %}
                             {% endwith %}
-			    {% if revision.approved_go_live_at %}
+			    {% if revision.approved_go_live_at and page_perms.can_unschedule %}
 				<li><a href="{% url 'wagtailadmin_pages:revisions_unschedule' page.id revision.id %}" class="button button-small button-secondary">{% trans 'Cancel scheduled publish' %}</a></li>
 			    {% endif %}
                         </ul>

--- a/wagtail/admin/views/pages.py
+++ b/wagtail/admin/views/pages.py
@@ -1154,7 +1154,7 @@ def revisions_unschedule(request, page_id, revision_id):
     page = get_object_or_404(Page, id=page_id).specific
 
     user_perms = UserPagePermissionsProxy(request.user)
-    if not user_perms.for_page(page).can_unpublish():
+    if not user_perms.for_page(page).can_publish():
         raise PermissionDenied
 
     revision = get_object_or_404(page.revisions, id=revision_id)

--- a/wagtail/admin/views/pages.py
+++ b/wagtail/admin/views/pages.py
@@ -1154,7 +1154,7 @@ def revisions_unschedule(request, page_id, revision_id):
     page = get_object_or_404(Page, id=page_id).specific
 
     user_perms = UserPagePermissionsProxy(request.user)
-    if not user_perms.for_page(page).can_publish():
+    if not user_perms.for_page(page).can_unschedule():
         raise PermissionDenied
 
     revision = get_object_or_404(page.revisions, id=revision_id)

--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -1759,6 +1759,9 @@ class PagePermissionTester:
     def can_set_view_restrictions(self):
         return self.can_publish()
 
+    def can_unschedule(self):
+        return self.can_publish()
+
     def can_lock(self):
         return self.user.is_superuser or ('lock' in self.permissions)
 


### PR DESCRIPTION
This PR fixes #4657 

Revisions unscheduling uses `can_unpublish` to determine if a user has permission to unschedule a revision, `can_unpublish` however checks if a page is live which causes unscheduling to fail if the page has not been published yet. This fix changes the permission check to use `can_publish` which also checks for all the necessary permissions too.

If there is a better approach to fixing this, I'm open ideas.

PR Checks
* Do the tests still pass? Yes
* Does the code comply with the style guide? Yes
* For Python changes: Have you added tests to cover the new/fixed behaviour? Yes
* For front-end changes: Did you test on all of Wagtail’s supported browsers? N/A
* For new features: Has the documentation been updated accordingly? N/A
