### PR TITLE
Collection display ordering

### DIFF
--- a/wagtail/admin/tests/test_collections_views.py
+++ b/wagtail/admin/tests/test_collections_views.py
@@ -1,7 +1,7 @@
 from django.test import TestCase
 from django.urls import reverse
 
-from wagtail.core.models import Collection, get_root_collection_id
+from wagtail.core.models import Collection
 from wagtail.documents.models import Document
 from wagtail.tests.utils import WagtailTestUtils
 
@@ -38,10 +38,9 @@ class TestCollectionsIndexView(TestCase, WagtailTestUtils):
         root_collection.add_child(name="Bread")
         root_collection.add_child(name="Avacado")
         response = self.get()
-        self.assertQuerysetEqual(
-            response.context['object_list'],
-            Collection.objects.for_display().exclude(id=get_root_collection_id()),
-            transform=lambda x: x)
+        self.assertEqual(
+            [collection.name for collection in response.context['object_list']],
+            ['Avacado', 'Bread', 'Milk'])
 
 
 class TestAddCollection(TestCase, WagtailTestUtils):

--- a/wagtail/admin/tests/test_collections_views.py
+++ b/wagtail/admin/tests/test_collections_views.py
@@ -1,7 +1,7 @@
 from django.test import TestCase
 from django.urls import reverse
 
-from wagtail.core.models import Collection
+from wagtail.core.models import Collection, get_root_collection_id
 from wagtail.documents.models import Document
 from wagtail.tests.utils import WagtailTestUtils
 
@@ -31,6 +31,17 @@ class TestCollectionsIndexView(TestCase, WagtailTestUtils):
         self.assertTemplateUsed(response, 'wagtailadmin/collections/index.html')
         self.assertNotContains(response, "No collections have been created.")
         self.assertContains(response, "Holiday snaps")
+
+    def test_ordering(self):
+        root_collection = Collection.get_first_root_node()
+        root_collection.add_child(name="Milk")
+        root_collection.add_child(name="Bread")
+        root_collection.add_child(name="Avacado")
+        response = self.get()
+        self.assertQuerysetEqual(
+            response.context['object_list'],
+            Collection.objects.for_display().exclude(id=get_root_collection_id()),
+            transform=lambda x: x)
 
 
 class TestAddCollection(TestCase, WagtailTestUtils):

--- a/wagtail/admin/views/collections.py
+++ b/wagtail/admin/views/collections.py
@@ -22,7 +22,7 @@ class Index(IndexView):
 
     def get_queryset(self):
         # Only return children of the root node, so that the root is not editable
-        return Collection.get_first_root_node().get_children()
+        return Collection.get_first_root_node().get_children().order_by('name')
 
 
 class Create(CreateView):
@@ -59,7 +59,7 @@ class Edit(EditView):
 
     def get_queryset(self):
         # Only return children of the root node, so that the root is not editable
-        return Collection.get_first_root_node().get_children()
+        return Collection.get_first_root_node().get_children().order_by('name')
 
 
 class Delete(DeleteView):
@@ -74,7 +74,7 @@ class Delete(DeleteView):
 
     def get_queryset(self):
         # Only return children of the root node, so that the root is not editable
