### PR TITLE
Cache the SVG icon HTML fragment

### DIFF
--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -547,11 +547,18 @@ def icon(name=None, class_name='icon', title=None, wrapped=False):
     }
 
 
-@register.inclusion_tag("wagtailadmin/shared/icons.html")
+_icons_html = None
+
+
+@register.simple_tag
 def icons():
-    icon_hooks = hooks.get_hooks('register_icons')
-    icons = sorted(itertools.chain.from_iterable(hook([]) for hook in icon_hooks))
-    return {'icons': icons}
+    global _icons_html
+    if _icons_html is None:
+        icon_hooks = hooks.get_hooks('register_icons')
+        icons = sorted(itertools.chain.from_iterable(hook([]) for hook in icon_hooks))
+        _icons_html = render_to_string("wagtailadmin/shared/icons.html", {'icons': icons})
+
+    return _icons_html
 
 
 @register.filter()


### PR DESCRIPTION
The `{% icons %}` tag runs on every admin page render, and without caching, this will perform a template fetch for every .svg file - which is exceptionally slow on environments with shared filesystems (e.g. Vagrant). Adding this cache reduces the runtime of `wagtail.admin.tests.pages.test_create_page` from 89 to 57 seconds.
