### PR TITLE
Strip away HTML tags from RichText searchable content

### DIFF
--- a/wagtail/core/blocks/field_block.py
+++ b/wagtail/core/blocks/field_block.py
@@ -1,4 +1,5 @@
 import datetime
+from html import unescape
 
 from django import forms
 from django.db.models.fields import BLANK_CHOICE_DASH
@@ -7,7 +8,7 @@ from django.template.loader import render_to_string
 from django.utils.dateparse import parse_date, parse_datetime, parse_time
 from django.utils.encoding import force_str
 from django.utils.functional import cached_property
-from django.utils.html import format_html
+from django.utils.html import format_html, strip_tags
 from django.utils.safestring import mark_safe
 
 from wagtail.core.rich_text import RichText
@@ -572,7 +573,9 @@ class RichTextBlock(FieldBlock):
         return RichText(value)
 
     def get_searchable_content(self, value):
-        return [force_str(value.source)]
+        # Strip HTML tags to prevent search backend to index them
+        source = force_str(value.source)
+        return [unescape(strip_tags(source))]
 
     class Meta:
         icon = "doc-full"

--- a/wagtail/core/fields.py
+++ b/wagtail/core/fields.py
@@ -1,7 +1,10 @@
 import json
+from html import unescape
 
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db import models
+from django.utils.encoding import force_str
+from django.utils.html import strip_tags
 
 from wagtail.core.blocks import Block, BlockField, StreamBlock, StreamValue
 
@@ -18,6 +21,11 @@ class RichTextField(models.TextField):
         defaults = {'widget': get_rich_text_editor_widget(self.editor, features=self.features)}
         defaults.update(kwargs)
         return super().formfield(**defaults)
+
+    def get_searchable_content(self, value):
+        # Strip HTML tags to prevent search backend to index them
+        source = force_str(value)
+        return [unescape(strip_tags(source))]
 
 
 # https://github.com/django/django/blob/64200c14e0072ba0ffef86da46b2ea82fd1e019a/django/db/models/fields/subclassing.py#L31-L44

--- a/wagtail/core/tests/test_blocks.py
+++ b/wagtail/core/tests/test_blocks.py
@@ -549,6 +549,20 @@ class TestRichTextBlock(TestCase):
         with self.assertRaises(ValidationError):
             block.clean(RichText('<p>bar</p>'))
 
+    def test_get_searchable_content(self):
+        block = blocks.RichTextBlock()
+        value = RichText(
+            '<p>Merry <a linktype="page" id="4">Christmas</a>!</p>\n'
+            '<p>Our Santa pet <b>Wagtail</b> has some cool stuff in store for you all!</p>'
+        )
+        result = block.get_searchable_content(value)
+        self.assertEqual(
+            result, [
+                'Merry Christmas!\n'
+                'Our Santa pet Wagtail has some cool stuff in store for you all!'
+            ]
+        )
+
 
 class TestChoiceBlock(WagtailTestUtils, SimpleTestCase):
     def setUp(self):

--- a/wagtail/core/tests/test_rich_text.py
+++ b/wagtail/core/tests/test_rich_text.py
@@ -6,6 +6,7 @@ from wagtail.core.rich_text import RichText, expand_db_html
 from wagtail.core.rich_text.feature_registry import FeatureRegistry
 from wagtail.core.rich_text.pages import PageLinkHandler
 from wagtail.core.rich_text.rewriters import LinkRewriter, extract_attrs
+from wagtail.tests.testapp.models import EventPage
 
 
 class TestPageLinktypeHandler(TestCase):
@@ -159,3 +160,17 @@ class TestLinkRewriterTagReplacing(TestCase):
         # Also call the rule if a custom linktype is mentioned.
         link_with_custom_linktype = rewriter('<a linktype="custom" href="tel:+4917640206387">')
         self.assertEqual(link_with_custom_linktype, '<a data-phone="true" href="tel:+4917640206387">')
+
+
+class TestRichTextField(TestCase):
+    fixtures = ['test.json']
+
+    def test_get_searchable_content(self):
+        christmas_page = EventPage.objects.get(url_path='/home/events/christmas/')
+        christmas_page.body = '<p><b>Merry Christmas from <a href="https://wagtail.io/">Wagtail!</a></b></p>'
+        christmas_page.save_revision(submitted_for_moderation=False)
+
+        body_field = christmas_page._meta.get_field('body')
+        value = body_field.value_from_object(christmas_page)
+        result = body_field.get_searchable_content(value)
+        self.assertEqual(result, ['Merry Christmas from Wagtail!'])


### PR DESCRIPTION
Fixes #6098

So far I only stripped HTML tags in searchable contents of `RichTextBlock`s per @gasman's proposal in the issue. Stripping out tags from `RichTextField`s are ~~currently a work in progress, so I'll remove the draft status from this PR once that's done.~~

**Edit:** `RichTextField.get_searchable_content` has been added (and was easier to implement than I thought).

---

* Do the tests still pass? Yes
* Does the code comply with the style guide? Yes
* For Python changes: Have you added tests to cover the new/fixed behaviour? Yes