### PR TITLE
Update admin views to consistently return a TemplateContext and ensure preferred language applies when rendering

### DIFF
--- a/wagtail/admin/auth.py
+++ b/wagtail/admin/auth.py
@@ -1,7 +1,6 @@
 from functools import wraps
 
 import l18n
-
 from django.contrib.auth import get_user_model
 from django.contrib.auth.views import redirect_to_login as auth_redirect_to_login
 from django.core.exceptions import PermissionDenied
@@ -9,7 +8,8 @@ from django.db.models import Q
 from django.shortcuts import redirect
 from django.urls import reverse
 from django.utils.timezone import activate as activate_tz
-from django.utils.translation import override, ugettext as _
+from django.utils.translation import ugettext as _
+from django.utils.translation import override
 
 from wagtail.admin import messages
 from wagtail.core.models import GroupPagePermission

--- a/wagtail/admin/auth.py
+++ b/wagtail/admin/auth.py
@@ -9,8 +9,7 @@ from django.db.models import Q
 from django.shortcuts import redirect
 from django.urls import reverse
 from django.utils.timezone import activate as activate_tz
-from django.utils.translation import ugettext as _
-from django.utils.translation import override
+from django.utils.translation import override, ugettext as _
 
 from wagtail.admin import messages
 from wagtail.core.models import GroupPagePermission
@@ -154,22 +153,25 @@ def require_admin_access(view_func):
         if user.is_anonymous:
             return reject_request(request)
 
-        if user.has_perms(['wagtailadmin.access_admin']):
-            preferred_language = None
-            if hasattr(user, 'wagtail_userprofile'):
-                preferred_language = user.wagtail_userprofile.get_preferred_language()
-                l18n.set_language(preferred_language)
-                time_zone = user.wagtail_userprofile.get_current_time_zone()
-                activate_tz(time_zone)
-            if preferred_language:
-                with override(preferred_language):
-                    return view_func(request, *args, **kwargs)
-            else:
-                return view_func(request, *args, **kwargs)
+        if not user.has_perm('wagtailadmin.access_admin'):
+            if not request.is_ajax():
+                messages.error(request, _('You do not have permission to access the admin'))
+            return reject_request(request)
 
-        if not request.is_ajax():
-            messages.error(request, _('You do not have permission to access the admin'))
-
-        return reject_request(request)
+        preferred_language = None
+        if hasattr(user, 'wagtail_userprofile'):
+            preferred_language = user.wagtail_userprofile.get_preferred_language()
+            l18n.set_language(preferred_language)
+            time_zone = user.wagtail_userprofile.get_current_time_zone()
+            activate_tz(time_zone)
+        if preferred_language:
+            with override(preferred_language):
+                response = view_func(request, *args, **kwargs)
+                # forcing rendering of reponse here so that
+                # language override applies
+                if hasattr(response, 'render'):
+                    return response.render()
+                return response
+        return view_func(request, *args, **kwargs)
 
     return decorated_view

--- a/wagtail/admin/views/account.py
+++ b/wagtail/admin/views/account.py
@@ -4,7 +4,8 @@ from django.contrib.auth import views as auth_views
 from django.contrib.auth import update_session_auth_hash
 from django.contrib.auth.forms import PasswordChangeForm
 from django.http import Http404
-from django.shortcuts import redirect, render
+from django.shortcuts import redirect
+from django.template.response import TemplateResponse
 from django.urls import reverse, reverse_lazy
 from django.utils.translation import ugettext as _
 from django.utils.translation import override
@@ -51,7 +52,7 @@ def account(request):
         if item:
             items.append(item)
 
