### PR TITLE
Tsquery fix

### DIFF
--- a/wagtail/contrib/postgres_search/backend.py
+++ b/wagtail/contrib/postgres_search/backend.py
@@ -228,7 +228,9 @@ class PostgresSearchQueryCompiler(BaseSearchQueryCompiler):
                 return self.get_search_field(sub_field_name, field.fields)
 
     def prepare_word(self, word):
-        return unidecode(word)
+        # remove backslash from string to prevent syntax error in tsquery
+        stripped_word = word.replace("\\", "") 
+        return unidecode(stripped_word)
 
     def build_tsquery_content(self, query, group=False):
         if isinstance(query, PlainText):

--- a/wagtail/contrib/postgres_search/backend.py
+++ b/wagtail/contrib/postgres_search/backend.py
@@ -228,9 +228,7 @@ class PostgresSearchQueryCompiler(BaseSearchQueryCompiler):
                 return self.get_search_field(sub_field_name, field.fields)
 
     def prepare_word(self, word):
-        # remove backslash from string to prevent syntax error in tsquery
-        stripped_word = word.replace("\\", "")
-        return unidecode(stripped_word)
+        return unidecode(word)
 
     def build_tsquery_content(self, query, group=False):
         if isinstance(query, PlainText):

--- a/wagtail/contrib/postgres_search/backend.py
+++ b/wagtail/contrib/postgres_search/backend.py
@@ -229,7 +229,7 @@ class PostgresSearchQueryCompiler(BaseSearchQueryCompiler):
 
     def prepare_word(self, word):
         # remove backslash from string to prevent syntax error in tsquery
-        stripped_word = word.replace("\\", "") 
+        stripped_word = word.replace("\\", "")
         return unidecode(stripped_word)
 
     def build_tsquery_content(self, query, group=False):

--- a/wagtail/contrib/postgres_search/models.py
+++ b/wagtail/contrib/postgres_search/models.py
@@ -18,7 +18,8 @@ class RawSearchQuery(SearchQuery):
         super().__init__(*args, **kwargs)
 
     def as_sql(self, compiler, connection):
-        params = [v.replace("'", "''") for v in self.value]
+        # escape apostrophe and backslash
+        params = [v.replace("'", "''").replace("\\", "\\\\") for v in self.value]
         if self.config:
             config_sql, config_params = compiler.compile(self.config)
             template = "to_tsquery(%s::regconfig, '%s')" % (config_sql, self.format)

--- a/wagtail/contrib/postgres_search/tests/test_backend.py
+++ b/wagtail/contrib/postgres_search/tests/test_backend.py
@@ -107,6 +107,11 @@ class TestPostgresSearchBackend(BackendTests, TestCase):
                                             models.Book)
         self.assertUnsortedListEqual([r.title for r in results], [])
 
+        # Backslashes should be escaped inside each tsquery term.
+        results = self.backend.autocomplete("backslash\\",
+                                            models.Book)
+        self.assertUnsortedListEqual([r.title for r in results], [])
+
         # Now suffixes.
         results = self.backend.autocomplete("Something:B", models.Book)
         self.assertUnsortedListEqual([r.title for r in results], [])


### PR DESCRIPTION
* Do the tests still pass? yes
* Does the code comply with the style guide? yes
* For Python changes: Yes, but those tests seem to be skipped for some reason.
* For front-end changes: N/A
* For new features: N/A

A fix for [this](https://github.com/wagtail/wagtail/issues/4993) issue where backslashes break the postgres search.