### PR TITLE
Adds PageQuerySet.viewable_by_user()

### DIFF
--- a/docs/reference/pages/queryset_reference.rst
+++ b/docs/reference/pages/queryset_reference.rst
@@ -20,7 +20,13 @@ Examples
 
       events = EventPage.objects.live().descendant_of(events_index)
 
-- Getting a list of menu items
+ - Selecting only pages that the current user is permitted to view
+
+   .. code-block:: python
+
+       events = Page.objects.viewable_by_user(user, request)
+
+ - Getting a list of menu items
 
   .. code-block:: python
 
@@ -190,6 +196,30 @@ Reference
 
     .. automethod:: not_public
 
+    .. automethod:: viewable_by_user
+
+        See: :ref:`private_pages`
+
+        .. note::
+
+            This doesn't filter out unpublished pages. If you want to only have published public pages, use ``.live().viewable_by_user(user, request)``
+
+        Examples:
+
+        .. code-block:: python
+
+            # Find all the pages that are viewable by the user making the request
+            all_pages = Page.objects.live().viewable_by_user(user, request)
+
+            # Find all the pages that are viewable by a user without a request
+            all_pages = Page.objects.live().viewable_by_user(user)
+
+            # Find pages viewable by several users:
+            fake_request = HttpRequest()  # to facilitate restriction caching
+            user_a_viewable = Page.objects.live().viewable_by_user(user_a, fake_request)
+            user_b_viewable = Page.objects.live().viewable_by_user(user_b, fake_request)
+            user_c_viewable = Page.objects.live().viewable_by_user(user_c, fake_request)
+
     .. automethod:: search
 
         See: :ref:`wagtailsearch_searching_pages`
@@ -200,6 +230,25 @@ Reference
 
             # Search future events
             results = EventPage.objects.live().filter(date__gt=timezone.now()).search("Hello")
+
+    .. automethod:: view_restricted
+
+        Example:
+
+        .. code-block:: python
+
+            # Find pages afffected by view restrictions
+            pages = Page.objects.view_restricted()
+
+    .. automethod:: not_view_restricted
+
+        Example:
+
+        .. code-block:: python
+
+            # Find pages unafffected by view restrictions
+            pages = Page.objects.not_view_restricted()
+
 
     .. automethod:: type
 

--- a/wagtail/models/__init__.py
+++ b/wagtail/models/__init__.py
@@ -2784,7 +2784,7 @@ class PageViewRestriction(BaseViewRestriction):
         return Q(path__startswith=self.page.path)
 
     def is_descendant_of(self, other: "PageViewRestriction") -> bool:
-        raise self.page.is_descendant_of(other.page)
+        return self.page.is_descendant_of(other.page)
 
     def save(self, user=None, **kwargs):
         """

--- a/wagtail/models/view_restrictions.py
+++ b/wagtail/models/view_restrictions.py
@@ -5,9 +5,13 @@ but the definitions here should remain generic and not depend on the base wagtai
 module or specific models defined there.
 """
 
+from typing import Iterator
+
 from django.conf import settings
 from django.contrib.auth.models import Group
 from django.db import models
+from django.db.models import Q, QuerySet
+from django.http import HttpRequest
 from django.utils.translation import gettext_lazy as _
 
 
@@ -28,28 +32,178 @@ class BaseViewRestriction(models.Model):
     password = models.CharField(verbose_name=_("password"), max_length=255, blank=True)
     groups = models.ManyToManyField(Group, verbose_name=_("groups"), blank=True)
 
