### PR TITLE
Don't make assumptions about the username field

### DIFF
--- a/wagtail/tests/utils/wagtail_tests.py
+++ b/wagtail/tests/utils/wagtail_tests.py
@@ -33,7 +33,8 @@ class WagtailTestUtils:
         user_model = get_user_model()
         # Login
         self.assertTrue(
-            self.client.login(password='password', **{user_model.USERNAME_FIELD: user.username})
+            self.client.login(password='password', 
+                              **{user_model.USERNAME_FIELD: getattr(user, user_model.USERNAME_FIELD, 'test@email.com')})
         )
 
         return user

--- a/wagtail/tests/utils/wagtail_tests.py
+++ b/wagtail/tests/utils/wagtail_tests.py
@@ -33,7 +33,7 @@ class WagtailTestUtils:
         user_model = get_user_model()
         # Login
         self.assertTrue(
-            self.client.login(password='password', 
+            self.client.login(password='password',
                               **{user_model.USERNAME_FIELD: getattr(user, user_model.USERNAME_FIELD, 'test@email.com')})
         )
 


### PR DESCRIPTION
The USERNAME_FIELD exists to allow customisation. Therefore we should make an assumption that `.username` exists on the model. Instead, we need to pull the required value from the USERNAME_FIELD and add in a fallback default.

Thanks for contributing to Wagtail! 🎉

Before submitting, please review the contributor guidelines <http://docs.wagtail.io/en/latest/contributing/index.html> and check the following:

* Do the tests still pass? (http://docs.wagtail.io/en/latest/contributing/developing.html#testing)
* Does the code comply with the style guide? (Run `make lint` from the Wagtail root)
* For Python changes: Have you added tests to cover the new/fixed behaviour?
