### PR TITLE
Add Azure CDN and Front Door front-end cache invalidation support

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -9,6 +9,7 @@ Changelog
  * Add collapse option to `StreamField`, `StreamBlock`, and `ListBlock` which will load all sub-blocks initially collapsed (Matt Westcott)
  * Private pages can now be fetched over the API (Nabil Khalil)
  * Added `alias_of` field to the pages API (Dmitrii Faiazov)
+ * Add support for Azure CDN and Front Door front-end cache invalidation (Tomasz Knapik)
  * Fix: Transform operations in Filter.run() when image has been re-oriented (Justin Michalicek)
  * Fix: Accessibility fixes for Windows high contrast mode; Dashboard icons colour and contrast (Sakshi Uppoor)
  * Fix: Rename additional 'spin' CSS animations to avoid clashes with other libraries (Kevin Gutiérrez)

--- a/docs/reference/contrib/frontendcache.rst
+++ b/docs/reference/contrib/frontendcache.rst
@@ -133,6 +133,124 @@ In case you run multiple sites with Wagtail and each site has its CloudFront dis
 .. note::
     In most cases, absolute URLs with ``www`` prefixed domain names should be used in your mapping. Only drop the ``www`` prefix if you're absolutely sure you're not using it (e.g. a subdomain).
 
