### PR TITLE
Optimize rich text rewrite handlers via bulk lookups

### DIFF
--- a/docs/extending/rich_text_internals.md
+++ b/docs/extending/rich_text_internals.md
@@ -118,11 +118,16 @@ You can create custom rewrite handlers to support your own new `linktype` and `e
 
         For example, ``PageLinkHandler.get_instance`` might receive ``{'id': 123}`` and return the instance of the Wagtail ``Page`` class with ID 123.
 
+        This method should raise an exception if the provided attributes cannot be used to retrieve a
+        Django model instance, for example if the provided ``id`` attribute is invalid.
+
         If left undefined, a default implementation of this method will query the ``id`` model field on the class returned by ``get_model`` using the provided ``id`` attribute; this can be overridden in your own handlers should you want to use some other model field.
 
     .. method:: get_many(attrs_list)
 
         Optional. The classmethod ``get_many`` method works similarly to ``get_instance`` but instead takes a list of attribute dictionaries and returns a list of Django model instances.
+
+        Any instances that cannot be retrieved will be represented by ``None`` in the returned list.
 ```
 
 Below is an example custom rewrite handler that implements some of these methods to add support for rich text linking to user email addresses. It supports the conversion of rich text tags like `<a linktype="user" username="wagtail">` to valid HTML like `<a href="mailto:hello@wagtail.org">`. This example assumes that equivalent front-end functionality has been added to allow users to insert these kinds of links into their rich text editor.

--- a/docs/extending/rich_text_internals.md
+++ b/docs/extending/rich_text_internals.md
@@ -92,9 +92,17 @@ You can create custom rewrite handlers to support your own new `linktype` and `e
 
     .. method:: expand_db_attributes(attrs)
 
-        Required. The ``expand_db_attributes`` method is expected to take a dictionary of attributes from a database rich text ``<a>`` tag (``<embed>`` for ``EmbedHandler``) and use it to generate valid frontend HTML.
+        Optional. The ``expand_db_attributes`` method is expected to take a dictionary of attributes from a database rich text ``<a>`` tag (``<embed>`` for ``EmbedHandler``) and use it to generate valid frontend HTML.
 
         For example, ``PageLinkHandler.expand_db_attributes`` might receive ``{'id': 123}``, use it to retrieve the Wagtail page with ID 123, and render a link to its URL like ``<a href="/path/to/page/123">``.
+
+        Either this method or ``expand_db_attributes_many`` must be defined in a custom rewrite handler.
+
+    .. method:: expand_db_attributes_many(attrs_list)
+
+        Optional. The ``expand_db_attributes_many`` method works similarly to ``expand_db_attributes`` but instead takes a list of attribute dictionaries and returns a list of HTML tags. This method is used by rewrite handlers to work in bulk, for example leveraging the ability to make one database query instead of multiple.
+
+        Either this method or ``expand_db_attributes`` must be defined in a custom rewrite handler. If not defined, the default implementation of ``expand_db_attributes_many`` works by making a series of calls to ``expand_db_attributes``.
 
     .. method:: get_model()
 
@@ -106,14 +114,18 @@ You can create custom rewrite handlers to support your own new `linktype` and `e
 
     .. method:: get_instance(attrs)
 
-        Optional. The static or classmethod ``get_instance`` method also only applies to those handlers that are used to render content related to Django models. This method is expected to take a dictionary of attributes from a database rich text ``<a>`` tag (``<embed>`` for ``EmbedHandler``) and use it to return the specific Django model instance being referred to.
+        Optional. The classmethod ``get_instance`` method also only applies to those handlers that are used to render content related to Django models. This method is expected to take a dictionary of attributes from a database rich text ``<a>`` tag (``<embed>`` for ``EmbedHandler``) and use it to return the specific Django model instance being referred to.
 
         For example, ``PageLinkHandler.get_instance`` might receive ``{'id': 123}`` and return the instance of the Wagtail ``Page`` class with ID 123.
 
         If left undefined, a default implementation of this method will query the ``id`` model field on the class returned by ``get_model`` using the provided ``id`` attribute; this can be overridden in your own handlers should you want to use some other model field.
+
+    .. method:: get_many(attrs_list)
+
+        Optional. The classmethod ``get_many`` method works similarly to ``get_instance`` but instead takes a list of attribute dictionaries and returns a list of Django model instances.
 ```
 
-Below is an example custom rewrite handler that implements these methods to add support for rich text linking to user email addresses. It supports the conversion of rich text tags like `<a linktype="user" username="wagtail">` to valid HTML like `<a href="mailto:hello@wagtail.org">`. This example assumes that equivalent front-end functionality has been added to allow users to insert these kinds of links into their rich text editor.
+Below is an example custom rewrite handler that implements some of these methods to add support for rich text linking to user email addresses. It supports the conversion of rich text tags like ``<a linktype="user" username="wagtail">`` to valid HTML like ``<a href="mailto:hello@wagtail.org">``. This example assumes that equivalent front-end functionality has been added to allow users to insert these kinds of links into their rich text editor.
 
 ```python
 from django.contrib.auth import get_user_model

