### PR TITLE
Reorganise wagtail.admin.utils and .decorators into meaningful sub-units

### DIFF
--- a/docs/reference/contrib/forms/customisation.rst
+++ b/docs/reference/contrib/forms/customisation.rst
@@ -716,7 +716,7 @@ If you want to change the content of the email that is sent when a form submits 
 To do this, you need to:
 
 * Ensure you have your form model defined that extends ``wagtail.contrib.forms.models.AbstractEmailForm``.
-* In your models.py file, import the ``wagtail.admin.utils.send_mail`` function.
+* In your models.py file, import the ``wagtail.admin.mail.send_mail`` function.
 * Override the ``send_mail`` method in your page model.
 
 Example:
@@ -725,7 +725,7 @@ Example:
 
     from datetime import date
     # ... additional wagtail imports
-    from wagtail.admin.utils import send_mail
+    from wagtail.admin.mail import send_mail
     from wagtail.contrib.forms.models import AbstractEmailForm
 
 
@@ -763,6 +763,6 @@ Example:
             # Content is joined with a new line to separate each text line
             content = '\n'.join(content)
 
-            # wagtail.wagtailadmin.utils - send_mail function is called
+            # wagtail.admin.mail - send_mail function is called
             # This function extends the Django default send_mail function
             send_mail(subject, content, addresses, self.from_address)

--- a/docs/releases/2.7.rst
+++ b/docs/releases/2.7.rst
@@ -55,3 +55,49 @@ Upgrade considerations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The internal ``Page.dummy_request`` method (which generates an HTTP request object simulating a real page request, for use in previews) has been deprecated, as it did not correctly handle errors generated during middleware processing. Any code that calls this method to render page previews should be updated to use the new method ``Page.make_preview_request(original_request=None, preview_mode=None)``, which builds the request and calls ``Page.serve_preview`` as a single operation.
+
+
+``wagtail.admin.utils`` and ``wagtail.admin.decorators`` modules deprecated
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The modules ``wagtail.admin.utils`` and ``wagtail.admin.decorators`` have been deprecated. The helper functions defined here exist primarily for Wagtail's internal use; however, some of them (particularly ``send_mail`` and ``permission_required``) may be found in user code, and import lines will need to be updated. The new locations for these definitions are as follows:
+
++---------------------------------+--------------------------+--------------------------+
+| Definition                      | Old location             | New location             |
++=================================+==========================+==========================+
+| any_permission_required         | wagtail.admin.utils      | wagtail.admin.auth       |
++---------------------------------+--------------------------+--------------------------+
+| permission_denied               | wagtail.admin.utils      | wagtail.admin.auth       |
++---------------------------------+--------------------------+--------------------------+
+| permission_required             | wagtail.admin.utils      | wagtail.admin.auth       |
++---------------------------------+--------------------------+--------------------------+
+| PermissionPolicyChecker         | wagtail.admin.utils      | wagtail.admin.auth       |
++---------------------------------+--------------------------+--------------------------+
+| user_has_any_page_permission    | wagtail.admin.utils      | wagtail.admin.auth       |
++---------------------------------+--------------------------+--------------------------+
+| user_passes_test                | wagtail.admin.utils      | wagtail.admin.auth       |
++---------------------------------+--------------------------+--------------------------+
+| users_with_page_permission      | wagtail.admin.utils      | wagtail.admin.auth       |
++---------------------------------+--------------------------+--------------------------+
+| reject_request                  | wagtail.admin.decorators | wagtail.admin.auth       |
++---------------------------------+--------------------------+--------------------------+
+| require_admin_access            | wagtail.admin.decorators | wagtail.admin.auth       |
++---------------------------------+--------------------------+--------------------------+
+| get_available_admin_languages   | wagtail.admin.utils      | wagtail.admin.locale     |
++---------------------------------+--------------------------+--------------------------+
+| get_available_admin_time_zones  | wagtail.admin.utils      | wagtail.admin.locale     |
++---------------------------------+--------------------------+--------------------------+
+| get_js_translation_strings      | wagtail.admin.utils      | wagtail.admin.locale     |
++---------------------------------+--------------------------+--------------------------+
+| WAGTAILADMIN_PROVIDED_LANGUAGES | wagtail.admin.utils      | wagtail.admin.locale     |
++---------------------------------+--------------------------+--------------------------+
+| send_mail                       | wagtail.admin.utils      | wagtail.admin.mail       |
++---------------------------------+--------------------------+--------------------------+
+| send_notification               | wagtail.admin.utils      | wagtail.admin.mail       |
++---------------------------------+--------------------------+--------------------------+
+| get_object_usage                | wagtail.admin.utils      | wagtail.admin.models     |
++---------------------------------+--------------------------+--------------------------+
+| popular_tags_for_model          | wagtail.admin.utils      | wagtail.admin.models     |
++---------------------------------+--------------------------+--------------------------+
+| get_site_for_user               | wagtail.admin.utils      | wagtail.admin.navigation |
++---------------------------------+--------------------------+--------------------------+

--- a/wagtail/admin/auth.py
+++ b/wagtail/admin/auth.py
@@ -1,12 +1,18 @@
 from functools import wraps
 
 from django.contrib.auth import get_user_model
+from django.contrib.auth.views import redirect_to_login as auth_redirect_to_login
 from django.core.exceptions import PermissionDenied
 from django.db.models import Q
 from django.shortcuts import redirect
+from django.urls import reverse
+from django.utils.timezone import activate as activate_tz
+from django.utils.translation import activate as activate_lang
 from django.utils.translation import ugettext as _
 
+from wagtail.admin import messages
 from wagtail.core.models import GroupPagePermission
+from wagtail.utils import l18n
 
 
 def users_with_page_permission(page, permission_type, include_superusers=True):
@@ -130,3 +136,35 @@ def user_has_any_page_permission(user):
 
     # No luck! This user can not do anything with pages.
     return False
+
+
+def reject_request(request):
+    if request.is_ajax():
+        raise PermissionDenied
+
+    return auth_redirect_to_login(
+        request.get_full_path(), login_url=reverse('wagtailadmin_login'))
+
+
+def require_admin_access(view_func):
+    def decorated_view(request, *args, **kwargs):
+        user = request.user
+
+        if user.is_anonymous:
+            return reject_request(request)
+
+        if user.has_perms(['wagtailadmin.access_admin']):
+            if hasattr(user, 'wagtail_userprofile'):
+                language = user.wagtail_userprofile.get_preferred_language()
+                l18n.set_language(language)
+                activate_lang(language)
+                time_zone = user.wagtail_userprofile.get_current_time_zone()
+                activate_tz(time_zone)
+            return view_func(request, *args, **kwargs)
+
+        if not request.is_ajax():
+            messages.error(request, _('You do not have permission to access the admin'))
+
+        return reject_request(request)
+
+    return decorated_view

