### PR TITLE
Users with blank preferred_language should use activated language (from LocaleMiddleware)

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -38,6 +38,11 @@ def pytest_configure(config):
     os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'wagtail.tests.settings')
     django.setup()
 
+    # Activate a language: This affects HTTP header HTTP_ACCEPT_LANGUAGE sent by
+    # the Django test client.
+    from django.utils import translation
+    translation.activate("en")
+
     from wagtail.tests.settings import MEDIA_ROOT, STATIC_ROOT
     shutil.rmtree(STATIC_ROOT, ignore_errors=True)
     shutil.rmtree(MEDIA_ROOT, ignore_errors=True)

--- a/wagtail/admin/tests/test_account_management.py
+++ b/wagtail/admin/tests/test_account_management.py
@@ -397,6 +397,9 @@ class TestAccountSection(TestCase, WagtailTestUtils):
         # Check that the language preferences are stored
         self.assertEqual(profile.preferred_language, '')
 
+        # Check that the current language is assumed as English
+        self.assertEqual(profile.get_preferred_language(), "en")
+
     @override_settings(WAGTAILADMIN_PERMITTED_LANGUAGES=[('en', 'English'), ('es', 'Spanish')])
     def test_available_admin_languages_with_permitted_languages(self):
         self.assertListEqual(get_available_admin_languages(), [('en', 'English'), ('es', 'Spanish')])

--- a/wagtail/tests/settings.py
+++ b/wagtail/tests/settings.py
@@ -49,6 +49,8 @@ STATICFILES_FINDERS = (
 
 USE_TZ = True
 
+LANGUAGE_CODE = "en"
+
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
@@ -88,6 +90,7 @@ MIDDLEWARE = (
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
+    'django.middleware.locale.LocaleMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',

--- a/wagtail/users/models.py
+++ b/wagtail/users/models.py
@@ -4,6 +4,7 @@ import uuid
 from django.conf import settings
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import get_language
 
 
 def upload_avatar_to(instance, filename):
@@ -63,7 +64,7 @@ class UserProfile(models.Model):
         return cls.objects.get_or_create(user=user)[0]
 
     def get_preferred_language(self):
-        return self.preferred_language or settings.LANGUAGE_CODE
+        return self.preferred_language or get_language()
 
     def get_current_time_zone(self):
         return self.current_time_zone or settings.TIME_ZONE


### PR DESCRIPTION
Supersedes #4837

....

Hi there!

As usual, thanks for the wonderful project! :)

The behavior of most Django locale middleware is this: Activate a language according to some HTTP header, cookie, session or URL path element. Then fallback to `settings.LANGUAGE_CODE` if all this fails.

So this is the bug, that I could/should also have opened an issue for: Let's say I'm on `/en/wagtail` but my default language is `zh_CN`. In this case, all users without a preferred language on their profile will be shown the Chinese version, regardless that they navigate to `/en`.

This is very problematic because I use a manual URL navigation workflow `/<language>/wagtail` to translate using django-modeltranslation, and I have no way of switching anymore once a user has a profile object created.

Suggesting this to target `1.13.x` as it would be nice to have the support here. Am still stuck with a lot of things in Django 1.11, and it's hard to make the migration to Django 2 still. I think other users will be in the same situation.

After this change, a user can just navigate to their Language Preferences and set '---------' as preferred language. That will make them use whatever language is specified in `/XX/wagtail/`.

I tested the change locally and manually and it works. I also looked at the way that `user_profile.get_preferred_language()` and `@activate_lang` were used around the codebase, and I can't see anywhere that it would be expected to force `settings.LANGUAGE_CODE` rather than just falling back to the currently active language.

Thanks!