### PR TITLE
Fix spacing around the privacy indicator panel.

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/pages/privacy_switch_panel.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/privacy_switch_panel.html
@@ -6,22 +6,24 @@
 {% endif %}
 
 {% if not page.is_root %}
-<div class="field-row privacy-indicator {% if is_public %}public{% else %}private{% endif %}">
-    <p>
-        {% trans "Current status:" %}
+<div class="privacy-indicator {% if is_public %}public{% else %}private{% endif %}">
+    <fieldset>
+        <p>
+            {% trans "Current status:" %}
 
-        <span class="label-public icon icon-view" aria-label="{% trans 'Page privacy. Current status: Public' %}">
-             {% trans "Public" %}
-        </span>
-        <span class="label-private icon icon-no-view" aria-label="{% trans 'Page privacy. Current status: Private' %}">
-            {% trans "Private" %}
-        </span>
-    </p>
+            <span class="label-public icon icon-view" aria-label="{% trans 'Page privacy. Current status: Public' %}">
+                {% trans "Public" %}
+            </span>
+            <span class="label-private icon icon-no-view" aria-label="{% trans 'Page privacy. Current status: Private' %}">
+                {% trans "Private" %}
+            </span>
+        </p>
 
-    {% if page.id and page_perms.can_set_view_restrictions %}
-        <button data-url="{% url 'wagtailadmin_pages:set_privacy' page.id %}" class="button action-set-privacy">
-            {% trans "Set page privacy" %}
-        </button>
-    {% endif %}
+        {% if page.id and page_perms.can_set_view_restrictions %}
+            <button data-url="{% url 'wagtailadmin_pages:set_privacy' page.id %}" class="button action-set-privacy">
+                {% trans "Set page privacy" %}
+            </button>
+        {% endif %}
+    </fieldset>
 </div>
 {% endif %}

--- a/wagtail/admin/tests/test_privacy.py
+++ b/wagtail/admin/tests/test_privacy.py
@@ -349,8 +349,8 @@ class TestPrivacyIndicators(TestCase, WagtailTestUtils):
 
         # Check the privacy indicator is public
         self.assertTemplateUsed(response, 'wagtailadmin/pages/privacy_switch_panel.html')
-        self.assertContains(response, '<div class="field-row privacy-indicator public">')
-        self.assertNotContains(response, '<div class="field-row privacy-indicator private">')
+        self.assertContains(response, '<div class="privacy-indicator public">')
+        self.assertNotContains(response, '<div class="privacy-indicator private">')
 
     def test_edit_private(self):
         """
@@ -363,8 +363,8 @@ class TestPrivacyIndicators(TestCase, WagtailTestUtils):
 
         # Check the privacy indicator is public
         self.assertTemplateUsed(response, 'wagtailadmin/pages/privacy_switch_panel.html')
-        self.assertContains(response, '<div class="field-row privacy-indicator private">')
-        self.assertNotContains(response, '<div class="field-row privacy-indicator public">')
+        self.assertContains(response, '<div class="privacy-indicator private">')
+        self.assertNotContains(response, '<div class="privacy-indicator public">')
 
     def test_edit_private_child(self):
         """
@@ -377,5 +377,5 @@ class TestPrivacyIndicators(TestCase, WagtailTestUtils):
 
         # Check the privacy indicator is public
         self.assertTemplateUsed(response, 'wagtailadmin/pages/privacy_switch_panel.html')
-        self.assertContains(response, '<div class="field-row privacy-indicator private">')
-        self.assertNotContains(response, '<div class="field-row privacy-indicator public">')
+        self.assertContains(response, '<div class="privacy-indicator private">')
+        self.assertNotContains(response, '<div class="privacy-indicator public">')


### PR DESCRIPTION
Fixes #6446 

I did two things:
* Wrapped the whole privacy indicator in a `fieldset` tag. It seems that most field panels do this anyway so this creates a uniform way of spacing things for a panel. 
* Removed the `field-row` class which gives a negative bottom margin.

After the change, this is how the panel looks with additional `FieldPanels`:

<img width="884" alt="Screenshot 2020-10-09 at 17 40 07" src="https://user-images.githubusercontent.com/143557/95615057-1a068700-0a57-11eb-933d-b43643c372a7.png">
