### PR TITLE
Fix playful tail wag animation

### DIFF
--- a/client/scss/components/_logo.scss
+++ b/client/scss/components/_logo.scss
@@ -1,13 +1,3 @@
-@keyframes nod {
-    from {
-        transform: rotate(2deg);
-    }
-
-    to {
-        transform: rotate(8deg);
-    }
-}
-
 @keyframes tail-wag {
     from {
         transform: rotate(-3deg);
@@ -84,7 +74,8 @@
     // Wagtail 'playful' animation (tail-wag, triggered by JS in base.html):
     &.logo-playful {
         &:hover {
-            animation: nod 1.2s forwards;
+            transform: rotate(8deg);
+            transition: transform 1.2s ease;
 
             .wagtail-logo {
                 // stylelint-disable max-nesting-depth


### PR DESCRIPTION
Fixes #3780

- Tests are untouched
- Style lint passes
- Too small bugfix to warrant a change log entry
- Tested on:
  - Firefox 66
  - Safari 12.1
  - Chrome 73

Video of fixed version: https://giphy.com/gifs/gg9To2CBkHvbnuwx72/html5