### PR TITLE
Fix deprecation warnings for Django 3.0

### DIFF
--- a/docs/advanced_topics/customisation/admin_templates.rst
+++ b/docs/advanced_topics/customisation/admin_templates.rst
@@ -34,7 +34,7 @@ To replace the default logo, create a template file ``dashboard/templates/wagtai
 .. code-block:: html+django
 
     {% extends "wagtailadmin/base.html" %}
-    {% load staticfiles %}
+    {% load static %}
 
     {% block branding_logo %}
         <img src="{% static 'images/custom-logo.svg' %}" alt="Custom Project" width="80" />
@@ -50,7 +50,7 @@ To replace the favicon displayed when viewing admin pages, create a template fil
 .. code-block:: html+django
 
     {% extends "wagtailadmin/admin_base.html" %}
-    {% load staticfiles %}
+    {% load static %}
 
     {% block branding_favicon %}
         <link rel="shortcut icon" href="{% static 'images/favicon.ico' %}" />

--- a/wagtail/admin/menu.py
+++ b/wagtail/admin/menu.py
@@ -1,7 +1,7 @@
-from django.contrib.staticfiles.templatetags.staticfiles import static
 from django.forms import Media, MediaDefiningClass
 from django.forms.utils import flatatt
 from django.template.loader import render_to_string
+from django.templatetags.static import static
 from django.utils.safestring import mark_safe
 from django.utils.text import slugify
 

--- a/wagtail/admin/templates/wagtailadmin/404.html
+++ b/wagtail/admin/templates/wagtailadmin/404.html
@@ -1,5 +1,5 @@
 {% extends "wagtailadmin/admin_base.html" %}
-{% load wagtailadmin_tags wagtailcore_tags staticfiles i18n %}
+{% load wagtailadmin_tags wagtailcore_tags static i18n %}
 {% block titletag %}{% trans "Error 404: Page not found" %}{% endblock %}
 
 

--- a/wagtail/admin/templates/wagtailadmin/account/password_reset/complete.html
+++ b/wagtail/admin/templates/wagtailadmin/account/password_reset/complete.html
@@ -1,5 +1,5 @@
 {% extends "wagtailadmin/admin_base.html" %}
-{% load staticfiles i18n %}
+{% load static i18n %}
 {% block titletag %}{% trans "Reset password" %}{% endblock %}
 {% block bodyclass %}login{% endblock %}
 

--- a/wagtail/admin/templates/wagtailadmin/account/password_reset/confirm.html
+++ b/wagtail/admin/templates/wagtailadmin/account/password_reset/confirm.html
@@ -1,5 +1,5 @@
 {% extends "wagtailadmin/admin_base.html" %}
-{% load staticfiles i18n %}
+{% load static i18n %}
 {% block titletag %}
     {% if validlink %}
         {% trans "Set your new password" %}

--- a/wagtail/admin/templates/wagtailadmin/account/password_reset/done.html
+++ b/wagtail/admin/templates/wagtailadmin/account/password_reset/done.html
@@ -1,5 +1,5 @@
 {% extends "wagtailadmin/admin_base.html" %}
-{% load staticfiles i18n %}
+{% load static i18n %}
 {% block titletag %}{% trans "Reset password" %}{% endblock %}
 {% block bodyclass %}login{% endblock %}
 

--- a/wagtail/admin/templates/wagtailadmin/account/password_reset/form.html
+++ b/wagtail/admin/templates/wagtailadmin/account/password_reset/form.html
@@ -1,5 +1,5 @@
 {% extends "wagtailadmin/admin_base.html" %}
-{% load staticfiles i18n %}
+{% load static i18n %}
 {% block titletag %}{% trans "Reset password" %}{% endblock %}
 {% block bodyclass %}login{% endblock %}
 

--- a/wagtail/admin/templates/wagtailadmin/admin_base.html
+++ b/wagtail/admin/templates/wagtailadmin/admin_base.html
@@ -1,5 +1,5 @@
 {% extends "wagtailadmin/skeleton.html" %}
