### PR TITLE
Add hooks to page move action

### DIFF
--- a/docs/reference/hooks.rst
+++ b/docs/reference/hooks.rst
@@ -492,6 +492,22 @@ Hooks for customising the way users are directed through the process of creating
 
   Uses the same behaviour as ``before_create_page``.
 
+.. _after_move_page:
+
+``after_move_page``
+~~~~~~~~~~~~~~~~~~~
+
+  Do something with a ``Page`` object after it has been moved passing in the request and page object. Uses the same behaviour as ``after_create_page``.
+
+
+.. _before_move_page:
+
+``before_move_page``
+~~~~~~~~~~~~~~~~~~~~~
+
+  Called at the beginning of the "move_confirm page" view passing in the request, the page object and the destination page object.
+
+  Uses the same behaviour as ``before_create_page``.
 
 .. _register_page_action_menu_item:
 

--- a/wagtail/admin/tests/test_pages_views.py
+++ b/wagtail/admin/tests/test_pages_views.py
@@ -2563,6 +2563,47 @@ class TestPageMove(TestCase, WagtailTestUtils):
         response = self.client.get(reverse('wagtailadmin_pages:set_page_position', args=(self.test_page.id, )))
         self.assertEqual(response.status_code, 200)
 
+    def test_before_move_page_hook(self):
+        def hook_func(request, page, destination):
+            self.assertIsInstance(request, HttpRequest)
+            self.assertIsInstance(page.specific, SimplePage)
+            self.assertIsInstance(destination.specific, SimplePage)
+
+            return HttpResponse("Overridden!")
+
+        with self.register_hook('before_move_page', hook_func):
+            response = self.client.get(reverse('wagtailadmin_pages:move_confirm', args=(self.test_page.id, self.section_b.id)))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, b"Overridden!")
+
+    def test_before_move_page_hook_post(self):
+        def hook_func(request, page, destination):
+            self.assertIsInstance(request, HttpRequest)
+            self.assertIsInstance(page.specific, SimplePage)
+            self.assertIsInstance(destination.specific, SimplePage)
+
+            return HttpResponse("Overridden!")
+
+        with self.register_hook('before_move_page', hook_func):
+            response = self.client.post(reverse('wagtailadmin_pages:move_confirm', args=(self.test_page.id, self.section_b.id)))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, b"Overridden!")
+
+    def test_after_move_page_hook(self):
+        def hook_func(request, page):
+            self.assertIsInstance(request, HttpRequest)
+            self.assertIsInstance(page.specific, SimplePage)
+
+            return HttpResponse("Overridden!")
+
+        with self.register_hook('after_move_page', hook_func):
+            response = self.client.post(reverse('wagtailadmin_pages:move_confirm', args=(self.test_page.id, self.section_b.id)))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, b"Overridden!")
+
 
 class TestPageCopy(TestCase, WagtailTestUtils):
 


### PR DESCRIPTION
This PR adds `before_move_page` and `after_move_page` hooks to the Editor workflow.

Every editor action on a page (`create`, `edit`, `delete`, `copy`) has hooks to register new behaviors to them except for `move`, and we at Twilio need to use them all to make some verifications on the user permissions and page content before letting them proceed. 

- [x] Do the tests still pass? (http://docs.wagtail.io/en/latest/contributing/developing.html#testing)
- [x] Does the code comply with the style guide? (Run `make lint` from the Wagtail root)
- [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
- [ ] For front-end changes: Did you test on all of Wagtail’s supported browsers? **No front-end changes**.
- [x] For new features: Has the documentation been updated accordingly?

