### PR TITLE
templates/wagtailadmin/shared/field.html: use safe with help_text

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/shared/field.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/field.html
@@ -6,12 +6,12 @@
             {% block form_field %}
                 {{ field|render_with_errors }}
             {% endblock %}
-            
+
             {# This span only used on rare occasions by certain types of input #}
             <span></span>
         </div>
         {% if show_help_text|default_if_none:True and field.help_text %}
-            <p class="help">{{ field.help_text }}</p>
+            <p class="help">{{ field.help_text|safe }}</p>
         {% endif %}
 
         {% if field|has_unrendered_errors %}


### PR DESCRIPTION
Without the HTML on e.g. `/admin/account/change_password/` gets rendered
as-is:

> `<ul><li>Your password can&#39;t be too similar …`

Django uses the safe filter itself.

Ref: https://docs.djangoproject.com/en/2.1/ref/models/fields/#help-text