### PR TITLE
add ability to overwrite wagtail logo with own logo for the userbar

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -19,6 +19,7 @@ Changelog
  * Show more granular error messages from Pillow when uploading images (Rick van Hattem)
  * Add ordering to `Site` object, so that index page and `Site` switcher will be sorted consistently (Coen van der Kamp, Tim Leguijt)
  * Add Reddit to oEmbed provider list (Luke Hardwick)
+ * Add ability to replace the default Wagtail logo in the userbar, via `branding_logo` block (Meteor0id)
  * Remove sticky footer on small devices, so that content is not blocked and more easily editable (Saeed Tahmasebi)
  * Fix: Support IPv6 domain (Alex Gleason, Coen van der Kamp)
  * Fix: Ensure link to add a new user works when no users are visible in the users list (LB (Ben Johnston))

--- a/docs/advanced_topics/customisation/admin_templates.rst
+++ b/docs/advanced_topics/customisation/admin_templates.rst
@@ -42,6 +42,8 @@ To replace the default logo, create a template file ``dashboard/templates/wagtai
 
 The logo also appears on the admin 404 error page; to replace it there too, create a template file ``dashboard/templates/wagtailadmin/404.html`` that overrides the ``branding_logo`` block.
 
+The logo also appears on the wagtail userbar; to replace it there too, create a template file ``dashboard/templates/wagtailadmin/userbar/base.html`` that overwrites the ``branding_logo`` block.
+
 ``branding_favicon``
 --------------------
 

--- a/docs/releases/2.10.rst
+++ b/docs/releases/2.10.rst
@@ -29,6 +29,7 @@ Other features
  * Add ordering to ``Site`` object, so that index page and ``Site`` switcher will be sorted consistently (Coen van der Kamp, Tim Leguijt)
  * Add Reddit to oEmbed provider list (Luke Hardwick)
  * Remove sticky footer on small devices, so that content is not blocked and more easily editable (Saeed Tahmasebi)
+ * Add ability to replace the default Wagtail logo in the userbar, via ``branding_logo`` block (Meteor0id)
 
 
 Bug fixes

--- a/wagtail/admin/static_src/wagtailadmin/scss/userbar.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/userbar.scss
@@ -141,7 +141,7 @@ $positions: (
         left: 0;
     }
 
-    &. #{$namespace}-icon:before {
+    .#{$namespace}-icon:before {
         transition: color 0.2s ease;
         font-size: 32px;
         width: auto;

--- a/wagtail/admin/static_src/wagtailadmin/scss/userbar.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/userbar.scss
@@ -141,7 +141,7 @@ $positions: (
         left: 0;
     }
 
-    &.#{$namespace}-icon:before {
+    &. #{$namespace}-icon:before {
         transition: color 0.2s ease;
         font-size: 32px;
         width: auto;

--- a/wagtail/admin/templates/wagtailadmin/userbar/base.html
+++ b/wagtail/admin/templates/wagtailadmin/userbar/base.html
@@ -4,7 +4,10 @@
     <div class="wagtail-userbar wagtail-userbar--{{ position|default:'bottom-right' }}" data-wagtail-userbar>
         <link rel="stylesheet" href="{% versioned_static 'wagtailadmin/css/userbar.css' %}" type="text/css" />
         <div class="wagtail-userbar-nav">
-            <div class="wagtail-icon wagtail-icon-wagtail wagtail-userbar-trigger" data-wagtail-userbar-trigger>
+            <div class="wagtail-userbar-trigger" data-wagtail-userbar-trigger>
+                {% block branding_logo %}
+                <i class="wagtail-icon wagtail-icon-wagtail"></i>
+                {% endblock %}
                 <span class="wagtail-userbar-help-text">{% trans 'Go to Wagtail admin interface' %}</span>
             </div>
             <div class='wagtail-userbar-items'>


### PR DESCRIPTION
In the userbar the wagtail logo is loaded though a font. This behavior remains, however the font icon may now be overwritten by an image.

To acomplish this the classes which define the font icon have been split out to an icon tag which is a child of the userbar trigger div. The `<i>` tag is containted within a block called branding_logo, so the user may overwrite this block similar to overwriting the branding logo in other templates.

Please test my work, and modify if needed. (should go without saying)