### PR TITLE
Fixed tabbed streamfield error reporting

### DIFF
--- a/wagtail/admin/static_src/wagtailadmin/js/page-editor.js
+++ b/wagtail/admin/static_src/wagtailadmin/js/page-editor.js
@@ -281,7 +281,7 @@ function initErrorDetection() {
     var errorSections = {};
 
     // first count up all the errors
-    $('.error-message').each(function() {
+    $('.error-message, .help-critical').each(function() {
         var parentSection = $(this).closest('section');
 
         if (!errorSections[parentSection.attr('id')]) {


### PR DESCRIPTION
This fixes an issue where streamfields nested in tabs might raise validation errors that are not indicated in the tab error counts. In the case of a heavily tabbed, large admin page, this leads to a lot of user (and dev) confusion.

Re: #4122 
