### PR TITLE
Fix help-text example in "Extending the Draftail Editor"

### DIFF
--- a/docs/advanced_topics/customisation/extending_draftail.rst
+++ b/docs/advanced_topics/customisation/extending_draftail.rst
@@ -105,7 +105,7 @@ Blocks are nearly as simple as inline styles:
         )
 
         features.register_converter_rule('contentstate', feature_name, {
-            'from_database_format': {'div.help-text': BlockElementHandler(type_)},
+            'from_database_format': {'div[class=help-text]': BlockElementHandler(type_)},
             'to_database_format': {'block_map': {type_: {'element': 'div', 'props': {'class': 'help-text'}}}},
         })
 


### PR DESCRIPTION
Due to wrong markup in converter rule the example with help-text does not work. Using div[class=help-text] instead of div.help-text makes it work correctly.

Fixes #5570 