### PR TITLE
Fix broken "make livehtml" command

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -185,6 +185,6 @@ pseudoxml:
 	@echo "Build finished. The pseudo-XML files are in $(BUILDDIR)/pseudoxml."
 
 livehtml:
-	sphinx-autobuild --poll -p 4000 -H 0.0.0.0 -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	sphinx-autobuild --port 4000 --host 0.0.0.0 -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 
 


### PR DESCRIPTION
The documentation [suggests](https://docs.wagtail.io/en/stable/contributing/developing.html#compiling-the-documentation) running `make livehtml` to automatically build the docs as you're working on them.

This uses the [sphinx-autobuild](https://github.com/executablebooks/sphinx-autobuild) package but unfortunately seems to have been broken since [its most recent release](https://github.com/executablebooks/sphinx-autobuild/blob/master/NEWS.rst#20200901---2020-09-01) last year. (This is because our setup.py [specifies](https://github.com/wagtail/wagtail/blob/7bb4fddcb382bf6b50ad58185ad049f7e2ea9753/setup.py#L77) the unbounded `sphinx-autobuild>=0.6.0` version.)

Specifically, the sphinx-autobuild command line syntax no longer accepts shorthand options `-p` and `-H`, requiring use of `--port` and `--host` instead. Additionally the `--poll` option is no longer supported.

To test, run `cd docs && make livehtml`.