### PR TITLE
Fix typo in 2.10 release notes doc

### DIFF
--- a/docs/releases/2.10.rst
+++ b/docs/releases/2.10.rst
@@ -67,7 +67,7 @@ Bug fixes
 Upgrade considerations
 ======================
 
- * Rich text will now be rendered without any markup, to use the old behaviour where a wrapper ``<div class="richt-text">`` is used see :ref:`legacy_richtext`.
+ * Rich text will now be rendered without any markup, to use the old behaviour where a wrapper ``<div class="rich-text">`` is used see :ref:`legacy_richtext`.
 
 
 Removed support for Python 3.5


### PR DESCRIPTION
Caught a loose T in `rich-text` :stuck_out_tongue_closed_eyes: