### PR TITLE
Telepath: Catch JavaScript errors from widget rendering

### DIFF
--- a/client/src/components/StreamField/blocks/FieldBlock.js
+++ b/client/src/components/StreamField/blocks/FieldBlock.js
@@ -20,7 +20,18 @@ export class FieldBlock {
     $(placeholder).replaceWith(dom);
     const widgetElement = dom.find('[data-streamfield-widget]').get(0);
     this.element = dom[0];
-    this.widget = this.blockDef.widget.render(widgetElement, prefix, prefix, initialState);
+
+    try {
+      this.widget = this.blockDef.widget.render(widgetElement, prefix, prefix, initialState);
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.error(e);
+      this.setError([
+        ['This widget failed to render, please check the console for details']
+      ]);
+      return;
+    }
+
     this.idForLabel = this.widget.idForLabel;
 
     if (this.blockDef.meta.helpText) {
@@ -36,7 +47,9 @@ export class FieldBlock {
   }
 
   setState(state) {
-    this.widget.setState(state);
+    if (this.widget) {
+      this.widget.setState(state);
+    }
   }
 
   setError(errorList) {
@@ -63,7 +76,9 @@ export class FieldBlock {
   }
 
   focus() {
-    this.widget.focus();
+    if (this.widget) {
+      this.widget.focus();
+    }
   }
 }
 

--- a/client/src/components/StreamField/blocks/FieldBlock.test.js
+++ b/client/src/components/StreamField/blocks/FieldBlock.test.js
@@ -13,11 +13,16 @@ let getValue = (_widgetName) => {};
 let focus = (_widgetName) => {};
 
 class DummyWidgetDefinition {
-  constructor(widgetName) {
+  constructor(widgetName, { throwErrorOnRender = false } = {}) {
     this.widgetName = widgetName;
+    this.throwErrorOnRender = throwErrorOnRender;
   }
 
   render(placeholder, name, id, initialState) {
+    if (this.throwErrorOnRender) {
+      throw new Error();
+    }
+
     const widgetName = this.widgetName;
     constructor(widgetName, { name, id, initialState });
 
@@ -102,5 +107,43 @@ describe('telepath: wagtail.blocks.FieldBlock', () => {
     boundBlock.focus();
     expect(focus.mock.calls.length).toBe(1);
     expect(focus.mock.calls[0][0]).toBe('The widget');
+  });
+});
+
+describe('telepath: wagtail.blocks.FieldBlock catches widget render errors', () => {
+  let boundBlock;
+
+  beforeEach(() => {
+    // Create mocks for callbacks
+    constructor = jest.fn();
+    setState = jest.fn();
+    getState = jest.fn();
+    getValue = jest.fn();
+    focus = jest.fn();
+
+    // Define a test block
+    const blockDef = new FieldBlockDefinition(
+      'test_field',
+      new DummyWidgetDefinition('The widget', { throwErrorOnRender: true }),
+      {
+        label: 'Test Field',
+        required: true,
+        icon: 'placeholder',
+        classname: 'field char_field widget-text_input fieldname-test_charblock',
+        helpText: 'drink <em>more</em> water'
+      }
+    );
+
+    // Render it
+    document.body.innerHTML = '<div id="placeholder"></div>';
+    boundBlock = blockDef.render(
+      $('#placeholder'),
+      'the-prefix',
+      'Test initial state'
+    );
+  });
+
+  test('it renders correctly', () => {
+    expect(document.body.innerHTML).toMatchSnapshot();
   });
 });

--- a/client/src/components/StreamField/blocks/__snapshots__/FieldBlock.test.js.snap
+++ b/client/src/components/StreamField/blocks/__snapshots__/FieldBlock.test.js.snap
@@ -1,5 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`telepath: wagtail.blocks.FieldBlock catches widget render errors it renders correctly 1`] = `
+"<div class=\\"field char_field widget-text_input fieldname-test_charblock error\\">
+        <div class=\\"field-content\\">
+          <div class=\\"input\\">
+            <div data-streamfield-widget=\\"\\"></div>
+            <span></span>
+          </div>
+        <p class=\\"error-message\\"><span>This widget failed to render, please check the console for details</span></p></div>
+      </div>"
+`;
+
 exports[`telepath: wagtail.blocks.FieldBlock it renders correctly 1`] = `
 "<div class=\\"field char_field widget-text_input fieldname-test_charblock\\">
         <div class=\\"field-content\\">


### PR DESCRIPTION
Currently, if a widget has a JS error and fails to render, the error is not caught causing state consistency problems in all of the structural blocks it is contained within.

This commit makes `FieldBlock` catch widget rendering errors and displays an error message to the user (and puts full details in the console).

![image](https://user-images.githubusercontent.com/1093808/107504543-60016200-6b93-11eb-9ed5-fc4b808fd69e.png)
