### PR TITLE
Revert "Add role="table" to TableBlock output"

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -13,6 +13,7 @@ Changelog
  * `AbstractEmailForm` now has a separate method (`render_email`) to build up email content on submission emails (Haydn Greatnews)
  * Fix: Ensure link to add a new user works when no users are visible in the users list (LB (Ben Johnston))
  * Fix: `AbstractEmailForm` saved submission fields are now aligned with the email content fields, `form.cleaned_data` will be used instead of `form.fields` (Haydn Greatnews)
+ * Fix: Removed ARIA `role="table"` from TableBlock output (Thibaud Colas)
 
 
 2.9 (xx.xx.xxxx) - IN DEVELOPMENT

--- a/docs/releases/2.10.rst
+++ b/docs/releases/2.10.rst
@@ -27,6 +27,7 @@ Bug fixes
 
  * Ensure link to add a new user works when no users are visible in the users list (LB (Ben Johnston))
  * ``AbstractEmailForm`` saved submission fields are now aligned with the email content fields, ``form.cleaned_data`` will be used instead of ``form.fields`` (Haydn Greatnews)
+ * Removed ARIA `role="table"` from TableBlock output (Thibaud Colas)
 
 
 Upgrade considerations

--- a/wagtail/contrib/table_block/templates/table_block/blocks/table.html
+++ b/wagtail/contrib/table_block/templates/table_block/blocks/table.html
@@ -1,6 +1,6 @@
 {% load table_block_tags %}
 
-<table role="table">
+<table>
     {% if table_caption %}
        <caption>{{ table_caption }}</caption>
     {% endif %}

--- a/wagtail/contrib/table_block/tests.py
+++ b/wagtail/contrib/table_block/tests.py
@@ -37,7 +37,7 @@ class TestTableBlock(TestCase):
         block = TableBlock()
         result = block.render(value)
         expected = """
-            <table role="table">
+            <table>
                 <tbody>
                     <tr><td>Test 1</td><td>Test 2</td><td>Test 3</td></tr>
                     <tr><td></td><td></td><td></td></tr>
@@ -61,7 +61,7 @@ class TestTableBlock(TestCase):
         block = TableBlock()
         result = block.render(value)
         expected = """
-            <table role="table">
+            <table>
                 <thead>
                     <tr><th scope="col">Test 1</th><th scope="col" class="htLeft">Test 2</th><th scope="col">Test 3</th></tr>
                 </thead>
@@ -90,7 +90,7 @@ class TestTableBlock(TestCase):
             ]
         })
         expected = """
-            <table role="table">
+            <table>
                 <tbody>
                     <tr><td></td><td></td><td></td></tr>
                     <tr><td></td><td></td><td></td></tr>
@@ -110,7 +110,7 @@ class TestTableBlock(TestCase):
                           [None, None, None]]}
 
         expected = """
-            <table role="table">
+            <table>
                 <tbody>
                     <tr><td>&lt;p&gt;&lt;strong&gt;Test&lt;/strong&gt;&lt;/p&gt;</td><td></td><td></td></tr>
                     <tr><td></td><td></td><td></td></tr>
@@ -131,7 +131,7 @@ class TestTableBlock(TestCase):
                  'data': [['Foo', 'Bar', 'Baz'], [None, None, None], [None, None, None]]}
 
         expected = """
-            <table role="table">
+            <table>
                 <thead>
                     <tr><th scope="col">Foo</th><th scope="col">Bar</th><th scope="col">Baz</th></tr>
                 </thead>
@@ -153,7 +153,7 @@ class TestTableBlock(TestCase):
                  'data': [['Foo', 'Bar', 'Baz'], ['one', 'two', 'three'], ['four', 'five', 'six']]}
 
         expected = """
-            <table role="table">
+            <table>
                 <tbody>
                     <tr><th scope="row">Foo</th><td>Bar</td><td>Baz</td></tr>
                     <tr><th scope="row">one</th><td>two</td><td>three</td></tr>
@@ -173,7 +173,7 @@ class TestTableBlock(TestCase):
                  'data': [['Foo', 'Bar', 'Baz'], ['one', 'two', 'three'], ['four', 'five', 'six']]}
 
         expected = """
-            <table role="table">
+            <table>
                 <thead>
                     <tr><th scope="col">Foo</th><th scope="col">Bar</th><th scope="col">Baz</th></tr>
                 </thead>
@@ -258,7 +258,7 @@ class TestTableBlock(TestCase):
         block = TableBlock()
         result = block.render(value)
         expected = """
-            <table role="table">
+            <table>
                 <caption>caption</caption>
                 <tbody>
                     <tr><td>Test 1</td><td>Test 2</td><td>Test 3</td></tr>


### PR DESCRIPTION
This reverts #5588, commit 9a21e79ff88e13d83c81d01f620313a4ddf16b14. cc @gasman and @loicteixeira for thoughts.

I’m proposing this revert for a few reasons:

First, `role="table"` is the default for `table` elements, so HTML5 validation raises the following warning when stumbling upon this: `Warning: The table role is unnecessary for element table`.
See for example https://www.buckinghamshire.gov.uk/libraries/library-membership/library-charges-and-concessions/ in https://html5.validator.nu/.

From my brief testing, it looks like the browser’s (Chrome) heuristics also take the presence of a `<caption>` on a table to determine it’s a data table. Adding a caption is a much more desirable if people experience this issue on their tables – as accessibility standards mandate usage of (data) table captions anyway, and forbid captions usage for layout tables.
- I get the same results with the table containing a `thead` / `th` elements. Which are also mandatory / (highly recommended?) by accessibility guidelines.

Additionally, I don’t see why we would want to override browser’s heuristics for this to start with. Even when the heuristics aren’t good enough (and as far as I can tell, they are), announcing a small data table as if it was presentational really doesn’t do that much harm - it just announces the content following the language’s directionality. On the other hand announcing a presentation table as data means having a much more verbose output than warranted.

In essence I don’t see how this can be a good idea as a blanket rule – if people use tables for layout then this change is harmful. If people use tables for data then they need to put a caption, th, thead anyway. And if they get that wrong, the browser can decide based on its heuristics, which seem quite good.