### PR TITLE
Update pagination icons to use SVGs

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,6 +5,7 @@ Changelog
 ~~~~~~~~~~~~~~~~~
 
  * Added support for Python 3.9
+ * Switch pagination icons to use SVG instead of icon fonts (Scott Cranfill)
  * Fix: Stop menu icon overlapping the breadcrumb on small viewport widths in page editor (Karran Besen)
  * Fix: Make sure document chooser pagination preserves the selected collection when moving between pages (Alex Sa)
 

--- a/docs/releases/2.12.rst
+++ b/docs/releases/2.12.rst
@@ -15,6 +15,7 @@ Other features
 ~~~~~~~~~~~~~~
 
  * Added support for Python 3.9
+ * Switch pagination icons to use SVG instead of icon fonts (Scott Cranfill)
 
 
 Bug fixes

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_pagination.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_pagination.html
@@ -11,12 +11,18 @@ Pagination for page listings. Used by the `{% paginate %}` template tag.
     <ul>
         <li class="prev">
             {% if page.has_previous %}
-                <a data-page="{{ page.previous_page_number }}" href="{{ base_url }}{% pagination_querystring page.previous_page_number page_key=page_key %}" class="icon icon-arrow-left {{ classnames }}">{% trans "Previous" %}</a>
+                <a data-page="{{ page.previous_page_number }}" href="{{ base_url }}{% pagination_querystring page.previous_page_number page_key=page_key %}" class="{{ classnames }}">
+                    {% icon name="arrow-left" class_name="default" %}
+                    {% trans "Previous" %}
+                </a>
             {% endif %}
         </li>
         <li class="next">
             {% if page.has_next %}
-                <a data-page="{{ page.next_page_number }}" href="{{ base_url }}{% pagination_querystring page.next_page_number page_key=page_key %}" class="icon icon-arrow-right-after {{ classnames }}">{% trans "Next" %}</a>
+                <a data-page="{{ page.next_page_number }}" href="{{ base_url }}{% pagination_querystring page.next_page_number page_key=page_key %}" class="{{ classnames }}">
+                    {% trans "Next" %}
+                    {% icon name="arrow-right" class_name="default" %}
+                </a>
             {% endif %}
         </li>
     </ul>

--- a/wagtail/admin/templates/wagtailadmin/shared/ajax_pagination_nav.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/ajax_pagination_nav.html
@@ -6,12 +6,18 @@
     <ul>
         <li class="prev">
             {% if items.has_previous %}
-                <a href="#" data-page="{{ items.previous_page_number }}" class="icon icon-arrow-left">{% trans 'Previous' %}</a>
+                <a href="#" data-page="{{ items.previous_page_number }}">
+                    {% icon name="arrow-left" class_name="default" %}
+                    {% trans 'Previous' %}
+                </a>
             {% endif %}
         </li>
         <li class="next">
             {% if items.has_next %}
-                <a href="#" data-page="{{ items.next_page_number }}" class="icon icon-arrow-right-after">{% trans 'Next' %}</a>
+                <a href="#" data-page="{{ items.next_page_number }}">
+                    {% trans 'Next' %}
+                    {% icon name="arrow-right" class_name="default" %}
+                </a>
             {% endif %}
         </li>
     </ul>

--- a/wagtail/admin/templates/wagtailadmin/shared/pagination_nav.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/pagination_nav.html
@@ -18,12 +18,18 @@
     <ul>
         <li class="prev">
             {% if items.has_previous %}
-                <a href="{{ url_to_use }}{% querystring p=items.previous_page_number %}" class="icon icon-arrow-left">{% trans 'Previous' %}</a>
+                <a href="{{ url_to_use }}{% querystring p=items.previous_page_number %}">
+                    {% icon name="arrow-left" class_name="default" %}
+                    {% trans 'Previous' %}
+                </a>
             {% endif %}
         </li>
         <li class="next">
             {% if items.has_next %}
