### PR TITLE
isort config file & isort import ordering

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,6 @@
+[settings]
+indent='    '
+multi_line_output=5
+known_django=django
+sections=FUTURE,STDLIB,DJANGO,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
+skip=migrations

--- a/wagtail/admin/decorators.py
+++ b/wagtail/admin/decorators.py
@@ -1,4 +1,5 @@
 import sys
+
 from wagtail.utils.deprecation import MovedDefinitionHandler, RemovedInWagtail29Warning
 
 MOVED_DEFINITIONS = {

--- a/wagtail/admin/forms/models.py
+++ b/wagtail/admin/forms/models.py
@@ -6,7 +6,6 @@ from taggit.managers import TaggableManager
 
 from wagtail.admin import widgets
 
-
 # Form field properties to override whenever we encounter a model field
 # that matches one of these types - including subclasses
 FORM_FIELD_OVERRIDES = {

--- a/wagtail/admin/locale.py
+++ b/wagtail/admin/locale.py
@@ -1,9 +1,7 @@
 import pytz
-
 from django.conf import settings
 from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_lazy
-
 
 # Wagtail languages with >=90% coverage
 # This list is manually maintained

--- a/wagtail/admin/mail.py
+++ b/wagtail/admin/mail.py
@@ -10,7 +10,6 @@ from wagtail.admin.auth import users_with_page_permission
 from wagtail.core.models import PageRevision
 from wagtail.users.models import UserProfile
 
-
 logger = logging.getLogger('wagtail.admin')
 
 

--- a/wagtail/admin/models.py
+++ b/wagtail/admin/models.py
@@ -1,6 +1,5 @@
 from django.contrib.contenttypes.models import ContentType
 from django.db.models import Count
-
 from modelcluster.fields import ParentalKey
 from taggit.models import Tag
 

--- a/wagtail/admin/rich_text/editors/draftail/features.py
+++ b/wagtail/admin/rich_text/editors/draftail/features.py
@@ -1,5 +1,6 @@
 from django.forms import Media
 
+
 # Feature objects: these are mapped to feature identifiers within the rich text
 # feature registry (wagtail.core.rich_text.features). Each one implements
 # a `construct_options` method which modifies an options dict as appropriate to

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -1,6 +1,5 @@
 import itertools
 import json
-
 from urllib.parse import urljoin
 
 from django import template

--- a/wagtail/admin/tests/pages/test_create_page.py
+++ b/wagtail/admin/tests/pages/test_create_page.py
@@ -14,8 +14,8 @@ from wagtail.admin.tests.pages.timestamps import submittable_timestamp
 from wagtail.core.models import GroupPagePermission, Page, PageRevision
 from wagtail.core.signals import page_published
 from wagtail.tests.testapp.models import (
-    BusinessChild, BusinessIndex, BusinessSubIndex, DefaultStreamPage, SimplePage,
-    SingletonPage, SingletonPageViaMaxCount, StandardChild, StandardIndex)
+    BusinessChild, BusinessIndex, BusinessSubIndex, DefaultStreamPage, SimplePage, SingletonPage,
+    SingletonPageViaMaxCount, StandardChild, StandardIndex)
 from wagtail.tests.utils import WagtailTestUtils
 
 

--- a/wagtail/admin/tests/pages/test_edit_page.py
+++ b/wagtail/admin/tests/pages/test_edit_page.py
@@ -16,8 +16,9 @@ from wagtail.admin.tests.pages.timestamps import submittable_timestamp
 from wagtail.core.models import Page, PageRevision, Site
 from wagtail.core.signals import page_published
 from wagtail.tests.testapp.models import (
-    EVENT_AUDIENCE_CHOICES, Advert, AdvertPlacement, EventCategory,
-    EventPage, EventPageCarouselItem, FilePage, ManyToManyBlogPage, SimplePage, SingleEventPage, StandardIndex, TaggedPage)
+    EVENT_AUDIENCE_CHOICES, Advert, AdvertPlacement, EventCategory, EventPage,
+    EventPageCarouselItem, FilePage, ManyToManyBlogPage, SimplePage, SingleEventPage, StandardIndex,
+    TaggedPage)
 from wagtail.tests.utils import WagtailTestUtils
 
 

