### PR TITLE
Avoid retranslating month / weekday names that Django already provides

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -34,6 +34,7 @@ Changelog
  * Fix: `Page.copy()` now raises an error if the page being copied is unsaved (Anton Zhyltsou)
  * Fix: `Page.copy()` now triggers a `page_published` if the copied page is live (Anton Zhyltsou)
  * Fix: The Elasticsearch `URLS` setting can now take a string on its own instead of a list (Sævar Öfjörð Magnússon)
+ * Fix: Avoid retranslating month / weekday names that Django already provides (Matt Westcott)
 
 
 2.10.2 (25.09.2020)

--- a/docs/releases/2.11.rst
+++ b/docs/releases/2.11.rst
@@ -48,6 +48,7 @@ Bug fixes
  * ``Page.copy()`` now raises an error if the page being copied is unsaved (Anton Zhyltsou)
  * ``Page.copy()`` now triggers a ``page_published`` if the copied page is live (Anton Zhyltsou)
  * The Elasticsearch ``URLS`` setting can now take a string on its own instead of a list (Sævar Öfjörð Magnússon)
+ * Avoid retranslating month / weekday names that Django already provides (Matt Westcott)
 
 Upgrade considerations
 ======================

--- a/wagtail/admin/localization.py
+++ b/wagtail/admin/localization.py
@@ -1,6 +1,7 @@
 import pytz
 
 from django.conf import settings
+from django.utils.dates import MONTHS, WEEKDAYS, WEEKDAYS_ABBR
 from django.utils.translation import gettext as _
 from django.utils.translation import gettext_lazy
 
@@ -76,38 +77,12 @@ def get_js_translation_strings():
         'VIEW_CHILD_PAGES_OF_PAGE': _('View child pages of \'{title}\''),
         'PAGE_EXPLORER': _('Page explorer'),
 
-        'MONTHS': [
-            _('January'),
-            _('February'),
-            _('March'),
-            _('April'),
-            _('May'),
-            _('June'),
-            _('July'),
-            _('August'),
-            _('September'),
-            _('October'),
-            _('November'),
-            _('December')
-        ],
-        'WEEKDAYS': [
-            _('Sunday'),
-            _('Monday'),
-            _('Tuesday'),
-            _('Wednesday'),
-            _('Thursday'),
-            _('Friday'),
-            _('Saturday')
-        ],
-        'WEEKDAYS_SHORT': [
-            _('Sun'),
-            _('Mon'),
-            _('Tue'),
-            _('Wed'),
-            _('Thu'),
-            _('Fri'),
-            _('Sat')
-        ]
+        'MONTHS': [str(m) for m in MONTHS.values()],
+
+        # Django's WEEKDAYS list begins on Monday, but ours should start on Sunday, so start
+        # counting from -1 and use modulo 7 to get an array index
+        'WEEKDAYS': [str(WEEKDAYS[d % 7]) for d in range(-1, 6)],
+        'WEEKDAYS_SHORT': [str(WEEKDAYS_ABBR[d % 7]) for d in range(-1, 6)],
     }
 
 


### PR DESCRIPTION
Fixes #6292. Having literal gettext calls here means that makemessages will add these to wagtailadmin's dictionary of strings for translation, creating redundant work for translators (and overriding Django's translations if they differ).

Note: this will not fix the specific behaviour described in #6292 until we've rebuilt, pushed and re-fetched translations from Transifex - up to that point, wagtailadmin's .po / .mo files will still contain our own translations, and the call to gettext will prioritise our translations over Django's, regardless of the fact that we're running it on a string that comes from the Django codebase rather than ours.