### PR TITLE
Color contrast

### DIFF
--- a/client/src/components/Explorer/Explorer.scss
+++ b/client/src/components/Explorer/Explorer.scss
@@ -1,5 +1,5 @@
 $c-explorer-bg: #4c4e4d;
-$c-explorer-bg-dark: $color-grey-1;
+$c-explorer-bg-dark: $nav-grey-1;
 $c-explorer-bg-active: rgba(0, 0, 0, 0.425);
 $c-explorer-secondary: #a5a5a5;
 $c-explorer-easing: cubic-bezier(0.075, 0.82, 0.165, 1);

--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -1,7 +1,7 @@
 body.wy-body-for-nav {
     font-family: -apple-system, BlinkMacSystemFont, 'Helvetica Neue', Helvetica, Arial, sans-serif;
     line-height: 1.5em;
-    color: #333; /*$color-grey-1-1*/
+    color: #333;
     background-color: #e6e6e6; /*$color-grey-4*/
 }
 

--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -1,7 +1,7 @@
 body.wy-body-for-nav {
     font-family: -apple-system, BlinkMacSystemFont, 'Helvetica Neue', Helvetica, Arial, sans-serif;
     line-height: 1.5em;
-    color: #333;
+    color: #333; /*$color-grey-1*/
     background-color: #e6e6e6; /*$color-grey-4*/
 }
 

--- a/wagtail/admin/static_src/wagtailadmin/scss/_variables.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/_variables.scss
@@ -39,8 +39,8 @@ $color-white: #fff;
 $color-black: #000;
 
 // darker to lighter
-$color-grey-1: darken($color-white, 80);
-$color-grey-2: darken($color-white, 60);
+$color-grey-1: darken($color-white, 90);
+$color-grey-2: darken($color-white, 70);
 
 $color-grey-3: darken($color-white, 15);
 $color-grey-4: darken($color-white, 10);

--- a/wagtail/admin/static_src/wagtailadmin/scss/_variables.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/_variables.scss
@@ -39,7 +39,7 @@ $color-white: #fff;
 $color-black: #000;
 
 // darker to lighter
-$color-grey-1: darken($color-white, 90);
+$color-grey-1: darken($color-white, 80);
 $color-grey-2: darken($color-white, 70);
 
 $color-grey-3: darken($color-white, 15);
@@ -53,7 +53,7 @@ $color-header-bg: $color-teal;
 
 $color-fieldset-hover: $color-grey-5;
 $color-input-border: $color-grey-4;
-$color-input-focus: lighten(saturate($color-teal, 12), 50);
+$color-input-focus: lighten(desaturate($color-teal, 40), 72);
 $color-input-focus-border: lighten(saturate($color-teal, 12), 10);
 $color-input-error-bg: lighten(saturate($color-red, 28), 45);
 
@@ -68,8 +68,8 @@ $color-button-warning-hover: darken($color-orange, 20%);
 $color-link: $color-teal;
 $color-link-hover: $color-teal-dark;
 
-$color-text-base: $color-grey-2;
-$color-text-input: $color-grey-1;
+$color-text-base: darken($color-white, 85);
+$color-text-input: darken($color-white, 90);
 
 // Color states
 $color-state-live: #59b524;

--- a/wagtail/admin/static_src/wagtailadmin/scss/_variables.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/_variables.scss
@@ -98,3 +98,11 @@ $nav-item-active-bg: darken($color-white, 90);
 $submenu-bg: darken($color-white, 85);
 $footer-account: $nav-item-active-bg;
 $footer-submenu: $submenu-bg;
+
+// Nav search
+$nav-search-color: darken($color-white, 20);
+$nav-search-border: darken($color-white, 40);
+$nav-search-bg: $nav-grey-1;
+$nav-search-hover-bg: $nav-item-hover-bg;
+$nav-search-focus-color: $color-white;
+$nav-search-focus-bg: $nav-item-hover-bg;

--- a/wagtail/admin/static_src/wagtailadmin/scss/_variables.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/_variables.scss
@@ -40,7 +40,6 @@ $color-black: #000;
 
 // darker to lighter
 $color-grey-1: darken($color-white, 80);
-$color-grey-1-1: darken($color-white, 74.9);
 $color-grey-2: darken($color-white, 60);
 
 $color-grey-3: darken($color-white, 14.9);

