### PR TITLE
Fix elasticsearch search backend tests broken by #5208

### DIFF
--- a/wagtail/contrib/modeladmin/views.py
+++ b/wagtail/contrib/modeladmin/views.py
@@ -439,19 +439,9 @@ class IndexView(WMABaseView):
         # database backends.
         pk_name = self.opts.pk.name
 
-        if hasattr(self.model, 'get_filterable_search_fields'):
-            # The model is indexed, so let's be careful to only add
-            # indexed fields to ordering where possible
-            filterable_fields = self.model.get_filterable_search_fields()
-        else:
-            filterable_fields = None
-
         if not (set(ordering) & {'pk', '-pk', pk_name, '-' + pk_name}):
             # ordering isn't already being applied to pk
-            if filterable_fields is None or 'pk' in filterable_fields:
-                ordering.append('-pk')
-            else:
-                ordering.append('-' + pk_name)
+            ordering.append('-' + pk_name)
 
         return ordering
 

--- a/wagtail/tests/modeladmintest/models.py
+++ b/wagtail/tests/modeladmintest/models.py
@@ -33,7 +33,7 @@ class Book(models.Model, index.Indexed):
     search_fields = [
         index.SearchField('title'),
         index.FilterField('title'),
-        index.FilterField('pk'),
+        index.FilterField('id'),
     ]
 
     def __str__(self):


### PR DESCRIPTION
@gasman I'm not entirely sure why, but indexing 'id' field instead of 'pk' seems to fix the broken search backend tests (as reported here: https://github.com/wagtail/wagtail/pull/5208#issuecomment-502697773)

I've also updated  `IndexView.get_ordering()` to always use the field name when modifying the ordering. If indexing 'pk' isn't supported for some reason, we want to avoid raising `IndexError` messages that encourage the user to index 'pk'.