### PR TITLE
increase font size accross admin, improve color contrast

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -15,6 +15,8 @@ Changelog
  * Use correct URL in API example in documentation (Michael Bunsen)
  * Move datetime widget initialiser JS into the widget's form media instead of page editor media (Matt Westcott)
  * Add form field prefixes for input forms in chooser modals (Matt Westcott)
+ * Increase font-size across the whole admin (Beth Menzies, Katie Locke)
+ * Improved text color contrast across the whole admin (Beth Menzies, Katie Locke)
  * Fix: ModelAdmin no longer fails when filtering over a foreign key relation (Jason Dilworth, Matt Westcott)
  * Fix: The Wagtail version number is now visible within the Settings menu (Kevin Howbrook)
  * Fix: Scaling images now rounds values to an integer so that images render without errors (Adrian Brunyate)
@@ -29,6 +31,7 @@ Changelog
  * Fix: Add empty alt attributes to all images in the CMS admin (Andreas Bernacca)
  * Fix: Make URL generator preview image alt translateable (Thibaud Colas)
  * Fix: Clear pending AJAX request if error occurs on page chooser (Matt Westcott)
+ * Fix: Prevent text from overlapping in focal point editing UI (Beth Menzies)
 
 
 2.5.1 (07.05.2019)

--- a/client/scss/components/_button.scss
+++ b/client/scss/components/_button.scss
@@ -222,7 +222,7 @@
     &.disabled {
         background-color: $color-grey-3;
         border-color: $color-grey-3;
-        color: lighten($color-grey-2, 15%);
+        color: $color-grey-2;
         cursor: default;
     }
 

--- a/client/scss/components/_header.scss
+++ b/client/scss/components/_header.scss
@@ -92,6 +92,10 @@ header {
         }
     }
 
+    .error-message {
+        color: inherit;
+    }
+
     .fields {
         margin-top: -0.5em;
 

--- a/client/scss/components/_help-block.scss
+++ b/client/scss/components/_help-block.scss
@@ -14,7 +14,7 @@
     }
 
     a {
-        color: $color-teal;
+        color: $color-link;
     }
 }
 

