### PR TITLE
Implement bulk_to_python on all structural StreamField block types

### DIFF
--- a/wagtail/core/blocks/base.py
+++ b/wagtail/core/blocks/base.py
@@ -211,6 +211,14 @@ class Block(metaclass=BaseBlock):
         """
         return value
 
+    def bulk_to_python(self, values):
+        """
+        Apply the to_python conversion to a list of values. The default implementation simply
+        iterates over the list; subclasses may optimise this, e.g. by combining database lookups
+        into a single query.
+        """
+        return [self.to_python(value) for value in values]
+
     def get_prep_value(self, value):
         """
         The reverse of to_python; convert the python value into JSON-serialisable form.

--- a/wagtail/core/blocks/list_block.py
+++ b/wagtail/core/blocks/list_block.py
@@ -133,15 +133,8 @@ class ListBlock(Block):
         return result
 
     def to_python(self, value):
-        # If child block supports bulk retrieval, use it.
-        if hasattr(self.child_block, 'bulk_to_python'):
-            return self.child_block.bulk_to_python(value)
-
-        # Otherwise recursively call to_python on each child and return as a list.
-        return [
-            self.child_block.to_python(item)
-            for item in value
-        ]
+        # 'value' is a list of child block values; use bulk_to_python to convert them all in one go
+        return self.child_block.bulk_to_python(value)
 
     def get_prep_value(self, value):
         # recursively call get_prep_value on children and return as a list

--- a/wagtail/core/blocks/list_block.py
+++ b/wagtail/core/blocks/list_block.py
@@ -34,6 +34,10 @@ class ListBlock(Block):
         self.dependencies = [self.child_block]
         self.child_js_initializer = self.child_block.js_initializer()
 
+    def get_default(self):
+        # wrap with list() so that each invocation of get_default returns a distinct instance
+        return list(self.meta.default)
+
     @property
     def media(self):
         return forms.Media(js=[

--- a/wagtail/core/blocks/list_block.py
+++ b/wagtail/core/blocks/list_block.py
@@ -1,3 +1,5 @@
+import itertools
+
 from django import forms
 from django.core.exceptions import ValidationError
 from django.forms.utils import ErrorList
@@ -135,6 +137,22 @@ class ListBlock(Block):
     def to_python(self, value):
         # 'value' is a list of child block values; use bulk_to_python to convert them all in one go
         return self.child_block.bulk_to_python(value)
+
+    def bulk_to_python(self, values):
+        # 'values' is a list of lists of child block values; concatenate them into one list so that
+        # we can make a single call to child_block.bulk_to_python
+        lengths = [len(val) for val in values]
+        raw_values = list(itertools.chain.from_iterable(values))
+        converted_values = self.child_block.bulk_to_python(raw_values)
+
+        # split converted_values back into sub-lists of the original lengths
+        result = []
+        offset = 0
+        for sublist_len in lengths:
+            result.append(converted_values[offset:offset + sublist_len])
+            offset += sublist_len
+
+        return result
 
     def get_prep_value(self, value):
         # recursively call get_prep_value on children and return as a list

--- a/wagtail/core/blocks/stream_block.py
+++ b/wagtail/core/blocks/stream_block.py
@@ -250,6 +250,57 @@ class BaseStreamBlock(Block):
             if child_data['type'] in self.child_blocks
         ], is_lazy=True)
 
+    def bulk_to_python(self, values):
+        # 'values' is a list of streams, each stream being a list of dicts with 'type', 'value' and
+        # optionally 'id'.
+        # We will iterate over these streams, constructing:
+        # 1) a set of per-child-block lists ('child_inputs'), to be sent to each child block's
+        #    bulk_to_python method in turn (giving us 'child_outputs')
+        # 2) a 'block map' of each stream, telling us the type and id of each block and the index we
+        #    need to look up in the corresponding child_outputs list to obtain its final value
+
+        child_inputs = defaultdict(list)
+        block_maps = []
+
+        for stream in values:
+            block_map = []
+            for block_dict in stream:
+                block_type = block_dict['type']
+
+                if block_type not in self.child_blocks:
+                    # skip any blocks with an unrecognised type
+                    continue
+
+                child_input_list = child_inputs[block_type]
+                child_index = len(child_input_list)
+                child_input_list.append(block_dict['value'])
+                block_map.append(
+                    (block_type, block_dict.get('id'), child_index)
+                )
+
+            block_maps.append(block_map)
+
+        # run each list in child_inputs through the relevant block's bulk_to_python
+        # to obtain child_outputs
+        child_outputs = {
+            block_type: self.child_blocks[block_type].bulk_to_python(child_input_list)
+            for block_type, child_input_list in child_inputs.items()
+        }
+
+        # for each stream, go through the block map, picking out the appropriately-indexed
+        # value from the relevant list in child_outputs
+        return [
+            StreamValue(
+                self,
+                [
+                    (block_type, child_outputs[block_type][child_index], id)
+                    for block_type, id, child_index in block_map
+                ],
+                is_lazy=False
+            )
+            for block_map in block_maps
+        ]
+
     def get_prep_value(self, value):
         if not value:
             # Falsy values (including None, empty string, empty list, and

