### PR TITLE
Further fixups for button hook next_url parameter

### DIFF
--- a/docs/reference/hooks.rst
+++ b/docs/reference/hooks.rst
@@ -878,6 +878,13 @@ Page explorer
             priority=10
         )
 
+  The arguments passed to the hook are as follows:
+
+  * ``page`` - the page object to generate the button for
+  * ``page_perms`` - a ``PagePermissionTester`` object that can be queried to determine the current user's permissions on the given page
+  * ``is_parent`` - if true, this button is being rendered for the parent page being displayed at the top of the listing
+  * ``next_url`` - the URL that the linked action should redirect back to on completion of the action, if the view supports it
+
   The ``priority`` argument controls the order the buttons are displayed in. Buttons are ordered from low to high priority, so a button with ``priority=10`` will be displayed before a button with ``priority=20``.
 
 
@@ -902,6 +909,13 @@ Page explorer
             priority=60
         )
 
+  The arguments passed to the hook are as follows:
+
+  * ``page`` - the page object to generate the button for
+  * ``page_perms`` - a ``PagePermissionTester`` object that can be queried to determine the current user's permissions on the given page
+  * ``is_parent`` - if true, this button is being rendered for the parent page being displayed at the top of the listing
+  * ``next_url`` - the URL that the linked action should redirect back to on completion of the action, if the view supports it
+
   The ``priority`` argument controls the order the buttons are displayed in the dropdown. Buttons are ordered from low to high priority, so a button with ``priority=10`` will be displayed before a button with ``priority=60``.
 
 
@@ -920,18 +934,19 @@ Buttons with dropdown lists
     from wagtail.admin import widgets as wagtailadmin_widgets
 
     @hooks.register('register_page_listing_buttons')
-    def page_custom_listing_buttons(page, page_perms, is_parent=False):
+    def page_custom_listing_buttons(page, page_perms, is_parent=False, next_url=None):
         yield wagtailadmin_widgets.ButtonWithDropdownFromHook(
             'More actions',
             hook_name='my_button_dropdown_hook',
             page=page,
             page_perms=page_perms,
             is_parent=is_parent,
+            next_url=next_url,
             priority=50
         )
 
     @hooks.register('my_button_dropdown_hook')
-    def page_custom_listing_more_buttons(page, page_perms, is_parent=False):
+    def page_custom_listing_more_buttons(page, page_perms, is_parent=False, next_url=None):
         if page_perms.can_move():
             yield wagtailadmin_widgets.Button('Move', reverse('wagtailadmin_pages:move', args=[page.id]), priority=10)
         if page_perms.can_delete():

--- a/docs/releases/2.10.rst
+++ b/docs/releases/2.10.rst
@@ -109,7 +109,27 @@ In previous releases, rich text values were enclosed in a ``<div class="rich-tex
 To restore the old behaviour, see :ref:`legacy_richtext`.
 
 
-Hooks functions ``register_page_listing_buttons`` & ``register_page_listing_more_buttons``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+New ``next_url`` keyword argument on ``register_page_listing_buttons`` & ``register_page_listing_more_buttons`` hooks
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Page listing button hook functions now accept an additional kwarg ``next_url``. Please update your hook function definitions to accept the new ``next_url`` kwarg.
+Functions registered through the hooks ``register_page_listing_buttons`` and ``register_page_listing_more_buttons`` now accept an additional keyword argument ``next_url``. A hook function currently written as:
+
+.. code-block:: python
+
+    @hooks.register('register_page_listing_buttons')
+    def page_listing_more_buttons(page, page_perms, is_parent=False):
+        yield wagtailadmin_widgets.Button(
+            'My button', '/goes/to/a/url/', priority=60
+        )
+
+should now become:
+
+.. code-block:: python
+
+    @hooks.register('register_page_listing_buttons')
+    def page_listing_more_buttons(page, page_perms, is_parent=False, next_url=None):
+        yield wagtailadmin_widgets.Button(
+            'My button', '/goes/to/a/url/', priority=60
+        )
+
+The ``next_url`` argument specifies a URL to redirect back to after the action is complete, and can be passed as a query parameter to the linked URL, if the view supports it.

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -13,7 +13,6 @@ from django.template.defaultfilters import stringfilter
 from django.template.loader import render_to_string
 from django.templatetags.static import static
 from django.utils.html import format_html, format_html_join
-from django.utils.http import urlencode
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
 
