### PR TITLE
Add possibility to filter image index by tag.

### DIFF
--- a/client/scss/components/_button.scss
+++ b/client/scss/components/_button.scss
@@ -106,7 +106,7 @@
     }
 
     &.bicolor {
-        border: 0;
+        border: 1px solid transparent;
         padding-left: 3.5em;
 
         &:before {
@@ -122,6 +122,10 @@
             display: block;
             border-top-left-radius: inherit;
             border-bottom-left-radius: inherit;
+        }
+
+        &.button-secondary {
+            border: 1px solid rgba(0, 0, 0, 0.2);
         }
     }
 
@@ -230,10 +234,6 @@
         background-color: $color-white;
         border-color: $color-grey-3;
         color: $color-grey-3;
-    }
-
-    &:not(:disabled):not(.disabled).active {
-        background-color: $color-button-active;
     }
 
     &.button-nostroke {

--- a/client/scss/components/_button.scss
+++ b/client/scss/components/_button.scss
@@ -232,6 +232,10 @@
         color: $color-grey-3;
     }
 
+    &:not(:disabled):not(.disabled).active {
+        background-color: $color-button-active;
+    }
+
     &.button-nostroke {
         border: 0;
     }

--- a/client/scss/components/_tag.scss
+++ b/client/scss/components/_tag.scss
@@ -29,9 +29,32 @@ a.tag:hover {
 .taglist {
     font-size: 0.9em;
     line-height: 2.4em;
+}
 
-    h3 {
-        display: inline;
-        margin-right: 1em;
+.tagfilter {
+    legend {
+        @include visuallyvisible;
+
+        @include media-breakpoint-up(sm) {
+            @include column(2);
+            padding-left: 0;
+        }
+
+        font-weight: 700;
+        color: #333;
+        font-size: 1.1em;
+        display: block;
+    }
+
+    a {
+        font-size: 0.9em;
+    }
+
+    .button.bicolor.icon-cross {
+        padding-left: 2em;
+
+        &:before {
+            background-color: transparent;
+        }
     }
 }

--- a/client/scss/settings/_variables.scss
+++ b/client/scss/settings/_variables.scss
@@ -64,7 +64,6 @@ $color-input-error-bg: lighten(saturate($color-red, 28), 45);
 
 $color-button: $color-teal;
 $color-button-hover: $color-teal-darker;
-$color-button-active: $color-teal-dark;
 $color-button-yes: $color-green-dark;
 $color-button-yes-hover: darken($color-button-yes, 8%);
 $color-button-no: $color-red-dark;

--- a/client/scss/settings/_variables.scss
+++ b/client/scss/settings/_variables.scss
@@ -64,6 +64,7 @@ $color-input-error-bg: lighten(saturate($color-red, 28), 45);
 
 $color-button: $color-teal;
 $color-button-hover: $color-teal-darker;
+$color-button-active: $color-teal-dark;
 $color-button-yes: $color-green-dark;
 $color-button-yes-hover: darken($color-button-yes, 8%);
 $color-button-no: $color-red-dark;

--- a/client/scss/tools/_mixins.general.scss
+++ b/client/scss/tools/_mixins.general.scss
@@ -81,10 +81,10 @@
 
 
 @mixin visuallyvisible {
-    clip: none;
+    clip: auto;
     height: auto;
     width: auto;
-    margin: auto;
+    margin: initial;
     overflow: visible;
     position: initial;
 }

--- a/wagtail/images/templates/wagtailimages/images/index.html
+++ b/wagtail/images/templates/wagtailimages/images/index.html
@@ -41,18 +41,20 @@
                     {% endif %}
                 {% endif %}
                 {% if popular_tags %}
-                <li class="taglist">
-                    <h3>{% trans 'Popular tags' %}</h3>
-                    {% for tag in popular_tags %}
-                        {% if tag.name != current_tag %}
-                            <a class="button button-small bicolor icon icon-tag" href="{% url 'wagtailimages:index' %}{% querystring tag=tag.name %}">{{ tag.name }}</a>
-                        {% else %}
-                            <a class="button button-small bicolor icon icon-tag active" href="{% url 'wagtailimages:index' %}{% querystring tag=tag.name %}">{{ tag.name }}</a>
-                        {% endif %}
-                    {% endfor %}
-                    {% if current_tag %}
-                        <a class="button button-small button-secondary" href="{% url 'wagtailimages:index' %}{% querystring tag='' %}">{% trans 'Clear choice' %}</a>
-                    {% endif %}
+                <li>
+                    <fieldset class="tagfilter">
+                    <legend>{% trans 'Popular Tags:' %}</legend>
+                      {% for tag in popular_tags %}
+                          {% if tag.name != current_tag %}
+                              <a class="button button-small button-secondary bicolor icon icon-tag" href="{% url 'wagtailimages:index' %}{% querystring tag=tag.name %}">{{ tag.name }}</a>
+                          {% else %}
+                              <a class="button button-small bicolor icon icon-tag" href="{% url 'wagtailimages:index' %}{% querystring tag=tag.name %}">{{ tag.name }}</a>
+                          {% endif %}
+                      {% endfor %}
+                      {% if current_tag %}
+                          <a class="button button-small bicolor button-secondary icon icon-cross" href="{% url 'wagtailimages:index' %}{% querystring tag='' %}">{% trans 'Clear choice' %}</a>
+                      {% endif %}
+                    </fieldset>
                 </li>
                 {% endif %}
             </ul>

--- a/wagtail/images/templates/wagtailimages/images/index.html
+++ b/wagtail/images/templates/wagtailimages/images/index.html
@@ -1,4 +1,5 @@
 {% extends "wagtailadmin/base.html" %}
+{% load wagtailadmin_tags %}
 {% load wagtailimages_tags %}
 {% load i18n %}
 
@@ -31,13 +32,31 @@
     {% endif %}
 
     <div class="nice-padding">
-        {% if collections %}
-            <form class="image-search search-bar" action="{% url 'wagtailimages:index' %}" method="GET" novalidate>
-                <ul class="fields">
+        <form class="image-search search-bar" action="{% url 'wagtailimages:index' %}" method="GET" novalidate>
+            <ul class="fields">
+                {% if collections %}
                     {% include "wagtailadmin/shared/collection_chooser.html" %}
-                </ul>
-            </form>
-        {% endif %}
+                    {% if current_tag %}
+                        <input type="hidden" name="tag" value="{{ current_tag }}" />
+                    {% endif %}
+                {% endif %}
+                {% if popular_tags %}
+                <li class="taglist">
+                    <h3>{% trans 'Popular tags' %}</h3>
+                    {% for tag in popular_tags %}
+                        {% if tag.name != current_tag %}
+                            <a class="button button-small bicolor icon icon-tag" href="{% url 'wagtailimages:index' %}{% querystring tag=tag.name %}">{{ tag.name }}</a>
+                        {% else %}
+                            <a class="button button-small bicolor icon icon-tag active" href="{% url 'wagtailimages:index' %}{% querystring tag=tag.name %}">{{ tag.name }}</a>
+                        {% endif %}
+                    {% endfor %}
+                    {% if current_tag %}
+                        <a class="button button-small button-secondary" href="{% url 'wagtailimages:index' %}{% querystring tag='' %}">{% trans 'Clear choice' %}</a>
+                    {% endif %}
+                </li>
+                {% endif %}
+            </ul>
+        </form>
 
         <div id="image-results">
             {% include "wagtailimages/images/results.html" %}

--- a/wagtail/images/views/images.py
+++ b/wagtail/images/views/images.py
@@ -62,7 +62,10 @@ def index(request):
     # Filter by tag
     current_tag = request.GET.get('tag')
     if current_tag:
-        images = images.filter(tags__name=current_tag)
+        try:
+            images = images.filter(tags__name=current_tag)
+        except (AttributeError):
+            current_tag = None
 
     paginator = Paginator(images, per_page=INDEX_PAGE_SIZE)
     images = paginator.get_page(request.GET.get('p'))

--- a/wagtail/images/views/images.py
+++ b/wagtail/images/views/images.py
@@ -59,6 +59,11 @@ def index(request):
         except (ValueError, Collection.DoesNotExist):
             pass
 
+    # Filter by tag
+    current_tag = request.GET.get('tag')
+    if current_tag:
+        images = images.filter(tags__name=current_tag)
+
     paginator = Paginator(images, per_page=INDEX_PAGE_SIZE)
     images = paginator.get_page(request.GET.get('p'))
 
@@ -85,6 +90,7 @@ def index(request):
 
             'search_form': form,
             'popular_tags': popular_tags_for_model(Image),
+            'current_tag': current_tag,
             'collections': collections,
             'current_collection': current_collection,
             'user_can_add': permission_policy.user_has_permission(request.user, 'add'),


### PR DESCRIPTION
![screenshot](https://user-images.githubusercontent.com/671294/68677893-29d2ce00-055d-11ea-9932-2b77a11bdc2a.png)

I added the possibility to filter the images on the image index page by tag. A client has a lot of images and has problems to find them on the image page. This pull request helps to fix this issue.

To make clear, which tag is active, I added some extra CSS – a new class .active – to the button component.

If you're happy with this, I'd make the same changes for the document page.
(There is also a small bug in the chooser template – one is unable to disable the filtering on tags once clicked. I'd look into that too, but first I'd like to get some feedback on the UI)