### PR TITLE
Add a note in editor manual about potential disabled moderation

### DIFF
--- a/docs/advanced_topics/settings.rst
+++ b/docs/advanced_topics/settings.rst
@@ -238,6 +238,7 @@ Allows the default ``LoginForm`` to be extended with extra fields.
 
 If a user has not uploaded a profile picture, Wagtail will look for an avatar linked to their email address on gravatar.com. This setting allows you to specify an alternative provider such as like robohash.org, or can be set to ``None`` to disable the use of remote avatars completely.
 
+.. _wagtail_moderation_enabled:
 
 .. code-block:: python
 

--- a/docs/editor_manual/new_pages/previewing_and_submitting_for_moderation.rst
+++ b/docs/editor_manual/new_pages/previewing_and_submitting_for_moderation.rst
@@ -4,7 +4,7 @@ Previewing and submitting pages for moderation
 The Save/Preview/Submit for moderation menu is always present at the bottom of the page edit/creation screen. The menu allows you to perform the following actions, dependent on whether you are an editor, moderator or administrator:
 
 * **Save draft:** Saves your current changes but doesn't submit the page for moderation and so won’t be published. (all roles)
-* **Submit for moderation:** Saves your current changes and submits the page for moderation. A moderator will be notified and they will then either publish or reject the page. (all roles)
+* **Submit for moderation:** Saves your current changes and submits the page for moderation. A moderator will be notified and they will then either publish or reject the page. This button may be missing if the site administrator has :ref:`disabled moderation<wagtail_moderation_enabled>`.  (all roles)
 * **Preview:** Opens a new window displaying the page as it would look if published, but does not save your changes or submit the page for moderation. (all roles)
 * **Publish/Unpublish:** Clicking the *Publish* button will publish this page. Clicking the *Unpublish* button will take you to a confirmation screen asking you to confirm that you wish to unpublish this page. If a page is published it will be accessible from its specific URL and will also be displayed in site search results. (moderators and administrators only)
 * **Delete:** Clicking this button will take you to a confirmation screen asking you to confirm that you wish to delete the current page. Be sure that this is actually what you want to do, as deleted pages are not recoverable. In many situations simply unpublishing the page will be enough. (moderators and administrators only)


### PR DESCRIPTION
This notes that the Submit for Moderation button may be disabled by the site administrator, and links to the relevant setting.