### PR TITLE
WIP - Add image rotation in image edit screen. (#2901)

### DIFF
--- a/docs/editor_manual/documents_images_snippets/images.rst
+++ b/docs/editor_manual/documents_images_snippets/images.rst
@@ -28,3 +28,13 @@ ___________
 * To set the focal area, drag a marquee around the most important element of the image.
 * To remove the focal area, hit the button below the image.
 * If the feature is set up in your website, then on the front-end you will see the crop of this image focusing on your selection.
+
+Rotating images
+______________________
+
+Rotate uploaded images with the "Rotate image" button - this will rotate the image in 90 degree steps clockwise.
+
+You will need to save the image for your changes to be stored.
+
+.. Warning::
+    Changing the file rotation will change it on all pages that use the image. You will also need to update the focal point if it is already set.

--- a/rough-plan.md
+++ b/rough-plan.md
@@ -1,0 +1,7 @@
+This is just here so we have a change to make a WIP PR - nuke it afterwards
+
+- add rotate field to form
+- add single button for rotate
+- add css rotate code
+
+We'll just just do this bit for now, so we can review in person at wagtil.space

--- a/wagtail/images/forms.py
+++ b/wagtail/images/forms.py
@@ -65,7 +65,7 @@ class BaseImageForm(BaseCollectionMemberForm):
 
     def save(self, *args, **kwargs):
         """
-        Save form, handling case for rotating images
+        Save form, handling the special case for rotating images
         """
 
         if 'rotation' in self.changed_data:
@@ -80,9 +80,10 @@ class BaseImageForm(BaseCollectionMemberForm):
 
             self.instance.file.save(file_name, rotated_image_file, save=True)
 
-            super(BaseImageForm, self).save(*args, **kwargs)
+            rotated_image_file.seek(0)
+            self.instance._set_file_hash(rotated_image_file.read())
 
-            # update_hash
+        super(BaseImageForm, self).save(*args, **kwargs)
 
 
 def get_image_form(model):

--- a/wagtail/images/forms.py
+++ b/wagtail/images/forms.py
@@ -6,6 +6,7 @@ from django.utils.translation import ugettext as _
 from wagtail.admin import widgets
 from wagtail.admin.forms.collections import (
     BaseCollectionMemberForm, collection_member_permission_formset_factory)
+from wagtail.images import get_image_model
 from wagtail.images.fields import WagtailImageField
 from wagtail.images.formats import get_image_formats
 from wagtail.images.models import Image
@@ -29,6 +30,36 @@ class BaseImageForm(BaseCollectionMemberForm):
         widget=forms.HiddenInput(attrs={'class': 'rotation'}),
         help_text="Press to rotate this image clockwise by 90 degrees.",
     )
+
+
+    def save(self, *args, **kwargs):
+        """
+        When making form submissions, check if we need to update corresponding
+        information about the image, in case we rotate or change the file this Image
+        links to.
+        """
+
+
+
+        # call super as usual
+        if 'rotation' in self.changed_data:
+
+            # rotate the new image, and then put the new
+            # image in place of the previous one
+            # self.instance.rotate
+
+
+        if 'file' in self.changed_data:
+                # Set new image file size
+                image.file_size = image.file.size
+
+                # Set new image file hash
+                image.file.seek(0)
+                image._set_file_hash(image.file.read())
+                image.file.seek(0)
+
+
+
 
 
 def get_image_form(model):
@@ -57,6 +88,7 @@ def get_image_form(model):
             'focal_point_width': forms.HiddenInput(attrs={'class': 'focal_point_width'}),
             'focal_point_height': forms.HiddenInput(attrs={'class': 'focal_point_height'}),
         })
+
 
 
 class ImageInsertionForm(forms.Form):

--- a/wagtail/images/forms.py
+++ b/wagtail/images/forms.py
@@ -25,9 +25,15 @@ def formfield_for_dbfield(db_field, **kwargs):
 class BaseImageForm(BaseCollectionMemberForm):
     permission_policy = images_permission_policy
 
