### PR TITLE
Fix: 500 error when searching in admin

### DIFF
--- a/wagtail/admin/tests/pages/test_page_search.py
+++ b/wagtail/admin/tests/pages/test_page_search.py
@@ -175,3 +175,12 @@ class TestPageSearch(TestCase, WagtailTestUtils):
         response = self.get({'q': 'Lunar', 'ordering': '-live'})
         page_ids = [page.id for page in response.context['pages']]
         self.assertEqual(page_ids, [live_event.id, draft_event.id])
+
+    def test_search_filter_content_type(self):
+        # Correct content_type
+        response = self.get({'content_type': "demosite.standardpage"})
+        self.assertEqual(response.status_code, 200)
+
+        # Incorrect content_type
+        response = self.get({'content_type': "demosite.standardpage.error"})
+        self.assertEqual(response.status_code, 404)

--- a/wagtail/admin/views/pages/search.py
+++ b/wagtail/admin/views/pages/search.py
@@ -43,7 +43,10 @@ def search(request):
     if 'content_type' in request.GET:
         pagination_query_params['content_type'] = request.GET['content_type']
 
-        app_label, model_name = request.GET['content_type'].split('.')
+        try:
+            app_label, model_name = request.GET['content_type'].split('.')
+        except ValueError:
+            raise Http404
 
         try:
             selected_content_type = ContentType.objects.get_by_natural_key(app_label, model_name)


### PR DESCRIPTION
# Current behavior:
Malformed query strings cause the app to crash while filtering search results in the admin.

Manually adding a period to the `content_type` in the URL's query string will cause the admin site to 500.

## Working Query

http://127.0.01:8000/admin/pages/search/?content_type=demosite.standardpage

## Broken Query

http://127.0.01:8000/admin/pages/search/?content_type=demosite.standardpage.broken

# Expected behavior:
Malformed URLS should 404.

# Cause

Too many values to unpack.

`app_label, model_name = request.GET['content_type'].split('.')`

Source: https://github.com/wagtail/wagtail/blob/main/wagtail/admin/views/pages/search.py#L46

# Fix:
Add a try/except block around `app_label, model_name = request.GET['content_type'].split('.')`


# Reproduce

This is reproducible on the demo site by using the following path.
`http://127.0.01:8000/admin/pages/search/?content_type=demosite.standardpage.error`

----

* Do the tests still pass? Yes
* Does the code comply with the style guide? Yes
* For Python changes: Have you added tests to cover the new/fixed behaviour? Yes
* For front-end changes: Did you test on all of Wagtail’s supported browsers? N/A
* For new features: Has the documentation been updated accordingly? N/A
