### PR TITLE
Pass down process_child_object when copying pages recursively

### DIFF
--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -1201,7 +1201,8 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
                     to=page_copy,
                     copy_revisions=copy_revisions,
                     keep_live=keep_live,
-                    user=user
+                    user=user,
+                    process_child_object=process_child_object,
                 )
 
         return page_copy


### PR DESCRIPTION
This was overlooked when we implemented the feature.

Marked as release blocker as this feature was introduced in 2.6.