### PR TITLE
Defer rendering StreamBlock menu until opened

### DIFF
--- a/client/src/components/StreamField/blocks/StreamBlock.js
+++ b/client/src/components/StreamField/blocks/StreamBlock.js
@@ -36,6 +36,7 @@ class StreamBlockMenu {
     this.index = opts && opts.index;
     this.onSelectBlockType = opts && opts.onSelectBlockType;
     this.isOpen = (opts && opts.isOpen) || false;
+    this.groupedChildBlockDefs = groupedChildBlockDefs;
 
     const dom = $(`
       <div>
@@ -56,15 +57,27 @@ class StreamBlockMenu {
     });
 
     this.outerContainer = dom.find('[data-streamblock-menu-outer]');
-    const innerContainer = dom.find('[data-streamblock-menu-inner]');
+    this.innerContainer = dom.find('[data-streamblock-menu-inner]');
+    this.hasRenderedMenu = false;
 
-    groupedChildBlockDefs.forEach(([group, blockDefs]) => {
+    if (this.isOpen) {
+      this.open({ animate: false });
+    } else {
+      this.close({ animate: false });
+    }
+  }
+
+  renderMenu() {
+    if (this.hasRenderedMenu) return;
+    this.hasRenderedMenu = true;
+
+    this.groupedChildBlockDefs.forEach(([group, blockDefs]) => {
       if (group) {
         const heading = $('<h4 class="c-sf-add-panel__group-title"></h4>').text(group);
-        innerContainer.append(heading);
+        this.innerContainer.append(heading);
       }
       const grid = $('<div class="c-sf-add-panel__grid"></div>');
-      innerContainer.append(grid);
+      this.innerContainer.append(grid);
       blockDefs.forEach(blockDef => {
         const button = $(`
           <button type="button" class="c-sf-button action-add-block-${blockDef.name}">
@@ -83,12 +96,6 @@ class StreamBlockMenu {
         });
       });
     });
