### PR TITLE
Upgrade django-taggit to 1.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,8 +22,8 @@ except ImportError:
 
 install_requires = [
     "Django>=2.0,<2.3",
-    "django-modelcluster>=4.2,<5.0",
-    "django-taggit>=0.23,<1.0",
+    "django-modelcluster>=5.0,<6.0",
+    "django-taggit>=1.0,<2.0",
     "django-treebeard>=4.2.0,<5.0",
     "djangorestframework>=3.7.4,<4.0",
     "draftjs_exporter>=2.1.5,<3.0",

--- a/wagtail/admin/compare.py
+++ b/wagtail/admin/compare.py
@@ -274,19 +274,6 @@ class M2MFieldComparison(FieldComparison):
 
 
 class TagsFieldComparison(M2MFieldComparison):
-    def get_items(self):
-        tags_a = [
-            tag.tag
-            for tag in self.val_a
-        ]
-
-        tags_b = [
-            tag.tag
-            for tag in self.val_b
-        ]
-
-        return tags_a, tags_b
-
     def get_item_display(self, tag):
         return tag.slug
 

--- a/wagtail/search/index.py
+++ b/wagtail/search/index.py
@@ -225,9 +225,9 @@ class BaseField:
             if hasattr(field, 'get_searchable_content'):
                 value = field.get_searchable_content(value)
             elif isinstance(field, TaggableManager):
-                # Special case for tags fields. Convert QuerySet of TaggedItems into QuerySet of Tags
-                Tag = field.remote_field.model
-                value = Tag.objects.filter(id__in=value.values_list('tag_id', flat=True))
+                # As of django-taggit 1.0, value_from_object returns a list of Tag objects,
+                # which matches what we want
+                pass
             elif isinstance(field, RelatedField):
                 # The type of the ForeignKey may have a get_searchable_content method that we should
                 # call. Firstly we need to find the field its referencing but it may be referencing


### PR DESCRIPTION
django-taggit 1.x drops Python 2.x support and thus the dependency on django.utils.six; this is a prerequisite for supporting Django 3.0.
The signature of TaggableManager.value_from_object has changed to return a list of Tags (previously it was a QuerySet of TaggedItems) and so search indexing and comparison need to be updated accordingly. There is a corresponding fix to ClusterTaggableManager in django-modelcluster 5.0.