### PR TITLE
Create hook for wagtailuserbar items which needs page context #5590

### DIFF
--- a/docs/reference/hooks.rst
+++ b/docs/reference/hooks.rst
@@ -631,6 +631,39 @@ Hooks for customising the way users are directed through the process of creating
         return items.append( UserbarPuppyLinkItem() )
 
 
+.. _construct_wagtail_userbar_with_context:
+
+``construct_wagtail_userbar_with_context``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Works same as ``construct_wagtail_userbar`` but takes template context as third argument in hook function
+
+  .. code-block:: python
+  from django.views.generics import TemplateView
+  from wagtail.core import hooks
+
+  class SomeView(TemplateView):
+      ...
+      def get_context_data(self, **kwargs):
+          ctx = super().get_context_data()
+          ctx['puppy_link'] = "http://cuteoverload.com/tag/puppehs/"
+          return ctx
+
+  class UserbarPuppyLinkItemFromContext:
+
+        def __init__(context):
+            self.context = context
+
+        def render(self, request):
+            link = self.context.get('puppy_link')
+            return '<li><a href="' + link + '" ' \
+                + 'target="_parent" class="action icon icon-wagtail">Puppies!</a></li>'
+
+    @hooks.register('construct_wagtail_userbar_with_context')
+    def add_puppy_link_item(request, items, context):
+        return items.append( UserbarPuppyLinkItemFromContext(context) )
+
+
 Admin workflow
 --------------
 Hooks for customising the way admins are directed through the process of editing users.

--- a/docs/reference/hooks.rst
+++ b/docs/reference/hooks.rst
@@ -631,13 +631,7 @@ Hooks for customising the way users are directed through the process of creating
         return items.append( UserbarPuppyLinkItem() )
 
 
-.. _construct_wagtail_userbar_with_context:
-
-``construct_wagtail_userbar_with_context``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Works same as ``construct_wagtail_userbar`` but takes template context as third argument in hook function
-
+You also can use ``construct_wagtail_userbar`` with template context. You have to create hook function with named argument `context`
   .. code-block:: python
   from django.views.generics import TemplateView
   from wagtail.core import hooks
@@ -651,16 +645,20 @@ Works same as ``construct_wagtail_userbar`` but takes template context as third 
 
   class UserbarPuppyLinkItemFromContext:
 
-        def __init__(context):
+        def __init__(self, context):
             self.context = context
 
         def render(self, request):
             link = self.context.get('puppy_link')
-            return '<li><a href="' + link + '" ' \
-                + 'target="_parent" class="action icon icon-wagtail">Puppies!</a></li>'
+            if link:
+                return '<li><a href="' + link + '" ' \
+                           + 'target="_parent" class="action icon icon-wagtail">Puppies!</a></li>'
+            return ''
 
-    @hooks.register('construct_wagtail_userbar_with_context')
-    def add_puppy_link_item(request, items, context):
+    @hooks.register('construct_wagtail_userbar')
+    def add_puppy_link_item(request, items, context=None):
+        if not context:
+            context={}
         return items.append( UserbarPuppyLinkItemFromContext(context) )
 
 

--- a/wagtail/admin/templatetags/wagtailuserbar.py
+++ b/wagtail/admin/templatetags/wagtailuserbar.py
@@ -1,3 +1,6 @@
+from warnings import warn
+from wagtail.utils.deprecation import RemovedInWagtail210Warning
+
 from django import template
 from django.template.loader import render_to_string
 
@@ -86,6 +89,8 @@ def wagtailuserbar(context, position='bottom-right'):
         if utils.accepts_kwarg(fn, 'context'):
             fn(request, items, context)
         else:
+            warn("Your function for 'construct_wagtail_userbar' must accept the context of the template "
+                 "as third argument named 'context'", RemovedInWagtail210Warning)
             fn(request, items)
 
     # Render the items

--- a/wagtail/admin/templatetags/wagtailuserbar.py
+++ b/wagtail/admin/templatetags/wagtailuserbar.py
@@ -4,7 +4,7 @@ from django.template.loader import render_to_string
 from wagtail.admin.userbar import (
     AddPageItem, AdminItem, ApproveModerationEditPageItem, EditPageItem, ExplorePageItem,
     RejectModerationEditPageItem)
-from wagtail.core import hooks
+from wagtail.core import hooks, utils
 from wagtail.core.models import PAGE_TEMPLATE_VAR, Page, PageRevision
 
 # from django.contrib.auth.decorators import permission_required
