### PR TITLE
[RFC 54] Internationalisation UI changes for snippets/modeladmin

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/admin_base.html
+++ b/wagtail/admin/templates/wagtailadmin/admin_base.html
@@ -27,6 +27,12 @@
                 EXTRA_CHILDREN_PARAMETERS: '',
             };
 
+            // The locale of the current page/snippet being edited
+            wagtailConfig.ACTIVE_CONTENT_LOCALE = null;
+            {% if locale %}
+                wagtailConfig.ACTIVE_CONTENT_LOCALE = '{{ locale.language_code }}'
+            {% endif %}
+
             wagtailConfig.STRINGS = {% js_translation_strings %};
 
             wagtailConfig.ADMIN_URLS = {

--- a/wagtail/contrib/modeladmin/options.py
+++ b/wagtail/contrib/modeladmin/options.py
@@ -9,7 +9,7 @@ from django.utils.safestring import mark_safe
 from wagtail.admin.checks import check_panels_in_model
 from wagtail.admin.edit_handlers import ObjectList, extract_panel_definitions_from_model_class
 from wagtail.core import hooks
-from wagtail.core.models import Page
+from wagtail.core.models import Page, TranslatableMixin
 
 from .helpers import (
     AdminURLHelper, ButtonHelper, DjangoORMSearchHandler, PageAdminURLHelper, PageButtonHelper,
@@ -222,7 +222,12 @@ class ModelAdmin(WagtailRegisterable):
         Returns a sequence containing the fields to be displayed as filters in
         the right sidebar in the list view.
         """
-        return self.list_filter
+        list_filter = self.list_filter
+
+        if issubclass(self.model, TranslatableMixin):
+            list_filter += ('locale', )
+
+        return list_filter
 
     def get_ordering(self, request):
         """

--- a/wagtail/contrib/modeladmin/templates/modeladmin/index.html
+++ b/wagtail/contrib/modeladmin/templates/modeladmin/index.html
@@ -22,6 +22,21 @@
                         {% block h1 %}<h1 {% if view.header_icon %}class="icon icon-{{ view.header_icon }}"{% endif %}>{{ view.get_page_title }}<span></span></h1>{% endblock %}
                     </div>
                     {% block search %}{% search_form %}{% endblock %}
+
+                    {% if locales %}
+                    <select id="locales" name="lang">
+                        {% for locale in locales %}
+                            <option value="{{ locale.language_code }}"{% if locale == chosen_locale %} selected{% endif %}>{{ locale.get_display_name }}</option>
+                        {% endfor %}
+                    </select>
+                    <script type="text/javascript">
+                        $(function() {
+                            $('#locales').change(function() {
+                                window.location.href = '?lang=' + $(this).val();
+                            });
+                        });
+                    </script>
+                {% endif %}
                 </div>
                 {% block header_extra %}
                     <div class="right">

--- a/wagtail/contrib/modeladmin/views.py
+++ b/wagtail/contrib/modeladmin/views.py
@@ -252,7 +252,8 @@ class IndexView(SpreadsheetExportMixin, WMABaseView):
     SEARCH_VAR = 'q'
     ERROR_FLAG = 'e'
     EXPORT_VAR = 'export'
-    IGNORED_PARAMS = (ORDER_VAR, ORDER_TYPE_VAR, SEARCH_VAR, EXPORT_VAR)
+    LANG_VAR = 'lang'
+    IGNORED_PARAMS = (ORDER_VAR, ORDER_TYPE_VAR, SEARCH_VAR, EXPORT_VAR, LANG_VAR)
 
     # sortable_by is required by the django.contrib.admin.templatetags.admin_list.result_headers
     # template tag as of Django 2.1 - see https://docs.djangoproject.com/en/2.1/ref/contrib/admin/#django.contrib.admin.ModelAdmin.sortable_by

--- a/wagtail/snippets/static_src/wagtailsnippets/js/snippet-chooser-modal.js
+++ b/wagtail/snippets/static_src/wagtailsnippets/js/snippet-chooser-modal.js
@@ -13,13 +13,24 @@ SNIPPET_CHOOSER_MODAL_ONLOAD_HANDLERS = {
             });
         }
 
