### PR TITLE
Modeladmin search backend

### DIFF
--- a/docs/reference/contrib/modeladmin/indexview.rst
+++ b/docs/reference/contrib/modeladmin/indexview.rst
@@ -306,7 +306,7 @@ assuming they are indexed, you can override this property with the included
 `WagtailBackendSearchHandler` class e.g.
 
 .. code-block:: python
-    from wagtail.contrib.helpers import WagtailBackendSearchHandler
+    from wagtail.contrib.modeladmin.helpers import WagtailBackendSearchHandler
 
     from .models import IndexedModel
 

--- a/docs/reference/contrib/modeladmin/indexview.rst
+++ b/docs/reference/contrib/modeladmin/indexview.rst
@@ -307,6 +307,7 @@ assuming they are indexed, you can override this property with the included
 
 .. code-block:: python
     from wagtail.contrib.helpers import WagtailBackendSearchHandler
+
     from .models import IndexedModel
 
     class DemoAdmin(ModelAdmin):
@@ -316,6 +317,27 @@ assuming they are indexed, you can override this property with the included
 Note: when using the `WagtailBackendSearchHandler` the `search_fields` are used to limit
 the backend to search only over the specified fields, so those fields must be indexed
 by the backend.
+
+.. _modeladmin_search_handler_extra_search_kwargs:
+
+-------------------------------------------------
+``ModelAdmin.search_handler_extra_search_kwargs``
+-------------------------------------------------
+
+A dictionary of keyword arguments that are used by the specified `search_handler_class` during search.
+e.g. to override the `WagtailBackendSearchHandler` default operator you could do the following:
+
+.. code-block:: python
+    from wagtail.contrib.helpers import WagtailBackendSearchHandler
+    from wagtail.search.utils import OR
+
+    from .models import IndexedModel
+
+    class DemoAdmin(ModelAdmin):
+        model = IndexedModel
+        search_handler_class = WagtailBackendSearchHandler
+        search_handler_extra_search_kwargs = {'operator': OR}
+
 
 .. _modeladmin_ordering:
 

--- a/docs/reference/contrib/modeladmin/indexview.rst
+++ b/docs/reference/contrib/modeladmin/indexview.rst
@@ -301,7 +301,7 @@ your project is using, and without any additional setup or configuration.
 The default value for this property is the `DjangoORMSearchHandler`, which uses
 the Django ORM to perform `icontains` lookups on the fields specified by `search_fields`.
 
-If you would prefer to use the built in Wagtail search backend to search your models,
+If you would prefer to use the built-in Wagtail search backend to search your models,
 assuming they are indexed, you can override this property with the included
 `WagtailBackendSearchHandler` class e.g.
 

--- a/docs/reference/contrib/modeladmin/indexview.rst
+++ b/docs/reference/contrib/modeladmin/indexview.rst
@@ -294,9 +294,9 @@ your project is using, and without any additional setup or configuration.
 
 .. _modeladmin_search_handler_class:
 
--------------------------------------
+-----------------------------------
 ``ModelAdmin.search_handler_class``
--------------------------------------
+-----------------------------------
 
 The default value for this property is the `DjangoORMSearchHandler`, which uses
 the Django ORM to perform `icontains` lookups on the fields specified by `search_fields`.

--- a/docs/reference/contrib/modeladmin/indexview.rst
+++ b/docs/reference/contrib/modeladmin/indexview.rst
@@ -283,10 +283,39 @@ for your model. For example:
 **Expected value**: A list or tuple, where each item is the name of a model field
 of type ``CharField``, ``TextField``, ``RichTextField`` or ``StreamField``.
 
-If your model is indexed using Wagtail's search backend, setting ``search_fields``
-will determine which indexed fields are searched. Otherwise setting ``search_fields``
-will allow searching via Django's QuerySet API, rather than using Wagtail's
-search backend.
+Set ``search_fields`` to enable a search box at the top of the index page
+for your model. You should add names of any fields on the model that should
+be searched whenever somebody submits a search query using the search box.
+
+Searching is handled via Django's QuerySet API by default,
+see `ModelAdmin.search_handler_class`_ about changing this behaviour.
+This means by default it will work for all models, whatever search backend
+your project is using, and without any additional setup or configuration.
+
+.. _modeladmin_search_handler_class:
+
+-------------------------------------
+``ModelAdmin.search_handler_class``
+-------------------------------------
+
+The default value for this property is the `DjangoORMSearchHandler`, which uses
+the Django ORM to perform `icontains` lookups on the fields specified by `search_fields`.
+
+If you would prefer to use the built in Wagtail search backend to search your models,
+assuming they are indexed, you can override this property with the included
+`WagtailBackendSearchHandler` class e.g.
+
+.. code-block:: python
+    from wagtail.contrib.helpers import WagtailBackendSearchHandler
+    from .models import IndexedModel
+
+    class DemoAdmin(ModelAdmin):
+        model = IndexedModel
+        search_handler_class = WagtailBackendSearchHandler
+
+Note: when using the `WagtailBackendSearchHandler` the `search_fields` are used to limit
+the backend to search only over the specified fields, so those fields must be indexed
+by the backend.
 
 .. _modeladmin_ordering:
 

