### PR TITLE
Simplify Page.copy()

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ except ImportError:
 
 install_requires = [
     "Django>=2.2,<3.2",
-    "django-modelcluster>=5.0.2,<6.0",
+    "django-modelcluster>=5.1,<6.0",
     "django-taggit>=1.0,<2.0",
     "django-treebeard>=4.2.0,<5.0",
     "djangorestframework>=3.11.1,<4.0",

--- a/wagtail/core/migrations/0047_add_workflow_models.py
+++ b/wagtail/core/migrations/0047_add_workflow_models.py
@@ -45,7 +45,7 @@ class Migration(migrations.Migration):
                 'verbose_name': 'Task state',
                 'verbose_name_plural': 'Task states',
             },
-            bases=(wagtail.core.models.MultiTableCopyMixin, models.Model),
+            bases=(wagtail.core.models.CopyMixin, models.Model),
         ),
         migrations.CreateModel(
             name='Workflow',

--- a/wagtail/core/migrations/0047_add_workflow_models.py
+++ b/wagtail/core/migrations/0047_add_workflow_models.py
@@ -4,7 +4,6 @@ from django.conf import settings
 from django.db import migrations, models
 import django.db.models.deletion
 import modelcluster.fields
-import wagtail.core.models
 
 
 class Migration(migrations.Migration):
@@ -45,7 +44,6 @@ class Migration(migrations.Migration):
                 'verbose_name': 'Task state',
                 'verbose_name_plural': 'Task states',
             },
