### PR TITLE
Check if new pages are site roots and clear the site_root_paths cache

### DIFF
--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -1004,7 +1004,9 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
             self._update_descendant_url_paths(old_url_path, new_url_path)
 
         # Check if this is a root page of any sites and clear the 'wagtail_site_root_paths' key if so
-        if not is_new and self.is_site_root():
+        # Note: New translations of existing site roots are considered site roots as well, so we must
+        #       always check if this page is a site root, even if it's new.
+        if self.is_site_root():
             cache.delete('wagtail_site_root_paths')
 
         # Log

--- a/wagtail/core/tests/tests.py
+++ b/wagtail/core/tests/tests.py
@@ -6,7 +6,7 @@ from django.test.utils import override_settings
 from django.urls.exceptions import NoReverseMatch
 from django.utils.safestring import SafeString
 
-from wagtail.core.models import Page, Site, SiteRootPath
+from wagtail.core.models import Locale, Page, Site, SiteRootPath
 from wagtail.core.templatetags.wagtailcore_tags import richtext, slugurl
 from wagtail.core.utils import resolve_model_string
 from wagtail.tests.testapp.models import SimplePage
@@ -263,6 +263,20 @@ class TestSiteRootPathsCache(TestCase):
 
         # Check url
         self.assertEqual(homepage.url, '/')
+
+    @override_settings(WAGTAIL_I18N_ENABLED=True)
+    def test_cache_clears_when_site_root_is_translated_as_alias(self):
+        # Get homepage
+        homepage = Page.objects.get(url_path='/home/')
+
+        # Warm up the cache by getting the url
+        _ = homepage.url  # noqa
+
+        # Translate the homepage
+        translated_homepage = homepage.copy_for_translation(Locale.objects.create(language_code="fr"), alias=True)
+
+        # Check url
+        self.assertEqual(translated_homepage.url, '/')
 
 
 class TestResolveModelString(TestCase):


### PR DESCRIPTION
Previously, we were only doing this check for existing pages as there was no way for a new page to be a site root.

But since internationalisation was implemented, new pages can be site roots if they have a translation that is assigned in a `Site` record's `root_page` field.

This commit removes a condition in `Page.save()` so `.is_site_root()` is now called on new pages as well and the cache can get cleared if needed.

Note: this was only happening when the page was copied as an alias. When a page is published, it's saved multiple times so the code did eventually run there.