### PR TITLE
Idenfity/cache Settings per-request, instead of just per-site

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -23,6 +23,7 @@ Changelog
  * FieldPanel now accepts a 'heading' argument (Jacob Topp-Mugglestone)
  * Replaced deprecated `ugettext` / `ungettext` calls with `gettext` / `ngettext` (Mohamed Feddad)
  * ListBlocks now call child block `bulk_to_python` if defined (Andy Chosak)
+ * Site settings are now identifiable/cachable by request as well as site (Andy Babic)
  * Fix: Added ARIA alert role to live search forms in the admin (Casper Timmers)
  * Fix: Reorder login form elements to match expected tab order (Kjartan Sverrisson)
  * Fix: Re-add 'Close Explorer' button on mobile viewports (Sævar Öfjörð Magnússon)

--- a/docs/reference/contrib/settings.rst
+++ b/docs/reference/contrib/settings.rst
@@ -108,16 +108,19 @@ Settings are designed to be used both in Python code, and in templates.
 Using in Python
 ---------------
 
-If access to a setting is required in the code, the :func:`~wagtail.contrib.settings.models.BaseSetting.for_site` method will retrieve the setting for the supplied site:
+If you require access to a setting in a view, the :func:`~wagtail.contrib.settings.models.BaseSetting.for_request` method allows you to retrieve the relevant settings for the current request:
 
 .. code-block:: python
 
-    from wagtail.core.models import Site
-
     def view(request):
-        site = Site.find_for_request(request)
-        social_media_settings = SocialMediaSettings.for_site(site)
+        social_media_settings = SocialMediaSettings.for_request(request)
         ...
+
+In places where the request is unavailable, but you know the ``Site`` you wish to retrieve settings for, you can use :func:`~wagtail.contrib.settings.models.BaseSetting.for_site` instead:
+
+.. code-block:: python
+
+    social_media_settings =  SocialMediaSettings.for_site(user.origin_site)
 
 Using in Django templates
 -------------------------

--- a/docs/releases/2.9.rst
+++ b/docs/releases/2.9.rst
@@ -36,6 +36,7 @@ Other features
  * FieldPanel now accepts a 'heading' argument (Jacob Topp-Mugglestone)
  * Replaced deprecated ``ugettext`` / ``ungettext`` calls with ``gettext`` / ``ngettext`` (Mohamed Feddad)
  * ListBLocks now call child block ``bulk_to_python`` if defined (Andy Chosak)
+ * Site settings are now identifiable/cachable by request as well as site (Andy Babic)
 
 
 Bug fixes

--- a/wagtail/contrib/settings/context_processors.py
+++ b/wagtail/contrib/settings/context_processors.py
@@ -1,5 +1,3 @@
-from django.utils.functional import SimpleLazyObject
-
 from wagtail.core.models import Site
 
 from .registry import registry

--- a/wagtail/contrib/settings/models.py
+++ b/wagtail/contrib/settings/models.py
@@ -22,7 +22,31 @@ class BaseSetting(models.Model):
     @classmethod
     def for_site(cls, site):
         """
-        Get an instance of this setting for the site.
+        Get or create an instance of this setting for the site.
         """
         instance, created = cls.objects.get_or_create(site=site)
         return instance
+
+    @classmethod
+    def for_request(cls, request):
+        """
+        Get or create an instance of this model for the request,
+        and cache the result on the request for faster repeat access.
+        """
+        attr_name = cls.get_cache_attr_name()
+        if hasattr(request, attr_name):
+            return getattr(request, attr_name)
+        site = Site.find_for_request(request)
+        site_settings = cls.for_site(site)
+        setattr(request, attr_name, site_settings)
+        return site_settings
+
+    @classmethod
+    def get_cache_attr_name(cls):
+        """
+        Returns the name of the attribute that should be used to store
+        a reference to the fetched/created object on a request.
+        """
+        return "_{}.{}".format(
+            cls._meta.app_label, cls._meta.model_name
+        ).lower()

--- a/wagtail/contrib/settings/templatetags/wagtailsettings_tags.py
+++ b/wagtail/contrib/settings/templatetags/wagtailsettings_tags.py
@@ -11,11 +11,10 @@ register = Library()
 def get_settings(context, use_default_site=False):
     if use_default_site:
         site = Site.objects.get(is_default_site=True)
+        context['settings'] = SettingsProxy(site)
     elif 'request' in context:
-        site = Site.find_for_request(context['request'])
+        context['settings'] = SettingsProxy(context['request'])
     else:
         raise RuntimeError('No request found in context, and use_default_site '
                            'flag not set')
-
-    context['settings'] = SettingsProxy(site)
     return ''

