### PR TITLE
Supporting proxy models throughout Wagtail [WIP]

### DIFF
--- a/wagtail/admin/utils.py
+++ b/wagtail/admin/utils.py
@@ -5,7 +5,6 @@ import pytz
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import PermissionDenied
 from django.core.mail import get_connection
@@ -327,49 +326,3 @@ def user_has_any_page_permission(user):
 
     # No luck! This user can not do anything with pages.
     return False
-
-
-def get_content_type_for_model(model):
-    """
-    A wrapper for ContentType.objects.get_for_model() with some special
-    handling for proxy models to ensure a model-specific ContentType is
-    returned, instead of that of the concrete model.
-    """
-    opts = model._meta
-    if opts.proxy:
-        try:
-            return ContentType.objects.get_by_natural_key(opts.app_label, opts.model_name)
-        except ContentType.DoesNotExist:
-            return create_content_type_for_proxy_model(model)
-    return ContentType.objects.get_for_model(model, for_concrete_model=False)
-
-
-def create_content_type_for_proxy_model(model):
-    """
-    Creates a ContentType object for the supplied proxy model, and updates
-    any Permission objects to be associated with the newly created ContentType
-    instead of the concrete model ContentType.
-    """
-    opts = model._meta
-    assert opts.proxy
-
-    # Using get_or_create for race condition handling
-    proxy_ctype, created = ContentType.objects.get_or_create(
-        app_label=opts.app_label, model=opts.model_name
-    )
-    if created:
-        permission_codenames = [
-            '%s_%s' % (action, opts.model_name)
-            for action in opts.default_permissions
-        ]
-        permissions_query = Q(codename__in=permission_codenames)
-        for codename, name in opts.permissions:
-            permissions_query = permissions_query | Q(codename=codename, name=name)
-
-        concrete_ctype = ContentType.objects.get_for_model(model, for_concrete_model=True)
-
-        Permission.objects.filter(
-            permissions_query, content_type=concrete_ctype
-        ).update(content_type=proxy_ctype)
-
-    return proxy_ctype

--- a/wagtail/admin/utils.py
+++ b/wagtail/admin/utils.py
@@ -5,6 +5,7 @@ import pytz
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import PermissionDenied
 from django.core.mail import get_connection
@@ -326,3 +327,49 @@ def user_has_any_page_permission(user):
 
     # No luck! This user can not do anything with pages.
     return False
+
+
+def get_content_type_for_model(model):
+    """
+    A wrapper for ContentType.objects.get_for_model() with some special
+    handling for proxy models to ensure a model-specific ContentType is
+    returned, instead of that of the concrete model.
+    """
+    opts = model._meta
+    if opts.proxy:
+        try:
+            return ContentType.objects.get_by_natural_key(opts.app_label, opts.model_name)
+        except ContentType.DoesNotExist:
+            return create_content_type_for_proxy_model(model)
+    return ContentType.objects.get_for_model(model, for_concrete_model=False)
+
+
+def create_content_type_for_proxy_model(model):
+    """
+    Creates a ContentType object for the supplied proxy model, and updates
+    any Permission objects to be associated with the newly created ContentType
+    instead of the concrete model ContentType.
+    """
+    opts = model._meta
+    assert opts.proxy
+
+    # Using get_or_create for race condition handling
+    proxy_ctype, created = ContentType.objects.get_or_create(
+        app_label=opts.app_label, model=opts.model_name
+    )
+    if created:
+        permission_codenames = [
+            '%s_%s' % (action, opts.model_name)
+            for action in opts.default_permissions
+        ]
+        permissions_query = Q(codename__in=permission_codenames)
+        for codename, name in opts.permissions:
+            permissions_query = permissions_query | Q(codename=codename, name=name)
+
+        concrete_ctype = ContentType.objects.get_for_model(model, for_concrete_model=True)
+
+        Permission.objects.filter(
+            permissions_query, content_type=concrete_ctype
+        ).update(content_type=proxy_ctype)
+
+    return proxy_ctype

--- a/wagtail/admin/views/pages.py
+++ b/wagtail/admin/views/pages.py
@@ -26,6 +26,7 @@ from wagtail.admin.utils import send_notification, user_has_any_page_permission,
 from wagtail.core import hooks
 from wagtail.core.models import Page, PageRevision, UserPagePermissionsProxy
 from wagtail.search.query import MATCH_ALL
