### PR TITLE
ImageChooser will be opened at the same place where it was closed 

### DIFF
--- a/wagtail/images/tests/test_admin_views.py
+++ b/wagtail/images/tests/test_admin_views.py
@@ -818,13 +818,6 @@ class TestImageChooserView(TestCase, WagtailTestUtils):
         self.assertIn('value="Very nice image"', response_json['html'])
         self.assertIn("Page 2 of 2", response_json['html'])
 
-        # response_json = json.loads(response.content.decode())
-        # self.assertEqual(response_json['step'], 'chooser')
-        # self.assertTemplateUsed(response, 'wagtailimages/chooser/chooser.html')
-
-        # # draftail should NOT be a standard JS include on this page
-        # self.assertNotIn('wagtailadmin/js/draftail.js', response_json['html'])
-
 
 class TestImageChooserChosenView(TestCase, WagtailTestUtils):
     def setUp(self):


### PR DESCRIPTION
The  GET 'q', 'tag', 'p' and 'collection_id' parameters are stored in the session.

My point: I have tons of images that all have the same names like IMG_0000.jpg. So I can't really make use of searching (with documents and snippets that may be different), so if I need for my new article 5 pictures which are on page 10, I have to navigate 5 times to page 10, because the chooser always opens on page 1.
The parameters WAGTAILIMAGES_CHOOSER_STORE_GET_PARAMS = False allows User to switch to old behavior and the session remains almost maiden clean.

P.S. with a request modifications hook i could not solve this problem. As soon as one of the GET parameters ('q', 'tag', 'p' and 'collection_id') is set, the server assumes that the chooser is already opened (which is not true) and sends only a part of the chooser content.

Thanks for contributing to Wagtail! 🎉

Before submitting, please review the contributor guidelines <https://docs.wagtail.io/en/latest/contributing/index.html> and check the following:

* Do the tests still pass? (https://docs.wagtail.io/en/latest/contributing/developing.html#testing)
yes
* Does the code comply with the style guide? (Run `make lint` from the Wagtail root)pip
yes
* For Python changes: Have you added tests to cover the new/fixed behaviour?
yes
* For new features: Has the documentation been updated accordingly?
No, that must be done,

Please feel free to change the variables or constant names. they may be not best choice
