### PR TITLE
[Bugfix-4996] preserve non breaking white spaces

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -36,6 +36,7 @@ Changelog
  * Fix: Make sure page chooser search results correspond to the latest search by canceling previous requests (Esper Kuijs)
  * Fix: Inform user when moving a page from one parent to another where there is an already existing page with the same slug (Casper Timmers)
  * Fix: User add/edit forms now support form widgets with JS/CSS media (Damian Grinwis)
+ * Fix: Rich text processing now preserves non-breaking spaces instead of converting them to normal spaces (Wesley van Lee)
 
 
 2.4 (19.12.2018)

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -355,6 +355,7 @@ Contributors
 * patta42
 * Esper Kuijs
 * Damian Grinwis
+* Wesley van Lee
 
 Translators
 ===========

--- a/docs/releases/2.5.rst
+++ b/docs/releases/2.5.rst
@@ -52,6 +52,7 @@ Bug fixes
  * Make sure page chooser search results correspond to the latest search by canceling previous requests (Esper Kuijs)
  * Inform user when moving a page from one parent to another where there is an already existing page with the same slug (Casper Timmers)
  * User add/edit forms now support form widgets with JS/CSS media (Damian Grinwis)
+ * Rich text processing now preserves non-breaking spaces instead of converting them to normal spaces (Wesley van Lee)
 
 
 Upgrade considerations

--- a/wagtail/admin/rich_text/converters/html_to_contentstate.py
+++ b/wagtail/admin/rich_text/converters/html_to_contentstate.py
@@ -12,11 +12,8 @@ STRIP_WHITESPACE = 0
 KEEP_WHITESPACE = 1
 FORCE_WHITESPACE = 2
 
-# match more than one consecutive normal spaces, new-lines, tabs and form-feeds
-WHITESPACE_RE = re.compile(r'[ \t\n\f]{2,}')
-
-# match more than one consecutive zero-width spaces
-ZERO_WIDTH_SPACE_RE = re.compile(r'[\u200b]{2,}')
+# match one or more consecutive normal spaces, new-lines, tabs and form-feeds
+WHITESPACE_RE = re.compile(r'[ \t\n\f\r]+')
 
 
 class HandlerState:
@@ -318,10 +315,9 @@ class HtmlToContentStateHandler(HTMLParser):
             element_handler.handle_endtag(name, self.state, self.contentstate)
 
     def handle_data(self, content):
-        # normalise whitespace sequences to a single character
+        # normalise whitespace sequences to a single space
         # This is in line with https://www.w3.org/TR/html4/struct/text.html#h-9.1
         content = re.sub(WHITESPACE_RE, ' ', content)
-        content = re.sub(ZERO_WIDTH_SPACE_RE, '\u200b', content)
 
         if self.state.current_block is None:
             if content == ' ':

--- a/wagtail/admin/rich_text/converters/html_to_contentstate.py
+++ b/wagtail/admin/rich_text/converters/html_to_contentstate.py
@@ -12,7 +12,7 @@ STRIP_WHITESPACE = 0
 KEEP_WHITESPACE = 1
 FORCE_WHITESPACE = 2
 
-WHITESPACE_RE = re.compile(r'\s+')
+WHITESPACE_RE = re.compile(r'(?![\xa0])\s+')
 
 
 class HandlerState:

--- a/wagtail/admin/rich_text/converters/html_to_contentstate.py
+++ b/wagtail/admin/rich_text/converters/html_to_contentstate.py
@@ -12,8 +12,11 @@ STRIP_WHITESPACE = 0
 KEEP_WHITESPACE = 1
 FORCE_WHITESPACE = 2
 
-# we match all types of white space characters except for non-breaking white spaces.
-WHITESPACE_RE = re.compile(r'(?![\xa0])\s+')
+# match more than one consecutive normal spaces, new-lines, tabs and form-feeds
+WHITESPACE_RE = re.compile(r'[ \t\n\f]{2,}')
+
+# match more than one consecutive zero-width spaces
+ZERO_WIDTH_SPACE_RE = re.compile(r'[\u200b]{2,}')
 
 
 class HandlerState:
@@ -315,8 +318,9 @@ class HtmlToContentStateHandler(HTMLParser):
             element_handler.handle_endtag(name, self.state, self.contentstate)
 
     def handle_data(self, content):
-        # normalise whitespace sequences to a single space
+        # normalise whitespace sequences to a single character
         content = re.sub(WHITESPACE_RE, ' ', content)
+        content = re.sub(ZERO_WIDTH_SPACE_RE, '\u200b', content)
 
         if self.state.current_block is None:
             if content == ' ':

--- a/wagtail/admin/rich_text/converters/html_to_contentstate.py
+++ b/wagtail/admin/rich_text/converters/html_to_contentstate.py
@@ -12,6 +12,7 @@ STRIP_WHITESPACE = 0
 KEEP_WHITESPACE = 1
 FORCE_WHITESPACE = 2
 
+# we match all types of white space characters except for non-breaking white spaces.
 WHITESPACE_RE = re.compile(r'(?![\xa0])\s+')
 
 

--- a/wagtail/admin/rich_text/converters/html_to_contentstate.py
+++ b/wagtail/admin/rich_text/converters/html_to_contentstate.py
@@ -319,6 +319,7 @@ class HtmlToContentStateHandler(HTMLParser):
 
     def handle_data(self, content):
         # normalise whitespace sequences to a single character
+        # This is in line with https://www.w3.org/TR/html4/struct/text.html#h-9.1
         content = re.sub(WHITESPACE_RE, ' ', content)
         content = re.sub(ZERO_WIDTH_SPACE_RE, '\u200b', content)
 

--- a/wagtail/admin/tests/test_contentstate.py
+++ b/wagtail/admin/tests/test_contentstate.py
@@ -754,19 +754,23 @@ class TestHtmlToContentState(TestCase):
             ]
         })
 
-    def test_replace_whitespaces(self):
-        # We expect all whitespace characters (one or more consecutively) to be replaced by a single space.
-        # Except for non-breaking white spaces, we keep them as they are. (\xa0 is a non-breaking whitespace character)
+    def test_collapse_targeted_whitespace_characters(self):
+        # We expect all targeted whitespace characters (more than one consecutively)
+        # to be replaced by a single space.
         converter = ContentstateConverter(features=[])
         result = json.loads(converter.from_database_format(
             '''
-            <p>It is    time to\xa0\xa0\xa0bring up fight   club again. Or is\xa0  it?</p>
+            <p>Multiple whitespaces:     should  be reduced</p>
+            <p>Multiple non-breaking whitespace characters:  \xa0\xa0\xa0  should be preserved</p>
+            <p>Zero\u200bwidth\u200bwhitespaces:  \u200b\u200b  should be reduced</p>
             '''
         ))
         self.assertContentStateEqual(result, {
             'entityMap': {},
             'blocks': [
-                {'inlineStyleRanges': [], 'text': 'It is time to\xa0\xa0\xa0bring up fight club again. Or is\xa0 it?', 'depth': 0, 'type': 'unstyled', 'key': '00000', 'entityRanges': []},
+                {'inlineStyleRanges': [], 'text': 'Multiple whitespaces: should be reduced', 'depth': 0, 'type': 'unstyled', 'key': '00000', 'entityRanges': []},
+                {'inlineStyleRanges': [], 'text': 'Multiple non-breaking whitespace characters: \xa0\xa0\xa0 should be preserved', 'depth': 0, 'type': 'unstyled', 'key': '00000', 'entityRanges': []},
+                {'inlineStyleRanges': [], 'text': 'Zero\u200bwidth\u200bwhitespaces: \u200b should be reduced', 'depth': 0, 'type': 'unstyled', 'key': '00000', 'entityRanges': []},
             ]
         })
 

