### PR TITLE
Fix Postgres search indexing on Postgres 9.4 and Django >=2.2.1

### DIFF
--- a/wagtail/contrib/postgres_search/tests/test_backend.py
+++ b/wagtail/contrib/postgres_search/tests/test_backend.py
@@ -135,3 +135,17 @@ class TestPostgresSearchBackend(BackendTests, TestCase):
         # Now the phrase operator.
         results = self.backend.autocomplete("first <-> second", models.Book)
         self.assertUnsortedListEqual([r.title for r in results], [])
+
+    def test_index_without_upsert(self):
+        # Test the add_items code path for Postgres 9.4, where upsert is not available
+        self.backend.reset_index()
+
+        index = self.backend.get_index_for_model(models.Book)
+        index._enable_upsert = False
+        index.add_items(models.Book, models.Book.objects.all())
+
+        results = self.backend.search("JavaScript", models.Book)
+        self.assertUnsortedListEqual([r.title for r in results], [
+            "JavaScript: The good parts",
+            "JavaScript: The Definitive Guide"
+        ])


### PR DESCRIPTION
Fixes #5547
As of Django 2.2.1, Value expressions within a SearchVector must specify an output_field: https://code.djangoproject.com/ticket/30446
