### PR TITLE
Re-add spacing between label and caret in listing headers

### DIFF
--- a/wagtail/admin/static_src/wagtailadmin/scss/components/_listing.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/components/_listing.scss
@@ -63,6 +63,7 @@ ul.listing {
             &.icon:after {
                 opacity: 0.5;
                 right: 0;
+                margin-left: 3px;
             }
         }
     }


### PR DESCRIPTION
This spacing was previously done with whitespace in the HTML, that got removed as part of #5124. This is much better done with CSS.

## Before/after #5124

![whitespace-collapsing](https://user-images.githubusercontent.com/877585/55158333-8ca26100-5156-11e9-9e0a-8ddd6c91947a.gif)

## New spacing in CSS

![5124-spacing](https://user-images.githubusercontent.com/877585/55158223-49e08900-5156-11e9-87c2-76967dfd0b95.png)

Tested in Chrome, Firefox, Safari on macOS.