### PR TITLE
Apply scss styling to collection_choice_field

### DIFF
--- a/client/scss/components/_forms.scss
+++ b/client/scss/components/_forms.scss
@@ -77,6 +77,7 @@ select::-ms-expand {
 }
 
 // select boxes
+.collection_choice_field .input,
 .choice_field .input,
 .model_choice_field .input,
 .typed_choice_field .input {


### PR DESCRIPTION
This is a simple change to include collection_choice_field in the set of class names that are styled with a chevron icon. This change notably impacts the Image and Document edit forms.

Before:
![image](https://user-images.githubusercontent.com/2699164/104227378-498eac00-5417-11eb-9b64-3046fbda7b50.png)

After:
![image](https://user-images.githubusercontent.com/2699164/104227340-354aaf00-5417-11eb-9dc4-9baf0ae5193b.png)

This PR resolves #6682.
