### PR TITLE
Fix Redux DevTools deprecation warning

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -11,5 +11,9 @@
         "config": "client/webpack/prod.config.js"
       }
     }
+  },
+  
+  "rules": {
+    "no-underscore-dangle": ["error", { "allow": ["__REDUX_DEVTOOLS_EXTENSION__"] }]
   }
 }

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -364,6 +364,7 @@ Contributors
 * Cassidy Brooke
 * dthompson86
 * Jason Dilworth
+* Deniz Dogan
 
 Translators
 ===========

--- a/client/src/components/Explorer/index.js
+++ b/client/src/components/Explorer/index.js
@@ -31,7 +31,7 @@ const initExplorer = (explorerNode, toggleNode) => {
   const store = createStore(rootReducer, {}, compose(
     applyMiddleware(...middleware),
     // Expose store to Redux DevTools extension.
-    window.devToolsExtension ? window.devToolsExtension() : func => func
+    window.__REDUX_DEVTOOLS_EXTENSION__ ? window.__REDUX_DEVTOOLS_EXTENSION__() : func => func
   ));
 
   const startPage = parseInt(toggleNode.getAttribute('data-explorer-start-page'), 10);


### PR DESCRIPTION
Fixes #5214

I considered adding the no-underscore-dangle rule to eslint-config-wagtail instead, but I figured this rule is more project-specific than that? Not sure.