### PR TITLE
Revert "Update search query classes for RFC 25"

### DIFF
--- a/wagtail/contrib/postgres_search/backend.py
+++ b/wagtail/contrib/postgres_search/backend.py
@@ -12,9 +12,10 @@ from django.utils.encoding import force_text
 from wagtail.search.backends.base import (
     BaseSearchBackend, BaseSearchQueryCompiler, BaseSearchResults, FilterFieldError)
 from wagtail.search.index import RelatedFields, SearchField, get_indexed_models
-from wagtail.search.query import And, Boost, MatchAll, Not, Or, PlainText
+from wagtail.search.query import And, MatchAll, Not, Or, Prefix, SearchQueryShortcut, Term
 from wagtail.search.utils import ADD, AND, OR
 
+from .models import SearchAutocomplete as PostgresSearchAutocomplete
 from .models import IndexEntry
 from .utils import (
     get_content_type_pk, get_descendants_content_types_pks, get_postgresql_connections,
@@ -190,10 +191,6 @@ class Index:
 
 class PostgresSearchQueryCompiler(BaseSearchQueryCompiler):
     DEFAULT_OPERATOR = 'and'
-    OPERATORS = {
-        'and': AND,
-        'or': OR,
-    }
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -230,38 +227,36 @@ class PostgresSearchQueryCompiler(BaseSearchQueryCompiler):
                 return self.get_search_field(sub_field_name, field.fields)
 
     # TODO: Find a way to use the term boosting.
-    def check_boost(self, query, boost=1.0):
-        if query.boost * boost != 1.0:
+    def check_boost(self, query):
+        if query.boost != 1:
             warn('PostgreSQL search backend '
                  'does not support term boosting for now.')
 
-    def build_database_query(self, query=None, config=None, boost=1.0):
+    def build_database_query(self, query=None, config=None):
         if query is None:
             query = self.query
 
-        if isinstance(query, PlainText):
-            self.check_boost(query, boost=boost)
-
-            operator = self.OPERATORS[query.operator]
-
-            return operator([
-                PostgresSearchQuery(unidecode(term), config=config)
-                for term in query.query_string.split()
-            ])
-        if isinstance(query, Boost):
-            boost *= query.boost
-            return self.build_database_query(query.subquery, config, boost=boost)
+        if isinstance(query, SearchQueryShortcut):
+            return self.build_database_query(query.get_equivalent(), config)
+        if isinstance(query, Prefix):
+            self.check_boost(query)
+            self.is_autocomplete = True
+            return PostgresSearchAutocomplete(unidecode(query.prefix),
+                                              config=config)
+        if isinstance(query, Term):
+            self.check_boost(query)
+            return PostgresSearchQuery(unidecode(query.term), config=config)
         if isinstance(query, Not):
-            return ~self.build_database_query(query.subquery, config, boost=boost)
+            return ~self.build_database_query(query.subquery, config)
         if isinstance(query, And):
-            return AND(self.build_database_query(subquery, config, boost=boost)
+            return AND(self.build_database_query(subquery, config)
                        for subquery in query.subqueries)
         if isinstance(query, Or):
-            return OR(self.build_database_query(subquery, config, boost=boost)
+            return OR(self.build_database_query(subquery, config)
                       for subquery in query.subqueries)
         raise NotImplementedError(
             '`%s` is not supported by the PostgreSQL search backend.'
-            % query.__class__.__name__)
+            % self.query.__class__.__name__)
 
     def search(self, config, start, stop, score_field=None):
         # TODO: Handle MatchAll nested inside other search query classes.

--- a/wagtail/contrib/postgres_search/tests/test_backend.py
+++ b/wagtail/contrib/postgres_search/tests/test_backend.py
@@ -1,5 +1,3 @@
-import unittest
-
 from django.test import TestCase
 
 from wagtail.search.tests.test_backends import BackendTests
@@ -37,8 +35,3 @@ class TestPostgresSearchBackend(BackendTests, TestCase):
                              [(6, 'A'), (4, 'B'), (2, 'C'), (0, 'D')])
         self.assertListEqual(determine_boosts_weights([-2, -1, 0, 1, 2, 3, 4]),
                              [(4, 'A'), (2, 'B'), (0, 'C'), (-2, 'D')])
-
-    # Doesn't support Boost() query class
-    @unittest.expectedFailure
-    def test_boost(self):
-        super().test_boost()

--- a/wagtail/search/query.py
+++ b/wagtail/search/query.py
@@ -16,14 +16,123 @@ class SearchQuery:
     def __invert__(self):
         return Not(self)
 
+    def apply(self, func):
+        raise NotImplementedError
+
+    def clone(self):
+        return self.apply(lambda o: o)
+
+    def get_children(self):
+        return ()
+
+    @property
+    def children(self):
+        return list(self.get_children())
+
+    @property
+    def child(self):
+        children = self.children
+        if len(children) != 1:
+            raise IndexError('`%s` object has %d children, not a single child.'
+                             % self.__class__.__name__, len(children))
+        return children[0]
+
+
+class SearchQueryOperator(SearchQuery):
+    pass
+
+
+class MultiOperandsSearchQueryOperator(SearchQueryOperator):
+    def __init__(self, subqueries):
+        self.subqueries = subqueries
+
+    def apply(self, func):
+        return func(self.__class__(
+            [subquery.apply(func) for subquery in self.subqueries]))
+
+    def get_children(self):
+        yield from self.subqueries
+
+
+class SearchQueryShortcut(SearchQuery):
+    def get_equivalent(self):
+        raise NotImplementedError
+
+    def get_children(self):
+        yield self.get_equivalent()
+
+#
+# Operators
+#
+
+
+class And(MultiOperandsSearchQueryOperator):
+    pass
+
+
+class Or(MultiOperandsSearchQueryOperator):
+    pass
+
+
+class Not(SearchQueryOperator):
+    def __init__(self, subquery: SearchQuery):
+        self.subquery = subquery
+
+    def apply(self, func):
+        return func(self.__class__(self.subquery.apply(func)))
+
+    def get_children(self):
+        yield self.subquery
+
 
 #
 # Basic query classes
 #
 
 
-class PlainText(SearchQuery):
-    OPERATORS = ['and', 'or']
+class MatchAll(SearchQuery):
+    def apply(self, func):
+        return self.__class__()
+
+
+class Term(SearchQuery):
+    def __init__(self, term: str, boost: float = 1):
+        self.term = term
+        self.boost = boost
+
+    def apply(self, func):
+        return func(self.__class__(self.term, self.boost))
+
+
+class Prefix(SearchQuery):
+    def __init__(self, prefix: str, boost: float = 1):
+        self.prefix = prefix
+        self.boost = boost
+
+    def apply(self, func):
+        return func(self.__class__(self.prefix, self.boost))
+
+
+class Fuzzy(SearchQuery):
+    def __init__(self, term: str, max_distance: float = 3, boost: float = 1):
+        self.term = term
+        self.max_distance = max_distance
+        self.boost = boost
+
+    def apply(self, func):
+        return func(self.__class__(self.term, self.max_distance, self.boost))
+
+
+#
+# Shortcut query classes
+#
+
+
+class PlainText(SearchQueryShortcut):
+    OPERATORS = {
+        'and': And,
+        'or': Or,
+    }
     DEFAULT_OPERATOR = 'and'
 
     def __init__(self, query_string: str, operator: str = DEFAULT_OPERATOR,
@@ -34,35 +143,52 @@ class PlainText(SearchQuery):
             raise ValueError("`operator` must be either 'or' or 'and'.")
         self.boost = boost
 
+    def apply(self, func):
+        return func(self.__class__(self.query_string, self.operator,
+                                   self.boost))
 
-class MatchAll(SearchQuery):
-    pass
+    def get_equivalent(self):
+        return self.OPERATORS[self.operator]([
+            Term(term, boost=self.boost)
+            for term in self.query_string.split()])
 
 
-class Boost(SearchQuery):
+class Filter(SearchQueryShortcut):
+    def __init__(self, query: SearchQuery,
+                 include: SearchQuery = None, exclude: SearchQuery = None):
+        self.query = query
+        self.include = include
+        self.exclude = exclude
+
+    def apply(self, func):
+        return func(self.__class__(
+            self.query.apply(func),
+            self.include.apply(func), self.exclude.apply(func)))
+
+    def get_equivalent(self):
+        query = self.query
+        if self.include is not None:
+            query &= Boost(self.include, 0)
+        if self.exclude is not None:
+            query &= Boost(~self.exclude, 0)
+        return query
+
+
+class Boost(SearchQueryShortcut):
     def __init__(self, subquery: SearchQuery, boost: float):
         self.subquery = subquery
         self.boost = boost
 
+    def apply(self, func):
+        return func(self.__class__(self.subquery.apply(func), self.boost))
 
-#
-# Combinators
-#
+    def get_equivalent(self):
+        def boost_child(child):
+            if isinstance(child, (PlainText, Fuzzy, Prefix, Term)):
+                child.boost *= self.boost
+            return child
 
-
-class And(SearchQuery):
-    def __init__(self, subqueries):
-        self.subqueries = subqueries
-
-
-class Or(SearchQuery):
-    def __init__(self, subqueries):
-        self.subqueries = subqueries
-
-
-class Not(SearchQuery):
-    def __init__(self, subquery: SearchQuery):
-        self.subquery = subquery
+        return self.subquery.apply(boost_child)
 
 
 MATCH_ALL = MatchAll()

--- a/wagtail/search/tests/test_backends.py
+++ b/wagtail/search/tests/test_backends.py
@@ -15,7 +15,7 @@ from wagtail.search.backends import (
     InvalidSearchBackendError, get_search_backend, get_search_backends)
 from wagtail.search.backends.base import FieldError, FilterFieldError
 from wagtail.search.backends.db import DatabaseSearchBackend
-from wagtail.search.query import MATCH_ALL, And, Boost, Not, Or, PlainText
+from wagtail.search.query import MATCH_ALL, And, Boost, Filter, Not, Or, PlainText, Prefix, Term
 from wagtail.tests.search import models
 from wagtail.tests.utils import WagtailTestUtils
 
@@ -480,6 +480,102 @@ class BackendTests(WagtailTestUtils):
             "The Fellowship of the Ring"  # If this item doesn't appear, "Foundation" is still in the index
         ])
 