+from wagtail.utils import contenttypes
 from wagtail.utils.pagination import paginate
 
 
@@ -317,7 +318,7 @@ def edit(request, page_id):
     page = real_page_record.get_latest_revision_as_page()
     parent = page.get_parent()
 
-    content_type = ContentType.objects.get_for_model(page)
+    content_type = contenttypes.get_for_model(page)
     page_class = content_type.model_class()
 
     page_perms = page.permissions_for_user(request.user)
@@ -1123,7 +1124,7 @@ def revisions_revert(request, page_id, revision_id):
     revision = get_object_or_404(page.revisions, id=revision_id)
     revision_page = revision.as_page_object()
 
-    content_type = ContentType.objects.get_for_model(page)
+    content_type = contenttypes.get_for_model(page)
     page_class = content_type.model_class()
 
     edit_handler = page_class.get_edit_handler()

--- a/wagtail/contrib/forms/utils.py
+++ b/wagtail/contrib/forms/utils.py
@@ -1,7 +1,7 @@
-from django.contrib.contenttypes.models import ContentType
-
 from wagtail.core import hooks
 from wagtail.core.models import UserPagePermissionsProxy, get_page_models
+from wagtail.utils import contenttypes
+
 
 _FORM_CONTENT_TYPES = None
 
@@ -16,7 +16,7 @@ def get_form_types():
         ]
 
         _FORM_CONTENT_TYPES = list(
-            ContentType.objects.get_for_models(*form_models).values()
+            contenttypes.get_for_models(*form_models).values()
         )
     return _FORM_CONTENT_TYPES
 

--- a/wagtail/contrib/modeladmin/helpers/permission.py
+++ b/wagtail/contrib/modeladmin/helpers/permission.py
@@ -1,6 +1,5 @@
 from django.contrib.auth import get_permission_codename
 from django.contrib.auth.models import Permission
-from django.contrib.contenttypes.models import ContentType
 
 from wagtail.core.models import Page, UserPagePermissionsProxy
 from wagtail.utils import contenttypes

--- a/wagtail/contrib/postgres_search/utils.py
+++ b/wagtail/contrib/postgres_search/utils.py
@@ -30,28 +30,30 @@ def get_descendant_models(model):
 
 def get_content_type_pk(model):
     # We import it locally because this file is loaded before apps are ready.
-    from django.contrib.contenttypes.models import ContentType
-    return ContentType.objects.get_for_model(model).pk
+    from wagtail.utils import contenttypes
+    return contenttypes.get_for_model(model).pk
 
 
 def get_ancestors_content_types_pks(model):
     """
     Returns content types ids for the ancestors of this model, excluding it.
     """
-    from django.contrib.contenttypes.models import ContentType
-    return [ct.pk for ct in
-            ContentType.objects.get_for_models(*model._meta.get_parent_list())
-            .values()]
+    from wagtail.utils import contenttypes
+    return [
+        ct.pk for ct in
+        contenttypes.get_for_models(*model._meta.get_parent_list()).values()
+    ]
 
 
 def get_descendants_content_types_pks(model):
     """
     Returns content types ids for the descendants of this model, including it.
     """
-    from django.contrib.contenttypes.models import ContentType
-    return [ct.pk for ct in
-            ContentType.objects.get_for_models(*get_descendant_models(model))
-            .values()]
+    from wagtail.utils import contenttypes
+    return [
+        ct.pk for ct in
+        contenttypes.get_for_models(*get_descendant_models(model)).values()
+    ]
 
 
 def get_search_fields(search_fields):

--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -31,6 +31,7 @@ from wagtail.core.sites import get_site_for_hostname
 from wagtail.core.url_routing import RouteResult
 from wagtail.core.utils import WAGTAIL_APPEND_SLASH, camelcase_to_underscore, resolve_model_string
 from wagtail.search import index
+from wagtail.utils import contenttypes
 
 logger = logging.getLogger('wagtail.core')
 
@@ -863,7 +864,7 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
 
     @classmethod
     def get_indexed_objects(cls):
