### PR TITLE
Don't focus date pickers when adding new blocks

### DIFF
--- a/client/src/components/StreamField/blocks/BaseSequenceBlock.js
+++ b/client/src/components/StreamField/blocks/BaseSequenceBlock.js
@@ -136,8 +136,8 @@ export class BaseSequenceChild {
     this.block.setError(error);
   }
 
-  focus() {
-    this.block.focus();
+  focus(opts) {
+    this.block.focus(opts);
   }
 }
 
@@ -204,7 +204,8 @@ export class BaseSequenceBlock {
     /* handler for an 'insert new block' action */
     const [blockDef, initialState] = this._getChildDataForInsertion(opts);
     const newChild = this._insert(blockDef, initialState, null, index, { animate: true });
-    newChild.focus();
+    // focus the newly added field if we can do so without obtrusive UI behaviour
+    newChild.focus({ soft: true });
   }
 
 
@@ -369,9 +370,9 @@ export class BaseSequenceBlock {
     return this.children.map(child => child.getValue());
   }
 
-  focus() {
+  focus(opts) {
     if (this.children.length) {
-      this.children[0].focus();
+      this.children[0].focus(opts);
     }
   }
 }

--- a/client/src/components/StreamField/blocks/FieldBlock.js
+++ b/client/src/components/StreamField/blocks/FieldBlock.js
@@ -75,9 +75,9 @@ export class FieldBlock {
     return this.widget.getValue();
   }
 
-  focus() {
+  focus(opts) {
     if (this.widget) {
-      this.widget.focus();
+      this.widget.focus(opts);
     }
   }
 }

--- a/client/src/components/StreamField/blocks/ListBlock.js
+++ b/client/src/components/StreamField/blocks/ListBlock.js
@@ -114,7 +114,7 @@ export class ListBlock extends BaseSequenceBlock {
   duplicateBlock(index) {
     const childState = this.children[index].getState();
     this.insert(childState, index + 1, { animate: true });
-    this.children[index + 1].focus();
+    this.children[index + 1].focus({ soft: true });
   }
 
   setError(errorList) {

--- a/client/src/components/StreamField/blocks/StreamBlock.js
+++ b/client/src/components/StreamField/blocks/StreamBlock.js
@@ -295,7 +295,8 @@ export class StreamBlock extends BaseSequenceBlock {
     const childState = this.children[index].getState();
     childState.id = null;
     this.insert(childState, index + 1, { animate: true });
-    this.children[index + 1].focus();
+    // focus the newly added field if we can do so without obtrusive UI behaviour
+    this.children[index + 1].focus({ soft: true });
 
     this.checkBlockCounts();
   }

--- a/client/src/components/StreamField/blocks/StructBlock.js
+++ b/client/src/components/StreamField/blocks/StructBlock.js
@@ -113,10 +113,10 @@ export class StructBlock {
     return value;
   }
 
-  focus() {
+  focus(opts) {
     if (this.blockDef.childBlockDefs.length) {
       const firstChildName = this.blockDef.childBlockDefs[0].name;
-      this.childBlocks[firstChildName].focus();
+      this.childBlocks[firstChildName].focus(opts);
     }
   }
 }

--- a/client/src/entrypoints/admin/telepath/widgets.js
+++ b/client/src/entrypoints/admin/telepath/widgets.js
@@ -161,7 +161,9 @@ class BaseDateTimeWidget extends Widget {
             setState(state) {
                 element.value = state;
             },
-            focus() {
+            focus(opts) {
+                // focusing opens the date picker, so don't do this if it's a 'soft' focus
+                if (opts && opts.soft) return;
                 element.focus();
             },
             idForLabel: id,


### PR DESCRIPTION
While focusing on the first child field of a new block is generally a good thing, focusing a date field opens the date picker, which looks clunky when you've not explicitly requested it. Introduce a 'soft' focus flag to indicate that we only want to focus the field if it can be done unobtrusively.
