### PR TITLE
Users with blank language setting should fallback to currently active language

### DIFF
--- a/wagtail/wagtailusers/models.py
+++ b/wagtail/wagtailusers/models.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, unicode_literals
 from django.conf import settings
 from django.db import models
 from django.utils.encoding import python_2_unicode_compatible
+from django.utils.translation import get_language
 from django.utils.translation import ugettext_lazy as _
 
 
@@ -42,7 +43,7 @@ class UserProfile(models.Model):
         return cls.objects.get_or_create(user=user)[0]
 
     def get_preferred_language(self):
-        return self.preferred_language or settings.LANGUAGE_CODE
+        return self.preferred_language or get_language()
 
     def __str__(self):
         return self.user.get_username()


### PR DESCRIPTION
Hi there!

As usual, thanks for the wonderful project! :)

The behavior of most Django locale middleware is this: Activate a language according to some HTTP header, cookie, session or URL path element. Then fallback to `settings.LANGUAGE_CODE` if all this fails.

So this is the bug, that I could/should also have opened an issue for: Let's say I'm on `/en/wagtail` but my default language is `zh_CN`. In this case, all users without a preferred language on their profile will be shown the Chinese version, regardless that they navigate to `/en`.

This is very problematic because I use a manual URL navigation workflow `/<language>/wagtail` to translate using django-modeltranslation, and I have no way of switching anymore once a user has a profile object created.

Suggesting this to target `1.13.x` as it would be nice to have the support here. Am still stuck with a lot of things in Django 1.11, and it's hard to make the migration to Django 2 still. I think other users will be in the same situation.

After this change, a user can just navigate to their Language Preferences and set '---------' as preferred language. That will make them use whatever language is specified in `/XX/wagtail/`.

I tested the change locally and manually and it works. I also looked at the way that `user_profile.get_preferred_language()` and `@activate_lang` were used around the codebase, and I can't see anywhere that it would be expected to force `settings.LANGUAGE_CODE` rather than just falling back to the currently active language.

Thanks!