### PR TITLE
Add button to compare with live version from page history.

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/pages/revisions/_actions.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/revisions/_actions.html
@@ -15,6 +15,9 @@
     {% if revision != page.get_latest_revision %}
         <li><a href="{% url 'wagtailadmin_pages:revisions_compare' page.id revision.id 'latest' %}" class="button button-small button-secondary">{% trans 'Compare with current version' %}</a></li>
     {% endif %}
+    {% if page.live_revision and revision != page.live_revision %}
+        <li><a href="{% url 'wagtailadmin_pages:revisions_compare' page.id 'live' revision.id %}" class="button button-small button-secondary">{% trans 'Compare with live version' %}</a></li>
+    {% endif %}
     {% endwith %}
     {% if revision.approved_go_live_at and page_perms.can_unschedule %}
     <li><a href="{% url 'wagtailadmin_pages:revisions_unschedule' page.id revision.id %}" class="button button-small button-secondary">{% trans 'Cancel scheduled publish' %}</a></li>


### PR DESCRIPTION
Addresses https://github.com/wagtail/wagtail/issues/6700, if determined to be a desired feature.

Adds a button to the revision history page to compare a given revision against the live version.

![Screen Shot 2021-01-16 at 12 08 21 PM](https://user-images.githubusercontent.com/13165465/104821850-9a294f00-57f3-11eb-9efa-41503a11a91a.png)
![Screen Shot 2021-01-16 at 12 08 27 PM](https://user-images.githubusercontent.com/13165465/104821852-9b5a7c00-57f3-11eb-915f-8aa454b8bbab.png)


* Do the tests still pass? (https://docs.wagtail.io/en/latest/contributing/developing.html#testing) -- yes
* Does the code comply with the style guide? (Run `make lint` from the Wagtail root) -- yes
* For Python changes: Have you added tests to cover the new/fixed behaviour? -- there's an existing test for the compare live functionality
* For front-end changes: Did you test on all of Wagtail’s supported browsers? -- n/a
* For new features: Has the documentation been updated accordingly? -- n/a
