### PR TITLE
Render user bar on non page views

### DIFF
--- a/docs/topics/writing_templates.rst
+++ b/docs/topics/writing_templates.rst
@@ -242,6 +242,8 @@ Wagtail User Bar
 
 This tag provides a contextual flyout menu for logged-in users. The menu gives editors the ability to edit the current page or add a child page, besides the options to show the page in the Wagtail page explorer or jump to the Wagtail admin dashboard. Moderators are also given the ability to accept or reject a page being previewed as part of content moderation.
 
+This tag may be used on regular Django views, without page object. The user bar will contain one item pointing to the admin.
+
 .. code-block:: html+django
 
     {% load wagtailuserbar %}

--- a/wagtail/admin/tests/test_userbar.py
+++ b/wagtail/admin/tests/test_userbar.py
@@ -62,6 +62,14 @@ class TestUserbarTag(TestCase):
         # Make sure nothing was rendered
         self.assertEqual(content, '')
 
+    def test_userbar_tag_no_page(self):
+        template = Template("{% load wagtailuserbar %}{% wagtailuserbar %}")
+        content = template.render(Context({
+            'request': self.dummy_request(self.user),
+        }))
+
+        self.assertIn("<!-- Wagtail user bar embed code -->", content)
+
 
 class TestUserbarFrontend(TestCase, WagtailTestUtils):
     def setUp(self):


### PR DESCRIPTION
This PR makes it possible to add the Wagtail user bar on non-page views (regular Django views).

It is inspired on the work done in https://github.com/wagtail/wagtail/pull/5636 by @con-cat. Thank you!

I took a slightly different approach than that PR and used a more readable `if-elif-else` condition.

This PR will supersede https://github.com/wagtail/wagtail/pull/5636

* Do the tests still pass? YES
* Does the code comply with the style guide? YES
* For Python changes: Have you added tests to cover the new/fixed behaviour? YES
* For front-end changes: Did you test on all of Wagtail’s supported browsers? N/A
* For new features: Has the documentation been updated accordingly? YES
