### PR TITLE
fixes #4928 remove deprecated references

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ language: python
 cache: pip
 dist: trusty
 
-# Use container-based infrastructure
-sudo: false
-
 addons:
   postgresql: "9.6"
 
@@ -25,36 +22,27 @@ matrix:
    - env: TOXENV=py37-dj20-mysql-noelasticsearch
      python: 3.7
      dist: xenial
-     sudo: true
    - env: TOXENV=py37-dj21-postgres-noelasticsearch
      python: 3.7
      dist: xenial
-     sudo: true
    - env: TOXENV=py37-dj21-sqlite-noelasticsearch
      python: 3.7
      dist: xenial
-     sudo: true
    - env: TOXENV=py36-djmaster-postgres-noelasticsearch
      python: 3.6
    - env: TOXENV=py36-dj20-sqlite-elasticsearch2 INSTALL_ELASTICSEARCH2=yes
      python: 3.6
-     sudo: true
    - env: TOXENV=py36-dj21-sqlite-elasticsearch2 INSTALL_ELASTICSEARCH2=yes
      python: 3.6
-     sudo: true
    - env: TOXENV=py36-dj21-postgres-elasticsearch5 INSTALL_ELASTICSEARCH5=yes
      python: 3.6
-     sudo: true
    - env: TOXENV=py36-dj20-postgres-elasticsearch6 INSTALL_ELASTICSEARCH6=yes
      python: 3.6
-     sudo: true
    - env: TOXENV=py36-dj21-postgres-elasticsearch6 INSTALL_ELASTICSEARCH6=yes
      python: 3.6
-     sudo: true
    - env: TOXENV=py37-dj21-postgres-elasticsearch6 INSTALL_ELASTICSEARCH6=yes
      python: 3.7
      dist: xenial
-     sudo: true
   allow_failures:
     # Ignore failures on Elasticsearch tests because ES on Travis is intermittently flaky
     - env: TOXENV=py36-dj20-sqlite-elasticsearch2 INSTALL_ELASTICSEARCH2=yes

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -28,6 +28,7 @@ Changelog
  * Fix: Allow nav menu to take up all available space instead of scrolling (Meteor0id)
  * Fix: Redirects now return 404 when destination is unspecified or a page with no site (Hillary Jeffrey)
  * Fix: Refactor all breakpoint definitions, removing style overlaps (Janneke Janssen)
+ * Cleanup: remove deprecated options for TravisCI
 
 
 2.3 LTS (23.10.2018)


### PR DESCRIPTION
This keeps the project slightly ahead of the curve on a TravisCI change that is coming quite rapidly down the line. It should not affect builds, according to their docs, and gets you on the new default infrastructure.