-        content_type = ContentType.objects.get_for_model(cls)
+        content_type = contenttypes.get_for_model(cls)
         return super(Page, cls).get_indexed_objects().filter(content_type=content_type)
 
     def get_indexed_instance(self):

--- a/wagtail/core/permission_policies/base.py
+++ b/wagtail/core/permission_policies/base.py
@@ -1,9 +1,10 @@
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Permission
-from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import FieldDoesNotExist, ImproperlyConfigured
 from django.db.models import Q
 from django.utils.functional import cached_property
+
+from wagtail.utils import contenttypes
 
 
 class BasePermissionPolicy:
@@ -178,7 +179,7 @@ class BaseDjangoAuthPermissionPolicy(BasePermissionPolicy):
 
     @cached_property
     def _content_type(self):
-        return ContentType.objects.get_for_model(self.auth_model)
+        return contenttypes.get_for_model(self.auth_model)
 
     def _get_permission_name(self, action):
         """

--- a/wagtail/core/query.py
+++ b/wagtail/core/query.py
@@ -9,6 +9,7 @@ from django.db.models.query import BaseIterable
 from treebeard.mp_tree import MP_NodeQuerySet
 
 from wagtail.search.queryset import SearchableQuerySetMixin
+from wagtail.utils import contenttypes
 
 
 class TreeQuerySet(MP_NodeQuerySet):
@@ -173,7 +174,7 @@ class PageQuerySet(SearchableQuerySetMixin, TreeQuerySet):
         return self.exclude(self.page_q(other))
 
     def type_q(self, klass):
-        content_types = ContentType.objects.get_for_models(*[
+        content_types = contenttypes.get_for_models(*[
             model for model in apps.get_models()
             if issubclass(model, klass)
         ]).values()
@@ -194,7 +195,7 @@ class PageQuerySet(SearchableQuerySetMixin, TreeQuerySet):
         return self.exclude(self.type_q(model))
 
     def exact_type_q(self, klass):
-        return Q(content_type=ContentType.objects.get_for_model(klass))
+        return Q(content_type=contenttypes.get_for_model(klass))
 
     def exact_type(self, model):
         """

--- a/wagtail/core/tests/test_collection_permission_policies.py
+++ b/wagtail/core/tests/test_collection_permission_policies.py
@@ -1,6 +1,5 @@
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AnonymousUser, Group, Permission
-from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase
 
 from wagtail.core.models import Collection, GroupCollectionPermission
@@ -8,12 +7,13 @@ from wagtail.core.permission_policies.collections import (
     CollectionOwnershipPermissionPolicy, CollectionPermissionPolicy)
 from wagtail.core.tests.test_permission_policies import PermissionPolicyTestUtils
 from wagtail.documents.models import Document
+from wagtail.utils import contenttypes
 
 
 class PermissionPolicyTestCase(PermissionPolicyTestUtils, TestCase):
     def setUp(self):
         # Permissions
-        document_content_type = ContentType.objects.get_for_model(Document)
+        document_content_type = contenttypes.get_for_model(Document)
         add_doc_permission = Permission.objects.get(
             content_type=document_content_type, codename='add_document'
         )

--- a/wagtail/core/tests/test_page_model.py
+++ b/wagtail/core/tests/test_page_model.py
@@ -4,7 +4,6 @@ import json
 import pytz
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AnonymousUser
-from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 from django.http import Http404, HttpRequest
 from django.test import Client, TestCase
@@ -20,10 +19,7 @@ from wagtail.tests.testapp.models import (
     MTIChildPage, MyCustomPage, OneToOnePage, PageWithExcludedCopyField, SimplePage,
     SingleEventPage, SingletonPage, StandardIndex, TaggedPage)
 from wagtail.tests.utils import WagtailTestUtils
-
-
-def get_ct(model):
-    return ContentType.objects.get_for_model(model)
+from wagtail.utils import contenttypes
 
 
 class TestValidation(TestCase):
@@ -1327,7 +1323,7 @@ class TestIssue2024(TestCase):
         event_index = Page.objects.get(url_path='/home/events/')
 
         # Check that the content_type changed to Page
