### PR TITLE
Specify required python versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -115,12 +115,12 @@ https://github.com/wagtail/wagtail/.",
         'Framework :: Wagtail',
         'Topic :: Internet :: WWW/HTTP :: Site Management',
     ],
+    python_requires='>=3.6',
     install_requires=install_requires,
     extras_require={
         'testing': testing_extras,
         'docs': documentation_extras
     },
-    python_requires='>=3.6, <3.9',
     entry_points="""
             [console_scripts]
             wagtail=wagtail.bin.wagtail:main

--- a/setup.py
+++ b/setup.py
@@ -120,6 +120,7 @@ https://github.com/wagtail/wagtail/.",
         'testing': testing_extras,
         'docs': documentation_extras
     },
+    python_requires='~=3.6, ~=3.7, ~=3.8',
     entry_points="""
             [console_scripts]
             wagtail=wagtail.bin.wagtail:main

--- a/setup.py
+++ b/setup.py
@@ -120,7 +120,7 @@ https://github.com/wagtail/wagtail/.",
         'testing': testing_extras,
         'docs': documentation_extras
     },
-    python_requires='~=3.6, ~=3.7, ~=3.8',
+    python_requires='>=3.6, <3.9',
     entry_points="""
             [console_scripts]
             wagtail=wagtail.bin.wagtail:main


### PR DESCRIPTION
I was recently bitten by the fact that you *can* install wagtail 2.10 in Python 3.5, it just breaks when you try to use it.

This change adds the `python_requires` argument in setup.py to properly specify the compatible versions for the pip package manager. It might be a good idea to also update previous wagtails (2.9 at least) to also include this with their respective python supports

See: https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires
