### PR TITLE
Fix image resizing failing on slim images

### DIFF
--- a/wagtail/images/image_operations.py
+++ b/wagtail/images/image_operations.py
@@ -182,6 +182,10 @@ class MinMaxOperation(Operation):
             # Unknown method
             return
 
+        # prevent zero width or height, it causes a ValueError on willow.resize
+        width = width if width > 0 else 1
+        height = height if height > 0 else 1
+
         return willow.resize((width, height))
 
 
@@ -214,6 +218,10 @@ class WidthHeightOperation(Operation):
             # Unknown method
             return
 
+        # prevent zero width or height, it causes a ValueError on willow.resize
+        width = width if width > 0 else 1
+        height = height if height > 0 else 1
+
         return willow.resize((width, height))
 
 
@@ -227,6 +235,10 @@ class ScaleOperation(Operation):
         scale = self.percent / 100
         width = int(image_width * scale)
         height = int(image_height * scale)
+
+        # prevent zero width or height, it causes a ValueError on willow.resize
+        width = width if width > 0 else 1
+        height = height if height > 0 else 1
 
         return willow.resize((width, height))
 

--- a/wagtail/images/tests/test_image_operations.py
+++ b/wagtail/images/tests/test_image_operations.py
@@ -361,6 +361,14 @@ class TestMinMaxOperation(ImageOperationTestCase):
         ('max-800x600', dict(width=1000, height=1000), [
             ('resize', ((600, 600), ), {}),
         ]),
+        # Resize doesn't try to set zero height
+        ('max-400x400', dict(width=1000, height=1), [
+            ('resize', ((400, 1), ), {}),
+        ]),
+        # Resize doesn't try to set zero width
+        ('max-400x400', dict(width=1, height=1000), [
+            ('resize', ((1, 400), ), {}),
+        ]),
     ]
 
 
@@ -390,6 +398,14 @@ class TestWidthHeightOperation(ImageOperationTestCase):
         # Basic usage of height
         ('height-400', dict(width=1000, height=500), [
             ('resize', ((800, 400), ), {}),
+        ]),
+        # Resize doesn't try to set zero height
+        ('width-400', dict(width=1000, height=1), [
+            ('resize', ((400, 1), ), {}),
+        ]),
+        # Resize doesn't try to set zero width
+        ('height-400', dict(width=1, height=800), [
+            ('resize', ((1, 400), ), {}),
         ]),
     ]
 
@@ -424,6 +440,14 @@ class TestScaleOperation(ImageOperationTestCase):
         # Rounded usage of scale
         ('scale-83.0322', dict(width=1000, height=500), [
             ('resize', ((int(1000 * 0.830322), int(500 * 0.830322)), ), {}),
+        ]),
+        # Resize doesn't try to set zero height
+        ('scale-50', dict(width=1000, height=1), [
+            ('resize', ((500, 1), ), {}),
+        ]),
+        # Resize doesn't try to set zero width
+        ('scale-50', dict(width=1, height=500), [
+            ('resize', ((1, 250), ), {}),
         ]),
     ]
 


### PR DESCRIPTION
Image operations sometimes calculate a target width or height of zero, which make Willow raise a `ValueError`. This is more likely to happen with very thin images in either height or width.

If an user uploads one such image it's possible to break the whole Wagtail image manager/picker/uploader for all users.

The fix is to use a minimum of 1 pixel for either the target height or the width. The image might lose some aspect ratio, but it's better than an exception.

Include regression tests.

Fixes #5878 .