### PR TITLE
Add global tab-through focus outline styles

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -17,6 +17,7 @@ Changelog
  * Add form field prefixes for input forms in chooser modals (Matt Westcott)
  * Increase font-size across the whole admin (Beth Menzies, Katie Locke)
  * Improved text color contrast across the whole admin (Beth Menzies, Katie Locke)
+ * Added consistent focus outline styles across the whole admin (Thibaud Colas)
  * Fix: ModelAdmin no longer fails when filtering over a foreign key relation (Jason Dilworth, Matt Westcott)
  * Fix: The Wagtail version number is now visible within the Settings menu (Kevin Howbrook)
  * Fix: Scaling images now rounds values to an integer so that images render without errors (Adrian Brunyate)

--- a/client/scss/components/_button.scss
+++ b/client/scss/components/_button.scss
@@ -22,7 +22,6 @@
     white-space: nowrap;
     position: relative;
     overflow: hidden;
-    outline: none;
     box-sizing: border-box;
     -webkit-font-smoothing: auto;
     // stylelint-disable-next-line property-no-vendor-prefix
@@ -163,7 +162,6 @@
         white-space: nowrap;
         position: relative;
         overflow: hidden;
-        outline: none;
         box-sizing: border-box;
         -webkit-font-smoothing: auto;
         // stylelint-disable-next-line property-no-vendor-prefix

--- a/client/scss/components/_forms.scss
+++ b/client/scss/components/_forms.scss
@@ -51,7 +51,6 @@
 //     color: $color-text-input;
 //     font-size: 1.2em;
 //     font-weight: 300;
-//     outline: none;
 //
 //     &:hover {
 //         background-color: $color-white;
@@ -60,7 +59,6 @@
 //     &:focus {
 //         background-color: $color-input-focus;
 //         border-color: $color-input-focus-border;
-//         outline: none;
 //     }
 //
 //     &:disabled,
