### PR TITLE
Correctly output Draft vs Published when no revisions exist

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/shared/workflow_status.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/workflow_status.html
@@ -21,18 +21,24 @@
 </li>
 {% else %}
 <li class="header-meta--status">
-    {% if page.get_latest_revision %}
-        {% if page.get_latest_revision.user %}
-            <span class="avatar small" data-wagtail-tooltip="{{ page.get_latest_revision.user.get_full_name|default:page.get_latest_revision.user.get_username }}"><img src="{% avatar_url page.get_latest_revision.user size=25 %}" alt="" /></span>
-        {% endif %}
-        {% if page.get_latest_revision == page.live_revision %}
-            {% trans "Published" %}
+    {% with latest_revision=page.get_latest_revision %}
+        {% if latest_revision %}
+            {% if latest_revision.user %}
+                <span class="avatar small" data-wagtail-tooltip="{{ latest_revision.user.get_full_name|default:latest_revision.user.get_username }}"><img src="{% avatar_url latest_revision.user size=25 %}" alt="" /></span>
+            {% endif %}
+            {% if latest_revision == page.live_revision %}
+                {% trans "Published" %}
+            {% else %}
+                {% trans "Draft saved" %}
+            {% endif %}
+            {% include "wagtailadmin/shared/last_updated.html" with last_updated=latest_revision.created_at time_prefix="at" %}
         {% else %}
-            {% trans "Draft saved" %}
+            {% if page.live %}
+                {% trans "Published" %}
+            {% else %}
+                {% trans "Draft" %}
+            {% endif %}
         {% endif %}
-        {% include "wagtailadmin/shared/last_updated.html" with last_updated=page.get_latest_revision.created_at time_prefix="at" %}
-    {% else %}
-        {% trans "Draft" %}
-    {% endif %}
+    {% endwith %}
 </li>
 {% endif %}

--- a/wagtail/admin/tests/pages/test_edit_page.py
+++ b/wagtail/admin/tests/pages/test_edit_page.py
@@ -83,6 +83,7 @@ class TestPageEdit(TestCase, WagtailTestUtils):
         response = self.client.get(reverse('wagtailadmin_pages:edit', args=(self.event_page.id, )))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response['Content-Type'], "text/html; charset=utf-8")
+        self.assertContains(response, '<li class="header-meta--status">Published</li>', html=True)
 
         # Test InlinePanel labels/headings
         self.assertContains(response, '<legend>Speaker lineup</legend>')
@@ -101,6 +102,7 @@ class TestPageEdit(TestCase, WagtailTestUtils):
         # Tests that the edit page loads
         response = self.client.get(reverse('wagtailadmin_pages:edit', args=(self.unpublished_page.id, )))
         self.assertEqual(response.status_code, 200)
+        self.assertContains(response, '<li class="header-meta--status">Draft</li>', html=True)
 
     def test_edit_multipart(self):
         """


### PR DESCRIPTION
Fixes #6324
Also removed repeated calls to page.get_latest_revision.