-    def accept_request(self, request):
-        if self.restriction_type == BaseViewRestriction.PASSWORD:
-            passed_restrictions = request.session.get(
-                self.passed_view_restrictions_session_key, []
+    @classmethod
+    def _get_all_cache_key(cls) -> str:
+        return f"__all__.{cls._meta.verbose_name_plural.lower()}"
+
+    @classmethod
+    def get_all_queryset(cls) -> QuerySet:
+        return cls.objects.all().prefetch_related("groups")
+
+    @classmethod
+    def get_all(cls, cache_target=None) -> QuerySet:
+        """
+        Return all item in descending page path order, and with page and
+        group values prefetched.
+        """
+        cache_key = cls._get_all_cache_key()
+
+        # Return a cached value from the supplied object if available
+        value = getattr(cache_target, cache_key, None)
+        if value is not None:
+            return value
+
+        value = cls.get_all_queryset()
+
+        # Add reference to the supplied `cache_target`
+        if cache_target is not None:
+            setattr(cache_target, cache_key, value)
+
+        return value
+
+    @classmethod
+    def get_all_accepting_user(
+        cls,
+        user,
+        request=None,
+        assume_user_authenticated=False,
+        assume_passwords_known=False,
+    ) -> Iterator["BaseViewRestriction"]:
+        """
+        Returns all restrictions of this type that the provided ``user`` passes.
+        """
+        for obj in cls.get_all(request or user):
+            if obj.accept_user(
+                user, request, assume_user_authenticated, assume_passwords_known
+            ):
+                yield obj
+
+    @classmethod
+    def get_permitted_objects_q(
+        cls,
+        user,
+        request=None,
+        assume_user_authenticated=False,
+        assume_passwords_known=False,
+    ) -> Q:
+        """
+        Returns a ``Q`` object that can be used to filter a queryset of objects
+        to only include items the provided ``user`` is permitted to access, based
+        on all saved restrictions of this type.
+        """
+        accepting_restrictions = tuple(
+            cls.get_all_accepting_user(
+                user, request, assume_user_authenticated, assume_passwords_known
             )
-            if self.id not in passed_restrictions:
+        )
+
+        inclusive_q = Q()
+        for obj in accepting_restrictions:
+            inclusive_q |= obj.get_affected_objects_q
+
+        restrictive_q = Q()
+        for obj in cls.get_all(request or user):
+            if obj not in accepting_restrictions:
+                restrictive_q += obj.get_affected_objects_with_conflicts_q(
+                    accepting_restrictions
+                )
+
+        return inclusive_q + ~restrictive_q
+
+    def get_affected_objects_q(self) -> Q:
+        """
+        Returns a ``Q`` object that can be used to filter a queryset of
+        objects to only include those affected by this restriction.
+        Must be overridden for each subclass.
+        """
+        raise NotImplementedError
+
+    def get_affected_objects_with_conflicts_q(self, conflicting_restrictions) -> Q:
+        """
+        Similar to ``get_affected_objects_q()``, but returns a more complex ``Q``
+        that excludes content affected by ``conflicting_restrictions`` (an iterable
+        of restrictions of the same type) if they happen to be applied to a
+        decendant node in the page (or collection) tree.
+        Utilises ``get_affected_objects_q()``, so shouldn't need overriding on
+        subclasses.
+        """
+        q = self.get_affected_objects_q()
+        for obj in conflicting_restrictions:
+            if obj.is_descendant_of(self):
+                q += ~obj.get_affected_objects_q()
+        return q
+
+    def is_descendant_of(self, other: "BaseViewRestriction") -> bool:
+        """
+        Returns a boolean indicating whether this object is a descandant
+        of another instance (based on where in the tree the content is applied).
+        """
+        raise False
+
+    def accept_request(self, request: HttpRequest) -> bool:
+        return self.accept_user(request.user, request)
+
+    def accept_user(
+        self,
+        user,
+        request: HttpRequest = None,
+        assume_user_authenticated: bool = False,
+        assume_password_known: bool = False,
+    ) -> bool:
+        """
+        Return a boolean indicating whether the supplied ``user`` passes the restriction.
+        ``request`` will typically be a ``HttpRequest`` instance representing a request
+        being made by ``user``. However, in contexts where another user is making the
+        request or where there is no request at all, any mutable object capable of
+        supporting ad hoc attribute assignment can be provided to improve efficiency when
+        calling the method more than once.
+
+        By default, restrictions requiring a user to be authenticated will return
+        ``False`` unless the ``user`` is indeed authenticated. The method can be called
+        with ``assume_user_authenticated=True`` to instead make such restrictions always
+        return ``True``.
+
+        By default, restrictions requiring a password return ``False`` unless there is
+        evidence of the user successfully passing the restriction (only works when ``user``
+        and ``request.user`` are the same user). The method can be called with
+        ``assume_password_known=True`` to make such restrictions always return ``True``.
+        """
+        if self.restriction_type == self.NONE:
+            return True
+
+        if self.restriction_type == self.LOGIN:
+            if not user.is_active:
                 return False
+            if assume_user_authenticated:
+                return True
+            if request and getattr(request, "user", None) == user:
+                return user.is_authenticated
+            return False
 
-        elif self.restriction_type == BaseViewRestriction.LOGIN:
-            if not request.user.is_authenticated:
+        if self.restriction_type == self.PASSWORD:
+            if not user.is_active:
                 return False
+            if assume_password_known:
+                return True
+            if request and getattr(request, "user", None) == user:
+                passed_restrictions = request.session.get(
+                    self.passed_view_restrictions_session_key, []
+                )
+                return self.id in passed_restrictions
+            return False
 
-        elif self.restriction_type == BaseViewRestriction.GROUPS:
-            if not request.user.is_superuser:
-                current_user_groups = request.user.groups.all()
+        if self.restriction_type == self.GROUPS:
+            if not user.is_active:
+                return False
+            if user.is_superuser:
+                return True
+            user_groups = user.groups.all()
+            for group in self.groups.all():
+                if group in user_groups:
+                    return True
+        return False
 
-                if not any(group in current_user_groups for group in self.groups.all()):
-                    return False
-
-        return True
-
-    def mark_as_passed(self, request):
+    def mark_as_passed(self, request: HttpRequest) -> None:
         """
         Update the session data in the request to mark the user as having passed this
         view restriction

--- a/wagtail/models/view_restrictions.py
+++ b/wagtail/models/view_restrictions.py
@@ -104,11 +104,11 @@ class BaseViewRestriction(models.Model):
         restrictive_q = Q()
         for obj in cls.get_all(request or user):
             if obj not in accepting_restrictions:
-                restrictive_q += obj.get_affected_objects_with_conflicts_q(
+                restrictive_q &= obj.get_affected_objects_with_conflicts_q(
                     accepting_restrictions
                 )
 
-        return inclusive_q + ~restrictive_q
+        return inclusive_q & ~restrictive_q
 
     def get_affected_objects_q(self) -> Q:
         """
@@ -130,7 +130,7 @@ class BaseViewRestriction(models.Model):
         q = self.get_affected_objects_q()
         for obj in conflicting_restrictions:
             if obj.is_descendant_of(self):
-                q += ~obj.get_affected_objects_q()
+                q &= ~obj.get_affected_objects_q()
         return q
 
     def is_descendant_of(self, other: "BaseViewRestriction") -> bool:

--- a/wagtail/models/view_restrictions.py
+++ b/wagtail/models/view_restrictions.py
@@ -99,7 +99,7 @@ class BaseViewRestriction(models.Model):
 
         inclusive_q = Q()
         for obj in accepting_restrictions:
-            inclusive_q |= obj.get_affected_objects_q
+            inclusive_q |= obj.get_affected_objects_q()
 
         restrictive_q = Q()
         for obj in cls.get_all(request or user):


### PR DESCRIPTION
Implements a more comprehensive pattern for finding pages affected/unaffected by page view restrictions and checking in bulk which ones a user passes or fails. Page view restrictions can now effectively be applied to multiple nodes in a page's ancestry - with only the 'closest restriction' to a page affecting its 'view-ability'. For example, you can now have a subsection of public pages within a password/login protected section, then another restricted section of pages within that.

`PageQuerySet.viewable_by_user()` and `PageQuerysSet.not_viewable_by_user()` are the primary methods for accessing this functionality, with the heavy lifting mostly done on `BaseViewRestriction`. `PageViewRestriction` and `CollectionViewRestriction` override just the bare minimum to make the generic functionality on `BaseViewRestriction` work for them.

Currently, `public()` and `not_public()` methods return pages unaffected by ANY restriction. These have both been updated to piggy-back on `viewable_by_user()` and `not_viewable_by_user()` - giving them the ability to identify public pages nested within one or more private sections. 