### PR TITLE
Implement autocomplete API for PostgreSQL

### DIFF
--- a/wagtail/contrib/postgres_search/query.py
+++ b/wagtail/contrib/postgres_search/query.py
@@ -114,7 +114,7 @@ class RawSearchQuery(SearchQueryCombinable, Expression):
         if self.config:
             config_sql, config_params = compiler.compile(self.config)
             template = 'to_tsquery({}::regconfig, {})'.format(config_sql, sql)
-            params = params + config_params
+            params = config_params + params
         else:
             template = 'to_tsquery({})'.format(sql)
         if self.invert:

--- a/wagtail/search/tests/elasticsearch_common_tests.py
+++ b/wagtail/search/tests/elasticsearch_common_tests.py
@@ -191,3 +191,8 @@ class ElasticsearchCommonSearchBackendTests(BackendTests):
     @unittest.expectedFailure
     def test_incomplete_plain_text(self):
         super().test_incomplete_plain_text()
+
+    # Elasticsearch does not support 'fields' arguments on autocomplete queries
+    @unittest.expectedFailure
+    def test_autocomplete_with_fields_arg(self):
+        super().test_autocomplete_with_fields_arg()

--- a/wagtail/search/tests/test_backends.py
+++ b/wagtail/search/tests/test_backends.py
@@ -187,6 +187,7 @@ class BackendTests(WagtailTestUtils):
             "Learning Python",
         ])
 
+    def test_autocomplete_uses_autocompletefield(self):
         # Autocomplete should only require an AutocompleteField, not a SearchField with
         # partial_match=True
         results = self.backend.autocomplete("Georg", models.Author)
@@ -194,6 +195,7 @@ class BackendTests(WagtailTestUtils):
             "George R.R. Martin",
         ])
 
+    def test_autocomplete_with_fields_arg(self):
         results = self.backend.autocomplete("Georg", models.Author, fields=['name'])
         self.assertUnsortedListEqual([r.name for r in results], [
             "George R.R. Martin",

--- a/wagtail/search/tests/test_backends.py
+++ b/wagtail/search/tests/test_backends.py
@@ -187,6 +187,18 @@ class BackendTests(WagtailTestUtils):
             "Learning Python",
         ])
 
+        # Autocomplete should only require an AutocompleteField, not a SearchField with
+        # partial_match=True
+        results = self.backend.autocomplete("Georg", models.Author)
+        self.assertUnsortedListEqual([r.name for r in results], [
+            "George R.R. Martin",
+        ])
+
+        results = self.backend.autocomplete("Georg", models.Author, fields=['name'])
+        self.assertUnsortedListEqual([r.name for r in results], [
+            "George R.R. Martin",
+        ])
+
     def test_autocomplete_not_affected_by_stemming(self):
         # If SEARCH_CONFIG is set, stemming will be enabled.
         # But we want to disable this for autocomplete as stemmed words don't always match on prefixes

--- a/wagtail/search/tests/test_backends.py
+++ b/wagtail/search/tests/test_backends.py
@@ -187,6 +187,16 @@ class BackendTests(WagtailTestUtils):
             "Learning Python",
         ])
 
+    def test_autocomplete_not_affected_by_stemming(self):
+        # If SEARCH_CONFIG is set, stemming will be enabled.
+        # But we want to disable this for autocomplete as stemmed words don't always match on prefixes
+        # See: https://www.postgresql.org/docs/9.1/datatype-textsearch.html#DATATYPE-TSQUERY
+        results = self.backend.autocomplete("Learni", models.Book)
+
+        self.assertUnsortedListEqual([r.title for r in results], [
+            "Learning Python",
+        ])
+
     # FILTERING TESTS
 
     def test_filter_exact_value(self):

--- a/wagtail/search/tests/test_db_backend.py
+++ b/wagtail/search/tests/test_db_backend.py
@@ -13,6 +13,11 @@ class TestDBBackend(BackendTests, TestCase):
     def test_autocomplete(self):
         super().test_autocomplete()
 
+    # Doesn't support autocomplete
+    @unittest.expectedFailure
+    def test_autocomplete_not_affected_by_stemming(self):
+        super().test_autocomplete_not_affected_by_stemming()
+
     # Doesn't support ranking
     @unittest.expectedFailure
     def test_ranking(self):

