### PR TITLE
Add template include page_switches in admin/edit.html

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/pages/_edit_switches.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/_edit_switches.html
@@ -1,0 +1,2 @@
+{% include "wagtailadmin/pages/_privacy_switch.html" with page=page page_perms=page_perms only %}
+{% include "wagtailadmin/pages/_lock_switch.html" %}

--- a/wagtail/admin/templates/wagtailadmin/pages/edit.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/edit.html
@@ -19,8 +19,7 @@
                 {% trans "Status" %}
                 {% include "wagtailadmin/shared/page_status_tag.html" with page=page_for_status %}
 
-                {% include "wagtailadmin/pages/_privacy_switch.html" with page=page page_perms=page_perms only %}
-                {% include "wagtailadmin/pages/_lock_switch.html" %}
+                {% include "wagtailadmin/pages/_edit_switches.html" %}
             </div>
         </div>
     </header>


### PR DESCRIPTION
I'm working on a feature in ``wagtailtrans`` which allows the user to easily switch between languages in the admin. Having this block will allow me to extend the page switches which will also provide an easy method of switching when editing a page.

Related PR: https://github.com/LUKKIEN/wagtailtrans/pull/136

Edit: Updated the block to a template include, since they're easier t override.