### PR TITLE
Allow url punctuation from RFC 3986

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -10,6 +10,7 @@ Changelog
  * Fix: Re-add 'Close Explorer' button on mobile viewports (Sævar Öfjörð Magnússon)
  * Fix: Add a more descriptive label to Password reset link for screen reader users (Casper Timmers, Martin Coote)
  * Fix: Improve Wagtail logo contrast by adding a background (Brian Edelman, Simon Evans, Ben Enright)
+ * Fix: Change url serving mechanism to allow url punctuations from RFC 3986 section 2.3 (https://www.ietf.org/rfc/rfc3986.txt) (Storm Heg)
  * Support the rel attribute on custom ModelAdmin buttons (Andy Chosak)
 
 

--- a/wagtail/contrib/routable_page/tests.py
+++ b/wagtail/contrib/routable_page/tests.py
@@ -1,6 +1,7 @@
 from unittest import mock
 
 from django.test import RequestFactory, TestCase
+from django.test.utils import override_settings
 from django.urls.exceptions import NoReverseMatch
 
 from wagtail.contrib.routable_page.templatetags.wagtailroutablepage_tags import routablepageurl
@@ -128,6 +129,17 @@ class TestRoutablePage(TestCase):
         response = self.client.get(self.routable_page.url + 'external-no-arg/')
 
         self.assertContains(response, "EXTERNAL VIEW: ARG NOT SET")
+
+    def test_get_external_view_allows_punctuation(self):
+        response = self.client.get(self.routable_page.url + "external/joe-._~%!$&'()*+,;=:@bloggs/")
+
+        self.assertContains(response, "EXTERNAL VIEW: joe-._~%!$&'()*+,;=:@bloggs")
+
+    @override_settings(WAGTAIL_APPEND_SLASH=False, APPEND_SLASH=False)
+    def test_get_external_view_allows_punctuation_no_append_slash(self):
+        response = self.client.get(self.routable_page.url + "external/joe-._~%!$&'()*+,;=:@bloggs/")
+
+        self.assertContains(response, "EXTERNAL VIEW: joe-._~%!$&'()*+,;=:@bloggs")
 
     def test_routable_page_can_have_instance_bound_descriptors(self):
         # This descriptor pretends that it does not exist in the class, hence

--- a/wagtail/contrib/routable_page/tests.py
+++ b/wagtail/contrib/routable_page/tests.py
@@ -131,15 +131,16 @@ class TestRoutablePage(TestCase):
         self.assertContains(response, "EXTERNAL VIEW: ARG NOT SET")
 
     def test_get_external_view_allows_punctuation(self):
-        response = self.client.get(self.routable_page.url + "external/joe-._~%!$&'()*+,;=:@bloggs/")
+        response = self.client.get(self.routable_page.url + "external/joe-._~bloggs/")
 
-        self.assertContains(response, "EXTERNAL VIEW: joe-._~%!$&'()*+,;=:@bloggs")
+        self.assertContains(response, "EXTERNAL VIEW: joe-._~bloggs")
 
     @override_settings(WAGTAIL_APPEND_SLASH=False, APPEND_SLASH=False)
-    def test_get_external_view_allows_punctuation_no_append_slash(self):
-        response = self.client.get(self.routable_page.url + "external/joe-._~%!$&'()*+,;=:@bloggs/")
+    def test_get_external_view_allows_punctuation_no_append_slash_with_slash(self):
+        # We are testing this with a slash because of this issue: https://github.com/wagtail/wagtail/issues/2871
+        response = self.client.get(self.routable_page.url + "external/joe-._~bloggs/")
 
-        self.assertContains(response, "EXTERNAL VIEW: joe-._~%!$&'()*+,;=:@bloggs")
+        self.assertContains(response, "EXTERNAL VIEW: joe-._~bloggs")
 
     def test_routable_page_can_have_instance_bound_descriptors(self):
         # This descriptor pretends that it does not exist in the class, hence

--- a/wagtail/core/urls.py
+++ b/wagtail/core/urls.py
@@ -5,16 +5,20 @@ from django.contrib.auth import views as auth_views
 from wagtail.core import views
 from wagtail.core.utils import WAGTAIL_APPEND_SLASH
 
+# Allowed punctuation from RFC 3986
+# Section 2.3: "-" / "." / "_" / "~"
+ALLOWED_PUNCTUATION = r"\-._~"
+
 if WAGTAIL_APPEND_SLASH:
     # If WAGTAIL_APPEND_SLASH is True (the default value), we match a
     # (possibly empty) list of path segments ending in slashes.
     # CommonMiddleware will redirect requests without a trailing slash to
     # a URL with a trailing slash
-    serve_pattern = r'^((?:[\w\-]+/)*)$'
+    serve_pattern = r"^((?:[\w{}]+/)*)$".format(ALLOWED_PUNCTUATION)
 else:
     # If WAGTAIL_APPEND_SLASH is False, allow Wagtail to serve pages on URLs
     # with and without trailing slashes
-    serve_pattern = r'^([\w\-/]*)$'
+    serve_pattern = r"^([\w{}/]*)$".format(ALLOWED_PUNCTUATION)
 
 
 WAGTAIL_FRONTEND_LOGIN_TEMPLATE = getattr(

--- a/wagtail/images/tests/tests.py
+++ b/wagtail/images/tests/tests.py
@@ -337,8 +337,8 @@ class TestFrontendServeView(TestCase):
         # Generate signature
         signature = generate_signature(self.image.id, 'fill-800x600')
 
-        # Get the image
-        response = self.client.get(reverse('wagtailimages_serve', args=(signature, self.image.id, 'fill-800x600')) + 'test/test.png')
+        # Get the image. Follow redirect because Wagtail attempts to serve the url as "." is part of the url match.
+        response = self.client.get(reverse('wagtailimages_serve', args=(signature, self.image.id, 'fill-800x600')) + 'test/test.png', follow=True)
 
         # URL pattern should not match
         self.assertEqual(response.status_code, 404)


### PR DESCRIPTION
This fixes #3653 by changing the regex against which urls are matched.

I took some of the allowed punctuation characters from [this comment](https://github.com/wagtail/wagtail/issues/3653#issuecomment-532596885) by @gasman 

`- . _ ~` are unreserved characters as stated in section 2.3 of [RFC 3986](https://www.ietf.org/rfc/rfc3986.txt)

I think we should allow all characters because of percentage encoding. Django sees the decoded url which could include things like spaces (`%20`). This could be used in a filename with spaces.

When I wrote the tests for this PR I also encountered issue #2871. Left a note about it in the test.

Feedback is appreciated!
