### PR TITLE
Replaced use of force_text with force_str.

### DIFF
--- a/wagtail/admin/compare.py
+++ b/wagtail/admin/compare.py
@@ -1,7 +1,7 @@
 import difflib
 
 from bs4 import BeautifulSoup
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.html import escape, format_html, format_html_join
 from django.utils.safestring import mark_safe
 from django.utils.text import capfirst
@@ -52,8 +52,8 @@ class TextFieldComparison(FieldComparison):
 class RichTextFieldComparison(TextFieldComparison):
     def htmldiff(self):
         return diff_text(
-            BeautifulSoup(force_text(self.val_a), 'html5lib').getText(),
-            BeautifulSoup(force_text(self.val_b), 'html5lib').getText()
+            BeautifulSoup(force_str(self.val_a), 'html5lib').getText(),
+            BeautifulSoup(force_str(self.val_b), 'html5lib').getText()
         ).to_html()
 
 
@@ -95,16 +95,16 @@ class BlockComparison:
 class CharBlockComparison(BlockComparison):
     def htmldiff(self):
         return diff_text(
-            force_text(self.val_a),
-            force_text(self.val_b)
+            force_str(self.val_a),
+            force_str(self.val_b)
         ).to_html()
 
 
 class RichTextBlockComparison(BlockComparison):
     def htmldiff(self):
         return diff_text(
-            BeautifulSoup(force_text(self.val_a), 'html5lib').getText(),
-            BeautifulSoup(force_text(self.val_b), 'html5lib').getText()
+            BeautifulSoup(force_str(self.val_a), 'html5lib').getText(),
+            BeautifulSoup(force_str(self.val_b), 'html5lib').getText()
         ).to_html()
 
 
@@ -219,15 +219,15 @@ class StreamFieldComparison(FieldComparison):
         else:
             # Fall back to diffing the HTML representation
             return diff_text(
-                BeautifulSoup(force_text(self.val_a), 'html5lib').getText(),
-                BeautifulSoup(force_text(self.val_b), 'html5lib').getText()
+                BeautifulSoup(force_str(self.val_a), 'html5lib').getText(),
+                BeautifulSoup(force_str(self.val_b), 'html5lib').getText()
             ).to_html()
 
 
 class ChoiceFieldComparison(FieldComparison):
     def htmldiff(self):
-        val_a = force_text(dict(self.field.flatchoices).get(self.val_a, self.val_a), strings_only=True)
-        val_b = force_text(dict(self.field.flatchoices).get(self.val_b, self.val_b), strings_only=True)
+        val_a = force_str(dict(self.field.flatchoices).get(self.val_a, self.val_a), strings_only=True)
+        val_b = force_str(dict(self.field.flatchoices).get(self.val_b, self.val_b), strings_only=True)
 
         if self.val_a != self.val_b:
             return TextDiff([('deletion', val_a), ('addition', val_b)]).to_html()
@@ -291,16 +291,16 @@ class ForeignObjectComparison(FieldComparison):
         if obj_a != obj_b:
             if obj_a and obj_b:
                 # Changed
-                return TextDiff([('deletion', force_text(obj_a)), ('addition', force_text(obj_b))]).to_html()
+                return TextDiff([('deletion', force_str(obj_a)), ('addition', force_str(obj_b))]).to_html()
             elif obj_b:
                 # Added
-                return TextDiff([('addition', force_text(obj_b))]).to_html()
+                return TextDiff([('addition', force_str(obj_b))]).to_html()
             elif obj_a:
                 # Removed
-                return TextDiff([('deletion', force_text(obj_a))]).to_html()
+                return TextDiff([('deletion', force_str(obj_a))]).to_html()
         else:
             if obj_a:
-                return escape(force_text(obj_a))
+                return escape(force_str(obj_a))
             else:
                 return mark_safe(_("None"))
 

--- a/wagtail/admin/tests/test_account_management.py
+++ b/wagtail/admin/tests/test_account_management.py
@@ -744,7 +744,7 @@ class TestPasswordReset(TestCase, WagtailTestUtils):
         self.assertEqual(len(mail.outbox), 0)
 
     def setup_password_reset_confirm_tests(self):
-        from django.utils.encoding import force_bytes, force_text
+        from django.utils.encoding import force_bytes, force_str
         from django.utils.http import urlsafe_base64_encode
 
         # Get user
@@ -754,7 +754,7 @@ class TestPasswordReset(TestCase, WagtailTestUtils):
         self.password_reset_token = PasswordResetTokenGenerator().make_token(self.user)
 
         # Generate a password reset uid
