### PR TITLE
Fix typo in import in reports documentation

### DIFF
--- a/docs/advanced_topics/adding_reports.rst
+++ b/docs/advanced_topics/adding_reports.rst
@@ -12,7 +12,7 @@ For this example, we'll add a report which shows any pages with unpublished chan
 
     # <project>/views.py
 
-    from wagtail.admin.views.report.ReportView
+    from wagtail.admin.views.reports import ReportView
 
 
     class UnpublishedChangesReportView(ReportView):

--- a/docs/advanced_topics/adding_reports.rst
+++ b/docs/advanced_topics/adding_reports.rst
@@ -160,14 +160,14 @@ url for the report, you will need to use the ``register_admin_urls`` hook (see :
 
     from django.conf.urls import url
 
-    from wagtail.admin.menu import MenuItem
+    from wagtail.admin.menu import AdminOnlyMenuItem
     from wagtail.core import hooks
 
     from .views import UnpublishedChangesReportView
 
     @hooks.register('register_reports_menu_item')
     def register_unpublished_changes_report_menu_item():
-        return MenuItem("Pages with unpublished changes", reverse('unpublished_changes_report'), classnames='icon icon-' + UnpublishedChangesReportView.header_icon, order=700)
+        return AdminOnlyMenuItem("Pages with unpublished changes", reverse('unpublished_changes_report'), classnames='icon icon-' + UnpublishedChangesReportView.header_icon, order=700)
     
     @hooks.register('register_admin_urls')
     def register_unpublished_changes_report_url():


### PR DESCRIPTION
Fixes one import of `ReportView` in the "Adding reports" section of the documentation