### PR TITLE
Filtering for locked page report

### DIFF
--- a/client/scss/components/_button-select.scss
+++ b/client/scss/components/_button-select.scss
@@ -1,0 +1,21 @@
+.button-select {
+    &__option {
+        display: block;
+        width: 100%;
+        margin-bottom: 10px;
+
+        background-color: #fff;
+        border-color: $color-teal;
+        color: #262626;
+
+        &--selected {
+            background-color: $color-teal;
+            color: #fff;
+        }
+    }
+}
+
+.button-select .button-select__option {
+    /* override default margin from horizontally-aligned buttons */
+    margin-left: 0;
+}

--- a/client/scss/styles.scss
+++ b/client/scss/styles.scss
@@ -128,6 +128,7 @@ These are classes for components.
 @import 'components/link.legacy';
 @import 'components/privacy-indicator';
 @import 'components/status-tag';
+@import 'components/button-select';
 
 
 /* OVERRIDES

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ install_requires = [
     "django-taggit>=1.0,<2.0",
     "django-treebeard>=4.2.0,<5.0",
     "djangorestframework>=3.7.4,<4.0",
+    "django-filter>=2.2,<3.0",
     "draftjs_exporter>=2.1.5,<3.0",
     "Pillow>=4.0.0,<8.0.0",
     "beautifulsoup4>=4.8,<4.9",

--- a/wagtail/admin/filters.py
+++ b/wagtail/admin/filters.py
@@ -1,0 +1,31 @@
+import django_filters
+from django import forms
+from django.utils.translation import gettext_lazy as _
+
+from wagtail.core.models import Page
+
+
+class ButtonSelect(forms.Select):
+    input_type = 'hidden'
+    template_name = 'wagtailadmin/widgets/button_select.html'
+    option_template_name = 'wagtailadmin/widgets/button_select_option.html'
+
+
+class WagtailFilterSet(django_filters.FilterSet):
+
+    @classmethod
+    def filter_for_lookup(cls, field, lookup_type):
+        filter_class, params = super().filter_for_lookup(field, lookup_type)
+
+        if filter_class == django_filters.ChoiceFilter:
+            params.setdefault('widget', ButtonSelect)
+            params.setdefault('empty_label', _("All"))
+
+        return filter_class, params
+
+
+class LockedPagesReportFilterSet(WagtailFilterSet):
+
+    class Meta:
+        model = Page
+        fields = ['title', 'locked_by', 'locked_at']

--- a/wagtail/admin/filters.py
+++ b/wagtail/admin/filters.py
@@ -9,12 +9,18 @@ from .widgets import AdminDateInput
 
 
 class ButtonSelect(forms.Select):
+    """
+    A select widget for fields with choices. Displays as a list of buttons.
+    """
     input_type = 'hidden'
     template_name = 'wagtailadmin/widgets/button_select.html'
     option_template_name = 'wagtailadmin/widgets/button_select_option.html'
 
 
 class BooleanButtonSelect(ButtonSelect):
+    """
+    A select widget for boolean fields. Displays as three buttons. "All", "Yes" and "No".
+    """
     def __init__(self, attrs=None):
         choices = (
             ('', _("All")),
@@ -45,6 +51,9 @@ class BooleanButtonSelect(ButtonSelect):
 
 
 class DateRangePickerWidget(SuffixedMultiWidget):
+    """
+    A widget allowing a start and end date to be picked.
+    """
     template_name = 'wagtailadmin/widgets/daterange_input.html'
     suffixes = ['after', 'before']
 

--- a/wagtail/admin/filters.py
+++ b/wagtail/admin/filters.py
@@ -14,6 +14,36 @@ class ButtonSelect(forms.Select):
     option_template_name = 'wagtailadmin/widgets/button_select_option.html'
 
 
+class BooleanButtonSelect(ButtonSelect):
+    def __init__(self, attrs=None):
+        choices = (
+            ('', _("All")),
+            ('true', _("Yes")),
+            ('false', _("No")),
+        )
+        super().__init__(attrs, choices)
+
+    def format_value(self, value):
+        try:
+            return {
+                True: ['true'], False: ['false'],
+                'true': ['true'], 'false': ['false'],
+            }[value]
+        except KeyError:
+            return ''
+
+    def value_from_datadict(self, data, files, name):
+        value = data.get(name)
+        return {
+            True: True,
+            'True': True,
+            'False': False,
+            False: False,
+            'true': True,
+            'false': False,
+        }.get(value)
+
+
 class DateRangePickerWidget(SuffixedMultiWidget):
     template_name = 'wagtailadmin/widgets/daterange_input.html'
     suffixes = ['after', 'before']
@@ -44,6 +74,9 @@ class WagtailFilterSet(django_filters.FilterSet):
         elif filter_class == django_filters.DateFromToRangeFilter:
             params.setdefault('widget', DateRangePickerWidget)
 
+        elif filter_class == django_filters.BooleanFilter:
+            params.setdefault('widget', BooleanButtonSelect)
+
         return filter_class, params
 
 
@@ -52,4 +85,4 @@ class LockedPagesReportFilterSet(WagtailFilterSet):
 
     class Meta:
         model = Page
-        fields = ['locked_by', 'locked_at']
+        fields = ['locked_by', 'locked_at', 'live']

--- a/wagtail/admin/filters.py
+++ b/wagtail/admin/filters.py
@@ -1,14 +1,31 @@
 import django_filters
 from django import forms
 from django.utils.translation import gettext_lazy as _
+from django_filters.widgets import SuffixedMultiWidget
 
 from wagtail.core.models import Page
+
+from .widgets import AdminDateInput
 
 
 class ButtonSelect(forms.Select):
     input_type = 'hidden'
     template_name = 'wagtailadmin/widgets/button_select.html'
     option_template_name = 'wagtailadmin/widgets/button_select_option.html'
+
+
+class DateRangePickerWidget(SuffixedMultiWidget):
+    template_name = 'wagtailadmin/widgets/daterange_input.html'
+    suffixes = ['after', 'before']
+
+    def __init__(self, attrs=None):
+        widgets = (AdminDateInput(attrs={'placeholder': _("Date from")}), AdminDateInput(attrs={'placeholder': _("Date to")}))
+        super().__init__(widgets, attrs)
+
+    def decompress(self, value):
+        if value:
+            return [value.start, value.stop]
+        return [None, None]
 
 
 class WagtailFilterSet(django_filters.FilterSet):
@@ -21,11 +38,18 @@ class WagtailFilterSet(django_filters.FilterSet):
             params.setdefault('widget', ButtonSelect)
             params.setdefault('empty_label', _("All"))
 
+        elif filter_class in [django_filters.DateFilter, django_filters.DateTimeFilter]:
+            params.setdefault('widget', AdminDateInput)
+
+        elif filter_class == django_filters.DateFromToRangeFilter:
+            params.setdefault('widget', DateRangePickerWidget)
+
         return filter_class, params
 
 
 class LockedPagesReportFilterSet(WagtailFilterSet):
+    locked_at = django_filters.DateFromToRangeFilter(widget=DateRangePickerWidget)
 
     class Meta:
         model = Page
-        fields = ['title', 'locked_by', 'locked_at']
+        fields = ['locked_by', 'locked_at']

--- a/wagtail/admin/static_src/wagtailadmin/js/core.js
+++ b/wagtail/admin/static_src/wagtailadmin/js/core.js
@@ -538,6 +538,28 @@ wagtail = (function(document, window, wagtail) {
     $(document).ready(initDropDowns);
     wagtail.ui.initDropDowns = initDropDowns;
     wagtail.ui.DropDownController = DropDownController;
+
+    // Initialise button selectors
+    function initButtonSelects() {
+        document.querySelectorAll('.button-select').forEach(function(element) {
+            var inputElement = element.querySelector('input[type="hidden"]');
+            element.querySelectorAll('.button-select__option').forEach(function(buttonElement) {
+                buttonElement.addEventListener('click', function(e) {
+                    e.preventDefault();
+                    inputElement.value = buttonElement.value;
+
+                    element.querySelectorAll('.button-select__option--selected').forEach(function(selectedButtonElement) {
+                        selectedButtonElement.classList.remove('button-select__option--selected');
+                    });
+
+                    buttonElement.classList.add('button-select__option--selected');
+                });
+            });
+        });
+    }
+
+    $(document).ready(initButtonSelects);
+
     return wagtail;
 
 })(document, window, wagtail);

--- a/wagtail/admin/static_src/wagtailadmin/scss/layouts/report.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/layouts/report.scss
@@ -20,4 +20,10 @@
             margin-top: 20px;
         }
     }
+
+    &__actions > div {
+        float: right;
+        display: block;
+        margin-right: 10px;
+    }
 }

--- a/wagtail/admin/static_src/wagtailadmin/scss/layouts/report.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/layouts/report.scss
@@ -1,0 +1,23 @@
+.report {
+    display: grid;
+    grid-template-columns: auto;
+    grid-column-gap: 50px;
+    margin-left: 50px;
+    margin-right: 50px;
+
+    &--has-filters {
+        grid-template-columns: auto 300px;
+    }
+
+    &__results {
+        grid-column-start: col-start 1 col-end 2;
+    }
+
+    &__filters {
+        grid-column-start: col-start -2 col-end -1;
+
+        button[type='submit'] {
+            margin-top: 20px;
+        }
+    }
+}

--- a/wagtail/admin/templates/wagtailadmin/reports/base_report.html
+++ b/wagtail/admin/templates/wagtailadmin/reports/base_report.html
@@ -15,10 +15,10 @@
                 {% block actions %}
                     {% if view.list_export %}
                         <div class="dropdown dropdown-button match-width">
-                            <a href="?export=xlsx" class="button bicolor icon icon-download">{% trans 'Download XLSX' %}</a>
+                            <a href="{{ view.xlsx_export_url }}" class="button bicolor icon icon-download">{% trans 'Download XLSX' %}</a>
                             <div class="dropdown-toggle icon icon-arrow-down"></div>
                             <ul>
-                                <li><a  class="button bicolor icon icon-download" href="?export=csv">{% trans 'Download CSV' %}</a></li>
+                                <li><a  class="button bicolor icon icon-download" href="{{ view.csv_export_url }}">{% trans 'Download CSV' %}</a></li>
                             </ul>
                         </div>
                     {% endif %}

--- a/wagtail/admin/templates/wagtailadmin/reports/base_report.html
+++ b/wagtail/admin/templates/wagtailadmin/reports/base_report.html
@@ -50,4 +50,10 @@
 
 {% block extra_css %}
     <link rel="stylesheet" href="{% versioned_static 'wagtailadmin/css/layouts/report.css' %}" type="text/css" />
+
+    {{ filters.form.media.css }}
+{% endblock %}
+
+{% block extra_js %}
+    {{ filters.form.media.js }}
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/reports/base_report.html
+++ b/wagtail/admin/templates/wagtailadmin/reports/base_report.html
@@ -27,8 +27,27 @@
         </div>
     </header>
 
-    <div class="nice-padding">
-        {% block results %}
-        {% endblock %}
+    <div class="report{% if filters %} report--has-filters{% endif %}">
+        <div class="report__results">
+            {% block results %}
+            {% endblock %}
+        </div>
+        {% if filters %}
+            <div class="report__filters">
+                <h2>{% trans 'Filter' %}</h2>
+                <form method="get">
+                    {% for filter in filters.form %}
+                        {{ filter.label_tag }}
+                        {{ filter }}
+                        {{ filter.errors }}
+                    {% endfor %}
+                    <button class="button button-longrunning" type="submit">{% trans 'Apply filters' %}</button>
+                </form>
+            </div>
+        {% endif %}
     </div>
+{% endblock %}
+
+{% block extra_css %}
+    <link rel="stylesheet" href="{% versioned_static 'wagtailadmin/css/layouts/report.css' %}" type="text/css" />
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/reports/base_report.html
+++ b/wagtail/admin/templates/wagtailadmin/reports/base_report.html
@@ -11,7 +11,7 @@
                     <h1 class="icon icon-{{ header_icon }}">{{ title }}{% if subtitle %} <span>{{ subtitle }}</span>{% endif %}</h1>
                 </div>
             </div>
-            <div class="right">
+            <div class="right report__actions">
                 {% block actions %}
                     {% if view.list_export %}
                         <div class="dropdown dropdown-button match-width">

--- a/wagtail/admin/templates/wagtailadmin/widgets/button_select.html
+++ b/wagtail/admin/templates/wagtailadmin/widgets/button_select.html
@@ -1,0 +1,12 @@
+<div class="button-select">
+    <input type="hidden" name="{{ widget.name }}" value="{{ widget.value.0 }}" {% include "django/forms/widgets/attrs.html" %}>
+
+    {% for group_name, group_choices, group_index in widget.optgroups %}
+        {% if group_name %}
+            <h4>{{ group_name }}</h4>
+        {% endif %}
+        {% for option in group_choices %}
+            {% include option.template_name with widget=option %}
+        {% endfor %}
+    {% endfor %}
+</div>

--- a/wagtail/admin/templates/wagtailadmin/widgets/button_select_option.html
+++ b/wagtail/admin/templates/wagtailadmin/widgets/button_select_option.html
@@ -1,0 +1,1 @@
+<button class="button button-select__option{% if widget.attrs.selected %} button-select__option--selected{% endif %}" value="{{ widget.value|stringformat:'s' }}">{{ widget.label }}</button>

--- a/wagtail/admin/templates/wagtailadmin/widgets/daterange_input.html
+++ b/wagtail/admin/templates/wagtailadmin/widgets/daterange_input.html
@@ -1,0 +1,1 @@
+{% for widget in widget.subwidgets %}{% include widget.template_name %}{% endfor %}


### PR DESCRIPTION
Allow the locked pages report to be filtered by 'locked at', 'locked by' and 'is live'.

Split out from #5940, to cover the parts of report filtering that do not depend on the workflow branch. Incorporates #5954.