### PR TITLE
Replace page explorer pushPage/popPage with gotoPage

### DIFF
--- a/client/src/components/Explorer/Explorer.js
+++ b/client/src/components/Explorer/Explorer.js
@@ -8,45 +8,40 @@ import ExplorerPanel from './ExplorerPanel';
 
 const Explorer = ({
   isVisible,
+  page,
   nodes,
-  path,
-  pushPage,
-  popPage,
+  depth,
+  gotoPage,
   onClose,
-}) => {
-  const page = nodes[path[path.length - 1]];
-
-  return isVisible ? (
-    <ExplorerPanel
-      path={path}
-      page={page}
-      nodes={nodes}
-      onClose={onClose}
-      popPage={popPage}
-      pushPage={pushPage}
-    />
-  ) : null;
-};
+}) => (isVisible ? (
+  <ExplorerPanel
+    page={nodes[page]}
+    nodes={nodes}
+    depth={depth}
+    onClose={onClose}
+    gotoPage={gotoPage}
+  />
+) : null);
 
 Explorer.propTypes = {
   isVisible: PropTypes.bool.isRequired,
-  path: PropTypes.array.isRequired,
+  page: PropTypes.number.isRequired,
   nodes: PropTypes.object.isRequired,
+  depth: PropTypes.number.isRequired,
 
-  pushPage: PropTypes.func.isRequired,
-  popPage: PropTypes.func.isRequired,
+  gotoPage: PropTypes.func.isRequired,
   onClose: PropTypes.func.isRequired,
 };
 
 const mapStateToProps = (state) => ({
   isVisible: state.explorer.isVisible,
-  path: state.explorer.path,
+  page: state.explorer.page,
   nodes: state.nodes,
+  depth: state.explorer.depth,
 });
 
 const mapDispatchToProps = (dispatch) => ({
-  pushPage: (id) => dispatch(actions.pushPage(id)),
-  popPage: () => dispatch(actions.popPage()),
+  gotoPage: (id, transition) => dispatch(actions.gotoPage(id, transition)),
   onClose: () => dispatch(actions.closeExplorer()),
 });
 

--- a/client/src/components/Explorer/Explorer.test.js
+++ b/client/src/components/Explorer/Explorer.test.js
@@ -39,13 +39,8 @@ describe('Explorer', () => {
       wrapper = shallow(<Explorer store={store} />);
     });
 
