### PR TITLE
Prevent search engines from indexing admin pages

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/skeleton.html
+++ b/wagtail/admin/templates/wagtailadmin/skeleton.html
@@ -6,6 +6,7 @@
     <title>Wagtail - {% block titletag %}{% endblock %}</title>
     <meta name="description" content="" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex" />
 
     <script src="{% static 'wagtailadmin/js/vendor/modernizr-2.6.2.min.js' %}"></script>
 


### PR DESCRIPTION
According to a google search I just did, it seems a lot of people have forgotten to add ``Disallow: /admin`` in their robots.txt (or forgot to add robots.txt) at all.

Adding this meta tag into the head of all admin pages should prevent any admin pages being indexed even if this was missed.