--- a/wagtail/admin/auth.py
+++ b/wagtail/admin/auth.py
@@ -1,0 +1,132 @@
+from functools import wraps
+
+from django.contrib.auth import get_user_model
+from django.core.exceptions import PermissionDenied
+from django.db.models import Q
+from django.shortcuts import redirect
+from django.utils.translation import ugettext as _
+
+from wagtail.core.models import GroupPagePermission
+
+
+def users_with_page_permission(page, permission_type, include_superusers=True):
+    # Get user model
+    User = get_user_model()
+
+    # Find GroupPagePermission records of the given type that apply to this page or an ancestor
+    ancestors_and_self = list(page.get_ancestors()) + [page]
+    perm = GroupPagePermission.objects.filter(permission_type=permission_type, page__in=ancestors_and_self)
+    q = Q(groups__page_permissions__in=perm)
+
+    # Include superusers
+    if include_superusers:
+        q |= Q(is_superuser=True)
+
+    return User.objects.filter(is_active=True).filter(q).distinct()
+
+
+def permission_denied(request):
+    """Return a standard 'permission denied' response"""
+    if request.is_ajax():
+        raise PermissionDenied
+
+    from wagtail.admin import messages
+
+    messages.error(request, _('Sorry, you do not have permission to access this area.'))
+    return redirect('wagtailadmin_home')
+
+
+def user_passes_test(test):
+    """
+    Given a test function that takes a user object and returns a boolean,
+    return a view decorator that denies access to the user if the test returns false.
+    """
+    def decorator(view_func):
+        # decorator takes the view function, and returns the view wrapped in
+        # a permission check
+
+        @wraps(view_func)
+        def wrapped_view_func(request, *args, **kwargs):
+            if test(request.user):
+                # permission check succeeds; run the view function as normal
+                return view_func(request, *args, **kwargs)
+            else:
+                # permission check failed
+                return permission_denied(request)
+
+        return wrapped_view_func
+
+    return decorator
+
+
+def permission_required(permission_name):
+    """
+    Replacement for django.contrib.auth.decorators.permission_required which returns a
+    more meaningful 'permission denied' response than just redirecting to the login page.
+    (The latter doesn't work anyway because Wagtail doesn't define LOGIN_URL...)
+    """
+    def test(user):
+        return user.has_perm(permission_name)
+
+    # user_passes_test constructs a decorator function specific to the above test function
+    return user_passes_test(test)
+
+
+def any_permission_required(*perms):
+    """
+    Decorator that accepts a list of permission names, and allows the user
+    to pass if they have *any* of the permissions in the list
+    """
+    def test(user):
+        for perm in perms:
+            if user.has_perm(perm):
+                return True
+
+        return False
+
+    return user_passes_test(test)
+
+
+class PermissionPolicyChecker:
+    """
+    Provides a view decorator that enforces the given permission policy,
+    returning the wagtailadmin 'permission denied' response if permission not granted
+    """
+    def __init__(self, policy):
+        self.policy = policy
+
+    def require(self, action):
+        def test(user):
+            return self.policy.user_has_permission(user, action)
+
+        return user_passes_test(test)
+
+    def require_any(self, *actions):
+        def test(user):
+            return self.policy.user_has_any_permission(user, actions)
+
+        return user_passes_test(test)
+
+
+def user_has_any_page_permission(user):
+    """
+    Check if a user has any permission to add, edit, or otherwise manage any
+    page.
+    """
+    # Can't do nothin if you're not active.
+    if not user.is_active:
+        return False
+
+    # Superusers can do anything.
+    if user.is_superuser:
+        return True
+
+    # At least one of the users groups has a GroupPagePermission.
+    # The user can probably do something.
+    if GroupPagePermission.objects.filter(group__in=user.groups.all()).exists():
+        return True
+
+    # Specific permissions for a page type do not mean anything.
+
+    # No luck! This user can not do anything with pages.
+    return False

--- a/wagtail/admin/decorators.py
+++ b/wagtail/admin/decorators.py
@@ -1,41 +1,9 @@
-from django.contrib.auth.views import redirect_to_login as auth_redirect_to_login
-from django.core.exceptions import PermissionDenied
-from django.urls import reverse
-from django.utils.timezone import activate as activate_tz
-from django.utils.translation import activate as activate_lang
-from django.utils.translation import ugettext as _
+import sys
+from wagtail.utils.deprecation import MovedDefinitionHandler, RemovedInWagtail29Warning
 
-from wagtail.admin import messages
-from wagtail.utils import l18n
+MOVED_DEFINITIONS = {
+    'reject_request': 'wagtail.admin.auth',
+    'require_admin_access': 'wagtail.admin.auth',
+}
 
-
-def reject_request(request):
-    if request.is_ajax():
-        raise PermissionDenied
-
-    return auth_redirect_to_login(
-        request.get_full_path(), login_url=reverse('wagtailadmin_login'))
-
-
-def require_admin_access(view_func):
-    def decorated_view(request, *args, **kwargs):
-        user = request.user
-
-        if user.is_anonymous:
-            return reject_request(request)
-
-        if user.has_perms(['wagtailadmin.access_admin']):
-            if hasattr(user, 'wagtail_userprofile'):
-                language = user.wagtail_userprofile.get_preferred_language()
-                l18n.set_language(language)
-                activate_lang(language)
-                time_zone = user.wagtail_userprofile.get_current_time_zone()
-                activate_tz(time_zone)
-            return view_func(request, *args, **kwargs)
-
-        if not request.is_ajax():
-            messages.error(request, _('You do not have permission to access the admin'))
-
-        return reject_request(request)
-
-    return decorated_view
+sys.modules[__name__] = MovedDefinitionHandler(sys.modules[__name__], MOVED_DEFINITIONS, RemovedInWagtail29Warning)

--- a/wagtail/admin/locale.py
+++ b/wagtail/admin/locale.py
@@ -1,0 +1,116 @@
+import pytz
+
+from django.conf import settings
+from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy
+
+
+# Wagtail languages with >=90% coverage
+# This list is manually maintained
+WAGTAILADMIN_PROVIDED_LANGUAGES = [
+    ('ar', ugettext_lazy('Arabic')),
+    ('ca', ugettext_lazy('Catalan')),
+    ('cs', ugettext_lazy('Czech')),
+    ('de', ugettext_lazy('German')),
+    ('el', ugettext_lazy('Greek')),
+    ('en', ugettext_lazy('English')),
+    ('es', ugettext_lazy('Spanish')),
+    ('fi', ugettext_lazy('Finnish')),
+    ('fr', ugettext_lazy('French')),
+    ('gl', ugettext_lazy('Galician')),
+    ('hu', ugettext_lazy('Hungarian')),
+    ('id-id', ugettext_lazy('Indonesian')),
+    ('is-is', ugettext_lazy('Icelandic')),
+    ('it', ugettext_lazy('Italian')),
+    ('jp', ugettext_lazy('Japanese')),
+    ('ko', ugettext_lazy('Korean')),
+    ('lt', ugettext_lazy('Lithuanian')),
+    ('mn', ugettext_lazy('Mongolian')),
+    ('nb', ugettext_lazy('Norwegian Bokmål')),
+    ('nl-nl', ugettext_lazy('Netherlands Dutch')),
+    ('fa', ugettext_lazy('Persian')),
+    ('pl', ugettext_lazy('Polish')),
+    ('pt-br', ugettext_lazy('Brazilian Portuguese')),
+    ('pt-pt', ugettext_lazy('Portuguese')),
+    ('ro', ugettext_lazy('Romanian')),
+    ('ru', ugettext_lazy('Russian')),
+    ('sv', ugettext_lazy('Swedish')),
+    ('sk-sk', ugettext_lazy('Slovak')),
+    ('th', ugettext_lazy('Thai')),
+    ('uk', ugettext_lazy('Ukrainian')),
+    ('zh-hans', ugettext_lazy('Chinese (Simplified)')),
+    ('zh-hant', ugettext_lazy('Chinese (Traditional)')),
+]
+
+
+# Translatable strings to be made available to Javascript code
+# as the wagtailConfig.STRINGS object
+def get_js_translation_strings():
+    return {
+        'DELETE': _('Delete'),
+        'PAGE': _('Page'),
+        'PAGES': _('Pages'),
+        'LOADING': _('Loading…'),
+        'NO_RESULTS': _('No results'),
+        'SERVER_ERROR': _('Server Error'),
+        'SEE_ALL': _('See all'),
+        'CLOSE_EXPLORER': _('Close explorer'),
+        'ALT_TEXT': _('Alt text'),
+        'WRITE_HERE': _('Write here…'),
+        'HORIZONTAL_LINE': _('Horizontal line'),
+        'LINE_BREAK': _('Line break'),
+        'UNDO': _('Undo'),
+        'REDO': _('Redo'),
+        'RELOAD_PAGE': _('Reload the page'),
+        'RELOAD_EDITOR': _('Reload saved content'),
+        'SHOW_LATEST_CONTENT': _('Show latest content'),
+        'SHOW_ERROR': _('Show error'),
+        'EDITOR_CRASH': _('The editor just crashed. Content has been reset to the last saved version.'),
+        'BROKEN_LINK': _('Broken link'),
+        'MISSING_DOCUMENT': _('Missing document'),
+        'CLOSE': _('Close'),
+        'EDIT_PAGE': _('Edit \'{title}\''),
+        'VIEW_CHILD_PAGES_OF_PAGE': _('View child pages of \'{title}\''),
+        'PAGE_EXPLORER': _('Page explorer'),
+
+        'MONTHS': [
+            _('January'),
+            _('February'),
+            _('March'),
+            _('April'),
+            _('May'),
+            _('June'),
+            _('July'),
+            _('August'),
+            _('September'),
+            _('October'),
+            _('November'),
+            _('December')
+        ],
+        'WEEKDAYS': [
+            _('Sunday'),
+            _('Monday'),
+            _('Tuesday'),
+            _('Wednesday'),
+            _('Thursday'),
+            _('Friday'),
+            _('Saturday')
+        ],
+        'WEEKDAYS_SHORT': [
+            _('Sun'),
+            _('Mon'),
+            _('Tue'),
+            _('Wed'),
+            _('Thu'),
+            _('Fri'),
+            _('Sat')
+        ]
+    }
+
+
+def get_available_admin_languages():
+    return getattr(settings, 'WAGTAILADMIN_PERMITTED_LANGUAGES', WAGTAILADMIN_PROVIDED_LANGUAGES)
+
+
+def get_available_admin_time_zones():
+    return getattr(settings, 'WAGTAIL_USER_TIME_ZONES', pytz.common_timezones)