+Azure CDN
+^^^^^^^^^
+
+With `Azure CDN <https://azure.microsoft.com/en-gb/services/cdn/>`_ you will need a CDN profile with an endpoint configured.
+
+.. _azure-mgmt-cdn: https://pypi.org/project/azure-mgmt-cdn/
+.. _azure-identity: https://pypi.org/project/azure-identity/
+.. _azure-mgmt-resource: https://pypi.org/project/azure-mgmt-resource/
+
+The third-party dependencies of this backend are:
+
++-------------------------+-----------+---------------------------------------------------------------------------------------------------------------------------------------+
+| PyPI Package            | Essential | Reason                                                                                                                                |
++=========================+===========+=======================================================================================================================================+
+| azure-mgmt-cdn_         | Yes       | Interacting with the CDN service.                                                                                                     |
++-------------------------+-----------+---------------------------------------------------------------------------------------------------------------------------------------+
+| azure-identity_         | No        | Obtaining credentials. It's optional if you want to specify your own credential using a ``CREDENTIALS`` setting (more details below). |
++-------------------------+-----------+---------------------------------------------------------------------------------------------------------------------------------------+
+| azure-mgmt-resource_    | No        | For obtaining the subscription ID. Redundant if you want to explicitly specify a ``SUBSCRIPTION_ID`` setting (more details below).    |
++-------------------------+-----------+---------------------------------------------------------------------------------------------------------------------------------------+
+
+Add an item into the ``WAGTAILFRONTENDCACHE`` and set the ``BACKEND`` parameter to ``wagtail.contrib.frontend_cache.backends.AzureCdnBackend``. This backend requires the following settings to be set:
+
+* ``RESOURCE_GROUP_NAME`` - the resource group that your CDN profile is in.
+* ``CDN_PROFILE_NAME`` - the profile name of the CDN service that you want to use.
+* ``CDN_ENDPOINT_NAME`` - the name of the endpoint you want to be purged.
+
+.. code-block:: python
+
+    WAGTAILFRONTENDCACHE = {
+        'azure_cdn': {
+            'BACKEND': 'wagtail.contrib.frontend_cache.backends.AzureCdnBackend',
+            'RESOURCE_GROUP_NAME': 'MY-WAGTAIL-RESOURCE-GROUP',
+            'CDN_PROFILE_NAME': 'wagtailio',
+            'CDN_ENDPOINT_NAME': 'wagtailio-cdn-endpoint-123',
+        },
+    }
+
+By default the credentials will use ``azure.identity.DefaultAzureCredential``. To modify the credential object used, please use ``CREDENTIALS`` setting. Read about your options on the `Azure documentation <https://docs.microsoft.com/en-us/azure/developer/python/azure-sdk-authenticate>`_.
+
+
+.. code-block:: python
+
+    from azure.common.credentials import ServicePrincipalCredentials
+
+    WAGTAILFRONTENDCACHE = {
+        'azure_cdn': {
+            'BACKEND': 'wagtail.contrib.frontend_cache.backends.AzureCdnBackend',
+            'RESOURCE_GROUP_NAME': 'MY-WAGTAIL-RESOURCE-GROUP',
+            'CDN_PROFILE_NAME': 'wagtailio',
+            'CDN_ENDPOINT_NAME': 'wagtailio-cdn-endpoint-123',
+            'CREDENTIALS': ServicePrincipalCredentials(
+                client_id='your client id',
+                secret='your client secret',
+            )
+        },
+    }
+
+Another option that can be set is ``SUBSCRIPTION_ID``. By default the first encountered subscription will be used, but if your credential has access to more subscriptions, you should set this to an explicit value.
+
+
+Azure Front Door
+^^^^^^^^^^^^^^^^
+
+With `Azure Front Door <https://azure.microsoft.com/en-gb/services/frontdoor/>`_ you will need a Front Door instance with caching enabled.
+
+.. _azure-mgmt-frontdoor: https://pypi.org/project/azure-mgmt-frontdoor/
+.. _azure-identity: https://pypi.org/project/azure-identity/
+.. _azure-mgmt-resource: https://pypi.org/project/azure-mgmt-resource/
+
+The third-party dependencies of this backend are:
+
++-------------------------+-----------+---------------------------------------------------------------------------------------------------------------------------------------+
+| PyPI Package            | Essential | Reason                                                                                                                                |
++=========================+===========+=======================================================================================================================================+
+| azure-mgmt-frontdoor_   | Yes       | Interacting with the Front Door service.                                                                                              |
++-------------------------+-----------+---------------------------------------------------------------------------------------------------------------------------------------+
+| azure-identity_         | No        | Obtaining credentials. It's optional if you want to specify your own credential using a ``CREDENTIALS`` setting (more details below). |
++-------------------------+-----------+---------------------------------------------------------------------------------------------------------------------------------------+
+| azure-mgmt-resource_    | No        | For obtaining the subscription ID. Redundant if you want to explicitly specify a ``SUBSCRIPTION_ID`` setting (more details below).    |
++-------------------------+-----------+---------------------------------------------------------------------------------------------------------------------------------------+
+
+Add an item into the ``WAGTAILFRONTENDCACHE`` and set the ``BACKEND`` parameter to ``wagtail.contrib.frontend_cache.backends.AzureFrontDoorBackend``. This backend requires the following settings to be set:
+
+* ``RESOURCE_GROUP_NAME`` - the resource group that your Front Door instance is part of.
+* ``FRONT_DOOR_NAME`` - your configured Front Door instance name.
+
+.. code-block:: python
+
+    WAGTAILFRONTENDCACHE = {
+        'azure_front_door': {
+            'BACKEND': 'wagtail.contrib.frontend_cache.backends.AzureFrontDoorBackend',
+            'RESOURCE_GROUP_NAME': 'MY-WAGTAIL-RESOURCE-GROUP',
+            'FRONT_DOOR_NAME': 'wagtail-io-front-door',
+        },
+    }
+
+By default the credentials will use ``azure.identity.DefaultAzureCredential``. To modify the credential object used, please use ``CREDENTIALS`` setting. Read about your options on the `Azure documentation <https://docs.microsoft.com/en-us/azure/developer/python/azure-sdk-authenticate>`_.
+
+
+.. code-block:: python
+
+    from azure.common.credentials import ServicePrincipalCredentials
+
+    WAGTAILFRONTENDCACHE = {
+        'azure_front_door': {
+            'BACKEND': 'wagtail.contrib.frontend_cache.backends.AzureFrontDoorBackend',
+            'RESOURCE_GROUP_NAME': 'MY-WAGTAIL-RESOURCE-GROUP',
+            'FRONT_DOOR_NAME': 'wagtail-io-front-door',
+            'CREDENTIALS': ServicePrincipalCredentials(
+                client_id='your client id',
+                secret='your client secret',
+            )
+        },
+    }
+
+Another option that can be set is ``SUBSCRIPTION_ID``. By default the first encountered subscription will be used, but if your credential has access to more subscriptions, you should set this to an explicit value.
+
 Advanced usage
 --------------
 

