### PR TITLE
Remove visible focus states from .visiblyhidden util

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -74,6 +74,7 @@ Changelog
  * Fix: Make "Site" chooser in site settings translateable (Andreas Bernacca)
  * Fix: Add missing dropdown icons to image upload, document upload, and site settings screens (Andreas Bernacca)
  * Fix: Prevent snippets’ bulk delete button from being present for screen reader users when it’s absent for sighted users (LB (Ben Johnston))
+ * Fix: Fix group permission checkboxes not being clickable in IE11 (LB (Ben Johnston))
 
 
 2.9.3 (20.07.2020)

--- a/client/scss/tools/_mixins.general.scss
+++ b/client/scss/tools/_mixins.general.scss
@@ -67,16 +67,6 @@
     padding: 0;
     position: absolute;
     width: 1px;
-
-    &:active,
-    &:focus {
-        clip: auto;
-        height: auto;
-        margin: 0;
-        overflow: visible;
-        position: static;
-        width: auto;
-    }
 }
 
 

--- a/docs/releases/2.10.rst
+++ b/docs/releases/2.10.rst
@@ -97,6 +97,7 @@ Bug fixes
  * Make "Site" chooser in site settings translateable (Andreas Bernacca)
  * Add missing dropdown icons to image upload, document upload, and site settings screens (Andreas Bernacca)
  * Prevent snippets’ bulk delete button from being present for screen reader users when it’s absent for sighted users (LB (Ben Johnston))
+ * Fix group permission checkboxes not being clickable in IE11 (LB (Ben Johnston))
 
 
 Upgrade considerations


### PR DESCRIPTION
- visuallyhidden should keep elements hidden even when focused
- Fixes #5903 (IE 11 will trigger :focus on the label when checkbox is in focus & click event would be lost)
- see: https://github.com/wagtail/wagtail/issues/5903#issuecomment-639380475
- note: I have a separate PR coming that will resolve the issue with the usage of .visuallyhidden on snippets index (see comment above)

## Checklist

* Do the tests still pass? ✅ 
* Does the code comply with the style guide? ✅ 
* For front-end changes: Did you test on all of Wagtail’s supported browsers?
  *  ✅ Mac Firefox 76
  *  ✅ Mac Chrome 83
  *  ✅ Mac Safari 13.1
  *  ✅ Windows IE 11
  *  ✅ Windows Edge 17

