### PR TITLE
Change docs code block style to 'default'

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -115,7 +115,7 @@ exclude_patterns = ['_build']
 #show_authors = False
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'sphinx'
+pygments_style = 'default'
 
 # A list of ignored prefixes for module index sorting.
 #modindex_common_prefix = []


### PR DESCRIPTION
Fixes #6432 

I think this highlighting style looks better and is more readable.

Before:
![image](https://user-images.githubusercontent.com/1093808/95018942-7f730600-065a-11eb-8328-eea3d418731e.png)

After:
![image](https://user-images.githubusercontent.com/1093808/95018956-8ef24f00-065a-11eb-9ba7-4f4c7755541d.png)

We could probably do even better. There's a list of code block styles at https://help.farbox.com/pygments.html, or we could make our own!