### PR TITLE
Fix malformed HTML issues identified with jinjalint. Fix #5258

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,10 @@ jobs:
       - run: pipenv run isort --check-only --diff --recursive wagtail
       # Filter out known false positives, while preserving normal output and error codes.
       # See https://github.com/motet-a/jinjalint/issues/18.
-      - run: pipenv run jinjalint --parse-only wagtail | grep -v 'welcome_page.html:6:70' | tee /dev/tty | wc -l | grep -q '0'
+      # And https://circleci.com/docs/2.0/configuration-reference/#default-shell-options.
+      - run:
+          shell: /bin/bash -e
+          command: pipenv run jinjalint --parse-only wagtail | grep -v 'welcome_page.html:6:70' | tee /dev/tty | wc -l | grep -q '0'
       - run: DATABASE_NAME=wagtail.db pipenv run python -u runtests.py
 
   frontend:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,9 @@ jobs:
           key: pip-package-v1-{{ .Branch }}
       - run: pipenv run flake8 wagtail
       - run: pipenv run isort --check-only --diff --recursive wagtail
-      - run: pipenv run jinjalint --parse-only wagtail || true
+      # Filter out known false positives, while preserving normal output and error codes.
+      # See https://github.com/motet-a/jinjalint/issues/18.
+      - run: pipenv run jinjalint --parse-only wagtail | grep -v 'welcome_page.html:6:70' | tee /dev/tty | wc -l | grep -q '0'
       - run: DATABASE_NAME=wagtail.db pipenv run python -u runtests.py
 
   frontend:

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -14,6 +14,7 @@ Changelog
  * Fix: Revised test decorator to ensure TestPageEditHandlers test cases run correctly (Alex Tomkins)
  * Fix: Wagtail bird animation in admin now ends correctly on all browsers (Deniz Dogan)
  * Fix: Explorer menu no longer shows sibling pages for which the user does not have access (Mike Hearn)
+ * Fix: Fixed occurences of invalid HTML across the CMS admin (Thibaud Colas)
 
 
 2.5.1 (07.05.2019)

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,9 @@ develop: clean-pyc
 lint:
 	flake8 wagtail
 	isort --check-only --diff --recursive wagtail
-	jinjalint --parse-only wagtail || true
+	# Filter out known false positives, while preserving normal output and error codes.
+	# See https://github.com/motet-a/jinjalint/issues/18.
+	jinjalint --parse-only wagtail | grep -v 'welcome_page.html:6:70' | tee /dev/tty | wc -l | grep -q '0'
 	npm run lint:css --silent
 	npm run lint:js --silent
 

--- a/docs/releases/2.6.rst
+++ b/docs/releases/2.6.rst
@@ -28,6 +28,7 @@ Bug fixes
  * Revised test decorator to ensure TestPageEditHandlers test cases run correctly (Alex Tomkins)
  * Wagtail bird animation in admin now ends correctly on all browsers (Deniz Dogan)
  * Explorer menu no longer shows sibling pages for which the user does not have access (Mike Hearn)
+ * Fixed occurences of invalid HTML across the CMS admin (Thibaud Colas)
 
 
 Upgrade considerations

--- a/wagtail/admin/templates/wagtailadmin/collection_privacy/ancestor_privacy.html
+++ b/wagtail/admin/templates/wagtailadmin/collection_privacy/ancestor_privacy.html
@@ -4,5 +4,5 @@
 
 <div class="nice-padding">
     <p>{% trans "This collection has been made private by a parent collection." %}</p>
-    <p>{% trans "You can edit the privacy settings on:" %} <a href="{% url 'wagtailadmin_collections:edit' collection_with_restriction.id %}">{{ collection_with_restriction.name }}</a>
+    <p>{% trans "You can edit the privacy settings on:" %} <a href="{% url 'wagtailadmin_collections:edit' collection_with_restriction.id %}">{{ collection_with_restriction.name }}</a></p>
 </div>

--- a/wagtail/admin/templates/wagtailadmin/edit_handlers/chooser_panel.html
+++ b/wagtail/admin/templates/wagtailadmin/edit_handlers/chooser_panel.html
@@ -23,7 +23,7 @@
 
             <div class="actions">
                 {% if not field.field.required %}
-                    <button type="button" class="button action-clear button-small button-secondary">{{ field.field.widget.clear_choice_text }}</button
+                    <button type="button" class="button action-clear button-small button-secondary">{{ field.field.widget.clear_choice_text }}</button>
                 {% endif %}
                 <button type="button" class="button action-choose button-small button-secondary">{{ field.field.widget.choose_another_text }}</button>
             </div>

