### PR TITLE
Make StreamField values mutable and deprecate stream_data

### DIFF
--- a/docs/topics/streamfield.rst
+++ b/docs/topics/streamfield.rst
@@ -1024,6 +1024,30 @@ Your extended value class methods will be available in your template:
     </div>
 
 
+Modifying StreamField data
+--------------------------
+
+A StreamField's value behaves as a list, and blocks can be inserted, overwritten and deleted before saving the instance back to the database. A new item can be written to the list as a tuple of *(block_type, value)* - when read back, it will be returned as a ``BoundBlock`` object.
+
+.. code-block:: python
+
+    # Replace the first block with a new block of type 'heading'
+    my_page.body[0] = ('heading', "My story")
+
+    # Delete the last block
+    del my_page.body[-1]
+
+    # Append a block to the stream
+    my_page.body.append(('paragraph', "<p>And they all lived happily ever after.</p>"))
+
+    # Save the updated data back to the database
+    my_page.save()
+
+
+.. versionadded:: 2.12
+
+    In earlier versions, a StreamField value could be replaced by assigning a new list of *(block_type, value)* tuples, but not modified in-place.
+
 
 Custom block types
 ------------------

--- a/wagtail/core/blocks/base.py
+++ b/wagtail/core/blocks/base.py
@@ -472,6 +472,9 @@ class BoundBlock:
         """Render the value according to the block's native rendering"""
         return self.block.render(self.value)
 
+    def __repr__(self):
+        return "<block %s: %r>" % (self.block.name or type(self.block).__name__, self.value)
+
 
 class DeclarativeSubBlocksMetaclass(BaseBlock):
     """

--- a/wagtail/core/blocks/stream_block.py
+++ b/wagtail/core/blocks/stream_block.py
@@ -457,6 +457,9 @@ class StreamValue(MutableSequence):
             self.stream_value._raw_data.insert(i, item)
             self.stream_value._bound_blocks.insert(i, None)
 
+        def __repr__(self):
+            return repr(list(self))
+
     def __init__(self, stream_block, stream_data, is_lazy=False, raw_text=None):
         """
         Construct a StreamValue linked to the given StreamBlock,
@@ -606,7 +609,7 @@ class StreamValue(MutableSequence):
         return len(self._bound_blocks)
 
     def __repr__(self):
-        return repr(list(self))
+        return "<%s %r>" % (type(self).__name__, list(self))
 
     def render_as_block(self, context=None):
         return self.stream_block.render(self, context=context)

--- a/wagtail/core/blocks/stream_block.py
+++ b/wagtail/core/blocks/stream_block.py
@@ -478,10 +478,12 @@ class StreamValue(MutableSequence):
         self._bound_blocks[i] = self._construct_stream_child(item)
 
     def __delitem__(self, i):
-        raise NotImplementedError
+        del self._bound_blocks[i]
+        del self._raw_data[i]
 
     def insert(self, i, item):
