### PR TITLE
Add hooks.register_temporarily for testing hooks

### DIFF
--- a/docs/reference/hooks.rst
+++ b/docs/reference/hooks.rst
@@ -43,6 +43,42 @@ If you need your hooks to run in a particular order, you can pass the ``order`` 
   def yet_another_hook_function(arg1, arg2...)
       # your code here
 
+Unit testing hooks
+------------------
+
+Hooks are usually registered on startup and can't be changed at runtime. But when writing unit tests, you might want to register a hook
+function just for a single test or block of code and unregister it so that it doesn't run when other tests are run.
+
+You can register hooks temporarily using the ``hooks.register_temporarily`` function, this can be used as both a decorator and a context
+manager. Here's an example of how to register a hook function for just a single test:
+
+.. code-block:: python
+
+  def my_hook_function():
+      ...
+
+  class MyHookTest(TestCase):
+
+      @hooks.register_temporarily('name_of_hook', my_hook_function)
+      def test_my_hook_function(self):
+          # Test with the hook registered here
+          ...
+
+And here's an example of registering a hook function for a single block of code:
+
+.. code-block:: python
+
+
+  def my_hook_function():
+      ...
+
+  with hooks.register_temporarily('name_of_hook', my_hook_function):
+      # Hook is registered here
+      ..
+
+  # Hook is unregistered here
+
+
 The available hooks are listed below.
 
 .. contents::

--- a/wagtail/admin/tests/test_buttons_hooks.py
+++ b/wagtail/admin/tests/test_buttons_hooks.py
@@ -13,7 +13,6 @@ class TestButtonsHooks(TestCase, WagtailTestUtils):
         self.login()
 
     def test_register_page_listing_buttons(self):
-        @hooks.register('register_page_listing_buttons')
         def page_listing_buttons(page, page_perms, is_parent=False, next_url=None):
             yield wagtailadmin_widgets.PageListingButton(
                 'Another useless page listing button',
@@ -21,9 +20,10 @@ class TestButtonsHooks(TestCase, WagtailTestUtils):
                 priority=10
             )
 
-        response = self.client.get(
-            reverse('wagtailadmin_explore', args=(self.root_page.id, ))
-        )
+        with hooks.register_temporarily('register_page_listing_buttons', page_listing_buttons):
+            response = self.client.get(
+                reverse('wagtailadmin_explore', args=(self.root_page.id, ))
+            )
 
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, 'wagtailadmin/pages/listing/_button_with_dropdown.html')
@@ -32,7 +32,6 @@ class TestButtonsHooks(TestCase, WagtailTestUtils):
         self.assertContains(response, 'Another useless page listing button')
 
     def test_register_page_listing_more_buttons(self):
-        @hooks.register('register_page_listing_more_buttons')
         def page_listing_more_buttons(page, page_perms, is_parent=False, next_url=None):
             yield wagtailadmin_widgets.Button(
                 'Another useless button in default "More" dropdown',
@@ -40,9 +39,10 @@ class TestButtonsHooks(TestCase, WagtailTestUtils):
                 priority=10
             )
 
-        response = self.client.get(
-            reverse('wagtailadmin_explore', args=(self.root_page.id, ))
-        )
+        with hooks.register_temporarily('register_page_listing_more_buttons', page_listing_more_buttons):
+            response = self.client.get(
+                reverse('wagtailadmin_explore', args=(self.root_page.id, ))
+            )
 
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, 'wagtailadmin/pages/listing/_button_with_dropdown.html')
@@ -51,7 +51,6 @@ class TestButtonsHooks(TestCase, WagtailTestUtils):
         self.assertContains(response, 'Another useless button in default &quot;More&quot; dropdown')
 
     def test_custom_button_with_dropdown(self):
-        @hooks.register('register_page_listing_buttons')
         def page_custom_listing_buttons(page, page_perms, is_parent=False, next_url=None):
             yield wagtailadmin_widgets.ButtonWithDropdownFromHook(
                 'One more more button',
@@ -64,7 +63,6 @@ class TestButtonsHooks(TestCase, WagtailTestUtils):
                 priority=50
             )
 
