### PR TITLE
Updated the stream block id initialization

### DIFF
--- a/wagtail/core/blocks/stream_block.py
+++ b/wagtail/core/blocks/stream_block.py
@@ -432,6 +432,10 @@ class StreamValue(Sequence):
                 # value (stream_data_item here) is still valid
                 prep_value_item = stream_data_item
 
+                # As this method is preparing this value to be saved to the database,
+                # this is an appropriate place to ensure that each block has a unique id.
+                prep_value_item['id'] = prep_value_item.get('id', str(uuid.uuid4()))
+
             else:
                 # convert the bound block back into JSONish data
                 child = self[i]

--- a/wagtail/core/blocks/stream_block.py
+++ b/wagtail/core/blocks/stream_block.py
@@ -435,16 +435,14 @@ class StreamValue(Sequence):
             else:
                 # convert the bound block back into JSONish data
                 child = self[i]
+                # As this method is preparing this value to be saved to the database,
+                # this is an appropriate place to ensure that each block has a unique id.
+                child.id = child.id or str(uuid.uuid4())
                 prep_value_item = {
                     'type': child.block.name,
                     'value': child.block.get_prep_value(child.value),
                     'id': child.id,
                 }
-
-            # As this method is preparing this value to be saved to the database,
-            # this is an appropriate place to ensure that each block has a unique id.
-            if not prep_value_item.get('id'):
-                prep_value_item['id'] = str(uuid.uuid4())
 
             prep_value.append(prep_value_item)
 


### PR DESCRIPTION
The current block id generation only sets the id as the block is serialized for storage in the database, which means that the id is unavailable in the block until it is pulled back from the database. In my debugging this caused the id to be set to new values up to 3 times when saving a brand new page (each time with a new id).
This updated logic applies the new id to the actual block which makes it available right away and prevents the id from being regenerated.

Thanks for contributing to Wagtail! 🎉

Before submitting, please review the contributor guidelines <http://docs.wagtail.io/en/latest/contributing/index.html> and check the following:

* Do the tests still pass? (http://docs.wagtail.io/en/latest/contributing/developing.html#testing)
* Does the code comply with the style guide? (Run `make lint` from the Wagtail root)
* For Python changes: Have you added tests to cover the new/fixed behaviour?
* For front-end changes: Did you test on all of Wagtail’s supported browsers? **Please list the exact versions you tested**.
* For new features: Has the documentation been updated accordingly?
