### PR TITLE
Allow the URL used by Page._get_dummy_headers() to be overridden

### DIFF
--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -1264,7 +1264,7 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
         Return a dict of META information to be included in a faked HttpRequest object to pass to
         serve_preview.
         """
-        url = self.full_url
+        url = self._get_dummy_header_url(original_request)
         if url:
             url_info = urlparse(url)
             hostname = url_info.hostname
@@ -1318,6 +1318,13 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
                     dummy_values[header] = original_request.META[header]
 
         return dummy_values
+
+    def _get_dummy_header_url(self, original_request=None):
+        """
+        Return the URL that _get_dummy_headers() should use to set META headers
+        for the faked HttpRequest.
+        """
+        return self.full_url
 
     def dummy_request(self, original_request=None, **meta):
         warn(


### PR DESCRIPTION
So, this came about because wagtailmenus has an `AbstractLinkPage` page type with some custom previewing behaviour which breaks badly in testing with the new dummy request creation implementation. 

This is because the page type overrides the various URL methods to return the target external/page URL instead. Previewing one of these pages renders a simple string that confirms "This page redirects to http://example.com", but this now results in a 400 error in some cases, because the target URL might be on a domain not permitted by `ALLOWED_HOSTS`.

I know Wagtail cannot possibly cater for every single case where some developer/third-party app is doing something strange :) But, this small/low-risk change will allow me to fix `AbstractLinkPage` without having to override the entire `_get_dummy_headers()` method, so thought it was worth proposing?

- [x] Do the tests still pass? (http://docs.wagtail.io/en/latest/contributing/developing.html#testing) 
- [x] Does the code comply with the style guide? (Run `make lint` from the Wagtail root)
- [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?