### PR TITLE
Add icon sprite

### DIFF
--- a/client/src/components/Icon/Icon.js
+++ b/client/src/components/Icon/Icon.js
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import { ADMIN_URLS } from '../../config/wagtailConfig';
 
 /**
  * Provide a `title` as an accessible label intended for screen readers.
@@ -7,7 +8,7 @@ import React from 'react';
 const Icon = ({ name, className, title }) => (
   <span>
     <svg className={`icon icon-${name} ${className || ''}`} aria-hidden="true">
-      <use href={`#icon-${name}`}></use>
+      <use href={`${ADMIN_URLS.SPRITE}#icon-${name}`}></use>
     </svg>
     {title ? (
       <span className="visuallyhidden">

--- a/client/src/utils/polyfills.js
+++ b/client/src/utils/polyfills.js
@@ -8,3 +8,10 @@ import 'core-js/shim';
 import 'whatwg-fetch';
 // IE11.
 import 'element-closest';
+// IE11.
+import { IS_IE11 } from '../config/wagtailConfig';
+import svg4everybody from 'svg4everybody';
+
+if (IS_IE11) {
+  svg4everybody();
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -17453,6 +17453,11 @@
       "integrity": "sha1-WPcc7jvVGbWdSyqEO2x95krAR2Q=",
       "dev": true
     },
+    "svg4everybody": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/svg4everybody/-/svg4everybody-2.1.9.tgz",
+      "integrity": "sha1-W9n23vwTOFmgRGRtR0P6vCjbfi0="
+    },
     "svgo": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/svgo/-/svgo-0.7.2.tgz",

--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "react-transition-group": "^1.1.3",
     "redux": "^4.0.0",
     "redux-thunk": "^2.3.0",
+    "svg4everybody": "^2.1.9",
     "whatwg-fetch": "^2.0.3"
   },
   "scripts": {

--- a/wagtail/admin/templates/wagtailadmin/admin_base.html
+++ b/wagtail/admin/templates/wagtailadmin/admin_base.html
@@ -30,7 +30,8 @@
             wagtailConfig.STRINGS = {% js_translation_strings %};
 
             wagtailConfig.ADMIN_URLS = {
-                PAGES: '{% url "wagtailadmin_explore_root" %}'
+                PAGES: '{% url "wagtailadmin_explore_root" %}',
+                SPRITE: '{% url "wagtailadmin_sprite" %}',
             };
         })(document, window);
     </script>

--- a/wagtail/admin/templates/wagtailadmin/icons/sprite.svg
+++ b/wagtail/admin/templates/wagtailadmin/icons/sprite.svg
@@ -1,0 +1,3 @@
+{% load wagtailadmin_tags %}
+
+{% icons %}

--- a/wagtail/admin/templates/wagtailadmin/shared/icon.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/icon.html
@@ -2,7 +2,7 @@
 {# Reference implementation: components/Icon.js #}
 {% if wrapped %}<span class="icon-wrapper">{% endif %}
 <svg class="icon icon-{{ name }} {{ class_name }}" aria-hidden="true" focusable="false">
-  <use href="#icon-{{ name }}"></use>
+  <use href="{{ sprite }}#icon-{{ name }}"></use>
 </svg>
 {% if title %}
   <span class="visuallyhidden">

--- a/wagtail/admin/templates/wagtailadmin/shared/icons.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/icons.html
@@ -1,11 +1,9 @@
 {% spaceless %}
-<div style="display: none">
-  <svg>
-      <defs>
+<svg xmlns="http://www.w3.org/2000/svg">
+    <defs>
         {% for icon in icons %}
             {% include icon %}
         {% endfor %}
-      </defs>
-  </svg>
-</div>
+    </defs>
+</svg>
 {% endspaceless %}

--- a/wagtail/admin/templates/wagtailadmin/skeleton.html
+++ b/wagtail/admin/templates/wagtailadmin/skeleton.html
@@ -13,6 +13,7 @@
     <script src="{% versioned_static 'wagtailadmin/js/vendor/modernizr-2.6.2.min.js' %}"></script>
 
     <link rel="stylesheet" href="{% versioned_static 'wagtailadmin/css/normalize.css' %}" />
+    <link rel="preload" href="{% url 'wagtailadmin_sprite' %}">
 
     {% block css %}{% endblock %}
 
@@ -28,8 +29,6 @@
             Here are the <a href="https://www.enable-javascript.com/" target="_blank" rel="noopener noreferrer">instructions how to enable JavaScript in your web browser</a>.
         {% endblocktrans %}
     </noscript>
-
-    {% icons %}
 
     {% block js %}{% endblock %}
 

--- a/wagtail/admin/templates/wagtailadmin/userbar/base.html
+++ b/wagtail/admin/templates/wagtailadmin/userbar/base.html
@@ -18,7 +18,7 @@
                         </defs>
                     </svg>
                   </div>
-                  {% icon name="wagtail-icon" class_name="wagtail-userbar-icon" %}
+                  {% icon name="wagtail-icon" class_name="wagtail-userbar-icon" sprite="" %}
                 {% endblock %}
                 <span class="wagtail-userbar-help-text">{% trans 'Go to Wagtail admin interface' %}</span>
             </div>

--- a/wagtail/admin/templates/wagtailadmin/userbar/item_admin.html
+++ b/wagtail/admin/templates/wagtailadmin/userbar/item_admin.html
@@ -4,7 +4,7 @@
 {% block item_content %}
     <div class="wagtail-action">
         <a href="{% url 'wagtailadmin_home' %}" target="_parent">
-          {% icon name="wagtail-icon" class_name="wagtail-action-icon" %}
+          {% icon name="wagtail-icon" class_name="wagtail-action-icon" sprite="" %}
           {% trans 'Go to Wagtail admin' %}
         </a>
     </div>

--- a/wagtail/admin/templates/wagtailadmin/userbar/item_page_add.html
+++ b/wagtail/admin/templates/wagtailadmin/userbar/item_page_add.html
@@ -4,7 +4,7 @@
 {% block item_content %}
     <div class="wagtail-action">
         <a href="{% url 'wagtailadmin_pages:add_subpage' self.page.id %}" target="_parent">
-          {% icon name="plus" class_name="wagtail-action-icon" %}
+          {% icon name="plus" class_name="wagtail-action-icon" sprite="" %}
           {% trans 'Add a child page' %}
         </a>
     </div>

--- a/wagtail/admin/templates/wagtailadmin/userbar/item_page_approve.html
+++ b/wagtail/admin/templates/wagtailadmin/userbar/item_page_approve.html
@@ -6,7 +6,7 @@
         {% csrf_token %}
         <div class="wagtail-action">
           <button type="submit" value="{% trans 'Approve' %}" class="button">
-            {% icon name="tick" class_name="wagtail-action-icon" %}
+            {% icon name="tick" class_name="wagtail-action-icon" sprite="" %}
             {% trans 'Approve' %}
           </button>
         </div>

--- a/wagtail/admin/templates/wagtailadmin/userbar/item_page_edit.html
+++ b/wagtail/admin/templates/wagtailadmin/userbar/item_page_edit.html
@@ -4,7 +4,7 @@
 {% block item_content %}
     <div class="wagtail-action">
         <a href="{% url 'wagtailadmin_pages:edit' self.page.id %}" target="_parent">
-          {% icon name="edit" class_name="wagtail-action-icon" %}
+          {% icon name="edit" class_name="wagtail-action-icon" sprite="" %}
           {% trans 'Edit this page' %}
         </a>
     </div>

--- a/wagtail/admin/templates/wagtailadmin/userbar/item_page_explore.html
+++ b/wagtail/admin/templates/wagtailadmin/userbar/item_page_explore.html
@@ -4,7 +4,7 @@
 {% block item_content %}
     <div class="wagtail-action">
         <a href="{% url 'wagtailadmin_explore' self.parent_page.id %}" target="_parent">
-          {% icon name="folder-open-inverse" class_name="wagtail-action-icon" %}
+          {% icon name="folder-open-inverse" class_name="wagtail-action-icon" sprite="" %}
           {% trans 'Show in Explorer' %}
         </a>
     </div>

--- a/wagtail/admin/templates/wagtailadmin/userbar/item_page_reject.html
+++ b/wagtail/admin/templates/wagtailadmin/userbar/item_page_reject.html
@@ -6,7 +6,7 @@
         {% csrf_token %}
         <div class="wagtail-action">
           <button type="submit" value="{% trans 'Reject' %}" class="button">
-            {% icon name="cross" class_name="wagtail-action-icon" %}
+            {% icon name="cross" class_name="wagtail-action-icon" sprite="" %}
             {% trans 'Reject' %}
           </button>
         </div>

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -12,6 +12,7 @@ from django.contrib.messages.constants import DEFAULT_TAGS as MESSAGE_TAGS
 from django.template.defaultfilters import stringfilter
 from django.template.loader import render_to_string
 from django.templatetags.static import static
+from django.urls import reverse
 from django.utils.html import format_html, format_html_join
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
@@ -518,7 +519,7 @@ def versioned_static(path):
 
 
 @register.inclusion_tag("wagtailadmin/shared/icon.html", takes_context=False)
-def icon(name=None, class_name='icon', title=None, wrapped=False):
+def icon(name=None, class_name='icon', title=None, wrapped=False, sprite=True):
     """
     Abstracts away the actual icon implementation.
 
@@ -530,16 +531,21 @@ def icon(name=None, class_name='icon', title=None, wrapped=False):
     :param name: the icon name/id, required (string)
     :param class_name: default 'icon' (string)
     :param title: accessible label intended for screen readers (string)
+    :param sprite: a sprite location (string), set empty string for no sprite, Defaults to Wagtail admin sprite
     :return: Rendered template snippet (string)
     """
     if not name:
         raise ValueError("You must supply an icon name")
 
+    if sprite is True:
+        sprite = reverse("wagtailadmin_sprite")
+
     return {
         'name': name,
         'class_name': class_name,
         'title': title,
-        'wrapped': wrapped
+        'wrapped': wrapped,
+        'sprite': sprite,
     }
 
 

--- a/wagtail/admin/urls/__init__.py
+++ b/wagtail/admin/urls/__init__.py
@@ -1,6 +1,7 @@
 import functools
 
 from django.urls import include, path, re_path
+from django.utils.crypto import get_random_string
 from django.views.decorators.cache import never_cache
 from django.views.generic import TemplateView
 from django.http import Http404
@@ -121,3 +122,13 @@ urlpatterns = decorate_urlpatterns(
     urlpatterns,
     never_cache
 )
+
+random_string = get_random_string(length=8).lower()
+
+# Prepend sprite pattern to come before 404 and allow caching.
+urlpatterns = [
+    # Random string invalidates browser cache.
+    path(f"sprite-{random_string}.svg", home.sprite, name="wagtailadmin_sprite"),
+    # Allow multi instance setup. Serve the sprite no matter the filename.
+    path(f"sprite-<slug:slug>.svg", home.sprite),
+] + urlpatterns

--- a/wagtail/admin/views/home.py
+++ b/wagtail/admin/views/home.py
@@ -4,8 +4,10 @@ from django.contrib.auth.decorators import permission_required
 from django.db import connection
 from django.db.models import Max
 from django.http import Http404
+from django.shortcuts import render
 from django.template.loader import render_to_string
 from django.template.response import TemplateResponse
+from django.views.decorators.cache import cache_page
 
 from wagtail.admin.navigation import get_site_for_user
 from wagtail.admin.site_summary import SiteSummaryPanel
@@ -144,3 +146,11 @@ def default(request):
     redirected to the login page.
     """
     raise Http404
+
+
+@cache_page(31536000)  # 1 year
+def sprite(request, **kwargs):
+    response = render(request, "wagtailadmin/icons/sprite.svg")
+    response["Content-Type"] = "image/svg+xml"
+    response["Cache-Control"] = "max-age=31536000"  # 1 year
+    return response


### PR DESCRIPTION
This PR moves the SVG icons from the body of each page to an SVG sprite.

- Sprite lives at `/admin/icon-[random string].svg`
- Has one year cache. Both view cache and browser cache.
- The random string is part of the filename. `#` is needed to reference the symbols by id.
- Random string changes when server restarts. This invalidates cache and makes easy development possible.
- In multi instance setups, each instance might have its own random string. And additional url pattern serves the sprite no matter the random string.
- Admin urls are never cached, but I'd wanted `/admin/sprite-[random].svg` to be cached. Fixed it by adding the url pattern after the `decorate_urlpatterns` `never_cache`.
- Pattern is added before `decorate_urlpatterns` `display_custom_404`. To prevent 404.
- Added svg4everybody to polyfill ie11.
- Icon template tag accepts a sprite argument. This was needed for the edit bird. There is no polyfill in the frontend, so symbols are in the body. So we do not need the sprite url here.
- JS can reference the correct sprite url via `wagtailConfig.ADMIN_URLS.SPRITE`

* Do the tests still pass? ✅
* Does the code comply with the style guide? ✅
* For Python changes: Have you added tests to cover the new/fixed behaviour?❌ TODO
  - View test
     - 200
     - content type
     - cache header
  - URL test
    - Reverse gives pattern with random sting.
    - Calling multiple times gives same filename.
    - Match no matter the random string.

* For front-end changes: Did you test on all of Wagtail’s supported browsers? ✅

  - Mobile Safari | iOS Phone | Last 2✅  IOS 13.5 Safari 13.1
  - Mobile Safari | iOS Tablet | Last 2
  - Chrome | Android | Last 2
  - IE | Desktop | 11 ✅
  - Chrome | Desktop | Last 2 ✅  83.0.4103.116
  - MS Edge | Desktop | Last 2
  - Firefox | Desktop | Latest ❌  78.0.2   Icons flash in admin on load. Edit bird is okay.
  - Firefox ESR | Desktop | Latest❌  68.10.0esr   Icons flash in admin on load. Edit bird is okay.
  - Safari | macOS | Last 2 ✅ 13.1.1

* For new features: Has the documentation been updated accordingly? N/A

Finally 
- I saw that the Page menu item chevron flashes in _all_ browsers. That has nothing to do with this PR. Probably a JS thing.
- I need some helpt to debug the Firefox flash.


