### PR TITLE
Allow long embed urls, add unique hash

### DIFF
--- a/wagtail/embeds/migrations/0006_add_embed_hash.py
+++ b/wagtail/embeds/migrations/0006_add_embed_hash.py
@@ -1,33 +1,5 @@
 from django.db import migrations, models
 
-from wagtail.embeds.embeds import get_embed_hash
-
-
-def migrate_forwards(apps, schema_editor):
-    Embed = apps.get_model("wagtailembeds.Embed")
-
-    # based each embed being ~500b, available memory being
-    # to 2MB, and leaving plenty of headway for app itself
-    batch_size = 1500
-
-    # allows small batches to be kept in memory in order
-    # to utilise bulk_update()
-    batch = []
-
-    for embed in Embed.objects.all().only("id", "url", "max_width").iterator():
-
-        embed.hash = get_embed_hash(embed.url, embed.max_width)
-        batch.append(embed)
-
-        if len(batch) == batch_size:
-            # save and reset current batch
-            Embed.objects.bulk_update(batch, ["hash"])
-            batch.clear()
-
-    # save any leftovers
-    if batch:
-        Embed.objects.bulk_update(batch, ["hash"])
-
 
 class Migration(migrations.Migration):
 
@@ -40,31 +12,5 @@ class Migration(migrations.Migration):
             model_name="embed",
             name="hash",
             field=models.CharField(blank=True, max_length=32),
-        ),
-        migrations.RunPython(migrate_forwards, migrations.RunPython.noop),
-        migrations.AlterField(
-            model_name="embed",
-            name="hash",
-            field=models.CharField(db_index=True, max_length=32, unique=True),
-        ),
-        # MySQL needs max length on the unique together fields.
-        # Drop unique together before alter char to text.
-        migrations.AlterUniqueTogether(
-            name="embed",
-            unique_together=set(),
-        ),
-        migrations.AlterField(
-            model_name="embed",
-            name="url",
-            field=models.TextField(),
-        ),
-        migrations.AlterField(
-            model_name="embed",
-            name="thumbnail_url",
-            field=models.TextField(
-                blank=True,
-                default="",
-            ),
-            preserve_default=False,
         ),
     ]

--- a/wagtail/embeds/migrations/0006_add_embed_hash.py
+++ b/wagtail/embeds/migrations/0006_add_embed_hash.py
@@ -1,0 +1,70 @@
+from django.db import migrations, models
+
+from wagtail.embeds.embeds import get_embed_hash
+
+
+def migrate_forwards(apps, schema_editor):
+    Embed = apps.get_model("wagtailembeds.Embed")
+
+    # based each embed being ~500b, available memory being
+    # to 2MB, and leaving plenty of headway for app itself
+    batch_size = 1500
+
+    # allows small batches to be kept in memory in order
+    # to utilise bulk_update()
+    batch = []
+
+    for embed in Embed.objects.all().only("id", "url", "max_width").iterator():
+
+        embed.hash = get_embed_hash(embed.url, embed.max_width)
+        batch.append(embed)
+
+        if len(batch) == batch_size:
+            # save and reset current batch
+            Embed.objects.bulk_update(batch, ["hash"])
+            batch.clear()
+
+    # save any leftovers
+    if batch:
+        Embed.objects.bulk_update(batch, ["hash"])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("wagtailembeds", "0005_specify_thumbnail_url_max_length"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="embed",
+            name="hash",
+            field=models.CharField(blank=True, max_length=32),
+        ),
+        migrations.RunPython(migrate_forwards, migrations.RunPython.noop),
+        migrations.AlterField(
+            model_name="embed",
+            name="hash",
+            field=models.CharField(db_index=True, max_length=32, unique=True),
+        ),
+        # MySQL needs max length on the unique together fields.
+        # Drop unique together before alter char to text.
+        migrations.AlterUniqueTogether(
+            name="embed",
+            unique_together=set(),
+        ),
+        migrations.AlterField(
+            model_name="embed",
+            name="url",
+            field=models.TextField(),
+        ),
+        migrations.AlterField(
+            model_name="embed",
+            name="thumbnail_url",
+            field=models.TextField(
+                blank=True,
+                default="",
+            ),
+            preserve_default=False,
+        ),
+    ]

--- a/wagtail/embeds/migrations/0007_populate_hash.py
+++ b/wagtail/embeds/migrations/0007_populate_hash.py
@@ -1,0 +1,40 @@
+from django.db import migrations
+
+from wagtail.embeds.embeds import get_embed_hash
+
+
+def migrate_forwards(apps, schema_editor):
+    Embed = apps.get_model("wagtailembeds.Embed")
+
+    # based each embed being ~500b, available memory being
+    # to 2MB, and leaving plenty of headway for app itself
+    batch_size = 1500
+
+    # allows small batches to be kept in memory in order
+    # to utilise bulk_update()
+    batch = []
+
+    for embed in Embed.objects.all().only("id", "url", "max_width").iterator():
+
+        embed.hash = get_embed_hash(embed.url, embed.max_width)
+        batch.append(embed)
+
+        if len(batch) == batch_size:
+            # save and reset current batch
+            Embed.objects.bulk_update(batch, ["hash"])
+            batch.clear()
+
+    # save any leftovers
+    if batch:
+        Embed.objects.bulk_update(batch, ["hash"])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("wagtailembeds", "0006_add_embed_hash"),
+    ]
+
+    operations = [
+        migrations.RunPython(migrate_forwards, migrations.RunPython.noop),
+    ]