--- a/docs/releases/2.16.md
+++ b/docs/releases/2.16.md
@@ -16,6 +16,7 @@
  * Add collapse option to `StreamField`, `StreamBlock`, and `ListBlock` which will load all sub-blocks initially collapsed (Matt Westcott)
  * Private pages can now be fetched over the API (Nabil Khalil)
  * Added `alias_of` field to the pages API (Dmitrii Faiazov)
+ * Add support for Azure CDN and Front Door front-end cache invalidation (Tomasz Knapik)
 
 
 ### Bug fixes

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,8 @@ testing_extras = [
     'freezegun>=0.3.8',
     'openpyxl>=2.6.4',
     'Unidecode>=0.04.14,<2.0',
+    'azure-mgmt-cdn>=5.1,<6.0',
+    'azure-mgmt-frontdoor>=0.3,<0.4',
 
     # For coverage and PEP8 linting
     'coverage>=3.7.0',

--- a/wagtail/contrib/frontend_cache/backends.py
+++ b/wagtail/contrib/frontend_cache/backends.py
@@ -3,7 +3,7 @@ import uuid
 
 from collections import defaultdict
 from urllib.error import HTTPError, URLError
-from urllib.parse import urlparse, urlunparse
+from urllib.parse import urlparse, urlsplit, urlunparse, urlunsplit
 from urllib.request import Request, urlopen
 
 import requests
@@ -202,3 +202,168 @@ class CloudfrontBackend(BaseBackend):
                     e.response['Error']['Code'],
                     e.response['Error']['Message']
                 )
