### PR TITLE
Force string url before passing to urlparse

### DIFF
--- a/wagtail/api/v2/tests/tests.py
+++ b/wagtail/api/v2/tests/tests.py
@@ -1,6 +1,5 @@
 from unittest import TestCase
 
-from django.conf import settings
 from django.test import RequestFactory, override_settings
 from django.utils.encoding import force_bytes
 
@@ -19,9 +18,7 @@ class DynamicBaseUrl(object):
 
 
 class TestGetBaseUrl(TestCase):
-    @override_settings()
-    def test_get_base_url_unset(self):
-        del settings.WAGTAILAPI_BASE_URL
+    def test_get_base_url(self):
         self.assertIsNone(get_base_url())
 
     def test_get_base_url_from_request(self):

--- a/wagtail/api/v2/tests/tests.py
+++ b/wagtail/api/v2/tests/tests.py
@@ -57,7 +57,7 @@ class TestGetBaseUrl(TestCase):
         # base url for request with a site should be based on the site's details
         site = self.prepare_records()
         self.clear_cached_site(request)
-        self.assertIsNotNone(Site.find_for_request(request))
+        self.assertEqual(site, Site.find_for_request(request))
         self.assertEqual(get_base_url(request), 'http://other.example.com:8080')
 
         # port 443 should indicate https without a port

--- a/wagtail/api/v2/tests/tests.py
+++ b/wagtail/api/v2/tests/tests.py
@@ -51,12 +51,12 @@ class TestGetBaseUrl(TestCase):
         )
         self.assertIsNotNone(Site.find_for_request(request))
         self.assertEqual(get_base_url(request), 'http://other.example.com:8080')
-        
+
         # port 443 should indicate https without a port
         site.port = 443
         site.save()
         self.assertEqual(get_base_url(request), 'https://other.example.com')
-        
+
         # port 80 should indicate http without a port
         site.port = 80
         site.save()

--- a/wagtail/api/v2/tests/tests.py
+++ b/wagtail/api/v2/tests/tests.py
@@ -66,15 +66,15 @@ class TestGetBaseUrl(TestCase):
         self.assertEqual(get_base_url(request), 'http://other.example.com')
 
     @override_settings(WAGTAILAPI_BASE_URL='https://bar.example.com')
-    def get_base_url_from_setting_string(self):
+    def test_get_base_url_from_setting_string(self):
         self.assertEqual(get_base_url(), 'https://bar.example.com')
 
     @override_settings(WAGTAILAPI_BASE_URL=b'https://baz.example.com')
-    def get_base_url_from_setting_bytes(self):
+    def test_get_base_url_from_setting_bytes(self):
         self.assertEqual(get_base_url(), 'https://baz.example.com')
 
     @override_settings(WAGTAILAPI_BASE_URL=DynamicBaseUrl())
-    def get_base_url_from_setting_object(self):
+    def test_get_base_url_from_setting_object(self):
         self.assertEqual(get_base_url(), 'https://www.example.com')
 
 

--- a/wagtail/api/v2/tests/tests.py
+++ b/wagtail/api/v2/tests/tests.py
@@ -45,8 +45,9 @@ class TestGetBaseUrl(TestCase):
             hostname='other.example.com',
             port=80,
             root_page=root_page,
+            is_default_site=True,
         )
-        request = RequestFactory().get('/', HTTP_HOST='other.example.com')
+        request = RequestFactory().get('/', HTTP_HOST='something')
         self.assertEqual(get_base_url(request), 'http://other.example.com')
 
     @override_settings(WAGTAILAPI_BASE_URL='https://bar.example.com')

--- a/wagtail/api/v2/tests/tests.py
+++ b/wagtail/api/v2/tests/tests.py
@@ -40,7 +40,7 @@ class TestGetBaseUrl(TestCase):
             root_page=root_page,
             is_default_site=True,
         )
-        return page_content_type, root_page, site
+        return site
 
     def clear_cached_site(self, request):
         del request._wagtail_site
@@ -55,7 +55,7 @@ class TestGetBaseUrl(TestCase):
         self.assertIsNone(get_base_url(request))
 
         # base url for request with a site should be based on the site's details
