### PR TITLE
Extra page for API on images, snippets, streamfield & snippets 

### DIFF
--- a/docs/advanced_topics/api/v2/extra_usage.rst
+++ b/docs/advanced_topics/api/v2/extra_usage.rst
@@ -5,12 +5,14 @@ Extra information on exposing the API
 Images
 ------
 
-If you have in your model an image you can expose the image by using the ImageRenditionField.
+You can expose an Image's rendition, a specific size of a related Image field's image, by using the ImageRenditionField class.
 :class:`wagtail.images.api.fields.ImageRenditionField`. The ImageRenditionField will return url, width, height.
 
 ..code-block:: python
 
-    class SomePage(Page):
+    from wagtail.images.api.fields import ImageRenditionField
+
+    class RockStars(Page):
         ...
         image = models.ForeignKey('wagtailimages.Image', null=True, blank=True, on_delete=models.SET_NULL, related_name='+')
         ...
@@ -53,7 +55,7 @@ You can expose your snippet to the API
 
 ..code-block:: python
 
-    class SomePage(Page):
+    class RockStarPage(Page):
         ...
         group = models.ForeignKey('snippet.band', null=True, blank=True, on_delete=models.SET_NULL, related_name="+")
 
@@ -72,6 +74,8 @@ Where streamfields are easy to include in your APIField it takes a littlebit ext
 snippets in combination. You have to add the fields to your API manualy in the streamfield block
 
 ..code-block:: python
+
+    from wagtail.images.api.fields import ImageRenditionField
 
     class BandBlock(blocks.StructBlock):
         band = block.SnippetChooserBlock('snippet.band')

--- a/docs/advanced_topics/api/v2/extra_usage.rst
+++ b/docs/advanced_topics/api/v2/extra_usage.rst
@@ -1,0 +1,86 @@
+=====================================
+Extra information on exposing the API
+=====================================
+
+Images
+------
+
+If you have in your model an image you can expose the image by using the ImageRenditionField.
+:class:`wagtail.images.api.fields.ImageRenditionField`. The ImageRenditionField will return url, width, height.
+
+..code-block:: python
+
+    class SomePage(Page):
+        ...
+        image = models.ForeignKey('wagtailimages.Image', null=True, blank=True, on_delete=models.SET_NULL, related_name='+')
+        ...
+
+        @property
+        def img(self):
+            return ImageRenditionField('width-700').to_representation(self.image)
+
+        @property
+        def alt(self):
+            return self.image.title
+
+        api_fields = [
+            ...
+            APIField('img'),
+            APIField('alt'),
+            ...
+        ]
+
+Alterantive you also can do the following
+
+..code-block:: python
+
+        api_field = [
+            APIField('image', serializer=ImageRenditionField('fill-300x300'))
+        ]
+
+If the name "image" is different as the can add the source name
+
+..code-block:: python
+    api_field = [
+            APIField('somename', serializer=ImageRenditionField('fill-300x300').source="myimage")
+        ]
+
+
+Snippets
+--------
+
+You can expose your snippet to the API
+
+..code-block:: python
+
+    class SomePage(Page):
+        ...
+        group = models.ForeignKey('snippet.band', null=True, blank=True, on_delete=models.SET_NULL, related_name="+")
+
+        @property
+        def band(self):
+            return self.band.name,
+
+        api_fields = [
+            APIField('band')
+
+
+Snippets and streamfield
+------------------------
+
+Where streamfields are easy to include in your APIField it takes a littlebit extra work if you use streamfield and
+snippets in combination. You have to add the fields to your API manualy in the streamfield block
+
+..code-block:: python
+
+    class BandBlock(blocks.StructBlock):
+        band = block.SnippetChooserBlock('snippet.band')
+
+        def get_api_representation(self, value, context=None)
+            img = ImageRenditionField('fill-200x200').to_representation(value['band'].image)
+            return {'name': value['band'].name,  'image': img}
+
+        class Meta:
+            ...
+
+Now these fields will get shown in your API page model if you use the streamfield.

--- a/docs/topics/snippets.rst
+++ b/docs/topics/snippets.rst
@@ -229,3 +229,25 @@ Adding tags to snippets is very similar to adding tags to pages. The only differ
         ]
 
 The :ref:`documentation on tagging pages <tagging>` has more information on how to use tags in views.
+
+
+ClusterableModel snippets
+-------------------------
+
+If you want to group a snippet you can use ClusterableModel. For example you want to insert bands and there members.
+The band member can then be orderd accordingly.
+
+.. code-block:: python
+
+    class BandMember(Orderable):
+         band = ParentalKey('Band', related_name='members', on_delete=models.CASCADE)
+         name = models.CharField(max_length=255)
+
+    @register_snippet
+    class Band(ClusterableModel):
+         name = models.CharField(max_length=255)
+
+         panels = [
+             FieldPanel('name'),
+             InlinePanel('members')
+      ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -5029,7 +5029,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5444,7 +5445,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5500,6 +5502,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5543,12 +5546,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },


### PR DESCRIPTION
I added a page with some examples and docs about using API with Snippets, streamfields and images. I believe this was missing from the docs.


=====================================
Extra information on exposing the API
=====================================

Images
------

If you have in your model an image you can expose the image by using the ImageRenditionField.
:class:`wagtail.images.api.fields.ImageRenditionField`. The ImageRenditionField will return url, width, height.

..code-block:: python

    class SomePage(Page):
        ...
        image = models.ForeignKey('wagtailimages.Image', null=True, blank=True, on_delete=models.SET_NULL, related_name='+')
        ...

        @property
        def img(self):
            return ImageRenditionField('width-700').to_representation(self.image)

        @property
        def alt(self):
            return self.image.title

        api_fields = [
            ...
            APIField('img'),
            APIField('alt'),
            ...
        ]

Alterantive you also can do the following

..code-block:: python

        api_field = [
            APIField('image', serializer=ImageRenditionField('fill-300x300'))
        ]

If the name "image" is different as the can add the source name

..code-block:: python
    api_field = [
            APIField('somename', serializer=ImageRenditionField('fill-300x300').source="myimage")
        ]


Snippets
--------

You can expose your snippet to the API

..code-block:: python

    class SomePage(Page):
        ...
        group = models.ForeignKey('snippet.band', null=True, blank=True, on_delete=models.SET_NULL, related_name="+")

        @property
        def band(self):
            return self.band.name,

        api_fields = [
            APIField('band')


Snippets and streamfield
------------------------

Where streamfields are easy to include in your APIField it takes a littlebit extra work if you use streamfield and
snippets in combination. You have to add the fields to your API manualy in the streamfield block

..code-block:: python

    class BandBlock(blocks.StructBlock):
        band = block.SnippetChooserBlock('snippet.band')

        def get_api_representation(self, value, context=None)
            img = ImageRenditionField('fill-200x200').to_representation(value['band'].image)
            return {'name': value['band'].name,  'image': img}

        class Meta:
            ...

Now these fields will get shown in your API page model if you use the streamfield.