### PR TITLE
Fix header icon name in settings' edit view

### DIFF
--- a/wagtail/contrib/settings/templates/wagtailsettings/edit.html
+++ b/wagtail/contrib/settings/templates/wagtailsettings/edit.html
@@ -8,7 +8,7 @@
             <div class="left">
                 <div class="col">
                     <h1>
-                        {% icon name="icon-cogs" class_name="header-title-icon" %}
+                        {% icon name="cogs" class_name="header-title-icon" %}
                         {% trans "Editing" %}
                         <span>{{ setting_type_name|capfirst }}</span>
                     </h1>


### PR DESCRIPTION
This was introduced in 2.11 with 437e0a8ec931378b278e82156ba04f9fef17727a.