### PR TITLE
Add template block for admin title name.

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/skeleton.html
+++ b/wagtail/admin/templates/wagtailadmin/skeleton.html
@@ -5,7 +5,7 @@
 <html class="no-js" lang="{{ LANGUAGE_CODE }}" dir="{% if LANGUAGE_BIDI %}rtl{% else %}ltr{% endif %}">
 <head>
     <meta charset="utf-8" />
-    <title>Wagtail - {% block titletag %}{% endblock %}</title>
+    <title>{% block titlename %}Wagtail{% endblock %} - {% block titletag %}{% endblock %}</title>
     <meta name="description" content="" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="robots" content="noindex" />


### PR DESCRIPTION
This change adds a template block around the "Wagtail" string in the skeleton title, allowing implementors to override the title instead of having to override the entire `skeleton.html` template.

Unsure if this was omitted intentionally or not (for branding?), but figured I'd open a PR to gauge interest.