### PR TITLE
Update AbstractForm to use mode_name for preview mode

### DIFF
--- a/wagtail/contrib/forms/models.py
+++ b/wagtail/contrib/forms/models.py
@@ -257,12 +257,12 @@ class AbstractForm(Page):
         ('landing', _('Landing page')),
     ]
 
-    def serve_preview(self, request, mode):
-        if mode == 'landing':
+    def serve_preview(self, request, mode_name):
+        if mode_name == 'landing':
             request.is_preview = True
             return self.render_landing_page(request)
         else:
-            return super().serve_preview(request, mode)
+            return super().serve_preview(request, mode_name)
 
 
 class AbstractEmailForm(AbstractForm):


### PR DESCRIPTION
- clean up to align with other usage across Wagtail
- no functionality change, just a naming convention change to align with similar usage across other files in Wagtail