### PR TITLE
Remove sticky footer on small devices

### DIFF
--- a/client/scss/components/_footer.scss
+++ b/client/scss/components/_footer.scss
@@ -4,12 +4,8 @@ footer {
     border-radius: 3px 3px 0 0;
     box-shadow: 0 0 2px rgba(255, 255, 255, 0.5);
     background: $color-grey-1;
-    position: fixed;
-    bottom: 0;
-    padding: 0.5em;
-    width: 90%;
-    margin: 0 5%;
     color: $color-white;
+    margin-top: $mobile-nice-padding;
 
     ul {
         @include unlist();
@@ -72,5 +68,8 @@ footer {
         margin-left: $desktop-nice-padding;
         margin-right: $desktop-nice-padding;
         width: calc(100% - #{$menu-width} - #{2 * $desktop-nice-padding});
+        position: fixed;
+        bottom: 0;
+        padding: 0.5em;
     }
 }

--- a/client/scss/components/_grid.legacy.scss
+++ b/client/scss/components/_grid.legacy.scss
@@ -19,8 +19,11 @@
     background: $color-white;
     border-top: 0 solid $color-grey-5; // this top border provides space for the floating logo to toggle the menu
     min-height: 100%;
-    padding-bottom: 4em;
     position: relative; // yuk. necessary for positions for jquery ui widgets
+
+    @include media-breakpoint-up(sm) {
+        padding-bottom: 4em;
+    }
 }
 
 @include media-breakpoint-up(sm) {


### PR DESCRIPTION
The default layout is the mobile one and “up from mobile” gets the overlap added.

Result:
![localhost_8000_admin_pages_34_edit_(iPhone 6_7_8)](https://user-images.githubusercontent.com/29326549/79008856-83264400-7b73-11ea-87c3-d0d780b81257.png)
![localhost_8000_admin_pages_34_edit_(iPhone 6_7_8) (1)](https://user-images.githubusercontent.com/29326549/79008864-87526180-7b73-11ea-8294-d8611006b246.png)

Fixes #4641