### PR TITLE
Fixes docs reference to the wagtailsearch section which now results in a dead-end

### DIFF
--- a/docs/advanced_topics/settings.rst
+++ b/docs/advanced_topics/settings.rst
@@ -110,7 +110,7 @@ Wagtail Apps
   Module governing oEmbed and Embedly content in Wagtail rich text fields. See :ref:`inserting_videos`.
 
 ``wagtailsearch``
-  Search framework for Page content. See :ref:`search`.
+  Search framework for Page content. See :ref:`wagtailsearch`.
 
 ``wagtailredirects``
   Admin interface for creating arbitrary redirects on your site.


### PR DESCRIPTION
I was looking up some configuration settings within the documentation. Right now on the `Configuring Django for Wagtail` page the link to the search section within [Wagtail Apps](https://docs.wagtail.io/en/latest/advanced_topics/settings.html#wagtail-apps) results in a dead-end. 

![image](https://user-images.githubusercontent.com/287422/47205412-1bc87300-d386-11e8-8c8f-6c9e3fc1178a.png)

This PR fixes this by linking to Usage Guide > Search
