### PR TITLE
Disable responsive embeds by default

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -23,7 +23,7 @@ Changelog
  * Add partial experimental support for nested InlinePanels (Matt Westcott, Sam Costigan, Andy Chosak, Scott Cranfill)
  * Added cache control headers when serving documents (Johannes Vogel)
  * Use `sensitive_post_parameters` on password reset form (Dan Braghis)
- * Add ``WAGTAIL_ENABLE_RESPONSIVE_EMBED`` setting to remove automatic addition of ``responsive-object`` around embeds (Kalob Taulien)
+ * Add `WAGTAILEMBEDS_RESPONSIVE_HTML` setting to remove automatic addition of `responsive-object` around embeds (Kalob Taulien)
  * Fix: Rename documents listing column 'uploaded' to 'created' (LB (Ben Johnston))
  * Fix: Unbundle the l18n library as it was bundled to avoid installation errors which have been resolved (Matt Westcott)
  * Fix: Prevent error when comparing pages that reference a model with a custom primary key (Fidel Ramos)

--- a/docs/reference/settings.rst
+++ b/docs/reference/settings.rst
@@ -75,6 +75,17 @@ Wagtail has a builtin list of the most common providers.
 The embeds fetching can be fully configured using the ``WAGTAILEMBEDS_FINDERS``
 setting. This is fully documented in :ref:`configuring_embed_finders`.
 
+.. code-block:: python
+
+    WAGTAILEMBEDS_RESPONSIVE_HTML = True
+
+Adds ``class="responsive-object"`` and an inline ``padding-bottom`` style to embeds,
+to assist in making them responsive. See :ref:`responsive-embeds` for details.
+
+.. versionadded:: 2.8
+
+  The ``WAGTAILEMBEDS_RESPONSIVE_HTML`` setting was added.
+
 Dashboard
 =========
 

--- a/docs/releases/2.8.rst
+++ b/docs/releases/2.8.rst
@@ -87,6 +87,15 @@ restore the previous behaviour, you can set the
 ``WAGTAILADMIN_GLOBAL_PAGE_EDIT_LOCK`` setting to ``True``.
 
 
+Responsive HTML for embeds no longer added by default
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In previous versions of Wagtail, embedded media elements were given
+a class name of ``responsive-object`` and an inline ``padding-bottom`` style to assist
+in styling them responsively. These are no longer added by default. To restore the previous
+behaviour, add ``WAGTAILEMBEDS_RESPONSIVE_HTML = True`` to your project settings.
+
+
 API endpoint classes have moved
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/releases/2.8.rst
+++ b/docs/releases/2.8.rst
@@ -43,7 +43,7 @@ Other features
  * Add partial experimental support for nested InlinePanels (Matt Westcott, Sam Costigan, Andy Chosak, Scott Cranfill)
  * Added cache control headers when serving documents (Johannes Vogel)
  * Use ``sensitive_post_parameters`` on password reset form (Dan Braghis)
- * Add ``WAGTAIL_ENABLE_RESPONSIVE_EMBED`` setting to remove automatic addition of ``responsive-object`` around embeds (Kalob Taulien)
+ * Add ``WAGTAILEMBEDS_RESPONSIVE_HTML`` setting to remove automatic addition of ``responsive-object`` around embeds (Kalob Taulien)
 
 
 Bug fixes

--- a/docs/topics/writing_templates.rst
+++ b/docs/topics/writing_templates.rst
@@ -145,7 +145,7 @@ Wagtail includes embeds and images at their full width, which may overflow the b
         height: 100%;
     }
 
-It's possible to disable responsive embeds entirely by setting ``WAGTAIL_ENABLE_RESPONSIVE_EMBED = False`` in your settings. Normally, Wagtail wraps your embed links in a ``<div>`` element. If you decide to disable responsive embeds the ``<div>`` element around your embed will not be given a CSS class of ``responsive-object`` and there won't be an inline style in the same parent ``<div>`` element. This means the responsiveness of your embed is entirely up to you.
+It's possible to disable responsive embeds entirely by setting ``WAGTAILEMBEDS_RESPONSIVE_HTML = False`` in your settings. Normally, Wagtail wraps your embed links in a ``<div>`` element. If you decide to disable responsive embeds the ``<div>`` element around your embed will not be given a CSS class of ``responsive-object`` and there won't be an inline style in the same parent ``<div>`` element. This means the responsiveness of your embed is entirely up to you.
 
 Internal links (tag)
 ~~~~~~~~~~~~~~~~~~~~

