### PR TITLE
Reference the third party embedly package requirement

### DIFF
--- a/docs/advanced_topics/embeds.rst
+++ b/docs/advanced_topics/embeds.rst
@@ -204,8 +204,10 @@ and a common video playback API which is useful if your site allows videos to
 be hosted on different providers and you need to implement custom controls for
 them.
 
-Wagtail has built in support for fetching embeds from Embed.ly.  To use it, add
-an embed finder to your ``WAGTAILEMBEDS_FINDERS`` setting that uses the
+Wagtail has built in support for fetching embeds from Embed.ly. To use it,
+first pip install the ``Embedly`` `python package <https://pypi.org/project/Embedly/>`_.
+
+Now add an embed finder to your ``WAGTAILEMBEDS_FINDERS`` setting that uses the
 ``wagtail.embeds.finders.oembed`` class and pass it your API key:
 
 .. code-block:: python


### PR DESCRIPTION
> Wagtail has built in support for fetching embeds from Embed.ly

But there is a third party dependence on embedly's own maintained python package.

I have added a reference to installing this to the documentation. 

I was not sure at what level this should be described, eg whether to detail `pip install embedly`, or to add to the project's `requirements.txt`.

I could not see any other examples, so to be brief, and because this is in the *advanced topics* I just specified to _pip_ install (intended to disambiguate against adding to INSTALLED_APPS).