### PR TITLE
[4087] Revamp the image editing page as far as possible

### DIFF
--- a/wagtail/admin/static_src/wagtailadmin/scss/_utilities.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/_utilities.scss
@@ -1,0 +1,1 @@
+@import 'wagtailadmin/scss/utilities/text';

--- a/wagtail/admin/static_src/wagtailadmin/scss/components/_forms.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/components/_forms.scss
@@ -1165,14 +1165,6 @@ select {
     @include transition(background-color 0.2s ease);
 }
 
-input[type=submit],
-input[type=reset],
-input[type=button],
-.button,
-button {
-    // @include transition(background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease);
-}
-
 .help {
     @include transition(opacity 0.2s ease);
 }

--- a/wagtail/admin/static_src/wagtailadmin/scss/components/_forms.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/components/_forms.scss
@@ -1169,6 +1169,12 @@ select {
     @include transition(opacity 0.2s ease);
 }
 
+.label-uppercase {
+    .field > label {
+        text-transform: uppercase;
+    }
+}
+
 @include media-breakpoint-up(sm) {
     label {
         @include column(2);
@@ -1240,12 +1246,6 @@ select {
             padding: 0 0 0.8em;
             float: none;
             width: auto;
-        }
-    }
-
-    .label-uppercase {
-        .field > label {
-            text-transform: uppercase;
         }
     }
 }

--- a/wagtail/admin/static_src/wagtailadmin/scss/components/_forms.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/components/_forms.scss
@@ -1250,4 +1250,10 @@ button {
             width: auto;
         }
     }
+
+    .label-uppercase {
+        .field > label {
+            text-transform: uppercase;
+        }
+    }
 }

--- a/wagtail/admin/static_src/wagtailadmin/scss/core.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/core.scss
@@ -19,6 +19,8 @@
 @import 'wagtailadmin/scss/components/tooltips';
 @import 'wagtailadmin/scss/components/logo';
 
+@import 'wagtailadmin/scss/utilities';
+
 @import 'wagtailadmin/scss/fonts';
 
 @import '../../../../../client/scss/styles';

--- a/wagtail/admin/static_src/wagtailadmin/scss/utilities/_text.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/utilities/_text.scss
@@ -1,0 +1,7 @@
+.u-text-transform-uppercase {
+    text-transform: uppercase;
+}
+
+.u-text-weight-normal {
+    font-weight: normal;
+}

