### PR TITLE
Change more instances of ugettext to gettext

### DIFF
--- a/wagtail/admin/forms/workflows.py
+++ b/wagtail/admin/forms/workflows.py
@@ -1,8 +1,8 @@
 from django import forms
 from django.core.exceptions import ImproperlyConfigured, ValidationError
 from django.utils.functional import cached_property
-from django.utils.translation import ugettext as _
-from django.utils.translation import ugettext_lazy as __
+from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy as __
 
 from wagtail.admin import widgets
 from wagtail.admin.edit_handlers import FieldPanel, InlinePanel, ObjectList

--- a/wagtail/admin/views/workflows.py
+++ b/wagtail/admin/views/workflows.py
@@ -9,7 +9,7 @@ from django.template.response import TemplateResponse
 from django.urls import reverse
 from django.utils.functional import cached_property
 from django.utils.http import is_safe_url
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.utils.translation import ngettext
 from django.views.decorators.http import require_POST
 


### PR DESCRIPTION
Removes instances of ugettext which were added with the new moderation workflow.

Closes #6278.

To test:

```
pip install -e git+https://github.com/tomkins/wagtail.git@more-ugettext#egg=wagtail
wagtail start warningdemo
cd warningdemo
python -Wall manage.py migrate
```

And you'll see considerably fewer deprecation warnings.