### PR TITLE
Change Image and Document field name in hooks.rst from uploaded_by to uploaded_by_user

### DIFF
--- a/docs/reference/hooks.rst
+++ b/docs/reference/hooks.rst
@@ -705,7 +705,7 @@ Choosers
     @hooks.register('construct_document_chooser_queryset')
     def show_my_uploaded_documents_only(documents, request):
         # Only show uploaded documents
-        documents = documents.filter(uploaded_by=request.user)
+        documents = documents.filter(uploaded_by_user=request.user)
 
         return documents
 
@@ -724,7 +724,7 @@ Choosers
     @hooks.register('construct_image_chooser_queryset')
     def show_my_uploaded_images_only(images, request):
         # Only show uploaded images
-        images = images.filter(uploaded_by=request.user)
+        images = images.filter(uploaded_by_user=request.user)
 
         return images
 


### PR DESCRIPTION
Document and Image fields changed from `uploaded_by` to `uploaded_by_user`

Thanks for contributing to Wagtail! 🎉

Before submitting, please review the contributor guidelines <http://docs.wagtail.io/en/latest/contributing/index.html> and check the following:

* Do the tests still pass? (http://docs.wagtail.io/en/latest/contributing/developing.html#testing)
* Does the code comply with the style guide? (Run `make lint` from the Wagtail root)
* For Python changes: Have you added tests to cover the new/fixed behaviour?
* For front-end changes: Did you test on all of Wagtail’s supported browsers? **Please list the exact versions you tested**.
* For new features: Has the documentation been updated accordingly?
