### PR TITLE
Feature - Make Promoted Search Results Orderable

### DIFF
--- a/wagtail/contrib/search_promotions/templates/wagtailsearchpromotions/list.html
+++ b/wagtail/contrib/search_promotions/templates/wagtailsearchpromotions/list.html
@@ -5,9 +5,23 @@
     <col />
     <thead>
         <tr>
-            <th class="title">{% trans "Search term(s)" %}</th>
+            <th class="title">
+                {% trans "Search term(s)" %}
+                {% if "query_string" in ordering %}
+                    <a href="{% url 'wagtailsearchpromotions:index' %}?ordering={% if '-' not in ordering %}-{% endif %}query_string" class="icon icon-arrow-{% if '-' in ordering %}up{% else %}down{% endif %}-after teal" title="{% if '-' in ordering %}{% trans 'Order by search term alphabetically' %}{% else %}{% trans 'Order by search term reverse alphabetically' %}{% endif %}"></a>
+                {% else %}
+                    <a href="{% url 'wagtailsearchpromotions:index' %}?ordering=query_string" class="icon icon-arrow-down-after" title="{% trans 'Order by search term alphabetically' %}"></a>
+                {% endif %}
+            </th>
             <th>{% trans "Promoted results" %}</th>
-            <th>{% trans "Views (past week)" %}</th>
+            <th>
+                {% trans "Views (past week)" %}
+                {% if "views" in ordering %}
+                    <a href="{% url 'wagtailsearchpromotions:index' %}?ordering={% if '-' not in ordering %}-{% endif %}views" class="icon icon-arrow-{% if '-' in ordering %}up{% else %}down{% endif %}-after teal" title="{% if '-' in ordering %}{% trans 'Order by views (lowest first)' %}{% else %}{% trans 'Order by views (highest first)' %}{% endif %}"></a>
+                {% else %}
+                    <a href="{% url 'wagtailsearchpromotions:index' %}?ordering=views" class="icon icon-arrow-down-after" title="{% trans 'Order by views (lowest first)' %}"></a>
+                {% endif %}
+            </th>
         </tr>
     </thead>
     <tbody>

--- a/wagtail/contrib/search_promotions/templates/wagtailsearchpromotions/list.html
+++ b/wagtail/contrib/search_promotions/templates/wagtailsearchpromotions/list.html
@@ -8,18 +8,18 @@
             <th class="title">
                 {% trans "Search term(s)" %}
                 {% if "query_string" in ordering %}
-                    <a href="{% url 'wagtailsearchpromotions:index' %}?ordering={% if '-' not in ordering %}-{% endif %}query_string" class="icon icon-arrow-{% if '-' in ordering %}up{% else %}down{% endif %}-after teal" title="{% if '-' in ordering %}{% trans 'Order by search term alphabetically' %}{% else %}{% trans 'Order by search term reverse alphabetically' %}{% endif %}"></a>
+                    <a href="{% url 'wagtailsearchpromotions:index' %}?ordering={% if '-' not in ordering %}-{% endif %}query_string" class="icon icon-arrow-{% if '-' in ordering %}up{% else %}down{% endif %}-after teal" aria-label="{% if '-' in ordering %}{% trans 'Order by search term alphabetically' %}{% else %}{% trans 'Order by search term reverse alphabetically' %}{% endif %}"></a>
                 {% else %}
-                    <a href="{% url 'wagtailsearchpromotions:index' %}?ordering=query_string" class="icon icon-arrow-down-after" title="{% trans 'Order by search term alphabetically' %}"></a>
+                    <a href="{% url 'wagtailsearchpromotions:index' %}?ordering=query_string" class="icon icon-arrow-down-after" aria-label="{% trans 'Order by search term alphabetically' %}"></a>
                 {% endif %}
             </th>
             <th>{% trans "Promoted results" %}</th>
             <th>
                 {% trans "Views (past week)" %}
                 {% if "views" in ordering %}
-                    <a href="{% url 'wagtailsearchpromotions:index' %}?ordering={% if '-' not in ordering %}-{% endif %}views" class="icon icon-arrow-{% if '-' in ordering %}up{% else %}down{% endif %}-after teal" title="{% if '-' in ordering %}{% trans 'Order by views (lowest first)' %}{% else %}{% trans 'Order by views (highest first)' %}{% endif %}"></a>
+                    <a href="{% url 'wagtailsearchpromotions:index' %}?ordering={% if '-' not in ordering %}-{% endif %}views" class="icon icon-arrow-{% if '-' in ordering %}up{% else %}down{% endif %}-after teal" aria-label="{% if '-' in ordering %}{% trans 'Order by views (lowest first)' %}{% else %}{% trans 'Order by views (highest first)' %}{% endif %}"></a>
                 {% else %}
-                    <a href="{% url 'wagtailsearchpromotions:index' %}?ordering=views" class="icon icon-arrow-down-after" title="{% trans 'Order by views (lowest first)' %}"></a>
+                    <a href="{% url 'wagtailsearchpromotions:index' %}?ordering=views" class="icon icon-arrow-down-after" aria-label="{% trans 'Order by views (lowest first)' %}"></a>
                 {% endif %}
             </th>
         </tr>


### PR DESCRIPTION
Extends the work done on #4614 
Closes #3897

Thanks @chrisranjana - really awesome stuff.

Just adds some tests, a bit of formatting in the Django template files and a bit of a reorganisation of how the ordering url args are handled in the view.

* Do the tests still pass? ✅ 
* Does the code comply with the style guide?  ✅ 
* For Python changes: Have you added tests to cover the new/fixed behaviour?  ✅ 
* For front-end changes: N/A
* For new features: Has the documentation been updated accordingly? N/A - pretty much expected behaviour and other similar pages are not documented in this way.
