### PR TITLE
Support calling get_image_model and get_document_model at import time

### DIFF
--- a/wagtail/documents/__init__.py
+++ b/wagtail/documents/__init__.py
@@ -23,7 +23,7 @@ def get_document_model():
     from django.apps import apps
     model_string = get_document_model_string()
     try:
-        return apps.get_model(model_string)
+        return apps.get_model(model_string, require_ready=False)
     except ValueError:
         raise ImproperlyConfigured("WAGTAILDOCS_DOCUMENT_MODEL must be of the form 'app_label.model_name'")
     except LookupError:

--- a/wagtail/documents/tests/test_models.py
+++ b/wagtail/documents/tests/test_models.py
@@ -9,7 +9,7 @@ from django.test.utils import override_settings
 from wagtail.core.models import Collection, GroupCollectionPermission
 from wagtail.documents import get_document_model, get_document_model_string, models, signal_handlers
 from wagtail.images.tests.utils import get_test_image_file
-from wagtail.tests.testapp.models import CustomDocument
+from wagtail.tests.testapp.models import CustomDocument, ReimportedDocumentModel
 from wagtail.tests.utils import WagtailTestUtils
 
 
@@ -231,6 +231,9 @@ class TestGetDocumentModel(WagtailTestUtils, TestCase):
     def test_custom_get_document_model(self):
         """Test get_document_model with a custom document model"""
         self.assertIs(get_document_model(), CustomDocument)
+
+    def test_get_document_model_at_import_time(self):
+        self.assertEqual(ReimportedDocumentModel, models.Document)
 
     @override_settings(WAGTAILDOCS_DOCUMENT_MODEL='tests.CustomDocument')
     def test_custom_get_document_model_string(self):

--- a/wagtail/images/__init__.py
+++ b/wagtail/images/__init__.py
@@ -24,7 +24,7 @@ def get_image_model():
     from django.apps import apps
     model_string = get_image_model_string()
     try:
-        return apps.get_model(model_string)
+        return apps.get_model(model_string, require_ready=False)
     except ValueError:
         raise ImproperlyConfigured("WAGTAILIMAGES_IMAGE_MODEL must be of the form 'app_label.model_name'")
     except LookupError:

--- a/wagtail/images/tests/test_models.py
+++ b/wagtail/images/tests/test_models.py
@@ -12,7 +12,7 @@ from willow.image import Image as WillowImage
 from wagtail.core.models import Collection, GroupCollectionPermission, Page
 from wagtail.images.models import Rendition, SourceImageIOError
 from wagtail.images.rect import Rect
-from wagtail.tests.testapp.models import EventPage, EventPageCarouselItem
+from wagtail.tests.testapp.models import EventPage, EventPageCarouselItem, ReimportedImageModel
 from wagtail.tests.utils import WagtailTestUtils
 
 from .utils import Image, get_test_image_file
@@ -25,6 +25,9 @@ class TestImage(TestCase):
             title="Test image",
             file=get_test_image_file(colour='white'),
         )
+
+    def test_get_image_model_at_import_time(self):
+        self.assertEqual(ReimportedImageModel, Image)
 
     def test_is_portrait(self):
         self.assertFalse(self.image.is_portrait())

--- a/wagtail/tests/testapp/models.py
+++ b/wagtail/tests/testapp/models.py
@@ -34,8 +34,10 @@ from wagtail.contrib.table_block.blocks import TableBlock
 from wagtail.core.blocks import CharBlock, RawHTMLBlock, RichTextBlock, StreamBlock, StructBlock
 from wagtail.core.fields import RichTextField, StreamField
 from wagtail.core.models import Orderable, Page, PageManager, PageQuerySet, Task, TranslatableMixin
+from wagtail.documents import get_document_model
 from wagtail.documents.edit_handlers import DocumentChooserPanel
 from wagtail.documents.models import AbstractDocument, Document
+from wagtail.images import get_image_model
 from wagtail.images.blocks import ImageChooserBlock
 from wagtail.images.edit_handlers import ImageChooserPanel
 from wagtail.images.models import AbstractImage, AbstractRendition, Image
@@ -1510,3 +1512,9 @@ class TaggedRestaurant(ItemBase):
 
 class SimpleTask(Task):
     pass
+
+
+# Check that get_image_model and get_document_model work at import time
+# (so that it's possible to use them in foreign key definitions, for example)
+ReimportedImageModel = get_image_model()
+ReimportedDocumentModel = get_document_model()


### PR DESCRIPTION
Attempting to call get_image_model or get_document_model at the top level of a models.py file currently fails with "Models aren't loaded yet". This can be avoided by passing `require_ready=False` to apps.get_model.

This change makes it possible for third-party apps to define abstract models with foreign key references to the possibly-custom image or document model (which can then be subclassed into concrete models in the project itself - defining concrete models in the third-party app probably still isn't safe, as the model will end up being baked into the third-party app's migrations).
