### PR TITLE
Telepath: Support custom form_template on StructBlock

### DIFF
--- a/client/src/entrypoints/admin/telepath/__snapshots__/blocks.test.js.snap
+++ b/client/src/entrypoints/admin/telepath/__snapshots__/blocks.test.js.snap
@@ -254,15 +254,39 @@ exports[`telepath: wagtail.blocks.StreamBlock it renders correctly 1`] = `
 
 exports[`telepath: wagtail.blocks.StructBlock it renders correctly 1`] = `
 "<div class=\\"struct-block\\">
-      
-        <span>
-          <div class=\\"help\\">
-            <div class=\\"icon-help\\">?</div>
-            use <strong>lots</strong> of these
+        
+          <span>
+            <div class=\\"help\\">
+              <div class=\\"icon-help\\">?</div>
+              use <strong>lots</strong> of these
+            </div>
+          </span>
+        <div class=\\"field required\\">
+            <label class=\\"field__label\\" for=\\"the-prefix-heading_text\\">Heading text</label>
+            <div class=\\"field char_field widget-text_input fieldname-heading_text\\">
+        <div class=\\"field-content\\">
+          <div class=\\"input\\">
+            <p name=\\"the-prefix-heading_text\\" id=\\"the-prefix-heading_text\\">Heading widget</p>
+            <span></span>
           </div>
-        </span>
-      <div class=\\"field required\\">
-          <label class=\\"field__label\\" for=\\"the-prefix-heading_text\\">Heading text</label>
+        </div>
+      </div>
+          </div><div class=\\"field \\">
+            <label class=\\"field__label\\" for=\\"the-prefix-size\\">Size</label>
+            <div class=\\"field choice_field widget-select fieldname-size\\">
+        <div class=\\"field-content\\">
+          <div class=\\"input\\">
+            <p name=\\"the-prefix-size\\" id=\\"the-prefix-size\\">Size widget</p>
+            <span></span>
+          </div>
+        </div>
+      </div>
+          </div></div>"
+`;
+
+exports[`telepath: wagtail.blocks.StructBlock with formTemplate it renders correctly 1`] = `
+"<div class=\\"custom-form-template\\">
+          <p>here comes the first field:</p>
           <div class=\\"field char_field widget-text_input fieldname-heading_text\\">
         <div class=\\"field-content\\">
           <div class=\\"input\\">
@@ -271,8 +295,7 @@ exports[`telepath: wagtail.blocks.StructBlock it renders correctly 1`] = `
           </div>
         </div>
       </div>
-        </div><div class=\\"field \\">
-          <label class=\\"field__label\\" for=\\"the-prefix-size\\">Size</label>
+          <p>and here is the second:</p>
           <div class=\\"field choice_field widget-select fieldname-size\\">
         <div class=\\"field-content\\">
           <div class=\\"input\\">
@@ -281,5 +304,5 @@ exports[`telepath: wagtail.blocks.StructBlock it renders correctly 1`] = `
           </div>
         </div>
       </div>