-{% load i18n staticfiles wagtailadmin_tags %}
+{% load i18n static wagtailadmin_tags %}
 
 {% block css %}
     <link rel="stylesheet" href="{% static 'wagtailadmin/css/vendor/jquery-ui/jquery-ui-1.10.3.verdant.css' %}" />

--- a/wagtail/admin/templates/wagtailadmin/base.html
+++ b/wagtail/admin/templates/wagtailadmin/base.html
@@ -1,5 +1,5 @@
 {% extends "wagtailadmin/admin_base.html" %}
-{% load wagtailadmin_tags wagtailcore_tags staticfiles i18n %}
+{% load wagtailadmin_tags wagtailcore_tags static i18n %}
 
 {% block furniture %}
     <div class="nav-wrapper">

--- a/wagtail/admin/templates/wagtailadmin/home.html
+++ b/wagtail/admin/templates/wagtailadmin/home.html
@@ -1,5 +1,5 @@
 {% extends "wagtailadmin/base.html" %}
-{% load wagtailadmin_tags staticfiles i18n %}
+{% load wagtailadmin_tags static i18n %}
 {% block titletag %}{% trans "Dashboard" %}{% endblock %}
 {% block bodyclass %}homepage{% endblock %}
 

--- a/wagtail/admin/templates/wagtailadmin/home/upgrade_notification.html
+++ b/wagtail/admin/templates/wagtailadmin/home/upgrade_notification.html
@@ -1,4 +1,4 @@
-{% load wagtailcore_tags staticfiles %}
+{% load wagtailcore_tags static %}
 
 <div class="panel nice-padding panel-upgrade-notification" style="display:none">
     <div class="help-block help-warning">Wagtail upgrade available. Your version: <strong>{% wagtail_version %}</strong>. New version: <strong class="newversion"></strong>. <a class="releasenotes-link" href="">Read the release notes.</a></div>

--- a/wagtail/admin/templates/wagtailadmin/login.html
+++ b/wagtail/admin/templates/wagtailadmin/login.html
@@ -1,5 +1,5 @@
 {% extends "wagtailadmin/admin_base.html" %}
-{% load staticfiles i18n %}
+{% load static i18n %}
 {% block titletag %}{% trans "Sign in" %}{% endblock %}
 {% block bodyclass %}login{% endblock %}
 

--- a/wagtail/admin/templates/wagtailadmin/notifications/base.html
+++ b/wagtail/admin/templates/wagtailadmin/notifications/base.html
@@ -1,4 +1,4 @@
-{% load i18n staticfiles %}
+{% load i18n static %}
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>

--- a/wagtail/admin/templates/wagtailadmin/pages/_editor_css.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/_editor_css.html
@@ -1,4 +1,4 @@
-{% load wagtailadmin_tags staticfiles %}
+{% load wagtailadmin_tags static %}
 
 {% comment %}
     CSS declarations to be included on the 'create page' and 'edit page' views

--- a/wagtail/admin/templates/wagtailadmin/pages/_editor_js.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/_editor_js.html
@@ -1,4 +1,4 @@
-{% load wagtailadmin_tags staticfiles %}
+{% load wagtailadmin_tags static %}
 
 {% comment %}
     Javascript declarations to be included on the 'create page' and 'edit page' views

--- a/wagtail/admin/templates/wagtailadmin/pages/index.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/index.html
@@ -1,5 +1,5 @@
 {% extends "wagtailadmin/base.html" %}
-{% load wagtailadmin_tags staticfiles i18n %}
+{% load wagtailadmin_tags static i18n %}
 {% block titletag %}{% blocktrans with title=parent_page.get_admin_display_title %}Exploring {{ title }}{% endblocktrans %}{% endblock %}
 {% block bodyclass %}page-explorer {% if ordering == 'ord' %}reordering{% endif %}{% endblock %}
 

--- a/wagtail/admin/templates/wagtailadmin/shared/animated_logo.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/animated_logo.html
@@ -1,4 +1,4 @@
-{% load wagtailadmin_tags staticfiles %}
+{% load wagtailadmin_tags static %}
 
 <div class="wagtail-logo-container__desktop u-hidden@small">
     <img class="wagtail-logo wagtail-logo__body" src="{% static 'wagtailadmin/images/logo-body.svg' %}" alt=""/>

