### PR TITLE
Docsearch w/ Search Results Page

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -5,8 +5,14 @@ body.wy-body-for-nav {
     background-color: #e6e6e6; /*$color-grey-4*/
 }
 
-div.wy-nav-side {
+nav.wy-nav-side {
     background-color: #333;  /*color-grey-1*/
+    position: absolute;
+    overflow: inherit;
+}
+
+div.wy-side-scroll {
+    overflow: inherit;
 }
 
 div.wy-side-nav-search {

--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -112,8 +112,3 @@ a.wagtailspace:hover svg {
   -webkit-animation-name: bounce;
   animation-name: bounce;
 }
-
-.algolia-autocomplete .algolia-docsearch-suggestion--highlight {
-  color: #2980B9;
-  background: #F1C40F;
-}

--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -112,3 +112,8 @@ a.wagtailspace:hover svg {
   -webkit-animation-name: bounce;
   animation-name: bounce;
 }
+
+.algolia-autocomplete .algolia-docsearch-suggestion--highlight {
+  color: #2980B9;
+  background: #F1C40F;
+}

--- a/docs/_static/css/docsearch.overrides.css
+++ b/docs/_static/css/docsearch.overrides.css
@@ -1,0 +1,4 @@
+.algolia-autocomplete .algolia-docsearch-suggestion--highlight {
+  color: #2980B9;
+  background: #F1C40F;
+}

--- a/docs/_static/css/docsearch.overrides.css
+++ b/docs/_static/css/docsearch.overrides.css
@@ -1,3 +1,4 @@
+.search .algolia-docsearch-suggestion--highlight,
 .algolia-autocomplete .algolia-docsearch-suggestion--highlight {
   color: #2980B9;
   background: #F1C40F;

--- a/docs/_static/js/banner.js
+++ b/docs/_static/js/banner.js
@@ -30,21 +30,4 @@ $(function () {
       $wagtailspace.detach();
     });
   }
-  
-  /**
-   * Configure Algolia DocSearch.
-   *
-   * PR builds have their version set to the PR ID (e.g. "6753").
-   * If the docs are built for a PR, use the "latest" search index.
-   * Otherwise, use the search index for the current version.
-   */
-  const rtd_version = (window.READTHEDOCS_DATA || {}).version || 'latest';
-  const version = rtd_version.match(/^\d+$/) ? 'latest' : rtd_version;
-  docsearch({
-    apiKey: '8325c57d16798633e29d211c26c7b6f9',
-    indexName: 'wagtail',
-    inputSelector: '#rtd-search-form [name="q"]',
-    algoliaOptions: { 'facetFilters': [`version:${version}`] },
-    debug: true // Set debug to true if you want to inspect the dropdown
-  });
 });

--- a/docs/_static/js/banner.js
+++ b/docs/_static/js/banner.js
@@ -30,4 +30,26 @@ $(function () {
       $wagtailspace.detach();
     });
   }
+  
+  /**
+   * Very quick and dirty implementation for prototyping purposes.
+   */
+  const l = document.createElement('link');
+  l.rel = 'stylesheet';
+  l.href = 'https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css';
+  document.body.appendChild(l);
+  const s = document.createElement('script');
+  s.src = 'https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js';
+  s.onload = () => {
+    // Default to "latest" index for PR builds.
+    const version = window.READTHEDOCS_DATA.version.match(/^\d+$/) ? 'latest' : window.READTHEDOCS_DATA.version
+    docsearch({
+      apiKey: '8325c57d16798633e29d211c26c7b6f9',
+      indexName: 'wagtail',
+      inputSelector: '#rtd-search-form [name="q"]',
+      algoliaOptions: { 'facetFilters': [`version:${version}`] },
+      debug: true // Set debug to true if you want to inspect the dropdown
+    });
+  };
+  document.body.appendChild(s);
 });

--- a/docs/_static/js/banner.js
+++ b/docs/_static/js/banner.js
@@ -32,27 +32,19 @@ $(function () {
   }
   
   /**
-   * Very quick and dirty implementation for prototyping purposes.
+   * Configure Algolia DocSearch.
+   *
+   * PR builds have their version set to the PR ID (e.g. "6753").
+   * If the docs are built for a PR, use the "latest" search index.
+   * Otherwise, use the search index for the current version.
    */
-  const l = document.createElement('link');
-  l.rel = 'stylesheet';
-  l.href = 'https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css';
-  document.body.appendChild(l);
-  const s = document.createElement('script');
-  s.src = 'https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js';
-  s.onload = () => {
-    // PR builds have their version set to the PR ID (e.g. "6753").
-    // If the docs are built for a PR, use the "latest" search index.
-    // Otherwise, use the search index for the current version.
-    const rtd_version = (window.READTHEDOCS_DATA || {}).version || 'latest';
-    const version = rtd_version.match(/^\d+$/) ? 'latest' : rtd_version;
-    docsearch({
-      apiKey: '8325c57d16798633e29d211c26c7b6f9',
-      indexName: 'wagtail',
-      inputSelector: '#rtd-search-form [name="q"]',
-      algoliaOptions: { 'facetFilters': [`version:${version}`] },
-      debug: true // Set debug to true if you want to inspect the dropdown
-    });
-  };
-  document.body.appendChild(s);
+  const rtd_version = (window.READTHEDOCS_DATA || {}).version || 'latest';
+  const version = rtd_version.match(/^\d+$/) ? 'latest' : rtd_version;
+  docsearch({
+    apiKey: '8325c57d16798633e29d211c26c7b6f9',
+    indexName: 'wagtail',
+    inputSelector: '#rtd-search-form [name="q"]',
+    algoliaOptions: { 'facetFilters': [`version:${version}`] },
+    debug: true // Set debug to true if you want to inspect the dropdown
+  });
 });