--- a/wagtail/admin/tests/test_account_management.py
+++ b/wagtail/admin/tests/test_account_management.py
@@ -2,7 +2,6 @@ import os
 import tempfile
 
 import pytz
-
 from django import VERSION as DJANGO_VERSION
 from django.contrib.auth import views as auth_views
 from django.contrib.auth import get_user_model

--- a/wagtail/admin/tests/test_edit_handlers.py
+++ b/wagtail/admin/tests/test_edit_handlers.py
@@ -9,9 +9,8 @@ from django.core.exceptions import FieldDoesNotExist, ImproperlyConfigured
 from django.test import RequestFactory, TestCase, override_settings
 
 from wagtail.admin.edit_handlers import (
-    FieldPanel, FieldRowPanel, InlinePanel, ObjectList, PageChooserPanel,
-    RichTextFieldPanel, TabbedInterface, extract_panel_definitions_from_model_class,
-    get_form_for_model)
+    FieldPanel, FieldRowPanel, InlinePanel, ObjectList, PageChooserPanel, RichTextFieldPanel,
+    TabbedInterface, extract_panel_definitions_from_model_class, get_form_for_model)
 from wagtail.admin.forms import WagtailAdminModelForm, WagtailAdminPageForm
 from wagtail.admin.rich_text import DraftailRichTextArea
 from wagtail.admin.widgets import AdminAutoHeightTextInput, AdminDateInput, AdminPageChooser
@@ -19,8 +18,7 @@ from wagtail.core.models import Page, Site
 from wagtail.images.edit_handlers import ImageChooserPanel
 from wagtail.tests.testapp.forms import ValidatedPageForm
 from wagtail.tests.testapp.models import (
-    EventPage, EventPageChooserModel, EventPageSpeaker, PageChooserModel,
-    SimplePage, ValidatedPage)
+    EventPage, EventPageChooserModel, EventPageSpeaker, PageChooserModel, SimplePage, ValidatedPage)
 from wagtail.tests.utils import WagtailTestUtils
 
 

--- a/wagtail/admin/utils.py
+++ b/wagtail/admin/utils.py
@@ -2,7 +2,6 @@ import sys
 
 from wagtail.utils.deprecation import MovedDefinitionHandler, RemovedInWagtail29Warning
 
-
 MOVED_DEFINITIONS = {
     'WAGTAILADMIN_PROVIDED_LANGUAGES': 'wagtail.admin.locale',
     'get_js_translation_strings': 'wagtail.admin.locale',

--- a/wagtail/admin/views/account.py
+++ b/wagtail/admin/views/account.py
@@ -12,7 +12,8 @@ from django.utils.translation import override
 from wagtail.admin.forms.auth import LoginForm, PasswordResetForm
 from wagtail.core import hooks
 from wagtail.users.forms import (
-    AvatarPreferencesForm, CurrentTimeZoneForm, EmailForm, NameForm, NotificationPreferencesForm, PreferredLanguageForm)
+    AvatarPreferencesForm, CurrentTimeZoneForm, EmailForm, NameForm, NotificationPreferencesForm,
+    PreferredLanguageForm)
 from wagtail.users.models import UserProfile
 from wagtail.utils.loading import get_custom_form
 

--- a/wagtail/admin/views/chooser.py
+++ b/wagtail/admin/views/chooser.py
@@ -4,7 +4,6 @@ from django.shortcuts import get_object_or_404, render
 
 from wagtail.admin.forms.choosers import (
     AnchorLinkChooserForm, EmailLinkChooserForm, ExternalLinkChooserForm, PhoneLinkChooserForm)