-        @hooks.register('register_page_listing_one_more_more_buttons')
         def page_custom_listing_more_buttons(page, page_perms, is_parent=False, next_url=None):
             yield wagtailadmin_widgets.Button(
                 'Another useless dropdown button in "One more more button" dropdown',
@@ -72,9 +70,10 @@ class TestButtonsHooks(TestCase, WagtailTestUtils):
                 priority=10
             )
 
-        response = self.client.get(
-            reverse('wagtailadmin_explore', args=(self.root_page.id, ))
-        )
+        with hooks.register_temporarily('register_page_listing_buttons', page_custom_listing_buttons), hooks.register_temporarily('register_page_listing_one_more_more_buttons', page_custom_listing_more_buttons):
+            response = self.client.get(
+                reverse('wagtailadmin_explore', args=(self.root_page.id, ))
+            )
 
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, 'wagtailadmin/pages/listing/_button_with_dropdown.html')

--- a/wagtail/core/hooks.py
+++ b/wagtail/core/hooks.py
@@ -1,3 +1,4 @@
+from contextlib import ContextDecorator
 from operator import itemgetter
 
 from wagtail.utils.apps import get_app_submodules
@@ -30,6 +31,48 @@ def register(hook_name, fn=None, order=0):
     if hook_name not in _hooks:
         _hooks[hook_name] = []
     _hooks[hook_name].append((fn, order))
+
+
+class TemporaryHook(ContextDecorator):
+    def __init__(self, hook_name, fn, order):
+        self.hook_name = hook_name
+        self.fn = fn
+        self.order = order
+
+    def __enter__(self):
+        if self.hook_name not in _hooks:
+            _hooks[self.hook_name] = []
+        _hooks[self.hook_name].append((self.fn, self.order))
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        _hooks[self.hook_name].remove((self.fn, self.order))
+
+
+def register_temporarily(hook_name, fn, order=0):
+    """
+    Register hook for ``hook_name`` temporarily. This is useful for testing hooks.
+
+    Can be used as a decorator::
+
+        def my_hook(...):
+            pass
+
+        class TestMyHook(Testcase):
+            @hooks.register_temporarily('hook_name', my_hook)
+            def test_my_hook(self):
+                pass
+
+    or as a context manager::
+
+        def my_hook(...):
+            pass
+
+        with hooks.register_temporarily('hook_name', my_hook):
+            # Hook is registered here
+
+        # Hook is unregistered here
+    """
+    return TemporaryHook(hook_name, fn, order)
 
 
 _searched_for_hooks = False

--- a/wagtail/images/tests/test_image_operations.py
+++ b/wagtail/images/tests/test_image_operations.py
@@ -485,10 +485,18 @@ class TestCacheKey(TestCase):
         self.assertEqual(cache_key, '0bbe3b2f')
 
 
+def register_image_operations_hook():
+    return [
+        ('operation1', Mock(return_value=TestFilter.operation_instance)),
+        ('operation2', Mock(return_value=TestFilter.operation_instance))
+    ]
+
+
 class TestFilter(TestCase):
 
     operation_instance = Mock()
 
+    @hooks.register_temporarily('register_image_operations', register_image_operations_hook)
     def test_runs_operations(self):
         run_mock = Mock()
 
@@ -505,14 +513,6 @@ class TestFilter(TestCase):
         fil.run(image, BytesIO())
 
         self.assertEqual(run_mock.call_count, 2)
-
-
-@hooks.register('register_image_operations')
-def register_image_operations():
-    return [
-        ('operation1', Mock(return_value=TestFilter.operation_instance)),
-        ('operation2', Mock(return_value=TestFilter.operation_instance))
-    ]
 
 
 class TestFormatFilter(TestCase):


### PR DESCRIPTION
There's currently a number of places where we test hooks by registering
hook functions from test methods. These are never cleaned up so that
hook remains registered in future tests. This can cause issues with
tests not working consistently when you run a subset of the tests.

This adds a `register_temporarily` function to the hooks module. This
function can be used either as a decorator or a context manager. It'll
always remove the hook after the decorated function or with block exits,
even if it exits through an exception.

This is required in order to get tests working in https://github.com/wagtail/wagtail/pull/6267