### PR TITLE
Reapply #4593 (Update search query classes for RFC 25)

### DIFF
--- a/wagtail/contrib/postgres_search/backend.py
+++ b/wagtail/contrib/postgres_search/backend.py
@@ -189,6 +189,10 @@ class Index:
 
 class PostgresSearchQueryCompiler(BaseSearchQueryCompiler):
     DEFAULT_OPERATOR = 'and'
+    OPERATORS = {
+        'and': AND,
+        'or': OR,
+    }
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -237,10 +241,7 @@ class PostgresSearchQueryCompiler(BaseSearchQueryCompiler):
         if isinstance(query, PlainText):
             self.check_boost(query, boost=boost)
 
-            operator = {
-                'and': AND,
-                'or': OR,
-            }[query.operator]
+            operator = self.OPERATORS[query.operator]
 
             return operator([
                 PostgresSearchQuery(unidecode(term), config=config)

--- a/wagtail/contrib/postgres_search/backend.py
+++ b/wagtail/contrib/postgres_search/backend.py
@@ -12,8 +12,7 @@ from django.utils.encoding import force_text
 from wagtail.search.backends.base import (
     BaseSearchBackend, BaseSearchQueryCompiler, BaseSearchResults, FilterFieldError)
 from wagtail.search.index import RelatedFields, SearchField, get_indexed_models
-from wagtail.search.query import (
-    And, Boost, MatchAll, Not, Or, PlainText, Prefix, SearchQueryShortcut, Term)
+from wagtail.search.query import And, Boost, MatchAll, Not, Or, PlainText, Prefix, Term
 from wagtail.search.utils import ADD, AND, OR
 
 from .models import SearchAutocomplete as PostgresSearchAutocomplete
@@ -249,8 +248,6 @@ class PostgresSearchQueryCompiler(BaseSearchQueryCompiler):
         if isinstance(query, Boost):
             boost *= query.boost
             return self.build_database_query(query.subquery, config, boost=boost)
-        if isinstance(query, SearchQueryShortcut):
-            return self.build_database_query(query.get_equivalent(), config, boost=boost)
         if isinstance(query, Prefix):
             self.check_boost(query, boost=boost)
             self.is_autocomplete = True

--- a/wagtail/contrib/postgres_search/backend.py
+++ b/wagtail/contrib/postgres_search/backend.py
@@ -13,7 +13,7 @@ from wagtail.search.backends.base import (
     BaseSearchBackend, BaseSearchQueryCompiler, BaseSearchResults, FilterFieldError)
 from wagtail.search.index import RelatedFields, SearchField, get_indexed_models
 from wagtail.search.query import (
-    And, MatchAll, Not, Or, PlainText, Prefix, SearchQueryShortcut, Term)
+    And, Boost, MatchAll, Not, Or, PlainText, Prefix, SearchQueryShortcut, Term)
 from wagtail.search.utils import ADD, AND, OR
 
 from .models import SearchAutocomplete as PostgresSearchAutocomplete
@@ -227,12 +227,12 @@ class PostgresSearchQueryCompiler(BaseSearchQueryCompiler):
                 return self.get_search_field(sub_field_name, field.fields)
 
     # TODO: Find a way to use the term boosting.
-    def check_boost(self, query):
-        if query.boost != 1:
+    def check_boost(self, query, boost=1.0):
+        if query.boost * boost != 1.0:
             warn('PostgreSQL search backend '
                  'does not support term boosting for now.')
 
-    def build_database_query(self, query=None, config=None):
+    def build_database_query(self, query=None, config=None, boost=1.0):
         if query is None:
             query = self.query
 
@@ -245,28 +245,31 @@ class PostgresSearchQueryCompiler(BaseSearchQueryCompiler):
                 Term(term, boost=query.boost)
                 for term in query.query_string.split()
             ])
-            return self.build_database_query(q, config)
+            return self.build_database_query(q, config, boost=boost)
+        if isinstance(query, Boost):
+            boost *= query.boost
+            return self.build_database_query(query.subquery, config, boost=boost)
         if isinstance(query, SearchQueryShortcut):
