### PR TITLE
Allow ListBlocks to leverage child bulk_to_python

### DIFF
--- a/wagtail/core/blocks/list_block.py
+++ b/wagtail/core/blocks/list_block.py
@@ -132,7 +132,11 @@ class ListBlock(Block):
         return result
 
     def to_python(self, value):
-        # recursively call to_python on children and return as a list
+        # If child block supports bulk retrieval, use it.
+        if hasattr(self.child_block, 'bulk_to_python'):
+            return self.child_block.bulk_to_python(value)
+
+        # Otherwise recursively call to_python on each child and return as a list.
         return [
             self.child_block.to_python(item)
             for item in value

--- a/wagtail/core/tests/test_blocks.py
+++ b/wagtail/core/tests/test_blocks.py
@@ -3275,6 +3275,26 @@ class TestPageChooserBlock(TestCase):
             'wagtail.core.blocks.PageChooserBlock',
             (), {'page_type': ['tests.SimplePage', 'tests.EventPage']}))
 
+    def test_bulk_to_python(self):
+        page_ids = [2, 3, 4, 5]
+        expected_pages = Page.objects.filter(pk__in=page_ids)
+        block = blocks.PageChooserBlock()
+
+        with self.assertNumQueries(1):
+            pages = block.bulk_to_python(page_ids)
+
+        self.assertSequenceEqual(pages, expected_pages)
+
+    def test_bulk_to_python_when_child_of_listblock(self):
+        page_ids = [2, 3, 4, 5]
+        expected_pages = Page.objects.filter(pk__in=page_ids)
+        block = blocks.ListBlock(blocks.PageChooserBlock())
+
+        with self.assertNumQueries(1):
+            pages = block.to_python(page_ids)
+
+        self.assertSequenceEqual(pages, expected_pages)
+
 
 class TestStaticBlock(unittest.TestCase):
     def test_render_form_with_constructor(self):


### PR DESCRIPTION
Currently a select set of StreamField blocks like PageChooserBlock expose a bulk_to_python method that is used to optimize their retrieval from the database. As reported in #5926, ListBlock could take advantage of this so that its child items are loaded at once, instead of one at a time.

This change modifies how ListBlock.to_python works so that it calls its child block's bulk_to_python, if defined. This allows for a single query instead of one query per child item.

Note that this change doesn't add `bulk_to_python` to ListBlock itself, meaning that individual ListBlocks in a StreamField or StructBlock are still retrieved independently. But it does optimize the lookup for each ListBlock.