### PR TITLE
Gracefully handle missing Locale records on Locale.get_active and .localized

### DIFF
--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -370,7 +370,7 @@ class Locale(models.Model):
         """
         try:
             return cls.objects.get_for_language(translation.get_language())
-        except cls.DoesNotExist:
+        except (cls.DoesNotExist, LookupError):
             return cls.get_default()
 
     def language_code_is_valid(self):
@@ -419,7 +419,10 @@ class TranslatableMixin(models.Model):
 
         If there is no translation in the active language, self is returned.
         """
-        locale = Locale.get_active()
+        try:
+            locale = Locale.get_active()
+        except (LookupError, Locale.DoesNotExist):
+            return self
 
         if locale.id == self.locale_id:
             return self
@@ -1209,7 +1212,10 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
         Note: This will return translations that are in draft. If you want to exclude
         these, use the ``.localized`` attribute.
         """
-        locale = Locale.get_active()
+        try:
+            locale = Locale.get_active()
+        except (LookupError, Locale.DoesNotExist):
+            return self
 
         if locale.id == self.locale_id:
             return self

--- a/wagtail/core/tests/test_page_model.py
+++ b/wagtail/core/tests/test_page_model.py
@@ -2776,3 +2776,28 @@ class TestLocalized(TestCase):
         with translation.override("fr"):
             self.assertEqual(self.event_page.localized, self.event_page)
             self.assertEqual(self.event_page.localized_draft, self.fr_event_page.page_ptr)
+
+    def test_localized_with_non_content_active_locale(self):
+        # if active locale does not have a Locale record, use default locale
+        with translation.override("de"):
+            self.assertEqual(self.event_page.localized, self.event_page)
+            self.assertEqual(self.fr_event_page.localized, self.event_page.specific)
+            self.assertEqual(self.event_page.localized_draft, self.event_page)
+            self.assertEqual(self.fr_event_page.localized_draft, self.event_page.specific)
+
+    def test_localized_with_missing_default_locale(self):
+        # if neither active locale nor default language code have a Locale record, return self
+
+        # Change the 'en' locale to 'pl', so that no locale record for LANGUAGE_CODE exists.
+        # This replicates a scenario where a site was originally built with LANGUAGE_CODE='pl'
+        # but subsequently changed to LANGUAGE_CODE='en' (a change which was not reflected in
+        # the database).
+        en_locale = Locale.objects.get(language_code="en")
+        en_locale.language_code = "pl"
+        en_locale.save()
+
+        with translation.override("de"):
+            self.assertEqual(self.event_page.localized, self.event_page)
+            self.assertEqual(self.fr_event_page.localized, self.fr_event_page)
+            self.assertEqual(self.event_page.localized_draft, self.event_page)
+            self.assertEqual(self.fr_event_page.localized_draft, self.fr_event_page)


### PR DESCRIPTION
Fixes #6540
There are various code paths where Page.localized and similar can be called even when WAGTAIL_I18N_ENABLED is False, and since it's entirely likely that hand-rolled i18n mechanisms and ad-hoc configuration changes (e.g changing LANGUAGE_CODE) will break the Locale model's assumptions about how things are meant to work, we need to provide sensible fallback behaviour for when the current active locale, or the default locale as per LANGUAGE_CODE, does not have a corresponding Locale record:

* Locale.get_active() will fall back on the default LANGUAGE_CODE locale, or raise Locale.DoesNotExist if that one does not exist either;
* TranslatableMixin.localized (along with Page.localized and Page.localized_draft) will handle a missing Locale record by falling back on the default LANGUAGE_CODE locale, or failing that, returning self.
