### PR TITLE
Cache image renditions

### DIFF
--- a/docs/advanced_topics/performance.rst
+++ b/docs/advanced_topics/performance.rst
@@ -30,6 +30,28 @@ We recommend `Redis <https://redis.io/>`_ as a fast, persistent cache. Install R
     }
 
 
+Caching image renditions
+------------------------
+
+If you define a cache named 'renditions' (typically alongside your 'default' cache), 
+Wagtail will cache image rendition lookups, which may improve the performance of pages 
+which include many images.
+
+.. code-block:: python
+
+    CACHES = {
+        'default': {...},
+        'renditions': {
+            'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
+            'LOCATION': '127.0.0.1:11211',
+            'TIMEOUT': 600,
+            'OPTIONS': {
+                'MAX_ENTRIES': 1000
+            }
+        }
+    }
+
+
 Search
 ------
 


### PR DESCRIPTION
This small change removes one common cause of N+1 queries, by returning image rendition lookups from a cache rather than the database. Rendition caching has to be explicitly enabled, by defining a new item in `settings.CACHES` called 'renditions'.

* Do the tests still pass? Yes
* Does the code comply with the style guide? Yes
* For Python changes: Have you added tests to cover the new/fixed behaviour? No
* For front-end changes: Did you test on all of Wagtail’s supported browsers? N/A
* For new features: Has the documentation been updated accordingly? Yes
