### PR TITLE
allow image page sizes to be configurable

### DIFF
--- a/docs/advanced_topics/settings.rst
+++ b/docs/advanced_topics/settings.rst
@@ -267,6 +267,23 @@ This setting lets you override the maximum number of pixels an image can have. I
 
 This setting enables feature detection once OpenCV is installed, see all details on the :ref:`image_feature_detection` documentation.
 
+.. code-block:: python
+
+    WAGTAILIMAGES_INDEX_PAGE_SIZE = 20
+
+This setting allows you to change the page size when viewing images in the Wagtail admin.
+
+.. code-block:: python
+
+    WAGTAILIMAGES_USAGE_PAGE_SIZE = 20
+
+This setting allows you to change the page size when viewing image usage lists, e.g. in the delete view.
+
+.. code-block:: python
+
+    WAGTAILIMAGES_CHOOSER_PAGE_SIZE = 12
+
+This setting allows you to change the page size when using the image chooser modal.
 
 Password Management
 -------------------

--- a/wagtail/images/views/chooser.py
+++ b/wagtail/images/views/chooser.py
@@ -1,8 +1,8 @@
+from django.conf import settings
 from django.core.paginator import Paginator
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
 from django.utils.translation import ugettext as _
-from django.conf import settings
 
 from wagtail.admin.auth import PermissionPolicyChecker
 from wagtail.admin.forms.search import SearchForm

--- a/wagtail/images/views/chooser.py
+++ b/wagtail/images/views/chooser.py
@@ -2,6 +2,7 @@ from django.core.paginator import Paginator
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
 from django.utils.translation import ugettext as _
+from django.conf import settings
 
 from wagtail.admin.auth import PermissionPolicyChecker
 from wagtail.admin.forms.search import SearchForm
@@ -16,6 +17,8 @@ from wagtail.images.permissions import permission_policy
 from wagtail.search import index as search_index
 
 permission_checker = PermissionPolicyChecker(permission_policy)
+
+CHOOSER_PAGE_SIZE = getattr(settings, 'WAGTAILIMAGES_CHOOSER_PAGE_SIZE', 12)
 
 
 def get_chooser_js_data():
@@ -106,7 +109,7 @@ def chooser(request):
                 images = images.filter(tags__name=tag_name)
 
         # Pagination
-        paginator = Paginator(images, per_page=12)
+        paginator = Paginator(images, per_page=CHOOSER_PAGE_SIZE)
         images = paginator.get_page(request.GET.get('p'))
 
         return render(request, "wagtailimages/chooser/results.html", {
@@ -116,7 +119,7 @@ def chooser(request):
             'will_select_format': request.GET.get('select_format')
         })
     else:
-        paginator = Paginator(images, per_page=12)
+        paginator = Paginator(images, per_page=CHOOSER_PAGE_SIZE)
         images = paginator.get_page(request.GET.get('p'))
 
         context = get_chooser_context(request)
@@ -187,7 +190,7 @@ def chooser_upload(request):
     for hook in hooks.get_hooks('construct_image_chooser_queryset'):
         images = hook(images, request)
 
-    paginator = Paginator(images, per_page=12)
+    paginator = Paginator(images, per_page=CHOOSER_PAGE_SIZE)
     images = paginator.get_page(request.GET.get('p'))
 
     context = get_chooser_context(request)

--- a/wagtail/images/views/images.py
+++ b/wagtail/images/views/images.py
@@ -1,5 +1,6 @@
 import os
 
+from django.conf import settings
 from django.core.paginator import Paginator
 from django.http import HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
@@ -7,7 +8,6 @@ from django.urls import reverse
 from django.urls.exceptions import NoReverseMatch
 from django.utils.translation import ugettext as _
 from django.views.decorators.vary import vary_on_headers
-from django.conf import settings
 
 from wagtail.admin import messages
 from wagtail.admin.auth import PermissionPolicyChecker, permission_denied

--- a/wagtail/images/views/images.py
+++ b/wagtail/images/views/images.py
@@ -7,6 +7,7 @@ from django.urls import reverse
 from django.urls.exceptions import NoReverseMatch
 from django.utils.translation import ugettext as _
 from django.views.decorators.vary import vary_on_headers
+from django.conf import settings
 
 from wagtail.admin import messages
 from wagtail.admin.auth import PermissionPolicyChecker, permission_denied
@@ -22,6 +23,9 @@ from wagtail.images.views.serve import generate_signature
 from wagtail.search import index as search_index
 
 permission_checker = PermissionPolicyChecker(permission_policy)
+
+INDEX_PAGE_SIZE = getattr(settings, 'WAGTAILIMAGES_INDEX_PAGE_SIZE', 20)
+USAGE_PAGE_SIZE = getattr(settings, 'WAGTAILIMAGES_USAGE_PAGE_SIZE', 20)
 
 
 @permission_checker.require_any('add', 'change', 'delete')
@@ -55,7 +59,7 @@ def index(request):
         except (ValueError, Collection.DoesNotExist):
             pass
 
-    paginator = Paginator(images, per_page=20)
+    paginator = Paginator(images, per_page=INDEX_PAGE_SIZE)
     images = paginator.get_page(request.GET.get('p'))
 
     collections = permission_policy.collections_user_has_any_permission_for(
@@ -289,7 +293,7 @@ def add(request):
 def usage(request, image_id):
     image = get_object_or_404(get_image_model(), id=image_id)
 
-    paginator = Paginator(image.get_usage(), per_page=20)
+    paginator = Paginator(image.get_usage(), per_page=USAGE_PAGE_SIZE)
     used_by = paginator.get_page(request.GET.get('p'))
 
     return render(request, "wagtailimages/images/usage.html", {


### PR DESCRIPTION
When wagtail's serving thousands of images, sometimes paging through the images (and filtered result sets) can get tedious. This feels like an unobtrusive way to allow user-land to edit the response size.