### PR TITLE
Add locale switchers to page edit, create and listing views

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/pages/create.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/create.html
@@ -28,6 +28,13 @@
     <form id="page-edit-form" action="{% url 'wagtailadmin_pages:add' content_type.app_label content_type.model parent_page.id %}" method="POST" novalidate{% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>
         {% csrf_token %}
         <input type="hidden" name="next" value="{{ next }}">
+
+        {% if parent_page.is_root %}
+            {# The user is allowed to set a different locale for pages created at the root #}
+            {# If they've done this, make sure their chosen locale is passed in the form #}
+            <input type="hidden" name="locale" value="{{ locale.language_code }}">
+        {% endif %}
+
         {{ edit_handler.render_form_content }}
 
         <footer>

--- a/wagtail/admin/templates/wagtailadmin/pages/create.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/create.html
@@ -15,6 +15,14 @@
                 <h1>{% trans 'New' %} <span>{{ content_type.model_class.get_verbose_name }}</span></h1>
             </div>
         </div>
+
+        {% if locale %}
+        <ul class="row header-meta">
+            <li class="header-meta--locale">
+                {% include "wagtailadmin/shared/locale_selector.html" %}
+            </li>
+        </ul>
+        {% endif %}
     </header>
 
     <form id="page-edit-form" action="{% url 'wagtailadmin_pages:add' content_type.app_label content_type.model parent_page.id %}" method="POST" novalidate{% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>

--- a/wagtail/admin/templates/wagtailadmin/pages/edit.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/edit.html
@@ -33,6 +33,11 @@
                 {% icon name="doc-empty-inverse" class_name="default" %}
                 {{ content_type.model_class.get_verbose_name }}
             </li>
+            {% if locale %}
+            <li class="header-meta--locale">
+                {% include "wagtailadmin/shared/locale_selector.html" %}
+            </li>
+            {% endif %}
         </ul>
     </header>
 

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_parent_page_title_explore.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_parent_page_title_explore.html
@@ -17,4 +17,10 @@
 
 <ul class="actions">
     {% page_listing_buttons parent_page parent_page_perms is_parent=True %}
+
+    {% if locale %}
+    <li class="header-meta--locale">
+        {% include "wagtailadmin/shared/locale_selector.html" %}
+    </li>
+    {% endif %}
 </ul>

--- a/wagtail/admin/templates/wagtailadmin/shared/locale_selector.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/locale_selector.html
@@ -1,0 +1,27 @@
+{# Based on listing/_button_with_dropdown.html #}
+{% load wagtailadmin_tags %}
+{% if translations %}
+    <div class="c-dropdown t-inverted" style="display: inline-block;" data-dropdown>
+        <a href="javascript:void(0)" aria-label="{{ locale.get_display_name }}" class="c-dropdown__button  u-btn-current">
+            {% icon name="site" class_name="default" %}
+            {{ locale.get_display_name }}
+            <div data-dropdown-toggle class="o-icon c-dropdown__toggle c-dropdown__togle--icon [ icon icon-arrow-down ]">
+                {% icon name="arrow-down" %}{% icon name="arrow-up" %}
+            </div>
+        </a>
+        <div class="t-dark">
+            <ul class="c-dropdown__menu u-toggle  u-arrow u-arrow--tl u-background">
+            {% for translation in translations %}
+                <li class="c-dropdown__item ">
+                    <a href="{{ translation.url }}" aria-label="{{ translation.locale.get_display_name }}" class="u-link is-live">
+                        {{ translation.locale.get_display_name }}
+                    </a>
+                </li>
+            {% endfor %}
+            </ul>
+        </div>
+    </div>
+{% else %}
+    {% icon name="site" class_name="default" %}
+    {{ locale.get_display_name }}
+{% endif %}

--- a/wagtail/admin/tests/pages/test_create_page.py
+++ b/wagtail/admin/tests/pages/test_create_page.py
@@ -1081,3 +1081,34 @@ class TestLocaleSelector(TestCase, WagtailTestUtils):
 
         add_translation_url = reverse('wagtailadmin_pages:add', args=['tests', 'eventpage', self.translated_events_page.id])
         self.assertNotContains(response, f'<a href="{add_translation_url}" aria-label="French" class="u-link is-live">')
+
+
+@override_settings(WAGTAIL_I18N_ENABLED=True)
+class TestLocaleSelectorOnRootPage(TestCase, WagtailTestUtils):
+    fixtures = ['test.json']
+
+    def setUp(self):
+        self.root_page = Page.objects.get(id=1)
+        self.fr_locale = Locale.objects.create(language_code='fr')
+        self.user = self.login()
+
+    def test_locale_selector(self):
+        response = self.client.get(
+            reverse('wagtailadmin_pages:add', args=['demosite', 'homepage', self.root_page.id])
+        )
+
+        self.assertContains(response, '<li class="header-meta--locale">')
+
+        add_translation_url = reverse('wagtailadmin_pages:add', args=['demosite', 'homepage', self.root_page.id]) + '?locale=fr'
+        self.assertContains(response, f'<a href="{add_translation_url}" aria-label="French" class="u-link is-live">')
+
+    @override_settings(WAGTAIL_I18N_ENABLED=False)
+    def test_locale_selector_not_present_when_i18n_disabled(self):
+        response = self.client.get(
+            reverse('wagtailadmin_pages:add', args=['demosite', 'homepage', self.root_page.id])
+        )
+
+        self.assertNotContains(response, '<li class="header-meta--locale">')
+
+        add_translation_url = reverse('wagtailadmin_pages:add', args=['demosite', 'homepage', self.root_page.id]) + '?locale=fr'
+        self.assertNotContains(response, f'<a href="{add_translation_url}" aria-label="French" class="u-link is-live">')


### PR DESCRIPTION
This PR implements a new locale switcher component and adds it to the page edit, creation and listing views.

On the page explorer: it shows the language of the current page being explored. This is only hidden when exploring the root page.

![image](https://user-images.githubusercontent.com/1093808/95892995-42f08a00-0d7f-11eb-80d8-ccbcf42cf525.png)

![image](https://user-images.githubusercontent.com/1093808/95893034-4e43b580-0d7f-11eb-8233-a7ea8fd7a30d.png)

On page creation, it shows the translations of the parent page. Changing language here changes the parent page, unless it's the root page which is the only page that can have children in different locales:
![image](https://user-images.githubusercontent.com/1093808/95893180-81864480-0d7f-11eb-9592-bf9ac511d5b6.png)

On pag eedit, this switches between translations of the page
![image](https://user-images.githubusercontent.com/1093808/95893270-a5e22100-0d7f-11eb-8710-b26765d47e42.png)

If there are no translations the styling changes from a selector to an indicator (same in all other places too):
![image](https://user-images.githubusercontent.com/1093808/95893534-d88c1980-0d7f-11eb-83df-deaa8f2b892f.png)