--- a/wagtail/images/static_src/wagtailimages/scss/focal-point-chooser.scss
+++ b/wagtail/images/static_src/wagtailimages/scss/focal-point-chooser.scss
@@ -3,6 +3,7 @@
 
 .focal-point-chooser {
     position: relative;
+    margin-bottom: 20px;
 
     .current-focal-point-indicator {
         @include transition(opacity 0.2s ease);

--- a/wagtail/images/templates/wagtailimages/images/edit.html
+++ b/wagtail/images/templates/wagtailimages/images/edit.html
@@ -46,7 +46,7 @@
                         {% endif %}
                     {% endfor %}
                 </ul>
-                <div class="u-hidden@small">
+                <div class="u-hidden@xs">
                     <input type="submit" value="{% trans 'Save' %}" class="button" />
                     {% if user_can_delete %}
                         <a href="{% url 'wagtailimages:delete' image.id %}" class="button button-secondary no">{% trans "Delete image" %}</a>
@@ -102,7 +102,7 @@
             </div>
         </div>
 
-        <div class="row row-flush nice-padding u-hidden@medium">
+        <div class="row row-flush nice-padding u-hidden@sm">
             <div class="col5">
                 <input type="submit" value="{% trans 'Save' %}" class="button" />
                 {% if user_can_delete %}

--- a/wagtail/images/templates/wagtailimages/images/edit.html
+++ b/wagtail/images/templates/wagtailimages/images/edit.html
@@ -33,29 +33,28 @@
 
     <form action="{% url 'wagtailimages:edit' image.id %}" method="POST" enctype="multipart/form-data" novalidate>
         {% csrf_token %}
-
         <div class="row row-flush nice-padding">
-
-            <div class="col5">
+            <div class="col6">
                 <ul class="fields">
                     {% for field in form %}
-
                         {% if field.name == 'file' %}
-                            {% include "wagtailimages/images/_file_field_as_li.html" %}
+                            {% include "wagtailimages/images/_file_field_as_li.html" with li_classes="label-above label-uppercase" %}
                         {% elif field.is_hidden %}
                             {{ field }}
                         {% else %}
-                            {% include "wagtailadmin/shared/field_as_li.html" %}
+                            {% include "wagtailadmin/shared/field_as_li.html" with li_classes="label-above label-uppercase" %}
                         {% endif %}
-
                     {% endfor %}
                 </ul>
+                <div class="u-hidden@small">
+                    <input type="submit" value="{% trans 'Save' %}" class="button" />
+                    {% if user_can_delete %}
+                        <a href="{% url 'wagtailimages:delete' image.id %}" class="button button-secondary no">{% trans "Delete image" %}</a>
+                    {% endif %}
+                </div>
             </div>
 
-            <div class="col5 divider-after">
-                <h2 class="label">{% trans "Focal point (optional)" %}</h2>
-                <p>{% trans "To define this image's most important region, drag a box over the image below." %} {% if image.focal_point %}({% trans "Current focal point shown" %}){% endif %}</p>
-
+            <div class="col6">
                 {% image image max-800x600 as rendition %}
 
                 <div class="focal-point-chooser"
@@ -66,40 +65,44 @@
                     data-focal-point-height="{{ image.focal_point_height }}">
 
                     <img {{ rendition.attrs }} data-original-width="{{ image.width|unlocalize }}" data-original-height="{{ image.height|unlocalize }}" class="show-transparency">
-
                     <div class="current-focal-point-indicator{% if not image.has_focal_point %} hidden{% endif %}"></div>
-
                 </div>
-                <br />
-                <button class="button button-secondary no remove-focal-point" type="button">{% trans "Remove focal area" %}</button>
-            </div>
 
-            <div class="col2 ">
                 {% if url_generator_enabled %}
                     <a href="{% url 'wagtailimages:url_generator' image.id %}" class="button bicolor icon icon-link">{% trans "URL Generator" %}</a>
                     <hr />
                 {% endif %}
 
-                {% image image original as original_image %}
+                <div class="row">
+                    <div class="col8 divider-after">
+                        <h2 class="label u-text-transform-uppercase">{% trans "Focal point" %} <span class="u-text-weight-normal">{% trans "(optional)" %}</span></h2>
+                        <p>{% trans "To define this image's most important region, drag a box over the image above." %} {% if image.focal_point %}({% trans "Current focal point shown" %}){% endif %}</p>
 
-                <dl>
-                    <dt>{% trans "Max dimensions" %}</dt>
-                    <dd>{{ original_image.width }}x{{ original_image.height }}</dd>
-                    <dt>{% trans "Filesize" %}</dt>
-                    <dd>{% if filesize %}{{ filesize|filesizeformat }}{% else %}{% trans "File not found" %}{% endif %}</dd>
+                        <button class="button button-secondary no remove-focal-point" type="button">{% trans "Remove focal area" %}</button>
+                    </div>
+                    <div class="col4">
+                        {% image image original as original_image %}
 
-                    {% usage_count_enabled as uc_enabled %}
-                    {% if uc_enabled %}
-                        <dt>{% trans "Usage" %}</dt>
-                        <dd>
-                            <a href="{{ image.usage_url }}">{% blocktrans count usage_count=image.get_usage.count %}Used {{ usage_count }} time{% plural %}Used {{ usage_count }} times{% endblocktrans %}</a>
-                        </dd>
-                    {% endif %}
-                </dl>
+                        <dl>
+                            <dt>{% trans "Max dimensions" %}</dt>
+                            <dd>{{ original_image.width }}x{{ original_image.height }}</dd>
+                            <dt>{% trans "Filesize" %}</dt>
+                            <dd>{% if filesize %}{{ filesize|filesizeformat }}{% else %}{% trans "File not found" %}{% endif %}</dd>
+
+                            {% usage_count_enabled as uc_enabled %}
+                            {% if uc_enabled %}
+                                <dt>{% trans "Usage" %}</dt>
+                                <dd>
+                                    <a href="{{ image.usage_url }}">{% blocktrans count usage_count=image.get_usage.count %}Used {{ usage_count }} time{% plural %}Used {{ usage_count }} times{% endblocktrans %}</a>
+                                </dd>
+                            {% endif %}
+                        </dl>
+                    </div>
+                </div>
             </div>
         </div>
 
-        <div class="row row-flush nice-padding">
+        <div class="row row-flush nice-padding u-hidden@medium">
             <div class="col5">
                 <input type="submit" value="{% trans 'Save' %}" class="button" />
                 {% if user_can_delete %}
@@ -107,6 +110,5 @@
                 {% endif %}
             </div>
         </div>
-
     </form>
 {% endblock %}


### PR DESCRIPTION
Based upon the design from #4087 

**Some remarks upfront:**
- I did not change the header as it would feel weird having a different mark-up on this page. I think would be better if we would pick this up in header redesign ticket;
- I did not change the file field or the order difference between title and file, because this has a separate design proposal as defined in #4055 and it would make this change bigger than editing an image alone.

**The code changes**
- Added an additional `label-uppercase` and `label-uppercase` due to the way `field_as_li.html` is defined right now throughout the application and not change everything at once.
- Added additional utilities for global usage. Although I'm not sure whether to continue this in `admin` or within `client`.

**So what did it turn out to be?**
Without the URL generator
![image](https://user-images.githubusercontent.com/287422/47616617-75d8df00-dad0-11e8-8bc6-c1b58587c8b0.png)

With the URL generator
![image](https://user-images.githubusercontent.com/287422/47616594-46c26d80-dad0-11e8-9892-5f949be06bae.png)

On tablet (1024px)
![image](https://user-images.githubusercontent.com/287422/47616719-a79e7580-dad1-11e8-88b5-775166468682.png)

On mobile (320px)
![image](https://user-images.githubusercontent.com/287422/47616655-f0a1fa00-dad0-11e8-8f2a-9ff2ddcd420d.png)
![image](https://user-images.githubusercontent.com/287422/47616712-8fc6f180-dad1-11e8-9c44-b2f65f89636f.png)







