### PR TITLE
 Add functionality to reorder pages with keyboard

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/pages/index.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/index.html
@@ -33,6 +33,73 @@
     <script type="text/javascript">
         {% if ordering == 'ord' %}
             $(function() {
+                var currentlySelected;
+                var currentPosition;
+                var movedPageId;
+                var moveNTimesDirection = 0;
+                $("*[id*=orderer]").on("keydown", function(e) {
+                    let keyCodes = {
+                        enter: 13,
+                        upArrow: 38,
+                        downArrow: 40,
+                        escape: 27
+                    }
+
+                    if (currentlySelected) {
+                        // We want to prevent default key actions (like scrolling) when we have an object selected
+                        e.preventDefault();
+                    }
+
+                    var children = $('.listing tbody').children();
+
+                    let moveElement = function() {
+                        var index = currentPosition + moveNTimesDirection;
+                        if (index < 0) {
+                            index = 0
+                        } else if (index > children.length - 1) {
+                            index = children.length - 1
+                        }
+                        var url = "{% url 'wagtailadmin_pages:set_page_position' '999999' %}".replace('999999', currentlySelected.id.substring(5));
+                        url += `?position=${(index)}`;
+                        let CSRFToken = $('input[name="csrfmiddlewaretoken"]', orderform).val();
+                        $.post(url, {csrfmiddlewaretoken: CSRFToken}, function(){
+                            addMessage('success', `"${$(currentlySelected).data('page-title')}" has been moved successfully.`)
+                        }).done(function() {
+                            currentlySelected = undefined;
+                        })
+                        if (moveNTimesDirection > 0) {
+                            $(currentlySelected).insertAfter($(children[index]));
+                        } else {
+                            $(currentlySelected).insertBefore($(children[index]));
+                        }
+                    }
+
+                    if(!currentlySelected && e.which == keyCodes.enter) {
+                        moveNTimesDirection = 0;
+                        currentlySelected = $(this).parents('tr')[0]
+                        children.toArray().forEach(function(item, index) {
+                            if (item === currentlySelected) {
+                                currentPosition = index;
+                            }
+                        })
+                    }
+                    if (currentlySelected && e.which == keyCodes.enter) {
+                        if (moveNTimesDirection != 0) {
+                            moveElement();
+                        }
+                    }
+
+                    if (currentlySelected && e.which == keyCodes.upArrow && children.first()[0] !== currentlySelected) {
+                        moveNTimesDirection--;
+                    };
+                    if (currentlySelected && e.which == keyCodes.downArrow && children.last()[0] !== currentlySelected) {
+                        moveNTimesDirection++;
+                    };
+                    if (currentlySelected && e.which == keyCodes.escape) {
+                        currentlySelected = undefined;
+                    }
+
+                })
                 var reorderCount = 0;
                 var orderform = $('#page-reorder-form');
 

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_list.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_list.html
@@ -48,7 +48,7 @@
                 {% page_permissions page as page_perms %}
                 <tr {% if ordering == "ord" %}id="page_{{ page.id|unlocalize }}" data-page-title="{{ page.get_admin_display_title }}"{% endif %} class="{% if not page.live %}unpublished{% endif %} {% block page_row_classname %}{% endblock %}">
                     {% if show_ordering_column %}
-                        <td class="ord">{% if orderable and ordering == "ord" %}<div class="handle icon icon-grip text-replace">{% trans 'Drag' %}</div>{% endif %}</td>
+                        <td class="ord">{% if orderable and ordering == "ord" %}<div tabindex="0" id="orderer" class="handle icon icon-grip text-replace">{% trans 'Drag' %}</div>{% endif %}</td>
                     {% endif %}
                     <td class="title" valign="top" data-listing-page-title>
                         {% block page_title %}


### PR DESCRIPTION
https://github.com/wagtail/wagtail/issues/5410

Added functionality to rearrange pages in the wagtail admin for keyboard-only users. To do this, you have to _tab_ through the elements after enabling ordering. Then select an element in the drop and drag area by pressing the enter key. You then selected the object and can use the up and down arrow keys to rearrange them. You can press the up or down arrow keys multiple times so you can place a page n amount of times higher or lower. Then press enter again to confirm and the page will be set accordingly in the list. You can deselect an object by pressing the escape key. 

This functionality uses the same backend call as drag and drop does. 