### PR TITLE
Keep datetimepicker input/output values un-localised

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/shared/datetimepicker_translations.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/datetimepicker_translations.html
@@ -36,4 +36,14 @@
         ],
     }
     $.datetimepicker.setLocale('wagtail_custom_locale');
+
+    {#
+    The date string read from and written to the form field should be un-localised,
+    as Django cannot parse dates with non-English day/month names.
+    This requires us to replace the default DateFormatter component (which has been
+    passed these translations as configuration options) with a fresh one in its
+    default (English) configuration.
+    #}
+
+    @.datetimepicker.setDateFormatter(DateFormatter());
 </script>


### PR DESCRIPTION
Fixes #4846
Setting a non-English locale for the date picker causes day/month names in the dates accepted and returned by the date picker to be translated, which Django's date parsing doesn't handle. Override the date formatter to always use English.

(While this is technically a regression in Wagtail 2.3, it only occurs if locale settings have been extensively customised as described on #4846, and so I think this is a minor enough issue that it doesn't warrant a 2.3.1 release by itself. I'll leave the milestone as 2.3.1 to keep track of it if we _do_ decide to make a 2.3.1 release though)