### PR TITLE
Support rich text rewrite handlers with custom primary keys

### DIFF
--- a/docs/advanced_topics/customisation/rich_text_internals.rst
+++ b/docs/advanced_topics/customisation/rich_text_internals.rst
@@ -109,7 +109,7 @@ You can create custom rewrite handlers to support your own new ``linktype`` and 
 
         For example, ``PageLinkHandler.get_instance`` might receive ``{'id': 123}`` and return the instance of the Wagtail ``Page`` class with ID 123.
 
-        If left undefined, a default implementation of this method will query the ``id`` model field on the class returned by ``get_model`` using the provided ``id`` attribute; this can be overriden in your own handlers should you want to use some other model field.
+        If left undefined, a default implementation of this method will retrieve an instance of the model class returned by ``get_model`` by querying its primary key using the provided ``id`` attribute; this can be overriden in your own handlers should you want to use some other model field.
 
 Below is an example custom rewrite handler that implements these methods to add support for rich text linking to user email addresses. It supports the conversion of rich text tags like ``<a linktype="user" username="wagtail">`` to valid HTML like ``<a href="mailto:hello@wagtail.io">``. This example assumes that equivalent front-end functionality has been added to allow users to insert these kinds of links into their rich text editor.
 

--- a/wagtail/core/rich_text/__init__.py
+++ b/wagtail/core/rich_text/__init__.py
@@ -74,7 +74,7 @@ class EntityHandler:
     @classmethod
     def get_instance(cls, attrs: dict) -> Model:
         model = cls.get_model()
-        return model._default_manager.get(id=attrs['id'])
+        return model._default_manager.get(pk=attrs['id'])
 
     @staticmethod
     def expand_db_attributes(attrs: dict) -> str:


### PR DESCRIPTION
The Wagtail documentation [describes the supported approach](https://docs.wagtail.io/en/v2.7/advanced_topics/customisation/rich_text_internals.html#rewrite-handlers) for defining custom rich text rewrite handlers, by inheriting from LinkHandler or EmbedHandler. This doesn't work using the default [`EntityHandler.get_instance`](https://docs.wagtail.io/en/v2.7/advanced_topics/customisation/rich_text_internals.html#LinkHandler.get_instance) if the entity model class uses a custom primary key (not `id`).

The default instance retrival code does a [`get(id=attrs['id'])`](https://github.com/wagtail/wagtail/blob/c72a4e09413bc6fc3a9cac8ed173378aa8652925/wagtail/core/rich_text/__init__.py#L77), which fails with an error like the following if there is no `id` field on the model class:

> django.core.exceptions.FieldError: Cannot resolve keyword 'id' into field. Choices are: ...

If this code instead used the Django [`pk` lookup shortcut](https://docs.djangoproject.com/en/3.0/topics/db/queries/#the-pk-lookup-shortcut), it could automatically query against the model's primary key, whatever it happens to be named.

This commit makes that change, adds a regression test that verifies the desired behavior, and updates the docs accordingly.