### PR TITLE
Fixes wording in document upload message

### DIFF
--- a/wagtail/documents/templates/wagtaildocs/multiple/add.html
+++ b/wagtail/documents/templates/wagtaildocs/multiple/add.html
@@ -56,7 +56,7 @@
                 </div>
             </div>
             <div class="right col9">
-                <p class="status-msg success">{% trans "Upload successful. Please update this documents with a more appropriate title, if necessary. You may also delete the document completely if the upload wasn't required." %}</p>
+                <p class="status-msg success">{% trans "Upload successful. Please update this document with a more appropriate title, if necessary. You may also delete the document completely if the upload wasn't required." %}</p>
                 <p class="status-msg failure">{% trans "Sorry, upload failed." %}</p>
                 <p class="status-msg failure error_messages"></p>
             </div>


### PR DESCRIPTION
Changes "Please update this documents" to "Please update this document".

Before:

![image](https://user-images.githubusercontent.com/654645/46871660-04c2d780-ce00-11e8-9f31-7c57bb18dd11.png)

After:

![image](https://user-images.githubusercontent.com/654645/46871974-d1347d00-ce00-11e8-9a4e-8081a8c39fd5.png)

Per [this wiki page](https://github.com/wagtail/wagtail/wiki/Managing-Wagtail-translations#generating-new-source-files-for-translation) I have not regenerated the Django .po files for this minor change.