### PR TITLE
Fix all `E303: Too many blank lines` Flake8 errors

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,12 +14,11 @@ python-tag = py3
 # D209: Multi-line docstring closing quotes should be on a separate line
 # D400: First line should end with a period
 # D401: First line should be in imperative mood
-# E303: Too many blank lines
 # E501: Line too long
 # W503: line break before binary operator (superseded by W504 line break after binary operator)
 # N805: First argument of a method should be named 'self'
 # N806: Variable in function should be lowercase
-ignore = D100,D101,D102,D103,D105,D200,D202,D204,D205,D209,D400,D401,E303,E501,W503,N805,N806
+ignore = D100,D101,D102,D103,D105,D200,D202,D204,D205,D209,D400,D401,E501,W503,N805,N806
 exclude = wagtail/project_template/*
 max-line-length = 120
 

--- a/wagtail/admin/mail.py
+++ b/wagtail/admin/mail.py
@@ -208,7 +208,6 @@ class EmailNotificationMixin:
             self.notification + '_notifications'
         )}
 
-
     def get_template_set(self, instance, **kwargs):
         """Return a dictionary of template paths for the templates for the email subject and the text and html
         alternatives"""

--- a/wagtail/admin/tests/api/test_pages.py
+++ b/wagtail/admin/tests/api/test_pages.py
@@ -101,7 +101,6 @@ class TestAdminPageListing(AdminAPITestCase, TestPageListing):
         content = json.loads(response.content.decode('UTF-8'))
         self.assertEqual(content['meta']['total_count'], new_total_count)
 
-
     # FIELDS
 
     # Not applicable to the admin API
@@ -254,7 +253,6 @@ class TestAdminPageListing(AdminAPITestCase, TestPageListing):
             self.assertEqual(set(page.keys()), {'id', 'meta', 'tags', 'title', 'admin_display_title'})
             self.assertIsInstance(page['tags'], list)
 
-
     # CHILD OF FILTER
 
     # Not applicable to the admin API
@@ -276,7 +274,6 @@ class TestAdminPageListing(AdminAPITestCase, TestPageListing):
         json.loads(response.content.decode('UTF-8'))
 
         self.assertEqual(response.status_code, 200)
-
 
     # DESCENDANT OF FILTER
 
@@ -362,7 +359,6 @@ class TestAdminPageListing(AdminAPITestCase, TestPageListing):
 
         page_id_list = self.get_page_id_list(content)
         self.assertEqual(page_id_list, [8, 9, 16, 18, 19, 10, 15, 17, 22, 23, 13, 14, 12])
-
 
     def test_has_children_filter_invalid_integer(self):
         response = self.get_response(has_children=3)

--- a/wagtail/admin/tests/pages/test_create_page.py
+++ b/wagtail/admin/tests/pages/test_create_page.py
@@ -116,7 +116,6 @@ class TestPageCreation(TestCase, WagtailTestUtils):
         # test construct_page_action_menu hook
         self.assertContains(response, '<button type="submit" name="action-relax" value="Relax." class="button">Relax.</button>')
 
-
     def test_create_multipart(self):
         """
         Test checks if 'enctype="multipart/form-data"' is added and only to forms that require multipart encoding.
@@ -453,7 +452,6 @@ class TestPageCreation(TestCase, WagtailTestUtils):
 
         # The page should now be in moderation
         self.assertEqual(page.current_workflow_state.status, page.current_workflow_state.STATUS_IN_PROGRESS)
-
 
     def test_create_simplepage_post_existing_slug(self):
         # This tests the existing slug checking on page save

--- a/wagtail/admin/tests/pages/test_edit_page.py
+++ b/wagtail/admin/tests/pages/test_edit_page.py
@@ -629,7 +629,6 @@ class TestPageEdit(TestCase, WagtailTestUtils):
         # The latest revision for the page should now be in moderation
         self.assertEqual(child_page_new.current_workflow_state.status, child_page_new.current_workflow_state.STATUS_IN_PROGRESS)
 
-
     def test_page_edit_post_existing_slug(self):
         # This tests the existing slug checking on page edit
 

--- a/wagtail/admin/tests/pages/test_moderation.py
+++ b/wagtail/admin/tests/pages/test_moderation.py
@@ -279,7 +279,6 @@ class TestNotificationPreferences(TestCase, WagtailTestUtils):
         # No email to send
         self.assertEqual(len(mail.outbox), 0)
 
-
     @override_settings(WAGTAILADMIN_NOTIFICATION_INCLUDE_SUPERUSERS=False)
     def test_disable_superuser_notification(self):
         # Add one of the superusers to the moderator group

--- a/wagtail/admin/tests/pages/test_move_page.py
+++ b/wagtail/admin/tests/pages/test_move_page.py
@@ -86,7 +86,6 @@ class TestPageMove(TestCase, WagtailTestUtils):
 
         self.assertEqual(response.status_code, 200)
 
-
     def test_page_move_confirm(self):
         response = self.client.get(
             reverse('wagtailadmin_pages:move_confirm', args=(self.test_page_a.id, self.section_b.id))

--- a/wagtail/admin/tests/test_account_management.py
+++ b/wagtail/admin/tests/test_account_management.py
@@ -213,7 +213,6 @@ class TestAccountSection(TestCase, WagtailTestUtils):
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, 'wagtailadmin/account/change_email.html')
 
-
     def test_change_email_post(self):
         post_data = {
             'email': 'test@email.com'
@@ -226,7 +225,6 @@ class TestAccountSection(TestCase, WagtailTestUtils):
 
         # Check that the email was changed
         self.assertEqual(get_user_model().objects.get(pk=self.user.pk).email, post_data['email'])
-
 
     def test_change_email_not_valid(self):
         post_data = {
@@ -244,7 +242,6 @@ class TestAccountSection(TestCase, WagtailTestUtils):
         # Check that the password was not changed
         self.assertNotEqual(get_user_model().objects.get(pk=self.user.pk).email, post_data['email'])
 
-
     @override_settings(WAGTAIL_EMAIL_MANAGEMENT_ENABLED=False)
     def test_account_view_with_email_management_disabled(self):
         # Get account page
@@ -254,7 +251,6 @@ class TestAccountSection(TestCase, WagtailTestUtils):
         self.assertTemplateUsed(response, 'wagtailadmin/account/account.html')
         # Page should NOT contain a 'Change email' option
         self.assertNotContains(response, "Change email")
-
 
     @override_settings(WAGTAIL_EMAIL_MANAGEMENT_ENABLED=False)
     def test_change_email_view_disabled(self):
@@ -267,7 +263,6 @@ class TestAccountSection(TestCase, WagtailTestUtils):
 
         # Check that the user received a 404
         self.assertEqual(response.status_code, 404)
-
 
     @override_settings(WAGTAIL_PASSWORD_MANAGEMENT_ENABLED=False)
     def test_account_view_with_password_management_disabled(self):

--- a/wagtail/admin/tests/test_compare.py
+++ b/wagtail/admin/tests/test_compare.py
@@ -1032,7 +1032,6 @@ class TestChildRelationComparisonUsingPK(TestCase):
         self.assertEqual(added, [1])  # add second head count
         self.assertEqual(deleted, [])
 
-
     def test_hasnt_changed_with_different_id(self):
         # Both of the child objects have the same field content but have a
         # different PK (ID) so they should be detected as separate objects

--- a/wagtail/admin/tests/test_edit_handlers.py
+++ b/wagtail/admin/tests/test_edit_handlers.py
@@ -432,7 +432,6 @@ class TestFieldPanel(TestCase):
                                                   .bind_to(model=EventPage, request=self.request, form=self.EventPageForm()))
         self.assertEqual(end_date_panel_with_overridden_heading.heading, "New heading")
 
-
     def test_render_as_object(self):
         form = self.EventPageForm(
             {'title': 'Pontypridd sheepdog trials', 'date_from': '2014-07-20', 'date_to': '2014-07-22'},
@@ -952,7 +951,6 @@ class TestInlinePanel(TestCase, WagtailTestUtils):
         panel = speaker_inline_panel.bind_to(instance=event_page, form=form)
 
         self.assertIn('maxForms: 1000', panel.render_js_init())
-
 
     def test_invalid_inlinepanel_declaration(self):
         with self.ignore_deprecation_warnings():

--- a/wagtail/admin/tests/test_rich_text.py
+++ b/wagtail/admin/tests/test_rich_text.py
@@ -477,7 +477,6 @@ class TestDraftailWithAdditionalFeatures(BaseRichTextEditHandlerTestCase, Wagtai
 
         self.login()
 
-
     @override_settings(WAGTAILADMIN_RICH_TEXT_EDITORS={
         'default': {
             'WIDGET': 'wagtail.admin.rich_text.DraftailRichTextArea',

--- a/wagtail/admin/tests/test_widgets.py
+++ b/wagtail/admin/tests/test_widgets.py
@@ -198,7 +198,6 @@ class TestAdminTagWidget(TestCase):
                 return json.loads('[%s]' % params_raw)
         return []
 
-
     def test_render_js_init_basic(self):
         """Checks that the 'initTagField' is correctly added to the inline script for tag widgets"""
         widget = widgets.AdminTagWidget()
@@ -210,7 +209,6 @@ class TestAdminTagWidget(TestCase):
             params,
             ['alpha', '/admin/tag-autocomplete/', {'allowSpaces': True, 'tagLimit': None, 'autocompleteOnly': False}]
         )
-
 
     @override_settings(TAG_SPACES_ALLOWED=False)
     def test_render_js_init_no_spaces_allowed(self):
@@ -224,7 +222,6 @@ class TestAdminTagWidget(TestCase):
             params,
             ['alpha', '/admin/tag-autocomplete/', {'allowSpaces': False, 'tagLimit': None, 'autocompleteOnly': False}]
         )
-
 
     @override_settings(TAG_LIMIT=5)
     def test_render_js_init_with_tag_limit(self):

--- a/wagtail/admin/tests/test_workflows.py
+++ b/wagtail/admin/tests/test_workflows.py
@@ -160,7 +160,6 @@ class TestWorkflowsCreateView(TestCase, WagtailTestUtils):
             'pages-1-DELETE': [''],
         })
 
-
         # Should redirect back to index
         self.assertRedirects(response, reverse('wagtailadmin_workflows:index'))
 
@@ -290,7 +289,6 @@ class TestWorkflowsEditView(TestCase, WagtailTestUtils):
             'pages-1-page': [''],
             'pages-1-DELETE': [''],
         })
-
 
         # Should redirect back to index
         self.assertRedirects(response, reverse('wagtailadmin_workflows:index'))
@@ -827,7 +825,6 @@ class TestSubmitToWorkflow(TestCase, WagtailTestUtils):
         # check that the workflow state's status is now cancelled
         self.assertEqual(workflow_state.status, WorkflowState.STATUS_CANCELLED)
         self.assertEqual(workflow_state.current_task_state.status, TaskState.STATUS_CANCELLED)
-
 
     def test_email_headers(self):
         # Submit

--- a/wagtail/contrib/forms/models.py
+++ b/wagtail/contrib/forms/models.py
@@ -118,7 +118,6 @@ class AbstractFormField(Orderable):
         FieldPanel('default_value', classname="formbuilder-default"),
     ]
 
-
     def save(self, *args, **kwargs):
         """
         When new fields are created, generate a template safe ascii name to use as the
@@ -132,7 +131,6 @@ class AbstractFormField(Orderable):
             self.clean_name = clean_name
 
         super().save(*args, **kwargs)
-
 
     @classmethod
     def _migrate_legacy_clean_name(cls):
@@ -165,7 +163,6 @@ class AbstractFormField(Orderable):
             'Added `clean_name` on %s form field(s)' % objects.count(),
             obj=cls
         )
-
 
     @classmethod
     def check(cls, **kwargs):

--- a/wagtail/contrib/forms/tests/test_models.py
+++ b/wagtail/contrib/forms/tests/test_models.py
@@ -559,7 +559,6 @@ class TestCleanedDataEmails(TestCase):
         self.assertEqual(len(mail.outbox), 2)
         self.assertIn("Date: 12/31/1917", mail.outbox[1].body)
 
-
     @override_settings(SHORT_DATETIME_FORMAT='m/d/Y P')
     def test_datetime_normalization(self):
         self.client.post('/contact-us/', {
@@ -582,7 +581,6 @@ class TestCleanedDataEmails(TestCase):
 
         self.assertEqual(len(mail.outbox), 3)
         self.assertIn("Datetime: 12/21/1910 9:19 p.m.", mail.outbox[2].body)
-
 
 
 class TestIssue798(TestCase):
@@ -630,9 +628,7 @@ class TestLegacyFormFieldCleanNameChecks(TestCase):
         self.assertTrue(self.client.login(username='siteeditor', password='password'))
         self.form_page = Page.objects.get(url_path='/home/contact-us-one-more-time/').specific
 
-
     def test_form_field_clean_name_update_on_checks(self):
-
         fields_before_checks = [
             (field.label, field.clean_name,)
             for field in FormFieldWithCustomSubmission.objects.all()
@@ -652,7 +648,6 @@ class TestLegacyFormFieldCleanNameChecks(TestCase):
             messages,
             [Info('Added `clean_name` on 3 form field(s)', obj=FormFieldWithCustomSubmission)]
         )
-
 
         fields_after_checks = [
             (field.label, field.clean_name,)

--- a/wagtail/contrib/forms/tests/test_views.py
+++ b/wagtail/contrib/forms/tests/test_views.py
@@ -620,7 +620,6 @@ class TestFormsSubmissionsExport(TestCase, WagtailTestUtils):
         self.assertIn('vim', data_lines[1])
 
 
-
 class TestCustomFormsSubmissionsExport(TestCase, WagtailTestUtils):
     def create_test_user_without_admin(self, username):
         return get_user_model().objects.create_user(username=username, password='123')
@@ -768,7 +767,6 @@ class TestCustomFormsSubmissionsExport(TestCase, WagtailTestUtils):
         data_lines = response.getvalue().decode('utf-8').split("\n")
         self.assertIn('Выберите самую любимую IDE для разработке на Python', data_lines[0])
         self.assertIn('vim', data_lines[1])
-
 
 
 class TestCustomFormsSubmissionsList(TestCase, WagtailTestUtils):

--- a/wagtail/contrib/forms/tests/utils.py
+++ b/wagtail/contrib/forms/tests/utils.py
@@ -87,7 +87,6 @@ def make_form_page_with_redirect(**kwargs):
     kwargs.setdefault('from_address', "from@email.com")
     kwargs.setdefault('subject', "The subject")
 
-
     home_page = Page.objects.get(url_path='/home/')
     kwargs.setdefault('thank_you_redirect_page', home_page)
     form_page = home_page.add_child(instance=FormPageWithRedirect(**kwargs))

--- a/wagtail/contrib/modeladmin/helpers/search.py
+++ b/wagtail/contrib/modeladmin/helpers/search.py
@@ -44,7 +44,6 @@ class DjangoORMSearchHandler(BaseSearchHandler):
                 return queryset.distinct()
         return queryset
 
-
     @property
     def show_search_form(self):
         return bool(self.search_fields)

--- a/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
+++ b/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
@@ -130,7 +130,6 @@ class TestBookIndexView(TestCase, WagtailTestUtils):
 
         self.assertContains(response, '<input id="id_q"')
 
-
     def test_search_form_absent(self):
         # DjangoORMSearchHandler + no search_fields, search form should be absent
         with mock.patch.object(BookModelAdmin, 'search_handler_class', DjangoORMSearchHandler):
@@ -487,7 +486,6 @@ class TestDeleteViewWithProtectedRelation(TestCase, WagtailTestUtils):
         # Author deleted
         self.assertFalse(Author.objects.filter(id=4).exists())
 
-
     def test_post_with_1to1_dependent_object(self):
         response = self.post(5)
 
@@ -622,9 +620,7 @@ class TestPanelConfigurationChecks(TestCase, WagtailTestUtils):
 
         self.get_checks_result = get_checks_result
 
-
     def test_model_with_single_tabbed_panel_only(self):
-
         Publisher.content_panels = [FieldPanel('name'), FieldPanel('headquartered_in')]
 
         warning = checks.Warning(
@@ -644,12 +640,9 @@ There are no default tabs on non-Page models so there will be no\
         # clean up for future checks
         delattr(Publisher, 'content_panels')
 
-
     def test_model_with_two_tabbed_panels_only(self):
-
         Publisher.settings_panels = [FieldPanel('name')]
         Publisher.promote_panels = [FieldPanel('headquartered_in')]
-
 
         warning_1 = checks.Warning(
             "Publisher.promote_panels will have no effect on modeladmin editing",
@@ -680,9 +673,7 @@ There are no default tabs on non-Page models so there will be no\
         delattr(Publisher, 'settings_panels')
         delattr(Publisher, 'promote_panels')
 
-
     def test_model_with_single_tabbed_panel_and_edit_handler(self):
-
         Publisher.content_panels = [FieldPanel('name'), FieldPanel('headquartered_in')]
         Publisher.edit_handler = TabbedInterface(Publisher.content_panels)
 

--- a/wagtail/contrib/modeladmin/views.py
+++ b/wagtail/contrib/modeladmin/views.py
@@ -556,7 +556,6 @@ class IndexView(SpreadsheetExportMixin, WMABaseView):
         # Apply search results
         return self.get_search_results(request, qs, self.query)
 
-
     def apply_select_related(self, qs):
         if self.select_related is True:
             return qs.select_related()

--- a/wagtail/contrib/postgres_search/tests/test_stemming.py
+++ b/wagtail/contrib/postgres_search/tests/test_stemming.py
@@ -34,7 +34,6 @@ class TestPostgresStemming(TestCase):
         results = self.backend.search("Голубое", models.Book)
         self.assertEqual(list(results), [ru_book])
 
-
         results = self.backend.search("Голубая", models.Book)
         self.assertEqual(list(results), [ru_book])
 

--- a/wagtail/contrib/routable_page/tests.py
+++ b/wagtail/contrib/routable_page/tests.py
@@ -280,7 +280,6 @@ class TestRoutablePageTemplateTagForSecondSiteAtDifferentRoot(TestCase):
         self.request.META['HTTP_HOST'] = second_site.hostname
         self.request.META['SERVER_PORT'] = second_site.port
 
-
     def test_templatetag_reverse_index_route(self):
         url = routablepageurl(self.context, self.routable_page,
                               'index_route')

--- a/wagtail/contrib/sitemaps/tests.py
+++ b/wagtail/contrib/sitemaps/tests.py
@@ -195,7 +195,6 @@ class TestSitemapView(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response['Content-Type'], 'application/xml')
 
-
     def test_sitemap_view_with_current_site_middleware(self):
         with self.modify_settings(MIDDLEWARE={
             'append': 'django.contrib.sites.middleware.CurrentSiteMiddleware',

--- a/wagtail/contrib/table_block/tests.py
+++ b/wagtail/contrib/table_block/tests.py
@@ -246,7 +246,6 @@ class TestTableBlock(TestCase):
         self.assertIn("Test 1", result)
         self.assertIn("<div>A fascinating table.</div>", result)
 
-
     def test_table_block_caption_render(self):
         """
         Test a generic render with caption.
@@ -376,7 +375,6 @@ class TestTableBlockForm(WagtailTestUtils, SimpleTestCase):
         # check value that is not part of the defaults
         block_3_opts = TableBlock(table_options={'allowEmpty': False}).table_options
         self.assertEqual(block_3_opts['allowEmpty'], False)
-
 
     def test_tableblock_render_form(self):
         """

--- a/wagtail/core/migrations/0048_add_default_workflows.py
+++ b/wagtail/core/migrations/0048_add_default_workflows.py
@@ -17,7 +17,6 @@ def ancestor_of_q(page):
 def create_default_workflows(apps, schema_editor):
     # This will recreate the existing publish-permission based moderation setup in the new workflow system, by creating new workflows
 
-
     # Get models
     ContentType = apps.get_model('contenttypes.ContentType')
     Workflow = apps.get_model('wagtailcore.Workflow')

--- a/wagtail/core/tests/test_blocks.py
+++ b/wagtail/core/tests/test_blocks.py
@@ -1823,7 +1823,6 @@ class TestStructBlockWithCustomStructValue(SimpleTestCase):
         with self.assertRaises(ValidationError):
             block.clean(value)
 
-
     def test_initialisation_from_subclass(self):
 
         class LinkStructValue(blocks.StructValue):
@@ -1847,7 +1846,6 @@ class TestStructBlockWithCustomStructValue(SimpleTestCase):
 
         default_value = block.get_default()
         self.assertIsInstance(default_value, LinkStructValue)
-
 
     def test_initialisation_with_multiple_subclassses(self):
         class LinkStructValue(blocks.StructValue):
@@ -1907,7 +1905,6 @@ class TestStructBlockWithCustomStructValue(SimpleTestCase):
             'source': 'google', 'classname': 'full-size',
         })
         self.assertIsInstance(block_value, LinkStructValue)
-
 
     def test_value_property(self):
 
@@ -3257,7 +3254,6 @@ class TestStreamBlock(WagtailTestUtils, SimpleTestCase):
 
         # including leading space to ensure class name gets added correctly
         self.assertEqual(html.count(' rocket-section'), 1)
-
 
     def test_render_with_classname_via_class_meta(self):
         """form_classname from meta to be used as an additional class when rendering stream block"""

--- a/wagtail/core/tests/test_management_commands.py
+++ b/wagtail/core/tests/test_management_commands.py
@@ -183,7 +183,6 @@ class TestPublishScheduledPagesCommand(TestCase):
 
         page_published.connect(page_published_handler)
 
-
         page = SimplePage(
             title="Hello world!",
             slug="hello-world",
@@ -367,7 +366,6 @@ class TestPurgeRevisionsCommand(TestCase):
         # revision 1 should be deleted, revision 2 should not be
         self.assertNotIn(revision_1, PageRevision.objects.filter(page=self.page))
         self.assertIn(revision_2, PageRevision.objects.filter(page=self.page))
-
 
     def test_revisions_in_moderation_not_purged(self):
 

--- a/wagtail/core/tests/test_page_model.py
+++ b/wagtail/core/tests/test_page_model.py
@@ -1268,7 +1268,6 @@ class TestCopyPage(TestCase):
             EventPage.exclude_fields_in_copy = []
 
 
-
 class TestSubpageTypeBusinessRules(TestCase, WagtailTestUtils):
     def test_allowed_subpage_models(self):
         # SimplePage does not define any restrictions on subpage types

--- a/wagtail/core/tests/test_rich_text.py
+++ b/wagtail/core/tests/test_rich_text.py
@@ -127,7 +127,6 @@ class TestLinkRewriterTagReplacing(TestCase):
         self.assertNotEqual(link_with_custom_linktype, '<a href="https://wagtail.io">')
         self.assertEqual(link_with_custom_linktype, '<a>')
 
-
     def test_supported_type_should_follow_given_rules(self):
         # we always have `page` rules by default
         rules = {

--- a/wagtail/documents/views/documents.py
+++ b/wagtail/documents/views/documents.py
@@ -162,7 +162,6 @@ def edit(request, document_id):
             # Reindex the document to make sure all tags are indexed
             search_index.insert_or_update_object(doc)
 
-
             messages.success(request, _("Document '{0}' updated").format(doc.title), buttons=[
                 messages.button(reverse('wagtaildocs:edit', args=(doc.id,)), _('Edit'))
             ])

--- a/wagtail/images/models.py
+++ b/wagtail/images/models.py
@@ -572,7 +572,6 @@ class AbstractRendition(models.Model):
         except InvalidCacheBackendError:
             pass
 
-
     class Meta:
         abstract = True
 

--- a/wagtail/images/tests/test_admin_views.py
+++ b/wagtail/images/tests/test_admin_views.py
@@ -87,7 +87,6 @@ class TestImageIndexView(TestCase, WagtailTestUtils):
             [collection.name for collection in response.context['collections']],
             ['Root', 'Evil plans', 'Good plans'])
 
-
     def test_tags(self):
         image_two_tags = Image.objects.create(
             title="Test image with two tags",
@@ -106,7 +105,6 @@ class TestImageIndexView(TestCase, WagtailTestUtils):
             [tag.name for tag in tags] == ["one", "two"]
             or [tag.name for tag in tags] == ["two", "one"]
         )
-
 
     def test_tag_filtering(self):
         Image.objects.create(
@@ -138,7 +136,6 @@ class TestImageIndexView(TestCase, WagtailTestUtils):
         response = self.get({'tag': 'two'})
         self.assertEqual(response.context['images'].paginator.count, 1)
 
-
     def test_tag_filtering_preserves_other_params(self):
         for i in range(1, 100):
             image = Image.objects.create(
@@ -148,7 +145,6 @@ class TestImageIndexView(TestCase, WagtailTestUtils):
             if (i % 2 != 0):
                 image.tags.add('even')
                 image.save()
-
 
         response = self.get({'tag': 'even', 'p': 2})
         self.assertEqual(response.status_code, 200)
@@ -551,7 +547,6 @@ class TestImageEditView(TestCase, WagtailTestUtils):
     @override_settings(DEFAULT_FILE_STORAGE='wagtail.tests.dummy_external_storage.DummyExternalStorage')
     def test_get_missing_file_displays_warning_with_custom_storage(self):
         self.check_get_missing_file_displays_warning()
-
 
     def get_content(self, f=None):
         if f is None:

--- a/wagtail/images/tests/test_image_operations.py
+++ b/wagtail/images/tests/test_image_operations.py
@@ -117,7 +117,6 @@ class ImageOperationTestCase(TestCase):
         test_norun.__name__ = str('test_norun_%s' % filter_spec)
         return test_norun
 
-
     @classmethod
     def setup_test_methods(cls):
         if cls.operation_class is None:

--- a/wagtail/images/tests/tests.py
+++ b/wagtail/images/tests/tests.py
@@ -172,7 +172,6 @@ class TestImageTag(TestCase):
             '/testimages/custom_view/.*/width-400/{}'.format(self.image.file.name.split('/')[-1]),
         )
 
-
     def test_image_url_no_imageserve_view_added(self):
         # if image_url tag is used, but the image serve view was not defined.
         with self.assertRaises(ImproperlyConfigured):

--- a/wagtail/tests/testapp/migrations/0034_advertwithuuidcustomprimarykey.py
+++ b/wagtail/tests/testapp/migrations/0034_advertwithuuidcustomprimarykey.py
@@ -5,7 +5,6 @@ from django.db import migrations, models
 import uuid
 
 
-
 class Migration(migrations.Migration):
     dependencies = [
         ('tests', '0033_eventpagespeaker_related_query_name'),

--- a/wagtail/users/views/groups.py
+++ b/wagtail/users/views/groups.py
@@ -157,7 +157,6 @@ class GroupViewSet(ModelViewSet):
     edit_view_class = EditView
     delete_view_class = DeleteView
 
-
     @property
     def users_view(self):
         return index


### PR DESCRIPTION
I think this is quite a useful rule to have. It makes flake8 check that the spacing between module level things and class methods are consistent.