### PR TITLE
Removing ambiguity in the Template Override ModelAdmin documentation

### DIFF
--- a/wagtail/search/query.py
+++ b/wagtail/search/query.py
@@ -45,7 +45,7 @@ class Phrase(SearchQuery):
         self.query_string = query_string
 
     def __repr__(self):
-        return '<PlainText {}>'.format(repr(self.query_string))
+        return '<Phrase {}>'.format(repr(self.query_string))
 
 
 class MatchAll(SearchQuery):


### PR DESCRIPTION
As it stands, the docs on this topic (Overriding Templates in ModelAdmin) seem to indicate that the /modeladmin/ directory should be placed in the project root folder.  I think a rewording of line 144 is in order as well, but I don't know a good way to phrase that.
