### PR TITLE
Ignore extra end tags in contentstate converter

### DIFF
--- a/wagtail/admin/rich_text/converters/html_to_contentstate.py
+++ b/wagtail/admin/rich_text/converters/html_to_contentstate.py
@@ -306,6 +306,8 @@ class HtmlToContentStateHandler(HTMLParser):
             element_handler.handle_starttag(name, attrs, self.state, self.contentstate)
 
     def handle_endtag(self, name):
+        if not self.open_elements:
+            return  # avoid a pop from an empty list if we have an extra end tag
         expected_name, element_handler = self.open_elements.pop()
         assert name == expected_name, "Unmatched tags: expected %s, got %s" % (expected_name, name)
         if element_handler:

--- a/wagtail/admin/tests/test_contentstate.py
+++ b/wagtail/admin/tests/test_contentstate.py
@@ -753,3 +753,37 @@ class TestHtmlToContentState(TestCase):
                 {'inlineStyleRanges': [], 'text': 'Arthur "two sheds" Jackson <the third> & his wife', 'depth': 0, 'type': 'unstyled', 'key': '00000', 'entityRanges': []},
             ]
         })
+
+    def test_extra_end_tag_before(self):
+        converter = ContentstateConverter(features=[])
+        result = json.loads(converter.from_database_format(
+            '''
+            </p>
+            <p>Before</p>
+            '''
+        ))
+        # The leading </p> tag should be ignored instead of blowing up with a
+        # pop from empty list error
+        self.assertContentStateEqual(result, {
+            'entityMap': {},
+            'blocks': [
+                {'inlineStyleRanges': [], 'text': 'Before', 'depth': 0, 'type': 'unstyled', 'key': '00000', 'entityRanges': []},
+            ]
+        })
+
+    def test_extra_end_tag_after(self):
+        converter = ContentstateConverter(features=[])
+        result = json.loads(converter.from_database_format(
+            '''
+            <p>After</p>
+            </p>
+            '''
+        ))
+        # The tailing </p> tag should be ignored instead of blowing up with a
+        # pop from empty list error
+        self.assertContentStateEqual(result, {
+            'entityMap': {},
+            'blocks': [
+                {'inlineStyleRanges': [], 'text': 'After', 'depth': 0, 'type': 'unstyled', 'key': '00000', 'entityRanges': []},
+            ]
+        })


### PR DESCRIPTION
This adds a check if an extra end tag exists (ex if importing/migrating data from other platforms) and avoids a "pop from empty list" error when this is the case.  

<hr/>

Thanks for contributing to Wagtail! 🎉

Before submitting, please review the contributor guidelines <http://docs.wagtail.io/en/latest/contributing/index.html> and check the following:

* Do the tests still pass? (http://docs.wagtail.io/en/latest/contributing/developing.html#testing) YES
* Does the code comply with the style guide? (Run `make lint` from the Wagtail root) YES
* For Python changes: Have you added tests to cover the new/fixed behaviour? YES
* For front-end changes: Did you test on all of Wagtail’s supported browsers? **Please list the exact versions you tested**. N/A
* For new features: Has the documentation been updated accordingly? N/A
