### PR TITLE
Limit GitHub Actions docs and test workflows depending on changed paths

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,12 @@ name: Wagtail Docs
 
 on:
   push:
+    paths:
+    - 'docs/**'
   pull_request:
+    paths:
+    - 'docs/**'
+
 
 jobs:
   build-docs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,11 @@ name: Wagtail CI
 
 on:
   push:
+    paths-ignore:
+    - 'docs/**'
   pull_request:
+    paths-ignore:
+    - 'docs/**'
 
 
 # Our test suite should cover:


### PR DESCRIPTION
This should result in the docs workflow only running if files in the `docs/` folder have changed, and only run the test workflow if files NOT in the `docs/` folder have changed.

This first commit itself should therefore, I think, only trigger the test workflow. I will follow up with test commits for the other scenarios (docs-only and both).