### PR TITLE
Update signals.rst for Python 3 compatibility

### DIFF
--- a/docs/reference/signals.rst
+++ b/docs/reference/signals.rst
@@ -26,8 +26,8 @@ example showing how you might notify your team when something is published:
 .. code-block:: python
 
     from wagtail.core.signals import page_published
-    import urllib
-    import urllib2
+    import requests
+    import json
 
 
     # Let everyone know when a new page is published
@@ -41,9 +41,8 @@ example showing how you might notify your team when something is published:
             "icon_emoji": ":octopus:"
         }
 
-        data = urllib.urlencode(values)
-        req = urllib2.Request(url, data)
-        response = urllib2.urlopen(req)
+        data = json.dumps(values)
+        response = requests.post(url, data)
 
     # Register a receiver
     page_published.connect(send_to_slack)

--- a/docs/reference/signals.rst
+++ b/docs/reference/signals.rst
@@ -27,7 +27,6 @@ example showing how you might notify your team when something is published:
 
     from wagtail.core.signals import page_published
     import requests
-    import json
 
 
     # Let everyone know when a new page is published
@@ -41,8 +40,7 @@ example showing how you might notify your team when something is published:
             "icon_emoji": ":octopus:"
         }
 
-        data = json.dumps(values)
-        response = requests.post(url, data)
+        response = requests.post(url, values)
 
     # Register a receiver
     page_published.connect(send_to_slack)


### PR DESCRIPTION
The send_to_slack example was not compatible with Python 3. Example is updated using the requests & json libraries (instead of urllib & urllib2)
