### PR TITLE
Show 'Close Explorer' button on mobile viewports

### DIFF
--- a/client/src/components/Explorer/Explorer.scss
+++ b/client/src/components/Explorer/Explorer.scss
@@ -58,6 +58,7 @@ $menu-footer-height: 50px;
     color: $c-explorer-secondary;
     border-bottom: 1px solid rgba(200, 200, 200, 0.1);
     cursor: pointer;
+    display: none;
 
     &:focus {
         background-color: $c-explorer-bg-active;

--- a/client/src/components/Explorer/ExplorerPanel.js
+++ b/client/src/components/Explorer/ExplorerPanel.js
@@ -146,7 +146,7 @@ class ExplorerPanel extends React.Component {
           onDeactivate: onClose,
         }}
       >
-        <Button className="c-explorer__close u-hidden" onClick={onClose}>
+        <Button className="c-explorer__close" onClick={onClose}>
           {STRINGS.CLOSE_EXPLORER}
         </Button>
         <Transition name={transition} className="c-explorer" component="nav" label={STRINGS.PAGE_EXPLORER}>

--- a/client/src/components/Explorer/__snapshots__/ExplorerPanel.test.js.snap
+++ b/client/src/components/Explorer/__snapshots__/ExplorerPanel.test.js.snap
@@ -17,7 +17,7 @@ exports[`ExplorerPanel general rendering #isError 1`] = `
 >
   <Button
     accessibleLabel={null}
-    className="c-explorer__close u-hidden"
+    className="c-explorer__close"
     dialogTrigger={false}
     href="#"
     icon=""
@@ -96,7 +96,7 @@ exports[`ExplorerPanel general rendering #isFetching 1`] = `
 >
   <Button
     accessibleLabel={null}
-    className="c-explorer__close u-hidden"
+    className="c-explorer__close"
     dialogTrigger={false}
     href="#"
     icon=""
@@ -165,7 +165,7 @@ exports[`ExplorerPanel general rendering #items 1`] = `
 >
   <Button
     accessibleLabel={null}
-    className="c-explorer__close u-hidden"
+    className="c-explorer__close"
     dialogTrigger={false}
     href="#"
     icon=""
@@ -259,7 +259,7 @@ exports[`ExplorerPanel general rendering no children 1`] = `
 >
   <Button
     accessibleLabel={null}
-    className="c-explorer__close u-hidden"
+    className="c-explorer__close"
     dialogTrigger={false}
     href="#"
     icon=""
@@ -322,7 +322,7 @@ exports[`ExplorerPanel general rendering renders 1`] = `
 >
   <Button
     accessibleLabel={null}
-    className="c-explorer__close u-hidden"
+    className="c-explorer__close"
     dialogTrigger={false}
     href="#"
     icon=""


### PR DESCRIPTION
In issue #5396 the proposed solution was to rework the button css so that it does not rely on the `u-hidden` class anymore. This PR does that by adding the `display: none` to the button css itself.

Tested on Chrome Version 79.0.3945.117 (Official Build) (64-bit) in both desktop and mobile viewports.