### PR TITLE
When two date fields are in the same form, chrome ignores multiple au…

### DIFF
--- a/wagtail/admin/tests/test_widgets.py
+++ b/wagtail/admin/tests/test_widgets.py
@@ -94,7 +94,7 @@ class TestAdminDateInput(TestCase):
 
         html = widget.render('test', None, attrs={'id': 'test-id'})
 
-        self.assertInHTML('<input type="text" name="test" autocomplete="off" id="test-id" />', html)
+        self.assertInHTML('<input type="text" name="test" autocomplete="new-date" id="test-id" />', html)
 
         # we should see the JS initialiser code:
         # initDateChooser("test-id", {"dayOfWeekStart": 0, "format": "Y-m-d"});
@@ -130,7 +130,7 @@ class TestAdminDateTimeInput(TestCase):
 
         html = widget.render('test', None, attrs={'id': 'test-id'})
 
-        self.assertInHTML('<input type="text" name="test" autocomplete="off" id="test-id" />', html)
+        self.assertInHTML('<input type="text" name="test" autocomplete="new-date-time" id="test-id" />', html)
 
         # we should see the JS initialiser code:
         # initDateTimeChooser("test-id", {"dayOfWeekStart": 0, "format": "Y-m-d H:i"});

--- a/wagtail/admin/widgets.py
+++ b/wagtail/admin/widgets.py
@@ -38,7 +38,7 @@ class AdminDateInput(widgets.DateInput):
     template_name = 'wagtailadmin/widgets/date_input.html'
 
     def __init__(self, attrs=None, format=None):
-        default_attrs = {'autocomplete': 'off'}
+        default_attrs = {'autocomplete': 'new-date'}
         fmt = format
         if attrs:
             default_attrs.update(attrs)
@@ -63,7 +63,7 @@ class AdminTimeInput(widgets.TimeInput):
     template_name = 'wagtailadmin/widgets/time_input.html'
 
     def __init__(self, attrs=None, format='%H:%M'):
-        default_attrs = {'autocomplete': 'off'}
+        default_attrs = {'autocomplete': 'new-time'}
         if attrs:
             default_attrs.update(attrs)
         super().__init__(attrs=default_attrs, format=format)
@@ -73,7 +73,7 @@ class AdminDateTimeInput(widgets.DateTimeInput):
     template_name = 'wagtailadmin/widgets/datetime_input.html'
 
     def __init__(self, attrs=None, format=None):
-        default_attrs = {'autocomplete': 'off'}
+        default_attrs = {'autocomplete': 'new-date-time'}
         fmt = format
         if attrs:
             default_attrs.update(attrs)

--- a/wagtail/core/tests/test_blocks.py
+++ b/wagtail/core/tests/test_blocks.py
@@ -2929,7 +2929,7 @@ class TestDateBlock(TestCase):
         self.assertIn('"format": "Y-m-d"', result)
 
         self.assertInHTML(
-            '<input id="dateblock" name="dateblock" placeholder="" type="text" value="2015-08-13" autocomplete="off" />',
+            '<input id="dateblock" name="dateblock" placeholder="" type="text" value="2015-08-13" autocomplete="new-date" />',
             result
         )
 
@@ -2942,7 +2942,7 @@ class TestDateBlock(TestCase):
         self.assertIn('"dayOfWeekStart": 0', result)
         self.assertIn('"format": "d.m.Y"', result)
         self.assertInHTML(
-            '<input id="dateblock" name="dateblock" placeholder="" type="text" value="13.08.2015" autocomplete="off" />',
+            '<input id="dateblock" name="dateblock" placeholder="" type="text" value="13.08.2015" autocomplete="new-date" />',
             result
         )
 
@@ -2958,7 +2958,7 @@ class TestDateTimeBlock(TestCase):
             result
         )
         self.assertInHTML(
-            '<input id="datetimeblock" name="datetimeblock" placeholder="" type="text" value="13.08.2015 10:00" autocomplete="off" />',
+            '<input id="datetimeblock" name="datetimeblock" placeholder="" type="text" value="13.08.2015 10:00" autocomplete="new-date-time" />',
             result
         )
 


### PR DESCRIPTION
…tocomplete=off values.

Issue https://github.com/wagtail/wagtail/issues/5134

I've investigated [various fixes](https://stackoverflow.com/questions/15738259/disabling-chrome-autofill) for this known issue with chromes autocomplete, some workarounds suggested adding duplicate input fields, which sounds bad. My suggestion here is taken from what people suggest doing with password update fields.
