### PR TITLE
Shorten and de-capitalise default workflow/task name

### DIFF
--- a/wagtail/core/migrations/0048_add_default_workflows.py
+++ b/wagtail/core/migrations/0048_add_default_workflows.py
@@ -51,7 +51,7 @@ def create_default_workflows(apps, schema_editor):
             # if no such task exists, create it
             group_names = ' '.join([group.name for group in groups])
             task = GroupApprovalTask.objects.create(
-                name=group_names + " Approval",
+                name=group_names + " approval",
                 content_type=group_approval_content_type,
                 active=True,
             )
@@ -61,7 +61,7 @@ def create_default_workflows(apps, schema_editor):
         workflow = Workflow.objects.annotate(task_number=Count('workflow_tasks')).filter(task_number=1).filter(workflow_tasks__task=task).filter(active=True).first()
         if not workflow:
             workflow = Workflow.objects.create(
-                name=task.name + " Workflow",
+                name=task.name,
                 active=True
             )
 


### PR DESCRIPTION
On the out-of-the-box setup, this will create a workflow named "Moderators approval" rather than "Moderators Approval Workflow"; the latter is too long to fit unshortened in the submit button, and the lower-case is a bit friendlier (it makes it an action, rather than a Complicated Concept You Need To Understand).