### PR TITLE
Fix/disabling workflows

### DIFF
--- a/wagtail/admin/tests/test_workflows.py
+++ b/wagtail/admin/tests/test_workflows.py
@@ -923,6 +923,8 @@ class TestDisableViews(TestCase, WagtailTestUtils):
         self.assertEqual(states.filter(status=WorkflowState.STATUS_IN_PROGRESS).count(), 0)
         self.assertEqual(states.filter(status=WorkflowState.STATUS_CANCELLED).count(), 1)
 
+        self.assertEqual(TaskState.objects.filter(workflow_state__workflow=self.workflow, status=TaskState.STATUS_IN_PROGRESS).count(), 0)
+
     def test_disable_task(self):
         """Test that deactivating a task sets it to inactive and cancels in progress states"""
         self.login(self.submitter)

--- a/wagtail/admin/views/workflows.py
+++ b/wagtail/admin/views/workflows.py
@@ -186,25 +186,6 @@ def enable_workflow(request, pk):
         return redirect('wagtailadmin_workflows:edit', workflow.id)
 
 
-class Delete(DeleteView):
-    permission_policy = workflow_permission_policy
-    model = Workflow
-    page_title = _("Delete workflow")
-    template_name = 'wagtailadmin/workflows/confirm_delete.html'
-    success_message = _("Workflow '{0}' deleted.")
-    add_url_name = 'wagtailadmin_workflows:add'
-    edit_url_name = 'wagtailadmin_workflows:edit'
-    delete_url_name = 'wagtailadmin_workflows:delete'
-    index_url_name = 'wagtailadmin_workflows:index'
-    header_icon = 'placeholder'
-
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
-        context['workflow_states_in_progress'] = WorkflowState.objects.filter(status=WorkflowState.STATUS_IN_PROGRESS).count()
-        return context
-
-
-
 @require_POST
 def remove_workflow(request, page_pk, workflow_pk=None):
     # Remove a workflow from a page (specifically a single workflow if workflow_pk is set)

--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -2741,6 +2741,9 @@ class WorkflowState(models.Model):
     def update(self, user=None, next_task=None):
         """Checks the status of the current task, and progresses (or ends) the workflow if appropriate. If the workflow progresses,
         next_task will be used to start a specific task next if provided."""
+        if self.status != self.STATUS_IN_PROGRESS:
+            # Updating a completed or cancelled workflow should have no effect
+            return
         try:
             current_status = self.current_task_state.status
         except AttributeError:
@@ -2784,6 +2787,9 @@ class WorkflowState(models.Model):
             raise PermissionDenied
         self.status = self.STATUS_CANCELLED
         self.save()
+        for state in self.task_states.filter(status=TaskState.STATUS_IN_PROGRESS):
+            # Cancel all in progress task states
+            state.specific.cancel(user=user)
         workflow_cancelled.send(sender=self.__class__, instance=self, user=user)
 
     @transaction.atomic


### PR DESCRIPTION
Previously when disabled via the settings menu, workflow states would not cancel in progress task states associated with them. This could lead to awkward situations in which pages would be in progress on tasks in cancelled and inactive workflows. This PR resolves this issue, as well as removing dead code from workflow views.
