### PR TITLE
url() is depriciated. Alias re_path()

### DIFF
--- a/docs/advanced_topics/settings.rst
+++ b/docs/advanced_topics/settings.rst
@@ -596,18 +596,23 @@ URL Patterns
   from wagtail.documents import urls as wagtaildocs_urls
 
   urlpatterns = [
-      url(r'^django-admin/', include(admin.site.urls)),
+      re_path(r'^django-admin/', include(admin.site.urls)),
 
-      url(r'^admin/', include(wagtailadmin_urls)),
-      url(r'^documents/', include(wagtaildocs_urls)),
+      re_path(r'^admin/', include(wagtailadmin_urls)),
+      re_path(r'^documents/', include(wagtaildocs_urls)),
 
       # Optional URL for including your own vanilla Django urls/views
-      url(r'', include('myapp.urls')),
+      re_path(r'', include('myapp.urls')),
 
       # For anything not caught by a more specific rule above, hand over to
       # Wagtail's serving mechanism
-      url(r'', include(wagtail_urls)),
+      re_path(r'', include(wagtail_urls)),
   ]
+
+.. important::
+
+   The example above assumes you are using Django version 2.0 or later. If you are using a Django version earlier than 2.0, you should rename all occurrences of re_path() to url(). For example: ``url(r'^django-admin/', include(admin.site.urls)),`` instead of ``re_path(r'^django-admin/', include(admin.site.urls)),``.
+   (`read more <https://docs.djangoproject.com/en/2.1/ref/urls/#url>`_).
 
 This block of code for your project's ``urls.py`` does a few things:
 
@@ -825,7 +830,7 @@ These two files should reside in your project directory (``myproject/myproject/`
 
 .. code-block:: python
 
-  from django.conf.urls import include, url
+  from django.conf.urls import include, re_path
   from django.conf.urls.static import static
   from django.views.generic.base import RedirectView
   from django.contrib import admin
@@ -838,14 +843,14 @@ These two files should reside in your project directory (``myproject/myproject/`
 
 
   urlpatterns = [
-      url(r'^django-admin/', include(admin.site.urls)),
+      re_path(r'^django-admin/', include(admin.site.urls)),
 
-      url(r'^admin/', include(wagtailadmin_urls)),
-      url(r'^documents/', include(wagtaildocs_urls)),
+      re_path(r'^admin/', include(wagtailadmin_urls)),
+      re_path(r'^documents/', include(wagtaildocs_urls)),
 
       # For anything not caught by a more specific rule above, hand over to
       # Wagtail's serving mechanism
-      url(r'', include(wagtail_urls)),
+      re_path(r'', include(wagtail_urls)),
   ]
 
 
@@ -855,5 +860,5 @@ These two files should reside in your project directory (``myproject/myproject/`
       urlpatterns += staticfiles_urlpatterns() # tell gunicorn where static files are in dev mode
       urlpatterns += static(settings.MEDIA_URL + 'images/', document_root=os.path.join(settings.MEDIA_ROOT, 'images'))
       urlpatterns += [
-          url(r'^favicon\.ico$', RedirectView.as_view(url=settings.STATIC_URL + 'myapp/images/favicon.ico'))
+          re_path(r'^favicon\.ico$', RedirectView.as_view(url=settings.STATIC_URL + 'myapp/images/favicon.ico'))
       ]


### PR DESCRIPTION
Added important note about using url() on older versions of django, but switched the examples to re_path as to comply with Django docs for 2.0 and later.

Thanks for contributing to Wagtail! 🎉

Before submitting, please review the contributor guidelines <http://docs.wagtail.io/en/latest/contributing/index.html> and check the following:

* Do the tests still pass? (http://docs.wagtail.io/en/latest/contributing/developing.html#testing)
* Does the code comply with the style guide? (Run `make lint` from the Wagtail root)
* For Python changes: Have you added tests to cover the new/fixed behaviour?
* For front-end changes: Did you test on all of Wagtail’s supported browsers? **Please list the exact versions you tested**.
* For new features: Has the documentation been updated accordingly?
