### PR TITLE
Convert remaining gettext .format strings to old-style string formatting

### DIFF
--- a/docs/reference/hooks.rst
+++ b/docs/reference/hooks.rst
@@ -1197,7 +1197,7 @@ Audit log
             actions.register_action('wagtail_package.echo', _('Echo'), _('Sent an echo'))
 
             def callback_message(data):
-                return _('Hello {audience}') % {
+                return _('Hello %(audience)s') % {
                     'audience': data['audience'],
                 }
             actions.register_action('wagtail_package.with_callback', _('Callback'), callback_message)

--- a/wagtail/admin/log_action_registry.py
+++ b/wagtail/admin/log_action_registry.py
@@ -47,7 +47,7 @@ class LogActionRegistry:
         return self.messages
 
     def format_message(self, log_entry):
-        message = self.get_messages().get(log_entry.action, _('Unknown {action}').format(action=log_entry.action))
+        message = self.get_messages().get(log_entry.action, _('Unknown %(action)s') % {'action': log_entry.action})
         if callable(message):
             message = message(log_entry.data)
 

--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -3756,7 +3756,7 @@ class BaseLogEntry(models.Model):
                 return self.user.get_username()
             except self._meta.get_field('user').related_model.DoesNotExist:
                 # User has been deleted
-                return _('user {id} (deleted)').format(id=self.user_id)
+                return _('user %(id)d (deleted)') % {'id': self.user_id}
         else:
             return _('system')
 


### PR DESCRIPTION
As per #5548 / #6238. Fixes #6343
