### PR TITLE
[Workflow management UI changes 3] Reduce usage of edit handlers for workflow management

### DIFF
--- a/wagtail/admin/edit_handlers.py
+++ b/wagtail/admin/edit_handlers.py
@@ -14,7 +14,7 @@ from taggit.managers import TaggableManager
 
 from wagtail.admin import compare, widgets
 from wagtail.core.fields import RichTextField
-from wagtail.core.models import Page, Workflow
+from wagtail.core.models import Page
 from wagtail.core.utils import camelcase_to_underscore, resolve_model_string
 from wagtail.utils.decorators import cached_classmethod
 
@@ -785,29 +785,6 @@ Page.settings_panels = [
 ]
 
 Page.base_form_class = WagtailAdminPageForm
-
-# Similarly, set up wagtailcore.Workflow to have edit handlers
-Workflow.panels = [
-    FieldPanel("name", heading=gettext_lazy("Give your workflow a name")),
-    InlinePanel("workflow_tasks", heading=gettext_lazy("Add tasks to your workflow")),
-]
-
-Workflow.base_form_class = WagtailAdminModelForm
-
-
-@cached_classmethod
-def get_simple_edit_handler(cls):
-    """
-    Get the EditHandler to use in the Wagtail admin when editing this class, constructing an ObjectList from the contents of cls.panels.
-    """
-    if hasattr(cls, 'edit_handler'):
-        edit_handler = cls.edit_handler
-    else:
-        edit_handler = ObjectList(cls.panels, base_form_class=cls.base_form_class)
-    return edit_handler.bind_to(model=cls)
-
-
-Workflow.get_edit_handler = get_simple_edit_handler
 
 
 @cached_classmethod