-
-    if (this.isOpen) {
-      this.open({ animate: false });
-    } else {
-      this.close({ animate: false });
-    }
   }
 
   setIndex(newIndex) {
@@ -103,6 +110,7 @@ class StreamBlockMenu {
     }
   }
   open(opts) {
+    this.renderMenu();
     if (opts && opts.animate) {
       this.outerContainer.slideDown();
     } else {

--- a/client/src/components/StreamField/blocks/StreamBlock.test.js
+++ b/client/src/components/StreamField/blocks/StreamBlock.test.js
@@ -108,6 +108,11 @@ describe('telepath: wagtail.blocks.StreamBlock', () => {
     expect(document.body.innerHTML).toMatchSnapshot();
   });
 
+  test('it renders menus on opening', () => {
+    boundBlock.menus[1].open();
+    expect(document.body.innerHTML).toMatchSnapshot();
+  });
+
   test('Widget constructors are called with correct parameters', () => {
     expect(constructor.mock.calls.length).toBe(2);
 

--- a/client/src/components/StreamField/blocks/__snapshots__/StreamBlock.test.js.snap
+++ b/client/src/components/StreamField/blocks/__snapshots__/StreamBlock.test.js.snap
@@ -13,17 +13,7 @@ exports[`telepath: wagtail.blocks.StreamBlock it renders correctly 1`] = `
           <i aria-hidden=\\"true\\">+</i>
         </button>
         <div data-streamblock-menu-outer=\\"\\" style=\\"display: none;\\" aria-hidden=\\"true\\">
-          <div data-streamblock-menu-inner=\\"\\" class=\\"c-sf-add-panel\\"><div class=\\"c-sf-add-panel__grid\\"><button type=\\"button\\" class=\\"c-sf-button action-add-block-test_block_a\\">
-            <span class=\\"c-sf-button__icon\\">
-              <i class=\\"icon icon-placeholder\\"></i>
-            </span>
-            <span class=\\"c-sf-button__label\\">Test Block A</span>
-          </button><button type=\\"button\\" class=\\"c-sf-button action-add-block-test_block_b\\">
-            <span class=\\"c-sf-button__icon\\">
-              <i class=\\"icon icon-pilcrow\\"></i>
-            </span>
-            <span class=\\"c-sf-button__label\\">Test Block B</span>
-          </button></div></div>
+          <div data-streamblock-menu-inner=\\"\\" class=\\"c-sf-add-panel\\"></div>
         </div>
       </div><div aria-hidden=\\"false\\">
         <input type=\\"hidden\\" name=\\"the-prefix-0-deleted\\" value=\\"\\">
@@ -72,6 +62,123 @@ exports[`telepath: wagtail.blocks.StreamBlock it renders correctly 1`] = `
           <i aria-hidden=\\"true\\">+</i>
         </button>
         <div data-streamblock-menu-outer=\\"\\" style=\\"display: none;\\" aria-hidden=\\"true\\">
+          <div data-streamblock-menu-inner=\\"\\" class=\\"c-sf-add-panel\\"></div>
+        </div>
+      </div><div aria-hidden=\\"false\\">
+        <input type=\\"hidden\\" name=\\"the-prefix-1-deleted\\" value=\\"\\">
+        <input type=\\"hidden\\" name=\\"the-prefix-1-order\\" value=\\"1\\">
+        <input type=\\"hidden\\" name=\\"the-prefix-1-type\\" value=\\"test_block_b\\">
+        <input type=\\"hidden\\" name=\\"the-prefix-1-id\\" value=\\"2\\">
+
+        <div>
+          <div class=\\"c-sf-container__block-container\\">
+            <div class=\\"c-sf-block\\">
+              <div class=\\"c-sf-block__header\\">
+                <span class=\\"c-sf-block__header__icon\\">
+                  <i class=\\"icon icon-pilcrow\\"></i>
+                </span>
+                <h3 class=\\"c-sf-block__header__title\\"></h3>
+                <div class=\\"c-sf-block__actions\\">
+                  <span class=\\"c-sf-block__type\\">Test Block B</span>
+                  <button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"{% trans 'Move up' %}\\">
+                    <i class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\"></i>
+                  </button>
+                  <button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"{% trans 'Move down' %}\\">
+                    <i class=\\"icon icon-arrow-down\\" aria-hidden=\\"true\\"></i>
+                  </button>
+                  <button type=\\"button\\" data-delete-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"{% trans 'Delete' %}\\">
+                    <i class=\\"icon icon-bin\\" aria-hidden=\\"true\\"></i>
+                  </button>
+                </div>
+              </div>
+              <div class=\\"c-sf-block__content\\" aria-hidden=\\"false\\">
+                <div class=\\"c-sf-block__content-inner\\">
+                  <div class=\\"field char_field widget-admin_auto_height_text_input fieldname-test_textblock\\">
+        <div class=\\"field-content\\">
+          <div class=\\"input\\">
+            <p name=\\"the-prefix-1-value\\" id=\\"the-prefix-1-value\\">Block B widget</p>
+            <span></span>
+          </div>
+        </div>
+      </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div><div>
+        <button data-streamblock-menu-open=\\"\\" type=\\"button\\" title=\\"Add\\" class=\\"c-sf-add-button c-sf-add-button--visible\\">
+          <i aria-hidden=\\"true\\">+</i>
+        </button>
+        <div data-streamblock-menu-outer=\\"\\" style=\\"display: none;\\" aria-hidden=\\"true\\">
+          <div data-streamblock-menu-inner=\\"\\" class=\\"c-sf-add-panel\\"></div>
+        </div>
+      </div></div>
+      </div>"
+`;
+
+exports[`telepath: wagtail.blocks.StreamBlock it renders menus on opening 1`] = `
+"<span>
+          <div class=\\"help\\">
+            <div class=\\"icon-help\\">?</div>
+            use <strong>plenty</strong> of these
+          </div>
+        </span><div class=\\"c-sf-container \\">
+        <input type=\\"hidden\\" name=\\"the-prefix-count\\" data-streamfield-stream-count=\\"\\" value=\\"2\\">
+        <div data-streamfield-stream-container=\\"\\"><div>
+        <button data-streamblock-menu-open=\\"\\" type=\\"button\\" title=\\"Add\\" class=\\"c-sf-add-button c-sf-add-button--visible\\">
+          <i aria-hidden=\\"true\\">+</i>
+        </button>
+        <div data-streamblock-menu-outer=\\"\\" style=\\"display: none;\\" aria-hidden=\\"true\\">
+          <div data-streamblock-menu-inner=\\"\\" class=\\"c-sf-add-panel\\"></div>
+        </div>
+      </div><div aria-hidden=\\"false\\">
+        <input type=\\"hidden\\" name=\\"the-prefix-0-deleted\\" value=\\"\\">
+        <input type=\\"hidden\\" name=\\"the-prefix-0-order\\" value=\\"0\\">
+        <input type=\\"hidden\\" name=\\"the-prefix-0-type\\" value=\\"test_block_a\\">
+        <input type=\\"hidden\\" name=\\"the-prefix-0-id\\" value=\\"1\\">
+
+        <div>
+          <div class=\\"c-sf-container__block-container\\">
+            <div class=\\"c-sf-block\\">
+              <div class=\\"c-sf-block__header\\">
+                <span class=\\"c-sf-block__header__icon\\">
+                  <i class=\\"icon icon-placeholder\\"></i>
+                </span>
+                <h3 class=\\"c-sf-block__header__title\\"></h3>
+                <div class=\\"c-sf-block__actions\\">
+                  <span class=\\"c-sf-block__type\\">Test Block A</span>
+                  <button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"{% trans 'Move up' %}\\">
+                    <i class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\"></i>
+                  </button>
+                  <button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"{% trans 'Move down' %}\\">
+                    <i class=\\"icon icon-arrow-down\\" aria-hidden=\\"true\\"></i>
+                  </button>
+                  <button type=\\"button\\" data-delete-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"{% trans 'Delete' %}\\">
+                    <i class=\\"icon icon-bin\\" aria-hidden=\\"true\\"></i>
+                  </button>
+                </div>
+              </div>
+              <div class=\\"c-sf-block__content\\" aria-hidden=\\"false\\">
+                <div class=\\"c-sf-block__content-inner\\">
+                  <div class=\\"field char_field widget-text_input fieldname-test_charblock\\">
+        <div class=\\"field-content\\">
+          <div class=\\"input\\">
+            <p name=\\"the-prefix-0-value\\" id=\\"the-prefix-0-value\\">Block A widget</p>
+            <span></span>
+          </div>
+        </div>
+      </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div><div>
+        <button data-streamblock-menu-open=\\"\\" type=\\"button\\" title=\\"Add\\" class=\\"c-sf-add-button c-sf-add-button--visible c-sf-add-button--close\\">
+          <i aria-hidden=\\"true\\">+</i>
+        </button>
+        <div data-streamblock-menu-outer=\\"\\" style=\\"\\" aria-hidden=\\"false\\">
           <div data-streamblock-menu-inner=\\"\\" class=\\"c-sf-add-panel\\"><div class=\\"c-sf-add-panel__grid\\"><button type=\\"button\\" class=\\"c-sf-button action-add-block-test_block_a\\">
             <span class=\\"c-sf-button__icon\\">
               <i class=\\"icon icon-placeholder\\"></i>
@@ -131,17 +238,7 @@ exports[`telepath: wagtail.blocks.StreamBlock it renders correctly 1`] = `
           <i aria-hidden=\\"true\\">+</i>
         </button>
         <div data-streamblock-menu-outer=\\"\\" style=\\"display: none;\\" aria-hidden=\\"true\\">
-          <div data-streamblock-menu-inner=\\"\\" class=\\"c-sf-add-panel\\"><div class=\\"c-sf-add-panel__grid\\"><button type=\\"button\\" class=\\"c-sf-button action-add-block-test_block_a\\">
-            <span class=\\"c-sf-button__icon\\">
-              <i class=\\"icon icon-placeholder\\"></i>
-            </span>
-            <span class=\\"c-sf-button__label\\">Test Block A</span>
-          </button><button type=\\"button\\" class=\\"c-sf-button action-add-block-test_block_b\\">
-            <span class=\\"c-sf-button__icon\\">
-              <i class=\\"icon icon-pilcrow\\"></i>
-            </span>
-            <span class=\\"c-sf-button__label\\">Test Block B</span>
-          </button></div></div>
+          <div data-streamblock-menu-inner=\\"\\" class=\\"c-sf-add-panel\\"></div>
         </div>
       </div></div>
       </div>"


### PR DESCRIPTION
A small optimisation for large StreamBlocks - most stream menus will never be expanded, so it's wasted work to render the menu contents up-front.