-
 from wagtail.admin.forms.search import SearchForm
 from wagtail.admin.modal_workflow import render_modal_workflow
 from wagtail.core import hooks

--- a/wagtail/bin/wagtail.py
+++ b/wagtail/bin/wagtail.py
@@ -9,7 +9,6 @@ from difflib import unified_diff
 
 from django.core.management import ManagementUtility
 
-
 CURRENT_PYTHON = sys.version_info[:2]
 REQUIRED_PYTHON = (3, 5)
 

--- a/wagtail/contrib/modeladmin/views.py
+++ b/wagtail/contrib/modeladmin/views.py
@@ -4,10 +4,12 @@ from django import forms
 from django.contrib.admin import FieldListFilter
 from django.contrib.admin.options import IncorrectLookupParameters
 from django.contrib.admin.utils import (
-    get_fields_from_path, label_for_field, lookup_needs_distinct, prepare_lookup_value, quote, unquote)
+    get_fields_from_path, label_for_field, lookup_needs_distinct, prepare_lookup_value, quote,
+    unquote)
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import (
-    FieldDoesNotExist, ImproperlyConfigured, ObjectDoesNotExist, PermissionDenied, SuspiciousOperation)
+    FieldDoesNotExist, ImproperlyConfigured, ObjectDoesNotExist, PermissionDenied,
+    SuspiciousOperation)
 from django.core.paginator import InvalidPage, Paginator
 from django.db import models
 from django.db.models.fields.related import ManyToManyField, OneToOneRel

--- a/wagtail/contrib/routable_page/models.py
+++ b/wagtail/contrib/routable_page/models.py
@@ -7,7 +7,6 @@ from django.urls.resolvers import RegexPattern
 from wagtail.core.models import Page
 from wagtail.core.url_routing import RouteResult
 
-
 _creation_counter = 0
 
 

--- a/wagtail/contrib/sitemaps/views.py
+++ b/wagtail/contrib/sitemaps/views.py
@@ -1,4 +1,5 @@
 import inspect
+
 from django.contrib.sitemaps import views as sitemap_views
 
 from .sitemap_generator import Sitemap

--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -35,7 +35,6 @@ from wagtail.core.utils import WAGTAIL_APPEND_SLASH, camelcase_to_underscore, re
 from wagtail.search import index
 from wagtail.utils.deprecation import RemovedInWagtail29Warning
 
-
 logger = logging.getLogger('wagtail.core')
 
 PAGE_TEMPLATE_VAR = 'page'

--- a/wagtail/core/tests/test_page_model.py
+++ b/wagtail/core/tests/test_page_model.py
@@ -17,9 +17,10 @@ from wagtail.core.models import Page, PageManager, Site, get_page_models
 from wagtail.tests.testapp.models import (
     AbstractPage, Advert, AlwaysShowInMenusPage, BlogCategory, BlogCategoryBlogPage, BusinessChild,
     BusinessIndex, BusinessNowherePage, BusinessSubIndex, CustomManager, CustomManagerPage,
-    CustomPageQuerySet, EventCategory, EventIndex, EventPage, GenericSnippetPage, ManyToManyBlogPage,
-    MTIBasePage, MTIChildPage, MyCustomPage, OneToOnePage, PageWithExcludedCopyField, SimpleChildPage,
-    SimplePage, SimpleParentPage, SingleEventPage, SingletonPage, StandardIndex, TaggedPage)
+    CustomPageQuerySet, EventCategory, EventIndex, EventPage, GenericSnippetPage,
+    ManyToManyBlogPage, MTIBasePage, MTIChildPage, MyCustomPage, OneToOnePage,
+    PageWithExcludedCopyField, SimpleChildPage, SimplePage, SimpleParentPage, SingleEventPage,
+    SingletonPage, StandardIndex, TaggedPage)
 from wagtail.tests.utils import WagtailTestUtils
 
 

