### PR TITLE
Prevent `invalid_image` from hiding Pillow errors

### DIFF
--- a/wagtail/images/fields.py
+++ b/wagtail/images/fields.py
@@ -34,7 +34,7 @@ class WagtailImageField(ImageField):
             }
 
         # Error messages
-        self.error_messages['invalid_image'] = _(
+        self.error_messages['invalid_image_extension'] = _(
             "Not a supported image format. Supported formats: %s."
         ) % SUPPORTED_FORMATS_TEXT
 
@@ -55,7 +55,7 @@ class WagtailImageField(ImageField):
         extension = os.path.splitext(f.name)[1].lower()[1:]
 
         if extension not in ALLOWED_EXTENSIONS:
-            raise ValidationError(self.error_messages['invalid_image'], code='invalid_image')
+            raise ValidationError(self.error_messages['invalid_image_extension'], code='invalid_image_extension')
 
         image_format = extension.upper()
         if image_format == 'JPG':

--- a/wagtail/images/tests/test_admin_views.py
+++ b/wagtail/images/tests/test_admin_views.py
@@ -765,7 +765,7 @@ class TestImageChooserUploadView(TestCase, WagtailTestUtils):
 
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, 'wagtailimages/chooser/chooser.html')
-        self.assertFormError(response, 'uploadform', 'file', "Not a supported image format. Supported formats: GIF, JPEG, PNG.")
+        self.assertFormError(response, 'uploadform', 'file', 'Upload a valid image. The file you uploaded was either not an image or a corrupted image.')
 
         # the action URL of the re-rendered form should include the select_format=true parameter
         # (NB the HTML in the response is embedded in a JS string, so need to escape accordingly)
@@ -957,7 +957,7 @@ class TestMultipleImageUploader(TestCase, WagtailTestUtils):
         self.assertIn('error_message', response_json)
         self.assertFalse(response_json['success'])
         self.assertEqual(
-            response_json['error_message'], "Not a supported image format. Supported formats: GIF, JPEG, PNG."
+            response_json['error_message'], 'Upload a valid image. The file you uploaded was either not an image or a corrupted image.'
         )
 
     def test_edit_get(self):

--- a/wagtail/images/views/multiple.py
+++ b/wagtail/images/views/multiple.py
@@ -100,7 +100,7 @@ def add(request):
         'help_text': form.fields['file'].help_text,
         'allowed_extensions': ALLOWED_EXTENSIONS,
         'error_max_file_size': form.fields['file'].error_messages['file_too_large_unknown_size'],
-        'error_accepted_file_types': form.fields['file'].error_messages['invalid_image'],
+        'error_accepted_file_types': form.fields['file'].error_messages['invalid_image_extension'],
         'collections': collections_to_choose,
     })
 


### PR DESCRIPTION
Prevent `invalid_image` from hiding Pillow errors

Because this code overrides the `invalid_image` error from Django (https://github.com/django/django/blob/846624ed0858aec0e51baebaa5b397e135c6d1dc/django/forms/fields.py#L640-L643) it hides errors from within Pillow/PIL.

Renaming it fixes the issue and shows the actual Pillow/PIP errors when uploading fails for some reason.

So instead of something useless like this:
![image](https://user-images.githubusercontent.com/270571/51145473-40809980-1854-11e9-866a-6ba400cc1645.png)

With this in the console:
```
[14/Jan/2019 22:01:34] "POST /admin/images/multiple/add/ HTTP/1.1" 200 103
```

I get this:
```
Traceback (most recent call last):
  File "django/core/handlers/exception.py", line 34, in inner
    response = get_response(request)
  File "django/core/handlers/base.py", line 126, in _get_response
    response = self.process_exception_by_middleware(e, request)
  File "django/core/handlers/base.py", line 124, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "django/views/decorators/cache.py", line 44, in _wrapped_view_func
    response = view_func(request, *args, **kwargs)
  File "wagtail/admin/urls/__init__.py", line 102, in wrapper
    return view_func(request, *args, **kwargs)
  File "wagtail/admin/decorators.py", line 34, in decorated_view
    return view_func(request, *args, **kwargs)
  File "wagtail/admin/utils.py", line 148, in wrapped_view_func
    return view_func(request, *args, **kwargs)
  File "django/views/decorators/vary.py", line 20, in inner_func
    response = func(*args, **kwargs)
  File "wagtail/images/views/multiple.py", line 66, in add
    if form.is_valid():
  File "django/forms/forms.py", line 185, in is_valid
    return self.is_bound and not self.errors
  File "django/forms/forms.py", line 180, in errors
    self.full_clean()
  File "django/forms/forms.py", line 381, in full_clean
    self._clean_fields()
  File "django/forms/forms.py", line 397, in _clean_fields
    value = field.clean(value, initial)
  File "django/forms/fields.py", line 584, in clean
    return super().clean(data)
  File "django/forms/fields.py", line 147, in clean
    value = self.to_python(value)
  File "wagtail/images/fields.py", line 87, in to_python
    f = super().to_python(data)
  File "django/forms/fields.py", line 639, in to_python
    raise RuntimeError('extension', exc)
RuntimeError: ('extension', SyntaxError("broken PNG file (incomplete checksum in b'IDAT')",))
Internal Server Error: /admin/images/multiple/add/
```