--- a/wagtail/search/tests/test_db_backend.py
+++ b/wagtail/search/tests/test_db_backend.py
@@ -18,6 +18,16 @@ class TestDBBackend(BackendTests, TestCase):
     def test_autocomplete_not_affected_by_stemming(self):
         super().test_autocomplete_not_affected_by_stemming()
 
+    # Doesn't support autocomplete
+    @unittest.expectedFailure
+    def test_autocomplete_uses_autocompletefield(self):
+        super().test_autocomplete_uses_autocompletefield()
+
+    # Doesn't support autocomplete
+    @unittest.expectedFailure
+    def test_autocomplete_with_fields_arg(self):
+        super().test_autocomplete_with_fields_arg()
+
     # Doesn't support ranking
     @unittest.expectedFailure
     def test_ranking(self):

--- a/wagtail/search/tests/test_elasticsearch2_backend.py
+++ b/wagtail/search/tests/test_elasticsearch2_backend.py
@@ -544,6 +544,7 @@ class TestElasticsearch2Mapping(TestCase):
                         'type': 'nested',
                         'properties': {
                             'name': {'type': 'string', 'include_in_all': True},
+                            'name_edgengrams': {'analyzer': 'edgengram_analyzer', 'include_in_all': False, 'search_analyzer': 'standard', 'type': 'string'},
                             'date_of_birth_filter': {'index': 'not_analyzed', 'type': 'date', 'include_in_all': False},
                         },
                     },
@@ -579,13 +580,14 @@ class TestElasticsearch2Mapping(TestCase):
         expected_result = {
             'pk': '4',
             'content_type': ["searchtests.Book"],
-            '_partials': ['The Fellowship of the Ring', 'The Fellowship of the Ring'],
+            '_partials': ['J. R. R. Tolkien', 'The Fellowship of the Ring', 'The Fellowship of the Ring'],
             'title': 'The Fellowship of the Ring',
             'title_edgengrams': 'The Fellowship of the Ring',
             'title_filter': 'The Fellowship of the Ring',
             'authors': [
                 {
                     'name': 'J. R. R. Tolkien',
+                    'name_edgengrams': 'J. R. R. Tolkien',
                     'date_of_birth_filter': datetime.date(1892, 1, 3)
                 }
             ],
@@ -653,6 +655,7 @@ class TestElasticsearch2MappingInheritance(TestCase):
                         'type': 'nested',
                         'properties': {
                             'name': {'type': 'string', 'include_in_all': True},
+                            'name_edgengrams': {'analyzer': 'edgengram_analyzer', 'include_in_all': False, 'search_analyzer': 'standard', 'type': 'string'},
                             'date_of_birth_filter': {'index': 'not_analyzed', 'type': 'date', 'include_in_all': False},
                         },
                     },
@@ -714,7 +717,7 @@ class TestElasticsearch2MappingInheritance(TestCase):
 
             # Changed
             'content_type': ["searchtests.Novel", "searchtests.Book"],
-            '_partials': ['Middle Earth', 'The Fellowship of the Ring', 'The Fellowship of the Ring'],
+            '_partials': ['J. R. R. Tolkien', 'Middle Earth', 'The Fellowship of the Ring', 'The Fellowship of the Ring'],
 
             # Inherited
             'pk': '4',
@@ -724,6 +727,7 @@ class TestElasticsearch2MappingInheritance(TestCase):
             'authors': [
                 {
                     'name': 'J. R. R. Tolkien',
+                    'name_edgengrams': 'J. R. R. Tolkien',
                     'date_of_birth_filter': datetime.date(1892, 1, 3)
                 }
             ],

--- a/wagtail/search/tests/test_elasticsearch5_backend.py
+++ b/wagtail/search/tests/test_elasticsearch5_backend.py
@@ -545,6 +545,7 @@ class TestElasticsearch5Mapping(TestCase):
                         'type': 'nested',
                         'properties': {
                             'name': {'type': 'text', 'include_in_all': True},
+                            'name_edgengrams': {'analyzer': 'edgengram_analyzer', 'include_in_all': False, 'search_analyzer': 'standard', 'type': 'text'},
                             'date_of_birth_filter': {'type': 'date', 'include_in_all': False},
                         },
                     },