--- a/wagtail/admin/static_src/wagtailadmin/scss/_variables.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/_variables.scss
@@ -26,8 +26,8 @@ $breakpoint-desktop-larger: 100em; // 1600px
 
 // colours
 $color-teal: #007d7e;
-$color-teal-darker: darken(adjust-hue($color-teal, 1), 3);
-$color-teal-dark: darken(adjust-hue($color-teal, 1), 6);
+$color-teal-darker: darken(adjust-hue($color-teal, 1), 4);
+$color-teal-dark: darken(adjust-hue($color-teal, 1), 7);
 
 $color-blue: #71b2d4;
 $color-red: #cd3238;

--- a/wagtail/admin/static_src/wagtailadmin/scss/_variables.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/_variables.scss
@@ -26,8 +26,8 @@ $breakpoint-desktop-larger: 100em; // 1600px
 
 // colours
 $color-teal: #43b1b0;
-$color-teal-darker: darken($color-teal, 10%);
-$color-teal-dark: darken(saturate(adjust-hue($color-teal, 1), 0.37), 21.96);
+$color-teal-darker: darken($color-teal, 10);
+$color-teal-dark: darken($color-teal, 22);
 
 $color-blue: #71b2d4;
 $color-red: #cd3238;
@@ -42,20 +42,20 @@ $color-black: #000;
 $color-grey-1: darken($color-white, 80);
 $color-grey-2: darken($color-white, 60);
 
-$color-grey-3: darken($color-white, 14.9);
-$color-grey-4: darken($color-white, 9.8);
-$color-grey-5: darken($color-white, 1.96);
+$color-grey-3: darken($color-white, 15);
+$color-grey-4: darken($color-white, 10);
+$color-grey-5: darken($color-white, 2);
 
-$color-menu-text: darken($color-white, 20.78);
+$color-menu-text: darken($color-white, 20);
 
 $color-thead-bg: $color-grey-5;
 $color-header-bg: $color-teal;
 
 $color-fieldset-hover: $color-grey-5;
 $color-input-border: $color-grey-4;
-$color-input-focus: lighten(saturate(adjust-hue($color-teal, 1), 12.06), 49.41);
-$color-input-focus-border: lighten(saturate(adjust-hue($color-teal, 1), 11.8), 9.41);
-$color-input-error-bg: lighten(saturate(adjust-hue($color-red, -1), 28.69), 46.27);
+$color-input-focus: lighten(saturate($color-teal, 12), 50);
+$color-input-focus-border: lighten(saturate($color-teal, 12), 10);
+$color-input-error-bg: lighten(saturate($color-red, 28), 45);
 
 $color-button: $color-teal;
 $color-button-hover: $color-teal-darker;

--- a/wagtail/admin/static_src/wagtailadmin/scss/_variables.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/_variables.scss
@@ -25,9 +25,9 @@ $breakpoint-desktop-large: 75em; // 1200px
 $breakpoint-desktop-larger: 100em; // 1600px
 
 // colours
-$color-teal: #43b1b0;
-$color-teal-darker: darken($color-teal, 10);
-$color-teal-dark: darken($color-teal, 22);
+$color-teal: #007d7e;
+$color-teal-darker: darken(adjust-hue($color-teal, 1), 3);
+$color-teal-dark: darken(adjust-hue($color-teal, 1), 6);
 
 $color-blue: #71b2d4;
 $color-red: #cd3238;
@@ -89,3 +89,12 @@ $mobile-nav-indent: 50px;
 
 $nav-wrapper-inner-z-index: 26;
 $draftail-editor-z-index: $nav-wrapper-inner-z-index + 1;
+
+// Nav
+$nav-grey-1: darken($color-white, 80);
+$nav-grey-2: darken($color-white, 60);
+$nav-item-hover-bg: rgba(100, 100, 100, 0.15);
+$nav-item-active-bg: darken($color-white, 90);
+$submenu-bg: darken($color-white, 85);
+$footer-account: $nav-item-active-bg;
+$footer-submenu: $submenu-bg;

--- a/wagtail/admin/static_src/wagtailadmin/scss/_variables.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/_variables.scss
@@ -27,7 +27,8 @@ $breakpoint-desktop-larger: 100em; // 1600px
 // colours
 $color-teal: #43b1b0;
 $color-teal-darker: darken($color-teal, 10%);
