### PR TITLE
Fixed live=true on unpublish before delete

### DIFF
--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -436,7 +436,13 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
 
     def clean(self):
         super().clean()
-        if not Page._slug_is_available(self.slug, self.get_parent(), self):
+        parent = None
+        try:
+            parent = self.get_parent()
+        except Page.DoesNotExist:
+            pass
+
+        if not Page._slug_is_available(self.slug, parent, self):
             raise ValidationError({'slug': _("This slug is already in use")})
 
     @transaction.atomic

--- a/wagtail/core/signal_handlers.py
+++ b/wagtail/core/signal_handlers.py
@@ -21,7 +21,7 @@ def pre_delete_page_unpublish(sender, instance, **kwargs):
     # Make sure pages are unpublished before deleting
     if instance.live:
         # Don't bother to save, this page is just about to be deleted!
-        instance.unpublish(commit=False)
+        instance.unpublish()
 
 
 def post_delete_page_log_deletion(sender, instance, **kwargs):


### PR DESCRIPTION
Related to issue #5166 

_Removed the `commit=False` on the `pre_delete` handler. This caused the `delete_orphan_pages` command to fail because in the `clean` method is trying to get a parent (that does not have), so I added a `try/catch` for the `get_parent`_

Let me know if you think this is a good fix or any suggestions you have. Thanks!

----

* Do the tests still pass? Yes
* Does the code comply with the style guide? Yes