### PR TITLE
Fix typo in generic EditView

### DIFF
--- a/wagtail/admin/views/generic/models.py
+++ b/wagtail/admin/views/generic/models.py
@@ -154,7 +154,7 @@ class EditView(PermissionCheckedMixin, TemplateResponseMixin, BaseUpdateView):
         context['can_delete'] = (
             self.permission_policy is None
             or self.permission_policy.user_has_permission(self.request.user, 'delete')
-        ),
+        )
         return context
 
 


### PR DESCRIPTION
The generic EditView has a trailing comma in get_context_data which is making can_delete always True.