### PR TITLE
Simplified Site.find_for_request().

### DIFF
--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -107,16 +107,8 @@ class Site(models.Model):
         still be routed to a different hostname which is set as the default
         """
 
-        try:
-            hostname = request.get_host().split(':')[0]
-        except KeyError:
-            hostname = None
-
-        try:
-            port = request.get_port()
-        except (AttributeError, KeyError):
-            port = request.META.get('SERVER_PORT')
-
+        hostname = request.get_host().split(':')[0]
+        port = request.get_port()
         return get_site_for_hostname(hostname, port)
 
     @property


### PR DESCRIPTION
Handling of `AttributeError` is unneeded since support for Django 1.8 is dropped and handling of `KeyError` is unneeded because both hostname and port are obtained now via Django API (its current implementation can raise `KeyError` if `SERVER_NAME` or `SERVER_PORT` are absent, but they are required per [PEP 3333](https://www.python.org/dev/peps/pep-3333/#environ-variables)).