### PR TITLE
Simplify pagination_nav.html include

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/shared/ajax_pagination_nav.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/ajax_pagination_nav.html
@@ -1,0 +1,18 @@
+{% load i18n %}
+{% load wagtailadmin_tags %}
+
+<div class="pagination">
+    <p>{% blocktrans with page_num=items.number total_pages=items.paginator.num_pages %}Page {{ page_num }} of {{ total_pages }}.{% endblocktrans %}</p>
+    <ul>
+        <li class="prev">
+            {% if items.has_previous %}
+                <a href="#" data-page="{{ items.previous_page_number }}" class="icon icon-arrow-left">{% trans 'Previous' %}</a>
+            {% endif %}
+        </li>
+        <li class="next">
+            {% if items.has_next %}
+                <a href="#" data-page="{{ items.next_page_number }}" class="icon icon-arrow-right-after">{% trans 'Next' %}</a>
+            {% endif %}
+        </li>
+    </ul>
+</div>

--- a/wagtail/admin/templates/wagtailadmin/shared/pagination_nav.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/pagination_nav.html
@@ -25,7 +25,7 @@
                 {% if is_searching %}
                     <a href="{{ url_to_use }}?q={{ query_string|urlencode }}&amp;p={{ items.previous_page_number }}" class="icon icon-arrow-left">{% trans 'Previous' %}</a>
                 {% elif not linkurl %}
-                    <a href="?{% replace_page_param request.META.QUERY_STRING items.previous_page_number %}" class="icon icon-arrow-left">{% trans 'Previous' %}</a>
+                    <a href="{% querystring p=items.previous_page_number %}" class="icon icon-arrow-left">{% trans 'Previous' %}</a>
                 {% else %}
                     <a href="{{ url_to_use }}?p={{ items.previous_page_number }}&amp;ordering={{ ordering }}" class="icon icon-arrow-left">{% trans 'Previous' %}</a>
                 {% endif %}
@@ -36,7 +36,7 @@
                 {% if is_searching %}
                     <a href="{{ url_to_use }}?q={{ query_string|urlencode }}&amp;p={{ items.next_page_number }}" class="icon icon-arrow-right-after">{% trans 'Next' %}</a>
                 {% elif not linkurl %}
-                    <a href="?{% replace_page_param request.META.QUERY_STRING items.next_page_number %}" class="icon icon-arrow-right-after">{% trans 'Next' %}</a>
+                    <a href="{% querystring p=items.next_page_number %}" class="icon icon-arrow-right-after">{% trans 'Next' %}</a>
                 {% else %}
                     <a href="{{ url_to_use }}?p={{ items.next_page_number }}&amp;ordering={{ ordering }}" class="icon icon-arrow-right-after">{% trans 'Next' %}</a>
                 {% endif %}

--- a/wagtail/admin/templates/wagtailadmin/shared/pagination_nav.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/pagination_nav.html
@@ -1,21 +1,20 @@
 {% load i18n %}
 {% load wagtailadmin_tags %}
-{% if not is_ajax %}
-    {% comment %}
-        HACK: This template expects to be passed a 'linkurl' parameter, containing a URL name
-        that can be reverse-resolved by the {% url %} tag with no further parameters.
-        Views that have parameters in their URL can work around this by passing a bogus
-        (but non-blank) URL name, which will return an empty string and produce a final URL
-        of the form "?q=123", implicitly preserving the current URL path.
-        Using the {% url ... as ... %} form of the tag ensures that this fails silently,
-        rather than throwing a NoReverseMatch exception.
 
-        If 'linkurl' is not passed, it will instead preserve the current URL and parameters,
-        just replacing the 'p' parameter.
-    {% endcomment %}
-    {% if linkurl %}
-      {% url linkurl as url_to_use %}
-    {% endif %}
+{% comment %}
+    HACK: This template expects to be passed a 'linkurl' parameter, containing a URL name
+    that can be reverse-resolved by the {% url %} tag with no further parameters.
+    Views that have parameters in their URL can work around this by passing a bogus
+    (but non-blank) URL name, which will return an empty string and produce a final URL
+    of the form "?q=123", implicitly preserving the current URL path.
+    Using the {% url ... as ... %} form of the tag ensures that this fails silently,
+    rather than throwing a NoReverseMatch exception.
+
+    If 'linkurl' is not passed, it will instead preserve the current URL and parameters,
+    just replacing the 'p' parameter.
+{% endcomment %}
+{% if linkurl %}
+    {% url linkurl as url_to_use %}
 {% endif %}
 
 <div class="pagination">
@@ -23,9 +22,7 @@
     <ul>
         <li class="prev">
             {% if items.has_previous %}
-                {% if is_ajax %}
-                    <a href="#" data-page="{{ items.previous_page_number }}" class="icon icon-arrow-left">{% trans 'Previous' %}</a>
-                {% elif is_searching %}
+                {% if is_searching %}
                     <a href="{{ url_to_use }}?q={{ query_string|urlencode }}&amp;p={{ items.previous_page_number }}" class="icon icon-arrow-left">{% trans 'Previous' %}</a>
                 {% elif not linkurl %}
                     <a href="?{% replace_page_param request.META.QUERY_STRING items.previous_page_number %}" class="icon icon-arrow-left">{% trans 'Previous' %}</a>
@@ -36,9 +33,7 @@
         </li>
         <li class="next">
             {% if items.has_next %}
