### PR TITLE
Re-establish datetimepicker localisation. Fix #4584

### DIFF
--- a/wagtail/admin/static_src/wagtailadmin/js/page-editor.js
+++ b/wagtail/admin/static_src/wagtailadmin/js/page-editor.js
@@ -32,10 +32,6 @@ function initDateChooser(id, opts) {
             timepicker: false,
             scrollInput: false,
             format: 'Y-m-d',
-            i18n: {
-                lang: window.dateTimePickerTranslations
-            },
-            lang: 'lang',
             onGenerate: hideCurrent
         }, opts || {}));
     } else {
@@ -55,10 +51,6 @@ function initTimeChooser(id) {
             datepicker: false,
             scrollInput: false,
             format: 'H:i',
-            i18n: {
-                lang: window.dateTimePickerTranslations
-            },
-            lang: 'lang'
         });
     } else {
         $('#' + id).datetimepicker({
@@ -74,10 +66,6 @@ function initDateTimeChooser(id, opts) {
             closeOnDateSelect: true,
             format: 'Y-m-d H:i',
             scrollInput: false,
-            i18n: {
-                lang: window.dateTimePickerTranslations
-            },
-            lang: 'lang',
             onGenerate: hideCurrent
         }, opts || {}));
     } else {

--- a/wagtail/admin/templates/wagtailadmin/shared/datetimepicker_translations.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/datetimepicker_translations.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 
 <script>
-    window.dateTimePickerTranslations = {
+    $.fn.datetimepicker.defaults.i18n.wagtail_custom_locale = {
         months: [
             '{% trans "January" %}',
             '{% trans "February" %}',
@@ -17,6 +17,15 @@
             '{% trans "December" %}'
         ],
         dayOfWeek: [
+            '{% trans "Sunday" %}',
+            '{% trans "Monday" %}',
+            '{% trans "Tuesday" %}',
+            '{% trans "Wednesday" %}',
+            '{% trans "Thursday" %}',
+            '{% trans "Friday" %}',
+            '{% trans "Saturday" %}'
+        ],
+        dayOfWeekShort: [
             '{% trans "Sun" %}',
             '{% trans "Mon" %}',
             '{% trans "Tue" %}',
@@ -24,6 +33,7 @@
             '{% trans "Thu" %}',
             '{% trans "Fri" %}',
             '{% trans "Sat" %}'
-        ]
+        ],
     }
+    $.datetimepicker.setLocale('wagtail_custom_locale');
 </script>

--- a/wagtail/contrib/forms/templates/wagtailforms/index_submissions.html
+++ b/wagtail/contrib/forms/templates/wagtailforms/index_submissions.html
@@ -10,18 +10,10 @@
             $('#id_date_from').datetimepicker({
                 timepicker: false,
                 format: 'Y-m-d',
-                i18n: {
-                    lang: window.dateTimePickerTranslations
-                },
-                lang: 'lang'
             });
             $('#id_date_to').datetimepicker({
                 timepicker: false,
                 format: 'Y-m-d',
-                i18n: {
-                    lang: window.dateTimePickerTranslations
-                },
-                lang: 'lang'
             });
 
             var selectAllCheckbox = document.getElementById('select-all');


### PR DESCRIPTION
Fixes #4584:

> Since the upgrade to jquery.datetimepicker v2.5.19 the widget is no longer being localized to the current language. That is, the month names and day abbreviations are being displayed in English regardless of the language being selected.

Analysis from @linuxsoftware (https://github.com/wagtail/wagtail/issues/4584#issue-329250209):

> Wagtail localization of datetimepicker used to work by creating a custom locale ('lang') for each widget and setting the widget to that locale using the lang option.
 
> Option 'lang' in datetimepicker for every widget was removed in https://github.com/xdan/datetimepicker/commit/9090478658a0a678fd0ea48ecfacb373e5ea7708
> Explained in this issue https://github.com/xdan/datetimepicker/issues/331 

---

In this implementation, we remove the locale configuration on each instance of the widget and instead define it globally in `datetimepicker_translations.html`.

Tested in latest Chrome, Firefox, Safari macOS 10.13.

<img width="779" alt="wagtail-4675" src="https://user-images.githubusercontent.com/877585/42412628-7820315c-8218-11e8-9958-8d0c1fca3435.png">