--- a/wagtail/admin/templates/wagtailadmin/page_privacy/ancestor_privacy.html
+++ b/wagtail/admin/templates/wagtailadmin/page_privacy/ancestor_privacy.html
@@ -4,5 +4,5 @@
 
 <div class="nice-padding">
     <p>{% trans "This page has been made private by a parent page." %}</p>
-    <p>{% trans "You can edit the privacy settings on:" %} <a href="{% url 'wagtailadmin_pages:edit' page_with_restriction.id %}">{{ page_with_restriction.get_admin_display_title }}</a>
+    <p>{% trans "You can edit the privacy settings on:" %} <a href="{% url 'wagtailadmin_pages:edit' page_with_restriction.id %}">{{ page_with_restriction.get_admin_display_title }}</a></p>
 </div>

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_button_with_dropdown.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_button_with_dropdown.html
@@ -1,10 +1,10 @@
 <div {{ self.attrs }} class="c-dropdown  {% if is_parent %}t-inverted{% else %}t-default{% endif %}" data-dropdown>
     <a href="javascript:void(0)" title="{{ title }}" class="c-dropdown__button  u-btn-current">
         {{ label }}
-        <div data-dropdown-toggle class="o-icon  c-dropdown__toggle  [ icon icon-arrow-down ]"></div>
+        <div data-dropdown-toggle class="o-icon c-dropdown__toggle  [ icon icon-arrow-down ]"></div>
     </a>
     <div class="t-dark">
-        <ul role="menu" class="c-dropdown__menu  u-toggle  u-arrow u-arrow--tl u-background">
+        <ul role="menu" class="c-dropdown__menu u-toggle  u-arrow u-arrow--tl u-background">
         {% for button in buttons %}
             <li class="c-dropdown__item ">
                 <a href="{{ button.url }}" title="{{ button.attrs.title }}" class="u-link is-live {{ button.classes|join:' ' }}">
@@ -12,5 +12,6 @@
                 </a>
             </li>
         {% endfor %}
+        </ul>
     </div>
 </div>

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_list_explore.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_list_explore.html
@@ -66,5 +66,5 @@
 
 {% block no_results %}
     {% url 'wagtailadmin_pages:add_subpage' parent_page.id as add_page_url%}
-    <tr><td colspan="3" class="no-results-message"><p>{% trans "No pages have been created at this location." %}{% if parent_page and parent_page_perms.can_add_subpage %} {% blocktrans %}Why not <a href="{{ add_page_url }}">create one</a>?{% endblocktrans %}{% endif %}</td></tr>
+    <tr><td colspan="3" class="no-results-message"><p>{% trans "No pages have been created at this location." %}{% if parent_page and parent_page_perms.can_add_subpage %} {% blocktrans %}Why not <a href="{{ add_page_url }}">create one</a>?{% endblocktrans %}{% endif %}</p></td></tr>
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/permissions/includes/collection_member_permissions_formset.html
+++ b/wagtail/admin/templates/wagtailadmin/permissions/includes/collection_member_permissions_formset.html
@@ -39,7 +39,7 @@
                 {% include "wagtailadmin/permissions/includes/collection_member_permissions_form.html" with form=form only %}
             </tr>
         {% endfor %}
-    <tbody>
+    </tbody>
 </table>
 
 <script type="text/django-form-template" id="id_{{ formset.prefix }}-EMPTY_FORM_TEMPLATE">

--- a/wagtail/contrib/forms/templates/wagtailforms/list_submissions.html
+++ b/wagtail/contrib/forms/templates/wagtailforms/list_submissions.html
@@ -30,7 +30,6 @@
                         {{ cell }}
                     </td>
                 {% endfor %}
-                <td>
             </tr>
         {% endfor %}
     </tbody>

--- a/wagtail/contrib/redirects/templates/wagtailredirects/results.html
+++ b/wagtail/contrib/redirects/templates/wagtailredirects/results.html
@@ -15,7 +15,7 @@
     {% include "wagtailadmin/shared/pagination_nav.html" with items=redirects linkurl="wagtailredirects:index" %}
 {% else %}
      {% if query_string %}
-         <p>{% blocktrans %}Sorry, no redirects match "<em>{{ query_string }}</em>"{% endblocktrans %}
+         <p>{% blocktrans %}Sorry, no redirects match "<em>{{ query_string }}</em>"{% endblocktrans %}</p>
      {% else %}
         {% url 'wagtailredirects:add' as wagtailredirects_add_redirect_url %}
         <p>{% blocktrans %}No redirects have been created. Why not <a href="{{ wagtailredirects_add_redirect_url }}">add one</a>?{% endblocktrans %}</p>

--- a/wagtail/contrib/styleguide/templates/wagtailstyleguide/base.html
+++ b/wagtail/contrib/styleguide/templates/wagtailstyleguide/base.html
@@ -431,7 +431,7 @@
 
         <section id="buttons">
             <h2>Buttons</h2>
