### PR TITLE
Refined creation of title on image & document uploads

### DIFF
--- a/docs/advanced_topics/documents/index.rst
+++ b/docs/advanced_topics/documents/index.rst
@@ -6,3 +6,7 @@ Documents
     :maxdepth: 2
 
     custom_document_model
+
+
+See also :ref:`Custom title generation from a filename on upload <image_custom_title_generation_from_filename>`.
+

--- a/docs/advanced_topics/images/custom_title_generation_from_filename.rst
+++ b/docs/advanced_topics/images/custom_title_generation_from_filename.rst
@@ -1,0 +1,58 @@
+.. _image_custom_title_generation_from_filename:
+
+Custom Title Generation From Filename
+=====================================
+
+Override how the title is set when uploading single files, multiple files or uploading a file within a chooser modal.
+
+.. note::
+    This will not apply to editing images or documents (e.g. uploading a replacement image file while editing an existing image).
+
+``wagtail.utils.getTitleFromFilename`` can be overridden with a custom function,
+the first argument is the filename (e.g. ``'some_file.jpg'``) and the second is an options object.
+If the return value is a ``String`` it will replace the value in the relevant title field, otherwise it will leave the title field as is (blank or with any current value).
+
+The options available to the function are as follows:
+
+* ``currentTitle`` - if uploading an image in place of an existing image, the currently entered title (e.g. in a chooser modal)
+* ``maxLength`` - will be the maximum length on the title form field (may not available for some forms, can be null)
+* ``model`` - file upload model, can be ``'DOCUMENT'`` or ``'IMAGE'``
+* ``widget`` - the type of upload widget, can be ``'ADD'``, ``'ADD_MULTIPLE'`` or ``'CHOOSER_MODAL'``
+
+Code Example
+------------
+
+.. code-block:: python
+
+  from django.utils.html import format_html, format_html_join
+  from django.templatetags.static import static
+
+  from wagtail.core import hooks
+
+  @hooks.register('insert_global_admin_js')
+  def get_global_admin_js():
+      # remember to use double '{{' so they are not parsed as template placeholders
+      return format_html(
+        """
+        <script>
+            $(function () {{
+                function getTitleFromFilename (filename, options) {{
+                    if (options.currentTitle) return null; // return if there is a title already entered so it will be left unchanged
+
+                    // model can be 'IMAGE' or 'DOCUMENT'
+                    if (options.model === 'IMAGE') {{
+                        return 'Image of: ' + filename; // prepend a label to all images by default
+                    }}
+
+                    filenameParts = filename.split('.');
+                    filenameParts.pop(); // remove the last element (file extension)
+                    return filenameParts.join('');
+                }}
+
+                // override the title util with this custom one
+                window.wagtail.utils.getTitleFromFilename = getTitleFromFilename;
+            }});
+        </script>
+        """
+      )
+

--- a/docs/advanced_topics/images/index.rst
+++ b/docs/advanced_topics/images/index.rst
@@ -12,3 +12,4 @@ Images
     changing_rich_text_representation
     feature_detection
     image_serve_view
+    custom_title_generation_from_filename

--- a/docs/reference/hooks.rst
+++ b/docs/reference/hooks.rst
@@ -387,12 +387,13 @@ Hooks for customising the editing interface for pages and snippets.
         js_includes = format_html_join('\n', '<script src="{0}"></script>',
             ((static(filename),) for filename in js_files)
         )
+        # remember to use double '{{' so they are not parsed as template placeholders
         return js_includes + format_html(
             """
             <script>
-                $(function() {
+                $(function() {{
                     $('button').raptorize();
-                });
+                }});
             </script>
             """
         )

