### PR TITLE
Fix: still possible to create copies of pages that exceed their models' `max_count`

### DIFF
--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -1841,9 +1841,15 @@ class PagePermissionTester:
         if recursive and (self.page == destination or destination.is_descendant_of(self.page)):
             return False
 
-        # shortcut the trivial 'everything' / 'nothing' permissions
+        # reject inactive users early
         if not self.user.is_active:
             return False
+
+        # reject early if pages of this type cannot be created at the destination
+        if not self.page.specific_class.can_create_at(destination):
+            return False
+
+        # skip permission checking for super users
         if self.user.is_superuser:
             return True
 

--- a/wagtail/core/tests/test_page_permissions.py
+++ b/wagtail/core/tests/test_page_permissions.py
@@ -475,7 +475,11 @@ class TestPagePermissionTesterCanCopyTo(TestCase):
         # These same pages will be used for testing the result for each user
         self.board_meetings_page = BusinessSubIndex.objects.get(url_path='/home/events/businessy-events/board-meetings/')
         self.event_page = EventPage.objects.get(url_path='/home/events/christmas/')
-        self.singleton_page = SingletonPageViaMaxCount.objects.get(url_path='/home/only-one/')
+
+        # We'll also create a SingletonPageViaMaxCount to use
+        homepage = Page.objects.get(url_path='/home/')
+        self.singleton_page = SingletonPageViaMaxCount(title='there can be only one')
+        homepage.add_child(instance=self.singleton_page)
 
     def test_inactive_user_cannot_copy_any_pages(self):
         user = get_user_model().objects.get(username='inactiveuser')

--- a/wagtail/core/tests/test_page_permissions.py
+++ b/wagtail/core/tests/test_page_permissions.py
@@ -466,7 +466,7 @@ class TestPagePermission(TestCase):
         self.assertFalse(perms.can_lock())
 
 
-class TestPagePermissionTesterCanCopyTo(TestCase):  
+class TestPagePermissionTesterCanCopyTo(TestCase):
     """Tests PagePermissionTester.can_copy_to()"""
 
     fixtures = ['test.json']

--- a/wagtail/core/tests/test_page_permissions.py
+++ b/wagtail/core/tests/test_page_permissions.py
@@ -468,7 +468,7 @@ class TestPagePermission(TestCase):
 
 class TestPagePermissionTesterCanCopyTo(TestCase):  
     """Tests PagePermissionTester.can_copy_to()"""
-    
+
     fixtures = ['test.json']
 
     def setUp(self):
@@ -484,7 +484,7 @@ class TestPagePermissionTesterCanCopyTo(TestCase):
         board_meetings_page_perms = self.board_meetings_page.permissions_for_user(user)
         event_page_perms = self.event_page.permissions_for_user(user)
         singleton_page_perms = self.singleton_page.permissions_for_user(user)
-       
+
         # This user should not be able to copy any pages
         self.assertFalse(event_page_perms.can_copy_to(self.event_page.get_parent()))
         self.assertFalse(board_meetings_page_perms.can_copy_to(self.board_meetings_page.get_parent()))
@@ -497,7 +497,7 @@ class TestPagePermissionTesterCanCopyTo(TestCase):
         board_meetings_page_perms = self.board_meetings_page.permissions_for_user(user)
         event_page_perms = self.event_page.permissions_for_user(user)
         singleton_page_perms = self.singleton_page.permissions_for_user(user)
-        
+
         # This user should not be able to copy any pages
         self.assertFalse(event_page_perms.can_copy_to(self.event_page.get_parent()))
         self.assertFalse(board_meetings_page_perms.can_copy_to(self.board_meetings_page.get_parent()))
@@ -505,12 +505,12 @@ class TestPagePermissionTesterCanCopyTo(TestCase):
 
     def test_event_moderator_cannot_copy_a_singleton_page(self):
         user = get_user_model().objects.get(username='eventmoderator')
-        
+
         # Create PagePermissionTester objects for this user, for each page
         board_meetings_page_perms = self.board_meetings_page.permissions_for_user(user)
         event_page_perms = self.event_page.permissions_for_user(user)
         singleton_page_perms = self.singleton_page.permissions_for_user(user)
-        
+
         # We'd expect an event moderator to be able to copy an event page
         self.assertTrue(event_page_perms.can_copy_to(self.event_page.get_parent()))
         # This works because copying doesn't necessarily have to mean publishing

