### PR TITLE
[WIP] Re-establish datetimepicker localisation. Fix #4584

### DIFF
--- a/wagtail/admin/static_src/wagtailadmin/js/page-editor.js
+++ b/wagtail/admin/static_src/wagtailadmin/js/page-editor.js
@@ -33,9 +33,8 @@ function initDateChooser(id, opts) {
             scrollInput: false,
             format: 'Y-m-d',
             i18n: {
-                lang: window.dateTimePickerTranslations
+                ru: window.dateTimePickerTranslations
             },
-            lang: 'lang',
             onGenerate: hideCurrent
         }, opts || {}));
     } else {
@@ -56,9 +55,8 @@ function initTimeChooser(id) {
             scrollInput: false,
             format: 'H:i',
             i18n: {
-                lang: window.dateTimePickerTranslations
-            },
-            lang: 'lang'
+                ru: window.dateTimePickerTranslations
+            }
         });
     } else {
         $('#' + id).datetimepicker({

--- a/wagtail/admin/templates/wagtailadmin/shared/datetimepicker_translations.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/datetimepicker_translations.html
@@ -16,7 +16,7 @@
             '{% trans "November" %}',
             '{% trans "December" %}'
         ],
-        dayOfWeek: [
+        dayOfWeekShort: [
             '{% trans "Sun" %}',
             '{% trans "Mon" %}',
             '{% trans "Tue" %}',
@@ -24,6 +24,18 @@
             '{% trans "Thu" %}',
             '{% trans "Fri" %}',
             '{% trans "Sat" %}'
+        ],
+        dayOfWeek: [
+            '{% trans "Sunday" %}',
+            '{% trans "Monday" %}',
+            '{% trans "Tuesday" %}',
+            '{% trans "Wednesday" %}',
+            '{% trans "Thursday" %}',
+            '{% trans "Friday" %}',
+            '{% trans "Saturday" %}'
         ]
     }
+    $(function() {
+        $.datetimepicker.setLocale('ru');
+    });
 </script>

--- a/wagtail/contrib/forms/templates/wagtailforms/index_submissions.html
+++ b/wagtail/contrib/forms/templates/wagtailforms/index_submissions.html
@@ -11,17 +11,15 @@
                 timepicker: false,
                 format: 'Y-m-d',
                 i18n: {
-                    lang: window.dateTimePickerTranslations
-                },
-                lang: 'lang'
+                    ru: window.dateTimePickerTranslations
+                }
             });
             $('#id_date_to').datetimepicker({
                 timepicker: false,
                 format: 'Y-m-d',
                 i18n: {
-                    lang: window.dateTimePickerTranslations
-                },
-                lang: 'lang'
+                    ru: window.dateTimePickerTranslations
+                }
             });
 
             var selectAllCheckbox = document.getElementById('select-all');


### PR DESCRIPTION
Fixes #4584:

> Since the upgrade to jquery.datetimepicker v2.5.19 the widget is no longer being localized to the current language. That is, the month names and day abbreviations are being displayed in English regardless of the language being selected.

Analysis from @linuxsoftware (https://github.com/wagtail/wagtail/issues/4584#issue-329250209):

> Wagtail localization of datetimepicker used to work by creating a custom locale ('lang') for each widget and setting the widget to that locale using the lang option.
 
> Option 'lang' in datetimepicker for every widget was removed in https://github.com/xdan/datetimepicker/commit/9090478658a0a678fd0ea48ecfacb373e5ea7708
> Explained in this issue https://github.com/xdan/datetimepicker/issues/331 