### PR TITLE
Add MEDIA_* settings to Django integration page

### DIFF
--- a/docs/getting_started/integrating_into_django.rst
+++ b/docs/getting_started/integrating_into_django.rst
@@ -47,6 +47,13 @@ Add a ``STATIC_ROOT`` setting, if your project does not have one already:
 .. code-block:: python
 
     STATIC_ROOT = os.path.join(BASE_DIR, 'static')
+    
+Add ``MEDIA_ROOT`` and ``MEDIA_URL`` settings, if your project does not have these already:
+
+.. code-block:: python
+
+    MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
+    MEDIA_URL = '/media/'
 
 Add a ``WAGTAIL_SITE_NAME`` - this will be displayed on the main dashboard of the Wagtail admin backend:
 


### PR DESCRIPTION
This change adds the required MEDIA_URL/MEDIA_ROOT settings to this documentation page, so the page outlines they are required and gives an example if they're not already configured.

