### PR TITLE
Preserve links when copy-pasting rich text content from Wagtail to other tools

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -9,6 +9,7 @@ Changelog
  * Automatic search indexing can now be disabled on a per-model basis via the `search_auto_update` attribute (Karl Hobley)
  * Improved diffing of StreamFields when comparing page revisions (Karl Hobley)
  * Highlight broken links to pages and missing documents in rich text (Brady Moe)
+ * Preserve links when copy-pasting rich text content from Wagtail to other tools (Thibaud Colas)
  * Fix: Set `SERVER_PORT` to 443 in `Page.dummy_request()` for HTTPS sites (Sergey Fedoseev)
  * Fix: Include port number in `Host` header of `Page.dummy_request()` (Sergey Fedoseev)
  * Fix: Validation error messages in `InlinePanel` no longer count towards `max_num` when disabling the 'add' button (Todd Dembrey, Thibaud Colas)

--- a/client/src/components/Draftail/decorators/TooltipEntity.js
+++ b/client/src/components/Draftail/decorators/TooltipEntity.js
@@ -84,6 +84,7 @@ class TooltipEntity extends Component {
     /* eslint-disable springload/jsx-a11y/interactive-supports-focus */
     return (
       <a
+        href={url}
         role="button"
         // Use onMouseUp to preserve focus in the text even after clicking.
         onMouseUp={this.openTooltip}

--- a/client/src/components/Draftail/decorators/__snapshots__/TooltipEntity.test.js.snap
+++ b/client/src/components/Draftail/decorators/__snapshots__/TooltipEntity.test.js.snap
@@ -4,6 +4,7 @@ exports[`TooltipEntity #openTooltip 1`] = `
 <a
   className="TooltipEntity"
   data-draftail-trigger={true}
+  href="https://www.example.com/"
   onMouseUp={[Function]}
   role="button"
 >
@@ -76,6 +77,7 @@ exports[`TooltipEntity works 1`] = `
 <a
   className="TooltipEntity"
   data-draftail-trigger={true}
+  href="https://www.example.com/"
   onMouseUp={[Function]}
   role="button"
 >

--- a/docs/releases/2.5.rst
+++ b/docs/releases/2.5.rst
@@ -19,6 +19,7 @@ Other features
  * Automatic search indexing can now be disabled on a per-model basis via the ``search_auto_update`` attribute (Karl Hobley)
  * Improved diffing of StreamFields when comparing page revisions (Karl Hobley)
  * Highlight broken links to pages and missing documents in rich text (Brady Moe)
+ * Preserve links when copy-pasting rich text content from Wagtail to other tools (Thibaud Colas)
 
 
 Bug fixes


### PR DESCRIPTION
This is a fairly minor improvement to the behaviour of links (pages, external, email, and also documents) in rich text. At the moment, copying rich text content from Wagtail does not preserve the links:

![richtext-copy-before](https://user-images.githubusercontent.com/877585/52167344-aa80b600-2711-11e9-8ac9-1d459ea73b67.gif)

This PR adds an `href` attr on the `a` tags rendered by the editor, so third-party tools have a better chance of preserving the links. New result with Google Docs and Dropbox Paper:

![richtext-copy-after](https://user-images.githubusercontent.com/877585/52167370-ea479d80-2711-11e9-8ee8-3cbffd5a7acf.gif)

Google Docs only preserves the external links. Dropbox Paper preserves them all, but with internal and document links having wrong targets. I haven’t experimented with other rich text tools.

---

* [x] Do the tests still pass? (http://docs.wagtail.io/en/latest/contributing/developing.html#testing)
* [x] Does the code comply with the style guide? (Run `make lint` from the Wagtail root)
* ~For Python changes: Have you added tests to cover the new/fixed behaviour?~
* [x] For front-end changes: Did you test on all of Wagtail’s supported browsers? **Please list the exact versions you tested**.
* ~For new features: Has the documentation been updated accordingly?~

To test this,

1. Make sure tooltips still open when clicking the links in the editor.
2. Copy-paste rich text content containing links from Wagtail to other sources, and see what is preserved.

Tested in:

- Chrome 71.0.3578.98 macOS 10.14.1
- Safari 12.0.1 macOS 10.14.1
- Firefox 64.0.2 macOS 10.14.1
- IE11 Windows 8.1
- Edge18 Windows 10
- Firefox 60 (ESR) Windows 10
- Mobile Safari iOS 12
- Chrome 68.0.3440.85 Android 8

Edit: stopped the Travis build manually.