### PR TITLE
Add alt attributes to images that was missing them

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -20,6 +20,9 @@ Changelog
  * Fix: Admin HTML now includes the correct `dir` attribute for the active language (Andreas Bernacca)
  * Fix: Fix type error when using `--chunk_size` argument on `./manage.py update_index` (Seb Brown)
  * Fix: Avoid rendering entire form in EditHandler's `repr` method (Alex Tomkins)
+ * Fix: Add empty alt attributes to HTML output of Embedly and oEmbed embed finders (Andreas Bernacca)
+ * Fix: Add empty alt attributes to all images in the CMS admin (Andreas Bernacca)
+ * Fix: Make URL generator preview image alt translateable (Thibaud Colas)
 
 
 2.5.1 (07.05.2019)

--- a/docs/releases/2.6.rst
+++ b/docs/releases/2.6.rst
@@ -33,6 +33,9 @@ Bug fixes
  * Admin HTML now includes the correct ``dir`` attribute for the active language (Andreas Bernacca)
  * Fix type error when using ``--chunk_size`` argument on ``./manage.py update_index`` (Seb Brown)
  * Avoid rendering entire form in EditHandler's ``repr`` method (Alex Tomkins)
+ * Add empty alt attributes to HTML output of Embedly and oEmbed embed finders (Andreas Bernacca)
+ * Add empty alt attributes to all images in the CMS admin (Andreas Bernacca)
+ * Make URL generator preview image alt translateable (Thibaud Colas)
 
 
 Upgrade considerations

--- a/wagtail/admin/templates/wagtailadmin/account/change_avatar.html
+++ b/wagtail/admin/templates/wagtailadmin/account/change_avatar.html
@@ -9,7 +9,7 @@
     <div class="nice-padding">
         <p>{% trans "Your current profile picture:" %}</p>
         <p>
-            <span class="avatar square"><img src="{% avatar_url request.user size=50 %}"></span>
+            <span class="avatar square"><img src="{% avatar_url request.user size=50 %}" alt=""></span>
         </p>
 
         <form action="{% url 'wagtailadmin_account_change_avatar' %}" method="POST" enctype="multipart/form-data">

--- a/wagtail/admin/templates/wagtailadmin/pages/edit.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/edit.html
@@ -69,7 +69,7 @@
                             {% blocktrans with last_mod=page.get_latest_revision.created_at %}Last modified: {{ last_mod }}{% endblocktrans %}
                             {% if page.get_latest_revision.user %}
                                 {% blocktrans with modified_by=page.get_latest_revision.user.get_full_name|default:page.get_latest_revision.user.get_username %}by {{ modified_by }}{% endblocktrans %}
-                                <span class="avatar small"><img src="{% avatar_url page.get_latest_revision.user size=25 %}" /></span>
+                                <span class="avatar small"><img src="{% avatar_url page.get_latest_revision.user size=25 %}" alt="" /></span>
                             {% endif %}
                             <a href="{% url 'wagtailadmin_pages:revisions_index' page.id %}" class="underlined">{% trans 'Revisions' %}</a>
                         {% endif %}

--- a/wagtail/admin/templates/wagtailadmin/pages/revisions/list.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/revisions/list.html
@@ -22,7 +22,7 @@
                         <h2>
                             <a href="{% url 'wagtailadmin_pages:revisions_revert' page.id revision.id %}">{{ revision.created_at }}</a>
                             <span class="unbold">
-                                {% trans 'by' context 'points to a user who created a revision' %}<span class="avatar small"><img src="{% avatar_url revision.user size=25 %}" /></span>{{ revision.user }}
+                                {% trans 'by' context 'points to a user who created a revision' %}<span class="avatar small"><img src="{% avatar_url revision.user size=25 %}" alt="" /></span>{{ revision.user }}
                             </span>
                             {% if revision == page.get_latest_revision %}({% trans 'Current draft' %}){% endif %}
                             {% if revision == page.live_revision %}({% trans 'Live version' %}){% endif %}

--- a/wagtail/admin/templates/wagtailadmin/shared/main_nav.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/main_nav.html
@@ -7,7 +7,7 @@
         <li class="footer" id="footer">
             <div class="account" id="account-settings" title="{% trans 'Edit your account' %}">
                 <span class="avatar square avatar-on-dark">
-                    <img src="{% avatar_url request.user size=50 %}" />
+                    <img src="{% avatar_url request.user size=50 %}" alt="" />
                 </span>
                 <em class="icon icon-arrow-up-after">{{ request.user.first_name|default:request.user.get_username }}</em>
             </div>

