### PR TITLE
Delay dirty form check’s snapshot to avoid race conditions. Fix #4978

### DIFF
--- a/wagtail/admin/static_src/wagtailadmin/js/core.js
+++ b/wagtail/admin/static_src/wagtailadmin/js/core.js
@@ -57,16 +57,23 @@ function enableDirtyFormCheck(formSelector, options) {
     var $form = $(formSelector);
     var confirmationMessage = options.confirmationMessage || ' ';
     var alwaysDirty = options.alwaysDirty || false;
-    var initialData = $form.serialize();
+    var initialData = null;
     var formSubmitted = false;
 
     $form.on('submit', function() {
         formSubmitted = true;
     });
 
+    // Delay snapshotting the form’s data to avoid race conditions with form widgets that might process the values.
+    // User interaction with the form within that delay also won’t trigger the confirmation message.
+    setTimeout(function() {
+        initialData = $form.serialize();
+    }, 1000 * 10);
+
     window.addEventListener('beforeunload', function(event) {
+        var isDirty = initialData && $form.serialize() != initialData;
         var displayConfirmation = (
-            !formSubmitted && (alwaysDirty || $form.serialize() != initialData)
+            !formSubmitted && (alwaysDirty || isDirty)
         );
 
         if (displayConfirmation) {


### PR DESCRIPTION
Fixes #4978. This adds a 10-sec delay to the initialisation of the "dirty form check" displaying a "Are you sure you want to leave this page?" message in the page editing UI.

This was broken because of a race condition – the dirty form check runs "when the page is done loading" rather than after the fields’ initialisation. The delay reduces the risk of race condition issues, and it also seems like a sensible behavior from an end user’s perspective not to aggressively prompt people who have only spent a few seconds on the page, even if they did change some content.

This race condition wasn’t a problem for most fields, but anything that stores JSON data structures (like the new rich text editor) is prone to differences in serialisation between server and client code – in that case whitespace, and perhaps keys ordering.

This change doesn’t alter the behavior of the dirty form check when it is initialised in "always prompt for confirmation" mode.

---

* [x] Do the tests still pass? (http://docs.wagtail.io/en/latest/contributing/developing.html#testing)
* [x] Does the code comply with the style guide? (Run `make lint` from the Wagtail root)
* ~For Python changes: Have you added tests to cover the new/fixed behaviour?~
* [ ] For front-end changes: Did you test on all of Wagtail’s supported browsers?
* ~For new features: Has the documentation been updated accordingly?~

Tested in latest Chrome, Firefox, Safari on macOS by:

- Opening an edit page then moving elsewhere right away – no confirmation
- Opening an edit page then moving elsewhere after the 10s delay – no confirmation
- Opening an edit page, editing content in less than 10s, moving elsewhere  – no confirmation
- Opening an edit page, editing content over more than 10s, moving elsewhere - confirmation