### PR TITLE
Fix JS not working in IE11 due to using unimplemented NodeList#forEach

### DIFF
--- a/wagtail/admin/static_src/wagtailadmin/js/core.js
+++ b/wagtail/admin/static_src/wagtailadmin/js/core.js
@@ -539,16 +539,20 @@ wagtail = (function(document, window, wagtail) {
     wagtail.ui.initDropDowns = initDropDowns;
     wagtail.ui.DropDownController = DropDownController;
 
+    function qsa(element, selector) {
+      return [].slice.call(element.querySelectorAll(selector));
+    }
+
     // Initialise button selectors
     function initButtonSelects() {
-        document.querySelectorAll('.button-select').forEach(function(element) {
+        qsa(document, '.button-select').forEach(function(element) {
             var inputElement = element.querySelector('input[type="hidden"]');
-            element.querySelectorAll('.button-select__option').forEach(function(buttonElement) {
+            qsa(element, '.button-select__option').forEach(function(buttonElement) {
                 buttonElement.addEventListener('click', function(e) {
                     e.preventDefault();
                     inputElement.value = buttonElement.value;
 
-                    element.querySelectorAll('.button-select__option--selected').forEach(function(selectedButtonElement) {
+                    qsa(element, '.button-select__option--selected').forEach(function(selectedButtonElement) {
                         selectedButtonElement.classList.remove('button-select__option--selected');
                     });
 


### PR DESCRIPTION
Spotted while testing #6105. It looks like some of the admin’s JS is broken since #5959, which is a change that hasn’t been released yet. The problem is using `forEach` on instances of NodeList, which IE11 doesn’t implement. Workaround is to convert NodeList instances to arrays to use any and all array methods, which is what we implement in the rest of the codebase.

Tested in IE11 on Windows 10, latest Chrome on macOS, latest Chrome on Android, latest Safari on iOS, latest Firefox on macOS, latest Safari on macOS.

Tested by:

- Opening any page and checking the browser’s console
- Using the pages explorer menu
- Using StreamField (stumbled upon #5914 there)
- Using the page editor’s tabs

* [x] Do the tests still pass? (https://docs.wagtail.io/en/latest/contributing/developing.html#testing)
* [x] Does the code comply with the style guide? (Run `make lint` from the Wagtail root)
* ~[x] For Python changes: Have you added tests to cover the new/fixed behaviour?~
* [x] For front-end changes: Did you test on all of Wagtail’s supported browsers? **Please list the exact versions you tested**.
* [x] For new features: Has the documentation been updated accordingly?
