### PR TITLE
Fix doc and test on ES6 python client compat

### DIFF
--- a/docs/topics/search/backends.rst
+++ b/docs/topics/search/backends.rst
@@ -113,11 +113,12 @@ Prerequisites are the `Elasticsearch`_ service itself and, via pip, the `elastic
 
 .. code-block:: sh
 
-  pip install "elasticsearch>=6.0.0,<6.3.1"  # for Elasticsearch 6.x
+  pip install "elasticsearch>=6.4.0,<7.0.0"  # for Elasticsearch 6.x
 
 .. warning::
 
-    | Version 6.3.1 of the Elasticsearch client library is incompatible with Wagtail. Use 6.3.0 or earlier.
+    | Version 6.3.1 of the Elasticsearch client library is incompatible with Wagtail. Use 6.4.0 or above.
+
 
 The backend is configured in settings:
 

--- a/tox.ini
+++ b/tox.ini
@@ -53,7 +53,7 @@ deps =
     elasticsearch2: elasticsearch>=2,<3
     elasticsearch5: elasticsearch>=5,<6
     elasticsearch5: certifi
-    elasticsearch6: elasticsearch>=6,<6.3.1
+    elasticsearch6: elasticsearch>=6.4.0,<7
     elasticsearch6: certifi
 
 setenv =


### PR DESCRIPTION
This commit changes the statement that version < 6.3.1 of the
elasticsearch python client should be used to instead state
that 6.4.0 is fine.

It also update the tests to reflect the statement.

Initially the `update_all_types` argument has been used to work
around an issue described in:
https://github.com/wagtail/wagtail/issues/2968

This argument was removed in elasticsearch-py 6.3.1 and making
use of it was raising an error.

With 6.4.0 nothing is raising anymore.
It is not quite clear why it's not raising anymore but it works.