### PR TITLE
[Workflow management UI changes 1] Implemented task chooser modal

### DIFF
--- a/wagtail/admin/forms/workflows.py
+++ b/wagtail/admin/forms/workflows.py
@@ -1,9 +1,77 @@
 from django import forms
 from django.core.exceptions import ValidationError
-from django.utils.translation import ugettext_lazy as _
+from django.utils.functional import cached_property
+from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as __
 
 from wagtail.admin import widgets
-from wagtail.core.models import Page, Workflow, WorkflowPage
+from wagtail.core.models import Page, Task, Workflow, WorkflowPage
+
+
+def model_name(model):
+    return model._meta.app_label + '.' + model.__name__
+
+
+class TaskChooserSearchForm(forms.Form):
+    q = forms.CharField(label=__("Search term"), widget=forms.TextInput(), required=False)
+
+    def __init__(self, *args, task_type_choices=None, **kwargs):
+        placeholder = kwargs.pop('placeholder', _("Search"))
+        super().__init__(*args, **kwargs)
+        self.fields['q'].widget.attrs = {'placeholder': placeholder}
+
+        # Add task type filter if there is more than one task type option
+        if task_type_choices and len(task_type_choices) > 1:
+            self.fields['task_type'] = forms.ChoiceField(
+                choices=(
+                    # Append an "All types" choice to the beginning
+                    [(None, _("All types"))]
+
+                    # The task type choices that are passed in use the models as values, we need
+                    # to convert these to something that can be represented in HTML
+                    + [
+                        (model_name(model), verbose_name)
+                        for model, verbose_name in task_type_choices
+                    ]
+                ),
+                required=False
+            )
+
+        # Save a mapping of task_type values back to the model that we can reference later
+        self.task_type_choices = {
+            model_name(model): model
+            for model, _ in task_type_choices
+        }
+
+    def is_searching(self):
+        """
+        Returns True if the user typed a search query
+        """
+        return self.is_valid() and bool(self.cleaned_data.get('q'))
+
+    @cached_property
+    def task_model(self):
+        """
+        Returns the selected task model.
+
+        This looks for the task model in the following order:
+         1) If there's only one task model option, return it
+         2) If a task model has been selected, return it
+         3) Return the generic Task model
+        """
+        models = list(self.task_type_choices.values())
+        if len(models) == 1:
+            return models[0]
+
+        elif self.is_valid():
+            model_name = self.cleaned_data.get('task_type')
+            if model_name and model_name in self.task_type_choices:
+                return self.task_type_choices[model_name]
+
+        return Task
+
+    def specific_task_model_selected(self):
+        return self.task_model is not Task
 
 
 class AddWorkflowToPageForm(forms.Form):

--- a/wagtail/admin/forms/workflows.py
+++ b/wagtail/admin/forms/workflows.py
@@ -6,10 +6,7 @@ from django.utils.translation import ugettext_lazy as __
 
 from wagtail.admin import widgets
 from wagtail.core.models import Page, Task, Workflow, WorkflowPage
-
-
-def model_name(model):
-    return model._meta.app_label + '.' + model.__name__
+from wagtail.core.utils import get_model_string
 
 
 class TaskChooserSearchForm(forms.Form):
@@ -30,7 +27,7 @@ class TaskChooserSearchForm(forms.Form):
                     # The task type choices that are passed in use the models as values, we need
                     # to convert these to something that can be represented in HTML
                     + [
-                        (model_name(model), verbose_name)
+                        (get_model_string(model), verbose_name)
                         for model, verbose_name in task_type_choices
                     ]
                 ),
@@ -39,8 +36,8 @@ class TaskChooserSearchForm(forms.Form):
 
         # Save a mapping of task_type values back to the model that we can reference later
         self.task_type_choices = {
-            model_name(model): model
-            for model, _ in task_type_choices
+            get_model_string(model): model
+            for model, verbose_name in task_type_choices
         }
 
     def is_searching(self):