@@ -81,10 +81,12 @@ def wagtailuserbar(context, position='bottom-right'):
         ]
 
     for fn in hooks.get_hooks('construct_wagtail_userbar'):
-        fn(request, items)
-
-    for fn in hooks.get_hooks('construct_wagtail_userbar_with_context'):
-        fn(request, items, context)
+        # magic for backward compatibility
+        # when hook functions didn't have template context in params
+        if utils.accepts_kwarg(fn, 'context'):
+            fn(request, items, context)
+        else:
+            fn(request, items)
 
     # Render the items
     rendered_items = [item.render(request) for item in items]

--- a/wagtail/admin/templatetags/wagtailuserbar.py
+++ b/wagtail/admin/templatetags/wagtailuserbar.py
@@ -1,5 +1,5 @@
 from warnings import warn
-from wagtail.utils.deprecation import RemovedInWagtail210Warning
+
 
 from django import template
 from django.template.loader import render_to_string
@@ -9,6 +9,7 @@ from wagtail.admin.userbar import (
     RejectModerationEditPageItem)
 from wagtail.core import hooks, utils
 from wagtail.core.models import PAGE_TEMPLATE_VAR, Page, PageRevision
+from wagtail.utils.deprecation import RemovedInWagtail210Warning
 
 # from django.contrib.auth.decorators import permission_required
 

--- a/wagtail/admin/templatetags/wagtailuserbar.py
+++ b/wagtail/admin/templatetags/wagtailuserbar.py
@@ -83,6 +83,9 @@ def wagtailuserbar(context, position='bottom-right'):
     for fn in hooks.get_hooks('construct_wagtail_userbar'):
         fn(request, items)
 
+    for fn in hooks.get_hooks('construct_wagtail_userbar_with_context'):
+        fn(request, items, context)
+
     # Render the items
     rendered_items = [item.render(request) for item in items]
 

--- a/wagtail/admin/views/userbar.py
+++ b/wagtail/admin/views/userbar.py
@@ -1,11 +1,13 @@
 from warnings import warn
+
 from django.contrib.auth.decorators import permission_required
 from django.shortcuts import render
-from wagtail.utils.deprecation import RemovedInWagtail210Warning
+
 from wagtail.admin.userbar import (
     AddPageItem, ApproveModerationEditPageItem, EditPageItem, RejectModerationEditPageItem)
 from wagtail.core import hooks, utils
 from wagtail.core.models import Page, PageRevision
+from wagtail.utils.deprecation import RemovedInWagtail210Warning
 
 
 @permission_required('wagtailadmin.access_admin', raise_exception=True)

--- a/wagtail/admin/views/userbar.py
+++ b/wagtail/admin/views/userbar.py
@@ -1,9 +1,10 @@
+from warnings import warn
 from django.contrib.auth.decorators import permission_required
 from django.shortcuts import render
-
+from wagtail.utils.deprecation import RemovedInWagtail210Warning
 from wagtail.admin.userbar import (
     AddPageItem, ApproveModerationEditPageItem, EditPageItem, RejectModerationEditPageItem)
-from wagtail.core import hooks
+from wagtail.core import hooks, utils
 from wagtail.core.models import Page, PageRevision
 
 
@@ -15,7 +16,12 @@ def for_frontend(request, page_id):
     ]
 
     for fn in hooks.get_hooks('construct_wagtail_userbar'):
-        fn(request, items)
+        if utils.accepts_kwarg(fn, 'context'):
+            fn(request, items, {})
+        else:
+            warn("Your function for 'construct_wagtail_userbar' must accept the context of the template "
+                 "as third argument named 'context'", RemovedInWagtail210Warning)
+            fn(request, items)
 
     # Render the items
     rendered_items = [item.render(request) for item in items]
@@ -39,7 +45,12 @@ def for_moderation(request, revision_id):
     ]
 
     for fn in hooks.get_hooks('construct_wagtail_userbar'):
-        fn(request, items)
+        if utils.accepts_kwarg(fn, 'context'):
+            fn(request, items, {})
+        else:
+            warn("Your function for 'construct_wagtail_userbar' must accept the context of the template "
+                 "as third argument named 'context'", RemovedInWagtail210Warning)
+            fn(request, items)
 
     # Render the items
     rendered_items = [item.render(request) for item in items]


### PR DESCRIPTION
At work I faced the need to customize wagtailuserbar by adding a link depending on the current page. By default, there is no way to find out which page I am on (we are talking about django view) without additional requests to the database, so I added a context to the function of adding an element. To maintain backward compatibility, I added an additional hook
