### PR TITLE
Site switcher, site ordering

### DIFF
--- a/wagtail/contrib/settings/forms.py
+++ b/wagtail/contrib/settings/forms.py
@@ -17,9 +17,17 @@ class SiteSwitchForm(forms.Form):
     def __init__(self, current_site, model, **kwargs):
         initial_data = {'site': self.get_change_url(current_site, model)}
         super().__init__(initial=initial_data, **kwargs)
-        sites = [(self.get_change_url(site, model), site)
-                 for site in Site.objects.all()]
-        self.fields['site'].choices = sites
+        self.fields["site"].choices = [
+            (
+                self.get_change_url(site, model),
+                (
+                    site.hostname + " [default]"
+                    if site.is_default_site
+                    else site.hostname
+                ),
+            )
+            for site in Site.objects.all()
+        ]
 
     @classmethod
     def get_change_url(cls, site, model):

--- a/wagtail/contrib/settings/tests/test_forms.py
+++ b/wagtail/contrib/settings/tests/test_forms.py
@@ -1,0 +1,23 @@
+from django.test import TestCase
+
+from wagtail.contrib.settings.forms import SiteSwitchForm
+from wagtail.core.models import Page, Site
+from wagtail.tests.testapp.models import TestSetting
+
+
+class TestSiteSwitchFromSiteOrdering(TestCase):
+    def setUp(self):
+        self.root_page = Page.objects.get(pk=2)
+        Site.objects.all().delete()  # Drop the initial site.
+
+    def test_site_order_by_hostname(self):
+        site_1 = Site.objects.create(hostname='charly.com', root_page=self.root_page)
+        site_2 = Site.objects.create(hostname='bravo.com', root_page=self.root_page, is_default_site=True)
+        site_3 = Site.objects.create(hostname='alfa.com', root_page=self.root_page)
+        form = SiteSwitchForm(site_1, TestSetting)
+        expected_choices = [
+            ('/admin/settings/tests/testsetting/{}/'.format(site_3.id), 'alfa.com'),
+            ('/admin/settings/tests/testsetting/{}/'.format(site_2.id), 'bravo.com [default]'),
+            ('/admin/settings/tests/testsetting/{}/'.format(site_1.id), 'charly.com')
+        ]
+        self.assertEqual(form.fields['site'].choices, expected_choices)

--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -14,7 +14,7 @@ from django.core.handlers.base import BaseHandler
 from django.core.handlers.wsgi import WSGIRequest
 from django.db import models, transaction
 from django.db.models import Case, Q, Value, When
-from django.db.models.functions import Concat, Substr
+from django.db.models.functions import Concat, Lower, Substr
 from django.http import Http404
 from django.http.request import split_domain_port
 from django.template.response import TemplateResponse
@@ -42,6 +42,9 @@ PAGE_TEMPLATE_VAR = 'page'
 
 
 class SiteManager(models.Manager):
+    def get_queryset(self):
+        return super(SiteManager, self).get_queryset().order_by(Lower("hostname"))
+
     def get_by_natural_key(self, hostname, port):
         return self.get(hostname=hostname, port=port)
 

--- a/wagtail/core/tests/test_sites.py
+++ b/wagtail/core/tests/test_sites.py
@@ -56,6 +56,30 @@ class TestSiteNameDisplay(TestCase):
         self.assertEqual(site.__str__(), 'example.com:8080 [default]')
 
 
+class TestSiteOrdering(TestCase):
+    def setUp(self):
+        self.root_page = Page.objects.get(pk=2)
+        Site.objects.all().delete()  # Drop the initial site.
+
+    def test_site_order_by_hostname(self):
+        site_1 = Site.objects.create(hostname='charly.com', root_page=self.root_page)
+        site_2 = Site.objects.create(hostname='bravo.com', root_page=self.root_page)
+        site_3 = Site.objects.create(hostname='alfa.com', root_page=self.root_page)
+        self.assertEqual(list(Site.objects.all().values_list("id", flat=True)), [site_3.id, site_2.id, site_1.id])
+
+    def test_site_order_by_hostname_upper(self):
+        site_1 = Site.objects.create(hostname='charly.com', root_page=self.root_page)
+        site_2 = Site.objects.create(hostname='Bravo.com', root_page=self.root_page)
+        site_3 = Site.objects.create(hostname='alfa.com', root_page=self.root_page)
+        self.assertEqual(list(Site.objects.all().values_list("id", flat=True)), [site_3.id, site_2.id, site_1.id])
+
+    def test_site_order_by_hostname_site_name_irrelevant(self):
+        site_1 = Site.objects.create(hostname='charly.com', site_name='X-ray', root_page=self.root_page)
+        site_2 = Site.objects.create(hostname='bravo.com', site_name='Yankee', root_page=self.root_page)
+        site_3 = Site.objects.create(hostname='alfa.com', site_name='Zulu', root_page=self.root_page)
+        self.assertEqual(list(Site.objects.all().values_list("id", flat=True)), [site_3.id, site_2.id, site_1.id])
+
+
 @override_settings(ALLOWED_HOSTS=['example.com', 'unknown.com', '127.0.0.1', '[::1]'])
 class TestFindSiteForRequest(TestCase):
     def setUp(self):


### PR DESCRIPTION
Inspired by the work in https://github.com/wagtail/wagtail/pull/5891

Sites do not have a default order. Sites do not have a consistent string representation (site name if given, else hostname). That makes selecting sites in the sites list view and site switcher hard. Especially with many sites.

This PR adds:
- ordering to sites.
- displays the hostnames in site switcher (not the site name).

The ordering of sites in site list view and site switcher are now consistent.

* Do the tests still pass? YES
* Does the code comply with the style guide? YES
* For Python changes: Have you added tests to cover the new/fixed behaviour? YES
* For front-end changes: Did you test on all of Wagtail’s supported browsers? N/A
* For new features: Has the documentation been updated accordingly? N/A
