### PR TITLE
Special case date lookups for searching

### DIFF
--- a/wagtail/search/backends/base.py
+++ b/wagtail/search/backends/base.py
@@ -1,6 +1,6 @@
 from warnings import warn
 
-from django.db.models.lookups import Lookup
+from django.db.models.lookups import Lookup, YearLookup
 from django.db.models.query import QuerySet
 from django.db.models.sql.where import SubqueryConstraint, WhereNode
 
@@ -88,7 +88,10 @@ class BaseSearchQueryCompiler:
     def _get_filters_from_where_node(self, where_node, check_only=False):
         # Check if this is a leaf node
         if isinstance(where_node, Lookup):
-            field_attname = where_node.lhs.target.attname
+            if isinstance(where_node, YearLookup):
+                field_attname = where_node.lhs.lhs.target.attname
+            else:
+                field_attname = where_node.lhs.target.attname
             lookup = where_node.lookup_name
             value = where_node.rhs
 

--- a/wagtail/search/backends/base.py
+++ b/wagtail/search/backends/base.py
@@ -1,6 +1,8 @@
 from warnings import warn
 
-from django.db.models.lookups import Lookup, YearLookup
+from django.db.models.functions.datetime import Extract as ExtractDate
+from django.db.models.functions.datetime import ExtractYear
+from django.db.models.lookups import Lookup
 from django.db.models.query import QuerySet
 from django.db.models.sql.where import SubqueryConstraint, WhereNode
 
@@ -88,8 +90,14 @@ class BaseSearchQueryCompiler:
     def _get_filters_from_where_node(self, where_node, check_only=False):
         # Check if this is a leaf node
         if isinstance(where_node, Lookup):
-            if isinstance(where_node, YearLookup):
-                field_attname = where_node.lhs.lhs.target.attname
+            if isinstance(where_node.lhs, ExtractDate):
+                if isinstance(where_node.lhs, ExtractYear):
+                    field_attname = where_node.lhs.lhs.target.attname
+                else:
+                    raise FilterError(
+                        'Cannot apply filter on search results: "' + where_node.lhs.lookup_name + 
+                        '" queries are not supported.'
+                    )
             else:
                 field_attname = where_node.lhs.target.attname
             lookup = where_node.lookup_name

--- a/wagtail/search/backends/base.py
+++ b/wagtail/search/backends/base.py
@@ -95,8 +95,8 @@ class BaseSearchQueryCompiler:
                     field_attname = where_node.lhs.lhs.target.attname
                 else:
                     raise FilterError(
-                        'Cannot apply filter on search results: "' + where_node.lhs.lookup_name + 
-                        '" queries are not supported.'
+                        'Cannot apply filter on search results: "' + where_node.lhs.lookup_name
+                        + '" queries are not supported.'
                     )
             else:
                 field_attname = where_node.lhs.target.attname

--- a/wagtail/search/tests/elasticsearch_common_tests.py
+++ b/wagtail/search/tests/elasticsearch_common_tests.py
@@ -176,6 +176,12 @@ class ElasticsearchCommonSearchBackendTests(BackendTests):
         results = self.backend.search(MATCH_ALL, models.Book)[110:]
         self.assertEqual(len(results), 54)
 
+    def test_search_with_date_filter(self):
+        after_1900 = models.Book.objects.filter(publication_date__year__gt=1900)
+
+        results = self.backend.search(MATCH_ALL, after_1900)
+        self.assertEqual(len(after_1900), len(results))
+
     # Elasticsearch always does prefix matching on `partial_match` fields,
     # even when we don’t use `Prefix`.
     @unittest.expectedFailure

--- a/wagtail/search/tests/elasticsearch_common_tests.py
+++ b/wagtail/search/tests/elasticsearch_common_tests.py
@@ -182,6 +182,13 @@ class ElasticsearchCommonSearchBackendTests(BackendTests):
         results = self.backend.search(MATCH_ALL, after_1900)
         self.assertEqual(len(after_1900), len(results))
 
+        # Filtering by date not supported, should throw a FilterError
+        from wagtail.search.backends.base import FilterError
+
+        in_jan = models.Book.objects.filter(publication_date__month=1)
+        with self.assertRaises(FilterError):
+            self.backend.search(MATCH_ALL, in_jan)
+
     # Elasticsearch always does prefix matching on `partial_match` fields,
     # even when we don’t use `Prefix`.
     @unittest.expectedFailure

