### PR TITLE
dropdown on search page by initing dropdowns on ajax success

### DIFF
--- a/wagtail/admin/static_src/wagtailadmin/js/core.js
+++ b/wagtail/admin/static_src/wagtailadmin/js/core.js
@@ -264,6 +264,7 @@ $(function() {
                         }
                     },
                     complete: function() {
+                        wagtail.ui.initDropDowns();
                         $inputContainer.removeClass(workingClasses);
                     }
                 });
@@ -542,7 +543,7 @@ wagtail = (function(document, window, wagtail) {
     }
 
     $(document).ready(initDropDowns);
-
+    wagtail.ui.initDropDowns = initDropDowns;
     wagtail.ui.DropDownController = DropDownController;
     return wagtail;
 


### PR DESCRIPTION
Tested on Chrome and Firefox.

This is my first PR, so let me know if I'm missing anything! It's a pretty small change, however. 

This fixes an issue where dropdown menus don't work on the search page after you have made a search result. The dropdown components needed to be re-initialized. 
