### PR TITLE
Make text 'There is one match' more translation-friendly

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/chooser/_search_results.html
+++ b/wagtail/admin/templates/wagtailadmin/chooser/_search_results.html
@@ -2,7 +2,7 @@
 
 <h2>
     {% blocktrans count counter=pages.paginator.count %}
-        There is one match
+        There is {{ counter }} match
     {% plural %}
         There are {{ counter }} matches
     {% endblocktrans %}

--- a/wagtail/admin/tests/test_page_chooser.py
+++ b/wagtail/admin/tests/test_page_chooser.py
@@ -255,7 +255,7 @@ class TestChooserSearch(TestCase, WagtailTestUtils):
         response = self.get({'q': "foobarbaz"})
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, 'wagtailadmin/chooser/_search_results.html')
-        self.assertContains(response, "There is one match")
+        self.assertContains(response, "There is 1 match")
         self.assertContains(response, "foobarbaz")
 
     def test_result_uses_custom_admin_display_title(self):
@@ -307,7 +307,7 @@ class TestChooserSearch(TestCase, WagtailTestUtils):
         response = self.get({'q': "foobarbaz", 'page_type': ''})
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, 'wagtailadmin/chooser/_search_results.html')
-        self.assertContains(response, "There is one match")
+        self.assertContains(response, "There is 1 match")
         self.assertContains(response, "foobarbaz")
 
     def test_with_multiple_page_types(self):

--- a/wagtail/contrib/redirects/templates/wagtailredirects/results.html
+++ b/wagtail/contrib/redirects/templates/wagtailredirects/results.html
@@ -3,7 +3,7 @@
     {% if query_string %}
         <h2>
         {% blocktrans count counter=redirects.paginator.count %}
-            There is one match
+            There is {{ counter }} match
         {% plural %}
             There are {{ counter }} matches
         {% endblocktrans %}

--- a/wagtail/contrib/search_promotions/templates/wagtailsearchpromotions/results.html
+++ b/wagtail/contrib/search_promotions/templates/wagtailsearchpromotions/results.html
@@ -3,7 +3,7 @@
     {% if is_searching %}
         <h2>
         {% blocktrans count counter=queries|length %}
-            There is one match
+            There is {{ counter }} match
         {% plural %}
             There are {{ counter }} matches
         {% endblocktrans %}

--- a/wagtail/documents/templates/wagtaildocs/chooser/results.html
+++ b/wagtail/documents/templates/wagtaildocs/chooser/results.html
@@ -3,7 +3,7 @@
     {% if is_searching %}
         <h2>
         {% blocktrans count counter=documents.paginator.count %}
-            There is one match
+            There is {{ counter }} match
         {% plural %}
             There are {{ counter }} matches
         {% endblocktrans %}

--- a/wagtail/documents/templates/wagtaildocs/documents/results.html
+++ b/wagtail/documents/templates/wagtaildocs/documents/results.html
@@ -3,7 +3,7 @@
     {% if is_searching %}
         <h2>
         {% blocktrans count counter=documents|length %}
-            There is one match
+            There is {{ counter }} match
         {% plural %}
             There are {{ counter }} matches
         {% endblocktrans %}

--- a/wagtail/images/templates/wagtailimages/chooser/results.html
+++ b/wagtail/images/templates/wagtailimages/chooser/results.html
@@ -4,7 +4,7 @@
     {% if is_searching %}
         <h2>
         {% blocktrans count counter=images.paginator.count %}
-            There is one match
+            There is {{ counter }} match
         {% plural %}
             There are {{ counter }} matches
         {% endblocktrans %}

--- a/wagtail/images/templates/wagtailimages/images/results.html
+++ b/wagtail/images/templates/wagtailimages/images/results.html
@@ -4,7 +4,7 @@
     {% if is_searching %}
         <h2>
         {% blocktrans count counter=images.paginator.count %}
-            There is one match
+            There is {{ counter }} match
         {% plural %}
             There are {{ counter }} matches
         {% endblocktrans %}

--- a/wagtail/snippets/templates/wagtailsnippets/chooser/results.html
+++ b/wagtail/snippets/templates/wagtailsnippets/chooser/results.html
@@ -3,7 +3,7 @@
     {% if is_searching %}
         <h2>
         {% blocktrans count counter=items.paginator.count %}
-            There is one match
+            There is {{ counter }} match
         {% plural %}
             There are {{ counter }} matches
         {% endblocktrans %}

--- a/wagtail/snippets/templates/wagtailsnippets/snippets/results.html
+++ b/wagtail/snippets/templates/wagtailsnippets/snippets/results.html
@@ -3,7 +3,7 @@
     {% if is_searching %}
         <h2>
         {% blocktrans count counter=items.paginator.count %}
-            There is one match
+            There is {{ counter }} match
         {% plural %}
             There are {{ counter }} matches
         {% endblocktrans %}

--- a/wagtail/users/templates/wagtailusers/users/results.html
+++ b/wagtail/users/templates/wagtailusers/users/results.html
@@ -3,7 +3,7 @@
     {% if is_searching %}
         <h2>
         {% blocktrans count counter=users|length %}
-            There is one match
+            There is {{ counter }} match
         {% plural %}
             There are {{ counter }} matches
         {% endblocktrans %}


### PR DESCRIPTION
For languages that have more than 2 plural forms (e.g. Belarussian) it's important for all the translation to have counter variable included. Otherwise transifex won't let translators include a variable like that to the forms that need it (e.g. we can't use counter for 2, 3 or 4 in Belarussian).

![image](https://user-images.githubusercontent.com/382950/47614061-a60d8700-daaa-11e8-8d88-d146d390cc2c.png)
![image](https://user-images.githubusercontent.com/382950/47614063-ab6ad180-daaa-11e8-8e76-9a42bc313215.png)
