### PR TITLE
Do not log user out when changing their own password

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -24,6 +24,7 @@ Changelog
  * Fix: Disable linking to root page in rich text, making the page non-functional (Matt Westcott)
  * Fix: Pages should be editable and save-able even if there are broken page or document links in rich text (Matt Westcott)
  * Fix: Avoid redundant round-trips of JSON StreamField data on save, improving performance and preventing consistency issues on fixture loading (Andy Chosak, Matt Westcott)
+ * Fix: Users are not logged out when changing their own password through the Users area (Matt Westcott)
 
 
 2.2.2 (29.08.2018)

--- a/docs/releases/2.3.rst
+++ b/docs/releases/2.3.rst
@@ -47,6 +47,7 @@ Bug fixes
  * Disable linking to root page in rich text, making the page non-functional (Matt Westcott)
  * Pages should be editable and save-able even if there are broken page or document links in rich text (Matt Westcott)
  * Avoid redundant round-trips of JSON StreamField data on save, improving performance and preventing consistency issues on fixture loading (Andy Chosak, Matt Westcott)
+ * Users are not logged out when changing their own password through the Users area (Matt Westcott)
 
 
 Upgrade considerations

--- a/wagtail/users/tests.py
+++ b/wagtail/users/tests.py
@@ -768,6 +768,29 @@ class TestUserEditView(TestCase, WagtailTestUtils):
         # Check that the user is still active
         self.assertEqual(user.is_active, True)
 
+    def test_editing_own_password_does_not_log_out(self):
+        response = self.post({
+            'username': 'test@email.com',
+            'email': 'test@email.com',
+            'first_name': "Edited Myself",
+            'last_name': "User",
+            'password1': "c0rrecth0rse",
+            'password2': "c0rrecth0rse",
+            'is_active': 'on',
+            'is_superuser': 'on',
+        }, self.current_user.pk)
+
+        # Should redirect back to index
+        self.assertRedirects(response, reverse('wagtailusers_users:index'))
+
+        # Check that the user was edited
+        user = get_user_model().objects.get(pk=self.current_user.pk)
+        self.assertEqual(user.first_name, 'Edited Myself')
+
+        # Check user is not logged out
+        response = self.client.get(reverse('wagtailusers_users:index'))
+        self.assertEqual(response.status_code, 200)
+
     def test_cannot_demote_self(self):
         """
         check that unsetting a user's own is_active or is_superuser flag has no effect

--- a/wagtail/users/views/users.py
+++ b/wagtail/users/views/users.py
@@ -149,8 +149,9 @@ def edit(request, user_id):
         form = get_user_edit_form()(request.POST, request.FILES, instance=user, editing_self=editing_self)
         if form.is_valid():
             user = form.save()
-            messages.success(request, _("Your details have been updated. You've been logged out for security reasons, "
-                                        "please login to continue."))
+            messages.success(request, _("User '{0}' updated.").format(user), buttons=[
+                messages.button(reverse('wagtailusers_users:edit', args=(user.pk,)), _('Edit'))
+            ])
             for fn in hooks.get_hooks('after_edit_user'):
                 result = fn(request, user)
                 if hasattr(result, 'status_code'):

--- a/wagtail/users/views/users.py
+++ b/wagtail/users/views/users.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.contrib.auth import get_user_model
+from django.contrib.auth import get_user_model, update_session_auth_hash
 from django.db.models import Q
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
@@ -149,6 +149,11 @@ def edit(request, user_id):
         form = get_user_edit_form()(request.POST, request.FILES, instance=user, editing_self=editing_self)
         if form.is_valid():
             user = form.save()
+
+            if user == request.user and 'password1' in form.changed_data:
+                # User is changing their own password; need to update their session hash
+                update_session_auth_hash(request, user)
+
             messages.success(request, _("User '{0}' updated.").format(user), buttons=[
                 messages.button(reverse('wagtailusers_users:edit', args=(user.pk,)), _('Edit'))
             ])


### PR DESCRIPTION
See https://github.com/wagtail/wagtail/issues/4794#issuecomment-428642027 - #4364 was an invalid fix for #4200, as logging a user out on changing their password was not a deliberate security feature, and the new message is inaccurate when editing another user or not changing the password.

Fixes #4200 and #4794