### PR TITLE
Add select_related to public_q query

### DIFF
--- a/wagtail/contrib/sitemaps/tests.py
+++ b/wagtail/contrib/sitemaps/tests.py
@@ -72,7 +72,7 @@ class TestSitemapGenerator(TestCase):
         req_protocol = request.scheme
 
         sitemap = Sitemap()
-        with self.assertNumQueries(18):
+        with self.assertNumQueries(17):
             urls = [url['location'] for url in sitemap.get_urls(1, django_site, req_protocol)]
 
         self.assertIn('http://localhost/', urls)  # Homepage
@@ -84,7 +84,7 @@ class TestSitemapGenerator(TestCase):
 
         sitemap = Sitemap(request)
 
-        with self.assertNumQueries(16):
+        with self.assertNumQueries(15):
             urls = [url['location'] for url in sitemap.get_urls(1, django_site, req_protocol)]
 
         self.assertIn('http://localhost/', urls)  # Homepage

--- a/wagtail/core/query.py
+++ b/wagtail/core/query.py
@@ -214,7 +214,7 @@ class PageQuerySet(SearchableQuerySetMixin, TreeQuerySet):
         from wagtail.core.models import PageViewRestriction
 
         q = Q()
-        for restriction in PageViewRestriction.objects.all():
+        for restriction in PageViewRestriction.objects.select_related('page').all():
             q &= ~self.descendant_of_q(restriction.page, inclusive=True)
         return q
 

--- a/wagtail/core/tests/test_page_queryset.py
+++ b/wagtail/core/tests/test_page_queryset.py
@@ -366,17 +366,18 @@ class TestPageQuerySet(TestCase):
         # Add PageViewRestriction to events_index
         PageViewRestriction.objects.create(page=events_index, password='hello')
 
-        # Get public pages
-        pages = Page.objects.public()
+        with self.assertNumQueries(4):
+            # Get public pages
+            pages = Page.objects.public()
 
-        # Check that the homepage is in the results
-        self.assertTrue(pages.filter(id=homepage.id).exists())
+            # Check that the homepage is in the results
+            self.assertTrue(pages.filter(id=homepage.id).exists())
 
-        # Check that the events index is not in the results
-        self.assertFalse(pages.filter(id=events_index.id).exists())
+            # Check that the events index is not in the results
+            self.assertFalse(pages.filter(id=events_index.id).exists())
 
-        # Check that the event is not in the results
-        self.assertFalse(pages.filter(id=event.id).exists())
+            # Check that the event is not in the results
+            self.assertFalse(pages.filter(id=event.id).exists())
 
     def test_not_public(self):
         events_index = Page.objects.get(url_path='/home/events/')
@@ -386,17 +387,18 @@ class TestPageQuerySet(TestCase):
         # Add PageViewRestriction to events_index
         PageViewRestriction.objects.create(page=events_index, password='hello')
 
-        # Get public pages
-        pages = Page.objects.not_public()
+        with self.assertNumQueries(4):
+            # Get public pages
+            pages = Page.objects.not_public()
 
-        # Check that the homepage is not in the results
-        self.assertFalse(pages.filter(id=homepage.id).exists())
+            # Check that the homepage is not in the results
+            self.assertFalse(pages.filter(id=homepage.id).exists())
 
-        # Check that the events index is in the results
-        self.assertTrue(pages.filter(id=events_index.id).exists())
+            # Check that the events index is in the results
+            self.assertTrue(pages.filter(id=events_index.id).exists())
 
-        # Check that the event is in the results
-        self.assertTrue(pages.filter(id=event.id).exists())
+            # Check that the event is in the results
+            self.assertTrue(pages.filter(id=event.id).exists())
 
     def test_merge_queries(self):
         type_q = Page.objects.type_q(EventPage)


### PR DESCRIPTION
Prevents *n*+1 query problem when getting a list of pages with view restrictions via `PageQuerySet.public()` or `PageQuerySet.not_public()`. Sites that contain a large number of pages with view restrictions will benefit from this.

---

* Do the tests still pass? Yes
* Does the code comply with the style guide? Yes
* For Python changes: Have you added tests to cover the new/fixed behaviour? Yes (only modified existing ones to include query counts)
