### PR TITLE
Fix the required styles on title fields

### DIFF
--- a/client/scss/components/_forms.scss
+++ b/client/scss/components/_forms.scss
@@ -133,7 +133,8 @@ li.focused > .help {
     opacity: 1;
 }
 
-.required .field > label:after {
+.required .field > label:after,
+.required .title-wrapper > label:after {
     content: '*';
     color: $color-red;
     font-weight: bold;

--- a/client/scss/components/_forms.scss
+++ b/client/scss/components/_forms.scss
@@ -133,8 +133,7 @@ li.focused > .help {
     opacity: 1;
 }
 
-.required .field > label:after,
-.required .title-wrapper > label:after {
+.required .field > label:after {
     content: '*';
     color: $color-red;
     font-weight: bold;

--- a/wagtail/admin/static_src/wagtailadmin/scss/layouts/page-editor.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/layouts/page-editor.scss
@@ -149,7 +149,7 @@ $object-title-height: 40px;
     }
 
     &.required {
-        > h3 label:after {
+        > .title-wrapper label:after {
             content: '*';
             color: $color-red;
             font-weight: bold;


### PR DESCRIPTION
I noticed that in the latest release candidates the required asterisk wasn't appearing for the title fields.

Wagtail 2.5.1:
<img width="564" alt="Screenshot 2019-07-19 at 15 32 58" src="https://user-images.githubusercontent.com/4086447/61551115-32524680-aa4c-11e9-84cd-09515119eb30.png">

Wagtail 2.6rc1
<img width="551" alt="Screenshot 2019-07-19 at 15 34 27" src="https://user-images.githubusercontent.com/4086447/61551116-32524680-aa4c-11e9-80fa-35ac36c3977d.png">