### PR TITLE
Fix soundcloud embedding of artist page

### DIFF
--- a/wagtail/embeds/oembed_providers.py
+++ b/wagtail/embeds/oembed_providers.py
@@ -221,7 +221,7 @@ twitter = {
 soundcloud = {
     "endpoint": "https://soundcloud.com/oembed",
     "urls": [
-        r'^https://soundcloud\.com/[^#?/]+/?(.+)?$',
+        r'^https://soundcloud\.com/.+$',
     ],
 }
 

--- a/wagtail/embeds/oembed_providers.py
+++ b/wagtail/embeds/oembed_providers.py
@@ -221,7 +221,7 @@ twitter = {
 soundcloud = {
     "endpoint": "https://soundcloud.com/oembed",
     "urls": [
-        r'^https://soundcloud\.com/[^#?/]+/.+$',
+        r'^https://soundcloud\.com/[^#?/]+/?(.+)?$',
     ],
 }
 


### PR DESCRIPTION
Fixes https://github.com/wagtail/wagtail/issues/5562. Artist page could not be embedded because URL expected extra layer of depth (i.e. soundcloud.com/artist/track worked but soundcloud.com/artist did not)