### PR TITLE
ImageRenditionField returns a relative URL

### DIFF
--- a/docs/advanced_topics/api/v2/configuration.rst
+++ b/docs/advanced_topics/api/v2/configuration.rst
@@ -238,7 +238,7 @@ This would add the following to the JSON:
             "height": 1125
         },
         "feed_image_thumbnail": {
-            "url": "http://www.example.com/media/images/a_test_image.fill-100x100.jpg",
+            "url": "/media/images/a_test_image.fill-100x100.jpg",
             "width": 100,
             "height": 100
         }


### PR DESCRIPTION
The example in the docs shows an absolute URL with the site's hostname, but the ImageRenditionField returns a relative URL. 

Relevant source can be found here: wagtail/images/api/fields.py