### PR TITLE
Use icon tag instead of CSS for lock/unlock messages

### DIFF
--- a/client/scss/components/_messages.scss
+++ b/client/scss/components/_messages.scss
@@ -66,18 +66,6 @@
     .errorlist {
         margin: 0.5em 0 0 1em;
     }
-
-    .lock {
-        &:before {
-            content: map-get($icons, 'locked');
-        }
-    }
-
-    .unlock {
-        &:before {
-            content: map-get($icons, 'unlocked');
-        }
-    }
 }
 
 .messages.new > ul {

--- a/wagtail/admin/templates/wagtailadmin/base.html
+++ b/wagtail/admin/templates/wagtailadmin/base.html
@@ -35,6 +35,10 @@
                               {% if message.level_tag == "error" %}
                                 {# There is no error icon, use warning icon instead #}
                                 {% icon name="warning" class_name="messages-icon" %}
+                              {% elif message.extra_tags == "lock" %}
+                                {% icon name="lock" class_name="messages-icon" %}
+                              {% elif message.extra_tags == "unlock" %}
+                                {% icon name="lock-open" class_name="messages-icon" %}
                               {% else %}
                                 {% icon name=message.level_tag class_name="messages-icon" %}
                               {% endif %}


### PR DESCRIPTION
Lock/unlock icons were being handled through CSS overrides on the message element, which no longer works now that the regular icons are handled in SVG rather than CSS.

before:
![Screenshot 2020-07-20 at 17 08 38](https://user-images.githubusercontent.com/85097/87960053-aeda9380-caab-11ea-8452-05ab22119e20.png)

after:
![Screenshot 2020-07-20 at 17 01 14](https://user-images.githubusercontent.com/85097/87959629-1512e680-caab-11ea-9952-bd1fdc96aa3c.png)
