### PR TITLE
Don't show pages in explorer that user has no permissions to access

### DIFF
--- a/wagtail/admin/views/pages.py
+++ b/wagtail/admin/views/pages.py
@@ -57,7 +57,12 @@ def index(request, parent_page_id=None):
     parent_page = parent_page.specific
 
     user_perms = UserPagePermissionsProxy(request.user)
-    pages = parent_page.get_children().prefetch_related('content_type', 'sites_rooted_here') & user_perms.explorable_pages()
+    pages = (
+        parent_page.get_children().prefetch_related(
+            "content_type", "sites_rooted_here"
+        )
+        & user_perms.explorable_pages()
+    )
 
     # Get page ordering
     ordering = request.GET.get('ordering', '-latest_revision_created_at')

--- a/wagtail/admin/views/pages.py
+++ b/wagtail/admin/views/pages.py
@@ -56,7 +56,8 @@ def index(request, parent_page_id=None):
 
     parent_page = parent_page.specific
 
-    pages = parent_page.get_children().prefetch_related('content_type', 'sites_rooted_here')
+    user_perms = UserPagePermissionsProxy(request.user)
+    pages = parent_page.get_children().prefetch_related('content_type', 'sites_rooted_here') & user_perms.explorable_pages()
 
     # Get page ordering
     ordering = request.GET.get('ordering', '-latest_revision_created_at')

--- a/wagtail/api/v2/filters.py
+++ b/wagtail/api/v2/filters.py
@@ -231,5 +231,7 @@ class ForExplorerFilter(BaseFilterBackend):
             for hook in hooks.get_hooks('construct_explorer_page_queryset'):
                 queryset = hook(parent_page, queryset, request)
 
-        user_perms = UserPagePermissionsProxy(request.user)
-        return queryset & user_perms.explorable_pages()
+            user_perms = UserPagePermissionsProxy(request.user)
+            queryset = queryset & user_perms.explorable_pages()
+
+        return queryset

--- a/wagtail/api/v2/filters.py
+++ b/wagtail/api/v2/filters.py
@@ -4,7 +4,7 @@ from rest_framework.filters import BaseFilterBackend
 from taggit.managers import TaggableManager
 
 from wagtail.core import hooks
-from wagtail.core.models import Page
+from wagtail.core.models import Page, UserPagePermissionsProxy
 from wagtail.search.backends import get_search_backend
 from wagtail.search.backends.base import FilterFieldError, OrderByFieldError
 
@@ -231,4 +231,5 @@ class ForExplorerFilter(BaseFilterBackend):
             for hook in hooks.get_hooks('construct_explorer_page_queryset'):
                 queryset = hook(parent_page, queryset, request)
 
-        return queryset
+        user_perms = UserPagePermissionsProxy(request.user)
+        return queryset & user_perms.explorable_pages()

--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -1642,7 +1642,8 @@ class UserPagePermissionsProxy:
         return PagePermissionTester(self, page)
 
     def explorable_pages(self):
-        """Return a queryset of the pages that this user has permission to edit"""
+        """Return a queryset of pages that the user has access to view in the
+        explorer (e.g. add/edit/publish permission)"""
         # Deal with the trivial cases first...
         if not self.user.is_active:
             return Page.objects.none()
@@ -1651,16 +1652,12 @@ class UserPagePermissionsProxy:
 
         editable_pages = Page.objects.none()
 
+        # Creates a union queryset of all objects the user has access to add,
+        # edit and publish
         for perm in self.permissions.filter(permission_type='add'):
-            # user has edit permission on any subpage of perm.page
-            # (including perm.page itself) that is owned by them
             editable_pages |= Page.objects.descendant_of(perm.page, inclusive=True)
-
         for perm in self.permissions.filter(permission_type='edit'):
-            # user has edit permission on any subpage of perm.page
-            # (including perm.page itself) regardless of owner
             editable_pages |= Page.objects.descendant_of(perm.page, inclusive=True)
-
         for perm in self.permissions.filter(permission_type='publish'):
             editable_pages |= Page.objects.descendant_of(perm.page, inclusive=True)
 

--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -1661,6 +1661,9 @@ class UserPagePermissionsProxy:
             # (including perm.page itself) regardless of owner
             editable_pages |= Page.objects.descendant_of(perm.page, inclusive=True)
 
+        for perm in self.permissions.filter(permission_type='publish'):
+            editable_pages |= Page.objects.descendant_of(perm.page, inclusive=True)
+
         return editable_pages
 
     def editable_pages(self):

