### PR TITLE
Changed Snippet Chooser AJAX delay from 50ms to 200ms, to remove laggy typing.

### DIFF
--- a/wagtail/snippets/static_src/wagtailsnippets/js/snippet-chooser-modal.js
+++ b/wagtail/snippets/static_src/wagtailsnippets/js/snippet-chooser-modal.js
@@ -49,7 +49,7 @@ SNIPPET_CHOOSER_MODAL_ONLOAD_HANDLERS = {
 
         $('#id_q').on('input', function() {
             clearTimeout($.data(this, 'timer'));
-            var wait = setTimeout(search, 50);
+            var wait = setTimeout(search, 200);
             $(this).data('timer', wait);
         });
 


### PR DESCRIPTION
50ms is the equivalent of about 200 words per minute, so typing slower than that meant that the javascript would send an AJAX request between every single keystroke, causing terrible lag. This change makes the javascript wait for 200ms between keystrokes, which lets you finish typing the word you're looking for before it sends an AJAX request.