### PR TITLE
Add a "Dashboard" label for logo link in the main nav for screen reader users

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -20,5 +20,5 @@ Any other relevant information. For example, why do you consider this a bug and 
 
 * Python version: Run `python --version`.
 * Django version: Look in your requirements.txt, or run `pip show django | grep Version`.
-* Wagtail version: Hover over the Wagtail bird in the admin, or run `pip show wagtail | grep Version:`.
+* Wagtail version: Look at the bottom of the Settings menu in the Wagtail admin, or run `pip show wagtail | grep Version:`.
 * Browser version: You can use http://www.whatsmybrowser.org/ to find this out.

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -18,6 +18,7 @@ Changelog
  * Increase font-size across the whole admin (Beth Menzies, Katie Locke)
  * Improved text color contrast across the whole admin (Beth Menzies, Katie Locke)
  * Added consistent focus outline styles across the whole admin (Thibaud Colas)
+ * Removed version number from the logo link’s title. The version can now be found under the Settings menu (Thibaud Colas)
  * Fix: ModelAdmin no longer fails when filtering over a foreign key relation (Jason Dilworth, Matt Westcott)
  * Fix: The Wagtail version number is now visible within the Settings menu (Kevin Howbrook)
  * Fix: Scaling images now rounds values to an integer so that images render without errors (Adrian Brunyate)
@@ -33,6 +34,7 @@ Changelog
  * Fix: Make URL generator preview image alt translateable (Thibaud Colas)
  * Fix: Clear pending AJAX request if error occurs on page chooser (Matt Westcott)
  * Fix: Prevent text from overlapping in focal point editing UI (Beth Menzies)
+ * Fix: Screen readers now announce "Dashboard" for the main nav’s logo link instead of Wagtail’s version number (Thibaud Colas)
 
 
 2.5.1 (07.05.2019)

--- a/docs/releases/2.6.rst
+++ b/docs/releases/2.6.rst
@@ -27,6 +27,7 @@ Other features
  * Increase font-size across the whole admin (Beth Menzies, Katie Locke)
  * Improved text color contrast across the whole admin (Beth Menzies, Katie Locke)
  * Added consistent focus outline styles across the whole admin (Thibaud Colas)
+ * Removed version number from the logo link’s title. The version can now be found under the Settings menu (Thibaud Colas)
 
 Bug fixes
 ~~~~~~~~~
@@ -46,6 +47,7 @@ Bug fixes
  * Make URL generator preview image alt translateable (Thibaud Colas)
  * Clear pending AJAX request if error occurs on page chooser (Matt Westcott)
  * Prevent text from overlapping in focal point editing UI (Beth Menzies)
+ * Screen readers now announce "Dashboard" for the main nav’s logo link instead of Wagtail’s version number (Thibaud Colas)
 
 
 Upgrade considerations

--- a/wagtail/admin/templates/wagtailadmin/base.html
+++ b/wagtail/admin/templates/wagtailadmin/base.html
@@ -4,7 +4,7 @@
 {% block furniture %}
     <aside class="nav-wrapper">
         <div class="inner">
-            <a href="{% url 'wagtailadmin_home' %}" class="logo" title="Wagtail v.{% wagtail_version %}">
+            <a href="{% url 'wagtailadmin_home' %}" class="logo" title="Wagtail v.{% wagtail_version %}" aria-label="{% trans 'Dashboard' %}">
                 {% block branding_logo %}
                     {# Mobile-only logo: #}
                     <div class="wagtail-logo-container__mobile u-hidden@sm">

--- a/wagtail/admin/templates/wagtailadmin/base.html
+++ b/wagtail/admin/templates/wagtailadmin/base.html
@@ -4,7 +4,7 @@
 {% block furniture %}
     <aside class="nav-wrapper">
         <div class="inner">
-            <a href="{% url 'wagtailadmin_home' %}" class="logo" title="Wagtail v.{% wagtail_version %}" aria-label="{% trans 'Dashboard' %}">
+            <a href="{% url 'wagtailadmin_home' %}" class="logo" aria-label="{% trans 'Dashboard' %}">
                 {% block branding_logo %}
                     {# Mobile-only logo: #}
                     <div class="wagtail-logo-container__mobile u-hidden@sm">


### PR DESCRIPTION
This change adds a "Dashboard" label to the main nav’s "logo link" for screen reader users:

<img width="393" alt="main-nav-logo-link" src="https://user-images.githubusercontent.com/877585/58893545-4b937380-86e8-11e9-97d9-3b79dccca2a5.png">

Up until now, for screen reader users, this link was announced as "Wagtail v2.x.y", which doesn't convey that the link takes you to the dashboard. This PR removes the `title` with the version number and adds an `aria-label`, so screen reader users have the same link label as what gets displayed on mobile viewports: "Dashboard".

I had also considered leaving the `title` as-is and just adding `aria-label` on top, but then some screen readers would announce the link as "link, Dashboard Wagtail v2.x.y", which isn't of much help.

I've updated the issue template to point users at the version number written in the Settings menu, rather than hovering Wagtail. This is also good because you could only access the version in `title` with a mouse, whereas the one under Settings is accessible with the keyboard and touch screens too.

---

Tested in macOS 10.14.4 with latest Chrome & Safari with VoiceOver, and iOS 12.3 Safari with VoiceOver. I think that's enough for cross-browser tests considering the change.