### PR TITLE
Suppress warning when adding valid `tag_id` filter search field to the index

### DIFF
--- a/wagtail/search/index.py
+++ b/wagtail/search/index.py
@@ -112,6 +112,10 @@ class Indexed:
         for field in cls.get_search_fields():
             message = "{model}.search_fields contains non-existent field '{name}'"
             if not cls._has_field(field.field_name):
+                # Special case for tag_id field
+                from taggit.models import TaggedItemBase
+                if field.field_name == 'tag_id' and any(issubclass(obj.related_model, TaggedItemBase) for obj in cls._meta.related_objects):
+                    continue
                 errors.append(
                     checks.Warning(
                         message.format(model=cls.__name__, name=field.field_name),


### PR DESCRIPTION
<img width="835" alt="Screen Shot 2019-11-11 at 3 30 36 PM" src="https://user-images.githubusercontent.com/22062601/68629325-3a6d4080-0498-11ea-99d0-1ea3a3fdcc1e.png">


I've been getting this warning, but everything seems to be configured correctly as far as I can tell. I have posted some info about my setup at this stack overflow question.

https://stackoverflow.com/questions/58758924/wagtail-postgresql-search-backend-shows-warning-mymodel-search-fields-contains

This PR just makes the warning go away, based on this particular case. I'm sure there is probably a better way to handle this, so if anyone has any suggestions would be awesome.

Thanks!