-        self.password_reset_uid = force_text(urlsafe_base64_encode(force_bytes(self.user.pk)))
+        self.password_reset_uid = force_str(urlsafe_base64_encode(force_bytes(self.user.pk)))
 
         # Create url_args
         if DJANGO_VERSION >= (3, 0):

--- a/wagtail/contrib/modeladmin/helpers/button.py
+++ b/wagtail/contrib/modeladmin/helpers/button.py
@@ -1,5 +1,5 @@
 from django.contrib.admin.utils import quote
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.translation import ugettext as _
 
 
@@ -16,8 +16,8 @@ class ButtonHelper:
         self.request = request
         self.model = view.model
         self.opts = view.model._meta
-        self.verbose_name = force_text(self.opts.verbose_name)
-        self.verbose_name_plural = force_text(self.opts.verbose_name_plural)
+        self.verbose_name = force_str(self.opts.verbose_name)
+        self.verbose_name_plural = force_str(self.opts.verbose_name_plural)
         self.permission_helper = view.permission_helper
         self.url_helper = view.url_helper
 

--- a/wagtail/contrib/modeladmin/templatetags/modeladmin_tags.py
+++ b/wagtail/contrib/modeladmin/templatetags/modeladmin_tags.py
@@ -7,7 +7,7 @@ from django.db import models
 from django.forms.utils import flatatt
 from django.template import Library
 from django.template.loader import get_template
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.html import format_html
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext as _
@@ -59,7 +59,7 @@ def items_for_result(view, result):
                     models.DateField, models.TimeField, models.ForeignKey)
                 ):
                     row_classes.append('nowrap')
