### PR TITLE
Do not download entire search index on search terms with no hits

### DIFF
--- a/wagtail/search/backends/base.py
+++ b/wagtail/search/backends/base.py
@@ -220,8 +220,8 @@ class BaseSearchResults:
 
         if isinstance(key, slice):
             # Set limits
-            start = int(key.start) if key.start else None
-            stop = int(key.stop) if key.stop else None
+            start = int(key.start) if key.start is not None else None
+            stop = int(key.stop) if key.stop is not None else None
             new._set_limits(start, stop)
 
             # Copy results cache

--- a/wagtail/search/tests/test_page_search.py
+++ b/wagtail/search/tests/test_page_search.py
@@ -5,6 +5,7 @@ from django.test import TestCase
 
 from wagtail.core.models import Page
 from wagtail.search.backends import get_search_backend
+from wagtail.search.backends.base import BaseSearchQueryCompiler, BaseSearchResults
 
 
 class PageSearchTests:
@@ -47,3 +48,12 @@ class PageSearchTests:
 for backend_name in settings.WAGTAILSEARCH_BACKENDS.keys():
     test_name = str("Test%sBackend" % backend_name.title())
     globals()[test_name] = type(test_name, (PageSearchTests, TestCase,), {'backend_name': backend_name})
+
+
+class TestBaseSearchResults(TestCase):
+
+    def test_get_item_no_results(self):
+        base_search_results = BaseSearchResults("BackendIrrelevant", BaseSearchQueryCompiler)
+        obj = base_search_results[0:0]
+        self.assertEqual(obj.start, 0)
+        self.assertEqual(obj.stop, 0)


### PR DESCRIPTION
When a slice is specifically set to [0:0] - which would yield an empty list - instead wagtail will clear the slice, effectively downloading the entire search
index.

This scenario happens when a search term does not return any results.
So every time you enter a search term that has no results, the entire search
index is downloaded, you don't really feel it because wagtail only downloads
the pk values, and it is unlikely a site has millions of pages, but it is still
very inefficient and unwanted.