### PR TITLE
Add a setting to apply limit on number of tags that can be added to any tagged model.

### DIFF
--- a/docs/advanced_topics/settings.rst
+++ b/docs/advanced_topics/settings.rst
@@ -384,6 +384,15 @@ Multi-word tags
 
 Tags can only consist of a single word, no spaces allowed. The default setting is ``True`` (spaces in tags are allowed).
 
+Tag limit
+---------
+
+ .. code-block:: python
+
+   TAG_LIMIT = 5
+
+Limit number of tags that can be added to (django-taggit) Tag model. Default setting is None, meaning no limit on tags.   
+
 Unicode Page Slugs
 ------------------
 

--- a/wagtail/admin/static_src/wagtailadmin/js/core.js
+++ b/wagtail/admin/static_src/wagtailadmin/js/core.js
@@ -21,7 +21,7 @@ function escapeHtml(text) {
     });
 }
 
-function initTagField(id, autocompleteUrl, allowSpaces) {
+function initTagField(id, autocompleteUrl, allowSpaces, tagLimit) {
     $('#' + id).tagit({
         autocomplete: {source: autocompleteUrl},
         preprocessTag: function(val) {
@@ -34,7 +34,8 @@ function initTagField(id, autocompleteUrl, allowSpaces) {
             return val;
         },
 
-        allowSpaces: allowSpaces
+        allowSpaces: allowSpaces,
+        tagLimit: tagLimit,
     });
 }
 

--- a/wagtail/admin/templates/wagtailadmin/widgets/tag_widget.html
+++ b/wagtail/admin/templates/wagtailadmin/widgets/tag_widget.html
@@ -1,1 +1,9 @@
-{% include 'django/forms/widgets/text.html' %}<script>initTagField('{{ widget.attrs.id|escapejs }}', '{{ widget.autocomplete_url|escapejs }}', {% if widget.tag_spaces_allowed %}true{% else %}false{% endif %});</script>
+{% include 'django/forms/widgets/text.html' %}
+<script>
+    initTagField(
+        '{{ widget.attrs.id|escapejs }}',
+        '{{ widget.autocomplete_url|escapejs }}',
+        {%if widget.tag_spaces_allowed %}true{% else %}false {% endif %},
+        {% if widget.tag_limit %}{{widget.tag_limit}}{%else %}null{% endif %}
+    );
+</script>

--- a/wagtail/admin/templates/wagtailadmin/widgets/tag_widget.html
+++ b/wagtail/admin/templates/wagtailadmin/widgets/tag_widget.html
@@ -3,7 +3,7 @@
     initTagField(
         '{{ widget.attrs.id|escapejs }}',
         '{{ widget.autocomplete_url|escapejs }}',
-        {%if widget.tag_spaces_allowed %}true{% else %}false {% endif %},
-        {% if widget.tag_limit %}{{widget.tag_limit}}{%else %}null{% endif %}
+        {% if widget.tag_spaces_allowed %}true{% else %}false{% endif %},
+        {% if widget.tag_limit %}{{widget.tag_limit}}{% else %}null{% endif %}
     );
 </script>

--- a/wagtail/admin/widgets.py
+++ b/wagtail/admin/widgets.py
@@ -101,6 +101,7 @@ class AdminTagWidget(TagWidget):
         context = super().get_context(name, value, attrs)
         context['widget']['autocomplete_url'] = reverse('wagtailadmin_tag_autocomplete')
         context['widget']['tag_spaces_allowed'] = getattr(settings, 'TAG_SPACES_ALLOWED', True)
+        context['widget']['tag_limit'] = getattr(settings, 'TAG_LIMIT', None)
 
         return context
 


### PR DESCRIPTION
Hello,

I was looking for feature where i can limit the number of tags that can be applied to Tagged model.
Wagtail uses django-taggit and it is tightly coupled with it as of now.

I did not find any better way of achieving this without modifying wagtail itself.
After digging through the code i found out that wagtail uses tag-it plugin which has this setting in built.
So why not use that :)

This PR basically adds setting called TAG_LIMIT which gets applied to tag-it jQuery plugin through tag widget.

Once setting is in place, user wont be able to add tags more than no specified by TAG_LIMIT setting.

* Do the tests still pass? **yes**
* Does the code comply with the style guide? **yes**
* For Python changes: Have you added tests to cover the new/fixed behaviour?**No existing placeholder found.**
* For front-end changes: Did you test on all of Wagtail’s supported browsers? 
**latest**
**Safari desktop**
**Chrome desktop**
**Firefox desktop**
**Chrome ios**
**Safari ios**
* For new features: Has the documentation been updated accordingly?**yes**
