### PR TITLE
Fix report icon

### DIFF
--- a/client/scss/components/_main-nav.scss
+++ b/client/scss/components/_main-nav.scss
@@ -128,7 +128,7 @@
 .icon--menuitem {
     width: 1.25em;
     height: 1.25em;
-    margin-right: 0.25em;
+    margin-right: 0.5em;
     vertical-align: text-top;
 }
 

--- a/wagtail/admin/wagtail_hooks.py
+++ b/wagtail/admin/wagtail_hooks.py
@@ -702,7 +702,7 @@ def register_site_history_report_menu_item():
 @hooks.register('register_admin_menu_item')
 def register_reports_menu():
     return ReportsMenuItem(
-        _('Reports'), reports_menu, classnames='icon icon-site', order=9000)
+        _('Reports'), reports_menu, icon_name='site', order=9000)
 
 
 @hooks.register('register_icons')


### PR DESCRIPTION
Fixes #6327

This pr:
- Switches Reports item icon to SVG
- Restores the margin for all items.

To see the icon font next to the svg font I created menu items in Bakerydemo like this:

```
hooks.register("register_admin_menu_item", lambda: MenuItem("Hages font", "#", classnames="icon icon-folder-open-inverse icon--menuitem", order=1))
hooks.register("register_admin_menu_item", lambda: MenuItem("Hages svg", "#", icon_name="folder-open-inverse", order=1))
# hooks.register("register_admin_menu_item", lambda: MenuItem("Hread Categories font", "#", classnames="icon icon-fa-suitcase", order=1))
# hooks.register("register_admin_menu_item", lambda: MenuItem("Hread Categories svg", "#", icon_name="THIRD_PARTY", order=1))
# hooks.register("register_admin_menu_item", lambda: MenuItem("Hakery Misc font", "#", classnames="icon icon-fa-cutlery", order=1))
# hooks.register("register_admin_menu_item", lambda: MenuItem("Hakery Misc svg", "#", icon_name="THIRD_PARTY", order=1))
hooks.register("register_admin_menu_item", lambda: MenuItem("Hmages font", "#", classnames="icon icon-image icon--menuitem", order=1))
hooks.register("register_admin_menu_item", lambda: MenuItem("Hmages svg", "#", icon_name="image", order=1))
hooks.register("register_admin_menu_item", lambda: MenuItem("Hocuments font", "#", classnames="icon icon-doc-full-inverse icon--menuitem", order=1))
hooks.register("register_admin_menu_item", lambda: MenuItem("Hocuments svg", "#", icon_name="doc-full-inverse", order=1))
hooks.register("register_admin_menu_item", lambda: MenuItem("Hnippets font", "#", classnames="icon icon-snippet icon--menuitem", order=1))
hooks.register("register_admin_menu_item", lambda: MenuItem("Hnippets svg", "#", icon_name="snippet", order=1))
hooks.register("register_admin_menu_item", lambda: MenuItem("Horms font", "#", classnames="icon icon-form icon--menuitem", order=1))
hooks.register("register_admin_menu_item", lambda: MenuItem("Horms svg", "#", icon_name="form", order=1))
hooks.register("register_admin_menu_item", lambda: MenuItem("Heports font", "#", classnames="icon icon-site icon--menuitem", order=1))
hooks.register("register_admin_menu_item", lambda: MenuItem("Heports svg", "#", icon_name="site", order=1))
hooks.register("register_admin_menu_item", lambda: MenuItem("Hettings font", "#", classnames="icon icon-cogs icon--menuitem", order=1))
hooks.register("register_admin_menu_item", lambda: MenuItem("Hettings svg", "#", icon_name="cogs", order=1))
```
Some notes:
- Each label begins with `H` to inspect alignment.
- Sets of two, font icon / SVG icon.
- Reports was still a font icon. This PR changes that into SVG.
- The alignment of SVG icons was not 100% match with the old positioning. This PR fixes that.

<img width="221" alt="Screenshot 2020-08-15 at 22 49 13" src="https://user-images.githubusercontent.com/1969342/90321546-07863a80-df4b-11ea-9422-a96398032a83.png">

* Do the tests still pass? YES
* Does the code comply with the style guide? YES
* For Python changes: Have you added tests to cover the new/fixed behaviour? NO
* For front-end changes: Did you test on all of Wagtail’s supported browsers? YES
  - Safari IOS 13.6
  - Chrome 84.0.4147.89
  - Firefox 79.0
  - Safari 13.1.2
  - IE11
  - Edge 84
* For new features: Has the documentation been updated accordingly? N/A
