### PR TITLE
Support disabling free tagging on tag models

### DIFF
--- a/docs/reference/pages/model_recipes.rst
+++ b/docs/reference/pages/model_recipes.rst
@@ -139,11 +139,13 @@ Be careful if you're introducing new required arguments to the ``serve()`` metho
 Tagging
 -------
 
-Wagtail provides tagging capability through the combination of two django modules, ``taggit`` and ``modelcluster``. ``taggit`` provides a model for tags which is extended by ``modelcluster``, which in turn provides some magical database abstraction which makes drafts and revisions possible in Wagtail. It's a tricky recipe, but the net effect is a many-to-many relationship between your model and a tag class reserved for your model.
+Wagtail provides tagging capabilities through the combination of two Django modules, `django-taggit <https://django-taggit.readthedocs.io/>`_ (which provides a general-purpose tagging implementation) and `django-modelcluster <https://github.com/wagtail/django-modelcluster>`_ (which extends django-taggit's ``TaggableManager`` to allow tag relations to be managed in memory without writing to the database - necessary for handling previews and revisions). To add tagging to a page model, you'll need to define a 'through' model inheriting from ``TaggedItemBase`` to set up the many-to-many relationship between django-taggit's ``Tag`` model and your page model, and add a ``ClusterTaggableManager`` accessor to your page model to present this relation as a single tag field.
 
-Using an example from the Wagtail demo site, here's what the tag model and the relationship field looks like in ``models.py``:
+In this example, we set up tagging on ``BlogPage`` through a ``BlogPageTag`` model:
 
 .. code-block:: python
+
+    # models.py
 
     from modelcluster.fields import ParentalKey
     from modelcluster.contrib.taggit import ClusterTaggableManager
@@ -163,7 +165,7 @@ Using an example from the Wagtail demo site, here's what the tag model and the r
 
 Wagtail's admin provides a nice interface for inputting tags into your content, with typeahead tag completion and friendly tag icons.
 
-Now that we have the many-to-many tag relationship in place, we can fit in a way to render both sides of the relation. Here's more of the Wagtail demo site ``models.py``, where the index model for ``BlogPage`` is extended with logic for filtering the index by tag:
+We can now make use of the many-to-many tag relationship in our views and templates. For example, we can set up the blog's index page to accept a ``?tag=...`` query parameter to filter the ``BlogPage`` listing by tag:
 
 .. code-block:: python
 
@@ -171,21 +173,24 @@ Now that we have the many-to-many tag relationship in place, we can fit in a way
 
     class BlogIndexPage(Page):
         ...
-        def serve(self, request):
-            # Get blogs
-            blogs = BlogPage.objects.child_of(self).live()
+        def get_context(self, request):
+            context = super().get_context(request)
+
+            # Get blog entries
+            blog_entries = BlogPage.objects.child_of(self).live()
 
             # Filter by tag
             tag = request.GET.get('tag')
             if tag:
-                blogs = blogs.filter(tags__name=tag)
+                blog_entries = blog_entries.filter(tags__name=tag)
 
+            context['blog_entries'] = blogs
             return render(request, self.template, {
                 'page': self,
                 'blogs': blogs,
             })
 
-Here, ``blogs.filter(tags__name=tag)`` invokes a reverse Django QuerySet filter on the ``BlogPageTag`` model to optionally limit the ``BlogPage`` objects sent to the template for rendering. Now, lets render both sides of the relation by showing the tags associated with an object and a way of showing all of the objects associated with each tag. This could be added to the ``blog_page.html`` template:
+Here, ``blogs.filter(tags__name=tag)`` follows the ``tags`` relation on ``BlogPage``, to filter the listing to only those pages with a matching tag name before passing this to the template for rendering. We can now update the ``blog_page.html`` template to show a list of tags associated with the page, with links back to the filtered index page:
 
 .. code-block:: html+django
 
@@ -193,9 +198,65 @@ Here, ``blogs.filter(tags__name=tag)`` invokes a reverse Django QuerySet filter 
         <a href="{% pageurl page.blog_index %}?tag={{ tag }}">{{ tag }}</a>
     {% endfor %}
 
-Iterating through ``page.tags.all`` will display each tag associated with ``page``, while the link(s) back to the index make use of the filter option added to the ``BlogIndexPage`` model. A Django query could also use the ``tagged_items`` related name field to get ``BlogPage`` objects associated with a tag.
+Iterating through ``page.tags.all`` will display each tag associated with ``page``, while the links back to the index make use of the filter option added to the ``BlogIndexPage`` model. A Django query could also use the ``tagged_items`` related name field to get ``BlogPage`` objects associated with a tag.
 
-This is just one possible way of creating a taxonomy for Wagtail objects. With all of the components for a taxonomy available through Wagtail, you should be able to fulfil even the most exotic taxonomic schemes.
+The same approach can be used to add tagging to non-page models managed through :ref:`snippets` and :doc:`/reference/contrib/modeladmin/index`. In this case, the model must inherit from ``modelcluster.models.ClusterableModel`` to be compatible with ``ClusterTaggableManager``.
+
+
+Custom tag models
+-----------------
+
+In the above example, any newly-created tags will be added to django-taggit's default ``Tag`` model, which will be shared by all other models using the same recipe as well as Wagtail's image and document models. In particular, this means that the autocompletion suggestions on tag fields will include tags previously added to other models. To avoid this, you can set up a custom tag model inheriting from ``TagBase``, along with a 'through' model inheriting from ``ItemBase``, which will provide an independent pool of tags for that page model.
+
+.. code-block:: python
+
+    from django.db import models
+    from modelcluster.contrib.taggit import ClusterTaggableManager
+    from modelcluster.fields import ParentalKey
+    from taggit.models import TagBase, ItemBase
+
+    class BlogTag(TagBase):
+        class Meta:
+            verbose_name = "blog tag"
+            verbose_name_plural = "blog tags"
+
+
+    class TaggedBlog(ItemBase):
+        tag = models.ForeignKey(
+            BlogTag, related_name="tagged_blogs", on_delete=models.CASCADE
+        )
+        content_object = ParentalKey(
+            to='demo.BlogPage',
+            on_delete=models.CASCADE,
+            related_name='tagged_items'
+        )
+
+    class BlogPage(Page):
+        ...
+        tags = ClusterTaggableManager(through='demo.TaggedBlog', blank=True)
+
+Within the admin, the tag field will automatically recognise the custom tag model being used, and will offer autocomplete suggestions taken from that tag model.
+
+
+Disabling free tagging
+----------------------
+
+By default, tag fields work on a "free tagging" basis: editors can enter anything into the field, and upon saving, any tag text not recognised as an existing tag will be created automatically. To disable this behaviour, and only allow editors to enter tags that already exist in the database, custom tag models accept a ``free_tagging = False`` option:
+
+.. code-block:: python
+
+    from taggit.models import TagBase
+    from wagtail.snippets.models import register_snippet
+
+    @register_snippet
+    class BlogTag(TagBase):
+        free_tagging = False
+
+        class Meta:
+            verbose_name = "blog tag"
+            verbose_name_plural = "blog tags"
+
+Here we have registered ``BlogTag`` as a snippet, to provide an interface for administrators (and other users with the appropriate permissions) to manage the allowed set of tags. With the ``free_tagging = False`` option set, editors can no longer enter arbitrary text into the tag field, and must instead select existing tags from the autocomplete dropdown.
 
 
 Have redirects created automatically when changing page slug

--- a/wagtail/admin/forms/models.py
+++ b/wagtail/admin/forms/models.py
@@ -5,13 +5,14 @@ from modelcluster.forms import ClusterForm, ClusterFormMetaclass
 from taggit.managers import TaggableManager
 
 from wagtail.admin import widgets
+from wagtail.admin.forms.tags import TagField
 
 
 # Form field properties to override whenever we encounter a model field
 # that matches one of these types - including subclasses
 
 def _get_tag_field_overrides(db_field):
-    return {'widget': widgets.AdminTagWidget(tag_model=db_field.related_model)}
+    return {'form_class': TagField, 'tag_model': db_field.related_model}
 
 
 FORM_FIELD_OVERRIDES = {

--- a/wagtail/admin/forms/tags.py
+++ b/wagtail/admin/forms/tags.py
@@ -25,7 +25,7 @@ class TagField(TaggitTagField):
             self.widget.tag_model = self.tag_model
 
         if self.free_tagging is None:
-            self.free_tagging = True
+            self.free_tagging = getattr(self.tag_model, 'free_tagging', True)
         else:
             self.widget.free_tagging = self.free_tagging
 

--- a/wagtail/admin/forms/tags.py
+++ b/wagtail/admin/forms/tags.py
@@ -1,0 +1,41 @@
+from taggit.forms import TagField as TaggitTagField
+from taggit.models import Tag
+
+from wagtail.admin.widgets import AdminTagWidget
+
+
+class TagField(TaggitTagField):
+    """
+    Extends taggit's TagField with the option to prevent creating tags that do not already exist
+    """
+    widget = AdminTagWidget
+
+    def __init__(self, *args, **kwargs):
+        self.tag_model = kwargs.pop('tag_model', None)
+        self.free_tagging = kwargs.pop('free_tagging', None)
+
+        super().__init__(*args, **kwargs)
+
+        # pass on tag_model and free_tagging kwargs to the widget,
+        # if (and only if) they have been passed explicitly here.
+        # Otherwise, set default values for clean() to use
+        if self.tag_model is None:
+            self.tag_model = Tag
+        else:
+            self.widget.tag_model = self.tag_model
+
+        if self.free_tagging is None:
+            self.free_tagging = True
+        else:
+            self.widget.free_tagging = self.free_tagging
+
+    def clean(self, value):
+        value = super().clean(value)
+
+        if not self.free_tagging:
+            # filter value to just the tags that already exist in tag_model
+            value = list(
+                self.tag_model.objects.filter(name__in=value).values_list('name', flat=True)
+            )
+
+        return value

--- a/wagtail/admin/static_src/wagtailadmin/js/core.js
+++ b/wagtail/admin/static_src/wagtailadmin/js/core.js
@@ -21,8 +21,8 @@ function escapeHtml(text) {
     });
 }
 