-            return self.build_database_query(query.get_equivalent(), config)
+            return self.build_database_query(query.get_equivalent(), config, boost=boost)
         if isinstance(query, Prefix):
-            self.check_boost(query)
+            self.check_boost(query, boost=boost)
             self.is_autocomplete = True
             return PostgresSearchAutocomplete(unidecode(query.prefix),
                                               config=config)
         if isinstance(query, Term):
-            self.check_boost(query)
+            self.check_boost(query, boost=boost)
             return PostgresSearchQuery(unidecode(query.term), config=config)
         if isinstance(query, Not):
-            return ~self.build_database_query(query.subquery, config)
+            return ~self.build_database_query(query.subquery, config, boost=boost)
         if isinstance(query, And):
-            return AND(self.build_database_query(subquery, config)
+            return AND(self.build_database_query(subquery, config, boost=boost)
                        for subquery in query.subqueries)
         if isinstance(query, Or):
-            return OR(self.build_database_query(subquery, config)
+            return OR(self.build_database_query(subquery, config, boost=boost)
                       for subquery in query.subqueries)
         raise NotImplementedError(
             '`%s` is not supported by the PostgreSQL search backend.'
-            % self.query.__class__.__name__)
+            % query.__class__.__name__)
 
     def search(self, config, start, stop, score_field=None):
         # TODO: Handle MatchAll nested inside other search query classes.

--- a/wagtail/contrib/postgres_search/tests/test_backend.py
+++ b/wagtail/contrib/postgres_search/tests/test_backend.py
@@ -42,3 +42,8 @@ class TestPostgresSearchBackend(BackendTests, TestCase):
     @unittest.expectedFailure
     def test_autocomplete(self):
         super().test_autocomplete()
+
+    # Doesn't support Boost() query class
+    @unittest.expectedFailure
+    def test_boost(self):
+        super().test_boost()

--- a/wagtail/search/backends/db.py
+++ b/wagtail/search/backends/db.py
@@ -13,6 +13,10 @@ from wagtail.search.utils import AND, OR
 
 class DatabaseSearchQueryCompiler(BaseSearchQueryCompiler):
     DEFAULT_OPERATOR = 'and'
+    OPERATORS = {
+        'and': AND,
+        'or': OR,
+    }
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -64,10 +68,7 @@ class DatabaseSearchQueryCompiler(BaseSearchQueryCompiler):
         if isinstance(query, PlainText):
             self.check_boost(query, boost=boost)
 
-            operator = {
-                'and': AND,
-                'or': OR,
-            }[query.operator]
+            operator = self.OPERATORS[query.operator]
 
             return operator([
                 self.build_single_term_filter(term)

--- a/wagtail/search/backends/db.py
+++ b/wagtail/search/backends/db.py
@@ -7,8 +7,7 @@ from django.db.models.expressions import Value
 
 from wagtail.search.backends.base import (
     BaseSearchBackend, BaseSearchQueryCompiler, BaseSearchResults, FilterFieldError)
-from wagtail.search.query import (
-    And, Boost, MatchAll, Not, Or, PlainText, Prefix, SearchQueryShortcut, Term)
+from wagtail.search.query import And, Boost, MatchAll, Not, Or, PlainText, Prefix, Term
 from wagtail.search.utils import AND, OR
 
 
@@ -80,8 +79,6 @@ class DatabaseSearchQueryCompiler(BaseSearchQueryCompiler):
         if isinstance(self.query, MatchAll):
             return models.Q()
 
-        if isinstance(query, SearchQueryShortcut):
-            return self.build_database_filter(query.get_equivalent(), boost=boost)
         if isinstance(query, Term):
             self.check_boost(query)
             return self.build_single_term_filter(query.term)

--- a/wagtail/search/backends/db.py
+++ b/wagtail/search/backends/db.py
@@ -7,7 +7,7 @@ from django.db.models.expressions import Value
 
 from wagtail.search.backends.base import (
     BaseSearchBackend, BaseSearchQueryCompiler, BaseSearchResults, FilterFieldError)
-from wagtail.search.query import And, Boost, MatchAll, Not, Or, PlainText, Prefix, Term
+from wagtail.search.query import And, Boost, MatchAll, Not, Or, PlainText
 from wagtail.search.utils import AND, OR
 
 
@@ -62,15 +62,17 @@ class DatabaseSearchQueryCompiler(BaseSearchQueryCompiler):
             query = self.query
 
         if isinstance(query, PlainText):
-            operator_class = {
-                'and': And,
-                'or': Or,
+            self.check_boost(query, boost=boost)
+
+            operator = {
+                'and': AND,
+                'or': OR,
             }[query.operator]
-            q = operator_class([
-                Term(term, boost=query.boost)
+
+            return operator([
+                self.build_single_term_filter(term)
                 for term in query.query_string.split()
             ])
-            return self.build_database_filter(q, boost=boost)
 
         if isinstance(query, Boost):
             boost *= query.boost
@@ -79,12 +81,6 @@ class DatabaseSearchQueryCompiler(BaseSearchQueryCompiler):
         if isinstance(self.query, MatchAll):
             return models.Q()
 
-        if isinstance(query, Term):
-            self.check_boost(query)
-            return self.build_single_term_filter(query.term)
-        if isinstance(query, Prefix):
-            self.check_boost(query)
-            return self.build_single_term_filter(query.prefix)
         if isinstance(query, Not):
             return ~self.build_database_filter(query.subquery, boost=boost)
         if isinstance(query, And):

--- a/wagtail/search/backends/elasticsearch2.py
+++ b/wagtail/search/backends/elasticsearch2.py
@@ -15,7 +15,7 @@ from wagtail.search.backends.base import (
     BaseSearchBackend, BaseSearchQueryCompiler, BaseSearchResults, FilterFieldError)
 from wagtail.search.index import (
     AutocompleteField, FilterField, Indexed, RelatedFields, SearchField, class_is_indexed)
-from wagtail.search.query import And, Boost, Fuzzy, MatchAll, Not, Or, PlainText, Prefix, Term
+from wagtail.search.query import And, Boost, MatchAll, Not, Or, PlainText
 from wagtail.utils.deprecation import RemovedInWagtail22Warning
 from wagtail.utils.utils import deep_update
 
@@ -393,20 +393,6 @@ class Elasticsearch2SearchQueryCompiler(BaseSearchQueryCompiler):
 
             return filter_out
 
-    def _compile_term_query(self, query_type, value, field, boost=1.0, **extra):
-        term_query = {
-            'value': value,
-        }
-
-        if boost != 1.0:
-            term_query['boost'] = boost
-
-        return {
-            query_type: {
-                field: term_query,
-            }
-        }
-
     def _compile_plaintext_query(self, query, fields, boost=1.0):
         match_query = {
             'query': query.query_string
@@ -439,15 +425,6 @@ class Elasticsearch2SearchQueryCompiler(BaseSearchQueryCompiler):
                 match_all_query['boost'] = boost
 
             return {'match_all': match_all_query}
-
-        elif isinstance(query, Term):
-            return self._compile_term_query('term', query.term, field, query.boost * boost)
-
-        elif isinstance(query, Prefix):
-            return self._compile_term_query('prefix', query.prefix, field, query.boost * boost)
-
-        elif isinstance(query, Fuzzy):
-            return self._compile_term_query('fuzzy', query.term, field, query.boost * boost, fuzziness=query.max_distance)
 
         elif isinstance(query, And):
             return {

--- a/wagtail/search/backends/elasticsearch2.py
+++ b/wagtail/search/backends/elasticsearch2.py
@@ -15,8 +15,7 @@ from wagtail.search.backends.base import (
     BaseSearchBackend, BaseSearchQueryCompiler, BaseSearchResults, FilterFieldError)
 from wagtail.search.index import (
     AutocompleteField, FilterField, Indexed, RelatedFields, SearchField, class_is_indexed)
-from wagtail.search.query import (
-    And, Boost, Filter, Fuzzy, MatchAll, Not, Or, PlainText, Prefix, Term)
+from wagtail.search.query import And, Boost, Fuzzy, MatchAll, Not, Or, PlainText, Prefix, Term
 from wagtail.utils.deprecation import RemovedInWagtail22Warning
 from wagtail.utils.utils import deep_update
 
@@ -480,20 +479,6 @@ class Elasticsearch2SearchQueryCompiler(BaseSearchQueryCompiler):
         elif isinstance(query, PlainText):
             return self._compile_plaintext_query(self.query, [field], boost)
 
-        elif isinstance(query, Filter):
-            bool_query = {
-                'must': self._compile_query(query.query, field, boost),
-            }
-
-            if query.include:
-                bool_query['filter'] = self._compile_query(query.include, field, 0.0)
-
-            if query.exclude:
-                bool_query['mustNot'] = self._compile_query(query.exclude, field, 0.0)
-
-            return {
-                'bool': bool_query,
-            }
 
         elif isinstance(query, Boost):
             return self._compile_query(query.subquery, field, boost * query.boost)

--- a/wagtail/search/backends/elasticsearch2.py
+++ b/wagtail/search/backends/elasticsearch2.py
@@ -477,7 +477,7 @@ class Elasticsearch2SearchQueryCompiler(BaseSearchQueryCompiler):
             }
 
         elif isinstance(query, PlainText):
-            return self._compile_plaintext_query(self.query, [field], boost)
+            return self._compile_plaintext_query(query, [field], boost)
 
 
         elif isinstance(query, Boost):

--- a/wagtail/search/query.py
+++ b/wagtail/search/query.py
@@ -153,27 +153,6 @@ class PlainText(SearchQueryShortcut):
             for term in self.query_string.split()])
 
 
-class Filter(SearchQueryShortcut):
-    def __init__(self, query: SearchQuery,
-                 include: SearchQuery = None, exclude: SearchQuery = None):
-        self.query = query
-        self.include = include
-        self.exclude = exclude
-
-    def apply(self, func):
-        return func(self.__class__(
-            self.query.apply(func),
-            self.include.apply(func), self.exclude.apply(func)))
-
-    def get_equivalent(self):
-        query = self.query
-        if self.include is not None:
-            query &= Boost(self.include, 0)
-        if self.exclude is not None:
-            query &= Boost(~self.exclude, 0)
-        return query
-
-
 class Boost(SearchQueryShortcut):
     def __init__(self, subquery: SearchQuery, boost: float):
         self.subquery = subquery

--- a/wagtail/search/query.py
+++ b/wagtail/search/query.py
@@ -38,46 +38,6 @@ class SearchQuery:
         return children[0]
 
 
-class SearchQueryOperator(SearchQuery):
-    pass
-
-
-class MultiOperandsSearchQueryOperator(SearchQueryOperator):
-    def __init__(self, subqueries):
-        self.subqueries = subqueries
-
-    def apply(self, func):
-        return func(self.__class__(
-            [subquery.apply(func) for subquery in self.subqueries]))
-
-    def get_children(self):
-        yield from self.subqueries
-
-
-#
-# Operators
-#
-
-
-class And(MultiOperandsSearchQueryOperator):
-    pass
-
-
-class Or(MultiOperandsSearchQueryOperator):
-    pass
-
-
-class Not(SearchQueryOperator):
-    def __init__(self, subquery: SearchQuery):
-        self.subquery = subquery
-
-    def apply(self, func):
-        return func(self.__class__(self.subquery.apply(func)))
-
-    def get_children(self):
-        yield self.subquery
-
-
 #
 # Basic query classes
 #
@@ -112,6 +72,46 @@ class Boost(SearchQuery):
 
     def apply(self, func):
         return func(self.__class__(self.subquery.apply(func), self.boost))
+
+
+#
+# Operators
+#
+
+
+class SearchQueryOperator(SearchQuery):
+    pass
+
+
+class MultiOperandsSearchQueryOperator(SearchQueryOperator):
+    def __init__(self, subqueries):
+        self.subqueries = subqueries
+
+    def apply(self, func):
+        return func(self.__class__(
+            [subquery.apply(func) for subquery in self.subqueries]))
+
+    def get_children(self):
+        yield from self.subqueries
+
+
+class And(MultiOperandsSearchQueryOperator):
+    pass
+
+
+class Or(MultiOperandsSearchQueryOperator):
+    pass
+
+
+class Not(SearchQueryOperator):
+    def __init__(self, subquery: SearchQuery):
+        self.subquery = subquery
+
+    def apply(self, func):
+        return func(self.__class__(self.subquery.apply(func)))
+
+    def get_children(self):
+        yield self.subquery
 
 
 MATCH_ALL = MatchAll()

--- a/wagtail/search/query.py
+++ b/wagtail/search/query.py
@@ -90,6 +90,23 @@ class Not(SearchQueryOperator):
 #
 
 
+class PlainText(SearchQuery):
+    OPERATORS = ['and', 'or']
+    DEFAULT_OPERATOR = 'and'
+
+    def __init__(self, query_string: str, operator: str = DEFAULT_OPERATOR,
+                 boost: float = 1):
+        self.query_string = query_string
+        self.operator = operator.lower()
+        if self.operator not in self.OPERATORS:
+            raise ValueError("`operator` must be either 'or' or 'and'.")
+        self.boost = boost
+
+    def apply(self, func):
+        return func(self.__class__(self.query_string, self.operator,
+                                   self.boost))
+
+
 class MatchAll(SearchQuery):
     def apply(self, func):
         return self.__class__()
@@ -126,31 +143,6 @@ class Fuzzy(SearchQuery):
 #
 # Shortcut query classes
 #
-
-
-class PlainText(SearchQueryShortcut):
-    OPERATORS = {
-        'and': And,
-        'or': Or,
-    }
-    DEFAULT_OPERATOR = 'and'
-
-    def __init__(self, query_string: str, operator: str = DEFAULT_OPERATOR,
-                 boost: float = 1):
-        self.query_string = query_string
-        self.operator = operator.lower()
-        if self.operator not in self.OPERATORS:
-            raise ValueError("`operator` must be either 'or' or 'and'.")
-        self.boost = boost
-
-    def apply(self, func):
-        return func(self.__class__(self.query_string, self.operator,
-                                   self.boost))
-
-    def get_equivalent(self):
-        return self.OPERATORS[self.operator]([
-            Term(term, boost=self.boost)
-            for term in self.query_string.split()])
 
 
 class Boost(SearchQueryShortcut):

--- a/wagtail/search/query.py
+++ b/wagtail/search/query.py
@@ -54,13 +54,6 @@ class MultiOperandsSearchQueryOperator(SearchQueryOperator):
         yield from self.subqueries
 
 
-class SearchQueryShortcut(SearchQuery):
-    def get_equivalent(self):
-        raise NotImplementedError
-
-    def get_children(self):
-        yield self.get_equivalent()
-
 #
 # Operators
 #
@@ -147,11 +140,6 @@ class Fuzzy(SearchQuery):
 
     def apply(self, func):
         return func(self.__class__(self.term, self.max_distance, self.boost))
-
-
-#
-# Shortcut query classes
-#
 
 
 MATCH_ALL = MatchAll()

--- a/wagtail/search/query.py
+++ b/wagtail/search/query.py
@@ -112,6 +112,15 @@ class MatchAll(SearchQuery):
         return self.__class__()
 
 
+class Boost(SearchQuery):
+    def __init__(self, subquery: SearchQuery, boost: float):
+        self.subquery = subquery
+        self.boost = boost
+
+    def apply(self, func):
+        return func(self.__class__(self.subquery.apply(func), self.boost))
+
+
 class Term(SearchQuery):
     def __init__(self, term: str, boost: float = 1):
         self.term = term
@@ -143,23 +152,6 @@ class Fuzzy(SearchQuery):
 #
 # Shortcut query classes
 #
-
-
-class Boost(SearchQueryShortcut):
-    def __init__(self, subquery: SearchQuery, boost: float):
-        self.subquery = subquery
-        self.boost = boost
-
-    def apply(self, func):
-        return func(self.__class__(self.subquery.apply(func), self.boost))
-
-    def get_equivalent(self):
-        def boost_child(child):
-            if isinstance(child, (PlainText, Fuzzy, Prefix, Term)):
-                child.boost *= self.boost
-            return child
-
-        return self.subquery.apply(boost_child)
 
 
 MATCH_ALL = MatchAll()

--- a/wagtail/search/query.py
+++ b/wagtail/search/query.py
@@ -114,32 +114,4 @@ class Boost(SearchQuery):
         return func(self.__class__(self.subquery.apply(func), self.boost))
 
 
-class Term(SearchQuery):
-    def __init__(self, term: str, boost: float = 1):
-        self.term = term
-        self.boost = boost
-
-    def apply(self, func):
-        return func(self.__class__(self.term, self.boost))
-
-
-class Prefix(SearchQuery):
-    def __init__(self, prefix: str, boost: float = 1):
-        self.prefix = prefix
-        self.boost = boost
-
-    def apply(self, func):
-        return func(self.__class__(self.prefix, self.boost))
-
-
-class Fuzzy(SearchQuery):
-    def __init__(self, term: str, max_distance: float = 3, boost: float = 1):
-        self.term = term
-        self.max_distance = max_distance
-        self.boost = boost
-
-    def apply(self, func):
-        return func(self.__class__(self.term, self.max_distance, self.boost))
-
-
 MATCH_ALL = MatchAll()

--- a/wagtail/search/tests/test_backends.py
+++ b/wagtail/search/tests/test_backends.py
@@ -491,77 +491,6 @@ class BackendTests(WagtailTestUtils):
             "The Fellowship of the Ring"  # If this item doesn't appear, "Foundation" is still in the index
         ])
 
-    #
-    # Basic query classes
-    #
-
-    def test_match_all(self):
-        results = self.backend.search(MATCH_ALL, models.Book.objects.all())
-        self.assertEqual(len(results), 13)
-
-    def test_and(self):
-        results = self.backend.search(And([PlainText('javascript'),
-                                           PlainText('definitive')]),
-                                      models.Book.objects.all())
-        self.assertSetEqual({r.title for r in results},
-                            {'JavaScript: The Definitive Guide'})
-
-        results = self.backend.search(PlainText('javascript') & PlainText('definitive'),
-                                      models.Book.objects.all())
-        self.assertSetEqual({r.title for r in results},
-                            {'JavaScript: The Definitive Guide'})
-
-    def test_or(self):
-        results = self.backend.search(Or([PlainText('hobbit'), PlainText('towers')]),
-                                      models.Book.objects.all())
-        self.assertSetEqual({r.title for r in results},
-                            {'The Hobbit', 'The Two Towers'})
-
-        results = self.backend.search(PlainText('hobbit') | PlainText('towers'),
-                                      models.Book.objects.all())
-        self.assertSetEqual({r.title for r in results},
-                            {'The Hobbit', 'The Two Towers'})
-
-    def test_not(self):
-        all_other_titles = {
-            'A Clash of Kings',
-            'A Game of Thrones',
-            'A Storm of Swords',
-            'Foundation',
-            'Learning Python',
-            'The Hobbit',
-            'The Two Towers',
-            'The Fellowship of the Ring',
-            'The Return of the King',
-            'The Rust Programming Language',
-            'Two Scoops of Django 1.11',
-        }
-
-        results = self.backend.search(Not(PlainText('javascript')),
-                                      models.Book.objects.all())
-        self.assertSetEqual({r.title for r in results}, all_other_titles)
-
-        results = self.backend.search(~PlainText('javascript'),
-                                      models.Book.objects.all())
-        self.assertSetEqual({r.title for r in results}, all_other_titles)
-
-    def test_operators_combination(self):
-        results = self.backend.search(
-            ((PlainText('javascript') & ~PlainText('definitive')) |
-             PlainText('python') | PlainText('rust')) |
-            PlainText('two'),
-            models.Book.objects.all())
-        self.assertSetEqual({r.title for r in results},
-                            {'JavaScript: The good parts',
-                             'Learning Python',
-                             'The Two Towers',
-                             'The Rust Programming Language',
-                             'Two Scoops of Django 1.11'})
-
-    #
-    # Shortcut query classes
-    #
-
     def test_plain_text_single_word(self):
         results = self.backend.search(PlainText('Javascript'),
                                       models.Book.objects.all())
@@ -629,7 +558,6 @@ class BackendTests(WagtailTestUtils):
             "JavaScript: The Definitive Guide",
         ])
 
-
         results = self.backend.search(PlainText('JavaScript Definitive') | Boost(PlainText('Learning Python'), 0.5), models.Book.objects.all())
 
         # Now they should be swapped
@@ -637,6 +565,69 @@ class BackendTests(WagtailTestUtils):
             "JavaScript: The Definitive Guide",
             "Learning Python",
         ])