--- a/docs/extending/rich_text_internals.md
+++ b/docs/extending/rich_text_internals.md
@@ -125,7 +125,7 @@ You can create custom rewrite handlers to support your own new `linktype` and `e
         Optional. The classmethod ``get_many`` method works similarly to ``get_instance`` but instead takes a list of attribute dictionaries and returns a list of Django model instances.
 ```
 
-Below is an example custom rewrite handler that implements some of these methods to add support for rich text linking to user email addresses. It supports the conversion of rich text tags like ``<a linktype="user" username="wagtail">`` to valid HTML like ``<a href="mailto:hello@wagtail.org">``. This example assumes that equivalent front-end functionality has been added to allow users to insert these kinds of links into their rich text editor.
+Below is an example custom rewrite handler that implements some of these methods to add support for rich text linking to user email addresses. It supports the conversion of rich text tags like `<a linktype="user" username="wagtail">` to valid HTML like `<a href="mailto:hello@wagtail.org">`. This example assumes that equivalent front-end functionality has been added to allow users to insert these kinds of links into their rich text editor.
 
 ```python
 from django.contrib.auth import get_user_model

--- a/wagtail/admin/rich_text/converters/editor_html.py
+++ b/wagtail/admin/rich_text/converters/editor_html.py
@@ -143,7 +143,9 @@ class EditorHTMLConverter:
             elif isinstance(rule, LinkTypeRule):
                 link_rules[rule.link_type] = rule.handler.expand_db_attributes
 
-        return MultiRuleRewriter([LinkRewriter(link_rules), EmbedRewriter(embed_rules)])
+        return MultiRuleRewriter(
+            [LinkRewriter(rules=link_rules), EmbedRewriter(rules=embed_rules)]
+        )
 
     def from_database_format(self, html):
         return self.html_rewriter(html)

--- a/wagtail/admin/tests/test_rich_text.py
+++ b/wagtail/admin/tests/test_rich_text.py
@@ -6,7 +6,10 @@ from django.test.utils import override_settings
 from django.urls import reverse, reverse_lazy
 
 from wagtail.admin.rich_text import DraftailRichTextArea, get_rich_text_editor_widget
-from wagtail.admin.rich_text.converters.editor_html import PageLinkHandler
+from wagtail.admin.rich_text.converters.editor_html import (
+    EditorHTMLConverter,
+    PageLinkHandler,
+)
 from wagtail.admin.rich_text.editors.draftail.features import Feature
 from wagtail.blocks import RichTextBlock
 from wagtail.models import Page, get_page_models
@@ -505,6 +508,17 @@ class TestPageLinkHandler(WagtailTestUtils, TestCase):
         self.assertEqual(
             result,
             '<a data-linktype="page" data-id="%d" data-parent-id="2" href="/events/">'
+            % events_page_id,
+        )
+
+    def test_editorhtmlconverter_from_database_format(self):
+        events_page_id = Page.objects.get(url_path="/home/events/").pk
+        db_html = '<a linktype="page" id="%d">foo</a>' % events_page_id
+        converter = EditorHTMLConverter(features=["link"])
+        editor_html = converter.from_database_format(db_html)
+        self.assertEqual(
+            editor_html,
+            '<a data-linktype="page" data-id="%d" data-parent-id="2" href="/events/">foo</a>'
             % events_page_id,
         )
 

--- a/wagtail/documents/rich_text/__init__.py
+++ b/wagtail/documents/rich_text/__init__.py
@@ -1,3 +1,5 @@
+from typing import List
+
 from django.utils.html import escape
 
 from wagtail.documents import get_document_model
@@ -14,11 +16,11 @@ class DocumentLinkHandler(LinkHandler):
         return get_document_model()
 
     @classmethod
-    def expand_db_attributes(cls, attrs):
+    def expand_db_attributes(cls, attrs: dict) -> str:
         return cls.expand_db_attributes_many([attrs])[0]
 
     @classmethod
-    def expand_db_attributes_many(cls, attrs_list):
+    def expand_db_attributes_many(cls, attrs_list: List[dict]) -> List[str]:
         return [
             '<a href="%s">' % escape(doc.url) if doc else "<a>"
             for doc in cls.get_many(attrs_list)

--- a/wagtail/documents/rich_text/__init__.py
+++ b/wagtail/documents/rich_text/__init__.py
@@ -1,4 +1,3 @@
-from django.core.exceptions import ObjectDoesNotExist
 from django.utils.html import escape
 
 from wagtail.documents import get_document_model
@@ -16,11 +15,14 @@ class DocumentLinkHandler(LinkHandler):
 
     @classmethod
     def expand_db_attributes(cls, attrs):
-        try:
-            doc = cls.get_instance(attrs)
-            return '<a href="%s">' % escape(doc.url)
-        except (ObjectDoesNotExist, KeyError):
-            return "<a>"
+        return cls.expand_db_attributes_many([attrs])[0]
+
+    @classmethod
+    def expand_db_attributes_many(cls, attrs_list):
+        return [
+            '<a href="%s">' % escape(doc.url) if doc else "<a>"
+            for doc in cls.get_many(attrs_list)
+        ]
 
     @classmethod
     def extract_references(cls, attrs):

--- a/wagtail/embeds/rich_text/__init__.py
+++ b/wagtail/embeds/rich_text/__init__.py
@@ -18,7 +18,7 @@ class MediaEmbedHandler(EmbedHandler):
         return get_embed(attrs["url"])
 
     @staticmethod
-    def expand_db_attributes(attrs):
+    def expand_db_attributes(attrs: dict) -> str:
         """
         Given a dict of attributes from the <embed> tag, return the real HTML
         representation for use on the front-end.

--- a/wagtail/images/rich_text/__init__.py
+++ b/wagtail/images/rich_text/__init__.py
@@ -1,3 +1,5 @@
+from typing import List
+
 from wagtail.images import get_image_model
 from wagtail.images.formats import get_image_format
 from wagtail.rich_text import EmbedHandler
@@ -13,11 +15,11 @@ class ImageEmbedHandler(EmbedHandler):
         return get_image_model()
 
     @classmethod
-    def expand_db_attributes(cls, attrs):
+    def expand_db_attributes(cls, attrs: dict) -> str:
         return cls.expand_db_attributes_many([attrs])[0]
 
     @classmethod
-    def expand_db_attributes_many(cls, attrs_list):
+    def expand_db_attributes_many(cls, attrs_list: List[dict]) -> List[str]:
         """
         Given a dict of attributes from the <embed> tag, return the real HTML
         representation for use on the front-end.

--- a/wagtail/rich_text/__init__.py
+++ b/wagtail/rich_text/__init__.py
@@ -131,6 +131,14 @@ class EntityHandler:
         model = cls.get_model()
         return model._default_manager.get(id=attrs["id"])
 
+    @classmethod
+    def get_many(cls, attrs_list: List[dict]) -> List[Model]:
+        model = cls.get_model()
+        instance_ids = [attrs.get("id") for attrs in attrs_list]
+        instances_by_id = model._default_manager.in_bulk(instance_ids)
+        instances_by_str_id = {str(k): v for k, v in instances_by_id.items()}
+        return [instances_by_str_id.get(str(id_)) for id_ in instance_ids]
+
     @staticmethod
     def expand_db_attributes(attrs: dict) -> str:
         """

--- a/wagtail/rich_text/pages.py
+++ b/wagtail/rich_text/pages.py
@@ -1,3 +1,6 @@
+from typing import List
+
+from django.db.models import Model
 from django.utils.html import escape
 
 from wagtail.models import Page
@@ -12,7 +15,7 @@ class PageLinkHandler(LinkHandler):
         return Page
 
     @classmethod
-    def get_many(cls, attrs_list):
+    def get_many(cls, attrs_list: List[dict]) -> List[Model]:
         # Override LinkHandler.get_many to reduce database queries through the
         # use of PageQuerySet.specific() instead of QuerySet.in_bulk().
         instance_ids = [attrs.get("id") for attrs in attrs_list]
@@ -21,11 +24,11 @@ class PageLinkHandler(LinkHandler):
         return [pages_by_str_id.get(str(id_)) for id_ in instance_ids]
 
     @classmethod
-    def expand_db_attributes(cls, attrs):
+    def expand_db_attributes(cls, attrs: dict) -> str:
         return cls.expand_db_attributes_many([attrs])[0]
 
     @classmethod
-    def expand_db_attributes_many(cls, attrs_list):
+    def expand_db_attributes_many(cls, attrs_list: List[dict]) -> List[str]:
         return [
             '<a href="%s">' % escape(page.localized.specific.url) if page else "<a>"
             for page in cls.get_many(attrs_list)

--- a/wagtail/rich_text/pages.py
+++ b/wagtail/rich_text/pages.py
@@ -11,17 +11,14 @@ class PageLinkHandler(LinkHandler):
     def get_model():
         return Page
 
-    @classmethod
-    def get_instance(cls, attrs):
-        return super().get_instance(attrs).specific
-
-    @classmethod
     def expand_db_attributes(cls, attrs):
-        try:
-            page = cls.get_instance(attrs)
-            return '<a href="%s">' % escape(page.localized.specific.url)
-        except Page.DoesNotExist:
-            return "<a>"
+        return cls.expand_db_attributes_many([attrs])[0]
+
+    def expand_db_attributes_many(cls, attrs_list):
+        return [
+            '<a href="%s">' % escape(page.localized.specific.url) if page else "<a>"
+            for page in cls.get_many(attrs_list)
+        ]
 
     @classmethod
     def extract_references(self, attrs):

--- a/wagtail/rich_text/pages.py
+++ b/wagtail/rich_text/pages.py
@@ -19,7 +19,7 @@ class PageLinkHandler(LinkHandler):
         # Override LinkHandler.get_many to reduce database queries through the
         # use of PageQuerySet.specific() instead of QuerySet.in_bulk().
         instance_ids = [attrs.get("id") for attrs in attrs_list]
-        qs = Page.objects.filter(id__in=instance_ids).specific_deferred()
+        qs = Page.objects.filter(id__in=instance_ids).defer_streamfields().specific()
         pages_by_str_id = {str(page.id): page for page in qs}
         return [pages_by_str_id.get(str(id_)) for id_ in instance_ids]
 

--- a/wagtail/rich_text/pages.py
+++ b/wagtail/rich_text/pages.py
@@ -19,7 +19,7 @@ class PageLinkHandler(LinkHandler):
         # Override LinkHandler.get_many to reduce database queries through the
         # use of PageQuerySet.specific() instead of QuerySet.in_bulk().
         instance_ids = [attrs.get("id") for attrs in attrs_list]
-        qs = Page.objects.filter(id__in=instance_ids).defer_streamfields().specific()
+        qs = Page.objects.filter(id__in=instance_ids).specific_deferred()
         pages_by_str_id = {str(page.id): page for page in qs}
         return [pages_by_str_id.get(str(id_)) for id_ in instance_ids]
 
@@ -30,7 +30,7 @@ class PageLinkHandler(LinkHandler):
     @classmethod
     def expand_db_attributes_many(cls, attrs_list: List[dict]) -> List[str]:
         return [
-            '<a href="%s">' % escape(page.localized.specific.url) if page else "<a>"
+            '<a href="%s">' % escape(page.localized.url) if page else "<a>"
             for page in cls.get_many(attrs_list)
         ]
 

--- a/wagtail/rich_text/pages.py
+++ b/wagtail/rich_text/pages.py
@@ -11,9 +11,20 @@ class PageLinkHandler(LinkHandler):
     def get_model():
         return Page
 
+    @classmethod
+    def get_many(cls, attrs_list):
+        # Override LinkHandler.get_many to reduce database queries through the
+        # use of PageQuerySet.specific() instead of QuerySet.in_bulk().
+        instance_ids = [attrs.get("id") for attrs in attrs_list]
+        qs = Page.objects.filter(id__in=instance_ids).specific()
+        pages_by_str_id = {str(page.id): page for page in qs}
+        return [pages_by_str_id.get(str(id_)) for id_ in instance_ids]
+
+    @classmethod
     def expand_db_attributes(cls, attrs):
         return cls.expand_db_attributes_many([attrs])[0]
 
+    @classmethod
     def expand_db_attributes_many(cls, attrs_list):
         return [
             '<a href="%s">' % escape(page.localized.specific.url) if page else "<a>"

--- a/wagtail/rich_text/pages.py
+++ b/wagtail/rich_text/pages.py
@@ -16,7 +16,7 @@ class PageLinkHandler(LinkHandler):
         # Override LinkHandler.get_many to reduce database queries through the
         # use of PageQuerySet.specific() instead of QuerySet.in_bulk().
         instance_ids = [attrs.get("id") for attrs in attrs_list]
-        qs = Page.objects.filter(id__in=instance_ids).specific()
+        qs = Page.objects.filter(id__in=instance_ids).defer_streamfields().specific()
         pages_by_str_id = {str(page.id): page for page in qs}
         return [pages_by_str_id.get(str(id_)) for id_ in instance_ids]
 

--- a/wagtail/rich_text/rewriters.py
+++ b/wagtail/rich_text/rewriters.py
@@ -5,13 +5,14 @@ Utility classes for rewriting elements of HTML-like strings
 import re
 from collections import defaultdict
 from itertools import chain
+from typing import Callable, Tuple
 
 FIND_A_TAG = re.compile(r"<a(\b[^>]*)>")
 FIND_EMBED_TAG = re.compile(r"<embed(\b[^>]*)/>")
 FIND_ATTRS = re.compile(r'([\w-]+)\="([^"]*)"')
 
 
-def extract_attrs(attr_string):
+def extract_attrs(attr_string: str) -> dict:
     """
     helper method to extract tag attributes, as a dict of un-escaped strings
     """
@@ -43,7 +44,7 @@ class TagRewriter:
         # Note: return an empty list for cases when you don't want any replacements made
         raise NotImplementedError
 
-    def __call__(self, html):
+    def __call__(self, html: str) -> str:
         matches_by_tag_type, attrs_by_tag_type = self.extract_tags(html)
 
         replacements = [
@@ -65,7 +66,7 @@ class TagRewriter:
 
         return html
 
-    def extract_tags(self, html):
+    def extract_tags(self, html: str) -> Tuple[dict, dict]:
         """Helper method to extract and group HTML tags and their attributes.
 
         Returns the full list of regex matches grouped by tag type as well as
@@ -86,7 +87,7 @@ class TagRewriter:
 
         return matches_by_tag_type, attrs_by_tag_type
 
-    def convert_rule_to_bulk_rule(self, rule):
+    def convert_rule_to_bulk_rule(self, rule: Callable) -> Callable:
         def bulk_rule(args):
             return list(map(rule, args))
 

--- a/wagtail/rich_text/rewriters.py
+++ b/wagtail/rich_text/rewriters.py
@@ -108,6 +108,12 @@ class TagRewriter:
 
 
 class EmbedRewriter(TagRewriter):
+    """
+    Rewrites <embed embedtype="foo" /> tags within rich text into the HTML
+    fragment given by the embed rule for 'foo'. Each embed rule is a function
+    that takes a dict of attributes and returns the HTML fragment.
+    """
+
     def get_opening_tag_regex(self):
         return FIND_EMBED_TAG
 
@@ -133,6 +139,12 @@ class EmbedRewriter(TagRewriter):
 
 
 class LinkRewriter(TagRewriter):
+    """
+    Rewrites <a linktype="foo"> tags within rich text into the HTML fragment
+    given by the rule for 'foo'. Each link rule is a function that takes a dict
+    of attributes and returns the HTML fragment for the opening tag (only).
+    """
+
     def get_opening_tag_regex(self):
         return FIND_A_TAG
 

--- a/wagtail/rich_text/rewriters.py
+++ b/wagtail/rich_text/rewriters.py
@@ -181,21 +181,6 @@ class LinkRewriter(TagRewriter):
         # Replace unrecognised link types with an empty link.
         return rule(attrs_list) if rule else ["<a>"] * len(attrs_list)
 
-    def unsupported_tag_type_rule(self, attrs):
-        return "<a>"
-
-    def get_rule(self, tag_type):
-        if tag_type:
-            try:
-                return self.rules[tag_type]
-            except KeyError:
-                if tag_type not in ["email", "external", "anchor"]:
-                    return self.unsupported_tag_type_rule
-
-        # We want to leave links untouched if they either provide no linktype
-        # or if the linktypes they provide don't have a registered rule.
-        return None
-
 
 class MultiRuleRewriter:
     """Rewrites HTML by applying a sequence of rewriter functions"""

--- a/wagtail/rich_text/rewriters.py
+++ b/wagtail/rich_text/rewriters.py
@@ -40,6 +40,7 @@ class TagRewriter:
         raise NotImplementedError
 
     def get_tag_replacements(self, tag_type, attrs_list):
+        # Note: return an empty list for cases when you don't want any replacements made
         raise NotImplementedError
 
     def __call__(self, html):

--- a/wagtail/rich_text/rewriters.py
+++ b/wagtail/rich_text/rewriters.py
@@ -3,6 +3,7 @@ Utility classes for rewriting elements of HTML-like strings
 """
 
 import re
+from collections import defaultdict
 
 FIND_A_TAG = re.compile(r"<a(\b[^>]*)>")
 FIND_EMBED_TAG = re.compile(r"<embed(\b[^>]*)/>")
@@ -25,101 +26,161 @@ def extract_attrs(attr_string):
     return attributes
 
 
-class EmbedRewriter:
-    """
-    Rewrites <embed embedtype="foo" /> tags within rich text into the HTML fragment given by the
-    embed rule for 'foo'. Each embed rule is a function that takes a dict of attributes and
-    returns the HTML fragment.
-    """
+def extract_and_group_attrs(re_pattern, attr_string, grouping_fn):
+    """Helper method to extract and group tag attributes.
 
-    def __init__(self, embed_rules, reference_extractors=None):
-        self.embed_rules = embed_rules
+    Returns a dict of {group_key: [(match, attrs), (match, attrs), ...]},
+    where attrs are a dict of un-escaped strings.
+    """
+    grouped_attrs = defaultdict(list)
+
+    for match in re_pattern.finditer(attr_string):
+        attrs = extract_attrs(match.group(1))
+        group_key = grouping_fn(attrs)
+        grouped_attrs[group_key].append((match, attrs))
+
+    return grouped_attrs
+
+
+class TagRewriter:
+    def __init__(self, rules=None, bulk_rules=None, reference_extractors=None):
+        self.rules = rules or {}
+        self.bulk_rules = bulk_rules or {}
         self.reference_extractors = reference_extractors or {}
 
-    def replace_tag(self, match):
-        attrs = extract_attrs(match.group(1))
+    def get_opening_tag_regex(self):
+        raise NotImplementedError
+
+    def get_tag_type_from_attrs(self, attrs):
+        raise NotImplementedError
+
+    def unsupported_tag_type_rule(self, attrs):
+        """By default, tags with unsupported types are removed."""
+        return ""
+
+    def get_rule(self, tag_type):
         try:
-            rule = self.embed_rules[attrs["embedtype"]]
+            return self.rules[tag_type]
         except KeyError:
-            # silently drop any tags with an unrecognised or missing embedtype attribute
-            return ""
-        return rule(attrs)
+            return self.unsupported_tag_type_rule
 
     def __call__(self, html):
-        return FIND_EMBED_TAG.sub(self.replace_tag, html)
+        matches_by_tag_type = extract_and_group_attrs(
+            self.get_opening_tag_regex(), html, self.get_tag_type_from_attrs
+        )
 
-    def extract_references(self, html):
-        for match in FIND_EMBED_TAG.findall(html):
-            attrs = extract_attrs(match)
-            if (
-                "embedtype" not in attrs
-                or attrs["embedtype"] not in self.reference_extractors
-            ):
+        offset = 0
+        for tag_type in matches_by_tag_type.keys():
+            rule = self.get_rule(tag_type)
+
+            if not rule:
                 continue
 
-            yield from self.reference_extractors[attrs["embedtype"]](attrs)
+            for match, attrs in matches_by_tag_type[tag_type]:
+                replacement_tag = rule(attrs)
+
+                html = (
+                    html[: match.start() + offset]
+                    + replacement_tag
+                    + html[match.end() + offset :]
+                )
+
+                offset += len(replacement_tag) - match.end() + match.start()
+
+        return html
+
+    def extract_tags(self, html):
+        """Helper method to extract and group HTML tags and their attributes.
+
+        Returns the full list of regex matches grouped by tag type as well as
+        the tag attribute dictionaries grouped by tag type.
+        """
+        matches_by_tag_type = defaultdict(list)
+        attrs_by_tag_type = defaultdict(list)
+
+        # Regex used to match <tag ...> tags in the HTML.
+        re_pattern = self.get_opening_tag_regex()
+
+        for match in re_pattern.finditer(html):
+            attrs = extract_attrs(match.group(1))
+            tag_type = self.get_tag_type_from_attrs(attrs)
+
+            matches_by_tag_type[tag_type].append(match)
+            attrs_by_tag_type[tag_type].append(attrs)
+
+        return matches_by_tag_type, attrs_by_tag_type
+
+    def convert_rule_to_bulk_rule(self, rule):
+        def bulk_rule(args):
+            return list(map(rule, args))
+
+        return bulk_rule
+
+    def extract_references(self, html):
+        re_pattern = self.get_opening_tag_regex()
+        for match in re_pattern.findall(html):
+            attrs = extract_attrs(match)
+            tag_type = self.get_tag_type_from_attrs(attrs)
+
+            if tag_type not in self.reference_extractors:
+                continue
+
+            yield from self.reference_extractors[tag_type](attrs)
+
+        return []
+
+
+class EmbedRewriter(TagRewriter):
+    """Rewrites <embed embedtype="foo" /> tags within rich text."""
+
+    def get_opening_tag_regex(self):
+        return FIND_EMBED_TAG
+
+    def get_tag_type_from_attrs(self, attrs):
+        try:
+            return attrs["embedtype"]
+        except KeyError:
+            return None
 
 
 class LinkRewriter:
-    """
-    Rewrites <a linktype="foo"> tags within rich text into the HTML fragment given by the
-    rule for 'foo'. Each link rule is a function that takes a dict of attributes and
-    returns the HTML fragment for the opening tag (only).
-    """
+    """Rewrites <a linktype="foo" /> tags within rich text."""
 
-    def __init__(self, link_rules, reference_extractors=None):
-        self.link_rules = link_rules
-        self.reference_extractors = reference_extractors or {}
+    def get_opening_tag_regex(self):
+        return FIND_A_TAG
 
-    def replace_tag(self, match):
-        attrs = extract_attrs(match.group(1))
+    def get_tag_type_from_attrs(self, attrs):
         try:
-            link_type = attrs["linktype"]
+            return attrs["linktype"]
         except KeyError:
-            link_type = None
             href = attrs.get("href", None)
             if href:
                 # From href attribute we try to detect only the linktypes that we
                 # currently support (`external` & `email`, `page` has a default handler)
                 # from the link chooser.
                 if href.startswith(("http:", "https:")):
-                    link_type = "external"
+                    return "external"
                 elif href.startswith("mailto:"):
-                    link_type = "email"
+                    return "email"
                 elif href.startswith("#"):
-                    link_type = "anchor"
+                    return "anchor"
 
-            if not link_type:
-                # otherwise return ordinary links without a linktype unchanged
-                return match.group(0)
+            return None
 
-        try:
-            rule = self.link_rules[link_type]
-        except KeyError:
-            if link_type in ["email", "external", "anchor"]:
-                # If no rule is registered for supported types
-                # return ordinary links without a linktype unchanged
-                return match.group(0)
-            # unrecognised link type
-            return "<a>"
+    def unsupported_tag_type_rule(self, attrs):
+        return "<a>"
 
-        return rule(attrs)
+    def get_rule(self, tag_type):
+        if tag_type:
+            try:
+                return self.rules[tag_type]
+            except KeyError:
+                if tag_type not in ["email", "external", "anchor"]:
+                    return self.unsupported_tag_type_rule
 
-    def __call__(self, html):
-        return FIND_A_TAG.sub(self.replace_tag, html)
-
-    def extract_references(self, html):
-        for match in FIND_A_TAG.findall(html):
-            attrs = extract_attrs(match)
-            if (
-                "linktype" not in attrs
-                or attrs["linktype"] not in self.reference_extractors
-            ):
-                continue
-
-            yield from self.reference_extractors[attrs["linktype"]](attrs)
-
-        return []
+        # We want to leave links untouched if they either provide no linktype
+        # or if the linktypes they provide don't have a registered rule.
+        return None
 
 
 class MultiRuleRewriter:

--- a/wagtail/test/testapp/fixtures/test.json
+++ b/wagtail/test/testapp/fixtures/test.json
@@ -879,6 +879,15 @@
     }
   },
   {
+    "pk": 2,
+    "model": "wagtaildocs.Document",
+    "fields": {
+      "title": "another test document",
+      "created_at": "2020-01-01T12:00:00.000Z",
+      "file": "documents/another_test.pdf"
+    }
+  },
+  {
     "pk": 1,
     "model": "wagtailcore.pageviewrestriction",
     "fields": {
@@ -913,6 +922,17 @@
       "width": 1000,
       "height": 1000,
       "created_at": "2014-01-01T12:00:00.000Z"
+    }
+  },
+  {
+    "pk": 2,
+    "model": "wagtailimages.image",
+    "fields": {
+      "title": "Another image",
+      "file": "original_images/another.jpg",
+      "width": 1000,
+      "height": 1000,
+      "created_at": "2020-01-01T12:00:00.000Z"
     }
   },
   {

--- a/wagtail/tests/test_rich_text.py
+++ b/wagtail/tests/test_rich_text.py
@@ -82,15 +82,33 @@ class TestExtractAttrs(TestCase):
 
 
 class TestExpandDbHtml(TestCase):
-    def test_expand_db_html_with_linktype(self):
-        html = '<a id="1" linktype="document">foo</a>'
-        result = expand_db_html(html)
-        self.assertEqual(result, "<a>foo</a>")
+    fixtures = ["test.json"]
 
     def test_expand_db_html_no_linktype(self):
         html = '<a id="1">foo</a>'
         result = expand_db_html(html)
         self.assertEqual(result, '<a id="1">foo</a>')
+
+    def test_invalid_linktype_set_to_empty_link(self):
+        html = '<a id="1" linktype="invalid">foo</a>'
+        result = expand_db_html(html)
+        self.assertEqual(result, "<a>foo</a>")
+
+    def test_valid_linktype_and_reference(self):
+        html = '<a id="1" linktype="document">foo</a>'
+        result = expand_db_html(html)
+        self.assertEqual(result, '<a href="/documents/1/test.pdf">foo</a>')
+
+    def test_valid_linktype_invalid_reference_set_to_empty_link(self):
+        html = '<a id="9999" linktype="document">foo</a>'
+        result = expand_db_html(html)
+        self.assertEqual(result, "<a>foo</a>")
+
+    def test_no_embedtype_remove_tag(self):
+        self.assertEqual(expand_db_html('<embed id="1" />'), "")
+
+    def test_invalid_embedtype_remove_tag(self):
+        self.assertEqual(expand_db_html('<embed id="1" embedtype="invalid" />'), "")
 
     @patch("wagtail.embeds.embeds.get_embed")
     def test_expand_db_html_with_embed(self, get_embed):

--- a/wagtail/tests/test_rich_text.py
+++ b/wagtail/tests/test_rich_text.py
@@ -5,7 +5,7 @@ from django.test import TestCase, override_settings
 from django.utils import translation
 
 from wagtail.fields import RichTextField
-from wagtail.models import Locale, Page
+from wagtail.models import Locale, Page, Site
 from wagtail.rich_text import RichText, RichTextMaxLengthValidator, expand_db_html
 from wagtail.rich_text.feature_registry import FeatureRegistry
 from wagtail.rich_text.pages import PageLinkHandler
@@ -118,6 +118,78 @@ class TestExpandDbHtml(TestCase):
         html = '<embed embedtype="media" url="http://www.youtube.com/watch" />'
         result = expand_db_html(html)
         self.assertIn("test html", result)
+
+    # Override CACHES so we don't generate any cache-related SQL queries
+    # for page site root paths (tests use DatabaseCache otherwise).
+    @override_settings(
+        CACHES={
+            "default": {
+                "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            },
+        }
+    )
+    def test_expand_db_html_database_queries_pages(self):
+        Site.clear_site_root_paths_cache()
+
+        with self.assertNumQueries(5):
+            expand_db_html(
+                """
+This rich text has 8 page links, and this test verifies that the code uses the
+minimal number of database queries (5) to expand them.
+
+All of these pages should be retrieved with 4 queries, one to do the base
+Page table lookup and then 1 each for the EventIndex, EventPage, and
+SimplePage tables.
+
+<a linktype="page" id="3">This links to an EventIndex page.</a>
+<a linktype="page" id="4">This links to an EventPage page.</a>
+<a linktype="page" id="5">This links to an EventPage page.</a>
+<a linktype="page" id="6">This links to an EventPage page.</a>
+<a linktype="page" id="9">This links to an EventPage page.</a>
+<a linktype="page" id="12">This links to an EventPage page.</a>
+<a linktype="page" id="7">This links to a SimplePage page.</a>
+<a linktype="page" id="11">This links to a SimplePage page.</a>
+
+Finally there's one additional query needed to do the Site root paths lookup.
+        """
+            )
+
+    def test_expand_db_html_database_queries_documents(self):
+        with self.assertNumQueries(1):
+            expand_db_html(
+                html="""
+This rich text has 2 document links, and this test verifies that the code uses
+the minimal number of database queries (1) to expand them.
+
+Both of these documents should be retrieved with 1 query:
+
+<a linktype="document" id="1">This links to a document.</a>
+<a linktype="document" id="2">This links to another document.</a>
+"""
+            )
+
+    # Disable rendition cache that might be populated by other tests.
+    @override_settings(
+        CACHES={
+            "renditions": {
+                "BACKEND": "django.core.cache.backends.dummy.DummyCache",
+            },
+        }
+    )
+    def test_expand_db_html_database_queries_images(self):
+        with self.assertNumQueries(3):
+            expand_db_html(
+                """
+This rich text has 2 image links, and this test verifies that the code uses the
+minimal number of database queries (3) to expand them.
+
+Both of these images should be retrieved with 3 queries, one to fetch the
+image objects in bulk and then one per image to fetch their renditions:
+
+This is an image: <embed embedtype="image" id="1" format="left" />
+This is another image: <embed embedtype="image" id="2" format="left" />
+        """
+            )
 
 
 class TestRichTextValue(TestCase):


### PR DESCRIPTION
Rich text rewrite handlers currently work on each link/embed tag independently: first the type of tag is determined (for example, a page link), then the related model instance is retrieved from the database, and then the instance is used to generate the HTML representation. This creates some inefficiency: for example, a rich text field with 10 page links requires 20 database queries (one each for the base page model and one each for the specific page model).

This PR modifies the rich text rewrite logic so that it instead groups and processes all link/embed tags of the same type at once. This allows us to optimize the database lookups by making significantly fewer queries, for example retrieving all images and documents in a single call and retrieving all pages in the minimal number of calls by leveraging `PageQuerySet.specific()`. For the example above, a rich text field with 10 page links of the same page type would now require only 2 database queries.

To accomplish this I expanded the definition of the `EntityHandler` class to add two new methods, `get_many` and `expand_db_attributes_many`. These changes should be backwards compatible with any custom rich text rewrite handlers that are out there. The main interface change is that the (undocumented) `EntityRewriter` class now supports the notion of both individual and bulk rewrite functions -- I played around with a few approaches for this and this seemed the best way to support the dual functionality for both the frontend and editor rich text representations.