### PR TITLE
Add basic skiplink

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -52,6 +52,7 @@ Changelog
  * Deprecate use of unidecode within form builder field names (Michael van Tellingen, LB (Ben Johnston))
  * Improve error feedback when editing a page with a missing model class (Andy Babic)
  * Change Wagtail tabs implementation to only allow slug-formatted tab identifiers, reducing false positives from security audits (Matt Westcott)
+ * Add skip link for keyboard users to bypass Wagtail navigation in the admin (Martin Coote)
  * Fix: Support IPv6 domain (Alex Gleason, Coen van der Kamp)
  * Fix: Ensure link to add a new user works when no users are visible in the users list (LB (Ben Johnston))
  * Fix: `AbstractEmailForm` saved submission fields are now aligned with the email content fields, `form.cleaned_data` will be used instead of `form.fields` (Haydn Greatnews)

--- a/client/scss/components/_skiplink.scss
+++ b/client/scss/components/_skiplink.scss
@@ -1,0 +1,16 @@
+.skiplink {
+    display: block;
+    position: fixed;
+    top: -1000rem;
+    left: 1rem;
+    z-index: 30;
+
+    &:focus {
+        top: 1rem;
+    }
+
+    &.button {
+        background: $color-green-darker;
+        border: $color-green-darker;
+    }
+}

--- a/client/scss/settings/_variables.scss
+++ b/client/scss/settings/_variables.scss
@@ -39,6 +39,7 @@ $color-orange: #e9b04d;
 $color-orange-dark: #bb5b03;
 $color-green: #189370;
 $color-green-dark: #157b57;
+$color-green-darker: #105d42; // White has AAA compatibility when this is used in bgd.
 $color-salmon: #f37e77;
 $color-salmon-light: #fcf2f2;
 $color-white: #fff;

--- a/client/scss/styles.scss
+++ b/client/scss/styles.scss
@@ -129,6 +129,7 @@ These are classes for components.
 @import 'components/privacy-indicator';
 @import 'components/status-tag';
 @import 'components/button-select';