--- a/client/scss/components/_listing.scss
+++ b/client/scss/components/_listing.scss
@@ -44,7 +44,7 @@ ul.listing {
         border-bottom: 1px solid $color-grey-4;
 
         th {
-            font-size: 0.85em;
+            font-size: 0.9em;
             text-align: left;
             font-weight: normal;
             white-space: nowrap;
@@ -129,7 +129,7 @@ ul.listing {
             }
 
             .parent a {
-                color: $color-link-hover;
+                color: $color-white;
             }
 
             .status-tag {

--- a/client/scss/components/_messages.scss
+++ b/client/scss/components/_messages.scss
@@ -32,7 +32,7 @@
     }
 
     .error {
-        background-color: $color-red;
+        background-color: $color-red-dark;
 
         &:before {
             font-family: wagtail;
@@ -41,7 +41,7 @@
     }
 
     .warning {
-        background-color: $color-orange;
+        background-color: $color-orange-dark;
 
         &:before {
             font-family: wagtail;
@@ -50,7 +50,7 @@
     }
 
     .success {
-        background-color: $color-green;
+        background-color: $color-green-dark;
 
         &:before {
             font-family: wagtail;
@@ -64,11 +64,10 @@
 
     .button-secondary {
         border-color: rgba(255, 255, 255, 0.5);
-        color: rgba(255, 255, 255, 0.8);
+        color: $color-white;
 
         &:hover {
             border-color: transparent;
-            color: $color-white;
         }
     }
 

--- a/client/scss/components/_messages.status.scss
+++ b/client/scss/components/_messages.status.scss
@@ -1,9 +1,9 @@
 .status-msg {
     &.success {
-        color: $color-green;
+        color: $color-green-dark;
     }
 
     &.failure {
-        color: $color-red;
+        color: $color-red-dark;
     }
 }

--- a/client/scss/elements/_forms.scss
+++ b/client/scss/elements/_forms.scss
@@ -40,6 +40,10 @@ label,
         display: inline;
     }
 
+    &.no-float {
+        float: none;
+    }
+
     @include media-breakpoint-up(sm) {
         @include column(2);
         padding-top: 1.2em;

--- a/client/scss/elements/_typography.scss
+++ b/client/scss/elements/_typography.scss
@@ -8,7 +8,7 @@
 body {
     -webkit-font-smoothing: antialiased; // Do not remove!
     font-family: Open Sans, Arial, sans-serif;
-    font-size: 80%;
+    font-size: 85%;
     line-height: 1.5em;
     color: $color-text-base;
 }
@@ -84,7 +84,7 @@ dl {
 }
 
 dt {
-    color: darken($color-grey-3, 15%);
+    color: $color-grey-2;
     text-transform: uppercase;
     font-size: 0.9em;
 }

--- a/client/scss/settings/_variables.scss
+++ b/client/scss/settings/_variables.scss
@@ -34,8 +34,11 @@ $color-teal-dark: darken(adjust-hue($color-teal, 1), 7);
 
 $color-blue: #71b2d4;
 $color-red: #cd3238;
+$color-red-dark: #b4191f;
 $color-orange: #e9b04d;
+$color-orange-dark: #bb5b03;
 $color-green: #189370;
+$color-green-dark: #157b57;
 $color-salmon: #f37e77;
 $color-salmon-light: #fcf2f2;
 $color-white: #fff;
@@ -44,7 +47,6 @@ $color-black: #000;
 // darker to lighter
 $color-grey-1: darken($color-white, 80);
 $color-grey-2: darken($color-white, 70);
-
 $color-grey-3: darken($color-white, 15);
 $color-grey-4: darken($color-white, 10);
 $color-grey-5: darken($color-white, 2);
@@ -62,13 +64,13 @@ $color-input-error-bg: lighten(saturate($color-red, 28), 45);
 
 $color-button: $color-teal;
 $color-button-hover: $color-teal-darker;
-$color-button-yes: $color-green;
+$color-button-yes: $color-green-dark;
 $color-button-yes-hover: darken($color-button-yes, 8%);
-$color-button-no: $color-red;
+$color-button-no: $color-red-dark;
 $color-button-no-hover: darken($color-button-no, 20%);
-$color-button-warning: $color-orange;
-$color-button-warning-hover: darken($color-orange, 20%);
-$color-link: $color-teal;
+$color-button-warning: $color-orange-dark;
+$color-button-warning-hover: darken($color-button-warning, 20%);
+$color-link: $color-teal-darker;
 $color-link-hover: $color-teal-dark;
 
 $color-text-base: darken($color-white, 85);
@@ -86,7 +88,7 @@ $font-serif: Roboto Slab, Georgia, serif;
 
 // misc sizing
 $thumbnail-width: 130px;
-$menu-width: 180px;
+$menu-width: 200px;
 $menu-width-max: 320px;
 $mobile-nav-indent: 50px;
 

--- a/docs/releases/2.6.rst
+++ b/docs/releases/2.6.rst
@@ -24,6 +24,8 @@ Other features
  * Use correct URL in API example in documentation (Michael Bunsen)
  * Move datetime widget initialiser JS into the widget's form media instead of page editor media (Matt Westcott)
  * Add form field prefixes for input forms in chooser modals (Matt Westcott)
+ * Increase font-size across the whole admin (Beth Menzies, Katie Locke)
+ * Improved text color contrast across the whole admin (Beth Menzies, Katie Locke)
 
 Bug fixes
 ~~~~~~~~~
@@ -42,6 +44,7 @@ Bug fixes
  * Add empty alt attributes to all images in the CMS admin (Andreas Bernacca)
  * Make URL generator preview image alt translateable (Thibaud Colas)
  * Clear pending AJAX request if error occurs on page chooser (Matt Westcott)
+ * Prevent text from overlapping in focal point editing UI (Beth Menzies)
 
 
 Upgrade considerations

--- a/wagtail/contrib/styleguide/static_src/wagtailstyleguide/scss/styleguide.scss
+++ b/wagtail/contrib/styleguide/static_src/wagtailstyleguide/scss/styleguide.scss
@@ -67,6 +67,10 @@ section {
         color: $color-green;
     }
 
+    .color-green-dark-text {
+        color: $color-green-dark;
+    }
+
     .color-teal-darker-text {
         color: $color-teal-darker;
     }
@@ -83,12 +87,20 @@ section {
         color: $color-red;
     }
 
+    .color-red-dark-text {
+        color: $color-red-dark;
+    }
+
     .color-teal-text {
         color: $color-teal;
     }
 
     .color-orange-text {
         color: $color-orange;
+    }
+
+    .color-orange-dark-text {
+        color: $color-orange-dark;
     }
 
     .color-blue-text {
@@ -131,12 +143,24 @@ section {
         background-color: $color-red;
     }
 
+    .color-red-dark {
+        background-color: $color-red-dark;
+    }
+
     .color-orange {
         background-color: $color-orange;
     }
 
+    .color-orange-dark {
+        background-color: $color-orange-dark;
+    }
+
     .color-green {
         background-color: $color-green;
+    }
+
+    .color-green-dark {
+        background-color: $color-green-dark;
     }
 
     .color-blue {

--- a/wagtail/contrib/styleguide/templates/wagtailstyleguide/base.html
+++ b/wagtail/contrib/styleguide/templates/wagtailstyleguide/base.html
@@ -43,26 +43,28 @@
             <h2>Colour palette</h2>
 
             <ul>
-                <li class="color-teal">color-teal</li>
-                <li class="color-teal-darker">color-teal-darker</li>
-                <li class="color-teal-dark">color-teal-dark</li>
+                <li class="color-teal color-white-text">color-teal</li>
+                <li class="color-teal-darker color-white-text">color-teal-darker</li>
+                <li class="color-teal-dark color-white-text">color-teal-dark</li>
             </ul>
             <ul>
                 <li class="color-salmon">color-salmon</li>
                 <li class="color-salmon-light">color-salmon-light</li>
             </ul>
             <ul>
-                <li class="color-grey-1">color-grey-1</li>
-                <li class="color-grey-1-1">color-grey-1-1</li>
-                <li class="color-grey-2">color-grey-2</li>
+                <li class="color-grey-1 color-white-text">color-grey-1</li>
+                <li class="color-grey-2 color-white-text">color-grey-2</li>
                 <li class="color-grey-3">color-grey-3</li>
                 <li class="color-grey-4">color-grey-4</li>
                 <li class="color-grey-5">color-grey-5</li>
             </ul>
             <ul>
-                <li class="color-red">color-red</li>
+                <li class="color-red color-white-text">color-red</li>
+                <li class="color-red-dark color-white-text">color-red-dark</li>
                 <li class="color-orange">color-orange</li>
+                <li class="color-orange-dark">color-orange-dark</li>
                 <li class="color-green">color-green</li>
+                <li class="color-green-dark color-white-text">color-green-dark</li>
                 <li class="color-blue">color-blue</li>
             </ul>
         </section>
@@ -76,9 +78,7 @@
 
             <h3>Small text combinations: for font sizes 16px or smaller</h3>
             <ul class="contrast">
-                <li class="color-teal"><span class="color-black-text">color-black on color-teal</span></li>
-                <li class="color-teal"><span class="color-grey-1-text">color-grey-1 on color-teal</span></li>
-                <li class="color-teal-darker"><span class="color-black-text">color-black on color-teal-darker</span></li>
+                <li class="color-teal "><span class="color-white-text">color-white on color-teal</span></li>
                 <li class="color-teal-dark"><span class="color-white-text">color-white on color-teal-dark</span></li>
                 <li class="color-teal-dark"><span class="color-salmon-light-text">color-salmon-light on color-teal-dark</span></li>
             </ul>
@@ -92,7 +92,6 @@
                 <li class="color-salmon-light"><span class="color-grey-2-text">color-grey-2 on color-salmon-light</span></li>
             </ul>
             <ul class="contrast">
-                <li class="color-grey-1"><span class="color-teal-text">color-teal on color-grey-1</span></li>
                 <li class="color-grey-1"><span class="color-blue-text">color-blue on color-grey-1</span></li>
                 <li class="color-grey-1"><span class="color-orange-text">color-orange on color-grey-1</span></li>
                 <li class="color-grey-1"><span class="color-salmon-text">color-salmon on color-grey-1</span></li>
@@ -102,15 +101,6 @@
                 <li class="color-grey-1"><span class="color-grey-4-text">color-grey-4 on color-grey-1</span></li>
                 <li class="color-grey-1"><span class="color-grey-5-text">color-grey-5 on color-grey-1</span></li>
                 <li class="color-grey-1"><span class="color-menu-text">color-menu-text on color-grey-1</span></li>
-            </ul>
-            <ul class="contrast">
-                <li class="color-grey-1-1"><span class="color-orange-text">color-orange on color-grey-1-1</span></li>
-                <li class="color-grey-1-1"><span class="color-salmon-light-text">color-salmon-light on color-grey-1-1</span></li>
-                <li class="color-grey-1-1"><span class="color-white-text">color-white on color-grey-1-1</span></li>
-                <li class="color-grey-1-1"><span class="color-grey-3-text">color-grey-3 on color-grey-1-1</span></li>
-                <li class="color-grey-1-1"><span class="color-grey-4-text">color-grey-4 on color-grey-1-1</span></li>
-                <li class="color-grey-1-1"><span class="color-grey-5-text">color-grey-5 on color-grey-1-1</span></li>
-                <li class="color-grey-1-1"><span class="color-menu-text">color-menu-text on color-grey-1-1</span></li>
             </ul>
             <ul class="contrast">
                 <li class="color-grey-2"><span class="color-salmon-light-text">color-salmon on color-grey-2</span></li>
@@ -151,12 +141,8 @@
             <br>
             <h3>Large text combinations: for font sizes 18px or larger</h3>
             <ul class="contrast contrast-large">
-                <li class="color-teal"><span class="color-black-text">color-black on color-teal</span></li>
-                <li class="color-teal"><span class="color-grey-1-text">color-grey-1 on color-teal</span></li>
                 <li class="color-teal-darker"><span class="color-salmon-light-text">color-salmon-light on color-teal-darker</span></li>
                 <li class="color-teal-darker"><span class="color-white-text">color-white on color-teal-darker</span></li>
-                <li class="color-teal-darker"><span class="color-black-text">color-black on color-teal-darker</span></li>
-                <li class="color-teal-darker"><span class="color-grey-1-text">color-grey-1 on color-teal-darker</span></li>
                 <li class="color-teal-darker"><span class="color-grey-4-text">color-grey-4 on color-teal-darker</span></li>
                 <li class="color-teal-darker"><span class="color-grey-5-text">color-grey-5 on color-teal-darker</span></li>
                 <li class="color-teal-dark"><span class="color-white-text">color-white on color-teal-dark</span></li>
@@ -172,16 +158,12 @@
                 <li class="color-salmon-light"><span class="color-teal-darker-text">color-teal-darker on color-salmon-light</span></li>
                 <li class="color-salmon-light"><span class="color-teal-dark-text">color-teal-dark on color-salmon-light</span></li>
                 <li class="color-salmon-light"><span class="color-red-text">color-red on color-salmon-light</span></li>
-                <li class="color-salmon-light"><span class="color-green-text">color-green on color-salmon-light</span></li>
                 <li class="color-salmon-light"><span class="color-black-text">color-black on color-salmon-light</span></li>
                 <li class="color-salmon-light"><span class="color-grey-1-text">color-grey-1 on color-salmon-light</span></li>
                 <li class="color-salmon-light"><span class="color-grey-2-text">color-grey-2 on color-salmon-light</span></li>
             </ul>
             <ul class="contrast contrast-large">
-                <li class="color-grey-1"><span class="color-teal-text">color-teal on color-grey-1</span></li>
-                <li class="color-grey-1"><span class="color-teal-darker-text">color-teal-darker on color-grey-1</span></li>
                 <li class="color-grey-1"><span class="color-blue-text">color-blue on color-grey-1</span></li>
-                <li class="color-grey-1"><span class="color-green-text">color-green on color-grey-1</span></li>
                 <li class="color-grey-1"><span class="color-orange-text">color-orange on color-grey-1</span></li>
                 <li class="color-grey-1"><span class="color-salmon-text">color-salmon on color-grey-1</span></li>
                 <li class="color-grey-1"><span class="color-salmon-light-text">color-salmon-light on color-grey-1</span></li>
@@ -190,18 +172,6 @@
                 <li class="color-grey-1"><span class="color-grey-4-text">color-grey-4 on color-grey-1</span></li>
                 <li class="color-grey-1"><span class="color-grey-5-text">color-grey-5 on color-grey-1</span></li>
                 <li class="color-grey-1"><span class="color-menu-text">color-menu-text on color-grey-1</span></li>
-            </ul>
-            <ul class="contrast contrast-large">
-                <li class="color-grey-1-1"><span class="color-teal-text">color-teal on color-grey-1-1</span></li>
-                <li class="color-grey-1-1"><span class="color-blue-text">color-blue on color-grey-1-1</span></li>
-                <li class="color-grey-1-1"><span class="color-orange-text">color-orange on color-grey-1-1</span></li>
-                <li class="color-grey-1-1"><span class="color-salmon-text">color-salmon on color-grey-1-1</span></li>
-                <li class="color-grey-1-1"><span class="color-salmon-light-text">color-salmon-light on color-grey-1-1</span></li>
-                <li class="color-grey-1-1"><span class="color-white-text">color-white on color-grey-1-1</span></li>
-                <li class="color-grey-1-1"><span class="color-grey-3-text">color-grey-3 on color-grey-1-1</span></li>
-                <li class="color-grey-1-1"><span class="color-grey-4-text">color-grey-4 on color-grey-1-1</span></li>
-                <li class="color-grey-1-1"><span class="color-grey-5-text">color-grey-5 on color-grey-1-1</span></li>
-                <li class="color-grey-1-1"><span class="color-menu-text">color-menu-text on color-grey-1-1</span></li>
             </ul>
             <ul class="contrast contrast-large">
                 <li class="color-grey-2"><span class="color-salmon-light-text">color-salmon on color-grey-2</span></li>
@@ -213,7 +183,6 @@
             </ul>
             <ul class="contrast contrast-large">
                 <li class="color-grey-3"><span class="color-teal-dark-text">color-teal-dark on color-grey-3</span></li>
-                <li class="color-grey-3"><span class="color-red-text">color-red on color-grey-3</span></li>
                 <li class="color-grey-3"><span class="color-black-text">color-black on color-grey-3</span></li>
                 <li class="color-grey-3"><span class="color-grey-1-text">color-grey-1 on color-grey-3</span></li>
                 <li class="color-grey-3"><span class="color-grey-2-text">color-grey-2 on color-grey-3</span></li>
@@ -221,8 +190,6 @@
             <ul class="contrast contrast-large">
                 <li class="color-grey-4"><span class="color-teal-darker-text">color-teal-darker on color-grey-4</span></li>
                 <li class="color-grey-4"><span class="color-teal-dark-text">color-teal-dark on color-grey-4</span></li>
-                <li class="color-grey-4"><span class="color-red-text">color-red on color-grey-4</span></li>
-                <li class="color-grey-4"><span class="color-green-text">color-green on color-grey-4</span></li>
                 <li class="color-grey-4"><span class="color-black-text">color-black on color-grey-4</span></li>
                 <li class="color-grey-4"><span class="color-grey-1-text">color-grey-1 on color-grey-4</span></li>
                 <li class="color-grey-4"><span class="color-grey-2-text">color-grey-2 on color-grey-4</span></li>
@@ -231,35 +198,26 @@
                 <li class="color-grey-5"><span class="color-teal-darker-text">color-teal-darker on color-grey-5</span></li>
                 <li class="color-grey-5"><span class="color-teal-dark-text">color-teal-dark on color-grey-5</span></li>
                 <li class="color-grey-5"><span class="color-red-text">color-red on color-grey-5</span></li>
-                <li class="color-grey-5"><span class="color-green-text">color-green on color-grey-5</span></li>
                 <li class="color-grey-5"><span class="color-black-text">color-black on color-grey-5</span></li>
                 <li class="color-grey-5"><span class="color-grey-1-text">color-grey-1 on color-grey-5</span></li>
                 <li class="color-grey-5"><span class="color-grey-2-text">color-grey-2 on color-grey-5</span></li>
             </ul>
             <ul class="contrast contrast-large">
-                <li class="color-red"><span class="color-salmon-light-text">color-salmon-light on color-red</span></li>
-                <li class="color-red"><span class="color-white-text">color-white on color-red</span></li>
-                <li class="color-red"><span class="color-black-text">color-black on color-red</span></li>
-                <li class="color-red"><span class="color-grey-3-text">color-grey-3 on color-red</span></li>
-                <li class="color-red"><span class="color-grey-4-text">color-grey-4 on color-red</span></li>
-                <li class="color-red"><span class="color-grey-5-text">color-grey-5 on color-red</span></li>
-                <li class="color-red"><span class="color-menu-text">color-menu-text on color-red</span></li>
+                <li class="color-red-dark"><span class="color-salmon-light-text">color-salmon-light on color-red-dark</span></li>
+                <li class="color-red-dark"><span class="color-white-text">color-white on color-red-dark</span></li>
+                <li class="color-red-dark"><span class="color-grey-3-text">color-grey-3 on color-red-dark</span></li>
+                <li class="color-red-dark"><span class="color-grey-4-text">color-grey-4 on color-red-dark</span></li>
+                <li class="color-red-dark"><span class="color-grey-5-text">color-grey-5 on color-red-dark</span></li>
             </ul>
             <ul class="contrast contrast-large">
-                <li class="color-orange"><span class="color-teal-dark-text">color-teal-dark on color-orange</span></li>
-                <li class="color-orange"><span class="color-black-text">color-black on color-orange</span></li>
-                <li class="color-orange"><span class="color-grey-1-text">color-grey-1 on color-orange</span></li>
+                <li class="color-orange-dark"><span class="color-white-text">color-white on color-orange-dark</span></li>
+                <li class="color-orange-dark"><span class="color-black-text">color-black on color-orange-dark</span></li>
             </ul>
             <ul class="contrast contrast-large">
-                <li class="color-green"><span class="color-white-text">color-white on color-green</span></li>
-                <li class="color-green"><span class="color-salmon-light-text">color-salmon-light on color-green</span></li>
-                <li class="color-green"><span class="color-black-text">color-black on color-green</span></li>
-                <li class="color-green"><span class="color-grey-1-text">color-grey-1 on color-green</span></li>
-                <li class="color-green"><span class="color-grey-4-text">color-grey-4 on color-green</span></li>
-                <li class="color-green"><span class="color-grey-5-text">color-grey-5 on color-green</span></li>
+                <li class="color-green-dark"><span class="color-white-text">color-white on color-green-dark</span></li>
+                <li class="color-green-dark"><span class="color-salmon-light-text">color-salmon-light on color-green-dark</span></li>
             </ul>
             <ul class="contrast contrast-large">
-                <li class="color-blue"><span class="color-teal-dark-text">color-teal-dark on color-blue</span></li>
                 <li class="color-blue"><span class="color-black-text">color-black on color-blue</span></li>
                 <li class="color-blue"><span class="color-grey-1-text">color-grey-1 on color-blue</span></li>
             </ul>

--- a/wagtail/images/templates/wagtailimages/images/edit.html
+++ b/wagtail/images/templates/wagtailimages/images/edit.html
@@ -75,7 +75,7 @@
 
                 <div class="row">
                     <div class="col8 divider-after">
-                        <h2 class="label u-text-transform-uppercase">{% trans "Focal point" %} <span class="u-text-weight-normal">{% trans "(optional)" %}</span></h2>
+                        <h2 class="label no-float u-text-transform-uppercase">{% trans "Focal point" %} <span class="u-text-weight-normal">{% trans "(optional)" %}</span></h2>
                         <p>{% trans "To define this image's most important region, drag a box over the image above." %} {% if image.focal_point %}({% trans "Current focal point shown" %}){% endif %}</p>
 
                         <button class="button button-secondary no remove-focal-point" type="button">{% trans "Remove focal area" %}</button>


### PR DESCRIPTION
Fixes #5270.

- add new color-grey variable, adjust existing variables
- increase body font size to 85%
- add 20px to sidebar width
- adjust layout on image focal point label to avoid text overlap
- add new dark color variables and use for improved contrast on text

browser testing in progress now, but @thibaudcolas if you could take a look in the meantime I would appreciate it