### PR TITLE
Fix create_homepage migration running out of order

### DIFF
--- a/wagtail/project_template/home/migrations/0002_create_homepage.py
+++ b/wagtail/project_template/home/migrations/0002_create_homepage.py
@@ -52,6 +52,10 @@ class Migration(migrations.Migration):
     dependencies = [
         ('home', '0001_initial'),
     ]
+    
+    run_before = [
+        ('wagtailcore', '0056_page_locale_fields_populate'),
+    ]
 
     operations = [
         migrations.RunPython(create_homepage, remove_homepage),


### PR DESCRIPTION
For new projects the template should ensure that the create_homepage migration is run before the locale field is made required. Currently it doesn't give any requirement for this so if for whatever reason django decides to run those later it can lead to an integrity error:

```python-traceback  
  Applying wagtailcore.0057_page_locale_fields_notnull... OK
  Applying wagtailcore.0058_page_alias_of... OK
  Applying wagtailcore.0059_apply_collection_ordering... OK
  Applying home.0001_initial... OK
  Applying home.0002_create_homepage...Traceback (most recent call last)
  File "venv/lib/python3.8/site-packages/django/db/backends/utils.py", line 84, in _execute
    return self.cursor.execute(sql, params)
  File "venv/lib/python3.8/site-packages/django/db/backends/sqlite3/base.py", line 413, in execute
    return Database.Cursor.execute(self, query, params)
sqlite3.IntegrityError: NOT NULL constraint failed: wagtailcore_page.locale_id
```

After

```
  Applying wagtailcore.0055_page_locale_fields... OK
  Applying home.0001_initial... OK
  Applying home.0002_create_homepage... OK
  Applying wagtailcore.0056_page_locale_fields_populate... OK

```