--- a/docs/_static/js/banner.js
+++ b/docs/_static/js/banner.js
@@ -41,8 +41,11 @@ $(function () {
   const s = document.createElement('script');
   s.src = 'https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js';
   s.onload = () => {
-    // Default to "latest" index for PR builds.
-    const version = window.READTHEDOCS_DATA.version.match(/^\d+$/) ? 'latest' : window.READTHEDOCS_DATA.version
+    // PR builds have their version set to the PR ID (e.g. "6753").
+    // If the docs are built for a PR, use the "latest" search index.
+    // Otherwise, use the search index for the current version.
+    const rtd_version = (window.READTHEDOCS_DATA || {}).version || 'latest';
+    const version = rtd_version.match(/^\d+$/) ? 'latest' : rtd_version;
     docsearch({
       apiKey: '8325c57d16798633e29d211c26c7b6f9',
       indexName: 'wagtail',

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -41,6 +41,8 @@
         facetFilters: [getVersionFacetFilter()],
       },
       autocompleteOptions: {
+        // Do NOT automatically select the first suggestion in the dropdown.
+        // https://github.com/algolia/autocomplete/blob/45fa32d008620cf52bf4a90530be338543dfba7f/README.md#global-options
         autoSelect: false
       },
       debug: true // Set debug to true if you want to inspect the dropdown

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -29,6 +29,15 @@
     return 'version:' + getReadTheDocsVersion()
   }
 
+  /**
+   * Return true (debug: on) when not hosted on Readthedocs.
+   *
+   * The debug mode allows inspection of the dropodown.
+   */
+  function getSearchDebugMode() {
+    return window.READTHEDOCS_DATA === undefined
+  }
+
   function docSearchReady(script) {
     /**
     * Configure Algolia DocSearch.
@@ -45,7 +54,7 @@
         // https://github.com/algolia/autocomplete/blob/45fa32d008620cf52bf4a90530be338543dfba7f/README.md#global-options
         autoSelect: false
       },
-      debug: true // Set debug to true if you want to inspect the dropdown
+      debug: getSearchDebugMode(),
     });
 
     return search

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -11,6 +11,7 @@
 {% block footer %}
 {{ super() }}
 <script async defer data-domain="docs.wagtail.io" src="https://plausible.io/js/plausible.js"></script>
+<script src="{{ docsearch_base }}docsearch.min.js"></script>
 <script>
   /**
    * Get version of the currently served docs.
@@ -60,9 +61,6 @@
     return search
   }
 
-  const s = document.createElement('script')
-  s.src = '{{ docsearch_base }}docsearch.min.js'
-  s.onload = docSearchReady
-  document.body.appendChild(s)
+  window.onload(docSearchReady())
 </script>
 {% endblock %}

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -23,7 +23,7 @@ function docSearchReady(script) {
   const rtd_version = (window.READTHEDOCS_DATA || {}).version || 'latest';
   const version = rtd_version.match(/^\d+$/) ? 'latest' : rtd_version;
 
-  docsearch({
+  const search = docsearch({
     apiKey: '8325c57d16798633e29d211c26c7b6f9',
     indexName: 'wagtail',
     inputSelector: '#rtd-search-form [name="q"]',
@@ -35,6 +35,8 @@ function docSearchReady(script) {
     },
     debug: true // Set debug to true if you want to inspect the dropdown
   });
+
+  return search
 }
 
 const s = document.createElement('script');

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,5 +1,10 @@
 {% extends "!layout.html" %}
 
+{% block extrahead %}
+<link rel="stylesheet" href="{{ docsearch_base ~ 'docsearch.min.css' }}"/>
+<link rel="stylesheet" href="{{ pathto('_static/css/docsearch.overrides.css', 1) }}" />
+{% endblock %}
+
 {% block footer %}
 {{ super() }}
 <script async defer data-domain="docs.wagtail.io" src="https://plausible.io/js/plausible.js"></script>
@@ -17,12 +22,18 @@ function docSearchReady(script) {
    */
   const rtd_version = (window.READTHEDOCS_DATA || {}).version || 'latest';
   const version = rtd_version.match(/^\d+$/) ? 'latest' : rtd_version;
+
   docsearch({
     apiKey: '8325c57d16798633e29d211c26c7b6f9',
     indexName: 'wagtail',
     inputSelector: '#rtd-search-form [name="q"]',
-    algoliaOptions: { 'facetFilters': [`version:${version}`] },
-    debug: true
+    algoliaOptions: {
+      facetFilters: ['version:' + version],
+    },
+    autocompleteOptions: {
+      autoSelect: false
+    },
+    debug: true // Set debug to true if you want to inspect the dropdown
   });
 }
 

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -12,14 +12,14 @@
 {{ super() }}
 <script async defer data-domain="docs.wagtail.io" src="https://plausible.io/js/plausible.js"></script>
 <script>
+  /**
+   * Get version of the currently served docs.
+   *
+   * PR builds have their version set to the PR ID (e.g. "6753").
+   * If the docs are built for a PR, use the "latest" search index.
+   * Otherwise, use the search index for the current version.
+   */
   function getReadTheDocsVersion() {
-    /**
-    * Get version of the currently served docs.
-    *
-    * PR builds have their version set to the PR ID (e.g. "6753").
-    * If the docs are built for a PR, use the "latest" search index.
-    * Otherwise, use the search index for the current version.
-    */
     const rtd_version = (window.READTHEDOCS_DATA || {}).version || 'latest';
     const version = rtd_version.match(/^\d+$/) ? 'latest' : rtd_version;
     return version

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -20,8 +20,8 @@
    * Otherwise, use the search index for the current version.
    */
   function getReadTheDocsVersion() {
-    const rtd_version = (window.READTHEDOCS_DATA || {}).version || 'latest';
-    const version = rtd_version.match(/^\d+$/) ? 'latest' : rtd_version;
+    const rtd_version = (window.READTHEDOCS_DATA || {}).version || 'latest'
+    const version = rtd_version.match(/^\d+$/) ? 'latest' : rtd_version
     return version
   }
 
@@ -55,14 +55,14 @@
         autoSelect: false
       },
       debug: getSearchDebugMode(),
-    });
+    })
 
     return search
   }
 
