### PR TITLE
Hide "add-buttons" in StreamBlock when 'max_num' child blocks is reached

### DIFF
--- a/wagtail/admin/static_src/wagtailadmin/js/blocks/list.js
+++ b/wagtail/admin/static_src/wagtailadmin/js/blocks/list.js
@@ -9,6 +9,7 @@
         return function(elementPrefix) {
             var sequence = Sequence({
                 prefix: elementPrefix,
+				maxNumChildBlocks: Infinity,
                 onInitializeMember: function(sequenceMember) {
                     /* initialize child block's JS behaviour */
                     if (opts.childInitializer) {

--- a/wagtail/admin/static_src/wagtailadmin/js/blocks/sequence.js
+++ b/wagtail/admin/static_src/wagtailadmin/js/blocks/sequence.js
@@ -357,6 +357,6 @@ CODE FOR SETTING UP SPECIFIC UI WIDGETS, SUCH AS DELETE BUTTONS OR MENUS, DOES N
           opts.onDisableAdd(members)
         }
 
-      return self;
+        return self;
     };
 })(jQuery);

--- a/wagtail/admin/static_src/wagtailadmin/js/blocks/sequence.js
+++ b/wagtail/admin/static_src/wagtailadmin/js/blocks/sequence.js
@@ -116,10 +116,10 @@ CODE FOR SETTING UP SPECIFIC UI WIDGETS, SUCH AS DELETE BUTTONS OR MENUS, DOES N
 
             newMember._markAdded();
 
-			if (members.length >= opts.maxNumChildBlocks){
-				/* maximum block capacity has been reached */
-				opts.onDisableAdd(members)
-			}
+            if (members.length >= opts.maxNumChildBlocks){
+                /* maximum block capacity has been reached */
+                opts.onDisableAdd(members)
+            }
         }
 
         function elementFromTemplate(template, newPrefix) {
@@ -253,10 +253,10 @@ CODE FOR SETTING UP SPECIFIC UI WIDGETS, SUCH AS DELETE BUTTONS OR MENUS, DOES N
                 opts.onDisableMoveDown(members[members.length - 1]);
             }
 
-			if (members.length + 1 >= opts.maxNumChildBlocks && members.length < opts.maxNumChildBlocks) {
-				/* there is now capacity left for another block */
-				opts.onEnableAdd(members)
-			}
+            if (members.length + 1 >= opts.maxNumChildBlocks && members.length < opts.maxNumChildBlocks) {
+                /* there is now capacity left for another block */
+                opts.onEnableAdd(members)
+            }
         };
 
         self.moveMemberUp = function(member) {
@@ -353,10 +353,10 @@ CODE FOR SETTING UP SPECIFIC UI WIDGETS, SUCH AS DELETE BUTTONS OR MENUS, DOES N
         }
 
         if (members.length >= opts.maxNumChildBlocks){
-          /* block capacity is already reached on initialization */
-          opts.onDisableAdd(members)
+            /* block capacity is already reached on initialization */
+            opts.onDisableAdd(members)
         }
-
+      
         return self;
     };
 })(jQuery);

--- a/wagtail/admin/static_src/wagtailadmin/js/blocks/sequence.js
+++ b/wagtail/admin/static_src/wagtailadmin/js/blocks/sequence.js
@@ -352,6 +352,11 @@ CODE FOR SETTING UP SPECIFIC UI WIDGETS, SUCH AS DELETE BUTTONS OR MENUS, DOES N
             }
         }
 
-        return self;
+        if (members.length >= opts.maxNumChildBlocks){
+          /* block capacity is already reached on initialization */
+          opts.onDisableAdd(members)
+        }
+
+      return self;
     };
 })(jQuery);

--- a/wagtail/admin/static_src/wagtailadmin/js/blocks/sequence.js
+++ b/wagtail/admin/static_src/wagtailadmin/js/blocks/sequence.js
@@ -115,6 +115,11 @@ CODE FOR SETTING UP SPECIFIC UI WIDGETS, SUCH AS DELETE BUTTONS OR MENUS, DOES N
             }
 
             newMember._markAdded();
+
+			if (members.length >= opts.maxNumChildBlocks){
+				/* maximum block capacity has been reached */
+				opts.onDisableAdd(members)
+			}
         }
 
         function elementFromTemplate(template, newPrefix) {
@@ -247,6 +252,11 @@ CODE FOR SETTING UP SPECIFIC UI WIDGETS, SUCH AS DELETE BUTTONS OR MENUS, DOES N
                 /* deleting the last member; the new last member cannot move down now */
                 opts.onDisableMoveDown(members[members.length - 1]);
             }
