### PR TITLE
Show userbar on moderation preview with approve and reject items

### DIFF
--- a/wagtail/admin/templatetags/wagtailuserbar.py
+++ b/wagtail/admin/templatetags/wagtailuserbar.py
@@ -42,38 +42,30 @@ def wagtailuserbar(context, position='bottom-right'):
     if not user.has_perm('wagtailadmin.access_admin'):
         return ''
 
-    # Don't render if this is a preview. Since some routes can render the userbar without going through Page.serve(),
-    # request.is_preview might not be defined.
-    if getattr(request, 'is_preview', False):
-        return ''
-
     page = get_page_instance(context)
+
     try:
         revision_id = request.revision_id
     except AttributeError:
         revision_id = None
 
     if page and page.id:
-        # Saved page.
-        if revision_id is None:
+        if revision_id:
+            items = [
+                AdminItem(),
+                ExplorePageItem(PageRevision.objects.get(id=revision_id).page),
+                EditPageItem(PageRevision.objects.get(id=revision_id).page),
+                ApproveModerationEditPageItem(PageRevision.objects.get(id=revision_id)),
+                RejectModerationEditPageItem(PageRevision.objects.get(id=revision_id)),
+            ]
+        else:
+            # Not a revision
             items = [
                 AdminItem(),
                 ExplorePageItem(Page.objects.get(id=page.id)),
                 EditPageItem(Page.objects.get(id=page.id)),
                 AddPageItem(Page.objects.get(id=page.id)),
             ]
-        else:
-            items = [
-                AdminItem(),
-                ExplorePageItem(PageRevision.objects.get(id=revision_id).page),
-                EditPageItem(PageRevision.objects.get(id=revision_id).page),
-                AddPageItem(PageRevision.objects.get(id=revision_id).page),
-                ApproveModerationEditPageItem(PageRevision.objects.get(id=revision_id)),
-                RejectModerationEditPageItem(PageRevision.objects.get(id=revision_id)),
-            ]
-    elif page:
-        # A page without an id is a preview.
-        return ""
     else:
         # Not a page.
         items = [AdminItem()]

--- a/wagtail/admin/tests/test_userbar.py
+++ b/wagtail/admin/tests/test_userbar.py
@@ -129,7 +129,7 @@ class TestUserbarModeration(TestCase, WagtailTestUtils):
     def setUp(self):
         self.login()
         self.homepage = Page.objects.get(id=2)
-        self.homepage.save_revision()
+        self.homepage.save_revision(submitted_for_moderation=True)
         self.revision = self.homepage.get_latest_revision()
 
     def test_userbar_moderation(self):
@@ -137,6 +137,26 @@ class TestUserbarModeration(TestCase, WagtailTestUtils):
 
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, 'wagtailadmin/userbar/base.html')
+
+        expected_approve_html = """
+            <form action="/admin/pages/moderation/{}/approve/" target="_parent" method="post">
+                <input type="hidden" name="csrfmiddlewaretoken">
+                <div class="wagtail-action wagtail-icon wagtail-icon-tick">
+                    <input type="submit" value="Approve" class="button" />
+                </div>
+            </form>
+        """.format(self.revision.id)
+        self.assertTagInHTML(expected_approve_html, str(response.content))
+
+        expected_reject_html = """
+            <form action="/admin/pages/moderation/{}/reject/" target="_parent" method="post">
+                <input type="hidden" name="csrfmiddlewaretoken">
+                <div class="wagtail-action wagtail-icon wagtail-icon-cross">
+                    <input type="submit" value="Reject" class="button" />
+                </div>
+            </form>
+        """.format(self.revision.id)
+        self.assertTagInHTML(expected_reject_html, str(response.content))
 
     def test_userbar_moderation_anonymous_user_cannot_see(self):
         # Logout


### PR DESCRIPTION
Fix https://github.com/wagtail/wagtail/issues/6008

Demo:
1. Edit a page
2. Choose "Submit for moderation"
3. Go to the admin dashboard
4. In the list "PAGES AWAITING MODERATION" click "Preview"
5. The preview now contains a menu bar with approve and reject items.

<img width="759" alt="Screenshot 2020-05-14 at 15 20 19" src="https://user-images.githubusercontent.com/1969342/81939327-7d9a9e80-95f6-11ea-8763-9bc05b600405.png">

I don't know why the code returned an empty string for previews. It is wrong.

I also expect the revision list to contain the same buttons (approve, reject, edit, preview) as the pages awaiting moderation list on the dashboard. This might be a separate issue. But I mention it anyway.

Navigate to revisions: Page edit, bottom right, click revisions.

<img width="998" alt="Screenshot 2020-05-14 at 15 07 40" src="https://user-images.githubusercontent.com/1969342/81938943-f6e5c180-95f5-11ea-998e-c4cea6728e38.png">

<img width="998" alt="Screenshot 2020-05-14 at 15 08 09" src="https://user-images.githubusercontent.com/1969342/81938974-01a05680-95f6-11ea-9234-8ce3678191ba.png">

TODO:
- [x] Fix wagtail.admin.tests.pages.test_preview.TestPreview

* Do the tests still pass? YES
* Does the code comply with the style guide? YES
* For Python changes: Have you added tests to cover the new/fixed behaviour? YES
* For front-end changes: Did you test on all of Wagtail’s supported browsers? N/A
* For new features: Has the documentation been updated accordingly? N/A
