### PR TITLE
Adds `ModelAdmin.prepopulated_fields` feature from django.admin - with tests

### DIFF
--- a/docs/reference/contrib/modeladmin/create_edit_delete_views.rst
+++ b/docs/reference/contrib/modeladmin/create_edit_delete_views.rst
@@ -199,6 +199,31 @@ excluded from the form. This is particularly useful when registering ModelAdmin
 classes for models from third-party apps, where defining panel configurations
 on the Model itself is more complicated.
 
+.. _modeladmin_prepopulated_fields:
+
+-----------------------------------
+``ModelAdmin.prepopulated_fields``
+-----------------------------------
+
+**Expected value**: A dict mapping prepopulated fields to a tuple of fields to
+prepopulate from
+
+When using CreateView or EditView to create or update model instances, the
+fields corresponding to the keys in the dict are prepopulated using the fields
+in the corresponding tuple. The main use for this functionality is to
+automatically generate the value for SlugField fields from one or more other
+fields. The generated value is produced by concatenating the values of the
+source fields, and then by transforming that result into a valid slug (e.g.
+substituting dashes for spaces; lowercasing ASCII letters; and removing various
+English stop words such as ‘a’, ‘an’, ‘as’, and similar).
+
+Prepopulated fields aren’t modified by JavaScript after a value has been saved.
+It’s usually undesired that slugs change (which would cause an object’s URL to
+change if the slug is used in it).
+
+prepopulated_fields doesn’t accept DateTimeField, ForeignKey, OneToOneField,
+and ManyToManyField fields.
+
 
 -----------------------------------
 ``ModelAdmin.get_edit_handler()``

--- a/docs/reference/contrib/modeladmin/index.rst
+++ b/docs/reference/contrib/modeladmin/index.rst
@@ -87,6 +87,7 @@ to create, view, and edit ``Book`` entries.
 
     class Book(models.Model):
         title = models.CharField(max_length=255)
