### PR TITLE
Extend Pillow dependency range to include 8.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ install_requires = [
     "djangorestframework>=3.11.1,<4.0",
     "django-filter>=2.2,<3.0",
     "draftjs_exporter>=2.1.5,<3.0",
-    "Pillow>=4.0.0,<8.0.0",
+    "Pillow>=4.0.0,<9.0.0",
     "beautifulsoup4>=4.8,<4.9",
     "html5lib>=0.999,<2",
     # RemovedInWagtail212Warning: unidecode is only used by _migrate_legacy_clean_name in wagtail.contrib.forms


### PR DESCRIPTION
Pillow 8.0.0 was released on October 14th - lagging behind on Pillow releases tends to cause headaches down the line with security patches / dependencies with other packages, so definitely worth getting this into 2.11LTS...