### PR TITLE
Add chevron to dropdowns that are missing them

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -71,6 +71,8 @@ Changelog
  * Fix: `wagtail.contrib.sitemaps` no longer depends on SiteMiddleware (Matt Westcott)
  * Fix: Purge image renditions cache when renditions are deleted (Pascal Widdershoven, Matt Westcott)
  * Fix: Image / document forms now display non-field errors such as `unique_together` constraints (Matt Westcott)
+ * Fix: Make "Site" chooser in site settings translateable (Andreas Bernacca)
+ * Fix: Add missing dropdown icons to image upload, document upload, and site settings screens (Andreas Bernacca)
 
 
 2.9.3 (20.07.2020)

--- a/client/scss/components/_forms.scss
+++ b/client/scss/components/_forms.scss
@@ -108,6 +108,10 @@ select::-ms-expand {
     }
 }
 
+// the site setting dropdown is auto width, so the chevron will overlap with text if not padded
+.choice_field .setting-site-switch-form .input select {
+    padding-right: 5em;
+}
 
 // Other text
 .help,

--- a/docs/releases/2.10.rst
+++ b/docs/releases/2.10.rst
@@ -94,6 +94,8 @@ Bug fixes
  * ``wagtail.contrib.sitemaps`` no longer depends on SiteMiddleware (Matt Westcott)
  * Purge image renditions cache when renditions are deleted (Pascal Widdershoven, Matt Westcott)
  * Image / document forms now display non-field errors such as ``unique_together`` constraints (Matt Westcott)
+ * Make "Site" chooser in site settings translateable (Andreas Bernacca)
+ * Add missing dropdown icons to image upload, document upload, and site settings screens (Andreas Bernacca)
 
 
 Upgrade considerations

--- a/wagtail/contrib/settings/templates/wagtailsettings/edit.html
+++ b/wagtail/contrib/settings/templates/wagtailsettings/edit.html
@@ -16,12 +16,17 @@
             </div>
             <div class="right">
                 {% if site_switcher %}
-                <form method="get" id="settings-site-switch" novalidate>
-                    <label for="{{ site_switcher.site.id_for_label }}">
-                        Site:
-                    </label>
-                    {{ site_switcher.site }}
-                </form>
+                <div class="field choice_field">
+                    <form method="get" class="setting-site-switch-form" id="settings-site-switch" novalidate>
+                        <label for="{{ site_switcher.site.id_for_label }}">
+                            {% trans "Site" %}:
+                        </label>
+                        <div class="input">
+                            {{ site_switcher.site }}
+                            <span></span>
+                        </div>
+                    </form>
+                </div>
                 {% endif %}
             </div>
         </div>

--- a/wagtail/documents/templates/wagtaildocs/multiple/add.html
+++ b/wagtail/documents/templates/wagtaildocs/multiple/add.html
@@ -27,14 +27,17 @@
                 </div>
                 {% csrf_token %}
                 {% if collections %}
-                    <div class="field">
+                    <div class="field choice_field select">
                         <label for="id_adddocument_collection">{% trans "Add to collection:" %}</label>
                         <div class="field-content">
-                            <select id="id_adddocument_collection" name="collection">
-                                {% for collection in collections %}
-                                    <option value="{{ collection.id|unlocalize }}">{{ collection.name }}</option>
-                                {% endfor %}
-                            </select>
+                            <div class="input">
+                                <select id="id_adddocument_collection" name="collection">
+                                    {% for collection in collections %}
+                                        <option value="{{ collection.id|unlocalize }}">{{ collection.name }}</option>
+                                    {% endfor %}
+                                </select>
+                                <span></span>
+                            </div>
                         </div>
                     </div>
                 {% endif %}

--- a/wagtail/images/templates/wagtailimages/multiple/add.html
+++ b/wagtail/images/templates/wagtailimages/multiple/add.html
@@ -27,14 +27,17 @@
                 </div>
                 {% csrf_token %}
                 {% if collections %}
-                    <div class="field">
+                    <div class="field choice_field select">
                         <label for="id_addimage_collection">{% trans "Add to collection:" %}</label>
                         <div class="field-content">
-                            <select id="id_addimage_collection" name="collection">
-                                {% for collection in collections %}
-                                    <option value="{{ collection.id|unlocalize }}">{{ collection.name }}</option>
-                                {% endfor %}
-                            </select>
+                            <div class="input">
+                                <select id="id_addimage_collection" name="collection">
+                                    {% for collection in collections %}
+                                        <option value="{{ collection.id|unlocalize }}">{{ collection.name }}</option>
+                                    {% endfor %}
+                                </select>
+                                <span></span>
+                            </div>
                         </div>
                     </div>
                 {% endif %}


### PR DESCRIPTION
This is a fix for #6072 

I reused already existing markup for dropdowns, however I needed to make a small addition to the css for the site dropdown. There might be a better way to do it so the addition isn't needed - if so I'm all ears. :)

I also added a translation tag for "Site", since I was already in the file and noticed, and it felt to minor to open a pull request for separately.

**Site settings before:**
<img width="1203" alt="Screenshot 2020-05-26 at 14 03 06" src="https://user-images.githubusercontent.com/156781/82898887-5202a700-9f5a-11ea-84ce-c3716170ed52.png">

**Site settings after:**
![Screenshot 2020-07-19 at 20 38 14](https://user-images.githubusercontent.com/156781/87882352-cc522380-c9ff-11ea-8012-4b539b4ac3bd.png)

**Adding documents before:**
![Screenshot 2020-07-19 at 19 57 02](https://user-images.githubusercontent.com/156781/87881549-4bdcf400-c9fa-11ea-8d59-310e246da2c0.png)

**Adding documents after:**
![Screenshot 2020-07-19 at 20 38 52](https://user-images.githubusercontent.com/156781/87882372-de33c680-c9ff-11ea-8174-7332db7b789c.png)

**Adding images:**
![Screenshot 2020-07-19 at 20 00 13](https://user-images.githubusercontent.com/156781/87881579-86df2780-c9fa-11ea-9717-41fb91bafaff.png)

**Adding images after:**
![Screenshot 2020-07-19 at 20 39 27](https://user-images.githubusercontent.com/156781/87882380-f4418700-c9ff-11ea-8639-b9607a620106.png)