### PR TITLE
Add fallback for old signature page listing button hooks

### DIFF
--- a/docs/releases/2.10.rst
+++ b/docs/releases/2.10.rst
@@ -104,3 +104,9 @@ Python 3.5 is no longer supported as of this release; please upgrade to Python 3
 
 In previous releases, rich text values were enclosed in a ``<div class="rich-text">`` element when rendered; this element has now been removed.
 To restore the old behaviour, see :ref:`legacy_richtext`.
+
+
+Hooks functions ``register_page_listing_buttons`` & ``register_page_listing_more_buttons``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Page listing button hook functions now accept an additional kwarg `next_url`.

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -1,6 +1,7 @@
 import itertools
 import json
 
+import warnings
 from urllib.parse import urljoin
 
 from django import template
@@ -25,8 +26,9 @@ from wagtail.core import hooks
 from wagtail.core.models import (
     CollectionViewRestriction, Page, PageViewRestriction, UserPagePermissionsProxy)
 from wagtail.core.utils import cautious_slugify as _cautious_slugify
-from wagtail.core.utils import camelcase_to_underscore, escape_script
+from wagtail.core.utils import accepts_kwarg, camelcase_to_underscore, escape_script
 from wagtail.users.utils import get_gravatar_url
+from wagtail.utils.deprecation import RemovedInWagtail212Warning
 
 register = template.Library()
 
@@ -430,9 +432,21 @@ def paginate(context, page, base_url='', page_key='p',
 def page_listing_buttons(context, page, page_perms, is_parent=False):
     next_url = urlencode({"next": context.request.path})
     button_hooks = hooks.get_hooks('register_page_listing_buttons')
-    buttons = sorted(itertools.chain.from_iterable(
-        hook(page, page_perms, is_parent, next_url)
-        for hook in button_hooks))
+
+    buttons = []
+    for hook in button_hooks:
+        if accepts_kwarg(hook, 'next_url'):
+            button = hook(page, page_perms, is_parent, next_url)
+        else:
+            warnings.warn(
+                'register_page_listing_buttons hooks will require an additional kwarg `next_url` in a future release. '
+                'Please update your hook function accept `next_url`.',
+                RemovedInWagtail212Warning
+            )
+            button = hook(page, page_perms, is_parent)
+        buttons.append(button)
+
+    buttons = sorted(itertools.chain.from_iterable(buttons))
 
     for hook in hooks.get_hooks('construct_page_listing_buttons'):
         hook(buttons, page, page_perms, is_parent, context)

--- a/wagtail/admin/widgets.py
+++ b/wagtail/admin/widgets.py
@@ -1,5 +1,6 @@
 import itertools
 import json
+import warnings
 from functools import total_ordering
 
 from django import forms
@@ -19,6 +20,8 @@ from wagtail.admin.datetimepicker import to_datetimepicker_format
 from wagtail.admin.staticfiles import versioned_static
 from wagtail.core import hooks
 from wagtail.core.models import Page
+from wagtail.core.utils import accepts_kwarg
+from wagtail.utils.deprecation import RemovedInWagtail212Warning
 from wagtail.utils.widgets import WidgetWithScript
 
 DEFAULT_DATE_FORMAT = '%Y-%m-%d'
@@ -379,6 +382,18 @@ class ButtonWithDropdownFromHook(BaseDropdownMenuButton):
     @cached_property
     def dropdown_buttons(self):
         button_hooks = hooks.get_hooks(self.hook_name)
-        return sorted(itertools.chain.from_iterable(
-            hook(self.page, self.page_perms, self.is_parent, self.next_url)
-            for hook in button_hooks))
+
+        buttons = []
+        for hook in button_hooks:
+            if accepts_kwarg(hook, 'next_url'):
+                button = hook(self.page, self.page_perms, self.is_parent, self.next_url)
+            else:
+                warnings.warn(
+                    '%s hooks will require an additional kwarg `next_url` in a future release. Please update your hook function accept `next_url`.' % self.hook_name,
+                    RemovedInWagtail212Warning
+                )
+                button = hook(self.page, self.page_perms, self.is_parent)
+
+            buttons.append(button)
+
+        return sorted(itertools.chain.from_iterable(buttons))


### PR DESCRIPTION
- hook - `register_page_listing_buttons`
- hook - `register_page_listing_more_buttons`
- fixes  #6208
- relates to the changes in #5764
- Note: I have added upgrade considerations to the release notes (hopefully this reads ok).
