### PR TITLE
Add cache-busting parameter to admin static files

### DIFF
--- a/docs/advanced_topics/settings.rst
+++ b/docs/advanced_topics/settings.rst
@@ -510,6 +510,14 @@ can only choose between front office languages:
     LANGUAGES = WAGTAILADMIN_PERMITTED_LANGUAGES = [('en', 'English'),
                                                     ('pt', 'Portuguese')]
 
+Static files
+------------
+
+.. code-block:: python
+
+    WAGTAILADMIN_STATIC_FILE_VERSION_STRINGS = False
+
+Static file URLs within the Wagtail admin are given a version-specific query string of the form ``?v=1a2b3c4d``, to prevent outdated cached copies of Javascript and CSS files from persisting after a Wagtail upgrade. To disable these, set ``WAGTAILADMIN_STATIC_FILE_VERSION_STRINGS`` to ``False``.
 
 API Settings
 ------------

--- a/docs/releases/2.7.rst
+++ b/docs/releases/2.7.rst
@@ -53,6 +53,12 @@ Bug fixes
 Upgrade considerations
 ======================
 
+Query strings added to static file URLs within the admin
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To avoid problems caused by outdated cached JavaScript / CSS files following a Wagtail upgrade, URLs to static files within the Wagtail admin now include a version-specific query parameter of the form ``?v=1a2b3c4d``. Under certain front-end cache configurations (such as `Cloudflare's 'No Query String' caching level <https://support.cloudflare.com/hc/en-us/articles/200168256-What-are-Cloudflare-s-caching-levels->`_), the presence of this parameter may prevent the file from being cached at all. If you are using such a setup, and have some other method in place to expire outdated files (e.g. clearing the cache on deployment), you can disable the query parameter by setting ``WAGTAILADMIN_STATIC_FILE_VERSION_STRINGS`` to False in your project settings. (Note that this is automatically disabled when ``ManifestStaticFilesStorage`` is in use.)
+
+
 ``Page.dummy_request`` is deprecated
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/wagtail/admin/rich_text/editors/draftail/__init__.py
+++ b/wagtail/admin/rich_text/editors/draftail/__init__.py
@@ -4,6 +4,7 @@ from django.forms import Media, widgets
 
 from wagtail.admin.edit_handlers import RichTextFieldPanel
 from wagtail.admin.rich_text.converters.contentstate import ContentstateConverter
+from wagtail.admin.staticfiles import versioned_static
 from wagtail.core.rich_text import features as feature_registry
 
 
@@ -23,9 +24,9 @@ class DraftailRichTextArea(widgets.HiddenInput):
         self.options = {}
 
         self._media = Media(js=[
-            'wagtailadmin/js/draftail.js',
+            versioned_static('wagtailadmin/js/draftail.js'),
         ], css={
-            'all': ['wagtailadmin/css/panels/draftail.css']
+            'all': [versioned_static('wagtailadmin/css/panels/draftail.css')]
         })
 
         self.features = kwargs.pop('features', None)

--- a/wagtail/admin/rich_text/editors/hallo.py
+++ b/wagtail/admin/rich_text/editors/hallo.py
@@ -5,6 +5,7 @@ from django.forms import Media, widgets
 
 from wagtail.admin.edit_handlers import RichTextFieldPanel
 from wagtail.admin.rich_text.converters.editor_html import EditorHTMLConverter
+from wagtail.admin.staticfiles import versioned_static
 from wagtail.core.rich_text import features
 
 
@@ -71,7 +72,7 @@ class HalloListPlugin(HalloPlugin):
 CORE_HALLO_PLUGINS = [
     HalloPlugin(name='halloreundo', order=50),
     HalloPlugin(name='hallorequireparagraphs', js=[
-        'wagtailadmin/js/hallo-plugins/hallo-requireparagraphs.js',
+        versioned_static('wagtailadmin/js/hallo-plugins/hallo-requireparagraphs.js'),
     ]),
     HalloHeadingPlugin(element='p')
 ]
@@ -138,10 +139,10 @@ class HalloRichTextArea(widgets.Textarea):
     @property
     def media(self):
         media = Media(js=[
-            'wagtailadmin/js/vendor/hallo.js',
-            'wagtailadmin/js/hallo-bootstrap.js',
+            versioned_static('wagtailadmin/js/vendor/hallo.js'),
+            versioned_static('wagtailadmin/js/hallo-bootstrap.js'),
         ], css={
-            'all': ['wagtailadmin/css/panels/hallo.css']
+            'all': [versioned_static('wagtailadmin/css/panels/hallo.css')]
         })
 
         for plugin in self.plugins:

--- a/wagtail/admin/staticfiles.py
+++ b/wagtail/admin/staticfiles.py
@@ -1,12 +1,34 @@
 import hashlib
 
 from django.conf import settings
+from django.contrib.staticfiles.storage import HashedFilesMixin
+from django.core.files.storage import get_storage_class
 from django.templatetags.static import static
 
 from wagtail import __version__
 
 
-if getattr(settings, 'WAGTAILADMIN_STATIC_FILE_VERSION_STRINGS', True):
+# Check whether we should add cache-busting '?v=...' parameters to static file URLs
+try:
+    # If a preference has been explicitly stated in the WAGTAILADMIN_STATIC_FILE_VERSION_STRINGS
+    # setting, use that
+    use_version_strings = settings.WAGTAILADMIN_STATIC_FILE_VERSION_STRINGS
+except AttributeError:
+    # If WAGTAILADMIN_STATIC_FILE_VERSION_STRINGS not specified, default to version strings
+    # enabled, UNLESS we're using a storage backend with hashed filenames; in this case having
+    # a query parameter is redundant, and in some configurations (e.g. Cloudflare with the
+    # "No Query String" setting) it could break a previously-working cache setup
+
+    if settings.DEBUG:
+        # Hashed filenames are disabled in debug mode, so keep the querystring
+        use_version_strings = True
+    else:
+        # see if we're using a storage backend using hashed filenames
+        storage = get_storage_class(settings.STATICFILES_STORAGE)
+        use_version_strings = not issubclass(storage, HashedFilesMixin)
+
+
+if use_version_strings:
     VERSION_HASH = hashlib.sha1(
         (__version__ + settings.SECRET_KEY).encode('utf-8')
     ).hexdigest()[:8]

--- a/wagtail/admin/staticfiles.py
+++ b/wagtail/admin/staticfiles.py
@@ -1,0 +1,29 @@
+import hashlib
+
+from django.conf import settings
+from django.templatetags.static import static
+
+from wagtail import __version__
+
+
+if getattr(settings, 'WAGTAILADMIN_STATIC_FILE_VERSION_STRINGS', True):
+    VERSION_HASH = hashlib.sha1(
+        (__version__ + settings.SECRET_KEY).encode('utf-8')
+    ).hexdigest()[:8]
+else:
+    VERSION_HASH = None
+
+
+def versioned_static(path):
+    """
+    Wrapper for Django's static file finder to append a cache-busting query parameter
+    that updates on each Wagtail version
+    """
+    base_url = static(path)
+
+    # if URL already contains a querystring, don't add our own, to avoid interfering
+    # with existing mechanisms
+    if VERSION_HASH is None or '?' in base_url:
+        return base_url
+    else:
+        return base_url + '?v=' + VERSION_HASH

--- a/wagtail/admin/templates/wagtailadmin/404.html
+++ b/wagtail/admin/templates/wagtailadmin/404.html
@@ -1,12 +1,12 @@
 {% extends "wagtailadmin/admin_base.html" %}
-{% load wagtailadmin_tags wagtailcore_tags static i18n %}
+{% load wagtailadmin_tags wagtailcore_tags i18n %}
 {% block titletag %}{% trans "Error 404: Page not found" %}{% endblock %}
 
 
 {% block extra_css %}
     {{ block.super }}
 
-    <link rel="stylesheet" href="{% static 'wagtailadmin/css/layouts/404.css' %}" />
+    <link rel="stylesheet" href="{% versioned_static 'wagtailadmin/css/layouts/404.css' %}" />
 {% endblock %}
 
 

