### PR TITLE
Image transforms

### DIFF
--- a/docs/advanced_topics/images/focal_points.rst
+++ b/docs/advanced_topics/images/focal_points.rst
@@ -6,10 +6,23 @@ This is used by the ``fill`` filter to focus the cropping on the subject, and av
 
 Focal points can be defined manually by a Wagtail user, or automatically by using face or feature detection.
 
+Setting the ``background-position`` inline style based on the focal point
+-------------------------------------------------------------------------
+
+When using a Wagtail image as the background of an element, you can use the ``.background_position_style``
+attribute on the rendition to position the rendition based on the focal point in the image:
+
+.. code-block:: html+Django
+
+    {% image page.image width-1024 as image %}
+
+    <div style="background-image: url('{{ image.url }}'); {{ image.background_position_style }}">
+    </div>
+
 Accessing the focal point in templates
 --------------------------------------
 
-.. versionadded:: 2.13
+.. versionadded:: 2.14
 
 You can access the focal point in the template by accessing the ``.focal_point`` attribute of a rendition:
 

--- a/docs/advanced_topics/images/focal_points.rst
+++ b/docs/advanced_topics/images/focal_points.rst
@@ -1,0 +1,31 @@
+Focal points
+============
+
+Focal points are used to indicate to Wagtail the area of an image that contains the subject.
+This is used by the ``fill`` filter to focus the cropping on the subject, and avoid cropping into it.
+
+Focal points can be defined manually by a Wagtail user, or automatically by using face or feature detection.
+
+Accessing the focal point in templates
+--------------------------------------
+
+.. versionadded:: 2.13
+
+You can access the focal point in the template by accessing the ``.focal_point`` attribute of a rendition:
+
+.. code-block:: html+Django
+
+    {% load wagtailimages %}
+
+    {% image myimage width-800 as myrendition %}
+
+    <img
+        src="{{ myrendition.url }}"
+        alt="{{ myimage.title }}"
+        {% if myrendition.focal_point %}
+            data-focus-x="{{ myrendition.focal_point.centroid.x }}"
+            data-focus-y="{{ myrendition.focal_point.centroid.y }}"
+            data-focus-width="{{ myrendition.focal_point.width }}"
+            data-focus-height="{{ myrendition.focal_point.height }}"
+        {% endif %}
+    />

--- a/docs/advanced_topics/images/index.rst
+++ b/docs/advanced_topics/images/index.rst
@@ -12,3 +12,4 @@ Images
     changing_rich_text_representation
     feature_detection
     image_serve_view
+    focal_points

--- a/wagtail/images/image_operations.py
+++ b/wagtail/images/image_operations.py
@@ -1,7 +1,7 @@
 import inspect
 
 from wagtail.images.exceptions import InvalidFilterSpecError
-from wagtail.images.rect import Rect
+from wagtail.images.rect import Rect, Vector
 from wagtail.images.utils import parse_color_string
 
 
@@ -29,8 +29,104 @@ class Operation:
 # Transforms
 
 
