### PR TITLE
Bump django-taggit to 0.24

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ except ImportError:
 install_requires = [
     "Django>=2.0,<2.3",
     "django-modelcluster>=4.2,<5.0",
-    "django-taggit>=0.23,<0.24",
+    "django-taggit>=0.23,<1.0",
     "django-treebeard>=4.2.0,<5.0",
     "djangorestframework>=3.7.4,<4.0",
     "draftjs_exporter>=2.1.5,<3.0",


### PR DESCRIPTION
Prompted by #5197 - it appears that we can't upgrade to django-taggit 1.x immediately due to breaking changes, but 0.24 is the first version to officially support Django 2.2, so we definitely want to extend our dependency range to include that.