### PR TITLE
Switch IE11 home warning message to show for all users regardless of role

### DIFF
--- a/wagtail/admin/views/home.py
+++ b/wagtail/admin/views/home.py
@@ -43,10 +43,7 @@ class IE11WarningPanel:
         self.request = request
 
     def render(self):
-        if self.request.user.is_superuser:
-            return render_to_string('wagtailadmin/home/ie11_warning.html', {}, request=self.request)
-        else:
-            return ""
+        return render_to_string('wagtailadmin/home/ie11_warning.html', {}, request=self.request)
 
 
 class PagesForModerationPanel:


### PR DESCRIPTION
See #6170. This is the second step on the plan highlighted in [Supported browsers – IE11](https://docs.wagtail.io/en/stable/editor_manual/browser_issues.html#ie11).

The change is pretty small this time around. In Wagtail 2.13, we’ll have to remove this home panel and move the message to one of the base templates like the "JS required" message.

Tested in Chrome & IE 11 only