### PR TITLE
Add setting to disable email management

### DIFF
--- a/docs/advanced_topics/settings.rst
+++ b/docs/advanced_topics/settings.rst
@@ -295,6 +295,11 @@ This specifies whether password fields are shown when creating or editing users 
 
 This specifies whether password is a required field when creating a new user. True by default; ignored if ``WAGTAILUSERS_PASSWORD_ENABLED`` is false. If this is set to False, and the password field is left blank when creating a user, then that user will have no usable password; in order to log in, they will have to reset their password (if ``WAGTAIL_PASSWORD_RESET_ENABLED`` is True) or use an alternative authentication system such as LDAP (if one is set up).
 
+.. code-block:: python
+
+  WAGTAIL_EMAIL_MANAGEMENT_ENABLED = True
+
+This specifies whether users are allowed to change their email (enabled by default).
 
 .. _email_notifications:
 

--- a/wagtail/admin/tests/test_account_management.py
+++ b/wagtail/admin/tests/test_account_management.py
@@ -240,6 +240,30 @@ class TestAccountSection(TestCase, WagtailTestUtils):
         self.assertNotEqual(get_user_model().objects.get(pk=self.user.pk).email, post_data['email'])
 
 
+    @override_settings(WAGTAIL_EMAIL_MANAGEMENT_ENABLED=False)
+    def test_account_view_with_email_management_disabled(self):
+        # Get account page
+        response = self.client.get(reverse('wagtailadmin_account'))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'wagtailadmin/account/account.html')
+        # Page should NOT contain a 'Change email' option
+        self.assertNotContains(response, "Change email")
+
+
+    @override_settings(WAGTAIL_EMAIL_MANAGEMENT_ENABLED=False)
+    def test_change_email_view_disabled(self):
+        """
+        This tests that the change email view responds with a 404
+        when setting WAGTAIL_EMAIL_MANAGEMENT_ENABLED is False
+        """
+        # Get change email page
+        response = self.client.get(reverse('wagtailadmin_account_change_email'))
+
+        # Check that the user received a 404
+        self.assertEqual(response.status_code, 404)
+
+
     @override_settings(WAGTAIL_PASSWORD_MANAGEMENT_ENABLED=False)
     def test_account_view_with_password_management_disabled(self):
         # Get account page

--- a/wagtail/admin/views/account.py
+++ b/wagtail/admin/views/account.py
@@ -33,6 +33,10 @@ def password_management_enabled():
     return getattr(settings, 'WAGTAIL_PASSWORD_MANAGEMENT_ENABLED', True)
 
 
+def email_management_enabled():
+    return getattr(settings, 'WAGTAIL_EMAIL_MANAGEMENT_ENABLED', True)
+
+
 def password_reset_enabled():
     return getattr(settings, 'WAGTAIL_PASSWORD_RESET_ENABLED', password_management_enabled())
 
@@ -80,6 +84,8 @@ def change_password(request):
 
 
 def change_email(request):
+    if not email_management_enabled():
+        raise Http404
     if request.method == 'POST':
         form = EmailForm(request.POST, instance=request.user)
 

--- a/wagtail/admin/wagtail_hooks.py
+++ b/wagtail/admin/wagtail_hooks.py
@@ -19,7 +19,8 @@ from wagtail.admin.search import SearchArea
 from wagtail.admin.utils import (
     get_available_admin_languages, get_available_admin_time_zones,
     user_has_any_page_permission)
-from wagtail.admin.views.account import password_management_enabled
+from wagtail.admin.views.account import (
+    password_management_enabled, email_management_enabled)
 from wagtail.admin.viewsets import viewsets
 from wagtail.admin.widgets import Button, ButtonWithDropdownFromHook, PageListingButton
 from wagtail.core import hooks
@@ -204,11 +205,12 @@ def register_account_set_profile_picture(request):
 
 @hooks.register('register_account_menu_item')
 def register_account_change_email(request):
-    return {
-        'url': reverse('wagtailadmin_account_change_email'),
-        'label': _('Change email'),
-        'help_text': _('Change the email address linked to your account.'),
-    }
+    if email_management_enabled():
+        return {
+            'url': reverse('wagtailadmin_account_change_email'),
+            'label': _('Change email'),
+            'help_text': _('Change the email address linked to your account.'),
+        }
 
 
 @hooks.register('register_account_menu_item')

--- a/wagtail/admin/wagtail_hooks.py
+++ b/wagtail/admin/wagtail_hooks.py
@@ -19,8 +19,7 @@ from wagtail.admin.search import SearchArea
 from wagtail.admin.utils import (
     get_available_admin_languages, get_available_admin_time_zones,
     user_has_any_page_permission)
-from wagtail.admin.views.account import (
-    password_management_enabled, email_management_enabled)
+from wagtail.admin.views.account import email_management_enabled, password_management_enabled
 from wagtail.admin.viewsets import viewsets
 from wagtail.admin.widgets import Button, ButtonWithDropdownFromHook, PageListingButton
 from wagtail.core import hooks


### PR DESCRIPTION
This commit adds WAGTAIL_EMAIL_MANAGEMENT_ENABLED setting that defaults
to True, but when disabled, hides the 'Change email' button in account
management view, and disables the associated route. This is useful when
using external authentication method like LDAP or OpenID Connect where
email management is handled elsewhere.

Wagtail already includes WAGTAIL_PASSWORD_MANAGEMENT_ENABLED setting.
This is almost exact copy of that implementation.