### PR TITLE
 Add trimmed to blocktrans blocks, remove redundant white from msgid

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/chooser/_search_results.html
+++ b/wagtail/admin/templates/wagtailadmin/chooser/_search_results.html
@@ -1,7 +1,7 @@
 {% load i18n wagtailadmin_tags %}
 
 <h2>
-    {% blocktrans count counter=pages.paginator.count %}
+    {% blocktrans trimmed count counter=pages.paginator.count %}
         There is {{ counter }} match
     {% plural %}
         There are {{ counter }} matches

--- a/wagtail/admin/templates/wagtailadmin/chooser/browse.html
+++ b/wagtail/admin/templates/wagtailadmin/chooser/browse.html
@@ -12,7 +12,7 @@
 
     {% if page_types_restricted %}
         <p class="help-block help-warning">
-            {% blocktrans with type=page_type_names|join:", " count counter=page_type_names|length %}
+            {% blocktrans trimmed with type=page_type_names|join:", " count counter=page_type_names|length %}
                 Only pages of type "{{ type }}" may be chosen for this field. Search results will exclude pages of other types.
                 {% plural %}
                 Only the following page types may be chosen for this field: {{ type }}. Search results will exclude pages of other types.

--- a/wagtail/admin/templates/wagtailadmin/home/site_summary_pages.html
+++ b/wagtail/admin/templates/wagtailadmin/home/site_summary_pages.html
@@ -2,7 +2,7 @@
 
 <li class="icon icon-doc-empty-inverse">
     <a href="{% url 'wagtailadmin_explore' root_page.pk %}">
-        {% blocktrans count counter=total_pages with total_pages|intcomma as total %}
+        {% blocktrans trimmed count counter=total_pages with total_pages|intcomma as total %}
             <span>{{ total }}</span> Page <span class="visuallyhidden">created in {{ site_name }}</span>
         {% plural %}
             <span>{{ total }}</span> Pages <span class="visuallyhidden">created in {{ site_name }}</span>

--- a/wagtail/admin/templates/wagtailadmin/notifications/submitted.html
+++ b/wagtail/admin/templates/wagtailadmin/notifications/submitted.html
@@ -3,7 +3,11 @@
 {% load i18n %}
 
 {% block content %}
-    <p>{% blocktrans with page=revision.page|safe editor=revision.user.get_full_name|default:revision.user.get_username %}The page "{{ page }}" has been submitted for moderation by {{ editor }}.{% endblocktrans %}</p>
+    <p>
+      {% blocktrans trimmed with page=revision.page|safe editor=revision.user.get_full_name|default:revision.user.get_username %}
+        The page "{{ page }}" has been submitted for moderation by {{ editor }}.
+      {% endblocktrans %}
+    </p>
 
     <p>
         {% trans "You can preview the page here:" %} <a href="{{ settings.BASE_URL }}{% url 'wagtailadmin_pages:preview_for_moderation' revision.id %}">{{ settings.BASE_URL }}{% url 'wagtailadmin_pages:preview_for_moderation' revision.id %}</a><br/>

--- a/wagtail/admin/templates/wagtailadmin/pages/confirm_delete.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/confirm_delete.html
@@ -10,7 +10,7 @@
         <p>
             {% trans 'Are you sure you want to delete this page?' %}
             {% if descendant_count %}
-                {% blocktrans count counter=descendant_count %}
+                {% blocktrans trimmed count counter=descendant_count %}
                     This will also delete one more subpage.
                 {% plural %}
                     This will also delete {{ descendant_count }} more subpages.

--- a/wagtail/admin/templates/wagtailadmin/pages/confirm_unpublish.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/confirm_unpublish.html
@@ -17,11 +17,13 @@
                         <div class="field-content">
                             <div class="input">
                                 <input id="id_include_descendants" name="include_descendants" type="checkbox">
