### PR TITLE
returns content_types as a list instead of dict_values

### DIFF
--- a/wagtail/core/query.py
+++ b/wagtail/core/query.py
@@ -178,7 +178,7 @@ class PageQuerySet(SearchableQuerySetMixin, TreeQuerySet):
             if issubclass(model, klass)
         ]).values()
 
-        return Q(content_type__in=content_types)
+        return Q(content_type__in=list(content_types))
 
     def type(self, model):
         """

--- a/wagtail/core/tests/test_page_queryset.py
+++ b/wagtail/core/tests/test_page_queryset.py
@@ -1,4 +1,5 @@
 from django.contrib.contenttypes.models import ContentType
+from django.db.models import Q
 from django.test import TestCase
 
 from wagtail.core.models import Page, PageViewRestriction, Site
@@ -396,6 +397,14 @@ class TestPageQuerySet(TestCase):
 
         # Check that the event is in the results
         self.assertTrue(pages.filter(id=event.id).exists())
+
+    def test_merge_queries(self):
+        type_q = Page.objects.type_q(EventPage)
+        query = Q()
+
+        query |= type_q
+
+        self.assertTrue(Page.objects.filter(query).exists())
 
 
 class TestPageQueryInSite(TestCase):


### PR DESCRIPTION
# What does this do?
Addresses #4489 - simply changes the return from a `dict_value` to a list, by wrapping the return in a `list()` 
