### PR TITLE
Use get_admin_display_title in PageChooserPanel

### DIFF
--- a/wagtail/admin/static_src/wagtailadmin/js/page-chooser.js
+++ b/wagtail/admin/static_src/wagtailadmin/js/page-chooser.js
@@ -26,7 +26,7 @@ function createPageChooser(id, pageTypes, openAtParentId, canChooseRoot, userPer
                 pageChosen: function(pageData) {
                     input.val(pageData.id);
                     openAtParentId = pageData.parentId;
-                    pageTitle.text(pageData.title);
+                    pageTitle.text(pageData.adminTitle);
                     chooserElement.removeClass('blank');
                     editLink.attr('href', pageData.editUrl);
                 }

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_page_title_choose.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_page_title_choose.html
@@ -8,7 +8,7 @@ Expects a variable 'page', the page instance.
 
 <div class="title-wrapper">
     {% if page.can_choose %}
-        <a class="choose-page" href="#{{ page.id|unlocalize }}" data-id="{{ page.id|unlocalize }}" data-title="{{ page.title }}" data-url="{{ page.url }}" data-parent-id="{{ page.get_parent.id|unlocalize }}" data-edit-url="{% url 'wagtailadmin_pages:edit' page.id %}">{{ page.get_admin_display_title }}</a>
+        <a class="choose-page" href="#{{ page.id|unlocalize }}" data-id="{{ page.id|unlocalize }}" data-title="{{ page.title }}" data-admin-title="{{ page.get_admin_display_title }}" data-url="{{ page.url }}" data-parent-id="{{ page.get_parent.id|unlocalize }}" data-edit-url="{% url 'wagtailadmin_pages:edit' page.id %}">{{ page.get_admin_display_title }}</a>
     {% else %}
         {{ page.get_admin_display_title }}
     {% endif %}


### PR DESCRIPTION
Should fix #5726 . @gasman This should fix the title of the page only in the PageChooserPanel. Do you think this is a good approach? Another approach might be to remove the `pageTitle.text()` entirely since by default `page_chooser.html`  shows `get_admin_display_title`. But I think adding a new data attribute is a better way.

I think I will need to add some tests also to ensure this behaviour works. I will add the tests once you confirm that this approach looks good.

- [X] Do the tests still pass? (https://docs.wagtail.io/en/latest/contributing/developing.html#testing)
- [X] Does the code comply with the style guide? (Run `make lint` from the Wagtail root)
- [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
* For front-end changes: Did you test on all of Wagtail’s supported browsers? **Please list the exact versions you tested**.
* For new features: Has the documentation been updated accordingly?
