### PR TITLE
Hide inactive delete button with .u-hidden instead of .visuallyhidden

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -73,6 +73,7 @@ Changelog
  * Fix: Image / document forms now display non-field errors such as `unique_together` constraints (Matt Westcott)
  * Fix: Make "Site" chooser in site settings translateable (Andreas Bernacca)
  * Fix: Add missing dropdown icons to image upload, document upload, and site settings screens (Andreas Bernacca)
+ * Fix: Prevent snippets’ bulk delete button from being present for screen reader users when it’s absent for sighted users (LB (Ben Johnston))
 
 
 2.9.3 (20.07.2020)

--- a/docs/releases/2.10.rst
+++ b/docs/releases/2.10.rst
@@ -96,6 +96,7 @@ Bug fixes
  * Image / document forms now display non-field errors such as ``unique_together`` constraints (Matt Westcott)
  * Make "Site" chooser in site settings translateable (Andreas Bernacca)
  * Add missing dropdown icons to image upload, document upload, and site settings screens (Andreas Bernacca)
+ * Prevent snippets’ bulk delete button from being present for screen reader users when it’s absent for sighted users (LB (Ben Johnston))
 
 
 Upgrade considerations

--- a/wagtail/snippets/static_src/wagtailsnippets/js/snippet-multiple-select.js
+++ b/wagtail/snippets/static_src/wagtailsnippets/js/snippet-multiple-select.js
@@ -18,14 +18,14 @@ var updateDeleteButton = function(anySelected, newState) {
         }
     });
     if (anySelected) {
-        // enable button and add url
-        $deleteButton.removeClass('visuallyhidden');
+        // hide button and add url
+        $deleteButton.removeClass('u-hidden');
         var url = $deleteButton.data('url');
         url = url + $.param({id: ids}, true);
         $deleteButton.attr('href', url);
     } else {
-        // disable button and remove url
-        $deleteButton.addClass('visuallyhidden');
+        // show button and remove url
+        $deleteButton.addClass('u-hidden');
         $deleteButton.attr('href', null);
     }
 };

--- a/wagtail/snippets/templates/wagtailsnippets/snippets/type_index.html
+++ b/wagtail/snippets/templates/wagtailsnippets/snippets/type_index.html
@@ -37,7 +37,7 @@
             </div>
             <div class="right col6">
                 {% if can_delete_snippets %}
-                    <a class="button bicolor button--icon serious delete-button visuallyhidden" data-url="{% url 'wagtailsnippets:delete-multiple' model_opts.app_label model_opts.model_name %}?">
+                    <a class="button bicolor button--icon serious delete-button u-hidden" data-url="{% url 'wagtailsnippets:delete-multiple' model_opts.app_label model_opts.model_name %}?">
                         {% icon name="bin" wrapped=1 %}
                         {% blocktrans with snippet_type_name=model_opts.verbose_name_plural %}Delete {{ snippet_type_name }}{% endblocktrans %}
                     </a>


### PR DESCRIPTION
- .visuallyhidden meant that this button was visible to assistive technologies when the button would not work
- instead of hiding with that util, use .u-hidden (essentially display: none)
- relates to issue where the focus/active states in the visuallyhidden mixin were breaking some items in IE 11 - see #5903
* To test - confirm that you can select one or all of the items in a snippet type list and the delete button should show/hide once one or more items are selected.

## Checklis
* Do the tests still pass? ✔️ 
* Does the code comply with the style guide? ✔️ 
* For front-end changes: Did you test on all of Wagtail’s supported browsers?
    ✅ Mac Firefox 76
    ✅ Mac Chrome 83
    ✅ Mac Safari 13.1
    ✅ Windows IE 11
    ✅ Windows Edge 17

