### PR TITLE
Improve focus outline styles for specific elements

### DIFF
--- a/client/scss/components/_breadcrumb.scss
+++ b/client/scss/components/_breadcrumb.scss
@@ -15,8 +15,7 @@
         white-space: nowrap;
         line-height: 1.5em;
 
-        a,
-        span {
+        a {
             color: $color-white;
             display: block;
             max-width: 12em;
@@ -73,7 +72,7 @@
         }
     }
 
-    header &  li {
+    header & li {
         &:before {
             border-left: 1em solid $color-white;
             position: absolute;
@@ -96,13 +95,8 @@
         margin-left: -($desktop-nice-padding);
         margin-right: -($desktop-nice-padding);
 
-        li {
-            a,
-            span {
-                &:after {
-                    color: $color-teal;
-                }
-            }
+        li a &:after {
+            color: $color-teal;
         }
     }
 }

--- a/client/scss/components/_breadcrumb.scss
+++ b/client/scss/components/_breadcrumb.scss
@@ -6,7 +6,9 @@
     padding-top: 1.4em;
     font-size: 0.85em;
 
-    *, *::before, *::after {
+    *,
+    *::before,
+    *::after {
         box-sizing: inherit;
     }
 
@@ -29,7 +31,6 @@
             overflow: hidden;
             line-height: 1.6em;
             padding-right: 2em;
-            margin: 3px 0;
 
             &:after {
                 right: 0;

--- a/client/scss/components/_breadcrumb.scss
+++ b/client/scss/components/_breadcrumb.scss
@@ -29,6 +29,7 @@
             overflow: hidden;
             line-height: 1.6em;
             padding-right: 2em;
+            margin: 3px 0;
 
             &:after {
                 right: 0;

--- a/client/scss/components/_breadcrumb.scss
+++ b/client/scss/components/_breadcrumb.scss
@@ -2,78 +2,73 @@
     @include unlist();
     @include clearfix();
     overflow: hidden;
+    box-sizing: border-box;
     padding-top: 1.4em;
     font-size: 0.85em;
+
+    *, *::before, *::after {
+        box-sizing: inherit;
+    }
 
     li {
         display: block;
         float: left;
-        padding: 0.5em 1.3em;
         position: relative;
         text-decoration: none;
-        color: $color-white;
         white-space: nowrap;
         line-height: 1.5em;
 
         a {
+            @include show-focus-outline-inside;
+            padding: 0.5em 1.3em;
             color: $color-white;
             display: block;
-            max-width: 12em;
+            max-width: 16em;
             white-space: nowrap;
             text-overflow: ellipsis;
             overflow: hidden;
             line-height: 1.6em;
-            padding-right: 1em;
+            padding-right: 2em;
 
             &:after {
                 right: 0;
-                // z-index: 5;
                 position: absolute;
                 font-family: wagtail;
                 content: map-get($icons, 'arrow-right');
-                padding-left: 20px;
+                width: 20px;
                 font-size: 2em;
                 color: $color-teal-darker;
                 line-height: 0.9em;
             }
-        }
 
-        &:hover {
-            background: $color-teal-dark;
-
-            a {
+            &:hover,
+            &:focus {
+                background: $color-teal-dark;
                 color: $color-white;
             }
-        }
 
-        &:hover:after {
-            border-left-color: $color-teal-dark;
+            &:after {
+                border-left-color: $color-teal-dark;
+            }
         }
 
         &.home {
             a {
                 // stylelint-disable max-nesting-depth
-                padding-right: 0;
-                text-align: center;
-                width: 3em;
+                width: 6em;
                 font-size: 1em;
-                text-overflow: clip;
 
-                &:before {
+                &::before {
                     font-size: 1.15rem;
                     line-height: 0.85em;
                     padding-top: 0.1em;
-                }
-
-                &:after {
-                    right: -0.3em;
                 }
             }
         }
     }
 
     header & li {
-        &:before {
+        &::before {
             border-left: 1em solid $color-white;
             position: absolute;
             left: 0;
@@ -95,8 +90,10 @@
         margin-left: -($desktop-nice-padding);
         margin-right: -($desktop-nice-padding);
 
-        li a &:after {
-            color: $color-teal;
+        li a {
+            &::after {
+                color: $color-teal;
+            }
         }
     }
 }

--- a/client/scss/elements/_forms.scss
+++ b/client/scss/elements/_forms.scss
@@ -135,27 +135,32 @@ input[type=checkbox] {
     border: 0;
 }
 
+$radio-size: 28px;
+
 input[type=radio] {
-    height: 12px;
-    width: auto;
+    box-sizing: border-box;
+    height: $radio-size;
+    width: $radio-size;
     position: relative;
-    margin-right: 27px;
+    top: -5px;
+    left: -2px;
+    margin-bottom: -16px;
+    background-color: transparent;
 }
 
 input[type=radio]:before {
+    box-sizing: border-box;
     border-radius: 100%;
     font-family: wagtail;
     font-style: normal;
     text-align: center;
     position: absolute;
-    top: -5px;
-    left: -2px;
     cursor: pointer;
     display: block;
     content: map-get($icons, 'radio-full');
-    width: 1em;
-    height: 1em;
-    line-height: 1.1em;
+    width: $radio-size;
+    height: $radio-size;
+    line-height: 18px;
     padding: 4px;
     background-color: $color-white;
     color: $color-grey-4;

--- a/client/scss/elements/_forms.scss
+++ b/client/scss/elements/_forms.scss
@@ -167,25 +167,28 @@ input[type=radio]:checked:before {
     color: $color-teal;
 }
 
+$checkbox-size: 22px;
+
 input[type=checkbox] {
-    height: 12px;
-    width: auto;
+    box-sizing: border-box;
+    height: $checkbox-size;
+    width: $checkbox-size;
     position: relative;
-    margin-right: 27px;
+    margin-right: 5px;
 }
 
 input[type=checkbox]:before {
+    box-sizing: border-box;
     font-family: wagtail;
     font-style: normal;
     text-align: center;
     position: absolute;
-    top: -5px;
     cursor: pointer;
     display: block;
     content: map-get($icons, 'tick');
-    line-height: 20px;
-    width: 20px;
-    height: 20px;
+    line-height: $checkbox-size;
+    width: $checkbox-size;
+    height: $checkbox-size;
     background-color: $color-white;
     border: 1px solid $color-grey-4;
     color: $color-white;

--- a/wagtail/admin/static_src/wagtailadmin/scss/layouts/login.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/layouts/login.scss
@@ -77,6 +77,11 @@ input[type=checkbox]:before {
         position: relative;
         padding: 0;
 
+        // Fix outline overflowing the elements' left side
+        @include media-breakpoint-up(sm) {
+            margin-left: -97px;
+        }
+
         label {
             display: none;
         }

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_list_explore.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_list_explore.html
@@ -66,5 +66,5 @@
 
 {% block no_results %}
     {% url 'wagtailadmin_pages:add_subpage' parent_page.id as add_page_url%}
-    <tr><td colspan="3" class="no-results-message"><p>{% trans "No pages have been created at this location." %}{% if parent_page and parent_page_perms.can_add_subpage %} {% blocktrans %}Why not <a href="{{ add_page_url }}">create one</a>?{% endblocktrans %}{% endif %}</p></td></tr>
+    <tr><td colspan="3" class="no-results-message"><p>{% trans "No pages have been created at this location." %}{% if parent_page and parent_page_perms.can_add_subpage %} {% blocktrans %}Why not <a href="{{ add_page_url }}">create one?</a>{% endblocktrans %}{% endif %}</p></td></tr>
 {% endblock %}

--- a/wagtail/snippets/templates/wagtailsnippets/chooser/results.html
+++ b/wagtail/snippets/templates/wagtailsnippets/chooser/results.html
@@ -18,6 +18,6 @@
          <p role="alert">{% blocktrans %}Sorry, no snippets match "<em>{{ query_string }}</em>"{% endblocktrans %}</p>
     {% else %}
         {% url 'wagtailsnippets:add' model_opts.app_label model_opts.model_name as wagtailsnippets_create_snippet_url %}
-        <p>{% blocktrans with snippet_type_name=model_opts.verbose_name %}You haven't created any {{ snippet_type_name }} snippets. Why not <a href="{{ wagtailsnippets_create_snippet_url }}" target="_blank" rel="noopener noreferrer">create one now</a>?{% endblocktrans %}</p>
+        <p>{% blocktrans with snippet_type_name=model_opts.verbose_name %}You haven't created any {{ snippet_type_name }} snippets. Why not <a href="{{ wagtailsnippets_create_snippet_url }}" target="_blank" rel="noopener noreferrer">create one now?</a>{% endblocktrans %}</p>
     {% endif %}
 {% endif %}


### PR DESCRIPTION
Follow-up to #5317. That PR added consistent focus styles for the whole admin, this PR tackles further improvements to specific components:

- [x] Breadcrumbs – make the whole "active" area actually active, and outline around whole area
- [x] Checkboxes – outline should be around whole checkbox
- [x] Radio button – outline should be around whole radio button, square
- [x] Full-width form fields on login & password reset pages
- Other suggestions welcome!
- [x] Fix focus states of links with punctuation
- [x] Cross-browser testing