### PR TITLE
Fix #4785 Wagtail Sitemaps does not allow for Django Sitemap instances

### DIFF
--- a/wagtail/contrib/sitemaps/views.py
+++ b/wagtail/contrib/sitemaps/views.py
@@ -1,3 +1,4 @@
+import inspect
 from django.contrib.sitemaps import views as sitemap_views
 
 from .sitemap_generator import Sitemap
@@ -20,7 +21,7 @@ def prepare_sitemaps(request, sitemaps):
     """Intialize the wagtail Sitemap by passing the request.site value. """
     initialised_sitemaps = {}
     for name, sitemap_cls in sitemaps.items():
-        if issubclass(sitemap_cls, Sitemap):
+        if inspect.isclass(sitemap_cls) and issubclass(sitemap_cls, Sitemap):
             initialised_sitemaps[name] = sitemap_cls(request)
         else:
             initialised_sitemaps[name] = sitemap_cls

--- a/wagtail/tests/testapp/models.py
+++ b/wagtail/tests/testapp/models.py
@@ -27,6 +27,7 @@ from wagtail.contrib.forms.forms import FormBuilder
 from wagtail.contrib.forms.models import (
     FORM_FIELD_CHOICES, AbstractEmailForm, AbstractFormField, AbstractFormSubmission)
 from wagtail.contrib.settings.models import BaseSetting, register_setting
+from wagtail.contrib.sitemaps import Sitemap
 from wagtail.contrib.table_block.blocks import TableBlock
 from wagtail.core.blocks import CharBlock, RichTextBlock, StructBlock
 from wagtail.core.fields import RichTextField, StreamField
@@ -362,6 +363,11 @@ class SingleEventPage(EventPage):
 
 
 SingleEventPage.content_panels = [FieldPanel('excerpt')] + EventPage.content_panels
+
+
+# "custom" sitemap object
+class EventSitemap(Sitemap):
+    pass
 
 
 # Event index (has a separate AJAX template, and a custom template context)

--- a/wagtail/tests/urls.py
+++ b/wagtail/tests/urls.py
@@ -12,6 +12,7 @@ from wagtail.images import urls as wagtailimages_urls
 from wagtail.images.api.v2.endpoints import ImagesAPIEndpoint
 from wagtail.images.tests import urls as wagtailimages_test_urls
 from wagtail.tests.testapp import urls as testapp_urls
+from wagtail.tests.testapp.models import EventSitemap
 
 api_router = WagtailAPIRouter('wagtailapi_v2')
 api_router.register_endpoint('pages', PagesAPIEndpoint)
@@ -29,7 +30,7 @@ urlpatterns = [
     url(r'^sitemap\.xml$', sitemaps_views.sitemap),
 
     url(r'^sitemap-index\.xml$', sitemaps_views.index, {
-        'sitemaps': {'pages': Sitemap},
+        'sitemaps': {'pages': Sitemap, 'events': EventSitemap(request=None)},
         'sitemap_url_name': 'sitemap',
     }),
     url(r'^sitemap-(?P<section>.+)\.xml$', sitemaps_views.sitemap, name='sitemap'),


### PR DESCRIPTION
Fixes #4785

* Do the tests still pass? ✅
* Does the code comply with the style guide? ✅
* For Python changes: Have you added tests to cover the new/fixed behaviour? ✅
* For front-end changes: Did you test on all of Wagtail’s supported browsers? N/A
* For new features: Has the documentation been updated accordingly? N/A