+class ImageTransform:
+    """
+    Tracks transformations that are performed on an image.
+
+    This allows multiple transforms to be processed in a single operation and also
+    accumulates the operations into a single scale/offset which can be used for
+    features such as transforming the focal point of the image.
+    """
+    def __init__(self, size):
+        self._check_size(size)
+        self.size = size
+        self.scale = (1.0, 1.0)
+        self.offset = (0.0, 0.0)
+
+    def clone(self):
+        clone = ImageTransform(self.size)
+        clone.scale = self.scale
+        clone.offset = self.offset
+        return clone
+
+    def resize(self, size):
+        """
+        Change the image size, stretching the transform to make it fit the new size.
+        """
+        self._check_size(size)
+        clone = self.clone()
+        clone.scale = (
+            clone.scale[0] * size[0] / self.size[0],
+            clone.scale[1] * size[1] / self.size[1]
+        )
+        clone.size = size
+        return clone
+
+    def crop(self, rect):
+        """
+        Crop the image to the specified rect.
+        """
+        self._check_size(tuple(rect.size))
+
+        # Transform the image so the top left of the rect is at (0, 0), then set the size
+        clone = self.clone()
+        clone.offset = (
+            clone.offset[0] - rect.left / self.scale[0],
+            clone.offset[1] - rect.top / self.scale[1]
+        )
+        clone.size = tuple(rect.size)
+        return clone
+
+    def transform_vector(self, vector):
+        """
+        Transforms the given vector into the coordinate space of the final image.
+
+        Use this to find out where a point on the source image would end up in the
+        final image after cropping/resizing has been performed.
+
+        Returns a new vector.
+        """
+        return Vector(
+            (vector.x + self.offset[0]) * self.scale[0],
+            (vector.y + self.offset[1]) * self.scale[1]
+        )
+
+    def untransform_vector(self, vector):
+        """
+        Transforms the given vector back to the coordinate space of the source image.
+
+        This performs the inverse of `transform_vector`. Use this to find where a point
+        in the final cropped/resized image originated from in the source image.
+
+        Returns a new vector.
+        """
+        return Vector(
+            vector.x / self.scale[0] - self.offset[0],
+            vector.y / self.scale[1] - self.offset[1]
+        )
+
+    def get_rect(self):
+        """
+        Returns a Rect representing the region of the original image to be cropped.
+        """
+        return Rect(
+            -self.offset[0],
+            -self.offset[1],
+            -self.offset[0] + self.size[0] / self.scale[0],
+            -self.offset[1] + self.size[1] / self.scale[1]
+        )
+
+    @staticmethod
+    def _check_size(size):
+        if not isinstance(size, tuple) or len(size) != 2 or int(size[0]) != size[0] or int(size[1]) != size[1]:
+            raise TypeError("Image size must be a 2-tuple of integers")
+
+        if size[0] < 1 or size[1] < 1:
+            raise ValueError("Image width and height must both be 1 or greater")
+
+
 class TransformOperation(Operation):
-    def run(self, willow, image, env):
+    def run(self, image, transform):
         raise NotImplementedError
 
 
@@ -59,8 +155,8 @@ class FillOperation(TransformOperation):
         if self.crop_closeness > 1:
             self.crop_closeness = 1
 
-    def run(self, willow, image, env):
-        image_width, image_height = willow.get_size()
+    def run(self, transform, image):
+        image_width, image_height = transform.size
         focal_point = image.get_focal_point()
 
         # Get crop aspect ratio
@@ -124,20 +220,20 @@ class FillOperation(TransformOperation):
         rect = rect.move_to_clamp(Rect(0, 0, image_width, image_height))
 
         # Crop!
-        willow = willow.crop(rect.round())
+        transform = transform.crop(rect.round())
 
         # Get scale for resizing
         # The scale should be the same for both the horizontal and
         # vertical axes
-        aftercrop_width, aftercrop_height = willow.get_size()
+        aftercrop_width, aftercrop_height = transform.size
         scale = self.width / aftercrop_width
 
         # Only resize if the image is too big
         if scale < 1.0:
             # Resize!
-            willow = willow.resize((self.width, self.height))
+            transform = transform.resize((self.width, self.height))
 
-        return willow
+        return transform
 
 
 class MinMaxOperation(TransformOperation):
@@ -147,15 +243,15 @@ class MinMaxOperation(TransformOperation):
         self.width = int(width_str)
         self.height = int(height_str)
 
-    def run(self, willow, image, env):
-        image_width, image_height = willow.get_size()
+    def run(self, transform, image):
+        image_width, image_height = transform.size
 
         horz_scale = self.width / image_width
         vert_scale = self.height / image_height
 
         if self.method == 'min':
             if image_width <= self.width or image_height <= self.height:
-                return
+                return transform
 
             if horz_scale > vert_scale:
                 width = self.width
@@ -166,7 +262,7 @@ class MinMaxOperation(TransformOperation):
 
         elif self.method == 'max':
             if image_width <= self.width and image_height <= self.height:
-                return
+                return transform
 
             if horz_scale < vert_scale:
                 width = self.width
@@ -177,25 +273,25 @@ class MinMaxOperation(TransformOperation):
 
         else:
             # Unknown method
-            return
+            return transform
 
