### PR TITLE
Resolve Py3.8 DeprecationWarning

### DIFF
--- a/wagtail/utils/l18n/translation.py
+++ b/wagtail/utils/l18n/translation.py
@@ -2,7 +2,7 @@ import os
 import gettext
 import bisect
 from locale import getdefaultlocale
-from collections import MutableMapping
+from collections.abc import MutableMapping
 from copy import copy, deepcopy
 
 import six


### PR DESCRIPTION
Resolves "DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working" - see #5484