-                                <label for="id_include_descendants" class="plain-checkbox-label">{% blocktrans count counter=live_descendant_count %}
-                    This page has one subpage. Unpublish this too
-                {% plural %}
-                    This page has {{ live_descendant_count }} subpages. Unpublish these too
-                {% endblocktrans %}</label>
+                                <label for="id_include_descendants" class="plain-checkbox-label">
+                                    {% blocktrans trimmed count counter=live_descendant_count %}
+                                        This page has one subpage. Unpublish this too
+                                    {% plural %}
+                                        This page has {{ live_descendant_count }} subpages. Unpublish these too
+                                    {% endblocktrans %}
+                                </label>
                             </div>
                         </div>
                     </div>

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_list_explore.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_list_explore.html
@@ -16,7 +16,7 @@
                 {% if perms.wagtailcore.add_site %}
                     {% url 'wagtailsites:index' as wagtailsites_index_url %}
                     <p>
-                        {% blocktrans %}
+                        {% blocktrans trimmed %}
                             The root level is where you can add new sites to your Wagtail installation. Pages created here will not be accessible at any URL until they are associated with a site.
                         {% endblocktrans %}
                         {% if wagtailsites_index_url %}
@@ -24,12 +24,12 @@
                         {% endif %}
                     </p>
                     <p>
-                        {% blocktrans %}
+                        {% blocktrans trimmed %}
                             If you just want to add pages to an existing site, create them as children of the homepage instead.
                         {% endblocktrans %}
                     </p>
                 {% else %}
-                    {% blocktrans %}
+                    {% blocktrans trimmed %}
                         Pages created here will not be accessible at any URL. To add pages to an existing site, create them as children of the homepage.
                     {% endblocktrans %}
                 {% endif %}
@@ -38,14 +38,14 @@
             <tr><td colspan="6"><div class="help-block help-warning">
                 {% if perms.wagtailcore.add_site %}
                     {% url 'wagtailsites:index' as wagtailsites_index_url %}
-                    {% blocktrans %}
+                    {% blocktrans trimmed %}
                         There is no site set up for this location. Pages created here will not be accessible at any URL until a site is associated with this location.
                     {% endblocktrans %}
                     {% if wagtailsites_index_url %}
                         <a href="{{ wagtailsites_index_url }}">{% trans "Configure a site now." %}</a>
                     {% endif %}
                 {% else %}
-                    {% blocktrans %}
+                    {% blocktrans trimmed %}
                         There is no site record for this location. Pages created here will not be accessible at any URL.
                     {% endblocktrans %}
                 {% endif %}

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_pagination.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_pagination.html
@@ -5,9 +5,11 @@ Pagination for page listings. Used by the `{% paginate %}` template tag.
 {% endcomment %}
 
 <nav class="pagination" aria-label="{% trans 'Pagination' %}">
-    <p>{% blocktrans with page_number=page.number num_pages=paginator.num_pages %}
-        Page {{ page_number }} of {{ num_pages }}.
-    {% endblocktrans %}</p>
+    <p>
+        {% blocktrans trimmed with page_number=page.number num_pages=paginator.num_pages %}
+            Page {{ page_number }} of {{ num_pages }}.
+        {% endblocktrans %}
+    </p>
     <ul>
         <li class="prev">
             {% if page.has_previous %}

--- a/wagtail/admin/templates/wagtailadmin/pages/preview_error.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/preview_error.html
@@ -9,7 +9,7 @@
     </header>
     <div class="nice-padding">
         <p>
-            {% blocktrans %}
+            {% blocktrans trimmed %}
                 Impossible to preview this page, some errors are remaining.
                 Please close this tab, edit the page to fix these errors,
                 then use preview again.

--- a/wagtail/admin/templates/wagtailadmin/pages/revisions/compare.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/revisions/compare.html
@@ -43,13 +43,13 @@
                                             <div class="help-block help-info">
                                                 <p>
                                                     {% if move > 0 %}
-                                                        {% blocktrans count counter=move %}
+                                                        {% blocktrans trimmed count counter=move %}
                                                             Moved down 1 place.
                                                         {% plural %}
                                                             Moved down {{ counter }} places.
                                                         {% endblocktrans %}
                                                     {% elif move < 0 %}
-                                                        {% blocktrans count counter=move|abs %}
+                                                        {% blocktrans trimmed count counter=move|abs %}
                                                             Moved up 1 place.
                                                         {% plural %}
                                                             Moved up {{ counter }} places.

