### PR TITLE
Output current language code in HTML header

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/skeleton.html
+++ b/wagtail/admin/templates/wagtailadmin/skeleton.html
@@ -1,5 +1,6 @@
 <!doctype html>
 {% load static i18n %}
+{% get_current_language as LANGUAGE_CODE %}
 <html class="no-js" lang="{{ LANGUAGE_CODE|default:"en-gb" }}">
 <head>
     <meta charset="utf-8" />

--- a/wagtail/admin/tests/test_account_management.py
+++ b/wagtail/admin/tests/test_account_management.py
@@ -363,6 +363,9 @@ class TestAccountSection(TestCase, WagtailTestUtils):
         # Page should contain a 'Language Preferences' title
         self.assertContains(response, "Language Preferences")
 
+        # check that current language preference is indicated in HTML header
+        self.assertContains(response, '<html class="no-js" lang="en">')
+
     def test_language_preferences_view_post(self):
         """
         This posts to the language preferences view and checks that the
@@ -381,6 +384,10 @@ class TestAccountSection(TestCase, WagtailTestUtils):
 
         # Check that the language preferences are stored
         self.assertEqual(profile.preferred_language, 'es')
+
+        # check that the updated language preference is now indicated in HTML header
+        response = self.client.get(reverse('wagtailadmin_home'))
+        self.assertContains(response, '<html class="no-js" lang="es">')
 
     def test_unset_language_preferences(self):
         # Post new values to the language preferences page

--- a/wagtail/admin/tests/test_views.py
+++ b/wagtail/admin/tests/test_views.py
@@ -1,4 +1,4 @@
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.urls import reverse
 
 from wagtail.core.models import Page
@@ -50,3 +50,8 @@ class TestLoginView(TestCase, WagtailTestUtils):
         login_url = reverse('wagtailadmin_login') + '?next={}'.format(homepage_admin_url)
         response = self.client.get(login_url)
         self.assertRedirects(response, homepage_admin_url)
+
+    @override_settings(LANGUAGE_CODE='de')
+    def test_language_code(self):
+        response = self.client.get(reverse('wagtailadmin_login'))
+        self.assertContains(response, '<html class="no-js" lang="de">')


### PR DESCRIPTION
Fixes #5051. The `lang` attribute of the `<html>` tag in the admin base template was meant to vary according to the variable `LANGUAGE_CODE`, but this variable was never populated. Here we use the `get_current_language` code as per https://docs.djangoproject.com/en/2.1/topics/i18n/translation/#switching-language-in-templates