### PR TITLE
Add form media to users/edit.html

### DIFF
--- a/wagtail/users/templates/wagtailusers/users/edit.html
+++ b/wagtail/users/templates/wagtailusers/users/edit.html
@@ -67,8 +67,10 @@
 {% block extra_css %}
     {{ block.super }}
     {% include "wagtailadmin/pages/_editor_css.html" %}
+    {{ form.media.css }}
 {% endblock %}
 {% block extra_js %}
     {{ block.super }}
     {% include "wagtailadmin/pages/_editor_js.html" %}
+    {{ form.media.js }}
 {% endblock %}


### PR DESCRIPTION
When I merged #5146, I added `{{ form.media.css }}` / `{{ form.media.js }}` to the extra_css / extra_js blocks as those had been moved out of _editor_css.html / _editor_js.html in the meantime. Unfortunately, it seems that I missed that on users/edit.html... 🤦‍♂ 