--- a/wagtail/embeds/migrations/0008_allow_long_urls.py
+++ b/wagtail/embeds/migrations/0008_allow_long_urls.py
@@ -1,0 +1,36 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("wagtailembeds", "0007_populate_hash"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="embed",
+            name="hash",
+            field=models.CharField(db_index=True, max_length=32, unique=True),
+        ),
+        # MySQL needs max length on the unique together fields.
+        # Drop unique together before alter char to text.
+        migrations.AlterUniqueTogether(
+            name="embed",
+            unique_together=set(),
+        ),
+        migrations.AlterField(
+            model_name="embed",
+            name="url",
+            field=models.TextField(),
+        ),
+        migrations.AlterField(
+            model_name="embed",
+            name="thumbnail_url",
+            field=models.TextField(
+                blank=True,
+                default="",
+            ),
+            preserve_default=False,
+        ),
+    ]

--- a/wagtail/embeds/models.py
+++ b/wagtail/embeds/models.py
@@ -22,22 +22,23 @@ class Embed(models.Model):
     If an instance of this model is deleted, it will be automatically refetched
     next time the embed code is needed.
     """
-    url = models.URLField()
+
+    url = models.TextField()
     max_width = models.SmallIntegerField(null=True, blank=True)
+    hash = models.CharField(max_length=32, unique=True, db_index=True)
     type = models.CharField(max_length=10, choices=EMBED_TYPES)
     html = models.TextField(blank=True)
     title = models.TextField(blank=True)
     author_name = models.TextField(blank=True)
     provider_name = models.TextField(blank=True)
-    thumbnail_url = models.URLField(max_length=255, null=True, blank=True)
+    thumbnail_url = models.TextField(blank=True)
     width = models.IntegerField(null=True, blank=True)
     height = models.IntegerField(null=True, blank=True)
     last_updated = models.DateTimeField(auto_now=True)
 
     class Meta:
-        unique_together = ('url', 'max_width')
-        verbose_name = _('embed')
-        verbose_name_plural = _('embeds')
+        verbose_name = _("embed")
+        verbose_name_plural = _("embeds")
 
     @property
     def ratio(self):

--- a/wagtail/embeds/tests/test_embeds.py
+++ b/wagtail/embeds/tests/test_embeds.py
@@ -13,7 +13,7 @@ from django.urls import reverse
 from wagtail.core import blocks
 from wagtail.embeds import oembed_providers
 from wagtail.embeds.blocks import EmbedBlock, EmbedValue
-from wagtail.embeds.embeds import get_embed
+from wagtail.embeds.embeds import get_embed, get_embed_hash
 from wagtail.embeds.exceptions import EmbedNotFoundException, EmbedUnsupportedProviderException
 from wagtail.embeds.finders import get_finders
 from wagtail.embeds.finders.embedly import AccessDeniedEmbedlyException, EmbedlyException
@@ -206,6 +206,14 @@ class TestEmbeds(TestCase):
     def test_no_finders_available(self):
         with self.assertRaises(EmbedUnsupportedProviderException):
             get_embed('www.test.com/1234', max_width=400)
+
+
+class TestEmbedHash(TestCase):
+    def test_get_embed_hash(self):
+        url = "www.test.com/1234"
+        self.assertEqual(get_embed_hash(url), "9a4cfc187266026cd68160b5db572629")
+        self.assertEqual(get_embed_hash(url, 0), "be54b69772d5e086ec07748741455736")
+        self.assertEqual(get_embed_hash(url, 1), "601c15cca60eb068ebcc166b9587ed63")
 
 
 class TestChooser(TestCase, WagtailTestUtils):


### PR DESCRIPTION
This PR removes the max_length constraint from embed url fields: `Embed.url` and `Embed.thumbnail_url` now accept any length of string.

Fixes: #6467 and #1985

Idea @ababic:
https://github.com/wagtail/wagtail/blob/master/wagtail/embeds/embeds.py#issuecomment-720111428

Note:
- Embed url+max_width uniqueness is now guaranteed by `Embed.hash`
- The hash field has a db index

Question:
- The migration combines structure, data and structure again in a single file. Is the right thing to do? Or should this migration be split into 3 files?

Checks
* Do the tests still pass? (https://docs.wagtail.io/en/latest/contributing/developing.html#testing)  YES
* Does the code comply with the style guide? (Run `make lint` from the Wagtail root) YES
* For Python changes: Have you added tests to cover the new/fixed behaviour? YES
* For front-end changes: Did you test on all of Wagtail’s supported browsers? **Please list the exact versions you tested**. N/A
* For new features: Has the documentation been updated accordingly? N/A
