### PR TITLE
Improve formatting of dates in AbstractEmailForm

### DIFF
--- a/wagtail/contrib/forms/models.py
+++ b/wagtail/contrib/forms/models.py
@@ -281,11 +281,13 @@ class AbstractEmailForm(AbstractForm):
 
     def render_email(self, form):
         content = []
-        for field in form:
-            value = field.value()
+        for field, value in form.cleaned_data.items():
             if isinstance(value, list):
                 value = ', '.join(value)
-            content.append('{}: {}'.format(field.label, value))
+
+            label = form.fields.get(field).label
+            content.append('{}: {}'.format(label, value))
+
         return '\n'.join(content)
 
     class Meta:

--- a/wagtail/contrib/forms/models.py
+++ b/wagtail/contrib/forms/models.py
@@ -2,8 +2,8 @@ import datetime
 import json
 import os
 
-from django.core.serializers.json import DjangoJSONEncoder
 from django.conf import settings
+from django.core.serializers.json import DjangoJSONEncoder
 from django.db import models
 from django.shortcuts import render
 from django.utils.formats import date_format

--- a/wagtail/contrib/forms/models.py
+++ b/wagtail/contrib/forms/models.py
@@ -277,14 +277,16 @@ class AbstractEmailForm(AbstractForm):
 
     def send_mail(self, form):
         addresses = [x.strip() for x in self.to_address.split(',')]
+        send_mail(self.subject, self.render_email(form), addresses, self.from_address,)
+
+    def render_email(self, form):
         content = []
         for field in form:
             value = field.value()
             if isinstance(value, list):
                 value = ', '.join(value)
             content.append('{}: {}'.format(field.label, value))
-        content = '\n'.join(content)
-        send_mail(self.subject, content, addresses, self.from_address,)
+        return '\n'.join(content)
 
     class Meta:
         abstract = True

--- a/wagtail/contrib/forms/models.py
+++ b/wagtail/contrib/forms/models.py
@@ -281,12 +281,18 @@ class AbstractEmailForm(AbstractForm):
 
     def render_email(self, form):
         content = []
-        for field, value in form.cleaned_data.items():
+
+        cleaned_data = form.cleaned_data
+        for field in form:
+            if field.name not in cleaned_data:
+                continue
+
+            value = cleaned_data.get(field.name)
+
             if isinstance(value, list):
                 value = ', '.join(value)
 
-            label = form.fields.get(field).label
-            content.append('{}: {}'.format(label, value))
+            content.append('{}: {}'.format(field.label, value))
 
         return '\n'.join(content)
 

--- a/wagtail/contrib/forms/models.py
+++ b/wagtail/contrib/forms/models.py
@@ -1,9 +1,12 @@
+import datetime
 import json
 import os
 
 from django.core.serializers.json import DjangoJSONEncoder
+from django.conf import settings
 from django.db import models
 from django.shortcuts import render
+from django.utils.formats import date_format
 from django.utils.text import slugify
 from django.utils.translation import ugettext_lazy as _
 from unidecode import unidecode
@@ -291,6 +294,12 @@ class AbstractEmailForm(AbstractForm):
 
             if isinstance(value, list):
                 value = ', '.join(value)
+
+            # Format dates and datetimes with SHORT_DATE(TIME)_FORMAT
+            if isinstance(value, datetime.datetime):
+                value = date_format(value, settings.SHORT_DATETIME_FORMAT)
+            elif isinstance(value, datetime.date):
+                value = date_format(value, settings.SHORT_DATE_FORMAT)
 
             content.append('{}: {}'.format(field.label, value))
 

--- a/wagtail/contrib/forms/tests/test_models.py
+++ b/wagtail/contrib/forms/tests/test_models.py
@@ -525,6 +525,24 @@ class TestCleanedDataEmails(TestCase):
             message_line = email_lines.pop(0)
             self.assertTrue(message_line.startswith(beginning))
 
+    def test_date_normalization(self):
+        self.client.post('/contact-us/', {
+            'date': '12/31/17',
+        })
+
+        # Check the email
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertIn("Date: 2017-12-31", mail.outbox[0].body)
+
+        self.client.post('/contact-us/', {
+            'date': '12/31/1917',
+        })
+
+        # Check the email
+        self.assertEqual(len(mail.outbox), 2)
+        self.assertIn("Date: 1917-12-31", mail.outbox[1].body)
+
+
 
 
 class TestIssue798(TestCase):

