### PR TITLE
Fix warnings on building documentation

### DIFF
--- a/docs/advanced_topics/customisation/extending_draftail.rst
+++ b/docs/advanced_topics/customisation/extending_draftail.rst
@@ -1,7 +1,7 @@
 Extending the Draftail Editor
 =============================
 
-Wagtail’s rich text editor is built with `Draftail <https://www.draftail.org/>`_, and its functionality can be extended through plugins.
+Wagtail’s rich text editor is built with `Draftail <https://www.draftail.org/>`__, and its functionality can be extended through plugins.
 
 Plugins come in three types:
 
@@ -61,7 +61,7 @@ These steps will always be the same for all Draftail plugins. The important part
 * Give enough information to Draftail so it knows how to make a button for the feature, and how to render it (more on this later).
 * Configure the conversion to use the right HTML element (as they are stored in the DB).
 
-For detailed configuration options, head over to the `Draftail documentation <https://www.draftail.org/docs/formatting-options>`_ to see all of the details. Here are some parts worth highlighting about controls:
+For detailed configuration options, head over to the `Draftail documentation <https://www.draftail.org/docs/formatting-options>`__ to see all of the details. Here are some parts worth highlighting about controls:
 
 * The ``type`` is the only mandatory piece of information.
 * To display the control in the toolbar, combine ``icon``, ``label`` and ``description``.
@@ -70,7 +70,7 @@ For detailed configuration options, head over to the `Draftail documentation <ht
 Creating new inline styles
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-In addition to the initial example, inline styles take a ``style`` property to define what CSS rules will be applied to text in the editor. Be sure to read the `Draftail documentation <https://www.draftail.org/docs/formatting-options>`_ on inline styles.
+In addition to the initial example, inline styles take a ``style`` property to define what CSS rules will be applied to text in the editor. Be sure to read the `Draftail documentation <https://www.draftail.org/docs/formatting-options>`__ on inline styles.
 
 Finally, the DB to/from conversion uses an ``InlineStyleElementHandler`` to map from a given tag (``<s>`` in the example above) to a Draftail type, and the inverse mapping is done with `Draft.js exporter configuration <https://github.com/springload/draftjs_exporter>`_ of the ``style_map``.
 
@@ -146,7 +146,7 @@ Here are the main requirements to create a new entity feature:
 * The conversion usually is more involved, since entities contain data that needs to be serialised to HTML.
 
 To write the React components, Wagtail exposes its own React, Draft.js and Draftail dependencies as global variables. Read more about this in :ref:`extending_clientside_components`.
-To go further, please look at the `Draftail documentation <https://www.draftail.org/docs/formatting-options>`_ as well as the `Draft.js exporter documentation <https://github.com/springload/draftjs_exporter>`_.
+To go further, please look at the `Draftail documentation <https://www.draftail.org/docs/formatting-options>`__ as well as the `Draft.js exporter documentation <https://github.com/springload/draftjs_exporter>`_.
 
 Here is a detailed example to showcase how those tools are used in the context of Wagtail.
 For the sake of our example, we can imagine a news team working at a financial newspaper.
@@ -326,7 +326,7 @@ To fully complete the demo, we can add a bit of JavaScript to the front-end in o
 
 ----
 
-Custom block entities can also be created (have a look at the separate `Draftail documentation <https://www.draftail.org/docs/blocks>`_), but these are not detailed here since :ref:`StreamField <streamfield>` is the go-to way to create block-level rich text in Wagtail.
+Custom block entities can also be created (have a look at the separate `Draftail documentation <https://www.draftail.org/docs/blocks>`__), but these are not detailed here since :ref:`StreamField <streamfield>` is the go-to way to create block-level rich text in Wagtail.
 
 Integration of the Draftail widgets
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/advanced_topics/third_party_tutorials.rst
+++ b/docs/advanced_topics/third_party_tutorials.rst
@@ -11,7 +11,7 @@ Third-party tutorials
 * `E-Commerce for Django developers (with Wagtail shop tutorial) <https://snipcart.com/blog/django-ecommerce-tutorial-wagtail-cms>`_ (5 July 2018)
 * `Wagtail and GraphQL <https://jossingram.wordpress.com/2018/04/19/wagtail-and-graphql/>`_ (19 April 2018)
 * `Wagtail and Azure storage blob containers <https://jossingram.wordpress.com/2017/11/29/wagtail-and-azure-storage-blob-containers/>`_ (29 November 2017)
