### PR TITLE
Don't use page admin title when editing rich text

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_page_title_choose.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_page_title_choose.html
@@ -8,7 +8,7 @@ Expects a variable 'page', the page instance.
 
 <div class="title-wrapper">
     {% if page.can_choose %}
-        <a class="choose-page" href="#{{ page.id|unlocalize }}" data-id="{{ page.id|unlocalize }}" data-title="{{ page.get_admin_display_title }}" data-url="{{ page.url }}" data-parent-id="{{ page.get_parent.id|unlocalize }}" data-edit-url="{% url 'wagtailadmin_pages:edit' page.id %}">{{ page.get_admin_display_title }}</a>
+        <a class="choose-page" href="#{{ page.id|unlocalize }}" data-id="{{ page.id|unlocalize }}" data-title="{{ page.title }}" data-url="{{ page.url }}" data-parent-id="{{ page.get_parent.id|unlocalize }}" data-edit-url="{% url 'wagtailadmin_pages:edit' page.id %}">{{ page.get_admin_display_title }}</a>
     {% else %}
         {{ page.get_admin_display_title }}
     {% endif %}

--- a/wagtail/admin/tests/test_page_chooser.py
+++ b/wagtail/admin/tests/test_page_chooser.py
@@ -208,7 +208,13 @@ class TestChooserBrowseChild(TestCase, WagtailTestUtils):
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, 'wagtailadmin/chooser/browse.html')
 
-        self.assertInHTML("foobarbaz (simple page)", response.json().get('html'))
+        html = response.json().get('html')
+        self.assertInHTML("foobarbaz (simple page)", html)
+
+        # The data-title attribute should not use the custom admin display title,
+        # because JS code that uses that attribute (e.g. the rich text editor)
+        # should use the real page title.
+        self.assertIn('data-title="foobarbaz"', html)
 
     def test_parent_with_admin_display_title(self):
         # Add another child under child_page so it renders a chooser list


### PR DESCRIPTION
When editing a rich text field and entering a link to a page whose Page type overrides [`get_admin_display_title`](http://docs.wagtail.io/en/v2.0/reference/pages/model_reference.html?highlight=get_admin_display_title#wagtail.core.models.Page.get_admin_display_title), the custom admin display title is used both when browsing to select the page to link to and also when viewing the rich text editor.

The first behavior is consistent with how custom admin display titles are used throughout the admin, but the second behavior is not. The Wagtail user should be able to use the rich text field as a reasonable preview of what the rendered content will look like for the end user. To do this, the "real" page title should be used, not the admin one.

This commit alters the data that gets passed to the rich text editor so that its title is the real page title and not the admin one.

I wasn't really sure how best to define a test for this, if such a thing is even easily possible. It looks to me like the current implementation was part of [a much larger set of changes](https://github.com/wagtail/wagtail/commit/8a3c47f76afcb45182aa11cc94e5e0443d2836a5#diff-ed9cd5801b0c3c10ba6eaf3878e2b7ebL9) around custom admin display titles.

Fixes #5131.