+    #
+    # Basic query classes
+    #
+
+    def test_match_all(self):
+        results = self.backend.search(MATCH_ALL, models.Book.objects.all())
+        self.assertEqual(len(results), 13)
+
+    def test_term(self):
+        results = self.backend.search(Term('javascript'),
+                                      models.Book.objects.all())
+
+        self.assertSetEqual({r.title for r in results},
+                            {'JavaScript: The Definitive Guide',
+                             'JavaScript: The good parts'})
+
+    def test_incomplete_term(self):
+        results = self.backend.search(Term('pro'),
+                                      models.Book.objects.all())
+
+        self.assertSetEqual({r.title for r in results}, set())
+
+    def test_and(self):
+        results = self.backend.search(And([Term('javascript'),
+                                           Term('definitive')]),
+                                      models.Book.objects.all())
+        self.assertSetEqual({r.title for r in results},
+                            {'JavaScript: The Definitive Guide'})
+
+        results = self.backend.search(Term('javascript') & Term('definitive'),
+                                      models.Book.objects.all())
+        self.assertSetEqual({r.title for r in results},
+                            {'JavaScript: The Definitive Guide'})
+
+    def test_or(self):
+        results = self.backend.search(Or([Term('hobbit'), Term('towers')]),
+                                      models.Book.objects.all())
+        self.assertSetEqual({r.title for r in results},
+                            {'The Hobbit', 'The Two Towers'})
+
+        results = self.backend.search(Term('hobbit') | Term('towers'),
+                                      models.Book.objects.all())
+        self.assertSetEqual({r.title for r in results},
+                            {'The Hobbit', 'The Two Towers'})
+
+    def test_not(self):
+        all_other_titles = {
+            'A Clash of Kings',
+            'A Game of Thrones',
+            'A Storm of Swords',
+            'Foundation',
+            'Learning Python',
+            'The Hobbit',
+            'The Two Towers',
+            'The Fellowship of the Ring',
+            'The Return of the King',
+            'The Rust Programming Language',
+            'Two Scoops of Django 1.11',
+        }
+
+        results = self.backend.search(Not(Term('javascript')),
+                                      models.Book.objects.all())
+        self.assertSetEqual({r.title for r in results}, all_other_titles)
+
+        results = self.backend.search(~Term('javascript'),
+                                      models.Book.objects.all())
+        self.assertSetEqual({r.title for r in results}, all_other_titles)
+
+    def test_operators_combination(self):
+        results = self.backend.search(
+            ((Term('javascript') & ~Term('definitive')) |
+             Term('python') | Term('rust')) |
+            Term('two'),
+            models.Book.objects.all())
+        self.assertSetEqual({r.title for r in results},
+                            {'JavaScript: The good parts',
+                             'Learning Python',
+                             'The Two Towers',
+                             'The Rust Programming Language',
+                             'Two Scoops of Django 1.11'})
+
+    def test_prefix_single_word(self):
+        results = self.backend.search(Prefix('pro'), models.Book.objects.all())
+        self.assertSetEqual({r.title for r in results},
+                            {'The Rust Programming Language'})
+
+    def test_prefix_multiple_words(self):
+        results = self.backend.search(Prefix('rust pro'),
+                                      models.Book.objects.all())
+        self.assertSetEqual({r.title for r in results},
+                            {'The Rust Programming Language'})
+
+    #
+    # Shortcut query classes
+    #
+
     def test_plain_text_single_word(self):
         results = self.backend.search(PlainText('Javascript'),
                                       models.Book.objects.all())
