### PR TITLE
[RFC 54] Internationalisation API changes

### DIFF
--- a/wagtail/admin/api/serializers.py
+++ b/wagtail/admin/api/serializers.py
@@ -109,9 +109,45 @@ class PageAncestorsField(Field):
         return serializer.to_representation(page.get_ancestors())
 
 
+class PageTranslationsField(Field):
+    """
+    Serializes the page's translations.
+
+    Example:
+    "translations": [
+        {
+            "id": 1,
+            "meta": {
+                "type": "home.HomePage",
+                "detail_url": "/api/v1/pages/1/",
+                "locale": "es"
+            },
+            "title": "Casa"
+        },
+        {
+            "id": 2,
+            "meta": {
+                "type": "home.HomePage",
+                "detail_url": "/api/v1/pages/2/",
+                "locale": "fr"
+            },
+            "title": "Maison"
+        }
+    ]
+    """
+    def get_attribute(self, instance):
+        return instance
+
+    def to_representation(self, page):
+        serializer_class = get_serializer_class(Page, ['id', 'type', 'detail_url', 'html_url', 'locale', 'title', 'admin_display_title'], meta_fields=['type', 'detail_url', 'html_url', 'locale'], base=AdminPageSerializer)
+        serializer = serializer_class(context=self.context, many=True)
+        return serializer.to_representation(page.get_translations())
+
+
 class AdminPageSerializer(PageSerializer):
     status = PageStatusField(read_only=True)
     children = PageChildrenField(read_only=True)
     descendants = PageDescendantsField(read_only=True)
     ancestors = PageAncestorsField(read_only=True)
+    translations = PageTranslationsField(read_only=True)
     admin_display_title = ReadOnlyField(source='get_admin_display_title')

--- a/wagtail/admin/api/views.py
+++ b/wagtail/admin/api/views.py
@@ -1,5 +1,6 @@
 from collections import OrderedDict
 
+from django.conf import settings
 from rest_framework.authentication import SessionAuthentication
 
 from wagtail.api.v2.views import PagesAPIViewSet
@@ -26,6 +27,7 @@ class PagesAdminAPIViewSet(PagesAPIViewSet):
         'descendants',
         'parent',
         'ancestors',
+        'translations',
     ]
 
     body_fields = PagesAPIViewSet.body_fields + [
@@ -46,6 +48,16 @@ class PagesAdminAPIViewSet(PagesAPIViewSet):
         'for_explorer',
         'has_children'
     ])
+
+    @classmethod
+    def get_detail_default_fields(cls, model):
+        detail_default_fields = super().get_detail_default_fields(model)
+
+        # When i18n is disabled, remove "translations" from default fields
+        if not getattr(settings, 'WAGTAIL_I18N_ENABLED', False):
+            detail_default_fields.remove('translations')
+
+        return detail_default_fields
 
     def get_root_page(self):
         """

--- a/wagtail/admin/tests/api/test_documents.py
+++ b/wagtail/admin/tests/api/test_documents.py
@@ -109,3 +109,8 @@ class TestAdminDocumentDetail(AdminAPITestCase, TestDocumentDetail):
         # Check the tags field
         self.assertIn('tags', content['meta'])
         self.assertEqual(content['meta']['tags'], [])
+
+
+# Overwrite imported test cases do Django doesn't run them
+TestDocumentDetail = None
+TestDocumentListing = None

--- a/wagtail/admin/tests/api/test_images.py
+++ b/wagtail/admin/tests/api/test_images.py
@@ -196,3 +196,8 @@ class TestAdminImageDetail(AdminAPITestCase, TestImageDetail):
 
         # Check that source_image_error didn't appear
         self.assertNotIn('source_image_error', content['meta'])
+
+
+# Overwrite imported test cases do Django doesn't run them
+TestImageDetail = None
+TestImageListing = None

--- a/wagtail/api/v2/serializers.py
+++ b/wagtail/api/v2/serializers.py
@@ -86,6 +86,17 @@ class PageTypeField(Field):
         return name
 
 
+class PageLocaleField(Field):
+    """
+    Serializes the "locale" field for pages.
+    """
+    def get_attribute(self, instance):
+        return instance
+
+    def to_representation(self, page):
+        return page.locale.language_code
+
+
 class RelatedField(relations.RelatedField):
     """
     Serializes related objects (eg, foreign keys).
@@ -310,6 +321,7 @@ class BaseSerializer(serializers.ModelSerializer):
 
 class PageSerializer(BaseSerializer):
     type = PageTypeField(read_only=True)
+    locale = PageLocaleField(read_only=True)
     html_url = PageHtmlUrlField(read_only=True)
     parent = PageParentField(read_only=True)
 

--- a/wagtail/api/v2/tests/test_pages.py
+++ b/wagtail/api/v2/tests/test_pages.py
@@ -8,7 +8,7 @@ from django.test.utils import override_settings
 from django.urls import reverse
 
 from wagtail.api.v2 import signal_handlers
