### PR TITLE
Fix version number label obscuring menu items in Settings submenu

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,7 @@ Changelog
 2.7 LTS (xx.xx.xxxx) - IN DEVELOPMENT
 ~~~~~~~~~~~~~~~~~~~~
 
+ * Fix: Submenu items longer then the page height are no longer broken by the submenu footer (Igor van Spengen)
  * Improved StreamField design (Bertrand Bordage)
  * Added `construct_page_listing_buttons` hook (Michael van Tellingen)
  * Added more detailed documentation and troubleshooting for installing OpenCV for feature detection (Daniele Procida)

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -411,6 +411,7 @@ Contributors
 * Tim White
 * Mike Janger
 * Prithvi MK
+* Igor van Spengen
 
 Translators
 ===========

--- a/client/scss/components/_main-nav.scss
+++ b/client/scss/components/_main-nav.scss
@@ -409,6 +409,11 @@ body.explorer-open {
 
         .footer {
             position: absolute;
+
+            &-submenu {
+                position: sticky;
+                max-height: unset;
+            }
         }
 
     }

--- a/docs/releases/2.7.rst
+++ b/docs/releases/2.7.rst
@@ -46,6 +46,7 @@ Other features
 Bug fixes
 ~~~~~~~~~
 
+ * Submenu items longer then the page height are no longer broken by the submenu footer (Igor van Spengen)
  * Added line breaks to long filenames on multiple image / document uploader (Kevin Howbrook)
  * Added https support for Scribd oEmbed provider (Rodrigo)
  * Changed StreamField group label color so labels are visible (Catherine Farman)

--- a/wagtail/admin/templates/wagtailadmin/shared/menu_settings_menu_item.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/menu_settings_menu_item.html
@@ -2,7 +2,7 @@
 {% load wagtailcore_tags %}
 
 {% block menu_footer %}
-    <li class="footer">
+    <li class="footer footer-submenu">
         <div class="menu-item"><p class="wagtail-version">Wagtail v.{% wagtail_version %}</p></div>
     </li>
 {% endblock %}


### PR DESCRIPTION
If you have a lot of items in the Settings submenu, then the footer breaks some of the items.
You can see in the gif below that the footer should be fixed at the bottom of the screen, but instead the footer is moving the more items are added.

![bug](https://user-images.githubusercontent.com/10074936/66319746-efeb2800-e91d-11e9-9c8d-f66a2a315a50.gif)

Fixed this by adding the `position: sticky;` and `max-height: unset;` to the new class `footer-submenu`. This way the footer is always shown after the last item on the submenu. But now when the height of the page is smaller than the items, the footer is sticky to the bottom of the browser, and none of the items are broken by the footer.

![fixed](https://user-images.githubusercontent.com/10074936/66319784-fd081700-e91d-11e9-96ce-e4f4a0cb19c2.gif)

Tested with:
Safari: Version 13.0.1 (14608.2.11.1.11)
Firefox: 69.0.2 (64-bit)
Opera: Version:63.0.3368.107
Chrome: Version 77.0.3865.90 (Official Build) (64-bit)
