### PR TITLE
Refined creation of title on image upload

### DIFF
--- a/client/src/entrypoints/admin/core.js
+++ b/client/src/entrypoints/admin/core.js
@@ -582,4 +582,6 @@ function initButtonSelects() {
 
 $(document).ready(initButtonSelects);
 
+window.wagtail.utils = {};
+
 window.wagtail = wagtail;

--- a/docs/advanced_topics/images/custom_title_generation_from_filename.rst
+++ b/docs/advanced_topics/images/custom_title_generation_from_filename.rst
@@ -1,0 +1,48 @@
+.. _image_custom_title_generation_from_filename:
+
+Custom Title Generation From Filename
+=====================================
+
+Override how the title is set when uploading single files, multiple files or uploading a file within a chooser modal.
+
+.. note::
+    This will not apply to editing images (e.g. uploading a replacement image file while editing an existing image).
+
+``wagtail.utils.getImageUploadTitle`` can be overridden with a custom function,
+the first argument is the filename (e.g. ``'some_file.jpg'``) and the second is an options object.
+If the return value is a ``String`` it will replace the value in the relevant title field, otherwise it will leave the title field as is (blank).
+
+The options available to the function are as follows:
+
+* ``event`` - event triggered by the DOM element
+* ``maxLength`` - will be the maximum length on the title form field (may not available for some forms, can be null)
+* ``widget`` - the type of upload widget, can be ``'ADD'``, ``'ADD_MULTIPLE'`` or ``'CHOOSER_MODAL'``
+
+Code Example
+------------
+
+.. code-block:: python
+
+  from django.utils.html import format_html, format_html_join
+  from django.templatetags.static import static
+
+  from wagtail.core import hooks
+
+  @hooks.register('insert_global_admin_js')
+  def get_global_admin_js():
+      # remember to use double '{{' so they are not parsed as template placeholders
+      return format_html(
+        """
+        <script>
+            $(function () {{
+                function getImageUploadTitle (filename, options) {{
+                    filenameParts = filename.split('.');
+                    filenameParts.pop(); // remove the last element (file extension)
+                    return ['IMAGE - '].concat(filenameParts).join(''); // return the desired title to be used
+                }}
+                window.wagtail.utils.getImageUploadTitle = getImageUploadTitle;
+            }});
+        </script>
+        """
+      )
+

--- a/docs/advanced_topics/images/index.rst
+++ b/docs/advanced_topics/images/index.rst
@@ -12,3 +12,4 @@ Images
     changing_rich_text_representation
     feature_detection
     image_serve_view
+    custom_title_generation_from_filename

--- a/wagtail/images/static_src/wagtailimages/js/add-multiple.js
+++ b/wagtail/images/static_src/wagtailimages/js/add-multiple.js
@@ -33,6 +33,7 @@ $(function() {
 
             $('#upload-list').append(li);
             data.context = li;
+            data.$titleField = $('#fileupload-title', data.form); // add upload title field for custom title on upload
 
             data.process(function() {
                 return $this.fileupload('process', data);
@@ -126,6 +127,38 @@ $(function() {
             itemElement.removeClass('upload-uploading').addClass('upload-complete');
         }
     });
+
+    $("#fileupload").on(
+        "fileuploadsubmit",
+        /**
+         * Called for each individual upload, allowing for the getImageUploadTitle global
+         * to override the provided filename with a custom title (e.g. a regex to remove the extension).
+         *
+         * @param {*} event - DOM event
+         * @param {Object} data - data object passed from jquery fileupload
+         */
+        function (event, data) {
+            var getImageUploadTitle = window.wagtail.utils.getImageUploadTitle;
+            if (typeof getImageUploadTitle !== "function") return;
+        
+            var $titleField = data.$titleField;
+            var files = data.files[0] || {};
+            var maxLength = $titleField.attr("maxLength") || null;
+        
+            var newTitle = getImageUploadTitle(files.name, {
+                event,
+                maxLength: maxLength && parseInt(maxLength),
+                widget: "ADD_MULTIPLE",
+            });
+        
+            if (typeof newTitle === "string") {
+                $titleField.val(newTitle);
+            } else {
+                // must clear any existing value for next upload
+                $titleField.val("");
+            }
+        }
+      );
 
     // ajax-enhance forms added on done()
     $('#upload-list').on('submit', 'form', function(e) {

--- a/wagtail/images/static_src/wagtailimages/js/image-upload-utils.js
+++ b/wagtail/images/static_src/wagtailimages/js/image-upload-utils.js
@@ -1,0 +1,15 @@
+(function () {
+  /**
+   * Default implementation of converting an image filename into a
+   * suitable title that will remove the file extension.
+   * Note: using prototype.call for better debugging stack.
+   *
+   * @param {string} str
+   * @returns {string}
+   */
+  function getImageUploadTitle(str) {
+    return String.prototype.replace.call(str, /\.[^\.]+$/, "");
+  }
+
+  window.wagtail.utils.getImageUploadTitle = getImageUploadTitle;
+})();

--- a/wagtail/images/templates/wagtailimages/images/add.html
+++ b/wagtail/images/templates/wagtailimages/images/add.html
@@ -1,5 +1,5 @@
 {% extends "wagtailadmin/base.html" %}
-{% load wagtailimages_tags %}
+{% load wagtailadmin_tags wagtailimages_tags %}
 {% load i18n %}
 {% block titletag %}{% trans "Add an image" %}{% endblock %}
 
@@ -8,12 +8,50 @@
 
     {{ form.media.js }}
 
+    <script src="{% versioned_static 'wagtailimages/js/image-upload-utils.js' %}"></script>
+
     {% url 'wagtailadmin_tag_autocomplete' as autocomplete_url %}
+
     <script>
         $(function() {
             $('#id_tags').tagit({
                 autocomplete: {source: "{{ autocomplete_url|addslashes }}"}
             });
+            $('#id_file').on(
+                'change',
+                { $titleField: $('#id_title') },
+                /**
+                * Called on change of the file upload field, allowing for the getImageUploadTitle
+                * global to override the provided filename with a custom title.
+                *
+                * @param {*} event - DOM event (contains reference to $titleField)
+                */
+                function(event) {
+                    var getImageUploadTitle = window.wagtail.utils.getImageUploadTitle;
+                    if (typeof getImageUploadTitle !== "function") return;
+
+                    var $titleField = event.data.$titleField;
+                    var currentTitle = $titleField.val();
+
+                    // do not override a title that already exists (from manual editing or previous upload)
+                    if (currentTitle) return;
+
+                    // file widget value example: `C:\fakepath\image.jpg` - convert to just the filename part
+                    var fileName = $(this).val().split('\\').slice(-1)[0];
+                    var maxLength = $titleField.attr('maxLength') || null;
+
+                    var newTitle = getImageUploadTitle(fileName, {
+                        event,
+                        maxLength: maxLength && parseInt(maxLength),
+                        widget: "ADD",
+                    });
+
+                    // allow for the util to return null/non-string to not update title
+                    if (typeof newTitle !== "string") return;
+
+                    $titleField.val(newTitle);
+                }
+            );
         });
     </script>
 {% endblock %}

--- a/wagtail/images/templates/wagtailimages/multiple/add.html
+++ b/wagtail/images/templates/wagtailimages/multiple/add.html
@@ -24,6 +24,7 @@
                 <div class="replace-file-input">
                     <button class="button bicolor button--icon">{% icon name="plus" wrapped=1 %}{% trans "Or choose from your computer" %}</button>
                     <input id="fileupload" type="file" name="files[]" data-url="{% url 'wagtailimages:add_multiple' %}" multiple>
+                    <input id="fileupload-title" type="hidden" name="title" maxlength="{{ max_title_length }}" value="">
                 </div>
                 {% csrf_token %}
                 {% if collections %}
@@ -98,6 +99,7 @@
     <script src="{% versioned_static 'wagtailadmin/js/vendor/tag-it.js' %}"></script>
 
     <!-- Main script -->
+    <script src="{% versioned_static 'wagtailimages/js/image-upload-utils.js' %}"></script>
     <script src="{% versioned_static 'wagtailimages/js/add-multiple.js' %}"></script>
 
     {% url 'wagtailadmin_tag_autocomplete' as autocomplete_url %}

--- a/wagtail/images/tests/test_admin_views.py
+++ b/wagtail/images/tests/test_admin_views.py
@@ -8,6 +8,7 @@ from django.urls import reverse
 from django.utils.http import RFC3986_SUBDELIMS, urlquote
 
 from wagtail.core.models import Collection, GroupCollectionPermission, get_root_collection_id
+from wagtail.images import get_image_model
 from wagtail.images.models import UploadedImage
 from wagtail.images.utils import generate_signature
 from wagtail.tests.testapp.models import CustomImage, CustomImageWithAuthor
@@ -1303,6 +1304,7 @@ class TestMultipleImageUploader(TestCase, WagtailTestUtils):
         This tests that a POST request to the add view saves the image and returns an edit form
         """
         response = self.client.post(reverse('wagtailimages:add_multiple'), {
+            'title': 'test title',
             'files[]': SimpleUploadedFile('test.png', get_test_image_file().file.getvalue()),
         }, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
 
@@ -1313,21 +1315,56 @@ class TestMultipleImageUploader(TestCase, WagtailTestUtils):
 
         # Check image
         self.assertIn('image', response.context)
-        self.assertEqual(response.context['image'].title, 'test.png')
+        self.assertEqual(response.context['image'].title, 'test title')
         self.assertTrue(response.context['image'].file_size)
         self.assertTrue(response.context['image'].file_hash)
 
         # Check form
         self.assertIn('form', response.context)
-        self.assertEqual(response.context['form'].initial['title'], 'test.png')
+        self.assertEqual(response.context['form'].initial['title'], 'test title')
         self.assertEqual(response.context['edit_action'], '/admin/images/multiple/%d/' % response.context['image'].id)
         self.assertEqual(response.context['delete_action'], '/admin/images/multiple/%d/delete/' % response.context['image'].id)
+        self.assertEqual(response.context['form'].initial['title'], 'test title')
+
+        image = get_image_model().objects.get(title='test title')
+        self.assertNotIn('title', image.filename)
+        self.assertIn('.png', image.filename)
+
+        # Check JSON
+        response_json = json.loads(response.content.decode())
+        self.assertIn('image_id', response_json)
+        self.assertIn('form', response_json)
+        self.assertIn('success', response_json)
+        self.assertEqual(response_json['image_id'], response.context['image'].id)
+        self.assertTrue(response_json['success'])
+
+    def test_add_post_no_title(self):
+        """
+        A POST request to the add view without the title value saves the image and uses file title if needed
+        """
+        response = self.client.post(reverse('wagtailimages:add_multiple'), {
+            'files[]': SimpleUploadedFile('no-title.png', get_test_image_file().file.getvalue()),
+        }, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+
+        # Check response
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response['Content-Type'], 'application/json')
+        self.assertTemplateUsed(response, 'wagtailimages/multiple/edit_form.html')
+
+        # Check image
+        self.assertIn('image', response.context)
+        self.assertEqual(response.context['image'].title, 'no-title.png')
+        self.assertTrue(response.context['image'].file_size)
+        self.assertTrue(response.context['image'].file_hash)
+
+        # Check form
+        self.assertIn('form', response.context)
+        self.assertEqual(response.context['form'].initial['title'], 'no-title.png')
 
         # Check JSON
         response_json = json.loads(response.content.decode())
         self.assertIn('form', response_json)
         self.assertIn('success', response_json)
-        self.assertTrue(response_json['success'])
 
     def test_add_post_noajax(self):
         """

--- a/wagtail/images/views/multiple.py
+++ b/wagtail/images/views/multiple.py
@@ -59,7 +59,7 @@ def add(request):
 
         # Build a form for validation
         form = ImageForm({
-            'title': request.FILES['files[]'].name,
+            'title': request.POST.get('title', request.FILES['files[]'].name),
             'collection': request.POST.get('collection'),
         }, {
             'file': request.FILES['files[]'],
@@ -121,6 +121,7 @@ def add(request):
         form = ImageForm(user=request.user)
 
         return TemplateResponse(request, 'wagtailimages/multiple/add.html', {
+            'max_title_length': form.fields['title'].max_length,
             'max_filesize': form.fields['file'].max_upload_size,
             'help_text': form.fields['file'].help_text,
             'allowed_extensions': ALLOWED_EXTENSIONS,

--- a/wagtail/images/wagtail_hooks.py
+++ b/wagtail/images/wagtail_hooks.py
@@ -71,6 +71,7 @@ def register_image_feature(features):
         HalloPlugin(
             name='hallowagtailimage',
             js=[
+                'wagtailimages/js/image-upload-utils.js',
                 'wagtailimages/js/image-chooser-modal.js',
                 'wagtailimages/js/hallo-plugins/hallo-wagtailimage.js',
             ],
@@ -95,6 +96,7 @@ def register_image_feature(features):
                 'id': True,
             }
         }, js=[
+            'wagtailimages/js/image-upload-utils.js',
             'wagtailimages/js/image-chooser-modal.js',
         ])
     )

--- a/wagtail/images/widgets.py
+++ b/wagtail/images/widgets.py
@@ -61,6 +61,7 @@ class AdminImageChooser(AdminChooser):
     @property
     def media(self):
         return forms.Media(js=[
+            versioned_static('wagtailimages/js/image-upload-utils.js',),
             versioned_static('wagtailimages/js/image-chooser-modal.js'),
             versioned_static('wagtailimages/js/image-chooser.js'),
         ])


### PR DESCRIPTION
Resolves #4945 & is a smaller scoped version of #5616 that only covers images (not documents).

## Overview of implementation
* New behaviour, by default -the file name will be used to generate a title which will be the file without the file extension
* If a value is already in the applicable title field, by default this value will be kept as is.
* Moves the implementation to 100% client side so user can 'edit' value before it is saved (or in the case of multiple upload, the initial title will based on the util)
* Adds the ability for this functionality to overridden (includes docs on how to do this)

## Forms updated
- view - admin/images/multiple/add
- view - admin/images/add
- modal - image-chooser-modal

## How to validate
* For each of the forms above, attempt to upload an image and check the title field gets pre-filled with the filename but not the extension.
* For the non-multiple forms, before clicking save, select a different file to upload and confirm the title is left unchanged.

## PR Checklist
* Do the tests still pass? the core.js is actually untested, I am happy to get some tests started but it appears this will be quite some effort.
* Does the code comply with the style guide?  ✅  - js lint passes
* For front-end changes: Tested on the following
  * Safari Version 12.1.1 MacOS 10.14.5
  * Firefox 69 MacOS 10.14.5
  * Chrome 77 MacOS 10.14.5
* For new features: Has the documentation been updated accordingly? ✅ 
