### PR TITLE
deprecate SiteMiddleware

### DIFF
--- a/docs/advanced_topics/settings.rst
+++ b/docs/advanced_topics/settings.rst
@@ -37,15 +37,10 @@ Middleware (``settings.py``)
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django.middleware.security.SecurityMiddleware',
 
-    'wagtail.core.middleware.SiteMiddleware',
-
     'wagtail.contrib.redirects.middleware.RedirectMiddleware',
   ]
 
 Wagtail requires several common Django middleware modules to work and cover basic security. Wagtail provides its own middleware to cover these tasks:
-
-``SiteMiddleware``
-  Wagtail routes pre-defined hosts to pages within the Wagtail tree using this middleware.
 
 ``RedirectMiddleware``
   Wagtail provides a simple interface for adding arbitrary redirects to your site and this module makes it happen.
@@ -692,7 +687,6 @@ These two files should reside in your project directory (``myproject/myproject/`
       'django.middleware.clickjacking.XFrameOptionsMiddleware',
       'django.middleware.security.SecurityMiddleware',
 
-      'wagtail.core.middleware.SiteMiddleware',
       'wagtail.contrib.redirects.middleware.RedirectMiddleware',
   ]
 

--- a/docs/reference/pages/model_reference.rst
+++ b/docs/reference/pages/model_reference.rst
@@ -233,7 +233,9 @@ In addition to the model fields provided, ``Page`` has many properties and metho
 
 The ``Site`` model is useful for multi-site installations as it allows an administrator to configure which part of the tree to use for each hostname that the server responds on.
 
-This configuration is used by the :class:`~wagtail.core.middleware.SiteMiddleware` middleware class which checks each request against this configuration and appends the Site object to the Django request object.
+This configuration is used by the :class:`~wagtail.core.middleware.SiteMiddleware` middleware class which checks each request against this configuration and appends the Site object to the Django request object. (deprecated)
+
+As of wagtail 2.6 use the :meth:`~wagtail.core.models.Site.find_for_request` function to get the current wagtail Site. This function will check at the first call which Site to return for a given Django request object.
 
 Database fields
 ~~~~~~~~~~~~~~~

--- a/wagtail/admin/tests/test_admin_search.py
+++ b/wagtail/admin/tests/test_admin_search.py
@@ -3,7 +3,7 @@ Tests for the search box in the admin side menu, and the custom search hooks.
 """
 from django.contrib.auth.models import Permission
 from django.template import Context, Template
-from django.test import RequestFactory, TestCase
+from django.test import RequestFactory, TestCase, override_settings
 from django.urls import reverse
 
 from wagtail.admin.utils import user_has_any_page_permission
@@ -14,17 +14,23 @@ from wagtail.tests.utils import WagtailTestUtils
 class BaseSearchAreaTestCase(WagtailTestUtils, TestCase):
     rf = RequestFactory()
 
+    @override_settings(ALLOWED_HOSTS=['*'])
     def search_other(self, current_url='/admin/', data=None):
         request = self.rf.get(current_url, data=data)
         request.user = self.user
-        request.site = Site.objects.get()
+        site = Site.objects.get()
+        request.META['HTTP_HOST'] = site.hostname
+        request.META['SERVER_PORT'] = site.port
         template = Template("{% load wagtailadmin_tags %}{% search_other %}")
         return template.render(Context({'request': request}))
 
+    @override_settings(ALLOWED_HOSTS=['*'])
     def menu_search(self, current_url='/admin/', data=None):
         request = self.rf.get(current_url, data=data)
         request.user = self.user
-        request.site = Site.objects.get()
+        site = Site.objects.get()
+        request.META['HTTP_HOST'] = site.hostname
+        request.META['SERVER_PORT'] = site.port
         template = Template("{% load wagtailadmin_tags %}{% menu_search %}")
         return template.render(Context({'request': request}))
 

--- a/wagtail/admin/tests/test_admin_search.py
+++ b/wagtail/admin/tests/test_admin_search.py
@@ -3,34 +3,25 @@ Tests for the search box in the admin side menu, and the custom search hooks.
 """
 from django.contrib.auth.models import Permission
 from django.template import Context, Template
-from django.test import RequestFactory, TestCase, override_settings
+from django.test import RequestFactory, TestCase
 from django.urls import reverse
 
 from wagtail.admin.utils import user_has_any_page_permission
-from wagtail.core.models import Site
 from wagtail.tests.utils import WagtailTestUtils
 
 
 class BaseSearchAreaTestCase(WagtailTestUtils, TestCase):
     rf = RequestFactory()
 
-    @override_settings(ALLOWED_HOSTS=['*'])
     def search_other(self, current_url='/admin/', data=None):
         request = self.rf.get(current_url, data=data)
         request.user = self.user
-        site = Site.objects.get()
-        request.META['HTTP_HOST'] = site.hostname
-        request.META['SERVER_PORT'] = site.port
         template = Template("{% load wagtailadmin_tags %}{% search_other %}")
         return template.render(Context({'request': request}))
 
-    @override_settings(ALLOWED_HOSTS=['*'])
     def menu_search(self, current_url='/admin/', data=None):
         request = self.rf.get(current_url, data=data)
         request.user = self.user
-        site = Site.objects.get()
-        request.META['HTTP_HOST'] = site.hostname
-        request.META['SERVER_PORT'] = site.port
         template = Template("{% load wagtailadmin_tags %}{% menu_search %}")
         return template.render(Context({'request': request}))
 

--- a/wagtail/admin/tests/test_jinja2.py
+++ b/wagtail/admin/tests/test_jinja2.py
@@ -2,12 +2,11 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AnonymousUser
 from django.http import HttpRequest
 from django.template import engines
-from django.test import TestCase, override_settings
+from django.test import TestCase
 
 from wagtail.core.models import PAGE_TEMPLATE_VAR, Page, Site
 
 
-@override_settings(ALLOWED_HOSTS=['*'])
 class TestCoreJinja(TestCase):
 
     def setUp(self):

--- a/wagtail/admin/tests/test_jinja2.py
+++ b/wagtail/admin/tests/test_jinja2.py
@@ -1,11 +1,13 @@
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AnonymousUser
+from django.http import HttpRequest
 from django.template import engines
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 from wagtail.core.models import PAGE_TEMPLATE_VAR, Page, Site
 
 
+@override_settings(ALLOWED_HOSTS=['*'])
 class TestCoreJinja(TestCase):
 
     def setUp(self):
@@ -28,8 +30,9 @@ class TestCoreJinja(TestCase):
     def dummy_request(self, user=None):
         site = Site.objects.get(is_default_site=True)
 
-        request = self.client.get('/')
-        request.site = site
+        request = HttpRequest()
+        request.META['HTTP_HOST'] = site.hostname
+        request.META['SERVER_PORT'] = site.port
         request.user = user or AnonymousUser()
         return request
 

--- a/wagtail/admin/tests/test_pages_views.py
+++ b/wagtail/admin/tests/test_pages_views.py
@@ -5208,6 +5208,7 @@ class TestValidationErrorMessages(TestCase, WagtailTestUtils):
         # Error on title shown in the header message
         self.assertContains(response, "<li>Title: This field is required.</li>", count=1)
 
+
 @override_settings(ALLOWED_HOSTS=['*'])
 class TestDraftAccess(TestCase, WagtailTestUtils):
     """Tests for the draft view access restrictions."""
@@ -5267,6 +5268,7 @@ class TestDraftAccess(TestCase, WagtailTestUtils):
 
         # User can view
         self.assertEqual(response.status_code, 200)
+
 
 @override_settings(ALLOWED_HOSTS=['*'])
 class TestPreview(TestCase, WagtailTestUtils):

--- a/wagtail/admin/tests/test_pages_views.py
+++ b/wagtail/admin/tests/test_pages_views.py
@@ -572,6 +572,7 @@ class TestExplorablePageVisibility(TestCase, WagtailTestUtils):
         self.assertNotContains(response, """<li class="home"><a href="/admin/pages/4/" class="icon icon-home text-replace">Home</a></li>""")
 
 
+@override_settings(ALLOWED_HOSTS=['*'])
 class TestPageCreation(TestCase, WagtailTestUtils):
     def setUp(self):
         # Find root page
@@ -1884,6 +1885,7 @@ class TestPageEdit(TestCase, WagtailTestUtils):
         # Check that a form error was raised
         self.assertFormError(response, 'form', 'slug', "This slug is already in use")
 
+    @override_settings(ALLOWED_HOSTS=['*'])
     def test_preview_on_edit(self):
         post_data = {
             'title': "I've been edited!",
@@ -1953,7 +1955,6 @@ class TestPageEdit(TestCase, WagtailTestUtils):
         # Check that the correct site object has been selected by the site middleware
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, 'tests/simple_page.html')
-        self.assertEqual(response.context['request'].site.hostname, 'childpage.example.com')
 
     def test_editor_picks_up_direct_model_edits(self):
         # If a page has no draft edits, the editor should show the version from the live database
@@ -4150,6 +4151,7 @@ class TestChildRelationsOnSuperclass(TestCase, WagtailTestUtils):
         self.assertContains(response, "alwaysDirty: true")
 
 
+@override_settings(ALLOWED_HOSTS=['*'])
 class TestRevisions(TestCase, WagtailTestUtils):
     fixtures = ['test.json']
 
@@ -4547,6 +4549,7 @@ class TestRevisionsUnscheduleForUnpublishedPages(TestCase, WagtailTestUtils):
         self.assertIsNone(self.unpublished_event.revisions.get(id=self.unpublished_revision.id).approved_go_live_at)
 
 
+@override_settings(ALLOWED_HOSTS=['*'])
 class TestIssue2599(TestCase, WagtailTestUtils):
     """
     When previewing a page on creation, we need to assign it a path value consistent with its
@@ -5205,7 +5208,7 @@ class TestValidationErrorMessages(TestCase, WagtailTestUtils):
         # Error on title shown in the header message
         self.assertContains(response, "<li>Title: This field is required.</li>", count=1)
 
-
+@override_settings(ALLOWED_HOSTS=['*'])
 class TestDraftAccess(TestCase, WagtailTestUtils):
     """Tests for the draft view access restrictions."""
 
@@ -5226,6 +5229,8 @@ class TestDraftAccess(TestCase, WagtailTestUtils):
         user.user_permissions.add(
             Permission.objects.get(content_type__app_label='wagtailadmin', codename='access_admin')
         )
+
+        self.site = Site.objects.first()
 
     def test_draft_access_admin(self):
         """Test that admin can view draft."""
@@ -5263,7 +5268,7 @@ class TestDraftAccess(TestCase, WagtailTestUtils):
         # User can view
         self.assertEqual(response.status_code, 200)
 
-
+@override_settings(ALLOWED_HOSTS=['*'])
 class TestPreview(TestCase, WagtailTestUtils):
     fixtures = ['test.json']
 

--- a/wagtail/admin/tests/test_pages_views.py
+++ b/wagtail/admin/tests/test_pages_views.py
@@ -572,7 +572,6 @@ class TestExplorablePageVisibility(TestCase, WagtailTestUtils):
         self.assertNotContains(response, """<li class="home"><a href="/admin/pages/4/" class="icon icon-home text-replace">Home</a></li>""")
 
 
-@override_settings(ALLOWED_HOSTS=['*'])
 class TestPageCreation(TestCase, WagtailTestUtils):
     def setUp(self):
         # Find root page
@@ -1885,7 +1884,6 @@ class TestPageEdit(TestCase, WagtailTestUtils):
         # Check that a form error was raised
         self.assertFormError(response, 'form', 'slug', "This slug is already in use")
 
-    @override_settings(ALLOWED_HOSTS=['*'])
     def test_preview_on_edit(self):
         post_data = {
             'title': "I've been edited!",
@@ -4151,7 +4149,6 @@ class TestChildRelationsOnSuperclass(TestCase, WagtailTestUtils):
         self.assertContains(response, "alwaysDirty: true")
 
 
-@override_settings(ALLOWED_HOSTS=['*'])
 class TestRevisions(TestCase, WagtailTestUtils):
     fixtures = ['test.json']
 
@@ -4549,7 +4546,6 @@ class TestRevisionsUnscheduleForUnpublishedPages(TestCase, WagtailTestUtils):
         self.assertIsNone(self.unpublished_event.revisions.get(id=self.unpublished_revision.id).approved_go_live_at)
 
 
-@override_settings(ALLOWED_HOSTS=['*'])
 class TestIssue2599(TestCase, WagtailTestUtils):
     """
     When previewing a page on creation, we need to assign it a path value consistent with its
@@ -5209,7 +5205,6 @@ class TestValidationErrorMessages(TestCase, WagtailTestUtils):
         self.assertContains(response, "<li>Title: This field is required.</li>", count=1)
 
 
-@override_settings(ALLOWED_HOSTS=['*'])
 class TestDraftAccess(TestCase, WagtailTestUtils):
     """Tests for the draft view access restrictions."""
 
@@ -5270,7 +5265,6 @@ class TestDraftAccess(TestCase, WagtailTestUtils):
         self.assertEqual(response.status_code, 200)
 
 
-@override_settings(ALLOWED_HOSTS=['*'])
 class TestPreview(TestCase, WagtailTestUtils):
     fixtures = ['test.json']
 

--- a/wagtail/admin/tests/test_userbar.py
+++ b/wagtail/admin/tests/test_userbar.py
@@ -1,7 +1,7 @@
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AnonymousUser
 from django.template import Context, Template
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.test.client import RequestFactory
 from django.urls import reverse
 
@@ -10,8 +10,10 @@ from wagtail.tests.testapp.models import BusinessChild, BusinessIndex
 from wagtail.tests.utils import WagtailTestUtils
 
 
+@override_settings(ALLOWED_HOSTS=['*'])
 class TestUserbarTag(TestCase):
     def setUp(self):
+
         self.user = get_user_model().objects.create_superuser(
             username='test',
             email='test@email.com',
@@ -22,8 +24,11 @@ class TestUserbarTag(TestCase):
     def dummy_request(self, user=None):
         request = RequestFactory().get('/')
         request.user = user or AnonymousUser()
-        request.site = Site.objects.first()
+        site = Site.objects.first()
+        request.META['HTTP_HOST'] = site.hostname
+        request.META['SERVER_PORT'] = site.port
         return request
+
 
     def test_userbar_tag(self):
         template = Template("{% load wagtailuserbar %}{% wagtailuserbar %}")
@@ -64,6 +69,7 @@ class TestUserbarTag(TestCase):
         self.assertEqual(content, '')
 
 
+@override_settings(ALLOWED_HOSTS=['*'])
 class TestUserbarFrontend(TestCase, WagtailTestUtils):
     def setUp(self):
         self.login()
@@ -85,6 +91,7 @@ class TestUserbarFrontend(TestCase, WagtailTestUtils):
         self.assertEqual(response.status_code, 403)
 
 
+@override_settings(ALLOWED_HOSTS=['*'])
 class TestUserbarAddLink(TestCase, WagtailTestUtils):
     fixtures = ['test.json']
 
@@ -118,6 +125,7 @@ class TestUserbarAddLink(TestCase, WagtailTestUtils):
         self.assertNotContains(response, expected_link)
 
 
+@override_settings(ALLOWED_HOSTS=['*'])
 class TestUserbarModeration(TestCase, WagtailTestUtils):
     def setUp(self):
         self.login()

--- a/wagtail/admin/tests/test_userbar.py
+++ b/wagtail/admin/tests/test_userbar.py
@@ -1,16 +1,15 @@
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AnonymousUser
 from django.template import Context, Template
-from django.test import TestCase, override_settings
+from django.test import TestCase
 from django.test.client import RequestFactory
 from django.urls import reverse
 
-from wagtail.core.models import PAGE_TEMPLATE_VAR, Page, Site
+from wagtail.core.models import PAGE_TEMPLATE_VAR, Page
 from wagtail.tests.testapp.models import BusinessChild, BusinessIndex
 from wagtail.tests.utils import WagtailTestUtils
 
 
-@override_settings(ALLOWED_HOSTS=['*'])
 class TestUserbarTag(TestCase):
     def setUp(self):
 
@@ -24,9 +23,6 @@ class TestUserbarTag(TestCase):
     def dummy_request(self, user=None):
         request = RequestFactory().get('/')
         request.user = user or AnonymousUser()
-        site = Site.objects.first()
-        request.META['HTTP_HOST'] = site.hostname
-        request.META['SERVER_PORT'] = site.port
         return request
 
 
@@ -69,7 +65,6 @@ class TestUserbarTag(TestCase):
         self.assertEqual(content, '')
 
 
-@override_settings(ALLOWED_HOSTS=['*'])
 class TestUserbarFrontend(TestCase, WagtailTestUtils):
     def setUp(self):
         self.login()
@@ -91,7 +86,6 @@ class TestUserbarFrontend(TestCase, WagtailTestUtils):
         self.assertEqual(response.status_code, 403)
 
 
-@override_settings(ALLOWED_HOSTS=['*'])
 class TestUserbarAddLink(TestCase, WagtailTestUtils):
     fixtures = ['test.json']
 
@@ -125,7 +119,6 @@ class TestUserbarAddLink(TestCase, WagtailTestUtils):
         self.assertNotContains(response, expected_link)
 
 
-@override_settings(ALLOWED_HOSTS=['*'])
 class TestUserbarModeration(TestCase, WagtailTestUtils):
     def setUp(self):
         self.login()

--- a/wagtail/api/v2/filters.py
+++ b/wagtail/api/v2/filters.py
@@ -4,7 +4,7 @@ from rest_framework.filters import BaseFilterBackend
 from taggit.managers import TaggableManager
 
 from wagtail.core import hooks
-from wagtail.core.models import Page, UserPagePermissionsProxy
+from wagtail.core.models import Page, UserPagePermissionsProxy, Site
 from wagtail.search.backends import get_search_backend
 from wagtail.search.backends.base import FilterFieldError, OrderByFieldError
 
@@ -167,10 +167,12 @@ class RestrictedChildOfFilter(ChildOfFilter):
     site to be specified.
     """
     def get_root_page(self, request):
-        return request.site.root_page
+        site = Site.find_for_request(request)
+        return site.root_page
 
     def get_page_by_id(self, request, page_id):
-        site_pages = pages_for_site(request.site)
+        site = Site.find_for_request(request)
+        site_pages = pages_for_site(site)
         return site_pages.get(id=page_id)
 
 
@@ -214,10 +216,12 @@ class RestrictedDescendantOfFilter(DescendantOfFilter):
     site to be specified.
     """
     def get_root_page(self, request):
-        return request.site.root_page
+        site = Site.find_for_request(request)
+        return site.root_page
 
     def get_page_by_id(self, request, page_id):
-        site_pages = pages_for_site(request.site)
+        site = Site.find_for_request(request)
+        site_pages = pages_for_site(site)
         return site_pages.get(id=page_id)
 
 

--- a/wagtail/api/v2/filters.py
+++ b/wagtail/api/v2/filters.py
@@ -4,7 +4,7 @@ from rest_framework.filters import BaseFilterBackend
 from taggit.managers import TaggableManager
 
 from wagtail.core import hooks
-from wagtail.core.models import Page, UserPagePermissionsProxy, Site
+from wagtail.core.models import Page, Site, UserPagePermissionsProxy
 from wagtail.search.backends import get_search_backend
 from wagtail.search.backends.base import FilterFieldError, OrderByFieldError
 

--- a/wagtail/api/v2/serializers.py
+++ b/wagtail/api/v2/serializers.py
@@ -7,6 +7,7 @@ from rest_framework.fields import Field, SkipField
 from taggit.managers import _TaggableManager
 
 from wagtail.core import fields as wagtailcore_fields
+from wagtail.core.models import Site
 
 from .utils import get_object_detail_url, pages_for_site
 
@@ -121,7 +122,8 @@ class PageParentField(relations.RelatedField):
     def get_attribute(self, instance):
         parent = instance.get_parent()
 
-        site_pages = pages_for_site(self.context['request'].site)
+        site = Site.find_for_request(self.context['request'])
+        site_pages = pages_for_site(site)
         if site_pages.filter(id=parent.id).exists():
             return parent
 

--- a/wagtail/api/v2/utils.py
+++ b/wagtail/api/v2/utils.py
@@ -2,7 +2,7 @@ from urllib.parse import urlparse
 
 from django.conf import settings
 
-from wagtail.core.models import Page
+from wagtail.core.models import Page, Site
 from wagtail.core.utils import resolve_model_string
 
 
@@ -11,7 +11,8 @@ class BadRequestError(Exception):
 
 
 def get_base_url(request=None):
-    base_url = getattr(settings, 'WAGTAILAPI_BASE_URL', request.site.root_url if request and request.site else None)
+    site = Site.find_for_request(request) if request else None
+    base_url = getattr(settings, 'WAGTAILAPI_BASE_URL', site.root_url if site else None)
 
     if base_url:
         # We only want the scheme and netloc

--- a/wagtail/contrib/redirects/middleware.py
+++ b/wagtail/contrib/redirects/middleware.py
@@ -5,17 +5,19 @@ from django.utils.deprecation import MiddlewareMixin
 from django.utils.encoding import uri_to_iri
 
 from wagtail.contrib.redirects import models
+from wagtail.core.models import Site
 
 
 def _get_redirect(request, path):
     if '\0' in path:  # reject URLs with null characters, which crash on Postgres (#4496)
         return None
 
+    site = Site.find_for_request(request)
     try:
-        return models.Redirect.get_for_site(request.site).get(old_path=path)
+        return models.Redirect.get_for_site(site).get(old_path=path)
     except models.Redirect.MultipleObjectsReturned:
         # We have a site-specific and a site-ambivalent redirect; prefer the specific one
-        return models.Redirect.objects.get(site=request.site, old_path=path)
+        return models.Redirect.objects.get(site=site, old_path=path)
     except models.Redirect.DoesNotExist:
         return None
 
@@ -37,8 +39,8 @@ class RedirectMiddleware(MiddlewareMixin):
 
         # If a middleware before `SiteMiddleware` returned a response the
         # `site` attribute was never set, ref #2120
-        if not hasattr(request, 'site'):
-            return response
+        #if not hasattr(request, 'site'):
+        #    return response
 
         # Get the path
         path = models.Redirect.normalise_path(request.get_full_path())

--- a/wagtail/contrib/redirects/middleware.py
+++ b/wagtail/contrib/redirects/middleware.py
@@ -37,11 +37,6 @@ class RedirectMiddleware(MiddlewareMixin):
         if response.status_code != 404:
             return response
 
-        # If a middleware before `SiteMiddleware` returned a response the
-        # `site` attribute was never set, ref #2120
-        #if not hasattr(request, 'site'):
-        #    return response
-
         # Get the path
         path = models.Redirect.normalise_path(request.get_full_path())
 

--- a/wagtail/contrib/routable_page/templatetags/wagtailroutablepage_tags.py
+++ b/wagtail/contrib/routable_page/templatetags/wagtailroutablepage_tags.py
@@ -1,4 +1,5 @@
 from django import template
+from wagtail.core.models import Site
 
 register = template.Library()
 
@@ -18,7 +19,8 @@ def routablepageurl(context, page, url_name, *args, **kwargs):
     positional arguments and keyword arguments.
     """
     request = context['request']
-    base_url = page.relative_url(request.site, request)
+    site = Site.find_for_request(request)
+    base_url = page.relative_url(site, request)
     routed_url = page.reverse_subpage(url_name, args=args, kwargs=kwargs)
     if not base_url.endswith('/'):
         base_url += '/'

--- a/wagtail/contrib/routable_page/tests.py
+++ b/wagtail/contrib/routable_page/tests.py
@@ -1,6 +1,6 @@
 from unittest import mock
 
-from django.test import RequestFactory, TestCase
+from django.test import RequestFactory, TestCase, override_settings
 from django.urls.exceptions import NoReverseMatch
 
 from wagtail.contrib.routable_page.templatetags.wagtailroutablepage_tags import routablepageurl
@@ -150,6 +150,8 @@ class TestRoutablePage(TestCase):
 
 
 class TestRoutablePageTemplateTag(TestCase):
+
+    @override_settings(ALLOWED_HOSTS=['*'])
     def setUp(self):
         self.home_page = Page.objects.get(id=2)
         self.routable_page = self.home_page.add_child(instance=RoutablePageTest(
@@ -159,7 +161,9 @@ class TestRoutablePageTemplateTag(TestCase):
 
         self.rf = RequestFactory()
         self.request = self.rf.get(self.routable_page.url)
-        self.request.site = Site.find_for_request(self.request)
+        site = Site.find_for_request(self.request)
+        self.request.META['HTTP_HOST'] = site.hostname
+        self.request.META['SERVER_PORT'] = site.port
         self.context = {'request': self.request}
 
     def test_templatetag_reverse_index_route(self):
@@ -252,6 +256,7 @@ class TestRoutablePageTemplateTagForSecondSiteAtSameRoot(TestCase):
         self.assertEqual(url, expected)
 
 
+@override_settings(ALLOWED_HOSTS=['*'])
 class TestRoutablePageTemplateTagForSecondSiteAtDifferentRoot(TestCase):
     """
     When multiple sites exist, relative URLs between such sites should include the domain portion
@@ -274,10 +279,11 @@ class TestRoutablePageTemplateTagForSecondSiteAtDifferentRoot(TestCase):
 
         self.rf = RequestFactory()
         self.request = self.rf.get(self.routable_page.url)
-        self.request.site = Site.find_for_request(self.request)
         self.context = {'request': self.request}
 
-        self.request.site = second_site
+        self.request.META['HTTP_HOST'] = second_site.hostname
+        self.request.META['SERVER_PORT'] = second_site.port
+
 
     def test_templatetag_reverse_index_route(self):
         url = routablepageurl(self.context, self.routable_page,

--- a/wagtail/contrib/routable_page/tests.py
+++ b/wagtail/contrib/routable_page/tests.py
@@ -151,7 +151,6 @@ class TestRoutablePage(TestCase):
 
 class TestRoutablePageTemplateTag(TestCase):
 
-    @override_settings(ALLOWED_HOSTS=['*'])
     def setUp(self):
         self.home_page = Page.objects.get(id=2)
         self.routable_page = self.home_page.add_child(instance=RoutablePageTest(
@@ -256,7 +255,7 @@ class TestRoutablePageTemplateTagForSecondSiteAtSameRoot(TestCase):
         self.assertEqual(url, expected)
 
 
-@override_settings(ALLOWED_HOSTS=['*'])
+@override_settings(ALLOWED_HOSTS=['events.local'])
 class TestRoutablePageTemplateTagForSecondSiteAtDifferentRoot(TestCase):
     """
     When multiple sites exist, relative URLs between such sites should include the domain portion

--- a/wagtail/contrib/settings/context_processors.py
+++ b/wagtail/contrib/settings/context_processors.py
@@ -1,3 +1,5 @@
+from wagtail.core.models import Site
+
 from .registry import registry
 
 
@@ -49,10 +51,10 @@ class SettingModuleProxy(dict):
 
 
 def settings(request):
-    site = getattr(request, 'site', None)
+    site = Site.find_for_request(request)
     if site is None:
-        # Can't assume SiteMiddleware already executed
-        # (e.g. middleware rendering a template before that)
+        # find_for_request() can't determine the site
+        # old SiteMiddleware case
         # Unittest or email templates might also mock request
         # objects that don't have a request.site.
         return {}

--- a/wagtail/contrib/settings/jinja2tags.py
+++ b/wagtail/contrib/settings/jinja2tags.py
@@ -60,7 +60,7 @@ def get_setting(context, model_string, use_default_site=False):
     if use_default_site:
         site = Site.objects.get(is_default_site=True)
     elif 'request' in context:
-        site = context['request'].site
+        site = Site.find_for_request(context['request'])
     else:
         raise RuntimeError('No request found in context, and use_default_site '
                            'flag not set')

--- a/wagtail/contrib/settings/templatetags/wagtailsettings_tags.py
+++ b/wagtail/contrib/settings/templatetags/wagtailsettings_tags.py
@@ -12,7 +12,7 @@ def get_settings(context, use_default_site=False):
     if use_default_site:
         site = Site.objects.get(is_default_site=True)
     elif 'request' in context:
-        site = context['request'].site
+        site = Site.find_for_request(context['request'])
     else:
         raise RuntimeError('No request found in context, and use_default_site '
                            'flag not set')

--- a/wagtail/contrib/settings/tests/test_templates.py
+++ b/wagtail/contrib/settings/tests/test_templates.py
@@ -30,7 +30,7 @@ class TemplateTestCase(TestCase, WagtailTestUtils):
     def get_request(self, site=None):
         if site is None:
             site = self.default_site
-        #request = self.client.get('/test/', HTTP_HOST=site.hostname)
+
         request = HttpRequest()
         request.META['HTTP_HOST'] = site.hostname
         request.META['SERVER_PORT'] = site.port
@@ -177,7 +177,6 @@ class TestSettingsJinja(TemplateTestCase):
             else:
                 site = Site.objects.get(is_default_site=True)
 
-            #request = self.client.get('/test/', HTTP_HOST=site.hostname)
             request = HttpRequest()
             request.META['HTTP_HOST'] = site.hostname
             request.META['SERVER_PORT'] = site.port

--- a/wagtail/contrib/settings/tests/test_templates.py
+++ b/wagtail/contrib/settings/tests/test_templates.py
@@ -7,7 +7,6 @@ from wagtail.tests.testapp.models import TestSetting
 from wagtail.tests.utils import WagtailTestUtils
 
 
-@override_settings(ALLOWED_HOSTS=['*'])
 class TemplateTestCase(TestCase, WagtailTestUtils):
     def setUp(self):
         root = Page.objects.first()
@@ -51,6 +50,7 @@ class TestContextProcessor(TemplateTestCase):
             self.render(request, '{{ settings.tests.TestSetting.title }}'),
             self.test_setting.title)
 
+    @override_settings(ALLOWED_HOSTS=['localhost', 'other'])
     def test_multisite(self):
         """ Check that the correct setting for the current site is returned """
         request = self.get_request(site=self.default_site)
@@ -104,6 +104,7 @@ class TestTemplateTag(TemplateTestCase):
         context = Context()
         self.assertEqual(template.render(context), '')
 
+    @override_settings(ALLOWED_HOSTS=['localhost', 'other'])
     def test_get_settings_request_context(self):
         """ Check that the {% get_settings %} tag works """
         request = self.get_request(site=self.other_site)
@@ -191,6 +192,7 @@ class TestSettingsJinja(TemplateTestCase):
             self.render('{{ settings("tests.TestSetting").title }}'),
             self.test_setting.title)
 
+    @override_settings(ALLOWED_HOSTS=['localhost', 'other'])
     def test_multisite(self):
         """ Check that the correct setting for the current site is returned """
         context = {'site': self.default_site}

--- a/wagtail/contrib/settings/views.py
+++ b/wagtail/contrib/settings/views.py
@@ -40,7 +40,8 @@ def get_setting_edit_handler(model):
 def edit_current_site(request, app_name, model_name):
     # Redirect the user to the edit page for the current site
     # (or the current request does not correspond to a site, the first site in the list)
-    site = request.site or Site.objects.first()
+    site_request = Site.find_for_request(request)
+    site = site_request or Site.objects.first()
     if not site:
         messages.error(request, _("This setting could not be opened because there is no site defined."))
         return redirect('wagtailadmin_home')

--- a/wagtail/contrib/sitemaps/tests.py
+++ b/wagtail/contrib/sitemaps/tests.py
@@ -84,7 +84,7 @@ class TestSitemapGenerator(TestCase):
 
         sitemap = Sitemap(request)
 
-        with self.assertNumQueries(16):
+        with self.assertNumQueries(17):
             urls = [url['location'] for url in sitemap.get_urls(1, django_site, req_protocol)]
 
         self.assertIn('http://localhost/', urls)  # Homepage

--- a/wagtail/core/middleware.py
+++ b/wagtail/core/middleware.py
@@ -2,6 +2,9 @@ from django.utils.deprecation import MiddlewareMixin
 
 from wagtail.core.models import Site
 
+import warnings
+from wagtail.utils.deprecation import RemovedInWagtail28Warning
+
 
 class SiteMiddleware(MiddlewareMixin):
     def process_request(self, request):
@@ -9,6 +12,12 @@ class SiteMiddleware(MiddlewareMixin):
         Set request.site to contain the Site object responsible for handling this request,
         according to hostname matching rules
         """
+        warnings.warn(
+            'wagtail SiteMiddleware and the use of request.site is deprecated '
+            'and will be removed in wagtail 2.8. Update your middleware settings.',
+            RemovedInWagtail28Warning, stacklevel=2
+        )
+
         try:
             request.site = Site.find_for_request(request)
         except Site.DoesNotExist:

--- a/wagtail/core/middleware.py
+++ b/wagtail/core/middleware.py
@@ -1,8 +1,7 @@
-from django.utils.deprecation import MiddlewareMixin
-
-from wagtail.core.models import Site
-
 import warnings
+
+from django.utils.deprecation import MiddlewareMixin
+from wagtail.core.models import Site
 from wagtail.utils.deprecation import RemovedInWagtail28Warning
 
 

--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -19,7 +19,7 @@ from django.http import Http404
 from django.template.response import TemplateResponse
 from django.urls import reverse
 from django.utils import timezone
-from django.utils.functional import cached_property, lazy
+from django.utils.functional import cached_property
 from django.utils.text import capfirst, slugify
 from django.utils.translation import ugettext_lazy as _
 from modelcluster.models import (

--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -19,7 +19,7 @@ from django.http import Http404
 from django.template.response import TemplateResponse
 from django.urls import reverse
 from django.utils import timezone
-from django.utils.functional import cached_property
+from django.utils.functional import cached_property, lazy
 from django.utils.text import capfirst, slugify
 from django.utils.translation import ugettext_lazy as _
 from modelcluster.models import (
@@ -106,11 +106,29 @@ class Site(models.Model):
 
         NB this means that high-numbered ports on an extant hostname may
         still be routed to a different hostname which is set as the default
+
+        The site will be cached via request._wagtail_site
         """
 
+        if request is None:
+            return None
+
+        if not hasattr(request, '_wagtail_site'):
+            site = Site._find_for_request(request)
+            setattr(request, '_wagtail_site', site)
+        return request._wagtail_site
+
+    @staticmethod
+    def _find_for_request(request):
         hostname = request.get_host().split(':')[0]
         port = request.get_port()
-        return get_site_for_hostname(hostname, port)
+        site = None
+        try:
+            site = get_site_for_hostname(hostname, port)
+        except Site.DoesNotExist:
+            pass
+            # copy old SiteMiddleware behavior
+        return site
 
     @property
     def root_url(self):
@@ -771,9 +789,10 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
 
         site_id, root_path, root_url = possible_sites[0]
 
-        if hasattr(request, 'site'):
+        site = Site.find_for_request(request)
+        if site:
             for site_id, root_path, root_url in possible_sites:
-                if site_id == request.site.pk:
+                if site_id == site.pk:
                     break
             else:
                 site_id, root_path, root_url = possible_sites[0]
@@ -814,14 +833,15 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
 
         Accepts an optional but recommended ``request`` keyword argument that, if provided, will
         be used to cache site-level URL information (thereby avoiding repeated database / cache
-        lookups) and, via the ``request.site`` attribute, determine whether a relative or full URL
-        is most appropriate.
+        lookups) and, via the ``Site.find_for_request()`` function, determine whether a relative
+        or full URL is most appropriate.
         """
         # ``current_site`` is purposefully undocumented, as one can simply pass the request and get
-        # a relative URL based on ``request.site``. Nonetheless, support it here to avoid
+        # a relative URL based on ``Site.find_for_request()``. Nonetheless, support it here to avoid
         # copy/pasting the code to the ``relative_url`` method below.
         if current_site is None and request is not None:
-            current_site = getattr(request, 'site', None)
+            site = Site.find_for_request(request)
+            current_site = site
         url_parts = self.get_url_parts(request=request)
 
         if url_parts is None:

--- a/wagtail/core/templatetags/wagtailcore_tags.py
+++ b/wagtail/core/templatetags/wagtailcore_tags.py
@@ -160,3 +160,11 @@ def include_block(parser, token):
         raise template.TemplateSyntaxError("Unexpected argument to %r tag: %r" % (tag_name, tokens[0]))
 
     return IncludeBlockNode(block_var, extra_context, use_parent_context)
+
+
+@register.simple_tag(takes_context=True)
+def wagtail_site(context):
+    """
+        Returns the Site object for the given request
+    """
+    return Site.find_for_request(request=context.request)

--- a/wagtail/core/templatetags/wagtailcore_tags.py
+++ b/wagtail/core/templatetags/wagtailcore_tags.py
@@ -5,7 +5,7 @@ from django.utils.encoding import force_text
 from django.utils.safestring import mark_safe
 
 from wagtail import VERSION, __version__
-from wagtail.core.models import Page
+from wagtail.core.models import Page, Site
 from wagtail.core.rich_text import RichText, expand_db_html
 from wagtail.utils.version import get_main_version
 
@@ -26,9 +26,10 @@ def pageurl(context, page, fallback=None):
         raise ValueError("pageurl tag expected a Page object, got %r" % page)
 
     try:
-        current_site = context['request'].site
+        site = Site.find_for_request(context['request'])
+        current_site = site
     except (KeyError, AttributeError):
-        # request.site not available in the current context; fall back on page.url
+        # site not available in the current context; fall back on page.url
         return page.url
 
     # Pass page.relative_url the request object, which may contain a cached copy of
@@ -49,7 +50,8 @@ def slugurl(context, slug):
     """
 
     try:
-        current_site = context['request'].site
+        site = Site.find_for_request(context['request'])
+        current_site = site
     except (KeyError, AttributeError):
         # No site object found - allow the fallback below to take place.
         page = None

--- a/wagtail/core/tests/test_jinja2.py
+++ b/wagtail/core/tests/test_jinja2.py
@@ -21,7 +21,8 @@ class TestCoreGlobalsAndFilters(TestCase):
         if request_context:
             site = Site.objects.get(is_default_site=True)
             request = self.client.get('/test/', HTTP_HOST=site.hostname)
-            request.site = site
+            #request.META['HTTP_HOST'] = site.hostname
+            #request.META['SERVER_PORT'] = site.port
             context['request'] = request
 
         template = self.engine.from_string(string)

--- a/wagtail/core/tests/test_jinja2.py
+++ b/wagtail/core/tests/test_jinja2.py
@@ -21,8 +21,6 @@ class TestCoreGlobalsAndFilters(TestCase):
         if request_context:
             site = Site.objects.get(is_default_site=True)
             request = self.client.get('/test/', HTTP_HOST=site.hostname)
-            #request.META['HTTP_HOST'] = site.hostname
-            #request.META['SERVER_PORT'] = site.port
             context['request'] = request
 
         template = self.engine.from_string(string)

--- a/wagtail/core/tests/test_page_model.py
+++ b/wagtail/core/tests/test_page_model.py
@@ -254,7 +254,7 @@ class TestRouting(TestCase):
         self.assertEqual(root.relative_url(default_site), None)
         self.assertEqual(root.get_site(), None)
 
-    @override_settings(ALLOWED_HOSTS=['*'])
+    @override_settings(ALLOWED_HOSTS=['localhost', 'events.example.com', 'second-events.example.com'])
     def test_urls_with_multiple_sites(self):
         events_page = Page.objects.get(url_path='/home/events/')
         events_site = Site.objects.create(hostname='events.example.com', root_page=events_page)
@@ -341,7 +341,6 @@ class TestRouting(TestCase):
         (found_page, args, kwargs) = homepage.route(request, ['events', 'christmas'])
         self.assertEqual(found_page, christmas_page)
 
-    @override_settings(ALLOWED_HOSTS=['*'])
     def test_request_serving(self):
         christmas_page = EventPage.objects.get(url_path='/home/events/christmas/')
 
@@ -376,7 +375,7 @@ class TestRouting(TestCase):
     # Override CACHES so we don't generate any cache-related SQL queries (tests use DatabaseCache
     # otherwise) and so cache.get will always return None.
     @override_settings(CACHES={'default': {'BACKEND': 'django.core.cache.backends.dummy.DummyCache'}})
-    @override_settings(ALLOWED_HOSTS=['*'])
+    @override_settings(ALLOWED_HOSTS=['localhost', 'dummy'])
     def test_request_scope_site_root_paths_cache(self):
         homepage = Page.objects.get(url_path='/home/')
         christmas_page = EventPage.objects.get(url_path='/home/events/christmas/')
@@ -392,6 +391,7 @@ class TestRouting(TestCase):
             self.assertEqual(christmas_page.get_url(), '/events/christmas/')
 
         # with a request, the first call to get_url should issue 1 SQL query
+
         request = HttpRequest()
         request.META['HTTP_HOST'] = "dummy"
         request.META['SERVER_PORT'] = "8888"
@@ -1517,7 +1517,6 @@ class TestDummyRequest(TestCase):
         # validation won't reject
         self.assertEqual(request.META['HTTP_HOST'], 'production.example.com')
 
-    @override_settings(ALLOWED_HOSTS=['*'])
     def test_dummy_request_for_inaccessible_page_with_wildcard_allowed_hosts(self):
         root_page = Page.objects.get(url_path='/')
         request = root_page.dummy_request()

--- a/wagtail/core/tests/tests.py
+++ b/wagtail/core/tests/tests.py
@@ -63,7 +63,7 @@ class TestPageUrlTags(TestCase):
         result = slugurl(context=template.Context({'request': HttpRequest()}), slug='bad-slug-doesnt-exist')
         self.assertEqual(result, None)
 
-    @override_settings(ALLOWED_HOSTS=['*'])
+    @override_settings(ALLOWED_HOSTS=['localhost', 'site2.example.com'])
     def test_slugurl_tag_returns_url_for_current_site(self):
         home_page = Page.objects.get(url_path='/home/')
         new_home_page = home_page.copy(update_attrs={'title': "New home page", 'slug': 'new-home'})
@@ -78,7 +78,7 @@ class TestPageUrlTags(TestCase):
         url = slugurl(context=template.Context({'request': request}), slug='christmas')
         self.assertEqual(url, '/christmas/')
 
-    @override_settings(ALLOWED_HOSTS=['*'])
+    @override_settings(ALLOWED_HOSTS=['localhost', 'site2.example.com'])
     def test_slugurl_tag_returns_url_for_other_site(self):
         home_page = Page.objects.get(url_path='/home/')
         new_home_page = home_page.copy(update_attrs={'title': "New home page", 'slug': 'new-home'})

--- a/wagtail/core/views.py
+++ b/wagtail/core/views.py
@@ -4,17 +4,18 @@ from django.urls import reverse
 
 from wagtail.core import hooks
 from wagtail.core.forms import PasswordViewRestrictionForm
-from wagtail.core.models import Page, PageViewRestriction
+from wagtail.core.models import Page, PageViewRestriction, Site
 
 
 def serve(request, path):
     # we need a valid Site object corresponding to this request (set in wagtail.core.middleware.SiteMiddleware)
     # in order to proceed
-    if not request.site:
+    site = Site.find_for_request(request)
+    if not site:
         raise Http404
 
     path_components = [component for component in path.split('/') if component]
-    page, args, kwargs = request.site.root_page.specific.route(request, path_components)
+    page, args, kwargs = site.root_page.specific.route(request, path_components)
 
     for fn in hooks.get_hooks('before_serve_page'):
         result = fn(page, request, args, kwargs)

--- a/wagtail/images/tests/test_jinja2.py
+++ b/wagtail/images/tests/test_jinja2.py
@@ -42,7 +42,6 @@ class TestImagesJinja(TestCase):
         if request_context:
             site = Site.objects.get(is_default_site=True)
             request = self.client.get('/test/', HTTP_HOST=site.hostname)
-            request.site = site
             context['request'] = request
 
         template = self.engine.from_string(string)

--- a/wagtail/tests/settings.py
+++ b/wagtail/tests/settings.py
@@ -8,6 +8,8 @@ MEDIA_URL = '/media/'
 
 TIME_ZONE = 'Asia/Tokyo'
 
+ALLOWED_HOSTS = ['localhost', ]
+
 DATABASES = {
     'default': {
         'ENGINE': os.environ.get('DATABASE_ENGINE', 'django.db.backends.sqlite3'),

--- a/wagtail/tests/settings.py
+++ b/wagtail/tests/settings.py
@@ -94,7 +94,6 @@ MIDDLEWARE = (
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 
-    'wagtail.core.middleware.SiteMiddleware',
     'wagtail.contrib.redirects.middleware.RedirectMiddleware',
 )
 


### PR DESCRIPTION
As proposed in the comment [#3834](https://github.com/wagtail/wagtail/issues/3834#issuecomment-340009510) by @gasman i changed the wagtail behaviour to only use `Site.find_for_request(request)` and added some caching via a `request._wagtail_site` variable.

Since there is no use for the `SiteMiddleware` anymore, i pushed it for deprecation in wagtail 2.8.

Also i don't see the need for a lazy evaluation of the `SiteMiddleware` `request.site` stuff due to the possibility to remove the middleware completely.

I needed to change a lot of tests. Please take some time to review them. There was some stuff going on with requests being responses from `self.client.get()`. e.G. see the `TestCoreJinja` class changes.

- [x] checked with chrome 74.0 on the bakerydemo
