### PR TITLE
Allow pages to have stopword-only slugs

### DIFF
--- a/wagtail/admin/static_src/wagtailadmin/js/page-editor.js
+++ b/wagtail/admin/static_src/wagtailadmin/js/page-editor.js
@@ -411,3 +411,5 @@ $(function() {
         });
     });
 });
+
+module.exports.cleanForSlug = cleanForSlug;

--- a/wagtail/admin/static_src/wagtailadmin/js/page-editor.js
+++ b/wagtail/admin/static_src/wagtailadmin/js/page-editor.js
@@ -241,14 +241,18 @@ function cleanForSlug(val, useURLify) {
     if (useURLify) {
         // URLify performs extra processing on the string (e.g. removing stopwords) and is more suitable
         // for creating a slug from the title, rather than sanitising a slug entered manually
-        return URLify(val, 255, unicodeSlugsEnabled);
-    } else {
-        // just do the "replace"
-        if (unicodeSlugsEnabled) {
-            return val.replace(/\s/g, '-').replace(/[&\/\\#,+()$~%.'":`@\^!*?<>{}]/g, '').toLowerCase();
-        } else {
-            return val.replace(/\s/g, '-').replace(/[^A-Za-z0-9\-\_]/g, '').toLowerCase();
+        let cleaned = URLify(val, 255, unicodeSlugsEnabled);
+
+        if (cleaned) {
+            return cleaned;
         }
+    }
+
+    // just do the "replace"
+    if (unicodeSlugsEnabled) {
+        return val.replace(/\s/g, '-').replace(/[&\/\\#,+()$~%.'":`@\^!*?<>{}]/g, '').toLowerCase();
+    } else {
+        return val.replace(/\s/g, '-').replace(/[^A-Za-z0-9\-\_]/g, '').toLowerCase();
     }
 }
 

--- a/wagtail/admin/static_src/wagtailadmin/js/page-editor.js
+++ b/wagtail/admin/static_src/wagtailadmin/js/page-editor.js
@@ -243,6 +243,8 @@ function cleanForSlug(val, useURLify) {
         // for creating a slug from the title, rather than sanitising a slug entered manually
         let cleaned = URLify(val, 255, unicodeSlugsEnabled);
 
+        // if the result is blank (e.g. because the title consisted entirely of stopwords),
+        // fall through to the non-URLify method
         if (cleaned) {
             return cleaned;
         }

--- a/wagtail/admin/static_src/wagtailadmin/js/page-editor.test.js
+++ b/wagtail/admin/static_src/wagtailadmin/js/page-editor.test.js
@@ -1,0 +1,32 @@
+window.$ = require('./vendor/jquery-3.2.1.min');
+require('./vendor/urlify').default;
+
+const cleanForSlug = require('./page-editor').cleanForSlug;
+
+describe('page-editor tests', () => {
+  describe('cleanForSlug without unicode slugs enabled', () => {
+    beforeEach(() => {
+      window.unicodeSlugsEnabled = false;
+    });
+
+    it('should return a correct slug which is escaped by urlify', () => {
+      /* true triggers to use django's urlify */
+      expect(cleanForSlug('Before', true)).toBe('before');
+      expect(cleanForSlug('The', true)).toBe('the');
+      expect(cleanForSlug('Before the sun rises', true)).toBe('before-the-sun-rises');
+      expect(cleanForSlug('ON', true)).toBe('on');
+      expect(cleanForSlug('ON this day in november', true)).toBe('on-this-day-in-november');
+      expect(cleanForSlug('This & That', true)).toBe('this--that');
+    });
+
+    it('should return a correct slug which is escaped by urlify', () => {
+      /* false triggers ignores django's urlify */
+      expect(cleanForSlug('Before', false)).toBe('before');
+      expect(cleanForSlug('The', false)).toBe('the');
+      expect(cleanForSlug('Before the sun rises', false)).toBe('before-the-sun-rises');
+      expect(cleanForSlug('ON', false)).toBe('on');
+      expect(cleanForSlug('ON this day in november', false)).toBe('on-this-day-in-november');
+      expect(cleanForSlug('This & That', false)).toBe('this--that');
+    });
+  });
+});

--- a/wagtail/admin/static_src/wagtailadmin/js/page-editor.test.js
+++ b/wagtail/admin/static_src/wagtailadmin/js/page-editor.test.js
@@ -13,9 +13,9 @@ describe('page-editor tests', () => {
       /* true triggers to use django's urlify */
       expect(cleanForSlug('Before', true)).toBe('before');
       expect(cleanForSlug('The', true)).toBe('the');
-      expect(cleanForSlug('Before the sun rises', true)).toBe('before-the-sun-rises');
+      expect(cleanForSlug('Before the sun rises', true)).toBe('sun-rises');
       expect(cleanForSlug('ON', true)).toBe('on');
-      expect(cleanForSlug('ON this day in november', true)).toBe('on-this-day-in-november');
+      expect(cleanForSlug('ON this day in november', true)).toBe('day-november');
       expect(cleanForSlug('This & That', true)).toBe('this--that');
     });
 


### PR DESCRIPTION
This change modifies the [`cleanForSlug`](https://github.com/wagtail/wagtail/blob/b34b547c6abe441429d019289dc542ac76930015/wagtail/admin/static_src/wagtailadmin/js/page-editor.js#L240) function used when creating a page's slug from its title. The current behavior uses the Django [`URLify`](https://github.com/wagtail/wagtail/blob/b34b547c6abe441429d019289dc542ac76930015/wagtail/admin/static_src/wagtailadmin/js/vendor/urlify.js#L152) function, which removes stopwords like "before". If a page title consists only of such stopwords, the generated slug will be blank, thus confusingly preventing page save.

This change handles this case by falling back to an alternate slug generation approach that allows the stopwords to be used.

This does unfortunately introduce some potentially inconsistent behavior; for example, a page titled "Before me" will be given a slug of "me" and a page titled "Before" will be given a slug of "before".
(Honestly, the inclusion of "before" as a stopword is somewhat unexpected.)

Fixes #4881.

(I took a look at adding some JS unit tests for this change, but it wasn't obvious the best way to do so, given how this function is defined. I'd be happy to add tests given a pointer to a good approach.)