### PR TITLE
Stop ModelAdmin from failing when filtering over a foreign key relation

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -7,6 +7,7 @@ Changelog
  * Removed support for Python 3.4
  * Added support for `short_description` for field labels in modeladmin's `InspectView` (Wesley van Lee)
  * Rearranged SCSS folder structure to the client folder and split them approximately according to ITCSS. (Naomi Morduch Toubman, Jonny Scholes, Janneke Janssen, Hugo van den Berg)
+ * Fix: ModelAdmin no longer fails when filtering over a foreign key relation (Jason Dilworth, Matt Westcott)
 
 
 2.5 (xx.xx.xxxx) - IN DEVELOPMENT

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -363,6 +363,7 @@ Contributors
 * Katie Locke
 * Cassidy Brooke
 * dthompson86
+* Jason Dilworth
 
 Translators
 ===========

--- a/docs/releases/2.6.rst
+++ b/docs/releases/2.6.rst
@@ -21,7 +21,7 @@ Other features
 Bug fixes
 ~~~~~~~~~
 
- * ...
+ * ModelAdmin no longer fails when filtering over a foreign key relation (Jason Dilworth, Matt Westcott)
 
 
 Upgrade considerations

--- a/wagtail/contrib/modeladmin/tests/test_page_modeladmin.py
+++ b/wagtail/contrib/modeladmin/tests/test_page_modeladmin.py
@@ -364,3 +364,16 @@ class TestHeaderBreadcrumbs(TestCase, WagtailTestUtils):
         position_of_header = content_str.index('<header')  # intentionally not closing tag
         position_of_breadcrumbs = content_str.index('<ul class="breadcrumb">')
         self.assertLess(position_of_header, position_of_breadcrumbs)
+
+
+class TestSearch(TestCase, WagtailTestUtils):
+    fixtures = ['test_specific.json']
+
+    def setUp(self):
+        self.login()
+
+    def test_lookup_allowed_on_parentalkey(self):
+        try:
+            self.client.get('/admin/tests/eventpage/?related_links__link_page__id__exact=1')
+        except AttributeError:
+            self.fail("Lookup on parentalkey raised AttributeError unexpectedly")


### PR DESCRIPTION
Supersedes #4998
As per https://github.com/wagtail/wagtail/pull/4998#issuecomment-471005219, the implementation of `lookup_allowed` is flawed and breaks on some valid lookups while allowing invalid ones. We are therefore better off removing that validation entirely.