### PR TITLE
Refactor draftail ModalWorkflowSource for extensibility

### DIFF
--- a/client/src/components/Draftail/index.js
+++ b/client/src/components/Draftail/index.js
@@ -12,7 +12,13 @@ export { default as Document } from './decorators/Document';
 export { default as ImageBlock } from './blocks/ImageBlock';
 export { default as EmbedBlock } from './blocks/EmbedBlock';
 
-import ModalWorkflowSource from './sources/ModalWorkflowSource';
+import {
+  ModalWorkflowSource,
+  ImageModalWorkflowSource,
+  EmbedModalWorkflowSource,
+  LinkModalWorkflowSource,
+  DocumentModalWorkflowSource
+} from './sources/ModalWorkflowSource';
 import Tooltip from './Tooltip/Tooltip';
 import TooltipEntity from './decorators/TooltipEntity';
 import EditorFallback from './EditorFallback/EditorFallback';
@@ -150,6 +156,10 @@ export default {
   registerPlugin,
   // Components exposed for third-party reuse.
   ModalWorkflowSource,
+  ImageModalWorkflowSource,
+  EmbedModalWorkflowSource,
+  LinkModalWorkflowSource,
+  DocumentModalWorkflowSource,
   Tooltip,
   TooltipEntity,
 };

--- a/client/src/components/Draftail/sources/ModalWorkflowSource.js
+++ b/client/src/components/Draftail/sources/ModalWorkflowSource.js
@@ -42,7 +42,7 @@ class ModalWorkflowSource extends Component {
   componentDidMount() {
     const { onClose, entity, editorState } = this.props;
     const selectedText = getSelectionText(editorState);
-    const { url, urlParams, onload } = this.getChooserConfig(entity, selectedText);
+    const { url, urlParams, onload, responses } = this.getChooserConfig(entity, selectedText);
 
     $(document.body).on('hidden.bs.modal', this.onClose);
 
@@ -51,13 +51,7 @@ class ModalWorkflowSource extends Component {
       url,
       urlParams,
       onload,
-      responses: {
-        imageChosen: this.onChosen,
-        // Discard the first parameter (HTML) to only transmit the data.
-        embedChosen: (_, data) => this.onChosen(data),
-        documentChosen: this.onChosen,
-        pageChosen: this.onChosen,
-      },
+      responses,
       onError: () => {
         // eslint-disable-next-line no-alert
         window.alert(STRINGS.SERVER_ERROR);
@@ -161,6 +155,9 @@ class ImageModalWorkflowSource extends ModalWorkflowSource {
       url,
       urlParams,
       onload: global.IMAGE_CHOOSER_MODAL_ONLOAD_HANDLERS,
+      responses: {
+        imageChosen: this.onChosen,
+      },
     };
   }
 
@@ -185,6 +182,10 @@ class EmbedModalWorkflowSource extends ModalWorkflowSource {
       url: global.chooserUrls.embedsChooser,
       urlParams,
       onload: global.EMBED_CHOOSER_MODAL_ONLOAD_HANDLERS,
+      responses: {
+        // Discard the first parameter (HTML) to only transmit the data.
+        embedChosen: (_, data) => this.onChosen(data),
+      }
     };
   }
 
@@ -240,6 +241,9 @@ class LinkModalWorkflowSource extends ModalWorkflowSource {
       url,
       urlParams,
       onload: global.PAGE_CHOOSER_MODAL_ONLOAD_HANDLERS,
+      responses: {
+        pageChosen: this.onChosen,
+      }
     };
   }
 
@@ -264,6 +268,9 @@ class DocumentModalWorkflowSource extends ModalWorkflowSource {
       url: global.chooserUrls.documentChooser,
       urlParams: {},
       onload: global.DOCUMENT_CHOOSER_MODAL_ONLOAD_HANDLERS,
+      responses: {
+        documentChosen: this.onChosen,
+      },
     };
   }
 

--- a/client/src/components/Draftail/sources/ModalWorkflowSource.test.js
+++ b/client/src/components/Draftail/sources/ModalWorkflowSource.test.js
@@ -41,6 +41,7 @@ describe('ModalWorkflowSource', () => {
       expect(imageSource.getChooserConfig(null, '')).toEqual({
         url: '/admin/images/chooser/?select_format=true',
         urlParams: {},
+        responses: { imageChosen: imageSource.onChosen },
         onload: global.IMAGE_CHOOSER_MODAL_ONLOAD_HANDLERS,
       });
     });