-$color-teal-dark: #246060;
+$color-teal-dark: darken(saturate(adjust-hue($color-teal, 1), 0.37), 21.96);
+
 $color-blue: #71b2d4;
 $color-red: #cd3238;
 $color-orange: #e9b04d;
@@ -38,22 +39,25 @@ $color-white: #fff;
 $color-black: #000;
 
 // darker to lighter
-$color-grey-1: #333;
-$color-grey-1-1: #404040;
-$color-grey-2: #666;
-$color-grey-3: #d9d9d9;
-$color-grey-4: #e6e6e6;
-$color-grey-5: #fafafa;
+$color-grey-1: darken($color-white, 80);
+$color-grey-1-1: darken($color-white, 74.9);
+$color-grey-2: darken($color-white, 60);
 
-$color-menu-text: #cacaca; // was #aaa wich was too low contrast
+$color-grey-3: darken($color-white, 14.9);
+$color-grey-4: darken($color-white, 9.8);
+$color-grey-5: darken($color-white, 1.96);
+
+$color-menu-text: darken($color-white, 20.78);
 
 $color-thead-bg: $color-grey-5;
-$color-header-bg: $color-teal; // #ff6a58;
+$color-header-bg: $color-teal;
+
 $color-fieldset-hover: $color-grey-5;
 $color-input-border: $color-grey-4;
-$color-input-focus: #f4fcfc;
-$color-input-focus-border: darken($color-input-focus, 40%);
-$color-input-error-bg: #feedee;
+$color-input-focus: lighten(saturate(adjust-hue($color-teal, 1), 12.06), 49.41);
+$color-input-focus-border: lighten(saturate(adjust-hue($color-teal, 1), 11.8), 9.41);
+$color-input-error-bg: lighten(saturate(adjust-hue($color-red, -1), 28.69), 46.27);
+
 $color-button: $color-teal;
 $color-button-hover: $color-teal-darker;
 $color-button-yes: $color-green;

--- a/wagtail/admin/static_src/wagtailadmin/scss/components/_dropdowns.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/components/_dropdowns.scss
@@ -319,13 +319,13 @@
 // }
 .t-default .u-btn-current {
     border-color: rgba(0, 0, 0, 0.15);
-    color: #43b1b0;
+    color: $color-teal;
 }
 
 .t-default .u-btn-current:hover {
-    background: #43b1b0;
+    background: $color-teal;
     color: #fff;
-    border-color: #43b1b0;
+    border-color: $color-teal;
 }
 
 .t-default .u-btn-current:active {

--- a/wagtail/admin/static_src/wagtailadmin/scss/components/_dropdowns.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/components/_dropdowns.scss
@@ -335,17 +335,17 @@
 }
 
 .t-inverted .u-btn-current {
-    border-color: rgba(0, 0, 0, 0.25);
+    border-color: rgba(0, 0, 0, 0.35);
     color: #fff;
 }
 
 .t-inverted .u-btn-current:hover {
     background-color: $color-teal-darker;
-    border-color: $color-teal-darker;
+    border-color: rgba(0, 0, 0, 0.35);
 }
 
 .t-inverted .u-btn-current:active {
-    border-color: rgba(0, 0, 0, 0.25);
+    border-color: rgba(0, 0, 0, 0.35);
     background: #333;
     color: #fff;
 }

