### PR TITLE
Fix/streamfield form has changed

### DIFF
--- a/wagtail/admin/action_menu.py
+++ b/wagtail/admin/action_menu.py
@@ -314,7 +314,7 @@ class PageActionMenu:
                 for name, label, launch_modal in actions:
                     icon_name = 'edit'
                     if name == "approve":
-                        if is_final_task:
+                        if is_final_task and not getattr(settings, 'WAGTAIL_WORKFLOW_REQUIRE_REAPPROVAL_ON_EDIT', False):
                             label = _("%(label)s and Publish") % {'label': label}
                         icon_name = 'success'
 

--- a/wagtail/core/blocks/base.py
+++ b/wagtail/core/blocks/base.py
@@ -542,6 +542,9 @@ class BlockField(forms.Field):
     def clean(self, value):
         return self.block.clean(value)
 
+    def has_changed(self, initial_value, data_value):
+        return self.block.get_prep_value(initial_value) != self.block.get_prep_value(data_value)
+
 
 DECONSTRUCT_ALIASES = {
     Block: 'wagtail.core.blocks.Block',

--- a/wagtail/core/tests/test_blocks.py
+++ b/wagtail/core/tests/test_blocks.py
@@ -2417,6 +2417,23 @@ class TestStreamBlock(WagtailTestUtils, SimpleTestCase):
         self.assertEqual(list(block.child_blocks.keys()),
                          ['heading', 'paragraph', 'intro', 'by_line'])
 
+    def test_field_has_changed(self):
+        block = blocks.StreamBlock([('paragraph', blocks.CharBlock())])
+        initial_value = blocks.StreamValue(block, [('paragraph', 'test')])
+        initial_value[0].id = 'a'
+
+        data_value = blocks.StreamValue(block, [('paragraph', 'test')])
+        data_value[0].id = 'a'
+
+        # identical ids and content, so has_changed should return False
+        self.assertFalse(blocks.BlockField(block).has_changed(initial_value, data_value))
+
+        changed_data_value = blocks.StreamValue(block, [('paragraph', 'not a test')])
+        changed_data_value[0].id = 'a'
+
+        # identical ids but changed content, so has_changed should return True
+        self.assertTrue(blocks.BlockField(block).has_changed(initial_value, changed_data_value))
+
     def test_required_raises_an_exception_if_empty(self):
         block = blocks.StreamBlock([('paragraph', blocks.CharBlock())], required=True)
         value = blocks.StreamValue(block, [])


### PR DESCRIPTION
This fixes a couple of issues with nonlinear workflows ('WAGTAIL_WORKFLOW_REQUIRE_REAPPROVAL_ON_EDIT=True`):

1. Due to checking `form.has_changed` when deciding whether to save a new revision on a workflow action from the edit view, and the fact that pages with StreamFields always returned True for this, this meant that nonlinear workflows would always act as if edited when being approved, and so return to earlier tasks to be reapproved. This PR adds a custom `has_changed` method to `BlockField` to resolve this.

2. The action menu button for the final workflow step would include "and publish" for the approve action. However, if edits are made, this is misleading, as the page will actually return to previous tasks for reapproval first. This removes "and publish" text for nonlinear workflows for now, although in future we could consider doing something with the form check used to provide the "unsaved changes" message on leaving the edit view.