-            <p class="help-block help-warning">Do not use <code>{% filter force_escape|lower %}<input type="button">{% endfilter %}</code> use <code>{% filter force_escape|lower %}<button type="button">{% endfilter %}</code> instead. This addresses inconsistencies between rendering of buttons x-browser.</p>
+            <p class="help-block help-warning">Do not use <code>{% filter force_escape|lower %}<input type="button">{% endfilter %}</code> use <code>{% filter force_escape|lower %}<button type="button"></button>{% endfilter %}</code> instead. This addresses inconsistencies between rendering of buttons x-browser.</p>
 
 
             <p>Buttons must have interaction possible (i.e be an input or button element) to get a suitable hover cursor</p>

--- a/wagtail/documents/templates/wagtaildocs/documents/edit.html
+++ b/wagtail/documents/templates/wagtaildocs/documents/edit.html
@@ -61,7 +61,4 @@
             </dl>
         </div>
     </div>
-
-
-    </div>
 {% endblock %}

--- a/wagtail/documents/templates/wagtaildocs/multiple/add.html
+++ b/wagtail/documents/templates/wagtaildocs/multiple/add.html
@@ -16,7 +16,7 @@
     <div class="nice-padding">
         <div class="drop-zone">
             <p>{% trans "Drag and drop documents into this area to upload immediately." %}</p>
-            <p>{{ help_text }}
+            <p>{{ help_text }}</p>
 
             <form action="{% url 'wagtaildocs:add_multiple' %}" method="POST" enctype="multipart/form-data">
                 <div class="replace-file-input">

--- a/wagtail/images/templates/wagtailimages/multiple/add.html
+++ b/wagtail/images/templates/wagtailimages/multiple/add.html
@@ -17,7 +17,7 @@
     <div class="nice-padding">
         <div class="drop-zone">
             <p>{% trans "Drag and drop images into this area to upload immediately." %}</p>
-            <p>{{ help_text }}
+            <p>{{ help_text }}</p>
 
             <form action="{% url 'wagtailimages:add_multiple' %}" method="POST" enctype="multipart/form-data">
                 <div class="replace-file-input">

--- a/wagtail/snippets/templates/wagtailsnippets/snippets/edit.html
+++ b/wagtail/snippets/templates/wagtailsnippets/snippets/edit.html
@@ -8,11 +8,7 @@
     <div class="row row-flush">
 
         {% usage_count_enabled as uc_enabled %}
