### PR TITLE
Stop ignoring Flake8 `First argument of a method should be named 'self'`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,17 +7,10 @@ python-tag = py3
 # D102: Missing docstring in public method
 # D103: Missing docstring in public function
 # D105: Missing docstring in magic method
-# D200: One-line docstring should fit on one line with quotes
-# D202: No blank lines allowed after function docstring
-# D204: 1 blank line required after docstring
-# D205: 1 blank line required between summary line and description
-# D209: Multi-line docstring closing quotes should be on a separate line
-# D400: First line should end with a period
-# D401: First line should be in imperative mood
 # E501: Line too long
 # W503: line break before binary operator (superseded by W504 line break after binary operator)
 # N806: Variable in function should be lowercase
-ignore = D100,D101,D102,D103,D105,D200,D202,D204,D205,D209,D400,D401,E501,W503,N806
+ignore = D100,D101,D102,D103,D105,E501,W503,N806
 exclude = wagtail/project_template/*
 max-line-length = 120
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,9 +16,8 @@ python-tag = py3
 # D401: First line should be in imperative mood
 # E501: Line too long
 # W503: line break before binary operator (superseded by W504 line break after binary operator)
-# N805: First argument of a method should be named 'self'
 # N806: Variable in function should be lowercase
-ignore = D100,D101,D102,D103,D105,D200,D202,D204,D205,D209,D400,D401,E501,W503,N805,N806
+ignore = D100,D101,D102,D103,D105,D200,D202,D204,D205,D209,D400,D401,E501,W503,N806
 exclude = wagtail/project_template/*
 max-line-length = 120
 


### PR DESCRIPTION
Already no breakages of this rule in the whole of Wagtail!