-        # prevent zero width or height, it causes a ValueError on willow.resize
+        # prevent zero width or height, it causes a ValueError on transform.resize
         width = width if width > 0 else 1
         height = height if height > 0 else 1
 
-        return willow.resize((width, height))
+        return transform.resize((width, height))
 
 
 class WidthHeightOperation(TransformOperation):
     def construct(self, size):
         self.size = int(size)
 
-    def run(self, willow, image, env):
-        image_width, image_height = willow.get_size()
+    def run(self, transform, image):
+        image_width, image_height = transform.size
 
         if self.method == 'width':
             if image_width <= self.size:
-                return
+                return transform
 
             scale = self.size / image_width
 
@@ -204,7 +300,7 @@ class WidthHeightOperation(TransformOperation):
 
         elif self.method == 'height':
             if image_height <= self.size:
-                return
+                return transform
 
             scale = self.size / image_height
 
@@ -213,31 +309,31 @@ class WidthHeightOperation(TransformOperation):
 
         else:
             # Unknown method
-            return
+            return transform
 
-        # prevent zero width or height, it causes a ValueError on willow.resize
+        # prevent zero width or height, it causes a ValueError on transform.resize
         width = width if width > 0 else 1
         height = height if height > 0 else 1
 
-        return willow.resize((width, height))
+        return transform.resize((width, height))
 
 
 class ScaleOperation(TransformOperation):
     def construct(self, percent):
         self.percent = float(percent)
 
-    def run(self, willow, image, env):
-        image_width, image_height = willow.get_size()
+    def run(self, transform, image):
+        image_width, image_height = transform.size
 
         scale = self.percent / 100
         width = int(image_width * scale)
         height = int(image_height * scale)
 
-        # prevent zero width or height, it causes a ValueError on willow.resize
+        # prevent zero width or height, it causes a ValueError on transform.resize
         width = width if width > 0 else 1
         height = height if height > 0 else 1
 
-        return willow.resize((width, height))
+        return transform.resize((width, height))
 
 
 # Filters

--- a/wagtail/images/image_operations.py
+++ b/wagtail/images/image_operations.py
@@ -25,19 +25,16 @@ class Operation:
     def construct(self, *args):
         raise NotImplementedError
 
+
+# Transforms
+
+
+class TransformOperation(Operation):
     def run(self, willow, image, env):
         raise NotImplementedError
 
 
-class DoNothingOperation(Operation):
-    def construct(self):
-        pass
-
-    def run(self, willow, image, env):
-        pass
-
-
-class FillOperation(Operation):
+class FillOperation(TransformOperation):
     vary_fields = ('focal_point_width', 'focal_point_height', 'focal_point_x', 'focal_point_y')
 
     def construct(self, size, *extra):
@@ -143,7 +140,7 @@ class FillOperation(Operation):
         return willow
 
 
-class MinMaxOperation(Operation):
+class MinMaxOperation(TransformOperation):
     def construct(self, size):
         # Get width and height
         width_str, height_str = size.split('x')
@@ -189,7 +186,7 @@ class MinMaxOperation(Operation):
         return willow.resize((width, height))
 
 
-class WidthHeightOperation(Operation):
+class WidthHeightOperation(TransformOperation):
     def construct(self, size):
         self.size = int(size)
 
@@ -225,7 +222,7 @@ class WidthHeightOperation(Operation):
         return willow.resize((width, height))
 
 
-class ScaleOperation(Operation):
+class ScaleOperation(TransformOperation):
     def construct(self, percent):
         self.percent = float(percent)
 
@@ -243,7 +240,23 @@ class ScaleOperation(Operation):
         return willow.resize((width, height))
 
 
-class JPEGQualityOperation(Operation):
+# Filters
+
+
+class FilterOperation(Operation):
+    def run(self, willow, image, env):
+        raise NotImplementedError
+
+
+class DoNothingOperation(FilterOperation):
+    def construct(self):
+        pass
+
+    def run(self, willow, image, env):
+        return willow
+
+
+class JPEGQualityOperation(FilterOperation):
     def construct(self, quality):
         self.quality = int(quality)
 
