### PR TITLE
Resolves Lack of construct_hook_name for settings_menu #5301

### DIFF
--- a/wagtail/admin/menu.py
+++ b/wagtail/admin/menu.py
@@ -120,4 +120,4 @@ class SubmenuMenuItem(MenuItem):
 
 
 admin_menu = Menu(register_hook_name='register_admin_menu_item', construct_hook_name='construct_main_menu')
-settings_menu = Menu(register_hook_name='register_settings_menu_item')
+settings_menu = Menu(register_hook_name='register_settings_menu_item', construct_hook_name='construct_settings_menu')


### PR DESCRIPTION
This PR is meant to resolve issue #5301 


Tested using 

@hooks.register('construct_settings_menu')
def hide_documents_menu_item(request, menu_items):
    menu_items[:] = [item for item in menu_items if item.name != 'redirects']