### PR TITLE
Add process_child_object and exclude_fields keyword arguments to Page.copy

### DIFF
--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -1050,11 +1050,11 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
         # Log
         logger.info("Page moved: \"%s\" id=%d path=%s", self.title, self.id, new_url_path)
 
-    def copy(self, recursive=False, to=None, update_attrs=None, copy_revisions=True, keep_live=True, user=None, process_child_object=None):
+    def copy(self, recursive=False, to=None, update_attrs=None, copy_revisions=True, keep_live=True, user=None, process_child_object=None, exclude_fields=None):
         # Fill dict with self.specific values
         specific_self = self.specific
         default_exclude_fields = ['id', 'path', 'depth', 'numchild', 'url_path', 'path', 'index_entries']
-        exclude_fields = default_exclude_fields + specific_self.exclude_fields_in_copy
+        exclude_fields = default_exclude_fields + specific_self.exclude_fields_in_copy + (exclude_fields or [])
         specific_dict = {}
 
         for field in specific_self._meta.get_fields():
@@ -1117,6 +1117,10 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
         specific_self = self.specific
         for child_relation in get_all_child_relations(specific_self):
             accessor_name = child_relation.get_accessor_name()
+
+            if accessor_name in exclude_fields:
+                continue
+
             parental_key_name = child_relation.field.attname
             child_objects = getattr(specific_self, accessor_name, None)
 

--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -1050,7 +1050,7 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
         # Log
         logger.info("Page moved: \"%s\" id=%d path=%s", self.title, self.id, new_url_path)
 
-    def copy(self, recursive=False, to=None, update_attrs=None, copy_revisions=True, keep_live=True, user=None):
+    def copy(self, recursive=False, to=None, update_attrs=None, copy_revisions=True, keep_live=True, user=None, process_child_object=None):
         # Fill dict with self.specific values
         specific_self = self.specific
         default_exclude_fields = ['id', 'path', 'depth', 'numchild', 'url_path', 'path', 'index_entries']
@@ -1125,6 +1125,10 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
                     old_pk = child_object.pk
                     child_object.pk = None
                     setattr(child_object, parental_key_name, page_copy.id)
+
+                    if process_child_object is not None:
+                        process_child_object(child_relation, child_object)
+
                     child_object.save()
 
                     # Add mapping to new primary key (so we can apply this change to revisions)

--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -1131,7 +1131,7 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
                     setattr(child_object, parental_key_name, page_copy.id)
 
                     if process_child_object is not None:
-                        process_child_object(child_relation, child_object)
+                        process_child_object(specific_self, page_copy, child_relation, child_object)
 
                     child_object.save()
 


### PR DESCRIPTION
This adds the following keyword arguments to the ``Page.copy`` method:

 - ``process_child_object`` allows a function to be passed which is called if a child object is copied. The passed arguments are ``page``, ``child_relation`` and ``child_object``.
 - ``exclude_fields`` allows a list of fields to be passed that should be excluded from copy

I've also fixed an issue where child relations were not being excluded if they were specified in excluded fields.