### PR TITLE
Switch breadcrumb icons to SVG

### DIFF
--- a/client/scss/components/_breadcrumb.scss
+++ b/client/scss/components/_breadcrumb.scss
@@ -4,90 +4,59 @@
     overflow: hidden;
     padding-top: 1.4em;
     font-size: 0.85em;
+    line-height: 1.5em;
+    margin-left: 2em;
+    background: $color-teal;
 
     li {
         display: block;
         float: left;
-        padding: 0.5em 1.3em;
         position: relative;
         text-decoration: none;
-        color: $color-white;
         white-space: nowrap;
-        line-height: 1.5em;
-
-        a,
-        span {
-            color: $color-white;
-            display: block;
-            max-width: 12em;
-            white-space: nowrap;
-            text-overflow: ellipsis;
-            overflow: hidden;
-            line-height: 1.6em;
-            padding-right: 1em;
-
-            &:after {
-                right: 0;
-                // z-index: 5;
-                position: absolute;
-                font-family: wagtail;
-                content: map-get($icons, 'arrow-right');
-                padding-left: 20px;
-                font-size: 2em;
-                color: $color-teal-darker;
-                line-height: 0.9em;
-            }
-        }
+        padding: 4px;
 
         &:hover {
             background: $color-teal-dark;
+        }
 
-            a {
-                color: $color-white;
+    }
+
+    a {
+        color: $color-white;
+        display: block;
+        padding: calc(0.5em - 4px) 1em;
+        white-space: nowrap;
+        line-height: 1.6em;
+
+        &:hover {
+            background: $color-teal-dark;
+            color: $color-white;
+
+            .arrow_right_icon {
+                color: $color-teal;
             }
         }
 
-        &:hover:after {
-            border-left-color: $color-teal-dark;
-        }
-
-        &.home {
-            a {
-                // stylelint-disable max-nesting-depth
-                padding-right: 0;
-                text-align: center;
-                width: 3em;
-                font-size: 1em;
-                text-overflow: clip;
-
-                &:before {
-                    font-size: 1.15rem;
-                    line-height: 0.85em;
-                    padding-top: 0.1em;
-                }
-
-                &:after {
-                    right: -0.3em;
-                }
-            }
-        }
-    }
-
-    header &  li {
-        &:before {
-            border-left: 1em solid $color-white;
-            position: absolute;
-            left: 0;
-            top: 0;
-        }
-    }
-
-    &.single {
-        li a {
+        .title {
+            display: inline-block;
+            max-width: 11.8em;
             white-space: nowrap;
-            text-overflow: inherit;
-            max-width: 100%;
+            text-overflow: ellipsis;
+            overflow: hidden;
+            vertical-align: bottom;
         }
+    }
+
+    .home_icon {
+        @include svg-icon(1em);
+        transform: scale(1.5) translate(0, 0.1em);
+    }
+
+    .arrow_right_icon {
+        @include svg-icon(1em);
+        color: $color-teal-dark;
+        transform: scale(1.75) translate(0.3em, 0.1em);
     }
 
     @include media-breakpoint-up(sm) {
@@ -96,13 +65,13 @@
         margin-left: -($desktop-nice-padding);
         margin-right: -($desktop-nice-padding);
 
-        li {
-            a,
-            span {
-                &:after {
-                    color: $color-teal;
-                }
-            }
+        .home_icon {
+            margin-left: 1.25em;
+        }
+
+        .arrow_right_icon {
+            color: $color-teal;
         }
     }
 }
+

--- a/client/scss/components/_header.scss
+++ b/client/scss/components/_header.scss
@@ -69,10 +69,6 @@ header {
             padding-right: 1.6em;
             padding-top: 11px;
 
-            .breadcrumb {
-                margin-left: 0;
-            }
-
             .nice-padding {
                 margin-left: -$desktop-nice-padding;
             }

--- a/wagtail/admin/templates/wagtailadmin/shared/breadcrumb.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/breadcrumb.html
@@ -1,16 +1,18 @@
-{% load i18n %}
+{% load i18n wagtailadmin_tags %}
 
 <nav aria-label="{% trans 'Breadcrumb' %}">
     <ul class="breadcrumb">
         {% for page in pages %}
             {% if page.is_root %}
                 {# Root section is shown as a 'site' icon in place of the title #}
-                <li class="home"><a href="{% url 'wagtailadmin_explore_root' %}" class="icon icon-site text-replace">{% trans 'Root' %}</a></li>
+                {% trans "Root" as root %}
+                <li class="home"><a href="{% url 'wagtailadmin_explore_root' %}">{% icon name="site" class_name="home_icon" title=root %}{% icon name="arrow-right" class_name="arrow_right_icon" %}</a></li>
             {% elif forloop.first %}
                 {# For limited-permission users whose breadcrumb starts further down from the root, the first item displays as a 'home' icon in place of the title #}
-                <li class="home"><a href="{% url 'wagtailadmin_explore' page.id %}" class="icon icon-home text-replace">{% trans 'Home' %}</a></li>
+                {% trans 'Home' as home %}
+                <li class="home"><a href="{% url 'wagtailadmin_explore' page.id %}" class="text-replace">{% icon name="site" class_name="home_icon" title=home %}</a>{% icon name="arrow-right" class_name="arrow_right_icon"%}</li>
             {% else %}
-                <li><a href="{% url 'wagtailadmin_explore' page.id %}">{{ page.get_admin_display_title }}</a></li>
+                <li><a href="{% url 'wagtailadmin_explore' page.id %}"><span class="title">{{ page.get_admin_display_title }}</span>{% icon name="arrow-right" class_name="arrow_right_icon" %}</a></li>
             {% endif %}
         {% endfor %}
     </ul>

--- a/wagtail/admin/tests/pages/test_explorer_view.py
+++ b/wagtail/admin/tests/pages/test_explorer_view.py
@@ -307,7 +307,16 @@ class TestBreadcrumb(TestCase, WagtailTestUtils):
 
         # The breadcrumb should pick up SimplePage's overridden get_admin_display_title method
         expected_url = reverse('wagtailadmin_explore', args=(Page.objects.get(url_path='/home/secret-plans/').id, ))
-        self.assertContains(response, """<li><a href="%s">Secret plans (simple page)</a></li>""" % expected_url)
+        expected = """
+            <li>
+                <a href="%s"><span class="title">Secret plans (simple page)</span>
+                    <svg class="icon icon-arrow-right arrow_right_icon" aria-hidden="true" focusable="false">
+                        <use href="#icon-arrow-right"></use>
+                    </svg>
+                </a>
+            </li>
+        """ % expected_url
+        self.assertContains(response, expected, html=True)
 
 
 class TestPageExplorerSignposting(TestCase, WagtailTestUtils):
@@ -506,13 +515,42 @@ class TestExplorablePageVisibility(TestCase, WagtailTestUtils):
         self.login(username='superman', password='password')
         response = self.client.get(reverse('wagtailadmin_explore', args=[6]))
         self.assertEqual(response.status_code, 200)
-
-        self.assertInHTML(
-            """<li class="home"><a href="/admin/pages/" class="icon icon-site text-replace">Root</a></li>""",
-            str(response.content)
-        )
-        self.assertInHTML("""<li><a href="/admin/pages/4/">Welcome to example.com!</a></li>""", str(response.content))
-        self.assertInHTML("""<li><a href="/admin/pages/5/">Content</a></li>""", str(response.content))
+        expected = """
+            <li class="home">
+                <a href="/admin/pages/">
+                    <svg class="icon icon-site home_icon" aria-hidden="true" focusable="false">
+                        <use href="#icon-site"></use>
+                    </svg>
+                    <span class="visuallyhidden">Root</span>
+                    <svg class="icon icon-arrow-right arrow_right_icon" aria-hidden="true" focusable="false">
+                        <use href="#icon-arrow-right"></use>
+                    </svg>
+                </a>
+            </li>
+        """
+        self.assertContains(response, expected, html=True)
+        expected = """
+            <li>
+                <a href="/admin/pages/4/">
+                    <span class="title">Welcome to example.com!</span>
+                    <svg class="icon icon-arrow-right arrow_right_icon" aria-hidden="true" focusable="false">
+                        <use href="#icon-arrow-right"></use>
+                    </svg>
+                </a>
+            </li>
+        """
+        self.assertContains(response, expected, html=True)
+        expected = """
+            <li>
+                <a href="/admin/pages/5/">
+                    <span class="title">Content</span>
+                    <svg class="icon icon-arrow-right arrow_right_icon" aria-hidden="true" focusable="false">
+                        <use href="#icon-arrow-right"></use>
+                    </svg>
+                </a>
+            </li>
+        """
+        self.assertContains(response, expected, html=True)
 
     def test_nonadmin_sees_breadcrumbs_up_to_cca(self):
         self.login(username='josh', password='password')
@@ -520,11 +558,31 @@ class TestExplorablePageVisibility(TestCase, WagtailTestUtils):
         self.assertEqual(response.status_code, 200)
         # While at "Page 1", Josh should see the breadcrumbs leading only as far back as the example.com homepage,
         # since it's his Closest Common Ancestor.
-        self.assertInHTML(
-            """<li class="home"><a href="/admin/pages/4/" class="icon icon-home text-replace">Home</a></li>""",
-            str(response.content)
-        )
-        self.assertInHTML("""<li><a href="/admin/pages/5/">Content</a></li>""", str(response.content))
+        expected = """
+            <li class="home">
+                <a href="/admin/pages/4/" class="text-replace">
+                    <svg class="icon icon-site home_icon" aria-hidden="true" focusable="false">
+                        <use href="#icon-site"></use>
+                    </svg>
+                    <span class="visuallyhidden">Home</span>
+                </a>
+                <svg class="icon icon-arrow-right arrow_right_icon" aria-hidden="true" focusable="false">
+                    <use href="#icon-arrow-right"></use>
+                </svg>
+            </li>
+        """
+        self.assertContains(response, expected, html=True)
+        expected = """
+            <li>
+                <a href="/admin/pages/5/">
+                    <span class="title">Content</span>
+                    <svg class="icon icon-arrow-right arrow_right_icon" aria-hidden="true" focusable="false">
+                        <use href="#icon-arrow-right"></use>
+                    </svg>
+                </a>
+            </li>
+        """
+        self.assertContains(response, expected, html=True)
         # The page title shouldn't appear because it's the "home" breadcrumb.
         self.assertNotContains(response, "Welcome to example.com!")
 

--- a/wagtail/contrib/modeladmin/templates/modeladmin/includes/breadcrumb.html
+++ b/wagtail/contrib/modeladmin/templates/modeladmin/includes/breadcrumb.html
@@ -1,5 +1,6 @@
-{% load i18n %}
+{% load i18n wagtailadmin_tags %}
 <ul class="breadcrumb">
-    <li class="home"><a href="{% url 'wagtailadmin_home' %}" class="icon icon-home text-replace">{% trans 'Home' %}</a></li>
+    {% trans 'Home' as home %}
+    <li class="home"><a href="{% url 'wagtailadmin_home' %}">{% icon name="home" class_name="home_icon" title=home %}{% icon name="arrow-right" class_name="arrow_right_icon" %}</a></li>
     <li><a href="{{ view.index_url }}">{{ view.verbose_name_plural|capfirst }}</a></li>
 </ul>

--- a/wagtail/contrib/modeladmin/tests/test_page_modeladmin.py
+++ b/wagtail/contrib/modeladmin/tests/test_page_modeladmin.py
@@ -341,7 +341,20 @@ class TestHeaderBreadcrumbs(TestCase, WagtailTestUtils):
         self.assertTemplateUsed(response, 'wagtailadmin/shared/header.html')
 
         # check that home breadcrumb link exists
-        self.assertContains(response, '<li class="home"><a href="/admin/" class="icon icon-home text-replace">Home</a></li>', html=True)
+        expected = """
+            <li class="home">
+                <a href="/admin/">
+                    <svg class="icon icon-home home_icon" aria-hidden="true" focusable="false">
+                        <use href="#icon-home"></use>
+                    </svg>
+                    <span class="visuallyhidden">Home</span>
+                    <svg class="icon icon-arrow-right arrow_right_icon" aria-hidden="true" focusable="false">
+                        <use href="#icon-arrow-right"></use>
+                    </svg>
+                </a>
+            </li>
+        """
+        self.assertContains(response, expected, html=True)
 
         # check that the breadcrumbs are after the header opening tag
         content_str = str(response.content)
@@ -357,7 +370,20 @@ class TestHeaderBreadcrumbs(TestCase, WagtailTestUtils):
         self.assertTemplateUsed(response, 'wagtailadmin/shared/header.html')
 
         # check that home breadcrumb link exists
-        self.assertContains(response, '<li class="home"><a href="/admin/" class="icon icon-home text-replace">Home</a></li>', html=True)
+        expected = """
+            <li class="home">
+                <a href="/admin/">
+                    <svg class="icon icon-home home_icon" aria-hidden="true" focusable="false">
+                        <use href="#icon-home"></use>
+                    </svg>
+                    <span class="visuallyhidden">Home</span>
+                    <svg class="icon icon-arrow-right arrow_right_icon" aria-hidden="true" focusable="false">
+                        <use href="#icon-arrow-right"></use>
+                    </svg>
+                </a>
+            </li>
+        """
+        self.assertContains(response, expected, html=True)
 
         # check that the breadcrumbs are after the header opening tag
         content_str = str(response.content)

--- a/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
+++ b/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
@@ -641,7 +641,20 @@ class TestHeaderBreadcrumbs(TestCase, WagtailTestUtils):
         self.assertTemplateUsed(response, 'wagtailadmin/shared/header.html')
 
         # check that home breadcrumb link exists
-        self.assertContains(response, '<li class="home"><a href="/admin/" class="icon icon-home text-replace">Home</a></li>', html=True)
+        expected = """
+            <li class="home">
+                <a href="/admin/">
+                    <svg class="icon icon-home home_icon" aria-hidden="true" focusable="false">
+                        <use href="#icon-home"></use>
+                    </svg>
+                    <span class="visuallyhidden">Home</span>
+                    <svg class="icon icon-arrow-right arrow_right_icon" aria-hidden="true" focusable="false">
+                        <use href="#icon-arrow-right"></use>
+                    </svg>
+                </a>
+            </li>
+        """
+        self.assertContains(response, expected, html=True)
 
         # check that the breadcrumbs are before the first header closing tag
         content_str = str(response.content)

--- a/wagtail/contrib/styleguide/templates/wagtailstyleguide/base.html
+++ b/wagtail/contrib/styleguide/templates/wagtailstyleguide/base.html
@@ -735,10 +735,11 @@
             <h2>Breadcrumbs</h2>
 
             <ul class="breadcrumb">
-                <li class="home"><a href="#" class="icon icon-home text-replace">Home</a></li>
-                <li><a href="#">Various</a></li>
-                <li><a href="#">Subpages</a></li>
-                <li><a href="#">There is a max length of this many</a></li>
+                {% trans 'Home' as home %}
+                <li class="home"><a href="{% url 'wagtailadmin_home' %}">{% icon name="home" class_name="home_icon" title=home %}{% icon name="arrow-right" class_name="arrow_right_icon" %}</a></li>
+                <li><a href="#"><span class="title">Various</span>{% icon name="arrow-right" class_name="arrow_right_icon" %}</a></li>
+                <li><a href="#"><span class="title">Subpages</span>{% icon name="arrow-right" class_name="arrow_right_icon" %}</a></li>
+                <li><a href="#"><span class="title">There is a max length of this many</span>{% icon name="arrow-right" class_name="arrow_right_icon" %}</a></li>
             </ul>
 
         </section>


### PR DESCRIPTION
https://github.com/wagtail/wagtail/issues/6107

This PR:
- Replace breadcrumb icons (font) with SVG icons.
- Hamburger menu on mobile was on top of the first breadcrumb item. Fixed.
- Breadcrumb is used on Pages and on ModelAdmin inspect view
- Enable inspect view example `wagtail/tests/modeladmintest/wagtail_hooks.py:20`
- Please review various viewports (don't forget mobile)

TODO:
* Do the tests still pass? YES
* Does the code comply with the style guide? YES
* For Python changes: Have you added tests to cover the new/fixed behaviour? YES
* For front-end changes: Did you test on all of Wagtail’s supported browsers?
  - Chrome 85, OSX
  -  FireFox 81, OSX
  - FireFox ESR 78, OSX
  - IE11, win10
  - iPhone SE Safari 13

* For new features: Has the documentation been updated accordingly? N/A
