### PR TITLE
Changes repr method of Phrase to label the object Phrase instead of PlainText

### DIFF
--- a/wagtail/search/query.py
+++ b/wagtail/search/query.py
@@ -45,7 +45,7 @@ class Phrase(SearchQuery):
         self.query_string = query_string
 
     def __repr__(self):
-        return '<PlainText {}>'.format(repr(self.query_string))
+        return '<Phrase {}>'.format(repr(self.query_string))
 
 
 class MatchAll(SearchQuery):


### PR DESCRIPTION
Fixes an error in the repr method of Phrase
