### PR TITLE
Fix incompatibility issue with django-taggit 1.3.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ except ImportError:
 install_requires = [
     "Django>=2.1,<3.1",
     "django-modelcluster>=5.0,<6.0",
-    "django-taggit>=1.0,<2.0",
+    "django-taggit>=1.0,<1.3",
     "django-treebeard>=4.2.0,<5.0",
     "djangorestframework>=3.7.4,<4.0",
     "django-filter>=2.2,<3.0",


### PR DESCRIPTION
`django-taggit` 1.3.0 was released today, which causes an incompatibility issue with Wagtail, as it introduced new arguments to the API. See: https://github.com/coderedcorp/coderedcms/issues/321

This PR locks Wagtail to < 1.3.0 as a quick fix.
