### PR TITLE
Squash integration

### DIFF
--- a/.squash.yml
+++ b/.squash.yml
@@ -1,7 +1,6 @@
 deployments:
   default:
     dockerimage: python:latest
-    port_forwarding: 80:3000
     build_steps:
       - apt-get update && apt-get install -y libssl-dev libpq-dev git build-essential libfontconfig1 libfontconfig1-dev
       - pip install setuptools pip --upgrade --force-reinstall

--- a/.squash.yml
+++ b/.squash.yml
@@ -1,0 +1,16 @@
+deployments:
+  default:
+    dockerimage: python:latest
+    port_forwarding: 80:3000
+    build_steps:
+      - apt-get update && apt-get install -y libssl-dev libpq-dev git build-essential libfontconfig1 libfontconfig1-dev
+      - pip install setuptools pip --upgrade --force-reinstall
+      - pip install wagtail
+      - mkdir /myproject
+      - cd /myproject
+      - wagtail start mysite
+      - cd /myproject/mysite
+      - python manage.py migrate
+      - echo "from django.contrib.auth import get_user_model; User = get_user_model(); User.objects.create_superuser('admin', 'admin@myproject.com', 'password')" | python manage.py shell
+    launch_steps:
+      python manage.py runserver 0.0.0.0:80

--- a/.squash.yml
+++ b/.squash.yml
@@ -2,9 +2,14 @@ deployments:
   default:
     dockerimage: python:latest
     build_steps:
-      - apt-get update && apt-get install -y libssl-dev libpq-dev git build-essential libfontconfig1 libfontconfig1-dev
+      - apt-get update && apt-get install -y libssl-dev libpq-dev git build-essential libfontconfig1 libfontconfig1-dev curl
+      - RUN bash -c "curl -sL https://deb.nodesource.com/setup_8.x | bash -"
+      - apt install -y nodejs
+      - cd /code
+      - npm install
+      - npm run dist
       - pip install setuptools pip --upgrade --force-reinstall
-      - pip install wagtail
+      - pip install /code
       - mkdir /myproject
       - cd /myproject
       - wagtail start mysite


### PR DESCRIPTION
This is a patch to integrate Squash.io with Wagtail. I believe this is going to be handy to the project so any project maintainers and developers can quickly check the branch changes deployed on its own isolated VM.

Example of Wagtail working with Squash: https://squash-integration-sds80.squash.io/

Admin area (credentials: admin/password): https://squash-integration-sds80.squash.io/admin/

Squash is free for Open Source, maintainers just need to [signup ](https://squash.io/signup/) and reach out to the support through the chat window and we will enable a forever free Open Source account. Once this is done, Squash will post a comment on each Pull Request like this:

![squash-pr-comment](https://user-images.githubusercontent.com/98694/50752537-de98b200-120b-11e9-9d8f-264eddc4ca3f.png)

When you click on the Squash link in a new PR it will deploy the branch of code into a brand new VM, **this process takes about 2 minutes**.  

Let me know what you think please. Thanks.

---

Thanks for contributing to Wagtail! 🎉

Before submitting, please review the contributor guidelines <http://docs.wagtail.io/en/latest/contributing/index.html> and check the following:

* Do the tests still pass? (http://docs.wagtail.io/en/latest/contributing/developing.html#testing)
* Does the code comply with the style guide? (Run `make lint` from the Wagtail root)
* For Python changes: Have you added tests to cover the new/fixed behaviour?
* For front-end changes: Did you test on all of Wagtail’s supported browsers? **Please list the exact versions you tested**.
* For new features: Has the documentation been updated accordingly?
