### PR TITLE
Make EmbedBlock tests work offline

### DIFF
--- a/wagtail/embeds/tests.py
+++ b/wagtail/embeds/tests.py
@@ -518,7 +518,10 @@ class TestEmbedBlock(TestCase):
         self.assertIsInstance(block5.get_default(), EmbedValue)
         self.assertEqual(block5.get_default().url, 'http://www.example.com/foo')
 
-    def test_clean_required(self):
+    @patch('wagtail.embeds.embeds.get_embed')
+    def test_clean_required(self, get_embed):
+        get_embed.return_value = Embed(html='<h1>Hello world!</h1>')
+
         block = EmbedBlock()
 
         cleaned_value = block.clean(
@@ -530,7 +533,10 @@ class TestEmbedBlock(TestCase):
         with self.assertRaisesMessage(ValidationError, ''):
             block.clean(None)
 
-    def test_clean_non_required(self):
+    @patch('wagtail.embeds.embeds.get_embed')
+    def test_clean_non_required(self, get_embed):
+        get_embed.return_value = Embed(html='<h1>Hello world!</h1>')
+
         block = EmbedBlock(required=False)
 
         cleaned_value = block.clean(
@@ -542,7 +548,10 @@ class TestEmbedBlock(TestCase):
         cleaned_value = block.clean(None)
         self.assertIsNone(cleaned_value)
 
-    def test_clean_invalid_url(self):
+    @patch('wagtail.embeds.embeds.get_embed')
+    def test_clean_invalid_url(self, get_embed):
+        get_embed.side_effect = EmbedNotFoundException
+
         non_required_block = EmbedBlock(required=False)
 
         with self.assertRaises(ValidationError):


### PR DESCRIPTION
As of 42caa586b445fa154c835802e3dbdee52c8b72d7 the embed endpoint is checked on EmbedBlock.clean, so we need to mock get_embed during these tests to avoid a live HTTP request.