@@ -580,13 +581,14 @@ class TestElasticsearch5Mapping(TestCase):
         expected_result = {
             'pk': '4',
             'content_type': ["searchtests.Book"],
-            '_partials': ['The Fellowship of the Ring', 'The Fellowship of the Ring'],
+            '_partials': ['J. R. R. Tolkien', 'The Fellowship of the Ring', 'The Fellowship of the Ring'],
             'title': 'The Fellowship of the Ring',
             'title_edgengrams': 'The Fellowship of the Ring',
             'title_filter': 'The Fellowship of the Ring',
             'authors': [
                 {
                     'name': 'J. R. R. Tolkien',
+                    'name_edgengrams': 'J. R. R. Tolkien',
                     'date_of_birth_filter': datetime.date(1892, 1, 3)
                 }
             ],
@@ -654,6 +656,7 @@ class TestElasticsearch5MappingInheritance(TestCase):
                         'type': 'nested',
                         'properties': {
                             'name': {'type': 'text', 'include_in_all': True},
+                            'name_edgengrams': {'analyzer': 'edgengram_analyzer', 'include_in_all': False, 'search_analyzer': 'standard', 'type': 'text'},
                             'date_of_birth_filter': {'type': 'date', 'include_in_all': False},
                         },
                     },
@@ -715,7 +718,7 @@ class TestElasticsearch5MappingInheritance(TestCase):
 
             # Changed
             'content_type': ["searchtests.Novel", "searchtests.Book"],
-            '_partials': ['Middle Earth', 'The Fellowship of the Ring', 'The Fellowship of the Ring'],
+            '_partials': ['J. R. R. Tolkien', 'Middle Earth', 'The Fellowship of the Ring', 'The Fellowship of the Ring'],
 
             # Inherited
             'pk': '4',
@@ -725,6 +728,7 @@ class TestElasticsearch5MappingInheritance(TestCase):
             'authors': [
                 {
                     'name': 'J. R. R. Tolkien',
+                    'name_edgengrams': 'J. R. R. Tolkien',
                     'date_of_birth_filter': datetime.date(1892, 1, 3)
                 }
             ],

--- a/wagtail/search/tests/test_elasticsearch6_backend.py
+++ b/wagtail/search/tests/test_elasticsearch6_backend.py
@@ -546,6 +546,7 @@ class TestElasticsearch6Mapping(TestCase):
                         'type': 'nested',
                         'properties': {
                             'name': {'type': 'text', 'copy_to': '_all_text'},
+                            'name_edgengrams': {'analyzer': 'edgengram_analyzer', 'search_analyzer': 'standard', 'type': 'text'},
                             'date_of_birth_filter': {'type': 'date'},
                         },
                     },
@@ -581,13 +582,14 @@ class TestElasticsearch6Mapping(TestCase):
         expected_result = {
             'pk': '4',
             'content_type': ["searchtests.Book"],
-            '_edgengrams': ['The Fellowship of the Ring', 'The Fellowship of the Ring'],
+            '_edgengrams': ['J. R. R. Tolkien', 'The Fellowship of the Ring', 'The Fellowship of the Ring'],
             'title': 'The Fellowship of the Ring',
             'title_edgengrams': 'The Fellowship of the Ring',
             'title_filter': 'The Fellowship of the Ring',
             'authors': [
                 {
                     'name': 'J. R. R. Tolkien',
+                    'name_edgengrams': 'J. R. R. Tolkien',
                     'date_of_birth_filter': datetime.date(1892, 1, 3)
                 }
             ],
@@ -656,6 +658,7 @@ class TestElasticsearch6MappingInheritance(TestCase):
                         'type': 'nested',
                         'properties': {
                             'name': {'type': 'text', 'copy_to': '_all_text'},
+                            'name_edgengrams': {'analyzer': 'edgengram_analyzer', 'search_analyzer': 'standard', 'type': 'text'},
                             'date_of_birth_filter': {'type': 'date'},
                         },
                     },
@@ -717,7 +720,7 @@ class TestElasticsearch6MappingInheritance(TestCase):
 
             # Changed
             'content_type': ["searchtests.Novel", "searchtests.Book"],
