### PR TITLE
Use functools.partial instead of django.utils.functional.curry().

### DIFF
--- a/wagtail/admin/edit_handlers.py
+++ b/wagtail/admin/edit_handlers.py
@@ -1,3 +1,4 @@
+import functools
 import re
 
 from django import forms
@@ -7,7 +8,7 @@ from django.forms.formsets import DELETION_FIELD_NAME, ORDERING_FIELD_NAME
 from django.forms.models import fields_for_model
 from django.template.loader import render_to_string
 from django.utils.encoding import force_text
-from django.utils.functional import cached_property, curry
+from django.utils.functional import cached_property
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy
 from taggit.managers import TaggableManager
@@ -500,7 +501,7 @@ class FieldPanel(EditHandler):
 
         if comparator_class:
             try:
-                return [curry(comparator_class, self.db_field)]
+                return [functools.partial(comparator_class, self.db_field)]
             except FieldDoesNotExist:
                 return []
         return []
@@ -681,8 +682,7 @@ class InlinePanel(EditHandler):
                 panel.bind_to_model(self.db_field.related_model)
                 .get_comparison())
 
-        return [curry(compare.ChildRelationComparison, self.db_field,
-                      field_comparisons)]
+        return [functools.partial(compare.ChildRelationComparison, self.db_field, field_comparisons)]
 
     def on_model_bound(self):
         manager = getattr(self.model, self.relation_name)

--- a/wagtail/admin/tests/test_compare.py
+++ b/wagtail/admin/tests/test_compare.py
@@ -1,7 +1,7 @@
 import unittest
+from functools import partial
 
 from django.test import TestCase
-from django.utils.functional import curry
 from django.utils.safestring import SafeText
 
 from wagtail.admin import compare
@@ -361,8 +361,8 @@ class TestChildRelationComparison(TestCase):
         comparison = self.comparison_class(
             EventPage._meta.get_field('speaker'),
             [
-                curry(self.field_comparison_class, EventPageSpeaker._meta.get_field('first_name')),
-                curry(self.field_comparison_class, EventPageSpeaker._meta.get_field('last_name')),
+                partial(self.field_comparison_class, EventPageSpeaker._meta.get_field('first_name')),
+                partial(self.field_comparison_class, EventPageSpeaker._meta.get_field('last_name')),
             ],
             event_page,
             modified_event_page,
@@ -408,8 +408,8 @@ class TestChildRelationComparison(TestCase):
         comparison = self.comparison_class(
             EventPage._meta.get_field('speaker'),
             [
-                curry(self.field_comparison_class, EventPageSpeaker._meta.get_field('first_name')),
-                curry(self.field_comparison_class, EventPageSpeaker._meta.get_field('last_name')),
+                partial(self.field_comparison_class, EventPageSpeaker._meta.get_field('first_name')),
+                partial(self.field_comparison_class, EventPageSpeaker._meta.get_field('last_name')),
             ],
             event_page,
             modified_event_page,
@@ -457,8 +457,8 @@ class TestChildRelationComparison(TestCase):
         comparison = self.comparison_class(
             EventPage._meta.get_field('speaker'),
             [
-                curry(self.field_comparison_class, EventPageSpeaker._meta.get_field('first_name')),
-                curry(self.field_comparison_class, EventPageSpeaker._meta.get_field('last_name')),
+                partial(self.field_comparison_class, EventPageSpeaker._meta.get_field('first_name')),
+                partial(self.field_comparison_class, EventPageSpeaker._meta.get_field('last_name')),
             ],
             event_page,
             modified_event_page,
@@ -498,8 +498,8 @@ class TestChildRelationComparison(TestCase):
         comparison = self.comparison_class(
             EventPage._meta.get_field('speaker'),
             [
-                curry(self.field_comparison_class, EventPageSpeaker._meta.get_field('first_name')),
-                curry(self.field_comparison_class, EventPageSpeaker._meta.get_field('last_name')),
+                partial(self.field_comparison_class, EventPageSpeaker._meta.get_field('first_name')),
+                partial(self.field_comparison_class, EventPageSpeaker._meta.get_field('last_name')),
             ],
             event_page,
             modified_event_page,
@@ -538,8 +538,8 @@ class TestChildObjectComparison(TestCase):
         comparison = self.comparison_class(
             EventPageSpeaker,
             [
-                curry(self.field_comparison_class, EventPageSpeaker._meta.get_field('first_name')),
-                curry(self.field_comparison_class, EventPageSpeaker._meta.get_field('last_name')),
+                partial(self.field_comparison_class, EventPageSpeaker._meta.get_field('first_name')),
+                partial(self.field_comparison_class, EventPageSpeaker._meta.get_field('last_name')),
             ],
             obj_a,
             obj_b,
@@ -565,8 +565,8 @@ class TestChildObjectComparison(TestCase):
         comparison = self.comparison_class(
             EventPageSpeaker,
             [
-                curry(self.field_comparison_class, EventPageSpeaker._meta.get_field('first_name')),
-                curry(self.field_comparison_class, EventPageSpeaker._meta.get_field('last_name')),
+                partial(self.field_comparison_class, EventPageSpeaker._meta.get_field('first_name')),
+                partial(self.field_comparison_class, EventPageSpeaker._meta.get_field('last_name')),
             ],
             obj_a,
             obj_b,
@@ -594,8 +594,8 @@ class TestChildObjectComparison(TestCase):
         comparison = self.comparison_class(
             EventPageSpeaker,
             [
-                curry(self.field_comparison_class, EventPageSpeaker._meta.get_field('first_name')),
-                curry(self.field_comparison_class, EventPageSpeaker._meta.get_field('last_name')),
+                partial(self.field_comparison_class, EventPageSpeaker._meta.get_field('first_name')),
+                partial(self.field_comparison_class, EventPageSpeaker._meta.get_field('last_name')),
             ],
             obj_a,
             obj_b,
@@ -616,8 +616,8 @@ class TestChildObjectComparison(TestCase):
         comparison = self.comparison_class(
             EventPageSpeaker,
             [
-                curry(self.field_comparison_class, EventPageSpeaker._meta.get_field('first_name')),
-                curry(self.field_comparison_class, EventPageSpeaker._meta.get_field('last_name')),
+                partial(self.field_comparison_class, EventPageSpeaker._meta.get_field('first_name')),
+                partial(self.field_comparison_class, EventPageSpeaker._meta.get_field('last_name')),
             ],
             None,
             obj,
@@ -638,8 +638,8 @@ class TestChildObjectComparison(TestCase):
         comparison = self.comparison_class(
             EventPageSpeaker,
             [
-                curry(self.field_comparison_class, EventPageSpeaker._meta.get_field('first_name')),
-                curry(self.field_comparison_class, EventPageSpeaker._meta.get_field('last_name')),
+                partial(self.field_comparison_class, EventPageSpeaker._meta.get_field('first_name')),
+                partial(self.field_comparison_class, EventPageSpeaker._meta.get_field('last_name')),
             ],
             obj,
             None,
@@ -679,7 +679,7 @@ class TestChildRelationComparisonUsingPK(TestCase):
 
         comparison = self.comparison_class(
             EventPage._meta.get_field('head_counts'),
-            [curry(self.field_comparison_class, HeadCountRelatedModelUsingPK._meta.get_field('head_count'))],
+            [partial(self.field_comparison_class, HeadCountRelatedModelUsingPK._meta.get_field('head_count'))],
             event_page,
             modified_event_page,
         )
@@ -716,7 +716,7 @@ class TestChildRelationComparisonUsingPK(TestCase):
 
         comparison = self.comparison_class(
             EventPage._meta.get_field('head_counts'),
-            [curry(self.field_comparison_class, HeadCountRelatedModelUsingPK._meta.get_field('head_count'))],
+            [partial(self.field_comparison_class, HeadCountRelatedModelUsingPK._meta.get_field('head_count'))],
             event_page,
             modified_event_page,
         )


### PR DESCRIPTION
django.utils.functional.curry() is planned to be removed in the future.
See https://code.djangoproject.com/ticket/27753.
