### PR TITLE
Telepath: Support for standard and rich text blocks

### DIFF
--- a/client/src/entrypoints/admin/telepath/blocks.js
+++ b/client/src/entrypoints/admin/telepath/blocks.js
@@ -32,7 +32,7 @@ class FieldBlock {
     this.type = blockDef.name;
 
     const html = $(`
-      <div>
+      <div class="${this.blockDef.meta.classname || ''}">
         <div class="field-content">
           <div class="input">
             <div data-streamfield-widget></div>

--- a/client/src/entrypoints/admin/telepath/blocks.js
+++ b/client/src/entrypoints/admin/telepath/blocks.js
@@ -44,8 +44,7 @@ class FieldBlock {
     const dom = $(html);
     $(placeholder).replaceWith(dom);
     const widgetElement = dom.find('[data-streamfield-widget]').get(0);
-    this.widget = this.blockDef.widget.render(widgetElement, prefix, prefix);
-    this.widget.setState(initialState);
+    this.widget = this.blockDef.widget.render(widgetElement, prefix, prefix, initialState);
   }
 
   setState(state) {

--- a/client/src/entrypoints/admin/telepath/blocks.js
+++ b/client/src/entrypoints/admin/telepath/blocks.js
@@ -27,14 +27,12 @@ function initBlockWidget(id) {
 }
 window.initBlockWidget = initBlockWidget;
 
-class FieldBlock {
-  constructor(name, widget, meta) {
-    this.name = name;
-    this.widget = window.telepath.unpack(widget);
-    this.meta = meta;
-  }
 
-  render(placeholder, prefix) {
+class FieldBlock {
+  constructor(blockDef, placeholder, prefix) {
+    this.blockDef = blockDef;
+    this.type = blockDef.name;
+
     const html = $(`
       <div>
         <div class="field-content">
@@ -48,95 +46,113 @@ class FieldBlock {
     const dom = $(html);
     $(placeholder).replaceWith(dom);
     const widgetElement = dom.find('[data-streamfield-widget]').get(0);
-    const boundWidget = this.widget.render(widgetElement, prefix, prefix);
-    return {
-      type: this.name,
-      setState(state) {
-        boundWidget.setState(state);
-      },
-      getState() {
-        boundWidget.getState();
-      },
-      getValue() {
-        boundWidget.getValue();
-      },
-    };
+    this.widget = this.blockDef.widget.render(widgetElement, prefix, prefix);
+  }
+
+  setState(state) {
+    this.widget.setState(state);
+  }
+
+  getState() {
+    return this.widget.getState();
+  }
+
+  getValue() {
+    return this.widget.getValue();
   }
 }
-window.telepath.register('wagtail.blocks.FieldBlock', FieldBlock);
 
-
-class StructBlock {
-  constructor(name, childBlocks, meta) {
+class FieldBlockDefinition {
+  constructor(name, widget, meta) {
     this.name = name;
-    this.childBlocks = childBlocks.map((child) => window.telepath.unpack(child));
+    this.widget = window.telepath.unpack(widget);
     this.meta = meta;
   }
 
   render(placeholder, prefix) {
+    return new FieldBlock(this, placeholder, prefix);
+  }
+}
+window.telepath.register('wagtail.blocks.FieldBlock', FieldBlockDefinition);
+
+
+class StructBlock {
+  constructor(blockDef, placeholder, prefix) {
+    this.blockDef = blockDef;
+    this.type = blockDef.name;
+
     const html = $(`
-      <div class="${this.meta.classname || ''}">
+      <div class="${this.blockDef.meta.classname || ''}">
       </div>
     `);
     const dom = $(html);
     $(placeholder).replaceWith(dom);
 
-    const boundBlocks = {};
-    this.childBlocks.forEach(childBlock => {
+    this.childBlocks = {};
+    this.blockDef.childBlockDefs.forEach(childBlockDef => {
       const childHtml = $(`
         <div class="field">
-          <label class="field__label">${childBlock.meta.label}</label>
+          <label class="field__label">${childBlockDef.meta.label}</label>
           <div data-streamfield-block></div>
         </div>
       `);
       const childDom = $(childHtml);
       dom.append(childDom);
       const childBlockElement = childDom.find('[data-streamfield-block]').get(0);
-      const boundBlock = childBlock.render(childBlockElement, prefix + '-' + childBlock.name);
+      const childBlock = childBlockDef.render(childBlockElement, prefix + '-' + childBlockDef.name);
 
-      boundBlocks[childBlock.name] = boundBlock;
+      this.childBlocks[childBlockDef.name] = childBlock;
     });
+  }
 
-    return {
-      type: this.name,
-      setState(state) {
-        // eslint-disable-next-line guard-for-in, no-restricted-syntax
-        for (const name in state) {
-          boundBlocks[name].setState(state[name]);
-        }
-      },
-      getState() {
-        const state = {};
-        // eslint-disable-next-line guard-for-in, no-restricted-syntax
-        for (const name in boundBlocks) {
-          state[name] = boundBlocks[name].getState();
-        }
-        return state;
-      },
-      getValue() {
-        const value = {};
-        // eslint-disable-next-line guard-for-in, no-restricted-syntax
-        for (const name in boundBlocks) {
-          value[name] = boundBlocks[name].getValue();
-        }
-        return value;
-      },
-    };
+  setState(state) {
+    // eslint-disable-next-line guard-for-in, no-restricted-syntax
+    for (const name in state) {
+      this.childBlocks[name].setState(state[name]);
+    }
+  }
+
+  getState() {
+    const state = {};
+    // eslint-disable-next-line guard-for-in, no-restricted-syntax
+    for (const name in this.childBlocks) {
+      state[name] = this.childBlocks[name].getState();
+    }
+    return state;
+  }
+
+  getValue() {
+    const value = {};
+    // eslint-disable-next-line guard-for-in, no-restricted-syntax
+    for (const name in this.childBlocks) {
+      value[name] = this.childBlocks[name].getValue();
+    }
+    return value;
   }
 }
-window.telepath.register('wagtail.blocks.StructBlock', StructBlock);
 
-
-class ListBlock {
-  constructor(name, childBlock, meta) {
+class StructBlockDefinition {
+  constructor(name, childBlockDefs, meta) {
     this.name = name;
-    this.childBlock = window.telepath.unpack(childBlock);
+    this.childBlockDefs = childBlockDefs.map((child) => window.telepath.unpack(child));
     this.meta = meta;
   }
 
   render(placeholder, prefix) {
+    return new StructBlock(this, placeholder, prefix);
+  }
+}
+window.telepath.register('wagtail.blocks.StructBlock', StructBlockDefinition);
+
+
+class ListBlock {
+  constructor(blockDef, placeholder, prefix) {
+    this.blockDef = blockDef;
+    this.type = blockDef.name;
+    this.prefix = prefix;
+
     const html = $(`
-      <div class="c-sf-container ${this.meta.classname || ''}">
+      <div class="c-sf-container ${this.blockDef.meta.classname || ''}">
         <input type="hidden" name="${prefix}-count" data-streamfield-list-count value="0">
 
         <div data-streamfield-list-container></div>
@@ -145,181 +161,220 @@ class ListBlock {
         </button>
       </div>
     `);
+
     const dom = $(html);
     $(placeholder).replaceWith(dom);
 
-    let boundBlocks = [];
-    const countInput = dom.find('[data-streamfield-list-count]');
-    const listContainer = dom.find('[data-streamfield-list-container]');
+    this.childBlocks = [];
+    this.countInput = dom.find('[data-streamfield-list-count]');
+    this.listContainer = dom.find('[data-streamfield-list-container]');
+  }
 
-    const self = this;
+  clear() {
+    this.countInput.val(0);
+    this.listContainer.empty();
+    this.childBlocks = [];
+  }
 
-    return {
-      type: this.name,
-      setState(values) {
-        countInput.val(values.length);
-        boundBlocks = [];
-        listContainer.empty();
-        values.forEach((val, index) => {
-          const childPrefix = prefix + '-' + index;
-          const childHtml = $(`
-            <div id="${childPrefix}-container" aria-hidden="false">
-              <input type="hidden" id="${childPrefix}-deleted" name="${childPrefix}-deleted" value="">
-              <input type="hidden" id="${childPrefix}-order" name="${childPrefix}-order" value="${index}">
-              <div>
-                <div class="c-sf-container__block-container">
-                  <div class="c-sf-block">
-                    <div class="c-sf-block__header">
-                      <span class="c-sf-block__header__icon">
-                        <i class="icon icon-${self.childBlock.meta.icon}"></i>
-                      </span>
-                      <h3 class="c-sf-block__header__title"></h3>
-                      <div class="c-sf-block__actions">
-                        <span class="c-sf-block__type"></span>
-                        <button type="button" id="${childPrefix}-moveup" class="c-sf-block__actions__single"
-                            title="{% trans 'Move up' %}">
-                          <i class="icon icon-arrow-up" aria-hidden="true"></i>
-                        </button>
-                        <button type="button" id="${childPrefix}-movedown" class="c-sf-block__actions__single"
-                            title="{% trans 'Move down' %}">
-                          <i class="icon icon-arrow-down" aria-hidden="true"></i>
-                        </button>
-                        <button type="button" id="${childPrefix}-delete" class="c-sf-block__actions__single"
-                            title="{% trans 'Delete' %}">
-                          <i class="icon icon-bin" aria-hidden="true"></i>
-                        </button>
-                      </div>
-                    </div>
-                    <div class="c-sf-block__content" aria-hidden="false">
-                      <div class="c-sf-block__content-inner">
-                        <div data-streamfield-block></div>
-                      </div>
-                    </div>
-                  </div>
+  append(value) {
+    const index = this.childBlocks.length;
+    const childPrefix = this.prefix + '-' + index;
+    const childHtml = $(`
+      <div id="${childPrefix}-container" aria-hidden="false">
+        <input type="hidden" id="${childPrefix}-deleted" name="${childPrefix}-deleted" value="">
+        <input type="hidden" id="${childPrefix}-order" name="${childPrefix}-order" value="${index}">
+        <div>
+          <div class="c-sf-container__block-container">
+            <div class="c-sf-block">
+              <div class="c-sf-block__header">
+                <span class="c-sf-block__header__icon">
+                  <i class="icon icon-${this.blockDef.childBlockDef.meta.icon}"></i>
+                </span>
+                <h3 class="c-sf-block__header__title"></h3>
+                <div class="c-sf-block__actions">
+                  <span class="c-sf-block__type"></span>
+                  <button type="button" id="${childPrefix}-moveup" class="c-sf-block__actions__single"
+                      title="{% trans 'Move up' %}">
+                    <i class="icon icon-arrow-up" aria-hidden="true"></i>
+                  </button>
+                  <button type="button" id="${childPrefix}-movedown" class="c-sf-block__actions__single"
+                      title="{% trans 'Move down' %}">
+                    <i class="icon icon-arrow-down" aria-hidden="true"></i>
+                  </button>
+                  <button type="button" id="${childPrefix}-delete" class="c-sf-block__actions__single"
+                      title="{% trans 'Delete' %}">
+                    <i class="icon icon-bin" aria-hidden="true"></i>
+                  </button>
+                </div>
+              </div>
+              <div class="c-sf-block__content" aria-hidden="false">
+                <div class="c-sf-block__content-inner">
+                  <div data-streamfield-block></div>
                 </div>
               </div>
             </div>
-          `);
-          const childDom = $(childHtml);
-          listContainer.append(childDom);
-          const childBlockElement = childDom.find('[data-streamfield-block]').get(0);
-          const boundBlock = self.childBlock.render(childBlockElement, childPrefix + '-value');
-          boundBlock.setState(val);
-          boundBlocks.push(boundBlock);
-        });
-      },
-      getState() {
-        return boundBlocks.map((boundBlock) => boundBlock.getState());
-      },
-      getValue() {
-        return boundBlocks.map((boundBlock) => boundBlock.getValue());
-      },
-    };
+          </div>
+        </div>
+      </div>
+    `);
+
+    const childDom = $(childHtml);
+    this.listContainer.append(childDom);
+    const childBlockElement = childDom.find('[data-streamfield-block]').get(0);
+    const childBlock = this.blockDef.childBlockDef.render(childBlockElement, childPrefix + '-value');
+    childBlock.setState(value);
+    this.childBlocks.push(childBlock);
+    this.countInput.val(this.childBlocks.length);
+  }
+
+  setState(values) {
+    this.clear();
+    values.forEach(val => {
+      this.append(val);
+    });
+  }
+
+  getState() {
+    return this.childBlocks.map((block) => block.getState());
+  }
+
+  getValue() {
+    return this.childBlocks.map((block) => block.getValue());
   }
 }
-window.telepath.register('wagtail.blocks.ListBlock', ListBlock);
 
-
-class StreamBlock {
-  constructor(name, childBlocks, meta) {
+class ListBlockDefinition {
+  constructor(name, childBlockDef, meta) {
     this.name = name;
-    this.childBlocks = childBlocks.map((child) => window.telepath.unpack(child));
-    this.childBlocksByName = {};
-    for (let i = 0; i < this.childBlocks.length; i++) {
-      const block = this.childBlocks[i];
-      this.childBlocksByName[block.name] = block;
-    }
+    this.childBlockDef = window.telepath.unpack(childBlockDef);
     this.meta = meta;
   }
 
   render(placeholder, prefix) {
+    return new ListBlock(this, placeholder, prefix);
+  }
+}
+window.telepath.register('wagtail.blocks.ListBlock', ListBlockDefinition);
+
+
+class StreamBlock {
+  constructor(blockDef, placeholder, prefix) {
+    this.blockDef = blockDef;
+    this.type = blockDef.name;
+    this.prefix = prefix;
+
     const html = $(`
-      <div class="c-sf-container ${this.meta.classname || ''}">
+      <div class="c-sf-container ${this.blockDef.meta.classname || ''}">
         <input type="hidden" name="${prefix}-count" data-streamfield-stream-count value="0">
         <div data-streamfield-stream-container></div>
       </div>
     `);
     const dom = $(html);
     $(placeholder).replaceWith(dom);
-    let boundBlocks = [];
-    const countInput = dom.find('[data-streamfield-stream-count]');
-    const streamContainer = dom.find('[data-streamfield-stream-container]');
 
-    const self = this;
+    this.childBlocks = [];
+    this.countInput = dom.find('[data-streamfield-stream-count]');
+    this.streamContainer = dom.find('[data-streamfield-stream-container]');
+  }
 
-    return {
-      type: this.name,
-      setState(values) {
-        countInput.val(values.length);
-        streamContainer.empty();
-        boundBlocks = [];
-        for (let index = 0; index < values.length; index++) {
-          const blockData = values[index];
-          const blockType = blockData.type;
-          const block = self.childBlocksByName[blockType];
+  clear() {
+    this.countInput.val(0);
+    this.streamContainer.empty();
+    this.childBlocks = [];
+  }
 
-          const childPrefix = prefix + '-' + index;
-          const childHtml = `
-            <div aria-hidden="false">
-              <input type="hidden" name="${childPrefix}-deleted" value="">
-              <input type="hidden" name="${childPrefix}-order" value="${index}">
-              <input type="hidden" name="${childPrefix}-type" value="${blockType}">
-              <input type="hidden" name="${childPrefix}-id" value="${blockData.id || ''}">
+  append(blockData) {
+    const blockType = blockData.type;
+    const blockDef = this.blockDef.childBlockDefsByName[blockType];
 
-              <div>
-                <div class="c-sf-container__block-container">
-                  <div class="c-sf-block">
-                    <div class="c-sf-block__header">
-                      <span class="c-sf-block__header__icon">
-                        <i class="icon icon-${block.meta.icon}"></i>
-                      </span>
-                      <h3 class="c-sf-block__header__title"></h3>
-                      <div class="c-sf-block__actions">
-                        <span class="c-sf-block__type">${block.meta.label}</span>
-                        <button type="button" class="c-sf-block__actions__single" title="{% trans 'Move up' %}">
-                          <i class="icon icon-arrow-up" aria-hidden="true"></i>
-                        </button>
-                        <button type="button" class="c-sf-block__actions__single" title="{% trans 'Move down' %}">
-                          <i class="icon icon-arrow-down" aria-hidden="true"></i>
-                        </button>
-                        <button type="button" class="c-sf-block__actions__single" title="{% trans 'Delete' %}">
-                          <i class="icon icon-bin" aria-hidden="true"></i>
-                        </button>
-                      </div>
-                    </div>
-                    <div class="c-sf-block__content" aria-hidden="false">
-                      <div class="c-sf-block__content-inner">
-                        <div data-streamfield-block></div>
-                      </div>
-                    </div>
-                  </div>
+    const index = this.childBlocks.length;
+    const childPrefix = this.prefix + '-' + index;
+    const childHtml = $(`
+      <div aria-hidden="false">
+        <input type="hidden" name="${childPrefix}-deleted" value="">
+        <input type="hidden" name="${childPrefix}-order" value="${index}">
+        <input type="hidden" name="${childPrefix}-type" value="${blockType}">
+        <input type="hidden" name="${childPrefix}-id" value="${blockData.id || ''}">
+
+        <div>
+          <div class="c-sf-container__block-container">
+            <div class="c-sf-block">
+              <div class="c-sf-block__header">
+                <span class="c-sf-block__header__icon">
+                  <i class="icon icon-${blockDef.meta.icon}"></i>
+                </span>
+                <h3 class="c-sf-block__header__title"></h3>
+                <div class="c-sf-block__actions">
+                  <span class="c-sf-block__type">${blockDef.meta.label}</span>
+                  <button type="button" class="c-sf-block__actions__single" title="{% trans 'Move up' %}">
+                    <i class="icon icon-arrow-up" aria-hidden="true"></i>
+                  </button>
+                  <button type="button" class="c-sf-block__actions__single" title="{% trans 'Move down' %}">
+                    <i class="icon icon-arrow-down" aria-hidden="true"></i>
+                  </button>
+                  <button type="button" class="c-sf-block__actions__single" title="{% trans 'Delete' %}">
+                    <i class="icon icon-bin" aria-hidden="true"></i>
+                  </button>
+                </div>
+              </div>
+              <div class="c-sf-block__content" aria-hidden="false">
+                <div class="c-sf-block__content-inner">
+                  <div data-streamfield-block></div>
                 </div>
               </div>
             </div>
-          `;
-          const childDom = $(childHtml);
-          streamContainer.append(childDom);
-          const childBlockElement = childDom.find('[data-streamfield-block]').get(0);
-          const boundBlock = block.render(childBlockElement, childPrefix + '-value');
-          boundBlock.setState(blockData.value);
-          boundBlocks.push(boundBlock);
-        }
-      },
-      getState() {
-        return boundBlocks.map((boundBlock) => ({
-          type: boundBlock.type,
-          val: boundBlock.getState(),
-          id: null, /* TODO: add this */
-        }));
-      },
-      getValue() {
-        return boundBlocks.map((boundBlock) => ({
-          type: boundBlock.type,
-          val: boundBlock.getValue(),
-          id: null, /* TODO: add this */
-        }));
-      },
-    };
+          </div>
+        </div>
+      </div>
+    `);
+
+    const childDom = $(childHtml);
+    this.streamContainer.append(childDom);
+    const childBlockElement = childDom.find('[data-streamfield-block]').get(0);
+    const childBlock = blockDef.render(childBlockElement, childPrefix + '-value');
+    childBlock.setState(blockData.value);
+    this.childBlocks.push(childBlock);
+    this.countInput.val(this.childBlocks.length);
+  }
+
+  setState(values) {
+    this.clear();
+    values.forEach(val => {
+      this.append(val);
+    });
+  }
+
+  getState() {
+    return this.childBlocks.map(block => ({
+      type: block.type,
+      val: block.getState(),
+      id: null, /* TODO: add this */
+    }));
+  }
+
+  getValue() {
+    return this.childBlocks.map(block => ({
+      type: block.type,
+      val: block.getValue(),
+      id: null, /* TODO: add this */
+    }));
   }
 }
-window.telepath.register('wagtail.blocks.StreamBlock', StreamBlock);
+
+class StreamBlockDefinition {
+  constructor(name, childBlockDefs, meta) {
+    this.name = name;
+    this.childBlockDefs = childBlockDefs.map((child) => window.telepath.unpack(child));
+    this.childBlockDefsByName = {};
+    for (let i = 0; i < this.childBlockDefs.length; i++) {
+      const blockDef = this.childBlockDefs[i];
+      this.childBlockDefsByName[blockDef.name] = blockDef;
+    }
+    this.meta = meta;
+  }
+
+  render(placeholder, prefix) {
+    return new StreamBlock(this, placeholder, prefix);
+  }
+}
+window.telepath.register('wagtail.blocks.StreamBlock', StreamBlockDefinition);

--- a/client/src/entrypoints/admin/telepath/blocks.js
+++ b/client/src/entrypoints/admin/telepath/blocks.js
@@ -1,322 +1,325 @@
-/* eslint-disable indent, vars-on-top, no-warning-comments, max-len */
+/* eslint-disable no-warning-comments */
 
 /* global $ */
 
 function initBlockWidget(id) {
-    /*
-    Initialises the top-level element of a BlockWidget
-    (i.e. the form widget for a StreamField).
-    Receives the ID of a DOM element with the attributes:
-        data-block: JSON-encoded block definition to be passed to telepath.unpack
-            to obtain a Javascript representation of the block
-            (i.e. an instance of one of the Block classes below)
-        data-value: JSON-encoded value for this block
-    */
+  /*
+  Initialises the top-level element of a BlockWidget
+  (i.e. the form widget for a StreamField).
+  Receives the ID of a DOM element with the attributes:
+    data-block: JSON-encoded block definition to be passed to telepath.unpack
+      to obtain a Javascript representation of the block
+      (i.e. an instance of one of the Block classes below)
+    data-value: JSON-encoded value for this block
+  */
 
-    var body = document.getElementById(id);
+  const body = document.getElementById(id);
 
-    // unpack the block definition and value
-    var blockDefData = JSON.parse(body.dataset.block);
-    var blockDef = window.telepath.unpack(blockDefData);
-    var blockValue = JSON.parse(body.dataset.value);
+  // unpack the block definition and value
+  const blockDefData = JSON.parse(body.dataset.block);
+  const blockDef = window.telepath.unpack(blockDefData);
+  const blockValue = JSON.parse(body.dataset.value);
 
-    // replace the 'body' element with the unpopulated HTML structure for the block
-    var block = blockDef.render(body, id);
-    // populate the block HTML with the value
-    block.setState(blockValue);
+  // replace the 'body' element with the unpopulated HTML structure for the block
+  const block = blockDef.render(body, id);
+  // populate the block HTML with the value
+  block.setState(blockValue);
 }
 window.initBlockWidget = initBlockWidget;
 
 class FieldBlock {
-    constructor(name, widget, meta) {
-        this.name = name;
-        this.widget = window.telepath.unpack(widget);
-        this.meta = meta;
-    }
+  constructor(name, widget, meta) {
+    this.name = name;
+    this.widget = window.telepath.unpack(widget);
+    this.meta = meta;
+  }
 
-    render(placeholder, prefix) {
-        var html = $(`
-            <div>
-                <div class="field-content">
-                    <div class="input">
-                        <div data-streamfield-widget></div>
-                        <span></span>
-                    </div>
-                </div>
-            </div>
-        `);
-        var dom = $(html);
-        $(placeholder).replaceWith(dom);
-        var widgetElement = dom.find('[data-streamfield-widget]').get(0);
-        var boundWidget = this.widget.render(widgetElement, prefix, prefix);
-        return {
-            type: this.name,
-            setState(state) {
-                boundWidget.setState(state);
-            },
-            getState() {
-                boundWidget.getState();
-            },
-            getValue() {
-                boundWidget.getValue();
-            },
-        };
-    }
+  render(placeholder, prefix) {
+    const html = $(`
+      <div>
+        <div class="field-content">
+          <div class="input">
+            <div data-streamfield-widget></div>
+            <span></span>
+          </div>
+        </div>
+      </div>
+    `);
+    const dom = $(html);
+    $(placeholder).replaceWith(dom);
+    const widgetElement = dom.find('[data-streamfield-widget]').get(0);
+    const boundWidget = this.widget.render(widgetElement, prefix, prefix);
+    return {
+      type: this.name,
+      setState(state) {
+        boundWidget.setState(state);
+      },
+      getState() {
+        boundWidget.getState();
+      },
+      getValue() {
+        boundWidget.getValue();
+      },
+    };
+  }
 }
 window.telepath.register('wagtail.blocks.FieldBlock', FieldBlock);
 
 
 class StructBlock {
-    constructor(name, childBlocks, meta) {
-        this.name = name;
-        this.childBlocks = childBlocks.map((child) => window.telepath.unpack(child));
-        this.meta = meta;
-    }
+  constructor(name, childBlocks, meta) {
+    this.name = name;
+    this.childBlocks = childBlocks.map((child) => window.telepath.unpack(child));
+    this.meta = meta;
+  }
 
-    render(placeholder, prefix) {
-        var html = $(`
-            <div class="${this.meta.classname || ''}">
-            </div>
-        `);
-        var dom = $(html);
-        $(placeholder).replaceWith(dom);
+  render(placeholder, prefix) {
+    const html = $(`
+      <div class="${this.meta.classname || ''}">
+      </div>
+    `);
+    const dom = $(html);
+    $(placeholder).replaceWith(dom);
 
-        var boundBlocks = {};
-        this.childBlocks.forEach(childBlock => {
-            var childHtml = $(`
-                <div class="field">
-                    <label class="field__label">${childBlock.meta.label}</label>
-                    <div data-streamfield-block></div>
-                </div>
-            `);
-            var childDom = $(childHtml);
-            dom.append(childDom);
-            var childBlockElement = childDom.find('[data-streamfield-block]').get(0);
-            var boundBlock = childBlock.render(childBlockElement, prefix + '-' + childBlock.name);
+    const boundBlocks = {};
+    this.childBlocks.forEach(childBlock => {
+      const childHtml = $(`
+        <div class="field">
+          <label class="field__label">${childBlock.meta.label}</label>
+          <div data-streamfield-block></div>
+        </div>
+      `);
+      const childDom = $(childHtml);
+      dom.append(childDom);
+      const childBlockElement = childDom.find('[data-streamfield-block]').get(0);
+      const boundBlock = childBlock.render(childBlockElement, prefix + '-' + childBlock.name);
 
-            boundBlocks[childBlock.name] = boundBlock;
-        });
+      boundBlocks[childBlock.name] = boundBlock;
+    });
 
-        return {
-            type: this.name,
-            setState(state) {
-                // eslint-disable-next-line guard-for-in, no-restricted-syntax, no-native-reassign
-                for (name in state) {
-                    boundBlocks[name].setState(state[name]);
-                }
-            },
-            getState() {
-                var state = {};
-                // eslint-disable-next-line guard-for-in, no-restricted-syntax, no-native-reassign
-                for (name in boundBlocks) {
-                    state[name] = boundBlocks[name].getState();
-                }
-                return state;
-            },
-            getValue() {
-                var value = {};
-                // eslint-disable-next-line guard-for-in, no-restricted-syntax, no-native-reassign
-                for (name in boundBlocks) {
-                    value[name] = boundBlocks[name].getValue();
-                }
-                return value;
-            },
-        };
-    }
+    return {
+      type: this.name,
+      setState(state) {
+        // eslint-disable-next-line guard-for-in, no-restricted-syntax
+        for (const name in state) {
+          boundBlocks[name].setState(state[name]);
+        }
+      },
+      getState() {
+        const state = {};
+        // eslint-disable-next-line guard-for-in, no-restricted-syntax
+        for (const name in boundBlocks) {
+          state[name] = boundBlocks[name].getState();
+        }
+        return state;
+      },
+      getValue() {
+        const value = {};
+        // eslint-disable-next-line guard-for-in, no-restricted-syntax
+        for (const name in boundBlocks) {
+          value[name] = boundBlocks[name].getValue();
+        }
+        return value;
+      },
+    };
+  }
 }
 window.telepath.register('wagtail.blocks.StructBlock', StructBlock);
 
 
 class ListBlock {
-    constructor(name, childBlock, meta) {
-        this.name = name;
-        this.childBlock = window.telepath.unpack(childBlock);
-        this.meta = meta;
-    }
+  constructor(name, childBlock, meta) {
+    this.name = name;
+    this.childBlock = window.telepath.unpack(childBlock);
+    this.meta = meta;
+  }
 
-    render(placeholder, prefix) {
-        var html = $(`
-            <div class="c-sf-container ${this.meta.classname || ''}">
-                <input type="hidden" name="${prefix}-count" data-streamfield-list-count value="0">
+  render(placeholder, prefix) {
+    const html = $(`
+      <div class="c-sf-container ${this.meta.classname || ''}">
+        <input type="hidden" name="${prefix}-count" data-streamfield-list-count value="0">
 
-                <div data-streamfield-list-container></div>
-                <button type="button" title="Add" data-streamfield-list-add class="c-sf-add-button c-sf-add-button--visible"><i aria-hidden="true">+</i></button>
+        <div data-streamfield-list-container></div>
+        <button type="button" title="Add" data-streamfield-list-add class="c-sf-add-button c-sf-add-button--visible">
+          <i aria-hidden="true">+</i>
+        </button>
+      </div>
+    `);
+    const dom = $(html);
+    $(placeholder).replaceWith(dom);
+
+    let boundBlocks = [];
+    const countInput = dom.find('[data-streamfield-list-count]');
+    const listContainer = dom.find('[data-streamfield-list-container]');
+
+    const self = this;
+
+    return {
+      type: this.name,
+      setState(values) {
+        countInput.val(values.length);
+        boundBlocks = [];
+        listContainer.empty();
+        values.forEach((val, index) => {
+          const childPrefix = prefix + '-' + index;
+          const childHtml = $(`
+            <div id="${childPrefix}-container" aria-hidden="false">
+              <input type="hidden" id="${childPrefix}-deleted" name="${childPrefix}-deleted" value="">
+              <input type="hidden" id="${childPrefix}-order" name="${childPrefix}-order" value="${index}">
+              <div>
+                <div class="c-sf-container__block-container">
+                  <div class="c-sf-block">
+                    <div class="c-sf-block__header">
+                      <span class="c-sf-block__header__icon">
+                        <i class="icon icon-${self.childBlock.meta.icon}"></i>
+                      </span>
+                      <h3 class="c-sf-block__header__title"></h3>
+                      <div class="c-sf-block__actions">
+                        <span class="c-sf-block__type"></span>
+                        <button type="button" id="${childPrefix}-moveup" class="c-sf-block__actions__single"
+                            title="{% trans 'Move up' %}">
+                          <i class="icon icon-arrow-up" aria-hidden="true"></i>
+                        </button>
+                        <button type="button" id="${childPrefix}-movedown" class="c-sf-block__actions__single"
+                            title="{% trans 'Move down' %}">
+                          <i class="icon icon-arrow-down" aria-hidden="true"></i>
+                        </button>
+                        <button type="button" id="${childPrefix}-delete" class="c-sf-block__actions__single"
+                            title="{% trans 'Delete' %}">
+                          <i class="icon icon-bin" aria-hidden="true"></i>
+                        </button>
+                      </div>
+                    </div>
+                    <div class="c-sf-block__content" aria-hidden="false">
+                      <div class="c-sf-block__content-inner">
+                        <div data-streamfield-block></div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
             </div>
-        `);
-        var dom = $(html);
-        $(placeholder).replaceWith(dom);
-
-        var boundBlocks = [];
-        var countInput = dom.find('[data-streamfield-list-count]');
-        var listContainer = dom.find('[data-streamfield-list-container]');
-
-        var self = this;
-
-        return {
-            type: this.name,
-            setState(values) {
-                countInput.val(values.length);
-                boundBlocks = [];
-                listContainer.empty();
-                values.forEach((val, index) => {
-                    var childPrefix = prefix + '-' + index;
-                    var childHtml = $(`
-                        <div id="${childPrefix}-container" aria-hidden="false">
-                            <input type="hidden" id="${childPrefix}-deleted" name="${childPrefix}-deleted" value="">
-                            <input type="hidden" id="${childPrefix}-order" name="${childPrefix}-order" value="${index}">
-                            <div>
-                                <div class="c-sf-container__block-container">
-                                    <div class="c-sf-block">
-                                        <div class="c-sf-block__header">
-                                            <span class="c-sf-block__header__icon">
-                                                <i class="icon icon-${self.childBlock.meta.icon}"></i>
-                                            </span>
-                                            <h3 class="c-sf-block__header__title"></h3>
-                                            <div class="c-sf-block__actions">
-                                                <span class="c-sf-block__type"></span>
-                                                <button type="button" id="${childPrefix}-moveup" class="c-sf-block__actions__single" title="{% trans 'Move up' %}">
-                                                <i class="icon icon-arrow-up" aria-hidden="true"></i>
-                                            </button>
-                                            <button type="button" id="${childPrefix}-movedown" class="c-sf-block__actions__single" title="{% trans 'Move down' %}">
-                                                <i class="icon icon-arrow-down" aria-hidden="true"></i>
-                                            </button>
-                                            <button type="button" id="${childPrefix}-delete" class="c-sf-block__actions__single" title="{% trans 'Delete' %}">
-                                                <i class="icon icon-bin" aria-hidden="true"></i>
-                                            </button>
-
-                                            </div>
-                                        </div>
-                                        <div class="c-sf-block__content" aria-hidden="false">
-                                            <div class="c-sf-block__content-inner">
-                                                <div data-streamfield-block></div>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    `);
-                    var childDom = $(childHtml);
-                    listContainer.append(childDom);
-                    var childBlockElement = childDom.find('[data-streamfield-block]').get(0);
-                    var boundBlock = self.childBlock.render(childBlockElement, childPrefix + '-value');
-                    boundBlock.setState(val);
-                    boundBlocks.push(boundBlock);
-                });
-            },
-            getState() {
-                return boundBlocks.map((boundBlock) => boundBlock.getState());
-            },
-            getValue() {
-                return boundBlocks.map((boundBlock) => boundBlock.getValue());
-            },
-        };
-    }
+          `);
+          const childDom = $(childHtml);
+          listContainer.append(childDom);
+          const childBlockElement = childDom.find('[data-streamfield-block]').get(0);
+          const boundBlock = self.childBlock.render(childBlockElement, childPrefix + '-value');
+          boundBlock.setState(val);
+          boundBlocks.push(boundBlock);
+        });
+      },
+      getState() {
+        return boundBlocks.map((boundBlock) => boundBlock.getState());
+      },
+      getValue() {
+        return boundBlocks.map((boundBlock) => boundBlock.getValue());
+      },
+    };
+  }
 }
 window.telepath.register('wagtail.blocks.ListBlock', ListBlock);
 
 
 class StreamBlock {
-    constructor(name, childBlocks, meta) {
-        this.name = name;
-        this.childBlocks = childBlocks.map((child) => window.telepath.unpack(child));
-        this.childBlocksByName = {};
-        for (var i = 0; i < this.childBlocks.length; i++) {
-            var block = this.childBlocks[i];
-            this.childBlocksByName[block.name] = block;
-        }
-        this.meta = meta;
+  constructor(name, childBlocks, meta) {
+    this.name = name;
+    this.childBlocks = childBlocks.map((child) => window.telepath.unpack(child));
+    this.childBlocksByName = {};
+    for (let i = 0; i < this.childBlocks.length; i++) {
+      const block = this.childBlocks[i];
+      this.childBlocksByName[block.name] = block;
     }
+    this.meta = meta;
+  }
 
-    render(placeholder, prefix) {
-        var html = $(`
-            <div class="c-sf-container ${this.meta.classname || ''}">
-                <input type="hidden" name="${prefix}-count" data-streamfield-stream-count value="0">
-                <div data-streamfield-stream-container></div>
+  render(placeholder, prefix) {
+    const html = $(`
+      <div class="c-sf-container ${this.meta.classname || ''}">
+        <input type="hidden" name="${prefix}-count" data-streamfield-stream-count value="0">
+        <div data-streamfield-stream-container></div>
+      </div>
+    `);
+    const dom = $(html);
+    $(placeholder).replaceWith(dom);
+    let boundBlocks = [];
+    const countInput = dom.find('[data-streamfield-stream-count]');
+    const streamContainer = dom.find('[data-streamfield-stream-container]');
+
+    const self = this;
+
+    return {
+      type: this.name,
+      setState(values) {
+        countInput.val(values.length);
+        streamContainer.empty();
+        boundBlocks = [];
+        for (let index = 0; index < values.length; index++) {
+          const blockData = values[index];
+          const blockType = blockData.type;
+          const block = self.childBlocksByName[blockType];
+
+          const childPrefix = prefix + '-' + index;
+          const childHtml = `
+            <div aria-hidden="false">
+              <input type="hidden" name="${childPrefix}-deleted" value="">
+              <input type="hidden" name="${childPrefix}-order" value="${index}">
+              <input type="hidden" name="${childPrefix}-type" value="${blockType}">
+              <input type="hidden" name="${childPrefix}-id" value="${blockData.id || ''}">
+
+              <div>
+                <div class="c-sf-container__block-container">
+                  <div class="c-sf-block">
+                    <div class="c-sf-block__header">
+                      <span class="c-sf-block__header__icon">
+                        <i class="icon icon-${block.meta.icon}"></i>
+                      </span>
+                      <h3 class="c-sf-block__header__title"></h3>
+                      <div class="c-sf-block__actions">
+                        <span class="c-sf-block__type">${block.meta.label}</span>
+                        <button type="button" class="c-sf-block__actions__single" title="{% trans 'Move up' %}">
+                          <i class="icon icon-arrow-up" aria-hidden="true"></i>
+                        </button>
+                        <button type="button" class="c-sf-block__actions__single" title="{% trans 'Move down' %}">
+                          <i class="icon icon-arrow-down" aria-hidden="true"></i>
+                        </button>
+                        <button type="button" class="c-sf-block__actions__single" title="{% trans 'Delete' %}">
+                          <i class="icon icon-bin" aria-hidden="true"></i>
+                        </button>
+                      </div>
+                    </div>
+                    <div class="c-sf-block__content" aria-hidden="false">
+                      <div class="c-sf-block__content-inner">
+                        <div data-streamfield-block></div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
             </div>
-        `);
-        var dom = $(html);
-        $(placeholder).replaceWith(dom);
-        var boundBlocks = [];
-        var countInput = dom.find('[data-streamfield-stream-count]');
-        var streamContainer = dom.find('[data-streamfield-stream-container]');
-
-        var self = this;
-
-        return {
-            type: this.name,
-            setState(values) {
-                countInput.val(values.length);
-                streamContainer.empty();
-                boundBlocks = [];
-                for (var index = 0; index < values.length; index++) {
-                    var blockData = values[index];
-                    var blockType = blockData.type;
-                    var block = self.childBlocksByName[blockType];
-
-                    var childPrefix = prefix + '-' + index;
-                    var childHtml = `
-                        <div aria-hidden="false">
-                            <input type="hidden" name="${childPrefix}-deleted" value="">
-                            <input type="hidden" name="${childPrefix}-order" value="${index}">
-                            <input type="hidden" name="${childPrefix}-type" value="${blockType}">
-                            <input type="hidden" name="${childPrefix}-id" value="${blockData.id || ''}">
-
-                            <div>
-                                <div class="c-sf-container__block-container">
-                                    <div class="c-sf-block">
-                                        <div class="c-sf-block__header">
-                                            <span class="c-sf-block__header__icon">
-                                                <i class="icon icon-${block.meta.icon}"></i>
-                                            </span>
-                                            <h3 class="c-sf-block__header__title"></h3>
-                                            <div class="c-sf-block__actions">
-                                                <span class="c-sf-block__type">${block.meta.label}</span>
-                                                <button type="button" class="c-sf-block__actions__single" title="{% trans 'Move up' %}">
-                                                    <i class="icon icon-arrow-up" aria-hidden="true"></i>
-                                                </button>
-                                                <button type="button" class="c-sf-block__actions__single" title="{% trans 'Move down' %}">
-                                                    <i class="icon icon-arrow-down" aria-hidden="true"></i>
-                                                </button>
-                                                <button type="button" class="c-sf-block__actions__single" title="{% trans 'Delete' %}">
-                                                    <i class="icon icon-bin" aria-hidden="true"></i>
-                                                </button>
-
-                                            </div>
-                                        </div>
-                                        <div class="c-sf-block__content" aria-hidden="false">
-                                            <div class="c-sf-block__content-inner">
-                                                <div data-streamfield-block></div>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    `;
-                    var childDom = $(childHtml);
-                    streamContainer.append(childDom);
-                    var childBlockElement = childDom.find('[data-streamfield-block]').get(0);
-                    var boundBlock = block.render(childBlockElement, childPrefix + '-value');
-                    boundBlock.setState(blockData.value);
-                    boundBlocks.push(boundBlock);
-                }
-            },
-            getState() {
-                return boundBlocks.map((boundBlock) => ({
-                        type: boundBlock.type,
-                        val: boundBlock.getState(),
-                        id: null, /* TODO: add this */
-                    }));
-            },
-            getValue() {
-                return boundBlocks.map((boundBlock) => ({
-                        type: boundBlock.type,
-                        val: boundBlock.getValue(),
-                        id: null, /* TODO: add this */
-                    }));
-            },
-        };
-    }
+          `;
+          const childDom = $(childHtml);
+          streamContainer.append(childDom);
+          const childBlockElement = childDom.find('[data-streamfield-block]').get(0);
+          const boundBlock = block.render(childBlockElement, childPrefix + '-value');
+          boundBlock.setState(blockData.value);
+          boundBlocks.push(boundBlock);
+        }
+      },
+      getState() {
+        return boundBlocks.map((boundBlock) => ({
+          type: boundBlock.type,
+          val: boundBlock.getState(),
+          id: null, /* TODO: add this */
+        }));
+      },
+      getValue() {
+        return boundBlocks.map((boundBlock) => ({
+          type: boundBlock.type,
+          val: boundBlock.getValue(),
+          id: null, /* TODO: add this */
+        }));
+      },
+    };
+  }
 }
 window.telepath.register('wagtail.blocks.StreamBlock', StreamBlock);

--- a/client/src/entrypoints/admin/telepath/widgets.js
+++ b/client/src/entrypoints/admin/telepath/widgets.js
@@ -80,3 +80,13 @@ class PageChooser {
     }
 }
 window.telepath.register('wagtail.widgets.PageChooser', PageChooser);
+
+
+class AdminAutoHeightTextInput extends Widget {
+    render(placeholder, name, id, initialState) {
+        const boundWidget = super.render(placeholder, name, id, initialState);
+        window.autosize($(id));
+        return boundWidget;
+    }
+}
+window.telepath.register('wagtail.widgets.AdminAutoHeightTextInput', AdminAutoHeightTextInput);

--- a/client/src/entrypoints/admin/telepath/widgets.js
+++ b/client/src/entrypoints/admin/telepath/widgets.js
@@ -90,3 +90,35 @@ class AdminAutoHeightTextInput extends Widget {
     }
 }
 window.telepath.register('wagtail.widgets.AdminAutoHeightTextInput', AdminAutoHeightTextInput);
+
+
+class DraftailRichTextArea {
+    constructor(options) {
+        this.options = options;
+    }
+
+    render(container, name, id, initialState) {
+        const options = this.options;
+        const input = document.createElement('input');
+        input.type = 'hidden';
+        input.id = id;
+        input.name = name;
+        input.value = initialState;
+        container.appendChild(input);
+        // eslint-disable-next-line no-undef
+        draftail.initEditor('#' + id, options, document.currentScript);
+
+        return {
+            getValue() {
+                return input.value;
+            },
+            getState() {
+                return input.value;
+            },
+            setState() {
+                throw new Error('DraftailRichTextArea.setState is not implemented');
+            }
+        };
+    }
+}
+window.telepath.register('wagtail.widgets.DraftailRichTextArea', DraftailRichTextArea);

--- a/client/src/entrypoints/admin/telepath/widgets.js
+++ b/client/src/entrypoints/admin/telepath/widgets.js
@@ -3,9 +3,10 @@
 /* global $ */
 
 class BoundWidget {
-    constructor(element, name) {
+    constructor(element, name, initialState) {
         var selector = ':input[name="' + name + '"]';
         this.input = element.find(selector).addBack(selector);  // find, including element itself
+        this.setState(initialState);
     }
     getValue() {
         return this.input.val();
@@ -26,22 +27,23 @@ class Widget {
 
     boundWidgetClass = BoundWidget;
 
-    render(placeholder, name, id) {
+    render(placeholder, name, id, initialState) {
         var html = this.html.replace(/__NAME__/g, name).replace(/__ID__/g, id);
         var dom = $(html);
         $(placeholder).replaceWith(dom);
         // eslint-disable-next-line new-cap
-        return new this.boundWidgetClass(dom, name);
+        return new this.boundWidgetClass(dom, name, initialState);
     }
 }
 window.telepath.register('wagtail.widgets.Widget', Widget);
 
 
 class BoundRadioSelect {
-    constructor(element, name) {
+    constructor(element, name, initialState) {
         this.element = element;
         this.name = name;
         this.selector = 'input[name="' + name + '"]:checked';
+        this.setState(initialState);
     }
     getValue() {
         return this.element.find(this.selector).val();
@@ -67,13 +69,14 @@ class PageChooser {
         this.config = config;
     }
 
-    render(placeholder, name, id) {
+    render(placeholder, name, id, initialState) {
         var html = this.html.replace(/__NAME__/g, name).replace(/__ID__/g, id);
         var dom = $(html);
         $(placeholder).replaceWith(dom);
         /* the chooser object returned by createPageChooser also serves as the JS widget representation */
         // eslint-disable-next-line no-undef
-        return createPageChooser(id, null, this.config);
+        const chooser = createPageChooser(id, null, this.config);
+        chooser.setState(initialState);
     }
 }
 window.telepath.register('wagtail.widgets.PageChooser', PageChooser);

--- a/wagtail/admin/rich_text/editors/draftail/__init__.py
+++ b/wagtail/admin/rich_text/editors/draftail/__init__.py
@@ -7,6 +7,8 @@ from wagtail.admin.edit_handlers import RichTextFieldPanel
 from wagtail.admin.rich_text.converters.contentstate import ContentstateConverter
 from wagtail.admin.staticfiles import versioned_static
 from wagtail.core.rich_text import features as feature_registry
+from wagtail.core.telepath import register
+from wagtail.core.widget_adapters import WidgetAdapter
 
 
 class DraftailRichTextArea(widgets.HiddenInput):
@@ -79,3 +81,15 @@ class DraftailRichTextArea(widgets.HiddenInput):
             media += plugin.media
 
         return media
+
+
+class DraftailRichTextAreaAdapter(WidgetAdapter):
+    js_constructor = 'wagtail.widgets.DraftailRichTextArea'
+
+    def js_args(self, widget, context):
+        return [
+            widget.options,
+        ]
+
+
+register(DraftailRichTextAreaAdapter(), DraftailRichTextArea)

--- a/wagtail/admin/widgets/auto_height_text.py
+++ b/wagtail/admin/widgets/auto_height_text.py
@@ -1,5 +1,8 @@
 from django.forms import widgets
 
+from wagtail.core.telepath import register
+from wagtail.core.widget_adapters import WidgetAdapter
+
 
 class AdminAutoHeightTextInput(widgets.Textarea):
     template_name = 'wagtailadmin/widgets/auto_height_text_input.html'
@@ -11,3 +14,10 @@ class AdminAutoHeightTextInput(widgets.Textarea):
             default_attrs.update(attrs)
 
         super().__init__(default_attrs)
+
+
+class AdminAutoHeightTextInputAdapter(WidgetAdapter):
+    js_constructor = 'wagtail.widgets.AdminAutoHeightTextInput'
+
+
+register(AdminAutoHeightTextInputAdapter(), AdminAutoHeightTextInput)

--- a/wagtail/core/blocks/field_block.py
+++ b/wagtail/core/blocks/field_block.py
@@ -60,6 +60,9 @@ class FieldBlock(Block):
         # a FieldBlock is required if and only if its underlying form field is required
         return self.field.required
 
+    def get_form_state(self, value):
+        return self.field.widget.format_value(self.value_for_form(value))
+
     class Meta:
         # No icon specified here, because that depends on the purpose that the
         # block is being used for. Feel encouraged to specify an icon in your

--- a/wagtail/core/blocks/field_block.py
+++ b/wagtail/core/blocks/field_block.py
@@ -12,7 +12,7 @@ from django.utils.safestring import mark_safe
 from wagtail.admin.staticfiles import versioned_static
 from wagtail.core.rich_text import RichText, get_text_for_indexing
 from wagtail.core.telepath import Adapter, register
-from wagtail.core.utils import resolve_model_string
+from wagtail.core.utils import camelcase_to_underscore, resolve_model_string
 
 from .base import Block
 
@@ -72,10 +72,23 @@ class FieldBlockAdapter(Adapter):
     js_constructor = 'wagtail.blocks.FieldBlock'
 
     def js_args(self, block, context):
+        classname = [
+            'field',
+            camelcase_to_underscore(block.field.__class__.__name__),
+            'widget-' + camelcase_to_underscore(block.field.widget.__class__.__name__),
+            'fieldname-' + block.name,
+            # TODO: if errors then add 'error'
+        ]
+
         return [
             block.name,
             context.pack(block.field.widget),
-            {'label': block.label, 'required': block.required, 'icon': block.meta.icon},
+            {
+                'label': block.label,
+                'required': block.required,
+                'icon': block.meta.icon,
+                'classname': ' '.join(classname),
+            },
         ]
 
     class Media:

--- a/wagtail/core/telepath.py
+++ b/wagtail/core/telepath.py
@@ -27,9 +27,10 @@ class JSContext:
         if adapter is None:
             raise Exception("don't know how to add object to JS context: %r" % obj)
 
-        self.media += adapter.media
+        self.media += adapter.get_media(obj, self)
         return [adapter.js_constructor, *adapter.js_args(obj, self)]
 
 
 class Adapter(metaclass=MediaDefiningClass):
-    pass
+    def get_media(self, obj, context):
+        return self.media

--- a/wagtail/core/widget_adapters.py
+++ b/wagtail/core/widget_adapters.py
@@ -19,10 +19,11 @@ class WidgetAdapter(Adapter):
             widget.id_for_label('__ID__'),
         ]
 
+    def get_media(self, widget, context):
+        media = super().get_media(widget, context)
+        return media + widget.media
+
     class Media:
-        # FIXME: where does the widget's own media get merged in? Probably here,
-        # but in that case we need this to be a method that receives the object as
-        # a parameter, like js_args
         js = [
             versioned_static('wagtailadmin/js/telepath/widgets.js')
         ]


### PR DESCRIPTION
This PR implements some tweaks to allow standard and rich text blocks to render properly:

 - Implements ``autosize()`` for text input
 - Adds the logic to calculate the default classnames that are usually added to fields
 - Implements ``get_form_state`` for Rich Text Block
 - Widget media is now passed through (allowing draftail to work)