### PR TITLE
Fix privacy switcher panel padding

### DIFF
--- a/wagtail/admin/static_src/wagtailadmin/scss/layouts/page-editor.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/layouts/page-editor.scss
@@ -127,7 +127,8 @@
     }
 
     fieldset,
-    .field-row {
+    .field-row,
+    .object-content-wrapper {
         padding-top: $object-title-height + 12px;
     }
 
@@ -138,6 +139,10 @@
         .field-row {
             padding-top: 0;
         }
+    }
+
+    .object-content-wrapper {
+        padding-bottom: 2em;
     }
 
     .object-help {

--- a/wagtail/admin/templates/wagtailadmin/pages/privacy_switch_panel.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/privacy_switch_panel.html
@@ -6,22 +6,25 @@
 {% endif %}
 
 {% if not page.is_root %}
-<div class="field-row privacy-indicator {% if is_public %}public{% else %}private{% endif %}">
-    <p>
-        {% trans "Current status:" %}
+<div class="object-content-wrapper privacy-indicator {% if is_public %}public{% else %}private{% endif %}">
+    <ul class="fields">
+        <li>
+            {% trans "Current status:" %}
 
-        <span class="label-public icon icon-view" aria-label="{% trans 'Page privacy. Current status: Public' %}">
-             {% trans "Public" %}
-        </span>
-        <span class="label-private icon icon-no-view" aria-label="{% trans 'Page privacy. Current status: Private' %}">
-            {% trans "Private" %}
-        </span>
-    </p>
-
-    {% if page.id and page_perms.can_set_view_restrictions %}
-        <button data-url="{% url 'wagtailadmin_pages:set_privacy' page.id %}" class="button action-set-privacy">
-            {% trans "Set page privacy" %}
-        </button>
-    {% endif %}
+            <span class="label-public icon icon-view" aria-label="{% trans 'Page privacy. Current status: Public' %}">
+                 {% trans "Public" %}
+            </span>
+            <span class="label-private icon icon-no-view" aria-label="{% trans 'Page privacy. Current status: Private' %}">
+                {% trans "Private" %}
+            </span>
+        </li>
+        {% if page.id and page_perms.can_set_view_restrictions %}
+        <li>
+            <button data-url="{% url 'wagtailadmin_pages:set_privacy' page.id %}" class="button action-set-privacy">
+                {% trans "Set page privacy" %}
+            </button>
+        </li>
+        {% endif %}
+    </ul>
 </div>
 {% endif %}

--- a/wagtail/admin/tests/test_privacy.py
+++ b/wagtail/admin/tests/test_privacy.py
@@ -349,8 +349,8 @@ class TestPrivacyIndicators(TestCase, WagtailTestUtils):
 
         # Check the privacy indicator is public
         self.assertTemplateUsed(response, 'wagtailadmin/pages/privacy_switch_panel.html')
-        self.assertContains(response, '<div class="field-row privacy-indicator public">')
-        self.assertNotContains(response, '<div class="field-row privacy-indicator private">')
+        self.assertContains(response, '<div class="object-content-wrapper privacy-indicator public">')
+        self.assertNotContains(response, '<div class="object-content-wrapper privacy-indicator private">')
 
     def test_edit_private(self):
         """
@@ -363,8 +363,8 @@ class TestPrivacyIndicators(TestCase, WagtailTestUtils):
 
         # Check the privacy indicator is public
         self.assertTemplateUsed(response, 'wagtailadmin/pages/privacy_switch_panel.html')
-        self.assertContains(response, '<div class="field-row privacy-indicator private">')
-        self.assertNotContains(response, '<div class="field-row privacy-indicator public">')
+        self.assertContains(response, '<div class="object-content-wrapper privacy-indicator private">')
+        self.assertNotContains(response, '<div class="object-content-wrapper privacy-indicator public">')
 
     def test_edit_private_child(self):
         """
@@ -377,5 +377,5 @@ class TestPrivacyIndicators(TestCase, WagtailTestUtils):
 
         # Check the privacy indicator is public
         self.assertTemplateUsed(response, 'wagtailadmin/pages/privacy_switch_panel.html')
-        self.assertContains(response, '<div class="field-row privacy-indicator private">')
-        self.assertNotContains(response, '<div class="field-row privacy-indicator public">')
+        self.assertContains(response, '<div class="object-content-wrapper privacy-indicator private">')
+        self.assertNotContains(response, '<div class="object-content-wrapper privacy-indicator public">')


### PR DESCRIPTION
This PR fixes #6446

The issue was in a class combination (resulting in negative bottom margin being applied)

Here's a screenshot with the fix applied.
![Screenshot 2020-10-09 at 18 41 59](https://user-images.githubusercontent.com/31622/95614954-51793180-0a5f-11eb-839d-1023bca2de0a.png)

I tested across several browsers, but worth double checking