### PR TITLE
option to disable submit for moderation

### DIFF
--- a/docs/advanced_topics/settings.rst
+++ b/docs/advanced_topics/settings.rst
@@ -239,6 +239,14 @@ Allows the default ``LoginForm`` to be extended with extra fields.
 If a user has not uploaded a profile picture, Wagtail will look for an avatar linked to their email address on gravatar.com. This setting allows you to specify an alternative provider such as like robohash.org, or can be set to ``None`` to disable the use of remote avatars completely.
 
 
+.. code-block:: python
+
+  WAGTAIL_DISPLAY_MODERATION = True
+
+Changes whether the Submit for Moderation button is displayed in the action menu.
+
+
+
 Images
 ------
 

--- a/docs/advanced_topics/settings.rst
+++ b/docs/advanced_topics/settings.rst
@@ -241,7 +241,7 @@ If a user has not uploaded a profile picture, Wagtail will look for an avatar li
 
 .. code-block:: python
 
-  WAGTAIL_DISPLAY_MODERATION = True
+  WAGTAIL_MODERATION_ENABLED = True
 
 Changes whether the Submit for Moderation button is displayed in the action menu.
 

--- a/wagtail/admin/action_menu.py
+++ b/wagtail/admin/action_menu.py
@@ -10,6 +10,7 @@ from django.utils.translation import ugettext_lazy as _
 from wagtail.core import hooks
 from wagtail.core.models import UserPagePermissionsProxy
 
+
 class ActionMenuItem(metaclass=MediaDefiningClass):
     """Defines an item in the actions drop-up on the page creation/edit view"""
     order = 100  # default order index if one is not specified on init

--- a/wagtail/admin/action_menu.py
+++ b/wagtail/admin/action_menu.py
@@ -10,8 +10,6 @@ from django.utils.translation import ugettext_lazy as _
 from wagtail.core import hooks
 from wagtail.core.models import UserPagePermissionsProxy
 
-WAGTAIL_DISPLAY_MODERATION = getattr(settings, 'WAGTAIL_DISPLAY_MODERATION', True)
-
 class ActionMenuItem(metaclass=MediaDefiningClass):
     """Defines an item in the actions drop-up on the page creation/edit view"""
     order = 100  # default order index if one is not specified on init
@@ -81,6 +79,7 @@ class SubmitForModerationMenuItem(ActionMenuItem):
     name = 'action-submit'
 
     def is_shown(self, request, context):
+        WAGTAIL_DISPLAY_MODERATION = getattr(settings, 'WAGTAIL_DISPLAY_MODERATION', True)
         if not WAGTAIL_DISPLAY_MODERATION:
             return False
         elif context['view'] == 'create':

--- a/wagtail/admin/action_menu.py
+++ b/wagtail/admin/action_menu.py
@@ -1,5 +1,6 @@
 """Handles rendering of the list of actions in the footer of the page create/edit views."""
 
+from django.conf import settings
 from django.forms import Media, MediaDefiningClass
 from django.template.loader import render_to_string
 from django.urls import reverse
@@ -9,6 +10,7 @@ from django.utils.translation import ugettext_lazy as _
 from wagtail.core import hooks
 from wagtail.core.models import UserPagePermissionsProxy
 
+WAGTAIL_DISPLAY_MODERATION = getattr(settings, 'WAGTAIL_DISPLAY_MODERATION', True)
 
 class ActionMenuItem(metaclass=MediaDefiningClass):
     """Defines an item in the actions drop-up on the page creation/edit view"""
@@ -79,7 +81,9 @@ class SubmitForModerationMenuItem(ActionMenuItem):
     name = 'action-submit'
 
     def is_shown(self, request, context):
-        if context['view'] == 'create':
+        if not WAGTAIL_DISPLAY_MODERATION:
+            return False
+        elif context['view'] == 'create':
             return True
         elif context['view'] == 'edit':
             return not context['page'].locked

--- a/wagtail/admin/action_menu.py
+++ b/wagtail/admin/action_menu.py
@@ -80,8 +80,8 @@ class SubmitForModerationMenuItem(ActionMenuItem):
     name = 'action-submit'
 
     def is_shown(self, request, context):
-        WAGTAIL_DISPLAY_MODERATION = getattr(settings, 'WAGTAIL_DISPLAY_MODERATION', True)
-        if not WAGTAIL_DISPLAY_MODERATION:
+        WAGTAIL_MODERATION_ENABLED = getattr(settings, 'WAGTAIL_MODERATION_ENABLED', True)
+        if not WAGTAIL_MODERATION_ENABLED:
             return False
         elif context['view'] == 'create':
             return True

--- a/wagtail/admin/tests/pages/test_create_page.py
+++ b/wagtail/admin/tests/pages/test_create_page.py
@@ -6,6 +6,7 @@ from django.contrib.auth.models import Group, Permission
 from django.core import mail
 from django.http import HttpRequest, HttpResponse
 from django.test import TestCase
+from django.test.utils import override_settings
 from django.urls import reverse
 from django.utils import timezone
 
@@ -39,6 +40,7 @@ class TestPageCreation(TestCase, WagtailTestUtils):
         self.assertNotContains(response, "Abstract page")
         # List of available page types should not contain pages whose parent_page_types forbid it
         self.assertNotContains(response, "Business child")
