### PR TITLE
Replace welcome page for Squash instances

### DIFF
--- a/.squash.yml
+++ b/.squash.yml
@@ -16,6 +16,7 @@ deployments:
       - wagtail start mysite
       - cd /myproject/mysite
       - python manage.py migrate
+      - echo "<br><h1>Wagtail test instance</h1><p>Log into <a href='/admin/'>/admin/</a> with 'admin' / 'changeme'.</p>" > home/templates/home/welcome_page.html
       - echo "from django.contrib.auth import get_user_model; User = get_user_model(); User.objects.create_superuser('admin', 'admin@example.com', 'changeme')" | python manage.py shell    
     launch_steps:
       - cd /myproject/mysite


### PR DESCRIPTION
Update the default welcome page from `wagtail start`, for ephemeral Squash instances only.