### PR TITLE
Recommend `npm install --no-save` when setting up node toolchain

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
             - node-v1-{{ .Branch }}-{{ checksum "package-lock.json" }}
             - node-v1-{{ .Branch }}-
             - node-v1-
-      - run: npm install
+      - run: npm install --no-save
       - save_cache:
           paths:
             - ~/project/node_modules/

--- a/.squash.yml
+++ b/.squash.yml
@@ -6,7 +6,7 @@ deployments:
       - RUN bash -c "curl -sL https://deb.nodesource.com/setup_8.x | bash -"
       - apt install -y nodejs
       - cd /code
-      - npm install
+      - npm install --no-save
       - npm run dist
       - pip install setuptools pip --upgrade --force-reinstall
       - pip install /code

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ clean-pyc:
 
 develop: clean-pyc
 	pip install -e .[testing,docs]
-	npm install && npm run build
+	npm install --no-save && npm run build
 
 lint:
 	flake8 wagtail

--- a/docs/contributing/css_guidelines.rst
+++ b/docs/contributing/css_guidelines.rst
@@ -37,7 +37,7 @@ Linting SCSS
 
 Wagtail uses the `stylelint <https://stylelint.io/>`_ linter.
 You'll need Node.js and npm on your development machine.
-Ensure project dependencies are installed by running ``npm install``
+Ensure project dependencies are installed by running ``npm install --no-save``
 
 Run the linter from the wagtail project root:
 

--- a/docs/contributing/css_guidelines.rst
+++ b/docs/contributing/css_guidelines.rst
@@ -14,7 +14,7 @@ run the following from the Wagtail repository root:
 
 .. code-block:: console
 
-    $ npm install
+    $ npm install --no-save
 
 
 To compile the assets, run:

--- a/docs/contributing/developing.rst
+++ b/docs/contributing/developing.rst
@@ -43,7 +43,7 @@ Install the tool chain for building static assets:
 
 .. code-block:: console
 
-    $ npm install
+    $ npm install --no-save
 
 Compile the assets:
 

--- a/docs/contributing/javascript_guidelines.rst
+++ b/docs/contributing/javascript_guidelines.rst
@@ -15,7 +15,7 @@ Linting and formatting code
 
 Wagtail provides some tooling configuration to help check your code meets the
 styleguide. You'll need node.js and npm on your development machine.
-Ensure project dependencies are installed by running ``npm install``
+Ensure project dependencies are installed by running ``npm install --no-save``
 
 Linting code
 ------------


### PR DESCRIPTION
Running `npm install` without `--no-save` can introduce spurious changes to package-lock.json due to differences in platform / node version, and these have been known to accidentally sneak into people's PRs. `npm install` without `--no-save` should only be used when actively updating node dependencies in package.json.