--- a/docs/reference/contrib/modeladmin/indexview.rst
+++ b/docs/reference/contrib/modeladmin/indexview.rst
@@ -283,13 +283,10 @@ for your model. For example:
 **Expected value**: A list or tuple, where each item is the name of a model field
 of type ``CharField``, ``TextField``, ``RichTextField`` or ``StreamField``.
 
-Set ``search_fields`` to enable a search box at the top of the index page
-for your model. You should add names of any fields on the model that should
-be searched whenever somebody submits a search query using the search box.
-
-Searching is all handled via Django's QuerySet API, rather than using Wagtail's
-search backend. This means it will work for all models, whatever search backend
-your project is using, and without any additional setup or configuration.
+If your model is indexed using Wagtail's search backend, setting ``search_fields``
+will determine which indexed fields are searched. Otherwise setting ``search_fields``
+will allow searching via Django's QuerySet API, rather than using Wagtail's
+search backend.
 
 .. _modeladmin_ordering:
 
@@ -646,4 +643,3 @@ See the following part of the docs to find out more:
 
 See the following part of the docs to find out more:
 :ref:`modeladmin_overriding_views`
-

--- a/wagtail/contrib/modeladmin/helpers/__init__.py
+++ b/wagtail/contrib/modeladmin/helpers/__init__.py
@@ -1,3 +1,4 @@
-from .button import ButtonHelper, PageButtonHelper # NOQA
-from .permission import PagePermissionHelper, PermissionHelper # NOQA
-from .url import AdminURLHelper, PageAdminURLHelper # NOQA
+from .button import ButtonHelper, PageButtonHelper  # NOQA
+from .permission import PagePermissionHelper, PermissionHelper  # NOQA
+from .search import DjangoORMSearchHandler, WagtailBackendSearchHandler  # NOQA
+from .url import AdminURLHelper, PageAdminURLHelper  # NOQA

--- a/wagtail/contrib/modeladmin/helpers/search.py
+++ b/wagtail/contrib/modeladmin/helpers/search.py
@@ -29,8 +29,8 @@ class ModelAdminSearchHandler:
 
 class DjangoORMSearchHandler(ModelAdminSearchHandler):
     def do_search(self, queryset, search_term):
-        if not search_term or self.search_fields:
-            return queryset
+        if not search_term or not self.search_fields:
+            return queryset, False
         use_distinct = False
         orm_lookups = ['%s__icontains' % str(search_field)
                        for search_field in self.search_fields]
@@ -54,7 +54,7 @@ class DjangoORMSearchHandler(ModelAdminSearchHandler):
 class WagtailBackendSearchHandler(ModelAdminSearchHandler):
     def do_search(self, queryset, search_term, backend='default'):
         if not search_term:
-            return queryset
+            return queryset, False
         backend = get_search_backend(backend)
         if self.search_fields:
             return backend.search(search_term, queryset, fields=self.search_fields), False

--- a/wagtail/contrib/modeladmin/helpers/search.py
+++ b/wagtail/contrib/modeladmin/helpers/search.py
@@ -60,4 +60,6 @@ class WagtailBackendSearchHandler(BaseSearchHandler):
             return backend.search(
                 search_term, queryset, fields=self.search_fields, operator=operator,
                 partial_match=partial_match, order_by_relevance=order_by_relevance)
-        return backend.search(search_term, queryset)
+        return backend.search(
+            search_term, queryset, operator=operator, partial_match=partial_match,
+            order_by_relevance=order_by_relevance)

--- a/wagtail/contrib/modeladmin/helpers/search.py
+++ b/wagtail/contrib/modeladmin/helpers/search.py
@@ -1,0 +1,49 @@
+import operator
+from functools import reduce
+
+from django.contrib.admin.utils import lookup_needs_distinct
+from django.db.models import Q
+
+from wagtail.search.backends import get_search_backend
+
+
+class ModelAdminSearchHandler:
+    def __init__(self, queryset, search_fields):
+        self.queryset = queryset
+        self.search_fields = search_fields
+
+    def search(self, search_term):
+        """
+        Returns a tuple containing a queryset to implement the search,
+        and a boolean indicating if the results may contain duplicates.
+        """
+        raise NotImplementedError()
+
+
+class DjangoORMSearchHandler(ModelAdminSearchHandler):
+    def search(self, search_term):
+        if not search_term or self.search_fields:
+            return self.queryset
+        use_distinct = False
+        querset = self.queryset
+        orm_lookups = ['%s__icontains' % str(search_field)
+                       for search_field in self.search_fields]
+        for bit in search_term.split():
+            or_queries = [Q(**{orm_lookup: bit})
+                          for orm_lookup in orm_lookups]
+            querset = querset.filter(reduce(operator.or_, or_queries))
+        opts = querset.model._meta
+        for search_spec in orm_lookups:
+            # Check wether out results may have duplicates, then remove them
+            if lookup_needs_distinct(opts, search_spec):
+                use_distinct = True
+                break
+        return querset, use_distinct
+
+
+class WagtailBackendSearchHandler(ModelAdminSearchHandler):
+    def search(self, search_term):
+        backend = get_search_backend()
+        if self.search_fields:
+            return backend.search(search_term, self.queryset, fields=self.search_fields), False
+        return backend.search(search_term, self.queryset), False

