### PR TITLE
Adds mark_safe to the render_form method of StructBlock

### DIFF
--- a/wagtail/core/blocks/struct_block.py
+++ b/wagtail/core/blocks/struct_block.py
@@ -6,6 +6,7 @@ from django.forms.utils import ErrorList
 from django.template.loader import render_to_string
 from django.utils.functional import cached_property
 from django.utils.html import format_html, format_html_join
+from django.utils.safestring import mark_safe
 
 from wagtail.admin.staticfiles import versioned_static
 
@@ -106,7 +107,7 @@ class BaseStructBlock(Block):
     def render_form(self, value, prefix='', errors=None):
         context = self.get_form_context(value, prefix=prefix, errors=errors)
 
-        return render_to_string(self.meta.form_template, context)
+        return mark_safe(render_to_string(self.meta.form_template, context))
 
     def value_from_datadict(self, data, files, prefix):
         return self._to_struct_value([

--- a/wagtail/core/tests/test_blocks.py
+++ b/wagtail/core/tests/test_blocks.py
@@ -1216,16 +1216,12 @@ class TestStructBlock(SimpleTestCase):
         self.assertNotIn('<li class="required">', html)
 
     def test_custom_render_form_template(self):
-        engine = engines['django']
-
-        template = engine.from_string('<div>Hello</div>').template
-
         class LinkBlock(blocks.StructBlock):
             title = blocks.CharBlock(required=False)
             link = blocks.URLBlock(required=False)
 
             class Meta:
-                form_template = template
+                form_template = 'tests/block_forms/struct_block_form_template.html'
 
         block = LinkBlock()
         html = block.render_form(block.to_python({
@@ -1238,16 +1234,12 @@ class TestStructBlock(SimpleTestCase):
         self.assertTrue(isinstance(html, SafeText))
 
     def test_custom_render_form_template_jinja(self):
-        engine = engines['jinja2']
-
-        template = engine.from_string('<div>Hello</div>').template
-
         class LinkBlock(blocks.StructBlock):
             title = blocks.CharBlock(required=False)
             link = blocks.URLBlock(required=False)
 
             class Meta:
-                form_template = template
+                form_template = 'tests/jinja2/struct_block_form_template.html'
 
         block = LinkBlock()
         html = block.render_form(block.to_python({

--- a/wagtail/core/tests/test_blocks.py
+++ b/wagtail/core/tests/test_blocks.py
@@ -10,7 +10,6 @@ from decimal import Decimal
 from django import forms
 from django.core.exceptions import ValidationError
 from django.forms.utils import ErrorList
-from django.template import engines
 from django.template.loader import render_to_string
 from django.test import SimpleTestCase, TestCase
 from django.utils.html import format_html

--- a/wagtail/tests/testapp/jinja2_templates/tests/jinja2/struct_block_form_template.html
+++ b/wagtail/tests/testapp/jinja2_templates/tests/jinja2/struct_block_form_template.html
@@ -1,0 +1,1 @@
+<div>Hello</div>

--- a/wagtail/tests/testapp/templates/tests/block_forms/struct_block_form_template.html
+++ b/wagtail/tests/testapp/templates/tests/block_forms/struct_block_form_template.html
@@ -1,0 +1,1 @@
+<div>Hello</div>


### PR DESCRIPTION
# What this does
Addresses: https://github.com/wagtail/wagtail/issues/5686

Adds `mark_safe` around the `render_form` method of the struct block. 

Jinja2 doesn't seem to return "safe" html, and instead is returning a string of the content, when it really should just be returning the HTML.

