### PR TITLE
Search query normalisation no longer removes punctuation #5416

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -35,6 +35,7 @@ Changelog
  * Added screen-reader labels for dashboard summary cards (Helen Chapman, Katie Locke)
  * Added screen-reader labels for privacy toggle of collections (Helen Chapman, Katie Locke)
  * Added `construct_settings_menu` hook (Jordan Bauer, Quadric)
+ * Fix: Query model no longer removes punctuation as part of string normalisation (William Blackie)
  * Fix: ModelAdmin no longer fails when filtering over a foreign key relation (Jason Dilworth, Matt Westcott)
  * Fix: The Wagtail version number is now visible within the Settings menu (Kevin Howbrook)
  * Fix: Scaling images now rounds values to an integer so that images render without errors (Adrian Brunyate)

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -380,6 +380,7 @@ Contributors
 * Jordan Bauer
 * Fidel Ramos
 * Quadric
+* William Blackie
 
 Translators
 ===========

--- a/wagtail/search/tests/test_queries.py
+++ b/wagtail/search/tests/test_queries.py
@@ -33,17 +33,17 @@ class TestHitCounter(TestCase):
 
 class TestQueryStringNormalisation(TestCase):
     def setUp(self):
-        self.query = models.Query.get("Hello World!")
+        self.query = models.Query.get("  Hello  World!  ")
 
     def test_normalisation(self):
-        self.assertEqual(str(self.query), "hello world")
+        self.assertEqual(str(self.query), "hello world!")
 
-    def test_equivilant_queries(self):
+    def test_equivalent_queries(self):
         queries = [
-            "Hello World",
-            "Hello  World!!",
-            "hello world",
-            "Hello' world",
+            "  Hello World!",
+            "Hello World!  ",
+            "hello  world!",
+            "  Hello  world!  ",
         ]
 
         for query in queries:
@@ -52,7 +52,8 @@ class TestQueryStringNormalisation(TestCase):
     def test_different_queries(self):
         queries = [
             "HelloWorld",
-            "Hello orld!!",
+            "HelloWorld!"
+            "  Hello  World!  ",
             "Hello",
         ]
 

--- a/wagtail/search/utils.py
+++ b/wagtail/search/utils.py
@@ -1,6 +1,5 @@
 import operator
 import re
-import string
 from functools import partial, reduce
 
 # Reduce any iterable to a single value using a logical OR e.g. (a | b | ...)
@@ -22,11 +21,8 @@ def normalise_query_string(query_string):
     # Convert query_string to lowercase
     query_string = query_string.lower()
 
-    # Strip punctuation characters
-    query_string = ''.join([c for c in query_string if c not in string.punctuation])
-
-    # Remove double spaces
-    query_string = ' '.join(query_string.split())
+    # Remove leading, trailing and multiple spaces
+    query_string = re.sub(' +', ' ', query_string).strip()
 
     return query_string
 


### PR DESCRIPTION
Hello,

Search queries are now normalised by removing excessive white spaces(leading, trailing and multiple white spaces) and capitalisation, punctuation is no longer removed.

Tests at wagtail.search.tests.test_queries.TestQueryStringNormalisation have been updated for the expected changes, now allowing for punctuation.

The fix has been added to the changelog.txt

Thanks, Will.
