### PR TITLE
Fix that proper document icon are shown

### DIFF
--- a/wagtail/documents/templates/wagtaildocs/multiple/add.html
+++ b/wagtail/documents/templates/wagtaildocs/multiple/add.html
@@ -13,7 +13,7 @@
 
 {% block content %}
     {% trans "Add documents" as add_str %}
-    {% include "wagtailadmin/shared/header.html" with title=add_str icon="doc" %}
+    {% include "wagtailadmin/shared/header.html" with title=add_str icon="doc-full-inverse" %}
 
     <div class="nice-padding">
         <div class="drop-zone">


### PR DESCRIPTION
I stumbled upon this while researching another issue, it seems like the header for document multiple add (`/admin/images/multiple/add/`) referred to a non-existing icon. This commit makes sure it uses the same class name as the rest of the document headers.

Before:
![Screenshot 2020-05-24 at 15 36 33](https://user-images.githubusercontent.com/286534/82755710-b6e0c480-9dd5-11ea-8254-7e3dc15ddc8e.png)
 
After:
![Screenshot 2020-05-24 at 15 46 37](https://user-images.githubusercontent.com/286534/82755727-ce1fb200-9dd5-11ea-80ea-b3932bc745b1.png)
