### PR TITLE
Fixes layout for FileField

### DIFF
--- a/wagtail/admin/static_src/wagtailadmin/scss/components/_forms.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/components/_forms.scss
@@ -93,6 +93,27 @@ select::-ms-expand {
     display: none;
 }
 
+.file_field {
+    .input {
+        label {
+            float: none;
+            display: inline;
+            padding: 0;
+        }
+
+        input[type=checkbox] {
+            margin-top: 5px;
+        }
+
+        a {
+            &:after {
+                content: ' ';
+                display: block;
+            }
+        }
+    }
+}
+
 // select boxes
 .choice_field .input,
 .model_choice_field .input,


### PR DESCRIPTION
Fixes #4780 

**Tested in the following browsers:**

* Chrome 69.0.3497.100 (including "iPhone 6/7/8" and "iPad" options in dev tools)
* Safari 11.0.1
* FireFox 63.0b7 and 63.0b9

**Screenshot:**

![file_field_fixed](https://user-images.githubusercontent.com/509198/46142337-89cdbe80-c24e-11e8-8137-7ef52c89df77.png)

**Note for a reviewer:**

I'm not sure about the approach. This PR is relying on the structure of HTML (partly from Wagtail and partly from Django) and existing classes which looks a bit fragile to me, but in `_forms.scss` there are a lot of overrides like this, so I wanted my changes to be consistent with the rest of the file.

An alternative approach is to override the `ClearableFileInput` widget in Wagtail and use own template with more specific CSS classes.