+    rotation = forms.CharField(max_length=100,
+        widget=forms.HiddenInput(attrs={'class': 'rotation'}),
+        help_text="Press to rotate this image clockwise by 90 degrees.",
+    )
+
 
 def get_image_form(model):
     fields = model.admin_form_fields
+
     if 'collection' not in fields:
         # force addition of the 'collection' field, because leaving it out can
         # cause dubious results when multiple collections exist (e.g adding the

--- a/wagtail/images/forms.py
+++ b/wagtail/images/forms.py
@@ -43,7 +43,7 @@ class BaseImageForm(BaseCollectionMemberForm):
         file_extension = self.instance.filename.split(".")[-1].lower()
 
         formats = {
-            "gif":  willow_image.save_as_gif,
+            "gif": willow_image.save_as_gif,
             "jpg": willow_image.save_as_jpeg,
             "jpeg": willow_image.save_as_jpeg,
             "png": willow_image.save_as_png,
@@ -53,7 +53,6 @@ class BaseImageForm(BaseCollectionMemberForm):
         res = formats[file_extension](BytesIO())
 
         return ImageFile(res.f, name=self.instance.file.name)
-
 
     def remove_stale_image_files(self):
         """

--- a/wagtail/images/models.py
+++ b/wagtail/images/models.py
@@ -232,6 +232,12 @@ class AbstractImage(CollectionMember, index.Indexed, models.Model):
             self.focal_point_width = None
             self.focal_point_height = None
 
+    def rotate(self, angle):
+        with self.get_willow_image() as willow:
+            image = willow.rotate(angle)
+
+            return image
+
     def get_suggested_focal_point(self):
         with self.get_willow_image() as willow:
             faces = willow.detect_faces()

--- a/wagtail/images/templates/wagtailimages/images/_file_field_as_li.html
+++ b/wagtail/images/templates/wagtailimages/images/_file_field_as_li.html
@@ -3,7 +3,7 @@
     {% include "wagtailimages/images/_file_field.html" %}
 
 
-                <button class="button image-rotation" type="button" style="margin-bottom:2rem;">
+                <button class="button image-rotation" type="button" style="padding-bottom:0.3rem;">
                 <span style="margin-right:0.5rem;">{% trans "Rotate image" %}</span>
 
                 <img src="{% static 'wagtailimages/img/img-rotate.svg' %}" style="width:1.5rem;" />

--- a/wagtail/images/templates/wagtailimages/images/_file_field_as_li.html
+++ b/wagtail/images/templates/wagtailimages/images/_file_field_as_li.html
@@ -4,7 +4,7 @@
 
 
                 <button class="button image-rotation" type="button" style="margin-bottom:2rem;">
-                <span style="margin-right:0.5rem;">{% trans "Rotate" %}</span>
+                <span style="margin-right:0.5rem;">{% trans "Rotate image" %}</span>
 
                 <img src="{% static 'wagtailimages/img/img-rotate.svg' %}" style="width:1.5rem;" />
 

--- a/wagtail/images/templates/wagtailimages/images/_file_field_as_li.html
+++ b/wagtail/images/templates/wagtailimages/images/_file_field_as_li.html
@@ -1,4 +1,13 @@
-{% load wagtailadmin_tags %}
+{% load wagtailadmin_tags static i18n l10n %}
 <li class="{% if field.field.required %}required{% endif %} {{ wrapper_classes }} {{ li_classes }} {% if field.errors %}error{% endif %}">
     {% include "wagtailimages/images/_file_field.html" %}
+
+
+                <button class="button image-rotation" type="button" style="margin-bottom:2rem;">
+                <span style="margin-right:0.5rem;">{% trans "Rotate" %}</span>
+
+                <img src="{% static 'wagtailimages/img/img-rotate.svg' %}" style="width:1.5rem;" />
+
+                </button>
 </li>
+

--- a/wagtail/images/templates/wagtailimages/images/edit.html
+++ b/wagtail/images/templates/wagtailimages/images/edit.html
@@ -18,7 +18,40 @@
             $('#id_tags').tagit({
                 autocomplete: {source: "{{ autocomplete_url|addslashes }}"}
             });
+
+            function findMargin(width, height) {
+                if (width > height) {
+                    return (width - height ) / 2
+                } else {
+                    return (height - width ) / 2
+                }
+            }
+
+            let fpc = $('.focal-point-chooser')[0]
+            let rotation = 0;
+
+            $(' button.image-rotation').click(function(event){
+                event.preventDefault();
+                // add our rotation code
+
+                let margin = findMargin(fpc.offsetWidth, fpc.offsetHeight)
+
+                let isPortrait = fpc.offsetWidth > fpc.offsetHeight
+
+                rotation += 90;
+                // set this in our form
+                $("#id_rotation").val(rotation);
+
+                fpc.style.transform = "rotate(" + rotation + "deg)"
+                if (isPortrait) {
+                    let extraSpace = 20
+                    fpc.style.marginTop = margin + extraSpace + "px";
+                    fpc.style.marginBottom = margin + extraSpace + "px";
+                }
+            })
         });
+
+
     </script>
 
     <!-- Focal point chooser -->
@@ -36,13 +69,18 @@
         <div class="row row-flush nice-padding">
             <div class="col6">
                 <ul class="fields">
+
                     {% for field in form %}
+
                         {% if field.name == 'file' %}
                             {% include "wagtailimages/images/_file_field_as_li.html" with li_classes="label-above label-uppercase" %}
+
                         {% elif field.is_hidden %}
                             {{ field }}
                         {% else %}
                             {% include "wagtailadmin/shared/field_as_li.html" with li_classes="label-above label-uppercase" %}
+
+
                         {% endif %}
                     {% endfor %}
                 </ul>
@@ -58,7 +96,11 @@
                 {% image image max-800x600 as rendition %}
 
                 <div class="focal-point-chooser"
-                    style="max-width: {{ rendition.width }}px; max-height: {{ rendition.height }}px;"
+                    style="max-width: {{ rendition.width }}px;
+                    max-height: {{ rendition.height }}px;
+                    -webkit-transition: -webkit-transform 0.5s ease-in-out;
+                    -ms-transition: -ms-transform 0.5s ease-in-out;
+                    transition: all 0.5s ease-in-out;"
                     data-focal-point-x="{{ image.focal_point_x|default_if_none:'' }}"
                     data-focal-point-y="{{ image.focal_point_y|default_if_none:'' }}"
                     data-focal-point-width="{{ image.focal_point_width|default_if_none:'' }}"
@@ -67,6 +109,14 @@
                     <img {{ rendition.attrs }} data-original-width="{{ image.width|unlocalize }}" data-original-height="{{ image.height|unlocalize }}" class="show-transparency">
                     <div class="current-focal-point-indicator{% if not image.has_focal_point %} hidden{% endif %}"></div>
                 </div>
+
+                <button class="button image-rotation" type="button" style="margin-bottom:2rem;">
+                <span style="margin-right:0.5rem;">{% trans "Rotate" %}</span>
+
+                <img src="{% static 'wagtailimages/img/img-rotate.svg' %}" style="width:1.5rem;" />
+
+                </button>
+
 
                 {% if url_generator_enabled %}
                     <a href="{% url 'wagtailimages:url_generator' image.id %}" class="button bicolor icon icon-link">{% trans "URL Generator" %}</a>

--- a/wagtail/images/templates/wagtailimages/images/edit.html
+++ b/wagtail/images/templates/wagtailimages/images/edit.html
@@ -110,12 +110,6 @@
                     <div class="current-focal-point-indicator{% if not image.has_focal_point %} hidden{% endif %}"></div>
                 </div>
 
-                <button class="button image-rotation" type="button" style="margin-bottom:2rem;">
-                <span style="margin-right:0.5rem;">{% trans "Rotate" %}</span>
-
-                <img src="{% static 'wagtailimages/img/img-rotate.svg' %}" style="width:1.5rem;" />
-
-                </button>
 
 
                 {% if url_generator_enabled %}

--- a/wagtail/images/templates/wagtailimages/images/edit.html
+++ b/wagtail/images/templates/wagtailimages/images/edit.html
@@ -27,10 +27,12 @@
                 }
             }
 
-            let fpc = $('.focal-point-chooser')[0]
+            let fpc = document.querySelector('.focal-point-chooser')
             let rotation = 0;
 
-            $(' button.image-rotation').click(function(event){
+            let rotateButton = document.querySelector('button.image-rotation')
+
+            rotateButton.addEventListener("click", function (event) {
                 event.preventDefault();
                 // add our rotation code
 
@@ -39,14 +41,18 @@
                 let isPortrait = fpc.offsetWidth > fpc.offsetHeight
 
                 rotation += 90;
-                // set this in our form
-                $("#id_rotation").val(rotation);
 
+                // set this in our form
+                document.querySelector("#id_rotation").value = rotation
                 fpc.style.transform = "rotate(" + rotation + "deg)"
+
+                // when we rotate it, we need to allow some space, so the rotating image doesn't end up clipping other elements on the page
                 if (isPortrait) {
                     let extraSpace = 20
                     fpc.style.marginTop = margin + extraSpace + "px";
                     fpc.style.marginBottom = margin + extraSpace + "px";
+                } else {
+                    fpc.style.marginLeft = margin + "px";
                 }
             })
         });

--- a/wagtail/images/templates/wagtailimages/images/edit.html
+++ b/wagtail/images/templates/wagtailimages/images/edit.html
@@ -7,7 +7,20 @@
     <!-- Focal point chooser -->
     <link rel="stylesheet" href="{% static 'wagtailimages/css/vendor/jquery.Jcrop.min.css' %}" type="text/css">
     <link rel="stylesheet" href="{% static 'wagtailimages/css/focal-point-chooser.css' %}" type="text/css">
+
+    <style>
+        /*
+        This is here as it's a one liner used to fix an
+        layout issue where jcrop shows a previous hidden
+        radio button when rotated.
+        */
+        input[type="radio"].jcrop-keymgr {
+            display:none;
+        }
+    </style>
 {% endblock %}
+
+
 
 {% block extra_js %}
     {{ block.super }}

--- a/wagtail/images/tests/tests.py
+++ b/wagtail/images/tests/tests.py
@@ -19,7 +19,6 @@ from wagtail.tests.testapp.models import CustomImage, CustomImageFilePath
 from wagtail.tests.utils import WagtailTestUtils
 
 from .utils import Image, get_test_image_file
-from django.test import tag
 
 try:
     import sendfile  # noqa
@@ -659,18 +658,15 @@ class TestDifferentUpload(TestCase):
         # it's filename
         self.assertFalse(image.file.url == second_image.file.url)
 
-class TestImageRotation(TestCase, WagtailTestUtils):
 
-    @tag('only')
+class TestImageRotation(TestCase, WagtailTestUtils):
     def test_image_can_be_rotated(self):
 
-        ### create image
         image = Image.objects.create(
             title="Test image",
             file=get_test_image_file(filename='landscape_img.png'),
         )
 
-        # wrap image in form, with rotation of 90
         ImageForm = get_image_form(Image)
 
         form_data = {
@@ -681,14 +677,13 @@ class TestImageRotation(TestCase, WagtailTestUtils):
 
         form = ImageForm(form_data, instance=image)
 
-        # now we have this, we can try calling the rotate and save methods
         self.assertEqual(form.instance.file.height, 480)
         self.assertEqual(form.instance.file.width, 640)
 
         form.is_valid()
         form.save()
 
-        # check height and width
+        # check height and width, after rotation
         self.assertEqual(form.instance.file.height, 640)
         self.assertEqual(form.instance.file.width, 480)
 

--- a/wagtail/images/tests/tests.py
+++ b/wagtail/images/tests/tests.py
@@ -669,7 +669,7 @@ class TestImageRotation(TestCase, WagtailTestUtils):
             title="Test image",
             file=get_test_image_file(filename='landscape_img.png'),
         )
-        
+
         # wrap image in form, with rotation of 90
         ImageForm = get_image_form(Image)
 

--- a/wagtail/images/tests/tests.py
+++ b/wagtail/images/tests/tests.py
@@ -19,6 +19,7 @@ from wagtail.tests.testapp.models import CustomImage, CustomImageFilePath
 from wagtail.tests.utils import WagtailTestUtils
 
 from .utils import Image, get_test_image_file
+from django.test import tag
 
 try:
     import sendfile  # noqa
@@ -657,6 +658,39 @@ class TestDifferentUpload(TestCase):
         # The files should be uploaded based on it's content, not just
         # it's filename
         self.assertFalse(image.file.url == second_image.file.url)
+
+class TestImageRotation(TestCase, WagtailTestUtils):
+
+    @tag('only')
+    def test_image_can_be_rotated(self):
+
+        ### create image
+        image = Image.objects.create(
+            title="Test image",
+            file=get_test_image_file(filename='landscape_img.png'),
+        )
+        
+        # wrap image in form, with rotation of 90
+        ImageForm = get_image_form(Image)
+
+        form_data = {
+            'rotation': '90',
+            'title': "Test image",
+            'collection': 1,
+        }
+
+        form = ImageForm(form_data, instance=image)
+
+        # now we have this, we can try calling the rotate and save methods
+        self.assertEqual(form.instance.file.height, 480)
+        self.assertEqual(form.instance.file.width, 640)
+
+        form.is_valid()
+        form.save()
+
+        # check height and width
+        self.assertEqual(form.instance.file.height, 640)
+        self.assertEqual(form.instance.file.width, 480)
 
 
 class TestGetImageModel(WagtailTestUtils, TestCase):

--- a/wagtail/images/views/images.py
+++ b/wagtail/images/views/images.py
@@ -93,6 +93,8 @@ def edit(request, image_id):
 
     image = get_object_or_404(Image, id=image_id)
 
+
+
     if not permission_policy.user_has_permission_for_instance(request.user, 'change', image):
         return permission_denied(request)
 
@@ -100,14 +102,6 @@ def edit(request, image_id):
         original_file = image.file
         form = ImageForm(request.POST, request.FILES, instance=image, user=request.user)
         if form.is_valid():
-            if 'file' in form.changed_data:
-                # Set new image file size
-                image.file_size = image.file.size
-
-                # Set new image file hash
-                image.file.seek(0)
-                image._set_file_hash(image.file.read())
-                image.file.seek(0)
 
             form.save()
 

--- a/wagtail/images/views/images.py
+++ b/wagtail/images/views/images.py
@@ -100,7 +100,9 @@ def edit(request, image_id):
 
     if request.method == 'POST':
         original_file = image.file
+
         form = ImageForm(request.POST, request.FILES, instance=image, user=request.user)
+        # import ipdb; ipdb.set_trace()
         if form.is_valid():
 
             form.save()
@@ -252,6 +254,7 @@ def add(request):
         image = ImageModel(uploaded_by_user=request.user)
         form = ImageForm(request.POST, request.FILES, instance=image, user=request.user)
         if form.is_valid():
+
             # Set image file size
             image.file_size = image.file.size
 


### PR DESCRIPTION
I've added this after a quick chat with @thibaudcolas at Wagtail space, to help resolve [issue 2901](https://github.com/wagtail/wagtail/issues/2901), giving us a way to rotate images in the server UI.

### WIP tag removal checklist

- [ ]  Do the tests still pass? (http://docs.wagtail.io/en/latest/contributing/developing.html#testing)
- [x]  Does the code comply with the style guide? (Run `make lint` from the Wagtail root)
- [x]  For Python changes: Have you added tests to cover the new/fixed behaviour?
- [x]  For front-end changes: Did you test on all of Wagtail’s supported browsers? **Please list the exact versions you tested**.
- [x]  For new features: Has the documentation been updated accordingly?


### Da current plan 

- [x] add a basic, unstyled rotate button
- [x] add some js to increment the rotate element when the button is pushed
- [x] add rotate field to the image edit form
- [x] add a code for calling `rotate()` when a user submits the form

When the button is pushed, and we update the rotate value, we use a bit of CSS to add a transform to the image, and animate it using a CSS transition to make it for a user to see what just happened (rotating is a bit jarring without this).

CSS transforms and transition animations seem to well supported, and it saves us needing much in the way of extra js dependencies:

https://caniuse.com/#search=transform
https://caniuse.com/#feat=css-animation

