### PR TITLE
Fix Bonsai link in Elasticsearch docs

### DIFF
--- a/docs/topics/search/backends.rst
+++ b/docs/topics/search/backends.rst
@@ -180,7 +180,7 @@ If you prefer not to run an Elasticsearch server in development or production, t
 -  Run ``./manage.py update_index``
 
 .. _elasticsearch-py: https://elasticsearch-py.readthedocs.org
-.. _Bonsai: https://bonsai.io/signup
+.. _Bonsai: https://bonsai.io/
 
 Amazon AWS Elasticsearch
 ~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
The [search docs](https://docs.wagtail.io/en/v2.11.2/topics/search/backends.html) currently link to [a Bonsai signup page that 404s](https://bonsai.io/signup). The signup page is currently [a different page](https://app.bonsai.io/signup).

This PR replaces the Bonsai link with [their homepage](https://bonsai.io/), to avoid being overly dependent on their URL structure.