### PR TITLE
Improve EditHandler repr

### DIFF
--- a/wagtail/admin/edit_handlers.py
+++ b/wagtail/admin/edit_handlers.py
@@ -185,7 +185,7 @@ class EditHandler:
     def __repr__(self):
         return '<%s with model=%s instance=%s request=%s form=%s>' % (
             self.__class__.__name__,
-            self.model, self.instance, self.request, self.form)
+            self.model, self.instance, self.request, self.form.__class__.__name__)
 
     def classes(self):
         """
@@ -547,7 +547,7 @@ class FieldPanel(EditHandler):
     def __repr__(self):
         return "<%s '%s' with model=%s instance=%s request=%s form=%s>" % (
             self.__class__.__name__, self.field_name,
-            self.model, self.instance, self.request, self.form)
+            self.model, self.instance, self.request, self.form.__class__.__name__)
 
 
 class RichTextFieldPanel(FieldPanel):

--- a/wagtail/admin/tests/test_edit_handlers.py
+++ b/wagtail/admin/tests/test_edit_handlers.py
@@ -204,6 +204,17 @@ class TestPageEditHandlers(TestCase):
             errors = ValidatedPage.check()
             self.assertEqual(errors, [])
 
+    @clear_edit_handler(ValidatedPage)
+    def test_repr(self):
+        edit_handler = ValidatedPage.get_edit_handler()
+
+        handler_handler_repr = repr(edit_handler)
+
+        self.assertIn("model=<class 'wagtail.tests.testapp.models.ValidatedPage'>", handler_handler_repr)
+        self.assertIn('instance=None', handler_handler_repr)
+        self.assertIn("request=None", handler_handler_repr)
+        self.assertIn('form=None', handler_handler_repr)
+
 
 class TestExtractPanelDefinitionsFromModelClass(TestCase):
     def test_can_extract_panel_property(self):
@@ -458,6 +469,19 @@ class TestFieldPanel(TestCase):
 
         self.assertIn('<p class="error-message">', result)
         self.assertIn('<span>Enter a valid date.</span>', result)
+
+    def test_repr(self):
+        form = self.EventPageForm()
+        field_panel = self.end_date_panel.bind_to(
+            form=form,
+        )
+
+        field_panel_repr = repr(field_panel)
+
+        self.assertIn("model=<class 'wagtail.tests.testapp.models.EventPage'>", field_panel_repr)
+        self.assertIn('instance=None', field_panel_repr)
+        self.assertIn("request=<WSGIRequest: GET '/'>", field_panel_repr)
+        self.assertIn('form=EventPageForm', field_panel_repr)
 
 
 class TestFieldRowPanel(TestCase):


### PR DESCRIPTION
~~Note: Review #5238 first - one of the tests I was trying to add here needed some fixes to a decorator used in other tests.~~

Closes #5243 

This PR simplifies the repr method on EditHandler to:

```
In [1]: from wagtail.admin.edit_handlers import get_form_for_model, EditHandler

In [2]: PageForm = get_form_for_model(Page, exclude=('content_type', 'owner'))

In [3]: form = PageForm()

In [4]: edit_handler = EditHandler()

In [5]: edit_handler = edit_handler.bind_to(form=form)

In [6]: edit_handler
Out[6]: <EditHandler with model=None instance=None request=None form=PageForm>
```

I wanted to add a couple of tests for the repr methods. Testing a super long string felt a bit inelegant - so split it up into multiple asserts.

However feedback on a better approach is welcome.