### PR TITLE
Quick fix for inconsistent margins between menu icons and labels

### DIFF
--- a/client/scss/components/_main-nav.scss
+++ b/client/scss/components/_main-nav.scss
@@ -76,7 +76,7 @@
         &:before {
             font-size: 1rem;
             vertical-align: -15%;
-            margin-right: 0.5em;
+            margin-right: 0.25em;
         }
 
         // only really used for spinners and settings menu


### PR DESCRIPTION
Fixes #6297

* Do the tests still pass? **N/A** since this only includes a change in the SCSS files
* Does the code comply with the style guide? **Yes**
* For front-end changes: Did you test on all of Wagtail’s supported browsers? **Yes** -- Firefox 79, Chrome 84

By the way, congratulations and thanks in advance for the big 2.10 release, Wagtail core team!