@@ -430,7 +429,7 @@ def paginate(context, page, base_url='', page_key='p',
 @register.inclusion_tag("wagtailadmin/pages/listing/_buttons.html",
                         takes_context=True)
 def page_listing_buttons(context, page, page_perms, is_parent=False):
-    next_url = urlencode({"next": context.request.path})
+    next_url = context.request.path
     button_hooks = hooks.get_hooks('register_page_listing_buttons')
 
     buttons = []

--- a/wagtail/admin/tests/pages/test_content_type_use_view.py
+++ b/wagtail/admin/tests/pages/test_content_type_use_view.py
@@ -1,6 +1,8 @@
 from django.test import TestCase
 from django.urls import reverse
+from django.utils.http import urlencode
 
+from wagtail.tests.testapp.models import EventPage
 from wagtail.tests.utils import WagtailTestUtils
 
 
@@ -9,12 +11,21 @@ class TestContentTypeUse(TestCase, WagtailTestUtils):
 
     def setUp(self):
         self.user = self.login()
+        self.christmas_page = EventPage.objects.get(title="Christmas")
 
     def test_content_type_use(self):
         # Get use of event page
-        response = self.client.get(reverse('wagtailadmin_pages:type_use', args=('tests', 'eventpage')))
+        request_url = reverse('wagtailadmin_pages:type_use', args=('tests', 'eventpage'))
+        response = self.client.get(request_url)
 
         # Check response
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, 'wagtailadmin/pages/content_type_use.html')
         self.assertContains(response, "Christmas")
+
+        # Links to 'delete' etc should include a 'next' URL parameter pointing back here
+        delete_url = (
+            reverse('wagtailadmin_pages:delete', args=(self.christmas_page.id,))
+            + '?' + urlencode({'next': request_url})
+        )
+        self.assertContains(response, delete_url)

--- a/wagtail/admin/wagtail_hooks.py
+++ b/wagtail/admin/wagtail_hooks.py
@@ -1,5 +1,6 @@
 from django.contrib.auth.models import Permission
 from django.urls import reverse
+from django.utils.http import urlencode
 from django.utils.translation import gettext_lazy as _
 from django.utils.translation import gettext
 from draftjs_exporter.dom import DOM
@@ -26,10 +27,6 @@ from wagtail.core import hooks
 from wagtail.core.models import UserPagePermissionsProxy
 from wagtail.core.permissions import collection_permission_policy
 from wagtail.core.whitelist import allow_without_attributes, attribute_rule, check_url
-
-
-def append_querystring(path, querystring=None):
-    return '%s%s' % (path, '?%s' % querystring if querystring else '')
 
 
 class ExplorerMenuItem(MenuItem):
@@ -177,23 +174,36 @@ def page_listing_more_buttons(page, page_perms, is_parent=False, next_url=None):
             priority=10
         )
     if page_perms.can_copy():
+        url = reverse('wagtailadmin_pages:copy', args=[page.id])
+        if next_url:
+            url += '?' + urlencode({'next': next_url})
+
+        urlencode
         yield Button(
             _('Copy'),
-            append_querystring(reverse('wagtailadmin_pages:copy', args=[page.id]), next_url),
+            url,
             attrs={'title': _("Copy page '%(title)s'") % {'title': page.get_admin_display_title()}},
             priority=20
         )
     if page_perms.can_delete():
+        url = reverse('wagtailadmin_pages:delete', args=[page.id])
+        if next_url:
+            url += '?' + urlencode({'next': next_url})
+
         yield Button(
             _('Delete'),
-            append_querystring(reverse('wagtailadmin_pages:delete', args=[page.id]), next_url),
+            url,
             attrs={'title': _("Delete page '%(title)s'") % {'title': page.get_admin_display_title()}},
             priority=30
         )
     if page_perms.can_unpublish():
+        url = reverse('wagtailadmin_pages:unpublish', args=[page.id])
+        if next_url:
+            url += '?' + urlencode({'next': next_url})
+
         yield Button(
             _('Unpublish'),
-            append_querystring(reverse('wagtailadmin_pages:unpublish', args=[page.id]), next_url),
+            url,
             attrs={'title': _("Unpublish page '%(title)s'") % {'title': page.get_admin_display_title()}},
             priority=40
         )


### PR DESCRIPTION
Follow-up to #6218:

* Add test for the original issue #3010
* Refactor `next_url` so that the value being passed is the unescaped URL, rather than one embedded into a querystring (which unnecessarily ties it to Wagtail's own parameter-passing scheme and makes it less useful to third-party code)
* Document the purpose of next_url in reference docs and release notes