### PR TITLE
Nested Collections

### DIFF
--- a/wagtail/admin/forms/collections.py
+++ b/wagtail/admin/forms/collections.py
@@ -236,6 +236,12 @@ class BaseGroupCollectionMemberPermissionFormSet(forms.BaseFormSet):
         )
 
 
+# TODO: This needs to be able to handle Collection permissions that don't include every Collection.
+class CollectionChoiceField(forms.ModelChoiceField):
+    def label_from_instance(self, obj):
+        return format_collection(obj)
+
+
 def collection_member_permission_formset_factory(
     model, permission_types, template, default_prefix=None
 ):
@@ -265,7 +271,8 @@ def collection_member_permission_formset_factory(
         defines the permissions that are assigned to an entity
         (i.e. group or user) for a specific collection
         """
-        collection = forms.ModelChoiceField(
+        collection = CollectionChoiceField(
+            # TODO: This needs to be able to handle Collection permissions that don't include every Collection.
             queryset=Collection.objects.all().prefetch_related('group_permissions')
         )
         permissions = PermissionMultipleChoiceField(

--- a/wagtail/admin/forms/collections.py
+++ b/wagtail/admin/forms/collections.py
@@ -9,6 +9,7 @@ from django.utils.translation import gettext as _
 from wagtail.core.models import Collection, CollectionViewRestriction, GroupCollectionPermission
 
 from .view_restrictions import BaseViewRestrictionForm
+from ..templatetags.wagtailadmin_tags import format_collection
 
 
 class CollectionViewRestrictionForm(BaseViewRestrictionForm):
@@ -18,11 +19,57 @@ class CollectionViewRestrictionForm(BaseViewRestrictionForm):
         fields = ('restriction_type', 'password', 'groups')
 
 
+class SelectWidget(forms.Select):
+    """
+    Subclass of Django's select widget that allows disabling options.
+    """
+
+    def __init__(self, *args, **kwargs):
+        self._disabled_choices = []
+        super().__init__(*args, **kwargs)
+
+    @property
+    def disabled_choices(self):
+        return self._disabled_choices
+
+    @disabled_choices.setter
+    def disabled_choices(self, other):
+        self._disabled_choices = other
+
+    def create_option(self, name, value, *args, **kwargs):
+        option_dict = super().create_option(name, value, *args, **kwargs)
+        if value in self.disabled_choices:
+            option_dict['attrs']['disabled'] = 'disabled'
+        return option_dict
+
+
 class CollectionForm(forms.ModelForm):
+    parent = forms.ChoiceField(
+        required=False,
+        widget=SelectWidget,
+        help_text=_("Select hierarchical position. Some options are disabled because they're descendants and therefore can't be its parent."),
+    )
+
     class Meta:
         model = Collection
         fields = ('name',)
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        choices = Collection.objects.all().order_by('path')
+
+        if self.instance and self.instance.id:
+            self.fields['parent'].initial = self.instance.get_parent().pk
+            disabled_choices = [c.pk for c in self.instance.get_descendants(inclusive=True)]
+            self.fields['parent'].widget.disabled_choices = disabled_choices
+
+        else:
+            self.fields['parent'].initial = Collection.get_first_root_node().pk
+
+        self.fields['parent'].choices = [
+            (c.pk, format_collection(c)) for c in choices
+        ]
 
 class BaseCollectionMemberForm(forms.ModelForm):
     """
@@ -43,19 +90,22 @@ class BaseCollectionMemberForm(forms.ModelForm):
             self.collections = Collection.objects.all()
         else:
             self.collections = (
-                self.permission_policy.collections_user_has_permission_for(user, 'add')
+                self.permission_policy.collections_user_has_permission_for(
+                    user, 'add')
             )
 
         if self.instance.pk:
             # editing an existing document; ensure that the list of available collections
             # includes its current collection
             self.collections = (
-                self.collections | Collection.objects.filter(id=self.instance.collection_id)
+                self.collections | Collection.objects.filter(
+                id=self.instance.collection_id)
             )
 
         if len(self.collections) == 0:
             raise Exception(
-                "Cannot construct %s for a user with no collection permissions" % type(self)
+                "Cannot construct %s for a user with no collection permissions" % type(
+                    self)
             )
         elif len(self.collections) == 1:
             # don't show collection field if only one collection is available
@@ -81,6 +131,7 @@ class BaseGroupCollectionMemberPermissionFormSet(forms.BaseFormSet):
     default_prefix - prefix to use on form fields if one is not specified in __init__
     template = template filename
     """
+
     def __init__(self, data=None, files=None, instance=None, prefix=None):
         if prefix is None:
             prefix = self.default_prefix
@@ -95,7 +146,8 @@ class BaseGroupCollectionMemberPermissionFormSet(forms.BaseFormSet):
         for collection, collection_permissions in groupby(
             instance.collection_permissions.filter(
                 permission__in=self.permission_queryset
-            ).select_related('permission__content_type', 'collection').order_by('collection'),
+            ).select_related('permission__content_type',
+                             'collection').order_by('collection'),
             lambda cp: cp.collection
         ):
             initial_data.append({
@@ -126,12 +178,14 @@ class BaseGroupCollectionMemberPermissionFormSet(forms.BaseFormSet):
             for form in self.forms
             # need to check for presence of 'collection' in cleaned_data,
             # because a completely blank form passes validation
-            if form not in self.deleted_forms and 'collection' in form.cleaned_data
+            if
+            form not in self.deleted_forms and 'collection' in form.cleaned_data
         ]
         if len(set(collections)) != len(collections):
             # collections list contains duplicates
             raise forms.ValidationError(
-                _("You cannot have multiple permission records for the same collection.")
+                _(
+                    "You cannot have multiple permission records for the same collection.")
             )
 
     @transaction.atomic
@@ -145,13 +199,15 @@ class BaseGroupCollectionMemberPermissionFormSet(forms.BaseFormSet):
         # get a set of (collection, permission) tuples for all ticked permissions
         forms_to_save = [
             form for form in self.forms
-            if form not in self.deleted_forms and 'collection' in form.cleaned_data
+            if
+            form not in self.deleted_forms and 'collection' in form.cleaned_data
         ]
 
         final_permission_records = set()
         for form in forms_to_save:
             for permission in form.cleaned_data['permissions']:
-                final_permission_records.add((form.cleaned_data['collection'], permission))
+                final_permission_records.add(
+                    (form.cleaned_data['collection'], permission))
 
         # fetch the group's existing collection permission records for this model,
         # and from that, build a list of records to be created / deleted
@@ -166,12 +222,14 @@ class BaseGroupCollectionMemberPermissionFormSet(forms.BaseFormSet):
             else:
                 permission_ids_to_delete.append(cp.id)
 
-        self.instance.collection_permissions.filter(id__in=permission_ids_to_delete).delete()
+        self.instance.collection_permissions.filter(
+            id__in=permission_ids_to_delete).delete()
 
         permissions_to_add = final_permission_records - permission_records_to_keep
         GroupCollectionPermission.objects.bulk_create([
             GroupCollectionPermission(
-                group=self.instance, collection=collection, permission=permission
+                group=self.instance, collection=collection,
+                permission=permission
             )
             for (collection, permission) in permissions_to_add
         ])
@@ -186,10 +244,10 @@ class BaseGroupCollectionMemberPermissionFormSet(forms.BaseFormSet):
 def collection_member_permission_formset_factory(
     model, permission_types, template, default_prefix=None
 ):
-
     permission_queryset = Permission.objects.filter(
         content_type__app_label=model._meta.app_label,
-        codename__in=[codename for codename, short_label, long_label in permission_types]
+        codename__in=[codename for codename, short_label, long_label in
+                      permission_types]
     ).select_related('content_type')
 
     if default_prefix is None:
@@ -200,6 +258,7 @@ def collection_member_permission_formset_factory(
         Allows the custom labels from ``permission_types`` to be applied to
         permission checkboxes for the ``CollectionMemberPermissionsForm`` below
         """
+
         def label_from_instance(self, obj):
             for codename, short_label, long_label in permission_types:
                 if codename == obj.codename:
@@ -213,7 +272,8 @@ def collection_member_permission_formset_factory(
         (i.e. group or user) for a specific collection
         """
         collection = forms.ModelChoiceField(
-            queryset=Collection.objects.all().prefetch_related('group_permissions')
+            queryset=Collection.objects.all().prefetch_related(
+                'group_permissions')
         )
         permissions = PermissionMultipleChoiceField(
             queryset=permission_queryset,
@@ -223,7 +283,7 @@ def collection_member_permission_formset_factory(
 
     GroupCollectionMemberPermissionFormSet = type(
         str('GroupCollectionMemberPermissionFormSet'),
-        (BaseGroupCollectionMemberPermissionFormSet, ),
+        (BaseGroupCollectionMemberPermissionFormSet,),
         {
             'permission_types': permission_types,
             'permission_queryset': permission_queryset,

--- a/wagtail/admin/forms/collections.py
+++ b/wagtail/admin/forms/collections.py
@@ -8,8 +8,8 @@ from django.utils.translation import gettext as _
 
 from wagtail.core.models import Collection, CollectionViewRestriction, GroupCollectionPermission
 
-from .view_restrictions import BaseViewRestrictionForm
 from ..templatetags.wagtailadmin_tags import format_collection
+from .view_restrictions import BaseViewRestrictionForm
 
 
 class CollectionViewRestrictionForm(BaseViewRestrictionForm):
@@ -47,7 +47,8 @@ class CollectionForm(forms.ModelForm):
     parent = forms.ChoiceField(
         required=False,
         widget=SelectWidget,
-        help_text=_("Select hierarchical position. Some options are disabled because they're descendants and therefore can't be its parent."),
+        help_text=_("Select hierarchical position. Some options are disabled because they're descendants of "
+                    "this Collection, and therefore can't be its parent."),
     )
 
     class Meta:
@@ -70,6 +71,7 @@ class CollectionForm(forms.ModelForm):
         self.fields['parent'].choices = [
             (c.pk, format_collection(c)) for c in choices
         ]
+
 
 class BaseCollectionMemberForm(forms.ModelForm):
     """
@@ -98,8 +100,7 @@ class BaseCollectionMemberForm(forms.ModelForm):
             # editing an existing document; ensure that the list of available collections
             # includes its current collection
             self.collections = (
-                self.collections | Collection.objects.filter(
-                id=self.instance.collection_id)
+                self.collections | Collection.objects.filter(id=self.instance.collection_id)
             )
 
         if len(self.collections) == 0:

--- a/wagtail/admin/forms/collections.py
+++ b/wagtail/admin/forms/collections.py
@@ -146,8 +146,7 @@ class BaseGroupCollectionMemberPermissionFormSet(forms.BaseFormSet):
         for collection, collection_permissions in groupby(
             instance.collection_permissions.filter(
                 permission__in=self.permission_queryset
-            ).select_related('permission__content_type',
-                             'collection').order_by('collection'),
+            ).select_related('permission__content_type', 'collection').order_by('collection'),
             lambda cp: cp.collection
         ):
             initial_data.append({
@@ -178,14 +177,12 @@ class BaseGroupCollectionMemberPermissionFormSet(forms.BaseFormSet):
             for form in self.forms
             # need to check for presence of 'collection' in cleaned_data,
             # because a completely blank form passes validation
-            if
-            form not in self.deleted_forms and 'collection' in form.cleaned_data
+            if form not in self.deleted_forms and 'collection' in form.cleaned_data
         ]
         if len(set(collections)) != len(collections):
             # collections list contains duplicates
             raise forms.ValidationError(
-                _(
-                    "You cannot have multiple permission records for the same collection.")
+                _("You cannot have multiple permission records for the same collection.")
             )
 
     @transaction.atomic
@@ -222,14 +219,12 @@ class BaseGroupCollectionMemberPermissionFormSet(forms.BaseFormSet):
             else:
                 permission_ids_to_delete.append(cp.id)
 
-        self.instance.collection_permissions.filter(
-            id__in=permission_ids_to_delete).delete()
+        self.instance.collection_permissions.filter(id__in=permission_ids_to_delete).delete()
 
         permissions_to_add = final_permission_records - permission_records_to_keep
         GroupCollectionPermission.objects.bulk_create([
             GroupCollectionPermission(
-                group=self.instance, collection=collection,
-                permission=permission
+                group=self.instance, collection=collection, permission=permission
             )
             for (collection, permission) in permissions_to_add
         ])
@@ -246,8 +241,7 @@ def collection_member_permission_formset_factory(
 ):
     permission_queryset = Permission.objects.filter(
         content_type__app_label=model._meta.app_label,
-        codename__in=[codename for codename, short_label, long_label in
-                      permission_types]
+        codename__in=[codename for codename, short_label, long_label in permission_types]
     ).select_related('content_type')
 
     if default_prefix is None:
@@ -272,8 +266,7 @@ def collection_member_permission_formset_factory(
         (i.e. group or user) for a specific collection
         """
         collection = forms.ModelChoiceField(
-            queryset=Collection.objects.all().prefetch_related(
-                'group_permissions')
+            queryset=Collection.objects.all().prefetch_related('group_permissions')
         )
         permissions = PermissionMultipleChoiceField(
             queryset=permission_queryset,

--- a/wagtail/admin/forms/collections.py
+++ b/wagtail/admin/forms/collections.py
@@ -236,8 +236,10 @@ class BaseGroupCollectionMemberPermissionFormSet(forms.BaseFormSet):
         )
 
 
-# TODO: This needs to be able to handle Collection permissions that don't include every Collection.
 class CollectionChoiceField(forms.ModelChoiceField):
+    """
+    Renders the names of Collections in a choice field with the appropriate nesting prefix.
+    """
     def label_from_instance(self, obj):
         return format_collection(obj)
 
@@ -272,7 +274,6 @@ def collection_member_permission_formset_factory(
         (i.e. group or user) for a specific collection
         """
         collection = CollectionChoiceField(
-            # TODO: This needs to be able to handle Collection permissions that don't include every Collection.
             queryset=Collection.objects.all().prefetch_related('group_permissions')
         )
         permissions = PermissionMultipleChoiceField(

--- a/wagtail/admin/templates/wagtailadmin/collections/index.html
+++ b/wagtail/admin/templates/wagtailadmin/collections/index.html
@@ -1,5 +1,5 @@
 {% extends "wagtailadmin/generic/index.html" %}
-{% load i18n %}
+{% load i18n wagtailadmin_tags %}
 
 {% block listing %}
     <div class="nice-padding">
@@ -18,7 +18,9 @@
                             <tr>
                                 <td class="title">
                                     <div class="title-wrapper">
-                                        <a href="{% url 'wagtailadmin_collections:edit' collection.id %}">{{ collection }}</a>
+                                        <a href="{% url 'wagtailadmin_collections:edit' collection.id %}">
+                                            {% format_collection collection collections %}
+                                        </a>
                                     </div>
                                 </td>
                             </tr>

--- a/wagtail/admin/templates/wagtailadmin/shared/collection_chooser.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/collection_chooser.html
@@ -1,5 +1,4 @@
-{% load i18n %}
-{% load l10n %}
+{% load i18n l10n wagtailadmin_tags %}
 
 <li>
     <div class="field choice_field select">
@@ -9,7 +8,16 @@
                 <select id="collection_chooser_collection_id" name="collection_id">
                     <option value="">{% trans "All collections" %}</option>
                     {% for collection in collections %}
-                        <option value="{{ collection.id|unlocalize }}" {% if collection == current_collection %}selected="selected"{% endif %}>{{ collection.name }}</option>
+                        <option value="{{ collection.id|unlocalize }}"
+                                {% if collection == current_collection %}selected="selected"{% endif %}>
+                            {% if request.user.is_superuser %}
+                                {# Superuser may see all collections #}
+                                {% format_collection collection %}
+                            {% else %}
+                                {# Pass the permitted collections since user isn't a superuser #}
+                                {% format_collection collection collections %}
+                            {% endif %}
+                        </option>
                     {% endfor %}
                 </select>
                 <span></span>

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -1,6 +1,5 @@
 import itertools
 import json
-
 from urllib.parse import urljoin
 
 from django import template
@@ -24,8 +23,7 @@ from wagtail.admin.search import admin_search_areas
 from wagtail.admin.staticfiles import versioned_static as versioned_static_func
 from wagtail.core import hooks
 from wagtail.core.models import (
-    CollectionViewRestriction, Page, PageViewRestriction,
-    UserPagePermissionsProxy, Collection)
+    Collection, CollectionViewRestriction, Page, PageViewRestriction, UserPagePermissionsProxy)
 from wagtail.core.utils import cautious_slugify as _cautious_slugify
 from wagtail.core.utils import camelcase_to_underscore, escape_script
 from wagtail.users.utils import get_gravatar_url

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -543,8 +543,8 @@ def icons():
 def format_collection(col: Collection, permitted: QuerySet = None) -> str:
     """
     A template tag that receives a collection and returns a formatted string,
-    taking into account its hierarchical depth,
-    and optionally its relative depth if a filtered queryset is supplied
+    taking into account its hierarchical depth, and optionally its relative
+    depth if a filtered queryset is supplied
     Example usage: {% format_collection collection collections %}
     """
     def _depth(cur_col, count=0):

--- a/wagtail/admin/tests/test_collections_views.py
+++ b/wagtail/admin/tests/test_collections_views.py
@@ -125,18 +125,14 @@ class TestEditCollection(TestCase, WagtailTestUtils):
         self.assertEqual(response.status_code, 404)
 
     def test_move_collection(self):
-        response = self.post(
-            {'name': "Level 2", 'parent': self.root_collection.pk}, self.l2.pk
-        )
+        self.post({'name': "Level 2", 'parent': self.root_collection.pk}, self.l2.pk)
         self.assertEqual(
             Collection.objects.get(pk=self.l2.pk).get_parent().pk,
             self.root_collection.pk,
         )
 
     def test_cannot_move_parent_collection_to_descendant(self):
-        response = self.post(
-            {'name': "Level 2", 'parent': self.l3.pk}, self.l2.pk
-        )
+        self.post({'name': "Level 2", 'parent': self.l3.pk}, self.l2.pk)
         self.assertEqual(
             Collection.objects.get(pk=self.l2.pk).get_parent().pk,
             self.l1.pk

--- a/wagtail/admin/tests/test_collections_views.py
+++ b/wagtail/admin/tests/test_collections_views.py
@@ -109,7 +109,7 @@ class TestEditCollection(TestCase, WagtailTestUtils):
     def post(self, post_data={}, collection_id=None):
         return self.client.post(
             reverse('wagtailadmin_collections:edit', args=(collection_id or self.collection.id,)),
-            post_data,
+            post_data
         )
 
     def test_get(self):

--- a/wagtail/admin/views/collections.py
+++ b/wagtail/admin/views/collections.py
@@ -70,9 +70,7 @@ class Edit(EditView):
             inclusive=True).values_list('pk', flat=True)
         )
         if new_parent_pk in old_descendants:
-            form.add_error(
-                'parent', ugettext_lazy('Please select another parent')
-            )
+            form.add_error('parent', gettext_lazy('Please select another parent'))
             return self.form_invalid(form)
         return super().form_valid(form)
 

--- a/wagtail/admin/views/collections.py
+++ b/wagtail/admin/views/collections.py
@@ -21,8 +21,8 @@ class Index(IndexView):
     header_icon = 'folder-open-1'
 
     def get_queryset(self):
-        # Only return children of the root node, so that the root is not editable
-        return Collection.get_first_root_node().get_children().order_by('name')
+        # Only return descendants of the root node, so that the root is not editable
+        return Collection.get_first_root_node().get_descendants().order_by('path')
 
 
 class Create(CreateView):
@@ -36,10 +36,10 @@ class Create(CreateView):
     header_icon = 'folder-open-1'
 
     def save_instance(self):
-        # Always create new collections as children of root
         instance = self.form.save(commit=False)
-        root_collection = Collection.get_first_root_node()
-        root_collection.add_child(instance=instance)
+        parent_pk = self.form.data.get('parent')
+        parent = Collection.objects.get(pk=parent_pk) if parent_pk else Collection.get_first_root_node()
+        parent.add_child(instance=instance)
         return instance
 
 
@@ -57,9 +57,28 @@ class Edit(EditView):
     context_object_name = 'collection'
     header_icon = 'folder-open-1'
 
+    def save_instance(self):
+        instance = self.form.save()
+        parent_pk = self.form.data.get('parent')
+        if parent_pk and parent_pk != instance.get_parent().pk:
+            instance.move(Collection.objects.get(pk=parent_pk), 'last-child')
+        return instance
+
+    def form_valid(self, form):
+        new_parent_pk = int(form.data.get('parent', 0))
+        old_descendants = list(form.instance.get_descendants(
+            inclusive=True).values_list('pk', flat=True)
+        )
+        if new_parent_pk in old_descendants:
+            form.add_error(
+                'parent', ugettext_lazy('Please select another parent')
+            )
+            return self.form_invalid(form)
+        return super().form_valid(form)
+
     def get_queryset(self):
-        # Only return children of the root node, so that the root is not editable
-        return Collection.get_first_root_node().get_children().order_by('name')
+        # Only return descendants of the root node, so that the root is not editable
+        return Collection.get_first_root_node().get_descendants().order_by('path')
 
 
 class Delete(DeleteView):
@@ -74,7 +93,7 @@ class Delete(DeleteView):
 
     def get_queryset(self):
         # Only return children of the root node, so that the root is not editable
-        return Collection.get_first_root_node().get_children().order_by('name')
+        return Collection.get_first_root_node().get_descendants().order_by('path')
 
     def get_collection_contents(self):
         collection_contents = [

--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -13,7 +13,7 @@ from django.core.exceptions import ValidationError
 from django.core.handlers.base import BaseHandler
 from django.core.handlers.wsgi import WSGIRequest
 from django.db import models, transaction
-from django.db.models import Case, Q, Value, When
+from django.db.models import Q, Value
 from django.db.models.functions import Concat, Lower, Substr
 from django.http import Http404
 from django.http.request import split_domain_port

--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -2289,11 +2289,7 @@ class Collection(MP_Node):
 
     @staticmethod
     def order_for_display(queryset):
-        return queryset.annotate(
-            display_order=Case(
-                When(depth=1, then=Value('')),
-                default='name')
-        ).order_by('display_order')
+        return queryset.order_by('path')
 
     class Meta:
         verbose_name = _('collection')

--- a/wagtail/documents/forms.py
+++ b/wagtail/documents/forms.py
@@ -4,7 +4,7 @@ from django.utils.translation import gettext_lazy as _
 
 from wagtail.admin import widgets
 from wagtail.admin.forms.collections import (
-    BaseCollectionMemberForm, collection_member_permission_formset_factory, CollectionChoiceField)
+    BaseCollectionMemberForm, CollectionChoiceField, collection_member_permission_formset_factory)
 from wagtail.core.models import Collection
 from wagtail.documents.models import Document
 from wagtail.documents.permissions import permission_policy as documents_permission_policy

--- a/wagtail/documents/forms.py
+++ b/wagtail/documents/forms.py
@@ -13,7 +13,6 @@ from wagtail.documents.permissions import permission_policy as documents_permiss
 # Callback to allow us to override the default form field for the image file field
 def formfield_for_dbfield(db_field, **kwargs):
     if db_field.name == 'collection':
-        # TODO: This needs to be able to handle Collection permissions that don't include every Collection.
         return CollectionChoiceField(queryset=Collection.objects.all(), **kwargs)
 
     # For all other fields, just call its formfield() method.

--- a/wagtail/documents/templates/wagtaildocs/multiple/add.html
+++ b/wagtail/documents/templates/wagtaildocs/multiple/add.html
@@ -32,7 +32,15 @@
                         <div class="field-content">
                             <select id="id_adddocument_collection" name="collection">
                                 {% for collection in collections %}
-                                    <option value="{{ collection.id|unlocalize }}">{{ collection.name }}</option>
+                                    <option value="{{ collection.id|unlocalize }}">
+                                      {% if request.user.is_superuser %}
+                                          {# Superuser may see all collections. #}
+                                          {% format_collection collection %}
+                                      {% else %}
+                                          {# Pass the permitted collections since user isn't a superuser. #}
+                                          {% format_collection collection collections %}
+                                      {% endif %}
+                                    </option>
                                 {% endfor %}
                             </select>
                         </div>

--- a/wagtail/images/forms.py
+++ b/wagtail/images/forms.py
@@ -19,7 +19,6 @@ def formfield_for_dbfield(db_field, **kwargs):
     if db_field.name == 'file':
         return WagtailImageField(label=capfirst(db_field.verbose_name), **kwargs)
     elif db_field.name == 'collection':
-        # TODO: This needs to be able to handle Collection permissions that don't include every Collection.
         return CollectionChoiceField(queryset=Collection.objects.all(), **kwargs)
 
     # For all other fields, just call its formfield() method.

--- a/wagtail/images/forms.py
+++ b/wagtail/images/forms.py
@@ -5,7 +5,7 @@ from django.utils.translation import gettext as _
 
 from wagtail.admin import widgets
 from wagtail.admin.forms.collections import (
-    BaseCollectionMemberForm, collection_member_permission_formset_factory, CollectionChoiceField)
+    BaseCollectionMemberForm, CollectionChoiceField, collection_member_permission_formset_factory)
 from wagtail.core.models import Collection
 from wagtail.images.fields import WagtailImageField
 from wagtail.images.formats import get_image_formats

--- a/wagtail/images/forms.py
+++ b/wagtail/images/forms.py
@@ -5,7 +5,8 @@ from django.utils.translation import gettext as _
 
 from wagtail.admin import widgets
 from wagtail.admin.forms.collections import (
-    BaseCollectionMemberForm, collection_member_permission_formset_factory)
+    BaseCollectionMemberForm, collection_member_permission_formset_factory, CollectionChoiceField)
+from wagtail.core.models import Collection
 from wagtail.images.fields import WagtailImageField
 from wagtail.images.formats import get_image_formats
 from wagtail.images.models import Image
@@ -17,6 +18,9 @@ def formfield_for_dbfield(db_field, **kwargs):
     # Check if this is the file field
     if db_field.name == 'file':
         return WagtailImageField(label=capfirst(db_field.verbose_name), **kwargs)
+    elif db_field.name == 'collection':
+        # TODO: This needs to be able to handle Collection permissions that don't include every Collection.
+        return CollectionChoiceField(queryset=Collection.objects.all(), **kwargs)
 
     # For all other fields, just call its formfield() method.
     return db_field.formfield(**kwargs)

--- a/wagtail/images/templates/wagtailimages/multiple/add.html
+++ b/wagtail/images/templates/wagtailimages/multiple/add.html
@@ -32,7 +32,15 @@
                         <div class="field-content">
                             <select id="id_addimage_collection" name="collection">
                                 {% for collection in collections %}
-                                    <option value="{{ collection.id|unlocalize }}">{{ collection.name }}</option>
+                                    <option value="{{ collection.id|unlocalize }}">
+                                      {% if request.user.is_superuser %}
+                                          {# Superuser may see all collections. #}
+                                          {% format_collection collection %}
+                                      {% else %}
+                                          {# Pass the permitted collections since user isn't a superuser. #}
+                                          {% format_collection collection collections %}
+                                      {% endif %}
+                                    </option>
                                 {% endfor %}
                             </select>
                         </div>


### PR DESCRIPTION
The purpose of this PR is to allow admins to create Collections as descendants of other Collections (rather than only being able to create children of Root). Collections were already using treebeard-based models, so SebJansen's and my code simply needed to let Wagtail take advantage of that. 

This PR is based on wagtail/rfcs#48, which started as this commit: https://github.com/SebJansen/wagtail/commit/71bb9267a176603ac4c77086fb1e86ec6e17dc1e

I enhanced the existing changes by making the remaining Collections dropdowns display the Collections' nesting levels (several `<select>`s had not had their naming schemes updated).

Here are some related issues and PRs that also deal with adding nested/hierarchical Collections:
#3380, #3407, #4106 

My own team at Caltech has been using a modified version of #4107 for several months, and it worked great. But it's also based on a very old version of the codebase (we've been stuck on Wagtail 2.3 for a _while_). When I saw Seb's code, I realized it was a superior implementation (and it also had @gasman's approval), so it's what my team decided to move forward with.

* Do the tests still pass?

Yes.
```----------------------------------------------------------------------
Ran 3771 tests in 288.148s

OK (skipped=388, expected failures=14)
```

* Does the code comply with the style guide? (Run `make lint` from the Wagtail root)

Yes, though I got a huge passle of baffling errors from the javascript linter. I didn't touch any javascript, so I think it's probably a config error on my end. I've been having really weird problems with npm and node on my dev machine.

* For Python changes: Have you added tests to cover the new/fixed behaviour?

Not all of it. Seb wrote tests for the majority of the new functionality, but I still need to add tests for the `<select>`s I updated.

* For front-end changes: Did you test on all of Wagtail’s supported browsers? **Please list the exact versions you tested**.

I didn't, but the only front-end change this PR applies is naming Collections differently. There are no markup, CSS, or JS changes.

* For new features: Has the documentation been updated accordingly?

I'm not entirely sure how best to do that, and I'd love some advice.

I really hope we can get any remaining issues with this PR resolved ASAP, so that it can make it into Wagtail 1.11. We **need** this functionality, and would _very much_ like to stop having to use a fork of Wagtail to get it.