### PR TITLE
Offer no delete options, as is on pages and snippets

### DIFF
--- a/wagtail/contrib/modeladmin/templates/modeladmin/delete.html
+++ b/wagtail/contrib/modeladmin/templates/modeladmin/delete.html
@@ -23,6 +23,7 @@
                 <form action="{{ view.delete_url }}" method="POST">
                     {% csrf_token %}
                     <input type="submit" value="{% trans 'Yes, delete' %}" class="button serious" />
+                    <a href="{{ view.index_url }}" class="button button-secondary">{% trans "No, don't delete" %}</a>
                 </form>
             {% endif %}
         </div>

--- a/wagtail/documents/templates/wagtaildocs/documents/confirm_delete.html
+++ b/wagtail/documents/templates/wagtaildocs/documents/confirm_delete.html
@@ -18,6 +18,7 @@
         <form action="{% url 'wagtaildocs:delete' document.id %}" method="POST">
             {% csrf_token %}
             <input type="submit" value='{% trans "Yes, delete" %}' class="button serious" />
+            <a href="{% url 'wagtaildocs:index' %}" class="button button-secondary">{% trans "No, don't delete" %}</a>
         </form>
     </div>
 {% endblock %}

--- a/wagtail/images/templates/wagtailimages/images/confirm_delete.html
+++ b/wagtail/images/templates/wagtailimages/images/confirm_delete.html
@@ -21,6 +21,7 @@
             <form action="{% url 'wagtailimages:delete' image.id %}" method="POST">
                 {% csrf_token %}
                 <input type="submit" value="{% trans 'Yes, delete' %}" class="button serious" />
+                <a href="{% url 'wagtailimages:index' %}" class="button button-secondary">{% trans "No, don't delete" %}</a>
             </form>
         </div>
     </div>


### PR DESCRIPTION
Really just an idea, as we now have 'No, don't delete' buttons for snippets, it might be good to adopt this in other places so the UI is more consistent.

* Do the tests still pass? *Yes*
* Does the code comply with the style guide? (Run `make lint` from the Wagtail root) *Yes*
* For Python changes: Have you added tests to cover the new/fixed behaviour? *No, I don't think a test for this is necessary.*