-        raise NotImplementedError
+        self._bound_blocks.insert(i, self._construct_stream_child(item))
+        self._raw_data.insert(i, None)
 
     def _prefetch_blocks(self, type_name):
         """

--- a/wagtail/core/tests/test_blocks.py
+++ b/wagtail/core/tests/test_blocks.py
@@ -3333,6 +3333,40 @@ class TestStreamBlock(WagtailTestUtils, SimpleTestCase):
         }
         self.check_get_prep_value_nested_streamblocks(stream_data, is_lazy=True)
 
+    def test_modifications_to_stream_child_id_are_saved(self):
+        class ArticleBlock(blocks.StreamBlock):
+            heading = blocks.CharBlock()
+            paragraph = blocks.CharBlock()
+
+        block = ArticleBlock()
+        stream = block.to_python([
+            {'type': 'heading', 'value': 'hello', 'id': '0001'},
+            {'type': 'paragraph', 'value': 'world', 'id': '0002'},
+        ])
+        stream[1].id = '0003'
+        raw_data = block.get_prep_value(stream)
+        self.assertEqual(raw_data, [
+            {'type': 'heading', 'value': 'hello', 'id': '0001'},
+            {'type': 'paragraph', 'value': 'world', 'id': '0003'},
+        ])
+
+    def test_modifications_to_stream_child_value_are_saved(self):
+        class ArticleBlock(blocks.StreamBlock):
+            heading = blocks.CharBlock()
+            paragraph = blocks.CharBlock()
+
+        block = ArticleBlock()
+        stream = block.to_python([
+            {'type': 'heading', 'value': 'hello', 'id': '0001'},
+            {'type': 'paragraph', 'value': 'world', 'id': '0002'},
+        ])
+        stream[1].value = 'earth'
+        raw_data = block.get_prep_value(stream)
+        self.assertEqual(raw_data, [
+            {'type': 'heading', 'value': 'hello', 'id': '0001'},
+            {'type': 'paragraph', 'value': 'earth', 'id': '0002'},
+        ])
+
     def test_render_with_classname_via_kwarg(self):
         """form_classname from kwargs to be used as an additional class when rendering stream block"""
 

--- a/wagtail/core/tests/test_blocks.py
+++ b/wagtail/core/tests/test_blocks.py
@@ -3367,6 +3367,40 @@ class TestStreamBlock(WagtailTestUtils, SimpleTestCase):
             {'type': 'paragraph', 'value': 'earth', 'id': '0002'},
         ])
 
+    def test_set_streamvalue_item(self):
+        class ArticleBlock(blocks.StreamBlock):
+            heading = blocks.CharBlock()
+            paragraph = blocks.CharBlock()
+
+        block = ArticleBlock()
+        stream = block.to_python([
+            {'type': 'heading', 'value': 'hello', 'id': '0001'},
+            {'type': 'paragraph', 'value': 'world', 'id': '0002'},
+        ])
+        stream[1] = ('heading', 'goodbye', '0003')
+        raw_data = block.get_prep_value(stream)
+        self.assertEqual(raw_data, [
+            {'type': 'heading', 'value': 'hello', 'id': '0001'},
+            {'type': 'heading', 'value': 'goodbye', 'id': '0003'},
+        ])
+
+    @unittest.expectedFailure
+    def test_delete_streamvalue_item(self):
+        class ArticleBlock(blocks.StreamBlock):
+            heading = blocks.CharBlock()
+            paragraph = blocks.CharBlock()
+
+        block = ArticleBlock()
+        stream = block.to_python([
+            {'type': 'heading', 'value': 'hello', 'id': '0001'},
+            {'type': 'paragraph', 'value': 'world', 'id': '0002'},
+        ])
+        del stream[0]
+        raw_data = block.get_prep_value(stream)
+        self.assertEqual(raw_data, [
+            {'type': 'paragraph', 'value': 'world', 'id': '0002'},
+        ])
+
     def test_render_with_classname_via_kwarg(self):
         """form_classname from kwargs to be used as an additional class when rendering stream block"""
 

--- a/wagtail/core/tests/test_blocks.py
+++ b/wagtail/core/tests/test_blocks.py
@@ -3384,7 +3384,6 @@ class TestStreamBlock(WagtailTestUtils, SimpleTestCase):
             {'type': 'heading', 'value': 'goodbye', 'id': '0003'},
         ])
 
-    @unittest.expectedFailure
     def test_delete_streamvalue_item(self):
         class ArticleBlock(blocks.StreamBlock):
             heading = blocks.CharBlock()
@@ -3399,6 +3398,42 @@ class TestStreamBlock(WagtailTestUtils, SimpleTestCase):
         raw_data = block.get_prep_value(stream)
         self.assertEqual(raw_data, [
             {'type': 'paragraph', 'value': 'world', 'id': '0002'},
+        ])
+
+    def test_insert_streamvalue_item(self):
+        class ArticleBlock(blocks.StreamBlock):
+            heading = blocks.CharBlock()
+            paragraph = blocks.CharBlock()
+
+        block = ArticleBlock()
+        stream = block.to_python([
+            {'type': 'heading', 'value': 'hello', 'id': '0001'},
+            {'type': 'paragraph', 'value': 'world', 'id': '0002'},
+        ])
+        stream.insert(1, ('paragraph', 'mutable', '0003'))
+        raw_data = block.get_prep_value(stream)
+        self.assertEqual(raw_data, [
+            {'type': 'heading', 'value': 'hello', 'id': '0001'},
+            {'type': 'paragraph', 'value': 'mutable', 'id': '0003'},
+            {'type': 'paragraph', 'value': 'world', 'id': '0002'},
+        ])
+
+    def test_append_streamvalue_item(self):
+        class ArticleBlock(blocks.StreamBlock):
+            heading = blocks.CharBlock()
+            paragraph = blocks.CharBlock()
+
+        block = ArticleBlock()
+        stream = block.to_python([
+            {'type': 'heading', 'value': 'hello', 'id': '0001'},
+            {'type': 'paragraph', 'value': 'world', 'id': '0002'},
+        ])
+        stream.append(('paragraph', 'of warcraft', '0003'))
+        raw_data = block.get_prep_value(stream)
+        self.assertEqual(raw_data, [
+            {'type': 'heading', 'value': 'hello', 'id': '0001'},
+            {'type': 'paragraph', 'value': 'world', 'id': '0002'},
+            {'type': 'paragraph', 'value': 'of warcraft', 'id': '0003'},
         ])
 
     def test_render_with_classname_via_kwarg(self):

--- a/wagtail/core/tests/test_streamfield.py
+++ b/wagtail/core/tests/test_streamfield.py
@@ -177,6 +177,18 @@ class TestStreamValueAccess(TestCase):
         self.assertIsInstance(fetched_body[0].value, RichText)
         self.assertEqual(fetched_body[0].value.source, "<h2>hello world</h2>")
 
+    def test_can_append(self):
+        self.json_body.body.append(('text', 'bar'))
+        self.json_body.save()
+
+        fetched_body = StreamModel.objects.get(id=self.json_body.id).body
+        self.assertIsInstance(fetched_body, StreamValue)
+        self.assertEqual(len(fetched_body), 2)
+        self.assertEqual(fetched_body[0].block_type, 'text')
+        self.assertEqual(fetched_body[0].value, 'foo')
+        self.assertEqual(fetched_body[1].block_type, 'text')
+        self.assertEqual(fetched_body[1].value, 'bar')
+
 
 class TestStreamFieldRenderingBase(TestCase):
     def setUp(self):


### PR DESCRIPTION
Fixes #2876 and supersedes #2886. StreamValue now implements the `MutableSequence` interface so that it can be modified in place, rather than having to reassign the entire list to update it:

    # Replace the first block with a new block of type 'heading'
    my_page.body[0] = ('heading', "My story")

    # Delete the last block
    del my_page.body[-1]

    # Append a block to the stream
    my_page.body.append(('paragraph', "<p>And they all lived happily ever after.</p>"))

    # Save the updated data back to the database
    my_page.save()

StreamValue has undergone some internal refactoring to make this possible: previously the internal `stream_data` property contained the underlying data in one of two possible formats, depending on whether the data came from the database ('lazy' mode, where it's stored as JSONish dicts and converted to native Python values on first access) or from Python code ('non-lazy' mode, where it's stored in tuples already containing the native Python values). This setup doesn't work for mutable sequences (where we might have some data items originating from the database, and others overwritten in python code) and is pretty messy anyhow.

Unfortunately, `stream_data` has found its way into a lot of end-user code that doesn't properly account for the lazy versus non-lazy cases (which usually means it mostly works, but breaks on page previews) and so this needs to go through the deprecation process. I've added a backwards-compatible shim for `stream_data`, along with a new accessor `raw_data` which consistently returns the JSONish data (i.e. it does what people _think_ `stream_data` did, and for 99% of cases people should be able to fix their code by replacing `stream_data` with `raw_data`).

~~Note: I've written the deprecation warnings and docs as if this is a 2.11 feature, but I'm not expecting it to make the deadline :-) Will update these to target 2.12 once the necessary bits of release housekeeping have been done.~~ (done)