### PR TITLE
fix: signal receivers example raising exception

### DIFF
--- a/docs/reference/contrib/frontendcache.rst
+++ b/docs/reference/contrib/frontendcache.rst
@@ -192,12 +192,12 @@ This signal handler would trigger the invalidation of the index page using the
 
 
     @receiver(page_published, sender=BlogPage)
-    def blog_published_handler(instance):
+    def blog_published_handler(instance, **kwargs):
         blog_page_changed(instance)
 
 
     @receiver(pre_delete, sender=BlogPage)
-    def blog_deleted_handler(instance):
+    def blog_deleted_handler(instance, **kwargs):
         blog_page_changed(instance)
 
 


### PR DESCRIPTION
Signal receivers must accept `**kwargs`, otherwise one runs into this:

```
File "/lib/python3.8/site-packages/django/dispatch/dispatcher.py", line 94, in connect
raise ValueError("Signal receivers must accept keyword arguments (**kwargs).")
ValueError: Signal receivers must accept keyword arguments (**kwargs).
```

Thanks for contributing to Wagtail! 🎉

Before submitting, please review the contributor guidelines <https://docs.wagtail.io/en/latest/contributing/index.html> and check the following:

* Do the tests still pass? (https://docs.wagtail.io/en/latest/contributing/developing.html#testing): Yes
* Does the code comply with the style guide? (Run `make lint` from the Wagtail root): Yes
* For Python changes: Have you added tests to cover the new/fixed behaviour?: N/A
* For front-end changes: Did you test on all of Wagtail’s supported browsers? **Please list the exact versions you tested**: N/A
* For new features: Has the documentation been updated accordingly?: N/A
