### PR TITLE
Clarify origin of From address used in password reset emails

### DIFF
--- a/docs/reference/settings.rst
+++ b/docs/reference/settings.rst
@@ -193,7 +193,7 @@ This specifies whether users are allowed to change their passwords (enabled by d
 
   WAGTAIL_PASSWORD_RESET_ENABLED = True
 
-This specifies whether users are allowed to reset their passwords. Defaults to the same as ``WAGTAIL_PASSWORD_MANAGEMENT_ENABLED``.
+This specifies whether users are allowed to reset their passwords. Defaults to the same as ``WAGTAIL_PASSWORD_MANAGEMENT_ENABLED``. Password reset emails will be sent from the address specified in Django's ``DEFAULT_FROM_EMAIL`` setting.
 
 .. code-block:: python
 
@@ -222,7 +222,7 @@ Email Notifications
 
   WAGTAILADMIN_NOTIFICATION_FROM_EMAIL = 'wagtail@myhost.io'
 
-Wagtail sends email notifications when content is submitted for moderation, and when the content is accepted or rejected. This setting lets you pick which email address these automatic notifications will come from. If omitted, Django will fall back to using the ``DEFAULT_FROM_EMAIL`` variable if set, and ``webmaster@localhost`` if not.
+Wagtail sends email notifications when content is submitted for moderation, and when the content is accepted or rejected. This setting lets you pick which email address these automatic notifications will come from. If omitted, Wagtail will fall back to using Django's ``DEFAULT_FROM_EMAIL`` setting if set, or ``webmaster@localhost`` if not.
 
 .. code-block:: python
 


### PR DESCRIPTION
Add a minor clarification that the From address used by the password reset mechanism is set by `DEFAULT_FROM_EMAIL`. Prompted by a recent conversation on Slack where the user was under the false impression this would be governed by `WAGTAIL_NOTIFICATION_FROM_EMAIL`.

(Plus pedantic clarification in the following section about what owns `DEFAULT_FROM_EMAIL`.)