### PR TITLE
Linting Telepath JS

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,6 @@
 {
   "extends": "wagtail",
+  "parser": "babel-eslint",
 
   "env": {
     "jest": true

--- a/client/src/entrypoints/telepath/blocks.js
+++ b/client/src/entrypoints/telepath/blocks.js
@@ -1,4 +1,7 @@
-/* eslint-disable */
+/* eslint-disable indent, vars-on-top, no-warning-comments, max-len */
+
+/* global $ */
+
 function initBlockWidget(id) {
     /*
     Initialises the top-level element of a BlockWidget
@@ -14,7 +17,7 @@ function initBlockWidget(id) {
 
     // unpack the block definition and value
     var blockDefData = JSON.parse(body.dataset.block);
-    var blockDef = telepath.unpack(blockDefData);
+    var blockDef = window.telepath.unpack(blockDefData);
     var blockValue = JSON.parse(body.dataset.value);
 
     // replace the 'body' element with the unpopulated HTML structure for the block
@@ -27,12 +30,12 @@ window.initBlockWidget = initBlockWidget;
 class FieldBlock {
     constructor(name, widget, meta) {
         this.name = name;
-        this.widget = telepath.unpack(widget);
+        this.widget = window.telepath.unpack(widget);
         this.meta = meta;
     }
 
     render(placeholder, prefix) {
-        var html =$(`
+        var html = $(`
             <div>
                 <div class="field-content">
                     <div class="input">
@@ -47,26 +50,26 @@ class FieldBlock {
         var widgetElement = dom.find('[data-streamfield-widget]').get(0);
         var boundWidget = this.widget.render(widgetElement, prefix, prefix);
         return {
-            'type': this.name,
-            'setState': function(state) {
+            type: this.name,
+            setState(state) {
                 boundWidget.setState(state);
             },
-            'getState': function() {
+            getState() {
                 boundWidget.getState();
             },
-            'getValue': function() {
+            getValue() {
                 boundWidget.getValue();
             },
         };
     }
 }
-telepath.register('wagtail.blocks.FieldBlock', FieldBlock);
+window.telepath.register('wagtail.blocks.FieldBlock', FieldBlock);
 
 
 class StructBlock {
     constructor(name, childBlocks, meta) {
         this.name = name;
-        this.childBlocks = childBlocks.map((child) => {return telepath.unpack(child);});
+        this.childBlocks = childBlocks.map((child) => window.telepath.unpack(child));
         this.meta = meta;
     }
 
@@ -90,26 +93,29 @@ class StructBlock {
             dom.append(childDom);
             var childBlockElement = childDom.find('[data-streamfield-block]').get(0);
             var boundBlock = childBlock.render(childBlockElement, prefix + '-' + childBlock.name);
-            
+
             boundBlocks[childBlock.name] = boundBlock;
         });
 
         return {
-            'type': this.name,
-            'setState': function(state) {
+            type: this.name,
+            setState(state) {
+                // eslint-disable-next-line guard-for-in, no-restricted-syntax, no-native-reassign
                 for (name in state) {
                     boundBlocks[name].setState(state[name]);
                 }
             },
-            'getState': function() {
+            getState() {
                 var state = {};
+                // eslint-disable-next-line guard-for-in, no-restricted-syntax, no-native-reassign
                 for (name in boundBlocks) {
                     state[name] = boundBlocks[name].getState();
                 }
                 return state;
             },
-            'getValue': function() {
+            getValue() {
                 var value = {};
+                // eslint-disable-next-line guard-for-in, no-restricted-syntax, no-native-reassign
                 for (name in boundBlocks) {
                     value[name] = boundBlocks[name].getValue();
                 }
@@ -118,13 +124,13 @@ class StructBlock {
         };
     }
 }
-telepath.register('wagtail.blocks.StructBlock', StructBlock);
+window.telepath.register('wagtail.blocks.StructBlock', StructBlock);
 
 
 class ListBlock {
     constructor(name, childBlock, meta) {
         this.name = name;
-        this.childBlock = telepath.unpack(childBlock);
+        this.childBlock = window.telepath.unpack(childBlock);
         this.meta = meta;
     }
 
@@ -143,17 +149,16 @@ class ListBlock {
         var boundBlocks = [];
         var countInput = dom.find('[data-streamfield-list-count]');
         var listContainer = dom.find('[data-streamfield-list-container]');
-        var addButton = dom.find('[data-streamfield-list-add]');
 
         var self = this;
 
         return {
-            'type': this.name,
-            'setState': function(values) {
+            type: this.name,
+            setState(values) {
                 countInput.val(values.length);
                 boundBlocks = [];
                 listContainer.empty();
-                values.forEach(function(val, index) {
+                values.forEach((val, index) => {
                     var childPrefix = prefix + '-' + index;
                     var childHtml = $(`
                         <div id="${childPrefix}-container" aria-hidden="false">
@@ -178,7 +183,7 @@ class ListBlock {
                                             <button type="button" id="${childPrefix}-delete" class="c-sf-block__actions__single" title="{% trans 'Delete' %}">
                                                 <i class="icon icon-bin" aria-hidden="true"></i>
                                             </button>
-                                        
+
                                             </div>
                                         </div>
                                         <div class="c-sf-block__content" aria-hidden="false">
@@ -199,22 +204,22 @@ class ListBlock {
                     boundBlocks.push(boundBlock);
                 });
             },
-            'getState': function() {
-                return boundBlocks.map(function(boundBlock) {return boundBlock.getState()});
+            getState() {
+                return boundBlocks.map((boundBlock) => boundBlock.getState());
             },
-            'getValue': function() {
-                return boundBlocks.map(function(boundBlock) {return boundBlock.getValue()});
+            getValue() {
+                return boundBlocks.map((boundBlock) => boundBlock.getValue());
             },
         };
     }
 }
-telepath.register('wagtail.blocks.ListBlock', ListBlock);
+window.telepath.register('wagtail.blocks.ListBlock', ListBlock);
 
 
 class StreamBlock {
     constructor(name, childBlocks, meta) {
         this.name = name;
-        this.childBlocks = childBlocks.map((child) => {return telepath.unpack(child);});
+        this.childBlocks = childBlocks.map((child) => window.telepath.unpack(child));
         this.childBlocksByName = {};
         for (var i = 0; i < this.childBlocks.length; i++) {
             var block = this.childBlocks[i];
@@ -239,14 +244,14 @@ class StreamBlock {
         var self = this;
 
         return {
-            'type': this.name,
-            'setState': function(values) {
+            type: this.name,
+            setState(values) {
                 countInput.val(values.length);
                 streamContainer.empty();
                 boundBlocks = [];
                 for (var index = 0; index < values.length; index++) {
                     var blockData = values[index];
-                    var blockType = blockData['type']
+                    var blockType = blockData.type;
                     var block = self.childBlocksByName[blockType];
 
                     var childPrefix = prefix + '-' + index;
@@ -255,7 +260,7 @@ class StreamBlock {
                             <input type="hidden" name="${childPrefix}-deleted" value="">
                             <input type="hidden" name="${childPrefix}-order" value="${index}">
                             <input type="hidden" name="${childPrefix}-type" value="${blockType}">
-                            <input type="hidden" name="${childPrefix}-id" value="${blockData['id'] || ''}">
+                            <input type="hidden" name="${childPrefix}-id" value="${blockData.id || ''}">
 
                             <div>
                                 <div class="c-sf-container__block-container">
@@ -276,7 +281,7 @@ class StreamBlock {
                                                 <button type="button" class="c-sf-block__actions__single" title="{% trans 'Delete' %}">
                                                     <i class="icon icon-bin" aria-hidden="true"></i>
                                                 </button>
-                                        
+
                                             </div>
                                         </div>
                                         <div class="c-sf-block__content" aria-hidden="false">
@@ -293,29 +298,25 @@ class StreamBlock {
                     streamContainer.append(childDom);
                     var childBlockElement = childDom.find('[data-streamfield-block]').get(0);
                     var boundBlock = block.render(childBlockElement, childPrefix + '-value');
-                    boundBlock.setState(blockData['value']);
+                    boundBlock.setState(blockData.value);
                     boundBlocks.push(boundBlock);
                 }
             },
-            'getState': function() {
-                return boundBlocks.map(function(boundBlock) {
-                    return {
-                        'type': boundBlock.type,
-                        'val': boundBlock.getState(),
-                        'id': null, /* TODO: add this */
-                    }
-                });
+            getState() {
+                return boundBlocks.map((boundBlock) => ({
+                        type: boundBlock.type,
+                        val: boundBlock.getState(),
+                        id: null, /* TODO: add this */
+                    }));
             },