--- a/wagtail/core/tests/test_page_permissions.py
+++ b/wagtail/core/tests/test_page_permissions.py
@@ -3,7 +3,7 @@ from django.contrib.auth.models import Group
 from django.test import TestCase
 
 from wagtail.core.models import GroupPagePermission, Page, UserPagePermissionsProxy
-from wagtail.tests.testapp.models import BusinessSubIndex, EventIndex, EventPage
+from wagtail.tests.testapp.models import BusinessSubIndex, EventIndex, EventPage, SingletonPageViaMaxCount
 
 
 class TestPagePermission(TestCase):
@@ -464,3 +464,70 @@ class TestPagePermission(TestCase):
         perms = UserPagePermissionsProxy(user).for_page(christmas_page)
 
         self.assertFalse(perms.can_lock())
+
+
+class TestPagePermissionTesterCanCopyTo(TestCase):  
+    """Tests PagePermissionTester.can_copy_to()"""
+    
+    fixtures = ['test.json']
+
+    def setUp(self):
+        # These same pages will be used for testing the result for each user
+        self.board_meetings_page = BusinessSubIndex.objects.get(url_path='/home/events/businessy-events/board-meetings/')
+        self.event_page = EventPage.objects.get(url_path='/home/events/christmas/')
+        self.singleton_page = SingletonPageViaMaxCount.objects.get(url_path='/home/only-one/')
+
+    def test_inactive_user_cannot_copy_any_pages(self):
+        user = get_user_model().objects.get(username='inactiveuser')
+
+        # Create PagePermissionTester objects for this user, for each page
+        board_meetings_page_perms = self.board_meetings_page.permissions_for_user(user)
+        event_page_perms = self.event_page.permissions_for_user(user)
+        singleton_page_perms = self.singleton_page.permissions_for_user(user)
+       
+        # This user should not be able to copy any pages
+        self.assertFalse(event_page_perms.can_copy_to(self.event_page.get_parent()))
+        self.assertFalse(board_meetings_page_perms.can_copy_to(self.board_meetings_page.get_parent()))
+        self.assertFalse(singleton_page_perms.can_copy_to(self.singleton_page.get_parent()))
+
+    def test_no_permissions_admin_cannot_copy_any_pages(self):
+        user = get_user_model().objects.get(username='admin_only_user')
+
+        # Create PagePermissionTester objects for this user, for each page
+        board_meetings_page_perms = self.board_meetings_page.permissions_for_user(user)
+        event_page_perms = self.event_page.permissions_for_user(user)
+        singleton_page_perms = self.singleton_page.permissions_for_user(user)
+        
+        # This user should not be able to copy any pages
+        self.assertFalse(event_page_perms.can_copy_to(self.event_page.get_parent()))
+        self.assertFalse(board_meetings_page_perms.can_copy_to(self.board_meetings_page.get_parent()))
+        self.assertFalse(singleton_page_perms.can_copy_to(self.singleton_page.get_parent()))
+
+    def test_event_moderator_cannot_copy_a_singleton_page(self):
+        user = get_user_model().objects.get(username='eventmoderator')
+        
+        # Create PagePermissionTester objects for this user, for each page
+        board_meetings_page_perms = self.board_meetings_page.permissions_for_user(user)
+        event_page_perms = self.event_page.permissions_for_user(user)
+        singleton_page_perms = self.singleton_page.permissions_for_user(user)
+        
+        # We'd expect an event moderator to be able to copy an event page
+        self.assertTrue(event_page_perms.can_copy_to(self.event_page.get_parent()))
+        # This works because copying doesn't necessarily have to mean publishing
+        self.assertTrue(board_meetings_page_perms.can_copy_to(self.board_meetings_page.get_parent()))
+        # SingletonPageViaMaxCount.can_create_at() prevents copying, regardless of a user's permissions
+        self.assertFalse(singleton_page_perms.can_copy_to(self.singleton_page.get_parent()))
+
+    def test_not_even_a_superuser_can_copy_a_singleton_page(self):
+        user = get_user_model().objects.get(username='superuser')
+
+        # Create PagePermissionTester object for this user, for each page
+        board_meetings_page_perms = self.board_meetings_page.permissions_for_user(user)
+        event_page_perms = self.event_page.permissions_for_user(user)
+        singleton_page_perms = self.singleton_page.permissions_for_user(user)
+
+        # A superuser has full permissions, so these are self explainatory
+        self.assertTrue(event_page_perms.can_copy_to(self.event_page.get_parent()))
+        self.assertTrue(board_meetings_page_perms.can_copy_to(self.board_meetings_page.get_parent()))
+        # However, SingletonPageViaMaxCount.can_create_at() prevents copying, regardless of a user's permissions
+        self.assertFalse(singleton_page_perms.can_copy_to(self.singleton_page.get_parent()))