-        self.assertEqual(event_index.content_type, ContentType.objects.get_for_model(Page))
+        self.assertEqual(event_index.content_type, contenttypes.get_for_model(Page))
 
 
 @override_settings(ALLOWED_HOSTS=['localhost'])

--- a/wagtail/core/tests/test_permission_policies.py
+++ b/wagtail/core/tests/test_permission_policies.py
@@ -1,6 +1,5 @@
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AnonymousUser, Group, Permission
-from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase
 
 from wagtail.core.permission_policies import (
@@ -8,6 +7,7 @@ from wagtail.core.permission_policies import (
     OwnershipPermissionPolicy)
 from wagtail.images.models import Image
 from wagtail.images.tests.utils import get_test_image_file
+from wagtail.utils import contenttypes
 
 
 class PermissionPolicyTestUtils:
@@ -70,7 +70,7 @@ class PermissionPolicyTestUtils:
 class PermissionPolicyTestCase(PermissionPolicyTestUtils, TestCase):
     def setUp(self):
         # Permissions
-        image_content_type = ContentType.objects.get_for_model(Image)
+        image_content_type = contenttypes.get_for_model(Image)
         add_image_permission = Permission.objects.get(
             content_type=image_content_type, codename='add_image'
         )

--- a/wagtail/snippets/wagtail_hooks.py
+++ b/wagtail/snippets/wagtail_hooks.py
@@ -1,6 +1,5 @@
 from django.conf.urls import include, url
 from django.contrib.auth.models import Permission
-from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
 from django.utils.html import format_html
 from django.utils.translation import ugettext_lazy as _
@@ -10,6 +9,7 @@ from wagtail.core import hooks
 from wagtail.snippets import urls
 from wagtail.snippets.models import get_snippet_models
 from wagtail.snippets.permissions import user_can_edit_snippets
+from wagtail.utils import contenttypes
 
 
 @hooks.register('register_admin_urls')
@@ -46,5 +46,5 @@ def editor_js():
 
 @hooks.register('register_permissions')
 def register_permissions():
-    content_types = ContentType.objects.get_for_models(*get_snippet_models()).values()
+    content_types = contenttypes.get_for_models(*get_snippet_models()).values()
     return Permission.objects.filter(content_type__in=content_types)

--- a/wagtail/utils/contenttypes.py
+++ b/wagtail/utils/contenttypes.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+
+from django.contrib.auth.models import Permission
+from django.contrib.contenttypes.models import ContentType
+from django.db.models import Q
+
+
+def get_content_type_for_model(model):
+    """
+    A wrapper for ContentType.objects.get_for_model() with some special
+    handling for proxy models to ensure a model-specific ContentType is
+    returned, instead of that of the concrete model.
+    """
+    opts = model._meta
+    if opts.proxy:
+        try:
+            return ContentType.objects.get_by_natural_key(opts.app_label, opts.model_name)
+        except ContentType.DoesNotExist:
+            return create_content_type_for_proxy_model(model)
+    return ContentType.objects.get_for_model(model, for_concrete_model=False)
+
+
+def create_content_type_for_proxy_model(model):
+    """
+    Creates a ContentType object for the supplied proxy model, and updates
+    any Permission objects to be associated with the newly created ContentType
+    instead of the concrete model ContentType.
+    """
+    opts = model._meta
+    assert opts.proxy
+
+    # Using get_or_create for race condition handling
+    proxy_ctype, created = ContentType.objects.get_or_create(
+        app_label=opts.app_label, model=opts.model_name
+    )
+    if created:
+        permission_codenames = [
+            '%s_%s' % (action, opts.model_name)
+            for action in opts.default_permissions
+        ]
+        permissions_query = Q(codename__in=permission_codenames)
+        for codename, name in opts.permissions:
+            permissions_query = permissions_query | Q(codename=codename, name=name)
+
+        concrete_ctype = ContentType.objects.get_for_model(model, for_concrete_model=True)
+
+        Permission.objects.filter(
+            permissions_query, content_type=concrete_ctype
+        ).update(content_type=proxy_ctype)
+
+    return proxy_ctype

--- a/wagtail/utils/contenttypes.py
+++ b/wagtail/utils/contenttypes.py
@@ -4,6 +4,20 @@ from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
 from django.db.models import Q
 
+"""
+This module is a temporary measure to help support proxy models throughout
+Wagtail, by ensuring each has it's own ``ContentType``, and that ``Permission``
+objects are correctly associated with any newly created ``ContentType`` objects
+(rather than that of the concrete model).
+
+Once Wagtail reaches a point where it supports only Django versions >= 2.2,
+this module should be removed, and the wider project updated to use the
+following:
+
+- ``ContentType.objects.get_for_model(model, for_concrete_model=False)``
+- ``ContentType.objects.get_for_models(*models, for_concrete_models=False)``
+"""
+
 manager = ContentType.objects
 db = ContentType.objects.db
 
@@ -60,7 +74,7 @@ def create_for_model(model):
     Creates and returns a ``ContentType`` object for the provided ``model``. If
     the model happens to be a proxy model, any related ``Permission`` objects
     will be correctly associated with the new object, matching the approach
-    taken by Django itself from v2.2.
+    taken by Django itself from 2.2.
     """
     opts = model._meta
     # get_or_create() used her to handle potential race conditions
@@ -68,18 +82,21 @@ def create_for_model(model):
         app_label=opts.app_label, model=opts.model_name
     )
     if created and opts.proxy and django.VERSION < (2, 2):
-        permission_codenames = [
+        # To avoid any consistent/compatibilty issues, the approach below
+        # matches that taken by Django in `0011_update_proxy_permissions.py` in
+        # https://github.com/django/django/commit/181fb60159e54d442d3610f4afba6f066a6dac05,
+        default_permissions_codenames = [
             '%s_%s' % (action, opts.model_name)
             for action in opts.default_permissions
         ]
-        permissions_query = Q(codename__in=permission_codenames)
+        permissions_query = Q(codename__in=default_permissions_codenames)
         for codename, name in opts.permissions:
-            permissions_query |= Q(codename=codename, name=name)
+            permissions_query = permissions_query | Q(codename=codename, name=name)
 
-        concrete_ctype = manager.get_for_model(model, for_concrete_model=True)
+        concrete_content_type = manager.get_for_model(model, for_concrete_model=True)
 
         Permission.objects.filter(
-            permissions_query, content_type=concrete_ctype
+            permissions_query, content_type=concrete_content_type
         ).update(content_type=content_type)
 
     manager._add_to_cache(db, content_type)

--- a/wagtail/utils/contenttypes.py
+++ b/wagtail/utils/contenttypes.py
@@ -4,58 +4,83 @@ from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
 from django.db.models import Q
 
+manager = ContentType.objects
+db = ContentType.objects.db
 
-def get_content_type_for_model(model):
+
+def get_for_model(model):
     """
-    A wrapper for ContentType.objects.get_for_model() that ensures
-    model-specific ContentType objects are returned for proxy models, instead
-    of that of the concrete model, and that model permissions are correctly
-    associated with any newly created objects.
+    An alternative to ContentType.objects.get_for_model() that ensures
+    model-specific content types are always returned for proxy models.
     """
     opts = model._meta
-    if opts.proxy:
+    try:
+        # get_by_natural_key allows efficient retrieval without creating
+        ct = manager.get_by_natural_key(opts.app_label, opts.model_name)
+    except ContentType.DoesNotExist:
+        return create_for_model(model)
+    else:
+        return ct
+
+
+def get_for_models(*models):
+    """
+    An alternative to ContentType.objects.get_for_models() that ensures
+    model-specific content types are always returned for proxy models.
+    """
+    results = {}
+    # Mapping of opts:model for any objects not found in the cache
+    not_found = {}
+    # This will be used to query the db for objects not found in the cache
+    contenttypes_q = Q()
+
+    for model in set(models):
+        opts = model._meta
         try:
-            # get_by_natural_key allows efficient retrieval without creating
-            return ContentType.objects.get_by_natural_key(opts.app_label, opts.model_name)
-        except ContentType.DoesNotExist:
-            if django.VERSION >= (2, 3):  # version could change here
-                raise ContentType.DoesNotExist(
-                    "ContentType could not be found for model '{app_label}.{model_name}'. Try "
-                    "runing makemigrations and migrate for the '{app_label}' app, then try again."
-                    .format(app_label=opts.app_label, model_name=opts.model_name)
-                )
-            return create_content_type_for_proxy_model(model)
-    return ContentType.objects.get_for_model(model, for_concrete_model=False)
+            ct = manager._get_from_cache(opts)
+        except KeyError:
+            not_found[opts] = model
+            contenttypes_q |= Q(app_label=opts.app_label, model=opts.model_name)
+        else:
+            results[model] = ct
+    if not_found:
+        # Lookup required content types from the DB.
+        for ct in manager.all().filter(contenttypes_q):
+            model = not_found.pop(ct.model_class()._meta)
+            manager._add_to_cache(db, ct)
+            results[model] = ct
+    # Create content types that weren't in the cache or DB.
+    for opts, model in not_found.items():
+        results[model] = create_for_model(model)
+    return results
 
 
-def create_content_type_for_proxy_model(model):
+def create_for_model(model):
     """
-    Creates a ContentType object for the supplied proxy model, and updates
-    any Permission objects to be associated with the newly created ContentType
-    instead of the ContentType for the concrete model.
+    Creates and returns a ``ContentType`` object for the provided ``model``. If
+    the model happens to be a proxy model, any related ``Permission`` objects
+    will be correctly associated with the new object, matching the approach
+    taken by Django itself from v2.2.
     """
     opts = model._meta
-    assert opts.proxy
-
-    # Using get_or_create to handle race conditions
-    proxy_ctype, created = ContentType.objects.get_or_create(
+    # get_or_create() used her to handle potential race conditions
+    content_type, created = manager.get_or_create(
         app_label=opts.app_label, model=opts.model_name
     )
-    if created:
+    if created and opts.proxy and django.VERSION < (2, 2):
         permission_codenames = [
             '%s_%s' % (action, opts.model_name)
             for action in opts.default_permissions
         ]
         permissions_query = Q(codename__in=permission_codenames)
         for codename, name in opts.permissions:
-            permissions_query = permissions_query | Q(codename=codename, name=name)
+            permissions_query |= Q(codename=codename, name=name)
 
-        concrete_ctype = ContentType.objects.get_for_model(model, for_concrete_model=True)
+        concrete_ctype = manager.get_for_model(model, for_concrete_model=True)
 
         Permission.objects.filter(
             permissions_query, content_type=concrete_ctype
-        ).update(content_type=proxy_ctype)
+        ).update(content_type=content_type)
 
-        # cache the new ContentType for speedier future lookups
-        ContentType.objects._add_to_cache(ContentType.objects.db, proxy_ctype)
-    return proxy_ctype
+    manager._add_to_cache(db, content_type)
+    return content_type

--- a/wagtail/utils/contenttypes.py
+++ b/wagtail/utils/contenttypes.py
@@ -82,7 +82,7 @@ def create_for_model(model):
         app_label=opts.app_label, model=opts.model_name
     )
     if created and opts.proxy and django.VERSION < (2, 2):
-        # To avoid any consistent/compatibilty issues, the approach below
+        # To avoid any consistency/compatibilty issues, the approach below
         # matches that taken by Django in `0011_update_proxy_permissions.py` in
         # https://github.com/django/django/commit/181fb60159e54d442d3610f4afba6f066a6dac05,
         default_permissions_codenames = [

--- a/wagtail/utils/contenttypes.py
+++ b/wagtail/utils/contenttypes.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-
+import django
 from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
 from django.db.models import Q
@@ -7,15 +7,23 @@ from django.db.models import Q
 
 def get_content_type_for_model(model):
     """
-    A wrapper for ContentType.objects.get_for_model() with some special
-    handling for proxy models to ensure a model-specific ContentType is
-    returned, instead of that of the concrete model.
+    A wrapper for ContentType.objects.get_for_model() that ensures
+    model-specific ContentType objects are returned for proxy models, instead
+    of that of the concrete model, and that model permissions are correctly
+    associated with any newly created objects.
     """
     opts = model._meta
     if opts.proxy:
         try:
+            # get_by_natural_key allows efficient retrieval without creating
             return ContentType.objects.get_by_natural_key(opts.app_label, opts.model_name)
         except ContentType.DoesNotExist:
+            if django.VERSION >= (2, 3):  # version could change here
+                raise ContentType.DoesNotExist(
+                    "ContentType could not be found for model '{app_label}.{model_name}'. Try "
+                    "runing makemigrations and migrate for the '{app_label}' app, then try again."
+                    .format(app_label=opts.app_label, model_name=opts.model_name)
+                )
             return create_content_type_for_proxy_model(model)
     return ContentType.objects.get_for_model(model, for_concrete_model=False)
 
@@ -24,12 +32,12 @@ def create_content_type_for_proxy_model(model):
     """
     Creates a ContentType object for the supplied proxy model, and updates
     any Permission objects to be associated with the newly created ContentType
-    instead of the concrete model ContentType.
+    instead of the ContentType for the concrete model.
     """
     opts = model._meta
     assert opts.proxy
 
-    # Using get_or_create for race condition handling
+    # Using get_or_create to handle race conditions
     proxy_ctype, created = ContentType.objects.get_or_create(
         app_label=opts.app_label, model=opts.model_name
     )
@@ -48,4 +56,6 @@ def create_content_type_for_proxy_model(model):
             permissions_query, content_type=concrete_ctype
         ).update(content_type=proxy_ctype)
 
+        # cache the new ContentType for speedier future lookups
+        ContentType.objects._add_to_cache(ContentType.objects.db, proxy_ctype)
     return proxy_ctype


### PR DESCRIPTION
Proposed implementation for #4973

The new `wagtail/utils/contenttypes.py` module is where you should direct most attention. Everything else is basically switching out every use of `ContentType.objects.get_for_model()` and `ContentType.objects.get_for_models()` to use the equivalent methods from the new module instead (ensuring a consistent approach throughout).

Still lots to do in terms of testing, but posting up early to start collecting feedback.

To do list:
- [ ] More manual testing
- [ ] Add unit tests for `wagtail.utils.contenttypes.get_for_model()`
- [ ] Add unit tests for `wagtail.utils.contenttypes.get_for_models()`
- [ ] Update documentation to inform users of backwards incompatible changes (`ContentType` and `Permission` changes for proxy models)

## About the changes

Functionally speaking, the new methods in `wagtail/utils/contenttypes.py` work in a very similar way to the equivalent methods on `ContentTypeManager`, and utilise the manager's built-in cache to provide faster look-ups after the first time. Developers going via `ContentTypeManager` directly will also benefit from that caching, because the cache is shared.

The 2 big differences are:
 
1. The complication of `for_concrete_model`/`for_concrete_models` method arguments is removed, because (within Wagtail) we always want to identify specific ContentTypes for models, regardless of whether they are a proxy model or not (and regardless of Django version). 
2. When a `ContentType` isn't found for a model, and a new object is created (which is something the `ContentTypeManager` methods do also); For proxy models, a little extra work is done to ensure related `Permission` objects are correctly associated with the new `ContentType` (the part that was missing from #1736). From Django 2.2, this part is taken care of automatically at migration time, so we toggle this behaviour based on Django version, so as not to confuse things.

## Known limitations / issues

The following would only affect developers that are using proxy models in their Wagtail project already AND either:

1. Have custom code that relies on `Permission` objects remaining associated with the `ContentType` of the concrete model (e.g. they identify model permissions by using `ContentType.objects.get_for_model()`) [1]
2. Have created `ContentType` objects for proxy models themselves, but not reallocated the `Permission` objects [2]
3. Are using the Django admin area in addition to the Wagtail one, have Django < 2.2 installed, and proxy models are administered via the Django admin [3]

[1] Because our code only works on proxy models registered with Wagtail (rather than affecting all models) this might make identifying `Permission` and `ContentType` objects tricky, due to inconsistency.

[2] This could have been intentional, or an unintended result of calling `ContentType.objects.get_for_model(for_concrete_model=False)`. In these cases, the existing `ContentType` would be picked up and used as is, without the `Permission` reallocation logic being triggered.

[3] As yet unclear about the affect this this would have. The permission reallocation logic would leave existing `User` -> `Permission` associations in-tact, but I think the Django admin might not pick up the new `ContentType` objects in some places? @arthurio - can you perhaps share some light on this one? 