### PR TITLE
Revert "Add README badges for LGTM"

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,4 @@ We thank the following organisations for their services used in Wagtail's develo
 [![License](https://img.shields.io/badge/license-BSD-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 [![Version](https://img.shields.io/pypi/v/wagtail.svg)](https://pypi.python.org/pypi/wagtail/) 
 [![Coverage](https://codecov.io/github/wagtail/wagtail/coverage.svg?branch=master)](https://codecov.io/github/wagtail/wagtail?branch=master)
-[![Total alerts](https://img.shields.io/lgtm/alerts/g/wagtail/wagtail.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/wagtail/wagtail/alerts/)
-[![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/wagtail/wagtail.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/wagtail/wagtail/context:python)
-[![Language grade: JavaScript](https://img.shields.io/lgtm/grade/javascript/g/wagtail/wagtail.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/wagtail/wagtail/context:javascript)
 [![Slack](https://wagtail-slack.now.sh/badge.svg)](https://wagtail-slack.now.sh)


### PR DESCRIPTION
Reverts wagtail/wagtail#5831

LGTM is currently generating false positive warnings on every new PR, which is a cardinal sin of any Github integration as it just encourages people to ignore legitimate warnings. Kill it with fire.