### PR TITLE
Abort unfinished ajax before new calls in all search ajax

### DIFF
--- a/wagtail/documents/static_src/wagtaildocs/js/document-chooser-modal.js
+++ b/wagtail/documents/static_src/wagtaildocs/js/document-chooser-modal.js
@@ -26,16 +26,21 @@ DOCUMENT_CHOOSER_MODAL_ONLOAD_HANDLERS = {
         };
 
         var searchUrl = $('form.document-search', modal.body).attr('action');
+        var request;
         function search() {
-            $.ajax({
+            request = $.ajax({
                 url: searchUrl,
                 data: {
                     q: $('#id_q').val(),
                     collection_id: $('#collection_chooser_collection_id').val()
                 },
                 success: function(data, status) {
+                    request = null;
                     $('#search-results').html(data);
                     ajaxifyLinks($('#search-results'));
+                },
+                error: function() {
+                    request = null;
                 }
             });
             return false;
@@ -48,12 +53,16 @@ DOCUMENT_CHOOSER_MODAL_ONLOAD_HANDLERS = {
                 dataObj = {p: page};
             }
 
-            $.ajax({
+            request = $.ajax({
                 url: searchUrl,
                 data: dataObj,
                 success: function(data, status) {
+                    request = null;
                     $('#search-results').html(data);
                     ajaxifyLinks($('#search-results'));
+                },
+                error: function() {
+                    request = null;
                 }
             });
             return false;
@@ -86,6 +95,9 @@ DOCUMENT_CHOOSER_MODAL_ONLOAD_HANDLERS = {
         $('form.document-search', modal.body).on('submit', search);
 
         $('#id_q').on('input', function() {
+            if (request) {
+                request.abort();
+            }
             clearTimeout($.data(this, 'timer'));
             var wait = setTimeout(search, 50);
             $(this).data('timer', wait);

--- a/wagtail/images/static_src/wagtailimages/js/image-chooser-modal.js
+++ b/wagtail/images/static_src/wagtailimages/js/image-chooser-modal.js
@@ -18,14 +18,19 @@ IMAGE_CHOOSER_MODAL_ONLOAD_HANDLERS = {
                 return false;
             });
         }
+        var request;
 
         function fetchResults(requestData) {
-            $.ajax({
+            request = $.ajax({
                 url: searchUrl,
                 data: requestData,
                 success: function(data, status) {
+                    request = null;
                     $('#image-results').html(data);
                     ajaxifyLinks($('#image-results'));
+                },
+                error: function() {
+                    request = null;
                 }
             });
         }
@@ -90,6 +95,9 @@ IMAGE_CHOOSER_MODAL_ONLOAD_HANDLERS = {
         $('form.image-search', modal.body).on('submit', search);
 
         $('#id_q').on('input', function() {
+            if (request) {
+                request.abort();
+            }
             clearTimeout($.data(this, 'timer'));
             var wait = setTimeout(search, 200);
             $(this).data('timer', wait);

--- a/wagtail/search/static_src/wagtailsearch/js/query-chooser-modal.js
+++ b/wagtail/search/static_src/wagtailsearch/js/query-chooser-modal.js
@@ -12,13 +12,19 @@ QUERY_CHOOSER_MODAL_ONLOAD_HANDLERS = {
         }
 
         var searchUrl = $('form.query-search', modal.body).attr('action');
+        var request;
+
         function search() {
-            $.ajax({
+            request = $.ajax({
                 url: searchUrl,
                 data: {q: $('#id_q').val()},
                 success: function(data, status) {
+                    request = null;
                     $('#query-results').html(data);
                     ajaxifyLinks($('#query-results'));
+                },
+                error: function() {
+                    request = null;
                 }
             });
             return false;
@@ -31,12 +37,16 @@ QUERY_CHOOSER_MODAL_ONLOAD_HANDLERS = {
                 dataObj = {p: page};
             }
 
-            $.ajax({
+            request = $.ajax({
                 url: searchUrl,
                 data: dataObj,
                 success: function(data, status) {
+                    request = null;
                     $('#query-results').html(data);
                     ajaxifyLinks($('#query-results'));
+                },
+                error: function() {
+                    request = null;
                 }
             });
             return false;
@@ -53,6 +63,9 @@ QUERY_CHOOSER_MODAL_ONLOAD_HANDLERS = {
         $('form.query-search', modal.body).on('submit', search);
 
         $('#id_q').on('input', function() {
+            if (request) {
+                request.abort();
+            }
             clearTimeout($.data(this, 'timer'));
             var wait = setTimeout(search, 200);
             $(this).data('timer', wait);

--- a/wagtail/snippets/static_src/wagtailsnippets/js/snippet-chooser-modal.js
+++ b/wagtail/snippets/static_src/wagtailsnippets/js/snippet-chooser-modal.js
@@ -14,14 +14,19 @@ SNIPPET_CHOOSER_MODAL_ONLOAD_HANDLERS = {
         }
 
         var searchUrl = $('form.snippet-search', modal.body).attr('action');
+        var request;
 
         function search() {
-            $.ajax({
+            request = $.ajax({
                 url: searchUrl,
                 data: {q: $('#id_q').val(), results: 'true'},
                 success: function(data, status) {
+                    request = null;
                     $('#search-results').html(data);
                     ajaxifyLinks($('#search-results'));
+                },
+                error: function() {
+                    request = null;
                 }
             });
             return false;
@@ -34,12 +39,16 @@ SNIPPET_CHOOSER_MODAL_ONLOAD_HANDLERS = {
                 dataObj.q = $('#id_q').val();
             }
 
-            $.ajax({
+            request = $.ajax({
                 url: searchUrl,
                 data: dataObj,
                 success: function(data, status) {
+                    request = null;
                     $('#search-results').html(data);
                     ajaxifyLinks($('#search-results'));
+                },
+                error: function() {
+                    request = null;
                 }
             });
             return false;
@@ -48,6 +57,9 @@ SNIPPET_CHOOSER_MODAL_ONLOAD_HANDLERS = {
         $('form.snippet-search', modal.body).on('submit', search);
 
         $('#id_q').on('input', function() {
+            if (request) {
+                request.abort();
+            }
             clearTimeout($.data(this, 'timer'));
             var wait = setTimeout(search, 200);
             $(this).data('timer', wait);


### PR DESCRIPTION
Fixes #5140. Cancel and abort the previous ajax calls when making a new ajax call.

- [x] Do the tests still pass? (https://docs.wagtail.io/en/latest/contributing/developing.html#testing)
- [x] Does the code comply with the style guide? (Run `make lint` from the Wagtail root)
* For Python changes: Have you added tests to cover the new/fixed behaviour?
- [x] For front-end changes: Did you test on all of Wagtail’s supported browsers? **Please list the exact versions you tested**.
* For new features: Has the documentation been updated accordingly?
