### PR TITLE
Allow select_related() to be utilised when fetching setting model objects for a site

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -24,6 +24,7 @@ Changelog
  * Replaced deprecated `ugettext` / `ungettext` calls with `gettext` / `ngettext` (Mohamed Feddad)
  * ListBlocks now call child block `bulk_to_python` if defined (Andy Chosak)
  * Site settings are now identifiable/cachable by request as well as site (Andy Babic)
+ * Added `select_related` attribute to site settings to enable more efficient fetching of foreign key values (Andy Babic)
  * Fix: Added ARIA alert role to live search forms in the admin (Casper Timmers)
  * Fix: Reorder login form elements to match expected tab order (Kjartan Sverrisson)
  * Fix: Re-add 'Close Explorer' button on mobile viewports (Sævar Öfjörð Magnússon)

--- a/docs/releases/2.9.rst
+++ b/docs/releases/2.9.rst
@@ -37,6 +37,7 @@ Other features
  * Replaced deprecated ``ugettext`` / ``ungettext`` calls with ``gettext`` / ``ngettext`` (Mohamed Feddad)
  * ListBLocks now call child block ``bulk_to_python`` if defined (Andy Chosak)
  * Site settings are now identifiable/cachable by request as well as site (Andy Babic)
+ * Added ``select_related`` attribute to site settings to enable more efficient fetching of foreign key values (Andy Babic)
 
 
 Bug fixes

--- a/wagtail/contrib/settings/models.py
+++ b/wagtail/contrib/settings/models.py
@@ -13,6 +13,10 @@ class BaseSetting(models.Model):
     :func:`~wagtail.contrib.settings.registry.register_setting`
     """
 
+    # Override to fetch ForeignKey values in the same query when
+    # retrieving settings via for_site()
+    select_related = None
+
     site = models.OneToOneField(
         Site, unique=True, db_index=True, editable=False, on_delete=models.CASCADE)
 
@@ -20,11 +24,31 @@ class BaseSetting(models.Model):
         abstract = True
 
     @classmethod
+    def base_queryset(cls):
+        """
+        Returns a queryset of objects of this type to use as a base
+        for calling get_or_create() on.
+
+        You can use the `select_related` attribute on your class to
+        specify a list of foreign key field names, which the method
+        will attempt to select additional related-object data for
+        when the query is executed.
+
+        If your needs are more complex than this, you can override
+        this method on your custom class.
+        """
+        queryset = cls.objects.all()
+        if cls.select_related is not None:
+            queryset = queryset.select_related(*cls.select_related)
+        return queryset
+
+    @classmethod
     def for_site(cls, site):
         """
         Get or create an instance of this setting for the site.
         """
-        instance, created = cls.objects.get_or_create(site=site)
+        queryset = cls.base_queryset()
+        instance, created = queryset.get_or_create(site=site)
         return instance
 
     @classmethod

--- a/wagtail/tests/testapp/migrations/0048_importantpages.py
+++ b/wagtail/tests/testapp/migrations/0048_importantpages.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('tests', '0047_restaurant_tags'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='ImportantPages',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('general_terms_page', models.ForeignKey(null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='+', to='wagtailcore.Page')),
+                ('privacy_policy_page', models.ForeignKey(null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='+', to='wagtailcore.Page')),
+                ('sign_up_page', models.ForeignKey(null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='+', to='wagtailcore.Page')),
+                ('site', models.OneToOneField(editable=False, on_delete=django.db.models.deletion.CASCADE, to='wagtailcore.Site')),
+            ],
+            options={
+                'abstract': False,
+            },
+        ),
+    ]

--- a/wagtail/tests/testapp/models.py
+++ b/wagtail/tests/testapp/models.py
@@ -1020,6 +1020,16 @@ class TestSetting(BaseSetting):
     email = models.EmailField(max_length=50)
 
 
+@register_setting
+class ImportantPages(BaseSetting):
+    sign_up_page = models.ForeignKey(
+        'wagtailcore.Page', related_name="+", null=True, on_delete=models.SET_NULL)
+    general_terms_page = models.ForeignKey(
+        'wagtailcore.Page', related_name="+", null=True, on_delete=models.SET_NULL)
+    privacy_policy_page = models.ForeignKey(
+        'wagtailcore.Page', related_name="+", null=True, on_delete=models.SET_NULL)
+
+
 @register_setting(icon="tag")
 class IconSetting(BaseSetting):
     pass


### PR DESCRIPTION
Builds on the work done in #5931 (to be merged first) to provide a convenient way to utilise select_related() when fetching setting model instances for a site/request. Simply set a list of the foreign key fields you want to be fetched to your class, and the related object data for those fields will be fetched in the same query when looking up the object, reducing the need for additional queries to access the related objects later on.

- [x] Do the tests still pass? (https://docs.wagtail.io/en/latest/contributing/developing.html#testing)
- [x] Does the code comply with the style guide? (Run `make lint` from the Wagtail root)
- [x] Have you added tests to cover the new/fixed behaviour?
- [x] Has the documentation been updated accordingly?
