### PR TITLE
Update tox config to test against Django's stable/2.2 branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,8 @@ matrix:
    - env: TOXENV=py37-dj21-sqlite-noelasticsearch
      python: 3.7
      dist: xenial
+   - env: TOXENV=py36-dj22-postgres-noelasticsearch
+     python: 3.6
    - env: TOXENV=py36-djmaster-postgres-noelasticsearch
      python: 3.6
    - env: TOXENV=py36-dj20-sqlite-elasticsearch2 INSTALL_ELASTICSEARCH2=yes
@@ -51,9 +53,10 @@ matrix:
     - env: TOXENV=py36-dj20-postgres-elasticsearch6 INSTALL_ELASTICSEARCH6=yes
     - env: TOXENV=py36-dj21-postgres-elasticsearch6 INSTALL_ELASTICSEARCH6=yes
     - env: TOXENV=py37-dj21-postgres-elasticsearch6 INSTALL_ELASTICSEARCH6=yes
+    # allow failures against Django 2.2 while support is still being worked on
+    - env: TOXENV=py36-dj22-postgres-noelasticsearch
     # allow failures against Django master
     - env: TOXENV=py36-djmaster-postgres-noelasticsearch
-
 
 # Services
 services:

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 skipsdist = True
 usedevelop = True
 
-envlist = py{34,35,36,37}-dj{20,21,master}-{sqlite,postgres,mysql,mssql}-{elasticsearch6,elasticsearch5,elasticsearch2,noelasticsearch},
+envlist = py{34,35,36,37}-dj{20,21,22,master}-{sqlite,postgres,mysql,mssql}-{elasticsearch6,elasticsearch5,elasticsearch2,noelasticsearch},
 
 [flake8]
 # D100: Missing docstring in public module
@@ -44,6 +44,7 @@ deps =
 
     dj20: Django>=2.0,<2.1
     dj21: Django>=2.1,<2.2
+    dj22: git+https://github.com/django/django.git@stable/2.2.x#egg=Django
     djmaster: git+https://github.com/django/django.git@master#egg=Django
 
     postgres: psycopg2>=2.6


### PR DESCRIPTION
Django's master branch now contains changes intended for the `3.0` release, so I've updated tox to tests against Django's `stable/2.2` branch, so that we have a better indication about how far away we are from supporting that version specifically. 