### PR TITLE
Routable Page url reversing honour WAGTAIL_APPEND_SLASH setting

### DIFF
--- a/wagtail/contrib/routable_page/models.py
+++ b/wagtail/contrib/routable_page/models.py
@@ -6,6 +6,7 @@ from django.urls.resolvers import RegexPattern
 
 from wagtail.core.models import Page
 from wagtail.core.url_routing import RouteResult
+from wagtail.core.utils import WAGTAIL_APPEND_SLASH
 
 
 _creation_counter = 0
@@ -82,7 +83,12 @@ class RoutablePageMixin:
         args = args or []
         kwargs = kwargs or {}
 
-        return self.get_resolver().reverse(name, *args, **kwargs)
+        url = self.get_resolver().reverse(name, *args, **kwargs)
+
+        # Strip the trailing slash if WAGTAIL_APPEND_SLASH is False
+        if url.endswith('/') and not WAGTAIL_APPEND_SLASH:
+            url = url[:-1]
+        return url
 
     def resolve_subpage(self, path):
         """

--- a/wagtail/contrib/routable_page/tests.py
+++ b/wagtail/contrib/routable_page/tests.py
@@ -186,10 +186,10 @@ class TestRoutablePageTemplateTag(TestCase):
         self.assertEqual(url, '/%s/external/joe-bloggs/' % self.routable_page.slug)
 
     def test_templatetag_reverse_external_view_without_append_slash(self):
-        with mock.patch('wagtail.core.models.WAGTAIL_APPEND_SLASH', False):
+        with mock.patch('wagtail.contrib.routable_page.models.WAGTAIL_APPEND_SLASH', False):
             url = routablepageurl(self.context, self.routable_page,
                                   'external_view', 'joe-bloggs')
-            expected = '/' + self.routable_page.slug + '/' + 'external/joe-bloggs/'
+            expected = '/' + self.routable_page.slug + '/' + 'external/joe-bloggs'
 
         self.assertEqual(url, expected)
 
@@ -244,10 +244,10 @@ class TestRoutablePageTemplateTagForSecondSiteAtSameRoot(TestCase):
         self.assertEqual(url, '/%s/external/joe-bloggs/' % self.routable_page.slug)
 
     def test_templatetag_reverse_external_view_without_append_slash(self):
-        with mock.patch('wagtail.core.models.WAGTAIL_APPEND_SLASH', False):
+        with mock.patch('wagtail.contrib.routable_page.models.WAGTAIL_APPEND_SLASH', False):
             url = routablepageurl(self.context, self.routable_page,
                                   'external_view', 'joe-bloggs')
-            expected = '/' + self.routable_page.slug + '/' + 'external/joe-bloggs/'
+            expected = '/' + self.routable_page.slug + '/' + 'external/joe-bloggs'
 
         self.assertEqual(url, expected)
 
@@ -303,9 +303,9 @@ class TestRoutablePageTemplateTagForSecondSiteAtDifferentRoot(TestCase):
         self.assertEqual(url, 'http://localhost/%s/external/joe-bloggs/' % self.routable_page.slug)
 
     def test_templatetag_reverse_external_view_without_append_slash(self):
-        with mock.patch('wagtail.core.models.WAGTAIL_APPEND_SLASH', False):
+        with mock.patch('wagtail.contrib.routable_page.models.WAGTAIL_APPEND_SLASH', False):
             url = routablepageurl(self.context, self.routable_page,
                                   'external_view', 'joe-bloggs')
-            expected = 'http://localhost/' + self.routable_page.slug + '/' + 'external/joe-bloggs/'
+            expected = 'http://localhost/' + self.routable_page.slug + '/' + 'external/joe-bloggs'
 
         self.assertEqual(url, expected)


### PR DESCRIPTION
Urls generated when the `WAGTAIL_APPEND_SLASH` is false should look like this: `/archive/year/2020`. Notice that there is no trailing slash at the end.

This works fine with the exception being the `reverse_subpage()` method on RoutablePageMixin.

This pull request fixes `reverse_subpage` to take this setting into account.