### PR TITLE
Feature/workflow permission registration

### DIFF
--- a/wagtail/admin/views/workflows.py
+++ b/wagtail/admin/views/workflows.py
@@ -193,7 +193,7 @@ def remove_workflow(request, page_pk, workflow_pk=None):
     page = get_object_or_404(Page, id=page_pk)
 
     # Check permissions
-    if not workflow_permission_policy.user_has_permission(request.user, 'remove_from_page'):
+    if not workflow_permission_policy.user_has_permission(request.user, 'change'):
         raise PermissionDenied
 
     if hasattr(page, 'workflowpage'):
@@ -214,7 +214,7 @@ def remove_workflow(request, page_pk, workflow_pk=None):
 def add_to_page(request, workflow_pk):
     # Assign a workflow to a Page, including a confirmation step if the Page has a different Workflow assigned already.
 
-    if not workflow_permission_policy.user_has_permission(request.user, 'add_to_page'):
+    if not workflow_permission_policy.user_has_permission(request.user, 'change'):
         raise PermissionDenied
 
     workflow = get_object_or_404(Workflow, pk=workflow_pk)

--- a/wagtail/admin/wagtail_hooks.py
+++ b/wagtail/admin/wagtail_hooks.py
@@ -23,7 +23,7 @@ from wagtail.admin.viewsets import viewsets
 from wagtail.admin.widgets import Button, ButtonWithDropdownFromHook, PageListingButton
 from wagtail.core import hooks
 from wagtail.core.models import UserPagePermissionsProxy
-from wagtail.core.permissions import collection_permission_policy
+from wagtail.core.permissions import collection_permission_policy, workflow_permission_policy
 from wagtail.core.whitelist import allow_without_attributes, attribute_rule, check_url
 
 
@@ -103,9 +103,16 @@ def register_collections_menu_item():
     return CollectionsMenuItem(_('Collections'), reverse('wagtailadmin_collections:index'), icon_name='folder-open-1', order=700)
 
 
+class WorkflowsMenuItem(MenuItem):
+    def is_shown(self, request):
+        return workflow_permission_policy.user_has_any_permission(
+            request.user, ['add', 'change', 'delete']
+        )
+
+
 @hooks.register('register_settings_menu_item')
 def register_workflows_menu_item():
-    return MenuItem(_('Workflows'), reverse('wagtailadmin_workflows:index'), icon_name='clipboard-list', order=100)
+    return WorkflowsMenuItem(_('Workflows'), reverse('wagtailadmin_workflows:index'), icon_name='clipboard-list', order=100)
 
 
 @hooks.register('register_page_listing_buttons')

--- a/wagtail/core/wagtail_hooks.py
+++ b/wagtail/core/wagtail_hooks.py
@@ -59,3 +59,19 @@ def register_collection_permissions():
         content_type__app_label='wagtailcore',
         codename__in=['add_collection', 'change_collection', 'delete_collection']
     )
+
+
+@hooks.register('register_permissions')
+def register_workflow_permissions():
+    return Permission.objects.filter(
+        content_type__app_label='wagtailcore',
+        codename__in=['add_workflow', 'change_workflow', 'delete_workflow']
+    )
+
+
+@hooks.register('register_permissions')
+def register_task_permissions():
+    return Permission.objects.filter(
+        content_type__app_label='wagtailcore',
+        codename__in=['add_task', 'change_task', 'delete_task']
+    )


### PR DESCRIPTION
Registers the workflow permissions properly so they can be added to groups in the admin, allowing non-superusers to set up workflows

Only shows the workflow menu icon if the index view is accessible

Adds tests for accessing workflow views with and without permissions in the Wagtail Admin