### PR TITLE
Assign file information to form object without using file.save

### DIFF
--- a/wagtail/images/views/multiple.py
+++ b/wagtail/images/views/multiple.py
@@ -114,7 +114,8 @@ class CreateFromUploadedImageView(BaseCreateFromUploadView):
         # assign the file content from uploaded_image to the image object, to ensure it gets saved to
         # Image's storage
 
-        self.object.file.save(os.path.basename(self.upload.file.name), self.upload.file.file, save=False)
+        self.object.file = self.upload.file.file
+        self.object.file.name = os.path.basename(self.upload.file.name)
         self.object.uploaded_by_user = self.request.user
         self.object.file_size = self.object.file.size
         self.object.file.open()


### PR DESCRIPTION
I changed the way file information is transferred from the UploadedImage model to the form that will create the normal image model.

For most sites, my change will not make any difference but it fixes a very specific issue we started seeing in our code base between Wagtail 2.10 and 2.11. Uploads using the single image form such as is used in the Image chooser modal window worked fine but uploads using the image multiple upload path started failing with an error in our custom `get_upload_to` method which uses the image's collection name as the folder name when storing the image file. The problem only occurs when there is a custom image model with a required field AND has a get_upload_to method that uses the collection name AND the person uploading the image only has write access to a single collection. When a user only has one collection, the image upload form removes the collection field from the form and then reassigns it in `BaseCollectionMemberForm#save`. 

The current save_object method of CreateFromUploadedImageView calls file.save(...save=False) to move the file data from UploadedFile to the site's image model. For my situation, that causes `get_upload_to` to be called before `BaseCollectionMemberForm#save` assigns the user's single collection to the image instance. This patch assigns the file name and file data to the image instance without the use of file.save and so defers calling get_upload_to until after the correct collection is available in the image instance. This makes the multiple upload path behave more like the single upload path with all the form saving deferred until the end.

* Do the tests still pass? yes
* Does the code comply with the style guide? yes
* For Python changes: Have you added tests to cover the new/fixed behaviour?
* For front-end changes: Did you test on all of Wagtail’s supported browsers? no frontend changes in this PR
* For new features: Has the documentation been updated accordingly? no new features in this PR
