### PR TITLE
Add missing import to example code snippet

### DIFF
--- a/docs/reference/contrib/forms/index.rst
+++ b/docs/reference/contrib/forms/index.rst
@@ -28,6 +28,7 @@ Within the ``models.py`` of one of your apps, create a model that extends ``wagt
 
 .. code-block:: python
 
+    from django.db import models
     from modelcluster.fields import ParentalKey
     from wagtail.admin.edit_handlers import (
         FieldPanel, FieldRowPanel,


### PR DESCRIPTION
Adding this makes the code snippet ready to use via copy and paste.