### PR TITLE
Remove imports of django.utils.six

### DIFF
--- a/wagtail/bin/wagtail.py
+++ b/wagtail/bin/wagtail.py
@@ -8,8 +8,6 @@ from argparse import ArgumentParser
 from difflib import unified_diff
 
 from django.core.management import ManagementUtility
-# Need to use the django.utils.six version of print, to avoid a syntax error on Py2 when using print(..., end='')
-from django.utils.six import print_
 
 
 CURRENT_PYTHON = sys.version_info[:2]
@@ -237,7 +235,7 @@ class UpdateModulePaths(Command):
         with fileinput.FileInput(filename, inplace=True) as f:
             for original_line in f:
                 line = self._rewrite_line(original_line)
-                print_(line, end='')  # NOQA
+                print(line, end='')  # NOQA
                 if line != original_line:
                     change_count += 1
 

--- a/wagtail/contrib/frontend_cache/utils.py
+++ b/wagtail/contrib/frontend_cache/utils.py
@@ -1,10 +1,10 @@
 import logging
 import re
+from urllib.parse import urlparse, urlunparse
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.module_loading import import_string
-from django.utils.six.moves.urllib.parse import urlparse, urlunparse
 
 logger = logging.getLogger('wagtail.frontendcache')
 

--- a/wagtail/documents/tests/test_admin_views.py
+++ b/wagtail/documents/tests/test_admin_views.py
@@ -8,7 +8,6 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase
 from django.test.utils import override_settings
 from django.urls import reverse
-from django.utils.six import b
 
 from wagtail.core.models import Collection, GroupCollectionPermission, Page
 from wagtail.documents import models
@@ -129,7 +128,7 @@ class TestDocumentAddView(TestCase, WagtailTestUtils):
 
     def test_post(self):
         # Build a fake file
-        fake_file = ContentFile(b("A boring example document"))
+        fake_file = ContentFile(b"A boring example document")
         fake_file.name = 'test.txt'
 
         # Submit
@@ -159,7 +158,7 @@ class TestDocumentAddView(TestCase, WagtailTestUtils):
         evil_plans_collection = root_collection.add_child(name="Evil plans")
 
         # Build a fake file
-        fake_file = ContentFile(b("A boring example document"))
+        fake_file = ContentFile(b"A boring example document")
         fake_file.name = 'test.txt'
 
         # Submit
