### PR TITLE
[Workflow] Cancel ongoing workflows when a page is published

### DIFF
--- a/docs/reference/settings.rst
+++ b/docs/reference/settings.rst
@@ -556,3 +556,9 @@ set ``WAGTAIL_WORKFLOW_REQUIRE_REAPPROVAL_ON_EDIT = False``.
 
 This sets the function to be called when a workflow completes successfully - by default, ``wagtail.core.workflows.publish_workflow_state``,
 which publishes the page. The function must accept a ``WorkflowState`` object as its only positional argument.
+
+.. code-block:: python
+
+  WAGTAIL_WORKFLOW_CANCEL_ON_PUBLISH = True
+
+This determines whether publishing a page with an ongoing workflow will cancel the workflow (if true) or leave the workflow unaffected (false).

--- a/wagtail/admin/templates/wagtailadmin/pages/confirm_workflow_cancellation.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/confirm_workflow_cancellation.html
@@ -1,0 +1,21 @@
+{% load i18n %}
+{% trans 'Publish page' as publish_title %}
+{% include "wagtailadmin/shared/header.html" with title=publish_title icon="clipboard-list" %}
+
+<div class="nice-padding">
+    <p>
+    {% if needs_changes %}
+        {% blocktrans %}
+            This page was marked as needing changes at <strong>{{ task }}</strong> in <strong>{{ workflow }}</strong>.
+        {% endblocktrans %}
+    {% else %}
+        {% blocktrans %}
+            This page is currently at <strong>{{ task }}</strong> in <strong>{{ workflow }}</strong>.
+        {% endblocktrans %}
+    {% endif %}
+    </p>
+    <p>{% trans 'Publishing this page will cancel the current workflow.' %}</p>
+    <p>{% trans 'Would you still like to publish this page?' %}</p>
+    <button type="submit" class="button" data-confirm-cancellation>{% trans 'Publish' %}</button>
+    <button type="submit" class="button button-secondary no" data-cancel-dialog>{% trans 'Cancel' %}</button>
+</div>

--- a/wagtail/admin/templates/wagtailadmin/pages/edit.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/edit.html
@@ -115,6 +115,39 @@
     {{ edit_handler.html_declarations }}
 
     <script>
+        {% if publishing_will_cancel_workflow %}
+        $(function() {
+            /* Make user confirm before publishing the page if it will cancel an ongoing workflow */
+            let cancellationConfirmed = false;
+            $('[name=action-publish]').click((e) => {
+                if (!cancellationConfirmed) {
+                    e.stopImmediatePropagation();
+                    e.preventDefault();
+                    ModalWorkflow({
+                    'url': "{% url 'wagtailadmin_pages:confirm_workflow_cancellation' page.id %}",
+                    'onload': {
+                        'confirm': function(modal, jsonData) {
+                            $('[data-confirm-cancellation]', modal.body).click((event) => {
+                                cancellationConfirmed = true;
+                                modal.close();
+                                e.currentTarget.click();
+                            })
+                            $('[data-cancel-dialog]', modal.body).click((event) => {
+                                modal.close();
+                            })
+                        },
+                        'no_confirmation_needed': function(modal, jsonData) {
+                            modal.close();
+                            cancellationConfirmed = true;
+                            e.currentTarget.click();
+                        }
+                    },
+                });
+                }
+                });
+        });
+        {% endif %}
+
         $(function() {
             /* Make user confirm before leaving the editor if there are unsaved changes */
             {% trans "This page has unsaved changes." as confirmation_message %}

--- a/wagtail/admin/urls/pages.py
+++ b/wagtail/admin/urls/pages.py
@@ -26,6 +26,7 @@ urlpatterns = [
     path('<int:page_id>/copy/', pages.copy, name='copy'),
 
     path('workflow/action/<int:page_id>/<slug:action_name>/<int:task_state_id>/', pages.workflow_action, name='workflow_action'),
+    path('workflow/confirm_cancellation/<int:page_id>/', pages.confirm_workflow_cancellation, name='confirm_workflow_cancellation'),
     path('workflow/preview/<int:page_id>/<int:task_id>/', pages.preview_revision_for_task, name='workflow_preview'),
 
     path('moderation/<int:revision_id>/approve/', pages.approve_moderation, name='approve_moderation'),

--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -2067,6 +2067,10 @@ class PageRevision(models.Model):
         self.submitted_for_moderation = False
         page.revisions.update(submitted_for_moderation=False)
 
+        workflow_state = page.current_workflow_state
+        if workflow_state and getattr(settings, 'WAGTAIL_WORKFLOW_CANCEL_ON_PUBLISH', True):
+            workflow_state.cancel(user=user)
+
         if page.live:
             page_published.send(sender=page.specific_class, instance=page.specific, revision=self)
 

--- a/wagtail/core/tests/test_workflow.py
+++ b/wagtail/core/tests/test_workflow.py
@@ -122,6 +122,22 @@ class TestWorkflows(TestCase):
         self.assertEqual(task_state.started_at, datetime.datetime(2017, 1, 1, 12, 0, 0, tzinfo=pytz.utc))
         self.assertEqual(task_state.finished_at, None)
 
+    @override_settings(WAGTAIL_WORKFLOW_CANCEL_ON_PUBLISH=True)
+    def test_publishing_page_cancels_workflow_when_cancel_on_publish_true(self):
+        data = self.start_workflow_on_homepage()
+        data['page'].get_latest_revision().publish()
+        workflow_state = data['workflow_state']
+        workflow_state.refresh_from_db()
+        self.assertEqual(workflow_state.status, WorkflowState.STATUS_CANCELLED)
+
+    @override_settings(WAGTAIL_WORKFLOW_CANCEL_ON_PUBLISH=False)
+    def test_publishing_page_does_not_cancel_workflow_when_cancel_on_publish_false(self):
+        data = self.start_workflow_on_homepage()
+        data['page'].get_latest_revision().publish()
+        workflow_state = data['workflow_state']
+        workflow_state.refresh_from_db()
+        self.assertEqual(workflow_state.status, WorkflowState.STATUS_IN_PROGRESS)
+
     def test_error_when_starting_multiple_in_progress_workflows(self):
         # test trying to start multiple status='in_progress' workflows on a single page will trigger an IntegrityError
         self.start_workflow_on_homepage()


### PR DESCRIPTION
Cancel ongoing workflows when a page is published depending on the value of a new setting, WAGTAIL_WORKFLOW_CANCEL_ON_PUBLISH. Add a warning modal before publication if a workflow will be cancelled

