### PR TITLE
Chunk Cloudflare frontend cache purging to fit within API limits

### DIFF
--- a/wagtail/contrib/frontend_cache/tests.py
+++ b/wagtail/contrib/frontend_cache/tests.py
@@ -203,6 +203,9 @@ class MockCloudflareBackend(CloudflareBackend):
         pass
 
     def _purge_urls(self, urls):
+        if len(urls) > self.CHUNK_SIZE:
+            raise Exception("Cloudflare backend is not chunking requests as expected")
+
         PURGED_URLS.extend(urls)
 
 

--- a/wagtail/contrib/frontend_cache/tests.py
+++ b/wagtail/contrib/frontend_cache/tests.py
@@ -198,6 +198,14 @@ class MockBackend(BaseBackend):
         PURGED_URLS.append(url)
 
 
+class MockCloudflareBackend(CloudflareBackend):
+    def __init__(self, config):
+        pass
+
+    def _purge_urls(self, urls):
+        PURGED_URLS.extend(urls)
+
+
 @override_settings(WAGTAILFRONTENDCACHE={
     'varnish': {
         'BACKEND': 'wagtail.contrib.frontend_cache.tests.MockBackend',
@@ -236,6 +244,25 @@ class TestCachePurgingFunctions(TestCase):
         batch.purge()
 
         self.assertEqual(PURGED_URLS, ['http://localhost/events/', 'http://localhost/events/past/', 'http://localhost/foo'])
+
+
+@override_settings(WAGTAILFRONTENDCACHE={
+    'cloudflare': {
+        'BACKEND': 'wagtail.contrib.frontend_cache.tests.MockCloudflareBackend',
+    },
+})
+class TestCloudflareCachePurgingFunctions(TestCase):
+    def setUp(self):
+        # Reset PURGED_URLS to an empty list
+        PURGED_URLS[:] = []
+
+    def test_cloudflare_purge_batch_chunked(self):
+        batch = PurgeBatch()
+        urls = ['https://localhost/foo{}'.format(i) for i in range(1, 65)]
+        batch.add_urls(urls)
+        batch.purge()
+
+        self.assertCountEqual(PURGED_URLS, urls)
 
 
 @override_settings(WAGTAILFRONTENDCACHE={


### PR DESCRIPTION
This updates the Cloudflare frontend cache backend to chunk purge requests to clear 30 URLs at a time (as required by their API https://api.cloudflare.com/#zone-purge-files-by-url).

Expect there may be a performance hit if someone is doing a big batch purge while handling a request, but hopefully this is rare.

* Do the tests still pass? Yes
* Does the code comply with the style guide? Yes
* For Python changes: Have you added tests to cover the new/fixed behaviour? Yes
* For front-end changes: Did you test on all of Wagtail’s supported browsers? N/A
* For new features: Has the documentation been updated accordingly? N/A