### PR TITLE
Use specific Page model in edit view

### DIFF
--- a/wagtail/admin/views/pages.py
+++ b/wagtail/admin/views/pages.py
@@ -321,7 +321,7 @@ def create(request, content_type_app_name, content_type_model_name, parent_page_
 
 
 def edit(request, page_id):
-    real_page_record = get_object_or_404(Page, id=page_id)
+    real_page_record = get_object_or_404(Page, id=page_id).specific
     latest_revision = real_page_record.get_latest_revision()
     page = real_page_record.get_latest_revision_as_page()
     parent = page.get_parent()


### PR DESCRIPTION
This allows for overriding `Page` methods such as `permissions_for_user`. Same approach was already done in `create` view, but not in `edit` view, which was keeping me from implementing a custom permission system by overriding `UserPagePermissionsProxy` and `PagePermissionTester` classes.

All tests pass and this change is working on production at www.outdoorsy.com.