-        return Collection.get_first_root_node().get_children()
+        return Collection.get_first_root_node().get_children().order_by('name')
 
     def get_collection_contents(self):
         collection_contents = [

--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -1943,14 +1943,6 @@ class BaseCollectionManager(models.Manager):
     def get_queryset(self):
         return TreeQuerySet(self.model).order_by('path')
 
-    def for_display(self):
-        # This will output the Root collection first, and alphabetize the rest
-        return TreeQuerySet(self.model).annotate(
-            display_order=Case(
-                When(id=get_root_collection_id(), then=Value('-1')),
-                default='name')
-        ).order_by('display_order')
-
 
 CollectionManager = BaseCollectionManager.from_queryset(TreeQuerySet)
 
@@ -1999,6 +1991,14 @@ class Collection(MP_Node):
     def get_view_restrictions(self):
         """Return a query set of all collection view restrictions that apply to this collection"""
         return CollectionViewRestriction.objects.filter(collection__in=self.get_ancestors(inclusive=True))
+
+    @staticmethod
+    def order_for_display(queryset):
+        return queryset.annotate(
+            display_order=Case(
+                When(depth=1, then=Value('')),
+                default='name')
+        ).order_by('display_order')
 
     class Meta:
         verbose_name = _('collection')

--- a/wagtail/core/permission_policies/collections.py
+++ b/wagtail/core/permission_policies/collections.py
@@ -67,7 +67,7 @@ class CollectionPermissionLookupMixin:
             for path in collection_root_paths[1:]:
                 collection_path_filter = collection_path_filter | Q(path__startswith=path)
 
-            return Collection.objects.for_display().filter(collection_path_filter)
+            return Collection.objects.all().filter(collection_path_filter)
         else:
             # no matching collections
             return Collection.objects.none()
@@ -187,7 +187,7 @@ class CollectionPermissionPolicy(CollectionPermissionLookupMixin, BaseDjangoAuth
         if user.is_active and user.is_superuser:
             # active superusers can perform any action (including unrecognised ones)
             # in any collection
-            return Collection.objects.for_display()
+            return Collection.objects.all()
 
         elif not user.is_authenticated:
             return Collection.objects.none()
@@ -328,7 +328,7 @@ class CollectionOwnershipPermissionPolicy(
         if user.is_active and user.is_superuser:
             # active superusers can perform any action (including unrecognised ones)
             # in any collection
-            return Collection.objects.for_display()
+            return Collection.objects.all()
 
         elif not user.is_authenticated:
             return Collection.objects.none()

--- a/wagtail/core/permission_policies/collections.py
+++ b/wagtail/core/permission_policies/collections.py
@@ -67,7 +67,7 @@ class CollectionPermissionLookupMixin:
             for path in collection_root_paths[1:]:
                 collection_path_filter = collection_path_filter | Q(path__startswith=path)
 
-            return Collection.objects.filter(collection_path_filter)
+            return Collection.objects.for_display().filter(collection_path_filter)
         else:
             # no matching collections
             return Collection.objects.none()
@@ -187,7 +187,7 @@ class CollectionPermissionPolicy(CollectionPermissionLookupMixin, BaseDjangoAuth
         if user.is_active and user.is_superuser:
             # active superusers can perform any action (including unrecognised ones)
             # in any collection
-            return Collection.objects.all()
+            return Collection.objects.for_display()
 
         elif not user.is_authenticated:
             return Collection.objects.none()
@@ -328,7 +328,7 @@ class CollectionOwnershipPermissionPolicy(
         if user.is_active and user.is_superuser:
             # active superusers can perform any action (including unrecognised ones)
             # in any collection
-            return Collection.objects.all()
+            return Collection.objects.for_display()
 
         elif not user.is_authenticated:
             return Collection.objects.none()

--- a/wagtail/documents/tests/test_admin_views.py
+++ b/wagtail/documents/tests/test_admin_views.py
@@ -95,10 +95,9 @@ class TestDocumentIndexView(TestCase, WagtailTestUtils):
         response = self.client.get(reverse('wagtaildocs:index'))
         self.assertContains(response, '<th>Collection</th>')
         self.assertContains(response, '<td>Root</td>')
-        self.assertQuerysetEqual(
-            response.context['collections'],
-            Collection.objects.for_display(),
-            transform=lambda x: x)
+        self.assertEqual(
+            [collection.name for collection in response.context['collections']],
+            ['Root', 'Evil plans', 'Good plans'])
 
 
 class TestDocumentAddView(TestCase, WagtailTestUtils):

--- a/wagtail/documents/tests/test_admin_views.py
+++ b/wagtail/documents/tests/test_admin_views.py
@@ -88,12 +88,17 @@ class TestDocumentIndexView(TestCase, WagtailTestUtils):
     def test_index_with_collection(self):
         root_collection = Collection.get_first_root_node()
         root_collection.add_child(name="Evil plans")
+        root_collection.add_child(name="Good plans")
 
         self.make_docs()
 
         response = self.client.get(reverse('wagtaildocs:index'))
         self.assertContains(response, '<th>Collection</th>')
         self.assertContains(response, '<td>Root</td>')
+        self.assertQuerysetEqual(
+            response.context['collections'],
+            Collection.objects.for_display(),
+            transform=lambda x: x)
 
 
 class TestDocumentAddView(TestCase, WagtailTestUtils):

--- a/wagtail/documents/views/chooser.py
+++ b/wagtail/documents/views/chooser.py
@@ -88,7 +88,7 @@ def chooser(request):
     else:
         searchform = SearchForm()
 
-        collections = Collection.objects.all()
+        collections = Collection.objects.for_display()
         if len(collections) < 2:
             collections = None
 

--- a/wagtail/documents/views/chooser.py
+++ b/wagtail/documents/views/chooser.py
@@ -88,9 +88,11 @@ def chooser(request):
     else:
         searchform = SearchForm()
 
-        collections = Collection.objects.for_display()
+        collections = Collection.objects.all()
         if len(collections) < 2:
             collections = None
+        else:
+            collections = Collection.order_for_display(collections)
 
         documents = documents.order_by('-created_at')
         documents_exist = documents.exists()

--- a/wagtail/documents/views/documents.py
+++ b/wagtail/documents/views/documents.py
@@ -63,6 +63,8 @@ def index(request):
     )
     if len(collections) < 2:
         collections = None
+    else:
+        collections = Collection.order_for_display(collections)
 
     # Create response
     if request.is_ajax():

--- a/wagtail/documents/views/multiple.py
+++ b/wagtail/documents/views/multiple.py
@@ -7,6 +7,7 @@ from django.views.decorators.http import require_POST
 from django.views.decorators.vary import vary_on_headers
 
 from wagtail.admin.utils import PermissionPolicyChecker
+from wagtail.core.models import Collection
 from wagtail.search.backends import get_search_backends
 
 from ..forms import get_document_form, get_document_multi_form
@@ -25,7 +26,7 @@ def add(request):
 
     collections = permission_policy.collections_user_has_permission_for(request.user, 'add')
     if len(collections) > 1:
-        collections_to_choose = collections
+        collections_to_choose = Collection.order_for_display(collections)
     else:
         # no need to show a collections chooser
         collections_to_choose = None

--- a/wagtail/images/tests/test_admin_views.py
+++ b/wagtail/images/tests/test_admin_views.py
@@ -75,6 +75,17 @@ class TestImageIndexView(TestCase, WagtailTestUtils):
             response = self.get({'ordering': ordering})
             self.assertEqual(response.status_code, 200)
 
+    def test_collection_order(self):
+        root_collection = Collection.get_first_root_node()
+        root_collection.add_child(name="Evil plans")
+        root_collection.add_child(name="Good plans")
+
+        response = self.get()
+        self.assertQuerysetEqual(
+            response.context['collections'],
+            Collection.objects.for_display(),
+            transform=lambda x: x)
+
 
 class TestImageAddView(TestCase, WagtailTestUtils):
     def setUp(self):

--- a/wagtail/images/tests/test_admin_views.py
+++ b/wagtail/images/tests/test_admin_views.py
@@ -81,10 +81,9 @@ class TestImageIndexView(TestCase, WagtailTestUtils):
         root_collection.add_child(name="Good plans")
 
         response = self.get()
-        self.assertQuerysetEqual(
-            response.context['collections'],
-            Collection.objects.for_display(),
-            transform=lambda x: x)
+        self.assertEqual(
+            [collection.name for collection in response.context['collections']],
+            ['Root', 'Evil plans', 'Good plans'])
 
 
 class TestImageAddView(TestCase, WagtailTestUtils):

--- a/wagtail/images/views/chooser.py
+++ b/wagtail/images/views/chooser.py
@@ -49,9 +49,11 @@ def get_image_result_data(image):
 def get_chooser_context(request):
     """Helper function to return common template context variables for the main chooser view"""
 
-    collections = Collection.objects.for_display()
+    collections = Collection.objects.all()
     if len(collections) < 2:
         collections = None
+    else:
+        collections = Collection.order_for_display(collections)
 
     return {
         'searchform': SearchForm(),

--- a/wagtail/images/views/chooser.py
+++ b/wagtail/images/views/chooser.py
@@ -49,7 +49,7 @@ def get_image_result_data(image):
 def get_chooser_context(request):
     """Helper function to return common template context variables for the main chooser view"""
 
-    collections = Collection.objects.all()
+    collections = Collection.objects.for_display()
     if len(collections) < 2:
         collections = None
 

--- a/wagtail/images/views/images.py
+++ b/wagtail/images/views/images.py
@@ -61,6 +61,8 @@ def index(request):
     )
     if len(collections) < 2:
         collections = None
+    else:
+        collections = Collection.order_for_display(collections)
 
     # Create response
     if request.is_ajax():

--- a/wagtail/images/views/multiple.py
+++ b/wagtail/images/views/multiple.py
@@ -7,6 +7,7 @@ from django.views.decorators.http import require_POST
 from django.views.decorators.vary import vary_on_headers
 
 from wagtail.admin.utils import PermissionPolicyChecker
+from wagtail.core.models import Collection
 from wagtail.images import get_image_model
 from wagtail.images.fields import ALLOWED_EXTENSIONS
 from wagtail.images.forms import get_image_form
@@ -42,7 +43,7 @@ def add(request):
 
     collections = permission_policy.collections_user_has_permission_for(request.user, 'add')
     if len(collections) > 1:
-        collections_to_choose = collections
+        collections_to_choose = Collection.order_for_display(collections)
     else:
         # no need to show a collections chooser
         collections_to_choose = None


### PR DESCRIPTION
We had a client with 100+ collections for images and because the drop down is ordered by the treebeard path by default they were finding it hard to find the collection they needed.

This solution alphabetizes the relevant `Collection` queryset wherever it's used by the admin templates but still puts the Root collection at the top of the list.