### PR TITLE
Implement Page.with_content_json

### DIFF
--- a/docs/reference/pages/model_reference.rst
+++ b/docs/reference/pages/model_reference.rst
@@ -226,6 +226,8 @@ In addition to the model fields provided, ``Page`` has many properties and metho
         Forms must be a subclass of :class:`~wagtail.admin.forms.WagtailAdminPageForm`.
         See :ref:`custom_edit_handler_forms` for more information.
 
+    .. automethod:: with_content_json
+
 .. _site-model-ref:
 
 ``Site``

--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -1421,6 +1421,7 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
 
         # Ensure other values that are meaningful for the page as a whole (rather than
         # to a specific revision) are preserved
+        obj.content_type = self.content_type
         obj.draft_title = self.draft_title
         obj.live = self.live
         obj.has_unpublished_changes = self.has_unpublished_changes
@@ -1428,6 +1429,7 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
         obj.locked = self.locked
         obj.latest_revision_created_at = self.latest_revision_created_at
         obj.first_published_at = self.first_published_at
+        obj.show_in_menus = self.show_in_menus
 
         return obj
 

--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -1429,7 +1429,6 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
         obj.locked = self.locked
         obj.latest_revision_created_at = self.latest_revision_created_at
         obj.first_published_at = self.first_published_at
-        obj.show_in_menus = self.show_in_menus
 
         return obj
 

--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -1409,19 +1409,18 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
     def with_content_json(self, content_json):
         obj = self.specific_class.from_json(content_json)
 
-        # Override the possibly-outdated tree parameter fields from this revision object
-        # with up-to-date values
+        # Override the possibly-outdated tree parameter fields from the supplied content
         obj.pk = self.pk
         obj.path = self.path
         obj.depth = self.depth
         obj.numchild = self.numchild
 
-        # Populate url_path based on the revision's current slug and the parent page as determined
-        # by path
+        # Update url_path to reflect potential slug changes, but maintining the page's
+        # existing tree position
         obj.set_url_path(self.get_parent())
 
-        # also copy over other properties which are meaningful for the page as a whole, not a
-        # specific revision of it
+        # Ensure other values that are meaningful for the page as a whole (rather than
+        # to a specific revision) are preserved
         obj.draft_title = self.draft_title
         obj.live = self.live
         obj.has_unpublished_changes = self.has_unpublished_changes

--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -1503,7 +1503,7 @@ class PageRevision(models.Model):
             self.page.revisions.exclude(id=self.id).update(submitted_for_moderation=False)
 
     def as_page_object(self):
-        return self.page.with_content_json(self.content_json)
+        return self.page.specific.with_content_json(self.content_json)
 
     def approve_moderation(self):
         if self.submitted_for_moderation:

--- a/wagtail/core/tests/test_page_model.py
+++ b/wagtail/core/tests/test_page_model.py
@@ -1534,3 +1534,62 @@ class TestShowInMenusDefaultOption(TestCase):
 
         # Check that the page instance creates with show_in_menu as True
         self.assertTrue(page.show_in_menus)
+
+
+class TestPageWithContentJSON(TestCase):
+    fixtures = ['test.json']
+
+    def test_with_content_json_preserves_values(self):
+        original_page = SimplePage.objects.get(url_path='/home/about-us/')
+        eventpage_content_type = ContentType.objects.get_for_model(EventPage)
+
+        # Take a json representation of the page and update it
+        # with the above values
+        content = json.loads(original_page.to_json())
+        content.update(
+            title='About them',
+            draft_title='About them',
+            slug='about-them',
+            url_path='/home/some-section/about-them/',
+            pk=original_page.pk + 999,
+            numchild=original_page.numchild + 999,
+            depth=original_page.depth + 999,
+            path=original_page.path + 'ABCDEF',
+            content='<p>They are not as good</p>',
+            first_published_at="2000-01-01T00:00:00Z",
+            last_published_at="2000-01-01T00:00:00Z",
+            live=not original_page.live,
+            locked=not original_page.locked,
+            has_unpublished_changes=not original_page.has_unpublished_changes,
+            content_type=eventpage_content_type.id,
+            show_in_menus=not original_page.show_in_menus,
+            owner=1
+        )
+
+        # Convert values back to json and pass them to with_content_json()
+        # to get an updated version of the page
+        content_json = json.dumps(content)
+        updated_page = original_page.with_content_json(content_json)
+
+        # The following attributes values should have changed
+        for attr_name in ('title', 'slug', 'content', 'url_path'):
+            self.assertNotEqual(
+                getattr(original_page, attr_name),
+                getattr(updated_page, attr_name)
+            )
+
+        # The following attribute values should have been preserved,
+        # despite new values being provided in content_json
+        for attr_name in (
+            'pk', 'path', 'depth', 'numchild', 'content_type', 'draft_title',
+            'live', 'has_unpublished_changes', 'owner', 'locked', 'show_in_menus',
+            'latest_revision_created_at', 'first_published_at',
+        ):
+            self.assertEqual(
+                getattr(original_page, attr_name),
+                getattr(updated_page, attr_name)
+            )
+
+        # The url_path should reflect the new slug value, but the
+        # rest of the path should have remained unchanged
+        self.assertEqual(updated_page.url_path, '/home/about-them/')

--- a/wagtail/core/tests/test_page_model.py
+++ b/wagtail/core/tests/test_page_model.py
@@ -1544,7 +1544,7 @@ class TestPageWithContentJSON(TestCase):
         eventpage_content_type = ContentType.objects.get_for_model(EventPage)
 
         # Take a json representation of the page and update it
-        # with the above values
+        # with some alternative values
         content = json.loads(original_page.to_json())
         content.update(
             title='About them',
@@ -1572,7 +1572,7 @@ class TestPageWithContentJSON(TestCase):
         updated_page = original_page.with_content_json(content_json)
 
         # The following attributes values should have changed
-        for attr_name in ('title', 'slug', 'content', 'url_path'):
+        for attr_name in ('title', 'slug', 'content', 'url_path', 'show_in_menus'):
             self.assertNotEqual(
                 getattr(original_page, attr_name),
                 getattr(updated_page, attr_name)
@@ -1582,7 +1582,7 @@ class TestPageWithContentJSON(TestCase):
         # despite new values being provided in content_json
         for attr_name in (
             'pk', 'path', 'depth', 'numchild', 'content_type', 'draft_title',
-            'live', 'has_unpublished_changes', 'owner', 'locked', 'show_in_menus',
+            'live', 'has_unpublished_changes', 'owner', 'locked',
             'latest_revision_created_at', 'first_published_at',
         ):
             self.assertEqual(


### PR DESCRIPTION
Fixes #5199

This implements a new method on ``Page`` which allows subclasses to alter behavior when a page object is created from JSON content.

Currently, this is used some internal fields are set to their live values, but it's now possible to reset some fields on the sub-class as well. Also, this provides an API for plugins such as the [wagtail-headless-preview-poc](https://github.com/gasman/wagtail-headless-preview-poc/) to use to convert serialised pages back into page objects with metadata fields set correctly.