### PR TITLE
Utilise PageQuerySet.defer_streamfields()

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -11,6 +11,7 @@ Changelog
  * Update default attribute copying behaviour of `Page.get_specific()` and added the `copy_attrs_exclude` option (Andy Babic)
  * Update `PageQueryset.specific(defer=True)` to only perform a single database query (Andy Babic)
  * Add `PageQueryset.defer_streamfields()` (Andy Babic)
+ * Utilize `PageQuerySet.defer_streamfields()` to improve efficiency in a few key places (Andy Babic)
  * Fix: StreamField required status is now consistently handled by the `blank` keyword argument (Matt Westcott)
  * Fix: Show 'required' asterisks for blocks inside required StreamFields (Matt Westcott)
  * Fix: Make image chooser "Select format" fields translatable (Helen Chapman, Thibaud Colas)

--- a/docs/releases/2.13.rst
+++ b/docs/releases/2.13.rst
@@ -17,6 +17,7 @@ Other features
 * Add the option to set rich text images as decorative, without alt text (Helen Chapman, Thibaud Colas)
 * Add support for ``__year`` filter in Elasticsearch queries (Seb Brown)
 * Add ``PageQuerySet.defer_streamfields()`` (Andy Babic)
+* Utilize ``PageQuerySet.defer_streamfields()`` to improve efficiency in a few key places (Andy Babic)
 * Support passing multiple models as arguments to ``type()``, ``not_type()``, ``exact_type()`` and ``not_exact_type()`` methods on ``PageQuerySet`` (Andy Babic)
 * Update default attribute copying behaviour of ``Page.get_specific()`` and added the ``copy_attrs_exclude`` option (Andy Babic)
 * Update ``PageQueryset.specific(defer=True)`` to only perform a single database query (Andy Babic)

--- a/wagtail/admin/api/views.py
+++ b/wagtail/admin/api/views.py
@@ -79,7 +79,7 @@ class PagesAdminAPIViewSet(PagesAPIViewSet):
 
         # Hide root page
         # TODO: Add "include_root" flag
-        queryset = queryset.exclude(depth=1).specific()
+        queryset = queryset.exclude(depth=1).defer_streamfields().specific()
 
         return queryset
 

--- a/wagtail/admin/tests/pages/test_explorer_view.py
+++ b/wagtail/admin/tests/pages/test_explorer_view.py
@@ -243,21 +243,6 @@ class TestPageExplorer(TestCase, WagtailTestUtils):
         response = self.client.get(reverse('wagtailadmin_explore', args=(new_event.id, )))
         self.assertContains(response, 'New event 0 (single event)')
 
-    def test_ordering_less_than_100_pages_uses_specific_page_with_custom_display_title(self):
-        # Reorder view should also use specific pages
-        # (provided there are <100 pages in the listing, as this may be a significant
-        # performance hit on larger listings)
-        # There are 3 pages created in setUp, so 96 more add to a total of 99.
-        self.make_event_pages(count=96)
-        response = self.client.get(reverse('wagtailadmin_explore', args=(self.root_page.id, )) + '?ordering=ord')
-        self.assertContains(response, 'New event 0 (single event)')
-
-    def test_ordering_100_or_more_pages_uses_generic_page_without_custom_display_title(self):
-        # There are 3 pages created in setUp, so 97 more add to a total of 100.
-        self.make_event_pages(count=97)
-        response = self.client.get(reverse('wagtailadmin_explore', args=(self.root_page.id, )) + '?ordering=ord')
-        self.assertNotContains(response, 'New event 0 (single event)')
-
     def test_parent_page_is_specific(self):
         response = self.client.get(reverse('wagtailadmin_explore', args=(self.child_page.id, )))
         self.assertEqual(response.status_code, 200)

--- a/wagtail/admin/views/chooser.py
+++ b/wagtail/admin/views/chooser.py
@@ -93,8 +93,8 @@ def browse(request, parent_page_id=None):
 
     parent_page = parent_page.specific
 
-    # Get children of parent page
-    pages = parent_page.get_children().specific()
+    # Get children of parent page (without streamfields)
+    pages = parent_page.get_children().defer_streamfields().specific()
 
     # allow hooks to modify the queryset
     for hook in hooks.get_hooks('construct_page_chooser_queryset'):

--- a/wagtail/admin/views/pages/listing.py
+++ b/wagtail/admin/views/pages/listing.py
@@ -77,15 +77,10 @@ def index(request, parent_page_id=None):
     # allow drag-and-drop reordering
     do_paginate = ordering != 'ord'
 
-    if do_paginate or pages.count() < 100:
-        # Retrieve pages in their most specific form, so that custom
-        # get_admin_display_title and get_url_parts methods on subclasses are respected.
-        # However, skip this on unpaginated listings with >100 child pages as this could
-        # be a significant performance hit. (This should only happen on the reorder view,
-        # and hopefully no-one is having to do manual reordering on listings that large...)
-        pages = pages.specific(defer=True)
+    # We want specific page instances, but do not need streamfield values here
+    pages = pages.defer_streamfields().specific()
 
-    # allow hooks to modify the queryset
+    # allow hooks defer_streamfieldsyset
     for hook in hooks.get_hooks('construct_explorer_page_queryset'):
         pages = hook(parent_page, pages, request)
 

--- a/wagtail/admin/views/pages/unpublish.py
+++ b/wagtail/admin/views/pages/unpublish.py
@@ -30,8 +30,7 @@ def unpublish(request, page_id):
         page.unpublish(user=request.user)
 
         if include_descendants:
-            live_descendant_pages = page.get_descendants().live().specific()
-            for live_descendant_page in live_descendant_pages:
+            for live_descendant_page in page.get_descendants().live().defer_streamfields().specific():
                 if user_perms.for_page(live_descendant_page).can_unpublish():
                     live_descendant_page.unpublish()
 

--- a/wagtail/contrib/sitemaps/sitemap_generator.py
+++ b/wagtail/contrib/sitemaps/sitemap_generator.py
@@ -37,7 +37,9 @@ class Sitemap(DjangoSitemap):
             .live()
             .public()
             .order_by('path')
-            .specific())
+            .defer_streamfields()
+            .specific()
+        )
 
     def _urls(self, page, protocol, domain):
         urls = []


### PR DESCRIPTION
Originally implemented in #6216

Utilises the newly implemented `PageQuerySet.defer_streamfields()` method to save resources in several places where `StreamField` values are unlikely to be needed.