### PR TITLE
Lint config fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
             - ~/.local/
           key: pip-package-v1-{{ .Branch }}
       - run: pipenv run flake8
-      - run: pipenv run isort --check-only --diff --recursive wagtail
+      - run: pipenv run isort --check-only --diff .
       # Filter out known false positives, while preserving normal output and error codes.
       # See https://github.com/motet-a/jinjalint/issues/18.
       # And https://circleci.com/docs/2.0/configuration-reference/#default-shell-options.

--- a/Makefile
+++ b/Makefile
@@ -17,12 +17,13 @@ develop: clean-pyc
 
 lint:
 	flake8
-	isort --check-only --diff --recursive .
+	isort --check-only --diff .
 	# Filter out known false positives, while preserving normal output and error codes.
 	# See https://github.com/motet-a/jinjalint/issues/18.
 	jinjalint --parse-only wagtail | grep -v 'welcome_page.html:6:70' | tee /dev/tty | wc -l | grep -q '0'
 	npm run lint:css --silent
 	npm run lint:js --silent
+	doc8 --ignore D001 docs
 
 test:
 	python runtests.py

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,6 +14,7 @@
 
 import os
 import sys
+
 from datetime import datetime
 
 import django

--- a/docs/contributing/python_guidelines.rst
+++ b/docs/contributing/python_guidelines.rst
@@ -8,7 +8,7 @@ We ask that all Python contributions adhere to the `PEP8 <https://www.python.org
 The list of PEP8 violations to ignore is in the ``setup.cfg`` file, under the ``[flake8]`` header.
 You might want to configure the flake8 linter in your editor/IDE to use the configuration in this file.
 
-In addition, import lines should be sorted according to `isort <https://timothycrosley.github.io/isort/>`_ 4.2.5 rules. If you have installed Wagtail's testing dependencies (``pip install -e .[testing]``), you can check your code by running ``make lint``.
+In addition, import lines should be sorted according to `isort <https://pycqa.github.io/isort/>`_ 5.6.4 rules. If you have installed Wagtail's testing dependencies (``pip install -e .[testing]``), you can check your code by running ``make lint``.
 
 Django compatibility
 ~~~~~~~~~~~~~~~~~~~~

--- a/runtests.py
+++ b/runtests.py
@@ -8,6 +8,7 @@ import warnings
 
 from django.core.management import execute_from_command_line
 
+
 os.environ['DJANGO_SETTINGS_MODULE'] = 'wagtail.tests.settings'
 
 
@@ -86,7 +87,7 @@ def runtests():
     try:
         execute_from_command_line(argv)
     finally:
-        from wagtail.tests.settings import STATIC_ROOT, MEDIA_ROOT
+        from wagtail.tests.settings import MEDIA_ROOT, STATIC_ROOT
         shutil.rmtree(STATIC_ROOT, ignore_errors=True)
         shutil.rmtree(MEDIA_ROOT, ignore_errors=True)
 

--- a/scripts/get-translator-credits.py
+++ b/scripts/get-translator-credits.py
@@ -1,9 +1,11 @@
 import re
 import subprocess
+
 from collections import defaultdict
 from io import open
 
 from babel import Locale
+
 
 authors_by_locale = defaultdict(set)
 

--- a/scripts/nightly/upload.py
+++ b/scripts/nightly/upload.py
@@ -4,6 +4,7 @@ import sys
 
 import boto3
 
+
 dist_folder = pathlib.Path.cwd() / 'dist'
 
 try:

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,8 @@ max-line-length = 120
 [isort]
 line_length=100
 multi_line_output=4
-skip=migrations,project_template
+skip=migrations,project_template,node_modules,.git,__pycache__,LC_MESSAGES
+blocked_extensions=rst,html,js,svg,txt,css,scss,png,snap
 known_first_party=wagtail
 default_section=THIRDPARTY
 lines_between_types=1

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ testing_extras = [
     # For coverage and PEP8 linting
     'coverage>=3.7.0',
     'flake8>=3.6.0',
-    'isort>=5.6.0,<6.0',
+    'isort==5.6.4',  # leave this pinned - it tends to change rules between patch releases
     'flake8-blind-except==0.1.1',
     'flake8-print==2.0.2',
     'doc8==0.8.1',


### PR DESCRIPTION
Ref #6463, #6428

* pin isort to 5.6.4
* update isort version mentioned in python_guidelines.rst
* make lint commands consistent between make lint and circleci
* fix isort errors on files outside of /wagtail
* speed up isort by ignoring additional directories and filetypes
