### PR TITLE
Add system check to validate that a model `edit_handler` is actually an EditHandler

### DIFF
--- a/wagtail/admin/checks.py
+++ b/wagtail/admin/checks.py
@@ -151,3 +151,33 @@ There are no default tabs on non-Page models so there will be no \
         errors.append(error)
 
     return errors
+
+
+def check_edit_handler_on_model(cls, context='model'):
+    """Check that the edit_handler is an instance of EditHandler."""
+    from wagtail.admin.edit_handlers import EditHandler
+
+    errors = []
+
+    edit_handler = getattr(cls, 'edit_handler', None)
+    if edit_handler is not None and not isinstance(edit_handler, EditHandler):
+        # Check for a typo at setup
+        class_name = cls.__name__
+        error = Error(
+            "edit_handler is not an EditHandler instance",
+            hint="Ensure that {}.edit_handler is an instance of "
+                 "wagtail.admin.edit_handler.EditHandler. It is currently: "
+                 "`{}`".format(class_name, type(edit_handler)),
+            obj=cls,
+            id='wagtailadmin.E003'
+        )
+        errors.append(error)
+    elif hasattr(cls, 'edit_handlers'):
+        error = Warning(
+            "edit_handlers has no effect",
+            hint="Did you mean to define an `edit_handler`?",
+            obj=cls,
+            id='wagtailadmin.W003'
+        )
+        errors.append(error)
+    return errors

--- a/wagtail/admin/checks.py
+++ b/wagtail/admin/checks.py
@@ -189,4 +189,3 @@ def check_edit_handler_on_model(cls, context='model'):
         )
         errors.append(error)
     return errors
-

--- a/wagtail/admin/checks.py
+++ b/wagtail/admin/checks.py
@@ -153,21 +153,29 @@ There are no default tabs on non-Page models so there will be no \
     return errors
 
 
-def check_edit_handler_on_model(cls, context='model'):
-    """Check that the edit_handler is an instance of EditHandler."""
+def is_valid_edit_handler(edit_handler):
     from wagtail.admin.edit_handlers import EditHandler
+    if not isinstance(edit_handler, EditHandler):
+        return False
+    if not hasattr(edit_handler, 'get_form_class'):
+        return False
+    return True
 
+
+def check_edit_handler_on_model(cls, context='model'):
+    """Check that the edit_handler defined (if any) is valid."""
     errors = []
 
     edit_handler = getattr(cls, 'edit_handler', None)
-    if edit_handler is not None and not isinstance(edit_handler, EditHandler):
+    if edit_handler is not None and not is_valid_edit_handler(edit_handler):
         # Check for a typo at setup
         class_name = cls.__name__
         error = Error(
-            "edit_handler is not an EditHandler instance",
+            "edit_handler definition is invalid",
             hint="Ensure that {}.edit_handler is an instance of "
-                 "wagtail.admin.edit_handler.EditHandler. It is currently: "
-                 "`{}`".format(class_name, type(edit_handler)),
+                 "wagtail.admin.edit_handler.EditHandler with a "
+                 "`get_form_class` method. Got: `{}`".format(
+                     class_name, type(edit_handler)),
             obj=cls,
             id='wagtailadmin.E003'
         )
@@ -181,3 +189,4 @@ def check_edit_handler_on_model(cls, context='model'):
         )
         errors.append(error)
     return errors
+

--- a/wagtail/contrib/modeladmin/options.py
+++ b/wagtail/contrib/modeladmin/options.py
@@ -6,7 +6,7 @@ from django.db.models import Model
 from django.urls import re_path
 from django.utils.safestring import mark_safe
 
-from wagtail.admin.checks import check_panels_in_model
+from wagtail.admin.checks import check_edit_handler_on_model, check_panels_in_model
 from wagtail.admin.edit_handlers import ObjectList, extract_panel_definitions_from_model_class
 from wagtail.core import hooks
 from wagtail.core.models import Page
@@ -572,7 +572,9 @@ class ModelAdmin(WagtailRegisterable):
 
         @checks.register('panels')
         def modeladmin_model_check(app_configs, **kwargs):
-            errors = check_panels_in_model(self.model, 'modeladmin')
+            model = self.model
+            errors = check_panels_in_model(model, 'modeladmin')
+            errors.extend(check_edit_handler_on_model(model, 'modeladmin'))
             return errors
 
 
@@ -669,7 +671,9 @@ class ModelAdminGroup(WagtailRegisterable):
         def modeladmin_model_check(app_configs, **kwargs):
             errors = []
             for modeladmin_class in self.items:
-                errors.extend(check_panels_in_model(modeladmin_class.model))
+                model = modeladmin_class.model
+                errors.extend(check_panels_in_model(model))
+                errors.extend(check_edit_handler_on_model(model))
             return errors
 
 


### PR DESCRIPTION
This adds a system check that makes sure the `edit_handler` (if any) assigned on a model that is registered using a modeladmin is actually EditHandler instance.  It also will warn if you accidentally assign `edit_handlers` which I seem to do by accident a lot...

For example
```
ERRORS:
menu.Menu: (wagtailadmin.E003) edit_handler is not an EditHandler instance
        HINT: Ensure that Menu.edit_handler is an instance of wagtail.admin.edit_handler.EditHandler. It is currently: `<class 'tuple'>`

website.Configuration: (wagtailadmin.W003) edit_handlers has no effect
        HINT: Did you mean to define an `edit_handler`?
```

* For Python changes: Have you added tests to cover the new/fixed behaviour?
Is there a way to test this?