### PR TITLE
Add safe filter to task and workflow names on plain text notification…

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/notifications/task_state_approved.txt
+++ b/wagtail/admin/templates/wagtailadmin/notifications/task_state_approved.txt
@@ -1,7 +1,7 @@
-{% extends 'wagtailadmin/notifications/base.html' %}
+{% extends 'wagtailadmin/notifications/base.txt' %}
 {% load i18n %}
 
 {% block content %}
-{% blocktrans with title=page.get_admin_display_title|safe task=task.name %}The page "{{ title }}" has been approved in moderation stage "{{ task }}".{% endblocktrans %}
+{% blocktrans with title=page.get_admin_display_title|safe task=task.name|safe %}The page "{{ title }}" has been approved in moderation stage "{{ task }}".{% endblocktrans %}
 {% trans "You can edit the page here:"%} {{ settings.BASE_URL }}{% url 'wagtailadmin_pages:edit' page.id %}
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/task_state_approved_subject.txt
+++ b/wagtail/admin/templates/wagtailadmin/notifications/task_state_approved_subject.txt
@@ -1,3 +1,3 @@
 {% load i18n %}
 
-{% blocktrans with title=page.get_admin_display_title|safe task=task.name %}The page "{{ title }}" has been approved in "{{ task }}".{% endblocktrans %}
+{% blocktrans with title=page.get_admin_display_title|safe task=task.name|safe %}The page "{{ title }}" has been approved in "{{ task }}".{% endblocktrans %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/task_state_rejected.txt
+++ b/wagtail/admin/templates/wagtailadmin/notifications/task_state_rejected.txt
@@ -2,6 +2,6 @@
 {% load i18n %}
 
 {% block content %}
-{% blocktrans with title=page.get_admin_display_title|safe task=task.name %}The page "{{ title }}" has been rejected in moderation stage "{{ task }}".{% endblocktrans %}
+{% blocktrans with title=page.get_admin_display_title|safe task=task.name|safe %}The page "{{ title }}" has been rejected in moderation stage "{{ task }}".{% endblocktrans %}
 {% trans "You can edit the page here:"%} {{ settings.BASE_URL }}{% url 'wagtailadmin_pages:edit' page.id %}
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/task_state_rejected_subject.txt
+++ b/wagtail/admin/templates/wagtailadmin/notifications/task_state_rejected_subject.txt
@@ -1,3 +1,3 @@
 {% load i18n %}
 
-{% blocktrans with title=page.get_admin_display_title|safe task=task.name %}The page "{{ title }}" has been rejected during "{{ task }}".{% endblocktrans %}
+{% blocktrans with title=page.get_admin_display_title|safe task=task.name|safe %}The page "{{ title }}" has been rejected during "{{ task }}".{% endblocktrans %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/task_state_submitted.txt
+++ b/wagtail/admin/templates/wagtailadmin/notifications/task_state_submitted.txt
@@ -1,9 +1,9 @@
-{% extends 'wagtailadmin/notifications/base.html' %}
+{% extends 'wagtailadmin/notifications/base.txt' %}
 
 {% load i18n %}
 
 {% block content %}
-{% blocktrans with task=task.name title=page.get_admin_display_title|safe %}The page "{{ title }}" has been submitted for approval to moderation stage "{{ task }}".{% endblocktrans %}
+{% blocktrans with task=task.name|safe title=page.get_admin_display_title|safe %}The page "{{ title }}" has been submitted for approval to moderation stage "{{ task }}".{% endblocktrans %}
 
 
 {% trans "You can preview the page here:" %} {{ settings.BASE_URL }}{% url 'wagtailadmin_pages:workflow_preview' page.id task.id %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/task_state_submitted_subject.txt
+++ b/wagtail/admin/templates/wagtailadmin/notifications/task_state_submitted_subject.txt
@@ -1,3 +1,3 @@
 {% load i18n %}
 
-{% blocktrans with title=page.get_admin_display_title|safe task=task.name %}The page "{{ title }}" has been submitted for approval in moderation stage "{{ task }}" {% endblocktrans %}
+{% blocktrans with title=page.get_admin_display_title|safe task=task.name|safe %}The page "{{ title }}" has been submitted for approval in moderation stage "{{ task }}" {% endblocktrans %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/workflow_state_approved.html
+++ b/wagtail/admin/templates/wagtailadmin/notifications/workflow_state_approved.html
@@ -2,6 +2,6 @@
 {% load i18n %}
 
 {% block content %}
-    <p>{% blocktrans with title=page.get_admin_display_title task=task.name %}The page "{{ title }}" has been approved in workflow "{{ workflow }}".{% endblocktrans %}</p>
+    <p>{% blocktrans with title=page.get_admin_display_title workflow=workflow.name %}The page "{{ title }}" has been approved in workflow "{{ workflow }}".{% endblocktrans %}</p>
     <p>{% trans "You can view the page here:" %} <a href="{{ page.full_url }}">{{ page.full_url }}</a></p>
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/workflow_state_approved.txt
+++ b/wagtail/admin/templates/wagtailadmin/notifications/workflow_state_approved.txt
@@ -1,7 +1,7 @@
-{% extends 'wagtailadmin/notifications/base.html' %}
+{% extends 'wagtailadmin/notifications/base.txt' %}
 {% load i18n %}
 
 {% block content %}
-{% blocktrans with title=page.get_admin_display_title|safe task=task.name %}The page "{{ title }}" has been approved in workflow "{{ workflow }}".{% endblocktrans %}
+{% blocktrans with title=page.get_admin_display_title|safe workflow=workflow.name|safe %}The page "{{ title }}" has been approved in workflow "{{ workflow }}".{% endblocktrans %}
 {% trans "You can view the page here:" %} {{ page.full_url }}
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/workflow_state_approved_subject.txt
+++ b/wagtail/admin/templates/wagtailadmin/notifications/workflow_state_approved_subject.txt
@@ -1,3 +1,3 @@
 {% load i18n %}
 
-{% blocktrans with title=page.get_admin_display_title|safe task=task.name %}The page "{{ title }}" has been approved in "{{ workflow }}".{% endblocktrans %}
+{% blocktrans with title=page.get_admin_display_title|safe workflow=workflow.name|safe %}The page "{{ title }}" has been approved in "{{ workflow }}".{% endblocktrans %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/workflow_state_rejected.txt
+++ b/wagtail/admin/templates/wagtailadmin/notifications/workflow_state_rejected.txt
@@ -2,7 +2,7 @@
 {% load i18n %}
 
 {% block content %}
-{% blocktrans with title=page.get_admin_display_title|safe workflow=workflow.name %}The page "{{ title }}" has been rejected in workflow "{{ workflow }}"".{% endblocktrans %}
+{% blocktrans with title=page.get_admin_display_title|safe workflow=workflow.name|safe %}The page "{{ title }}" has been rejected in workflow "{{ workflow }}"".{% endblocktrans %}
 
 {% trans "You can edit the page here:"%} {{ settings.BASE_URL }}{% url 'wagtailadmin_pages:edit' page.id %}
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/workflow_state_rejected_subject.txt
+++ b/wagtail/admin/templates/wagtailadmin/notifications/workflow_state_rejected_subject.txt
@@ -1,3 +1,3 @@
 {% load i18n %}
 
-{% blocktrans with title=page.get_admin_display_title|safe workflow=workflow.name %}The page "{{ title }}" has been rejected during "{{ workflow }}".{% endblocktrans %}
+{% blocktrans with title=page.get_admin_display_title|safe workflow=workflow.name|safe %}The page "{{ title }}" has been rejected during "{{ workflow }}".{% endblocktrans %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/workflow_state_submitted.txt
+++ b/wagtail/admin/templates/wagtailadmin/notifications/workflow_state_submitted.txt
@@ -1,9 +1,9 @@
-{% extends 'wagtailadmin/notifications/base.html' %}
+{% extends 'wagtailadmin/notifications/base.txt' %}
 
 {% load i18n %}
 
 {% block content %}
-{% blocktrans with workflow=workflow.name title=page.get_admin_display_title|safe %}The page "{{ title }}" has been submitted for moderation to workflow "{{ workflow }}".{% endblocktrans %}
+{% blocktrans with workflow=workflow.name|safe title=page.get_admin_display_title|safe %}The page "{{ title }}" has been submitted for moderation to workflow "{{ workflow }}".{% endblocktrans %}
 
 
 {% trans "You can edit the page here:" %} {{ settings.BASE_URL }}{% url 'wagtailadmin_pages:edit' page.id %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/workflow_state_submitted_subject.txt
+++ b/wagtail/admin/templates/wagtailadmin/notifications/workflow_state_submitted_subject.txt
@@ -1,3 +1,3 @@
 {% load i18n %}
 
-{% blocktrans with title=page.get_admin_display_title|safe workflow=workflow.name %}The page "{{ title }}" has been submitted to workflow "{{ workflow }}" {% endblocktrans %}
+{% blocktrans with title=page.get_admin_display_title|safe workflow=workflow.name|safe %}The page "{{ title }}" has been submitted to workflow "{{ workflow }}" {% endblocktrans %}


### PR DESCRIPTION
Fix notification emails:
- Prevent unnecessary escaping of workflow/task names in plain text.
- Ensure plain text templates inherit from the plain text base template, not html.