### PR TITLE
Add providerName and url to embed preview

### DIFF
--- a/client/src/components/Draftail/blocks/EmbedBlock.js
+++ b/client/src/components/Draftail/blocks/EmbedBlock.js
@@ -10,7 +10,7 @@ import MediaBlock from '../blocks/MediaBlock';
  */
 const EmbedBlock = props => {
   const { entity, onRemoveEntity } = props.blockProps;
-  const { url, title, thumbnail } = entity.getData();
+  const { providerName, url, title, thumbnail } = entity.getData();
 
   return (
     <MediaBlock {...props} src={thumbnail} alt="">
@@ -23,6 +23,7 @@ const EmbedBlock = props => {
           rel="noopener noreferrer"
         >
           {title}
+          {providerName}, {url}
         </a>
       ) : null}
 


### PR DESCRIPTION
Pull request for #5176 
Add providerName to embed description, and add url as well. 
In case title / thumbnail is not present, this provides minimum information to the user. 