### PR TITLE
Use .specific_deferred when calling .get_admin_display_title()

### DIFF
--- a/docs/reference/pages/model_reference.rst
+++ b/docs/reference/pages/model_reference.rst
@@ -158,7 +158,11 @@ In addition to the model fields provided, ``Page`` has many properties and metho
 .. class:: Page
     :noindex:
 
+    .. automethod:: get_specific
+
     .. autoattribute:: specific
+
+    .. autoattribute:: specific_deferred
 
     .. autoattribute:: specific_class
 

--- a/wagtail/admin/forms/pages.py
+++ b/wagtail/admin/forms/pages.py
@@ -75,7 +75,7 @@ class CopyForm(forms.Form):
         # check if user is allowed to create a page at given location.
         if not parent_page.permissions_for_user(self.user).can_add_subpage():
             self._errors['new_parent_page'] = self.error_class([
-                _("You do not have permission to copy to page \"%(page_title)s\"") % {'page_title': parent_page.get_admin_display_title()}
+                _("You do not have permission to copy to page \"%(page_title)s\"") % {'page_title': parent_page.specific_deferred.get_admin_display_title()}
             ])
 
         # Count the pages with the same slug within the context of our copy's parent page

--- a/wagtail/admin/templates/wagtailadmin/home/pages_for_moderation.html
+++ b/wagtail/admin/templates/wagtailadmin/home/pages_for_moderation.html
@@ -23,11 +23,11 @@
                         <td class="title" valign="top">
                             <div class="title-wrapper">
                                 {% if page_perms.can_edit %}
-                                    <a href="{% url 'wagtailadmin_pages:edit' revision.page.id %}" title="{% trans 'Edit this page' %}">{{ revision.page.get_admin_display_title }}</a>
+                                    <a href="{% url 'wagtailadmin_pages:edit' revision.page.id %}" title="{% trans 'Edit this page' %}">{{ revision.page.specific_deferred.get_admin_display_title }}</a>
                                 {% elif revision.page.is_previewable %}
-                                    <a href="{% url 'wagtailadmin_pages:preview_for_moderation' revision.id %}" title="{% trans 'Preview this page' %}">{{ revision.page.get_admin_display_title }}</a>
+                                    <a href="{% url 'wagtailadmin_pages:preview_for_moderation' revision.id %}" title="{% trans 'Preview this page' %}">{{ revision.page.specific_deferred.get_admin_display_title }}</a>
                                 {% else %}
-                                    {{ revision.page.get_admin_display_title }}
+                                    {{ revision.page.specific_deferred.get_admin_display_title }}
                                 {% endif %}
 
                                 {% include "wagtailadmin/pages/listing/_privacy_indicator.html" with page=revision.page %}
@@ -55,7 +55,7 @@
                             </ul>
                         </td>
                         <td valign="top">
-                            <a href="{% url 'wagtailadmin_explore' revision.page.get_parent.id %}">{{ revision.page.get_parent.get_admin_display_title }}</a>
+                            <a href="{% url 'wagtailadmin_explore' revision.page.get_parent.id %}">{{ revision.page.get_parent.specific_deferred.get_admin_display_title }}</a>
                         </td>
                         <td class="type" valign="top">
                             {{ revision.page.content_type.model_class.get_verbose_name }}

--- a/wagtail/admin/templates/wagtailadmin/home/user_pages_in_workflow_moderation.html
+++ b/wagtail/admin/templates/wagtailadmin/home/user_pages_in_workflow_moderation.html
@@ -22,9 +22,9 @@
                     <td class="title" valign="top">
                         <div class="title-wrapper">
                             {% if page_perms.can_edit %}
-                                <a href="{% url 'wagtailadmin_pages:edit' workflow_state.page.id %}" title="{% trans 'Edit this page' %}">{{ workflow_state.page.get_admin_display_title }}</a>
+                                <a href="{% url 'wagtailadmin_pages:edit' workflow_state.page.id %}" title="{% trans 'Edit this page' %}">{{ workflow_state.page.specific_deferred.get_admin_display_title }}</a>
                             {% else %}
