### PR TITLE
Fix #6408: InvokeViaAttributeShortcut makes it impossible to pickle objects

### DIFF
--- a/wagtail/contrib/settings/tests/test_model.py
+++ b/wagtail/contrib/settings/tests/test_model.py
@@ -1,3 +1,5 @@
+import pickle
+
 from django.test import TestCase, override_settings
 
 from wagtail.core.models import Site
@@ -56,6 +58,31 @@ class SettingModelTestCase(SettingsTestMixin, TestCase):
             sign_up_page=site.root_page,
             general_terms_page=site.root_page,
             privacy_policy_page=self.other_site.root_page,
+        )
+
+    def test_importantpages_object_is_pickleable(self):
+        obj = self._create_importantpages_object()
+        # Triggers creation of the InvokeViaAttributeShortcut instance,
+        # and also gives us a value we can use for comparisson
+        signup_page_url = obj.page_url.sign_up_page
+
+        # Attempt to pickle ImportantPages instance
+        try:
+            pickled = pickle.dumps(obj, -1)
+        except Exception as e:
+            raise AssertionError('An error occured when attempting to pickle %r: %s' % (obj, e))
+
+        # Now unpickle the pickled ImportantPages
+        try:
+            unpickled = pickle.loads(pickled)
+        except Exception as e:
+            raise AssertionError('An error occured when attempting to unpickle %r: %s' % (obj, e))
+
+        # Using 'page_url' should create a new InvokeViaAttributeShortcut
+        # instance, which should give the same result as the original
+        self.assertEqual(
+            unpickled.page_url.sign_up_page,
+            signup_page_url,
         )
 
     def test_select_related(self, expected_queries=4):

--- a/wagtail/core/tests/test_utils.py
+++ b/wagtail/core/tests/test_utils.py
@@ -1,14 +1,17 @@
 # -*- coding: utf-8 -*
+import pickle
+
 from django.core.exceptions import ImproperlyConfigured
-from django.test import TestCase, override_settings
+from django.test import SimpleTestCase, TestCase, override_settings
 from django.utils.text import slugify
 from django.utils.translation import _trans
 from django.utils.translation import gettext_lazy as _
 
 from wagtail.core.models import Page
 from wagtail.core.utils import (
-    accepts_kwarg, camelcase_to_underscore, cautious_slugify, find_available_slug,
-    get_content_languages, get_supported_content_language_variant, safe_snake_case, string_to_ascii)
+    InvokeViaAttributeShortcut, accepts_kwarg, camelcase_to_underscore, cautious_slugify,
+    find_available_slug, get_content_languages, get_supported_content_language_variant,
+    safe_snake_case, string_to_ascii)
 
 
 class TestCamelCaseToUnderscore(TestCase):
@@ -120,6 +123,45 @@ class TestAcceptsKwarg(TestCase):
         self.assertFalse(accepts_kwarg(func_without_banana, 'banana'))
         self.assertTrue(accepts_kwarg(func_with_banana, 'banana'))
         self.assertTrue(accepts_kwarg(func_with_kwargs, 'banana'))
+
+
+class TestTargetClass:
+    """
+    Used in TestInvokeViaAttributeShortcut (below)
+    """
+    def __init__(self):
+        self.target_method_called_with = []
+
+    def target_method(self, arg):
+        self.target_method_called_with.append(arg)
+
+
+class TestInvokeViaAttributeShortcut(SimpleTestCase):
+
+    def setUp(self):
+        self.target_object = TestTargetClass()
+        self.test_object = InvokeViaAttributeShortcut(self.target_object, 'target_method')
+
+    def test_basic(self):
+        for value in ('foo', 'bar', 'baz'):
+            # Use the shortcut to call the underlying method
+            getattr(self.test_object, value)
+            # Confirm that the underlying method was called
+            self.assertIn(value, self.target_object.target_method_called_with)
+
+    def test_pickleability(self):
+        try:
+            pickled = pickle.dumps(self.test_object, -1)
+        except Exception as e:
+            raise AssertionError('An error occured when attempting to pickle %r: %s' % (self.test_object, e))
+        try:
+            self.test_object = pickle.loads(pickled)
+        except Exception as e:
+            raise AssertionError('An error occured when attempting to unpickle %r: %s' % (self.test_object, e))
+
+        # Confirm unpickled object works the same
+        self.target_object = self.test_object.obj
+        self.test_basic()
 
 
 class TestFindAvailableSlug(TestCase):

--- a/wagtail/core/utils.py
+++ b/wagtail/core/utils.py
@@ -176,6 +176,13 @@ class InvokeViaAttributeShortcut:
         method = getattr(self.obj, self.method_name)
         return method(name)
 
+    def __getstate__(self):
+        return {'obj': self.obj, 'method_name': self.method_name}
+
+    def __setstate__(self, state):
+        self.obj = state['obj']
+        self.method_name = state['method_name']
+
 
 def find_available_slug(parent, requested_slug, ignore_page_id=None):
     """


### PR DESCRIPTION
Resolves #6408 