--- a/wagtail/search/tests/test_elasticsearch5_backend.py
+++ b/wagtail/search/tests/test_elasticsearch5_backend.py
@@ -333,6 +333,17 @@ class TestElasticsearch5SearchQuery(TestCase):
         expected_result = {'match_phrase': {'title': "Hello world"}}
         self.assertDictEqual(query_compiler.get_inner_query(), expected_result)
 
+    def test_year_filter(self):
+        # Create a query
+        query_compiler = self.query_compiler_class(models.Book.objects.filter(publication_date__year__gt=1900), "Hello")
+
+        # Check it
+        expected_result = {'bool': {'filter': [
+            {'match': {'content_type': 'searchtests.Book'}},
+            {'range': {'publication_date_filter': {'gt': 1900}}}
+        ], 'must': {'multi_match': {'query': 'Hello', 'fields': ['_all', '_partials']}}}}
+        self.assertDictEqual(query_compiler.get_query(), expected_result)
+
 
 class TestElasticsearch5SearchResults(TestCase):
     fixtures = ['search']

--- a/wagtail/search/tests/test_elasticsearch6_backend.py
+++ b/wagtail/search/tests/test_elasticsearch6_backend.py
@@ -333,6 +333,17 @@ class TestElasticsearch6SearchQuery(TestCase):
         expected_result = {'match_phrase': {'title': "Hello world"}}
         self.assertDictEqual(query_compiler.get_inner_query(), expected_result)
 
+    def test_year_filter(self):
+        # Create a query
+        query_compiler = self.query_compiler_class(models.Book.objects.filter(publication_date__year=1900), "Hello")
+
+        # Check it
+        expected_result = {'bool': {'filter': [
+            {'match': {'content_type': 'searchtests.Book'}},
+            {'term': {'publication_date_filter': 1900}}
+        ], 'must': {'multi_match': {'query': 'Hello', 'fields': ['_all_text', '_edgengrams']}}}}
+        self.assertDictEqual(query_compiler.get_query(), expected_result)
+
 
 class TestElasticsearch6SearchResults(TestCase):
     fixtures = ['search']

--- a/wagtail/search/tests/test_elasticsearch7_backend.py
+++ b/wagtail/search/tests/test_elasticsearch7_backend.py
@@ -332,6 +332,17 @@ class TestElasticsearch7SearchQuery(TestCase):
         # Check it
         expected_result = {'match_phrase': {'title': "Hello world"}}
         self.assertDictEqual(query_compiler.get_inner_query(), expected_result)
+    
+    def test_year_filter(self):
+        # Create a query
+        query_compiler = self.query_compiler_class(models.Book.objects.filter(publication_date__year__lt=1900), "Hello")
+
+        # Check it
+        expected_result = {'bool': {'filter': [
+            {'match': {'content_type': 'searchtests.Book'}},
+            {'range': {'publication_date_filter': {'lt': 1900}}}
+        ], 'must': {'multi_match': {'query': 'Hello', 'fields': ['_all_text', '_edgengrams']}}}}
+        self.assertDictEqual(query_compiler.get_query(), expected_result)
 
 
 class TestElasticsearch7SearchResults(TestCase):

--- a/wagtail/search/tests/test_elasticsearch7_backend.py
+++ b/wagtail/search/tests/test_elasticsearch7_backend.py
@@ -332,7 +332,7 @@ class TestElasticsearch7SearchQuery(TestCase):
         # Check it
         expected_result = {'match_phrase': {'title': "Hello world"}}
         self.assertDictEqual(query_compiler.get_inner_query(), expected_result)
-    
+
     def test_year_filter(self):
         # Create a query
         query_compiler = self.query_compiler_class(models.Book.objects.filter(publication_date__year__lt=1900), "Hello")


### PR DESCRIPTION
Fixes #5967. I didn't delve too deep into why date lookups have nested `lhs` clauses, but this seems to fix the problem.

* Do the tests still pass? (https://docs.wagtail.io/en/latest/contributing/developing.html#testing)
Yes
* Does the code comply with the style guide? (Run `make lint` from the Wagtail root)
Yes
* For Python changes: Have you added tests to cover the new/fixed behaviour?
Yes
* For front-end changes: Did you test on all of Wagtail’s supported browsers? **Please list the exact versions you tested**.
N/A
* For new features: Has the documentation been updated accordingly?
N/A

