### PR TITLE
Redirect to previous url when deleting/copying/unpublish a page

### DIFF
--- a/docs/reference/hooks.rst
+++ b/docs/reference/hooks.rst
@@ -830,7 +830,7 @@ Page explorer
     from wagtail.admin import widgets as wagtailadmin_widgets
 
     @hooks.register('register_page_listing_buttons')
-    def page_listing_buttons(page, page_perms, is_parent=False):
+    def page_listing_buttons(page, page_perms, is_parent=False, next_url=None):
         yield wagtailadmin_widgets.PageListingButton(
             'A page listing button',
             '/goes/to/a/url/',
@@ -854,7 +854,7 @@ Page explorer
     from wagtail.admin import widgets as wagtailadmin_widgets
 
     @hooks.register('register_page_listing_more_buttons')
-    def page_listing_more_buttons(page, page_perms, is_parent=False):
+    def page_listing_more_buttons(page, page_perms, is_parent=False, next_url=None):
         yield wagtailadmin_widgets.Button(
             'A dropdown button',
             '/goes/to/a/url/',

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -12,6 +12,7 @@ from django.template.defaultfilters import stringfilter
 from django.template.loader import render_to_string
 from django.templatetags.static import static
 from django.utils.html import format_html, format_html_join
+from django.utils.http import urlencode
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy as _
 
@@ -427,9 +428,10 @@ def paginate(context, page, base_url='', page_key='p',
 @register.inclusion_tag("wagtailadmin/pages/listing/_buttons.html",
                         takes_context=True)
 def page_listing_buttons(context, page, page_perms, is_parent=False):
+    next_url = urlencode({"next": context.request.path})
     button_hooks = hooks.get_hooks('register_page_listing_buttons')
     buttons = sorted(itertools.chain.from_iterable(
-        hook(page, page_perms, is_parent)
+        hook(page, page_perms, is_parent, next_url)
         for hook in button_hooks))
 
     for hook in hooks.get_hooks('construct_page_listing_buttons'):

--- a/wagtail/admin/tests/test_buttons_hooks.py
+++ b/wagtail/admin/tests/test_buttons_hooks.py
@@ -14,7 +14,7 @@ class TestButtonsHooks(TestCase, WagtailTestUtils):
 
     def test_register_page_listing_buttons(self):
         @hooks.register('register_page_listing_buttons')
-        def page_listing_buttons(page, page_perms, is_parent=False):
+        def page_listing_buttons(page, page_perms, is_parent=False, next_url=None):
             yield wagtailadmin_widgets.PageListingButton(
                 'Another useless page listing button',
                 '/custom-url',
@@ -33,7 +33,7 @@ class TestButtonsHooks(TestCase, WagtailTestUtils):
 
     def test_register_page_listing_more_buttons(self):
         @hooks.register('register_page_listing_more_buttons')
-        def page_listing_more_buttons(page, page_perms, is_parent=False):
+        def page_listing_more_buttons(page, page_perms, is_parent=False, next_url=None):
             yield wagtailadmin_widgets.Button(
                 'Another useless button in default "More" dropdown',
                 '/custom-url',
@@ -52,19 +52,20 @@ class TestButtonsHooks(TestCase, WagtailTestUtils):
 
     def test_custom_button_with_dropdown(self):
         @hooks.register('register_page_listing_buttons')
-        def page_custom_listing_buttons(page, page_perms, is_parent=False):
+        def page_custom_listing_buttons(page, page_perms, is_parent=False, next_url=None):
             yield wagtailadmin_widgets.ButtonWithDropdownFromHook(
                 'One more more button',
                 hook_name='register_page_listing_one_more_more_buttons',
                 page=page,
                 page_perms=page_perms,
                 is_parent=is_parent,
+                next_url=next_url,
                 attrs={'target': '_blank', 'rel': 'noopener noreferrer'},
                 priority=50
             )
 
         @hooks.register('register_page_listing_one_more_more_buttons')
-        def page_custom_listing_more_buttons(page, page_perms, is_parent=False):
+        def page_custom_listing_more_buttons(page, page_perms, is_parent=False, next_url=None):
             yield wagtailadmin_widgets.Button(
                 'Another useless dropdown button in "One more more button" dropdown',
                 '/custom-url',

--- a/wagtail/admin/wagtail_hooks.py
+++ b/wagtail/admin/wagtail_hooks.py
@@ -27,6 +27,10 @@ from wagtail.core.permissions import collection_permission_policy
 from wagtail.core.whitelist import allow_without_attributes, attribute_rule, check_url
 
 
+def append_querystring(path, querystring=None):
+    return '%s%s' % (path, '?%s' % querystring if querystring else '')
+
+
 class ExplorerMenuItem(MenuItem):
     template = 'wagtailadmin/shared/explorer_menu_item.html'
 
@@ -97,7 +101,7 @@ def register_collections_menu_item():
 
 
 @hooks.register('register_page_listing_buttons')
-def page_listing_buttons(page, page_perms, is_parent=False):
+def page_listing_buttons(page, page_perms, is_parent=False, next_url=None):
     if page_perms.can_edit():
         yield PageListingButton(
             _('Edit'),
@@ -150,6 +154,7 @@ def page_listing_buttons(page, page_perms, is_parent=False):
         page=page,
         page_perms=page_perms,
         is_parent=is_parent,
+        next_url=next_url,
         attrs={
             'target': '_blank', 'rel': 'noopener noreferrer',
             'title': _("View more options for '%(title)s'") % {'title': page.get_admin_display_title()}
@@ -159,7 +164,7 @@ def page_listing_buttons(page, page_perms, is_parent=False):
 
 
 @hooks.register('register_page_listing_more_buttons')
-def page_listing_more_buttons(page, page_perms, is_parent=False):
+def page_listing_more_buttons(page, page_perms, is_parent=False, next_url=None):
     if page_perms.can_move():
         yield Button(
             _('Move'),
@@ -170,21 +175,21 @@ def page_listing_more_buttons(page, page_perms, is_parent=False):
     if page_perms.can_copy():
         yield Button(
             _('Copy'),
-            reverse('wagtailadmin_pages:copy', args=[page.id]),
+            append_querystring(reverse('wagtailadmin_pages:copy', args=[page.id]), next_url),
             attrs={'title': _("Copy page '%(title)s'") % {'title': page.get_admin_display_title()}},
             priority=20
         )
     if page_perms.can_delete():
         yield Button(
             _('Delete'),
-            reverse('wagtailadmin_pages:delete', args=[page.id]),
+            append_querystring(reverse('wagtailadmin_pages:delete', args=[page.id]), next_url),
             attrs={'title': _("Delete page '%(title)s'") % {'title': page.get_admin_display_title()}},
             priority=30
         )
     if page_perms.can_unpublish():
         yield Button(
             _('Unpublish'),
-            reverse('wagtailadmin_pages:unpublish', args=[page.id]),
+            append_querystring(reverse('wagtailadmin_pages:unpublish', args=[page.id]), next_url),
             attrs={'title': _("Unpublish page '%(title)s'") % {'title': page.get_admin_display_title()}},
             priority=40
         )

--- a/wagtail/admin/widgets.py
+++ b/wagtail/admin/widgets.py
@@ -318,11 +318,12 @@ class BaseDropdownMenuButton(Button):
 class ButtonWithDropdownFromHook(BaseDropdownMenuButton):
     template_name = 'wagtailadmin/pages/listing/_button_with_dropdown.html'
 
-    def __init__(self, label, hook_name, page, page_perms, is_parent, **kwargs):
+    def __init__(self, label, hook_name, page, page_perms, is_parent, next_url=None, **kwargs):
         self.hook_name = hook_name
         self.page = page
         self.page_perms = page_perms
         self.is_parent = is_parent
+        self.next_url = next_url
 
         super().__init__(label, **kwargs)
 
@@ -334,5 +335,5 @@ class ButtonWithDropdownFromHook(BaseDropdownMenuButton):
     def dropdown_buttons(self):
         button_hooks = hooks.get_hooks(self.hook_name)
         return sorted(itertools.chain.from_iterable(
-            hook(self.page, self.page_perms, self.is_parent)
+            hook(self.page, self.page_perms, self.is_parent, self.next_url)
             for hook in button_hooks))


### PR DESCRIPTION
This fixes #3010 appending the `next` querystring parameter to the "Delete", "Copy" and "Unpublish" actions.

Waiting for feedbak,
Carlo
