### PR TITLE
Fix for IndexView to allow AdminModel methods for fields #6076

### DIFF
--- a/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
+++ b/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from io import BytesIO
 from unittest import mock
 
@@ -73,10 +74,13 @@ class TestBookIndexView(TestCase, WagtailTestUtils):
         worksheet = load_workbook(filename=BytesIO(workbook_data))['Sheet1']
         cell_array = [[cell.value for cell in row] for row in worksheet.rows]
         self.assertEqual(cell_array[0], ['Title', 'Author', 'Author Date Of Birth'])
-        self.assertEqual(cell_array[1], ['Charlie and the Chocolate Factory', 'Roald Dahl', '1916-09-13'])
-        self.assertEqual(cell_array[2], ['The Chronicles of Narnia', 'Roald Dahl', '1898-11-29'])
-        self.assertEqual(cell_array[3], ['The Hobbit', 'J. R. R. Tolkien', '1892-01-03'])
-        self.assertEqual(cell_array[4], ['The Lord of the Rings', 'J. R. R. Tolkien', '1892-01-03'])
+        self.assertEqual(cell_array[1], ['Charlie and the Chocolate Factory', 'Roald Dahl', datetime(1916, 9, 13)])
+        # Dates before 1900 are not handled by Excel. This works around that by expecting the dates as
+        # openpyxl parses dates.
+        # See: https://bitbucket.org/openpyxl/openpyxl/issues/1325/python-dates-before-march-1-1900-are
+        self.assertEqual(cell_array[2], ['The Chronicles of Narnia', 'Roald Dahl', datetime(1898, 11, 28)])
+        self.assertEqual(cell_array[3], ['The Hobbit', 'J. R. R. Tolkien', datetime(1892, 1, 2)])
+        self.assertEqual(cell_array[4], ['The Lord of the Rings', 'J. R. R. Tolkien', datetime(1892, 1, 2)])
         self.assertEqual(len(cell_array), 5)
 
     def test_tr_attributes(self):

--- a/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
+++ b/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
@@ -54,11 +54,11 @@ class TestBookIndexView(TestCase, WagtailTestUtils):
 
         # Check response - all books should be in it
         data_lines = response.getvalue().decode().split("\n")
-        self.assertEqual(data_lines[0], 'Title,Author\r')
-        self.assertEqual(data_lines[1], 'Charlie and the Chocolate Factory,Roald Dahl\r')
-        self.assertEqual(data_lines[2], 'The Chronicles of Narnia,Roald Dahl\r')
-        self.assertEqual(data_lines[3], 'The Hobbit,J. R. R. Tolkien\r')
-        self.assertEqual(data_lines[4], 'The Lord of the Rings,J. R. R. Tolkien\r')
+        self.assertEqual(data_lines[0], 'Title,Author,Author Date Of Birth\r')
+        self.assertEqual(data_lines[1], 'Charlie and the Chocolate Factory,Roald Dahl,1916-09-13\r')
+        self.assertEqual(data_lines[2], 'The Chronicles of Narnia,Roald Dahl,1898-11-29\r')
+        self.assertEqual(data_lines[3], 'The Hobbit,J. R. R. Tolkien,1892-01-03\r')
+        self.assertEqual(data_lines[4], 'The Lord of the Rings,J. R. R. Tolkien,1892-01-03\r')
 
     def test_xlsx_export(self):
         # Export the whole queryset
@@ -72,11 +72,11 @@ class TestBookIndexView(TestCase, WagtailTestUtils):
         workbook_data = response.getvalue()
         worksheet = load_workbook(filename=BytesIO(workbook_data))['Sheet1']
         cell_array = [[cell.value for cell in row] for row in worksheet.rows]
-        self.assertEqual(cell_array[0], ['Title', 'Author'])
-        self.assertEqual(cell_array[1], ['Charlie and the Chocolate Factory', 'Roald Dahl'])
-        self.assertEqual(cell_array[2], ['The Chronicles of Narnia', 'Roald Dahl'])
-        self.assertEqual(cell_array[3], ['The Hobbit', 'J. R. R. Tolkien'])
-        self.assertEqual(cell_array[4], ['The Lord of the Rings', 'J. R. R. Tolkien'])
+        self.assertEqual(cell_array[0], ['Title', 'Author', 'Author Date Of Birth'])
+        self.assertEqual(cell_array[1], ['Charlie and the Chocolate Factory', 'Roald Dahl','1916-09-13'])
+        self.assertEqual(cell_array[2], ['The Chronicles of Narnia', 'Roald Dahl', '1898-11-29'])
+        self.assertEqual(cell_array[3], ['The Hobbit', 'J. R. R. Tolkien','1892-01-03'])
+        self.assertEqual(cell_array[4], ['The Lord of the Rings', 'J. R. R. Tolkien','1892-01-03'])
         self.assertEqual(len(cell_array), 5)
 
     def test_tr_attributes(self):
