### PR TITLE
Avoid circular import between wagtail.admin.auth and custom user models

### DIFF
--- a/wagtail/admin/auth.py
+++ b/wagtail/admin/auth.py
@@ -5,7 +5,6 @@ from functools import wraps
 import l18n
 
 from django.contrib.auth import get_user_model
-from django.contrib.auth.views import redirect_to_login as auth_redirect_to_login
 from django.core.exceptions import PermissionDenied
 from django.db.models import Q
 from django.shortcuts import redirect
@@ -145,6 +144,9 @@ def reject_request(request):
     if request.is_ajax():
         raise PermissionDenied
 
+    # import redirect_to_login here to avoid circular imports on model files that import
+    # wagtail.admin.auth, specifically where custom user models are involved
+    from django.contrib.auth.views import redirect_to_login as auth_redirect_to_login
     return auth_redirect_to_login(
         request.get_full_path(), login_url=reverse('wagtailadmin_login'))
 

--- a/wagtail/tests/customuser/models.py
+++ b/wagtail/tests/customuser/models.py
@@ -1,6 +1,10 @@
 from django.contrib.auth.models import AbstractBaseUser, BaseUserManager, PermissionsMixin
 from django.db import models
 
+# make sure we can import wagtail.admin.auth here without triggering a circular import
+# (which is easily done because it's dealing with django.contrib.auth views which depend
+# on the user model)
+from wagtail.admin.auth import permission_denied  # noqa
 from wagtail.admin.edit_handlers import FieldPanel
 
 from .fields import ConvertedValueField


### PR DESCRIPTION
Fixes #6518

If the models.py containing a custom user model directly or indirectly imports wagtail.admin.auth, this causes a circular dependency because wagtail.admin.auth attempts to import django.contrib.auth.views, which in turn depends on the custom user model. Fix this by moving the django.contrib.auth.views import inside reject_request.
