### PR TITLE
Site hostnames duplicates

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -17,6 +17,7 @@ Changelog
  * Fix: Support creating `StructValue` copies (Tidiane Dia)
  * Fix: Fix image uploads on storage backends that require file pointer to be at the start of the file (Matt Westcott)
  * Fix: Fix "Edit this page" missing from userbar (Satvik Vashisht)
+ * Fix: No longer allow invalid duplicate site hostname creation as hostnames and domain names are a case insensitive (Coen van der Kamp)
  * Docs: Add code block to make it easier to understand contribution docs (Suyash Singh)
  * Docs: Add new "Icons" page for icons customisation and reuse across the admin interface (Coen van der Kamp)
  * Docs: Fix broken formatting for MultiFieldPanel / FieldRowPanel permission kwarg docs (Matt Westcott)

--- a/docs/releases/5.0.md
+++ b/docs/releases/5.0.md
@@ -30,6 +30,7 @@ depth: 1
  * Resize in the correct direction for RTL languages with the side panel resizer (Sage Abdullah)
  * Fix image uploads on storage backends that require file pointer to be at the start of the file (Matt Westcott)
  * Fix "Edit this page" missing from userbar (Satvik Vashisht)
+ * No longer allow invalid duplicate site hostname creation as hostnames and domain names are a case insensitive (Coen van der Kamp)
 
 ### Documentation
 

--- a/wagtail/admin/templates/wagtailadmin/generic/form.html
+++ b/wagtail/admin/templates/wagtailadmin/generic/form.html
@@ -1,12 +1,16 @@
 {% extends "wagtailadmin/generic/base.html" %}
-{% load i18n %}
+{% load i18n wagtailadmin_tags %}
 
 {% block main_content %}
     {% block before_form %}{% endblock %}
     <form action="{{ action_url }}" method="POST" novalidate{% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>
         {% csrf_token %}
 
-        {{ form.non_field_errors }}
+        {% block non_field_errors %}
+            {% for error in form.non_field_errors %}
+                {% help_block status="critical" %}{{ error }}{% endhelp_block %}
+            {% endfor %}
+        {% endblock %}
 
         {% block hidden_fields %}
             {% for field in form.hidden_fields %}{{ field }}{% endfor %}

--- a/wagtail/admin/templates/wagtailadmin/generic/form.html
+++ b/wagtail/admin/templates/wagtailadmin/generic/form.html
@@ -6,6 +6,8 @@
     <form action="{{ action_url }}" method="POST" novalidate{% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>
         {% csrf_token %}
 
+        {{ form.non_field_errors }}
+
         {% block hidden_fields %}
             {% for field in form.hidden_fields %}{{ field }}{% endfor %}
         {% endblock %}

--- a/wagtail/models/sites.py
+++ b/wagtail/models/sites.py
@@ -129,6 +129,9 @@ class Site(models.Model):
                 + (default_suffix if self.is_default_site else "")
             )
 
+    def clean(self):
+        self.hostname = self.hostname.lower()
+
     @staticmethod
     def find_for_request(request):
         """

--- a/wagtail/sites/tests.py
+++ b/wagtail/sites/tests.py
@@ -154,9 +154,12 @@ class TestSiteCreateView(WagtailTestUtils, TestCase):
             {"hostname": "localhost", "port": "80", "root_page": str(self.home_page.id)}
         )
         expected_html = """
-            <ul class="errorlist nonfield">
-                <li>Site with this Hostname and Port already exists.</li>
-            </ul>
+            <div class="help-block help-critical">
+                <svg class="icon icon-warning icon" aria-hidden="true">
+                    <use href="#icon-warning"></use>
+                </svg>
+                Site with this Hostname and Port already exists.
+            </div>
         """
         self.assertTagInHTML(expected_html, str(response.content))
 
@@ -283,13 +286,13 @@ class TestSiteEditView(WagtailTestUtils, TestCase):
             hostname="something_different",
             port=80,
             is_default_site=False,
-            root_page=self.home_page
+            root_page=self.home_page,
         )
         response = self.post(
             {
-                'hostname': "Localhost",
+                "hostname": "Localhost",
             },
-            site_id=second_site.id
+            site_id=second_site.id,
         )
 
         # Should return the form with errors
@@ -304,18 +307,21 @@ class TestSiteEditView(WagtailTestUtils, TestCase):
             hostname="something_different",
             port=80,
             is_default_site=False,
-            root_page=self.home_page
+            root_page=self.home_page,
         )
         response = self.post(
             {
-                'hostname': "Localhost",
+                "hostname": "Localhost",
             },
-            site_id=second_site.id
+            site_id=second_site.id,
         )
         expected_html = """
-            <ul class="errorlist nonfield">
-                <li>Site with this Hostname and Port already exists.</li>
-            </ul>
+            <div class="help-block help-critical">
+                <svg class="icon icon-warning icon" aria-hidden="true">
+                    <use href="#icon-warning"></use>
+                </svg>
+                Site with this Hostname and Port already exists.
+            </div>
         """
         self.assertTagInHTML(expected_html, str(response.content))
 


### PR DESCRIPTION
https://github.com/wagtail/wagtail/issues/6085

This PR:
- Prevents duplicates. Adding `foo.com` and `Foo.com` raises an error.
- Adds non field errors too create and edit templates

* Do the tests still pass? Y
* Does the code comply with the style guide? Y
* For Python changes: Have you added tests to cover the new/fixed behaviour? Y
* For front-end changes: Did you test on all of Wagtail’s supported browsers? N
* For new features: Has the documentation been updated accordingly? N/A

# Current
Non field errors are not rendered at all.

# This pr
<img width="952" alt="Screenshot 2020-06-03 at 17 41 55" src="https://user-images.githubusercontent.com/1969342/83657833-aee90780-a5c1-11ea-8a30-244e028e2bcc.png">

The `.help-critical` styling is broken. The icon is gone, and indentation is off. (outside of the scope of this pr, I'll create a new issue).
