### PR TITLE
Store empty string if embed does not have thumbnail_url

### DIFF
--- a/wagtail/embeds/embeds.py
+++ b/wagtail/embeds/embeds.py
@@ -42,6 +42,10 @@ def get_embed(url, max_width=None, finder=None):
     if 'html' not in embed_dict or not embed_dict['html']:
         embed_dict['html'] = ''
 
+    # If the finder does not return an thumbnail_url, convert null to '' before inserting into the db
+    if 'thumbnail_url' not in embed_dict or not embed_dict['thumbnail_url']:
+        embed_dict['thumbnail_url'] = ''
+
     # Create database record
     embed, created = Embed.objects.get_or_create(
         hash=embed_hash,

--- a/wagtail/embeds/migrations/0009_convert_null_to_empty_string.py
+++ b/wagtail/embeds/migrations/0009_convert_null_to_empty_string.py
@@ -1,0 +1,18 @@
+from django.db import migrations
+
+
+def migrate_forwards(apps, schema_editor):
+    Embed = apps.get_model("wagtailembeds.Embed")
+
+    Embed.objects.filter(thumbnail_url__isnull=True).all().update(thumbnail_url='')
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("wagtailembeds", "0008_allow_long_urls"),
+    ]
+
+    operations = [
+        migrations.RunPython(migrate_forwards, migrations.RunPython.noop),
+    ]

--- a/wagtail/embeds/tests/test_embeds.py
+++ b/wagtail/embeds/tests/test_embeds.py
@@ -128,7 +128,6 @@ class TestEmbeds(TestCase):
         return {
             'title': "Test: " + url,
             'type': 'video',
-            'thumbnail_url': '',
             'width': max_width if max_width else 640,
             'height': 480,
             'html': "<p>Blah blah blah</p>",
@@ -142,6 +141,7 @@ class TestEmbeds(TestCase):
         self.assertEqual(embed.title, "Test: www.test.com/1234")
         self.assertEqual(embed.type, 'video')
         self.assertEqual(embed.width, 400)
+        self.assertEqual(embed.thumbnail_url, '')
 
         # Check ratio calculations
         self.assertEqual(embed.ratio, 480 / 400)
@@ -518,7 +518,6 @@ class TestFacebookOEmbed(TestCase):
                     "title": "test_title",
                     "author_name": "test_author",
                     "provider_name": "Facebook",
-                    "thumbnail_url": "test_thumbail_url",
                     "width": "test_width",
                     "height": "test_height",
                     "html": "<blockquote class=\\\"facebook-media\\\">Content</blockquote>"
@@ -539,7 +538,7 @@ class TestFacebookOEmbed(TestCase):
             'title': 'test_title',
             'author_name': 'test_author',
             'provider_name': 'Facebook',
-            'thumbnail_url': 'test_thumbail_url',
+            'thumbnail_url': None,
             'width': 'test_width',
             'height': 'test_height',
             'html': '<blockquote class="facebook-media">Content</blockquote>'


### PR DESCRIPTION
Fixes issue #6788 

* Do the tests still pass? yes
* Does the code comply with the style guide? yes
* For Python changes: Have you added tests to cover the new/fixed behaviour? Modified one existing test to cover this
* For front-end changes: Did you test on all of Wagtail’s supported browsers? N/A
* For new features: Has the documentation been updated accordingly?  N/A
