### PR TITLE
Reuse lazy StreamField values in get_prep_value

### DIFF
--- a/wagtail/admin/tests/api/test_pages.py
+++ b/wagtail/admin/tests/api/test_pages.py
@@ -679,7 +679,7 @@ class TestAdminPageDetailWithStreamField(AdminAPITestCase):
         return self.homepage.add_child(instance=stream_page)
 
     def test_can_fetch_streamfield_content(self):
-        stream_page = self.make_stream_page('[{"type": "text", "value": "foo"}]')
+        stream_page = self.make_stream_page('[{"type": "text", "value": "foo", "id": "test-id"}]')
 
         response_url = reverse('wagtailadmin_api_v1:pages:detail', args=(stream_page.id, ))
         response = self.client.get(response_url)
@@ -695,7 +695,7 @@ class TestAdminPageDetailWithStreamField(AdminAPITestCase):
         self.assertEqual(len(content['body']), 1)
         self.assertEqual(content['body'][0]['type'], 'text')
         self.assertEqual(content['body'][0]['value'], 'foo')
-        self.assertTrue(content['body'][0]['id'])
+        self.assertEqual(content['body'][0]['id'], 'test-id')
 
     def test_image_block(self):
         stream_page = self.make_stream_page('[{"type": "image", "value": 1}]')

--- a/wagtail/api/v2/tests/test_pages.py
+++ b/wagtail/api/v2/tests/test_pages.py
@@ -1137,7 +1137,7 @@ class TestPageDetailWithStreamField(TestCase):
         return self.homepage.add_child(instance=stream_page)
 
     def test_can_fetch_streamfield_content(self):
-        stream_page = self.make_stream_page('[{"type": "text", "value": "foo"}]')
+        stream_page = self.make_stream_page('[{"type": "text", "value": "foo", "id": "test-id" }]')
 
         response_url = reverse('wagtailapi_v2:pages:detail', args=(stream_page.id, ))
         response = self.client.get(response_url)
@@ -1153,7 +1153,7 @@ class TestPageDetailWithStreamField(TestCase):
         self.assertEqual(len(content['body']), 1)
         self.assertEqual(content['body'][0]['type'], 'text')
         self.assertEqual(content['body'][0]['value'], 'foo')
-        self.assertTrue(content['body'][0]['id'])
+        self.assertEqual(content['body'][0]['id'], 'test-id')
 
     def test_image_block(self):
         stream_page = self.make_stream_page('[{"type": "image", "value": 1}]')

--- a/wagtail/core/tests/test_streamfield.py
+++ b/wagtail/core/tests/test_streamfield.py
@@ -111,6 +111,21 @@ class TestLazyStreamField(TestCase):
             assert instance.body[1].value is None
             assert instance.body[2].value.title == 'Test image 3'
 
+    def test_lazy_load_get_prep_value(self):
+        """
+        Saving a lazy StreamField that hasn't had its data accessed should not
+        cause extra database queries by loading and then re-saving block values.
+        Instead the initial JSON stream data should be written back for any
+        blocks that have not been accessed.
+        """
+        with self.assertNumQueries(1):
+            instance = StreamModel.objects.get(pk=self.with_image.pk)
+
+        # Expect a single UPDATE to update the model, without any additional
+        # SELECT related to the image block that has not been accessed.
+        with self.assertNumQueries(1):
+            instance.save()
+
 
 class TestSystemCheck(TestCase):
     def tearDown(self):


### PR DESCRIPTION
Currently lazy StreamFields contain initial JSON data read from the database. When written back to the database, instead of reusing the JSON, it is first converted to Python objects and then converted back to JSON. This not only potentially introduces extraneous database queries but also makes it more difficult for developers to access the raw JSON for e.g. migrations.

This change fixes #2218 (filed by @timheap) where using `loaddata` to load PageChooserBlock/ImageChooserBlock values in a StreamField may lead to broken references. To verify, follow the instructions in that issue to create a data dump with a page and images, then edit the dump so that the page is loaded before the image. You'll see that page-image references are properly loaded even if the dump order isn't in dependency order.

This change includes some slight changes to two API unit tests to get them to pass. In those tests we manually create StreamField data without providing an ID. The test was checking to see that the data retrieved from the API did contain an ID, because the previous logic would add one during the JSON->Python->JSON round trip. This change removes that roundtrip and so the test needs to provide an ID in the test data.

Unfortunately this does mean that if anyone is using a similar mechanism to create StreamField data manually, and counting on IDs being added automatically even if they are never accessed outside of the API, this will break. As this kind of creation is unsupported I wasn't sure if I should add some kind of logic to handle this; one potential place to do that would be in [`wagtail.api.v2.serializers.StreamField`](https://github.com/wagtail/wagtail/blob/0129e4ce777bcade6da812bf0b8601b0a076ad4d/wagtail/api/v2/serializers.py#L185): if the field is lazy, make sure that it's fully realized as bound blocks before returning the API representation.