### PR TITLE
Fixes Django 2.1 breaking changes; QUERY_TERMS & auth_views.login()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ matrix:
      python: 3.4
    - env: TOXENV=py34-dj20-mysql-noelasticsearch
      python: 3.4
+   - env: TOXENV=py34-dj21-mysql-noelasticsearch
+     python: 3.4
    - env: TOXENV=py35-dj111-postgres-noelasticsearch
      python: 3.5
    - env: TOXENV=py35-dj111-mysql-noelasticsearch
@@ -29,6 +31,8 @@ matrix:
      sudo: true
    - env: TOXENV=py35-dj20-sqlite-noelasticsearch
      python: 3.5
+   - env: TOXENV=py35-dj21-sqlite-noelasticsearch
+     python: 3.5
    - env: TOXENV=py36-dj111-sqlite-noelasticsearch
      python: 3.6
    - env: TOXENV=py36-dj111-postgres-noelasticsearch
@@ -37,10 +41,15 @@ matrix:
      python: 3.6
    - env: TOXENV=py36-dj20-postgres-noelasticsearch
      python: 3.6
+   - env: TOXENV=py36-dj21-postgres-noelasticsearch
+     python: 3.6
    - env: TOXENV=py36-dj111-postgres-elasticsearch2 INSTALL_ELASTICSEARCH2=yes
      python: 3.6
      sudo: true
    - env: TOXENV=py36-dj20-sqlite-elasticsearch2 INSTALL_ELASTICSEARCH2=yes
+     python: 3.6
+     sudo: true
+   - env: TOXENV=py36-dj21-sqlite-elasticsearch2 INSTALL_ELASTICSEARCH2=yes
      python: 3.6
      sudo: true
    - env: TOXENV=py36-dj111-postgres-elasticsearch5 INSTALL_ELASTICSEARCH5=yes
@@ -49,10 +58,16 @@ matrix:
    - env: TOXENV=py36-dj20-postgres-elasticsearch5 INSTALL_ELASTICSEARCH5=yes
      python: 3.6
      sudo: true
+   - env: TOXENV=py36-dj21-postgres-elasticsearch5 INSTALL_ELASTICSEARCH5=yes
+     python: 3.6
+     sudo: true
    - env: TOXENV=py36-dj111-postgres-elasticsearch6 INSTALL_ELASTICSEARCH6=yes
      python: 3.6
      sudo: true
    - env: TOXENV=py36-dj20-postgres-elasticsearch6 INSTALL_ELASTICSEARCH6=yes
+     python: 3.6
+     sudo: true
+   - env: TOXENV=py36-dj21-postgres-elasticsearch6 INSTALL_ELASTICSEARCH6=yes
      python: 3.6
      sudo: true
   allow_failures:
@@ -60,10 +75,14 @@ matrix:
     - env: TOXENV=py35-dj111-postgres-elasticsearch2 INSTALL_ELASTICSEARCH2=yes
     - env: TOXENV=py36-dj111-postgres-elasticsearch2 INSTALL_ELASTICSEARCH2=yes
     - env: TOXENV=py36-dj20-sqlite-elasticsearch2 INSTALL_ELASTICSEARCH2=yes
+    - env: TOXENV=py36-dj21-sqlite-elasticsearch2 INSTALL_ELASTICSEARCH2=yes
     - env: TOXENV=py36-dj111-postgres-elasticsearch5 INSTALL_ELASTICSEARCH5=yes
     - env: TOXENV=py36-dj20-postgres-elasticsearch5 INSTALL_ELASTICSEARCH5=yes
+    - env: TOXENV=py36-dj21-postgres-elasticsearch5 INSTALL_ELASTICSEARCH5=yes
     - env: TOXENV=py36-dj111-postgres-elasticsearch6 INSTALL_ELASTICSEARCH6=yes
     - env: TOXENV=py36-dj20-postgres-elasticsearch6 INSTALL_ELASTICSEARCH6=yes
+    - env: TOXENV=py36-dj21-postgres-elasticsearch6 INSTALL_ELASTICSEARCH6=yes
+
 
 # Services
 services:

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -31,6 +31,7 @@ Changelog
  * Fix: Null characters in URLs no longer crash the redirect middleware on PostgreSQL (Andrew Crewdson, Matt Westcott)
  * Fix: Permission checks no longer prevent a non-live page from being unscheduled (Abdulmalik Abdulwahab)
  * Fix: Copy-paste between Draftail editors now preserves all formatting/content (Thibaud Colas)
+ * Fix: Django 2.1 breaking changes: removal of QUERY_TERMS & django.contrib.auth.views.login (Ryan Verner)
 
 
 2.1.1 (04.07.2018)

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -311,6 +311,7 @@ Contributors
 * Andrew Crewdson
 * Aram Dulyan
 * Kevin Howbrook
+* Ryan Verner
 
 Translators
 ===========

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Wagtail is used by NASA, Google, Oxfam, the NHS, Mozilla, MIT, the Red Cross, Sa
 
 Wagtail supports:
 
