### PR TITLE
Add hooks for snippet listing buttons

### DIFF
--- a/docs/reference/hooks.rst
+++ b/docs/reference/hooks.rst
@@ -43,6 +43,42 @@ If you need your hooks to run in a particular order, you can pass the ``order`` 
   def yet_another_hook_function(arg1, arg2...)
       # your code here
 
+Unit testing hooks
+------------------
+
+Hooks are usually registered on startup and can't be changed at runtime. But when writing unit tests, you might want to register a hook
+function just for a single test or block of code and unregister it so that it doesn't run when other tests are run.
+
+You can register hooks temporarily using the ``hooks.register_temporarily`` function, this can be used as both a decorator and a context
+manager. Here's an example of how to register a hook function for just a single test:
+
+.. code-block:: python
+
+  def my_hook_function():
+      ...
+
+  class MyHookTest(TestCase):
+
+      @hooks.register_temporarily('name_of_hook', my_hook_function)
+      def test_my_hook_function(self):
+          # Test with the hook registered here
+          ...
+
+And here's an example of registering a hook function for a single block of code:
+
+.. code-block:: python
+
+
+  def my_hook_function():
+      ...
+
+  with hooks.register_temporarily('name_of_hook', my_hook_function):
+      # Hook is registered here
+      ..
+
+  # Hook is unregistered here
+
+
 The available hooks are listed below.
 
 .. contents::

--- a/docs/reference/hooks.rst
+++ b/docs/reference/hooks.rst
@@ -1081,6 +1081,51 @@ Hooks for working with registered Snippets.
         return HttpResponse(f"{total} snippets have been deleted", content_type="text/plain")
 
 
+.. _register_snippet_listing_buttons:
+
+``register_snippet_listing_buttons``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+  Add buttons to the actions list for a snippet in the snippets listing. This is useful when adding custom actions to the listing, such as translations or a complex workflow.
+
+  This example will add a simple button to the listing:
+
+  .. code-block:: python
+
+    from wagtail.snippets import widgets as wagtailsnippets_widgets
+
+    @hooks.register('register_snippet_listing_buttons')
+    def snippet_listing_buttons(snippet, user, next_url=None):
+        yield wagtailsnippets_widgets.SnippetListingButton(
+            'A page listing button',
+            '/goes/to/a/url/',
+            priority=10
+        )
+
+  The arguments passed to the hook are as follows:
+
+  * ``snippet`` - the snippet object to generate the button for
+  * ``user`` - the user who is viewing the snippets listing
+  * ``next_url`` - the URL that the linked action should redirect back to on completion of the action, if the view supports it
+
+  The ``priority`` argument controls the order the buttons are displayed in. Buttons are ordered from low to high priority, so a button with ``priority=10`` will be displayed before a button with ``priority=20``.
+
+.. construct_snippet_listing_buttons:
+
+``construct_snippet_listing_buttons``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+  Modify the final list of snippet listing buttons. The
+  callable passed to this hook receives a list of ``SnippetListingButton`` objects, a user,
+  and a context dictionary as per ``register_snippet_listing_buttons``,
+  and should modify the list of menu items in-place.
+
+  .. code-block:: python
+
+    @hooks.register('construct_snippet_listing_buttons')
+    def remove_snippet_listing_button_item(buttons, snippet, user, context=None):
+        buttons.pop()  # Removes the 'delete' button
+
 Audit log
 ---------
 

--- a/wagtail/admin/tests/test_buttons_hooks.py
+++ b/wagtail/admin/tests/test_buttons_hooks.py
@@ -13,7 +13,6 @@ class TestButtonsHooks(TestCase, WagtailTestUtils):
         self.login()
 
     def test_register_page_listing_buttons(self):
-        @hooks.register('register_page_listing_buttons')
         def page_listing_buttons(page, page_perms, is_parent=False, next_url=None):
             yield wagtailadmin_widgets.PageListingButton(
                 'Another useless page listing button',
@@ -21,9 +20,10 @@ class TestButtonsHooks(TestCase, WagtailTestUtils):
                 priority=10
             )
 
-        response = self.client.get(
-            reverse('wagtailadmin_explore', args=(self.root_page.id, ))
-        )
+        with hooks.register_temporarily('register_page_listing_buttons', page_listing_buttons):
+            response = self.client.get(
+                reverse('wagtailadmin_explore', args=(self.root_page.id, ))
+            )
 
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, 'wagtailadmin/pages/listing/_button_with_dropdown.html')
@@ -32,7 +32,6 @@ class TestButtonsHooks(TestCase, WagtailTestUtils):
         self.assertContains(response, 'Another useless page listing button')
 
     def test_register_page_listing_more_buttons(self):
