### PR TITLE
Fix page chooser not rendering proper get_admin_display_title

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/shared/chooser_breadcrumb.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/chooser_breadcrumb.html
@@ -1,7 +1,7 @@
 {% load i18n wagtailadmin_tags %}
 
 <ul class="breadcrumb">
-    {% for page in page.get_ancestors %}
+    {% for page in page.get_ancestors.specific %}
         {% if page.is_root %}
             <li class="home"><a href="{% url 'wagtailadmin_choose_page_child' page.id %}{% querystring p=None %}" class="navigate-pages icon icon-home text-replace">{% trans 'Home' %}</a></li>
         {% else %}

--- a/wagtail/admin/tests/test_page_chooser.py
+++ b/wagtail/admin/tests/test_page_chooser.py
@@ -233,15 +233,14 @@ class TestChooserBrowseChild(TestCase, WagtailTestUtils):
 
         # Use the leaf page as the chooser parent, so child is in the breadcrumbs
         response = self.client.get(
-            reverse('wagtailadmin_choose_page_child', args=(leaf_page.id,)),
-            params={'page_type': 'wagtailcore.Page'}
+            reverse('wagtailadmin_choose_page_child', args=(leaf_page.id,))
         )
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, 'wagtailadmin/chooser/browse.html')
 
         # Look for a link element in the breadcrumbs with the admin title
         self.assertTagInHTML(
-            '<a href="/admin/choose-page/{page_id}/?page_type=wagtailcore.page" class="navigate-pages">{page_title}</a>'.format(
+            '<li><a href="/admin/choose-page/{page_id}/?" class="navigate-pages">{page_title}</a></li>'.format(
                 page_id=self.child_page.id,
                 page_title=self.child_page.get_admin_display_title(),
             ),

--- a/wagtail/admin/tests/test_page_chooser.py
+++ b/wagtail/admin/tests/test_page_chooser.py
@@ -208,7 +208,7 @@ class TestChooserBrowseChild(TestCase, WagtailTestUtils):
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, 'wagtailadmin/chooser/browse.html')
 
-        self.assertInHTML(self.child_page.get_admin_display_title(), response.json().get('html'))
+        self.assertInHTML("foobarbaz (simple page)", response.json().get('html'))
 
     def test_parent_with_admin_display_title(self):
         # Add another child under child_page so it renders a chooser list
@@ -223,8 +223,8 @@ class TestChooserBrowseChild(TestCase, WagtailTestUtils):
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, 'wagtailadmin/chooser/browse.html')
 
-        self.assertInHTML(self.child_page.get_admin_display_title(), response.json().get('html'))
-        self.assertInHTML(leaf_page.get_admin_display_title(), response.json().get('html'))
+        self.assertInHTML("foobarbaz (simple page)", response.json().get('html'))
+        self.assertInHTML("quux (simple page)", response.json().get('html'))
 
     def test_admin_display_title_breadcrumb(self):
         # Add another child under child_page so we get breadcrumbs
@@ -242,7 +242,7 @@ class TestChooserBrowseChild(TestCase, WagtailTestUtils):
         self.assertTagInHTML(
             '<li><a href="/admin/choose-page/{page_id}/?" class="navigate-pages">{page_title}</a></li>'.format(
                 page_id=self.child_page.id,
-                page_title=self.child_page.get_admin_display_title(),
+                page_title="foobarbaz (simple page)",
             ),
             response.json().get('html')
         )

--- a/wagtail/admin/tests/test_page_chooser.py
+++ b/wagtail/admin/tests/test_page_chooser.py
@@ -202,6 +202,30 @@ class TestChooserBrowseChild(TestCase, WagtailTestUtils):
         response = self.get({'page_type': 'foo'})
         self.assertEqual(response.status_code, 404)
 
+    def test_with_admin_display_title(self):
+        # Check the display of the child page title when it's a child
+        response = self.get({'page_type': 'wagtailcore.Page'})
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'wagtailadmin/chooser/browse.html')
+
+        self.assertInHTML(self.child_page.get_admin_display_title(), response.json().get('html'))
+
+    def test_parent_with_admin_display_title(self):
+        # Add another child under child_page so it renders a chooser list
+        leaf_page = SimplePage(title="quux", content="goodbye")
+        self.child_page.add_child(instance=leaf_page)
+
+        # Use the child page as the chooser parent
+        response = self.client.get(
+            reverse('wagtailadmin_choose_page_child', args=(self.child_page.id,)),
+            params={'page_type': 'wagtailcore.Page'}
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'wagtailadmin/chooser/browse.html')
+
+        self.assertInHTML(self.child_page.get_admin_display_title(), response.json().get('html'))
+        self.assertInHTML(leaf_page.get_admin_display_title(), response.json().get('html'))
+
     def setup_pagination_test_data(self):
         # Create lots of pages
         for i in range(100):

--- a/wagtail/admin/views/chooser.py
+++ b/wagtail/admin/views/chooser.py
@@ -87,6 +87,8 @@ def browse(request, parent_page_id=None):
         all_desired_pages = filter_page_type(Page.objects.all(), desired_classes)
         parent_page = all_desired_pages.first_common_ancestor()
 
+    parent_page = parent_page.specific
+
     # Get children of parent page
     pages = parent_page.get_children().specific()
 


### PR DESCRIPTION
On a project, I noticed a couple of places in the page chooser where the `get_admin_display_title` function was not showing the correct title.

This was happening both when the title appeared in the chooser breadcrumbs and when the page title appeared in the top "parent page" section. It would also show the incorrect title in the value section of a filled chooser. 

This can be reproduced by adding a page with an overridden `get_admin_display_title` function, then adding another two layers of pages underneath it.
As an example, let the tree be:
```
- Overridden page
    \- Middle page
        \- Leaf page
```
1. Using the page chooser, select the middle page
1. Click "Choose another page" on the same chooser
    The parent page entry for Overridden page at the top of the chooser will show the incorrect title
1. Using the page chooser, descend under the middle page
    The breadcrumb entry for Overridden page will show the incorrect title

This PR adds testing for both the parent page section and the breadcrumbs at the level of the rendered HTML (as extracted from the JSON response), and adds two calls to `.specific` - one in the code for `chooser.browse` and one in the template for `chooser_breadcrumb` - the ensure the override version of `get_admin_display_title` is called.
