### PR TITLE
Reimplement PageQuerySet.specific() to utilise select_related() instead of making additional queries

### DIFF
--- a/wagtail/contrib/sitemaps/tests.py
+++ b/wagtail/contrib/sitemaps/tests.py
@@ -63,8 +63,8 @@ class TestSitemapGenerator(TestCase):
             hostname='other.example.com', port=80, root_page=self.other_site_homepage
         )
 
-        # Clear the cache to that runs are deterministic regarding the sql count
-        ContentType.objects.clear_cache()
+        # populate cache so that test runs have deterministic query counts
+        ContentType.objects.get_for_models(Page, SimplePage, EventIndex)
 
     def get_request_and_django_site(self, url):
         request = RequestFactory().get(url)
@@ -93,7 +93,7 @@ class TestSitemapGenerator(TestCase):
         req_protocol = request.scheme
 
         sitemap = Sitemap()
-        with self.assertNumQueries(17):
+        with self.assertNumQueries(13):
             urls = [url['location'] for url in sitemap.get_urls(1, django_site, req_protocol)]
 
         self.assertIn('http://localhost/', urls)  # Homepage
@@ -108,7 +108,7 @@ class TestSitemapGenerator(TestCase):
         # pre-seed find_for_request cache, so that it's not counted towards the query count
         Site.find_for_request(request)
 
-        with self.assertNumQueries(14):
+        with self.assertNumQueries(10):
             urls = [url['location'] for url in sitemap.get_urls(1, django_site, req_protocol)]
 
         self.assertIn('http://localhost/', urls)  # Homepage
@@ -120,7 +120,7 @@ class TestSitemapGenerator(TestCase):
         req_protocol = request.scheme
 
         sitemap = Sitemap()
-        with self.assertNumQueries(19):
+        with self.assertNumQueries(15):
             urls = [url['location'] for url in sitemap.get_urls(1, django_site, req_protocol)]
 
         self.assertIn('http://localhost/', urls)  # Homepage
@@ -136,7 +136,7 @@ class TestSitemapGenerator(TestCase):
         # pre-seed find_for_request cache, so that it's not counted towards the query count
         Site.find_for_request(request)
 
-        with self.assertNumQueries(16):
+        with self.assertNumQueries(12):
             urls = [url['location'] for url in sitemap.get_urls(1, django_site, req_protocol)]
 
         self.assertIn('http://localhost/', urls)  # Homepage

--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -928,8 +928,10 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
         return self.title
 
     @classmethod
-    def get_streamfield_names(cls):
-        return get_streamfield_names(cls)
+    def get_streamfield_names(cls, prefix=None):
+        if not prefix:
+            return get_streamfield_names(cls)
+        return tuple(f'{prefix}__{name}' for name in get_streamfield_names(cls))
 
     @classmethod
     def get_concrete_subclasses(cls):


### PR DESCRIPTION
Using an approach inspired by [Jeff Elmore's](https://jeffelmore.org/2010/11/11/automatic-downcasting-of-inherited-models-in-django/) implementation of [`InheritanceManager`](https://django-model-utils.readthedocs.io/en/stable/managers.html#inheritancemanager) from `django-model-utils`, this PR utilises `Model._meta` and `QuerySet.select_related()` to fetch specific pages in a single query instead of making separate queries to fetch the pages for each type.

### What are the benefits?

1. Improved speed: Fewer queries overall means less time spent communicating with the database and interpreting the results.
2. Fetching the page data in a single query means that combining with `prefetch_related()` becomes viable, which is obviously very useful for query optimisation.
3. Any other values requested via `select_related()` and `annotate()` are also included on the returned values.
5. Because the database result returns all of the data needed for each row (in the order it is needed), we can use a 'generator style' to return results (instead of building an in-memory list of combined results). This alllows `specific()` to be combined with `iterator()` to vastly reduce peak memory usage when processing with large querysets.
6. In cases where the specific version of a page cannot be found, no additional queries are needed to fetch the generic page data (to return as a backup), as the generic page instance is already present in the result.
7. The implementation penalises the developer less when `specific()` is used in places where it would be clearly of no benefit.

### What are the negatives?

1.  Memory usage over time in python is higher, because using `select_related()` activates a lot of additional processing before the query, and while processing it. In addition to this, a full generic instance is always created in-memory in order to 'get to' the specific one. 

### DEPENDS ON

To be ticked off as merged:

- [x] #6845 
- [x] #6846
- [x] #6847
- [x] #6850

### TO DO

- [x] Do some benchmarking to compare performance against existing implementation
- [x] Remove existing `specific()` method and iterators
- [x] Address failing tests and add new ones
- [ ] Update documentation