### PR TITLE
add gitignore to tests folder - ignore test-media sub-folder

### DIFF
--- a/wagtail/tests/.gitignore
+++ b/wagtail/tests/.gitignore
@@ -1,0 +1,1 @@
+test-media


### PR DESCRIPTION
A minor clean up item, when tests run they create a bunch of files in the tests/test-media folder, this will ensure these files will not show up in git.