### PR TITLE
Add labels to snippet checkboxes for accessibility (#5328)

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -12,6 +12,7 @@ Changelog
  * Fix: Changed StreamField group labels color so labels are visible (Catherine Farman)
  * Fix: Prevented images with a very wide aspect ratio from being displayed distorted in the rich text editor (Iman Syed)
  * Fix: Prevent exception when deleting a model with a protected One-to-one relationship (Neal Todd)
+ * Fix: Added labels to snippet bulk edit checkboxes for screen reader users (Martey Dodoo)
 
 
 2.6.1 (xx.xx.xxxx) - IN DEVELOPMENT

--- a/docs/releases/2.7.rst
+++ b/docs/releases/2.7.rst
@@ -30,6 +30,7 @@ Bug fixes
  * Changed StreamField group label color so labels are visible (Catherine Farman)
  * Prevented images with a very wide aspect ratio from being displayed distorted in the rich text editor (Iman Syed)
  * Prevent exception when deleting a model with a protected One-to-one relationship (Neal Todd)
+ * Added labels to snippet bulk edit checkboxes for screen reader users (Martey Dodoo)
 
 
 Upgrade considerations

--- a/wagtail/snippets/templates/wagtailsnippets/snippets/list.html
+++ b/wagtail/snippets/templates/wagtailsnippets/snippets/list.html
@@ -6,7 +6,12 @@
     <col width="16%" />
     <thead>
         <tr class="table-headers">
-            {% if can_delete_snippets %}<th><input type="checkbox" class="toggle-select-all"/></th>{% endif %}
+            {% if can_delete_snippets %}
+            <th>
+                <input type="checkbox" class="toggle-select-all" id="toggle-select-all-snippets" />
+                <label for="toggle-select-all-snippets" class="visuallyhidden">{% blocktrans with snippet_type_name_plural=model_opts.verbose_name_plural %}Select all {{ snippet_type_name_plural }}{% endblocktrans %}</label>
+            </th>
+        {% endif %}
             <th>{% trans "Title" %}</th>
         </tr>
     </thead>
@@ -14,7 +19,10 @@
         {% for snippet in items %}
             <tr id="snippet-row-{{ snippet.pk }}">
                 {% if can_delete_snippets %}
-                    <td class="select"><input type="checkbox" name="select_snippet" value="{{ snippet.pk }}" class="toggle-select-row"/></td>
+                    <td class="select">
+                        <input type="checkbox" name="select_snippet" id="select-snippet-{{ snippet.pk }}" value="{{ snippet.pk }}" class="toggle-select-row"/>
+                        <label for="select-snippet-{{ snippet.pk }}" class="visuallyhidden">{% blocktrans %}Select {{ snippet }}{% endblocktrans %}</label>
+                    </td>
                 {% endif %}
                 <td class="title">
                     {% if choosing %}


### PR DESCRIPTION
Add labels for checkboxes on snippet list page (including "select all" checkbox) on snippet list page for screen readers.

--- 

* Do the tests still pass? *yes*
* Does the code comply with the style guide? (Run `make lint` from the Wagtail root) *yes*
* For Python changes: Have you added tests to cover the new/fixed behaviour? *n/a*
* For front-end changes: Did you test on all of Wagtail’s supported browsers? **Please list the exact versions you tested**.
    - Google Chrome 75 w/ [ChromeVox extension](https://chrome.google.com/webstore/detail/chromevox/kgejglhpjiefppelpmljglcjbhoiplfn)
    - I would love it if others (especially people on Windows or OS X) could help me test this.

* For new features: Has the documentation been updated accordingly? *n/a*
