### PR TITLE
Allow nav menu to take up all available space instead of scrolling

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -17,6 +17,7 @@ Changelog
  * Fix: Additional fields on custom document models now show on the multiple document upload view (Robert Rollins, Sergey Fedoseev)
  * Fix: Help text is partially hidden when using a combination of BooleanField and FieldPanel in page model (Dzianis Sheka)
  * Fix: Allow custom logos of any height in the admin menu (Meteor0id)
+ * Fix: Allow nav menu to take up all available space instead of scrolling (Meteor0id)
  * Fix: Redirects now return 404 when destination is unspecified or a page with no site (Hillary Jeffrey)
 
 

--- a/docs/releases/2.4.rst
+++ b/docs/releases/2.4.rst
@@ -40,6 +40,7 @@ Bug fixes
  * Help text does not overflow when using a combination of BooleanField and FieldPanel in page model (Dzianis Sheka)
  * Document chooser now displays more useful help message when there are no documents in Wagtail document library (gmmoraes, Stas Rudakou)
  * Allow custom logos of any height in the admin menu (Meteor0id)
+ * Allow nav menu to take up all available space instead of scrolling (Meteor0id)
  * Users without the edit permission no longer see "Edit" links in list of pages waiting for moderation (Justin Focus, Fedor Selitsky)
  * Redirects now return 404 when destination is unspecified or a page with no site (Hillary Jeffrey)
 

--- a/wagtail/admin/static_src/wagtailadmin/js/core.js
+++ b/wagtail/admin/static_src/wagtailadmin/js/core.js
@@ -92,6 +92,7 @@ $(function() {
     // Enable toggle to open/close user settings
     $(document).on('click', '#account-settings', function() {
         $('#footer').toggleClass('footer-open');
+        $('.nav-main').toggleClass('nav-more-margin-for-footer');
         $(this).find('em').toggleClass('icon-arrow-down-after icon-arrow-up-after');
     });
 

--- a/wagtail/admin/static_src/wagtailadmin/js/core.js
+++ b/wagtail/admin/static_src/wagtailadmin/js/core.js
@@ -91,8 +91,7 @@ $(function() {
 
     // Enable toggle to open/close user settings
     $(document).on('click', '#account-settings', function() {
-        $('#footer').toggleClass('footer-open');
-        $('.nav-main').toggleClass('nav-more-margin-for-footer');
+        $('.nav-main').toggleClass('nav-main--open-footer');
         $(this).find('em').toggleClass('icon-arrow-down-after icon-arrow-up-after');
     });
 

--- a/wagtail/admin/static_src/wagtailadmin/scss/components/_main-nav.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/components/_main-nav.scss
@@ -307,6 +307,7 @@ body.explorer-open {
             position: fixed;
             width: $menu-width;
             bottom: 0;
+            background-color: $footer-submenu; // Also acts as background for .account when it is semi-transparent
         }
 
         .footer-open .footer-submenu {
@@ -315,7 +316,7 @@ body.explorer-open {
 
         .footer-submenu {
             @include transition(max-height 0.2s ease);
-            background-color: $footer-submenu;
+            background-color: transparent;
             overflow: hidden;
             max-height: 0;
         }

--- a/wagtail/admin/static_src/wagtailadmin/scss/components/_main-nav.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/components/_main-nav.scss
@@ -295,27 +295,31 @@ body.explorer-open {
     }
 
     .nav-main {
+        $footer-closed-height: 50px;
+        $footer-submenu-height: 77px;
+        $footer-open-height: $footer-closed-height + $footer-submenu-height;
         overflow: auto;
+        margin-bottom: $footer-closed-height;
+        @include transition(margin-bottom 0.2s ease);
 
         .footer {
             position: fixed;
             width: $menu-width;
             bottom: 0;
-            background-color: $footer-submenu; // Also acts as background for .account when it is semi-transparent
+            background-color: $footer-submenu;
         }
 
         .footer-submenu {
             @include transition(max-height 0.2s ease);
-            background-color: transparent;
             overflow: hidden;
             max-height: 0;
         }
 
         &--open-footer {
-            margin-bottom: 127px; // WARNING - magic number - the height of the expanded .footer
+            margin-bottom: $footer-open-height;
 
             .footer-submenu {
-                max-height: 77px; // WARNING - magic number - the height of the .footer - the 50px height of .account
+                max-height: $footer-submenu-height;
             }
         }
 

--- a/wagtail/admin/static_src/wagtailadmin/scss/components/_main-nav.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/components/_main-nav.scss
@@ -310,15 +310,19 @@ body.explorer-open {
             background-color: $footer-submenu; // Also acts as background for .account when it is semi-transparent
         }
 
-        .footer-open .footer-submenu {
-            max-height: 77px; // WARNING - magic number - the height of the .footer - the 50px height of .account
-        }
-
         .footer-submenu {
             @include transition(max-height 0.2s ease);
             background-color: transparent;
             overflow: hidden;
             max-height: 0;
+        }
+
+        &--open-footer {
+            margin-bottom: 127px; // WARNING - magic number - the height of the expanded .footer
+
+            .footer-submenu {
+                max-height: 77px; // WARNING - magic number - the height of the .footer - the 50px height of .account
+            }
         }
 
         .account {
@@ -365,10 +369,6 @@ body.explorer-open {
                 }
             }
         }
-    }
-
-    .nav-main.nav-more-margin-for-footer {
-        margin-bottom: 127px; // WARNING - magic number - the height of the expanded .footer
     }
 
     .nav-submenu {

--- a/wagtail/admin/static_src/wagtailadmin/scss/components/_main-nav.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/components/_main-nav.scss
@@ -295,12 +295,6 @@ body.explorer-open {
     }
 
     .nav-main {
-        @include transition(margin-bottom 0.2s ease);
-        position: absolute;
-        top: 175px; // WARNING - magic number - the height of the logo plus search box
-        bottom: 0;
-        margin-bottom: 50px; // WARNING - magic number - the height of the unexpanded .footer
-        width: 100%;
         overflow: auto;
 
         .footer {

--- a/wagtail/admin/static_src/wagtailadmin/scss/components/_main-nav.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/components/_main-nav.scss
@@ -295,7 +295,12 @@ body.explorer-open {
     }
 
     .nav-main {
-        margin-bottom: 127px; // WARNING - magic number - the height of the .footer
+        @include transition(margin-bottom 0.2s ease);
+        position: absolute;
+        top: 175px; // WARNING - magic number - the height of the logo plus search box
+        bottom: 0;
+        margin-bottom: 50px; // WARNING - magic number - the height of the unexpanded .footer
+        width: 100%;
         overflow: auto;
 
         .footer {
@@ -305,7 +310,7 @@ body.explorer-open {
         }
 
         .footer-open .footer-submenu {
-            max-height: 127px; // WARNING - magic number - the height of the .footer
+            max-height: 77px; // WARNING - magic number - the height of the .footer - the 50px height of .account
         }
 
         .footer-submenu {
@@ -359,6 +364,10 @@ body.explorer-open {
                 }
             }
         }
+    }
+
+    .nav-main.nav-more-margin-for-footer {
+        margin-bottom: 127px; // WARNING - magic number - the height of the expanded .footer
     }
 
     .nav-submenu {


### PR DESCRIPTION
I noticed the nav-main had too much margin, always assuming the footer is in expanded position, and even than it was inaccurate. Fixed it.

To reproduce the issue, open an admin interface page with the footer not expanded, and resize your browsers height. You will notice the nav-main does not take up all the space it has, leaving a significant margin unused.

This PR fixes that.