### PR TITLE
Make snippets action menu hookable

### DIFF
--- a/docs/reference/hooks.rst
+++ b/docs/reference/hooks.rst
@@ -1129,6 +1129,85 @@ Hooks for working with registered Snippets.
 
           return HttpResponse(f"{total} snippets have been deleted", content_type="text/plain")
 
+.. _register_snippet_action_menu_item:
+
+``register_snippet_action_menu_item``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+  Add an item to the popup menu of actions on the snippet creation and edit views.
+  The callable passed to this hook must return an instance of
+  ``wagtail.snippets.action_menu.ActionMenuItem``. The following attributes and
+  methods are available to be overridden on subclasses of ``ActionMenuItem``:
+
+  :order: an integer (default 100) which determines the item's position in the menu. Can also be passed as a keyword argument to the object constructor. The lowest-numbered item in this sequence will be selected as the default menu item; as standard, this is "Save draft" (which has an ``order`` of 0).
+  :label: the displayed text of the menu item
+  :get_url: a method which returns a URL for the menu item to link to; by default, returns ``None`` which causes the menu item to behave as a form submit button instead
+  :name: value of the ``name`` attribute of the submit button if no URL is specified
+  :icon_name: icon to display against the menu item
+  :classname: a ``class`` attribute value to add to the button element
+  :is_shown: a method which returns a boolean indicating whether the menu item should be shown; by default, true except when editing a locked page
+  :template: the path to a template to render to produce the menu item HTML
+  :get_context: a method that returns a context dictionary to pass to the template
+  :render_html: a method that returns the menu item HTML; by default, renders ``template`` with the context returned from ``get_context``
+  :Media: an inner class defining Javascript and CSS to import when this menu item is shown - see `Django form media <https://docs.djangoproject.com/en/stable/topics/forms/media/>`_
+
+  The ``get_url``, ``is_shown``, ``get_context`` and ``render_html`` methods all accept a request object and a context dictionary containing the following fields:
+
+  :view: name of the current view: ``'create'`` or ``'edit'``
+  :model: The snippets model class
+  :instance: For ``view`` = ``'edit'``, the instance being edited
+
+  .. code-block:: python
+
+    from wagtail.core import hooks
+    from wagtail.snippets.action_menu import ActionMenuItem
+
+    class GuacamoleMenuItem(ActionMenuItem):
+        name = 'action-guacamole'
+        label = "Guacamole"
+
+        def get_url(self, request, context):
+            return "https://www.youtube.com/watch?v=dNJdJIwCF_Y"
+
+
+    @hooks.register('register_snippet_action_menu_item')
+    def register_guacamole_menu_item():
+        return GuacamoleMenuItem(order=10)
+
+.. _construct_snippet_action_menu:
+
+``construct_snippet_action_menu``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+  Modify the final list of action menu items on the snippet creation and edit views.
+  The callable passed to this hook receives a list of ``ActionMenuItem`` objects, a
+  request object and a context dictionary as per ``register_snippet_action_menu_item``,
+  and should modify the list of menu items in-place.
+
+  .. code-block:: python
+
+    @hooks.register('construct_snippet_action_menu')
+    def remove_delete_option(menu_items, request, context):
+        menu_items[:] = [item for item in menu_items if item.name != 'delete']
+
+
+  The ``construct_snippet_action_menu`` hook is called after the menu items have been
+  sorted by their order attributes, and so setting a menu item's order will have no
+  effect at this point. Instead, items can be reordered by changing their position in
+  the list, with the first item being selected as the default action. For example, to
+  change the default action to Delete:
+
+  .. code-block:: python
+
+    @hooks.register('construct_snippet_action_menu')
+    def make_delete_default_action(menu_items, request, context):
+        for (index, item) in enumerate(menu_items):
+            if item.name == 'delete':
+                # move to top of list
+                menu_items.pop(index)
+                menu_items.insert(0, item)
+                break
+
 .. _register_snippet_listing_buttons:
 
 ``register_snippet_listing_buttons``

