### PR TITLE
Use sensitive_post_parameters on password reset form

### DIFF
--- a/wagtail/admin/views/account.py
+++ b/wagtail/admin/views/account.py
@@ -8,6 +8,7 @@ from django.shortcuts import redirect, render
 from django.urls import reverse, reverse_lazy
 from django.utils.translation import ugettext as _
 from django.utils.translation import override
+from django.views.decorators.debug import sensitive_post_parameters
 
 from wagtail.admin.forms.auth import LoginForm, PasswordResetForm
 from wagtail.core import hooks
@@ -56,6 +57,7 @@ def account(request):
     })
 
 
+@sensitive_post_parameters()
 def change_password(request):
     if not password_management_enabled():
         raise Http404


### PR DESCRIPTION
@kaedroho mentioned we could potentially be leaking password should an issue occur in the account password reset form

---
* Do the tests still pass? (https://docs.wagtail.io/en/latest/contributing/developing.html#testing)
✅ 
* Does the code comply with the style guide? (Run `make lint` from the Wagtail root)
✅ 
* For Python changes: Have you added tests to cover the new/fixed behaviour?
✅ 
* For front-end changes: Did you test on all of Wagtail’s supported browsers? **Please list the exact versions you tested**.
N/A
* For new features: Has the documentation been updated accordingly?
N/A