-from wagtail.core.models import Page, Site
+from wagtail.core.models import Locale, Page, Site
 from wagtail.tests.demosite import models
 from wagtail.tests.testapp.models import StreamPage
 
@@ -144,6 +144,21 @@ class TestPageListing(TestCase):
 
         self.assertEqual(response.status_code, 400)
         self.assertEqual(content, {'message': "type doesn't exist"})
+
+    # LOCALE FILTER
+
+    @override_settings(WAGTAIL_I18N_ENABLED=True)
+    def test_locale_filter(self):
+        french = Locale.objects.create(language_code='fr')
+        homepage = Page.objects.get(depth=2)
+        french_homepage = homepage.copy_for_translation(french)
+        french_homepage.get_latest_revision().publish()
+
+        response = self.get_response(locale='fr')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(len(content['items']), 1)
+        self.assertEqual(content['items'][0]['id'], french_homepage.id)
 
     # FIELDS
 

--- a/wagtail/api/v2/tests/test_pages.py
+++ b/wagtail/api/v2/tests/test_pages.py
@@ -160,6 +160,21 @@ class TestPageListing(TestCase):
         self.assertEqual(len(content['items']), 1)
         self.assertEqual(content['items'][0]['id'], french_homepage.id)
 
+    # TRANSLATION OF FILTER
+
+    @override_settings(WAGTAIL_I18N_ENABLED=True)
+    def test_translation_of_filter(self):
+        french = Locale.objects.create(language_code='fr')
+        homepage = Page.objects.get(depth=2)
+        french_homepage = homepage.copy_for_translation(french)
+        french_homepage.get_latest_revision().publish()
+
+        response = self.get_response(translation_of=homepage.id)
+        content = json.loads(response.content.decode('UTF-8'))
+
+        self.assertEqual(len(content['items']), 1)
+        self.assertEqual(content['items'][0]['id'], french_homepage.id)
+
     # FIELDS
 
     def test_fields_default(self):

--- a/wagtail/api/v2/tests/test_pages.py
+++ b/wagtail/api/v2/tests/test_pages.py
@@ -185,6 +185,15 @@ class TestPageListing(TestCase):
             self.assertEqual(set(page.keys()), {'id', 'meta', 'title'})
             self.assertEqual(set(page['meta'].keys()), {'type', 'detail_url', 'html_url', 'slug', 'first_published_at'})
 
+    @override_settings(WAGTAIL_I18N_ENABLED=True)
+    def test_fields_default_with_i18n_enabled(self):
+        # 'locale' should be added to the default set of fields when i18n is enabled
+        response = self.get_response(type='demosite.BlogEntryPage')
+        content = json.loads(response.content.decode('UTF-8'))
+
+        for page in content['items']:
+            self.assertIn('locale', set(page['meta'].keys()))
+
     def test_fields(self):
         response = self.get_response(type='demosite.BlogEntryPage', fields='title,date,feed_image')
         content = json.loads(response.content.decode('UTF-8'))
@@ -227,7 +236,7 @@ class TestPageListing(TestCase):
 
         for page in content['items']:
             self.assertEqual(set(page.keys()), {'id', 'meta', 'title', 'date', 'related_links', 'tags', 'carousel_items', 'body', 'feed_image', 'feed_image_thumbnail'})
-            self.assertEqual(set(page['meta'].keys()), {'type', 'detail_url', 'show_in_menus', 'first_published_at', 'seo_title', 'slug', 'html_url', 'search_description'})
+            self.assertEqual(set(page['meta'].keys()), {'type', 'detail_url', 'show_in_menus', 'first_published_at', 'seo_title', 'slug', 'html_url', 'search_description', 'locale'})
 
     def test_all_fields_then_remove_something(self):
         response = self.get_response(type='demosite.BlogEntryPage', fields='*,-title,-date,-seo_title')
@@ -235,7 +244,7 @@ class TestPageListing(TestCase):
 
         for page in content['items']:
             self.assertEqual(set(page.keys()), {'id', 'meta', 'related_links', 'tags', 'carousel_items', 'body', 'feed_image', 'feed_image_thumbnail'})
-            self.assertEqual(set(page['meta'].keys()), {'type', 'detail_url', 'show_in_menus', 'first_published_at', 'slug', 'html_url', 'search_description'})
+            self.assertEqual(set(page['meta'].keys()), {'type', 'detail_url', 'show_in_menus', 'first_published_at', 'slug', 'html_url', 'search_description', 'locale'})
 
     def test_remove_all_fields(self):
         response = self.get_response(type='demosite.BlogEntryPage', fields='_,id,type')
@@ -930,6 +939,19 @@ class TestPageDetail(TestCase):
         ]
         self.assertEqual(list(content.keys()), field_order)
 
