### PR TITLE
Fix user preferred language override not working with TemplateResponse

### DIFF
--- a/wagtail/admin/auth.py
+++ b/wagtail/admin/auth.py
@@ -1,6 +1,7 @@
 from functools import wraps
 
 import l18n
+import types
 
 from django.contrib.auth import get_user_model
 from django.contrib.auth.views import redirect_to_login as auth_redirect_to_login
@@ -149,6 +150,7 @@ def reject_request(request):
 
 def require_admin_access(view_func):
     def decorated_view(request, *args, **kwargs):
+
         user = request.user
 
         if user.is_anonymous:
@@ -163,7 +165,23 @@ def require_admin_access(view_func):
                 activate_tz(time_zone)
             if preferred_language:
                 with override(preferred_language):
-                    return view_func(request, *args, **kwargs)
+                    response = view_func(request, *args, **kwargs)
+                if hasattr(response, "render"):
+                    # If the response has a render() method, Django treats it
+                    # like a TemplateResponse, so we should do the same
+                    # In this case, we need to guarantee that when the TemplateResponse
+                    # is rendered, it is done within the override context manager
+                    # or the user preferred_language will not be used
+                    # (this could be replaced with simply rendering the TemplateResponse
+                    # for simplicity but this does remove some of its middleware modification 
+                    # potential)
+                    render = response.render
+                    # decorate the response render method with the override context manager
+                    def overridden_render(response):
+                        with override(preferred_language):
+                            return render()
+                    response.render = types.MethodType(overridden_render, response)
+                return response
             else:
                 return view_func(request, *args, **kwargs)
 

--- a/wagtail/admin/auth.py
+++ b/wagtail/admin/auth.py
@@ -1,7 +1,7 @@
+import types
 from functools import wraps
 
 import l18n
-import types
 
 from django.contrib.auth import get_user_model
 from django.contrib.auth.views import redirect_to_login as auth_redirect_to_login

--- a/wagtail/admin/auth.py
+++ b/wagtail/admin/auth.py
@@ -173,14 +173,16 @@ def require_admin_access(view_func):
                     # is rendered, it is done within the override context manager
                     # or the user preferred_language will not be used
                     # (this could be replaced with simply rendering the TemplateResponse
-                    # for simplicity but this does remove some of its middleware modification 
+                    # for simplicity but this does remove some of its middleware modification
                     # potential)
                     render = response.render
-                    # decorate the response render method with the override context manager
+
                     def overridden_render(response):
                         with override(preferred_language):
                             return render()
+
                     response.render = types.MethodType(overridden_render, response)
+                    # decorate the response render method with the override context manager
                 return response
             else:
                 return view_func(request, *args, **kwargs)


### PR DESCRIPTION
This addresses https://github.com/wagtail/wagtail/issues/5893, which turned out to be a much more general issue, where the user profile language would not be used on rendering anything returning a TemplateResponse from the Wagtail Admin, including collections and modeladmin.

This fix is intended to preserve as much as possible the ability of the TemplateResponse to be further modified by middleware if we decide to change to use these more. However, given that we largely return HttpResponses, the simpler fix of forcing the TemplateResponse to render could be preferred - I'm happy to implement that instead if that's preferred.