### PR TITLE
Search query classes cleanup

### DIFF
--- a/wagtail/search/backends/elasticsearch2.py
+++ b/wagtail/search/backends/elasticsearch2.py
@@ -431,7 +431,7 @@ class Elasticsearch2SearchQueryCompiler(BaseSearchQueryCompiler):
                 'bool': {
                     'must': [
                         self._compile_query(child_query, field, boost)
-                        for child_query in query.get_children()
+                        for child_query in query.subqueries
                     ]
                 }
             }
@@ -441,7 +441,7 @@ class Elasticsearch2SearchQueryCompiler(BaseSearchQueryCompiler):
                 'bool': {
                     'should': [
                         self._compile_query(child_query, field, boost)
-                        for child_query in query.get_children()
+                        for child_query in query.subqueries
                     ]
                 }
             }

--- a/wagtail/search/query.py
+++ b/wagtail/search/query.py
@@ -46,28 +46,21 @@ class Boost(SearchQuery):
 
 
 #
-# Operators
+# Combinators
 #
 
 
-class SearchQueryOperator(SearchQuery):
-    pass
-
-
-class MultiOperandsSearchQueryOperator(SearchQueryOperator):
+class And(SearchQuery):
     def __init__(self, subqueries):
         self.subqueries = subqueries
 
 
-class And(MultiOperandsSearchQueryOperator):
-    pass
+class Or(SearchQuery):
+    def __init__(self, subqueries):
+        self.subqueries = subqueries
 
 
-class Or(MultiOperandsSearchQueryOperator):
-    pass
-
-
-class Not(SearchQueryOperator):
+class Not(SearchQuery):
     def __init__(self, subquery: SearchQuery):
         self.subquery = subquery
 

--- a/wagtail/search/query.py
+++ b/wagtail/search/query.py
@@ -16,27 +16,6 @@ class SearchQuery:
     def __invert__(self):
         return Not(self)
 
-    def apply(self, func):
-        raise NotImplementedError
-
-    def clone(self):
-        return self.apply(lambda o: o)
-
-    def get_children(self):
-        return ()
-
-    @property
-    def children(self):
-        return list(self.get_children())
-
-    @property
-    def child(self):
-        children = self.children
-        if len(children) != 1:
-            raise IndexError('`%s` object has %d children, not a single child.'
-                             % self.__class__.__name__, len(children))
-        return children[0]
-
 
 #
 # Basic query classes
@@ -55,23 +34,15 @@ class PlainText(SearchQuery):
             raise ValueError("`operator` must be either 'or' or 'and'.")
         self.boost = boost
 
-    def apply(self, func):
-        return func(self.__class__(self.query_string, self.operator,
-                                   self.boost))
-
 
 class MatchAll(SearchQuery):
-    def apply(self, func):
-        return self.__class__()
+    pass
 
 
 class Boost(SearchQuery):
     def __init__(self, subquery: SearchQuery, boost: float):
         self.subquery = subquery
         self.boost = boost
-
-    def apply(self, func):
-        return func(self.__class__(self.subquery.apply(func), self.boost))
 
 
 #
@@ -87,13 +58,6 @@ class MultiOperandsSearchQueryOperator(SearchQueryOperator):
     def __init__(self, subqueries):
         self.subqueries = subqueries
 
-    def apply(self, func):
-        return func(self.__class__(
-            [subquery.apply(func) for subquery in self.subqueries]))
-
-    def get_children(self):
-        yield from self.subqueries
-
 
 class And(MultiOperandsSearchQueryOperator):
     pass
@@ -106,12 +70,6 @@ class Or(MultiOperandsSearchQueryOperator):
 class Not(SearchQueryOperator):
     def __init__(self, subquery: SearchQuery):
         self.subquery = subquery
-
-    def apply(self, func):
-        return func(self.__class__(self.subquery.apply(func)))
-
-    def get_children(self):
-        yield self.subquery
 
 
 MATCH_ALL = MatchAll()


### PR DESCRIPTION
This removes the reference to ``get_children`` from the Elasticsearch backend and reapplies the commits that were removed from https://github.com/wagtail/wagtail/pull/4682