### PR TITLE
Replace calls to django.conf.urls.url with path and re_path

### DIFF
--- a/docs/advanced_topics/add_to_django_project.rst
+++ b/docs/advanced_topics/add_to_django_project.rst
@@ -368,7 +368,7 @@ These two files should reside in your project directory (``myproject/myproject/`
 
 .. code-block:: python
 
-  from django.conf.urls import include, re_path
+  from django.urls import include, re_path
   from django.conf.urls.static import static
   from django.views.generic.base import RedirectView
   from django.contrib import admin

--- a/docs/advanced_topics/add_to_django_project.rst
+++ b/docs/advanced_topics/add_to_django_project.rst
@@ -140,10 +140,10 @@ URL Patterns
   from wagtail.documents import urls as wagtaildocs_urls
 
   urlpatterns = [
-      re_path(r'^django-admin/', include(admin.site.urls)),
+      path('django-admin/', admin.site.urls),
 
-      re_path(r'^admin/', include(wagtailadmin_urls)),
-      re_path(r'^documents/', include(wagtaildocs_urls)),
+      path('admin/', include(wagtailadmin_urls)),
+      path('documents/', include(wagtaildocs_urls)),
 
       # Optional URL for including your own vanilla Django urls/views
       re_path(r'', include('myapp.urls')),
@@ -368,7 +368,7 @@ These two files should reside in your project directory (``myproject/myproject/`
 
 .. code-block:: python
 
-  from django.urls import include, re_path
+  from django.urls import include, path, re_path
   from django.conf.urls.static import static
   from django.views.generic.base import RedirectView
   from django.contrib import admin
@@ -381,10 +381,10 @@ These two files should reside in your project directory (``myproject/myproject/`
 
 
   urlpatterns = [
-      re_path(r'^django-admin/', include(admin.site.urls)),
+      path('django-admin/', admin.site.urls),
 
-      re_path(r'^admin/', include(wagtailadmin_urls)),
-      re_path(r'^documents/', include(wagtaildocs_urls)),
+      path('admin/', include(wagtailadmin_urls)),
+      path('documents/', include(wagtaildocs_urls)),
 
       # For anything not caught by a more specific rule above, hand over to
       # Wagtail's serving mechanism
@@ -398,5 +398,5 @@ These two files should reside in your project directory (``myproject/myproject/`
       urlpatterns += staticfiles_urlpatterns() # tell gunicorn where static files are in dev mode
       urlpatterns += static(settings.MEDIA_URL + 'images/', document_root=os.path.join(settings.MEDIA_ROOT, 'images'))
       urlpatterns += [
-          re_path(r'^favicon\.ico$', RedirectView.as_view(url=settings.STATIC_URL + 'myapp/images/favicon.ico'))
+          path('favicon.ico', RedirectView.as_view(url=settings.STATIC_URL + 'myapp/images/favicon.ico'))
       ]

--- a/docs/advanced_topics/amp.rst
+++ b/docs/advanced_topics/amp.rst
@@ -163,7 +163,7 @@ file for the ``/amp`` prefix:
         # Change this line to point at your amp_urls instead of Wagtail's urls
         path('amp/', include(wagtail_amp_urls)),
 
-        path('', include(wagtail_urls)),
+        re_path(r'', include(wagtail_urls)),
     ]
 
 After this, there shouldn't be any noticeable difference to the AMP version of

--- a/docs/advanced_topics/amp.rst
+++ b/docs/advanced_topics/amp.rst
@@ -37,9 +37,9 @@ the default URL from Wagtail, or it will try to find ``/amp`` as a page:
 
     urlpatterns += [
         # Add this line just before the default ``include(wagtail_urls)`` line
-        url(r'amp/', include(wagtail_urls)),
+        path('amp/', include(wagtail_urls)),
 
-        url(r'', include(wagtail_urls)),
+        path('', include(wagtail_urls)),
     ]
 
 If you now open ``http://localhost:8000/amp/`` in your browser, you should see
@@ -141,13 +141,13 @@ Then we need to create a ``amp_urls.py`` file in the same app:
 
     # <app>/amp_urls.py
 
-    from django.conf.urls import url
+    from django.urls import re_path
     from wagtail.core.urls import serve_pattern
 
     from . import amp_views
 
     urlpatterns = [
-        url(serve_pattern, amp_views.serve, name='wagtail_amp_serve')
+        re_path(serve_pattern, amp_views.serve, name='wagtail_amp_serve')
     ]
 
 Finally, we need to update the project's main ``urls.py`` to use this new URLs
@@ -161,9 +161,9 @@ file for the ``/amp`` prefix:
 
     urlpatterns += [
         # Change this line to point at your amp_urls instead of Wagtail's urls
-        url(r'amp/', include(wagtail_amp_urls)),
+        path('amp/', include(wagtail_amp_urls)),
 
-        url(r'', include(wagtail_urls)),
+        path('', include(wagtail_urls)),
     ]
 
 After this, there shouldn't be any noticeable difference to the AMP version of

--- a/docs/advanced_topics/api/v2/configuration.rst
+++ b/docs/advanced_topics/api/v2/configuration.rst
@@ -87,12 +87,12 @@ Next, register the URLs so Django can route requests into the API:
     urlpatterns = [
         ...
 
-        url(r'^api/v2/', api_router.urls),
+        path('api/v2/', api_router.urls),
 
         ...
 
         # Ensure that the api_router line appears above the default Wagtail page serving route
-        url(r'', include(wagtail_urls)),
+        re_path('^', include(wagtail_urls)),
     ]
 
 With this configuration, pages will be available at ``/api/v2/pages/``, images

--- a/docs/advanced_topics/images/image_serve_view.rst
+++ b/docs/advanced_topics/images/image_serve_view.rst
@@ -33,7 +33,7 @@ Add an entry for the view into your URLs configuration:
         ...
 
         # Ensure that the wagtailimages_serve line appears above the default Wagtail page serving route
-        path('', include(wagtail_urls)),
+        re_path(r'', include(wagtail_urls)),
     ]
 
 Usage

--- a/docs/advanced_topics/images/image_serve_view.rst
+++ b/docs/advanced_topics/images/image_serve_view.rst
@@ -28,12 +28,12 @@ Add an entry for the view into your URLs configuration:
     urlpatterns = [
         ...
 
-        url(r'^images/([^/]*)/(\d*)/([^/]*)/[^/]*$', ServeView.as_view(), name='wagtailimages_serve'),
+        re_path(r'^images/([^/]*)/(\d*)/([^/]*)/[^/]*$', ServeView.as_view(), name='wagtailimages_serve'),
 
         ...
 
         # Ensure that the wagtailimages_serve line appears above the default Wagtail page serving route
-        url(r'', include(wagtail_urls)),
+        path('', include(wagtail_urls)),
     ]
 
 Usage
@@ -121,7 +121,7 @@ method in your urls configuration:
    urlpatterns = [
        ...
 
-       url(r'^images/([^/]*)/(\d*)/([^/]*)/[^/]*$', ServeView.as_view(action='redirect'), name='wagtailimages_serve'),
+       re_path(r'^images/([^/]*)/(\d*)/([^/]*)/[^/]*$', ServeView.as_view(action='redirect'), name='wagtailimages_serve'),
    ]
 
 .. _image_serve_view_sendfile:
@@ -150,7 +150,7 @@ This view can be used out of the box:
    urlpatterns = [
        ...
 
-       url(r'^images/([^/]*)/(\d*)/([^/]*)/[^/]*$', SendFileView.as_view(), name='wagtailimages_serve'),
+       re_path(r'^images/([^/]*)/(\d*)/([^/]*)/[^/]*$', SendFileView.as_view(), name='wagtailimages_serve'),
    ]
 
 You can customise it to override the backend defined in the ``SENDFILE_BACKEND``

--- a/docs/getting_started/integrating_into_django.rst
+++ b/docs/getting_started/integrating_into_django.rst
@@ -77,9 +77,9 @@ Now make the following additions to your ``urls.py`` file:
 
     urlpatterns = [
         ...
-        re_path(r'^cms/', include(wagtailadmin_urls)),
-        re_path(r'^documents/', include(wagtaildocs_urls)),
-        re_path(r'^pages/', include(wagtail_urls)),
+        path('cms/', include(wagtailadmin_urls)),
+        path('documents/', include(wagtaildocs_urls)),
+        path('pages/', include(wagtail_urls)),
         ...
     ]
 

--- a/docs/reference/contrib/sitemaps.rst
+++ b/docs/reference/contrib/sitemaps.rst
@@ -47,12 +47,12 @@ sitemap:
     urlpatterns = [
         ...
 
-        url('^sitemap\.xml$', sitemap),
+        path('sitemap.xml', sitemap),
 
         ...
 
         # Ensure that the 'sitemap' line appears above the default Wagtail page serving route
-        url(r'', include(wagtail_urls)),
+        path('', include(wagtail_urls)),
     ]
 
 

--- a/docs/reference/contrib/sitemaps.rst
+++ b/docs/reference/contrib/sitemaps.rst
@@ -52,7 +52,7 @@ sitemap:
         ...
 
         # Ensure that the 'sitemap' line appears above the default Wagtail page serving route
-        path('', include(wagtail_urls)),
+        re_path(r'', include(wagtail_urls)),
     ]
 
 