@@ -254,7 +267,7 @@ class JPEGQualityOperation(Operation):
         env['jpeg-quality'] = self.quality
 
 
-class WebPQualityOperation(Operation):
+class WebPQualityOperation(FilterOperation):
     def construct(self, quality):
         self.quality = int(quality)
 
@@ -265,7 +278,7 @@ class WebPQualityOperation(Operation):
         env['webp-quality'] = self.quality
 
 
-class FormatOperation(Operation):
+class FormatOperation(FilterOperation):
     def construct(self, format, *options):
         self.format = format
         self.options = options
@@ -279,7 +292,7 @@ class FormatOperation(Operation):
         env['output-format-options'] = self.options
 
 
-class BackgroundColorOperation(Operation):
+class BackgroundColorOperation(FilterOperation):
     def construct(self, color_string):
         self.color = parse_color_string(color_string)
 

--- a/wagtail/images/models.py
+++ b/wagtail/images/models.py
@@ -568,6 +568,17 @@ class AbstractRendition(models.Model):
             url = settings.BASE_URL + url
         return url
 
+    @property
+    def filter(self):
+        return Filter(self.filter_spec)
+
+    @cached_property
+    def focal_point(self):
+        image_focal_point = self.image.get_focal_point()
+        if image_focal_point:
+            transform = self.filter.get_transform(self.image)
+            return image_focal_point.transform(transform)
+
     def img_tag(self, extra_attributes={}):
         attrs = self.attrs_dict.copy()
         attrs.update(extra_attributes)

--- a/wagtail/images/models.py
+++ b/wagtail/images/models.py
@@ -579,6 +579,28 @@ class AbstractRendition(models.Model):
             transform = self.filter.get_transform(self.image)
             return image_focal_point.transform(transform)
 
