### PR TITLE
Add PageQuerySet.defer_streamfields()

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -10,6 +10,7 @@ Changelog
  * Support passing multiple models as arguments to `type()`, `not_type()`, `exact_type()` and `not_exact_type()` methods on `PageQuerySet` (Andy Babic)
  * Update default attribute copying behaviour of `Page.get_specific()` and added the `copy_attrs_exclude` option (Andy Babic)
  * Update `PageQueryset.specific(defer=True)` to only perform a single database query (Andy Babic)
+ * Add `PageQueryset.defer_streamfields()` (Andy Babic)
  * Fix: StreamField required status is now consistently handled by the `blank` keyword argument (Matt Westcott)
  * Fix: Show 'required' asterisks for blocks inside required StreamFields (Matt Westcott)
  * Fix: Make image chooser "Select format" fields translatable (Helen Chapman, Thibaud Colas)

--- a/docs/reference/pages/queryset_reference.rst
+++ b/docs/reference/pages/queryset_reference.rst
@@ -270,4 +270,18 @@ Reference
 
         See also: :py:attr:`Page.specific <wagtail.core.models.Page.specific>`
 
+    .. automethod:: defer_streamfields
+
+        Example:
+
+        .. code-block:: python
+
+            # Apply to a queryset to avoid fetching StreamField values
+            # for a specific model
+            EventPage.objects.all().defer_streamfields()
+
+            # Or combine with specific() to avoid fetching StreamField
+            # values for all models
+            homepage.get_children().defer_streamfields().specific()
+
     .. automethod:: first_common_ancestor

--- a/docs/releases/2.13.rst
+++ b/docs/releases/2.13.rst
@@ -16,6 +16,7 @@ Other features
 * Support passing ``min_num``, ``max_num`` and ``block_counts`` arguments directly to ``StreamField`` (Haydn Greatnews, Matt Westcott)
 * Add the option to set rich text images as decorative, without alt text (Helen Chapman, Thibaud Colas)
 * Add support for ``__year`` filter in Elasticsearch queries (Seb Brown)
+* Add ``PageQuerySet.defer_streamfields()`` (Andy Babic)
 * Support passing multiple models as arguments to ``type()``, ``not_type()``, ``exact_type()`` and ``not_exact_type()`` methods on ``PageQuerySet`` (Andy Babic)
 * Update default attribute copying behaviour of ``Page.get_specific()`` and added the ``copy_attrs_exclude`` option (Andy Babic)
 * Update ``PageQueryset.specific(defer=True)`` to only perform a single database query (Andy Babic)


### PR DESCRIPTION
Originally implemented in #6216.

Adds a `defer_streamfields()` method to PageQuerySet that can be used in situations where specific page instance are required, but only in a 'listing' capacity, where `Streamfield` values are not unlikely to be needed. For example: Page explorer views, API list views, sitemap generation.

It can also be used as an alternative to `specific(defer=True)` in cases where overridden methods are likely to be utilising specific field values, but the likelihood of those fields being streamfields is slim.