### PR TITLE
Upgrade isort and add pre-commit support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+  - repo: https://github.com/timothycrosley/isort
+    # isort config is in setup.cfg
+    rev: 5.6.4
+    hooks:
+      - id: isort
+        language_version: python3
+  - repo: https://gitlab.com/pycqa/flake8
+    # flake8 config is in setup.cfg
+    rev: 3.8.4
+    hooks:
+      - id: flake8
+        language_version: python3

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,8 @@ multi_line_output=4
 skip=migrations,project_template
 known_first_party=wagtail
 default_section=THIRDPARTY
+lines_between_types=1
+lines_after_imports=2
 
 [tool:pytest]
 django_find_project = false

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,9 @@
 from wagtail import __version__
 from wagtail.utils.setup import assets, check_bdist_egg, sdist
 
+
 try:
-    from setuptools import setup, find_packages
+    from setuptools import find_packages, setup
 except ImportError:
     from distutils.core import setup
 
@@ -55,7 +56,7 @@ testing_extras = [
     # For coverage and PEP8 linting
     'coverage>=3.7.0',
     'flake8>=3.6.0',
-    'isort==4.2.5',
+    'isort>=5.6.0,<6.0',
     'flake8-blind-except==0.1.1',
     'flake8-print==2.0.2',
     'doc8==0.8.1',

--- a/tox.ini
+++ b/tox.ini
@@ -60,5 +60,5 @@ setenv =
 
 [testenv:flake8]
 basepython=python3.6
-deps=flake8>=2.2.0
+deps=flake8>=3.6.0
 commands=flake8

--- a/wagtail/__init__.py
+++ b/wagtail/__init__.py
@@ -4,6 +4,7 @@
 
 from wagtail.utils.version import get_semver_version, get_version
 
+
 # major.minor.patch.release.number
 # release must be one of alpha, beta, rc, or final
 VERSION = (2, 11, 0, 'alpha', 0)

--- a/wagtail/admin/api/urls.py
+++ b/wagtail/admin/api/urls.py
@@ -5,6 +5,7 @@ from wagtail.core import hooks
 
 from .views import PagesAdminAPIViewSet
 
+
 admin_api = WagtailAPIRouter('wagtailadmin_api')
 admin_api.register_endpoint('pages', PagesAdminAPIViewSet)
 

--- a/wagtail/admin/auth.py
+++ b/wagtail/admin/auth.py
@@ -1,4 +1,5 @@
 import types
+
 from functools import wraps
 
 import l18n

--- a/wagtail/admin/blocks.py
+++ b/wagtail/admin/blocks.py
@@ -2,4 +2,5 @@ import warnings
 
 from wagtail.core.blocks import *  # noqa
 
+
 warnings.warn("wagtail.admin.blocks has moved to wagtail.core.blocks", UserWarning, stacklevel=2)

--- a/wagtail/admin/checks.py
+++ b/wagtail/admin/checks.py
@@ -92,8 +92,8 @@ def inline_panel_model_panels_check(app_configs, **kwargs):
 
 def check_panels_in_model(cls, context='model'):
     """Check panels configuration uses `panels` when `edit_handler` not in use."""
-    from wagtail.core.models import Page
     from wagtail.admin.edit_handlers import BaseCompositeEditHandler, InlinePanel
+    from wagtail.core.models import Page
 
     errors = []
 

--- a/wagtail/admin/filters.py
+++ b/wagtail/admin/filters.py
@@ -1,4 +1,5 @@
 import django_filters
+
 from django.contrib.auth import get_user_model
 from django.db import models
 from django.utils.translation import gettext_lazy as _

--- a/wagtail/admin/forms/__init__.py
+++ b/wagtail/admin/forms/__init__.py
@@ -1,5 +1,5 @@
 # definitions which are not being deprecated from wagtail.admin.forms
 from .models import (  # NOQA
-    FORM_FIELD_OVERRIDES, DIRECT_FORM_FIELD_OVERRIDES, formfield_for_dbfield, WagtailAdminModelFormMetaclass, WagtailAdminModelForm
-)
+    DIRECT_FORM_FIELD_OVERRIDES, FORM_FIELD_OVERRIDES, WagtailAdminModelForm,
+    WagtailAdminModelFormMetaclass, formfield_for_dbfield)
 from .pages import WagtailAdminPageForm  # NOQA

--- a/wagtail/admin/jinja2tags.py
+++ b/wagtail/admin/jinja2tags.py
@@ -1,4 +1,5 @@
 import jinja2
+
 from jinja2.ext import Extension
 
 from .templatetags.wagtailuserbar import wagtailuserbar

--- a/wagtail/admin/models.py
+++ b/wagtail/admin/models.py
@@ -1,6 +1,5 @@
 from django.contrib.contenttypes.models import ContentType
 from django.db.models import Count
-
 from modelcluster.fields import ParentalKey
 from taggit.models import Tag
 

--- a/wagtail/admin/rich_text/__init__.py
+++ b/wagtail/admin/rich_text/__init__.py
@@ -1,10 +1,9 @@
 from django.conf import settings
 from django.utils.module_loading import import_string
 
-from wagtail.admin.rich_text.editors.hallo import (  # NOQA
-    HalloFormatPlugin, HalloHeadingPlugin, HalloListPlugin, HalloPlugin, HalloRichTextArea
-)
 from wagtail.admin.rich_text.editors.draftail import DraftailRichTextArea  # NOQA
+from wagtail.admin.rich_text.editors.hallo import (  # NOQA
+    HalloFormatPlugin, HalloHeadingPlugin, HalloListPlugin, HalloPlugin, HalloRichTextArea)
 
 
 DEFAULT_RICH_TEXT_EDITORS = {

--- a/wagtail/admin/rich_text/converters/contentstate_models.py
+++ b/wagtail/admin/rich_text/converters/contentstate_models.py
@@ -2,6 +2,7 @@ import json
 import random
 import string
 
+
 ALPHANUM = string.ascii_lowercase + string.digits
 
 

--- a/wagtail/admin/rich_text/converters/html_ruleset.py
+++ b/wagtail/admin/rich_text/converters/html_ruleset.py
@@ -1,5 +1,7 @@
 import re
+
 from collections.abc import Mapping
+
 
 ELEMENT_SELECTOR = re.compile(r'^([\w-]+)$')
 ELEMENT_WITH_ATTR_SELECTOR = re.compile(r'^([\w-]+)\[([\w-]+)\]$')

--- a/wagtail/admin/rich_text/converters/html_to_contentstate.py
+++ b/wagtail/admin/rich_text/converters/html_to_contentstate.py
@@ -1,4 +1,5 @@
 import re
+
 from html.parser import HTMLParser
 
 from wagtail.admin.rich_text.converters.contentstate_models import (
@@ -6,6 +7,7 @@ from wagtail.admin.rich_text.converters.contentstate_models import (
 from wagtail.admin.rich_text.converters.html_ruleset import HTMLRuleset
 from wagtail.core.models import Page
 from wagtail.core.rich_text import features as feature_registry
+
 
 # constants to keep track of what to do with leading whitespace on the next text node we encounter
 STRIP_WHITESPACE = 0

--- a/wagtail/admin/rich_text/editors/draftail/features.py
+++ b/wagtail/admin/rich_text/editors/draftail/features.py
@@ -2,6 +2,7 @@ from django.forms import Media
 
 from wagtail.admin.staticfiles import versioned_static
 
+
 # Feature objects: these are mapped to feature identifiers within the rich text
 # feature registry (wagtail.core.rich_text.features). Each one implements
 # a `construct_options` method which modifies an options dict as appropriate to

--- a/wagtail/admin/rich_text/editors/hallo.py
+++ b/wagtail/admin/rich_text/editors/hallo.py
@@ -1,4 +1,5 @@
 import json
+
 from collections import OrderedDict
 
 from django.forms import Media, widgets

--- a/wagtail/admin/signal_handlers.py
+++ b/wagtail/admin/signal_handlers.py
@@ -5,6 +5,7 @@ from wagtail.core.models import TaskState, WorkflowState
 from wagtail.core.signals import (
     task_submitted, workflow_approved, workflow_rejected, workflow_submitted)
 
+
 task_submission_email_notifier = GroupApprovalTaskStateSubmissionEmailNotifier()
 workflow_submission_email_notifier = WorkflowStateSubmissionEmailNotifier()
 workflow_approval_email_notifier = WorkflowStateApprovalEmailNotifier()

--- a/wagtail/admin/signals.py
+++ b/wagtail/admin/signals.py
@@ -1,3 +1,4 @@
 from django.dispatch import Signal
 
+
 init_new_page = Signal(providing_args=['page', 'parent'])

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -1,7 +1,7 @@
 import json
 import warnings
-from datetime import datetime
 
+from datetime import datetime
 from urllib.parse import urljoin
 
 from django import template
@@ -27,11 +27,14 @@ from wagtail.admin.search import admin_search_areas
 from wagtail.admin.staticfiles import versioned_static as versioned_static_func
 from wagtail.core import hooks
 from wagtail.core.models import (
-    Collection, CollectionViewRestriction, Page, PageLogEntry, PageViewRestriction, UserPagePermissionsProxy)
+    Collection, CollectionViewRestriction, Page, PageLogEntry, PageViewRestriction,
+    UserPagePermissionsProxy)
+from wagtail.core.utils import accepts_kwarg, camelcase_to_underscore
 from wagtail.core.utils import cautious_slugify as _cautious_slugify
-from wagtail.core.utils import accepts_kwarg, camelcase_to_underscore, escape_script
+from wagtail.core.utils import escape_script
 from wagtail.users.utils import get_gravatar_url
 from wagtail.utils.deprecation import RemovedInWagtail212Warning
+
 
 register = template.Library()
 

--- a/wagtail/admin/tests/pages/test_create_page.py
+++ b/wagtail/admin/tests/pages/test_create_page.py
@@ -1,4 +1,5 @@
 import datetime
+
 from unittest import mock
 
 from django.contrib.auth.models import Group, Permission
@@ -13,8 +14,8 @@ from wagtail.admin.tests.pages.timestamps import submittable_timestamp
 from wagtail.core.models import GroupPagePermission, Locale, Page, PageRevision
 from wagtail.core.signals import page_published
 from wagtail.tests.testapp.models import (
-    BusinessChild, BusinessIndex, BusinessSubIndex, DefaultStreamPage, PersonPage,
-    SimplePage, SingletonPage, SingletonPageViaMaxCount, StandardChild, StandardIndex)
+    BusinessChild, BusinessIndex, BusinessSubIndex, DefaultStreamPage, PersonPage, SimplePage,
+    SingletonPage, SingletonPageViaMaxCount, StandardChild, StandardIndex)
 from wagtail.tests.utils import WagtailTestUtils
 
 

--- a/wagtail/admin/tests/pages/test_edit_page.py
+++ b/wagtail/admin/tests/pages/test_edit_page.py
@@ -1,5 +1,6 @@
 import datetime
 import os
+
 from unittest import mock
 
 from django.conf import settings
@@ -16,8 +17,9 @@ from wagtail.core.exceptions import PageClassNotFoundError
 from wagtail.core.models import Page, PageRevision, Site
 from wagtail.core.signals import page_published
 from wagtail.tests.testapp.models import (
-    EVENT_AUDIENCE_CHOICES, Advert, AdvertPlacement, EventCategory,
-    EventPage, EventPageCarouselItem, FilePage, ManyToManyBlogPage, SimplePage, SingleEventPage, StandardIndex, TaggedPage)
+    EVENT_AUDIENCE_CHOICES, Advert, AdvertPlacement, EventCategory, EventPage,
+    EventPageCarouselItem, FilePage, ManyToManyBlogPage, SimplePage, SingleEventPage, StandardIndex,
+    TaggedPage)
 from wagtail.tests.utils import WagtailTestUtils
 from wagtail.tests.utils.form_data import inline_formset, nested_form_data
 

