### PR TITLE
Sanitise window.location.hash when passing to jquery for tab handling

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -51,6 +51,7 @@ Changelog
  * Use underscores for form builder field names to allow use as template variables (Ashia Zawaduk, LB (Ben Johnston))
  * Deprecate use of unidecode within form builder field names (Michael van Tellingen, LB (Ben Johnston))
  * Improve error feedback when editing a page with a missing model class (Andy Babic)
+ * Change Wagtail tabs implementation to only allow slug-formatted tab identifiers, reducing false positives from security audits (Matt Westcott)
  * Fix: Support IPv6 domain (Alex Gleason, Coen van der Kamp)
  * Fix: Ensure link to add a new user works when no users are visible in the users list (LB (Ben Johnston))
  * Fix: `AbstractEmailForm` saved submission fields are now aligned with the email content fields, `form.cleaned_data` will be used instead of `form.fields` (Haydn Greatnews)

--- a/docs/releases/2.10.rst
+++ b/docs/releases/2.10.rst
@@ -69,6 +69,7 @@ Other features
  * Use underscores for form builder field names to allow use as template variables (Ashia Zawaduk, LB (Ben Johnston))
  * Deprecate use of unidecode within form builder field names (Michael van Tellingen, LB (Ben Johnston))
  * Improve error feedback when editing a page with a missing model class (Andy Babic)
+ * Change Wagtail tabs implementation to only allow slug-formatted tab identifiers, reducing false positives from security audits (Matt Westcott)
 
 
 Bug fixes

--- a/wagtail/admin/static_src/wagtailadmin/js/core.js
+++ b/wagtail/admin/static_src/wagtailadmin/js/core.js
@@ -177,7 +177,8 @@ $(function() {
 
     /* tabs */
     if (window.location.hash) {
-      $('a[href="' + window.location.hash + '"]').tab('show');
+        var cleanedHash = window.location.hash.replace(/[^\w\-\#]/g, '');
+        $('a[href="' + cleanedHash + '"]').tab('show');
     }
 
     $(document).on('click', '.tab-nav a', function(e) {


### PR DESCRIPTION
An automated vulnerability scanner flagged up an untrusted string (the hash portion of the URL) being passed as a jQuery selector. In versions of jQuery prior to 1.9.0, this was a potential vector for XSS attacks:

https://www.cvedetails.com/cve/CVE-2012-6708/
https://stackoverflow.com/questions/11169894/can-malicious-javascript-code-be-injected-through

There is no indication that this is exploitable on the version of jQuery shipped with Wagtail (3.2.1), but as an extra level of protection (and to avoid further false positives from vulnerability scanners), we should filter the passed ID to only allow alphanumerics, dashes and underscores. This is unlikely to affect legitimate tab IDs - for example, the TabbedInterface edit handler passes labels through `cautious_slugify`.
