### PR TITLE
'Parent' link in page chooser search should not navigate away

### DIFF
--- a/wagtail/admin/static_src/wagtailadmin/js/page-chooser-modal.js
+++ b/wagtail/admin/static_src/wagtailadmin/js/page-chooser-modal.js
@@ -69,6 +69,11 @@ PAGE_CHOOSER_MODAL_ONLOAD_HANDLERS = {
                 $('.page-results', modal.body).load(this.href, ajaxifySearchResults);
                 return false;
             });
+            /* Set up parent navigation links (.navigate-parent) to open in the modal */
+            $('.page-results a.navigate-parent', modal.body).on('click',function() {
+                modal.loadUrl(this.href);
+                return false;
+            });
         }
 
         function ajaxifyBrowseResults() {

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_list.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_list.html
@@ -55,13 +55,15 @@
                         {% endblock %}
                     </td>
                     {% if show_parent %}
-                        {% with page.get_parent as parent %}
                             <td class="parent" valign="top">
-                                {% if parent %}
-                                    <a href="{% url 'wagtailadmin_explore' parent.id %}">{{ parent.get_admin_display_title }}</a>
-                                {% endif %}
+                                {% block page_parent_page_title %}
+                                    {% with page.get_parent as parent %}
+                                        {% if parent %}
+                                            <a href="{% url 'wagtailadmin_explore' parent.id %}">{{ parent.get_admin_display_title }}</a>
+                                        {% endif %}
+                                    {% endwith %}
+                                {% endblock %}
                             </td>
-                        {% endwith %}
                     {% endif %}
                     <td class="updated" valign="top">{% if page.latest_revision_created_at %}<div class="human-readable-date" title="{{ page.latest_revision_created_at|date:"d M Y H:i" }}">{% blocktrans with time_period=page.latest_revision_created_at|timesince %}{{ time_period }} ago{% endblocktrans %}</div>{% endif %}</td>
                     <td class="type" valign="top">{{ page.content_type.model_class.get_verbose_name }}</td>

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_list_choose.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_list_choose.html
@@ -33,6 +33,10 @@
     {% include "wagtailadmin/pages/listing/_page_title_choose.html" with page=page %}
 {% endblock %}
 
+{% block page_parent_page_title %}
+        {% include "wagtailadmin/pages/listing/_page_parent_page_title_choose.html" with page=page %}
+{% endblock %}
+
 {% block page_navigation %}
     {% include "wagtailadmin/pages/listing/_navigation_choose.html" %}
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_page_parent_page_title_choose.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_page_parent_page_title_choose.html
@@ -1,0 +1,13 @@
+{% load l10n %}
+
+{% comment %}
+The parent field for a page in the page listing, when in 'choose' mode.
+
+Expects a variable 'page', the page instance.
+{% endcomment %}
+
+{% with page.get_parent as parent %}
+    {% if parent %}
+        <a href="{% url 'wagtailadmin_choose_page_child' parent.id %}" class="navigate-parent">{{ parent.get_admin_display_title }}</a>
+    {% endif %}
+{% endwith %}


### PR DESCRIPTION
Fixes #3085 
This fix overrides the link for 'Parent' field in search results using  a new block `{% block page_parent_page_title  %}` in wagtailadmin/pages/listing/_list.html.

Existing code for the parent link kept untouched within `{% block page_parent_page_title  %} `. The block get overridden in wagtailadmin/pages/listing/_list_choose.html for page chooser modals.

Then it uses a new event handler in `ajaxifySearchResults()`  to capture click events for those overridden links.