### PR TITLE
Ensure admin API always uses SessionAuthentication backend

### DIFF
--- a/wagtail/admin/api/endpoints.py
+++ b/wagtail/admin/api/endpoints.py
@@ -1,5 +1,7 @@
 from collections import OrderedDict
 
+from rest_framework.authentication import SessionAuthentication
+
 from wagtail.api.v2.endpoints import PagesAPIEndpoint
 from wagtail.api.v2.filters import (
     ChildOfFilter, DescendantOfFilter, FieldsFilter, ForExplorerFilter, OrderingFilter,
@@ -13,6 +15,7 @@ from .serializers import AdminPageSerializer
 
 class PagesAdminAPIEndpoint(PagesAPIEndpoint):
     base_serializer_class = AdminPageSerializer
+    authentication_classes = [SessionAuthentication]
 
     # Use unrestricted child_of/descendant_of filters
     # Add has_children filter

--- a/wagtail/tests/settings.py
+++ b/wagtail/tests/settings.py
@@ -220,3 +220,13 @@ WAGTAILADMIN_RICH_TEXT_EDITORS = {
         'WIDGET': 'wagtail.tests.testapp.rich_text.CustomRichTextArea'
     },
 }
+
+
+# Set a non-standard DEFAULT_AUTHENTICATION_CLASSES value, to verify that the
+# admin API still works with session-based auth regardless of this setting
+# (see https://github.com/wagtail/wagtail/issues/5585)
+REST_FRAMEWORK = {
+    'DEFAULT_AUTHENTICATION_CLASSES': [
+        'rest_framework.authentication.BasicAuthentication',
+    ]
+}


### PR DESCRIPTION
Fixes #5585 and (at least partly) #5628. I suggest that we backport this to 2.6.x (for a 2.6.3 bugfix release) and 2.7.x (for release candidate 2, along with a fix for #5632).

I would have preferred to test this with a new test with a suitable `@override_settings` decorator, but that doesn't work, presumably because DRF only checks that setting on application startup when constructing endpoints - so we have to take the slightly more ham-fisted approach and set it in `wagtail.tests.settings` (which, without the fix, breaks the existing tests `wagtail.admin.tests.api.test_pages.TestAdminPageListing.test_for_explorer_filter` and `wagtail.core.tests.test_page_permissions.TestPagePermission.test_explorable_pages_in_explorer`).