### PR TITLE
Disable password auto-completion on UserForm password fields.

### DIFF
--- a/wagtail/users/forms.py
+++ b/wagtail/users/forms.py
@@ -83,11 +83,11 @@ class UserForm(UsernameForm):
 
     password1 = forms.CharField(
         label=_('Password'), required=False,
-        widget=forms.PasswordInput,
+        widget=forms.PasswordInput(attrs={'autocomplete': 'new-password'}),
         help_text=_("Leave blank if not changing."))
     password2 = forms.CharField(
         label=_("Password confirmation"), required=False,
-        widget=forms.PasswordInput,
+        widget=forms.PasswordInput(attrs={'autocomplete': 'new-password'}),
         help_text=_("Enter the same password as above, for verification."))
 
     is_superuser = forms.BooleanField(


### PR DESCRIPTION
If you use the web browser's password manager to store the login credentials for a Wagtail site, it will auto-populate these credentials into the password field of the `UserForm` when you go to edit a user. This is not the desired behaviour, because the fields are for editing another user's password rather than logging in with your own.

This patch adds the `autocomplete="off"` [attribute](https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion) to these inputs to prevent auto-completion. (We could potentially also use `autocomplete="new-password"`, but I didn't do this because the password suggestions that modern browsers provide would be different for both password1 and password2 fields, which may cause confusion).