+        slug = models.SlugField()
         author = models.CharField(max_length=255)
         cover_photo = models.ForeignKey(
             'wagtailimages.Image',
@@ -128,6 +129,7 @@ to create, view, and edit ``Book`` entries.
         list_display = ('title', 'author')
         list_filter = ('author',)
         search_fields = ('title', 'author')
+        prepopulated_fields = {'slug': ('title',)} # Prepopulate the slug field using data from the title field
 
     # Now you just need to register your customised ModelAdmin class with Wagtail
     modeladmin_register(BookAdmin)

--- a/wagtail/contrib/modeladmin/options.py
+++ b/wagtail/contrib/modeladmin/options.py
@@ -85,6 +85,7 @@ class ModelAdmin(WagtailRegisterable):
     search_fields = None
     ordering = None
     parent = None
+    prepopulated_fields = {}
     index_view_class = IndexView
     create_view_class = CreateView
     edit_view_class = EditView
@@ -291,6 +292,12 @@ class ModelAdmin(WagtailRegisterable):
         Must always return a dictionary.
         """
         return {}
+
+    def get_prepopulated_fields(self, request):
+        """
+        Returns a sequence specifying custom prepopulated fields slugs on Create/Edit pages.
+        """
+        return self.prepopulated_fields or {}    
 
     def get_form_fields_exclude(self, request):
         """

--- a/wagtail/contrib/modeladmin/options.py
+++ b/wagtail/contrib/modeladmin/options.py
@@ -297,7 +297,7 @@ class ModelAdmin(WagtailRegisterable):
         """
         Returns a sequence specifying custom prepopulated fields slugs on Create/Edit pages.
         """
-        return self.prepopulated_fields or {}    
+        return self.prepopulated_fields or {}
 
     def get_form_fields_exclude(self, request):
         """

--- a/wagtail/contrib/modeladmin/static_src/wagtailmodeladmin/js/prepopulate.js
+++ b/wagtail/contrib/modeladmin/static_src/wagtailmodeladmin/js/prepopulate.js
@@ -1,0 +1,55 @@
+/*global URLify*/
+(function($) {
+    'use strict';
+    $.fn.prepopulate = function(dependencies, maxLength, allowUnicode) {
+        /*
+            Depends on urlify.js
+            Populates a selected field with the values of the dependent fields,
+            URLifies and shortens the string.
+            dependencies - array of dependent fields ids
+            maxLength - maximum length of the URLify'd string
+            allowUnicode - Unicode support of the URLify'd string
+        */
+        return this.each(function() {
+            var prepopulatedField = $(this);
+
+            var populate = function() {
+                // Bail if the field's value has been changed by the user
+                if (prepopulatedField.data('_changed')) {
+                    return;
+                }
+
+                var values = [];
+                $.each(dependencies, function(i, field) {
+                    field = $(field);
+                    if (field.val().length > 0) {
+                        values.push(field.val());
+                    }
+                });
+                prepopulatedField.val(URLify(values.join(' '), maxLength, allowUnicode));
+            };
+
+            prepopulatedField.data('_changed', false);
+            prepopulatedField.on('change', function() {
+                prepopulatedField.data('_changed', true);
+            });
+
+            if (!prepopulatedField.val()) {
+                $(dependencies.join(',')).on('keyup change focus', populate);
+            }
+        });
+    };
+})(jQuery);
+
+(function ($) {
+    'use strict';
+    $(function () {
+        var fields = $('#modeladmin-prepopulated-fields-constants').data('prepopulatedFields');
+        $.each(fields, function (index, field) {
+            $('.empty-form .form-row .field-' + field.name + ', .empty-form.form-row .field-' + field.name).addClass('prepopulated_field');
+            $(field.id).data('dependency_list', field.dependency_list).prepopulate(
+                field.dependency_ids, field.maxLength, field.allowUnicode
+            );
+        });
+    });
+})(jQuery);

--- a/wagtail/contrib/modeladmin/templates/modeladmin/create.html
+++ b/wagtail/contrib/modeladmin/templates/modeladmin/create.html
@@ -1,5 +1,5 @@
 {% extends "wagtailadmin/base.html" %}
-{% load i18n wagtailadmin_tags %}
+{% load i18n modeladmin_tags modeladmin_tags %}
 
 {% block titletag %}{{ view.get_meta_title }}{% endblock %}
 
@@ -20,6 +20,7 @@
     {{ edit_handler.html_declarations }}
 
     {{ view.media.js }}
+    {% prepopulated_slugs %}
 {% endblock %}
 
 {% block content %}

--- a/wagtail/contrib/modeladmin/templates/modeladmin/create.html
+++ b/wagtail/contrib/modeladmin/templates/modeladmin/create.html
@@ -1,5 +1,5 @@
 {% extends "wagtailadmin/base.html" %}
-{% load i18n modeladmin_tags modeladmin_tags %}
+{% load i18n wagtailadmin_tags modeladmin_tags %}
 
 {% block titletag %}{{ view.get_meta_title }}{% endblock %}
 

--- a/wagtail/contrib/modeladmin/templates/modeladmin/prepopulated_slugs.html
+++ b/wagtail/contrib/modeladmin/templates/modeladmin/prepopulated_slugs.html
@@ -1,0 +1,6 @@
+{% load l10n static %}
+<script type="text/javascript"
+        id="modeladmin-prepopulated-fields-constants"
+        src="{% static "wagtailmodeladmin/js/prepopulate.js" %}"
+        data-prepopulated-fields="{{ prepopulated_fields_json }}">
+</script>

--- a/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
+++ b/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
@@ -272,6 +272,12 @@ class TestCreateView(TestCase, WagtailTestUtils):
 
             mock_form_clean.assert_called_once()
 
+    def test_in_context(self):
+        response = self.get()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('data-prepopulated-fields="[{&quot;id&quot;: &quot;#id_title&quot;, &quot;name&quot;: &quot;title&quot;, &quot;dependency_ids&quot;: [&quot;#id_author&quot;], &quot;dependency_list&quot;: [&quot;author&quot;], &quot;maxLength&quot;: 255, &quot;allowUnicode&quot;: false}]"', response.content.decode('UTF-8'))
+
 
 class TestInspectView(TestCase, WagtailTestUtils):
     fixtures = ['modeladmintest_test.json']

--- a/wagtail/contrib/modeladmin/views.py
+++ b/wagtail/contrib/modeladmin/views.py
@@ -147,10 +147,16 @@ class ModelFormView(WMABaseView, FormView):
     def get_context_data(self, form=None, **kwargs):
         if form is None:
             form = self.get_form()
+        
+        prepopulated_fields = [
+            {'field': form[field_name], 'dependencies': [form[f] for f in dependencies]}
+            for field_name, dependencies in self.model_admin.prepopulated_fields.items()
+        ]
         context = {
             'is_multipart': form.is_multipart(),
             'edit_handler': self.edit_handler,
             'form': form,
+            'prepopulated_fields': prepopulated_fields,
         }
         context.update(kwargs)
         return super().get_context_data(**context)

--- a/wagtail/tests/modeladmintest/wagtail_hooks.py
+++ b/wagtail/tests/modeladmintest/wagtail_hooks.py
@@ -71,6 +71,7 @@ class BookModelAdmin(ThumbnailMixin, ModelAdmin):
     inspect_view_fields_exclude = ('title', )
     thumb_image_field_name = 'cover_image'
     search_handler_class = WagtailBackendSearchHandler
+    prepopulated_fields = {'title': ('author',)}
 
     def get_extra_attrs_for_row(self, obj, context):
         return {


### PR DESCRIPTION
Thanks for contributing to Wagtail! 🎉

Before submitting, please review the contributor guidelines <https://docs.wagtail.io/en/latest/contributing/index.html> and check the following:

* Do the tests still pass? (https://docs.wagtail.io/en/latest/contributing/developing.html#testing)
* Does the code comply with the style guide? (Run `make lint` from the Wagtail root)
* For Python changes: Have you added tests to cover the new/fixed behaviour?
* For front-end changes: Did you test on all of Wagtail’s supported browsers? **Please list the exact versions you tested**.
* For new features: Has the documentation been updated accordingly?

Hi,

I've taken a crack at adding tests for [#5522](https://github.com/wagtail/wagtail/pull/5522). Pretty new to python, wagtail and django, so let me know if I've missed anything or done anything daft.

I've added a small bit of documentation. There's more documentation on it in the django docs but I wasn't really sure where to wedge it in in the wagtail docs. Let me know where and I'll copy paste it somewhere. 
