### PR TITLE
Replace deprecated ugettext, ungettext with gettext and ngettext.

### DIFF
--- a/docs/advanced_topics/customisation/custom_user_models.rst
+++ b/docs/advanced_topics/customisation/custom_user_models.rst
@@ -29,7 +29,7 @@ Create your custom user 'create' and 'edit' forms in your app:
 .. code-block:: python
 
   from django import forms
-  from django.utils.translation import ugettext_lazy as _
+  from django.utils.translation import gettext_lazy as _
 
   from wagtail.users.forms import UserEditForm, UserCreationForm
 

--- a/docs/reference/hooks.rst
+++ b/docs/reference/hooks.rst
@@ -119,7 +119,7 @@ Hooks for building new areas of the admin interface (alongside pages, images, do
   A numeric count of items in this collection
 
 ``count_text``
-  A human-readable string describing the number of items in this collection, such as "3 documents". (Sites with multi-language support should return a translatable string here, most likely using the ``django.utils.translation.ungettext`` function.)
+  A human-readable string describing the number of items in this collection, such as "3 documents". (Sites with multi-language support should return a translatable string here, most likely using the ``django.utils.translation.ngettext`` function.)
 
 ``url`` (optional)
   A URL to an index page that lists the objects being described.

--- a/wagtail/admin/action_menu.py
+++ b/wagtail/admin/action_menu.py
@@ -5,7 +5,7 @@ from django.forms import Media, MediaDefiningClass
 from django.template.loader import render_to_string
 from django.urls import reverse
 from django.utils.functional import cached_property
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from wagtail.core import hooks
 from wagtail.core.models import UserPagePermissionsProxy

--- a/wagtail/admin/apps.py
+++ b/wagtail/admin/apps.py
@@ -1,5 +1,5 @@
 from django.apps import AppConfig
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from . import checks  # NOQA
 

--- a/wagtail/admin/auth.py
+++ b/wagtail/admin/auth.py
@@ -9,7 +9,7 @@ from django.db.models import Q
 from django.shortcuts import redirect
 from django.urls import reverse
 from django.utils.timezone import activate as activate_tz
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from django.utils.translation import override
 
 from wagtail.admin import messages

--- a/wagtail/admin/compare.py
+++ b/wagtail/admin/compare.py
@@ -5,7 +5,7 @@ from django.utils.encoding import force_str
 from django.utils.html import escape, format_html, format_html_join
 from django.utils.safestring import mark_safe
 from django.utils.text import capfirst
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from wagtail.core import blocks
 

--- a/wagtail/admin/edit_handlers.py
+++ b/wagtail/admin/edit_handlers.py
@@ -9,7 +9,7 @@ from django.forms.models import fields_for_model
 from django.template.loader import render_to_string
 from django.utils.functional import cached_property
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext_lazy
+from django.utils.translation import gettext_lazy
 from taggit.managers import TaggableManager
 
 from wagtail.admin import compare, widgets
@@ -759,7 +759,7 @@ class PublishingPanel(MultiFieldPanel):
                     FieldPanel('expire_at'),
                 ], classname="label-above"),
             ],
-            'heading': ugettext_lazy('Scheduled publishing'),
+            'heading': gettext_lazy('Scheduled publishing'),
             'classname': 'publishing',
         }
         updated_kwargs.update(kwargs)
@@ -777,7 +777,7 @@ Page.promote_panels = [
         FieldPanel('seo_title'),
         FieldPanel('show_in_menus'),
         FieldPanel('search_description'),
-    ], ugettext_lazy('Common page configuration')),
+    ], gettext_lazy('Common page configuration')),
 ]
 
 Page.settings_panels = [
@@ -801,13 +801,13 @@ def get_edit_handler(cls):
 
         if cls.content_panels:
             tabs.append(ObjectList(cls.content_panels,
-                                   heading=ugettext_lazy('Content')))
+                                   heading=gettext_lazy('Content')))
         if cls.promote_panels:
             tabs.append(ObjectList(cls.promote_panels,
-                                   heading=ugettext_lazy('Promote')))
+                                   heading=gettext_lazy('Promote')))
         if cls.settings_panels:
             tabs.append(ObjectList(cls.settings_panels,
-                                   heading=ugettext_lazy('Settings'),
+                                   heading=gettext_lazy('Settings'),
                                    classname='settings'))
 
         edit_handler = TabbedInterface(tabs, base_form_class=cls.base_form_class)

--- a/wagtail/admin/forms/auth.py
+++ b/wagtail/admin/forms/auth.py
@@ -1,6 +1,6 @@
 from django import forms
 from django.contrib.auth.forms import AuthenticationForm, PasswordResetForm
-from django.utils.translation import ugettext_lazy
+from django.utils.translation import gettext_lazy
 
 
 class LoginForm(AuthenticationForm):
@@ -9,13 +9,13 @@ class LoginForm(AuthenticationForm):
 
     password = forms.CharField(
         widget=forms.PasswordInput(attrs={
-            'placeholder': ugettext_lazy("Enter password"),
+            'placeholder': gettext_lazy("Enter password"),
         }))
 
     def __init__(self, request=None, *args, **kwargs):
         super().__init__(request=request, *args, **kwargs)
         self.fields['username'].widget.attrs['placeholder'] = (
-            ugettext_lazy("Enter your %s") % self.username_field.verbose_name)
+            gettext_lazy("Enter your %s") % self.username_field.verbose_name)
 
     @property
     def extra_fields(self):
@@ -26,5 +26,5 @@ class LoginForm(AuthenticationForm):
 
 class PasswordResetForm(PasswordResetForm):
     email = forms.EmailField(
-        label=ugettext_lazy("Enter your email address to reset your password"),
+        label=gettext_lazy("Enter your email address to reset your password"),
         max_length=254, required=True)

--- a/wagtail/admin/forms/choosers.py
+++ b/wagtail/admin/forms/choosers.py
@@ -1,7 +1,7 @@
 from django import forms
 from django.core import validators
 from django.forms.widgets import TextInput
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class URLOrAbsolutePathValidator(validators.URLValidator):

--- a/wagtail/admin/forms/collections.py
+++ b/wagtail/admin/forms/collections.py
@@ -4,7 +4,7 @@ from django import forms
 from django.contrib.auth.models import Group, Permission
 from django.db import transaction
 from django.template.loader import render_to_string
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from wagtail.core.models import Collection, CollectionViewRestriction, GroupCollectionPermission
 

--- a/wagtail/admin/forms/pages.py
+++ b/wagtail/admin/forms/pages.py
@@ -1,7 +1,7 @@
 from django import forms
 from django.utils import timezone
-from django.utils.translation import ugettext as _
-from django.utils.translation import ungettext
+from django.utils.translation import gettext as _
+from django.utils.translation import ngettext
 
 from wagtail.admin import widgets
 from wagtail.core.models import Page, PageViewRestriction