--- a/wagtail/contrib/forms/tests/test_models.py
+++ b/wagtail/contrib/forms/tests/test_models.py
@@ -6,7 +6,8 @@ from django.test import TestCase, override_settings
 
 from wagtail.contrib.forms.models import FormSubmission
 from wagtail.contrib.forms.tests.utils import (
-    make_form_page, make_form_page_with_custom_submission, make_form_page_with_redirect, make_types_test_form_page)
+    make_form_page, make_form_page_with_custom_submission, make_form_page_with_redirect,
+    make_types_test_form_page)
 from wagtail.core.models import Page
 from wagtail.tests.testapp.models import (
     CustomFormPageSubmission, ExtendedFormField, FormField, FormPageWithCustomFormBuilder,

--- a/wagtail/contrib/forms/tests/utils.py
+++ b/wagtail/contrib/forms/tests/utils.py
@@ -116,3 +116,105 @@ def make_form_page_with_redirect(**kwargs):
     )
 
     return form_page
+
+
+def make_types_test_form_page(**kwargs):
+    kwargs.setdefault('title', "Contact us")
+    kwargs.setdefault('slug', "contact-us")
+    kwargs.setdefault('to_address', "to@email.com")
+    kwargs.setdefault('from_address', "from@email.com")
+    kwargs.setdefault('subject', "The subject")
+
+    home_page = Page.objects.get(url_path='/home/')
+    form_page = home_page.add_child(instance=FormPage(**kwargs))
+
+    FormField.objects.create(
+        page=form_page,
+        sort_order=1,
+        label="Single line text",
+        field_type='singleline',
+        required=False,
+    )
+    FormField.objects.create(
+        page=form_page,
+        sort_order=2,
+        label="Multiline",
+        field_type='multiline',
+        required=False,
+    )
+    FormField.objects.create(
+        page=form_page,
+        sort_order=3,
+        label="Email",
+        field_type='email',
+        required=False,
+    )
+    FormField.objects.create(
+        page=form_page,
+        sort_order=4,
+        label="Number",
+        field_type='number',
+        required=False,
+    )
+    FormField.objects.create(
+        page=form_page,
+        sort_order=5,
+        label="URL",
+        field_type='url',
+        required=False,
+    )
+    FormField.objects.create(
+        page=form_page,
+        sort_order=6,
+        label="Checkbox",
+        field_type='checkbox',
+        required=False,
+    )
+    FormField.objects.create(
+        page=form_page,
+        sort_order=7,
+        label="Checkboxes",
+        field_type='checkboxes',
+        required=False,
+        choices='foo,bar,baz',
+    )
+    FormField.objects.create(
+        page=form_page,
+        sort_order=8,
+        label="Drop down",
+        field_type='dropdown',
+        required=False,
+        choices='spam,ham,eggs',
+    )
+    FormField.objects.create(
+        page=form_page,
+        sort_order=9,
+        label="Multiple select",
+        field_type='multiselect',
+        required=False,
+        choices='qux,quux,quuz,corge',
+    )
+    FormField.objects.create(
+        page=form_page,
+        sort_order=10,
+        label="Radio buttons",
+        field_type='radio',
+        required=False,
+        choices='wibble,wobble,wubble',
+    )
+    FormField.objects.create(
+        page=form_page,
+        sort_order=11,
+        label="Date",
+        field_type='date',
+        required=False,
+    )
+    FormField.objects.create(
+        page=form_page,
+        sort_order=12,
+        label="Datetime",
+        field_type='datetime',
+        required=False,
+    )
+
+    return form_page


### PR DESCRIPTION
In #3733 there is a request to format dates consistently in the emails that `AbstractEmailForm` sends - It seems the simplest way to do this is to use the `form.cleaned_data` of the submitted form, where those dates have already been parsed into `datetime` objects, and in doing so, could tie up #4313 as well.

In implementing this, I've split out the rendering portion of `AbstractEmailForm.send_mail`, so that it could be overridden independently.

I've also added tests to check that the fields are output in the form order in the email, and to check that various date/datetime input formats all normalise to the correct formats.