### PR TITLE
Removing confirmation of publishing from documentation

### DIFF
--- a/docs/editor_manual/new_pages/previewing_and_submitting_for_moderation.rst
+++ b/docs/editor_manual/new_pages/previewing_and_submitting_for_moderation.rst
@@ -6,7 +6,7 @@ The Save/Preview/Submit for moderation menu is always present at the bottom of t
 * **Save draft:** Saves your current changes but doesn't submit the page for moderation and so won’t be published. (all roles)
 * **Submit for moderation:** Saves your current changes and submits the page for moderation. A moderator will be notified and they will then either publish or reject the page. (all roles)
 * **Preview:** Opens a new window displaying the page as it would look if published, but does not save your changes or submit the page for moderation. (all roles)
-* **Publish/Unpublish:** Clicking either the *Publish* or *Unpublish* buttons will take you to a confirmation screen asking you to confirm that you wish to publish or unpublish this page. If a page is published it will be accessible from its specific URL and will also be displayed in site search results. (moderators and administrators only)
+* **Publish/Unpublish:** Clicking the *Publish* button will publish this page. Clicking *Unpublish* button will take you to a confirmation screen asking you to confirm that you wish to unpublish this page. If a page is published it will be accessible from its specific URL and will also be displayed in site search results. (moderators and administrators only)
 * **Delete:** Clicking this button will take you to a confirmation screen asking you to confirm that you wish to delete the current page. Be sure that this is actually what you want to do, as deleted pages are not recoverable. In many situations simply unpublishing the page will be enough. (moderators and administrators only)
 
 .. image:: ../../_static/images/screen13_publish_menu.png


### PR DESCRIPTION
Fixes #5000. I noticed that it asks for confirmation while unpublishing and ignores it while publishing.