### PR TITLE
Make collapsible behaviour usable on all fields and remove duplicate JS

### DIFF
--- a/docs/reference/pages/panels.rst
+++ b/docs/reference/pages/panels.rst
@@ -66,7 +66,7 @@ MultiFieldPanel
 
 .. topic:: Collapsing MultiFieldPanels to save space
 
-    By default, ``MultiFieldPanel`` s are expanded and not collapsible. Adding ``collapsible`` to ``classname`` will enable the collapse control. Adding both ``collapsible`` and ``collapsed`` to the ``classname`` parameter will load the editor page with the ``MultiFieldPanel`` collapsed under its heading.
+    By default, ``MultiFieldPanel`` s are expanded and not collapsible. Adding ``collapsible`` to ``classname`` will enable the collapse control. Adding both ``collapsible`` and ``collapsed`` to the ``classname`` parameter will load the editor page with the ``MultiFieldPanel`` collapsed under its heading. You must define a ``heading`` when using ``collapsible`` with ``MultiFieldPanel``.
 
     .. code-block:: python
 
@@ -90,6 +90,18 @@ InlinePanel
     This panel allows for the creation of a "cluster" of related objects over a join to a separate model, such as a list of related links or slides to an image carousel.
 
     This is a powerful but complex feature which will take some space to cover, so we'll skip over it for now. For a full explanation on the usage of ``InlinePanel``, see :ref:`inline_panels`.
+
+
+.. topic:: Collapsing InlinePanels to save space
+
+    By default, ``InlinePanel`` s are expanded and not collapsible. Adding ``collapsible`` to ``classname`` will enable the collapse control. Adding both ``collapsible`` and ``collapsed`` to the ``classname`` parameter will load the editor page with the ``FieldPanel`` collapsed under its heading. You must define a ``heading`` or ``label`` when using ``collapsible`` with ``InlinePanel``.
+
+    .. code-block:: python
+
+        content_panels = [
+            InlinePanel("ingredients", label="Ingredients", classname="collapsible collapsed"),
+        ]
+
 
 FieldRowPanel
 -------------

--- a/wagtail/admin/static_src/wagtailadmin/js/page-editor.js
+++ b/wagtail/admin/static_src/wagtailadmin/js/page-editor.js
@@ -242,7 +242,7 @@ function initCollapsibleBlocks() {
             $content.hide();
         }
 
-        $target.find('> .title-wrapper').on('click', function() {
+        $target.find('> .title-wrapper, > .collapsible-toggle').on('click', function() {
             if (!$target.hasClass('collapsed')) {
                 $target.addClass('collapsed');
                 $content.hide('slow');

--- a/wagtail/admin/static_src/wagtailadmin/js/page-editor.js
+++ b/wagtail/admin/static_src/wagtailadmin/js/page-editor.js
@@ -235,20 +235,20 @@ function initErrorDetection() {
 }
 
 function initCollapsibleBlocks() {
-    $('.object.multi-field.collapsible').each(function() {
-        var $li = $(this);
-        var $fieldset = $li.find('fieldset');
-        if ($li.hasClass('collapsed') && $li.find('.error-message').length == 0) {
-            $fieldset.hide();
+    $('.object.collapsible').each(function() {
+        var $target = $(this);
+        var $content = $target.find('.object-layout');
+        if ($target.hasClass('collapsed') && $target.find('.error-message').length == 0) {
+            $content.hide();
         }
 
-        $li.find('> .title-wrapper').on('click', function() {
-            if (!$li.hasClass('collapsed')) {
-                $li.addClass('collapsed');
-                $fieldset.hide('slow');
+        $target.find('> .title-wrapper').on('click', function() {
+            if (!$target.hasClass('collapsed')) {
+                $target.addClass('collapsed');
+                $content.hide('slow');
             } else {
-                $li.removeClass('collapsed');
-                $fieldset.show('show');
+                $target.removeClass('collapsed');
+                $content.show('slow');
             }
         });
     });

--- a/wagtail/admin/static_src/wagtailadmin/js/page-editor.js
+++ b/wagtail/admin/static_src/wagtailadmin/js/page-editor.js
@@ -237,7 +237,7 @@ function initErrorDetection() {
 function initCollapsibleBlocks() {
     $('.object.collapsible').each(function() {
         var $target = $(this);
-        var $content = $target.find('.object-layout');
+        var $content = $target.find('> .object-layout, > fieldset');
         if ($target.hasClass('collapsed') && $target.find('.error-message').length == 0) {
             $content.hide();
         }

--- a/wagtail/admin/templates/wagtailadmin/home.html
+++ b/wagtail/admin/templates/wagtailadmin/home.html
@@ -33,25 +33,5 @@
 {% endblock %}
 
 {% block extra_js %}
-<script>
-$(function() {
-    $('.object.collapsible').each(function() {
-        var $target = $(this);
-        var $content = $target.find('.object-layout');
-        if ($target.hasClass('collapsed') && $target.find('.error-message').length == 0) {
-            $content.hide();
-        }
-
-        $target.find('> .title-wrapper').on('click', function() {
-            if (!$target.hasClass('collapsed')) {
-                $target.addClass('collapsed');
-                $content.hide('slow');
-            } else {
-                $target.removeClass('collapsed');
-                $content.show('show');
-            }
-        });
-    });
-});
-</script>
+<script src="{% versioned_static 'wagtailadmin/js/page-editor.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
- Make collapsible behaviour usable on any .object, not only .multi-field
- Use the more generic version of the JS from home.html - collapse .object-layout instead of fieldset
- Remove the duplicate JS in home.html and include page-editor.js on home too.
   Home already includes page-editor.css so this seems logical.

Fixes #6187 

Before submitting, please review the contributor guidelines <https://docs.wagtail.io/en/latest/contributing/index.html> and check the following:

* Do the tests still pass?  *Yes*
* Does the code comply with the style guide? *Yes*
* For front-end changes: Did you test on all of Wagtail’s supported browsers? **Please list the exact versions you tested**.
* For new features: Has the documentation been updated accordingly? *Yes*
