### PR TITLE
Model autocomplete widget

### DIFF
--- a/wagtail/admin/filters.py
+++ b/wagtail/admin/filters.py
@@ -1,11 +1,12 @@
 import django_filters
 from django import forms
+from django.contrib.auth import get_user_model
 from django.utils.translation import gettext_lazy as _
 from django_filters.widgets import SuffixedMultiWidget
 
 from wagtail.core.models import Page
 
-from .widgets import AdminDateInput
+from .widgets import AdminDateInput, AutocompleteWidget
 
 
 class ButtonSelect(forms.Select):
@@ -90,6 +91,11 @@ class WagtailFilterSet(django_filters.FilterSet):
 
 
 class LockedPagesReportFilterSet(WagtailFilterSet):
+    locked_by = django_filters.ModelChoiceFilter(
+        field_name='locked_by',
+        queryset=get_user_model().objects.all(),
+        widget=AutocompleteWidget(get_user_model(), lookup_field='username')
+    )
     locked_at = django_filters.DateFromToRangeFilter(widget=DateRangePickerWidget)
 
     class Meta:

--- a/wagtail/admin/filters.py
+++ b/wagtail/admin/filters.py
@@ -94,7 +94,7 @@ class LockedPagesReportFilterSet(WagtailFilterSet):
     locked_by = django_filters.ModelChoiceFilter(
         field_name='locked_by',
         queryset=get_user_model().objects.all(),
-        widget=AutocompleteWidget(get_user_model(), lookup_field='username')
+        widget=AutocompleteWidget(get_user_model(), lookup_fields='username')
     )
     locked_at = django_filters.DateFromToRangeFilter(widget=DateRangePickerWidget)
 

--- a/wagtail/admin/static_src/wagtailadmin/js/autocomplete.js
+++ b/wagtail/admin/static_src/wagtailadmin/js/autocomplete.js
@@ -1,7 +1,7 @@
 function hideAutocompleteSuggestions() {
   setTimeout(function() {
     $('.autocomplete-suggestions--active').removeClass('autocomplete-suggestions--active').attr('aria-hidden', true);
-  }, 100);
+  }, 200);
 }
 
 (function($) {

--- a/wagtail/admin/static_src/wagtailadmin/js/autocomplete.js
+++ b/wagtail/admin/static_src/wagtailadmin/js/autocomplete.js
@@ -1,0 +1,52 @@
+(function($) {
+  window.wagtailAutocomplete = function ($input) {
+    var lookupIndex = 0,
+      lookupNextIndex = 0,
+      newQuery = $input.val(),
+      currentQuery = $input.data('currentQuery') || '',
+      autocompleteUrl = $input.data('autocomplete-url'),
+      $suggestionsContainer = $('.autocomplete-suggestions', $input.parent());
+
+    $('li', $suggestionsContainer).on('click', function () {
+      var $selection = $(this),
+        $container = $selection.parent(),
+        $target = $('#' + $container.data('target-id')),
+        query = $selection.html();
+
+      $target.val($selection.data('value'));
+      $container.removeClass('autocomplete-suggestions--active').attr('aria-hidden', true);
+      $input.data('currentQuery', query);
+      $input.val(query);
+    });
+
+    // only do the query if it has changed for trimmed queries
+    // eg. " " === "" and "firstword " === "firstword"
+    if (currentQuery.trim() !== newQuery.trim()) {
+      lookupNextIndex++;
+      var index = lookupNextIndex;
+      $.ajax({
+        url: autocompleteUrl,
+        data: { query: newQuery },
+        success: function (data, status) {
+          if (index > lookupIndex) {
+            lookupIndex = index;
+            $input.data('currentQuery', newQuery);
+            var liHTML = '';
+            $.each(data.items, function (i, item) {
+              liHTML += '<li data-value="' + item.pk + '">' + item.label + '</li>';
+            });
+            $suggestionsContainer.addClass('autocomplete-suggestions--active').html(liHTML).attr('aria-hidden', false);
+          }
+        },
+      });
+    }
+  };
+})(jQuery);
+
+function initializeAutocompleteWidget(id) {
+  var $input = $('input[data-autocomplete-id=' + id + ']');
+  $input.on('keyup cut paste change', function() {
+    clearTimeout($input.data('timer'));
+    $input.data('timer', setTimeout(window.wagtailAutocomplete($input), 200));
+  });
+}

--- a/wagtail/admin/static_src/wagtailadmin/js/autocomplete.js
+++ b/wagtail/admin/static_src/wagtailadmin/js/autocomplete.js
@@ -1,3 +1,9 @@
+function hideAutocompleteSuggestions() {
+  setTimeout(function() {
+    $('.autocomplete-suggestions--active').removeClass('autocomplete-suggestions--active').attr('aria-hidden', true);
+  }, 100);
+}
+
 (function($) {
   window.wagtailAutocomplete = function ($input) {
     var lookupIndex = 0,
@@ -41,6 +47,12 @@
       });
     }
   };
+
+  $(document).on('click', function(event) {
+    if (!$(event.target).closest('.autocomplete-suggestions--active').length) {
+      hideAutocompleteSuggestions();
+    }
+  });
 })(jQuery);
 
 function initializeAutocompleteWidget(id) {
@@ -49,4 +61,6 @@ function initializeAutocompleteWidget(id) {
     clearTimeout($input.data('timer'));
     $input.data('timer', setTimeout(window.wagtailAutocomplete($input), 200));
   });