--- a/wagtail/admin/edit_handlers.py
+++ b/wagtail/admin/edit_handlers.py
@@ -795,26 +795,6 @@ Workflow.panels = [
 Workflow.base_form_class = WagtailAdminModelForm
 
 
-class ExcludeFieldsOnEditMixin:
-    """A mixin for edit handlers, which disables fields listed in a model's 'exclude_on_edit' attribute when binding
-    to an existing instance - editing rather than creating"""
-
-    def bind_to(self, *args, **kwargs):
-        new = super(ExcludeFieldsOnEditMixin, self).bind_to(*args, **kwargs)
-        # when binding to an existing instance with a pk - ie editing - set those fields in the form to disabled
-        if new.form and new.instance and new.instance.pk is not None and hasattr(new.model, 'exclude_on_edit'):
-            for field in new.model.exclude_on_edit:
-                try:
-                    new.form.fields[field].disabled = True
-                except KeyError:
-                    continue
-        return new
-
-
-class VaryOnEditObjectList(ExcludeFieldsOnEditMixin, ObjectList):
-    pass
-
-
 @cached_classmethod
 def get_simple_edit_handler(cls):
     """
@@ -823,7 +803,7 @@ def get_simple_edit_handler(cls):
     if hasattr(cls, 'edit_handler'):
         edit_handler = cls.edit_handler
     else:
-        edit_handler = VaryOnEditObjectList(cls.panels, base_form_class=cls.base_form_class)
+        edit_handler = ObjectList(cls.panels, base_form_class=cls.base_form_class)
     return edit_handler.bind_to(model=cls)
 
 

--- a/wagtail/admin/edit_handlers.py
+++ b/wagtail/admin/edit_handlers.py
@@ -14,7 +14,7 @@ from taggit.managers import TaggableManager
 
 from wagtail.admin import compare, widgets
 from wagtail.core.fields import RichTextField
-from wagtail.core.models import GroupApprovalTask, Page, Task, Workflow
+from wagtail.core.models import Page, Workflow
 from wagtail.core.utils import camelcase_to_underscore, resolve_model_string
 from wagtail.utils.decorators import cached_classmethod
 
@@ -791,16 +791,8 @@ Workflow.panels = [
     FieldPanel("name", heading=gettext_lazy("Give your workflow a name")),
     InlinePanel("workflow_tasks", heading=gettext_lazy("Add tasks to your workflow")),
 ]
-Task.panels = [
-    FieldPanel("name", heading=gettext_lazy("Give your task a name")),
-]
-GroupApprovalTask.panels = Task.panels + [FieldPanel('groups', heading=gettext_lazy("Choose approval groups"))]
-# do not allow editing of group post creation - this could lead to confusing history if a group is changed after tasks
-# are started/completed
-GroupApprovalTask.exclude_on_edit = {'groups'}
 
 Workflow.base_form_class = WagtailAdminModelForm
-Task.base_form_class = WagtailAdminModelForm
 
 
 class ExcludeFieldsOnEditMixin:
@@ -836,7 +828,6 @@ def get_simple_edit_handler(cls):
 
 
 Workflow.get_edit_handler = get_simple_edit_handler
-Task.get_edit_handler = get_simple_edit_handler
 
 
 @cached_classmethod

--- a/wagtail/admin/forms/workflows.py
+++ b/wagtail/admin/forms/workflows.py
@@ -171,7 +171,7 @@ def get_task_form_class(task_model, for_edit=False):
             if field_name not in form_class.base_fields:
                 raise ImproperlyConfigured(
                     "`%s.admin_form_readonly_on_edit_fields` contains the field "
-                    "'%s' but this field doesn't exist. Have you forgotten to add "
+                    "'%s' that doesn't exist. Did you forget to add "
                     "it to `%s.admin_form_fields`?"
                     % (task_model.__name__, field_name, task_model.__name__)
                 )

--- a/wagtail/admin/forms/workflows.py
+++ b/wagtail/admin/forms/workflows.py
@@ -5,6 +5,9 @@ from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_lazy as __
 
 from wagtail.admin import widgets
+from wagtail.admin.edit_handlers import FieldPanel, InlinePanel, ObjectList
+from wagtail.admin.forms import WagtailAdminModelForm
+from wagtail.admin.widgets.workflows import AdminTaskChooser
 from wagtail.core.models import Page, Task, Workflow, WorkflowPage
 from wagtail.core.utils import get_model_string
 
@@ -176,3 +179,22 @@ def get_task_form_class(task_model, for_edit=False):
             form_class.base_fields[field_name].disabled = True
 
     return form_class
+
+
+def get_workflow_edit_handler():
+    """
+    Returns an edit handler which provides the "name" and "tasks" fields for workflow.
+    """
+    # Note. It's a bit of a hack that we use edit handlers here. Ideally, it should be
+    # made easier to reuse the inline panel templates for any formset.
+    # Since this form is internal, we're OK with this for now. We might want to revisit
+    # this decision later if we decide to allow custom fields on Workflows.
+
+    panels = [
+        FieldPanel("name", heading=_("Give your workflow a name")),
+        InlinePanel("workflow_tasks", [
+            FieldPanel('task', widget=AdminTaskChooser(show_clear_link=False)),
+        ], heading=_("Add tasks to your workflow")),
+    ]
+    edit_handler = ObjectList(panels, base_form_class=WagtailAdminModelForm)
+    return edit_handler.bind_to(model=Workflow)

--- a/wagtail/admin/templates/wagtailadmin/workflows/create_task.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/create_task.html
@@ -25,7 +25,15 @@
     <form action="{{ view.get_add_url }}" enctype="multipart/form-data" method="POST" novalidate>
         {% csrf_token %}
 
-        {% block form %}{{ edit_handler.render_form_content }}{% endblock %}
+        <ul class="fields nice-padding">
+            {% for field in form %}
+                {% if not field.is_hidden %}
+                    {% include "wagtailadmin/shared/field_as_li.html" %}
+                {% else %}
+                    {{ field }}
+                {% endif %}
+            {% endfor %}
+        </ul>
 
         {% block footer %}
             <footer role="contentinfo">

--- a/wagtail/admin/templates/wagtailadmin/workflows/edit_task.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/edit_task.html
@@ -25,7 +25,15 @@
     <form action="{{ view.edit_url }}" enctype="multipart/form-data" method="POST" novalidate>
         {% csrf_token %}
 
-        {% block form %}{{ edit_handler.render_form_content }}{% endblock %}
+        <ul class="fields nice-padding">
+            {% for field in form %}
+                {% if not field.is_hidden %}
+                    {% include "wagtailadmin/shared/field_as_li.html" %}
+                {% else %}
+                    {{ field }}
+                {% endif %}
+            {% endfor %}
+        </ul>
 
         {% block footer %}
             <footer role="contentinfo">

--- a/wagtail/admin/templates/wagtailadmin/workflows/task_chooser/includes/create_form.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/task_chooser/includes/create_form.html
@@ -8,7 +8,7 @@
 
     {{ form }}
 
-    <div style="clear: both;">
+    <div class="clearfix">
         <button type="submit" class="button action-save button-longrunning" data-clicked-text="{% trans 'Creating…' %}">{% trans "Create" %}</button>
     </div>
 </form>

--- a/wagtail/admin/templates/wagtailadmin/workflows/task_chooser/includes/create_form.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/task_chooser/includes/create_form.html
@@ -8,7 +8,7 @@
 
     {{ form }}
 
-    <div>
-        <button type="submit" class="button">{% trans "Create" %}</button>
+    <div style="clear: both;">
+        <button type="submit" class="button action-save button-longrunning" data-clicked-text="{% trans 'Creating…' %}">{% trans "Create" %}</button>
     </div>
 </form>

--- a/wagtail/admin/views/workflows.py
+++ b/wagtail/admin/views/workflows.py
@@ -15,12 +15,11 @@ from django.views.decorators.http import require_POST
 
 from wagtail.admin import messages
 from wagtail.admin.auth import PermissionPolicyChecker
-from wagtail.admin.edit_handlers import Workflow
 from wagtail.admin.forms.workflows import (
-    TaskChooserSearchForm, WorkflowPagesFormSet, get_task_form_class)
+    TaskChooserSearchForm, WorkflowPagesFormSet, get_task_form_class, get_workflow_edit_handler)
 from wagtail.admin.modal_workflow import render_modal_workflow
 from wagtail.admin.views.generic import CreateView, DeleteView, EditView, IndexView
-from wagtail.core.models import Page, Task, TaskState, WorkflowState
+from wagtail.core.models import Page, Task, TaskState, Workflow, WorkflowState
 from wagtail.core.permissions import task_permission_policy, workflow_permission_policy
 from wagtail.core.utils import resolve_model_string
 from wagtail.core.workflows import get_task_types
@@ -66,18 +65,11 @@ class Create(CreateView):
 
     def get_edit_handler(self):
         if not self.edit_handler:
-            self.edit_handler = self.model.get_edit_handler()
-            self.edit_handler = self.edit_handler.bind_to(request=self.request)
+            self.edit_handler = get_workflow_edit_handler().bind_to(request=self.request)
         return self.edit_handler
 
     def get_form_class(self):
-        form_class = self.get_edit_handler().get_form_class()
-
-        # TODO Unhack
-        from wagtail.admin.widgets.workflows import AdminTaskChooser
-        form_class.formsets['workflow_tasks'].form.base_fields['task'].widget = AdminTaskChooser(show_clear_link=False)
-
-        return form_class
+        return self.get_edit_handler().get_form_class()
 
     def get_form(self, form_class=None):
         form = super().get_form(form_class)
@@ -138,18 +130,11 @@ class Edit(EditView):
 
     def get_edit_handler(self):
         if not self.edit_handler:
-            self.edit_handler = self.model.get_edit_handler()
-            self.edit_handler = self.edit_handler.bind_to(request=self.request, instance=self.get_object())
+            self.edit_handler = get_workflow_edit_handler().bind_to(request=self.request)
         return self.edit_handler
 
     def get_form_class(self):
-        form_class = self.get_edit_handler().get_form_class()
-
-        # TODO Unhack
-        from wagtail.admin.widgets.workflows import AdminTaskChooser
-        form_class.formsets['workflow_tasks'].form.base_fields['task'].widget = AdminTaskChooser(show_clear_link=False)
-
-        return form_class
+        return self.get_edit_handler().get_form_class()
 
     def get_form(self, form_class=None):
         form = super().get_form(form_class)

--- a/wagtail/admin/views/workflows.py
+++ b/wagtail/admin/views/workflows.py
@@ -16,7 +16,8 @@ from django.views.decorators.http import require_POST
 from wagtail.admin import messages
 from wagtail.admin.auth import PermissionPolicyChecker
 from wagtail.admin.edit_handlers import Workflow
-from wagtail.admin.forms.workflows import TaskChooserSearchForm, WorkflowPagesFormSet
+from wagtail.admin.forms.workflows import (
+    TaskChooserSearchForm, WorkflowPagesFormSet, get_task_form_class)
 from wagtail.admin.modal_workflow import render_modal_workflow
 from wagtail.admin.views.generic import CreateView, DeleteView, EditView, IndexView
 from wagtail.core.models import Page, Task, TaskState, WorkflowState
@@ -352,7 +353,6 @@ class CreateTask(CreateView):
     edit_url_name = 'wagtailadmin_workflows:edit_task'
     index_url_name = 'wagtailadmin_workflows:task_index'
     header_icon = 'clipboard-list'
-    edit_handler = None
 
     @cached_property
     def model(self):
@@ -370,24 +370,8 @@ class CreateTask(CreateView):
 
         return model
 
-    def get_edit_handler(self):
-        if not self.edit_handler:
-            self.edit_handler = self.model.get_edit_handler()
-            self.edit_handler = self.edit_handler.bind_to(request=self.request)
-        return self.edit_handler
-
     def get_form_class(self):
-        return self.get_edit_handler().get_form_class()
-
-    def get_form(self, form_class=None):
-        form = super().get_form(form_class)
-        self.edit_handler = self.edit_handler.bind_to(form=form)
-        return form
-
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
-        context['edit_handler'] = self.edit_handler
-        return context
+        return get_task_form_class(self.model)
 
     def get_add_url(self):
         return reverse(self.add_url_name, kwargs={'app_label': self.kwargs.get('app_label'), 'model_name': self.kwargs.get('model_name')})
@@ -407,7 +391,6 @@ class EditTask(EditView):
     enable_item_label = _('Enable')
     enable_url_name = 'wagtailadmin_workflows:enable_task'
     header_icon = 'clipboard-list'
-    edit_handler = None
 
     @cached_property
     def model(self):
@@ -420,23 +403,11 @@ class EditTask(EditView):
     def get_object(self, queryset=None):
         return super().get_object().specific
 
-    def get_edit_handler(self):
-        if not self.edit_handler:
-            self.edit_handler = self.model.get_edit_handler()
-            self.edit_handler = self.edit_handler.bind_to(request=self.request, instance=self.get_object())
-        return self.edit_handler
-
     def get_form_class(self):
-        return self.get_edit_handler().get_form_class()
-
-    def get_form(self, form_class=None):
-        form = super().get_form(form_class)
-        self.edit_handler = self.edit_handler.bind_to(form=form)
-        return form
+        return get_task_form_class(self.model, for_edit=True)
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context['edit_handler'] = self.edit_handler
         context['can_disable'] = (self.permission_policy is None or self.permission_policy.user_has_permission(self.request.user, 'delete')) and self.object.active
         context['can_enable'] = (self.permission_policy is None or self.permission_policy.user_has_permission(self.request.user, 'create')) and not self.object.active
 
@@ -561,9 +532,7 @@ def task_chooser(request):
     task_type_choices.sort(key=lambda task_type: task_type[1].lower())
 
     if create_model:
-        edit_handler = create_model.get_edit_handler()
-        edit_handler = edit_handler.bind_to(request=request)
-        createform_class = edit_handler.get_form_class()
+        createform_class = get_task_form_class(create_model)
     else:
         createform_class = None
 

--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -4,6 +4,7 @@ from collections import defaultdict
 from io import StringIO
 from urllib.parse import urlparse
 
+from django import forms
 from django.conf import settings
 from django.contrib.auth.models import Group, Permission
 from django.contrib.contenttypes.models import ContentType
@@ -2571,6 +2572,9 @@ class Task(models.Model):
         "Active tasks can be added to workflows. Deactivating a task does not remove it from existing workflows."))
     objects = TaskManager()
 
+    admin_form_fields = ['name']
+    admin_form_readonly_on_edit_fields = []
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         if not self.id:
@@ -2737,6 +2741,12 @@ class Workflow(ClusterableModel):
 
 class GroupApprovalTask(Task):
     groups = models.ManyToManyField(Group, verbose_name=_('groups'), help_text=_('Pages at this step in a workflow will be moderated or approved by these groups of users'))
+
+    admin_form_fields = Task.admin_form_fields + ['groups']
+    admin_form_readonly_on_edit_fields = ['groups']
+    admin_form_widgets = {
+        'groups': forms.CheckboxSelectMultiple,
+    }
 
     def start(self, workflow_state, user=None):
         if workflow_state.page.locked_by:

--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -2573,7 +2573,7 @@ class Task(models.Model):
     objects = TaskManager()
 
     admin_form_fields = ['name']
-    admin_form_readonly_on_edit_fields = []
+    admin_form_readonly_on_edit_fields = ['name']
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -2743,7 +2743,6 @@ class GroupApprovalTask(Task):
     groups = models.ManyToManyField(Group, verbose_name=_('groups'), help_text=_('Pages at this step in a workflow will be moderated or approved by these groups of users'))
 
     admin_form_fields = Task.admin_form_fields + ['groups']
-    admin_form_readonly_on_edit_fields = ['groups']
     admin_form_widgets = {
         'groups': forms.CheckboxSelectMultiple,
     }


### PR DESCRIPTION
Separated from: https://github.com/wagtail/wagtail/pull/6157
Based on: https://github.com/wagtail/wagtail/pull/6171

- Convert tasks to use plain Django forms
- Bury usage of edit handlers into workflow views to make it in internal implementation detail that we can change later