--- a/wagtail/core/tests/test_page_permissions.py
+++ b/wagtail/core/tests/test_page_permissions.py
@@ -3,7 +3,8 @@ from django.contrib.auth.models import Group
 from django.test import TestCase
 
 from wagtail.core.models import GroupPagePermission, Page, UserPagePermissionsProxy
-from wagtail.tests.testapp.models import BusinessSubIndex, EventIndex, EventPage, SingletonPageViaMaxCount
+from wagtail.tests.testapp.models import (
+    BusinessSubIndex, EventIndex, EventPage, SingletonPageViaMaxCount)
 
 
 class TestPagePermission(TestCase):

--- a/wagtail/tests/testapp/fixtures/test.json
+++ b/wagtail/tests/testapp/fixtures/test.json
@@ -595,29 +595,6 @@
 },
 
 {
-    "pk": 21,
-    "model": "wagtailcore.page",
-    "fields": {
-        "title": "There can be only one!",
-        "draft_title": "There can be only one!",
-        "numchild": 0,
-        "show_in_menus": true,
-        "live": true,
-        "depth": 2,
-        "content_type": ["tests", "singletonpageviamaxcount"],
-        "path": "00010001000a",
-        "url_path": "/home/only-one/",
-        "slug": "only-one",
-        "owner": 3
-    }
-},
-{
-    "pk": 21,
-    "model": "tests.singletonpageviamaxcount",
-    "fields": {}
-},
-
-{
     "pk": 20,
     "model": "wagtailcore.page",
     "fields": {

--- a/wagtail/tests/testapp/fixtures/test.json
+++ b/wagtail/tests/testapp/fixtures/test.json
@@ -25,7 +25,7 @@
     "fields": {
         "title": "Welcome to the Wagtail test site!",
         "draft_title": "Welcome to the Wagtail test site!",
-        "numchild": 10,
+        "numchild": 9,
         "show_in_menus": false,
         "live": true,
         "depth": 2,

--- a/wagtail/tests/testapp/fixtures/test.json
+++ b/wagtail/tests/testapp/fixtures/test.json
@@ -25,7 +25,7 @@
     "fields": {
         "title": "Welcome to the Wagtail test site!",
         "draft_title": "Welcome to the Wagtail test site!",
-        "numchild": 9,
+        "numchild": 10,
         "show_in_menus": false,
         "live": true,
         "depth": 2,
@@ -595,6 +595,29 @@
 },
 
 {
+    "pk": 21,
+    "model": "wagtailcore.page",
+    "fields": {
+        "title": "There can be only one!",
+        "draft_title": "There can be only one!",
+        "numchild": 0,
+        "show_in_menus": true,
+        "live": true,
+        "depth": 2,
+        "content_type": ["tests", "singletonpageviamaxcount"],
+        "path": "00010001000a",
+        "url_path": "/home/only-one/",
+        "slug": "only-one",
+        "owner": 3
+    }
+},
+{
+    "pk": 21,
+    "model": "tests.singletonpageviamaxcount",
+    "fields": {}
+},
+
+{
     "pk": 20,
     "model": "wagtailcore.page",
     "fields": {
@@ -610,7 +633,6 @@
         "slug": "does-not-exist"
     }
 },
-
 
 {
     "pk": 1,


### PR DESCRIPTION
Fixes #5111.

Updated `PagePermissionTester.can_copy_to()` to use the page class's `can_create_at()` method to check viability of the action, before checking the user's permissions

Also added some tests for this method, as it didn't seem to be covered by the current tests in `test_page_pernissions.py`

* Do the tests still pass? **Yes**
* Does the code comply with the style guide? **Yes**
* For Python changes: Have you added tests to cover the new/fixed behaviour? **Yes**
* For front-end changes: Did you test on all of Wagtail’s supported browsers? **N/A**
* For new features: Has the documentation been updated accordingly? **N/A**
