### PR TITLE
EditHandler “dynamic” forms

### DIFF
--- a/wagtail/admin/edit_handlers.py
+++ b/wagtail/admin/edit_handlers.py
@@ -1,4 +1,5 @@
 import re
+from warnings import warn
 
 from django import forms
 from django.core.exceptions import ImproperlyConfigured
@@ -21,6 +22,7 @@ from wagtail.utils.decorators import cached_classmethod
 # DIRECT_FORM_FIELD_OVERRIDES, FORM_FIELD_OVERRIDES are imported for backwards
 # compatibility, as people are likely importing them from here and then
 # appending their own overrides
+from wagtail.utils.deprecation import RemovedInWagtail25Warning
 from .forms import (  # NOQA
     DIRECT_FORM_FIELD_OVERRIDES, FORM_FIELD_OVERRIDES, WagtailAdminModelForm, WagtailAdminPageForm,
     formfield_for_dbfield)
@@ -96,13 +98,20 @@ class EditHandler:
         self.heading = heading
         self.classname = classname
         self.help_text = help_text
+        self.model = None
+        self.instance = None
+        self.request = None
+        self.form = None
 
     def clone(self):
-        return self.__class__(
-            heading=self.heading,
-            classname=self.classname,
-            help_text=self.help_text,
-        )
+        return self.__class__(**self.clone_kwargs())
+
+    def clone_kwargs(self):
+        return {
+            'heading': self.heading,
+            'classname': self.classname,
+            'help_text': self.help_text,
+        }
 
     # return list of widget overrides that this EditHandler wants to be in place
     # on the form it receives
@@ -125,45 +134,58 @@ class EditHandler:
     def html_declarations(self):
         return ''
 
-    def bind_to_model(self, model):
+    def bind_to(self, model=None, instance=None, request=None, form=None):
+        if model is None and instance is not None and self.model is None:
+            model = instance._meta.model
+
         new = self.clone()
-        new.model = model
-        new.on_model_bound()
+        new.model = self.model if model is None else model
+        new.instance = self.instance if instance is None else instance
+        new.request = self.request if request is None else request
+        new.form = self.form if form is None else form
+
+        if new.model is not None:
+            new.on_model_bound()
+
+        if new.instance is not None:
+            new.on_instance_bound()
+
+        if new.request is not None:
+            new.on_request_bound()
+
+        if new.form is not None:
+            new.on_form_bound()
+
         return new
+
+    def bind_to_model(self, model):
+        warn('EditHandler.bind_to_model(model) is deprecated. '
+             'Use EditHandler.bind_to(model=model) instead',
+             category=RemovedInWagtail25Warning)
+        return self.bind_to(model=model)
+
+    def bind_to_instance(self, instance, form, request):
+        warn('EditHandler.bind_to_instance(instance, request, form) is deprecated. '
+             'Use EditHandler.bind_to(instance=instance, request=request, form=form) instead',
+             category=RemovedInWagtail25Warning)
+        return self.bind_to(instance=instance, request=request, form=form)
 
     def on_model_bound(self):
         pass
 
-    def bind_to_instance(self, instance=None, form=None, request=None):
-        new = self.bind_to_model(self.model)
-
-        if not instance:
-            raise ValueError("EditHandler did not receive an instance object")
-        new.instance = instance
-
-        if not form:
-            raise ValueError("EditHandler did not receive a form object")
-        new.form = form
-
-        if request is None:
-            raise ValueError("EditHandler did not receive a request object")
-        new.request = request
-
-        new.on_instance_bound()
-
-        return new
-
     def on_instance_bound(self):
         pass
 
+    def on_request_bound(self):
+        pass
+
+    def on_form_bound(self):
+        pass
+
     def __repr__(self):
-        class_name = self.__class__.__name__
-        try:
-            bound_to = force_text(getattr(self, 'instance',
-                                          getattr(self, 'model')))
-        except AttributeError:
-            return '<%s>' % class_name
-        return '<%s bound to %s>' % (class_name, bound_to)
+        return '<%s with model=%s instance=%s request=%s form=%s>' % (
+            self.__class__.__name__,
+            self.model, self.instance, self.request, self.form)
 
     def classes(self):
         """
@@ -243,13 +265,10 @@ class BaseCompositeEditHandler(EditHandler):
         super().__init__(*args, **kwargs)
         self.children = children
 
-    def clone(self):
-        return self.__class__(
-            children=self.children,
-            heading=self.heading,
-            classname=self.classname,
-            help_text=self.help_text,
-        )
+    def clone_kwargs(self):
+        kwargs = super().clone_kwargs()
+        kwargs['children'] = self.children
+        return kwargs
 
     def widget_overrides(self):
         # build a collated version of all its children's widget lists
@@ -276,10 +295,18 @@ class BaseCompositeEditHandler(EditHandler):
         return mark_safe(''.join([c.html_declarations() for c in self.children]))
 
     def on_model_bound(self):
-        self.children = [child.bind_to_model(self.model)
+        self.children = [child.bind_to(model=self.model)
                          for child in self.children]
 
     def on_instance_bound(self):
+        self.children = [child.bind_to(instance=self.instance)
+                         for child in self.children]
+
+    def on_request_bound(self):
+        self.children = [child.bind_to(request=self.request)
+                         for child in self.children]
+
+    def on_form_bound(self):
         children = []
         for child in self.children:
             if isinstance(child, FieldPanel):
@@ -289,9 +316,7 @@ class BaseCompositeEditHandler(EditHandler):
                 if self.form._meta.fields:
                     if child.field_name not in self.form._meta.fields:
                         continue
-            children.append(child.bind_to_instance(instance=self.instance,
-                                                   form=self.form,
-                                                   request=self.request))
+            children.append(child.bind_to(form=self.form))
         self.children = children
 
     def render(self):
@@ -325,9 +350,9 @@ class BaseFormEditHandler(BaseCompositeEditHandler):
         Construct a form class that has all the fields and formsets named in
         the children of this edit handler.
         """