--- a/docs/reference/hooks.rst
+++ b/docs/reference/hooks.rst
@@ -184,7 +184,7 @@ Hooks for building new areas of the admin interface (alongside pages, images, do
   .. code-block:: python
 
     from django.http import HttpResponse
-    from django.conf.urls import url
+    from django.urls import path
 
     from wagtail.core import hooks
 
@@ -196,7 +196,7 @@ Hooks for building new areas of the admin interface (alongside pages, images, do
     @hooks.register('register_admin_urls')
     def urlconf_time():
       return [
-        url(r'^how_did_you_almost_know_my_name/$', admin_view, name='frank'),
+        path('how_did_you_almost_know_my_name/', admin_view, name='frank'),
       ]
 
 

--- a/wagtail/admin/api/urls.py
+++ b/wagtail/admin/api/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url
+from django.urls import path
 
 from wagtail.api.v2.router import WagtailAPIRouter
 from wagtail.core import hooks
@@ -12,5 +12,5 @@ for fn in hooks.get_hooks('construct_admin_api'):
     fn(admin_api)
 
 urlpatterns = [
-    url(r'^main/', admin_api.urls),
+    path('main/', admin_api.urls),
 ]

--- a/wagtail/admin/urls/__init__.py
+++ b/wagtail/admin/urls/__init__.py
@@ -1,6 +1,6 @@
 import functools
 
-from django.conf.urls import url, include
+from django.urls import include, path, re_path
 from django.views.decorators.cache import never_cache
 from django.views.generic import TemplateView
 from django.http import Http404
@@ -18,57 +18,57 @@ from wagtail.utils.urlpatterns import decorate_urlpatterns
 
 
 urlpatterns = [
-    url(r'^$', home.home, name='wagtailadmin_home'),
+    path('', home.home, name='wagtailadmin_home'),
 
-    url(r'^test404/$', TemplateView.as_view(template_name='wagtailadmin/404.html')),
+    path('test404/', TemplateView.as_view(template_name='wagtailadmin/404.html')),
 
-    url(r'api/', include(api_urls)),
+    path('api/', include(api_urls)),
 
-    url(r'^failwhale/$', home.error_test, name='wagtailadmin_error_test'),
-
-    # TODO: Move into wagtailadmin_pages namespace
-    url(r'^pages/$', pages.index, name='wagtailadmin_explore_root'),
-    url(r'^pages/(\d+)/$', pages.index, name='wagtailadmin_explore'),
-
-    url(r'^pages/', include(wagtailadmin_pages_urls, namespace='wagtailadmin_pages')),
+    path('failwhale/', home.error_test, name='wagtailadmin_error_test'),
 
     # TODO: Move into wagtailadmin_pages namespace
-    url(r'^choose-page/$', chooser.browse, name='wagtailadmin_choose_page'),
-    url(r'^choose-page/(\d+)/$', chooser.browse, name='wagtailadmin_choose_page_child'),
-    url(r'^choose-page/search/$', chooser.search, name='wagtailadmin_choose_page_search'),
-    url(r'^choose-external-link/$', chooser.external_link, name='wagtailadmin_choose_page_external_link'),
-    url(r'^choose-email-link/$', chooser.email_link, name='wagtailadmin_choose_page_email_link'),
-    url(r'^choose-phone-link/$', chooser.phone_link, name='wagtailadmin_choose_page_phone_link'),
-    url(r'^choose-anchor-link/$', chooser.anchor_link, name='wagtailadmin_choose_page_anchor_link'),
+    path('pages/', pages.index, name='wagtailadmin_explore_root'),
+    re_path(r'^pages/(\d+)/$', pages.index, name='wagtailadmin_explore'),
 
-    url(r'^tag-autocomplete/$', tags.autocomplete, name='wagtailadmin_tag_autocomplete'),
-    url(r'^tag-autocomplete/(\w+)/(\w+)/$', tags.autocomplete, name='wagtailadmin_tag_model_autocomplete'),
+    path('pages/', include(wagtailadmin_pages_urls, namespace='wagtailadmin_pages')),
 
-    url(r'^collections/', include(wagtailadmin_collections_urls, namespace='wagtailadmin_collections')),
+    # TODO: Move into wagtailadmin_pages namespace
+    path('choose-page/', chooser.browse, name='wagtailadmin_choose_page'),
+    re_path(r'^choose-page/(\d+)/$', chooser.browse, name='wagtailadmin_choose_page_child'),
+    path('choose-page/search/', chooser.search, name='wagtailadmin_choose_page_search'),
+    path('choose-external-link/', chooser.external_link, name='wagtailadmin_choose_page_external_link'),
+    path('choose-email-link/', chooser.email_link, name='wagtailadmin_choose_page_email_link'),
+    path('choose-phone-link/', chooser.phone_link, name='wagtailadmin_choose_page_phone_link'),
+    path('choose-anchor-link/', chooser.anchor_link, name='wagtailadmin_choose_page_anchor_link'),
 
-    url(r'^reports/', include(wagtailadmin_reports_urls, namespace='wagtailadmin_reports')),
+    path('tag-autocomplete/', tags.autocomplete, name='wagtailadmin_tag_autocomplete'),
+    re_path(r'^tag-autocomplete/(\w+)/(\w+)/$', tags.autocomplete, name='wagtailadmin_tag_model_autocomplete'),
 
-    url(r'^account/$', account.account, name='wagtailadmin_account'),
-    url(r'^account/change_password/$', account.change_password, name='wagtailadmin_account_change_password'),
-    url(r'^account/change_email/$', account.change_email, name='wagtailadmin_account_change_email'),
-    url(r'^account/change_name/$', account.change_name, name='wagtailadmin_account_change_name'),
-    url(
-        r'^account/notification_preferences/$',
+    path('collections/', include(wagtailadmin_collections_urls, namespace='wagtailadmin_collections')),
+
+    path('reports/', include(wagtailadmin_reports_urls, namespace='wagtailadmin_reports')),
+
+    path('account/', account.account, name='wagtailadmin_account'),
+    path('account/change_password/', account.change_password, name='wagtailadmin_account_change_password'),
+    path('account/change_email/', account.change_email, name='wagtailadmin_account_change_email'),
+    path('account/change_name/', account.change_name, name='wagtailadmin_account_change_name'),
+    path(
+        'account/notification_preferences/',
         account.notification_preferences,
         name='wagtailadmin_account_notification_preferences'
     ),
-    url(r'account/change_avatar/$', account.change_avatar, name='wagtailadmin_account_change_avatar'),
-    url(
-        r'^account/language_preferences/$',
+    path('account/change_avatar/', account.change_avatar, name='wagtailadmin_account_change_avatar'),
+    path(
+        'account/language_preferences/',
         account.language_preferences,
         name='wagtailadmin_account_language_preferences'
     ),
-    url(
-        r'^account/current_time_zone/$',
+    path(
+        'account/current_time_zone/',
         account.current_time_zone,
         name='wagtailadmin_account_current_time_zone'
     ),
-    url(r'^logout/$', account.LogoutView.as_view(), name='wagtailadmin_logout'),
+    path('logout/', account.LogoutView.as_view(), name='wagtailadmin_logout'),
 ]
 
 
@@ -85,19 +85,19 @@ urlpatterns = decorate_urlpatterns(urlpatterns, require_admin_access)
 
 # These url patterns do not require an authenticated admin user
 urlpatterns += [
-    url(r'^login/$', account.LoginView.as_view(), name='wagtailadmin_login'),
+    path('login/', account.LoginView.as_view(), name='wagtailadmin_login'),
 
     # These two URLs have the "permission_required" decorator applied directly
     # as they need to fail with a 403 error rather than redirect to the login page
-    url(r'^userbar/(\d+)/$', userbar.for_frontend, name='wagtailadmin_userbar_frontend'),
-    url(r'^userbar/moderation/(\d+)/$', userbar.for_moderation, name='wagtailadmin_userbar_moderation'),
+    re_path(r'^userbar/(\d+)/$', userbar.for_frontend, name='wagtailadmin_userbar_frontend'),
+    re_path(r'^userbar/moderation/(\d+)/$', userbar.for_moderation, name='wagtailadmin_userbar_moderation'),
 
     # Password reset
-    url(r'^password_reset/', include(wagtailadmin_password_reset_urls)),
+    path('password_reset/', include(wagtailadmin_password_reset_urls)),
 
     # Default view (will show 404 page)
     # This must be the last URL in this file!
-    url(r'^', home.default),
+    re_path(r'^', home.default),
 ]
 
 

--- a/wagtail/admin/urls/__init__.py
+++ b/wagtail/admin/urls/__init__.py
@@ -28,13 +28,13 @@ urlpatterns = [
 
     # TODO: Move into wagtailadmin_pages namespace
     path('pages/', pages.index, name='wagtailadmin_explore_root'),
-    re_path(r'^pages/(\d+)/$', pages.index, name='wagtailadmin_explore'),
+    path('pages/<int:parent_page_id>/', pages.index, name='wagtailadmin_explore'),
 
     path('pages/', include(wagtailadmin_pages_urls, namespace='wagtailadmin_pages')),
 
     # TODO: Move into wagtailadmin_pages namespace
     path('choose-page/', chooser.browse, name='wagtailadmin_choose_page'),
-    re_path(r'^choose-page/(\d+)/$', chooser.browse, name='wagtailadmin_choose_page_child'),
+    path('choose-page/<int:parent_page_id>/', chooser.browse, name='wagtailadmin_choose_page_child'),
     path('choose-page/search/', chooser.search, name='wagtailadmin_choose_page_search'),
     path('choose-external-link/', chooser.external_link, name='wagtailadmin_choose_page_external_link'),
     path('choose-email-link/', chooser.email_link, name='wagtailadmin_choose_page_email_link'),
@@ -42,7 +42,7 @@ urlpatterns = [
     path('choose-anchor-link/', chooser.anchor_link, name='wagtailadmin_choose_page_anchor_link'),
 
     path('tag-autocomplete/', tags.autocomplete, name='wagtailadmin_tag_autocomplete'),
-    re_path(r'^tag-autocomplete/(\w+)/(\w+)/$', tags.autocomplete, name='wagtailadmin_tag_model_autocomplete'),
+    path('tag-autocomplete/<str:app_name>/<str:model_name>/', tags.autocomplete, name='wagtailadmin_tag_model_autocomplete'),
 
     path('collections/', include(wagtailadmin_collections_urls, namespace='wagtailadmin_collections')),
 
@@ -89,8 +89,8 @@ urlpatterns += [
 
     # These two URLs have the "permission_required" decorator applied directly
     # as they need to fail with a 403 error rather than redirect to the login page
-    re_path(r'^userbar/(\d+)/$', userbar.for_frontend, name='wagtailadmin_userbar_frontend'),
-    re_path(r'^userbar/moderation/(\d+)/$', userbar.for_moderation, name='wagtailadmin_userbar_moderation'),
+    path('userbar/<int:page_id>/', userbar.for_frontend, name='wagtailadmin_userbar_frontend'),
+    path('userbar/moderation/<int:revision_id>/', userbar.for_moderation, name='wagtailadmin_userbar_moderation'),
 
     # Password reset
     path('password_reset/', include(wagtailadmin_password_reset_urls)),

--- a/wagtail/admin/urls/collections.py
+++ b/wagtail/admin/urls/collections.py
@@ -1,12 +1,12 @@
-from django.conf.urls import url
+from django.urls import path, re_path
 
 from wagtail.admin.views import collection_privacy, collections
 
 app_name = 'wagtailadmin_collections'
 urlpatterns = [
-    url(r'^$', collections.Index.as_view(), name='index'),
-    url(r'^add/$', collections.Create.as_view(), name='add'),
-    url(r'^(\d+)/$', collections.Edit.as_view(), name='edit'),
-    url(r'^(\d+)/delete/$', collections.Delete.as_view(), name='delete'),
-    url(r'^(\d+)/privacy/$', collection_privacy.set_privacy, name='set_privacy'),
+    path('', collections.Index.as_view(), name='index'),
+    path('add/', collections.Create.as_view(), name='add'),
+    re_path(r'^(\d+)/$', collections.Edit.as_view(), name='edit'),
+    re_path(r'^(\d+)/delete/$', collections.Delete.as_view(), name='delete'),
+    re_path(r'^(\d+)/privacy/$', collection_privacy.set_privacy, name='set_privacy'),
 ]

--- a/wagtail/admin/urls/collections.py
+++ b/wagtail/admin/urls/collections.py
@@ -1,4 +1,4 @@
-from django.urls import path, re_path
+from django.urls import path
 
 from wagtail.admin.views import collection_privacy, collections
 
@@ -7,7 +7,6 @@ urlpatterns = [
     path('', collections.Index.as_view(), name='index'),
     path('add/', collections.Create.as_view(), name='add'),
     path('<int:pk>/', collections.Edit.as_view(), name='edit'),
-    # TODO: replace this with path converter
-    re_path(r'^(\d+)/delete/$', collections.Delete.as_view(), name='delete'),
+    path('<int:pk>/delete/', collections.Delete.as_view(), name='delete'),
     path('<int:collection_id>/privacy/', collection_privacy.set_privacy, name='set_privacy'),
 ]

--- a/wagtail/admin/urls/collections.py
+++ b/wagtail/admin/urls/collections.py
@@ -6,7 +6,8 @@ app_name = 'wagtailadmin_collections'
 urlpatterns = [
     path('', collections.Index.as_view(), name='index'),
     path('add/', collections.Create.as_view(), name='add'),
-    re_path(r'^(\d+)/$', collections.Edit.as_view(), name='edit'),
+    path('<int:pk>/', collections.Edit.as_view(), name='edit'),
+    # TODO: replace this with path converter
     re_path(r'^(\d+)/delete/$', collections.Delete.as_view(), name='delete'),
-    re_path(r'^(\d+)/privacy/$', collection_privacy.set_privacy, name='set_privacy'),
+    path('<int:collection_id>/privacy/', collection_privacy.set_privacy, name='set_privacy'),
 ]

--- a/wagtail/admin/urls/pages.py
+++ b/wagtail/admin/urls/pages.py
@@ -1,42 +1,42 @@
-from django.conf.urls import url
+from django.urls import re_path
 
 from wagtail.admin.views import page_privacy, pages
 
 app_name = 'wagtailadmin_pages'
 urlpatterns = [
-    url(r'^add/(\w+)/(\w+)/(\d+)/$', pages.create, name='add'),
-    url(r'^add/(\w+)/(\w+)/(\d+)/preview/$', pages.PreviewOnCreate.as_view(), name='preview_on_add'),
-    url(r'^usage/(\w+)/(\w+)/$', pages.content_type_use, name='type_use'),
+    re_path(r'^add/(\w+)/(\w+)/(\d+)/$', pages.create, name='add'),
+    re_path(r'^add/(\w+)/(\w+)/(\d+)/preview/$', pages.PreviewOnCreate.as_view(), name='preview_on_add'),
+    re_path(r'^usage/(\w+)/(\w+)/$', pages.content_type_use, name='type_use'),
 
-    url(r'^(\d+)/edit/$', pages.edit, name='edit'),
-    url(r'^(\d+)/edit/preview/$', pages.PreviewOnEdit.as_view(), name='preview_on_edit'),
+    re_path(r'^(\d+)/edit/$', pages.edit, name='edit'),
+    re_path(r'^(\d+)/edit/preview/$', pages.PreviewOnEdit.as_view(), name='preview_on_edit'),
 
-    url(r'^(\d+)/view_draft/$', pages.view_draft, name='view_draft'),
-    url(r'^(\d+)/add_subpage/$', pages.add_subpage, name='add_subpage'),
-    url(r'^(\d+)/delete/$', pages.delete, name='delete'),
-    url(r'^(\d+)/unpublish/$', pages.unpublish, name='unpublish'),
+    re_path(r'^(\d+)/view_draft/$', pages.view_draft, name='view_draft'),
+    re_path(r'^(\d+)/add_subpage/$', pages.add_subpage, name='add_subpage'),
+    re_path(r'^(\d+)/delete/$', pages.delete, name='delete'),
+    re_path(r'^(\d+)/unpublish/$', pages.unpublish, name='unpublish'),
 
-    url(r'^search/$', pages.search, name='search'),
+    re_path(r'^search/$', pages.search, name='search'),
 
-    url(r'^(\d+)/move/$', pages.move_choose_destination, name='move'),
-    url(r'^(\d+)/move/(\d+)/$', pages.move_choose_destination, name='move_choose_destination'),
-    url(r'^(\d+)/move/(\d+)/confirm/$', pages.move_confirm, name='move_confirm'),
-    url(r'^(\d+)/set_position/$', pages.set_page_position, name='set_page_position'),
+    re_path(r'^(\d+)/move/$', pages.move_choose_destination, name='move'),
+    re_path(r'^(\d+)/move/(\d+)/$', pages.move_choose_destination, name='move_choose_destination'),
+    re_path(r'^(\d+)/move/(\d+)/confirm/$', pages.move_confirm, name='move_confirm'),
+    re_path(r'^(\d+)/set_position/$', pages.set_page_position, name='set_page_position'),
 
-    url(r'^(\d+)/copy/$', pages.copy, name='copy'),
+    re_path(r'^(\d+)/copy/$', pages.copy, name='copy'),
 
-    url(r'^moderation/(\d+)/approve/$', pages.approve_moderation, name='approve_moderation'),
-    url(r'^moderation/(\d+)/reject/$', pages.reject_moderation, name='reject_moderation'),
-    url(r'^moderation/(\d+)/preview/$', pages.preview_for_moderation, name='preview_for_moderation'),
+    re_path(r'^moderation/(\d+)/approve/$', pages.approve_moderation, name='approve_moderation'),
+    re_path(r'^moderation/(\d+)/reject/$', pages.reject_moderation, name='reject_moderation'),
+    re_path(r'^moderation/(\d+)/preview/$', pages.preview_for_moderation, name='preview_for_moderation'),
 
-    url(r'^(\d+)/privacy/$', page_privacy.set_privacy, name='set_privacy'),
+    re_path(r'^(\d+)/privacy/$', page_privacy.set_privacy, name='set_privacy'),
 
-    url(r'^(\d+)/lock/$', pages.lock, name='lock'),
-    url(r'^(\d+)/unlock/$', pages.unlock, name='unlock'),
+    re_path(r'^(\d+)/lock/$', pages.lock, name='lock'),
+    re_path(r'^(\d+)/unlock/$', pages.unlock, name='unlock'),
 
-    url(r'^(\d+)/revisions/$', pages.revisions_index, name='revisions_index'),
-    url(r'^(\d+)/revisions/(\d+)/view/$', pages.revisions_view, name='revisions_view'),
-    url(r'^(\d+)/revisions/(\d+)/revert/$', pages.revisions_revert, name='revisions_revert'),
-    url(r'^(\d+)/revisions/(\d+)/unschedule/$', pages.revisions_unschedule, name='revisions_unschedule'),
-    url(r'^(\d+)/revisions/compare/(live|earliest|\d+)\.\.\.(live|latest|\d+)/$', pages.revisions_compare, name='revisions_compare'),
+    re_path(r'^(\d+)/revisions/$', pages.revisions_index, name='revisions_index'),
+    re_path(r'^(\d+)/revisions/(\d+)/view/$', pages.revisions_view, name='revisions_view'),
+    re_path(r'^(\d+)/revisions/(\d+)/revert/$', pages.revisions_revert, name='revisions_revert'),
+    re_path(r'^(\d+)/revisions/(\d+)/unschedule/$', pages.revisions_unschedule, name='revisions_unschedule'),
+    re_path(r'^(\d+)/revisions/compare/(live|earliest|\d+)\.\.\.(live|latest|\d+)/$', pages.revisions_compare, name='revisions_compare'),
 ]

--- a/wagtail/admin/urls/pages.py
+++ b/wagtail/admin/urls/pages.py
@@ -4,13 +4,12 @@ from wagtail.admin.views import page_privacy, pages
 
 app_name = 'wagtailadmin_pages'
 urlpatterns = [
-    re_path(r'^add/(\w+)/(\w+)/(\d+)/$', pages.create, name='add'),
-    re_path(r'^add/(\w+)/(\w+)/(\d+)/preview/$', pages.PreviewOnCreate.as_view(), name='preview_on_add'),
-    re_path(r'^usage/(\w+)/(\w+)/$', pages.content_type_use, name='type_use'),
+    path('add/<str:content_type_app_name>/<str:content_type_model_name>/<int:parent_page_id>/', pages.create, name='add'),
+    path('add/<str:content_type_app_name>/<str:content_type_model_name>/<int:parent_page_id>/preview/', pages.PreviewOnCreate.as_view(), name='preview_on_add'),
+    path('usage/<str:content_type_app_name>/<str:content_type_model_name>/', pages.content_type_use, name='type_use'),
 
     path('<int:page_id>/edit/', pages.edit, name='edit'),
-    re_path(r'^(\d+)/edit/preview/$', pages.PreviewOnEdit.as_view(), name='preview_on_edit'),
-    # path('<int:pk>/edit/preview/', pages.PreviewOnEdit.as_view(), name='preview_on_edit'),
+    path('<int:page_id>/edit/preview/', pages.PreviewOnEdit.as_view(), name='preview_on_edit'),
 
     path('<int:page_id>/view_draft/', pages.view_draft, name='view_draft'),
     path('<int:parent_page_id>/add_subpage/', pages.add_subpage, name='add_subpage'),

--- a/wagtail/admin/urls/pages.py
+++ b/wagtail/admin/urls/pages.py
@@ -1,4 +1,4 @@
-from django.urls import re_path
+from django.urls import path, re_path
 
 from wagtail.admin.views import page_privacy, pages
 
@@ -8,35 +8,36 @@ urlpatterns = [
     re_path(r'^add/(\w+)/(\w+)/(\d+)/preview/$', pages.PreviewOnCreate.as_view(), name='preview_on_add'),
     re_path(r'^usage/(\w+)/(\w+)/$', pages.content_type_use, name='type_use'),
 
-    re_path(r'^(\d+)/edit/$', pages.edit, name='edit'),
+    path('<int:page_id>/edit/', pages.edit, name='edit'),
     re_path(r'^(\d+)/edit/preview/$', pages.PreviewOnEdit.as_view(), name='preview_on_edit'),
+    # path('<int:pk>/edit/preview/', pages.PreviewOnEdit.as_view(), name='preview_on_edit'),
 
-    re_path(r'^(\d+)/view_draft/$', pages.view_draft, name='view_draft'),
-    re_path(r'^(\d+)/add_subpage/$', pages.add_subpage, name='add_subpage'),
-    re_path(r'^(\d+)/delete/$', pages.delete, name='delete'),
-    re_path(r'^(\d+)/unpublish/$', pages.unpublish, name='unpublish'),
+    path('<int:page_id>/view_draft/', pages.view_draft, name='view_draft'),
+    path('<int:parent_page_id>/add_subpage/', pages.add_subpage, name='add_subpage'),
+    path('<int:page_id>/delete/', pages.delete, name='delete'),
+    path('<int:page_id>/unpublish/', pages.unpublish, name='unpublish'),
 
-    re_path(r'^search/$', pages.search, name='search'),
+    path('search/', pages.search, name='search'),
 
-    re_path(r'^(\d+)/move/$', pages.move_choose_destination, name='move'),
-    re_path(r'^(\d+)/move/(\d+)/$', pages.move_choose_destination, name='move_choose_destination'),
-    re_path(r'^(\d+)/move/(\d+)/confirm/$', pages.move_confirm, name='move_confirm'),
-    re_path(r'^(\d+)/set_position/$', pages.set_page_position, name='set_page_position'),
+    path('<int:page_to_move_id>/move/', pages.move_choose_destination, name='move'),
+    path('<int:page_to_move_id>/move/<int:viewed_page_id>/', pages.move_choose_destination, name='move_choose_destination'),
+    path('<int:page_to_move_id>/move/<int:destination_id>/confirm/', pages.move_confirm, name='move_confirm'),
+    path('<int:page_to_move_id>/set_position/', pages.set_page_position, name='set_page_position'),
 
-    re_path(r'^(\d+)/copy/$', pages.copy, name='copy'),
+    path('<int:page_id>/copy/', pages.copy, name='copy'),
 
-    re_path(r'^moderation/(\d+)/approve/$', pages.approve_moderation, name='approve_moderation'),
-    re_path(r'^moderation/(\d+)/reject/$', pages.reject_moderation, name='reject_moderation'),
-    re_path(r'^moderation/(\d+)/preview/$', pages.preview_for_moderation, name='preview_for_moderation'),
+    path('moderation/<int:revision_id>/approve/', pages.approve_moderation, name='approve_moderation'),
+    path('moderation/<int:revision_id>/reject/', pages.reject_moderation, name='reject_moderation'),
+    path('moderation/<int:revision_id>/preview/', pages.preview_for_moderation, name='preview_for_moderation'),
 
-    re_path(r'^(\d+)/privacy/$', page_privacy.set_privacy, name='set_privacy'),
+    path('<int:page_id>/privacy/', page_privacy.set_privacy, name='set_privacy'),
 
-    re_path(r'^(\d+)/lock/$', pages.lock, name='lock'),
-    re_path(r'^(\d+)/unlock/$', pages.unlock, name='unlock'),
+    path('<int:page_id>/lock/', pages.lock, name='lock'),
+    path('<int:page_id>/unlock/', pages.unlock, name='unlock'),
 
-    re_path(r'^(\d+)/revisions/$', pages.revisions_index, name='revisions_index'),
-    re_path(r'^(\d+)/revisions/(\d+)/view/$', pages.revisions_view, name='revisions_view'),
-    re_path(r'^(\d+)/revisions/(\d+)/revert/$', pages.revisions_revert, name='revisions_revert'),
-    re_path(r'^(\d+)/revisions/(\d+)/unschedule/$', pages.revisions_unschedule, name='revisions_unschedule'),
+    path('<int:page_id>/revisions/', pages.revisions_index, name='revisions_index'),
+    path('<int:page_id>/revisions/<int:revision_id>/view/', pages.revisions_view, name='revisions_view'),
+    path('<int:page_id>/revisions/<int:revision_id>/revert/', pages.revisions_revert, name='revisions_revert'),
+    path('<int:page_id>/revisions/<int:revision_id>/unschedule/', pages.revisions_unschedule, name='revisions_unschedule'),
     re_path(r'^(\d+)/revisions/compare/(live|earliest|\d+)\.\.\.(live|latest|\d+)/$', pages.revisions_compare, name='revisions_compare'),
 ]

--- a/wagtail/admin/urls/password_reset.py
+++ b/wagtail/admin/urls/password_reset.py
@@ -1,19 +1,19 @@
-from django.conf.urls import url
+from django.urls import path, re_path
 
 from wagtail.admin.views import account
 
 urlpatterns = [
-    url(
-        r'^$', account.PasswordResetView.as_view(), name='wagtailadmin_password_reset'
+    path(
+        '', account.PasswordResetView.as_view(), name='wagtailadmin_password_reset'
     ),
-    url(
-        r'^done/$', account.PasswordResetDoneView.as_view(), name='wagtailadmin_password_reset_done'
+    path(
+        'done/', account.PasswordResetDoneView.as_view(), name='wagtailadmin_password_reset_done'
     ),
-    url(
+    re_path(
         r'^confirm/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})/$',
         account.PasswordResetConfirmView.as_view(), name='wagtailadmin_password_reset_confirm',
     ),
-    url(
-        r'^complete/$', account.PasswordResetCompleteView.as_view(), name='wagtailadmin_password_reset_complete'
+    path(
+        'complete/', account.PasswordResetCompleteView.as_view(), name='wagtailadmin_password_reset_complete'
     ),
 ]

--- a/wagtail/admin/urls/reports.py
+++ b/wagtail/admin/urls/reports.py
@@ -1,8 +1,8 @@
-from django.conf.urls import url
+from django.urls import path
 
 from wagtail.admin.views import reports
 
 app_name = 'wagtailadmin_reports'
 urlpatterns = [
-    url(r'^locked/$', reports.LockedPagesView.as_view(), name='locked_pages')
+    path('locked/', reports.LockedPagesView.as_view(), name='locked_pages')
 ]

--- a/wagtail/admin/views/collections.py
+++ b/wagtail/admin/views/collections.py
@@ -100,8 +100,8 @@ class Delete(DeleteView):
 
         return context
 
-    def post(self, request, instance_id):
-        self.object = get_object_or_404(self.get_queryset(), id=instance_id)
+    def post(self, request, pk):
+        self.object = get_object_or_404(self.get_queryset(), id=pk)
         collection_contents = self.get_collection_contents()
 
         if collection_contents:

--- a/wagtail/admin/views/pages.py
+++ b/wagtail/admin/views/pages.py
@@ -630,7 +630,7 @@ class PreviewOnEdit(View):
 
     def get_page(self):
         return get_object_or_404(Page,
-                                 id=self.args[0]).get_latest_revision_as_page()
+                                 id=self.kwargs["page_id"]).get_latest_revision_as_page()
 
     def get_form(self, page, query_dict):
         form_class = page.get_edit_handler().get_form_class()
@@ -672,8 +672,9 @@ class PreviewOnEdit(View):
 
 class PreviewOnCreate(PreviewOnEdit):
     def get_page(self):
-        (content_type_app_name, content_type_model_name,
-         parent_page_id) = self.args
+        content_type_app_name = self.kwargs["content_type_app_name"]
+        content_type_model_name = self.kwargs["content_type_model_name"]
+        parent_page_id = self.kwargs["parent_page_id"]
         try:
             content_type = ContentType.objects.get_by_natural_key(
                 content_type_app_name, content_type_model_name)

--- a/wagtail/admin/viewsets/__init__.py
+++ b/wagtail/admin/viewsets/__init__.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url, include
+from django.urls import re_path, include
 
 from wagtail.core import hooks
 
@@ -23,7 +23,7 @@ class ViewSetRegistry:
             vs_urlpatterns = viewset.get_urlpatterns()
 
             if vs_urlpatterns:
-                urlpatterns.append(url(
+                urlpatterns.append(re_path(
                     r'^{}/'.format(viewset.url_prefix),
                     include((vs_urlpatterns, viewset.name), namespace=viewset.name)
                 ))

--- a/wagtail/admin/viewsets/model.py
+++ b/wagtail/admin/viewsets/model.py
@@ -1,6 +1,6 @@
 from django.core.exceptions import ImproperlyConfigured
 from django.forms.models import modelform_factory
-from django.urls import path, re_path
+from django.urls import path
 
 from wagtail.admin.views import generic
 from wagtail.core.permissions import ModelPermissionPolicy
@@ -89,6 +89,6 @@ class ModelViewSet(ViewSet):
         return super().get_urlpatterns() + [
             path('', self.index_view, name='index'),
             path('new/', self.add_view, name='add'),
-            re_path(r'^(\d+)/$', self.edit_view, name='edit'),
-            re_path(r'^(\d+)/delete/$', self.delete_view, name='delete'),
+            path('<int:pk>/', self.edit_view, name='edit'),
+            path('<int:pk>delete/', self.delete_view, name='delete'),
         ]

--- a/wagtail/admin/viewsets/model.py
+++ b/wagtail/admin/viewsets/model.py
@@ -1,6 +1,6 @@
-from django.urls import path, re_path
 from django.core.exceptions import ImproperlyConfigured
 from django.forms.models import modelform_factory
+from django.urls import path, re_path
 
 from wagtail.admin.views import generic
 from wagtail.core.permissions import ModelPermissionPolicy

--- a/wagtail/admin/viewsets/model.py
+++ b/wagtail/admin/viewsets/model.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url
+from django.urls import path, re_path
 from django.core.exceptions import ImproperlyConfigured
 from django.forms.models import modelform_factory
 
@@ -87,8 +87,8 @@ class ModelViewSet(ViewSet):
 
     def get_urlpatterns(self):
         return super().get_urlpatterns() + [
-            url(r'^$', self.index_view, name='index'),
-            url(r'^new/$', self.add_view, name='add'),
-            url(r'^(\d+)/$', self.edit_view, name='edit'),
-            url(r'^(\d+)/delete/$', self.delete_view, name='delete'),
+            path('', self.index_view, name='index'),
+            path('new/', self.add_view, name='add'),
+            re_path(r'^(\d+)/$', self.edit_view, name='edit'),
+            re_path(r'^(\d+)/delete/$', self.delete_view, name='delete'),
         ]

--- a/wagtail/api/v2/router.py
+++ b/wagtail/api/v2/router.py
@@ -1,6 +1,6 @@
 import functools
 
-from django.conf.urls import include, url
+from django.urls import include, re_path
 
 from wagtail.utils.urlpatterns import decorate_urlpatterns
 
@@ -68,7 +68,7 @@ class WagtailAPIRouter:
         urlpatterns = []
 
         for name, class_ in self._endpoints.items():
-            pattern = url(
+            pattern = re_path(
                 r'^{}/'.format(name),
                 include((class_.get_urlpatterns(), name), namespace=name)
             )
@@ -85,6 +85,6 @@ class WagtailAPIRouter:
 
         Use with Django's include() function:
 
-            url(r'api/', include(myapi.urls)),
+            path('api/', include(myapi.urls)),
         """
         return self.get_urlpatterns(), self.url_namespace, self.url_namespace

--- a/wagtail/api/v2/views.py
+++ b/wagtail/api/v2/views.py
@@ -3,7 +3,7 @@ from collections import OrderedDict
 from django.core.exceptions import FieldDoesNotExist
 from django.http import Http404
 from django.shortcuts import redirect
-from django.urls import path, re_path, reverse
+from django.urls import path, reverse
 from modelcluster.fields import ParentalKey
 from rest_framework import status
 from rest_framework.renderers import BrowsableAPIRenderer, JSONRenderer
@@ -336,7 +336,7 @@ class BaseAPIViewSet(GenericViewSet):
         """
         return [
             path('', cls.as_view({'get': 'listing_view'}), name='listing'),
-            re_path(r'^(?P<pk>\d+)/$', cls.as_view({'get': 'detail_view'}), name='detail'),
+            path('<int:pk>/', cls.as_view({'get': 'detail_view'}), name='detail'),
             path('find/', cls.as_view({'get': 'find_view'}), name='find'),
         ]
 

--- a/wagtail/api/v2/views.py
+++ b/wagtail/api/v2/views.py
@@ -1,10 +1,9 @@
 from collections import OrderedDict
 
-from django.urls import path, re_path
 from django.core.exceptions import FieldDoesNotExist
 from django.http import Http404
 from django.shortcuts import redirect
-from django.urls import reverse
+from django.urls import path, re_path, reverse
 from modelcluster.fields import ParentalKey
 from rest_framework import status
 from rest_framework.renderers import BrowsableAPIRenderer, JSONRenderer

--- a/wagtail/api/v2/views.py
+++ b/wagtail/api/v2/views.py
@@ -1,6 +1,6 @@
 from collections import OrderedDict
 
-from django.conf.urls import url
+from django.urls import path, re_path
 from django.core.exceptions import FieldDoesNotExist
 from django.http import Http404
 from django.shortcuts import redirect
@@ -336,9 +336,9 @@ class BaseAPIViewSet(GenericViewSet):
         This returns a list of URL patterns for the endpoint
         """
         return [
-            url(r'^$', cls.as_view({'get': 'listing_view'}), name='listing'),
-            url(r'^(?P<pk>\d+)/$', cls.as_view({'get': 'detail_view'}), name='detail'),
-            url(r'^find/$', cls.as_view({'get': 'find_view'}), name='find'),
+            path('', cls.as_view({'get': 'listing_view'}), name='listing'),
+            re_path(r'^(?P<pk>\d+)/$', cls.as_view({'get': 'detail_view'}), name='detail'),
+            path('find/', cls.as_view({'get': 'find_view'}), name='find'),
         ]
 
     @classmethod

--- a/wagtail/contrib/forms/urls.py
+++ b/wagtail/contrib/forms/urls.py
@@ -1,4 +1,4 @@
-from django.urls import path, re_path
+from django.urls import path
 
 from wagtail.contrib.forms.views import (
     DeleteSubmissionsView, FormPagesListView, get_submissions_list_view)
@@ -6,6 +6,6 @@ from wagtail.contrib.forms.views import (
 app_name = 'wagtailforms'
 urlpatterns = [
     path('', FormPagesListView.as_view(), name='index'),
-    re_path(r'^submissions/(?P<page_id>\d+)/$', get_submissions_list_view, name='list_submissions'),
-    re_path(r'^submissions/(?P<page_id>\d+)/delete/$', DeleteSubmissionsView.as_view(), name='delete_submissions')
+    path('submissions/<int:page_id>/', get_submissions_list_view, name='list_submissions'),
+    path('submissions/<int:page_id>/delete/', DeleteSubmissionsView.as_view(), name='delete_submissions')
 ]

--- a/wagtail/contrib/forms/urls.py
+++ b/wagtail/contrib/forms/urls.py
@@ -1,11 +1,11 @@
-from django.conf.urls import url
+from django.urls import path, re_path
 
 from wagtail.contrib.forms.views import (
     DeleteSubmissionsView, FormPagesListView, get_submissions_list_view)
 
 app_name = 'wagtailforms'
 urlpatterns = [
-    url(r'^$', FormPagesListView.as_view(), name='index'),
-    url(r'^submissions/(?P<page_id>\d+)/$', get_submissions_list_view, name='list_submissions'),
-    url(r'^submissions/(?P<page_id>\d+)/delete/$', DeleteSubmissionsView.as_view(), name='delete_submissions')
+    path('', FormPagesListView.as_view(), name='index'),
+    re_path(r'^submissions/(?P<page_id>\d+)/$', get_submissions_list_view, name='list_submissions'),
+    re_path(r'^submissions/(?P<page_id>\d+)/delete/$', DeleteSubmissionsView.as_view(), name='delete_submissions')
 ]

--- a/wagtail/contrib/forms/wagtail_hooks.py
+++ b/wagtail/contrib/forms/wagtail_hooks.py
@@ -1,4 +1,4 @@
-from django.conf.urls import include, url
+from django.urls import include, path
 from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
 
@@ -11,7 +11,7 @@ from wagtail.core import hooks
 @hooks.register('register_admin_urls')
 def register_admin_urls():
     return [
-        url(r'^forms/', include(urls, namespace='wagtailforms')),
+        path('forms/', include(urls, namespace='wagtailforms')),
     ]
 
 

--- a/wagtail/contrib/forms/wagtail_hooks.py
+++ b/wagtail/contrib/forms/wagtail_hooks.py
@@ -1,5 +1,4 @@
-from django.urls import include, path
-from django.urls import reverse
+from django.urls import include, path, reverse
 from django.utils.translation import ugettext_lazy as _
 
 from wagtail.admin.menu import MenuItem

--- a/wagtail/contrib/modeladmin/options.py
+++ b/wagtail/contrib/modeladmin/options.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url
+from django.urls import re_path
 from django.contrib.admin import site as default_django_admin_site
 from django.contrib.auth.models import Permission
 from django.core import checks
@@ -511,28 +511,34 @@ class ModelAdmin(WagtailRegisterable):
         our the views that class offers.
         """
         urls = (
-            url(self.url_helper.get_action_url_pattern('index'),
+            re_path(
+                self.url_helper.get_action_url_pattern('index'),
                 self.index_view,
                 name=self.url_helper.get_action_url_name('index')),
-            url(self.url_helper.get_action_url_pattern('create'),
+            re_path(
+                self.url_helper.get_action_url_pattern('create'),
                 self.create_view,
                 name=self.url_helper.get_action_url_name('create')),
-            url(self.url_helper.get_action_url_pattern('edit'),
+            re_path(
+                self.url_helper.get_action_url_pattern('edit'),
                 self.edit_view,
                 name=self.url_helper.get_action_url_name('edit')),
-            url(self.url_helper.get_action_url_pattern('delete'),
+            re_path(
+                self.url_helper.get_action_url_pattern('delete'),
                 self.delete_view,
                 name=self.url_helper.get_action_url_name('delete')),
         )
         if self.inspect_view_enabled:
             urls = urls + (
-                url(self.url_helper.get_action_url_pattern('inspect'),
+                re_path(
+                    self.url_helper.get_action_url_pattern('inspect'),
                     self.inspect_view,
                     name=self.url_helper.get_action_url_name('inspect')),
             )
         if self.is_pagemodel:
             urls = urls + (
-                url(self.url_helper.get_action_url_pattern('choose_parent'),
+                re_path(
+                    self.url_helper.get_action_url_pattern('choose_parent'),
                     self.choose_parent_view,
                     name=self.url_helper.get_action_url_name('choose_parent')),
             )

--- a/wagtail/contrib/modeladmin/options.py
+++ b/wagtail/contrib/modeladmin/options.py
@@ -1,9 +1,9 @@
-from django.urls import re_path
 from django.contrib.admin import site as default_django_admin_site
 from django.contrib.auth.models import Permission
 from django.core import checks
 from django.core.exceptions import ImproperlyConfigured
 from django.db.models import Model
+from django.urls import re_path
 from django.utils.safestring import mark_safe
 
 from wagtail.admin.checks import check_panels_in_model

--- a/wagtail/contrib/redirects/urls.py
+++ b/wagtail/contrib/redirects/urls.py
@@ -1,4 +1,4 @@
-from django.urls import path, re_path
+from django.urls import path
 
 from wagtail.contrib.redirects import views
 

--- a/wagtail/contrib/redirects/urls.py
+++ b/wagtail/contrib/redirects/urls.py
@@ -1,11 +1,11 @@
-from django.conf.urls import url
+from django.urls import path, re_path
 
 from wagtail.contrib.redirects import views
 
 app_name = 'wagtailredirects'
 urlpatterns = [
-    url(r'^$', views.index, name='index'),
-    url(r'^add/$', views.add, name='add'),
-    url(r'^(\d+)/$', views.edit, name='edit'),
-    url(r'^(\d+)/delete/$', views.delete, name='delete'),
+    path('', views.index, name='index'),
+    path('add/', views.add, name='add'),
+    re_path(r'^(\d+)/$', views.edit, name='edit'),
+    re_path(r'^(\d+)/delete/$', views.delete, name='delete'),
 ]

--- a/wagtail/contrib/redirects/urls.py
+++ b/wagtail/contrib/redirects/urls.py
@@ -6,6 +6,6 @@ app_name = 'wagtailredirects'
 urlpatterns = [
     path('', views.index, name='index'),
     path('add/', views.add, name='add'),
-    re_path(r'^(\d+)/$', views.edit, name='edit'),
-    re_path(r'^(\d+)/delete/$', views.delete, name='delete'),
+    path('<int:redirect_id>/', views.edit, name='edit'),
+    path('<int:redirect_id>/delete/', views.delete, name='delete'),
 ]

--- a/wagtail/contrib/redirects/wagtail_hooks.py
+++ b/wagtail/contrib/redirects/wagtail_hooks.py
@@ -1,6 +1,5 @@
-from django.urls import include, path
 from django.contrib.auth.models import Permission
-from django.urls import reverse
+from django.urls import include, path, reverse
 from django.utils.translation import ugettext_lazy as _
 
 from wagtail.admin.menu import MenuItem

--- a/wagtail/contrib/redirects/wagtail_hooks.py
+++ b/wagtail/contrib/redirects/wagtail_hooks.py
@@ -1,4 +1,4 @@
-from django.conf.urls import include, url
+from django.urls import include, path
 from django.contrib.auth.models import Permission
 from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
@@ -12,7 +12,7 @@ from wagtail.core import hooks
 @hooks.register('register_admin_urls')
 def register_admin_urls():
     return [
-        url(r'^redirects/', include(urls, namespace='wagtailredirects')),
+        path('redirects/', include(urls, namespace='wagtailredirects')),
     ]
 
 

--- a/wagtail/contrib/routable_page/models.py
+++ b/wagtail/contrib/routable_page/models.py
@@ -1,12 +1,10 @@
-from django.urls import re_path
 from django.http import Http404
 from django.template.response import TemplateResponse
-from django.urls import URLResolver
+from django.urls import URLResolver, re_path
 from django.urls.resolvers import RegexPattern
 
 from wagtail.core.models import Page
 from wagtail.core.url_routing import RouteResult
-
 
 _creation_counter = 0
 

--- a/wagtail/contrib/routable_page/models.py
+++ b/wagtail/contrib/routable_page/models.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url
+from django.urls import re_path
 from django.http import Http404
 from django.template.response import TemplateResponse
 from django.urls import URLResolver
@@ -22,7 +22,7 @@ def route(pattern, name=None):
 
         # Add new route to view
         view_func._routablepage_routes.append((
-            url(pattern, view_func, name=(name or view_func.__name__)),
+            re_path(pattern, view_func, name=(name or view_func.__name__)),
             _creation_counter,
         ))
 

--- a/wagtail/contrib/search_promotions/admin_urls.py
+++ b/wagtail/contrib/search_promotions/admin_urls.py
@@ -1,11 +1,11 @@
-from django.conf.urls import url
+from django.urls import path, re_path
 
 from wagtail.contrib.search_promotions import views
 
 app_name = 'wagtailsearchpromotions'
 urlpatterns = [
-    url(r'^$', views.index, name='index'),
-    url(r'^add/$', views.add, name='add'),
-    url(r'^(\d+)/$', views.edit, name='edit'),
-    url(r'^(\d+)/delete/$', views.delete, name='delete'),
+    path('', views.index, name='index'),
+    path('add/', views.add, name='add'),
+    re_path(r'^(\d+)/$', views.edit, name='edit'),
+    re_path(r'^(\d+)/delete/$', views.delete, name='delete'),
 ]

--- a/wagtail/contrib/search_promotions/admin_urls.py
+++ b/wagtail/contrib/search_promotions/admin_urls.py
@@ -1,4 +1,4 @@
-from django.urls import path, re_path
+from django.urls import path
 
 from wagtail.contrib.search_promotions import views
 
@@ -6,6 +6,6 @@ app_name = 'wagtailsearchpromotions'
 urlpatterns = [
     path('', views.index, name='index'),
     path('add/', views.add, name='add'),
-    re_path(r'^(\d+)/$', views.edit, name='edit'),
-    re_path(r'^(\d+)/delete/$', views.delete, name='delete'),
+    path('<int:query_id>/', views.edit, name='edit'),
+    path('<int:query_id>/delete/', views.delete, name='delete'),
 ]

--- a/wagtail/contrib/search_promotions/wagtail_hooks.py
+++ b/wagtail/contrib/search_promotions/wagtail_hooks.py
@@ -1,4 +1,4 @@
-from django.conf.urls import include, url
+from django.urls import include, path
 from django.contrib.auth.models import Permission
 from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
@@ -11,7 +11,7 @@ from wagtail.core import hooks
 @hooks.register('register_admin_urls')
 def register_admin_urls():
     return [
-        url(r'^searchpicks/', include(admin_urls, namespace='wagtailsearchpromotions')),
+        path('searchpicks/', include(admin_urls, namespace='wagtailsearchpromotions')),
     ]
 
 

--- a/wagtail/contrib/search_promotions/wagtail_hooks.py
+++ b/wagtail/contrib/search_promotions/wagtail_hooks.py
@@ -1,6 +1,5 @@
-from django.urls import include, path
 from django.contrib.auth.models import Permission
-from django.urls import reverse
+from django.urls import include, path, reverse
 from django.utils.translation import ugettext_lazy as _
 
 from wagtail.admin.menu import MenuItem

--- a/wagtail/contrib/settings/urls.py
+++ b/wagtail/contrib/settings/urls.py
@@ -1,9 +1,9 @@
-from django.conf.urls import url
+from django.urls import re_path
 
 from . import views
 
 app_name = 'wagtailsettings'
 urlpatterns = [
-    url(r'^(\w+)/(\w+)/$', views.edit_current_site, name='edit'),
-    url(r'^(\w+)/(\w+)/(\d+)/$', views.edit, name='edit'),
+    re_path(r'^(\w+)/(\w+)/$', views.edit_current_site, name='edit'),
+    re_path(r'^(\w+)/(\w+)/(\d+)/$', views.edit, name='edit'),
 ]

--- a/wagtail/contrib/settings/urls.py
+++ b/wagtail/contrib/settings/urls.py
@@ -1,9 +1,9 @@
-from django.urls import re_path
+from django.urls import path
 
 from . import views
 
 app_name = 'wagtailsettings'
 urlpatterns = [
-    re_path(r'^(\w+)/(\w+)/$', views.edit_current_site, name='edit'),
-    re_path(r'^(\w+)/(\w+)/(\d+)/$', views.edit, name='edit'),
+    path('<str:app_name>/<str:model_name>/', views.edit_current_site, name='edit'),
+    path('<str:app_name>/<str:model_name>/<int:site_pk>/', views.edit, name='edit'),
 ]

--- a/wagtail/contrib/settings/wagtail_hooks.py
+++ b/wagtail/contrib/settings/wagtail_hooks.py
@@ -1,4 +1,4 @@
-from django.conf.urls import include, url
+from django.urls import include, path
 
 from wagtail.core import hooks
 
@@ -8,5 +8,5 @@ from . import urls
 @hooks.register('register_admin_urls')
 def register_admin_urls():
     return [
-        url(r'^settings/', include(urls, namespace='wagtailsettings')),
+        path('settings/', include(urls, namespace='wagtailsettings')),
     ]

--- a/wagtail/contrib/styleguide/wagtail_hooks.py
+++ b/wagtail/contrib/styleguide/wagtail_hooks.py
@@ -1,5 +1,4 @@
-from django.urls import path
-from django.urls import reverse
+from django.urls import path, reverse
 from django.utils.translation import ugettext_lazy as _
 
 from wagtail.admin.menu import MenuItem

--- a/wagtail/contrib/styleguide/wagtail_hooks.py
+++ b/wagtail/contrib/styleguide/wagtail_hooks.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url
+from django.urls import path
 from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
 
@@ -11,7 +11,7 @@ from . import views
 @hooks.register('register_admin_urls')
 def register_admin_urls():
     return [
-        url(r'^styleguide/$', views.index, name='wagtailstyleguide'),
+        path('styleguide/', views.index, name='wagtailstyleguide'),
     ]
 
 

--- a/wagtail/core/urls.py
+++ b/wagtail/core/urls.py
@@ -23,8 +23,8 @@ WAGTAIL_FRONTEND_LOGIN_TEMPLATE = getattr(
 
 
 urlpatterns = [
-    re_path(
-        r'^_util/authenticate_with_password/(\d+)/(\d+)/',
+    path(
+        '_util/authenticate_with_password/<int:page_view_restriction_id>/<int:page_id>/',
         views.authenticate_with_password,
         name='wagtailcore_authenticate_with_password'),
     path(

--- a/wagtail/core/urls.py
+++ b/wagtail/core/urls.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.conf.urls import url
+from django.urls import path, re_path
 from django.contrib.auth import views as auth_views
 
 from wagtail.core import views
@@ -23,12 +23,16 @@ WAGTAIL_FRONTEND_LOGIN_TEMPLATE = getattr(
 
 
 urlpatterns = [
-    url(r'^_util/authenticate_with_password/(\d+)/(\d+)/$', views.authenticate_with_password,
+    re_path(
+        r'^_util/authenticate_with_password/(\d+)/(\d+)/',
+        views.authenticate_with_password,
         name='wagtailcore_authenticate_with_password'),
-    url(r'^_util/login/$', auth_views.LoginView.as_view(template_name=WAGTAIL_FRONTEND_LOGIN_TEMPLATE),
+    path(
+        '_util/login/',
+        auth_views.LoginView.as_view(template_name=WAGTAIL_FRONTEND_LOGIN_TEMPLATE),
         name='wagtailcore_login'),
 
     # Front-end page views are handled through Wagtail's core.views.serve
     # mechanism
-    url(serve_pattern, views.serve, name='wagtail_serve')
+    re_path(serve_pattern, views.serve, name='wagtail_serve')
 ]

--- a/wagtail/core/urls.py
+++ b/wagtail/core/urls.py
@@ -1,6 +1,6 @@
 from django.conf import settings
-from django.urls import path, re_path
 from django.contrib.auth import views as auth_views
+from django.urls import path, re_path
 
 from wagtail.core import views
 from wagtail.core.utils import WAGTAIL_APPEND_SLASH

--- a/wagtail/documents/admin_urls.py
+++ b/wagtail/documents/admin_urls.py
@@ -1,20 +1,20 @@
-from django.conf.urls import url
+from django.urls import path, re_path
 
 from wagtail.documents.views import chooser, documents, multiple
 
 app_name = 'wagtaildocs'
 urlpatterns = [
-    url(r'^$', documents.index, name='index'),
-    url(r'^add/$', documents.add, name='add'),
-    url(r'^edit/(\d+)/$', documents.edit, name='edit'),
-    url(r'^delete/(\d+)/$', documents.delete, name='delete'),
+    path('', documents.index, name='index'),
+    path('add/', documents.add, name='add'),
+    re_path(r'^edit/(\d+)/$', documents.edit, name='edit'),
+    re_path(r'^delete/(\d+)/$', documents.delete, name='delete'),
 
-    url(r'^multiple/add/$', multiple.add, name='add_multiple'),
-    url(r'^multiple/(\d+)/$', multiple.edit, name='edit_multiple'),
-    url(r'^multiple/(\d+)/delete/$', multiple.delete, name='delete_multiple'),
+    path('multiple/add/', multiple.add, name='add_multiple'),
+    re_path(r'^multiple/(\d+)/$', multiple.edit, name='edit_multiple'),
+    re_path(r'^multiple/(\d+)/delete/$', multiple.delete, name='delete_multiple'),
 
-    url(r'^chooser/$', chooser.chooser, name='chooser'),
-    url(r'^chooser/(\d+)/$', chooser.document_chosen, name='document_chosen'),
-    url(r'^chooser/upload/$', chooser.chooser_upload, name='chooser_upload'),
-    url(r'^usage/(\d+)/$', documents.usage, name='document_usage'),
+    path('chooser/', chooser.chooser, name='chooser'),
+    re_path(r'^chooser/(\d+)/$', chooser.document_chosen, name='document_chosen'),
+    path('chooser/upload/', chooser.chooser_upload, name='chooser_upload'),
+    re_path(r'^usage/(\d+)/$', documents.usage, name='document_usage'),
 ]

--- a/wagtail/documents/admin_urls.py
+++ b/wagtail/documents/admin_urls.py
@@ -1,4 +1,4 @@
-from django.urls import path, re_path
+from django.urls import path
 
 from wagtail.documents.views import chooser, documents, multiple
 

--- a/wagtail/documents/admin_urls.py
+++ b/wagtail/documents/admin_urls.py
@@ -6,15 +6,15 @@ app_name = 'wagtaildocs'
 urlpatterns = [
     path('', documents.index, name='index'),
     path('add/', documents.add, name='add'),
-    re_path(r'^edit/(\d+)/$', documents.edit, name='edit'),
-    re_path(r'^delete/(\d+)/$', documents.delete, name='delete'),
+    path('edit/<int:document_id>/', documents.edit, name='edit'),
+    path('delete/<int:document_id>/', documents.delete, name='delete'),
 
     path('multiple/add/', multiple.add, name='add_multiple'),
-    re_path(r'^multiple/(\d+)/$', multiple.edit, name='edit_multiple'),
-    re_path(r'^multiple/(\d+)/delete/$', multiple.delete, name='delete_multiple'),
+    path('multiple/<str:doc_id>/', multiple.edit, name='edit_multiple'),
+    path('multiple/<str:doc_id>/delete/', multiple.delete, name='delete_multiple'),
 
     path('chooser/', chooser.chooser, name='chooser'),
-    re_path(r'^chooser/(\d+)/$', chooser.document_chosen, name='document_chosen'),
+    path('chooser/<int:document_id>/', chooser.document_chosen, name='document_chosen'),
     path('chooser/upload/', chooser.chooser_upload, name='chooser_upload'),
-    re_path(r'^usage/(\d+)/$', documents.usage, name='document_usage'),
+    path('usage/<int:document_id>/', documents.usage, name='document_usage'),
 ]

--- a/wagtail/documents/urls.py
+++ b/wagtail/documents/urls.py
@@ -1,11 +1,11 @@
-from django.urls import re_path
+from django.urls import path, re_path
 
 from wagtail.documents.views import serve
 
 urlpatterns = [
     re_path(r'^(\d+)/(.*)$', serve.serve, name='wagtaildocs_serve'),
-    re_path(
-        r'^authenticate_with_password/(\d+)/$',
+    path(
+        'authenticate_with_password/<int:restriction_id>/',
         serve.authenticate_with_password,
         name='wagtaildocs_authenticate_with_password'),
 ]

--- a/wagtail/documents/urls.py
+++ b/wagtail/documents/urls.py
@@ -1,9 +1,11 @@
-from django.conf.urls import url
+from django.urls import re_path
 
 from wagtail.documents.views import serve
 
 urlpatterns = [
-    url(r'^(\d+)/(.*)$', serve.serve, name='wagtaildocs_serve'),
-    url(r'^authenticate_with_password/(\d+)/$', serve.authenticate_with_password,
+    re_path(r'^(\d+)/(.*)$', serve.serve, name='wagtaildocs_serve'),
+    re_path(
+        r'^authenticate_with_password/(\d+)/$',
+        serve.authenticate_with_password,
         name='wagtaildocs_authenticate_with_password'),
 ]

--- a/wagtail/documents/wagtail_hooks.py
+++ b/wagtail/documents/wagtail_hooks.py
@@ -1,7 +1,6 @@
 from django.conf import settings
-from django.urls import include, path
 from django.template.response import TemplateResponse
-from django.urls import reverse
+from django.urls import include, path, reverse
 from django.utils.html import format_html
 from django.utils.translation import ugettext_lazy as _
 from django.utils.translation import ugettext, ungettext

--- a/wagtail/documents/wagtail_hooks.py
+++ b/wagtail/documents/wagtail_hooks.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.conf.urls import include, url
+from django.urls import include, path
 from django.template.response import TemplateResponse
 from django.urls import reverse
 from django.utils.html import format_html
@@ -27,7 +27,7 @@ from wagtail.documents.rich_text.editor_html import EditorHTMLDocumentLinkConver
 @hooks.register('register_admin_urls')
 def register_admin_urls():
     return [
-        url(r'^documents/', include(admin_urls, namespace='wagtaildocs')),
+        path('documents/', include(admin_urls, namespace='wagtaildocs')),
     ]
 
 

--- a/wagtail/embeds/urls.py
+++ b/wagtail/embeds/urls.py
@@ -1,9 +1,9 @@
-from django.conf.urls import url
+from django.urls import path
 
 from wagtail.embeds.views import chooser
 
 app_name = 'wagtailembeds'
 urlpatterns = [
-    url(r'^chooser/$', chooser.chooser, name='chooser'),
-    url(r'^chooser/upload/$', chooser.chooser_upload, name='chooser_upload'),
+    path('chooser/', chooser.chooser, name='chooser'),
+    path('chooser/upload/', chooser.chooser_upload, name='chooser_upload'),
 ]

--- a/wagtail/embeds/wagtail_hooks.py
+++ b/wagtail/embeds/wagtail_hooks.py
@@ -1,4 +1,4 @@
-from django.conf.urls import include, url
+from django.urls import include, path
 from django.urls import reverse
 from django.utils.html import format_html
 from django.utils.translation import ugettext as _
@@ -15,7 +15,7 @@ from wagtail.embeds.rich_text.editor_html import EditorHTMLEmbedConversionRule
 @hooks.register('register_admin_urls')
 def register_admin_urls():
     return [
-        url(r'^embeds/', include(urls, namespace='wagtailembeds')),
+        path('embeds/', include(urls, namespace='wagtailembeds')),
     ]
 
 

--- a/wagtail/embeds/wagtail_hooks.py
+++ b/wagtail/embeds/wagtail_hooks.py
@@ -1,5 +1,4 @@
-from django.urls import include, path
-from django.urls import reverse
+from django.urls import include, path, reverse
 from django.utils.html import format_html
 from django.utils.translation import ugettext as _
 

--- a/wagtail/images/admin_urls.py
+++ b/wagtail/images/admin_urls.py
@@ -5,11 +5,11 @@ from wagtail.images.views import chooser, images, multiple
 app_name = 'wagtailimages'
 urlpatterns = [
     path('', images.index, name='index'),
-    re_path(r'^(\d+)/$', images.edit, name='edit'),
-    re_path(r'^(\d+)/delete/$', images.delete, name='delete'),
-    re_path(r'^(\d+)/generate_url/$', images.url_generator, name='url_generator'),
-    re_path(r'^(\d+)/generate_url/(.*)/$', images.generate_url, name='generate_url'),
-    re_path(r'^(\d+)/preview/(.*)/$', images.preview, name='preview'),
+    path('<int:image_id>/', images.edit, name='edit'),
+    path('<int:image_id>/delete/', images.delete, name='delete'),
+    path('<int:image_id>/generate_url/', images.url_generator, name='url_generator'),
+    path('<int:image_id>/generate_url/<str:filter_spec>/', images.generate_url, name='generate_url'),
+    path('<int:image_id>/preview/<str:filter_spec>/', images.preview, name='preview'),
     path('add/', images.add, name='add'),
     re_path(r'^usage/(\d+)/$', images.usage, name='image_usage'),
 

--- a/wagtail/images/admin_urls.py
+++ b/wagtail/images/admin_urls.py
@@ -1,4 +1,4 @@
-from django.urls import path, re_path
+from django.urls import path
 
 from wagtail.images.views import chooser, images, multiple
 
@@ -11,14 +11,14 @@ urlpatterns = [
     path('<int:image_id>/generate_url/<str:filter_spec>/', images.generate_url, name='generate_url'),
     path('<int:image_id>/preview/<str:filter_spec>/', images.preview, name='preview'),
     path('add/', images.add, name='add'),
-    re_path(r'^usage/(\d+)/$', images.usage, name='image_usage'),
+    path('usage/<int:image_id>/', images.usage, name='image_usage'),
 
     path('multiple/add/', multiple.add, name='add_multiple'),
-    re_path(r'^multiple/(\d+)/$', multiple.edit, name='edit_multiple'),
-    re_path(r'^multiple/(\d+)/delete/$', multiple.delete, name='delete_multiple'),
+    path('multiple/<str:image_id>/', multiple.edit, name='edit_multiple'),
+    path('multiple/<str:image_id>/delete/', multiple.delete, name='delete_multiple'),
 
     path('chooser/', chooser.chooser, name='chooser'),
-    re_path(r'^chooser/(\d+)/$', chooser.image_chosen, name='image_chosen'),
+    path('chooser/<int:image_id>/', chooser.image_chosen, name='image_chosen'),
     path('chooser/upload/', chooser.chooser_upload, name='chooser_upload'),
-    re_path(r'^chooser/(\d+)/select_format/$', chooser.chooser_select_format, name='chooser_select_format'),
+    path('chooser/<int:image_id>/select_format/', chooser.chooser_select_format, name='chooser_select_format'),
 ]

--- a/wagtail/images/admin_urls.py
+++ b/wagtail/images/admin_urls.py
@@ -1,24 +1,24 @@
-from django.conf.urls import url
+from django.urls import path, re_path
 
 from wagtail.images.views import chooser, images, multiple
 
 app_name = 'wagtailimages'
 urlpatterns = [
-    url(r'^$', images.index, name='index'),
-    url(r'^(\d+)/$', images.edit, name='edit'),
-    url(r'^(\d+)/delete/$', images.delete, name='delete'),
-    url(r'^(\d+)/generate_url/$', images.url_generator, name='url_generator'),
-    url(r'^(\d+)/generate_url/(.*)/$', images.generate_url, name='generate_url'),
-    url(r'^(\d+)/preview/(.*)/$', images.preview, name='preview'),
-    url(r'^add/$', images.add, name='add'),
-    url(r'^usage/(\d+)/$', images.usage, name='image_usage'),
+    path('', images.index, name='index'),
+    re_path(r'^(\d+)/$', images.edit, name='edit'),
+    re_path(r'^(\d+)/delete/$', images.delete, name='delete'),
+    re_path(r'^(\d+)/generate_url/$', images.url_generator, name='url_generator'),
+    re_path(r'^(\d+)/generate_url/(.*)/$', images.generate_url, name='generate_url'),
+    re_path(r'^(\d+)/preview/(.*)/$', images.preview, name='preview'),
+    path('add/', images.add, name='add'),
+    re_path(r'^usage/(\d+)/$', images.usage, name='image_usage'),
 
-    url(r'^multiple/add/$', multiple.add, name='add_multiple'),
-    url(r'^multiple/(\d+)/$', multiple.edit, name='edit_multiple'),
-    url(r'^multiple/(\d+)/delete/$', multiple.delete, name='delete_multiple'),
+    path('multiple/add/', multiple.add, name='add_multiple'),
+    re_path(r'^multiple/(\d+)/$', multiple.edit, name='edit_multiple'),
+    re_path(r'^multiple/(\d+)/delete/$', multiple.delete, name='delete_multiple'),
 
-    url(r'^chooser/$', chooser.chooser, name='chooser'),
-    url(r'^chooser/(\d+)/$', chooser.image_chosen, name='image_chosen'),
-    url(r'^chooser/upload/$', chooser.chooser_upload, name='chooser_upload'),
-    url(r'^chooser/(\d+)/select_format/$', chooser.chooser_select_format, name='chooser_select_format'),
+    path('chooser/', chooser.chooser, name='chooser'),
+    re_path(r'^chooser/(\d+)/$', chooser.image_chosen, name='image_chosen'),
+    path('chooser/upload/', chooser.chooser_upload, name='chooser_upload'),
+    re_path(r'^chooser/(\d+)/select_format/$', chooser.chooser_select_format, name='chooser_select_format'),
 ]

--- a/wagtail/images/tests/urls.py
+++ b/wagtail/images/tests/urls.py
@@ -4,6 +4,7 @@ from wagtail.images.views.serve import SendFileView, ServeView
 from wagtail.tests import dummy_sendfile_backend
 
 urlpatterns = [
+    # Format: signature, image_id, filter_spec, filename=None
     re_path(r'^actions/serve/(.*)/(\d*)/(.*)/[^/]*', ServeView.as_view(action='serve'), name='wagtailimages_serve_action_serve'),
     re_path(r'^actions/redirect/(.*)/(\d*)/(.*)/[^/]*', ServeView.as_view(action='redirect'), name='wagtailimages_serve_action_redirect'),
     re_path(r'^custom_key/(.*)/(\d*)/(.*)/[^/]*', ServeView.as_view(key='custom'), name='wagtailimages_serve_custom_key'),

--- a/wagtail/images/tests/urls.py
+++ b/wagtail/images/tests/urls.py
@@ -1,13 +1,13 @@
-from django.conf.urls import url
+from django.urls import re_path
 
 from wagtail.images.views.serve import SendFileView, ServeView
 from wagtail.tests import dummy_sendfile_backend
 
 urlpatterns = [
-    url(r'^actions/serve/(.*)/(\d*)/(.*)/[^/]*', ServeView.as_view(action='serve'), name='wagtailimages_serve_action_serve'),
-    url(r'^actions/redirect/(.*)/(\d*)/(.*)/[^/]*', ServeView.as_view(action='redirect'), name='wagtailimages_serve_action_redirect'),
-    url(r'^custom_key/(.*)/(\d*)/(.*)/[^/]*', ServeView.as_view(key='custom'), name='wagtailimages_serve_custom_key'),
-    url(r'^custom_view/([^/]*)/(\d*)/([^/]*)/[^/]*$', ServeView.as_view(), name='wagtailimages_serve_custom_view'),
-    url(r'^sendfile/(.*)/(\d*)/(.*)/[^/]*', SendFileView.as_view(), name='wagtailimages_sendfile'),
-    url(r'^sendfile-dummy/(.*)/(\d*)/(.*)/[^/]*', SendFileView.as_view(backend=dummy_sendfile_backend.sendfile), name='wagtailimages_sendfile_dummy'),
+    re_path(r'^actions/serve/(.*)/(\d*)/(.*)/[^/]*', ServeView.as_view(action='serve'), name='wagtailimages_serve_action_serve'),
+    re_path(r'^actions/redirect/(.*)/(\d*)/(.*)/[^/]*', ServeView.as_view(action='redirect'), name='wagtailimages_serve_action_redirect'),
+    re_path(r'^custom_key/(.*)/(\d*)/(.*)/[^/]*', ServeView.as_view(key='custom'), name='wagtailimages_serve_custom_key'),
+    re_path(r'^custom_view/([^/]*)/(\d*)/([^/]*)/[^/]*$', ServeView.as_view(), name='wagtailimages_serve_custom_view'),
+    re_path(r'^sendfile/(.*)/(\d*)/(.*)/[^/]*', SendFileView.as_view(), name='wagtailimages_sendfile'),
+    re_path(r'^sendfile-dummy/(.*)/(\d*)/(.*)/[^/]*', SendFileView.as_view(backend=dummy_sendfile_backend.sendfile), name='wagtailimages_sendfile_dummy'),
 ]

--- a/wagtail/images/urls.py
+++ b/wagtail/images/urls.py
@@ -1,7 +1,7 @@
-from django.conf.urls import url
+from django.urls import re_path
 
 from wagtail.images.views.serve import serve
 
 urlpatterns = [
-    url(r'^([^/]*)/(\d*)/([^/]*)/[^/]*$', serve, name='wagtailimages_serve'),
+    re_path(r'^([^/]*)/(\d*)/([^/]*)/[^/]*$', serve, name='wagtailimages_serve'),
 ]

--- a/wagtail/images/urls.py
+++ b/wagtail/images/urls.py
@@ -1,7 +1,8 @@
-from django.urls import re_path
+from django.urls import path
 
 from wagtail.images.views.serve import serve
 
 urlpatterns = [
-    re_path(r'^([^/]*)/(\d*)/([^/]*)/[^/]*$', serve, name='wagtailimages_serve'),
+    path('<str:signature>/<int:image_id>/<str:filter_spec>/', serve, name="wagtailimages_serve"),
+    path('<str:signature>/<int:image_id>/<str:filter_spec>/<str:filename>', serve, name="wagtailimages_serve")
 ]

--- a/wagtail/images/views/serve.py
+++ b/wagtail/images/views/serve.py
@@ -57,7 +57,7 @@ class ServeView(View):
 
         return super(ServeView, cls).as_view(**initkwargs)
 
-    def get(self, request, signature, image_id, filter_spec):
+    def get(self, request, signature, image_id, filter_spec, filename=None):
         if not verify_signature(signature.encode(), image_id, filter_spec, key=self.key):
             raise PermissionDenied
 

--- a/wagtail/images/wagtail_hooks.py
+++ b/wagtail/images/wagtail_hooks.py
@@ -1,4 +1,4 @@
-from django.conf.urls import include, url
+from django.urls import include, path
 from django.urls import reverse
 from django.utils.html import format_html
 from django.utils.translation import ugettext_lazy as _
@@ -23,7 +23,7 @@ from wagtail.images.rich_text.editor_html import EditorHTMLImageConversionRule
 @hooks.register('register_admin_urls')
 def register_admin_urls():
     return [
-        url(r'^images/', include(admin_urls, namespace='wagtailimages')),
+        path('images/', include(admin_urls, namespace='wagtailimages')),
     ]
 
 

--- a/wagtail/images/wagtail_hooks.py
+++ b/wagtail/images/wagtail_hooks.py
@@ -1,5 +1,4 @@
-from django.urls import include, path
-from django.urls import reverse
+from django.urls import include, path, reverse
 from django.utils.html import format_html
 from django.utils.translation import ugettext_lazy as _
 from django.utils.translation import ugettext, ungettext

--- a/wagtail/project_template/project_name/urls.py
+++ b/wagtail/project_template/project_name/urls.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.conf.urls import include, url
+from django.urls import include, path
 from django.contrib import admin
 
 from wagtail.admin import urls as wagtailadmin_urls
@@ -9,12 +9,12 @@ from wagtail.documents import urls as wagtaildocs_urls
 from search import views as search_views
 
 urlpatterns = [
-    url(r'^django-admin/', admin.site.urls),
+    path('django-admin/', admin.site.urls),
 
-    url(r'^admin/', include(wagtailadmin_urls)),
-    url(r'^documents/', include(wagtaildocs_urls)),
+    path('admin/', include(wagtailadmin_urls)),
+    path('documents/', include(wagtaildocs_urls)),
 
-    url(r'^search/$', search_views.search, name='search'),
+    path('search/', search_views.search, name='search'),
 
 ]
 
@@ -31,9 +31,9 @@ urlpatterns = urlpatterns + [
     # For anything not caught by a more specific rule above, hand over to
     # Wagtail's page serving mechanism. This should be the last pattern in
     # the list:
-    url(r"", include(wagtail_urls)),
+    path("", include(wagtail_urls)),
 
     # Alternatively, if you want Wagtail pages to be served from a subpath
     # of your site, rather than the site root:
-    #    url(r"^pages/", include(wagtail_urls)),
+    #    path("pages/", include(wagtail_urls)),
 ]

--- a/wagtail/search/urls/admin.py
+++ b/wagtail/search/urls/admin.py
@@ -1,9 +1,9 @@
-from django.conf.urls import url
+from django.urls import path
 
 from wagtail.search.views import queries
 
 app_name = 'wagtailsearch_admin'
 urlpatterns = [
-    url(r"^queries/chooser/$", queries.chooser, name="queries_chooser"),
-    url(r"^queries/chooser/results/$", queries.chooserresults, name="queries_chooserresults"),
+    path("queries/chooser/", queries.chooser, name="queries_chooser"),
+    path("queries/chooser/results/", queries.chooserresults, name="queries_chooserresults"),
 ]

--- a/wagtail/search/wagtail_hooks.py
+++ b/wagtail/search/wagtail_hooks.py
@@ -1,4 +1,4 @@
-from django.conf.urls import include, url
+from django.urls import include, path
 
 from wagtail.core import hooks
 from wagtail.search.urls import admin as admin_urls
@@ -7,5 +7,5 @@ from wagtail.search.urls import admin as admin_urls
 @hooks.register('register_admin_urls')
 def register_admin_urls():
     return [
-        url(r'^search/', include(admin_urls, namespace='wagtailsearch_admin')),
+        path('search/', include(admin_urls, namespace='wagtailsearch_admin')),
     ]

--- a/wagtail/snippets/urls.py
+++ b/wagtail/snippets/urls.py
@@ -1,19 +1,19 @@
-from django.conf.urls import url
+from django.urls import path, re_path
 
 from wagtail.snippets.views import chooser, snippets
 
 app_name = 'wagtailsnippets'
 urlpatterns = [
-    url(r'^$', snippets.index, name='index'),
+    path('', snippets.index, name='index'),
 
-    url(r'^choose/$', chooser.choose, name='choose_generic'),
-    url(r'^choose/(\w+)/(\w+)/$', chooser.choose, name='choose'),
-    url(r'^choose/(\w+)/(\w+)/([^/]+?)/$', chooser.chosen, name='chosen'),
+    path('choose/', chooser.choose, name='choose_generic'),
+    re_path(r'^choose/(\w+)/(\w+)/$', chooser.choose, name='choose'),
+    re_path(r'^choose/(\w+)/(\w+)/([^/]+?)/$', chooser.chosen, name='chosen'),
 
-    url(r'^(\w+)/(\w+)/$', snippets.list, name='list'),
-    url(r'^(\w+)/(\w+)/add/$', snippets.create, name='add'),
-    url(r'^(\w+)/(\w+)/([^/]+?)/$', snippets.edit, name='edit'),
-    url(r'^(\w+)/(\w+)/multiple/delete/$', snippets.delete, name='delete-multiple'),
-    url(r'^(\w+)/(\w+)/([^/]+?)/delete/$', snippets.delete, name='delete'),
-    url(r'^(\w+)/(\w+)/([^/]+?)/usage/$', snippets.usage, name='usage'),
+    re_path(r'^(\w+)/(\w+)/$', snippets.list, name='list'),
+    re_path(r'^(\w+)/(\w+)/add/$', snippets.create, name='add'),
+    re_path(r'^(\w+)/(\w+)/([^/]+?)/$', snippets.edit, name='edit'),
+    re_path(r'^(\w+)/(\w+)/multiple/delete/$', snippets.delete, name='delete-multiple'),
+    re_path(r'^(\w+)/(\w+)/([^/]+?)/delete/$', snippets.delete, name='delete'),
+    re_path(r'^(\w+)/(\w+)/([^/]+?)/usage/$', snippets.usage, name='usage'),
 ]

--- a/wagtail/snippets/urls.py
+++ b/wagtail/snippets/urls.py
@@ -1,4 +1,4 @@
-from django.urls import path, re_path
+from django.urls import path
 
 from wagtail.snippets.views import chooser, snippets
 
@@ -7,13 +7,13 @@ urlpatterns = [
     path('', snippets.index, name='index'),
 
     path('choose/', chooser.choose, name='choose_generic'),
-    re_path(r'^choose/(\w+)/(\w+)/$', chooser.choose, name='choose'),
-    re_path(r'^choose/(\w+)/(\w+)/([^/]+?)/$', chooser.chosen, name='chosen'),
+    path('choose/<str:app_label>/<str:model_name>/', chooser.choose, name='choose'),
+    path('choose/<str:app_label>/<str:model_name>/<str:pk>/', chooser.chosen, name='chosen'),
 
-    re_path(r'^(\w+)/(\w+)/$', snippets.list, name='list'),
-    re_path(r'^(\w+)/(\w+)/add/$', snippets.create, name='add'),
-    re_path(r'^(\w+)/(\w+)/([^/]+?)/$', snippets.edit, name='edit'),
-    re_path(r'^(\w+)/(\w+)/multiple/delete/$', snippets.delete, name='delete-multiple'),
-    re_path(r'^(\w+)/(\w+)/([^/]+?)/delete/$', snippets.delete, name='delete'),
-    re_path(r'^(\w+)/(\w+)/([^/]+?)/usage/$', snippets.usage, name='usage'),
+    path('<str:app_label>/<str:model_name>/', snippets.list, name='list'),
+    path('<str:app_label>/<str:model_name>/add/', snippets.create, name='add'),
+    path('<str:app_label>/<str:model_name>/<str:pk>/', snippets.edit, name='edit'),
+    path('<str:app_label>/<str:model_name>/multiple/delete/', snippets.delete, name='delete-multiple'),
+    path('<str:app_label>/<str:model_name>/<str:pk>/delete/', snippets.delete, name='delete'),
+    path('<str:app_label>/<str:model_name>/<str:pk>/usage/', snippets.usage, name='usage'),
 ]

--- a/wagtail/snippets/wagtail_hooks.py
+++ b/wagtail/snippets/wagtail_hooks.py
@@ -1,7 +1,6 @@
-from django.urls import include, path
 from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
-from django.urls import reverse
+from django.urls import include, path, reverse
 from django.utils.html import format_html
 from django.utils.translation import ugettext_lazy as _
 

--- a/wagtail/snippets/wagtail_hooks.py
+++ b/wagtail/snippets/wagtail_hooks.py
@@ -1,4 +1,4 @@
-from django.conf.urls import include, url
+from django.urls import include, path
 from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
@@ -15,7 +15,7 @@ from wagtail.snippets.permissions import user_can_edit_snippets
 @hooks.register('register_admin_urls')
 def register_admin_urls():
     return [
-        url(r'^snippets/', include(urls, namespace='wagtailsnippets')),
+        path('snippets/', include(urls, namespace='wagtailsnippets')),
     ]
 
 

--- a/wagtail/tests/non_root_urls.py
+++ b/wagtail/tests/non_root_urls.py
@@ -1,7 +1,7 @@
 """An alternative urlconf module where Wagtail front-end URLs
 are rooted at '/site/' rather than '/'"""
 
-from django.conf.urls import include, url
+from django.urls import include, path
 
 from wagtail.admin import urls as wagtailadmin_urls
 from wagtail.core import urls as wagtail_urls
@@ -9,8 +9,8 @@ from wagtail.documents import urls as wagtaildocs_urls
 from wagtail.images import urls as wagtailimages_urls
 
 urlpatterns = [
-    url(r'^admin/', include(wagtailadmin_urls)),
-    url(r'^documents/', include(wagtaildocs_urls)),
-    url(r'^images/', include(wagtailimages_urls)),
-    url(r'^site/', include(wagtail_urls)),
+    path('admin/', include(wagtailadmin_urls)),
+    path('documents/', include(wagtaildocs_urls)),
+    path('images/', include(wagtailimages_urls)),
+    path('site/', include(wagtail_urls)),
 ]

--- a/wagtail/tests/testapp/urls.py
+++ b/wagtail/tests/testapp/urls.py
@@ -1,8 +1,8 @@
-from django.conf.urls import url
+from django.urls import path
 
 from wagtail.tests.testapp.views import bob_only_zone, message_test
 
 urlpatterns = [
-    url(r'^bob-only-zone$', bob_only_zone, name='testapp_bob_only_zone'),
-    url(r'^messages/$', message_test, name='testapp_message_test')
+    path('bob-only-zone', bob_only_zone, name='testapp_bob_only_zone'),
+    path('messages/', message_test, name='testapp_message_test')
 ]

--- a/wagtail/tests/urls.py
+++ b/wagtail/tests/urls.py
@@ -1,5 +1,5 @@
 from django.http import HttpResponse
-from django.urls import include, path, re_path
+from django.urls import include, path
 
 from wagtail.admin import urls as wagtailadmin_urls
 from wagtail.api.v2.router import WagtailAPIRouter
@@ -34,7 +34,7 @@ urlpatterns = [
         'sitemaps': {'pages': Sitemap, 'events': EventSitemap(request=None)},
         'sitemap_url_name': 'sitemap',
     }),
-    re_path(r'^sitemap-(?P<section>.+)\.xml$', sitemaps_views.sitemap, name='sitemap'),
+    path('sitemap-<str:section>.xml', sitemaps_views.sitemap, name='sitemap'),
 
     path('testapp/', include(testapp_urls)),
 

--- a/wagtail/tests/urls.py
+++ b/wagtail/tests/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import include, url
+from django.urls import include, path, re_path
 from django.http import HttpResponse
 
 from wagtail.admin import urls as wagtailadmin_urls
@@ -22,25 +22,25 @@ api_router.register_endpoint('documents', DocumentsAPIViewSet)
 
 
 urlpatterns = [
-    url(r'^admin/', include(wagtailadmin_urls)),
-    url(r'^documents/', include(wagtaildocs_urls)),
-    url(r'^testimages/', include(wagtailimages_test_urls)),
-    url(r'^images/', include(wagtailimages_urls)),
+    path('admin/', include(wagtailadmin_urls)),
+    path('documents/', include(wagtaildocs_urls)),
+    path('testimages/', include(wagtailimages_test_urls)),
+    path('images/', include(wagtailimages_urls)),
 
-    url(r'^api/main/', api_router.urls),
-    url(r'^sitemap\.xml$', sitemaps_views.sitemap),
+    path('api/main/', api_router.urls),
+    path('sitemap.xml', sitemaps_views.sitemap),
 
-    url(r'^sitemap-index\.xml$', sitemaps_views.index, {
+    path('sitemap-index.xml', sitemaps_views.index, {
         'sitemaps': {'pages': Sitemap, 'events': EventSitemap(request=None)},
         'sitemap_url_name': 'sitemap',
     }),
-    url(r'^sitemap-(?P<section>.+)\.xml$', sitemaps_views.sitemap, name='sitemap'),
+    re_path(r'^sitemap-(?P<section>.+)\.xml$', sitemaps_views.sitemap, name='sitemap'),
 
-    url(r'^testapp/', include(testapp_urls)),
+    path('testapp/', include(testapp_urls)),
 
-    url(r'^fallback/', lambda: HttpResponse('ok'), name='fallback'),
+    path('fallback/', lambda: HttpResponse('ok'), name='fallback'),
 
     # For anything not caught by a more specific rule above, hand over to
     # Wagtail's serving mechanism
-    url(r'', include(wagtail_urls)),
+    path('', include(wagtail_urls)),
 ]

--- a/wagtail/tests/urls.py
+++ b/wagtail/tests/urls.py
@@ -1,5 +1,5 @@
-from django.urls import include, path, re_path
 from django.http import HttpResponse
+from django.urls import include, path, re_path
 
 from wagtail.admin import urls as wagtailadmin_urls
 from wagtail.api.v2.router import WagtailAPIRouter

--- a/wagtail/tests/urls_multilang.py
+++ b/wagtail/tests/urls_multilang.py
@@ -1,9 +1,9 @@
 from __future__ import absolute_import, unicode_literals
 
-from django.conf.urls import include, url
+from django.urls import include, path
 from django.conf.urls.i18n import i18n_patterns
 
 from wagtail.core import urls as wagtail_urls
 
 
-urlpatterns = i18n_patterns(url(r'', include(wagtail_urls)))
+urlpatterns = i18n_patterns(path('', include(wagtail_urls)))

--- a/wagtail/tests/urls_multilang.py
+++ b/wagtail/tests/urls_multilang.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 
-from django.urls import include, path
 from django.conf.urls.i18n import i18n_patterns
+from django.urls import include, path
 
 from wagtail.core import urls as wagtail_urls
 

--- a/wagtail/users/urls/users.py
+++ b/wagtail/users/urls/users.py
@@ -1,11 +1,11 @@
-from django.conf.urls import url
+from django.urls import path, re_path
 
 from wagtail.users.views import users
 
 app_name = 'wagtailusers_users'
 urlpatterns = [
-    url(r'^$', users.index, name='index'),
-    url(r'^add/$', users.create, name='add'),
-    url(r'^([^\/]+)/$', users.edit, name='edit'),
-    url(r'^([^\/]+)/delete/$', users.delete, name='delete'),
+    path('', users.index, name='index'),
+    path('add/', users.create, name='add'),
+    re_path(r'^([^\/]+)/$', users.edit, name='edit'),
+    re_path(r'^([^\/]+)/delete/$', users.delete, name='delete'),
 ]

--- a/wagtail/users/urls/users.py
+++ b/wagtail/users/urls/users.py
@@ -6,6 +6,6 @@ app_name = 'wagtailusers_users'
 urlpatterns = [
     path('', users.index, name='index'),
     path('add/', users.create, name='add'),
-    re_path(r'^([^\/]+)/$', users.edit, name='edit'),
-    re_path(r'^([^\/]+)/delete/$', users.delete, name='delete'),
+    path('<str:user_id>/', users.edit, name='edit'),
+    path('<str:user_id>/delete/', users.delete, name='delete'),
 ]

--- a/wagtail/users/urls/users.py
+++ b/wagtail/users/urls/users.py
@@ -1,4 +1,4 @@
-from django.urls import path, re_path
+from django.urls import path
 
 from wagtail.users.views import users
 

--- a/wagtail/users/wagtail_hooks.py
+++ b/wagtail/users/wagtail_hooks.py
@@ -1,7 +1,6 @@
-from django.urls import include, path
 from django.contrib.auth.models import Permission
 from django.db.models import Q
-from django.urls import reverse
+from django.urls import include, path, reverse
 from django.utils.translation import ugettext_lazy as _
 
 from wagtail.admin.menu import MenuItem

--- a/wagtail/users/wagtail_hooks.py
+++ b/wagtail/users/wagtail_hooks.py
@@ -1,4 +1,4 @@
-from django.conf.urls import include, url
+from django.urls import include, path
 from django.contrib.auth.models import Permission
 from django.db.models import Q
 from django.urls import reverse
@@ -17,7 +17,7 @@ from wagtail.users.widgets import UserListingButton
 @hooks.register('register_admin_urls')
 def register_admin_urls():
     return [
-        url(r'^users/', include(users, namespace='wagtailusers_users')),
+        path('users/', include(users, namespace='wagtailusers_users')),
     ]
 
 


### PR DESCRIPTION
Fixes #4433

This is a (very large) PR that will replace calls to `django.conf.urls.url()` with `django.urls.path()` or `django.urls.re_path()` where appropriate.

`path()` introduces simpler routing syntax and was introduced in Django 2.0: https://docs.djangoproject.com/en/3.0/releases/2.0/#simplified-url-routing-syntax

**TODO:**
- [x] Fix import sorting issues
- [x] Simplify regexes to use [path converters](https://docs.djangoproject.com/en/3.0/releases/2.0/#simplified-url-routing-syntax) where possible.

I think especially the fairly complex url patterns benefit from this new syntax. It's much clearer although more verbose now.

I'd love to get a review and input on this!
