### PR TITLE
Module fix for browser module loading in cleanForSlug

### DIFF
--- a/wagtail/admin/static_src/wagtailadmin/js/page-editor.js
+++ b/wagtail/admin/static_src/wagtailadmin/js/page-editor.js
@@ -412,4 +412,6 @@ $(function() {
     });
 });
 
-module.exports.cleanForSlug = cleanForSlug;
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports.cleanForSlug = cleanForSlug;
+}


### PR DESCRIPTION
In addition we've forgot about the client-side module.exports handling of cleanForSlug. This is not required for the Node side of the added unit-tests but this does not help the browser. The proper way to do this is: `if (typeof module !== 'undefined' && module.exports)`

Tested in:
- Chrome latest
- Firefox ESR
- Internet Explorer 11

Related to #4884