### PR TITLE
deleted the div that conatined the actionbutton class in Model Admin template

### DIFF
--- a/wagtail/contrib/modeladmin/templates/modeladmin/index.html
+++ b/wagtail/contrib/modeladmin/templates/modeladmin/index.html
@@ -26,9 +26,7 @@
                 {% block header_extra %}
                     <div class="right">
                         {% if user_can_create %}
-                            <div class="actionbutton">
                                 {% include 'modeladmin/includes/button.html' with button=view.button_helper.add_button %}
-                            </div>
                         {% endif %}
                         {% if view.list_export %}
                             <div class="dropdown dropdown-button match-width col">


### PR DESCRIPTION
Deleted the div that conatined the actionbutton class in the Model Admin template

It was creating styling issues in the Wagtail admin when I was using wagtail hooks to expose a model to the admin for moderatioon and export.

Before (w/ actionbutton)

![Screenshot_2020-09-17 Wagtail - Village Stories](https://user-images.githubusercontent.com/25583369/93438547-5c5bfe80-f8c5-11ea-8b88-2903e6765297.png)

After (without the div with actionbutton class)

![Screenshot_2020-09-17 Wagtail - Village Stories(1)](https://user-images.githubusercontent.com/25583369/93438642-80b7db00-f8c5-11ea-8245-9ac6081946a6.png)

I had a look at adding the same class to the 

` {% if view.list_export %}` 

however it required additional styling to create space with the button above. I figured this solution would be simplest and most effective.


