### PR TITLE
Fix appconf for wagtail.tests.modeladmintest

### DIFF
--- a/wagtail/tests/modeladmintest/__init__.py
+++ b/wagtail/tests/modeladmintest/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'wagtail.tests.modeladmintest.apps.WagtailTestsAppConfig'

--- a/wagtail/tests/modeladmintest/apps.py
+++ b/wagtail/tests/modeladmintest/apps.py
@@ -4,5 +4,5 @@ from django.utils.translation import gettext_lazy as _
 
 class WagtailTestsAppConfig(AppConfig):
     name = 'wagtail.tests.modeladmintest'
-    label = 'test_modeladmintest'
+    label = 'modeladmintest'
     verbose_name = _("Test Wagtail Model Admin")


### PR DESCRIPTION
WagtailTestsAppConfig had an incorrect label, but this didn't matter because it wasn't being specified in the app's __init__.py. However, Django 3.2 autodetects appconfs in apps.py, which causes the error to surface.