### PR TITLE
Stronger check on blocks names

### DIFF
--- a/wagtail/core/blocks/base.py
+++ b/wagtail/core/blocks/base.py
@@ -1,4 +1,5 @@
 import collections
+import re
 from importlib import import_module
 
 from django import forms
@@ -314,6 +315,16 @@ class Block(metaclass=BaseBlock):
             errors.append(checks.Error(
                 "Block name %r is invalid" % self.name,
                 "Block names cannot begin with a digit",
+                obj=kwargs.get('field', self),
+                id='wagtailcore.E001',
+            ))
+
+        if not errors and not re.match(r'^[_a-zA-Z][_a-zA-Z0-9]*$', self.name):
+            errors.append(checks.Error(
+                "Block name %r is invalid" % self.name,
+                "Block names should follow standard Python conventions for "
+                "variable names: alpha-numeric and underscores, and cannot "
+                "begin with a digit",
                 obj=kwargs.get('field', self),
                 id='wagtailcore.E001',
             ))

--- a/wagtail/core/tests/test_blocks.py
+++ b/wagtail/core/tests/test_blocks.py
@@ -3550,6 +3550,18 @@ class TestDateTimeBlock(TestCase):
 
 
 class TestSystemCheck(TestCase):
+    def test_name_cannot_contain_non_alphanumeric(self):
+        block = blocks.StreamBlock([
+            ('heading', blocks.CharBlock()),
+            ('rich+text', blocks.RichTextBlock()),
+        ])
+
+        errors = block.check()
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(errors[0].id, 'wagtailcore.E001')
+        self.assertEqual(errors[0].hint, "Block names should follow standard Python conventions for variable names: alpha-numeric and underscores, and cannot begin with a digit")
+        self.assertEqual(errors[0].obj, block.child_blocks['rich+text'])
+
     def test_name_must_be_nonempty(self):
         block = blocks.StreamBlock([
             ('heading', blocks.CharBlock()),


### PR DESCRIPTION
Ref: https://github.com/wagtail/wagtail-react-streamfield/issues/54

This PR stronger check on block names as stated in the [docs](https://docs.wagtail.io/en/stable/topics/streamfield.html).
> ‘name’ is used to identify the block type within templates and the internal JSON representation (and should follow standard Python conventions for variable names: lower-case and underscores, no spaces)

Since it may break existing code I made use of a warning rather than an error. Let me know how do you think about it.
Maybe only in a second phase it should become a strong error and could replace others name checks.

Thanks for Wagtail! 🎉