### PR TITLE
Fix draft view when preview modes are disabled

### DIFF
--- a/wagtail/admin/tests/pages/test_preview.py
+++ b/wagtail/admin/tests/pages/test_preview.py
@@ -213,3 +213,11 @@ class TestDisablePreviewButton(TestCase, WagtailTestUtils):
         preview_url = reverse('wagtailadmin_pages:preview_on_edit', args=(stream_page.id, ))
         self.assertNotContains(response, '<li class="preview">')
         self.assertNotContains(response, 'data-action="%s"' % preview_url)
+
+    def test_view_draft_with_disabled_preview_modes(self):
+        stream_page = StreamPage(title='stream page', body=[('text', 'hello')])
+        self.root_page.add_child(instance=stream_page)
+
+        # Check that we can still access the page draft when preview modes have been disabled
+        response = self.client.get(reverse('wagtailadmin_pages:view_draft', args=(stream_page.id,)))
+        self.assertEqual(response.status_code, 200)

--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -1395,7 +1395,10 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
 
     @property
     def default_preview_mode(self):
-        return self.preview_modes[0][0]
+        try:
+            return self.preview_modes[0][0]
+        except IndexError:
+            return None
 
     def serve_preview(self, request, mode_name):
         """

--- a/wagtail/tests/testapp/templates/tests/stream_page.html
+++ b/wagtail/tests/testapp/templates/tests/stream_page.html
@@ -1,0 +1,5 @@
+{% extends "tests/base.html" %}
+
+{% block content %}
+    <h2>Stream page</h2>
+{% endblock %}


### PR DESCRIPTION
Ref: #5670

View draft uses `page.make_preview_request(request, page.default_preview_mode)`, as does viewing a revision

This PR fixes `default_preview_mode` to fall gracefully to returning `None` when no preview modes are defined

* Do the tests still pass? (https://docs.wagtail.io/en/latest/contributing/developing.html#testing) ✅
* Does the code comply with the style guide? (Run `make lint` from the Wagtail root) ✅
* For Python changes: Have you added tests to cover the new/fixed behaviour? ✅
* For front-end changes: Did you test on all of Wagtail’s supported browsers? **Please list the exact versions you tested**. N/A
* For new features: Has the documentation been updated accordingly? N/A
