### PR TITLE
Ensure the 'add child page' icon displays when focused

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -47,6 +47,7 @@ Changelog
  * Fix: Restore custom "Date" icon for scheduled publishing panel in Edit page’s Settings tab (Helen Chapman)
  * Fix: Added missing form media to user edit form template (Matt Westcott)
  * Fix: Add a label to the modals’ “close” button for screen reader users (Helen Chapman, Katie Locke)
+ * Fix: Ensure the 'add child page' button displays when focused (Helen Chapman, Katie Locke)
 
 
 2.5.1 (07.05.2019)

--- a/client/scss/components/_listing.scss
+++ b/client/scss/components/_listing.scss
@@ -279,8 +279,13 @@ ul.listing {
             font-size: 1.5rem;
         }
 
-        &:hover {
+        &:hover,
+        &:focus {
             color: $color-teal;
+        }
+
+        &:focus {
+            opacity: 1; //opacity is already changed on hover on the parent tr
         }
     }
 

--- a/docs/releases/2.6.rst
+++ b/docs/releases/2.6.rst
@@ -61,6 +61,7 @@ Bug fixes
  * Restore custom "Date" icon for scheduled publishing panel in Edit page’s Settings tab (Helen Chapman)
  * Added missing form media to user edit form template (Matt Westcott)
  * Added a label to the modals’ “close” button for screen reader users (Helen Chapman, Katie Locke)
+ * Ensured the 'add child page' button displays when focused (Helen Chapman, Katie Locke)
 
 
 Upgrade considerations


### PR DESCRIPTION
See https://github.com/wagtail/wagtail/issues/5274

This PR adjusts the CSS to ensure that if the 'add child page' icon in the page listing is focused, it is visible and a green colour.

Tested in the following browsers:

Latest Chrome on Max OSX High Sierra
Latest Safari on Max OSX High Sierra
Latest Firefox on Max OSX High Sierra
IE11 on Windows 10
IE Edge latest version on Windows 10

I also tested on the following touchscreen devices, as the focus state displays briefly when you click on the button:
iOS 12 on iphone XS
iOS 11 on iPad Pro 2017
Android 8 on Galaxy S9
Android 7 on Galaxy S8