-        @hooks.register('register_page_listing_more_buttons')
         def page_listing_more_buttons(page, page_perms, is_parent=False, next_url=None):
             yield wagtailadmin_widgets.Button(
                 'Another useless button in default "More" dropdown',
@@ -40,9 +39,10 @@ class TestButtonsHooks(TestCase, WagtailTestUtils):
                 priority=10
             )
 
-        response = self.client.get(
-            reverse('wagtailadmin_explore', args=(self.root_page.id, ))
-        )
+        with hooks.register_temporarily('register_page_listing_more_buttons', page_listing_more_buttons):
+            response = self.client.get(
+                reverse('wagtailadmin_explore', args=(self.root_page.id, ))
+            )
 
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, 'wagtailadmin/pages/listing/_button_with_dropdown.html')
@@ -51,7 +51,6 @@ class TestButtonsHooks(TestCase, WagtailTestUtils):
         self.assertContains(response, 'Another useless button in default &quot;More&quot; dropdown')
 
     def test_custom_button_with_dropdown(self):
-        @hooks.register('register_page_listing_buttons')
         def page_custom_listing_buttons(page, page_perms, is_parent=False, next_url=None):
             yield wagtailadmin_widgets.ButtonWithDropdownFromHook(
                 'One more more button',
@@ -64,7 +63,6 @@ class TestButtonsHooks(TestCase, WagtailTestUtils):
                 priority=50
             )
 
-        @hooks.register('register_page_listing_one_more_more_buttons')
         def page_custom_listing_more_buttons(page, page_perms, is_parent=False, next_url=None):
             yield wagtailadmin_widgets.Button(
                 'Another useless dropdown button in "One more more button" dropdown',
@@ -72,9 +70,10 @@ class TestButtonsHooks(TestCase, WagtailTestUtils):
                 priority=10
             )
 
-        response = self.client.get(
-            reverse('wagtailadmin_explore', args=(self.root_page.id, ))
-        )
+        with hooks.register_temporarily('register_page_listing_buttons', page_custom_listing_buttons), hooks.register_temporarily('register_page_listing_one_more_more_buttons', page_custom_listing_more_buttons):
+            response = self.client.get(
+                reverse('wagtailadmin_explore', args=(self.root_page.id, ))
+            )
 
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, 'wagtailadmin/pages/listing/_button_with_dropdown.html')

--- a/wagtail/admin/widgets/button.py
+++ b/wagtail/admin/widgets/button.py
@@ -48,10 +48,16 @@ class Button:
                 and self.priority == other.priority)
 
 
-class PageListingButton(Button):
+# Base class for all listing buttons
+# This is also used by SnippetListingButton defined in wagtail.snippets.widgets
+class ListingButton(Button):
     def __init__(self, label, url, classes=set(), **kwargs):
         classes = {'button', 'button-small', 'button-secondary'} | set(classes)
         super().__init__(label, url, classes=classes, **kwargs)
+
+
+class PageListingButton(ListingButton):
+    pass
 
 
 class BaseDropdownMenuButton(Button):

--- a/wagtail/core/hooks.py
+++ b/wagtail/core/hooks.py
@@ -1,3 +1,4 @@
+from contextlib import ContextDecorator
 from operator import itemgetter
 
 from wagtail.utils.apps import get_app_submodules
@@ -30,6 +31,48 @@ def register(hook_name, fn=None, order=0):
     if hook_name not in _hooks:
         _hooks[hook_name] = []
     _hooks[hook_name].append((fn, order))
+
+
+class TemporaryHook(ContextDecorator):
+    def __init__(self, hook_name, fn, order):
+        self.hook_name = hook_name
+        self.fn = fn
+        self.order = order
+
+    def __enter__(self):
+        if self.hook_name not in _hooks:
+            _hooks[self.hook_name] = []
+        _hooks[self.hook_name].append((self.fn, self.order))
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        _hooks[self.hook_name].remove((self.fn, self.order))
+
+
+def register_temporarily(hook_name, fn, order=0):
+    """
+    Register hook for ``hook_name`` temporarily. This is useful for testing hooks.
+
+    Can be used as a decorator::
+
+        def my_hook(...):
+            pass
+
+        class TestMyHook(Testcase):
+            @hooks.register_temporarily('hook_name', my_hook)
+            def test_my_hook(self):
+                pass
+
+    or as a context manager::
+
+        def my_hook(...):
+            pass
+
+        with hooks.register_temporarily('hook_name', my_hook):
+            # Hook is registered here
+
+        # Hook is unregistered here
+    """
+    return TemporaryHook(hook_name, fn, order)
 
 
 _searched_for_hooks = False