+
 
     def test_add_subpage_with_subpage_types(self):
         # Add a BusinessIndex to test business rules in
@@ -114,6 +116,7 @@ class TestPageCreation(TestCase, WagtailTestUtils):
         self.assertContains(response, 'testapp/js/siren.js')
         # test construct_page_action_menu hook
         self.assertContains(response, '<input type="submit" name="action-relax" value="Relax." class="button" />')
+
 
     def test_create_multipart(self):
         """
@@ -665,6 +668,21 @@ class TestPageCreation(TestCase, WagtailTestUtils):
 
         # page should be created
         self.assertTrue(Page.objects.filter(title="New page!").exists())
+
+    def test_display_moderation_button(self):
+        """
+        Tests that by default the "Submit for Moderation" button is shown.
+        """
+        response = self.client.get(reverse('wagtailadmin_pages:add', args=('tests', 'simplepage', self.root_page.id)))
+        self.assertContains(response,'<input type="submit" name="action-submit" value="Submit for moderation" class="button" />')
+
+    @override_settings(WAGTAIL_DISPLAY_MODERATION=False)
+    def test_not_display_moderation_button(self):
+        """
+        Tests that if WAGTAIL_DISPLAY_MODERATION is set to False, the "Submit for Moderation" button is not shown.
+        """
+        response = self.client.get(reverse('wagtailadmin_pages:add', args=('tests', 'simplepage', self.root_page.id)))
+        self.assertNotContains(response, '<input type="submit" name="action-submit" value="Submit for moderation" class="button" />')
 
 
 class TestPerRequestEditHandler(TestCase, WagtailTestUtils):

--- a/wagtail/admin/tests/pages/test_create_page.py
+++ b/wagtail/admin/tests/pages/test_create_page.py
@@ -674,7 +674,7 @@ class TestPageCreation(TestCase, WagtailTestUtils):
         Tests that by default the "Submit for Moderation" button is shown in the action menu.
         """
         response = self.client.get(reverse('wagtailadmin_pages:add', args=('tests', 'simplepage', self.root_page.id)))
-        self.assertContains(response,'<input type="submit" name="action-submit" value="Submit for moderation" class="button" />')
+        self.assertContains(response, '<input type="submit" name="action-submit" value="Submit for moderation" class="button" />')
 
     @override_settings(WAGTAIL_DISPLAY_MODERATION=False)
     def test_hide_moderation_button(self):

--- a/wagtail/admin/tests/pages/test_create_page.py
+++ b/wagtail/admin/tests/pages/test_create_page.py
@@ -41,7 +41,6 @@ class TestPageCreation(TestCase, WagtailTestUtils):
         # List of available page types should not contain pages whose parent_page_types forbid it
         self.assertNotContains(response, "Business child")
 
-
     def test_add_subpage_with_subpage_types(self):
         # Add a BusinessIndex to test business rules in
         business_index = BusinessIndex(
@@ -676,10 +675,10 @@ class TestPageCreation(TestCase, WagtailTestUtils):
         response = self.client.get(reverse('wagtailadmin_pages:add', args=('tests', 'simplepage', self.root_page.id)))
         self.assertContains(response, '<input type="submit" name="action-submit" value="Submit for moderation" class="button" />')
 
-    @override_settings(WAGTAIL_DISPLAY_MODERATION=False)
+    @override_settings(WAGTAIL_MODERATION_ENABLED=False)
     def test_hide_moderation_button(self):
         """
-        Tests that if WAGTAIL_DISPLAY_MODERATION is set to False, the "Submit for Moderation" button is not shown.
+        Tests that if WAGTAIL_MODERATION_ENABLED is set to False, the "Submit for Moderation" button is not shown.
         """
         response = self.client.get(reverse('wagtailadmin_pages:add', args=('tests', 'simplepage', self.root_page.id)))
         self.assertNotContains(response, '<input type="submit" name="action-submit" value="Submit for moderation" class="button" />')

--- a/wagtail/admin/tests/pages/test_create_page.py
+++ b/wagtail/admin/tests/pages/test_create_page.py
@@ -669,15 +669,15 @@ class TestPageCreation(TestCase, WagtailTestUtils):
         # page should be created
         self.assertTrue(Page.objects.filter(title="New page!").exists())
 
-    def test_display_moderation_button(self):
+    def test_display_moderation_button_by_default(self):
         """
-        Tests that by default the "Submit for Moderation" button is shown.
+        Tests that by default the "Submit for Moderation" button is shown in the action menu.
         """
         response = self.client.get(reverse('wagtailadmin_pages:add', args=('tests', 'simplepage', self.root_page.id)))
         self.assertContains(response,'<input type="submit" name="action-submit" value="Submit for moderation" class="button" />')
 
     @override_settings(WAGTAIL_DISPLAY_MODERATION=False)
-    def test_not_display_moderation_button(self):
+    def test_hide_moderation_button(self):
         """
         Tests that if WAGTAIL_DISPLAY_MODERATION is set to False, the "Submit for Moderation" button is not shown.
         """


### PR DESCRIPTION
Adds a setting, WAGTAIL_DISPLAY_MODERATION. Assumed True by default, when False, the "Submit for Moderation" button in the action menu is not shown.
