### PR TITLE
Added missing is_stored_locally() to AbstractDocument

### DIFF
--- a/wagtail/documents/models.py
+++ b/wagtail/documents/models.py
@@ -52,6 +52,17 @@ class AbstractDocument(CollectionMember, index.Indexed, models.Model):
         index.FilterField('uploaded_by_user'),
     ]
 
+    def is_stored_locally(self):
+        """
+        Returns True if the image is hosted on the local filesystem
+        """
+        try:
+            self.file.path
+
+            return True
+        except NotImplementedError:
+            return False
+
     @contextmanager
     def open_file(self):
         # Open file if it is closed


### PR DESCRIPTION
Unless I'm missing something obvious, there's no definition of `is_stored_locally()` in AbstractDocument, so `open_file()` fails. The functionality seems to mirror AbstractImage, so I have copied the implementation of `is_stored_locally()` from there and it now works properly.