### PR TITLE
Remove notes about URL confs for Django<2.0

### DIFF
--- a/docs/advanced_topics/i18n/index.rst
+++ b/docs/advanced_topics/i18n/index.rst
@@ -108,11 +108,6 @@ This feature is enabled through the project's root URL configuration. Just put t
         re_path(r'', include(wagtail_urls)),
     )
 
-.. important::
-
-   The example above assumes you are using Django version 2.0 or later. If you are using a Django version earlier than 2.0, you should rename all occurrences of re_path() to url(). For example: ``from django.conf.urls import include, url`` instead of ``from django.conf.urls import include, re_path`` and ``url(r'^django-admin/', include(admin.site.urls)),`` instead of ``re_path(r'^django-admin/', include(admin.site.urls)),``.
-   (`read more <https://docs.djangoproject.com/en/2.1/ref/urls/#url>`_).
-
 You can implement switching between languages by changing the part at the beginning of the URL. As each language has its own URL, it also works well with just about any caching setup.
 
 

--- a/docs/advanced_topics/settings.rst
+++ b/docs/advanced_topics/settings.rst
@@ -609,11 +609,6 @@ URL Patterns
       re_path(r'', include(wagtail_urls)),
   ]
 
-.. important::
-
-   The example above assumes you are using Django version 2.0 or later. If you are using a Django version earlier than 2.0, you should rename all occurrences of re_path() to url(). For example: ``url(r'^django-admin/', include(admin.site.urls)),`` instead of ``re_path(r'^django-admin/', include(admin.site.urls)),``.
-   (`read more <https://docs.djangoproject.com/en/2.1/ref/urls/#url>`_).
-
 This block of code for your project's ``urls.py`` does a few things:
 
 * Load the vanilla Django admin interface to ``/django-admin/``

--- a/docs/getting_started/integrating_into_django.rst
+++ b/docs/getting_started/integrating_into_django.rst
@@ -77,11 +77,6 @@ Now make the following additions to your ``urls.py`` file:
         ...
     ]
 
-.. important::
-
-   The example above assumes you are using Django version 2.0 or later. If you are using a Django version earlier than 2.0, you should rename all occurrences of re_path() to url(). For example: ``from django.urls import path, url, include`` instead of ``from django.urls import path, re_path, include`` and ``url(r'^cms/', include(wagtailadmin_urls)),`` instead of ``re_path(r'^cms/', include(wagtailadmin_urls)),``.
-   (`read more <https://docs.djangoproject.com/en/2.1/ref/urls/#url>`_).
-
 The URL paths here can be altered as necessary to fit your project's URL scheme.
 
 ``wagtailadmin_urls`` provides the admin interface for Wagtail. This is separate from the Django admin interface (``django.contrib.admin``); Wagtail-only projects typically host the Wagtail admin at ``/admin/``, but if this would clash with your project's existing admin backend then an alternative path can be used, such as ``/cms/`` here.


### PR DESCRIPTION
These notes are redundant now that we're dropping Django <2.0 support.