### PR TITLE
update docs for TabbedInterface

### DIFF
--- a/docs/reference/contrib/modeladmin/create_edit_delete_views.rst
+++ b/docs/reference/contrib/modeladmin/create_edit_delete_views.rst
@@ -56,7 +56,7 @@ Or alternatively:
         ]
         edit_handler = ObjectList(custom_panels)
         # or
-        edit_handler = TabbedInterface([ObjectList(custom_panels), ObjectList(...)])
+        edit_handler = TabbedInterface([ObjectList(custom_panels, heading='First Tab'), ObjectList(...)])
 
 
 .. versionadded:: 2.5


### PR DESCRIPTION
This micro-PR just updates the docs for the TabbedInterface to be consistent with the other places that it's documented (by including a `heading` kwarg)

*Correct*
https://docs.wagtail.io/en/v2.5.1/reference/contrib/settings.html?highlight=tabbedinterface

vs

*Borderline Incorrect*
https://docs.wagtail.io/en/v2.5.1/reference/contrib/modeladmin/create_edit_delete_views.html?highlight=tabbedinterface

It's worth noting that without a `heading` field the tabbed interface doesn't work properly because the javascript on the page uses an identifier of `#tab-{{ heading }}` -- this means if all of the tabs have the same default `''` for the heading -- they won't switch properly.

This means it could be worth making `heading` a required field for the tabbed interface! But that would be a slightly bigger change (and I'd be willing to take a look tomorrow)

Thanks!