@@ -111,9 +111,9 @@ class TestBookIndexView(TestCase, WagtailTestUtils):
         # Check response - only books by JRR Tolkien should be in it
         self.assertEqual(response.status_code, 200)
         data_lines = response.getvalue().decode().split("\n")
-        self.assertEqual(data_lines[0], 'Title,Author\r')
-        self.assertEqual(data_lines[1], 'The Hobbit,J. R. R. Tolkien\r')
-        self.assertEqual(data_lines[2], 'The Lord of the Rings,J. R. R. Tolkien\r')
+        self.assertEqual(data_lines[0], 'Title,Author,Author Date Of Birth\r')
+        self.assertEqual(data_lines[1], 'The Hobbit,J. R. R. Tolkien,1892-01-03\r')
+        self.assertEqual(data_lines[2], 'The Lord of the Rings,J. R. R. Tolkien,1892-01-03\r')
         self.assertEqual(data_lines[3], '')
 
     def test_search_indexed(self):

--- a/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
+++ b/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
@@ -73,10 +73,10 @@ class TestBookIndexView(TestCase, WagtailTestUtils):
         worksheet = load_workbook(filename=BytesIO(workbook_data))['Sheet1']
         cell_array = [[cell.value for cell in row] for row in worksheet.rows]
         self.assertEqual(cell_array[0], ['Title', 'Author', 'Author Date Of Birth'])
-        self.assertEqual(cell_array[1], ['Charlie and the Chocolate Factory', 'Roald Dahl','1916-09-13'])
+        self.assertEqual(cell_array[1], ['Charlie and the Chocolate Factory', 'Roald Dahl', '1916-09-13'])
         self.assertEqual(cell_array[2], ['The Chronicles of Narnia', 'Roald Dahl', '1898-11-29'])
-        self.assertEqual(cell_array[3], ['The Hobbit', 'J. R. R. Tolkien','1892-01-03'])
-        self.assertEqual(cell_array[4], ['The Lord of the Rings', 'J. R. R. Tolkien','1892-01-03'])
+        self.assertEqual(cell_array[3], ['The Hobbit', 'J. R. R. Tolkien', '1892-01-03'])
+        self.assertEqual(cell_array[4], ['The Lord of the Rings', 'J. R. R. Tolkien', '1892-01-03'])
         self.assertEqual(len(cell_array), 5)
 
     def test_tr_attributes(self):

--- a/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
+++ b/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from io import BytesIO
 from unittest import mock
 
@@ -74,13 +73,10 @@ class TestBookIndexView(TestCase, WagtailTestUtils):
         worksheet = load_workbook(filename=BytesIO(workbook_data))['Sheet1']
         cell_array = [[cell.value for cell in row] for row in worksheet.rows]
         self.assertEqual(cell_array[0], ['Title', 'Author', 'Author Date Of Birth'])
-        self.assertEqual(cell_array[1], ['Charlie and the Chocolate Factory', 'Roald Dahl', datetime(1916, 9, 13)])
-        # Dates before 1900 are not handled by Excel. This works around that by expecting the dates as
-        # openpyxl parses dates.
-        # See: https://bitbucket.org/openpyxl/openpyxl/issues/1325/python-dates-before-march-1-1900-are
-        self.assertEqual(cell_array[2], ['The Chronicles of Narnia', 'Roald Dahl', datetime(1898, 11, 28)])
-        self.assertEqual(cell_array[3], ['The Hobbit', 'J. R. R. Tolkien', datetime(1892, 1, 2)])
-        self.assertEqual(cell_array[4], ['The Lord of the Rings', 'J. R. R. Tolkien', datetime(1892, 1, 2)])
+        self.assertEqual(cell_array[1], ['Charlie and the Chocolate Factory', 'Roald Dahl', '1916-09-13'])
+        self.assertEqual(cell_array[2], ['The Chronicles of Narnia', 'Roald Dahl', '1898-11-29'])
+        self.assertEqual(cell_array[3], ['The Hobbit', 'J. R. R. Tolkien', '1892-01-03'])
+        self.assertEqual(cell_array[4], ['The Lord of the Rings', 'J. R. R. Tolkien', '1892-01-03'])
         self.assertEqual(len(cell_array), 5)
 
     def test_tr_attributes(self):

