### PR TITLE
Add system check for missing core page fields in search_fields

### DIFF
--- a/wagtail/admin/checks.py
+++ b/wagtail/admin/checks.py
@@ -3,7 +3,7 @@ import os
 from django.core.checks import Error, Warning, register
 
 
-@register()
+@register('css')
 def css_install_check(app_configs, **kwargs):
     errors = []
 

--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -320,7 +320,7 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
         editable=False
     )
 
-    search_fields = [
+    search_fields_core = [
         index.SearchField('title', partial_match=True, boost=2),
         index.AutocompleteField('title'),
         index.FilterField('title'),
@@ -330,6 +330,9 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
         index.FilterField('content_type'),
         index.FilterField('path'),
         index.FilterField('depth'),
+    ]
+
+    search_fields = search_fields_core + [
         index.FilterField('locked'),
         index.FilterField('show_in_menus'),
         index.FilterField('first_published_at'),

--- a/wagtail/images/checks.py
+++ b/wagtail/images/checks.py
@@ -33,7 +33,7 @@ def has_png_support():
     return succeeded
 
 
-@register()
+@register('images')
 def image_library_check(app_configs, **kwargs):
     errors = []
 

--- a/wagtail/search/apps.py
+++ b/wagtail/search/apps.py
@@ -3,6 +3,8 @@ from django.utils.translation import ugettext_lazy as _
 
 from wagtail.search.signal_handlers import register_signal_handlers
 
+from . import checks  # NOQA
+
 
 class WagtailSearchAppConfig(AppConfig):
     name = 'wagtail.search'

--- a/wagtail/search/checks.py
+++ b/wagtail/search/checks.py
@@ -1,0 +1,25 @@
+from django.core.checks import Warning, register
+
+
+@register('search')
+def page_search_fields_check(app_configs, **kwargs):
+    """Checks each page model with search_fields to ensure core fields are included"""
+    from wagtail.core.models import get_page_models, Page
+
+    page_models = get_page_models()
+    errors = []
+
+    for cls in page_models:
+        if not all(field in cls.search_fields for field in Page.search_fields_core):
+            errors.append(
+                Warning(
+                    'Core Page fields missing in `search_fields`',
+                    hint=' '.join([
+                        'Ensure that {} extends the Page model search fields',
+                        '`search_fields = Page.search_fields + [...]`'
+                    ]).format(cls.__name__),
+                    obj=cls,
+                    id='wagtailsearch.W001'
+                ))
+
+    return errors

--- a/wagtail/search/checks.py
+++ b/wagtail/search/checks.py
@@ -13,7 +13,7 @@ def page_search_fields_check(app_configs, **kwargs):
         if not all(field in cls.search_fields for field in Page.search_fields_core):
             errors.append(
                 Warning(
-                    'Core Page fields missing in `search_fields`',
+                    'Core page fields missing in `search_fields`',
                     hint=' '.join([
                         'Ensure that {} extends the Page model search fields',
                         '`search_fields = Page.search_fields + [...]`'

--- a/wagtail/search/tests/test_indexed_class.py
+++ b/wagtail/search/tests/test_indexed_class.py
@@ -3,10 +3,10 @@ from contextlib import contextmanager
 from django.core import checks
 from django.test import TestCase
 
+from wagtail.core.models import Page
 from wagtail.search import index
 from wagtail.tests.search import models
 from wagtail.tests.testapp.models import EventPage, SingleEventPage
-from wagtail.core.models import Page
 
 
 @contextmanager


### PR DESCRIPTION
Closes #4940

Adds a Django check for all page models where `search_fields` is declared to ensure critical core search fields are included. Flags as a warning, not an error.

Implementation questions:
* I did this using a new checks file in the search app - is this ok (compared to using the `.check()` method on the model?), this is a simpler implementation but maybe devs will want to override this behaviour? Happy to move it to the indexed model but was not sure.
* I split the page model into two sets of search fields, some core (ie. required) and some not, preserving the order of these is important so that is kept. My reasoning is that the Page model should declare what it deems to be critical search fields, not the search app itself - otherwise we will have logic split across files.
* I also added some 'tags' to other register search functions, this aids in testing and future checks grouping.
* On an aside, the actual `EventPage` model in our test app does not correctly extend `Page.search_fields`.

* Do the tests still pass? 👍 
* Does the code comply with the style guide? 👍 
* For Python changes: Have you added tests to cover the new/fixed behaviour? 👍 
* For front-end changes: Did you test on all of Wagtail’s supported browsers? N/A
* For new features: Has the documentation been updated accordingly? N/A (honours existing configuration)
