### PR TITLE
Move pages summary item hook into wagtail.admin.wagtail_hooks

### DIFF
--- a/wagtail/admin/site_summary.py
+++ b/wagtail/admin/site_summary.py
@@ -59,11 +59,6 @@ class PagesSummaryItem(SummaryItem):
         return user_has_any_page_permission(self.request.user)
 
 
-@hooks.register('construct_homepage_summary_items')
-def add_pages_summary_item(request, items):
-    items.append(PagesSummaryItem(request))
-
-
 class SiteSummaryPanel:
     name = 'site_summary'
     order = 100

--- a/wagtail/admin/wagtail_hooks.py
+++ b/wagtail/admin/wagtail_hooks.py
@@ -18,6 +18,7 @@ from wagtail.admin.rich_text.converters.html_to_contentstate import (
     BlockElementHandler, ExternalLinkElementHandler, HorizontalRuleHandler,
     InlineStyleElementHandler, ListElementHandler, ListItemElementHandler, PageLinkElementHandler)
 from wagtail.admin.search import SearchArea
+from wagtail.admin.site_summary import PagesSummaryItem
 from wagtail.admin.views.account import email_management_enabled, password_management_enabled
 from wagtail.admin.viewsets import viewsets
 from wagtail.admin.widgets import Button, ButtonWithDropdownFromHook, PageListingButton
@@ -725,3 +726,8 @@ def register_icons(icons):
     ]:
         icons.append('wagtailadmin/icons/{}'.format(icon))
     return icons
+
+
+@hooks.register('construct_homepage_summary_items')
+def add_pages_summary_item(request, items):
+    items.insert(0, PagesSummaryItem(request))


### PR DESCRIPTION
As per https://github.com/wagtail/wagtail/issues/6160#issuecomment-646080597 - this ensures that the hook will be triggered in the correct order with respect to INSTALLED_APPS.

(Have tweaked it to prepend rather than append to the list, so the pages item still consistently appears before the images / docs even if this fix causes the sequence of the built-in hooks to change.)