### PR TITLE
Made HTTP_HOST of page dummy request include port.

### DIFF
--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -1232,13 +1232,16 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
             port = 80
             scheme = 'http'
 
+        http_host = hostname
+        if port != (443 if scheme == 'https' else 80):
+            http_host = '%s:%s' % (http_host, port)
         dummy_values = {
             'REQUEST_METHOD': 'GET',
             'PATH_INFO': path,
             'SERVER_NAME': hostname,
             'SERVER_PORT': port,
             'SERVER_PROTOCOL': 'HTTP/1.1',
-            'HTTP_HOST': hostname,
+            'HTTP_HOST': http_host,
             'wsgi.version': (1, 0),
             'wsgi.input': StringIO(),
             'wsgi.errors': StringIO(),

--- a/wagtail/core/tests/test_page_model.py
+++ b/wagtail/core/tests/test_page_model.py
@@ -1389,6 +1389,31 @@ class TestDummyRequest(TestCase):
         self.assertIn('wsgi.multiprocess', request.META)
         self.assertIn('wsgi.run_once', request.META)
 
+    def test_dummy_request_for_accessible_page_non_standard_port(self):
+        Site.objects.update(port=8888)
+
+        event_index = Page.objects.get(url_path='/home/events/')
+        request = event_index.dummy_request()
+
+        # request should have the correct path and hostname for this page
+        self.assertEqual(request.path, '/events/')
+        self.assertEqual(request.META['HTTP_HOST'], 'localhost:8888')
+
+        # check other env vars required by the WSGI spec
+        self.assertEqual(request.META['REQUEST_METHOD'], 'GET')
+        self.assertEqual(request.META['SCRIPT_NAME'], '')
+        self.assertEqual(request.META['PATH_INFO'], '/events/')
+        self.assertEqual(request.META['SERVER_NAME'], 'localhost')
+        self.assertEqual(request.META['SERVER_PORT'], 8888)
+        self.assertEqual(request.META['SERVER_PROTOCOL'], 'HTTP/1.1')
+        self.assertEqual(request.META['wsgi.version'], (1, 0))
+        self.assertEqual(request.META['wsgi.url_scheme'], 'http')
+        self.assertIn('wsgi.input', request.META)
+        self.assertIn('wsgi.errors', request.META)
+        self.assertIn('wsgi.multithread', request.META)
+        self.assertIn('wsgi.multiprocess', request.META)
+        self.assertIn('wsgi.run_once', request.META)
+
     def test_dummy_request_for_accessible_page_with_original_request(self):
         event_index = Page.objects.get(url_path='/home/events/')
         original_headers = {


### PR DESCRIPTION
`Host` header should include port, see https://tools.ietf.org/html/rfc7230#section-5.4.