### PR TITLE
Support custom add/edit page views on a per-page-type basis

### DIFF
--- a/docs/advanced_topics/customisation/page_editing_interface.rst
+++ b/docs/advanced_topics/customisation/page_editing_interface.rst
@@ -211,3 +211,25 @@ Wagtail will generate a new subclass of this form for the model,
 adding any fields defined in ``panels`` or ``content_panels``.
 Any fields already defined on the model will not be overridden by these automatically added fields,
 so the form field for a model field can be overridden by adding it to the custom form.
+
+
+Customising page creation/edit views
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For customisations that cannot be achieved by replacing the form class, the ``register_create_page_view`` and ``register_edit_page_view`` functions in ``wagtail.admin.views.pages`` allow you to specify a custom view to be used when creating or editing a page of a given type. The default views are implemented as class-based views ``wagtail.admin.views.pages.CreatePageView`` and ``wagtail.admin.views.pages.EditPageView``, which provide the overrideable methods ``get_page_instance``, ``get_edit_handler``, ``get_form_class`` and ``get_context_data``; ``EditPageView`` additionally provides the method ``get_latest_revision``.
+
+For example, the following code (placed in a ``wagtail_hooks.py`` file within one of your apps) will extend ``EventPage``'s creation view with the ability to pre-populate the 'location' field from a URL parameter:
+
+.. code-block:: python
+
+    from wagtail.admin.views.pages import CreatePageView, register_create_page_view
+    from myapp.models import EventPage
+
+    class EventPageCreateView(CreatePageView):
+        def get_page_instance(self):
+            page = super().get_page_instance()
+            page.location = self.request.GET.get('location', '')
+            return page
+
+
+    register_create_page_view(EventPage, EventPageCreateView.as_view())

--- a/wagtail/admin/tests/test_pages_views.py
+++ b/wagtail/admin/tests/test_pages_views.py
@@ -1220,6 +1220,17 @@ class TestPageCreation(TestCase, WagtailTestUtils):
         # page should be created
         self.assertTrue(Page.objects.filter(title="New page!").exists())
 
+    def test_custom_create_page_view(self):
+        # SingleEventPage has a custom create view allowing passing location as a URL parameter
+
+        response = self.client.get(
+            reverse('wagtailadmin_pages:add', args=('tests', 'singleeventpage', self.root_page.id)),
+            {'location': "Massachusetts"}
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, '"Massachusetts"')
+
 
 class TestPerRequestEditHandler(TestCase, WagtailTestUtils):
     fixtures = ['test.json']
@@ -2089,6 +2100,25 @@ class TestPageEdit(TestCase, WagtailTestUtils):
 
         # page should be edited
         self.assertEqual(Page.objects.get(id=self.child_page.id).title, "I've been edited!")
+
+
+class TestCustomPageEditView(TestCase, WagtailTestUtils):
+    fixtures = ['test.json']
+
+    def test_custom_edit_page_view(self):
+        self.login()
+
+        page_id = Page.objects.get(url_path='/home/events/saint-patrick/').id
+
+        # SingleEventPage has a custom edit view that adds [UPDATED] to the title
+        # if 'updated' is passed in the URL
+        response = self.client.get(
+            reverse('wagtailadmin_pages:edit', args=(page_id, )),
+            {'updated': '1'}
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, '"Saint Patrick [UPDATED]"')
 
 
 class TestPageEditReordering(TestCase, WagtailTestUtils):

--- a/wagtail/admin/urls/pages.py
+++ b/wagtail/admin/urls/pages.py
@@ -4,11 +4,11 @@ from wagtail.admin.views import page_privacy, pages
 
 app_name = 'wagtailadmin_pages'
 urlpatterns = [
-    url(r'^add/(\w+)/(\w+)/(\d+)/$', pages.create, name='add'),
+    url(r'^add/(\w+)/(\w+)/(\d+)/$', pages.CreatePageView.as_view(), name='add'),
     url(r'^add/(\w+)/(\w+)/(\d+)/preview/$', pages.PreviewOnCreate.as_view(), name='preview_on_add'),
     url(r'^usage/(\w+)/(\w+)/$', pages.content_type_use, name='type_use'),
 
-    url(r'^(\d+)/edit/$', pages.edit, name='edit'),
+    url(r'^(\d+)/edit/$', pages.EditPageView.as_view(), name='edit'),
     url(r'^(\d+)/edit/preview/$', pages.PreviewOnEdit.as_view(), name='preview_on_edit'),
 
     url(r'^(\d+)/view_draft/$', pages.view_draft, name='view_draft'),

--- a/wagtail/admin/views/pages.py
+++ b/wagtail/admin/views/pages.py
@@ -179,371 +179,373 @@ def content_type_use(request, content_type_app_name, content_type_model_name):
     })
 
 
-def create(request, content_type_app_name, content_type_model_name, parent_page_id):
-    parent_page = get_object_or_404(Page, id=parent_page_id).specific
-    parent_page_perms = parent_page.permissions_for_user(request.user)
-    if not parent_page_perms.can_add_subpage():
-        raise PermissionDenied
+class CreatePageView(View):
+    def dispatch(self, request, content_type_app_name, content_type_model_name, parent_page_id):
+        parent_page = get_object_or_404(Page, id=parent_page_id).specific
+        parent_page_perms = parent_page.permissions_for_user(request.user)
+        if not parent_page_perms.can_add_subpage():
+            raise PermissionDenied
 
