### PR TITLE
Diffing StreamFields

### DIFF
--- a/wagtail/admin/static_src/wagtailadmin/scss/layouts/compare-revisions.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/layouts/compare-revisions.scss
@@ -10,6 +10,10 @@ $color-deletion-light: #ffebeb;
         border-top: 1px dashed $color-grey-4;
         padding: 1em;
 
+        dd {
+            margin-left: 40px;
+        }
+
         &:first-child {
             border-top: 0;
         }

--- a/wagtail/images/blocks.py
+++ b/wagtail/images/blocks.py
@@ -1,5 +1,7 @@
+from django.template.loader import render_to_string
 from django.utils.functional import cached_property
 
+from wagtail.admin.compare import BlockComparison
 from wagtail.core.blocks import ChooserBlock
 
 from .shortcuts import get_rendition_or_not_found
@@ -22,5 +24,22 @@ class ImageChooserBlock(ChooserBlock):
         else:
             return ''
 
+    def get_comparison_class(self):
+        return ImageChooserBlockComparison
+
     class Meta:
         icon = "image"
+
+
+class ImageChooserBlockComparison(BlockComparison):
+    def htmlvalue(self, val):
+        return render_to_string("wagtailimages/widgets/compare.html", {
+            'image_a': val,
+            'image_b': val,
+        })
+
+    def htmldiff(self):
+        return render_to_string("wagtailimages/widgets/compare.html", {
+            'image_a': self.val_a,
+            'image_b': self.val_b,
+        })


### PR DESCRIPTION
This PR implements diffing of StreamFields. It utilises the block IDs introduced in https://github.com/wagtail/wagtail/pull/3593 to work out which blocks have been created, deleted and moved.

I've currently implemented comparison logic for the rich text, image, struct and stream blocks. Other block types fall back to diffing on their HTML representation (as what happens now).

Before:

![streamfield-diff-before](https://user-images.githubusercontent.com/1093808/49251799-388ea680-f41a-11e8-8ad8-9add5a7ac640.png)

After:

![streamfield-diff-after](https://user-images.githubusercontent.com/1093808/49251765-201e8c00-f41a-11e8-8ff7-bb5ca014a4ab.png)

TODO:

 - [x] Tests
 - [ ] ~Indicate moved blocks~ will leave for another PR as I will also refactor diffing inline panels as well
 - [x] Fallback for diffing with revision without block IDs
 - [ ] ~ListBlock~ will leave for another PR as I will also refactor diffing inline panels as well