--- a/wagtail/contrib/modeladmin/views.py
+++ b/wagtail/contrib/modeladmin/views.py
@@ -274,7 +274,7 @@ class IndexView(SpreadsheetExportMixin, WMABaseView):
         heading_override = self.export_headings.get(field)
         if heading_override:
             return force_str(heading_override)
-        return force_str(label_for_field(field, model=self.model).title())
+        return force_str(label_for_field(field, model=self.model, model_admin=self.model_admin).title())
 
     def to_row_dict(self, item):
         """ Returns an OrderedDict (in the order given by list_export) of the exportable information for a model instance"""
@@ -283,7 +283,7 @@ class IndexView(SpreadsheetExportMixin, WMABaseView):
             f, attr, value = lookup_field(field, item, self.model_admin)
             if not value:
                 value = getattr(attr, 'empty_value_display', self.model_admin.get_empty_value_display(field))
-            row_dict[field] = value
+            row_dict[field] = force_str(value)
 
         return row_dict
 

--- a/wagtail/contrib/modeladmin/views.py
+++ b/wagtail/contrib/modeladmin/views.py
@@ -283,7 +283,7 @@ class IndexView(SpreadsheetExportMixin, WMABaseView):
             f, attr, value = lookup_field(field, item, self.model_admin)
             if not value:
                 value = getattr(attr, 'empty_value_display', self.model_admin.get_empty_value_display(field))
-            row_dict[field] = force_str(value)
+            row_dict[field] = value
 
         return row_dict
 

--- a/wagtail/tests/modeladmintest/wagtail_hooks.py
+++ b/wagtail/tests/modeladmintest/wagtail_hooks.py
@@ -2,7 +2,7 @@ from wagtail.admin.edit_handlers import FieldPanel, ObjectList, TabbedInterface
 from wagtail.contrib.modeladmin.helpers import WagtailBackendSearchHandler
 from wagtail.contrib.modeladmin.options import (
     ModelAdmin, ModelAdminGroup, ThumbnailMixin, modeladmin_register)
-from wagtail.contrib.modeladmin.views import CreateView
+from wagtail.contrib.modeladmin.views import CreateView, IndexView
 from wagtail.tests.testapp.models import BusinessChild, EventPage, SingleEventPage
 
 from .forms import PublisherModelAdminForm
@@ -42,8 +42,25 @@ class AuthorModelAdmin(ModelAdmin):
         return attrs
 
 
+class BookModelIndexView(IndexView):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # Dates before 1900 are not handled by Excel. This works around that
+        # by serializing dates in iso format.
+        # See: https://bitbucket.org/openpyxl/openpyxl/issues/1325/python-dates-before-march-1-1900-are
+        # And:  https://en.wikipedia.org/wiki/Year_1900_problem#Microsoft_Excel
+        def date_isoformat(date_obj):
+            return date_obj.isoformat()
+
+        self.custom_field_preprocess = {
+            'author_date_of_birth': {'xlsx': date_isoformat}
+        }
+
+
 class BookModelAdmin(ThumbnailMixin, ModelAdmin):
     model = Book
+    index_view_class = BookModelIndexView
     menu_order = 300
     list_display = ('title', 'author', 'admin_thumb')
     list_export = ('title', 'author', 'author_date_of_birth')

--- a/wagtail/tests/modeladmintest/wagtail_hooks.py
+++ b/wagtail/tests/modeladmintest/wagtail_hooks.py
@@ -46,7 +46,7 @@ class BookModelAdmin(ThumbnailMixin, ModelAdmin):
     model = Book
     menu_order = 300
     list_display = ('title', 'author', 'admin_thumb')
-    list_export = ('title', 'author')
+    list_export = ('title', 'author', 'author_date_of_birth')
     list_filter = ('author', )
     export_filename = "books-export"
     ordering = ('title', )
@@ -60,6 +60,9 @@ class BookModelAdmin(ThumbnailMixin, ModelAdmin):
             'data-author-yob': obj.author.date_of_birth.year,
             'class': 'book',
         }
+
+    def author_date_of_birth(self, obj):
+        return obj.author.date_of_birth
 
 
 class TokenModelAdmin(ModelAdmin):


### PR DESCRIPTION
Fixes issue #6076
For xlsx and csv export, list_export should behave like list_display. The bug was that the model_admin wasn't passed along to allow field lookups to be resolved by model_admin methods.

- Added method to do lookup on Book model to Author.date_of_birth
- Added tests to cover this case
- Verified that test fail
- Added fix in IndexView.get_heading
- Verified that tests now pass