### PR TITLE
Avoid setting self.content_type on page CreateView / EditView

### DIFF
--- a/wagtail/admin/tests/pages/test_create_page.py
+++ b/wagtail/admin/tests/pages/test_create_page.py
@@ -108,6 +108,7 @@ class TestPageCreation(TestCase, WagtailTestUtils):
     def test_create_simplepage(self):
         response = self.client.get(reverse('wagtailadmin_pages:add', args=('tests', 'simplepage', self.root_page.id)))
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(response['Content-Type'], "text/html; charset=utf-8")
         self.assertContains(response, '<a href="#tab-content" class="active">Content</a>')
         self.assertContains(response, '<a href="#tab-promote" class="">Promote</a>')
         # test register_page_action_menu_item hook

--- a/wagtail/admin/tests/pages/test_edit_page.py
+++ b/wagtail/admin/tests/pages/test_edit_page.py
@@ -82,6 +82,7 @@ class TestPageEdit(TestCase, WagtailTestUtils):
         # Tests that the edit page loads
         response = self.client.get(reverse('wagtailadmin_pages:edit', args=(self.event_page.id, )))
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(response['Content-Type'], "text/html; charset=utf-8")
 
         # Test InlinePanel labels/headings
         self.assertContains(response, '<legend>Speaker lineup</legend>')

--- a/wagtail/admin/views/pages/create.py
+++ b/wagtail/admin/views/pages/create.py
@@ -52,12 +52,12 @@ class CreateView(TemplateResponseMixin, ContextMixin, HookResponseMixin, View):
             raise PermissionDenied
 
         try:
-            self.content_type = ContentType.objects.get_by_natural_key(content_type_app_name, content_type_model_name)
+            self.page_content_type = ContentType.objects.get_by_natural_key(content_type_app_name, content_type_model_name)
         except ContentType.DoesNotExist:
             raise Http404
 
         # Get class
-        self.page_class = self.content_type.model_class()
+        self.page_class = self.page_content_type.model_class()
 
         # Make sure the class is a descendant of Page
         if not issubclass(self.page_class, Page):
@@ -244,7 +244,7 @@ class CreateView(TemplateResponseMixin, ContextMixin, HookResponseMixin, View):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context.update({
-            'content_type': self.content_type,
+            'content_type': self.page_content_type,
             'page_class': self.page_class,
             'parent_page': self.parent_page,
             'edit_handler': self.edit_handler,

--- a/wagtail/admin/views/pages/edit.py
+++ b/wagtail/admin/views/pages/edit.py
@@ -81,14 +81,14 @@ class EditView(TemplateResponseMixin, ContextMixin, HookResponseMixin, View):
     def dispatch(self, request, page_id):
         self.real_page_record = get_object_or_404(Page, id=page_id)
         self.latest_revision = self.real_page_record.get_latest_revision()
-        self.content_type = self.real_page_record.cached_content_type
+        self.page_content_type = self.real_page_record.cached_content_type
         self.page_class = self.real_page_record.specific_class
 
         if self.page_class is None:
             raise PageClassNotFoundError(
                 f"The page '{self.real_page_record}' cannot be edited because the "
-                f"model class used to create it ({self.content_type.app_label}."
-                f"{self.content_type.model}) can no longer be found in the codebase. "
+                f"model class used to create it ({self.page_content_type.app_label}."
+                f"{self.page_content_type.model}) can no longer be found in the codebase. "
                 "This usually happens as a result of switching between git "
                 "branches without running migrations to trigger the removal of "
                 "unused ContentTypes. To edit the page, you will need to switch "
@@ -504,7 +504,7 @@ class EditView(TemplateResponseMixin, ContextMixin, HookResponseMixin, View):
         context.update({
             'page': self.page,
             'page_for_status': self.page_for_status,
-            'content_type': self.content_type,
+            'content_type': self.page_content_type,
             'edit_handler': self.edit_handler,
             'errors_debug': self.errors_debug,
             'action_menu': PageActionMenu(self.request, view='edit', page=self.page),


### PR DESCRIPTION
Fix regression in #6306 - an instance variable `self.content_type` will be picked up by TemplateResponseMixin as the MIME content type for the response. Use `page_content_type` to avoid this.
