### PR TITLE
Move flake8 config to setup.cfg

### DIFF
--- a/docs/contributing/python_guidelines.rst
+++ b/docs/contributing/python_guidelines.rst
@@ -5,7 +5,7 @@ PEP8
 ~~~~
 
 We ask that all Python contributions adhere to the `PEP8 <http://www.python.org/dev/peps/pep-0008/>`_ style guide, apart from the restriction on line length (E501) and some minor docstring-related issues.
-The list of PEP8 violations to ignore is in the ``tox.ini`` file, under the ``[flake8]`` header.
+The list of PEP8 violations to ignore is in the ``setup.cfg`` file, under the ``[flake8]`` header.
 You might want to configure the flake8 linter in your editor/IDE to use the configuration in this file.
 
 In addition, import lines should be sorted according to `isort <http://timothycrosley.github.io/isort/>`_ 4.2.5 rules. If you have installed Wagtail's testing dependencies (``pip install -e .[testing]``), you can check your code by running ``make lint``.

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,24 @@
 python-tag = py3
 
 [flake8]
-ignore = E501,E303,W503
+# D100: Missing docstring in public module
+# D101: Missing docstring in public class
+# D102: Missing docstring in public method
+# D103: Missing docstring in public function
+# D105: Missing docstring in magic method
+# D200: One-line docstring should fit on one line with quotes
+# D202: No blank lines allowed after function docstring
+# D204: 1 blank line required after docstring
+# D205: 1 blank line required between summary line and description
+# D209: Multi-line docstring closing quotes should be on a separate line
+# D400: First line should end with a period
+# D401: First line should be in imperative mood
+# E303: Too many blank lines
+# E501: Line too long
+# W503: line break before binary operator (superseded by W504 line break after binary operator)
+# N805: First argument of a method should be named 'self'
+# N806: Variable in function should be lowercase
+ignore = D100,D101,D102,D103,D105,D200,D202,D204,D205,D209,D400,D401,E303,E501,W503,N805,N806
 exclude = wagtail/project_template/*,wagtail/utils/l18n/*
 max-line-length = 120
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,26 +4,6 @@ usedevelop = True
 
 envlist = py{35,36,37}-dj{20,21,22,master}-{sqlite,postgres,mysql,mssql}-{elasticsearch7,elasticsearch6,elasticsearch5,elasticsearch2,noelasticsearch},
 
-[flake8]
-# D100: Missing docstring in public module
-# D101: Missing docstring in public class
-# D102: Missing docstring in public method
-# D103: Missing docstring in public function
-# D105: Missing docstring in magic method
-# D200: One-line docstring should fit on one line with quotes
-# D202: No blank lines allowed after function docstring
-# D204: 1 blank line required after docstring
-# D205: 1 blank line required between summary line and description
-# D209: Multi-line docstring cloasing quotes should be on a separate line
-# D400: First line should end with a period
-# D401: First line should be in imperative mood
-# E303: Too many blank lines
-# E501: Line too long
-# W503: line break before binary operator (superseded by W504 line break after binary operator)
-# N805: First argument of a method should be named 'self'
-# N806: Variable in function should be lowercase
-ignore = D100,D101,D102,D103,D105,D200,D202,D204,D205,D209,D400,D401,E303,E501,W503,N805,N806
-
 [testenv]
 install_command = pip install -e ".[testing]" -U {opts} {packages}
 commands =


### PR DESCRIPTION
flake8 config was moved once from tox.ini to setup.cfg in https://github.com/wagtail/wagtail/commit/b85c34016351141086db0ade3e2e81880a216c9f, but #3503 added flake8 section in tox.ini again.