-                <a href="{{ url_to_use }}{% querystring p=items.next_page_number %}" class="icon icon-arrow-right-after">{% trans 'Next' %}</a>
+                <a href="{{ url_to_use }}{% querystring p=items.next_page_number %}">
+                    {% trans 'Next' %}
+                    {% icon name="arrow-right" class_name="default" %}
+                </a>
             {% endif %}
         </li>
     </ul>

--- a/wagtail/contrib/modeladmin/templatetags/modeladmin_tags.py
+++ b/wagtail/contrib/modeladmin/templatetags/modeladmin_tags.py
@@ -101,11 +101,13 @@ def result_list(context):
 def pagination_link_previous(current_page, view):
     if current_page.has_previous():
         previous_page_number0 = current_page.previous_page_number() - 1
+        tpl = get_template('wagtailadmin/shared/icon.html')
+        icon_svg = tpl.render({'name': 'arrow-left', 'class_name': 'default'})
         return format_html(
-            '<li class="prev"><a href="%s" class="icon icon-arrow-left">%s'
-            '</a></li>' %
-            (view.get_query_string({view.PAGE_VAR: previous_page_number0}),
-                _('Previous'))
+            '<li class="prev"><a href="{}">{} {}</a></li>',
+            view.get_query_string({view.PAGE_VAR: previous_page_number0}),
+            icon_svg,
+            _('Previous')
         )
     return ''
 
@@ -114,11 +116,13 @@ def pagination_link_previous(current_page, view):
 def pagination_link_next(current_page, view):
     if current_page.has_next():
         next_page_number0 = current_page.next_page_number() - 1
+        tpl = get_template('wagtailadmin/shared/icon.html')
+        icon_svg = tpl.render({'name': 'arrow-right', 'class_name': 'default'})
         return format_html(
-            '<li class="next"><a href="%s" class="icon icon-arrow-right-after"'
-            '>%s</a></li>' %
-            (view.get_query_string({view.PAGE_VAR: next_page_number0}),
-                _('Next'))
+            '<li class="next"><a href="{}">{} {}</a></li>',
+            view.get_query_string({view.PAGE_VAR: next_page_number0}),
+            _('Next'),
+            icon_svg
         )
     return ''
 


### PR DESCRIPTION
Updates pagination left and right arrow icons to use SVG icons.

I couldn't figure out how to invoke the `icon` template inclusion tag from inside the `pagination_link_previous` and `pagination_link_next` tags defined in `modeladmin_tags.py`, so I settled for just rendering the `icon.html` template into a variable. Definitely open to hearing better ideas on this!

The other mild concern I had was the fact that there are three templates that create very very similar pagination code. I didn't have time to fully digest the differences, but I see in the release notes for 2.5 that it was definitely a conscious decision to split out `ajax_pagination_nav` from `pagination_nav`. What I'm really not sure about is why `_pagination` and `pagination_nav` both exist. The main difference appears to be how the URLs for the pagination links are constructed, but I'm not sure why they are different or if they _need_ to be. @gasman, looks like you're the primary contributor to both files. Would you have any insight into that?

---

Thanks for contributing to Wagtail! 🎉

Before submitting, please review the contributor guidelines <https://docs.wagtail.io/en/latest/contributing/index.html> and check the following:

- [x] Do the tests still pass? (https://docs.wagtail.io/en/latest/contributing/developing.html#testing)
  - There's a failing Draftail Jest snapshot, but I don't believe that would have anything to do with what I've done here
- [x] Does the code comply with the style guide? (Run `make lint` from the Wagtail root)
- For Python changes: Have you added tests to cover the new/fixed behaviour?
  - N/A
- For front-end changes: Did you test on all of Wagtail’s supported browsers? **Please list the exact versions you tested**.
  - No, but should work the same as other SVG icon changes
- For new features: Has the documentation been updated accordingly?
  - N/A
