### PR TITLE
Added overview of collections in the Image/Document chooser templates

### DIFF
--- a/wagtail/documents/templates/wagtaildocs/documents/list.html
+++ b/wagtail/documents/templates/wagtaildocs/documents/list.html
@@ -15,6 +15,7 @@
                 {% endif %}
             </th>
             <th>{% trans "File" %}</th>
+            <th>{% trans "Collection" %}</th>
             <th>
                 {% if not is_searching %}
                     <a href="{% url 'wagtaildocs:index' %}{% if not ordering == "-created_at" %}?ordering=-created_at{% endif %}" class="icon icon-arrow-down-after {% if  ordering == "-created_at" %}teal{% endif %}">
@@ -37,6 +38,7 @@
                     {% endif %}
                 </td>
                 <td><a href="{{ doc.url }}" class="nolink" download>{{ doc.filename }}</a></td>
+                <td>{{ doc.collection.name }}</td>
                 <td><div class="human-readable-date" title="{{ doc.created_at|date:"d M Y H:i" }}">{% blocktrans with time_period=doc.created_at|timesince %}{{ time_period }} ago{% endblocktrans %}</div></td>
             </tr>
         {% endfor %}

--- a/wagtail/documents/templates/wagtaildocs/documents/list.html
+++ b/wagtail/documents/templates/wagtaildocs/documents/list.html
@@ -15,7 +15,9 @@
                 {% endif %}
             </th>
             <th>{% trans "File" %}</th>
-            <th>{% trans "Collection" %}</th>
+            {% if collections %}
+                <th>{% trans "Collection" %}</th>
+            {% endif %}
             <th>
                 {% if not is_searching %}
                     <a href="{% url 'wagtaildocs:index' %}{% if not ordering == "-created_at" %}?ordering=-created_at{% endif %}" class="icon icon-arrow-down-after {% if  ordering == "-created_at" %}teal{% endif %}">
@@ -38,7 +40,9 @@
                     {% endif %}
                 </td>
                 <td><a href="{{ doc.url }}" class="nolink" download>{{ doc.filename }}</a></td>
-                <td>{{ doc.collection.name }}</td>
+                {% if collections %}
+                    <td>{{ doc.collection.name }}</td>
+                {% endif %}
                 <td><div class="human-readable-date" title="{{ doc.created_at|date:"d M Y H:i" }}">{% blocktrans with time_period=doc.created_at|timesince %}{{ time_period }} ago{% endblocktrans %}</div></td>
             </tr>
         {% endfor %}

--- a/wagtail/documents/tests/test_admin_views.py
+++ b/wagtail/documents/tests/test_admin_views.py
@@ -77,6 +77,23 @@ class TestDocumentIndexView(TestCase, WagtailTestUtils):
             response = self.client.get(reverse('wagtaildocs:index'), {'ordering': ordering})
             self.assertEqual(response.status_code, 200)
 
+    def test_index_without_collections(self):
+        self.make_docs()
+
+        response = self.client.get(reverse('wagtaildocs:index'))
+        self.assertNotContains(response, '<th>Collection</th>')
+        self.assertNotContains(response, '<td>Root</td>')
+
+    def test_index_with_collection(self):
+        root_collection = Collection.get_first_root_node()
+        root_collection.add_child(name="Evil plans")
+
+        self.make_docs()
+
+        response = self.client.get(reverse('wagtaildocs:index'))
+        self.assertContains(response, '<th>Collection</th>')
+        self.assertContains(response, '<td>Root</td>')
+
 
 class TestDocumentAddView(TestCase, WagtailTestUtils):
     def setUp(self):
@@ -704,6 +721,23 @@ class TestDocumentChooserView(TestCase, WagtailTestUtils):
             response = self.client.get(reverse('wagtaildocs:chooser'), {'q': 'Test'})
         self.assertEqual(len(response.context['documents']), 1)
         self.assertEqual(response.context['documents'][0], document)
+
+    def test_index_without_collections(self):
+        self.make_docs()
+
+        response = self.client.get(reverse('wagtaildocs:index'))
+        self.assertNotContains(response, '<th>Collection</th>')
+        self.assertNotContains(response, '<td>Root</td>')
+
+    def test_index_with_collection(self):
+        root_collection = Collection.get_first_root_node()
+        root_collection.add_child(name="Evil plans")
+
+        self.make_docs()
+
+        response = self.client.get(reverse('wagtaildocs:index'))
+        self.assertContains(response, '<th>Collection</th>')
+        self.assertContains(response, '<td>Root</td>')
 
 
 class TestDocumentChooserChosenView(TestCase, WagtailTestUtils):

