### PR TITLE
Fix page history view on custom user models without username field

### DIFF
--- a/wagtail/admin/filters.py
+++ b/wagtail/admin/filters.py
@@ -112,9 +112,10 @@ class LockedPagesReportFilterSet(WagtailFilterSet):
 
 
 def get_requested_by_queryset(request):
-    return get_user_model().objects.filter(
+    User = get_user_model()
+    return User.objects.filter(
         pk__in=set(WorkflowState.objects.values_list('requested_by__pk', flat=True))
-    ).order_by('username')
+    ).order_by(User.USERNAME_FIELD)
 
 
 class WorkflowReportFilterSet(WagtailFilterSet):
@@ -176,9 +177,10 @@ class WorkflowTasksReportFilterSet(WagtailFilterSet):
 
 
 def get_audit_log_users_queryset(request):
-    return get_user_model().objects.filter(
+    User = get_user_model()
+    return User.objects.filter(
         pk__in=set(PageLogEntry.objects.values_list('user__pk', flat=True))
-    ).order_by('username')
+    ).order_by(User.USERNAME_FIELD)
 
 
 class SiteHistoryReportFilterSet(WagtailFilterSet):


### PR DESCRIPTION
Username models without username field caused an exception on page history views.

This commit fixes #6317.