### PR TITLE
Document the Dockerfile in the project template

### DIFF
--- a/docs/reference/project_template.rst
+++ b/docs/reference/project_template.rst
@@ -38,6 +38,7 @@ The project template
             __init__.py
             urls.py
             wsgi.py
+        Dockerfile
         manage.py
         requirements.txt
 
@@ -87,3 +88,16 @@ The Django settings files are split up into ``base.py``, ``dev.py``, ``productio
         .. tip::
 
             On production servers, we recommend that you only store secrets in ``local.py`` (such as API keys and passwords). This can save you headaches in the future if you are ever trying to debug why a server is behaving badly. If you are using multiple servers which need different settings then we recommend that you create a different ``production.py`` file for each one.
+
+
+Dockerfile
+----------
+
+Location: ``/mysite/Dockerfile``
+
+Contains configuration for building and deploying the site as a `Docker <https://docs.docker.com/>`_ container. To set up Docker for your project, run:
+
+.. code-block:: console
+
+    docker build -t mysite .
+    docker run -p 8000:8000 mysite

--- a/docs/reference/project_template.rst
+++ b/docs/reference/project_template.rst
@@ -95,7 +95,7 @@ Dockerfile
 
 Location: ``/mysite/Dockerfile``
 
-Contains configuration for building and deploying the site as a `Docker <https://docs.docker.com/>`_ container. To set up Docker for your project, run:
+Contains configuration for building and deploying the site as a `Docker <https://docs.docker.com/>`_ container. To build and use the Docker image for your project, run:
 
 .. code-block:: console
 


### PR DESCRIPTION
The documentation is currently missing details of what to do with the Dockerfile in the project template (#4119), or the fact that it exists at all - adding a brief mention of it here.