-    try:
-        content_type = ContentType.objects.get_by_natural_key(content_type_app_name, content_type_model_name)
-    except ContentType.DoesNotExist:
-        raise Http404
+        try:
+            content_type = ContentType.objects.get_by_natural_key(content_type_app_name, content_type_model_name)
+        except ContentType.DoesNotExist:
+            raise Http404
 
-    # Get class
-    page_class = content_type.model_class()
+        # Get class
+        page_class = content_type.model_class()
 
-    # Make sure the class is a descendant of Page
-    if not issubclass(page_class, Page):
-        raise Http404
+        # Make sure the class is a descendant of Page
+        if not issubclass(page_class, Page):
+            raise Http404
 
-    # page must be in the list of allowed subpage types for this parent ID
-    if page_class not in parent_page.creatable_subpage_models():
-        raise PermissionDenied
+        # page must be in the list of allowed subpage types for this parent ID
+        if page_class not in parent_page.creatable_subpage_models():
+            raise PermissionDenied
 
-    if not page_class.can_create_at(parent_page):
-        raise PermissionDenied
+        if not page_class.can_create_at(parent_page):
+            raise PermissionDenied
 
-    for fn in hooks.get_hooks('before_create_page'):
-        result = fn(request, parent_page, page_class)
-        if hasattr(result, 'status_code'):
-            return result
+        for fn in hooks.get_hooks('before_create_page'):
+            result = fn(request, parent_page, page_class)
+            if hasattr(result, 'status_code'):
+                return result
 
-    page = page_class(owner=request.user)
-    edit_handler = page_class.get_edit_handler()
-    edit_handler = edit_handler.bind_to(request=request, instance=page)
-    form_class = edit_handler.get_form_class()
+        page = page_class(owner=request.user)
+        edit_handler = page_class.get_edit_handler()
+        edit_handler = edit_handler.bind_to(request=request, instance=page)
+        form_class = edit_handler.get_form_class()
 
-    next_url = get_valid_next_url_from_request(request)
+        next_url = get_valid_next_url_from_request(request)
 
-    if request.method == 'POST':
-        form = form_class(request.POST, request.FILES, instance=page,
-                          parent_page=parent_page)
+        if request.method == 'POST':
+            form = form_class(request.POST, request.FILES, instance=page,
+                              parent_page=parent_page)
 
-        if form.is_valid():
-            page = form.save(commit=False)
+            if form.is_valid():
+                page = form.save(commit=False)
 
-            is_publishing = bool(request.POST.get('action-publish')) and parent_page_perms.can_publish_subpage()
-            is_submitting = bool(request.POST.get('action-submit'))
+                is_publishing = bool(request.POST.get('action-publish')) and parent_page_perms.can_publish_subpage()
+                is_submitting = bool(request.POST.get('action-submit'))
 
-            if not is_publishing:
-                page.live = False
+                if not is_publishing:
+                    page.live = False
 
-            # Save page
-            parent_page.add_child(instance=page)
+                # Save page
+                parent_page.add_child(instance=page)
 