--- a/wagtail/images/tests/test_image_operations.py
+++ b/wagtail/images/tests/test_image_operations.py
@@ -485,10 +485,18 @@ class TestCacheKey(TestCase):
         self.assertEqual(cache_key, '0bbe3b2f')
 
 
+def register_image_operations_hook():
+    return [
+        ('operation1', Mock(return_value=TestFilter.operation_instance)),
+        ('operation2', Mock(return_value=TestFilter.operation_instance))
+    ]
+
+
 class TestFilter(TestCase):
 
     operation_instance = Mock()
 
+    @hooks.register_temporarily('register_image_operations', register_image_operations_hook)
     def test_runs_operations(self):
         run_mock = Mock()
 
@@ -505,14 +513,6 @@ class TestFilter(TestCase):
         fil.run(image, BytesIO())
 
         self.assertEqual(run_mock.call_count, 2)
-
-
-@hooks.register('register_image_operations')
-def register_image_operations():
-    return [
-        ('operation1', Mock(return_value=TestFilter.operation_instance)),
-        ('operation2', Mock(return_value=TestFilter.operation_instance))
-    ]
 
 
 class TestFormatFilter(TestCase):

--- a/wagtail/snippets/templates/wagtailsnippets/snippets/list.html
+++ b/wagtail/snippets/templates/wagtailsnippets/snippets/list.html
@@ -1,4 +1,4 @@
-{% load i18n wagtailadmin_tags %}
+{% load i18n wagtailadmin_tags wagtailsnippets_admin_tags %}
 <table class="listing">
     {% if can_delete_snippets %}<col width="5%" />{% endif %}
     <col />
@@ -7,11 +7,11 @@
     <thead>
         <tr class="table-headers">
             {% if can_delete_snippets %}
-            <th>
-                <input type="checkbox" class="toggle-select-all" id="toggle-select-all-snippets" />
-                <label for="toggle-select-all-snippets" class="visuallyhidden">{% blocktrans with snippet_type_name_plural=model_opts.verbose_name_plural %}Select all {{ snippet_type_name_plural }}{% endblocktrans %}</label>
-            </th>
-        {% endif %}
+                <th>
+                    <input type="checkbox" class="toggle-select-all" id="toggle-select-all-snippets" />
+                    <label for="toggle-select-all-snippets" class="visuallyhidden">{% blocktrans with snippet_type_name_plural=model_opts.verbose_name_plural %}Select all {{ snippet_type_name_plural }}{% endblocktrans %}</label>
+                </th>
+            {% endif %}
             <th>{% trans "Title" %}</th>
         </tr>
     </thead>
@@ -30,14 +30,7 @@
                     {% else %}
                         <div class="title-wrapper"><a href="{% url 'wagtailsnippets:edit' model_opts.app_label model_opts.model_name snippet.pk|admin_urlquote %}">{{ snippet }}</a></div>
                          <ul class="actions">
-                            <li>
-                                <a href="{% url 'wagtailsnippets:edit' model_opts.app_label model_opts.model_name snippet.pk|admin_urlquote %}" class="button button-secondary button-small">{% trans "Edit" %}</a>
-                            </li>
-                            {% if can_delete_snippets %}
-                                <li>
-                                    <a href="{% url 'wagtailsnippets:delete' model_opts.app_label model_opts.model_name snippet.pk|admin_urlquote %}" class="button button-secondary button-small">{% trans "Delete" %}</a>
-                                </li>
-                            {% endif %}
+                            {% snippet_listing_buttons snippet %}
                         </ul>
                     {% endif %}
                 </td>

--- a/wagtail/snippets/templates/wagtailsnippets/snippets/listing_buttons.html
+++ b/wagtail/snippets/templates/wagtailsnippets/snippets/listing_buttons.html
@@ -1,0 +1,5 @@
+{% for button in buttons %}
+    {% if button.show %}
+        <li>{{ button|safe }}</li>
+    {% endif %}
+{% endfor %}

