### PR TITLE
Add js translatable string for comment save warning

### DIFF
--- a/client/tests/stubs.js
+++ b/client/tests/stubs.js
@@ -57,6 +57,7 @@ global.wagtailConfig = {
     DELETE_ERROR: 'Delete error',
     CONFIRM_DELETE_COMMENT: 'Are you sure?',
     SAVE_ERROR: 'Save error',
+    SAVE_COMMENT_WARNING: 'This will be saved when the page is saved',
     FOCUS_COMMENT: 'Focus comment',
     UNFOCUS_COMMENT: 'Unfocus comment'
   },

--- a/wagtail/admin/localization.py
+++ b/wagtail/admin/localization.py
@@ -89,6 +89,7 @@ def get_js_translation_strings():
         'DELETE_ERROR': _('Delete error'),
         'CONFIRM_DELETE_COMMENT': _('Are you sure?'),
         'SAVE_ERROR': _('Save error'),
+        'SAVE_COMMENT_WARNING': _('This will be saved when the page is saved'),
         'FOCUS_COMMENT': _('Focus comment'),
         'UNFOCUS_COMMENT': _('Unfocus comment'),
 


### PR DESCRIPTION
Adds string necessary for https://github.com/jacobtoppm/wagtail-comment-frontend/pull/5