### PR TITLE
Button icons to svg

### DIFF
--- a/client/scss/components/_button.scss
+++ b/client/scss/components/_button.scss
@@ -211,7 +211,7 @@
     }
 
     &.button-longrunning {
-        span {
+        span {  // iconfont
             @include transition(all 0.3s ease);
             transform: scale(0.9);
             display: inline-block;
@@ -228,15 +228,16 @@
             font-style: normal;
         }
 
-        &.button-longrunning-active span {
+        &.button-longrunning-active span { // iconfont
             transform: scale(1);
             visibility: visible;
             width: 1em;
+            height: 1em;
             opacity: 0.8;
             padding-right: 0.5em;
         }
 
-        .icon-spinner:after {
+        span.icon-spinner:after { // iconfont
             text-align: center;
             position: absolute;
             left: 0;
@@ -244,6 +245,24 @@
             line-height: 1em;
             display: inline-block;
             font-size: 1em;
+        }
+
+        svg.icon-spinner {
+            @include transition(all 0.3s ease);
+            opacity: 0;
+            visibility: hidden;
+            width: 0;
+            height: 0;
+        }
+
+        &.button-longrunning-active svg.icon-spinner {
+            transform: scale(1);
+            visibility: visible;
+            width: 1em;
+            height: 1em;
+            opacity: 0.8;
+            padding: 0;
+            margin-right: 0.5em;
         }
     }
 

--- a/client/scss/components/_button.scss
+++ b/client/scss/components/_button.scss
@@ -142,9 +142,10 @@
             &:before {
                 display: none;  // TODO: remove once the icon font styles are gone
             }
+
             .icon {
                 @include svg-icon(1rem);
-                padding: .75em;
+                padding: 0.75em;
             }
         }
 
@@ -159,9 +160,10 @@
         .icon-wrapper {
             width: 2em;
         }
+
         &.button--icon .icon {
             @include svg-icon(0.9rem);
-            padding: .25em;
+            padding: 0.25em;
         }
     }
 
@@ -277,27 +279,6 @@
         padding: 0 1.4em;
         height: 3em;
 
-        &.icon.text-replace {
-            width: 2.2rem;
-            height: 2.2rem;
-
-            &:before {
-                line-height: 2.1em;
-            }
-        }
-
-        &.button-small {
-            &.icon.text-replace {
-                height: 1.8rem;
-                width: 1.8rem;
-
-                // stylelint-disable-next-line max-nesting-depth
-                &:before {
-                    line-height: 1.7em;
-                }
-            }
-        }
-
         &.bicolor {
             padding-left: 3.7em;
 
@@ -333,13 +314,62 @@
 }
 
 // Buttons which are only an icon
-.button.icon.text-replace {
+.button.icon.text-replace {  // iconfont
     font-size: 0; // unavoidable duplication of setting in icons.scss
     width: 1.8rem;
     height: 1.8rem;
 
     &:before {
         line-height: 1.7em;
+    }
+
+    @include media-breakpoint-up(sm) {
+        width: 2.2rem;
+        height: 2.2rem;
+
+        &:before {
+            line-height: 2.1em;
+        }
+
+
+        &.button-small {
+            height: 1.8rem;
+            width: 1.8rem;
+
+            // stylelint-disable-next-line max-nesting-depth
+            &:before {
+                line-height: 1.7em;
+            }
+        }
+    }
+}
+
+.button--icon.text-replace {
+    font-size: 0;
+    text-align: center;
+
+    .icon {
+        font-size: initial;
+        @include svg-icon(1rem, middle);
+        padding: 0.5em;
+    }
+
+    &.button-small {
+        line-height: 1.7rem;
+
+        .icon {
+            padding: 0.25em;
+        }
+    }
+
+    @include media-breakpoint-up(sm) {
+        width: 2.2rem;
+        height: 2.2rem;
+
+        &.button-small {
+            height: 1.8rem;
+            width: 1.8rem;
+        }
     }
 }
 

--- a/client/scss/components/_button.scss
+++ b/client/scss/components/_button.scss
@@ -109,7 +109,7 @@
         border: 1px solid transparent;
         padding-left: 3.5em;
 
-        &:before {
+        &:before {  // iconfont
             font-size: 1rem;
             position: absolute;
             left: 0;
@@ -124,6 +124,30 @@
             border-bottom-left-radius: inherit;
         }
 
+        .icon-wrapper {
+            background-color: rgba(0, 0, 0, 0.2);
+            display: block;
+            position: absolute;
+            left: 0;
+            top: 0;
+            width: 3em;
+            line-height: 1.85em;
+            height: 100%;
+            text-align: center;
+            border-top-left-radius: inherit;
+            border-bottom-left-radius: inherit;
+        }
+
+        &.button--icon {
+            &:before {
+                display: none;  // TODO: remove once the icon font styles are gone
+            }
+            .icon {
+                @include svg-icon(1rem);
+                padding: .75em;
+            }
+        }
+
         &.button-secondary {
             border: 1px solid rgba(0, 0, 0, 0.2);
         }
@@ -132,10 +156,12 @@
     &.button-small.bicolor {
         padding-left: 3.5em;
 
-        &:before {
+        .icon-wrapper {
             width: 2em;
-            font-size: 0.9rem;
-            line-height: 1.65em;
+        }
+        &.button--icon .icon {
+            @include svg-icon(0.9rem);
+            padding: .25em;
         }
     }
 
@@ -240,6 +266,12 @@
         border: 0;
     }
 
+    &.button--icon {
+        .icon {
+            @include svg-icon(1.5em);
+        }
+    }
+
     @include media-breakpoint-up(sm) {
         font-size: 0.95em;
         padding: 0 1.4em;
@@ -309,6 +341,10 @@
     &:before {
         line-height: 1.7em;
     }
+}
+
+button.button.bicolor .icon-wrapper {
+    line-height: 1.65em;  // work around differences in a and button elements
 }
 
 .button-neutral {

--- a/client/scss/components/_dropdown.legacy.scss
+++ b/client/scss/components/_dropdown.legacy.scss
@@ -7,14 +7,12 @@
     input[type=button],
     button,
     .button {
-        padding: 0;
+        padding: 0 5em 0 1em;
         display: block;
         width: 100%;
         height: 3em;
         line-height: 3em;
         text-align: left;
-        padding-left: 1em;
-        padding-right: 5em;
         float: left;
     }
 
@@ -149,6 +147,10 @@
 
         &:hover {
             background-color: $color-teal-darker;
+        }
+
+        svg.icon { // TODO: remove svg qualifier once the icon font styles are gone
+            @include svg-icon(1.3em);
         }
     }
 

--- a/client/scss/components/_dropdown.scss
+++ b/client/scss/components/_dropdown.scss
@@ -23,6 +23,30 @@
     display: inline-block;
 }
 
+.c-dropdown__togle--icon {
+    &:before {
+        display: none; // TODO: remove when iconfont styles are removed
+    }
+
+    .icon {
+        @include svg-icon(1em, middle);
+    }
+
+    .icon-arrow-up {
+        display: none;
+    }
+}
+
+.is-open .c-dropdown__togle--icon {
+    .icon-arrow-up {
+        display: inline-block;
+    }
+
+    .icon-arrow-down {
+        display: none;
+    }
+}
+
 .c-dropdown__menu.c-dropdown__menu {
     margin-top: 0.75rem;
     padding: 0.75rem 1rem;

--- a/client/scss/components/_icons.scss
+++ b/client/scss/components/_icons.scss
@@ -90,7 +90,7 @@
     font-size: 1.5em;
 }
 
-.icon.text-replace {
+.icon.text-replace { // iconfont
     font-size: 0;
     line-height: 0;
     overflow: hidden;
@@ -103,6 +103,16 @@
         line-height: 1.2em;
         text-align: center;
         vertical-align: middle;
+    }
+}
+
+.text-replace {
+    font-size: 0;
+    line-height: 0;
+    overflow: hidden;
+
+    .icon {
+        @include svg-icon(1rem, middle);
     }
 }
 

--- a/client/scss/components/_icons.scss
+++ b/client/scss/components/_icons.scss
@@ -69,16 +69,20 @@
 }
 
 .icon-view:before,
-.icon-no-view:before {
+.icon-no-view:before {  // icon-font
     vertical-align: -3.5px;
     font-size: 1.1rem;
 }
 
 .icon-spinner:after,
-.icon-spinner:before {
+.icon-spinner:before {  // iconfont
     width: 1em;
     animation: spin 0.5s infinite linear;
     display: inline-block;
+}
+
+svg.icon-spinner { // TODO: leave only class when iconfont styles are removed
+    animation: spin 0.5s infinite linear;
 }
 
 .icon-horizontalrule:before {

--- a/wagtail/admin/static_src/wagtailadmin/js/core.js
+++ b/wagtail/admin/static_src/wagtailadmin/js/core.js
@@ -539,7 +539,7 @@ wagtail = (function(document, window, wagtail) {
     wagtail.ui.initDropDowns = initDropDowns;
     wagtail.ui.DropDownController = DropDownController;
 
-    // provide a workaround for NodeList#forEach not being available in IE 11 
+    // provide a workaround for NodeList#forEach not being available in IE 11
     function qsa(element, selector) {
       return [].slice.call(element.querySelectorAll(selector));
     }

--- a/wagtail/admin/static_src/wagtailadmin/js/modal-workflow.js
+++ b/wagtail/admin/static_src/wagtailadmin/js/modal-workflow.js
@@ -21,7 +21,8 @@ function ModalWorkflow(opts) {
     $('body > .modal').remove();
 
     // set default contents of container
-    var container = $('<div class="modal fade" tabindex="-1" role="dialog" aria-hidden="true">\n    <div class="modal-dialog">\n        <div class="modal-content">\n            <button type="button" class="button close icon text-replace icon-cross" data-dismiss="modal">' + wagtailConfig.STRINGS.CLOSE + '</button>\n            <div class="modal-body"></div>\n        </div><!-- /.modal-content -->\n    </div><!-- /.modal-dialog -->\n</div>');
+    var iconClose = '<svg class="icon icon-cross" aria-hidden="true" focusable="false"><use href="#icon-cross"></use></svg>';
+    var container = $('<div class="modal fade" tabindex="-1" role="dialog" aria-hidden="true">\n    <div class="modal-dialog">\n        <div class="modal-content">\n            <button type="button" class="button close button--icon text-replace" data-dismiss="modal">' + iconClose + wagtailConfig.STRINGS.CLOSE + '</button>\n            <div class="modal-body"></div>\n        </div><!-- /.modal-content -->\n    </div><!-- /.modal-dialog -->\n</div>');
 
     // add container to body and hide it, so content can be added to it before display
     $('body').append(container);

--- a/wagtail/admin/templates/wagtailadmin/edit_handlers/inline_panel.html
+++ b/wagtail/admin/templates/wagtailadmin/edit_handlers/inline_panel.html
@@ -24,7 +24,8 @@
 </script>
 
 <p class="add">
-    <a class="button bicolor icon icon-plus" id="id_{{ self.formset.prefix }}-ADD">
+    <a class="button bicolor button--icon" id="id_{{ self.formset.prefix }}-ADD">
+        {% icon name="plus" wrapped=1 %}
         {% blocktrans with label=self.label|lower %}Add {{ label }}{% endblocktrans %}
     </a>
 </p>

--- a/wagtail/admin/templates/wagtailadmin/edit_handlers/inline_panel_child.html
+++ b/wagtail/admin/templates/wagtailadmin/edit_handlers/inline_panel_child.html
@@ -1,4 +1,4 @@
-{% load i18n %}
+{% load i18n wagtailadmin_tags %}
 <li data-inline-panel-child id="inline_child_{{ child.form.prefix }}">
     {% if child.form.non_field_errors %}
     <ul>
@@ -11,10 +11,10 @@
     {% endif %}
     <ul class="controls">
         {% if can_order %}
-            <li><button type="button" class="button button--icon text-replace white icon-order-up inline-child-move-up" id="{{ child.form.prefix }}-move-up" title="{% trans 'Move up' %}">{% trans "Move up" %}</button></li>
-            <li><button type="button" class="button button--icon text-replace white icon-order-down inline-child-move-down" id="{{ child.form.prefix }}-move-down" title="{% trans 'Move down' %}">{% trans "Move down" %}</button></li>
+            <li><button type="button" class="button button-small button--icon text-replace white inline-child-move-up" id="{{ child.form.prefix }}-move-up" title="{% trans 'Move up' %}">{% icon name="order-up" %}{% trans "Move up" %}</button></li>
+            <li><button type="button" class="button button-small button--icon text-replace white inline-child-move-down" id="{{ child.form.prefix }}-move-down" title="{% trans 'Move down' %}">{% icon name="order-down" %}{% trans "Move down" %}</button></li>
         {% endif %}
-        <li><button type="button" class="button button--icon text-replace white icon-bin hover-no" id="{{ child.form.DELETE.id_for_label }}-button" title="{% trans 'Delete' %}">{% trans "Delete" %}</button></li>
+        <li><button type="button" class="button button-small button--icon text-replace white hover-no" id="{{ child.form.DELETE.id_for_label }}-button" title="{% trans 'Delete' %}">{% icon name="bin" %}{% trans "Delete" %}</button></li>
     </ul>
     {{ child.render_form_content }}
 </li>

--- a/wagtail/admin/templates/wagtailadmin/edit_handlers/inline_panel_child.html
+++ b/wagtail/admin/templates/wagtailadmin/edit_handlers/inline_panel_child.html
@@ -11,10 +11,10 @@
     {% endif %}
     <ul class="controls">
         {% if can_order %}
-            <li><button type="button" class="button icon text-replace white icon-order-up inline-child-move-up" id="{{ child.form.prefix }}-move-up" title="{% trans 'Move up' %}">{% trans "Move up" %}</button></li>
-            <li><button type="button" class="button icon text-replace white icon-order-down inline-child-move-down" id="{{ child.form.prefix }}-move-down" title="{% trans 'Move down' %}">{% trans "Move down" %}</button></li>
+            <li><button type="button" class="button button--icon text-replace white icon-order-up inline-child-move-up" id="{{ child.form.prefix }}-move-up" title="{% trans 'Move up' %}">{% trans "Move up" %}</button></li>
+            <li><button type="button" class="button button--icon text-replace white icon-order-down inline-child-move-down" id="{{ child.form.prefix }}-move-down" title="{% trans 'Move down' %}">{% trans "Move down" %}</button></li>
         {% endif %}
-        <li><button type="button" class="button icon text-replace white icon-bin hover-no" id="{{ child.form.DELETE.id_for_label }}-button" title="{% trans 'Delete' %}">{% trans "Delete" %}</button></li>
+        <li><button type="button" class="button button--icon text-replace white icon-bin hover-no" id="{{ child.form.DELETE.id_for_label }}-button" title="{% trans 'Delete' %}">{% trans "Delete" %}</button></li>
     </ul>
     {{ child.render_form_content }}
 </li>

--- a/wagtail/admin/templates/wagtailadmin/login.html
+++ b/wagtail/admin/templates/wagtailadmin/login.html
@@ -1,5 +1,5 @@
 {% extends "wagtailadmin/admin_base.html" %}
-{% load wagtailadmin_tags i18n %}
+{% load i18n wagtailadmin_tags %}
 {% block titletag %}{% trans "Sign in" %}{% endblock %}
 {% block bodyclass %}login{% endblock %}
 
@@ -76,7 +76,7 @@
                 {% endblock %}
                 <li class="submit">
                     {% block submit_buttons %}
-                    <button type="submit" class="button button-longrunning" data-clicked-text="{% trans 'Signing in…' %}"><span class="icon icon-spinner"></span><em>{% trans 'Sign in' %}</em></button>
+                    <button type="submit" class="button button-longrunning" data-clicked-text="{% trans 'Signing in…' %}">{% icon name="spinner" %}<em>{% trans 'Sign in' %}</em></button>
                     {% endblock %}
                 </li>
             </ul>

--- a/wagtail/admin/templates/wagtailadmin/pages/_preview_button_on_edit.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/_preview_button_on_edit.html
@@ -1,6 +1,6 @@
 {% load wagtailadmin_tags %}
 
 {% auto_update_preview as auto_update %}
-<button class="button action-preview {% if icon %}icon icon-view{% endif %}"
+<button class="button action-preview {% if icon %}button--icon{% endif %}"
     data-action="{% url 'wagtailadmin_pages:preview_on_edit' page.id %}{% if mode %}?mode={{ mode|urlencode }}{% endif %}"
-    data-auto-update="{{ auto_update|yesno:'true,false' }}">{{ label }}</button>
+    data-auto-update="{{ auto_update|yesno:'true,false' }}">{% if icon %}{% icon name="view" %}{% endif %}{{ label }}</button>

--- a/wagtail/admin/templates/wagtailadmin/pages/action_menu/menu.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/action_menu/menu.html
@@ -1,8 +1,9 @@
+{% load wagtailadmin_tags %}
 {% if default_menu_item %}
     {{ default_menu_item }}
 {% endif %}
 {% if show_menu %}
-    <div class="dropdown-toggle icon icon-arrow-up"></div>
+    <div class="dropdown-toggle">{% icon name="arrow-up" %}</div>
     <ul>
         {% for item in rendered_menu_items %}
             <li>

--- a/wagtail/admin/templates/wagtailadmin/pages/action_menu/publish.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/action_menu/publish.html
@@ -1,2 +1,2 @@
-{% load i18n %}
-<button type="submit" name="action-publish" value="action-publish" class="button button-longrunning {% if is_revision %}warning{% endif %}" data-clicked-text="{% trans 'Publishing…' %}"><span class="icon icon-spinner"></span><em>{% if is_revision %}{% trans 'Publish this revision' %}{% else %}{% trans 'Publish' %}{% endif %}</em></button>
+{% load i18n wagtailadmin_tags %}
+<button type="submit" name="action-publish" value="action-publish" class="button button-longrunning {% if is_revision %}warning{% endif %}" data-clicked-text="{% trans 'Publishing…' %}">{% icon name="spinner" %}<em>{% if is_revision %}{% trans 'Publish this revision' %}{% else %}{% trans 'Publish' %}{% endif %}</em></button>

--- a/wagtail/admin/templates/wagtailadmin/pages/action_menu/save_draft.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/action_menu/save_draft.html
@@ -1,2 +1,2 @@
-{% load i18n %}
-<button type="submit" class="button action-save button-longrunning {% if is_revision %}warning{% endif %}" data-clicked-text="{% trans 'Saving…' %}"><span class="icon icon-spinner"></span><em>{% if is_revision %}{% trans 'Replace current draft' %}{% else %}{% trans 'Save draft' %}{% endif %}</em></button>
+{% load i18n wagtailadmin_tags %}
+<button type="submit" class="button action-save button-longrunning {% if is_revision %}warning{% endif %}" data-clicked-text="{% trans 'Saving…' %}">{% icon name="spinner" %}<em>{% if is_revision %}{% trans 'Replace current draft' %}{% else %}{% trans 'Save draft' %}{% endif %}</em></button>

--- a/wagtail/admin/templates/wagtailadmin/pages/create.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/create.html
@@ -40,7 +40,7 @@
                             {% if preview_modes|length > 1 %}
                                 <div class="dropdown dropup dropdown-button match-width">
                                     {% include "wagtailadmin/pages/_preview_button_on_create.html" with label=preview_label icon=1 %}
-                                    <div class="dropdown-toggle icon icon-arrow-up"></div>
+                                    <div class="dropdown-toggle">{% icon name="arrow-up" %}</div>
                                     <ul>
                                         {% for mode_name, mode_display_name in preview_modes %}
                                             <li>

--- a/wagtail/admin/templates/wagtailadmin/pages/edit.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/edit.html
@@ -51,7 +51,7 @@
                             {% if preview_modes|length > 1 %}
                                 <div class="dropdown dropup dropdown-button match-width">
                                     {% include "wagtailadmin/pages/_preview_button_on_edit.html" with label=preview_label icon=1 %}
-                                    <div class="dropdown-toggle icon icon-arrow-up"></div>
+                                    <div class="dropdown-toggle">{% icon name="arrow-up" %}</div>
                                     <ul>
                                         {% for mode_name, mode_display_name in preview_modes %}
                                             <li>

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_button_with_dropdown.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_button_with_dropdown.html
@@ -1,7 +1,10 @@
+{% load wagtailadmin_tags %}
 <div {{ self.attrs }} class="c-dropdown  {% if is_parent %}t-inverted{% else %}t-default{% endif %}" data-dropdown>
     <a href="javascript:void(0)" aria-label="{{ title }}" class="c-dropdown__button  u-btn-current">
         {{ label }}
-        <div data-dropdown-toggle class="o-icon c-dropdown__toggle  [ icon icon-arrow-down ]"></div>
+        <div data-dropdown-toggle class="o-icon c-dropdown__toggle c-dropdown__togle--icon [ icon icon-arrow-down ]">
+            {% icon name="arrow-down" %}{% icon name="arrow-up" %}
+        </div>
     </a>
     <div class="t-dark">
         <ul class="c-dropdown__menu u-toggle  u-arrow u-arrow--tl u-background">

--- a/wagtail/admin/templates/wagtailadmin/permissions/includes/collection_member_permissions_formset.html
+++ b/wagtail/admin/templates/wagtailadmin/permissions/includes/collection_member_permissions_formset.html
@@ -51,7 +51,7 @@
 </script>
 
 <p class="add">
-    <a class="button bicolor icon icon-plus" id="id_{{ formset.prefix }}-ADD" value="Add">{% block add_button_label %}{% endblock %}</a>
+    <a class="button bicolor button--icon" id="id_{{ formset.prefix }}-ADD" value="Add">{% icon name="plus" wrapped=1 %}{% block add_button_label %}{% endblock %}</a>
 </p>
 
 <script>

--- a/wagtail/admin/templates/wagtailadmin/reports/base_report.html
+++ b/wagtail/admin/templates/wagtailadmin/reports/base_report.html
@@ -18,10 +18,10 @@
                 {% block actions %}
                     {% if view.list_export %}
                         <div class="dropdown dropdown-button match-width">
-                            <a href="{{ view.xlsx_export_url }}" class="button bicolor icon icon-download">{% trans 'Download XLSX' %}</a>
+                            <a href="{{ view.xlsx_export_url }}" class="button bicolor button--icon">{% icon name="download" wrapped=1 %}{% trans 'Download XLSX' %}</a>
                             <div class="dropdown-toggle icon icon-arrow-down"></div>
                             <ul>
-                                <li><a  class="button bicolor icon icon-download" href="{{ view.csv_export_url }}">{% trans 'Download CSV' %}</a></li>
+                                <li><a  class="button bicolor button--icon" href="{{ view.csv_export_url }}">{% icon name="download" wrapped=1 %}{% trans 'Download CSV' %}</a></li>
                             </ul>
                         </div>
                     {% endif %}

--- a/wagtail/admin/templates/wagtailadmin/reports/base_report.html
+++ b/wagtail/admin/templates/wagtailadmin/reports/base_report.html
@@ -19,7 +19,7 @@
                     {% if view.list_export %}
                         <div class="dropdown dropdown-button match-width">
                             <a href="{{ view.xlsx_export_url }}" class="button bicolor button--icon">{% icon name="download" wrapped=1 %}{% trans 'Download XLSX' %}</a>
-                            <div class="dropdown-toggle icon icon-arrow-down"></div>
+                            <div class="dropdown-toggle">{% icon name="arrow-down" %}</div>
                             <ul>
                                 <li><a  class="button bicolor button--icon" href="{{ view.csv_export_url }}">{% icon name="download" wrapped=1 %}{% trans 'Download CSV' %}</a></li>
                             </ul>

--- a/wagtail/admin/templates/wagtailadmin/reports/base_report.html
+++ b/wagtail/admin/templates/wagtailadmin/reports/base_report.html
@@ -44,7 +44,7 @@
                         {{ filter }}
                         {{ filter.errors }}
                     {% endfor %}
-                    <button class="button button-longrunning" type="submit">{% trans 'Apply filters' %}</button>
+                    <button class="button button-longrunning" type="submit">{% icon name="spinner" %}{% trans 'Apply filters' %}</button>
                 </form>
             </div>
         {% endif %}

--- a/wagtail/admin/templates/wagtailadmin/shared/header.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/header.html
@@ -41,7 +41,9 @@
         <div class="right">
             {% if action_url %}
                 <div class="actionbutton">
-                    <a href="{{ action_url }}" class="button bicolor icon {{ action_icon|default:'icon-plus' }}">{{ action_text }}</a>
+                    {% with action_icon|default:'plus' as action_icon_name %}
+                    <a href="{{ action_url }}" class="button bicolor button--icon">{% icon name=action_icon_name wrapped=1 %}{{ action_text }}</a>
+                    {% endwith %}
                 </div>
             {% endif %}
         </div>

--- a/wagtail/admin/templates/wagtailadmin/shared/icon.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/icon.html
@@ -1,5 +1,6 @@
 {% spaceless %}
 {# Reference implementation: components/Icon.js #}
+{% if wrapped %}<span class="icon-wrapper">{% endif %}
 <svg class="icon icon-{{ name }} {{ class_name }}" aria-hidden="true" focusable="false">
   <use href="#icon-{{ name }}"></use>
 </svg>
@@ -8,4 +9,5 @@
     {{ title }}
   </span>
 {% endif %}
+{% if wrapped %}</span>{% endif %}
 {% endspaceless %}

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -506,7 +506,7 @@ def versioned_static(path):
 
 
 @register.inclusion_tag("wagtailadmin/shared/icon.html", takes_context=False)
-def icon(name=None, class_name='icon', title=None):
+def icon(name=None, class_name='icon', title=None, wrapped=False):
     """
     Abstracts away the actual icon implementation.
 
@@ -527,6 +527,7 @@ def icon(name=None, class_name='icon', title=None):
         'name': name,
         'class_name': class_name,
         'title': title,
+        'wrapped': wrapped
     }
 
 

--- a/wagtail/admin/tests/pages/test_edit_page.py
+++ b/wagtail/admin/tests/pages/test_edit_page.py
@@ -945,12 +945,12 @@ class TestPageEdit(TestCase, WagtailTestUtils):
 
         publish_button = '''
             <button type="submit" name="action-publish" value="action-publish" class="button button-longrunning " data-clicked-text="Publishing…">
-                <span class="icon icon-spinner"></span><em>Publish</em>
+                <svg class="icon icon-spinner icon" aria-hidden="true" focusable="false"><use href="#icon-spinner"></use></svg><em>Publish</em>
             </button>
         '''
         save_button = '''
             <button type="submit" class="button action-save button-longrunning " data-clicked-text="Saving…" >
-                <span class="icon icon-spinner"></span><em>Save draft</em>
+                <svg class="icon icon-spinner icon" aria-hidden="true" focusable="false"><use href="#icon-spinner"></use></svg><em>Save draft</em>
             </button>
         '''
 

--- a/wagtail/contrib/forms/templates/wagtailforms/index_submissions.html
+++ b/wagtail/contrib/forms/templates/wagtailforms/index_submissions.html
@@ -105,7 +105,7 @@
                 <div class="right">
                     <div class="dropdown dropdown-button match-width">
                         <a href="?export=xlsx" class="button bicolor button--icon">{% icon name="download" wrapped=1 %}{% trans 'Download XLSX' %}</a>
-                       <div class="dropdown-toggle icon icon-arrow-down"></div>
+                        <div class="dropdown-toggle">{% icon name="arrow-down" %}</div>
                         <ul>
                             <li><a  class="button bicolor button--icon" href="?export=csv">{% icon name="download" wrapped=1 %}{% trans 'Download CSV' %}</a></li>
                         </ul>

--- a/wagtail/contrib/forms/templates/wagtailforms/index_submissions.html
+++ b/wagtail/contrib/forms/templates/wagtailforms/index_submissions.html
@@ -104,10 +104,10 @@
                 </div>
                 <div class="right">
                     <div class="dropdown dropdown-button match-width">
-                        <a href="?export=xlsx" class="button bicolor icon icon-download">{% trans 'Download XLSX' %}</a>
+                        <a href="?export=xlsx" class="button bicolor button--icon">{% icon name="download" wrapped=1 %}{% trans 'Download XLSX' %}</a>
                        <div class="dropdown-toggle icon icon-arrow-down"></div>
                         <ul>
-                            <li><a  class="button bicolor icon icon-download" href="?export=csv">{% trans 'Download CSV' %}</a></li>
+                            <li><a  class="button bicolor button--icon" href="?export=csv">{% icon name="download" wrapped=1 %}{% trans 'Download CSV' %}</a></li>
                         </ul>
                     </div>
                 </div>

--- a/wagtail/contrib/modeladmin/templates/modeladmin/create.html
+++ b/wagtail/contrib/modeladmin/templates/modeladmin/create.html
@@ -1,5 +1,5 @@
 {% extends "wagtailadmin/base.html" %}
-{% load i18n %}
+{% load i18n wagtailadmin_tags %}
 
 {% block titletag %}{{ view.get_meta_title }}{% endblock %}
 
@@ -40,7 +40,7 @@
                         {% block form_actions %}
                             <div class="dropdown dropup dropdown-button match-width">
                                 <button type="submit" class="button action-save button-longrunning" data-clicked-text="{% trans 'Saving…' %}">
-                                    <span class="icon icon-spinner"></span><em>{% trans 'Save' %}</em>
+                                    {% icon name="spinner" %}<em>{% trans 'Save' %}</em>
                                 </button>
                             </div>
                         {% endblock %}

--- a/wagtail/contrib/modeladmin/templates/modeladmin/edit.html
+++ b/wagtail/contrib/modeladmin/templates/modeladmin/edit.html
@@ -1,5 +1,5 @@
 {% extends "modeladmin/create.html" %}
-{% load i18n %}
+{% load i18n wagtailadmin_tags %}
 
 {% block form_action %}{{ view.edit_url }}{% endblock %}
 
@@ -10,7 +10,7 @@
         </button>
 
         {% if user_can_delete %}
-            <div class="dropdown-toggle icon icon-arrow-up"></div>
+            <div class="dropdown-toggle">{% icon name="arrow-up" %}</div>
             <ul>
                 <li><a href="{{ view.delete_url }}" class="shortcut">{% trans "Delete" %}</a></li>
             </ul>

--- a/wagtail/contrib/modeladmin/templates/modeladmin/edit.html
+++ b/wagtail/contrib/modeladmin/templates/modeladmin/edit.html
@@ -6,7 +6,7 @@
 {% block form_actions %}
     <div class="dropdown dropup dropdown-button match-width">
         <button type="submit" class="button action-save button-longrunning" data-clicked-text="{% trans 'Saving…' %}">
-            <span class="icon icon-spinner"></span><em>{% trans 'Save' %}</em>
+            {% icon name="spinner" %}<em>{% trans 'Save' %}</em>
         </button>
 
         {% if user_can_delete %}

--- a/wagtail/contrib/modeladmin/templates/modeladmin/index.html
+++ b/wagtail/contrib/modeladmin/templates/modeladmin/index.html
@@ -33,7 +33,7 @@
                         {% if view.list_export %}
                             <div class="dropdown dropdown-button match-width col">
                                 <a href="?export=xlsx&{{ request.GET.urlencode }}" class="button bicolor button--icon">{% icon name="download" wrapped=1 %}{% trans 'Download XLSX' %}</a>
-                                <div class="dropdown-toggle icon icon-arrow-down"></div>
+                                <div class="dropdown-toggle">{% icon name="arrow-down" %}</div>
                                 <ul>
                                     <li><a  class="button bicolor button--icon" href="?export=csv&{{ request.GET.urlencode }}">{% icon name="download" wrapped=1 %}{% trans 'Download CSV' %}</a></li>
                                 </ul>

--- a/wagtail/contrib/modeladmin/templates/modeladmin/index.html
+++ b/wagtail/contrib/modeladmin/templates/modeladmin/index.html
@@ -1,5 +1,5 @@
 {% extends "wagtailadmin/base.html" %}
-{% load i18n modeladmin_tags %}
+{% load i18n modeladmin_tags wagtailadmin_tags %}
 
 {% block titletag %}{{ view.get_meta_title }}{% endblock %}
 
@@ -32,10 +32,10 @@
                         {% endif %}
                         {% if view.list_export %}
                             <div class="dropdown dropdown-button match-width col">
-                                <a href="?export=xlsx&{{ request.GET.urlencode }}" class="button bicolor icon icon-download">{% trans 'Download XLSX' %}</a>
+                                <a href="?export=xlsx&{{ request.GET.urlencode }}" class="button bicolor button--icon">{% icon name="download" wrapped=1 %}{% trans 'Download XLSX' %}</a>
                                 <div class="dropdown-toggle icon icon-arrow-down"></div>
                                 <ul>
-                                    <li><a  class="button bicolor icon icon-download" href="?export=csv&{{ request.GET.urlencode }}">{% trans 'Download CSV' %}</a></li>
+                                    <li><a  class="button bicolor button--icon" href="?export=csv&{{ request.GET.urlencode }}">{% icon name="download" wrapped=1 %}{% trans 'Download CSV' %}</a></li>
                                 </ul>
                             </div>
                         {% endif %}
@@ -94,7 +94,7 @@
                             {% endif %}
                         </nav>
                     {% endblock %}
-                    
+
                 {% endblock %}
             </div>
         </div>

--- a/wagtail/contrib/redirects/templates/wagtailredirects/index.html
+++ b/wagtail/contrib/redirects/templates/wagtailredirects/index.html
@@ -1,6 +1,6 @@
 {% extends "wagtailadmin/base.html" %}
 {% load i18n %}
-{% load static %}
+{% load static wagtailadmin_tags %}
 
 {% block titletag %}{% trans "Redirects" %}{% endblock %}
 
@@ -43,10 +43,10 @@
                 </div>
                 <div class="right has-multiple-actions">
                     <div class="actionbutton">
-                        <a href="{{ add_link }}" class="button bicolor icon icon-plus">{{ add_str }}</a>
+                        <a href="{{ add_link }}" class="button bicolor button--icon">{% icon name="plus" wrapped=1 %}{{ add_str }}</a>
                     </div>
                     <div class="actionbutton">
-                        <a href="{{ import_link }}" class="button bicolor icon icon-doc-full-inverse">{{ import_str }}</a>
+                        <a href="{{ import_link }}" class="button bicolor button--icon">{% icon name="doc-full-inverse" wrapped=1 %}{{ import_str }}</a>
                     </div>
                 </div>
             </div>

--- a/wagtail/contrib/search_promotions/templates/wagtailsearchpromotions/includes/searchpromotion_form.html
+++ b/wagtail/contrib/search_promotions/templates/wagtailsearchpromotions/includes/searchpromotion_form.html
@@ -1,9 +1,9 @@
-{% load i18n %}
+{% load i18n wagtailadmin_tags %}
 <li id="inline_child_{{ form.prefix }}"{% if form.DELETE.value %} style="display: none;"{% endif %}>
     <ul class="controls">
-        <li><button type="button" class="button button--icon text-replace icon-order-up inline-child-move-up" id="{{ form.prefix }}-move-up">{% trans "Move up" %}</button></li>
-        <li><button type="button" class="button button--icon text-replace icon-order-down inline-child-move-down" id="{{ form.prefix }}-move-down">{% trans "Move down" %}</button></li>
-        <li><button type="button" class="button button--icon text-replace icon-bin" id="{{ form.DELETE.id_for_label }}-button">{% trans "Delete" %}</button></li>
+        <li><button type="button" class="button button--icon text-replace inline-child-move-up" id="{{ form.prefix }}-move-up">{% icon name="order-up" %}{% trans "Move up" %}</button></li>
+        <li><button type="button" class="button button--icon text-replace inline-child-move-down" id="{{ form.prefix }}-move-down">{% icon name="order-down" %}{% trans "Move down" %}</button></li>
+        <li><button type="button" class="button button--icon text-replace" id="{{ form.DELETE.id_for_label }}-button">{% icon name="bin" %}{% trans "Delete" %}</button></li>
     </ul>
 
     <fieldset>

--- a/wagtail/contrib/search_promotions/templates/wagtailsearchpromotions/includes/searchpromotion_form.html
+++ b/wagtail/contrib/search_promotions/templates/wagtailsearchpromotions/includes/searchpromotion_form.html
@@ -1,9 +1,9 @@
 {% load i18n %}
 <li id="inline_child_{{ form.prefix }}"{% if form.DELETE.value %} style="display: none;"{% endif %}>
     <ul class="controls">
-        <li><button type="button" class="button icon text-replace icon-order-up inline-child-move-up" id="{{ form.prefix }}-move-up">{% trans "Move up" %}</button></li>
-        <li><button type="button" class="button icon text-replace icon-order-down inline-child-move-down" id="{{ form.prefix }}-move-down">{% trans "Move down" %}</button></li>
-        <li><button type="button" class="button icon text-replace icon-bin" id="{{ form.DELETE.id_for_label }}-button">{% trans "Delete" %}</button></li>
+        <li><button type="button" class="button button--icon text-replace icon-order-up inline-child-move-up" id="{{ form.prefix }}-move-up">{% trans "Move up" %}</button></li>
+        <li><button type="button" class="button button--icon text-replace icon-order-down inline-child-move-down" id="{{ form.prefix }}-move-down">{% trans "Move down" %}</button></li>
+        <li><button type="button" class="button button--icon text-replace icon-bin" id="{{ form.DELETE.id_for_label }}-button">{% trans "Delete" %}</button></li>
     </ul>
 
     <fieldset>

--- a/wagtail/contrib/search_promotions/templates/wagtailsearchpromotions/includes/searchpromotions_formset.html
+++ b/wagtail/contrib/search_promotions/templates/wagtailsearchpromotions/includes/searchpromotions_formset.html
@@ -13,5 +13,5 @@
 </script>
 
 <p class="add">
-    <a class="button bicolor icon icon-plus" id="id_{{ formset.prefix }}-ADD" value="Add">{% trans "Add recommended page" %}</a>
+    <a class="button bicolor button--icon" id="id_{{ formset.prefix }}-ADD" value="Add">{% icon name="plus" wrapped=1 %}{% trans "Add recommended page" %}</a>
 </p>

--- a/wagtail/contrib/settings/templates/wagtailsettings/edit.html
+++ b/wagtail/contrib/settings/templates/wagtailsettings/edit.html
@@ -34,7 +34,7 @@
         <footer>
             <ul>
                 <li class="actions dropdown dropup match-width">
-                    <button type="submit" class="button button-longrunning" data-clicked-text="{% trans 'Saving…' %}"><span class="icon icon-spinner"></span><em>{% trans 'Save' %}</em></button>
+                    <button type="submit" class="button button-longrunning" data-clicked-text="{% trans 'Saving…' %}">{% icon name="spinner" %}<em>{% trans 'Save' %}</em></button>
                 </li>
             </ul>
         </footer>

--- a/wagtail/contrib/styleguide/templates/wagtailstyleguide/base.html
+++ b/wagtail/contrib/styleguide/templates/wagtailstyleguide/base.html
@@ -453,16 +453,16 @@
 
             <h3>Buttons with internal loading indicators (currently only <code>button</code> supported)</h3>
             <p class="help-block help-warning">Note that in some browsers, clicking these buttons minutely affects the appearance of Dropdown buttons, below. This is yet to be resolved.</p>
-            <button class="button button-longrunning"><span class="icon icon-spinner"></span>Click me</button>
+            <button class="button button-longrunning">{% icon name="spinner" %}Click me</button>
 
             <h4>Secondary</h4>
-            <button class="button button-secondary button-longrunning"><span class="icon icon-spinner"></span>Click me</button>
+            <button class="button button-secondary button-longrunning">{% icon name="spinner" %}Click me</button>
 
             <h4>Small</h4>
-            <button class="button button-small button-longrunning"><span class="icon icon-spinner"></span>Click me</button>
+            <button class="button button-small button-longrunning">{% icon name="spinner" %}Click me</button>
 
             <h4>Buttons where the text is replaced on click</h4>
-            <button class="button button-longrunning" data-clicked-text="Test"><span class="icon icon-spinner"></span><em>Click me</em></button>
+            <button class="button button-longrunning" data-clicked-text="Test">{% icon name="spinner" %}<em>Click me</em></button>
 
             <h4>Arbitrarily bigger</h4>
             <style>
@@ -472,7 +472,7 @@
                     height:3.5em;
                 }
             </style>
-            <button class="button button-longrunning" id="button-arbitrarily-bigger"><span class="icon icon-spinner"></span>Click me</button>
+            <button class="button button-longrunning" id="button-arbitrarily-bigger">{% icon name="spinner" %}Click me</button>
 
             <h3>Mixtures</h3>
 

--- a/wagtail/contrib/styleguide/templates/wagtailstyleguide/base.html
+++ b/wagtail/contrib/styleguide/templates/wagtailstyleguide/base.html
@@ -506,7 +506,7 @@
                 <div class="col3">
                     <div class="dropdown dropdown-button match-width">
                         <input type="button" value="drop down" class="button" />
-                        <div class="dropdown-toggle icon icon-arrow-down"></div>
+                        <div class="dropdown-toggle">{% icon name="arrow-down" %}</div>
                         <ul>
                             <li><a href="#">items should not exceed button width</a></li>
                             <li><a href="#">item 2</a></li>
@@ -517,7 +517,7 @@
                 <div class="col3">
                     <div class="dropdown dropdown-button">
                         <input type="button" value="drop down" class="button" />
-                        <div class="dropdown-toggle icon icon-arrow-down"></div>
+                        <div class="dropdown-toggle">{% icon name="arrow-down" %}</div>
                         <ul>
                             <li><a href="#">Items in this list do not match button width</a></li>
                             <li><a href="#">item 2</a></li>
@@ -528,7 +528,7 @@
                 <div class="col3">
                     <div class="dropdown dropup dropdown-button match-width">
                         <input type="button" value="drop up" class="button" />
-                        <div class="dropdown-toggle icon icon-arrow-up"></div>
+                        <div class="dropdown-toggle">{% icon name="arrow-up" %}</div>
                         <ul>
                             <li><a href="#">item 1</a></li>
                             <li><a href="#">item 2</a></li>
@@ -539,7 +539,7 @@
                 <div class="col3">
                     <div class="dropdown dropup dropdown-button match-width">
                         <button value="drop up" class="button icon icon-view">icon dropup</button>
-                        <div class="dropdown-toggle icon icon-arrow-up"></div>
+                        <div class="dropdown-toggle">{% icon name="arrow-up" %}</div>
                         <ul>
                             <li><a href="#">item 1</a></li>
                             <li><a href="#">item 2</a></li>
@@ -553,7 +553,7 @@
                 <div class="col3">
                     <div class="dropdown dropdown-button match-width">
                         <a href="#" class="button" value="drop down">Link button</a>
-                        <div class="dropdown-toggle icon icon-arrow-down"></div>
+                        <div class="dropdown-toggle">{% icon name="arrow-down" %}</div>
                         <ul>
                             <li><a href="#">items should not exceed button width</a></li>
                             <li><a href="#">item 2</a></li>

--- a/wagtail/contrib/styleguide/templates/wagtailstyleguide/base.html
+++ b/wagtail/contrib/styleguide/templates/wagtailstyleguide/base.html
@@ -421,13 +421,13 @@
             <h3>Bi-color icon buttons with text</h3>
             <p>Note that <code>input</code> elements are not supported by any icon buttons.</p>
 
-            <a href="#" class="button bicolor icon icon-plus">button link</a>
-            <button class="button bicolor icon icon-plus">button element</button>
+            <a href="#" class="button bicolor button--icon">{% icon name="plus" wrapped=1 %}button link</a>
+            <button class="button bicolor button--icon">{% icon name="plus" wrapped=1 %}button element</button>
 
             <h4>(small)</h4>
 
-            <a href="#" class="button button-small bicolor icon icon-plus">button link</a>
-            <button class="button button-small bicolor icon icon-plus">button element</button>
+            <a href="#" class="button button-small bicolor button--icon">{% icon name="plus" wrapped=1 %}button link</a>
+            <button class="button button-small bicolor button--icon">{% icon name="plus" wrapped=1 %}button element</button>
 
             <h3>Icon buttons without text</h3>
 

--- a/wagtail/contrib/styleguide/templates/wagtailstyleguide/base.html
+++ b/wagtail/contrib/styleguide/templates/wagtailstyleguide/base.html
@@ -431,13 +431,13 @@
 
             <h3>Icon buttons without text</h3>
 
-            <a href="#" class="button text-replace icon icon-cog">button link</a>
-            <button class="button text-replace icon icon-cog">button element</button>
+            <a href="#" class="button text-replace button--icon">{% icon name="cog" %}button link</a>
+            <button class="button text-replace button--icon">{% icon name="cog" %}button element</button>
 
             <h4>(small)</h4>
 
-            <a href="#" class="button button-small text-replace icon icon-cog">button link</a>
-            <button class="button button-small text-replace icon icon-cog">button element</button>
+            <a href="#" class="button button-small text-replace button--icon">{% icon name="cog" %}button link</a>
+            <button class="button button-small text-replace button--icon">{% icon name="cog" %}button element</button>
 
             <h3>Colour signifiers</h3>
 
@@ -476,10 +476,10 @@
 
             <h3>Mixtures</h3>
 
-            <button class="button icon text-replace yes icon-tick">A proper button</button>
-            <a href="#" class="button icon text-replace white icon-cog">A link button</a>
-            <span class="button icon text-replace no icon-bin">A non-link button</span>
-            <a href="#" class="button bicolor disabled icon icon-tick">button link</a>
+            <button class="button button--icon text-replace yes">{% icon name="tick" %}A proper button</button>
+            <a href="#" class="button button--icon text-replace white">{% icon name="cog" %}A link button</a>
+            <span class="button button--icon text-replace no ">{% icon name="bin" %}A non-link button</span>
+            <a href="#" class="button button--icon bicolor disabled">{% icon name="tick" wrapped=1 %}button link</a>
 
         </section>
 
@@ -493,9 +493,9 @@
             </div>
             <br />
             <div class="button-group">
-                <button class="button icon text-replace yes icon-tick">A proper button</button>
-                <a href="#" class="button icon text-replace white icon-cog">A link button</a>
-                <span class="button icon text-replace no icon-bin">A non-link button</span>
+                <button class="button button--icon text-replace yes">{% icon name="tick" %}A proper button</button>
+                <a href="#" class="button button--icon text-replace white">{% icon name="cog" %}A link button</a>
+                <span class="button button--icon text-replace no">{% icon name="bin" %}A non-link button</span>
             </div>
         </section>
 

--- a/wagtail/contrib/styleguide/templates/wagtailstyleguide/base.html
+++ b/wagtail/contrib/styleguide/templates/wagtailstyleguide/base.html
@@ -576,7 +576,10 @@
                 <div class="c-dropdown u-para t-default" data-dropdown="">
                     <a class="c-dropdown__button  u-btn-current">
                         More
-                        <div data-dropdown-toggle="" class="o-icon  c-dropdown__toggle  [ icon icon-arrow-down ]"></div>
+                        <div data-dropdown-toggle="" class="o-icon  c-dropdown__toggle c-dropdown__togle--icon  [ icon icon-arrow-down ]">
+                            {% icon name="arrow-down" %}
+                            {% icon name="arrow-up" %}
+                        </div>
                     </a>
                     <div class="t-dark">
                         <nav aria-label="Inline dropdown menu example">
@@ -639,7 +642,10 @@
                 <div class="c-dropdown  t-inverted" data-dropdown="">
                     <a class="c-dropdown__button  u-btn-current">
                         More
-                        <div data-dropdown-toggle="" class="o-icon  c-dropdown__toggle  [ icon icon-arrow-down ]"></div>
+                        <div data-dropdown-toggle="" class="o-icon  c-dropdown__toggle c-dropdown__togle--icon  [ icon icon-arrow-down ]">
+                            {% icon name="arrow-down" %}
+                            {% icon name="arrow-up" %}
+                        </div>
                     </a>
                     <div class="t-dark">
                         <nav aria-label="Dark inline dropdown menu example">

--- a/wagtail/documents/templates/wagtaildocs/chooser/chooser.html
+++ b/wagtail/documents/templates/wagtaildocs/chooser/chooser.html
@@ -1,4 +1,4 @@
-{% load i18n %}
+{% load i18n wagtailadmin_tags %}
 {% trans "Choose a document" as  choose_str %}
 {% include "wagtailadmin/shared/header.html" with title=choose_str tabbed=1 merged=1 icon="doc-full-inverse" %}
 
@@ -42,7 +42,7 @@
                         {% endif %}
                     {% endfor %}
                     <li>
-                        <button type="submit" class="button button-longrunning" data-clicked-text="{% trans 'Uploading…' %}"><span class="icon icon-spinner"></span><em>{% trans 'Upload' %}</em></button>
+                        <button type="submit" class="button button-longrunning" data-clicked-text="{% trans 'Uploading…' %}">{% icon name="spinner" %}<em>{% trans 'Upload' %}</em></button>
                     </li>
                 </ul>
             </form>

--- a/wagtail/documents/templates/wagtaildocs/documents/add.html
+++ b/wagtail/documents/templates/wagtaildocs/documents/add.html
@@ -1,6 +1,6 @@
 {% extends "wagtailadmin/base.html" %}
 {% load i18n %}
-{% load wagtailimages_tags %}
+{% load wagtailimages_tags wagtailadmin_tags %}
 {% block titletag %}{% trans "Add a document" %}{% endblock %}
 
 {% block extra_js %}
@@ -40,7 +40,7 @@
                     {% endif %}
                 {% endfor %}
                 <li>
-                    <button type="submit" class="button button-longrunning" data-clicked-text="{% trans 'Uploading…' %}"><span class="icon icon-spinner"></span><em>{% trans 'Upload' %}</em></button>
+                    <button type="submit" class="button button-longrunning" data-clicked-text="{% trans 'Uploading…' %}">{% icon name="spinner" %}<em>{% trans 'Upload' %}</em></button>
                 </li>
             </ul>
         </form>

--- a/wagtail/documents/templates/wagtaildocs/multiple/add.html
+++ b/wagtail/documents/templates/wagtaildocs/multiple/add.html
@@ -22,7 +22,7 @@
 
             <form action="{% url 'wagtaildocs:add_multiple' %}" method="POST" enctype="multipart/form-data">
                 <div class="replace-file-input">
-                    <button class="button bicolor icon icon-plus">{% trans "Or choose from your computer" %}</button>
+                    <button class="button bicolor button--icon">{% icon name="plus" wrapped=1 %}{% trans "Or choose from your computer" %}</button>
                     <input id="fileupload" type="file" name="files[]" data-url="{% url 'wagtaildocs:add_multiple' %}" multiple>
                 </div>
                 {% csrf_token %}

--- a/wagtail/embeds/templates/wagtailembeds/chooser/chooser.html
+++ b/wagtail/embeds/templates/wagtailembeds/chooser/chooser.html
@@ -1,4 +1,4 @@
-{% load wagtailimages_tags %}
+{% load wagtailimages_tags wagtailadmin_tags %}
 {% load i18n %}
 {% trans "Insert embed" as ins_emb_str %}
 {% include "wagtailadmin/shared/header.html" with title=ins_emb_str merged=1 %}
@@ -11,7 +11,7 @@
                 {% for field in form %}
                     {% include "wagtailadmin/shared/field_as_li.html" with field=field %}
                 {% endfor %}
-                <li><button type="submit" class="button  button-longrunning"><span class="icon icon-spinner"></span><em>{% trans 'Insert' %}</em></button></li>
+                <li><button type="submit" class="button  button-longrunning">{% icon name="spinner" %}<em>{% trans 'Insert' %}</em></button></li>
             </ul>
         </form>
     </section>

--- a/wagtail/images/templates/wagtailimages/chooser/chooser.html
+++ b/wagtail/images/templates/wagtailimages/chooser/chooser.html
@@ -1,4 +1,4 @@
-{% load wagtailimages_tags %}
+{% load wagtailimages_tags wagtailadmin_tags %}
 {% load i18n %}
 {% trans "Choose an image" as choose_str %}
 {% include "wagtailadmin/shared/header.html" with title=choose_str merged=1 tabbed=1 icon="image" %}
@@ -51,7 +51,7 @@
                         {% endif %}
                     {% endfor %}
                     <li>
-                        <button type="submit" class="button button-longrunning" data-clicked-text="{% trans 'Uploading…' %}"><span class="icon icon-spinner"></span><em>{% trans 'Upload' %}</em></button>
+                        <button type="submit" class="button button-longrunning" data-clicked-text="{% trans 'Uploading…' %}">{% icon name="spinner" %}<em>{% trans 'Upload' %}</em></button>
                     </li>
                 </ul>
             </form>

--- a/wagtail/images/templates/wagtailimages/images/edit.html
+++ b/wagtail/images/templates/wagtailimages/images/edit.html
@@ -74,7 +74,7 @@
                 </div>
 
                 {% if url_generator_enabled %}
-                    <a href="{% url 'wagtailimages:url_generator' image.id %}" class="button bicolor icon icon-link">{% trans "URL Generator" %}</a>
+                    <a href="{% url 'wagtailimages:url_generator' image.id %}" class="button bicolor button--icon">{% icon name="link" wrapped=1 %}{% trans "URL Generator" %}</a>
                     <hr />
                 {% endif %}
 

--- a/wagtail/images/templates/wagtailimages/images/index.html
+++ b/wagtail/images/templates/wagtailimages/images/index.html
@@ -47,13 +47,13 @@
                     <legend>{% trans 'Popular Tags:' %}</legend>
                       {% for tag in popular_tags %}
                           {% if tag.name != current_tag %}
-                              <a class="button button-small button-secondary bicolor icon icon-tag" href="{% url 'wagtailimages:index' %}{% querystring tag=tag.name %}">{{ tag.name }}</a>
+                              <a class="button button-small button-secondary bicolor button--icon" href="{% url 'wagtailimages:index' %}{% querystring tag=tag.name %}">{% icon name="tag" wrapped=1 %}{{ tag.name }}</a>
                           {% else %}
-                              <a class="button button-small bicolor icon icon-tag" href="{% url 'wagtailimages:index' %}{% querystring tag=tag.name %}">{{ tag.name }}</a>
+                              <a class="button button-small bicolor button--icon" href="{% url 'wagtailimages:index' %}{% querystring tag=tag.name %}">{% icon name="tag" wrapped=1 %}{{ tag.name }}</a>
                           {% endif %}
                       {% endfor %}
                       {% if current_tag %}
-                          <a class="button button-small bicolor button-secondary icon icon-cross" href="{% url 'wagtailimages:index' %}{% querystring tag='' %}">{% trans 'Clear choice' %}</a>
+                          <a class="button button-small bicolor button-secondary button--icon" href="{% url 'wagtailimages:index' %}{% querystring tag='' %}">{% icon name="cross" wrapped=1 %}{% trans 'Clear choice' %}</a>
                       {% endif %}
                     </fieldset>
                 </li>

--- a/wagtail/images/templates/wagtailimages/multiple/add.html
+++ b/wagtail/images/templates/wagtailimages/multiple/add.html
@@ -22,7 +22,7 @@
 
             <form action="{% url 'wagtailimages:add_multiple' %}" method="POST" enctype="multipart/form-data">
                 <div class="replace-file-input">
-                    <button class="button bicolor icon icon-plus">{% trans "Or choose from your computer" %}</button>
+                    <button class="button bicolor button--icon">{% icon name="plus" wrapped=1 %}{% trans "Or choose from your computer" %}</button>
                     <input id="fileupload" type="file" name="files[]" data-url="{% url 'wagtailimages:add_multiple' %}" multiple>
                 </div>
                 {% csrf_token %}

--- a/wagtail/snippets/templates/wagtailsnippets/snippets/create.html
+++ b/wagtail/snippets/templates/wagtailsnippets/snippets/create.html
@@ -1,5 +1,5 @@
 {% extends "wagtailadmin/base.html" %}
-{% load i18n %}
+{% load i18n wagtailadmin_tags %}
 {% block titletag %}{% blocktrans with snippet_type_name=model_opts.verbose_name %}New  {{ snippet_type_name }}{% endblocktrans %}{% endblock %}
 {% block content %}
     {% trans "New" as new_str %}
@@ -14,7 +14,7 @@
                 <li class="actions">
                     <div class="dropdown dropup dropdown-button match-width">
                         <button type="submit" class="button action-save button-longrunning" data-clicked-text="{% trans 'Saving…' %}">
-                            <span class="icon icon-spinner"></span><em>{% trans 'Save' %}</em>
+                            {% icon name="spinner" %}<em>{% trans 'Save' %}</em>
                         </button>
                     </div>
                 </li>

--- a/wagtail/snippets/templates/wagtailsnippets/snippets/edit.html
+++ b/wagtail/snippets/templates/wagtailsnippets/snippets/edit.html
@@ -18,7 +18,7 @@
                         <li class="actions">
                             <div class="dropdown dropup dropdown-button match-width">
                                 <button type="submit" class="button action-save button-longrunning" data-clicked-text="{% trans 'Saving…' %}">
-                                    <span class="icon icon-spinner"></span><em>{% trans 'Save' %}</em>
+                                    {% icon name="spinner" %}<em>{% trans 'Save' %}</em>
                                 </button>
                                 <div class="dropdown-toggle">{% icon name="arrow-up" %}</div>
                                 <ul>

--- a/wagtail/snippets/templates/wagtailsnippets/snippets/edit.html
+++ b/wagtail/snippets/templates/wagtailsnippets/snippets/edit.html
@@ -20,7 +20,7 @@
                                 <button type="submit" class="button action-save button-longrunning" data-clicked-text="{% trans 'Saving…' %}">
                                     <span class="icon icon-spinner"></span><em>{% trans 'Save' %}</em>
                                 </button>
-                                <div class="dropdown-toggle icon icon-arrow-up"></div>
+                                <div class="dropdown-toggle">{% icon name="arrow-up" %}</div>
                                 <ul>
                                     <li><a href="{% url 'wagtailsnippets:delete' model_opts.app_label model_opts.model_name instance.pk|admin_urlquote %}" class="shortcut">{% trans "Delete" %}</a></li>
                                 </ul>

--- a/wagtail/snippets/templates/wagtailsnippets/snippets/type_index.html
+++ b/wagtail/snippets/templates/wagtailsnippets/snippets/type_index.html
@@ -37,10 +37,15 @@
             </div>
             <div class="right col6">
                 {% if can_delete_snippets %}
-                    <a class="button bicolor icon icon-bin serious delete-button visuallyhidden" data-url="{% url 'wagtailsnippets:delete-multiple' model_opts.app_label model_opts.model_name %}?">{% blocktrans with snippet_type_name=model_opts.verbose_name_plural %}Delete {{ snippet_type_name }}{% endblocktrans %}</a>
+                    <a class="button bicolor button--icon serious delete-button visuallyhidden" data-url="{% url 'wagtailsnippets:delete-multiple' model_opts.app_label model_opts.model_name %}?">
+                        {% icon name="bin" wrapped=1 %}
+                        {% blocktrans with snippet_type_name=model_opts.verbose_name_plural %}Delete {{ snippet_type_name }}{% endblocktrans %}
+                    </a>
                 {% endif %}
                 {% if can_add_snippet %}
-                    <a href="{% url 'wagtailsnippets:add' model_opts.app_label model_opts.model_name %}" class="button bicolor icon icon-plus">{% blocktrans with snippet_type_name=model_opts.verbose_name %}Add {{ snippet_type_name }}{% endblocktrans %}</a>
+                    <a href="{% url 'wagtailsnippets:add' model_opts.app_label model_opts.model_name %}" class="button bicolor button--icon">
+                        {% icon name="plus" wrapped=1 %}
+                        {% blocktrans with snippet_type_name=model_opts.verbose_name %}Add {{ snippet_type_name }}{% endblocktrans %}</a>
                     {# TODO: figure out a way of saying "Add a/an [foo]" #}
                 {% endif %}
             </div>

--- a/wagtail/users/templates/wagtailusers/groups/edit.html
+++ b/wagtail/users/templates/wagtailusers/groups/edit.html
@@ -15,7 +15,7 @@
     {% trans "Editing" as editing_str %}
     {% trans "View users of this group" as users_str %}
     {% url 'wagtailusers_groups:users' group.id as group_users_url %}
-    {% include "wagtailadmin/shared/header.html" with title=editing_str action_icon="icon-user" action_url=group_users_url action_text=users_str subtitle=group.name icon="group" %}
+    {% include "wagtailadmin/shared/header.html" with title=editing_str action_icon="user" action_url=group_users_url action_text=users_str subtitle=group.name icon="group" %}
 
     <div class="nice-padding">
         <form action="{% url 'wagtailusers_groups:edit' group.id %}" method="POST" novalidate>

--- a/wagtail/users/templates/wagtailusers/groups/includes/page_permissions_formset.html
+++ b/wagtail/users/templates/wagtailusers/groups/includes/page_permissions_formset.html
@@ -51,6 +51,6 @@
 </script>
 
 <p class="add">
-    <a class="button bicolor icon icon-plus" id="id_{{ formset.prefix }}-ADD" value="Add">{% trans "Add a page permission" %}</a>
+    <a class="button bicolor button--icon" id="id_{{ formset.prefix }}-ADD" value="Add">{% icon name="plus" wrapped=1 %}{% trans "Add a page permission" %}</a>
 </p>
 


### PR DESCRIPTION
This builds on #6125 and updates the icon usage in buttons to SVG for #6107.

Font icon styles have been marked as such and will old markup continue to work until these styles are removed.

* Do the tests still pass? (https://docs.wagtail.io/en/latest/contributing/developing.html#testing) ✅
* Does the code comply with the style guide? (Run `make lint` from the Wagtail root) ✅
* For Python changes: Have you added tests to cover the new/fixed behaviour? ✅
* For front-end changes: Did you test on all of Wagtail’s supported browsers? **Please list the exact versions you tested**.
* For new features: Has the documentation been updated accordingly? N/A
