### PR TITLE
Adds `ModelAdmin.prepopulated_fields` feature  from django.admin

### DIFF
--- a/wagtail/contrib/modeladmin/options.py
+++ b/wagtail/contrib/modeladmin/options.py
@@ -289,7 +289,7 @@ class ModelAdmin(WagtailRegisterable):
         """
         Returns a sequence specifying custom prepopulated fields slugs on Create/Edit pages.
         """
-        return self.prepopulated_fields or {}    
+        return self.prepopulated_fields or {}
 
     def get_form_fields_exclude(self, request):
         """

--- a/wagtail/contrib/modeladmin/options.py
+++ b/wagtail/contrib/modeladmin/options.py
@@ -84,6 +84,7 @@ class ModelAdmin(WagtailRegisterable):
     search_fields = None
     ordering = None
     parent = None
+    prepopulated_fields = {}
     index_view_class = IndexView
     create_view_class = CreateView
     edit_view_class = EditView
@@ -283,6 +284,12 @@ class ModelAdmin(WagtailRegisterable):
         Must always return a dictionary.
         """
         return {}
+
+    def get_prepopulated_fields(self, request):
+        """
+        Returns a sequence specifying custom prepopulated fields slugs on Create/Edit pages.
+        """
+        return self.prepopulated_fields or {}    
 
     def get_form_fields_exclude(self, request):
         """

--- a/wagtail/contrib/modeladmin/static_src/wagtailmodeladmin/js/prepopulate.js
+++ b/wagtail/contrib/modeladmin/static_src/wagtailmodeladmin/js/prepopulate.js
@@ -1,0 +1,55 @@
+/*global URLify*/
+(function($) {
+    'use strict';
+    $.fn.prepopulate = function(dependencies, maxLength, allowUnicode) {
+        /*
+            Depends on urlify.js
+            Populates a selected field with the values of the dependent fields,
+            URLifies and shortens the string.
+            dependencies - array of dependent fields ids
+            maxLength - maximum length of the URLify'd string
+            allowUnicode - Unicode support of the URLify'd string
+        */
+        return this.each(function() {
+            var prepopulatedField = $(this);
+
+            var populate = function() {
+                // Bail if the field's value has been changed by the user
+                if (prepopulatedField.data('_changed')) {
+                    return;
+                }
+
+                var values = [];
+                $.each(dependencies, function(i, field) {
+                    field = $(field);
+                    if (field.val().length > 0) {
+                        values.push(field.val());
+                    }
+                });
+                prepopulatedField.val(URLify(values.join(' '), maxLength, allowUnicode));
+            };
+
+            prepopulatedField.data('_changed', false);
+            prepopulatedField.on('change', function() {
+                prepopulatedField.data('_changed', true);
+            });
+
+            if (!prepopulatedField.val()) {
+                $(dependencies.join(',')).on('keyup change focus', populate);
+            }
+        });
+    };
+})(jQuery);
+
+(function ($) {
+    'use strict';
+    $(function () {
+        var fields = $('#modeladmin-prepopulated-fields-constants').data('prepopulatedFields');
+        $.each(fields, function (index, field) {
+            $('.empty-form .form-row .field-' + field.name + ', .empty-form.form-row .field-' + field.name).addClass('prepopulated_field');
+            $(field.id).data('dependency_list', field.dependency_list).prepopulate(
+                field.dependency_ids, field.maxLength, field.allowUnicode
+            );
+        });
+    });
+})(jQuery);

--- a/wagtail/contrib/modeladmin/templates/modeladmin/create.html
+++ b/wagtail/contrib/modeladmin/templates/modeladmin/create.html
@@ -1,5 +1,5 @@
 {% extends "wagtailadmin/base.html" %}
-{% load i18n %}
+{% load i18n modeladmin_tags %}
 
 {% block titletag %}{{ view.get_meta_title }}{% endblock %}
 
@@ -16,6 +16,7 @@
     {{ edit_handler.html_declarations }}
 
     {{ view.media.js }}
+    {% prepopulated_slugs %}
 {% endblock %}
 
 {% block content %}

--- a/wagtail/contrib/modeladmin/templates/modeladmin/prepopulated_slugs.html
+++ b/wagtail/contrib/modeladmin/templates/modeladmin/prepopulated_slugs.html
@@ -1,0 +1,6 @@
+{% load l10n static %}
+<script type="text/javascript"
+        id="modeladmin-prepopulated-fields-constants"
+        src="{% static "wagtailmodeladmin/js/prepopulate.js" %}"
+        data-prepopulated-fields="{{ prepopulated_fields_json }}">
+</script>

--- a/wagtail/contrib/modeladmin/views.py
+++ b/wagtail/contrib/modeladmin/views.py
@@ -140,12 +140,17 @@ class ModelFormView(WMABaseView, FormView):
         instance = self.get_instance()
         edit_handler = self.get_edit_handler()
         form = self.get_form()
+        prepopulated_fields = [
+            {'field': form[field_name], 'dependencies': [form[f] for f in dependencies]}
+            for field_name, dependencies in self.model_admin.prepopulated_fields.items()
+        ]
         edit_handler = edit_handler.bind_to(
             instance=instance, request=self.request, form=form)
         context = {
             'is_multipart': form.is_multipart(),
             'edit_handler': edit_handler,
             'form': form,
+            'prepopulated_fields': prepopulated_fields,
         }
         context.update(kwargs)
         return super().get_context_data(**context)


### PR DESCRIPTION
This PR brings auto slug functionality from `django.contrib.admin` described [here](https://docs.djangoproject.com/en/2.2/ref/contrib/admin/#django.contrib.admin.ModelAdmin.prepopulated_fields) into Wagtail modeladmin.

It works fine with modeladmin integrations, however I havent tested it with inlines (not sure inlines are supported within modeladmin). It obviosly won't work for snippets, but thats expected.

I'm sorry for lack of documentation and tests and I hope someone will help me the following:

* Do the tests still pass? (http://docs.wagtail.io/en/latest/contributing/developing.html#testing)
* Does the code comply with the style guide? (Run `make lint` from the Wagtail root)
* For Python changes: Have you added tests to cover the new/fixed behaviour?
* For front-end changes: Did you test on all of Wagtail’s supported browsers? **Please list the exact versions you tested**.make 
* For new features: Has the documentation been updated accordingly?
