### PR TITLE
Pass chooser URLs to widgets via data attributes instead of global JS vars

### DIFF
--- a/client/tests/stubs.js
+++ b/client/tests/stubs.js
@@ -61,7 +61,6 @@ global.chooserUrls = {
   externalLinkChooser: '/admin/choose-external-link/',
   imageChooser: '/admin/images/chooser/',
   pageChooser: '/admin/choose-page/',
-  snippetChooser: '/admin/snippets/choose/',
 };
 
 /* use dummy content for onload handlers just so that we can verify that we've chosen the right one */

--- a/wagtail/admin/static_src/wagtailadmin/js/page-chooser.js
+++ b/wagtail/admin/static_src/wagtailadmin/js/page-chooser.js
@@ -5,7 +5,7 @@ function createPageChooser(id, pageTypes, openAtParentId, canChooseRoot, userPer
     var editLink = chooserElement.find('.edit-link');
 
     $('.action-choose', chooserElement).on('click', function() {
-        var initialUrl = window.chooserUrls.pageChooser;
+        var initialUrl = chooserElement.data('chooserUrl');
         if (openAtParentId) {
             initialUrl += openAtParentId + '/';
         }

--- a/wagtail/admin/static_src/wagtailadmin/js/task-chooser.js
+++ b/wagtail/admin/static_src/wagtailadmin/js/task-chooser.js
@@ -6,7 +6,7 @@ function createTaskChooser(id) {
 
     $('.action-choose', chooserElement).on('click', function() {
         ModalWorkflow({
-            url: window.chooserUrls.taskChooser,
+            url: chooserElement.data('chooserUrl'),
             onload: TASK_CHOOSER_MODAL_ONLOAD_HANDLERS,
             responses: {
                 taskChosen: function(data) {

--- a/wagtail/admin/templates/wagtailadmin/pages/_editor_js.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/_editor_js.html
@@ -12,7 +12,6 @@
         'emailLinkChooser': '{% url "wagtailadmin_choose_page_email_link" %}',
         'phoneLinkChooser': '{% url "wagtailadmin_choose_page_phone_link" %}',
         'anchorLinkChooser': '{% url "wagtailadmin_choose_page_anchor_link" %}',
-        'taskChooser': '{% url "wagtailadmin_workflows:task_chooser" %}',
     };
     window.unicodeSlugsEnabled = {% if unicode_slugs_enabled %}true{% else %}false{% endif %};
 </script>

--- a/wagtail/admin/templates/wagtailadmin/widgets/chooser.html
+++ b/wagtail/admin/templates/wagtailadmin/widgets/chooser.html
@@ -6,7 +6,7 @@
     when clicked.
 {% endcomment %}
 
-<div id="{{ attrs.id }}-chooser" class="chooser {% block chooser_class %}page-chooser{% endblock %} {% if not value %}blank{% endif %}">
+<div id="{{ attrs.id }}-chooser" class="chooser {% block chooser_class %}page-chooser{% endblock %} {% if not value %}blank{% endif %}" {% block chooser_attributes %}{% endblock %}>
 
     <div class="chosen">
         {% block chosen_state_view %}{% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/widgets/page_chooser.html
+++ b/wagtail/admin/templates/wagtailadmin/widgets/page_chooser.html
@@ -1,4 +1,5 @@
 {% extends "wagtailadmin/widgets/chooser.html" %}
+{% block chooser_attributes %}data-chooser-url="{% url "wagtailadmin_choose_page" %}"{% endblock %}
 
 {% block chosen_state_view %}
     <span class="title">{{ page.specific.get_admin_display_title }}</span>

--- a/wagtail/admin/templates/wagtailadmin/workflows/widgets/task_chooser.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/widgets/task_chooser.html
@@ -1,5 +1,6 @@
 {% extends "wagtailadmin/widgets/chooser.html" %}
 {% block chooser_class %}task-chooser{% endblock %}
+{% block chooser_attributes %}data-chooser-url="{% url "wagtailadmin_workflows:task_chooser" %}"{% endblock %}
 
 {% block chosen_state_view %}
     <span class="name">{{ task.name }}</span>

--- a/wagtail/documents/static_src/wagtaildocs/js/document-chooser.js
+++ b/wagtail/documents/static_src/wagtaildocs/js/document-chooser.js
@@ -6,7 +6,7 @@ function createDocumentChooser(id) {
 
     $('.action-choose', chooserElement).on('click', function() {
         ModalWorkflow({
-            url: window.chooserUrls.documentChooser,
+            url: chooserElement.data('chooserUrl'),
             onload: DOCUMENT_CHOOSER_MODAL_ONLOAD_HANDLERS,
             responses: {
                 documentChosen: function(docData) {

--- a/wagtail/documents/templates/wagtaildocs/widgets/document_chooser.html
+++ b/wagtail/documents/templates/wagtaildocs/widgets/document_chooser.html
@@ -1,5 +1,6 @@
 {% extends "wagtailadmin/widgets/chooser.html" %}
 {% block chooser_class %}document-chooser{% endblock %}
+{% block chooser_attributes %}data-chooser-url="{% url "wagtaildocs:chooser" %}"{% endblock %}
 
 {% block chosen_state_view %}
     <span class="title">{{ document.title }}</span>

--- a/wagtail/images/static_src/wagtailimages/js/image-chooser.js
+++ b/wagtail/images/static_src/wagtailimages/js/image-chooser.js
@@ -6,7 +6,7 @@ function createImageChooser(id) {
 
     $('.action-choose', chooserElement).on('click', function() {
         ModalWorkflow({
-            url: window.chooserUrls.imageChooser,
+            url: chooserElement.data('chooserUrl'),
             onload: IMAGE_CHOOSER_MODAL_ONLOAD_HANDLERS,
             responses: {
                 imageChosen: function(imageData) {

--- a/wagtail/images/templates/wagtailimages/widgets/image_chooser.html
+++ b/wagtail/images/templates/wagtailimages/widgets/image_chooser.html
@@ -2,6 +2,7 @@
 {% load wagtailimages_tags %}
 
 {% block chooser_class %}image-chooser{% endblock %}
+{% block chooser_attributes %}data-chooser-url="{% url "wagtailimages:chooser" %}"{% endblock %}
 
 {% block chosen_state_view %}
     <div class="preview-image">

--- a/wagtail/snippets/static_src/wagtailsnippets/js/snippet-chooser.js
+++ b/wagtail/snippets/static_src/wagtailsnippets/js/snippet-chooser.js
@@ -6,7 +6,7 @@ function createSnippetChooser(id, modelString) {
 
     $('.action-choose', chooserElement).on('click', function() {
         ModalWorkflow({
-            url: window.chooserUrls.snippetChooser + modelString + '/',
+            url: chooserElement.data('chooserUrl') + modelString + '/',
             onload: SNIPPET_CHOOSER_MODAL_ONLOAD_HANDLERS,
             responses: {
                 snippetChosen: function(snippetData) {

--- a/wagtail/snippets/templates/wagtailsnippets/widgets/snippet_chooser.html
+++ b/wagtail/snippets/templates/wagtailsnippets/widgets/snippet_chooser.html
@@ -2,6 +2,7 @@
 {% load wagtailadmin_tags %}
 
 {% block chooser_class %}snippet-chooser{% endblock %}
+{% block chooser_attributes %}data-chooser-url="{% url 'wagtailsnippets:choose_generic' %}"{% endblock %}
 
 {% block chosen_state_view %}
     <span class="title">{{ item }}</span>

--- a/wagtail/snippets/wagtail_hooks.py
+++ b/wagtail/snippets/wagtail_hooks.py
@@ -2,7 +2,6 @@ from django.contrib.admin.utils import quote
 from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
 from django.urls import include, path, reverse
-from django.utils.html import format_html
 from django.utils.translation import gettext_lazy as _
 
 from wagtail.admin.menu import MenuItem
@@ -33,16 +32,6 @@ def register_snippets_menu_item():
         reverse('wagtailsnippets:index'),
         icon_name='snippet',
         order=500
-    )
-
-
-@hooks.register('insert_editor_js')
-def editor_js():
-    return format_html(
-        """
-            <script>window.chooserUrls.snippetChooser = '{0}';</script>
-        """,
-        reverse('wagtailsnippets:choose_generic')
     )
 
 

--- a/wagtail/users/templates/wagtailusers/groups/includes/group_form_js.html
+++ b/wagtail/users/templates/wagtailusers/groups/includes/group_form_js.html
@@ -1,10 +1,4 @@
 {% load wagtailadmin_tags %}
-<script>
-    window.chooserUrls = {
-        'pageChooser': '{% url "wagtailadmin_choose_page" %}'
-    };
-</script>
-
 <script src="{% versioned_static 'wagtailadmin/js/expanding_formset.js' %}"></script>
 <script src="{% versioned_static 'wagtailadmin/js/modal-workflow.js' %}"></script>
 <script src="{% versioned_static 'wagtailusers/js/group-form.js' %}"></script>


### PR DESCRIPTION
Chipping away at `_editor_js.html` bit by bit...

Update chooser widgets so that the URLs to the modal views are passed via a `data-` attribute on the widget's root element, instead of depending on the global `chooserUrls` object in _editor_js.html.

Draftail (and hallo.js) still relies on `chooserUrls`, so it can't be eliminated _just_ yet.