### PR TITLE
Quote pip install command in developing docs

### DIFF
--- a/docs/contributing/developing.rst
+++ b/docs/contributing/developing.rst
@@ -257,7 +257,7 @@ The Wagtail documentation is built by Sphinx. To install Sphinx and compile the 
 
     $ cd /path/to/wagtail
     $ # Install the documentation dependencies
-    $ pip install -e .[docs]
+    $ pip install -e '.[docs]'
     $ # Compile the docs
     $ cd docs/
     $ make html


### PR DESCRIPTION
Prevents it from failing with zsh: no matches found: .[docs]

Thanks for contributing to Wagtail! 🎉

Before submitting, please review the contributor guidelines <https://docs.wagtail.io/en/latest/contributing/index.html> and check the following:

* Do the tests still pass? (https://docs.wagtail.io/en/latest/contributing/developing.html#testing)
* Does the code comply with the style guide? (Run `make lint` from the Wagtail root)
* For Python changes: Have you added tests to cover the new/fixed behaviour?
* For front-end changes: Did you test on all of Wagtail’s supported browsers? **Please list the exact versions you tested**.
* For new features: Has the documentation been updated accordingly?
