### PR TITLE
Refactor page listing headers into a template tag

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/pages/index.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/index.html
@@ -14,7 +14,7 @@
         {% csrf_token %}
 
         {% page_permissions parent_page as parent_page_perms %}
-        {% include "wagtailadmin/pages/listing/_list_explore.html" with sortable=1 full_width=1 show_ordering_column=1 parent_page=parent_page orderable=parent_page_perms.can_reorder_children %}
+        {% include "wagtailadmin/pages/listing/_list_explore.html" with sortable=1 sortable_by_type=1 full_width=1 show_ordering_column=1 parent_page=parent_page orderable=parent_page_perms.can_reorder_children %}
 
         {% if do_paginate %}
             {% url 'wagtailadmin_explore' parent_page.id as pagination_base_url %}

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_table_headers_explore.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_table_headers_explore.html
@@ -5,6 +5,7 @@
 Table headers for the page listing, when in 'explore' mode. Expects the following variables:
 
 sortable: if true, headings are links to wagtailadmin_explore with sort parameters applied.
+sortable_by_type: must be true to allow sorting on the 'type' column
 show_ordering_column: if true, an 'ordering' column is added.
 orderable: if true, the 'ordering' column is populated (again with links to wagtailadmin_explore).
 
@@ -49,7 +50,7 @@ ordering: the current sort parameter
         {% endif %}
     </th>
     <th class="type">
-        {% if sortable and not not_sortable_by_type %}
+        {% if sortable and sortable_by_type %}
             <a href="{% if ordering == 'content_type' %}{% querystring ordering='-content_type' %}{% else %}{% querystring ordering='content_type' %}{% endif %}" class="icon icon-arrow-{% if ordering == '-content_type' %}up-after{% else %}down-after{% endif %} {% if ordering == 'content_type' or ordering == '-content_type' %}teal {% endif %}">
                 {% trans 'Type' %}
             </a>

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_table_headers_explore.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_table_headers_explore.html
@@ -29,43 +29,31 @@ ordering: the current sort parameter
         </th>
     {% endif %}
     <th class="title">
-        {% if sortable %}
-            <a href="{% if ordering == 'title' %}{% querystring ordering='-title' %}{% else %}{% querystring ordering='title' %}{% endif %}" class="icon icon-arrow-{% if ordering == 'title' %}down-after{% elif ordering == '-title' %}up-after{% else %}down-after{% endif %} {% if ordering == 'title' or ordering == '-title' %}teal{% endif %}">
-                {% trans 'Title' %}
-            </a>
-        {% else %}
-            {% trans 'Title' %}
-        {% endif %}
+        {% trans 'Title' as title_label %}
+        {% table_header_label label=title_label sortable=sortable sort_field='title' %}
     </th>
     {% if show_parent %}
-    <th class="parent">{% trans 'Parent' %}</th>
+        <th class="parent">
+            {% trans 'Parent' as parent_label %}
+            {% table_header_label label=parent_label sortable=0 %}
+        </th>
     {% endif %}
      <th class="updated">
-        {% if sortable %}
-            <a href="{% if ordering == 'latest_revision_created_at' %}{% querystring ordering='-latest_revision_created_at' %}{% else %}{% querystring ordering='latest_revision_created_at' %}{% endif %}" class="icon icon-arrow-{% if ordering == '-latest_revision_created_at' %}up-after{% else %}down-after{% endif %} {% if ordering == 'latest_revision_created_at' or ordering == '-latest_revision_created_at' %}teal {% endif %}">
-                {% trans 'Updated' %}
-            </a>
-        {% else %}
-            {% trans 'Updated' %}
-        {% endif %}
+        {% trans 'Updated' as updated_label %}
+        {% table_header_label label=updated_label sortable=sortable sort_field='latest_revision_created_at' %}
     </th>
     <th class="type">
+        {% trans 'Type' as type_label %}
+
         {% if sortable and sortable_by_type %}
-            <a href="{% if ordering == 'content_type' %}{% querystring ordering='-content_type' %}{% else %}{% querystring ordering='content_type' %}{% endif %}" class="icon icon-arrow-{% if ordering == '-content_type' %}up-after{% else %}down-after{% endif %} {% if ordering == 'content_type' or ordering == '-content_type' %}teal {% endif %}">
-                {% trans 'Type' %}
-            </a>
+            {% table_header_label label=type_label sortable=1 sort_field='content_type' %}
         {% else %}
