### PR TITLE
Emphasizing unpublished pages. Issue #5370

### DIFF
--- a/client/scss/components/_listing.scss
+++ b/client/scss/components/_listing.scss
@@ -363,8 +363,14 @@ ul.listing {
         padding-left: 20px;
     }
 
-    .unpublished .title-wrapper {
-        opacity: 0.7;
+    .unpublished {
+        background: #fff url('#{$images-root}bg-dark-diag.svg');
+
+        .status-tag {
+            color: $color-grey-2;
+            border: 1px solid $color-grey-2;
+            background: #fff;
+        }
     }
 
     .index {

--- a/client/scss/components/_listing.scss
+++ b/client/scss/components/_listing.scss
@@ -95,6 +95,10 @@ ul.listing {
                 border-top: 1px dashed $color-input-border;
             }
 
+            &:last-child {
+                border-bottom: 1px dashed $color-input-border;
+            }
+
             &:hover {
                 background-color: #fcfcfc;
             }
@@ -548,7 +552,6 @@ table.listing {
 
 .listing.full-width + .pagination {
     margin-top: 3em;
-    border-top: 1px dashed #d9d9d9;
     padding: 2em 50px 0;
 }
 

--- a/client/scss/overrides/_utilities.dropdowns.scss
+++ b/client/scss/overrides/_utilities.dropdowns.scss
@@ -21,6 +21,7 @@
 
 // }
 .t-default .u-btn-current {
+    background: $color-white;
     border-color: rgba(0, 0, 0, 0.15);
     color: $color-teal;
 }
@@ -38,6 +39,7 @@
 }
 
 .t-inverted .u-btn-current {
+    background: $color-teal;
     border-color: rgba(0, 0, 0, 0.35);
     color: #fff;
 }

--- a/wagtail/admin/templates/wagtailadmin/home/recent_edits.html
+++ b/wagtail/admin/templates/wagtailadmin/home/recent_edits.html
@@ -16,7 +16,7 @@
                 </thead>
                 <tbody>
                     {% for revision, page in last_edits %}
-                        <tr>
+                        <tr{% if not page.live %} class="unpublished"{% endif %}>
                             <td class="title" valign="top">
                                 <div class="title-wrapper">
                                     <a href="{% url 'wagtailadmin_pages:edit' page.id %}" title="{% trans 'Edit this page' %}">{{ page.get_admin_display_title }}</a>


### PR DESCRIPTION
Further work on issue #5370 after discussion at Bristol sprint. We agreed that having the whole row greyed out using the diagonal line background is more visually pleasing. After that change, we felt that reduced opacity on the title would not be necessary and probably not visible enough. I also discovered that the status tag of the page is probably not WCAG compliant since it is using a very light grey on top of white background. After discussion with @thibaudcolas we agreed that these status tags and their compliance should be looked into as a separate issue, since they are used in many places and the consequences of changing them are not obvious.

The final result looks like this:
<img width="1013" alt="Screenshot 2020-01-23 at 12 30 59" src="https://user-images.githubusercontent.com/143557/72985788-a6481f80-3dde-11ea-9c7a-915ef13e60d9.png">

Tested in:
* Chrome Version 79.0.3945.117 (Official Build) (64-bit) in MacOS
* Safari version 13.0.2 (15608.2.30.1.1)
* Firefox developer edition version 72.0b9 