### PR TITLE
Update squash user details to be more portable

### DIFF
--- a/.squash.yml
+++ b/.squash.yml
@@ -16,7 +16,7 @@ deployments:
       - wagtail start mysite
       - cd /myproject/mysite
       - python manage.py migrate
-      - echo "from django.contrib.auth import get_user_model; User = get_user_model(); User.objects.create_superuser('admin', 'admin@myproject.com', 'password')" | python manage.py shell    
+      - echo "from django.contrib.auth import get_user_model; User = get_user_model(); User.objects.create_superuser('admin', 'admin@example.com', 'changeme')" | python manage.py shell    
     launch_steps:
       - cd /myproject/mysite
       - python manage.py runserver 0.0.0.0:80


### PR DESCRIPTION
- Changes the user's email from `@myproject.com` to `@example.com`. myproject.com points to a real website, it feels better to use a domain that's definitely meant as a placeholder.
- Changes the password to `changeme`, matching the credentials used for https://github.com/wagtail/bakerydemo.