### PR TITLE
Don't discard page edits made while performing a workflow action

### DIFF
--- a/docs/advanced_topics/custom_tasks.rst
+++ b/docs/advanced_topics/custom_tasks.rst
@@ -179,7 +179,8 @@ For example:
 ``Task.get_form_for_action(action)``:
 
 Returns a form to be used for additional data input for the given action modal. By default,
-returns ``TaskStateCommentForm``, with a single comment field.
+returns ``TaskStateCommentForm``, with a single comment field. The form data returned in
+``form.cleaned_data`` must be fully serializable as JSON.
 
 ``Task.get_template_for_action(action)``:
 

--- a/wagtail/admin/static_src/wagtailadmin/js/workflow-action.js
+++ b/wagtail/admin/static_src/wagtailadmin/js/workflow-action.js
@@ -1,5 +1,13 @@
+function _addHiddenInput(form, name, val) {
+    var element = document.createElement('input');
+    element.type = 'hidden';
+    element.name = name;
+    element.value = val;
+    form.appendChild(element);
+}
+
 /* When a workflow action button is clicked, either show a modal or make a POST request to the workflow action view */
-function ActivateWorkflowActions(csrfToken) {
+function ActivateWorkflowActionsForDashboard(csrfToken) {
     document.querySelectorAll('[data-workflow-action-url]').forEach(function (buttonElement) {
         buttonElement.addEventListener('click', function (e) {
             // Stop the button from submitting the form
@@ -30,20 +38,52 @@ function ActivateWorkflowActions(csrfToken) {
                 formElement.action = buttonElement.dataset.workflowActionUrl;
                 formElement.method = 'POST';
 
-                var csrftokenElement = document.createElement('input');
-                csrftokenElement.type = 'hidden';
-                csrftokenElement.name = 'csrfmiddlewaretoken';
-                csrftokenElement.value = csrfToken;
-                formElement.appendChild(csrftokenElement);
-
-                var nextElement = document.createElement('input');
-                nextElement.type = 'hidden';
-                nextElement.name = 'next';
-                nextElement.value = window.location;
-                formElement.appendChild(nextElement);
+                _addHiddenInput(formElement, 'csrfmiddlewaretoken', csrfToken);
+                _addHiddenInput(formElement, 'next', window.location);
 
                 document.body.appendChild(formElement);
                 formElement.submit();
+            }
+        }, {capture: true});
+    });
+}
+
+
+function ActivateWorkflowActionsForEditView(formSelector) {
+    var form = $(formSelector).get(0);
+
+    document.querySelectorAll('[data-workflow-action-name]').forEach(function (buttonElement) {
+        buttonElement.addEventListener('click', function (e) {
+            if ('workflowActionModalUrl' in buttonElement.dataset) {
+                // This action requires opening a modal to collect additional data.
+                // Stop the button from submitting the form
+                e.preventDefault();
+                e.stopPropagation();
+
+                // open the modal at the given URL
+                ModalWorkflow({
+                    'url': buttonElement.dataset.workflowActionModalUrl,
+                    'onload': {
+                        'action': function(modal, jsonData) {
+                            modal.ajaxifyForm($('form', modal.body));
+                        },
+                        'success': function(modal, jsonData) {
+                            // a success response includes the additional data to submit with the edit form
+                            _addHiddenInput(form, 'action-workflow-action', 'true')
+                            _addHiddenInput(form, 'workflow-action-name', buttonElement.dataset.workflowActionName)
+                            _addHiddenInput(form, 'workflow-action-extra-data', JSON.stringify(jsonData['cleaned_data']))
+                            // note: need to submit via jQuery (as opposed to form.submit()) so that the onsubmit handler
+                            // that disables the dirty-form prompt doesn't get bypassed
+                            $(form).submit();
+                        }
+                    },
+                });
+
+            } else {
+                // no modal, so let the form submission to the edit view proceed, with additional
+                // hidden inputs to tell it to perform our action
+                _addHiddenInput(form, 'action-workflow-action', 'true')
+                _addHiddenInput(form, 'workflow-action-name', buttonElement.dataset.workflowActionName)
             }
         }, {capture: true});
     });

--- a/wagtail/admin/templates/wagtailadmin/home/workflow_pages_to_moderate.html
+++ b/wagtail/admin/templates/wagtailadmin/home/workflow_pages_to_moderate.html
@@ -76,7 +76,7 @@
     <script src="{% versioned_static 'wagtailadmin/js/workflow-action.js' %}"></script>
     <script src="{% versioned_static 'wagtailadmin/js/vendor/bootstrap-tooltip.js' %}"></script>
     <script>
-        document.addEventListener('DOMContentLoaded', ActivateWorkflowActions('{{ csrf_token|escapejs }}'));
+        document.addEventListener('DOMContentLoaded', ActivateWorkflowActionsForDashboard('{{ csrf_token|escapejs }}'));
         /* Tooltips used by the workflow status component */
         $(function() {
             $('[data-wagtail-tooltip]').tooltip({

--- a/wagtail/admin/templates/wagtailadmin/pages/action_menu/workflow_menu_item.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/action_menu/workflow_menu_item.html
@@ -1,4 +1,4 @@
 {% load wagtailadmin_tags %}
-<button class="button" data-workflow-action-url="{% url 'wagtailadmin_pages:workflow_action' page.id name current_task_state.id %}" {% if launch_modal %}data-launch-modal{% endif %}>
+<button class="button" data-workflow-action-name="{{ name }}" {% if launch_modal %}data-workflow-action-modal-url="{% url 'wagtailadmin_pages:collect_workflow_action_data' page.id name current_task_state.id %}"{% endif %}>
     {% if icon_name %}{% icon name=icon_name %}{% endif %}{{ label }}
 </button>

--- a/wagtail/admin/templates/wagtailadmin/pages/edit.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/edit.html
@@ -169,7 +169,7 @@
         });
 
         $(function() {
-            document.addEventListener('DOMContentLoaded', ActivateWorkflowActions('{{ csrf_token|escapejs }}'));
+            document.addEventListener('DOMContentLoaded', ActivateWorkflowActionsForEditView('#page-edit-form'));
             document.addEventListener('DOMContentLoaded', LockUnlockAction('{{ csrf_token|escapejs }}', '{% url 'wagtailadmin_pages:edit' page.id %}'));
         })
     </script>

--- a/wagtail/admin/templates/wagtailadmin/pages/workflow_action_modal.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/workflow_action_modal.html
@@ -2,7 +2,7 @@
 {% include "wagtailadmin/shared/header.html" with title=action_verbose icon="clipboard-list" %}
 
 <div class="nice-padding">
-    <form action="{% url 'wagtailadmin_pages:workflow_action' page.id action task_state.id %}" method="POST" novalidate>
+    <form action="{{ submit_url }}" method="POST" novalidate>
         {% csrf_token %}
         <ul class="fields">
             {% include 'wagtailadmin/shared/form_as_ul.html' %}

--- a/wagtail/admin/tests/test_workflows.py
+++ b/wagtail/admin/tests/test_workflows.py
@@ -1038,6 +1038,31 @@ class TestApproveRejectWorkflow(TestCase, WagtailTestUtils):
         # Check that the user received a 403 response
         self.assertEqual(response.status_code, 403)
 
+    def test_collect_workflow_action_data_get(self):
+        """
+        This tests that a GET request to the collect_workflow_action_data view (for the approve action) returns a modal with a form for extra data entry:
+        adding a comment
+        """
+        response = self.client.get(reverse('wagtailadmin_pages:collect_workflow_action_data', args=(self.page.id, 'approve', self.page.current_workflow_task_state.id)))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'wagtailadmin/pages/workflow_action_modal.html')
+        html = json.loads(response.content)['html']
+        self.assertTagInHTML('<form action="' + reverse('wagtailadmin_pages:workflow_action', args=(self.page.id, 'approve', self.page.current_workflow_task_state.id)) + '" method="POST" novalidate>', html)
+        self.assertIn('Comment', html)
+
+    def test_collect_workflow_action_data_post(self):
+        """
+        This tests that a POST request to the collect_workflow_action_data view (for the approve action) returns a modal response with the validated data
+        """
+        response = self.client.post(
+            reverse('wagtailadmin_pages:collect_workflow_action_data', args=(self.page.id, 'approve', self.page.current_workflow_task_state.id)),
+            {'comment': "This is my comment"}
+        )
+        self.assertEqual(response.status_code, 200)
+        response_json = json.loads(response.content)
+        self.assertEqual(response_json['step'], 'success')
+        self.assertEqual(response_json['cleaned_data'], {'comment': "This is my comment"})
+
     def test_workflow_report(self):
         response = self.client.get(reverse('wagtailadmin_reports:workflow'))
         self.assertEqual(response.status_code, 200)

--- a/wagtail/admin/tests/test_workflows.py
+++ b/wagtail/admin/tests/test_workflows.py
@@ -1047,7 +1047,7 @@ class TestApproveRejectWorkflow(TestCase, WagtailTestUtils):
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, 'wagtailadmin/pages/workflow_action_modal.html')
         html = json.loads(response.content)['html']
-        self.assertTagInHTML('<form action="' + reverse('wagtailadmin_pages:workflow_action', args=(self.page.id, 'approve', self.page.current_workflow_task_state.id)) + '" method="POST" novalidate>', html)
+        self.assertTagInHTML('<form action="' + reverse('wagtailadmin_pages:collect_workflow_action_data', args=(self.page.id, 'approve', self.page.current_workflow_task_state.id)) + '" method="POST" novalidate>', html)
         self.assertIn('Comment', html)
 
     def test_collect_workflow_action_data_post(self):

--- a/wagtail/admin/urls/pages.py
+++ b/wagtail/admin/urls/pages.py
@@ -26,6 +26,7 @@ urlpatterns = [
     path('<int:page_id>/copy/', pages.copy, name='copy'),
 
     path('workflow/action/<int:page_id>/<slug:action_name>/<int:task_state_id>/', pages.WorkflowAction.as_view(), name='workflow_action'),
+    path('workflow/collect_action_data/<int:page_id>/<slug:action_name>/<int:task_state_id>/', pages.CollectWorkflowActionData.as_view(), name='collect_workflow_action_data'),
     path('workflow/confirm_cancellation/<int:page_id>/', pages.confirm_workflow_cancellation, name='confirm_workflow_cancellation'),
     path('workflow/preview/<int:page_id>/<int:task_id>/', pages.preview_revision_for_task, name='workflow_preview'),
     path('workflow/status/<int:page_id>/', pages.workflow_status, name='workflow_status'),

--- a/wagtail/admin/urls/pages.py
+++ b/wagtail/admin/urls/pages.py
@@ -25,7 +25,7 @@ urlpatterns = [
 
     path('<int:page_id>/copy/', pages.copy, name='copy'),
 
-    path('workflow/action/<int:page_id>/<slug:action_name>/<int:task_state_id>/', pages.workflow_action, name='workflow_action'),
+    path('workflow/action/<int:page_id>/<slug:action_name>/<int:task_state_id>/', pages.WorkflowAction.as_view(), name='workflow_action'),
     path('workflow/confirm_cancellation/<int:page_id>/', pages.confirm_workflow_cancellation, name='confirm_workflow_cancellation'),
     path('workflow/preview/<int:page_id>/<int:task_id>/', pages.preview_revision_for_task, name='workflow_preview'),
     path('workflow/status/<int:page_id>/', pages.workflow_status, name='workflow_status'),

--- a/wagtail/admin/views/pages.py
+++ b/wagtail/admin/views/pages.py
@@ -1296,16 +1296,7 @@ class WorkflowAction(View):
                 redirect_to = self.task.on_action(self.task_state, request.user, self.action_name, **form.cleaned_data) or self.redirect_to
             elif self.action_modal and request.is_ajax():
                 # show form errors
-                return render_modal_workflow(
-                    request, 'wagtailadmin/pages/workflow_action_modal.html', None, {
-                        'page': self.page,
-                        'form': form,
-                        'action': self.action_name,
-                        'action_verbose': self.action_verbose_name,
-                        'task_state': self.task_state,
-                    },
-                    json_data={'step': 'action'}
-                )
+                return self.render_modal_form(request, form)
         else:
             redirect_to = self.task.on_action(self.task_state, request.user, self.action_name) or self.redirect_to
 
@@ -1315,6 +1306,9 @@ class WorkflowAction(View):
 
     def get(self, request, page_id, action_name, task_state_id):
         form = self.form_class()
+        return self.render_modal_form(request, form)
+
+    def render_modal_form(self, request, form):
         return render_modal_workflow(
             request, 'wagtailadmin/pages/workflow_action_modal.html', None, {
                 'page': self.page,

--- a/wagtail/admin/views/pages.py
+++ b/wagtail/admin/views/pages.py
@@ -1248,77 +1248,79 @@ def reject_moderation(request, revision_id):
     return redirect('wagtailadmin_home')
 
 
-def workflow_action(request, page_id, action_name, task_state_id):
+class WorkflowAction(View):
     """Provides a modal view to enter additional data for the specified workflow action on GET,
     or perform the specified action on POST"""
-    page = get_object_or_404(Page, id=page_id)
 
-    redirect_to = request.POST.get('next', None)
-    if not redirect_to or not is_safe_url(url=redirect_to, allowed_hosts={request.get_host()}):
-        redirect_to = reverse('wagtailadmin_pages:edit', args=[page_id])
+    def dispatch(self, request, page_id, action_name, task_state_id):
+        page = get_object_or_404(Page, id=page_id)
 
-    if not page.workflow_in_progress:
-        messages.error(request, _("The page '{0}' is not currently awaiting moderation.").format(page.get_admin_display_title()))
-        return redirect(redirect_to)
+        redirect_to = request.POST.get('next', None)
+        if not redirect_to or not is_safe_url(url=redirect_to, allowed_hosts={request.get_host()}):
+            redirect_to = reverse('wagtailadmin_pages:edit', args=[page_id])
 
-    task_state = get_object_or_404(TaskState, id=task_state_id)
-    task_state = task_state.specific
+        if not page.workflow_in_progress:
+            messages.error(request, _("The page '{0}' is not currently awaiting moderation.").format(page.get_admin_display_title()))
+            return redirect(redirect_to)
 
-    task = task_state.task.specific
+        task_state = get_object_or_404(TaskState, id=task_state_id)
+        task_state = task_state.specific
 
-    actions = task.get_actions(page, request.user)
-    action_verbose_name = ''
-    action_available = False
-    action_modal = False
+        task = task_state.task.specific
 
-    for name, verbose_name, modal in actions:
-        if name == action_name:
-            action_available = True
-            if modal:
-                action_modal = True
-                # if two actions have the same name, use the verbose name of the one allowing modal data entry
-                # within the modal
-                action_verbose_name = verbose_name
-    if not action_available:
-        raise PermissionDenied
+        actions = task.get_actions(page, request.user)
+        action_verbose_name = ''
+        action_available = False
+        action_modal = False
 
-    form_class = task.get_form_for_action(action_name)
+        for name, verbose_name, modal in actions:
+            if name == action_name:
+                action_available = True
+                if modal:
+                    action_modal = True
+                    # if two actions have the same name, use the verbose name of the one allowing modal data entry
+                    # within the modal
+                    action_verbose_name = verbose_name
+        if not action_available:
+            raise PermissionDenied
 
-    if request.method == 'POST':
-        if form_class:
-            form = form_class(request.POST)
-            if form.is_valid():
-                redirect_to = task.on_action(task_state, request.user, action_name, **form.cleaned_data) or redirect_to
-            elif action_modal and request.is_ajax():
-                # show form errors
-                return render_modal_workflow(
-                    request, 'wagtailadmin/pages/workflow_action_modal.html', None, {
-                        'page': page,
-                        'form': form,
-                        'action': action_name,
-                        'action_verbose': action_verbose_name,
-                        'task_state': task_state,
-                    },
-                    json_data={'step': 'action'}
-                )
+        form_class = task.get_form_for_action(action_name)
+
+        if request.method == 'POST':
+            if form_class:
+                form = form_class(request.POST)
+                if form.is_valid():
+                    redirect_to = task.on_action(task_state, request.user, action_name, **form.cleaned_data) or redirect_to
+                elif action_modal and request.is_ajax():
+                    # show form errors
+                    return render_modal_workflow(
+                        request, 'wagtailadmin/pages/workflow_action_modal.html', None, {
+                            'page': page,
+                            'form': form,
+                            'action': action_name,
+                            'action_verbose': action_verbose_name,
+                            'task_state': task_state,
+                        },
+                        json_data={'step': 'action'}
+                    )
+            else:
+                redirect_to = task.on_action(task_state, request.user, action_name) or redirect_to
+
+            if request.is_ajax():
+                return render_modal_workflow(request, '', None, {}, json_data={'step': 'success', 'redirect': redirect_to})
+            return redirect(redirect_to)
         else:
-            redirect_to = task.on_action(task_state, request.user, action_name) or redirect_to
-
-        if request.is_ajax():
-            return render_modal_workflow(request, '', None, {}, json_data={'step': 'success', 'redirect': redirect_to})
-        return redirect(redirect_to)
-    else:
-        form = form_class()
-        return render_modal_workflow(
-            request, 'wagtailadmin/pages/workflow_action_modal.html', None, {
-                'page': page,
-                'form': form,
-                'action': action_name,
-                'action_verbose': action_verbose_name,
-                'task_state': task_state,
-            },
-            json_data={'step': 'action'}
-        )
+            form = form_class()
+            return render_modal_workflow(
+                request, 'wagtailadmin/pages/workflow_action_modal.html', None, {
+                    'page': page,
+                    'form': form,
+                    'action': action_name,
+                    'action_verbose': action_verbose_name,
+                    'task_state': task_state,
+                },
+                json_data={'step': 'action'}
+            )
 
 
 def confirm_workflow_cancellation(request, page_id):

--- a/wagtail/admin/views/pages.py
+++ b/wagtail/admin/views/pages.py
@@ -1248,9 +1248,11 @@ def reject_moderation(request, revision_id):
     return redirect('wagtailadmin_home')
 
 
-class WorkflowAction(View):
-    """Provides a modal view to enter additional data for the specified workflow action on GET,
-    or perform the specified action on POST"""
+class BaseWorkflowFormView(View):
+    """
+    Shared functionality for views that need to render the modal form to collect extra details
+    for a workflow task
+    """
 
     def dispatch(self, request, page_id, action_name, task_state_id):
         self.page = get_object_or_404(Page, id=page_id)
@@ -1290,6 +1292,33 @@ class WorkflowAction(View):
         return super().dispatch(request, page_id, action_name, task_state_id)
 
     def post(self, request, page_id, action_name, task_state_id):
+        raise NotImplementedError
+
+    def get(self, request, page_id, action_name, task_state_id):
+        form = self.form_class()
+        return self.render_modal_form(request, form)
+
+    def get_submit_url(self):
+        raise NotImplementedError
+
+    def render_modal_form(self, request, form):
+        return render_modal_workflow(
+            request, 'wagtailadmin/pages/workflow_action_modal.html', None, {
+                'page': self.page,
+                'form': form,
+                'action': self.action_name,
+                'action_verbose': self.action_verbose_name,
+                'task_state': self.task_state,
+                'submit_url': self.get_submit_url(),
+            },
+            json_data={'step': 'action'}
+        )
+
+
+class WorkflowAction(BaseWorkflowFormView):
+    """Provides a modal view to enter additional data for the specified workflow action on GET,
+    or perform the specified action on POST"""
+    def post(self, request, page_id, action_name, task_state_id):
         if self.form_class:
             form = self.form_class(request.POST)
             if form.is_valid():
@@ -1304,21 +1333,27 @@ class WorkflowAction(View):
             return render_modal_workflow(request, '', None, {}, json_data={'step': 'success', 'redirect': redirect_to})
         return redirect(redirect_to)
 
-    def get(self, request, page_id, action_name, task_state_id):
-        form = self.form_class()
-        return self.render_modal_form(request, form)
+    def get_submit_url(self):
+        return reverse('wagtailadmin_pages:workflow_action', args=(self.page.id, self.action_name, self.task_state.id))
 
-    def render_modal_form(self, request, form):
-        return render_modal_workflow(
-            request, 'wagtailadmin/pages/workflow_action_modal.html', None, {
-                'page': self.page,
-                'form': form,
-                'action': self.action_name,
-                'action_verbose': self.action_verbose_name,
-                'task_state': self.task_state,
-            },
-            json_data={'step': 'action'}
-        )
+
+class CollectWorkflowActionData(BaseWorkflowFormView):
+    """
+    On GET, provides a modal view to enter additional data for the specified workflow action;
+    on POST, return the validated form data back to the modal's caller via a JSON response, so that
+    the calling view can subsequently perform the action as part of its own processing
+    (for example, approving moderation while making an edit).
+    """
+    def post(self, request, page_id, action_name, task_state_id):
+        form = self.form_class(request.POST)
+        if form.is_valid():
+            return render_modal_workflow(request, '', None, {}, json_data={'step': 'success', 'cleaned_data': form.cleaned_data})
+        elif self.action_modal and request.is_ajax():
+            # show form errors
+            return self.render_modal_form(request, form)
+
+    def get_submit_url(self):
+        return reverse('wagtailadmin_pages:collect_workflow_action_data', args=(self.page.id, self.action_name, self.task_state.id))
 
 
 def confirm_workflow_cancellation(request, page_id):

--- a/wagtail/admin/views/pages.py
+++ b/wagtail/admin/views/pages.py
@@ -1287,41 +1287,44 @@ class WorkflowAction(View):
 
         self.form_class = self.task.get_form_for_action(self.action_name)
 
-        if request.method == 'POST':
-            if self.form_class:
-                form = self.form_class(request.POST)
-                if form.is_valid():
-                    redirect_to = self.task.on_action(self.task_state, request.user, self.action_name, **form.cleaned_data) or self.redirect_to
-                elif self.action_modal and request.is_ajax():
-                    # show form errors
-                    return render_modal_workflow(
-                        request, 'wagtailadmin/pages/workflow_action_modal.html', None, {
-                            'page': self.page,
-                            'form': form,
-                            'action': self.action_name,
-                            'action_verbose': self.action_verbose_name,
-                            'task_state': self.task_state,
-                        },
-                        json_data={'step': 'action'}
-                    )
-            else:
-                redirect_to = self.task.on_action(self.task_state, request.user, self.action_name) or self.redirect_to
+        return super().dispatch(request, page_id, action_name, task_state_id)
 
-            if request.is_ajax():
-                return render_modal_workflow(request, '', None, {}, json_data={'step': 'success', 'redirect': redirect_to})
-            return redirect(redirect_to)
+    def post(self, request, page_id, action_name, task_state_id):
+        if self.form_class:
+            form = self.form_class(request.POST)
+            if form.is_valid():
+                redirect_to = self.task.on_action(self.task_state, request.user, self.action_name, **form.cleaned_data) or self.redirect_to
+            elif self.action_modal and request.is_ajax():
+                # show form errors
+                return render_modal_workflow(
+                    request, 'wagtailadmin/pages/workflow_action_modal.html', None, {
+                        'page': self.page,
+                        'form': form,
+                        'action': self.action_name,
+                        'action_verbose': self.action_verbose_name,
+                        'task_state': self.task_state,
+                    },
+                    json_data={'step': 'action'}
+                )
         else:
-            form = self.form_class()
-            return render_modal_workflow(
-                request, 'wagtailadmin/pages/workflow_action_modal.html', None, {
-                    'page': self.page,
-                    'form': form,
-                    'action': self.action_name,
-                    'action_verbose': self.action_verbose_name,
-                    'task_state': self.task_state,
-                },
-                json_data={'step': 'action'}
-            )
+            redirect_to = self.task.on_action(self.task_state, request.user, self.action_name) or self.redirect_to
+
+        if request.is_ajax():
+            return render_modal_workflow(request, '', None, {}, json_data={'step': 'success', 'redirect': redirect_to})
+        return redirect(redirect_to)
+
+    def get(self, request, page_id, action_name, task_state_id):
+        form = self.form_class()
+        return render_modal_workflow(
+            request, 'wagtailadmin/pages/workflow_action_modal.html', None, {
+                'page': self.page,
+                'form': form,
+                'action': self.action_name,
+                'action_verbose': self.action_verbose_name,
+                'task_state': self.task_state,
+            },
+            json_data={'step': 'action'}
+        )
 
 
 def confirm_workflow_cancellation(request, page_id):

--- a/wagtail/admin/views/pages.py
+++ b/wagtail/admin/views/pages.py
@@ -1,3 +1,4 @@
+import json
 from datetime import timedelta
 from time import time
 
@@ -446,6 +447,16 @@ def edit(request, page_id):
             is_submitting = bool(request.POST.get('action-submit')) and page_perms.can_submit_for_moderation()
             is_restarting_workflow = bool(request.POST.get('action-restart-workflow')) and page_perms.can_submit_for_moderation() and workflow_state and workflow_state.user_can_cancel(request.user)
             is_reverting = bool(request.POST.get('revision'))
+
+            is_performing_workflow_action = bool(request.POST.get('action-workflow-action'))
+            if is_performing_workflow_action:
+                workflow_action = request.POST['workflow-action-name']
+                available_actions = page.current_workflow_task.get_actions(page, request.user)
+                available_action_names = [name for name, verbose_name, modal in available_actions]
+                if workflow_action not in available_action_names:
+                    # prevent this action
+                    is_performing_workflow_action = False
+
             is_saving = True
             has_content_changes = form.has_changed()
 
@@ -457,12 +468,18 @@ def edit(request, page_id):
             if is_reverting:
                 previous_revision = get_object_or_404(page.revisions, id=request.POST.get('revision'))
 
-            # Save revision
-            revision = page.save_revision(
-                user=request.user,
-                log_action=True,  # Always log the new revision on edit
-                previous_revision=(previous_revision if is_reverting else None)
-            )
+            if is_performing_workflow_action and not has_content_changes:
+                # don't save a new revision, as we're just going to update the page's
+                # workflow state with no content changes
+                revision = latest_revision
+            else:
+                # Save revision
+                revision = page.save_revision(
+                    user=request.user,
+                    log_action=True,  # Always log the new revision on edit
+                    previous_revision=(previous_revision if is_reverting else None)
+                )
+
             # store submitted go_live_at for messaging below
             go_live_at = page.go_live_at
 
@@ -497,6 +514,11 @@ def edit(request, page_id):
                     # Otherwise start a new workflow
                     workflow = page.get_workflow()
                     workflow.start(page, request.user)
+
+            if is_performing_workflow_action:
+                extra_workflow_data_json = request.POST.get('workflow-action-extra-data', '{}')
+                extra_workflow_data = json.loads(extra_workflow_data_json)
+                page.current_workflow_task.on_action(page.current_workflow_task_state, request.user, workflow_action, **extra_workflow_data)
 
         # Notifications
         if is_publishing:
@@ -638,7 +660,7 @@ def edit(request, page_id):
                 if hasattr(result, 'status_code'):
                     return result
 
-            if is_publishing or is_submitting or is_restarting_workflow:
+            if is_publishing or is_submitting or is_restarting_workflow or is_performing_workflow_action:
                 # we're done here - redirect back to the explorer
                 if next_url:
                     # redirect back to 'next' url if present


### PR DESCRIPTION
Previously, any workflow actions in the edit-page action menu (e.g. 'Approve', 'Approve with comment') were handled by posting to the `workflow_action` view, which is separate from the edit view. This meant that if a moderator made any content edits immediately before selecting an action (for example, fixing a typo that doesn't warrant going through the 'suggest changes' route), those edits would be lost.

This PR fixes that by funnelling workflow actions through the edit view. A bit of trickery is needed for actions that require a modal form (e.g. approve with comment), since we need to validate that form before going ahead with either the action or the save; we do that by introducing a variant of the `workflow_action` view that just collects and validates the form data and hands it back so that we can stuff it into the big edit form submission as a hidden JSON field.

The existing code path has been left in place so that it can still be used for the action buttons on the 'pages for moderation' dashboard (which doesn't have this problem, since there's no way of making content edits when performing actions from there).