### PR TITLE
Fix site delete URL

### DIFF
--- a/wagtail/admin/viewsets/model.py
+++ b/wagtail/admin/viewsets/model.py
@@ -90,5 +90,5 @@ class ModelViewSet(ViewSet):
             path('', self.index_view, name='index'),
             path('new/', self.add_view, name='add'),
             path('<int:pk>/', self.edit_view, name='edit'),
-            path('<int:pk>delete/', self.delete_view, name='delete'),
+            path('<int:pk>/delete/', self.delete_view, name='delete'),
         ]


### PR DESCRIPTION
Currently, site delete URLs look like `/admin/sites/1delete/`. This PR adds the missing '/'