### PR TITLE
Properly handle links to root page and missing pages in Draftail

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -21,6 +21,8 @@ Changelog
  * Fix: Tag input field no longer treats 'б' on Russian keyboards as a comma (Michael Borisov)
  * Fix: Disabled autocomplete dropdowns on date/time chooser fields (Janneke Janssen)
  * Fix: Split up `wagtail.admin.forms` to make it less prone to circular imports (Matt Westcott)
+ * Fix: Disable linking to root page in rich text, making the page non-functional (Matt Westcott)
+ * Fix: Pages should be editable and save-able even if there are broken links in rich text (Matt Westcott)
 
 
 2.2.2 (29.08.2018)

--- a/client/src/components/Draftail/decorators/TooltipEntity.js
+++ b/client/src/components/Draftail/decorators/TooltipEntity.js
@@ -101,7 +101,7 @@ class TooltipEntity extends Component {
             closeOnResize
           >
             <Tooltip target={showTooltipAt} direction="top">
-              {(
+              {label ? (
                 <a
                   href={url}
                   title={url}
@@ -111,7 +111,7 @@ class TooltipEntity extends Component {
                 >
                   {shortenLabel(label)}
                 </a>
-              )}
+              ) : null}
 
               <button
                 className="button Tooltip__button"

--- a/client/src/components/Draftail/decorators/TooltipEntity.test.js
+++ b/client/src/components/Draftail/decorators/TooltipEntity.test.js
@@ -37,6 +37,23 @@ describe('TooltipEntity', () => {
       .text()).toBe('www.example.example.…');
   });
 
+  it('empty label', () => {
+    expect(shallow((
+      <TooltipEntity
+        entityKey="1"
+        onEdit={() => {}}
+        onRemove={() => {}}
+        icon="#icon-test"
+        url="https://www.example.com/"
+        label=""
+      >
+        test
+      </TooltipEntity>
+    )).setState({
+      showTooltipAt: document.createElement('div').getBoundingClientRect(),
+    }).find('Tooltip a').length).toBe(0);
+  });
+
   it('#openTooltip', () => {
     const wrapper = shallow((
       <TooltipEntity

--- a/client/src/components/Draftail/sources/ModalWorkflowSource.js
+++ b/client/src/components/Draftail/sources/ModalWorkflowSource.js
@@ -42,7 +42,6 @@ export const getChooserConfig = (entityType, entity, selectedText) => {
       page_type: 'wagtailcore.page',
       allow_external_link: true,
       allow_email_link: true,
-      can_choose_root: 'false',
       link_text: selectedText,
     };
 

--- a/client/src/components/Draftail/sources/ModalWorkflowSource.js
+++ b/client/src/components/Draftail/sources/ModalWorkflowSource.js
@@ -50,7 +50,11 @@ export const getChooserConfig = (entityType, entity, selectedText) => {
       const data = entity.getData();
 
       if (data.id) {
-        url = `${global.chooserUrls.pageChooser}${data.parentId}/`;
+        if (data.parentId !== null) {
+          url = `${global.chooserUrls.pageChooser}${data.parentId}/`;
+        } else {
+          url = global.chooserUrls.pageChooser;
+        }
       } else if (data.url.startsWith('mailto:')) {
         url = global.chooserUrls.emailLinkChooser;
         urlParams.link_url = data.url.replace('mailto:', '');

--- a/client/src/components/Draftail/sources/ModalWorkflowSource.test.js
+++ b/client/src/components/Draftail/sources/ModalWorkflowSource.test.js
@@ -61,7 +61,13 @@ describe('ModalWorkflowSource', () => {
 
       it('page', () => {
         expect(getChooserConfig({ type: 'LINK' }, {
-          getData: () => ({ id: 1, parentId: 0 })
+          getData: () => ({ id: 2, parentId: 1 })
+        }, '')).toMatchSnapshot();
+      });
+
+      it('root page', () => {
+        expect(getChooserConfig({ type: 'LINK' }, {
+          getData: () => ({ id: 1, parentId: null })
         }, '')).toMatchSnapshot();
       });
 

--- a/client/src/components/Draftail/sources/__snapshots__/ModalWorkflowSource.test.js.snap
+++ b/client/src/components/Draftail/sources/__snapshots__/ModalWorkflowSource.test.js.snap
@@ -57,7 +57,6 @@ Object {
   "urlParams": Object {
     "allow_email_link": true,
     "allow_external_link": true,
-    "can_choose_root": "false",
     "link_text": "",
     "link_url": "https://www.example.com/",
     "page_type": "wagtailcore.page",
@@ -74,7 +73,6 @@ Object {
   "urlParams": Object {
     "allow_email_link": true,
     "allow_external_link": true,
-    "can_choose_root": "false",
     "link_text": "",
     "link_url": "test@example.com",
     "page_type": "wagtailcore.page",
@@ -91,7 +89,6 @@ Object {
   "urlParams": Object {
     "allow_email_link": true,
     "allow_external_link": true,
-    "can_choose_root": "false",
     "link_text": "",
     "page_type": "wagtailcore.page",
   },
@@ -122,7 +119,6 @@ Object {
   "urlParams": Object {
     "allow_email_link": true,
     "allow_external_link": true,
-    "can_choose_root": "false",
     "link_text": "",
     "page_type": "wagtailcore.page",
   },

--- a/client/src/components/Draftail/sources/__snapshots__/ModalWorkflowSource.test.js.snap
+++ b/client/src/components/Draftail/sources/__snapshots__/ModalWorkflowSource.test.js.snap
@@ -103,7 +103,22 @@ Object {
   "onload": Object {
     "type": "page",
   },
-  "url": "/admin/choose-page/0/",
+  "url": "/admin/choose-page/1/",
+  "urlParams": Object {
+    "allow_email_link": true,
+    "allow_external_link": true,
+    "link_text": "",
+    "page_type": "wagtailcore.page",
+  },
+}
+`;
+
+exports[`ModalWorkflowSource #getChooserConfig LINK root page 1`] = `
+Object {
+  "onload": Object {
+    "type": "page",
+  },
+  "url": "/admin/choose-page/",
   "urlParams": Object {
     "allow_email_link": true,
     "allow_external_link": true,

--- a/docs/releases/2.3.rst
+++ b/docs/releases/2.3.rst
@@ -44,6 +44,8 @@ Bug fixes
  * Tag input field no longer treats 'б' on Russian keyboards as a comma (Michael Borisov)
  * Disabled autocomplete dropdowns on date/time chooser fields (Janneke Janssen)
  * Split up ``wagtail.admin.forms`` to make it less prone to circular imports (Matt Westcott)
+ * Disable linking to root page in rich text, making the page non-functional (Matt Westcott)
+ * Pages should be editable and save-able even if there are broken links in rich text (Matt Westcott)
 
 Upgrade considerations
 ======================

--- a/wagtail/admin/rich_text/converters/html_to_contentstate.py
+++ b/wagtail/admin/rich_text/converters/html_to_contentstate.py
@@ -206,7 +206,12 @@ class PageLinkElementHandler(LinkElementHandler):
         try:
             page = Page.objects.get(id=attrs['id']).specific
         except Page.DoesNotExist:
-            return {}
+            # retain ID so that it's still identified as a page link (albeit a broken one)
+            return {
+                'id': int(attrs['id']),
+                'url': None,
+                'parentId': None
+            }
 
         parent_page = page.get_parent()
 

--- a/wagtail/admin/rich_text/converters/html_to_contentstate.py
+++ b/wagtail/admin/rich_text/converters/html_to_contentstate.py
@@ -208,10 +208,12 @@ class PageLinkElementHandler(LinkElementHandler):
         except Page.DoesNotExist:
             return {}
 
+        parent_page = page.get_parent()
+
         return {
             'id': page.id,
             'url': page.url,
-            'parentId': page.get_parent().id,
+            'parentId': parent_page.id if parent_page else None,
         }
 
 

--- a/wagtail/admin/tests/test_contentstate.py
+++ b/wagtail/admin/tests/test_contentstate.py
@@ -337,6 +337,28 @@ class TestHtmlToContentState(TestCase):
             ]
         })
 
+    def test_link_to_root_page(self):
+        converter = ContentstateConverter(features=['link'])
+        result = json.loads(converter.from_database_format(
+            '''
+            <p>an <a linktype="page" id="1">internal</a> link</p>
+            '''
+        ))
+        self.assertContentStateEqual(result, {
+            'entityMap': {
+                '0': {
+                    'mutability': 'MUTABLE', 'type': 'LINK',
+                    'data': {'id': 1, 'url': None, 'parentId': None}
+                }
+            },
+            'blocks': [
+                {
+                    'inlineStyleRanges': [], 'text': 'an internal link', 'depth': 0, 'type': 'unstyled', 'key': '00000',
+                    'entityRanges': [{'offset': 3, 'length': 8, 'key': 0}]
+                },
+            ]
+        })
+
     def test_document_link(self):
         converter = ContentstateConverter(features=['document-link'])
         result = json.loads(converter.from_database_format(

--- a/wagtail/admin/tests/test_contentstate.py
+++ b/wagtail/admin/tests/test_contentstate.py
@@ -326,7 +326,9 @@ class TestHtmlToContentState(TestCase):
             'entityMap': {
                 '0': {
                     'mutability': 'MUTABLE', 'type': 'LINK',
-                    'data': {}
+                    'data': {
+                        'id': 9999, 'url': None, 'parentId': None,
+                    }
                 }
             },
             'blocks': [


### PR DESCRIPTION
Fixes #4605, along with a similar issue to #4791 but for broken page links rather than document links: our Draftail integration uses the presence of an ID to differentiate page links from external URL links, so it makes sense to preserve the ID in the link data even if the corresponding page is missing.