### PR TITLE
Fix Wagtail admin crashing when wagtail_serve is not registered in urls

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_list_explore.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_list_explore.html
@@ -34,7 +34,7 @@
                     {% endblocktrans %}
                 {% endif %}
             </div></td></tr>
-        {% elif not parent_page.url %}
+        {% elif not parent_page.get_site %}
             <tr><td colspan="6"><div class="help-block help-warning">
                 {% if perms.wagtailcore.add_site %}
                     {% url 'wagtailsites:index' as wagtailsites_index_url %}

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_list_explore.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_list_explore.html
@@ -34,7 +34,8 @@
                     {% endblocktrans %}
                 {% endif %}
             </div></td></tr>
-        {% elif not parent_page.get_site %}
+        {# get_url_parts will return None is the page has no site #}
+        {% elif not parent_page.get_url_parts %}
             <tr><td colspan="6"><div class="help-block help-warning">
                 {% if perms.wagtailcore.add_site %}
                     {% url 'wagtailsites:index' as wagtailsites_index_url %}

--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -796,7 +796,7 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
             page_path = reverse(
                 'wagtail_serve', args=(self.url_path[len(root_path):],))
         except NoReverseMatch:
-            return None
+            return (site_id, None, None)
 
         # Remove the trailing slash from the URL reverse generates if
         # WAGTAIL_APPEND_SLASH is False and we're not trying to serve
@@ -810,7 +810,7 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
         """Return the full URL (including protocol / domain) to this page, or None if it is not routable"""
         url_parts = self.get_url_parts(request=request)
 
-        if url_parts is None:
+        if url_parts is None or url_parts[1] is None and url_parts[2] is None:
             # page is not routable
             return
 
@@ -841,7 +841,7 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
             current_site = getattr(request, 'site', None)
         url_parts = self.get_url_parts(request=request)
 
-        if url_parts is None:
+        if url_parts is None or url_parts[1] is None and url_parts[2] is None:
             # page is not routable
             return
 

--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -17,7 +17,7 @@ from django.db.models import Case, Q, Value, When
 from django.db.models.functions import Concat, Substr
 from django.http import Http404
 from django.template.response import TemplateResponse
-from django.urls import reverse
+from django.urls import NoReverseMatch, reverse
 from django.utils import timezone
 from django.utils.functional import cached_property
 from django.utils.text import capfirst, slugify
@@ -790,8 +790,13 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
             else:
                 site_id, root_path, root_url = possible_sites[0]
 
-        page_path = reverse(
-            'wagtail_serve', args=(self.url_path[len(root_path):],))
+        # The page may not be routable because wagtail_serve is not registered
+        # This may be the case if Wagtail is used headless
+        try:
+            page_path = reverse(
+                'wagtail_serve', args=(self.url_path[len(root_path):],))
+        except NoReverseMatch:
+            return None
 
         # Remove the trailing slash from the URL reverse generates if
         # WAGTAIL_APPEND_SLASH is False and we're not trying to serve

--- a/wagtail/core/tests/test_page_model.py
+++ b/wagtail/core/tests/test_page_model.py
@@ -339,6 +339,18 @@ class TestRouting(TestCase):
         self.assertEqual(christmas_page.relative_url(default_site), '/site/events/christmas/')
         self.assertEqual(christmas_page.get_site(), default_site)
 
+    @override_settings(ROOT_URLCONF='wagtail.tests.headless_urls')
+    def test_urls_headless(self):
+        homepage = Page.objects.get(url_path='/home/')
+
+        # The page should not be routable because wagtail_serve is not registered
+        self.assertEqual(
+            homepage.get_url_parts(),
+            None
+        )
+        self.assertEqual(homepage.full_url, None)
+        self.assertEqual(homepage.url, None)
+
     def test_request_routing(self):
         homepage = Page.objects.get(url_path='/home/')
         christmas_page = EventPage.objects.get(url_path='/home/events/christmas/')

--- a/wagtail/core/tests/test_page_model.py
+++ b/wagtail/core/tests/test_page_model.py
@@ -341,12 +341,14 @@ class TestRouting(TestCase):
 
     @override_settings(ROOT_URLCONF='wagtail.tests.headless_urls')
     def test_urls_headless(self):
+        default_site = Site.objects.get(is_default_site=True)
         homepage = Page.objects.get(url_path='/home/')
 
         # The page should not be routable because wagtail_serve is not registered
+        # However it is still associated with a site
         self.assertEqual(
             homepage.get_url_parts(),
-            None
+            (default_site.id, None, None)
         )
         self.assertEqual(homepage.full_url, None)
         self.assertEqual(homepage.url, None)

--- a/wagtail/tests/headless_urls.py
+++ b/wagtail/tests/headless_urls.py
@@ -1,0 +1,13 @@
+"""An alternative urlconf module where Wagtail does not serve front-end URLs"""
+
+from django.conf.urls import include, url
+
+from wagtail.admin import urls as wagtailadmin_urls
+from wagtail.documents import urls as wagtaildocs_urls
+from wagtail.images import urls as wagtailimages_urls
+
+urlpatterns = [
+    url(r'^admin/', include(wagtailadmin_urls)),
+    url(r'^documents/', include(wagtaildocs_urls)),
+    url(r'^images/', include(wagtailimages_urls)),
+]


### PR DESCRIPTION
This fixes #4276 

Wagtail's Page model `get_url_parts()` raises a `NoReverseMatch` exception if `wagtail_serve` is not registered in the urls. This PR fixes that behaviour by returning None instead. This should prevent the Wagtail admin from crashing because it tried to reverse a page url (as described in the linked issue).

When testing the changes described above I ran into a few regressions. `Page.get_site()` was no longer working and the Wagtail admin would display an inaccurate warning that a Site should be setup.

I asked @gasman what to do about this and a fix was suggested which involves having `Page.get_url_parts()` return a tuple that looks like `(site_id, None, None)` if the page is not routable but has a site associated. This fix has been implemented in this PR.

A test has been added. I don't think further admin tests are necessary because it already handles cases where None is returned when reversing the page url. In that case it doesn't show "view live" buttons. 

I feel like this PR is a step towards a more headless capable Wagtail.

Feedback welcome!
