### PR TITLE
Fix jcrop holder image having no alt tag. Fix part of #5309

### DIFF
--- a/wagtail/images/static_src/wagtailimages/js/focal-point-chooser.js
+++ b/wagtail/images/static_src/wagtailimages/js/focal-point-chooser.js
@@ -24,6 +24,10 @@ function setupJcrop(image, original, focalPointOriginal, fields) {
         }
     }, function() {
         jcropapi = this
+
+        // Set alt="" on the image so its src is not read out loud to screen reader users.
+        var $holderImage = $('img', jcropapi.ui.holder);
+        $holderImage.attr('alt', '');
     });
 }
 


### PR DESCRIPTION
Fixes part of #5309. I’ve looked at the [jcrop API docs](http://deepliquid.com/content/Jcrop_API.html), this seems to be the most correct solution according to their API – manipulating the holder image in Jcrop’s "ready" callback.

Tested in Chrome & Firefox on macOS, IE11.

This can easily be tested over at https://thibaudcolasbugjcrop-img-alt-5-yms7s.squash.io/admin/images/1/.