### PR TITLE
Set TreeQueryset.delete.queryset_only = True

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -40,6 +40,7 @@ Changelog
  * Fix: Added `scope` attribute to table headers in TableBlock output (Quadric)
  * Fix: Prevent KeyError when accessing a StreamField on a deferred queryset (Paulo Alvarado)
  * Fix: Hide empty 'view live' links (Karran Besen)
+ * Fix: No longer expose the ``.delete()`` method on the default Page.objects manager (Nick Smith)
 
 
 2.8 (03.02.2020)

--- a/docs/releases/2.9.rst
+++ b/docs/releases/2.9.rst
@@ -58,6 +58,7 @@ Bug fixes
  * Added ``scope`` attribute to table headers in TableBlock output (Quadric)
  * Prevent KeyError when accessing a StreamField on a deferred queryset (Paulo Alvarado)
  * Hide empty 'view live' links (Karran Besen)
+ * No longer expose the ``.delete()`` method on the default Page.objects manager (Nick Smith)
 
 
 Upgrade considerations

--- a/wagtail/core/query.py
+++ b/wagtail/core/query.py
@@ -15,6 +15,12 @@ class TreeQuerySet(MP_NodeQuerySet):
     """
     Extends Treebeard's MP_NodeQuerySet with additional useful tree-related operations.
     """
+    def delete(self):
+        """Redefine the delete method unbound, so we can set the queryset_only parameter. """
+        super().delete()
+
+    delete.queryset_only = True
+
     def descendant_of_q(self, other, inclusive=False):
         q = Q(path__startswith=other.path) & Q(depth__gte=other.depth)
 

--- a/wagtail/core/tests/test_page_queryset.py
+++ b/wagtail/core/tests/test_page_queryset.py
@@ -406,6 +406,14 @@ class TestPageQuerySet(TestCase):
 
         self.assertTrue(Page.objects.filter(query).exists())
 
+    def test_delete_queryset(self):
+        Page.objects.all().delete()
+        self.assertEqual(Page.objects.count(), 0)
+
+    def test_delete_is_not_available_on_manager(self):
+        with self.assertRaises(AttributeError):
+            Page.objects.delete()
+
 
 class TestPageQueryInSite(TestCase):
     fixtures = ['test.json']


### PR DESCRIPTION
Fixes wagtail/wagtail#5937

This reverts Wagtail's behaviour to match Django's, where an error is
raised as a safety mechanism.

Projects relying on the non-safe behaviour should update e.g.
`MyModel.objects.delete()` to `MyModel.objects.all().delete()`.

* Do the tests still pass? (https://docs.wagtail.io/en/latest/contributing/developing.html#testing) **Yes.**
* Does the code comply with the style guide? (Run `make lint` from the Wagtail root) **Yes.**
* For Python changes: Have you added tests to cover the new/fixed behaviour? **Yes.**