@@ -83,10 +81,6 @@ select::-ms-expand {
 .model_choice_field .input,
 .typed_choice_field .input {
     position: relative;
-
-    select {
-        outline: none;
-    }
 
     // Add select arrow back on browsers where native ui has been removed
     select ~ span:after {

--- a/client/scss/components/_listing.scss
+++ b/client/scss/components/_listing.scss
@@ -422,6 +422,8 @@ ul.listing {
 }
 
 .image-choice {
+    // Force the link to be displayed as a block, so its focus outline has the right shape.
+    display: block;
     color: inherit;
     overflow-wrap: break-word;
     word-wrap: break-word;

--- a/client/scss/components/_main-nav.scss
+++ b/client/scss/components/_main-nav.scss
@@ -119,6 +119,10 @@
     .account {
         display: none;
     }
+
+    *:focus {
+        @include show-focus-outline-inside;
+    }
 }
 
 .submenu-trigger:after {
@@ -311,7 +315,6 @@ body.explorer-open {
 
         .footer-submenu {
             @include transition(max-height 0.2s ease);
-            overflow: hidden;
             max-height: 0;
         }
 

--- a/client/scss/components/_main-nav.scss
+++ b/client/scss/components/_main-nav.scss
@@ -62,7 +62,6 @@
         // making the text semi-transparent
         &:hover,
         &:focus {
-            outline: none;
             background-color: $nav-item-hover-bg;
             color: $color-white;
             text-shadow: -1px -1px 0 rgba(0, 0, 0, 0.3);
@@ -333,7 +332,6 @@ body.explorer-open {
             cursor: pointer;
 
             &:hover {
-                outline: none;
                 background-color: rgba(100, 100, 100, 0.15);
                 color: $color-white;
                 text-shadow: -1px -1px 0 rgba(0, 0, 0, 0.3);

--- a/client/scss/components/_modals.scss
+++ b/client/scss/components/_modals.scss
@@ -58,7 +58,6 @@ $zindex-modal-background: 500;
     width: 98.7%;
     position: relative;
     background-color: $color-white;
-    outline: none;
     margin-top: 2em;
     padding-bottom: 3em;
     display: inline-block;

--- a/client/scss/components/_streamfield.scss
+++ b/client/scss/components/_streamfield.scss
@@ -252,7 +252,6 @@ li.sequence-member {
         z-index: 1;
         color: $color-grey-1;
         background-color: $color-white;
-        outline: none;
 
         span {
             @include visuallyhidden();
@@ -305,7 +304,6 @@ li.sequence-member {
         display: block;
         width: 100%;
         padding: 0 0 0.5em;
-        outline: $color-teal;
         overflow: visible;
 
         span {

--- a/client/scss/components/_tabs.scss
+++ b/client/scss/components/_tabs.scss
@@ -19,7 +19,6 @@
     a {
         @include transition(border-color 0.2s ease);
         background-color: $color-teal-darker;
-        outline: none;
         text-transform: uppercase;
         font-weight: 700;
         font-size: 1.2em;

--- a/client/scss/elements/_forms.scss
+++ b/client/scss/elements/_forms.scss
@@ -80,7 +80,6 @@ select,
     color: $color-text-input;
     font-size: 1.2em;
     font-weight: 300;
-    outline: none;
 
     &:hover {
         background-color: $color-white;
@@ -89,7 +88,6 @@ select,
     &:focus {
         background-color: $color-input-focus;
         border-color: $color-input-focus-border;
-        outline: none;
     }
 
     &:disabled,

--- a/client/scss/elements/_typography.scss
+++ b/client/scss/elements/_typography.scss
@@ -49,7 +49,6 @@ p {
 
 a {
     // @include transition(color 0.2s ease, background-color 0.2s ease);
-    outline: none;
     color: $color-link;
     text-decoration: none;
 

--- a/client/scss/overrides/_utilities.focus.scss
+++ b/client/scss/overrides/_utilities.focus.scss
@@ -1,0 +1,11 @@
+// stylelint-disable declaration-no-important
+// Set global focus outline styles so they are consistent across the UI,
+// without individual components having to explicitly define focus styles.
+// Using !important because we want to enforce only one style is used across the UI.
+.focus-outline-on *:focus {
+    outline: 3px solid $color-focus-outline !important;
+}
+
+.focus-outline-off *:focus {
+    outline: none !important;
+}

--- a/client/scss/overrides/_utilities.focus.scss
+++ b/client/scss/overrides/_utilities.focus.scss
@@ -3,7 +3,7 @@
 // without individual components having to explicitly define focus styles.
 // Using !important because we want to enforce only one style is used across the UI.
 .focus-outline-on *:focus {
-    outline: 3px solid $color-focus-outline !important;
+    outline: $focus-outline-width solid $color-focus-outline !important;
 }
 
 .focus-outline-off *:focus {

--- a/client/scss/settings/_variables.scss
+++ b/client/scss/settings/_variables.scss
@@ -70,8 +70,13 @@ $color-button-no: $color-red-dark;
 $color-button-no-hover: darken($color-button-no, 20%);
 $color-button-warning: $color-orange-dark;
 $color-button-warning-hover: darken($color-button-warning, 20%);
+
 $color-link: $color-teal-darker;
 $color-link-hover: $color-teal-dark;
+
+// The focus outline color is defined without reusing a named color variable
+// because it shouldn’t be reused for anything else in the UI.
+$color-focus-outline: #ffbf47;
 
 $color-text-base: darken($color-white, 85);
 $color-text-input: darken($color-white, 90);

--- a/client/scss/settings/_variables.scss
+++ b/client/scss/settings/_variables.scss
@@ -97,6 +97,8 @@ $menu-width: 200px;
 $menu-width-max: 320px;
 $mobile-nav-indent: 50px;
 
+$focus-outline-width: 3px;
+
 $nav-wrapper-inner-z-index: 26;
 $draftail-editor-z-index: $nav-wrapper-inner-z-index + 1;
 

--- a/client/scss/styles.scss
+++ b/client/scss/styles.scss
@@ -144,6 +144,7 @@ These are classes that provide overrides.
 @import 'overrides/utilities.hidden';
 @import 'overrides/utilities.text';
 @import 'overrides/utilities.dropdowns';
+@import 'overrides/utilities.focus';
 
 // Legacy utilities
 @import 'overrides/utilities.text.legacy';

--- a/client/scss/tools/_mixins.general.scss
+++ b/client/scss/tools/_mixins.general.scss
@@ -114,3 +114,9 @@
         @content;
     }
 }
+
+// Where included, show the focus outline within focusable items instead of around them.
+// This is useful when focusable items are tightly packed and there is no space in-between.
+@mixin show-focus-outline-inside {
+    outline-offset: -1 * $focus-outline-width;
+}

--- a/client/src/components/Draftail/blocks/MediaBlock.scss
+++ b/client/src/components/Draftail/blocks/MediaBlock.scss
@@ -5,10 +5,6 @@
     padding: 0;
     cursor: pointer;
 
-    &:focus {
-        outline: none;
-    }
-
     &__icon-wrapper {
         position: absolute;
         top: 0;

--- a/client/src/components/Explorer/Explorer.scss
+++ b/client/src/components/Explorer/Explorer.scss
@@ -29,6 +29,10 @@ $menu-footer-height: 50px;
         z-index: 500;
         left: $menu-width;
     }
+
+    *:focus {
+        @include show-focus-outline-inside;
+    }
 }
 
 .c-explorer {

--- a/client/src/components/Explorer/Explorer.scss
+++ b/client/src/components/Explorer/Explorer.scss
@@ -58,7 +58,6 @@ $menu-footer-height: 50px;
     &:focus {
         background-color: $c-explorer-bg-active;
         color: $color-white;
-        outline: none;
     }
 
     // Overrides for default link hover.
@@ -88,7 +87,6 @@ $menu-footer-height: 50px;
     &:focus {
         background-color: $c-explorer-bg-active;
         color: $color-white;
-        outline: none;
     }
 
     // Overrides for default link hover.
@@ -136,7 +134,6 @@ $menu-footer-height: 50px;
     &:focus {
         color: $c-explorer-secondary;
         background: $c-explorer-bg-active;
-        outline: none;
     }
 
     // Overrides for default link hover.

--- a/client/src/components/Explorer/ExplorerItem.scss
+++ b/client/src/components/Explorer/ExplorerItem.scss
@@ -14,7 +14,6 @@
     &:focus {
         background: $c-explorer-bg-active;
         color: $color-white;
-        outline: none;
     }
 
     // Overrides for default link hover.
@@ -60,7 +59,6 @@
     &:focus {
         background: $c-explorer-bg-active;
         color: $color-white;
-        outline: none;
     }
 
     // Overrides for default link hover.

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -13,6 +13,7 @@ import Explorer, {
   ExplorerToggle,
   initExplorer,
 } from './components/Explorer';
+import { initFocusOutline } from './utils/focus';
 
 export {
   Button,
@@ -24,4 +25,5 @@ export {
   Explorer,
   ExplorerToggle,
   initExplorer,
+  initFocusOutline,
 };

--- a/client/src/utils/focus.js
+++ b/client/src/utils/focus.js
@@ -1,0 +1,30 @@
+const OUTLINE_ON = 'focus-outline-on';
+const OUTLINE_OFF = 'focus-outline-off';
+
+const toggleFocusOutline = (isOn) => {
+  document.body.classList.toggle(OUTLINE_OFF, !isOn);
+  document.body.classList.toggle(OUTLINE_ON, isOn);
+};
+
+const removeFocusOutline = toggleFocusOutline.bind(null, false);
+const addFocusOutline = toggleFocusOutline.bind(null, true);
+
+/**
+ * Adds a heavy focus outline to the UI, only for users who tab through the page.
+ * The outline is not useful with touch or mouse input – these remove the outline.
+ */
+export const initFocusOutline = () => {
+  // Focus outline styles are added by default in the HTML, so they work without JS enabled.
+  removeFocusOutline();
+
+  window.addEventListener('mousedown', removeFocusOutline);
+  window.addEventListener('touchstart', removeFocusOutline);
+
+  window.addEventListener('keydown', e => {
+    const isTabKey = e.keyCode === 9;
+
+    if (isTabKey) {
+      addFocusOutline();
+    }
+  });
+};

--- a/client/src/utils/focus.test.js
+++ b/client/src/utils/focus.test.js
@@ -1,0 +1,48 @@
+import { initFocusOutline } from './focus';
+
+describe('initFocusOutline', () => {
+  beforeEach(() => {
+    document.body.classList.add('focus-outline-on');
+  });
+
+  it('removes styles on init', () => {
+    initFocusOutline();
+    expect(document.body.className).toBe('focus-outline-off');
+  });
+
+  it('adds styles when tabbing', () => {
+    initFocusOutline();
+    window.dispatchEvent(
+      Object.assign(new Event('keydown'), {
+        keyCode: 9
+      })
+    );
+    expect(document.body.className).toBe('focus-outline-on');
+  });
+
+  it('does not change styles when using keys that are not tab', () => {
+    initFocusOutline();
+    window.dispatchEvent(new Event('keydown'));
+    expect(document.body.className).toBe('focus-outline-off');
+  });
+
+  it('removes styles when using a mouse', () => {
+    window.dispatchEvent(
+      Object.assign(new Event('keydown'), {
+        keyCode: 9
+      })
+    );
+    window.dispatchEvent(new Event('mousedown'));
+    expect(document.body.className).toBe('focus-outline-off');
+  });
+
+  it('removes styles when using a touch screen', () => {
+    window.dispatchEvent(
+      Object.assign(new Event('keydown'), {
+        keyCode: 9
+      })
+    );
+    window.dispatchEvent(new Event('touchstart'));
+    expect(document.body.className).toBe('focus-outline-off');
+  });
+});

--- a/docs/contributing/developing.rst
+++ b/docs/contributing/developing.rst
@@ -174,6 +174,7 @@ IE 11 is gradually falling out of use, and specific features are unsupported in 
 
 * Rich text copy-paste in the rich text editor.
 * Sticky toolbar in the rich text editor.
+* Focus outline styles in the main menu & explorer menu.
 
 **Unsupported browsers / devices include:**
 

--- a/docs/releases/2.6.rst
+++ b/docs/releases/2.6.rst
@@ -26,6 +26,7 @@ Other features
  * Add form field prefixes for input forms in chooser modals (Matt Westcott)
  * Increase font-size across the whole admin (Beth Menzies, Katie Locke)
  * Improved text color contrast across the whole admin (Beth Menzies, Katie Locke)
+ * Added consistent focus outline styles across the whole admin (Thibaud Colas)
 
 Bug fixes
 ~~~~~~~~~

--- a/wagtail/admin/static_src/wagtailadmin/app/wagtailadmin.entry.js
+++ b/wagtail/admin/static_src/wagtailadmin/app/wagtailadmin.entry.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { initExplorer, Icon, Portal } from 'wagtail-client';
+import { initExplorer, Icon, Portal, initFocusOutline } from 'wagtail-client';
 
 if (process.env.NODE_ENV === 'development') {
   // Run react-axe in development only, so it does not affect performance
@@ -26,4 +26,6 @@ document.addEventListener('DOMContentLoaded', () => {
   if (explorerNode && toggleNode) {
     initExplorer(explorerNode, toggleNode);
   }
+
+  initFocusOutline();
 });

--- a/wagtail/admin/templates/wagtailadmin/skeleton.html
+++ b/wagtail/admin/templates/wagtailadmin/skeleton.html
@@ -18,7 +18,7 @@
 
     {% block branding_favicon %}{% endblock %}
 </head>
-<body id="wagtail" class="{% block bodyclass %}{% endblock %} {% if messages %}has-messages{% endif %}">
+<body id="wagtail" class="{% block bodyclass %}{% endblock %} {% if messages %}has-messages{% endif %} focus-outline-on">
     <!--[if lt IE 9]>
         <p class="capabilitymessage">{% blocktrans %}You are using an <strong>outdated</strong> browser not supported by this software. Please <a href="http://browsehappy.com/">upgrade your browser</a>.{% endblocktrans %}</p>
     <![endif]-->

--- a/wagtail/contrib/modeladmin/static_src/wagtailmodeladmin/scss/index.scss
+++ b/wagtail/contrib/modeladmin/static_src/wagtailmodeladmin/scss/index.scss
@@ -84,7 +84,6 @@
         text-transform: uppercase;
         position: relative;
         overflow: hidden;
-        outline: none;
         box-sizing: border-box;
         -webkit-font-smoothing: auto;
         // stylelint-disable-next-line property-no-vendor-prefix


### PR DESCRIPTION
At the moment, the admin interface has different focus styles across its UI. Generally, those styles are quite subtle, and don't make for a good experience if the user is tabbing through a fair amount of the UI (for example the main menu).

This PR adds focus outline styles that are global, applied to all of the UI admin-wide. Those global styles only define an outline, so are only meant when tabbing through the UI, and are disabled for mouse users (who don't use tabbing, and for whom the heavy outlines might be more distracting than anything). Focus styles on form fields being interacted with are still relevant.

Here is what tabbing through the dashboard page looks like before this change:

![focus-styles-before](https://user-images.githubusercontent.com/877585/58193464-f3597c00-7cba-11e9-9a33-6c89779fac99.gif)

And with the new styles (old screencap, I since improved the styles for the main menu):

![focus-styles-after](https://user-images.githubusercontent.com/877585/58193583-3c113500-7cbb-11e9-8156-80d2f9a4dca4.gif)

---

For the choice of colour, @Katielocke3 and I tried to go for something that works well across the colour variations used in Wagtail. This yellow shade works quite well with the teal button, but also the green and red ones.

Here is a sample of me tabbing through the styleguide for reference:

![focus-styles-tab-through](https://user-images.githubusercontent.com/877585/58193675-711d8780-7cbb-11e9-8d20-b5c484f78bc1.gif)

