### PR TITLE
Add warning about unregistering image formats.

### DIFF
--- a/docs/advanced_topics/customisation/page_editing_interface.rst
+++ b/docs/advanced_topics/customisation/page_editing_interface.rst
@@ -143,6 +143,9 @@ To begin, import the ``Format`` class, ``register_image_format`` function, and o
 
 To unregister, call ``unregister_image_format`` with the string of the ``name`` of the ``Format`` as the only argument.
 
+  .. warning::
+     Unregistering ``Format`` objects will cause errors viewing or editing pages that reference them.
+
 .. _custom_edit_handler_forms:
 
 Customising generated forms


### PR DESCRIPTION
Add warning to documentation to warn that unregistering image formats
that are being used will create an error when viewing or editing pages.

See https://groups.google.com/forum/#!topic/wagtail/X8xTUs-2npA and
https://github.com/wagtail/wagtail/issues/1471#issuecomment-118436706.
