### PR TITLE
Reuse the label_for_field function for fields in the InspectView

### DIFF
--- a/wagtail/contrib/modeladmin/tests/test_page_modeladmin.py
+++ b/wagtail/contrib/modeladmin/tests/test_page_modeladmin.py
@@ -157,9 +157,15 @@ class TestInspectView(TestCase, WagtailTestUtils):
         response = self.get(100)
         self.assertEqual(response.status_code, 404)
 
-    def test_label_display(self):
+    def test_short_description_is_used_as_field_label(self):
+        """
+        A custom field has been added to the inspect view's `inspect_view_fields` and since
+        this field has a `short_description` we expect it to be used as the field's label,
+        and not use the name of the function.
+        """
         response = self.client.get('/admin/modeladmintest/author/inspect/1/')
         self.assertContains(response, 'Birth information')
+        self.assertNotContains(response, 'author_birth_string')
 
 
 class TestEditView(TestCase, WagtailTestUtils):

--- a/wagtail/contrib/modeladmin/tests/test_page_modeladmin.py
+++ b/wagtail/contrib/modeladmin/tests/test_page_modeladmin.py
@@ -103,7 +103,7 @@ class TestCreateView(TestCase, WagtailTestUtils):
 
 
 class TestInspectView(TestCase, WagtailTestUtils):
-    fixtures = ['test_specific.json']
+    fixtures = ['test_specific.json', 'modeladmintest_test.json']
 
     def setUp(self):
         self.login()
@@ -156,6 +156,10 @@ class TestInspectView(TestCase, WagtailTestUtils):
     def test_non_existent(self):
         response = self.get(100)
         self.assertEqual(response.status_code, 404)
+
+    def test_label_display(self):
+        response = self.client.get('/admin/modeladmintest/author/inspect/1/')
+        self.assertContains(response, 'Birth information')
 
 
 class TestEditView(TestCase, WagtailTestUtils):

--- a/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
+++ b/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
@@ -222,11 +222,11 @@ class TestInspectView(TestCase, WagtailTestUtils):
 
     def test_author_name_present(self):
         """
-        The author name should appear three times. Once in the header, once
-        in the name field and once more in the birth string
+        The author name should appear twice. Once in the header, and once
+        more in the field listing
         """
         response = self.get_for_author(1)
-        self.assertContains(response, 'J. R. R. Tolkien', 3)
+        self.assertContains(response, 'J. R. R. Tolkien', 2)
 
     def test_author_dob_not_present(self):
         """

--- a/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
+++ b/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
@@ -222,11 +222,11 @@ class TestInspectView(TestCase, WagtailTestUtils):
 
     def test_author_name_present(self):
         """
-        The author name should appear twice. Once in the header, and once
-        more in the field listing
+        The author name should appear three times. Once in the header, once
+        in the name field and once more in the birth string
         """
         response = self.get_for_author(1)
-        self.assertContains(response, 'J. R. R. Tolkien', 2)
+        self.assertContains(response, 'J. R. R. Tolkien', 3)
 
     def test_author_dob_not_present(self):
         """

--- a/wagtail/contrib/modeladmin/views.py
+++ b/wagtail/contrib/modeladmin/views.py
@@ -842,9 +842,9 @@ class InspectView(InstanceSpecificView):
     def get_meta_title(self):
         return _('Inspecting %s') % self.verbose_name
 
-    def get_field_label(self, field_name):
+    def get_field_label(self, field_name, field=None):
         """ Return a label to display for a field """
-        return label_for_field(field_name, model=self.model, model_admin=self.model_admin)
+        return label_for_field(field_name, model=self.model)
 
     def get_field_display_value(self, field_name, field=None):
         """ Return a display value for a field/attribute """
@@ -924,7 +924,7 @@ class InspectView(InstanceSpecificView):
         except FieldDoesNotExist:
             field = None
         return {
-            'label': self.get_field_label(field_name),
+            'label': self.get_field_label(field_name, field),
             'value': self.get_field_display_value(field_name, field),
         }
 

--- a/wagtail/contrib/modeladmin/views.py
+++ b/wagtail/contrib/modeladmin/views.py
@@ -7,7 +7,7 @@ from django.contrib.admin import FieldListFilter, widgets
 from django.contrib.admin.exceptions import DisallowedModelAdminLookup
 from django.contrib.admin.options import IncorrectLookupParameters
 from django.contrib.admin.utils import (
-    get_fields_from_path, lookup_needs_distinct, prepare_lookup_value, quote, unquote)
+    get_fields_from_path, label_for_field, lookup_needs_distinct, prepare_lookup_value, quote, unquote)
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import ImproperlyConfigured, PermissionDenied, SuspiciousOperation
 from django.core.paginator import InvalidPage, Paginator
@@ -842,16 +842,9 @@ class InspectView(InstanceSpecificView):
     def get_meta_title(self):
         return _('Inspecting %s') % self.verbose_name
 
-    def get_field_label(self, field_name, field=None):
+    def get_field_label(self, field_name):
         """ Return a label to display for a field """
-        label = None
-        if field is not None:
-            label = getattr(field, 'verbose_name', None)
-            if label is None:
-                label = getattr(field, 'name', None)
-        if label is None:
-            label = field_name
-        return label
+        return label_for_field(field_name, model=self.model, model_admin=self.model_admin)
 
     def get_field_display_value(self, field_name, field=None):
         """ Return a display value for a field/attribute """
@@ -931,7 +924,7 @@ class InspectView(InstanceSpecificView):
         except FieldDoesNotExist:
             field = None
         return {
-            'label': self.get_field_label(field_name, field),
+            'label': self.get_field_label(field_name),
             'value': self.get_field_display_value(field_name, field),
         }
 

--- a/wagtail/tests/modeladmintest/models.py
+++ b/wagtail/tests/modeladmintest/models.py
@@ -10,7 +10,7 @@ class Author(models.Model):
     date_of_birth = models.DateField()
 
     def author_birth_string(self):
-        return '{} was born in pallet town'.format(self.name)
+        return 'This author was born in pallet town'
 
     author_birth_string.short_description = "Birth information"
 

--- a/wagtail/tests/modeladmintest/models.py
+++ b/wagtail/tests/modeladmintest/models.py
@@ -9,6 +9,11 @@ class Author(models.Model):
     name = models.CharField(max_length=255)
     date_of_birth = models.DateField()
 
+    def author_birth_string(self):
+        return '{} was born in pallet town'.format(self.name)
+
+    author_birth_string.short_description = "Birth information"
+
     def __str__(self):
         return self.name
 

--- a/wagtail/tests/modeladmintest/wagtail_hooks.py
+++ b/wagtail/tests/modeladmintest/wagtail_hooks.py
@@ -15,7 +15,7 @@ class AuthorModelAdmin(ModelAdmin):
     list_filter = ('date_of_birth', )
     search_fields = ('name', )
     inspect_view_enabled = True
-    inspect_view_fields = ('name', )
+    inspect_view_fields = ('name', 'author_birth_string')
 
     def last_book(self, obj):
         # For testing use of modeladmin methods in list_display


### PR DESCRIPTION
Summary
---------

In the InspectView the labels used for the fields will either be the field's **name** or **verbose name**. Assigning a short description to a field will have therefore have no effect for this view (#4320). Using the label_for_field function to create the labels in the inspect view will result in equal labels in the IndexView and in the InspectView, making them more predictable and consistent.
