### PR TITLE
Add form_classname to ListBlock & StreamBlock

### DIFF
--- a/docs/topics/streamfield.rst
+++ b/docs/topics/streamfield.rst
@@ -444,6 +444,28 @@ Any block type is valid as the sub-block type, including structural types:
         ('amount', blocks.CharBlock(required=False)),
     ])))
 
+To customise the class name of a ``ListBlock`` as it appears in the page editor, you can specify a ``form_classname`` attribute as a keyword argument to the ``ListBlock`` constructor:
+
+.. code-block:: python
+    :emphasize-lines: 4
+
+    ('ingredients_list', blocks.ListBlock(blocks.StructBlock([
+        ('ingredient', blocks.CharBlock()),
+        ('amount', blocks.CharBlock(required=False)),
+    ]), form_classname='ingredients-list'))
+
+Alternatively, you can add ``form_classname`` in a subclass's ``Meta``:
+
+.. code-block:: python
+    :emphasize-lines: 6
+
+    class IngredientsListBlock(blocks.ListBlock):
+        ingredient = blocks.CharBlock()
+        amount = blocks.CharBlock(required=False)
+
+        class Meta:
+            form_classname = 'ingredients-list'
+    
 
 StreamBlock
 ~~~~~~~~~~~
@@ -503,6 +525,27 @@ Since ``StreamField`` accepts an instance of ``StreamBlock`` as a parameter, in 
 
 ``block_counts``
   Specifies the minimum and maximum number of each block type, as a dictionary mapping block names to dicts with (optional) ``min_num`` and ``max_num`` fields.
+
+``form_classname``
+  Customise the class name added to a ``StreamBlock`` form in the page editor.
+
+    .. code-block:: python
+        :emphasize-lines: 4
+
+        ('event_promotions', blocks.StreamBlock([
+            ('hashtag', blocks.CharBlock()),
+            ('post_date', blocks.DateBlock()),
+        ], form_classname='event-promotions'))
+
+    .. code-block:: python
+        :emphasize-lines: 6
+
+        class EventPromotionsBlock(blocks.StreamBlock):
+            hashtag = blocks.CharBlock()
+            post_date = blocks.DateBlock()
+
+            class Meta:
+                form_classname = 'event-promotions'
 
 
 .. _streamfield_personblock_example:

--- a/wagtail/admin/templates/wagtailadmin/block_forms/sequence.html
+++ b/wagtail/admin/templates/wagtailadmin/block_forms/sequence.html
@@ -22,7 +22,7 @@
     </span>
 {% endif %}
 
-<div class="c-sf-container">
+<div class="c-sf-container{% if classname %} {{ classname }}{% endif %}">
     <input type="hidden" name="{{ prefix }}-count" id="{{ prefix }}-count" value="{{ list_members_html|length }}">
 
     {% block header %}{% endblock %}

--- a/wagtail/core/blocks/list_block.py
+++ b/wagtail/core/blocks/list_block.py
@@ -92,6 +92,7 @@ class ListBlock(Block):
             'help_text': getattr(self.meta, 'help_text', None),
             'prefix': prefix,
             'list_members_html': list_members_html,
+            'classname': getattr(self.meta, 'form_classname', None),
         })
 
     def value_from_datadict(self, data, files, prefix):

--- a/wagtail/core/blocks/stream_block.py
+++ b/wagtail/core/blocks/stream_block.py
@@ -152,6 +152,7 @@ class BaseStreamBlock(Block):
             'child_blocks': self.sorted_child_blocks(),
             'header_menu_prefix': '%s-before' % prefix,
             'block_errors': error_dict.get(NON_FIELD_ERRORS),
+            'classname': getattr(self.meta, 'form_classname', None),
         })
 
     def value_from_datadict(self, data, files, prefix):