+
+  $input.on('blur focusout', hideAutocompleteSuggestions);
 }

--- a/wagtail/admin/static_src/wagtailadmin/scss/autocomplete.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/autocomplete.scss
@@ -1,0 +1,33 @@
+@import 'wagtailadmin/scss/helpers';
+
+
+.autocomplete-wrapper {
+    position: relative;
+}
+
+.autocomplete-suggestions {
+    display: none;
+
+    &--active {
+        background-color: $color-grey-5;
+        display: inline-block;
+        position: absolute;
+        left: 0;
+        right: 0;
+        z-index: $nav-wrapper-inner-z-index;
+        box-shadow: 0 3px 3px 0 rgba(0, 0, 0, 0.2);
+
+        li {
+            background-color: $color-fieldset-hover;
+            border: 1px solid $color-input-border;
+            border-top: 0;
+            box-sizing: border-box;
+            padding: 0.9em 1.2em;
+
+            &:hover {
+                background-color: $color-input-focus;
+                cursor: pointer;
+            }
+        }
+    }
+}

--- a/wagtail/admin/templates/wagtailadmin/widgets/autocomplete_widget.html
+++ b/wagtail/admin/templates/wagtailadmin/widgets/autocomplete_widget.html
@@ -1,0 +1,9 @@
+<div class="autocomplete-wrapper">
+    <input type="text"
+           data-autocomplete-id="{{ widget.attrs.id }}"
+           data-autocomplete-url="{{ widget.autocomplete_url }}"
+           value="{{ widget.lookup_value }}"
+           class="autocomplete-input" autocomplete="off" role="textbox" aria-autocomplete="list" aria-haspopup="true" />
+    {% include "django/forms/widgets/hidden.html" %}
+    <ul class="autocomplete-suggestions" data-target-id="{{ widget.attrs.id }}" aria-hidden="true"></ul>
+</div>

