### PR TITLE
Make wagtail api renderer_classes configurable

### DIFF
--- a/wagtail/api/v2/tests/test_renderer_classes.py
+++ b/wagtail/api/v2/tests/test_renderer_classes.py
@@ -1,0 +1,22 @@
+from django.test import TestCase
+from django.test.utils import override_settings
+from rest_framework.renderers import BrowsableAPIRenderer, JSONRenderer
+
+from wagtail.api.v2.utils import get_default_renderer_classes
+
+
+class TestPageListing(TestCase):
+    @override_settings(WAGTAILAPI_DEFAULT_RENDERER_CLASSES=[
+        'rest_framework.renderers.JSONRenderer',
+    ])
+    def test_renderer_classes_override(self):
+        renderer_classes = get_default_renderer_classes()
+        self.assertEqual(len(renderer_classes), 1)
+        self.assertEqual(renderer_classes[0], JSONRenderer)
+
+    def test_default_renderer_classes_return_expected_value(self):
+        renderer_classes = get_default_renderer_classes()
+        self.assertEqual(renderer_classes, [
+            JSONRenderer,
+            BrowsableAPIRenderer,
+        ])

--- a/wagtail/api/v2/utils.py
+++ b/wagtail/api/v2/utils.py
@@ -1,6 +1,7 @@
 from urllib.parse import urlparse
 
 from django.conf import settings
+from django.utils.module_loading import import_string
 
 from wagtail.core.models import Page, Site
 from wagtail.core.utils import resolve_model_string
@@ -241,3 +242,16 @@ def parse_boolean(value):
         return False
     else:
         raise ValueError("expected 'true' or 'false', got '%s'" % value)
+
+
+def get_default_renderer_classes():
+    rendered_classes = getattr(
+        settings,
+        'WAGTAILAPI_DEFAULT_RENDERER_CLASSES',
+        [
+            'rest_framework.renderers.JSONRenderer',
+            'rest_framework.renderers.BrowsableAPIRenderer',
+        ]
+    )
+
+    return [import_string(x) for x in rendered_classes]

--- a/wagtail/api/v2/views.py
+++ b/wagtail/api/v2/views.py
@@ -7,7 +7,6 @@ from django.shortcuts import redirect
 from django.urls import reverse
 from modelcluster.fields import ParentalKey
 from rest_framework import status
-from rest_framework.renderers import BrowsableAPIRenderer, JSONRenderer
 from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
 
@@ -18,12 +17,12 @@ from .filters import ChildOfFilter, DescendantOfFilter, FieldsFilter, OrderingFi
 from .pagination import WagtailPagination
 from .serializers import BaseSerializer, PageSerializer, get_serializer_class
 from .utils import (
-    BadRequestError, filter_page_type, get_object_detail_url, page_models_from_string,
-    parse_fields_parameter)
+    BadRequestError, filter_page_type, get_default_renderer_classes, get_object_detail_url,
+    page_models_from_string, parse_fields_parameter)
 
 
 class BaseAPIViewSet(GenericViewSet):
-    renderer_classes = [JSONRenderer, BrowsableAPIRenderer]
+    renderer_classes = get_default_renderer_classes()
 
     pagination_class = WagtailPagination
     base_serializer_class = BaseSerializer


### PR DESCRIPTION
This PR originates from https://github.com/wagtail/wagtail/issues/6066  and acts as a proposal on how we can make the `renderer_classes` configurable from the settings in a similar way as DRF works today.

This is my setting proposal;

```python
WAGTAILAPI_DEFAULT_RENDERER_CLASSES = [
    'rest_framework.renderers.JSONRenderer',
    'rest_framework.renderers.BrowsableAPIRenderer',
]
```

Some considerations I’ve had while doing this:

**Using the built in settings in DRF. (REST_FRAMEWORK.DEFAULT_RENDERER_CLASSES)**
This works by just removing the renderer_classes in the View definition, it works well but will most likely introduce bugs for users using custom `renderer_classes` that will start to affect the wagtail api.

**Using the setting design proposed in the originating issue. (WAGTAIL_API.DEFAULT_RENDERER_CLASSES)**
I’ve decided against using a multi key dictionary for definition since there are already flat level  `WAGTAILAPI_*` settings in the api app.