### PR TITLE
Improve the snippet UI by offering 'Don't delete' actions to the edit form. 

### DIFF
--- a/wagtail/snippets/templates/wagtailsnippets/snippets/confirm_delete.html
+++ b/wagtail/snippets/templates/wagtailsnippets/snippets/confirm_delete.html
@@ -35,6 +35,7 @@
         <form action="{{ submit_url }}" method="POST">
             {% csrf_token %}
             <input type="submit" value="{% trans 'Yes, delete' %}" class="button serious" />
+            <a href="{% if next %}{{ next }}{% else %}{% url 'wagtailsnippets:list' model_opts.app_label model_opts.model_name %}{% endif %}" class="button button-secondary">{% trans "No, don't delete it" %}</a>
         </form>
     </div>
 

--- a/wagtail/snippets/templates/wagtailsnippets/snippets/list.html
+++ b/wagtail/snippets/templates/wagtailsnippets/snippets/list.html
@@ -21,6 +21,16 @@
                         <h2><a class="snippet-choice" href="{% url 'wagtailsnippets:chosen' model_opts.app_label model_opts.model_name snippet.pk|admin_urlquote %}">{{ snippet }}</a></h2>
                     {% else %}
                         <h2><a href="{% url 'wagtailsnippets:edit' model_opts.app_label model_opts.model_name snippet.pk|admin_urlquote %}">{{ snippet }}</a></h2>
+                         <ul class="actions">
+                            <li>
+                                <a href="{% url 'wagtailsnippets:edit' model_opts.app_label model_opts.model_name snippet.pk|admin_urlquote %}" class="button button-secondary button-small">Edit</a>
+                            </li>
+                            {% if can_delete_snippets %}
+                                <li>
+                                    <a href="{% url 'wagtailsnippets:delete' model_opts.app_label model_opts.model_name snippet.pk|admin_urlquote %}" class="button button-secondary button-small">Delete</a>
+                                </li>
+                            {% endif %}
+                        </ul>
                     {% endif %}
                 </td>
             </tr>


### PR DESCRIPTION
It's useful to have a 'No, don't delete' button on the delete snippet form. I think it's important to keep UI bits like this as similar as possible, with this addition snippet deletion looks and acts more like page 
deletion which is visually less jarring.

The snippets now have a delete/edit button on hover as well as a 'Don't delete' action on the delete form:

![snippet list image](https://i.imgur.com/vHKA4ss.png)

![dont delete snippet](https://i.imgur.com/ei7CdGw.png)



* Do the tests still pass? : Yes
* Does the code comply with the style guide? Yes
* For front-end changes: Did you test on all of Wagtail’s supported browsers? Chrome 70.0.3
