### PR TITLE
Move wagtail_urls to the end of template urls.py

### DIFF
--- a/wagtail/project_template/project_name/urls.py
+++ b/wagtail/project_template/project_name/urls.py
@@ -16,14 +16,6 @@ urlpatterns = [
 
     url(r'^search/$', search_views.search, name='search'),
 
-    # For anything not caught by a more specific rule above, hand over to
-    # Wagtail's page serving mechanism. This should be the last pattern in
-    # the list:
-    url(r'', include(wagtail_urls)),
-
-    # Alternatively, if you want Wagtail pages to be served from a subpath
-    # of your site, rather than the site root:
-    #    url(r'^pages/', include(wagtail_urls)),
 ]
 
 
@@ -34,3 +26,14 @@ if settings.DEBUG:
     # Serve static and media files from development server
     urlpatterns += staticfiles_urlpatterns()
     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+
+urlpatterns = urlpatterns + [
+    # For anything not caught by a more specific rule above, hand over to
+    # Wagtail's page serving mechanism. This should be the last pattern in
+    # the list:
+    url(r"", include(wagtail_urls)),
+
+    # Alternatively, if you want Wagtail pages to be served from a subpath
+    # of your site, rather than the site root:
+    #    url(r"^pages/", include(wagtail_urls)),
+]


### PR DESCRIPTION
The `wagtail_urls` patterns is a catch-all list of urlpatterns, and will
prevent any patterns later in the list from being matched. The default
case when Django is in debug mode for local development is to use
`django-admin.py runserver`, and in this case the static patterns in the
example [are redundant][1]. However for anyone using a different server
for local development, this makes them work again.

[1]: https://docs.djangoproject.com/en/3.0/howto/static-files/#serving-static-files-during-development
