### PR TITLE
Fix summary item counts

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -43,6 +43,7 @@ Changelog
  * Fix: Prevent broken images in notification emails when static files are hosted on a remote domain (Eduard Luca)
  * Fix: Replace styleguide example avatar with default image to avoid issues when custom user model is used (Matt Westcott)
  * Fix: `DraftailRichTextArea` is no longer treated as a hidden field by Django's form logic (Sergey Fedoseev)
+ * Fix: `ImagesSummaryItem` image counter to consider user permissions on existing collections (George Y. Kussumoto)
 
 
 2.6.2 (19.09.2019)

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -411,6 +411,7 @@ Contributors
 * Tim White
 * Mike Janger
 * Prithvi MK
+* George Y. Kussumoto (georgeyk)
 
 Translators
 ===========

--- a/wagtail/images/wagtail_hooks.py
+++ b/wagtail/images/wagtail_hooks.py
@@ -127,10 +127,13 @@ class ImagesSummaryItem(SummaryItem):
     template = 'wagtailimages/homepage/site_summary_images.html'
 
     def get_context(self):
+        collections = permission_policy.collections_user_has_any_permission_for(
+            self.request.user, ['add', 'change', 'delete']
+        )
         site_name = get_site_for_user(self.request.user)['site_name']
 
         return {
-            'total_images': get_image_model().objects.count(),
+            'total_images': get_image_model().objects.filter(collection__in=collections).count(),
             'site_name': site_name,
         }
 


### PR DESCRIPTION
Fixes #5129 

Consider user permissions in ImagesSummaryItem and DocumentsSummaryItem counter.

I'm not very familiar with the codebase, so before I replicate the suggested fix in DocumentsSummaryItem, I would like to validate if this is going in the right direction.

~ :v: 