### PR TITLE
[Workflow] Update home dashboard styles

### DIFF
--- a/wagtail/admin/static_src/wagtailadmin/js/lock-unlock-action.js
+++ b/wagtail/admin/static_src/wagtailadmin/js/lock-unlock-action.js
@@ -1,0 +1,33 @@
+/* When a lock/unlock action button is clicked, make a POST request to the relevant view */
+
+function LockUnlockAction(csrfToken, next) {
+  document.querySelectorAll('[data-locking-action]').forEach(function (buttonElement) {
+    buttonElement.addEventListener('click', function (e) {
+      // Stop the button from submitting the form
+      e.preventDefault();
+      e.stopPropagation();
+
+      var formElement = document.createElement('form');
+
+      formElement.action = buttonElement.dataset.lockingAction;
+      formElement.method = 'POST';
+
+      var csrftokenElement = document.createElement('input');
+      csrftokenElement.type = 'hidden';
+      csrftokenElement.name = 'csrfmiddlewaretoken';
+      csrftokenElement.value = csrfToken;
+      formElement.appendChild(csrftokenElement);
+
+      if (typeof next !== 'undefined') {
+        var nextElement = document.createElement('input');
+        nextElement.type = 'hidden';
+        nextElement.name = 'next';
+        nextElement.value = next;
+        formElement.appendChild(nextElement);
+      }
+
+      document.body.appendChild(formElement);
+      formElement.submit();
+    }, {capture: true});
+  });
+}

