### PR TITLE
Add Vidyard to oEmbed provider whitelist

### DIFF
--- a/wagtail/embeds/oembed_providers.py
+++ b/wagtail/embeds/oembed_providers.py
@@ -642,6 +642,16 @@ tumblr = {
     ]
 }
 
+vidyard = {
+    "endpoint": "https://api.vidyard.com/dashboard/v1.1/oembed",
+    "urls": [
+        r'^http(?:s)?://play\.vidyard\.com/.+$',
+        r'^http(?:s)?://embed\.vidyard\.com/.+$',
+        r'^http(?:s)?://share\.vidyard\.com/.+$',
+        r'^http(?:s)?://.+?\.hubs\.vidyard\.com/.+$'
+    ]
+}
+
 all_providers = [
     speakerdeck, app_net, youtube, deviantart, blip_tv, dailymotion, flikr,
     hulu, nfb, qik, revision3, scribd, viddler, vimeo, dotsub, yfrog,
@@ -654,5 +664,5 @@ all_providers = [
     circuitlab, geograph_uk, hlipp, geograph_gg, vzaar, minoto, videojug, sapo,
     vhx_tv, justin_tv, official_fm, huffduffer, spotify, shoudio, mobypicture,
     twenty_three_hq, gmep, urtak, cacoo, dailymile, dipity, sketchfab, meetup,
-    roomshare, crowd_ranking, etsy, audioboom, clikthrough, ifttt, issuu, tumblr
+    roomshare, crowd_ranking, etsy, audioboom, clikthrough, ifttt, issuu, tumblr, vidyard
 ]


### PR DESCRIPTION
Hi Wagtail contributors! 

This PR adds Vidyard as an oEmbed provider, which enables content editors to embed their content hosted on Vidyard.

Verified locally that these embeds now work and that lint and tests pass. This is my first contribution to this project, so please let me know if any changes are needed for this PR to be acceptable.

[http://www.vidyard.com](http://www.vidyard.com)
> Vidyard is the video platform that helps businesses transform communications and drive more revenue through the strategic use of online video. Global leaders and industry pioneers such as Honeywell, McKesson, Lenovo, LinkedIn, Cision, Citibank, Marketo, MongoDB, GroupOn, Terminus and Sharp rely on Vidyard to power their video strategies and turn viewers into customers.