### PR TITLE
Re-add loading of Wagtail icon font for userbar. Fix #5397

### DIFF
--- a/wagtail/admin/static_src/wagtailadmin/scss/userbar.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/userbar.scss
@@ -47,6 +47,13 @@ $positions: (
 
 @include webfont(Open Sans, opensans-regular, 400, normal);
 
+@font-face {
+    font-family: 'wagtail';
+    src: url('#{$font-root}wagtail.woff') format('woff');
+    font-weight: normal;
+    font-style: normal;
+}
+
 // =============================================================================
 // Namespaced icon component
 // =============================================================================


### PR DESCRIPTION
Fixes #5397, regression from #5215. This adds the userbar’s icons back:

<img width="369" alt="wagtail-userbar-icon" src="https://user-images.githubusercontent.com/877585/59702590-f67b5580-91ef-11e9-8d4e-cef129e866b2.png">

* [x] Do the tests still pass?
* [x] Does the code comply with the style guide? (Run `make lint` from the Wagtail root)
* ~For Python changes: Have you added tests to cover the new/fixed behaviour?~
* ~[ ] For front-end changes: Did you test on all of Wagtail’s supported browsers?~
* ~For new features: Has the documentation been updated accordingly?~

Tested in macOS Chrome, Firefox, Safari + Windows IE11.