### PR TITLE
Adds clearer text to the close button for modals

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -46,6 +46,7 @@ Changelog
  * Fix: Remove duplicate labels in image gallery and image choosers for screen reader users (Helen Chapman)
  * Fix: Restore custom "Date" icon for scheduled publishing panel in Edit page’s Settings tab (Helen Chapman)
  * Fix: Added missing form media to user edit form template (Matt Westcott)
+ * Fix: Add a label to the modals’ “close” button for screen reader users (Helen Chapman, Katie Locke)
 
 
 2.5.1 (07.05.2019)

--- a/client/tests/stubs.js
+++ b/client/tests/stubs.js
@@ -43,6 +43,7 @@ global.wagtailConfig = {
     EDITOR_CRASH: 'The editor just crashed. Content has been reset to the last saved version.',
     BROKEN_LINK: 'Broken link',
     MISSING_DOCUMENT: 'Missing document',
+    CLOSE: 'Close',
   },
 };
 

--- a/docs/releases/2.6.rst
+++ b/docs/releases/2.6.rst
@@ -60,6 +60,7 @@ Bug fixes
  * Remove duplicate labels in image gallery and image choosers for screen reader users (Helen Chapman)
  * Restore custom "Date" icon for scheduled publishing panel in Edit page’s Settings tab (Helen Chapman)
  * Added missing form media to user edit form template (Matt Westcott)
+ * Added a label to the modals’ “close” button for screen reader users (Helen Chapman, Katie Locke)
 
 
 Upgrade considerations

