### PR TITLE
Adds `rel="noopener noreferrer"` to target blank link

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/shared/page_status_tag.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/page_status_tag.html
@@ -1,5 +1,7 @@
 {% if page.live %}
-    <a href="{{ page.url }}" target="_blank" class="status-tag primary">{{ page.status_string }}</a>
+    <a href="{{ page.url }}" target="_blank" rel="noopener noreferrer" class="status-tag primary">
+        {{ page.status_string }}
+    </a>
 {% else %}
     <span class="status-tag">{{ page.status_string }}</span>
 {% endif %}


### PR DESCRIPTION
Our security scanning software is flagging target blank without noopener noreferrer, probably [best practice](https://www.jitbit.com/alexblog/256-targetblank---the-most-underestimated-vulnerability-ever/ ) to add it.