### PR TITLE
Avoid recommending replacing image/document models entirely

### DIFF
--- a/docs/reference/settings.rst
+++ b/docs/reference/settings.rst
@@ -207,7 +207,7 @@ Images
 
   WAGTAILIMAGES_IMAGE_MODEL = 'myapp.MyImage'
 
-This setting lets you provide your own image model for use in Wagtail, which might extend the built-in ``AbstractImage`` class or replace it entirely.
+This setting lets you provide your own image model for use in Wagtail, which should extend the built-in ``AbstractImage`` class.
 
 
 .. code-block:: python
@@ -261,7 +261,7 @@ Documents
 
   WAGTAILDOCS_DOCUMENT_MODEL = 'myapp.MyDocument'
 
-This setting lets you provide your own document model for use in Wagtail, which might extend the built-in ``AbstractDocument`` class or replace it entirely.
+This setting lets you provide your own document model for use in Wagtail, which should extend the built-in ``AbstractDocument`` class.
 
 
 .. code-block:: python


### PR DESCRIPTION
... when using the ``WAGTAILIMAGES_IMAGE_MODEL``/``WAGTAILDOCS_DOCUMENT_MODEL`` settings.

We can't really support this as we add new fields and methods to these base classes which all images/documents must support. If we did want to support swapping out the models entirely, every addition we make to the base models could be a breaking change.