### PR TITLE
Update styles for unpublished page listings

### DIFF
--- a/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_listing.scss
+++ b/wagtail/wagtailadmin/static_src/wagtailadmin/scss/components/_listing.scss
@@ -343,6 +343,7 @@ ul.listing {
     }
 
     .unpublished h2 {
+        font-style: italic;
         opacity: 0.7;
     }
 


### PR DESCRIPTION
Fixes #5370 as suggested by @thibaudcolas and @cfarm. Just a small change to make it easier to identity unpublished pages along with the extremely subtle (to my eyes) opacity decrease currently used.

Current styling:
![Screenshot 2019-12-19 at 15 44 17](https://user-images.githubusercontent.com/14837124/71187220-89b44700-2276-11ea-9673-50737a5c7f64.png)

Updated styling:
![Screenshot 2019-12-19 at 15 44 43](https://user-images.githubusercontent.com/14837124/71187218-88831a00-2276-11ea-997a-ce5880b43abb.png)

Tested on Chrome 78