### PR TITLE
Make server-side slug generation respect WAGTAIL_ALLOW_UNICODE_SLUGS

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -430,6 +430,7 @@ Contributors
 * Eric Sherman
 * Martin Coote
 * Simon Evans
+* Arkadiusz Michał Ryś
 
 Translators
 ===========

--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -431,7 +431,8 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
 
         if not self.slug:
             # Try to auto-populate slug from title
-            base_slug = slugify(self.title, allow_unicode=True)
+            allow_unicode = getattr(settings, 'WAGTAIL_ALLOW_UNICODE_SLUGS', True)
+            base_slug = slugify(self.title, allow_unicode=allow_unicode)
 
             # only proceed if we get a non-empty base slug back from slugify
             if base_slug:

--- a/wagtail/core/tests/test_page_model.py
+++ b/wagtail/core/tests/test_page_model.py
@@ -84,6 +84,18 @@ class TestValidation(TestCase):
         homepage.add_child(instance=christmas_page)
         self.assertTrue(Page.objects.filter(id=christmas_page.id).exists())
 
+    @override_settings(WAGTAIL_ALLOW_UNICODE_SLUGS=True)
+    def test_slug_generation_respects_unicode_setting_true(self):
+        page = Page(title="A mööse bit me önce")
+        Page.get_first_root_node().add_child(instance=page)
+        self.assertEqual(page.slug, 'a-mööse-bit-me-önce')
+
+    @override_settings(WAGTAIL_ALLOW_UNICODE_SLUGS=False)
+    def test_slug_generation_respects_unicode_setting_false(self):
+        page = Page(title="A mööse bit me önce")
+        Page.get_first_root_node().add_child(instance=page)
+        self.assertEqual(page.slug, 'a-moose-bit-me-once')
+
     def test_get_admin_display_title(self):
         homepage = Page.objects.get(url_path='/home/')
         self.assertEqual(homepage.draft_title, homepage.get_admin_display_title())


### PR DESCRIPTION
This fixes #5805 by checking the WAGTAIL_ALLOW_UNICODE_SLUGS setting before the slug is created.

I added two tests, one for each case. I based the tests on the original report.

I don't know if this needs a documentation update.