--- a/wagtail/admin/mail.py
+++ b/wagtail/admin/mail.py
@@ -1,0 +1,114 @@
+import logging
+
+from django.conf import settings
+from django.core.mail import get_connection
+from django.core.mail.message import EmailMultiAlternatives
+from django.template.loader import render_to_string
+from django.utils.translation import override
+
+from wagtail.admin.auth import users_with_page_permission
+from wagtail.core.models import PageRevision
+from wagtail.users.models import UserProfile
+
+
+logger = logging.getLogger('wagtail.admin')
+
+
+def send_mail(subject, message, recipient_list, from_email=None, **kwargs):
+    """
+    Wrapper around Django's EmailMultiAlternatives as done in send_mail().
+    Custom from_email handling and special Auto-Submitted header.
+    """
+    if not from_email:
+        if hasattr(settings, 'WAGTAILADMIN_NOTIFICATION_FROM_EMAIL'):
+            from_email = settings.WAGTAILADMIN_NOTIFICATION_FROM_EMAIL
+        elif hasattr(settings, 'DEFAULT_FROM_EMAIL'):
+            from_email = settings.DEFAULT_FROM_EMAIL
+        else:
+            from_email = 'webmaster@localhost'
+
+    connection = kwargs.get('connection', False) or get_connection(
+        username=kwargs.get('auth_user', None),
+        password=kwargs.get('auth_password', None),
+        fail_silently=kwargs.get('fail_silently', None),
+    )
+    multi_alt_kwargs = {
+        'connection': connection,
+        'headers': {
+            'Auto-Submitted': 'auto-generated',
+        }
+    }
+    mail = EmailMultiAlternatives(subject, message, from_email, recipient_list, **multi_alt_kwargs)
+    html_message = kwargs.get('html_message', None)
+    if html_message:
+        mail.attach_alternative(html_message, 'text/html')
+
+    return mail.send()
+
+
+def send_notification(page_revision_id, notification, excluded_user_id):
+    # Get revision
+    revision = PageRevision.objects.get(id=page_revision_id)
+
+    # Get list of recipients
+    if notification == 'submitted':
+        # Get list of publishers
+        include_superusers = getattr(settings, 'WAGTAILADMIN_NOTIFICATION_INCLUDE_SUPERUSERS', True)
+        recipients = users_with_page_permission(revision.page, 'publish', include_superusers)
+    elif notification in ['rejected', 'approved']:
+        # Get submitter
+        recipients = [revision.user]
+    else:
+        return False
+
+    # Get list of email addresses
+    email_recipients = [
+        recipient for recipient in recipients
+        if recipient.email and recipient.pk != excluded_user_id and getattr(
+            UserProfile.get_for_user(recipient),
+            notification + '_notifications'
+        )
+    ]
+
+    # Return if there are no email addresses
+    if not email_recipients:
+        return True
+
+    # Get template
+    template_subject = 'wagtailadmin/notifications/' + notification + '_subject.txt'
+    template_text = 'wagtailadmin/notifications/' + notification + '.txt'
+    template_html = 'wagtailadmin/notifications/' + notification + '.html'
+
+    # Common context to template
+    context = {
+        "revision": revision,
+        "settings": settings,
+    }
+
+    # Send emails
+    sent_count = 0
+    for recipient in email_recipients:
+        try:
+            # update context with this recipient
+            context["user"] = recipient
+
+            # Translate text to the recipient language settings
+            with override(recipient.wagtail_userprofile.get_preferred_language()):
+                # Get email subject and content
+                email_subject = render_to_string(template_subject, context).strip()
+                email_content = render_to_string(template_text, context).strip()
+
+            kwargs = {}
+            if getattr(settings, 'WAGTAILADMIN_NOTIFICATION_USE_HTML', False):
+                kwargs['html_message'] = render_to_string(template_html, context)
+
+            # Send email
+            send_mail(email_subject, email_content, [recipient.email], **kwargs)
+            sent_count += 1
+        except Exception:
+            logger.exception(
+                "Failed to send notification email '%s' to %s",
+                email_subject, recipient.email
+            )
+
+    return sent_count == len(email_recipients)

--- a/wagtail/admin/models.py
+++ b/wagtail/admin/models.py
@@ -1,5 +1,55 @@
+from django.contrib.contenttypes.models import ContentType
+from django.db.models import Count
+
+from modelcluster.fields import ParentalKey
+from taggit.models import Tag
+
 # The edit_handlers module extends Page with some additional attributes required by
 # wagtailadmin (namely, base_form_class and get_edit_handler). Importing this within
 # wagtailadmin.models ensures that this happens in advance of running wagtailadmin's
 # system checks.
 from wagtail.admin import edit_handlers  # NOQA
+from wagtail.core.models import Page
+
+
+def get_object_usage(obj):
+    "Returns a queryset of pages that link to a particular object"
+
+    pages = Page.objects.none()
+
+    # get all the relation objects for obj
+    relations = [f for f in type(obj)._meta.get_fields(include_hidden=True)
+                 if (f.one_to_many or f.one_to_one) and f.auto_created]
+    for relation in relations:
+        related_model = relation.related_model
+
+        # if the relation is between obj and a page, get the page
+        if issubclass(related_model, Page):
+            pages |= Page.objects.filter(
+                id__in=related_model._base_manager.filter(**{
+                    relation.field.name: obj.id
+                }).values_list('id', flat=True)
+            )
+        else:
+            # if the relation is between obj and an object that has a page as a
+            # property, return the page
+            for f in related_model._meta.fields:
+                if isinstance(f, ParentalKey) and issubclass(f.remote_field.model, Page):
+                    pages |= Page.objects.filter(
+                        id__in=related_model._base_manager.filter(
+                            **{
+                                relation.field.name: obj.id
+                            }).values_list(f.attname, flat=True)
+                    )
+
+    return pages
+
+
+def popular_tags_for_model(model, count=10):
+    """Return a queryset of the most frequently used tags used on this model class"""
+    content_type = ContentType.objects.get_for_model(model)
+    return Tag.objects.filter(
+        taggit_taggeditem_items__content_type=content_type
+    ).annotate(
+        item_count=Count('taggit_taggeditem_items')
+    ).order_by('-item_count')[:count]

--- a/wagtail/admin/models.py
+++ b/wagtail/admin/models.py
@@ -5,8 +5,8 @@ from modelcluster.fields import ParentalKey
 from taggit.models import Tag
 
 # The edit_handlers module extends Page with some additional attributes required by
-# wagtailadmin (namely, base_form_class and get_edit_handler). Importing this within
-# wagtailadmin.models ensures that this happens in advance of running wagtailadmin's
+# wagtail admin (namely, base_form_class and get_edit_handler). Importing this within
+# wagtail.admin.models ensures that this happens in advance of running wagtail.admin's
 # system checks.
 from wagtail.admin import edit_handlers  # NOQA
 from wagtail.core.models import Page