@@ -538,85 +634,95 @@ class BackendTests(WagtailTestUtils):
             self.backend.search('Guide', models.Book.objects.all(),
                                 operator='xor')
 
-    def test_boost(self):
-        results = self.backend.search(PlainText('JavaScript Definitive') | Boost(PlainText('Learning Python'), 2.0), models.Book.objects.all())
+    def test_filter_equivalent(self):
+        filter = Filter(Term('javascript'))
+        term = filter.child
+        self.assertIsInstance(term, Term)
+        self.assertEqual(term.term, 'javascript')
 
-        # Both python and JavaScript should be returned with Python at the top
-        self.assertEqual([r.title for r in results], [
-            "Learning Python",
-            "JavaScript: The Definitive Guide",
-        ])
+        filter = Filter(Term('javascript'), include=Term('definitive'))
+        and_obj = filter.child
+        self.assertIsInstance(and_obj, And)
+        javascript = and_obj.children[0]
+        self.assertIsInstance(javascript, Term)
+        self.assertEqual(javascript.term, 'javascript')
+        boost_obj = and_obj.children[1]
+        self.assertIsInstance(boost_obj, Boost)
+        self.assertEqual(boost_obj.boost, 0)
+        definitive = boost_obj.child
+        self.assertIsInstance(definitive, Term)
+        self.assertEqual(definitive.term, 'definitive')
 
