### PR TITLE
Django 3.1 compatibility fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ matrix:
      python: 3.8
    - env: TOXENV=py38-dj30stable-postgres-noelasticsearch
      python: 3.8
+   - env: TOXENV=py38-dj31stable-postgres-noelasticsearch
+     python: 3.8
    - env: TOXENV=py38-djmaster-postgres-noelasticsearch
      python: 3.8
    - env: TOXENV=py36-dj22-sqlite-elasticsearch2 INSTALL_ELASTICSEARCH2=yes
@@ -40,9 +42,9 @@ matrix:
     - env: TOXENV=py37-dj22-postgres-elasticsearch6 INSTALL_ELASTICSEARCH6=yes
     - env: TOXENV=py38-dj22-postgres-elasticsearch7 INSTALL_ELASTICSEARCH7=yes
     - env: TOXENV=py38-dj30-postgres-elasticsearch7 INSTALL_ELASTICSEARCH7=yes
-    # allow failures against Django 3.0.x stable branch
+    # allow failures against Django pre-releases on git
     - env: TOXENV=py38-dj30stable-postgres-noelasticsearch
-    # allow failures against Django master
+    - env: TOXENV=py38-dj31stable-postgres-noelasticsearch
     - env: TOXENV=py38-djmaster-postgres-noelasticsearch
 
 # Services

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 skipsdist = True
 usedevelop = True
 
-envlist = py{35,36,37}-dj{22,30,30stable,master}-{sqlite,postgres,mysql,mssql}-{elasticsearch7,elasticsearch6,elasticsearch5,elasticsearch2,noelasticsearch},
+envlist = py{35,36,37}-dj{22,30,30stable,31stable,master}-{sqlite,postgres,mysql,mssql}-{elasticsearch7,elasticsearch6,elasticsearch5,elasticsearch2,noelasticsearch},
 
 [testenv]
 install_command = pip install -e ".[testing]" -U {opts} {packages}
@@ -26,9 +26,10 @@ deps =
     dj22: Django>=2.2,<2.3
     dj30: Django>=3.0,<3.1
     dj30stable: git+https://github.com/django/django.git@stable/3.0.x#egg=Django
-    dj30stable: git+https://github.com/wagtail/django-modelcluster.git
+    dj31stable: git+https://github.com/django/django.git@stable/3.1.x#egg=Django
+    dj31stable: git+https://github.com/encode/django-rest-framework.git
     djmaster: git+https://github.com/django/django.git@master#egg=Django
-    djmaster: git+https://github.com/wagtail/django-modelcluster.git
+    djmaster: git+https://github.com/encode/django-rest-framework.git
 
     postgres: psycopg2>=2.6
     mysql: mysqlclient>=1.3.7,<1.4

--- a/wagtail/admin/tests/tests.py
+++ b/wagtail/admin/tests/tests.py
@@ -2,6 +2,7 @@
 
 import json
 
+from django import VERSION as DJANGO_VERSION
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group, Permission
 from django.core import mail
@@ -32,10 +33,19 @@ class TestHome(TestCase, WagtailTestUtils):
         response = self.client.get(reverse('wagtailadmin_home'))
         self.assertEqual(response.status_code, 200)
         # check that media attached to menu items is correctly pulled in
-        self.assertContains(
-            response,
-            '<script type="text/javascript" src="/static/testapp/js/kittens.js"></script>'
-        )
+        if DJANGO_VERSION >= (3, 1):
+            self.assertContains(
+                response,
+                '<script src="/static/testapp/js/kittens.js"></script>',
+                html=True
+            )
+        else:
+            self.assertContains(
+                response,
+                '<script type="text/javascript" src="/static/testapp/js/kittens.js"></script>',
+                html=True
+            )
+
         # check that custom menu items (including classname / attrs parameters) are pulled in
         self.assertContains(
             response,

--- a/wagtail/admin/urls/password_reset.py
+++ b/wagtail/admin/urls/password_reset.py
@@ -1,4 +1,4 @@
-from django.urls import path, re_path
+from django.urls import path
 
 from wagtail.admin.views import account
 
@@ -9,8 +9,8 @@ urlpatterns = [
     path(
         'done/', account.PasswordResetDoneView.as_view(), name='wagtailadmin_password_reset_done'
     ),
-    re_path(
-        r'^confirm/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})/$',
+    path(
+        'confirm/<uidb64>/<token>/',
         account.PasswordResetConfirmView.as_view(), name='wagtailadmin_password_reset_confirm',
     ),
     path(

--- a/wagtail/contrib/postgres_search/backend.py
+++ b/wagtail/contrib/postgres_search/backend.py
@@ -2,6 +2,7 @@ import warnings
 from collections import OrderedDict
 from functools import reduce
 
+from django import VERSION as DJANGO_VERSION
 from django.contrib.postgres.search import SearchQuery, SearchRank, SearchVector
 from django.db import DEFAULT_DB_ALIAS, NotSupportedError, connections, transaction
 from django.db.models import Avg, Count, F, Manager, Q, TextField, Value
@@ -361,7 +362,10 @@ class PostgresSearchQueryCompiler(BaseSearchQueryCompiler):
                 else:
                     lexemes |= new_lexeme
 
-            return RawSearchQuery(lexemes, config=config)
+            if DJANGO_VERSION >= (3, 1):
+                return SearchQuery(lexemes, search_type='raw', config=config)
+            else:
+                return RawSearchQuery(lexemes, config=config)
 
         elif isinstance(query, Phrase):
             return SearchQuery(query.query_string, search_type='phrase')

--- a/wagtail/users/templatetags/wagtailusers_tags.py
+++ b/wagtail/users/templatetags/wagtailusers_tags.py
@@ -1,5 +1,6 @@
 import itertools
 
+from django import VERSION as DJANGO_VERSION
 from django import template
 
 from wagtail.core import hooks
@@ -29,8 +30,7 @@ def format_permissions(permission_bound_field):
         ]
 
         (where 'checkbox' is an object with a tag() method that renders the checkbox as HTML;
-        this is an instance of django.forms.widgets.CheckboxChoiceInput on Django <1.11,
-        and a BoundWidget on Django >=1.11)
+        this is a BoundWidget on Django >=1.11)
 
         - and returns a table template formatted with this list.
 
@@ -41,10 +41,18 @@ def format_permissions(permission_bound_field):
 
     # iterate over permission_bound_field to build a lookup of individual renderable
     # checkbox objects
-    checkboxes_by_id = {
-        int(checkbox.data['value']): checkbox
-        for checkbox in permission_bound_field
-    }
+    if DJANGO_VERSION < (3, 1):
+        # checkbox.data['value'] gives the ID
+        checkboxes_by_id = {
+            int(checkbox.data['value']): checkbox
+            for checkbox in permission_bound_field
+        }
+    else:
+        # checkbox.data['value'] gives a ModelChoiceIteratorValue
+        checkboxes_by_id = {
+            int(checkbox.data['value'].value): checkbox
+            for checkbox in permission_bound_field
+        }
 
     object_perms = []
     other_perms = []


### PR DESCRIPTION
Add Django's stable/3.1.x branch to tests in preparation for the 3.1 release, and apply the fairly simple fixes to get them passing again.

django-rest-framework requires additional fixes, which are in master but not yet released.