-            {% trans 'Type' %}
+            {% table_header_label label=type_label sortable=0 %}
         {% endif %}
     </th>
     <th class="status">
-        {% if sortable %}
-            <a href="{% if ordering == 'live' %}{% querystring ordering='-live' %}{% else %}{% querystring ordering='live' %}{% endif %}" class="icon icon-arrow-{% if ordering == '-live' %}up-after{% else %}down-after{% endif %} {% if ordering == 'live' or ordering == '-live' %}teal {% endif %}">
-                {% trans 'Status' %}
-            </a>
-        {% else %}
-            {% trans 'Status' %}
-        {% endif %}
+        {% trans 'Status' as status_label %}
+        {% table_header_label label=status_label sortable=sortable sort_field='live' %}
     </th>
     <th></th>
 </tr>

--- a/wagtail/admin/templates/wagtailadmin/pages/search_results.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/search_results.html
@@ -32,7 +32,7 @@
             </nav>
         {% endif %}
 
-        {% include "wagtailadmin/pages/listing/_list_explore.html" with show_parent=1 sortable=1 not_sortable_by_type=1 %}
+        {% include "wagtailadmin/pages/listing/_list_explore.html" with show_parent=1 sortable=1 sortable_by_type=0 %}
 
         {% url 'wagtailadmin_pages:search' as pagination_base_url %}
         {% paginate pages base_url=pagination_base_url %}

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -8,7 +8,7 @@ from django.contrib.messages.constants import DEFAULT_TAGS as MESSAGE_TAGS
 from django.template.defaultfilters import stringfilter
 from django.template.loader import render_to_string
 from django.templatetags.static import static
-from django.utils.html import conditional_escape
+from django.utils.html import conditional_escape, format_html
 from django.utils.safestring import mark_safe
 
 from wagtail.admin.menu import admin_menu
@@ -287,6 +287,52 @@ def querystring(context, **kwargs):
             querydict[key] = str(value)
 
     return '?' + querydict.urlencode()
+
+
+@register.simple_tag(takes_context=True)
+def table_header_label(context, label=None, sortable=True, ordering=None, sort_context_var='ordering', sort_param='ordering', sort_field=None):
+    """
+    A label to go in a table header cell, optionally with a 'sort' link that alternates between
+    forward and reverse sorting
+
+    label = label text
+    ordering = current active ordering. If not specified, we will fetch it from the template context variable
+        given by sort_context_var. (We don't fetch it from the URL because that wouldn't give the view method
+        the opportunity to set a default)
+    sort_param = URL parameter that indicates the current active ordering
+    sort_field = the value for sort_param that indicates that sorting is currently on this column.
+        For example, if sort_param='ordering' and sort_field='title', then a URL parameter of
+        ordering=title indicates that the listing is ordered forwards on this column, and a URL parameter
+        of ordering=-title indicated that the listing is ordered in reverse on this column
+    To disable sorting on this column, set sortable=False or leave sort_field unspecified.
+    """
+    if not sortable or not sort_field:
+        # render label without a sort link
+        return label
+
+    if ordering is None:
+        ordering = context.get(sort_context_var)
+    reverse_sort_field = "-%s" % sort_field
+
+    if ordering == sort_field:
+        # currently ordering forwards on this column; link should change to reverse ordering
+        url = querystring(context, **{sort_param: reverse_sort_field})
+        classname = "icon icon-arrow-down-after teal"
+
+    elif ordering == reverse_sort_field:
+        # currently ordering backwards on this column; link should change to forward ordering
+        url = querystring(context, **{sort_param: sort_field})
+        classname = "icon icon-arrow-up-after teal"
+
+    else:
+        # not currently ordering on this column; link should change to forward ordering
+        url = querystring(context, **{sort_param: sort_field})
+        classname = "icon icon-arrow-down-after"
+
+    return format_html(
+        '<a href="{url}" class="{classname}">{label}</a>',
+        url=url, classname=classname, label=label
+    )
 
 
 @register.simple_tag(takes_context=True)


### PR DESCRIPTION
Introduce a `table_header_label` tag to replace the template-tag-soup that generates the URLs and classnames for the ordering links in the page listing header.

(Ideally we'd go on to introduce this tag on other listings, but it seems that very few of them have fully-functional bidirectional sorting right now, so I'll leave that for another PR...)