### PR TITLE
Check key value for tag-it.js

### DIFF
--- a/wagtail/admin/static_src/wagtailadmin/js/vendor/tag-it.js
+++ b/wagtail/admin/static_src/wagtailadmin/js/vendor/tag-it.js
@@ -241,7 +241,7 @@
                     // Tab will also create a tag, unless the tag input is empty,
                     // in which case it isn't caught.
                     if (
-                        event.which === $.ui.keyCode.COMMA ||
+                        (event.which === $.ui.keyCode.COMMA && event.key === ',') ||
                         event.which === $.ui.keyCode.ENTER ||
                         (
                             event.which == $.ui.keyCode.TAB &&


### PR DESCRIPTION
It fixes issue when press 'б' in Russian keyboard it's trigger ','