### PR TITLE
Mention options for schema in sitemap

### DIFF
--- a/docs/reference/contrib/sitemaps.rst
+++ b/docs/reference/contrib/sitemaps.rst
@@ -88,7 +88,7 @@ a valid, crawlable hostname. If you change the site's hostname from
     </url>
 
 
-If you change site's port to ``443``, ``https`` scheme will be used.
+If you change the site's port to ``443``, the ``https`` scheme will be used.
 Find out more about :ref:`working with Sites<site-model-ref>`.
 
 

--- a/docs/reference/contrib/sitemaps.rst
+++ b/docs/reference/contrib/sitemaps.rst
@@ -88,6 +88,7 @@ a valid, crawlable hostname. If you change the site's hostname from
     </url>
 
 
+If you change site's port to ``443``, ``https`` scheme will be used.
 Find out more about :ref:`working with Sites<site-model-ref>`.
 
 


### PR DESCRIPTION
Mention clear way to change schema in `sitemap.xml` to https on `sitemap` documentation page. I believe it's really common question. In my case this change would save me from few clicks thru documentation and nasty hacking ideas.