--- a/wagtail/admin/static_src/wagtailadmin/js/task-chooser-modal.js
+++ b/wagtail/admin/static_src/wagtailadmin/js/task-chooser-modal.js
@@ -1,0 +1,114 @@
+TASK_CHOOSER_MODAL_ONLOAD_HANDLERS = {
+    'chooser': function(modal, jsonData) {
+        function ajaxifyLinks (context) {
+            $('a.task-type-choice, a.choose-different-task-type, a.task-choice', context).on('click', function() {
+                modal.loadUrl(this.href);
+                return false;
+            });
+
+            $('.pagination a', context).on('click', function() {
+                var page = this.getAttribute("data-page");
+                setPage(page);
+                return false;
+            });
+
+            $('a.create-one-now').on('click', function(e) {
+                // Select upload form tab
+                $('a[href="#new"]').tab('show');
+                e.preventDefault();
+            });
+        };
+
+        var searchUrl = $('form.task-search', modal.body).attr('action');
+        var request;
+        function search() {
+            request = $.ajax({
+                url: searchUrl,
+                data: {
+                    q: $('#id_q').val(),
+                    task_type: $('#id_task_type').val(),
+                },
+                success: function(data, status) {
+                    request = null;
+                    $('#search-results').html(data);
+                    ajaxifyLinks($('#search-results'));
+                },
+                error: function() {
+                    request = null;
+                }
+            });
+            return false;
+        };
+        function setPage(page) {
+            var dataObj;
+
+            if($('#id_q').val().length){
+                dataObj = {q: $('#id_q').val(), p: page};
+            }else{
+                dataObj = {p: page};
+            }
+
+            request = $.ajax({
+                url: searchUrl,
+                data: dataObj,
+                success: function(data, status) {
+                    request = null;
+                    $('#search-results').html(data);
+                    ajaxifyLinks($('#search-results'));
+                },
+                error: function() {
+                    request = null;
+                }
+            });
+            return false;
+        }
+
+        ajaxifyLinks(modal.body);
+
+        $('form.task-create', modal.body).on('submit', function() {
+            var formdata = new FormData(this);
+
+            $.ajax({
+                url: this.action,
+                data: formdata,
+                processData: false,
+                contentType: false,
+                type: 'POST',
+                dataType: 'text',
+                success: modal.loadResponseText,
+                error: function(response, textStatus, errorThrown) {
+                    var message = jsonData['error_message'] + '<br />' + errorThrown + ' - ' + response.status;
+                    $('#new').append(
+                        '<div class="help-block help-critical">' +
+                        '<strong>' + jsonData['error_label'] + ': </strong>' + message + '</div>');
+                }
+            });
+
+            return false;
+        });
+
+        $('form.task-search', modal.body).on('submit', search);
+
+        $('#id_q').on('input', function() {
+            if (request) {
+                request.abort();
+            }
+            clearTimeout($.data(this, 'timer'));
+            var wait = setTimeout(search, 50);
+            $(this).data('timer', wait);
+        });
+
+        $('#id_task_type').on('change', function() {
+            if (request) {
+                request.abort();
+            }
+            clearTimeout($.data(this, 'timer'));
+            var wait = setTimeout(search, 50);
+            $(this).data('timer', wait);
+        });
+    },
+    'task_chosen': function(modal, jsonData) {
+        modal.respond('taskChosen', jsonData['result']);
+        modal.close();
+    }
+};

--- a/wagtail/admin/static_src/wagtailadmin/js/task-chooser.js
+++ b/wagtail/admin/static_src/wagtailadmin/js/task-chooser.js
@@ -1,0 +1,21 @@
+function createTaskChooser(id) {
+    var chooserElement = $('#' + id + '-chooser');
+    var taskName = chooserElement.find('.name');
+    var input = $('#' + id);
+    var editAction = chooserElement.find('.action-edit');
+
+    $('.action-choose', chooserElement).on('click', function() {
+        ModalWorkflow({
+            url: window.chooserUrls.taskChooser,
+            onload: TASK_CHOOSER_MODAL_ONLOAD_HANDLERS,
+            responses: {
+                taskChosen: function(data) {
+                    input.val(data.id);
+                    taskName.text(data.name);
+                    chooserElement.removeClass('blank');
+                    editAction.attr('href', data.edit_url);
+                }
+            }
+        });
+    });
+}

--- a/wagtail/admin/templates/wagtailadmin/pages/_editor_js.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/_editor_js.html
@@ -12,6 +12,7 @@
         'emailLinkChooser': '{% url "wagtailadmin_choose_page_email_link" %}',
         'phoneLinkChooser': '{% url "wagtailadmin_choose_page_phone_link" %}',
         'anchorLinkChooser': '{% url "wagtailadmin_choose_page_anchor_link" %}',
+        'taskChooser': '{% url "wagtailadmin_workflows:task_chooser" %}',
     };
     window.unicodeSlugsEnabled = {% if unicode_slugs_enabled %}true{% else %}false{% endif %};
 </script>

--- a/wagtail/admin/templates/wagtailadmin/widgets/chooser.html
+++ b/wagtail/admin/templates/wagtailadmin/widgets/chooser.html
@@ -12,12 +12,16 @@
         {% block chosen_state_view %}{% endblock %}
 
         <ul class="actions">
