### PR TITLE
Fix pageurl and slugurl handling of situations where request.site is null

### DIFF
--- a/wagtail/core/templatetags/wagtailcore_tags.py
+++ b/wagtail/core/templatetags/wagtailcore_tags.py
@@ -31,6 +31,10 @@ def pageurl(context, page, fallback=None):
         # request.site not available in the current context; fall back on page.url
         return page.url
 
+    if current_site is None:
+        # request.site is set to None; fall back on page.url
+        return page.url
+
     # Pass page.relative_url the request object, which may contain a cached copy of
     # Site.get_site_root_paths()
     # This avoids page.relative_url having to make a database/cache fetch for this list
@@ -48,13 +52,15 @@ def slugurl(context, slug):
     that matches the slug on any site.
     """
 
+    page = None
     try:
         current_site = context['request'].site
     except (KeyError, AttributeError):
         # No site object found - allow the fallback below to take place.
-        page = None
+        pass
     else:
-        page = Page.objects.in_site(current_site).filter(slug=slug).first()
+        if current_site is not None:
+            page = Page.objects.in_site(current_site).filter(slug=slug).first()
 
     # If no page is found, fall back to searching the whole tree.
     if page is None:

--- a/wagtail/core/tests/tests.py
+++ b/wagtail/core/tests/tests.py
@@ -48,6 +48,16 @@ class TestPageUrlTags(TestCase):
         result = tpl.render(template.Context({'page': page, 'request': HttpRequest()}))
         self.assertIn('<a href="/events/">Events</a>', result)
 
+    def test_pageurl_with_null_site_in_request(self):
+        page = Page.objects.get(url_path='/home/events/')
+        tpl = template.Template('''{% load wagtailcore_tags %}<a href="{% pageurl page %}">{{ page.title }}</a>''')
+
+        # 'request' object in context, but site is None
+        request = HttpRequest()
+        request.site = None
+        result = tpl.render(template.Context({'page': page, 'request': request}))
+        self.assertIn('<a href="/events/">Events</a>', result)
+
     def test_bad_pageurl(self):
         tpl = template.Template('''{% load wagtailcore_tags %}<a href="{% pageurl page %}">{{ page.title }}</a>''')
 
@@ -94,6 +104,13 @@ class TestPageUrlTags(TestCase):
 
         # 'request' object in context, but no 'site' attribute
         result = slugurl(template.Context({'request': HttpRequest()}), 'events')
+        self.assertEqual(result, '/events/')
+
+    def test_slugurl_with_null_site_in_request(self):
+        # 'request' object in context, but site is None
+        request = HttpRequest()
+        request.site = None
+        result = slugurl(template.Context({'request': request}), 'events')
         self.assertEqual(result, '/events/')
 
 


### PR DESCRIPTION
Hi!

I've run into an edge case when using `pageurl` and `slugurl`. 

It is possible for `SiteMiddleware` to [set `request.site` to `None`](https://github.com/wagtail/wagtail/blob/master/wagtail/core/middleware.py#L15) (as opposed to not setting the `site` attribute at all) - e.g., if no default site exists. In such cases the existing behaviour of these template tags fails, because they assume that `request.site` will always be a `Site` object.

This patch adds a check for this condition and falls back to using a non-site-aware URL as would be the case if `request.site` was not set at all.