+    @property
+    def background_position_style(self):
+        """
+        Returns a `background-position` rule to be put in the inline style of an element which uses the rendition for its background.
+
+        This positions the rendition according to the value of the focal point. This is helpful for when the element does not have
+        the same aspect ratio as the rendition.
+
+        For example:
+
+            {% image page.image fill-1920x600 as image %}
+            <div style="background-image: url('{{ image.url }}'); {{ image.background_position_style }}">
+            </div>
+        """
+        focal_point = self.focal_point
+        if focal_point:
+            horz = int((focal_point.x * 100) // self.width)
+            vert = int((focal_point.y * 100) // self.height)
+            return 'background-position: {}% {}%;'.format(horz, vert)
+        else:
+            return 'background-position: 50% 50%;'
+
     def img_tag(self, extra_attributes={}):
         attrs = self.attrs_dict.copy()
         attrs.update(extra_attributes)

--- a/wagtail/images/rect.py
+++ b/wagtail/images/rect.py
@@ -154,6 +154,21 @@ class Rect:
 
         return clone
 
+    def transform(self, transform):
+        # Transform each corner of the rect
+        tl_transformed = transform.transform_vector(Vector(self.left, self.top))
+        tr_transformed = transform.transform_vector(Vector(self.right, self.top))
+        bl_transformed = transform.transform_vector(Vector(self.left, self.bottom))
+        br_transformed = transform.transform_vector(Vector(self.right, self.bottom))
+
+        # Find extents of the transformed corners
+        left = min([tl_transformed.x, tr_transformed.x, bl_transformed.x, br_transformed.x])
+        right = max([tl_transformed.x, tr_transformed.x, bl_transformed.x, br_transformed.x])
+        top = min([tl_transformed.y, tr_transformed.y, bl_transformed.y, br_transformed.y])
+        bottom = max([tl_transformed.y, tr_transformed.y, bl_transformed.y, br_transformed.y])
+
+        return Rect(left, top, right, bottom)
+
     def __iter__(self):
         return iter((self.left, self.top, self.right, self.bottom))
 

--- a/wagtail/images/tests/test_models.py
+++ b/wagtail/images/tests/test_models.py
@@ -318,6 +318,14 @@ class TestRenditions(TestCase):
         self.assertEqual(rendition.focal_point.width, 25)
         self.assertEqual(rendition.focal_point.height, 10)
 
+        self.assertEqual(rendition.background_position_style, 'background-position: 15% 41%;')
+
+    def test_background_position_style_default(self):
+        # Generate a rendition that's half the size of the original
+        rendition = self.image.get_rendition('width-320')
+
+        self.assertEqual(rendition.background_position_style, 'background-position: 50% 50%;')
+
 
 class TestUsageCount(TestCase):
     fixtures = ['test.json']

--- a/wagtail/images/tests/test_models.py
+++ b/wagtail/images/tests/test_models.py
@@ -302,6 +302,22 @@ class TestRenditions(TestCase):
         new_rendition = self.image.get_rendition('width-500')
         self.assertFalse(hasattr(new_rendition, '_from_cache'))
 
+    def test_focal_point(self):
+        self.image.focal_point_x = 100
+        self.image.focal_point_y = 200
+        self.image.focal_point_width = 50
+        self.image.focal_point_height = 20
+        self.image.save()
+
+        # Generate a rendition that's half the size of the original
+        rendition = self.image.get_rendition('width-320')
+
+        self.assertEqual(rendition.focal_point.round(), Rect(37, 95, 63, 105))
+        self.assertEqual(rendition.focal_point.centroid.x, 50)
+        self.assertEqual(rendition.focal_point.centroid.y, 100)
+        self.assertEqual(rendition.focal_point.width, 25)
+        self.assertEqual(rendition.focal_point.height, 10)
+
 
 class TestUsageCount(TestCase):
     fixtures = ['test.json']

--- a/wagtail/images/tests/test_transform.py
+++ b/wagtail/images/tests/test_transform.py
@@ -1,0 +1,60 @@
+from unittest import TestCase
+
+from wagtail.images.image_operations import ImageTransform
+from wagtail.images.rect import Rect, Vector
+
+
+class TestTransform(TestCase):
+    def test_resize(self):
+        context = ImageTransform((640, 480))
+        resized = context.resize((320, 240))
+
+        vector = Vector(100, 200)
+        transformed = resized.transform_vector(vector)
+
+        self.assertEqual(transformed, Vector(50, 100))
+
+        untransformed = resized.untransform_vector(transformed)
+
+        self.assertEqual(untransformed, vector)
+
+    def test_crop(self):
+        context = ImageTransform((640, 480))
+        cropped = context.crop(Rect(200, 100, 300, 200))
+
+        vector = Vector(250, 150)
+        transformed = cropped.transform_vector(vector)
+
+        self.assertEqual(transformed, Vector(50, 50))
+
+        untransformed = cropped.untransform_vector(transformed)
+
+        self.assertEqual(untransformed, vector)
+
+    def test_resize_then_crop(self):
+        context = ImageTransform((640, 480))
+        resized = context.resize((320, 240))
+        cropped = resized.crop(Rect(200, 100, 300, 200))
+
+        vector = Vector(500, 300)
+        transformed = cropped.transform_vector(vector)
+
+        self.assertEqual(transformed, Vector(50, 50))
+
+        untransformed = cropped.untransform_vector(transformed)
+
+        self.assertEqual(untransformed, vector)
+
+    def test_crop_then_resize(self):
+        context = ImageTransform((640, 480))
+        cropped = context.crop(Rect(200, 100, 300, 200))
+        resized = cropped.resize((50, 50))
+
+        vector = Vector(250, 150)
+        transformed = resized.transform_vector(vector)
+
+        self.assertEqual(transformed, Vector(25, 25))
+
+        untransformed = resized.untransform_vector(transformed)
+
+        self.assertEqual(untransformed, vector)


### PR DESCRIPTION
Fixes https://github.com/wagtail/wagtail/issues/6641

This separates the 'transform' image operations from the 'filter' so that we can calculate the transform separately and apply this to the focal point on its own, allowing us to calculate a new focal point to be passed into the image tag on the frontend.

I originally tried to implement this using an affine transform matrix and perform all the transformations with a single call Pillow's ``transform()`` method. However, the resampling was pretty horrible (see the middle image on https://pythontic.com/image-processing/pillow/rotate) so I replaced this with tracking the offset and scale instead and use Pillow's ``crop()``/``resize()`` methods.