-  const s = document.createElement('script');
-  s.src = '{{ docsearch_base }}docsearch.min.js';
-  s.onload = docSearchReady;
-  document.body.appendChild(s);
+  const s = document.createElement('script')
+  s.src = '{{ docsearch_base }}docsearch.min.js'
+  s.onload = docSearchReady
+  document.body.appendChild(s)
 </script>
 {% endblock %}

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,5 +1,8 @@
 {% extends "!layout.html" %}
 
+{% set docsearch_version = '2' %}
+{% set docsearch_base = 'https://cdn.jsdelivr.net/npm/docsearch.js@' ~ docsearch_version ~ '/dist/cdn/' %}
+
 {% block extrahead %}
 <link rel="stylesheet" href="{{ docsearch_base ~ 'docsearch.min.css' }}"/>
 <link rel="stylesheet" href="{{ pathto('_static/css/docsearch.overrides.css', 1) }}" />
@@ -8,50 +11,47 @@
 {% block footer %}
 {{ super() }}
 <script async defer data-domain="docs.wagtail.io" src="https://plausible.io/js/plausible.js"></script>
-{% set docsearch_version = '2' %}
-{% set docsearch_base = 'https://cdn.jsdelivr.net/npm/docsearch.js@' ~ docsearch_version ~ '/dist/cdn/' %}
-
 <script>
-function getReadTheDocsVersion() {
-  /**
-   * Get version of the currently served docs.
-   *
-   * PR builds have their version set to the PR ID (e.g. "6753").
-   * If the docs are built for a PR, use the "latest" search index.
-   * Otherwise, use the search index for the current version.
-   */
-  const rtd_version = (window.READTHEDOCS_DATA || {}).version || 'latest';
-  const version = rtd_version.match(/^\d+$/) ? 'latest' : rtd_version;
-  return version
-}
+  function getReadTheDocsVersion() {
+    /**
+    * Get version of the currently served docs.
+    *
+    * PR builds have their version set to the PR ID (e.g. "6753").
+    * If the docs are built for a PR, use the "latest" search index.
+    * Otherwise, use the search index for the current version.
+    */
+    const rtd_version = (window.READTHEDOCS_DATA || {}).version || 'latest';
+    const version = rtd_version.match(/^\d+$/) ? 'latest' : rtd_version;
+    return version
+  }
 
-function getVersionFacetFilter() {
-  return 'version:' + getReadTheDocsVersion()
-}
+  function getVersionFacetFilter() {
+    return 'version:' + getReadTheDocsVersion()
+  }
 
-function docSearchReady(script) {
-  /**
-   * Configure Algolia DocSearch.
-   */
-  const search = docsearch({
-    apiKey: '8325c57d16798633e29d211c26c7b6f9',
-    indexName: 'wagtail',
-    inputSelector: '#rtd-search-form [name="q"]',
-    algoliaOptions: {
-      facetFilters: [getVersionFacetFilter()],
-    },
-    autocompleteOptions: {
-      autoSelect: false
-    },
-    debug: true // Set debug to true if you want to inspect the dropdown
-  });
+  function docSearchReady(script) {
+    /**
+    * Configure Algolia DocSearch.
+    */
+    const search = docsearch({
+      apiKey: '8325c57d16798633e29d211c26c7b6f9',
+      indexName: 'wagtail',
+      inputSelector: '#rtd-search-form [name="q"]',
+      algoliaOptions: {
+        facetFilters: [getVersionFacetFilter()],
+      },
+      autocompleteOptions: {
+        autoSelect: false
+      },
+      debug: true // Set debug to true if you want to inspect the dropdown
+    });
 
-  return search
-}
+    return search
+  }
 
-const s = document.createElement('script');
-s.src = '{{ docsearch_base }}docsearch.min.js';
-s.onload = docSearchReady;
-document.body.appendChild(s);
+  const s = document.createElement('script');
+  s.src = '{{ docsearch_base }}docsearch.min.js';
+  s.onload = docSearchReady;
+  document.body.appendChild(s);
 </script>
 {% endblock %}

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -12,9 +12,9 @@
 {% set docsearch_base = 'https://cdn.jsdelivr.net/npm/docsearch.js@' ~ docsearch_version ~ '/dist/cdn/' %}
 
 <script>
