### PR TITLE
Serve PDFs inline in the browser and make content-type / content-disposition configurable

### DIFF
--- a/docs/reference/settings.rst
+++ b/docs/reference/settings.rst
@@ -180,6 +180,26 @@ For this reason, Wagtail provides a number of serving methods which trade some o
 
 If ``WAGTAILDOCS_SERVE_METHOD`` is unspecified or set to ``None``, the default method is ``'redirect'`` when a remote storage backend is in use (i.e. one that exposes a URL but not a local filesystem path), and ``'serve_view'`` otherwise. Finally, some storage backends may not expose a URL at all; in this case, serving will proceed as for ``'serve_view'``.
 
+.. _wagtaildocs_content_types:
+
+.. code-block:: python
+
+  WAGTAILDOCS_CONTENT_TYPES = {
+      'pdf': 'application/pdf',
+      'txt': 'text/plain',
+  }
+
+Specifies the MIME content type that will be returned for the given file extension, when using the ``serve_view`` method. Content types not listed here will be guessed using the Python ``mimetypes.guess_type`` function, or ``application/octet-stream`` if unsuccessful.
+
+.. _wagtaildocs_inline_content_types:
+
+.. code-block:: python
+
+  WAGTAILDOCS_INLINE_CONTENT_TYPES = ['application/pdf', 'text/plain']
+
+A list of MIME content types that will be shown inline in the browser (by serving the HTTP header ``Content-Disposition: inline``) rather than served as a download, when using the ``serve_view`` method. Defaults to ``application/pdf``.
+
+
 Password Management
 ===================
 

--- a/wagtail/documents/tests/test_models.py
+++ b/wagtail/documents/tests/test_models.py
@@ -87,21 +87,43 @@ class TestDocumentFilenameProperties(TestCase):
         self.document = models.Document(title="Test document")
         self.document.file.save('example.doc', ContentFile("A boring example document"))
 
+        self.pdf_document = models.Document(title="Test document")
+        self.pdf_document.file.save('example.pdf', ContentFile("A boring example document"))
+
         self.extensionless_document = models.Document(title="Test document")
         self.extensionless_document.file.save('example', ContentFile("A boring example document"))
 
     def test_filename(self):
         self.assertEqual('example.doc', self.document.filename)
+        self.assertEqual('example.pdf', self.pdf_document.filename)
         self.assertEqual('example', self.extensionless_document.filename)
 
     def test_file_extension(self):
         self.assertEqual('doc', self.document.file_extension)
+        self.assertEqual('pdf', self.pdf_document.file_extension)
         self.assertEqual('', self.extensionless_document.file_extension)
+
+    def test_content_type(self):
+        self.assertEqual('application/msword', self.document.content_type)
+        self.assertEqual('application/pdf', self.pdf_document.content_type)
+        self.assertEqual('application/octet-stream', self.extensionless_document.content_type)
+
+    def test_content_disposition(self):
+        self.assertEqual(
+            '''attachment; filename=example.doc; filename*=UTF-8''example.doc''',
+            self.document.content_disposition
+        )
+        self.assertEqual('inline', self.pdf_document.content_disposition)
+        self.assertEqual(
+            '''attachment; filename=example; filename*=UTF-8''example''',
+            self.extensionless_document.content_disposition
+        )
 
     def tearDown(self):
         # delete the FieldFile directly because the TestCase does not commit
         # transactions to trigger transaction.on_commit() in the signal handler
         self.document.file.delete()
+        self.pdf_document.file.delete()
         self.extensionless_document.file.delete()
 
 

--- a/wagtail/utils/sendfile.py
+++ b/wagtail/utils/sendfile.py
@@ -85,6 +85,8 @@ def sendfile(request, filename, attachment=False, attachment_filename=None, mime
                 parts.append('filename*=UTF-8\'\'%s' % quoted_filename)
 
         response['Content-Disposition'] = '; '.join(parts)
+    else:
+        response['Content-Disposition'] = 'inline'
 
     response['Content-length'] = os.path.getsize(filename)
     response['Content-Type'] = mimetype


### PR DESCRIPTION
Fixes #1158
Add config options WAGTAILDOCS_CONTENT_TYPES and WAGTAILDOCS_INLINE_CONTENT_TYPES to determine the Content-Type and Content-Disposition headers returned for documents when using the Django serve view, and default to application/pdf being served inline.

