### PR TITLE
SVG utility modifiers and styleguide list

### DIFF
--- a/client/scss/components/_icons.scss
+++ b/client/scss/components/_icons.scss
@@ -140,3 +140,14 @@
         border: 1px solid currentColor;
     }
 }
+
+.icon {
+    &.initial {
+        @include svg-icon(1em);
+        vertical-align: initial;
+    }
+
+    &.default {
+        @include svg-icon(1.5em);
+    }
+}

--- a/wagtail/contrib/styleguide/static_src/wagtailstyleguide/scss/styleguide.scss
+++ b/wagtail/contrib/styleguide/static_src/wagtailstyleguide/scss/styleguide.scss
@@ -202,6 +202,10 @@ section {
         font-size: 2em;
     }
 
+    .icon {
+        @include svg-icon(1.5em);
+    }
+
     ul {
         column-count: 3;
     }


### PR DESCRIPTION
Thanks for contributing to Wagtail! 🎉

Add a couple of [utility classes for SVG icons](https://github.com/wagtail/wagtail/issues/6142#issuecomment-643596671)
and fixes the icon sizes on the styleguide

* Do the tests still pass? (https://docs.wagtail.io/en/latest/contributing/developing.html#testing) ✅
* Does the code comply with the style guide? (Run `make lint` from the Wagtail root) ✅
* For Python changes: Have you added tests to cover the new/fixed behaviour? N/A
* For front-end changes: Did you test on all of Wagtail’s supported browsers? **Please list the exact versions you tested**.
  * Firefox 77, Chrome 83, Safari 13.1
* For new features: Has the documentation been updated accordingly? N/A
