### PR TITLE
Added before_move_page and after_move_page hooks to Editor page re-ordering (WIP)

### DIFF
--- a/wagtail/admin/views/pages.py
+++ b/wagtail/admin/views/pages.py
@@ -791,6 +791,11 @@ def set_page_position(request, page_to_move_id):
     if not parent_page.permissions_for_user(request.user).can_reorder_children():
         raise PermissionDenied
 
+    for fn in hooks.get_hooks('before_move_page'):
+        result = fn(request, page_to_move, parent_page)
+        if hasattr(result, 'status_code'):
+            return result
+
     if request.method == 'POST':
         # Get position parameter
         position = request.GET.get('position', None)
@@ -819,6 +824,11 @@ def set_page_position(request, page_to_move_id):
         else:
             # Move page to end
             page_to_move.move(parent_page, pos='last-child')
+
+        for fn in hooks.get_hooks('after_move_page'):
+            result = fn(request, page_to_move)
+            if hasattr(result, 'status_code'):
+                return result
 
     return HttpResponse('')
 


### PR DESCRIPTION
I've been using wagtail only a tiny number of hours so I am not expecting this PR to be accepted. I add it here in case the solution is as simple as I think it might be.

Pull request https://github.com/wagtail/wagtail/pull/4924 added `before_move_page` and `after_move_page` hooks to the Editor workflow. It is my (newbie) view that these should also be called when re-ordering sibling pages, not just when moving up and down the tree. If you agree, does my PR do enough to fix the problem, please?

If what I suggest here somehow "pollutes" `before_move_page` and `after_move_page`, maybe adding something like `before_reorder_page` and `after_reorder_page` would be preferable? Advice gratefully accepted.

- [x] Do the tests still pass? (http://docs.wagtail.io/en/latest/contributing/developing.html#testing)
- [x] Does the code comply with the style guide? (Run `make lint` from the Wagtail root)
- [ ] For Python changes: Have you added tests to cover the new/fixed behaviour? **I think existing tests already cover this. Happy to be wrong.**
- [ ] For front-end changes: Did you test on all of Wagtail’s supported browsers? **No FE changes**
