### PR TITLE
Fix: Properly save ordering of nested InlinePanels

### DIFF
--- a/wagtail/admin/static_src/wagtailadmin/js/page-editor.js
+++ b/wagtail/admin/static_src/wagtailadmin/js/page-editor.js
@@ -38,13 +38,13 @@ function InlinePanel(opts) {
         if (opts.canOrder) {
             $('#' + prefix + '-move-up').on('click', function() {
                 var currentChild = $('#' + childId);
-                var currentChildOrderElem = currentChild.find('input[name$="-ORDER"]');
+                var currentChildOrderElem = currentChild.children('input[name$="-ORDER"]');
                 var currentChildOrder = currentChildOrderElem.val();
 
                 /* find the previous visible 'inline_child' li before this one */
                 var prevChild = currentChild.prevAll(':not(.deleted)').first();
                 if (!prevChild.length) return;
-                var prevChildOrderElem = prevChild.find('input[name$="-ORDER"]');
+                var prevChildOrderElem = prevChild.children('input[name$="-ORDER"]');
                 var prevChildOrder = prevChildOrderElem.val();
 
                 // async swap animation must run before the insertBefore line below, but doesn't need to finish first
@@ -59,13 +59,13 @@ function InlinePanel(opts) {
 
             $('#' + prefix + '-move-down').on('click', function() {
                 var currentChild = $('#' + childId);
-                var currentChildOrderElem = currentChild.find('input[name$="-ORDER"]');
+                var currentChildOrderElem = currentChild.children('input[name$="-ORDER"]');
                 var currentChildOrder = currentChildOrderElem.val();
 
                 /* find the next visible 'inline_child' li after this one */
                 var nextChild = currentChild.nextAll(':not(.deleted)').first();
                 if (!nextChild.length) return;
-                var nextChildOrderElem = nextChild.find('input[name$="-ORDER"]');
+                var nextChildOrderElem = nextChild.children('input[name$="-ORDER"]');
                 var nextChildOrder = nextChildOrderElem.val();
 
                 // async swap animation must run before the insertAfter line below, but doesn't need to finish first


### PR DESCRIPTION
The order of nested InlinePanels (recently formally added in #5566) doesn't get saved properly due to some now-invalid assumptions in the JS selector code.

Currently, Wagtail users can use the editor up/down arrows to order InlinePanel elements that contain child InlinePanels, but these may not be properly saved.

Before InlinePanel nesting was supported, it was a safer bet that a child panel would only contain one hidden input named `"-ORDER"`. With nesting, however, a parent panel will also contain hidden inputs named like this for its child panels. This breaks the logic used in the ordering code.

This change modifies the logic to use the jQuery [`.children()`](https://api.jquery.com/children/#children-selector) selector instead of `.next()`, ensuring that we reference the correct adjacent panel item.

An easy way to test this against current master is to use the Wagtail `testapp` test models that exercise this behavior:

1. `wagtail start testwagtail` to create a new project.
2. `cd testwagtail`
3. Edit testwagtail/settings/base.py to add the Wagtail test application `'wagtail.tests.testapp'` to the list of `INSTALLED_APPS`. For the admin to work properly with this app, you also need to add `'wagtail.contrib.settings'` to that list and copy the definition of `WAGTAILADMIN_RICH_TEXT_EDITORS` from [wagtail/tests/settings.py](https://github.com/wagtail/wagtail/blob/8238a338888258554ed6eae0e25eaf903a0a5831/wagtail/tests/settings.py#L212).
4. `./manage.py migrate` to create your local database.
5. `./manage.py createsuperuser` to create an admin user.
6. Create a [new Event Page](http://localhost:8000/admin/pages/add/tests/eventpage/3/).
7. Fill in all required items, and then add multiple speakers under "Speaker Lineup". For each speaker, add at least one Award. Save the page.
8. Try using the up/down arrows to reorder the speakers (the parent InlinePanel), and save the page.
9. Note that when the page reloads, the ordering hasn't been saved. If you debug using the developer tools, you'll notice that this is because the code being modified here selects the child panel items instead of the adjacent parent panel item.

Thanks to @Scotchester for pairing on this fix.

* Do the tests still pass? YES
* Does the code comply with the style guide? YES
* For Python changes: Have you added tests to cover the new/fixed behaviour? N/A
* For front-end changes: Did you test on all of Wagtail’s supported browsers? Chrome 78 
* For new features: Has the documentation been updated accordingly? N/A
