### PR TITLE
Create reference in docs to PostgreSQL backend

### DIFF
--- a/docs/topics/search/backends.rst
+++ b/docs/topics/search/backends.rst
@@ -73,6 +73,8 @@ It also doesn't support:
 
 If any of these features are important to you, we recommend using Elasticsearch instead.
 
+.. _wagtailsearch_backends_postgresql:
+
 PostgreSQL Backend
 ------------------
 


### PR DESCRIPTION
The documentation reference point wagtailsearch_backends_postgresql is not present in the docs for the change made in [PR 5233](https://github.com/wagtail/wagtail/pull/5233) and so _wagtailsearch_backends_postgresql_ is showing in the docs instead of _PostgreSQL Backend_.  This PR fixes the deficiency in 5233.