### PR TITLE
Support overriding default item in page action menu

### DIFF
--- a/docs/reference/hooks.rst
+++ b/docs/reference/hooks.rst
@@ -524,7 +524,7 @@ Hooks for customising the way users are directed through the process of creating
 
   Add an item to the popup menu of actions on the page creation and edit views. The callable passed to this hook must return an instance of ``wagtail.admin.action_menu.ActionMenuItem``. The following attributes and methods are available to be overridden on subclasses of ``ActionMenuItem``:
 
-  :order: an integer (default 100) which determines the item's position in the menu. Can also be passed as a keyword argument to the object constructor
+  :order: an integer (default 100) which determines the item's position in the menu. Can also be passed as a keyword argument to the object constructor. The lowest-numbered item in this sequence will be selected as the default menu item; as standard, this is "Save draft" (which has an ``order`` of 0).
   :label: the displayed text of the menu item
   :get_url: a method which returns a URL for the menu item to link to; by default, returns ``None`` which causes the menu item to behave as a form submit button instead
   :name: value of the ``name`` attribute of the submit button, if no URL is specified
@@ -574,23 +574,18 @@ Hooks for customising the way users are directed through the process of creating
         menu_items[:] = [item for item in menu_items if item.name != 'action-submit']
 
 
-.. _construct_page_action_menu:
-
-  Can also be used to customize default action menu button. The last item in menu_item variable is chosen as the default action. An example on changing the default to publish can be seen below.
+  The order of items in this list determines the menu ordering, and the first item in the list will be selected as the default action. For example, to change the default action to Publish:
 
   .. code-block:: python
 
-    from wagtail.admin.action_menu import UnpublishMenuItem, DeleteMenuItem, SubmitForModerationMenuItem, SaveDraftMenuItem, PublishMenuItem
-
     @hooks.register('construct_page_action_menu')
     def make_publish_default_action(menu_items, request, context):
-        menu_items[:] = [
-            UnpublishMenuItem(order=10),
-            DeleteMenuItem(order=20),
-            SubmitForModerationMenuItem(order=30),
-            SaveDraftMenuItem(order=40),
-            PublishMenuItem(order=50),
-        ]
+        for (index, item) in enumerate(menu_items):
+            if item.name == 'action-publish':
+                # move to top of list
+                menu_items.pop(index)
+                menu_items.insert(0, item)
+                break
 
 
 .. construct_page_listing_buttons:

--- a/docs/reference/hooks.rst
+++ b/docs/reference/hooks.rst
@@ -566,11 +566,32 @@ Hooks for customising the way users are directed through the process of creating
 
   Modify the final list of action menu items on the page creation and edit views. The callable passed to this hook receives a list of ``ActionMenuItem`` objects, a request object and a context dictionary as per ``register_page_action_menu_item``, and should modify the list of menu items in-place.
 
+
   .. code-block:: python
 
     @hooks.register('construct_page_action_menu')
     def remove_submit_to_moderator_option(menu_items, request, context):
         menu_items[:] = [item for item in menu_items if item.name != 'action-submit']
+
+
+.. _construct_page_action_menu:
+
+  Can also be used to customize default action menu button. The last item in menu_item variable is chosen as the default action. An example on changing the default to publish can be seen below.
+
+  .. code-block:: python
+
+    from wagtail.admin.action_menu import UnpublishMenuItem, DeleteMenuItem, SubmitForModerationMenuItem, SaveDraftMenuItem, PublishMenuItem
+
+    @hooks.register('construct_page_action_menu')
+    def make_publish_default_action(menu_items, request, context):
+        menu_items[:] = [
+            UnpublishMenuItem(order=10),
+            DeleteMenuItem(order=20),
+            SubmitForModerationMenuItem(order=30),
+            SaveDraftMenuItem(order=40),
+            PublishMenuItem(order=50),
+        ]
+
 
 .. construct_page_listing_buttons:
 

