### PR TITLE
Clear pending AJAX request if error occurs on page chooser

### DIFF
--- a/wagtail/admin/static_src/wagtailadmin/js/page-chooser-modal.js
+++ b/wagtail/admin/static_src/wagtailadmin/js/page-chooser-modal.js
@@ -40,6 +40,9 @@ PAGE_CHOOSER_MODAL_ONLOAD_HANDLERS = {
                         request = null;
                         $('.page-results', modal.body).html(data);
                         ajaxifySearchResults();
+                    },
+                    error: function() {
+                        request = null;
                     }
                 });
             } else {


### PR DESCRIPTION
Little addendum to #5137: the 'pending request' flag should be cleared when an XHR error occurs, as well as on a successful response - otherwise, a temporary server error will cause subsequent requests to be blocked.

This can be verified on a dev instance by opening the page chooser, stopping the server, searching for something, restarting the server and searching again.