### PR TITLE
Remove IE9 debugging information from style guide

### DIFF
--- a/wagtail/contrib/styleguide/templates/wagtailstyleguide/base.html
+++ b/wagtail/contrib/styleguide/templates/wagtailstyleguide/base.html
@@ -36,7 +36,6 @@
                 <li><a href="#progress">Progress indicators</a></li>
                 <li><a href="#misc">Misc formatters</a></li>
                 <li><a href="#icons">Icons</a></li>
-                <li><a href="#ie9">IE9 debugging</a></li>
             </ul>
         </nav>
 
@@ -885,14 +884,6 @@
 
         </section>
 
-        <section id="ie9">
-            <h2>IE9 debugging</h2>
-
-            <p>Internet Explorer 9 has two critical limitations in its CSS support: a maximum of 31 stylesheets per page and a maximum of 4096 selectors per stylesheet. The latter is particularly problematic when CSS is concatenated.</p>
-
-            <div id="ie9-debug"></div>
-
-        </section>
     </div>
 
 {% endblock %}
@@ -906,30 +897,6 @@
 
     <script>
         $(function(){
-            // Debugging for stylesheet problems
-            var styleSheets = document.styleSheets, totalStyleSheets = styleSheets.length;
-            for (var j = 0; j < totalStyleSheets; j++) {
-                var styleSheet = styleSheets[j], rules = styleSheet.cssRules, totalSelectorsInStylesheet = 0, style = "";
-
-                var totalRulesInStylesheet = rules ? rules.length : 0;
-
-                for (var i = 0; i < totalRulesInStylesheet; i++) {
-                    if (rules[i].selectorText) {
-                        try {
-                            totalSelectorsInStylesheet += rules[i].selectorText.split(',').length;
-                        }
-                        catch (err) {
-                            console.log(err);
-                        }
-                    }
-                }
-
-                if(totalSelectorsInStylesheet > 4095){
-                    style = 'color:red';
-                }
-                $('#ie9-debug').append("<h3>" + styleSheet.href + "</h3>" + "<p>Total rules: <strong>" + totalRulesInStylesheet + "</strong>. " + "Total selectors: <strong style='" + style + "'>" + totalSelectorsInStylesheet + "</strong></p>");
-            }
-
             (function runprogress(){
                 var to = setTimeout(function(){
                     runprogress();


### PR DESCRIPTION
As per https://github.com/wagtail/wagtail/blob/master/docs/contributing/developing.rst Wagtail only supports IE11 and higher, and IE9 is end of life. 