### PR TITLE
Fix typo in ModelAdminGroup example

### DIFF
--- a/docs/reference/contrib/modeladmin/index.rst
+++ b/docs/reference/contrib/modeladmin/index.rst
@@ -216,7 +216,7 @@ the same ``wagtail_hooks.py`` file if you want. The example below will create
         ...
 
     class MusicAdminGroup(ModelAdminGroup):
-        label = _("Music")
+        menu_label = _("Music")
         items = (AlbumAdmin, ArtistAdmin)
         ...
 


### PR DESCRIPTION
I noticed a typo in the code example for the `ModelAdminGroup` where it shows you can alter the text that will appear in the menu item, this should be `menu_label` and not `label`