### PR TITLE
Fix non-ascii content disposition

### DIFF
--- a/wagtail/documents/tests/test_views.py
+++ b/wagtail/documents/tests/test_views.py
@@ -171,7 +171,7 @@ class TestServeWithUnicodeFilename(TestCase):
         self.assertEqual(response.status_code, 200)
 
     @mock.patch('wagtail.documents.views.serve.hooks')
-    @mock.patch('wagtail.documents.views.serve.get_object_or_404') 
+    @mock.patch('wagtail.documents.views.serve.get_object_or_404')
     def test_non_local_filesystem_unicode_content_disposition_header(
         self, mock_get_object_or_404, mock_hooks
     ):

--- a/wagtail/documents/tests/test_views.py
+++ b/wagtail/documents/tests/test_views.py
@@ -1,7 +1,7 @@
 import os.path
 import unittest
-from unittest import mock
 import urllib
+from unittest import mock
 
 from django.conf import settings
 from django.core.files.base import ContentFile

--- a/wagtail/documents/tests/test_views.py
+++ b/wagtail/documents/tests/test_views.py
@@ -1,6 +1,7 @@
 import os.path
 import unittest
 from unittest import mock
+import urllib
 
 from django.conf import settings
 from django.core.files.base import ContentFile
@@ -31,6 +32,31 @@ class TestServeView(TestCase):
         self.assertEqual(
             self.get()['Content-Disposition'],
             'attachment; filename="{}"'.format(self.document.filename))
+
+    @mock.patch('wagtail.documents.views.serve.hooks')
+    @mock.patch('wagtail.documents.views.serve.get_object_or_404')
+    def test_non_local_filesystem_content_disposition_header(
+        self, mock_get_object_or_404, mock_hooks
+    ):
+        """
+        Tests the 'Content-Disposition' header in a response when using a
+        storage backend that doesn't expose filesystem paths.
+        """
+        # Create a mock document with no local file to hit the correct code path
+        mock_doc = mock.Mock()
+        mock_doc.filename = 'example.doc'
+        mock_doc.file.path = None
+        mock_get_object_or_404.return_value = mock_doc
+
+        # Bypass 'before_serve_document' hooks
+        mock_hooks.get_hooks.return_value = []
+
+        self.assertEqual(
+            self.get()['Content-Disposition'],
+            "attachment; filename={0}; filename*=UTF-8''{0}".format(
+                urllib.parse.quote(self.document.filename)
+            )
+        )
 
     def test_content_length_header(self):
         self.assertEqual(self.get()['Content-Length'], '25')
@@ -135,6 +161,42 @@ class TestServeWithUnicodeFilename(TestCase):
         except UnicodeEncodeError:
             raise unittest.SkipTest("Filesystem doesn't support unicode filenames")
 
+    def tearDown(self):
+        # delete the FieldFile directly because the TestCase does not commit
+        # transactions to trigger transaction.on_commit() in the signal handler
+        self.document.file.delete()
+
     def test_response_code(self):
         response = self.client.get(reverse('wagtaildocs_serve', args=(self.document.id, self.filename)))
         self.assertEqual(response.status_code, 200)
+
+    @mock.patch('wagtail.documents.views.serve.hooks')
+    @mock.patch('wagtail.documents.views.serve.get_object_or_404') 
+    def test_non_local_filesystem_unicode_content_disposition_header(
+        self, mock_get_object_or_404, mock_hooks
+    ):
+        """
+        Tests that a unicode 'Content-Disposition' header (for a response using
+        a storage backend that doesn't expose filesystem paths) doesn't cause an
+        error if encoded differently.
+        """
+        # Create a mock document to hit the correct code path.
+        mock_doc = mock.Mock()
+        mock_doc.filename = 'TÈST.doc'
+        mock_doc.file.path = None
+        mock_get_object_or_404.return_value = mock_doc
+
+        # Bypass 'before_serve_document' hooks
+        mock_hooks.get_hooks.return_value = []
+
+        response = self.client.get(reverse('wagtaildocs_serve', args=(self.document.id, mock_doc.filename)))
+
+        try:
+            response['Content-Disposition'].encode('ascii')
+        except UnicodeDecodeError:
+            self.fail('Content-Disposition with unicode characters failed ascii encoding.')
+
+        try:
+            response['Content-Disposition'].encode('latin-1')
+        except UnicodeDecodeError:
+            self.fail('Content-Disposition with unicode characters failed latin-1 encoding.')

--- a/wagtail/documents/views/serve.py
+++ b/wagtail/documents/views/serve.py
@@ -1,3 +1,4 @@
+import urllib
 from wsgiref.util import FileWrapper
 
 from django.conf import settings
@@ -64,7 +65,7 @@ def serve(request, document_id, document_filename):
         wrapper = FileWrapper(doc.file)
         response = StreamingHttpResponse(wrapper, content_type='application/octet-stream')
 
-        response['Content-Disposition'] = 'attachment; filename=%s' % doc.filename
+        response['Content-Disposition'] = "attachment; filename={0}; filename*=UTF-8''{0}".format(urllib.parse.quote(doc.filename))
 
         # FIXME: storage backends are not guaranteed to implement 'size'
         response['Content-Length'] = doc.file.size


### PR DESCRIPTION
Hi @gasman, 

This is a PR for the issue with document filenames containing non-asciii characters we discussed, where a [WSGI server](https://github.com/benoitc/gunicorn/blob/19.9.0/gunicorn/http/wsgi.py#L329) might attempt to encode the header as ascii. It implements the [suggestion](https://github.com/wagtail/wagtail/pull/1244#issuecomment-97134194) to url encode the document file and add `filename*=UTF-8''` to the header.

Thanks,

Rich.