--- a/wagtail/admin/templates/wagtailadmin/skeleton.html
+++ b/wagtail/admin/templates/wagtailadmin/skeleton.html
@@ -1,5 +1,5 @@
 <!doctype html>
-{% load staticfiles i18n %}
+{% load static i18n %}
 <html class="no-js" lang="{{ LANGUAGE_CODE|default:"en-gb" }}">
 <head>
     <meta charset="utf-8" />

--- a/wagtail/admin/templates/wagtailadmin/userbar/base.html
+++ b/wagtail/admin/templates/wagtailadmin/userbar/base.html
@@ -1,4 +1,4 @@
-{% load staticfiles i18n %}
+{% load static i18n %}
 <!-- Wagtail user bar embed code -->
 <div class="wagtail-userbar-reset">
     <div class="wagtail-userbar wagtail-userbar--{{ position|default:'bottom-right' }}" data-wagtail-userbar>

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -5,9 +5,9 @@ from django.conf import settings
 from django.contrib.admin.utils import quote
 from django.contrib.humanize.templatetags.humanize import intcomma
 from django.contrib.messages.constants import DEFAULT_TAGS as MESSAGE_TAGS
-from django.contrib.staticfiles.templatetags.staticfiles import static
 from django.template.defaultfilters import stringfilter
 from django.template.loader import render_to_string
+from django.templatetags.static import static
 from django.utils.html import conditional_escape
 from django.utils.safestring import mark_safe
 

--- a/wagtail/contrib/modeladmin/templates/modeladmin/choose_parent.html
+++ b/wagtail/contrib/modeladmin/templates/modeladmin/choose_parent.html
@@ -1,5 +1,5 @@
 {% extends "wagtailadmin/base.html" %}
-{% load i18n modeladmin_tags admin_static %}
+{% load i18n modeladmin_tags static %}
 
 {% block titletag %}{{ view.get_meta_title }}{% endblock %}
 

--- a/wagtail/contrib/modeladmin/templates/modeladmin/includes/search_form.html
+++ b/wagtail/contrib/modeladmin/templates/modeladmin/includes/search_form.html
@@ -1,4 +1,4 @@
-{% load i18n admin_static %}
+{% load i18n static %}
 {% if view.search_fields %}
 <form id="changelist-search" class="col search-form" action="{{ view.index_url }}" method="get">
     <ul class="fields">

--- a/wagtail/contrib/modeladmin/templates/modeladmin/inspect.html
+++ b/wagtail/contrib/modeladmin/templates/modeladmin/inspect.html
@@ -1,5 +1,5 @@
 {% extends "wagtailadmin/base.html" %}
-{% load i18n admin_static %}
+{% load i18n static %}
 
 {% block titletag %}{{ view.get_meta_title }}{% endblock %}
 

--- a/wagtail/contrib/search_promotions/templates/wagtailsearchpromotions/add.html
+++ b/wagtail/contrib/search_promotions/templates/wagtailsearchpromotions/add.html
@@ -1,5 +1,5 @@
 {% extends "wagtailadmin/base.html" %}
-{% load i18n staticfiles %}
+{% load i18n static %}
 {% block titletag %}{% trans "Add search promotion" %}{% endblock %}
 {% block content %}
     {% trans "Add search pick" as add_str %}

--- a/wagtail/contrib/search_promotions/templates/wagtailsearchpromotions/edit.html
+++ b/wagtail/contrib/search_promotions/templates/wagtailsearchpromotions/edit.html
@@ -1,5 +1,5 @@
 {% extends "wagtailadmin/base.html" %}
-{% load i18n staticfiles %}
+{% load i18n static %}
 {% block titletag %}{% blocktrans with query=query.query_string %}Editing {{ query }}{% endblocktrans %}{% endblock %}
 {% block content %}
     {% trans "Editing" as editing_str %}

--- a/wagtail/contrib/styleguide/templates/wagtailstyleguide/base.html
+++ b/wagtail/contrib/styleguide/templates/wagtailstyleguide/base.html
@@ -1,5 +1,5 @@
 {% extends "wagtailadmin/base.html" %}
