### PR TITLE
Allow nested sections in tabs

### DIFF
--- a/client/scss/components/_tabs.scss
+++ b/client/scss/components/_tabs.scss
@@ -75,7 +75,7 @@
 }
 
 .tab-content {
-    section {
+    > section {
         display: none;
         padding-top: 1em;
 


### PR DESCRIPTION
This CSS rule was hiding all nested sections, not just the one the tabs are using.