--- a/wagtail/contrib/settings/tests/base.py
+++ b/wagtail/contrib/settings/tests/base.py
@@ -1,0 +1,31 @@
+from django.http import HttpRequest
+from wagtail.core.models import Page, Site
+from wagtail.tests.testapp.models import TestSetting
+
+
+class SettingsTestMixin:
+
+    def setUp(self):
+        root = Page.objects.first()
+        other_home = Page(title='Other Root')
+        root.add_child(instance=other_home)
+
+        self.default_site = Site.objects.get(is_default_site=True)
+        self.default_site_settings = TestSetting.objects.create(
+            title='Site title',
+            email='initial@example.com',
+            site=self.default_site)
+
+        self.other_site = Site.objects.create(hostname='other', root_page=other_home)
+        self.other_site_settings = TestSetting.objects.create(
+            title='Other title',
+            email='other@other.com',
+            site=self.other_site)
+
+    def get_request(self, site=None):
+        if site is None:
+            site = self.default_site
+        request = HttpRequest()
+        request.META['HTTP_HOST'] = site.hostname
+        request.META['SERVER_PORT'] = site.port
+        return request

--- a/wagtail/contrib/settings/tests/test_model.py
+++ b/wagtail/contrib/settings/tests/test_model.py
@@ -1,0 +1,50 @@
+from django.test import TestCase, override_settings
+
+from wagtail.core.models import Site
+from wagtail.tests.testapp.models import TestSetting
+
+from .base import SettingsTestMixin
+
+
+@override_settings(ALLOWED_HOSTS=['localhost', 'other'])
+class SettingModelTestCase(SettingsTestMixin, TestCase):
+
+    def test_for_site_returns_expected_settings(self):
+        for site, expected_site_settings in (
+            (self.default_site, self.default_site_settings),
+            (self.other_site, self.other_site_settings),
+        ):
+            with self.subTest(site=site):
+                self.assertEqual(
+                    TestSetting.for_site(site),
+                    expected_site_settings
+                )
+
+    def test_for_request_returns_expected_settings(self):
+        default_site_request = self.get_request()
+        other_site_request = self.get_request(site=self.other_site)
+        for request, expected_site_settings in (
+            (default_site_request, self.default_site_settings),
+            (other_site_request, self.other_site_settings),
+        ):
+            with self.subTest(request=request):
+                self.assertEqual(
+                    TestSetting.for_request(request),
+                    expected_site_settings
+                )
+
+    def test_for_request_result_caching(self):
+        # repeat test to show caching is unique per request instance,
+        # even when the requests are for the same site
+        for i, request in enumerate(
+            [self.get_request(), self.get_request()], 1
+        ):
+            with self.subTest(attempt=i):
+
+                # force site query beforehand
+                Site.find_for_request(request)
+
+                # only the first lookup should result in a query
+                with self.assertNumQueries(1):
+                    for i in range(4):
+                        TestSetting.for_request(request)


### PR DESCRIPTION
### Rationale

I use `wagtail.contrib.settings` quite heavily. One thing I regularly use them for is to define the 'Important pages' for a site (e.g. signup terms and conditions, privacy policy, cookie policy).

It's often necessary to access these settings outside of the "Template context". For example, I may need a signup view to identify the important pages for the request, work out the URLs for the necessary pages, then pass those values to the signup form so that they can be used in field labels/help text. 

In cases like these, my only option currently is to:

- Import the `Site` model and use `Site.find_for_request()` to identify the relevant site
- Call `SettingModel.for_site()` to get/create the relevant `SettingModel` instance
- Accepting that, if my view template also references setting values from the same setting model, the query to identify the relevant settings will be repeated when rendered

But: 

- What if I could just do `SettingModel.for_request()`, and not have the added complication of identifying the site separately first?
- What if the relevant `SettingModel` object were cached in a way that would mean my template could reuse the `SettingModel` object that I'd already fetched for use in my view/elsewhere?

So, that's what I've gone for here. I know it feels like a big departure to how things are done currently, but I can only see potential benefits from a performance perspective, and it's all backwards-compatible too, for example:

- `SettingModel.for_site()` still functions exactly as it did before
- You can still use the `{% get_settings use_default_site=True %}` in cases where you know there isn't a request in the context to derive the value from
- You can still create a `SettingsProxy` using a `Site` object as the 'source value'

### TODOs

- [x] Do the tests still pass? (https://docs.wagtail.io/en/latest/contributing/developing.html#testing)
- [x] Does the code comply with the style guide? (Run `make lint` from the Wagtail root)
- [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
- [x] Has the documentation been updated accordingly?

Any feedback would be much appreciated. I haven't reviewed/amended the docs yet, but I would really love some feedback on the technical implementation here before I get any further.
