### PR TITLE
fix: breadcrumb margin overlapping burger menu

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,6 +5,7 @@ Changelog
 ~~~~~~~~~~~~~~~~~
 
  * Added support for Python 3.9
+ * Fix: Stop menu icon overlapping the breadcrumb on small viewport widths in page editor (Karran Besen)
 
 
 2.11.2 (17.11.2020)

--- a/docs/releases/2.12.rst
+++ b/docs/releases/2.12.rst
@@ -20,7 +20,7 @@ Other features
 Bug fixes
 ~~~~~~~~~
 
- * ...
+ * Stop menu icon overlapping the breadcrumb on small viewport widths in page editor (Karran Besen)
 
 
 Upgrade considerations

--- a/wagtail/admin/static_src/wagtailadmin/scss/layouts/page-editor.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/layouts/page-editor.scss
@@ -7,12 +7,12 @@
 
     .breadcrumb {
         margin: -1.2em 0 2em;  // sass linter complains about $desktop-nice-padding here because of unit mismatch
-        margin-left: -$desktop-nice-padding;
-        margin-right: -$desktop-nice-padding;
         padding-left: calc(#{$desktop-nice-padding} - 2em);
 
         @include media-breakpoint-up(sm) {
             margin-top: -1.8em;
+            margin-left: -$desktop-nice-padding;
+            margin-right: -$desktop-nice-padding;
         }
     }
 


### PR DESCRIPTION
This PR is supposed to fix #6590.

I tested it on firefox and chrome. 