### PR TITLE
Fix update_index throwing AttributeError when value is None

### DIFF
--- a/wagtail/contrib/table_block/blocks.py
+++ b/wagtail/contrib/table_block/blocks.py
@@ -83,8 +83,9 @@ class TableBlock(FieldBlock):
 
     def get_searchable_content(self, value):
         content = []
-        for row in value.get('data', []):
-            content.extend([v for v in row if v])
+        if value:
+            for row in value.get('data', []):
+                content.extend([v for v in row if v])
         return content
 
     def render(self, value, context=None):
@@ -116,7 +117,7 @@ class TableBlock(FieldBlock):
 
             return render_to_string(template, new_context)
         else:
-            return self.render_basic(value, context=context)
+            return self.render_basic(value or "", context=context)
 
     @property
     def media(self):

--- a/wagtail/contrib/table_block/tests.py
+++ b/wagtail/contrib/table_block/tests.py
@@ -264,6 +264,18 @@ class TestTableBlock(TestCase):
         self.assertHTMLEqual(result, expected)
         self.assertIn('Test 2', result)
 
+    def test_empty_table_block_is_not_rendered(self):
+        """
+        Test an empty table is not rendered.
+        """
+        value = None
+        block = TableBlock()
+        result = block.render(value)
+        expected = ''
+
+        self.assertHTMLEqual(result, expected)
+        self.assertNotIn('None', result)
+
 
 class TestTableBlockForm(WagtailTestUtils, SimpleTestCase):
 


### PR DESCRIPTION
This fixes #4822 
Also avoid rendering "None" if the table value is None.

I noticed that value is None only if you save the page without touching the block form.
Not sure if that's the correct behaviour.  