-{% load wagtailadmin_tags i18n staticfiles %}
+{% load wagtailadmin_tags i18n static %}
 
 {% block extra_css %}
     {{ block.super }}

--- a/wagtail/core/blocks/list_block.py
+++ b/wagtail/core/blocks/list_block.py
@@ -1,8 +1,8 @@
 from django import forms
-from django.contrib.staticfiles.templatetags.staticfiles import static
 from django.core.exceptions import ValidationError
 from django.forms.utils import ErrorList
 from django.template.loader import render_to_string
+from django.templatetags.static import static
 from django.utils.html import format_html, format_html_join
 from django.utils.safestring import mark_safe
 

--- a/wagtail/core/blocks/stream_block.py
+++ b/wagtail/core/blocks/stream_block.py
@@ -3,10 +3,10 @@ from collections import OrderedDict, defaultdict
 from collections.abc import Sequence
 
 from django import forms
-from django.contrib.staticfiles.templatetags.staticfiles import static
 from django.core.exceptions import NON_FIELD_ERRORS, ValidationError
 from django.forms.utils import ErrorList
 from django.template.loader import render_to_string
+from django.templatetags.static import static
 from django.utils.html import format_html_join
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext as _

--- a/wagtail/core/blocks/struct_block.py
+++ b/wagtail/core/blocks/struct_block.py
@@ -1,10 +1,10 @@
 import collections
 
 from django import forms
-from django.contrib.staticfiles.templatetags.staticfiles import static
 from django.core.exceptions import ValidationError
 from django.forms.utils import ErrorList
 from django.template.loader import render_to_string
+from django.templatetags.static import static
 from django.utils.functional import cached_property
 from django.utils.html import format_html, format_html_join
 

--- a/wagtail/core/fields.py
+++ b/wagtail/core/fields.py
@@ -105,7 +105,7 @@ class StreamField(models.Field):
         else:
             return json.dumps(self.stream_block.get_prep_value(value), cls=DjangoJSONEncoder)
 
-    def from_db_value(self, value, expression, connection, context):
+    def from_db_value(self, value, expression, connection):
         return self.to_python(value)
 
     def formfield(self, **kwargs):

--- a/wagtail/documents/templates/wagtaildocs/multiple/add.html
+++ b/wagtail/documents/templates/wagtaildocs/multiple/add.html
@@ -1,7 +1,7 @@
 {% extends "wagtailadmin/base.html" %}
 {% load i18n %}
 {% load l10n %}
-{% load staticfiles %}
+{% load static %}
 {% block titletag %}{% trans "Add multiple documents" %}{% endblock %}
 {% block extra_css %}
     {{ block.super }}

--- a/wagtail/embeds/tests.py
+++ b/wagtail/embeds/tests.py
@@ -518,7 +518,10 @@ class TestEmbedBlock(TestCase):
         self.assertIsInstance(block5.get_default(), EmbedValue)
         self.assertEqual(block5.get_default().url, 'http://www.example.com/foo')
 
