### PR TITLE
Respect CSS precedence rules in HTMLRuleset

### DIFF
--- a/wagtail/admin/tests/test_contentstate.py
+++ b/wagtail/admin/tests/test_contentstate.py
@@ -787,3 +787,22 @@ class TestHtmlToContentState(TestCase):
                 {'inlineStyleRanges': [], 'text': 'After', 'depth': 0, 'type': 'unstyled', 'key': '00000', 'entityRanges': []},
             ]
         })
+
+    def test_p_with_class(self):
+        # Test support for custom conversion rules which require correct treatment of
+        # CSS precedence in HTMLRuleset. Here, <p class="intro"> should match the
+        # 'p[class="intro"]' rule rather than 'p' and thus become an 'intro-paragraph' block
+        converter = ContentstateConverter(features=['intro'])
+        result = json.loads(converter.from_database_format(
+            '''
+            <p class="intro">before</p>
+            <p>after</p>
+            '''
+        ))
+        self.assertContentStateEqual(result, {
+            'blocks': [
+                {'key': '00000', 'inlineStyleRanges': [], 'entityRanges': [], 'depth': 0, 'text': 'before', 'type': 'intro-paragraph'},
+                {'key': '00000', 'inlineStyleRanges': [], 'entityRanges': [], 'depth': 0, 'text': 'after', 'type': 'unstyled'}
+            ],
+            'entityMap': {}
+        })

--- a/wagtail/admin/tests/test_html_ruleset.py
+++ b/wagtail/admin/tests/test_html_ruleset.py
@@ -22,3 +22,11 @@ class TestHTMLRuleset(TestCase):
         self.assertEqual(ruleset.match('a', {'class': 'button', 'linktype': 'page'}), 'page-link')
         self.assertEqual(ruleset.match('a', {'class': 'button', 'linktype': 'silly page'}), 'silly-page-link')
         self.assertEqual(ruleset.match('a', {'class': 'button', 'linktype': 'sensible page'}), 'sensible-page-link')
+
+    def test_precedence(self):
+        ruleset = HTMLRuleset()
+        ruleset.add_rule('p', 'normal-paragraph')
+        ruleset.add_rule('p[class="intro"]', 'intro-paragraph')
+        ruleset.add_rule('p', 'normal-paragraph-again')
+
+        self.assertEqual(ruleset.match('p', {'class': 'intro'}), 'intro-paragraph')

--- a/wagtail/tests/testapp/wagtail_hooks.py
+++ b/wagtail/tests/testapp/wagtail_hooks.py
@@ -6,6 +6,7 @@ import wagtail.admin.rich_text.editors.draftail.features as draftail_features
 from wagtail.admin.action_menu import ActionMenuItem
 from wagtail.admin.menu import MenuItem
 from wagtail.admin.rich_text import HalloPlugin
+from wagtail.admin.rich_text.converters.html_to_contentstate import BlockElementHandler
 from wagtail.admin.search import SearchArea
 from wagtail.core import hooks
 
@@ -105,6 +106,20 @@ def register_blockquote_feature(features):
             css={'all': ['testapp/css/draftail-blockquote.css']},
         )
     )
+
+
+# register 'intro' as a rich text feature which converts an `intro-paragraph` contentstate block
+# to a <p class="intro"> tag in db HTML and vice versa
+@hooks.register('register_rich_text_features')
+def register_intro_rule(features):
+    features.register_converter_rule('contentstate', 'intro', {
+        'from_database_format': {
+            'p[class="intro"]': BlockElementHandler('intro-paragraph'),
+        },
+        'to_database_format': {
+            'block_map': {'intro-paragraph': {'element': 'p', 'props': {'class': 'intro'}}},
+        }
+    })
 
 
 class PanicMenuItem(ActionMenuItem):


### PR DESCRIPTION
Fixes #4527

Enhances the HTMLRuleset engine used in dbHTML-to-contentState conversion, so that more specific CSS rules are matched with higher priority. This makes it possible to define conversion rules for elements such as `<p class="intro">` that don't get overruled by the default `<p>` rule.