### PR TITLE
5950 add parameters to mailto links

### DIFF
--- a/wagtail/admin/forms/choosers.py
+++ b/wagtail/admin/forms/choosers.py
@@ -39,6 +39,8 @@ class AnchorLinkChooserForm(forms.Form):
 class EmailLinkChooserForm(forms.Form):
     email_address = forms.EmailField(required=True)
     link_text = forms.CharField(required=False)
+    subject = forms.CharField(required=False)
+    body = forms.CharField(required=False)
 
 
 class PhoneLinkChooserForm(forms.Form):

--- a/wagtail/admin/tests/test_page_chooser.py
+++ b/wagtail/admin/tests/test_page_chooser.py
@@ -663,6 +663,13 @@ class TestChooserEmailLink(TestCase, WagtailTestUtils):
         self.assertEqual(result['title'], "contact")  # When link text is given, it is used
         self.assertEqual(result['prefer_this_title_as_link_text'], True)
 
+    def test_create_link_with_subject_and_body(self):
+        response = self.post({'email-link-chooser-email_address': 'example@example.com', 'email-link-chooser-subject': 'Awesome Subject', 'email-link-chooser-body': 'An example body', 'email-link-chooser-link_text': 'contact'})
+        result = json.loads(response.content.decode())['result']
+        self.assertEqual(result['url'], "mailto:example@example.com?subject=Awesome%20Subject&body=An%20example%20body")
+        self.assertEqual(result['title'], "contact")  # When link text is given, it is used
+        self.assertEqual(result['prefer_this_title_as_link_text'], True)
+
     def test_create_link_without_text(self):
         response = self.post({'email-link-chooser-email_address': 'example@example.com'})
         result = json.loads(response.content.decode())['result']

--- a/wagtail/admin/views/chooser.py
+++ b/wagtail/admin/views/chooser.py
@@ -15,10 +15,10 @@ from wagtail.core.utils import resolve_model_string
 try:
     import urlparse
     from urllib import urlencode
-except: # For Python 3
+except ImportError:  # For Python 3
     import urllib.parse as urlparse
     from urllib.parse import urlencode
-    
+
 
 def shared_context(request, extra_context=None):
     context = {
@@ -292,14 +292,14 @@ def email_link(request):
     if request.method == 'POST':
         form = EmailLinkChooserForm(request.POST, initial=initial_data, prefix='email-link-chooser')
 
-        if form.is_valid():            
-            params = { 
-                'subject': form.cleaned_data['subject'], 
-                'body': form.cleaned_data['body'], 
+        if form.is_valid():
+            params = {
+                'subject': form.cleaned_data['subject'],
+                'body': form.cleaned_data['body'],
             }
-            encoded_params = urlencode({k: v for k, v in params.items() if v is not None and v is not ''}, quote_via=urlparse.quote)
+            encoded_params = urlencode({k: v for k, v in params.items() if v is not None and v != ''}, quote_via=urlparse.quote)
 
-            url = 'mailto:' + form.cleaned_data['email_address'] 
+            url = 'mailto:' + form.cleaned_data['email_address']
             if encoded_params:
                 url += '?' + encoded_params
 


### PR DESCRIPTION
This PR adds a `subject` and `body` field to the email link in the RichText Editor. 

It does not completely solve #5950 as I didn't add the `cc` & `bcc` fields. The reason for this, is that the standard allows multiple email address in the 'cc' and 'bcc' (actually in the `to` as well – and it should be optional, but that's another story 😉 ) 