+@import 'components/skiplink';
 
 
 /* OVERRIDES

--- a/client/src/includes/initSkipLink.js
+++ b/client/src/includes/initSkipLink.js
@@ -1,0 +1,23 @@
+const initSkipLink = () => {
+    // Inspired by https://github.com/selfthinker/dokuwiki_template_writr/blob/master/js/skip-link-focus-fix.js
+
+    const skiplink = document.querySelector('.skiplink');
+    const main = document.querySelector('main');
+
+    const handleClick = () => {
+        main.setAttribute('tabindex', -1);
+        main.addEventListener('blur', handleBlur);
+        main.addEventListener('focusout', handleBlur);
+        main.focus();
+    };
+
+    const handleBlur = () => {
+        main.removeAttribute('tabindex');
+        main.removeEventListener('blur', handleBlur);
+        main.removeEventListener('focusout', handleBlur);
+    };
+
+    skiplink.addEventListener('click', handleClick);
+};
+
+export { initSkipLink };

--- a/client/src/includes/initSkipLink.js
+++ b/client/src/includes/initSkipLink.js
@@ -1,23 +1,23 @@
 const initSkipLink = () => {
-    // Inspired by https://github.com/selfthinker/dokuwiki_template_writr/blob/master/js/skip-link-focus-fix.js
+  // Inspired by https://github.com/selfthinker/dokuwiki_template_writr/blob/master/js/skip-link-focus-fix.js
 
-    const skiplink = document.querySelector('.skiplink');
-    const main = document.querySelector('main');
+  const skiplink = document.querySelector('.skiplink');
+  const main = document.querySelector('main');
 
-    const handleClick = () => {
-        main.setAttribute('tabindex', -1);
-        main.addEventListener('blur', handleBlur);
-        main.addEventListener('focusout', handleBlur);
-        main.focus();
-    };
+  const handleBlur = () => {
+    main.removeAttribute('tabindex');
+    main.removeEventListener('blur', handleBlur);
+    main.removeEventListener('focusout', handleBlur);
+  };
 
-    const handleBlur = () => {
-        main.removeAttribute('tabindex');
-        main.removeEventListener('blur', handleBlur);
-        main.removeEventListener('focusout', handleBlur);
-    };
+  const handleClick = () => {
+    main.setAttribute('tabindex', -1);
+    main.addEventListener('blur', handleBlur);
+    main.addEventListener('focusout', handleBlur);
+    main.focus();
+  };
 
-    skiplink.addEventListener('click', handleClick);
+  skiplink.addEventListener('click', handleClick);
 };
 
 export { initSkipLink };

--- a/client/src/includes/initSkipLink.js
+++ b/client/src/includes/initSkipLink.js
@@ -1,7 +1,7 @@
 const initSkipLink = () => {
   // Inspired by https://github.com/selfthinker/dokuwiki_template_writr/blob/master/js/skip-link-focus-fix.js
 
-  const skiplink = document.querySelector('.skiplink');
+  const skiplink = document.querySelector('[data-skiplink]');
   const main = document.querySelector('main');
 
   const handleBlur = () => {
@@ -17,7 +17,9 @@ const initSkipLink = () => {
     main.focus();
   };
 
-  if (skiplink) skiplink.addEventListener('click', handleClick);
+  if (skiplink && main) {
+    skiplink.addEventListener('click', handleClick);
+  }
 };
 
 export { initSkipLink };

--- a/client/src/includes/initSkipLink.js
+++ b/client/src/includes/initSkipLink.js
@@ -17,7 +17,7 @@ const initSkipLink = () => {
     main.focus();
   };
 
-  skiplink.addEventListener('click', handleClick);
+  if (skiplink) skiplink.addEventListener('click', handleClick);
 };
 
 export { initSkipLink };

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -12,6 +12,7 @@ import PublicationStatus from './components/PublicationStatus/PublicationStatus'
 import Transition from './components/Transition/Transition';
 import { initFocusOutline } from './utils/focus';
 import { initSubmenus } from './includes/initSubmenus';
+import { initSkipLink } from './includes/initSkipLink';
 import { initUpgradeNotification } from './components/UpgradeNotification';
 
 export {
@@ -26,5 +27,6 @@ export {
   initExplorer,
   initFocusOutline,
   initSubmenus,
+  initSkipLink,
   initUpgradeNotification,
 };

--- a/docs/releases/2.10.rst
+++ b/docs/releases/2.10.rst
@@ -70,6 +70,7 @@ Other features
  * Deprecate use of unidecode within form builder field names (Michael van Tellingen, LB (Ben Johnston))
  * Improve error feedback when editing a page with a missing model class (Andy Babic)
  * Change Wagtail tabs implementation to only allow slug-formatted tab identifiers, reducing false positives from security audits (Matt Westcott)
+ * Add skip link for keyboard users to bypass Wagtail navigation in the admin (Martin Coote)
 
 
 Bug fixes

--- a/wagtail/admin/static_src/wagtailadmin/app/wagtailadmin.entry.js
+++ b/wagtail/admin/static_src/wagtailadmin/app/wagtailadmin.entry.js
@@ -6,6 +6,7 @@ import {
   initExplorer,
   initFocusOutline,
   initSubmenus,
+  initSkipLink,
   initUpgradeNotification,
 } from 'wagtail-client';
 
@@ -37,4 +38,5 @@ document.addEventListener('DOMContentLoaded', () => {
   initFocusOutline();
   initSubmenus();
   initUpgradeNotification();
+  initSkipLink();
 });

--- a/wagtail/admin/static_src/wagtailadmin/js/core.js
+++ b/wagtail/admin/static_src/wagtailadmin/js/core.js
@@ -337,48 +337,6 @@ $(function() {
         }, 10);
     });
 });
-// =========================================================================================================
-// For focusing skiplink and other in page anchor tags in navigation
-// Sourced from https://github.com/selfthinker/dokuwiki_template_writr/blob/master/js/skip-link-focus-fix.js
-// =========================================================================================================
-
-(function($) {
-
-    jQuery.extend(jQuery.expr[':'], {
-      focusable: function(el, index, selector){
-        var $element = $(el);
-        return $element.is(':input:enabled, a[href], area[href], object, [tabindex]') && !$element.is(':hidden');
-      }
-    });
-
-    function focusOnElement($element) {
-      if (!$element.length) {
-        return;
-      }
-      if (!$element.is(':focusable')) {
-        // add tabindex to make focusable and remove again
-        $element.attr('tabindex', -1).on('blur focusout', function () {
-          $(this).removeAttr('tabindex');
-        });
-      }
-      $element.focus();
-    }
-
-    $(document).ready(function(){
-      // if there is a '#' in the URL (someone linking directly to a page with an anchor)
-      if (document.location.hash) {
-        focusOnElement($(document.location.hash));
-      }
-
-      // if the hash has been changed (activation of an in-page link)
-      $(window).bind('hashchange', function() {
-        var hash = "#"+window.location.hash.replace(/^#/,'');
-        focusOnElement($(hash));
-      });
-    });
-
-  })(jQuery);
-
 
 // =============================================================================
 // Wagtail global module, mainly useful for debugging.

--- a/wagtail/admin/static_src/wagtailadmin/js/core.js
+++ b/wagtail/admin/static_src/wagtailadmin/js/core.js
@@ -337,6 +337,47 @@ $(function() {
         }, 10);
     });
 });
+// =========================================================================================================
+// For focusing skiplink and other in page anchor tags in navigation
+// Sourced from https://github.com/selfthinker/dokuwiki_template_writr/blob/master/js/skip-link-focus-fix.js
+// =========================================================================================================
+
+(function($) {
+
+    jQuery.extend(jQuery.expr[':'], {
+      focusable: function(el, index, selector){
+        var $element = $(el);
+        return $element.is(':input:enabled, a[href], area[href], object, [tabindex]') && !$element.is(':hidden');
+      }
+    });
+
+    function focusOnElement($element) {
+      if (!$element.length) {
+        return;
+      }
+      if (!$element.is(':focusable')) {
+        // add tabindex to make focusable and remove again
+        $element.attr('tabindex', -1).on('blur focusout', function () {
+          $(this).removeAttr('tabindex');
+        });
+      }
+      $element.focus();
+    }
+
+    $(document).ready(function(){
+      // if there is a '#' in the URL (someone linking directly to a page with an anchor)
+      if (document.location.hash) {
+        focusOnElement($(document.location.hash));
+      }
+
+      // if the hash has been changed (activation of an in-page link)
+      $(window).bind('hashchange', function() {
+        var hash = "#"+window.location.hash.replace(/^#/,'');
+        focusOnElement($(hash));
+      });
+    });
+
+  })(jQuery);
 
 
 // =============================================================================

--- a/wagtail/admin/templates/wagtailadmin/base.html
+++ b/wagtail/admin/templates/wagtailadmin/base.html
@@ -24,7 +24,7 @@
         <div class="explorer__wrapper" data-explorer-menu></div>
     </aside>
 
-    <main class="content-wrapper" role="main">
+    <main class="content-wrapper" role="main" id="main">
         <div class="content">
             {# Always show messages div so it can be appended to by JS #}
             <div class="messages">

--- a/wagtail/admin/templates/wagtailadmin/skeleton.html
+++ b/wagtail/admin/templates/wagtailadmin/skeleton.html
@@ -19,7 +19,6 @@
     {% block branding_favicon %}{% endblock %}
 </head>
 <body id="wagtail" class="{% block bodyclass %}{% endblock %} {% if messages %}has-messages{% endif %} focus-outline-on">
-    <a class="skiplink button" href="#main">Skip to main content</a>
     <!--[if lt IE 9]>
         <p class="capabilitymessage">{% blocktrans %}You are using an <strong>outdated</strong> browser not supported by this software. Please <a href="https://browsehappy.com/">upgrade your browser</a>.{% endblocktrans %}</p>
     <![endif]-->
@@ -33,6 +32,8 @@
     {% icons %}
 
     {% block js %}{% endblock %}
+
+    <a class="skiplink button" href="#main" data-skiplink>{% trans 'Skip to main content' %}</a>
 
     <div class="wrapper">
        {% block furniture %}{% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/skeleton.html
+++ b/wagtail/admin/templates/wagtailadmin/skeleton.html
@@ -19,7 +19,7 @@
     {% block branding_favicon %}{% endblock %}
 </head>
 <body id="wagtail" class="{% block bodyclass %}{% endblock %} {% if messages %}has-messages{% endif %} focus-outline-on">
-    <a class="skiplink" href="#main">Skip to main content</a>
+    <a class="skiplink button" href="#main">Skip to main content</a>
     <!--[if lt IE 9]>
         <p class="capabilitymessage">{% blocktrans %}You are using an <strong>outdated</strong> browser not supported by this software. Please <a href="https://browsehappy.com/">upgrade your browser</a>.{% endblocktrans %}</p>
     <![endif]-->

--- a/wagtail/admin/templates/wagtailadmin/skeleton.html
+++ b/wagtail/admin/templates/wagtailadmin/skeleton.html
@@ -19,6 +19,7 @@
     {% block branding_favicon %}{% endblock %}
 </head>
 <body id="wagtail" class="{% block bodyclass %}{% endblock %} {% if messages %}has-messages{% endif %} focus-outline-on">
+    <a class="skiplink" href="#main">Skip to main content</a>
     <!--[if lt IE 9]>
         <p class="capabilitymessage">{% blocktrans %}You are using an <strong>outdated</strong> browser not supported by this software. Please <a href="https://browsehappy.com/">upgrade your browser</a>.{% endblocktrans %}</p>
     <![endif]-->


### PR DESCRIPTION
Closes #5406

Tested in:

- Safari MacOS 13.0.4
- Firefox MacOS 72.0.2
- Chrome MacOS 79 all using Voiceover
- Mobile Chrome 79 on Android using TalkBack screenreader
- IE11 on windows 10 via browserstack (no screen reader testing)

Implement a JS powered skip link inspired by this post https://axesslab.com/skip-links/ and specifically this update https://axesslab.com/skip-links#update-3-a-comment-from-gov-uk.

The functionality works as follows. 
1. When the skiplink button is clicked the main element gets the attribute `tabindex="-1"` 
2. on blur or focus out the tabindex is removed so it no longer interferes with the tabbing order.