### PR TITLE
Fix formatting in Development documentation

### DIFF
--- a/docs/contributing/developing.rst
+++ b/docs/contributing/developing.rst
@@ -144,7 +144,7 @@ If you need to use different connection settings, use the following environment 
 * ``DATABASE_HOST``
 
   * Note that for MySQL, this must be ``127.0.0.1`` rather than ``localhost`` if you need to connect using a TCP socket
-  
+
 * ``DATABASE_PORT``
 
 Testing Elasticsearch

--- a/docs/contributing/developing.rst
+++ b/docs/contributing/developing.rst
@@ -142,7 +142,9 @@ If you need to use different connection settings, use the following environment 
 * ``DATABASE_NAME``
 * ``DATABASE_PASSWORD``
 * ``DATABASE_HOST``
-  * Note that for MySQL, this must be `127.0.0.1` rather than `localhost` if you need to connect using a TCP socket
+
+  * Note that for MySQL, this must be ``127.0.0.1`` rather than ``localhost`` if you need to connect using a TCP socket
+  
 * ``DATABASE_PORT``
 
 Testing Elasticsearch


### PR DESCRIPTION
Fix formatting on the Development page by inserting spacing for the nested list and updating the literal backticks to be double (for reST).

----

Thanks for contributing to Wagtail! 🎉

Before submitting, please review the contributor guidelines <https://docs.wagtail.io/en/latest/contributing/index.html> and check the following:

* [x] Do the tests still pass? (https://docs.wagtail.io/en/latest/contributing/developing.html#testing)
* [x] Does the code comply with the style guide? (Run `make lint` from the Wagtail root)
* For Python changes: Have you added tests to cover the new/fixed behaviour?  N/A
* For front-end changes: Did you test on all of Wagtail’s supported browsers? **Please list the exact versions you tested**.   N/A
* For new features: Has the documentation been updated accordingly? N/A
