### PR TITLE
fix ModelAdmin example in docs

### DIFF
--- a/docs/reference/contrib/modeladmin/create_edit_delete_views.rst
+++ b/docs/reference/contrib/modeladmin/create_edit_delete_views.rst
@@ -33,8 +33,9 @@ model class.
                 FieldRowPanel([
                     FieldPanel('first_name', classname='fn'),
                     FieldPanel('last_name', classname='ln'),
-            ]),
-            FieldPanel('address', classname='custom1',))
+                ]),
+                FieldPanel('address', classname='custom1',)
+            ])
         ]
 
 Or alternatively:
@@ -51,8 +52,9 @@ Or alternatively:
                 FieldRowPanel([
                     FieldPanel('first_name', classname='fn'),
                     FieldPanel('last_name', classname='ln'),
-            ]),
-            FieldPanel('address', classname='custom1',))
+                ]),
+                FieldPanel('address', classname='custom1',)
+            ])
         ]
         edit_handler = ObjectList(custom_panels)
         # or


### PR DESCRIPTION
There is small typo that prevents one from using the example code without modifying it.
I tried to fix it. Its my first contribution here, let me know if i made a mistake
