### PR TITLE
Missing step for Migrating RichTextFields to StreamField

### DIFF
--- a/docs/topics/streamfield.rst
+++ b/docs/topics/streamfield.rst
@@ -993,6 +993,13 @@ If you change an existing RichTextField to a StreamField, and create and run mig
             # leave the dependency line from the generated migration intact!
             ('demo', '0001_initial'),
         ]
+        
+        # leave the generated AlterField intact!
+        migrations.AlterField(
+            model_name='BlogPage',
+            name='body',
+            field=wagtail.core.fields.StreamField([('rich_text', wagtail.core.blocks.RichTextBlock())]),
+        ),
 
         operations = [
             migrations.RunPython(
@@ -1104,6 +1111,13 @@ Note that the above migration will work on published Page objects only. If you a
             # leave the dependency line from the generated migration intact!
             ('demo', '0001_initial'),
         ]
+        
+        # leave the generated AlterField intact!
+        migrations.AlterField(
+            model_name='BlogPage',
+            name='body',
+            field=wagtail.core.fields.StreamField([('rich_text', wagtail.core.blocks.RichTextBlock())]),
+        ),
 
         operations = [
             migrations.RunPython(


### PR DESCRIPTION
This generated block of code needs to stay or else there will be an error while running ./manage.py migrate. It is misleading that it is not included in this tutorial.

Thanks for contributing to Wagtail! 🎉

Before submitting, please review the contributor guidelines <http://docs.wagtail.io/en/latest/contributing/index.html> and check the following:

* Do the tests still pass? (http://docs.wagtail.io/en/latest/contributing/developing.html#testing)
* Does the code comply with the style guide? (Run `make lint` from the Wagtail root)
* For Python changes: Have you added tests to cover the new/fixed behaviour?
* For front-end changes: Did you test on all of Wagtail’s supported browsers? **Please list the exact versions you tested**.
* For new features: Has the documentation been updated accordingly?
