### PR TITLE
Fix StreamField full-width layout, UI regression from #4855

### DIFF
--- a/wagtail/admin/static_src/wagtailadmin/scss/layouts/page-editor.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/layouts/page-editor.scss
@@ -207,7 +207,7 @@ $object-title-height: 40px;
         }
 
         // Undo column widths usually applied to the contents of a field panel
-        > fieldset {
+        .object-layout_big-part > fieldset {
             width: 100%;
             max-width: none;
         }


### PR DESCRIPTION
Spotted by @jjanssen in https://github.com/wagtail/wagtail/pull/4855#issuecomment-433689296: 

> A regression occurred when this PR got merged which reflects to the streamfields.

> We used to render the streamfield on full-width:
![image](https://user-images.githubusercontent.com/287422/47614179-9a22c480-daac-11e8-801c-0b55883bb2e3.png)

> Now it renders collapsed:
![image](https://user-images.githubusercontent.com/287422/47614183-ab6bd100-daac-11e8-9cc0-a58c644b13b3.png)

---

This was due to the `> fieldset` selector, which relies on the structure of the HTML, which changed in #4855. I had seen the faulty UI but didn't realise it wasn't meant to look like that.

Tested in IE11, Edge17, Chrome, Firefox, iOS11