### PR TITLE
Catch JSON decode errors in oembed responses

### DIFF
--- a/wagtail/embeds/finders/oembed.py
+++ b/wagtail/embeds/finders/oembed.py
@@ -60,9 +60,9 @@ class OEmbedFinder(EmbedFinder):
         request.add_header('User-agent', 'Mozilla/5.0')
         try:
             r = urllib_request.urlopen(request)
-        except URLError:
+            oembed = json.loads(r.read().decode('utf-8'))
+        except (URLError, json.decoder.JSONDecodeError):
             raise EmbedNotFoundException
-        oembed = json.loads(r.read().decode('utf-8'))
 
         # Convert photos into HTML
         if oembed['type'] == 'photo':

--- a/wagtail/embeds/tests/test_embeds.py
+++ b/wagtail/embeds/tests/test_embeds.py
@@ -368,6 +368,14 @@ class TestOembed(TestCase):
                               "http://www.youtube.com/watch/")
 
     @patch('urllib.request.urlopen')
+    def test_oembed_non_json_response(self, urlopen):
+        urlopen.return_value = self.dummy_response
+        self.assertRaises(
+            EmbedNotFoundException, OEmbedFinder().find_embed,
+            "https://www.youtube.com/watch?v=ReblZ7o7lu4"
+        )
+
+    @patch('urllib.request.urlopen')
     @patch('json.loads')
     def test_oembed_photo_request(self, loads, urlopen):
         urlopen.return_value = self.dummy_response


### PR DESCRIPTION
Fixes #6646 - for private videos, Youtube's oembed endpoint returns the text "Forbidden", but with a 200 status code, which fails JSON decoding.
