### PR TITLE
Add ETag header when serving documents

### DIFF
--- a/wagtail/documents/tests/test_views.py
+++ b/wagtail/documents/tests/test_views.py
@@ -14,7 +14,7 @@ from wagtail.documents import models
 @override_settings(WAGTAILDOCS_SERVE_METHOD=None)
 class TestServeView(TestCase):
     def setUp(self):
-        self.document = models.Document(title="Test document")
+        self.document = models.Document(title="Test document", file_hash="123456")
         self.document.file.save('example.doc', ContentFile("A boring example document"))
 
     def tearDown(self):
@@ -62,6 +62,12 @@ class TestServeView(TestCase):
     def test_with_incorrect_filename(self):
         response = self.client.get(reverse('wagtaildocs_serve', args=(self.document.id, 'incorrectfilename')))
         self.assertEqual(response.status_code, 404)
+
+    def test_has_etag_header(self):
+        self.assertEqual(self.get()['ETag'], '"123456"')
+
+    def test_has_cache_control_header(self):
+        self.assertEqual(self.get()['Cache-Control'], 'max-age=3600, public')
 
     def clear_sendfile_cache(self):
         from wagtail.utils.sendfile import _get_sendfile


### PR DESCRIPTION
This PR uses the `file_hash` in Documents to add an `ETag` Header to the HTTP Response:
```
ETag "14e0553f9be19646cf4aa7a5ea0396f1d12e3463"
```
It utilizes Django's [Conditional View Processing](https://docs.djangoproject.com/en/3.0/topics/conditional-view-processing/) to achieve this. If a client has a certain document already cached, it can check if the Document has changed by adding `If-None-Match` to the request header:
```
If-None-Match "14e0553f9be19646cf4aa7a5ea0396f1d12e3463"
```
If the document has changed, Wagtail will serve that new file. If the document has _not_ changed, Wagtail responds with `304 Not Modified`. Then the client's cached version is used. This functionality is implemented in all modern Browsers, including Internet Explorer. It is an efficient way of "cache busting" even when the URL stays the same. I implemented this to (at least partially) solve the problem described in #4567 and #5712.