### PR TITLE
Include default embed finders in facebook embeds configuration example

### DIFF
--- a/docs/advanced_topics/embeds.rst
+++ b/docs/advanced_topics/embeds.rst
@@ -221,6 +221,11 @@ the App ID and App Secret from your app:
             'class': 'wagtail.embeds.finders.instagram',
             'app_id': 'YOUR INSTAGRAM APP_ID HERE',
             'app_secret': 'YOUR INSTAGRAM APP_SECRET HERE',
+        },
+        
+        # Handles all other oEmbed providers the default way
+        {
+            'class': 'wagtail.embeds.finders.oembed',
         }
     ]
 


### PR DESCRIPTION
Facebook and Instagram embeds configuration section should include the default finders for all other providers. It's unclear for someone who just wants to fix his facebook embeds

Thanks for contributing to Wagtail! 🎉

Before submitting, please review the contributor guidelines <https://docs.wagtail.io/en/latest/contributing/index.html> and check the following:


