### PR TITLE
Hide "delete snippets" button when no snippets selected

### DIFF
--- a/wagtail/snippets/static_src/wagtailsnippets/js/snippet-multiple-select.js
+++ b/wagtail/snippets/static_src/wagtailsnippets/js/snippet-multiple-select.js
@@ -19,13 +19,13 @@ var updateDeleteButton = function(anySelected, newState) {
     });
     if (anySelected) {
         // enable button and add url
-        $deleteButton.css('visibility', 'visible');
+        $deleteButton.removeClass('visuallyhidden');
         var url = $deleteButton.data('url');
         url = url + $.param({id: ids}, true);
         $deleteButton.attr('href', url);
     } else {
         // disable button and remove url
-        $deleteButton.css('visibility', 'hidden');
+        $deleteButton.addClass('visuallyhidden');
         $deleteButton.attr('href', null);
     }
 };

--- a/wagtail/snippets/static_src/wagtailsnippets/js/snippet-multiple-select.js
+++ b/wagtail/snippets/static_src/wagtailsnippets/js/snippet-multiple-select.js
@@ -19,13 +19,13 @@ var updateDeleteButton = function(anySelected, newState) {
     });
     if (anySelected) {
         // enable button and add url
-        $deleteButton.removeClass('disabled');
+        $deleteButton.css('visibility', 'visible');
         var url = $deleteButton.data('url');
         url = url + $.param({id: ids}, true);
         $deleteButton.attr('href', url);
     } else {
         // disable button and remove url
-        $deleteButton.addClass('disabled');
+        $deleteButton.css('visibility', 'hidden');
         $deleteButton.attr('href', null);
     }
 };

--- a/wagtail/snippets/templates/wagtailsnippets/snippets/type_index.html
+++ b/wagtail/snippets/templates/wagtailsnippets/snippets/type_index.html
@@ -37,7 +37,7 @@
             </div>
             <div class="right col6">
                 {% if can_delete_snippets %}
-                    <a class="button bicolor icon icon-bin serious disabled delete-button" data-url="{% url 'wagtailsnippets:delete-multiple' model_opts.app_label model_opts.model_name %}?">{% blocktrans with snippet_type_name=model_opts.verbose_name_plural %}Delete {{ snippet_type_name }}{% endblocktrans %}</a>
+                    <a class="button bicolor icon icon-bin serious delete-button" style="visibility: hidden;" data-url="{% url 'wagtailsnippets:delete-multiple' model_opts.app_label model_opts.model_name %}?">{% blocktrans with snippet_type_name=model_opts.verbose_name_plural %}Delete {{ snippet_type_name }}{% endblocktrans %}</a>
                 {% endif %}
                 {% if can_add_snippet %}
                     <a href="{% url 'wagtailsnippets:add' model_opts.app_label model_opts.model_name %}" class="button bicolor icon icon-plus">{% blocktrans with snippet_type_name=model_opts.verbose_name %}Add {{ snippet_type_name }}{% endblocktrans %}</a>

--- a/wagtail/snippets/templates/wagtailsnippets/snippets/type_index.html
+++ b/wagtail/snippets/templates/wagtailsnippets/snippets/type_index.html
@@ -37,7 +37,7 @@
             </div>
             <div class="right col6">
                 {% if can_delete_snippets %}
-                    <a class="button bicolor icon icon-bin serious delete-button" style="visibility: hidden;" data-url="{% url 'wagtailsnippets:delete-multiple' model_opts.app_label model_opts.model_name %}?">{% blocktrans with snippet_type_name=model_opts.verbose_name_plural %}Delete {{ snippet_type_name }}{% endblocktrans %}</a>
+                    <a class="button bicolor icon icon-bin serious delete-button visuallyhidden" data-url="{% url 'wagtailsnippets:delete-multiple' model_opts.app_label model_opts.model_name %}?">{% blocktrans with snippet_type_name=model_opts.verbose_name_plural %}Delete {{ snippet_type_name }}{% endblocktrans %}</a>
                 {% endif %}
                 {% if can_add_snippet %}
                     <a href="{% url 'wagtailsnippets:add' model_opts.app_label model_opts.model_name %}" class="button bicolor icon icon-plus">{% blocktrans with snippet_type_name=model_opts.verbose_name %}Add {{ snippet_type_name }}{% endblocktrans %}</a>


### PR DESCRIPTION
Fixes #4904 

Removes the ugly disabled button from the header of the snippets section. The button is displayed when the user selects a snippet.

This is more consistent with the interface we have for form submissions (except for the button being in a different place). Also, the hiding of action buttons behaviour is used by other popular online tools such as Gmail so shouldn't be too surprising for users.