### PR TITLE
Hide preview / view draft buttons throughout admin UI when preview_modes is empty

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/home/locked_pages.html
+++ b/wagtail/admin/templates/wagtailadmin/home/locked_pages.html
@@ -28,7 +28,7 @@
                                 </div>
                                 <ul class="actions">
                                     <li><a href="{% url 'wagtailadmin_pages:edit' page.id %}" class="button button-small button-secondary">{% trans "Edit" %}</a></li>
-                                    {% if page.has_unpublished_changes %}
+                                    {% if page.has_unpublished_changes and page.is_previewable %}
                                         <li><a href="{% url 'wagtailadmin_pages:view_draft' page.id %}" class="button button-small button-secondary" target="_blank" rel="noopener noreferrer">{% trans 'Draft' %}</a></li>
                                     {% endif %}
                                     {% if page.live %}

--- a/wagtail/admin/templates/wagtailadmin/home/pages_for_moderation.html
+++ b/wagtail/admin/templates/wagtailadmin/home/pages_for_moderation.html
@@ -24,8 +24,10 @@
                                 <div class="title-wrapper">
                                     {% if page_perms.can_edit %}
                                         <a href="{% url 'wagtailadmin_pages:edit' revision.page.id %}" title="{% trans 'Edit this page' %}">{{ revision.page.get_admin_display_title }}</a>
-                                    {% else %}
+                                    {% elif revision.page.is_previewable %}
                                         <a href="{% url 'wagtailadmin_pages:preview_for_moderation' revision.id %}" title="{% trans 'Preview this page' %}">{{ revision.page.get_admin_display_title }}</a>
+                                    {% else %}
+                                        {{ revision.page.get_admin_display_title }}
                                     {% endif %}
 
                                     {% include "wagtailadmin/pages/listing/_privacy_indicator.html" with page=revision.page %}
@@ -47,7 +49,9 @@
                                     {% if page_perms.can_edit %}
                                         <li><a href="{% url 'wagtailadmin_pages:edit' revision.page.id %}" class="button button-small button-secondary">{% trans 'Edit' %}</a></li>
                                     {% endif %}
-                                    <li><a href="{% url 'wagtailadmin_pages:preview_for_moderation' revision.id %}" class="button button-small button-secondary" target="_blank" rel="noopener noreferrer">{% trans 'Preview' %}</a></li>
+                                    {% if revision.page.is_previewable %}
+                                        <li><a href="{% url 'wagtailadmin_pages:preview_for_moderation' revision.id %}" class="button button-small button-secondary" target="_blank" rel="noopener noreferrer">{% trans 'Preview' %}</a></li>
+                                    {% endif %}
                                 </ul>
                             </td>
                             <td valign="top">
@@ -58,7 +62,9 @@
                             </td>
                             <td valign="top">
                                 <div class="human-readable-date" title="{{ revision.created_at|date:"d M Y H:i" }}">{% blocktrans with time_period=revision.created_at|timesince %}{{ time_period }} ago{% endblocktrans %} </div>
-                                by {{ revision.user.get_full_name|default:revision.user.get_username }}
+                                {% if revision.user %}
+                                    by {{ revision.user.get_full_name|default:revision.user.get_username }}
+                                {% endif %}
                             </td>
                         </tr>
                     {% endfor %}

--- a/wagtail/admin/templates/wagtailadmin/home/recent_edits.html
+++ b/wagtail/admin/templates/wagtailadmin/home/recent_edits.html
@@ -26,7 +26,7 @@
                                 </div>
                                 <ul class="actions">
                                     <li><a href="{% url 'wagtailadmin_pages:edit' page.id %}" class="button button-small button-secondary">{% trans "Edit" %}</a></li>
