### PR TITLE
Add missing block.super in extra_css/extra_js blocks in wagtailsettings, modeladmin templates

### DIFF
--- a/wagtail/contrib/modeladmin/templates/modeladmin/choose_parent.html
+++ b/wagtail/contrib/modeladmin/templates/modeladmin/choose_parent.html
@@ -4,6 +4,7 @@
 {% block titletag %}{{ view.get_meta_title }}{% endblock %}
 
 {% block extra_css %}
+    {{ block.super }}
     {% include "wagtailadmin/pages/_editor_css.html" %}
     {{ form.media.css }}
     <link rel="stylesheet" href="{% versioned_static 'wagtailmodeladmin/css/choose_parent_page.css' %}" type="text/css"/>
@@ -11,6 +12,7 @@
 {% endblock %}
 
 {% block extra_js %}
+    {{ block.super }}
     {% include "wagtailadmin/pages/_editor_js.html" %}
     {{ form.media.js }}
 {% endblock %}

--- a/wagtail/contrib/modeladmin/templates/modeladmin/create.html
+++ b/wagtail/contrib/modeladmin/templates/modeladmin/create.html
@@ -4,6 +4,8 @@
 {% block titletag %}{{ view.get_meta_title }}{% endblock %}
 
 {% block extra_css %}
+    {{ block.super }}
+
     {% include "wagtailadmin/pages/_editor_css.html" %}
     {{ edit_handler.form.media.css }}
 
@@ -11,6 +13,8 @@
 {% endblock %}
 
 {% block extra_js %}
+    {{ block.super }}
+
     {% include "wagtailadmin/pages/_editor_js.html" %}
     {{ edit_handler.form.media.js }}
     {{ edit_handler.html_declarations }}

--- a/wagtail/contrib/modeladmin/templates/modeladmin/index.html
+++ b/wagtail/contrib/modeladmin/templates/modeladmin/index.html
@@ -9,6 +9,7 @@
 {% endblock %}
 
 {% block extra_js %}
+    {{ block.super }}
     {{ view.media.js }}
 {% endblock %}
 

--- a/wagtail/contrib/modeladmin/templates/modeladmin/inspect.html
+++ b/wagtail/contrib/modeladmin/templates/modeladmin/inspect.html
@@ -4,11 +4,13 @@
 {% block titletag %}{{ view.get_meta_title }}{% endblock %}
 
 {% block extra_css %}
+    {{ block.super }}
     {{ view.media.css }}
     <link rel="stylesheet" href="{% versioned_static 'wagtailmodeladmin/css/breadcrumbs_page.css' %}" type="text/css"/>
 {% endblock %}
 
 {% block extra_js %}
+    {{ block.super }}
     {{ view.media.js }}
 {% endblock %}
 

--- a/wagtail/contrib/settings/templates/wagtailsettings/edit.html
+++ b/wagtail/contrib/settings/templates/wagtailsettings/edit.html
@@ -41,12 +41,14 @@
 
 {% endblock %}
 
-{% block extra_css %}
+{% block css %}
+    {{ block.super }}
     {% include "wagtailadmin/pages/_editor_css.html" %}
     {{ edit_handler.form.media.css }}
     {{ site_switcher.media.css }}
 {% endblock %}
-{% block extra_js %}
+{% block js %}
+    {{ block.super }}
     {% include "wagtailadmin/pages/_editor_js.html" %}
     {{ edit_handler.form.media.js }}
     {{ edit_handler.html_declarations }}

--- a/wagtail/contrib/settings/templates/wagtailsettings/edit.html
+++ b/wagtail/contrib/settings/templates/wagtailsettings/edit.html
@@ -41,13 +41,13 @@
 
 {% endblock %}
 
-{% block css %}
+{% block extra_css %}
     {{ block.super }}
     {% include "wagtailadmin/pages/_editor_css.html" %}
     {{ edit_handler.form.media.css }}
     {{ site_switcher.media.css }}
 {% endblock %}
-{% block js %}
+{% block extra_js %}
     {{ block.super }}
     {% include "wagtailadmin/pages/_editor_js.html" %}
     {{ edit_handler.form.media.js }}


### PR DESCRIPTION
This fixes a bug where custom styles and scripts provided in `extra_css` and `extra_js` template blocks from the user's project files aren't being applied/run in `wagtail.contrib.settings` edit pages.

In my Wagtail project, I extended the `wagtailadmin/admin_base.html` template to add my custom styles for the entire admin site like this:

```html
{% extends 'wagtailadmin/admin_base.html' %}

{% block extra_css %}
<!-- custom CSS styles go here -->
{% endblock %}

{% block extra_js %}
<!-- custom scripts go here -->
{% endblock %}
```

The [`wagtailsettings/edit.html`](https://github.com/wagtail/wagtail/blob/master/wagtail/contrib/settings/templates/wagtailsettings/edit.html#L44-L54) template overrides the above blocks, causing my styles/scripts to not show in the page's source.

---

* Do the tests still pass? yes
* Does the code comply with the style guide? yes
* For front-end changes: Did you test on all of Wagtail’s supported browsers? yes (Chrome 78, Firefox 70, Edge 18)
