### PR TITLE
Ask issue openers to confirm that bugs are reproducible

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -4,15 +4,17 @@ Found a bug? Please fill out the sections below. 👍
 
 A summary of the issue.
 
-### Steps to Reproduce
 
-It's essential that you provide enough information for someone else to replicate the problem you're seeing. Simply describing something that's broken on your current project is not enough!
+### Steps to Reproduce
 
 1. (for example) Start a new project with `wagtail start myproject`
 2. Edit models.py as follows...
 3. ...
 
 Any other relevant information. For example, why do you consider this a bug and what did you expect to happen instead?
+
+* I have confirmed that this issue can be reproduced as described on a fresh Wagtail project: (yes / no)
+
 
 ### Technical details
 


### PR DESCRIPTION
Right now, a lot of my time is wasted on bug reports where the "steps to reproduce" don't work because the reporter is simply describing something that happens on their existing project, without attempting to reproduce it independently - despite the note specifically telling people not to do that.

Hopefully, by changing it to a statement people have to actively fill in, we can make it harder to ignore (or, at least, easier to see when it's been ignored :-) )