--- a/wagtail/admin/static_src/wagtailadmin/js/modal-workflow.js
+++ b/wagtail/admin/static_src/wagtailadmin/js/modal-workflow.js
@@ -21,7 +21,7 @@ function ModalWorkflow(opts) {
     $('body > .modal').remove();
 
     // set default contents of container
-    var container = $('<div class="modal fade" tabindex="-1" role="dialog" aria-hidden="true">\n    <div class="modal-dialog">\n        <div class="modal-content">\n            <button type="button" class="button close icon text-replace icon-cross" data-dismiss="modal" aria-hidden="true">' + wagtailConfig.STRINGS.CLOSE + '</button>\n            <div class="modal-body"></div>\n        </div><!-- /.modal-content -->\n    </div><!-- /.modal-dialog -->\n</div>');
+    var container = $('<div class="modal fade" tabindex="-1" role="dialog" aria-hidden="true">\n    <div class="modal-dialog">\n        <div class="modal-content">\n            <button type="button" class="button close icon text-replace icon-cross" data-dismiss="modal">' + wagtailConfig.STRINGS.CLOSE + '</button>\n            <div class="modal-body"></div>\n        </div><!-- /.modal-content -->\n    </div><!-- /.modal-dialog -->\n</div>');
 
     // add container to body and hide it, so content can be added to it before display
     $('body').append(container);

--- a/wagtail/admin/static_src/wagtailadmin/js/modal-workflow.js
+++ b/wagtail/admin/static_src/wagtailadmin/js/modal-workflow.js
@@ -21,7 +21,7 @@ function ModalWorkflow(opts) {
     $('body > .modal').remove();
 
     // set default contents of container
-    var container = $('<div class="modal fade" tabindex="-1" role="dialog" aria-hidden="true">\n    <div class="modal-dialog">\n        <div class="modal-content">\n            <button type="button" class="button close icon text-replace icon-cross" data-dismiss="modal" aria-hidden="true">&times;</button>\n            <div class="modal-body"></div>\n        </div><!-- /.modal-content -->\n    </div><!-- /.modal-dialog -->\n</div>');
+    var container = $('<div class="modal fade" tabindex="-1" role="dialog" aria-hidden="true">\n    <div class="modal-dialog">\n        <div class="modal-content">\n            <button type="button" class="button close icon text-replace icon-cross" data-dismiss="modal" aria-hidden="true">' + gettext('close') + '</button>\n            <div class="modal-body"></div>\n        </div><!-- /.modal-content -->\n    </div><!-- /.modal-dialog -->\n</div>');
 
     // add container to body and hide it, so content can be added to it before display
     $('body').append(container);

--- a/wagtail/admin/static_src/wagtailadmin/js/modal-workflow.js
+++ b/wagtail/admin/static_src/wagtailadmin/js/modal-workflow.js
@@ -21,7 +21,7 @@ function ModalWorkflow(opts) {
     $('body > .modal').remove();
 
     // set default contents of container
-    var container = $('<div class="modal fade" tabindex="-1" role="dialog" aria-hidden="true">\n    <div class="modal-dialog">\n        <div class="modal-content">\n            <button type="button" class="button close icon text-replace icon-cross" data-dismiss="modal" aria-hidden="true">' + gettext('close') + '</button>\n            <div class="modal-body"></div>\n        </div><!-- /.modal-content -->\n    </div><!-- /.modal-dialog -->\n</div>');
+    var container = $('<div class="modal fade" tabindex="-1" role="dialog" aria-hidden="true">\n    <div class="modal-dialog">\n        <div class="modal-content">\n            <button type="button" class="button close icon text-replace icon-cross" data-dismiss="modal" aria-hidden="true">' + wagtailConfig.STRINGS.CLOSE + '</button>\n            <div class="modal-body"></div>\n        </div><!-- /.modal-content -->\n    </div><!-- /.modal-dialog -->\n</div>');
 
     // add container to body and hide it, so content can be added to it before display
     $('body').append(container);

--- a/wagtail/admin/templates/wagtailadmin/admin_base.html
+++ b/wagtail/admin/templates/wagtailadmin/admin_base.html
@@ -102,6 +102,7 @@
     <script src="{% static 'wagtailadmin/js/core.js' %}"></script>
     <script src="{% static 'wagtailadmin/js/vendor.js' %}"></script>
     <script src="{% static 'wagtailadmin/js/wagtailadmin.js' %}"></script>
+    <script type="text/javascript" src="{% url 'jsi18n' %}"></script>
     {% hook_output 'insert_global_admin_js' %}
 
 

--- a/wagtail/admin/templates/wagtailadmin/admin_base.html
+++ b/wagtail/admin/templates/wagtailadmin/admin_base.html
@@ -51,6 +51,7 @@
                 EDITOR_CRASH: "{% trans 'The editor just crashed. Content has been reset to the last saved version.' %}",
                 BROKEN_LINK: "{% trans 'Broken link' %}",
                 MISSING_DOCUMENT: "{% trans 'Missing document' %}",
+                CLOSE: "{% trans 'Close' %}",
 
                 MONTHS: [
                     "{% trans 'January' %}",
@@ -102,7 +103,6 @@
     <script src="{% static 'wagtailadmin/js/core.js' %}"></script>
     <script src="{% static 'wagtailadmin/js/vendor.js' %}"></script>
     <script src="{% static 'wagtailadmin/js/wagtailadmin.js' %}"></script>
-    <script type="text/javascript" src="{% url 'jsi18n' %}"></script>
     {% hook_output 'insert_global_admin_js' %}
 
 

--- a/wagtail/core/urls.py
+++ b/wagtail/core/urls.py
@@ -1,7 +1,6 @@
 from django.conf import settings
 from django.conf.urls import url
 from django.contrib.auth import views as auth_views
-from django.views.i18n import JavaScriptCatalog
 
 from wagtail.core import views
 from wagtail.core.utils import WAGTAIL_APPEND_SLASH
@@ -28,7 +27,6 @@ urlpatterns = [
         name='wagtailcore_authenticate_with_password'),
     url(r'^_util/login/$', auth_views.LoginView.as_view(template_name=WAGTAIL_FRONTEND_LOGIN_TEMPLATE),
         name='wagtailcore_login'),
-    url(r'^jsi18n/', JavaScriptCatalog.as_view(), name='jsi18n'),
 
     # Front-end page views are handled through Wagtail's core.views.serve
     # mechanism

--- a/wagtail/core/urls.py
+++ b/wagtail/core/urls.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 from django.conf.urls import url
 from django.contrib.auth import views as auth_views
+from django.views.i18n import JavaScriptCatalog
 
 from wagtail.core import views
 from wagtail.core.utils import WAGTAIL_APPEND_SLASH
@@ -27,6 +28,7 @@ urlpatterns = [
         name='wagtailcore_authenticate_with_password'),
     url(r'^_util/login/$', auth_views.LoginView.as_view(template_name=WAGTAIL_FRONTEND_LOGIN_TEMPLATE),
         name='wagtailcore_login'),
+    url(r'^jsi18n/', JavaScriptCatalog.as_view(), name='jsi18n'),
 
     # Front-end page views are handled through Wagtail's core.views.serve
     # mechanism


### PR DESCRIPTION
This relates to https://github.com/wagtail/wagtail/issues/5274

Instead of using a X symbol for the close button, use the word 'close'

Because this involves adding text to a javascript file I have added the option to translate text in javascript.