-        if force_text(result_repr) == '':
+        if force_str(result_repr) == '':
             result_repr = mark_safe('&nbsp;')
         row_classes.extend(
             modeladmin.get_extra_class_names_for_field_col(result, field_name)

--- a/wagtail/contrib/modeladmin/views.py
+++ b/wagtail/contrib/modeladmin/views.py
@@ -15,7 +15,7 @@ from django.db.models.fields.related import ManyToManyField, OneToOneRel
 from django.shortcuts import get_object_or_404, redirect
 from django.template.defaultfilters import filesizeformat
 from django.utils.decorators import method_decorator
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.functional import cached_property
 from django.utils.http import urlencode
 from django.utils.safestring import mark_safe
@@ -53,10 +53,10 @@ class WMABaseView(TemplateView):
         self.model_admin = model_admin
         self.model = model_admin.model
         self.opts = self.model._meta
-        self.app_label = force_text(self.opts.app_label)
-        self.model_name = force_text(self.opts.model_name)
-        self.verbose_name = force_text(self.opts.verbose_name)
-        self.verbose_name_plural = force_text(self.opts.verbose_name_plural)
+        self.app_label = force_str(self.opts.app_label)
+        self.model_name = force_str(self.opts.model_name)
+        self.verbose_name = force_str(self.opts.verbose_name)
+        self.verbose_name_plural = force_str(self.opts.verbose_name_plural)
         self.pk_attname = self.opts.pk.attname
         self.is_pagemodel = model_admin.is_pagemodel
         self.permission_helper = model_admin.permission_helper

--- a/wagtail/contrib/postgres_search/backend.py
+++ b/wagtail/contrib/postgres_search/backend.py
@@ -5,7 +5,7 @@ from django.db import DEFAULT_DB_ALIAS, NotSupportedError, connections, transact
 from django.db.models import Count, F, Manager, Q, TextField, Value
 from django.db.models.constants import LOOKUP_SEP
 from django.db.models.functions import Cast
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 
 from wagtail.search.backends.base import (
     BaseSearchBackend, BaseSearchQueryCompiler, BaseSearchResults, FilterFieldError)
@@ -65,7 +65,7 @@ class Index:
         if isinstance(value, dict):
             return ', '.join(self.prepare_value(item)
                              for item in value.values())
-        return force_text(value)
+        return force_str(value)
 
     def prepare_field(self, obj, field):
         if isinstance(field, SearchField):
@@ -86,7 +86,7 @@ class Index:
                     yield from self.prepare_field(sub_obj, sub_field)
 
     def prepare_obj(self, obj, search_fields):
-        obj._object_id_ = force_text(obj.pk)
+        obj._object_id_ = force_str(obj.pk)
         obj._autocomplete_ = []
         obj._body_ = []
         for field in search_fields:

--- a/wagtail/core/blocks/base.py
+++ b/wagtail/core/blocks/base.py
@@ -5,13 +5,9 @@ from django import forms
 from django.core import checks
 from django.core.exceptions import ImproperlyConfigured
 from django.template.loader import render_to_string
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.safestring import mark_safe
 from django.utils.text import capfirst
-
-# unicode_literals ensures that any render / __str__ methods returning HTML via calls to mark_safe / format_html
-# return a SafeText, not SafeBytes; necessary so that it doesn't get re-encoded when the template engine
-# calls force_text, which would cause it to lose its 'safe' flag
 
 __all__ = ['BaseBlock', 'Block', 'BoundBlock', 'DeclarativeSubBlocksMetaclass', 'BlockWidget', 'BlockField']
 
@@ -101,7 +97,7 @@ class Block(metaclass=BaseBlock):
     def set_name(self, name):
         self.name = name
         if not self.meta.label:
-            self.label = capfirst(force_text(name).replace('_', ' '))
+            self.label = capfirst(force_str(name).replace('_', ' '))
 
     @property
     def media(self):
@@ -256,7 +252,7 @@ class Block(metaclass=BaseBlock):
         Return a text rendering of 'value', suitable for display on templates. render() will fall back on
         this if the block does not define a 'template' property.
         """
-        return force_text(value)
+        return force_str(value)
 
     def get_searchable_content(self, value):
         """

--- a/wagtail/core/blocks/field_block.py
+++ b/wagtail/core/blocks/field_block.py
@@ -5,7 +5,7 @@ from django.db.models.fields import BLANK_CHOICE_DASH
 from django.forms.fields import CallableChoiceIterator
 from django.template.loader import render_to_string
 from django.utils.dateparse import parse_date, parse_datetime, parse_time
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.functional import cached_property
 from django.utils.html import format_html
 from django.utils.safestring import mark_safe
@@ -109,7 +109,7 @@ class CharBlock(FieldBlock):
         super().__init__(**kwargs)
 
     def get_searchable_content(self, value):
-        return [force_text(value)]
+        return [force_str(value)]
 
 
 class TextBlock(FieldBlock):
@@ -133,7 +133,7 @@ class TextBlock(FieldBlock):
         return forms.CharField(**field_kwargs)
 
     def get_searchable_content(self, value):
-        return [force_text(value)]
+        return [force_str(value)]
 
     class Meta:
         icon = "pilcrow"
@@ -453,16 +453,16 @@ class ChoiceBlock(FieldBlock):
 
     def get_searchable_content(self, value):
         # Return the display value as the searchable value
-        text_value = force_text(value)
+        text_value = force_str(value)
         for k, v in self.field.choices:
             if isinstance(v, (list, tuple)):
                 # This is an optgroup, so look inside the group for options
                 for k2, v2 in v:
-                    if value == k2 or text_value == force_text(k2):
-                        return [force_text(k), force_text(v2)]
+                    if value == k2 or text_value == force_str(k2):
+                        return [force_str(k), force_str(v2)]
             else:
-                if value == k or text_value == force_text(k):
-                    return [force_text(v)]
+                if value == k or text_value == force_str(k):
+                    return [force_str(v)]
         return []  # Value was not found in the list of choices
 
     class Meta:
@@ -518,7 +518,7 @@ class RichTextBlock(FieldBlock):
         return RichText(value)
 
     def get_searchable_content(self, value):
-        return [force_text(value.source)]
+        return [force_str(value.source)]
 
     class Meta:
         icon = "doc-full"

--- a/wagtail/core/templatetags/wagtailcore_tags.py
+++ b/wagtail/core/templatetags/wagtailcore_tags.py
@@ -1,7 +1,7 @@
 from django import template
 from django.shortcuts import reverse
 from django.template.defaulttags import token_kwargs
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.safestring import mark_safe
 
 from wagtail import VERSION, __version__
@@ -130,7 +130,7 @@ class IncludeBlockNode(template.Node):
 
             return value.render_as_block(context=new_context)
         else:
-            return force_text(value)
+            return force_str(value)
 
 
 @register.tag

--- a/wagtail/core/utils.py
+++ b/wagtail/core/utils.py
@@ -5,7 +5,7 @@ import unicodedata
 from django.apps import apps
 from django.conf import settings
 from django.db.models import Model
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.text import slugify
 
 WAGTAIL_APPEND_SLASH = getattr(settings, 'WAGTAIL_APPEND_SLASH', True)
@@ -70,7 +70,7 @@ def cautious_slugify(value):
     This ensures that the result of slugifying e.g. Cyrillic text will not be an empty
     string, and can thus be safely used as an identifier (albeit not a human-readable one).
     """
-    value = force_text(value)
+    value = force_str(value)
 
     # Normalize the string to decomposed unicode form. This causes accented Latin
     # characters to be split into 'base character' + 'accent modifier'; the latter will

--- a/wagtail/documents/views/multiple.py
+++ b/wagtail/documents/views/multiple.py
@@ -2,7 +2,7 @@ from django.core.exceptions import PermissionDenied
 from django.http import HttpResponseBadRequest, JsonResponse
 from django.shortcuts import get_object_or_404, render
 from django.template.loader import render_to_string
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.views.decorators.http import require_POST
 from django.views.decorators.vary import vary_on_headers
 
@@ -76,7 +76,7 @@ def add(request):
                 'success': False,
 
                 # https://github.com/django/django/blob/stable/1.6.x/django/forms/util.py#L45
-                'error_message': '\n'.join(['\n'.join([force_text(i) for i in v]) for k, v in form.errors.items()]),
+                'error_message': '\n'.join(['\n'.join([force_str(i) for i in v]) for k, v in form.errors.items()]),
             })
     else:
         form = DocumentForm(user=request.user)

--- a/wagtail/images/views/multiple.py
+++ b/wagtail/images/views/multiple.py
@@ -2,7 +2,7 @@ from django.core.exceptions import PermissionDenied
 from django.http import HttpResponseBadRequest, JsonResponse
 from django.shortcuts import get_object_or_404, render
 from django.template.loader import render_to_string
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.views.decorators.http import require_POST
 from django.views.decorators.vary import vary_on_headers
 
@@ -90,7 +90,7 @@ def add(request):
                 'success': False,
 
                 # https://github.com/django/django/blob/stable/1.6.x/django/forms/util.py#L45
-                'error_message': '\n'.join(['\n'.join([force_text(i) for i in v]) for k, v in form.errors.items()]),
+                'error_message': '\n'.join(['\n'.join([force_str(i) for i in v]) for k, v in form.errors.items()]),
             })
     else:
         # Instantiate a dummy copy of the form that we can retrieve validation messages and media from;

--- a/wagtail/images/views/serve.py
+++ b/wagtail/images/views/serve.py
@@ -10,7 +10,7 @@ from django.http import HttpResponse, HttpResponsePermanentRedirect, StreamingHt
 from django.shortcuts import get_object_or_404
 from django.urls import reverse
 from django.utils.decorators import classonlymethod
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.views.generic import View
 
 from wagtail.images import get_image_model
@@ -30,11 +30,11 @@ def generate_signature(image_id, filter_spec, key=None):
     # Based on libthumbor hmac generation
     # https://github.com/thumbor/libthumbor/blob/b19dc58cf84787e08c8e397ab322e86268bb4345/libthumbor/crypto.py#L50
     url = '{}/{}/'.format(image_id, filter_spec)
-    return force_text(base64.urlsafe_b64encode(hmac.new(key, url.encode(), hashlib.sha1).digest()))
+    return force_str(base64.urlsafe_b64encode(hmac.new(key, url.encode(), hashlib.sha1).digest()))
 
 
 def verify_signature(signature, image_id, filter_spec, key=None):
-    return force_text(signature) == generate_signature(image_id, filter_spec, key=key)
+    return force_str(signature) == generate_signature(image_id, filter_spec, key=key)
 
 
 def generate_image_url(image, filter_spec, viewname='wagtailimages_serve', key=None):

--- a/wagtail/utils/sendfile.py
+++ b/wagtail/utils/sendfile.py
@@ -72,8 +72,8 @@ def sendfile(request, filename, attachment=False, attachment_filename=None, mime
         parts = ['attachment']
         if attachment_filename:
             from unidecode import unidecode
-            from django.utils.encoding import force_text
-            attachment_filename = force_text(attachment_filename)
+            from django.utils.encoding import force_str
+            attachment_filename = force_str(attachment_filename)
             ascii_filename = unidecode(attachment_filename)
             parts.append('filename="%s"' % ascii_filename)
             if ascii_filename != attachment_filename:


### PR DESCRIPTION
Will be deprecated in Django 3.0.

The comment seems a bit dated, so I guess it could be removed. `SafeBytes` was removed in the removal of support for Python 2.  
