### PR TITLE
Edit handler heading override

### DIFF
--- a/docs/reference/pages/panels.rst
+++ b/docs/reference/pages/panels.rst
@@ -8,7 +8,7 @@ Available panel types
 FieldPanel
 ----------
 
-.. class:: FieldPanel(field_name, classname=None, widget=None)
+.. class:: FieldPanel(field_name, classname=None, widget=None, heading='')
 
     This is the panel used for basic Django field types.
 
@@ -27,6 +27,10 @@ FieldPanel
     .. attribute:: FieldPanel.widget (optional)
 
         This parameter allows you to specify a :doc:`Django form widget <django:ref/forms/widgets>` to use instead of the default widget for this field type.
+
+    .. attribute:: FieldPanel.heading (optional)
+
+        This allows you to override the heading for the panel, which will otherwise be set automatically using the form field's label (taken in turn from a model field's ``verbose_name``).
 
 StreamFieldPanel
 ----------------

--- a/wagtail/admin/edit_handlers.py
+++ b/wagtail/admin/edit_handlers.py
@@ -531,7 +531,7 @@ class FieldPanel(EditHandler):
 
     def on_form_bound(self):
         self.bound_field = self.form[self.field_name]
-        self.heading = self.bound_field.label
+        self.heading = self.heading or self.bound_field.label
         self.help_text = self.bound_field.help_text
 
     def __repr__(self):

--- a/wagtail/admin/tests/test_edit_handlers.py
+++ b/wagtail/admin/tests/test_edit_handlers.py
@@ -425,10 +425,10 @@ class TestFieldPanel(TestCase):
         # heading from the bound field label
         self.assertEqual(self.end_date_panel.heading, self.end_date_panel.bound_field.label)
 
-        # if heading is explicitly provided to constructor, that heading should be taken in 
+        # if heading is explicitly provided to constructor, that heading should be taken in
         # preference to the field's label
         end_date_panel_with_overridden_heading = (FieldPanel('date_to', classname='full-width', heading="New heading")
-                               .bind_to(model=EventPage, request=self.request))
+                                                  .bind_to(model=EventPage, request=self.request))
         self.assertEqual(end_date_panel_with_overridden_heading.heading, "New heading")
 
 

--- a/wagtail/admin/tests/test_edit_handlers.py
+++ b/wagtail/admin/tests/test_edit_handlers.py
@@ -420,6 +420,18 @@ class TestFieldPanel(TestCase):
         with self.assertRaises(FieldDoesNotExist):
             field_panel.db_field
 
+    def test_override_heading(self):
+        # unless heading is specified in keyword arguments, a bound edit handler should take its
+        # heading from the bound field label
+        self.assertEqual(self.end_date_panel.heading, self.end_date_panel.bound_field.label)
+
+        # if heading is explicitly provided to constructor, that heading should be taken in 
+        # preference to the field's label
+        end_date_panel_with_overridden_heading = (FieldPanel('date_to', classname='full-width', heading="New heading")
+                               .bind_to(model=EventPage, request=self.request))
+        self.assertEqual(end_date_panel_with_overridden_heading.heading, "New heading")
+
+
     def test_render_as_object(self):
         form = self.EventPageForm(
             {'title': 'Pontypridd sheepdog trials', 'date_from': '2014-07-20', 'date_to': '2014-07-22'},

--- a/wagtail/admin/tests/test_edit_handlers.py
+++ b/wagtail/admin/tests/test_edit_handlers.py
@@ -421,14 +421,15 @@ class TestFieldPanel(TestCase):
             field_panel.db_field
 
     def test_override_heading(self):
-        # unless heading is specified in keyword arguments, a bound edit handler should take its
+        # unless heading is specified in keyword arguments, an edit handler with bound form should take its
         # heading from the bound field label
-        self.assertEqual(self.end_date_panel.heading, self.end_date_panel.bound_field.label)
+        bound_panel = self.end_date_panel.bind_to(form=self.EventPageForm())
+        self.assertEqual(bound_panel.heading, bound_panel.bound_field.label)
 
         # if heading is explicitly provided to constructor, that heading should be taken in
         # preference to the field's label
         end_date_panel_with_overridden_heading = (FieldPanel('date_to', classname='full-width', heading="New heading")
-                                                  .bind_to(model=EventPage, request=self.request))
+                                                  .bind_to(model=EventPage, request=self.request, form=self.EventPageForm()))
         self.assertEqual(end_date_panel_with_overridden_heading.heading, "New heading")
 
 


### PR DESCRIPTION
Pulled out from https://github.com/wagtail/wagtail/pull/5868 as requested to ensure this is added to release notes:

Adds the ability to override a FieldPanel's heading by providing it explicitly in the constructor. (Previously this would be overridden as soon as a field was bound by the form field's label)

Adds a test for this new function