-        page_content_type, root_page, site = self.prepare_records()
+        site = self.prepare_records()
         self.clear_cached_site(request)
         self.assertIsNotNone(Site.find_for_request(request))
         self.assertEqual(get_base_url(request), 'http://other.example.com:8080')
@@ -75,7 +75,7 @@ class TestGetBaseUrl(TestCase):
     @override_settings(WAGTAILAPI_BASE_URL='https://bar.example.com')
     def test_get_base_url_prefers_setting(self):
         request = RequestFactory().get('/')
-        page_content_type, root_page, site = self.prepare_records()
+        site = self.prepare_records()
         self.assertEqual(site, Site.find_for_request(request))
         self.assertEqual(get_base_url(request), 'https://bar.example.com')
         del settings.WAGTAILAPI_BASE_URL

--- a/wagtail/api/v2/tests/tests.py
+++ b/wagtail/api/v2/tests/tests.py
@@ -1,5 +1,6 @@
 from unittest import TestCase
 
+from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.test import RequestFactory, override_settings
 from django.utils.encoding import force_bytes

--- a/wagtail/api/v2/tests/tests.py
+++ b/wagtail/api/v2/tests/tests.py
@@ -27,7 +27,11 @@ class TestGetBaseUrl(TestCase):
         self.assertIsNone(get_base_url(request))
 
     def test_get_base_url_from_request(self):
-        Site.objects.create(hostname='other.example.com', port=80, root_page=Page.objects.get(pk=2))
+        Site.objects.create(
+            hostname='other.example.com',
+            port=80,
+            root_page=Page.objects.all().first(),
+        )
         request = RequestFactory().get('/', HTTP_HOST='other.example.com')
         self.assertEqual(get_base_url(request), 'http://other.example.com')
 

--- a/wagtail/api/v2/tests/tests.py
+++ b/wagtail/api/v2/tests/tests.py
@@ -49,17 +49,20 @@ class TestGetBaseUrl(TestCase):
             root_page=root_page,
             is_default_site=True,
         )
+        del request._wagtail_site  # clear site lookup cache
         self.assertIsNotNone(Site.find_for_request(request))
         self.assertEqual(get_base_url(request), 'http://other.example.com:8080')
 
         # port 443 should indicate https without a port
         site.port = 443
         site.save()
+        del request._wagtail_site  # clear site lookup cache
         self.assertEqual(get_base_url(request), 'https://other.example.com')
 
         # port 80 should indicate http without a port
         site.port = 80
         site.save()
+        del request._wagtail_site  # clear site lookup cache
         self.assertEqual(get_base_url(request), 'http://other.example.com')
 
     @override_settings(WAGTAILAPI_BASE_URL='https://bar.example.com')

--- a/wagtail/api/v2/tests/tests.py
+++ b/wagtail/api/v2/tests/tests.py
@@ -22,7 +22,7 @@ class TestGetBaseUrl(TestCase):
         self.assertIsNone(get_base_url())
 
     def test_get_base_url_from_request(self):
-        request = RequestFactory().get('http://foo.example.com')
+        request = RequestFactory().get('/', HTTP_HOST='http://foo.example.com')
         self.assertEqual(get_base_url(request), 'http://foo.example.com')
 
     @override_settings(WAGTAILAPI_BASE_URL='https://www.example.com')

--- a/wagtail/api/v2/tests/tests.py
+++ b/wagtail/api/v2/tests/tests.py
@@ -28,11 +28,11 @@ class TestGetBaseUrl(TestCase):
         self.assertIsNone(get_base_url(request))
 
     def test_get_base_url_from_request(self):
