### PR TITLE
Order sites in site switcher by site_name

### DIFF
--- a/wagtail/contrib/settings/forms.py
+++ b/wagtail/contrib/settings/forms.py
@@ -18,7 +18,7 @@ class SiteSwitchForm(forms.Form):
         initial_data = {'site': self.get_change_url(current_site, model)}
         super().__init__(initial=initial_data, **kwargs)
         sites = [(self.get_change_url(site, model), site)
-                 for site in Site.objects.all()]
+                 for site in Site.objects.all().order_by("site_name")]
         self.fields['site'].choices = sites
 
     @classmethod


### PR DESCRIPTION
I've added this small change since managing a large set of sites can become quite difficult if these are not ordered.