@@ -31,7 +31,7 @@ class CopyForm(forms.Form):
         if subpage_count > 0:
             self.fields['copy_subpages'] = forms.BooleanField(
                 required=False, initial=True, label=_("Copy subpages"),
-                help_text=ungettext(
+                help_text=ngettext(
                     "This will copy %(count)s subpage.",
                     "This will copy %(count)s subpages.",
                     subpage_count) % {'count': subpage_count})
@@ -45,7 +45,7 @@ class CopyForm(forms.Form):
                     help_text = _("This page is live. Would you like to publish its copy as well?")
                 else:
                     label = _("Publish copies")
-                    help_text = ungettext(
+                    help_text = ngettext(
                         "%(count)s of the pages being copied is live. Would you like to publish its copy?",
                         "%(count)s of the pages being copied are live. Would you like to publish their copies?",
                         pages_to_publish_count) % {'count': pages_to_publish_count}

--- a/wagtail/admin/forms/search.py
+++ b/wagtail/admin/forms/search.py
@@ -1,6 +1,6 @@
 from django import forms
-from django.utils.translation import ugettext as _
-from django.utils.translation import ugettext_lazy
+from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy
 
 
 class SearchForm(forms.Form):
@@ -9,4 +9,4 @@ class SearchForm(forms.Form):
         super().__init__(*args, **kwargs)
         self.fields['q'].widget.attrs = {'placeholder': placeholder}
 
-    q = forms.CharField(label=ugettext_lazy("Search term"), widget=forms.TextInput())
+    q = forms.CharField(label=gettext_lazy("Search term"), widget=forms.TextInput())

--- a/wagtail/admin/forms/view_restrictions.py
+++ b/wagtail/admin/forms/view_restrictions.py
@@ -1,14 +1,14 @@
 from django import forms
 from django.contrib.auth.models import Group
-from django.utils.translation import ugettext as _
-from django.utils.translation import ugettext_lazy
+from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy
 
 from wagtail.core.models import BaseViewRestriction
 
 
 class BaseViewRestrictionForm(forms.ModelForm):
     restriction_type = forms.ChoiceField(
-        label=ugettext_lazy("Visibility"), choices=BaseViewRestriction.RESTRICTION_CHOICES,
+        label=gettext_lazy("Visibility"), choices=BaseViewRestriction.RESTRICTION_CHOICES,
         widget=forms.RadioSelect)
 
     def __init__(self, *args, **kwargs):

--- a/wagtail/admin/localization.py
+++ b/wagtail/admin/localization.py
@@ -1,47 +1,47 @@
 import pytz
 
 from django.conf import settings
-from django.utils.translation import ugettext as _
-from django.utils.translation import ugettext_lazy
+from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy
 
 
 # Wagtail languages with >=90% coverage
 # This list is manually maintained
 WAGTAILADMIN_PROVIDED_LANGUAGES = [
-    ('ar', ugettext_lazy('Arabic')),
-    ('ca', ugettext_lazy('Catalan')),
-    ('cs', ugettext_lazy('Czech')),
-    ('de', ugettext_lazy('German')),
-    ('el', ugettext_lazy('Greek')),
-    ('en', ugettext_lazy('English')),
-    ('es', ugettext_lazy('Spanish')),
-    ('fi', ugettext_lazy('Finnish')),
-    ('fr', ugettext_lazy('French')),
-    ('gl', ugettext_lazy('Galician')),
-    ('hu', ugettext_lazy('Hungarian')),
-    ('id-id', ugettext_lazy('Indonesian')),
-    ('is-is', ugettext_lazy('Icelandic')),
-    ('it', ugettext_lazy('Italian')),
-    ('jp', ugettext_lazy('Japanese')),
-    ('ko', ugettext_lazy('Korean')),
-    ('lt', ugettext_lazy('Lithuanian')),
-    ('mn', ugettext_lazy('Mongolian')),
-    ('nb', ugettext_lazy('Norwegian Bokmål')),
-    ('nl-nl', ugettext_lazy('Netherlands Dutch')),
-    ('fa', ugettext_lazy('Persian')),
-    ('pl', ugettext_lazy('Polish')),
-    ('pt-br', ugettext_lazy('Brazilian Portuguese')),
-    ('pt-pt', ugettext_lazy('Portuguese')),
-    ('ro', ugettext_lazy('Romanian')),
-    ('ru', ugettext_lazy('Russian')),
-    ('sv', ugettext_lazy('Swedish')),
-    ('sk-sk', ugettext_lazy('Slovak')),
-    ('th', ugettext_lazy('Thai')),
-    ('tr', ugettext_lazy('Turkish')),
-    ('tr-tr', ugettext_lazy('Turkish (Turkey)')),
-    ('uk', ugettext_lazy('Ukrainian')),
-    ('zh-hans', ugettext_lazy('Chinese (Simplified)')),
-    ('zh-hant', ugettext_lazy('Chinese (Traditional)')),
+    ('ar', gettext_lazy('Arabic')),
+    ('ca', gettext_lazy('Catalan')),
+    ('cs', gettext_lazy('Czech')),
+    ('de', gettext_lazy('German')),
+    ('el', gettext_lazy('Greek')),
+    ('en', gettext_lazy('English')),
+    ('es', gettext_lazy('Spanish')),
+    ('fi', gettext_lazy('Finnish')),
+    ('fr', gettext_lazy('French')),
+    ('gl', gettext_lazy('Galician')),
+    ('hu', gettext_lazy('Hungarian')),
+    ('id-id', gettext_lazy('Indonesian')),
+    ('is-is', gettext_lazy('Icelandic')),
+    ('it', gettext_lazy('Italian')),
+    ('jp', gettext_lazy('Japanese')),
+    ('ko', gettext_lazy('Korean')),
+    ('lt', gettext_lazy('Lithuanian')),
+    ('mn', gettext_lazy('Mongolian')),
+    ('nb', gettext_lazy('Norwegian Bokmål')),
+    ('nl-nl', gettext_lazy('Netherlands Dutch')),
+    ('fa', gettext_lazy('Persian')),
+    ('pl', gettext_lazy('Polish')),
+    ('pt-br', gettext_lazy('Brazilian Portuguese')),
+    ('pt-pt', gettext_lazy('Portuguese')),
+    ('ro', gettext_lazy('Romanian')),
+    ('ru', gettext_lazy('Russian')),
+    ('sv', gettext_lazy('Swedish')),
+    ('sk-sk', gettext_lazy('Slovak')),
+    ('th', gettext_lazy('Thai')),
+    ('tr', gettext_lazy('Turkish')),
+    ('tr-tr', gettext_lazy('Turkish (Turkey)')),
+    ('uk', gettext_lazy('Ukrainian')),
+    ('zh-hans', gettext_lazy('Chinese (Simplified)')),
+    ('zh-hant', gettext_lazy('Chinese (Traditional)')),
 ]
 
 

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -13,7 +13,7 @@ from django.template.loader import render_to_string
 from django.templatetags.static import static
 from django.utils.html import format_html, format_html_join
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from wagtail.admin.localization import get_js_translation_strings
 from wagtail.admin.menu import admin_menu

--- a/wagtail/admin/tests/tests.py
+++ b/wagtail/admin/tests/tests.py
@@ -7,7 +7,7 @@ from django.contrib.auth.models import Group, Permission
 from django.core import mail
 from django.test import TestCase, override_settings
 from django.urls import reverse, reverse_lazy
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from taggit.models import Tag
 
 from wagtail.admin.auth import user_has_any_page_permission

--- a/wagtail/admin/views/account.py
+++ b/wagtail/admin/views/account.py
@@ -6,7 +6,7 @@ from django.contrib.auth.forms import PasswordChangeForm
 from django.http import Http404
 from django.shortcuts import redirect, render
 from django.urls import reverse, reverse_lazy
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from django.utils.translation import override
 from django.views.decorators.debug import sensitive_post_parameters
 

--- a/wagtail/admin/views/collections.py
+++ b/wagtail/admin/views/collections.py
@@ -1,6 +1,6 @@
 from django.http import HttpResponseForbidden
 from django.shortcuts import get_object_or_404, redirect
-from django.utils.translation import ugettext_lazy
+from django.utils.translation import gettext_lazy
 
 from wagtail.admin import messages
 from wagtail.admin.forms.collections import CollectionForm
@@ -16,8 +16,8 @@ class Index(IndexView):
     context_object_name = 'collections'
     template_name = 'wagtailadmin/collections/index.html'
     add_url_name = 'wagtailadmin_collections:add'
-    page_title = ugettext_lazy("Collections")
-    add_item_label = ugettext_lazy("Add a collection")
+    page_title = gettext_lazy("Collections")
+    add_item_label = gettext_lazy("Add a collection")
     header_icon = 'folder-open-1'
 
     def get_queryset(self):
@@ -28,8 +28,8 @@ class Index(IndexView):
 class Create(CreateView):
     permission_policy = collection_permission_policy
     form_class = CollectionForm
-    page_title = ugettext_lazy("Add collection")
-    success_message = ugettext_lazy("Collection '{0}' created.")
+    page_title = gettext_lazy("Add collection")
+    success_message = gettext_lazy("Collection '{0}' created.")
     add_url_name = 'wagtailadmin_collections:add'
     edit_url_name = 'wagtailadmin_collections:edit'
     index_url_name = 'wagtailadmin_collections:index'
@@ -48,9 +48,9 @@ class Edit(EditView):
     model = Collection
     form_class = CollectionForm
     template_name = 'wagtailadmin/collections/edit.html'
-    success_message = ugettext_lazy("Collection '{0}' updated.")
-    error_message = ugettext_lazy("The collection could not be saved due to errors.")
-    delete_item_label = ugettext_lazy("Delete collection")
+    success_message = gettext_lazy("Collection '{0}' updated.")
+    error_message = gettext_lazy("The collection could not be saved due to errors.")
+    delete_item_label = gettext_lazy("Delete collection")
     edit_url_name = 'wagtailadmin_collections:edit'
     index_url_name = 'wagtailadmin_collections:index'
     delete_url_name = 'wagtailadmin_collections:delete'
@@ -65,11 +65,11 @@ class Edit(EditView):
 class Delete(DeleteView):
     permission_policy = collection_permission_policy
     model = Collection
-    success_message = ugettext_lazy("Collection '{0}' deleted.")
+    success_message = gettext_lazy("Collection '{0}' deleted.")
     index_url_name = 'wagtailadmin_collections:index'
     delete_url_name = 'wagtailadmin_collections:delete'
-    page_title = ugettext_lazy("Delete collection")
-    confirmation_message = ugettext_lazy("Are you sure you want to delete this collection?")
+    page_title = gettext_lazy("Delete collection")
+    confirmation_message = gettext_lazy("Are you sure you want to delete this collection?")
     header_icon = 'folder-open-1'
 
     def get_queryset(self):

--- a/wagtail/admin/views/generic.py
+++ b/wagtail/admin/views/generic.py
@@ -1,7 +1,7 @@
 from django.shortcuts import redirect
 from django.urls import reverse
-from django.utils.translation import ugettext as _
-from django.utils.translation import ugettext_lazy
+from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy
 from django.views.generic.base import TemplateResponseMixin
 from django.views.generic.edit import BaseCreateView, BaseDeleteView, BaseUpdateView
 from django.views.generic.list import BaseListView
@@ -123,11 +123,11 @@ class EditView(PermissionCheckedMixin, TemplateResponseMixin, BaseUpdateView):
     index_url_name = None
     edit_url_name = None
     delete_url_name = None
-    page_title = ugettext_lazy("Editing")
+    page_title = gettext_lazy("Editing")
     context_object_name = None
     template_name = 'wagtailadmin/generic/edit.html'
     permission_required = 'change'
-    delete_item_label = ugettext_lazy("Delete")
+    delete_item_label = gettext_lazy("Delete")
     success_message = None
     error_message = None
 

--- a/wagtail/admin/views/mixins.py
+++ b/wagtail/admin/views/mixins.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from wagtail.admin.forms.search import SearchForm
 from wagtail.search.backends import get_search_backend

--- a/wagtail/admin/views/pages.py
+++ b/wagtail/admin/views/pages.py
@@ -14,7 +14,7 @@ from django.utils import timezone
 from django.utils.html import format_html
 from django.utils.http import is_safe_url, urlquote
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from django.views.decorators.http import require_GET, require_POST
 from django.views.decorators.vary import vary_on_headers
 from django.views.generic import View

--- a/wagtail/admin/views/reports.py
+++ b/wagtail/admin/views/reports.py
@@ -5,7 +5,7 @@ from collections import OrderedDict
 from django.core.exceptions import FieldDoesNotExist
 from django.http import HttpResponse, StreamingHttpResponse
 from django.utils.encoding import force_str
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.views.generic.base import TemplateResponseMixin
 from django.views.generic.list import BaseListView
 from xlsxwriter.workbook import Workbook

--- a/wagtail/admin/wagtail_hooks.py
+++ b/wagtail/admin/wagtail_hooks.py
@@ -1,7 +1,7 @@
 from django.contrib.auth.models import Permission
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
-from django.utils.translation import ugettext
+from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext
 from draftjs_exporter.dom import DOM
 
 import wagtail.admin.rich_text.editors.draftail.features as draftail_features
@@ -361,7 +361,7 @@ def register_core_features(features):
         'draftail', 'h1', draftail_features.BlockFeature({
             'label': 'H1',
             'type': 'header-one',
-            'description': ugettext('Heading %(level)d') % {'level': 1},
+            'description': gettext('Heading %(level)d') % {'level': 1},
         })
     )
     features.register_converter_rule('contentstate', 'h1', {
@@ -376,7 +376,7 @@ def register_core_features(features):
         'draftail', 'h2', draftail_features.BlockFeature({
             'label': 'H2',
             'type': 'header-two',
-            'description': ugettext('Heading %(level)d') % {'level': 2},
+            'description': gettext('Heading %(level)d') % {'level': 2},
         })
     )
     features.register_converter_rule('contentstate', 'h2', {
@@ -391,7 +391,7 @@ def register_core_features(features):
         'draftail', 'h3', draftail_features.BlockFeature({
             'label': 'H3',
             'type': 'header-three',
-            'description': ugettext('Heading %(level)d') % {'level': 3},
+            'description': gettext('Heading %(level)d') % {'level': 3},
         })
     )
     features.register_converter_rule('contentstate', 'h3', {
@@ -406,7 +406,7 @@ def register_core_features(features):
         'draftail', 'h4', draftail_features.BlockFeature({
             'label': 'H4',
             'type': 'header-four',
-            'description': ugettext('Heading %(level)d') % {'level': 4},
+            'description': gettext('Heading %(level)d') % {'level': 4},
         })
     )
     features.register_converter_rule('contentstate', 'h4', {
@@ -421,7 +421,7 @@ def register_core_features(features):
         'draftail', 'h5', draftail_features.BlockFeature({
             'label': 'H5',
             'type': 'header-five',
-            'description': ugettext('Heading %(level)d') % {'level': 5},
+            'description': gettext('Heading %(level)d') % {'level': 5},
         })
     )
     features.register_converter_rule('contentstate', 'h5', {
@@ -436,7 +436,7 @@ def register_core_features(features):
         'draftail', 'h6', draftail_features.BlockFeature({
             'label': 'H6',
             'type': 'header-six',
-            'description': ugettext('Heading %(level)d') % {'level': 6},
+            'description': gettext('Heading %(level)d') % {'level': 6},
         })
     )
     features.register_converter_rule('contentstate', 'h6', {
@@ -451,7 +451,7 @@ def register_core_features(features):
         'draftail', 'ul', draftail_features.BlockFeature({
             'type': 'unordered-list-item',
             'icon': 'list-ul',
-            'description': ugettext('Bulleted list'),
+            'description': gettext('Bulleted list'),
         })
     )
     features.register_converter_rule('contentstate', 'ul', {
@@ -467,7 +467,7 @@ def register_core_features(features):
         'draftail', 'ol', draftail_features.BlockFeature({
             'type': 'ordered-list-item',
             'icon': 'list-ol',
-            'description': ugettext('Numbered list'),
+            'description': gettext('Numbered list'),
         })
     )
     features.register_converter_rule('contentstate', 'ol', {
@@ -483,7 +483,7 @@ def register_core_features(features):
         'draftail', 'blockquote', draftail_features.BlockFeature({
             'type': 'blockquote',
             'icon': 'openquote',
-            'description': ugettext('Blockquote'),
+            'description': gettext('Blockquote'),
         })
     )
     features.register_converter_rule('contentstate', 'blockquote', {
@@ -499,7 +499,7 @@ def register_core_features(features):
         'draftail', 'bold', draftail_features.InlineStyleFeature({
             'type': 'BOLD',
             'icon': 'bold',
-            'description': ugettext('Bold'),
+            'description': gettext('Bold'),
         })
     )
     features.register_converter_rule('contentstate', 'bold', {
@@ -515,7 +515,7 @@ def register_core_features(features):
         'draftail', 'italic', draftail_features.InlineStyleFeature({
             'type': 'ITALIC',
             'icon': 'italic',
-            'description': ugettext('Italic'),
+            'description': gettext('Italic'),
         })
     )
     features.register_converter_rule('contentstate', 'italic', {
@@ -532,7 +532,7 @@ def register_core_features(features):
         'draftail', 'link', draftail_features.EntityFeature({
             'type': 'LINK',
             'icon': 'link',
-            'description': ugettext('Link'),
+            'description': gettext('Link'),
             # We want to enforce constraints on which links can be pasted into rich text.
             # Keep only the attributes Wagtail needs.
             'attributes': ['url', 'id', 'parentId'],
@@ -557,7 +557,7 @@ def register_core_features(features):
         'draftail', 'superscript', draftail_features.InlineStyleFeature({
             'type': 'SUPERSCRIPT',
             'icon': 'superscript',
-            'description': ugettext('Superscript'),
+            'description': gettext('Superscript'),
         })
     )
     features.register_converter_rule('contentstate', 'superscript', {
@@ -572,7 +572,7 @@ def register_core_features(features):
         'draftail', 'subscript', draftail_features.InlineStyleFeature({
             'type': 'SUBSCRIPT',
             'icon': 'subscript',
-            'description': ugettext('Subscript'),
+            'description': gettext('Subscript'),
         })
     )
     features.register_converter_rule('contentstate', 'subscript', {
@@ -587,7 +587,7 @@ def register_core_features(features):
         'draftail', 'strikethrough', draftail_features.InlineStyleFeature({
             'type': 'STRIKETHROUGH',
             'icon': 'strikethrough',
-            'description': ugettext('Strikethrough'),
+            'description': gettext('Strikethrough'),
         })
     )
     features.register_converter_rule('contentstate', 'strikethrough', {
@@ -602,7 +602,7 @@ def register_core_features(features):
         'draftail', 'code', draftail_features.InlineStyleFeature({
             'type': 'CODE',
             'icon': 'code',
-            'description': ugettext('Code'),
+            'description': gettext('Code'),
         })
     )
     features.register_converter_rule('contentstate', 'code', {

--- a/wagtail/admin/widgets.py
+++ b/wagtail/admin/widgets.py
@@ -11,7 +11,7 @@ from django.urls import reverse
 from django.utils.formats import get_format
 from django.utils.functional import cached_property
 from django.utils.html import format_html
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from taggit.forms import TagWidget
 from taggit.models import Tag
 

--- a/wagtail/api/v2/apps.py
+++ b/wagtail/api/v2/apps.py
@@ -1,7 +1,7 @@
 from django.apps import AppConfig, apps
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class WagtailAPIV2AppConfig(AppConfig):

--- a/wagtail/contrib/forms/apps.py
+++ b/wagtail/contrib/forms/apps.py
@@ -1,5 +1,5 @@
 from django.apps import AppConfig
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class WagtailFormsAppConfig(AppConfig):

--- a/wagtail/contrib/forms/edit_handlers.py
+++ b/wagtail/contrib/forms/edit_handlers.py
@@ -1,6 +1,6 @@
 from django.template.loader import render_to_string
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from wagtail.admin.edit_handlers import EditHandler
 

--- a/wagtail/contrib/forms/forms.py
+++ b/wagtail/contrib/forms/forms.py
@@ -1,7 +1,7 @@
 from collections import OrderedDict
 
 import django.forms
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from wagtail.admin.forms import WagtailAdminPageForm
 

--- a/wagtail/contrib/forms/models.py
+++ b/wagtail/contrib/forms/models.py
@@ -5,7 +5,7 @@ from django.core.serializers.json import DjangoJSONEncoder
 from django.db import models
 from django.shortcuts import render
 from django.utils.text import slugify
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from unidecode import unidecode
 
 from wagtail.admin.edit_handlers import FieldPanel

--- a/wagtail/contrib/forms/views.py
+++ b/wagtail/contrib/forms/views.py
@@ -5,7 +5,7 @@ from collections import OrderedDict
 from django.core.exceptions import PermissionDenied
 from django.core.paginator import InvalidPage
 from django.shortcuts import get_object_or_404, redirect
-from django.utils.translation import ungettext
+from django.utils.translation import ngettext
 from django.views.generic import ListView, TemplateView
 
 from wagtail.admin import messages
@@ -91,7 +91,7 @@ class DeleteSubmissionsView(TemplateView):
         submissions.delete()
         messages.success(
             self.request,
-            ungettext(
+            ngettext(
                 'One submission has been deleted.',
                 '%(count)d submissions have been deleted.',
                 count

--- a/wagtail/contrib/forms/wagtail_hooks.py
+++ b/wagtail/contrib/forms/wagtail_hooks.py
@@ -1,6 +1,6 @@
 from django.conf.urls import include, url
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from wagtail.admin.menu import MenuItem
 from wagtail.contrib.forms import urls

--- a/wagtail/contrib/frontend_cache/apps.py
+++ b/wagtail/contrib/frontend_cache/apps.py
@@ -1,5 +1,5 @@
 from django.apps import AppConfig
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from wagtail.contrib.frontend_cache.signal_handlers import register_signal_handlers
 

--- a/wagtail/contrib/modeladmin/apps.py
+++ b/wagtail/contrib/modeladmin/apps.py
@@ -1,5 +1,5 @@
 from django.apps import AppConfig
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class WagtailModelAdminAppConfig(AppConfig):

--- a/wagtail/contrib/modeladmin/forms.py
+++ b/wagtail/contrib/modeladmin/forms.py
@@ -1,6 +1,6 @@
 from django import forms
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from wagtail.core.models import Page
 

--- a/wagtail/contrib/modeladmin/helpers/button.py
+++ b/wagtail/contrib/modeladmin/helpers/button.py
@@ -1,6 +1,6 @@
 from django.contrib.admin.utils import quote
 from django.utils.encoding import force_str
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 
 class ButtonHelper:

--- a/wagtail/contrib/modeladmin/mixins.py
+++ b/wagtail/contrib/modeladmin/mixins.py
@@ -2,7 +2,7 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.forms.utils import flatatt
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class ThumbnailMixin:

--- a/wagtail/contrib/modeladmin/templatetags/modeladmin_tags.py
+++ b/wagtail/contrib/modeladmin/templatetags/modeladmin_tags.py
@@ -10,7 +10,7 @@ from django.template.loader import get_template
 from django.utils.encoding import force_str
 from django.utils.html import format_html
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 register = Library()
 

--- a/wagtail/contrib/modeladmin/views.py
+++ b/wagtail/contrib/modeladmin/views.py
@@ -19,7 +19,7 @@ from django.utils.functional import cached_property
 from django.utils.http import urlencode
 from django.utils.safestring import mark_safe
 from django.utils.text import capfirst
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from django.views.generic import TemplateView
 from django.views.generic.edit import FormView
 

--- a/wagtail/contrib/postgres_search/models.py
+++ b/wagtail/contrib/postgres_search/models.py
@@ -5,7 +5,7 @@ from django.contrib.postgres.indexes import GinIndex
 from django.contrib.postgres.search import SearchQuery, SearchVectorField
 from django.db.models import CASCADE, ForeignKey, Model, TextField
 from django.db.models.functions import Cast
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from wagtail.search.index import class_is_indexed
 

--- a/wagtail/contrib/redirects/apps.py
+++ b/wagtail/contrib/redirects/apps.py
@@ -1,5 +1,5 @@
 from django.apps import AppConfig
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class WagtailRedirectsAppConfig(AppConfig):

--- a/wagtail/contrib/redirects/forms.py
+++ b/wagtail/contrib/redirects/forms.py
@@ -1,5 +1,5 @@
 from django import forms
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from wagtail.admin.widgets import AdminPageChooser
 from wagtail.contrib.redirects.models import Redirect

--- a/wagtail/contrib/redirects/models.py
+++ b/wagtail/contrib/redirects/models.py
@@ -1,7 +1,7 @@
 from urllib.parse import urlparse
 
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class Redirect(models.Model):

--- a/wagtail/contrib/redirects/views.py
+++ b/wagtail/contrib/redirects/views.py
@@ -2,7 +2,7 @@ from django.core.paginator import Paginator
 from django.db.models import Q
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from django.views.decorators.vary import vary_on_headers
 
 from wagtail.admin import messages

--- a/wagtail/contrib/redirects/wagtail_hooks.py
+++ b/wagtail/contrib/redirects/wagtail_hooks.py
@@ -1,7 +1,7 @@
 from django.conf.urls import include, url
 from django.contrib.auth.models import Permission
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from wagtail.admin.menu import MenuItem
 from wagtail.contrib.redirects import urls

--- a/wagtail/contrib/routable_page/apps.py
+++ b/wagtail/contrib/routable_page/apps.py
@@ -1,5 +1,5 @@
 from django.apps import AppConfig
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class WagtailRoutablePageAppConfig(AppConfig):

--- a/wagtail/contrib/search_promotions/apps.py
+++ b/wagtail/contrib/search_promotions/apps.py
@@ -1,5 +1,5 @@
 from django.apps import AppConfig
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class WagtailSearchPromotionsAppConfig(AppConfig):

--- a/wagtail/contrib/search_promotions/forms.py
+++ b/wagtail/contrib/search_promotions/forms.py
@@ -1,6 +1,6 @@
 from django import forms
 from django.forms.models import inlineformset_factory
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from wagtail.admin.widgets import AdminPageChooser
 from wagtail.contrib.search_promotions.models import SearchPromotion

--- a/wagtail/contrib/search_promotions/models.py
+++ b/wagtail/contrib/search_promotions/models.py
@@ -1,5 +1,5 @@
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from wagtail.search.models import Query
 

--- a/wagtail/contrib/search_promotions/views.py
+++ b/wagtail/contrib/search_promotions/views.py
@@ -1,7 +1,7 @@
 from django.core.paginator import Paginator
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from django.views.decorators.vary import vary_on_headers
 
 from wagtail.admin import messages

--- a/wagtail/contrib/search_promotions/wagtail_hooks.py
+++ b/wagtail/contrib/search_promotions/wagtail_hooks.py
@@ -1,7 +1,7 @@
 from django.conf.urls import include, url
 from django.contrib.auth.models import Permission
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from wagtail.admin.menu import MenuItem
 from wagtail.contrib.search_promotions import admin_urls

--- a/wagtail/contrib/settings/views.py
+++ b/wagtail/contrib/settings/views.py
@@ -4,7 +4,7 @@ from django.core.exceptions import PermissionDenied
 from django.http import Http404
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils.text import capfirst
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from wagtail.admin import messages
 from wagtail.admin.edit_handlers import (

--- a/wagtail/contrib/sitemaps/apps.py
+++ b/wagtail/contrib/sitemaps/apps.py
@@ -1,5 +1,5 @@
 from django.apps import AppConfig
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class WagtailSitemapsAppConfig(AppConfig):

--- a/wagtail/contrib/styleguide/apps.py
+++ b/wagtail/contrib/styleguide/apps.py
@@ -1,5 +1,5 @@
 from django.apps import AppConfig
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class WagtailStyleGuideAppConfig(AppConfig):

--- a/wagtail/contrib/styleguide/views.py
+++ b/wagtail/contrib/styleguide/views.py
@@ -1,7 +1,7 @@
 from django import forms
 from django.core.paginator import Paginator
 from django.shortcuts import render
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from wagtail.admin import messages
 from wagtail.admin.forms.search import SearchForm

--- a/wagtail/contrib/styleguide/wagtail_hooks.py
+++ b/wagtail/contrib/styleguide/wagtail_hooks.py
@@ -1,6 +1,6 @@
 from django.conf.urls import url
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from wagtail.admin.menu import MenuItem
 from wagtail.core import hooks

--- a/wagtail/contrib/table_block/apps.py
+++ b/wagtail/contrib/table_block/apps.py
@@ -1,5 +1,5 @@
 from django.apps import AppConfig
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class WagtailTableBlockAppConfig(AppConfig):

--- a/wagtail/core/apps.py
+++ b/wagtail/core/apps.py
@@ -1,5 +1,5 @@
 from django.apps import AppConfig
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class WagtailCoreAppConfig(AppConfig):

--- a/wagtail/core/blocks/static_block.py
+++ b/wagtail/core/blocks/static_block.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from .base import Block
 

--- a/wagtail/core/blocks/stream_block.py
+++ b/wagtail/core/blocks/stream_block.py
@@ -8,7 +8,7 @@ from django.forms.utils import ErrorList
 from django.template.loader import render_to_string
 from django.utils.html import format_html_join
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from wagtail.admin.staticfiles import versioned_static
 from wagtail.core.utils import escape_script

--- a/wagtail/core/forms.py
+++ b/wagtail/core/forms.py
@@ -1,10 +1,10 @@
 from django import forms
-from django.utils.translation import ugettext as _
-from django.utils.translation import ugettext_lazy
+from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy
 
 
 class PasswordViewRestrictionForm(forms.Form):
-    password = forms.CharField(label=ugettext_lazy("Password"), widget=forms.PasswordInput)
+    password = forms.CharField(label=gettext_lazy("Password"), widget=forms.PasswordInput)
     return_url = forms.CharField(widget=forms.HiddenInput)
 
     def __init__(self, *args, **kwargs):

--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -21,7 +21,7 @@ from django.urls import NoReverseMatch, reverse
 from django.utils import timezone
 from django.utils.functional import cached_property
 from django.utils.text import capfirst, slugify
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from modelcluster.models import (
     ClusterableModel, get_all_child_m2m_relations, get_all_child_relations)
 from treebeard.mp_tree import MP_Node

--- a/wagtail/core/tests/test_blocks.py
+++ b/wagtail/core/tests/test_blocks.py
@@ -6,7 +6,7 @@ import unittest
 from datetime import date, datetime
 from decimal import Decimal
 
-# non-standard import name for ugettext_lazy, to prevent strings from being picked up for translation
+# non-standard import name for gettext_lazy, to prevent strings from being picked up for translation
 from django import forms
 from django.core.exceptions import ValidationError
 from django.forms.utils import ErrorList
@@ -14,7 +14,7 @@ from django.template.loader import render_to_string
 from django.test import SimpleTestCase, TestCase
 from django.utils.html import format_html
 from django.utils.safestring import SafeData, SafeText, mark_safe
-from django.utils.translation import ugettext_lazy as __
+from django.utils.translation import gettext_lazy as __
 
 from wagtail.core import blocks
 from wagtail.core.models import Page

--- a/wagtail/documents/forms.py
+++ b/wagtail/documents/forms.py
@@ -1,6 +1,6 @@
 from django import forms
 from django.forms.models import modelform_factory
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from wagtail.admin import widgets
 from wagtail.admin.forms.collections import (

--- a/wagtail/documents/models.py
+++ b/wagtail/documents/models.py
@@ -7,7 +7,7 @@ from django.conf import settings
 from django.db import models
 from django.dispatch import Signal
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from taggit.managers import TaggableManager
 
 from wagtail.admin.models import get_object_usage

--- a/wagtail/documents/views/chooser.py
+++ b/wagtail/documents/views/chooser.py
@@ -1,7 +1,7 @@
 from django.core.paginator import Paginator
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from wagtail.admin.auth import PermissionPolicyChecker
 from wagtail.admin.forms.search import SearchForm

--- a/wagtail/documents/views/documents.py
+++ b/wagtail/documents/views/documents.py
@@ -3,7 +3,7 @@ import os
 from django.core.paginator import Paginator
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from django.views.decorators.vary import vary_on_headers
 
 from wagtail.admin import messages

--- a/wagtail/documents/wagtail_hooks.py
+++ b/wagtail/documents/wagtail_hooks.py
@@ -3,8 +3,8 @@ from django.conf.urls import include, url
 from django.template.response import TemplateResponse
 from django.urls import reverse
 from django.utils.html import format_html
-from django.utils.translation import ugettext_lazy as _
-from django.utils.translation import ugettext, ungettext
+from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext, ngettext
 
 import wagtail.admin.rich_text.editors.draftail.features as draftail_features
 from wagtail.admin.menu import MenuItem
@@ -84,7 +84,7 @@ def register_document_feature(features):
         'draftail', 'document-link', draftail_features.EntityFeature({
             'type': 'DOCUMENT',
             'icon': 'doc-full',
-            'description': ugettext('Document'),
+            'description': gettext('Document'),
         }, js=['wagtaildocs/js/document-chooser-modal.js'])
     )
 
@@ -149,7 +149,7 @@ def describe_collection_docs(collection):
         url = reverse('wagtaildocs:index') + ('?collection_id=%d' % collection.id)
         return {
             'count': docs_count,
-            'count_text': ungettext(
+            'count_text': ngettext(
                 "%(count)s document",
                 "%(count)s documents",
                 docs_count

--- a/wagtail/documents/widgets.py
+++ b/wagtail/documents/widgets.py
@@ -2,7 +2,7 @@ import json
 
 from django import forms
 from django.template.loader import render_to_string
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from wagtail.admin.staticfiles import versioned_static
 from wagtail.admin.widgets import AdminChooser

--- a/wagtail/embeds/apps.py
+++ b/wagtail/embeds/apps.py
@@ -1,5 +1,5 @@
 from django.apps import AppConfig
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from .finders import get_finders
 

--- a/wagtail/embeds/blocks.py
+++ b/wagtail/embeds/blocks.py
@@ -1,6 +1,6 @@
 from django.core.exceptions import ValidationError
 from django.utils.functional import cached_property
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from wagtail.core import blocks
 from wagtail.embeds.format import embed_to_frontend_html

--- a/wagtail/embeds/forms.py
+++ b/wagtail/embeds/forms.py
@@ -1,6 +1,6 @@
 from django import forms
 from django.core.validators import URLValidator
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class EmbedForm(forms.Form):

--- a/wagtail/embeds/models.py
+++ b/wagtail/embeds/models.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 EMBED_TYPES = (
     ('video', 'Video'),

--- a/wagtail/embeds/views/chooser.py
+++ b/wagtail/embeds/views/chooser.py
@@ -1,5 +1,5 @@
 from django.forms.utils import ErrorList
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from wagtail.admin.modal_workflow import render_modal_workflow
 from wagtail.embeds import embeds

--- a/wagtail/embeds/wagtail_hooks.py
+++ b/wagtail/embeds/wagtail_hooks.py
@@ -1,7 +1,7 @@
 from django.conf.urls import include, url
 from django.urls import reverse
 from django.utils.html import format_html
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 import wagtail.admin.rich_text.editors.draftail.features as draftail_features
 from wagtail.admin.rich_text import HalloPlugin

--- a/wagtail/images/fields.py
+++ b/wagtail/images/fields.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.forms.fields import ImageField
 from django.template.defaultfilters import filesizeformat
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 ALLOWED_EXTENSIONS = ['gif', 'jpg', 'jpeg', 'png', 'webp']
 SUPPORTED_FORMATS_TEXT = _("GIF, JPEG, PNG, WEBP")

--- a/wagtail/images/formats.py
+++ b/wagtail/images/formats.py
@@ -1,5 +1,5 @@
 from django.utils.html import escape
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from wagtail.utils.apps import get_app_submodules
 

--- a/wagtail/images/forms.py
+++ b/wagtail/images/forms.py
@@ -1,7 +1,7 @@
 from django import forms
 from django.forms.models import modelform_factory
 from django.utils.text import capfirst
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from wagtail.admin import widgets
 from wagtail.admin.forms.collections import (

--- a/wagtail/images/models.py
+++ b/wagtail/images/models.py
@@ -12,7 +12,7 @@ from django.forms.utils import flatatt
 from django.urls import reverse
 from django.utils.functional import cached_property
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from taggit.managers import TaggableManager
 from unidecode import unidecode
 from willow.image import Image as WillowImage

--- a/wagtail/images/views/chooser.py
+++ b/wagtail/images/views/chooser.py
@@ -2,7 +2,7 @@ from django.conf import settings
 from django.core.paginator import Paginator
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from wagtail.admin.auth import PermissionPolicyChecker
 from wagtail.admin.forms.search import SearchForm

--- a/wagtail/images/views/images.py
+++ b/wagtail/images/views/images.py
@@ -6,7 +6,7 @@ from django.http import HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.urls.exceptions import NoReverseMatch
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from django.views.decorators.vary import vary_on_headers
 
 from wagtail.admin import messages

--- a/wagtail/images/wagtail_hooks.py
+++ b/wagtail/images/wagtail_hooks.py
@@ -1,8 +1,8 @@
 from django.conf.urls import include, url
 from django.urls import reverse
 from django.utils.html import format_html
-from django.utils.translation import ugettext_lazy as _
-from django.utils.translation import ugettext, ungettext
+from django.utils.translation import gettext_lazy as _
+from django.utils.translation import gettext, ngettext
 
 import wagtail.admin.rich_text.editors.draftail.features as draftail_features
 from wagtail.admin.menu import MenuItem
@@ -85,7 +85,7 @@ def register_image_feature(features):
         'draftail', 'image', draftail_features.EntityFeature({
             'type': 'IMAGE',
             'icon': 'image',
-            'description': ugettext('Image'),
+            'description': gettext('Image'),
             # We do not want users to be able to copy-paste hotlinked images into rich text.
             # Keep only the attributes Wagtail needs.
             'attributes': ['id', 'src', 'alt', 'format'],
@@ -173,7 +173,7 @@ def describe_collection_docs(collection):
         url = reverse('wagtailimages:index') + ('?collection_id=%d' % collection.id)
         return {
             'count': images_count,
-            'count_text': ungettext(
+            'count_text': ngettext(
                 "%(count)s image",
                 "%(count)s images",
                 images_count

--- a/wagtail/images/widgets.py
+++ b/wagtail/images/widgets.py
@@ -2,7 +2,7 @@ import json
 
 from django import forms
 from django.template.loader import render_to_string
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from wagtail.admin.staticfiles import versioned_static
 from wagtail.admin.widgets import AdminChooser

--- a/wagtail/search/apps.py
+++ b/wagtail/search/apps.py
@@ -1,5 +1,5 @@
 from django.apps import AppConfig
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from wagtail.search.signal_handlers import register_signal_handlers
 

--- a/wagtail/search/forms.py
+++ b/wagtail/search/forms.py
@@ -1,5 +1,5 @@
 from django import forms
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class QueryForm(forms.Form):

--- a/wagtail/search/models.py
+++ b/wagtail/search/models.py
@@ -3,7 +3,7 @@ import datetime
 from django.conf import settings
 from django.db import models
 from django.utils import timezone
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from wagtail.search.utils import MAX_QUERY_STRING_LENGTH, normalise_query_string
 

--- a/wagtail/sites/apps.py
+++ b/wagtail/sites/apps.py
@@ -1,5 +1,5 @@
 from django.apps import AppConfig
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class WagtailSitesAppConfig(AppConfig):

--- a/wagtail/sites/forms.py
+++ b/wagtail/sites/forms.py
@@ -1,5 +1,5 @@
 from django import forms
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from wagtail.admin.widgets import AdminPageChooser
 from wagtail.core.models import Site

--- a/wagtail/sites/views.py
+++ b/wagtail/sites/views.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy
+from django.utils.translation import gettext_lazy
 
 from wagtail.admin.views import generic
 from wagtail.admin.viewsets.model import ModelViewSet
@@ -9,29 +9,29 @@ from wagtail.sites.forms import SiteForm
 
 class IndexView(generic.IndexView):
     template_name = 'wagtailsites/index.html'
-    page_title = ugettext_lazy("Sites")
-    add_item_label = ugettext_lazy("Add a site")
+    page_title = gettext_lazy("Sites")
+    add_item_label = gettext_lazy("Add a site")
     context_object_name = 'sites'
 
 
 class CreateView(generic.CreateView):
-    page_title = ugettext_lazy("Add site")
-    success_message = ugettext_lazy("Site '{0}' created.")
+    page_title = gettext_lazy("Add site")
+    success_message = gettext_lazy("Site '{0}' created.")
     template_name = 'wagtailsites/create.html'
 
 
 class EditView(generic.EditView):
-    success_message = ugettext_lazy("Site '{0}' updated.")
-    error_message = ugettext_lazy("The site could not be saved due to errors.")
-    delete_item_label = ugettext_lazy("Delete site")
+    success_message = gettext_lazy("Site '{0}' updated.")
+    error_message = gettext_lazy("The site could not be saved due to errors.")
+    delete_item_label = gettext_lazy("Delete site")
     context_object_name = 'site'
     template_name = 'wagtailsites/edit.html'
 
 
 class DeleteView(generic.DeleteView):
-    success_message = ugettext_lazy("Site '{0}' deleted.")
-    page_title = ugettext_lazy("Delete site")
-    confirmation_message = ugettext_lazy("Are you sure you want to delete this site?")
+    success_message = gettext_lazy("Site '{0}' deleted.")
+    page_title = gettext_lazy("Delete site")
+    confirmation_message = gettext_lazy("Are you sure you want to delete this site?")
 
 
 class SiteViewSet(ModelViewSet):

--- a/wagtail/sites/wagtail_hooks.py
+++ b/wagtail/sites/wagtail_hooks.py
@@ -1,6 +1,6 @@
 from django.contrib.auth.models import Permission
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from wagtail.admin.menu import MenuItem
 from wagtail.core import hooks

--- a/wagtail/snippets/views/chooser.py
+++ b/wagtail/snippets/views/chooser.py
@@ -2,7 +2,7 @@ from django.contrib.admin.utils import quote, unquote
 from django.core.paginator import Paginator
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from wagtail.admin.forms.search import SearchForm
 from wagtail.admin.modal_workflow import render_modal_workflow

--- a/wagtail/snippets/views/snippets.py
+++ b/wagtail/snippets/views/snippets.py
@@ -7,8 +7,8 @@ from django.http import Http404
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils.text import capfirst
-from django.utils.translation import ugettext as _
-from django.utils.translation import ungettext
+from django.utils.translation import gettext as _
+from django.utils.translation import ngettext
 
 from wagtail.admin import messages
 from wagtail.admin.auth import permission_denied
@@ -245,10 +245,10 @@ def delete(request, app_label, model_name, pk=None):
                 'instance': instance
             }
         else:
-            # This message is only used in plural form, but we'll define it with ungettext so that
+            # This message is only used in plural form, but we'll define it with ngettext so that
             # languages with multiple plural forms can be handled correctly (or, at least, as
             # correctly as possible within the limitations of verbose_name_plural...)
-            message_content = ungettext(
+            message_content = ngettext(
                 "%(count)d %(snippet_type)s deleted.",
                 "%(count)d %(snippet_type)s deleted.",
                 count

--- a/wagtail/snippets/wagtail_hooks.py
+++ b/wagtail/snippets/wagtail_hooks.py
@@ -3,7 +3,7 @@ from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
 from django.utils.html import format_html
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from wagtail.admin.menu import MenuItem
 from wagtail.core import hooks

--- a/wagtail/snippets/widgets.py
+++ b/wagtail/snippets/widgets.py
@@ -2,7 +2,7 @@ import json
 
 from django import forms
 from django.template.loader import render_to_string
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from wagtail.admin.staticfiles import versioned_static
 from wagtail.admin.widgets import AdminChooser

--- a/wagtail/tests/modeladmintest/apps.py
+++ b/wagtail/tests/modeladmintest/apps.py
@@ -1,5 +1,5 @@
 from django.apps import AppConfig
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class WagtailTestsAppConfig(AppConfig):

--- a/wagtail/tests/routablepage/apps.py
+++ b/wagtail/tests/routablepage/apps.py
@@ -1,5 +1,5 @@
 from django.apps import AppConfig
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class WagtailRoutablePageTestsAppConfig(AppConfig):

--- a/wagtail/tests/search/apps.py
+++ b/wagtail/tests/search/apps.py
@@ -1,5 +1,5 @@
 from django.apps import AppConfig
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class WagtailSearchTestsAppConfig(AppConfig):

--- a/wagtail/tests/snippets/apps.py
+++ b/wagtail/tests/snippets/apps.py
@@ -1,5 +1,5 @@
 from django.apps import AppConfig
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class WagtailSnippetsTestsAppConfig(AppConfig):

--- a/wagtail/tests/testapp/apps.py
+++ b/wagtail/tests/testapp/apps.py
@@ -1,5 +1,5 @@
 from django.apps import AppConfig
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class WagtailTestsAppConfig(AppConfig):

--- a/wagtail/users/apps.py
+++ b/wagtail/users/apps.py
@@ -1,5 +1,5 @@
 from django.apps import AppConfig
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class WagtailUsersAppConfig(AppConfig):

--- a/wagtail/users/forms.py
+++ b/wagtail/users/forms.py
@@ -14,7 +14,7 @@ from django.db import transaction
 from django.db.models.fields import BLANK_CHOICE_DASH
 from django.template.loader import render_to_string
 from django.utils.html import mark_safe
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from wagtail.admin.localization import get_available_admin_languages, get_available_admin_time_zones
 from wagtail.admin.widgets import AdminPageChooser

--- a/wagtail/users/models.py
+++ b/wagtail/users/models.py
@@ -3,7 +3,7 @@ import uuid
 
 from django.conf import settings
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.utils.translation import get_language
 
 

--- a/wagtail/users/views/groups.py
+++ b/wagtail/users/views/groups.py
@@ -1,5 +1,5 @@
 from django.contrib.auth.models import Group
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from wagtail.admin.views import generic, mixins
 from wagtail.admin.viewsets.model import ModelViewSet

--- a/wagtail/users/views/users.py
+++ b/wagtail/users/views/users.py
@@ -4,7 +4,7 @@ from django.core.paginator import Paginator
 from django.db.models import Q
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from django.views.decorators.vary import vary_on_headers
 
 from wagtail.admin import messages

--- a/wagtail/users/wagtail_hooks.py
+++ b/wagtail/users/wagtail_hooks.py
@@ -2,7 +2,7 @@ from django.conf.urls import include, url
 from django.contrib.auth.models import Permission
 from django.db.models import Q
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from wagtail.admin.menu import MenuItem
 from wagtail.admin.search import SearchArea


### PR DESCRIPTION
#### Problem
- `ugettext`, `ungettext`, `ugettext_lazy` were deprecated and should be replaced with `gettext`, `ngettext` and `ugettext_lazy`

#### Solution
- Replace  every `ugettext`, `ungettext`, `ugettext_lazy` with `gettext`, `ngettext` and `ugettext_lazy`

##### Before
-  `python -Wall manage.py runserver`

![wagtail_warnings_before](https://user-images.githubusercontent.com/26286907/77458400-2d316c80-6e0f-11ea-81e5-f35e9b4d1c1f.png)

##### After
-  `python -Wall manage.py runserver`

![wagtail_warnings_after](https://user-images.githubusercontent.com/26286907/77458290-02dfaf00-6e0f-11ea-9ba1-52a306f45eba.png)

#### Related Issues
Resolves #5842 