### PR TITLE
Un-deprecate index methods from Elasticsearch2SearchBackend

### DIFF
--- a/wagtail/search/backends/elasticsearch2.py
+++ b/wagtail/search/backends/elasticsearch2.py
@@ -1,6 +1,5 @@
 import copy
 import json
-import warnings
 from collections import OrderedDict
 from urllib.parse import urlparse
 
@@ -16,7 +15,6 @@ from wagtail.search.backends.base import (
 from wagtail.search.index import (
     AutocompleteField, FilterField, Indexed, RelatedFields, SearchField, class_is_indexed)
 from wagtail.search.query import And, Boost, MatchAll, Not, Or, PlainText
-from wagtail.utils.deprecation import RemovedInWagtail22Warning
 from wagtail.utils.utils import deep_update
 
 
@@ -1099,51 +1097,6 @@ class Elasticsearch2SearchBackend(BaseSearchBackend):
     def reset_index(self):
         # Use the rebuilder to reset the index
         self.get_rebuilder().reset_index()
-
-    def add_type(self, model):
-        warnings.warn(
-            "The `backend.add_type(model)` method is deprecated. "
-            "Please use `backend.get_index_for_model(model).add_model(model)` instead.",
-            category=RemovedInWagtail22Warning
-        )
-
-        self.get_index_for_model(model).add_model(model)
-
-    def refresh_index(self):
-        warnings.warn(
-            "The `backend.refresh_index()` method is deprecated. "
-            "Please use `backend.get_index_for_model(model).refresh()` for each model instead.",
-            category=RemovedInWagtail22Warning
-        )
-
-        self.get_index().refresh()
-
-    def add(self, obj):
-        warnings.warn(
-            "The `backend.add(obj)` method is deprecated. "
-            "Please use `backend.get_index_for_model(type(obj)).add_item(obj)` instead.",
-            category=RemovedInWagtail22Warning
-        )
-
-        self.get_index_for_model(type(obj)).add_item(obj)
-
-    def add_bulk(self, model, obj_list):
-        warnings.warn(
-            "The `backend.add_bulk(model, obj_list)` method is deprecated. "
-            "Please use `self.get_index_for_model(model).add_items(model, obj_list)` instead.",
-            category=RemovedInWagtail22Warning
-        )
-
-        self.get_index_for_model(model).add_items(model, obj_list)
-
-    def delete(self, obj):
-        warnings.warn(
-            "The `backend.delete(obj)` method is deprecated. "
-            "Please use `backend.get_index_for_model(type(obj)).delete_item(obj)` instead.",
-            category=RemovedInWagtail22Warning
-        )
-
-        self.get_index_for_model(type(obj)).delete_item(obj)
 
 
 SearchBackend = Elasticsearch2SearchBackend

--- a/wagtail/search/tests/test_db_backend.py
+++ b/wagtail/search/tests/test_db_backend.py
@@ -33,11 +33,6 @@ class TestDBBackend(BackendTests, TestCase):
     def test_search_boosting_on_related_fields(self):
         super().test_search_boosting_on_related_fields()
 
-    # Doesn't support ranking
-    @unittest.expectedFailure
-    def test_same_rank_pages(self):
-        super(TestDBBackend, self).test_same_rank_pages()
-
     # Doesn't support searching specific fields
     @unittest.expectedFailure
     def test_search_child_class_field_from_parent(self):

--- a/wagtail/utils/deprecation.py
+++ b/wagtail/utils/deprecation.py
@@ -1,7 +1,3 @@
-class RemovedInWagtail22Warning(DeprecationWarning):
-    pass
-
-
 class RemovedInWagtail23Warning(DeprecationWarning):
     pass
 


### PR DESCRIPTION
Fixes #4552

As discussed at https://github.com/wagtail/wagtail/pull/3975#issuecomment-389961302 - the base search backend class now implements generic versions of these methods so that they can be removed from the ES2-specific code without any loss of functionality.