--- a/wagtail/snippets/action_menu.py
+++ b/wagtail/snippets/action_menu.py
@@ -1,0 +1,150 @@
+"""Handles rendering of the list of actions in the footer of the snippet create/edit views."""
+
+from functools import lru_cache
+
+from django.contrib.admin.utils import quote
+from django.forms import Media, MediaDefiningClass
+from django.template.loader import render_to_string
+from django.urls import reverse
+from django.utils.functional import cached_property
+from django.utils.translation import gettext_lazy as _
+
+from wagtail.core import hooks
+from wagtail.snippets.permissions import get_permission_name
+
+
+class ActionMenuItem(metaclass=MediaDefiningClass):
+    """Defines an item in the actions drop-up on the snippet creation/edit view"""
+    order = 100  # default order index if one is not specified on init
+    template = 'wagtailsnippets/snippets/action_menu/menu_item.html'
+
+    label = ''
+    name = None
+    classname = ''
+    icon_name = ''
+
+    def __init__(self, order=None):
+        if order is not None:
+            self.order = order
+
+    def is_shown(self, request, context):
+        """
+        Whether this action should be shown on this request; permission checks etc should go here.
+
+        request = the current request object
+
+        context = dictionary containing at least:
+            'view' = 'create' or 'edit'
+            'model' = the model of the snippet being created/edited
+            'instance' (if view = 'edit') = the snippet being edited
+        """
+        return True
+
+    def get_context(self, request, parent_context):
+        """Defines context for the template, overridable to use more data"""
+        context = parent_context.copy()
+        context.update({
+            'label': self.label,
+            'url': self.get_url(request, context),
+            'name': self.name,
+            'classname': self.classname,
+            'icon_name': self.icon_name,
+        })
+        return context
+
+    def get_url(self, request, context):
+        return None
+
+    def render_html(self, request, parent_context):
+        context = self.get_context(request, parent_context)
+        return render_to_string(self.template, context, request=request)
+
+
+class DeleteMenuItem(ActionMenuItem):
+    name = 'action-delete'
+    label = _("Delete")
+    icon_name = 'bin'
+    classname = 'action-secondary'
+
+    def is_shown(self, request, context):
+        delete_permission = get_permission_name('delete', context['model'])
+
+        return (
+            context['view'] == 'edit'
+            and request.user.has_perm(delete_permission)
+        )
+
+    def get_url(self, request, context):
+        return reverse('wagtailsnippets:delete', args=[
+            context['model']._meta.app_label,
+            context['model']._meta.model_name,
+            quote(context['instance'].pk)
+        ])
+
+
+class SaveMenuItem(ActionMenuItem):
+    name = 'action-save'
+    label = _("Save")
+    template = 'wagtailsnippets/snippets/action_menu/save.html'
+
+
+@lru_cache(maxsize=None)
+def get_base_snippet_action_menu_items(model):
+    """
+    Retrieve the global list of menu items for the snippet action menu,
+    which may then be customised on a per-request basis
+    """
+    menu_items = [
+        SaveMenuItem(order=0),
+        DeleteMenuItem(order=10),
+    ]
+
+    for hook in hooks.get_hooks('register_snippet_action_menu_item'):
+        menu_items.append(hook(model))
+
+    return menu_items
+
+
+class SnippetActionMenu:
+    template = 'wagtailsnippets/snippets/action_menu/menu.html'
+
+    def __init__(self, request, **kwargs):
+        self.request = request
+        self.context = kwargs
+        self.menu_items = []
+
+        if 'instance' in self.context:
+            self.context['model'] = self.context['instance'].__class__
+
+        self.menu_items.extend([
+            menu_item
+            for menu_item in get_base_snippet_action_menu_items(self.context['model'])
+            if menu_item.is_shown(self.request, self.context)
+        ])
+
+        self.menu_items.sort(key=lambda item: item.order)
+
+        for hook in hooks.get_hooks('construct_snippet_action_menu'):
+            hook(self.menu_items, self.request, self.context)
+
+        try:
+            self.default_item = self.menu_items.pop(0)
+        except IndexError:
+            self.default_item = None
+
+    def render_html(self):
+        return render_to_string(self.template, {
+            'default_menu_item': self.default_item.render_html(self.request, self.context),
+            'show_menu': bool(self.menu_items),
+            'rendered_menu_items': [
+                menu_item.render_html(self.request, self.context)
+                for menu_item in self.menu_items
+            ],
+        }, request=self.request)
+
+    @cached_property
+    def media(self):
+        media = Media()
+        for item in self.menu_items:
+            media += item.media
+        return media

--- a/wagtail/snippets/templates/wagtailsnippets/snippets/action_menu/menu.html
+++ b/wagtail/snippets/templates/wagtailsnippets/snippets/action_menu/menu.html
@@ -1,0 +1,14 @@
+{% load wagtailadmin_tags %}
+{% if default_menu_item %}
+    {{ default_menu_item }}
+{% endif %}
+{% if show_menu %}
+    <div class="dropdown-toggle">{% icon name="arrow-up" %}</div>
+    <ul>
+        {% for item in rendered_menu_items %}
+            <li>
+                 {{ item }}
+            </li>
+        {% endfor %}
+    </ul>
+{% endif %}

