### PR TITLE
Fix: Update modeladmin to preserve compatibility with RelatedFieldListFilter in Django 2.2+

### DIFF
--- a/wagtail/contrib/modeladmin/options.py
+++ b/wagtail/contrib/modeladmin/options.py
@@ -123,7 +123,7 @@ class ModelAdmin(WagtailRegisterable):
 
         # Needed to support RelatedFieldListFilter in Django 2.2+
         # See: https://github.com/wagtail/wagtail/issues/5105
-        self.admin_site = default_django_admin_site  
+        self.admin_site = default_django_admin_site
 
     def get_permission_helper_class(self):
         """

--- a/wagtail/contrib/modeladmin/options.py
+++ b/wagtail/contrib/modeladmin/options.py
@@ -1,4 +1,5 @@
 from django.conf.urls import url
+from django.contrib.admin import site as default_django_admin_site
 from django.contrib.auth.models import Permission
 from django.core import checks
 from django.core.exceptions import ImproperlyConfigured
@@ -119,6 +120,10 @@ class ModelAdmin(WagtailRegisterable):
         self.permission_helper = self.get_permission_helper_class()(
             self.model, self.inspect_view_enabled)
         self.url_helper = self.get_url_helper_class()(self.model)
+
+        # Needed to support RelatedFieldListFilter in Django 2.2+
+        # See: https://github.com/wagtail/wagtail/issues/5105
+        self.admin_site = default_django_admin_site  
 
     def get_permission_helper_class(self):
         """


### PR DESCRIPTION
Resolves #5105

* Do the tests still pass? **Yes**
* Does the code comply with the style guide? **Yes**

Tests in `wagtail.contrib.modeladmin.tests.test_simple_modeladmin.TestBookIndexView` should no longer error when running against Django's `master` branch
