### PR TITLE
Workflow implementation fixes

### DIFF
--- a/wagtail/admin/mail.py
+++ b/wagtail/admin/mail.py
@@ -227,35 +227,37 @@ class EmailNotificationMixin:
     def send_emails(self, template_set, context, recipients, **kwargs):
 
         connection = get_connection()
+        sent_count = 0
+        try:
+            with OpenedConnection(connection) as open_connection:
+            
+                # Send emails
+                for recipient in recipients:
+                    try:
 
-        with OpenedConnection(connection) as open_connection:
+                        # update context with this recipient
+                        context["user"] = recipient
 
-            # Send emails
-            sent_count = 0
-            for recipient in recipients:
-                try:
+                        # Translate text to the recipient language settings
+                        with override(recipient.wagtail_userprofile.get_preferred_language()):
+                            # Get email subject and content
+                            email_subject = render_to_string(template_set['subject'], context).strip()
+                            email_content = render_to_string(template_set['text'], context).strip()
 
-                    # update context with this recipient
-                    context["user"] = recipient
+                        kwargs = {}
+                        if getattr(settings, 'WAGTAILADMIN_NOTIFICATION_USE_HTML', False):
+                            kwargs['html_message'] = render_to_string(template_set['html'], context)
 
-                    # Translate text to the recipient language settings
-                    with override(recipient.wagtail_userprofile.get_preferred_language()):
-                        # Get email subject and content
-                        email_subject = render_to_string(template_set['subject'], context).strip()
-                        email_content = render_to_string(template_set['text'], context).strip()
-
-                    kwargs = {}
-                    if getattr(settings, 'WAGTAILADMIN_NOTIFICATION_USE_HTML', False):
-                        kwargs['html_message'] = render_to_string(template_set['html'], context)
-
-                    # Send email
-                    send_mail(email_subject, email_content, [recipient.email], connection=open_connection, **kwargs)
-                    sent_count += 1
-                except Exception:
-                    logger.exception(
-                        "Failed to send notification email '%s' to %s",
-                        email_subject, recipient.email
-                    )
+                        # Send email
+                        send_mail(email_subject, email_content, [recipient.email], connection=open_connection, **kwargs)
+                        sent_count += 1
+                    except Exception:
+                        logger.exception(
+                            "Failed to send notification email '%s' to %s",
+                            email_subject, recipient.email
+                        )
+        except (TimeoutError, ConnectionError):
+            logger.exception("Mail connection error, notification sending skipped")
 
         return sent_count == len(recipients)
 

--- a/wagtail/admin/mail.py
+++ b/wagtail/admin/mail.py
@@ -230,7 +230,7 @@ class EmailNotificationMixin:
         sent_count = 0
         try:
             with OpenedConnection(connection) as open_connection:
-            
+
                 # Send emails
                 for recipient in recipients:
                     try:

--- a/wagtail/admin/views/workflows.py
+++ b/wagtail/admin/views/workflows.py
@@ -17,6 +17,7 @@ from wagtail.admin.views.generic import CreateView, DeleteView, EditView, IndexV
 from wagtail.admin.views.pages import get_valid_next_url_from_request
 from wagtail.core.models import Page, Task, TaskState, WorkflowState
 from wagtail.core.permissions import task_permission_policy, workflow_permission_policy
+from wagtail.core.workflows import get_task_types
 
 
 class Index(IndexView):
@@ -290,7 +291,7 @@ def select_task_type(request):
 
     task_types = [
         (model.get_verbose_name(), model._meta.app_label, model._meta.model_name)
-        for model in Task.__subclasses__()
+        for model in get_task_types()
     ]
     # sort by lower-cased version of verbose name
     task_types.sort(key=lambda task_type: task_type[0].lower())

--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -2758,6 +2758,9 @@ class WorkflowState(models.Model):
                     # not STATUS_IN_PROGRESS), move to the next task
                     self.current_task_state = next_task.specific.start(self, user=user)
                     self.save()
+                    # if task has auto-approved, update the workflow again
+                    if self.current_task_state.status != self.current_task_state.STATUS_IN_PROGRESS:
+                        self.update(user=user)
                 # otherwise, continue on the current task
             else:
                 # if there is no uncompleted task, finish the workflow.
@@ -2765,7 +2768,7 @@ class WorkflowState(models.Model):
 
     def get_next_task(self):
         """Returns the next active task associated with the latest page revision, which has not been either approved or skipped"""
