### PR TITLE
Add autocomplete off to custom datetime widgets

### DIFF
--- a/wagtail/admin/tests/test_widgets.py
+++ b/wagtail/admin/tests/test_widgets.py
@@ -94,6 +94,8 @@ class TestAdminDateInput(TestCase):
 
         html = widget.render('test', None, attrs={'id': 'test-id'})
 
+        self.assertInHTML('<input type="text" name="test" autocomplete="off" id="test-id" />', html)
+
         # we should see the JS initialiser code:
         # initDateChooser("test-id", {"dayOfWeekStart": 0, "format": "Y-m-d"});
         # except that we can't predict the order of the config options
@@ -127,6 +129,8 @@ class TestAdminDateTimeInput(TestCase):
         widget = widgets.AdminDateTimeInput()
 
         html = widget.render('test', None, attrs={'id': 'test-id'})
+
+        self.assertInHTML('<input type="text" name="test" autocomplete="off" id="test-id" />', html)
 
         # we should see the JS initialiser code:
         # initDateTimeChooser("test-id", {"dayOfWeekStart": 0, "format": "Y-m-d H:i"});

--- a/wagtail/admin/widgets.py
+++ b/wagtail/admin/widgets.py
@@ -38,11 +38,14 @@ class AdminDateInput(widgets.DateInput):
     template_name = 'wagtailadmin/widgets/date_input.html'
 
     def __init__(self, attrs=None, format=None):
+        default_attrs = {'autocomplete': 'off'}
         fmt = format
+        if attrs:
+            default_attrs.update(attrs)
         if fmt is None:
             fmt = getattr(settings, 'WAGTAIL_DATE_FORMAT', DEFAULT_DATE_FORMAT)
         self.js_format = to_datetimepicker_format(fmt)
-        super().__init__(attrs=attrs, format=fmt)
+        super().__init__(attrs=default_attrs, format=fmt)
 
     def get_context(self, name, value, attrs):
         context = super().get_context(name, value, attrs)
@@ -60,6 +63,9 @@ class AdminTimeInput(widgets.TimeInput):
     template_name = 'wagtailadmin/widgets/time_input.html'
 
     def __init__(self, attrs=None, format='%H:%M'):
+        default_attrs = {'autocomplete': 'off'}
+        if attrs:
+            default_attrs.update(attrs)
         super().__init__(attrs=attrs, format=format)
 
 
@@ -67,11 +73,14 @@ class AdminDateTimeInput(widgets.DateTimeInput):
     template_name = 'wagtailadmin/widgets/datetime_input.html'
 
     def __init__(self, attrs=None, format=None):
+        default_attrs = {'autocomplete': 'off'}
         fmt = format
+        if attrs:
+            default_attrs.update(attrs)
         if fmt is None:
             fmt = getattr(settings, 'WAGTAIL_DATETIME_FORMAT', DEFAULT_DATETIME_FORMAT)
         self.js_format = to_datetimepicker_format(fmt)
-        super().__init__(attrs=attrs, format=fmt)
+        super().__init__(attrs=default_attrs, format=fmt)
 
     def get_context(self, name, value, attrs):
         context = super().get_context(name, value, attrs)


### PR DESCRIPTION
This will fix #4782 which was showing up when giving a presentation to a client. I have added the `autocomplete="off"` property default to date, time and datetime widget.

* Do the tests still pass? Local at least. We have to wait on Travis though
* Does the code comply with the style guide? Yes
* For Python changes: Have you added tests to cover the new/fixed behaviour? Yes
* For front-end changes: Did you test on all of Wagtail’s supported browsers? **Please list the exact versions you tested**. Firefox ESR, Chrome 69, Safari 12
