### PR TITLE
Make documentation links on welcome page work for prereleases

### DIFF
--- a/wagtail/core/templatetags/wagtailcore_tags.py
+++ b/wagtail/core/templatetags/wagtailcore_tags.py
@@ -3,9 +3,10 @@ from django.template.defaulttags import token_kwargs
 from django.utils.encoding import force_text
 from django.utils.safestring import mark_safe
 
-from wagtail import __version__
+from wagtail import VERSION, __version__
 from wagtail.core.models import Page
 from wagtail.core.rich_text import RichText, expand_db_html
+from wagtail.utils.version import get_main_version
 
 register = template.Library()
 
@@ -62,6 +63,20 @@ def slugurl(context, slug):
 @register.simple_tag
 def wagtail_version():
     return __version__
+
+
+@register.simple_tag
+def wagtail_documentation_path():
+    major, minor, patch, release, num = VERSION
+    if release == 'final':
+        return 'https://docs.wagtail.io/en/v%s' % __version__
+    else:
+        return 'https://docs.wagtail.io/en/latest'
+
+
+@register.simple_tag
+def wagtail_release_notes_path():
+    return "%s.html" % get_main_version(VERSION)
 
 
 @register.filter

--- a/wagtail/project_template/home/templates/home/welcome_page.html
+++ b/wagtail/project_template/home/templates/home/welcome_page.html
@@ -10,7 +10,7 @@
     {% templatetag openblock %} comment {% templatetag closeblock %}
       This works for all cases but prerelease versions:
     {% templatetag openblock %} endcomment {% templatetag closeblock %}
-    <a href="https://docs.wagtail.io/en/latest/releases/{% templatetag openblock %} wagtail_version {% templatetag closeblock %}.html">
+    <a href="{% templatetag openblock %} wagtail_documentation_path {% templatetag closeblock %}/releases/{% templatetag openblock %} wagtail_release_notes_path {% templatetag closeblock %}">
       {% templatetag openblock %} trans "View the release notes" {% templatetag closeblock %}
     </a>
   </div>
@@ -28,14 +28,14 @@
   </div>
 </main>
 <footer class="footer">
-  <a class="option option-one" href="https://docs.wagtail.io/en/v{% templatetag openblock %} wagtail_version {% templatetag closeblock %}/">
+  <a class="option option-one" href="{% templatetag openblock %} wagtail_documentation_path {% templatetag closeblock %}/">
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M9 21c0 .5.4 1 1 1h4c.6 0 1-.5 1-1v-1H9v1zm3-19C8.1 2 5 5.1 5 9c0 2.4 1.2 4.5 3 5.7V17c0 .5.4 1 1 1h6c.6 0 1-.5 1-1v-2.3c1.8-1.3 3-3.4 3-5.7 0-3.9-3.1-7-7-7zm2.9 11.1l-.9.6V16h-4v-2.3l-.9-.6C7.8 12.2 7 10.6 7 9c0-2.8 2.2-5 5-5s5 2.2 5 5c0 1.6-.8 3.2-2.1 4.1z"/></svg>
     <div>
       <h4>{% templatetag openblock %} trans "Wagtail Documentation" {% templatetag closeblock %}</h4>
       <p>{% templatetag openblock %} trans "Topics, references, & how-tos" {% templatetag closeblock %}</p>
     </div>
   </a>
-  <a class="option option-two" href="https://docs.wagtail.io/en/v{% templatetag openblock %} wagtail_version {% templatetag closeblock %}/getting_started/tutorial.html">
+  <a class="option option-two" href="{% templatetag openblock %} wagtail_documentation_path {% templatetag closeblock %}/getting_started/tutorial.html">
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M9.4 16.6L4.8 12l4.6-4.6L8 6l-6 6 6 6 1.4-1.4zm5.2 0l4.6-4.6-4.6-4.6L16 6l6 6-6 6-1.4-1.4z"/></svg>
     <div>
       <h4>{% templatetag openblock %} trans "Tutorial" {% templatetag closeblock %}</h4>


### PR DESCRIPTION
On a prerelease or release candidate of Wagtail, the documentation links on the welcome page are broken, which may confuse users into thinking this is a bug. In this case, we should link to the 'latest' branch of the docs, and use the 'main' version (e.g. 2.4a0 => 2.4) as the release notes page.