@@ -53,13 +54,14 @@ describe('ModalWorkflowSource', () => {
           format: 'left',
           alt_text: 'alt',
         },
+        responses: { imageChosen: imageSource.onChosen },
         onload: global.IMAGE_CHOOSER_MODAL_ONLOAD_HANDLERS,
       });
     });
 
     const embedSource = new EmbedModalWorkflowSource();
     it('EMBED without entity', () => {
-      expect(embedSource.getChooserConfig(null, '')).toEqual({
+      expect(embedSource.getChooserConfig(null, '')).toMatchObject({
         url: '/admin/embeds/chooser/',
         urlParams: {},
         onload: global.EMBED_CHOOSER_MODAL_ONLOAD_HANDLERS,
@@ -68,7 +70,7 @@ describe('ModalWorkflowSource', () => {
 
     it('EMBED with entity', () => {
       const entity = { getData: () => ({ url: 'http://example.org/content' }) };
-      expect(embedSource.getChooserConfig(entity, '')).toEqual({
+      expect(embedSource.getChooserConfig(entity, '')).toMatchObject({
         url: '/admin/embeds/chooser/',
         urlParams: { url: 'http://example.org/content' },
         onload: global.EMBED_CHOOSER_MODAL_ONLOAD_HANDLERS,
@@ -80,6 +82,7 @@ describe('ModalWorkflowSource', () => {
       expect(documentSource.getChooserConfig(null, '')).toEqual({
         url: '/admin/documents/chooser/',
         urlParams: {},
+        responses: { documentChosen: documentSource.onChosen },
         onload: global.DOCUMENT_CHOOSER_MODAL_ONLOAD_HANDLERS,
       });
     });

--- a/client/src/components/Draftail/sources/__snapshots__/ModalWorkflowSource.test.js.snap
+++ b/client/src/components/Draftail/sources/__snapshots__/ModalWorkflowSource.test.js.snap
@@ -59,6 +59,9 @@ Object {
   "onload": Object {
     "type": "page",
   },
+  "responses": Object {
+    "pageChosen": [Function],
+  },
   "url": "/admin/choose-external-link/",
   "urlParams": Object {
     "allow_anchor_link": true,
@@ -76,6 +79,9 @@ exports[`ModalWorkflowSource #getChooserConfig LINK mail 1`] = `
 Object {
   "onload": Object {
     "type": "page",
+  },
+  "responses": Object {
+    "pageChosen": [Function],
   },
   "url": "/admin/choose-email-link/",
   "urlParams": Object {
@@ -95,6 +101,9 @@ Object {
   "onload": Object {
     "type": "page",
   },
+  "responses": Object {
+    "pageChosen": [Function],
+  },
   "url": "/admin/choose-page/",
   "urlParams": Object {
     "allow_anchor_link": true,
@@ -112,6 +121,9 @@ Object {
   "onload": Object {
     "type": "page",
   },
+  "responses": Object {
+    "pageChosen": [Function],
+  },
   "url": "/admin/choose-page/1/",
   "urlParams": Object {
     "allow_anchor_link": true,
@@ -128,6 +140,9 @@ exports[`ModalWorkflowSource #getChooserConfig LINK root page 1`] = `
 Object {
   "onload": Object {
     "type": "page",
+  },
+  "responses": Object {
+    "pageChosen": [Function],
   },
   "url": "/admin/choose-page/",
   "urlParams": Object {

--- a/client/src/entrypoints/admin/draftail.js
+++ b/client/src/entrypoints/admin/draftail.js
@@ -19,22 +19,22 @@ window.draftail = draftail;
 const plugins = [
   {
     type: 'DOCUMENT',
-    source: draftail.ModalWorkflowSource,
+    source: draftail.DocumentModalWorkflowSource,
     decorator: Document,
   },
   {
     type: 'LINK',
-    source: draftail.ModalWorkflowSource,
+    source: draftail.LinkModalWorkflowSource,
     decorator: Link,
   },
   {
     type: 'IMAGE',
-    source: draftail.ModalWorkflowSource,
+    source: draftail.ImageModalWorkflowSource,
     block: ImageBlock,
   },
   {
     type: 'EMBED',
-    source: draftail.ModalWorkflowSource,
+    source: draftail.EmbedModalWorkflowSource,
     block: EmbedBlock,
   },
 ];

--- a/docs/advanced_topics/customisation/admin_templates.rst
+++ b/docs/advanced_topics/customisation/admin_templates.rst
@@ -270,5 +270,9 @@ Pages containing rich text editors also have access to:
     // Wagtail’s Draftail-related APIs and components.
     window.draftail;
     window.draftail.ModalWorkflowSource;
+    window.draftail.ImageModalWorkflowSource;
+    window.draftail.EmbedModalWorkflowSource;
+    window.draftail.LinkModalWorkflowSource;
+    window.draftail.DocumentModalWorkflowSource;
     window.draftail.Tooltip;
     window.draftail.TooltipEntity;


### PR DESCRIPTION
Currently, the important work in draftail's ModalWorkflowSource.js is handled by two functions `getChooserConfig` and `filterEntityData` which consist of a switch/case over the four built-in entity types: images, embeds, links and documents. This makes it impossible to extend draftail with new modal-powered entity types without editing (or duplicating) this file. To address this, I've refactored ModalWorkflowSource into an abstract class which is subclassed for each entity type.

~Along the way I've relaxed the no-unused-vars eslint rule so that it doesn't complain about unused function parameters - I think this is needlessly restrictive, since a case like this (where multiple classes are implementing the same interface) is a valid place where unused parameters can arise.~ Now rebased to use `"args": "after-used"` and eslint-ignore as per Slack discussion...