### PR TITLE
Fix help-inverse icon regression introduced by icon refactorings in #5359

### DIFF
--- a/client/scss/components/_icons.scss
+++ b/client/scss/components/_icons.scss
@@ -122,7 +122,6 @@
     $size: 15px;
 
     &:before {
-        content: map-get($icons, 'help');
         display: inline-block;
         width: $size;
         height: $size;

--- a/client/scss/settings/_variables.icons.scss
+++ b/client/scss/settings/_variables.icons.scss
@@ -30,6 +30,8 @@ $icons: (
     'grip': '\e03b',
     'group': '\e031',
     'help': '\e041',
+    // help-inverse directly renders the corresponding character.
+    'help-inverse': '?',
     'home': '\e035',
     // horizontalrule is not rendered as an icon font – it uses a unicode dash character rendered with a fallback font.
     'horizontalrule': '\2014',

--- a/wagtail/contrib/styleguide/templates/wagtailstyleguide/base.html
+++ b/wagtail/contrib/styleguide/templates/wagtailstyleguide/base.html
@@ -798,6 +798,7 @@
                 <li class="icon icon-grip">grip</li>
                 <li class="icon icon-group">group</li>
                 <li class="icon icon-help">help</li>
+                <li class="icon icon-help-inverse">help-inverse</li>
                 <li class="icon icon-home">home</li>
                 <li class="icon icon-horizontalrule">horizontalrule</li>
                 <li class="icon icon-image">image</li>


### PR DESCRIPTION
Changes from #5359 broke the `help-inverse` icon used for help text in the page editing UI. I thought this icon was using the same glyph as `help` – it’s not, it’s actually just displaying the "?" character.

The icon was missing from the styleguide which is also why I missed the breakage. I’ve added it there.

Tested in Chrome, Safari, Firefox on macOS + iOS Safari & IE11.