### PR TITLE
Ability for filter_spec to be a template variable

### DIFF
--- a/docs/releases/2.4.rst
+++ b/docs/releases/2.4.rst
@@ -31,6 +31,7 @@ Other features
  * Added ``file_hash`` field to documents (Karl Hobley, Dan Braghis)
  * Added last login to the user overview (Noah B Johnson)
  * Changed design of image editing page (Janneke Janssen, Ben Enright)
+ * The ``{% image %}`` templatetag now supports passing a template variable as filter spec (Luis Nell)
 
 Bug fixes
 ~~~~~~~~~

--- a/wagtail/images/templatetags/wagtailimages_tags.py
+++ b/wagtail/images/templatetags/wagtailimages_tags.py
@@ -99,7 +99,13 @@ class ImageNode(template.Node):
         if not image:
             return ''
 
-        rendition = get_rendition_or_not_found(image, self.filter)
+        try:
+            rend_filter = Filter(
+                spec=template.Variable(self.filter_spec).resolve(context)
+            )
+            rendition = get_rendition_or_not_found(image, rend_filter)
+        except template.VariableDoesNotExist:
+            rendition = get_rendition_or_not_found(image, self.filter)
 
         if self.output_var_name:
             # return the rendition object in the given variable

--- a/wagtail/images/tests/tests.py
+++ b/wagtail/images/tests/tests.py
@@ -52,6 +52,18 @@ class TestImageTag(TestCase):
         result = self.render_image_tag(None, "width-500")
         self.assertEqual(result, '')
 
+    def test_image_tag_spec_as_variable(self):
+        temp = template.Template('{% load wagtailimages_tags %}{% image image_obj filter_spec %}')
+        context = template.Context(
+            {'image_obj': self.image, 'filter_spec': 'width-400'}
+        )
+        result = temp.render(context)
+
+        # Check that all the required HTML attributes are set
+        self.assertTrue('width="400"' in result)
+        self.assertTrue('height="300"' in result)
+        self.assertTrue('alt="Test image"' in result)
+
     def render_image_tag_as(self, image, filter_spec):
         temp = template.Template(
             '{% load wagtailimages_tags %}{% image image_obj ' + filter_spec


### PR DESCRIPTION
* Do the tests still pass? (http://docs.wagtail.io/en/latest/contributing/developing.html#testing) *Yes*
* Does the code comply with the style guide? (Run `make lint` from the Wagtail root) *Yes*
* For Python changes: Have you added tests to cover the new/fixed behaviour? *Yes*
* For front-end changes: Did you test on all of Wagtail’s supported browsers? **Please list the exact versions you tested**. *No frontend changes*
* For new features: Has the documentation been updated accordingly? *Not yet*

--- 

This pull requests proposes allowing `filter_spec` used in the `{% image %}` template tag to be a template variable.

Why? In most bigger projects it is usually a wish to keep a single source of truth. Now, sprinkling `width-300` and `width-325` etc. throughout your templates is not really DRY.

In order to solve this we did something along these lines:

```python
# settings.py
WAGTAIL_RENDITION_FILTER_SPECS = {
    "thumbnail": "fill-100x100",
    "small": "width-300",
    "medium": "width-600",
    "large": "width-1200",
    "x-large": "width-1600",
}
```
```python
# context_processor.py
from django.conf import settings


def standardized_image_renditions(request):
    """Exposes our ``WAGTAIL_RENDITION_FILTER_SPECS`` setting in the templates.

    So we don't have to hardcode image rendition formats throughout all of
    our (template) code.
    """
    return {"renditions": settings.WAGTAIL_RENDITION_FILTER_SPECS}
```

Finally, in our templates I wanted to replace the "hardcoded" specs with our new standardized variables:

```html
<!-- our template before -->
{% image box.image width-300 as small %}
{% image box.image width-1200 as medium %}
<img src="{{ small.url }}" srcset="{{ small.url }} 1x, {{ medium.url }} 2x" class="box__image__img" alt="" />
```
```html
<!-- our template after... -->
{% image box.image renditions.small as small %}
{% image box.image renditions.medium as medium %}
<img src="{{ small.url }}" srcset="{{ small.url }} 1x, {{ medium.url }} 2x" class="box__image__img" alt="" />
```

Sadly, this lead to an exception (invalid filter spec), as wagtail does not support template variables being the filter spec. Or I just couldn't find how to do it the right way 😅 Hence, this pull request.

I noticed the use of `@cached_property`. I guess this means that constructing the filter is rather expensive. I could imagine that you are not too happy with my proposed changes then, as they might introduce a performance hit. Not sure how big it is though.

Looking forward to comments 😄 