--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -1650,18 +1650,18 @@ class UserPagePermissionsProxy:
         if self.user.is_superuser:
             return Page.objects.all()
 
-        editable_pages = Page.objects.none()
+        explorable_pages = Page.objects.none()
 
         # Creates a union queryset of all objects the user has access to add,
         # edit and publish
         for perm in self.permissions.filter(permission_type='add'):
-            editable_pages |= Page.objects.descendant_of(perm.page, inclusive=True)
+            explorable_pages |= Page.objects.descendant_of(perm.page, inclusive=True)
         for perm in self.permissions.filter(permission_type='edit'):
-            editable_pages |= Page.objects.descendant_of(perm.page, inclusive=True)
+            explorable_pages |= Page.objects.descendant_of(perm.page, inclusive=True)
         for perm in self.permissions.filter(permission_type='publish'):
-            editable_pages |= Page.objects.descendant_of(perm.page, inclusive=True)
+            explorable_pages |= Page.objects.descendant_of(perm.page, inclusive=True)
 
-        return editable_pages
+        return explorable_pages
 
     def editable_pages(self):
         """Return a queryset of the pages that this user has permission to edit"""

--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -1656,12 +1656,14 @@ class UserPagePermissionsProxy:
 
         # Creates a union queryset of all objects the user has access to add,
         # edit and publish
-        for perm in self.permissions.filter(permission_type='add'):
-            explorable_pages |= Page.objects.descendant_of(perm.page, inclusive=True)
-        for perm in self.permissions.filter(permission_type='edit'):
-            explorable_pages |= Page.objects.descendant_of(perm.page, inclusive=True)
-        for perm in self.permissions.filter(permission_type='publish'):
-            explorable_pages |= Page.objects.descendant_of(perm.page, inclusive=True)
+        for perm in self.permissions.filter(
+            Q(permission_type="add")
+            | Q(permission_type="edit")
+            | Q(permission_type="publish")
+        ):
+            explorable_pages |= Page.objects.descendant_of(
+                perm.page, inclusive=True
+            )
 
         # For all pages with specific permissions, add their ancestors as
         # explorable. This will allow deeply nested pages to be accessed in the

--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -1675,6 +1675,10 @@ class UserPagePermissionsProxy:
         for page in page_permissions:
             explorable_pages |= page.get_ancestors()
 
+        # Remove unnecessary top-level ancestors that the user has no access to
+        fca_page = page_permissions.first_common_ancestor()
+        explorable_pages = explorable_pages.filter(path__startswith=fca_page.path)
+
         return explorable_pages
 
     def editable_pages(self):

--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -1660,6 +1660,7 @@ class UserPagePermissionsProxy:
             Q(permission_type="add")
             | Q(permission_type="edit")
             | Q(permission_type="publish")