-                {% if is_ajax %}
-                    <a href="#" data-page="{{ items.next_page_number }}" class="icon icon-arrow-right-after">{% trans 'Next' %}</a>
-                {% elif is_searching %}
+                {% if is_searching %}
                     <a href="{{ url_to_use }}?q={{ query_string|urlencode }}&amp;p={{ items.next_page_number }}" class="icon icon-arrow-right-after">{% trans 'Next' %}</a>
                 {% elif not linkurl %}
                     <a href="?{% replace_page_param request.META.QUERY_STRING items.next_page_number %}" class="icon icon-arrow-right-after">{% trans 'Next' %}</a>

--- a/wagtail/admin/templates/wagtailadmin/shared/pagination_nav.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/pagination_nav.html
@@ -4,14 +4,10 @@
 {% comment %}
     HACK: This template expects to be passed a 'linkurl' parameter, containing a URL name
     that can be reverse-resolved by the {% url %} tag with no further parameters.
-    Views that have parameters in their URL can work around this by passing a bogus
-    (but non-blank) URL name, which will return an empty string and produce a final URL
-    of the form "?q=123", implicitly preserving the current URL path.
+    Views that have parameters in their URL can work around this by omitting linkurl,
+    which will produce a final URL of the form "?q=123", implicitly preserving the current URL path.
     Using the {% url ... as ... %} form of the tag ensures that this fails silently,
     rather than throwing a NoReverseMatch exception.
-
-    If 'linkurl' is not passed, it will instead preserve the current URL and parameters,
-    just replacing the 'p' parameter.
 {% endcomment %}
 {% if linkurl %}
     {% url linkurl as url_to_use %}
@@ -22,24 +18,12 @@
     <ul>
         <li class="prev">
             {% if items.has_previous %}
-                {% if is_searching %}
-                    <a href="{{ url_to_use }}?q={{ query_string|urlencode }}&amp;p={{ items.previous_page_number }}" class="icon icon-arrow-left">{% trans 'Previous' %}</a>
-                {% elif not linkurl %}
-                    <a href="{% querystring p=items.previous_page_number %}" class="icon icon-arrow-left">{% trans 'Previous' %}</a>
-                {% else %}
-                    <a href="{{ url_to_use }}?p={{ items.previous_page_number }}&amp;ordering={{ ordering }}" class="icon icon-arrow-left">{% trans 'Previous' %}</a>
-                {% endif %}
+                <a href="{{ url_to_use }}{% querystring p=items.previous_page_number %}" class="icon icon-arrow-left">{% trans 'Previous' %}</a>
             {% endif %}
         </li>
         <li class="next">
             {% if items.has_next %}
-                {% if is_searching %}
-                    <a href="{{ url_to_use }}?q={{ query_string|urlencode }}&amp;p={{ items.next_page_number }}" class="icon icon-arrow-right-after">{% trans 'Next' %}</a>
-                {% elif not linkurl %}
-                    <a href="{% querystring p=items.next_page_number %}" class="icon icon-arrow-right-after">{% trans 'Next' %}</a>
-                {% else %}
-                    <a href="{{ url_to_use }}?p={{ items.next_page_number }}&amp;ordering={{ ordering }}" class="icon icon-arrow-right-after">{% trans 'Next' %}</a>
-                {% endif %}
+                <a href="{{ url_to_use }}{% querystring p=items.next_page_number %}" class="icon icon-arrow-right-after">{% trans 'Next' %}</a>
             {% endif %}
         </li>
     </ul>

--- a/wagtail/admin/templates/wagtailadmin/shared/pagination_nav.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/pagination_nav.html
@@ -1,30 +1,35 @@
 {% load i18n %}
 {% load wagtailadmin_tags %}
 
-{% comment %}
-    HACK: This template expects to be passed a 'linkurl' parameter, containing a URL name
-    that can be reverse-resolved by the {% url %} tag with no further parameters.
-    Views that have parameters in their URL can work around this by omitting linkurl,
-    which will produce a final URL of the form "?q=123", implicitly preserving the current URL path.
-    Using the {% url ... as ... %} form of the tag ensures that this fails silently,
-    rather than throwing a NoReverseMatch exception.
-{% endcomment %}
-{% if linkurl %}
-    {% url linkurl as url_to_use %}
-{% endif %}
+{% if is_ajax %}
+    {% ajax_pagination_nav_deprecation_warning %}
+    {% include "wagtailadmin/shared/ajax_pagination_nav.html" %}
+{% else %}
+    {% comment %}
+        HACK: This template expects to be passed a 'linkurl' parameter, containing a URL name
+        that can be reverse-resolved by the {% url %} tag with no further parameters.
+        Views that have parameters in their URL can work around this by omitting linkurl,
+        which will produce a final URL of the form "?q=123", implicitly preserving the current URL path.
+        Using the {% url ... as ... %} form of the tag ensures that this fails silently,
+        rather than throwing a NoReverseMatch exception.
+    {% endcomment %}
+    {% if linkurl %}
+        {% url linkurl as url_to_use %}
+    {% endif %}
 
