### PR TITLE
Add support for natural keys to group collection permissions for use in fixtures

### DIFF
--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -2324,6 +2324,13 @@ class CollectionMember(models.Model):
         abstract = True
 
 
+class GroupCollectionPermissionManager(models.Manager):
+    def get_by_natural_key(self, group, collection, permission):
+        return self.get(group=group,
+                        collection=collection,
+                        permission=permission)
+
+
 class GroupCollectionPermission(models.Model):
     """
     A rule indicating that a group has permission for some action (e.g. "create document")
@@ -2353,6 +2360,11 @@ class GroupCollectionPermission(models.Model):
             self.permission,
             self.collection.id, self.collection
         )
+
+    def natural_key(self):
+        return (self.group, self.collection, self.permission)
+
+    objects = GroupCollectionPermissionManager()
 
     class Meta:
         unique_together = ('group', 'collection', 'permission')


### PR DESCRIPTION
In working with Wagtail & Django's native fixture support, I've found that loading fixtures when using Sqlite3, as we do in our CI/CD environment, results in an integrity error:

```
sqlite3.IntegrityError: UNIQUE constraint failed: 
wagtailcore_groupcollectionpermission.group_id, 
wagtailcore_groupcollectionpermission.collection_id, 
wagtailcore_groupcollectionpermission.permission_id
```

This is the query that throws it:

```
query = 'UPDATE "wagtailcore_groupcollectionpermission" 
SET "group_id" = ?, "collection_id" = ?, "permission_id" = ? WHERE "wagtailcore_groupcollectionpermission"."id" = ?'
params = (1, 1, 1, 1)
```

Our workaround to date has been removing `wagtailcore.groupcollectionpermission` from wagtailcore fixtures. However, I have also found that adding support for natural foreign keys to GroupCollectionPermissions fixes this problem, when fixtures are exported with the `--natural-foreign` option. 

Because this change is only taking advantage of underlying, unused Django functionality, that is only used for generating & loading fixtures, I didn't write any new tests for it.

✅ tests pass
✅ `make lint` didn't complain