### PR TITLE
Fix WAGTAILFRONTENDCACHE_LANGUAGES

### DIFF
--- a/wagtail/contrib/frontend_cache/tests.py
+++ b/wagtail/contrib/frontend_cache/tests.py
@@ -300,15 +300,20 @@ class TestCachePurgingSignals(TestCase):
 
     @override_settings(ROOT_URLCONF='wagtail.tests.urls_multilang',
                        LANGUAGE_CODE='en',
-                       WAGTAILFRONTENDCACHE_LANGUAGES=['en'])
+                       WAGTAILFRONTENDCACHE_LANGUAGES=['en', 'fr', 'pt-br'])
     def test_purge_on_publish_in_multilang_env(self):
-        from django.conf import settings
         PURGED_URLS[:] = []  # reset PURGED_URLS to the empty list
         page = EventIndex.objects.get(url_path='/home/events/')
         page.save_revision().publish()
-        self.assertEqual(len(PURGED_URLS), len(settings.WAGTAILFRONTENDCACHE_LANGUAGES) * 2)
-        for isocode, description in settings.WAGTAILFRONTENDCACHE_LANGUAGES:
-            self.assertIn('http://localhost/%s/events/' % isocode, PURGED_URLS)
+
+        self.assertEqual(PURGED_URLS, [
+            'http://localhost/en/events/',
+            'http://localhost/en/events/past/',
+            'http://localhost/fr/events/',
+            'http://localhost/fr/events/past/',
+            'http://localhost/pt-br/events/',
+            'http://localhost/pt-br/events/past/',
+        ])
 
 
 class TestPurgeBatchClass(TestCase):

--- a/wagtail/contrib/frontend_cache/utils.py
+++ b/wagtail/contrib/frontend_cache/utils.py
@@ -69,7 +69,7 @@ def purge_urls_from_cache(urls, backend_settings=None, backends=None):
         new_urls = []
 
         # Purge the given url for each managed language
-        for isocode, description in languages:
+        for isocode in languages:
             for url in urls:
                 up = urlparse(url)
                 new_url = urlunparse((


### PR DESCRIPTION
The code was incorrectly expecting a 2-tuple so it was purging URLs with the first letter of the language code when the langauge code had two characters. It crashed with more than two letters.