-        var searchUrl = $('form.snippet-search', modal.body).attr('action');
+        var searchForm$ = $('form.snippet-search', modal.body);
+        var searchUrl = searchForm$.attr('action');
         var request;
 
         function search() {
+            var data = {q: $('#id_q').val(), results: 'true'};
+
+            if (searchForm$.has('input[name="locale"]')) {
+                data['locale'] = $('input[name="locale"]', searchForm$).val();
+            }
+
+            if (searchForm$.has('#snippet-chooser-locale')) {
+                data['locale_filter'] = $('#snippet-chooser-locale', searchForm$).val();
+            }
+
             request = $.ajax({
                 url: searchUrl,
-                data: {q: $('#id_q').val(), results: 'true'},
+                data: data,
                 success: function(data, status) {
                     request = null;
                     $('#search-results').html(data);

--- a/wagtail/snippets/static_src/wagtailsnippets/js/snippet-chooser.js
+++ b/wagtail/snippets/static_src/wagtailsnippets/js/snippet-chooser.js
@@ -5,8 +5,17 @@ function createSnippetChooser(id, modelString) {
     var editLink = chooserElement.find('.edit-link');
 
     $('.action-choose', chooserElement).on('click', function() {
+        var urlQuery = '';
+        if (wagtailConfig.ACTIVE_CONTENT_LOCALE) {
+            // The user is editing a piece of translated content.
+            // Pass the locale along as a request parameter. If this
+            // snippet is also translatable, the results will be
+            // pre-filtered by this locale.
+            urlQuery = '?locale=' + wagtailConfig.ACTIVE_CONTENT_LOCALE;
+        }
+
         ModalWorkflow({
-            url: chooserElement.data('chooserUrl') + modelString + '/',
+            url: chooserElement.data('chooserUrl') + modelString + '/' + urlQuery,
             onload: SNIPPET_CHOOSER_MODAL_ONLOAD_HANDLERS,
             responses: {
                 snippetChosen: function(snippetData) {

--- a/wagtail/snippets/templates/wagtailsnippets/chooser/choose.html
+++ b/wagtail/snippets/templates/wagtailsnippets/chooser/choose.html
@@ -6,12 +6,37 @@
     {# Need to keep the form in the HTML, even if the snippet is not searchable #}
     {# This is to allow pagination links to be generated from the form action URL #}
     <form class="snippet-search search-bar" action="{% url 'wagtailsnippets:choose' model_opts.app_label model_opts.model_name %}" method="GET" novalidate>
+        {% if locale %}
+            <input type="hidden" name="locale" value="{{ locale.language_code }}">
+        {% endif %}
+
         {% if is_searchable %}
             <ul class="fields">
                 {% for field in search_form %}
                     {% include "wagtailadmin/shared/field_as_li.html" with field=field %}
                 {% endfor %}
                 <li class="submit"><input type="submit" value="{% trans 'Search' %}" class="button" /></li>
+            </ul>
+        {% endif %}
+
+        {% if locale_options %}
+            <ul class="fields">
+                <li class="col">
+                    <div class="field field-small">
+                        <select id="snippet-chooser-locale" name="lang">
+                            {% for locale_option in locale_options %}
+                                <option value="{{ locale_option.language_code }}"{% if locale_option == selected_locale %} selected{% endif %}>{{ locale_option.get_display_name }}</option>
+                            {% endfor %}
+                        </select>
+                        <script type="text/javascript">
+                            $(function() {
+                                $('#snippet-chooser-locale').change(function() {
+                                    $('form.snippet-search').submit();
+                                });
+                            });
+                        </script>
+                    </div>
+                </li>
             </ul>
         {% endif %}
     </form>

--- a/wagtail/snippets/templates/wagtailsnippets/snippets/create.html
+++ b/wagtail/snippets/templates/wagtailsnippets/snippets/create.html
@@ -5,7 +5,7 @@
     {% trans "New" as new_str %}
     {% include "wagtailadmin/shared/header.html" with title=new_str subtitle=model_opts.verbose_name icon="snippet" tabbed=1 merged=1 %}
 
-    <form action="{% url 'wagtailsnippets:add' model_opts.app_label model_opts.model_name %}" method="POST" novalidate{% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>
+    <form action="{% url 'wagtailsnippets:add' model_opts.app_label model_opts.model_name %}{% if locale %}?locale={{ locale.language_code }}{% endif %}" method="POST" novalidate{% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>
         {% csrf_token %}
         {{ edit_handler.render_form_content }}
 

--- a/wagtail/snippets/templates/wagtailsnippets/snippets/type_index.html
+++ b/wagtail/snippets/templates/wagtailsnippets/snippets/type_index.html
@@ -74,7 +74,7 @@
                         {% endif %}
                         {% if can_add_snippet %}
                             <li class="col">
-                                <a href="{% url 'wagtailsnippets:add' model_opts.app_label model_opts.model_name %}" class="button bicolor button--icon">
+                                <a href="{% url 'wagtailsnippets:add' model_opts.app_label model_opts.model_name %}{% if chosen_locale %}?locale={{ chosen_locale.language_code }}{% endif %}" class="button bicolor button--icon">
                                     {% icon name="plus" wrapped=1 %}
                                     {% blocktrans with snippet_type_name=model_opts.verbose_name %}Add {{ snippet_type_name }}{% endblocktrans %}</a>
                                 {# TODO: figure out a way of saying "Add a/an [foo]" #}

--- a/wagtail/snippets/templates/wagtailsnippets/snippets/type_index.html
+++ b/wagtail/snippets/templates/wagtailsnippets/snippets/type_index.html
@@ -20,34 +20,68 @@
 
     <header class="nice-padding">
         <div class="row row-flush">
-            <div class="left col6 header-title">
-                <h1>{% icon name="snippet" class_name="header-title-icon" %}
-                {% blocktrans with snippet_type_name_plural=model_opts.verbose_name_plural|capfirst %}Snippets <span>{{ snippet_type_name_plural }}</span>{% endblocktrans %}</h1>
+            <div class="left">
+                <div class="col header-title">
+                    <h1>{% icon name="snippet" class_name="header-title-icon" %}
+                        {% blocktrans with snippet_type_name_plural=model_opts.verbose_name_plural|capfirst %}Snippets <span>{{ snippet_type_name_plural }}</span>{% endblocktrans %}</h1>
 
-                {% if is_searchable %}
-                    <form class="col search-form" action="{% url 'wagtailsnippets:list' model_opts.app_label model_opts.model_name %}" method="get" novalidate>
-                        <ul class="fields">
-                            {% for field in search_form %}
-                                {% include "wagtailadmin/shared/field_as_li.html" with field=field field_classes="field-small iconfield" input_classes="icon-search" %}
-                            {% endfor %}
-                            <li class="submit visuallyhidden"><input type="submit" value="Search" class="button" /></li>
-                        </ul>
-                    </form>
+                    {% if is_searchable %}
+                        <form class="col search-form" action="{% url 'wagtailsnippets:list' model_opts.app_label model_opts.model_name %}" method="get" novalidate>
+                            <ul class="fields">
+                                {% for field in search_form %}
+                                    {% include "wagtailadmin/shared/field_as_li.html" with field=field field_classes="field-small iconfield" input_classes="icon-search" %}
+                                {% endfor %}
+                                <li class="submit visuallyhidden"><input type="submit" value="Search" class="button" /></li>
+                            </ul>
+                        </form>
+                    {% endif %}
+                </div>
+
+                {% if locales %}
+                    <div class="col">
+
+                    </div>
                 {% endif %}
             </div>
-            <div class="right col6">
-                {% if can_delete_snippets %}
-                    <a class="button bicolor button--icon serious delete-button u-hidden" data-url="{% url 'wagtailsnippets:delete-multiple' model_opts.app_label model_opts.model_name %}?">
-                        {% icon name="bin" wrapped=1 %}
-                        {% blocktrans with snippet_type_name=model_opts.verbose_name_plural %}Delete {{ snippet_type_name }}{% endblocktrans %}
-                    </a>
-                {% endif %}
-                {% if can_add_snippet %}
-                    <a href="{% url 'wagtailsnippets:add' model_opts.app_label model_opts.model_name %}" class="button bicolor button--icon">
-                        {% icon name="plus" wrapped=1 %}
-                        {% blocktrans with snippet_type_name=model_opts.verbose_name %}Add {{ snippet_type_name }}{% endblocktrans %}</a>
-                    {# TODO: figure out a way of saying "Add a/an [foo]" #}
-                {% endif %}
+            <div class="right col">
+                <form>  {# HACK Removes list-style-type #}
+                    <ul class="fields row rowflush">
+                        {% if can_delete_snippets %}
+                            <li class="col">
+                                <a class="button bicolor button--icon serious delete-button u-hidden" data-url="{% url 'wagtailsnippets:delete-multiple' model_opts.app_label model_opts.model_name %}?">
+                                    {% icon name="bin" wrapped=1 %}
+                                    {% blocktrans with snippet_type_name=model_opts.verbose_name_plural %}Delete {{ snippet_type_name }}{% endblocktrans %}
+                                </a>
+                            </li>
+                        {% endif %}
+                        {% if locales %}
+                            <li class="col">
+                                <div class="field field-small">
+                                    <select id="locales" name="lang">
+                                        {% for locale in locales %}
+                                            <option value="{{ locale.language_code }}"{% if locale == chosen_locale %} selected{% endif %}>{{ locale.get_display_name }}</option>
+                                        {% endfor %}
+                                    </select>
+                                    <script type="text/javascript">
+                                        $(function() {
+                                            $('#locales').change(function() {
+                                                window.location.href = '?lang=' + $(this).val();
+                                            });
+                                        });
+                                    </script>
+                                </div>
+                            </li>
+                        {% endif %}
+                        {% if can_add_snippet %}
+                            <li class="col">
+                                <a href="{% url 'wagtailsnippets:add' model_opts.app_label model_opts.model_name %}" class="button bicolor button--icon">
+                                    {% icon name="plus" wrapped=1 %}
+                                    {% blocktrans with snippet_type_name=model_opts.verbose_name %}Add {{ snippet_type_name }}{% endblocktrans %}</a>
+                                {# TODO: figure out a way of saying "Add a/an [foo]" #}
+                            </li>
+                        {% endif %}
+                    </ul>
+                </form>
             </div>
         </div>
     </header>

--- a/wagtail/snippets/views/snippets.py
+++ b/wagtail/snippets/views/snippets.py
@@ -282,6 +282,7 @@ def edit(request, app_label, model_name, pk):
         'edit_handler': edit_handler,
         'form': form,
         'action_menu': SnippetActionMenu(request, view='edit', instance=instance),
+        'locale': instance.locale if isinstance(instance, TranslatableMixin) else None,
     })
 
 

--- a/wagtail/snippets/views/snippets.py
+++ b/wagtail/snippets/views/snippets.py
@@ -163,6 +163,16 @@ def create(request, app_label, model_name):
             return result
 
     instance = model()
+
+    # Set locale of the new instance
+    if issubclass(model, TranslatableMixin):
+        selected_locale = request.GET.get('locale')
+        if selected_locale:
+            instance.locale = get_object_or_404(Locale, language_code=selected_locale)
+        else:
+            instance.locale = Locale.get_default()
+
+    # Make edit handler
     edit_handler = get_snippet_edit_handler(model)
     edit_handler = edit_handler.bind_to(request=request)
     form_class = edit_handler.get_form_class()
@@ -191,7 +201,11 @@ def create(request, app_label, model_name):
                 if hasattr(result, 'status_code'):
                     return result
 
-            return redirect('wagtailsnippets:list', app_label, model_name)
+            urlquery = ''
+            if isinstance(instance, TranslatableMixin) and instance.locale is not Locale.get_default():
+                urlquery = '?lang=' + instance.locale.language_code
+
+            return redirect(reverse('wagtailsnippets:list', args=[app_label, model_name]) + urlquery)
         else:
             messages.validation_error(
                 request, _("The snippet could not be created due to errors."), form
@@ -206,6 +220,7 @@ def create(request, app_label, model_name):
         'edit_handler': edit_handler,
         'form': form,
         'action_menu': SnippetActionMenu(request, view='create', model=model),
+        'locale': instance.locale if isinstance(instance, TranslatableMixin) else None,
     })
 
 


### PR DESCRIPTION
This PR implements UI changes for the internationalisation feature as specified in: https://github.com/wagtail/rfcs/pull/54


- [x] Locale switcher on snippet index
- [x] Locale switcher on modeladmin index
---

- [x] Locale restriction on snippet chooser - 3h
  - (Needs tests)

---

- [ ] Locale switcher on settings edit
- [ ] Locale switcher on snippet edit
- [ ] Locale switcher on modeladmin edit