-        results = self.backend.search(PlainText('JavaScript Definitive') | Boost(PlainText('Learning Python'), 0.5), models.Book.objects.all())
+        filter = Filter(Term('javascript'),
+                        include=Term('definitive'), exclude=Term('guide'))
+        and_obj1 = filter.child
+        self.assertIsInstance(and_obj1, And)
+        and_obj2 = and_obj1.children[0]
+        javascript = and_obj2.children[0]
+        self.assertIsInstance(javascript, Term)
+        self.assertEqual(javascript.term, 'javascript')
+        boost_obj = and_obj2.children[1]
+        self.assertIsInstance(boost_obj, Boost)
+        self.assertEqual(boost_obj.boost, 0)
+        definitive = boost_obj.child
+        self.assertIsInstance(definitive, Term)
+        self.assertEqual(definitive.term, 'definitive')
+        boost_obj = and_obj1.children[1]
+        self.assertIsInstance(boost_obj, Boost)
+        self.assertEqual(boost_obj.boost, 0)
+        not_obj = boost_obj.child
+        self.assertIsInstance(not_obj, Not)
+        guide = not_obj.child
+        self.assertEqual(guide.term, 'guide')
 
-        # Now they should be swapped
-        self.assertEqual([r.title for r in results], [
-            "JavaScript: The Definitive Guide",
-            "Learning Python",
-        ])
+    def test_filter_query(self):
+        results = self.backend.search(Filter(Term('javascript')),
+                                      models.Book.objects.all())
+        self.assertSetEqual({r.title for r in results},
+                            {'JavaScript: The Definitive Guide',
+                             'JavaScript: The good parts'})
 