--- a/wagtail/admin/navigation.py
+++ b/wagtail/admin/navigation.py
@@ -1,3 +1,5 @@
+from django.conf import settings
+
 from wagtail.core.models import Page
 
 
@@ -26,3 +28,19 @@ def get_explorable_root_page(user):
         root_page = None
 
     return root_page
+
+
+def get_site_for_user(user):
+    root_page = get_explorable_root_page(user)
+    if root_page:
+        root_site = root_page.get_site()
+    else:
+        root_site = None
+    real_site_name = None
+    if root_site:
+        real_site_name = root_site.site_name if root_site.site_name else root_site.hostname
+    return {
+        'root_page': root_page,
+        'root_site': root_site,
+        'site_name': real_site_name if real_site_name else settings.WAGTAIL_SITE_NAME,
+    }

--- a/wagtail/admin/site_summary.py
+++ b/wagtail/admin/site_summary.py
@@ -1,6 +1,7 @@
 from django.template.loader import render_to_string
 
-from wagtail.admin.utils import get_site_for_user, user_has_any_page_permission
+from wagtail.admin.auth import user_has_any_page_permission
+from wagtail.admin.navigation import get_site_for_user
 from wagtail.core import hooks
 from wagtail.core.models import Page, Site
 

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -13,10 +13,10 @@ from django.utils.html import format_html, format_html_join
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy as _
 
+from wagtail.admin.locale import get_js_translation_strings
 from wagtail.admin.menu import admin_menu
 from wagtail.admin.navigation import get_explorable_root_page
 from wagtail.admin.search import admin_search_areas
-from wagtail.admin.utils import get_js_translation_strings
 from wagtail.core import hooks
 from wagtail.core.models import (
     CollectionViewRestriction, Page, PageViewRestriction, UserPagePermissionsProxy)

--- a/wagtail/admin/tests/test_account_management.py
+++ b/wagtail/admin/tests/test_account_management.py
@@ -12,7 +12,7 @@ from django.core import mail
 from django.test import TestCase, override_settings
 from django.urls import reverse
 
