### PR TITLE
Implemented explorer admin API

### DIFF
--- a/client/src/api/admin.js
+++ b/client/src/api/admin.js
@@ -10,7 +10,7 @@ export const getPage = (id) => {
 };
 
 export const getPageChildren = (id, options = {}) => {
-  let url = `${ADMIN_API.PAGES}?child_of=${id}&for_explorer=1`;
+  let url = `${ADMIN_API.PAGES}?child_of=${id}`;
 
   if (options.fields) {
     url += `&fields=${global.encodeURIComponent(options.fields.join(','))}`;

--- a/client/src/api/admin.test.js
+++ b/client/src/api/admin.test.js
@@ -20,23 +20,23 @@ describe('admin API', () => {
   describe('getPageChildren', () => {
     it('works', () => {
       getPageChildren(3);
-      expect(client.get).toBeCalledWith(`${ADMIN_API.PAGES}?child_of=3&for_explorer=1`);
+      expect(client.get).toBeCalledWith(`${ADMIN_API.PAGES}?child_of=3`);
     });
 
     it('#fields', () => {
       getPageChildren(3, { fields: ['title', 'latest_revision_created_at'] });
       // eslint-disable-next-line max-len
-      expect(client.get).toBeCalledWith(`${ADMIN_API.PAGES}?child_of=3&for_explorer=1&fields=title%2Clatest_revision_created_at`);
+      expect(client.get).toBeCalledWith(`${ADMIN_API.PAGES}?child_of=3&fields=title%2Clatest_revision_created_at`);
     });
 
     it('#onlyWithChildren', () => {
       getPageChildren(3, { onlyWithChildren: true });
-      expect(client.get).toBeCalledWith(`${ADMIN_API.PAGES}?child_of=3&for_explorer=1&has_children=1`);
+      expect(client.get).toBeCalledWith(`${ADMIN_API.PAGES}?child_of=3&has_children=1`);
     });
 
     it('#offset', () => {
       getPageChildren(3, { offset: 5 });
-      expect(client.get).toBeCalledWith(`${ADMIN_API.PAGES}?child_of=3&for_explorer=1&offset=5`);
+      expect(client.get).toBeCalledWith(`${ADMIN_API.PAGES}?child_of=3&offset=5`);
     });
   });
 

--- a/client/src/components/Explorer/ExplorerToggle.js
+++ b/client/src/components/Explorer/ExplorerToggle.js
@@ -28,12 +28,12 @@ ExplorerToggle.propTypes = {
 const mapStateToProps = () => ({});
 
 const mapDispatchToProps = (dispatch) => ({
-  onToggle: (page) => dispatch(actions.toggleExplorer(page)),
+  onToggle: () => dispatch(actions.toggleExplorer('root')),
 });
 
 const mergeProps = (stateProps, dispatchProps, ownProps) => ({
   children: ownProps.children,
-  onToggle: dispatchProps.onToggle.bind(null, ownProps.startPage),
+  onToggle: dispatchProps.onToggle.bind(null),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps, mergeProps)(ExplorerToggle);

--- a/client/src/components/Explorer/__snapshots__/actions.test.js.snap
+++ b/client/src/components/Explorer/__snapshots__/actions.test.js.snap
@@ -56,13 +56,13 @@ exports[`actions toggleExplorer open at root 1`] = `
 Array [
   Object {
     "payload": Object {
-      "id": 1,
+      "id": "root",
     },
     "type": "OPEN_EXPLORER",
   },
   Object {
     "payload": Object {
-      "id": 1,
+      "id": "root",
     },
     "type": "GET_CHILDREN_START",
   },

--- a/client/src/components/Explorer/actions.js
+++ b/client/src/components/Explorer/actions.js
@@ -68,7 +68,7 @@ export function toggleExplorer(id) {
       }
 
       // We need to get the title of the starting page, only if it is not the site's root.
-      const isNotRoot = id !== 1;
+      const isNotRoot = id !== 'root';
       if (isNotRoot) {
         dispatch(getPage(id));
       }

--- a/client/src/components/Explorer/actions.test.js
+++ b/client/src/components/Explorer/actions.test.js
@@ -60,7 +60,7 @@ describe('actions', () => {
       const stub = Object.assign({}, stubState);
       stub.explorer.isVisible = false;
       const store = mockStore(stub);
-      store.dispatch(actions.toggleExplorer(1));
+      store.dispatch(actions.toggleExplorer('root'));
       expect(store.getActions()).toMatchSnapshot();
     });
   });

--- a/client/src/components/Explorer/index.js
+++ b/client/src/components/Explorer/index.js
@@ -34,11 +34,9 @@ const initExplorer = (explorerNode, toggleNode) => {
     window.__REDUX_DEVTOOLS_EXTENSION__ ? window.__REDUX_DEVTOOLS_EXTENSION__() : func => func
   ));
 
-  const startPage = parseInt(toggleNode.getAttribute('data-explorer-start-page'), 10);
-
   ReactDOM.render((
     <Provider store={store}>
-      <ExplorerToggle startPage={startPage}>{toggleNode.textContent}</ExplorerToggle>
+      <ExplorerToggle>{toggleNode.textContent}</ExplorerToggle>
     </Provider>
   ), toggleNode.parentNode);
 

--- a/wagtail/admin/api/filters.py
+++ b/wagtail/admin/api/filters.py
@@ -1,8 +1,6 @@
 from rest_framework.filters import BaseFilterBackend
 
 from wagtail.api.v2.utils import BadRequestError, parse_boolean
-from wagtail.core import hooks
-from wagtail.core.models import UserPagePermissionsProxy
 
 
 class HasChildrenFilter(BaseFilterBackend):
@@ -21,21 +19,5 @@ class HasChildrenFilter(BaseFilterBackend):
                 return queryset.filter(numchild__gt=0)
             else:
                 return queryset.filter(numchild=0)
-
-        return queryset
-
-
-class ForExplorerFilter(BaseFilterBackend):
-    def filter_queryset(self, request, queryset, view):
-        if request.GET.get('for_explorer'):
-            if not hasattr(queryset, '_filtered_by_child_of'):
-                raise BadRequestError("filtering by for_explorer without child_of is not supported")
-
-            parent_page = queryset._filtered_by_child_of
-            for hook in hooks.get_hooks('construct_explorer_page_queryset'):
-                queryset = hook(parent_page, queryset, request)
-
-            user_perms = UserPagePermissionsProxy(request.user)
-            queryset = queryset & user_perms.explorable_pages()
 
         return queryset

--- a/wagtail/admin/api/urls.py
+++ b/wagtail/admin/api/urls.py
@@ -3,7 +3,7 @@ from django.conf.urls import url
 from wagtail.api.v2.router import WagtailAPIRouter
 from wagtail.core import hooks
 
-from .views import PagesAdminAPIViewSet
+from .views import PagesAdminAPIViewSet, PagesForExplorerAdminAPIViewSet
 
 admin_api = WagtailAPIRouter('wagtailadmin_api')
 admin_api.register_endpoint('pages', PagesAdminAPIViewSet)
@@ -11,6 +11,10 @@ admin_api.register_endpoint('pages', PagesAdminAPIViewSet)
 for fn in hooks.get_hooks('construct_admin_api'):
     fn(admin_api)
 
+explorer_admin_api = WagtailAPIRouter('wagtailadmin_api_for_explorer')
+explorer_admin_api.register_endpoint('pages', PagesForExplorerAdminAPIViewSet)
+
 urlpatterns = [
     url(r'^main/', admin_api.urls),
+    url(r'^explorer/', explorer_admin_api.urls),
 ]

--- a/wagtail/admin/static_src/wagtailadmin/app/wagtailadmin.entry.js
+++ b/wagtail/admin/static_src/wagtailadmin/app/wagtailadmin.entry.js
@@ -28,7 +28,7 @@ window.wagtail.components = {
  */
 document.addEventListener('DOMContentLoaded', () => {
   const explorerNode = document.querySelector('[data-explorer-menu]');
-  const toggleNode = document.querySelector('[data-explorer-start-page]');
+  const toggleNode = document.querySelector('[data-explorer-toggle]');
 
   if (explorerNode && toggleNode) {
     initExplorer(explorerNode, toggleNode);

--- a/wagtail/admin/static_src/wagtailadmin/app/wagtailadmin.entry.test.js
+++ b/wagtail/admin/static_src/wagtailadmin/app/wagtailadmin.entry.test.js
@@ -22,7 +22,7 @@ describe('wagtailadmin.entry', () => {
   });
 
   it('init with DOM', () => {
-    document.body.innerHTML = '<div data-explorer-menu></div><div data-explorer-start-page></div>';
+    document.body.innerHTML = '<div data-explorer-menu></div><div data-explorer-toggle></div>';
     listener();
     expect(wagtail.initExplorer).toHaveBeenCalled();
   });

--- a/wagtail/admin/templates/wagtailadmin/admin_base.html
+++ b/wagtail/admin/templates/wagtailadmin/admin_base.html
@@ -19,7 +19,7 @@
         (function(document, window) {
             window.wagtailConfig = window.wagtailConfig || {};
             wagtailConfig.ADMIN_API = {
-                PAGES: '{% url "wagtailadmin_api:pages:listing" %}',
+                PAGES: '{% url "wagtailadmin_api_for_explorer:pages:listing" %}',
                 DOCUMENTS: '{% url "wagtailadmin_api:documents:listing" %}',
                 IMAGES: '{% url "wagtailadmin_api:images:listing" %}',
                 {# // Use this to add an extra query string on all API requests. #}

--- a/wagtail/admin/templates/wagtailadmin/shared/explorer_menu_item.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/explorer_menu_item.html
@@ -1,5 +1,3 @@
-{% if start_page_id %}
-    <li class="menu-item{% if active %} menu-active{% endif %}" data-explorer-menu-item>
-        <a href="{{ url }}" class="{{ classnames }}"{{ attr_string }} data-explorer-start-page="{{ start_page_id }}">{{ label }}</a>
-    </li>
-{% endif %}
+<li class="menu-item{% if active %} menu-active{% endif %}" data-explorer-menu-item>
+    <a href="{{ url }}" class="{{ classnames }}"{{ attr_string }} data-explorer-toggle>{{ label }}</a>
+</li>

--- a/wagtail/admin/tests/api/test_explorer_pages_api.py
+++ b/wagtail/admin/tests/api/test_explorer_pages_api.py
@@ -1,0 +1,51 @@
+import json
+from django.urls import reverse
+
+from wagtail.core.models import Page
+from wagtail.tests.testapp.models import SimplePage
+
+from .utils import AdminAPITestCase
+
+
+class TestExplorerPagesApi(AdminAPITestCase):
+
+    def get_response(self, **params):
+        return self.client.get(reverse('wagtailadmin_api_for_explorer:pages:listing'), params)
+
+    def get_page_id_list(self, content):
+        return [page['id'] for page in content['items']]
+
+    def make_simple_page(self, parent, title):
+        return parent.add_child(instance=SimplePage(title=title, content='Simple page'))
+
+    def test_filter(self):
+        movies = self.make_simple_page(Page.objects.get(pk=1), 'Movies')
+        visible_movies = [
+            self.make_simple_page(movies, 'The Way of the Dragon'),
+            self.make_simple_page(movies, 'Enter the Dragon'),
+            self.make_simple_page(movies, 'Dragons Forever'),
+        ]
+
+        # These will be filtered out
+        self.make_simple_page(movies, 'The Hidden Fortress')
+        self.make_simple_page(movies, 'Crouching Tiger, Hidden Dragon')
+        self.make_simple_page(movies, 'Crouching Tiger, Hidden Dragon: Sword of Destiny')
+
+        response = self.get_response(child_of=movies.pk)
+        content = json.loads(response.content.decode('UTF-8'))
+        page_id_list = self.get_page_id_list(content)
+        self.assertEqual(page_id_list, [page.pk for page in visible_movies])
+
+        # Now test with ?type= filter, so we can check that the filtering logic works with specific querysets
+        response = self.get_response(child_of=movies.pk, type='tests.SimplePage')
+        content = json.loads(response.content.decode('UTF-8'))
+        page_id_list = self.get_page_id_list(content)
+        self.assertEqual(page_id_list, [page.pk for page in visible_movies])
+
+    def test_no_child_of(self):
+        response = self.get_response()
+        self.assertEqual(response.status_code, 400)
+        content = json.loads(response.content.decode('UTF-8'))
+        self.assertEqual(content, {
+            'message': 'calling explorer API without child_of is not supported',
+        })

--- a/wagtail/admin/tests/api/test_pages.py
+++ b/wagtail/admin/tests/api/test_pages.py
@@ -8,7 +8,7 @@ from django.utils import timezone
 from wagtail.api.v2.tests.test_pages import TestPageDetail, TestPageListing
 from wagtail.core.models import Page
 from wagtail.tests.demosite import models
-from wagtail.tests.testapp.models import SimplePage, StreamPage
+from wagtail.tests.testapp.models import StreamPage
 
 from .utils import AdminAPITestCase
 
@@ -296,42 +296,6 @@ class TestAdminPageListing(AdminAPITestCase, TestPageListing):
         json.loads(response.content.decode('UTF-8'))
 
         self.assertEqual(response.status_code, 200)
-
-    # FOR EXPLORER FILTER
-
-    def make_simple_page(self, parent, title):
-        return parent.add_child(instance=SimplePage(title=title, content='Simple page'))
-
-    def test_for_explorer_filter(self):
-        movies = self.make_simple_page(Page.objects.get(pk=1), 'Movies')
-        visible_movies = [
-            self.make_simple_page(movies, 'The Way of the Dragon'),
-            self.make_simple_page(movies, 'Enter the Dragon'),
-            self.make_simple_page(movies, 'Dragons Forever'),
-        ]
-        hidden_movies = [
-            self.make_simple_page(movies, 'The Hidden Fortress'),
-            self.make_simple_page(movies, 'Crouching Tiger, Hidden Dragon'),
-            self.make_simple_page(movies, 'Crouching Tiger, Hidden Dragon: Sword of Destiny'),
-        ]
-
-        response = self.get_response(child_of=movies.pk, for_explorer=1)
-        content = json.loads(response.content.decode('UTF-8'))
-        page_id_list = self.get_page_id_list(content)
-        self.assertEqual(page_id_list, [page.pk for page in visible_movies])
-
-        response = self.get_response(child_of=movies.pk)
-        content = json.loads(response.content.decode('UTF-8'))
-        page_id_list = self.get_page_id_list(content)
-        self.assertEqual(page_id_list, [page.pk for page in visible_movies + hidden_movies])
-
-    def test_for_explorer_no_child_of(self):
-        response = self.get_response(for_explorer=1)
-        self.assertEqual(response.status_code, 400)
-        content = json.loads(response.content.decode('UTF-8'))
-        self.assertEqual(content, {
-            'message': 'filtering by for_explorer without child_of is not supported',
-        })
 
     # HAS CHILDREN FILTER
 

--- a/wagtail/admin/tests/tests.py
+++ b/wagtail/admin/tests/tests.py
@@ -41,10 +41,10 @@ class TestHome(TestCase, WagtailTestUtils):
             '<a href="http://www.tomroyal.com/teaandkittens/" class="icon icon-kitten" data-fluffy="yes">Kittens!</a>'
         )
 
-        # Check that the explorer menu item is here, with the right start page.
+        # Check that the explorer menu item is here
         self.assertContains(
             response,
-            'data-explorer-start-page="1"'
+            'data-explorer-toggle'
         )
 
         # check that is_shown is respected on menu items

--- a/wagtail/admin/wagtail_hooks.py
+++ b/wagtail/admin/wagtail_hooks.py
@@ -8,7 +8,6 @@ import wagtail.admin.rich_text.editors.draftail.features as draftail_features
 from wagtail.admin.auth import user_has_any_page_permission
 from wagtail.admin.localization import get_available_admin_languages, get_available_admin_time_zones
 from wagtail.admin.menu import MenuItem, SubmenuMenuItem, settings_menu
-from wagtail.admin.navigation import get_explorable_root_page
 from wagtail.admin.rich_text import (
     HalloFormatPlugin, HalloHeadingPlugin, HalloListPlugin, HalloPlugin)
 from wagtail.admin.rich_text.converters.contentstate import link_entity
@@ -33,15 +32,6 @@ class ExplorerMenuItem(MenuItem):
 
     def is_shown(self, request):
         return user_has_any_page_permission(request.user)
-
-    def get_context(self, request):
-        context = super().get_context(request)
-        start_page = get_explorable_root_page(request.user)
-
-        if start_page:
-            context['start_page_id'] = start_page.id
-
-        return context
 
 
 @hooks.register('register_admin_menu_item')

--- a/wagtail/core/tests/test_page_permissions.py
+++ b/wagtail/core/tests/test_page_permissions.py
@@ -1,8 +1,6 @@
-import json
-
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group
-from django.test import Client, TestCase
+from django.test import TestCase
 
 from wagtail.core.models import GroupPagePermission, Page, UserPagePermissionsProxy
 from wagtail.tests.testapp.models import (
@@ -342,23 +340,6 @@ class TestPagePermission(TestCase):
 
         # Verify page outside /events/ tree are not explorable
         self.assertFalse(explorable_pages.filter(id=about_us_page.id).exists())
-
-    def test_explorable_pages_in_explorer(self):
-        event_editor = get_user_model().objects.get(username='eventeditor')
-
-        client = Client()
-        client.force_login(event_editor)
-
-        homepage = Page.objects.get(url_path='/home/')
-        explorer_response = client.get('/admin/api/main/pages/?child_of={}&for_explorer=1'.format(homepage.pk))
-        explorer_json = json.loads(explorer_response.content.decode('utf-8'))
-
-        events_page = Page.objects.get(url_path='/home/events/')
-        about_us_page = Page.objects.get(url_path='/home/about-us/')
-
-        explorable_titles = [t.get('title') for t in explorer_json.get('items')]
-        self.assertIn(events_page.title, explorable_titles)
-        self.assertNotIn(about_us_page.title, explorable_titles)
 
     def test_explorable_pages_with_permission_gap_in_hierarchy(self):
         corporate_editor = get_user_model().objects.get(username='corporateeditor')


### PR DESCRIPTION
This PR adds a separate instance of the admin API for the explorer menu (replacing the ``&for_explorer=1`` filter. Having a separate instance allows us to customise the API for this component in a neater way (we can also customise which page gets the special ID `root`, for example).

In a future PR, I'd like to make it easy for developers to create new instances of the Admin API which they could use to customise the explorer, choosers, search, etc (when we have all these in React).

This is based on my previous admin API refactoring PR: https://github.com/wagtail/wagtail/pull/5677
Which itself is based on https://github.com/wagtail/wagtail/pull/5676