### PR TITLE
Add a check for elasticsearch URLS

### DIFF
--- a/wagtail/search/backends/elasticsearch2.py
+++ b/wagtail/search/backends/elasticsearch2.py
@@ -1070,6 +1070,10 @@ class Elasticsearch2SearchBackend(BaseSearchBackend):
         if self.hosts is None:
             self.hosts = []
 
+            # if es_urls is not a list, convert it to a list
+            if isinstance(es_urls, str):
+                es_urls = [es_urls]
+
             for url in es_urls:
                 parsed_url = urlparse(url)
 

--- a/wagtail/search/tests/test_elasticsearch2_backend.py
+++ b/wagtail/search/tests/test_elasticsearch2_backend.py
@@ -853,7 +853,6 @@ class TestBackendConfiguration(TestCase):
         )
 
 
-
 class TestGetModelRoot(TestCase):
     def test_root_model(self):
         from wagtail.core.models import Page

--- a/wagtail/search/tests/test_elasticsearch2_backend.py
+++ b/wagtail/search/tests/test_elasticsearch2_backend.py
@@ -833,6 +833,26 @@ class TestBackendConfiguration(TestCase):
             timeout=10
         )
 
+    def test_urls_as_string_works(self, Elasticsearch):
+        Elasticsearch2SearchBackend(params={
+            'URLS': 'http://localhost:9200'
+        })
+
+        Elasticsearch.assert_called_with(
+            hosts=[
+                {
+                    'host': 'localhost',
+                    'port': 9200,
+                    'url_prefix': '',
+                    'use_ssl': False,
+                    'verify_certs': False,
+                    'http_auth': None,
+                }
+            ],
+            timeout=10
+        )
+
+
 
 class TestGetModelRoot(TestCase):
     def test_root_model(self):


### PR DESCRIPTION
Fixes #6424 

This way, a string attribute is converted to a list of one item.

I had some trouble running the elasticsearch tests so I am hoping that the pull request will pass through the automated tests in Travis CI.
