### PR TITLE
Fix incorrect reference to edit fields in image documentation

### DIFF
--- a/docs/editor_manual/documents_images_snippets/images.rst
+++ b/docs/editor_manual/documents_images_snippets/images.rst
@@ -5,10 +5,7 @@ If you want to edit, add or remove images from the CMS outside of the individual
 
 .. image:: ../../_static/images/screen31_images_page.png
 
-* Clicking an image will allow you to edit the data associated with it. This includes the Alt text, the photographers credit, the medium of the subject matter and much more.
-
-.. Warning::
-    Changing the alt text here will alter it for all occurrences of the image in carousels, but not in inline images, where the alt text can be set separately.
+* Clicking an image will allow you to edit the data associated with it. This includes the photographers credit, the focal point of the image and much more.
 
 .. image:: ../../_static/images/screen32_image_edit_page.png
 

--- a/docs/editor_manual/documents_images_snippets/images.rst
+++ b/docs/editor_manual/documents_images_snippets/images.rst
@@ -5,7 +5,7 @@ If you want to edit, add or remove images from the CMS outside of the individual
 
 .. image:: ../../_static/images/screen31_images_page.png
 
-* Clicking an image will allow you to edit the data associated with it. This includes the photographers credit, the focal point of the image and much more.
+* Clicking an image will allow you to edit the data associated with it. This includes the title, the focal point of the image and much more.
 
 .. image:: ../../_static/images/screen32_image_edit_page.png
 


### PR DESCRIPTION
Fixes #6375 

Took the liberty of mentioning the focal point editing instead of the non-existent fields, as well as simply removing the warning as it does not make any sense.