### PR TITLE
Fixed reference to LoginView in docs.

### DIFF
--- a/docs/advanced_topics/privacy.rst
+++ b/docs/advanced_topics/privacy.rst
@@ -24,7 +24,7 @@ The basic login page can be customised by setting ``WAGTAIL_FRONTEND_LOGIN_TEMPL
 
   WAGTAIL_FRONTEND_LOGIN_TEMPLATE = 'myapp/login.html'
 
-Wagtail uses Django's standard ``django.contrib.auth.views.login`` view here, and so the context variables available on the template are as detailed in `Django's login view documentation <https://docs.djangoproject.com/en/stable/topics/auth/default/#django.contrib.auth.views.login>`_.
+Wagtail uses Django's standard ``django.contrib.auth.views.LoginView`` view here, and so the context variables available on the template are as detailed in :class:`Django's login view documentation <django.contrib.auth.views.LoginView>`.
 
 If the stock Django login view is not suitable - for example, you wish to use an external authentication system, or you are integrating Wagtail into an existing Django site that already has a working login view - you can specify the URL of the login view via the ``WAGTAIL_FRONTEND_LOGIN_URL`` setting:
 


### PR DESCRIPTION
`LoginView` is used since a657a75cd7822bd29913f0a48e37eb97ecfd4175.