-        return Task.objects.filter(workflow_tasks__workflow=self.workflow, active=True).exclude(Q(task_states__page_revision=self.page.get_latest_revision()), Q(task_states__status=TaskState.STATUS_APPROVED) | Q(task_states__status=TaskState.STATUS_SKIPPED)).order_by('workflow_tasks__sort_order').first()
+        return Task.objects.filter(workflow_tasks__workflow=self.workflow, active=True).exclude(task_states__in=TaskState.objects.filter(Q(page_revision=self.page.get_latest_revision()), Q(status=TaskState.STATUS_APPROVED) | Q(status=TaskState.STATUS_SKIPPED))).order_by('workflow_tasks__sort_order').first()
 
     def cancel(self, user=None):
         """Cancels the workflow state"""
@@ -2911,26 +2914,28 @@ class TaskState(MultiTableCopyMixin, models.Model):
             return content_type.get_object_for_this_type(id=self.id)
 
     @transaction.atomic
-    def approve(self, user=None):
+    def approve(self, user=None, update=True):
         """Approve the task state and update the workflow state"""
         if self.status != self.STATUS_IN_PROGRESS:
             raise PermissionDenied
         self.status = self.STATUS_APPROVED
         self.finished_at = timezone.now()
         self.save()
-        self.workflow_state.update(user=user)
+        if update:
+            self.workflow_state.update(user=user)
         task_approved.send(sender=self.specific.__class__, instance=self.specific, user=user)
         return self
 
     @transaction.atomic
-    def reject(self, user=None):
+    def reject(self, user=None, update=True):
         """Reject the task state and update the workflow state"""
         if self.status != self.STATUS_IN_PROGRESS:
             raise PermissionDenied
         self.status = self.STATUS_REJECTED
         self.finished_at = timezone.now()
         self.save()
-        self.workflow_state.update(user=user)
+        if update:
+            self.workflow_state.update(user=user)
         task_rejected.send(sender=self.specific.__class__, instance=self.specific, user=user)
         return self
 

--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -2768,7 +2768,15 @@ class WorkflowState(models.Model):
 
     def get_next_task(self):
         """Returns the next active task associated with the latest page revision, which has not been either approved or skipped"""
-        return Task.objects.filter(workflow_tasks__workflow=self.workflow, active=True).exclude(task_states__in=TaskState.objects.filter(Q(page_revision=self.page.get_latest_revision()), Q(status=TaskState.STATUS_APPROVED) | Q(status=TaskState.STATUS_SKIPPED))).order_by('workflow_tasks__sort_order').first()
+        return (
+            Task.objects.filter(workflow_tasks__workflow=self.workflow, active=True)
+            .exclude(
+                task_states__in=TaskState.objects.filter(
+                    Q(page_revision=self.page.get_latest_revision()),
+                    Q(status=TaskState.STATUS_APPROVED) | Q(status=TaskState.STATUS_SKIPPED)
+                )
+            ).order_by('workflow_tasks__sort_order').first()
+        )
 
     def cancel(self, user=None):
         """Cancels the workflow state"""

--- a/wagtail/core/workflows.py
+++ b/wagtail/core/workflows.py
@@ -3,6 +3,7 @@ from wagtail.core.models import Task
 
 TASK_TYPES = []
 
+
 def get_concrete_descendants(model_class, inclusive=True):
     """Retrieves non-abstract descendants of the given model class. If `inclusive` is set to
     True, includes model_class"""

--- a/wagtail/core/workflows.py
+++ b/wagtail/core/workflows.py
@@ -1,3 +1,27 @@
+from wagtail.core.models import Task
+
+
+TASK_TYPES = []
+
+def get_concrete_descendants(model_class, inclusive=True):
+    """Retrieves non-abstract descendants of the given model class. If `inclusive` is set to
+    True, includes model_class"""
+    subclasses = model_class.__subclasses__()
+    if subclasses:
+        for subclass in subclasses:
+            yield from get_concrete_descendants(subclass)
+    if inclusive and not model_class._meta.abstract:
+        yield model_class
+
+
+def get_task_types(task_class=None):
+    global TASK_TYPES
+    if TASK_TYPES:
+        return TASK_TYPES
+    TASK_TYPES = list(get_concrete_descendants(Task, inclusive=False))
+    return TASK_TYPES
+
+
 def publish_workflow_state(workflow_state):
     # publish the Page associated with a WorkflowState
     if workflow_state.current_task_state:


### PR DESCRIPTION
Fixes:
- `get_next_task` excluding tasks erroneously (see commit for details)
- Task type selection only allowing one level of inheritance, and not preventing attempts to create abstract tasks
- Mail connection opening not wrapped in try/except block
