### PR TITLE
Reset padding for checkbox & radio inputs

### DIFF
--- a/client/scss/elements/_forms.scss
+++ b/client/scss/elements/_forms.scss
@@ -154,6 +154,7 @@ input[type=checkbox] {
     border-radius: 0;
     cursor: pointer;
     border: 0;
+    padding: 0;
 }
 
 input[type=radio] {


### PR DESCRIPTION
Previously, the normalize stylesheet covered this, however that's no longer applicable due to selector specificity.

Works in Safari 14, Chrome 85 and Firefox 81.

Note; this doesn't fix the `full` versions of these input types, which also may look odd(ref: https://github.com/wagtail/wagtail/commit/1bbf541d7aa14b51a113c074dce9f17f97e43ab1). I'm not sure those ever were properly styled, though.