### PR TITLE
Abort unfinished ajax before firing new ajax call. Fix #4594

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -33,6 +33,7 @@ Changelog
  * Fix: `send_mail` now correctly uses the `html_message` kwarg for HTML messages (Tiago Requeijo)
  * Fix: Page copying no longer allowed if page model has reached its `max_count` (Andy Babic)
  * Fix: Don't show page type on page chooser button when multiple types are allowed (Thijs Kramer)
+ * Fix: Make sure page chooser search results correspond to the latest search by canceling previous requests (Esper Kuijs)
 
 
 2.4 (19.12.2018)

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -353,6 +353,7 @@ Contributors
 * Gassan Gousseinov
 * Thomas Kremmel
 * patta42
+* Esper Kuijs
 
 Translators
 ===========

--- a/docs/releases/2.5.rst
+++ b/docs/releases/2.5.rst
@@ -49,6 +49,7 @@ Bug fixes
  * ``send_mail`` now correctly uses the ``html_message`` kwarg for HTML messages (Tiago Requeijo)
  * Page copying no longer allowed if page model has reached its ``max_count`` (Andy Babic)
  * Don't show page type on page chooser button when multiple types are allowed (Thijs Kramer)
+ * Make sure page chooser search results correspond to the latest search by canceling previous requests (Esper Kuijs)
 
 
 Upgrade considerations

--- a/wagtail/admin/static_src/wagtailadmin/js/page-chooser-modal.js
+++ b/wagtail/admin/static_src/wagtailadmin/js/page-chooser-modal.js
@@ -25,16 +25,19 @@ PAGE_CHOOSER_MODAL_ONLOAD_HANDLERS = {
         /* save initial page browser HTML, so that we can restore it if the search box gets cleared */
         var initialPageResultsHtml = $('.page-results', modal.body).html();
 
+        var request;
+
         function search() {
             var query = $('#id_q', modal.body).val();
             if (query != '') {
-                $.ajax({
+                request = $.ajax({
                     url: searchUrl,
                     data: {
                         q: query,
                         results_only: true
                     },
                     success: function(data, status) {
+                        request = null;
                         $('.page-results', modal.body).html(data);
                         ajaxifySearchResults();
                     }
@@ -48,6 +51,9 @@ PAGE_CHOOSER_MODAL_ONLOAD_HANDLERS = {
         }
 
         $('#id_q', modal.body).on('input', function() {
+            if(request) {
+              request.abort();
+            }
             clearTimeout($.data(this, 'timer'));
             var wait = setTimeout(search, 200);
             $(this).data('timer', wait);


### PR DESCRIPTION
Fixes #4594. To prevent showing old results always cancel unfinished query requests before firing a new one.

* [x] Do the tests still pass? (http://docs.wagtail.io/en/latest/contributing/developing.html#testing)
* [x] Does the code comply with the style guide? (Run `make lint` from the Wagtail root)
* ~~[ ] For Python changes: Have you added tests to cover the new/fixed behaviour?~~
* [x] For front-end changes: Did you test on all of Wagtail’s supported browsers? **Please list the exact versions you tested**. 
* ~~[ ] For new features: Has the documentation been updated accordingly?~~