--- a/wagtail/snippets/templates/wagtailsnippets/snippets/action_menu/menu_item.html
+++ b/wagtail/snippets/templates/wagtailsnippets/snippets/action_menu/menu_item.html
@@ -1,0 +1,6 @@
+{% load wagtailadmin_tags %}
+{% if url %}
+    <a class="button{% if classname %} {{ classname }}{% endif %}" href="{{ url }}">{% if icon_name %}{% icon name=icon_name %}{% endif %}{{ label }}</a>
+{% else %}
+    <button type="submit" name="{{ name }}" value="{{ label }}" class="button{% if classname %} {{ classname }}{% endif %}">{% if icon_name %}{% icon name=icon_name %}{% endif %}{{ label }}</button>
+{% endif %}

--- a/wagtail/snippets/templates/wagtailsnippets/snippets/action_menu/save.html
+++ b/wagtail/snippets/templates/wagtailsnippets/snippets/action_menu/save.html
@@ -1,0 +1,5 @@
+{% load i18n wagtailadmin_tags %}
+<button type="submit" class="button action-save button-longrunning" data-clicked-text="{% trans 'Saving…' %}">
+    {% icon name="download-alt" class_name="button-longrunning__icon" %}
+    {% icon name="spinner" %}<em>{% trans 'Save' %}</em>
+</button>

--- a/wagtail/snippets/templates/wagtailsnippets/snippets/create.html
+++ b/wagtail/snippets/templates/wagtailsnippets/snippets/create.html
@@ -10,15 +10,15 @@
         {{ edit_handler.render_form_content }}
 
         <footer>
-            <ul>
-                <li class="actions">
-                    <div class="dropdown dropup dropdown-button match-width">
-                        <button type="submit" class="button action-save button-longrunning" data-clicked-text="{% trans 'Saving…' %}">
-                            {% icon name="spinner" %}<em>{% trans 'Save' %}</em>
-                        </button>
-                    </div>
-                </li>
-            </ul>
+            <nav aria-label="{% trans 'Actions' %}">
+                <ul>
+                    <li class="actions actions--primary">
+                        <div class="dropdown dropup dropdown-button match-width">
+                            {{ action_menu.render_html }}
+                        </div>
+                    </li>
+                </ul>
+            </nav>
         </footer>
     </form>
 

--- a/wagtail/snippets/templates/wagtailsnippets/snippets/edit.html
+++ b/wagtail/snippets/templates/wagtailsnippets/snippets/edit.html
@@ -14,19 +14,13 @@
                 {{ edit_handler.render_form_content }}
                 <footer>
                     <nav aria-label="{% trans 'Actions' %}">
-                    <ul>
-                        <li class="actions">
-                            <div class="dropdown dropup dropdown-button match-width">
-                                <button type="submit" class="button action-save button-longrunning" data-clicked-text="{% trans 'Saving…' %}">
-                                    {% icon name="spinner" %}<em>{% trans 'Save' %}</em>
-                                </button>
-                                <div class="dropdown-toggle">{% icon name="arrow-up" %}</div>
-                                <ul>
-                                    <li><a href="{% url 'wagtailsnippets:delete' model_opts.app_label model_opts.model_name instance.pk|admin_urlquote %}" class="shortcut">{% trans "Delete" %}</a></li>
-                                </ul>
-                            </div>
-                        </li>
-                    </ul>
+                        <ul>
+                            <li class="actions actions--primary">
+                                <div class="dropdown dropup dropdown-button match-width">
+                                    {{ action_menu.render_html }}
+                                </div>
+                            </li>
+                        </ul>
                     </nav>
                 </footer>
             </form>

--- a/wagtail/snippets/views/snippets.py
+++ b/wagtail/snippets/views/snippets.py
@@ -18,6 +18,7 @@ from wagtail.admin.forms.search import SearchForm
 from wagtail.core import hooks
 from wagtail.search.backends import get_search_backend
 from wagtail.search.index import class_is_indexed
+from wagtail.snippets.action_menu import SnippetActionMenu
 from wagtail.snippets.models import get_snippet_models
 from wagtail.snippets.permissions import get_permission_name, user_can_edit_snippet_type
 
@@ -182,6 +183,7 @@ def create(request, app_label, model_name):
         'model_opts': model._meta,
         'edit_handler': edit_handler,
         'form': form,
+        'action_menu': SnippetActionMenu(request, view='create', model=model),
     })
 
 
@@ -242,6 +244,7 @@ def edit(request, app_label, model_name, pk):
         'instance': instance,
         'edit_handler': edit_handler,
         'form': form,
+        'action_menu': SnippetActionMenu(request, view='edit', instance=instance),
     })
 
 


### PR DESCRIPTION
This PR copies all the action menu code from pages into snippets. This makes the UI look more consistent but also adds the ability to make buttons on snippet edit hookable as well.