### PR TITLE
Support SVG icons in ModelAdmin menu items

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -15,6 +15,7 @@ Changelog
  * Specify minimum Python version in setup.py (Vince Salvino)
  * Show user's full name in report views (Matt Westcott)
  * Improve Wagtail admin page load performance by caching SVG icons sprite in localstorage (Coen van der Kamp)
+ * Support SVG icons in ModelAdmin menu items (Scott Cranfill)
  * Fix: Make page-level actions accessible to keyboard users in page listing tables (Jesse Menn)
  * Fix: `WAGTAILFRONTENDCACHE_LANGUAGES` was being interpreted incorrectly. It now accepts a list of strings, as documented (Karl Hobley)
  * Fix: Update oEmbed endpoints to use https where available (Matt Westcott)

--- a/docs/reference/contrib/modeladmin/menu_item.rst
+++ b/docs/reference/contrib/modeladmin/menu_item.rst
@@ -39,7 +39,7 @@ page-type models, and ``'snippet'`` for others.
 If you're using a ``ModelAdminGroup`` class to group together several
 ``ModelAdmin`` classes in their own sub-menu, and want to change the menu item
 used to represent the group, you should override the ``menu_icon`` attribute on
-your ``ModelAdminGroup`` class (``'icon-folder-open-inverse'`` is the default).
+your ``ModelAdminGroup`` class (``'folder-open-inverse'`` is the default).
 
 .. _modeladmin_menu_order:
 

--- a/docs/releases/2.11.rst
+++ b/docs/releases/2.11.rst
@@ -24,6 +24,7 @@ Other features
  * Add support for hierarchical/nested Collections (Robert Rollins)
  * Show user's full name in report views (Matt Westcott)
  * Improve Wagtail admin page load performance by caching SVG icons sprite in localstorage (Coen van der Kamp)
+ * Support SVG icons in ModelAdmin menu items (Scott Cranfill)
 
 
 Bug fixes

--- a/wagtail/contrib/modeladmin/menus.py
+++ b/wagtail/contrib/modeladmin/menus.py
@@ -9,10 +9,16 @@ class ModelAdminMenuItem(MenuItem):
     def __init__(self, model_admin, order):
         self.model_admin = model_admin
         url = model_admin.url_helper.index_url
-        classnames = 'icon icon-%s' % model_admin.get_menu_icon()
+        menu_icon = model_admin.get_menu_icon()
+        if menu_icon[:3] == 'fa-':
+            classnames = 'icon icon-%s' % menu_icon
+            icon_name = None
+        else:
+            classnames = ''
+            icon_name = menu_icon
         super().__init__(
             label=model_admin.get_menu_label(), url=url,
-            classnames=classnames, order=order)
+            classnames=classnames, icon_name=icon_name, order=order)
 
     def is_shown(self, request):
         return self.model_admin.permission_helper.user_can_list(request.user)
@@ -25,10 +31,16 @@ class GroupMenuItem(SubmenuMenuItem):
     pages
     """
     def __init__(self, modeladmingroup, order, menu):
-        classnames = 'icon icon-%s' % modeladmingroup.get_menu_icon()
+        menu_icon = modeladmingroup.get_menu_icon()
+        if menu_icon[:3] == 'fa-':
+            classnames = 'icon icon-%s' % menu_icon
+            icon_name = None
+        else:
+            classnames = ''
+            icon_name = menu_icon
         super().__init__(
             label=modeladmingroup.get_menu_label(), menu=menu,
-            classnames=classnames, order=order, )
+            classnames=classnames, icon_name=icon_name, order=order, )
 
     def is_shown(self, request):
         """

--- a/wagtail/contrib/modeladmin/options.py
+++ b/wagtail/contrib/modeladmin/options.py
@@ -599,7 +599,7 @@ class ModelAdminGroup(WagtailRegisterable):
         return ''
 
     def get_menu_icon(self):
-        return self.menu_icon or 'icon-folder-open-inverse'
+        return self.menu_icon or 'folder-open-inverse'
 
     def get_menu_order(self):
         return self.menu_order or 999


### PR DESCRIPTION
Fixes #6379

Support is already present in the MenuItem and SubmenuMenuItem classes that ModelAdminMenuItem and GroupMenuItem subclass (and their respective templates), but those two subclasses needed to be updated to pass the new `icon_name` kwarg.

This commit retains support for the popular wagtail-fontawesome package by checking for `menu_icon` properties beginning with `fa-`, and following the same old `classname` logic as before. If that's not found, it sets the `icon_name` kwarg which triggers the SVG icon rendering in the template. Curious if this rubs anyone the wrong way.

---

- [x] Do the tests still pass? (https://docs.wagtail.io/en/latest/contributing/developing.html#testing)
- [x] Does the code comply with the style guide? (Run `make lint` from the Wagtail root)
- [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
- ~~For front-end changes: Did you test on all of Wagtail’s supported browsers? **Please list the exact versions you tested**.~~
- ~~For new features: Has the documentation been updated accordingly?~~