-                                {{ workflow_state.page.get_admin_display_title }}
+                                {{ workflow_state.page.specific_deferred.get_admin_display_title }}
                             {% endif %}
 
                             {% include "wagtailadmin/pages/listing/_privacy_indicator.html" with page=workflow_state.page %}

--- a/wagtail/admin/templates/wagtailadmin/home/workflow_pages_to_moderate.html
+++ b/wagtail/admin/templates/wagtailadmin/home/workflow_pages_to_moderate.html
@@ -22,9 +22,9 @@
                             <td class="title" valign="top">
                                 <div class="title-wrapper">
                                     {% if page_perms.can_edit %}
-                                        <a href="{% url 'wagtailadmin_pages:edit' revision.page.id %}" title="{% trans 'Edit this page' %}">{{ revision.page.get_admin_display_title }}</a>
+                                        <a href="{% url 'wagtailadmin_pages:edit' revision.page.id %}" title="{% trans 'Edit this page' %}">{{ revision.page.specific_deferred.get_admin_display_title }}</a>
                                     {% else %}
-                                        {{ revision.page.get_admin_display_title }}
+                                        {{ revision.page.specific_deferred.get_admin_display_title }}
                                     {% endif %}
 
                                     {% include "wagtailadmin/pages/listing/_privacy_indicator.html" with page=revision.page %}

--- a/wagtail/admin/templates/wagtailadmin/page_privacy/ancestor_privacy.html
+++ b/wagtail/admin/templates/wagtailadmin/page_privacy/ancestor_privacy.html
@@ -4,5 +4,5 @@
 
 <div class="nice-padding">
     <p>{% trans "This page has been made private by a parent page." %}</p>
-    <p>{% trans "You can edit the privacy settings on:" %} <a href="{% url 'wagtailadmin_pages:edit' page_with_restriction.id %}">{{ page_with_restriction.get_admin_display_title }}</a></p>
+    <p>{% trans "You can edit the privacy settings on:" %} <a href="{% url 'wagtailadmin_pages:edit' page_with_restriction.id %}">{{ page_with_restriction.specific_deferred.get_admin_display_title }}</a></p>
 </div>

--- a/wagtail/admin/templates/wagtailadmin/pages/copy.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/copy.html
@@ -1,9 +1,9 @@
 {% extends "wagtailadmin/base.html" %}
 {% load i18n %}
-{% block titletag %}{% blocktrans with title=page.get_admin_display_title %}Copy {{ title }}{% endblocktrans %}{% endblock %}
+{% block titletag %}{% blocktrans with title=page.specific_deferred.get_admin_display_title %}Copy {{ title }}{% endblocktrans %}{% endblock %}
 {% block content %}
     {% trans "Copy" as copy_str %}
-    {% include "wagtailadmin/shared/header.html" with title=copy_str subtitle=page.get_admin_display_title icon="doc-empty-inverse" %}
+    {% include "wagtailadmin/shared/header.html" with title=copy_str subtitle=page.specific_deferred.get_admin_display_title icon="doc-empty-inverse" %}
 
     <div class="nice-padding">
         <form action="{% url 'wagtailadmin_pages:copy' page.id %}" method="POST" novalidate>

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_list.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_list.html
@@ -59,7 +59,7 @@
                                 {% block page_parent_page_title %}
                                     {% with page.get_parent as parent %}
                                         {% if parent %}
-                                            <a href="{% url 'wagtailadmin_explore' parent.id %}">{{ parent.get_admin_display_title }}</a>
+                                            <a href="{% url 'wagtailadmin_explore' parent.id %}">{{ parent.specific_deferred.get_admin_display_title }}</a>
                                         {% endif %}
                                     {% endwith %}
                                 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/pages/move_choose_destination.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/move_choose_destination.html
@@ -1,11 +1,11 @@
 {% extends "wagtailadmin/base.html" %}
 {% load i18n wagtailadmin_tags %}
-{% block titletag %}{% blocktrans with title=page_to_move.get_admin_display_title %}Select a new parent page for {{ title }}{% endblocktrans %}{% endblock %}
+{% block titletag %}{% blocktrans with title=page_to_move.specific_deferred.get_admin_display_title %}Select a new parent page for {{ title }}{% endblocktrans %}{% endblock %}
 {% block content %}
     <header class="nice-padding">
         <h1>
           {% icon name="doc-empty-inverse" class_name="header-title-icon" %}
