### PR TITLE
Fix missing comma in Draftail docs code

### DIFF
--- a/docs/advanced_topics/customisation/extending_draftail.rst
+++ b/docs/advanced_topics/customisation/extending_draftail.rst
@@ -183,7 +183,7 @@ In order to achieve this, we start with registering the rich text feature like f
         features.register_editor_plugin(
             'draftail', feature_name, draftail_features.EntityFeature(
                 control,
-                js=['stock.js']
+                js=['stock.js'],
                 css={'all': ['stock.css']}
             )
         )


### PR DESCRIPTION
Sample code is just missing a comma.