### PR TITLE
Add Javascript API for page chooser widget

### DIFF
--- a/client/src/entrypoints/page-chooser.js
+++ b/client/src/entrypoints/page-chooser.js
@@ -1,5 +1,5 @@
 /* eslint-disable */
-function createPageChooser(id, pageTypes, openAtParentId, canChooseRoot, userPerms) {
+function createPageChooser(id, openAtParentId, config) {
   const chooserElement = $('#' + id + '-chooser');
   const pageTitle = chooserElement.find('.title');
   const input = $('#' + id);
@@ -47,12 +47,12 @@ function createPageChooser(id, pageTypes, openAtParentId, canChooseRoot, userPer
       if (state && state.parentId) {
         url += state.parentId + '/';
       }
-      const urlParams = { page_type: pageTypes.join(',') };
-      if (canChooseRoot) {
+      const urlParams = { page_type: config['model_names'].join(',') };
+      if (config['can_choose_root']) {
         urlParams.can_choose_root = 'true';
       }
-      if (userPerms) {
-        urlParams.user_perms = userPerms;
+      if (config['user_perms']) {
+        urlParams.user_perms = config['user_perms'];
       }
       ModalWorkflow({
         url: url,

--- a/wagtail/admin/templates/wagtailadmin/widgets/chooser.html
+++ b/wagtail/admin/templates/wagtailadmin/widgets/chooser.html
@@ -9,7 +9,9 @@
 <div id="{{ attrs.id }}-chooser" class="chooser {% block chooser_class %}page-chooser{% endblock %} {% if not value %}blank{% endif %}" {% block chooser_attributes %}{% endblock %}>
 
     <div class="chosen">
-        {% block chosen_state_view %}{% endblock %}
+        {% block chosen_state_view %}
+            <span class="title">{{ display_title }}</span>
+        {% endblock %}
 
         <ul class="actions">
             {% if not widget.is_required and widget.show_clear_link %}
@@ -19,7 +21,7 @@
             {% if widget.show_edit_link %}
                 <li>
                     {% block edit_link %}
-                        <a href="{% block edit_chosen_item_url %}#{% endblock %}" class="edit-link button button-small button-secondary" target="_blank" rel="noopener noreferrer">{{ widget.link_to_chosen_text }}</a>
+                        <a href="{% block edit_chosen_item_url %}{{ edit_url }}{% endblock %}" class="edit-link button button-small button-secondary" target="_blank" rel="noopener noreferrer">{{ widget.link_to_chosen_text }}</a>
                     {% endblock %}
                 </li>
             {% endif %}

--- a/wagtail/admin/templates/wagtailadmin/widgets/page_chooser.html
+++ b/wagtail/admin/templates/wagtailadmin/widgets/page_chooser.html
@@ -1,8 +1,2 @@
 {% extends "wagtailadmin/widgets/chooser.html" %}
 {% block chooser_attributes %}data-chooser-url="{% url "wagtailadmin_choose_page" %}"{% endblock %}
-
-{% block chosen_state_view %}
-    <span class="title">{{ page.specific.get_admin_display_title }}</span>
-{% endblock %}
-
-{% block edit_chosen_item_url %}{% if page %}{% url 'wagtailadmin_pages:edit' page.id %}{% endif %}{% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/workflows/widgets/task_chooser.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/widgets/task_chooser.html
@@ -3,7 +3,5 @@
 {% block chooser_attributes %}data-chooser-url="{% url "wagtailadmin_workflows:task_chooser" %}"{% endblock %}
 
 {% block chosen_state_view %}
-    <span class="name">{{ task.name }}</span>
+    <span class="name">{{ display_title }}</span>
 {% endblock %}
-
-{% block edit_chosen_item_url %}{% if task %}{% url 'wagtailadmin_workflows:edit_task' task.id %}{% endif %}{% endblock %}

--- a/wagtail/admin/tests/test_edit_handlers.py
+++ b/wagtail/admin/tests/test_edit_handlers.py
@@ -697,7 +697,7 @@ class TestPageChooserPanel(TestCase):
 
     def test_render_js_init(self):
         result = self.page_chooser_panel.render_as_field()
-        expected_js = 'createPageChooser("{id}", ["{model}"], {parent}, false, null);'.format(
+        expected_js = 'createPageChooser("{id}", {parent}, {{"model_names": ["{model}"], "can_choose_root": false, "user_perms": null}});'.format(
             id="id_page", model="wagtailcore.page", parent=self.events_index_page.id)
 
         self.assertIn(expected_js, result)
@@ -717,7 +717,7 @@ class TestPageChooserPanel(TestCase):
         result = page_chooser_panel.render_as_field()
 
         # the canChooseRoot flag on createPageChooser should now be true
-        expected_js = 'createPageChooser("{id}", ["{model}"], {parent}, true, null);'.format(
+        expected_js = 'createPageChooser("{id}", {parent}, {{"model_names": ["{model}"], "can_choose_root": true, "user_perms": null}});'.format(
             id="id_page", model="wagtailcore.page", parent=self.events_index_page.id)
         self.assertIn(expected_js, result)
 
@@ -766,7 +766,7 @@ class TestPageChooserPanel(TestCase):
             instance=self.test_instance, form=form, request=self.request)
 
         result = page_chooser_panel.render_as_field()
-        expected_js = 'createPageChooser("{id}", ["{model}"], {parent}, false, null);'.format(
+        expected_js = 'createPageChooser("{id}", {parent}, {{"model_names": ["{model}"], "can_choose_root": false, "user_perms": null}});'.format(
             id="id_page", model="tests.eventpage", parent=self.events_index_page.id)
 
         self.assertIn(expected_js, result)
@@ -784,8 +784,9 @@ class TestPageChooserPanel(TestCase):
             instance=self.test_instance, form=form)
 
         result = page_chooser_panel.render_as_field()
-        expected_js = 'createPageChooser("{id}", ["{model}"], {parent}, false, null);'.format(
-            id="id_page", model="tests.eventpage", parent=self.events_index_page.id)
+        expected_js = 'createPageChooser("{id}", {parent}, {{"model_names": ["{model}"], "can_choose_root": false, "user_perms": null}});'.format(
+            id="id_page", model="tests.eventpage", parent=self.events_index_page.id
+        )
 
         self.assertIn(expected_js, result)
 

--- a/wagtail/admin/tests/test_widgets.py
+++ b/wagtail/admin/tests/test_widgets.py
@@ -37,13 +37,13 @@ class TestAdminPageChooserWidget(TestCase):
         widget = widgets.AdminPageChooser()
 
         js_init = widget.render_js_init('test-id', 'test', None)
-        self.assertEqual(js_init, "createPageChooser(\"test-id\", [\"wagtailcore.page\"], null, false, null);")
+        self.assertEqual(js_init, 'createPageChooser("test-id", null, {"model_names": ["wagtailcore.page"], "can_choose_root": false, "user_perms": null});')
 
     def test_render_js_init_with_user_perm(self):
         widget = widgets.AdminPageChooser(user_perms='copy_to')
 
         js_init = widget.render_js_init('test-id', 'test', None)
-        self.assertEqual(js_init, "createPageChooser(\"test-id\", [\"wagtailcore.page\"], null, false, \"copy_to\");")
+        self.assertEqual(js_init, 'createPageChooser("test-id", null, {"model_names": ["wagtailcore.page"], "can_choose_root": false, "user_perms": "copy_to"});')
 
     def test_render_html_with_value(self):
         widget = widgets.AdminPageChooser()
@@ -58,7 +58,7 @@ class TestAdminPageChooserWidget(TestCase):
 
         js_init = widget.render_js_init('test-id', 'test', self.child_page)
         self.assertEqual(
-            js_init, "createPageChooser(\"test-id\", [\"wagtailcore.page\"], %d, false, null);" % self.root_page.id
+            js_init, 'createPageChooser("test-id", %d, {"model_names": ["wagtailcore.page"], "can_choose_root": false, "user_perms": null});' % self.root_page.id
         )
 
     # def test_render_html_init_with_content_type omitted as HTML does not
@@ -68,7 +68,7 @@ class TestAdminPageChooserWidget(TestCase):
         widget = widgets.AdminPageChooser(target_models=[SimplePage])
 
         js_init = widget.render_js_init('test-id', 'test', None)
-        self.assertEqual(js_init, "createPageChooser(\"test-id\", [\"tests.simplepage\"], null, false, null);")
+        self.assertEqual(js_init, 'createPageChooser("test-id", null, {"model_names": ["tests.simplepage"], "can_choose_root": false, "user_perms": null});')
 
         html = widget.render_html('test', self.child_page, {})
         self.assertIn(">Choose a page (Simple Page)<", html)
@@ -79,7 +79,7 @@ class TestAdminPageChooserWidget(TestCase):
 
         js_init = widget.render_js_init('test-id', 'test', None)
         self.assertEqual(
-            js_init, "createPageChooser(\"test-id\", [\"tests.simplepage\", \"tests.eventpage\"], null, false, null);"
+            js_init, 'createPageChooser("test-id", null, {"model_names": ["tests.simplepage", "tests.eventpage"], "can_choose_root": false, "user_perms": null});'
         )
 
         html = widget.render_html('test', self.child_page, {})
@@ -90,7 +90,7 @@ class TestAdminPageChooserWidget(TestCase):
 
         js_init = widget.render_js_init('test-id', 'test', self.child_page)
         self.assertEqual(
-            js_init, "createPageChooser(\"test-id\", [\"wagtailcore.page\"], %d, true, null);" % self.root_page.id
+            js_init, 'createPageChooser("test-id", %d, {"model_names": ["wagtailcore.page"], "can_choose_root": true, "user_perms": null});' % self.root_page.id
         )
 
 

--- a/wagtail/admin/widgets/chooser.py
+++ b/wagtail/admin/widgets/chooser.py
@@ -3,6 +3,7 @@ import json
 from django import forms
 from django.forms import widgets
 from django.template.loader import render_to_string
+from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 
 from wagtail.admin.staticfiles import versioned_static
@@ -117,7 +118,7 @@ class AdminPageChooser(AdminChooser):
     def render_html(self, name, value, attrs):
         model_class = self._get_lowest_common_page_class()
 
-        instance, value = self.get_instance_and_id(model_class, value)
+        page, value = self.get_instance_and_id(model_class, value)
 
         original_field_html = super().render_html(name, value, attrs)
 
@@ -126,7 +127,8 @@ class AdminPageChooser(AdminChooser):
             'original_field_html': original_field_html,
             'attrs': attrs,
             'value': value,
-            'page': instance,
+            'display_title': page.specific.get_admin_display_title() if page else '',
+            'edit_url': reverse('wagtailadmin_pages:edit', args=[page.id]) if page else '',
         })
 
     def render_js_init(self, id_, name, value):

--- a/wagtail/admin/widgets/workflows.py
+++ b/wagtail/admin/widgets/workflows.py
@@ -2,6 +2,7 @@ import json
 
 from django import forms
 from django.template.loader import render_to_string
+from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 
 from wagtail.admin.staticfiles import versioned_static
@@ -15,7 +16,7 @@ class AdminTaskChooser(AdminChooser):
     link_to_chosen_text = _('Edit this task')
 
     def render_html(self, name, value, attrs):
-        instance, value = self.get_instance_and_id(Task, value)
+        task, value = self.get_instance_and_id(Task, value)
         original_field_html = super().render_html(name, value, attrs)
 
         return render_to_string("wagtailadmin/workflows/widgets/task_chooser.html", {
@@ -23,7 +24,8 @@ class AdminTaskChooser(AdminChooser):
             'original_field_html': original_field_html,
             'attrs': attrs,
             'value': value,
-            'task': instance,
+            'display_title': task.name if task else '',
+            'edit_url': reverse('wagtailadmin_workflows:edit_task', args=[task.id]) if task else '',
         })
 
     def render_js_init(self, id_, name, value):

--- a/wagtail/core/tests/test_blocks.py
+++ b/wagtail/core/tests/test_blocks.py
@@ -3650,7 +3650,7 @@ class TestPageChooserBlock(TestCase):
 
         empty_form_html = block.render_form(None, 'page')
         self.assertInHTML('<input id="page" name="page" placeholder="" type="hidden" />', empty_form_html)
-        self.assertIn('createPageChooser("page", ["wagtailcore.page"], null, false, null);', empty_form_html)
+        self.assertIn('createPageChooser("page", null, {"model_names": ["wagtailcore.page"], "can_choose_root": false, "user_perms": null});', empty_form_html)
 
         christmas_page = Page.objects.get(slug='christmas')
         christmas_form_html = block.render_form(christmas_page, 'page')
@@ -3661,32 +3661,32 @@ class TestPageChooserBlock(TestCase):
     def test_form_render_with_target_model_default(self):
         block = blocks.PageChooserBlock()
         empty_form_html = block.render_form(None, 'page')
-        self.assertIn('createPageChooser("page", ["wagtailcore.page"], null, false, null);', empty_form_html)
+        self.assertIn('createPageChooser("page", null, {"model_names": ["wagtailcore.page"], "can_choose_root": false, "user_perms": null});', empty_form_html)
 
     def test_form_render_with_target_model_string(self):
         block = blocks.PageChooserBlock(help_text="pick a page, any page", page_type='tests.SimplePage')
         empty_form_html = block.render_form(None, 'page')
-        self.assertIn('createPageChooser("page", ["tests.simplepage"], null, false, null);', empty_form_html)
+        self.assertIn('createPageChooser("page", null, {"model_names": ["tests.simplepage"], "can_choose_root": false, "user_perms": null});', empty_form_html)
 
     def test_form_render_with_target_model_literal(self):
         block = blocks.PageChooserBlock(help_text="pick a page, any page", page_type=SimplePage)
         empty_form_html = block.render_form(None, 'page')
-        self.assertIn('createPageChooser("page", ["tests.simplepage"], null, false, null);', empty_form_html)
+        self.assertIn('createPageChooser("page", null, {"model_names": ["tests.simplepage"], "can_choose_root": false, "user_perms": null});', empty_form_html)
 
     def test_form_render_with_target_model_multiple_strings(self):
         block = blocks.PageChooserBlock(help_text="pick a page, any page", page_type=['tests.SimplePage', 'tests.EventPage'])
         empty_form_html = block.render_form(None, 'page')
-        self.assertIn('createPageChooser("page", ["tests.simplepage", "tests.eventpage"], null, false, null);', empty_form_html)
+        self.assertIn('createPageChooser("page", null, {"model_names": ["tests.simplepage", "tests.eventpage"], "can_choose_root": false, "user_perms": null});', empty_form_html)
 
     def test_form_render_with_target_model_multiple_literals(self):
         block = blocks.PageChooserBlock(help_text="pick a page, any page", page_type=[SimplePage, EventPage])
         empty_form_html = block.render_form(None, 'page')
-        self.assertIn('createPageChooser("page", ["tests.simplepage", "tests.eventpage"], null, false, null);', empty_form_html)
+        self.assertIn('createPageChooser("page", null, {"model_names": ["tests.simplepage", "tests.eventpage"], "can_choose_root": false, "user_perms": null});', empty_form_html)
 
     def test_form_render_with_can_choose_root(self):
         block = blocks.PageChooserBlock(help_text="pick a page, any page", can_choose_root=True)
         empty_form_html = block.render_form(None, 'page')
-        self.assertIn('createPageChooser("page", ["wagtailcore.page"], null, true, null);', empty_form_html)
+        self.assertIn('createPageChooser("page", null, {"model_names": ["wagtailcore.page"], "can_choose_root": true, "user_perms": null});', empty_form_html)
 
     def test_form_response(self):
         block = blocks.PageChooserBlock()

--- a/wagtail/documents/templates/wagtaildocs/widgets/document_chooser.html
+++ b/wagtail/documents/templates/wagtaildocs/widgets/document_chooser.html
@@ -1,9 +1,3 @@
 {% extends "wagtailadmin/widgets/chooser.html" %}
 {% block chooser_class %}document-chooser{% endblock %}
 {% block chooser_attributes %}data-chooser-url="{% url "wagtaildocs:chooser" %}"{% endblock %}
-
-{% block chosen_state_view %}
-    <span class="title">{{ document.title }}</span>
-{% endblock %}
-
-{% block edit_chosen_item_url %}{% if document %}{% url 'wagtaildocs:edit' document.id %}{% endif %}{% endblock %}

--- a/wagtail/documents/widgets.py
+++ b/wagtail/documents/widgets.py
@@ -2,6 +2,7 @@ import json
 
 from django import forms
 from django.template.loader import render_to_string
+from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 
 from wagtail.admin.staticfiles import versioned_static
@@ -19,7 +20,7 @@ class AdminDocumentChooser(AdminChooser):
         self.document_model = get_document_model()
 
     def render_html(self, name, value, attrs):
-        instance, value = self.get_instance_and_id(self.document_model, value)
+        document, value = self.get_instance_and_id(self.document_model, value)
         original_field_html = super().render_html(name, value, attrs)
 
         return render_to_string("wagtaildocs/widgets/document_chooser.html", {
@@ -27,7 +28,8 @@ class AdminDocumentChooser(AdminChooser):
             'original_field_html': original_field_html,
             'attrs': attrs,
             'value': value,
-            'document': instance,
+            'display_title': document.title if document else '',
+            'edit_url': reverse('wagtaildocs:edit', args=[document.id]) if document else '',
         })
 
     def render_js_init(self, id_, name, value):

--- a/wagtail/images/templates/wagtailimages/widgets/image_chooser.html
+++ b/wagtail/images/templates/wagtailimages/widgets/image_chooser.html
@@ -6,12 +6,6 @@
 
 {% block chosen_state_view %}
     <div class="preview-image">
-        {% if image %}
-            {% image image max-165x165 class="show-transparency" title=image.title %}
-        {% else %}
-            <img alt="">
-        {% endif %}
+        <img alt="{{ title }}" class="show-transparency" height="{{ preview.height }}" src="{{ preview.url }}" title="{{ title }}" width="{{ preview.width }}">
     </div>
 {% endblock %}
-
-{% block edit_chosen_item_url %}{% if image %}{% url 'wagtailimages:edit' image.id %}{% endif %}{% endblock %}

--- a/wagtail/snippets/templates/wagtailsnippets/widgets/snippet_chooser.html
+++ b/wagtail/snippets/templates/wagtailsnippets/widgets/snippet_chooser.html
@@ -3,9 +3,3 @@
 
 {% block chooser_class %}snippet-chooser{% endblock %}
 {% block chooser_attributes %}data-chooser-url="{% url 'wagtailsnippets:choose_generic' %}"{% endblock %}
-
-{% block chosen_state_view %}
-    <span class="title">{{ item }}</span>
-{% endblock %}
-
-{% block edit_chosen_item_url %}{% if item %}{% url 'wagtailsnippets:edit' model_opts.app_label model_opts.model_name item.pk|admin_urlquote %}{% endif %}{% endblock %}

--- a/wagtail/snippets/widgets.py
+++ b/wagtail/snippets/widgets.py
@@ -1,7 +1,9 @@
 import json
 
 from django import forms
+from django.contrib.admin.utils import quote
 from django.template.loader import render_to_string
+from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 
 from wagtail.admin.staticfiles import versioned_static
@@ -25,13 +27,22 @@ class AdminSnippetChooser(AdminChooser):
 
         original_field_html = super().render_html(name, value, attrs)
 
+        if instance:
+            app_label = self.target_model._meta.app_label
+            model_name = self.target_model._meta.model_name
+            quoted_id = quote(instance.pk)
+            edit_url = reverse('wagtailsnippets:edit', args=[app_label, model_name, quoted_id])
+        else:
+            edit_url = ''
+
         return render_to_string("wagtailsnippets/widgets/snippet_chooser.html", {
             'widget': self,
             'model_opts': self.target_model._meta,
             'original_field_html': original_field_html,
             'attrs': attrs,
             'value': value,
-            'item': instance,
+            'display_title': str(instance) if instance else '',
+            'edit_url': edit_url,
         })
 
     def render_js_init(self, id_, name, value):

--- a/wagtail/utils/widgets.py
+++ b/wagtail/utils/widgets.py
@@ -7,6 +7,14 @@ class WidgetWithScript(Widget):
         """Render the HTML (non-JS) portion of the field markup"""
         return super().render(name, value, attrs)
 
+    def get_value_data(self, value):
+        # Perform any necessary preprocessing on the value passed to render() before it is passed
+        # on to render_html / render_js_init. This is a good place to perform database lookups
+        # that are needed by both render_html and render_js_init. Return value is arbitrary
+        # (we only care that render_html / render_js_init can accept it), but will typically be
+        # a dict of data needed for rendering: id, title etc.
+        return value
+
     def render(self, name, value, attrs=None, renderer=None):
         # no point trying to come up with sensible semantics for when 'id' is missing from attrs,
         # so let's make sure it fails early in the process
@@ -15,9 +23,10 @@ class WidgetWithScript(Widget):
         except (KeyError, TypeError):
             raise TypeError("WidgetWithScript cannot be rendered without an 'id' attribute")
 
-        widget_html = self.render_html(name, value, attrs)
+        value_data = self.get_value_data(value)
+        widget_html = self.render_html(name, value_data, attrs)
 
-        js = self.render_js_init(id_, name, value)
+        js = self.render_js_init(id_, name, value_data)
         out = '{0}<script>{1}</script>'.format(widget_html, js)
         return mark_safe(out)
 


### PR DESCRIPTION
Some non-destructive (and hopefully safe to merge into master now) refactoring to AdminPageChooser to make its client-side functionality more hackable to client-side code (including Telepath) - createPageChooser now returns an object with accessors for populating the chooser state, retrieving its value, and triggering the modal. (This object will also be used as the Telepath client-side representation of the widget, in the follow-up PR I'm about to open.) Since constructing a state to pass to `chooser.setState` involves some non-trivial logic (such as retrieving the parent page and constructing an edit-view URL), I've extracted a `get_value_data` method from `render_html` and `render_js_init` so that we can re-use that logic.

(I've also done a small part of the latter refactoring on the other choosers - image, document, snippet and task - but didn't get time to finish the job off for those...)