### PR TITLE
Fix issues in React explorer when there are many languages

### DIFF
--- a/client/src/api/admin.test.js
+++ b/client/src/api/admin.test.js
@@ -20,28 +20,28 @@ describe('admin API', () => {
   describe('getPageChildren', () => {
     it('works', () => {
       getPageChildren(3);
-      expect(client.get).toBeCalledWith(`${ADMIN_API.PAGES}?child_of=3&for_explorer=1&fields=parent,translations`);
+      expect(client.get).toBeCalledWith(`${ADMIN_API.PAGES}?child_of=3&for_explorer=1&fields=parent`);
     });
 
     it('#fields', () => {
       getPageChildren(3, { fields: ['title', 'latest_revision_created_at'] });
       // eslint-disable-next-line max-len
       expect(client.get).toBeCalledWith(
-        `${ADMIN_API.PAGES}?child_of=3&for_explorer=1&fields=parent,translations,title%2Clatest_revision_created_at`
+        `${ADMIN_API.PAGES}?child_of=3&for_explorer=1&fields=parent,title%2Clatest_revision_created_at`
       );
     });
 
     it('#onlyWithChildren', () => {
       getPageChildren(3, { onlyWithChildren: true });
       expect(client.get).toBeCalledWith(
-        `${ADMIN_API.PAGES}?child_of=3&for_explorer=1&fields=parent,translations&has_children=1`
+        `${ADMIN_API.PAGES}?child_of=3&for_explorer=1&fields=parent&has_children=1`
       );
     });
 
     it('#offset', () => {
       getPageChildren(3, { offset: 5 });
       expect(client.get).toBeCalledWith(
-        `${ADMIN_API.PAGES}?child_of=3&for_explorer=1&fields=parent,translations&offset=5`
+        `${ADMIN_API.PAGES}?child_of=3&for_explorer=1&fields=parent&offset=5`
       );
     });
   });

--- a/client/src/api/admin.ts
+++ b/client/src/api/admin.ts
@@ -68,6 +68,7 @@ export const getPageChildren: GetPageChildren = (id, options = {}) => {
 interface GetPageTranslationsOptions {
   fields?: string[];
   onlyWithChildren?: boolean;
+  offset?: number;
 }
 type GetPageTranslations = (id: number, options: GetPageTranslationsOptions) => Promise<WagtailPageListAPI>;
 export const getPageTranslations: GetPageTranslations = (id, options = {}) => {
@@ -83,5 +84,29 @@ export const getPageTranslations: GetPageTranslations = (id, options = {}) => {
     url += '&has_children=1';
   }
 
+  if (options.offset) {
+    url += `&offset=${options.offset}`;
+  }
+
   return get(url);
+};
+
+interface GetAllPageTranslationsOptions {
+  fields?: string[];
+  onlyWithChildren?: boolean;
+}
+
+export const getAllPageTranslations = async (id: number, options: GetAllPageTranslationsOptions) => {
+  const items: WagtailPageAPI[] = [];
+  let iterLimit = 100;
+
+  for (;;) {
+    const page = await getPageTranslations(id, { offset: items.length, ...options });
+
+    page.items.forEach(item => items.push(item));
+
+    if (items.length >= page.meta.total_count || iterLimit-- <= 0) {
+      return items;
+    }
+  }
 };

--- a/client/src/api/admin.ts
+++ b/client/src/api/admin.ts
@@ -47,9 +47,9 @@ export const getPageChildren: GetPageChildren = (id, options = {}) => {
   let url = `${ADMIN_API.PAGES}?child_of=${id}&for_explorer=1`;
 
   if (options.fields) {
-    url += `&fields=parent,translations,${window.encodeURIComponent(options.fields.join(','))}`;
+    url += `&fields=parent,${window.encodeURIComponent(options.fields.join(','))}`;
   } else {
-    url += '&fields=parent,translations';
+    url += '&fields=parent';
   }
 
   if (options.onlyWithChildren) {

--- a/client/src/components/Explorer/actions.ts
+++ b/client/src/components/Explorer/actions.ts
@@ -54,7 +54,7 @@ function getChildren(id: number, offset = 0): ThunkActionType {
 }
 
 const getTranslationsStart = createAction('GET_TRANSLATIONS_START', id => ({ id }));
-const getTranslationsSuccess = createAction('GET_TRANSLATIONS_SUCCESS', (id, items, meta) => ({ id, items, meta }));
+const getTranslationsSuccess = createAction('GET_TRANSLATIONS_SUCCESS', (id, items) => ({ id, items }));
 const getTranslationsFailure = createAction('GET_TRANSLATIONS_FAILURE', (id, error) => ({ id, error }));
 
 /**
@@ -64,8 +64,8 @@ function getTranslations(id) {
   return (dispatch) => {
     dispatch(getTranslationsStart(id));
 
-    return admin.getPageTranslations(id, { onlyWithChildren: true }).then(({ items, meta }) => {
-      dispatch(getTranslationsSuccess(id, items, meta));
+    return admin.getAllPageTranslations(id, { onlyWithChildren: true }).then(items => {
+      dispatch(getTranslationsSuccess(id, items));
     }, (error) => {
       dispatch(getTranslationsFailure(id, error));
     });


### PR DESCRIPTION
This PR fixes two bugs with the react explorer, both issues occur on sites using i18n and have many locales.

Requesting translations to be nested with each page causes major performance problems when there are many languages. Mozilla has 61 languages, each with a separate homepage that's a translation of the others, so the response for this query contains details of 61 * 61 pages.

This isn't actually required since we only need to know the translations if the user navigates into a page, and the translations are requested again anyway by the ``getPageTranslations`` function.

The other issue is that it wasn't fetching subsequent pages of translations for the translation picker.