### PR TITLE
Fix timesince_last_update for naive datetimes (USE_TZ=False)

### DIFF
--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -584,7 +584,11 @@ def timesince_last_update(last_update, time_prefix='', use_shorthand=True):
            but can return the full string if needed
     """
     if last_update.date() == datetime.today().date():
-        time_str = timezone.localtime(last_update).strftime("%H:%M")
+        if timezone.is_aware(last_update):
+            time_str = timezone.localtime(last_update).strftime("%H:%M")
+        else:
+            time_str = last_update.strftime("%H:%M")
+
         return time_str if not time_prefix else '%(prefix)s %(formatted_time)s' % {
             'prefix': time_prefix, 'formatted_time': time_str
         }


### PR DESCRIPTION
Prevent timesince_last_update template tag from failing when passed a naive datetime, which happens when USE_TZ is set to False. Fixes #6345

I'll open a separate PR against master, built on top of #6330, which adds test coverage for this by adding a new test run for USE_TZ=False (just as #6330 added a new test run for a username-less user model). In the interests of not holding up the 2.10.1 release, I propose that we don't wait for #6330 and the new PR to be reviewed in full, but they can still serve as verification that this fix is valid.