-* `Building TwilioQuest with Twilio Sync, Django [incl. Wagtail], and Vue.js https://www.twilio.com/blog/2017/11/building-twilioquest-with-twilio-sync-django-and-vue-js.html`_ (6 November 2017)
+* `Building TwilioQuest with Twilio Sync, Django [incl. Wagtail], and Vue.js <https://www.twilio.com/blog/2017/11/building-twilioquest-with-twilio-sync-django-and-vue-js.html>`_ (6 November 2017)
 * `Upgrading from Wagtail 1.0 to Wagtail 1.11 <https://www.caktusgroup.com/blog/2017/07/19/upgrading-wagtail/>`_ (19 July 2017) 
 * `Wagtail-Multilingual: a simple project to demonstrate how multilingual is implemented <https://github.com/cristovao-alves/Wagtail-Multilingual>`_ (31 January 2017)
 * `Wagtail: 2 Steps for Adding Pages Outside of the CMS <https://www.caktusgroup.com/blog/2016/02/15/wagtail-2-steps-adding-pages-outside-cms/>`_ (15 February 2016)

--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -1355,12 +1355,24 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
                 yield '/' + child.slug + path
 
     def get_ancestors(self, inclusive=False):
+        """
+        Returns a queryset of the current page's ancestors, starting at the root page
+        and descending to the parent, or to the current page itself if ``inclusive`` is true.
+        """
         return Page.objects.ancestor_of(self, inclusive)
 
     def get_descendants(self, inclusive=False):
+        """
+        Returns a queryset of all pages underneath the current page, any number of levels deep.
+        If ``inclusive`` is true, the current page itself is included in the queryset.
+        """
         return Page.objects.descendant_of(self, inclusive)
 
     def get_siblings(self, inclusive=True):
+        """
+        Returns a queryset of all other pages with the same parent as the current page.
+        If ``inclusive`` is true, the current page itself is included in the queryset.
+        """
         return Page.objects.sibling_of(self, inclusive)
 
     def get_next_siblings(self, inclusive=False):


### PR DESCRIPTION
Building docs from scratch (`make clean` then `make html` from the `docs` folder) currently produces the following warnings:

```
/vagrant/wagtail/docs/advanced_topics/customisation/extending_draftail.rst:2: WARNING: Duplicate explicit target name: "draftail".
/vagrant/wagtail/docs/advanced_topics/customisation/extending_draftail.rst:2: WARNING: Duplicate explicit target name: "draftail documentation".
/vagrant/wagtail/docs/advanced_topics/third_party_tutorials.rst:14: WARNING: Unknown target name: "building twilioquest with twilio sync, django [incl. wagtail], and vue.js https://www.twilio.com/blog/2017/11/building-twilioquest-with-twilio-sync-django-and-vue-js.html".
/vagrant/wagtail/wagtail/core/models.py:docstring of wagtail.core.models.Page.get_ancestors:2: WARNING: Field list ends without a blank line; unexpected unindent.
/vagrant/wagtail/wagtail/core/models.py:docstring of wagtail.core.models.Page.get_descendants:2: WARNING: Field list ends without a blank line; unexpected unindent.
/vagrant/wagtail/wagtail/core/models.py:docstring of wagtail.core.models.Page.get_siblings:2: WARNING: Field list ends without a blank line; unexpected unindent.
```

These are all fixed here.