-          {% blocktrans with title=page_to_move.get_admin_display_title %}Select a new parent page for <span>{{ title }}</span>{% endblocktrans %}
+          {% blocktrans with title=page_to_move.specific_deferred.get_admin_display_title %}Select a new parent page for <span>{{ title }}</span>{% endblocktrans %}
         </h1>
     </header>
 

--- a/wagtail/admin/templates/wagtailadmin/pages/workflow_history/detail.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/workflow_history/detail.html
@@ -8,7 +8,7 @@
     {% include "wagtailadmin/shared/header.html" with title=title_str %}
 
     <div class="nice-padding">
-        <h2>{% icon "doc-empty-inverse" class_name="initial" %} {{ page.get_admin_display_title }}</h2>
+        <h2>{% icon "doc-empty-inverse" class_name="initial" %} {{ page.specific_deferred.get_admin_display_title }}</h2>
         <p>
             <a href="{% url 'wagtailadmin_pages:edit' page.id %}" class="button button-small button-secondary">{% trans "Edit / Review" %}</a>
             <a href="{% url 'wagtailadmin_pages:workflow_history' page.id %}" class="button button-small button-secondary">{% trans "Workflow history" %}</a>

--- a/wagtail/admin/templates/wagtailadmin/pages/workflow_history/index.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/workflow_history/index.html
@@ -1,11 +1,11 @@
 {% extends "wagtailadmin/base.html" %}
 {% load i18n %}
 
-{% block titletag %}{% blocktrans with title=page.get_admin_display_title %}Workflow history for {{ title }}{% endblocktrans %}{% endblock %}
+{% block titletag %}{% blocktrans with title=page.specific_deferred.get_admin_display_title %}Workflow history for {{ title }}{% endblocktrans %}{% endblock %}
 
 {% block content %}
     {% trans "Workflow history for" as workflow_history_str %}
-    {% include "wagtailadmin/shared/header.html" with title=workflow_history_str subtitle=page.get_admin_display_title icon="doc-empty-inverse" %}
+    {% include "wagtailadmin/shared/header.html" with title=workflow_history_str subtitle=page.specific_deferred.get_admin_display_title icon="doc-empty-inverse" %}
 
     <div class="nice-padding">
         <p style="margin-bottom: 30px;">

--- a/wagtail/admin/templates/wagtailadmin/reports/workflow.html
+++ b/wagtail/admin/templates/wagtailadmin/reports/workflow.html
@@ -41,7 +41,7 @@
                         </td>
                         <td>
                             <a href="{% url 'wagtailadmin_pages:edit' workflow_state.page.id %}">
-                                {{ workflow_state.page.get_admin_display_title }}
+                                {{ workflow_state.page.specific_deferred.get_admin_display_title }}
                             </a>
                         </td>
                         <td>

--- a/wagtail/admin/templates/wagtailadmin/reports/workflow_tasks.html
+++ b/wagtail/admin/templates/wagtailadmin/reports/workflow_tasks.html
@@ -39,7 +39,7 @@
                         <td>
                             {% with task_state.workflow_state.page as page %}
                                 <a href="{% url 'wagtailadmin_pages:edit' page.id %}">
-                                    {{ page.get_admin_display_title }}
+                                    {{ page.specific_deferred.get_admin_display_title }}
                                 </a>
                             {% endwith %}
                         </td>

--- a/wagtail/admin/templates/wagtailadmin/workflows/usage.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/usage.html
@@ -23,11 +23,11 @@
                 {% for page in used_by %}
                     <tr>
                         <td class="title" valign="top">
-                            <div class="title-wrapper"><a href="{% url 'wagtailadmin_pages:edit' page.id %}" title="{% trans 'Edit this page' %}">{{ page.title }}</a></div>
+                            <div class="title-wrapper"><a href="{% url 'wagtailadmin_pages:edit' page.id %}" title="{% trans 'Edit this page' %}">{{ page.get_admin_display_title }}</a></div>
                         </td>
                         <td>
                             {% if page.get_parent %}
