### PR TITLE
Compare foreign keys using pk, not id

### DIFF
--- a/wagtail/admin/compare.py
+++ b/wagtail/admin/compare.py
@@ -288,8 +288,8 @@ class TagsFieldComparison(M2MFieldComparison):
 class ForeignObjectComparison(FieldComparison):
     def get_objects(self):
         model = self.field.related_model
-        obj_a = model.objects.filter(id=self.val_a).first()
-        obj_b = model.objects.filter(id=self.val_b).first()
+        obj_a = model.objects.filter(pk=self.val_a).first()
+        obj_b = model.objects.filter(pk=self.val_b).first()
         return obj_a, obj_b
 
     def htmldiff(self):


### PR DESCRIPTION
Trying to compare revisions of a page that includes changes to a foreign key field of a related model that declared a custom primary key failed with an uncaught exception.

The root cause was `ForeignObjectComparison` filtering by the `id` field, which is not present in models that declare a custom primary key.

The solution is simply to filter by `pk` instead of `id`, which always maps to the primary key of the corresponding model.

Include a regression unit test.

Fixes #5678.