### PR TITLE
Pin Squash docker image to a specific version

### DIFF
--- a/.squash.yml
+++ b/.squash.yml
@@ -1,6 +1,6 @@
 deployments:
   default:
-    dockerimage: python:latest
+    dockerimage: python:3.7.4-stretch
     build_steps:
       - apt-get update && apt-get install -y libssl-dev libpq-dev git build-essential libfontconfig1 libfontconfig1-dev curl
       - RUN bash -c "curl -sL https://deb.nodesource.com/setup_8.x | bash -"


### PR DESCRIPTION
Recent builds have been breaking due to the following error: `/post_build.sh: line 2: npm: command not found`. I’m not entirely sure this is the fix, but it looks like this `latest` tag is now resolving to `3.7.4-buster` (https://hub.docker.com/_/python). Debian Buster got released 2 weeks ago. It feels safer to have a pinned dependency, and Stretch is probably what it was resolving to before.