### PR TITLE
Update links in docs to point at stable Django version

### DIFF
--- a/docs/advanced_topics/add_to_django_project.rst
+++ b/docs/advanced_topics/add_to_django_project.rst
@@ -298,7 +298,7 @@ These two files should reside in your project directory (``myproject/myproject/`
   MANAGERS = ADMINS
 
   # Default to dummy email backend. Configure dev/production/local backend
-  # as per https://docs.djangoproject.com/en/dev/topics/email/#email-backends
+  # as per https://docs.djangoproject.com/en/stable/topics/email/#email-backends
   EMAIL_BACKEND = 'django.core.mail.backends.dummy.EmailBackend'
 
   # Hosts/domain names that are valid for this site; required if DEBUG is False
@@ -314,7 +314,7 @@ These two files should reside in your project directory (``myproject/myproject/`
   # A sample logging configuration. The only tangible logging
   # performed by this configuration is to send an email to
   # the site admins on every HTTP 500 error when DEBUG=False.
-  # See https://docs.djangoproject.com/en/dev/topics/logging for
+  # See https://docs.djangoproject.com/en/stable/topics/logging for
   # more details on how to customize your logging configuration.
   LOGGING = {
       'version': 1,

--- a/docs/advanced_topics/customisation/custom_user_models.rst
+++ b/docs/advanced_topics/customisation/custom_user_models.rst
@@ -86,4 +86,4 @@ Add the wagtail settings to your project to reference the user form additions:
   WAGTAIL_USER_CUSTOM_FIELDS = ['country', 'status']
 
 
-.. _AUTH_USER_MODEL: https://docs.djangoproject.com/en/dev/topics/auth/customizing/#substituting-a-custom-user-model
+.. _AUTH_USER_MODEL: https://docs.djangoproject.com/en/stable/topics/auth/customizing/#substituting-a-custom-user-model

--- a/docs/advanced_topics/testing.rst
+++ b/docs/advanced_topics/testing.rst
@@ -162,5 +162,5 @@ Filling in the ``path`` / ``numchild`` / ``depth`` fields is necessary in order 
 
 The `Treebeard docs`_ might help in understanding how this works.
 
-.. _dumpdata: https://docs.djangoproject.com/en/2.0/ref/django-admin/#django-admin-dumpdata
+.. _dumpdata: https://docs.djangoproject.com/en/stable/ref/django-admin/#django-admin-dumpdata
 .. _Treebeard docs: https://django-treebeard.readthedocs.io/en/latest/mp_tree.html


### PR DESCRIPTION
Updated a few links in the docs that were previously linking to old or dev versions of the Django docs.