--- a/wagtail/admin/static_src/wagtailadmin/js/page-editor.js
+++ b/wagtail/admin/static_src/wagtailadmin/js/page-editor.js
@@ -127,7 +127,6 @@ function InlinePanel(opts) {  // lgtm[js/unused-local-variable]
         parent.addClass('moving').css('height', parent.height());
 
         children.each(function() {
-            // console.log($(this));
             $(this).css('top', $(this).position().top);
         }).addClass('moving');
 

--- a/wagtail/documents/static_src/wagtaildocs/js/add-multiple.js
+++ b/wagtail/documents/static_src/wagtaildocs/js/add-multiple.js
@@ -22,6 +22,7 @@ $(function() {
 
             $('#upload-list').append(li);
             data.context = li;
+            data.$titleField = $('#title', data.form); // add upload title field for custom title on upload
 
             data.process(function() {
                 return $this.fileupload('process', data);
@@ -106,6 +107,12 @@ $(function() {
             itemElement.removeClass('upload-uploading').addClass('upload-complete');
         }
     });
+
+    /* update the #title input within the form before each file upload to add custom titles */
+    $('#fileupload').bind(
+        'fileuploadsubmit',
+        wagtail.utils.getPopulateTitleHandler('DOCUMENT', 'ADD_MULTIPLE')
+    );
 
     // ajax-enhance forms added on done()
     $('#upload-list').on('submit', 'form', function(e) {

--- a/wagtail/documents/static_src/wagtaildocs/js/document-chooser-modal.js
+++ b/wagtail/documents/static_src/wagtaildocs/js/document-chooser-modal.js
@@ -93,6 +93,13 @@ DOCUMENT_CHOOSER_MODAL_ONLOAD_HANDLERS = {
             return false;
         });
 
+        /* set up pre-filling of title based on selected file */
+        $('form.document-upload', modal.body).find('[type="file"]').on(
+            'change',
+            { $titleField: $('#id_document-chooser-upload-title', modal.body) },
+            wagtail.utils.getPopulateTitleHandler('DOCUMENT', 'CHOOSER_MODAL')
+        );
+
         $('form.document-search', modal.body).on('submit', search);
 
         $('#id_q').on('input', function() {

--- a/wagtail/documents/templates/wagtaildocs/documents/add.html
+++ b/wagtail/documents/templates/wagtaildocs/documents/add.html
@@ -14,6 +14,11 @@
             $('#id_tags').tagit({
                 autocomplete: {source: "{{ autocomplete_url|addslashes }}"}
             });
+            $('#id_file').on(
+                'change',
+                { $titleField: $('#id_title') },
+                window.wagtail.utils.getPopulateTitleHandler('DOCUMENT', 'ADD')
+            );
         });
     </script>
 {% endblock %}

--- a/wagtail/documents/templates/wagtaildocs/multiple/add.html
+++ b/wagtail/documents/templates/wagtaildocs/multiple/add.html
@@ -24,6 +24,7 @@
                 <div class="replace-file-input">
                     <button class="button bicolor icon icon-plus">{% trans "Or choose from your computer" %}</button>
                     <input id="fileupload" type="file" name="files[]" data-url="{% url 'wagtaildocs:add_multiple' %}" multiple>
+                    <input id="title" type="hidden" name="title" maxlength="{{ max_title_length }}" value="">
                 </div>
                 {% csrf_token %}
                 {% if collections %}

--- a/wagtail/documents/views/multiple.py
+++ b/wagtail/documents/views/multiple.py
@@ -41,7 +41,7 @@ def add(request):
 
         # Build a form for validation
         form = DocumentForm({
-            'title': request.FILES['files[]'].name,
+            'title': request.POST.get('title', request.FILES['files[]'].name),
             'collection': request.POST.get('collection'),
         }, {
             'file': request.FILES['files[]']
@@ -85,6 +85,7 @@ def add(request):
         form = DocumentForm(user=request.user)
 
         return TemplateResponse(request, 'wagtaildocs/multiple/add.html', {
+            'max_title_length': form.fields['title'].max_length,
             'help_text': form.fields['file'].help_text,
             'collections': collections_to_choose,
             'form_media': form.media,

--- a/wagtail/images/static_src/wagtailimages/js/add-multiple.js
+++ b/wagtail/images/static_src/wagtailimages/js/add-multiple.js
@@ -33,6 +33,7 @@ $(function() {
 
             $('#upload-list').append(li);
             data.context = li;
+            data.$titleField = $('#title', data.form); // add upload title field for custom title on upload
 
             data.process(function() {
                 return $this.fileupload('process', data);
@@ -126,6 +127,12 @@ $(function() {
             itemElement.removeClass('upload-uploading').addClass('upload-complete');
         }
     });
+
+    /* update the #title input within the form before each file upload to add custom titles */
+    $('#fileupload').bind(
+        'fileuploadsubmit',
+        wagtail.utils.getPopulateTitleHandler('IMAGE', 'ADD_MULTIPLE')
+    );
 
     // ajax-enhance forms added on done()
     $('#upload-list').on('submit', 'form', function(e) {

--- a/wagtail/images/static_src/wagtailimages/js/image-chooser-modal.js
+++ b/wagtail/images/static_src/wagtailimages/js/image-chooser-modal.js
@@ -92,6 +92,13 @@ IMAGE_CHOOSER_MODAL_ONLOAD_HANDLERS = {
             return false;
         });
 
+        /* set up pre-filling of title based on selected file */
+        $('form.image-upload', modal.body).find('[type="file"]').on(
+            'change',
+            { $titleField: $('#id_image-chooser-upload-title', modal.body) },
+            wagtail.utils.getPopulateTitleHandler('IMAGE', 'CHOOSER_MODAL')
+        );
+
         $('form.image-search', modal.body).on('submit', search);
 
         $('#id_q').on('input', function() {
@@ -112,22 +119,6 @@ IMAGE_CHOOSER_MODAL_ONLOAD_HANDLERS = {
             });
             return false;
         });
-
-        function populateTitle(context) {
-            var fileWidget = $('#id_image-chooser-upload-file', context);
-            fileWidget.on('change', function () {
-                var titleWidget = $('#id_image-chooser-upload-title', context);
-                var title = titleWidget.val();
-                if (title === '') {
-                    // The file widget value example: `C:\fakepath\image.jpg`
-                    var parts = fileWidget.val().split('\\');
-                    var fileName = parts[parts.length - 1];
-                    titleWidget.val(fileName);
-                }
-            });
-        }
-
-        populateTitle(modal.body);
     },
     'image_chosen': function(modal, jsonData) {
         modal.respond('imageChosen', jsonData['result']);

--- a/wagtail/images/templates/wagtailimages/images/add.html
+++ b/wagtail/images/templates/wagtailimages/images/add.html
@@ -14,6 +14,11 @@
             $('#id_tags').tagit({
                 autocomplete: {source: "{{ autocomplete_url|addslashes }}"}
             });
+            $('#id_file').on(
+                'change',
+                { $titleField: $('#id_title') },
+                window.wagtail.utils.getPopulateTitleHandler('IMAGE', 'ADD')
+            );
         });
     </script>
 {% endblock %}

--- a/wagtail/images/templates/wagtailimages/multiple/add.html
+++ b/wagtail/images/templates/wagtailimages/multiple/add.html
@@ -24,6 +24,7 @@
                 <div class="replace-file-input">
                     <button class="button bicolor icon icon-plus">{% trans "Or choose from your computer" %}</button>
                     <input id="fileupload" type="file" name="files[]" data-url="{% url 'wagtailimages:add_multiple' %}" multiple>
+                    <input id="title" type="hidden" maxlength="{{ max_title_length }}" name="title" value="">
                 </div>
                 {% csrf_token %}
                 {% if collections %}

--- a/wagtail/images/views/multiple.py
+++ b/wagtail/images/views/multiple.py
@@ -61,7 +61,7 @@ def add(request):
 
         # Build a form for validation
         form = ImageForm({
-            'title': request.FILES['files[]'].name,
+            'title': request.POST.get('title', request.FILES['files[]'].name),
             'collection': request.POST.get('collection'),
         }, {
             'file': request.FILES['files[]'],
@@ -123,6 +123,7 @@ def add(request):
         form = ImageForm(user=request.user)
 
         return TemplateResponse(request, 'wagtailimages/multiple/add.html', {
+            'max_title_length': form.fields['title'].max_length,
             'max_filesize': form.fields['file'].max_upload_size,
             'help_text': form.fields['file'].help_text,
             'allowed_extensions': ALLOWED_EXTENSIONS,


### PR DESCRIPTION
Resolves #4945 

## Overview of implementation
* By default, the file name will be used to generate a title which will be the file without the file extension
* If a value is already in the applicable title field, by default this value will be kept as is
* Standardises the implementation across multiple upload forms (was previously inconsistent)
* Moves the implementation to 100% client side so user can 'edit' value before it is saved
* Adds the ability for this functionality to overridden (includes docs on how to do this)
* Contains some minor JS code fix ups

## Forms updated
- view - admin/images/multiple/add
- view - admin/images/add
- view - admin/documents/add
- view - admin/documents/multiple/add
- modal - image-chooser-modal
- modal - document-chooser-modal

## How to validate
* For each of the forms above, attempt to upload a document or image and check the title field gets pre-filled with the filename but not the extension
* For the non-multiple forms, before clicking save, select a different file to upload and confirm the title is left unchanged

## PR Checklist
* Do the tests still pass? the core.js is actually untested, I am happy to get some tests started but it appears this will be quite some effort.
* Does the code comply with the style guide?  ✅  - js lint passes
* For front-end changes: Tested on the following
  * Safari Version 12.1.1 MacOS 10.14.5
  * Firefox 69 MacOS 10.14.5
  * Chrome 77 MacOS 10.14.5
* For new features: Has the documentation been updated accordingly? ✅ 
