### PR TITLE
Fix task_states_with_status to get only latest task state status for task

### DIFF
--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -2948,7 +2948,9 @@ class WorkflowState(models.Model):
                 status=Subquery(
                     task_states.filter(
                         task_id=OuterRef('id'),
-                    ).values('status')
+                    ).order_by(
+                        '-started_at', '-id'
+                    ).values('status')[:1]
                 ),
             )
         )


### PR DESCRIPTION

This allows `task_states_with_status` to work with resubmission