### PR TITLE
Force nodejs install to use nodesource

### DIFF
--- a/.squash.yml
+++ b/.squash.yml
@@ -1,9 +1,12 @@
 deployments:
   default:
-    dockerimage: python:3.7.4-stretch
+    dockerimage: python:latest
     build_steps:
       - apt-get update && apt-get install -y libssl-dev libpq-dev git build-essential libfontconfig1 libfontconfig1-dev curl
       - RUN bash -c "curl -sL https://deb.nodesource.com/setup_8.x | bash -"
+      - >-
+        (echo "Package: *" && echo "Pin: origin deb.nodesource.com" && echo "Pin-Priority: 600") >
+        /etc/apt/preferences.d/nodesource
       - apt install -y nodejs
       - pip install setuptools pip --upgrade --force-reinstall
       - cd /code


### PR DESCRIPTION
Admin assets on Squash PR deployments are currently broken due to a problem running npm. This is the same issue previously reported in #5441. See https://github.com/nodesource/distributions/issues/875 for the rationale behind this workaround; this ensures that nodejs is installed from nodesource instead of from the distro, which may have a newer version.

As part of this change I've restored the Docker image back to `python:latest`, figuring we might as well do that if we can as opposed to pinning.

Note that the somewhat ugly YAML syntax is needed due to issues including special characters like `*&>` in YAML.

I've tested this on my fork and it works correctly; hopefully this will work here too, in which case functionality can be tested by visiting the link that Squash posts below and confirming that the admin area properly includes static assets.