### PR TITLE
WIP: Workflow management UI changes

### DIFF
--- a/client/scss/components/_workflow-tasks.scss
+++ b/client/scss/components/_workflow-tasks.scss
@@ -1,0 +1,42 @@
+.workflow-tasks {
+    $task-width: 117px;
+    $task-height: 56px;
+
+    list-style-type: none;
+
+    &__task {
+        display: inline-block;
+        background-color: #f8ffff;
+        border: 2px solid #7ebebe;
+        border-radius: 5px;
+        color: #007d7e;
+        box-sizing: border-box;
+        width: $task-width;
+        height: $task-height;
+        margin: 7px;
+        padding-left: 9px;
+        padding-right: 9px;
+    }
+
+    &__step {
+        font-size: 10px;
+        text-transform: uppercase;
+        margin-top: 3px;
+    }
+
+    &__name {
+        font-size: 16px;
+        font-weight: bold;
+        margin: 0;
+
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+    }
+
+    &__extra-tasks {
+        display: inline-block;
+        height: $task-height;
+        vertical-align: middle;
+    }
+}

--- a/client/scss/styles.scss
+++ b/client/scss/styles.scss
@@ -129,6 +129,7 @@ These are classes for components.
 @import 'components/privacy-indicator';
 @import 'components/status-tag';
 @import 'components/button-select';