--- a/wagtail/admin/templates/wagtailadmin/shared/user_avatar.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/user_avatar.html
@@ -1,7 +1,7 @@
 {% load wagtailadmin_tags %}
 
 <span class="avatar small">
-    <img src="{% avatar_url user size=25 %}" />
+    <img src="{% avatar_url user size=25 %}" alt="" />
 </span>
 
 {{ user }}

--- a/wagtail/contrib/styleguide/templates/wagtailstyleguide/base.html
+++ b/wagtail/contrib/styleguide/templates/wagtailstyleguide/base.html
@@ -780,9 +780,9 @@
             <h2>Misc formatters</h2>
             <h3>Avatar icons</h3>
 
-            <p><span class="avatar"><img src="{% avatar_url user size=50 %}" /></span> Avatar normal</p>
-            <p><span class="avatar square"><img src="{% avatar_url user size=50 %}" /></span> Avatar square</p>
-            <p><span class="avatar small"><img src="{% avatar_url user size=25 %}" /></span> Avatar small</p>
+            <p><span class="avatar"><img src="{% avatar_url user size=50 %}" alt="" /></span> Avatar normal</p>
+            <p><span class="avatar square"><img src="{% avatar_url user size=50 %}" alt="" /></span> Avatar square</p>
+            <p><span class="avatar small"><img src="{% avatar_url user size=25 %}" alt="" /></span> Avatar small</p>
 
             <h3>Status tags</h3>
             <div class="status-tag primary">Primary tag</div>
@@ -793,12 +793,12 @@
             <p>Add the following <code>div</code> around any items you wish to display with a spinner overlay and fading out</p>
             <p>Remove the "loading" class to disable the effect</p>
             <div class="loading-mask loading" style="width:200px">
-                <img src="{% static 'wagtailadmin/images/wagtail-logo.svg' %}" width="200" />
+                <img src="{% static 'wagtailadmin/images/wagtail-logo.svg' %}" width="200" alt="Wagtail" />
             </div>
 
             <h3>Image transparency</h3>
             <p>It can be useful to show users the transparent areas of images. Add a transparency checkerboard with the <code>.show-transparency</code> on the <code>img</code> tag thus:</p>
-            <img src="{% static 'wagtailadmin/images/wagtail-logo.svg' %}" width="200" class="show-transparency" />
+            <img src="{% static 'wagtailadmin/images/wagtail-logo.svg' %}" width="200" class="show-transparency" alt="Wagtail" />
         </section>
 
         <section id="icons" class="icons">

--- a/wagtail/embeds/finders/embedly.py
+++ b/wagtail/embeds/finders/embedly.py
@@ -52,7 +52,7 @@ class EmbedlyFinder(EmbedFinder):
 
         # Convert photos into HTML
         if oembed['type'] == 'photo':
-            html = '<img src="%s" />' % (oembed['url'], )
+            html = '<img src="%s" alt="">' % (oembed['url'], )
         else:
             html = oembed.get('html')
 

--- a/wagtail/embeds/finders/oembed.py
+++ b/wagtail/embeds/finders/oembed.py
@@ -65,7 +65,7 @@ class OEmbedFinder(EmbedFinder):
 
         # Convert photos into HTML
         if oembed['type'] == 'photo':
-            html = '<img src="%s" />' % (oembed['url'], )
+            html = '<img src="%s" alt="">' % (oembed['url'], )
         else:
             html = oembed.get('html')
 

--- a/wagtail/embeds/tests/test_embeds.py
+++ b/wagtail/embeds/tests/test_embeds.py
@@ -259,7 +259,7 @@ class TestEmbedly(TestCase):
             oembed.return_value = {'type': 'photo',
                                    'url': 'http://www.example.com'}
             result = EmbedlyFinder(key='foo').find_embed('http://www.example.com')
-            self.assertEqual(result['html'], '<img src="http://www.example.com" />')
+            self.assertEqual(result['html'], '<img src="http://www.example.com" alt="">')
 
             oembed.return_value = {'type': 'something else',
                                    'html': '<foo>bar</foo>'}
@@ -325,7 +325,7 @@ class TestOembed(TestCase):
                               'url': 'http://www.example.com'}
         result = OEmbedFinder().find_embed("http://www.youtube.com/watch/")
         self.assertEqual(result['type'], 'photo')