@@ -222,7 +221,7 @@ class TestDocumentAddViewWithLimitedCollectionPermissions(TestCase, WagtailTestU
 
     def test_post(self):
         # Build a fake file
-        fake_file = ContentFile(b("A boring example document"))
+        fake_file = ContentFile(b"A boring example document")
         fake_file.name = 'test.txt'
 
         # Submit
@@ -250,7 +249,7 @@ class TestDocumentEditView(TestCase, WagtailTestUtils):
         self.login()
 
         # Build a fake file
-        fake_file = ContentFile(b("A boring example document"))
+        fake_file = ContentFile(b"A boring example document")
         fake_file.name = 'test.txt'
 
         # Create a document to edit
@@ -266,7 +265,7 @@ class TestDocumentEditView(TestCase, WagtailTestUtils):
 
     def test_post(self):
         # Build a fake file
-        fake_file = ContentFile(b("A boring example document"))
+        fake_file = ContentFile(b"A boring example document")
         fake_file.name = 'test.txt'
 
         # Submit title change
@@ -284,7 +283,7 @@ class TestDocumentEditView(TestCase, WagtailTestUtils):
 
     def test_with_missing_source_file(self):
         # Build a fake file
-        fake_file = ContentFile(b("An ephemeral document"))
+        fake_file = ContentFile(b"An ephemeral document")
         fake_file.name = 'to-be-deleted.txt'
 
         # Create a new document to delete the source for
@@ -392,7 +391,7 @@ class TestMultipleDocumentUploader(TestCase, WagtailTestUtils):
         # Create a document for running tests on
         self.doc = models.get_document_model().objects.create(
             title="Test document",
-            file=ContentFile(b("Simple text document")),
+            file=ContentFile(b"Simple text document"),
         )
 
     def check_doc_after_edit(self):
@@ -820,7 +819,7 @@ class TestDocumentChooserUploadView(TestCase, WagtailTestUtils):
 
     def test_post(self):
         # Build a fake file
-        fake_file = ContentFile(b("A boring example document"))
+        fake_file = ContentFile(b"A boring example document")
         fake_file.name = 'test.txt'
 
         # Submit
@@ -890,7 +889,7 @@ class TestDocumentChooserUploadViewWithLimitedPermissions(TestCase, WagtailTestU
 
     def test_post(self):
         # Build a fake file
-        fake_file = ContentFile(b("A boring example document"))
+        fake_file = ContentFile(b"A boring example document")
         fake_file.name = 'test.txt'
 
         # Submit
@@ -1014,7 +1013,7 @@ class TestGetUsage(TestCase, WagtailTestUtils):
 class TestEditOnlyPermissions(TestCase, WagtailTestUtils):
     def setUp(self):
         # Build a fake file
-        fake_file = ContentFile(b("A boring example document"))
+        fake_file = ContentFile(b"A boring example document")
         fake_file.name = 'test.txt'
 
         self.root_collection = Collection.get_first_root_node()

--- a/wagtail/documents/tests/test_collection_privacy.py
+++ b/wagtail/documents/tests/test_collection_privacy.py
@@ -2,7 +2,6 @@ from django.contrib.auth.models import Group
 from django.core.files.base import ContentFile
 from django.test import TestCase
 from django.urls import reverse
-from django.utils.six import b
 
 from wagtail.core.models import Collection, CollectionViewRestriction
 from wagtail.documents.models import Document
@@ -17,7 +16,7 @@ class TestCollectionPrivacyDocument(TestCase):
     fixtures = ['test.json']
 
     def setUp(self):
-        self.fake_file = ContentFile(b("A boring example document"))
+        self.fake_file = ContentFile(b"A boring example document")
         self.fake_file.name = 'test.txt'
         self.password_collection = Collection.objects.get(name='Password protected')
         self.login_collection = Collection.objects.get(name='Login protected')

--- a/wagtail/documents/tests/test_search.py
+++ b/wagtail/documents/tests/test_search.py
@@ -4,7 +4,6 @@ from django.core.files.base import ContentFile
 from django.test import TestCase
 from django.test.utils import override_settings
 from django.urls import reverse
-from django.utils.six import b
 
 from wagtail.documents import models
 from wagtail.tests.utils import WagtailTestUtils
@@ -32,7 +31,7 @@ class TestIssue613(TestCase, WagtailTestUtils):
 
     def add_document(self, **params):
         # Build a fake file
-        fake_file = ContentFile(b("A boring example document"))
+        fake_file = ContentFile(b"A boring example document")
         fake_file.name = 'test.txt'
 
         # Submit
@@ -53,14 +52,14 @@ class TestIssue613(TestCase, WagtailTestUtils):
 
     def edit_document(self, **params):
         # Build a fake file
-        fake_file = ContentFile(b("A boring example document"))
+        fake_file = ContentFile(b"A boring example document")
         fake_file.name = 'test.txt'
 
         # Create a document without tags to edit
         document = models.Document.objects.create(title="Test document", file=fake_file)
 
         # Build another fake file
-        another_fake_file = ContentFile(b("A boring example document"))
+        another_fake_file = ContentFile(b"A boring example document")
         another_fake_file.name = 'test.txt'
 
         # Submit


### PR DESCRIPTION
django.utils.six is being removed in Django 3.0. Now that we're hopefully on top of Django 2.2 compatibility, it can't hurt to be ahead of the game a bit :-)