--- a/wagtail/embeds/tests/test_rich_text.py
+++ b/wagtail/embeds/tests/test_rich_text.py
@@ -1,7 +1,6 @@
 from unittest.mock import patch
 
 from bs4 import BeautifulSoup
-
 from django.test import TestCase
 
 from wagtail.core.rich_text import expand_db_html

--- a/wagtail/images/api/v2/serializers.py
+++ b/wagtail/images/api/v2/serializers.py
@@ -1,4 +1,5 @@
 from rest_framework.fields import Field
+
 from wagtail.api.v2.serializers import BaseSerializer
 
 

--- a/wagtail/images/jinja2tags.py
+++ b/wagtail/images/jinja2tags.py
@@ -6,7 +6,6 @@ from jinja2.ext import Extension
 from .shortcuts import get_rendition_or_not_found
 from .templatetags.wagtailimages_tags import image_url
 
-
 allowed_filter_pattern = re.compile(r"^[A-Za-z0-9_\-\.\|]+$")
 
 

--- a/wagtail/images/rich_text/editor_html.py
+++ b/wagtail/images/rich_text/editor_html.py
@@ -1,5 +1,4 @@
 from wagtail.admin.rich_text.converters import editor_html
-
 from wagtail.images import get_image_model
 from wagtail.images.formats import get_image_format
 

--- a/wagtail/images/templatetags/wagtailimages_tags.py
+++ b/wagtail/images/templatetags/wagtailimages_tags.py
@@ -9,7 +9,6 @@ from wagtail.images.models import Filter
 from wagtail.images.shortcuts import get_rendition_or_not_found
 from wagtail.images.views.serve import generate_image_url
 
-
 register = template.Library()
 allowed_filter_pattern = re.compile(r"^[A-Za-z0-9_\-\.]+$")
 

--- a/wagtail/search/backends/elasticsearch5.py
+++ b/wagtail/search/backends/elasticsearch5.py
@@ -1,6 +1,7 @@
 from .elasticsearch2 import (
     Elasticsearch2Index, Elasticsearch2Mapping, Elasticsearch2SearchBackend,
-    Elasticsearch2SearchQueryCompiler, Elasticsearch2SearchResults, ElasticsearchAutocompleteQueryCompilerImpl)
+    Elasticsearch2SearchQueryCompiler, Elasticsearch2SearchResults,
+    ElasticsearchAutocompleteQueryCompilerImpl)
 
 
 class Elasticsearch5Mapping(Elasticsearch2Mapping):

--- a/wagtail/search/index.py
+++ b/wagtail/search/index.py
@@ -6,10 +6,9 @@ from django.core import checks
 from django.core.exceptions import FieldDoesNotExist
 from django.db import models
 from django.db.models.fields.related import ForeignObjectRel, OneToOneRel, RelatedField
-
 from modelcluster.fields import ParentalManyToManyField
-from wagtail.search.backends import get_search_backends_with_name
 
+from wagtail.search.backends import get_search_backends_with_name
 
 logger = logging.getLogger('wagtail.search.index')
 

--- a/wagtail/tests/urls_multilang.py
+++ b/wagtail/tests/urls_multilang.py
@@ -5,5 +5,4 @@ from django.conf.urls.i18n import i18n_patterns
 
 from wagtail.core import urls as wagtail_urls
 
-
 urlpatterns = i18n_patterns(url(r'', include(wagtail_urls)))

--- a/wagtail/users/utils.py
+++ b/wagtail/users/utils.py
@@ -1,4 +1,5 @@
 import hashlib
+
 from django.conf import settings
 from django.utils.http import urlencode
 


### PR DESCRIPTION
When running `make lint` I had noticed a bunch of isort ordering warnings. This commit addresses those warnings by running `isort` on those files. 

I've also added an `.isort.cfg` file (and purposely left out the `line_length` setting). The `multi_line_output` has a [number of options](https://github.com/timothycrosley/isort#multi-line-output-modes) we can run, I just chose a fairly generic option (#5). 

After running `make lint` I no longer get any isort warnings. 