-            {% if not widget.is_required %}
+            {% if not widget.is_required and widget.show_clear_link %}
                 <li><button type="button" class="button action-clear button-small button-secondary">{{ widget.clear_choice_text }}</button></li>
             {% endif %}
             <li><button type="button" class="button action-choose button-small button-secondary">{{ widget.choose_another_text }}</button></li>
             {% if widget.show_edit_link %}
-                <li><a href="{% block edit_chosen_item_url %}#{% endblock %}" class="edit-link button button-small button-secondary" target="_blank" rel="noopener noreferrer">{{ widget.link_to_chosen_text }}</a></li>
+                <li>
+                    {% block edit_link %}
+                        <a href="{% block edit_chosen_item_url %}#{% endblock %}" class="edit-link button button-small button-secondary" target="_blank" rel="noopener noreferrer">{{ widget.link_to_chosen_text }}</a>
+                    {% endblock %}
+                </li>
             {% endif %}
         </ul>
     </div>

--- a/wagtail/admin/templates/wagtailadmin/workflows/task_chooser/chooser.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/task_chooser/chooser.html
@@ -1,0 +1,38 @@
+{% load i18n %}
+{% trans "Choose a task" as  choose_str %}
+{% include "wagtailadmin/shared/header.html" with title=choose_str tabbed=1 merged=1 icon="doc-full-inverse" %}
+
+{% if can_create %}
+<ul class="tab-nav merged">
+    <li class="active"><a href="#new">{% trans "New" %}</a></li>
+    <li><a href="#existing">{% trans "Existing" %}</a></li>
+</ul>
+{% endif %}
+
+<div class="tab-content">
+    {% if can_create %}
+    <section id="new" class="active nice-padding">
+        {% if createform %}
+            {% if task_types|length > 1 %}
+                <a href="{% url 'wagtailadmin_workflows:task_chooser' %}" class="choose-different-task-type">{% trans "Choose a different task type" %}</a>
+            {% endif %}
+
+            {% include "./includes/create_form.html" with form=createform %}
+        {% else %}
+            {% include "./includes/select_task_type.html" %}
+        {% endif %}
+    </section>
+    {% endif %}
+    <section id="existing" class="nice-padding{% if not can_create %} active{% endif %}">
+        <form class="task-search search-bar" action="{% url 'wagtailadmin_workflows:task_chooser' %}" method="GET" novalidate>
+            <ul class="fields">
+                {% for field in searchform %}
+                    {% include "wagtailadmin/shared/field_as_li.html" with field=field %}
+                {% endfor %}
+            </ul>
+        </form>
+        <div id="search-results" class="listing tasks">
+            {% include "./includes/results.html" %}
+        </div>
+    </section>
+</div>

--- a/wagtail/admin/templates/wagtailadmin/workflows/task_chooser/chooser.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/task_chooser/chooser.html
@@ -17,9 +17,9 @@
                 <a href="{% url 'wagtailadmin_workflows:task_chooser' %}" class="choose-different-task-type">{% trans "Choose a different task type" %}</a>
             {% endif %}
 
-            {% include "./includes/create_form.html" with form=createform %}
+            {% include "wagtailadmin/workflows/task_chooser/includes/create_form.html" with form=createform %}
         {% else %}
-            {% include "./includes/select_task_type.html" %}
+            {% include "wagtailadmin/workflows/task_chooser/includes/select_task_type.html" %}
         {% endif %}
     </section>
     {% endif %}
@@ -32,7 +32,7 @@
             </ul>
         </form>
         <div id="search-results" class="listing tasks">
-            {% include "./includes/results.html" %}
+            {% include "wagtailadmin/workflows/task_chooser/includes/results.html" %}
         </div>
     </section>
 </div>

--- a/wagtail/admin/templates/wagtailadmin/workflows/task_chooser/includes/create_form.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/task_chooser/includes/create_form.html
@@ -1,0 +1,14 @@
+{% load i18n %}
+
+{{ form.media.css }}
+{{ form.media.js }}
+
+<form class="task-create" action="{{ add_url }}" enctype="multipart/form-data" method="POST" novalidate>
+    {% csrf_token %}
+
+    {{ form }}
+
+    <div>
+        <button type="submit" class="button">{% trans "Create" %}</button>
+    </div>
+</form>

