### PR TITLE
Make image fallback work for images with big/small aspect ratios

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -9,6 +9,7 @@ Changelog
  * Fix: Added line breaks to long filenames on multiple image / document uploader (Kevin Howbrook)
  * Fix: Added https support for Scribd oEmbed provider (Rodrigo)
  * Fix: Changed StreamField group labels color so labels are visible (Catherine Farman)
+ * Fix: Prevented images with a very wide aspect ratio from being displayed distorted in the rich text editor (Iman Syed)
 
 
 2.6 (01.08.2019)

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -384,6 +384,7 @@ Contributors
 * William Blackie
 * Andrew Miller
 * Rodrigo
+* Iman Syed
 
 Translators
 ===========

--- a/client/src/components/Draftail/blocks/MediaBlock.scss
+++ b/client/src/components/Draftail/blocks/MediaBlock.scss
@@ -25,7 +25,8 @@
 
     @mixin invalid-image-fallback {
         min-width: 256px;
-        min-height: 25px;
+        min-height: 50px;
+        object-fit: contain;
         background-color: $color-grey-1;
     }
 

--- a/client/src/components/Draftail/blocks/MediaBlock.scss
+++ b/client/src/components/Draftail/blocks/MediaBlock.scss
@@ -25,7 +25,7 @@
 
     @mixin invalid-image-fallback {
         min-width: 256px;
-        min-height: 100px;
+        min-height: 25px;
         background-color: $color-grey-1;
     }
 

--- a/docs/releases/2.7.rst
+++ b/docs/releases/2.7.rst
@@ -27,6 +27,7 @@ Bug fixes
  * Added line breaks to long filenames on multiple image / document uploader (Kevin Howbrook)
  * Added https support for Scribd oEmbed provider (Rodrigo)
  * Changed StreamField group label color so labels are visible (Catherine Farman)
+ * Prevented images with a very wide aspect ratio from being displayed distorted in the rich text editor (Iman Syed)
 
 
 Upgrade considerations


### PR DESCRIPTION
Fixes #5472 

Tested on Chrome with approx  7:1 aspect ratio

![ldIxFVVIRuiysz5nVRzthQ_thumb_6](https://user-images.githubusercontent.com/52247241/62202172-b4ae0500-b380-11e9-9e41-e910acfdefec.jpg)

Went with this option under advice of Thibaud