-            bases=(wagtail.core.models.CopyMixin, models.Model),
         ),
         migrations.CreateModel(
             name='Workflow',

--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -51,7 +51,7 @@ PAGE_TEMPLATE_VAR = 'page'
 
 
 def _extract_field_data(source, exclude_fields=None):
-    """Get dictionaries representing the model: one with all non m2m fields, and one containing the m2m fields"""
+    """Get dictionaries representing the model's field data. Excluding many to many fields (which are handled by _copy_m2m_relations)'"""
     exclude_fields = exclude_fields or []
     data_dict = {}
 
@@ -84,21 +84,6 @@ def _extract_field_data(source, exclude_fields=None):
     return data_dict
 
 
-def _make_copy(source, data_dict, update_attrs=None):
-    """Create a copy instance (without saving) from dictionaries of the model's fields, and update any attributes in update_attrs"""
-
-    if not update_attrs:
-        update_attrs = {}
-
-    target = source.__class__(**data_dict)
-
-    if update_attrs:
-        for field, value in update_attrs.items():
-            setattr(target, field, value)
-
-    return target
-
-
 def _copy_m2m_relations(source, target, exclude_fields=None, update_attrs=None):
     """Copy non-ParentalManyToMany m2m relations"""
     update_attrs = update_attrs or {}
@@ -126,7 +111,12 @@ def _copy_m2m_relations(source, target, exclude_fields=None, update_attrs=None):
 
 def _copy(source, exclude_fields=None, update_attrs=None):
     data_dict = _extract_field_data(source, exclude_fields=exclude_fields)
-    target = _make_copy(source, data_dict, update_attrs=update_attrs)
+    target = source.__class__(**data_dict)
+
+    if update_attrs:
+        for field, value in update_attrs.items():
+            setattr(target, field, value)
+
     child_object_map = source.copy_all_child_relations(target, exclude=exclude_fields)
     return target, child_object_map
 

--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -3582,7 +3582,7 @@ class TaskState(models.Model):
         """Copy this task state, excluding the attributes in the ``exclude_fields`` list and updating any attributes to values
         specified in the ``update_attrs`` dictionary of ``attribute``: ``new value`` pairs"""
         exclude_fields = self.default_exclude_fields_in_copy + self.exclude_fields_in_copy + (exclude_fields or [])
-        instance, _ = _copy(self.specific, exclude_fields, update_attrs)
+        instance, child_object_map = _copy(self.specific, exclude_fields, update_attrs)
         instance.save()
         _copy_m2m_relations(self, instance, exclude_fields=exclude_fields)
         return instance

--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -51,8 +51,6 @@ PAGE_TEMPLATE_VAR = 'page'
 
 
 class CopyMixin:
-    default_exclude_fields_in_copy = ['id']
-
     def _get_field_dictionaries(self, exclude_fields=None):
         """Get dictionaries representing the model: one with all non m2m fields, and one containing the m2m fields"""
         exclude_fields = exclude_fields or []
@@ -125,8 +123,6 @@ class CopyMixin:
         return instance
 
     def _copy(self, copy_fn, exclude_fields=None, update_attrs=None, commit_child_objects=True, **kwargs):
-        exclude_fields = self.default_exclude_fields_in_copy + self.exclude_fields_in_copy + (exclude_fields or [])
-
         data_dict, m2m_dict = self._get_field_dictionaries(exclude_fields=exclude_fields)
 
         copy_instance = self._get_copy_instance(data_dict, m2m_dict, update_attrs=update_attrs)
@@ -1390,7 +1386,7 @@ class Page(CopyMixin, AbstractPage, index.Indexed, ClusterableModel, metaclass=P
         :param log_action flag for logging the action. Pass None to skip logging.
             Can be passed an action string. Defaults to 'wagtail.copy'
         """
-
+        exclude_fields = self.default_exclude_fields_in_copy + self.exclude_fields_in_copy + (exclude_fields or [])
         specific_self = self.specific
         if keep_live:
             base_update_attrs = {}
@@ -3497,6 +3493,7 @@ class TaskState(CopyMixin, models.Model):
         on_delete=models.CASCADE
     )
     exclude_fields_in_copy = []
+    default_exclude_fields_in_copy = ['id']
 
     objects = TaskStateManager()
 
@@ -3601,6 +3598,8 @@ class TaskState(CopyMixin, models.Model):
     def copy(self, update_attrs=None, exclude_fields=None):
         """Copy this task state, excluding the attributes in the ``exclude_fields`` list and updating any attributes to values
         specified in the ``update_attrs`` dictionary of ``attribute``: ``new value`` pairs"""
+        exclude_fields = self.default_exclude_fields_in_copy + self.exclude_fields_in_copy + (exclude_fields or [])
+
         def _save_copy_instance(instance):
             # Called from self._copy when it's ready to save an instance
             instance.save()

--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -87,6 +87,8 @@ class MultiTableCopyMixin:
                             continue
                     except AttributeError:
                         pass
+
+                    # TODO: Wouldn't this reassign the objects to the new page rather than copy them?
                     specific_m2m_dict[field.name] = getattr(specific_self, field.name).all()
                 continue
 
@@ -104,9 +106,7 @@ class MultiTableCopyMixin:
         if not update_attrs:
             update_attrs = {}
 
-        specific_class = self.specific.__class__
-
-        copy_instance = specific_class(**specific_dict)
+        copy_instance = self.specific_class(**specific_dict)
 
         if update_attrs:
             for field, value in update_attrs.items():

--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -51,7 +51,11 @@ PAGE_TEMPLATE_VAR = 'page'
 
 
 def _extract_field_data(source, exclude_fields=None):
-    """Get dictionaries representing the model's field data. Excluding many to many fields (which are handled by _copy_m2m_relations)'"""
+    """
+    Get dictionaries representing the model's field data.
+
+    This excludes many to many fields (which are handled by _copy_m2m_relations)'
+    """
     exclude_fields = exclude_fields or []
     data_dict = {}
 
@@ -65,7 +69,6 @@ def _extract_field_data(source, exclude_fields=None):
             continue
 
         # Copy parental m2m relations
-        # Otherwise add them to the m2m dict to be set after saving
         if field.many_to_many:
             if isinstance(field, ParentalManyToManyField):
                 parental_field = getattr(source, field.name)
@@ -85,7 +88,9 @@ def _extract_field_data(source, exclude_fields=None):
 
 
 def _copy_m2m_relations(source, target, exclude_fields=None, update_attrs=None):
-    """Copy non-ParentalManyToMany m2m relations"""
+    """
+    Copies non-ParentalManyToMany m2m relations
+    """
     update_attrs = update_attrs or {}
     exclude_fields = exclude_fields or []
 
@@ -115,6 +120,8 @@ def _copy(source, exclude_fields=None, update_attrs=None):
 
     if update_attrs:
         for field, value in update_attrs.items():
+            if field not in data_dict:
+                continue
             setattr(target, field, value)
 
     child_object_map = source.copy_all_child_relations(target, exclude=exclude_fields)


### PR DESCRIPTION
This PR refactors the copy code to remove some of the spaghetti and hopefully make it more reusable (it still only works with Clusterable models though!). I've also moved bits into Django modelcluster itself (https://github.com/wagtail/django-modelcluster/pull/128 and https://github.com/wagtail/django-modelcluster/pull/129)

This also means that the nested copying feature https://github.com/wagtail/wagtail/issues/6271 can now be completely handled by Django modelcluster so I'll fix that there.