### PR TITLE
Implement WAGTAILDOCS_SERVE_METHOD setting

### DIFF
--- a/docs/advanced_topics/settings.rst
+++ b/docs/advanced_topics/settings.rst
@@ -268,6 +268,24 @@ This setting lets you override the maximum number of pixels an image can have. I
 This setting enables feature detection once OpenCV is installed, see all details on the :ref:`image_feature_detection` documentation.
 
 
+Documents
+---------
+
+.. code-block:: python
+
+  WAGTAILDOCS_SERVE_METHOD = 'redirect'
+
+Determines how document downloads will be served. Normally, requests for documents are sent through a Django view, to perform permission checks (see :ref:`image_document_permissions`) and potentially other housekeeping tasks such as hit counting. To fully protect against users bypassing this check, it needs to happen in the same request where the document is served; however, this incurs a performance hit as the document then needs to be served by the Django server. In particular, this cancels out much of the benefit of hosting documents on external storage, such as S3 or a CDN.
+
+For this reason, Wagtail provides a number of serving methods which trade some of the strictness of the permission check for performance:
+
+ * ``'direct'`` - links to documents point directly to the URL provided by the underlying storage, bypassing the permission check. This is most useful when deploying sites as fully static HTML (e.g. using `wagtail-bakery <https://github.com/wagtail/wagtail-bakery>`_ or `Gatsby <https://www.gatsbyjs.org/>`_).
+ * ``'redirect'`` - links to documents point to a Django view which will check the user's permission; if successful, it will redirect to the URL provided by the underlying storage to allow the document to be downloaded. This is most suitable for remote storage backends such as S3, as it allows the document to be served independently of the Django server. Note that if a user is able to guess the latter URL, they will be able to bypass the permission check; some storage backends may provide configuration options to generate a random or short-lived URL to mitigate this.
+ * ``'serve_view'`` - links to documents point to a Django view which both checks the user's permission, and serves the document. Serving will be handled by `django-sendfile <https://github.com/johnsensible/django-sendfile>`_, if this is installed and supported by your server configuration, or as a streaming response from Django if not. When using this method, it is recommended that you configure your webserver to *disallow* serving documents directly from their location under ``MEDIA_ROOT``, as this would provide a way to bypass the permission check.
+
+If ``WAGTAILDOCS_SERVE_METHOD`` is unspecified or set to ``None``, the default method is ``'redirect'`` when a remote storage backend is in use (i.e. one that exposes a URL but not a local filesystem path), and ``'serve_view'`` otherwise. Finally, some storage backends may not expose a URL at all; in this case, serving will proceed as for ``'serve_view'``.
+
+
 Password Management
 -------------------
 

--- a/docs/advanced_topics/settings.rst
+++ b/docs/advanced_topics/settings.rst
@@ -271,15 +271,17 @@ This setting enables feature detection once OpenCV is installed, see all details
 Documents
 ---------
 
+.. _wagtaildocs_serve_method:
+
 .. code-block:: python
 
   WAGTAILDOCS_SERVE_METHOD = 'redirect'
 
-Determines how document downloads will be served. Normally, requests for documents are sent through a Django view, to perform permission checks (see :ref:`image_document_permissions`) and potentially other housekeeping tasks such as hit counting. To fully protect against users bypassing this check, it needs to happen in the same request where the document is served; however, this incurs a performance hit as the document then needs to be served by the Django server. In particular, this cancels out much of the benefit of hosting documents on external storage, such as S3 or a CDN.
+Determines how document downloads will be linked to and served. Normally, requests for documents are sent through a Django view, to perform permission checks (see :ref:`image_document_permissions`) and potentially other housekeeping tasks such as hit counting. To fully protect against users bypassing this check, it needs to happen in the same request where the document is served; however, this incurs a performance hit as the document then needs to be served by the Django server. In particular, this cancels out much of the benefit of hosting documents on external storage, such as S3 or a CDN.
 
 For this reason, Wagtail provides a number of serving methods which trade some of the strictness of the permission check for performance:
 
- * ``'direct'`` - links to documents point directly to the URL provided by the underlying storage, bypassing the permission check. This is most useful when deploying sites as fully static HTML (e.g. using `wagtail-bakery <https://github.com/wagtail/wagtail-bakery>`_ or `Gatsby <https://www.gatsbyjs.org/>`_).
+ * ``'direct'`` - links to documents point directly to the URL provided by the underlying storage, bypassing the Django view that provides the permission check. This is most useful when deploying sites as fully static HTML (e.g. using `wagtail-bakery <https://github.com/wagtail/wagtail-bakery>`_ or `Gatsby <https://www.gatsbyjs.org/>`_).
  * ``'redirect'`` - links to documents point to a Django view which will check the user's permission; if successful, it will redirect to the URL provided by the underlying storage to allow the document to be downloaded. This is most suitable for remote storage backends such as S3, as it allows the document to be served independently of the Django server. Note that if a user is able to guess the latter URL, they will be able to bypass the permission check; some storage backends may provide configuration options to generate a random or short-lived URL to mitigate this.
  * ``'serve_view'`` - links to documents point to a Django view which both checks the user's permission, and serves the document. Serving will be handled by `django-sendfile <https://github.com/johnsensible/django-sendfile>`_, if this is installed and supported by your server configuration, or as a streaming response from Django if not. When using this method, it is recommended that you configure your webserver to *disallow* serving documents directly from their location under ``MEDIA_ROOT``, as this would provide a way to bypass the permission check.
 

--- a/docs/reference/hooks.rst
+++ b/docs/reference/hooks.rst
@@ -868,4 +868,4 @@ Document serving
 ``before_serve_document``
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-  Called when Wagtail is about to serve a document. The callable passed into the hook will receive the document object and the request object. If the callable returns an ``HttpResponse``, that response will be returned immediately to the user, instead of serving the document.
+  Called when Wagtail is about to serve a document. The callable passed into the hook will receive the document object and the request object. If the callable returns an ``HttpResponse``, that response will be returned immediately to the user, instead of serving the document. Note that this hook will be skipped if the :ref:`WAGTAILDOCS_SERVE_METHOD <wagtaildocs_serve_method>` setting is set to ``direct``.

--- a/wagtail/documents/models.py
+++ b/wagtail/documents/models.py
@@ -116,6 +116,13 @@ class AbstractDocument(CollectionMember, index.Indexed, models.Model):
 
     @property
     def url(self):
+        if getattr(settings, 'WAGTAILDOCS_SERVE_METHOD', None) == 'direct':
+            try:
+                return self.file.url
+            except NotImplementedError:
+                # backend does not provide a url, so fall back on the serve view
+                pass
+
         return reverse('wagtaildocs_serve', args=[self.id, self.filename])
 
     def get_usage(self):


### PR DESCRIPTION
Implements the main part of #1420, based on earlier work from @tobiasmcnulty in #3772. Document serving can now be configured to:

1. use the underlying storage's URL directly (`WAGTAILDOCS_SERVE_METHOD = 'direct'`)
2. Have the Django view serve the document (the current behaviour, `WAGTAILDOCS_SERVE_METHOD = 'serve_view'`)
3. Have the Django view redirect to the storage's URL after running permission checks and other hooks/signals (`WAGTAILDOCS_SERVE_METHOD = 'redirect'`)

with 3 becoming the new default behaviour for remote backends such as S3. This is probably the desired behaviour for most people using those backends (so that documents are served to the user from that remote storage, rather than going through Django) but is a potentially breaking change and will need to be noted in release notes.