### PR TITLE
Prevent errors on get_url_parts when a non-content-language locale is active

### DIFF
--- a/wagtail/core/tests/test_page_model.py
+++ b/wagtail/core/tests/test_page_model.py
@@ -499,6 +499,12 @@ class TestRoutingWithI18N(TestRouting):
         with translation.override("en-us"):
             self.test_urls()
 
+    def test_urls_with_language_not_in_wagtail_content_languages(self):
+        # If the active locale doesn't map to anything in WAGTAIL_CONTENT_LANGUAGES,
+        # URL prefixes should remain the same as the page's reported locale
+        with translation.override("se"):
+            self.test_urls()
+
     def test_urls_with_different_language_tree(self):
         default_site = Site.objects.get(is_default_site=True)
         homepage = Page.objects.get(url_path='/home/')


### PR DESCRIPTION
Fixes #6510 and #6511

Catch the LookupError from get_supported_content_language_variant so that if the active language is not one that is recognised as a content language, the URL prefix will be left unchanged from the page's reported locale.

Additionally, skip the `translation.override` when WAGTAIL_I18N_ENABLED is false; this accounts for the fact that existing sites may have used alternative / custom i18n implementations involving i18n_patterns, and on these sites we can't rely on the page's locale field to be meaningful. That way, we restore the pre-2.11 behaviour: if the existing i18n code was using some kind of wrapper around the get_url_parts call, then that will work again; and if not, the URL will reflect the current active locale, which is no worse than before.