### PR TITLE
Update Python and JS test coverage collection to exclude tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -6,6 +6,7 @@ source = wagtail
 
 omit =
     */migrations/*
+    */tests/*
     docs/conf.py
 
 

--- a/package.json
+++ b/package.json
@@ -44,6 +44,10 @@
       "/node_modules/",
       "/build/"
     ],
+    "coveragePathIgnorePatterns": [
+      "/node_modules/",
+      "/tests/"
+    ],
     "setupFiles": [
       "./client/tests/adapter.js",
       "./client/tests/stubs.js",


### PR DESCRIPTION
Updates the configuration of coverage and Jest to exclude the "tests" folders from test coverage collection. Apart from highlighting dead test code, it’s meaningless to collect test coverage on test cases, and skews the coverage percentage towards a higher value than it would have otherwise.

Before this change, we’re currently at [94.34%](https://codecov.io/gh/wagtail/wagtail/branch/master) coverage for the whole codebase. After, we’re at [89.81%](https://codecov.io/gh/wagtail/wagtail/pull/6054/tree).