### PR TITLE
Implemented branding title prefix customization

### DIFF
--- a/docs/advanced_topics/customisation/admin_templates.rst
+++ b/docs/advanced_topics/customisation/admin_templates.rst
@@ -56,6 +56,17 @@ To replace the favicon displayed when viewing admin pages, create a template fil
         <link rel="shortcut icon" href="{% static 'images/favicon.ico' %}" />
     {% endblock %}
 
+``branding_title``
+------------------
+
+To replace the title prefix (which is 'Wagtail' by default), create a template file ``dashboard/templates/wagtailadmin/admin_base.html`` that overrides the block ``branding_title``:
+
+.. code-block:: html+django
+
+    {% extends "wagtailadmin/admin_base.html" %}
+
+    {% block branding_title %}Frank's CMS{% endblock %}
+
 ``branding_login``
 ------------------
 

--- a/wagtail/admin/templates/wagtailadmin/skeleton.html
+++ b/wagtail/admin/templates/wagtailadmin/skeleton.html
@@ -5,7 +5,7 @@
 <html class="no-js" lang="{{ LANGUAGE_CODE }}" dir="{% if LANGUAGE_BIDI %}rtl{% else %}ltr{% endif %}">
 <head>
     <meta charset="utf-8" />
-    <title>Wagtail - {% block titletag %}{% endblock %}</title>
+    <title>{% block branding_title %}Wagtail{% endblock %} - {% block titletag %}{% endblock %}</title>
     <meta name="description" content="" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="robots" content="noindex" />


### PR DESCRIPTION
Currently there is no way to override the (meta)title prefix (which is "Wagtail" by default). With these small changes it's possible to brand/customize this as well.