### PR TITLE
Allow page's variable name in context to be configurable

### DIFF
--- a/docs/reference/pages/model_reference.rst
+++ b/docs/reference/pages/model_reference.rst
@@ -153,6 +153,10 @@ In addition to the model fields provided, ``Page`` has many properties and metho
 
     .. automethod:: serve
 
+    .. autoattribute:: context_object_name
+
+        Custom name for page instance in page's ``Context``.
+
     .. automethod:: get_context
 
     .. automethod:: get_template

--- a/docs/topics/writing_templates.rst
+++ b/docs/topics/writing_templates.rst
@@ -38,6 +38,8 @@ Page content
 
 The data/content entered into each page is accessed/output through Django's ``{{ double-brace }}`` notation. Each field from the model must be accessed by prefixing ``page.``. e.g the page title ``{{ page.title }}`` or another field ``{{ page.author }}``.
 
+A custom variable name can be :attr:`configured on the page model <wagtail.core.models.Page.context_object_name>`. If a custom name is defined, ``page`` is still available for use in shared templates.
+
 Additionally ``request.`` is available and contains Django's request object.
 
 Static assets

--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -750,12 +750,19 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
 
             self.revisions.update(approved_go_live_at=None)
 
+    context_object_name = None
+
     def get_context(self, request, *args, **kwargs):
-        return {
+        context = {
             PAGE_TEMPLATE_VAR: self,
             'self': self,
             'request': request,
         }
+
+        if self.context_object_name:
+            context[self.context_object_name] = self
+
+        return context
 
     def get_template(self, request, *args, **kwargs):
         if request.is_ajax():

--- a/wagtail/core/tests/test_page_model.py
+++ b/wagtail/core/tests/test_page_model.py
@@ -500,6 +500,17 @@ class TestServeView(TestCase):
         response = c.get('/christmas/', HTTP_HOST='localhost')
         self.assertEqual(response.status_code, 404)
 
+    def test_serve_with_custom_context_name(self):
+        EventPage.context_object_name = 'event_page'
+        christmas_page = EventPage.objects.get(url_path='/home/events/christmas/')
+
+        response = self.client.get('/events/christmas/')
+
+        # Context should contain context_object_name key along with standard page keys
+        self.assertEqual(response.context['event_page'], christmas_page)
+        self.assertEqual(response.context['page'], christmas_page)
+        self.assertEqual(response.context['self'], christmas_page)
+
     def test_serve_with_custom_context(self):
         response = self.client.get('/events/')
         self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
`Page.context_object_name` can be used to define a more meaningful name
for the page variable in the template.

If defined a `context_object_name` is defined, the default `page` and `self` variables are still available for use in templates.

I might have missed a trick adding the variable to the Page's Meta class but `django.db.models.options.Options`'s `contribute_to_class` method [raises a TypeError](https://github.com/django/django/blob/b4068bc65636cca6c2905aa8c40bea69bb0e4245/django/db/models/options.py#L198) for any unexpected properties found on the Meta.

Instead, `context_object_name` lives on the `Page` and is configurable on a per-page basis.

Resolves #5213

