### PR TITLE
Facet search: make 'All' translatable

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/pages/search_results.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/search_results.html
@@ -16,9 +16,9 @@
                 <h3 id="page-types-title" class="filter-title">{% trans "Page types" %}</h3>
                 <ul class="filter-options">
                     {% if not selected_content_type %}
-                        <li style="background-color: #E6E6E6">All ({{ all_pages.count }})</li>
+                        <li style="background-color: #E6E6E6">{% trans "All" %} ({{ all_pages.count }})</li>
                     {% else %}
-                        <li><a href="{% url 'wagtailadmin_pages:search' %}?q={{ query_string|urlencode }}">All ({{ all_pages.count }})</a></li>
+                        <li><a href="{% url 'wagtailadmin_pages:search' %}?q={{ query_string|urlencode }}">{% trans "All" %} ({{ all_pages.count }})</a></li>
                     {% endif %}
 
                     {% for content_type, count in content_types %}


### PR DESCRIPTION
Minor fix allowing "All" to be translatable on wagtail search results
