### PR TITLE
Always publish the latest version of a page on workflow completion

### DIFF
--- a/wagtail/core/workflows.py
+++ b/wagtail/core/workflows.py
@@ -25,7 +25,4 @@ def get_task_types(task_class=None):
 
 def publish_workflow_state(workflow_state, user=None):
     # publish the Page associated with a WorkflowState
-    if workflow_state.current_task_state:
-        workflow_state.current_task_state.page_revision.publish(user=user)
-    else:
-        workflow_state.page.get_latest_revision().publish(user=user)
+    workflow_state.page.get_latest_revision().publish(user=user)


### PR DESCRIPTION
This ensures that any edits made by the approving user prior to approval are preserved in the final published page.