### PR TITLE
Reuse lazy StreamField values in get_prep_value. Fixes #2218

### DIFF
--- a/wagtail/core/blocks/stream_block.py
+++ b/wagtail/core/blocks/stream_block.py
@@ -426,11 +426,6 @@ class StreamValue(collections.Sequence):
             if self.is_lazy and i not in self._bound_blocks:
                 # This child has not been accessed as a bound block, so its raw JSONish
                 # value (stream_data_item here) is still valid
-
-                # assign a new ID if it didn't have one already
-                if not stream_data_item.get('id'):
-                    stream_data_item['id'] = str(uuid.uuid4())
-
                 prep_value_item = stream_data_item
 
             else:
@@ -439,9 +434,14 @@ class StreamValue(collections.Sequence):
                 prep_value_item = {
                     'type': child.block.name,
                     'value': child.block.get_prep_value(child.value),
-                    # assign a new ID on save if it didn't have one already
-                    'id': child.id or str(uuid.uuid4()),
+                    'id': child.id,
                 }
+
+            # As this method is preparing this value to be saved to the database,
+            # this is an appropriate place to ensure that each block has a unique id.
+            if not prep_value_item.get('id'):
+                prep_value_item['id'] = str(uuid.uuid4())
+
             prep_value.append(prep_value_item)
 
         return prep_value

--- a/wagtail/core/blocks/stream_block.py
+++ b/wagtail/core/blocks/stream_block.py
@@ -246,16 +246,11 @@ class BaseStreamBlock(Block):
         if value is None:
             # treat None as identical to an empty stream
             return []
-
-        return [
-            {
-                'type': child.block.name,
-                'value': child.block.get_prep_value(child.value),
-                # assign a new ID on save if it didn't have one already
-                'id': child.id or str(uuid.uuid4()),
-            }
-            for child in value  # child is a StreamChild instance
-        ]
+        else:
+            # value is a StreamValue - delegate to its get_prep_value() method
+            # (which has special-case handling for lazy StreamValues to avoid useless
+            # round-trips to the full data representation and back)
+            return value.get_prep_value()
 
     def get_api_representation(self, value, context=None):
         if value is None:
@@ -423,6 +418,33 @@ class StreamValue(collections.Sequence):
             # also pass the block ID to StreamChild, if one exists for this stream index
             block_id = self.stream_data[i].get('id')
             self._bound_blocks[i] = StreamValue.StreamChild(child_block, value, id=block_id)
+
+    def get_prep_value(self):
+        prep_value = []
+
+        for i, stream_data_item in enumerate(self.stream_data):
+            if self.is_lazy and i not in self._bound_blocks:
+                # This child has not been accessed as a bound block, so its raw JSONish
+                # value (stream_data_item here) is still valid
+
+                # assign a new ID if it didn't have one already
+                if not stream_data_item.get('id'):
+                    stream_data_item['id'] = str(uuid.uuid4())
+
+                prep_value_item = stream_data_item
+
+            else:
+                # convert the bound block back into JSONish data
+                child = self[i]
+                prep_value_item = {
+                    'type': child.block.name,
+                    'value': child.block.get_prep_value(child.value),
+                    # assign a new ID on save if it didn't have one already
+                    'id': child.id or str(uuid.uuid4()),
+                }
+            prep_value.append(prep_value_item)
+
+        return prep_value
 
     def __eq__(self, other):
         if not isinstance(other, StreamValue):

--- a/wagtail/core/tests/test_streamfield.py
+++ b/wagtail/core/tests/test_streamfield.py
@@ -111,6 +111,21 @@ class TestLazyStreamField(TestCase):
             assert instance.body[1].value is None
             assert instance.body[2].value.title == 'Test image 3'
 
+    def test_lazy_load_get_prep_value(self):
+        """
+        Saving a lazy StreamField that hasn't had its data accessed should not
+        cause extra database queries by loading and then re-saving block values.
+        Instead the initial JSON stream data should be written back for any
+        blocks that have not been accessed.
+        """
+        with self.assertNumQueries(1):
+            instance = StreamModel.objects.get(pk=self.with_image.pk)
+
+        # Expect a single UPDATE to update the model, without any additional
+        # SELECT related to the image block that has not been accessed.
+        with self.assertNumQueries(1):
+            instance.save()
+
 
 class TestSystemCheck(TestCase):
     def tearDown(self):


### PR DESCRIPTION
Fixes #2218 - proposed alternative fix to #4727. This version ensures that the same code path (`StreamBlock.get_prep_value` calling `StreamValue.get_prep_value`) is used for both top-level and nested StreamBlocks, and also preserves the behaviour of assigning an ID on save if one is not already present.