### PR TITLE
Set context variable to None if no image provided to image template tag

### DIFF
--- a/wagtail/images/templatetags/wagtailimages_tags.py
+++ b/wagtail/images/templatetags/wagtailimages_tags.py
@@ -97,6 +97,8 @@ class ImageNode(template.Node):
             return ''
 
         if not image:
+            if self.output_var_name:
+                context[self.output_var_name] = None
             return ''
 
         if not hasattr(image, 'get_rendition'):

--- a/wagtail/images/tests/test_templatetags.py
+++ b/wagtail/images/tests/test_templatetags.py
@@ -1,0 +1,65 @@
+from django.template import Variable
+from django.test import TestCase
+
+from wagtail.images.models import Image, Rendition
+from wagtail.images.templatetags.wagtailimages_tags import ImageNode
+from wagtail.images.tests.utils import get_test_image_file
+
+
+class ImageNodeTestCase(TestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        # Create an image for running tests on
+        cls.image = Image.objects.create(
+            title="Test image",
+            file=get_test_image_file(),
+        )
+
+    def test_render_valid_image_to_string(self):
+        """
+        Tests that an ImageNode with a valid image renders an img tag
+        """
+        context = {'image': self.image}
+        node = ImageNode(Variable('image'), 'original')
+
+        rendered = node.render(context)
+
+        self.assertIn('<img alt="Test image"', rendered)
+
+    def test_render_none_to_string(self):
+        """
+        Tests that an ImageNode without image renders an empty string
+        """
+        context = {'image': None}
+        node = ImageNode(Variable('image'), 'original')
+
+        rendered = node.render(context)
+
+        self.assertEqual(rendered, '')
+
+    def test_render_valid_image_as_context_variable(self):
+        """
+        Tests that an ImageNode with a valid image and a context variable name
+        renders an empty string and puts a rendition in the context variable
+        """
+        context = {'image': self.image, 'image_node': 'fake value'}
+        node = ImageNode(Variable('image'), 'original', 'image_node')
+
+        rendered = node.render(context)
+
+        self.assertEqual(rendered, '')
+        self.assertIsInstance(context['image_node'], Rendition)
+
+    def test_render_none_as_context_variable(self):
+        """
+        Tests that an ImageNode without an image and a context variable name
+        renders an empty string and puts None in the context variable
+        """
+        context = {'image': None, 'image_node': 'fake value'}
+        node = ImageNode(Variable('image'), 'original', 'image_node')
+
+        rendered = node.render(context)
+
+        self.assertEqual(rendered, '')
+        self.assertIsNone(context['image_node'])


### PR DESCRIPTION
This PR improves the `image` template tag in `wagtailimages_tags`.

How to reproduce the issue it solves:
1. Set a context variable with a list of images and None values
    ```
    def get_context(self, request, *args, **kwargs):
        context =  super().get_context(*args, **kwargs)
        context[images] = [Image(), None]
    ``` 
1. Use the list in a template with the template tag using a context variable
    ```
    {% load wagtailimages_tags %}
    {% for instance in images %}
        {% image instance original as image_node %}
        <img src="{{ image_node.url }}" />
    {% endfor %} 
    ```

This code will render the first image twice as the second call the template tag doesn't clean the context variable. I know this issue could be prevented from the template as I could check for the value before calling the template tag but the template tag should be consistent itself and return the right value for the supplied one.

With this fix, if the supplied value is `None` then the expected context variable it is set to `None` too.

[x] Do the tests still pass? (https://docs.wagtail.io/en/latest/contributing/developing.html#testing)
[x] Does the code comply with the style guide? (Run `make lint` from the Wagtail root)
[x] For Python changes: Have you added tests to cover the new/fixed behavior?
[ ] For front-end changes: Did you test on all of Wagtail’s supported browsers? **Doesn't apply**.
[ ] For new features: Has the documentation been updated accordingly? **Doesn't apply**
