### PR TITLE
fix small youtube embed - allow to override max_width/max_height in EmbedBlock

### DIFF
--- a/docs/advanced_topics/embeds.rst
+++ b/docs/advanced_topics/embeds.rst
@@ -33,6 +33,9 @@ nest the embed code.
 The :class:`~wagtail.embeds.block.EmbedBlock` block type allows embeds
 to be placed into a ``StreamField``.
 
+The `max_width` and `max_height` init attributes will be passed to
+the oEmbed as `maxwidth` and `maxheight`.
+
 For example:
 
 .. code-block:: python
@@ -42,7 +45,7 @@ For example:
     class MyStreamField(blocks.StreamBlock):
         ...
 
-        embed = EmbedBlock()
+        embed = EmbedBlock(max_width=800, max_height=400)
 
 ``{% embed %}`` tag
 -------------------

--- a/wagtail/embeds/blocks.py
+++ b/wagtail/embeds/blocks.py
@@ -14,12 +14,14 @@ class EmbedValue:
     we want to be able to do {% embed value.url 500 %} without
     doing a redundant fetch of the embed at the default width.
     """
-    def __init__(self, url):
+    def __init__(self, url, max_width=None, max_height=None):
         self.url = url
+        self.max_width = max_width
+        self.max_height = max_height
 
     @cached_property
     def html(self):
-        return embed_to_frontend_html(self.url)
+        return embed_to_frontend_html(self.url, self.max_width, self.max_height)
 
     def __str__(self):
         return self.html
@@ -34,7 +36,7 @@ class EmbedBlock(blocks.URLBlock):
             return self.meta.default
         else:
             # assume default has been passed as a string
-            return EmbedValue(self.meta.default)
+            return EmbedValue(self.meta.default, getattr(self.meta, 'max_width', None), getattr(self.meta, 'max_height', None))
 
     def to_python(self, value):
         # The JSON representation of an EmbedBlock's value is a URL string;
@@ -42,7 +44,7 @@ class EmbedBlock(blocks.URLBlock):
         if not value:
             return None
         else:
-            return EmbedValue(value)
+            return EmbedValue(value, getattr(self.meta, 'max_width', None), getattr(self.meta, 'max_height', None))
 
     def get_prep_value(self, value):
         # serialisable value should be a URL string
@@ -63,7 +65,7 @@ class EmbedBlock(blocks.URLBlock):
         if not value:
             return None
         else:
-            return EmbedValue(value)
+            return EmbedValue(value, getattr(self.meta, 'max_width', None), getattr(self.meta, 'max_height', None))
 
     def clean(self, value):
         if isinstance(value, EmbedValue) and not value.html:

--- a/wagtail/embeds/embeds.py
+++ b/wagtail/embeds/embeds.py
@@ -6,26 +6,28 @@ from .finders import get_finders
 from .models import Embed
 
 
-def get_embed(url, max_width=None, finder=None):
-    embed_hash = get_embed_hash(url, max_width)
+def get_embed(url, max_width=None, max_height=None, finder=None):
+    print(url, max_width)
+    embed_hash = get_embed_hash(url, max_width, max_height)
 
     # Check database
     try:
         return Embed.objects.get(hash=embed_hash)
     except Embed.DoesNotExist:
         pass
+    print("does not exist")
 
     # Get/Call finder
     if not finder:
 
-        def finder(url, max_width=None):
+        def finder(url, max_width=None, max_height=None):
             for finder in get_finders():
                 if finder.accept(url):
-                    return finder.find_embed(url, max_width=max_width)
+                    return finder.find_embed(url, max_width=max_width, max_height=max_height)
 
             raise EmbedUnsupportedProviderException
 
-    embed_dict = finder(url, max_width)
+    embed_dict = finder(url, max_width, max_height)
 
     # Make sure width and height are valid integers before inserting into database
     try:
@@ -63,10 +65,13 @@ def get_embed(url, max_width=None, finder=None):
     return embed
 
 
-def get_embed_hash(url, max_width=None):
+def get_embed_hash(url, max_width=None, max_height=None):
     h = md5()
     h.update(url.encode("utf-8"))
     if max_width is not None:
         h.update(b"\n")
         h.update(str(max_width).encode("utf-8"))
+    if max_height is not None:
+        h.update(b"\n")
+        h.update(str(max_height).encode("utf-8"))
     return h.hexdigest()

--- a/wagtail/embeds/embeds.py
+++ b/wagtail/embeds/embeds.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from hashlib import md5
 
+from ..core.utils import accepts_kwarg
 from .exceptions import EmbedUnsupportedProviderException
 from .finders import get_finders
 from .models import Embed
@@ -21,7 +22,10 @@ def get_embed(url, max_width=None, max_height=None, finder=None):
         def finder(url, max_width=None, max_height=None):
             for finder in get_finders():
                 if finder.accept(url):
-                    return finder.find_embed(url, max_width=max_width, max_height=max_height)
+                    kwargs = {}
+                    if accepts_kwarg(finder.find_embed, 'max_height'):
+                        kwargs['max_height'] = max_height
+                    return finder.find_embed(url, max_width=max_width, **kwargs)
 
             raise EmbedUnsupportedProviderException
 

--- a/wagtail/embeds/embeds.py
+++ b/wagtail/embeds/embeds.py
@@ -7,7 +7,6 @@ from .models import Embed
 
 
 def get_embed(url, max_width=None, max_height=None, finder=None):
-    print(url, max_width)
     embed_hash = get_embed_hash(url, max_width, max_height)
 
     # Check database
@@ -15,7 +14,6 @@ def get_embed(url, max_width=None, max_height=None, finder=None):
         return Embed.objects.get(hash=embed_hash)
     except Embed.DoesNotExist:
         pass
-    print("does not exist")
 
     # Get/Call finder
     if not finder:

--- a/wagtail/embeds/finders/oembed.py
+++ b/wagtail/embeds/finders/oembed.py
@@ -42,7 +42,7 @@ class OEmbedFinder(EmbedFinder):
     def accept(self, url):
         return self._get_endpoint(url) is not None
 
-    def find_embed(self, url, max_width=None):
+    def find_embed(self, url, max_width=None, max_height=None):
         # Find provider
         endpoint = self._get_endpoint(url)
         if endpoint is None:
@@ -54,6 +54,8 @@ class OEmbedFinder(EmbedFinder):
         params['format'] = 'json'
         if max_width:
             params['maxwidth'] = max_width
+        if max_height:
+            params['maxheight'] = max_height
 
         # Perform request
         request = Request(endpoint + '?' + urlencode(params))

--- a/wagtail/embeds/format.py
+++ b/wagtail/embeds/format.py
@@ -4,9 +4,9 @@ from wagtail.embeds import embeds
 from wagtail.embeds.exceptions import EmbedException
 
 
-def embed_to_frontend_html(url):
+def embed_to_frontend_html(url, max_width=None, max_height=None):
     try:
-        embed = embeds.get_embed(url)
+        embed = embeds.get_embed(url, max_width, max_height)
 
         # Render template
         return render_to_string('wagtailembeds/embed_frontend.html', {

--- a/wagtail/embeds/tests/test_embeds.py
+++ b/wagtail/embeds/tests/test_embeds.py
@@ -120,7 +120,7 @@ class TestEmbeds(TestCase):
     def setUp(self):
         self.hit_count = 0
 
-    def dummy_finder(self, url, max_width=None):
+    def dummy_finder(self, url, max_width=None, max_height=None):
         # Up hit count
         self.hit_count += 1
 
@@ -172,7 +172,7 @@ class TestEmbeds(TestCase):
         self.assertEqual(embed.width, 400)
         self.assertFalse(embed.is_responsive)
 
-    def dummy_finder_invalid_width(self, url, max_width=None):
+    def dummy_finder_invalid_width(self, url, max_width=None, max_height=None):
         # Return a record with an invalid width
         return {
             'title': "Test: " + url,
@@ -190,7 +190,7 @@ class TestEmbeds(TestCase):
         self.assertEqual(embed.width, None)
 
     def test_no_html(self):
-        def no_html_finder(url, max_width=None):
+        def no_html_finder(url, max_width=None, max_height=None):
             """
             A finder which returns everything but HTML
             """
@@ -641,7 +641,7 @@ class TestEmbedBlock(TestCase):
         self.assertIn('<h1>Hello world!</h1>', result)
 
         # Check that get_embed was called correctly
-        get_embed.assert_any_call('http://www.example.com/foo')
+        get_embed.assert_any_call('http://www.example.com/foo', None, None)
 
     @patch('wagtail.embeds.embeds.get_embed')
     def test_render_within_structblock(self, get_embed):
@@ -666,7 +666,7 @@ class TestEmbedBlock(TestCase):
         self.assertIn('<h1>Hello world!</h1>', result)
 
         # Check that get_embed was called correctly
-        get_embed.assert_any_call('http://www.example.com/foo')
+        get_embed.assert_any_call('http://www.example.com/foo', None, None)
 
     def test_render_form(self):
         """

--- a/wagtail/embeds/tests/test_rich_text.py
+++ b/wagtail/embeds/tests/test_rich_text.py
@@ -129,4 +129,4 @@ class TestFrontendMediaEmbedHandler(TestCase):
 
         result = expand_db_html('<p>1 2 <embed embedtype="media" url="https://www.youtube.com/watch?v=O7D-1RG-VRk&amp;t=25" /> 3 4</p>')
         self.assertIn('test html', result)
-        get_embed.assert_called_with('https://www.youtube.com/watch?v=O7D-1RG-VRk&t=25')
+        get_embed.assert_called_with('https://www.youtube.com/watch?v=O7D-1RG-VRk&t=25', None, None)


### PR DESCRIPTION
YouTube embeds are ending up to be very small:
![Snímek obrazovky_2021-02-26_17-42-48](https://user-images.githubusercontent.com/156755/109328805-29e20480-785a-11eb-8742-2bf2c9a8c96e.png)

This is because YouTube oEmbed changed defaults to smaller size.
This PR allows to set `max_width` and `max_height` parameters to EmbedBlock init in order to set up bigger embeds.