### PR TITLE
Update help text to use SVG icons

### DIFF
--- a/wagtail/admin/static_src/wagtailadmin/scss/layouts/page-editor.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/layouts/page-editor.scss
@@ -151,6 +151,10 @@
         padding-left: 3em;
         opacity: 1;
 
+        .icon-help {
+            margin-left: -1.75em;
+        }
+
         .icon-help-inverse {
             float: left;
             margin-left: -2em;

--- a/wagtail/admin/static_src/wagtailadmin/scss/layouts/page-editor.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/layouts/page-editor.scss
@@ -154,12 +154,6 @@
         .icon-help {
             margin-left: -1.75em;
         }
-
-        .icon-help-inverse {
-            float: left;
-            margin-left: -2em;
-            margin-top: 0.3em;
-        }
     }
 
     &:hover .object-help {

--- a/wagtail/admin/templates/wagtailadmin/block_forms/sequence.html
+++ b/wagtail/admin/templates/wagtailadmin/block_forms/sequence.html
@@ -13,10 +13,12 @@
 
 {% endcomment %}
 
+{% load wagtailadmin_tags  %}
+
 {% if help_text %}
     <span>
         <div class="help">
-            <span class="icon-help-inverse" aria-hidden="true"></span>
+            {% icon name="help" class_name="default" %}
             {{ help_text }}
         </div>
     </span>

--- a/wagtail/admin/templates/wagtailadmin/block_forms/struct.html
+++ b/wagtail/admin/templates/wagtailadmin/block_forms/struct.html
@@ -1,8 +1,10 @@
+{% load wagtailadmin_tags  %}
+
 <div class="{{ classname }}">
     {% if help_text %}
         <span>
             <div class="help">
-                <span class="icon-help-inverse" aria-hidden="true"></span>
+                {% icon name="help" class_name="default" %}
                 {{ help_text }}
             </div>
         </span>

--- a/wagtail/admin/templates/wagtailadmin/edit_handlers/object_list.html
+++ b/wagtail/admin/templates/wagtailadmin/edit_handlers/object_list.html
@@ -1,3 +1,5 @@
+{% load wagtailadmin_tags  %}
+
 <ul class="objects">
     {% for child in self.children %}
         <li class="object {{ child.classes|join:" " }}">
@@ -11,7 +13,10 @@
             <div class="object-layout">
                 {% if child.help_text %}
                 <div class="object-layout_small-part">
-                    <div class="object-help help"><span class="icon-help-inverse" aria-hidden="true"></span>{{ child.help_text }}</div>
+                    <div class="object-help help">
+                        {% icon name="help" class_name="default" %}
+                        {{ child.help_text }}
+                    </div>
                 </div>
                 {% endif %}
                 <div class="object-layout_big-part">

--- a/wagtail/admin/tests/test_edit_handlers.py
+++ b/wagtail/admin/tests/test_edit_handlers.py
@@ -388,7 +388,7 @@ class TestObjectList(TestCase):
         self.assertInHTML('<label for="id_date_from">Start date</label>', result)
 
         # result should include help text for children
-        self.assertIn('<div class="object-help help"><span class="icon-help-inverse" aria-hidden="true"></span>Not required if event is on a single day</div>', result)
+        self.assertInHTML('<div class="object-help help"> <svg class="icon icon-help default" aria-hidden="true" focusable="false"><use href="#icon-help"></use></svg> Not required if event is on a single day</div>', result)
 
         # result should contain rendered content from descendants
         self.assertIn('Abergavenny sheepdog trials</textarea>', result)

--- a/wagtail/core/tests/test_blocks.py
+++ b/wagtail/core/tests/test_blocks.py
@@ -1630,7 +1630,7 @@ class TestStructBlock(SimpleTestCase):
             'link': 'http://www.wagtail.io',
         }), prefix='mylink')
 
-        self.assertInHTML('<div class="help"><span class="icon-help-inverse" aria-hidden="true"></span> Self-promotion is encouraged</div>', html)
+        self.assertInHTML('<div class="help"> <svg class="icon icon-help default" aria-hidden="true" focusable="false"><use href="#icon-help"></use></svg>  Self-promotion is encouraged</div>', html)
 
         # check it can be overridden in the block constructor
         block = LinkBlock(help_text="Self-promotion is discouraged")
@@ -1639,7 +1639,7 @@ class TestStructBlock(SimpleTestCase):
             'link': 'http://www.wagtail.io',
         }), prefix='mylink')
 
-        self.assertInHTML('<div class="help"><span class="icon-help-inverse" aria-hidden="true"></span> Self-promotion is discouraged</div>', html)
+        self.assertInHTML('<div class="help"> <svg class="icon icon-help default" aria-hidden="true" focusable="false"><use href="#icon-help"></use></svg>  Self-promotion is discouraged</div>', html)
 
     def test_media_inheritance(self):
         class ScriptedCharBlock(blocks.CharBlock):


### PR DESCRIPTION
This PR updates the icons in help text to use SVG icons.

As it turns out, the existing icon was some sort of construction made only with CSS (source [here](https://github.com/wagtail/wagtail/blob/82a2002f2d7463a5082908479c878c30e4a61192/client/scss/components/_icons.scss#L140-L156), [here](https://github.com/wagtail/wagtail/blob/82a2002f2d7463a5082908479c878c30e4a61192/wagtail/admin/static_src/wagtailadmin/scss/layouts/page-editor.scss#L158-L162), and [here](https://github.com/wagtail/wagtail/blob/82a2002f2d7463a5082908479c878c30e4a61192/client/scss/settings/_variables.icons.scss#L34-L35)). The icon font did not have a circled dark-on-light question mark, and the new set of SVGs does not, either.

So, I guess, strictly speaking, this update was not _necessary,_ except insofar as we plan to remove the whole suite of old icon-generation code when we finish the SVG transition. The approach I've taken here is to replace the constructed icon with the light-on-dark question mark SVG icon. This makes the icon more prominent, but I personally think that that's a usability improvement. I am not sure that the help text called enough attention to itself previously. But if anyone objects to this, we can roll it back.

before | after
--- | ---
![existing inverse icon](https://user-images.githubusercontent.com/1044670/95790673-d9ed1180-0cad-11eb-94fc-2e9398fbcce6.png) | ![new svg icon](https://user-images.githubusercontent.com/1044670/95790735-f6894980-0cad-11eb-830c-d13fe908bec1.png)


- [x] Do the tests still pass? (https://docs.wagtail.io/en/latest/contributing/developing.html#testing)
- [x] Does the code comply with the style guide? (Run `make lint` from the Wagtail root)
- [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
- [x] For front-end changes: Did you test on all of Wagtail’s supported browsers?
  - [x] Chrome
  - [x] Firefox
  - [x] IE 11
  - [x] Safari
  - [x] Edge 18
  - [x] iOS Safari
  - [x] Android Chrome