### PR TITLE
5336 focus move to pages explorer when open

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -55,6 +55,7 @@ Changelog
  * Fix: Remove tab order customisations in CMS admin (Jordan Bauer)
  * Fix: Add labels to permission checkboxes for screen reader users (Helen Chapman, Katie Locke)
  * Fix: Page.copy() no longer copies child objects when the accesssor name is included in `exclude_fields_in_copy` (Karl Hobley)
+ * Fix: Move focus to the pages explorer menu when open (Helen Chapman)
 
 
 2.5.1 (07.05.2019)

--- a/client/src/components/Button/Button.js
+++ b/client/src/components/Button/Button.js
@@ -38,6 +38,7 @@ const Button = ({
   target,
   preventDefault,
   onClick,
+  dialogTrigger,
 }) => {
   const hasText = children !== null;
   const iconName = isLoading ? 'spinner' : icon;
@@ -54,6 +55,7 @@ const Button = ({
       rel={target === '_blank' ? 'noopener noreferrer' : null}
       href={href}
       target={target}
+      aria-haspopup={dialogTrigger ? 'dialog' : null}
     >
       {hasText ? children : accessibleElt}
     </a>
@@ -73,6 +75,7 @@ Button.propTypes = {
   onClick: PropTypes.func,
   isLoading: PropTypes.bool,
   preventDefault: PropTypes.bool,
+  dialogTrigger: PropTypes.bool,
 };
 
 Button.defaultProps = {
@@ -85,6 +88,7 @@ Button.defaultProps = {
   onClick: null,
   isLoading: false,
   preventDefault: true,
+  dialogTrigger: false,
 };
 
 export default Button;

--- a/client/src/components/Button/Button.test.js
+++ b/client/src/components/Button/Button.test.js
@@ -20,6 +20,10 @@ describe('Button', () => {
     expect(shallow(<Button accessibleLabel="I am here in the shadows" />)).toMatchSnapshot();
   });
 
+  it('#dialogTrigger', () => {
+    expect(shallow(<Button dialogTrigger />)).toMatchSnapshot();
+  });
+
   it('#icon', () => {
     expect(shallow(<Button icon="test-icon" />)).toMatchSnapshot();
   });

--- a/client/src/components/Button/__snapshots__/Button.test.js.snap
+++ b/client/src/components/Button/__snapshots__/Button.test.js.snap
@@ -30,6 +30,17 @@ exports[`Button #children 1`] = `
 </a>
 `;
 
+exports[`Button #dialogTrigger 1`] = `
+<a
+  aria-haspopup="dialog"
+  className=" "
+  href="#"
+  onClick={[Function]}
+  rel={null}
+  target={null}
+/>
+`;
+
 exports[`Button #icon 1`] = `
 <a
   aria-haspopup={null}

--- a/client/src/components/Button/__snapshots__/Button.test.js.snap
+++ b/client/src/components/Button/__snapshots__/Button.test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`Button #accessibleLabel 1`] = `
 <a
+  aria-haspopup={null}
   className=" "
   href="#"
   onClick={[Function]}
@@ -18,6 +19,7 @@ exports[`Button #accessibleLabel 1`] = `
 
 exports[`Button #children 1`] = `
 <a
+  aria-haspopup={null}
   className=" "
   href="#"
   onClick={[Function]}
@@ -30,6 +32,7 @@ exports[`Button #children 1`] = `
 
 exports[`Button #icon 1`] = `
 <a
+  aria-haspopup={null}
   className=" icon icon-test-icon"
   href="#"
   onClick={[Function]}
@@ -40,6 +43,7 @@ exports[`Button #icon 1`] = `
 
 exports[`Button #icon changes with #isLoading 1`] = `
 <a
+  aria-haspopup={null}
   className=" icon icon-spinner"
   href="#"
   onClick={[Function]}
@@ -50,6 +54,7 @@ exports[`Button #icon changes with #isLoading 1`] = `
 
 exports[`Button #multiple icons 1`] = `
 <a
+  aria-haspopup={null}
   className=" icon icon-test-icon icon-secondary-icon"
   href="#"
   onClick={[Function]}
@@ -60,6 +65,7 @@ exports[`Button #multiple icons 1`] = `
 
 exports[`Button #target 1`] = `
 <a
+  aria-haspopup={null}
   className=" "
   href="#"
   onClick={[Function]}
@@ -70,6 +76,7 @@ exports[`Button #target 1`] = `
 
 exports[`Button basic 1`] = `
 <a
+  aria-haspopup={null}
   className=" "
   href="#"
   onClick={[Function]}

--- a/client/src/components/Explorer/ExplorerPanel.js
+++ b/client/src/components/Explorer/ExplorerPanel.js
@@ -137,8 +137,9 @@ class ExplorerPanel extends React.Component {
 
     return (
       <FocusTrap
-        tag="nav"
+        tag="div"
         aria-labelledby="nav-page-explorer-header"
+        role="dialog"
         className="explorer"
         paused={paused || !page || page.isFetching}
         focusTrapOptions={{
@@ -147,7 +148,7 @@ class ExplorerPanel extends React.Component {
         }}
       >
         <h2 className="visuallyhidden" id="nav-page-explorer-header">Page Explorer</h2>
-        <Button className="c-explorer__close u-hidden" onClick={onClose}>
+        <Button className="c-explorer__close visuallyhidden" onClick={onClose}>
           {STRINGS.CLOSE_EXPLORER}
         </Button>
         <Transition name={transition} className="c-explorer">

--- a/client/src/components/Explorer/ExplorerPanel.js
+++ b/client/src/components/Explorer/ExplorerPanel.js
@@ -138,13 +138,15 @@ class ExplorerPanel extends React.Component {
     return (
       <FocusTrap
         tag="nav"
+        aria-labelledby="nav-page-explorer-header"
         className="explorer"
         paused={paused || !page || page.isFetching}
         focusTrapOptions={{
-          initialFocus: '.c-explorer__close',
+          initialFocus: '.c-explorer__header',
           onDeactivate: onClose,
         }}
       >
+        <h2 className="visuallyhidden" id="nav-page-explorer-header">Page Explorer</h2>
         <Button className="c-explorer__close u-hidden" onClick={onClose}>
           {STRINGS.CLOSE_EXPLORER}
         </Button>

--- a/client/src/components/Explorer/ExplorerPanel.js
+++ b/client/src/components/Explorer/ExplorerPanel.js
@@ -138,7 +138,6 @@ class ExplorerPanel extends React.Component {
     return (
       <FocusTrap
         tag="div"
-        aria-labelledby="nav-page-explorer-header"
         role="dialog"
         className="explorer"
         paused={paused || !page || page.isFetching}
@@ -147,12 +146,12 @@ class ExplorerPanel extends React.Component {
           onDeactivate: onClose,
         }}
       >
-        <h2 className="visuallyhidden" id="nav-page-explorer-header">Page Explorer</h2>
         <Button className="c-explorer__close visuallyhidden" onClick={onClose}>
           {STRINGS.CLOSE_EXPLORER}
         </Button>
         <Transition name={transition} className="c-explorer">
-          <div key={path.length} className="c-transition-group">
+          <nav key={path.length} className="c-transition-group" aria-labelledby="nav-page-explorer-header">
+            <h2 className="visuallyhidden" id="nav-page-explorer-header">Page Explorer</h2>
             <ExplorerHeader
               depth={path.length}
               page={page}
@@ -164,7 +163,7 @@ class ExplorerPanel extends React.Component {
             {page.isError || page.children.items && page.children.count > MAX_EXPLORER_PAGES ? (
               <PageCount page={page} />
             ) : null}
-          </div>
+          </nav>
         </Transition>
       </FocusTrap>
     );

--- a/client/src/components/Explorer/ExplorerPanel.js
+++ b/client/src/components/Explorer/ExplorerPanel.js
@@ -146,24 +146,21 @@ class ExplorerPanel extends React.Component {
           onDeactivate: onClose,
         }}
       >
-        <Button className="c-explorer__close visuallyhidden" onClick={onClose}>
+        <Button className="c-explorer__close u-hidden" onClick={onClose}>
           {STRINGS.CLOSE_EXPLORER}
         </Button>
-        <Transition name={transition} className="c-explorer">
-          <nav key={path.length} className="c-transition-group" aria-labelledby="nav-page-explorer-header">
-            <h2 className="visuallyhidden" id="nav-page-explorer-header">Page Explorer</h2>
-            <ExplorerHeader
-              depth={path.length}
-              page={page}
-              onClick={this.onHeaderClick}
-            />
+        <Transition name={transition} className="c-explorer" component="nav" label={STRINGS.PAGE_EXPLORER}>
+          <ExplorerHeader
+            depth={path.length}
+            page={page}
+            onClick={this.onHeaderClick}
+          />
 
-            {this.renderChildren()}
+          {this.renderChildren()}
 
-            {page.isError || page.children.items && page.children.count > MAX_EXPLORER_PAGES ? (
-              <PageCount page={page} />
-            ) : null}
-          </nav>
+          {page.isError || page.children.items && page.children.count > MAX_EXPLORER_PAGES ? (
+            <PageCount page={page} />
+          ) : null}
         </Transition>
       </FocusTrap>
     );

--- a/client/src/components/Explorer/ExplorerPanel.js
+++ b/client/src/components/Explorer/ExplorerPanel.js
@@ -150,17 +150,19 @@ class ExplorerPanel extends React.Component {
           {STRINGS.CLOSE_EXPLORER}
         </Button>
         <Transition name={transition} className="c-explorer" component="nav" label={STRINGS.PAGE_EXPLORER}>
-          <ExplorerHeader
-            depth={path.length}
-            page={page}
-            onClick={this.onHeaderClick}
-          />
+          <div key={path.length} className="c-transition-group">
+            <ExplorerHeader
+              depth={path.length}
+              page={page}
+              onClick={this.onHeaderClick}
+            />
 
-          {this.renderChildren()}
+            {this.renderChildren()}
 
-          {page.isError || page.children.items && page.children.count > MAX_EXPLORER_PAGES ? (
-            <PageCount page={page} />
-          ) : null}
+            {page.isError || page.children.items && page.children.count > MAX_EXPLORER_PAGES ? (
+              <PageCount page={page} />
+            ) : null}
+          </div>
         </Transition>
       </FocusTrap>
     );

--- a/client/src/components/Explorer/ExplorerToggle.js
+++ b/client/src/components/Explorer/ExplorerToggle.js
@@ -13,6 +13,7 @@ const ExplorerToggle = ({ children, onToggle }) => (
   <Button
     className="submenu-trigger"
     icon="folder-open-inverse"
+    dialogTrigger={true}
     onClick={onToggle}
   >
     {children}

--- a/client/src/components/Explorer/__snapshots__/ExplorerHeader.test.js.snap
+++ b/client/src/components/Explorer/__snapshots__/ExplorerHeader.test.js.snap
@@ -4,6 +4,7 @@ exports[`ExplorerHeader #depth at root 1`] = `
 <Button
   accessibleLabel={null}
   className="c-explorer__header"
+  dialogTrigger={false}
   href="/admin/pages/"
   icon=""
   isLoading={false}
@@ -30,6 +31,7 @@ exports[`ExplorerHeader #page 1`] = `
 <Button
   accessibleLabel={null}
   className="c-explorer__header"
+  dialogTrigger={false}
   href="/admin/pages/a/"
   icon=""
   isLoading={false}
@@ -56,6 +58,7 @@ exports[`ExplorerHeader basic 1`] = `
 <Button
   accessibleLabel={null}
   className="c-explorer__header"
+  dialogTrigger={false}
   href="/admin/pages/"
   icon=""
   isLoading={false}

--- a/client/src/components/Explorer/__snapshots__/ExplorerItem.test.js.snap
+++ b/client/src/components/Explorer/__snapshots__/ExplorerItem.test.js.snap
@@ -7,6 +7,7 @@ exports[`ExplorerItem children 1`] = `
   <Button
     accessibleLabel={null}
     className="c-explorer__item__link"
+    dialogTrigger={false}
     href="/admin/pages/5/"
     icon=""
     isLoading={false}
@@ -28,6 +29,7 @@ exports[`ExplorerItem children 1`] = `
   <Button
     accessibleLabel={null}
     className="c-explorer__item__action c-explorer__item__action--small"
+    dialogTrigger={false}
     href="/admin/pages/5/edit/"
     icon=""
     isLoading={false}
@@ -44,6 +46,7 @@ exports[`ExplorerItem children 1`] = `
   <Button
     accessibleLabel={null}
     className="c-explorer__item__action"
+    dialogTrigger={false}
     href="/admin/pages/5/"
     icon=""
     isLoading={false}
@@ -67,6 +70,7 @@ exports[`ExplorerItem renders 1`] = `
   <Button
     accessibleLabel={null}
     className="c-explorer__item__link"
+    dialogTrigger={false}
     href="/admin/pages/5/"
     icon=""
     isLoading={false}
@@ -83,6 +87,7 @@ exports[`ExplorerItem renders 1`] = `
   <Button
     accessibleLabel={null}
     className="c-explorer__item__action c-explorer__item__action--small"
+    dialogTrigger={false}
     href="/admin/pages/5/edit/"
     icon=""
     isLoading={false}
@@ -106,6 +111,7 @@ exports[`ExplorerItem should show a publication status if not live 1`] = `
   <Button
     accessibleLabel={null}
     className="c-explorer__item__link"
+    dialogTrigger={false}
     href="/admin/pages/5/"
     icon=""
     isLoading={false}
@@ -140,6 +146,7 @@ exports[`ExplorerItem should show a publication status if not live 1`] = `
   <Button
     accessibleLabel={null}
     className="c-explorer__item__action c-explorer__item__action--small"
+    dialogTrigger={false}
     href="/admin/pages/5/edit/"
     icon=""
     isLoading={false}
@@ -156,6 +163,7 @@ exports[`ExplorerItem should show a publication status if not live 1`] = `
   <Button
     accessibleLabel={null}
     className="c-explorer__item__action"
+    dialogTrigger={false}
     href="/admin/pages/5/"
     icon=""
     isLoading={false}
@@ -179,6 +187,7 @@ exports[`ExplorerItem should show a publication status with unpublished changes 
   <Button
     accessibleLabel={null}
     className="c-explorer__item__link"
+    dialogTrigger={false}
     href="/admin/pages/5/"
     icon=""
     isLoading={false}
@@ -213,6 +222,7 @@ exports[`ExplorerItem should show a publication status with unpublished changes 
   <Button
     accessibleLabel={null}
     className="c-explorer__item__action c-explorer__item__action--small"
+    dialogTrigger={false}
     href="/admin/pages/5/edit/"
     icon=""
     isLoading={false}
@@ -229,6 +239,7 @@ exports[`ExplorerItem should show a publication status with unpublished changes 
   <Button
     accessibleLabel={null}
     className="c-explorer__item__action"
+    dialogTrigger={false}
     href="/admin/pages/5/"
     icon=""
     isLoading={false}

--- a/client/src/components/Explorer/__snapshots__/ExplorerPanel.test.js.snap
+++ b/client/src/components/Explorer/__snapshots__/ExplorerPanel.test.js.snap
@@ -35,41 +35,46 @@ exports[`ExplorerPanel general rendering #isError 1`] = `
     label="Page explorer"
     name="push"
   >
-    <ExplorerHeader
-      depth={0}
-      onClick={[Function]}
-      page={
-        Object {
-          "children": Object {
-            "items": Array [],
-          },
-          "isError": true,
-        }
-      }
-    />
     <div
-      className="c-explorer__drawer"
+      className="c-transition-group"
+      key="0"
     >
-      <div
-        key="children"
+      <ExplorerHeader
+        depth={0}
+        onClick={[Function]}
+        page={
+          Object {
+            "children": Object {
+              "items": Array [],
+            },
+            "isError": true,
+          }
+        }
       />
       <div
-        className="c-explorer__placeholder"
-        key="error"
+        className="c-explorer__drawer"
       >
-        Server Error
+        <div
+          key="children"
+        />
+        <div
+          className="c-explorer__placeholder"
+          key="error"
+        >
+          Server Error
+        </div>
       </div>
-    </div>
-    <PageCount
-      page={
-        Object {
-          "children": Object {
-            "items": Array [],
-          },
-          "isError": true,
+      <PageCount
+        page={
+          Object {
+            "children": Object {
+              "items": Array [],
+            },
+            "isError": true,
+          }
         }
-      }
-    />
+      />
+    </div>
   </Transition>
 </FocusTrap>
 `;
@@ -109,29 +114,34 @@ exports[`ExplorerPanel general rendering #isFetching 1`] = `
     label="Page explorer"
     name="push"
   >
-    <ExplorerHeader
-      depth={0}
-      onClick={[Function]}
-      page={
-        Object {
-          "children": Object {
-            "items": Array [],
-          },
-          "isFetching": true,
-        }
-      }
-    />
     <div
-      className="c-explorer__drawer"
+      className="c-transition-group"
+      key="0"
     >
-      <div
-        key="children"
+      <ExplorerHeader
+        depth={0}
+        onClick={[Function]}
+        page={
+          Object {
+            "children": Object {
+              "items": Array [],
+            },
+            "isFetching": true,
+          }
+        }
       />
       <div
-        className="c-explorer__placeholder"
-        key="fetching"
+        className="c-explorer__drawer"
       >
-        <LoadingSpinner />
+        <div
+          key="children"
+        />
+        <div
+          className="c-explorer__placeholder"
+          key="fetching"
+        >
+          <LoadingSpinner />
+        </div>
       </div>
     </div>
   </Transition>
@@ -173,54 +183,59 @@ exports[`ExplorerPanel general rendering #items 1`] = `
     label="Page explorer"
     name="push"
   >
-    <ExplorerHeader
-      depth={0}
-      onClick={[Function]}
-      page={
-        Object {
-          "children": Object {
-            "items": Array [
-              1,
-              2,
-            ],
-          },
-        }
-      }
-    />
     <div
-      className="c-explorer__drawer"
+      className="c-transition-group"
+      key="0"
     >
+      <ExplorerHeader
+        depth={0}
+        onClick={[Function]}
+        page={
+          Object {
+            "children": Object {
+              "items": Array [
+                1,
+                2,
+              ],
+            },
+          }
+        }
+      />
       <div
-        key="children"
+        className="c-explorer__drawer"
       >
-        <ExplorerItem
-          item={
-            Object {
-              "admin_display_title": "Test",
-              "id": 1,
-              "meta": Object {
-                "status": Object {},
-                "type": "test",
-              },
+        <div
+          key="children"
+        >
+          <ExplorerItem
+            item={
+              Object {
+                "admin_display_title": "Test",
+                "id": 1,
+                "meta": Object {
+                  "status": Object {},
+                  "type": "test",
+                },
+              }
             }
-          }
-          key="1"
-          onClick={[Function]}
-        />
-        <ExplorerItem
-          item={
-            Object {
-              "admin_display_title": "Foo",
-              "id": 2,
-              "meta": Object {
-                "status": Object {},
-                "type": "foo",
-              },
+            key="1"
+            onClick={[Function]}
+          />
+          <ExplorerItem
+            item={
+              Object {
+                "admin_display_title": "Foo",
+                "id": 2,
+                "meta": Object {
+                  "status": Object {},
+                  "type": "foo",
+                },
+              }
             }
-          }
-          key="2"
-          onClick={[Function]}
-        />
+            key="2"
+            onClick={[Function]}
+          />
+        </div>
       </div>
     </div>
   </Transition>
@@ -262,23 +277,28 @@ exports[`ExplorerPanel general rendering no children 1`] = `
     label="Page explorer"
     name="push"
   >
-    <ExplorerHeader
-      depth={0}
-      onClick={[Function]}
-      page={
-        Object {
-          "children": Object {},
-        }
-      }
-    />
     <div
-      className="c-explorer__drawer"
+      className="c-transition-group"
+      key="0"
     >
+      <ExplorerHeader
+        depth={0}
+        onClick={[Function]}
+        page={
+          Object {
+            "children": Object {},
+          }
+        }
+      />
       <div
-        className="c-explorer__placeholder"
-        key="empty"
+        className="c-explorer__drawer"
       >
-        No results
+        <div
+          className="c-explorer__placeholder"
+          key="empty"
+        >
+          No results
+        </div>
       </div>
     </div>
   </Transition>
@@ -320,23 +340,28 @@ exports[`ExplorerPanel general rendering renders 1`] = `
     label="Page explorer"
     name="push"
   >
-    <ExplorerHeader
-      depth={0}
-      onClick={[Function]}
-      page={
-        Object {
-          "children": Object {
-            "items": Array [],
-          },
-        }
-      }
-    />
     <div
-      className="c-explorer__drawer"
+      className="c-transition-group"
+      key="0"
     >
-      <div
-        key="children"
+      <ExplorerHeader
+        depth={0}
+        onClick={[Function]}
+        page={
+          Object {
+            "children": Object {
+              "items": Array [],
+            },
+          }
+        }
       />
+      <div
+        className="c-explorer__drawer"
+      >
+        <div
+          key="children"
+        />
+      </div>
     </div>
   </Transition>
 </FocusTrap>

--- a/client/src/components/Explorer/__snapshots__/ExplorerPanel.test.js.snap
+++ b/client/src/components/Explorer/__snapshots__/ExplorerPanel.test.js.snap
@@ -17,7 +17,7 @@ exports[`ExplorerPanel general rendering #isError 1`] = `
 >
   <Button
     accessibleLabel={null}
-    className="c-explorer__close visuallyhidden"
+    className="c-explorer__close u-hidden"
     dialogTrigger={false}
     href="#"
     icon=""
@@ -30,57 +30,46 @@ exports[`ExplorerPanel general rendering #isError 1`] = `
   </Button>
   <Transition
     className="c-explorer"
-    component="div"
+    component="nav"
     duration={210}
+    label="Page explorer"
     name="push"
   >
-    <nav
-      aria-labelledby="nav-page-explorer-header"
-      className="c-transition-group"
-      key="0"
-    >
-      <h2
-        className="visuallyhidden"
-        id="nav-page-explorer-header"
-      >
-        Page Explorer
-      </h2>
-      <ExplorerHeader
-        depth={0}
-        onClick={[Function]}
-        page={
-          Object {
-            "children": Object {
-              "items": Array [],
-            },
-            "isError": true,
-          }
+    <ExplorerHeader
+      depth={0}
+      onClick={[Function]}
+      page={
+        Object {
+          "children": Object {
+            "items": Array [],
+          },
+          "isError": true,
         }
+      }
+    />
+    <div
+      className="c-explorer__drawer"
+    >
+      <div
+        key="children"
       />
       <div
-        className="c-explorer__drawer"
+        className="c-explorer__placeholder"
+        key="error"
       >
-        <div
-          key="children"
-        />
-        <div
-          className="c-explorer__placeholder"
-          key="error"
-        >
-          Server Error
-        </div>
+        Server Error
       </div>
-      <PageCount
-        page={
-          Object {
-            "children": Object {
-              "items": Array [],
-            },
-            "isError": true,
-          }
+    </div>
+    <PageCount
+      page={
+        Object {
+          "children": Object {
+            "items": Array [],
+          },
+          "isError": true,
         }
-      />
-    </nav>
+      }
+    />
   </Transition>
 </FocusTrap>
 `;
@@ -102,7 +91,7 @@ exports[`ExplorerPanel general rendering #isFetching 1`] = `
 >
   <Button
     accessibleLabel={null}
-    className="c-explorer__close visuallyhidden"
+    className="c-explorer__close u-hidden"
     dialogTrigger={false}
     href="#"
     icon=""
@@ -115,47 +104,36 @@ exports[`ExplorerPanel general rendering #isFetching 1`] = `
   </Button>
   <Transition
     className="c-explorer"
-    component="div"
+    component="nav"
     duration={210}
+    label="Page explorer"
     name="push"
   >
-    <nav
-      aria-labelledby="nav-page-explorer-header"
-      className="c-transition-group"
-      key="0"
-    >
-      <h2
-        className="visuallyhidden"
-        id="nav-page-explorer-header"
-      >
-        Page Explorer
-      </h2>
-      <ExplorerHeader
-        depth={0}
-        onClick={[Function]}
-        page={
-          Object {
-            "children": Object {
-              "items": Array [],
-            },
-            "isFetching": true,
-          }
+    <ExplorerHeader
+      depth={0}
+      onClick={[Function]}
+      page={
+        Object {
+          "children": Object {
+            "items": Array [],
+          },
+          "isFetching": true,
         }
+      }
+    />
+    <div
+      className="c-explorer__drawer"
+    >
+      <div
+        key="children"
       />
       <div
-        className="c-explorer__drawer"
+        className="c-explorer__placeholder"
+        key="fetching"
       >
-        <div
-          key="children"
-        />
-        <div
-          className="c-explorer__placeholder"
-          key="fetching"
-        >
-          <LoadingSpinner />
-        </div>
+        <LoadingSpinner />
       </div>
-    </nav>
+    </div>
   </Transition>
 </FocusTrap>
 `;
@@ -177,7 +155,7 @@ exports[`ExplorerPanel general rendering #items 1`] = `
 >
   <Button
     accessibleLabel={null}
-    className="c-explorer__close visuallyhidden"
+    className="c-explorer__close u-hidden"
     dialogTrigger={false}
     href="#"
     icon=""
@@ -190,72 +168,61 @@ exports[`ExplorerPanel general rendering #items 1`] = `
   </Button>
   <Transition
     className="c-explorer"
-    component="div"
+    component="nav"
     duration={210}
+    label="Page explorer"
     name="push"
   >
-    <nav
-      aria-labelledby="nav-page-explorer-header"
-      className="c-transition-group"
-      key="0"
-    >
-      <h2
-        className="visuallyhidden"
-        id="nav-page-explorer-header"
-      >
-        Page Explorer
-      </h2>
-      <ExplorerHeader
-        depth={0}
-        onClick={[Function]}
-        page={
-          Object {
-            "children": Object {
-              "items": Array [
-                1,
-                2,
-              ],
-            },
-          }
+    <ExplorerHeader
+      depth={0}
+      onClick={[Function]}
+      page={
+        Object {
+          "children": Object {
+            "items": Array [
+              1,
+              2,
+            ],
+          },
         }
-      />
+      }
+    />
+    <div
+      className="c-explorer__drawer"
+    >
       <div
-        className="c-explorer__drawer"
+        key="children"
       >
-        <div
-          key="children"
-        >
-          <ExplorerItem
-            item={
-              Object {
-                "admin_display_title": "Test",
-                "id": 1,
-                "meta": Object {
-                  "status": Object {},
-                  "type": "test",
-                },
-              }
+        <ExplorerItem
+          item={
+            Object {
+              "admin_display_title": "Test",
+              "id": 1,
+              "meta": Object {
+                "status": Object {},
+                "type": "test",
+              },
             }
-            key="1"
-            onClick={[Function]}
-          />
-          <ExplorerItem
-            item={
-              Object {
-                "admin_display_title": "Foo",
-                "id": 2,
-                "meta": Object {
-                  "status": Object {},
-                  "type": "foo",
-                },
-              }
+          }
+          key="1"
+          onClick={[Function]}
+        />
+        <ExplorerItem
+          item={
+            Object {
+              "admin_display_title": "Foo",
+              "id": 2,
+              "meta": Object {
+                "status": Object {},
+                "type": "foo",
+              },
             }
-            key="2"
-            onClick={[Function]}
-          />
-        </div>
+          }
+          key="2"
+          onClick={[Function]}
+        />
       </div>
-    </nav>
+    </div>
   </Transition>
 </FocusTrap>
 `;
@@ -277,7 +244,7 @@ exports[`ExplorerPanel general rendering no children 1`] = `
 >
   <Button
     accessibleLabel={null}
-    className="c-explorer__close visuallyhidden"
+    className="c-explorer__close u-hidden"
     dialogTrigger={false}
     href="#"
     icon=""
@@ -290,41 +257,30 @@ exports[`ExplorerPanel general rendering no children 1`] = `
   </Button>
   <Transition
     className="c-explorer"
-    component="div"
+    component="nav"
     duration={210}
+    label="Page explorer"
     name="push"
   >
-    <nav
-      aria-labelledby="nav-page-explorer-header"
-      className="c-transition-group"
-      key="0"
-    >
-      <h2
-        className="visuallyhidden"
-        id="nav-page-explorer-header"
-      >
-        Page Explorer
-      </h2>
-      <ExplorerHeader
-        depth={0}
-        onClick={[Function]}
-        page={
-          Object {
-            "children": Object {},
-          }
+    <ExplorerHeader
+      depth={0}
+      onClick={[Function]}
+      page={
+        Object {
+          "children": Object {},
         }
-      />
+      }
+    />
+    <div
+      className="c-explorer__drawer"
+    >
       <div
-        className="c-explorer__drawer"
+        className="c-explorer__placeholder"
+        key="empty"
       >
-        <div
-          className="c-explorer__placeholder"
-          key="empty"
-        >
-          No results
-        </div>
+        No results
       </div>
-    </nav>
+    </div>
   </Transition>
 </FocusTrap>
 `;
@@ -346,7 +302,7 @@ exports[`ExplorerPanel general rendering renders 1`] = `
 >
   <Button
     accessibleLabel={null}
-    className="c-explorer__close visuallyhidden"
+    className="c-explorer__close u-hidden"
     dialogTrigger={false}
     href="#"
     icon=""
@@ -359,40 +315,29 @@ exports[`ExplorerPanel general rendering renders 1`] = `
   </Button>
   <Transition
     className="c-explorer"
-    component="div"
+    component="nav"
     duration={210}
+    label="Page explorer"
     name="push"
   >
-    <nav
-      aria-labelledby="nav-page-explorer-header"
-      className="c-transition-group"
-      key="0"
-    >
-      <h2
-        className="visuallyhidden"
-        id="nav-page-explorer-header"
-      >
-        Page Explorer
-      </h2>
-      <ExplorerHeader
-        depth={0}
-        onClick={[Function]}
-        page={
-          Object {
-            "children": Object {
-              "items": Array [],
-            },
-          }
+    <ExplorerHeader
+      depth={0}
+      onClick={[Function]}
+      page={
+        Object {
+          "children": Object {
+            "items": Array [],
+          },
         }
-      />
+      }
+    />
+    <div
+      className="c-explorer__drawer"
+    >
       <div
-        className="c-explorer__drawer"
-      >
-        <div
-          key="children"
-        />
-      </div>
-    </nav>
+        key="children"
+      />
+    </div>
   </Transition>
 </FocusTrap>
 `;

--- a/client/src/components/Explorer/__snapshots__/ExplorerPanel.test.js.snap
+++ b/client/src/components/Explorer/__snapshots__/ExplorerPanel.test.js.snap
@@ -7,16 +7,18 @@ exports[`ExplorerPanel general rendering #isError 1`] = `
   className="explorer"
   focusTrapOptions={
     Object {
-      "initialFocus": ".c-explorer__close",
+      "initialFocus": ".c-explorer__header",
       "onDeactivate": [MockFunction],
     }
   }
   paused={false}
-  tag="nav"
+  role="dialog"
+  tag="div"
 >
   <Button
     accessibleLabel={null}
-    className="c-explorer__close u-hidden"
+    className="c-explorer__close visuallyhidden"
+    dialogTrigger={false}
     href="#"
     icon=""
     isLoading={false}
@@ -32,10 +34,17 @@ exports[`ExplorerPanel general rendering #isError 1`] = `
     duration={210}
     name="push"
   >
-    <div
+    <nav
+      aria-labelledby="nav-page-explorer-header"
       className="c-transition-group"
       key="0"
     >
+      <h2
+        className="visuallyhidden"
+        id="nav-page-explorer-header"
+      >
+        Page Explorer
+      </h2>
       <ExplorerHeader
         depth={0}
         onClick={[Function]}
@@ -71,7 +80,7 @@ exports[`ExplorerPanel general rendering #isError 1`] = `
           }
         }
       />
-    </div>
+    </nav>
   </Transition>
 </FocusTrap>
 `;
@@ -83,16 +92,18 @@ exports[`ExplorerPanel general rendering #isFetching 1`] = `
   className="explorer"
   focusTrapOptions={
     Object {
-      "initialFocus": ".c-explorer__close",
+      "initialFocus": ".c-explorer__header",
       "onDeactivate": [MockFunction],
     }
   }
   paused={true}
-  tag="nav"
+  role="dialog"
+  tag="div"
 >
   <Button
     accessibleLabel={null}
-    className="c-explorer__close u-hidden"
+    className="c-explorer__close visuallyhidden"
+    dialogTrigger={false}
     href="#"
     icon=""
     isLoading={false}
@@ -108,10 +119,17 @@ exports[`ExplorerPanel general rendering #isFetching 1`] = `
     duration={210}
     name="push"
   >
-    <div
+    <nav
+      aria-labelledby="nav-page-explorer-header"
       className="c-transition-group"
       key="0"
     >
+      <h2
+        className="visuallyhidden"
+        id="nav-page-explorer-header"
+      >
+        Page Explorer
+      </h2>
       <ExplorerHeader
         depth={0}
         onClick={[Function]}
@@ -137,7 +155,7 @@ exports[`ExplorerPanel general rendering #isFetching 1`] = `
           <LoadingSpinner />
         </div>
       </div>
-    </div>
+    </nav>
   </Transition>
 </FocusTrap>
 `;
@@ -149,16 +167,18 @@ exports[`ExplorerPanel general rendering #items 1`] = `
   className="explorer"
   focusTrapOptions={
     Object {
-      "initialFocus": ".c-explorer__close",
+      "initialFocus": ".c-explorer__header",
       "onDeactivate": [MockFunction],
     }
   }
   paused={false}
-  tag="nav"
+  role="dialog"
+  tag="div"
 >
   <Button
     accessibleLabel={null}
-    className="c-explorer__close u-hidden"
+    className="c-explorer__close visuallyhidden"
+    dialogTrigger={false}
     href="#"
     icon=""
     isLoading={false}
@@ -174,10 +194,17 @@ exports[`ExplorerPanel general rendering #items 1`] = `
     duration={210}
     name="push"
   >
-    <div
+    <nav
+      aria-labelledby="nav-page-explorer-header"
       className="c-transition-group"
       key="0"
     >
+      <h2
+        className="visuallyhidden"
+        id="nav-page-explorer-header"
+      >
+        Page Explorer
+      </h2>
       <ExplorerHeader
         depth={0}
         onClick={[Function]}
@@ -228,7 +255,7 @@ exports[`ExplorerPanel general rendering #items 1`] = `
           />
         </div>
       </div>
-    </div>
+    </nav>
   </Transition>
 </FocusTrap>
 `;
@@ -240,16 +267,18 @@ exports[`ExplorerPanel general rendering no children 1`] = `
   className="explorer"
   focusTrapOptions={
     Object {
-      "initialFocus": ".c-explorer__close",
+      "initialFocus": ".c-explorer__header",
       "onDeactivate": [MockFunction],
     }
   }
   paused={false}
-  tag="nav"
+  role="dialog"
+  tag="div"
 >
   <Button
     accessibleLabel={null}
-    className="c-explorer__close u-hidden"
+    className="c-explorer__close visuallyhidden"
+    dialogTrigger={false}
     href="#"
     icon=""
     isLoading={false}
@@ -265,10 +294,17 @@ exports[`ExplorerPanel general rendering no children 1`] = `
     duration={210}
     name="push"
   >
-    <div
+    <nav
+      aria-labelledby="nav-page-explorer-header"
       className="c-transition-group"
       key="0"
     >
+      <h2
+        className="visuallyhidden"
+        id="nav-page-explorer-header"
+      >
+        Page Explorer
+      </h2>
       <ExplorerHeader
         depth={0}
         onClick={[Function]}
@@ -288,7 +324,7 @@ exports[`ExplorerPanel general rendering no children 1`] = `
           No results
         </div>
       </div>
-    </div>
+    </nav>
   </Transition>
 </FocusTrap>
 `;
@@ -300,16 +336,18 @@ exports[`ExplorerPanel general rendering renders 1`] = `
   className="explorer"
   focusTrapOptions={
     Object {
-      "initialFocus": ".c-explorer__close",
+      "initialFocus": ".c-explorer__header",
       "onDeactivate": [MockFunction],
     }
   }
   paused={false}
-  tag="nav"
+  role="dialog"
+  tag="div"
 >
   <Button
     accessibleLabel={null}
-    className="c-explorer__close u-hidden"
+    className="c-explorer__close visuallyhidden"
+    dialogTrigger={false}
     href="#"
     icon=""
     isLoading={false}
@@ -325,10 +363,17 @@ exports[`ExplorerPanel general rendering renders 1`] = `
     duration={210}
     name="push"
   >
-    <div
+    <nav
+      aria-labelledby="nav-page-explorer-header"
       className="c-transition-group"
       key="0"
     >
+      <h2
+        className="visuallyhidden"
+        id="nav-page-explorer-header"
+      >
+        Page Explorer
+      </h2>
       <ExplorerHeader
         depth={0}
         onClick={[Function]}
@@ -347,7 +392,7 @@ exports[`ExplorerPanel general rendering renders 1`] = `
           key="children"
         />
       </div>
-    </div>
+    </nav>
   </Transition>
 </FocusTrap>
 `;

--- a/client/src/components/Explorer/__snapshots__/ExplorerToggle.test.js.snap
+++ b/client/src/components/Explorer/__snapshots__/ExplorerToggle.test.js.snap
@@ -4,6 +4,7 @@ exports[`ExplorerToggle basic 1`] = `
 <Button
   accessibleLabel={null}
   className="submenu-trigger"
+  dialogTrigger={true}
   href="#"
   icon="folder-open-inverse"
   isLoading={false}

--- a/client/src/components/Transition/Transition.js
+++ b/client/src/components/Transition/Transition.js
@@ -38,6 +38,7 @@ Transition.propTypes = {
   className: PropTypes.string,
   duration: PropTypes.number,
   children: PropTypes.node,
+  label: PropTypes.string,
 };
 
 Transition.defaultProps = {
@@ -45,6 +46,7 @@ Transition.defaultProps = {
   children: null,
   className: null,
   duration: TRANSITION_DURATION,
+  label: null,
 };
 
 export default Transition;

--- a/client/src/components/Transition/Transition.js
+++ b/client/src/components/Transition/Transition.js
@@ -18,6 +18,7 @@ const Transition = ({
   className,
   duration,
   children,
+  label,
 }) => (
   <CSSTransitionGroup
     component={component}
@@ -25,6 +26,7 @@ const Transition = ({
     transitionLeaveTimeout={duration}
     transitionName={`c-transition-${name}`}
     className={className}
+    aria-label={label}
   >
     {children}
   </CSSTransitionGroup>

--- a/client/src/components/Transition/Transition.test.js
+++ b/client/src/components/Transition/Transition.test.js
@@ -11,4 +11,8 @@ describe('Transition', () => {
   it('basic', () => {
     expect(shallow(<Transition name={PUSH} />)).toMatchSnapshot();
   });
+
+  it('label', () => {
+    expect(shallow(<Transition name={PUSH} label="Page explorer" />)).toMatchSnapshot();
+  });
 });

--- a/client/src/components/Transition/__snapshots__/Transition.test.js.snap
+++ b/client/src/components/Transition/__snapshots__/Transition.test.js.snap
@@ -12,3 +12,17 @@ exports[`Transition basic 1`] = `
   transitionName="c-transition-push"
 />
 `;
+
+exports[`Transition label 1`] = `
+<CSSTransitionGroup
+  aria-label="Page explorer"
+  className={null}
+  component="div"
+  transitionAppear={false}
+  transitionEnter={true}
+  transitionEnterTimeout={210}
+  transitionLeave={true}
+  transitionLeaveTimeout={210}
+  transitionName="c-transition-push"
+/>
+`;

--- a/client/src/components/Transition/__snapshots__/Transition.test.js.snap
+++ b/client/src/components/Transition/__snapshots__/Transition.test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`Transition basic 1`] = `
 <CSSTransitionGroup
+  aria-label={null}
   className={null}
   component="div"
   transitionAppear={false}

--- a/client/tests/stubs.js
+++ b/client/tests/stubs.js
@@ -44,6 +44,7 @@ global.wagtailConfig = {
     CLOSE: 'Close',
     EDIT_PAGE: 'Edit \'{title}\'',
     VIEW_CHILD_PAGES_OF_PAGE: 'View child pages of \'{title}\'',
+    PAGE_EXPLORER: 'Page explorer',
   },
 };
 

--- a/docs/releases/2.6.rst
+++ b/docs/releases/2.6.rst
@@ -33,6 +33,7 @@ This release also contains many big improvements for screen reader users:
 * Screen readers now treat page-level action dropdowns as navigation instead of menus (Helen Chapman)
 * Fixed occurrences of invalid HTML across the CMS admin (Thibaud Colas)
 * Add empty alt attributes to all images in the CMS admin (Andreas Bernacca)
+* Fixed focus not moving to the pages explorer menu when open (Helen Chapman)
 
 We’ve also had a look at how controls are labeled across the UI for screen reader users:
 

--- a/wagtail/admin/templates/wagtailadmin/admin_base.html
+++ b/wagtail/admin/templates/wagtailadmin/admin_base.html
@@ -52,6 +52,7 @@
                 CLOSE: "{% trans 'Close' %}",
                 EDIT_PAGE: "{% trans 'Edit \'{title}\'' %}",
                 VIEW_CHILD_PAGES_OF_PAGE: "{% trans 'View child pages of \'{title}\'' %}",
+                PAGE_EXPLORER: "{% trans 'Page explorer' %}",
 
                 MONTHS: [
                     "{% trans 'January' %}",


### PR DESCRIPTION
#5336

This ensures that when a user clicks on the 'Pages' link, focus automatically moves to the top of the explorer menu. The screen reader will now also correctly announce that the user is on a pop up link, and the explorer pop-up is marked with `role="dialog"`. Because `nav` elements cannot have `role="dialog"`, this is moved inside the pop-up element. A heading for the `nav` element has been added.

The 'close' button was previously inaccessible, because it was marked with the `u--hidden` class - instead this now uses `visuallyhidden`. This ensures that if you use the tab keys to move through the menu you don't get trapped, unable to close the pop-up box.

Tested in:
Latest Chrome on Max OSX High Sierra
Latest Safari on Max OSX High Sierra
Latest Firefox on Max OSX High Sierra (issue with icons)
IE11 on Windows 10
IE Edge latest version on Windows 10
Safari on iPad Pro 12.9 2018 iOS 12
Safari on iPad Pro 12.9 2017 iOS 11 
Chrome on Galaxy Tab S4 Android 8

(not tested on a phone because the explore menu only appears at wider breakpoints)
