### PR TITLE
Add `wagtail.reorder` audit log action

### DIFF
--- a/docs/advanced_topics/audit_log.rst
+++ b/docs/advanced_topics/audit_log.rst
@@ -72,6 +72,7 @@ Action                               Notes
 ``wagtail.revert``                   The page was reverted to a previous draft
 ``wagtail.copy``                     The page was copied to a new location
 ``wagtail.move``                     The page was moved to a new location
+``wagtail.reorder``                  The order of the page under it's parent was changed
 ``wagtail.view_restriction.create``  The page was restricted
 ``wagtail.view_restriction.edit``    The page restrictions were updated
 ``wagtail.view_restriction.delete``  The page restrictions were removed

--- a/wagtail/admin/views/pages/ordering.py
+++ b/wagtail/admin/views/pages/ordering.py
@@ -34,11 +34,11 @@ def set_page_position(request, page_to_move_id):
             # right. If left, then left.
             old_position = list(parent_page.get_children()).index(page_to_move)
             if int(position) < old_position:
-                page_to_move.move(position_page, pos='left')
+                page_to_move.move(position_page, pos='left', user=request.user)
             elif int(position) > old_position:
-                page_to_move.move(position_page, pos='right')
+                page_to_move.move(position_page, pos='right', user=request.user)
         else:
             # Move page to end
-            page_to_move.move(parent_page, pos='last-child')
+            page_to_move.move(parent_page, pos='last-child', user=request.user)
 
     return HttpResponse('')

--- a/wagtail/admin/wagtail_hooks.py
+++ b/wagtail/admin/wagtail_hooks.py
@@ -866,6 +866,14 @@ def register_core_log_actions(actions):
         except KeyError:
             return _('Moved')
 
+    def reorder_message(data):
+        try:
+            return _("Reordered under '%(parent)s'") % {
+                'parent': data['destination']['title'],
+            }
+        except KeyError:
+            return _('Reordered')
+
     def schedule_publish_message(data):
         try:
             if data['revision']['has_live_version']:
@@ -935,6 +943,7 @@ def register_core_log_actions(actions):
     actions.register_action('wagtail.create_alias', _('Create alias'), create_alias_message)
     actions.register_action('wagtail.convert_alias', _('Convert alias into regular page'), convert_alias_message)
     actions.register_action('wagtail.move', _('Move'), move_message)
+    actions.register_action('wagtail.reorder', _('Reorder'), reorder_message)
     actions.register_action('wagtail.publish.schedule', _("Schedule publication"), schedule_publish_message)
     actions.register_action('wagtail.schedule.cancel', _("Unschedule publication"), unschedule_publish_message)
     actions.register_action('wagtail.view_restriction.create', _("Add view restrictions"), add_view_restriction)

--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -2062,7 +2062,8 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
         # Log
         PageLogEntry.objects.log_action(
             instance=self,
-            action='wagtail.move',
+            # Check if page was reordered (reordering doesn't change the parent)
+            action='wagtail.reorder' if parent_before.id == target.id else 'wagtail.move',
             user=user,
             data={
                 'source': {

--- a/wagtail/core/tests/test_audit_log.py
+++ b/wagtail/core/tests/test_audit_log.py
@@ -189,9 +189,10 @@ class TestAuditLog(TestCase):
         section = self.root_page.add_child(
             instance=SimplePage(title="About us", slug="about", content="hello")
         )
+        user = get_user_model().objects.first()
+        section.move(self.home_page, user=user)
 
-        section.move(self.home_page)
-        self.assertEqual(PageLogEntry.objects.filter(action='wagtail.move').count(), 1)
+        self.assertEqual(PageLogEntry.objects.filter(action='wagtail.move', user=user).count(), 1)
 
     def test_page_delete(self):
         self.home_page.add_child(


### PR DESCRIPTION
Include `request.user` so `Page.move()` can include it in it's log entry. This will prevent the log entry from having no acting user associated with it (#6761).