--- a/wagtail/admin/tests/pages/test_moderation.py
+++ b/wagtail/admin/tests/pages/test_moderation.py
@@ -1,4 +1,5 @@
 import logging
+
 from itertools import chain
 from unittest import mock
 

--- a/wagtail/admin/tests/test_account_management.py
+++ b/wagtail/admin/tests/test_account_management.py
@@ -5,8 +5,8 @@ import pytz
 
 from django import VERSION as DJANGO_VERSION
 from django.conf import settings
-from django.contrib.auth import views as auth_views
 from django.contrib.auth import get_user_model
+from django.contrib.auth import views as auth_views
 from django.contrib.auth.models import Group, Permission
 from django.contrib.auth.tokens import PasswordResetTokenGenerator
 from django.core import mail

--- a/wagtail/admin/tests/test_compare.py
+++ b/wagtail/admin/tests/test_compare.py
@@ -9,8 +9,8 @@ from wagtail.images import get_image_model
 from wagtail.images.tests.utils import get_test_image_file
 from wagtail.tests.testapp.models import (
     AdvertWithCustomPrimaryKey, EventCategory, EventPage, EventPageSpeaker,
-    HeadCountRelatedModelUsingPK, SimplePage, SnippetChooserModelWithCustomPrimaryKey,
-    StreamPage, TaggedPage)
+    HeadCountRelatedModelUsingPK, SimplePage, SnippetChooserModelWithCustomPrimaryKey, StreamPage,
+    TaggedPage)
 
 
 class TestFieldComparison(TestCase):

--- a/wagtail/admin/tests/test_contentstate.py
+++ b/wagtail/admin/tests/test_contentstate.py
@@ -1,4 +1,5 @@
 import json
+
 from unittest.mock import patch
 
 from django.test import TestCase

--- a/wagtail/admin/tests/test_edit_handlers.py
+++ b/wagtail/admin/tests/test_edit_handlers.py
@@ -9,9 +9,8 @@ from django.core.exceptions import FieldDoesNotExist, ImproperlyConfigured
 from django.test import RequestFactory, TestCase, override_settings
 
 from wagtail.admin.edit_handlers import (
-    FieldPanel, FieldRowPanel, InlinePanel, ObjectList, PageChooserPanel,
-    RichTextFieldPanel, TabbedInterface, extract_panel_definitions_from_model_class,
-    get_form_for_model)
+    FieldPanel, FieldRowPanel, InlinePanel, ObjectList, PageChooserPanel, RichTextFieldPanel,
+    TabbedInterface, extract_panel_definitions_from_model_class, get_form_for_model)
 from wagtail.admin.forms import WagtailAdminModelForm, WagtailAdminPageForm
 from wagtail.admin.rich_text import DraftailRichTextArea
 from wagtail.admin.widgets import AdminAutoHeightTextInput, AdminDateInput, AdminPageChooser
@@ -19,8 +18,8 @@ from wagtail.core.models import Page, Site
 from wagtail.images.edit_handlers import ImageChooserPanel
 from wagtail.tests.testapp.forms import ValidatedPageForm
 from wagtail.tests.testapp.models import (
-    EventPage, EventPageChooserModel, EventPageSpeaker, PageChooserModel,
-    RestaurantPage, RestaurantTag, SimplePage, ValidatedPage)
+    EventPage, EventPageChooserModel, EventPageSpeaker, PageChooserModel, RestaurantPage,
+    RestaurantTag, SimplePage, ValidatedPage)
 from wagtail.tests.utils import WagtailTestUtils
 
 

--- a/wagtail/admin/tests/test_reports_views.py
+++ b/wagtail/admin/tests/test_reports_views.py
@@ -1,4 +1,5 @@
 import datetime
+
 from io import BytesIO
 
 from django.conf import settings

--- a/wagtail/admin/tests/test_rich_text.py
+++ b/wagtail/admin/tests/test_rich_text.py
@@ -11,8 +11,8 @@ from wagtail.admin.rich_text.editors.draftail.features import Feature
 from wagtail.admin.rich_text.editors.hallo import HalloPlugin
 from wagtail.core.blocks import RichTextBlock
 from wagtail.core.models import Page, get_page_models
-from wagtail.core.rich_text import features as feature_registry
 from wagtail.core.rich_text import RichText
+from wagtail.core.rich_text import features as feature_registry
 from wagtail.tests.testapp.models import SingleEventPage
 from wagtail.tests.testapp.rich_text import CustomRichTextArea
 from wagtail.tests.utils import WagtailTestUtils

--- a/wagtail/admin/tests/test_workflows.py
+++ b/wagtail/admin/tests/test_workflows.py
@@ -1,5 +1,6 @@
 import json
 import logging
+
 from unittest import mock
 
 from django.conf import settings
@@ -8,8 +9,8 @@ from django.core import mail
 from django.core.mail import EmailMultiAlternatives
 from django.test import TestCase, override_settings
 from django.urls import reverse
-
 from freezegun import freeze_time
+
 from wagtail.core.models import (
     GroupApprovalTask, Page, Task, TaskState, Workflow, WorkflowPage, WorkflowState, WorkflowTask)
 from wagtail.core.signals import page_published

--- a/wagtail/admin/urls/__init__.py
+++ b/wagtail/admin/urls/__init__.py
@@ -2,21 +2,21 @@ import functools
 import hashlib
 
 from django.conf import settings
+from django.http import Http404
 from django.urls import include, path, re_path
 from django.views.decorators.cache import never_cache
-from django.views.generic import TemplateView
-from django.http import Http404
 from django.views.defaults import page_not_found
+from django.views.generic import TemplateView
 
+from wagtail.admin.api import urls as api_urls
 from wagtail.admin.auth import require_admin_access
-from wagtail.admin.urls import pages as wagtailadmin_pages_urls
 from wagtail.admin.urls import collections as wagtailadmin_collections_urls
-from wagtail.admin.urls import reports as wagtailadmin_reports_urls
+from wagtail.admin.urls import pages as wagtailadmin_pages_urls
 from wagtail.admin.urls import password_reset as wagtailadmin_password_reset_urls
+from wagtail.admin.urls import reports as wagtailadmin_reports_urls
 from wagtail.admin.urls import workflows as wagtailadmin_workflows_urls
 from wagtail.admin.views import account, chooser, home, tags, userbar
 from wagtail.admin.views.pages import listing
-from wagtail.admin.api import urls as api_urls
 from wagtail.core import hooks
 from wagtail.utils.urlpatterns import decorate_urlpatterns
 

--- a/wagtail/admin/urls/collections.py
+++ b/wagtail/admin/urls/collections.py
@@ -2,6 +2,7 @@ from django.urls import path
 
 from wagtail.admin.views import collection_privacy, collections
 
