### PR TITLE
page.copy to use `exclude_fields_in_copy` for child & parental m2m relations

### DIFF
--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -1136,6 +1136,10 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
 
         # copy child m2m relations
         for related_field in get_all_child_m2m_relations(specific_self):
+            # Ignore explicitly excluded fields
+            if related_field.name in exclude_fields:
+                continue
+
             field = getattr(specific_self, related_field.name)
             if field and hasattr(field, 'all'):
                 values = field.all()
@@ -1180,6 +1184,9 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
 
             parental_key_name = child_relation.field.attname
             child_objects = getattr(specific_self, accessor_name, None)
+            # Ignore explicitly excluded fields
+            if accessor_name in exclude_fields:
+                continue
 
             if child_objects:
                 for child_object in child_objects.all():

--- a/wagtail/core/tests/test_page_model.py
+++ b/wagtail/core/tests/test_page_model.py
@@ -1195,6 +1195,61 @@ class TestCopyPage(TestCase):
         # special_field is in the list to be excluded
         self.assertNotEqual(page.special_field, new_page.special_field)
 
+    def test_copy_page_with_excluded_parental_and_child_relations(self):
+        """Test that a page will be copied with parental and child relations removed if excluded."""
+        EventPage.exclude_fields_in_copy = ['advert_placements', 'categories', 'signup_link']
+        christmas_event = EventPage.objects.get(url_path='/home/events/christmas/')
+        summer_category = EventCategory.objects.create(name='Summer')
+        holiday_category = EventCategory.objects.create(name='Holidays')
+
+        # add URL (to test excluding a basic field)
+        christmas_event.signup_link = "https://christmas-is-awesome.com/rsvp"
+
+        # add parental many to many relations
+        christmas_event.categories = (summer_category, holiday_category)
+        christmas_event.save()
+
+        # Copy it
+        new_christmas_event = christmas_event.copy(
+            update_attrs={'title': "New christmas event", 'slug': 'new-christmas-event'}
+        )
+
+        # check that the signup_link was NOT copied
+        self.assertEqual(christmas_event.signup_link, "https://christmas-is-awesome.com/rsvp")
+        self.assertEqual(new_christmas_event.signup_link, '')
+
+        # check that original event is untouched
+        self.assertEqual(
+            christmas_event.categories.count(),
+            2,
+            "Child objects (parental many to many) defined on the superclass were removed from the original page"
+        )
+
+        # check that parental many to many are NOT copied
+        self.assertEqual(
+            new_christmas_event.categories.count(),
+            0,
+            "Child objects (parental many to many) were copied but should be excluded"
+        )
+
+        # check that child objects on original event were left untouched
+        self.assertEqual(
+            christmas_event.advert_placements.count(),
+            1,
+            "Child objects defined on the original superclass were edited when copied"
+        )
+
+        # check that child objects were NOT copied
+        self.assertEqual(
+            new_christmas_event.advert_placements.count(),
+            0,
+            "Child objects defined on the superclass were copied and should not be"
+        )
+
+        # reset excluded fields for future tests
+        EventPage.exclude_fields_in_copy = []
+
+
 
 class TestSubpageTypeBusinessRules(TestCase, WagtailTestUtils):
     def test_allowed_subpage_models(self):

--- a/wagtail/core/tests/test_page_model.py
+++ b/wagtail/core/tests/test_page_model.py
@@ -1197,57 +1197,63 @@ class TestCopyPage(TestCase):
 
     def test_copy_page_with_excluded_parental_and_child_relations(self):
         """Test that a page will be copied with parental and child relations removed if excluded."""
-        EventPage.exclude_fields_in_copy = ['advert_placements', 'categories', 'signup_link']
-        christmas_event = EventPage.objects.get(url_path='/home/events/christmas/')
-        summer_category = EventCategory.objects.create(name='Summer')
-        holiday_category = EventCategory.objects.create(name='Holidays')
 
-        # add URL (to test excluding a basic field)
-        christmas_event.signup_link = "https://christmas-is-awesome.com/rsvp"
+        try:
+            # modify excluded fields for this test
+            EventPage.exclude_fields_in_copy = ['advert_placements', 'categories', 'signup_link']
+            
+            # set up data
+            christmas_event = EventPage.objects.get(url_path='/home/events/christmas/')
+            summer_category = EventCategory.objects.create(name='Summer')
+            holiday_category = EventCategory.objects.create(name='Holidays')
 
-        # add parental many to many relations
-        christmas_event.categories = (summer_category, holiday_category)
-        christmas_event.save()
+            # add URL (to test excluding a basic field)
+            christmas_event.signup_link = "https://christmas-is-awesome.com/rsvp"
 
-        # Copy it
-        new_christmas_event = christmas_event.copy(
-            update_attrs={'title': "New christmas event", 'slug': 'new-christmas-event'}
-        )
+            # add parental many to many relations
+            christmas_event.categories = (summer_category, holiday_category)
+            christmas_event.save()
 
-        # check that the signup_link was NOT copied
-        self.assertEqual(christmas_event.signup_link, "https://christmas-is-awesome.com/rsvp")
-        self.assertEqual(new_christmas_event.signup_link, '')
+            # Copy it
+            new_christmas_event = christmas_event.copy(
+                update_attrs={'title': "New christmas event", 'slug': 'new-christmas-event'}
+            )
 
-        # check that original event is untouched
-        self.assertEqual(
-            christmas_event.categories.count(),
-            2,
-            "Child objects (parental many to many) defined on the superclass were removed from the original page"
-        )
+            # check that the signup_link was NOT copied
+            self.assertEqual(christmas_event.signup_link, "https://christmas-is-awesome.com/rsvp")
+            self.assertEqual(new_christmas_event.signup_link, '')
 
-        # check that parental many to many are NOT copied
-        self.assertEqual(
-            new_christmas_event.categories.count(),
-            0,
-            "Child objects (parental many to many) were copied but should be excluded"
-        )
+            # check that original event is untouched
+            self.assertEqual(
+                christmas_event.categories.count(),
+                2,
+                "Child objects (parental many to many) defined on the superclass were removed from the original page"
+            )
 
-        # check that child objects on original event were left untouched
-        self.assertEqual(
-            christmas_event.advert_placements.count(),
-            1,
-            "Child objects defined on the original superclass were edited when copied"
-        )
+            # check that parental many to many are NOT copied
+            self.assertEqual(
+                new_christmas_event.categories.count(),
+                0,
+                "Child objects (parental many to many) were copied but should be excluded"
+            )
 
-        # check that child objects were NOT copied
-        self.assertEqual(
-            new_christmas_event.advert_placements.count(),
-            0,
-            "Child objects defined on the superclass were copied and should not be"
-        )
+            # check that child objects on original event were left untouched
+            self.assertEqual(
+                christmas_event.advert_placements.count(),
+                1,
+                "Child objects defined on the original superclass were edited when copied"
+            )
 
-        # reset excluded fields for future tests
-        EventPage.exclude_fields_in_copy = []
+            # check that child objects were NOT copied
+            self.assertEqual(
+                new_christmas_event.advert_placements.count(),
+                0,
+                "Child objects defined on the superclass were copied and should not be"
+            )
+
+        finally:
+            # reset excluded fields for future tests
+            EventPage.exclude_fields_in_copy = []
 
 
 

--- a/wagtail/core/tests/test_page_model.py
+++ b/wagtail/core/tests/test_page_model.py
@@ -1201,7 +1201,7 @@ class TestCopyPage(TestCase):
         try:
             # modify excluded fields for this test
             EventPage.exclude_fields_in_copy = ['advert_placements', 'categories', 'signup_link']
-            
+
             # set up data
             christmas_event = EventPage.objects.get(url_path='/home/events/christmas/')
             summer_category = EventCategory.objects.create(name='Summer')


### PR DESCRIPTION
Fixes #5099

Ensure that `exclude_fields_in_copy` can be used to also 'exclude' copying child relations and parental many to many relations.

* Do the tests still pass? 👍 
* Does the code comply with the style guide? 👍 
* For Python changes: Have you added tests to cover the new/fixed behaviour? 👍 
* For new features: Has the documentation been updated accordingly? N/A