--- a/docs/topics/writing_templates.rst
+++ b/docs/topics/writing_templates.rst
@@ -119,10 +119,13 @@ Only fields using ``RichTextField`` need this applied in the template.
     ...
     {{ page.body|richtext }}
 
+
+.. _responsive-embeds:
+
 Responsive Embeds
 -----------------
 
-Wagtail includes embeds and images at their full width, which may overflow the bounds of the content container you've defined in your templates. To make images and embeds responsive -- meaning they'll resize to fit their container -- include the following CSS.
+By default, Wagtail includes embeds and images at their full width, which may overflow the bounds of the content container you've defined in your templates. To address this, Wagtail provides the ability to make images and embeds responsive -- meaning they'll resize to fit their container. Responsive embeds can be enabled by setting ``WAGTAILEMBEDS_RESPONSIVE_HTML = True`` in your project settings; this adds a CSS class of ``responsive-object`` and an inline ``padding-bottom`` style to the embed, to be used in conjunction with CSS such as the following:
 
 .. code-block:: css
 
@@ -145,7 +148,11 @@ Wagtail includes embeds and images at their full width, which may overflow the b
         height: 100%;
     }
 
-It's possible to disable responsive embeds entirely by setting ``WAGTAILEMBEDS_RESPONSIVE_HTML = False`` in your settings. Normally, Wagtail wraps your embed links in a ``<div>`` element. If you decide to disable responsive embeds the ``<div>`` element around your embed will not be given a CSS class of ``responsive-object`` and there won't be an inline style in the same parent ``<div>`` element. This means the responsiveness of your embed is entirely up to you.
+
+.. versionchanged:: 2.8
+
+  The ``WAGTAILEMBEDS_RESPONSIVE_HTML`` setting was added. Previous versions always added the class and style attributes.
+
 
 Internal links (tag)
 ~~~~~~~~~~~~~~~~~~~~

--- a/wagtail/embeds/models.py
+++ b/wagtail/embeds/models.py
@@ -51,7 +51,7 @@ class Embed(models.Model):
 
     @property
     def is_responsive(self):
-        if not getattr(settings, 'WAGTAILEMBEDS_RESPONSIVE_HTML', True):
+        if not getattr(settings, 'WAGTAILEMBEDS_RESPONSIVE_HTML', False):
             return False
         return self.ratio is not None
 

--- a/wagtail/embeds/models.py
+++ b/wagtail/embeds/models.py
@@ -51,7 +51,7 @@ class Embed(models.Model):
 
     @property
     def is_responsive(self):
-        if not getattr(settings, 'WAGTAIL_ENABLE_RESPONSIVE_EMBED', True):
+        if not getattr(settings, 'WAGTAILEMBEDS_RESPONSIVE_HTML', True):
             return False
         return self.ratio is not None
 

--- a/wagtail/embeds/tests/test_embeds.py
+++ b/wagtail/embeds/tests/test_embeds.py
@@ -94,7 +94,8 @@ class TestEmbeds(TestCase):
             'html': "<p>Blah blah blah</p>",
         }
 
-    def test_get_embed(self):
+    @override_settings(WAGTAILEMBEDS_RESPONSIVE_HTML=True)
+    def test_get_embed_responsive(self):
         embed = get_embed('www.test.com/1234', max_width=400, finder=self.dummy_finder)
 
         # Check that the embed is correct
@@ -121,6 +122,15 @@ class TestEmbeds(TestCase):
         # Look for the same embed with a different width, this should also increase hit count
         embed = get_embed('www.test.com/4321', finder=self.dummy_finder)
         self.assertEqual(self.hit_count, 3)
+
+    def test_get_embed_nonresponsive(self):
+        embed = get_embed('www.test.com/1234', max_width=400, finder=self.dummy_finder)
+
+        # Check that the embed is correct
+        self.assertEqual(embed.title, "Test: www.test.com/1234")
+        self.assertEqual(embed.type, 'video')
+        self.assertEqual(embed.width, 400)
+        self.assertFalse(embed.is_responsive)
 
     def dummy_finder_invalid_width(self, url, max_width=None):
         # Return a record with an invalid width


### PR DESCRIPTION
Follow-up to #5758 - rename setting to `WAGTAILEMBEDS_RESPONSIVE_HTML` for consistency with other settings; disable it by default; update tests to cover both cases, and update docs / release notes accordingly.