### PR TITLE
Datetime picker dispatches 'change' event

### DIFF
--- a/wagtail/admin/static_src/wagtailadmin/js/date-time-chooser.js
+++ b/wagtail/admin/static_src/wagtailadmin/js/date-time-chooser.js
@@ -30,14 +30,20 @@ function initDateChooser(id, opts) {
             timepicker: false,
             scrollInput: false,
             format: 'Y-m-d',
-            onGenerate: hideCurrent
+            onGenerate: hideCurrent,
+            onChangeDateTime: function(_, $el) {
+              $el.get(0).dispatchEvent(new Event('change'))
+            }
         }, opts || {}));
     } else {
         $('#' + id).datetimepicker($.extend({
             timepicker: false,
             scrollInput: false,
             format: 'Y-m-d',
-            onGenerate: hideCurrent
+            onGenerate: hideCurrent,
+            onChangeDateTime: function(_, $el) {
+              $el.get(0).dispatchEvent(new Event('change'))
+            }
         }, opts || {}));
     }
 }
@@ -49,11 +55,17 @@ function initTimeChooser(id) {
             datepicker: false,
             scrollInput: false,
             format: 'H:i',
+            onChangeDateTime: function(_, $el) {
+              $el.get(0).dispatchEvent(new Event('change'))
+            }
         });
     } else {
         $('#' + id).datetimepicker({
             datepicker: false,
-            format: 'H:i'
+            format: 'H:i',
+            onChangeDateTime: function(_, $el) {
+              $el.get(0).dispatchEvent(new Event('change'))
+            }
         });
     }
 }

--- a/wagtail/admin/static_src/wagtailadmin/js/date-time-chooser.js
+++ b/wagtail/admin/static_src/wagtailadmin/js/date-time-chooser.js
@@ -64,12 +64,18 @@ function initDateTimeChooser(id, opts) {
             closeOnDateSelect: true,
             format: 'Y-m-d H:i',
             scrollInput: false,
-            onGenerate: hideCurrent
+            onGenerate: hideCurrent,
+            onChangeDateTime: function(_, $el) {
+              $el.get(0).dispatchEvent(new Event('change'))
+            }
         }, opts || {}));
     } else {
         $('#' + id).datetimepicker($.extend({
             format: 'Y-m-d H:i',
-            onGenerate: hideCurrent
+            onGenerate: hideCurrent,
+            onChangeDateTime: function(_, $el) {
+              $el.get(0).dispatchEvent(new Event('change'))
+            }
         }, opts || {}));
     }
 }


### PR DESCRIPTION
Fixes https://github.com/wagtail/wagtail-react-streamfield/issues/41

This issue was caused because the date/time picker, when changing the value of the input field it was binded to, does not automatically fire a `change` event when the data is changed.

The react-streamfield plugin only [updates the component's value](https://github.com/wagtail/react-streamfield/blob/198f702a89e3ec32a83b79adeaec94309378cb79/src/RawHtmlFieldInput.js#L96-L110) specifically on the `change`, so this PR manually dispatches `change` using the date picker plugin's [built-in](https://xdsoft.net/jqplugins/datetimepicker/) `onChangeDateTime` method.