-                                <a href="{% url 'wagtailadmin_explore' page.get_parent.id %}">{{ page.get_parent.title }}</a>
+                                <a href="{% url 'wagtailadmin_explore' page.get_parent.id %}">{{ page.get_parent.specific_deferred.get_admin_display_title }}</a>
                             {% endif %}
                         </td>
                         <td>

--- a/wagtail/admin/views/pages/copy.py
+++ b/wagtail/admin/views/pages/copy.py
@@ -76,10 +76,10 @@ def copy(request, page_id):
             if form.cleaned_data.get('copy_subpages'):
                 messages.success(
                     request,
-                    _("Page '{0}' and {1} subpages copied.").format(page.get_admin_display_title(), new_page.get_descendants().count())
+                    _("Page '{0}' and {1} subpages copied.").format(page.specific_deferred.get_admin_display_title(), new_page.get_descendants().count())
                 )
             else:
-                messages.success(request, _("Page '{0}' copied.").format(page.get_admin_display_title()))
+                messages.success(request, _("Page '{0}' copied.").format(page.specific_deferred.get_admin_display_title()))
 
             for fn in hooks.get_hooks('after_copy_page'):
                 result = fn(request, page, new_page)

--- a/wagtail/admin/views/pages/moderation.py
+++ b/wagtail/admin/views/pages/moderation.py
@@ -15,13 +15,13 @@ def approve_moderation(request, revision_id):
         raise PermissionDenied
 
     if not revision.submitted_for_moderation:
-        messages.error(request, _("The page '{0}' is not currently awaiting moderation.").format(revision.page.get_admin_display_title()))
+        messages.error(request, _("The page '{0}' is not currently awaiting moderation.").format(revision.page.specific_deferred.get_admin_display_title()))
         return redirect('wagtailadmin_home')
 
     if request.method == 'POST':
         revision.approve_moderation(user=request.user)
 
-        message = _("Page '{0}' published.").format(revision.page.get_admin_display_title())
+        message = _("Page '{0}' published.").format(revision.page.specific_deferred.get_admin_display_title())
         buttons = []
         if revision.page.url is not None:
             buttons.append(messages.button(revision.page.url, _('View live'), new_window=True))
@@ -40,13 +40,13 @@ def reject_moderation(request, revision_id):
         raise PermissionDenied
 
     if not revision.submitted_for_moderation:
-        messages.error(request, _("The page '{0}' is not currently awaiting moderation.").format(revision.page.get_admin_display_title()))
+        messages.error(request, _("The page '{0}' is not currently awaiting moderation.").format(revision.page.specific_deferred.get_admin_display_title()))
         return redirect('wagtailadmin_home')
 
     if request.method == 'POST':
         revision.reject_moderation(user=request.user)
 