--- a/wagtail/admin/templates/wagtailadmin/account/password_reset/complete.html
+++ b/wagtail/admin/templates/wagtailadmin/account/password_reset/complete.html
@@ -1,12 +1,12 @@
 {% extends "wagtailadmin/admin_base.html" %}
-{% load static i18n %}
+{% load wagtailadmin_tags i18n %}
 {% block titletag %}{% trans "Reset password" %}{% endblock %}
 {% block bodyclass %}login{% endblock %}
 
 {% block extra_css %}
     {{ block.super }}
 
-    <link rel="stylesheet" href="{% static 'wagtailadmin/css/layouts/login.css' %}" type="text/css" />
+    <link rel="stylesheet" href="{% versioned_static 'wagtailadmin/css/layouts/login.css' %}" type="text/css" />
 {% endblock %}
 
 {% block furniture %}

--- a/wagtail/admin/templates/wagtailadmin/account/password_reset/confirm.html
+++ b/wagtail/admin/templates/wagtailadmin/account/password_reset/confirm.html
@@ -1,5 +1,5 @@
 {% extends "wagtailadmin/admin_base.html" %}
-{% load static i18n %}
+{% load wagtailadmin_tags i18n %}
 {% block titletag %}
     {% if validlink %}
         {% trans "Set your new password" %}
@@ -12,7 +12,7 @@
 {% block extra_css %}
     {{ block.super }}
 
-    <link rel="stylesheet" href="{% static 'wagtailadmin/css/layouts/login.css' %}" type="text/css" />
+    <link rel="stylesheet" href="{% versioned_static 'wagtailadmin/css/layouts/login.css' %}" type="text/css" />
 {% endblock %}
 
 {% block furniture %}

--- a/wagtail/admin/templates/wagtailadmin/account/password_reset/done.html
+++ b/wagtail/admin/templates/wagtailadmin/account/password_reset/done.html
@@ -1,12 +1,12 @@
 {% extends "wagtailadmin/admin_base.html" %}
-{% load static i18n %}
+{% load wagtailadmin_tags i18n %}
 {% block titletag %}{% trans "Reset password" %}{% endblock %}
 {% block bodyclass %}login{% endblock %}
 
 {% block extra_css %}
     {{ block.super }}
 
-    <link rel="stylesheet" href="{% static 'wagtailadmin/css/layouts/login.css' %}" type="text/css" />
+    <link rel="stylesheet" href="{% versioned_static 'wagtailadmin/css/layouts/login.css' %}" type="text/css" />
 {% endblock %}
 
 {% block furniture %}

--- a/wagtail/admin/templates/wagtailadmin/account/password_reset/form.html
+++ b/wagtail/admin/templates/wagtailadmin/account/password_reset/form.html
@@ -1,12 +1,12 @@
 {% extends "wagtailadmin/admin_base.html" %}
-{% load static i18n %}
+{% load wagtailadmin_tags i18n %}
 {% block titletag %}{% trans "Reset password" %}{% endblock %}
 {% block bodyclass %}login{% endblock %}
 
 {% block extra_css %}
     {{ block.super }}
 
-    <link rel="stylesheet" href="{% static 'wagtailadmin/css/layouts/login.css' %}" type="text/css" />
+    <link rel="stylesheet" href="{% versioned_static 'wagtailadmin/css/layouts/login.css' %}" type="text/css" />
 {% endblock %}
 
 {% block furniture %}

--- a/wagtail/admin/templates/wagtailadmin/admin_base.html
+++ b/wagtail/admin/templates/wagtailadmin/admin_base.html
@@ -1,17 +1,17 @@
 {% extends "wagtailadmin/skeleton.html" %}
-{% load i18n static wagtailadmin_tags %}
+{% load i18n wagtailadmin_tags %}
 
 {% block css %}
-    <link rel="stylesheet" href="{% static 'wagtailadmin/css/vendor/jquery-ui/jquery-ui-1.10.3.verdant.css' %}" />
-    <link rel="stylesheet" href="{% static 'wagtailadmin/css/vendor/jquery.tagit.css' %}">
-    <link rel="stylesheet" href="{% static 'wagtailadmin/css/core.css' %}" type="text/css" />
+    <link rel="stylesheet" href="{% versioned_static 'wagtailadmin/css/vendor/jquery-ui/jquery-ui-1.10.3.verdant.css' %}" />
+    <link rel="stylesheet" href="{% versioned_static 'wagtailadmin/css/vendor/jquery.tagit.css' %}">
+    <link rel="stylesheet" href="{% versioned_static 'wagtailadmin/css/core.css' %}" type="text/css" />
     {% hook_output 'insert_global_admin_css' %}
 
     {% block extra_css %}{% endblock %}
 {% endblock %}
 
 {% block branding_favicon %}
-    <link rel="shortcut icon" href="{% static 'wagtailadmin/images/favicon.ico' %}" />
+    <link rel="shortcut icon" href="{% versioned_static 'wagtailadmin/images/favicon.ico' %}" />
 {% endblock %}
 
 {% block js %}
@@ -34,17 +34,17 @@
             };
         })(document, window);
     </script>
-    <script src="{% static 'wagtailadmin/js/vendor/jquery-3.2.1.min.js' %}"></script>
-    <script src="{% static 'wagtailadmin/js/vendor/jquery-ui-1.12.1.min.js' %}"></script>
-    <script src="{% static 'wagtailadmin/js/vendor/jquery.datetimepicker.js' %}"></script>
-    <script src="{% static 'wagtailadmin/js/vendor/jquery.autosize.js' %}"></script>
-    <script src="{% static 'wagtailadmin/js/vendor/bootstrap-transition.js' %}"></script>
-    <script src="{% static 'wagtailadmin/js/vendor/bootstrap-modal.js' %}"></script>
-    <script src="{% static 'wagtailadmin/js/vendor/bootstrap-tab.js' %}"></script>
-    <script src="{% static 'wagtailadmin/js/vendor/tag-it.js' %}"></script>
-    <script src="{% static 'wagtailadmin/js/core.js' %}"></script>
-    <script src="{% static 'wagtailadmin/js/vendor.js' %}"></script>
-    <script src="{% static 'wagtailadmin/js/wagtailadmin.js' %}"></script>
+    <script src="{% versioned_static 'wagtailadmin/js/vendor/jquery-3.2.1.min.js' %}"></script>
+    <script src="{% versioned_static 'wagtailadmin/js/vendor/jquery-ui-1.12.1.min.js' %}"></script>
+    <script src="{% versioned_static 'wagtailadmin/js/vendor/jquery.datetimepicker.js' %}"></script>
+    <script src="{% versioned_static 'wagtailadmin/js/vendor/jquery.autosize.js' %}"></script>
+    <script src="{% versioned_static 'wagtailadmin/js/vendor/bootstrap-transition.js' %}"></script>
+    <script src="{% versioned_static 'wagtailadmin/js/vendor/bootstrap-modal.js' %}"></script>
+    <script src="{% versioned_static 'wagtailadmin/js/vendor/bootstrap-tab.js' %}"></script>
+    <script src="{% versioned_static 'wagtailadmin/js/vendor/tag-it.js' %}"></script>
+    <script src="{% versioned_static 'wagtailadmin/js/core.js' %}"></script>
+    <script src="{% versioned_static 'wagtailadmin/js/vendor.js' %}"></script>
+    <script src="{% versioned_static 'wagtailadmin/js/wagtailadmin.js' %}"></script>
     {% hook_output 'insert_global_admin_js' %}
 
 

--- a/wagtail/admin/templates/wagtailadmin/base.html
+++ b/wagtail/admin/templates/wagtailadmin/base.html
@@ -1,5 +1,5 @@
 {% extends "wagtailadmin/admin_base.html" %}
-{% load wagtailadmin_tags wagtailcore_tags static i18n %}
+{% load wagtailadmin_tags wagtailcore_tags i18n %}
 
 {% block furniture %}
     <aside class="nav-wrapper" data-nav-primary>
