### PR TITLE
Fixed `ValueError` not raised

### DIFF
--- a/wagtail/images/utils.py
+++ b/wagtail/images/utils.py
@@ -57,6 +57,6 @@ def parse_color_string(color_string):
         g = int(color_string[2:4], 16)
         b = int(color_string[4:6], 16)
     else:
-        ValueError('Color string must be either 3 or 6 hexadecimal digits long')
+        raise ValueError('Color string must be either 3 or 6 hexadecimal digits long')
 
     return r, g, b


### PR DESCRIPTION
Raised `ValueError` in `wagtail/images/utils.py` that was called but not raised

I work for Semmle and I noticed these issues using our LGTM code analyzer
https://lgtm.com/projects/g/wagtail/wagtail/alerts/?mode=tree&severity=error&ruleFocus=1505923886371

* Do the tests still pass? (http://docs.wagtail.io/en/latest/contributing/developing.html#testing)
yes
* Does the code comply with the style guide? (Run `make lint` from the Wagtail root)
yes
* For Python changes: Have you added tests to cover the new/fixed behaviour?
no
* For front-end changes: Did you test on all of Wagtail’s supported browsers? **Please list the exact versions you tested**.
not applicable
* For new features: Has the documentation been updated accordingly?
not applicable