--- a/wagtail/contrib/modeladmin/helpers/search.py
+++ b/wagtail/contrib/modeladmin/helpers/search.py
@@ -7,11 +7,11 @@ from django.db.models import Q
 from wagtail.search.backends import get_search_backend
 
 
-class ModelAdminSearchHandler:
+class BaseSearchHandler:
     def __init__(self, search_fields):
         self.search_fields = search_fields
 
-    def do_search(self, queryset, search_term, **kwargs):
+    def search_queryset(self, queryset, search_term, **kwargs):
         """
         Returns a tuple containing a queryset to implement the search,
         and a boolean indicating if the results may contain duplicates.
@@ -21,14 +21,14 @@ class ModelAdminSearchHandler:
     @property
     def show_search_form(self):
         """
-        Defines whether this SearchHandler should show the search form on
-        the index page.
+        Returns a boolean that determines whether a search form should be
+        displayed in the IndexView UI
         """
         return True
 
 
-class DjangoORMSearchHandler(ModelAdminSearchHandler):
-    def do_search(self, queryset, search_term):
+class DjangoORMSearchHandler(BaseSearchHandler):
+    def search_queryset(self, queryset, search_term):
         if not search_term or not self.search_fields:
             return queryset, False
         use_distinct = False
@@ -51,8 +51,8 @@ class DjangoORMSearchHandler(ModelAdminSearchHandler):
         return bool(self.search_fields)
 
 
-class WagtailBackendSearchHandler(ModelAdminSearchHandler):
-    def do_search(self, queryset, search_term, backend='default'):
+class WagtailBackendSearchHandler(BaseSearchHandler):
+    def search_queryset(self, queryset, search_term, backend='default'):
         if not search_term:
             return queryset, False
         backend = get_search_backend(backend)

--- a/wagtail/contrib/modeladmin/helpers/search.py
+++ b/wagtail/contrib/modeladmin/helpers/search.py
@@ -44,7 +44,6 @@ class DjangoORMSearchHandler(BaseSearchHandler):
             queryset = queryset.filter(reduce(operator.or_, or_queries))
         opts = queryset.model._meta
         for search_spec in orm_lookups:
-            # Check wether out results may have duplicates, then remove them
             if lookup_needs_distinct(opts, search_spec):
                 use_distinct = True
                 break

--- a/wagtail/contrib/modeladmin/helpers/search.py
+++ b/wagtail/contrib/modeladmin/helpers/search.py
@@ -11,7 +11,7 @@ class BaseSearchHandler:
     def __init__(self, search_fields):
         self.search_fields = search_fields
 
-    def search_queryset(self, queryset, search_term, distinct_applied, **kwargs):
+    def search_queryset(self, queryset, search_term, **kwargs):
         """
         Search the queryset for the provided term.
         """
@@ -27,7 +27,7 @@ class BaseSearchHandler:
 
 
 class DjangoORMSearchHandler(BaseSearchHandler):
-    def search_queryset(self, queryset, search_term, **kwargs):
+    def search_queryset(self, queryset, search_term, distinct_applied=False, **kwargs):
         if not search_term or not self.search_fields:
             return queryset
 
@@ -38,7 +38,7 @@ class DjangoORMSearchHandler(BaseSearchHandler):
                           for orm_lookup in orm_lookups]
             queryset = queryset.filter(reduce(operator.or_, or_queries))
         opts = queryset.model._meta
-        if not kwargs.get('distinct_applied', True):
+        if not distinct_applied:
             for search_spec in orm_lookups:
                 if lookup_needs_distinct(opts, search_spec):
                     return queryset.distinct()

--- a/wagtail/contrib/modeladmin/helpers/search.py
+++ b/wagtail/contrib/modeladmin/helpers/search.py
@@ -28,9 +28,13 @@ class BaseSearchHandler:
 
 
 class DjangoORMSearchHandler(BaseSearchHandler):
-    def search_queryset(self, queryset, search_term):
+    def search_queryset(self, queryset, search_term, **extra_search_kwargs):
         if not search_term or not self.search_fields:
             return queryset, False
+
+        if extra_search_kwargs:
+            queryset = queryset.filter(**extra_search_kwargs)
+
         use_distinct = False
         orm_lookups = ['%s__icontains' % str(search_field)
                        for search_field in self.search_fields]
@@ -52,10 +56,12 @@ class DjangoORMSearchHandler(BaseSearchHandler):
 
 
 class WagtailBackendSearchHandler(BaseSearchHandler):
-    def search_queryset(self, queryset, search_term, backend='default'):
+    def search_queryset(self, queryset, search_term,
+                        operator=None, order_by_relevance=True, partial_match=True, backend='default'):
         if not search_term:
             return queryset, False
         backend = get_search_backend(backend)
         if self.search_fields:
-            return backend.search(search_term, queryset, fields=self.search_fields), False
+            return backend.search(
+                search_term, queryset, fields=self.search_fields, operator=operator, partial_match=partial_match), False
         return backend.search(search_term, queryset), False

--- a/wagtail/contrib/modeladmin/options.py
+++ b/wagtail/contrib/modeladmin/options.py
@@ -97,6 +97,7 @@ class ModelAdmin(WagtailRegisterable):
     delete_template_name = ''
     choose_parent_template_name = ''
     search_handler_class = DjangoORMSearchHandler
+    search_handler_extra_search_kwargs = {}
     permission_helper_class = None
     url_helper_class = None
     button_helper_class = None

--- a/wagtail/contrib/modeladmin/options.py
+++ b/wagtail/contrib/modeladmin/options.py
@@ -12,8 +12,8 @@ from wagtail.core import hooks
 from wagtail.core.models import Page
 
 from .helpers import (
-    AdminURLHelper, ButtonHelper, PageAdminURLHelper, PageButtonHelper, PagePermissionHelper,
-    PermissionHelper)
+    AdminURLHelper, ButtonHelper, DjangoORMSearchHandler, PageAdminURLHelper, PageButtonHelper,
+    PagePermissionHelper, PermissionHelper)
 from .menus import GroupMenuItem, ModelAdminMenuItem, SubMenu
 from .mixins import ThumbnailMixin  # NOQA
 from .views import ChooseParentView, CreateView, DeleteView, EditView, IndexView, InspectView
@@ -96,6 +96,7 @@ class ModelAdmin(WagtailRegisterable):
     inspect_template_name = ''
     delete_template_name = ''
     choose_parent_template_name = ''
+    search_handler_class = DjangoORMSearchHandler
     permission_helper_class = None
     url_helper_class = None
     button_helper_class = None

--- a/wagtail/contrib/modeladmin/templates/modeladmin/includes/search_form.html
+++ b/wagtail/contrib/modeladmin/templates/modeladmin/includes/search_form.html
@@ -1,5 +1,5 @@
 {% load i18n static %}
-{% if view.show_search %}
+{% if show_search %}
 <form id="changelist-search" class="col search-form" action="{{ view.index_url }}" method="get">
     <ul class="fields">
         <li class="required">

--- a/wagtail/contrib/modeladmin/templates/modeladmin/includes/search_form.html
+++ b/wagtail/contrib/modeladmin/templates/modeladmin/includes/search_form.html
@@ -1,5 +1,5 @@
 {% load i18n static %}
-{% if view.search_fields %}
+{% if view.show_search %}
 <form id="changelist-search" class="col search-form" action="{{ view.index_url }}" method="get">
     <ul class="fields">
         <li class="required">

--- a/wagtail/contrib/modeladmin/tests/test_page_modeladmin.py
+++ b/wagtail/contrib/modeladmin/tests/test_page_modeladmin.py
@@ -40,12 +40,12 @@ class TestIndexView(TestCase, WagtailTestUtils):
             self.assertEqual(eventpage.audience, 'public')
 
     def test_search(self):
-        response = self.get(q='moon')
+        response = self.get(q='Someone')
 
         self.assertEqual(response.status_code, 200)
 
-        # There are two eventpage's where the location is 'The moon'
-        self.assertEqual(response.context['result_count'], 2)
+        # There is one eventpage where the title contains 'Someone'
+        self.assertEqual(response.context['result_count'], 1)
 
     def test_ordering(self):
         response = self.get(o='0.1')

--- a/wagtail/contrib/modeladmin/tests/test_page_modeladmin.py
+++ b/wagtail/contrib/modeladmin/tests/test_page_modeladmin.py
@@ -40,12 +40,12 @@ class TestIndexView(TestCase, WagtailTestUtils):
             self.assertEqual(eventpage.audience, 'public')
 
     def test_search(self):
-        response = self.get(q='Someone')
+        response = self.get(q='moon')
 
         self.assertEqual(response.status_code, 200)
 
-        # There are two eventpage's where the title contains 'Someone'
-        self.assertEqual(response.context['result_count'], 1)
+        # There are two eventpage's where the location is 'The moon'
+        self.assertEqual(response.context['result_count'], 2)
 
     def test_ordering(self):
         response = self.get(o='0.1')

--- a/wagtail/contrib/modeladmin/tests/test_search_handlers.py
+++ b/wagtail/contrib/modeladmin/tests/test_search_handlers.py
@@ -41,8 +41,6 @@ class TestORMSearchHandler(TestCase):
         results = search_handler.search_queryset(self.get_search_queryset(), 'Lord of the rings')
         self.assertEqual(list(lord_of_the_rings), list(results))
 
-
-
     def test_show_search_form(self):
         search_handler = self.get_search_handler(search_fields=None)
         self.assertFalse(search_handler.show_search_form)
@@ -81,8 +79,10 @@ class TestSearchBackendHandler(TestCase):
 
         # Test other kwargs
         self.assertEqual(
-            self.search_kwargs_to_dict(search_fields=search_fields, operator='and', partial_match=False, order_by_relevance=True),
-            search_handler.search_queryset(search_queryset, 'Lord', operator='and', order_by_relevance=True, partial_match=False)
+            self.search_kwargs_to_dict(
+                search_fields=search_fields, operator='and', partial_match=False, order_by_relevance=True),
+            search_handler.search_queryset(
+                search_queryset, 'Lord', operator='and', order_by_relevance=True, partial_match=False)
         )
 
     def test_show_search_form(self):

--- a/wagtail/contrib/modeladmin/tests/test_search_handlers.py
+++ b/wagtail/contrib/modeladmin/tests/test_search_handlers.py
@@ -1,0 +1,93 @@
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from wagtail.contrib.modeladmin.helpers import DjangoORMSearchHandler, WagtailBackendSearchHandler
+from wagtail.tests.modeladmintest.models import Book
+
+
+class FakeBackend():
+    def search(
+            self, query, model_or_queryset, fields=None, operator=None, order_by_relevance=True, partial_match=True):
+        return {
+            'fields': fields,
+            'operator': operator,
+            'order_by_relevance': order_by_relevance,
+            'partial_match': partial_match
+        }
+
+
+class TestORMSearchHandler(TestCase):
+    fixtures = ['modeladmintest_test.json']
+
+    def get_search_handler(self, search_fields=None):
+        return DjangoORMSearchHandler(search_fields)
+
+    def get_search_queryset(self):
+        return Book.objects.all()
+
+    def test_search_queryset(self):
+        search_handler = self.get_search_handler()
+        # No search fields, return same queryset
+        results = search_handler.search_queryset(self.get_search_queryset(), 'Lord')
+        self.assertEqual(list(self.get_search_queryset()), list(results))
+
+        search_handler = self.get_search_handler(search_fields=('title',))
+        # No search_term, return same, queryset
+        results = search_handler.search_queryset(self.get_search_queryset(), '')
+        self.assertEqual(list(self.get_search_queryset()), list(results))
+
+        lord_of_the_rings = Book.objects.filter(pk=1)
+        results = search_handler.search_queryset(self.get_search_queryset(), 'Lord of the rings')
+        self.assertEqual(list(lord_of_the_rings), list(results))
+
+
+
+    def test_show_search_form(self):
+        search_handler = self.get_search_handler(search_fields=None)
+        self.assertFalse(search_handler.show_search_form)
+
+        search_handler = self.get_search_handler(search_fields=('content',))
+        self.assertTrue(search_handler.show_search_form)
+
+
+class TestSearchBackendHandler(TestCase):
+    def get_search_handler(self, search_fields=None):
+        return WagtailBackendSearchHandler(search_fields)
+
+    def search_kwargs_to_dict(self, search_fields=None, operator=None, order_by_relevance=False, partial_match=True):
+        return {
+            'fields': search_fields,
+            'operator': operator,
+            'order_by_relevance': order_by_relevance,
+            'partial_match': partial_match
+        }
+
+    @patch('wagtail.contrib.modeladmin.helpers.search.get_search_backend', return_value=FakeBackend())
+    def test_search_queryset(self, get_search_backend):
+        search_queryset = Book.objects.all()
+
+        # Test default backend kwargs
+        search_handler = self.get_search_handler()
+        search_kwargs = search_handler.search_queryset(search_queryset, 'Lord')
+
+        self.assertEqual(self.search_kwargs_to_dict(), search_kwargs)
+
+        # Test search_fields
+        search_fields = ('content',)
+        search_handler = self.get_search_handler(search_fields=search_fields)
+        self.assertEqual(self.search_kwargs_to_dict(search_fields=search_fields),
+                         search_handler.search_queryset(search_queryset, 'Lord'))
+
+        # Test other kwargs
+        self.assertEqual(
+            self.search_kwargs_to_dict(search_fields=search_fields, operator='and', partial_match=False, order_by_relevance=True),
+            search_handler.search_queryset(search_queryset, 'Lord', operator='and', order_by_relevance=True, partial_match=False)
+        )
+
+    def test_show_search_form(self):
+        search_handler = self.get_search_handler(search_fields=None)
+        self.assertTrue(search_handler.show_search_form)
+
+        search_handler = self.get_search_handler(search_fields=('content',))
+        self.assertTrue(search_handler.show_search_form)

--- a/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
+++ b/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
@@ -65,7 +65,7 @@ class TestBookIndexView(TestCase, WagtailTestUtils):
         for book in response.context['object_list']:
             self.assertEqual(book.author_id, 1)
 
-    def test_search(self):
+    def test_search_indexed(self):
         response = self.get(q='of')
 
         self.assertEqual(response.status_code, 200)
@@ -108,6 +108,13 @@ class TestAuthorIndexView(TestCase, WagtailTestUtils):
 
     def get(self, **params):
         return self.client.get('/admin/modeladmintest/author/', params)
+
+    def test_search(self):
+        response = self.get(q='Roald Dahl')
+
+        self.assertEqual(response.status_code, 200)
+
+        self.assertEqual(response.context['result_count'], 2)
 
     def test_col_extra_class_names(self):
         response = self.get()

--- a/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
+++ b/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
@@ -6,9 +6,11 @@ from django.core import checks
 from django.test import TestCase
 
 from wagtail.admin.edit_handlers import FieldPanel, TabbedInterface
+from wagtail.contrib.modeladmin.helpers.search import DjangoORMSearchHandler
 from wagtail.images.models import Image
 from wagtail.images.tests.utils import get_test_image_file
 from wagtail.tests.modeladmintest.models import Author, Book, Publisher, Token
+from wagtail.tests.modeladmintest.wagtail_hooks import BookModelAdmin
 from wagtail.tests.utils import WagtailTestUtils
 
 
@@ -72,6 +74,20 @@ class TestBookIndexView(TestCase, WagtailTestUtils):
 
         # There are two books where the title contains 'of'
         self.assertEqual(response.context['result_count'], 2)
+
+    def test_search_form_present(self):
+        # Test the backend search handler allows the search form to render
+        response = self.get()
+
+        self.assertContains(response, '<input id="id_q"')
+
+
+    def test_search_form_absent(self):
+        # DjangoORMSearchHandler + no search_fields, search form should be absent
+        with mock.patch.object(BookModelAdmin, 'search_handler_class', DjangoORMSearchHandler):
+            response = self.get()
+
+            self.assertNotContains(response, '<input id="id_q"')
 
     def test_ordering(self):
         response = self.get(o='0.1')

--- a/wagtail/contrib/modeladmin/views.py
+++ b/wagtail/contrib/modeladmin/views.py
@@ -28,7 +28,7 @@ from django.views.generic import TemplateView
 from django.views.generic.edit import FormView
 
 from wagtail.admin import messages
-from wagtail.search.backend import get_search_backend
+from wagtail.search.backends import get_search_backend
 from wagtail.search.index import Indexed
 
 from .forms import ParentChooserForm
@@ -280,7 +280,7 @@ class IndexView(WMABaseView):
             if issubclass(self.model, Indexed):
                 backend = get_search_backend()
                 if self.search_fields:
-                    queryset = backend.search(search_term, queryset, fiels=self.search_fields)
+                    queryset = backend.search(search_term, queryset, fields=self.search_fields)
                 else:
                     queryset = backend.search(search_term, queryset)
             elif self.search_fields:

--- a/wagtail/contrib/modeladmin/views.py
+++ b/wagtail/contrib/modeladmin/views.py
@@ -258,6 +258,7 @@ class IndexView(WMABaseView):
         self.queryset = self.get_queryset(request)
 
         return super().dispatch(request, *args, **kwargs)
+
     @property
     def media(self):
         return forms.Media(
@@ -663,6 +664,13 @@ class IndexView(WMABaseView):
 
         context.update(kwargs)
         return super().get_context_data(**context)
+
+    @property
+    def show_search(self):
+        """
+        Whether or not to show the search form on the index, used by the search_form tag
+        """
+        return issubclass(self.model, Indexed) or self.search_fields
 
     def get_template_names(self):
         return self.model_admin.get_index_template()

--- a/wagtail/contrib/modeladmin/views.py
+++ b/wagtail/contrib/modeladmin/views.py
@@ -273,9 +273,9 @@ class IndexView(WMABaseView):
         return self.model_admin.search_handler_extra_search_kwargs
 
     def get_search_results(self, request, queryset, search_term, distinct_applied):
+        search_kwargs = self.get_search_handler_extra_search_kwargs(request, queryset, search_term)
         return self.search_handler.search_queryset(
-            queryset, search_term, distinct_applied=distinct_applied,
-            **self.get_search_handler_extra_search_kwargs(request, queryset, search_term))
+            queryset, search_term, distinct_applied=distinct_applied, **search_kwargs)
 
     def lookup_allowed(self, lookup, value):
         # Check FKey lookups that are allowed, so that popups produced by

--- a/wagtail/contrib/modeladmin/views.py
+++ b/wagtail/contrib/modeladmin/views.py
@@ -273,7 +273,8 @@ class IndexView(WMABaseView):
         return self.model_admin.search_handler_extra_search_kwargs
 
     def get_search_results(self, request, queryset, search_term):
-        results, use_distinct = self.search_handler.search_queryset(queryset, search_term,
+        results, use_distinct = self.search_handler.search_queryset(
+            queryset, search_term,
             **self.get_search_handler_extra_search_kwargs(request, queryset, search_term))
         return results, use_distinct
 

--- a/wagtail/contrib/modeladmin/views.py
+++ b/wagtail/contrib/modeladmin/views.py
@@ -274,7 +274,7 @@ class IndexView(WMABaseView):
 
     def get_search_results(self, request, queryset, search_term, distinct_applied):
         return self.search_handler.search_queryset(
-            queryset, search_term, distinct_applied,
+            queryset, search_term, distinct_applied=distinct_applied,
             **self.get_search_handler_extra_search_kwargs(request, queryset, search_term))
 
     def lookup_allowed(self, lookup, value):

--- a/wagtail/contrib/modeladmin/views.py
+++ b/wagtail/contrib/modeladmin/views.py
@@ -272,7 +272,8 @@ class IndexView(WMABaseView):
             obj, classnames_add=['button-small', 'button-secondary'])
 
     def get_search_results(self, request, queryset, search_term):
-        return self.search_handler.search(queryset, search_term)
+        results, use_distinct = self.search_handler.do_search(queryset, search_term)
+        return results, use_distinct
 
     def lookup_allowed(self, lookup, value):
         # Check FKey lookups that are allowed, so that popups produced by

--- a/wagtail/contrib/modeladmin/views.py
+++ b/wagtail/contrib/modeladmin/views.py
@@ -268,7 +268,7 @@ class IndexView(WMABaseView):
             obj, classnames_add=['button-small', 'button-secondary'])
 
     def get_search_results(self, request, queryset, search_term):
-        results, use_distinct = self.search_handler.do_search(queryset, search_term)
+        results, use_distinct = self.search_handler.search_queryset(queryset, search_term)
         return results, use_distinct
 
     def lookup_allowed(self, lookup, value):
@@ -622,7 +622,8 @@ class IndexView(WMABaseView):
             'paginator': paginator,
             'page_obj': page_obj,
             'object_list': page_obj.object_list,
-            'user_can_create': self.permission_helper.user_can_create(user)
+            'user_can_create': self.permission_helper.user_can_create(user),
+            'show_search': self.search_handler.show_search_form,
         }
 
         if self.is_pagemodel:
@@ -637,13 +638,6 @@ class IndexView(WMABaseView):
 
         context.update(kwargs)
         return super().get_context_data(**context)
-
-    @property
-    def show_search(self):
-        """
-        Whether or not to show the search form on the index, used by the search_form tag
-        """
-        return self.search_handler.show_search_form
 
     def get_template_names(self):
         return self.model_admin.get_index_template()

--- a/wagtail/contrib/modeladmin/views.py
+++ b/wagtail/contrib/modeladmin/views.py
@@ -241,7 +241,7 @@ class IndexView(WMABaseView):
         self.search_fields = self.model_admin.get_search_fields(request)
         self.items_per_page = self.model_admin.list_per_page
         self.select_related = self.model_admin.list_select_related
-        self.search_handler_class = self.model_admin.search_handler_class
+        self.search_handler = self.model_admin.search_handler_class(self.search_fields)
 
         # Get search parameters from the query string.
         try:
@@ -272,8 +272,7 @@ class IndexView(WMABaseView):
             obj, classnames_add=['button-small', 'button-secondary'])
 
     def get_search_results(self, request, queryset, search_term):
-        SearchHandler = self.search_handler_class(queryset, self.search_fields)
-        return SearchHandler.search(search_term)
+        return self.search_handler.search(queryset, search_term)
 
     def lookup_allowed(self, lookup, value):
         # Check FKey lookups that are allowed, so that popups produced by
@@ -647,7 +646,7 @@ class IndexView(WMABaseView):
         """
         Whether or not to show the search form on the index, used by the search_form tag
         """
-        return issubclass(self.model, Indexed) or self.search_fields
+        return self.search_handler.show_search_form
 
     def get_template_names(self):
         return self.model_admin.get_index_template()

--- a/wagtail/contrib/modeladmin/views.py
+++ b/wagtail/contrib/modeladmin/views.py
@@ -1,6 +1,4 @@
-import operator
 from collections import OrderedDict
-from functools import reduce
 
 from django import forms
 from django.contrib.admin import FieldListFilter, widgets
@@ -28,8 +26,6 @@ from django.views.generic import TemplateView
 from django.views.generic.edit import FormView
 
 from wagtail.admin import messages
-from wagtail.search.backends import get_search_backend
-from wagtail.search.index import Indexed
 
 from .forms import ParentChooserForm
 

--- a/wagtail/contrib/modeladmin/views.py
+++ b/wagtail/contrib/modeladmin/views.py
@@ -267,8 +267,14 @@ class IndexView(WMABaseView):
         return self.button_helper.get_buttons_for_obj(
             obj, classnames_add=['button-small', 'button-secondary'])
 
+
+    def get_search_handler_extra_search_kwargs(self, request, queryset, search_term):
+        """ Returns a dictionary of kwargs to be sent to the SearchHandler.search_queryset """
+        return self.model_admin.search_handler_extra_search_kwargs
+
     def get_search_results(self, request, queryset, search_term):
-        results, use_distinct = self.search_handler.search_queryset(queryset, search_term)
+        results, use_distinct = self.search_handler.search_queryset(queryset, search_term,
+            **self.get_search_handler_extra_search_kwargs(request, queryset, search_term))
         return results, use_distinct
 
     def lookup_allowed(self, lookup, value):

--- a/wagtail/tests/modeladmintest/models.py
+++ b/wagtail/tests/modeladmintest/models.py
@@ -25,6 +25,10 @@ class Book(models.Model, index.Indexed):
     title = models.CharField(max_length=255)
     cover_image = models.ForeignKey('wagtailimages.Image', on_delete=models.SET_NULL, null=True, blank=True)
 
+    search_fields = [
+        index.SearchField('title'),
+    ]
+
     def __str__(self):
         return self.title
 

--- a/wagtail/tests/modeladmintest/models.py
+++ b/wagtail/tests/modeladmintest/models.py
@@ -27,6 +27,8 @@ class Book(models.Model, index.Indexed):
 
     search_fields = [
         index.SearchField('title'),
+        index.FilterField('title'),
+        index.FilterField('pk'),
     ]
 
     def __str__(self):

--- a/wagtail/tests/modeladmintest/wagtail_hooks.py
+++ b/wagtail/tests/modeladmintest/wagtail_hooks.py
@@ -79,9 +79,9 @@ class EventPageAdmin(ModelAdmin):
     model = EventPage
     list_display = ('title', 'date_from', 'audience')
     list_filter = ('audience', )
+    search_fields = ('title', )
     inspect_view_enabled = True
     inspect_view_fields_exclude = ('feed_image', )
-    search_handler_class = WagtailBackendSearchHandler
 
 
 class SingleEventPageAdmin(EventPageAdmin):

--- a/wagtail/tests/modeladmintest/wagtail_hooks.py
+++ b/wagtail/tests/modeladmintest/wagtail_hooks.py
@@ -78,7 +78,6 @@ class EventPageAdmin(ModelAdmin):
     model = EventPage
     list_display = ('title', 'date_from', 'audience')
     list_filter = ('audience', )
-    search_fields = ('title', )
     inspect_view_enabled = True
     inspect_view_fields_exclude = ('feed_image', )
 

--- a/wagtail/tests/modeladmintest/wagtail_hooks.py
+++ b/wagtail/tests/modeladmintest/wagtail_hooks.py
@@ -1,4 +1,5 @@
 from wagtail.admin.edit_handlers import FieldPanel, ObjectList, TabbedInterface
+from wagtail.contrib.modeladmin.helpers import WagtailBackendSearchHandler
 from wagtail.contrib.modeladmin.options import (
     ModelAdmin, ModelAdminGroup, ThumbnailMixin, modeladmin_register)
 from wagtail.contrib.modeladmin.views import CreateView
@@ -51,6 +52,7 @@ class BookModelAdmin(ThumbnailMixin, ModelAdmin):
     inspect_view_enabled = True
     inspect_view_fields_exclude = ('title', )
     thumb_image_field_name = 'cover_image'
+    search_handler_class = WagtailBackendSearchHandler
 
     def get_extra_attrs_for_row(self, obj, context):
         return {
@@ -80,6 +82,7 @@ class EventPageAdmin(ModelAdmin):
     list_filter = ('audience', )
     inspect_view_enabled = True
     inspect_view_fields_exclude = ('feed_image', )
+    search_handler_class = WagtailBackendSearchHandler
 
 
 class SingleEventPageAdmin(EventPageAdmin):

--- a/wagtail/tests/modeladmintest/wagtail_hooks.py
+++ b/wagtail/tests/modeladmintest/wagtail_hooks.py
@@ -48,7 +48,6 @@ class BookModelAdmin(ThumbnailMixin, ModelAdmin):
     list_display = ('title', 'author', 'admin_thumb')
     list_filter = ('author', )
     ordering = ('title', )
-    search_fields = ('title', )
     inspect_view_enabled = True
     inspect_view_fields_exclude = ('title', )
     thumb_image_field_name = 'cover_image'


### PR DESCRIPTION
I was using modeladmin for a model that searched several fields, including related lookups. The search was timing out because the orm query that it built up was pretty big.

So I thought it would be a good idea if modeladmin could use the built in wagtail searching, since Wagtail allows the indexing of custom models.

This doesn't include is a way to turn off searching for an `Indexed` model, but I couldn't think of a use case for that. You could just override the `show_search` property.
