### PR TITLE
Allow overridden copy() methods in Page subclasses to be called from wagtail.admin.views.pages.copy()

### DIFF
--- a/wagtail/admin/views/pages.py
+++ b/wagtail/admin/views/pages.py
@@ -849,7 +849,7 @@ def copy(request, page_id):
             can_publish = parent_page.permissions_for_user(request.user).can_publish_subpage()
 
             # Copy the page
-            new_page = page.copy(
+            new_page = page.specific.copy(
                 recursive=form.cleaned_data.get('copy_subpages'),
                 to=parent_page,
                 update_attrs={


### PR DESCRIPTION
Since the existing code calls `page.copy()` directly on the `Page` object, the specific subclasses don't get a chance to inject the overridden method into the process.

The reason I needed this was to make it possible to copy a number of ManyToMany relationships on my `EventPage` model, which `Page.copy()` skips for some reason. Here's my `EventPage.copy()`:

```
    def copy(self, **kwargs):
        # First we need to perform the full copy operation, so that a new page fully exists before we start copying m2m.
        page_copy = super().copy(**kwargs)

        # Now we copy all the many-to-many relationships.
        page_copy.sponsors = self.sponsors.all()
        page_copy.tags = self.tags.all()
        page_copy.featured_on = self.featured_on.all()
        page_copy.save()

        return page_copy
```

This seems to be working fine, so it'd be nice if you could accept this PR so I won't need to resort to a monkey patch on `wagtail.admin.views.pages.copy()` in order to get my `copy()` method to run.