--- a/wagtail/admin/static_src/wagtailadmin/scss/layouts/home.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/layouts/home.scss
@@ -36,7 +36,6 @@ header {
 
 .summary {
     @include clearfix();
-    background-color: $color-grey-5;
     margin-bottom: 2em;
     padding-top: 2em;
 
@@ -44,6 +43,7 @@ header {
         @include clearfix();
         @include unlist();
         width: 100%;
+        margin-left: -$padding;
 
         li {
             @include column(4);
@@ -116,11 +116,40 @@ header {
         }
 
         label {
-            display: inline-blo;
+            display: inline-block;
         }
 
         input {
             background-color: $color-white;
         }
     }
+}
+
+.object.collapsible .object-layout .title-wrapper::before {
+    display: none;
+}
+
+.object-layout {
+    // enforce flex display at all screen sizes
+    display: flex;
+    flex-flow: row-reverse wrap;
+
+    thead {
+        display: table-caption;
+        height: $object-title-height;
+        margin-bottom: 2em;
+    }
+
+    .listing--push-top {
+        margin-top: 3em;
+
+        thead {
+            display: table-row-group;
+            margin-bottom: 0;
+        }
+    }
+}
+
+.task .icon {
+    margin-left: -1.75em; // pull out the icon so it aligns with no-icon text
 }

--- a/wagtail/admin/templates/wagtailadmin/home.html
+++ b/wagtail/admin/templates/wagtailadmin/home.html
@@ -7,11 +7,12 @@
     {{ block.super }}
 
     <link rel="stylesheet" href="{% versioned_static 'wagtailadmin/css/layouts/home.css' %}" type="text/css" />
+    <link rel="stylesheet" href="{% versioned_static 'wagtailadmin/css/layouts/page-editor.css' %}" />
 {% endblock %}
 
 {% block content %}
     <header class="merged nice-padding">
-        <div class="row row-flush">
+        <div class="row">
             <div class="col1">
                 <div class="avatar"><img src="{% avatar_url user %}" alt="" /></div>
             </div>
@@ -29,4 +30,28 @@
     {% else %}
         <p>{% trans "This is your dashboard on which helpful information about content you've created will be displayed." %}</p>
     {% endif %}
+{% endblock %}
+
+{% block extra_js %}
+<script>
+$(function() {
+    $('.object.collapsible').each(function() {
+        var $target = $(this);
+        var $content = $target.find('.object-layout');
+        if ($target.hasClass('collapsed') && $target.find('.error-message').length == 0) {
+            $content.hide();
+        }
+
+        $target.find('> .title-wrapper').on('click', function() {
+            if (!$target.hasClass('collapsed')) {
+                $target.addClass('collapsed');
+                $content.hide('slow');
+            } else {
+                $target.removeClass('collapsed');
+                $content.show('show');
+            }
+        });
+    });
+});
+</script>
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/home/locked_pages.html
+++ b/wagtail/admin/templates/wagtailadmin/home/locked_pages.html
@@ -1,50 +1,57 @@
 {% load i18n wagtailadmin_tags %}
 {% if locked_pages %}
-    <div class="panel nice-padding">{# TODO try moving these classes onto the section tag #}
-        <section>
-            <h2>{% trans "Your locked pages" %}</h2>
-            {% if can_remove_locks %}
-                <a href="{% url 'wagtailadmin_reports:locked_pages' %}" class="button button-small button-secondary">{% trans "See all locked pages" %}</a>
-            {% endif %}
-            <table class="listing listing-page">
-                <col />
-                <col width="15%"/>
-                <col width="15%"/>
-                <thead>
-                    <tr>
-                        <th class="title">{% trans "Title" %}</th>
-                        <th>{% trans "Locked at" %}</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {% for page in locked_pages %}
-                        <tr>
-                            <td class="title" valign="top">
-                                <div class="title-wrapper">
-                                    <a href="{% url 'wagtailadmin_pages:edit' page.id %}" title="{% trans 'Edit this page' %}">{{ page.get_admin_display_title }}</a>
+<section class="object collapsible">
+    <h2 class="title-wrapper">{% trans "Your locked pages" %}</h2>
 
-                                    {% include "wagtailadmin/pages/listing/_privacy_indicator.html" with page=page %}
-                                    {% include "wagtailadmin/pages/listing/_locked_indicator.html" with page=page %}
-                                </div>
-                                <ul class="actions">
-                                    <li><a href="{% url 'wagtailadmin_pages:edit' page.id %}" class="button button-small button-secondary">{% trans "Edit" %}</a></li>
-                                    {% if page.has_unpublished_changes and page.is_previewable %}
-                                        <li><a href="{% url 'wagtailadmin_pages:view_draft' page.id %}" class="button button-small button-secondary" target="_blank" rel="noopener noreferrer">{% trans 'Draft' %}</a></li>
-                                    {% endif %}
-                                    {% if page.live %}
-                                        {% with page_url=page.url %}
-                                            {% if page_url is not None %}
-                                                <li><a href="{{ page_url }}" class="button button-small button-secondary" target="_blank" rel="noopener noreferrer">{% trans 'Live' %}</a></li>
-                                            {% endif %}
-                                        {% endwith %}
-                                    {% endif %}
-                                </ul>
-                            </td>
-                            <td valign="top"><div class="human-readable-date" title="{{ page.locked_at|date:"d M Y H:i" }}">{% blocktrans with time_period=page.locked_at|timesince %}{{ time_period }} ago{% endblocktrans %}</div></td>
-                        </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
-        </section>
+    <div class="object-layout">
+        <table class="listing listing-page">
+            <col />
+            <col width="30%"/>
+            <col width="15%"/>
+
+            <thead>
+                <tr>
+                    <th class="title">{% trans "Title" %}</th>
+                    <th></th>
+                    <th>{% trans "Locked at" %}</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for page in locked_pages %}
+                    <tr>
+                        <td class="title" valign="top">
+                            <div class="title-wrapper">
+                                <a href="{% url 'wagtailadmin_pages:edit' page.id %}" title="{% trans 'Edit this page' %}">{{ page.get_admin_display_title }}</a>
+                                {% include "wagtailadmin/pages/listing/_privacy_indicator.html" with page=page %}
+                                {% include "wagtailadmin/pages/listing/_locked_indicator.html" with page=page %}
+                            </div>
+                            <ul class="actions">
+                                {% if can_remove_locks %}
+                                    <li><button data-locking-action="{% url 'wagtailadmin_pages:unlock' page.id %}" class="button button-small button-secondary">{% trans "Unlock" %}</button></li>
+                                {% endif %}
+                                <li><a href="{% url 'wagtailadmin_pages:edit' page.id %}" class="button button-small button-secondary">{% trans "Edit" %}</a></li>
+                                {% if page.has_unpublished_changes and page.is_previewable %}
+                                    <li><a href="{% url 'wagtailadmin_pages:view_draft' page.id %}" class="button button-small button-secondary" target="_blank" rel="noopener noreferrer">{% trans 'Draft' %}</a></li>
+                                {% endif %}
+                                {% if page.live %}
+                                    {% with page_url=page.url %}
+                                        {% if page_url is not None %}
+                                            <li><a href="{{ page_url }}" class="button button-small button-secondary" target="_blank" rel="noopener noreferrer">{% trans 'Live' %}</a></li>
+                                        {% endif %}
+                                    {% endwith %}
+                                {% endif %}
+                            </ul>
+                        </td>
+                        <td>{# Deliberately empty #}</td>
+                        <td valign="top"><div class="human-readable-date" title="{{ page.locked_at|date:"d M Y H:i" }}">{% blocktrans with time_period=page.locked_at|timesince %}{{ time_period }} ago{% endblocktrans %}</div></td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
     </div>
+</section>
+<script src="{% versioned_static 'wagtailadmin/js/lock-unlock-action.js' %}"></script>
+<script>
+    document.addEventListener('DOMContentLoaded', LockUnlockAction('{{ csrf_token|escapejs }}', '{% url 'wagtailadmin_home' %}'));
+</script>
 {% endif %}

--- a/wagtail/admin/templates/wagtailadmin/home/locked_pages.html
+++ b/wagtail/admin/templates/wagtailadmin/home/locked_pages.html
@@ -43,7 +43,7 @@
                             </ul>
                         </td>
                         <td>{# Deliberately empty #}</td>
-                        <td valign="top"><div class="human-readable-date" title="{{ page.locked_at|date:"d M Y H:i" }}">{% blocktrans with time_period=page.locked_at|timesince %}{{ time_period }} ago{% endblocktrans %}</div></td>
+                        <td valign="top"><div class="human-readable-date" title="{{ page.locked_at|date:"d M Y H:i" }}">{% blocktrans with time_period=page.locked_at|timesince_simple %}{{ time_period }}{% endblocktrans %}</div></td>
                     </tr>
                 {% endfor %}
             </tbody>

--- a/wagtail/admin/templates/wagtailadmin/home/pages_for_moderation.html
+++ b/wagtail/admin/templates/wagtailadmin/home/pages_for_moderation.html
@@ -1,75 +1,75 @@
 {% load i18n wagtailadmin_tags %}
 {% if page_revisions_for_moderation %}
-    <div class="panel nice-padding">{# TODO try moving these classes onto the section tag #}
-        <section>
-            <h2>{% trans 'Pages awaiting moderation' %}</h2>
-            <table class="listing">
-                <col />
-                <col width="30%"/>
-                <col width="15%"/>
-                <col width="15%"/>
-                <thead>
+<section class="object collapsible">
+    <h2 class="title-wrapper">{% trans 'Pages awaiting moderation' %}</h2>
+    <div class="object-layout">
+        <table class="listing">
+            <col />
+            <col width="30%"/>
+            <col width="15%"/>
+            <col width="15%"/>
+            <thead>{# Note: the header is visually hidden behind .title-wrapper #}
+                <tr>
+                    <th class="title">{% trans "Title" %}</th>
+                    <th>{% trans "Parent" %}</th>
+                    <th>{% trans "Type" %}</th>
+                    <th>{% trans "Edited" %}</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for revision in page_revisions_for_moderation %}
+                    {% page_permissions revision.page as page_perms %}
                     <tr>
-                        <th class="title">{% trans "Title" %}</th>
-                        <th>{% trans "Parent" %}</th>
-                        <th>{% trans "Type" %}</th>
-                        <th>{% trans "Edited" %}</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {% for revision in page_revisions_for_moderation %}
-                        {% page_permissions revision.page as page_perms %}
-                        <tr>
-                            <td class="title" valign="top">
-                                <div class="title-wrapper">
-                                    {% if page_perms.can_edit %}
-                                        <a href="{% url 'wagtailadmin_pages:edit' revision.page.id %}" title="{% trans 'Edit this page' %}">{{ revision.page.get_admin_display_title }}</a>
-                                    {% elif revision.page.is_previewable %}
-                                        <a href="{% url 'wagtailadmin_pages:preview_for_moderation' revision.id %}" title="{% trans 'Preview this page' %}">{{ revision.page.get_admin_display_title }}</a>
-                                    {% else %}
-                                        {{ revision.page.get_admin_display_title }}
-                                    {% endif %}
-
-                                    {% include "wagtailadmin/pages/listing/_privacy_indicator.html" with page=revision.page %}
-                                    {% include "wagtailadmin/pages/listing/_locked_indicator.html" with page=revision.page %}
-                                </div>
-                                <ul class="actions">
-                                    <li>
-                                         <form action="{% url 'wagtailadmin_pages:approve_moderation' revision.id %}" method="POST">
-                                            {% csrf_token %}
-                                            <input type="submit" class="button button-small button-secondary" value="{% trans 'Approve' %}">
-                                        </form>
-                                    </li>
-                                    <li class="no-border">
-                                        <form action="{% url 'wagtailadmin_pages:reject_moderation' revision.id %}" method="POST">
-                                            {% csrf_token %}
-                                            <input type="submit" class="button button-small button-secondary no" value="{% trans 'Reject' %}">
-                                        </form>
-                                    </li>
-                                    {% if page_perms.can_edit %}
-                                        <li><a href="{% url 'wagtailadmin_pages:edit' revision.page.id %}" class="button button-small button-secondary">{% trans 'Edit' %}</a></li>
-                                    {% endif %}
-                                    {% if revision.page.is_previewable %}
-                                        <li><a href="{% url 'wagtailadmin_pages:preview_for_moderation' revision.id %}" class="button button-small button-secondary" target="_blank" rel="noopener noreferrer">{% trans 'Preview' %}</a></li>
-                                    {% endif %}
-                                </ul>
-                            </td>
-                            <td valign="top">
-                                <a href="{% url 'wagtailadmin_explore' revision.page.get_parent.id %}">{{ revision.page.get_parent.get_admin_display_title }}</a>
-                            </td>
-                            <td class="type" valign="top">
-                                {{ revision.page.content_type.model_class.get_verbose_name }}
-                            </td>
-                            <td valign="top">
-                                <div class="human-readable-date" title="{{ revision.created_at|date:"d M Y H:i" }}">{% blocktrans with time_period=revision.created_at|timesince %}{{ time_period }} ago{% endblocktrans %} </div>
-                                {% if revision.user %}
-                                    by {{ revision.user.get_full_name|default:revision.user.get_username }}
+                        <td class="title" valign="top">
+                            <div class="title-wrapper">
+                                {% if page_perms.can_edit %}
+                                    <a href="{% url 'wagtailadmin_pages:edit' revision.page.id %}" title="{% trans 'Edit this page' %}">{{ revision.page.get_admin_display_title }}</a>
+                                {% elif revision.page.is_previewable %}
+                                    <a href="{% url 'wagtailadmin_pages:preview_for_moderation' revision.id %}" title="{% trans 'Preview this page' %}">{{ revision.page.get_admin_display_title }}</a>
+                                {% else %}
+                                    {{ revision.page.get_admin_display_title }}
                                 {% endif %}
-                            </td>
-                        </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
-        </section>
+
+                                {% include "wagtailadmin/pages/listing/_privacy_indicator.html" with page=revision.page %}
+                                {% include "wagtailadmin/pages/listing/_locked_indicator.html" with page=revision.page %}
+                            </div>
+                            <ul class="actions">
+                                <li>
+                                     <form action="{% url 'wagtailadmin_pages:approve_moderation' revision.id %}" method="POST">
+                                        {% csrf_token %}
+                                        <input type="submit" class="button button-small button-secondary" value="{% trans 'Approve' %}">
+                                    </form>
+                                </li>
+                                <li class="no-border">
+                                    <form action="{% url 'wagtailadmin_pages:reject_moderation' revision.id %}" method="POST">
+                                        {% csrf_token %}
+                                        <input type="submit" class="button button-small button-secondary no" value="{% trans 'Reject' %}">
+                                    </form>
+                                </li>
+                                {% if page_perms.can_edit %}
+                                    <li><a href="{% url 'wagtailadmin_pages:edit' revision.page.id %}" class="button button-small button-secondary">{% trans 'Edit' %}</a></li>
+                                {% endif %}
+                                {% if revision.page.is_previewable %}
+                                    <li><a href="{% url 'wagtailadmin_pages:preview_for_moderation' revision.id %}" class="button button-small button-secondary" target="_blank" rel="noopener noreferrer">{% trans 'Preview' %}</a></li>
+                                {% endif %}
+                            </ul>
+                        </td>
+                        <td valign="top">
+                            <a href="{% url 'wagtailadmin_explore' revision.page.get_parent.id %}">{{ revision.page.get_parent.get_admin_display_title }}</a>
+                        </td>
+                        <td class="type" valign="top">
+                            {{ revision.page.content_type.model_class.get_verbose_name }}
+                        </td>
+                        <td valign="top">
+                            <div class="human-readable-date" title="{{ revision.created_at|date:"d M Y H:i" }}">{% blocktrans with time_period=revision.created_at|timesince %}{{ time_period }} ago{% endblocktrans %} </div>
+                            {% if revision.user %}
+                                by {{ revision.user.get_full_name|default:revision.user.get_username }}
+                            {% endif %}
+                        </td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
     </div>
+</section>
 {% endif %}

--- a/wagtail/admin/templates/wagtailadmin/home/pages_for_moderation.html
+++ b/wagtail/admin/templates/wagtailadmin/home/pages_for_moderation.html
@@ -61,7 +61,7 @@
                             {{ revision.page.content_type.model_class.get_verbose_name }}
                         </td>
                         <td valign="top">
-                            <div class="human-readable-date" title="{{ revision.created_at|date:"d M Y H:i" }}">{% blocktrans with time_period=revision.created_at|timesince %}{{ time_period }} ago{% endblocktrans %} </div>
+                            <div class="human-readable-date" title="{{ revision.created_at|date:"d M Y H:i" }}">{% blocktrans with time_period=revision.created_at|timesince_simple %}{{ time_period }}{% endblocktrans %} </div>
                             {% if revision.user %}
                                 by {{ revision.user.get_full_name|default:revision.user.get_username }}
                             {% endif %}

--- a/wagtail/admin/templates/wagtailadmin/home/recent_edits.html
+++ b/wagtail/admin/templates/wagtailadmin/home/recent_edits.html
@@ -1,51 +1,51 @@
 {% load i18n wagtailadmin_tags %}
 {% if last_edits %}
-    <div class="panel nice-padding">{# TODO try moving these classes onto the section tag #}
-        <section>
-            <h2>{% trans "Your most recent edits" %}</h2>
-            <table class="listing listing-page">
-                <col />
-                <col width="15%"/>
-                <col width="15%"/>
-                <thead>
+<section class="object collapsible">
+    <h2 class="title-wrapper">{% trans "Your most recent edits" %}</h2>
+    <div class="object-layout">
+        <table class="listing listing-page">
+            <col />
+            <col width="30%"/>
+            <col width="15%"/>
+            <thead>{# Note: the header is visually hidden behind .title-wrapper #}
+                <tr>
+                    <th class="title">{% trans "Title" %}</th>
+                    <th>{% trans "Status" %}</th>
+                    <th>{% trans "Date" %}</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for revision, page in last_edits %}
                     <tr>
-                        <th class="title">{% trans "Title" %}</th>
-                        <th>{% trans "Date" %}</th>
-                        <th>{% trans "Status" %}</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {% for revision, page in last_edits %}
-                        <tr>
-                            <td class="title" valign="top">
-                                <div class="title-wrapper">
-                                    <a href="{% url 'wagtailadmin_pages:edit' page.id %}" title="{% trans 'Edit this page' %}">{{ page.get_admin_display_title }}</a>
+                        <td class="title" valign="top">
+                            <div class="title-wrapper">
+                                <a href="{% url 'wagtailadmin_pages:edit' page.id %}" title="{% trans 'Edit this page' %}">{{ page.get_admin_display_title }}</a>
 
-                                    {% include "wagtailadmin/pages/listing/_privacy_indicator.html" with page=page %}
-                                    {% include "wagtailadmin/pages/listing/_locked_indicator.html" with page=page %}
-                                </div>
-                                <ul class="actions">
-                                    <li><a href="{% url 'wagtailadmin_pages:edit' page.id %}" class="button button-small button-secondary">{% trans "Edit" %}</a></li>
-                                    {% if page.has_unpublished_changes and page.is_previewable %}
-                                        <li><a href="{% url 'wagtailadmin_pages:view_draft' page.id %}" class="button button-small button-secondary" target="_blank" rel="noopener noreferrer">{% trans 'Draft' %}</a></li>
-                                    {% endif %}
-                                    {% if page.live %}
-                                        {% with page_url=page.url %}
-                                            {% if page_url is not None %}
-                                                <li><a href="{{ page_url }}" class="button button-small button-secondary" target="_blank" rel="noopener noreferrer">{% trans 'Live' %}</a></li>
-                                            {% endif %}
-                                        {% endwith %}
-                                    {% endif %}
-                                </ul>
-                            </td>
-                            <td valign="top"><div class="human-readable-date" title="{{ revision.created_at|date:"d M Y H:i" }}">{% blocktrans with time_period=revision.created_at|timesince %}{{ time_period }} ago{% endblocktrans %}</div></td>
-                            <td valign="top">
-                                {% include "wagtailadmin/shared/page_status_tag.html" with page=page %}
-                            </td>
-                        </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
-        </section>
+                                {% include "wagtailadmin/pages/listing/_privacy_indicator.html" with page=page %}
+                                {% include "wagtailadmin/pages/listing/_locked_indicator.html" with page=page %}
+                            </div>
+                            <ul class="actions">
+                                <li><a href="{% url 'wagtailadmin_pages:edit' page.id %}" class="button button-small button-secondary">{% trans "Edit" %}</a></li>
+                                {% if page.has_unpublished_changes and page.is_previewable %}
+                                    <li><a href="{% url 'wagtailadmin_pages:view_draft' page.id %}" class="button button-small button-secondary" target="_blank" rel="noopener noreferrer">{% trans 'Draft' %}</a></li>
+                                {% endif %}
+                                {% if page.live %}
+                                    {% with page_url=page.url %}
+                                        {% if page_url is not None %}
+                                            <li><a href="{{ page_url }}" class="button button-small button-secondary" target="_blank" rel="noopener noreferrer">{% trans 'Live' %}</a></li>
+                                        {% endif %}
+                                    {% endwith %}
+                                {% endif %}
+                            </ul>
+                        </td>
+                        <td valign="top">
+                            {% include "wagtailadmin/shared/page_status_tag.html" with page=page %}
+                        </td>
+                        <td valign="top"><div class="human-readable-date" title="{{ revision.created_at|date:"d M Y H:i" }}">{% blocktrans with time_period=revision.created_at|timesince %}{{ time_period }} ago{% endblocktrans %}</div></td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
     </div>
+</section>
 {% endif %}

--- a/wagtail/admin/templates/wagtailadmin/home/recent_edits.html
+++ b/wagtail/admin/templates/wagtailadmin/home/recent_edits.html
@@ -41,7 +41,7 @@
                         <td valign="top">
                             {% include "wagtailadmin/shared/page_status_tag.html" with page=page %}
                         </td>
-                        <td valign="top"><div class="human-readable-date" title="{{ revision.created_at|date:"d M Y H:i" }}">{% blocktrans with time_period=revision.created_at|timesince %}{{ time_period }} ago{% endblocktrans %}</div></td>
+                        <td valign="top"><div class="human-readable-date" title="{{ revision.created_at|date:"d M Y H:i" }}">{% blocktrans with time_period=revision.created_at|timesince_simple %}{{ time_period }}{% endblocktrans %}</div></td>
                     </tr>
                 {% endfor %}
             </tbody>

--- a/wagtail/admin/templates/wagtailadmin/home/user_pages_in_workflow_moderation.html
+++ b/wagtail/admin/templates/wagtailadmin/home/user_pages_in_workflow_moderation.html
@@ -15,33 +15,33 @@
             </tr>
         </thead>
         <tbody>
-            {% for state in workflow_states %}
-                {% with state.current_task_state.page_revision as revision %}
-                {% page_permissions state.page as page_perms %}
+            {% for workflow_state in workflow_states %}
+                {% with workflow_state.current_task_state.page_revision as revision %}
+                {% page_permissions workflow_state.page as page_perms %}
                 <tr>
                     <td class="title" valign="top">
                         <div class="title-wrapper">
                             {% if page_perms.can_edit %}
-                                <a href="{% url 'wagtailadmin_pages:edit' state.page.id %}" title="{% trans 'Edit this page' %}">{{ state.page.get_admin_display_title }}</a>
+                                <a href="{% url 'wagtailadmin_pages:edit' workflow_state.page.id %}" title="{% trans 'Edit this page' %}">{{ workflow_state.page.get_admin_display_title }}</a>
                             {% else %}
-                                {{ state.page.get_admin_display_title }}
+                                {{ workflow_state.page.get_admin_display_title }}
                             {% endif %}
 
-                            {% include "wagtailadmin/pages/listing/_privacy_indicator.html" with page=state.page %}
-                            {% include "wagtailadmin/pages/listing/_locked_indicator.html" with page=state.page %}
+                            {% include "wagtailadmin/pages/listing/_privacy_indicator.html" with page=workflow_state.page %}
+                            {% include "wagtailadmin/pages/listing/_locked_indicator.html" with page=workflow_state.page %}
                         </div>
                     </td>
                     <td class="task" valign="top">
-                        {% if state.current_task_state.status == 'rejected' %}
+                        {% if workflow_state.current_task_state.status == 'rejected' %}
                             {% icon name="warning" class_name="uniform" %}
                             {% trans "Changes requested at" %}
-                        {% elif state.current_task_state.status == 'in_progress' %}
+                        {% elif workflow_state.current_task_state.status == 'in_progress' %}
                             {% trans "Awaiting" %}
                         {% endif %}
-                        {{ state.current_task_state.task.name }}
+                        {{ workflow_state.current_task_state.task.name }}
                     </td>
                     <td valign="top">
-                        <div class="human-readable-date" title="{{ state.current_task_state.task_type_started_at|date:"d M Y H:i" }}">{% blocktrans with time_period=state.current_task_state.task_type_started_at|timesince_simple %}{{ time_period }}{% endblocktrans %} </div>
+                        <div class="human-readable-date" title="{{ workflow_state.current_task_state.started_at|date:"d M Y H:i" }}">{% blocktrans with time_period=workflow_state.current_task_state.started_at|timesince_simple %}{{ time_period }}{% endblocktrans %} </div>
                     </td>
                 </tr>
                 {% endwith %}

--- a/wagtail/admin/templates/wagtailadmin/home/user_pages_in_workflow_moderation.html
+++ b/wagtail/admin/templates/wagtailadmin/home/user_pages_in_workflow_moderation.html
@@ -41,7 +41,7 @@
                         {{ state.current_task_state.task.name }}
                     </td>
                     <td valign="top">
-                        <div class="human-readable-date" title="{{ state.current_task_state.task_type_started_at|date:"d M Y H:i" }}">{% blocktrans with time_period=state.current_task_state.task_type_started_at|timesince %}{{ time_period }} ago{% endblocktrans %} </div>
+                        <div class="human-readable-date" title="{{ state.current_task_state.task_type_started_at|date:"d M Y H:i" }}">{% blocktrans with time_period=state.current_task_state.task_type_started_at|timesince_simple %}{{ time_period }}{% endblocktrans %} </div>
                     </td>
                 </tr>
                 {% endwith %}

--- a/wagtail/admin/templates/wagtailadmin/home/user_pages_in_workflow_moderation.html
+++ b/wagtail/admin/templates/wagtailadmin/home/user_pages_in_workflow_moderation.html
@@ -1,52 +1,53 @@
 {% load i18n wagtailadmin_tags %}
 {% if workflow_states %}
-    <div class="panel nice-padding">{# TODO try moving these classes onto the section tag #}
-        <section>
-            <h2>{% trans 'Your pages in workflow moderation' %}</h2>
-            <table class="listing">
-                <col />
-                <col width="30%"/>
-                <col width="15%"/>
-                <col width="15%"/>
-                <thead>
-                    <tr>
-                        <th class="title">{% trans "Title" %}</th>
-                        <th>{% trans "Task" %}</th>
-                        <th>{% trans "Task started" %}</th>
-                        <th>{% trans "Edited" %}</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {% for state in workflow_states %}
-                        {% with state.current_task_state.page_revision as revision %}
-                        {% page_permissions state.page as page_perms %}
-                        <tr>
-                            <td class="title" valign="top">
-                                <div class="title-wrapper">
-                                    {% if page_perms.can_edit %}
-                                        <a href="{% url 'wagtailadmin_pages:edit' state.page.id %}" title="{% trans 'Edit this page' %}">{{ state.page.get_admin_display_title }}</a>
-                                    {% else %}
-                                        {{ state.page.get_admin_display_title }}
-                                    {% endif %}
+<section class="object collapsible">
+    <h2 class="title-wrapper">{% trans 'Your pages in a workflow' %}</h2>
+    <div class="object-layout">
+        <table class="listing">
+        <col />
+        <col width="30%"/>
+        <col width="15%"/>
+        <thead>{# Note: the header is visually hidden behind .title-wrapper #}
+            <tr>
+                <th class="title">{% trans "Title" %}</th>
+                <th>{% trans "Task" %}</th>
+                <th>{% trans "Task started" %}</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for state in workflow_states %}
+                {% with state.current_task_state.page_revision as revision %}
+                {% page_permissions state.page as page_perms %}
+                <tr>
+                    <td class="title" valign="top">
+                        <div class="title-wrapper">
+                            {% if page_perms.can_edit %}
+                                <a href="{% url 'wagtailadmin_pages:edit' state.page.id %}" title="{% trans 'Edit this page' %}">{{ state.page.get_admin_display_title }}</a>
+                            {% else %}
+                                {{ state.page.get_admin_display_title }}
+                            {% endif %}
 
-                                    {% include "wagtailadmin/pages/listing/_privacy_indicator.html" with page=state.page %}
-                                    {% include "wagtailadmin/pages/listing/_locked_indicator.html" with page=state.page %}
-                                </div>
-                            </td>
-                            <td class="task" valign="top">
-                                {{ state.current_task_state.task.name }}
-                            </td>
-                            <td valign="top">
-                                <div class="human-readable-date" title="{{ state.current_task_state.task_type_started_at|date:"d M Y H:i" }}">{% blocktrans with time_period=state.current_task_state.task_type_started_at|timesince %}{{ time_period }} ago{% endblocktrans %} </div>
-                            </td>
-                            <td valign="top">
-                                <div class="human-readable-date" title="{{ revision.created_at|date:"d M Y H:i" }}">{% blocktrans with time_period=revision.created_at|timesince %}{{ time_period }} ago{% endblocktrans %} </div>
-                            </td>
-                        </tr>
-                        {% endwith %}
-                    {% endfor %}
-                </tbody>
-            </table>
-        </section>
+                            {% include "wagtailadmin/pages/listing/_privacy_indicator.html" with page=state.page %}
+                            {% include "wagtailadmin/pages/listing/_locked_indicator.html" with page=state.page %}
+                        </div>
+                    </td>
+                    <td class="task" valign="top">
+                        {% if state.current_task_state.status == 'rejected' %}
+                            {% icon name="warning" class_name="uniform" %}
+                            {% trans "Changes requested at" %}
+                        {% elif state.current_task_state.status == 'in_progress' %}
+                            {% trans "Awaiting" %}
+                        {% endif %}
+                        {{ state.current_task_state.task.name }}
+                    </td>
+                    <td valign="top">
+                        <div class="human-readable-date" title="{{ state.current_task_state.task_type_started_at|date:"d M Y H:i" }}">{% blocktrans with time_period=state.current_task_state.task_type_started_at|timesince %}{{ time_period }} ago{% endblocktrans %} </div>
+                    </td>
+                </tr>
+                {% endwith %}
+            {% endfor %}
+        </tbody>
+    </table>
     </div>
+</section>
 {% endif %}

--- a/wagtail/admin/templates/wagtailadmin/home/workflow_pages_to_moderate.html
+++ b/wagtail/admin/templates/wagtailadmin/home/workflow_pages_to_moderate.html
@@ -62,7 +62,7 @@
                                 {% endfor %}
                             </td>
                             <td valign="top">
-                                <div class="human-readable-date" title="{{ state.task_type_started_at|date:"d M Y H:i" }}">{% blocktrans with time_period=state.task_type_started_at|timesince %}{{ time_period }} ago{% endblocktrans %} </div>
+                                <div class="human-readable-date" title="{{ state.task_type_started_at|date:"d M Y H:i" }}">{% blocktrans with time_period=state.task_type_started_at|timesince_simple %}{{ time_period }}{% endblocktrans %} </div>
                             </td>
                         </tr>
                         {% endwith %}

--- a/wagtail/admin/templates/wagtailadmin/home/workflow_pages_to_moderate.html
+++ b/wagtail/admin/templates/wagtailadmin/home/workflow_pages_to_moderate.html
@@ -1,23 +1,21 @@
 {% load i18n wagtailadmin_tags %}
 {% if states %}
-    <div class="panel nice-padding">{# TODO try moving these classes onto the section tag #}
-        <section>
-            <h2>{% trans 'Pages you can moderate' %}</h2>
+<section class="object collapsible">
+    <h2 class="title-wrapper">{% trans 'Awaiting your review' %}</h2>
+        <div class="object-layout">
             <table class="listing">
                 <col />
                 <col width="30%"/>
                 <col width="15%"/>
-                <col width="15%"/>
-                <thead>
+                <thead>{# Note: the header is visually hidden behind .title-wrapper #}
                     <tr>
                         <th class="title">{% trans "Title" %}</th>
-                        <th>{% trans "Task" %}</th>
+                        <th>{% trans "Tasks" %}</th>
                         <th>{% trans "Task started" %}</th>
-                        <th>{% trans "Edited" %}</th>
                     </tr>
                 </thead>
                 <tbody>
-                    {% for state, actions in states %}
+                    {% for state, actions, workflow_tasks in states %}
                         {% with state.page_revision as revision %}
                         {% page_permissions revision.page as page_perms %}
                         <tr>
@@ -50,25 +48,45 @@
                                     </ul>
                                 {% endif %}
                             </td>
-                            <td class="task" valign="top">
-                                {{ state.task.name }}
+                            <td class="tasks" valign="top">
+                                {% for task in workflow_tasks %}
+                                    <span data-wagtail-tooltip="{{ task.name }}: {{ task.status_display }}">
+                                        {% if task.status == 'approved' %}
+                                            {% icon "success" title=task.status_display class_name="uniform" %}
+                                        {% elif task.status == 'rejected' %}
+                                            {% icon "error" title=task.status_display class_name="uniform" %}
+                                        {% else %}
+                                            {% icon "radio-empty" title=status_display class_name="uniform" %}
+                                        {% endif %}
+                                    </span>
+                                {% endfor %}
                             </td>
                             <td valign="top">
-                                <div class="human-readable-date" title="{{ state_type_started_at|date:"d M Y H:i" }}">{% blocktrans with time_period=state.task_type_started_at|timesince %}{{ time_period }} ago{% endblocktrans %} </div>
-                            </td>
-                            <td valign="top">
-                                <div class="human-readable-date" title="{{ revision.created_at|date:"d M Y H:i" }}">{% blocktrans with time_period=revision.created_at|timesince %}{{ time_period }} ago{% endblocktrans %} </div>
+                                <div class="human-readable-date" title="{{ state.task_type_started_at|date:"d M Y H:i" }}">{% blocktrans with time_period=state.task_type_started_at|timesince %}{{ time_period }} ago{% endblocktrans %} </div>
                             </td>
                         </tr>
                         {% endwith %}
                     {% endfor %}
                 </tbody>
             </table>
-        </section>
-    </div>
+        </div>
+</section>
+
     <script src="{% versioned_static 'wagtailadmin/js/modal-workflow.js' %}"></script>
     <script src="{% versioned_static 'wagtailadmin/js/workflow-action.js' %}"></script>
+    <script src="{% versioned_static 'wagtailadmin/js/vendor/bootstrap-tooltip.js' %}"></script>
     <script>
         document.addEventListener('DOMContentLoaded', ActivateWorkflowActions('{{ csrf_token|escapejs }}'));
+        /* Tooltips used by the workflow status component */
+        $(function() {
+            $('[data-wagtail-tooltip]').tooltip({
+                animation: false,
+                title: function() {
+                    return $(this).attr('data-wagtail-tooltip');
+                },
+                trigger: 'hover',
+                placement: 'bottom',
+            });
+        });
     </script>
 {% endif %}

--- a/wagtail/admin/templates/wagtailadmin/home/workflow_pages_to_moderate.html
+++ b/wagtail/admin/templates/wagtailadmin/home/workflow_pages_to_moderate.html
@@ -15,8 +15,8 @@
                     </tr>
                 </thead>
                 <tbody>
-                    {% for state, actions, workflow_tasks in states %}
-                        {% with state.page_revision as revision %}
+                    {% for task_state, actions, workflow_tasks in states %}
+                        {% with task_state.page_revision as revision %}
                         {% page_permissions revision.page as page_perms %}
                         <tr>
                             <td class="title" valign="top">
@@ -34,7 +34,7 @@
                                     <ul class="actions">
                                         {% for action_name, action_label, modal in actions %}
                                             <li>
-                                                <button class="button button-small button-secondary" data-workflow-action-url="{% url 'wagtailadmin_pages:workflow_action' revision.page.id action_name state.id %}" {% if modal %}data-launch-modal{% endif %}>{{ action_label }}</button>
+                                                <button class="button button-small button-secondary" data-workflow-action-url="{% url 'wagtailadmin_pages:workflow_action' revision.page.id action_name task_state.id %}" {% if modal %}data-launch-modal{% endif %}>{{ action_label }}</button>
                                             </li>
                                         {% endfor %}
                                         {% if page_perms.can_edit %}
@@ -43,7 +43,7 @@
                                             </li>
                                         {% endif %}
                                         <li>
-                                            <a href="{% url 'wagtailadmin_pages:workflow_preview' revision.page.id state.task.id %}" class="button button-small button-secondary">{% trans 'Preview' %}</a>
+                                            <a href="{% url 'wagtailadmin_pages:workflow_preview' revision.page.id task_state.task.id %}" class="button button-small button-secondary">{% trans 'Preview' %}</a>
                                         </li>
                                     </ul>
                                 {% endif %}
@@ -62,7 +62,7 @@
                                 {% endfor %}
                             </td>
                             <td valign="top">
-                                <div class="human-readable-date" title="{{ state.task_type_started_at|date:"d M Y H:i" }}">{% blocktrans with time_period=state.task_type_started_at|timesince_simple %}{{ time_period }}{% endblocktrans %} </div>
+                                <div class="human-readable-date" title="{{ task_state.started_at|date:"d M Y H:i" }}">{% blocktrans with time_period=task_state.started_at|timesince_simple %}{{ time_period }}{% endblocktrans %}</div>
                             </td>
                         </tr>
                         {% endwith %}

--- a/wagtail/admin/templates/wagtailadmin/pages/edit.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/edit.html
@@ -141,7 +141,7 @@
                 trigger: 'hover',
                 placement: 'bottom',
             });
-        })
+        });
 
         $(function() {
             document.addEventListener('DOMContentLoaded', ActivateWorkflowActions('{{ csrf_token|escapejs }}'));

--- a/wagtail/admin/templates/wagtailadmin/workflows/includes/workflow_tasks_with_status.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/includes/workflow_tasks_with_status.html
@@ -1,0 +1,12 @@
+{% load wagtailadmin_tags %}
+{% for task in workflow_tasks %}
+    <span data-wagtail-tooltip="{{ task.name }}: {{ task.status_display }}">
+        {% if task.status == 'approved' %}
+            {% icon name="success" title=task.status_display class_name="uniform" %}
+        {% elif task.status == 'rejected' %}
+            {% icon name="failure" title=task.status_display class_name="uniform" %}
+        {% else %}
+            {% icon name="radio-empty" title=incomplete_title|default:status_display class_name="uniform" %}
+        {% endif %}
+    </span>
+{% endfor %}

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -11,9 +11,10 @@ from django.contrib.messages.constants import DEFAULT_TAGS as MESSAGE_TAGS
 from django.template.defaultfilters import stringfilter
 from django.template.loader import render_to_string
 from django.templatetags.static import static
-from django.utils.html import format_html, format_html_join
+from django.utils.html import avoid_wrapping, format_html, format_html_join
 from django.utils.http import urlencode
 from django.utils.safestring import mark_safe
+from django.utils.timesince import timesince
 from django.utils.translation import gettext_lazy as _
 
 from wagtail.admin.localization import get_js_translation_strings
@@ -535,3 +536,17 @@ def icons():
     icon_hooks = hooks.get_hooks('register_icons')
     icons = sorted(itertools.chain.from_iterable(hook([]) for hook in icon_hooks))
     return {'icons': icons}
+
+
+@register.filter()
+def timesince_simple(d):
+    """
+    Returns a simplified timesince:
+    19 hours, 48 minutes ago -> 19 hours ago
+    1 week, 1 day ago -> 1 week ago
+    0 minutes ago -> just now
+    """
+    time_period = timesince(d).split(',')[0]
+    if time_period == avoid_wrapping(_('0 minutes')):
+        return _("Just now")
+    return _("%(time_period)s ago" % {'time_period': time_period})

--- a/wagtail/admin/tests/test_templatetags.py
+++ b/wagtail/admin/tests/test_templatetags.py
@@ -1,11 +1,15 @@
+from datetime import timedelta
 from unittest import mock
 
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 from django.test.utils import override_settings
+from django.utils import timezone
+from freezegun import freeze_time
 
 from wagtail.admin.staticfiles import versioned_static
-from wagtail.admin.templatetags.wagtailadmin_tags import avatar_url, notification_static
+from wagtail.admin.templatetags.wagtailadmin_tags import (
+    avatar_url, notification_static, timesince_simple)
 from wagtail.images.tests.utils import get_test_image_file
 from wagtail.users.models import UserProfile
 
@@ -83,3 +87,17 @@ class TestVersionedStatic(TestCase):
     def test_versioned_static_url(self):
         result = versioned_static('http://example.org/static/wagtailadmin/js/core.js')
         self.assertEqual(result, 'http://example.org/static/wagtailadmin/js/core.js')
+
+
+@freeze_time("2020-07-01 12:00:00")
+class TestTimesinceTags(TestCase):
+    def test_timesince_simple(self):
+        now = timezone.now()
+        ts = timesince_simple(now)
+        self.assertEqual(ts, "Just now")
+
+        ts = timesince_simple(now - timedelta(hours=1, minutes=10))
+        self.assertEqual(ts, "1\xa0hour ago")
+
+        ts = timesince_simple(now - timedelta(weeks=2, hours=1, minutes=10))
+        self.assertEqual(ts, "2\xa0weeks ago")


### PR DESCRIPTION
This PR:
- brings the admin home dashboard panels more in line with the edit panels.
- updates the panel heading text, and order
- adds an unlock button for the locked pages
- sorts the workflow-related items descending
- simplifies the workflow-related columns for consistency
- includes task progreesion for pages awaiting review and adds a visual indicator for any items that require changes

<details>
<summary>See screenshot</summary>
<img src="https://user-images.githubusercontent.com/31622/86461558-12319b00-bd22-11ea-819c-66638dd9019b.png" />
</details
