### PR TITLE
Update release schedule documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ We take the security of Wagtail, and related packages we maintain, seriously. If
 
 If you want to send an encrypted email (optional), the public key ID for security@wagtail.io is 0x6ba1e1a86e0f8ce8, and this public key is available from most commonly-used keyservers.
 
+### Release schedule
+
+Feature releases of Wagtail are released every three months. Selected releases are designated as Long Term Support (LTS) releases, and will receive maintenance updates for an extended period to address any security and data-loss related issues. For dates of past and upcoming releases and support periods, see [Release Schedule](https://github.com/wagtail/wagtail/wiki/Release-schedule).
+
 ### Contributing
 
 If you're a Python or Django developer, fork the repo and get stuck in! We run a separate group for developers of Wagtail itself at https://groups.google.com/forum/#!forum/wagtail-developers (please note that this is not for support requests).

--- a/docs/releases/upgrading.rst
+++ b/docs/releases/upgrading.rst
@@ -6,31 +6,15 @@ Upgrading Wagtail
 Version numbers
 ===============
 
-New feature releases of Wagtail are released approximately every two months. These releases provide new features, improvements and bugfixes, and are marked by incrementing the second part of the version number (for example, 1.11 to 1.12).
+New feature releases of Wagtail are released every three months. These releases provide new features, improvements and bugfixes, and are marked by incrementing the second part of the version number (for example, 2.6 to 2.7).
 
-Additionally, patch releases will be issued as needed, to fix bugs and security issues. These are marked by incrementing the third part of the version number (for example, 1.12 to 1.12.1). Wherever possible, these releases will remain fully backwards compatible with the corresponding feature and not introduce any breaking changes.
+Additionally, patch releases will be issued as needed, to fix bugs and security issues. These are marked by incrementing the third part of the version number (for example, 2.6 to 2.6.1). Wherever possible, these releases will remain fully backwards compatible with the corresponding feature and not introduce any breaking changes.
 
-A feature release will usually stop receiving patch release updates when the next feature release comes out. However, selected feature releases are designated as Long Term Support (LTS) releases, and will continue to receive maintenance updates to address any security and data-loss related issues that arise. Typically, a Long Term Support release will happen once every four feature releases and receive updates for five feature releases, giving a support period of ten months with a two months overlap.
+A feature release will usually stop receiving patch release updates when the next feature release comes out. However, selected feature releases are designated as Long Term Support (LTS) releases, and will continue to receive maintenance updates to address any security and data-loss related issues that arise. Typically, a Long Term Support release will happen once every four feature releases and receive updates for five feature releases, giving a support period of fifteen months with a three month overlap.
 
 Also, Long Term Support releases will ensure compatibility with at least one `Django Long Term Support release <https://www.djangoproject.com/download/#supported-versions>`_.
 
-Exceptionally, with 2.0 introducing breaking changes, 1.13 was designated as LTS in addition to 1.12. The support period for 1.13 will last until April 2019.
-
-+-------------------+------------------------------------------+
-| Wagtail release   | LTS support period                       |
-+===================+==========================================+
-| 0.8 LTS           | November 2014 - March 2016               |
-+-------------------+------------------------------------------+
-| 1.4 LTS           | March 2016 - December 2016               |
-+-------------------+------------------------------------------+
-| 1.8 LTS           | December 2016 - August 2017              |
-+-------------------+------------------------------------------+
-| 1.12 LTS          | August 2017 - November 2019              |
-+-------------------+------------------------------------------+
-| 1.13 LTS          | October 2017 - April 2019                |
-+-------------------+------------------------------------------+
-| 2.3 LTS           | October 2018 - June 2019 (expected)      |
-+-------------------+------------------------------------------+
+For dates of past and upcoming releases and support periods, see `Release Schedule <https://github.com/wagtail/wagtail/wiki/Release-schedule>`_.
 
 Deprecation policy
 ==================


### PR DESCRIPTION
Update release schedule information to reflect the new three-month release cycle, and move the date listing to the wiki where it can be kept up to date more effectively.