### PR TITLE
Improve test database settings to fix SQLite error when creating migrations

### DIFF
--- a/docs/contributing/developing.rst
+++ b/docs/contributing/developing.rst
@@ -106,6 +106,10 @@ You can create migrations for the test app by running the following from the Wag
 Testing against PostgreSQL
 --------------------------
 
+.. note::
+
+   In order to run these tests, you must install the required modules for PostgreSQL as described in Django's `Databases documentation`_.
+
 By default, Wagtail tests against SQLite. You can switch to using PostgreSQL by
 using the ``--postgres`` argument:
 
@@ -113,10 +117,14 @@ using the ``--postgres`` argument:
 
     $ python runtests.py --postgres
 
-If you need to use a different user, password or host. Use the ``PGUSER``, ``PGPASSWORD`` and ``PGHOST`` environment variables.
+If you need to use a different user, password, host or port, use the ``PGUSER``, ``PGPASSWORD``, ``PGHOST`` and ``PGPORT`` environment variables respectively.
 
 Testing against a different database
 ------------------------------------
+
+.. note::
+
+   In order to run these tests, you must install the required client libraries and modules for the given database as described in Django's `Databases`_ documentation or 3rd-party database backend's documentation.
 
 If you need to test against a different database, set the ``DATABASE_ENGINE``
 environment variable to the name of the Django database backend to test against:
@@ -127,6 +135,15 @@ environment variable to the name of the Django database backend to test against:
 
 This will create a new database called ``test_wagtail`` in MySQL and run
 the tests against it.
+
+If you need to use different connection settings, use the following environment variables which correspond to the respective keys within Django's `DATABASES`_ settings dictionary:
+
+* ``DATABASE_ENGINE``
+* ``DATABASE_NAME``
+* ``DATABASE_PASSWORD``
+* ``DATABASE_HOST``
+  * Note that for MySQL, this must be `127.0.0.1` rather than `localhost` if you need to connect using a TCP socket
+* ``DATABASE_PORT``
 
 Testing Elasticsearch
 ---------------------
@@ -272,3 +289,5 @@ To do this, you can run the following command to see the changes automatically a
     $ make livehtml
 
 
+.. _Databases documentation: https://docs.djangoproject.com/en/stable/ref/databases/
+.. _DATABASES: https://docs.djangoproject.com/en/stable/ref/settings/#databases

--- a/tox.ini
+++ b/tox.ini
@@ -55,7 +55,7 @@ setenv =
     mssql: DATABASE_HOST=(local)\SQL2016
     mssql: DATABASE_NAME=master
     mssql: DATABASE_USER=sa
-    mssql: DATABASE_PASS=Password12!
+    mssql: DATABASE_PASSWORD=Password12!
 
 [testenv:flake8]
 basepython=python3.6

--- a/wagtail/tests/settings.py
+++ b/wagtail/tests/settings.py
@@ -12,16 +12,21 @@ TIME_ZONE = 'Asia/Tokyo'
 DATABASES = {
     'default': {
         'ENGINE': os.environ.get('DATABASE_ENGINE', 'django.db.backends.sqlite3'),
-        'NAME': os.environ.get('DATABASE_NAME', 'wagtail'),
-        'USER': os.environ.get('DATABASE_USER', None),
-        'PASSWORD': os.environ.get('DATABASE_PASS', None),
-        'HOST': os.environ.get('DATABASE_HOST', None),
+        'NAME': os.environ.get('DATABASE_NAME', ':memory:'),
+        'USER': os.environ.get('DATABASE_USER', ''),
+        'PASSWORD': os.environ.get('DATABASE_PASSWORD', ''),
+        'HOST': os.environ.get('DATABASE_HOST', ''),
+        'PORT': os.environ.get('DATABASE_PORT', ''),
 
         'TEST': {
-            'NAME': os.environ.get('DATABASE_NAME', None),
+            'NAME': os.environ.get('DATABASE_NAME', '')
         }
     }
 }
+
+# Set regular database name when a non-SQLite db is used
+if DATABASES['default']['ENGINE'] != 'django.db.backends.sqlite3':
+    DATABASES['default']['NAME'] = os.environ.get('DATABASE_NAME', 'wagtail')
 
 # Add extra options when mssql is used (on for example appveyor)
 if DATABASES['default']['ENGINE'] == 'sql_server.pyodbc':


### PR DESCRIPTION
This change makes several improvements:

* Use in-memory SQLite database for test migrations

  The default database is SQLite but its `NAME` (which SQLite uses as the filename) was `wagtail`, which isn't valid since the wagtail codebase already has a `wagtail/` directory.  Trying to run migration creation commands (https://docs.wagtail.io/en/latest/contributing/developing.html#running-migrations-for-the-test-app-models) produced an error:

  ```
  Traceback (most recent call last):
    File "wagtail/lib/python3.9/site-packages/django/db/backends/base/base.py", line 219, in ensure_connection
      self.connect()
    File "wagtail/lib/python3.9/site-packages/django/utils/asyncio.py", line 26, in inner
      return func(*args, **kwargs)
    File "wagtail/lib/python3.9/site-packages/django/db/backends/base/base.py", line 200, in connect
      self.connection = self.get_new_connection(conn_params)
    File "wagtail/lib/python3.9/site-packages/django/utils/asyncio.py", line 26, in inner
      return func(*args, **kwargs)
    File "wagtail/lib/python3.9/site-packages/django/db/backends/sqlite3/base.py", line 207, in get_new_connection
      conn = Database.connect(**conn_params)
  sqlite3.OperationalError: unable to open database file
  ```

  because of this conflict. (This traceback also causes a subsequent error `django.db.utils.OperationalError: unable to open database file`)

  This change uses `:memory` as the default database filename if SQLite is used, thereby fixing the above issue and avoiding a potential for an empty SQLite database file to be created (if DATABASE_NAME was the path to a real file; as it was in the first version of this PR).

  Other non-SQLite engines continue to use the original `wagtail` name, meaning that the `test_wagtail` database gets created just as before.

* Modifies the default values for database USER, PASSWORD, HOST etc to being an empty string rather than None, to match Django's [defaults](https://docs.djangoproject.com/en/stable/ref/settings/#host).  This helps avoid any potential issues as some parts of Django rely on certain values being a string (e.g. NAME where `test_` gets appended).

* Adds documentation to `developing.rst` regarding installation of required database modules and available environment variables for database connection customisation (`PGPORT`, `DATABASE_*` etc)

* Normalises the `DATABASE_PASSWORD` tests environment variable to match the name in Django's database settings object


----

Thanks for contributing to Wagtail! 🎉

Before submitting, please review the contributor guidelines <https://docs.wagtail.io/en/latest/contributing/index.html> and check the following:

* [x] Do the tests still pass? (https://docs.wagtail.io/en/latest/contributing/developing.html#testing)
* [x] Does the code comply with the style guide? (Run `make lint` from the Wagtail root)
* [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
* [ ] For front-end changes: Did you test on all of Wagtail’s supported browsers? **Please list the exact versions you tested**.
* [x] For new features: Has the documentation been updated accordingly?
