### PR TITLE
Update docs for construct_homepage_panels hook

### DIFF
--- a/docs/reference/hooks.rst
+++ b/docs/reference/hooks.rst
@@ -76,7 +76,7 @@ Hooks for building new areas of the admin interface (alongside pages, images, do
 
     @hooks.register('construct_homepage_panels')
     def add_another_welcome_panel(request, panels):
-      return panels.append( WelcomePanel() )
+        panels.append(WelcomePanel())
 
 
 .. _construct_homepage_summary_items:


### PR DESCRIPTION
`construct_homepage_panels` hook doesn't need a `return` statement.

[Looking at the code](https://github.com/wagtail/wagtail/blob/master/wagtail/admin/views/home.py#L101-L102), the user doesn't need to return a list, they need to mutate the list passed in.

Thanks for contributing to Wagtail! 🎉

Before submitting, please review the contributor guidelines <http://docs.wagtail.io/en/latest/contributing/index.html> and check the following:

* Do the tests still pass? (http://docs.wagtail.io/en/latest/contributing/developing.html#testing)
* Does the code comply with the style guide? (Run `make lint` from the Wagtail root)
* For Python changes: Have you added tests to cover the new/fixed behaviour?
* For front-end changes: Did you test on all of Wagtail’s supported browsers? **Please list the exact versions you tested**.
* For new features: Has the documentation been updated accordingly?
