### PR TITLE
Show required asterisks for required descendant blocks of required streamfields

### DIFF
--- a/wagtail/admin/static_src/wagtailadmin/scss/layouts/page-editor.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/layouts/page-editor.scss
@@ -274,10 +274,6 @@
         padding-left: 20px;
         padding-right: 20px;
 
-        &.required .field > label:after {
-            display: none;
-        }
-
         .object-layout_big-part {
             max-width: 100%;
         }


### PR DESCRIPTION
Fixes #5983; possibly also has a bearing on #4306. A CSS rule dating from the original StreamField design was hiding the 'required' asterisk on fields within a required StreamField, presumably on the mistaken belief that they duplicate the information given by the top-level asterisk on the streamfield. (In #5983 this was reported as a regression in 2.7 when the react-streamfield CSS was introduced, so it's possible that the old design had something to mitigate this, e.g. an asterisk being inserted elsewhere.)