### PR TITLE
[Workflow] Get STATUS_CHOICES from Task when annotating all_tasks_with_status

### DIFF
--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -2963,7 +2963,7 @@ class WorkflowState(models.Model):
         )
 
         # Manually annotate status_display
-        status_choices = dict(self.STATUS_CHOICES)
+        status_choices = dict(TaskState.STATUS_CHOICES)
         for task in tasks:
             task.status_display = status_choices.get(task.status, _("Not started"))
 


### PR DESCRIPTION
Previously it was getting STATUS_CHOICES from WorkflowState, causing the lookup for STATUS_NEEDS_CHANGES to fail.