### PR TITLE
Implement admin-only IE11 support warning message, linking to support plans

### DIFF
--- a/client/src/includes/initIE11Warning.js
+++ b/client/src/includes/initIE11Warning.js
@@ -1,0 +1,19 @@
+import { IS_IE11 } from '../config/wagtailConfig';
+
+/**
+ * Toggles IE11-only warning messages, if any.
+ */
+const initIE11Warning = () => {
+  if (!IS_IE11) {
+    return;
+  }
+
+  const warnings = [].slice.call(document.querySelectorAll('[data-ie11-warning]'));
+
+  warnings.forEach(warning => {
+    // eslint-disable-next-line no-param-reassign
+    warning.hidden = false;
+  });
+};
+
+export { initIE11Warning };

--- a/client/src/includes/initIE11Warning.test.js
+++ b/client/src/includes/initIE11Warning.test.js
@@ -1,0 +1,22 @@
+const wagtailConfig = require('../config/wagtailConfig');
+const { initIE11Warning } = require('./initIE11Warning');
+
+describe('initIE11Warning', () => {
+  it('skips logic if the page has no warnings', () => {
+    initIE11Warning();
+  });
+
+  it('shows warnings in IE11', () => {
+    wagtailConfig.IS_IE11 = true;
+    document.body.innerHTML = '<p data-ie11-warning hidden>Test</p>';
+    initIE11Warning();
+    expect(document.querySelector('[data-ie11-warning]').hidden).toBe(false);
+  });
+
+  it('no warnings for other browsers', () => {
+    wagtailConfig.IS_IE11 = false;
+    document.body.innerHTML = '<p data-ie11-warning hidden>Test</p>';
+    initIE11Warning();
+    expect(document.querySelector('[data-ie11-warning]').hidden).toBe(true);
+  });
+});

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -13,6 +13,7 @@ import Transition from './components/Transition/Transition';
 import { initFocusOutline } from './utils/focus';
 import { initSubmenus } from './includes/initSubmenus';
 import { initSkipLink } from './includes/initSkipLink';
+import { initIE11Warning } from './includes/initIE11Warning';
 import { initUpgradeNotification } from './components/UpgradeNotification';
 
 export {
@@ -28,5 +29,6 @@ export {
   initFocusOutline,
   initSubmenus,
   initSkipLink,
+  initIE11Warning,
   initUpgradeNotification,
 };

--- a/docs/editor_manual/browser_issues.rst
+++ b/docs/editor_manual/browser_issues.rst
@@ -9,3 +9,12 @@ Supported browsers
 __________________
 
 For the best experience and security, we recommend that you keep your browser up to date. Go to `Browse Happy <https://browsehappy.com/>`_ for more information.
+
+IE11
+____
+
+Wagtail is gradually removing support for the legacy Internet Explorer browser over the course of future releases.
+If this affects you or your organisation, consider which alternative browsers you may be able to use.
+Wagtail is fully compatible with Microsoft Edge, Microsoft’s replacement for Internet Explorer. You may consider using its `IE mode <https://docs.microsoft.com/en-us/deployedge/edge-ie-mode>`_ to keep access to IE11-only sites, while other sites and apps like Wagtail can leverage modern browser capabilities.
+
+We are looking for feedback on this change to our support policy, please `get in touch <https://github.com/wagtail/wagtail/issues/6170>`_ if it affects you and there are no clear alternatives.

--- a/docs/editor_manual/browser_issues.rst
+++ b/docs/editor_manual/browser_issues.rst
@@ -13,7 +13,13 @@ For the best experience and security, we recommend that you keep your browser up
 IE11
 ____
 
-Wagtail is gradually removing support for the legacy Internet Explorer browser over the course of future releases.
+Wagtail is gradually removing support for the legacy Internet Explorer browser over the course of `future releases <https://github.com/wagtail/wagtail/wiki/Release-schedule>`_.
+
+ * In Wagtail 2.11 (LTS), there will be a warning message displayed on the Wagtail dashboard for IE11 users with administrator role.
+ * In Wagtail 2.12, the message will be displayed to all users regardless of their role.
+ * In Wagtail 2.13, the message will be displayed at the top of all pages.
+ * Wagtail will no longer support IE11 in version 2.14.
+ 
 If this affects you or your organisation, consider which alternative browsers you may be able to use.
 Wagtail is fully compatible with Microsoft Edge, Microsoft’s replacement for Internet Explorer. You may consider using its `IE mode <https://docs.microsoft.com/en-us/deployedge/edge-ie-mode>`_ to keep access to IE11-only sites, while other sites and apps like Wagtail can leverage modern browser capabilities.
 

--- a/docs/editor_manual/browser_issues.rst
+++ b/docs/editor_manual/browser_issues.rst
@@ -18,7 +18,7 @@ Wagtail is gradually removing support for the legacy Internet Explorer browser o
  * In Wagtail 2.11 (LTS), there will be a warning message displayed on the Wagtail dashboard for IE11 users with administrator role.
  * In Wagtail 2.12, the message will be displayed to all users regardless of their role.
  * In Wagtail 2.13, the message will be displayed at the top of all pages.
- * Wagtail will no longer support IE11 in version 2.14.
+ * Wagtail will no longer support IE11 starting in version 2.14.
  
 If this affects you or your organisation, consider which alternative browsers you may be able to use.
 Wagtail is fully compatible with Microsoft Edge, Microsoft’s replacement for Internet Explorer. You may consider using its `IE mode <https://docs.microsoft.com/en-us/deployedge/edge-ie-mode>`_ to keep access to IE11-only sites, while other sites and apps like Wagtail can leverage modern browser capabilities.

--- a/wagtail/admin/static_src/wagtailadmin/app/wagtailadmin.entry.js
+++ b/wagtail/admin/static_src/wagtailadmin/app/wagtailadmin.entry.js
@@ -7,6 +7,7 @@ import {
   initFocusOutline,
   initSubmenus,
   initSkipLink,
+  initIE11Warning,
   initUpgradeNotification,
 } from 'wagtail-client';
 
@@ -37,6 +38,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   initFocusOutline();
   initSubmenus();
+  initIE11Warning();
   initUpgradeNotification();
   initSkipLink();
 });

