### PR TITLE
Switch messages icons to SVG

### DIFF
--- a/client/scss/components/_messages.scss
+++ b/client/scss/components/_messages.scss
@@ -31,31 +31,23 @@
         vertical-align: middle;
     }
 
+    &-icon {
+        vertical-align: text-top;
+        margin-right: 0.5em;
+        width: 1.5em;
+        height: 1.5em;
+    }
+
     .error {
         background-color: $color-red-dark;
-
-        &:before {
-            font-family: wagtail;
-            content: map-get($icons, 'warning');
-        }
     }
 
     .warning {
         background-color: $color-orange-dark;
-
-        &:before {
-            font-family: wagtail;
-            content: map-get($icons, 'warning');
-        }
     }
 
     .success {
         background-color: $color-green-dark;
-
-        &:before {
-            font-family: wagtail;
-            content: map-get($icons, 'success');
-        }
     }
 
     .success .button:hover {

--- a/wagtail/admin/templates/wagtailadmin/base.html
+++ b/wagtail/admin/templates/wagtailadmin/base.html
@@ -31,7 +31,15 @@
                 {% if messages %}
                     <ul>
                         {% for message in messages %}
-                            <li class="{% message_tags message %}">{{ message|safe }}</li>
+                            <li class="{% message_tags message %}">
+                              {% if message.level_tag == "error" %}
+                                {# There is no error icon, use warning icon instead #}
+                                {% icon name="warning" class_name="messages-icon" %}
+                              {% else %}
+                                {% icon name=message.level_tag class_name="messages-icon" %}
+                              {% endif %}
+                              {{ message|safe }}
+                            </li>
                         {% endfor %}
                     </ul>
                 {% endif %}


### PR DESCRIPTION
https://github.com/wagtail/wagtail/issues/6107
Messages icons.

Do the tests still pass? YES
Does the code comply with the style guide? YES
For Python changes: Have you added tests to cover the new/fixed behaviour? N/A
For front-end changes: Did you test on all of Wagtail’s supported browsers?
- Google Chrome OSX Version 81
For new features: Has the documentation been updated accordingly? N/A