--- a/wagtail/admin/templates/wagtailadmin/pages/search_results.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/search_results.html
@@ -2,7 +2,7 @@
 <div class="nice-padding">
     {% if pages %}
         <h2>
-            {% blocktrans count counter=all_pages.count %}
+            {% blocktrans trimmed count counter=all_pages.count %}
                 There is one matching page
             {% plural %}
                 There are {{ counter }} matching pages

--- a/wagtail/admin/templates/wagtailadmin/skeleton.html
+++ b/wagtail/admin/templates/wagtailadmin/skeleton.html
@@ -23,7 +23,7 @@
         <p class="capabilitymessage">{% blocktrans %}You are using an <strong>outdated</strong> browser not supported by this software. Please <a href="http://browsehappy.com/">upgrade your browser</a>.{% endblocktrans %}</p>
     <![endif]-->
     <noscript class="capabilitymessage">
-        {% blocktrans %}
+        {% blocktrans trimmed %}
             Javascript is required to use Wagtail, but it is currently disabled.<br />
             Here are the <a href="http://www.enable-javascript.com/" target="_blank" rel="noopener noreferrer">instructions how to enable JavaScript in your web browser</a>.
         {% endblocktrans %}

--- a/wagtail/contrib/forms/templates/wagtailforms/confirm_delete.html
+++ b/wagtail/contrib/forms/templates/wagtailforms/confirm_delete.html
@@ -9,7 +9,7 @@
 
     <div class="nice-padding">
         <p>
-            {% blocktrans count counter=submissions.count %}
+            {% blocktrans trimmed count counter=submissions.count %}
                 Are you sure you want to delete this form submission?
             {% plural %}
                 Are you sure you want to delete these form submissions?

--- a/wagtail/contrib/modeladmin/templates/modeladmin/index.html
+++ b/wagtail/contrib/modeladmin/templates/modeladmin/index.html
@@ -61,7 +61,7 @@
                                     {% else %}
                                         <p>{% blocktrans with view.verbose_name_plural as name %}No {{ name }} have been created yet.{% endblocktrans %}
                                         {% if user_can_create %}
-                                            {% blocktrans with view.create_url as url %}
+                                            {% blocktrans trimmed with view.create_url as url %}
                                                 Why not <a href="{{ url }}">add one</a>?
                                             {% endblocktrans %}
                                         {% endif %}</p>

--- a/wagtail/contrib/redirects/templates/wagtailredirects/results.html
+++ b/wagtail/contrib/redirects/templates/wagtailredirects/results.html
@@ -2,7 +2,7 @@
 {% if redirects %}
     {% if query_string %}
         <h2>
-        {% blocktrans count counter=redirects.paginator.count %}
+        {% blocktrans trimmed count counter=redirects.paginator.count %}
             There is {{ counter }} match
         {% plural %}
             There are {{ counter }} matches

--- a/wagtail/contrib/search_promotions/templates/wagtailsearchpromotions/add.html
+++ b/wagtail/contrib/search_promotions/templates/wagtailsearchpromotions/add.html
@@ -7,13 +7,16 @@
 
     <div class="nice-padding">
         <div class="help-block help-info">
-            {% blocktrans %}
-                <p>Promoted search results are a means of recommending specific pages that might not organically come high up in search results. E.g recommending your primary donation page to a user searching with the less common term "<em>giving</em>".</p>
-            {% endblocktrans %}
-
-            {% blocktrans %}
-                <p>The "Search term(s)/phrase" field below must contain the full and exact search for which you wish to provide recommended results, <em>including</em> any misspellings/user error. To help, you can choose from search terms that have been popular with users of your site.</p>
-            {% endblocktrans %}
+            <p>
+                {% blocktrans trimmed %}
+                    Promoted search results are a means of recommending specific pages that might not organically come high up in search results. E.g recommending your primary donation page to a user searching with the less common term "<em>giving</em>".
+                {% endblocktrans %}
+            </p>
+            <p>
+                {% blocktrans trimmed %}
+                    The "Search term(s)/phrase" field below must contain the full and exact search for which you wish to provide recommended results, <em>including</em> any misspellings/user error. To help, you can choose from search terms that have been popular with users of your site.
+                {% endblocktrans %}
+            </p>
         </div>
         <form action="{% url 'wagtailsearchpromotions:add' %}" method="POST" novalidate>
             {% csrf_token %}