@@ -8,7 +8,7 @@
                 {% block branding_logo %}
                     {# Mobile-only logo: #}
                     <div class="wagtail-logo-container__mobile u-hidden@sm">
-                        <img class="wagtail-logo wagtail-logo__full" src="{% static 'wagtailadmin/images/wagtail-logo.svg' %}" alt="Wagtail" width="80" />
+                        <img class="wagtail-logo wagtail-logo__full" src="{% versioned_static 'wagtailadmin/images/wagtail-logo.svg' %}" alt="Wagtail" width="80" />
                     </div>
 
                     {# Desktop logo (animated): #}

--- a/wagtail/admin/templates/wagtailadmin/collections/edit.html
+++ b/wagtail/admin/templates/wagtailadmin/collections/edit.html
@@ -1,5 +1,5 @@
 {% extends "wagtailadmin/generic/edit.html" %}
-{% load static %}
+{% load wagtailadmin_tags %}
 
 {% block before_form %}
     {% include "wagtailadmin/collections/_privacy_switch.html" with collection=object collection_perms=collection_perms only %}
@@ -7,6 +7,6 @@
 
 {% block extra_js %}
     {{ block.super }}
-    <script src="{% static 'wagtailadmin/js/modal-workflow.js' %}"></script>
-    <script src="{% static 'wagtailadmin/js/privacy-switch.js' %}"></script>
+    <script src="{% versioned_static 'wagtailadmin/js/modal-workflow.js' %}"></script>
+    <script src="{% versioned_static 'wagtailadmin/js/privacy-switch.js' %}"></script>
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/home.html
+++ b/wagtail/admin/templates/wagtailadmin/home.html
@@ -1,12 +1,12 @@
 {% extends "wagtailadmin/base.html" %}
-{% load wagtailadmin_tags static i18n %}
+{% load wagtailadmin_tags i18n %}
 {% block titletag %}{% trans "Dashboard" %}{% endblock %}
 {% block bodyclass %}homepage{% endblock %}
 
 {% block extra_css %}
     {{ block.super }}
 
-    <link rel="stylesheet" href="{% static 'wagtailadmin/css/layouts/home.css' %}" type="text/css" />
+    <link rel="stylesheet" href="{% versioned_static 'wagtailadmin/css/layouts/home.css' %}" type="text/css" />
 {% endblock %}
 
 {% block content %}

--- a/wagtail/admin/templates/wagtailadmin/login.html
+++ b/wagtail/admin/templates/wagtailadmin/login.html
@@ -1,12 +1,12 @@
 {% extends "wagtailadmin/admin_base.html" %}
-{% load static i18n %}
+{% load wagtailadmin_tags i18n %}
 {% block titletag %}{% trans "Sign in" %}{% endblock %}
 {% block bodyclass %}login{% endblock %}
 
 {% block extra_css %}
     {{ block.super }}
 
-    <link rel="stylesheet" href="{% static 'wagtailadmin/css/layouts/login.css' %}" type="text/css" />
+    <link rel="stylesheet" href="{% versioned_static 'wagtailadmin/css/layouts/login.css' %}" type="text/css" />
 {% endblock %}
 
 {% block furniture %}

--- a/wagtail/admin/templates/wagtailadmin/pages/_editor_css.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/_editor_css.html
@@ -1,9 +1,9 @@
-{% load wagtailadmin_tags static %}
+{% load wagtailadmin_tags %}
 
 {% comment %}
     CSS declarations to be included on the 'create page' and 'edit page' views
 {% endcomment %}
 
-<link rel="stylesheet" href="{% static 'wagtailadmin/css/layouts/page-editor.css' %}" />
+<link rel="stylesheet" href="{% versioned_static 'wagtailadmin/css/layouts/page-editor.css' %}" />
 
 {% hook_output 'insert_editor_css' %}

--- a/wagtail/admin/templates/wagtailadmin/pages/_editor_js.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/_editor_js.html
@@ -1,4 +1,4 @@
-{% load wagtailadmin_tags static %}
+{% load wagtailadmin_tags %}
 
 {% comment %}
     Javascript declarations to be included on the 'create page' and 'edit page' views
@@ -16,14 +16,14 @@
     window.unicodeSlugsEnabled = {% if unicode_slugs_enabled %}true{% else %}false{% endif %};
 </script>
 
-<script src="{% static 'wagtailadmin/js/vendor/rangy-core.js' %}"></script>
-<script src="{% static 'wagtailadmin/js/vendor/mousetrap.min.js' %}"></script>
-<script src="{% static 'wagtailadmin/js/expanding_formset.js' %}"></script>
-<script src="{% static 'wagtailadmin/js/modal-workflow.js' %}"></script>
-<script src="{% static 'wagtailadmin/js/page-editor.js' %}"></script>
-<script src="{% static 'wagtailadmin/js/vendor/xregexp.min.js' %}"></script>
-<script src="{% static 'wagtailadmin/js/vendor/urlify.js' %}"></script>
-<script src="{% static 'wagtailadmin/js/privacy-switch.js' %}"></script>
-<script src="{% static 'wagtailadmin/js/vendor/bootstrap-tooltip.js' %}"></script>
+<script src="{% versioned_static 'wagtailadmin/js/vendor/rangy-core.js' %}"></script>
+<script src="{% versioned_static 'wagtailadmin/js/vendor/mousetrap.min.js' %}"></script>
+<script src="{% versioned_static 'wagtailadmin/js/expanding_formset.js' %}"></script>
+<script src="{% versioned_static 'wagtailadmin/js/modal-workflow.js' %}"></script>
+<script src="{% versioned_static 'wagtailadmin/js/page-editor.js' %}"></script>
+<script src="{% versioned_static 'wagtailadmin/js/vendor/xregexp.min.js' %}"></script>
+<script src="{% versioned_static 'wagtailadmin/js/vendor/urlify.js' %}"></script>
+<script src="{% versioned_static 'wagtailadmin/js/privacy-switch.js' %}"></script>
+<script src="{% versioned_static 'wagtailadmin/js/vendor/bootstrap-tooltip.js' %}"></script>
 
 {% hook_output 'insert_editor_js' %}

--- a/wagtail/admin/templates/wagtailadmin/pages/index.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/index.html
@@ -1,5 +1,5 @@
 {% extends "wagtailadmin/base.html" %}
-{% load wagtailadmin_tags static i18n %}
+{% load wagtailadmin_tags i18n %}
 {% block titletag %}{% blocktrans with title=parent_page.get_admin_display_title %}Exploring {{ title }}{% endblocktrans %}{% endblock %}
 {% block bodyclass %}page-explorer {% if ordering == 'ord' %}reordering{% endif %}{% endblock %}
 
@@ -27,8 +27,8 @@
     {{ block.super }}
 
     {% comment %} modal-workflow is required by the view restrictions interface {% endcomment %}
-    <script src="{% static 'wagtailadmin/js/modal-workflow.js' %}"></script>
-    <script src="{% static 'wagtailadmin/js/privacy-switch.js' %}"></script>
+    <script src="{% versioned_static 'wagtailadmin/js/modal-workflow.js' %}"></script>
+    <script src="{% versioned_static 'wagtailadmin/js/privacy-switch.js' %}"></script>
 
     <script type="text/javascript">
         {% if ordering == 'ord' %}

--- a/wagtail/admin/templates/wagtailadmin/pages/revisions/compare.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/revisions/compare.html
@@ -1,5 +1,5 @@
 {% extends "wagtailadmin/base.html" %}
-{% load static i18n wagtailadmin_tags %}
+{% load i18n wagtailadmin_tags %}
 
 {% block titletag %}{% blocktrans with title=page.get_admin_display_title %}Comparing {{ title }}{% endblocktrans %}{% endblock %}
 
@@ -86,5 +86,5 @@
 
 {% block extra_css %}
     {{ block.super }}
-    <link rel="stylesheet" href="{% static 'wagtailadmin/css/layouts/compare-revisions.css' %}" type="text/css" />
+    <link rel="stylesheet" href="{% versioned_static 'wagtailadmin/css/layouts/compare-revisions.css' %}" type="text/css" />
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/shared/animated_logo.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/animated_logo.html
@@ -1,8 +1,8 @@
-{% load wagtailadmin_tags static %}
+{% load wagtailadmin_tags %}
 
 <div class="wagtail-logo-container__desktop u-hidden@xs">
-    <img class="wagtail-logo wagtail-logo__body" src="{% static 'wagtailadmin/images/logo-body.svg' %}" alt=""/>
-    <img class="wagtail-logo wagtail-logo__tail" src="{% static 'wagtailadmin/images/logo-tail.svg' %}" alt="" />
-    <img class="wagtail-logo wagtail-logo__eye--open" src="{% static 'wagtailadmin/images/logo-eyeopen.svg' %}" alt="" />
-    <img class="wagtail-logo wagtail-logo__eye--closed" src="{% static 'wagtailadmin/images/logo-eyeclosed.svg' %}" alt="" />
+    <img class="wagtail-logo wagtail-logo__body" src="{% versioned_static 'wagtailadmin/images/logo-body.svg' %}" alt=""/>
+    <img class="wagtail-logo wagtail-logo__tail" src="{% versioned_static 'wagtailadmin/images/logo-tail.svg' %}" alt="" />
+    <img class="wagtail-logo wagtail-logo__eye--open" src="{% versioned_static 'wagtailadmin/images/logo-eyeopen.svg' %}" alt="" />
+    <img class="wagtail-logo wagtail-logo__eye--closed" src="{% versioned_static 'wagtailadmin/images/logo-eyeclosed.svg' %}" alt="" />
 </div>

--- a/wagtail/admin/templates/wagtailadmin/skeleton.html
+++ b/wagtail/admin/templates/wagtailadmin/skeleton.html
@@ -1,5 +1,5 @@
 <!doctype html>
-{% load static i18n %}
+{% load wagtailadmin_tags i18n %}
 {% get_current_language as LANGUAGE_CODE %}
 {% get_current_language_bidi as LANGUAGE_BIDI %}
 <html class="no-js" lang="{{ LANGUAGE_CODE }}" dir="{% if LANGUAGE_BIDI %}rtl{% else %}ltr{% endif %}">
@@ -10,9 +10,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="robots" content="noindex" />
 
-    <script src="{% static 'wagtailadmin/js/vendor/modernizr-2.6.2.min.js' %}"></script>
+    <script src="{% versioned_static 'wagtailadmin/js/vendor/modernizr-2.6.2.min.js' %}"></script>
 
-    <link rel="stylesheet" href="{% static 'wagtailadmin/css/normalize.css' %}" />
+    <link rel="stylesheet" href="{% versioned_static 'wagtailadmin/css/normalize.css' %}" />
 
     {% block css %}{% endblock %}
 

--- a/wagtail/admin/templates/wagtailadmin/userbar/base.html
+++ b/wagtail/admin/templates/wagtailadmin/userbar/base.html
@@ -1,8 +1,8 @@
-{% load static i18n %}
+{% load wagtailadmin_tags i18n %}
 <!-- Wagtail user bar embed code -->
 <div class="wagtail-userbar-reset">
     <div class="wagtail-userbar wagtail-userbar--{{ position|default:'bottom-right' }}" data-wagtail-userbar>
-        <link rel="stylesheet" href="{% static 'wagtailadmin/css/userbar.css' %}" type="text/css" />
+        <link rel="stylesheet" href="{% versioned_static 'wagtailadmin/css/userbar.css' %}" type="text/css" />
         <div class="wagtail-userbar-nav">
             <div class="wagtail-icon wagtail-icon-wagtail wagtail-userbar-trigger" data-wagtail-userbar-trigger>
                 <span class="wagtail-userbar-help-text">{% trans 'Go to Wagtail admin interface' %}</span>
@@ -13,7 +13,7 @@
                 {% endfor %}
             </div>
         </div>
-        <script src="{% static 'wagtailadmin/js/userbar.js' %}"></script>
+        <script src="{% versioned_static 'wagtailadmin/js/userbar.js' %}"></script>
     </div>
 </div>
 <!-- end Wagtail user bar embed code -->

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -8,7 +8,6 @@ from django.contrib.humanize.templatetags.humanize import intcomma
 from django.contrib.messages.constants import DEFAULT_TAGS as MESSAGE_TAGS
 from django.template.defaultfilters import stringfilter
 from django.template.loader import render_to_string
-from django.templatetags.static import static
 from django.utils.html import format_html, format_html_join
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy as _
@@ -17,6 +16,7 @@ from wagtail.admin.locale import get_js_translation_strings
 from wagtail.admin.menu import admin_menu
 from wagtail.admin.navigation import get_explorable_root_page
 from wagtail.admin.search import admin_search_areas
+from wagtail.admin.staticfiles import versioned_static as versioned_static_func
 from wagtail.core import hooks
 from wagtail.core.models import (
     CollectionViewRestriction, Page, PageViewRestriction, UserPagePermissionsProxy)
@@ -474,9 +474,18 @@ def avatar_url(user, size=50):
         if gravatar_url is not None:
             return gravatar_url
 
-    return static('wagtailadmin/images/default-user-avatar.png')
+    return versioned_static_func('wagtailadmin/images/default-user-avatar.png')
 
 
 @register.simple_tag
 def js_translation_strings():
     return mark_safe(json.dumps(get_js_translation_strings()))
+
+
+@register.simple_tag
+def versioned_static(path):
+    """
+    Wrapper for Django's static file finder to append a cache-busting query parameter
+    that updates on each Wagtail version
+    """
+    return versioned_static_func(path)

--- a/wagtail/admin/tests/test_templatetags.py
+++ b/wagtail/admin/tests/test_templatetags.py
@@ -2,6 +2,7 @@ from django.contrib.auth import get_user_model
 from django.test import TestCase
 from django.test.utils import override_settings
 
+from wagtail.admin.staticfiles import versioned_static
 from wagtail.admin.templatetags.wagtailadmin_tags import avatar_url
 from wagtail.images.tests.utils import get_test_image_file
 from wagtail.users.models import UserProfile
@@ -42,3 +43,9 @@ class TestAvatarTemplateTag(TestCase):
 
         url = avatar_url(self.test_user)
         self.assertIn('custom-avatar', url)
+
+
+class TestVersionedStatic(TestCase):
+    def test_versioned_static(self):
+        result = versioned_static('wagtailadmin/js/core.js')
+        self.assertRegex(result, r'^/static/wagtailadmin/js/core.js\?v=(\w+)$')

--- a/wagtail/admin/wagtail_hooks.py
+++ b/wagtail/admin/wagtail_hooks.py
@@ -18,6 +18,7 @@ from wagtail.admin.rich_text.converters.html_to_contentstate import (
     BlockElementHandler, ExternalLinkElementHandler, HorizontalRuleHandler,
     InlineStyleElementHandler, ListElementHandler, ListItemElementHandler, PageLinkElementHandler)
 from wagtail.admin.search import SearchArea
+from wagtail.admin.staticfiles import versioned_static
 from wagtail.admin.views.account import password_management_enabled
 from wagtail.admin.viewsets import viewsets
 from wagtail.admin.widgets import Button, ButtonWithDropdownFromHook, PageListingButton
@@ -272,7 +273,7 @@ def register_core_features(features):
         'hallo', 'hr',
         HalloPlugin(
             name='hallohr',
-            js=['wagtailadmin/js/hallo-plugins/hallo-hr.js'],
+            js=[versioned_static('wagtailadmin/js/hallo-plugins/hallo-hr.js')],
             order=45,
         )
     )
@@ -285,8 +286,8 @@ def register_core_features(features):
         HalloPlugin(
             name='hallowagtaillink',
             js=[
-                'wagtailadmin/js/page-chooser-modal.js',
-                'wagtailadmin/js/hallo-plugins/hallo-wagtaillink.js',
+                versioned_static('wagtailadmin/js/page-chooser-modal.js'),
+                versioned_static('wagtailadmin/js/hallo-plugins/hallo-wagtaillink.js'),
             ],
         )
     )