--- a/wagtail/admin/tests/test_contentstate.py
+++ b/wagtail/admin/tests/test_contentstate.py
@@ -755,8 +755,8 @@ class TestHtmlToContentState(TestCase):
         })
 
     def test_collapse_targeted_whitespace_characters(self):
-        # We expect all targeted whitespace characters (more than one consecutively)
-        # to be replaced by a single space.
+        # We expect all targeted whitespace characters (one or more consecutively)
+        # to be replaced by a single space. (\xa0 is a non-breaking whitespace)
         converter = ContentstateConverter(features=[])
         result = json.loads(converter.from_database_format(
             '''

--- a/wagtail/admin/tests/test_contentstate.py
+++ b/wagtail/admin/tests/test_contentstate.py
@@ -762,7 +762,6 @@ class TestHtmlToContentState(TestCase):
             '''
             <p>Multiple whitespaces:     should  be reduced</p>
             <p>Multiple non-breaking whitespace characters:  \xa0\xa0\xa0  should be preserved</p>
-            <p>Zero\u200bwidth\u200bwhitespaces:  \u200b\u200b  should be reduced</p>
             '''
         ))
         self.assertContentStateEqual(result, {
@@ -770,7 +769,6 @@ class TestHtmlToContentState(TestCase):
             'blocks': [
                 {'inlineStyleRanges': [], 'text': 'Multiple whitespaces: should be reduced', 'depth': 0, 'type': 'unstyled', 'key': '00000', 'entityRanges': []},
                 {'inlineStyleRanges': [], 'text': 'Multiple non-breaking whitespace characters: \xa0\xa0\xa0 should be preserved', 'depth': 0, 'type': 'unstyled', 'key': '00000', 'entityRanges': []},
-                {'inlineStyleRanges': [], 'text': 'Zero\u200bwidth\u200bwhitespaces: \u200b should be reduced', 'depth': 0, 'type': 'unstyled', 'key': '00000', 'entityRanges': []},
             ]
         })
 

--- a/wagtail/admin/tests/test_contentstate.py
+++ b/wagtail/admin/tests/test_contentstate.py
@@ -754,6 +754,21 @@ class TestHtmlToContentState(TestCase):
             ]
         })
 
+    def test_replace_whitespaces(self):
+        # \xa0 is a non-breaking whitespace character
+        converter = ContentstateConverter(features=[])
+        result = json.loads(converter.from_database_format(
+            '''
+            <p>It is    time to\xa0\xa0\xa0bring up fight   club again. Or is\xa0  it?</p>
+            '''
+        ))
+        self.assertContentStateEqual(result, {
+            'entityMap': {},
+            'blocks': [
+                {'inlineStyleRanges': [], 'text': 'It is time to\xa0\xa0\xa0bring up fight club again. Or is\xa0 it?', 'depth': 0, 'type': 'unstyled', 'key': '00000', 'entityRanges': []},
+            ]
+        })
+
     def test_extra_end_tag_before(self):
         converter = ContentstateConverter(features=[])
         result = json.loads(converter.from_database_format(

--- a/wagtail/admin/tests/test_contentstate.py
+++ b/wagtail/admin/tests/test_contentstate.py
@@ -755,7 +755,8 @@ class TestHtmlToContentState(TestCase):
         })
 
     def test_replace_whitespaces(self):
-        # \xa0 is a non-breaking whitespace character
+        # We expect all whitespace characters (one or more consecutively) to be replaced by a single space.
+        # Except for non-breaking white spaces, we keep them as they are. (\xa0 is a non-breaking whitespace character)
         converter = ContentstateConverter(features=[])
         result = json.loads(converter.from_database_format(
             '''


### PR DESCRIPTION
Fixes #4996.

The regex is currently not covering all different cases of non-breaking white spaces in the content (in combination with other whitespace characters). I'm not sure if handling this through a regex is the way to go here.