### PR TITLE
Check if menu_item is not None

### DIFF
--- a/wagtail/admin/action_menu.py
+++ b/wagtail/admin/action_menu.py
@@ -289,7 +289,9 @@ def _get_base_page_action_menu_items():
             PageLockedMenuItem(order=10000),
         ]
         for hook in hooks.get_hooks('register_page_action_menu_item'):
-            BASE_PAGE_ACTION_MENU_ITEMS.append(hook())
+            action_menu_item = hook()
+            if action_menu_item:
+                BASE_PAGE_ACTION_MENU_ITEMS.append(action_menu_item)
 
     return BASE_PAGE_ACTION_MENU_ITEMS
 

--- a/wagtail/snippets/action_menu.py
+++ b/wagtail/snippets/action_menu.py
@@ -119,7 +119,7 @@ class SnippetActionMenu:
         self.menu_items.extend([
             menu_item
             for menu_item in get_base_snippet_action_menu_items(self.context['model'])
-            if menu_item.is_shown(self.request, self.context)
+            if menu_item and menu_item.is_shown(self.request, self.context)
         ])
 
         self.menu_items.sort(key=lambda item: item.order)

--- a/wagtail/snippets/action_menu.py
+++ b/wagtail/snippets/action_menu.py
@@ -100,7 +100,9 @@ def get_base_snippet_action_menu_items(model):
     ]
 
     for hook in hooks.get_hooks('register_snippet_action_menu_item'):
-        menu_items.append(hook(model))
+        action_menu_item = hook(model)
+        if action_menu_item:
+            menu_items.append(action_menu_item)
 
     return menu_items
 
@@ -119,7 +121,7 @@ class SnippetActionMenu:
         self.menu_items.extend([
             menu_item
             for menu_item in get_base_snippet_action_menu_items(self.context['model'])
-            if menu_item and menu_item.is_shown(self.request, self.context)
+            if menu_item.is_shown(self.request, self.context)
         ])
 
         self.menu_items.sort(key=lambda item: item.order)

--- a/wagtail/snippets/tests.py
+++ b/wagtail/snippets/tests.py
@@ -429,6 +429,18 @@ class TestSnippetCreateView(TestCase, WagtailTestUtils):
 
         self.assertContains(response, '<button type="submit" name="test" value="Test" class="button action-secondary"><svg class="icon icon-undo icon" aria-hidden="true" focusable="false"><use href="#icon-undo"></use></svg>Test</button>', html=True)
 
+    def test_register_snippet_action_menu_item_as_none(self):
+        def hook_func(model):
+            return None
+
+        with self.register_hook('register_snippet_action_menu_item', hook_func):
+            get_base_snippet_action_menu_items.cache_clear()
+
+            response = self.get()
+
+        get_base_snippet_action_menu_items.cache_clear()
+        self.assertEqual(response.status_code, 200)
+
     def test_construct_snippet_action_menu(self):
         class TestSnippetActionMenuItem(ActionMenuItem):
             label = "Test"

--- a/wagtail/tests/testapp/wagtail_hooks.py
+++ b/wagtail/tests/testapp/wagtail_hooks.py
@@ -137,6 +137,11 @@ def register_panic_menu_item():
     return PanicMenuItem()
 
 
+@hooks.register('register_page_action_menu_item')
+def register_none_menu_item():
+    return None
+
+
 class RelaxMenuItem(ActionMenuItem):
     label = "Relax."
     name = 'action-relax'


### PR DESCRIPTION
For some reason when viewing Snippets in the latest Wagtail version I'm getting this error message -
![image](https://user-images.githubusercontent.com/26556210/99738400-0e38c680-2ad3-11eb-9bc4-ca07eb75aaf7.png)

I'm not sure what caused this, maybe that I used a new localization feature in the project (not on this snippet though), maybe this is the problem.

To resolve this I made a simple checkup in the **wagtail/snippets/action_menu.py** that prevents calling the **is_shown** method on the None variables.

Please, let me know if you have any questions.

BR,
Vadim.