### PR TITLE
Telepath - prevent object ID collisions when packing

### DIFF
--- a/wagtail/core/telepath.py
+++ b/wagtail/core/telepath.py
@@ -248,10 +248,8 @@ class ValueContext:
 
         # as fallback, try handling as an iterable
         try:
-            return ListNode([self.pack(item) for item in obj])
-        except UnpackableTypeError:  # error while packing an item
-            raise
+            items = iter(obj)
         except TypeError:  # obj is not iterable
-            pass
-
-        raise UnpackableTypeError("don't know how to pack object: %r" % obj)
+            raise UnpackableTypeError("don't know how to pack object: %r" % obj)
+        else:
+            return ListNode([self.pack(item) for item in items])

--- a/wagtail/core/telepath.py
+++ b/wagtail/core/telepath.py
@@ -233,9 +233,11 @@ class ValueContext:
             self.packed_values[obj_id] = packed_val
             return packed_val
 
-        # Assign existing_packed_val an ID so that we can create references to it
-        existing_packed_val.id = self.next_id
-        self.next_id += 1
+        if existing_packed_val.id is None:
+            # Assign existing_packed_val an ID so that we can create references to it
+            existing_packed_val.id = self.next_id
+            self.next_id += 1
+
         return existing_packed_val
 
     def _pack_as_value(self, obj):

--- a/wagtail/core/telepath.py
+++ b/wagtail/core/telepath.py
@@ -217,6 +217,7 @@ class ValueContext:
     """
     def __init__(self, parent_context):
         self.parent_context = parent_context
+        self.raw_values = {}
         self.packed_values = {}
         self.next_id = 0
 
@@ -231,6 +232,10 @@ class ValueContext:
             # not seen this value before, so pack it and store in packed_values
             packed_val = self._pack_as_value(val)
             self.packed_values[obj_id] = packed_val
+            # Also keep a reference to the original value to stop it from getting deallocated
+            # and the ID being recycled
+            self.raw_values[obj_id] = val
+
             return packed_val
 
         if existing_packed_val.id is None:

--- a/wagtail/core/tests/test_telepath.py
+++ b/wagtail/core/tests/test_telepath.py
@@ -1,5 +1,4 @@
 import itertools
-import unittest
 
 from django.test import TestCase
 
@@ -266,7 +265,6 @@ register(ArkAdapter(), Ark)
 
 
 class TestIDCollisions(TestCase):
-    @unittest.expectedFailure
     def test_grouper_object_collisions(self):
         """
         Certain functions such as itertools.groupby will cause new objects (namely, tuples and


### PR DESCRIPTION
A couple of fixes to the telepath packing mechanism - in increasing order of importance...

* don't reassign IDs to nodes that already have them
* fix try/catch for unsupported value types so that we're not masking unrelated TypeErrors that happen during `pack`
* keep references to original objects encountered while walking the object tree, so that they don't get deallocated and their object IDs recycled (nasty!)