### PR TITLE
django 3.1 deprecated django-admin.py

### DIFF
--- a/docs/contributing/developing.rst
+++ b/docs/contributing/developing.rst
@@ -100,7 +100,7 @@ You can create migrations for the test app by running the following from the Wag
 
 .. code-block:: console
 
-    $ django-admin.py makemigrations --settings=wagtail.tests.settings
+    $ django-admin makemigrations --settings=wagtail.tests.settings
 
 
 Testing against PostgreSQL

--- a/wagtail/bin/wagtail.py
+++ b/wagtail/bin/wagtail.py
@@ -80,7 +80,7 @@ class CreateProject(Command):
         template_path = os.path.join(wagtail_path, 'project_template')
 
         # Call django-admin startproject
-        utility_args = ['django-admin.py',
+        utility_args = ['django-admin',
                         'startproject',
                         '--template=' + template_path,
                         '--ext=html,rst',


### PR DESCRIPTION
Mechanical change to use `django-admin` instead of `django-admin.py` as Django 3.1 deprecated the later.

I did not change the last remaining location: `etc/uwsgi.conf.sample` because to be honest that comment makes no sense to me, but I am not a native speaker.

Announcement: https://docs.djangoproject.com/en/3.1/releases/3.1/#id2