+@import 'components/workflow-tasks';
 
 
 /* OVERRIDES

--- a/wagtail/admin/edit_handlers.py
+++ b/wagtail/admin/edit_handlers.py
@@ -14,7 +14,7 @@ from taggit.managers import TaggableManager
 
 from wagtail.admin import compare, widgets
 from wagtail.core.fields import RichTextField
-from wagtail.core.models import Page, Workflow
+from wagtail.core.models import Page
 from wagtail.core.utils import camelcase_to_underscore, resolve_model_string
 from wagtail.utils.decorators import cached_classmethod
 
@@ -785,29 +785,6 @@ Page.settings_panels = [
 ]
 
 Page.base_form_class = WagtailAdminPageForm
-
-# Similarly, set up wagtailcore.Workflow to have edit handlers
-Workflow.panels = [
-    FieldPanel("name", heading=gettext_lazy("Give your workflow a name")),
-    InlinePanel("workflow_tasks", heading=gettext_lazy("Add tasks to your workflow")),
-]
-
-Workflow.base_form_class = WagtailAdminModelForm
-
-
-@cached_classmethod
-def get_simple_edit_handler(cls):
-    """
-    Get the EditHandler to use in the Wagtail admin when editing this class, constructing an ObjectList from the contents of cls.panels.
-    """
-    if hasattr(cls, 'edit_handler'):
-        edit_handler = cls.edit_handler
-    else:
-        edit_handler = ObjectList(cls.panels, base_form_class=cls.base_form_class)
-    return edit_handler.bind_to(model=cls)
-
-
-Workflow.get_edit_handler = get_simple_edit_handler
 
 
 @cached_classmethod

--- a/wagtail/admin/edit_handlers.py
+++ b/wagtail/admin/edit_handlers.py
@@ -795,26 +795,6 @@ Workflow.panels = [
 Workflow.base_form_class = WagtailAdminModelForm
 
 
-class ExcludeFieldsOnEditMixin:
-    """A mixin for edit handlers, which disables fields listed in a model's 'exclude_on_edit' attribute when binding
-    to an existing instance - editing rather than creating"""
-
-    def bind_to(self, *args, **kwargs):
-        new = super(ExcludeFieldsOnEditMixin, self).bind_to(*args, **kwargs)
-        # when binding to an existing instance with a pk - ie editing - set those fields in the form to disabled
-        if new.form and new.instance and new.instance.pk is not None and hasattr(new.model, 'exclude_on_edit'):
-            for field in new.model.exclude_on_edit:
-                try:
-                    new.form.fields[field].disabled = True
-                except KeyError:
-                    continue
-        return new
-
-
-class VaryOnEditObjectList(ExcludeFieldsOnEditMixin, ObjectList):
-    pass
-
-
 @cached_classmethod
 def get_simple_edit_handler(cls):
     """
@@ -823,7 +803,7 @@ def get_simple_edit_handler(cls):
     if hasattr(cls, 'edit_handler'):
         edit_handler = cls.edit_handler
     else:
-        edit_handler = VaryOnEditObjectList(cls.panels, base_form_class=cls.base_form_class)
+        edit_handler = ObjectList(cls.panels, base_form_class=cls.base_form_class)
     return edit_handler.bind_to(model=cls)
 
 

--- a/wagtail/admin/edit_handlers.py
+++ b/wagtail/admin/edit_handlers.py
@@ -14,7 +14,7 @@ from taggit.managers import TaggableManager
 
 from wagtail.admin import compare, widgets
 from wagtail.core.fields import RichTextField
-from wagtail.core.models import GroupApprovalTask, Page, Task, Workflow
+from wagtail.core.models import Page, Workflow
 from wagtail.core.utils import camelcase_to_underscore, resolve_model_string
 from wagtail.utils.decorators import cached_classmethod
 
@@ -791,16 +791,8 @@ Workflow.panels = [
     FieldPanel("name", heading=gettext_lazy("Give your workflow a name")),
     InlinePanel("workflow_tasks", heading=gettext_lazy("Add tasks to your workflow")),
 ]
-Task.panels = [
-    FieldPanel("name", heading=gettext_lazy("Give your task a name")),
-]
-GroupApprovalTask.panels = Task.panels + [FieldPanel('groups', heading=gettext_lazy("Choose approval groups"))]
-# do not allow editing of group post creation - this could lead to confusing history if a group is changed after tasks
-# are started/completed
-GroupApprovalTask.exclude_on_edit = {'groups'}
 
 Workflow.base_form_class = WagtailAdminModelForm
-Task.base_form_class = WagtailAdminModelForm
 
 
 class ExcludeFieldsOnEditMixin:
@@ -836,7 +828,6 @@ def get_simple_edit_handler(cls):
 
 
 Workflow.get_edit_handler = get_simple_edit_handler
-Task.get_edit_handler = get_simple_edit_handler
 
 
 @cached_classmethod

--- a/wagtail/admin/forms/workflows.py
+++ b/wagtail/admin/forms/workflows.py
@@ -191,7 +191,7 @@ def get_workflow_edit_handler():
     # this decision later if we decide to allow custom fields on Workflows.
 
     panels = [
-        FieldPanel("name", heading=_("Give your workflow a name")),
+        FieldPanel("name", heading=_("Give your workflow a name"), classname="full title"),
         InlinePanel("workflow_tasks", [
             FieldPanel('task', widget=AdminTaskChooser(show_clear_link=False)),
         ], heading=_("Add tasks to your workflow")),

--- a/wagtail/admin/forms/workflows.py
+++ b/wagtail/admin/forms/workflows.py
@@ -5,6 +5,9 @@ from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_lazy as __
 
 from wagtail.admin import widgets
+from wagtail.admin.edit_handlers import FieldPanel, InlinePanel, ObjectList
+from wagtail.admin.forms import WagtailAdminModelForm
+from wagtail.admin.widgets.workflows import AdminTaskChooser
 from wagtail.core.models import Page, Task, Workflow, WorkflowPage
 from wagtail.core.utils import get_model_string
 
@@ -176,3 +179,22 @@ def get_task_form_class(task_model, for_edit=False):
             form_class.base_fields[field_name].disabled = True
 
     return form_class
+
+
+def get_workflow_edit_handler():
+    """
+    Returns an edit handler which provides the "name" and "tasks" fields for workflow.
+    """
+    # Note. It's a bit of a hack that we use edit handlers here. Ideally, it should be
+    # made easier to reuse the inline panel templates for any formset.
+    # Since this form is internal, we're OK with this for now. We might want to revisit
+    # this decision later if we decide to allow custom fields on Workflows.
+
+    panels = [
+        FieldPanel("name", heading=_("Give your workflow a name")),
+        InlinePanel("workflow_tasks", [
+            FieldPanel('task', widget=AdminTaskChooser(show_clear_link=False)),
+        ], heading=_("Add tasks to your workflow")),
+    ]
+    edit_handler = ObjectList(panels, base_form_class=WagtailAdminModelForm)
+    return edit_handler.bind_to(model=Workflow)

--- a/wagtail/admin/templates/wagtailadmin/workflows/create_task.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/create_task.html
@@ -25,7 +25,15 @@
     <form action="{{ view.get_add_url }}" enctype="multipart/form-data" method="POST" novalidate>
         {% csrf_token %}
 
-        {% block form %}{{ edit_handler.render_form_content }}{% endblock %}
+        <ul class="fields nice-padding">
+            {% for field in form %}
+                {% if not field.is_hidden %}
+                    {% include "wagtailadmin/shared/field_as_li.html" %}
+                {% else %}
+                    {{ field }}
+                {% endif %}
+            {% endfor %}
+        </ul>
 
         {% block footer %}
             <footer role="contentinfo">

--- a/wagtail/admin/templates/wagtailadmin/workflows/edit.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/edit.html
@@ -25,7 +25,6 @@
 
     {% include "wagtailadmin/shared/header.html" with title=view.page_title icon=view.header_icon merged=1 %}
 
-
     <form action="{% block form_action %}{{ view.edit_url }}{% endblock %}"{% if is_multipart %} enctype="multipart/form-data"{% endif %} method="POST" novalidate>
         {% csrf_token %}
 
@@ -54,17 +53,21 @@
             </li>
         </ul>
 
-        <div class="object">
-            <ul class="object-layout">
-                <li class="object-layout_big-part">
-                    <p class="actions">
-                        <button type="submit" class="button action-save button-longrunning" data-clicked-text="{% trans 'Saving…' %}">
-                            <span class="icon icon-spinner"></span><em>{% trans 'Save' %}</em>
-                        </button>
-                    </p>
-                </li>
-            </ul>
-        </div>
+        {% block footer %}
+            <footer role="contentinfo">
+                <ul>
+                    <li class="actions">
+                        {% block form_actions %}
+                            <div class="dropdown dropup dropdown-button match-width">
+                                <button type="submit" class="button action-save button-longrunning" data-clicked-text="{% trans 'Saving…' %}">
+                                    <span class="icon icon-spinner"></span><em>{% trans 'Save' %}</em>
+                                </button>
+                            </div>
+                        {% endblock %}
+                    </li>
+                </ul>
+            </footer>
+        {% endblock %}
     </form>
 
     {% if can_enable or can_disable %}

--- a/wagtail/admin/templates/wagtailadmin/workflows/edit_task.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/edit_task.html
@@ -25,7 +25,15 @@
     <form action="{{ view.edit_url }}" enctype="multipart/form-data" method="POST" novalidate>
         {% csrf_token %}
 
-        {% block form %}{{ edit_handler.render_form_content }}{% endblock %}
+        <ul class="fields nice-padding">
+            {% for field in form %}
+                {% if not field.is_hidden %}
+                    {% include "wagtailadmin/shared/field_as_li.html" %}
+                {% else %}
+                    {{ field }}
+                {% endif %}
+            {% endfor %}
+        </ul>
 
         {% block footer %}
             <footer role="contentinfo">

--- a/wagtail/admin/templates/wagtailadmin/workflows/index.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/index.html
@@ -13,7 +13,6 @@
             <div class="right">
                 <div class="addbutton">
                     <a href="{% url view.add_url_name %}" class="button bicolor icon icon-plus">{{ view.add_item_label }}</a>
-                    <a href="{% url 'wagtailadmin_workflows:task_index' %}" class="button">{% trans 'Edit workflow tasks' %}</a>
                 </div>
             </div>
         </div>
@@ -69,6 +68,5 @@
         {% else %}
             <a href="?show_disabled" class="button secondary">{% trans "Show disabled workflows" %}</a>
         {% endif %}
-        <a href="{% url 'wagtailadmin_workflows:task_index' %}" class="button">{% trans "Edit workflow tasks" %}</a>
     </div>
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/workflows/index.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/index.html
@@ -37,7 +37,7 @@
                             {% trans "Name" %}
                         </th>
                         <th>
-                            {% trans "Linked pages" %}
+                            {% trans "Used by" %}
                         </th>
                         <th>
                             {% trans "Tasks" %}
@@ -57,7 +57,13 @@
                             </td>
                             <td class="title">
                                 <div class="title-wrapper">
-                                    {{ workflow.workflow_pages.count }}
+                                    <a href="{% url 'wagtailadmin_workflows:usage' workflow.pk %}">
+                                        {% blocktrans count counter=workflow.all_pages.count %}
+                                            1 page
+                                        {% plural %}
+                                            {{ counter }} pages
+                                        {% endblocktrans %}
+                                    </a>
                                 </div>
                             </td>
                             <td>

--- a/wagtail/admin/templates/wagtailadmin/workflows/index.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/index.html
@@ -17,44 +17,70 @@
             </div>
         </div>
     </header>
+
     <div class="nice-padding">
         {% if workflows %}
-            <div id="sites-list">
-                <table class="listing">
-                    <thead>
-                        <tr>
-                            <th>
-                                {% trans "Name" %}
-                            </th>
-                            <th>
-                                {% trans "Tasks" %}
-                            </th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {% for workflow in workflows %}
-                            <tr>
-                                <td class="title">
-                                    <div class="title-wrapper">
-                                        <a href="{% url view.edit_url_name workflow.pk %}">{{ workflow }}</a>
-                                        {% if not workflow.active %}
-                                            <span class="status-tag">Disabled</span>
-                                        {% endif %}
-                                    </div>
-                                </td>
-                                <td class="tasks">
-                                    <div class="task-wrapper">
-                                        {% for task in workflow.tasks %}
-                                        <button class="status-tag primary" >{{ task }}</button>
-                                        {% endfor %}
-                                    </div>
-                                </td>
-                            </tr>
-                        {% endfor %}
-                    </tbody>
-                </table>
+            <label>
+                {% if showing_disabled %}
+                    <input type="checkbox" onclick="javascript:window.location.href='.';" checked>
+                {% else %}
+                    <input type="checkbox" onclick="javascript:window.location.href='?show_disabled';">
+                {% endif %}
 
-            </div>
+                {% trans "Show disabled workflows" %}
+            </label>
+
+            <table class="listing">
+                <thead>
+                    <tr>
+                        <th>
+                            {% trans "Name" %}
+                        </th>
+                        <th>
+                            {% trans "Linked pages" %}
+                        </th>
+                        <th>
+                            {% trans "Tasks" %}
+                        </th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for workflow in workflows %}
+                        <tr>
+                            <td class="title">
+                                <div class="title-wrapper">
+                                    <a href="{% url view.edit_url_name workflow.pk %}">{{ workflow }}</a>
+                                    {% if not workflow.active %}
+                                        <span class="status-tag">Disabled</span>
+                                    {% endif %}
+                                </div>
+                            </td>
+                            <td class="title">
+                                <div class="title-wrapper">
+                                    {{ workflow.workflow_pages.count }}
+                                </div>
+                            </td>
+                            <td>
+                                <ul class="workflow-tasks">
+                                    {% for task in workflow.tasks|slice:":5" %}
+                                        <a href="{% url 'wagtailadmin_workflows:edit_task' task.pk %}">
+                                            <li class="workflow-tasks__task" data-wagtail-tooltip="{% blocktrans with forloop.counter as step_number %}Step {{ step_number }}{% endblocktrans %}: {{ task.name }}">
+                                                <div class="workflow-tasks__step">{% blocktrans with forloop.counter as step_number %}Step {{ step_number }}{% endblocktrans %}</div>
+                                                <h4 class="workflow-tasks__name">{{ task.name }}</h4>
+                                            </li>
+                                        </a>
+                                    {% endfor %}
+                                    {% if workflow.tasks.count > 5 %}
+                                        <li class="workflow-tasks__extra-tasks">
+                                            {% blocktrans count counter=workflow.tasks.count|add:-5 %}+{{ counter }} more{% plural %}+{{ counter }} more{% endblocktrans %}
+                                        </li>
+                                    {% endif %}
+                                </ul>
+                            </td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
         {% else %}
             {% url view.add_url_name as add_url %}
             {% if showing_disabled %}
@@ -63,10 +89,28 @@
                 <p>{% blocktrans %}There are no enabled workflows. Why not <a href="{{ add_url }}">add one</a>?{% endblocktrans %}</p>
             {% endif %}
         {% endif %}
-        {% if showing_disabled %}
-            <a href="." class="button secondary">{% trans "Hide disabled workflows" %}</a>
-        {% else %}
-            <a href="?show_disabled" class="button secondary">{% trans "Show disabled workflows" %}</a>
-        {% endif %}
     </div>
+{% endblock %}
+
+{% block extra_css %}
+    {{ block.super }}
+    {% include "wagtailadmin/pages/_editor_css.html" %}
+{% endblock %}
+
+{% block extra_js %}
+    {{ block.super }}
+    {% include "wagtailadmin/pages/_editor_js.html" %}
+
+    <script type="text/javascript">
+        $(function() {
+            $('[data-wagtail-tooltip]').tooltip({
+                animation: false,
+                title: function() {
+                    return $(this).attr('data-wagtail-tooltip');
+                },
+                trigger: 'hover',
+                placement: 'bottom',
+            });
+        });
+    </script>
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/workflows/task_chooser/includes/create_form.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/task_chooser/includes/create_form.html
@@ -8,7 +8,7 @@
 
     {{ form }}
 
-    <div>
-        <button type="submit" class="button">{% trans "Create" %}</button>
+    <div style="clear: both;">
+        <button type="submit" class="button action-save button-longrunning" data-clicked-text="{% trans 'Creating…' %}">{% trans "Create" %}</button>
     </div>
 </form>

--- a/wagtail/admin/templates/wagtailadmin/workflows/task_index.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/task_index.html
@@ -13,7 +13,6 @@
             <div class="right">
                 <div class="addbutton">
                     <a href="{% url view.add_url_name %}" class="button bicolor icon icon-plus">{{ view.add_item_label }}</a>
-                    <a href="{% url 'wagtailadmin_workflows:index' %}" class="button">Workflows</a>
                 </div>
             </div>
         </div>

--- a/wagtail/admin/templates/wagtailadmin/workflows/task_index.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/task_index.html
@@ -19,38 +19,35 @@
     </header>
     <div class="nice-padding">
         {% if tasks %}
-            <div id="sites-list">
-                <table class="listing">
-                    <thead>
+            <table class="listing">
+                <thead>
+                    <tr>
+                        <th>
+                            {% trans "Name" %}
+                        </th>
+                        <th>
+                            {% trans "Type" %}
+                        </th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for task in tasks %}
                         <tr>
-                            <th>
-                                {% trans "Name" %}
-                            </th>
-                            <th>
-                                {% trans "Type" %}
-                            </th>
+                            <td class="title">
+                                <div class="title-wrapper">
+                                    <a href="{% url view.edit_url_name task.pk %}">{{ task }}</a>
+                                    {% if not task.active %}
+                                        <span class="status-tag">Disabled</span>
+                                    {% endif %}
+                                </div>
+                            </td>
+                            <td>
+                                {{ task.specific.get_verbose_name }}
+                            </td>
                         </tr>
-                    </thead>
-                    <tbody>
-                        {% for task in tasks %}
-                            <tr>
-                                <td class="title">
-                                    <div class="title-wrapper">
-                                        <a href="{% url view.edit_url_name task.pk %}">{{ task }}</a>
-                                        {% if not task.active %}
-                                            <span class="status-tag">Disabled</span>
-                                        {% endif %}
-                                    </div>
-                                </td>
-                                <td>
-                                    {{ task.specific.get_verbose_name }}
-                                </td>
-                            </tr>
-                        {% endfor %}
-                    </tbody>
-                </table>
-
-            </div>
+                    {% endfor %}
+                </tbody>
+            </table>
         {% else %}
             {% url view.add_url_name as add_url %}
             {% if showing_disabled %}

--- a/wagtail/admin/templates/wagtailadmin/workflows/usage.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/usage.html
@@ -1,0 +1,45 @@
+{% extends "wagtailadmin/base.html" %}
+{% load i18n %}
+{% block titletag %}{% blocktrans with name=workflow.name %}Usage of {{ name }}{% endblocktrans %}{% endblock %}
+{% block content %}
+    {% trans "Usage of" as usage_str %}
+    {% include "wagtailadmin/shared/header.html" with title=usage_str subtitle=workflow.name %}
+
+    <div class="nice-padding">
+        <table class="listing">
+            <col />
+            <col width="30%"/>
+            <col width="15%"/>
+            <col width="15%"/>
+            <thead>
+                <tr>
+                    <th class="title">{% trans "Title" %}</th>
+                    <th>{% trans "Parent" %}</th>
+                    <th>{% trans "Type" %}</th>
+                    <th>{% trans "Status" %}</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for page in used_by %}
+                    <tr>
+                        <td class="title" valign="top">
+                            <div class="title-wrapper"><a href="{% url 'wagtailadmin_pages:edit' page.id %}" title="{% trans 'Edit this page' %}">{{ page.title }}</a></div>
+                        </td>
+                        <td>
+                            {% if page.get_parent %}
+                                <a href="{% url 'wagtailadmin_explore' page.get_parent.id %}">{{ page.get_parent.title }}</a>
+                            {% endif %}
+                        </td>
+                        <td>
+                            {{ page.content_type.model_class.get_verbose_name }}
+                        </td>
+                        <td>
+                            {% include "wagtailadmin/shared/page_status_tag.html" with page=page %}
+                        </td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+    {% include "wagtailadmin/shared/pagination_nav.html" with items=used_by %}
+{% endblock %}

--- a/wagtail/admin/urls/__init__.py
+++ b/wagtail/admin/urls/__init__.py
@@ -46,7 +46,7 @@ urlpatterns = [
     url(r'^tag-autocomplete/(\w+)/(\w+)/$', tags.autocomplete, name='wagtailadmin_tag_model_autocomplete'),
 
     url(r'^collections/', include(wagtailadmin_collections_urls, namespace='wagtailadmin_collections')),
-    url(r'^workflows/', include(wagtailadmin_workflows_urls, namespace='wagtailadmin_workflows')),
+    url(r'^workflow/', include(wagtailadmin_workflows_urls, namespace='wagtailadmin_workflows')),
 
     url(r'^reports/', include(wagtailadmin_reports_urls, namespace='wagtailadmin_reports')),
 

--- a/wagtail/admin/urls/workflows.py
+++ b/wagtail/admin/urls/workflows.py
@@ -5,13 +5,13 @@ from wagtail.admin.views import workflows
 
 app_name = 'wagtailadmin_workflows'
 urlpatterns = [
-    path('', workflows.Index.as_view(), name='index'),
-    path('add/', workflows.Create.as_view(), name='add'),
-    path('enable/<int:pk>/', workflows.enable_workflow, name='enable'),
-    path('disable/<int:pk>/', workflows.Disable.as_view(), name='disable'),
-    path('edit/<int:pk>/', workflows.Edit.as_view(), name='edit'),
-    path('remove/<int:page_pk>/', workflows.remove_workflow, name='remove'),
-    path('remove/<int:page_pk>/<int:workflow_pk>/', workflows.remove_workflow, name='remove'),
+    path('workflows/', workflows.Index.as_view(), name='index'),
+    path('workflows/add/', workflows.Create.as_view(), name='add'),
+    path('workflows/enable/<int:pk>/', workflows.enable_workflow, name='enable'),
+    path('workflows/disable/<int:pk>/', workflows.Disable.as_view(), name='disable'),
+    path('workflows/edit/<int:pk>/', workflows.Edit.as_view(), name='edit'),
+    path('workflows/remove/<int:page_pk>/', workflows.remove_workflow, name='remove'),
+    path('workflows/remove/<int:page_pk>/<int:workflow_pk>/', workflows.remove_workflow, name='remove'),
     path('tasks/add/<str:app_label>/<str:model_name>/', workflows.CreateTask.as_view(), name='add_task'),
     path('tasks/select_type/', workflows.select_task_type, name='select_task_type'),
     path('tasks/index/', workflows.TaskIndex.as_view(), name='task_index'),

--- a/wagtail/admin/urls/workflows.py
+++ b/wagtail/admin/urls/workflows.py
@@ -10,6 +10,7 @@ urlpatterns = [
     path('workflows/enable/<int:pk>/', workflows.enable_workflow, name='enable'),
     path('workflows/disable/<int:pk>/', workflows.Disable.as_view(), name='disable'),
     path('workflows/edit/<int:pk>/', workflows.Edit.as_view(), name='edit'),
+    path('workflows/usage/<int:pk>/', workflows.usage, name='usage'),
     path('workflows/remove/<int:page_pk>/', workflows.remove_workflow, name='remove'),
     path('workflows/remove/<int:page_pk>/<int:workflow_pk>/', workflows.remove_workflow, name='remove'),
     path('tasks/add/<str:app_label>/<str:model_name>/', workflows.CreateTask.as_view(), name='add_task'),

--- a/wagtail/admin/views/workflows.py
+++ b/wagtail/admin/views/workflows.py
@@ -36,7 +36,7 @@ class Index(IndexView):
     add_url_name = 'wagtailadmin_workflows:add'
     edit_url_name = 'wagtailadmin_workflows:edit'
     page_title = _("Workflows")
-    add_item_label = _("Create a new workflow")
+    add_item_label = _("Add a workflow")
     header_icon = 'clipboard-list'
 
     def get_queryset(self):

--- a/wagtail/admin/views/workflows.py
+++ b/wagtail/admin/views/workflows.py
@@ -15,12 +15,11 @@ from django.views.decorators.http import require_POST
 
 from wagtail.admin import messages
 from wagtail.admin.auth import PermissionPolicyChecker
-from wagtail.admin.edit_handlers import Workflow
 from wagtail.admin.forms.workflows import (
-    TaskChooserSearchForm, WorkflowPagesFormSet, get_task_form_class)
+    TaskChooserSearchForm, WorkflowPagesFormSet, get_task_form_class, get_workflow_edit_handler)
 from wagtail.admin.modal_workflow import render_modal_workflow
 from wagtail.admin.views.generic import CreateView, DeleteView, EditView, IndexView
-from wagtail.core.models import Page, Task, TaskState, WorkflowState
+from wagtail.core.models import Page, Task, TaskState, Workflow, WorkflowState
 from wagtail.core.permissions import task_permission_policy, workflow_permission_policy
 from wagtail.core.utils import resolve_model_string
 from wagtail.core.workflows import get_task_types
@@ -66,18 +65,11 @@ class Create(CreateView):
 
     def get_edit_handler(self):
         if not self.edit_handler:
-            self.edit_handler = self.model.get_edit_handler()
-            self.edit_handler = self.edit_handler.bind_to(request=self.request)
+            self.edit_handler = get_workflow_edit_handler().bind_to(request=self.request)
         return self.edit_handler
 
     def get_form_class(self):
-        form_class = self.get_edit_handler().get_form_class()
-
-        # TODO Unhack
-        from wagtail.admin.widgets.workflows import AdminTaskChooser
-        form_class.formsets['workflow_tasks'].form.base_fields['task'].widget = AdminTaskChooser(show_clear_link=False)
-
-        return form_class
+        return self.get_edit_handler().get_form_class()
 
     def get_form(self, form_class=None):
         form = super().get_form(form_class)
@@ -138,18 +130,11 @@ class Edit(EditView):
 
     def get_edit_handler(self):
         if not self.edit_handler:
-            self.edit_handler = self.model.get_edit_handler()
-            self.edit_handler = self.edit_handler.bind_to(request=self.request, instance=self.get_object())
+            self.edit_handler = get_workflow_edit_handler().bind_to(request=self.request)
         return self.edit_handler
 
     def get_form_class(self):
-        form_class = self.get_edit_handler().get_form_class()
-
-        # TODO Unhack
-        from wagtail.admin.widgets.workflows import AdminTaskChooser
-        form_class.formsets['workflow_tasks'].form.base_fields['task'].widget = AdminTaskChooser(show_clear_link=False)
-
-        return form_class
+        return self.get_edit_handler().get_form_class()
 
     def get_form(self, form_class=None):
         form = super().get_form(form_class)

--- a/wagtail/admin/views/workflows.py
+++ b/wagtail/admin/views/workflows.py
@@ -16,7 +16,8 @@ from django.views.decorators.http import require_POST
 from wagtail.admin import messages
 from wagtail.admin.auth import PermissionPolicyChecker
 from wagtail.admin.edit_handlers import Workflow
-from wagtail.admin.forms.workflows import TaskChooserSearchForm, WorkflowPagesFormSet
+from wagtail.admin.forms.workflows import (
+    TaskChooserSearchForm, WorkflowPagesFormSet, get_task_form_class)
 from wagtail.admin.modal_workflow import render_modal_workflow
 from wagtail.admin.views.generic import CreateView, DeleteView, EditView, IndexView
 from wagtail.core.models import Page, Task, TaskState, WorkflowState
@@ -352,7 +353,6 @@ class CreateTask(CreateView):
     edit_url_name = 'wagtailadmin_workflows:edit_task'
     index_url_name = 'wagtailadmin_workflows:task_index'
     header_icon = 'clipboard-list'
-    edit_handler = None
 
     @cached_property
     def model(self):
@@ -370,24 +370,8 @@ class CreateTask(CreateView):
 
         return model
 
-    def get_edit_handler(self):
-        if not self.edit_handler:
-            self.edit_handler = self.model.get_edit_handler()
-            self.edit_handler = self.edit_handler.bind_to(request=self.request)
-        return self.edit_handler
-
     def get_form_class(self):
-        return self.get_edit_handler().get_form_class()
-
-    def get_form(self, form_class=None):
-        form = super().get_form(form_class)
-        self.edit_handler = self.edit_handler.bind_to(form=form)
-        return form
-
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
-        context['edit_handler'] = self.edit_handler
-        return context
+        return get_task_form_class(self.model)
 
     def get_add_url(self):
         return reverse(self.add_url_name, kwargs={'app_label': self.kwargs.get('app_label'), 'model_name': self.kwargs.get('model_name')})
@@ -407,7 +391,6 @@ class EditTask(EditView):
     enable_item_label = _('Enable')
     enable_url_name = 'wagtailadmin_workflows:enable_task'
     header_icon = 'clipboard-list'
-    edit_handler = None
 
     @cached_property
     def model(self):
@@ -420,23 +403,11 @@ class EditTask(EditView):
     def get_object(self, queryset=None):
         return super().get_object().specific
 
-    def get_edit_handler(self):
-        if not self.edit_handler:
-            self.edit_handler = self.model.get_edit_handler()
-            self.edit_handler = self.edit_handler.bind_to(request=self.request, instance=self.get_object())
-        return self.edit_handler
-
     def get_form_class(self):
-        return self.get_edit_handler().get_form_class()
-
-    def get_form(self, form_class=None):
-        form = super().get_form(form_class)
-        self.edit_handler = self.edit_handler.bind_to(form=form)
-        return form
+        return get_task_form_class(self.model, for_edit=True)
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context['edit_handler'] = self.edit_handler
         context['can_disable'] = (self.permission_policy is None or self.permission_policy.user_has_permission(self.request.user, 'delete')) and self.object.active
         context['can_enable'] = (self.permission_policy is None or self.permission_policy.user_has_permission(self.request.user, 'create')) and not self.object.active
 
@@ -561,9 +532,7 @@ def task_chooser(request):
     task_type_choices.sort(key=lambda task_type: task_type[1].lower())
 
     if create_model:
-        edit_handler = create_model.get_edit_handler()
-        edit_handler = edit_handler.bind_to(request=request)
-        createform_class = edit_handler.get_form_class()
+        createform_class = get_task_form_class(create_model)
     else:
         createform_class = None
 

--- a/wagtail/admin/views/workflows.py
+++ b/wagtail/admin/views/workflows.py
@@ -19,7 +19,8 @@ from wagtail.admin.forms.workflows import (
     TaskChooserSearchForm, WorkflowPagesFormSet, get_task_form_class, get_workflow_edit_handler)
 from wagtail.admin.modal_workflow import render_modal_workflow
 from wagtail.admin.views.generic import CreateView, DeleteView, EditView, IndexView
-from wagtail.core.models import Page, Task, TaskState, Workflow, WorkflowState
+from wagtail.core.models import (
+    Page, Task, TaskState, UserPagePermissionsProxy, Workflow, WorkflowState)
 from wagtail.core.permissions import task_permission_policy, workflow_permission_policy
 from wagtail.core.utils import resolve_model_string
 from wagtail.core.workflows import get_task_types
@@ -231,6 +232,21 @@ class Disable(DeleteView):
         self.object.deactivate(user=request.user)
         messages.success(request, self.get_success_message())
         return redirect(reverse(self.index_url_name))
+
+
+def usage(request, pk):
+    workflow = get_object_or_404(Workflow, id=pk)
+
+    perms = UserPagePermissionsProxy(request.user)
+
+    pages = workflow.all_pages() & perms.editable_pages()
+    paginator = Paginator(pages, per_page=10)
+    pages = paginator.get_page(request.GET.get('p'))
+
+    return render(request, 'wagtailadmin/workflows/usage.html', {
+        'workflow': workflow,
+        'used_by': pages,
+    })
 
 
 @require_POST

--- a/wagtail/admin/wagtail_hooks.py
+++ b/wagtail/admin/wagtail_hooks.py
@@ -115,6 +115,11 @@ def register_workflows_menu_item():
     return WorkflowsMenuItem(_('Workflows'), reverse('wagtailadmin_workflows:index'), icon_name='clipboard-list', order=100)
 
 
+@hooks.register('register_settings_menu_item')
+def register_workflow_tasks_menu_item():
+    return MenuItem(_('Workflow tasks'), reverse('wagtailadmin_workflows:task_index'), icon_name='clipboard-list', order=150)
+
+
 @hooks.register('register_page_listing_buttons')
 def page_listing_buttons(page, page_perms, is_parent=False, next_url=None):
     if page_perms.can_edit():

--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -4,6 +4,7 @@ from collections import defaultdict
 from io import StringIO
 from urllib.parse import urlparse
 
+from django import forms
 from django.conf import settings
 from django.contrib.auth.models import Group, Permission
 from django.contrib.contenttypes.models import ContentType
@@ -2571,6 +2572,9 @@ class Task(models.Model):
         "Active tasks can be added to workflows. Deactivating a task does not remove it from existing workflows."))
     objects = TaskManager()
 
+    admin_form_fields = ['name']
+    admin_form_readonly_on_edit_fields = []
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         if not self.id:
@@ -2737,6 +2741,12 @@ class Workflow(ClusterableModel):
 
 class GroupApprovalTask(Task):
     groups = models.ManyToManyField(Group, verbose_name=_('groups'), help_text=_('Pages at this step in a workflow will be moderated or approved by these groups of users'))
+
+    admin_form_fields = Task.admin_form_fields + ['groups']
+    admin_form_readonly_on_edit_fields = ['groups']
+    admin_form_widgets = {
+        'groups': forms.CheckboxSelectMultiple,
+    }
 
     def start(self, workflow_state, user=None):
         if workflow_state.page.locked_by:

--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -2573,7 +2573,7 @@ class Task(models.Model):
     objects = TaskManager()
 
     admin_form_fields = ['name']
-    admin_form_readonly_on_edit_fields = []
+    admin_form_readonly_on_edit_fields = ['name']
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -2743,7 +2743,6 @@ class GroupApprovalTask(Task):
     groups = models.ManyToManyField(Group, verbose_name=_('groups'), help_text=_('Pages at this step in a workflow will be moderated or approved by these groups of users'))
 
     admin_form_fields = Task.admin_form_fields + ['groups']
-    admin_form_readonly_on_edit_fields = ['groups']
     admin_form_widgets = {
         'groups': forms.CheckboxSelectMultiple,
     }


### PR DESCRIPTION
This PR updates the workflow management UI to reflect the designs that have been done recently.

Improvements include:

 - Made the workflow tasks view accessible from settings menu
 - Added number of pages a workflow applies to column to the index
 - Redesigned how tasks are displayed on workflows index
 - Added chooser modal for tasks, that allows creating and editing tasks
 - Improved assigning to page UI to work as a formset on the workflow edit view (instead of separate view)
 - Cleaned up usage of edit handlers
   - Tasks use plain Django forms, similar to Images
   - All code related to edit handlers moved and buried in forms/workflows.py as it's internal

This is still WIP. I'm posting this to make use of CI.