-        {% if uc_enabled %}
-        <div class="col10 divider-after">
-        {% else %}
-        <div class="col12">
-        {% endif %}
+        <div class="{% if uc_enabled %}col10 divider-after{% else %}col12{% endif %}">
             <form action="{% url 'wagtailsnippets:edit' model_opts.app_label model_opts.model_name instance.pk|admin_urlquote %}" method="POST" novalidate{% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>
                 {% csrf_token %}
                 {{ edit_handler.render_form_content }}

--- a/wagtail/users/templates/wagtailusers/groups/includes/page_permissions_formset.html
+++ b/wagtail/users/templates/wagtailusers/groups/includes/page_permissions_formset.html
@@ -39,7 +39,7 @@
                 {% include "wagtailusers/groups/includes/page_permissions_form.html" with form=form only %}
             </tr>
         {% endfor %}
-    <tbody>
+    </tbody>
 </table>
 
 <script type="text/django-form-template" id="id_{{ formset.prefix }}-EMPTY_FORM_TEMPLATE">

--- a/wagtail/users/templates/wagtailusers/groups/list.html
+++ b/wagtail/users/templates/wagtailusers/groups/list.html
@@ -15,7 +15,7 @@
                         <a href="{% url 'wagtailusers_groups:edit' group.id %}">{{ group.name }}</a>
                     </h2>
                 </td>
-            </li>
+            </tr>
         {% endfor %}
     </tbody>
 </table>


### PR DESCRIPTION
Fixes #5258. I have tried all of these in Chrome only, there wasn't any difference that I could see in the rendered page before/after making the changes.

Here are the errors broken down into categories:

## Real issues

### Missing closing `</p>` tag

```
admin/templates/wagtailadmin/collection_privacy/ancestor_privacy.html:8:2:  expected 'p' at 7:2
admin/templates/wagtailadmin/page_privacy/ancestor_privacy.html:8:2:  expected 'p' at 7:2
```

<img width="774" alt="page-privacy" src="https://user-images.githubusercontent.com/877585/57457005-9f847700-7266-11e9-911d-a466ee0f46fd.png">

```
admin/templates/wagtailadmin/pages/listing/_list_explore.html:69:271:  expected 'p' at 68:271
```

<img width="654" alt="child-pages-empty" src="https://user-images.githubusercontent.com/877585/57457102-c80c7100-7266-11e9-9d22-2eae660ee5e3.png">

```
documents/templates/wagtaildocs/multiple/add.html:40:10:  expected 'p' at 39:10
images/templates/wagtailimages/multiple/add.html:41:10:  expected 'p' at 40:10
```

<img width="890" alt="docs-add-multiple" src="https://user-images.githubusercontent.com/877585/57457123-d064ac00-7266-11e9-92f0-9565308c779c.png">

<img width="892" alt="images-add-multiple" src="https://user-images.githubusercontent.com/877585/57457137-d9557d80-7266-11e9-81b5-0f57dfd4bc72.png">

```
contrib/redirects/templates/wagtailredirects/results.html:19:8:  expected one of 'autoescape', 'block', 'blocktrans', 'comment', 'filter', 'for', 'if', 'ifchanged', 'ifequal', 'ifnotequal', 'not an intermediate Jinja tag name', 'spaceless', 'verbatim', 'with' at 18:8
```

<img width="494" alt="redirects-results" src="https://user-images.githubusercontent.com/877585/57457157-e5413f80-7266-11e9-8498-00cbc3e334f4.png">

### Missing closing `</ul>` tag only:

```
admin/templates/wagtailadmin/pages/listing/_button_with_dropdown.html:15:6:  expected 'ul' at 14:6
```

<img width="245" alt="dropdown-menu" src="https://user-images.githubusercontent.com/877585/57457170-eb372080-7266-11e9-88da-32070a8eaef7.png">

### Extra closing `</div>` tag:

```
documents/templates/wagtaildocs/documents/edit.html:66:5:  expected one of '[:a-z]', 'area', 'base', 'br', 'col', 'command', 'embed', 'hr', 'img', 'input', 'keygen', 'link', 'meta', 'param', 'script', 'source', 'style', 'track', 'wbr', '{#', '{%', '{{' at 65:5
```

### Invalid table tbody closing tag:

```
admin/templates/wagtailadmin/permissions/includes/collection_member_permissions_formset.html:43:2:  expected 'tbody' at 42:2
users/templates/wagtailusers/groups/includes/page_permissions_formset.html:43:2:  expected 'tbody' at 42:2
```

### Extra td opening tag:

```
contrib/forms/templates/wagtailforms/list_submissions.html:34:14:  expected 'td' at 33:14
```

<img width="854" alt="list-submissions-html" src="https://user-images.githubusercontent.com/877585/57457239-0e61d000-7267-11e9-8111-c22bfb032027.png">

### Mismatched start and end tags:

```
users/templates/wagtailusers/groups/list.html:18:14:  expected 'tr' at 17:14
```

<img width="845" alt="invalid-groups-list" src="https://user-images.githubusercontent.com/877585/57457282-1f124600-7267-11e9-8749-f477440b1697.png">


## Real issues but no real impact

### Missing bracket in a deprecated template

```
admin/templates/wagtailadmin/edit_handlers/chooser_panel.html:26:150:  expected '>' at 25:150
```

### Invalid code sample in the styleguide

```
contrib/styleguide/templates/wagtailstyleguide/base.html:434:205:  expected one of 'autoescape', 'block', 'blocktrans', 'comment', 'filter', 'for', 'if', 'ifchanged', 'ifequal', 'ifnotequal', 'not an intermediate Jinja tag name', 'spaceless', 'verbatim', 'with' at 433:205
```

<img width="779" alt="styleguide-code-sample" src="https://user-images.githubusercontent.com/877585/57457209-00ac4a80-7267-11e9-92d8-286e60df62ea.png">


## False positives

### Mismatched start and end tags because of conditional

```
snippets/templates/wagtailsnippets/snippets/edit.html:13:11:  expected one of 'autoescape', 'block', 'blocktrans', 'comment', 'endif', 'filter', 'for', 'if', 'ifchanged', 'ifequal', 'ifnotequal', 'not an intermediate Jinja tag name', 'spaceless', 'verbatim', 'with' at 12:11
```

This was a really simple refactoring to make the false positive disappear, but this shouldn't be a problem so I’ve opened https://github.com/motet-a/jinjalint/issues/19 to hopefully get this fixed in the linter/parser.

False positive for SVG attributes casing:

```
project_template/home/templates/home/welcome_page.html:6:70:  expected one of '=', '>', '[0-9-_.]', '[:a-z]', '\\s+', '{#', '{%', '{{' at 5:70
```

There is no way to refactor this, the code is valid as-is, it's just that jinjalint has no awareness of SVG embedded in HTML. I have opened https://github.com/motet-a/jinjalint/issues/18, and in the meantime have added filtering logic where the linter is integrated so this isn't reported. It's a bit of a shame that this is necessary and that there is no built-in way to ignore individual errors, but the linter still feels valuable nonetheless.