### PR TITLE
fix JS code example in hooks docs

### DIFF
--- a/docs/reference/hooks.rst
+++ b/docs/reference/hooks.rst
@@ -423,12 +423,13 @@ Hooks for customising the editing interface for pages and snippets.
         js_includes = format_html_join('\n', '<script src="{0}"></script>',
             ((static(filename),) for filename in js_files)
         )
+        # remember to use double '{{' so they are not parsed as template placeholders
         return js_includes + format_html(
             """
             <script>
-                $(function() {
+                $(function() {{
                     $('button').raptorize();
-                });
+                }});
             </script>
             """
         )


### PR DESCRIPTION
Small docs typo fix

- when returning format_html `{` & `}` (brace) characters must be escaped
- https://docs.python.org/3/library/string.html#format-string-syntax
