### PR TITLE
Add filter string character check to jinja2 image template tag

### DIFF
--- a/wagtail/images/jinja2tags.py
+++ b/wagtail/images/jinja2tags.py
@@ -1,12 +1,24 @@
+import re
+
+from django import template
 from jinja2.ext import Extension
 
 from .shortcuts import get_rendition_or_not_found
 from .templatetags.wagtailimages_tags import image_url
 
 
+allowed_filter_pattern = re.compile(r"^[A-Za-z0-9_\-\.\|]+$")
+
+
 def image(image, filterspec, **attrs):
     if not image:
         return ''
+
+    if not allowed_filter_pattern.match(filterspec):
+        raise template.TemplateSyntaxError(
+            "filter specs in 'image' tag may only contain A-Z, a-z, 0-9, dots, hyphens, pipes and underscores. "
+            "(given filter: {})".format(filterspec)
+        )
 
     rendition = get_rendition_or_not_found(image, filterspec)
 

--- a/wagtail/images/tests/test_jinja2.py
+++ b/wagtail/images/tests/test_jinja2.py
@@ -1,5 +1,6 @@
 import os
 
+from django import template
 from django.conf import settings
 from django.core import serializers
 from django.template import engines
@@ -78,6 +79,16 @@ class TestImagesJinja(TestCase):
             self.render('{{ image(myimage, "width-200") }}', {'myimage': self.bad_image}),
             '<img alt="missing image" src="/media/not-found" width="0" height="0">'
         )
+
+    def test_invalid_character(self):
+        with self.assertRaises(template.TemplateSyntaxError):
+            self.render('{{ image(myimage, "fill-200×200") }}', {'myimage': self.image})
+
+    def test_chaining_filterspecs(self):
+        self.assertHTMLEqual(
+            self.render('{{ image(myimage, "width-200|jpegquality-40") }}', {'myimage': self.image}),
+            '<img alt="Test image" src="{}" width="200" height="150">'.format(
+                self.get_image_filename(self.image, "width-200.jpegquality-40")))
 
     def test_image_url(self):
         self.assertRegex(


### PR DESCRIPTION
Got tripped up by a `×` instead of a `x` when I copied an aspect ratio from Chromes devtools. This should help with that :)

I considered pulling both the django and jinja2 tags out into a base function, but that seemed like more work than necessary given the django template tag is mostly parsing the tag. 