--- a/wagtail/core/blocks/stream_block.py
+++ b/wagtail/core/blocks/stream_block.py
@@ -429,7 +429,7 @@ class StreamValue(Sequence):
         """
         self.is_lazy = is_lazy
         self.stream_block = stream_block  # the StreamBlock object that handles this value
-        self.stream_data = stream_data  # a list of (type_name, value) tuples
+        self.stream_data = stream_data  # a list of dicts (when lazy) or tuples (when non-lazy) as outlined above
         self._bound_blocks = {}  # populated lazily from stream_data as we access items through __getitem__
         self.raw_text = raw_text
 

--- a/wagtail/core/blocks/stream_block.py
+++ b/wagtail/core/blocks/stream_block.py
@@ -388,12 +388,8 @@ class StreamValue(Sequence):
                 raw_value = self.stream_data[i]
                 type_name = raw_value['type']
                 child_block = self.stream_block.child_blocks[type_name]
-                if hasattr(child_block, 'bulk_to_python'):
-                    self._prefetch_blocks(type_name, child_block)
-                    return self._bound_blocks[i]
-                else:
-                    value = child_block.to_python(raw_value['value'])
-                    block_id = raw_value.get('id')
+                self._prefetch_blocks(type_name, child_block)
+                return self._bound_blocks[i]
             else:
                 try:
                     type_name, value, block_id = self.stream_data[i]

--- a/wagtail/core/blocks/struct_block.py
+++ b/wagtail/core/blocks/struct_block.py
@@ -149,6 +149,45 @@ class BaseStructBlock(Block):
             for name, child_block in self.child_blocks.items()
         ])
 
+    def bulk_to_python(self, values):
+        # values is a list of dicts; split this into a series of per-subfield lists so that we can
+        # call bulk_to_python on each subfield
+
+        values_by_subfield = {}
+        for name, child_block in self.child_blocks.items():
+            # We need to keep track of which dicts actually have an item for this field, as missing
+            # values will be populated with child_block.get_default(); this is expected to be a
+            # value in the block's native type, and should therefore not undergo conversion via
+            # bulk_to_python.
+            indexes = []
+            raw_values = []
+            for i, val in enumerate(values):
+                if name in val:
+                    indexes.append(i)
+                    raw_values.append(val[name])
+
+            converted_values = child_block.bulk_to_python(raw_values)
+            # create a mapping from original index to converted value
+            converted_values_by_index = dict(zip(indexes, converted_values))
+
+            # now loop over all list indexes, falling back on the default for any indexes not in
+            # the mapping, to arrive at the final list for this subfield
+            default = child_block.get_default()
+            values_by_subfield[name] = [
+                converted_values_by_index.get(i, default)
+                for i in range(0, len(values))
+            ]
+
+        # now form the final list of StructValues, with each one constructed by taking the
+        # appropriately-indexed item from all of the per-subfield lists
+        return [
+            self._to_struct_value({
+                name: values_by_subfield[name][i]
+                for name in self.child_blocks.keys()
+            })
+            for i in range(0, len(values))
+        ]
+
     def _to_struct_value(self, block_items):
         """ Return a Structvalue representation of the sub-blocks in this block """
         return self.meta.value_class(self, block_items)

--- a/wagtail/core/blocks/struct_block.py
+++ b/wagtail/core/blocks/struct_block.py
@@ -172,11 +172,14 @@ class BaseStructBlock(Block):
 
             # now loop over all list indexes, falling back on the default for any indexes not in
             # the mapping, to arrive at the final list for this subfield
-            default = child_block.get_default()
-            values_by_subfield[name] = [
-                converted_values_by_index.get(i, default)
-                for i in range(0, len(values))
-            ]
+            values_by_subfield[name] = []
+            for i in range(0, len(values)):
+                try:
+                    converted_value = converted_values_by_index[i]
+                except KeyError:
+                    converted_value = child_block.get_default()
+
+                values_by_subfield[name].append(converted_value)
 
         # now form the final list of StructValues, with each one constructed by taking the
         # appropriately-indexed item from all of the per-subfield lists

--- a/wagtail/core/tests/test_blocks.py
+++ b/wagtail/core/tests/test_blocks.py
@@ -3285,6 +3285,35 @@ class TestStreamBlock(WagtailTestUtils, SimpleTestCase):
         self.assertEqual(html.count(' profile-block-large'), 1)
 
 
+class TestStructBlockWithFixtures(TestCase):
+    fixtures = ['test.json']
+
+    def test_bulk_to_python(self):
+        page_link_block = blocks.StructBlock([
+            ('page', blocks.PageChooserBlock(required=False)),
+            ('link_text', blocks.CharBlock(default="missing title")),
+        ])
+
+        with self.assertNumQueries(1):
+            result = page_link_block.bulk_to_python([
+                {'page': 2, 'link_text': 'page two'},
+                {'page': 3, 'link_text': 'page three'},
+                {'page': None, 'link_text': 'no page'},
+                {'page': 4},
+            ])
+
+        result_types = [type(val) for val in result]
+        self.assertEqual(result_types, [blocks.StructValue] * 4)
+
+        result_titles = [val['link_text'] for val in result]
+        self.assertEqual(result_titles, ['page two', 'page three', 'no page', 'missing title'])
+
+        result_pages = [val['page'] for val in result]
+        self.assertEqual(result_pages, [
+            Page.objects.get(id=2), Page.objects.get(id=3), None, Page.objects.get(id=4)
+        ])
+
+
 class TestPageChooserBlock(TestCase):
     fixtures = ['test.json']
 

--- a/wagtail/core/tests/test_blocks.py
+++ b/wagtail/core/tests/test_blocks.py
@@ -3326,6 +3326,62 @@ class TestStructBlockWithFixtures(TestCase):
         ])
 
 
+class TestStreamBlockWithFixtures(TestCase):
+    fixtures = ['test.json']
+
+    def test_bulk_to_python(self):
+        stream_block = blocks.StreamBlock([
+            ('page', blocks.PageChooserBlock()),
+            ('heading', blocks.CharBlock()),
+        ])
+
+        # The naive implementation of bulk_to_python (calling to_python on each item) would perform
+        # NO queries, as StreamBlock.to_python returns a lazy StreamValue that only starts calling
+        # to_python on its children (and thus triggering DB queries) when its items are accessed.
+        # This is a good thing for a standalone to_python call, because loading a model instance
+        # with a StreamField in it will immediately call StreamField.to_python which in turn calls
+        # to_python on the top-level StreamBlock, and we really don't want
+        # SomeModelWithAStreamField.objects.get(id=1) to immediately trigger a cascading fetch of
+        # all objects referenced in the StreamField.
+        #
+        # However, for bulk_to_python that's bad, as it means each stream in the list would end up
+        # doing its own object lookups in isolation, missing the opportunity to group them together
+        # into a single call to the child block's bulk_to_python. Therefore, the ideal outcome is
+        # that we perform one query now (covering all PageChooserBlocks across all streams),
+        # returning a list of non-lazy StreamValues.
+
+        with self.assertNumQueries(1):
+            results = stream_block.bulk_to_python([
+                [{'type': 'heading', 'value': 'interesting pages'}, {'type': 'page', 'value': 2}, {'type': 'page', 'value': 3}],
+                [{'type': 'heading', 'value': 'pages written by dogs'}, {'type': 'woof', 'value': 'woof woof'}],
+                [{'type': 'heading', 'value': 'boring pages'}, {'type': 'page', 'value': 4}],
+            ])
+
+        # If bulk_to_python has indeed given us non-lazy StreamValues, then no further queries
+        # should be performed when iterating over its child blocks.
+        with self.assertNumQueries(0):
+            block_types = [
+                [block.block_type for block in stream]
+                for stream in results
+            ]
+        self.assertEqual(block_types, [
+            ['heading', 'page', 'page'],
+            ['heading'],
+            ['heading', 'page'],
+        ])
+
+        with self.assertNumQueries(0):
+            block_values = [
+                [block.value for block in stream]
+                for stream in results
+            ]
+        self.assertEqual(block_values, [
+            ['interesting pages', Page.objects.get(id=2), Page.objects.get(id=3)],
+            ['pages written by dogs'],
+            ['boring pages', Page.objects.get(id=4)],
+        ])
+
+
 class TestPageChooserBlock(TestCase):
     fixtures = ['test.json']
 

--- a/wagtail/core/tests/test_blocks.py
+++ b/wagtail/core/tests/test_blocks.py
@@ -1722,6 +1722,52 @@ class TestStructBlock(SimpleTestCase):
         self.assertEqual(event['guest_speaker']['first_name'], 'Ed')
         self.assertTrue(isinstance(event['guest_speaker'], blocks.StructValue))
 
+    def test_default_value_is_distinct_instance(self):
+        """
+        Whenever the default value of a StructBlock is invoked, it should be a distinct
+        instance of the dict so that modifying it doesn't modify other places where the
+        default value appears.
+        """
+        class PersonBlock(blocks.StructBlock):
+            first_name = blocks.CharBlock()
+            surname = blocks.CharBlock()
+
+        class EventBlock(blocks.StructBlock):
+            title = blocks.CharBlock()
+            guest_speaker = PersonBlock(default={'first_name': 'Ed', 'surname': 'Balls'})
+
+        event_block = EventBlock()
+
+        event1 = event_block.to_python({'title': 'Birthday party'})  # guest_speaker will default to Ed Balls
+        event2 = event_block.to_python({'title': 'Christmas party'})  # guest_speaker will default to Ed Balls, but a distinct instance
+
+        event1['guest_speaker']['surname'] = 'Miliband'
+        self.assertEqual(event1['guest_speaker']['surname'], 'Miliband')
+        # event2 should not be modified
+        self.assertEqual(event2['guest_speaker']['surname'], 'Balls')
+
+    def test_bulk_to_python_returns_distinct_default_instances(self):
+        """
+        Whenever StructBlock.bulk_to_python invokes a child block's get_default method to
+        fill in missing fields, it should use a separate invocation for each record so that
+        we don't end up with the same instance of a mutable value on multiple records
+        """
+        class ShoppingListBlock(blocks.StructBlock):
+            shop = blocks.CharBlock()
+            items = blocks.ListBlock(blocks.CharBlock(default='chocolate'))
+
+        block = ShoppingListBlock()
+
+        shopping_lists = block.bulk_to_python([
+            {'shop': 'Tesco'},  # 'items' defaults to ['chocolate']
+            {'shop': 'Asda'},  # 'items' defaults to ['chocolate'], but a distinct instance
+        ])
+
+        shopping_lists[0]['items'].append('cake')
+        self.assertEqual(shopping_lists[0]['items'], ['chocolate', 'cake'])
+        # shopping_lists[1] should not be updated
+        self.assertEqual(shopping_lists[1]['items'], ['chocolate'])
+
     def test_clean(self):
         block = blocks.StructBlock([
             ('title', blocks.CharBlock()),
@@ -2275,6 +2321,26 @@ class TestListBlock(WagtailTestUtils, SimpleTestCase):
             form_html
         )
         self.assertIn('value="chocolate"', form_html)
+
+    def test_default_value_is_distinct_instance(self):
+        """
+        Whenever the default value of a ListBlock is invoked, it should be a distinct
+        instance of the list so that modifying it doesn't modify other places where the
+        default value appears.
+        """
+        class ShoppingListBlock(blocks.StructBlock):
+            shop = blocks.CharBlock()
+            items = blocks.ListBlock(blocks.CharBlock(default='chocolate'))
+
+        block = ShoppingListBlock()
+
+        tesco_shopping = block.to_python({'shop': 'Tesco'})  # 'items' will default to ['chocolate']
+        asda_shopping = block.to_python({'shop': 'Asda'})  # 'items' will default to ['chocolate'], but a distinct instance
+
+        tesco_shopping['items'].append('cake')
+        self.assertEqual(tesco_shopping['items'], ['chocolate', 'cake'])
+        # asda_shopping should not be modified
+        self.assertEqual(asda_shopping['items'], ['chocolate'])
 
     def test_render_with_classname_via_kwarg(self):
         """form_classname from kwargs to be used as an additional class when rendering list block"""

--- a/wagtail/core/tests/test_blocks.py
+++ b/wagtail/core/tests/test_blocks.py
@@ -2341,6 +2341,18 @@ class TestListBlockWithFixtures(TestCase):
 
         self.assertSequenceEqual(pages, expected_pages)
 
+    def test_bulk_to_python(self):
+        block = blocks.ListBlock(blocks.PageChooserBlock())
+
+        with self.assertNumQueries(1):
+            result = block.bulk_to_python([[4, 5], [], [2]])
+
+        self.assertEqual(result, [
+            [Page.objects.get(id=4), Page.objects.get(id=5)],
+            [],
+            [Page.objects.get(id=2)],
+        ])
+
 
 class TestStreamBlock(WagtailTestUtils, SimpleTestCase):
     def test_initialisation(self):


### PR DESCRIPTION
Fixes #5926.

Provide a naive implementation of bulk_to_python on the base Block class (so that it's guaranteed to return correct results on any block type, albeit not necessarily efficiently), and efficient implementations on `StructBlock`, `ListBlock` and `StreamBlock` that only perform one call to `bulk_to_python` per unique child block, regardless of how many items they're called with.

Since these `bulk_to_python` implementations are agnostic about the data types used for their child blocks, they will continue to work in nested structures; in this case, the 'bundling' and 'unbundling' of `bulk_to_python` calls will happen recursively for as many levels as necessary, and so a PageChooserBlock (for example) inside a multi-level structure will only require a single query to retrieve all instances across the whole stream.