### PR TITLE
Add note about Elasticsearch backend credentials to docs

### DIFF
--- a/docs/topics/search/backends.rst
+++ b/docs/topics/search/backends.rst
@@ -143,6 +143,18 @@ The backend is configured in settings:
 
 Other than ``BACKEND``, the keys are optional and default to the values shown. Any defined key in ``OPTIONS`` is passed directly to the Elasticsearch constructor as case-sensitive keyword argument (e.g. ``'max_retries': 1``).
 
+A username and password may be optionally be supplied to the ``URL`` field to provide authentication credentials for the Elasticsearch service:
+
+.. code-block:: python
+
+  WAGTAILSEARCH_BACKENDS = {
+      'default': {
+          ...
+          'URLS': ['http://username:password@localhost:9200'],
+          ...
+      }
+  }
+
 ``INDEX_SETTINGS`` is a dictionary used to override the default settings to create the index. The default settings are defined inside the ``ElasticsearchSearchBackend`` class in the module ``wagtail/wagtail/wagtailsearch/backends/elasticsearch.py``. Any new key is added, any existing key, if not a dictionary, is replaced with the new value. Here's a sample on how to configure the number of shards and setting the Italian LanguageAnalyzer as the default analyzer:
 
 .. code-block:: python


### PR DESCRIPTION
I was configuring an Elasticsearch backend today to require authentication, and went through the source code to find a way to pass a username and password. I didn't see this information in the docs anywhere, and thought it might be a useful note to have available.