### PR TITLE
Refs #161: Use cleaned page instance on preview

### DIFF
--- a/wagtail/admin/views/pages.py
+++ b/wagtail/admin/views/pages.py
@@ -636,7 +636,7 @@ class PreviewOnEdit(View):
         if not form.is_valid():
             return self.error_response(page)
 
-        form.save(commit=False)
+        page = form.save(commit=False)
         preview_mode = request.GET.get('mode', page.default_preview_mode)
         return page.serve_preview(page.dummy_request(request),
                                   preview_mode)


### PR DESCRIPTION
We have setup like this:

```python
class ProfilePageForm(WagtailAdminPageForm):
    def __init__(self, *args, **kwargs):
        super().__init__(*args, **kwargs)
        self.fields['slug'].required = False


class ProfilePage(Page):
    first_name = models.CharField(max_length=30)
    last_name = models.CharField(max_length=30)

    content_panels = [
        FieldPanel('first_name'),
        FieldPanel('last_name'),
    ]
    base_form_class = AbstractProfilePageForm

    def full_clean(self, *args, **kwargs):
        self.title = f'{self.first_name} {self.last_name}'
        super().full_clean()
```

It works for us, but non-saved page preview crashes, because `url_path` is not set. Tests are TBD.