-    it('pushPage', () => {
-      wrapper.prop('pushPage')();
-      expect(store.dispatch).toHaveBeenCalled();
-    });
-
-    it('popPage', () => {
-      wrapper.prop('popPage')();
+    it('gotoPage', () => {
+      wrapper.prop('gotoPage')();
       expect(store.dispatch).toHaveBeenCalled();
     });
 

--- a/client/src/components/Explorer/ExplorerHeader.js
+++ b/client/src/components/Explorer/ExplorerHeader.js
@@ -9,32 +9,27 @@ import Icon from '../../components/Icon/Icon';
  * The bar at the top of the explorer, displaying the current level
  * and allowing access back to the parent level.
  */
-const ExplorerHeader = ({ page, depth, onClick }) => {
-  const isRoot = depth === 1;
-
-  return (
-    <Button
-      href={page.id ? `${ADMIN_URLS.PAGES}${page.id}/` : ADMIN_URLS.PAGES}
-      className="c-explorer__header"
-      onClick={onClick}
-    >
-      <div className="c-explorer__header__inner">
-        <Icon
-          name={isRoot ? 'home' : 'arrow-left'}
-          className="icon--explorer-header"
-        />
-        <span>{page.data && page.data.admin_display_title || STRINGS.PAGES}</span>
-      </div>
-    </Button>
-  );
-};
+const ExplorerHeader = ({ page, onClick }) => (
+  <Button
+    href={page.id ? `${ADMIN_URLS.PAGES}${page.id}/` : ADMIN_URLS.PAGES}
+    className="c-explorer__header"
+    onClick={onClick}
+  >
+    <div className="c-explorer__header__inner">
+      <Icon
+        name={page.parent ? 'arrow-left' : 'home'}
+        className="icon--explorer-header"
+      />
+      <span>{page.data && page.data.admin_display_title || STRINGS.PAGES}</span>
+    </div>
+  </Button>
+);
 
 ExplorerHeader.propTypes = {
   page: PropTypes.shape({
     id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     admin_display_title: PropTypes.string,
   }).isRequired,
-  depth: PropTypes.number.isRequired,
   onClick: PropTypes.func.isRequired,
 };
 

--- a/client/src/components/Explorer/ExplorerHeader.js
+++ b/client/src/components/Explorer/ExplorerHeader.js
@@ -11,7 +11,7 @@ import Icon from '../../components/Icon/Icon';
  */
 const ExplorerHeader = ({ page, onClick }) => (
   <Button
-    href={page.id ? `${ADMIN_URLS.PAGES}${page.id}/` : ADMIN_URLS.PAGES}
+    href={page.data.id ? `${ADMIN_URLS.PAGES}${page.data.id}/` : ADMIN_URLS.PAGES}
     className="c-explorer__header"
     onClick={onClick}
   >

--- a/client/src/components/Explorer/ExplorerHeader.js
+++ b/client/src/components/Explorer/ExplorerHeader.js
@@ -23,7 +23,7 @@ const ExplorerHeader = ({ page, depth, onClick }) => {
           name={isRoot ? 'home' : 'arrow-left'}
           className="icon--explorer-header"
         />
-        <span>{page.admin_display_title || STRINGS.PAGES}</span>
+        <span>{page.data && page.data.admin_display_title || STRINGS.PAGES}</span>
       </div>
     </Button>
   );

--- a/client/src/components/Explorer/ExplorerHeader.test.js
+++ b/client/src/components/Explorer/ExplorerHeader.test.js
@@ -4,8 +4,9 @@ import { mount, shallow } from 'enzyme';
 import ExplorerHeader from './ExplorerHeader';
 
 const mockProps = {
-  page: {},
-  depth: 2,
+  page: {
+    parent: 1,
+  },
   onClick: jest.fn(),
 };
 
@@ -18,12 +19,8 @@ describe('ExplorerHeader', () => {
     expect(shallow(<ExplorerHeader {...mockProps} />)).toMatchSnapshot();
   });
 
-  it('#depth at root', () => {
-    expect(shallow(<ExplorerHeader {...mockProps} depth={1} />)).toMatchSnapshot();
-  });
-
   it('#page', () => {
-    const wrapper = shallow(<ExplorerHeader {...mockProps} page={{ id: 'a', admin_display_title: 'test' }} />);
+    const wrapper = shallow(<ExplorerHeader {...mockProps} page={{ id: 'a', admin_display_title: 'test', parent: 1 }} />);
     expect(wrapper).toMatchSnapshot();
   });
 

--- a/client/src/components/Explorer/ExplorerHeader.test.js
+++ b/client/src/components/Explorer/ExplorerHeader.test.js
@@ -6,7 +6,6 @@ import ExplorerHeader from './ExplorerHeader';
 const mockProps = {
   page: {},
   depth: 2,
-  transitionName: 'pop',
   onClick: jest.fn(),
 };
 

--- a/client/src/components/Explorer/ExplorerItem.js
+++ b/client/src/components/Explorer/ExplorerItem.js
@@ -16,7 +16,7 @@ const childrenIcon = (
  * and information depending on the metadata of the page.
  */
 const ExplorerItem = ({ item, onClick }) => {
-  const { id, admin_display_title: title, meta } = item;
+  const { id, admin_display_title: title, meta } = item.data;
   const hasChildren = meta.children.count > 0;
   const isPublished = meta.status.live && !meta.status.has_unpublished_changes;
 
@@ -60,10 +60,12 @@ const ExplorerItem = ({ item, onClick }) => {
 
 ExplorerItem.propTypes = {
   item: PropTypes.shape({
-    id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
-    admin_display_title: PropTypes.string.isRequired,
-    meta: PropTypes.shape({
-      status: PropTypes.object.isRequired,
+    data: PropTypes.shape({
+      id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+      admin_display_title: PropTypes.string.isRequired,
+      meta: PropTypes.shape({
+        status: PropTypes.object.isRequired,
+      }).isRequired,
     }).isRequired,
   }).isRequired,
   onClick: PropTypes.func.isRequired,

--- a/client/src/components/Explorer/ExplorerItem.test.js
+++ b/client/src/components/Explorer/ExplorerItem.test.js
@@ -5,22 +5,24 @@ import ExplorerItem from './ExplorerItem';
 
 const mockProps = {
   item: {
-    id: 5,
-    admin_display_title: 'test',
-    meta: {
-      latest_revision_created_at: null,
-      status: {
-        live: true,
-        status: 'test',
-        has_unpublished_changes: false,
+    data: {
+      id: 5,
+      admin_display_title: 'test',
+      meta: {
+        latest_revision_created_at: null,
+        status: {
+          live: true,
+          status: 'test',
+          has_unpublished_changes: false,
+        },
+        descendants: {
+          count: 0,
+        },
+        children: {
+          count: 0,
+        }
       },
-      descendants: {
-        count: 0,
-      },
-      children: {
-        count: 0,
-      }
-    },
+    }
   },
   onClick: () => {},
 };
@@ -36,19 +38,19 @@ describe('ExplorerItem', () => {
 
   it('children', () => {
     const props = Object.assign({}, mockProps);
-    props.item.meta.children.count = 5;
+    props.item.data.meta.children.count = 5;
     expect(shallow(<ExplorerItem {...props} />)).toMatchSnapshot();
   });
 
   it('should show a publication status with unpublished changes', () => {
     const props = Object.assign({}, mockProps);
-    props.item.meta.status.has_unpublished_changes = true;
+    props.item.data.meta.status.has_unpublished_changes = true;
     expect(shallow(<ExplorerItem {...props} />)).toMatchSnapshot();
   });
 
   it('should show a publication status if not live', () => {
     const props = Object.assign({}, mockProps);
-    props.item.meta.status.live = false;
+    props.item.data.meta.status.live = false;
     expect(shallow(<ExplorerItem {...props} />)).toMatchSnapshot();
   });
 });

--- a/client/src/components/Explorer/ExplorerPanel.js
+++ b/client/src/components/Explorer/ExplorerPanel.js
@@ -30,8 +30,8 @@ class ExplorerPanel extends React.Component {
   }
 
   componentWillReceiveProps(newProps) {
-    const { path } = this.props;
-    const isPush = newProps.path.length > path.length;
+    const { depth } = this.props;
+    const isPush = newProps.depth > depth;
 
     this.setState({
       transition: isPush ? PUSH : POP,
@@ -70,23 +70,22 @@ class ExplorerPanel extends React.Component {
   }
 
   onItemClick(id, e) {
-    const { pushPage } = this.props;
+    const { gotoPage } = this.props;
 
     e.preventDefault();
     e.stopPropagation();
 
-    pushPage(id);
+    gotoPage(id, 1);
   }
 
   onHeaderClick(e) {
-    const { path, popPage } = this.props;
-    const hasBack = path.length > 1;
+    const { page, gotoPage } = this.props;
 
-    if (hasBack) {
+    if (page.parent) {
       e.preventDefault();
       e.stopPropagation();
 
-      popPage();
+      gotoPage(page.parent, -1);
     }
   }
 
@@ -132,7 +131,7 @@ class ExplorerPanel extends React.Component {
   }
 
   render() {
-    const { page, onClose, path } = this.props;
+    const { page, depth, onClose } = this.props;
     const { transition, paused } = this.state;
 
     return (
@@ -150,9 +149,8 @@ class ExplorerPanel extends React.Component {
           {STRINGS.CLOSE_EXPLORER}
         </Button>
         <Transition name={transition} className="c-explorer" component="nav" label={STRINGS.PAGE_EXPLORER}>
-          <div key={path.length} className="c-transition-group">
+          <div key={depth} className="c-transition-group">
             <ExplorerHeader
-              depth={path.length}
               page={page}
               onClick={this.onHeaderClick}
             />
@@ -171,7 +169,6 @@ class ExplorerPanel extends React.Component {
 
 ExplorerPanel.propTypes = {
   nodes: PropTypes.object.isRequired,
-  path: PropTypes.array.isRequired,
   page: PropTypes.shape({
     isFetching: PropTypes.bool,
     children: PropTypes.shape({
@@ -179,9 +176,9 @@ ExplorerPanel.propTypes = {
       items: PropTypes.array,
     }),
   }).isRequired,
+  depth: PropTypes.number.isRequired,
   onClose: PropTypes.func.isRequired,
-  popPage: PropTypes.func.isRequired,
-  pushPage: PropTypes.func.isRequired,
+  gotoPage: PropTypes.func.isRequired,
 };
 
 export default ExplorerPanel;

--- a/client/src/components/Explorer/ExplorerPanel.test.js
+++ b/client/src/components/Explorer/ExplorerPanel.test.js
@@ -4,14 +4,14 @@ import ExplorerPanel from './ExplorerPanel';
 
 const mockProps = {
   page: {
+    parent: 1,
     children: {
       items: [],
     },
   },
+  depth: 1,
   onClose: jest.fn(),
-  path: [],
-  popPage: jest.fn(),
-  pushPage: jest.fn(),
+  gotoPage: jest.fn(),
   nodes: {},
 };
 
@@ -72,38 +72,40 @@ describe('ExplorerPanel', () => {
 
   describe('onHeaderClick', () => {
     beforeEach(() => {
-      mockProps.popPage.mockReset();
+      mockProps.gotoPage.mockReset();
     });
 
-    it('calls popPage', () => {
+    it('calls gotoPage', () => {
       shallow((
-        <ExplorerPanel {...mockProps} path={[1, 2, 3]} />
+        <ExplorerPanel {...mockProps} depth={1} />
       )).find('ExplorerHeader').prop('onClick')({
         preventDefault() {},
         stopPropagation() {},
       });
 
-      expect(mockProps.popPage).toHaveBeenCalled();
+      expect(mockProps.gotoPage).toHaveBeenCalled();
     });
 
-    it('does not call popPage for first page', () => {
+    it('does not call gotoPage for first page', () => {
+      mockProps.page.parent = null;
+
       shallow((
-        <ExplorerPanel {...mockProps} path={[1]} />
+        <ExplorerPanel {...mockProps} depth={1} />
       )).find('ExplorerHeader').prop('onClick')({
         preventDefault() {},
         stopPropagation() {},
       });
 
-      expect(mockProps.popPage).not.toHaveBeenCalled();
+      expect(mockProps.gotoPage).not.toHaveBeenCalled();
     });
   });
 
   describe('onItemClick', () => {
     beforeEach(() => {
-      mockProps.pushPage.mockReset();
+      mockProps.gotoPage.mockReset();
     });
 
-    it('calls pushPage', () => {
+    it('calls gotoPage', () => {
       shallow((
         <ExplorerPanel
           {...mockProps}
@@ -116,19 +118,19 @@ describe('ExplorerPanel', () => {
         stopPropagation() {},
       });
 
-      expect(mockProps.pushPage).toHaveBeenCalled();
+      expect(mockProps.gotoPage).toHaveBeenCalled();
     });
   });
 
   describe('hooks', () => {
     it('componentWillReceiveProps push', () => {
       const wrapper = shallow(<ExplorerPanel {...mockProps} />);
-      expect(wrapper.setProps({ path: [1] }).state('transition')).toBe('push');
+      expect(wrapper.setProps({ depth: 2 }).state('transition')).toBe('push');
     });
 
     it('componentWillReceiveProps pop', () => {
       const wrapper = shallow(<ExplorerPanel {...mockProps} />);
-      expect(wrapper.setProps({ path: [] }).state('transition')).toBe('pop');
+      expect(wrapper.setProps({ depth: 0 }).state('transition')).toBe('pop');
     });
 
     it('componentDidMount', () => {

--- a/client/src/components/Explorer/__snapshots__/Explorer.test.js.snap
+++ b/client/src/components/Explorer/__snapshots__/Explorer.test.js.snap
@@ -2,12 +2,12 @@
 
 exports[`Explorer renders 1`] = `
 <Explorer
+  depth={0}
+  gotoPage={[Function]}
   isVisible={false}
   nodes={Object {}}
   onClose={[Function]}
-  path={Array []}
-  popPage={[Function]}
-  pushPage={[Function]}
+  page={null}
   store={
     Object {
       "dispatch": [Function],
@@ -44,6 +44,8 @@ exports[`Explorer renders 2`] = `<Connect(Explorer) />`;
 
 exports[`Explorer visible 1`] = `
 <Explorer
+  depth={0}
+  gotoPage={[Function]}
   isVisible={true}
   nodes={
     Object {
@@ -55,17 +57,12 @@ exports[`Explorer visible 1`] = `
         "data": null,
         "isError": false,
         "isFetching": true,
+        "parent": null,
       },
     }
   }
   onClose={[Function]}
-  path={
-    Array [
-      1,
-    ]
-  }
-  popPage={[Function]}
-  pushPage={[Function]}
+  page={1}
   store={
     Object {
       "dispatch": [Function],
@@ -100,6 +97,8 @@ exports[`Explorer visible 1`] = `
 
 exports[`Explorer visible 2`] = `
 <ExplorerPanel
+  depth={0}
+  gotoPage={[Function]}
   nodes={
     Object {
       "1": Object {
@@ -110,6 +109,7 @@ exports[`Explorer visible 2`] = `
         "data": null,
         "isError": false,
         "isFetching": true,
+        "parent": null,
       },
     }
   }
@@ -123,14 +123,8 @@ exports[`Explorer visible 2`] = `
       "data": null,
       "isError": false,
       "isFetching": true,
+      "parent": null,
     }
   }
-  path={
-    Array [
-      1,
-    ]
-  }
-  popPage={[Function]}
-  pushPage={[Function]}
 />
 `;

--- a/client/src/components/Explorer/__snapshots__/Explorer.test.js.snap
+++ b/client/src/components/Explorer/__snapshots__/Explorer.test.js.snap
@@ -52,11 +52,9 @@ exports[`Explorer visible 1`] = `
           "count": 0,
           "items": Array [],
         },
+        "data": null,
         "isError": false,
         "isFetching": true,
-        "meta": Object {
-          "children": Object {},
-        },
       },
     }
   }
@@ -109,11 +107,9 @@ exports[`Explorer visible 2`] = `
           "count": 0,
           "items": Array [],
         },
+        "data": null,
         "isError": false,
         "isFetching": true,
-        "meta": Object {
-          "children": Object {},
-        },
       },
     }
   }
@@ -124,11 +120,9 @@ exports[`Explorer visible 2`] = `
         "count": 0,
         "items": Array [],
       },
+      "data": null,
       "isError": false,
       "isFetching": true,
-      "meta": Object {
-        "children": Object {},
-      },
     }
   }
   path={

--- a/client/src/components/Explorer/__snapshots__/ExplorerHeader.test.js.snap
+++ b/client/src/components/Explorer/__snapshots__/ExplorerHeader.test.js.snap
@@ -1,31 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ExplorerHeader #depth at root 1`] = `
-<Button
-  accessibleLabel={null}
-  className="c-explorer__header"
-  dialogTrigger={false}
-  href="/admin/pages/"
-  isLoading={false}
-  onClick={[MockFunction]}
-  preventDefault={true}
-  target={null}
->
-  <div
-    className="c-explorer__header__inner"
-  >
-    <Icon
-      className="icon--explorer-header"
-      name="home"
-      title={null}
-    />
-    <span>
-      Pages
-    </span>
-  </div>
-</Button>
-`;
-
 exports[`ExplorerHeader #page 1`] = `
 <Button
   accessibleLabel={null}

--- a/client/src/components/Explorer/__snapshots__/ExplorerHeader.test.js.snap
+++ b/client/src/components/Explorer/__snapshots__/ExplorerHeader.test.js.snap
@@ -46,7 +46,7 @@ exports[`ExplorerHeader #page 1`] = `
       title={null}
     />
     <span>
-      test
+      Pages
     </span>
   </div>
 </Button>

--- a/client/src/components/Explorer/__snapshots__/ExplorerPanel.test.js.snap
+++ b/client/src/components/Explorer/__snapshots__/ExplorerPanel.test.js.snap
@@ -36,10 +36,9 @@ exports[`ExplorerPanel general rendering #isError 1`] = `
   >
     <div
       className="c-transition-group"
-      key="0"
+      key="1"
     >
       <ExplorerHeader
-        depth={0}
         onClick={[Function]}
         page={
           Object {
@@ -47,6 +46,7 @@ exports[`ExplorerPanel general rendering #isError 1`] = `
               "items": Array [],
             },
             "isError": true,
+            "parent": 1,
           }
         }
       />
@@ -70,6 +70,7 @@ exports[`ExplorerPanel general rendering #isError 1`] = `
               "items": Array [],
             },
             "isError": true,
+            "parent": 1,
           }
         }
       />
@@ -114,10 +115,9 @@ exports[`ExplorerPanel general rendering #isFetching 1`] = `
   >
     <div
       className="c-transition-group"
-      key="0"
+      key="1"
     >
       <ExplorerHeader
-        depth={0}
         onClick={[Function]}
         page={
           Object {
@@ -125,6 +125,7 @@ exports[`ExplorerPanel general rendering #isFetching 1`] = `
               "items": Array [],
             },
             "isFetching": true,
+            "parent": 1,
           }
         }
       />
@@ -182,10 +183,9 @@ exports[`ExplorerPanel general rendering #items 1`] = `
   >
     <div
       className="c-transition-group"
-      key="0"
+      key="1"
     >
       <ExplorerHeader
-        depth={0}
         onClick={[Function]}
         page={
           Object {
@@ -275,10 +275,9 @@ exports[`ExplorerPanel general rendering no children 1`] = `
   >
     <div
       className="c-transition-group"
-      key="0"
+      key="1"
     >
       <ExplorerHeader
-        depth={0}
         onClick={[Function]}
         page={
           Object {
@@ -337,16 +336,16 @@ exports[`ExplorerPanel general rendering renders 1`] = `
   >
     <div
       className="c-transition-group"
-      key="0"
+      key="1"
     >
       <ExplorerHeader
-        depth={0}
         onClick={[Function]}
         page={
           Object {
             "children": Object {
               "items": Array [],
             },
+            "parent": 1,
           }
         }
       />

--- a/client/src/components/Explorer/__snapshots__/actions.test.js.snap
+++ b/client/src/components/Explorer/__snapshots__/actions.test.js.snap
@@ -1,23 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`actions pushPage creates action 1`] = `
+exports[`actions gotoPage creates action 1`] = `
 Array [
   Object {
     "payload": Object {
       "id": 5,
+      "transition": undefined,
     },
-    "type": "PUSH_PAGE",
+    "type": "GOTO_PAGE",
   },
 ]
 `;
 
-exports[`actions pushPage triggers getChildren 1`] = `
+exports[`actions gotoPage triggers getChildren 1`] = `
 Array [
   Object {
     "payload": Object {
       "id": 5,
+      "transition": undefined,
     },
-    "type": "PUSH_PAGE",
+    "type": "GOTO_PAGE",
   },
   Object {
     "payload": Object {

--- a/client/src/components/Explorer/actions.js
+++ b/client/src/components/Explorer/actions.js
@@ -76,15 +76,14 @@ export function toggleExplorer(id) {
   };
 }
 
-export const popPage = createAction('POP_PAGE');
-const pushPagePrivate = createAction('PUSH_PAGE', id => ({ id }));
+const gotoPagePrivate = createAction('GOTO_PAGE', (id, transition) => ({ id, transition }));
 
-export function pushPage(id) {
+export function gotoPage(id, transition) {
   return (dispatch, getState) => {
     const { nodes } = getState();
     const page = nodes[id];
 
-    dispatch(pushPagePrivate(id));
+    dispatch(gotoPagePrivate(id, transition));
 
     if (page && !page.isFetching && !(page.children.count > 0)) {
       dispatch(getChildren(id));

--- a/client/src/components/Explorer/actions.test.js
+++ b/client/src/components/Explorer/actions.test.js
@@ -65,24 +65,14 @@ describe('actions', () => {
     });
   });
 
-  describe('popPage', () => {
+  describe('gotoPage', () => {
     it('exists', () => {
-      expect(actions.popPage).toBeDefined();
-    });
-
-    it('works', () => {
-      expect(actions.popPage().type).toEqual('POP_PAGE');
-    });
-  });
-
-  describe('pushPage', () => {
-    it('exists', () => {
-      expect(actions.pushPage).toBeDefined();
+      expect(actions.gotoPage).toBeDefined();
     });
 
     it('creates action', () => {
       const store = mockStore(stubState);
-      store.dispatch(actions.pushPage(5));
+      store.dispatch(actions.gotoPage(5));
       expect(store.getActions()).toMatchSnapshot();
     });
 
@@ -90,7 +80,7 @@ describe('actions', () => {
       const stub = Object.assign({}, stubState);
       stub.nodes[5].isFetching = false;
       const store = mockStore(stub);
-      store.dispatch(actions.pushPage(5));
+      store.dispatch(actions.gotoPage(5));
       expect(store.getActions()).toMatchSnapshot();
     });
   });

--- a/client/src/components/Explorer/reducers/__snapshots__/explorer.test.js.snap
+++ b/client/src/components/Explorer/reducers/__snapshots__/explorer.test.js.snap
@@ -2,25 +2,16 @@
 
 exports[`explorer OPEN_EXPLORER 1`] = `
 Object {
+  "depth": 0,
   "isVisible": true,
-  "path": Array [
-    1,
-  ],
+  "page": 1,
 }
 `;
 
-exports[`explorer POP_PAGE 1`] = `
+exports[`explorer GOTO_PAGE 1`] = `
 Object {
+  "depth": 0,
   "isVisible": false,
-  "path": Array [],
-}
-`;
-
-exports[`explorer PUSH_PAGE 1`] = `
-Object {
-  "isVisible": false,
-  "path": Array [
-    100,
-  ],
+  "page": null,
 }
 `;

--- a/client/src/components/Explorer/reducers/__snapshots__/nodes.test.js.snap
+++ b/client/src/components/Explorer/reducers/__snapshots__/nodes.test.js.snap
@@ -7,11 +7,9 @@ Object {
       "count": 0,
       "items": Array [],
     },
+    "data": null,
     "isError": true,
     "isFetching": false,
-    "meta": Object {
-      "children": Object {},
-    },
   },
 }
 `;
@@ -23,11 +21,9 @@ Object {
       "count": 0,
       "items": Array [],
     },
+    "data": null,
     "isError": false,
     "isFetching": true,
-    "meta": Object {
-      "children": Object {},
-    },
   },
 }
 `;
@@ -43,47 +39,42 @@ Object {
         5,
       ],
     },
+    "data": null,
     "isError": false,
     "isFetching": false,
-    "meta": Object {
-      "children": Object {},
-    },
   },
   "3": Object {
     "children": Object {
       "count": 0,
       "items": Array [],
     },
-    "id": 3,
+    "data": Object {
+      "id": 3,
+    },
     "isError": false,
     "isFetching": false,
-    "meta": Object {
-      "children": Object {},
-    },
   },
   "4": Object {
     "children": Object {
       "count": 0,
       "items": Array [],
     },
-    "id": 4,
+    "data": Object {
+      "id": 4,
+    },
     "isError": false,
     "isFetching": false,
-    "meta": Object {
-      "children": Object {},
-    },
   },
   "5": Object {
     "children": Object {
       "count": 0,
       "items": Array [],
     },
-    "id": 5,
+    "data": Object {
+      "id": 5,
+    },
     "isError": false,
     "isFetching": false,
-    "meta": Object {
-      "children": Object {},
-    },
   },
 }
 `;
@@ -95,11 +86,9 @@ Object {
       "count": 0,
       "items": Array [],
     },
+    "data": null,
     "isError": true,
     "isFetching": false,
-    "meta": Object {
-      "children": Object {},
-    },
   },
 }
 `;
@@ -111,11 +100,9 @@ Object {
       "count": 0,
       "items": Array [],
     },
+    "data": Object {},
     "isError": false,
     "isFetching": false,
-    "meta": Object {
-      "children": Object {},
-    },
   },
 }
 `;
@@ -127,11 +114,9 @@ Object {
       "count": 0,
       "items": Array [],
     },
+    "data": null,
     "isError": false,
     "isFetching": false,
-    "meta": Object {
-      "children": Object {},
-    },
   },
 }
 `;

--- a/client/src/components/Explorer/reducers/__snapshots__/nodes.test.js.snap
+++ b/client/src/components/Explorer/reducers/__snapshots__/nodes.test.js.snap
@@ -10,6 +10,7 @@ Object {
     "data": null,
     "isError": true,
     "isFetching": false,
+    "parent": null,
   },
 }
 `;
@@ -24,6 +25,7 @@ Object {
     "data": null,
     "isError": false,
     "isFetching": true,
+    "parent": null,
   },
 }
 `;
@@ -42,6 +44,7 @@ Object {
     "data": null,
     "isError": false,
     "isFetching": false,
+    "parent": null,
   },
   "3": Object {
     "children": Object {
@@ -53,6 +56,7 @@ Object {
     },
     "isError": false,
     "isFetching": false,
+    "parent": 1,
   },
   "4": Object {
     "children": Object {
@@ -64,6 +68,7 @@ Object {
     },
     "isError": false,
     "isFetching": false,
+    "parent": 1,
   },
   "5": Object {
     "children": Object {
@@ -75,6 +80,7 @@ Object {
     },
     "isError": false,
     "isFetching": false,
+    "parent": 1,
   },
 }
 `;
@@ -89,6 +95,7 @@ Object {
     "data": null,
     "isError": true,
     "isFetching": false,
+    "parent": null,
   },
 }
 `;
@@ -100,9 +107,16 @@ Object {
       "count": 0,
       "items": Array [],
     },
-    "data": Object {},
+    "data": Object {
+      "meta": Object {
+        "parent": Object {
+          "id": 2,
+        },
+      },
+    },
     "isError": false,
     "isFetching": false,
+    "parent": 2,
   },
 }
 `;
@@ -117,6 +131,7 @@ Object {
     "data": null,
     "isError": false,
     "isFetching": false,
+    "parent": null,
   },
 }
 `;

--- a/client/src/components/Explorer/reducers/explorer.js
+++ b/client/src/components/Explorer/reducers/explorer.js
@@ -1,6 +1,7 @@
 const defaultState = {
   isVisible: false,
-  path: [],
+  depth: 0,
+  page: null,
 };
 
 /**
@@ -14,22 +15,18 @@ export default function explorer(prevState = defaultState, { type, payload }) {
     // Provide a starting page when opening the explorer.
     return {
       isVisible: true,
-      path: [payload.id],
+      depth: 0,
+      page: payload.id,
     };
 
   case 'CLOSE_EXPLORER':
     return defaultState;
 
-  case 'PUSH_PAGE':
+  case 'GOTO_PAGE':
     return {
       isVisible: prevState.isVisible,
-      path: prevState.path.concat([payload.id]),
-    };
-
-  case 'POP_PAGE':
-    return {
-      isVisible: prevState.isVisible,
-      path: prevState.path.slice(0, -1),
+      depth: prevState.depth + payload.transition,
+      page: payload.id,
     };
 
   default:

--- a/client/src/components/Explorer/reducers/explorer.test.js
+++ b/client/src/components/Explorer/reducers/explorer.test.js
@@ -20,13 +20,7 @@ describe('explorer', () => {
     expect(explorer(initialState, { type: 'CLOSE_EXPLORER' })).toEqual(initialState);
   });
 
-  it('PUSH_PAGE', () => {
+  it('GOTO_PAGE', () => {
     expect(explorer(initialState, { type: 'PUSH_PAGE', payload: { id: 100 } })).toMatchSnapshot();
-  });
-
-  it('POP_PAGE', () => {
-    const state = explorer(initialState, { type: 'PUSH_PAGE', payload: { id: 100 } });
-    const action = { type: 'POP_PAGE', payload: { id: 100 } };
-    expect(explorer(state, action)).toMatchSnapshot();
   });
 });

--- a/client/src/components/Explorer/reducers/explorer.test.js
+++ b/client/src/components/Explorer/reducers/explorer.test.js
@@ -21,6 +21,6 @@ describe('explorer', () => {
   });
 
   it('GOTO_PAGE', () => {
-    expect(explorer(initialState, { type: 'PUSH_PAGE', payload: { id: 100 } })).toMatchSnapshot();
+    expect(explorer(initialState, { type: 'GOTO_PAGE', payload: { id: 100 } })).toMatchSnapshot();
   });
 });

--- a/client/src/components/Explorer/reducers/nodes.js
+++ b/client/src/components/Explorer/reducers/nodes.js
@@ -1,6 +1,7 @@
 const defaultPageState = {
   isFetching: false,
   isError: false,
+  parent: null,
   children: {
     items: [],
     count: 0,
@@ -19,6 +20,7 @@ const node = (state = defaultPageState, { type, payload }) => {
   case 'GET_PAGE_SUCCESS':
     return Object.assign({}, state, {
       isError: false,
+      parent: (payload.data.meta.parent && payload.data.meta.parent.id) || null,
       data: payload.data,
     });
 
@@ -73,7 +75,7 @@ export default function nodes(state = defaultState, { type, payload }) {
     });
 
     payload.items.forEach((item) => {
-      newState[item.id] = Object.assign({}, defaultPageState, { data: item });
+      newState[item.id] = Object.assign({}, defaultPageState, { data: item, parent: payload.id });
     });
 
     return newState;

--- a/client/src/components/Explorer/reducers/nodes.js
+++ b/client/src/components/Explorer/reducers/nodes.js
@@ -5,9 +5,7 @@ const defaultPageState = {
     items: [],
     count: 0,
   },
-  meta: {
-    children: {},
-  },
+  data: null,
 };
 
 /**
@@ -19,8 +17,9 @@ const node = (state = defaultPageState, { type, payload }) => {
     return state || defaultPageState;
 
   case 'GET_PAGE_SUCCESS':
-    return Object.assign({}, state, payload.data, {
+    return Object.assign({}, state, {
       isError: false,
+      data: payload.data,
     });
 
   case 'GET_CHILDREN_START':
@@ -74,7 +73,7 @@ export default function nodes(state = defaultState, { type, payload }) {
     });
 
     payload.items.forEach((item) => {
-      newState[item.id] = Object.assign({}, defaultPageState, item);
+      newState[item.id] = Object.assign({}, defaultPageState, { data: item });
     });
 
     return newState;

--- a/client/src/components/Explorer/reducers/nodes.test.js
+++ b/client/src/components/Explorer/reducers/nodes.test.js
@@ -17,7 +17,13 @@ describe('nodes', () => {
   });
 
   it('GET_PAGE_SUCCESS', () => {
-    const action = { type: 'GET_PAGE_SUCCESS', payload: { id: 1, data: {} } };
+    const action = { type: 'GET_PAGE_SUCCESS', payload: { id: 1, data: {
+      meta: {
+        parent: {
+          id: 2,
+        }
+      }
+    } } };
     expect(nodes(initialState, action)).toMatchSnapshot();
   });
 


### PR DESCRIPTION
The current actions only allow navigating into children and back up to the parent. This PR replaces the existing actions with one that allows navigating to any part of the tree.

This is a prerequisite for the "locale" filter that I am implementing in the explorer (see https://github.com/wagtail/rfcs/blob/internationalisation/text/054-internationalisation.md#page-explorer).

I've also removed "path" from the reducer and replaced this with "depth" and "page". Page nodes now have a "parent" attribute which we use for navigating back up the tree

 - "page" is the ID of the current page
 - "depth" is an integer, when you navigate down it's incremented, when you navigate up it's decremented. This is used by the `ExplorerPanel` to work on which direction to run the animation. The absolute value doesn't mean anything; we only care about how much this value changes between page transitions.