### PR TITLE
Fix misapplied format strings inside gettext

### DIFF
--- a/wagtail/admin/forms/pages.py
+++ b/wagtail/admin/forms/pages.py
@@ -74,7 +74,7 @@ class CopyForm(forms.Form):
         # Count the pages with the same slug within the context of our copy's parent page
         if slug and parent_page.get_children().filter(slug=slug).count():
             self._errors['new_slug'] = self.error_class(
-                [_("This slug is already in use within the context of its parent page \"%s\"" % parent_page)]
+                [_("This slug is already in use within the context of its parent page \"%s\"") % parent_page]
             )
             # The slug is no longer valid, hence remove it from cleaned_data
             del cleaned_data['new_slug']

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -565,7 +565,7 @@ def timesince_simple(d):
     time_period = timesince(d).split(',')[0]
     if time_period == avoid_wrapping(_('0 minutes')):
         return _("Just now")
-    return _("%(time_period)s ago" % {'time_period': time_period})
+    return _("%(time_period)s ago") % {'time_period': time_period}
 
 
 @register.simple_tag
@@ -584,7 +584,7 @@ def timesince_last_update(last_update, time_prefix='', use_shorthand=True):
     else:
         if use_shorthand:
             return timesince_simple(last_update)
-        return _("%(time_period)s ago" % {'time_period': timesince(last_update)})
+        return _("%(time_period)s ago") % {'time_period': timesince(last_update)}
 
 
 @register.filter

--- a/wagtail/admin/views/pages.py
+++ b/wagtail/admin/views/pages.py
@@ -1007,7 +1007,7 @@ def move_confirm(request, page_to_move_id, destination_id):
     if not Page._slug_is_available(page_to_move.slug, destination, page=page_to_move):
         messages.error(
             request,
-            _("The slug '{0}' is already in use at the selected parent page. Make sure the slug is unique and try again".format(page_to_move.slug))
+            _("The slug '{0}' is already in use at the selected parent page. Make sure the slug is unique and try again").format(page_to_move.slug)
         )
         return redirect('wagtailadmin_pages:move_choose_destination', page_to_move.id, destination.id)
 

--- a/wagtail/admin/views/workflows.py
+++ b/wagtail/admin/views/workflows.py
@@ -405,7 +405,7 @@ class EditTask(EditView):
 
     @cached_property
     def page_title(self):
-        return _("Editing {task_type}".format(task_type=self.get_object().content_type.name))
+        return _("Editing %(task_type)s") % {'task_type': self.get_object().content_type.name}
 
     def get_queryset(self):
         if self.queryset is None:

--- a/wagtail/contrib/forms/forms.py
+++ b/wagtail/contrib/forms/forms.py
@@ -161,5 +161,5 @@ class WagtailAdminFormPageForm(WagtailAdminPageForm):
                         if idx != i and clean_name == ff_clean_name:
                             form.add_error(
                                 'label',
-                                django.forms.ValidationError(_('There is another field with the label %s, please change one of them.' % label))
+                                django.forms.ValidationError(_('There is another field with the label %s, please change one of them.') % label)
                             )


### PR DESCRIPTION
Strings inside `gettext` / `_(...)` need to be literals to be picked up by the translation framework, so format parameters should be outside the function - `_("Hello %s") % name` not `_("Hello %s" % name)`.