-    return render(request, 'wagtailadmin/account/account.html', {
+    return TemplateResponse(request, 'wagtailadmin/account/account.html', {
         'items': items,
     })
 
@@ -77,7 +78,7 @@ def change_password(request):
     else:
         form = None
 
-    return render(request, 'wagtailadmin/account/change_password.html', {
+    return TemplateResponse(request, 'wagtailadmin/account/change_password.html', {
         'form': form,
         'can_change_password': can_change_password,
     })
@@ -96,7 +97,7 @@ def change_email(request):
     else:
         form = EmailForm(instance=request.user)
 
-    return render(request, 'wagtailadmin/account/change_email.html', {
+    return TemplateResponse(request, 'wagtailadmin/account/change_email.html', {
         'form': form,
     })
 
@@ -112,7 +113,7 @@ def change_name(request):
     else:
         form = NameForm(instance=request.user)
 
-    return render(request, 'wagtailadmin/account/change_name.html', {
+    return TemplateResponse(request, 'wagtailadmin/account/change_name.html', {
         'form': form,
     })
 
@@ -167,7 +168,7 @@ def notification_preferences(request):
     if not form.fields:
         return redirect('wagtailadmin_account')
 
-    return render(request, 'wagtailadmin/account/notification_preferences.html', {
+    return TemplateResponse(request, 'wagtailadmin/account/notification_preferences.html', {
         'form': form,
     })
 
@@ -186,7 +187,7 @@ def language_preferences(request):
     else:
         form = PreferredLanguageForm(instance=UserProfile.get_for_user(request.user))
 
-    return render(request, 'wagtailadmin/account/language_preferences.html', {
+    return TemplateResponse(request, 'wagtailadmin/account/language_preferences.html', {
         'form': form,
     })
 
@@ -202,7 +203,7 @@ def current_time_zone(request):
     else:
         form = CurrentTimeZoneForm(instance=UserProfile.get_for_user(request.user))
 
-    return render(request, 'wagtailadmin/account/current_time_zone.html', {
+    return TemplateResponse(request, 'wagtailadmin/account/current_time_zone.html', {
         'form': form,
     })
 
@@ -218,7 +219,7 @@ def change_avatar(request):
     else:
         form = AvatarPreferencesForm(instance=UserProfile.get_for_user(request.user))
 
-    return render(request, 'wagtailadmin/account/change_avatar.html', {'form': form})
+    return TemplateResponse(request, 'wagtailadmin/account/change_avatar.html', {'form': form})
 
 
 class LoginView(auth_views.LoginView):

--- a/wagtail/admin/views/chooser.py
+++ b/wagtail/admin/views/chooser.py
@@ -1,6 +1,7 @@
 from django.core.paginator import Paginator
 from django.http import Http404
-from django.shortcuts import get_object_or_404, render
+from django.shortcuts import get_object_or_404
+from django.template.response import TemplateResponse
 
 from wagtail.admin.forms.choosers import (
     AnchorLinkChooserForm, EmailLinkChooserForm, ExternalLinkChooserForm, PhoneLinkChooserForm)
@@ -179,7 +180,7 @@ def search(request, parent_page_id=None):
     for page in pages:
         page.can_choose = True
 
-    return render(
+    return TemplateResponse(
         request, 'wagtailadmin/chooser/_search_results.html',
         shared_context(request, {
             'searchform': search_form,

--- a/wagtail/admin/views/home.py
+++ b/wagtail/admin/views/home.py
@@ -4,8 +4,8 @@ from django.contrib.auth.decorators import permission_required
 from django.db import connection
 from django.db.models import Max
 from django.http import Http404
-from django.shortcuts import render
 from django.template.loader import render_to_string
+from django.template.response import TemplateResponse
 
 from wagtail.admin.navigation import get_site_for_user
 from wagtail.admin.site_summary import SiteSummaryPanel
@@ -103,7 +103,7 @@ def home(request):
 
     site_details = get_site_for_user(request.user)
 
-    return render(request, "wagtailadmin/home.html", {
+    return TemplateResponse(request, "wagtailadmin/home.html", {
         'root_page': site_details['root_page'],
         'root_site': site_details['root_site'],
         'site_name': site_details['site_name'],

--- a/wagtail/admin/views/pages.py
+++ b/wagtail/admin/views/pages.py
@@ -631,8 +631,7 @@ class PreviewOnEdit(View):
         return JsonResponse({'is_valid': form.is_valid()})
 
     def error_response(self, page):
-        return TemplateResponse(self.request, 'wagtailadmin/pages/preview_error.html',
-                      {'page': page})
+        return TemplateResponse(self.request, 'wagtailadmin/pages/preview_error.html', {'page': page})
 
     def get(self, request, *args, **kwargs):
         page = self.get_page()

--- a/wagtail/admin/views/pages.py
+++ b/wagtail/admin/views/pages.py
@@ -7,8 +7,9 @@ from django.db import transaction
 from django.db.models import Count
 from django.http import Http404, HttpResponse, JsonResponse
 from django.http.request import QueryDict
-from django.shortcuts import get_object_or_404, redirect, render
+from django.shortcuts import get_object_or_404, redirect
 from django.template.loader import render_to_string
+from django.template.response import TemplateResponse
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.http import is_safe_url, urlquote
@@ -120,7 +121,7 @@ def index(request, parent_page_id=None):
         paginator = Paginator(pages, per_page=50)
         pages = paginator.get_page(request.GET.get('p'))
 
-    return render(request, 'wagtailadmin/pages/index.html', {
+    return TemplateResponse(request, 'wagtailadmin/pages/index.html', {
         'parent_page': parent_page.specific,
         'ordering': ordering,
         'pagination_query_params': "ordering=%s" % ordering,
@@ -148,7 +149,7 @@ def add_subpage(request, parent_page_id):
         verbose_name, app_label, model_name = page_types[0]
         return redirect('wagtailadmin_pages:add', app_label, model_name, parent_page.id)
 
-    return render(request, 'wagtailadmin/pages/add_subpage.html', {
+    return TemplateResponse(request, 'wagtailadmin/pages/add_subpage.html', {
         'parent_page': parent_page,
         'page_types': page_types,
         'next': get_valid_next_url_from_request(request),
@@ -172,7 +173,7 @@ def content_type_use(request, content_type_app_name, content_type_model_name):
     paginator = Paginator(pages, per_page=10)
     pages = paginator.get_page(request.GET.get('p'))
 
-    return render(request, 'wagtailadmin/pages/content_type_use.html', {
+    return TemplateResponse(request, 'wagtailadmin/pages/content_type_use.html', {
         'pages': pages,
         'app_name': content_type_app_name,
         'content_type': content_type,
@@ -307,7 +308,7 @@ def create(request, content_type_app_name, content_type_model_name, parent_page_
 
     edit_handler = edit_handler.bind_to(form=form)
 
-    return render(request, 'wagtailadmin/pages/create.html', {
+    return TemplateResponse(request, 'wagtailadmin/pages/create.html', {
         'content_type': content_type,
         'page_class': page_class,
         'parent_page': parent_page,
@@ -533,7 +534,7 @@ def edit(request, page_id):
     else:
         page_for_status = page
 
-    return render(request, 'wagtailadmin/pages/edit.html', {
+    return TemplateResponse(request, 'wagtailadmin/pages/edit.html', {
         'page': page,
         'page_for_status': page_for_status,
         'content_type': content_type,
@@ -575,7 +576,7 @@ def delete(request, page_id):
                 return redirect(next_url)
             return redirect('wagtailadmin_explore', parent_id)
 
-    return render(request, 'wagtailadmin/pages/confirm_delete.html', {
+    return TemplateResponse(request, 'wagtailadmin/pages/confirm_delete.html', {
         'page': page,
         'descendant_count': page.get_descendant_count(),
         'next': next_url,
@@ -630,7 +631,7 @@ class PreviewOnEdit(View):
         return JsonResponse({'is_valid': form.is_valid()})
 
     def error_response(self, page):
-        return render(self.request, 'wagtailadmin/pages/preview_error.html',
+        return TemplateResponse(self.request, 'wagtailadmin/pages/preview_error.html',
                       {'page': page})
 
     def get(self, request, *args, **kwargs):
@@ -713,7 +714,7 @@ def unpublish(request, page_id):
             return redirect(next_url)
         return redirect('wagtailadmin_explore', page.get_parent().id)
 
-    return render(request, 'wagtailadmin/pages/confirm_unpublish.html', {
+    return TemplateResponse(request, 'wagtailadmin/pages/confirm_unpublish.html', {
         'page': page,
         'next': next_url,
         'live_descendant_count': page.get_descendants().live().count(),
@@ -750,7 +751,7 @@ def move_choose_destination(request, page_to_move_id, viewed_page_id=None):
     paginator = Paginator(child_pages, per_page=50)
     child_pages = paginator.get_page(request.GET.get('p'))
 
-    return render(request, 'wagtailadmin/pages/move_choose_destination.html', {
+    return TemplateResponse(request, 'wagtailadmin/pages/move_choose_destination.html', {
         'page_to_move': page_to_move,
         'viewed_page': viewed_page,
         'child_pages': child_pages,
@@ -791,7 +792,7 @@ def move_confirm(request, page_to_move_id, destination_id):
 
         return redirect('wagtailadmin_explore', destination.id)
 
-    return render(request, 'wagtailadmin/pages/confirm_move.html', {
+    return TemplateResponse(request, 'wagtailadmin/pages/confirm_move.html', {
         'page_to_move': page_to_move,
         'destination': destination,
     })
@@ -905,7 +906,7 @@ def copy(request, page_id):
                 return redirect(next_url)
             return redirect('wagtailadmin_explore', parent_page.id)
 
-    return render(request, 'wagtailadmin/pages/copy.html', {
+    return TemplateResponse(request, 'wagtailadmin/pages/copy.html', {
         'page': page,
         'form': form,
         'next': next_url,
@@ -976,7 +977,7 @@ def search(request):
     pages = paginator.get_page(request.GET.get('p'))
 
     if request.is_ajax():
-        return render(request, "wagtailadmin/pages/search_results.html", {
+        return TemplateResponse(request, "wagtailadmin/pages/search_results.html", {
             'pages': pages,
             'all_pages': all_pages,
             'query_string': q,
@@ -986,7 +987,7 @@ def search(request):
             'pagination_query_params': pagination_query_params.urlencode(),
         })
     else:
-        return render(request, "wagtailadmin/pages/search.html", {
+        return TemplateResponse(request, "wagtailadmin/pages/search.html", {
             'search_form': form,
             'pages': pages,
             'all_pages': all_pages,
@@ -1122,7 +1123,7 @@ def revisions_index(request, page_id):
     paginator = Paginator(revisions, per_page=20)
     revisions = paginator.get_page(request.GET.get('p'))
 
-    return render(request, 'wagtailadmin/pages/revisions/index.html', {
+    return TemplateResponse(request, 'wagtailadmin/pages/revisions/index.html', {
         'page': page,
         'ordering': ordering,
         'pagination_query_params': "ordering=%s" % ordering,
@@ -1159,7 +1160,7 @@ def revisions_revert(request, page_id, revision_id):
         }
     ))
 
-    return render(request, 'wagtailadmin/pages/edit.html', {
+    return TemplateResponse(request, 'wagtailadmin/pages/edit.html', {
         'page': page,
         'revision': revision,
         'is_revision': True,
@@ -1229,7 +1230,7 @@ def revisions_compare(request, page_id, revision_id_a, revision_id_b):
     comparison = [comp(revision_a, revision_b) for comp in comparison]
     comparison = [comp for comp in comparison if comp.has_changed()]
 
-    return render(request, 'wagtailadmin/pages/revisions/compare.html', {
+    return TemplateResponse(request, 'wagtailadmin/pages/revisions/compare.html', {
         'page': page,
         'revision_a_heading': revision_a_heading,
         'revision_a': revision_a,
@@ -1264,7 +1265,7 @@ def revisions_unschedule(request, page_id, revision_id):
             return redirect(next_url)
         return redirect('wagtailadmin_pages:revisions_index', page.id)
 
-    return render(request, 'wagtailadmin/pages/revisions/confirm_unschedule.html', {
+    return TemplateResponse(request, 'wagtailadmin/pages/revisions/confirm_unschedule.html', {
         'page': page,
         'revision': revision,
         'next': next_url,

--- a/wagtail/admin/views/userbar.py
+++ b/wagtail/admin/views/userbar.py
@@ -1,5 +1,5 @@
 from django.contrib.auth.decorators import permission_required
-from django.shortcuts import render
+from django.template.response import TemplateResponse
 
 from wagtail.admin.userbar import (
     AddPageItem, ApproveModerationEditPageItem, EditPageItem, RejectModerationEditPageItem)
@@ -24,7 +24,7 @@ def for_frontend(request, page_id):
     rendered_items = [item for item in rendered_items if item]
 
     # Render the edit bird
-    return render(request, 'wagtailadmin/userbar/base.html', {
+    return TemplateResponse(request, 'wagtailadmin/userbar/base.html', {
         'items': rendered_items,
     })
 
@@ -48,6 +48,6 @@ def for_moderation(request, revision_id):
     rendered_items = [item for item in rendered_items if item]
 
     # Render the edit bird
-    return render(request, 'wagtailadmin/userbar/base.html', {
+    return TemplateResponse(request, 'wagtailadmin/userbar/base.html', {
         'items': rendered_items,
     })

--- a/wagtail/contrib/forms/models.py
+++ b/wagtail/contrib/forms/models.py
@@ -3,7 +3,7 @@ import os
 
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db import models
-from django.shortcuts import render
+from django.template.response import TemplateResponse
 from django.utils.text import slugify
 from django.utils.translation import ugettext_lazy as _
 from unidecode import unidecode
@@ -210,7 +210,7 @@ class AbstractForm(Page):
         """
         context = self.get_context(request)
         context['form_submission'] = form_submission
-        return render(
+        return TemplateResponse(
             request,
             self.get_landing_page_template(request),
             context
@@ -238,7 +238,7 @@ class AbstractForm(Page):
 
         context = self.get_context(request)
         context['form'] = form
-        return render(
+        return TemplateResponse(
             request,
             self.get_template(request),
             context

--- a/wagtail/contrib/redirects/views.py
+++ b/wagtail/contrib/redirects/views.py
@@ -1,6 +1,7 @@
 from django.core.paginator import Paginator
 from django.db.models import Q
-from django.shortcuts import get_object_or_404, redirect, render
+from django.shortcuts import get_object_or_404, redirect
+from django.template.response import TemplateResponse
 from django.urls import reverse
 from django.utils.translation import ugettext as _
 from django.views.decorators.vary import vary_on_headers
@@ -41,13 +42,13 @@ def index(request):
 
     # Render template
     if request.is_ajax():
-        return render(request, "wagtailredirects/results.html", {
+        return TemplateResponse(request, "wagtailredirects/results.html", {
             'ordering': ordering,
             'redirects': redirects,
             'query_string': query_string,
         })
     else:
-        return render(request, "wagtailredirects/index.html", {
+        return TemplateResponse(request, "wagtailredirects/index.html", {
             'ordering': ordering,
             'redirects': redirects,
             'query_string': query_string,
@@ -80,7 +81,7 @@ def edit(request, redirect_id):
     else:
         form = RedirectForm(instance=theredirect)
 
-    return render(request, "wagtailredirects/edit.html", {
+    return TemplateResponse(request, "wagtailredirects/edit.html", {
         'redirect': theredirect,
         'form': form,
         'user_can_delete': permission_policy.user_has_permission(request.user, 'delete'),
@@ -101,7 +102,7 @@ def delete(request, redirect_id):
         messages.success(request, _("Redirect '{0}' deleted.").format(theredirect.title))
         return redirect('wagtailredirects:index')
 
-    return render(request, "wagtailredirects/confirm_delete.html", {
+    return TemplateResponse(request, "wagtailredirects/confirm_delete.html", {
         'redirect': theredirect,
     })
 
@@ -122,6 +123,6 @@ def add(request):
     else:
         form = RedirectForm()
 
-    return render(request, "wagtailredirects/add.html", {
+    return TemplateResponse(request, "wagtailredirects/add.html", {
         'form': form,
     })

--- a/wagtail/contrib/search_promotions/views.py
+++ b/wagtail/contrib/search_promotions/views.py
@@ -1,5 +1,6 @@
 from django.core.paginator import Paginator
-from django.shortcuts import get_object_or_404, redirect, render
+from django.shortcuts import get_object_or_404, redirect
+from django.template.response import TemplateResponse
 from django.urls import reverse
 from django.utils.translation import ugettext as _
 from django.views.decorators.vary import vary_on_headers
@@ -33,13 +34,13 @@ def index(request):
     queries = paginator.get_page(request.GET.get('p'))
 
     if request.is_ajax():
-        return render(request, "wagtailsearchpromotions/results.html", {
+        return TemplateResponse(request, "wagtailsearchpromotions/results.html", {
             'is_searching': is_searching,
             'queries': queries,
             'query_string': query_string,
         })
     else:
-        return render(request, 'wagtailsearchpromotions/index.html', {
+        return TemplateResponse(request, 'wagtailsearchpromotions/index.html', {
             'is_searching': is_searching,
             'queries': queries,
             'query_string': query_string,
@@ -98,7 +99,7 @@ def add(request):
         query_form = search_forms.QueryForm()
         searchpicks_formset = forms.SearchPromotionsFormSet()
 
-    return render(request, 'wagtailsearchpromotions/add.html', {
+    return TemplateResponse(request, 'wagtailsearchpromotions/add.html', {
         'query_form': query_form,
         'searchpicks_formset': searchpicks_formset,
         'form_media': query_form.media + searchpicks_formset.media,
@@ -136,7 +137,7 @@ def edit(request, query_id):
         query_form = search_forms.QueryForm(initial=dict(query_string=query.query_string))
         searchpicks_formset = forms.SearchPromotionsFormSet(instance=query)
 
-    return render(request, 'wagtailsearchpromotions/edit.html', {
+    return TemplateResponse(request, 'wagtailsearchpromotions/edit.html', {
         'query_form': query_form,
         'searchpicks_formset': searchpicks_formset,
         'query': query,
@@ -153,6 +154,6 @@ def delete(request, query_id):
         messages.success(request, _("Editor's picks deleted."))
         return redirect('wagtailsearchpromotions:index')
 
-    return render(request, 'wagtailsearchpromotions/confirm_delete.html', {
+    return TemplateResponse(request, 'wagtailsearchpromotions/confirm_delete.html', {
         'query': query,
     })

--- a/wagtail/contrib/settings/views.py
+++ b/wagtail/contrib/settings/views.py
@@ -3,6 +3,7 @@ from functools import lru_cache
 from django.core.exceptions import PermissionDenied
 from django.http import Http404
 from django.shortcuts import get_object_or_404, redirect, render
+from django.template.response import TemplateResponse
 from django.utils.text import capfirst
 from django.utils.translation import ugettext as _
 
@@ -88,7 +89,7 @@ def edit(request, app_name, model_name, site_pk):
     if Site.objects.count() > 1:
         site_switcher = SiteSwitchForm(site, model)
 
-    return render(request, 'wagtailsettings/edit.html', {
+    return TemplateResponse(request, 'wagtailsettings/edit.html', {
         'opts': model._meta,
         'setting_type_name': setting_type_name,
         'instance': instance,

--- a/wagtail/contrib/settings/views.py
+++ b/wagtail/contrib/settings/views.py
@@ -2,7 +2,7 @@ from functools import lru_cache
 
 from django.core.exceptions import PermissionDenied
 from django.http import Http404
-from django.shortcuts import get_object_or_404, redirect, render
+from django.shortcuts import get_object_or_404, redirect
 from django.template.response import TemplateResponse
 from django.utils.text import capfirst
 from django.utils.translation import ugettext as _

--- a/wagtail/contrib/styleguide/views.py
+++ b/wagtail/contrib/styleguide/views.py
@@ -1,6 +1,6 @@
 from django import forms
 from django.core.paginator import Paginator
-from django.shortcuts import render
+from django.template.response import TemplateResponse
 from django.utils.translation import ugettext as _
 
 from wagtail.admin import messages
@@ -71,7 +71,7 @@ def index(request):
     paginator = Paginator(list(range(100)), 10)
     page = paginator.page(2)
 
-    return render(request, 'wagtailstyleguide/base.html', {
+    return TemplateResponse(request, 'wagtailstyleguide/base.html', {
         'search_form': form,
         'example_form': example_form,
         'example_page': page,

--- a/wagtail/documents/views/chooser.py
+++ b/wagtail/documents/views/chooser.py
@@ -1,5 +1,6 @@
 from django.core.paginator import Paginator
-from django.shortcuts import get_object_or_404, render
+from django.shortcuts import get_object_or_404
+from django.template.response import TemplateResponse
 from django.urls import reverse
 from django.utils.translation import ugettext as _
 
@@ -78,7 +79,7 @@ def chooser(request):
         paginator = Paginator(documents, per_page=10)
         documents = paginator.get_page(request.GET.get('p'))
 
-        return render(request, "wagtaildocs/chooser/results.html", {
+        return TemplateResponse(request, "wagtaildocs/chooser/results.html", {
             'documents': documents,
             'documents_exist': documents_exist,
             'uploadform': uploadform,

--- a/wagtail/documents/views/documents.py
+++ b/wagtail/documents/views/documents.py
@@ -1,7 +1,8 @@
 import os
 
 from django.core.paginator import Paginator
-from django.shortcuts import get_object_or_404, redirect, render
+from django.shortcuts import get_object_or_404, redirect
+from django.template.response import TemplateResponse
 from django.urls import reverse
 from django.utils.translation import ugettext as _
 from django.views.decorators.vary import vary_on_headers
@@ -70,14 +71,14 @@ def index(request):
 
     # Create response
     if request.is_ajax():
-        return render(request, 'wagtaildocs/documents/results.html', {
+        return TemplateResponse(request, 'wagtaildocs/documents/results.html', {
             'ordering': ordering,
             'documents': documents,
             'query_string': query_string,
             'is_searching': bool(query_string),
         })
     else:
-        return render(request, 'wagtaildocs/documents/index.html', {
+        return TemplateResponse(request, 'wagtaildocs/documents/index.html', {
             'ordering': ordering,
             'documents': documents,
             'query_string': query_string,
@@ -121,7 +122,7 @@ def add(request):
     else:
         form = DocumentForm(user=request.user)
 
-    return render(request, "wagtaildocs/documents/add.html", {
+    return TemplateResponse(request, "wagtaildocs/documents/add.html", {
         'form': form,
     })
 
@@ -185,7 +186,7 @@ def edit(request, document_id):
                 buttons=[messages.button(reverse('wagtaildocs:delete', args=(doc.id,)), _('Delete'))]
             )
 
-    return render(request, "wagtaildocs/documents/edit.html", {
+    return TemplateResponse(request, "wagtaildocs/documents/edit.html", {
         'document': doc,
         'filesize': doc.get_file_size(),
         'form': form,
@@ -208,7 +209,7 @@ def delete(request, document_id):
         messages.success(request, _("Document '{0}' deleted.").format(doc.title))
         return redirect('wagtaildocs:index')
 
-    return render(request, "wagtaildocs/documents/confirm_delete.html", {
+    return TemplateResponse(request, "wagtaildocs/documents/confirm_delete.html", {
         'document': doc,
     })
 
@@ -220,7 +221,7 @@ def usage(request, document_id):
     paginator = Paginator(doc.get_usage(), per_page=20)
     used_by = paginator.get_page(request.GET.get('p'))
 
-    return render(request, "wagtaildocs/documents/usage.html", {
+    return TemplateResponse(request, "wagtaildocs/documents/usage.html", {
         'document': doc,
         'used_by': used_by
     })

--- a/wagtail/documents/views/multiple.py
+++ b/wagtail/documents/views/multiple.py
@@ -1,7 +1,8 @@
 from django.core.exceptions import PermissionDenied
 from django.http import HttpResponseBadRequest, JsonResponse
-from django.shortcuts import get_object_or_404, render
+from django.shortcuts import get_object_or_404
 from django.template.loader import render_to_string
+from django.template.response import TemplateResponse
 from django.utils.encoding import force_str
 from django.views.decorators.http import require_POST
 from django.views.decorators.vary import vary_on_headers
@@ -83,7 +84,7 @@ def add(request):
         # actual rendering of forms will happen on AJAX POST rather than here
         form = DocumentForm(user=request.user)
 
-        return render(request, 'wagtaildocs/multiple/add.html', {
+        return TemplateResponse(request, 'wagtaildocs/multiple/add.html', {
             'help_text': form.fields['file'].help_text,
             'collections': collections_to_choose,
             'form_media': form.media,

--- a/wagtail/images/views/chooser.py
+++ b/wagtail/images/views/chooser.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 from django.core.paginator import Paginator
-from django.shortcuts import get_object_or_404, render
+from django.shortcuts import get_object_or_404
+from django.template.response import TemplateResponse
 from django.urls import reverse
 from django.utils.translation import ugettext as _
 
@@ -112,7 +113,7 @@ def chooser(request):
         paginator = Paginator(images, per_page=CHOOSER_PAGE_SIZE)
         images = paginator.get_page(request.GET.get('p'))
 
-        return render(request, "wagtailimages/chooser/results.html", {
+        return TemplateResponse(request, "wagtailimages/chooser/results.html", {
             'images': images,
             'is_searching': is_searching,
             'query_string': q,

--- a/wagtail/images/views/images.py
+++ b/wagtail/images/views/images.py
@@ -3,7 +3,7 @@ import os
 from django.conf import settings
 from django.core.paginator import Paginator
 from django.http import HttpResponse, JsonResponse
-from django.shortcuts import get_object_or_404, redirect, render
+from django.shortcuts import get_object_or_404, redirect
 from django.template.response import TemplateResponse
 from django.urls import reverse
 from django.urls.exceptions import NoReverseMatch

--- a/wagtail/images/views/images.py
+++ b/wagtail/images/views/images.py
@@ -4,6 +4,7 @@ from django.conf import settings
 from django.core.paginator import Paginator
 from django.http import HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
+from django.template.response import TemplateResponse
 from django.urls import reverse
 from django.urls.exceptions import NoReverseMatch
 from django.utils.translation import ugettext as _
@@ -80,13 +81,13 @@ def index(request):
 
     # Create response
     if request.is_ajax():
-        return render(request, 'wagtailimages/images/results.html', {
+        return TemplateResponse(request, 'wagtailimages/images/results.html', {
             'images': images,
             'query_string': query_string,
             'is_searching': bool(query_string),
         })
     else:
-        return render(request, 'wagtailimages/images/index.html', {
+        return TemplateResponse(request, 'wagtailimages/images/index.html', {
             'images': images,
             'query_string': query_string,
             'is_searching': bool(query_string),
@@ -165,7 +166,7 @@ def edit(request, image_id):
     except SourceImageIOError:
         filesize = None
 
-    return render(request, "wagtailimages/images/edit.html", {
+    return TemplateResponse(request, "wagtailimages/images/edit.html", {
         'image': image,
         'form': form,
         'url_generator_enabled': url_generator_enabled,
@@ -188,7 +189,7 @@ def url_generator(request, image_id):
         'height': image.height,
     })
 
-    return render(request, "wagtailimages/images/url_generator.html", {
+    return TemplateResponse(request, "wagtailimages/images/url_generator.html", {
         'image': image,
         'form': form,
     })
@@ -258,7 +259,7 @@ def delete(request, image_id):
         messages.success(request, _("Image '{0}' deleted.").format(image.title))
         return redirect('wagtailimages:index')
 
-    return render(request, "wagtailimages/images/confirm_delete.html", {
+    return TemplateResponse(request, "wagtailimages/images/confirm_delete.html", {
         'image': image,
     })
 
@@ -294,7 +295,7 @@ def add(request):
     else:
         form = ImageForm(user=request.user)
 
-    return render(request, "wagtailimages/images/add.html", {
+    return TemplateResponse(request, "wagtailimages/images/add.html", {
         'form': form,
     })
 
@@ -305,7 +306,7 @@ def usage(request, image_id):
     paginator = Paginator(image.get_usage(), per_page=USAGE_PAGE_SIZE)
     used_by = paginator.get_page(request.GET.get('p'))
 
-    return render(request, "wagtailimages/images/usage.html", {
+    return TemplateResponse(request, "wagtailimages/images/usage.html", {
         'image': image,
         'used_by': used_by
     })

--- a/wagtail/images/views/multiple.py
+++ b/wagtail/images/views/multiple.py
@@ -1,7 +1,8 @@
 from django.core.exceptions import PermissionDenied
 from django.http import HttpResponseBadRequest, JsonResponse
-from django.shortcuts import get_object_or_404, render
+from django.shortcuts import get_object_or_404
 from django.template.loader import render_to_string
+from django.template.response import TemplateResponse
 from django.utils.encoding import force_str
 from django.views.decorators.http import require_POST
 from django.views.decorators.vary import vary_on_headers
@@ -97,7 +98,7 @@ def add(request):
         # actual rendering of forms will happen on AJAX POST rather than here
         form = ImageForm(user=request.user)
 
-        return render(request, 'wagtailimages/multiple/add.html', {
+        return TemplateResponse(request, 'wagtailimages/multiple/add.html', {
             'max_filesize': form.fields['file'].max_upload_size,
             'help_text': form.fields['file'].help_text,
             'allowed_extensions': ALLOWED_EXTENSIONS,

--- a/wagtail/project_template/search/views.py
+++ b/wagtail/project_template/search/views.py
@@ -1,5 +1,5 @@
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
-from django.shortcuts import render
+from django.template.response import TemplateResponse
 
 from wagtail.core.models import Page
 from wagtail.search.models import Query
@@ -28,7 +28,7 @@ def search(request):
     except EmptyPage:
         search_results = paginator.page(paginator.num_pages)
 
-    return render(request, 'search/search.html', {
+    return TemplateResponse(request, 'search/search.html', {
         'search_query': search_query,
         'search_results': search_results,
     })

--- a/wagtail/search/views/queries.py
+++ b/wagtail/search/views/queries.py
@@ -1,5 +1,5 @@
 from django.core.paginator import Paginator
-from django.shortcuts import render
+from django.template.response import TemplateResponse
 
 from wagtail.admin.forms.search import SearchForm
 from wagtail.admin.modal_workflow import render_modal_workflow
@@ -26,7 +26,7 @@ def chooser(request, get_results=False):
 
     # Render
     if get_results:
-        return render(request, "wagtailsearch/queries/chooser/results.html", {
+        return TemplateResponse(request, "wagtailsearch/queries/chooser/results.html", {
             'queries': queries,
         })
     else:

--- a/wagtail/snippets/views/chooser.py
+++ b/wagtail/snippets/views/chooser.py
@@ -1,6 +1,7 @@
 from django.contrib.admin.utils import quote, unquote
 from django.core.paginator import Paginator
-from django.shortcuts import get_object_or_404, render
+from django.shortcuts import get_object_or_404
+from django.template.response import TemplateResponse
 from django.urls import reverse
 from django.utils.translation import ugettext as _
 
@@ -48,7 +49,7 @@ def choose(request, app_label, model_name):
 
     # If paginating or searching, render "results.html"
     if request.GET.get('results', None) == 'true':
-        return render(request, "wagtailsnippets/chooser/results.html", {
+        return TemplateResponse(request, "wagtailsnippets/chooser/results.html", {
             'model_opts': model._meta,
             'items': paginated_items,
             'query_string': search_query,

--- a/wagtail/snippets/views/snippets.py
+++ b/wagtail/snippets/views/snippets.py
@@ -4,7 +4,8 @@ from django.apps import apps
 from django.contrib.admin.utils import quote, unquote
 from django.core.paginator import Paginator
 from django.http import Http404
-from django.shortcuts import get_object_or_404, redirect, render
+from django.shortcuts import get_object_or_404, redirect
+from django.template.response import TemplateResponse
 from django.urls import reverse
 from django.utils.text import capfirst
 from django.utils.translation import ugettext as _
@@ -61,7 +62,7 @@ def index(request):
     snippet_model_opts = [
         model._meta for model in get_snippet_models()
         if user_can_edit_snippet_type(request.user, model)]
-    return render(request, 'wagtailsnippets/snippets/index.html', {
+    return TemplateResponse(request, 'wagtailsnippets/snippets/index.html', {
         'snippet_model_opts': sorted(
             snippet_model_opts, key=lambda x: x.verbose_name.lower())})
 
@@ -113,7 +114,7 @@ def list(request, app_label, model_name):
     else:
         template = 'wagtailsnippets/snippets/type_index.html'
 
-    return render(request, template, {
+    return TemplateResponse(request, template, {
         'model_opts': model._meta,
         'items': paginated_items,
         'can_add_snippet': request.user.has_perm(get_permission_name('add', model)),
@@ -165,7 +166,7 @@ def create(request, app_label, model_name):
 
     edit_handler = edit_handler.bind_to(instance=instance, form=form)
 
-    return render(request, 'wagtailsnippets/snippets/create.html', {
+    return TemplateResponse(request, 'wagtailsnippets/snippets/create.html', {
         'model_opts': model._meta,
         'edit_handler': edit_handler,
         'form': form,
@@ -212,7 +213,7 @@ def edit(request, app_label, model_name, pk):
 
     edit_handler = edit_handler.bind_to(form=form)
 
-    return render(request, 'wagtailsnippets/snippets/edit.html', {
+    return TemplateResponse(request, 'wagtailsnippets/snippets/edit.html', {
         'model_opts': model._meta,
         'instance': instance,
         'edit_handler': edit_handler,
@@ -261,7 +262,7 @@ def delete(request, app_label, model_name, pk=None):
 
         return redirect('wagtailsnippets:list', app_label, model_name)
 
-    return render(request, 'wagtailsnippets/snippets/confirm_delete.html', {
+    return TemplateResponse(request, 'wagtailsnippets/snippets/confirm_delete.html', {
         'model_opts': model._meta,
         'count': count,
         'instances': instances,
@@ -279,7 +280,7 @@ def usage(request, app_label, model_name, pk):
     paginator = Paginator(instance.get_usage(), per_page=20)
     used_by = paginator.get_page(request.GET.get('p'))
 
-    return render(request, "wagtailsnippets/snippets/usage.html", {
+    return TemplateResponse(request, "wagtailsnippets/snippets/usage.html", {
         'instance': instance,
         'used_by': used_by
     })

--- a/wagtail/tests/testapp/models.py
+++ b/wagtail/tests/testapp/models.py
@@ -11,7 +11,8 @@ from django.core.exceptions import ValidationError
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db import models
-from django.shortcuts import redirect, render
+from django.shortcuts import redirect
+from django.template.response import TemplateResponse
 from modelcluster.contrib.taggit import ClusterTaggableManager
 from modelcluster.fields import ParentalKey, ParentalManyToManyField
 from modelcluster.models import ClusterableModel
@@ -585,7 +586,7 @@ class FormPageWithCustomSubmission(AbstractEmailForm):
 
     def serve(self, request, *args, **kwargs):
         if self.get_submission_class().objects.filter(page=self, user__pk=request.user.pk).exists():
-            return render(
+            return TemplateResponse(
                 request,
                 self.template,
                 self.get_context(request)

--- a/wagtail/users/views/users.py
+++ b/wagtail/users/views/users.py
@@ -2,7 +2,8 @@ from django.conf import settings
 from django.contrib.auth import get_user_model, update_session_auth_hash
 from django.core.paginator import Paginator
 from django.db.models import Q
-from django.shortcuts import get_object_or_404, redirect, render
+from django.shortcuts import get_object_or_404, redirect
+from django.template.response import TemplateResponse
 from django.urls import reverse
 from django.utils.translation import ugettext as _
 from django.views.decorators.vary import vary_on_headers
@@ -92,14 +93,14 @@ def index(request):
     users = paginator.get_page(request.GET.get('p'))
 
     if request.is_ajax():
-        return render(request, "wagtailusers/users/results.html", {
+        return TemplateResponse(request, "wagtailusers/users/results.html", {
             'users': users,
             'is_searching': is_searching,
             'query_string': q,
             'ordering': ordering,
         })
     else:
-        return render(request, "wagtailusers/users/index.html", {
+        return TemplateResponse(request, "wagtailusers/users/index.html", {
             'search_form': form,
             'users': users,
             'is_searching': is_searching,
@@ -131,7 +132,7 @@ def create(request):
     else:
         form = get_user_creation_form()()
 
-    return render(request, 'wagtailusers/users/create.html', {
+    return TemplateResponse(request, 'wagtailusers/users/create.html', {
         'form': form,
     })
 
@@ -168,7 +169,7 @@ def edit(request, user_id):
     else:
         form = get_user_edit_form()(instance=user, editing_self=editing_self)
 
-    return render(request, 'wagtailusers/users/edit.html', {
+    return TemplateResponse(request, 'wagtailusers/users/edit.html', {
         'user': user,
         'form': form,
         'can_delete': can_delete,
@@ -195,6 +196,6 @@ def delete(request, user_id):
                 return result
         return redirect('wagtailusers_users:index')
 
-    return render(request, "wagtailusers/users/confirm_delete.html", {
+    return TemplateResponse(request, "wagtailusers/users/confirm_delete.html", {
         'user': user,
     })


### PR DESCRIPTION
As explained [in the Django docs](https://docs.djangoproject.com/en/stable/ref/template-response/#the-rendering-process), when using `TemplateResponse`, the rendering of the template is delayed until necessary, and middleware and view decorators have the opportunity to make changes before rendering happens. 

Specifically, the [`process_template_response()`](https://docs.djangoproject.com/en/stable/topics/http/middleware/#process-template-response) method on custom middleware gets to do its thing (which doesn't happen when using the `render()` shortcut), giving developers an important and convenient hook to make certain types of customisation (that might otherwise require replacing entire function-based views or monkey-patching).

Most class-based views in Wagtail subclass Django's [`TemplateResponseMixin`](http://ccbv.co.uk/projects/Django/2.2/django.views.generic.base/TemplateResponseMixin/) somewhere along the line, and so  already return a `TemplateResponse` - So these changes also greatly improve consistency.

While implementing these changes, I also noticed an issue that seems not to have been reported yet: The `wagtail.auth.require_admin_access` decorator isn't working quite as expected in many cases: Specifically, where views return a `TemplateResponse`. Because template rendering is delayed, it happens _outside_ the `translation.override()` context manager, meaning the language is only active while view logic is run - the template itself is still rendered in the default language. I've fixed this here by invoking the response's `render()` method if it has one - which means the language override is fully applied.