### PR TITLE
Fix Python 3.9 Deprecation Warning

### DIFF
--- a/wagtail/admin/rich_text/converters/html_ruleset.py
+++ b/wagtail/admin/rich_text/converters/html_ruleset.py
@@ -1,5 +1,5 @@
 import re
-from collections import Mapping
+from collections.abc import Mapping
 
 ELEMENT_SELECTOR = re.compile(r'^([\w-]+)$')
 ELEMENT_WITH_ATTR_SELECTOR = re.compile(r'^([\w-]+)\[([\w-]+)\]$')


### PR DESCRIPTION
While working on wagtail-bakery, I came across a deprecation warning for Python 3.9 on Wagtail itself:

> DeprecationWarning: Using or importing the ABCs from 'collections'
> instead of from 'collections.abc' is deprecated since Python 3.3,
> and in 3.9 it will stop working

Since we only support Python 3.5+, it there shouldn't be any compatibility issue.

I haven't checked if there are other deprecation warnings just yet.