### PR TITLE
Allow the tabs content to define the tab width on xs screens to stop cutting of text

### DIFF
--- a/client/scss/components/_tabs.scss
+++ b/client/scss/components/_tabs.scss
@@ -148,6 +148,6 @@
     }
 
     .tab-nav li {
-        width: 25%;
+        width: auto;
     }
 }


### PR DESCRIPTION
Tabbed title on small screens is getting cut off due to the width setting:

![tab eg](https://i.imgur.com/vcBAPVd.png)

This PR sets the width as auto resulting in:

![tab eg 2](https://i.imgur.com/gMxuYL6.png)