### PR TITLE
Add a comment to describe why _filtered_by_child_of exists

### DIFF
--- a/wagtail/api/v2/filters.py
+++ b/wagtail/api/v2/filters.py
@@ -154,6 +154,10 @@ class ChildOfFilter(BaseFilterBackend):
                 raise BadRequestError("parent page doesn't exist")
 
             queryset = queryset.child_of(parent_page)
+
+            # Save the parent page on the queryset. This is required for the page
+            # explorer, which needs to pass the parent page into
+            # `construct_explorer_page_queryset` hook functions
             queryset._filtered_by_child_of = parent_page
 
         return queryset


### PR DESCRIPTION
I was just going to remove this as per https://github.com/wagtail/wagtail/pull/6222#discussion_r493740072 but I notuced that we actually use this attribute to pass the parent page into the `construct_explorer_page_queryset` hook.

This adds a comment to document this a bit better.