-<div class="pagination">
-    <p>{% blocktrans with page_num=items.number total_pages=items.paginator.num_pages %}Page {{ page_num }} of {{ total_pages }}.{% endblocktrans %}</p>
-    <ul>
-        <li class="prev">
-            {% if items.has_previous %}
-                <a href="{{ url_to_use }}{% querystring p=items.previous_page_number %}" class="icon icon-arrow-left">{% trans 'Previous' %}</a>
-            {% endif %}
-        </li>
-        <li class="next">
-            {% if items.has_next %}
-                <a href="{{ url_to_use }}{% querystring p=items.next_page_number %}" class="icon icon-arrow-right-after">{% trans 'Next' %}</a>
-            {% endif %}
-        </li>
-    </ul>
-</div>
+    <div class="pagination">
+        <p>{% blocktrans with page_num=items.number total_pages=items.paginator.num_pages %}Page {{ page_num }} of {{ total_pages }}.{% endblocktrans %}</p>
+        <ul>
+            <li class="prev">
+                {% if items.has_previous %}
+                    <a href="{{ url_to_use }}{% querystring p=items.previous_page_number %}" class="icon icon-arrow-left">{% trans 'Previous' %}</a>
+                {% endif %}
+            </li>
+            <li class="next">
+                {% if items.has_next %}
+                    <a href="{{ url_to_use }}{% querystring p=items.next_page_number %}" class="icon icon-arrow-right-after">{% trans 'Next' %}</a>
+                {% endif %}
+            </li>
+        </ul>
+    </div>
+{% endif %}

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -19,7 +19,6 @@ from wagtail.core.models import (
 from wagtail.core.utils import cautious_slugify as _cautious_slugify
 from wagtail.core.utils import camelcase_to_underscore, escape_script
 from wagtail.users.utils import get_gravatar_url
-from wagtail.utils.pagination import DEFAULT_PAGE_KEY
 
 register = template.Library()
 
@@ -289,7 +288,7 @@ def querystring(context, **kwargs):
 
 
 @register.simple_tag(takes_context=True)
-def pagination_querystring(context, page_number, page_key=DEFAULT_PAGE_KEY):
+def pagination_querystring(context, page_number, page_key='p'):
     """
     Print out a querystring with an updated page number:
 
@@ -302,7 +301,7 @@ def pagination_querystring(context, page_number, page_key=DEFAULT_PAGE_KEY):
 
 @register.inclusion_tag("wagtailadmin/pages/listing/_pagination.html",
                         takes_context=True)
-def paginate(context, page, base_url='', page_key=DEFAULT_PAGE_KEY,
+def paginate(context, page, base_url='', page_key='p',
              classnames=''):
     """
     Print pagination previous/next links, and the page count. Take the
@@ -318,9 +317,7 @@ def paginate(context, page, base_url='', page_key=DEFAULT_PAGE_KEY,
         querystring for the next/previous page.
 
     page_key
-        The name of the page variable in the query string. Defaults to the same
-        name as used in the :func:`~wagtail.utils.pagination.paginate`
-        function.
+        The name of the page variable in the query string. Defaults to 'p'.
 
     classnames
         Extra classes to add to the next/previous links.

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -8,7 +8,6 @@ from django.contrib.messages.constants import DEFAULT_TAGS as MESSAGE_TAGS
 from django.template.defaultfilters import stringfilter
 from django.template.loader import render_to_string
 from django.templatetags.static import static
-from django.utils.html import conditional_escape
 from django.utils.safestring import mark_safe
 
 from wagtail.admin.menu import admin_menu
@@ -20,7 +19,7 @@ from wagtail.core.models import (
 from wagtail.core.utils import cautious_slugify as _cautious_slugify
 from wagtail.core.utils import camelcase_to_underscore, escape_script
 from wagtail.users.utils import get_gravatar_url
-from wagtail.utils.pagination import DEFAULT_PAGE_KEY, replace_page_in_query
+from wagtail.utils.pagination import DEFAULT_PAGE_KEY
 
 register = template.Library()
 
@@ -358,14 +357,6 @@ def message_tags(message):
         return level_tag
     else:
         return ''
-
-
-@register.simple_tag
-def replace_page_param(query, page_number, page_key='p'):
-    """
-    Replaces ``page_key`` from query string with ``page_number``.
-    """
-    return conditional_escape(replace_page_in_query(query, page_number, page_key))
 
 
 @register.filter('abs')

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -1,4 +1,5 @@
 import itertools
+from warnings import warn
 
 from django import template
 from django.conf import settings
@@ -19,6 +20,7 @@ from wagtail.core.models import (
 from wagtail.core.utils import cautious_slugify as _cautious_slugify
 from wagtail.core.utils import camelcase_to_underscore, escape_script
 from wagtail.users.utils import get_gravatar_url
+from wagtail.utils.deprecation import RemovedInWagtail26Warning
 
 register = template.Library()
 
@@ -383,3 +385,11 @@ def avatar_url(user, size=50):
             return gravatar_url
 
     return static('wagtailadmin/images/default-user-avatar.png')
+
+
+@register.simple_tag
+def ajax_pagination_nav_deprecation_warning():
+    warn('Passing is_ajax=1 to wagtailadmin/shared/pagination_nav.html is deprecated. '
+         'Use wagtailadmin/shared/ajax_pagination_nav.html instead',
+         category=RemovedInWagtail26Warning)
+    return ''

--- a/wagtail/admin/views/chooser.py
+++ b/wagtail/admin/views/chooser.py
@@ -1,3 +1,4 @@
+from django.core.paginator import Paginator
 from django.http import Http404
 from django.shortcuts import get_object_or_404, render
 
@@ -7,7 +8,6 @@ from wagtail.admin.modal_workflow import render_modal_workflow
 from wagtail.core import hooks
 from wagtail.core.models import Page, UserPagePermissionsProxy
 from wagtail.core.utils import resolve_model_string
-from wagtail.utils.pagination import paginate
 
 
 def shared_context(request, extra_context=None):
@@ -115,7 +115,8 @@ def browse(request, parent_page_id=None):
     # Pagination
     # We apply pagination first so we don't need to walk the entire list
     # in the block below
-    paginator, pages = paginate(request, pages, per_page=25)
+    paginator = Paginator(pages, per_page=25)
+    pages = paginator.get_page(request.GET.get('p'))
 
     # Annotate each page with can_choose/can_decend flags
     for page in pages:
@@ -166,7 +167,8 @@ def search(request, parent_page_id=None):
     else:
         pages = pages.none()
 
-    paginator, pages = paginate(request, pages, per_page=25)
+    paginator = Paginator(pages, per_page=25)
+    pages = paginator.get_page(request.GET.get('p'))
 
     for page in pages:
         page.can_choose = True

--- a/wagtail/admin/views/pages.py
+++ b/wagtail/admin/views/pages.py
@@ -2,6 +2,7 @@ from time import time
 
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import PermissionDenied
+from django.core.paginator import Paginator
 from django.db import transaction
 from django.db.models import Count
 from django.http import Http404, HttpResponse, JsonResponse
@@ -26,7 +27,6 @@ from wagtail.admin.utils import send_notification, user_has_any_page_permission,
 from wagtail.core import hooks
 from wagtail.core.models import Page, PageRevision, UserPagePermissionsProxy
 from wagtail.search.query import MATCH_ALL
-from wagtail.utils.pagination import paginate
 
 
 def get_valid_next_url_from_request(request):
@@ -110,7 +110,8 @@ def index(request, parent_page_id=None):
 
     # Pagination
     if do_paginate:
-        paginator, pages = paginate(request, pages, per_page=50)
+        paginator = Paginator(pages, per_page=50)
+        pages = paginator.get_page(request.GET.get('p'))
 
     return render(request, 'wagtailadmin/pages/index.html', {
         'parent_page': parent_page.specific,
@@ -161,7 +162,8 @@ def content_type_use(request, content_type_app_name, content_type_model_name):
 
     pages = page_class.objects.all()
 
-    paginator, pages = paginate(request, pages, per_page=10)
+    paginator = Paginator(pages, per_page=10)
+    pages = paginator.get_page(request.GET.get('p'))
 
     return render(request, 'wagtailadmin/pages/content_type_use.html', {
         'pages': pages,
@@ -739,7 +741,8 @@ def move_choose_destination(request, page_to_move_id, viewed_page_id=None):
         child_pages.append(target)
 
     # Pagination
-    paginator, child_pages = paginate(request, child_pages, per_page=50)
+    paginator = Paginator(child_pages, per_page=50)
+    child_pages = paginator.get_page(request.GET.get('p'))
 
     return render(request, 'wagtailadmin/pages/move_choose_destination.html', {
         'page_to_move': page_to_move,
@@ -956,7 +959,8 @@ def search(request):
     else:
         form = SearchForm()
 
-    paginator, pages = paginate(request, pages)
+    paginator = Paginator(pages, per_page=20)
+    pages = paginator.get_page(request.GET.get('p'))
 
     if request.is_ajax():
         return render(request, "wagtailadmin/pages/search_results.html", {
@@ -1104,7 +1108,8 @@ def revisions_index(request, page_id):
 
     revisions = page.revisions.order_by(ordering)
 
-    paginator, revisions = paginate(request, revisions)
+    paginator = Paginator(revisions, per_page=20)
+    revisions = paginator.get_page(request.GET.get('p'))
 
     return render(request, 'wagtailadmin/pages/revisions/index.html', {
         'page': page,

--- a/wagtail/contrib/forms/templates/wagtailforms/index_submissions.html
+++ b/wagtail/contrib/forms/templates/wagtailforms/index_submissions.html
@@ -106,7 +106,7 @@
         {% if submissions %}
             <form action="{% url 'wagtailforms:delete_submissions' form_page.id %}" method="get">
                 {% include "wagtailforms/list_submissions.html" %}
-                {% include "wagtailadmin/shared/pagination_nav.html" with items=page_obj is_searching=False %}
+                {% include "wagtailadmin/shared/pagination_nav.html" with items=page_obj %}
             </form>
         {% else %}
             <p class="no-results-message">{% blocktrans with title=form_page.title %}There have been no submissions of the '{{ title }}' form.{% endblocktrans %}</p>

--- a/wagtail/contrib/forms/views.py
+++ b/wagtail/contrib/forms/views.py
@@ -13,7 +13,6 @@ from wagtail.admin import messages
 from wagtail.contrib.forms.forms import SelectDateForm
 from wagtail.contrib.forms.utils import get_forms_for_user
 from wagtail.core.models import Page
-from wagtail.utils.pagination import DEFAULT_PAGE_KEY
 
 
 def get_submissions_list_view(request, *args, **kwargs):
@@ -27,7 +26,7 @@ class SafePaginateListView(ListView):
     """ Listing view with safe pagination, allowing incorrect or out of range values """
 
     paginate_by = 20
-    page_kwarg = DEFAULT_PAGE_KEY
+    page_kwarg = 'p'
 
     def paginate_queryset(self, queryset, page_size):
         """Paginate the queryset if needed with nice defaults on invalid param."""

--- a/wagtail/contrib/redirects/templates/wagtailredirects/results.html
+++ b/wagtail/contrib/redirects/templates/wagtailredirects/results.html
@@ -12,7 +12,7 @@
 
     {% include "wagtailredirects/list.html" %}
 
-    {% include "wagtailadmin/shared/pagination_nav.html" with items=redirects is_searching=query_string linkurl="wagtailredirects:index" %}
+    {% include "wagtailadmin/shared/pagination_nav.html" with items=redirects linkurl="wagtailredirects:index" %}
 {% else %}
      {% if query_string %}
          <p>{% blocktrans %}Sorry, no redirects match "<em>{{ query_string }}</em>"{% endblocktrans %}

--- a/wagtail/contrib/redirects/views.py
+++ b/wagtail/contrib/redirects/views.py
@@ -1,3 +1,4 @@
+from django.core.paginator import Paginator
 from django.db.models import Q
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
@@ -10,7 +11,6 @@ from wagtail.admin.utils import PermissionPolicyChecker, permission_denied
 from wagtail.contrib.redirects import models
 from wagtail.contrib.redirects.forms import RedirectForm
 from wagtail.contrib.redirects.permissions import permission_policy
-from wagtail.utils.pagination import paginate
 
 permission_checker = PermissionPolicyChecker(permission_policy)
 
@@ -36,7 +36,8 @@ def index(request):
     redirects = redirects.order_by(ordering)
 
     # Pagination
-    paginator, redirects = paginate(request, redirects)
+    paginator = Paginator(redirects, per_page=20)
+    redirects = paginator.get_page(request.GET.get('p'))
 
     # Render template
     if request.is_ajax():

--- a/wagtail/contrib/search_promotions/templates/wagtailsearchpromotions/results.html
+++ b/wagtail/contrib/search_promotions/templates/wagtailsearchpromotions/results.html
@@ -12,7 +12,7 @@
 
     {% include "wagtailsearchpromotions/list.html" %}
 
-    {% include "wagtailadmin/shared/pagination_nav.html" with items=queries is_searching=is_searching linkurl="wagtailsearchpromotions:index" %}
+    {% include "wagtailadmin/shared/pagination_nav.html" with items=queries linkurl="wagtailsearchpromotions:index" %}
 {% else %}
     {% if is_searching %}
          <p>{% blocktrans %}Sorry, no promoted results match "<em>{{ query_string }}</em>"{% endblocktrans %}</p>

--- a/wagtail/contrib/search_promotions/views.py
+++ b/wagtail/contrib/search_promotions/views.py
@@ -1,3 +1,4 @@
+from django.core.paginator import Paginator
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils.translation import ugettext as _
@@ -9,7 +10,6 @@ from wagtail.admin.utils import any_permission_required, permission_required
 from wagtail.contrib.search_promotions import forms
 from wagtail.search import forms as search_forms
 from wagtail.search.models import Query
-from wagtail.utils.pagination import paginate
 
 
 @any_permission_required(
@@ -29,7 +29,8 @@ def index(request):
         queries = queries.filter(query_string__icontains=query_string)
         is_searching = True
 
-    paginator, queries = paginate(request, queries)
+    paginator = Paginator(queries, per_page=20)
+    queries = paginator.get_page(request.GET.get('p'))
 
     if request.is_ajax():
         return render(request, "wagtailsearchpromotions/results.html", {

--- a/wagtail/documents/templates/wagtaildocs/chooser/results.html
+++ b/wagtail/documents/templates/wagtaildocs/chooser/results.html
@@ -14,7 +14,7 @@
 
     {% include "wagtaildocs/documents/list.html" with choosing=1 %}
 
-    {% include "wagtailadmin/shared/pagination_nav.html" with items=documents is_ajax=1 %}
+    {% include "wagtailadmin/shared/ajax_pagination_nav.html" with items=documents %}
 {% else %}
     {% if documents_exist %}
         <p>{% blocktrans %}Sorry, no documents match "<em>{{ query_string }}</em>"{% endblocktrans %}</p>

--- a/wagtail/documents/templates/wagtaildocs/documents/results.html
+++ b/wagtail/documents/templates/wagtaildocs/documents/results.html
@@ -14,7 +14,7 @@
 
     {% include "wagtaildocs/documents/list.html" %}
 
-    {% include "wagtailadmin/shared/pagination_nav.html" with items=documents is_searching=is_searching %}
+    {% include "wagtailadmin/shared/pagination_nav.html" with items=documents %}
 {% else %}
     {% if is_searching %}
          <h2>{% blocktrans %}Sorry, no documents match "<em>{{ query_string }}</em>"{% endblocktrans %}</h2>

--- a/wagtail/documents/templates/wagtaildocs/documents/usage.html
+++ b/wagtail/documents/templates/wagtaildocs/documents/usage.html
@@ -41,5 +41,5 @@
             </tbody>
         </table>
     </div>
-    {% include "wagtailadmin/shared/pagination_nav.html" with items=used_by linkurl="-" %}
+    {% include "wagtailadmin/shared/pagination_nav.html" with items=used_by %}
 {% endblock %}

--- a/wagtail/documents/views/chooser.py
+++ b/wagtail/documents/views/chooser.py
@@ -1,3 +1,4 @@
+from django.core.paginator import Paginator
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
 from django.utils.translation import ugettext as _
@@ -11,7 +12,6 @@ from wagtail.documents.forms import get_document_form
 from wagtail.documents.models import get_document_model
 from wagtail.documents.permissions import permission_policy
 from wagtail.search import index as search_index
-from wagtail.utils.pagination import paginate
 
 permission_checker = PermissionPolicyChecker(permission_policy)
 
@@ -75,7 +75,8 @@ def chooser(request):
             is_searching = False
 
         # Pagination
-        paginator, documents = paginate(request, documents, per_page=10)
+        paginator = Paginator(documents, per_page=10)
+        documents = paginator.get_page(request.GET.get('p'))
 
         return render(request, "wagtaildocs/chooser/results.html", {
             'documents': documents,
@@ -96,7 +97,8 @@ def chooser(request):
 
         documents = documents.order_by('-created_at')
         documents_exist = documents.exists()
-        paginator, documents = paginate(request, documents, per_page=10)
+        paginator = Paginator(documents, per_page=10)
+        documents = paginator.get_page(request.GET.get('p'))
 
         return render_modal_workflow(request, 'wagtaildocs/chooser/chooser.html', None, {
             'documents': documents,

--- a/wagtail/documents/views/documents.py
+++ b/wagtail/documents/views/documents.py
@@ -1,5 +1,6 @@
 import os
 
+from django.core.paginator import Paginator
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils.translation import ugettext as _
@@ -13,7 +14,6 @@ from wagtail.documents.forms import get_document_form
 from wagtail.documents.models import get_document_model
 from wagtail.documents.permissions import permission_policy
 from wagtail.search import index as search_index
-from wagtail.utils.pagination import paginate
 
 permission_checker = PermissionPolicyChecker(permission_policy)
 
@@ -56,7 +56,8 @@ def index(request):
         form = SearchForm(placeholder=_("Search documents"))
 
     # Pagination
-    paginator, documents = paginate(request, documents)
+    paginator = Paginator(documents, per_page=20)
+    documents = paginator.get_page(request.GET.get('p'))
 
     collections = permission_policy.collections_user_has_any_permission_for(
         request.user, ['add', 'change']
@@ -211,7 +212,8 @@ def usage(request, document_id):
     Document = get_document_model()
     doc = get_object_or_404(Document, id=document_id)
 
-    paginator, used_by = paginate(request, doc.get_usage())
+    paginator = Paginator(doc.get_usage(), per_page=20)
+    used_by = paginator.get_page(request.GET.get('p'))
 
     return render(request, "wagtaildocs/documents/usage.html", {
         'document': doc,

--- a/wagtail/images/templates/wagtailimages/chooser/results.html
+++ b/wagtail/images/templates/wagtailimages/chooser/results.html
@@ -24,5 +24,5 @@
         {% endfor %}
     </ul>
 
-    {% include "wagtailadmin/shared/pagination_nav.html" with items=images is_ajax=1 %}
+    {% include "wagtailadmin/shared/ajax_pagination_nav.html" with items=images %}
 {% endif %}

--- a/wagtail/images/templates/wagtailimages/images/results.html
+++ b/wagtail/images/templates/wagtailimages/images/results.html
@@ -26,7 +26,7 @@
         {% endfor %}
     </ul>
 
-    {% include "wagtailadmin/shared/pagination_nav.html" with items=images is_searching=is_searching query_string=query_string %}
+    {% include "wagtailadmin/shared/pagination_nav.html" with items=images %}
 
 {% else %}
     {% if is_searching %}

--- a/wagtail/images/templates/wagtailimages/images/usage.html
+++ b/wagtail/images/templates/wagtailimages/images/usage.html
@@ -41,5 +41,5 @@
             </tbody>
         </table>
     </div>
-    {% include "wagtailadmin/shared/pagination_nav.html" with items=used_by linkurl="-" %}
+    {% include "wagtailadmin/shared/pagination_nav.html" with items=used_by %}
 {% endblock %}

--- a/wagtail/images/views/chooser.py
+++ b/wagtail/images/views/chooser.py
@@ -1,3 +1,4 @@
+from django.core.paginator import Paginator
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
 from django.utils.translation import ugettext as _
@@ -12,7 +13,6 @@ from wagtail.images.formats import get_image_format
 from wagtail.images.forms import ImageInsertionForm, get_image_form
 from wagtail.images.permissions import permission_policy
 from wagtail.search import index as search_index
-from wagtail.utils.pagination import paginate
 
 permission_checker = PermissionPolicyChecker(permission_policy)
 
@@ -105,7 +105,8 @@ def chooser(request):
                 images = images.filter(tags__name=tag_name)
 
         # Pagination
-        paginator, images = paginate(request, images, per_page=12)
+        paginator = Paginator(images, per_page=12)
+        images = paginator.get_page(request.GET.get('p'))
 
         return render(request, "wagtailimages/chooser/results.html", {
             'images': images,
@@ -114,7 +115,8 @@ def chooser(request):
             'will_select_format': request.GET.get('select_format')
         })
     else:
-        paginator, images = paginate(request, images, per_page=12)
+        paginator = Paginator(images, per_page=12)
+        images = paginator.get_page(request.GET.get('p'))
 
         context = get_chooser_context(request)
         context.update({
@@ -180,7 +182,8 @@ def chooser_upload(request):
     for hook in hooks.get_hooks('construct_image_chooser_queryset'):
         images = hook(images, request)
 
-    paginator, images = paginate(request, images, per_page=12)
+    paginator = Paginator(images, per_page=12)
+    images = paginator.get_page(request.GET.get('p'))
 
     context = get_chooser_context(request)
     context.update({

--- a/wagtail/search/views/queries.py
+++ b/wagtail/search/views/queries.py
@@ -1,10 +1,10 @@
+from django.core.paginator import Paginator
 from django.shortcuts import render
 
 from wagtail.admin.forms.search import SearchForm
 from wagtail.admin.modal_workflow import render_modal_workflow
 from wagtail.search import models
 from wagtail.search.utils import normalise_query_string
-from wagtail.utils.pagination import paginate
 
 
 def chooser(request, get_results=False):
@@ -21,7 +21,8 @@ def chooser(request, get_results=False):
     else:
         searchform = SearchForm()
 
-    paginator, queries = paginate(request, queries, per_page=10)
+    paginator = Paginator(queries, per_page=10)
+    queries = paginator.get_page(request.GET.get('p'))
 
     # Render
     if get_results:

--- a/wagtail/snippets/templates/wagtailsnippets/chooser/results.html
+++ b/wagtail/snippets/templates/wagtailsnippets/chooser/results.html
@@ -12,7 +12,7 @@
 
     {% include "wagtailsnippets/snippets/list.html" with choosing=1 %}
 
-    {% include "wagtailadmin/shared/pagination_nav.html" with items=items is_ajax=1 %}
+    {% include "wagtailadmin/shared/ajax_pagination_nav.html" with items=items %}
 {% else %}
     {% if is_searching %}
          <p>{% blocktrans %}Sorry, no snippets match "<em>{{ query_string }}</em>"{% endblocktrans %}</p>

--- a/wagtail/snippets/templates/wagtailsnippets/snippets/results.html
+++ b/wagtail/snippets/templates/wagtailsnippets/snippets/results.html
@@ -13,7 +13,7 @@
     {% include "wagtailsnippets/snippets/list.html" %}
 
     {% url 'wagtailsnippets:list' model_opts.app_label model_opts.model_name as wagtailsnippets_list_url %}
-    {% include "wagtailadmin/shared/pagination_nav.html" with items=items is_searching=is_searching linkurl=wagtailsnippets_list_url %}
+    {% include "wagtailadmin/shared/pagination_nav.html" with items=items linkurl=wagtailsnippets_list_url %}
 {% else %}
     {% if is_searching %}
          <p>{% blocktrans %}Sorry, no snippets match "<em>{{ query_string }}</em>"{% endblocktrans %}</p>

--- a/wagtail/snippets/templates/wagtailsnippets/snippets/usage.html
+++ b/wagtail/snippets/templates/wagtailsnippets/snippets/usage.html
@@ -41,5 +41,5 @@
             </tbody>
         </table>
     </div>
-    {% include "wagtailadmin/shared/pagination_nav.html" with items=used_by linkurl="-"%}
+    {% include "wagtailadmin/shared/pagination_nav.html" with items=used_by %}
 {% endblock %}

--- a/wagtail/snippets/views/chooser.py
+++ b/wagtail/snippets/views/chooser.py
@@ -1,4 +1,5 @@
 from django.contrib.admin.utils import quote, unquote
+from django.core.paginator import Paginator
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
 from django.utils.translation import ugettext as _
@@ -8,7 +9,6 @@ from wagtail.admin.modal_workflow import render_modal_workflow
 from wagtail.search.backends import get_search_backend
 from wagtail.search.index import class_is_indexed
 from wagtail.snippets.views.snippets import get_snippet_model_from_url_params
-from wagtail.utils.pagination import paginate
 
 
 def choose(request, app_label, model_name):
@@ -43,7 +43,8 @@ def choose(request, app_label, model_name):
         })
 
     # Pagination
-    paginator, paginated_items = paginate(request, items, per_page=25)
+    paginator = Paginator(items, per_page=25)
+    paginated_items = paginator.get_page(request.GET.get('p'))
 
     # If paginating or searching, render "results.html"
     if request.GET.get('results', None) == 'true':

--- a/wagtail/snippets/views/snippets.py
+++ b/wagtail/snippets/views/snippets.py
@@ -2,6 +2,7 @@ from urllib.parse import urlencode
 
 from django.apps import apps
 from django.contrib.admin.utils import quote, unquote
+from django.core.paginator import Paginator
 from django.http import Http404
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
@@ -16,7 +17,6 @@ from wagtail.search.backends import get_search_backend
 from wagtail.search.index import class_is_indexed
 from wagtail.snippets.models import get_snippet_models
 from wagtail.snippets.permissions import get_permission_name, user_can_edit_snippet_type
-from wagtail.utils.pagination import paginate
 
 
 # == Helper functions ==
@@ -103,7 +103,8 @@ def list(request, app_label, model_name):
             'snippet_type_name': model._meta.verbose_name_plural
         })
 
-    paginator, paginated_items = paginate(request, items)
+    paginator = Paginator(items, per_page=20)
+    paginated_items = paginator.get_page(request.GET.get('p'))
 
     # Template
     if request.is_ajax():
@@ -267,7 +268,8 @@ def usage(request, app_label, model_name, pk):
     model = get_snippet_model_from_url_params(app_label, model_name)
     instance = get_object_or_404(model, pk=unquote(pk))
 
-    paginator, used_by = paginate(request, instance.get_usage())
+    paginator = Paginator(instance.get_usage(), per_page=20)
+    used_by = paginator.get_page(request.GET.get('p'))
 
     return render(request, "wagtailsnippets/snippets/usage.html", {
         'instance': instance,

--- a/wagtail/tests/demosite/models.py
+++ b/wagtail/tests/demosite/models.py
@@ -1,5 +1,6 @@
 from datetime import date
 
+from django.core.paginator import Paginator
 from django.db import models
 from modelcluster.contrib.taggit import ClusterTaggableManager
 from modelcluster.fields import ParentalKey
@@ -13,7 +14,6 @@ from wagtail.documents.edit_handlers import DocumentChooserPanel
 from wagtail.images.api.fields import ImageRenditionField
 from wagtail.images.edit_handlers import ImageChooserPanel
 from wagtail.search import index
-from wagtail.utils.pagination import paginate
 
 
 # ABSTRACT MODELS
@@ -351,7 +351,8 @@ class BlogIndexPage(Page):
         if tag:
             entries = entries.filter(tags__name=tag)
 
-        paginator, entries = paginate(request, entries, page_key='page', per_page=10)
+        paginator = Paginator(entries, per_page=10)
+        entries = paginator.get_page(request.GET.get('page'))
 
         # Update template context
         context = super().get_context(request)

--- a/wagtail/users/templates/wagtailusers/groups/results.html
+++ b/wagtail/users/templates/wagtailusers/groups/results.html
@@ -3,7 +3,7 @@
 {% if groups %}
     {% include "wagtailusers/groups/list.html" %}
 
-    {% include "wagtailadmin/shared/pagination_nav.html" with items=page_obj is_searching=is_searching linkurl="wagtailusers_groups:index" %}
+    {% include "wagtailadmin/shared/pagination_nav.html" with items=page_obj linkurl="wagtailusers_groups:index" %}
 {% elif is_searching %}
     <p>{% blocktrans with query=search_form.q.value %}Sorry, no groups match "{{ query }}"{% endblocktrans %}</p>
 {% else %}

--- a/wagtail/users/templates/wagtailusers/users/results.html
+++ b/wagtail/users/templates/wagtailusers/users/results.html
@@ -14,7 +14,7 @@
 
     {% include "wagtailusers/users/list.html" %}
 
-    {% include "wagtailadmin/shared/pagination_nav.html" with items=users is_searching=is_searching linkurl="wagtailusers_users:index" %}
+    {% include "wagtailadmin/shared/pagination_nav.html" with items=users linkurl="wagtailusers_users:index" %}
 {% else %}
     {% if is_searching %}
          <h2>{% blocktrans %}Sorry, no users match "<em>{{ query_string }}</em>"{% endblocktrans %}</h2>

--- a/wagtail/users/views/users.py
+++ b/wagtail/users/views/users.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 from django.contrib.auth import get_user_model, update_session_auth_hash
+from django.core.paginator import Paginator
 from django.db.models import Q
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
@@ -14,7 +15,6 @@ from wagtail.core.compat import AUTH_USER_APP_LABEL, AUTH_USER_MODEL_NAME
 from wagtail.users.forms import UserCreationForm, UserEditForm
 from wagtail.users.utils import user_can_delete_user
 from wagtail.utils.loading import get_custom_form
-from wagtail.utils.pagination import paginate
 
 User = get_user_model()
 
@@ -88,7 +88,8 @@ def index(request):
     else:
         ordering = 'name'
 
-    paginator, users = paginate(request, users)
+    paginator = Paginator(users, per_page=20)
+    users = paginator.get_page(request.GET.get('p'))
 
     if request.is_ajax():
         return render(request, "wagtailusers/users/results.html", {

--- a/wagtail/utils/pagination.py
+++ b/wagtail/utils/pagination.py
@@ -1,4 +1,14 @@
+from warnings import warn
+
 from django.core.paginator import Paginator
+
+from wagtail.utils.deprecation import RemovedInWagtail27Warning
+
+
+warn('wagtail.utils.pagination is deprecated. '
+     'Use django.core.paginator.Paginator directly with get_page instead',
+     category=RemovedInWagtail27Warning)
+
 
 DEFAULT_PAGE_KEY = 'p'
 

--- a/wagtail/utils/pagination.py
+++ b/wagtail/utils/pagination.py
@@ -1,17 +1,9 @@
-from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
+from django.core.paginator import Paginator
 
 DEFAULT_PAGE_KEY = 'p'
 
 
 def paginate(request, items, page_key=DEFAULT_PAGE_KEY, per_page=20):
-    page = request.GET.get(page_key, 1)
-
     paginator = Paginator(items, per_page)
-    try:
-        page = paginator.page(page)
-    except PageNotAnInteger:
-        page = paginator.page(1)
-    except EmptyPage:
-        page = paginator.page(paginator.num_pages)
-
+    page = paginator.get_page(request.GET.get(page_key))
     return paginator, page

--- a/wagtail/utils/pagination.py
+++ b/wagtail/utils/pagination.py
@@ -1,7 +1,4 @@
-from urllib.parse import parse_qs
-
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
-from django.utils.http import urlencode
 
 DEFAULT_PAGE_KEY = 'p'
 
@@ -18,20 +15,3 @@ def paginate(request, items, page_key=DEFAULT_PAGE_KEY, per_page=20):
         page = paginator.page(paginator.num_pages)
 
     return paginator, page
-
-
-def replace_page_in_query(query, page_number, page_key=DEFAULT_PAGE_KEY):
-    """
-    Replaces ``page_key`` from query string with ``page_number``.
-
-    >>> replace_page_in_query("p=1&key=value", 2)
-    'p=2&key=value'
-    >>> replace_page_in_query("p=1&key=value", None)
-    'key=value'
-    """
-    getvars = parse_qs(query)
-    if page_number is None:
-        getvars.pop(page_key, None)
-    else:
-        getvars[page_key] = page_number
-    return urlencode(getvars, True)


### PR DESCRIPTION
Rather than having messy individual cases for searching vs not searching vs no base URL, use the `{% querystring %}` tag to consistently preserve all query params. Also eliminate the `replace_page_param` tag, which just duplicated `{% querystring %}` but with less functionality.