--- a/wagtail/images/templates/wagtailimages/chooser/results.html
+++ b/wagtail/images/templates/wagtailimages/chooser/results.html
@@ -16,7 +16,7 @@
     <ul class="listing horiz images chooser">
         {% for image in images %}
             <li>
-                <a class="image-choice" title="{{ image.collection.name }} » {{ image.title }}" href="{% if will_select_format %}{% url 'wagtailimages:chooser_select_format' image.id %}{% else %}{% url 'wagtailimages:image_chosen' image.id %}{% endif %}">
+                <a class="image-choice" title="{% if collections %}{{ image.collection.name }} » {% endif %}{{ image.title }}" href="{% if will_select_format %}{% url 'wagtailimages:chooser_select_format' image.id %}{% else %}{% url 'wagtailimages:image_chosen' image.id %}{% endif %}">
                     <div class="image">{% image image max-165x165 class="show-transparency" %}</div>
                     <h3>{{ image.title|ellipsistrim:60 }}</h3>
                 </a>

--- a/wagtail/images/templates/wagtailimages/chooser/results.html
+++ b/wagtail/images/templates/wagtailimages/chooser/results.html
@@ -12,11 +12,11 @@
     {% else %}
         <h2>{% trans "Latest images" %}</h2>
     {% endif %}
-    
+
     <ul class="listing horiz images chooser">
         {% for image in images %}
             <li>
-                <a class="image-choice" href="{% if will_select_format %}{% url 'wagtailimages:chooser_select_format' image.id %}{% else %}{% url 'wagtailimages:image_chosen' image.id %}{% endif %}">
+                <a class="image-choice" title="{{ image.collection.name }} » {{ image.title }}" href="{% if will_select_format %}{% url 'wagtailimages:chooser_select_format' image.id %}{% else %}{% url 'wagtailimages:image_chosen' image.id %}{% endif %}">
                     <div class="image">{% image image max-165x165 class="show-transparency" %}</div>
                     <h3>{{ image.title|ellipsistrim:60 }}</h3>
                 </a>

--- a/wagtail/images/templates/wagtailimages/images/results.html
+++ b/wagtail/images/templates/wagtailimages/images/results.html
@@ -9,7 +9,7 @@
             There are {{ counter }} matches
         {% endblocktrans %}
         </h2>
-        
+
         {% search_other %}
     {% else %}
         <h2>{% trans "Latest images" %}</h2>
@@ -18,7 +18,7 @@
     <ul class="listing horiz images">
         {% for image in images %}
             <li>
-                <a class="image-choice" href="{% url 'wagtailimages:edit' image.id %}">
+                <a class="image-choice" title="{{ image.collection.name }} » {{ image.title }}" href="{% url 'wagtailimages:edit' image.id %}">
                     {% include "wagtailimages/images/results_image.html" %}
                     <h3>{{ image.title|ellipsistrim:60 }}</h3>
                 </a>
@@ -31,7 +31,7 @@
 {% else %}
     {% if is_searching %}
         <h2>{% blocktrans %}Sorry, no images match "<em>{{ query_string }}</em>"{% endblocktrans %}</h2>
-        
+
         {% search_other %}
     {% else %}
         {% url 'wagtailimages:add_multiple' as wagtailimages_add_image_url %}

--- a/wagtail/images/templates/wagtailimages/images/results.html
+++ b/wagtail/images/templates/wagtailimages/images/results.html
@@ -18,7 +18,7 @@
     <ul class="listing horiz images">
         {% for image in images %}
             <li>
-                <a class="image-choice" title="{{ image.collection.name }} » {{ image.title }}" href="{% url 'wagtailimages:edit' image.id %}">
+                <a class="image-choice" title="{% if collections %}{{ image.collection.name }} » {% endif %}{{ image.title }}" href="{% url 'wagtailimages:edit' image.id %}">
                     {% include "wagtailimages/images/results_image.html" %}
                     <h3>{{ image.title|ellipsistrim:60 }}</h3>
                 </a>


### PR DESCRIPTION
Follow up from #4383 which was missing the check on whether an end-user is actually using collections, so we could get this merged. It initially refers to issue #4162