+        meta_field_order = [
+            'type',
+            'detail_url',
+            'html_url',
+            'slug',
+            'show_in_menus',
+            'seo_title',
+            'search_description',
+            'first_published_at',
+            'parent',
+        ]
+        self.assertEqual(list(content['meta'].keys()), meta_field_order)
+
     def test_null_foreign_key(self):
         models.BlogEntryPage.objects.filter(id=16).update(feed_image_id=None)
 
@@ -951,6 +973,14 @@ class TestPageDetail(TestCase):
         self.assertEqual(response.status_code, 200)
 
     # FIELDS
+
+    @override_settings(WAGTAIL_I18N_ENABLED=True)
+    def test_default_fields_with_i18n_enabled(self):
+        # 'locale' should be added to the default set of fields when i18n is enabled
+        response = self.get_response(16)
+        page = json.loads(response.content.decode('UTF-8'))
+
+        self.assertIn('locale', set(page['meta'].keys()))
 
     def test_remove_fields(self):
         response = self.get_response(16, fields='-title')

--- a/wagtail/api/v2/views.py
+++ b/wagtail/api/v2/views.py
@@ -391,6 +391,7 @@ class PagesAPIViewSet(BaseAPIViewSet):
         'search_description',
         'first_published_at',
         'parent',
+        'locale',
     ]
     listing_default_fields = BaseAPIViewSet.listing_default_fields + [
         'title',
@@ -404,6 +405,26 @@ class PagesAPIViewSet(BaseAPIViewSet):
     detail_only_fields = ['parent']
     name = 'pages'
     model = Page
+
+    @classmethod
+    def get_detail_default_fields(cls, model):
+        detail_default_fields = super().get_detail_default_fields(model)
+
+        # When i18n is disabled, remove "locale" from default fields
+        if not getattr(settings, 'WAGTAIL_I18N_ENABLED', False):
+            detail_default_fields.remove('locale')
+
+        return detail_default_fields
+
+    @classmethod
+    def get_listing_default_fields(cls, model):
+        listing_default_fields = super().get_listing_default_fields(model)
+
+        # When i18n is enabled, add "locale" to default fields
+        if getattr(settings, 'WAGTAIL_I18N_ENABLED', False):
+            listing_default_fields.append('locale')
+
+        return listing_default_fields
 
     def get_root_page(self):
         """

--- a/wagtail/api/v2/views.py
+++ b/wagtail/api/v2/views.py
@@ -14,7 +14,8 @@ from rest_framework.viewsets import GenericViewSet
 from wagtail.api import APIField
 from wagtail.core.models import Page, Site
 
-from .filters import ChildOfFilter, DescendantOfFilter, FieldsFilter, OrderingFilter, SearchFilter
+from .filters import (
+    ChildOfFilter, DescendantOfFilter, FieldsFilter, LocaleFilter, OrderingFilter, SearchFilter)
 from .pagination import WagtailPagination
 from .serializers import BaseSerializer, PageSerializer, get_serializer_class
 from .utils import (
@@ -367,12 +368,14 @@ class PagesAPIViewSet(BaseAPIViewSet):
         ChildOfFilter,
         DescendantOfFilter,
         OrderingFilter,
-        SearchFilter
+        SearchFilter,
+        LocaleFilter,
     ]
     known_query_parameters = BaseAPIViewSet.known_query_parameters.union([
         'type',
         'child_of',
         'descendant_of',
+        'locale',
     ])
     body_fields = BaseAPIViewSet.body_fields + [
         'title',

--- a/wagtail/api/v2/views.py
+++ b/wagtail/api/v2/views.py
@@ -15,7 +15,8 @@ from wagtail.api import APIField
 from wagtail.core.models import Page, Site
 
 from .filters import (
-    ChildOfFilter, DescendantOfFilter, FieldsFilter, LocaleFilter, OrderingFilter, SearchFilter)
+    ChildOfFilter, DescendantOfFilter, FieldsFilter, LocaleFilter, OrderingFilter, SearchFilter,
+    TranslationOfFilter)
 from .pagination import WagtailPagination
 from .serializers import BaseSerializer, PageSerializer, get_serializer_class
 from .utils import (
@@ -369,12 +370,14 @@ class PagesAPIViewSet(BaseAPIViewSet):
         DescendantOfFilter,
         OrderingFilter,
         SearchFilter,
+        TranslationOfFilter,
         LocaleFilter,
     ]
     known_query_parameters = BaseAPIViewSet.known_query_parameters.union([
         'type',
         'child_of',
         'descendant_of',
+        'translation_of',
         'locale',
     ])
     body_fields = BaseAPIViewSet.body_fields + [


### PR DESCRIPTION
This implements the following new features on the pages endpoint:

 - Logic to pull in pages from other locale trees
 - A `locale` filter that filters pages by a Locale's `language_code`
 - A `translation_of` filter that takes a page id and returns the pages that are translations of that page
 - A `meta.locale` field to show the Locale of a page
 - A `meta.translations` field that nests data about a pages translations in each page (admin API only due to performance)