### PR TITLE
Add support for bulk sending notification emails

### DIFF
--- a/docs/reference/settings.rst
+++ b/docs/reference/settings.rst
@@ -236,6 +236,12 @@ Notification emails are sent in `text/plain` by default, change this to use HTML
 
 Notification emails are sent to moderators and superusers by default. You can change this to exclude superusers and only notify moderators.
 
+.. code-block:: python
+
+  WAGTAILADMIN_NOTIFICATION_BULK_SEND_THRESHOLD = 30
+
+Wagtail will usually send notifications one-by-one so that the notifications can be personalised with a user's name and language which can be slow on sites with lots of recipients. This setting sets a threshold at which Wagtail will send these emails in bulk instead. Emails sent in bulk will not be personalised or translated.
+
 .. _update_notifications:
 
 Wagtail update notifications

--- a/wagtail/admin/templates/wagtailadmin/notifications/base.html
+++ b/wagtail/admin/templates/wagtailadmin/notifications/base.html
@@ -108,12 +108,14 @@ body[yahoo] .text {
                 {% endblock %}
 
                 {% block greeting %}
+                {% if user %}
                 <p>{% blocktrans with username=user.get_short_name|default:user.get_username %}Hello {{ username }},{% endblocktrans %}</p>
+                {% endif %}
                 {% endblock %}
 
                 {% block content %}
                 {% endblock %}
-                
+
                 <div style="font-size: 10px; margin-top: 20px;">
                   {% block preferences %}
                     {% trans "Edit your notification preferences here:" %} <a href="{{ settings.BASE_URL }}{% url 'wagtailadmin_account_notification_preferences' %}">{{ settings.BASE_URL }}{% url 'wagtailadmin_account_notification_preferences' %}</a>

--- a/wagtail/admin/templates/wagtailadmin/notifications/base.txt
+++ b/wagtail/admin/templates/wagtailadmin/notifications/base.txt
@@ -1,7 +1,9 @@
 {% load i18n %}
 
 {% block greeting %}
+{% if user %}
 {% blocktrans with username=user.get_short_name|default:user.get_username %}Hello {{ username }},{% endblocktrans %}
+{% endif %}
 {% endblock %}
 
 {% block content %}

--- a/wagtail/admin/tests/test_mail.py
+++ b/wagtail/admin/tests/test_mail.py
@@ -1,0 +1,70 @@
+from django.contrib.auth.models import Group
+from django.core import mail
+from django.test import TestCase, override_settings
+
+from wagtail.admin.mail import EmailNotificationMixin, Notifier
+from wagtail.core.models import Page
+from wagtail.tests.testapp.models import SimplePage
+from wagtail.tests.utils import WagtailTestUtils
+
+
+class TestNotifier(EmailNotificationMixin, Notifier):
+    notification = "approved"
+
+    def __init__(self, *args, **kwargs):
+        self.recipients = kwargs.pop("recipients")
+
+    def can_handle(self, instance, **kwargs):
+        return True
+
+    def get_recipient_users(self, instance, **kwargs):
+        return self.recipients
+
+    def get_context(self, instance, **kwargs):
+        return {
+            "page": instance
+        }
+
+    def get_template_base_prefix(self, instance, **kwargs):
+        return "task_state_"
+
+
+class TestEmailNotificationMixin(TestCase, WagtailTestUtils):
+    def setUp(self):
+        self.login()
+
+        # Create 5 editors
+        self.editor_users = []
+        editors = Group.objects.get(name='Editors')
+        for i in range(5):
+            editor = self.create_user(
+                username='editor{}'.format(i),
+                email='editor{}@email.com'.format(i),
+                password='password',
+            )
+            self.editor_users.append(editor)
+            editors.user_set.add(editor)
+
+        root_page = Page.objects.get(id=2)
+        self.page = SimplePage(
+            title="Hello world!",
+            slug='hello-world',
+            content="hello",
+            live=False,
+            has_unpublished_changes=True,
+        )
+
+        root_page.add_child(instance=self.page)
+
+    def test_non_bulk_emails(self):
+        notifier = TestNotifier(recipients=self.editor_users)
+        notifier(instance=self.page)
+
+        self.assertEqual(len(mail.outbox), 5)
+
+    @override_settings(WAGTAILADMIN_NOTIFICATION_BULK_SEND_THRESHOLD=2)
+    def test_bulk_emails(self):
+        notifier = TestNotifier(recipients=self.editor_users)
+        notifier(instance=self.page)
+
+        self.assertEqual(len(mail.outbox), 1)


### PR DESCRIPTION
On sites with lots of admin notification recipients, submitted a page for moderation/in to a workflow can be quite slow as each emails is localised and sent individually.

This PR adds a new setting which sets a threshold at which Wagtail will bulk send these emails (in the BCC field) instead.

As we're sending a single email to multiple users, the emails can't be personalised or translated, so the default for this settings is set quite high (30 recipients) so it shouldn't affect sites that aren't already seeing this issue - but I'm not sure if this is something we need to think more carefully about, or turn it off altogether by default.

Appreciate if this is not the right solution to the problem - if it's too specific an issue I could separate it out in to a package and update Wagtail core to allow specifying a custom notifier, or provide a set of built-in notifiers adjustable with a setting.

* Do the tests still pass? Yes
* Does the code comply with the style guide? Yes
* For Python changes: Have you added tests to cover the new/fixed behaviour? Yes
* For new features: Has the documentation been updated accordingly? Yes