--- a/wagtail/contrib/search_promotions/templates/wagtailsearchpromotions/results.html
+++ b/wagtail/contrib/search_promotions/templates/wagtailsearchpromotions/results.html
@@ -2,7 +2,7 @@
 {% if queries %}
     {% if is_searching %}
         <h2>
-        {% blocktrans count counter=queries|length %}
+        {% blocktrans trimmed count counter=queries|length %}
             There is {{ counter }} match
         {% plural %}
             There are {{ counter }} matches

--- a/wagtail/documents/templates/wagtaildocs/chooser/results.html
+++ b/wagtail/documents/templates/wagtaildocs/chooser/results.html
@@ -2,7 +2,7 @@
 {% if documents %}
     {% if is_searching %}
         <h2>
-        {% blocktrans count counter=documents.paginator.count %}
+        {% blocktrans trimmed count counter=documents.paginator.count %}
             There is {{ counter }} match
         {% plural %}
             There are {{ counter }} matches
@@ -27,8 +27,8 @@
         {% endif %}
         {% if uploadform %}
             {% url 'wagtaildocs:add_multiple' as wagtaildocs_add_document_url %}
-            {% blocktrans %}
-            Why not <a class="upload-one-now" href="{{ wagtaildocs_add_document_url }}">upload one now</a>?
+            {% blocktrans trimmed %}
+                Why not <a class="upload-one-now" href="{{ wagtaildocs_add_document_url }}">upload one now</a>?
             {% endblocktrans %}
         {% endif %}
         </p>

--- a/wagtail/documents/templates/wagtaildocs/documents/results.html
+++ b/wagtail/documents/templates/wagtaildocs/documents/results.html
@@ -2,7 +2,7 @@
 {% if documents %}
     {% if is_searching %}
         <h2>
-        {% blocktrans count counter=documents|length %}
+        {% blocktrans trimmed count counter=documents|length %}
             There is {{ counter }} match
         {% plural %}
             There are {{ counter }} matches

--- a/wagtail/documents/templates/wagtaildocs/homepage/site_summary_documents.html
+++ b/wagtail/documents/templates/wagtaildocs/homepage/site_summary_documents.html
@@ -2,7 +2,7 @@
 
 <li class="icon icon-doc-full-inverse">
     <a href="{% url 'wagtaildocs:index' %}">
-    {% blocktrans count counter=total_docs with total_docs|intcomma as total %}
+    {% blocktrans trimmed count counter=total_docs with total_docs|intcomma as total %}
         <span>{{ total }}</span> Document <span class="visuallyhidden">created in {{ site_name }}</span>
     {% plural %}
         <span>{{ total }}</span> Documents <span class="visuallyhidden">created in {{ site_name }}</span>

--- a/wagtail/images/templates/wagtailimages/chooser/results.html
+++ b/wagtail/images/templates/wagtailimages/chooser/results.html
@@ -3,7 +3,7 @@
 {% if images %}
     {% if is_searching %}
         <h2>
-        {% blocktrans count counter=images.paginator.count %}
+        {% blocktrans trimmed count counter=images.paginator.count %}
             There is {{ counter }} match
         {% plural %}
             There are {{ counter }} matches

--- a/wagtail/images/templates/wagtailimages/homepage/site_summary_images.html
+++ b/wagtail/images/templates/wagtailimages/homepage/site_summary_images.html
@@ -2,7 +2,7 @@
 
 <li class="icon icon-image">
     <a href="{% url 'wagtailimages:index' %}">
-    {% blocktrans count counter=total_images with total_images|intcomma as total %}
+    {% blocktrans trimmed count counter=total_images with total_images|intcomma as total %}
         <span>{{ total }}</span> Image <span class="visuallyhidden">created in {{ site_name }}</span>
     {% plural %}
         <span>{{ total }}</span> Images <span class="visuallyhidden">created in {{ site_name }}</span>

--- a/wagtail/images/templates/wagtailimages/images/results.html
+++ b/wagtail/images/templates/wagtailimages/images/results.html
@@ -3,7 +3,7 @@
 {% if images %}
     {% if is_searching %}
         <h2>
-        {% blocktrans count counter=images.paginator.count %}
+        {% blocktrans trimmed count counter=images.paginator.count %}
             There is {{ counter }} match
         {% plural %}
             There are {{ counter }} matches

--- a/wagtail/snippets/templates/wagtailsnippets/chooser/results.html
+++ b/wagtail/snippets/templates/wagtailsnippets/chooser/results.html
@@ -2,7 +2,7 @@
 {% if items %}
     {% if is_searching %}
         <h2>
-        {% blocktrans count counter=items.paginator.count %}
+        {% blocktrans trimmed count counter=items.paginator.count %}
             There is {{ counter }} match
         {% plural %}
             There are {{ counter }} matches

--- a/wagtail/snippets/templates/wagtailsnippets/snippets/results.html
+++ b/wagtail/snippets/templates/wagtailsnippets/snippets/results.html
@@ -2,7 +2,7 @@
 {% if items %}
     {% if is_searching %}
         <h2>
-        {% blocktrans count counter=items.paginator.count %}
+        {% blocktrans trimmed count counter=items.paginator.count %}
             There is {{ counter }} match
         {% plural %}
             There are {{ counter }} matches

--- a/wagtail/users/templates/wagtailusers/groups/confirm_delete.html
+++ b/wagtail/users/templates/wagtailusers/groups/confirm_delete.html
@@ -8,7 +8,7 @@
 
     <div class="nice-padding">
         <p>
-            {% blocktrans with group_name=group.name count group_user_count=group.user_set.count %}
+            {% blocktrans trimmed with group_name=group.name count group_user_count=group.user_set.count %}
                 The group '{{ group_name }}' has <strong>{{ group_user_count }}</strong> member.
             {% plural %}
                 The group '{{ group_name }}' has <strong>{{ group_user_count }}</strong> members.

--- a/wagtail/users/templates/wagtailusers/users/results.html
+++ b/wagtail/users/templates/wagtailusers/users/results.html
@@ -2,7 +2,7 @@
 {% if users %}
     {% if is_searching %}
         <h2>
-        {% blocktrans count counter=users|length %}
+        {% blocktrans trimmed count counter=users|length %}
             There is {{ counter }} match
         {% plural %}
             There are {{ counter }} matches


### PR DESCRIPTION
Wagtail templates contain many message ids that have redundant whitespace: Leading and trailing line breaks. This is caused by `{% blocktrans %}` blocks and gettext which _is_ whitespace significant.

Whitespace in msgid is annoying for translators since they have to match the whitespace in their msgstr.

<img width="449" alt="Screenshot 2019-10-17 at 23 50 45" src="https://user-images.githubusercontent.com/1969342/67050562-163c6f00-f139-11e9-80bd-4fa7044bf947.png">

In this PR I updated all blocktrans tags that cause redundant whitespace to use the `trimmed` argument. `{% blocktrans %}` => `{% blocktrans trimmed %}`

This change requires translations to be updated as wel. All that redundant whitespce needs to be deleted form the message strings. Since we value the translators efforts, I propose to only update Transifex nl_NL translations to see the impact. I hope Transifex does something smart, I hope it kan keep the msgid and msgstr together. I that is the case, updating the strings will not be hard. If the link between msgid an msgstr is lost we might not want to merge this PR.

Why nl_NL? I'm a translator and nl_NL is 100% translated. If the impact is too big we can revert the change.

I attached a diff of the English source po file. To illustrate the change in msgid
[django.po.diff.zip](https://github.com/wagtail/wagtail/files/3741448/django.po.diff.zip)

I did not include that source po file in this PR since running makemessages is part of the release process.

@gasman Is it possible to test this PR against Transifex for only the nl_NL translations?

* Do the tests still pass? YES
* Does the code comply with the style guide? YES
* For Python changes: Have you added tests to cover the new/fixed behaviour? N/A
* For front-end changes: Did you test on all of Wagtail’s supported browsers? N/A
* For new features: Has the documentation been updated accordingly? N?A