--- a/wagtail/snippets/templatetags/wagtailsnippets_admin_tags.py
+++ b/wagtail/snippets/templatetags/wagtailsnippets_admin_tags.py
@@ -1,0 +1,23 @@
+from django import template
+
+from wagtail.core import hooks
+
+register = template.Library()
+
+
+@register.inclusion_tag("wagtailsnippets/snippets/listing_buttons.html",
+                        takes_context=True)
+def snippet_listing_buttons(context, snippet):
+    next_url = context.request.path
+    button_hooks = hooks.get_hooks('register_snippet_listing_buttons')
+
+    buttons = []
+    for hook in button_hooks:
+        buttons.extend(hook(snippet, context.request.user, next_url))
+
+    buttons.sort()
+
+    for hook in hooks.get_hooks('construct_snippet_listing_buttons'):
+        hook(buttons, snippet, context.request.user, context)
+
+    return {'snippet': snippet, 'buttons': buttons}

--- a/wagtail/snippets/wagtail_hooks.py
+++ b/wagtail/snippets/wagtail_hooks.py
@@ -1,3 +1,4 @@
+from django.contrib.admin.utils import quote
 from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
 from django.urls import include, path, reverse
@@ -8,7 +9,9 @@ from wagtail.admin.menu import MenuItem
 from wagtail.core import hooks
 from wagtail.snippets import urls
 from wagtail.snippets.models import get_snippet_models
-from wagtail.snippets.permissions import user_can_edit_snippets
+from wagtail.snippets.permissions import (
+    get_permission_name, user_can_edit_snippet_type, user_can_edit_snippets)
+from wagtail.snippets.widgets import SnippetListingButton
 
 
 @hooks.register('register_admin_urls')
@@ -47,3 +50,24 @@ def editor_js():
 def register_permissions():
     content_types = ContentType.objects.get_for_models(*get_snippet_models()).values()
     return Permission.objects.filter(content_type__in=content_types)
+
+
+@hooks.register('register_snippet_listing_buttons')
+def register_snippet_listing_buttons(snippet, user, next_url=None):
+    model = type(snippet)
+
+    if user_can_edit_snippet_type(user, model):
+        yield SnippetListingButton(
+            _('Edit'),
+            reverse('wagtailsnippets:edit', args=[model._meta.app_label, model._meta.model_name, quote(snippet.pk)]),
+            attrs={'aria-label': _("Edit '%(title)s'") % {'title': str(snippet)}},
+            priority=10
+        )
+
+    if user.has_perm(get_permission_name('delete', model)):
+        yield SnippetListingButton(
+            _('Delete'),
+            reverse('wagtailsnippets:delete', args=[model._meta.app_label, model._meta.model_name, quote(snippet.pk)]),
+            attrs={'aria-label': _("Delete '%(title)s'") % {'title': str(snippet)}},
+            priority=20
+        )

--- a/wagtail/snippets/widgets.py
+++ b/wagtail/snippets/widgets.py
@@ -6,6 +6,7 @@ from django.utils.translation import gettext_lazy as _
 
 from wagtail.admin.staticfiles import versioned_static
 from wagtail.admin.widgets import AdminChooser
+from wagtail.admin.widgets.button import ListingButton
 
 
 class AdminSnippetChooser(AdminChooser):
@@ -48,3 +49,7 @@ class AdminSnippetChooser(AdminChooser):
             versioned_static('wagtailsnippets/js/snippet-chooser-modal.js'),
             versioned_static('wagtailsnippets/js/snippet-chooser.js'),
         ])
+
+
+class SnippetListingButton(ListingButton):
+    pass

--- a/wagtail/tests/testapp/wagtail_hooks.py
+++ b/wagtail/tests/testapp/wagtail_hooks.py
@@ -160,3 +160,13 @@ def register_page_listing_button_item(buttons, page, page_perms, is_parent=False
         priority=10,
     )
     buttons.append(item)
+
+
+@hooks.register('construct_snippet_listing_buttons')
+def register_snippet_listing_button_item(buttons, snippet, user, context=None):
+    item = Button(
+        label="Dummy Button",
+        url='/dummy-button',
+        priority=10,
+    )
+    buttons.append(item)


### PR DESCRIPTION
This PR implements two new hooks to allow customising the listing buttons on snippets:
 - `register_snippet_listing_buttons`
 - `construct_snippet_listing_buttons`

These are based on  `register_page_listing_buttons` and  `construct_page_listing_buttons`.

I need the `register_page_listing_buttons` hook in order to add a "Translate" button for snippets in `wagtail-localize`.

Sponsored by The Mozilla Foundation.

This depends on https://github.com/wagtail/wagtail/pull/6268