### PR TITLE
Add release note about populating form builder clean_name

### DIFF
--- a/docs/releases/2.10.rst
+++ b/docs/releases/2.10.rst
@@ -163,6 +163,14 @@ Prepopulating data for site history report
 This release introduces logging of user actions, viewable through the "Site history" report. To pre-populate these logs with data from page revision history, run the management command: ``./manage.py create_log_entries_from_revisions``.
 
 
+``clean_name`` field added to form builder form field models
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A ``clean_name`` field has been added to form field models that extend ``AbstractForm``. This is used as the name attribute of the HTML form field, and the dictionary key that the submitted form data is stored under. Storing this on the model (rather than calculating it on-the-fly as was done previously) ensures that if the algorithm for generating the clean name changes in future, the existing data will not become inaccessible. A future version of Wagtail will drop the ``unidecode`` library currently used for this.
+
+For forms created through the Wagtail admin interface, no action is required, as the new field will be populated on server startup. However, any process that creates form pages through direct insertion on the database (such as loading from fixtures) should now be updated to populate ``clean_name``.
+
+
 New ``next_url`` keyword argument on ``register_page_listing_buttons`` and ``register_page_listing_more_buttons`` hooks
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Add a release note relating to #6093 - if form field objects are created directly on the database rather than through the ORM (for example, loading from fixtures as bakerydemo does), that process needs to be updated to populate the new `clean_name` field - otherwise, the startup check will treat them as legacy fields that need to be populated with unidecode.