### PR TITLE
Allow disabling search auto-update on a per-model basis

### DIFF
--- a/docs/topics/search/indexing.rst
+++ b/docs/topics/search/indexing.rst
@@ -26,6 +26,21 @@ Signal handlers
 
 ``wagtailsearch`` provides some signal handlers which bind to the save/delete signals of all indexed models. This would automatically add and delete them from all backends you have registered in ``WAGTAILSEARCH_BACKENDS``. These signal handlers are automatically registered when the ``wagtail.search`` app is loaded.
 
+In some cases, you may not want your content to be automatically reindexed and instead rely on the ``update_index`` command for indexing. If you need to disable these signal handlers, use one of the following methods:
+
+Disabling auto update signal handlers for a model
+`````````````````````````````````````````````````
+You can disable the signal handlers for an individual model by adding ``search_auto_update = False`` as an attribute on the model class.
+
+Disabling auto update signal handlers for a search backend/whole site
+`````````````````````````````````````````````````````````````````````
+
+You can disable the signal handlers for a whole search backend by setting the ``AUTO_UPDATE`` setting on the backend to ``False``.
+
+If all search backends have ``AUTO_UPDATE`` set to ``False``. The signal handlers will be completely disabled for the whole site.
+
+See the documentation for the ``AUTO_UPDATE`` setting :ref:`here <wagtailsearch_backends_auto_update>`.
+
 
 The ``update_index`` command
 ----------------------------

--- a/wagtail/search/signal_handlers.py
+++ b/wagtail/search/signal_handlers.py
@@ -20,5 +20,8 @@ def post_delete_signal_handler(instance, **kwargs):
 def register_signal_handlers():
     # Loop through list and register signal handlers for each one
     for model in index.get_indexed_models():
+        if getattr(model, 'search_auto_update', True) == False:
+            continue
+
         post_save.connect(post_save_signal_handler, sender=model)
         post_delete.connect(post_delete_signal_handler, sender=model)


### PR DESCRIPTION
In some cases, you may want ``AUTO_UPDATE`` enabled on your Wagtail Page model but rely on ``update_index`` for a custom indexed model.

This PR implements some logic to allow auto-update to be configured on a per-model basis using the ``search_auto_update`` attribute.