-            '_edgengrams': ['Middle Earth', 'The Fellowship of the Ring', 'The Fellowship of the Ring'],
+            '_edgengrams': ['J. R. R. Tolkien', 'Middle Earth', 'The Fellowship of the Ring', 'The Fellowship of the Ring'],
 
             # Inherited
             'pk': '4',
@@ -727,6 +730,7 @@ class TestElasticsearch6MappingInheritance(TestCase):
             'authors': [
                 {
                     'name': 'J. R. R. Tolkien',
+                    'name_edgengrams': 'J. R. R. Tolkien',
                     'date_of_birth_filter': datetime.date(1892, 1, 3)
                 }
             ],

--- a/wagtail/search/tests/test_elasticsearch7_backend.py
+++ b/wagtail/search/tests/test_elasticsearch7_backend.py
@@ -545,6 +545,7 @@ class TestElasticsearch7Mapping(TestCase):
                     'type': 'nested',
                     'properties': {
                         'name': {'type': 'text', 'copy_to': '_all_text'},
+                        'name_edgengrams': {'analyzer': 'edgengram_analyzer', 'search_analyzer': 'standard', 'type': 'text'},
                         'date_of_birth_filter': {'type': 'date'},
                     },
                 },
@@ -579,13 +580,14 @@ class TestElasticsearch7Mapping(TestCase):
         expected_result = {
             'pk': '4',
             'content_type': ["searchtests.Book"],
-            '_edgengrams': ['The Fellowship of the Ring', 'The Fellowship of the Ring'],
+            '_edgengrams': ['J. R. R. Tolkien', 'The Fellowship of the Ring', 'The Fellowship of the Ring'],
             'title': 'The Fellowship of the Ring',
             'title_edgengrams': 'The Fellowship of the Ring',
             'title_filter': 'The Fellowship of the Ring',
             'authors': [
                 {
                     'name': 'J. R. R. Tolkien',
+                    'name_edgengrams': 'J. R. R. Tolkien',
                     'date_of_birth_filter': datetime.date(1892, 1, 3)
                 }
             ],
@@ -653,6 +655,7 @@ class TestElasticsearch7MappingInheritance(TestCase):
                     'type': 'nested',
                     'properties': {
                         'name': {'type': 'text', 'copy_to': '_all_text'},
+                        'name_edgengrams': {'analyzer': 'edgengram_analyzer', 'search_analyzer': 'standard', 'type': 'text'},
                         'date_of_birth_filter': {'type': 'date'},
                     },
                 },
@@ -713,7 +716,7 @@ class TestElasticsearch7MappingInheritance(TestCase):
 
             # Changed
             'content_type': ["searchtests.Novel", "searchtests.Book"],
-            '_edgengrams': ['Middle Earth', 'The Fellowship of the Ring', 'The Fellowship of the Ring'],
+            '_edgengrams': ['J. R. R. Tolkien', 'Middle Earth', 'The Fellowship of the Ring', 'The Fellowship of the Ring'],
 
             # Inherited
             'pk': '4',
@@ -723,6 +726,7 @@ class TestElasticsearch7MappingInheritance(TestCase):
             'authors': [
                 {
                     'name': 'J. R. R. Tolkien',
+                    'name_edgengrams': 'J. R. R. Tolkien',
                     'date_of_birth_filter': datetime.date(1892, 1, 3)
                 }
             ],

--- a/wagtail/tests/search/models.py
+++ b/wagtail/tests/search/models.py
@@ -10,6 +10,7 @@ class Author(index.Indexed, models.Model):
 
     search_fields = [
         index.SearchField('name'),
+        index.AutocompleteField('name'),
         index.FilterField('date_of_birth'),
     ]
 

--- a/wagtail/tests/settings.py
+++ b/wagtail/tests/settings.py
@@ -171,6 +171,7 @@ if os.environ.get('DATABASE_ENGINE') == 'django.db.backends.postgresql':
     WAGTAILSEARCH_BACKENDS['postgresql'] = {
         'BACKEND': 'wagtail.contrib.postgres_search.backend',
         'AUTO_UPDATE': False,
+        'SEARCH_CONFIG': 'english'
     }
 
 if 'ELASTICSEARCH_URL' in os.environ:


### PR DESCRIPTION
This PR finishes the implementation of the autocomplete API ([RFC 27](https://github.com/wagtail/rfcs/blob/master/text/027-autocomplete.md)) for PostgreSQL.