### PR TITLE
Fix tests that check storage.exists on missing files

### DIFF
--- a/wagtail/documents/tests/test_admin_views.py
+++ b/wagtail/documents/tests/test_admin_views.py
@@ -305,7 +305,7 @@ class TestDocumentEditView(TestCase, WagtailTestUtils):
         Checks that reuploading the document file with the same file name
         changes the file name, to avoid browser cache issues (see #3816).
         """
-        old_file = self.document.file
+        old_filename = self.document.file.name
         new_name = self.document.filename
         new_file = SimpleUploadedFile(new_name, b'An updated test content.')
 
@@ -314,7 +314,7 @@ class TestDocumentEditView(TestCase, WagtailTestUtils):
         })
         self.assertRedirects(response, reverse('wagtaildocs:index'))
         self.document.refresh_from_db()
-        self.assertFalse(self.document.file.storage.exists(old_file.name))
+        self.assertFalse(self.document.file.storage.exists(old_filename))
         self.assertTrue(self.document.file.storage.exists(self.document.file.name))
         self.assertNotEqual(self.document.file.name, 'documents/' + new_name)
         self.assertEqual(self.document.file.read(),
@@ -325,7 +325,7 @@ class TestDocumentEditView(TestCase, WagtailTestUtils):
         Checks that reuploading the document file with a different file name
         correctly uses the new file name.
         """
-        old_file = self.document.file
+        old_filename = self.document.file.name
         new_name = 'test_reupload_different_name.txt'
         new_file = SimpleUploadedFile(new_name, b'An updated test content.')
 
@@ -334,7 +334,7 @@ class TestDocumentEditView(TestCase, WagtailTestUtils):
         })
         self.assertRedirects(response, reverse('wagtaildocs:index'))
         self.document.refresh_from_db()
-        self.assertFalse(self.document.file.storage.exists(old_file.name))
+        self.assertFalse(self.document.file.storage.exists(old_filename))
         self.assertTrue(self.document.file.storage.exists(self.document.file.name))
         self.assertEqual(self.document.file.name, 'documents/' + new_name)
         self.assertEqual(self.document.file.read(),

--- a/wagtail/documents/tests/test_models.py
+++ b/wagtail/documents/tests/test_models.py
@@ -130,10 +130,12 @@ class TestFilesDeletedForDefaultModels(TransactionTestCase):
     def test_document_file_deleted_oncommit(self):
         with transaction.atomic():
             document = get_document_model().objects.create(title="Test Image", file=get_test_image_file())
-            self.assertTrue(document.file.storage.exists(document.file.name))
+            filename = document.file.name
+
+            self.assertTrue(document.file.storage.exists(filename))
             document.delete()
-            self.assertTrue(document.file.storage.exists(document.file.name))
-        self.assertFalse(document.file.storage.exists(document.file.name))
+            self.assertTrue(document.file.storage.exists(filename))
+        self.assertFalse(document.file.storage.exists(filename))
 
 
 @override_settings(WAGTAILDOCS_DOCUMENT_MODEL='tests.CustomDocument')

--- a/wagtail/images/tests/test_signal_handlers.py
+++ b/wagtail/images/tests/test_signal_handlers.py
@@ -35,19 +35,21 @@ class TestFilesDeletedForDefaultModels(TransactionTestCase):
     def test_image_file_deleted_oncommit(self):
         with transaction.atomic():
             image = get_image_model().objects.create(title="Test Image", file=get_test_image_file())
-            self.assertTrue(image.file.storage.exists(image.file.name))
+            filename = image.file.name
+            self.assertTrue(image.file.storage.exists(filename))
             image.delete()
-            self.assertTrue(image.file.storage.exists(image.file.name))
-        self.assertFalse(image.file.storage.exists(image.file.name))
+            self.assertTrue(image.file.storage.exists(filename))
+        self.assertFalse(image.file.storage.exists(filename))
 
     def test_rendition_file_deleted_oncommit(self):
         with transaction.atomic():
             image = get_image_model().objects.create(title="Test Image", file=get_test_image_file())
             rendition = image.get_rendition('original')
-            self.assertTrue(rendition.file.storage.exists(rendition.file.name))
+            filename = rendition.file.name
+            self.assertTrue(rendition.file.storage.exists(filename))
             rendition.delete()
-            self.assertTrue(rendition.file.storage.exists(rendition.file.name))
-        self.assertFalse(rendition.file.storage.exists(rendition.file.name))
+            self.assertTrue(rendition.file.storage.exists(filename))
+        self.assertFalse(rendition.file.storage.exists(filename))
 
 
 @override_settings(WAGTAILIMAGES_IMAGE_MODEL='tests.CustomImage')


### PR DESCRIPTION
Several tests that check for the deletion of underlying files of FileField were implemented incorrectly: the filename of a FileField is cleared on deletion, so they were testing the presence of None as a filename rather than testing the filename we're interested in.

Up until https://github.com/django/django/commit/bb81c22d90e5eb168544670ead1a13aa9695fed5 , None was being cast to a string and thus the assertions were always succeeding (assuming no file named "None" existed); the removal of this cast has caused the error to surface in Django 2.2a0.