### PR TITLE
Fixed 2.6.3 date in Changelog

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -57,7 +57,7 @@ Changelog
  * Fix: Altering Django REST Framework's `DEFAULT_AUTHENTICATION_CLASSES` setting no longer breaks the page explorer menu and admin API (Matt Westcott)
 
 
-2.6.3 (22.01.2019)
+2.6.3 (22.10.2019)
 ~~~~~~~~~~~~~~~~~~
 
  * Fix: Altering Django REST Framework's `DEFAULT_AUTHENTICATION_CLASSES` setting no longer breaks the page explorer menu and admin API (Matt Westcott)

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -255,7 +255,7 @@ Contributors
 * Lucas Moeskops
 * Rob van der Linde
 * Paul Kamp
-* dwasyl
+* David Wasylciw
 * Eugene Morozov
 * Levi Adler
 * Edwar Baron


### PR DESCRIPTION
This PR only updates the Changelog release date for 2.6.3 (and subsequently the Contributors doc).