### PR TITLE
Fix RestaurantTag migration tests introducing an extra migration

### DIFF
--- a/wagtail/tests/testapp/migrations/0047_restaurant_tags.py
+++ b/wagtail/tests/testapp/migrations/0047_restaurant_tags.py
@@ -28,8 +28,8 @@ class Migration(migrations.Migration):
             name='RestaurantTag',
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('name', models.CharField(max_length=100, unique=True, verbose_name='Name')),
-                ('slug', models.SlugField(max_length=100, unique=True, verbose_name='Slug')),
+                ('name', models.CharField(max_length=100, unique=True, verbose_name='name')),
+                ('slug', models.SlugField(max_length=100, unique=True, verbose_name='slug')),
             ],
             options={
                 'verbose_name': 'Tag',


### PR DESCRIPTION
Follow-up for https://github.com/wagtail/django-modelcluster/pull/123, fixing another change in django-taggit 1.3.0 that breaks our tests. For this one I’m pretty sure this just breaks Wagtail’s tests but has no other consequences for websites (well, except for the extra migration they’ll get as well).

Since those migrations are just here for tests I’ve assumed it was ok to edit the existing migration as the only change is with `verbose_name`.

Change from django-taggit: https://github.com/jazzband/django-taggit/commit/90c7224018c941b9a260c8e8bed166536f5870df

---

* [x] Do the tests still pass? (https://docs.wagtail.io/en/latest/contributing/developing.html#testing)
* [x] Does the code comply with the style guide? (Run `make lint` from the Wagtail root)
* [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
* ~[ ] For front-end changes: Did you test on all of Wagtail’s supported browsers? **Please list the exact versions you tested**.~
* ~[ ] For new features: Has the documentation been updated accordingly?~