-    def test_clean_required(self):
+    @patch('wagtail.embeds.embeds.get_embed')
+    def test_clean_required(self, get_embed):
+        get_embed.return_value = Embed(html='<h1>Hello world!</h1>')
+
         block = EmbedBlock()
 
         cleaned_value = block.clean(
@@ -530,7 +533,10 @@ class TestEmbedBlock(TestCase):
         with self.assertRaisesMessage(ValidationError, ''):
             block.clean(None)
 
-    def test_clean_non_required(self):
+    @patch('wagtail.embeds.embeds.get_embed')
+    def test_clean_non_required(self, get_embed):
+        get_embed.return_value = Embed(html='<h1>Hello world!</h1>')
+
         block = EmbedBlock(required=False)
 
         cleaned_value = block.clean(
@@ -542,7 +548,10 @@ class TestEmbedBlock(TestCase):
         cleaned_value = block.clean(None)
         self.assertIsNone(cleaned_value)
 
-    def test_clean_invalid_url(self):
+    @patch('wagtail.embeds.embeds.get_embed')
+    def test_clean_invalid_url(self, get_embed):
+        get_embed.side_effect = EmbedNotFoundException
+
         non_required_block = EmbedBlock(required=False)
 
         with self.assertRaises(ValidationError):

--- a/wagtail/images/templates/wagtailimages/images/edit.html
+++ b/wagtail/images/templates/wagtailimages/images/edit.html
@@ -1,5 +1,5 @@
 {% extends "wagtailadmin/base.html" %}
-{% load wagtailimages_tags wagtailadmin_tags staticfiles i18n l10n %}
+{% load wagtailimages_tags wagtailadmin_tags static i18n l10n %}
 {% block titletag %}{% blocktrans with title=image.title %}Editing image {{ title }}{% endblocktrans %}{% endblock %}
 {% block extra_css %}
     {{ block.super }}

--- a/wagtail/images/templates/wagtailimages/images/url_generator.html
+++ b/wagtail/images/templates/wagtailimages/images/url_generator.html
@@ -1,5 +1,5 @@
 {% extends "wagtailadmin/base.html" %}
-{% load wagtailimages_tags staticfiles i18n %}
+{% load wagtailimages_tags static i18n %}
 
 {% block titletag %}{% blocktrans with title=image.title %}Editing image {{ title }}{% endblocktrans %}{% endblock %}
 

--- a/wagtail/images/templates/wagtailimages/multiple/add.html
+++ b/wagtail/images/templates/wagtailimages/multiple/add.html
@@ -1,7 +1,7 @@
 {% extends "wagtailadmin/base.html" %}
 {% load i18n %}
 {% load l10n %}
-{% load staticfiles %}
+{% load static %}
 {% load wagtailimages_tags %}
 {% block titletag %}{% trans "Add multiple images" %}{% endblock %}
 {% block extra_css %}

--- a/wagtail/tests/customuser/fields.py
+++ b/wagtail/tests/customuser/fields.py
@@ -54,7 +54,7 @@ class ConvertedValueField(models.IntegerField):
             value = ConvertedValue(value)
         return value
 
-    def from_db_value(self, value, expression, connection, context):
+    def from_db_value(self, value, expression, connection):
         if not value:
             return
         return ConvertedValue(value)

--- a/wagtail/tests/testapp/wagtail_hooks.py
+++ b/wagtail/tests/testapp/wagtail_hooks.py
@@ -1,6 +1,6 @@
 from django import forms
-from django.contrib.staticfiles.templatetags.staticfiles import static
 from django.http import HttpResponse
+from django.templatetags.static import static
 
 import wagtail.admin.rich_text.editors.draftail.features as draftail_features
 from wagtail.admin.menu import MenuItem

--- a/wagtail/users/templates/wagtailusers/groups/create.html
+++ b/wagtail/users/templates/wagtailusers/groups/create.html
@@ -1,5 +1,5 @@
 {% extends "wagtailadmin/base.html" %}
-{% load wagtailusers_tags wagtailimages_tags staticfiles i18n %}
+{% load wagtailusers_tags wagtailimages_tags static i18n %}
 
 {% block titletag %}{% trans "Add group" %}{% endblock %}
 

--- a/wagtail/users/templates/wagtailusers/groups/edit.html
+++ b/wagtail/users/templates/wagtailusers/groups/edit.html
@@ -1,5 +1,5 @@
 {% extends "wagtailadmin/base.html" %}
-{% load wagtailusers_tags staticfiles i18n %}
+{% load wagtailusers_tags static i18n %}
 
 {% block titletag %}{% trans "Editing" %} {{ group.name }}{% endblock %}
 

--- a/wagtail/users/templates/wagtailusers/groups/includes/group_form_js.html
+++ b/wagtail/users/templates/wagtailusers/groups/includes/group_form_js.html
@@ -1,4 +1,4 @@
-{% load staticfiles %}
+{% load static %}
 <script>
     window.chooserUrls = {
         'pageChooser': '{% url "wagtailadmin_choose_page" %}'


### PR DESCRIPTION
Just two (fairly trivial) issues to address to make Django 3.0 deprecation warnings go away: removing the `context` argument from `from_db_value` methods on custom model fields, and replacing the `django.contrib.staticfiles` template tag library with `django.templatetags.static`.

Incorporates #4847