### PR TITLE
Fix: More informative error for invalid values passed to `|richtext`

### DIFF
--- a/wagtail/core/templatetags/wagtailcore_tags.py
+++ b/wagtail/core/templatetags/wagtailcore_tags.py
@@ -87,7 +87,11 @@ def richtext(value):
     elif value is None:
         html = ''
     else:
-        html = expand_db_html(value)
+        if isinstance(value,str) or isinstance(value,bytes):
+            html = expand_db_html(value)
+        else:
+            raise TypeError("'richtext' template filter received an invalid value; expected string or bytes type, got {value}.".format(type(value)))
+
 
     return mark_safe('<div class="rich-text">' + html + '</div>')
 

--- a/wagtail/core/templatetags/wagtailcore_tags.py
+++ b/wagtail/core/templatetags/wagtailcore_tags.py
@@ -90,7 +90,7 @@ def richtext(value):
         if isinstance(value,str) or isinstance(value,bytes):
             html = expand_db_html(value)
         else:
-            raise TypeError("'richtext' template filter received an invalid value; expected string or bytes type, got {value}.".format(type(value)))
+            raise TypeError("'richtext' template filter received an invalid value; expected string or bytes type, got {}.".format(type(value)))
 
 
     return mark_safe('<div class="rich-text">' + html + '</div>')


### PR DESCRIPTION
More informative error for invalid values passed to `|richtext`