### PR TITLE
Add a `construct_page_listing_buttons` hook

### DIFF
--- a/docs/reference/hooks.rst
+++ b/docs/reference/hooks.rst
@@ -564,6 +564,22 @@ Hooks for customising the way users are directed through the process of creating
     def remove_submit_to_moderator_option(menu_items, request, context):
         menu_items[:] = [item for item in menu_items if item.name != 'action-submit']
 
+.. construct_page_listing_buttons:
+
+``construct_page_listing_buttons``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+  Modify the final list of page listing buttons in the page explorer. The
+  callable passed to this hook receives a list of ``Button`` objects, a request
+  object and a context dictionary as per ``register_page_action_menu_item``,
+  and should modify the list of menu items in-place.
+
+  .. code-block:: python
+
+    @hooks.register('construct_page_listing_buttons')
+    def remove_page_listing_button_item(buttons, page, page_perms, is_parent=False, context=None):
+        menu_items.pop()
+
 
 .. _construct_wagtail_userbar:
 

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -390,6 +390,10 @@ def page_listing_buttons(context, page, page_perms, is_parent=False):
     buttons = sorted(itertools.chain.from_iterable(
         hook(page, page_perms, is_parent)
         for hook in button_hooks))
+
+    for hook in hooks.get_hooks('construct_page_listing_buttons'):
+        hook(buttons, page, page_perms, is_parent, context)
+
     return {'page': page, 'buttons': buttons}
 
 

--- a/wagtail/admin/tests/test_pages_views.py
+++ b/wagtail/admin/tests/test_pages_views.py
@@ -190,6 +190,18 @@ class TestPageExplorer(TestCase, WagtailTestUtils):
         page_ids = [page.id for page in response.context['pages']]
         self.assertEqual(page_ids, [self.child_page.id])
 
+    def test_construct_construct_page_listing_buttons_hook(self):
+        # testapp implements a construct_page_listing_buttons hook
+        # that add's an dummy button with the label 'Dummy Button' which points
+        # to '/dummy-button'
+        response = self.client.get(
+            reverse('wagtailadmin_explore', args=(self.root_page.id, )),
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'wagtailadmin/pages/index.html')
+        self.assertContains(response, 'Dummy Button')
+        self.assertContains(response, '/dummy-button')
+
     def make_pages(self):
         for i in range(150):
             self.root_page.add_child(instance=SimplePage(

--- a/wagtail/tests/testapp/wagtail_hooks.py
+++ b/wagtail/tests/testapp/wagtail_hooks.py
@@ -8,6 +8,7 @@ from wagtail.admin.menu import MenuItem
 from wagtail.admin.rich_text import HalloPlugin
 from wagtail.admin.rich_text.converters.html_to_contentstate import BlockElementHandler
 from wagtail.admin.search import SearchArea
+from wagtail.admin.widgets import Button
 from wagtail.core import hooks
 
 
@@ -149,3 +150,13 @@ def register_relax_menu_item(menu_items, request, context):
         raise AttributeError('all core sub-classes of ActionMenuItems must have a name attribute', names)
 
     menu_items.append(RelaxMenuItem())
+
+
+@hooks.register('construct_page_listing_buttons')
+def register_page_listing_button_item(buttons, page, page_perms, is_parent=False, context=None):
+    item = Button(
+        label="Dummy Button",
+        url='/dummy-button',
+        priority=10,
+    )
+    buttons.append(item)


### PR DESCRIPTION
This hook mimics the functiolity provided by `construct_page_action_menu`
in that it constructs the final list of buttons to be shown in the wagtail
admin interface.  This means that within this function button's can be
removed, added or re-ordered.

See #4925 