+
+    def test_match_all(self):
+        results = self.backend.search(MATCH_ALL, models.Book.objects.all())
+        self.assertEqual(len(results), 13)
+
+    def test_and(self):
+        results = self.backend.search(And([PlainText('javascript'),
+                                           PlainText('definitive')]),
+                                      models.Book.objects.all())
+        self.assertSetEqual({r.title for r in results},
+                            {'JavaScript: The Definitive Guide'})
+
+        results = self.backend.search(PlainText('javascript') & PlainText('definitive'),
+                                      models.Book.objects.all())
+        self.assertSetEqual({r.title for r in results},
+                            {'JavaScript: The Definitive Guide'})
+
+    def test_or(self):
+        results = self.backend.search(Or([PlainText('hobbit'), PlainText('towers')]),
+                                      models.Book.objects.all())
+        self.assertSetEqual({r.title for r in results},
+                            {'The Hobbit', 'The Two Towers'})
+
+        results = self.backend.search(PlainText('hobbit') | PlainText('towers'),
+                                      models.Book.objects.all())
+        self.assertSetEqual({r.title for r in results},
+                            {'The Hobbit', 'The Two Towers'})
+
+    def test_not(self):
+        all_other_titles = {
+            'A Clash of Kings',
+            'A Game of Thrones',
+            'A Storm of Swords',
+            'Foundation',
+            'Learning Python',
+            'The Hobbit',
+            'The Two Towers',
+            'The Fellowship of the Ring',
+            'The Return of the King',
+            'The Rust Programming Language',
+            'Two Scoops of Django 1.11',
+        }
+
+        results = self.backend.search(Not(PlainText('javascript')),
+                                      models.Book.objects.all())
+        self.assertSetEqual({r.title for r in results}, all_other_titles)
+
+        results = self.backend.search(~PlainText('javascript'),
+                                      models.Book.objects.all())
+        self.assertSetEqual({r.title for r in results}, all_other_titles)
+
+    def test_operators_combination(self):
+        results = self.backend.search(
+            ((PlainText('javascript') & ~PlainText('definitive')) |
+             PlainText('python') | PlainText('rust')) |
+            PlainText('two'),
+            models.Book.objects.all())
+        self.assertSetEqual({r.title for r in results},
+                            {'JavaScript: The good parts',
+                             'Learning Python',
+                             'The Two Towers',
+                             'The Rust Programming Language',
+                             'Two Scoops of Django 1.11'})
 
 
 @override_settings(

--- a/wagtail/search/tests/test_db_backend.py
+++ b/wagtail/search/tests/test_db_backend.py
@@ -62,3 +62,8 @@ class TestDBBackend(BackendTests, TestCase):
     @unittest.expectedFailure
     def test_incomplete_plain_text(self):
         super().test_incomplete_plain_text()
+
+    # Database backend doesn't support Boost() query class
+    @unittest.expectedFailure
+    def test_boost(self):
+        super().test_boost()


### PR DESCRIPTION
Rebase of #4593 on master (previously reverted in #4680 due to test breakage).

The following commits from the original PR have been omitted:

2faa90ec942c6b5f31cf1032847f2a41e8801b3c - broke several tests on Elasticsearch, evidently because the `get_children` method was still in use
3b26b3fc75e1436ffa84ee9a21b040f59749fd8c - due to dropping the above commit, `MultiOperandsSearchQueryOperator` isn't as empty any more, so may not make sense to eliminate