-        if not hasattr(self, 'model'):
+        if self.model is None:
             raise AttributeError(
-                '%s is not bound to a model yet. Use `.bind_to_model(model)` '
+                '%s is not bound to a model yet. Use `.bind_to(model=model)` '
                 'before using this method.' % self.__class__.__name__)
         # If a custom form class was passed to the EditHandler, use it.
         # Otherwise, use the base_form_class from the model.
@@ -351,10 +376,10 @@ class TabbedInterface(BaseFormEditHandler):
         self.base_form_class = kwargs.pop('base_form_class', None)
         super().__init__(*args, **kwargs)
 
-    def clone(self):
-        new = super().clone()
-        new.base_form_class = self.base_form_class
-        return new
+    def clone_kwargs(self):
+        kwargs = super().clone_kwargs()
+        kwargs['base_form_class'] = self.base_form_class
+        return kwargs
 
 
 class ObjectList(TabbedInterface):
@@ -391,13 +416,14 @@ class HelpPanel(EditHandler):
         self.content = content
         self.template = template
 
-    def clone(self):
-        return self.__class__(
+    def clone_kwargs(self):
+        kwargs = super().clone_kwargs()
+        del kwargs['help_text']
+        kwargs.update(
             content=self.content,
             template=self.template,
-            heading=self.heading,
-            classname=self.classname,
         )
+        return kwargs
 
     def render(self):
         return mark_safe(render_to_string(self.template, {
@@ -415,14 +441,13 @@ class FieldPanel(EditHandler):
         super().__init__(*args, **kwargs)
         self.field_name = field_name
 
-    def clone(self):
-        return self.__class__(
+    def clone_kwargs(self):
+        kwargs = super().clone_kwargs()
+        kwargs.update(
             field_name=self.field_name,
             widget=self.widget if hasattr(self, 'widget') else None,
-            heading=self.heading,
-            classname=self.classname,
-            help_text=self.help_text
         )
+        return kwargs
 
     def widget_overrides(self):
         """check if a specific widget has been defined for this field"""
@@ -514,19 +539,15 @@ class FieldPanel(EditHandler):
 
         return model._meta.get_field(self.field_name)
 
-    def on_instance_bound(self):
+    def on_form_bound(self):
         self.bound_field = self.form[self.field_name]
         self.heading = self.bound_field.label
         self.help_text = self.bound_field.help_text
 
     def __repr__(self):
-        class_name = self.__class__.__name__
-        try:
-            bound_to = force_text(getattr(self, 'instance',
-                                          getattr(self, 'model')))
-        except AttributeError:
-            return "<%s '%s'>" % (class_name, self.field_name)
-        return "<%s '%s' bound to %s>" % (class_name, self.field_name, bound_to)
+        return "<%s '%s' with model=%s instance=%s request=%s form=%s>" % (
+            self.__class__.__name__, self.field_name,
+            self.model, self.instance, self.request, self.form)
 
 
 class RichTextFieldPanel(FieldPanel):
@@ -583,12 +604,12 @@ class PageChooserPanel(BaseChooserPanel):
         self.page_type = page_type
         self.can_choose_root = can_choose_root
 
-    def clone(self):
-        return self.__class__(
-            field_name=self.field_name,
-            page_type=self.page_type,
-            can_choose_root=self.can_choose_root,
-        )
+    def clone_kwargs(self):
+        return {
+            'field_name': self.field_name,
+            'page_type': self.page_type,
+            'can_choose_root': self.can_choose_root,
+        }
 
     def widget_overrides(self):
         return {self.field_name: widgets.AdminPageChooser(
@@ -630,17 +651,16 @@ class InlinePanel(EditHandler):
         self.min_num = min_num
         self.max_num = max_num
 
-    def clone(self):
-        return self.__class__(
+    def clone_kwargs(self):
+        kwargs = super().clone_kwargs()
+        kwargs.update(
             relation_name=self.relation_name,
             panels=self.panels,
-            heading=self.heading,
             label=self.label,
-            help_text=self.help_text,
             min_num=self.min_num,
             max_num=self.max_num,
-            classname=self.classname,
         )
+        return kwargs
 
     def get_panel_definitions(self):
         # Look for a panels definition in the InlinePanel declaration
@@ -655,7 +675,7 @@ class InlinePanel(EditHandler):
     def get_child_edit_handler(self):
         panels = self.get_panel_definitions()
         child_edit_handler = MultiFieldPanel(panels, heading=self.heading)
-        return child_edit_handler.bind_to_model(self.db_field.related_model)
+        return child_edit_handler.bind_to(model=self.db_field.related_model)
 
     def required_formsets(self):
         child_edit_handler = self.get_child_edit_handler()
@@ -678,7 +698,7 @@ class InlinePanel(EditHandler):
 
         for panel in self.get_panel_definitions():
             field_comparisons.extend(
-                panel.bind_to_model(self.db_field.related_model)
+                panel.bind_to(model=self.db_field.related_model)
                 .get_comparison())
 
         return [curry(compare.ChildRelationComparison, self.db_field,
@@ -688,7 +708,7 @@ class InlinePanel(EditHandler):
         manager = getattr(self.model, self.relation_name)
         self.db_field = manager.rel
 
-    def on_instance_bound(self):
+    def on_form_bound(self):
         self.formset = self.form.formsets[self.relation_name]
 
         self.children = []
@@ -701,10 +721,8 @@ class InlinePanel(EditHandler):
                 subform.fields[ORDERING_FIELD_NAME].widget = forms.HiddenInput()
 
             child_edit_handler = self.get_child_edit_handler()
-            self.children.append(
-                child_edit_handler.bind_to_instance(instance=subform.instance,
-                                                    form=subform,
-                                                    request=self.request))
+            self.children.append(child_edit_handler.bind_to(
+                instance=subform.instance, request=self.request, form=subform))
 
         # if this formset is valid, it may have been re-ordered; respect that
         # in case the parent form errored and we need to re-render
@@ -718,8 +736,8 @@ class InlinePanel(EditHandler):
             empty_form.fields[ORDERING_FIELD_NAME].widget = forms.HiddenInput()
 
         self.empty_child = self.get_child_edit_handler()
-        self.empty_child = self.empty_child.bind_to_instance(
-            instance=empty_form.instance, form=empty_form, request=self.request)
+        self.empty_child = self.empty_child.bind_to(
+            instance=empty_form.instance, request=self.request, form=empty_form)
 
     template = "wagtailadmin/edit_handlers/inline_panel.html"
 
@@ -786,21 +804,26 @@ def get_edit_handler(cls):
     Get the EditHandler to use in the Wagtail admin when editing this page type.
     """
     if hasattr(cls, 'edit_handler'):
-        return cls.edit_handler.bind_to_model(cls)
+        edit_handler = cls.edit_handler
+    else:
+        # construct a TabbedInterface made up of content_panels, promote_panels
+        # and settings_panels, skipping any which are empty
+        tabs = []
 
-    # construct a TabbedInterface made up of content_panels, promote_panels
-    # and settings_panels, skipping any which are empty
-    tabs = []
+        if cls.content_panels:
+            tabs.append(ObjectList(cls.content_panels,
+                                   heading=ugettext_lazy('Content')))
+        if cls.promote_panels:
+            tabs.append(ObjectList(cls.promote_panels,
+                                   heading=ugettext_lazy('Promote')))
+        if cls.settings_panels:
+            tabs.append(ObjectList(cls.settings_panels,
+                                   heading=ugettext_lazy('Settings'),
+                                   classname='settings'))
 
-    if cls.content_panels:
-        tabs.append(ObjectList(cls.content_panels, heading=ugettext_lazy('Content')))
-    if cls.promote_panels:
-        tabs.append(ObjectList(cls.promote_panels, heading=ugettext_lazy('Promote')))
-    if cls.settings_panels:
-        tabs.append(ObjectList(cls.settings_panels, heading=ugettext_lazy('Settings'), classname="settings"))
+        edit_handler = TabbedInterface(tabs, base_form_class=cls.base_form_class)
 
-    edit_handler = TabbedInterface(tabs, base_form_class=cls.base_form_class)
-    return edit_handler.bind_to_model(cls)
+    return edit_handler.bind_to(model=cls)
 
 
 Page.get_edit_handler = get_edit_handler

--- a/wagtail/admin/edit_handlers.py
+++ b/wagtail/admin/edit_handlers.py
@@ -7,7 +7,6 @@ from django.db.models.fields import FieldDoesNotExist
 from django.forms.formsets import DELETION_FIELD_NAME, ORDERING_FIELD_NAME
 from django.forms.models import fields_for_model
 from django.template.loader import render_to_string
-from django.utils.encoding import force_text
 from django.utils.functional import cached_property, curry
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy

--- a/wagtail/admin/tests/test_edit_handlers.py
+++ b/wagtail/admin/tests/test_edit_handlers.py
@@ -241,7 +241,7 @@ class TestTabbedInterface(TestCase):
             ObjectList([
                 InlinePanel('speakers', label="Speakers"),
             ], heading='Speakers'),
-        ]).bind_to_model(EventPage)
+        ]).bind_to(model=EventPage, request=self.request)
 
     def test_get_form_class(self):
         EventPageForm = self.event_page_tabbed_interface.get_form_class()
@@ -258,10 +258,9 @@ class TestTabbedInterface(TestCase):
         event = EventPage(title='Abergavenny sheepdog trials')
         form = EventPageForm(instance=event)
 
-        tabbed_interface = self.event_page_tabbed_interface.bind_to_instance(
+        tabbed_interface = self.event_page_tabbed_interface.bind_to(
             instance=event,
             form=form,
-            request=self.request
         )
 
         result = tabbed_interface.render()
@@ -291,10 +290,9 @@ class TestTabbedInterface(TestCase):
         event = EventPage(title='Abergavenny sheepdog trials')
         form = EventPageForm(instance=event)
 
-        tabbed_interface = self.event_page_tabbed_interface.bind_to_instance(
+        tabbed_interface = self.event_page_tabbed_interface.bind_to(
             instance=event,
             form=form,
-            request=self.request
         )
 
         result = tabbed_interface.render_form_content()
@@ -316,7 +314,8 @@ class TestObjectList(TestCase):
             FieldPanel('date_from'),
             FieldPanel('date_to'),
             InlinePanel('speakers', label="Speakers"),
-        ], heading='Event details', classname="shiny").bind_to_model(EventPage)
+        ], heading='Event details', classname="shiny").bind_to(
+            model=EventPage, request=self.request)
 
     def test_get_form_class(self):
         EventPageForm = self.event_page_object_list.get_form_class()
@@ -333,10 +332,9 @@ class TestObjectList(TestCase):
         event = EventPage(title='Abergavenny sheepdog trials')
         form = EventPageForm(instance=event)
 
-        object_list = self.event_page_object_list.bind_to_instance(
+        object_list = self.event_page_object_list.bind_to(
             instance=event,
             form=form,
-            request=self.request
         )
 
         result = object_list.render()
@@ -369,12 +367,12 @@ class TestFieldPanel(TestCase):
                                date_from=date(2014, 7, 20), date_to=date(2014, 7, 21))
 
         self.end_date_panel = (FieldPanel('date_to', classname='full-width')
-                               .bind_to_model(EventPage))
+                               .bind_to(model=EventPage, request=self.request))
 
     def test_non_model_field(self):
         # defining a FieldPanel for a field which isn't part of a model is OK,
         # because it might be defined on the form instead
-        field_panel = FieldPanel('barbecue').bind_to_model(Page)
+        field_panel = FieldPanel('barbecue').bind_to(model=Page)
 
         # however, accessing db_field will fail
         with self.assertRaises(FieldDoesNotExist):
@@ -387,10 +385,9 @@ class TestFieldPanel(TestCase):
 
         form.is_valid()
 
-        field_panel = self.end_date_panel.bind_to_instance(
+        field_panel = self.end_date_panel.bind_to(
             instance=self.event,
             form=form,
-            request=self.request
         )
         result = field_panel.render_as_object()
 
@@ -415,10 +412,9 @@ class TestFieldPanel(TestCase):
 
         form.is_valid()
 
-        field_panel = self.end_date_panel.bind_to_instance(
+        field_panel = self.end_date_panel.bind_to(
             instance=self.event,
             form=form,
-            request=self.request
         )
         result = field_panel.render_as_field()
 
@@ -446,10 +442,9 @@ class TestFieldPanel(TestCase):
 
         form.is_valid()
 
-        field_panel = self.end_date_panel.bind_to_instance(
+        field_panel = self.end_date_panel.bind_to(
             instance=self.event,
             form=form,
-            request=self.request
         )
         result = field_panel.render_as_field()
 
@@ -471,7 +466,7 @@ class TestFieldRowPanel(TestCase):
         self.dates_panel = FieldRowPanel([
             FieldPanel('date_from', classname='col4'),
             FieldPanel('date_to', classname='coltwo'),
-        ]).bind_to_model(EventPage)
+        ]).bind_to(model=EventPage, request=self.request)
 
     def test_render_as_object(self):
         form = self.EventPageForm(
@@ -480,10 +475,9 @@ class TestFieldRowPanel(TestCase):
 
         form.is_valid()
 
-        field_panel = self.dates_panel.bind_to_instance(
+        field_panel = self.dates_panel.bind_to(
             instance=self.event,
             form=form,
-            request=self.request
         )
         result = field_panel.render_as_object()
 
@@ -500,10 +494,9 @@ class TestFieldRowPanel(TestCase):
 
         form.is_valid()
 
-        field_panel = self.dates_panel.bind_to_instance(
+        field_panel = self.dates_panel.bind_to(
             instance=self.event,
             form=form,
-            request=self.request
         )
         result = field_panel.render_as_field()
 
@@ -527,10 +520,9 @@ class TestFieldRowPanel(TestCase):
 
         form.is_valid()
 
-        field_panel = self.dates_panel.bind_to_instance(
+        field_panel = self.dates_panel.bind_to(
             instance=self.event,
             form=form,
-            request=self.request
         )
         result = field_panel.render_as_field()
 
@@ -544,10 +536,9 @@ class TestFieldRowPanel(TestCase):
 
         form.is_valid()
 
-        field_panel = self.dates_panel.bind_to_instance(
+        field_panel = self.dates_panel.bind_to(
             instance=self.event,
             form=form,
-            request=self.request
         )
 
         result = field_panel.render_as_field()
@@ -561,10 +552,9 @@ class TestFieldRowPanel(TestCase):
 
         form.is_valid()
 
-        field_panel = self.dates_panel.bind_to_instance(
+        field_panel = self.dates_panel.bind_to(
             instance=self.event,
             form=form,
-            request=self.request
         )
 
         result = field_panel.render_as_field()
@@ -586,7 +576,7 @@ class TestFieldRowPanelWithChooser(TestCase):
         self.dates_panel = FieldRowPanel([
             FieldPanel('date_from'),
             ImageChooserPanel('feed_image'),
-        ]).bind_to_model(EventPage)
+        ]).bind_to(model=EventPage, request=self.request)
 
     def test_render_as_object(self):
         form = self.EventPageForm(
@@ -595,10 +585,9 @@ class TestFieldRowPanelWithChooser(TestCase):
 
         form.is_valid()
 
-        field_panel = self.dates_panel.bind_to_instance(
+        field_panel = self.dates_panel.bind_to(
             instance=self.event,
             form=form,
-            request=self.request
         )
         result = field_panel.render_as_object()
 
@@ -621,7 +610,8 @@ class TestPageChooserPanel(TestCase):
 
         # a PageChooserPanel class that works on PageChooserModel's 'page' field
         self.edit_handler = (ObjectList([PageChooserPanel('page')])
-                             .bind_to_model(PageChooserModel))
+                             .bind_to(model=PageChooserModel,
+                                      request=self.request))
         self.my_page_chooser_panel = self.edit_handler.children[0]
 
         # build a form class containing the fields that MyPageChooserPanel wants
@@ -633,8 +623,8 @@ class TestPageChooserPanel(TestCase):
         self.test_instance = model.objects.create(page=self.christmas_page)
 
         self.form = self.PageChooserForm(instance=self.test_instance)
-        self.page_chooser_panel = self.my_page_chooser_panel.bind_to_instance(
-            instance=self.test_instance, form=self.form, request=self.request)
+        self.page_chooser_panel = self.my_page_chooser_panel.bind_to(
+            instance=self.test_instance, form=self.form)
 
     def test_page_chooser_uses_correct_widget(self):
         self.assertEqual(type(self.form.fields['page'].widget), AdminPageChooser)
@@ -651,12 +641,12 @@ class TestPageChooserPanel(TestCase):
 
         my_page_object_list = ObjectList([
             PageChooserPanel('page', can_choose_root=True)
-        ]).bind_to_model(PageChooserModel)
+        ]).bind_to(model=PageChooserModel)
         my_page_chooser_panel = my_page_object_list.children[0]
         PageChooserForm = my_page_object_list.get_form_class()
 
         form = PageChooserForm(instance=self.test_instance)
-        page_chooser_panel = my_page_chooser_panel.bind_to_instance(
+        page_chooser_panel = my_page_chooser_panel.bind_to(
             instance=self.test_instance, form=form, request=self.request)
         result = page_chooser_panel.render_as_field()
 
@@ -681,7 +671,7 @@ class TestPageChooserPanel(TestCase):
     def test_render_as_empty_field(self):
         test_instance = PageChooserModel()
         form = self.PageChooserForm(instance=test_instance)
-        page_chooser_panel = self.my_page_chooser_panel.bind_to_instance(
+        page_chooser_panel = self.my_page_chooser_panel.bind_to(
             instance=test_instance, form=form, request=self.request)
         result = page_chooser_panel.render_as_field()
 
@@ -693,7 +683,7 @@ class TestPageChooserPanel(TestCase):
         form = self.PageChooserForm({'page': ''}, instance=self.test_instance)
         self.assertFalse(form.is_valid())
 
-        page_chooser_panel = self.my_page_chooser_panel.bind_to_instance(
+        page_chooser_panel = self.my_page_chooser_panel.bind_to(
             instance=self.test_instance, form=form, request=self.request)
         self.assertIn('<span>This field is required.</span>', page_chooser_panel.render_as_field())
 
@@ -702,11 +692,11 @@ class TestPageChooserPanel(TestCase):
         # to restrict the chooser to that page type
         my_page_object_list = ObjectList([
             PageChooserPanel('page', 'tests.EventPage')
-        ]).bind_to_model(EventPageChooserModel)
+        ]).bind_to(model=EventPageChooserModel)
         my_page_chooser_panel = my_page_object_list.children[0]
         PageChooserForm = my_page_object_list.get_form_class()
         form = PageChooserForm(instance=self.test_instance)
-        page_chooser_panel = my_page_chooser_panel.bind_to_instance(
+        page_chooser_panel = my_page_chooser_panel.bind_to(
             instance=self.test_instance, form=form, request=self.request)
 
         result = page_chooser_panel.render_as_field()
@@ -719,12 +709,13 @@ class TestPageChooserPanel(TestCase):
         # Model has a foreign key to EventPage, which we want to autodetect
         # instead of specifying the page type in PageChooserPanel
         my_page_object_list = (ObjectList([PageChooserPanel('page')])
-                               .bind_to_model(EventPageChooserModel))
+                               .bind_to(model=EventPageChooserModel,
+                                        request=self.request))
         my_page_chooser_panel = my_page_object_list.children[0]
         PageChooserForm = my_page_object_list.get_form_class()
         form = PageChooserForm(instance=self.test_instance)
-        page_chooser_panel = my_page_chooser_panel.bind_to_instance(
-            instance=self.test_instance, form=form, request=self.request)
+        page_chooser_panel = my_page_chooser_panel.bind_to(
+            instance=self.test_instance, form=form)
 
         result = page_chooser_panel.render_as_field()
         expected_js = 'createPageChooser("{id}", ["{model}"], {parent}, false, null);'.format(
@@ -736,14 +727,14 @@ class TestPageChooserPanel(TestCase):
         result = PageChooserPanel(
             'page',
             'wagtailcore.site'
-        ).bind_to_model(PageChooserModel).target_models()
+        ).bind_to(model=PageChooserModel).target_models()
         self.assertEqual(result, [Site])
 
     def test_target_models_malformed_type(self):
         result = PageChooserPanel(
             'page',
             'snowman'
-        ).bind_to_model(PageChooserModel)
+        ).bind_to(model=PageChooserModel)
         self.assertRaises(ImproperlyConfigured,
                           result.target_models)
 
@@ -751,7 +742,7 @@ class TestPageChooserPanel(TestCase):
         result = PageChooserPanel(
             'page',
             'snowman.lorry'
-        ).bind_to_model(PageChooserModel)
+        ).bind_to(model=PageChooserModel)
         self.assertRaises(ImproperlyConfigured,
                           result.target_models)
 
@@ -771,7 +762,7 @@ class TestInlinePanel(TestCase, WagtailTestUtils):
         """
         speaker_object_list = ObjectList([
             InlinePanel('speakers', label="Speakers", classname="classname-for-speakers")
-        ]).bind_to_model(EventPage)
+        ]).bind_to(model=EventPage, request=self.request)
         EventPageForm = speaker_object_list.get_form_class()
 
         # SpeakerInlinePanel should instruct the form class to include a 'speakers' formset
@@ -780,9 +771,7 @@ class TestInlinePanel(TestCase, WagtailTestUtils):
         event_page = EventPage.objects.get(slug='christmas')
 
         form = EventPageForm(instance=event_page)
-        panel = speaker_object_list.bind_to_instance(instance=event_page,
-                                                     form=form,
-                                                     request=self.request)
+        panel = speaker_object_list.bind_to(instance=event_page, form=form)
 
         result = panel.render_as_field()
 
@@ -826,7 +815,7 @@ class TestInlinePanel(TestCase, WagtailTestUtils):
                 FieldPanel('first_name', widget=forms.Textarea),
                 ImageChooserPanel('image'),
             ]),
-        ]).bind_to_model(EventPage)
+        ]).bind_to(model=EventPage, request=self.request)
         speaker_inline_panel = speaker_object_list.children[0]
         EventPageForm = speaker_object_list.get_form_class()
 
@@ -836,8 +825,7 @@ class TestInlinePanel(TestCase, WagtailTestUtils):
         event_page = EventPage.objects.get(slug='christmas')
 
         form = EventPageForm(instance=event_page)
-        panel = speaker_inline_panel.bind_to_instance(
-            instance=event_page, form=form, request=self.request)
+        panel = speaker_inline_panel.bind_to(instance=event_page, form=form)
 
         result = panel.render_as_field()
 
@@ -888,13 +876,12 @@ class TestInlinePanel(TestCase, WagtailTestUtils):
                 FieldPanel('first_name', widget=forms.Textarea),
                 ImageChooserPanel('image'),
             ]),
