### PR TITLE
fix(docs/customization): Add django.db.models import in the example

### DIFF
--- a/docs/advanced_topics/customisation/page_editing_interface.rst
+++ b/docs/advanced_topics/customisation/page_editing_interface.rst
@@ -159,6 +159,7 @@ or to add custom validation logic for your models:
 .. code-block:: python
 
     from django import forms
+    from django.db import models
     import geocoder  # not in Wagtail, for example only - http://geocoder.readthedocs.io/
     from wagtail.admin.edit_handlers import FieldPanel
     from wagtail.admin.forms import WagtailAdminPageForm


### PR DESCRIPTION
This is a minor doc fix in one of the examples where fields from `django.db.models` are used but it is not imported in the first place.

The proposed change fixes this.