+            | Q(permission_type="lock")
         ):
             explorable_pages |= Page.objects.descendant_of(
                 perm.page, inclusive=True

--- a/wagtail/core/tests/test_page_permissions.py
+++ b/wagtail/core/tests/test_page_permissions.py
@@ -334,7 +334,7 @@ class TestPagePermission(TestCase):
         someone_elses_event_page = EventPage.objects.get(url_path='/home/events/someone-elses-event/')
 
         user_perms = UserPagePermissionsProxy(event_editor)
-        explorable_pages = user_perms.editable_pages()
+        explorable_pages = user_perms.explorable_pages()
 
         self.assertFalse(explorable_pages.filter(id=homepage.id).exists())
         self.assertTrue(explorable_pages.filter(id=christmas_page.id).exists())

--- a/wagtail/core/tests/test_page_permissions.py
+++ b/wagtail/core/tests/test_page_permissions.py
@@ -2,7 +2,7 @@ import json
 
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group
-from django.test import TestCase, Client
+from django.test import Client, TestCase
 
 from wagtail.core.models import GroupPagePermission, Page, UserPagePermissionsProxy
 from wagtail.tests.testapp.models import (

--- a/wagtail/core/tests/test_page_permissions.py
+++ b/wagtail/core/tests/test_page_permissions.py
@@ -327,7 +327,6 @@ class TestPagePermission(TestCase):
 
     def test_explorable_pages(self):
         event_editor = get_user_model().objects.get(username='eventeditor')
-        homepage = Page.objects.get(url_path='/home/')
         christmas_page = EventPage.objects.get(url_path='/home/events/christmas/')
         unpublished_event_page = EventPage.objects.get(url_path='/home/events/tentative-unpublished-event/')
         someone_elses_event_page = EventPage.objects.get(url_path='/home/events/someone-elses-event/')
@@ -335,9 +334,6 @@ class TestPagePermission(TestCase):
 
         user_perms = UserPagePermissionsProxy(event_editor)
         explorable_pages = user_perms.explorable_pages()
-
-        # Homepage, while the first common ancestor, is not explorable
-        self.assertFalse(explorable_pages.filter(id=homepage.id).exists())
 
         # Verify all pages below /home/events/ are explorable
         self.assertTrue(explorable_pages.filter(id=christmas_page.id).exists())
@@ -365,7 +361,18 @@ class TestPagePermission(TestCase):
         self.assertNotIn(about_us_page.title, explorable_titles)
 
     def test_explorable_pages_with_permission_gap_in_hierarchy(self):
-        pass
+        corporate_editor = get_user_model().objects.get(username='corporateeditor')
+        user_perms = UserPagePermissionsProxy(corporate_editor)
+
+        about_us_page = Page.objects.get(url_path='/home/about-us/')
+        businessy_events = Page.objects.get(url_path='/home/events/businessy-events/')
+        events_page = Page.objects.get(url_path='/home/events/')
+
+        explorable_pages = user_perms.explorable_pages()
+
+        self.assertTrue(explorable_pages.filter(id=about_us_page.id).exists())
+        self.assertTrue(explorable_pages.filter(id=businessy_events.id).exists())
+        self.assertTrue(explorable_pages.filter(id=events_page.id).exists())
 
     def test_editable_pages_for_user_with_edit_permission(self):
         event_moderator = get_user_model().objects.get(username='eventmoderator')

--- a/wagtail/core/tests/test_page_permissions.py
+++ b/wagtail/core/tests/test_page_permissions.py
@@ -355,7 +355,7 @@ class TestPagePermission(TestCase):
 
         homepage = Page.objects.get(url_path='/home/')
         explorer_response = client.get('/admin/api/v2beta/pages/?child_of={}&for_explorer=1'.format(homepage.pk))
-        explorer_json = json.loads(explorer_response.content)
+        explorer_json = json.loads(explorer_response.content.decode('utf-8'))
 
         events_page = Page.objects.get(url_path='/home/events/')
         about_us_page = Page.objects.get(url_path='/home/about-us/')

--- a/wagtail/tests/testapp/fixtures/test.json
+++ b/wagtail/tests/testapp/fixtures/test.json
@@ -672,6 +672,19 @@
     }
 },
 {
+    "pk": 7,
+    "model": "auth.group",
+    "fields": {
+        "name": "Corporate Editor",
+        "permissions": [
+            ["access_admin", "wagtailadmin", "admin"],
+            ["add_image", "wagtailimages", "image"],
+            ["change_image", "wagtailimages", "image"],
+            ["delete_image", "wagtailimages", "image"]
+        ]
+    }
+},
+{
     "pk": 1,
     "model": "wagtailcore.grouppagepermission",
     "fields": {
@@ -723,6 +736,24 @@
         "group": ["Event moderators"],
         "page": 3,
         "permission_type": "lock"
+    }
+},
+{
+    "pk": 7,
+    "model": "wagtailcore.grouppagepermission",
+    "fields": {
+        "group": ["Corporate Editor"],
+        "page": 7,
+        "permission_type": "edit"
+    }
+},
+{
+    "pk": 8,
+    "model": "wagtailcore.grouppagepermission",
+    "fields": {
+        "group": ["Corporate Editor"],
+        "page": 15,
+        "permission_type": "add"
     }
 },
 {
@@ -830,6 +861,24 @@
         "user_permissions": [],
         "password": "md5$seasalt$1e9bf2bf5606aa5c39852cc30f0f6f22",
         "email": "admin_only_user@example.com"
+    }
+},
+{
+    "pk": 7,
+    "model": "customuser.customuser",
+    "fields": {
+        "username": "corporateeditor",
+        "first_name": "",
+        "last_name": "",
+        "is_active": true,
+        "is_superuser": false,
+        "is_staff": false,
+        "groups": [
+            ["Corporate Editor"]
+        ],
+        "user_permissions": [],
+        "password": "md5$seasalt$1e9bf2bf5606aa5c39852cc30f0f6f22",
+        "email": "corporateeditor@example.com"
     }
 },
 {


### PR DESCRIPTION
This PR fixes an issue where having add/edit/publish access to two sibling pages allows the user to see _every_ page at that level, even if they don't have explicit access to it.