### PR TITLE
Add more detail to RoutablePageMixin example

### DIFF
--- a/docs/reference/contrib/routablepage.rst
+++ b/docs/reference/contrib/routablepage.rst
@@ -30,32 +30,50 @@ Add ``"wagtail.contrib.routable_page"`` to your INSTALLED_APPS:
 The basics
 ==========
 
-To use ``RoutablePageMixin``, you need to make your class inherit from both :class:`wagtail.contrib.routable_page.models.RoutablePageMixin` and :class:`wagtail.core.models.Page`, then define some view methods and decorate them with ``wagtail.contrib.routable_page.models.route``.
+To use ``RoutablePageMixin``, you need to make your class inherit from both :class:`wagtail.contrib.routable_page.models.RoutablePageMixin` and :class:`wagtail.core.models.Page`, then define some view methods and decorate them with ``wagtail.contrib.routable_page.models.route``. These view methods behave like ordinary Django view functions, and must return an ``HttpResponse`` object; typically this is done through a call to ``django.shortcuts.render``.
 
-Here's an example of an ``EventPage`` with three views:
+Here's an example of an ``EventIndexPage`` with three views, assuming that an ``EventPage`` model with an ``event_date`` field has been defined elsewhere:
 
 .. code-block:: python
 
+    import datetime
+    from django.shortcuts import render
+    from wagtail.core.fields import RichTextField
     from wagtail.core.models import Page
     from wagtail.contrib.routable_page.models import RoutablePageMixin, route
 
 
-    class EventPage(RoutablePageMixin, Page):
-        ...
+    class EventIndexPage(RoutablePageMixin, Page):
+
+        # Routable pages can have fields like any other - here we would
+        # render the intro text on a template with {{ page.intro|richtext }}
+        intro = RichTextField()
 
         @route(r'^$') # will override the default Page serving mechanism
         def current_events(self, request):
             """
             View function for the current events page
             """
-            ...
+            events = EventPage.objects.filter(event_date__gte=datetime.date.today())
+
+            return render(request, 'events/event_index.html', {
+                'title': "Current events",
+                'page': self,
+                'events': events,
+            })
 
         @route(r'^past/$')
         def past_events(self, request):
             """
             View function for the past events page
             """
-            ...
+            events = EventPage.objects.filter(event_date__lt=datetime.date.today())
+
+            return render(request, 'events/event_index.html', {
+                'title': "Past events",
+                'page': self,
+                'events': events,
+            })
 
         # Multiple routes!
         @route(r'^year/(\d+)/$')
@@ -64,7 +82,37 @@ Here's an example of an ``EventPage`` with three views:
             """
             View function for the events for year page
             """
-            ...
+            if year is None:
+                year = datetime.date.today().year
+
+            events = EventPage.objects.filter(event_date__year=year)
+
+            return render(request, 'events/event_index.html', {
+                'title': "Events for %d" % year,
+                'page': self,
+                'events': events,
+            })
+
+
+Rendering other pages
+=====================
+
+Another way of returning an ``HttpResponse`` is to call the ``serve`` method of another page. (Calling a page's own ``serve`` method within a view method is not valid, as the view method is already being called within ``serve``, and this would create a circular definition).
+
+For example, ``EventIndexPage`` could be extended with a ``next/`` route that displays the page for the next event:
+
+.. code-block:: python
+
+    @route(r'^next/$')
+    def next_event(self, request):
+        """
+        Display the page for the next event
+        """
+        future_events = EventPage.objects.filter(event_date__gt=datetime.date.today())
+        next_event = future_events.order_by('event_date').first()
+
+        return next_event.serve(request)
+
 
 Reversing URLs
 ==============


### PR DESCRIPTION
The RoutablePageMixin documentation doesn't fully explain that view methods should be written as standard Django views, and stops short of giving a full example, which seems to have led people to come up with ill-advised solutions involving `Page.serve`.

This PR extends the `EventPage` example to include example view methods, and clarifies the situations where calling `serve` is valid.