### PR TITLE
get_indexed_models is a function, lets call it and loop through the results

### DIFF
--- a/wagtail/search/backends/base.py
+++ b/wagtail/search/backends/base.py
@@ -317,7 +317,7 @@ class BaseSearchBackend:
 
     def refresh_index(self):
         refreshed_indexes = []
-        for model in get_indexed_models:
+        for model in get_indexed_models():
             index = self.get_index_for_model(model)
             if index not in refreshed_indexes:
                 index.refresh()


### PR DESCRIPTION
Most likely nobody has ever called refresh_index, because I just tried it and found this bug.
