### PR TITLE
Round to integer dimensions when scaling, address #5071

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8141,9 +8141,9 @@
       }
     },
     "natives": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.6.tgz",
-      "integrity": "sha512-6+TDFewD4yxY14ptjKaS63GVdtKiES1pTPyxn9Jb0rBqPMZ7VcCiooEhPNsr+mqHtMGxa/5c/HhcC4uPEUw/nA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.1.tgz",
+      "integrity": "sha512-8eRaxn8u/4wN8tGkhlc2cgwwvOLMLUMUn4IYTexMgWd+LyUDfeXVkk2ygQR0hvIHbJQXgHujia3ieUUDwNGkEA==",
       "dev": true
     },
     "natural-compare": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8141,9 +8141,9 @@
       }
     },
     "natives": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.1.tgz",
-      "integrity": "sha512-8eRaxn8u/4wN8tGkhlc2cgwwvOLMLUMUn4IYTexMgWd+LyUDfeXVkk2ygQR0hvIHbJQXgHujia3ieUUDwNGkEA==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.6.tgz",
+      "integrity": "sha512-6+TDFewD4yxY14ptjKaS63GVdtKiES1pTPyxn9Jb0rBqPMZ7VcCiooEhPNsr+mqHtMGxa/5c/HhcC4uPEUw/nA==",
       "dev": true
     },
     "natural-compare": {

--- a/wagtail/images/image_operations.py
+++ b/wagtail/images/image_operations.py
@@ -225,8 +225,8 @@ class ScaleOperation(Operation):
         image_width, image_height = willow.get_size()
 
         scale = self.percent / 100
-        width = float(image_width * scale)
-        height = float(image_height * scale)
+        width = int(image_width * scale)
+        height = int(image_height * scale)
 
         return willow.resize((width, height))
 

--- a/wagtail/images/tests/test_image_operations.py
+++ b/wagtail/images/tests/test_image_operations.py
@@ -31,7 +31,7 @@ class WillowOperationRecorder:
 
     def validate_operation(self, operation, args, kwargs):
         """Check if the requested operation is sane and raise an exception if not."""
-        #The Willow docs say resize must take integral dimensions.
+        # The Willow docs say resize must take integral dimensions.
         if operation == "resize":
             x, y = args[0]
             if x != int(x) or y != int(y):

--- a/wagtail/images/tests/test_image_operations.py
+++ b/wagtail/images/tests/test_image_operations.py
@@ -23,10 +23,19 @@ class WillowOperationRecorder:
 
     def __getattr__(self, attr):
         def operation(*args, **kwargs):
+            self.validate_operation(attr, args, kwargs)
             self.ran_operations.append((attr, args, kwargs))
             return self
 
         return operation
+
+    def validate_operation(self, operation, args, kwargs):
+        """Check if the requested operation is sane and raise an exception if not."""
+        #The Willow docs say resize must take integral dimensions.
+        if operation == "resize":
+            x, y = args[0]
+            if x != int(x) or y != int(y):
+                raise ValueError
 
     def get_size(self):
         size = self.start_size
@@ -46,6 +55,7 @@ class ImageOperationTestCase(TestCase):
     filter_spec_tests = []
     filter_spec_error_tests = []
     run_tests = []
+    norun_tests = []
 
     @classmethod
     def make_filter_spec_test(cls, filter_spec, expected_output):
@@ -89,6 +99,25 @@ class ImageOperationTestCase(TestCase):
         return test_run
 
     @classmethod
+    def make_norun_test(cls, filter_spec, image_kwargs):
+        def test_norun(self):
+            image = Image(**image_kwargs)
+
+            # Make operation
+            operation = self.operation_class(*filter_spec.split('-'))
+
+            # Make operation recorder
+            operation_recorder = WillowOperationRecorder((image.width, image.height))
+
+            # Attempt (and hopefully fail) to run
+            with self.assertRaises(ValueError):
+                operation.run(operation_recorder, image, {})
+
+        test_norun.__name__ = str('test_norun_%s' % filter_spec)
+        return test_norun
+
+
+    @classmethod
     def setup_test_methods(cls):
         if cls.operation_class is None:
             return
@@ -107,6 +136,11 @@ class ImageOperationTestCase(TestCase):
         for args in cls.run_tests:
             run_test = cls.make_run_test(*args)
             setattr(cls, run_test.__name__, run_test)
+
+        # Runtime error tests
+        for args in cls.norun_tests:
+            norun_test = cls.make_norun_test(*args)
+            setattr(cls, norun_test.__name__, norun_test)
 
 
 class TestDoNothingOperation(ImageOperationTestCase):
@@ -388,7 +422,7 @@ class TestScaleOperation(ImageOperationTestCase):
         ]),
         # Rounded usage of scale
         ('scale-83.0322', dict(width=1000, height=500), [
-            ('resize', ((1000 * 0.830322, 500 * 0.830322), ), {}),
+            ('resize', ((int(1000 * 0.830322), int(500 * 0.830322)), ), {}),
         ]),
     ]
 


### PR DESCRIPTION
Closes #5071 

As in the title. The tests have been modified to check the new behavior, as well as to generate an exception if resizing to fractional dimensions is attempted (forbidden per the Willow docs). Also added opportunity in the basic test case to check for invalid values in image operations, but this is not used.