--- a/docs/releases/2.7.rst
+++ b/docs/releases/2.7.rst
@@ -86,6 +86,30 @@ This release introduces a new setting :ref:`WAGTAILDOCS_SERVE_METHOD <wagtaildoc
 In Wagtail 2.7, the default behaviour on remote storage backends is to redirect to the storage's underlying URL after performing the permission check. If this is unsuitable for your project (for example, your storage provider is configured to block public access, or revealing its URL would be a security risk) you can revert to the previous behaviour by setting ``WAGTAILDOCS_SERVE_METHOD`` to ``'serve_view'``.
 
 
+Template change for page action menu hooks
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When customising the action menu on the page edit view through the :ref:`register_page_action_menu_item <register_page_action_menu_item>` or :ref:`construct_page_action_menu <construct_page_action_menu>` hook, the ``ActionMenuItem`` object's ``template`` attribute or ``render_html`` method can be overridden to customise the menu item's HTML. As of Wagtail 2.7, the HTML returned from these should *not* include the enclosing ``<li>`` element.
+
+Any add-on library that uses this feature and needs to preserve backward compatibility with previous Wagtail versions can conditionally reinsert the ``<li>`` wrapper through its ``render_html`` method - for example:
+
+  .. code-block:: python
+
+    from django.utils.html import format_html
+    from wagtail import VERSION as WAGTAIL_VERSION
+    from wagtail.admin.action_menu import ActionMenuItem
+
+    class CustomMenuItem(ActionMenuItem):
+        template = 'myapp/my_menu_item.html'
+
+        def render_html(self, request, parent_context):
+            html = super().render_html(request, parent_context)
+            if WAGTAIL_VERSION < (2, 7):
+                html = format_html('<li>{}</li>', html)
+            return html
+
+
+
 ``wagtail.admin.utils`` and ``wagtail.admin.decorators`` modules deprecated
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/wagtail/admin/action_menu.py
+++ b/wagtail/admin/action_menu.py
@@ -159,12 +159,12 @@ def _get_base_page_action_menu_items():
 
     if BASE_PAGE_ACTION_MENU_ITEMS is None:
         BASE_PAGE_ACTION_MENU_ITEMS = [
+            PageLockedMenuItem(order=-10000),
+            SaveDraftMenuItem(order=0),
             UnpublishMenuItem(order=10),
             DeleteMenuItem(order=20),
             PublishMenuItem(order=30),
             SubmitForModerationMenuItem(order=40),
-            SaveDraftMenuItem(order=50),
-            PageLockedMenuItem(order=10000),
         ]
         for hook in hooks.get_hooks('register_page_action_menu_item'):
             BASE_PAGE_ACTION_MENU_ITEMS.append(hook())
@@ -192,7 +192,7 @@ class PageActionMenu:
             hook(self.menu_items, self.request, self.context)
 
         try:
-            self.default_item = self.menu_items.pop()
+            self.default_item = self.menu_items.pop(0)
         except IndexError:
             self.default_item = None
 

--- a/wagtail/admin/templates/wagtailadmin/pages/action_menu/menu.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/action_menu/menu.html
@@ -1,6 +1,11 @@
 {% if show_menu %}
+    {{ default_menu_item }}
     <div class="dropdown-toggle icon icon-arrow-up"></div>
     <ul>
-        {% for item in rendered_menu_items %}{{ item }}{% endfor %}
+        {% for item in rendered_menu_items %}
+            <li>
+                 {{ item }}
+            </li>
+        {% endfor %}
     </ul>
 {% endif %}

--- a/wagtail/admin/templates/wagtailadmin/pages/action_menu/menu.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/action_menu/menu.html
@@ -1,5 +1,7 @@
-{% if show_menu %}
+{% if default_menu_item %}
     {{ default_menu_item }}
+{% endif %}
+{% if show_menu %}
     <div class="dropdown-toggle icon icon-arrow-up"></div>
     <ul>
         {% for item in rendered_menu_items %}

--- a/wagtail/admin/templates/wagtailadmin/pages/action_menu/menu_item.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/action_menu/menu_item.html
@@ -1,7 +1,5 @@
-<li>
-    {% if url %}
-        <a href="{{ url }}">{{ label }}</a>
-    {% else %}
-        <input type="submit" name="{{ name }}" value="{{ label }}" class="button" />
-    {% endif %}
-</li>
+{% if url %}
+    <a class="button" href="{{ url }}">{{ label }}</a>
+{% else %}
+    <input type="submit" name="{{ name }}" value="{{ label }}" class="button" />
+{% endif %}

--- a/wagtail/admin/templates/wagtailadmin/pages/action_menu/page_locked.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/action_menu/page_locked.html
@@ -1,0 +1,2 @@
+{% load i18n %}
+<button type="submit" class="button action-save {% if is_revision %}warning{% endif %}" disabled>{% trans 'Page locked' %}</button>

--- a/wagtail/admin/templates/wagtailadmin/pages/action_menu/publish.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/action_menu/publish.html
@@ -1,4 +1,2 @@
 {% load i18n %}
-<li>
-    <button type="submit" name="action-publish" value="action-publish" class="button button-longrunning {% if is_revision %}warning{% endif %}" data-clicked-text="{% trans 'Publishing…' %}"><span class="icon icon-spinner"></span><em>{% if is_revision %}{% trans 'Publish this revision' %}{% else %}{% trans 'Publish' %}{% endif %}</em></button>
-</li>
+<button type="submit" name="action-publish" value="action-publish" class="button button-longrunning {% if is_revision %}warning{% endif %}" data-clicked-text="{% trans 'Publishing…' %}"><span class="icon icon-spinner"></span><em>{% if is_revision %}{% trans 'Publish this revision' %}{% else %}{% trans 'Publish' %}{% endif %}</em></button>

--- a/wagtail/admin/templates/wagtailadmin/pages/action_menu/save_draft.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/action_menu/save_draft.html
@@ -1,2 +1,2 @@
 {% load i18n %}
-<button type="submit" class="button action-save button-longrunning {% if is_revision %}warning{% endif %}" data-clicked-text="{% trans 'Saving…' %}" {% if page.locked %}disabled {% endif %}><span class="icon icon-spinner"></span><em>{% if page.locked %}{% trans 'Page locked' %}{% else %}{% if is_revision %}{% trans 'Replace current draft' %}{% else %}{% trans 'Save draft' %}{% endif %}{% endif %}</em></button>
+<button type="submit" class="button action-save button-longrunning {% if is_revision %}warning{% endif %}" data-clicked-text="{% trans 'Saving…' %}"><span class="icon icon-spinner"></span><em>{% if is_revision %}{% trans 'Replace current draft' %}{% else %}{% trans 'Save draft' %}{% endif %}</em></button>

--- a/wagtail/admin/templates/wagtailadmin/pages/action_menu/save_draft.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/action_menu/save_draft.html
@@ -1,0 +1,2 @@
+{% load i18n %}
+<button type="submit" class="button action-save button-longrunning {% if is_revision %}warning{% endif %}" data-clicked-text="{% trans 'Saving…' %}" {% if page.locked %}disabled {% endif %}><span class="icon icon-spinner"></span><em>{% if page.locked %}{% trans 'Page locked' %}{% else %}{% if is_revision %}{% trans 'Replace current draft' %}{% else %}{% trans 'Save draft' %}{% endif %}{% endif %}</em></button>

--- a/wagtail/admin/templates/wagtailadmin/pages/create.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/create.html
@@ -26,12 +26,11 @@
         <footer role="contentinfo">
             <nav aria-label="{% trans 'Actions' %}">
                 <ul>
-                    <li class="actions">
-                        <div class="dropdown dropup dropdown-button match-width">
-                            <button type="submit" class="button action-save button-longrunning" data-clicked-text="{% trans 'Saving…' %}"><span class="icon icon-spinner"></span><em>{% trans 'Save draft' %}</em></button>
-                            {{ action_menu.render_html }}
-                        </div>
-                    </li>
+                  <li class="actions">
+                      <div class="dropdown dropup dropdown-button match-width {% if is_revision %}warning{% endif %}">
+                          {{ action_menu.render_html }}
+                      </div>
+                  </li>
 
                     <li class="preview">
                         {% trans 'Preview' as preview_label %}

--- a/wagtail/admin/templates/wagtailadmin/pages/edit.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/edit.html
@@ -39,8 +39,6 @@
                 <ul>
                     <li class="actions">
                         <div class="dropdown dropup dropdown-button match-width {% if is_revision %}warning{% endif %}">
-                            <button type="submit" class="button action-save button-longrunning {% if is_revision %}warning{% endif %}" data-clicked-text="{% trans 'Saving…' %}" {% if page.locked %}disabled {% endif %}><span class="icon icon-spinner"></span><em>{% if page.locked %}{% trans 'Page locked' %}{% else %}{% if is_revision %}{% trans 'Replace current draft' %}{% else %}{% trans 'Save draft' %}{% endif %}{% endif %}</em></button>
-
                             {{ action_menu.render_html }}
                         </div>
                     </li>

--- a/wagtail/admin/tests/pages/test_edit_page.py
+++ b/wagtail/admin/tests/pages/test_edit_page.py
@@ -12,9 +12,6 @@ from django.test import TestCase, modify_settings
 from django.urls import reverse
 from django.utils import timezone
 
-from wagtail.admin.action_menu import (
-    DeleteMenuItem, PublishMenuItem, SaveDraftMenuItem, SubmitForModerationMenuItem,
-    UnpublishMenuItem)
 from wagtail.admin.tests.pages.timestamps import submittable_timestamp
 from wagtail.core.models import Page, PageRevision, Site
 from wagtail.core.signals import page_published
@@ -857,74 +854,35 @@ class TestPageEdit(TestCase, WagtailTestUtils):
         # page should be edited
         self.assertEqual(Page.objects.get(id=self.child_page.id).title, "I've been edited!")
 
-    def test_construct_page_action_menu_hook(self):
-        menu = [
-            UnpublishMenuItem(order=10),
-            DeleteMenuItem(order=20),
-            SubmitForModerationMenuItem(order=30),
-            SaveDraftMenuItem(order=40),
-            PublishMenuItem(order=50),
-        ]
-
-        default_item = '<button type="submit" name="action-publish" value="action-publish" class="button button-longrunning " data-clicked-text="Publishing…"><span class="icon icon-spinner"></span><em>Publish</em></button>'
-        menu_items_html = '''<ul>
-            <li>
-                <a class="button" href="/admin/pages/{id}/unpublish/">Unpublish</a>
-            </li>
-            <li>
-                <a class="button" href="/admin/pages/{id}/delete/">Delete</a>
-            </li>
-            <li>
-                <input type="submit" name="action-submit" value="Submit for moderation" class="button" />
-            </li>
-            <li>
-                <button type="submit" class="button action-save button-longrunning " data-clicked-text="Saving…" ><span class="icon icon-spinner"></span><em>Save draft</em></button>
-            </li>
-        </ul>'''.format(id=self.single_event_page.id)
-
+    def test_override_default_action_menu_item(self):
         def hook_func(menu_items, request, context):
-            menu_items[:] = menu
+            for (index, item) in enumerate(menu_items):
+                if item.name == 'action-publish':
+                    # move to top of list
+                    menu_items.pop(index)
+                    menu_items.insert(0, item)
+                    break
 
         with self.register_hook('construct_page_action_menu', hook_func):
-            response = self.client.get(reverse('wagtailadmin_pages:edit',
-                                       args=(self.single_event_page.id, )))
+            response = self.client.get(reverse('wagtailadmin_pages:edit', args=(self.single_event_page.id, )))
 
-        self.assertContains(response, default_item, html=True)
-        self.assertContains(response, menu_items_html, html=True)
+        publish_button = '''
+            <button type="submit" name="action-publish" value="action-publish" class="button button-longrunning " data-clicked-text="Publishing…">
+                <span class="icon icon-spinner"></span><em>Publish</em>
+            </button>
+        '''
+        save_button = '''
+            <button type="submit" class="button action-save button-longrunning " data-clicked-text="Saving…" >
+                <span class="icon icon-spinner"></span><em>Save draft</em>
+            </button>
+        '''
 
-        for item in menu:
-            if item.template:
-                self.assertTemplateUsed(response, item.template)
+        # save button should be in a <li>
+        self.assertContains(response, "<li>%s</li>" % save_button, html=True)
 
-    def test_construct_page_action_menu_hook_2(self):
-        menu = [
-            DeleteMenuItem(order=20),
-            SubmitForModerationMenuItem(order=30),
-        ]
-
-        default_item = '<input type="submit" name="action-submit" value="Submit for moderation" class="button" />'
-        menu_items_html = '''<ul>
-            <li>
-                <a class="button" href="/admin/pages/{id}/delete/">Delete</a>
-            </li>
-        </ul>'''.format(id=self.single_event_page.id)
-
-        def hook_func(menu_items, request, context):
-            menu_items[:] = menu
-
-        with self.register_hook('construct_page_action_menu', hook_func):
-            response = self.client.get(reverse('wagtailadmin_pages:edit',
-                                       args=(self.single_event_page.id, )))
-
-        self.assertContains(response, default_item, html=True)
-        self.assertContains(response, menu_items_html, html=True)
-
-        for item in menu:
-            if item.template:
-                self.assertTemplateUsed(response, item.template)
-
-        self.assertTemplateNotUsed(response, "wagtailadmin/pages/action_menu/save_draft.html")
-        self.assertTemplateNotUsed(response, "wagtailadmin/pages/action_menu/publish.html")
+        # publish button should be present, but not in a <li>
+        self.assertContains(response, publish_button, html=True)
+        self.assertNotContains(response, "<li>%s</li>" % publish_button, html=True)
 
 
 class TestPageEditReordering(TestCase, WagtailTestUtils):


### PR DESCRIPTION
Fixes #5438; rebase and update of #5500.

The behaviour has now been reversed so that the first item in the list is selected as the default, rather than the last; this way developers will have to either set a negative `order` value or explicitly reorder items in `construct_page_action_menu` to replace the Save Draft item, which makes it unlikely to happen by accident on existing uses of this hook.

Have also fixed behaviour for locked pages, updated docs/tests to avoid rewriting the whole list, and added a release note to cover the minor template change.