-        self.assertEqual(result['html'], '<img src="http://www.example.com" />')
+        self.assertEqual(result['html'], '<img src="http://www.example.com" alt="">')
         loads.assert_called_with("foo")
 
     @patch('urllib.request.urlopen')

--- a/wagtail/images/rich_text/__init__.py
+++ b/wagtail/images/rich_text/__init__.py
@@ -23,7 +23,7 @@ class ImageEmbedHandler(EmbedHandler):
         try:
             image = cls.get_instance(attrs)
         except ObjectDoesNotExist:
-            return "<img>"
+            return '<img alt="">'
 
         image_format = get_image_format(attrs['format'])
         return image_format.image_to_html(image, attrs.get('alt', ''))

--- a/wagtail/images/rich_text/editor_html.py
+++ b/wagtail/images/rich_text/editor_html.py
@@ -36,7 +36,7 @@ class ImageEmbedHandler:
         try:
             image = Image.objects.get(id=attrs['id'])
         except Image.DoesNotExist:
-            return "<img>"
+            return '<img alt="">'
 
         image_format = get_image_format(attrs['format'])
 

--- a/wagtail/images/templates/wagtailimages/images/url_generator.html
+++ b/wagtail/images/templates/wagtailimages/images/url_generator.html
@@ -27,7 +27,7 @@
         <h2 class="icon icon-view">{% trans "Preview" %}</h2>
         <div>
             <div class="loading-mask inline-block">
-                <img class="preview" src="" alt="Preview" />
+                <img class="preview" src="" alt="{% trans 'Preview' %}" />
             </div>
         </div>
         <p id="note-size" class="help-block help-warning">{% trans "Note that images generated larger than the screen will appear smaller when previewed here, so they fit the screen." %}</p>

--- a/wagtail/images/templates/wagtailimages/widgets/compare.html
+++ b/wagtail/images/templates/wagtailimages/widgets/compare.html
@@ -32,7 +32,7 @@
         {% if image_a %}
             {% image image_a max-165x165 class="show-transparency" %}
         {% else %}
-            <img>
+            <img alt="">
         {% endif %}
     </div>
 {% endif %}

--- a/wagtail/images/templates/wagtailimages/widgets/image_chooser.html
+++ b/wagtail/images/templates/wagtailimages/widgets/image_chooser.html
@@ -8,7 +8,7 @@
         {% if image %}
             {% image image max-165x165 class="show-transparency" title=image.title %}
         {% else %}
-            <img>
+            <img alt="">
         {% endif %}
     </div>
 {% endblock %}

--- a/wagtail/images/tests/test_rich_text.py
+++ b/wagtail/images/tests/test_rich_text.py
@@ -44,7 +44,7 @@ class TestEditorHtmlImageEmbedHandler(TestCase, WagtailTestUtils):
     def test_expand_db_attributes_for_editor_nonexistent_image(self):
         self.assertEqual(
             EditorHtmlImageEmbedHandler.expand_db_attributes({'id': 0}),
-            '<img>'
+            '<img alt="">'
         )
 
     def test_expand_db_attributes_for_editor_escapes_alt_text(self):
@@ -96,7 +96,7 @@ class TestFrontendImageEmbedHandler(TestCase, WagtailTestUtils):
 
     def test_expand_db_attributes_for_frontend_with_nonexistent_image(self):
         result = FrontendImageEmbedHandler.expand_db_attributes({'id': 0})
-        self.assertEqual(result, '<img>')
+        self.assertEqual(result, '<img alt="">')
 
     def test_expand_db_attributes_for_frontend_escapes_alt_text(self):
         Image.objects.create(id=1, title='Test', file=get_test_image_file())

--- a/wagtail/users/templates/wagtailusers/users/list.html
+++ b/wagtail/users/templates/wagtailusers/users/list.html
@@ -34,7 +34,7 @@
             <tr>
                 <td class="title" valign="top">
                     <h2>
-                        <span class="avatar small"><img src="{% avatar_url user size=25 %}" /></span>
+                        <span class="avatar small"><img src="{% avatar_url user size=25 %}" alt="" /></span>
                         <a href="{% url 'wagtailusers_users:edit' user.pk %}">{{ user.get_full_name|default:user.get_username }}</a>
                     </h2>
                     <ul class="actions">


### PR DESCRIPTION
Fixes #5291 - found a couple of more places where images had no alt attribute.

On a side note not related to accessibility i found that the `<img>` tags are inconsistent in when they're `<img>` or `<img />`. If it's worth changing to be more consistent I'm willing to create an issue and PR.