+
 app_name = 'wagtailadmin_collections'
 urlpatterns = [
     path('', collections.Index.as_view(), name='index'),

--- a/wagtail/admin/urls/pages.py
+++ b/wagtail/admin/urls/pages.py
@@ -5,6 +5,7 @@ from wagtail.admin.views.pages import (
     convert_alias, copy, create, delete, edit, history, lock, moderation, move, ordering, preview,
     revisions, search, unpublish, usage, workflow)
 
+
 app_name = 'wagtailadmin_pages'
 urlpatterns = [
     path('add/<slug:content_type_app_name>/<slug:content_type_model_name>/<int:parent_page_id>/', create.CreateView.as_view(), name='add'),

--- a/wagtail/admin/urls/password_reset.py
+++ b/wagtail/admin/urls/password_reset.py
@@ -2,6 +2,7 @@ from django.urls import path
 
 from wagtail.admin.views import account
 
+
 urlpatterns = [
     path(
         '', account.PasswordResetView.as_view(), name='wagtailadmin_password_reset'

--- a/wagtail/admin/urls/reports.py
+++ b/wagtail/admin/urls/reports.py
@@ -2,6 +2,7 @@ from django.urls import path
 
 from wagtail.admin.views import reports
 
+
 app_name = 'wagtailadmin_reports'
 urlpatterns = [
     path('locked/', reports.LockedPagesView.as_view(), name='locked_pages'),

--- a/wagtail/admin/views/account.py
+++ b/wagtail/admin/views/account.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from django.contrib import messages
-from django.contrib.auth import views as auth_views
 from django.contrib.auth import update_session_auth_hash
+from django.contrib.auth import views as auth_views
 from django.contrib.auth.forms import PasswordChangeForm
 from django.http import Http404
 from django.shortcuts import redirect
@@ -14,7 +14,8 @@ from django.views.decorators.debug import sensitive_post_parameters
 from wagtail.admin.forms.auth import LoginForm, PasswordResetForm
 from wagtail.core import hooks
 from wagtail.users.forms import (
-    AvatarPreferencesForm, CurrentTimeZoneForm, EmailForm, NameForm, NotificationPreferencesForm, PreferredLanguageForm)
+    AvatarPreferencesForm, CurrentTimeZoneForm, EmailForm, NameForm, NotificationPreferencesForm,
+    PreferredLanguageForm)
 from wagtail.users.models import UserProfile
 from wagtail.utils.loading import get_custom_form
 

--- a/wagtail/admin/views/chooser.py
+++ b/wagtail/admin/views/chooser.py
@@ -5,7 +5,6 @@ from django.template.response import TemplateResponse
 
 from wagtail.admin.forms.choosers import (
     AnchorLinkChooserForm, EmailLinkChooserForm, ExternalLinkChooserForm, PhoneLinkChooserForm)
-
 from wagtail.admin.forms.search import SearchForm
 from wagtail.admin.modal_workflow import render_modal_workflow
 from wagtail.core import hooks

--- a/wagtail/admin/views/home.py
+++ b/wagtail/admin/views/home.py
@@ -15,6 +15,7 @@ from wagtail.core import hooks
 from wagtail.core.models import (
     Page, PageRevision, TaskState, UserPagePermissionsProxy, WorkflowState)
 
+
 User = get_user_model()
 
 

--- a/wagtail/admin/views/mixins.py
+++ b/wagtail/admin/views/mixins.py
@@ -1,5 +1,6 @@
 import csv
 import datetime
+
 from collections import OrderedDict
 
 from django.core.exceptions import FieldDoesNotExist

--- a/wagtail/admin/viewsets/__init__.py
+++ b/wagtail/admin/viewsets/__init__.py
@@ -1,4 +1,4 @@
-from django.urls import re_path, include
+from django.urls import include, re_path
 
 from wagtail.core import hooks
 

--- a/wagtail/admin/wagtail_hooks.py
+++ b/wagtail/admin/wagtail_hooks.py
@@ -1,11 +1,12 @@
 from django.contrib.auth.models import Permission
 from django.urls import reverse
 from django.utils.http import urlencode
-from django.utils.translation import gettext_lazy as _
 from django.utils.translation import gettext
+from django.utils.translation import gettext_lazy as _
 from draftjs_exporter.dom import DOM
 
 import wagtail.admin.rich_text.editors.draftail.features as draftail_features
+
 from wagtail.admin.auth import user_has_any_page_permission
 from wagtail.admin.localization import get_available_admin_languages, get_available_admin_time_zones
 from wagtail.admin.menu import MenuItem, SubmenuMenuItem, reports_menu, settings_menu

--- a/wagtail/admin/widgets/button.py
+++ b/wagtail/admin/widgets/button.py
@@ -1,4 +1,5 @@
 import warnings
+
 from functools import total_ordering
 
 from django.forms.utils import flatatt

--- a/wagtail/admin/widgets/tags.py
+++ b/wagtail/admin/widgets/tags.py
@@ -2,7 +2,6 @@ import json
 
 from django.conf import settings
 from django.urls import reverse
-
 from taggit.forms import TagWidget
 from taggit.models import Tag
 

--- a/wagtail/api/v2/tests/test_documents.py
+++ b/wagtail/api/v2/tests/test_documents.py
@@ -1,4 +1,5 @@
 import json
+
 from unittest import mock
 
 from django.test import TestCase

--- a/wagtail/api/v2/tests/test_images.py
+++ b/wagtail/api/v2/tests/test_images.py
@@ -1,4 +1,5 @@
 import json
+
 from unittest import mock
 
 from django.test import TestCase

--- a/wagtail/api/v2/tests/test_pages.py
+++ b/wagtail/api/v2/tests/test_pages.py
@@ -1,5 +1,6 @@
 import collections
 import json
+
 from unittest import mock
 
 from django.contrib.contenttypes.models import ContentType

--- a/wagtail/api/v2/tests/tests.py
+++ b/wagtail/api/v2/tests/tests.py
@@ -2,6 +2,7 @@ from django.test import RequestFactory, TestCase, override_settings
 from django.utils.encoding import force_bytes
 
 from wagtail.core.models import Site
+
 from ..utils import FieldsParameterParseError, get_base_url, parse_boolean, parse_fields_parameter
 
 

--- a/wagtail/bin/wagtail.py
+++ b/wagtail/bin/wagtail.py
@@ -4,6 +4,7 @@ import fnmatch
 import os
 import re
 import sys
+
 from argparse import ArgumentParser
 from difflib import unified_diff
 

--- a/wagtail/contrib/forms/forms.py
+++ b/wagtail/contrib/forms/forms.py
@@ -1,6 +1,7 @@
 from collections import OrderedDict
 
 import django.forms
+
 from django.conf import settings
 from django.utils.html import conditional_escape
 from django.utils.translation import gettext_lazy as _

--- a/wagtail/contrib/forms/models.py
+++ b/wagtail/contrib/forms/models.py
@@ -12,7 +12,6 @@ from django.utils.formats import date_format
 from django.utils.text import slugify
 from django.utils.translation import gettext_lazy as _
 
-
 from wagtail.admin.edit_handlers import FieldPanel
 from wagtail.admin.mail import send_mail
 from wagtail.contrib.forms.utils import get_field_clean_name

--- a/wagtail/contrib/forms/tests/test_views.py
+++ b/wagtail/contrib/forms/tests/test_views.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import datetime
 import json
+
 from io import BytesIO
 
 from django.conf import settings

--- a/wagtail/contrib/forms/urls.py
+++ b/wagtail/contrib/forms/urls.py
@@ -3,6 +3,7 @@ from django.urls import path
 from wagtail.contrib.forms.views import (
     DeleteSubmissionsView, FormPagesListView, get_submissions_list_view)
 
+
 app_name = 'wagtailforms'
 urlpatterns = [
     path('', FormPagesListView.as_view(), name='index'),

--- a/wagtail/contrib/forms/utils.py
+++ b/wagtail/contrib/forms/utils.py
@@ -4,6 +4,7 @@ from wagtail.core import hooks
 from wagtail.core.models import UserPagePermissionsProxy, get_page_models
 from wagtail.core.utils import safe_snake_case
 
+
 _FORM_CONTENT_TYPES = None
 
 

--- a/wagtail/contrib/frontend_cache/backends.py
+++ b/wagtail/contrib/frontend_cache/backends.py
@@ -1,14 +1,17 @@
 import logging
 import uuid
+
 from collections import defaultdict
 from urllib.error import HTTPError, URLError
 from urllib.parse import urlparse, urlunparse
 from urllib.request import Request, urlopen
 
 import requests
+
 from django.core.exceptions import ImproperlyConfigured
 
 from wagtail import __version__
+
 
 logger = logging.getLogger('wagtail.frontendcache')
 

--- a/wagtail/contrib/frontend_cache/tests.py
+++ b/wagtail/contrib/frontend_cache/tests.py
@@ -2,6 +2,7 @@ from unittest import mock
 from urllib.error import HTTPError, URLError
 
 import requests
+
 from django.core.exceptions import ImproperlyConfigured
 from django.test import TestCase
 from django.test.utils import override_settings

--- a/wagtail/contrib/frontend_cache/utils.py
+++ b/wagtail/contrib/frontend_cache/utils.py
@@ -1,5 +1,6 @@
 import logging
 import re
+
 from urllib.parse import urlparse, urlunparse
 
 from django.conf import settings
@@ -7,6 +8,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.utils.module_loading import import_string
 
 from wagtail.core.utils import get_content_languages
+
 
 logger = logging.getLogger('wagtail.frontendcache')
 

--- a/wagtail/contrib/legacy/sitemiddleware/__init__.py
+++ b/wagtail/contrib/legacy/sitemiddleware/__init__.py
@@ -1,4 +1,5 @@
 from django.utils.deprecation import MiddlewareMixin
+
 from wagtail.core.models import Site
 
 

--- a/wagtail/contrib/modeladmin/helpers/search.py
+++ b/wagtail/contrib/modeladmin/helpers/search.py
@@ -1,4 +1,5 @@
 import operator
+
 from functools import reduce
 
 from django.contrib.admin.utils import lookup_needs_distinct

--- a/wagtail/contrib/modeladmin/templatetags/modeladmin_tags.py
+++ b/wagtail/contrib/modeladmin/templatetags/modeladmin_tags.py
@@ -12,6 +12,7 @@ from django.utils.html import format_html
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext as _
 
+
 register = Library()
 
 

--- a/wagtail/contrib/modeladmin/views.py
+++ b/wagtail/contrib/modeladmin/views.py
@@ -4,10 +4,12 @@ from django import forms
 from django.contrib.admin import FieldListFilter
 from django.contrib.admin.options import IncorrectLookupParameters
 from django.contrib.admin.utils import (
-    get_fields_from_path, label_for_field, lookup_field, lookup_needs_distinct, prepare_lookup_value, quote, unquote)
+    get_fields_from_path, label_for_field, lookup_field, lookup_needs_distinct,
+    prepare_lookup_value, quote, unquote)
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import (
-    FieldDoesNotExist, ImproperlyConfigured, ObjectDoesNotExist, PermissionDenied, SuspiciousOperation)
+    FieldDoesNotExist, ImproperlyConfigured, ObjectDoesNotExist, PermissionDenied,
+    SuspiciousOperation)
 from django.core.paginator import InvalidPage, Paginator
 from django.db import models
 from django.db.models.fields.related import ManyToManyField, OneToOneRel
@@ -27,6 +29,7 @@ from wagtail.admin import messages
 from wagtail.admin.views.mixins import SpreadsheetExportMixin
 
 from .forms import ParentChooserForm
+
 
 try:
     from django.db.models.sql.constants import QUERY_TERMS

--- a/wagtail/contrib/postgres_search/backend.py
+++ b/wagtail/contrib/postgres_search/backend.py
@@ -1,4 +1,5 @@
 import warnings
+
 from collections import OrderedDict
 from functools import reduce
 
@@ -23,6 +24,7 @@ from .query import Lexeme, RawSearchQuery
 from .utils import (
     get_content_type_pk, get_descendants_content_types_pks, get_postgresql_connections,
     get_sql_weights, get_weight)
+
 
 EMPTY_VECTOR = SearchVector(Value('', output_field=TextField()))
 

--- a/wagtail/contrib/redirects/base_formats.py
+++ b/wagtail/contrib/redirects/base_formats.py
@@ -25,6 +25,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 # https://raw.githubusercontent.com/django-import-export/django-import-export/master/import_export/formats/base_formats.py
 from importlib import import_module
+
 import tablib
 
 
@@ -198,6 +199,7 @@ class XLSX(TablibFormat):
         Create dataset from first sheet.
         """
         from io import BytesIO
+
         import openpyxl
         xlsx_book = openpyxl.load_workbook(BytesIO(in_stream), read_only=True)
 

--- a/wagtail/contrib/redirects/management/commands/import_redirects.py
+++ b/wagtail/contrib/redirects/management/commands/import_redirects.py
@@ -1,6 +1,7 @@
 import os
 
 import tablib
+
 from django.core.management.base import BaseCommand
 
 from wagtail.contrib.redirects.forms import RedirectForm

--- a/wagtail/contrib/redirects/permissions.py
+++ b/wagtail/contrib/redirects/permissions.py
@@ -1,4 +1,5 @@
 from wagtail.contrib.redirects.models import Redirect
 from wagtail.core.permission_policies import ModelPermissionPolicy
 
+
 permission_policy = ModelPermissionPolicy(Redirect)

--- a/wagtail/contrib/redirects/tests/test_import_command.py
+++ b/wagtail/contrib/redirects/tests/test_import_command.py
@@ -1,5 +1,6 @@
 import os
 import tempfile
+
 from io import StringIO
 from unittest.mock import patch
 

--- a/wagtail/contrib/redirects/tests/test_import_utils.py
+++ b/wagtail/contrib/redirects/tests/test_import_utils.py
@@ -5,8 +5,7 @@ from django.core.files.base import ContentFile
 from django.test import TestCase, override_settings
 
 from wagtail.contrib.redirects.utils import (
-    get_file_storage, get_import_formats, write_to_file_storage
-)
+    get_file_storage, get_import_formats, write_to_file_storage)
 
 
 TEST_ROOT = os.path.abspath(os.path.dirname(__file__))

--- a/wagtail/contrib/redirects/tmp_storages.py
+++ b/wagtail/contrib/redirects/tmp_storages.py
@@ -26,6 +26,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 # Copied from: https://raw.githubusercontent.com/django-import-export/django-import-export/5795e114210adf250ac6e146db2fa413f38875de/import_export/tmp_storages.py
 import os
 import tempfile
+
 from uuid import uuid4
 
 from django.core.cache import cache

--- a/wagtail/contrib/redirects/urls.py
+++ b/wagtail/contrib/redirects/urls.py
@@ -2,6 +2,7 @@ from django.urls import path
 
 from wagtail.contrib.redirects import views
 
+
 app_name = 'wagtailredirects'
 urlpatterns = [
     path('', views.index, name='index'),

--- a/wagtail/contrib/redirects/views.py
+++ b/wagtail/contrib/redirects/views.py
@@ -22,6 +22,7 @@ from wagtail.contrib.redirects.utils import (
     get_file_storage, get_format_cls_by_extension, get_import_formats, get_supported_extensions,
     write_to_file_storage)
 
+
 permission_checker = PermissionPolicyChecker(permission_policy)
 
 

--- a/wagtail/contrib/routable_page/models.py
+++ b/wagtail/contrib/routable_page/models.py
@@ -6,6 +6,7 @@ from django.urls.resolvers import RegexPattern
 from wagtail.core.models import Page
 from wagtail.core.url_routing import RouteResult
 
+
 _creation_counter = 0
 
 

--- a/wagtail/contrib/routable_page/templatetags/wagtailroutablepage_tags.py
+++ b/wagtail/contrib/routable_page/templatetags/wagtailroutablepage_tags.py
@@ -1,5 +1,7 @@
 from django import template
+
 from wagtail.core.models import Site
+
 
 register = template.Library()
 

--- a/wagtail/contrib/search_promotions/admin_urls.py
+++ b/wagtail/contrib/search_promotions/admin_urls.py
@@ -2,6 +2,7 @@ from django.urls import path
 
 from wagtail.contrib.search_promotions import views
 
+
 app_name = 'wagtailsearchpromotions'
 urlpatterns = [
     path('', views.index, name='index'),

--- a/wagtail/contrib/search_promotions/templatetags/wagtailsearchpromotions_tags.py
+++ b/wagtail/contrib/search_promotions/templatetags/wagtailsearchpromotions_tags.py
@@ -3,6 +3,7 @@ from django import template
 from wagtail.contrib.search_promotions.models import SearchPromotion
 from wagtail.search.models import Query
 
+
 register = template.Library()
 
 

--- a/wagtail/contrib/search_promotions/tests.py
+++ b/wagtail/contrib/search_promotions/tests.py
@@ -2,8 +2,8 @@ from django.test import TestCase
 from django.urls import reverse
 
 from wagtail.contrib.search_promotions.models import SearchPromotion
-from wagtail.contrib.search_promotions.templatetags.wagtailsearchpromotions_tags import \
-    get_search_promotions
+from wagtail.contrib.search_promotions.templatetags.wagtailsearchpromotions_tags import (
+    get_search_promotions)
 from wagtail.search.models import Query
 from wagtail.tests.utils import WagtailTestUtils
 

--- a/wagtail/contrib/settings/jinja2tags.py
+++ b/wagtail/contrib/settings/jinja2tags.py
@@ -1,11 +1,13 @@
 from weakref import WeakKeyDictionary
 
 import jinja2
+
 from django.utils.encoding import force_str
 from jinja2.ext import Extension
 
 from wagtail.contrib.settings.registry import registry
 from wagtail.core.models import Site
+
 
 # Settings are cached per template context, to prevent excessive database
 # lookups. The cached settings are disposed of once the template context is no

--- a/wagtail/contrib/settings/models.py
+++ b/wagtail/contrib/settings/models.py
@@ -5,6 +5,7 @@ from wagtail.core.utils import InvokeViaAttributeShortcut
 
 from .registry import register_setting
 
+
 __all__ = ['BaseSetting', 'register_setting']
 
 

--- a/wagtail/contrib/settings/templatetags/wagtailsettings_tags.py
+++ b/wagtail/contrib/settings/templatetags/wagtailsettings_tags.py
@@ -4,6 +4,7 @@ from wagtail.core.models import Site
 
 from ..context_processors import SettingsProxy
 
+
 register = Library()
 
 

--- a/wagtail/contrib/settings/tests/base.py
+++ b/wagtail/contrib/settings/tests/base.py
@@ -1,4 +1,5 @@
 from django.http import HttpRequest
+
 from wagtail.core.models import Page, Site
 from wagtail.tests.testapp.models import TestSetting
 

--- a/wagtail/contrib/settings/urls.py
+++ b/wagtail/contrib/settings/urls.py
@@ -2,6 +2,7 @@ from django.urls import path
 
 from . import views
 
+
 app_name = 'wagtailsettings'
 urlpatterns = [
     path('<slug:app_name>/<slug:model_name>/', views.edit_current_site, name='edit'),

--- a/wagtail/contrib/sitemaps/sitemap_generator.py
+++ b/wagtail/contrib/sitemaps/sitemap_generator.py
@@ -1,5 +1,6 @@
 from django.contrib.sitemaps import Sitemap as DjangoSitemap
 
+
 # Note: avoid importing models here. This module is imported from __init__.py
 # which causes it to be loaded early in startup if wagtail.contrib.sitemaps is
 # included in INSTALLED_APPS (not required, but developers are likely to add it

--- a/wagtail/contrib/sitemaps/tests.py
+++ b/wagtail/contrib/sitemaps/tests.py
@@ -1,6 +1,7 @@
 import datetime
 
 import pytz
+
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.sites.shortcuts import get_current_site

--- a/wagtail/contrib/sitemaps/views.py
+++ b/wagtail/contrib/sitemaps/views.py
@@ -1,4 +1,5 @@
 import inspect
+
 from django.contrib.sitemaps import views as sitemap_views
 
 from .sitemap_generator import Sitemap

--- a/wagtail/contrib/table_block/blocks.py
+++ b/wagtail/contrib/table_block/blocks.py
@@ -8,6 +8,7 @@ from django.utils.functional import cached_property
 from wagtail.admin.staticfiles import versioned_static
 from wagtail.core.blocks import FieldBlock
 
+
 DEFAULT_TABLE_OPTIONS = {
     'minSpareRows': 0,
     'startRows': 3,

--- a/wagtail/contrib/table_block/templatetags/table_block_tags.py
+++ b/wagtail/contrib/table_block/templatetags/table_block_tags.py
@@ -1,6 +1,7 @@
 from django import template
 from django.utils.safestring import mark_safe
 
+
 register = template.Library()
 
 

--- a/wagtail/core/__init__.py
+++ b/wagtail/core/__init__.py
@@ -1,11 +1,13 @@
 # Imported for historical reasons
 from wagtail import __semver__, __version__  # noqa
 
+
 default_app_config = 'wagtail.core.apps.WagtailCoreAppConfig'
 
 
 def setup():
     import warnings
+
     from wagtail.utils.deprecation import removed_in_next_version_warning
 
     warnings.simplefilter("default", removed_in_next_version_warning)

--- a/wagtail/core/blocks/__init__.py
+++ b/wagtail/core/blocks/__init__.py
@@ -1,7 +1,7 @@
 # Import block types defined in submodules into the wagtail.core.blocks namespace
 from .base import *  # NOQA
 from .field_block import *  # NOQA
-from .struct_block import *  # NOQA
 from .list_block import *  # NOQA
-from .stream_block import *  # NOQA
 from .static_block import *  # NOQA
+from .stream_block import *  # NOQA
+from .struct_block import *  # NOQA

--- a/wagtail/core/blocks/base.py
+++ b/wagtail/core/blocks/base.py
@@ -1,5 +1,6 @@
 import collections
 import re
+
 from importlib import import_module
 
 from django import forms
@@ -9,6 +10,7 @@ from django.template.loader import render_to_string
 from django.utils.encoding import force_str
 from django.utils.safestring import mark_safe
 from django.utils.text import capfirst
+
 
 __all__ = ['BaseBlock', 'Block', 'BoundBlock', 'DeclarativeSubBlocksMetaclass', 'BlockWidget', 'BlockField']
 

--- a/wagtail/core/blocks/list_block.py
+++ b/wagtail/core/blocks/list_block.py
@@ -11,6 +11,7 @@ from wagtail.core.utils import escape_script
 from .base import Block
 from .utils import js_dict
 
+
 __all__ = ['ListBlock']
 
 

--- a/wagtail/core/blocks/static_block.py
+++ b/wagtail/core/blocks/static_block.py
@@ -2,6 +2,7 @@ from django.utils.translation import gettext_lazy as _
 
 from .base import Block
 
+
 __all__ = ['StaticBlock']
 
 

--- a/wagtail/core/blocks/stream_block.py
+++ b/wagtail/core/blocks/stream_block.py
@@ -1,4 +1,5 @@
 import uuid
+
 from collections import OrderedDict, defaultdict
 from collections.abc import Sequence
 
@@ -15,6 +16,7 @@ from wagtail.core.utils import escape_script
 
 from .base import Block, BoundBlock, DeclarativeSubBlocksMetaclass
 from .utils import indent, js_dict
+
 
 __all__ = ['BaseStreamBlock', 'StreamBlock', 'StreamValue', 'StreamBlockValidationError']
 

--- a/wagtail/core/blocks/struct_block.py
+++ b/wagtail/core/blocks/struct_block.py
@@ -13,6 +13,7 @@ from wagtail.admin.staticfiles import versioned_static
 from .base import Block, DeclarativeSubBlocksMetaclass
 from .utils import js_dict
 
+
 __all__ = ['BaseStructBlock', 'StructBlock', 'StructValue']
 
 

--- a/wagtail/core/hooks.py
+++ b/wagtail/core/hooks.py
@@ -3,6 +3,7 @@ from operator import itemgetter
 
 from wagtail.utils.apps import get_app_submodules
 
+
 _hooks = {}
 
 

--- a/wagtail/core/jinja2tags.py
+++ b/wagtail/core/jinja2tags.py
@@ -1,5 +1,6 @@
 import jinja2
 import jinja2.nodes
+
 from jinja2.ext import Extension
 
 from .templatetags.wagtailcore_tags import pageurl, richtext, slugurl, wagtail_version

--- a/wagtail/core/management/commands/create_log_entries_from_revisions.py
+++ b/wagtail/core/management/commands/create_log_entries_from_revisions.py
@@ -1,4 +1,5 @@
 from django.core.management.base import BaseCommand
+
 from wagtail.core.models import PageLogEntry, PageRevision
 
 

--- a/wagtail/core/management/commands/purge_revisions.py
+++ b/wagtail/core/management/commands/purge_revisions.py
@@ -4,6 +4,7 @@ from django.utils import timezone
 
 from wagtail.core.models import PageRevision
 
+
 try:
     from wagtail.core.models import WorkflowState
     workflow_support = True

--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import uuid
+
 from collections import namedtuple
 from io import StringIO
 from urllib.parse import urlparse
@@ -42,9 +43,9 @@ from treebeard.mp_tree import MP_Node
 from wagtail.core.forms import TaskStateCommentForm
 from wagtail.core.query import PageQuerySet, TreeQuerySet
 from wagtail.core.signals import (
-    page_published, page_unpublished, post_page_move, pre_page_move,
-    task_approved, task_cancelled, task_rejected, task_submitted,
-    workflow_approved, workflow_cancelled, workflow_rejected, workflow_submitted)
+    page_published, page_unpublished, post_page_move, pre_page_move, task_approved, task_cancelled,
+    task_rejected, task_submitted, workflow_approved, workflow_cancelled, workflow_rejected,
+    workflow_submitted)
 from wagtail.core.sites import get_site_for_hostname
 from wagtail.core.treebeard import TreebeardPathFixMixin
 from wagtail.core.url_routing import RouteResult
@@ -53,6 +54,7 @@ from wagtail.search import index
 
 from .utils import (
     find_available_slug, get_content_languages, get_supported_content_language_variant)
+
 
 logger = logging.getLogger('wagtail.core')
 

--- a/wagtail/core/permissions.py
+++ b/wagtail/core/permissions.py
@@ -1,6 +1,7 @@
 from wagtail.core.models import Collection, Locale, Site, Task, Workflow
 from wagtail.core.permission_policies import ModelPermissionPolicy
 
+
 site_permission_policy = ModelPermissionPolicy(Site)
 collection_permission_policy = ModelPermissionPolicy(Collection)
 task_permission_policy = ModelPermissionPolicy(Task)

--- a/wagtail/core/query.py
+++ b/wagtail/core/query.py
@@ -1,5 +1,6 @@
 import posixpath
 import warnings
+
 from collections import defaultdict
 
 from django.apps import apps

--- a/wagtail/core/rich_text/__init__.py
+++ b/wagtail/core/rich_text/__init__.py
@@ -1,4 +1,5 @@
 import re
+
 from html import unescape
 
 from django.db.models import Model

--- a/wagtail/core/rich_text/rewriters.py
+++ b/wagtail/core/rich_text/rewriters.py
@@ -4,6 +4,7 @@ Utility classes for rewriting elements of HTML-like strings
 
 import re
 
+
 FIND_A_TAG = re.compile(r'<a(\b[^>]*)>')
 FIND_EMBED_TAG = re.compile(r'<embed(\b[^>]*)/>')
 FIND_ATTRS = re.compile(r'([\w-]+)\="([^"]*)"')

--- a/wagtail/core/signal_handlers.py
+++ b/wagtail/core/signal_handlers.py
@@ -5,6 +5,7 @@ from django.db.models.signals import post_delete, post_save, pre_delete
 
 from wagtail.core.models import Page, Site
 
+
 logger = logging.getLogger('wagtail.core')
 
 

--- a/wagtail/core/signals.py
+++ b/wagtail/core/signals.py
@@ -1,5 +1,6 @@
 from django.dispatch import Signal
 
+
 page_published = Signal(providing_args=['instance', 'revision'])
 page_unpublished = Signal(providing_args=['instance'])
 pre_page_move = Signal(providing_args=['instance', 'parent_page_before', 'parent_page_after', 'url_path_before', 'url_path_after'])

--- a/wagtail/core/sites.py
+++ b/wagtail/core/sites.py
@@ -1,6 +1,7 @@
 from django.apps import apps
 from django.db.models import Case, IntegerField, Q, When
 
+
 MATCH_HOSTNAME_PORT = 0
 MATCH_HOSTNAME_DEFAULT = 1
 MATCH_DEFAULT = 2

--- a/wagtail/core/templatetags/wagtailcore_tags.py
+++ b/wagtail/core/templatetags/wagtailcore_tags.py
@@ -9,6 +9,7 @@ from wagtail.core.models import Page, Site
 from wagtail.core.rich_text import RichText, expand_db_html
 from wagtail.utils.version import get_main_version
 
+
 register = template.Library()
 
 

--- a/wagtail/core/tests/test_blocks.py
+++ b/wagtail/core/tests/test_blocks.py
@@ -3,6 +3,7 @@ import base64
 import collections
 import json
 import unittest
+
 from datetime import date, datetime
 from decimal import Decimal
 

--- a/wagtail/core/tests/test_page_model.py
+++ b/wagtail/core/tests/test_page_model.py
@@ -1,9 +1,11 @@
 import datetime
 import json
 import unittest
+
 from unittest.mock import Mock
 
 import pytz
+
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AnonymousUser
@@ -17,7 +19,8 @@ from django.utils import timezone, translation
 from freezegun import freeze_time
 
 from wagtail.core.models import (
-    Locale, Page, PageLogEntry, PageManager, ParentNotTranslatedError, Site, get_page_models, get_translatable_models)
+    Locale, Page, PageLogEntry, PageManager, ParentNotTranslatedError, Site, get_page_models,
+    get_translatable_models)
 from wagtail.core.signals import page_published
 from wagtail.tests.testapp.models import (
     AbstractPage, Advert, AlwaysShowInMenusPage, BlogCategory, BlogCategoryBlogPage, BusinessChild,

--- a/wagtail/core/tests/test_page_permissions.py
+++ b/wagtail/core/tests/test_page_permissions.py
@@ -6,7 +6,8 @@ from django.test import Client, TestCase, override_settings
 from django.utils import timezone
 
 from wagtail.core.models import (
-    GroupApprovalTask, GroupPagePermission, Locale, Page, UserPagePermissionsProxy, Workflow, WorkflowTask)
+    GroupApprovalTask, GroupPagePermission, Locale, Page, UserPagePermissionsProxy, Workflow,
+    WorkflowTask)
 from wagtail.tests.testapp.models import (
     BusinessSubIndex, EventIndex, EventPage, SingletonPageViaMaxCount)
 

--- a/wagtail/core/tests/test_translatablemixin.py
+++ b/wagtail/core/tests/test_translatablemixin.py
@@ -5,7 +5,6 @@ from django.core import checks
 from django.test import TestCase
 
 from wagtail.core.models import Locale
-
 from wagtail.tests.i18n.models import InheritedTestModel, TestModel
 
 

--- a/wagtail/core/tests/test_workflow.py
+++ b/wagtail/core/tests/test_workflow.py
@@ -1,17 +1,17 @@
 import datetime
 
 import pytz
+
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group
 from django.core.exceptions import ValidationError
 from django.db.utils import IntegrityError
 from django.test import TestCase, override_settings
-
 from freezegun import freeze_time
+
 from wagtail.core.models import (
     GroupApprovalTask, Page, Task, TaskState, Workflow, WorkflowPage, WorkflowState, WorkflowTask)
-
 from wagtail.tests.testapp.models import SimplePage
 
 

--- a/wagtail/core/urls.py
+++ b/wagtail/core/urls.py
@@ -5,6 +5,7 @@ from django.urls import path, re_path
 from wagtail.core import views
 from wagtail.core.utils import WAGTAIL_APPEND_SLASH
 
+
 if WAGTAIL_APPEND_SLASH:
     # If WAGTAIL_APPEND_SLASH is True (the default value), we match a
     # (possibly empty) list of path segments ending in slashes.

--- a/wagtail/core/utils.py
+++ b/wagtail/core/utils.py
@@ -2,8 +2,8 @@ import functools
 import inspect
 import re
 import unicodedata
-from anyascii import anyascii
 
+from anyascii import anyascii
 from django.apps import apps
 from django.conf import settings
 from django.conf.locale import LANG_INFO
@@ -14,6 +14,7 @@ from django.dispatch import receiver
 from django.utils.encoding import force_str
 from django.utils.text import slugify
 from django.utils.translation import check_for_language, get_supported_language_variant
+
 
 WAGTAIL_APPEND_SLASH = getattr(settings, 'WAGTAIL_APPEND_SLASH', True)
 

--- a/wagtail/core/whitelist.py
+++ b/wagtail/core/whitelist.py
@@ -7,6 +7,7 @@ import re
 from bs4 import BeautifulSoup, Comment, NavigableString, Tag
 from django.utils.html import escape
 
+
 ALLOWED_URL_SCHEMES = ['http', 'https', 'ftp', 'mailto', 'tel']
 
 PROTOCOL_RE = re.compile("^[a-z0-9][-+.a-z0-9]*:")

--- a/wagtail/documents/__init__.py
+++ b/wagtail/documents/__init__.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 
+
 default_app_config = 'wagtail.documents.apps.WagtailDocsAppConfig'
 
 

--- a/wagtail/documents/admin.py
+++ b/wagtail/documents/admin.py
@@ -3,6 +3,7 @@ from django.contrib import admin
 
 from wagtail.documents.models import Document
 
+
 if hasattr(settings, 'WAGTAILDOCS_DOCUMENT_MODEL') and settings.WAGTAILDOCS_DOCUMENT_MODEL != 'wagtaildocs.Document':
     # This installation provides its own custom document class;
     # to avoid confusion, we won't expose the unused wagtaildocs.Document class

--- a/wagtail/documents/admin_urls.py
+++ b/wagtail/documents/admin_urls.py
@@ -2,6 +2,7 @@ from django.urls import path
 
 from wagtail.documents.views import chooser, documents, multiple
 
+
 app_name = 'wagtaildocs'
 urlpatterns = [
     path('', documents.index, name='index'),

--- a/wagtail/documents/models.py
+++ b/wagtail/documents/models.py
@@ -1,6 +1,7 @@
 import hashlib
 import os.path
 import urllib
+
 from contextlib import contextmanager
 from mimetypes import guess_type
 

--- a/wagtail/documents/permissions.py
+++ b/wagtail/documents/permissions.py
@@ -2,6 +2,7 @@ from wagtail.core.permission_policies.collections import CollectionOwnershipPerm
 from wagtail.documents import get_document_model
 from wagtail.documents.models import Document
 
+
 permission_policy = CollectionOwnershipPermissionPolicy(
     get_document_model(),
     auth_model=Document,

--- a/wagtail/documents/rich_text/__init__.py
+++ b/wagtail/documents/rich_text/__init__.py
@@ -4,6 +4,7 @@ from django.utils.html import escape
 from wagtail.core.rich_text import LinkHandler
 from wagtail.documents import get_document_model
 
+
 # Front-end conversion
 
 

--- a/wagtail/documents/rich_text/contentstate.py
+++ b/wagtail/documents/rich_text/contentstate.py
@@ -1,6 +1,8 @@
 from draftjs_exporter.dom import DOM
+
 from wagtail.admin.rich_text.converters.html_to_contentstate import LinkElementHandler
 from wagtail.documents import get_document_model
+
 
 # draft.js / contentstate conversion
 

--- a/wagtail/documents/rich_text/editor_html.py
+++ b/wagtail/documents/rich_text/editor_html.py
@@ -3,6 +3,7 @@ from django.utils.html import escape
 from wagtail.admin.rich_text.converters import editor_html
 from wagtail.documents import get_document_model
 
+
 # hallo.js / editor-html conversion
 
 

--- a/wagtail/documents/tests/test_admin_views.py
+++ b/wagtail/documents/tests/test_admin_views.py
@@ -1,4 +1,5 @@
 import json
+
 from unittest import mock
 
 from django.contrib.auth.models import Group, Permission

--- a/wagtail/documents/tests/test_collection_privacy.py
+++ b/wagtail/documents/tests/test_collection_privacy.py
@@ -7,6 +7,7 @@ from wagtail.core.models import Collection, CollectionViewRestriction
 from wagtail.documents.models import Document
 from wagtail.tests.utils import WagtailTestUtils
 
+
 try:
     from urllib.parse import quote
 except ImportError:

--- a/wagtail/documents/tests/test_search.py
+++ b/wagtail/documents/tests/test_search.py
@@ -13,6 +13,7 @@ from wagtail.tests.utils import WagtailTestUtils
 class TestIssue613(TestCase, WagtailTestUtils):
     def get_elasticsearch_backend(self):
         from django.conf import settings
+
         from wagtail.search.backends import get_search_backend
 
         if 'elasticsearch' not in settings.WAGTAILSEARCH_BACKENDS:

--- a/wagtail/documents/tests/test_views.py
+++ b/wagtail/documents/tests/test_views.py
@@ -1,6 +1,7 @@
 import os.path
 import unittest
 import urllib
+
 from io import StringIO
 from unittest import mock
 

--- a/wagtail/documents/urls.py
+++ b/wagtail/documents/urls.py
@@ -2,6 +2,7 @@ from django.urls import path, re_path
 
 from wagtail.documents.views import serve
 
+
 urlpatterns = [
     re_path(r'^(\d+)/(.*)$', serve.serve, name='wagtaildocs_serve'),
     path(

--- a/wagtail/documents/views/chooser.py
+++ b/wagtail/documents/views/chooser.py
@@ -14,6 +14,7 @@ from wagtail.documents.forms import get_document_form
 from wagtail.documents.permissions import permission_policy
 from wagtail.search import index as search_index
 
+
 permission_checker = PermissionPolicyChecker(permission_policy)
 
 

--- a/wagtail/documents/views/documents.py
+++ b/wagtail/documents/views/documents.py
@@ -17,6 +17,7 @@ from wagtail.documents.forms import get_document_form
 from wagtail.documents.permissions import permission_policy
 from wagtail.search import index as search_index
 
+
 permission_checker = PermissionPolicyChecker(permission_policy)
 
 

--- a/wagtail/documents/views/multiple.py
+++ b/wagtail/documents/views/multiple.py
@@ -14,6 +14,7 @@ from .. import get_document_model
 from ..forms import get_document_form, get_document_multi_form
 from ..permissions import permission_policy
 
+
 permission_checker = PermissionPolicyChecker(permission_policy)
 
 

--- a/wagtail/documents/wagtail_hooks.py
+++ b/wagtail/documents/wagtail_hooks.py
@@ -2,10 +2,12 @@ from django.conf import settings
 from django.template.response import TemplateResponse
 from django.urls import include, path, reverse
 from django.utils.html import format_html
+from django.utils.translation import gettext
 from django.utils.translation import gettext_lazy as _
-from django.utils.translation import gettext, ngettext
+from django.utils.translation import ngettext
 
 import wagtail.admin.rich_text.editors.draftail.features as draftail_features
+
 from wagtail.admin.menu import MenuItem
 from wagtail.admin.navigation import get_site_for_user
 from wagtail.admin.rich_text import HalloPlugin

--- a/wagtail/embeds/finders/__init__.py
+++ b/wagtail/embeds/finders/__init__.py
@@ -1,7 +1,7 @@
 from importlib import import_module
 
-from django.utils.module_loading import import_string
 from django.conf import settings
+from django.utils.module_loading import import_string
 
 
 def import_finder_class(dotted_path):

--- a/wagtail/embeds/finders/oembed.py
+++ b/wagtail/embeds/finders/oembed.py
@@ -1,5 +1,6 @@
 import json
 import re
+
 from urllib import request as urllib_request
 from urllib.error import URLError
 from urllib.parse import urlencode

--- a/wagtail/embeds/models.py
+++ b/wagtail/embeds/models.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 
+
 EMBED_TYPES = (
     ('video', 'Video'),
     ('photo', 'Photo'),

--- a/wagtail/embeds/templatetags/wagtailembeds_tags.py
+++ b/wagtail/embeds/templatetags/wagtailembeds_tags.py
@@ -4,6 +4,7 @@ from django.utils.safestring import mark_safe
 from wagtail.embeds import embeds
 from wagtail.embeds.exceptions import EmbedException
 
+
 register = template.Library()
 
 

--- a/wagtail/embeds/tests/test_embeds.py
+++ b/wagtail/embeds/tests/test_embeds.py
@@ -1,6 +1,7 @@
 import json
 import unittest
 import urllib.request
+
 from unittest.mock import patch
 from urllib.error import URLError
 
@@ -15,12 +16,13 @@ from wagtail.embeds.blocks import EmbedBlock, EmbedValue
 from wagtail.embeds.embeds import get_embed
 from wagtail.embeds.exceptions import EmbedNotFoundException, EmbedUnsupportedProviderException
 from wagtail.embeds.finders import get_finders
-from wagtail.embeds.finders.embedly import EmbedlyFinder as EmbedlyFinder
 from wagtail.embeds.finders.embedly import AccessDeniedEmbedlyException, EmbedlyException
+from wagtail.embeds.finders.embedly import EmbedlyFinder as EmbedlyFinder
 from wagtail.embeds.finders.oembed import OEmbedFinder as OEmbedFinder
 from wagtail.embeds.models import Embed
 from wagtail.embeds.templatetags.wagtailembeds_tags import embed_tag
 from wagtail.tests.utils import WagtailTestUtils
+
 
 try:
     import embedly  # noqa

--- a/wagtail/embeds/tests/test_rich_text.py
+++ b/wagtail/embeds/tests/test_rich_text.py
@@ -1,7 +1,6 @@
 from unittest.mock import patch
 
 from bs4 import BeautifulSoup
-
 from django.test import TestCase, override_settings
 
 from wagtail.core.rich_text import expand_db_html

--- a/wagtail/embeds/urls.py
+++ b/wagtail/embeds/urls.py
@@ -2,6 +2,7 @@ from django.urls import path
 
 from wagtail.embeds.views import chooser
 
+
 app_name = 'wagtailembeds'
 urlpatterns = [
     path('chooser/', chooser.chooser, name='chooser'),

--- a/wagtail/embeds/wagtail_hooks.py
+++ b/wagtail/embeds/wagtail_hooks.py
@@ -3,6 +3,7 @@ from django.utils.html import format_html
 from django.utils.translation import gettext as _
 
 import wagtail.admin.rich_text.editors.draftail.features as draftail_features
+
 from wagtail.admin.rich_text import HalloPlugin
 from wagtail.core import hooks
 from wagtail.embeds import urls

--- a/wagtail/images/admin.py
+++ b/wagtail/images/admin.py
@@ -3,6 +3,7 @@ from django.contrib import admin
 
 from wagtail.images.models import Image
 
+
 if hasattr(settings, 'WAGTAILIMAGES_IMAGE_MODEL') and settings.WAGTAILIMAGES_IMAGE_MODEL != 'wagtailimages.Image':
     # This installation provides its own custom image class;
     # to avoid confusion, we won't expose the unused wagtailimages.Image class

--- a/wagtail/images/admin_urls.py
+++ b/wagtail/images/admin_urls.py
@@ -2,6 +2,7 @@ from django.urls import path
 
 from wagtail.images.views import chooser, images, multiple
 
+
 app_name = 'wagtailimages'
 urlpatterns = [
     path('', images.index, name='index'),

--- a/wagtail/images/api/v2/serializers.py
+++ b/wagtail/images/api/v2/serializers.py
@@ -1,4 +1,5 @@
 from rest_framework.fields import Field
+
 from wagtail.api.v2.serializers import BaseSerializer
 
 

--- a/wagtail/images/checks.py
+++ b/wagtail/images/checks.py
@@ -1,4 +1,5 @@
 import os
+
 from functools import lru_cache
 
 from django.core.checks import Warning, register

--- a/wagtail/images/fields.py
+++ b/wagtail/images/fields.py
@@ -1,11 +1,13 @@
 import os
 
 import willow
+
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.forms.fields import ImageField
 from django.template.defaultfilters import filesizeformat
 from django.utils.translation import gettext_lazy as _
+
 
 ALLOWED_EXTENSIONS = ['gif', 'jpg', 'jpeg', 'png', 'webp']
 SUPPORTED_FORMATS_TEXT = _("GIF, JPEG, PNG, WEBP")

--- a/wagtail/images/models.py
+++ b/wagtail/images/models.py
@@ -1,5 +1,6 @@
 import hashlib
 import os.path
+
 from collections import OrderedDict
 from contextlib import contextmanager
 from io import BytesIO

--- a/wagtail/images/permissions.py
+++ b/wagtail/images/permissions.py
@@ -2,6 +2,7 @@ from wagtail.core.permission_policies.collections import CollectionOwnershipPerm
 from wagtail.images import get_image_model
 from wagtail.images.models import Image
 
+
 permission_policy = CollectionOwnershipPermissionPolicy(
     get_image_model(),
     auth_model=Image,

--- a/wagtail/images/rich_text/editor_html.py
+++ b/wagtail/images/rich_text/editor_html.py
@@ -1,5 +1,4 @@
 from wagtail.admin.rich_text.converters import editor_html
-
 from wagtail.images import get_image_model
 from wagtail.images.formats import get_image_format
 

--- a/wagtail/images/tests/test_admin_views.py
+++ b/wagtail/images/tests/test_admin_views.py
@@ -15,6 +15,7 @@ from wagtail.tests.utils import WagtailTestUtils
 
 from .utils import Image, get_test_image_file
 
+
 # Get the chars that Django considers safe to leave unescaped in a URL
 urlquote_safechars = RFC3986_SUBDELIMS + str('/~:@')
 

--- a/wagtail/images/tests/test_models.py
+++ b/wagtail/images/tests/test_models.py
@@ -14,6 +14,7 @@ from wagtail.images.models import Rendition, SourceImageIOError
 from wagtail.images.rect import Rect
 from wagtail.tests.testapp.models import EventPage, EventPageCarouselItem
 from wagtail.tests.utils import WagtailTestUtils
+
 from .utils import Image, get_test_image_file
 
 
@@ -426,6 +427,7 @@ class TestIssue573(TestCase):
 class TestIssue613(TestCase, WagtailTestUtils):
     def get_elasticsearch_backend(self):
         from django.conf import settings
+
         from wagtail.search.backends import get_search_backend
 
         if 'elasticsearch' not in settings.WAGTAILSEARCH_BACKENDS:

--- a/wagtail/images/tests/tests.py
+++ b/wagtail/images/tests/tests.py
@@ -21,6 +21,7 @@ from wagtail.tests.utils import WagtailTestUtils
 
 from .utils import Image, get_test_image_file
 
+
 try:
     import sendfile  # noqa
     sendfile_mod = True

--- a/wagtail/images/tests/urls.py
+++ b/wagtail/images/tests/urls.py
@@ -3,6 +3,7 @@ from django.urls import re_path
 from wagtail.images.views.serve import SendFileView, ServeView
 from wagtail.tests import dummy_sendfile_backend
 
+
 urlpatterns = [
     # Format: signature, image_id, filter_spec, filename=None
     re_path(r'^actions/serve/(.*)/(\d*)/(.*)/[^/]*', ServeView.as_view(action='serve'), name='wagtailimages_serve_action_serve'),

--- a/wagtail/images/tests/utils.py
+++ b/wagtail/images/tests/utils.py
@@ -1,9 +1,11 @@
 from io import BytesIO
 
 import PIL.Image
+
 from django.core.files.images import ImageFile
 
 from wagtail.images import get_image_model
+
 
 Image = get_image_model()
 

--- a/wagtail/images/urls.py
+++ b/wagtail/images/urls.py
@@ -2,6 +2,7 @@ from django.urls import re_path
 
 from wagtail.images.views.serve import serve
 
+
 urlpatterns = [
     re_path(r'^([^/]*)/(\d*)/([^/]*)/[^/]*$', serve, name='wagtailimages_serve'),
 ]

--- a/wagtail/images/views/chooser.py
+++ b/wagtail/images/views/chooser.py
@@ -17,6 +17,7 @@ from wagtail.images.forms import ImageInsertionForm, get_image_form
 from wagtail.images.permissions import permission_policy
 from wagtail.search import index as search_index
 
+
 permission_checker = PermissionPolicyChecker(permission_policy)
 
 CHOOSER_PAGE_SIZE = getattr(settings, 'WAGTAILIMAGES_CHOOSER_PAGE_SIZE', 12)

--- a/wagtail/images/views/images.py
+++ b/wagtail/images/views/images.py
@@ -23,6 +23,7 @@ from wagtail.images.permissions import permission_policy
 from wagtail.images.utils import generate_signature
 from wagtail.search import index as search_index
 
+
 permission_checker = PermissionPolicyChecker(permission_policy)
 
 INDEX_PAGE_SIZE = getattr(settings, 'WAGTAILIMAGES_INDEX_PAGE_SIZE', 20)

--- a/wagtail/images/views/multiple.py
+++ b/wagtail/images/views/multiple.py
@@ -17,6 +17,7 @@ from wagtail.images.models import UploadedImage
 from wagtail.images.permissions import permission_policy
 from wagtail.search.backends import get_search_backends
 
+
 permission_checker = PermissionPolicyChecker(permission_policy)
 
 

--- a/wagtail/images/views/serve.py
+++ b/wagtail/images/views/serve.py
@@ -1,4 +1,5 @@
 import imghdr
+
 from wsgiref.util import FileWrapper
 
 from django.core.exceptions import ImproperlyConfigured, PermissionDenied

--- a/wagtail/images/wagtail_hooks.py
+++ b/wagtail/images/wagtail_hooks.py
@@ -1,9 +1,11 @@
 from django.urls import include, path, reverse
 from django.utils.html import format_html
+from django.utils.translation import gettext
 from django.utils.translation import gettext_lazy as _
-from django.utils.translation import gettext, ngettext
+from django.utils.translation import ngettext
 
 import wagtail.admin.rich_text.editors.draftail.features as draftail_features
+
 from wagtail.admin.menu import MenuItem
 from wagtail.admin.navigation import get_site_for_user
 from wagtail.admin.rich_text import HalloPlugin

--- a/wagtail/search/backends/__init__.py
+++ b/wagtail/search/backends/__init__.py
@@ -4,9 +4,9 @@
 
 from importlib import import_module
 
-from django.utils.module_loading import import_string
-from django.core.exceptions import ImproperlyConfigured
 from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+from django.utils.module_loading import import_string
 
 
 class InvalidSearchBackendError(ImproperlyConfigured):

--- a/wagtail/search/backends/elasticsearch2.py
+++ b/wagtail/search/backends/elasticsearch2.py
@@ -1,5 +1,6 @@
 import copy
 import json
+
 from collections import OrderedDict
 from urllib.parse import urlparse
 

--- a/wagtail/search/backends/elasticsearch5.py
+++ b/wagtail/search/backends/elasticsearch5.py
@@ -1,6 +1,7 @@
 from .elasticsearch2 import (
     Elasticsearch2Index, Elasticsearch2Mapping, Elasticsearch2SearchBackend,
-    Elasticsearch2SearchQueryCompiler, Elasticsearch2SearchResults, ElasticsearchAutocompleteQueryCompilerImpl)
+    Elasticsearch2SearchQueryCompiler, Elasticsearch2SearchResults,
+    ElasticsearchAutocompleteQueryCompilerImpl)
 
 
 class Elasticsearch5Mapping(Elasticsearch2Mapping):

--- a/wagtail/search/index.py
+++ b/wagtail/search/index.py
@@ -6,8 +6,8 @@ from django.core import checks
 from django.core.exceptions import FieldDoesNotExist
 from django.db import models
 from django.db.models.fields.related import ForeignObjectRel, OneToOneRel, RelatedField
-
 from modelcluster.fields import ParentalManyToManyField
+
 from wagtail.search.backends import get_search_backends_with_name
 
 

--- a/wagtail/search/management/commands/update_index.py
+++ b/wagtail/search/management/commands/update_index.py
@@ -7,6 +7,7 @@ from django.db import transaction
 from wagtail.search.backends import get_search_backend
 from wagtail.search.index import get_indexed_models
 
+
 DEFAULT_CHUNK_SIZE = 1000
 
 

--- a/wagtail/search/tests/elasticsearch_common_tests.py
+++ b/wagtail/search/tests/elasticsearch_common_tests.py
@@ -1,4 +1,5 @@
 import unittest
+
 from datetime import date
 from io import StringIO
 

--- a/wagtail/search/tests/test_backends.py
+++ b/wagtail/search/tests/test_backends.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 
 import unittest
+
 from collections import OrderedDict
 from datetime import date
 from io import StringIO

--- a/wagtail/search/tests/test_elasticsearch2_backend.py
+++ b/wagtail/search/tests/test_elasticsearch2_backend.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import datetime
 import json
+
 from unittest import mock
 
 from django.db.models import Q

--- a/wagtail/search/tests/test_elasticsearch5_backend.py
+++ b/wagtail/search/tests/test_elasticsearch5_backend.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import datetime
 import json
+
 from unittest import mock
 
 from django.db.models import Q

--- a/wagtail/search/tests/test_elasticsearch6_backend.py
+++ b/wagtail/search/tests/test_elasticsearch6_backend.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import datetime
 import json
+
 from unittest import mock
 
 from django.db.models import Q

--- a/wagtail/search/tests/test_elasticsearch7_backend.py
+++ b/wagtail/search/tests/test_elasticsearch7_backend.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import datetime
 import json
+
 from unittest import mock
 
 from django.db.models import Q

--- a/wagtail/search/tests/test_queries.py
+++ b/wagtail/search/tests/test_queries.py
@@ -1,5 +1,6 @@
 import datetime
 import json
+
 from io import StringIO
 
 from django.core import management

--- a/wagtail/search/urls/admin.py
+++ b/wagtail/search/urls/admin.py
@@ -2,6 +2,7 @@ from django.urls import path
 
 from wagtail.search.views import queries
 
+
 app_name = 'wagtailsearch_admin'
 urlpatterns = [
     path("queries/chooser/", queries.chooser, name="queries_chooser"),

--- a/wagtail/search/utils.py
+++ b/wagtail/search/utils.py
@@ -1,8 +1,10 @@
 import operator
 import re
+
 from functools import partial
 
 from .query import MATCH_NONE, Phrase, PlainText
+
 
 NOT_SET = object()
 

--- a/wagtail/snippets/models.py
+++ b/wagtail/snippets/models.py
@@ -5,6 +5,7 @@ from django.urls import reverse
 from wagtail.admin.checks import check_panels_in_model
 from wagtail.admin.models import get_object_usage
 
+
 SNIPPET_MODELS = []
 
 

--- a/wagtail/snippets/templatetags/wagtailsnippets_admin_tags.py
+++ b/wagtail/snippets/templatetags/wagtailsnippets_admin_tags.py
@@ -2,6 +2,7 @@ from django import template
 
 from wagtail.core import hooks
 
+
 register = template.Library()
 
 

--- a/wagtail/snippets/urls.py
+++ b/wagtail/snippets/urls.py
@@ -2,6 +2,7 @@ from django.urls import path
 
 from wagtail.snippets.views import chooser, snippets
 
+
 app_name = 'wagtailsnippets'
 urlpatterns = [
     path('', snippets.index, name='index'),

--- a/wagtail/tests/customuser/fields.py
+++ b/wagtail/tests/customuser/fields.py
@@ -2,6 +2,7 @@ import random
 
 from django.db import models
 
+
 LOWER_BOUND = -2147483648
 UPPER_BOUND = 2147483647
 SHIFT = 92147483647

--- a/wagtail/tests/headless_urls.py
+++ b/wagtail/tests/headless_urls.py
@@ -6,6 +6,7 @@ from wagtail.admin import urls as wagtailadmin_urls
 from wagtail.documents import urls as wagtaildocs_urls
 from wagtail.images import urls as wagtailimages_urls
 
+
 urlpatterns = [
     path('admin/', include(wagtailadmin_urls)),
     path('documents/', include(wagtaildocs_urls)),

--- a/wagtail/tests/modeladmintest/models.py
+++ b/wagtail/tests/modeladmintest/models.py
@@ -1,8 +1,7 @@
 from django.db import models
 
 from wagtail.admin.edit_handlers import (
-    FieldPanel, MultiFieldPanel, ObjectList, PageChooserPanel, TabbedInterface
-)
+    FieldPanel, MultiFieldPanel, ObjectList, PageChooserPanel, TabbedInterface)
 from wagtail.core.models import Page
 from wagtail.search import index
 

--- a/wagtail/tests/modeladmintest/wagtail_hooks.py
+++ b/wagtail/tests/modeladmintest/wagtail_hooks.py
@@ -7,8 +7,7 @@ from wagtail.tests.testapp.models import BusinessChild, EventPage, SingleEventPa
 
 from .forms import PublisherModelAdminForm
 from .models import (
-    Author, Book, Contributor, Friend, Person, Publisher, RelatedLink, Token, VenuePage, Visitor
-)
+    Author, Book, Contributor, Friend, Person, Publisher, RelatedLink, Token, VenuePage, Visitor)
 
 
 class AuthorModelAdmin(ModelAdmin):

--- a/wagtail/tests/non_root_urls.py
+++ b/wagtail/tests/non_root_urls.py
@@ -8,6 +8,7 @@ from wagtail.core import urls as wagtail_urls
 from wagtail.documents import urls as wagtaildocs_urls
 from wagtail.images import urls as wagtailimages_urls
 
+
 urlpatterns = [
     path('admin/', include(wagtailadmin_urls)),
     path('documents/', include(wagtaildocs_urls)),

--- a/wagtail/tests/settings.py
+++ b/wagtail/tests/settings.py
@@ -1,5 +1,6 @@
 import os
 
+
 DEBUG = False
 WAGTAIL_ROOT = os.path.dirname(os.path.dirname(__file__))
 STATIC_ROOT = os.path.join(WAGTAIL_ROOT, 'tests', 'test-static')

--- a/wagtail/tests/testapp/urls.py
+++ b/wagtail/tests/testapp/urls.py
@@ -2,6 +2,7 @@ from django.urls import path
 
 from wagtail.tests.testapp.views import bob_only_zone, message_test
 
+
 urlpatterns = [
     path('bob-only-zone', bob_only_zone, name='testapp_bob_only_zone'),
     path('messages/', message_test, name='testapp_message_test')

--- a/wagtail/tests/testapp/wagtail_hooks.py
+++ b/wagtail/tests/testapp/wagtail_hooks.py
@@ -3,6 +3,7 @@ from django.http import HttpResponse
 from django.templatetags.static import static
 
 import wagtail.admin.rich_text.editors.draftail.features as draftail_features
+
 from wagtail.admin.action_menu import ActionMenuItem
 from wagtail.admin.menu import MenuItem
 from wagtail.admin.rich_text import HalloPlugin

--- a/wagtail/tests/urls.py
+++ b/wagtail/tests/urls.py
@@ -4,8 +4,8 @@ from django.urls import include, path
 from wagtail.admin import urls as wagtailadmin_urls
 from wagtail.api.v2.router import WagtailAPIRouter
 from wagtail.api.v2.views import PagesAPIViewSet
-from wagtail.contrib.sitemaps import views as sitemaps_views
 from wagtail.contrib.sitemaps import Sitemap
+from wagtail.contrib.sitemaps import views as sitemaps_views
 from wagtail.core import urls as wagtail_urls
 from wagtail.documents import urls as wagtaildocs_urls
 from wagtail.documents.api.v2.views import DocumentsAPIViewSet
@@ -14,6 +14,7 @@ from wagtail.images.api.v2.views import ImagesAPIViewSet
 from wagtail.images.tests import urls as wagtailimages_test_urls
 from wagtail.tests.testapp import urls as testapp_urls
 from wagtail.tests.testapp.models import EventSitemap
+
 
 api_router = WagtailAPIRouter('wagtailapi_v2')
 api_router.register_endpoint('pages', PagesAPIViewSet)

--- a/wagtail/tests/utils/wagtail_tests.py
+++ b/wagtail/tests/utils/wagtail_tests.py
@@ -1,4 +1,5 @@
 import warnings
+
 from contextlib import contextmanager
 
 from django.contrib.auth import get_user_model

--- a/wagtail/users/forms.py
+++ b/wagtail/users/forms.py
@@ -1,4 +1,5 @@
 import warnings
+
 from itertools import groupby
 from operator import itemgetter
 
@@ -23,6 +24,7 @@ from wagtail.core.models import (
     PAGE_PERMISSION_TYPE_CHOICES, PAGE_PERMISSION_TYPES, GroupPagePermission, Page,
     UserPagePermissionsProxy)
 from wagtail.users.models import UserProfile
+
 
 User = get_user_model()
 

--- a/wagtail/users/models.py
+++ b/wagtail/users/models.py
@@ -3,8 +3,8 @@ import uuid
 
 from django.conf import settings
 from django.db import models
-from django.utils.translation import gettext_lazy as _
 from django.utils.translation import get_language
+from django.utils.translation import gettext_lazy as _
 
 
 def upload_avatar_to(instance, filename):

--- a/wagtail/users/templatetags/wagtailusers_tags.py
+++ b/wagtail/users/templatetags/wagtailusers_tags.py
@@ -5,6 +5,7 @@ from django import template
 
 from wagtail.core import hooks
 
+
 register = template.Library()
 
 

--- a/wagtail/users/tests.py
+++ b/wagtail/users/tests.py
@@ -18,6 +18,7 @@ from wagtail.users.forms import UserCreationForm, UserEditForm
 from wagtail.users.models import UserProfile
 from wagtail.users.views.users import get_user_creation_form, get_user_edit_form
 
+
 delete_user_perm_codename = "delete_{0}".format(AUTH_USER_MODEL_NAME.lower())
 change_user_perm_codename = "change_{0}".format(AUTH_USER_MODEL_NAME.lower())
 

--- a/wagtail/users/urls/users.py
+++ b/wagtail/users/urls/users.py
@@ -2,6 +2,7 @@ from django.urls import path
 
 from wagtail.users.views import users
 
+
 app_name = 'wagtailusers_users'
 urlpatterns = [
     path('', users.index, name='index'),

--- a/wagtail/users/utils.py
+++ b/wagtail/users/utils.py
@@ -1,8 +1,10 @@
 import hashlib
+
 from django.conf import settings
 from django.utils.http import urlencode
 
 from wagtail.core.compat import AUTH_USER_APP_LABEL, AUTH_USER_MODEL_NAME
+
 
 delete_user_perm = "{0}.delete_{1}".format(AUTH_USER_APP_LABEL, AUTH_USER_MODEL_NAME.lower())
 

--- a/wagtail/users/views/groups.py
+++ b/wagtail/users/views/groups.py
@@ -8,6 +8,7 @@ from wagtail.core import hooks
 from wagtail.users.forms import GroupForm, GroupPagePermissionFormSet
 from wagtail.users.views.users import index
 
+
 _permission_panel_classes = None
 
 

--- a/wagtail/users/views/users.py
+++ b/wagtail/users/views/users.py
@@ -18,6 +18,7 @@ from wagtail.users.forms import UserCreationForm, UserEditForm
 from wagtail.users.utils import user_can_delete_user
 from wagtail.utils.loading import get_custom_form
 
+
 User = get_user_model()
 
 # Typically we would check the permission 'auth.change_user' (and 'auth.add_user' /

--- a/wagtail/utils/deprecation.py
+++ b/wagtail/utils/deprecation.py
@@ -1,4 +1,5 @@
 import warnings
+
 from importlib import import_module
 
 

--- a/wagtail/utils/sendfile.py
+++ b/wagtail/utils/sendfile.py
@@ -2,7 +2,9 @@
 # to sendfile()
 # See: https://github.com/johnsensible/django-sendfile/pull/33
 import os.path
+
 from mimetypes import guess_type
+
 
 VERSION = (0, 3, 6)
 __version__ = '.'.join(map(str, VERSION))
@@ -26,6 +28,7 @@ def _lazy_load(fn):
 @_lazy_load
 def _get_sendfile():
     from importlib import import_module
+
     from django.conf import settings
     from django.core.exceptions import ImproperlyConfigured
 
@@ -72,6 +75,7 @@ def sendfile(request, filename, attachment=False, attachment_filename=None, mime
         parts = ['attachment']
         if attachment_filename:
             from django.utils.encoding import force_str
+
             from wagtail.core.utils import string_to_ascii
 
             attachment_filename = force_str(attachment_filename)

--- a/wagtail/utils/sendfile_streaming_backend.py
+++ b/wagtail/utils/sendfile_streaming_backend.py
@@ -4,6 +4,7 @@
 import os
 import re
 import stat
+
 from email.utils import mktime_tz, parsedate_tz
 from wsgiref.util import FileWrapper
 


### PR DESCRIPTION
This PR:
* upgrades isort to latest version
* and adds https://pre-commit.com/ configuration to aid local development.
  Time and time again I find myself forgetting to lint. With this I can `pre-commit install` then forget until it complains about the wrong sort order or missing imports.

Note: this is now  using the latest isort (5.x, [upgrade notes[(https://pycqa.github.io/isort/docs/upgrade_guides/5.0.0/))