### PR TITLE
Update rich text toolbar styles 

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,7 @@ Changelog
 2.9 (xx.xx.xxxx) - IN DEVELOPMENT
 ~~~~~~~~~~~~~~~~
 
+ * Reduced contrast of rich text toolbar (Jack Paine)
  * Fix: Added ARIA alert role to live search forms in the admin (Casper Timmers)
  * Fix: Reorder login form elements to match expected tab order (Kjartan Sverrisson)
  * Fix: Re-add 'Close Explorer' button on mobile viewports (Sævar Öfjörð Magnússon)

--- a/client/src/components/Draftail/Draftail.scss
+++ b/client/src/components/Draftail/Draftail.scss
@@ -1,10 +1,10 @@
 $editor-z-index: $draftail-editor-z-index;
 
 $draftail-editor-text: $color-text-input;
-$draftail-editor-chrome: $color-grey-1;
-$draftail-editor-chrome-text: $color-white;
-$draftail-editor-chrome-active: $color-white;
-$draftail-editor-chrome-accent: lighten($draftail-editor-chrome, 20%);
+$draftail-editor-chrome: $color-white;
+$draftail-editor-chrome-text: $color-grey-2;
+$draftail-editor-chrome-active: $color-grey-2;
+$draftail-editor-chrome-accent: transparent;
 
 $draftail-editor-border: 0;
 $draftail-editor-padding: 0;
@@ -97,6 +97,10 @@ $draftail-editor-font-family: $font-serif;
 
 .full .Draftail-Toolbar {
     @include nice-margin;
+}
+
+.Draftail-Toolbar {
+    border: 1px solid $color-grey-3;
 }
 
 .title .Draftail-Editor .public-DraftEditor-content,

--- a/docs/releases/2.9.rst
+++ b/docs/releases/2.9.rst
@@ -14,7 +14,7 @@ What's new
 Other features
 ~~~~~~~~~~~~~~
 
- * ...
+ * Reduced contrast of rich text toolbar (Jack Paine)
 
 
 Bug fixes


### PR DESCRIPTION
Fixes #4997 by overriding the Draftail toolbar styling.

Changes:
- White background (with light shadow behind for visibility)
- Black toolbar buttons
-  Removed dividers (but kept their spacing, they could be removed altogether however I think the spacing is beneficial)

![Screenshot 2019-12-20 at 16 49 31](https://user-images.githubusercontent.com/14837124/71270137-c51f4600-2348-11ea-8347-1b187e6a6508.png)

Tested on Chrome 79. Needs testing on more browsers/platforms