### PR TITLE
Make the API's get_base_url tests use Django TestCase

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -20,6 +20,7 @@ Changelog
  * Make document `content-type` and `content-disposition` configurable via `WAGTAILDOCS_CONTENT_TYPES` and `WAGTAILDOCS_INLINE_CONTENT_TYPES` (Matt Westcott)
  * Slug generation no longer removes stopwords (Andy Chosak, Scott Cranfill)
  * Add check to disallow StreamField block names that do not match Python variable syntax (François Poulain)
+ * The `BASE_URL` setting is now converted to a str, if it isn't already, when constructing API URLs (thenewguy)
  * Fix: Make page-level actions accessible to keyboard users in page listing tables (Jesse Menn)
  * Fix: `WAGTAILFRONTENDCACHE_LANGUAGES` was being interpreted incorrectly. It now accepts a list of strings, as documented (Karl Hobley)
  * Fix: Update oEmbed endpoints to use https where available (Matt Westcott)

--- a/docs/releases/2.11.rst
+++ b/docs/releases/2.11.rst
@@ -29,6 +29,7 @@ Other features
  * Make document ``content-type`` and ``content-disposition`` configurable via ``WAGTAILDOCS_CONTENT_TYPES`` and ``WAGTAILDOCS_INLINE_CONTENT_TYPES`` (Matt Westcott)
  * Slug generation no longer removes stopwords (Andy Chosak, Scott Cranfill)
  * Add check to disallow StreamField block names that do not match Python variable syntax (François Poulain)
+ * The ``BASE_URL`` setting is now converted to a str, if it isn't already, when constructing API URLs (thenewguy)
 
 
 Bug fixes

--- a/wagtail/api/v2/utils.py
+++ b/wagtail/api/v2/utils.py
@@ -1,6 +1,7 @@
 from urllib.parse import urlparse
 
 from django.conf import settings
+from django.utils.encoding import force_str
 
 from wagtail.core.models import Page, Site
 from wagtail.core.utils import resolve_model_string
@@ -11,19 +12,16 @@ class BadRequestError(Exception):
 
 
 def get_base_url(request=None):
-    base_url = None
+    base_url = getattr(settings, 'WAGTAILAPI_BASE_URL', None)
 
-    try:
-        base_url = getattr(settings, 'WAGTAILAPI_BASE_URL')
-    except AttributeError:
-        if request:
-            site = Site.find_for_request(request)
-            if site:
-                base_url = site.root_url
+    if base_url is None and request:
+        site = Site.find_for_request(request)
+        if site:
+            base_url = site.root_url
 
     if base_url:
         # We only want the scheme and netloc
-        base_url_parsed = urlparse(base_url)
+        base_url_parsed = urlparse(force_str(base_url))
 
         return base_url_parsed.scheme + '://' + base_url_parsed.netloc
 


### PR DESCRIPTION
In my review of https://github.com/wagtail/wagtail/pull/6341, I completely missed the fact that the test case was using `unittest.TestCase` and not Django's `TestCase`. But the tests were passing at the time I reviewed it.

After merge though, this caused some problems because this test case modifies data but Django is unable to roll it back properly causing strange test failures.

This PR fixes this test case to be an ordinary Django `TestCase`. Note that this also changes a little bit of logic so that `WAGTAILAPI_BASE_URL = None` which is interpreted the same way as if you didn't specify this setting at all. This brings it in line with other settings in Wagtail.