### PR TITLE
renamed filters: The nGram and edgeNGram token filter names that have…

### DIFF
--- a/wagtail/search/backends/elasticsearch7.py
+++ b/wagtail/search/backends/elasticsearch7.py
@@ -43,13 +43,12 @@ class Elasticsearch7Index(Elasticsearch6Index):
 
         # Get mapping
         mapping = self.mapping_class(model)
-        doc_type = "_doc"
 
         # Create list of actions
         actions = []
         for item in items:
             # Create the action
-            action = {"_type": doc_type, "_id": mapping.get_document_id(item)}
+            action = {'_id': mapping.get_document_id(item)}
             action.update(mapping.get_document(item))
             actions.append(action)
 
@@ -93,7 +92,11 @@ class Elasticsearch7SearchBackend(Elasticsearch6SearchBackend):
     results_class = Elasticsearch7SearchResults
 
     settings = deepcopy(Elasticsearch6SearchBackend.settings)
-    settings["settings"]["index"] = {"max_ngram_diff": 12}
+    settings['settings']['index'] = {'max_ngram_diff': 12}
+    settings['settings']['analysis']['filter']['ngram']['type'] = 'ngram'
+    settings['settings']['analysis']['filter']['edgengram']['type'] = 'edge_ngram'
+    settings['settings']['analysis']['tokenizer']['ngram_tokenizer']['type'] = 'ngram'
+    settings['settings']['analysis']['tokenizer']['edgengram_tokenizer']['type'] = 'edge_ngram'
 
 
 SearchBackend = Elasticsearch7SearchBackend


### PR DESCRIPTION
… been deprecated since version 6.4 have been removed. Both token filters can only be used by their alternative names ngram and edge_ngram since version 7.0.

fixed notice: ElasticsearchDeprecationWarning: [types removal] Specifying types in bulk requests is deprecated.

Thanks for contributing to Wagtail! 🎉

Before submitting, please review the contributor guidelines <https://docs.wagtail.io/en/latest/contributing/index.html> and check the following:

* Do the tests still pass? (https://docs.wagtail.io/en/latest/contributing/developing.html#testing)
* Does the code comply with the style guide? (Run `make lint` from the Wagtail root)
* For Python changes: Have you added tests to cover the new/fixed behaviour?
* For front-end changes: Did you test on all of Wagtail’s supported browsers? **Please list the exact versions you tested**.
* For new features: Has the documentation been updated accordingly?
