### PR TITLE
Marks preview models for translation

### DIFF
--- a/wagtail/contrib/forms/models.py
+++ b/wagtail/contrib/forms/models.py
@@ -245,8 +245,8 @@ class AbstractForm(Page):
         )
 
     preview_modes = [
-        ('form', 'Form'),
-        ('landing', 'Landing page'),
+        ('form', _('Form')),
+        ('landing', _('Landing page')),
     ]
 
     def serve_preview(self, request, mode):


### PR DESCRIPTION
Small Fix to to mark `preview_modes` in `AbstractForm(Page)` for translation.

Fixes #5563 
