### PR TITLE
fix help text positioning to avoid text cutting with narrow field

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -10,6 +10,7 @@ Changelog
  * Fix: Query objects returned from `PageQuerySet.type_q` can now be merged with `|` (Brady Moe)
  * Fix: Add `rel="noopener noreferrer"` to target blank links (Anselm Bradford)
  * Fix: Additional fields on custom document models now show on the multiple document upload view (Robert Rollins, Sergey Fedoseev)
+ * Fix: Help text is partially hidden when using a combination of BooleanField and FieldPanel in page model (Dzianis Sheka)
 
 
 2.3 LTS (23.10.2018)

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -326,6 +326,7 @@ Contributors
 * Yi Huang
 * Stas Rudakou
 * Abdulaziz Alfuhigi
+* Dzianis Sheka
 
 Translators
 ===========

--- a/docs/releases/2.4.rst
+++ b/docs/releases/2.4.rst
@@ -25,6 +25,7 @@ Bug fixes
  * Query objects returned from ``PageQuerySet.type_q`` can now be merged with ``|`` (Brady Moe)
  * Add ``rel="noopener noreferrer"`` to target blank links (Anselm Bradford)
  * Additional fields on custom document models now show on the multiple document upload view (Robert Rollins, Sergey Fedoseev)
+ * Help text does not overflow when using a combination of BooleanField and FieldPanel in page model (Dzianis Sheka)
 
 
 Upgrade considerations

--- a/wagtail/admin/static_src/wagtailadmin/scss/layouts/page-editor.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/layouts/page-editor.scss
@@ -409,10 +409,14 @@ footer .preview {
             flex-flow: row-reverse wrap;
 
             &_small-part {
+                // IE11 requires units on the flex basis. Unitless breaks.
+                // stylelint-disable-next-line length-zero-no-unit
                 flex: 1 0 0px;
             }
 
             &_big-part {
+                // IE11 requires units on the flex basis. Unitless breaks.
+                // stylelint-disable-next-line length-zero-no-unit
                 flex: 5 0 0px;
             }
         }

--- a/wagtail/admin/static_src/wagtailadmin/scss/layouts/page-editor.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/layouts/page-editor.scss
@@ -390,7 +390,7 @@ footer .preview {
 @include medium {
     .object {
         fieldset {
-            @include column(10);
+            // @include column(10);
             // Override column mixin for column items.
             display: block;
             // Override column mixin for column items.
@@ -404,14 +404,33 @@ footer .preview {
             }
         }
 
+        .object-layout {
+            display: flex;
+            flex-flow: row-reverse wrap;
+
+            &_small-part {
+                flex: 1 0 0;
+            }
+
+            &_big-part {
+                flex: 5 0 0;
+            }
+        }
+
         .object-help {
-            @include column(2);
-            position: absolute;
+            // switch off due to problems with help text
+             // @include column(2);
+            // position: absolute;
+            // float: right;
             right: 0;
             padding-right: $grid-gutter-width / 2;
-            float: right;
+
             opacity: 0;
             padding-left: 3em;
+
+            padding-bottom: 40px;
+
+            margin-left: 10px;
         }
 
         &.stream-field {
@@ -429,7 +448,7 @@ footer .preview {
 
         &.full {
             fieldset {
-                @include column(11);
+                // @include column(11);
                 // Override column mixin for column items.
                 display: block;
                 // Override column mixin for column items.

--- a/wagtail/admin/static_src/wagtailadmin/scss/layouts/page-editor.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/layouts/page-editor.scss
@@ -419,7 +419,7 @@ footer .preview {
 
         .object-help {
             // switch off due to problems with help text
-             // @include column(2);
+            // @include column(2);
             // position: absolute;
             // float: right;
             right: 0;

--- a/wagtail/admin/static_src/wagtailadmin/scss/layouts/page-editor.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/layouts/page-editor.scss
@@ -390,7 +390,6 @@ footer .preview {
 @include medium {
     .object {
         fieldset {
-            // @include column(10);
             // Override column mixin for column items.
             display: block;
             // Override column mixin for column items.

--- a/wagtail/admin/static_src/wagtailadmin/scss/layouts/page-editor.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/layouts/page-editor.scss
@@ -409,46 +409,28 @@ footer .preview {
             flex-flow: row-reverse wrap;
 
             &_small-part {
-                flex: 1 0 0;
+                flex: 1 0 0px;
             }
 
             &_big-part {
-                flex: 5 0 0;
+                flex: 5 0 0px;
             }
         }
 
         .object-help {
-            // switch off due to problems with help text
-            // @include column(2);
-            // position: absolute;
-            // float: right;
-            right: 0;
-            padding-right: $grid-gutter-width / 2;
-
-            opacity: 0;
-            padding-left: 3em;
-
             padding-bottom: 40px;
-
             margin-left: 10px;
+            opacity: 0;
         }
 
         &.stream-field {
             .object-help {
-                opacity: 0;
-                position: relative;
-                width: 100%;
                 padding-left: 6.4em;
-            }
-
-            &:hover .object-help {
-                opacity: 1;
             }
         }
 
         &.full {
             fieldset {
-                // @include column(11);
                 // Override column mixin for column items.
                 display: block;
                 // Override column mixin for column items.

--- a/wagtail/admin/templates/wagtailadmin/edit_handlers/object_list.html
+++ b/wagtail/admin/templates/wagtailadmin/edit_handlers/object_list.html
@@ -8,10 +8,16 @@
                     </label>
                 </h2>
             {% endif %}
-            {% if child.help_text %}
-                <div class="object-help help"><span class="icon-help-inverse" aria-hidden="true"></span>{{ child.help_text }}</div>
-            {% endif %}
-            {{ child.render_as_object }}
+            <div class="object-layout">
+                {% if child.help_text %}
+                <div class="object-layout_small-part">
+                    <div class="object-help help"><span class="icon-help-inverse" aria-hidden="true"></span>{{ child.help_text }}</div>
+                </div>
+                {% endif %}
+                <div class="object-layout_big-part">
+                    {{ child.render_as_object }}
+                </div>
+            </div>
         </li>
     {% endfor %}
 </ul>


### PR DESCRIPTION
Fix for https://github.com/wagtail/wagtail/issues/3522

* Do the tests still pass? (http://docs.wagtail.io/en/latest/contributing/developing.html#testing)
_Yes_

* Does the code comply with the style guide? (Run `make lint` from the Wagtail root)
_Yes_

* For Python changes: Have you added tests to cover the new/fixed behaviour?
_Not applicapable_ 

* For front-end changes: Did you test on all of Wagtail’s supported browsers? **Please list the exact versions you tested**.
Chrome 70
Firefox 63.0

![image](https://user-images.githubusercontent.com/893650/47604564-3775ee00-da04-11e8-874e-45895fef4ddf.png)
