### PR TITLE
Update Django version requirement in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ except ImportError:
 
 
 install_requires = [
-    "Django>=1.11,<2.2",
+    "Django>=2.0,<2.2",
     "django-modelcluster>=4.2,<5.0",
     "django-taggit>=0.23,<0.24",
     "django-treebeard>=4.2.0,<5.0",


### PR DESCRIPTION
Support for Django 1.11.x was dropped some time ago (see https://github.com/wagtail/wagtail/commit/e844200f27fe6a2089175b488a283bc27331c4c6) but this is not enforced in `setup.py`, meaning that it is possible to install Wagtail 2.4 alongside Django 1.11 without any warning that these are incompatible.

I think this change was just forgotten when dropping Django 1.11 support - it definitely doesn't work with Django 1.11.