-* Django 1.11.x and 2.0
+* Django 1.11.x, 2.0 and 2.1
 * Python 3.4, 3.5 and 3.6
 * PostgreSQL, MySQL and SQLite as database backends
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ except ImportError:
 
 
 install_requires = [
-    "Django>=1.11,<2.1",
+    "Django>=1.11,<2.2",
     "django-modelcluster>=4.0,<5.0",
     "django-taggit>=0.22.2,<1.0",
     "django-treebeard>=4.2.0,<5.0",
@@ -94,6 +94,7 @@ https://github.com/wagtail/wagtail/.",
         'Framework :: Django',
         'Framework :: Django :: 1.11',
         'Framework :: Django :: 2.0',
+        'Framework :: Django :: 2.1',
         'Framework :: Wagtail',
         'Topic :: Internet :: WWW/HTTP :: Site Management',
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -42,7 +42,9 @@ deps =
 
     dj111: Django>=1.11b1,<2.0
     dj111-mssql: django-pyodbc-azure==1.11.0.0
-    dj20: Django>=2.0,<2.2
+    dj20: Django>=2.0,<2.1
+    dj21: Django>=2.1rc1,<2.2
+
     postgres: psycopg2>=2.6
     mysql: mysqlclient==1.3.6
     elasticsearch2: elasticsearch>=2,<3

--- a/tox.ini
+++ b/tox.ini
@@ -42,7 +42,7 @@ deps =
 
     dj111: Django>=1.11b1,<2.0
     dj111-mssql: django-pyodbc-azure==1.11.0.0
-    dj20: Django>=2.0,<2.1
+    dj20: Django>=2.0,<2.2
     postgres: psycopg2>=2.6
     mysql: mysqlclient==1.3.6
     elasticsearch2: elasticsearch>=2,<3

--- a/tox.ini
+++ b/tox.ini
@@ -43,7 +43,7 @@ deps =
     dj111: Django>=1.11b1,<2.0
     dj111-mssql: django-pyodbc-azure==1.11.0.0
     dj20: Django>=2.0,<2.1
-    dj21: Django>=2.1rc1,<2.2
+    dj21: git+https://github.com/django/django.git@2.1rc1#egg=Django
 
     postgres: psycopg2>=2.6
     mysql: mysqlclient==1.3.6

--- a/wagtail/contrib/modeladmin/views.py
+++ b/wagtail/contrib/modeladmin/views.py
@@ -15,7 +15,6 @@ from django.db import models
 from django.db.models.constants import LOOKUP_SEP
 from django.db.models.fields import FieldDoesNotExist
 from django.db.models.fields.related import ForeignObjectRel, ManyToManyField
-from django.db.models.sql.constants import QUERY_TERMS
 from django.shortcuts import get_object_or_404, redirect
 from django.template.defaultfilters import filesizeformat
 from django.utils.decorators import method_decorator
@@ -32,6 +31,18 @@ from wagtail.admin import messages
 from wagtail.admin.edit_handlers import ObjectList, extract_panel_definitions_from_model_class
 
 from .forms import ParentChooserForm
+
+
+try:
+    from django.db.models.sql.constants import QUERY_TERMS
+except ImportError:
+    # Django 2.1+ does not have QUERY_TERMS anymore
+    QUERY_TERMS = {
+        'contains', 'day', 'endswith', 'exact', 'gt', 'gte', 'hour',
+        'icontains', 'iendswith', 'iexact', 'in', 'iregex', 'isnull',
+        'istartswith', 'lt', 'lte', 'minute', 'month', 'range', 'regex',
+        'search', 'second', 'startswith', 'week_day', 'year',
+    }
 
 
 class WMABaseView(TemplateView):

--- a/wagtail/core/urls.py
+++ b/wagtail/core/urls.py
@@ -25,7 +25,7 @@ WAGTAIL_FRONTEND_LOGIN_TEMPLATE = getattr(
 urlpatterns = [
     url(r'^_util/authenticate_with_password/(\d+)/(\d+)/$', views.authenticate_with_password,
         name='wagtailcore_authenticate_with_password'),
-    url(r'^_util/login/$', auth_views.login, {'template_name': WAGTAIL_FRONTEND_LOGIN_TEMPLATE},
+    url(r'^_util/login/$', auth_views.LoginView.as_view(template_name=WAGTAIL_FRONTEND_LOGIN_TEMPLATE),
         name='wagtailcore_login'),
 
     # Front-end page views are handled through Wagtail's core.views.serve


### PR DESCRIPTION
Fixes breaking changes in Django 2.1 which is due for release on the 1st August; in ~6 days.
Would recommend a core developer carefully reviews my changes before accepting; if Wagtail 2.2 isn't being released in the next week, may necessitate a 2.1.x minor release ASAP, too (edit: just noticed that setup.py prevents installation with Django 2.1, so may be OK for current Wagtail 2.1.x).

### Fix 1 - QUERY_TERMS

``django.db.models.sql.constants.QUERY_TERMS`` is removed in Django 2.1.
This isn't mentioned in the release notes :(  (I've added a bug there, so it can be added).

This is imported in ``wagtail.contrib.modeladmin.views``.

It was removed on 2017-07-05, link to Django repo:
https://github.com/django/django/commit/244cc401559e924355cf943b6b8e66ccf2f6da3a

It appears the checks for field validity have been removed.  I assume the rationale for this change is if the field is invalid, an Exception will be thrown elsewhere, so it's superfluous having explicit checks which are likely database conditional anyway.

The safest option for a fix appears to be what django-filter has done, which is to add compatibility terms here:
https://github.com/carltongibson/django-filter/pull/921/files

It may be preferential to rewrite lookup_allowed() to not need QUERY_TERMS, but it's probably best a core developer who best understands this code does this.

This PR at least safely prevents an upgrade to Django 2.1 breaking Wagtail; which is likely going to start happening in a week.

### Fix 2 - django.contrib.auth.views methods

``django.contrib.auth.views.login()`` et al were depreciated in 1.11, and removed in 2.1

See the release notes:
https://docs.djangoproject.com/en/2.1/releases/2.1/#features-removed-in-2-1

I've just changed this to LoginView.as_view() instead and moved the template_name into this as a parameter.

Manually tested, both fixes provide a working Wagtail for me (both on the latest RC for Django 2.1 and 2.2-master).  I've updated tox.ini to test for Django 2.1 too, but it's not on pypi so the automated tests won't check against 2.1 until it's released.