### PR TITLE
Cover additional redirect behavior cases

### DIFF
--- a/wagtail/contrib/redirects/middleware.py
+++ b/wagtail/contrib/redirects/middleware.py
@@ -54,7 +54,7 @@ class RedirectMiddleware(MiddlewareMixin):
                 return response
 
             redirect = get_redirect(request, path_without_query)
-            if redirect is None:
+            if redirect is None or redirect.link is None:
                 return response
 
         if redirect.is_permanent:

--- a/wagtail/contrib/redirects/middleware.py
+++ b/wagtail/contrib/redirects/middleware.py
@@ -54,7 +54,10 @@ class RedirectMiddleware(MiddlewareMixin):
                 return response
 
             redirect = get_redirect(request, path_without_query)
-            if redirect is None or redirect.link is None:
+            if redirect is None:
+                return response
+
+        if redirect.link is None:
                 return response
 
         if redirect.is_permanent:

--- a/wagtail/contrib/redirects/models.py
+++ b/wagtail/contrib/redirects/models.py
@@ -34,8 +34,10 @@ class Redirect(models.Model):
     def link(self):
         if self.redirect_page:
             return self.redirect_page.url
-        else:
+        elif self.redirect_link:
             return self.redirect_link
+
+        return None
 
     def get_is_permanent_display(self):
         if self.is_permanent:

--- a/wagtail/contrib/redirects/tests.py
+++ b/wagtail/contrib/redirects/tests.py
@@ -176,6 +176,13 @@ class TestRedirects(TestCase):
         response = self.client.get('/xmas/', HTTP_HOST='localhost')
         self.assertEqual(response.status_code, 404)
 
+    def test_redirect_without_page_or_link_target(self):
+        models.Redirect.objects.create(old_path='/xmas/', redirect_link='')
+
+        # the redirect has been created but has no target and should 404
+        response = self.client.get('/xmas/', HTTP_HOST='localhost')
+        self.assertEqual(response.status_code, 404)
+
     def test_redirect_to_page_without_site(self):
         siteless_page = Page.objects.get(url_path='/does-not-exist/')
         models.Redirect.objects.create(old_path='/xmas', redirect_page=siteless_page)

--- a/wagtail/contrib/redirects/tests.py
+++ b/wagtail/contrib/redirects/tests.py
@@ -176,6 +176,14 @@ class TestRedirects(TestCase):
         response = self.client.get('/xmas/', HTTP_HOST='localhost')
         self.assertEqual(response.status_code, 404)
 
+    def test_redirect_to_page_without_site(self):
+        siteless_page = Page.objects.get(url_path='/does-not-exist/')
+        models.Redirect.objects.create(old_path='/xmas', redirect_page=siteless_page)
+
+        # the redirect's destination page doesn't have a site so the redirect should 404
+        response = self.client.get('/xmas/', HTTP_HOST='localhost')
+        self.assertEqual(response.status_code, 404)
+
     def test_duplicate_redirects_when_match_is_for_generic(self):
         contact_page = Page.objects.get(url_path='/home/contact-us/')
         site = Site.objects.create(hostname='other.example.com', port=80, root_page=contact_page)

--- a/wagtail/tests/testapp/fixtures/test.json
+++ b/wagtail/tests/testapp/fixtures/test.json
@@ -79,6 +79,22 @@
     }
 },
 {
+    "pk": 21,
+    "model": "wagtailcore.page",
+    "fields": {
+        "title": "This page doesn't get served",
+        "draft_title": "This page doesn't get served",
+        "numchild": 0,
+        "show_in_menus": false,
+        "live": true,
+        "depth": 2,
+        "content_type": ["wagtailcore", "page"],
+        "path": "00010005",
+        "url_path": "/does-not-exist/",
+        "slug": "does-not-exist",
+    }
+},
+{
     "pk": 4,
     "model": "tests.eventpage",
     "fields": {


### PR DESCRIPTION
This PR fixes certain uncovered redirect behavioral cases:

- Redirects without target page or link no longer result in an infinite redirect loop
    - Formerly, if a redirect was  created for a `old_path` but didn't specify a target page or link, then going to the redirect would result in a redirect loop.
    - Added case coverage and a test for this situation.
- Redirects pointing to a page without a Site should result in a 404
    - Currently, an uncovered case results in `None` being appended to the current page. This PR changes it so the link will 404 instead
    - Added test and test fixture to catch when a redirect is pointing to a page that does not have a corresponding Site
    - Note: Ideally, when a page that is the target of a redirect is moved to no longer have a Site, it would warn in the move dialog but that behavior is not included.

Many thanks to @willbarton for his help developing and testing this.

