### PR TITLE
Show InlinePanel non field validation errors

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -15,6 +15,7 @@ Changelog
  * Fix: Add a more descriptive label to Password reset link for screen reader users (Casper Timmers, Martin Coote)
  * Fix: Improve Wagtail logo contrast by adding a background (Brian Edelman, Simon Evans, Ben Enright)
  * Fix: Prevent duplicate notification messages on page locking (Jacob Topp-Mugglestone)
+ * Fix: Fix InlinePanel item non field errors not visible (Storm Heg)
 
 
 2.8 (03.02.2020)

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -432,6 +432,7 @@ Contributors
 * Simon Evans
 * Arkadiusz Michał Ryś
 * James O'Toole
+* Storm Heg
 
 Translators
 ===========

--- a/wagtail/admin/templates/wagtailadmin/edit_handlers/inline_panel_child.html
+++ b/wagtail/admin/templates/wagtailadmin/edit_handlers/inline_panel_child.html
@@ -1,5 +1,14 @@
 {% load i18n %}
 <li data-inline-panel-child id="inline_child_{{ child.form.prefix }}">
+    {% if child.form.non_field_errors %}
+    <ul>
+        <li class="error-message">
+            {% for error in child.form.non_field_errors %}
+                <span>{{ error|escape }}</span>
+            {% endfor %}
+        </li>
+    </ul>
+    {% endif %}
     <ul class="controls">
         {% if can_order %}
             <li><button type="button" class="button icon text-replace white icon-order-up inline-child-move-up" id="{{ child.form.prefix }}-move-up" title="{% trans 'Move up' %}">{% trans "Move up" %}</button></li>

--- a/wagtail/admin/templates/wagtailadmin/edit_handlers/inline_panel_child.html
+++ b/wagtail/admin/templates/wagtailadmin/edit_handlers/inline_panel_child.html
@@ -2,11 +2,11 @@
 <li data-inline-panel-child id="inline_child_{{ child.form.prefix }}">
     {% if child.form.non_field_errors %}
     <ul>
-        <li class="error-message">
-            {% for error in child.form.non_field_errors %}
+        {% for error in child.form.non_field_errors %}
+            <li class="error-message">
                 <span>{{ error|escape }}</span>
-            {% endfor %}
-        </li>
+            </li>
+        {% endfor %}
     </ul>
     {% endif %}
     <ul class="controls">

--- a/wagtail/tests/demosite/models.py
+++ b/wagtail/tests/demosite/models.py
@@ -1,5 +1,6 @@
 from datetime import date
 
+from django.core.exceptions import ValidationError
 from django.core.paginator import Paginator
 from django.db import models
 from modelcluster.contrib.taggit import ClusterTaggableManager
@@ -44,6 +45,10 @@ class AbstractLinkFields(models.Model):
             return self.link_document.url
         else:
             return self.link_external
+
+    def clean(self):
+        if self.link_page is None and self.link_document is None and not self.link_external:
+            raise ValidationError('You must provide a related page, related document or an external URL')
 
     api_fields = ('link', )
 


### PR DESCRIPTION
This fixes https://github.com/wagtail/wagtail/issues/3890.
Non field form errors were not rendered for InlinePanel items. This PR fixes the issue and renders the error message like this:
![Screenshot 2020-02-06 at 11 17 38](https://user-images.githubusercontent.com/13856515/73932819-f9d46600-48d2-11ea-92fa-816bd47c9d1d.png)

I've added a test case for the issue.
Feedback is appreciated