### PR TITLE
Fix gulp.dest path rewriter output from Gulp 4 upgrade

### DIFF
--- a/gulpfile.js/tasks/styles.js
+++ b/gulpfile.js/tasks/styles.js
@@ -85,7 +85,7 @@ gulp.task('styles:sass', function () {
                     '/' + config.srcDir + '/',
                     '/' + config.destDir + '/'
                 )
-                .replace('/scss/', '/css/');
+                .replace('/scss', '/css');
         }))
         .on('error', gutil.log);
 });


### PR DESCRIPTION
Fixes a regression with #5995. It seems like the behavior of `gulp.dest` changed between v3 and v4. It’s not entirely clear to me what change affected us from reviewing the [CHANGELOG](https://github.com/gulpjs/gulp/blob/master/CHANGELOG.md#gulp-changelog), but doesn’t feel worth confirming.

To try this,

```sh
rm -rf wagtail/*/static
npx gulp styles
tree wagtail/*/static/*
```

The output should be:

```text
wagtail/admin/static/wagtailadmin
└── css
    ├── core.css
    ├── layouts
    │   ├── 404.css
    │   ├── compare-revisions.css
    │   ├── home.css
    │   ├── login.css
    │   ├── page-editor.css
    │   └── report.css
    ├── normalize.css
    ├── panels
    │   ├── draftail.css
    │   ├── hallo.css
    │   └── streamfield.css
    ├── userbar.css
    └── vendor
        ├── jquery-ui
        │   ├── images
        │   │   ├── animated-overlay.gif
        │   │   ├── ui-bg_flat_0_aaaaaa_40x100.png
        │   │   ├── ui-bg_flat_100_246060_40x100.png
        │   │   ├── ui-bg_flat_100_49c0c1_40x100.png
        │   │   ├── ui-bg_flat_100_e8f8f9_40x100.png
        │   │   ├── ui-bg_flat_100_f7474e_40x100.png
        │   │   ├── ui-bg_flat_100_ffffff_40x100.png
        │   │   ├── ui-bg_flat_65_49c0c1_40x100.png
        │   │   ├── ui-icons_222222_256x240.png
        │   │   ├── ui-icons_49c0c1_256x240.png
        │   │   ├── ui-icons_555555_256x240.png
        │   │   └── ui-icons_ffffff_256x240.png
        │   └── jquery-ui-1.10.3.verdant.css
        ├── jquery.tagit.css
        └── tagit.ui-zendesk.css
wagtail/documents/static/wagtaildocs
└── css
    └── add-multiple.css
wagtail/images/static/wagtailimages
└── css
    ├── add-multiple.css
    ├── focal-point-chooser.css
    └── vendor
        ├── Jcrop.gif
        └── jquery.Jcrop.min.css
wagtail/users/static/wagtailusers
└── css
    └── groups_edit.css

10 directories, 33 files
```