### PR TITLE
Add HTTP_AUTHORIZATION to values copied to dummy preview requests

### DIFF
--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -1242,7 +1242,7 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
 
         # Add important values from the original request object, if it was provided.
         HEADERS_FROM_ORIGINAL_REQUEST = [
-            'REMOTE_ADDR', 'HTTP_X_FORWARDED_FOR', 'HTTP_COOKIE', 'HTTP_USER_AGENT',
+            'REMOTE_ADDR', 'HTTP_X_FORWARDED_FOR', 'HTTP_COOKIE', 'HTTP_USER_AGENT', 'HTTP_AUTHORIZATION',
             'wsgi.version', 'wsgi.multithread', 'wsgi.multiprocess', 'wsgi.run_once',
         ]
         if settings.SECURE_PROXY_SSL_HEADER:

--- a/wagtail/core/tests/test_page_model.py
+++ b/wagtail/core/tests/test_page_model.py
@@ -1371,6 +1371,7 @@ class TestDummyRequest(TestCase):
             'HTTP_X_FORWARDED_FOR': '192.168.0.2,192.168.0.3',
             'HTTP_COOKIE': "test=1;blah=2",
             'HTTP_USER_AGENT': "Test Agent",
+            'HTTP_AUTHORIZATION': "Basic V2FndGFpbDpXYWd0YWlsCg==",
         }
         factory = RequestFactory(**original_headers)
         original_request = factory.get('/home/events/')
@@ -1381,6 +1382,7 @@ class TestDummyRequest(TestCase):
         self.assertEqual(request.META['HTTP_X_FORWARDED_FOR'], original_request.META['HTTP_X_FORWARDED_FOR'])
         self.assertEqual(request.META['HTTP_COOKIE'], original_request.META['HTTP_COOKIE'])
         self.assertEqual(request.META['HTTP_USER_AGENT'], original_request.META['HTTP_USER_AGENT'])
+        self.assertEqual(request.META['HTTP_AUTHORIZATION'], original_request.META['HTTP_AUTHORIZATION'])
 
         # check other env vars required by the WSGI spec
         self.assertEqual(request.META['REQUEST_METHOD'], 'GET')


### PR DESCRIPTION
This PR fixes #4772 by adding the `HTTP_AUTHORIZATION` header to those copied from the original request to the dummy request for previews.