-            # Save revision
-            revision = page.save_revision(
-                user=request.user,
-                submitted_for_moderation=is_submitting,
-            )
-
-            # Publish
-            if is_publishing:
-                revision.publish()
-
-            # Notifications
-            if is_publishing:
-                if page.go_live_at and page.go_live_at > timezone.now():
-                    messages.success(request, _("Page '{0}' created and scheduled for publishing.").format(page.get_admin_display_title()), buttons=[
-                        messages.button(reverse('wagtailadmin_pages:edit', args=(page.id,)), _('Edit'))
-                    ])
-                else:
-                    buttons = []
-                    if page.url is not None:
-                        buttons.append(messages.button(page.url, _('View live'), new_window=True))
-                    buttons.append(messages.button(reverse('wagtailadmin_pages:edit', args=(page.id,)), _('Edit')))
-                    messages.success(request, _("Page '{0}' created and published.").format(page.get_admin_display_title()), buttons=buttons)
-            elif is_submitting:
-                messages.success(
-                    request,
-                    _("Page '{0}' created and submitted for moderation.").format(page.get_admin_display_title()),
-                    buttons=[
-                        messages.button(
-                            reverse('wagtailadmin_pages:view_draft', args=(page.id,)),
-                            _('View draft'),
-                            new_window=True
-                        ),
-                        messages.button(
-                            reverse('wagtailadmin_pages:edit', args=(page.id,)),
-                            _('Edit')
-                        )
-                    ]
+                # Save revision
+                revision = page.save_revision(
+                    user=request.user,
+                    submitted_for_moderation=is_submitting,
                 )
-                if not send_notification(page.get_latest_revision().id, 'submitted', request.user.pk):
-                    messages.error(request, _("Failed to send notifications to moderators"))
-            else:
-                messages.success(request, _("Page '{0}' created.").format(page.get_admin_display_title()))
 
-            for fn in hooks.get_hooks('after_create_page'):
-                result = fn(request, page)
-                if hasattr(result, 'status_code'):
-                    return result
+                # Publish
+                if is_publishing:
+                    revision.publish()
 
-            if is_publishing or is_submitting:
-                # we're done here
-                if next_url:
-                    # redirect back to 'next' url if present
-                    return redirect(next_url)
-                # redirect back to the explorer
-                return redirect('wagtailadmin_explore', page.get_parent().id)
-            else:
-                # Just saving - remain on edit page for further edits
-                target_url = reverse('wagtailadmin_pages:edit', args=[page.id])
-                if next_url:
-                    # Ensure the 'next' url is passed through again if present
-                    target_url += '?next=%s' % urlquote(next_url)
-                return redirect(target_url)
-        else:
-            messages.validation_error(
-                request, _("The page could not be created due to validation errors"), form
-            )
-            has_unsaved_changes = True
-    else:
-        signals.init_new_page.send(sender=create, page=page, parent=parent_page)
-        form = form_class(instance=page, parent_page=parent_page)
-        has_unsaved_changes = False
-
-    edit_handler = edit_handler.bind_to(form=form)
-
-    return render(request, 'wagtailadmin/pages/create.html', {
-        'content_type': content_type,
-        'page_class': page_class,
-        'parent_page': parent_page,
-        'edit_handler': edit_handler,
-        'action_menu': PageActionMenu(request, view='create', parent_page=parent_page),
-        'preview_modes': page.preview_modes,
-        'form': form,
-        'next': next_url,
-        'has_unsaved_changes': has_unsaved_changes,
-    })
-
-
-def edit(request, page_id):
-    real_page_record = get_object_or_404(Page, id=page_id)
-    latest_revision = real_page_record.get_latest_revision()
-    page = real_page_record.get_latest_revision_as_page()
-    parent = page.get_parent()
-
-    content_type = ContentType.objects.get_for_model(page)
-    page_class = content_type.model_class()
-
-    page_perms = page.permissions_for_user(request.user)
-    if not page_perms.can_edit():
-        raise PermissionDenied
-
-    for fn in hooks.get_hooks('before_edit_page'):
-        result = fn(request, page)
-        if hasattr(result, 'status_code'):
-            return result
-
-    edit_handler = page_class.get_edit_handler()
-    edit_handler = edit_handler.bind_to(instance=page, request=request)
-    form_class = edit_handler.get_form_class()
-
-    next_url = get_valid_next_url_from_request(request)
-
-    errors_debug = None
-
-    if request.method == 'POST':
-        form = form_class(request.POST, request.FILES, instance=page,
-                          parent_page=parent)
-
-        if form.is_valid() and not page.locked:
-            page = form.save(commit=False)
-
-            is_publishing = bool(request.POST.get('action-publish')) and page_perms.can_publish()
-            is_submitting = bool(request.POST.get('action-submit'))
-            is_reverting = bool(request.POST.get('revision'))
-
-            # If a revision ID was passed in the form, get that revision so its
-            # date can be referenced in notification messages
-            if is_reverting:
-                previous_revision = get_object_or_404(page.revisions, id=request.POST.get('revision'))
-
-            # Save revision
-            revision = page.save_revision(
-                user=request.user,
-                submitted_for_moderation=is_submitting,
-            )
-            # store submitted go_live_at for messaging below
-            go_live_at = page.go_live_at
-
-            # Publish
-            if is_publishing:
-                revision.publish()
-                # Need to reload the page because the URL may have changed, and we
-                # need the up-to-date URL for the "View Live" button.
-                page = page.specific_class.objects.get(pk=page.pk)
-
-            # Notifications
-            if is_publishing:
-                if go_live_at and go_live_at > timezone.now():
-                    # Page has been scheduled for publishing in the future
-
-                    if is_reverting:
-                        message = _(
-                            "Revision from {0} of page '{1}' has been scheduled for publishing."
-                        ).format(
-                            previous_revision.created_at.strftime("%d %b %Y %H:%M"),
-                            page.get_admin_display_title()
-                        )
+                # Notifications
+                if is_publishing:
+                    if page.go_live_at and page.go_live_at > timezone.now():
+                        messages.success(request, _("Page '{0}' created and scheduled for publishing.").format(page.get_admin_display_title()), buttons=[
+                            messages.button(reverse('wagtailadmin_pages:edit', args=(page.id,)), _('Edit'))
+                        ])
                     else:
-                        if page.live:
+                        buttons = []
+                        if page.url is not None:
+                            buttons.append(messages.button(page.url, _('View live'), new_window=True))
+                        buttons.append(messages.button(reverse('wagtailadmin_pages:edit', args=(page.id,)), _('Edit')))
+                        messages.success(request, _("Page '{0}' created and published.").format(page.get_admin_display_title()), buttons=buttons)
+                elif is_submitting:
+                    messages.success(
+                        request,
+                        _("Page '{0}' created and submitted for moderation.").format(page.get_admin_display_title()),
+                        buttons=[
+                            messages.button(
+                                reverse('wagtailadmin_pages:view_draft', args=(page.id,)),
+                                _('View draft'),
+                                new_window=True
+                            ),
+                            messages.button(
+                                reverse('wagtailadmin_pages:edit', args=(page.id,)),
+                                _('Edit')
+                            )
+                        ]
+                    )
+                    if not send_notification(page.get_latest_revision().id, 'submitted', request.user.pk):
+                        messages.error(request, _("Failed to send notifications to moderators"))
+                else:
+                    messages.success(request, _("Page '{0}' created.").format(page.get_admin_display_title()))
+
+                for fn in hooks.get_hooks('after_create_page'):
+                    result = fn(request, page)
+                    if hasattr(result, 'status_code'):
+                        return result
+
+                if is_publishing or is_submitting:
+                    # we're done here
+                    if next_url:
+                        # redirect back to 'next' url if present
+                        return redirect(next_url)
+                    # redirect back to the explorer
+                    return redirect('wagtailadmin_explore', page.get_parent().id)
+                else:
+                    # Just saving - remain on edit page for further edits
+                    target_url = reverse('wagtailadmin_pages:edit', args=[page.id])
+                    if next_url:
+                        # Ensure the 'next' url is passed through again if present
+                        target_url += '?next=%s' % urlquote(next_url)
+                    return redirect(target_url)
+            else:
+                messages.validation_error(
+                    request, _("The page could not be created due to validation errors"), form
+                )
+                has_unsaved_changes = True
+        else:
+            signals.init_new_page.send(sender=self, page=page, parent=parent_page)
+            form = form_class(instance=page, parent_page=parent_page)
+            has_unsaved_changes = False
+
+        edit_handler = edit_handler.bind_to(form=form)
+
+        return render(request, 'wagtailadmin/pages/create.html', {
+            'content_type': content_type,
+            'page_class': page_class,
+            'parent_page': parent_page,
+            'edit_handler': edit_handler,
+            'action_menu': PageActionMenu(request, view='create', parent_page=parent_page),
+            'preview_modes': page.preview_modes,
+            'form': form,
+            'next': next_url,
+            'has_unsaved_changes': has_unsaved_changes,
+        })
+
+
+class EditPageView(View):
+    def dispatch(self, request, page_id):
+        real_page_record = get_object_or_404(Page, id=page_id)
+        latest_revision = real_page_record.get_latest_revision()
+        page = real_page_record.get_latest_revision_as_page()
+        parent = page.get_parent()
+
+        content_type = ContentType.objects.get_for_model(page)
+        page_class = content_type.model_class()
+
+        page_perms = page.permissions_for_user(request.user)
+        if not page_perms.can_edit():
+            raise PermissionDenied
+
+        for fn in hooks.get_hooks('before_edit_page'):
+            result = fn(request, page)
+            if hasattr(result, 'status_code'):
+                return result
+
+        edit_handler = page_class.get_edit_handler()
+        edit_handler = edit_handler.bind_to(instance=page, request=request)
+        form_class = edit_handler.get_form_class()
+
+        next_url = get_valid_next_url_from_request(request)
+
+        errors_debug = None
+
+        if request.method == 'POST':
+            form = form_class(request.POST, request.FILES, instance=page,
+                              parent_page=parent)
+
+            if form.is_valid() and not page.locked:
+                page = form.save(commit=False)
+
+                is_publishing = bool(request.POST.get('action-publish')) and page_perms.can_publish()
+                is_submitting = bool(request.POST.get('action-submit'))
+                is_reverting = bool(request.POST.get('revision'))
+
+                # If a revision ID was passed in the form, get that revision so its
+                # date can be referenced in notification messages
+                if is_reverting:
+                    previous_revision = get_object_or_404(page.revisions, id=request.POST.get('revision'))
+
+                # Save revision
+                revision = page.save_revision(
+                    user=request.user,
+                    submitted_for_moderation=is_submitting,
+                )
+                # store submitted go_live_at for messaging below
+                go_live_at = page.go_live_at
+
+                # Publish
+                if is_publishing:
+                    revision.publish()
+                    # Need to reload the page because the URL may have changed, and we
+                    # need the up-to-date URL for the "View Live" button.
+                    page = page.specific_class.objects.get(pk=page.pk)
+
+                # Notifications
+                if is_publishing:
+                    if go_live_at and go_live_at > timezone.now():
+                        # Page has been scheduled for publishing in the future
+
+                        if is_reverting:
                             message = _(
-                                "Page '{0}' is live and this revision has been scheduled for publishing."
+                                "Revision from {0} of page '{1}' has been scheduled for publishing."
                             ).format(
+                                previous_revision.created_at.strftime("%d %b %Y %H:%M"),
+                                page.get_admin_display_title()
+                            )
+                        else:
+                            if page.live:
+                                message = _(
+                                    "Page '{0}' is live and this revision has been scheduled for publishing."
+                                ).format(
+                                    page.get_admin_display_title()
+                                )
+                            else:
+                                message = _(
+                                    "Page '{0}' has been scheduled for publishing."
+                                ).format(
+                                    page.get_admin_display_title()
+                                )
+
+                        messages.success(request, message, buttons=[
+                            messages.button(
+                                reverse('wagtailadmin_pages:edit', args=(page.id,)),
+                                _('Edit')
+                            )
+                        ])
+
+                    else:
+                        # Page is being published now
+
+                        if is_reverting:
+                            message = _(
+                                "Revision from {0} of page '{1}' has been published."
+                            ).format(
+                                previous_revision.created_at.strftime("%d %b %Y %H:%M"),
                                 page.get_admin_display_title()
                             )
                         else:
                             message = _(
-                                "Page '{0}' has been scheduled for publishing."
+                                "Page '{0}' has been published."
                             ).format(
                                 page.get_admin_display_title()
                             )
 
-                    messages.success(request, message, buttons=[
-                        messages.button(
-                            reverse('wagtailadmin_pages:edit', args=(page.id,)),
-                            _('Edit')
-                        )
-                    ])
+                        buttons = []
+                        if page.url is not None:
+                            buttons.append(messages.button(page.url, _('View live'), new_window=True))
+                        buttons.append(messages.button(reverse('wagtailadmin_pages:edit', args=(page_id,)), _('Edit')))
+                        messages.success(request, message, buttons=buttons)
 
-                else:
-                    # Page is being published now
+                elif is_submitting:
 
-                    if is_reverting:
-                        message = _(
-                            "Revision from {0} of page '{1}' has been published."
-                        ).format(
-                            previous_revision.created_at.strftime("%d %b %Y %H:%M"),
-                            page.get_admin_display_title()
-                        )
-                    else:
-                        message = _(
-                            "Page '{0}' has been published."
-                        ).format(
-                            page.get_admin_display_title()
-                        )
-
-                    buttons = []
-                    if page.url is not None:
-                        buttons.append(messages.button(page.url, _('View live'), new_window=True))
-                    buttons.append(messages.button(reverse('wagtailadmin_pages:edit', args=(page_id,)), _('Edit')))
-                    messages.success(request, message, buttons=buttons)
-
-            elif is_submitting:
-
-                message = _(
-                    "Page '{0}' has been submitted for moderation."
-                ).format(
-                    page.get_admin_display_title()
-                )
-
-                messages.success(request, message, buttons=[
-                    messages.button(
-                        reverse('wagtailadmin_pages:view_draft', args=(page_id,)),
-                        _('View draft'),
-                        new_window=True
-                    ),
-                    messages.button(
-                        reverse('wagtailadmin_pages:edit', args=(page_id,)),
-                        _('Edit')
-                    )
-                ])
-
-                if not send_notification(page.get_latest_revision().id, 'submitted', request.user.pk):
-                    messages.error(request, _("Failed to send notifications to moderators"))
-
-            else:  # Saving
-
-                if is_reverting:
                     message = _(
-                        "Page '{0}' has been replaced with revision from {1}."
-                    ).format(
-                        page.get_admin_display_title(),
-                        previous_revision.created_at.strftime("%d %b %Y %H:%M")
-                    )
-                else:
-                    message = _(
-                        "Page '{0}' has been updated."
+                        "Page '{0}' has been submitted for moderation."
                     ).format(
                         page.get_admin_display_title()
                     )
 
-                messages.success(request, message)
+                    messages.success(request, message, buttons=[
+                        messages.button(
+                            reverse('wagtailadmin_pages:view_draft', args=(page_id,)),
+                            _('View draft'),
+                            new_window=True
+                        ),
+                        messages.button(
+                            reverse('wagtailadmin_pages:edit', args=(page_id,)),
+                            _('Edit')
+                        )
+                    ])
 
-            for fn in hooks.get_hooks('after_edit_page'):
-                result = fn(request, page)
-                if hasattr(result, 'status_code'):
-                    return result
+                    if not send_notification(page.get_latest_revision().id, 'submitted', request.user.pk):
+                        messages.error(request, _("Failed to send notifications to moderators"))
 
-            if is_publishing or is_submitting:
-                # we're done here - redirect back to the explorer
-                if next_url:
-                    # redirect back to 'next' url if present
-                    return redirect(next_url)
-                # redirect back to the explorer
-                return redirect('wagtailadmin_explore', page.get_parent().id)
+                else:  # Saving
+
+                    if is_reverting:
+                        message = _(
+                            "Page '{0}' has been replaced with revision from {1}."
+                        ).format(
+                            page.get_admin_display_title(),
+                            previous_revision.created_at.strftime("%d %b %Y %H:%M")
+                        )
+                    else:
+                        message = _(
+                            "Page '{0}' has been updated."
+                        ).format(
+                            page.get_admin_display_title()
+                        )
+
+                    messages.success(request, message)
+
+                for fn in hooks.get_hooks('after_edit_page'):
+                    result = fn(request, page)
+                    if hasattr(result, 'status_code'):
+                        return result
+
+                if is_publishing or is_submitting:
+                    # we're done here - redirect back to the explorer
+                    if next_url:
+                        # redirect back to 'next' url if present
+                        return redirect(next_url)
+                    # redirect back to the explorer
+                    return redirect('wagtailadmin_explore', page.get_parent().id)
+                else:
+                    # Just saving - remain on edit page for further edits
+                    target_url = reverse('wagtailadmin_pages:edit', args=[page.id])
+                    if next_url:
+                        # Ensure the 'next' url is passed through again if present
+                        target_url += '?next=%s' % urlquote(next_url)
+                    return redirect(target_url)
             else:
-                # Just saving - remain on edit page for further edits
-                target_url = reverse('wagtailadmin_pages:edit', args=[page.id])
-                if next_url:
-                    # Ensure the 'next' url is passed through again if present
-                    target_url += '?next=%s' % urlquote(next_url)
-                return redirect(target_url)
-        else:
-            if page.locked:
-                messages.error(request, _("The page could not be saved as it is locked"))
-            else:
-                messages.validation_error(
-                    request, _("The page could not be saved due to validation errors"), form
+                if page.locked:
+                    messages.error(request, _("The page could not be saved as it is locked"))
+                else:
+                    messages.validation_error(
+                        request, _("The page could not be saved due to validation errors"), form
+                    )
+                errors_debug = (
+                    repr(form.errors)
+                    + repr([
+                        (name, formset.errors)
+                        for (name, formset) in form.formsets.items()
+                        if formset.errors
+                    ])
                 )
-            errors_debug = (
-                repr(form.errors)
-                + repr([
-                    (name, formset.errors)
-                    for (name, formset) in form.formsets.items()
-                    if formset.errors
-                ])
-            )
-            has_unsaved_changes = True
-    else:
-        form = form_class(instance=page, parent_page=parent)
-        has_unsaved_changes = False
+                has_unsaved_changes = True
+        else:
+            form = form_class(instance=page, parent_page=parent)
+            has_unsaved_changes = False
 
-    edit_handler = edit_handler.bind_to(form=form)
+        edit_handler = edit_handler.bind_to(form=form)
 
-    # Check for revisions still undergoing moderation and warn
-    if latest_revision and latest_revision.submitted_for_moderation:
-        buttons = []
+        # Check for revisions still undergoing moderation and warn
+        if latest_revision and latest_revision.submitted_for_moderation:
+            buttons = []
 
-        if page.live:
-            buttons.append(messages.button(
-                reverse('wagtailadmin_pages:revisions_compare', args=(page.id, 'live', latest_revision.id)),
-                _('Compare with live version')
-            ))
+            if page.live:
+                buttons.append(messages.button(
+                    reverse('wagtailadmin_pages:revisions_compare', args=(page.id, 'live', latest_revision.id)),
+                    _('Compare with live version')
+                ))
 
-        messages.warning(request, _("This page is currently awaiting moderation"), buttons=buttons)
+            messages.warning(request, _("This page is currently awaiting moderation"), buttons=buttons)
 
-    if page.live and page.has_unpublished_changes:
-        # Page status needs to present the version of the page containing the correct live URL
-        page_for_status = real_page_record.specific
-    else:
-        page_for_status = page
+        if page.live and page.has_unpublished_changes:
+            # Page status needs to present the version of the page containing the correct live URL
+            page_for_status = real_page_record.specific
+        else:
+            page_for_status = page
 
-    return render(request, 'wagtailadmin/pages/edit.html', {
-        'page': page,
-        'page_for_status': page_for_status,
-        'content_type': content_type,
-        'edit_handler': edit_handler,
-        'errors_debug': errors_debug,
-        'action_menu': PageActionMenu(request, view='edit', page=page),
-        'preview_modes': page.preview_modes,
-        'form': form,
-        'next': next_url,
-        'has_unsaved_changes': has_unsaved_changes,
-    })
+        return render(request, 'wagtailadmin/pages/edit.html', {
+            'page': page,
+            'page_for_status': page_for_status,
+            'content_type': content_type,
+            'edit_handler': edit_handler,
+            'errors_debug': errors_debug,
+            'action_menu': PageActionMenu(request, view='edit', page=page),
+            'preview_modes': page.preview_modes,
+            'form': form,
+            'next': next_url,
+            'has_unsaved_changes': has_unsaved_changes,
+        })
 
 
 def delete(request, page_id):

--- a/wagtail/admin/views/pages.py
+++ b/wagtail/admin/views/pages.py
@@ -181,60 +181,60 @@ def content_type_use(request, content_type_app_name, content_type_model_name):
 
 class CreatePageView(View):
     def dispatch(self, request, content_type_app_name, content_type_model_name, parent_page_id):
-        parent_page = get_object_or_404(Page, id=parent_page_id).specific
-        parent_page_perms = parent_page.permissions_for_user(request.user)
-        if not parent_page_perms.can_add_subpage():
+        self.parent_page = get_object_or_404(Page, id=parent_page_id).specific
+        self.parent_page_perms = self.parent_page.permissions_for_user(request.user)
+        if not self.parent_page_perms.can_add_subpage():
             raise PermissionDenied
 
         try:
-            content_type = ContentType.objects.get_by_natural_key(content_type_app_name, content_type_model_name)
+            self.content_type = ContentType.objects.get_by_natural_key(content_type_app_name, content_type_model_name)
         except ContentType.DoesNotExist:
             raise Http404
 
         # Get class
-        page_class = content_type.model_class()
+        self.page_class = self.content_type.model_class()
 
         # Make sure the class is a descendant of Page
-        if not issubclass(page_class, Page):
+        if not issubclass(self.page_class, Page):
             raise Http404
 
         # page must be in the list of allowed subpage types for this parent ID
-        if page_class not in parent_page.creatable_subpage_models():
+        if self.page_class not in self.parent_page.creatable_subpage_models():
             raise PermissionDenied
 
-        if not page_class.can_create_at(parent_page):
+        if not self.page_class.can_create_at(self.parent_page):
             raise PermissionDenied
 
         for fn in hooks.get_hooks('before_create_page'):
-            result = fn(request, parent_page, page_class)
+            result = fn(request, self.parent_page, self.page_class)
             if hasattr(result, 'status_code'):
                 return result
 
-        page = page_class(owner=request.user)
-        edit_handler = page_class.get_edit_handler()
-        edit_handler = edit_handler.bind_to(request=request, instance=page)
-        form_class = edit_handler.get_form_class()
+        self.page = self.page_class(owner=request.user)
+        self.edit_handler = self.page_class.get_edit_handler()
+        self.edit_handler = self.edit_handler.bind_to(request=request, instance=self.page)
+        self.form_class = self.edit_handler.get_form_class()
 
-        next_url = get_valid_next_url_from_request(request)
+        self.next_url = get_valid_next_url_from_request(request)
 
         if request.method == 'POST':
-            form = form_class(request.POST, request.FILES, instance=page,
-                              parent_page=parent_page)
+            self.form = self.form_class(request.POST, request.FILES, instance=self.page,
+                                        parent_page=self.parent_page)
 
-            if form.is_valid():
-                page = form.save(commit=False)
+            if self.form.is_valid():
+                self.page = self.form.save(commit=False)
 
-                is_publishing = bool(request.POST.get('action-publish')) and parent_page_perms.can_publish_subpage()
+                is_publishing = bool(request.POST.get('action-publish')) and self.parent_page_perms.can_publish_subpage()
                 is_submitting = bool(request.POST.get('action-submit'))
 
                 if not is_publishing:
-                    page.live = False
+                    self.page.live = False
 
                 # Save page
-                parent_page.add_child(instance=page)
+                self.parent_page.add_child(instance=self.page)
 
                 # Save revision
-                revision = page.save_revision(
+                revision = self.page.save_revision(
                     user=request.user,
                     submitted_for_moderation=is_submitting,
                 )
@@ -245,78 +245,86 @@ class CreatePageView(View):
 
                 # Notifications
                 if is_publishing:
-                    if page.go_live_at and page.go_live_at > timezone.now():
-                        messages.success(request, _("Page '{0}' created and scheduled for publishing.").format(page.get_admin_display_title()), buttons=[
-                            messages.button(reverse('wagtailadmin_pages:edit', args=(page.id,)), _('Edit'))
-                        ])
+                    if self.page.go_live_at and self.page.go_live_at > timezone.now():
+                        messages.success(
+                            request,
+                            _("Page '{0}' created and scheduled for publishing.").format(self.page.get_admin_display_title()),
+                            buttons=[
+                                messages.button(reverse('wagtailadmin_pages:edit', args=(self.page.id,)), _('Edit'))
+                            ]
+                        )
                     else:
                         buttons = []
-                        if page.url is not None:
-                            buttons.append(messages.button(page.url, _('View live'), new_window=True))
-                        buttons.append(messages.button(reverse('wagtailadmin_pages:edit', args=(page.id,)), _('Edit')))
-                        messages.success(request, _("Page '{0}' created and published.").format(page.get_admin_display_title()), buttons=buttons)
+                        if self.page.url is not None:
+                            buttons.append(messages.button(self.page.url, _('View live'), new_window=True))
+                        buttons.append(messages.button(reverse('wagtailadmin_pages:edit', args=(self.page.id,)), _('Edit')))
+                        messages.success(
+                            request,
+                            _("Page '{0}' created and published.").format(self.page.get_admin_display_title()),
+                            buttons=buttons
+                        )
                 elif is_submitting:
                     messages.success(
                         request,
-                        _("Page '{0}' created and submitted for moderation.").format(page.get_admin_display_title()),
+                        _("Page '{0}' created and submitted for moderation.").format(self.page.get_admin_display_title()),
                         buttons=[
                             messages.button(
-                                reverse('wagtailadmin_pages:view_draft', args=(page.id,)),
+                                reverse('wagtailadmin_pages:view_draft', args=(self.page.id,)),
                                 _('View draft'),
                                 new_window=True
                             ),
                             messages.button(
-                                reverse('wagtailadmin_pages:edit', args=(page.id,)),
+                                reverse('wagtailadmin_pages:edit', args=(self.page.id,)),
                                 _('Edit')
                             )
                         ]
                     )
-                    if not send_notification(page.get_latest_revision().id, 'submitted', request.user.pk):
+                    if not send_notification(self.page.get_latest_revision().id, 'submitted', request.user.pk):
                         messages.error(request, _("Failed to send notifications to moderators"))
                 else:
-                    messages.success(request, _("Page '{0}' created.").format(page.get_admin_display_title()))
+                    messages.success(request, _("Page '{0}' created.").format(self.page.get_admin_display_title()))
 
                 for fn in hooks.get_hooks('after_create_page'):
-                    result = fn(request, page)
+                    result = fn(request, self.page)
                     if hasattr(result, 'status_code'):
                         return result
 
                 if is_publishing or is_submitting:
                     # we're done here
-                    if next_url:
+                    if self.next_url:
                         # redirect back to 'next' url if present
-                        return redirect(next_url)
+                        return redirect(self.next_url)
                     # redirect back to the explorer
-                    return redirect('wagtailadmin_explore', page.get_parent().id)
+                    return redirect('wagtailadmin_explore', self.page.get_parent().id)
                 else:
                     # Just saving - remain on edit page for further edits
-                    target_url = reverse('wagtailadmin_pages:edit', args=[page.id])
-                    if next_url:
+                    target_url = reverse('wagtailadmin_pages:edit', args=[self.page.id])
+                    if self.next_url:
                         # Ensure the 'next' url is passed through again if present
-                        target_url += '?next=%s' % urlquote(next_url)
+                        target_url += '?next=%s' % urlquote(self.next_url)
                     return redirect(target_url)
             else:
                 messages.validation_error(
-                    request, _("The page could not be created due to validation errors"), form
+                    request, _("The page could not be created due to validation errors"), self.form
                 )
-                has_unsaved_changes = True
+                self.has_unsaved_changes = True
         else:
-            signals.init_new_page.send(sender=self, page=page, parent=parent_page)
-            form = form_class(instance=page, parent_page=parent_page)
-            has_unsaved_changes = False
+            signals.init_new_page.send(sender=self, page=self.page, parent=self.parent_page)
+            self.form = self.form_class(instance=self.page, parent_page=self.parent_page)
+            self.has_unsaved_changes = False
 
-        edit_handler = edit_handler.bind_to(form=form)
+        self.edit_handler = self.edit_handler.bind_to(form=self.form)
 
         return render(request, 'wagtailadmin/pages/create.html', {
-            'content_type': content_type,
-            'page_class': page_class,
-            'parent_page': parent_page,
-            'edit_handler': edit_handler,
-            'action_menu': PageActionMenu(request, view='create', parent_page=parent_page),
-            'preview_modes': page.preview_modes,
-            'form': form,
-            'next': next_url,
-            'has_unsaved_changes': has_unsaved_changes,
+            'content_type': self.content_type,
+            'page_class': self.page_class,
+            'parent_page': self.parent_page,
+            'edit_handler': self.edit_handler,
+            'action_menu': PageActionMenu(request, view='create', parent_page=self.parent_page),
+            'preview_modes': self.page.preview_modes,
+            'form': self.form,
+            'next': self.next_url,
+            'has_unsaved_changes': self.has_unsaved_changes,
         })
 
 

--- a/wagtail/tests/testapp/wagtail_hooks.py
+++ b/wagtail/tests/testapp/wagtail_hooks.py
@@ -8,7 +8,11 @@ from wagtail.admin.menu import MenuItem
 from wagtail.admin.rich_text import HalloPlugin
 from wagtail.admin.rich_text.converters.html_to_contentstate import BlockElementHandler
 from wagtail.admin.search import SearchArea
+from wagtail.admin.views.pages import (
+    CreatePageView, EditPageView, register_create_page_view, register_edit_page_view)
 from wagtail.core import hooks
+
+from wagtail.tests.testapp.models import SingleEventPage
 
 
 # Register one hook using decorators...
@@ -149,3 +153,29 @@ def register_relax_menu_item(menu_items, request, context):
         raise AttributeError('all core sub-classes of ActionMenuItems must have a name attribute', names)
 
     menu_items.append(RelaxMenuItem())
+
+
+# Custom page creation view for SingleEventPage -
+# allows passing a location in the URL
+class SingleEventPageCreateView(CreatePageView):
+    def get_page_instance(self):
+        page = super().get_page_instance()
+        page.location = self.request.GET.get('location', '')
+        return page
+
+
+register_create_page_view(SingleEventPage, SingleEventPageCreateView.as_view())
+
+
+# Custom page edit view for SingleEventPage -
+# adds [UPDATED] to the title if 'updated' URL parameter passed
+class SingleEventPageEditView(EditPageView):
+    def get_page_instance(self):
+        page = super().get_page_instance()
+        if self.request.GET.get('updated'):
+            page.title += ' [UPDATED]'
+
+        return page
+
+
+register_edit_page_view(SingleEventPage, SingleEventPageEditView.as_view())


### PR DESCRIPTION
This PR converts the page creation and edit views in `wagtail.admin.views.pages` into class-based views with several overrideable methods (`get_page_instance`, `get_edit_handler`, `get_form_class`, `get_context_data`) and provides a mechanism for custom versions of those views to be hooked in on a per-page-type basis.

The motivation for this was to provide a shortcut link for editors, taking them to a version of the 'create page' view with some fields dynamically pre-populated based on a URL parameter. This apparently isn't possible (aside from questionable hacks) through the existing hooks or form / edit_handler customisation features.

This is, admittedly, a pretty heavyweight code change for that one use-case, but it seems like the most future-proof approach. Other options I considered and rejected were a new hook for modifying the page instance used to build the form (but that felt like an overly specific 'niche' thing for a hook - if every similarly low-level detail was hookable, we'd end up with millions of them...) and adding new properties / methods to the model to control how the object/form instantiation behaves (which would have coupled the model code far too tightly to the view-level behaviour - we're already pushing this probably further than necessary with the likes of `base_form_class`).