### PR TITLE
Fix MediaBlock SVG icon size in the rich text editor

### DIFF
--- a/client/src/components/Draftail/blocks/MediaBlock.scss
+++ b/client/src/components/Draftail/blocks/MediaBlock.scss
@@ -14,6 +14,10 @@
         line-height: 1;
         padding: $controls-spacing * 2 $controls-spacing * 3;
         pointer-events: none;
+
+        .icon {
+            @include svg-icon();
+        }
     }
 
     &__icon {


### PR DESCRIPTION
Fixes #6142 

Fixes the `.icon` style specifically, not https://github.com/wagtail/wagtail/issues/6142#issuecomment-644175830

* Do the tests still pass? (https://docs.wagtail.io/en/latest/contributing/developing.html#testing) ✅
* Does the code comply with the style guide? (Run `make lint` from the Wagtail root)✅
* For Python changes: Have you added tests to cover the new/fixed behaviour? N/A
* For front-end changes: Did you test on all of Wagtail’s supported browsers? **Please list the exact versions you tested**.
  * Firefox 77, Chrome 83, Safari 13.1.1
* For new features: Has the documentation been updated accordingly? N/A
