### PR TITLE
Adding support for `form_classname` meta in FieldBlock

### DIFF
--- a/docs/topics/streamfield.rst
+++ b/docs/topics/streamfield.rst
@@ -29,7 +29,7 @@ Using StreamField
         author = models.CharField(max_length=255)
         date = models.DateField("Post date")
         body = StreamField([
-            ('heading', blocks.CharBlock(classname="full title")),
+            ('heading', blocks.CharBlock(form_classname="full title")),
             ('paragraph', blocks.RichTextBlock()),
             ('image', ImageChooserBlock()),
         ])
@@ -411,7 +411,7 @@ This defines ``PersonBlock()`` as a block type that can be re-used as many times
 .. code-block:: python
 
     body = StreamField([
-        ('heading', blocks.CharBlock(classname="full title")),
+        ('heading', blocks.CharBlock(form_classname="full title")),
         ('paragraph', blocks.RichTextBlock()),
         ('image', ImageChooserBlock()),
         ('person', PersonBlock()),

--- a/wagtail/core/blocks/base.py
+++ b/wagtail/core/blocks/base.py
@@ -97,6 +97,13 @@ class Block(metaclass=BaseBlock):
         return mark_safe('\n'.join(declarations))
 
     def __init__(self, **kwargs):
+        if 'classname' in self._constructor_args[1]:
+            # Adding this so that migrations are not triggered
+            # when form_classname is used instead of classname
+            # in the initialisation of the FieldBlock
+            classname = self._constructor_args[1].pop('classname')
+            self._constructor_args[1].setdefault('form_classname', classname)
+
         self.meta = self._meta_class()
 
         for attr, value in kwargs.items():

--- a/wagtail/core/blocks/field_block.py
+++ b/wagtail/core/blocks/field_block.py
@@ -39,7 +39,7 @@ class FieldBlock(Block):
 
         return render_to_string('wagtailadmin/block_forms/field.html', {
             'name': self.name,
-            'classes': self.meta.classname,
+            'classes': getattr(self.meta, 'form_classname', self.meta.classname),
             'widget': widget_html,
             'field': field,
             'errors': errors if (not widget_has_rendered_errors) else None

--- a/wagtail/core/tests/test_blocks.py
+++ b/wagtail/core/tests/test_blocks.py
@@ -72,7 +72,7 @@ class TestFieldBlock(WagtailTestUtils, SimpleTestCase):
         block_with_classname = blocks.CharBlock(
             classname='special-char-class'
         )
-        html = block.render_form("Hello world!")
+        html = block_with_classname.render_form("Hello world!")
         self.assertEqual(html.count(' special-char-class'), 1)
     
     def test_charfield_render_with_template_with_extra_context(self):

--- a/wagtail/core/tests/test_blocks.py
+++ b/wagtail/core/tests/test_blocks.py
@@ -55,10 +55,10 @@ class TestFieldBlock(WagtailTestUtils, SimpleTestCase):
         html = block.render("Hello world!")
 
         self.assertEqual(html, '<h1>Hello world!</h1>')
-    
+
     def test_charfield_form_classname(self):
         """
-        Meta data test for FormField; this checks if both the meta values 
+        Meta data test for FormField; this checks if both the meta values
         form_classname and classname are accepted and are rendered
         in the form
         """
@@ -74,7 +74,7 @@ class TestFieldBlock(WagtailTestUtils, SimpleTestCase):
         )
         html = block_with_classname.render_form("Hello world!")
         self.assertEqual(html.count(' special-char-class'), 1)
-    
+
     def test_charfield_render_with_template_with_extra_context(self):
         block = ContextCharBlock(template='tests/blocks/heading_block.html')
         html = block.render("Bonjour le monde!", context={

--- a/wagtail/core/tests/test_blocks.py
+++ b/wagtail/core/tests/test_blocks.py
@@ -63,17 +63,17 @@ class TestFieldBlock(WagtailTestUtils, SimpleTestCase):
         in the form
         """
         block = blocks.CharBlock(
-            form_classname='special-char-class'
+            form_classname='special-char-formclassname'
         )
         html = block.render_form("Hello world!")
-        self.assertEqual(html.count(' special-char-class'), 1)
+        self.assertEqual(html.count(' special-char-formclassname'), 1)
 
         # Checks if it is  backward compatible with classname
         block_with_classname = blocks.CharBlock(
-            classname='special-char-class'
+            classname='special-char-classname'
         )
         html = block_with_classname.render_form("Hello world!")
-        self.assertEqual(html.count(' special-char-class'), 1)
+        self.assertEqual(html.count(' special-char-classname'), 1)
 
     def test_charfield_render_with_template_with_extra_context(self):
         block = ContextCharBlock(template='tests/blocks/heading_block.html')

--- a/wagtail/core/tests/test_blocks.py
+++ b/wagtail/core/tests/test_blocks.py
@@ -58,7 +58,7 @@ class TestFieldBlock(WagtailTestUtils, SimpleTestCase):
     
     def test_charfield_form_classname(self):
         """
-        For FormField this checks if both the meta values 
+        Meta data test for FormField; this checks if both the meta values 
         form_classname and classname are accepted and are rendered
         in the form
         """
@@ -68,7 +68,7 @@ class TestFieldBlock(WagtailTestUtils, SimpleTestCase):
         html = block.render_form("Hello world!")
         self.assertEqual(html.count(' special-char-class'), 1)
 
-        # Also check if it's backward compatible with classname meta
+        # Checks if it is  backward compatible with classname
         block_with_classname = blocks.CharBlock(
             classname='special-char-class'
         )

--- a/wagtail/core/tests/test_blocks.py
+++ b/wagtail/core/tests/test_blocks.py
@@ -55,7 +55,26 @@ class TestFieldBlock(WagtailTestUtils, SimpleTestCase):
         html = block.render("Hello world!")
 
         self.assertEqual(html, '<h1>Hello world!</h1>')
+    
+    def test_charfield_form_classname(self):
+        """
+        For FormField this checks if both the meta values 
+        form_classname and classname are accepted and are rendered
+        in the form
+        """
+        block = blocks.CharBlock(
+            form_classname='special-char-class'
+        )
+        html = block.render_form("Hello world!")
+        self.assertEqual(html.count(' special-char-class'), 1)
 
+        # Also check if it's backward compatible with classname meta
+        block_with_classname = blocks.CharBlock(
+            classname='special-char-class'
+        )
+        html = block.render_form("Hello world!")
+        self.assertEqual(html.count(' special-char-class'), 1)
+    
     def test_charfield_render_with_template_with_extra_context(self):
         block = ContextCharBlock(template='tests/blocks/heading_block.html')
         html = block.render("Bonjour le monde!", context={


### PR DESCRIPTION
Changed the meta input for FormField to take in both `classname` and `form_classname` with reference to #6192

I didn't see any other blocks that use `self.meta.classname` so I believe that FormField is the only block that requires the changes. If I missed anything please do point me to the right place.

### Checklist ✨

- [x] Do the tests still pass?
- [x] Does the code comply with the style guide? 
- [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
