### PR TITLE
Clean ModelAdmin form only once at creation and edit

### DIFF
--- a/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
+++ b/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
@@ -266,6 +266,13 @@ class TestCreateView(TestCase, WagtailTestUtils):
                 self.assertTrue(mock_form_fields_exclude.called)
                 m.assert_called_with(Book, exclude=mock_form_fields_exclude.return_value)
 
+    def test_clean_form_once(self):
+        with mock.patch('wagtail.tests.modeladmintest.wagtail_hooks.PublisherModelAdminForm.clean') as mock_form_clean:
+            response = self.client.post('/admin/modeladmintest/publisher/create/', {'name': ''})
+            self.assertEqual(response.status_code, 200)
+
+            mock_form_clean.assert_called_once()
+
 
 class TestInspectView(TestCase, WagtailTestUtils):
     fixtures = ['modeladmintest_test.json']
@@ -393,6 +400,15 @@ class TestEditView(TestCase, WagtailTestUtils):
                 self.get(1)
                 self.assertTrue(mock_form_fields_exclude.called)
                 m.assert_called_with(Book, exclude=mock_form_fields_exclude.return_value)
+
+    def test_clean_form_once(self):
+        with mock.patch('wagtail.tests.modeladmintest.wagtail_hooks.PublisherModelAdminForm.clean') as mock_form_clean:
+            publisher = Publisher.objects.create(name='Sharper Collins')
+
+            response = self.client.post('/admin/modeladmintest/publisher/edit/%d/' % publisher.pk, {'name': ''})
+            self.assertEqual(response.status_code, 200)
+
+            mock_form_clean.assert_called_once()
 
 
 class TestPageSpecificViews(TestCase, WagtailTestUtils):

--- a/wagtail/contrib/modeladmin/views.py
+++ b/wagtail/contrib/modeladmin/views.py
@@ -136,19 +136,20 @@ class ModelFormView(WMABaseView, FormView):
             js=self.model_admin.get_form_view_extra_js()
         )
 
-    def get_context_data(self, **kwargs):
-        instance = self.get_instance()
-        edit_handler = self.get_edit_handler()
-        form = self.get_form()
-        edit_handler = edit_handler.bind_to(
-            instance=instance, request=self.request, form=form)
-        context = {
+    def get_context_data(self, form=None, edit_handler=None, **kwargs):
+        if form is None:
+            form = self.get_form()
+        if edit_handler is None:
+            instance = self.get_instance()
+            edit_handler = self.get_edit_handler()
+            edit_handler = edit_handler.bind_to(
+                instance=instance, request=self.request, form=form)
+        kwargs.update({
             'is_multipart': form.is_multipart(),
             'edit_handler': edit_handler,
             'form': form,
-        }
-        context.update(kwargs)
-        return super().get_context_data(**context)
+        })
+        return super().get_context_data(**kwargs)
 
     def get_success_message(self, instance):
         return _("%(model_name)s '%(instance)s' created.") % {
@@ -177,7 +178,7 @@ class ModelFormView(WMABaseView, FormView):
         messages.validation_error(
             self.request, self.get_error_message(), form
         )
-        return self.render_to_response(self.get_context_data())
+        return self.render_to_response(self.get_context_data(form=form))
 
 
 class InstanceSpecificView(WMABaseView):

--- a/wagtail/tests/modeladmintest/wagtail_hooks.py
+++ b/wagtail/tests/modeladmintest/wagtail_hooks.py
@@ -2,7 +2,7 @@ from wagtail.admin.edit_handlers import FieldPanel, ObjectList, TabbedInterface
 from wagtail.contrib.modeladmin.helpers import WagtailBackendSearchHandler
 from wagtail.contrib.modeladmin.options import (
     ModelAdmin, ModelAdminGroup, ThumbnailMixin, modeladmin_register)
-from wagtail.contrib.modeladmin.views import CreateView, IndexView
+from wagtail.contrib.modeladmin.views import CreateView, EditView, IndexView
 from wagtail.tests.testapp.models import BusinessChild, EventPage, SingleEventPage
 
 from .forms import PublisherModelAdminForm
@@ -92,9 +92,15 @@ class PublisherCreateView(CreateView):
         return PublisherModelAdminForm
 
 
+class PublisherEditView(EditView):
+    def get_form_class(self):
+        return PublisherModelAdminForm
+
+
 class PublisherModelAdmin(ModelAdmin):
     model = Publisher
     create_view_class = PublisherCreateView
+    edit_view_class = PublisherEditView
 
 
 class EventPageAdmin(ModelAdmin):


### PR DESCRIPTION
The same form instance is used during the whole create and edit view process to ensure the form is cleaned only once. This will improve performances when form cleaning requires extra database queries or external requests for example.