--- a/wagtail/admin/templates/wagtailadmin/home/ie11_warning.html
+++ b/wagtail/admin/templates/wagtailadmin/home/ie11_warning.html
@@ -1,0 +1,5 @@
+{% load i18n wagtailcore_tags %}
+
+<div data-ie11-warning hidden class="panel nice-padding">
+    <div class="help-block help-info">{% blocktrans %}Wagtail is gradually removing support for IE11, which may affect you or your organisation. <a href="https://docs.wagtail.io/en/stable/editor_manual/browser_issues.html#ie11">Learn more about our IE11 support plans</a>.{% endblocktrans %}</div>
+</div>

--- a/wagtail/admin/views/home.py
+++ b/wagtail/admin/views/home.py
@@ -34,6 +34,20 @@ class UpgradeNotificationPanel:
             return ""
 
 
+class IE11WarningPanel:
+    name = 'ie11_warning'
+    order = 110
+
+    def __init__(self, request):
+        self.request = request
+
+    def render(self):
+        if self.request.user.is_superuser:
+            return render_to_string('wagtailadmin/home/ie11_warning.html', {}, request=self.request)
+        else:
+            return ""
+
+
 class PagesForModerationPanel:
     name = 'pages_for_moderation'
     order = 200
@@ -158,6 +172,7 @@ def home(request):
     panels = [
         SiteSummaryPanel(request),
         UpgradeNotificationPanel(request),
+        IE11WarningPanel(request),
         WorkflowPagesToModeratePanel(request),
         PagesForModerationPanel(request),
         UserPagesInWorkflowModerationPanel(request),


### PR DESCRIPTION
First step towards removing support, as discussed in https://github.com/wagtail/wagtail/issues/6170#issuecomment-693523810. Right now this is an admin-only, IE11-only, dashboard-only message. In the future, we will have this be visible for all users, and further down the line, on all pages like Wagtail’s "JavaScript is required" message.

The message is remove-able with the `construct_homepage_panels` hook, like all home panels. I didn’t find tests for these so I haven’t added any, happy to add a test if someone points me in the right direction.

In addition to what we discussed, I decided to add this to the documentation as well. It felt important to have this written somewhere more visible than the issue tracker, and is also a natural place for us to add more guidance about our plans.

Here is the message in its current iteration, displayed right after the admin-only upgrade notification:

![ie-warning](https://user-images.githubusercontent.com/877585/94924411-5feea880-04b5-11eb-9b4a-2db86a64fff0.png)

---

* [x] Do the tests still pass? (https://docs.wagtail.io/en/latest/contributing/developing.html#testing)
* [x] Does the code comply with the style guide? (Run `make lint` from the Wagtail root)
* For Python changes: Have you added tests to cover the new/fixed behaviour? No, I couldn’t find existing tests I could add to for the other panels (might have missed them!)
* For front-end changes: Did you test on all of Wagtail’s supported browsers? **Please list the exact versions you tested**. Tested in latest Chrome macOS, latest Safari macOS, IE11 Win 10, latest MS Edge Win 10
* [x] For new features: Has the documentation been updated accordingly?