@@ -534,7 +535,7 @@ def register_core_features(features):
                 'href': "^(http:|https:|undefined$)",
             }
         }, js=[
-            'wagtailadmin/js/page-chooser-modal.js',
+            versioned_static('wagtailadmin/js/page-chooser-modal.js'),
         ])
     )
     features.register_converter_rule('contentstate', 'link', {

--- a/wagtail/admin/widgets.py
+++ b/wagtail/admin/widgets.py
@@ -14,6 +14,7 @@ from django.utils.translation import ugettext_lazy as _
 from taggit.forms import TagWidget
 
 from wagtail.admin.datetimepicker import to_datetimepicker_format
+from wagtail.admin.staticfiles import versioned_static
 from wagtail.core import hooks
 from wagtail.core.models import Page
 from wagtail.utils.widgets import WidgetWithScript
@@ -59,7 +60,7 @@ class AdminDateInput(widgets.DateInput):
         return context
 
     class Media:
-        js = ['wagtailadmin/js/date-time-chooser.js']
+        js = [versioned_static('wagtailadmin/js/date-time-chooser.js')]
 
 
 class AdminTimeInput(widgets.TimeInput):
@@ -72,7 +73,7 @@ class AdminTimeInput(widgets.TimeInput):
         super().__init__(attrs=default_attrs, format=format)
 
     class Media:
-        js = ['wagtailadmin/js/date-time-chooser.js']
+        js = [versioned_static('wagtailadmin/js/date-time-chooser.js')]
 
 
 class AdminDateTimeInput(widgets.DateTimeInput):
@@ -100,7 +101,7 @@ class AdminDateTimeInput(widgets.DateTimeInput):
         return context
 
     class Media:
-        js = ['wagtailadmin/js/date-time-chooser.js']
+        js = [versioned_static('wagtailadmin/js/date-time-chooser.js')]
 
 
 class AdminTagWidget(TagWidget):
@@ -239,8 +240,8 @@ class AdminPageChooser(AdminChooser):
 
     class Media:
         js = [
-            'wagtailadmin/js/page-chooser-modal.js',
-            'wagtailadmin/js/page-chooser.js',
+            versioned_static('wagtailadmin/js/page-chooser-modal.js'),
+            versioned_static('wagtailadmin/js/page-chooser.js'),
         ]
 
 

--- a/wagtail/contrib/modeladmin/templates/modeladmin/choose_parent.html
+++ b/wagtail/contrib/modeladmin/templates/modeladmin/choose_parent.html
@@ -1,13 +1,13 @@
 {% extends "wagtailadmin/base.html" %}
-{% load i18n modeladmin_tags static %}
+{% load i18n modeladmin_tags wagtailadmin_tags %}
 
 {% block titletag %}{{ view.get_meta_title }}{% endblock %}
 
 {% block extra_css %}
     {% include "wagtailadmin/pages/_editor_css.html" %}
     {{ form.media.css }}
-    <link rel="stylesheet" href="{% static 'wagtailmodeladmin/css/choose_parent_page.css' %}" type="text/css"/>
-    <link rel="stylesheet" href="{% static 'wagtailmodeladmin/css/breadcrumbs_page.css' %}" type="text/css"/>
+    <link rel="stylesheet" href="{% versioned_static 'wagtailmodeladmin/css/choose_parent_page.css' %}" type="text/css"/>
+    <link rel="stylesheet" href="{% versioned_static 'wagtailmodeladmin/css/breadcrumbs_page.css' %}" type="text/css"/>
 {% endblock %}
 
 {% block extra_js %}

--- a/wagtail/contrib/modeladmin/templates/modeladmin/inspect.html
+++ b/wagtail/contrib/modeladmin/templates/modeladmin/inspect.html
@@ -1,11 +1,11 @@
 {% extends "wagtailadmin/base.html" %}
-{% load i18n static %}
+{% load i18n wagtailadmin_tags %}
 
 {% block titletag %}{{ view.get_meta_title }}{% endblock %}
 
 {% block extra_css %}
     {{ view.media.css }}
-    <link rel="stylesheet" href="{% static 'wagtailmodeladmin/css/breadcrumbs_page.css' %}" type="text/css"/>
+    <link rel="stylesheet" href="{% versioned_static 'wagtailmodeladmin/css/breadcrumbs_page.css' %}" type="text/css"/>
 {% endblock %}
 
 {% block extra_js %}

--- a/wagtail/contrib/search_promotions/templates/wagtailsearchpromotions/add.html
+++ b/wagtail/contrib/search_promotions/templates/wagtailsearchpromotions/add.html
@@ -1,5 +1,5 @@
 {% extends "wagtailadmin/base.html" %}
-{% load i18n static %}
+{% load i18n wagtailadmin_tags %}
 {% block titletag %}{% trans "Add search promotion" %}{% endblock %}
 {% block content %}
     {% trans "Add search pick" as add_str %}
@@ -39,7 +39,7 @@
 {% block extra_js %}
     {{ block.super }}
     {% include "wagtailadmin/pages/_editor_js.html" %}
-    <script src="{% static 'wagtailsearch/js/query-chooser-modal.js' %}"></script>
+    <script src="{% versioned_static 'wagtailsearch/js/query-chooser-modal.js' %}"></script>
     {{ form_media.js }}
 
     <script type="text/javascript">

--- a/wagtail/contrib/search_promotions/templates/wagtailsearchpromotions/edit.html
+++ b/wagtail/contrib/search_promotions/templates/wagtailsearchpromotions/edit.html
@@ -1,5 +1,5 @@
 {% extends "wagtailadmin/base.html" %}
-{% load i18n static %}
+{% load i18n wagtailadmin_tags %}
 {% block titletag %}{% blocktrans with query=query.query_string %}Editing {{ query }}{% endblocktrans %}{% endblock %}
 {% block content %}
     {% trans "Editing" as editing_str %}
@@ -31,7 +31,7 @@
 {% block extra_js %}
     {{ block.super }}
     {% include "wagtailadmin/pages/_editor_js.html" %}
-    <script src="{% static 'wagtailsearch/js/query-chooser-modal.js' %}"></script>
+    <script src="{% versioned_static 'wagtailsearch/js/query-chooser-modal.js' %}"></script>
     {{ form_media.js }}
 
     <script type="text/javascript">

--- a/wagtail/contrib/settings/forms.py
+++ b/wagtail/contrib/settings/forms.py
@@ -1,6 +1,7 @@
 from django import forms
 from django.urls import reverse
 
+from wagtail.admin.staticfiles import versioned_static
 from wagtail.core.models import Site
 
 
@@ -9,7 +10,7 @@ class SiteSwitchForm(forms.Form):
 
     class Media:
         js = [
-            'wagtailsettings/js/site-switcher.js',
+            versioned_static('wagtailsettings/js/site-switcher.js'),
         ]
 
     def __init__(self, current_site, model, **kwargs):

--- a/wagtail/contrib/styleguide/templates/wagtailstyleguide/base.html
+++ b/wagtail/contrib/styleguide/templates/wagtailstyleguide/base.html
@@ -1,10 +1,10 @@
 {% extends "wagtailadmin/base.html" %}
-{% load wagtailadmin_tags i18n static %}
+{% load wagtailadmin_tags i18n %}
 
 {% block extra_css %}
     {{ block.super }}
 
-    <link rel="stylesheet" href="{% static 'wagtailstyleguide/css/styleguide.css' %}" type="text/css" />
+    <link rel="stylesheet" href="{% versioned_static 'wagtailstyleguide/css/styleguide.css' %}" type="text/css" />
 
     {{ example_form.media.css }}
 {% endblock %}
@@ -755,12 +755,12 @@
             <p>Add the following <code>div</code> around any items you wish to display with a spinner overlay and fading out</p>
             <p>Remove the "loading" class to disable the effect</p>
             <div class="loading-mask loading" style="width:200px">
-                <img src="{% static 'wagtailadmin/images/wagtail-logo.svg' %}" width="200" alt="Wagtail" />
+                <img src="{% versioned_static 'wagtailadmin/images/wagtail-logo.svg' %}" width="200" alt="Wagtail" />
             </div>
 
             <h3>Image transparency</h3>
             <p>It can be useful to show users the transparent areas of images. Add a transparency checkerboard with the <code>.show-transparency</code> on the <code>img</code> tag thus:</p>
-            <img src="{% static 'wagtailadmin/images/wagtail-logo.svg' %}" width="200" class="show-transparency" alt="Wagtail" />
+            <img src="{% versioned_static 'wagtailadmin/images/wagtail-logo.svg' %}" width="200" class="show-transparency" alt="Wagtail" />
         </section>
 
         <section id="icons" class="icons">

--- a/wagtail/contrib/table_block/blocks.py
+++ b/wagtail/contrib/table_block/blocks.py
@@ -5,6 +5,7 @@ from django.template.loader import render_to_string
 from django.utils import translation
 from django.utils.functional import cached_property
 
+from wagtail.admin.staticfiles import versioned_static
 from wagtail.core.blocks import FieldBlock
 
 DEFAULT_TABLE_OPTIONS = {
@@ -120,8 +121,13 @@ class TableBlock(FieldBlock):
     @property
     def media(self):
         return forms.Media(
-            css={'all': ['table_block/css/vendor/handsontable-6.2.2.full.min.css']},
-            js=['table_block/js/vendor/handsontable-6.2.2.full.min.js', 'table_block/js/table.js']
+            css={'all': [
+                versioned_static('table_block/css/vendor/handsontable-6.2.2.full.min.css')
+            ]},
+            js=[
+                versioned_static('table_block/js/vendor/handsontable-6.2.2.full.min.js'),
+                versioned_static('table_block/js/table.js')
+            ]
         )
 
     def get_table_options(self, table_options=None):

--- a/wagtail/core/blocks/list_block.py
+++ b/wagtail/core/blocks/list_block.py
@@ -2,10 +2,10 @@ from django import forms
 from django.core.exceptions import ValidationError
 from django.forms.utils import ErrorList
 from django.template.loader import render_to_string
-from django.templatetags.static import static
 from django.utils.html import format_html, format_html_join
 from django.utils.safestring import mark_safe
 
+from wagtail.admin.staticfiles import versioned_static
 from wagtail.core.utils import escape_script
 
 from .base import Block
@@ -34,7 +34,10 @@ class ListBlock(Block):
 
     @property
     def media(self):
-        return forms.Media(js=[static('wagtailadmin/js/blocks/sequence.js'), static('wagtailadmin/js/blocks/list.js')])
+        return forms.Media(js=[
+            versioned_static('wagtailadmin/js/blocks/sequence.js'),
+            versioned_static('wagtailadmin/js/blocks/list.js')
+        ])
 
     def render_list_member(self, value, prefix, index, errors=None):
         """

--- a/wagtail/core/blocks/stream_block.py
+++ b/wagtail/core/blocks/stream_block.py
@@ -6,11 +6,11 @@ from django import forms
 from django.core.exceptions import NON_FIELD_ERRORS, ValidationError
 from django.forms.utils import ErrorList
 from django.template.loader import render_to_string
-from django.templatetags.static import static
 from django.utils.html import format_html_join
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext as _
 
+from wagtail.admin.staticfiles import versioned_static
 from wagtail.core.utils import escape_script
 
 from .base import Block, BoundBlock, DeclarativeSubBlocksMetaclass
@@ -93,7 +93,10 @@ class BaseStreamBlock(Block):
 
     @property
     def media(self):
-        return forms.Media(js=[static('wagtailadmin/js/blocks/sequence.js'), static('wagtailadmin/js/blocks/stream.js')])
+        return forms.Media(js=[
+            versioned_static('wagtailadmin/js/blocks/sequence.js'),
+            versioned_static('wagtailadmin/js/blocks/stream.js')
+        ])
 
     def js_initializer(self):
         # compile a list of info dictionaries, one for each available block type

--- a/wagtail/core/blocks/struct_block.py
+++ b/wagtail/core/blocks/struct_block.py
@@ -4,9 +4,10 @@ from django import forms
 from django.core.exceptions import ValidationError
 from django.forms.utils import ErrorList
 from django.template.loader import render_to_string
-from django.templatetags.static import static
 from django.utils.functional import cached_property
 from django.utils.html import format_html, format_html_join
+
+from wagtail.admin.staticfiles import versioned_static
 
 from .base import Block, DeclarativeSubBlocksMetaclass
 from .utils import js_dict
@@ -73,7 +74,7 @@ class BaseStructBlock(Block):
 
     @property
     def media(self):
-        return forms.Media(js=[static('wagtailadmin/js/blocks/struct.js')])
+        return forms.Media(js=[versioned_static('wagtailadmin/js/blocks/struct.js')])
 
     def get_form_context(self, value, prefix='', errors=None):
         if errors:

--- a/wagtail/documents/templates/wagtaildocs/multiple/add.html
+++ b/wagtail/documents/templates/wagtaildocs/multiple/add.html
@@ -1,12 +1,12 @@
 {% extends "wagtailadmin/base.html" %}
 {% load i18n %}
 {% load l10n %}
-{% load static %}
+{% load wagtailadmin_tags %}
 {% block titletag %}{% trans "Add multiple documents" %}{% endblock %}
 {% block extra_css %}
     {{ block.super }}
 
-    <link rel="stylesheet" href="{% static 'wagtaildocs/css/add-multiple.css' %}" type="text/css" />
+    <link rel="stylesheet" href="{% versioned_static 'wagtaildocs/css/add-multiple.css' %}" type="text/css" />
 {% endblock %}
 
 {% block content %}
@@ -68,13 +68,13 @@
     {{ block.super }}
 
     <!-- this exact order of plugins is vital -->
-    <script src="{% static 'wagtailadmin/js/vendor/jquery.iframe-transport.js' %}"></script>
-    <script src="{% static 'wagtailadmin/js/vendor/jquery.fileupload.js' %}"></script>
-    <script src="{% static 'wagtailadmin/js/vendor/jquery.fileupload-process.js' %}"></script>
-    <script src="{% static 'wagtailadmin/js/vendor/tag-it.js' %}"></script>
+    <script src="{% versioned_static 'wagtailadmin/js/vendor/jquery.iframe-transport.js' %}"></script>
+    <script src="{% versioned_static 'wagtailadmin/js/vendor/jquery.fileupload.js' %}"></script>
+    <script src="{% versioned_static 'wagtailadmin/js/vendor/jquery.fileupload-process.js' %}"></script>
+    <script src="{% versioned_static 'wagtailadmin/js/vendor/tag-it.js' %}"></script>
 
     <!-- Main script -->
-    <script src="{% static 'wagtaildocs/js/add-multiple.js' %}"></script>
+    <script src="{% versioned_static 'wagtaildocs/js/add-multiple.js' %}"></script>
 
     {% url 'wagtailadmin_tag_autocomplete' as autocomplete_url %}
     <script>

--- a/wagtail/documents/wagtail_hooks.py
+++ b/wagtail/documents/wagtail_hooks.py
@@ -12,6 +12,7 @@ from wagtail.admin.navigation import get_site_for_user
 from wagtail.admin.rich_text import HalloPlugin
 from wagtail.admin.search import SearchArea
 from wagtail.admin.site_summary import SummaryItem
+from wagtail.admin.staticfiles import versioned_static
 from wagtail.core import hooks
 from wagtail.core.models import BaseViewRestriction
 from wagtail.core.wagtail_hooks import require_wagtail_login
@@ -76,8 +77,8 @@ def register_document_feature(features):
         HalloPlugin(
             name='hallowagtaildoclink',
             js=[
-                'wagtaildocs/js/document-chooser-modal.js',
-                'wagtaildocs/js/hallo-plugins/hallo-wagtaildoclink.js',
+                versioned_static('wagtaildocs/js/document-chooser-modal.js'),
+                versioned_static('wagtaildocs/js/hallo-plugins/hallo-wagtaildoclink.js'),
             ],
         )
     )
@@ -86,7 +87,7 @@ def register_document_feature(features):
             'type': 'DOCUMENT',
             'icon': 'doc-full',
             'description': ugettext('Document'),
-        }, js=['wagtaildocs/js/document-chooser-modal.js'])
+        }, js=[versioned_static('wagtaildocs/js/document-chooser-modal.js')])
     )
 
     features.register_converter_rule(

--- a/wagtail/documents/widgets.py
+++ b/wagtail/documents/widgets.py
@@ -3,6 +3,7 @@ import json
 from django.template.loader import render_to_string
 from django.utils.translation import ugettext_lazy as _
 
+from wagtail.admin.staticfiles import versioned_static
 from wagtail.admin.widgets import AdminChooser
 from wagtail.documents.models import get_document_model
 
@@ -33,6 +34,6 @@ class AdminDocumentChooser(AdminChooser):
 
     class Media:
         js = [
-            'wagtaildocs/js/document-chooser-modal.js',
-            'wagtaildocs/js/document-chooser.js',
+            versioned_static('wagtaildocs/js/document-chooser-modal.js'),
+            versioned_static('wagtaildocs/js/document-chooser.js'),
         ]

--- a/wagtail/embeds/wagtail_hooks.py
+++ b/wagtail/embeds/wagtail_hooks.py
@@ -5,6 +5,7 @@ from django.utils.translation import ugettext as _
 
 import wagtail.admin.rich_text.editors.draftail.features as draftail_features
 from wagtail.admin.rich_text import HalloPlugin
+from wagtail.admin.staticfiles import versioned_static
 from wagtail.core import hooks
 from wagtail.embeds import urls
 from wagtail.embeds.rich_text import MediaEmbedHandler
@@ -42,8 +43,8 @@ def register_embed_feature(features):
         HalloPlugin(
             name='hallowagtailembeds',
             js=[
-                'wagtailembeds/js/embed-chooser-modal.js',
-                'wagtailembeds/js/hallo-plugins/hallo-wagtailembeds.js',
+                versioned_static('wagtailembeds/js/embed-chooser-modal.js'),
+                versioned_static('wagtailembeds/js/hallo-plugins/hallo-wagtailembeds.js'),
             ],
         )
     )
@@ -58,7 +59,7 @@ def register_embed_feature(features):
             'type': 'EMBED',
             'icon': 'media',
             'description': _('Embed'),
-        }, js=['wagtailembeds/js/embed-chooser-modal.js'])
+        }, js=[versioned_static('wagtailembeds/js/embed-chooser-modal.js')])
     )
 
     # define how to convert between contentstate's representation of embeds and

--- a/wagtail/images/templates/wagtailimages/images/edit.html
+++ b/wagtail/images/templates/wagtailimages/images/edit.html
@@ -1,5 +1,5 @@
 {% extends "wagtailadmin/base.html" %}
-{% load wagtailimages_tags wagtailadmin_tags static i18n l10n %}
+{% load wagtailimages_tags wagtailadmin_tags i18n l10n %}
 {% block titletag %}{% blocktrans with title=image.title %}Editing image {{ title }}{% endblocktrans %}{% endblock %}
 {% block extra_css %}
     {{ block.super }}
@@ -7,8 +7,8 @@
     {{ form.media.css }}
 
     <!-- Focal point chooser -->
-    <link rel="stylesheet" href="{% static 'wagtailimages/css/vendor/jquery.Jcrop.min.css' %}" type="text/css">
-    <link rel="stylesheet" href="{% static 'wagtailimages/css/focal-point-chooser.css' %}" type="text/css">
+    <link rel="stylesheet" href="{% versioned_static 'wagtailimages/css/vendor/jquery.Jcrop.min.css' %}" type="text/css">
+    <link rel="stylesheet" href="{% versioned_static 'wagtailimages/css/focal-point-chooser.css' %}" type="text/css">
 {% endblock %}
 
 {% block extra_js %}
@@ -26,9 +26,9 @@
     </script>
 
     <!-- Focal point chooser -->
-    <script src="{% static 'wagtailadmin/js/vendor/jquery.ba-throttle-debounce.min.js' %}"></script>
-    <script src="{% static 'wagtailimages/js/vendor/jquery.Jcrop.min.js' %}"></script>
-    <script src="{% static 'wagtailimages/js/focal-point-chooser.js' %}"></script>
+    <script src="{% versioned_static 'wagtailadmin/js/vendor/jquery.ba-throttle-debounce.min.js' %}"></script>
+    <script src="{% versioned_static 'wagtailimages/js/vendor/jquery.Jcrop.min.js' %}"></script>
+    <script src="{% versioned_static 'wagtailimages/js/focal-point-chooser.js' %}"></script>
 {% endblock %}
 
 {% block content %}

--- a/wagtail/images/templates/wagtailimages/images/url_generator.html
+++ b/wagtail/images/templates/wagtailimages/images/url_generator.html
@@ -1,5 +1,5 @@
 {% extends "wagtailadmin/base.html" %}
-{% load wagtailimages_tags static i18n %}
+{% load wagtailimages_tags wagtailadmin_tags i18n %}
 
 {% block titletag %}{% blocktrans with title=image.title %}Editing image {{ title }}{% endblocktrans %}{% endblock %}
 
@@ -37,6 +37,6 @@
 {% block extra_js %}
     {{ block.super }}
 
-    <script src="{% static 'wagtailadmin/js/vendor/jquery.ba-throttle-debounce.min.js' %}"></script>
-    <script src="{% static 'wagtailimages/js/image-url-generator.js' %}"></script>
+    <script src="{% versioned_static 'wagtailadmin/js/vendor/jquery.ba-throttle-debounce.min.js' %}"></script>
+    <script src="{% versioned_static 'wagtailimages/js/image-url-generator.js' %}"></script>
 {% endblock %}

--- a/wagtail/images/templates/wagtailimages/multiple/add.html
+++ b/wagtail/images/templates/wagtailimages/multiple/add.html
@@ -1,15 +1,14 @@
 {% extends "wagtailadmin/base.html" %}
 {% load i18n %}
 {% load l10n %}
-{% load static %}
-{% load wagtailimages_tags %}
+{% load wagtailadmin_tags wagtailimages_tags %}
 {% block titletag %}{% trans "Add multiple images" %}{% endblock %}
 {% block extra_css %}
     {{ block.super }}
 
     {{ form_media.css }}
 
-    <link rel="stylesheet" href="{% static 'wagtailimages/css/add-multiple.css' %}" type="text/css" />
+    <link rel="stylesheet" href="{% versioned_static 'wagtailimages/css/add-multiple.css' %}" type="text/css" />
 {% endblock %}
 
 {% block content %}
@@ -80,17 +79,17 @@
     {{ form_media.js }}
 
     <!-- this exact order of plugins is vital -->
-    <script src="{% static 'wagtailimages/js/vendor/load-image.min.js' %}"></script>
-    <script src="{% static 'wagtailimages/js/vendor/canvas-to-blob.min.js' %}"></script>
-    <script src="{% static 'wagtailadmin/js/vendor/jquery.iframe-transport.js' %}"></script>
-    <script src="{% static 'wagtailadmin/js/vendor/jquery.fileupload.js' %}"></script>
-    <script src="{% static 'wagtailadmin/js/vendor/jquery.fileupload-process.js' %}"></script>
-    <script src="{% static 'wagtailimages/js/vendor/jquery.fileupload-image.js' %}"></script>
-    <script src="{% static 'wagtailimages/js/vendor/jquery.fileupload-validate.js' %}"></script>
-    <script src="{% static 'wagtailadmin/js/vendor/tag-it.js' %}"></script>
+    <script src="{% versioned_static 'wagtailimages/js/vendor/load-image.min.js' %}"></script>
+    <script src="{% versioned_static 'wagtailimages/js/vendor/canvas-to-blob.min.js' %}"></script>
+    <script src="{% versioned_static 'wagtailadmin/js/vendor/jquery.iframe-transport.js' %}"></script>
+    <script src="{% versioned_static 'wagtailadmin/js/vendor/jquery.fileupload.js' %}"></script>
+    <script src="{% versioned_static 'wagtailadmin/js/vendor/jquery.fileupload-process.js' %}"></script>
+    <script src="{% versioned_static 'wagtailimages/js/vendor/jquery.fileupload-image.js' %}"></script>
+    <script src="{% versioned_static 'wagtailimages/js/vendor/jquery.fileupload-validate.js' %}"></script>
+    <script src="{% versioned_static 'wagtailadmin/js/vendor/tag-it.js' %}"></script>
 
     <!-- Main script -->
-    <script src="{% static 'wagtailimages/js/add-multiple.js' %}"></script>
+    <script src="{% versioned_static 'wagtailimages/js/add-multiple.js' %}"></script>
 
     {% url 'wagtailadmin_tag_autocomplete' as autocomplete_url %}
     <script>

--- a/wagtail/images/wagtail_hooks.py
+++ b/wagtail/images/wagtail_hooks.py
@@ -10,6 +10,7 @@ from wagtail.admin.navigation import get_site_for_user
 from wagtail.admin.rich_text import HalloPlugin
 from wagtail.admin.search import SearchArea
 from wagtail.admin.site_summary import SummaryItem
+from wagtail.admin.staticfiles import versioned_static
 from wagtail.core import hooks
 from wagtail.images import admin_urls, get_image_model, image_operations
 from wagtail.images.api.admin.endpoints import ImagesAdminAPIEndpoint
@@ -70,8 +71,8 @@ def register_image_feature(features):
         HalloPlugin(
             name='hallowagtailimage',
             js=[
-                'wagtailimages/js/image-chooser-modal.js',
-                'wagtailimages/js/hallo-plugins/hallo-wagtailimage.js',
+                versioned_static('wagtailimages/js/image-chooser-modal.js'),
+                versioned_static('wagtailimages/js/hallo-plugins/hallo-wagtailimage.js'),
             ],
         )
     )
@@ -94,7 +95,7 @@ def register_image_feature(features):
                 'id': True,
             }
         }, js=[
-            'wagtailimages/js/image-chooser-modal.js',
+            versioned_static('wagtailimages/js/image-chooser-modal.js'),
         ])
     )
 

--- a/wagtail/images/widgets.py
+++ b/wagtail/images/widgets.py
@@ -3,6 +3,7 @@ import json
 from django.template.loader import render_to_string
 from django.utils.translation import ugettext_lazy as _
 
+from wagtail.admin.staticfiles import versioned_static
 from wagtail.admin.widgets import AdminChooser
 from wagtail.images import get_image_model
 
@@ -33,6 +34,6 @@ class AdminImageChooser(AdminChooser):
 
     class Media:
         js = [
-            'wagtailimages/js/image-chooser-modal.js',
-            'wagtailimages/js/image-chooser.js',
+            versioned_static('wagtailimages/js/image-chooser-modal.js'),
+            versioned_static('wagtailimages/js/image-chooser.js'),
         ]

--- a/wagtail/snippets/templates/wagtailsnippets/snippets/type_index.html
+++ b/wagtail/snippets/templates/wagtailsnippets/snippets/type_index.html
@@ -1,5 +1,5 @@
 {% extends "wagtailadmin/base.html" %}
-{% load i18n static %}
+{% load i18n wagtailadmin_tags %}
 {% block titletag %}{% blocktrans with snippet_type_name_plural=model_opts.verbose_name_plural|capfirst %}Snippets {{ snippet_type_name_plural }}{% endblocktrans %}{% endblock %}
 
 {% block extra_js %}
@@ -12,7 +12,7 @@
         }
     </script>
     {% if can_delete_snippets %}
-        <script src="{% static 'wagtailsnippets/js/snippet-multiple-select.js' %}"></script>
+        <script src="{% versioned_static 'wagtailsnippets/js/snippet-multiple-select.js' %}"></script>
     {% endif %}
 {% endblock %}
 

--- a/wagtail/snippets/widgets.py
+++ b/wagtail/snippets/widgets.py
@@ -3,6 +3,7 @@ import json
 from django.template.loader import render_to_string
 from django.utils.translation import ugettext_lazy as _
 
+from wagtail.admin.staticfiles import versioned_static
 from wagtail.admin.widgets import AdminChooser
 
 
@@ -42,6 +43,6 @@ class AdminSnippetChooser(AdminChooser):
 
     class Media:
         js = [
-            'wagtailsnippets/js/snippet-chooser-modal.js',
-            'wagtailsnippets/js/snippet-chooser.js',
+            versioned_static('wagtailsnippets/js/snippet-chooser-modal.js'),
+            versioned_static('wagtailsnippets/js/snippet-chooser.js'),
         ]

--- a/wagtail/tests/context_processors.py
+++ b/wagtail/tests/context_processors.py
@@ -1,7 +1,7 @@
 
 def do_not_use_static_url(request):
     def exception():
-        raise Exception("Do not use STATIC_URL in templates. Use the {% static %} templatetag instead.")
+        raise Exception("Do not use STATIC_URL in templates. Use the {% static %} templatetag (or {% versioned_static %} within admin templates) instead.")
 
     return {
         'STATIC_URL': lambda: exception(),

--- a/wagtail/users/templates/wagtailusers/groups/create.html
+++ b/wagtail/users/templates/wagtailusers/groups/create.html
@@ -1,12 +1,12 @@
 {% extends "wagtailadmin/base.html" %}
-{% load wagtailusers_tags wagtailimages_tags static i18n %}
+{% load wagtailusers_tags wagtailimages_tags wagtailadmin_tags i18n %}
 
 {% block titletag %}{% trans "Add group" %}{% endblock %}
 
 {% block extra_css %}
     {{ block.super }}
 
-    <link rel="stylesheet" href="{% static 'wagtailusers/css/groups_edit.css' %}" type="text/css" />
+    <link rel="stylesheet" href="{% versioned_static 'wagtailusers/css/groups_edit.css' %}" type="text/css" />
     {{ form_media.css }}
 {% endblock %}
 

--- a/wagtail/users/templates/wagtailusers/groups/edit.html
+++ b/wagtail/users/templates/wagtailusers/groups/edit.html
@@ -1,12 +1,12 @@
 {% extends "wagtailadmin/base.html" %}
-{% load wagtailusers_tags static i18n %}
+{% load wagtailusers_tags wagtailadmin_tags i18n %}
 
 {% block titletag %}{% trans "Editing" %} {{ group.name }}{% endblock %}
 
 {% block extra_css %}
     {{ block.super }}
 
-    <link rel="stylesheet" href="{% static 'wagtailusers/css/groups_edit.css' %}" type="text/css" />
+    <link rel="stylesheet" href="{% versioned_static 'wagtailusers/css/groups_edit.css' %}" type="text/css" />
     {{ form_media.css }}
 {% endblock %}
 

--- a/wagtail/users/templates/wagtailusers/groups/includes/group_form_js.html
+++ b/wagtail/users/templates/wagtailusers/groups/includes/group_form_js.html
@@ -1,12 +1,12 @@
-{% load static %}
+{% load wagtailadmin_tags %}
 <script>
     window.chooserUrls = {
         'pageChooser': '{% url "wagtailadmin_choose_page" %}'
     };
 </script>
 
-<script src="{% static 'wagtailadmin/js/expanding_formset.js' %}"></script>
-<script src="{% static 'wagtailadmin/js/modal-workflow.js' %}"></script>
-<script src="{% static 'wagtailusers/js/group-form.js' %}"></script>
+<script src="{% versioned_static 'wagtailadmin/js/expanding_formset.js' %}"></script>
+<script src="{% versioned_static 'wagtailadmin/js/modal-workflow.js' %}"></script>
+<script src="{% versioned_static 'wagtailusers/js/group-form.js' %}"></script>
 
 {{ form_media.js }}


### PR DESCRIPTION
Fixes #5493

To be investigated:

* are there situations where the presence of a querystring disables caching entirely (and therefore this change would cause a performance hit)?
* would it be beneficial to disable this when `ManifestStaticFilesStorage` is active?