-function docSearchReady(script) {
+function getReadTheDocsVersion() {
   /**
-   * Configure Algolia DocSearch.
+   * Get version of the currently served docs.
    *
    * PR builds have their version set to the PR ID (e.g. "6753").
    * If the docs are built for a PR, use the "latest" search index.
@@ -22,13 +22,23 @@ function docSearchReady(script) {
    */
   const rtd_version = (window.READTHEDOCS_DATA || {}).version || 'latest';
   const version = rtd_version.match(/^\d+$/) ? 'latest' : rtd_version;
+  return version
+}
 
+function getVersionFacetFilter() {
+  return 'version:' + getReadTheDocsVersion()
+}
+
+function docSearchReady(script) {
+  /**
+   * Configure Algolia DocSearch.
+   */
   const search = docsearch({
     apiKey: '8325c57d16798633e29d211c26c7b6f9',
     indexName: 'wagtail',
     inputSelector: '#rtd-search-form [name="q"]',
     algoliaOptions: {
-      facetFilters: ['version:' + version],
+      facetFilters: [getVersionFacetFilter()],
     },
     autocompleteOptions: {
       autoSelect: false

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -31,7 +31,7 @@
   }
 
   /**
-   * Return true (debug: on) when not hosted on Readthedocs or is PR preview.
+   * Return true (debug: on) for local builds or Read the Docs PR previews.
    *
    * The debug mode allows inspection of the dropodown.
    */
@@ -53,6 +53,7 @@
   function docSearchReady(script) {
     /**
     * Configure Algolia DocSearch.
+    * See https://github.com/algolia/docsearch-configs/blob/master/configs/wagtail.json for index configuration.
     */
     const search = docsearch({
       apiKey: '8325c57d16798633e29d211c26c7b6f9',

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -3,4 +3,32 @@
 {% block footer %}
 {{ super() }}
 <script async defer data-domain="docs.wagtail.io" src="https://plausible.io/js/plausible.js"></script>
+{% set docsearch_version = '2' %}
+{% set docsearch_base = 'https://cdn.jsdelivr.net/npm/docsearch.js@' ~ docsearch_version ~ '/dist/cdn/' %}
+
+<script>
+function docSearchReady(script) {
+  /**
+   * Configure Algolia DocSearch.
+   *
+   * PR builds have their version set to the PR ID (e.g. "6753").
+   * If the docs are built for a PR, use the "latest" search index.
+   * Otherwise, use the search index for the current version.
+   */
+  const rtd_version = (window.READTHEDOCS_DATA || {}).version || 'latest';
+  const version = rtd_version.match(/^\d+$/) ? 'latest' : rtd_version;
+  docsearch({
+    apiKey: '8325c57d16798633e29d211c26c7b6f9',
+    indexName: 'wagtail',
+    inputSelector: '#rtd-search-form [name="q"]',
+    algoliaOptions: { 'facetFilters': [`version:${version}`] },
+    debug: true
+  });
+}
+
+const s = document.createElement('script');
+s.src = '{{ docsearch_base }}docsearch.min.js';
+s.onload = docSearchReady;
+document.body.appendChild(s);
+</script>
 {% endblock %}

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -23,7 +23,7 @@ function docSearchReady(script) {
   const rtd_version = (window.READTHEDOCS_DATA || {}).version || 'latest';
   const version = rtd_version.match(/^\d+$/) ? 'latest' : rtd_version;
 
-  window.search = docsearch({
+  const search = docsearch({
     apiKey: '8325c57d16798633e29d211c26c7b6f9',
     indexName: 'wagtail',
     inputSelector: '#rtd-search-form [name="q"]',
@@ -35,6 +35,8 @@ function docSearchReady(script) {
     },
     debug: true // Set debug to true if you want to inspect the dropdown
   });
+
+  return search
 }
 
 const s = document.createElement('script');

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -23,7 +23,7 @@ function docSearchReady(script) {
   const rtd_version = (window.READTHEDOCS_DATA || {}).version || 'latest';
   const version = rtd_version.match(/^\d+$/) ? 'latest' : rtd_version;
 
-  const search = docsearch({
+  window.search = docsearch({
     apiKey: '8325c57d16798633e29d211c26c7b6f9',
     indexName: 'wagtail',
     inputSelector: '#rtd-search-form [name="q"]',
@@ -35,8 +35,6 @@ function docSearchReady(script) {
     },
     debug: true // Set debug to true if you want to inspect the dropdown
   });
-
-  return search
 }
 
 const s = document.createElement('script');

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -31,12 +31,23 @@
   }
 
   /**
-   * Return true (debug: on) when not hosted on Readthedocs.
+   * Return true (debug: on) when not hosted on Readthedocs or is PR preview.
    *
    * The debug mode allows inspection of the dropodown.
    */
   function getSearchDebugMode() {
-    return window.READTHEDOCS_DATA === undefined
+    let debug = false
+    if (window.READTHEDOCS_DATA === undefined) {
+      // When developing locally, the `window.READTHEDOCS_DATA` object does not exist.
+      debug = true
+    } else {
+      // When PR preview on Readthedocs, then the version can be converted into
+      // a number. This does not work for the production version identifiers
+      // like 'stable', 'latest', 'v2.12', etc. In that case `Number()` is `NaN`.
+      const versionNumber = Number(window.READTHEDOCS_DATA.version)
+      debug = !isNaN(versionNumber)
+    }
+    return debug
   }
 
   function docSearchReady(script) {

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -27,7 +27,7 @@
   }
 
   function getVersionFacetFilter() {
-    return 'version:' + getReadTheDocsVersion()
+    return `version:${getReadTheDocsVersion()}`;
   }
 
   /**

--- a/docs/_templates/search.html
+++ b/docs/_templates/search.html
@@ -31,11 +31,11 @@ function runSearchPageSearch(event) {
   index.search(
     query,
     {
-      hitsPerPage: 100,
+      hitsPerPage: 50,
       facetFilters: [getVersionFacetFilter()]
     }
   )
-  .then(({ hits }) => addResultsList(hits, searchResultsContainer))
+  .then(({ hits }) => addResultsList(hits, query, searchResultsContainer))
   .catch((error) => console.log(error))
 }
 
@@ -45,20 +45,20 @@ function addHeadingForQuery(query, parentElement) {
   parentElement.appendChild(searchHeading)
 }
 
-function addResultsList(hits, parentElement) {
+function addResultsList(hits, query, parentElement) {
   const searchResultsList = document.createElement('ul')
   searchResultsList.className = "search"
   for (hit of hits) {
-    const hitElement = createHitElement(hit)
+    const hitElement = createHitElement(hit, query)
     searchResultsList.appendChild(hitElement)
   }
   parentElement.appendChild(searchResultsList)
 }
 
-function createHitElement(hitData) {
-  console.log(hitData)
-  const pageURL = extractPageLink(hitData.url)
+function createHitElement(hitData, query) {
+  const pageURL = extractPageLink(hitData.url) + '?highlight=' + query
   const anchor = hitData.anchor
+  const anchorURL = pageURL + '#' + anchor
   const result = hitData._highlightResult
 
   const hitListElement = document.createElement('li')
@@ -81,14 +81,13 @@ function createHitElement(hitData) {
   hitListElement.appendChild(contextElement)
   contextElement.className = 'context'
 
-  console.log(lastHierarchyLevel)
   if (lastHierarchyLevel && lastHierarchyLevel !== firstHierarchyLevel ) {
     const contextLinkContainer = document.createElement('div')
     contextElement.appendChild(contextLinkContainer)
     const contextLink = document.createElement('a')
     contextLinkContainer.appendChild(contextLink)
     contextLink.innerHTML = lastHierarchyLevel.value
-    contextLink.href = pageURL + '#' + anchor
+    contextLink.href = anchorURL
   }
 
   if (result.content) {

--- a/docs/_templates/search.html
+++ b/docs/_templates/search.html
@@ -27,7 +27,8 @@ function search(event) {
   searchHeading.textContent = query
   searchResultsContainer.appendChild(searchHeading)
 
-  const index = window.search.client.initIndex('wagtail')
+  const search = docSearchReady()
+  const index = search.client.initIndex('wagtail')
   index.search(query).then(({ hits }) => {
     console.log(hits);
   });

--- a/docs/_templates/search.html
+++ b/docs/_templates/search.html
@@ -1,0 +1,16 @@
+{%- extends "layout.html" %}
+{% set title = _('Search') %}
+
+{% block body %}
+  <noscript>
+  <div id="fallback" class="admonition warning">
+    <p class="last">
+      {% trans trimmed %}Please activate JavaScript to enable the search
+      functionality.{% endtrans %}
+    </p>
+  </div>
+  </noscript>
+
+  <div id="search-results">
+  </div>
+{% endblock %}

--- a/docs/_templates/search.html
+++ b/docs/_templates/search.html
@@ -40,7 +40,7 @@ function runSearchPageSearch(event) {
 }
 
 function addHeadingForQuery(query, parentElement) {
-  const searchHeading = document.createElement('h2')
+  const searchHeading = document.createElement('h1')
   searchHeading.textContent = `Search Results for "${query}"`
   parentElement.appendChild(searchHeading)
 }

--- a/docs/_templates/search.html
+++ b/docs/_templates/search.html
@@ -31,7 +31,7 @@ function runSearchPageSearch(event) {
   index.search(
     query,
     {
-      hitsPerPage: 10,
+      hitsPerPage: 100,
       facetFilters: [getVersionFacetFilter()]
     }
   )
@@ -40,13 +40,14 @@ function runSearchPageSearch(event) {
 }
 
 function addHeadingForQuery(query, parentElement) {
-  const searchHeading = document.createElement('h1')
-  searchHeading.textContent = query
+  const searchHeading = document.createElement('h2')
+  searchHeading.textContent = `Search Results for "${query}"`
   parentElement.appendChild(searchHeading)
 }
 
 function addResultsList(hits, parentElement) {
   const searchResultsList = document.createElement('ul')
+  searchResultsList.className = "search"
   for (hit of hits) {
     const hitElement = createHitElement(hit)
     searchResultsList.appendChild(hitElement)
@@ -54,23 +55,44 @@ function addResultsList(hits, parentElement) {
   parentElement.appendChild(searchResultsList)
 }
 
+function getElementTypeForHierarchyLevelLabel(level) {
+  const elementTypes = {
+    'lvl0': 'h3',
+    'lvl1': 'h4',
+    'lvl2': 'span',
+    'lvl3': 'span',
+    'lvl4': 'span',
+    'lvl5': 'span',
+    'lvl6': 'span',
+  }
+  return elementTypes[level]
+}
+
 function createHitElement(hitData) {
   console.log(hitData)
+  const result = hitData._highlightResult
+
   const hitListElement = document.createElement('li')
-  hitListElement.style = "margin-bottom: 2rem"
+
+  for (levelLabel in result.hierarchy) {
+    const elementType = getElementTypeForHierarchyLevelLabel(levelLabel)
+    const levelDiv = document.createElement(elementType)
+    const levelData = result.hierarchy[levelLabel]
+    levelDiv.innerHTML = levelData.value
+    hitListElement.appendChild(levelDiv)
+  }
+
+  if (result.content) {
+    const contentElement = document.createElement('div')
+    contentElement.className = 'context'
+    contentElement.innerHTML = result.content.value
+    hitListElement.appendChild(contentElement)
+  }
+
   const hitAnchor = document.createElement('a')
   hitAnchor.href = hitData.url
+  hitAnchor.textContent = hitData.url
   hitListElement.appendChild(hitAnchor)
-  const hitAnchorContent = document.createElement('div')
-  hitAnchor.appendChild(hitAnchorContent)
-  // hitListElement.textContent = "Hit"
-  // hitListElement.innerHTML = hitData._highlightResult.hierarchy.lvl0.value
-  for (levelLabel in hitData._highlightResult.hierarchy) {
-    const levelData = hitData._highlightResult.hierarchy[levelLabel]
-    const levelDiv = document.createElement('div')
-    levelDiv.innerHTML = levelData.value
-    hitAnchorContent.appendChild(levelDiv)
-  }
 
   return hitListElement
 }

--- a/docs/_templates/search.html
+++ b/docs/_templates/search.html
@@ -14,3 +14,17 @@
   <div id="search-results">
   </div>
 {% endblock %}
+
+{% block footer %}
+{{ super() }}
+<script>
+  const urlParams = new URLSearchParams(window.location.search)
+  const query = urlParams.get('q')
+  const searchResultsContainer = document.getElementById('search-results')
+
+  const searchHeading = document.createElement('h1')
+  searchHeading.textContent = query
+
+  searchResultsContainer.appendChild(searchHeading)
+</script>
+{% endblock %}

--- a/docs/_templates/search.html
+++ b/docs/_templates/search.html
@@ -18,6 +18,14 @@
 {% block footer %}
 {{ super() }}
 <script>
+
+function makeHitElement(hitData) {
+  console.log(hitData)
+  const hitListElement = document.createElement('li')
+  hitListElement.textContent = "Hit"
+  return hitListElement
+}
+
 function runSearchPageSearch(event) {
   const urlParams = new URLSearchParams(window.location.search)
   const query = urlParams.get('q')
@@ -31,7 +39,13 @@ function runSearchPageSearch(event) {
   const index = search.client.initIndex('wagtail')
   index.search(query).then(({ hits }) => {
     console.log(hits);
-  });
+    const searchResultsList = document.createElement('ul')
+    for (hit of hits) {
+      const hitElement = makeHitElement(hit)
+      searchResultsList.appendChild(hitElement)
+    }
+    searchResultsContainer.appendChild(searchResultsList)
+  }).catch((error) => console.log(error))
 }
 
 window.onload = runSearchPageSearch

--- a/docs/_templates/search.html
+++ b/docs/_templates/search.html
@@ -96,6 +96,6 @@ function createHitElement(hitData, query) {
   return hitListElement
 }
 
-window.onload = runSearchPageSearch
+window.addEventListener('DOMContentLoaded', runSearchPageSearch)
 </script>
 {% endblock %}

--- a/docs/_templates/search.html
+++ b/docs/_templates/search.html
@@ -35,8 +35,8 @@ function runSearchPageSearch(event) {
   searchHeading.textContent = query
   searchResultsContainer.appendChild(searchHeading)
 
-  const search = docSearchReady()
-  const index = search.client.initIndex('wagtail')
+  const docSearch = docSearchReady()
+  const index = docSearch.client.initIndex('wagtail')
   index.search(
     query,
     {

--- a/docs/_templates/search.html
+++ b/docs/_templates/search.html
@@ -104,19 +104,6 @@ function extractPageLink(url) {
   return url.slice(0, endPageUrlIndex)
 }
 
-function getElementTypeForHierarchyLevelLabel(level) {
-  const elementTypes = {
-    'lvl0': 'h3',
-    'lvl1': 'h4',
-    'lvl2': 'span',
-    'lvl3': 'span',
-    'lvl4': 'span',
-    'lvl5': 'span',
-    'lvl6': 'span',
-  }
-  return elementTypes[level]
-}
-
 window.onload = runSearchPageSearch
 </script>
 {% endblock %}

--- a/docs/_templates/search.html
+++ b/docs/_templates/search.html
@@ -56,9 +56,11 @@ function addResultsList(hits, query, parentElement) {
 }
 
 function createHitElement(hitData, query) {
-  const pageURL = extractPageLink(hitData.url) + '?highlight=' + query
-  const anchor = hitData.anchor
-  const anchorURL = pageURL + '#' + anchor
+  const pageURL = new URL(hitData.url)
+  pageURL.hash = '';
+  pageURL.searchParams.set('highlight', query);
+  const anchorURL = new URL(hitData.url);
+  anchorURL.searchParams.set('highlight', query);
   const result = hitData._highlightResult
 
   const hitListElement = document.createElement('li')

--- a/docs/_templates/search.html
+++ b/docs/_templates/search.html
@@ -41,7 +41,7 @@ function runSearchPageSearch(event) {
 
 function addHeadingForQuery(query, parentElement) {
   const searchHeading = document.createElement('h1')
-  searchHeading.textContent = `Search Results for "${query}"`
+  searchHeading.textContent = `Search results for “${query}”`
   parentElement.appendChild(searchHeading)
 }
 

--- a/docs/_templates/search.html
+++ b/docs/_templates/search.html
@@ -96,11 +96,6 @@ function createHitElement(hitData, query) {
   return hitListElement
 }
 
-function extractPageLink(url) {
-  const endPageUrlIndex = url.lastIndexOf('#')
-  return url.slice(0, endPageUrlIndex)
-}
-
 window.onload = runSearchPageSearch
 </script>
 {% endblock %}

--- a/docs/_templates/search.html
+++ b/docs/_templates/search.html
@@ -18,7 +18,7 @@
 {% block footer %}
 {{ super() }}
 <script>
-function search(event) {
+function runSearchPageSearch(event) {
   const urlParams = new URLSearchParams(window.location.search)
   const query = urlParams.get('q')
   const searchResultsContainer = document.getElementById('search-results')
@@ -34,6 +34,6 @@ function search(event) {
   });
 }
 
-window.onload = search
+window.onload = runSearchPageSearch
 </script>
 {% endblock %}

--- a/docs/_templates/search.html
+++ b/docs/_templates/search.html
@@ -1,4 +1,4 @@
-{%- extends "layout.html" %}
+{% extends "layout.html" %}
 {% set title = _('Search') %}
 
 {% block body %}
@@ -18,13 +18,21 @@
 {% block footer %}
 {{ super() }}
 <script>
+function search(event) {
   const urlParams = new URLSearchParams(window.location.search)
   const query = urlParams.get('q')
   const searchResultsContainer = document.getElementById('search-results')
 
   const searchHeading = document.createElement('h1')
   searchHeading.textContent = query
-
   searchResultsContainer.appendChild(searchHeading)
+
+  const index = window.search.client.initIndex('wagtail')
+  index.search(query).then(({ hits }) => {
+    console.log(hits);
+  });
+}
+
+window.onload = search
 </script>
 {% endblock %}

--- a/docs/_templates/search.html
+++ b/docs/_templates/search.html
@@ -63,14 +63,9 @@ function createHitElement(hitData, query) {
 
   const hitListElement = document.createElement('li')
 
-  let firstHierarchyLevel = undefined
-  let lastHierarchyLevel = undefined
-  for (levelLabel in result.hierarchy) {
-    if (firstHierarchyLevel === undefined ) {
-      firstHierarchyLevel = result.hierarchy[levelLabel]
-    }
-    lastHierarchyLevel = result.hierarchy[levelLabel]
-  }
+  const hierarchies = Object.values(result.hierarchy);
+  const firstHierarchyLevel = hierarchies[0];
+  const lastHierarchyLevel = hierarchies[hierarchies.length - 1];
 
   const pageLink = document.createElement('a')
   hitListElement.appendChild(pageLink)

--- a/docs/_templates/search.html
+++ b/docs/_templates/search.html
@@ -37,7 +37,13 @@ function runSearchPageSearch(event) {
 
   const search = docSearchReady()
   const index = search.client.initIndex('wagtail')
-  index.search(query).then(({ hits }) => {
+  index.search(
+    query,
+    {
+      hitsPerPage: 10,
+      facetFilters: [getVersionFacetFilter()]
+    }
+  ).then(({ hits }) => {
     console.log(hits);
     const searchResultsList = document.createElement('ul')
     for (hit of hits) {

--- a/docs/_templates/search.html
+++ b/docs/_templates/search.html
@@ -19,21 +19,12 @@
 {{ super() }}
 <script>
 
-function makeHitElement(hitData) {
-  console.log(hitData)
-  const hitListElement = document.createElement('li')
-  hitListElement.textContent = "Hit"
-  return hitListElement
-}
-
 function runSearchPageSearch(event) {
   const urlParams = new URLSearchParams(window.location.search)
   const query = urlParams.get('q')
-  const searchResultsContainer = document.getElementById('search-results')
 
-  const searchHeading = document.createElement('h1')
-  searchHeading.textContent = query
-  searchResultsContainer.appendChild(searchHeading)
+  const searchResultsContainer = document.getElementById('search-results')
+  addHeadingForQuery(query, searchResultsContainer)
 
   const docSearch = docSearchReady()
   const index = docSearch.client.initIndex('wagtail')
@@ -43,15 +34,45 @@ function runSearchPageSearch(event) {
       hitsPerPage: 10,
       facetFilters: [getVersionFacetFilter()]
     }
-  ).then(({ hits }) => {
-    console.log(hits);
-    const searchResultsList = document.createElement('ul')
-    for (hit of hits) {
-      const hitElement = makeHitElement(hit)
-      searchResultsList.appendChild(hitElement)
-    }
-    searchResultsContainer.appendChild(searchResultsList)
-  }).catch((error) => console.log(error))
+  )
+  .then(({ hits }) => addResultsList(hits, searchResultsContainer))
+  .catch((error) => console.log(error))
+}
+
+function addHeadingForQuery(query, parentElement) {
+  const searchHeading = document.createElement('h1')
+  searchHeading.textContent = query
+  parentElement.appendChild(searchHeading)
+}
+
+function addResultsList(hits, parentElement) {
+  const searchResultsList = document.createElement('ul')
+  for (hit of hits) {
+    const hitElement = createHitElement(hit)
+    searchResultsList.appendChild(hitElement)
+  }
+  parentElement.appendChild(searchResultsList)
+}
+
+function createHitElement(hitData) {
+  console.log(hitData)
+  const hitListElement = document.createElement('li')
+  hitListElement.style = "margin-bottom: 2rem"
+  const hitAnchor = document.createElement('a')
+  hitAnchor.href = hitData.url
+  hitListElement.appendChild(hitAnchor)
+  const hitAnchorContent = document.createElement('div')
+  hitAnchor.appendChild(hitAnchorContent)
+  // hitListElement.textContent = "Hit"
+  // hitListElement.innerHTML = hitData._highlightResult.hierarchy.lvl0.value
+  for (levelLabel in hitData._highlightResult.hierarchy) {
+    const levelData = hitData._highlightResult.hierarchy[levelLabel]
+    const levelDiv = document.createElement('div')
+    levelDiv.innerHTML = levelData.value
+    hitAnchorContent.appendChild(levelDiv)
+  }
+
+  return hitListElement
 }
 
 window.onload = runSearchPageSearch

--- a/docs/_templates/search.html
+++ b/docs/_templates/search.html
@@ -55,6 +55,56 @@ function addResultsList(hits, parentElement) {
   parentElement.appendChild(searchResultsList)
 }
 
+function createHitElement(hitData) {
+  console.log(hitData)
+  const pageURL = extractPageLink(hitData.url)
+  const anchor = hitData.anchor
+  const result = hitData._highlightResult
+
+  const hitListElement = document.createElement('li')
+
+  let firstHierarchyLevel = undefined
+  let lastHierarchyLevel = undefined
+  for (levelLabel in result.hierarchy) {
+    if (firstHierarchyLevel === undefined ) {
+      firstHierarchyLevel = result.hierarchy[levelLabel]
+    }
+    lastHierarchyLevel = result.hierarchy[levelLabel]
+  }
+
+  const pageLink = document.createElement('a')
+  hitListElement.appendChild(pageLink)
+  pageLink.innerHTML = firstHierarchyLevel.value
+  pageLink.href = pageURL
+
+  const contextElement = document.createElement('div')
+  hitListElement.appendChild(contextElement)
+  contextElement.className = 'context'
+
+  console.log(lastHierarchyLevel)
+  if (lastHierarchyLevel && lastHierarchyLevel !== firstHierarchyLevel ) {
+    const contextLinkContainer = document.createElement('div')
+    contextElement.appendChild(contextLinkContainer)
+    const contextLink = document.createElement('a')
+    contextLinkContainer.appendChild(contextLink)
+    contextLink.innerHTML = lastHierarchyLevel.value
+    contextLink.href = pageURL + '#' + anchor
+  }
+
+  if (result.content) {
+    const contentElement = document.createElement('div')
+    contentElement.innerHTML = result.content.value
+    contextElement.appendChild(contentElement)
+  }
+
+  return hitListElement
+}
+
+function extractPageLink(url) {
+  const endPageUrlIndex = url.lastIndexOf('#')
+  return url.slice(0, endPageUrlIndex)
+}
+
 function getElementTypeForHierarchyLevelLabel(level) {
   const elementTypes = {
     'lvl0': 'h3',
@@ -66,35 +116,6 @@ function getElementTypeForHierarchyLevelLabel(level) {
     'lvl6': 'span',
   }
   return elementTypes[level]
-}
-
-function createHitElement(hitData) {
-  console.log(hitData)
-  const result = hitData._highlightResult
-
-  const hitListElement = document.createElement('li')
-
-  for (levelLabel in result.hierarchy) {
-    const elementType = getElementTypeForHierarchyLevelLabel(levelLabel)
-    const levelDiv = document.createElement(elementType)
-    const levelData = result.hierarchy[levelLabel]
-    levelDiv.innerHTML = levelData.value
-    hitListElement.appendChild(levelDiv)
-  }
-
-  if (result.content) {
-    const contentElement = document.createElement('div')
-    contentElement.className = 'context'
-    contentElement.innerHTML = result.content.value
-    hitListElement.appendChild(contentElement)
-  }
-
-  const hitAnchor = document.createElement('a')
-  hitAnchor.href = hitData.url
-  hitAnchor.textContent = hitData.url
-  hitListElement.appendChild(hitAnchor)
-
-  return hitListElement
 }
 
 window.onload = runSearchPageSearch

--- a/docs/_templates/searchbox.html
+++ b/docs/_templates/searchbox.html
@@ -1,6 +1,4 @@
-<div role="search">
-  <form id="rtd-search-form" class="wy-form" action="{{ pathto('search') }}" method="get">
-    <input type="text" name="q" placeholder="{{ _('Search docs') }}" />
-    <input type="submit" style="visibility:hidden;position:absolute">
-  </form>
-</div>
+<form id="rtd-search-form" class="wy-form" action="{{ pathto('search') }}" method="get" role="search">
+  <input type="text" name="q" placeholder="{{ _('Search docs') }}" />
+  <input type="submit" style="visibility:hidden;position:absolute">
+</form>

--- a/docs/_templates/searchbox.html
+++ b/docs/_templates/searchbox.html
@@ -1,0 +1,6 @@
+<div role="search">
+  <form id="rtd-search-form" class="wy-form" action="{{ pathto('search') }}" method="get">
+    <input type="text" name="q" placeholder="{{ _('Search docs') }}" />
+    <input type="submit" style="visibility:hidden;position:absolute">
+  </form>
+</div>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -187,8 +187,8 @@ html_extra_path = ['robots.txt']
 # html_domain_indices = True
 
 # If false, no index is generated.
-# Since we are implementing search with Docsearch, we do not need Sphinx to
-# generate it's own index. It might not hurt to keep the Sphinx index, but it
+# Since we are implementing search with Algolia DocSearch, we do not need Sphinx to
+# generate its own index. It might not hurt to keep the Sphinx index, but it
 # could potentially speed up the build process.
 html_use_index = False
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -187,7 +187,7 @@ html_extra_path = ['robots.txt']
 # html_domain_indices = True
 
 # If false, no index is generated.
-# html_use_index = True
+html_use_index = False
 
 # If true, the index is split into individual pages for each letter.
 # html_split_index = False
@@ -301,12 +301,7 @@ texinfo_documents = [
 
 
 def setup(app):
-    docsearch_root = 'https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn'
-
-    app.add_css_file(f'{docsearch_root}/docsearch.min.css')
     app.add_css_file('css/custom.css')
-
-    app.add_js_file(f'{docsearch_root}/docsearch.min.js')
     app.add_js_file('js/banner.js')
 
     github_doc_root = 'https://github.com/wagtail/wagtail/tree/master/docs/'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -301,7 +301,12 @@ texinfo_documents = [
 
 
 def setup(app):
+    docsearch_root = 'https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn'
+
+    app.add_css_file(f'{docsearch_root}/docsearch.min.css')
     app.add_css_file('css/custom.css')
+
+    app.add_js_file(f'{docsearch_root}/docsearch.min.js')
     app.add_js_file('js/banner.js')
 
     github_doc_root = 'https://github.com/wagtail/wagtail/tree/master/docs/'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -187,6 +187,9 @@ html_extra_path = ['robots.txt']
 # html_domain_indices = True
 
 # If false, no index is generated.
+# Since we are implementing search with Docsearch, we do not need Sphinx to
+# generate it's own index. It might not hurt to keep the Sphinx index, but it
+# could potentially speed up the build process.
 html_use_index = False
 
 # If true, the index is split into individual pages for each letter.


### PR DESCRIPTION
I have build on #6753 by @thibaudcolas and extended it to generate a search results page from the Algolia Docsearch results. 
The search results page has the advantage of being available as a link target (and you can keep it open in your browser as you check the different results). 

This is only an extension of the Algolia dropdown. The dropdown still exists and shows the results as you type. Once you hit `enter` the results page is loaded. 

I have tried to keep the styling of the results page close to the "Read the docs" search. 

Currently, only the first 50 results are returned and no pagination is enabled. 

Please let me know what you think and if any changes are needed. 

---

Here is a screenshot of a results page:
![Results page screenshot](https://user-images.githubusercontent.com/24797493/109097853-41878480-76c4-11eb-8f8f-bb36519aa327.png)
