### PR TITLE
Prepare react-streamfield JS integration

### DIFF
--- a/wagtail/contrib/table_block/static/table_block/js/table.js
+++ b/wagtail/contrib/table_block/static/table_block/js/table.js
@@ -63,13 +63,11 @@ function initTable(id, tableOptions) {
     }
 
     if (!tableOptions.hasOwnProperty('width') || !tableOptions.hasOwnProperty('height')) {
-        // Size to parent .sequence-member-inner width if width is not given in tableOptions
         $(window).on('resize', function() {
             hot.updateSettings({
-                width: getWidth(),
+                width: '100%',
                 height: getHeight()
             });
-            resizeWidth('100%');
         });
     }
 

--- a/wagtail/contrib/table_block/static/table_block/js/table.js
+++ b/wagtail/contrib/table_block/static/table_block/js/table.js
@@ -21,9 +21,6 @@ function initTable(id, tableOptions) {
     var dataForForm = null;
     var isInitialized = false;
 
-    var getWidth = function() {
-        return $('.widget-table_input').closest('.sequence-member-inner').width();
-    };
     var getHeight = function() {
         var tableParent = $('#' + id).parent();
         return tableParent.find('.htCore').height() + (tableParent.find('.input').height() * 2);

--- a/wagtail/documents/static_src/wagtaildocs/js/document-chooser.js
+++ b/wagtail/documents/static_src/wagtaildocs/js/document-chooser.js
@@ -4,17 +4,21 @@ function createDocumentChooser(id) {
     var input = $('#' + id);
     var editLink = chooserElement.find('.edit-link');
 
+    function documentChosen(docData, isInitial) {
+        if (!isInitial) {
+          input.val(docData.id);
+        }
+        docTitle.text(docData.title);
+        chooserElement.removeClass('blank');
+        editLink.attr('href', docData.edit_link);
+    }
+
     $('.action-choose', chooserElement).on('click', function() {
         ModalWorkflow({
             url: window.chooserUrls.documentChooser,
             onload: DOCUMENT_CHOOSER_MODAL_ONLOAD_HANDLERS,
             responses: {
-                documentChosen: function(docData) {
-                    input.val(docData.id);
-                    docTitle.text(docData.title);
-                    chooserElement.removeClass('blank');
-                    editLink.attr('href', docData.edit_link);
-                }
+                documentChosen: documentChosen,
             }
         });
     });
@@ -23,4 +27,11 @@ function createDocumentChooser(id) {
         input.val('');
         chooserElement.addClass('blank');
     });
+
+    if (input.val()) {
+        $.ajax(window.chooserUrls.documentChooser + encodeURIComponent(input.val()) + '/')
+            .done(function (data) {
+                documentChosen(data.result, true);
+            });
+    }
 }

--- a/wagtail/images/static_src/wagtailimages/js/image-chooser.js
+++ b/wagtail/images/static_src/wagtailimages/js/image-chooser.js
@@ -4,23 +4,27 @@ function createImageChooser(id) {
     var input = $('#' + id);
     var editLink = chooserElement.find('.edit-link');
 
+    function imageChosen(imageData, isInitial) {
+        if (!isInitial) {
+          input.val(imageData.id);
+        }
+        previewImage.attr({
+            src: imageData.preview.url,
+            width: imageData.preview.width,
+            height: imageData.preview.height,
+            alt: imageData.title,
+            title: imageData.title
+        });
+        chooserElement.removeClass('blank');
+        editLink.attr('href', imageData.edit_link);
+    }
+
     $('.action-choose', chooserElement).on('click', function() {
         ModalWorkflow({
             url: window.chooserUrls.imageChooser,
             onload: IMAGE_CHOOSER_MODAL_ONLOAD_HANDLERS,
             responses: {
-                imageChosen: function(imageData) {
-                    input.val(imageData.id);
-                    previewImage.attr({
-                        src: imageData.preview.url,
-                        width: imageData.preview.width,
-                        height: imageData.preview.height,
-                        alt: imageData.title,
-                        title: imageData.title
-                    });
-                    chooserElement.removeClass('blank');
-                    editLink.attr('href', imageData.edit_link);
-                }
+                imageChosen: imageChosen,
             }
         });
     });
@@ -29,4 +33,11 @@ function createImageChooser(id) {
         input.val('');
         chooserElement.addClass('blank');
     });
+
+    if (input.val()) {
+        $.ajax(window.chooserUrls.imageChooser + encodeURIComponent(input.val()) + '/')
+            .done(function (data) {
+                imageChosen(data.result, true);
+            });
+    }
 }

--- a/wagtail/snippets/static_src/wagtailsnippets/js/snippet-chooser.js
+++ b/wagtail/snippets/static_src/wagtailsnippets/js/snippet-chooser.js
@@ -4,17 +4,21 @@ function createSnippetChooser(id, modelString) {
     var input = $('#' + id);
     var editLink = chooserElement.find('.edit-link');
 
+    function snippetChosen(snippetData, isInitial) {
+        if (!isInitial) {
+          input.val(snippetData.id);
+        }
+        docTitle.text(snippetData.string);
+        chooserElement.removeClass('blank');
+        editLink.attr('href', snippetData.edit_link);
+    }
+
     $('.action-choose', chooserElement).on('click', function() {
         ModalWorkflow({
             url: window.chooserUrls.snippetChooser + modelString + '/',
             onload: SNIPPET_CHOOSER_MODAL_ONLOAD_HANDLERS,
             responses: {
-                snippetChosen: function(snippetData) {
-                    input.val(snippetData.id);
-                    docTitle.text(snippetData.string);
-                    chooserElement.removeClass('blank');
-                    editLink.attr('href', snippetData.edit_link);
-                }
+                snippetChosen: snippetChosen,
             }
         });
     });
@@ -23,4 +27,12 @@ function createSnippetChooser(id, modelString) {
         input.val('');
         chooserElement.addClass('blank');
     });
+
+    if (input.val()) {
+        $.ajax(window.chooserUrls.snippetChooser + modelString + '/'
+               + encodeURIComponent(input.val()) + '/')
+            .done(function (data) {
+                snippetChosen(data.result, true);
+            });
+    }
 }


### PR DESCRIPTION
This pull request integrates inside Wagtail all the JS compatibility fixes implemented in [wagtail/wagtail-react-streamfield](https://github.com/wagtail/wagtail-react-streamfield).

The **choosers fixes** are there to fix block duplication. Block duplication in react-streamfield is done by:
1. copying the block template (by “template” I mean the rendered block with a `__PREFIX__` ID in it)
2. running its inline `<script>`
3. changing its value to apply the value fetched from the original block

If we tried instead to copy the modified HTML and running the JS, it would result in a broken state for the block.

Before those chooser fixes, step 3 didn’t work because applying the original value only changed the hidden input state. It was not fetching the thumbnail and file/page/snippet name.

If you are concerned about the extra cost of the AJAX requests, we can always add conditional processing to page chooser Python views to prevent extra server and network cost. But keep in mind that with react-streamfield, StreamFields are considerably faster because we don’t render templates for each block, so the cost of the extra requests stays negligible, even for a huge StreamField.

The **table fix** is here to fix the width of the table that was overflowing from the block. That fix is perfectly compatible with the current StreamField.