### PR TITLE
Fix compatibility with pylint-django

### DIFF
--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -246,7 +246,7 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
         help_text=_("The name of the page as it will appear in URLs e.g http://domain.com/blog/[my-slug]/")
     )
     content_type = models.ForeignKey(
-        'contenttypes.ContentType',
+        ContentType,
         verbose_name=_('content type'),
         related_name='pages',
         on_delete=models.SET(get_default_page_content_type)


### PR DESCRIPTION
It's not possible to use wagtail in a project with pylint and the
pylint-django plugin.

Pylint-django does not work with foreign keys that are referenced by
their string names. See: https://github.com/PyCQA/pylint-django#known-issues

If we simply replace the string name with the foreign-key class, linting
on wagtail projects is fixed.

Also see:
https://github.com/PyCQA/pylint/issues/2995
https://github.com/PyCQA/pylint-django/issues/241
