### PR TITLE
Clarify CHANGELOG instructions in "Committing code" docs

### DIFF
--- a/docs/contributing/committing.rst
+++ b/docs/contributing/committing.rst
@@ -2,8 +2,7 @@
 Committing code
 ===============
 
-This section is for the committers of Wagtail,
-or for anyone interested in the process of getting code committed to Wagtail.
+**This section is for the core team of Wagtail, or for anyone interested in the process of getting code committed to Wagtail.**
 
 Code should only be committed after it has been reviewed
 by at least one other reviewer or committer,
@@ -66,6 +65,10 @@ depending on which will be more readable in the commit history.
 
 Update ``CHANGELOG.txt`` and release notes
 ==========================================
+
+.. note::
+
+    This should only be done by core committers, once the changes have been reviewed and accepted.
 
 Every significant change to Wagtail should get an entry in the ``CHANGELOG.txt``,
 and the release notes for the current version.


### PR DESCRIPTION
This changes the "Committing code" documentation to clarify whose role it is to update the CHANGELOG and release notes. It’s quite common for contributors to Wagtail to update the CHANGELOG / release notes in their PRs, which is a source of merging conflicts.

New version:

<img width="797" alt="committing-code" src="https://user-images.githubusercontent.com/877585/62464348-430cf700-b784-11e9-926d-c1307c2f531d.png">

[…]

![changelog-notes](https://user-images.githubusercontent.com/877585/62464369-4ef8b900-b784-11e9-8078-240aec908df4.png)
