### PR TITLE
Added CI config to generate nightly builds from master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,9 +47,34 @@ jobs:
       - run: npm run dist
       - run: bash <(curl -s https://codecov.io/bash) -F frontend
 
+  nightly-build:
+    docker:
+      - image: circleci/python:3.7.3
+    steps:
+      - checkout
+      - run: cd ~ && wget https://nodejs.org/dist/v8.7.0/node-v8.7.0-linux-x64.tar.gz
+      - run: cd /usr/local/ && sudo tar --strip-components 1 -xzf ~/node-v8.7.0-linux-x64.tar.gz
+      - run: pip install wheel boto3
+      - run: npm install
+      - run: npm run dist
+      - run: PYTHONPATH=. python scripts/nightly/get_version.py > wagtail/__init__.py
+      - run: python setup.py bdist_wheel
+      - run: python cripts/nightly/upload.py
+
 workflows:
     version: 2
     test:
-        jobs:
-          - backend
-          - frontend
+      jobs:
+        - backend
+        - frontend
+
+    nightly:
+      jobs:
+        - nightly-build
+      triggers:
+        - schedule:
+            cron: "0 0 * * *"
+            filters:
+              branches:
+                only:
+                  - master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ jobs:
       - run: npm run dist
       - run: PYTHONPATH=. python scripts/nightly/get_version.py > wagtail/__init__.py
       - run: python setup.py bdist_wheel
-      - run: python cripts/nightly/upload.py
+      - run: python scripts/nightly/upload.py
 
 workflows:
     version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,8 @@ jobs:
       - run: pip install wheel boto3
       - run: npm install
       - run: npm run dist
-      - run: PYTHONPATH=. python scripts/nightly/get_version.py > wagtail/__init__.py
+      - run: PYTHONPATH=. python scripts/nightly/get_version.py > __init__.py
+      - run: mv __init__.py wagtail/__init__.py
       - run: python setup.py bdist_wheel
       - run: python scripts/nightly/upload.py
 

--- a/scripts/nightly/get_version.py
+++ b/scripts/nightly/get_version.py
@@ -1,0 +1,31 @@
+"""
+This script is called by the nightly build in Circle CI.
+
+It alters the version of Wagtail to include the build date
+"""
+
+import datetime
+
+from wagtail import VERSION
+
+
+INIT_TEMPLATE = """
+from wagtail.utils.version import get_semver_version, get_version
+
+# major.minor.patch.release.number
+# release must be one of alpha, beta, rc, or final
+VERSION = ({major}, {minor}, {patch}, 'dev', '{datestamp}')
+
+__version__ = get_version(VERSION)
+
+# Required for npm package for frontend
+__semver__ = get_semver_version(VERSION)
+"""
+
+
+print(INIT_TEMPLATE.format(
+    major=VERSION[0],
+    minor=VERSION[1],
+    patch=VERSION[2],
+    datestamp=datetime.date.today().strftime('%Y%m%d'),
+))

--- a/scripts/nightly/upload.py
+++ b/scripts/nightly/upload.py
@@ -1,0 +1,24 @@
+import datetime
+import pathlib
+import sys
+import json
+
+import boto3
+
+dist_folder = pathlib.Path.cwd() / 'dist'
+
+try:
+    f = next(dist_folder.glob('*.whl'))
+except StopIteration:
+    print("No .whl files found in ./dist!")
+    sys.exit()
+
+print("Uploading", f.name)
+s3 = boto3.client('s3')
+s3.upload_file(str(f), 'releases.wagtail.io', 'nightly/' + f.name, ExtraArgs={'ACL':'public-read'})
+
+print("Updating latest.json")
+
+boto3.resource('s3').Object('releases.wagtail.io', 'nightly/latest.json').put(Body=json.dumps({
+    "url": 'https://releases.wagtail.io/nightly/' + f.name,
+}))

--- a/wagtail/__init__.py
+++ b/wagtail/__init__.py
@@ -1,3 +1,6 @@
+# PLEASE NOTE: If you edit this file, please also update scripts/nightly/get_version.py as well
+# as that needs to generate a new version of this file from a template for nightly builds
+
 from wagtail.utils.version import get_semver_version, get_version
 
 # major.minor.patch.release.number

--- a/wagtail/utils/version.py
+++ b/wagtail/utils/version.py
@@ -3,26 +3,43 @@
 
 
 def get_version(version):
-    "Returns a PEP 386-compliant version number from VERSION."
+    """Return a PEP 440-compliant version number from VERSION."""
+    version = get_complete_version(version)
+
     # Now build the two parts of the version number:
     # main = X.Y[.Z]
     # sub = .devN - for pre-alpha releases
-    #     | {a|b|c}N - for alpha, beta and rc releases
+    #     | {a|b|rc}N - for alpha, beta, and rc releases
 
     main = get_main_version(version)
 
     sub = ''
     if version[3] != 'final':
-        mapping = {'alpha': 'a', 'beta': 'b', 'rc': 'c'}
+        mapping = {'alpha': 'a', 'beta': 'b', 'rc': 'rc', 'dev': '.dev'}
         sub = mapping[version[3]] + str(version[4])
 
     return main + sub
 
 
-def get_main_version(version):
-    "Returns main version (X.Y[.Z]) from VERSION."
+def get_main_version(version=None):
+    """Return main version (X.Y[.Z]) from VERSION."""
+    version = get_complete_version(version)
     parts = 2 if version[2] == 0 else 3
     return '.'.join(str(x) for x in version[:parts])
+
+
+def get_complete_version(version=None):
+    """
+    Return a tuple of the Wagtail version. If version argument is non-empty,
+    check for correctness of the tuple provided.
+    """
+    if version is None:
+        from wagtail import VERSION as version
+    else:
+        assert len(version) == 5
+        assert version[3] in ('dev', 'alpha', 'beta', 'rc', 'final')
+
+    return version
 
 
 def get_semver_version(version):


### PR DESCRIPTION
This adds CI config to generate a wheel file each night (12am UTC) and upload it to a public S3 bucket. This should make it easier for developers to try out the latest master without having to make a build of Wagtail.