--- a/wagtail/admin/templates/wagtailadmin/workflows/task_chooser/includes/results.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/task_chooser/includes/results.html
@@ -1,0 +1,62 @@
+{% load i18n wagtailadmin_tags %}
+{% if tasks %}
+    {% if searchform.is_searching %}
+        <h2 role="alert">
+        {% blocktrans count counter=tasks.paginator.count %}
+            There is {{ counter }} match
+        {% plural %}
+            There are {{ counter }} matches
+        {% endblocktrans %}
+        </h2>
+    {% else %}
+        <h2>{% trans "Tasks" %}</h2>
+    {% endif %}
+
+    <table class="listing">
+        <thead>
+            <tr class="table-headers">
+                <th>
+                    {% trans "Name" %}
+                </th>
+                {% if searchform.specific_task_model_selected %}
+                    {# TODO #}
+                {% else %}
+                    <th>
+                        {% trans "Task type" %}
+                    </th>
+                {% endif %}
+            </tr>
+        </thead>
+        <tbody>
+            {% for task in tasks %}
+                <tr>
+                    <td class="title">
+                        <div class="title-wrapper"><a href="{% url 'wagtailadmin_workflows:task_chosen' task.id %}" class="task-choice">{{ task.name }}</a></div>
+                    </td>
+                    {% if searchform.specific_task_model_selected %}
+                        {# TODO #}
+                    {% else %}
+                        <th>
+                            {{ task.content_type.name }}
+                        </th>
+                    {% endif %}
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+
+    {% include "wagtailadmin/shared/ajax_pagination_nav.html" with items=tasks %}
+{% else %}
+    {% if all_tasks.exists %}
+        <p role="alert">{% blocktrans %}Sorry, no tasks match "<em>{{ query_string }}</em>"{% endblocktrans %}</p>
+    {% else %}
+        <p>
+        {% trans "You haven't created any tasks." %}
+        {% if createform %}
+            {% blocktrans %}
+                Why not <a class="create-one-now" href="#">create one now</a>?
+            {% endblocktrans %}
+        {% endif %}
+        </p>
+    {% endif %}
+{% endif %}

--- a/wagtail/admin/templates/wagtailadmin/workflows/task_chooser/includes/results.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/task_chooser/includes/results.html
@@ -36,9 +36,9 @@
                     {% if searchform.specific_task_model_selected %}
                         {# TODO #}
                     {% else %}
-                        <th>
+                        <td>
                             {{ task.content_type.name }}
-                        </th>
+                        </td>
                     {% endif %}
                 </tr>
             {% endfor %}

--- a/wagtail/admin/templates/wagtailadmin/workflows/task_chooser/includes/select_task_type.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/task_chooser/includes/select_task_type.html
@@ -1,0 +1,17 @@
+{% load i18n %}
+
+<p>{% trans "Choose which type of task you'd like to create." %}</p>
+
+{% if task_types %}
+    <ul class="listing">
+        {% for verbose_name, app_label, model_name in task_types %}
+            <li>
+                <div class="row row-flush">
+                    <div class="col6">
+                        <a href="{% url 'wagtailadmin_workflows:task_chooser' %}?create_model={{ app_label|urlencode }}.{{ model_name|urlencode }}" class="icon icon-plus-inverse icon-larger task-type-choice">{{ verbose_name }}</a>
+                    </div>
+                </div>
+            </li>
+        {% endfor %}
+    </ul>
+{% endif %}

--- a/wagtail/admin/templates/wagtailadmin/workflows/widgets/task_chooser.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/widgets/task_chooser.html
@@ -1,0 +1,8 @@
+{% extends "wagtailadmin/widgets/chooser.html" %}
+{% block chooser_class %}task-chooser{% endblock %}
+
+{% block chosen_state_view %}
+    <span class="name">{{ task.name }}</span>
+{% endblock %}
+
+{% block edit_chosen_item_url %}{% if task %}{% url 'wagtailadmin_workflows:edit_task' task.id %}{% endif %}{% endblock %}

--- a/wagtail/admin/urls/workflows.py
+++ b/wagtail/admin/urls/workflows.py
@@ -19,4 +19,6 @@ urlpatterns = [
     path('tasks/edit/<int:pk>/', workflows.EditTask.as_view(), name='edit_task'),
     path('tasks/disable/<int:pk>/', workflows.DisableTask.as_view(), name='disable_task'),
     path('tasks/enable/<int:pk>/', workflows.enable_task, name='enable_task'),
+    path('task_chooser/', workflows.task_chooser, name='task_chooser'),
+    path('task_chooser/<int:task_id>/', workflows.task_chosen, name='task_chosen'),
 ]

--- a/wagtail/admin/views/workflows.py
+++ b/wagtail/admin/views/workflows.py
@@ -480,7 +480,6 @@ def get_chooser_context():
         'step': 'chooser',
         'error_label': _("Server Error"),
         'error_message': _("Report this error to your webmaster with the following information:"),
-        'tag_autocomplete_url': reverse('wagtailadmin_tag_autocomplete'),
     }
 
 
@@ -535,11 +534,6 @@ def task_chooser(request):
         createform_class = edit_handler.get_form_class()
     else:
         createform_class = None
-
-    # TODO
-    #  # allow hooks to modify the queryset
-    # for hook in hooks.get_hooks('construct_document_chooser_queryset'):
-    #     documents = hook(documents, request)
 
     q = None
     if 'q' in request.GET or 'p' in request.GET or 'task_type' in request.GET:

--- a/wagtail/admin/views/workflows.py
+++ b/wagtail/admin/views/workflows.py
@@ -528,7 +528,6 @@ def task_chooser(request):
         for model in task_models
     ]
     task_type_choices.sort(key=lambda task_type: task_type[1].lower())
-    task_type_choices += [(Page, "Page")]
 
     if create_model:
         edit_handler = create_model.get_edit_handler()

--- a/wagtail/admin/widgets/chooser.py
+++ b/wagtail/admin/widgets/chooser.py
@@ -17,6 +17,7 @@ class AdminChooser(WidgetWithScript, widgets.Input):
     clear_choice_text = _("Clear choice")
     link_to_chosen_text = _("Edit this item")
     show_edit_link = True
+    show_clear_link = True
 
     # when looping over form fields, this one should appear in visible_fields, not hidden_fields
     # despite the underlying input being type="hidden"
@@ -63,6 +64,8 @@ class AdminChooser(WidgetWithScript, widgets.Input):
             self.link_to_chosen_text = kwargs.pop('link_to_chosen_text')
         if 'show_edit_link' in kwargs:
             self.show_edit_link = kwargs.pop('show_edit_link')
+        if 'show_clear_link' in kwargs:
+            self.show_clear_link = kwargs.pop('show_clear_link')
         super().__init__(**kwargs)
 
 

--- a/wagtail/admin/widgets/workflows.py
+++ b/wagtail/admin/widgets/workflows.py
@@ -1,0 +1,37 @@
+import json
+
+from django import forms
+from django.template.loader import render_to_string
+from django.utils.translation import gettext_lazy as _
+
+from wagtail.admin.staticfiles import versioned_static
+from wagtail.admin.widgets import AdminChooser
+from wagtail.core.models import Task
+
+
+class AdminTaskChooser(AdminChooser):
+    choose_one_text = _('Choose a task')
+    choose_another_text = _('Choose another task')
+    link_to_chosen_text = _('Edit this task')
+
+    def render_html(self, name, value, attrs):
+        instance, value = self.get_instance_and_id(Task, value)
+        original_field_html = super().render_html(name, value, attrs)
+
+        return render_to_string("wagtailadmin/workflows/widgets/task_chooser.html", {
+            'widget': self,
+            'original_field_html': original_field_html,
+            'attrs': attrs,
+            'value': value,
+            'task': instance,
+        })
+
+    def render_js_init(self, id_, name, value):
+        return "createTaskChooser({0});".format(json.dumps(id_))
+
+    @property
+    def media(self):
+        return forms.Media(js=[
+            versioned_static('wagtailadmin/js/task-chooser-modal.js'),
+            versioned_static('wagtailadmin/js/task-chooser.js'),
+        ])

--- a/wagtail/core/utils.py
+++ b/wagtail/core/utils.py
@@ -16,6 +16,17 @@ def camelcase_to_underscore(str):
     return re.sub('(((?<=[a-z])[A-Z])|([A-Z](?![A-Z]|$)))', '_\\1', str).lower().strip('_')
 
 
+def get_model_string(model):
+    """
+    Returns a string that can be used to identify the specified model.
+
+    The format is: `app_label.ModelName`
+
+    This an be reversed with the `resolve_model_string` function
+    """
+    return model._meta.app_label + '.' + model.__name__
+
+
 def resolve_model_string(model_string, default_app=None):
     """
     Resolve an 'app_label.model_name' string into an actual model class.


### PR DESCRIPTION
This adds a new task chooser modal. The modal allows the creation of new tasks or choosing an existing one.

This PR doesn't include:

 - Converting tasks to use plain Django forms
 - Admin listing fields for tasks
 - Fix for the checkbox widget styling

These will be included in future PRs.

Separated from: https://github.com/wagtail/wagtail/pull/6157