### PR TITLE
Exclude the error messages from the count of inline panel elements (#4304 redux)

### DIFF
--- a/wagtail/admin/static_src/wagtailadmin/js/page-editor.js
+++ b/wagtail/admin/static_src/wagtailadmin/js/page-editor.js
@@ -177,7 +177,6 @@ function InlinePanel(opts) {
     self.updateAddButtonState = function() {
         if (opts.maxForms) {
             var forms = $('> [data-inline-panel-child]', self.formsUl).not('.deleted');
-            console.log('form count', forms.length);
             var addButton = $('#' + opts.formsetPrefix + '-ADD');
 
             if (forms.length >= opts.maxForms) {

--- a/wagtail/admin/static_src/wagtailadmin/js/page-editor.js
+++ b/wagtail/admin/static_src/wagtailadmin/js/page-editor.js
@@ -176,7 +176,8 @@ function InlinePanel(opts) {
 
     self.updateAddButtonState = function() {
         if (opts.maxForms) {
-            var forms = $('> li', self.formsUl).not('.deleted');
+            var forms = $('> [data-inline-panel-child]', self.formsUl).not('.deleted');
+            console.log('form count', forms.length);
             var addButton = $('#' + opts.formsetPrefix + '-ADD');
 
             if (forms.length >= opts.maxForms) {

--- a/wagtail/admin/templates/wagtailadmin/edit_handlers/inline_panel_child.html
+++ b/wagtail/admin/templates/wagtailadmin/edit_handlers/inline_panel_child.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-<li id="inline_child_{{ child.form.prefix }}">
+<li data-inline-panel-child id="inline_child_{{ child.form.prefix }}">
     <ul class="controls">
         {% if can_order %}
             <li><button type="button" class="button icon text-replace white icon-order-up inline-child-move-up" id="{{ child.form.prefix }}-move-up" title="{% trans 'Move up' %}">{% trans "Move up" %}</button></li>


### PR DESCRIPTION
Alternative fix for #4304 as per @thibaudcolas's suggestion in https://github.com/wagtail/wagtail/pull/4304#pullrequestreview-97629789 - explicitly identify and count InlinePanel children using a `data-inline-panel-child` when enforcing the `max_num` attribute.