### PR TITLE
Change default WAGTAIL_REDIRECTS_FILE_STORAGE setting to cache

### DIFF
--- a/docs/reference/settings.rst
+++ b/docs/reference/settings.rst
@@ -655,13 +655,13 @@ Redirects
 
 .. code-block:: python
 
-   WAGTAIL_REDIRECTS_FILE_STORAGE = 'tmp_file'
+   WAGTAIL_REDIRECTS_FILE_STORAGE = 'cache'
 
-By default the redirect importer keeps track of the uploaded file as a temp file, but on certain environments (load balanced/cloud environments), you cannot keep a shared file between environments. For those cases you can use the built-in cache to store the file instead.
+By default the redirect importer keeps track of the uploaded file by storing it in the built-in cache. It's less effective then handling the upload as a actual file, but lets us support load balanced environment out of the box. If you are on a single server environment you can use the more effective tmp_file method instead.
 
 .. code-block:: python
 
-   WAGTAIL_REDIRECTS_FILE_STORAGE = 'cache'
+   WAGTAIL_REDIRECTS_FILE_STORAGE = 'tmp_file'
 
 Form builder
 ============

--- a/wagtail/contrib/redirects/utils.py
+++ b/wagtail/contrib/redirects/utils.py
@@ -38,15 +38,15 @@ def get_import_formats():
 
 def get_file_storage():
     file_storage = getattr(
-        settings, 'WAGTAIL_REDIRECTS_FILE_STORAGE', 'tmp_file'
+        settings, 'WAGTAIL_REDIRECTS_FILE_STORAGE', 'cache'
     )
-    if file_storage == 'tmp_file':
-        return TempFolderStorage
     if file_storage == 'cache':
         return RedirectsCacheStorage
+    if file_storage == 'tmp_file':
+        return TempFolderStorage
 
     raise Exception(
-        "Invalid file storage, must be either 'tmp_file' or 'cache'"
+        "Invalid file storage, must be either 'cache' or 'tmp_file'"
     )
 
 


### PR DESCRIPTION
Hi! 

This PR comes from a discussion I had with @kaedroho and @pySilver on how the redirect import treats the uploaded file. 

How it works: To enable a preview of the redirects before import we need to keep the file around after initial upload, there are two methods, as a temporary file or in the builtin cache. The default method is as a temporary file. The temporary file is more effective but does not always work on load balanced environments (such as Heroku).

So in this PR I'm suggesting that we change the default method from using a temporary file to using the builtin cache. This will guarantee that the feature works out of the box on all environments.

The change is minimal. Feedback are much appreciated, cheers!