### PR TITLE
Eliminate dependency on default User model from style guide

### DIFF
--- a/wagtail/contrib/styleguide/templates/wagtailstyleguide/base.html
+++ b/wagtail/contrib/styleguide/templates/wagtailstyleguide/base.html
@@ -742,9 +742,9 @@
             <h2>Misc formatters</h2>
             <h3>Avatar icons</h3>
 
-            <p><span class="avatar"><img src="{% avatar_url user size=50 %}" alt="" /></span> Avatar normal</p>
-            <p><span class="avatar square"><img src="{% avatar_url user size=50 %}" alt="" /></span> Avatar square</p>
-            <p><span class="avatar small"><img src="{% avatar_url user size=25 %}" alt="" /></span> Avatar small</p>
+            <p><span class="avatar"><img src="{% static 'wagtailadmin/images/default-user-avatar.png' %}" alt="" /></span> Avatar normal</p>
+            <p><span class="avatar square"><img src="{% static 'wagtailadmin/images/default-user-avatar.png' %}" alt="" /></span> Avatar square</p>
+            <p><span class="avatar small"><img src="{% static 'wagtailadmin/images/default-user-avatar.png' %}" alt="" /></span> Avatar small</p>
 
             <h3>Status tags</h3>
             <div class="status-tag primary">Primary tag</div>

--- a/wagtail/contrib/styleguide/views.py
+++ b/wagtail/contrib/styleguide/views.py
@@ -1,5 +1,4 @@
 from django import forms
-from django.contrib.auth.models import User
 from django.core.paginator import Paginator
 from django.shortcuts import render
 from django.utils.translation import ugettext as _
@@ -72,11 +71,8 @@ def index(request):
     paginator = Paginator(list(range(100)), 10)
     page = paginator.page(2)
 
-    user = User(email='david@torchbox.com')
-
     return render(request, 'wagtailstyleguide/base.html', {
         'search_form': form,
         'example_form': example_form,
         'example_page': page,
-        'user': user,
     })


### PR DESCRIPTION
Fixes #5442. Building a User object for david@torchbox.com may cause problems if a custom user model is in use, and is redundant anyhow because there's no longer a registered gravatar for that email - we should just hard-code the default blank avatar instead.