### PR TITLE
Update urlify.js to retain stopwords and fix handling of Turkish İ

### DIFF
--- a/wagtail/admin/static_src/wagtailadmin/js/page-editor.test.js
+++ b/wagtail/admin/static_src/wagtailadmin/js/page-editor.test.js
@@ -13,10 +13,10 @@ describe('page-editor tests', () => {
       /* true triggers to use django's urlify */
       expect(cleanForSlug('Before', true)).toBe('before');
       expect(cleanForSlug('The', true)).toBe('the');
-      expect(cleanForSlug('Before the sun rises', true)).toBe('sun-rises');
+      expect(cleanForSlug('Before the sun rises', true)).toBe('before-the-sun-rises');
       expect(cleanForSlug('ON', true)).toBe('on');
-      expect(cleanForSlug('ON this day in november', true)).toBe('day-november');
-      expect(cleanForSlug('This & That', true)).toBe('this--that');
+      expect(cleanForSlug('ON this day in november', true)).toBe('on-this-day-in-november');
+      expect(cleanForSlug('This & That', true)).toBe('this-that');
     });
 
     it('should return a correct slug which is escaped by urlify', () => {

--- a/wagtail/admin/static_src/wagtailadmin/js/vendor/urlify.js
+++ b/wagtail/admin/static_src/wagtailadmin/js/vendor/urlify.js
@@ -128,7 +128,7 @@
 
     var Downcoder = {
         'Initialize': function() {
-            if (Downcoder.map) {  // already made
+            if (Downcoder.map) { // already made
                 return;
             }
             Downcoder.map = {};
@@ -165,30 +165,32 @@
             s = downcode(s);
         }
         var hasUnicodeChars = /[^\u0000-\u007f]/.test(s);
-        // Javascript RegExp does not identify word boundaries correctly
-        // when dealing with unicode characters. If the string does not
-        // contain unicode chars, it's safe to use the regular expression.
+        // Remove English words only if the string contains ASCII (English)
+        // characters.
         if (!hasUnicodeChars) {
-          var removelist = [
-            "a", "an", "as", "at", "before", "but", "by", "for", "from", "is",
-            "in", "into", "like", "of", "off", "on", "onto", "per", "since",
-            "than", "the", "this", "that", "to", "up", "via", "with"
-          ];
-          var r = new RegExp('\\b(' + removelist.join('|') + ')\\b', 'gi');
-          s = s.replace(r, '');
+            var removeList = [
+                "a", "an", "as", "at", "before", "but", "by", "for", "from",
+                "is", "in", "into", "like", "of", "off", "on", "onto", "per",
+                "since", "than", "the", "this", "that", "to", "up", "via",
+                "with"
+            ];
+            var r = new RegExp('\\b(' + removeList.join('|') + ')\\b', 'gi');
+            s = s.replace(r, '');
         }
+        s = s.toLowerCase(); // convert to lowercase
         // if downcode doesn't hit, the char will be stripped here
         if (allowUnicode) {
             // Keep Unicode letters including both lowercase and uppercase
             // characters, whitespace, and dash; remove other characters.
             s = XRegExp.replace(s, XRegExp('[^-_\\p{L}\\p{N}\\s]', 'g'), '');
         } else {
-            s = s.replace(/[^-\w\s]/g, '');  // remove unneeded chars
+            s = s.replace(/[^-\w\s]/g, ''); // remove unneeded chars
         }
-        s = s.replace(/^\s+|\s+$/g, '');   // trim leading/trailing spaces
-        s = s.replace(/[-\s]+/g, '-');     // convert spaces to hyphens
-        s = s.toLowerCase();               // convert to lowercase
-        return s.substring(0, num_chars);  // trim to first num_chars chars
+        s = s.replace(/^\s+|\s+$/g, ''); // trim leading/trailing spaces
+        s = s.replace(/[-\s]+/g, '-'); // convert spaces to hyphens
+        s = s.substring(0, num_chars); // trim to first num_chars chars
+        s = s.replace(/-+$/g, ''); // trim any trailing hyphens
+        return s;
     }
     window.URLify = URLify;
 })();

--- a/wagtail/admin/static_src/wagtailadmin/js/vendor/urlify.js
+++ b/wagtail/admin/static_src/wagtailadmin/js/vendor/urlify.js
@@ -160,22 +160,8 @@
 
     function URLify(s, num_chars, allowUnicode) {
         // changes, e.g., "Petty theft" to "petty-theft"
-        // remove all these words from the string before urlifying
         if (!allowUnicode) {
             s = downcode(s);
-        }
-        var hasUnicodeChars = /[^\u0000-\u007f]/.test(s);
-        // Remove English words only if the string contains ASCII (English)
-        // characters.
-        if (!hasUnicodeChars) {
-            var removeList = [
-                "a", "an", "as", "at", "before", "but", "by", "for", "from",
-                "is", "in", "into", "like", "of", "off", "on", "onto", "per",
-                "since", "than", "the", "this", "that", "to", "up", "via",
-                "with"
-            ];
-            var r = new RegExp('\\b(' + removeList.join('|') + ')\\b', 'gi');
-            s = s.replace(r, '');
         }
         s = s.toLowerCase(); // convert to lowercase
         // if downcode doesn't hit, the char will be stripped here


### PR DESCRIPTION
Fixes #4899 and the İstanbul issue raised on Slack and at https://github.com/django/django/pull/12237.

I reapplied @chosak / @Scotchester's fix from https://github.com/django/django/commit/62f1655a64795d055f72e53557fb8404c5430963 manually rather than just taking the latest Django version, as there were a few ES6-specific fixes in the interim that could break IE11 compatibility (which Django has dropped, but we haven't).