### PR TITLE
Make all Collection form fields translate-able

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -573,6 +573,7 @@ Changelog
  * Fix: Query model no longer removes punctuation as part of string normalisation (William Blackie)
  * Fix: Make login test helper work with user models with non-default username fields (Andrew Miller)
  * Fix: Delay dirty form check to prevent "unsaved changes" warning from being wrongly triggered (Thibaud Colas)
+ * Fix: Make "Collection" and "Parent" form field labels translatable (Thibaud Colas)
 
 
 2.5.2 (01.08.2019)

--- a/docs/releases/2.13.rst
+++ b/docs/releases/2.13.rst
@@ -60,6 +60,7 @@ Bug fixes
 * Validate host/scheme of return URLs on password authentication forms (Susan Dreher)
 * Reordering a page now includes the correct user in the audit log (Storm Heg)
 * Fix reverse migration errors in images and documents (Mike Brown)
+* Make "Collection" and "Parent" form field labels translatable (Thibaud Colas)
 
 
 Upgrade considerations

--- a/wagtail/admin/forms/collections.py
+++ b/wagtail/admin/forms/collections.py
@@ -68,6 +68,7 @@ class CollectionChoiceField(forms.ModelChoiceField):
 
 class CollectionForm(forms.ModelForm):
     parent = CollectionChoiceField(
+        label=_("Parent"),
         queryset=Collection.objects.all(),
         required=False,
         help_text=_(
@@ -279,6 +280,7 @@ def collection_member_permission_formset_factory(
         (i.e. group or user) for a specific collection
         """
         collection = CollectionChoiceField(
+            label=_("Collection"),
             queryset=Collection.objects.all().prefetch_related('group_permissions'),
             empty_label=None
         )

--- a/wagtail/admin/forms/collections.py
+++ b/wagtail/admin/forms/collections.py
@@ -6,6 +6,7 @@ from django.db import transaction
 from django.db.models import Min
 from django.template.loader import render_to_string
 from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy
 
 from wagtail.core.models import Collection, CollectionViewRestriction, GroupCollectionPermission
 
@@ -68,10 +69,10 @@ class CollectionChoiceField(forms.ModelChoiceField):
 
 class CollectionForm(forms.ModelForm):
     parent = CollectionChoiceField(
-        label=_("Parent"),
+        label=gettext_lazy("Parent"),
         queryset=Collection.objects.all(),
         required=False,
-        help_text=_(
+        help_text=gettext_lazy(
             "Select hierarchical position. Note: a collection cannot become a child of itself or one of its "
             "descendants."
         )

--- a/wagtail/documents/forms.py
+++ b/wagtail/documents/forms.py
@@ -14,7 +14,7 @@ from wagtail.documents.permissions import permission_policy as documents_permiss
 # Callback to allow us to override the default form field for the collection field
 def formfield_for_dbfield(db_field, **kwargs):
     if db_field.name == 'collection':
-        return CollectionChoiceField(queryset=Collection.objects.all(), empty_label=None, **kwargs)
+        return CollectionChoiceField(label=_("Collection"), queryset=Collection.objects.all(), empty_label=None, **kwargs)
 
     # For all other fields, just call its formfield() method.
     return db_field.formfield(**kwargs)

--- a/wagtail/images/forms.py
+++ b/wagtail/images/forms.py
@@ -20,7 +20,7 @@ def formfield_for_dbfield(db_field, **kwargs):
     if db_field.name == 'file':
         return WagtailImageField(label=capfirst(db_field.verbose_name), **kwargs)
     elif db_field.name == 'collection':
-        return CollectionChoiceField(queryset=Collection.objects.all(), empty_label=None, **kwargs)
+        return CollectionChoiceField(label=_("Collection"), queryset=Collection.objects.all(), empty_label=None, **kwargs)
 
     # For all other fields, just call its formfield() method.
     return db_field.formfield(**kwargs)


### PR DESCRIPTION
Initially reported in #6737 for the image chooser, but I then realised the issue was more widespread. The "Collection" field wasn’t set up for translations in:

- Document upload form
- Image edit form
- Image multi-upload form
- Image chooser upload form
- Document chooser upload form

The fix is just to override the auto-generated label with our translate-able equivalent, just like we do for other form fields.

Additionally, the "Parent" field also needed the same treatment in the collection  create/edit form.

I’ve only tested this in Chrome by navigating to some of the relevant forms. Existing translations already have a "collection" string, so the translated label should appear without further work. For "Parent", this will need to be translated in Transifex.