### PR TITLE
A couple of minor tweaks to the admin search

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/pages/search_results.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/search_results.html
@@ -38,7 +38,7 @@
         {% paginate pages base_url=pagination_base_url %}
     {% else %}
         {% if query_string %}
-            <h2 role="alert">{% blocktrans %}Sorry, no pages match <em>"{{ query_string }}"</em>{% endblocktrans %}</h2>
+            <h2 role="alert">{% blocktrans %}Sorry, no pages match <em>{{ query_string }}</em>{% endblocktrans %}</h2>
 
             {% search_other %}
         {% else %}

--- a/wagtail/admin/views/pages.py
+++ b/wagtail/admin/views/pages.py
@@ -1033,7 +1033,7 @@ def search(request):
             pagination_query_params['q'] = q
 
             # Parse query
-            filters, query = parse_query_string(q, operator='and')
+            filters, query = parse_query_string(q, operator='and', zero_terms=MATCH_ALL)
 
             # Live filter
             live_filter = filters.get('live') or filters.get('published')


### PR DESCRIPTION
Set the `zero_terms` parameter to `MATCH_ALL` so filters in the query string run if there are no search terms.
Remove the quotes from around the query string in the "Sorry, no pages match" message. This makes the output less messy when doing phrase searches.