-        messages.success(request, _("Page '{0}' rejected for publication.").format(revision.page.get_admin_display_title()), buttons=[
+        messages.success(request, _("Page '{0}' rejected for publication.").format(revision.page.specific_deferred.get_admin_display_title()), buttons=[
             messages.button(reverse('wagtailadmin_pages:edit', args=(revision.page.id,)), _('Edit'))
         ])
 
@@ -63,7 +63,7 @@ def preview_for_moderation(request, revision_id):
         raise PermissionDenied
 
     if not revision.submitted_for_moderation:
-        messages.error(request, _("The page '{0}' is not currently awaiting moderation.").format(revision.page.get_admin_display_title()))
+        messages.error(request, _("The page '{0}' is not currently awaiting moderation.").format(revision.page.specific_deferred.get_admin_display_title()))
         return redirect('wagtailadmin_home')
 
     page = revision.as_page_object()

--- a/wagtail/admin/views/pages/move.py
+++ b/wagtail/admin/views/pages/move.py
@@ -49,7 +49,8 @@ def move_choose_destination(request, page_to_move_id, viewed_page_id=None):
 
 def move_confirm(request, page_to_move_id, destination_id):
     page_to_move = get_object_or_404(Page, id=page_to_move_id).specific
-    destination = get_object_or_404(Page, id=destination_id)
+    # Needs .specific_deferred because the .get_admin_display_title method is called in template
+    destination = get_object_or_404(Page, id=destination_id).specific_deferred
     if not page_to_move.permissions_for_user(request.user).can_move_to(destination):
         raise PermissionDenied
 

--- a/wagtail/admin/views/pages/usage.py
+++ b/wagtail/admin/views/pages/usage.py
@@ -18,7 +18,7 @@ def content_type_use(request, content_type_app_name, content_type_model_name):
     if not issubclass(page_class, Page):
         raise Http404
 
-    pages = page_class.objects.all()
+    pages = page_class.objects.all().specific(defer=True)
 
     paginator = Paginator(pages, per_page=10)
     pages = paginator.get_page(request.GET.get('p'))

--- a/wagtail/admin/views/reports.py
+++ b/wagtail/admin/views/reports.py
@@ -84,7 +84,7 @@ class LockedPagesView(PageReportView):
         pages = (
             UserPagePermissionsProxy(self.request.user).editable_pages()
             | Page.objects.filter(locked_by=self.request.user)
-        ).filter(locked=True)
+        ).filter(locked=True).specific(defer=True)
         self.queryset = pages
         return super().get_queryset()
 

--- a/wagtail/api/v2/serializers.py
+++ b/wagtail/api/v2/serializers.py
@@ -292,6 +292,9 @@ class BaseSerializer(serializers.ModelSerializer):
         # Serialise core fields
         for field in fields:
             try:
+                if field.field_name == 'admin_display_title':
+                    instance = instance.specific_deferred
+
                 attribute = field.get_attribute(instance)
             except SkipField:
                 continue

--- a/wagtail/contrib/modeladmin/forms.py
+++ b/wagtail/contrib/modeladmin/forms.py
@@ -8,7 +8,7 @@ from wagtail.core.models import Page
 class PageChoiceField(forms.ModelChoiceField):
     def label_from_instance(self, obj):
         bits = []
-        for ancestor in obj.get_ancestors(inclusive=True).exclude(depth=1):
+        for ancestor in obj.get_ancestors(inclusive=True).exclude(depth=1).specific(defer=True):
             bits.append(ancestor.get_admin_display_title())
         return mark_safe('<span class="icon icon-arrow-right"></span>'.join(bits))
 

--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -2021,11 +2021,11 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
             data={
                 'source': {
                     'id': parent_before.id,
-                    'title': parent_before.get_admin_display_title()
+                    'title': parent_before.specific_deferred.get_admin_display_title()
                 },
                 'destination': {
                     'id': parent_after.id,
-                    'title': parent_after.get_admin_display_title()
+                    'title': parent_after.specific_deferred.get_admin_display_title()
                 }
             }
         )
@@ -2166,8 +2166,8 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
                         'id': page_copy.id,
                         'title': page_copy.get_admin_display_title()
                     },
-                    'source': {'id': parent.id, 'title': parent.get_admin_display_title()} if parent else None,
-                    'destination': {'id': to.id, 'title': to.get_admin_display_title()} if to else None,
+                    'source': {'id': parent.id, 'title': parent.specific_deferred.get_admin_display_title()} if parent else None,
+                    'destination': {'id': to.id, 'title': to.specific_deferred.get_admin_display_title()} if to else None,
                     'keep_live': page_copy.live and keep_live
                 },
             )
@@ -2308,8 +2308,8 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
                         'id': alias.id,
                         'title': alias.get_admin_display_title()
                     },
-                    'source': {'id': source_parent.id, 'title': source_parent.get_admin_display_title()} if source_parent else None,
-                    'destination': {'id': parent.id, 'title': parent.get_admin_display_title()} if parent else None,
+                    'source': {'id': source_parent.id, 'title': source_parent.specific_deferred.get_admin_display_title()} if source_parent else None,
+                    'destination': {'id': parent.id, 'title': parent.specific_deferred.get_admin_display_title()} if parent else None,
                 },
             )
             if alias.live:
@@ -4594,8 +4594,8 @@ class BaseLogEntryManager(models.Manager):
         data = kwargs.pop('data', '')
         title = kwargs.pop('title', None)
         if not title:
-            if hasattr(instance, 'get_admin_display_title'):
-                title = instance.get_admin_display_title()
+            if isinstance(instance, Page):
+                title = instance.specific_deferred.get_admin_display_title()
             else:
                 title = str(instance)
 

--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -18,7 +18,7 @@ from django.core.exceptions import PermissionDenied, ValidationError
 from django.core.handlers.base import BaseHandler
 from django.core.handlers.wsgi import WSGIRequest
 from django.db import migrations, models, transaction
-from django.db.models import Q, Value
+from django.db.models import DEFERRED, Q, Value
 from django.db.models.expressions import OuterRef, Subquery
 from django.db.models.functions import Concat, Lower, Substr
 from django.db.models.signals import pre_save
@@ -1165,10 +1165,23 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
             )
         )
 
-    @cached_property
-    def specific(self):
+    def get_specific(self, deferred=False, copy_attrs=None):
         """
+        .. versionadded:: 2.12
+
         Return this page in its most specific subclassed form.
+
+        By default, a database query is made to fetch all field values for the
+        specific object. If you only require access to custom methods or other
+        non-field attributes on the specific object, you can use
+        ``deferred=True`` to avoid this query. However, any attempts to access
+        specific field values from the returned object will trigger additional
+        database queries.
+
+        If there are attribute values on this object that you wish to be copied
+        over to the specific version (for example: evaluated relationship field
+        values, annotations or cached properties), use `copy_attrs`` to pass an
+        iterable of names of attributes you wish to be copied.
 
         If called on a page object that is already an instance of the most
         specific class (e.g. an ``EventPage``), the object will be returned
@@ -1189,10 +1202,52 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
             # reverted before switching branches). So, the best we can do is
             # return the page in it's current form.
             return self
+
         if isinstance(self, model_class):
             # self is already the an instance of the most specific class
             return self
-        return self.cached_content_type.get_object_for_this_type(id=self.id)
+
+        if deferred:
+            # Generate a tuple of values in the order expected by __init__(),
+            # with missing values substituted with DEFERRED ()
+            values = tuple(
+                getattr(self, f.attname, self.pk if f.primary_key else DEFERRED)
+                for f in model_class._meta.concrete_fields
+            )
+            # Create object from known attribute values
+            specific_obj = model_class(*values)
+            specific_obj._state.adding = self._state.adding
+        else:
+            # Fetch object from database
+            specific_obj = model_class._default_manager.get(id=self.id)
+
+        # Copy additional attribute values
+        if copy_attrs:
+            for attr in copy_attrs:
+                if attr in self.__dict__:
+                    setattr(specific_obj, attr, getattr(self, attr))
+
+        return specific_obj
+
+    @cached_property
+    def specific(self):
+        """
+        A wrapper for ``self.get_specific()`` that returns this page in its
+        most specific subclassed form with all field values fetched from the
+        database. The result is cached in memory.
+        """
+        return self.get_specific()
+
+    @cached_property
+    def specific_deferred(self):
+        """
+        .. versionadded:: 2.12
+
+        A wrapper for ``self.get_specific()`` that returns this page in its
+        most specific subclassed form without any additional field values being
+        fetched from the database. The result is cached in memory.
+        """
+        return self.get_specific(deferred=True)
 
     @cached_property
     def specific_class(self):
@@ -1202,7 +1257,7 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
 
         If the model class can no longer be found in the codebase, and the
         relevant ``ContentType`` has been removed by a database migration,
-        the return value will be ``Page``.
+        the return value will be ``None``.
 
         If the model class can no longer be found in the codebase, but the
         relevant ``ContentType`` is still present in the database (usually a


### PR DESCRIPTION
There are quite a few places where we are not calling ``.get_admin_display_title()`` with a specific page instance so custom implementations of this method weren't being used.

@ababic's [`.specific_deferred`](https://github.com/wagtail/wagtail/pull/6661) method allows us to get a specific instance without an extra query. So custom implementations of ``.get_admin_display_title`` will be called without much of a performance hit for those who don't use this feature (hopefully).