-        ]).bind_to_model(EventPage)
+        ]).bind_to(model=EventPage, request=self.request)
         speaker_inline_panel = speaker_object_list.children[0]
         EventPageForm = speaker_object_list.get_form_class()
         event_page = EventPage.objects.get(slug='christmas')
         form = EventPageForm(instance=event_page)
-        panel = speaker_inline_panel.bind_to_instance(
-            instance=event_page, form=form, request=self.request)
+        panel = speaker_inline_panel.bind_to(instance=event_page, form=form)
 
         self.assertIn('maxForms: 1000', panel.render_js_init())
 

--- a/wagtail/admin/tests/test_edit_handlers.py
+++ b/wagtail/admin/tests/test_edit_handlers.py
@@ -27,7 +27,7 @@ class TestGetFormForModel(TestCase):
         with self.assertRaisesMessage(
                 AttributeError,
                 'ObjectList is not bound to a model yet. '
-                'Use `.bind_to_model(model)` before using this method.'):
+                'Use `.bind_to(model=model)` before using this method.'):
             edit_handler.get_form_class()
 
     def test_get_form_for_model(self):

--- a/wagtail/admin/views/pages.py
+++ b/wagtail/admin/views/pages.py
@@ -201,6 +201,7 @@ def create(request, content_type_app_name, content_type_model_name, parent_page_
 
     page = page_class(owner=request.user)
     edit_handler = page_class.get_edit_handler()
+    edit_handler = edit_handler.bind_to(request=request)
     form_class = edit_handler.get_form_class()
 
     next_url = get_valid_next_url_from_request(request)
@@ -287,15 +288,13 @@ def create(request, content_type_app_name, content_type_model_name, parent_page_
             messages.validation_error(
                 request, _("The page could not be created due to validation errors"), form
             )
-            edit_handler = edit_handler.bind_to_instance(instance=page,
-                                                         form=form,
-                                                         request=request)
             has_unsaved_changes = True
     else:
         signals.init_new_page.send(sender=create, page=page, parent=parent_page)
         form = form_class(instance=page, parent_page=parent_page)
-        edit_handler = edit_handler.bind_to_instance(instance=page, form=form, request=request)
         has_unsaved_changes = False
+
+    edit_handler = edit_handler.bind_to(instance=page, form=form)
 
     return render(request, 'wagtailadmin/pages/create.html', {
         'content_type': content_type,
@@ -328,6 +327,7 @@ def edit(request, page_id):
             return result
 
     edit_handler = page_class.get_edit_handler()
+    edit_handler = edit_handler.bind_to(instance=page, request=request)
     form_class = edit_handler.get_form_class()
 
     next_url = get_valid_next_url_from_request(request)
@@ -488,23 +488,20 @@ def edit(request, page_id):
                 messages.validation_error(
                     request, _("The page could not be saved due to validation errors"), form
                 )
-
-            edit_handler = edit_handler.bind_to_instance(instance=page,
-                                                         form=form,
-                                                         request=request)
             errors_debug = (
-                repr(edit_handler.form.errors) +
+                repr(form.errors) +
                 repr([
                     (name, formset.errors)
-                    for (name, formset) in edit_handler.form.formsets.items()
+                    for (name, formset) in form.formsets.items()
                     if formset.errors
                 ])
             )
             has_unsaved_changes = True
     else:
         form = form_class(instance=page, parent_page=parent)
-        edit_handler = edit_handler.bind_to_instance(instance=page, form=form, request=request)
         has_unsaved_changes = False
+
+    edit_handler = edit_handler.bind_to(form=form)
 
     # Check for revisions still undergoing moderation and warn
     if latest_revision and latest_revision.submitted_for_moderation:
@@ -1116,12 +1113,12 @@ def revisions_revert(request, page_id, revision_id):
     page_class = content_type.model_class()
 
     edit_handler = page_class.get_edit_handler()
+    edit_handler = edit_handler.bind_to(instance=revision_page,
+                                        request=request)
     form_class = edit_handler.get_form_class()
 
     form = form_class(instance=revision_page)
-    edit_handler = edit_handler.bind_to_instance(instance=revision_page,
-                                                 form=form,
-                                                 request=request)
+    edit_handler = edit_handler.bind_to(form=form)
 
     user_avatar = render_to_string('wagtailadmin/shared/user_avatar.html', {'user': revision.user})
 

--- a/wagtail/contrib/forms/tests/test_views.py
+++ b/wagtail/contrib/forms/tests/test_views.py
@@ -31,9 +31,7 @@ class TestFormResponsesPanel(TestCase):
             FormPage, form_class=WagtailAdminPageForm
         )
 
-        submissions_panel = FormSubmissionsPanel().bind_to_model(FormPage)
-
-        self.panel = submissions_panel.bind_to_instance(
+        self.panel = FormSubmissionsPanel().bind_to(
             instance=self.form_page, form=self.FormPageForm(), request=self.request)
 
     def test_render_with_submissions(self):
@@ -74,11 +72,8 @@ class TestFormResponsesPanelWithCustomSubmissionClass(TestCase):
         self.test_user = get_user_model().objects.create_user(
             username='user-n1kola', password='123')
 
-        submissions_panel = FormSubmissionsPanel().bind_to_model(FormPageWithCustomSubmission)
-
-        self.panel = submissions_panel.bind_to_instance(self.form_page,
-                                                        self.FormPageForm(),
-                                                        request=self.request)
+        self.panel = FormSubmissionsPanel().bind_to(
+            instance=self.form_page, form=self.FormPageForm(), request=self.request)
 
     def test_render_with_submissions(self):
         """Show the panel with the count of submission and a link to the list_submissions view."""

--- a/wagtail/contrib/modeladmin/views.py
+++ b/wagtail/contrib/modeladmin/views.py
@@ -121,7 +121,7 @@ class ModelFormView(WMABaseView, FormView):
             fields_to_exclude = self.model_admin.get_form_fields_exclude(request=self.request)
             panels = extract_panel_definitions_from_model_class(self.model, exclude=fields_to_exclude)
             edit_handler = ObjectList(panels)
-        return edit_handler.bind_to_model(self.model)
+        return edit_handler.bind_to(model=self.model)
 
     def get_form_class(self):
         return self.get_edit_handler().get_form_class()
@@ -148,8 +148,8 @@ class ModelFormView(WMABaseView, FormView):
         instance = self.get_instance()
         edit_handler = self.get_edit_handler()
         form = self.get_form()
-        edit_handler = edit_handler.bind_to_instance(
-            instance=instance, form=form, request=self.request)
+        edit_handler = edit_handler.bind_to(
+            instance=instance, request=self.request, form=form)
         context = {
             'is_multipart': form.is_multipart(),
             'edit_handler': edit_handler,

--- a/wagtail/snippets/tests.py
+++ b/wagtail/snippets/tests.py
@@ -442,9 +442,8 @@ class TestSnippetChooserPanel(TestCase, WagtailTestUtils):
         self.edit_handler = get_snippet_edit_handler(model)
         self.form_class = self.edit_handler.get_form_class()
         form = self.form_class(instance=test_snippet)
-        edit_handler = self.edit_handler.bind_to_instance(instance=test_snippet,
-                                                          form=form,
-                                                          request=self.request)
+        edit_handler = self.edit_handler.bind_to(
+            instance=test_snippet, form=form, request=self.request)
 
         self.snippet_chooser_panel = [
             panel for panel in edit_handler.children
@@ -462,9 +461,8 @@ class TestSnippetChooserPanel(TestCase, WagtailTestUtils):
     def test_render_as_empty_field(self):
         test_snippet = SnippetChooserModel()
         form = self.form_class(instance=test_snippet)
-        edit_handler = self.edit_handler.bind_to_instance(instance=test_snippet,
-                                                          form=form,
-                                                          request=self.request)
+        edit_handler = self.edit_handler.bind_to(
+            instance=test_snippet, form=form, request=self.request)
 
         snippet_chooser_panel = [
             panel for panel in edit_handler.children
@@ -482,7 +480,7 @@ class TestSnippetChooserPanel(TestCase, WagtailTestUtils):
     def test_target_model_autodetected(self):
         result = SnippetChooserPanel(
             'advert'
-        ).bind_to_model(SnippetChooserModel).target_model
+        ).bind_to(model=SnippetChooserModel).target_model
         self.assertEqual(result, Advert)
 
 
@@ -1043,9 +1041,8 @@ class TestSnippetChooserPanelWithCustomPrimaryKey(TestCase, WagtailTestUtils):
         self.edit_handler = get_snippet_edit_handler(model)
         self.form_class = self.edit_handler.get_form_class()
         form = self.form_class(instance=test_snippet)
-        edit_handler = self.edit_handler.bind_to_instance(instance=test_snippet,
-                                                          form=form,
-                                                          request=self.request)
+        edit_handler = self.edit_handler.bind_to(
+            instance=test_snippet, form=form, request=self.request)
 
         self.snippet_chooser_panel = [
             panel for panel in edit_handler.children
@@ -1063,9 +1060,8 @@ class TestSnippetChooserPanelWithCustomPrimaryKey(TestCase, WagtailTestUtils):
     def test_render_as_empty_field(self):
         test_snippet = SnippetChooserModelWithCustomPrimaryKey()
         form = self.form_class(instance=test_snippet)
-        edit_handler = self.edit_handler.bind_to_instance(instance=test_snippet,
-                                                          form=form,
-                                                          request=self.request)
+        edit_handler = self.edit_handler.bind_to(
+            instance=test_snippet, form=form, request=self.request)
 
         snippet_chooser_panel = [
             panel for panel in edit_handler.children
@@ -1083,7 +1079,7 @@ class TestSnippetChooserPanelWithCustomPrimaryKey(TestCase, WagtailTestUtils):
     def test_target_model_autodetected(self):
         result = SnippetChooserPanel(
             'advertwithcustomprimarykey'
-        ).bind_to_model(SnippetChooserModelWithCustomPrimaryKey).target_model
+        ).bind_to(model=SnippetChooserModelWithCustomPrimaryKey).target_model
         self.assertEqual(result, AdvertWithCustomPrimaryKey)
 
 

--- a/wagtail/snippets/views/snippets.py
+++ b/wagtail/snippets/views/snippets.py
@@ -48,7 +48,7 @@ def get_snippet_edit_handler(model):
             panels = extract_panel_definitions_from_model_class(model)
             edit_handler = ObjectList(panels)
 
-        SNIPPET_EDIT_HANDLERS[model] = edit_handler.bind_to_model(model)
+        SNIPPET_EDIT_HANDLERS[model] = edit_handler.bind_to(model=model)
 
     return SNIPPET_EDIT_HANDLERS[model]
 
@@ -132,6 +132,7 @@ def create(request, app_label, model_name):
 
     instance = model()
     edit_handler = get_snippet_edit_handler(model)
+    edit_handler = edit_handler.bind_to(request=request)
     form_class = edit_handler.get_form_class()
 
     if request.method == 'POST':
@@ -157,14 +158,10 @@ def create(request, app_label, model_name):
             messages.validation_error(
                 request, _("The snippet could not be created due to errors."), form
             )
-            edit_handler = edit_handler.bind_to_instance(instance=instance,
-                                                         form=form,
-                                                         request=request)
     else:
         form = form_class(instance=instance)
-        edit_handler = edit_handler.bind_to_instance(instance=instance,
-                                                     form=form,
-                                                     request=request)
+
+    edit_handler = edit_handler.bind_to(instance=instance, form=form)
 
     return render(request, 'wagtailsnippets/snippets/create.html', {
         'model_opts': model._meta,
@@ -182,6 +179,7 @@ def edit(request, app_label, model_name, pk):
 
     instance = get_object_or_404(model, pk=unquote(pk))
     edit_handler = get_snippet_edit_handler(model)
+    edit_handler = edit_handler.bind_to(instance=instance, request=request)
     form_class = edit_handler.get_form_class()
 
     if request.method == 'POST':
@@ -207,14 +205,10 @@ def edit(request, app_label, model_name, pk):
             messages.validation_error(
                 request, _("The snippet could not be saved due to errors."), form
             )
-            edit_handler = edit_handler.bind_to_instance(instance=instance,
-                                                         form=form,
-                                                         request=request)
     else:
         form = form_class(instance=instance)
-        edit_handler = edit_handler.bind_to_instance(instance=instance,
-                                                     form=form,
-                                                     request=request)
+
+    edit_handler = edit_handler.bind_to(form=form)
 
     return render(request, 'wagtailsnippets/snippets/edit.html', {
         'model_opts': model._meta,


### PR DESCRIPTION
Currently, `EditHandler`s are bound to a model, then forms are generated **then** the model instance and request are bound to the `EditHandler`, along with the generated form. It prevents users from generating different `EditHandler` tree structures (and therefore forms) depending on the current instance or request.

This has been a blocking limitation in numerous projects I worked on, and the common workarounds today are:
- display all fields and inform editors (not safe)
- hide some fields via JavaScript (not safe)
- server-side data validation depending on the instance or user (safe, but not as clean as “dynamic” forms)

What I call a “dynamic” form is not a form that would dynamically change in JavaScript; it’s a form that changes between one request and another.

This pull request replaces `EditHandler.bind_to_model()` and `EditHandler.bind_to_instance()` with a single `EditHandler.bind_to()` method that allows to bind any of these objects as soon as possible: `model`, `instance`, `request` & `form`.

This work also binds requests and saved model instances as soon as possible. That way, developers are able to access the request and instance (if it exists) before the form class is generated.

Here is an example generating different `content_panels` depending on a user permission, with this pull request applied:
```python
class PerUserContentPanels(ObjectList):
    def on_instance_bound(self):
        self.children = self.instance.basic_content_panels
        if self.request.user.is_superuser:
            self.children = self.instance.superuser_content_panels
        self.children = [
            child.bind_to(model=self.model, instance=self.instance,
                          request=self.request, form=self.form)
            for child in self.children]


class PerUserPageMixin:
    basic_content_panels = []
    superuser_content_panels = []

    @cached_classmethod
    def get_edit_handler(cls):
        tabs = []

        if cls.basic_content_panels and cls.superuser_content_panels:
            tabs.append(PerUserContentPanels(heading=_('Content')))
        if cls.promote_panels:
            tabs.append(ObjectList(cls.promote_panels,
                                   heading=_('Promote')))
        if cls.settings_panels:
            tabs.append(ObjectList(cls.settings_panels,
                                   heading=_('Settings'),
                                   classname='settings'))

        edit_handler = TabbedInterface(tabs,
                                       base_form_class=cls.base_form_class)

        return edit_handler.bind_to(model=cls)


class Home(PerUserPageMixin, Page):
    secret_data = TextField()

    basic_content_panels = Page.content_panels
    superuser_content_panels = basic_content_panels + [
        FieldPanel('secret_data'),
    ]
```

Obviously, this is not that simple to use for now, but at least it gives full flexibility while slightly simplifying code.

This work was commissioned by @kutenai from [ShaperTool](https://sharpertool.com/) :smiley: 