### PR TITLE
Allow html formatted error messages in javascript validation from the multi image uploader

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -17,6 +17,7 @@ Changelog
  * Simplify generic admin view templates plus ensure `page_title` and `page_subtitle` are used consistently (Matt Westcott)
  * Extend support for collapsing edit panels from just MultiFieldPanels to all kinds of panels (Fabien Le Frapper, Robbie Mackay)
  * Add object count to header within modeladmin listing view (Jonathan "Yoni" Knoll)
+ * Add ability to return HTML in multiple image upload errors (Gordon Pendleton)
  * Fix: Delete button is now correct colour on snippets and modeladmin listings (Brandon Murch)
  * Fix: Ensure that StreamBlock / ListBlock-level validation errors are counted towards error counts (Matt Westcott)
  * Fix: InlinePanel add button is now keyboard navigatable (Jesse Menn)

--- a/docs/releases/2.15.rst
+++ b/docs/releases/2.15.rst
@@ -28,6 +28,7 @@ Other features
  * Simplify generic admin view templates plus ensure ``page_title`` and ``page_subtitle`` are used consistently (Matt Westcott)
  * Extend support for :ref:`collapsing edit panels <collapsible>` from just MultiFieldPanels to all kinds of panels (Fabien Le Frapper, Robbie Mackay)
  * Add object count to header within modeladmin listing view (Jonathan "Yoni" Knoll)
+ * Add ability to return HTML in multiple image upload errors (Gordon Pendleton)
 
 Bug fixes
 ~~~~~~~~~

--- a/wagtail/images/static_src/wagtailimages/js/add-multiple.js
+++ b/wagtail/images/static_src/wagtailimages/js/add-multiple.js
@@ -59,7 +59,7 @@ $(function() {
                     data.context.each(function(index) {
                         var error = data.files[index].error;
                         if (error) {
-                            $(this).find('.error_messages').text(error);
+                            $(this).find('.error_messages').html(error);
                         }
                     });
                 }

--- a/wagtail/images/templates/wagtailimages/multiple/add.html
+++ b/wagtail/images/templates/wagtailimages/multiple/add.html
@@ -107,8 +107,8 @@
             accepted_file_types: /\.({{ allowed_extensions|join:"|" }})$/i, //must be regex
             max_file_size: {{ max_filesize|stringformat:"s"|default:"null" }}, //numeric format
             errormessages: {
-                max_file_size: "{{ error_max_file_size }}",
-                accepted_file_types: "{{ error_accepted_file_types }}"
+                max_file_size: "{{ error_max_file_size|escapejs }}",
+                accepted_file_types: "{{ error_accepted_file_types|escapejs }}"
             }
         }
         window.tagit_opts = {


### PR DESCRIPTION
Fixes #6824