### PR TITLE
Be more specific regarding the cached loader.

### DIFF
--- a/docs/advanced_topics/performance.rst
+++ b/docs/advanced_topics/performance.rst
@@ -47,7 +47,7 @@ Wagtail is tested on PostgreSQL, SQLite and MySQL. It should work on some third-
 Templates
 ---------
 
-The overhead from reading and compiling templates adds up. Django's :class:`cached template loader <django.template.loaders.cached.Loader>`: stores the compiled ``Template`` in memory and returns it for subsequent requests. Unless additional custom loaders are used, the cached loader is automatically enabled when ``DEBUG`` is False. To enable it for custom loaders, use a settings like this:
+The overhead from reading and compiling templates adds up. Django's :class:`cached template loader <django.template.loaders.cached.Loader>`: stores the compiled ``Template`` in memory and returns it for subsequent requests. Unless additional custom loaders are used, the cached loader is automatically enabled when ``DEBUG`` is ``False``. To enable it for custom loaders, use a settings like this:
 
 .. code-block:: python
 

--- a/docs/advanced_topics/performance.rst
+++ b/docs/advanced_topics/performance.rst
@@ -47,7 +47,7 @@ Wagtail is tested on PostgreSQL, SQLite and MySQL. It should work on some third-
 Templates
 ---------
 
-The overhead from reading and compiling templates adds up. Django's :class:`cached template loader <django.template.loaders.cached.Loader>`: stores the compiled ``Template`` in memory and returns it for subsequent requests. Unless additional custom loaders are used, the cached loader is automatically enabled when ``DEBUG`` is ``False``. To enable it for custom loaders, use a settings like this:
+The overhead from reading and compiling templates adds up. Django wraps its default loaders with :class:`cached template loader <django.template.loaders.cached.Loader>`: which stores the compiled ``Template`` in memory and returns it for subsequent requests. The cached loader is automatically enabled when ``DEBUG`` is ``False``. If you are using custom loaders, update your settings to use it:
 
 .. code-block:: python
 

--- a/docs/advanced_topics/performance.rst
+++ b/docs/advanced_topics/performance.rst
@@ -47,7 +47,7 @@ Wagtail is tested on PostgreSQL, SQLite and MySQL. It should work on some third-
 Templates
 ---------
 
-The overhead from reading and compiling templates can add up. In some cases a significant performance improvement can be gained by using :class:`Django's cached template loader <django.template.loaders.cached.Loader>`:
+The overhead from reading and compiling templates adds up. Django's :class:`cached template loader <django.template.loaders.cached.Loader>`: stores the compiled ``Template`` in memory and returns it for subsequent requests. Unless additional custom loaders are used, the cached loader is automatically enabled when ``DEBUG`` is False. To enable it for custom loaders, use a settings like this:
 
 .. code-block:: python
 
@@ -59,12 +59,11 @@ The overhead from reading and compiling templates can add up. In some cases a si
                 ('django.template.loaders.cached.Loader', [
                     'django.template.loaders.filesystem.Loader',
                     'django.template.loaders.app_directories.Loader',
+                    'path.to.custom.Loader',
                 ]),
             ],
         },
     }]
-
-There is a caveat associated with this loader though. Changes to a template file will not be picked up once it is cached. This means that this loader should *not* be enabled during development.
 
 
 Public users


### PR DESCRIPTION
Be more explicit about not needing to enable the `cached.Loader` manually, unless using some custom loaders.

While an explicit setting is better than an implicit one, I still think the documentation should mention that this optimization is already there for free, unless a custom loader has to be used, in which case the developer will come accross that bit of django documentation anyway.