### PR TITLE
Feature for default customization in action menu

### DIFF
--- a/docs/reference/hooks.rst
+++ b/docs/reference/hooks.rst
@@ -566,13 +566,19 @@ Hooks for customising the way users are directed through the process of creating
 
   Modify the final list of action menu items on the page creation and edit views. The callable passed to this hook receives a list of ``ActionMenuItem`` objects, a request object and a context dictionary as per ``register_page_action_menu_item``, and should modify the list of menu items in-place.
 
-  Can also be used to customize default action menu.
 
   .. code-block:: python
 
     @hooks.register('construct_page_action_menu')
     def remove_submit_to_moderator_option(menu_items, request, context):
         menu_items[:] = [item for item in menu_items if item.name != 'action-submit']
+
+
+.. _construct_page_action_menu:
+
+  Can also be used to customize default action menu button. The last item in menu_item variable is chosen as the default action. An example on changing the default to publish can be seen below.
+
+  .. code-block:: python
 
     from wagtail.admin.action_menu import UnpublishMenuItem, DeleteMenuItem, SubmitForModerationMenuItem, SaveDraftMenuItem, PublishMenuItem
 
@@ -583,10 +589,8 @@ Hooks for customising the way users are directed through the process of creating
                 DeleteMenuItem(order=20),
                 SubmitForModerationMenuItem(order=30),
                 SaveDraftMenuItem(order=40),
-                PublishMenuItem(_isDefault=True),
+                PublishMenuItem(order=50),
         ]
-
-
 
 
 .. construct_page_listing_buttons:

--- a/docs/reference/hooks.rst
+++ b/docs/reference/hooks.rst
@@ -566,11 +566,28 @@ Hooks for customising the way users are directed through the process of creating
 
   Modify the final list of action menu items on the page creation and edit views. The callable passed to this hook receives a list of ``ActionMenuItem`` objects, a request object and a context dictionary as per ``register_page_action_menu_item``, and should modify the list of menu items in-place.
 
+  Can also be used to customize default action menu.
+
   .. code-block:: python
 
     @hooks.register('construct_page_action_menu')
     def remove_submit_to_moderator_option(menu_items, request, context):
         menu_items[:] = [item for item in menu_items if item.name != 'action-submit']
+
+    from wagtail.admin.action_menu import UnpublishMenuItem, DeleteMenuItem, SubmitForModerationMenuItem, SaveDraftMenuItem, PublishMenuItem
+
+    @hooks.register('construct_page_action_menu')
+    def make_publish_default_action(menu_items, request, context):
+        menu_items[:] = [
+                UnpublishMenuItem(order=10),
+                DeleteMenuItem(order=20),
+                SubmitForModerationMenuItem(order=30),
+                SaveDraftMenuItem(order=40),
+                PublishMenuItem(_isDefault=True),
+        ]
+
+
+
 
 .. construct_page_listing_buttons:
 

--- a/wagtail/admin/action_menu.py
+++ b/wagtail/admin/action_menu.py
@@ -1,6 +1,5 @@
 """Handles rendering of the list of actions in the footer of the page create/edit views."""
 
-from django.core.exceptions import ImproperlyConfigured
 from django.forms import Media, MediaDefiningClass
 from django.template.loader import render_to_string
 from django.urls import reverse
@@ -19,10 +18,9 @@ class ActionMenuItem(metaclass=MediaDefiningClass):
     label = ''
     name = None
 
-    def __init__(self, order=None, _isDefault=False):
+    def __init__(self, order=None):
         if order is not None:
             self.order = order
