### PR TITLE
use lighter grey for streamfield group label for accessible contrast

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -8,6 +8,7 @@ Changelog
  * Added more detailed documentation and troubleshooting for installing OpenCV for feature detection (Daniele Procida)
  * Fix: Added line breaks to long filenames on multiple image / document uploader (Kevin Howbrook)
  * Fix: Added https support for Scribd oEmbed provider (Rodrigo)
+ * Fix: Changed StreamField group labels color so labels are visible (Catherine Farman)
 
 
 2.6 (xx.xx.xxxx) - IN DEVELOPMENT

--- a/client/scss/components/_streamfield.scss
+++ b/client/scss/components/_streamfield.scss
@@ -268,6 +268,7 @@ li.sequence-member {
     }
 
     .stream-menu-inner {
+        color: $color-grey-3;
         transform: translate3d(0, 0, 0);
         max-width: 50em;
         margin: auto;
@@ -299,7 +300,7 @@ li.sequence-member {
         @include transition(all 0.2s ease);
         background-color: transparent;
         border: 0;
-        color: darken($color-grey-3, 5%);
+        color: $color-grey-3;
         height: auto;
         display: block;
         width: 100%;

--- a/docs/releases/2.7.rst
+++ b/docs/releases/2.7.rst
@@ -26,6 +26,7 @@ Bug fixes
 
  * Added line breaks to long filenames on multiple image / document uploader (Kevin Howbrook)
  * Added https support for Scribd oEmbed provider (Rodrigo)
+ * Changed StreamField group label color so labels are visible (Catherine Farman)
 
 
 Upgrade considerations


### PR DESCRIPTION
Fixes https://github.com/wagtail/wagtail/issues/5455

Changes the group label / streamfield menu default text color to `$color-grey-3` instead of inheriting the default body font color (which is a dark grey).

Also changes the default button text color to match the style guide with `$color-grey-3` instead of #ccc.

- [x] * Do the tests still pass? (http://docs.wagtail.io/en/latest/contributing/developing.html#testing)
- [ ] * Does the code comply with the style guide? (Run `make lint` from the Wagtail root)
- [ ] * For front-end changes: Did you test on all of Wagtail’s supported browsers? **Please list the exact versions you tested**.

Large screen layout
![Screen Shot 2019-07-26 at 4 17 57 PM](https://user-images.githubusercontent.com/702526/61979108-f295dc80-afc0-11e9-8bc7-838870e9963d.png)

Small screen layout
![Screen Shot 2019-07-26 at 4 17 46 PM](https://user-images.githubusercontent.com/702526/61979110-f295dc80-afc0-11e9-95ed-dca562db9b55.png)