--- a/wagtail/core/tests/test_blocks.py
+++ b/wagtail/core/tests/test_blocks.py
@@ -2259,6 +2259,57 @@ class TestListBlock(WagtailTestUtils, SimpleTestCase):
         )
         self.assertIn('value="chocolate"', form_html)
 
+    def test_render_with_classname_via_kwarg(self):
+        """form_classname from kwargs to be used as an additional class when rendering list block"""
+
+        class LinkBlock(blocks.StructBlock):
+            title = blocks.CharBlock()
+            link = blocks.URLBlock()
+
+        block = blocks.ListBlock(LinkBlock, form_classname='special-list-class')
+
+        html = block.render_form([
+            {
+                'title': "Wagtail",
+                'link': 'http://www.wagtail.io',
+            },
+            {
+                'title': "Django",
+                'link': 'http://www.djangoproject.com',
+            },
+        ], prefix='links')
+
+        # including leading space to ensure class name gets added correctly
+        self.assertEqual(html.count(' special-list-class'), 1)
+
+    def test_render_with_classname_via_class_meta(self):
+        """form_classname from meta to be used as an additional class when rendering list block"""
+
+        class LinkBlock(blocks.StructBlock):
+            title = blocks.CharBlock()
+            link = blocks.URLBlock()
+
+        class CustomListBlock(blocks.ListBlock):
+
+            class Meta:
+                form_classname = 'custom-list-class'
+
+        block = CustomListBlock(LinkBlock)
+
+        html = block.render_form([
+            {
+                'title': "Wagtail",
+                'link': 'http://www.wagtail.io',
+            },
+            {
+                'title': "Django",
+                'link': 'http://www.djangoproject.com',
+            },
+        ], prefix='links')
+
+        # including leading space to ensure class name gets added correctly
+        self.assertEqual(html.count(' custom-list-class'), 1)
+
 
 class TestListBlockWithFixtures(TestCase):
     fixtures = ['test.json']
@@ -3149,6 +3200,56 @@ class TestStreamBlock(WagtailTestUtils, SimpleTestCase):
             }],
         }
         self.check_get_prep_value_nested_streamblocks(stream_data, is_lazy=True)
+
+    def test_render_with_classname_via_kwarg(self):
+        """form_classname from kwargs to be used as an additional class when rendering stream block"""
+
+        block = blocks.StreamBlock([
+            (b'heading', blocks.CharBlock()),
+            (b'paragraph', blocks.CharBlock()),
+        ], form_classname='rocket-section')
+
+        value = block.to_python([
+            {
+                'type': 'heading',
+                'value': "Falcon Heavy",
+                'id': '2',
+            },
+            {
+                'type': 'paragraph',
+                'value': "Ultra heavy launch capability",
+                'id': '3',
+            }
+        ])
+
+        html = block.render_form(value)
+
+        # including leading space to ensure class name gets added correctly
+        self.assertEqual(html.count(' rocket-section'), 1)
+
+
+    def test_render_with_classname_via_class_meta(self):
+        """form_classname from meta to be used as an additional class when rendering stream block"""
+
+        class ProfileBlock(blocks.StreamBlock):
+            username = blocks.CharBlock()
+
+            class Meta:
+                form_classname = 'profile-block-large'
+
+        block = ProfileBlock()
+        value = block.to_python([
+            {
+                'type': 'username',
+                'value': "renegadeM@ster",
+                'id': '789',
+            }
+        ])
+
+        html = block.render_form(value, prefix='profiles')
+
+        # including leading space to ensure class name gets added correctly
+        self.assertEqual(html.count(' profile-block-large'), 1)
 
 
 class TestPageChooserBlock(TestCase):


### PR DESCRIPTION
Full implementation of this feature, allowing `form_classname` to be set on both `ListBlock` and `StreamBlock`.

Replaces #4047
Resolves #4042

---

* Do the tests still pass? Yes
* Does the code comply with the style guide? Yes
* For Python changes: Have you added tests to cover the new/fixed behaviour? Yes
* For new features: Has the documentation been updated accordingly? Yes