-        self._isDefault = _isDefault
 
     def is_shown(self, request, context):
         """
@@ -102,7 +100,6 @@ class UnpublishMenuItem(ActionMenuItem):
         )
 
     def get_url(self, request, context):
-        print(self.is_shown(request, context), self._isDefault)
         return reverse('wagtailadmin_pages:unpublish', args=(context['page'].id,))
 
 
@@ -148,6 +145,7 @@ def _get_base_page_action_menu_items():
             DeleteMenuItem(order=20),
             PublishMenuItem(order=30),
             SubmitForModerationMenuItem(order=40),
+            SaveDraftMenuItem(order=50),
         ]
         for hook in hooks.get_hooks('register_page_action_menu_item'):
             BASE_PAGE_ACTION_MENU_ITEMS.append(hook())
@@ -162,7 +160,6 @@ class PageActionMenu:
         self.request = request
         self.context = kwargs
         self.context['user_page_permissions'] = UserPagePermissionsProxy(self.request.user)
-        self.default_item = SaveDraftMenuItem(_isDefault=True)
 
         self.menu_items = [
             menu_item
@@ -170,34 +167,25 @@ class PageActionMenu:
             if menu_item.is_shown(self.request, self.context)
         ]
 
-
-        self.menu_items.sort(key=lambda item: (item._isDefault, item.order))
+        self.menu_items.sort(key=lambda item: item.order)
 
         for hook in hooks.get_hooks('construct_page_action_menu'):
             hook(self.menu_items, self.request, self.context)
 
-        # Chcek improperly configured default menu_itmes
-        default_count = 0
-        for menu_item in self.menu_items:
-            if menu_item._isDefault:
-                self.default_item = menu_item
-                default_count += 1
+        self.default_item = self.menu_items.pop() if self.menu_items else SaveDraftMenuItem(order=50)
 
-            if default_count > 1:
-                raise ImproperlyConfigured("Only one menu item can be default")
 
     def render_html(self):
+        print(self.template)
         return render_to_string(self.template, {
+            'default_menu_item': self.default_item.render_html(self.request, self.context),
             'show_menu': bool(self.menu_items),
             'rendered_menu_items': [
                 menu_item.render_html(self.request, self.context)
                 for menu_item in self.menu_items
-                if not menu_item._isDefault and menu_item.is_shown(self.request, self.context)
+                if menu_item.is_shown(self.request, self.context)
             ],
         }, request=self.request)
-
-    def render_default_html(self):
-        return self.default_item.render_html(self.request, self.context)
 
     @cached_property
     def media(self):

--- a/wagtail/admin/templates/wagtailadmin/pages/action_menu/menu.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/action_menu/menu.html
@@ -1,6 +1,10 @@
 {% if show_menu %}
     <div class="dropdown-toggle icon icon-arrow-up"></div>
     <ul>
-        {% for item in rendered_menu_items %}{{ item }}{% endfor %}
+        {% for item in rendered_menu_items %}
+            <li>
+                 {{ item }}
+            </li>
+        {% endfor %}
     </ul>
 {% endif %}

--- a/wagtail/admin/templates/wagtailadmin/pages/action_menu/menu.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/action_menu/menu.html
@@ -1,4 +1,5 @@
 {% if show_menu %}
+    {{ default_menu_item }}
     <div class="dropdown-toggle icon icon-arrow-up"></div>
     <ul>
         {% for item in rendered_menu_items %}

--- a/wagtail/admin/templates/wagtailadmin/pages/action_menu/menu_item.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/action_menu/menu_item.html
@@ -1,7 +1,5 @@
-<li>
-    {% if url %}
-        <a href="{{ url }}">{{ label }}</a>
-    {% else %}
-        <input type="submit" name="{{ name }}" value="{{ label }}" class="button" />
-    {% endif %}
-</li>
+{% if url %}
+    <a class="button" href="{{ url }}">{{ label }}</a>
+{% else %}
+    <input type="submit" name="{{ name }}" value="{{ label }}" class="button" />
+{% endif %}

--- a/wagtail/admin/templates/wagtailadmin/pages/action_menu/publish.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/action_menu/publish.html
@@ -1,4 +1,2 @@
 {% load i18n %}
-<li>
-    <button type="submit" name="action-publish" value="action-publish" class="button button-longrunning {% if is_revision %}warning{% endif %}" data-clicked-text="{% trans 'Publishing…' %}"><span class="icon icon-spinner"></span><em>{% if is_revision %}{% trans 'Publish this revision' %}{% else %}{% trans 'Publish' %}{% endif %}</em></button>
-</li>
+<button type="submit" name="action-publish" value="action-publish" class="button button-longrunning {% if is_revision %}warning{% endif %}" data-clicked-text="{% trans 'Publishing…' %}"><span class="icon icon-spinner"></span><em>{% if is_revision %}{% trans 'Publish this revision' %}{% else %}{% trans 'Publish' %}{% endif %}</em></button>

--- a/wagtail/admin/templates/wagtailadmin/pages/action_menu/save_draft.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/action_menu/save_draft.html
@@ -1,0 +1,2 @@
+{% load i18n %}
+<button type="submit" class="button action-save button-longrunning {% if is_revision %}warning{% endif %}" data-clicked-text="{% trans 'Saving…' %}" {% if page.locked %}disabled {% endif %}><span class="icon icon-spinner"></span><em>{% if page.locked %}{% trans 'Page locked' %}{% else %}{% if is_revision %}{% trans 'Replace current draft' %}{% else %}{% trans 'Save draft' %}{% endif %}{% endif %}</em></button>

--- a/wagtail/admin/templates/wagtailadmin/pages/create.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/create.html
@@ -26,12 +26,13 @@
         <footer role="contentinfo">
             <nav aria-label="{% trans 'Actions' %}">
                 <ul>
-                    <li class="actions">
-                        <div class="dropdown dropup dropdown-button match-width">
-                            <button type="submit" class="button action-save button-longrunning" data-clicked-text="{% trans 'Saving…' %}"><span class="icon icon-spinner"></span><em>{% trans 'Save draft' %}</em></button>
-                            {{ action_menu.render_html }}
-                        </div>
-                    </li>
+                  <li class="actions">
+                      <div class="dropdown dropup dropdown-button match-width {% if is_revision %}warning{% endif %}">
+                          {{ action_menu.render_default_html }}
+
+                          {{ action_menu.render_html }}
+                      </div>
+                  </li>
 
                     <li class="preview">
                         {% trans 'Preview' as preview_label %}

--- a/wagtail/admin/templates/wagtailadmin/pages/edit.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/edit.html
@@ -39,7 +39,7 @@
                 <ul>
                     <li class="actions">
                         <div class="dropdown dropup dropdown-button match-width {% if is_revision %}warning{% endif %}">
-                            <button type="submit" class="button action-save button-longrunning {% if is_revision %}warning{% endif %}" data-clicked-text="{% trans 'Saving…' %}" {% if page.locked %}disabled {% endif %}><span class="icon icon-spinner"></span><em>{% if page.locked %}{% trans 'Page locked' %}{% else %}{% if is_revision %}{% trans 'Replace current draft' %}{% else %}{% trans 'Save draft' %}{% endif %}{% endif %}</em></button>
+                            {{ action_menu.render_default_html }}
 
                             {{ action_menu.render_html }}
                         </div>

--- a/wagtail/admin/templates/wagtailadmin/pages/edit.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/edit.html
@@ -39,8 +39,6 @@
                 <ul>
                     <li class="actions">
                         <div class="dropdown dropup dropdown-button match-width {% if is_revision %}warning{% endif %}">
-                            {{ action_menu.render_default_html }}
-
                             {{ action_menu.render_html }}
                         </div>
                     </li>

--- a/wagtail/admin/tests/test_pages_views.py
+++ b/wagtail/admin/tests/test_pages_views.py
@@ -20,6 +20,9 @@ from django.utils import formats, timezone
 from django.utils.dateparse import parse_date
 from freezegun import freeze_time
 
+from wagtail.admin.action_menu import (
+    DeleteMenuItem, PublishMenuItem, SaveDraftMenuItem, SubmitForModerationMenuItem,
+    UnpublishMenuItem)
 from wagtail.admin.views.home import RecentEditsPanel
 from wagtail.admin.views.pages import PreviewOnEdit
 from wagtail.core.models import GroupPagePermission, Page, PageRevision, Site
@@ -2101,6 +2104,41 @@ class TestPageEdit(TestCase, WagtailTestUtils):
 
         # page should be edited
         self.assertEqual(Page.objects.get(id=self.child_page.id).title, "I've been edited!")
+
+    def test_construct_page_action_menu_hook(self):
+        def hook_func(menu_items, request, context):
+            menu_items[:] = [
+                UnpublishMenuItem(order=10),
+                DeleteMenuItem(order=20),
+                SubmitForModerationMenuItem(order=30),
+                SaveDraftMenuItem(order=40),
+                PublishMenuItem(_isDefault=True),
+            ]
+
+        default_item = '<button type="submit" name="action-publish" value="action-publish" class="button button-longrunning " data-clicked-text="Publishing…"><span class="icon icon-spinner"></span><em>Publish</em></button>'
+        menu_items_html = '''
+        <ul>
+            <li>
+                <a class="button" href="/admin/pages/6/unpublish/">Unpublish</a>
+            </li>
+            <li>
+                <a class="button" href="/admin/pages/6/delete/">Delete</a>
+            </li>
+            <li>
+                <input type="submit" name="action-submit" value="Submit for moderation" class="button" />
+            </li>
+            <li>
+                <button type="submit" class="button action-save button-longrunning " data-clicked-text="Saving…" ><span class="icon icon-spinner"></span><em>Save draft</em></button>
+            </li>
+        </ul>
+        '''
+        with self.register_hook('construct_page_action_menu', hook_func):
+            response = self.client.get(reverse('wagtailadmin_pages:edit',
+                                       args=(self.single_event_page.id, )))
+
+        self.assertContains(response, default_item, html=True)
+        self.assertContains(response, menu_items_html, html=True)
+
 
 
 class TestPageEditReordering(TestCase, WagtailTestUtils):

--- a/wagtail/admin/tests/test_pages_views.py
+++ b/wagtail/admin/tests/test_pages_views.py
@@ -2120,6 +2120,8 @@ class TestPageEdit(TestCase, WagtailTestUtils):
         with self.register_hook('construct_page_action_menu', hook_func):
             response = self.client.get(reverse('wagtailadmin_pages:edit',
                                        args=(self.single_event_page.id, )))
+
+        print(response.content)
         for item in menu:
             if item.template:
                 self.assertTemplateUsed(response, item.template)

--- a/wagtail/admin/tests/test_pages_views.py
+++ b/wagtail/admin/tests/test_pages_views.py
@@ -2114,6 +2114,22 @@ class TestPageEdit(TestCase, WagtailTestUtils):
             PublishMenuItem(order=50),
         ]
 
+        default_item = '<button type="submit" name="action-publish" value="action-publish" class="button button-longrunning " data-clicked-text="Publishing…"><span class="icon icon-spinner"></span><em>Publish</em></button>'
+        menu_items_html = '''<ul>
+            <li>
+                <a class="button" href="/admin/pages/{id}/unpublish/">Unpublish</a>
+            </li>
+            <li>
+                <a class="button" href="/admin/pages/{id}/delete/">Delete</a>
+            </li>
+            <li>
+                <input type="submit" name="action-submit" value="Submit for moderation" class="button" />
+            </li>
+            <li>
+                <button type="submit" class="button action-save button-longrunning " data-clicked-text="Saving…" ><span class="icon icon-spinner"></span><em>Save draft</em></button>
+            </li>
+        </ul>'''.format(id=self.single_event_page.id)
+
         def hook_func(menu_items, request, context):
             menu_items[:] = menu
 
@@ -2121,7 +2137,9 @@ class TestPageEdit(TestCase, WagtailTestUtils):
             response = self.client.get(reverse('wagtailadmin_pages:edit',
                                        args=(self.single_event_page.id, )))
 
-        print(response.content)
+        self.assertContains(response, default_item, html=True)
+        self.assertContains(response, menu_items_html, html=True)
+
         for item in menu:
             if item.template:
                 self.assertTemplateUsed(response, item.template)
@@ -2133,12 +2151,24 @@ class TestPageEdit(TestCase, WagtailTestUtils):
             SubmitForModerationMenuItem(order=30),
         ]
 
+        default_item = '<input type="submit" name="action-submit" value="Submit for moderation" class="button" />'
+        menu_items_html = '''<ul>
+            <li>
+                <a class="button" href="/admin/pages/{id}/delete/">Delete</a>
+            </li>
+        </ul>'''.format(id=self.single_event_page.id)
+
+
         def hook_func(menu_items, request, context):
             menu_items[:] = menu
 
         with self.register_hook('construct_page_action_menu', hook_func):
             response = self.client.get(reverse('wagtailadmin_pages:edit',
                                        args=(self.single_event_page.id, )))
+
+        self.assertContains(response, default_item, html=True)
+        self.assertContains(response, menu_items_html, html=True)
+
         for item in menu:
             if item.template:
                 self.assertTemplateUsed(response, item.template)

--- a/wagtail/admin/tests/test_pages_views.py
+++ b/wagtail/admin/tests/test_pages_views.py
@@ -2112,12 +2112,11 @@ class TestPageEdit(TestCase, WagtailTestUtils):
                 DeleteMenuItem(order=20),
                 SubmitForModerationMenuItem(order=30),
                 SaveDraftMenuItem(order=40),
-                PublishMenuItem(_isDefault=True),
+                PublishMenuItem(order=50),
             ]
 
         default_item = '<button type="submit" name="action-publish" value="action-publish" class="button button-longrunning " data-clicked-text="Publishing…"><span class="icon icon-spinner"></span><em>Publish</em></button>'
-        menu_items_html = '''
-        <ul>
+        menu_items_html = '''<ul>
             <li>
                 <a class="button" href="/admin/pages/6/unpublish/">Unpublish</a>
             </li>
@@ -2130,8 +2129,7 @@ class TestPageEdit(TestCase, WagtailTestUtils):
             <li>
                 <button type="submit" class="button action-save button-longrunning " data-clicked-text="Saving…" ><span class="icon icon-spinner"></span><em>Save draft</em></button>
             </li>
-        </ul>
-        '''
+        </ul>'''
         with self.register_hook('construct_page_action_menu', hook_func):
             response = self.client.get(reverse('wagtailadmin_pages:edit',
                                        args=(self.single_event_page.id, )))

--- a/wagtail/admin/tests/test_pages_views.py
+++ b/wagtail/admin/tests/test_pages_views.py
@@ -2134,6 +2134,8 @@ class TestPageEdit(TestCase, WagtailTestUtils):
             response = self.client.get(reverse('wagtailadmin_pages:edit',
                                        args=(self.single_event_page.id, )))
 
+        print(response.context)
+
         self.assertContains(response, default_item, html=True)
         self.assertContains(response, menu_items_html, html=True)
 


### PR DESCRIPTION
Action menu html files were edited to be render in a list tag or just
a button to leverage existing code. Default button is rendered by
action_menu because the toggled list is rendered in same pattern.
Looking for alternative ways of writing documentation. Preferred
separate code block with instructions, but syntax would not allow.

Thanks for contributing to Wagtail! 🎉

Before submitting, please review the contributor guidelines <http://docs.wagtail.io/en/latest/contributing/index.html> and check the following:

* Do the tests still pass? (http://docs.wagtail.io/en/latest/contributing/developing.html#testing) yes
* Does the code comply with the style guide? (Run `make lint` from the Wagtail root) yes
* For Python changes: Have you added tests to cover the new/fixed behaviour? yes
* For front-end changes: Did you test on all of Wagtail’s supported browsers? **Please list the exact versions you tested**. chrome
* For new features: Has the documentation been updated accordingly? Yes, but I would like to make it look a little better. Could use help on where to read up on writing documentation.