-from wagtail.admin.utils import (
+from wagtail.admin.locale import (
     WAGTAILADMIN_PROVIDED_LANGUAGES, get_available_admin_languages, get_available_admin_time_zones)
 from wagtail.tests.utils import WagtailTestUtils
 from wagtail.users.models import UserProfile

--- a/wagtail/admin/tests/test_admin_search.py
+++ b/wagtail/admin/tests/test_admin_search.py
@@ -6,7 +6,7 @@ from django.template import Context, Template
 from django.test import RequestFactory, TestCase
 from django.urls import reverse
 
-from wagtail.admin.utils import user_has_any_page_permission
+from wagtail.admin.auth import user_has_any_page_permission
 from wagtail.core.models import Site
 from wagtail.tests.utils import WagtailTestUtils
 

--- a/wagtail/admin/tests/tests.py
+++ b/wagtail/admin/tests/tests.py
@@ -10,8 +10,9 @@ from django.urls import reverse, reverse_lazy
 from django.utils.translation import ugettext_lazy as _
 from taggit.models import Tag
 
+from wagtail.admin.auth import user_has_any_page_permission
+from wagtail.admin.mail import send_mail
 from wagtail.admin.menu import MenuItem
-from wagtail.admin.utils import send_mail, user_has_any_page_permission
 from wagtail.core.models import Page
 from wagtail.tests.utils import WagtailTestUtils
 

--- a/wagtail/admin/urls/__init__.py
+++ b/wagtail/admin/urls/__init__.py
@@ -6,6 +6,7 @@ from django.views.generic import TemplateView
 from django.http import Http404
 from django.views.defaults import page_not_found
 
+from wagtail.admin.auth import require_admin_access
 from wagtail.admin.urls import pages as wagtailadmin_pages_urls
 from wagtail.admin.urls import collections as wagtailadmin_collections_urls
 from wagtail.admin.urls import password_reset as wagtailadmin_password_reset_urls
@@ -13,7 +14,6 @@ from wagtail.admin.views import account, chooser, home, pages, tags, userbar
 from wagtail.admin.api import urls as api_urls
 from wagtail.core import hooks
 from wagtail.utils.urlpatterns import decorate_urlpatterns
-from wagtail.admin.decorators import require_admin_access
 
 
 urlpatterns = [

--- a/wagtail/admin/utils.py
+++ b/wagtail/admin/utils.py
@@ -1,124 +1,20 @@
 # -*- coding: utf-8 -*-
 import logging
 import sys
-from functools import wraps
 
 from django.conf import settings
-from django.contrib.auth import get_user_model
-from django.core.exceptions import PermissionDenied
 from django.core.mail import get_connection
 from django.core.mail.message import EmailMultiAlternatives
-from django.db.models import Q
-from django.shortcuts import redirect
 from django.template.loader import render_to_string
-from django.utils.translation import ugettext as _
 from django.utils.translation import override
 
+from wagtail.admin.auth import users_with_page_permission
 from wagtail.admin.navigation import get_explorable_root_page
-from wagtail.core.models import GroupPagePermission, PageRevision
+from wagtail.core.models import PageRevision
 from wagtail.users.models import UserProfile
 from wagtail.utils.deprecation import MovedDefinitionHandler, RemovedInWagtail29Warning
 
 logger = logging.getLogger('wagtail.admin')
-
-
-def users_with_page_permission(page, permission_type, include_superusers=True):
-    # Get user model
-    User = get_user_model()
-
-    # Find GroupPagePermission records of the given type that apply to this page or an ancestor
-    ancestors_and_self = list(page.get_ancestors()) + [page]
-    perm = GroupPagePermission.objects.filter(permission_type=permission_type, page__in=ancestors_and_self)
-    q = Q(groups__page_permissions__in=perm)
-
-    # Include superusers
-    if include_superusers:
-        q |= Q(is_superuser=True)
-
-    return User.objects.filter(is_active=True).filter(q).distinct()
-
-
-def permission_denied(request):
-    """Return a standard 'permission denied' response"""
-    if request.is_ajax():
-        raise PermissionDenied
-
-    from wagtail.admin import messages
-
-    messages.error(request, _('Sorry, you do not have permission to access this area.'))
-    return redirect('wagtailadmin_home')
-
-
-def user_passes_test(test):
-    """
-    Given a test function that takes a user object and returns a boolean,
-    return a view decorator that denies access to the user if the test returns false.
-    """
-    def decorator(view_func):
-        # decorator takes the view function, and returns the view wrapped in
-        # a permission check
-
-        @wraps(view_func)
-        def wrapped_view_func(request, *args, **kwargs):
-            if test(request.user):
-                # permission check succeeds; run the view function as normal
-                return view_func(request, *args, **kwargs)
-            else:
-                # permission check failed
-                return permission_denied(request)
-
-        return wrapped_view_func
-
-    return decorator
-
-
-def permission_required(permission_name):
-    """
-    Replacement for django.contrib.auth.decorators.permission_required which returns a
-    more meaningful 'permission denied' response than just redirecting to the login page.
-    (The latter doesn't work anyway because Wagtail doesn't define LOGIN_URL...)
-    """
-    def test(user):
-        return user.has_perm(permission_name)
-
-    # user_passes_test constructs a decorator function specific to the above test function
-    return user_passes_test(test)
-
-
-def any_permission_required(*perms):
-    """
-    Decorator that accepts a list of permission names, and allows the user
-    to pass if they have *any* of the permissions in the list
-    """
-    def test(user):
-        for perm in perms:
-            if user.has_perm(perm):
-                return True
-
-        return False
-
-    return user_passes_test(test)
-
-
-class PermissionPolicyChecker:
-    """
-    Provides a view decorator that enforces the given permission policy,
-    returning the wagtailadmin 'permission denied' response if permission not granted
-    """
-    def __init__(self, policy):
-        self.policy = policy
-
-    def require(self, action):
-        def test(user):
-            return self.policy.user_has_permission(user, action)
-
-        return user_passes_test(test)
-
-    def require_any(self, *actions):
-        def test(user):
-            return self.policy.user_has_any_permission(user, actions)
-
-        return user_passes_test(test)
 
 
 def send_mail(subject, message, recipient_list, from_email=None, **kwargs):
@@ -221,30 +117,6 @@ def send_notification(page_revision_id, notification, excluded_user_id):
     return sent_count == len(email_recipients)
 
 
-def user_has_any_page_permission(user):
-    """
-    Check if a user has any permission to add, edit, or otherwise manage any
-    page.
-    """
-    # Can't do nothin if you're not active.
-    if not user.is_active:
-        return False
-
-    # Superusers can do anything.
-    if user.is_superuser:
-        return True
-
-    # At least one of the users groups has a GroupPagePermission.
-    # The user can probably do something.
-    if GroupPagePermission.objects.filter(group__in=user.groups.all()).exists():
-        return True
-
-    # Specific permissions for a page type do not mean anything.
-
-    # No luck! This user can not do anything with pages.
-    return False
-
-
 def get_site_for_user(user):
     root_page = get_explorable_root_page(user)
     if root_page:
@@ -269,6 +141,14 @@ MOVED_DEFINITIONS = {
 
     'get_object_usage': 'wagtail.admin.models',
     'popular_tags_for_model': 'wagtail.admin.models',
+
+    'users_with_page_permission': 'wagtail.admin.auth',
+    'permission_denied': 'wagtail.admin.auth',
+    'user_passes_test': 'wagtail.admin.auth',
+    'permission_required': 'wagtail.admin.auth',
+    'any_permission_required': 'wagtail.admin.auth',
+    'PermissionPolicyChecker': 'wagtail.admin.auth',
+    'user_has_any_page_permission': 'wagtail.admin.auth',
 }
 
 sys.modules[__name__] = MovedDefinitionHandler(sys.modules[__name__], MOVED_DEFINITIONS, RemovedInWagtail29Warning)

--- a/wagtail/admin/utils.py
+++ b/wagtail/admin/utils.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import logging
+import sys
 from functools import wraps
-import pytz
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -13,125 +13,16 @@ from django.db.models import Count, Q
 from django.shortcuts import redirect
 from django.template.loader import render_to_string
 from django.utils.translation import ugettext as _
-from django.utils.translation import override, ugettext_lazy
+from django.utils.translation import override
 from modelcluster.fields import ParentalKey
 from taggit.models import Tag
 
 from wagtail.admin.navigation import get_explorable_root_page
 from wagtail.core.models import GroupPagePermission, Page, PageRevision
 from wagtail.users.models import UserProfile
+from wagtail.utils.deprecation import MovedDefinitionHandler, RemovedInWagtail29Warning
 
 logger = logging.getLogger('wagtail.admin')
-
-# Wagtail languages with >=90% coverage
-# This list is manually maintained
-WAGTAILADMIN_PROVIDED_LANGUAGES = [
-    ('ar', ugettext_lazy('Arabic')),
-    ('ca', ugettext_lazy('Catalan')),
-    ('cs', ugettext_lazy('Czech')),
-    ('de', ugettext_lazy('German')),
-    ('el', ugettext_lazy('Greek')),
-    ('en', ugettext_lazy('English')),
-    ('es', ugettext_lazy('Spanish')),
-    ('fi', ugettext_lazy('Finnish')),
-    ('fr', ugettext_lazy('French')),
-    ('gl', ugettext_lazy('Galician')),
-    ('hu', ugettext_lazy('Hungarian')),
-    ('id-id', ugettext_lazy('Indonesian')),
-    ('is-is', ugettext_lazy('Icelandic')),
-    ('it', ugettext_lazy('Italian')),
-    ('jp', ugettext_lazy('Japanese')),
-    ('ko', ugettext_lazy('Korean')),
-    ('lt', ugettext_lazy('Lithuanian')),
-    ('mn', ugettext_lazy('Mongolian')),
-    ('nb', ugettext_lazy('Norwegian Bokmål')),
-    ('nl-nl', ugettext_lazy('Netherlands Dutch')),
-    ('fa', ugettext_lazy('Persian')),
-    ('pl', ugettext_lazy('Polish')),
-    ('pt-br', ugettext_lazy('Brazilian Portuguese')),
-    ('pt-pt', ugettext_lazy('Portuguese')),
-    ('ro', ugettext_lazy('Romanian')),
-    ('ru', ugettext_lazy('Russian')),
-    ('sv', ugettext_lazy('Swedish')),
-    ('sk-sk', ugettext_lazy('Slovak')),
-    ('th', ugettext_lazy('Thai')),
-    ('uk', ugettext_lazy('Ukrainian')),
-    ('zh-hans', ugettext_lazy('Chinese (Simplified)')),
-    ('zh-hant', ugettext_lazy('Chinese (Traditional)')),
-]
-
-
-# Translatable strings to be made available to Javascript code
-# as the wagtailConfig.STRINGS object
-def get_js_translation_strings():
-    return {
-        'DELETE': _('Delete'),
-        'PAGE': _('Page'),
-        'PAGES': _('Pages'),
-        'LOADING': _('Loading…'),
-        'NO_RESULTS': _('No results'),
-        'SERVER_ERROR': _('Server Error'),
-        'SEE_ALL': _('See all'),
-        'CLOSE_EXPLORER': _('Close explorer'),
-        'ALT_TEXT': _('Alt text'),
-        'WRITE_HERE': _('Write here…'),
-        'HORIZONTAL_LINE': _('Horizontal line'),
-        'LINE_BREAK': _('Line break'),
-        'UNDO': _('Undo'),
-        'REDO': _('Redo'),
-        'RELOAD_PAGE': _('Reload the page'),
-        'RELOAD_EDITOR': _('Reload saved content'),
-        'SHOW_LATEST_CONTENT': _('Show latest content'),
-        'SHOW_ERROR': _('Show error'),
-        'EDITOR_CRASH': _('The editor just crashed. Content has been reset to the last saved version.'),
-        'BROKEN_LINK': _('Broken link'),
-        'MISSING_DOCUMENT': _('Missing document'),
-        'CLOSE': _('Close'),
-        'EDIT_PAGE': _('Edit \'{title}\''),
-        'VIEW_CHILD_PAGES_OF_PAGE': _('View child pages of \'{title}\''),
-        'PAGE_EXPLORER': _('Page explorer'),
-
-        'MONTHS': [
-            _('January'),
-            _('February'),
-            _('March'),
-            _('April'),
-            _('May'),
-            _('June'),
-            _('July'),
-            _('August'),
-            _('September'),
-            _('October'),
-            _('November'),
-            _('December')
-        ],
-        'WEEKDAYS': [
-            _('Sunday'),
-            _('Monday'),
-            _('Tuesday'),
-            _('Wednesday'),
-            _('Thursday'),
-            _('Friday'),
-            _('Saturday')
-        ],
-        'WEEKDAYS_SHORT': [
-            _('Sun'),
-            _('Mon'),
-            _('Tue'),
-            _('Wed'),
-            _('Thu'),
-            _('Fri'),
-            _('Sat')
-        ]
-    }
-
-
-def get_available_admin_languages():
-    return getattr(settings, 'WAGTAILADMIN_PERMITTED_LANGUAGES', WAGTAILADMIN_PROVIDED_LANGUAGES)
-
-
-def get_available_admin_time_zones():
-    return getattr(settings, 'WAGTAIL_USER_TIME_ZONES', pytz.common_timezones)
 
 
 def get_object_usage(obj):
@@ -414,3 +305,13 @@ def get_site_for_user(user):
         'root_site': root_site,
         'site_name': real_site_name if real_site_name else settings.WAGTAIL_SITE_NAME,
     }
+
+
+MOVED_DEFINITIONS = {
+    'WAGTAILADMIN_PROVIDED_LANGUAGES': 'wagtail.admin.locale',
+    'get_js_translation_strings': 'wagtail.admin.locale',
+    'get_available_admin_languages': 'wagtail.admin.locale',
+    'get_available_admin_time_zones': 'wagtail.admin.locale',
+}
+
+sys.modules[__name__] = MovedDefinitionHandler(sys.modules[__name__], MOVED_DEFINITIONS, RemovedInWagtail29Warning)

--- a/wagtail/admin/utils.py
+++ b/wagtail/admin/utils.py
@@ -1,25 +1,6 @@
 import sys
 
-from django.conf import settings
-
-from wagtail.admin.navigation import get_explorable_root_page
 from wagtail.utils.deprecation import MovedDefinitionHandler, RemovedInWagtail29Warning
-
-
-def get_site_for_user(user):
-    root_page = get_explorable_root_page(user)
-    if root_page:
-        root_site = root_page.get_site()
-    else:
-        root_site = None
-    real_site_name = None
-    if root_site:
-        real_site_name = root_site.site_name if root_site.site_name else root_site.hostname
-    return {
-        'root_page': root_page,
-        'root_site': root_site,
-        'site_name': real_site_name if real_site_name else settings.WAGTAIL_SITE_NAME,
-    }
 
 
 MOVED_DEFINITIONS = {
@@ -41,6 +22,8 @@ MOVED_DEFINITIONS = {
 
     'send_mail': 'wagtail.admin.mail',
     'send_notification': 'wagtail.admin.mail',
+
+    'get_site_for_user': 'wagtail.admin.navigation',
 }
 
 sys.modules[__name__] = MovedDefinitionHandler(sys.modules[__name__], MOVED_DEFINITIONS, RemovedInWagtail29Warning)

--- a/wagtail/admin/utils.py
+++ b/wagtail/admin/utils.py
@@ -1,120 +1,9 @@
-# -*- coding: utf-8 -*-
-import logging
 import sys
 
 from django.conf import settings
-from django.core.mail import get_connection
-from django.core.mail.message import EmailMultiAlternatives
-from django.template.loader import render_to_string
-from django.utils.translation import override
 
-from wagtail.admin.auth import users_with_page_permission
 from wagtail.admin.navigation import get_explorable_root_page
-from wagtail.core.models import PageRevision
-from wagtail.users.models import UserProfile
 from wagtail.utils.deprecation import MovedDefinitionHandler, RemovedInWagtail29Warning
-
-logger = logging.getLogger('wagtail.admin')
-
-
-def send_mail(subject, message, recipient_list, from_email=None, **kwargs):
-    """
-    Wrapper around Django's EmailMultiAlternatives as done in send_mail().
-    Custom from_email handling and special Auto-Submitted header.
-    """
-    if not from_email:
-        if hasattr(settings, 'WAGTAILADMIN_NOTIFICATION_FROM_EMAIL'):
-            from_email = settings.WAGTAILADMIN_NOTIFICATION_FROM_EMAIL
-        elif hasattr(settings, 'DEFAULT_FROM_EMAIL'):
-            from_email = settings.DEFAULT_FROM_EMAIL
-        else:
-            from_email = 'webmaster@localhost'
-
-    connection = kwargs.get('connection', False) or get_connection(
-        username=kwargs.get('auth_user', None),
-        password=kwargs.get('auth_password', None),
-        fail_silently=kwargs.get('fail_silently', None),
-    )
-    multi_alt_kwargs = {
-        'connection': connection,
-        'headers': {
-            'Auto-Submitted': 'auto-generated',
-        }
-    }
-    mail = EmailMultiAlternatives(subject, message, from_email, recipient_list, **multi_alt_kwargs)
-    html_message = kwargs.get('html_message', None)
-    if html_message:
-        mail.attach_alternative(html_message, 'text/html')
-
-    return mail.send()
-
-
-def send_notification(page_revision_id, notification, excluded_user_id):
-    # Get revision
-    revision = PageRevision.objects.get(id=page_revision_id)
-
-    # Get list of recipients
-    if notification == 'submitted':
-        # Get list of publishers
-        include_superusers = getattr(settings, 'WAGTAILADMIN_NOTIFICATION_INCLUDE_SUPERUSERS', True)
-        recipients = users_with_page_permission(revision.page, 'publish', include_superusers)
-    elif notification in ['rejected', 'approved']:
-        # Get submitter
-        recipients = [revision.user]
-    else:
-        return False
-
-    # Get list of email addresses
-    email_recipients = [
-        recipient for recipient in recipients
-        if recipient.email and recipient.pk != excluded_user_id and getattr(
-            UserProfile.get_for_user(recipient),
-            notification + '_notifications'
-        )
-    ]
-
-    # Return if there are no email addresses
-    if not email_recipients:
-        return True
-
-    # Get template
-    template_subject = 'wagtailadmin/notifications/' + notification + '_subject.txt'
-    template_text = 'wagtailadmin/notifications/' + notification + '.txt'
-    template_html = 'wagtailadmin/notifications/' + notification + '.html'
-
-    # Common context to template
-    context = {
-        "revision": revision,
-        "settings": settings,
-    }
-
-    # Send emails
-    sent_count = 0
-    for recipient in email_recipients:
-        try:
-            # update context with this recipient
-            context["user"] = recipient
-
-            # Translate text to the recipient language settings
-            with override(recipient.wagtail_userprofile.get_preferred_language()):
-                # Get email subject and content
-                email_subject = render_to_string(template_subject, context).strip()
-                email_content = render_to_string(template_text, context).strip()
-
-            kwargs = {}
-            if getattr(settings, 'WAGTAILADMIN_NOTIFICATION_USE_HTML', False):
-                kwargs['html_message'] = render_to_string(template_html, context)
-
-            # Send email
-            send_mail(email_subject, email_content, [recipient.email], **kwargs)
-            sent_count += 1
-        except Exception:
-            logger.exception(
-                "Failed to send notification email '%s' to %s",
-                email_subject, recipient.email
-            )
-
-    return sent_count == len(email_recipients)
 
 
 def get_site_for_user(user):
@@ -149,6 +38,9 @@ MOVED_DEFINITIONS = {
     'any_permission_required': 'wagtail.admin.auth',
     'PermissionPolicyChecker': 'wagtail.admin.auth',
     'user_has_any_page_permission': 'wagtail.admin.auth',
+
+    'send_mail': 'wagtail.admin.mail',
+    'send_notification': 'wagtail.admin.mail',
 }
 
 sys.modules[__name__] = MovedDefinitionHandler(sys.modules[__name__], MOVED_DEFINITIONS, RemovedInWagtail29Warning)

--- a/wagtail/admin/views/generic.py
+++ b/wagtail/admin/views/generic.py
@@ -7,7 +7,7 @@ from django.views.generic.edit import BaseCreateView, BaseDeleteView, BaseUpdate
 from django.views.generic.list import BaseListView
 
 from wagtail.admin import messages
-from wagtail.admin.utils import permission_denied
+from wagtail.admin.auth import permission_denied
 
 
 class PermissionCheckedMixin:

--- a/wagtail/admin/views/home.py
+++ b/wagtail/admin/views/home.py
@@ -7,8 +7,8 @@ from django.http import Http404
 from django.shortcuts import render
 from django.template.loader import render_to_string
 
+from wagtail.admin.navigation import get_site_for_user
 from wagtail.admin.site_summary import SiteSummaryPanel
-from wagtail.admin.utils import get_site_for_user
 from wagtail.core import hooks
 from wagtail.core.models import Page, PageRevision, UserPagePermissionsProxy
 

--- a/wagtail/admin/views/pages.py
+++ b/wagtail/admin/views/pages.py
@@ -20,10 +20,11 @@ from django.views.generic import View
 
 from wagtail.admin import messages, signals
 from wagtail.admin.action_menu import PageActionMenu
+from wagtail.admin.auth import user_has_any_page_permission, user_passes_test
 from wagtail.admin.forms.pages import CopyForm
 from wagtail.admin.forms.search import SearchForm
+from wagtail.admin.mail import send_notification
 from wagtail.admin.navigation import get_explorable_root_page
-from wagtail.admin.utils import send_notification, user_has_any_page_permission, user_passes_test
 from wagtail.core import hooks
 from wagtail.core.models import Page, PageRevision, UserPagePermissionsProxy
 from wagtail.search.query import MATCH_ALL

--- a/wagtail/admin/wagtail_hooks.py
+++ b/wagtail/admin/wagtail_hooks.py
@@ -5,6 +5,8 @@ from django.utils.translation import ugettext
 from draftjs_exporter.dom import DOM
 
 import wagtail.admin.rich_text.editors.draftail.features as draftail_features
+from wagtail.admin.auth import user_has_any_page_permission
+from wagtail.admin.locale import get_available_admin_languages, get_available_admin_time_zones
 from wagtail.admin.menu import MenuItem, SubmenuMenuItem, settings_menu
 from wagtail.admin.navigation import get_explorable_root_page
 from wagtail.admin.rich_text import (
@@ -16,9 +18,6 @@ from wagtail.admin.rich_text.converters.html_to_contentstate import (
     BlockElementHandler, ExternalLinkElementHandler, HorizontalRuleHandler,
     InlineStyleElementHandler, ListElementHandler, ListItemElementHandler, PageLinkElementHandler)
 from wagtail.admin.search import SearchArea
-from wagtail.admin.utils import (
-    get_available_admin_languages, get_available_admin_time_zones,
-    user_has_any_page_permission)
 from wagtail.admin.views.account import password_management_enabled
 from wagtail.admin.viewsets import viewsets
 from wagtail.admin.widgets import Button, ButtonWithDropdownFromHook, PageListingButton

--- a/wagtail/contrib/forms/models.py
+++ b/wagtail/contrib/forms/models.py
@@ -9,7 +9,7 @@ from django.utils.translation import ugettext_lazy as _
 from unidecode import unidecode
 
 from wagtail.admin.edit_handlers import FieldPanel
-from wagtail.admin.utils import send_mail
+from wagtail.admin.mail import send_mail
 from wagtail.core.models import Orderable, Page
 
 from .forms import FormBuilder, WagtailAdminFormPageForm

--- a/wagtail/contrib/redirects/views.py
+++ b/wagtail/contrib/redirects/views.py
@@ -6,8 +6,8 @@ from django.utils.translation import ugettext as _
 from django.views.decorators.vary import vary_on_headers
 
 from wagtail.admin import messages
+from wagtail.admin.auth import PermissionPolicyChecker, permission_denied
 from wagtail.admin.forms.search import SearchForm
-from wagtail.admin.utils import PermissionPolicyChecker, permission_denied
 from wagtail.contrib.redirects import models
 from wagtail.contrib.redirects.forms import RedirectForm
 from wagtail.contrib.redirects.permissions import permission_policy

--- a/wagtail/contrib/search_promotions/views.py
+++ b/wagtail/contrib/search_promotions/views.py
@@ -5,8 +5,8 @@ from django.utils.translation import ugettext as _
 from django.views.decorators.vary import vary_on_headers
 
 from wagtail.admin import messages
+from wagtail.admin.auth import any_permission_required, permission_required
 from wagtail.admin.forms.search import SearchForm
-from wagtail.admin.utils import any_permission_required, permission_required
 from wagtail.contrib.search_promotions import forms
 from wagtail.search import forms as search_forms
 from wagtail.search.models import Query

--- a/wagtail/documents/models.py
+++ b/wagtail/documents/models.py
@@ -10,7 +10,7 @@ from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
 from taggit.managers import TaggableManager
 
-from wagtail.admin.utils import get_object_usage
+from wagtail.admin.models import get_object_usage
 from wagtail.core.models import CollectionMember
 from wagtail.search import index
 from wagtail.search.queryset import SearchableQuerySetMixin

--- a/wagtail/documents/views/chooser.py
+++ b/wagtail/documents/views/chooser.py
@@ -3,9 +3,9 @@ from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
 from django.utils.translation import ugettext as _
 
+from wagtail.admin.auth import PermissionPolicyChecker
 from wagtail.admin.forms.search import SearchForm
 from wagtail.admin.modal_workflow import render_modal_workflow
-from wagtail.admin.utils import PermissionPolicyChecker
 from wagtail.core import hooks
 from wagtail.core.models import Collection
 from wagtail.documents.forms import get_document_form

--- a/wagtail/documents/views/documents.py
+++ b/wagtail/documents/views/documents.py
@@ -7,8 +7,9 @@ from django.utils.translation import ugettext as _
 from django.views.decorators.vary import vary_on_headers
 
 from wagtail.admin import messages
+from wagtail.admin.auth import PermissionPolicyChecker, permission_denied
 from wagtail.admin.forms.search import SearchForm
-from wagtail.admin.utils import PermissionPolicyChecker, permission_denied, popular_tags_for_model
+from wagtail.admin.models import popular_tags_for_model
 from wagtail.core.models import Collection
 from wagtail.documents.forms import get_document_form
 from wagtail.documents.models import get_document_model

--- a/wagtail/documents/views/multiple.py
+++ b/wagtail/documents/views/multiple.py
@@ -6,7 +6,7 @@ from django.utils.encoding import force_text
 from django.views.decorators.http import require_POST
 from django.views.decorators.vary import vary_on_headers
 
-from wagtail.admin.utils import PermissionPolicyChecker
+from wagtail.admin.auth import PermissionPolicyChecker
 from wagtail.core.models import Collection
 from wagtail.search.backends import get_search_backends
 

--- a/wagtail/documents/wagtail_hooks.py
+++ b/wagtail/documents/wagtail_hooks.py
@@ -8,10 +8,10 @@ from django.utils.translation import ugettext, ungettext
 
 import wagtail.admin.rich_text.editors.draftail.features as draftail_features
 from wagtail.admin.menu import MenuItem
+from wagtail.admin.navigation import get_site_for_user
 from wagtail.admin.rich_text import HalloPlugin
 from wagtail.admin.search import SearchArea
 from wagtail.admin.site_summary import SummaryItem
-from wagtail.admin.utils import get_site_for_user
 from wagtail.core import hooks
 from wagtail.core.models import BaseViewRestriction
 from wagtail.core.wagtail_hooks import require_wagtail_login

--- a/wagtail/images/models.py
+++ b/wagtail/images/models.py
@@ -17,7 +17,7 @@ from taggit.managers import TaggableManager
 from unidecode import unidecode
 from willow.image import Image as WillowImage
 
-from wagtail.admin.utils import get_object_usage
+from wagtail.admin.models import get_object_usage
 from wagtail.core import hooks
 from wagtail.core.models import CollectionMember
 from wagtail.images.exceptions import InvalidFilterSpecError

--- a/wagtail/images/views/chooser.py
+++ b/wagtail/images/views/chooser.py
@@ -3,9 +3,10 @@ from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
 from django.utils.translation import ugettext as _
 
+from wagtail.admin.auth import PermissionPolicyChecker
 from wagtail.admin.forms.search import SearchForm
 from wagtail.admin.modal_workflow import render_modal_workflow
-from wagtail.admin.utils import PermissionPolicyChecker, popular_tags_for_model
+from wagtail.admin.models import popular_tags_for_model
 from wagtail.core import hooks
 from wagtail.core.models import Collection
 from wagtail.images import get_image_model

--- a/wagtail/images/views/images.py
+++ b/wagtail/images/views/images.py
@@ -9,8 +9,9 @@ from django.utils.translation import ugettext as _
 from django.views.decorators.vary import vary_on_headers
 
 from wagtail.admin import messages
+from wagtail.admin.auth import PermissionPolicyChecker, permission_denied
 from wagtail.admin.forms.search import SearchForm
-from wagtail.admin.utils import PermissionPolicyChecker, permission_denied, popular_tags_for_model
+from wagtail.admin.models import popular_tags_for_model
 from wagtail.core.models import Collection, Site
 from wagtail.images import get_image_model
 from wagtail.images.exceptions import InvalidFilterSpecError

--- a/wagtail/images/views/multiple.py
+++ b/wagtail/images/views/multiple.py
@@ -6,7 +6,7 @@ from django.utils.encoding import force_text
 from django.views.decorators.http import require_POST
 from django.views.decorators.vary import vary_on_headers
 
-from wagtail.admin.utils import PermissionPolicyChecker
+from wagtail.admin.auth import PermissionPolicyChecker
 from wagtail.core.models import Collection
 from wagtail.images import get_image_model
 from wagtail.images.fields import ALLOWED_EXTENSIONS

--- a/wagtail/images/wagtail_hooks.py
+++ b/wagtail/images/wagtail_hooks.py
@@ -6,10 +6,10 @@ from django.utils.translation import ugettext, ungettext
 
 import wagtail.admin.rich_text.editors.draftail.features as draftail_features
 from wagtail.admin.menu import MenuItem
+from wagtail.admin.navigation import get_site_for_user
 from wagtail.admin.rich_text import HalloPlugin
 from wagtail.admin.search import SearchArea
 from wagtail.admin.site_summary import SummaryItem
-from wagtail.admin.utils import get_site_for_user
 from wagtail.core import hooks
 from wagtail.images import admin_urls, get_image_model, image_operations
 from wagtail.images.api.admin.endpoints import ImagesAdminAPIEndpoint

--- a/wagtail/snippets/models.py
+++ b/wagtail/snippets/models.py
@@ -3,7 +3,7 @@ from django.core import checks
 from django.urls import reverse
 
 from wagtail.admin.checks import check_panels_in_model
-from wagtail.admin.utils import get_object_usage
+from wagtail.admin.models import get_object_usage
 
 SNIPPET_MODELS = []
 

--- a/wagtail/snippets/views/snippets.py
+++ b/wagtail/snippets/views/snippets.py
@@ -10,9 +10,9 @@ from django.utils.text import capfirst
 from django.utils.translation import ugettext as _
 
 from wagtail.admin import messages
+from wagtail.admin.auth import permission_denied
 from wagtail.admin.edit_handlers import ObjectList, extract_panel_definitions_from_model_class
 from wagtail.admin.forms.search import SearchForm
-from wagtail.admin.utils import permission_denied
 from wagtail.search.backends import get_search_backend
 from wagtail.search.index import class_is_indexed
 from wagtail.snippets.models import get_snippet_models

--- a/wagtail/tests/testapp/models.py
+++ b/wagtail/tests/testapp/models.py
@@ -22,7 +22,7 @@ from wagtail.admin.edit_handlers import (
     FieldPanel, InlinePanel, MultiFieldPanel, ObjectList, PageChooserPanel, StreamFieldPanel,
     TabbedInterface)
 from wagtail.admin.forms import WagtailAdminPageForm
-from wagtail.admin.utils import send_mail
+from wagtail.admin.mail import send_mail
 from wagtail.contrib.forms.forms import FormBuilder
 from wagtail.contrib.forms.models import (
     FORM_FIELD_CHOICES, AbstractEmailForm, AbstractFormField, AbstractFormSubmission)

--- a/wagtail/tests/testapp/views.py
+++ b/wagtail/tests/testapp/views.py
@@ -3,7 +3,7 @@ from django.shortcuts import redirect
 from django.template.response import TemplateResponse
 
 from wagtail.admin import messages
-from wagtail.admin.utils import user_passes_test
+from wagtail.admin.auth import user_passes_test
 from wagtail.contrib.forms.views import SubmissionsListView
 
 

--- a/wagtail/users/forms.py
+++ b/wagtail/users/forms.py
@@ -14,7 +14,7 @@ from django.template.loader import render_to_string
 from django.utils.html import mark_safe
 from django.utils.translation import ugettext_lazy as _
 
-from wagtail.admin.utils import get_available_admin_languages, get_available_admin_time_zones
+from wagtail.admin.locale import get_available_admin_languages, get_available_admin_time_zones
 from wagtail.admin.widgets import AdminPageChooser
 from wagtail.core import hooks
 from wagtail.core.models import (

--- a/wagtail/users/views/users.py
+++ b/wagtail/users/views/users.py
@@ -8,8 +8,8 @@ from django.utils.translation import ugettext as _
 from django.views.decorators.vary import vary_on_headers
 
 from wagtail.admin import messages
+from wagtail.admin.auth import any_permission_required, permission_denied, permission_required
 from wagtail.admin.forms.search import SearchForm
-from wagtail.admin.utils import any_permission_required, permission_denied, permission_required
 from wagtail.core import hooks
 from wagtail.core.compat import AUTH_USER_APP_LABEL, AUTH_USER_MODEL_NAME
 from wagtail.users.forms import UserCreationForm, UserEditForm

--- a/wagtail/utils/deprecation.py
+++ b/wagtail/utils/deprecation.py
@@ -49,7 +49,7 @@ class MovedDefinitionHandler(object):
 
             warnings.warn(
                 "%s has been moved from %s to %s" % (name, self.real_module.__name__, new_module_name),
-                category=self.warning_class
+                category=self.warning_class, stacklevel=2
             )
 
             # load the requested definition from the module named in moved_definitions

--- a/wagtail/utils/deprecation.py
+++ b/wagtail/utils/deprecation.py
@@ -1,3 +1,7 @@
+import warnings
+from importlib import import_module
+
+
 class RemovedInWagtail28Warning(DeprecationWarning):
     pass
 
@@ -7,3 +11,53 @@ removed_in_next_version_warning = RemovedInWagtail28Warning
 
 class RemovedInWagtail29Warning(PendingDeprecationWarning):
     pass
+
+
+class MovedDefinitionHandler(object):
+    """
+    A wrapper for module objects to enable definitions to be moved to a new module, with a
+    deprecation path for the old location. Importing the name from the old location will
+    raise a deprecation warning (but will still complete successfully).
+
+    To use, place the following code in the old module:
+
+    import sys
+    from wagtail.utils.deprecation import MovedDefinitionHandler, RemovedInWagtailXWarning
+
+    MOVED_DEFINITIONS = {
+        'SomeClassOrVariableName': 'path.to.new.module',
+    }
+
+    sys.modules[__name__] = MovedDefinitionHandler(sys.modules[__name__], MOVED_DEFINITIONS, RemovedInWagtailXWarning)
+    """
+    def __init__(self, real_module, moved_definitions, warning_class):
+        self.real_module = real_module
+        self.moved_definitions = moved_definitions
+        self.warning_class = warning_class
+
+    def __getattr__(self, name):
+        try:
+            return getattr(self.real_module, name)
+        except AttributeError as e:
+            try:
+                # is the missing name one of our moved definitions?
+                new_module_name = self.moved_definitions[name]
+            except KeyError:
+                # raise the original AttributeError without including the inner try/catch
+                # in the stack trace
+                raise e from None
+
+            warnings.warn(
+                "%s has been moved from %s to %s" % (name, self.real_module.__name__, new_module_name),
+                category=self.warning_class
+            )
+
+            # load the requested definition from the module named in moved_definitions
+            new_module = import_module(new_module_name)
+            definition = getattr(new_module, name)
+
+            # stash that definition into the current module so that we don't have to
+            # redo this import next time we access it
+            setattr(self.real_module, name, definition)
+
+            return definition

--- a/wagtail/utils/deprecation.py
+++ b/wagtail/utils/deprecation.py
@@ -47,17 +47,17 @@ class MovedDefinitionHandler(object):
                 # in the stack trace
                 raise e from None
 
-            warnings.warn(
-                "%s has been moved from %s to %s" % (name, self.real_module.__name__, new_module_name),
-                category=self.warning_class, stacklevel=2
-            )
+        warnings.warn(
+            "%s has been moved from %s to %s" % (name, self.real_module.__name__, new_module_name),
+            category=self.warning_class, stacklevel=2
+        )
 
-            # load the requested definition from the module named in moved_definitions
-            new_module = import_module(new_module_name)
-            definition = getattr(new_module, name)
+        # load the requested definition from the module named in moved_definitions
+        new_module = import_module(new_module_name)
+        definition = getattr(new_module, name)
 
-            # stash that definition into the current module so that we don't have to
-            # redo this import next time we access it
-            setattr(self.real_module, name, definition)
+        # stash that definition into the current module so that we don't have to
+        # redo this import next time we access it
+        setattr(self.real_module, name, definition)
 
-            return definition
+        return definition


### PR DESCRIPTION
Fixes #5507.

@chosak Assigning you for review, as you previously did the honours for wagtail.admin.forms in #4777 and the only 'clever' bit of code here is essentially the same :-)

(Memo to self: update https://github.com/wagtail/wagtail/wiki/Managing-Wagtail-translations#fetching-new-translations-from-transifex to point to wagtail/admin/locale.py once this is merged)