### PR TITLE
Add more readable focus state for buttons

### DIFF
--- a/wagtail/admin/static_src/wagtailadmin/scss/components/_forms.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/components/_forms.scss
@@ -53,6 +53,7 @@ label,
 input,
 textarea,
 select,
+button,
 .halloeditor,
 .tagit {
     appearance: none;
@@ -76,6 +77,7 @@ select,
         background-color: $color-input-focus;
         border-color: $color-input-focus-border;
         outline: none;
+        color: $color-teal-darker;
     }
 
     &:disabled,


### PR DESCRIPTION
Hi there, 

I was working on #2901 earlier today, and when testing it with just a keyboard, I notices that the focus state on inputs wasn't very readable.

You can see an example of what I mean on the user edit screen, but any input with a submit had the same issue, when they had focus:

![low-contrast-focus-state](https://user-images.githubusercontent.com/17906/54479041-137f4180-4819-11e9-9c6f-4269c239fbff.gif)

This PR adds some more contrast in the text so it's more readable:

![higher-contrast-focus-state](https://user-images.githubusercontent.com/17906/54479063-3a3d7800-4819-11e9-87f0-29914bedc7c0.gif)

This also applies the same `focus` pseudo class  to `<button>` elements as well now, as when I had a button in the new image rotate feature (#2901) I realised there wasn't an obvious focus state when tabbing through the UI.

> Before submitting, please review the contributor guidelines <http://docs.wagtail.io/en/latest/contributing/index.html> and checkI was workin the following:
>
> * For front-end changes: Did you test on all of Wagtail’s supported browsers? **Please list the exact versions you tested**.

I've tested this on Chrome, and Firefox, but I don't have any linux boxes with GUIs or Windows VMs on my machine, and I think someone will need to check if it looks okay there, but I'm only reusing existing colours and styles, so the chances feel quite low.

Anyway - hope it helps!

C