### PR TITLE
Switch order of hook injected css in admin_base.html

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/admin_base.html
+++ b/wagtail/admin/templates/wagtailadmin/admin_base.html
@@ -5,9 +5,11 @@
     <link rel="stylesheet" href="{% versioned_static 'wagtailadmin/css/vendor/jquery-ui/jquery-ui-1.10.3.verdant.css' %}" />
     <link rel="stylesheet" href="{% versioned_static 'wagtailadmin/css/vendor/jquery.tagit.css' %}">
     <link rel="stylesheet" href="{% versioned_static 'wagtailadmin/css/core.css' %}" type="text/css" />
-    {% hook_output 'insert_global_admin_css' %}
 
     {% block extra_css %}{% endblock %}
+
+    {% hook_output 'insert_global_admin_css' %}
+
 {% endblock %}
 
 {% block branding_favicon %}


### PR DESCRIPTION
When trying to fully skin the admin login pages I noticed that the
`login.css` file is injected via `{% block extra_css %}` which exists
below the `{% hook_output 'insert_global_admin_css' %}`. This means
that any customization to the login / password_reset pages will need
to create a `.html` file with their own `{% block extra_css %}` to
override colors and styles rather than just relying on the hook
to inject custom styles.
