### PR TITLE
More prominent note about wagtail-localize in i18n docs

### DIFF
--- a/docs/advanced_topics/i18n.rst
+++ b/docs/advanced_topics/i18n.rst
@@ -18,9 +18,13 @@ Overview
 
 Out of the box, Wagtail assumes all content will be authored in a single language.
 This document describes how to configure Wagtail for authoring content in
-multiple languages. For translating content between different languages, a translation
-plugin (such as `wagtail-localize <https://github.com/wagtail/wagtail-localize>`_)
-must be installed separately.
+multiple languages.
+
+.. note::
+    Wagtail provides the infrastructure for creating and serving content in multiple languages,
+    but does not itself provide an admin interface for managing translations of the same content
+    across different languages. For this, the `wagtail-localize <https://github.com/wagtail/wagtail-localize>`_
+    app must be installed separately.
 
 This document only covers the internationalisation of content managed by Wagtail.
 For information on how to translate static content in template files, JavaScript


### PR DESCRIPTION
Fixes #6504 - clarify the difference in roles between Wagtail's i18n support and wagtail-localize, and emphasise that you need wagtail-localize if you're translating content between languages. A few people have missed this detail and been sent on the wrong track - I suspect that describing it as a "translation plugin" is leading people to imagine something like a Google Translate widget, rather than the whole admin UI for translation.

I've also removed the "such as..." wording, since wagtail-localize is currently the only app that integrates with the i18n model described here - we can reinstate it if and when alternative apps appear.