### PR TITLE
Add custom robots.txt to docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -163,7 +163,7 @@ html_static_path = ['_static']
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied
 # directly to the root of the documentation.
-# html_extra_path = []
+html_extra_path = ['robots.txt']
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,0 +1,8 @@
+User-agent: *
+
+# Only index `/en/stable/`
+Disallow: /en/v*/
+Disallow: /en/latest/
+Disallow: /*/pdf/
+
+Sitemap: https://docs.wagtail.io/sitemap.xml


### PR DESCRIPTION
This PR adds a custom robots.txt to the docs.

It allows crawling of `/en/stable/` and blocks latest, versions and pdf.

* Do the tests still pass? N/A
* Does the code comply with the style guide? YES
* For Python changes: Have you added tests to cover the new/fixed behaviour? N/A
* For front-end changes: Did you test on all of Wagtail’s supported browsers? **Please list the exact versions you tested**. N/A
* For new features: Has the documentation been updated accordingly? N/A
