### PR TITLE
Add string representation to image Format()

### DIFF
--- a/wagtail/images/formats.py
+++ b/wagtail/images/formats.py
@@ -12,6 +12,12 @@ class Format:
         self.label = label
         self.classnames = classnames
         self.filter_spec = filter_spec
+    
+    def __str__(self):
+        return f'"{self.name}", "{self.label}", "{self.classnames}", "{self.filter_spec}"'
+    
+    def __repr__(self):
+        return f"Format({self})"
 
     def editor_attributes(self, image, alt_text):
         """

--- a/wagtail/images/formats.py
+++ b/wagtail/images/formats.py
@@ -12,10 +12,10 @@ class Format:
         self.label = label
         self.classnames = classnames
         self.filter_spec = filter_spec
-    
+
     def __str__(self):
         return f'"{self.name}", "{self.label}", "{self.classnames}", "{self.filter_spec}"'
-    
+
     def __repr__(self):
         return f"Format({self})"
 


### PR DESCRIPTION
when checking on the currently registered Formats, e.g. with `get_image_formats()` the output is now easier to read.

It's just some cosmetics, but let me know if you think tests and such are still necessary