### PR TITLE
move import of Site to avoid error when wagtail.contrib.sitemaps is in INSTALLED_APPS

### DIFF
--- a/wagtail/contrib/sitemaps/sitemap_generator.py
+++ b/wagtail/contrib/sitemaps/sitemap_generator.py
@@ -1,5 +1,9 @@
 from django.contrib.sitemaps import Sitemap as DjangoSitemap
-from wagtail.core.models import Site
+
+# Note: avoid importing models here. This module is imported from __init__.py
+# which causes it to be loaded early in startup if wagtail.contrib.sitemaps is
+# included in INSTALLED_APPS (not required, but developers are likely to add it
+# anyhow) leading to an AppRegistryNotReady exception.
 
 
 class Sitemap(DjangoSitemap):
@@ -16,6 +20,7 @@ class Sitemap(DjangoSitemap):
         return (obj.last_published_at or obj.latest_revision_created_at)
 
     def get_wagtail_site(self):
+        from wagtail.core.models import Site
         site = Site.find_for_request(self.request)
         if site is None:
             return Site.objects.select_related(


### PR DESCRIPTION
The sitemap_generator module is imported from `wagtail/contrib/sitemaps/__init__.py`, which causes it to be imported immediately if wagtail.contrib.sitemaps is in INSTALLED_APPS (which is not required or part of the setup docs, but is something people are understandably likely to do). This is too early in startup to import models, and fails with an AppRegistryNotReady exception.

There's probably a good case for not having that import in `__init__.py`, but some code/docs in the wild relies on it (e.g. https://stackoverflow.com/questions/44681046/how-to-join-wagtail-and-django-sitemaps), so better to leave it in for now.