-function initTagField(id, autocompleteUrl, allowSpaces, tagLimit) {
-    $('#' + id).tagit({
+function initTagField(id, autocompleteUrl, options) {
+    var finalOptions = Object.assign({
         autocomplete: {source: autocompleteUrl},
         preprocessTag: function(val) {
             // Double quote a tag if it contains a space
@@ -33,10 +33,9 @@ function initTagField(id, autocompleteUrl, allowSpaces, tagLimit) {
 
             return val;
         },
+    }, options);
 
-        allowSpaces: allowSpaces,
-        tagLimit: tagLimit,
-    });
+    $('#' + id).tagit(finalOptions);
 }
 
 /*

--- a/wagtail/admin/static_src/wagtailadmin/js/vendor/tag-it.js
+++ b/wagtail/admin/static_src/wagtailadmin/js/vendor/tag-it.js
@@ -48,6 +48,9 @@
             // Shows autocomplete before the user even types anything.
             showAutocompleteOnFocus: false,
 
+            // When enabled, forces users to create new tags through autocomplete
+            autocompleteOnly: false,
+
             // When enabled, quotes are unneccesary for inputting multi-word tags.
             allowSpaces: false,
 
@@ -266,14 +269,14 @@
                         }
 
                         // Autocomplete will create its own tag from a selection and close automatically.
-                        if (!that.tagInput.data('autocomplete-open')) {
+                        if (!that.tagInput.data('autocomplete-open') && !that.options.autocompleteOnly) {
                             that.createTag(that._cleanedInput());
                         }
                     }
                 }).on('blur', function(e){
                     // Create a tag when the element loses focus.
                     // If autocomplete is enabled and suggestion was clicked, don't add it.
-                    if (!that.tagInput.data('autocomplete-open')) {
+                    if (!that.tagInput.data('autocomplete-open') && !that.options.autocompleteOnly) {
                         that.createTag(that._cleanedInput());
                     }
                 });

--- a/wagtail/admin/templates/wagtailadmin/widgets/tag_widget.html
+++ b/wagtail/admin/templates/wagtailadmin/widgets/tag_widget.html
@@ -1,9 +1,8 @@
 {% include 'django/forms/widgets/text.html' %}
 <script>
     initTagField(
-        '{{ widget.attrs.id|escapejs }}',
-        '{{ widget.autocomplete_url|escapejs }}',
-        {% if widget.tag_spaces_allowed %}true{% else %}false{% endif %},
-        {% if widget.tag_limit %}{{widget.tag_limit}}{% else %}null{% endif %}
+        "{{ widget.attrs.id|escapejs }}",
+        "{{ widget.autocomplete_url|escapejs }}",
+        {{ widget.options_json|safe }}
     );
 </script>

--- a/wagtail/admin/tests/test_edit_handlers.py
+++ b/wagtail/admin/tests/test_edit_handlers.py
@@ -20,7 +20,7 @@ from wagtail.images.edit_handlers import ImageChooserPanel
 from wagtail.tests.testapp.forms import ValidatedPageForm
 from wagtail.tests.testapp.models import (
     EventPage, EventPageChooserModel, EventPageSpeaker, PageChooserModel,
-    RestaurantPage, SimplePage, ValidatedPage)
+    RestaurantPage, RestaurantTag, SimplePage, ValidatedPage)
 from wagtail.tests.utils import WagtailTestUtils
 
 
@@ -125,6 +125,22 @@ class TestGetFormForModel(TestCase):
         )
         form_html = RestaurantPageForm().as_p()
         self.assertIn('/admin/tag\\u002Dautocomplete/tests/restauranttag/', form_html)
+
+        # widget should pick up the free_tagging=False attribute on the tag model
+        # and set itself to autocomplete only
+        self.assertIn('"autocompleteOnly": true', form_html)
+
+        # Free tagging should also be disabled at the form field validation level
+        RestaurantTag.objects.create(name='Italian', slug='italian')
+        RestaurantTag.objects.create(name='Indian', slug='indian')
+
+        form = RestaurantPageForm({
+            'title': 'Buonasera',
+            'slug': 'buonasera',
+            'tags': "Italian, delicious",
+        })
+        self.assertTrue(form.is_valid())
+        self.assertEqual(form.cleaned_data['tags'], ["Italian"])
 
 
 def clear_edit_handler(page_cls):

--- a/wagtail/admin/tests/test_widgets.py
+++ b/wagtail/admin/tests/test_widgets.py
@@ -1,9 +1,11 @@
 import json
 
+from django import forms
 from django.test import TestCase
 from django.test.utils import override_settings
 
 from wagtail.admin import widgets
+from wagtail.admin.forms.tags import TagField
 from wagtail.core.models import Page
 from wagtail.tests.testapp.forms import AdminStarDateInput
 from wagtail.tests.testapp.models import EventPage, RestaurantTag, SimplePage
@@ -251,3 +253,18 @@ class TestAdminTagWidget(TestCase):
             params,
             ['alpha', '/admin/tag-autocomplete/', {'allowSpaces': True, 'tagLimit': None, 'autocompleteOnly': True}]
         )
+
+
+class TestTagField(TestCase):
+    def setUp(self):
+        RestaurantTag.objects.create(name='Italian', slug='italian')
+        RestaurantTag.objects.create(name='Indian', slug='indian')
+
+    def test_tag_whitelisting(self):
+
+        class RestaurantTagForm(forms.Form):
+            tags = TagField(tag_model=RestaurantTag, free_tagging=False)
+
+        form = RestaurantTagForm({'tags': "Italian, delicious"})
+        self.assertTrue(form.is_valid())
+        self.assertEqual(form.cleaned_data['tags'], ["Italian"])

--- a/wagtail/admin/widgets.py
+++ b/wagtail/admin/widgets.py
@@ -119,6 +119,7 @@ class AdminTagWidget(TagWidget):
 
     def __init__(self, *args, **kwargs):
         self.tag_model = kwargs.pop('tag_model', None)
+        self.free_tagging = kwargs.pop('free_tagging', True)
         super().__init__(*args, **kwargs)
 
     def get_context(self, name, value, attrs):
@@ -133,8 +134,11 @@ class AdminTagWidget(TagWidget):
             autocomplete_url = reverse('wagtailadmin_tag_autocomplete')
 
         context['widget']['autocomplete_url'] = autocomplete_url
-        context['widget']['tag_spaces_allowed'] = getattr(settings, 'TAG_SPACES_ALLOWED', True)
-        context['widget']['tag_limit'] = getattr(settings, 'TAG_LIMIT', None)
+        context['widget']['options_json'] = json.dumps({
+            'allowSpaces': getattr(settings, 'TAG_SPACES_ALLOWED', True),
+            'tagLimit': getattr(settings, 'TAG_LIMIT', None),
+            'autocompleteOnly': not self.free_tagging,
+        })
 
         return context
 

--- a/wagtail/admin/widgets.py
+++ b/wagtail/admin/widgets.py
@@ -13,6 +13,7 @@ from django.utils.functional import cached_property
 from django.utils.html import format_html
 from django.utils.translation import ugettext_lazy as _
 from taggit.forms import TagWidget
+from taggit.models import Tag
 
 from wagtail.admin.datetimepicker import to_datetimepicker_format
 from wagtail.admin.staticfiles import versioned_static
@@ -118,26 +119,32 @@ class AdminTagWidget(TagWidget):
     template_name = 'wagtailadmin/widgets/tag_widget.html'
 
     def __init__(self, *args, **kwargs):
-        self.tag_model = kwargs.pop('tag_model', None)
-        self.free_tagging = kwargs.pop('free_tagging', True)
+        self.tag_model = kwargs.pop('tag_model', Tag)
+        # free_tagging = None means defer to the tag model's setting
+        self.free_tagging = kwargs.pop('free_tagging', None)
         super().__init__(*args, **kwargs)
 
     def get_context(self, name, value, attrs):
         context = super().get_context(name, value, attrs)
 
-        if self.tag_model:
+        if self.tag_model == Tag:
+            autocomplete_url = reverse('wagtailadmin_tag_autocomplete')
+        else:
             autocomplete_url = reverse(
                 'wagtailadmin_tag_model_autocomplete',
                 args=(self.tag_model._meta.app_label, self.tag_model._meta.model_name)
             )
+
+        if self.free_tagging is None:
+            free_tagging = getattr(self.tag_model, 'free_tagging', True)
         else:
-            autocomplete_url = reverse('wagtailadmin_tag_autocomplete')
+            free_tagging = self.free_tagging
 
         context['widget']['autocomplete_url'] = autocomplete_url
         context['widget']['options_json'] = json.dumps({
             'allowSpaces': getattr(settings, 'TAG_SPACES_ALLOWED', True),
             'tagLimit': getattr(settings, 'TAG_LIMIT', None),
-            'autocompleteOnly': not self.free_tagging,
+            'autocompleteOnly': not free_tagging,
         })
 
         return context

--- a/wagtail/tests/testapp/models.py
+++ b/wagtail/tests/testapp/models.py
@@ -1422,6 +1422,8 @@ class RestaurantPage(Page):
 
 
 class RestaurantTag(TagBase):
+    free_tagging = False
+
     class Meta:
         verbose_name = "Tag"
         verbose_name_plural = "Tags"


### PR DESCRIPTION
Add a `free_tagging=False` option that disables the creation of new tags through a tag form field and only allows them to be entered through autocompletion; this can be set on a per-field basis on `AdminTagWidget` and the newly-added `wagtail.admin.forms.tags.TagField`, or globally on the tag model:

    from taggit.models import TagBase

    class RestaurantTag(TagBase):
        free_tagging = False

TODO: documentation.