--- a/wagtail/admin/tests/test_widgets.py
+++ b/wagtail/admin/tests/test_widgets.py
@@ -314,7 +314,7 @@ class TestAutocompleteWidget(TestCase):
 
         autocomplete_url = reverse(
             'wagtailadmin_model_autocomplete'
-        ) + "?type=tests.SimplePage&amp;lookup_field=title&amp;limit=10"
+        ) + "?type=tests.SimplePage&amp;lookup_fields=title&amp;limit=10"
 
         needle = f"""
         <input type="text"

--- a/wagtail/admin/urls/__init__.py
+++ b/wagtail/admin/urls/__init__.py
@@ -11,7 +11,7 @@ from wagtail.admin.urls import pages as wagtailadmin_pages_urls
 from wagtail.admin.urls import collections as wagtailadmin_collections_urls
 from wagtail.admin.urls import reports as wagtailadmin_reports_urls
 from wagtail.admin.urls import password_reset as wagtailadmin_password_reset_urls
-from wagtail.admin.views import account, chooser, home, pages, tags, userbar
+from wagtail.admin.views import account, autocomplete, chooser, home, pages, tags, userbar
 from wagtail.admin.api import urls as api_urls
 from wagtail.core import hooks
 from wagtail.utils.urlpatterns import decorate_urlpatterns
@@ -43,6 +43,8 @@ urlpatterns = [
 
     path('tag-autocomplete/', tags.autocomplete, name='wagtailadmin_tag_autocomplete'),
     path('tag-autocomplete/<slug:app_name>/<slug:model_name>/', tags.autocomplete, name='wagtailadmin_tag_model_autocomplete'),
+
+    path('autocomplete/', autocomplete.lookup, name='wagtailadmin_model_autocomplete'),
 
     path('collections/', include(wagtailadmin_collections_urls, namespace='wagtailadmin_collections')),
 

--- a/wagtail/admin/views/autocomplete.py
+++ b/wagtail/admin/views/autocomplete.py
@@ -1,0 +1,34 @@
+from bs4 import BeautifulSoup
+from django.apps import apps
+from django.http import HttpResponseBadRequest, JsonResponse
+from django.views.decorators.http import require_GET
+
+
+@require_GET
+def lookup(request):
+    target_model = request.GET.get('type')
+    search_query = request.GET.get('query', '')
+
+    try:
+        model = apps.get_model(target_model)
+    except Exception:
+        return HttpResponseBadRequest("Invalid model")
+
+    limit = int(request.GET.get('limit', 10))
+    search_field = request.GET.get('lookup_field', 'title')
+
+    if not hasattr(model, search_field):
+        return HttpResponseBadRequest('Invalid lookup field')
+    filter_kwargs = {
+        search_field + '__icontains': search_query,
+    }
+    queryset = model.objects.filter(**filter_kwargs).order_by(search_field)
+
+    results = []
+    for result in queryset[:limit]:
+        label = BeautifulSoup(
+            getattr(result, search_field, str(result)).strip(), 'html.parser'
+        ).text
+        results.append(dict(pk=result.pk, label=label))
+
+    return JsonResponse(dict(items=results))

--- a/wagtail/admin/widgets.py
+++ b/wagtail/admin/widgets.py
@@ -391,10 +391,10 @@ class AutocompleteWidget(WidgetWithScript, widgets.Input):
     template_name = 'wagtailadmin/widgets/autocomplete_widget.html'
     limit = 10
 
-    def __init__(self, target_model, lookup_field='title', limit=10, attrs=None):
+    def __init__(self, target_model, lookup_fields='title', limit=10, attrs=None):
         super().__init__(attrs)
         self.target_model = target_model
-        self.lookup_field = lookup_field
+        self.lookup_fields = lookup_fields.join(',') if isinstance(lookup_fields, list) else lookup_fields
         self.limit = limit
 
     def get_context(self, name, value, attrs):
@@ -403,14 +403,14 @@ class AutocompleteWidget(WidgetWithScript, widgets.Input):
         url = reverse('wagtailadmin_model_autocomplete')
         querydict = {
             'type': self.target_model._meta.label,
-            'lookup_field': self.lookup_field,
+            'lookup_fields': self.lookup_fields,
             'limit': self.limit
         }
         context['widget']['autocomplete_url'] = url + "?" + urlencode(querydict)
 
         if context['widget']['value']:
             item = self.target_model.objects.get(pk=context['widget']['value'])
-            context['widget']['lookup_value'] = getattr(item, self.lookup_field)
+            context['widget']['lookup_value'] = str(item)
         else:
             context['widget']['lookup_value'] = ''
 

--- a/wagtail/contrib/styleguide/views.py
+++ b/wagtail/contrib/styleguide/views.py
@@ -27,7 +27,7 @@ class ExampleForm(forms.Form):
         self.fields['datetime'].widget = AdminDateTimeInput()
         self.fields['auto_height_text'].widget = AdminAutoHeightTextInput()
         self.fields['default_rich_text'].widget = get_rich_text_editor_widget('default')
-        self.fields['autocomplete'].widget = AutocompleteWidget(get_user_model(), lookup_field='username')
+        self.fields['autocomplete'].widget = AutocompleteWidget(get_user_model(), lookup_fields='username')
 
     CHOICES = (
         ('choice1', 'choice 1'),

--- a/wagtail/contrib/styleguide/views.py
+++ b/wagtail/contrib/styleguide/views.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.contrib.auth import get_user_model
 from django.core.paginator import Paginator
 from django.template.response import TemplateResponse
 from django.utils.translation import gettext as _
@@ -7,7 +8,7 @@ from wagtail.admin import messages
 from wagtail.admin.forms.search import SearchForm
 from wagtail.admin.rich_text import get_rich_text_editor_widget
 from wagtail.admin.widgets import (
-    AdminAutoHeightTextInput, AdminDateInput, AdminDateTimeInput, AdminPageChooser, AdminTimeInput)
+    AdminAutoHeightTextInput, AdminDateInput, AdminDateTimeInput, AdminPageChooser, AdminTimeInput, AutocompleteWidget)
 from wagtail.core.models import Page
 from wagtail.documents.widgets import AdminDocumentChooser
 from wagtail.images.widgets import AdminImageChooser
@@ -26,6 +27,7 @@ class ExampleForm(forms.Form):
         self.fields['datetime'].widget = AdminDateTimeInput()
         self.fields['auto_height_text'].widget = AdminAutoHeightTextInput()
         self.fields['default_rich_text'].widget = get_rich_text_editor_widget('default')
+        self.fields['autocomplete'].widget = AutocompleteWidget(get_user_model(), lookup_field='username')
 
     CHOICES = (
         ('choice1', 'choice 1'),
@@ -47,6 +49,7 @@ class ExampleForm(forms.Form):
     image_chooser = forms.BooleanField(required=True)
     document_chooser = forms.BooleanField(required=True)
     snippet_chooser = forms.BooleanField(required=True)
+    autocomplete = forms.ModelChoiceField(queryset=get_user_model().objects.all())
 
 
 def index(request):


### PR DESCRIPTION
Adds a model autocomplete widget and changes the locked pages "locked_by" filter to use it. Currently supports only single choice.

![Screenshot 2020-07-08 at 14 41 40](https://user-images.githubusercontent.com/31622/86925769-2d891580-c129-11ea-8388-bda1fdf486f0.png)

Tried to keep it as lightweight as I could. All feedback is welcome.

Note: ideally we would fold https://github.com/wagtail/wagtail-autocomplete into core and expand it to allow a separate lookup field and work without needing `autocomplete_label`. If that is deemed the preferred approach, can try to look into getting that package ready for core.

**edit:** related issue #4798