### PR TITLE
Fix bug with page URL always going to default region

### DIFF
--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -1402,6 +1402,12 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
             else:
                 site_id, root_path, root_url, language_code = possible_sites[0]
 
+        # If the active language code is a variant of the page's language, then
+        # use that instead
+        # This is used when LANGUAGES contain more languages than WAGTAIL_CONTENT_LANGUAGES
+        if get_supported_content_language_variant(translation.get_language()) == language_code:
+            language_code = translation.get_language()
+
         # The page may not be routable because wagtail_serve is not registered
         # This may be the case if Wagtail is used headless
         try:


### PR DESCRIPTION
On sites where multiple regions have the same content, Wagtail currently always generates URLs for the default region, even if a perfectly valid region is active.

For example, say we have the following languages configuration:

```python
LANGUAGES = [
    ('en-gb', "English (United Kingdom)"),
    ('en-us', "English (United States)")
    ('fr-fr', "French (France)"),
    ('fr-ca', "French (Canada)"),
]

WAGTAIL_CONTENT_LANGUAGES = [
    ('en-gb', "English"),
    ('fr-fr', "French"),
]
```

This configuration would let me author content in English or French. The English content would be served under `/en-gb/` and `/en-us/`. The French content would be served under `/fr-fr/` and `/fr-ca/`.

The problem is if a user visited either `/en-us/` or `/fr-ca/` the URLs for all the internal links would point at `/en-gb/` and `/fr-fr/` respectively, as those are the language codes the pages were authored in.

This adds a check to see if the currently active language is a variant of the linked page's language. If so, it doesn't override the language.