### PR TITLE
Allows to mark the language names as translation strings

### DIFF
--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -400,7 +400,7 @@ class Locale(models.Model):
         return get_content_languages().get(self.language_code)
 
     def __str__(self):
-        return self.get_display_name() or self.language_code
+        return force_str(self.get_display_name() or self.language_code)
 
 
 class TranslatableMixin(models.Model):

--- a/wagtail/core/tests/test_locale_model.py
+++ b/wagtail/core/tests/test_locale_model.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 from django.test import TestCase, override_settings
 from django.utils import translation
+from django.utils.translation import gettext_lazy as _
 
 from wagtail.core.models import Locale, Page
 from wagtail.tests.i18n.models import TestPage
@@ -52,3 +53,8 @@ class TestLocaleModel(TestCase):
         # This language is not in LANGUAGES so it should just return the language code
         locale = Locale.objects.create(language_code="foo")
         self.assertEqual(str(locale), "foo")
+
+    @override_settings(LANGUAGES=[("en", _("English")), ("fr", _("French"))])
+    def test_str_when_languages_uses_gettext(self):
+        locale = Locale.objects.get(language_code="en")
+        self.assertIsInstance(locale.__str__(), str)

--- a/wagtail/core/tests/test_utils.py
+++ b/wagtail/core/tests/test_utils.py
@@ -3,6 +3,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.test import TestCase, override_settings
 from django.utils.text import slugify
 from django.utils.translation import _trans
+from django.utils.translation import gettext_lazy as _
 
 from wagtail.core.models import Page
 from wagtail.core.utils import (
@@ -182,6 +183,18 @@ class TestGetContentLanguages(TestCase):
         ],
     )
     def test_can_be_different_to_django_languages(self):
+        self.assertEqual(get_content_languages(), {
+            'de': 'German',
+            'en': 'English',
+        })
+
+    @override_settings(
+        WAGTAIL_CONTENT_LANGUAGES=[
+            ('en', _('English')),
+            ('de', _('German')),
+        ],
+    )
+    def test_can_be_a_translation_proxy(self):
         self.assertEqual(get_content_languages(), {
             'de': 'German',
             'en': 'English',

--- a/wagtail/tests/settings.py
+++ b/wagtail/tests/settings.py
@@ -227,10 +227,11 @@ WAGTAILADMIN_RICH_TEXT_EDITORS = {
     },
 }
 
+from django.utils.translation import gettext_lazy as _
 
 WAGTAIL_CONTENT_LANGUAGES = [
-    ("en", "English"),
-    ("fr", "French"),
+    ("en", _("English")),
+    ("fr", _("French")),
 ]
 
 

--- a/wagtail/tests/settings.py
+++ b/wagtail/tests/settings.py
@@ -1,5 +1,7 @@
 import os
+
 from django.utils.translation import gettext_lazy as _
+
 
 DEBUG = False
 WAGTAIL_ROOT = os.path.dirname(os.path.dirname(__file__))

--- a/wagtail/tests/settings.py
+++ b/wagtail/tests/settings.py
@@ -1,5 +1,5 @@
 import os
-
+from django.utils.translation import gettext_lazy as _
 
 DEBUG = False
 WAGTAIL_ROOT = os.path.dirname(os.path.dirname(__file__))
@@ -226,8 +226,6 @@ WAGTAILADMIN_RICH_TEXT_EDITORS = {
         'WIDGET': 'wagtail.tests.testapp.rich_text.CustomRichTextArea'
     },
 }
-
-from django.utils.translation import gettext_lazy as _
 
 WAGTAIL_CONTENT_LANGUAGES = [
     ("en", _("English")),


### PR DESCRIPTION
This is a solution for #6571 .