-                                    {% if page.has_unpublished_changes %}
+                                    {% if page.has_unpublished_changes and page.is_previewable %}
                                         <li><a href="{% url 'wagtailadmin_pages:view_draft' page.id %}" class="button button-small button-secondary" target="_blank" rel="noopener noreferrer">{% trans 'Draft' %}</a></li>
                                     {% endif %}
                                     {% if page.live %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/submitted.html
+++ b/wagtail/admin/templates/wagtailadmin/notifications/submitted.html
@@ -6,7 +6,9 @@
     <p>{% blocktrans with page=revision.page|safe editor=revision.user.get_full_name|default:revision.user.get_username %}The page "{{ page }}" has been submitted for moderation by {{ editor }}.{% endblocktrans %}</p>
 
     <p>
-        {% trans "You can preview the page here:" %} <a href="{{ settings.BASE_URL }}{% url 'wagtailadmin_pages:preview_for_moderation' revision.id %}">{{ settings.BASE_URL }}{% url 'wagtailadmin_pages:preview_for_moderation' revision.id %}</a><br/>
+        {% if revision.page.is_previewable %}
+            {% trans "You can preview the page here:" %} <a href="{{ settings.BASE_URL }}{% url 'wagtailadmin_pages:preview_for_moderation' revision.id %}">{{ settings.BASE_URL }}{% url 'wagtailadmin_pages:preview_for_moderation' revision.id %}</a><br/>
+        {% endif %}
         {% trans "You can edit the page here:" %} <a href="{{ settings.BASE_URL }}{% url 'wagtailadmin_pages:edit' revision.page.id %}">{{ settings.BASE_URL }}{% url 'wagtailadmin_pages:edit' revision.page.id %}</a>
     </p>
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/submitted.txt
+++ b/wagtail/admin/templates/wagtailadmin/notifications/submitted.txt
@@ -4,6 +4,6 @@
 {% block content %}
 {% blocktrans with page=revision.page|safe editor=revision.user.get_full_name|default:revision.user.get_username %}The page "{{ page }}" has been submitted for moderation by {{ editor }}.{% endblocktrans %}
 
-{% trans "You can preview the page here:" %} {{ settings.BASE_URL }}{% url 'wagtailadmin_pages:preview_for_moderation' revision.id %}
+{% if revision.page.is_previewable %}{% trans "You can preview the page here:" %} {{ settings.BASE_URL }}{% url 'wagtailadmin_pages:preview_for_moderation' revision.id %}{% endif %}
 {% trans "You can edit the page here:" %} {{ settings.BASE_URL }}{% url 'wagtailadmin_pages:edit' revision.page.id %}
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/pages/revisions/list.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/revisions/list.html
@@ -30,7 +30,9 @@
                         </div>
 
                         <ul class="actions">
-                            <li><a href="{% url 'wagtailadmin_pages:revisions_view' page.id revision.id %}" class="button button-small button-secondary" target="_blank" rel="noopener noreferrer">{% trans 'Preview' %}</a></li>
+                            {% if page.is_previewable %}
+                                <li><a href="{% url 'wagtailadmin_pages:revisions_view' page.id revision.id %}" class="button button-small button-secondary" target="_blank" rel="noopener noreferrer">{% trans 'Preview' %}</a></li>
+                            {% endif %}
                             {% if revision == page.get_latest_revision %}
                                 <li><a href="{% url 'wagtailadmin_pages:edit' page.id %}" class="button button-small button-secondary">{% trans 'Edit' %}</a></li>
                             {% else %}

--- a/wagtail/admin/views/pages.py
+++ b/wagtail/admin/views/pages.py
@@ -615,7 +615,13 @@ def view_draft(request, page_id):
     perms = page.permissions_for_user(request.user)
     if not (perms.can_publish() or perms.can_edit()):
         raise PermissionDenied
-    return page.make_preview_request(request, page.default_preview_mode)
+
+    try:
+        preview_mode = page.default_preview_mode
+    except IndexError:
+        raise PermissionDenied
+
+    return page.make_preview_request(request, preview_mode)
 
 
 class PreviewOnEdit(View):
@@ -676,7 +682,12 @@ class PreviewOnEdit(View):
             return self.error_response(page)
 
         form.save(commit=False)
-        preview_mode = request.GET.get('mode', page.default_preview_mode)
+
+        try:
+            preview_mode = request.GET.get('mode', page.default_preview_mode)
+        except IndexError:
+            raise PermissionDenied
+
         return page.make_preview_request(request, preview_mode)
 
 
@@ -1085,7 +1096,12 @@ def preview_for_moderation(request, revision_id):
 
     page = revision.as_page_object()
 
-    return page.make_preview_request(request, page.default_preview_mode, extra_request_attrs={
+    try:
+        preview_mode = page.default_preview_mode
+    except IndexError:
+        raise PermissionDenied
+
+    return page.make_preview_request(request, preview_mode, extra_request_attrs={
         'revision_id': revision_id
     })
 
@@ -1215,7 +1231,12 @@ def revisions_view(request, page_id, revision_id):
     revision = get_object_or_404(page.revisions, id=revision_id)
     revision_page = revision.as_page_object()
 
-    return revision_page.make_preview_request(request, page.default_preview_mode)
+    try:
+        preview_mode = page.default_preview_mode
+    except IndexError:
+        raise PermissionDenied
+
+    return revision_page.make_preview_request(request, preview_mode)
 
 
 def revisions_compare(request, page_id, revision_id_a, revision_id_b):

--- a/wagtail/admin/views/pages.py
+++ b/wagtail/admin/views/pages.py
@@ -258,20 +258,27 @@ def create(request, content_type_app_name, content_type_model_name, parent_page_
                     buttons.append(messages.button(reverse('wagtailadmin_pages:edit', args=(page.id,)), _('Edit')))
                     messages.success(request, _("Page '{0}' created and published.").format(page.get_admin_display_title()), buttons=buttons)
             elif is_submitting:
-                messages.success(
-                    request,
-                    _("Page '{0}' created and submitted for moderation.").format(page.get_admin_display_title()),
-                    buttons=[
+                buttons = []
+                if page.is_previewable():
+                    buttons.append(
                         messages.button(
                             reverse('wagtailadmin_pages:view_draft', args=(page.id,)),
                             _('View draft'),
                             new_window=True
                         ),
-                        messages.button(
-                            reverse('wagtailadmin_pages:edit', args=(page.id,)),
-                            _('Edit')
-                        )
-                    ]
+                    )
+
+                buttons.append(
+                    messages.button(
+                        reverse('wagtailadmin_pages:edit', args=(page.id,)),
+                        _('Edit')
+                    )
+                )
+
+                messages.success(
+                    request,
+                    _("Page '{0}' created and submitted for moderation.").format(page.get_admin_display_title()),
+                    buttons=buttons
                 )
                 if not send_notification(page.get_latest_revision().id, 'submitted', request.user.pk):
                     messages.error(request, _("Failed to send notifications to moderators"))

--- a/wagtail/admin/wagtail_hooks.py
+++ b/wagtail/admin/wagtail_hooks.py
@@ -105,7 +105,7 @@ def page_listing_buttons(page, page_perms, is_parent=False):
             attrs={'aria-label': _("Edit '%(title)s'") % {'title': page.get_admin_display_title()}},
             priority=10
         )
-    if page.has_unpublished_changes:
+    if page.has_unpublished_changes and page.is_previewable():
         yield PageListingButton(
             _('View draft'),
             reverse('wagtailadmin_pages:view_draft', args=[page.id]),

--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -1402,6 +1402,10 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
 
     @property
     def default_preview_mode(self):
+        """
+        The preview mode to use in workflows that do not give the user the option of selecting a
+        mode explicitly, e.g. moderator approval. Will raise IndexError if preview_modes is empty
+        """
         return self.preview_modes[0][0]
 
     def is_previewable(self):


### PR DESCRIPTION
Ref: https://github.com/wagtail/wagtail/issues/5670#issuecomment-615836390
Add an `is_previewable` method to Page (which accounts for being called either on the base Page model or the specific subclass, as either may be in use on listing pages that display these buttons), and check this when rendering buttons.

Additionally, fix the 'pages for moderation' panel to check that revision.user is defined before trying to output a username - this field is intentionally nullable to allow for scripted processes. Without this check, under normal template-rendering rules the whole panel is liable to be silently dropped.
