### PR TITLE
Break listing titles by word so action buttons are visible on smaller screens

### DIFF
--- a/client/scss/components/_listing.scss
+++ b/client/scss/components/_listing.scss
@@ -188,6 +188,8 @@ ul.listing {
     }
 
     .title {
+        word-break: break-word;
+
         .title-wrapper,
         h2 {
             text-transform: none;


### PR DESCRIPTION
#5428

On smaller screens, listing titles aren't being _broken_:

![bug eg](https://i.imgur.com/7OzWvo6.png)

This PR will break listing titles like so:

![fix eg](https://i.imgur.com/XOmmYWW.png)