### PR TITLE
Allow custom logos of any height in the admin menu

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -12,6 +12,7 @@ Changelog
  * Fix: Add `rel="noopener noreferrer"` to target blank links (Anselm Bradford)
  * Fix: Additional fields on custom document models now show on the multiple document upload view (Robert Rollins, Sergey Fedoseev)
  * Fix: Help text is partially hidden when using a combination of BooleanField and FieldPanel in page model (Dzianis Sheka)
+ * Fix: Allow custom logos of any height in the admin menu (Meteor0id)
 
 
 2.3 LTS (23.10.2018)

--- a/docs/releases/2.4.rst
+++ b/docs/releases/2.4.rst
@@ -35,6 +35,7 @@ Bug fixes
  * Additional fields on custom document models now show on the multiple document upload view (Robert Rollins, Sergey Fedoseev)
  * Help text does not overflow when using a combination of BooleanField and FieldPanel in page model (Dzianis Sheka)
  * Document chooser now displays more useful help message when there are no documents in Wagtail document library (gmmoraes, Stas Rudakou)
+ * Allow custom logos of any height in the admin menu (Meteor0id)
 
 
 Upgrade considerations

--- a/wagtail/admin/static_src/wagtailadmin/scss/components/_logo.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/components/_logo.scss
@@ -30,6 +30,8 @@
     padding: 0.9em 1.2em;
     margin: 0;
     -webkit-font-smoothing: auto;
+    width: 100%;
+    box-sizing: border-box;
 }
 
 // Desktop styling (override mobile styling):

--- a/wagtail/admin/static_src/wagtailadmin/scss/components/_logo.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/components/_logo.scss
@@ -24,14 +24,9 @@
 
 .logo {
     display: block;
-    text-align: left;
-    text-decoration: none;
     color: #aaa;
     padding: 0.9em 1.2em;
-    margin: 0;
     -webkit-font-smoothing: auto;
-    width: 100%;
-    box-sizing: border-box;
 }
 
 // Desktop styling (override mobile styling):

--- a/wagtail/admin/static_src/wagtailadmin/scss/components/_main-nav.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/components/_main-nav.scss
@@ -10,8 +10,12 @@
 
     .inner {
         background: $nav-grey-1;
-        display: flex;
-        flex-flow: column nowrap;
+
+        @include medium {
+            // On medium, make it possible for the nav links to scroll.
+            display: flex;
+            flex-flow: column nowrap;
+        }
     }
 }
 

--- a/wagtail/admin/static_src/wagtailadmin/scss/components/_main-nav.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/components/_main-nav.scss
@@ -10,6 +10,8 @@
 
     .inner {
         background: $nav-grey-1;
+        display: flex;
+        flex-flow: column nowrap;
     }
 }
 
@@ -162,8 +164,10 @@
 
 .nav-search {
     position: relative;
-    padding: 0;
-    margin: 0 1em 1em;
+    padding: 0 1em 1em;
+    margin: 0;
+    width: 100%;
+    box-sizing: border-box;
 
     label {
         @include visuallyhidden();
@@ -205,10 +209,10 @@
         top: 0;
         right: 0;
         bottom: 0;
-        margin: auto;
+        margin: 0 1em 1em;
         padding: 0;
         width: 3em;
-        height: 100%;
+        height: auto;
         overflow: hidden;
 
         &:hover {
@@ -290,9 +294,7 @@ body.explorer-open {
     }
 
     .nav-main {
-        position: absolute;
-        top: 175px; // WARNING - magic number - the height of the logo plus search box
-        bottom: 0;
+        position: relative;
         margin-bottom: 127px; // WARNING - magic number - the height of the .footer
         width: 100%;
         overflow: auto;

--- a/wagtail/admin/static_src/wagtailadmin/scss/components/_main-nav.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/components/_main-nav.scss
@@ -211,13 +211,10 @@
         background-color: transparent;
         position: absolute;
         top: 0;
-        right: 0;
+        right: 1em;
         bottom: 0;
-        margin: 0 1em 1em;
         padding: 0;
         width: 3em;
-        height: auto;
-        overflow: hidden;
 
         &:hover {
             background-color: $nav-item-hover-bg;
@@ -298,9 +295,7 @@ body.explorer-open {
     }
 
     .nav-main {
-        position: relative;
         margin-bottom: 127px; // WARNING - magic number - the height of the .footer
-        width: 100%;
         overflow: auto;
 
         .footer {


### PR DESCRIPTION
This provides a fix for Issue #3798 

Turns .inner into a flex container. The scrollbar is not compromised this way.

There is also PR #4746 which fixes various issues with other components of the nav bar.