### PR TITLE
option for assertCanCreateAt to check for saving draft pages

### DIFF
--- a/wagtail/tests/utils/page_tests.py
+++ b/wagtail/tests/utils/page_tests.py
@@ -82,20 +82,16 @@ class WagtailPageTests(WagtailTestUtils, TestCase):
             raise self.failureException(msg)
 
         if publish:
-            explore_url = reverse('wagtailadmin_explore', args=[parent.pk])
-            if response.redirect_chain != [(explore_url, 302)]:
-                msg = self._formatMessage(msg, 'Creating a page %s.%s didnt redirect the user to the explorer, but to %s' % (
-                    child_model._meta.app_label, child_model._meta.model_name,
-                    response.redirect_chain))
-                raise self.failureException(msg)
+            expected_url = reverse('wagtailadmin_explore', args=[parent.pk])
         else:
-            edit_url = reverse('wagtailadmin_pages:edit', args=[Page.objects.order_by('pk').last().pk])
-            if response.redirect_chain != [(edit_url, 302)]:
-                msg = self._formatMessage(msg, 'Creating a page %s.%s didnt redirect the user to the edit page %s, but to %s' % (
-                    child_model._meta.app_label, child_model._meta.model_name,
-                    edit_url,
-                    response.redirect_chain))
-                raise self.failureException(msg)
+            expected_url = reverse('wagtailadmin_pages:edit', args=[Page.objects.order_by('pk').last().pk])
+
+        if response.redirect_chain != [(expected_url, 302)]:
+            msg = self._formatMessage(msg, 'Creating a page %s.%s didnt redirect the user to the expected page %s, but to %s' % (
+                child_model._meta.app_label, child_model._meta.model_name,
+                expected_url,
+                response.redirect_chain))
+            raise self.failureException(msg)
 
 
     def assertAllowedSubpageTypes(self, parent_model, child_models, msg=None):

--- a/wagtail/tests/utils/page_tests.py
+++ b/wagtail/tests/utils/page_tests.py
@@ -3,6 +3,7 @@ from django.urls import reverse
 from django.utils.text import slugify
 
 from .wagtail_tests import WagtailTestUtils
+from wagtail.core.models import Page
 
 
 class WagtailPageTests(WagtailTestUtils, TestCase):
@@ -40,7 +41,7 @@ class WagtailPageTests(WagtailTestUtils, TestCase):
                 parent_model._meta.app_label, parent_model._meta.model_name))
             raise self.failureException(msg)
 
-    def assertCanCreate(self, parent, child_model, data, msg=None):
+    def assertCanCreate(self, parent, child_model, data, msg=None, live=True):
         """
         Assert that a child of the given Page type can be created under the
         parent, using the supplied POST data.
@@ -53,7 +54,8 @@ class WagtailPageTests(WagtailTestUtils, TestCase):
 
         if 'slug' not in data and 'title' in data:
             data['slug'] = slugify(data['title'])
-        data['action-publish'] = 'action-publish'
+        if live:
+            data['action-publish'] = 'action-publish'
 
         add_url = reverse('wagtailadmin_pages:add', args=[
             child_model._meta.app_label, child_model._meta.model_name, parent.pk])
@@ -79,12 +81,22 @@ class WagtailPageTests(WagtailTestUtils, TestCase):
                 child_model._meta.app_label, child_model._meta.model_name, errors))
             raise self.failureException(msg)
 
-        explore_url = reverse('wagtailadmin_explore', args=[parent.pk])
-        if response.redirect_chain != [(explore_url, 302)]:
-            msg = self._formatMessage(msg, 'Creating a page %s.%s didnt redirect the user to the explorer, but to %s' % (
-                child_model._meta.app_label, child_model._meta.model_name,
-                response.redirect_chain))
-            raise self.failureException(msg)
+        if live:
+            explore_url = reverse('wagtailadmin_explore', args=[parent.pk])
+            if response.redirect_chain != [(explore_url, 302)]:
+                msg = self._formatMessage(msg, 'Creating a page %s.%s didnt redirect the user to the explorer, but to %s' % (
+                    child_model._meta.app_label, child_model._meta.model_name,
+                    response.redirect_chain))
+                raise self.failureException(msg)
+        else:
+            edit_url = reverse('wagtailadmin_pages:edit', args=[Page.objects.order_by('pk').last().pk])
+            if response.redirect_chain != [(edit_url, 302)]:
+                msg = self._formatMessage(msg, 'Creating a page %s.%s didnt redirect the user to the edit page %s, but to %s' % (
+                    child_model._meta.app_label, child_model._meta.model_name,
+                    edit_url,
+                    response.redirect_chain))
+                raise self.failureException(msg)
+
 
     def assertAllowedSubpageTypes(self, parent_model, child_models, msg=None):
         """

--- a/wagtail/tests/utils/page_tests.py
+++ b/wagtail/tests/utils/page_tests.py
@@ -41,7 +41,7 @@ class WagtailPageTests(WagtailTestUtils, TestCase):
                 parent_model._meta.app_label, parent_model._meta.model_name))
             raise self.failureException(msg)
 
-    def assertCanCreate(self, parent, child_model, data, msg=None, live=True):
+    def assertCanCreate(self, parent, child_model, data, msg=None, publish=True):
         """
         Assert that a child of the given Page type can be created under the
         parent, using the supplied POST data.
@@ -54,7 +54,7 @@ class WagtailPageTests(WagtailTestUtils, TestCase):
 
         if 'slug' not in data and 'title' in data:
             data['slug'] = slugify(data['title'])
-        if live:
+        if publish:
             data['action-publish'] = 'action-publish'
 
         add_url = reverse('wagtailadmin_pages:add', args=[
@@ -81,7 +81,7 @@ class WagtailPageTests(WagtailTestUtils, TestCase):
                 child_model._meta.app_label, child_model._meta.model_name, errors))
             raise self.failureException(msg)
 
-        if live:
+        if publish:
             explore_url = reverse('wagtailadmin_explore', args=[parent.pk])
             if response.redirect_chain != [(explore_url, 302)]:
                 msg = self._formatMessage(msg, 'Creating a page %s.%s didnt redirect the user to the explorer, but to %s' % (


### PR DESCRIPTION
this is something i wanted in my own project, was quite a simple hack to change the helper test utils, thought i'd see if y'all were interested.  
WIP!

* [ ] Do the tests still pass? (http://docs.wagtail.io/en/latest/contributing/developing.html#testing)
* [ ] Does the code comply with the style guide? (Run `make lint` from the Wagtail root)
* [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
* [x] For front-end changes: Did you test on all of Wagtail’s supported browsers? **Please list the exact versions you tested**.
* [ ] For new features: Has the documentation been updated accordingly?
