### PR TITLE
Fix code example in image file formats docs

### DIFF
--- a/docs/advanced_topics/images/image_file_formats.rst
+++ b/docs/advanced_topics/images/image_file_formats.rst
@@ -21,7 +21,7 @@ image formats and let the browser choose the one it prefers. For example:
         {% image myimage width-1000 format-png as image_png %}
         <source srcset="{{ image_png.url }}" type="image/png">
 
-        {{ image_png }}
+        {% image myimage width-1000 format-png %}
     </picture>
 
 Customizing output formats


### PR DESCRIPTION
[The code in the docs](https://docs.wagtail.io/en/v2.8.1/advanced_topics/images/image_file_formats.html#using-the-picture-element) result in a `Rendition object (xxx)` because the `{% image %}` template tag used with `as` returns a rendition object instead of an `img` tag. 