### PR TITLE
Django 2.1 fix - Pass renderer kwarg to widget render methods

### DIFF
--- a/wagtail/admin/rich_text/editors/draftail/__init__.py
+++ b/wagtail/admin/rich_text/editors/draftail/__init__.py
@@ -41,9 +41,10 @@ class DraftailRichTextArea(WidgetWithScript, widgets.HiddenInput):
 
         super().__init__(*args, **kwargs)
 
-    def translate_value(self, value):
+    def format_value(self, value):
         # Convert database rich text representation to the format required by
         # the input field
+        value = super().format_value(value)
 
         if value is None:
             value = ''
@@ -56,8 +57,7 @@ class DraftailRichTextArea(WidgetWithScript, widgets.HiddenInput):
 
         attrs['data-draftail-input'] = True
 
-        translated_value = self.translate_value(value)
-        return super().render(name, translated_value, attrs)
+        return super().render(name, value, attrs)
 
     def render_js_init(self, id_, name, value):
         return "window.draftail.initEditor('#{id}', {opts}, document.currentScript)".format(

--- a/wagtail/admin/rich_text/editors/hallo.py
+++ b/wagtail/admin/rich_text/editors/hallo.py
@@ -104,17 +104,15 @@ class HalloRichTextArea(WidgetWithScript, widgets.Textarea):
 
         super().__init__(*args, **kwargs)
 
-    def translate_value(self, value):
+    def format_value(self, value):
         # Convert database rich text representation to the format required by
         # the input field
+        value = super().format_value(value)
+
         if value is None:
             return None
 
         return self.converter.from_database_format(value)
-
-    def render(self, name, value, attrs=None):
-        translated_value = self.translate_value(value)
-        return super().render(name, translated_value, attrs)
 
     def render_js_init(self, id_, name, value):
         if self.options is not None and 'plugins' in self.options:

--- a/wagtail/admin/templates/wagtailadmin/widgets/draftail_rich_text_area.html
+++ b/wagtail/admin/templates/wagtailadmin/widgets/draftail_rich_text_area.html
@@ -1,0 +1,1 @@
+{% include 'django/forms/widgets/hidden.html' %}<script>window.draftail.initEditor('#{{ widget.attrs.id|escapejs }}', {{ widget.options_json|safe }}, document.currentScript)</script>

--- a/wagtail/admin/tests/test_rich_text.py
+++ b/wagtail/admin/tests/test_rich_text.py
@@ -126,7 +126,7 @@ class TestDefaultRichText(BaseRichTextEditHandlerTestCase, WagtailTestUtils):
         self.assertEqual(response.status_code, 200)
 
         # Check that draftail (default editor) initialisation is applied
-        self.assertContains(response, "window.draftail.initEditor('#__PREFIX__-value',")
+        self.assertContains(response, "window.draftail.initEditor('#__PREFIX__\\u002Dvalue',")
 
         # check that media for draftail is being imported
         self.assertContains(response, 'wagtailadmin/js/draftail.js')

--- a/wagtail/core/blocks/base.py
+++ b/wagtail/core/blocks/base.py
@@ -485,7 +485,7 @@ class BlockWidget(forms.Widget):
         super().__init__(attrs=attrs)
         self.block_def = block_def
 
-    def render_with_errors(self, name, value, attrs=None, errors=None):
+    def render_with_errors(self, name, value, attrs=None, errors=None, renderer=None):
         bound_block = self.block_def.bind(value, prefix=name, errors=errors)
         js_initializer = self.block_def.js_initializer()
         if js_initializer:
@@ -501,8 +501,8 @@ class BlockWidget(forms.Widget):
             js_snippet = ''
         return mark_safe(bound_block.render_form() + js_snippet)
 
-    def render(self, name, value, attrs=None):
-        return self.render_with_errors(name, value, attrs=attrs, errors=None)
+    def render(self, name, value, attrs=None, renderer=None):
+        return self.render_with_errors(name, value, attrs=attrs, errors=None, renderer=renderer)
 
     @property
     def media(self):

--- a/wagtail/tests/utils/form_data.py
+++ b/wagtail/tests/utils/form_data.py
@@ -133,4 +133,4 @@ def rich_text(value, editor='default', features=None):
         }))
     """
     widget = get_rich_text_editor_widget(editor, features)
-    return widget.translate_value(value)
+    return widget.format_value(value)

--- a/wagtail/utils/widgets.py
+++ b/wagtail/utils/widgets.py
@@ -7,7 +7,7 @@ class WidgetWithScript(Widget):
         """Render the HTML (non-JS) portion of the field markup"""
         return super().render(name, value, attrs)
 
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, renderer=None):
         # no point trying to come up with sensible semantics for when 'id' is missing from attrs,
         # so let's make sure it fails early in the process
         try:


### PR DESCRIPTION
As of Django 2.1, form widget `render` methods need to accept a `renderer` kwarg - this PR updates all custom form widgets to accept this.

This is one place where making the 'direct' fix, and following the _spirit_ of the Django change, are very different things... Ideally, rather than simply adding and ignoring the new kwarg, we'd refactor our widgets to make use of the template-rendering mechanism introduced in Django 1.11 (so that custom logic now happens in methods such as `get_context` and `format_value`, and there's no need to override `render` at all). This would mean phasing out use of the `wagtail.admin.utils.widgets.WidgetWithScript` helper, which is fundamentally incompatible with the Django 1.11 approach. I made a start down this path, but hit a wall with `AdminChooser` (which is frequently subclassed in third-party code and so can't be refactored without a fiddly deprecation process).

With that in mind, this PR applies the 'proper' fix to the Draftail text area widget, and the minimal fix to `WidgetWithScript` and `BlockWidget` to get everything else working again in Django 2.1. I'll open a separate PR to cover converting a few more widgets to Django-1.11-style (lower priority and not essential for Django 2.1 compatibility).