### PR TITLE
Add https support for scribd oembed provider

### DIFF
--- a/wagtail/embeds/oembed_providers.py
+++ b/wagtail/embeds/oembed_providers.py
@@ -92,7 +92,7 @@ revision3 = {
 scribd = {
     "endpoint": "http://www.scribd.com/services/oembed",
     "urls": [
-        r'^http://[-\w]+\.scribd\.com/.+$',
+        r'^http(?:s)?://[-\w]+\.scribd\.com/.+$',
     ],
 }
 


### PR DESCRIPTION
Currently scribd defaults to https for their sharing links - http still works but if you copy&paste quickly you may think it's broken :)