### PR TITLE
Fix clear_edit_handler decorator

### DIFF
--- a/wagtail/admin/tests/test_edit_handlers.py
+++ b/wagtail/admin/tests/test_edit_handlers.py
@@ -1,4 +1,5 @@
 from datetime import date
+from functools import wraps
 from unittest import mock
 
 from django import forms
@@ -121,14 +122,16 @@ class TestGetFormForModel(TestCase):
 
 def clear_edit_handler(page_cls):
     def decorator(fn):
-        def decorated(self):
+        @wraps(fn)
+        def decorated(*args, **kwargs):
             # Clear any old EditHandlers generated
             page_cls.get_edit_handler.cache_clear()
             try:
-                fn(self)
+                fn(*args, **kwargs)
             finally:
                 # Clear the bad EditHandler generated just now
                 page_cls.get_edit_handler.cache_clear()
+        return decorated
     return decorator
 
 

--- a/wagtail/admin/tests/test_edit_handlers.py
+++ b/wagtail/admin/tests/test_edit_handlers.py
@@ -185,6 +185,9 @@ class TestPageEditHandlers(TestCase):
             # don't build the CSS)
             errors = [e for e in errors if e.id != 'wagtailadmin.W001']
 
+            # Errors may appear out of order, so sort them by id
+            errors.sort(key=lambda e: e.id)
+
             self.assertEqual(errors, [invalid_base_form, invalid_edit_handler])
 
     @clear_edit_handler(ValidatedPage)


### PR DESCRIPTION
Fixes #5237 

The decorator added to most of the tests for `TestPageEditHandlers` causes the methods to be replaced with `None`.

This should allow the decorator to return the function and allow the tests to run.