+
+			if (members.length + 1 >= opts.maxNumChildBlocks && members.length < opts.maxNumChildBlocks) {
+				/* there is now capacity left for another block */
+				opts.onEnableAdd(members)
+			}
         };
 
         self.moveMemberUp = function(member) {

--- a/wagtail/admin/static_src/wagtailadmin/js/blocks/stream.js
+++ b/wagtail/admin/static_src/wagtailadmin/js/blocks/stream.js
@@ -81,6 +81,7 @@
         return function(elementPrefix) {
             var sequence = Sequence({
                 prefix: elementPrefix,
+				maxNumChildBlocks: opts.maxNumChildBlocks,
                 onInitializeMember: function(sequenceMember) {
                     /* initialize child block's JS behaviour */
                     var blockTypeName = $('#' + sequenceMember.prefix + '-type').val();
@@ -129,7 +130,26 @@
 
                 onDisableMoveDown: function(sequenceMember) {
                     $('#' + sequenceMember.prefix + '-movedown').addClass('disabled');
-                }
+                },
+				
+				onDisableAdd: function(members) {
+					for (var i = 0; i < members.length; i++){
+						$('#' + members[i].prefix + '-appendmenu-openclose')
+							.removeClass('c-sf-add-button--visible').delay(300).slideUp()
+					}
+					$('#' + elementPrefix + '-prependmenu-openclose')
+						.removeClass('c-sf-add-button--visible').delay(300).slideUp()
+				},
+
+				onEnableAdd: function(members) {
+					for (var i = 0; i < members.length; i++){
+						
+						$('#' + members[i].prefix + '-appendmenu-openclose')
+							.addClass('c-sf-add-button--visible').delay(300).slideDown()
+					}
+					$('#' + elementPrefix + '-prependmenu-openclose')
+						.addClass('c-sf-add-button--visible').delay(300).slideDown()
+				}
             });
 
             /* Set up the 'prepend a block' menu that appears above the first block in the sequence */

--- a/wagtail/admin/static_src/wagtailadmin/js/blocks/stream.js
+++ b/wagtail/admin/static_src/wagtailadmin/js/blocks/stream.js
@@ -81,7 +81,7 @@
         return function(elementPrefix) {
             var sequence = Sequence({
                 prefix: elementPrefix,
-				maxNumChildBlocks: opts.maxNumChildBlocks,
+                maxNumChildBlocks: opts.maxNumChildBlocks,
                 onInitializeMember: function(sequenceMember) {
                     /* initialize child block's JS behaviour */
                     var blockTypeName = $('#' + sequenceMember.prefix + '-type').val();
@@ -131,25 +131,25 @@
                 onDisableMoveDown: function(sequenceMember) {
                     $('#' + sequenceMember.prefix + '-movedown').addClass('disabled');
                 },
-				
-				onDisableAdd: function(members) {
-					for (var i = 0; i < members.length; i++){
-						$('#' + members[i].prefix + '-appendmenu-openclose')
-							.removeClass('c-sf-add-button--visible').delay(300).slideUp()
-					}
-					$('#' + elementPrefix + '-prependmenu-openclose')
-						.removeClass('c-sf-add-button--visible').delay(300).slideUp()
-				},
+                
+                onDisableAdd: function(members) {
+                    for (var i = 0; i < members.length; i++){
+                        $('#' + members[i].prefix + '-appendmenu-openclose')
+                            .removeClass('c-sf-add-button--visible').delay(300).slideUp()
+                    }
+                    $('#' + elementPrefix + '-prependmenu-openclose')
+                        .removeClass('c-sf-add-button--visible').delay(300).slideUp()
+                },
 
-				onEnableAdd: function(members) {
-					for (var i = 0; i < members.length; i++){
-						
-						$('#' + members[i].prefix + '-appendmenu-openclose')
-							.addClass('c-sf-add-button--visible').delay(300).slideDown()
-					}
-					$('#' + elementPrefix + '-prependmenu-openclose')
-						.addClass('c-sf-add-button--visible').delay(300).slideDown()
-				}
+                onEnableAdd: function(members) {
+                    for (var i = 0; i < members.length; i++){
+                        
+                        $('#' + members[i].prefix + '-appendmenu-openclose')
+                            .addClass('c-sf-add-button--visible').delay(300).slideDown()
+                    }
+                    $('#' + elementPrefix + '-prependmenu-openclose')
+                        .addClass('c-sf-add-button--visible').delay(300).slideDown()
+                }
             });
 
             /* Set up the 'prepend a block' menu that appears above the first block in the sequence */

--- a/wagtail/core/blocks/stream_block.py
+++ b/wagtail/core/blocks/stream_block.py
@@ -118,6 +118,7 @@ class BaseStreamBlock(Block):
         opts = {
             'definitionPrefix': "'%s'" % self.definition_prefix,
             'childBlocks': '[\n%s\n]' % ',\n'.join(child_blocks),
+            'maxNumChildBlocks': 'Infinity' if self.meta.max_num is None else ('%s' % self.meta.max_num),
         }
 
         return "StreamBlock(%s)" % js_dict(opts)


### PR DESCRIPTION
This change hides the add-buttons in the `StreamBlock` interface when `max_num` number of child blocks is reached. This also adds two new callbacks to sequence.js, onDisableAdd and onEnableAdd that is called whenever the number of members reach or dip below the maximum number of allowed children.

Setting `max_num` to 1 now makes it simple and intuitive to create the commonly requested "choose one"-style block, which allows users to pick one block from a set. This is functionally similar to the type of conditional rendering other CMS-interfaces regularly provide.

If #2379 or #3914 ever gets resolved, it would be trivial to make the ListBlock interface behave similarly by hooking into the callbacks.