-            'getValue': function() {
-                return boundBlocks.map(function(boundBlock) {
-                    return {
-                        'type': boundBlock.type,
-                        'val': boundBlock.getValue(),
-                        'id': null, /* TODO: add this */
-                    }
-                });
+            getValue() {
+                return boundBlocks.map((boundBlock) => ({
+                        type: boundBlock.type,
+                        val: boundBlock.getValue(),
+                        id: null, /* TODO: add this */
+                    }));
             },
-        }
+        };
     }
 }
-telepath.register('wagtail.blocks.StreamBlock', StreamBlock);
+window.telepath.register('wagtail.blocks.StreamBlock', StreamBlock);

--- a/client/src/entrypoints/telepath/telepath.js
+++ b/client/src/entrypoints/telepath/telepath.js
@@ -1,10 +1,11 @@
-/* eslint-disable */
+/* eslint-disable indent, vars-on-top, no-warning-comments, max-len */
+
 window.telepath = {
     constructors: {},
-    register: function(name, constructor) {
+    register(name, constructor) {
         this.constructors[name] = constructor;
     },
-    unpack: function(objData) {
+    unpack(objData) {
         var [constructorName, ...args] = objData;
         var constructor = this.constructors[constructorName];
         return new constructor(...args);

--- a/client/src/entrypoints/telepath/widgets.js
+++ b/client/src/entrypoints/telepath/widgets.js
@@ -1,4 +1,7 @@
-/* eslint-disable */
+/* eslint-disable indent, vars-on-top, no-warning-comments, max-len */
+
+/* global $ */
+
 class BoundWidget {
     constructor(element, name) {
         var selector = ':input[name="' + name + '"]';
@@ -21,16 +24,17 @@ class Widget {
         this.idForLabel = idForLabel;
     }
 
-    boundWidgetClass = BoundWidget;
+    static boundWidgetClass = BoundWidget;
 
     render(placeholder, name, id) {
         var html = this.html.replace(/__NAME__/g, name).replace(/__ID__/g, id);
         var dom = $(html);
         $(placeholder).replaceWith(dom);
+        // eslint-disable-next-line new-cap
         return new this.boundWidgetClass(dom, name);
     }
 }
-telepath.register('wagtail.widgets.Widget', Widget);
+window.telepath.register('wagtail.widgets.Widget', Widget);
 
 
 class BoundRadioSelect {
@@ -51,6 +55,6 @@ class BoundRadioSelect {
 }
 
 class RadioSelect extends Widget {
-    boundWidgetClass = BoundRadioSelect;
+    static boundWidgetClass = BoundRadioSelect;
 }
-telepath.register('wagtail.widgets.RadioSelect', RadioSelect);
+window.telepath.register('wagtail.widgets.RadioSelect', RadioSelect);

--- a/package-lock.json
+++ b/package-lock.json
@@ -2172,6 +2172,28 @@
       "integrity": "sha512-5P0QZ6J5xGikH780pghEdbEKijCTrruK9KxtPZCFWUpef0f6GipO+xEZ5GKCb020mmqgbiNO6TcA55CriL784Q==",
       "dev": true
     },
+    "babel-eslint": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.1.0.tgz",
+      "integrity": "sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/parser": "^7.7.0",
+        "@babel/traverse": "^7.7.0",
+        "@babel/types": "^7.7.0",
+        "eslint-visitor-keys": "^1.0.0",
+        "resolve": "^1.12.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+          "dev": true
+        }
+      }
+    },
     "babel-jest": {
       "version": "26.6.0",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-26.6.0.tgz",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@typescript-eslint/parser": "^4.5.0",
     "@wagtail/stylelint-config-wagtail": "^0.1.1",
     "autoprefixer": "^9.8.0",
+    "babel-eslint": "^10.1.0",
     "cssnano": "^4.1.10",
     "enzyme": "^3.9.0",
     "enzyme-adapter-react-16": "^1.9.1",


### PR DESCRIPTION
This PR contains some linting for the Telepath JavaScript. I've avoided large-scale issues such as indentation to reduce merge conflicts.

I had to change the eslint parser to ``babel-eslint`` in order to support class properties. See https://stackoverflow.com/questions/60046847/eslint-does-not-allow-static-class-properties