+
+
+class AzureBaseBackend(BaseBackend):
+    def __init__(self, params):
+        self._credentials = params.pop("CREDENTIALS", None)
+        self._subscription_id = params.pop("SUBSCRIPTION_ID", None)
+        try:
+            self._resource_group_name = params.pop("RESOURCE_GROUP_NAME")
+        except KeyError:
+            raise ImproperlyConfigured(
+                "The setting 'WAGTAILFRONTENDCACHE' requires 'RESOURCE_GROUP_NAME' to be specified."
+            )
+        self._custom_headers = params.pop("CUSTOM_HEADERS", None)
+
+    def purge_batch(self, urls):
+        self._purge_content([self._get_path(url) for url in urls])
+
+    def purge(self, url):
+        self.purge_batch([url])
+
+    def _get_default_credentials(self):
+        try:
+            from azure.identity import DefaultAzureCredential
+        except ImportError:
+            return
+        return DefaultAzureCredential()
+
+    def _get_credentials(self):
+        """
+        Use credentials object set by user. If not set, use the one configured
+        in the current environment.
+        """
+        user_credentials = self._credentials
+        if user_credentials:
+            return user_credentials
+        return self._get_default_credentials()
+
+    def _get_default_subscription_id(self):
+        """
+        Obtain subscription ID directly from Azure.
+        """
+        try:
+            from azure.mgmt.resource import SubscriptionClient
+        except ImportError:
+            return ""
+        credential = self._get_credentials()
+        subscription_client = SubscriptionClient(credential)
+        subscription = next(subscription_client.subscriptions.list())
+        return subscription.subscription_id
+
+    def _get_subscription_id(self):
+        """
+        Use subscription ID set in the user configuration. If not set, try to
+        retrieve one from Azure directly.
+        """
+        user_subscription_id = self._subscription_id
+        if user_subscription_id:
+            return user_subscription_id
+        return self._get_default_subscription_id()
+
+    def _get_client_kwargs(self):
+        return {
+            "credentials": self._get_credentials(),
+            "subscription_id": self._get_subscription_id(),
+        }
+
+    def _get_path(self, url):
+        """
+        Split netloc from the URL and return path only.
+        """
+        # Delete scheme and netloc from the URL, that will result in only path being
+        # left.
+        url_parts = ("",) * 2 + urlsplit(url)[2:]
+        return urlunsplit(url_parts)
+
+    def _get_client(self):
+        """
+        Get Azure client instance.
+        """
+        klass = self._get_client_class()
+        kwargs = self._get_client_kwargs()
+        return klass(**kwargs)
+
+    def _get_purge_kwargs(self, paths):
+        """
+        Get keyword arguments passes to Azure purge content calls.
+        """
+        return {
+            "resource_group_name": self._resource_group_name,
+            "custom_headers": self._custom_headers,
+            "content_paths": paths,
+        }
+
+    def _purge_content(self, paths):
+        from msrest.exceptions import HttpOperationError
+
+        client = self._get_client()
+        try:
+            self._make_purge_call(client, paths)
+        except HttpOperationError as exception:
+            for path in paths:
+                logger.exception(
+                    "Couldn't purge '%s' from %s cache. HttpOperationError: %r",
+                    path,
+                    type(self).__name__,
+                    exception.response,
+                )
+
+
+class AzureFrontDoorBackend(AzureBaseBackend):
+    def __init__(self, params):
+        super().__init__(params)
+        try:
+            self._front_door_name = params.pop("FRONT_DOOR_NAME")
+        except KeyError:
+            raise ImproperlyConfigured(
+                "The setting 'WAGTAILFRONTENDCACHE' requires 'FRONT_DOOR_NAME' to be specified."
+            )
+        self._front_door_service_url = params.pop("FRONT_DOOR_SERVICE_URL", None)
+
+    def _get_client_class(self):
+        from azure.mgmt.frontdoor import FrontDoorManagementClient
+
+        return FrontDoorManagementClient
+
+    def _get_client_kwargs(self):
+        kwargs = super()._get_client_kwargs()
+        kwargs.setdefault("base_url", self._front_door_service_url)
+        return kwargs
+
+    def _make_purge_call(self, client, paths):
+        return client.endpoints.purge_content(
+            **self._get_purge_kwargs(paths),
+            front_door_name=self._front_door_name,
+        )
+
+
+class AzureCdnBackend(AzureBaseBackend):
+    def __init__(self, params):
+        super().__init__(params)
+        try:
+            self._cdn_profile_name = params.pop("CDN_PROFILE_NAME")
+            self._cdn_endpoint_name = params.pop("CDN_ENDPOINT_NAME")
+        except KeyError:
+            raise ImproperlyConfigured(
+                "The setting 'WAGTAILFRONTENDCACHE' requires 'CDN_PROFILE_NAME' and 'CDN_ENDPOINT_NAME' to be specified."
+            )
+        self._cdn_service_url = params.pop("CDN_SERVICE_URL", None)
+
+    def _get_client_class(self):
+        from azure.mgmt.cdn import CdnManagementClient
+
+        return CdnManagementClient
+
+    def _get_client_kwargs(self):
+        kwargs = super()._get_client_kwargs()
+        kwargs.setdefault("base_url", self._cdn_service_url)
+        return kwargs
+
+    def _make_purge_call(self, client, paths):
+        return client.endpoints.purge_content(
+            **self._get_purge_kwargs(paths),
+            profile_name=self._cdn_profile_name,
+            endpoint_name=self._cdn_endpoint_name,
+        )


### PR DESCRIPTION
This PR adds support for invalidating cache on two platforms:

* Azure CDN
* Azure Front Door

This is based on [wagtail-azure-cdn](https://github.com/torchbox/wagtail-azure-cdn) with multi site support taken out as it would only make this PR more complex.

I am not sure if this is a rich approach to have a massive `backends.py` file. Would it help to first create a PR that splits individual backends into separate files?