### PR TITLE
Additional safeguard to check if a cached site is from an old Wagtail version

### DIFF
--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -299,19 +299,11 @@ class Site(models.Model):
         """
         result = cache.get('wagtail_site_root_paths')
 
-        # Wagtail 2.11 changed the way site root paths were stored which would cause
-        # an upgraded 2.11 site to break when loading cached site root paths that were cached with 2.10.2
-        # or older versions of Wagtail.
-        # The code below checks if the any of the cached site urls is consistent with an older version of
-        # Wagtail and busts the cache.
-        if result is not None:
-            for site_root_paths in result:
-                if len(site_root_paths) == 3:
-                    cache.delete('wagtail_site_root_paths')
-                    result = None
-                    break
-
-        if result is None:
+        # Wagtail 2.11 changed the way site root paths were stored. This can cause an upgraded 2.11
+        # site to break when loading cached site root paths that were cached with 2.10.2 or older
+        # versions of Wagtail. The line below checks if the any of the cached site urls is consistent
+        # with an older version of Wagtail and invalidates the cache.
+        if result is None or any(len(site_record) == 3 for site_record in result):
             result = []
 
             for site in Site.objects.select_related('root_page', 'root_page__locale').order_by('-root_page__url_path', '-is_default_site', 'hostname'):

--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -301,6 +301,7 @@ class Site(models.Model):
 
         # Wagtail 2.11 changed the way site root paths were stored which would cause 
         # an upgraded 2.11 site to break when loading cached site root paths that were cached with 2.10.2
+        # or older versions of Wagtail.
         # The code below checks if the any of the cached site urls is consistent with an older version of 
         # Wagtail and busts the cache.
         if result is not None:

--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -299,6 +299,17 @@ class Site(models.Model):
         """
         result = cache.get('wagtail_site_root_paths')
 
+        # Wagtail 2.11 changed the way site root paths were stored which would cause 
+        # an upgraded 2.11 site to break when loading cached site root paths that were cached with 2.10.2
+        # The code below checks if the any of the cached site urls is consistent with an older version of 
+        # Wagtail and busts the cache.
+        if result is not None:
+            for site_root_paths in result:
+                if len(site_root_paths) == 3:
+                    cache.delete('wagtail_site_root_paths')
+                    result = None
+                    break
+
         if result is None:
             result = []
 

--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -299,10 +299,10 @@ class Site(models.Model):
         """
         result = cache.get('wagtail_site_root_paths')
 
-        # Wagtail 2.11 changed the way site root paths were stored which would cause 
+        # Wagtail 2.11 changed the way site root paths were stored which would cause
         # an upgraded 2.11 site to break when loading cached site root paths that were cached with 2.10.2
         # or older versions of Wagtail.
-        # The code below checks if the any of the cached site urls is consistent with an older version of 
+        # The code below checks if the any of the cached site urls is consistent with an older version of
         # Wagtail and busts the cache.
         if result is not None:
             for site_root_paths in result:


### PR DESCRIPTION
Fixes #6513. 
This proposed PR fixes the immediate problem that I had with upgrading to Wagtail 2.11. 