### PR TITLE
Improve feedback when attempting to edit a page who's model class cannot be found in the codebase

### DIFF
--- a/docs/reference/pages/model_reference.rst
+++ b/docs/reference/pages/model_reference.rst
@@ -140,6 +140,8 @@ In addition to the model fields provided, ``Page`` has many properties and metho
 
     .. autoattribute:: specific_class
 
+    .. autoattribute:: cached_content_type
+
     .. automethod:: get_url
 
     .. autoattribute:: full_url

--- a/wagtail/admin/tests/pages/test_edit_page.py
+++ b/wagtail/admin/tests/pages/test_edit_page.py
@@ -14,6 +14,7 @@ from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
 from wagtail.admin.tests.pages.timestamps import submittable_timestamp
+from wagtail.core.exceptions import PageClassNotFoundError
 from wagtail.core.models import Page, PageRevision, Site
 from wagtail.core.signals import page_published
 from wagtail.tests.testapp.models import (
@@ -113,6 +114,11 @@ class TestPageEdit(TestCase, WagtailTestUtils):
         response = self.client.get(reverse('wagtailadmin_pages:edit', args=(self.file_page.id, )))
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'enctype="multipart/form-data"')
+
+    @mock.patch('wagtail.core.models.ContentType.model_class', return_value=None)
+    def test_edit_when_specific_class_cannot_be_found(self, mocked_method):
+        with self.assertRaises(PageClassNotFoundError):
+            self.client.get(reverse('wagtailadmin_pages:edit', args=(self.event_page.id, )))
 
     def test_upload_file_publish(self):
         """

--- a/wagtail/core/exceptions.py
+++ b/wagtail/core/exceptions.py
@@ -1,0 +1,8 @@
+class PageClassNotFoundError(ImportError):
+    """
+    Raised when a model class referenced by a page object's ``content_type``
+    value cannot be found in the codebase. Usually, this is as a result of
+    switching to a different git branch without first running/reverting
+    migrations.
+    """
+    pass

--- a/wagtail/core/tests/test_page_model.py
+++ b/wagtail/core/tests/test_page_model.py
@@ -1,6 +1,6 @@
 import datetime
 import json
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytz
 from django.contrib.auth import get_user_model
@@ -1810,3 +1810,27 @@ class TestUnpublish(TestCase):
         home_page.save(clean=False)
         # This shouldn't fail with a ValidationError.
         home_page.unpublish()
+
+
+class TestCachedContentType(TestCase):
+    """Tests for Page.cached_content_type"""
+
+    def setUp(self):
+        root_page = Page.objects.first()
+        self.page = root_page.add_child(
+            instance=SimplePage(title="Test1", slug="test1", content="test")
+        )
+        self.specific_page_ctype = ContentType.objects.get_for_model(SimplePage)
+
+    def test_golden_path(self):
+        """
+        The return value should match the value you'd get
+        if fetching the ContentType from the database,
+        and shouldn't trigger any database queries when
+        the ContentType is already in memory.
+        """
+        with self.assertNumQueries(0):
+            result = self.page.cached_content_type
+        self.assertEqual(
+            result, ContentType.objects.get(id=self.page.content_type_id)
+        )


### PR DESCRIPTION
The scope of this PR has been revised after feedback from @gasman.

- General tidying of `Page.specific` and `Page.specific_class`
- Improved docstrings for the above methods to better explain some of the edge cases and why they might occur.
- Added `Page.cached_content_type` to offer more convenient access to a page's `ContentType` without hitting the database.
- Raising a more useful exception from the edit view when the model class cannot be found.
