### PR TITLE
Disable codecov PR checks

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,8 @@
 codecov:
+  status:
+    patch:
+      default:
+        enabled: no
   notify:
     after_n_builds: 10
     require_ci_to_pass: no

--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -38,6 +38,17 @@ PAGE_TEMPLATE_VAR = 'page'
 
 
 class SiteManager(models.Manager):
+    def pointless_method(self):
+        # dummy code change to test that codecov reports have been disabled on PRs
+        print("zzz")
+        print("zzz")
+        print("zzz")
+        print("zzz")
+        print("zzz")
+        print("zzz")
+        print("zzz")
+        print("zzz")
+
     def get_by_natural_key(self, hostname, port):
         return self.get(hostname=hostname, port=port)
 


### PR DESCRIPTION
Codecov checks on PRs are unnecessary (it's not essential for every PR to have test coverage equal or greater than the codebase as a whole) and are training us to ignore red crosses on PR checks, so we should disable them.

(Please don't merge this as-is, since it contains a dummy commit to confirm that the config change is indeed taking effect)