-    def test_match_all(self):
-        results = self.backend.search(MATCH_ALL, models.Book.objects.all())
-        self.assertEqual(len(results), 13)
-
-    def test_and(self):
-        results = self.backend.search(And([PlainText('javascript'),
-                                           PlainText('definitive')]),
+        results = self.backend.search(Filter(Term('javascript'),
+                                             include=Term('definitive')),
                                       models.Book.objects.all())
         self.assertSetEqual({r.title for r in results},
                             {'JavaScript: The Definitive Guide'})
 
-        results = self.backend.search(PlainText('javascript') & PlainText('definitive'),
+        results = self.backend.search(Filter(Term('javascript'),
+                                             include=Term('definitive'),
+                                             exclude=Term('guide')),
                                       models.Book.objects.all())
-        self.assertSetEqual({r.title for r in results},
-                            {'JavaScript: The Definitive Guide'})
+        self.assertSetEqual({r.title for r in results}, set())
 
-    def test_or(self):
-        results = self.backend.search(Or([PlainText('hobbit'), PlainText('towers')]),
-                                      models.Book.objects.all())
-        self.assertSetEqual({r.title for r in results},
-                            {'The Hobbit', 'The Two Towers'})
+    def test_boost_equivalent(self):
+        boost = Boost(Term('guide'), 5)
+        equivalent = boost.children[0]
+        self.assertIsInstance(equivalent, Term)
+        self.assertAlmostEqual(equivalent.boost, 5)
 
-        results = self.backend.search(PlainText('hobbit') | PlainText('towers'),
-                                      models.Book.objects.all())
-        self.assertSetEqual({r.title for r in results},
-                            {'The Hobbit', 'The Two Towers'})
+        boost = Boost(Term('guide', boost=0.5), 5)
+        equivalent = boost.children[0]
+        self.assertIsInstance(equivalent, Term)
+        self.assertAlmostEqual(equivalent.boost, 2.5)
 
-    def test_not(self):
-        all_other_titles = {
-            'A Clash of Kings',
-            'A Game of Thrones',
-            'A Storm of Swords',
-            'Foundation',
-            'Learning Python',
-            'The Hobbit',
-            'The Two Towers',
-            'The Fellowship of the Ring',
-            'The Return of the King',
-            'The Rust Programming Language',
-            'Two Scoops of Django 1.11',
-        }
+        boost = Boost(Boost(Term('guide', 0.1), 3), 5)
+        sub_boost = boost.children[0]
+        self.assertIsInstance(sub_boost, Boost)
+        sub_boost = sub_boost.children[0]
+        self.assertIsInstance(sub_boost, Term)
+        self.assertAlmostEqual(sub_boost.boost, 1.5)
 
-        results = self.backend.search(Not(PlainText('javascript')),
-                                      models.Book.objects.all())
-        self.assertSetEqual({r.title for r in results}, all_other_titles)
-
-        results = self.backend.search(~PlainText('javascript'),
-                                      models.Book.objects.all())
-        self.assertSetEqual({r.title for r in results}, all_other_titles)
-
-    def test_operators_combination(self):
-        results = self.backend.search(
-            ((PlainText('javascript') & ~PlainText('definitive')) |
-             PlainText('python') | PlainText('rust')) |
-            PlainText('two'),
-            models.Book.objects.all())
-        self.assertSetEqual({r.title for r in results},
-                            {'JavaScript: The good parts',
-                             'Learning Python',
-                             'The Two Towers',
-                             'The Rust Programming Language',
-                             'Two Scoops of Django 1.11'})
+        boost = Boost(And([Boost(Term('guide', 0.1), 3), Term('two', 2)]), 5)
+        and_obj = boost.children[0]
+        self.assertIsInstance(and_obj, And)
+        sub_boost = and_obj.children[0]
+        self.assertIsInstance(sub_boost, Boost)
+        guide = sub_boost.children[0]
+        self.assertIsInstance(guide, Term)
+        self.assertAlmostEqual(guide.boost, 1.5)
+        two = and_obj.children[1]
+        self.assertIsInstance(two, Term)
+        self.assertAlmostEqual(two.boost, 10)
 
 
 @override_settings(

--- a/wagtail/search/tests/test_db_backend.py
+++ b/wagtail/search/tests/test_db_backend.py
@@ -57,8 +57,3 @@ class TestDBBackend(BackendTests, TestCase):
     @unittest.expectedFailure
     def test_incomplete_plain_text(self):
         super().test_incomplete_plain_text()
-
-    # Database backend doesn't support Boost() query class
-    @unittest.expectedFailure
-    def test_boost(self):
-        super().test_boost()


### PR DESCRIPTION
Reverts wagtail/wagtail#4593. This broke various Elasticsearch tests (in addition to `test_facet_tags` which was previously broken from #4508) - will try rebasing these commits once we have a working master again.