-        page_content_type, _ = ContentType.objects.get_or_create(
+        page_content_type = ContentType.objects.get_or_create(
             model='page',
             app_label='wagtailcore'
-        )
-        root = Page.objects.create(
+        )[0]
+        root_page = Page.objects.create(
             title="Root",
             slug='root',
             content_type=page_content_type,
@@ -44,7 +44,7 @@ class TestGetBaseUrl(TestCase):
         Site.objects.create(
             hostname='other.example.com',
             port=80,
-            root_page=Page.objects.all().first(),
+            root_page=root_page,
         )
         request = RequestFactory().get('/', HTTP_HOST='other.example.com')
         self.assertEqual(get_base_url(request), 'http://other.example.com')

--- a/wagtail/api/v2/tests/tests.py
+++ b/wagtail/api/v2/tests/tests.py
@@ -25,8 +25,8 @@ class TestGetBaseUrl(TestCase):
         self.assertIsNone(get_base_url())
 
     def test_get_base_url_from_request(self):
-        request = RequestFactory().get('/')
-        self.assertEqual(get_base_url(request), 'http://testserver')
+        request = RequestFactory().get('http://foo.example.com')
+        self.assertEqual(get_base_url(request), 'http://foo.example.com')
 
     @override_settings(WAGTAILAPI_BASE_URL='https://www.example.com')
     def get_base_url_from_setting_string(self):

--- a/wagtail/api/v2/tests/tests.py
+++ b/wagtail/api/v2/tests/tests.py
@@ -21,7 +21,7 @@ class DynamicBaseUrl(object):
 
 
 class TestGetBaseUrl(TestCase):
-    def prepare_records(self):
+    def prepare_site(self):
         page_content_type = ContentType.objects.get_or_create(
             model='page',
             app_label='wagtailcore'
@@ -46,7 +46,7 @@ class TestGetBaseUrl(TestCase):
     def clear_cached_site(self, request):
         del request._wagtail_site
 
-    def test_get_base_url(self):
+    def test_get_base_url_unset(self):
         self.assertIsNone(get_base_url())
 
     def test_get_base_url_from_request(self):
@@ -56,7 +56,7 @@ class TestGetBaseUrl(TestCase):
         self.assertIsNone(get_base_url(request))
 
         # base url for request with a site should be based on the site's details
-        site = self.prepare_records()
+        site = self.prepare_site()
         self.clear_cached_site(request)
         self.assertEqual(site, Site.find_for_request(request))
         self.assertEqual(get_base_url(request), 'http://other.example.com:8080')
@@ -76,7 +76,7 @@ class TestGetBaseUrl(TestCase):
     @override_settings(WAGTAILAPI_BASE_URL='https://bar.example.com')
     def test_get_base_url_prefers_setting(self):
         request = RequestFactory().get('/')
-        site = self.prepare_records()
+        site = self.prepare_site()
         self.assertEqual(site, Site.find_for_request(request))
         self.assertEqual(get_base_url(request), 'https://bar.example.com')
         del settings.WAGTAILAPI_BASE_URL

--- a/wagtail/api/v2/tests/tests.py
+++ b/wagtail/api/v2/tests/tests.py
@@ -41,7 +41,10 @@ class TestGetBaseUrl(TestCase):
             is_default_site=True,
         )
         return page_content_type, root_page, site
-    
+
+    def clear_cached_site(self, request):
+        del request._wagtail_site
+
     def test_get_base_url(self):
         self.assertIsNone(get_base_url())
 
@@ -53,20 +56,20 @@ class TestGetBaseUrl(TestCase):
 
         # base url for request with a site should be based on the site's details
         page_content_type, root_page, site = self.prepare_records()
-        del request._wagtail_site  # clear site lookup cache
+        self.clear_cached_site(request)
         self.assertIsNotNone(Site.find_for_request(request))
         self.assertEqual(get_base_url(request), 'http://other.example.com:8080')
 
         # port 443 should indicate https without a port
         site.port = 443
         site.save()
-        del request._wagtail_site  # clear site lookup cache
+        self.clear_cached_site(request)
         self.assertEqual(get_base_url(request), 'https://other.example.com')
 
         # port 80 should indicate http without a port
         site.port = 80
         site.save()
-        del request._wagtail_site  # clear site lookup cache
+        self.clear_cached_site(request)
         self.assertEqual(get_base_url(request), 'http://other.example.com')
 
     @override_settings(WAGTAILAPI_BASE_URL='https://bar.example.com')

--- a/wagtail/api/v2/tests/tests.py
+++ b/wagtail/api/v2/tests/tests.py
@@ -47,7 +47,7 @@ class TestGetBaseUrl(TestCase):
 
     def test_get_base_url_from_request(self):
         # base url for siteless request should be None
-        request = RequestFactory().get('/', HTTP_HOST='other.example.com')
+        request = RequestFactory().get('/')
         self.assertIsNone(Site.find_for_request(request))
         self.assertIsNone(get_base_url(request))
 
@@ -71,7 +71,7 @@ class TestGetBaseUrl(TestCase):
 
     @override_settings(WAGTAILAPI_BASE_URL='https://bar.example.com')
     def test_get_base_url_prefers_setting(self):
-        request = RequestFactory().get('/', HTTP_HOST='other.example.com')
+        request = RequestFactory().get('/')
         page_content_type, root_page, site = self.prepare_records()
         self.assertEqual(site, Site.find_for_request(request))
         self.assertEqual(get_base_url(request), 'https://bar.example.com')

--- a/wagtail/api/v2/tests/tests.py
+++ b/wagtail/api/v2/tests/tests.py
@@ -1,5 +1,6 @@
 from unittest import TestCase
 
+from django.contrib.contenttypes.models import ContentType
 from django.test import RequestFactory, override_settings
 from django.utils.encoding import force_bytes
 
@@ -27,6 +28,19 @@ class TestGetBaseUrl(TestCase):
         self.assertIsNone(get_base_url(request))
 
     def test_get_base_url_from_request(self):
+        page_content_type, _ = ContentType.objects.get_or_create(
+            model='page',
+            app_label='wagtailcore'
+        )
+        root = Page.objects.create(
+            title="Root",
+            slug='root',
+            content_type=page_content_type,
+            path='0001',
+            depth=1,
+            numchild=1,
+            url_path='/',
+        )
         Site.objects.create(
             hostname='other.example.com',
             port=80,

--- a/wagtail/api/v2/tests/tests.py
+++ b/wagtail/api/v2/tests/tests.py
@@ -27,13 +27,13 @@ class TestGetBaseUrl(TestCase):
         request = RequestFactory().get('/', HTTP_HOST='foo.example.com')
         self.assertEqual(get_base_url(request), 'http://foo.example.com')
 
-    @override_settings(WAGTAILAPI_BASE_URL='https://www.example.com')
+    @override_settings(WAGTAILAPI_BASE_URL='https://bar.example.com')
     def get_base_url_from_setting_string(self):
-        self.assertEqual(get_base_url(), 'https://www.example.com')
+        self.assertEqual(get_base_url(), 'https://bar.example.com')
 
-    @override_settings(WAGTAILAPI_BASE_URL=b'https://www.example.com')
+    @override_settings(WAGTAILAPI_BASE_URL=b'https://baz.example.com')
     def get_base_url_from_setting_bytes(self):
-        self.assertEqual(get_base_url(), 'https://www.example.com')
+        self.assertEqual(get_base_url(), 'https://baz.example.com')
 
     @override_settings(WAGTAILAPI_BASE_URL=DynamicBaseUrl())
     def get_base_url_from_setting_object(self):

--- a/wagtail/api/v2/tests/tests.py
+++ b/wagtail/api/v2/tests/tests.py
@@ -18,6 +18,9 @@ class DynamicBaseUrl(object):
 
 
 class TestGetBaseUrl(TestCase):
+    def test_get_base_url(self):
+        self.assertIsNone(get_base_url())
+
     def test_get_base_url_from_request(self):
         request = RequestFactory().get('/')
         self.assertEqual(get_base_url(request), 'http://testserver')

--- a/wagtail/api/v2/tests/tests.py
+++ b/wagtail/api/v2/tests/tests.py
@@ -3,6 +3,7 @@ from unittest import TestCase
 from django.test import RequestFactory, override_settings
 from django.utils.encoding import force_bytes
 
+from wagtail.core.models import Page, Site
 from ..utils import FieldsParameterParseError, get_base_url, parse_boolean, parse_fields_parameter
 
 
@@ -22,7 +23,8 @@ class TestGetBaseUrl(TestCase):
         self.assertIsNone(get_base_url())
 
     def test_get_base_url_from_request(self):
-        request = RequestFactory().get('/', HTTP_HOST='http://foo.example.com')
+        site = Site.objects.create(hostname='foo.example.com', port=80, root_page=Page.objects.get(pk=2))
+        request = RequestFactory().get('/', HTTP_HOST='foo.example.com')
         self.assertEqual(get_base_url(request), 'http://foo.example.com')
 
     @override_settings(WAGTAILAPI_BASE_URL='https://www.example.com')

--- a/wagtail/api/v2/tests/tests.py
+++ b/wagtail/api/v2/tests/tests.py
@@ -24,7 +24,7 @@ class TestGetBaseUrl(TestCase):
         self.assertIsNone(get_base_url())
 
     def test_get_base_url_from_siteless_request(self):
-        request = RequestFactory().get('/', HTTP_HOST='other.example.com')
+        request = RequestFactory().get('/', HTTP_HOST='localhost')
         self.assertIsNone(get_base_url(request))
 
     def test_get_base_url_from_request(self):
@@ -45,9 +45,8 @@ class TestGetBaseUrl(TestCase):
             hostname='other.example.com',
             port=80,
             root_page=root_page,
-            is_default_site=True,
         )
-        request = RequestFactory().get('/', HTTP_HOST='something')
+        request = RequestFactory().get('/', HTTP_HOST='other.example.com')
         self.assertEqual(get_base_url(request), 'http://other.example.com')
 
     @override_settings(WAGTAILAPI_BASE_URL='https://bar.example.com')

--- a/wagtail/api/v2/tests/tests.py
+++ b/wagtail/api/v2/tests/tests.py
@@ -23,7 +23,7 @@ class TestGetBaseUrl(TestCase):
         self.assertIsNone(get_base_url())
 
     def test_get_base_url_from_request(self):
-        site = Site.objects.create(hostname='foo.example.com', port=80, root_page=Page.objects.get(pk=2))
+        Site.objects.create(hostname='foo.example.com', port=80, root_page=Page.objects.get(pk=2))
         request = RequestFactory().get('/', HTTP_HOST='foo.example.com')
         self.assertEqual(get_base_url(request), 'http://foo.example.com')
 

--- a/wagtail/api/v2/tests/tests.py
+++ b/wagtail/api/v2/tests/tests.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 from django.test import RequestFactory, override_settings
 from django.utils.encoding import force_bytes
 
-from ..utils import FieldsParameterParseError, parse_boolean, parse_fields_parameter, get_base_url
+from ..utils import FieldsParameterParseError, get_base_url, parse_boolean, parse_fields_parameter
 
 
 class DynamicBaseUrl(object):

--- a/wagtail/api/v2/tests/tests.py
+++ b/wagtail/api/v2/tests/tests.py
@@ -9,10 +9,10 @@ from ..utils import FieldsParameterParseError, parse_boolean, parse_fields_param
 class DynamicBaseUrl(object):
     def __str__(self):
         return 'https://www.example.com'
-    
+
     def __bytes__(self):
         return force_bytes(self.__str__())
-    
+
     def decode(self, *args, **kwargs):
         return self.__bytes__().decode(*args, **kwargs)
 
@@ -21,15 +21,15 @@ class TestGetBaseUrl(TestCase):
     def test_get_base_url_from_request(self):
         request = RequestFactory().get('/')
         self.assertEqual(get_base_url(request), 'http://testserver')
-    
+
     @override_settings(WAGTAILAPI_BASE_URL='https://www.example.com')
     def get_base_url_from_setting_string(self):
         self.assertEqual(get_base_url(), 'https://www.example.com')
-    
+
     @override_settings(WAGTAILAPI_BASE_URL=b'https://www.example.com')
     def get_base_url_from_setting_bytes(self):
         self.assertEqual(get_base_url(), 'https://www.example.com')
-    
+
     @override_settings(WAGTAILAPI_BASE_URL=DynamicBaseUrl())
     def get_base_url_from_setting_object(self):
         self.assertEqual(get_base_url(), 'https://www.example.com')

--- a/wagtail/api/v2/tests/tests.py
+++ b/wagtail/api/v2/tests/tests.py
@@ -26,7 +26,7 @@ class TestGetBaseUrl(TestCase):
             model='page',
             app_label='wagtailcore'
         )[0]
-        root_page = Page.objects.create(
+        root_page = Page.objects.get_or_create(
             title="Root",
             slug='root',
             content_type=page_content_type,
@@ -34,13 +34,13 @@ class TestGetBaseUrl(TestCase):
             depth=1,
             numchild=1,
             url_path='/',
-        )
-        site = Site.objects.create(
+        )[0]
+        site = Site.objects.get_or_create(
             hostname='other.example.com',
             port=8080,
             root_page=root_page,
             is_default_site=True,
-        )
+        )[0]
         return site
 
     def clear_cached_site(self, request):

--- a/wagtail/api/v2/tests/tests.py
+++ b/wagtail/api/v2/tests/tests.py
@@ -23,13 +23,13 @@ class TestGetBaseUrl(TestCase):
         self.assertIsNone(get_base_url())
 
     def test_get_base_url_from_siteless_request(self):
-        request = RequestFactory().get('/', HTTP_HOST='unknown.example.com')
+        request = RequestFactory().get('/', HTTP_HOST='other.example.com')
         self.assertIsNone(get_base_url(request))
 
     def test_get_base_url_from_request(self):
-        Site.objects.create(hostname='foo.example.com', port=80, root_page=Page.objects.get(pk=2))
-        request = RequestFactory().get('/', HTTP_HOST='foo.example.com')
-        self.assertEqual(get_base_url(request), 'http://foo.example.com')
+        Site.objects.create(hostname='other.example.com', port=80, root_page=Page.objects.get(pk=2))
+        request = RequestFactory().get('/', HTTP_HOST='other.example.com')
+        self.assertEqual(get_base_url(request), 'http://other.example.com')
 
     @override_settings(WAGTAILAPI_BASE_URL='https://bar.example.com')
     def get_base_url_from_setting_string(self):

--- a/wagtail/api/v2/tests/tests.py
+++ b/wagtail/api/v2/tests/tests.py
@@ -1,5 +1,6 @@
 from unittest import TestCase
 
+from django.conf import settings
 from django.test import RequestFactory, override_settings
 from django.utils.encoding import force_bytes
 
@@ -18,7 +19,9 @@ class DynamicBaseUrl(object):
 
 
 class TestGetBaseUrl(TestCase):
-    def test_get_base_url(self):
+    @override_settings()
+    def test_get_base_url_unset(self):
+        del settings.WAGTAILAPI_BASE_URL
         self.assertIsNone(get_base_url())
 
     def test_get_base_url_from_request(self):

--- a/wagtail/api/v2/tests/tests.py
+++ b/wagtail/api/v2/tests/tests.py
@@ -22,6 +22,10 @@ class TestGetBaseUrl(TestCase):
     def test_get_base_url(self):
         self.assertIsNone(get_base_url())
 
+    def test_get_base_url_from_siteless_request(self):
+        request = RequestFactory().get('/', HTTP_HOST='unknown.example.com')
+        self.assertIsNone(get_base_url(request))
+
     def test_get_base_url_from_request(self):
         Site.objects.create(hostname='foo.example.com', port=80, root_page=Page.objects.get(pk=2))
         request = RequestFactory().get('/', HTTP_HOST='foo.example.com')

--- a/wagtail/api/v2/tests/tests.py
+++ b/wagtail/api/v2/tests/tests.py
@@ -25,6 +25,7 @@ class TestGetBaseUrl(TestCase):
 
     def test_get_base_url_from_siteless_request(self):
         request = RequestFactory().get('/', HTTP_HOST='localhost')
+        self.assertIsNone(Site.find_for_request(request))
         self.assertIsNone(get_base_url(request))
 
     def test_get_base_url_from_request(self):

--- a/wagtail/api/v2/utils.py
+++ b/wagtail/api/v2/utils.py
@@ -1,6 +1,7 @@
 from urllib.parse import urlparse
 
 from django.conf import settings
+from django.utils.encoding import force_str
 
 from wagtail.core.models import Page, Site
 from wagtail.core.utils import resolve_model_string
@@ -23,7 +24,7 @@ def get_base_url(request=None):
 
     if base_url:
         # We only want the scheme and netloc
-        base_url_parsed = urlparse(base_url)
+        base_url_parsed = urlparse(force_str(base_url))
 
         return base_url_parsed.scheme + '://' + base_url_parsed.netloc
 


### PR DESCRIPTION
I am hitting an issue that I cannot really work around as this setting needs to change during runtime.

urlparse assumes input is either a str or bytes.  If it isn't str, it assumes bytes and calls the decode method.  The problem is this sets the return value to bytes.  This then breaks at the string concatenation line.

Similar to https://github.com/wagtail/wagtail/issues/5719 but due to this problem, providing an object that changes when cast doesn't work.