### PR TITLE
Add Django models import to Site Settings docs

### DIFF
--- a/docs/reference/contrib/settings.rst
+++ b/docs/reference/contrib/settings.rst
@@ -22,6 +22,7 @@ Create a model that inherits from ``BaseSetting``, and register it using the ``r
 
 .. code-block:: python
 
+    from django.db import models
     from wagtail.contrib.settings.models import BaseSetting, register_setting
 
     @register_setting


### PR DESCRIPTION
Makes the implied import of Django's models explicit within the Site Settings documentation.  This helps clarify where the fields are coming from (eg that they're not Wagtail-specific).

This doesn't _seem_ overly "significant" (as per https://docs.wagtail.io/en/latest/contributing/committing.html#update-changelog-txt-and-release-notes) but let me know if you'd like me to update the changelog/etc.

----

Before submitting, please review the contributor guidelines <http://docs.wagtail.io/en/latest/contributing/index.html> and check the following:

* Do the tests still pass? (http://docs.wagtail.io/en/latest/contributing/developing.html#testing) **N/A**
* Does the code comply with the style guide? (Run `make lint` from the Wagtail root) **N/A**
* For Python changes: Have you added tests to cover the new/fixed behaviour? **N/A**
* For front-end changes: Did you test on all of Wagtail’s supported browsers? **N/A**.
* For new features: Has the documentation been updated accordingly? **N/A**
