### PR TITLE
Expose Permission object in format_permssions tag

### DIFF
--- a/wagtail/users/templates/wagtailusers/groups/includes/formatted_permissions.html
+++ b/wagtail/users/templates/wagtailusers/groups/includes/formatted_permissions.html
@@ -19,13 +19,13 @@
         <tr>
             <td class="title"><h3>{{ content_perms_dict.object|capfirst }}</h3></td>
             <td>
-                {% if content_perms_dict.add %}{{ content_perms_dict.add.tag }}{% endif %}
+                {% if content_perms_dict.add %}{{ content_perms_dict.add.checkbox.tag }}{% endif %}
             </td>
             <td>
-                {% if content_perms_dict.change %}{{ content_perms_dict.change.tag }}{% endif %}
+                {% if content_perms_dict.change %}{{ content_perms_dict.change.checkbox.tag }}{% endif %}
             </td>
             <td>
-                {% if content_perms_dict.delete %}{{ content_perms_dict.delete.tag }}{% endif %}
+                {% if content_perms_dict.delete %}{{ content_perms_dict.delete.checkbox.tag }}{% endif %}
             </td>
         </tr>
         {% endfor %}

--- a/wagtail/users/templatetags/wagtailusers_tags.py
+++ b/wagtail/users/templatetags/wagtailusers_tags.py
@@ -59,7 +59,9 @@ def format_permissions(permission_bound_field):
             permission_action = perm.codename.split('_')[0]
             if permission_action in ['add', 'change', 'delete']:
                 content_perms_dict['object'] = perm.content_type.name
-                content_perms_dict[permission_action] = checkbox
+                content_perms_dict[permission_action] = {
+                    'perm': perm, 'checkbox': checkbox,
+                }
             else:
                 other_perms.append((perm, checkbox))
         if content_perms_dict:


### PR DESCRIPTION
A checkbox (specifically, a `BoundWidget`) is instantiated with data from a `django.contrib.auth.models.Permission` instance.  However it doesn't receive the full object so it isn't available in the template.  This stops a user from accessing useful values like `Permission.name`.

This adds the relevant Permission object to the template in a dict for ease of access.