### PR TITLE
Fix form submissions listing - header & page layout

### DIFF
--- a/wagtail/contrib/forms/templates/wagtailforms/index_submissions.html
+++ b/wagtail/contrib/forms/templates/wagtailforms/index_submissions.html
@@ -80,33 +80,34 @@
         });
     </script>
 {% endblock %}
+
 {% block content %}
     <header class="nice-padding">
         <form action="" method="get" novalidate>
-            <div class="row">
-                <div class="left">
-                    <div class="col header-title">
-                        <h1 class="icon icon-form">
+            <div class="row row-flush">
+                <div class="left col6 header-title">
+                    <h1 class="icon icon-form">
                         {% blocktrans with form_title=form_page.title|capfirst %}Form data <span>{{ form_title }}</span>{% endblocktrans %}
-                        </h1>
-                    </div>
-                    <div class="col search-bar">
-                        <ul class="fields row rowflush">
+                    </h1>
+                    <div class="search-bar">
+                        <ul class="fields row row-flush">
                             {% for field in select_date_form %}
                                 {% include "wagtailadmin/shared/field_as_li.html" with field=field field_classes="field-small" li_classes="col4" %}
                             {% endfor %}
-                            <li class="submit col2">
+                            <li class="submit col4">
                                 <button name="action" value="filter" class="button button-filter">{% trans 'Filter' %}</button>
                             </li>
                         </ul>
                     </div>
                 </div>
-                <div class="right">
+                <div class="right col5">
                     <div class="dropdown dropdown-button match-width">
-                        <a href="?export=xlsx" class="button bicolor icon icon-download">{% trans 'Download XLSX' %}</a>
-                       <div class="dropdown-toggle icon icon-arrow-down"></div>
+                        <a class="button bicolor icon icon-download" href="?export=xlsx" >{% trans 'Download XLSX' %}</a>
+                        <div class="dropdown-toggle icon icon-arrow-down"></div>
                         <ul>
-                            <li><a  class="button bicolor icon icon-download" href="?export=csv">{% trans 'Download CSV' %}</a></li>
+                            <li>
+                                <a class="button bicolor icon icon-download" href="?export=csv">{% trans 'Download CSV' %}</a>
+                            </li>
                         </ul>
                     </div>
                 </div>

--- a/wagtail/contrib/forms/templates/wagtailforms/list_submissions.html
+++ b/wagtail/contrib/forms/templates/wagtailforms/list_submissions.html
@@ -6,15 +6,16 @@
     <col />
     <thead>
         <tr>
-            <th colspan="{{ data_headings|length|add:1 }}">
-                <button class="button no" id="delete-submissions" style="visibility: hidden">{% trans "Delete selected submissions" %}</button>
+            <th>
+                <input type="checkbox" id="select-all" />
             </th>
-        </tr>
-        <tr>
-            <th><input type="checkbox" id="select-all" /></th>
             {% for heading in data_headings %}
                 <th id="{{ heading.name }}" class="{% if heading.order %}ordered {{ heading.order }}{% endif %}">
-                  {% if heading.order %}<a href="?order_by={% if heading.order == 'ascending' %}-{% endif %}{{ heading.name }}">{{ heading.label }}</a>{% else %}{{ heading.label }}{% endif %}
+                  {% if heading.order %}
+                    <a href="?order_by={% if heading.order == 'ascending' %}-{% endif %}{{ heading.name }}">{{ heading.label }}</a>
+                {% else %}
+                    {{ heading.label }}
+                {% endif %}
                 </th>
             {% endfor %}
         </tr>

--- a/wagtail/snippets/templates/wagtailsnippets/snippets/type_index.html
+++ b/wagtail/snippets/templates/wagtailsnippets/snippets/type_index.html
@@ -17,13 +17,12 @@
 {% endblock %}
 
 {% block content %}
-
     <header class="nice-padding">
         <div class="row row-flush">
             <div class="left col6 header-title">
                 <h1 class="icon icon-snippet">
-                {% blocktrans with snippet_type_name_plural=model_opts.verbose_name_plural|capfirst %}Snippets <span>{{ snippet_type_name_plural }}</span>{% endblocktrans %}</h1>
-
+                    {% blocktrans with snippet_type_name_plural=model_opts.verbose_name_plural|capfirst %}Snippets <span>{{ snippet_type_name_plural }}</span>{% endblocktrans %}
+                </h1>
                 {% if is_searchable %}
                     <form class="col search-form" action="{% url 'wagtailsnippets:list' model_opts.app_label model_opts.model_name %}" method="get" novalidate>
                         <ul class="fields">


### PR DESCRIPTION

Resolves #3759  - **form submissions listing looks ugly on screens with >=1280px.**

## Overview 
* Moved the 'delete' button to the header, this is what was causing the extra blank space between the top of the table and the header.
* The delete button appearing in the header is what the snippets listing does so I followed that layout as a guide.
* Uses the existing class names and row/col structure to get a much simpler layout/wrapping scenario.
* This is not perfect, when the delete/download button stack at some breakpoints there is no margin above them (but this is the same as snippets currently), plus the to/from date fields now fill up the available space (which again happens in snippets for the sometimes enabled search field).
* Overall, I feel this is much better without adding more complex styles or use of flexbox (which I know is on the roadmap in other style clean up tickets).

## Checklist

* Do the tests still pass? 👍 
* Does the code comply with the style guide? 👍 
* For Python changes: Have you added tests to cover the new/fixed behaviour? (N/A - just a small refactor of existing html structure in templates)
* For front-end changes: Did you test on all of Wagtail’s supported browsers?
  * Chrome 77 MacOS
  * Firefox 69 MacOS
* For new features: Has the documentation been updated accordingly? (N/A)

## Images

![forms_submissions_large_screen](https://user-images.githubusercontent.com/1396140/67144044-9f78b080-f2b5-11e9-899f-dcfa45a85854.png)
![form_submissions_small_screen](https://user-images.githubusercontent.com/1396140/67144045-9f78b080-f2b5-11e9-85a5-46893e498b6f.png)
