### PR TITLE
Add action buttons to editing view header

### DIFF
--- a/client/scss/components/_dropdown.scss
+++ b/client/scss/components/_dropdown.scss
@@ -29,7 +29,7 @@
     min-width: 8rem;
     text-transform: none;
     position: absolute;
-    z-index: 1;
+    z-index: 10;
     animation: dropdownIn 0.1s ease-out backwards;
     list-style: none;
 }

--- a/client/scss/components/_header.scss
+++ b/client/scss/components/_header.scss
@@ -165,3 +165,12 @@ header {
         padding-left: $mobile-nav-indent;
     }
 }
+
+.page-title {
+    font-size: 1.8em;
+
+    .span {
+        font-weight: 500;
+        margin-left: 0.3em;
+    }
+}

--- a/client/scss/components/_listing.scss
+++ b/client/scss/components/_listing.scss
@@ -445,7 +445,9 @@ table.listing {
 }
 
 // explorer specific tweaks
-.page-explorer .listing {
+.page-explorer .listing,
+// action buttons on the edit page
+.listing.edit-page-buttons {
     position: relative;
 
     .index {

--- a/docs/reference/hooks.rst
+++ b/docs/reference/hooks.rst
@@ -794,7 +794,7 @@ Page explorer
     from wagtail.admin import widgets as wagtailadmin_widgets
 
     @hooks.register('register_page_listing_buttons')
-    def page_listing_buttons(page, page_perms, is_parent=False):
+    def page_listing_buttons(page, page_perms, is_parent=False, editing=False):
         yield wagtailadmin_widgets.PageListingButton(
             'A page listing button',
             '/goes/to/a/url/',
@@ -843,7 +843,7 @@ Buttons with dropdown lists
     from wagtail.admin import widgets as wagtailadmin_widgets
 
     @hooks.register('register_page_listing_buttons')
-    def page_custom_listing_buttons(page, page_perms, is_parent=False):
+    def page_custom_listing_buttons(page, page_perms, is_parent=False, editing=False):
         yield wagtailadmin_widgets.ButtonWithDropdownFromHook(
             'More actions',
             hook_name='my_button_dropdown_hook',

--- a/wagtail/admin/static_src/wagtailadmin/scss/layouts/page-editor.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/layouts/page-editor.scss
@@ -41,6 +41,21 @@
             // on mobile viewports due to snippets
         }
     }
+
+    .right {
+        @include media-breakpoint-up(sm) {
+            margin-bottom: -3rem;
+        }
+    }
+
+    .status-information {
+        margin-right: 0.5em;
+
+        span {
+            margin-left: 0.3em;
+            font-weight: 600;
+        }
+    }
 }
 
 $object-title-height: 40px;

--- a/wagtail/admin/templates/wagtailadmin/pages/_edit_switches.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/_edit_switches.html
@@ -1,2 +1,7 @@
+{% load i18n %}
+
 {% include "wagtailadmin/pages/_privacy_switch.html" with page=page page_perms=page_perms only %}
 {% include "wagtailadmin/pages/_lock_switch.html" %}
+<div class="status-information">
+    {% blocktrans with page_type=content_type.model_class.get_verbose_name %}Page type <span>{{ page_type }}</span>{% endblocktrans %}
+</div>

--- a/wagtail/admin/templates/wagtailadmin/pages/edit.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/edit.html
@@ -12,8 +12,16 @@
 
         <div class="row row-flush">
             <div class="left col9 header-title">
-                <h1 class="icon icon-doc-empty-inverse">
-                {% blocktrans with title=page.get_admin_display_title page_type=content_type.model_class.get_verbose_name %}Editing {{ page_type }} <span>{{ title }}</span>{% endblocktrans %}</h1>
+                <h1 class="icon icon-doc-empty-inverse page-title">
+                {% blocktrans with title=page.get_admin_display_title %}Editing <span>{{ title }}</span>{% endblocktrans %}</h1>
+
+                <div class="listing full-width edit-page-buttons">
+                    <div class="index">
+                        <ul class="actions">
+                            {% page_listing_buttons page page_perms is_parent=True editing=True %}
+                        </ul>
+                    </div>
+                </div>
             </div>
             <div class="right col3">
                 {% trans "Status" %}

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -421,10 +421,10 @@ def paginate(context, page, base_url='', page_key='p',
 
 @register.inclusion_tag("wagtailadmin/pages/listing/_buttons.html",
                         takes_context=True)
-def page_listing_buttons(context, page, page_perms, is_parent=False):
+def page_listing_buttons(context, page, page_perms, is_parent=False, editing=False):
     button_hooks = hooks.get_hooks('register_page_listing_buttons')
     buttons = sorted(itertools.chain.from_iterable(
-        hook(page, page_perms, is_parent)
+        hook(page, page_perms, is_parent, editing)
         for hook in button_hooks))
 
     for hook in hooks.get_hooks('construct_page_listing_buttons'):

--- a/wagtail/admin/tests/test_buttons_hooks.py
+++ b/wagtail/admin/tests/test_buttons_hooks.py
@@ -14,7 +14,7 @@ class TestButtonsHooks(TestCase, WagtailTestUtils):
 
     def test_register_page_listing_buttons(self):
         @hooks.register('register_page_listing_buttons')
-        def page_listing_buttons(page, page_perms, is_parent=False):
+        def page_listing_buttons(page, page_perms, is_parent=False, editing=False):
             yield wagtailadmin_widgets.PageListingButton(
                 'Another useless page listing button',
                 '/custom-url',
@@ -52,7 +52,7 @@ class TestButtonsHooks(TestCase, WagtailTestUtils):
 
     def test_custom_button_with_dropdown(self):
         @hooks.register('register_page_listing_buttons')
-        def page_custom_listing_buttons(page, page_perms, is_parent=False):
+        def page_custom_listing_buttons(page, page_perms, is_parent=False, editing=False):
             yield wagtailadmin_widgets.ButtonWithDropdownFromHook(
                 'One more more button',
                 hook_name='register_page_listing_one_more_more_buttons',

--- a/wagtail/admin/wagtail_hooks.py
+++ b/wagtail/admin/wagtail_hooks.py
@@ -98,14 +98,22 @@ def register_collections_menu_item():
 
 
 @hooks.register('register_page_listing_buttons')
-def page_listing_buttons(page, page_perms, is_parent=False):
+def page_listing_buttons(page, page_perms, is_parent=False, editing=False):
     if page_perms.can_edit():
-        yield PageListingButton(
-            _('Edit'),
-            reverse('wagtailadmin_pages:edit', args=[page.id]),
-            attrs={'aria-label': _("Edit '{title}'").format(title=page.get_admin_display_title())},
-            priority=10
-        )
+        if editing:
+            yield PageListingButton(
+                _('Show in Explorer'),
+                reverse('wagtailadmin_explore', args=[page.id]),
+                attrs={'aria-label': _("Show '{title}' in the Explorer").format(title=page.get_admin_display_title())},
+                priority=10
+            )
+        else:
+            yield PageListingButton(
+                _('Edit'),
+                reverse('wagtailadmin_pages:edit', args=[page.id]),
+                attrs={'aria-label': _("Edit '{title}'").format(title=page.get_admin_display_title())},
+                priority=10
+            )
     if page.has_unpublished_changes:
         yield PageListingButton(
             _('View draft'),


### PR DESCRIPTION
Fixes #4599

## Changes

### Add action buttons to editing view header

- Add `editing` argument to page listing buttons template tag and hook, to indicate whether in editing view
- Action buttons in editing view have first button `Show in Explorer` instead of `Edit`. This had originally been `View in Explorer`, but `Show in Explorer` is consistent with the userbar.
- Update tests and documentation to use additional argument
- Increase dropdown menu z-index so that it is not behind editing view headings

### Other small changes to the header

- Increase font size in page title of editing view to more closely match styles in explorer view
- Move page type in editing view from page title to list of status indicators

## Notes

### Potential other changes

This isn't a very elegant way of adding these buttons, but I didn't want to get into too much refactoring because I wanted to start with this being as small a change as possible. Here are a few notes on potential changes I could also make if that would be preferred:

- I noticed that the `is_parent` argument for page listing buttons is really used to determine whether to use the styles that make sense on the teal heading. This is no longer used only for parent pages, so it could make sense to rename it.
- I added the `editing` argument to `page_listing_buttons` but not to `page_listing_more_buttons`. It seems reasonable that people might want to have custom buttons for the `more` dropdown that vary based on whether one is editing, so I could add that argument to the `more` buttons as well.
- My additional CSS is not terribly well organized, but neither is the CSS it's amending. I would personally be inclined to address that CSS in a separate pull request.

### Other things I tested

- I tested the front end only in Firefox 61 for both wide and narrow screens. Testing with more browsers would not be unwise, though none of the changes use poorly-supported CSS.
- Clicking the new buttons does indeed yield a warning about navigating off of the page.