### PR TITLE
Added label 'URL' for external link

### DIFF
--- a/wagtail/admin/forms/choosers.py
+++ b/wagtail/admin/forms/choosers.py
@@ -1,6 +1,7 @@
 from django import forms
 from django.core import validators
 from django.forms.widgets import TextInput
+from django.utils.translation import ugettext_lazy as _
 
 
 class URLOrAbsolutePathValidator(validators.URLValidator):
@@ -26,7 +27,7 @@ class URLOrAbsolutePathField(forms.URLField):
 
 
 class ExternalLinkChooserForm(forms.Form):
-    url = URLOrAbsolutePathField(required=True, label="")
+    url = URLOrAbsolutePathField(required=True, label=_("URL"))
     link_text = forms.CharField(required=False)
 
 


### PR DESCRIPTION
Related to [Missing label for external link URL field](https://github.com/wagtail/wagtail/issues/5656) issue. Follow the steps stated in the issue to test it.

_The label had an empty string instead of the `"url"` one as it had in previous versions_

----
* Do the tests still pass? Yes
* Does the code comply with the style guide? Yes
* Tested on:
  * Chrome Version 71.0.3578.98 (Official Build) (64-bit)
  * Firefox Version 69.0.1 (64-bit)

