### PR TITLE
Fix JS linting issue that slipped into SVG icon PR

### DIFF
--- a/client/src/components/Explorer/ExplorerItem.js
+++ b/client/src/components/Explorer/ExplorerItem.js
@@ -47,7 +47,11 @@ const ExplorerItem = ({ item, onClick }) => {
           onClick={onClick}
           href={`${ADMIN_URLS.PAGES}${id}/`}
         >
-          <Icon name="arrow-right" title={STRINGS.VIEW_CHILD_PAGES_OF_PAGE.replace('{title}', title)} className="icon--item-action" />
+          <Icon
+            name="arrow-right"
+            title={STRINGS.VIEW_CHILD_PAGES_OF_PAGE.replace('{title}', title)}
+            className="icon--item-action"
+          />
         </Button>
       ) : null}
     </div>


### PR DESCRIPTION
In #4821, we accidentally merged a line of JavaScript that was too long. This change breaks it across multiple lines.