### PR TITLE
Let modeladmin customize field display if needed

### DIFF
--- a/wagtail/contrib/modeladmin/options.py
+++ b/wagtail/contrib/modeladmin/options.py
@@ -3,7 +3,7 @@ from django.contrib.admin.utils import display_for_field
 from django.contrib.auth.models import Permission
 from django.core import checks
 from django.core.exceptions import ImproperlyConfigured
-from django.db.models import Model
+from django.db.models import Model, ManyToOneRel
 from django.urls import re_path
 from django.utils.safestring import mark_safe
 
@@ -218,11 +218,16 @@ class ModelAdmin(WagtailRegisterable):
         """
         return mark_safe(self.empty_value_display)
 
-    def get_display_for_field(self, value, field, empty_value_display):
+    def get_display_for_field(self, instance, value, field, empty_value_display):
         """
         Returns the field display value. Override this to
         customize the field display for a specific model admin.
         """
+        if isinstance(field, ManyToOneRel):
+            field_val = getattr(instance, field.name)
+            if field_val is None:
+                return empty_value_display
+            return field_val
         return display_for_field(value, field, empty_value_display)
 
     def get_list_filter(self, request):

--- a/wagtail/contrib/modeladmin/options.py
+++ b/wagtail/contrib/modeladmin/options.py
@@ -3,7 +3,7 @@ from django.contrib.admin.utils import display_for_field
 from django.contrib.auth.models import Permission
 from django.core import checks
 from django.core.exceptions import ImproperlyConfigured
-from django.db.models import Model, ManyToOneRel
+from django.db.models import ManyToOneRel, Model
 from django.urls import re_path
 from django.utils.safestring import mark_safe
 

--- a/wagtail/contrib/modeladmin/options.py
+++ b/wagtail/contrib/modeladmin/options.py
@@ -1,4 +1,5 @@
 from django.contrib.admin import site as default_django_admin_site
+from django.contrib.admin.utils import display_for_field
 from django.contrib.auth.models import Permission
 from django.core import checks
 from django.core.exceptions import ImproperlyConfigured
@@ -216,6 +217,13 @@ class ModelAdmin(WagtailRegisterable):
         Return the empty_value_display value defined on ModelAdmin
         """
         return mark_safe(self.empty_value_display)
+
+    def get_display_for_field(self, value, field, empty_value_display):
+        """
+        Returns the field display value. Override this to
+        customize the field display for a specific model admin.
+        """
+        return display_for_field(value, field, empty_value_display)
 
     def get_list_filter(self, request):
         """

--- a/wagtail/contrib/modeladmin/options.py
+++ b/wagtail/contrib/modeladmin/options.py
@@ -218,13 +218,13 @@ class ModelAdmin(WagtailRegisterable):
         """
         return mark_safe(self.empty_value_display)
 
-    def get_display_for_field(self, instance, value, field, empty_value_display):
+    def get_display_for_field(self, obj, value, field, empty_value_display):
         """
         Returns the field display value. Override this to
         customize the field display for a specific model admin.
         """
         if isinstance(field, ManyToOneRel):
-            field_val = getattr(instance, field.name)
+            field_val = getattr(obj, field.name)
             if field_val is None:
                 return empty_value_display
             return field_val

--- a/wagtail/contrib/modeladmin/templatetags/modeladmin_tags.py
+++ b/wagtail/contrib/modeladmin/templatetags/modeladmin_tags.py
@@ -47,15 +47,8 @@ def items_for_result(view, result):
                 if isinstance(value, (datetime.date, datetime.time)):
                     row_classes.append('nowrap')
             else:
-                if isinstance(f, models.ManyToOneRel):
-                    field_val = getattr(result, f.name)
-                    if field_val is None:
-                        result_repr = empty_value_display
-                    else:
-                        result_repr = field_val
-                else:
-                    result_repr = modeladmin.get_display_for_field(
-                        value, f, empty_value_display)
+                result_repr = modeladmin.get_display_for_field(
+                    result, value, f, empty_value_display)
 
                 if isinstance(f, (
                     models.DateField, models.TimeField, models.ForeignKey)

--- a/wagtail/contrib/modeladmin/templatetags/modeladmin_tags.py
+++ b/wagtail/contrib/modeladmin/templatetags/modeladmin_tags.py
@@ -2,7 +2,7 @@ import datetime
 import json
 
 from django.contrib.admin.templatetags.admin_list import ResultList, result_headers
-from django.contrib.admin.utils import display_for_field, display_for_value, lookup_field
+from django.contrib.admin.utils import display_for_value, lookup_field
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import models
 from django.forms.utils import flatatt
@@ -54,7 +54,7 @@ def items_for_result(view, result):
                     else:
                         result_repr = field_val
                 else:
-                    result_repr = display_for_field(
+                    result_repr = modeladmin.get_display_for_field(
                         value, f, empty_value_display)
 
                 if isinstance(f, (


### PR DESCRIPTION
This lets each `modeladmin` customize the display value for specific fields if needed.

The primary motivation for this is so the display can be customized __without__ breaking sorting since using a method on the model admin disables the sorting link.

```python

    def get_display_for_field(self, obj, value, field, empty_value_display):
        if field.name == "due_date":
            return naturaltime(value)
        return super().get_display_for_field(obj, value, field, empty_value_display)
```

it also makes it easier to customize certain values, eg 

```python
    def get_display_for_field(self, obj, value, field, empty_value_display):
        if isinstance(value, Image):
            return get_image_thumbnail(value)
        return super().get_display_for_field(obj, value, field, empty_value_display)

```