### PR TITLE
First positional argument for tox as test module/case path

### DIFF
--- a/docs/contributing/developing.rst
+++ b/docs/contributing/developing.rst
@@ -68,18 +68,29 @@ From the root of the Wagtail codebase, run the following command to run all the 
 
 At the time of writing, Wagtail has well over 2500 tests, which takes a while to
 run. You can run tests for only one part of Wagtail by passing in the path as
-an argument to ``runtests.py``:
+an argument to ``runtests.py`` or ``tox``:
 
 .. code-block:: console
 
+    $ # Running in the current environment
     $ python runtests.py wagtail.core
+
+    $ # Running in a specified Tox environment
+    $ tox -e py36-dj20-sqlite-noelasticsearch wagtail.core
+
+    $ # See a list of available Tox environments
+    $ tox -l
 
 You can also run tests for individual TestCases by passing in the path as
 an argument to ``runtests.py``
 
 .. code-block:: console
 
+    $ # Running in the current environment
     $ python runtests.py wagtail.core.tests.test_blocks.TestIntegerBlock
+
+    $ # Running in a specified Tox environment
+    $ tox -e py36-dj20-sqlite-noelasticsearch wagtail.core.tests.test_blocks.TestIntegerBlock
 
 **Running migrations for the test app models**
 

--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,7 @@ commands =
     elasticsearch2: coverage run runtests.py wagtail.search wagtail.documents wagtail.images --elasticsearch2
     elasticsearch5: coverage run runtests.py wagtail.search wagtail.documents wagtail.images --elasticsearch5
     elasticsearch6: coverage run runtests.py wagtail.search wagtail.documents wagtail.images --elasticsearch6
-    noelasticsearch: coverage run runtests.py
+    noelasticsearch: coverage run runtests.py {posargs}
 
 basepython =
     py34: python3.4


### PR DESCRIPTION
After playing a bit of the old "push and wait for Travis" game, I decided that adding this pattern would help me to quickly bootstrap a test environment in a familiar way.

Is it okay to add?