### PR TITLE
added collection_id param to setPage in document-chooser-modal.js

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -6,6 +6,7 @@ Changelog
 
  * Added support for Python 3.9
  * Fix: Stop menu icon overlapping the breadcrumb on small viewport widths in page editor (Karran Besen)
+ * Fix: Make sure document chooser pagination preserves the selected collection when moving between pages (Alex Sa)
 
 
 2.11.2 (17.11.2020)

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -485,6 +485,7 @@ Contributors
 * David Bramwell
 * Naglis Jonaitis
 * Luis Nell
+* Alex Sa
 
 Translators
 ===========

--- a/docs/releases/2.12.rst
+++ b/docs/releases/2.12.rst
@@ -21,6 +21,7 @@ Bug fixes
 ~~~~~~~~~
 
  * Stop menu icon overlapping the breadcrumb on small viewport widths in page editor (Karran Besen)
+ * Make sure document chooser pagination preserves the selected collection when moving between pages (Alex Sa)
 
 
 Upgrade considerations

--- a/wagtail/documents/static_src/wagtaildocs/js/document-chooser-modal.js
+++ b/wagtail/documents/static_src/wagtaildocs/js/document-chooser-modal.js
@@ -54,6 +54,8 @@ DOCUMENT_CHOOSER_MODAL_ONLOAD_HANDLERS = {
                 dataObj = {p: page};
             }
 
+            dataObj.collection_id = $('#collection_chooser_collection_id').val();
+
             request = $.ajax({
                 url: searchUrl,
                 data: dataObj,


### PR DESCRIPTION
The setPage function in document-chooser-modal.js does not send the collection_id parameter, so you cannot use the pagination for collections of documents. image-chooser-modal.js looks good.

Fixes https://github.com/wagtail/wagtail/issues/5913

Tested in:
  - Chrome 86.0.4240.183
  - Safari 14.0.1

Didn't have more browsers to test with, but should even work in IE11.