-        </div></div>"
+        </div>"
 `;

--- a/client/src/entrypoints/admin/telepath/blocks.test.js
+++ b/client/src/entrypoints/admin/telepath/blocks.test.js
@@ -217,6 +217,122 @@ describe('telepath: wagtail.blocks.StructBlock', () => {
   });
 });
 
+describe('telepath: wagtail.blocks.StructBlock with formTemplate', () => {
+  let boundField;
+
+  beforeEach(() => {
+    // Create mocks for callbacks
+    constructor = jest.fn();
+    setState = jest.fn();
+    getState = jest.fn();
+    getValue = jest.fn();
+    focus = jest.fn();
+
+    // Create a placeholder to render the block
+    document.body.innerHTML = '<div id="placeholder"></div>';
+
+    // Unpack and render
+    const fieldDef = window.telepath.unpack({
+      _type: 'wagtail.blocks.StructBlock',
+      _args: ['heading_block', [{
+        _type: 'wagtail.blocks.FieldBlock',
+        _args: ['heading_text', {
+          _type: 'wagtail.widgets.DummyWidget',
+          _args: ['Heading widget']
+        }, {
+          label: 'Heading text',
+          required: true,
+          icon: 'placeholder',
+          classname: 'field char_field widget-text_input fieldname-heading_text'
+        }]
+      }, {
+        _type: 'wagtail.blocks.FieldBlock',
+        _args: ['size', {
+          _type: 'wagtail.widgets.DummyWidget',
+          _args: ['Size widget']
+        }, {
+          label: 'Size',
+          required: false,
+          icon: 'placeholder',
+          classname: 'field choice_field widget-select fieldname-size'
+        }]
+      }], {
+        label: 'Heading block',
+        required: false,
+        icon: 'title',
+        formTemplate: `<div class="custom-form-template">
+          <p>here comes the first field:</p>
+          <div data-structblock-child="heading_text"></div>
+          <p>and here is the second:</p>
+          <div data-structblock-child="size"></div>
+        </div>`,
+      }]
+    });
+    boundField = fieldDef.render($('#placeholder'), 'the-prefix', {
+      heading_text: 'Test heading text',
+      size: '123'
+    });
+  });
+
+  test('it renders correctly', () => {
+    expect(document.body.innerHTML).toMatchSnapshot();
+  });
+
+  test('Widget constructors are called with correct parameters', () => {
+    expect(constructor.mock.calls.length).toBe(2);
+
+    expect(constructor.mock.calls[0][0]).toBe('Heading widget');
+    expect(constructor.mock.calls[0][1]).toEqual({
+      name: 'the-prefix-heading_text',
+      id: 'the-prefix-heading_text',
+      initialState: 'Test heading text',
+    });
+
+    expect(constructor.mock.calls[1][0]).toBe('Size widget');
+    expect(constructor.mock.calls[1][1]).toEqual({
+      name: 'the-prefix-size',
+      id: 'the-prefix-size',
+      initialState: '123',
+    });
+  });
+
+  test('getValue() calls getValue() on all widgets', () => {
+    const value = boundField.getValue();
+    expect(getValue.mock.calls.length).toBe(2);
+    expect(value).toEqual({
+      heading_text: 'value: Heading widget - the-prefix-heading_text',
+      size: 'value: Size widget - the-prefix-size'
+    });
+  });
+
+  test('getState() calls getState() on all widgets', () => {
+    const state = boundField.getState();
+    expect(getState.mock.calls.length).toBe(2);
+    expect(state).toEqual({
+      heading_text: 'state: Heading widget - the-prefix-heading_text',
+      size: 'state: Size widget - the-prefix-size'
+    });
+  });
+
+  test('setState() calls setState() on all widgets', () => {
+    boundField.setState({
+      heading_text: 'Changed heading text',
+      size: '456'
+    });
+    expect(setState.mock.calls.length).toBe(2);
+    expect(setState.mock.calls[0][0]).toBe('Heading widget');
+    expect(setState.mock.calls[0][1]).toBe('Changed heading text');
+    expect(setState.mock.calls[1][0]).toBe('Size widget');
+    expect(setState.mock.calls[1][1]).toBe('456');
+  });
+
+  test('focus() calls focus() on first widget', () => {
+    boundField.focus();
+    expect(focus.mock.calls.length).toBe(1);
+    expect(focus.mock.calls[0][0]).toBe('Heading widget');
+  });
+});
+
 describe('telepath: wagtail.blocks.ListBlock', () => {
   let boundField;
 


### PR DESCRIPTION
Reimplement `form_template` on StructBlock as per https://docs.wagtail.io/en/stable/topics/streamfield.html#custom-editing-interfaces-for-structblock. This works by setting up a dict of custom child BoundBlock objects with a `render_form` method that returns a `<div data-structblock-child="foo"></div>` placeholder, allowing templates to follow the same calling conventions as when rendering happened server-side. This placeholder-rendered template is then passed via telepath and used by the client-side StructBlock where present.

The only limitation is that `get_form_context` does not receive a 'real' value or errors argument, and so anyone relying on those to insert block-value-dependent variables into the context will have to bite the bullet and learn the workings of the new telepath block API instead...