### PR TITLE
Adds :focus-within .actions for page listings

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,6 +5,7 @@ Changelog
 ~~~~~~~~~~~~~~~~~
 
  * Add `before_edit_snippet`, `before_create_snippet` and `before_delete_snippet` hooks and documentation (Karl Hobley. Sponsored by the Mozilla Foundation)
+ * Fix: Make page-level actions accessible to keyboard users in page listing tables (Jesse Menn)
 
 2.10 (xx.xx.xxxx) - IN DEVELOPMENT
 ~~~~~~~~~~~~~~~~~

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -472,6 +472,7 @@ Contributors
 * Max Gabrielsson
 * Steven Wood
 * Gabriel Peracio
+* Jesse Menn
 
 Translators
 ===========

--- a/client/scss/components/_listing.scss
+++ b/client/scss/components/_listing.scss
@@ -642,7 +642,8 @@ table.listing {
 
 
 
-        td:hover .actions {
+        td:hover .actions,
+        td:focus-within .actions {
             visibility: visible;
         }
 

--- a/docs/contributing/developing.rst
+++ b/docs/contributing/developing.rst
@@ -175,6 +175,7 @@ IE 11 is gradually falling out of use, and specific features are unsupported in 
 * Rich text copy-paste in the rich text editor.
 * Sticky toolbar in the rich text editor.
 * Focus outline styles in the main menu & explorer menu.
+* Keyboard access to the actions in page listing tables.
 
 **Unsupported browsers / devices include:**
 

--- a/docs/releases/2.11.rst
+++ b/docs/releases/2.11.rst
@@ -19,7 +19,7 @@ Other features
 Bug fixes
 ~~~~~~~~~
 
- * ...
+ * Fix: Make page-level actions accessible to keyboard users in page listing tables (Jesse Menn)
 
 
 Upgrade considerations


### PR DESCRIPTION
Adds a :focus-within for page listings for better keyboard navigation. 

For front-end changes: Did you test on all of Wagtail’s supported browsers?

- Chrome 84.0.4147.89 on OS X 10.14.6
- Firefox 68.10.0esr on OS X 10.14.6
- Safari 13.1.1