### PR TITLE
Apply escaping to JS translation strings.

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/admin_base.html
+++ b/wagtail/admin/templates/wagtailadmin/admin_base.html
@@ -27,66 +27,7 @@
                 EXTRA_CHILDREN_PARAMETERS: '',
             };
 
-            wagtailConfig.STRINGS = {
-                DELETE: "{% trans 'Delete' %}",
-                PAGE: "{% trans 'Page' %}",
-                PAGES: "{% trans 'Pages' %}",
-                LOADING: "{% trans 'Loading…' %}",
-                NO_RESULTS: "{% trans 'No results' %}",
-                SERVER_ERROR: "{% trans 'Server Error' %}",
-                SEE_ALL: "{% trans 'See all' %}",
-                CLOSE_EXPLORER: "{% trans 'Close explorer' %}",
-                ALT_TEXT: "{% trans 'Alt text' %}",
-                WRITE_HERE: "{% trans 'Write here…' %}",
-                HORIZONTAL_LINE: "{% trans 'Horizontal line' %}",
-                LINE_BREAK: "{% trans 'Line break' %}",
-                UNDO: "{% trans 'Undo' %}",
-                REDO: "{% trans 'Redo' %}",
-                RELOAD_PAGE: "{% trans 'Reload the page' %}",
-                RELOAD_EDITOR: "{% trans 'Reload saved content' %}",
-                SHOW_LATEST_CONTENT: "{% trans 'Show latest content' %}",
-                SHOW_ERROR: "{% trans 'Show error' %}",
-                EDITOR_CRASH: "{% trans 'The editor just crashed. Content has been reset to the last saved version.' %}",
-                BROKEN_LINK: "{% trans 'Broken link' %}",
-                MISSING_DOCUMENT: "{% trans 'Missing document' %}",
-                CLOSE: "{% trans 'Close' %}",
-                EDIT_PAGE: "{% trans 'Edit \'{title}\'' %}",
-                VIEW_CHILD_PAGES_OF_PAGE: "{% trans 'View child pages of \'{title}\'' %}",
-                PAGE_EXPLORER: "{% trans 'Page explorer' %}",
-
-                MONTHS: [
-                    "{% trans 'January' %}",
-                    "{% trans 'February' %}",
-                    "{% trans 'March' %}",
-                    "{% trans 'April' %}",
-                    "{% trans 'May' %}",
-                    "{% trans 'June' %}",
-                    "{% trans 'July' %}",
-                    "{% trans 'August' %}",
-                    "{% trans 'September' %}",
-                    "{% trans 'October' %}",
-                    "{% trans 'November' %}",
-                    "{% trans 'December' %}"
-                ],
-                WEEKDAYS: [
-                    "{% trans 'Sunday' %}",
-                    "{% trans 'Monday' %}",
-                    "{% trans 'Tuesday' %}",
-                    "{% trans 'Wednesday' %}",
-                    "{% trans 'Thursday' %}",
-                    "{% trans 'Friday' %}",
-                    "{% trans 'Saturday' %}"
-                ],
-                WEEKDAYS_SHORT: [
-                    "{% trans 'Sun' %}",
-                    "{% trans 'Mon' %}",
-                    "{% trans 'Tue' %}",
-                    "{% trans 'Wed' %}",
-                    "{% trans 'Thu' %}",
-                    "{% trans 'Fri' %}",
-                    "{% trans 'Sat' %}"
-                ]
-            };
+            wagtailConfig.STRINGS = {% js_translation_strings %};
 
             wagtailConfig.ADMIN_URLS = {
                 PAGES: '{% url "wagtailadmin_explore_root" %}'

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -1,4 +1,5 @@
 import itertools
+import json
 
 from django import template
 from django.conf import settings
@@ -15,6 +16,7 @@ from django.utils.translation import ugettext_lazy as _
 from wagtail.admin.menu import admin_menu
 from wagtail.admin.navigation import get_explorable_root_page
 from wagtail.admin.search import admin_search_areas
+from wagtail.admin.utils import get_js_translation_strings
 from wagtail.core import hooks
 from wagtail.core.models import (
     CollectionViewRestriction, Page, PageViewRestriction, UserPagePermissionsProxy)
@@ -473,3 +475,8 @@ def avatar_url(user, size=50):
             return gravatar_url
 
     return static('wagtailadmin/images/default-user-avatar.png')
+
+
+@register.simple_tag
+def js_translation_strings():
+    return mark_safe(json.dumps(get_js_translation_strings()))

--- a/wagtail/admin/utils.py
+++ b/wagtail/admin/utils.py
@@ -61,6 +61,71 @@ WAGTAILADMIN_PROVIDED_LANGUAGES = [
 ]
 
 
+# Translatable strings to be made available to Javascript code
+# as the wagtailConfig.STRINGS object
+def get_js_translation_strings():
+    return {
+        'DELETE': _('Delete'),
+        'PAGE': _('Page'),
+        'PAGES': _('Pages'),
+        'LOADING': _('Loading…'),
+        'NO_RESULTS': _('No results'),
+        'SERVER_ERROR': _('Server Error'),
+        'SEE_ALL': _('See all'),
+        'CLOSE_EXPLORER': _('Close explorer'),
+        'ALT_TEXT': _('Alt text'),
+        'WRITE_HERE': _('Write here…'),
+        'HORIZONTAL_LINE': _('Horizontal line'),
+        'LINE_BREAK': _('Line break'),
+        'UNDO': _('Undo'),
+        'REDO': _('Redo'),
+        'RELOAD_PAGE': _('Reload the page'),
+        'RELOAD_EDITOR': _('Reload saved content'),
+        'SHOW_LATEST_CONTENT': _('Show latest content'),
+        'SHOW_ERROR': _('Show error'),
+        'EDITOR_CRASH': _('The editor just crashed. Content has been reset to the last saved version.'),
+        'BROKEN_LINK': _('Broken link'),
+        'MISSING_DOCUMENT': _('Missing document'),
+        'CLOSE': _('Close'),
+        'EDIT_PAGE': _('Edit \'{title}\''),
+        'VIEW_CHILD_PAGES_OF_PAGE': _('View child pages of \'{title}\''),
+        'PAGE_EXPLORER': _('Page explorer'),
+
+        'MONTHS': [
+            _('January'),
+            _('February'),
+            _('March'),
+            _('April'),
+            _('May'),
+            _('June'),
+            _('July'),
+            _('August'),
+            _('September'),
+            _('October'),
+            _('November'),
+            _('December')
+        ],
+        'WEEKDAYS': [
+            _('Sunday'),
+            _('Monday'),
+            _('Tuesday'),
+            _('Wednesday'),
+            _('Thursday'),
+            _('Friday'),
+            _('Saturday')
+        ],
+        'WEEKDAYS_SHORT': [
+            _('Sun'),
+            _('Mon'),
+            _('Tue'),
+            _('Wed'),
+            _('Thu'),
+            _('Fri'),
+            _('Sat')
+        ]
+    }
+
+
 def get_available_admin_languages():
     return getattr(settings, 'WAGTAILADMIN_PERMITTED_LANGUAGES', WAGTAILADMIN_PROVIDED_LANGUAGES)
 


### PR DESCRIPTION
Fixes #5477

Rather than inserting translations individually into the template via the `{% trans %}` tag (which fails to apply Javascript escaping), write out the full dictionary in one go via `json.dumps`.