--- a/wagtail/admin/static_src/wagtailadmin/scss/components/_formatters.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/components/_formatters.scss
@@ -127,7 +127,6 @@ button.status-tag:hover {
     .label-public {
         &:before {
             font-size: 1.5em;
-            color: $color-teal;
         }
     }
 

--- a/wagtail/admin/static_src/wagtailadmin/scss/components/_listing.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/components/_listing.scss
@@ -375,7 +375,7 @@ ul.listing {
         .button {
             background-color: $color-white;
             color: $color-teal;
-            border-color: rgba(0, 0, 0, 0.25);
+            border-color: rgba(0, 0, 0, 0.35);
 
             &:hover {
                 color: $color-white;
@@ -472,7 +472,7 @@ table.listing {
         .button {
             background-color: transparent;
             color: $color-white;
-            border-color: rgba(0, 0, 0, 0.25);
+            border-color: rgba(0, 0, 0, 0.35);
 
             &:hover {
                 color: $color-white;

--- a/wagtail/admin/static_src/wagtailadmin/scss/components/_listing.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/components/_listing.scss
@@ -5,7 +5,7 @@ ul.listing {
 
 .listing {
     margin-bottom: 2em;
-    color: lighten($color-text-base, 10%);
+    color: $color-text-base;
     font-size: 0.95em;
 
     ul {
@@ -188,14 +188,12 @@ ul.listing {
     }
 
     .title {
-        color: darken($color-grey-2, 10%);
-
         h2 {
             text-transform: none;
             margin: 0;
             font-size: 1.15em;
             font-weight: 600;
-            color: inherit;
+            color: darken($color-text-base, 10);
             line-height: 1.5em;
 
             a {

--- a/wagtail/admin/static_src/wagtailadmin/scss/components/_listing.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/components/_listing.scss
@@ -193,7 +193,7 @@ ul.listing {
             margin: 0;
             font-size: 1.15em;
             font-weight: 600;
-            color: darken($color-text-base, 10);
+            color: $color-text-base;
             line-height: 1.5em;
 
             a {
@@ -375,7 +375,7 @@ ul.listing {
         .button {
             background-color: $color-white;
             color: $color-teal;
-            border-color: $color-teal;
+            border-color: rgba(0, 0, 0, 0.25);
 
             &:hover {
                 color: $color-white;
@@ -472,7 +472,7 @@ table.listing {
         .button {
             background-color: transparent;
             color: $color-white;
-            border-color: $color-teal-darker;
+            border-color: rgba(0, 0, 0, 0.25);
 
             &:hover {
                 color: $color-white;

--- a/wagtail/admin/static_src/wagtailadmin/scss/components/_main-nav.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/components/_main-nav.scss
@@ -178,19 +178,24 @@
 
     input {
         cursor: pointer;
-        border: 1px solid darken($color-grey-2, 10%);
-        background-color: darken($color-grey-2, 15%);
-        color: $color-menu-text;
+        border: 1px solid $nav-search-border;
+        background-color: $nav-search-bg;
+        color: $nav-search-color;
         padding: 0.8em 2.5em 0.8em 1em;
+        font-weight: 600;
 
         &:hover {
-            background-color: darken($color-grey-2, 10%);
+            background-color: $nav-search-hover-bg;
         }
 
         &:active,
         &:focus {
-            background-color: darken($color-grey-2, 5%);
-            color: $color-white;
+            background-color: $nav-search-focus-bg;
+            color: $nav-search-focus-color;
+        }
+
+        &::placeholder {
+            color: $color-menu-text;
         }
     }
 
@@ -205,6 +210,14 @@
         width: 3em;
         height: 100%;
         overflow: hidden;
+
+        &:hover {
+            background-color: $nav-item-hover-bg;
+        }
+
+        &:active {
+            background-color: $nav-item-active-bg;
+        }
 
         &:before {
             font-family: wagtail;

--- a/wagtail/admin/static_src/wagtailadmin/scss/components/_main-nav.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/components/_main-nav.scss
@@ -1,8 +1,3 @@
-$selected-highlight: darken($color-grey-1, 10%);
-$submenu-color: darken($color-grey-1, 5%);
-$footer-account: $selected-highlight;
-$footer-submenu: $submenu-color;
-
 .nav-wrapper {
     position: relative;
     margin-left: -$menu-width;
@@ -11,10 +6,10 @@ $footer-submenu: $submenu-color;
     display: flex;
     flex-direction: column;
     height: 100%;
-    background: $color-grey-1;
+    background: $nav-grey-1;
 
     .inner {
-        background: $color-grey-1;
+        background: $nav-grey-1;
     }
 }
 
@@ -62,7 +57,7 @@ $footer-submenu: $submenu-color;
         &:hover,
         &:focus {
             outline: none;
-            background-color: rgba(100, 100, 100, 0.15);
+            background-color: $nav-item-hover-bg;
             color: $color-white;
             text-shadow: -1px -1px 0 rgba(0, 0, 0, 0.3);
         }
@@ -92,7 +87,7 @@ $footer-submenu: $submenu-color;
     }
 
     .menu-active {
-        background: $selected-highlight;
+        background: $nav-item-active-bg;
         text-shadow: -1px -1px 0 rgba(0, 0, 0, 0.3);
 
         > a {
@@ -136,7 +131,7 @@ $footer-submenu: $submenu-color;
 }
 
 .nav-submenu {
-    background: $submenu-color;
+    background: $submenu-bg;
 
     h2 {
         display: none;
@@ -395,7 +390,7 @@ body.explorer-open {
     }
 
     li.submenu-active {
-        background: $submenu-color;
+        background: $submenu-bg;
 
         > a {
             text-shadow: -1px -1px 0 rgba(0, 0, 0, 0.3);

--- a/wagtail/admin/static_src/wagtailadmin/scss/components/_tabs.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/components/_tabs.scss
@@ -33,7 +33,7 @@
 
         &:hover {
             color: $color-white;
-            border-top-color: $color-teal-dark;
+            border-top-color: darken($color-teal-darker, 8);
         }
     }
 

--- a/wagtail/admin/static_src/wagtailadmin/scss/components/_tabs.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/components/_tabs.scss
@@ -18,7 +18,7 @@
 
     a {
         @include transition(border-color 0.2s ease);
-        background-color: lighten($color-teal-darker, 3%);
+        background-color: $color-teal-darker;
         outline: none;
         text-transform: uppercase;
         font-weight: 700;
@@ -27,7 +27,7 @@
         display: block;
         padding: 0.7em;
         color: $color-white;
-        border-top: 0.3em solid lighten($color-teal-darker, 3%);
+        border-top: 0.3em solid $color-teal-darker;
         max-height: 1.2em;
         overflow: hidden;
 

--- a/wagtail/admin/static_src/wagtailadmin/scss/core.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/core.scss
@@ -212,7 +212,7 @@ footer {
 
         a,
         span {
-            color: lighten($color-teal, 40%);
+            color: $color-white;
             display: block;
             max-width: 12em;
             white-space: nowrap;

--- a/wagtail/contrib/styleguide/static_src/wagtailstyleguide/scss/styleguide.scss
+++ b/wagtail/contrib/styleguide/static_src/wagtailstyleguide/scss/styleguide.scss
@@ -77,10 +77,6 @@ section {
         color: $color-teal-dark;
     }
 
-    .color-grey-1-1-text {
-        color: $color-grey-1-1;
-    }
-
     .color-grey-2-text {
         color: $color-grey-2;
     }
@@ -151,10 +147,6 @@ section {
 
     .color-grey-1 {
         background-color: $color-grey-1;
-    }
-
-    .color-grey-1-1 {
-        background-color: $color-grey-1-1;
     }
 
     .color-grey-2 {

--- a/wagtail/contrib/styleguide/templates/wagtailstyleguide/base.html
+++ b/wagtail/contrib/styleguide/templates/wagtailstyleguide/base.html
@@ -90,7 +90,6 @@
                 <li class="color-salmon-light"><span class="color-red-text">color-red on color-salmon-light</span></li>
                 <li class="color-salmon-light"><span class="color-black-text">color-black on color-salmon-light</span></li>
                 <li class="color-salmon-light"><span class="color-grey-1-text">color-grey-1 on color-salmon-light</span></li>
-                <li class="color-salmon-light"><span class="color-grey-1-1-text">color-grey-1-1 on color-salmon-light</span></li>
                 <li class="color-salmon-light"><span class="color-grey-2-text">color-grey-2 on color-salmon-light</span></li>
             </ul>
             <ul class="contrast">
@@ -124,13 +123,11 @@
                 <li class="color-grey-3"><span class="color-teal-dark-text">color-teal-dark on color-grey-3</span></li>
                 <li class="color-grey-3"><span class="color-black-text">color-black on color-grey-3</span></li>
                 <li class="color-grey-3"><span class="color-grey-1-text">color-grey-1 on color-grey-3</span></li>
-                <li class="color-grey-3"><span class="color-grey-1-1-text">color-grey-1-1 on color-grey-3</span></li>
             </ul>
             <ul class="contrast">
                 <li class="color-grey-4"><span class="color-teal-dark-text">color-teal-dark on color-grey-4</span></li>
                 <li class="color-grey-4"><span class="color-black-text">color-black on color-grey-4</span></li>
                 <li class="color-grey-4"><span class="color-grey-1-text">color-grey-1 on color-grey-4</span></li>
-                <li class="color-grey-4"><span class="color-grey-1-1-text">color-grey-1-1 on color-grey-4</span></li>
                 <li class="color-grey-4"><span class="color-grey-2-text">color-grey-2 on color-grey-4</span></li>
             </ul>
             <ul class="contrast">
@@ -138,7 +135,6 @@
                 <li class="color-grey-5"><span class="color-red-text">color-red on color-grey-5</span></li>
                 <li class="color-grey-5"><span class="color-black-text">color-black on color-grey-5</span></li>
                 <li class="color-grey-5"><span class="color-grey-1-text">color-grey-1 on color-grey-5</span></li>
-                <li class="color-grey-5"><span class="color-grey-1-1-text">color-grey-1-1 on color-grey-5</span></li>
                 <li class="color-grey-5"><span class="color-grey-2-text">color-grey-2 on color-grey-5</span></li>
             </ul>
             <ul class="contrast">
@@ -147,7 +143,6 @@
                 <li class="color-red"><span class="color-grey-5-text">color-grey-5 on color-red</span></li>
                 <li class="color-orange"><span class="color-black-text">color-black on color-orange</span></li>
                 <li class="color-orange"><span class="color-grey-1-text">color-grey-1 on color-orange</span></li>
-                <li class="color-orange"><span class="color-grey-1-1-text">color-grey-1-1 on color-orange</span></li>
                 <li class="color-green"><span class="color-black-text">color-black on color-green</span></li>
                 <li class="color-blue"><span class="color-black-text">color-black on color-blue</span></li>
                 <li class="color-blue"><span class="color-grey-1-text">color-grey-1 on color-blue</span></li>
@@ -159,7 +154,6 @@
             <ul class="contrast contrast-large">
                 <li class="color-teal"><span class="color-black-text">color-black on color-teal</span></li>
                 <li class="color-teal"><span class="color-grey-1-text">color-grey-1 on color-teal</span></li>
-                <li class="color-teal"><span class="color-grey-1-1-text">color-grey-1-1 on color-teal</span></li>
                 <li class="color-teal-darker"><span class="color-salmon-light-text">color-salmon-light on color-teal-darker</span></li>
                 <li class="color-teal-darker"><span class="color-white-text">color-white on color-teal-darker</span></li>
                 <li class="color-teal-darker"><span class="color-black-text">color-black on color-teal-darker</span></li>
@@ -176,14 +170,12 @@
             <ul class="contrast contrast-large">
                 <li class="color-salmon"><span class="color-black-text">color-black on color-salmon</span></li>
                 <li class="color-salmon"><span class="color-grey-1-text">color-grey-1 on color-salmon</span></li>
-                <li class="color-salmon"><span class="color-grey-1-1-text">color-grey-1-1 on color-salmon</span></li>
                 <li class="color-salmon-light"><span class="color-teal-darker-text">color-teal-darker on color-salmon-light</span></li>
                 <li class="color-salmon-light"><span class="color-teal-dark-text">color-teal-dark on color-salmon-light</span></li>
                 <li class="color-salmon-light"><span class="color-red-text">color-red on color-salmon-light</span></li>
                 <li class="color-salmon-light"><span class="color-green-text">color-green on color-salmon-light</span></li>
                 <li class="color-salmon-light"><span class="color-black-text">color-black on color-salmon-light</span></li>
                 <li class="color-salmon-light"><span class="color-grey-1-text">color-grey-1 on color-salmon-light</span></li>
-                <li class="color-salmon-light"><span class="color-grey-1-1-text">color-grey-1-1 on color-salmon-light</span></li>
                 <li class="color-salmon-light"><span class="color-grey-2-text">color-grey-2 on color-salmon-light</span></li>
             </ul>
             <ul class="contrast contrast-large">
@@ -225,7 +217,6 @@
                 <li class="color-grey-3"><span class="color-red-text">color-red on color-grey-3</span></li>
                 <li class="color-grey-3"><span class="color-black-text">color-black on color-grey-3</span></li>
                 <li class="color-grey-3"><span class="color-grey-1-text">color-grey-1 on color-grey-3</span></li>
-                <li class="color-grey-3"><span class="color-grey-1-1-text">color-grey-1-1 on color-grey-3</span></li>
                 <li class="color-grey-3"><span class="color-grey-2-text">color-grey-2 on color-grey-3</span></li>
             </ul>
             <ul class="contrast contrast-large">
@@ -235,7 +226,6 @@
                 <li class="color-grey-4"><span class="color-green-text">color-green on color-grey-4</span></li>
                 <li class="color-grey-4"><span class="color-black-text">color-black on color-grey-4</span></li>
                 <li class="color-grey-4"><span class="color-grey-1-text">color-grey-1 on color-grey-4</span></li>
-                <li class="color-grey-4"><span class="color-grey-1-1-text">color-grey-1-1 on color-grey-4</span></li>
                 <li class="color-grey-4"><span class="color-grey-2-text">color-grey-2 on color-grey-4</span></li>
             </ul>
             <ul class="contrast contrast-large">
@@ -245,7 +235,6 @@
                 <li class="color-grey-5"><span class="color-green-text">color-green on color-grey-5</span></li>
                 <li class="color-grey-5"><span class="color-black-text">color-black on color-grey-5</span></li>
                 <li class="color-grey-5"><span class="color-grey-1-text">color-grey-1 on color-grey-5</span></li>
-                <li class="color-grey-5"><span class="color-grey-1-1-text">color-grey-1-1 on color-grey-5</span></li>
                 <li class="color-grey-5"><span class="color-grey-2-text">color-grey-2 on color-grey-5</span></li>
             </ul>
             <ul class="contrast contrast-large">
@@ -261,7 +250,6 @@
                 <li class="color-orange"><span class="color-teal-dark-text">color-teal-dark on color-orange</span></li>
                 <li class="color-orange"><span class="color-black-text">color-black on color-orange</span></li>
                 <li class="color-orange"><span class="color-grey-1-text">color-grey-1 on color-orange</span></li>
-                <li class="color-orange"><span class="color-grey-1-1-text">color-grey-1-1 on color-orange</span></li>
             </ul>
             <ul class="contrast contrast-large">
                 <li class="color-green"><span class="color-white-text">color-white on color-green</span></li>
@@ -275,7 +263,6 @@
                 <li class="color-blue"><span class="color-teal-dark-text">color-teal-dark on color-blue</span></li>
                 <li class="color-blue"><span class="color-black-text">color-black on color-blue</span></li>
                 <li class="color-blue"><span class="color-grey-1-text">color-grey-1 on color-blue</span></li>
-                <li class="color-blue"><span class="color-grey-1-1-text">color-grey-1-1 on color-blue</span></li>
             </ul>
 
         </section>


### PR DESCRIPTION
This PR increases color contrast in the Wagtail admin.
Chrome Lighthouse is used to check for accessibility errors on contrast. All contrast tests pass.
I used the design by @benenright 
![unnamed](https://user-images.githubusercontent.com/1969342/46069544-0fcd0500-c17c-11e8-977c-4cd89afe5a7c.png)

The individual commits might give additional insight in my work process.
- Increase text on white contrast
- Detach nav colors from color-grey vars gives fine grained color control
- Simplify color functions and round numbers.
- Remove color from privacy icon to make hover state more notable and design less complex
- Stop style bleeding on listing. Make Privacy text label white
- Increase breadcrumb contrast
- Drop redundant color color-grey-1-1
- Use color variable
- Use color functions where there is a obvious relation between them

Current:
![simulator screen shot - ipad air - 2018-09-26 at 23 58 43](https://user-images.githubusercontent.com/1969342/46111738-55271c00-c1e8-11e8-91f1-46cdb1e1abf0.png)

New:
![simulator screen shot - ipad air - 2018-09-26 at 23 58 21](https://user-images.githubusercontent.com/1969342/46111749-5b1cfd00-c1e8-11e8-8193-08699cd55b2c.png)

Also note the changes to search input and privacy toggle and the body text.
![screen_shot_2018-09-26_at_11_25_39](https://user-images.githubusercontent.com/1969342/46070952-3d677d80-c17f-11e8-99d0-620f485b328e.png)

Checks:
* Do the tests still pass? YES
* Does the code comply with the style guide? YES
* For Python changes: N/A
* For front-end changes. Tested browsers:

- Mobile Safari | iOS Phone => iPhone 6s IOS 9 Safari, iPhone XS Max 12 Safari
- Mobile Safari | iOS Tablet  => iPad Air2 IOS 8 Safari, iPad Air 12 Safari
- Chrome | Android => Google Nexus 6 Chrome 63 && Samsung Galaxy S5 Android 4.4 Chrome 
- IE | Desktop | 11 => Win7 IE11
- Chrome | Desktop | Last 2
- MS Edge | Desktop => Windows 10 Edge 17
- Firefox | Desktop => Windows 10 Firefox 61 and 62
- Firefox ESR | Desktop | OSX 10.13.6 Firfox ESR 60
- Safari | macOS => OSX 10.13.6 Safari 12

* For new features: N/A
