### PR TITLE
Fix crash when copying an alias page 

### DIFF
--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -2051,14 +2051,17 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
         exclude_fields = self.default_exclude_fields_in_copy + self.exclude_fields_in_copy + (exclude_fields or [])
         specific_self = self.specific
         if keep_live:
-            base_update_attrs = {}
+            base_update_attrs = {
+                'alias_of': None,
+            }
         else:
             base_update_attrs = {
                 'live': False,
                 'has_unpublished_changes': True,
                 'live_revision': None,
                 'first_published_at': None,
-                'last_published_at': None
+                'last_published_at': None,
+                'alias_of': None,
             }
 
         if user:

--- a/wagtail/core/tests/test_page_model.py
+++ b/wagtail/core/tests/test_page_model.py
@@ -1666,6 +1666,22 @@ class TestCopyPage(TestCase):
         )
         self.assertFalse(signal_fired)
 
+    def test_copy_alias_page(self):
+        about_us = SimplePage.objects.get(url_path='/home/about-us/')
+        about_us_alias = about_us.create_alias(update_slug='about-us-alias')
+
+        about_us_alias_copy = about_us_alias.copy(update_attrs={
+            'slug': 'about-us-alias-copy'
+        })
+
+        self.assertIsInstance(about_us_alias_copy, SimplePage)
+        self.assertEqual(about_us_alias_copy.slug, 'about-us-alias-copy')
+        self.assertNotEqual(about_us_alias_copy.id, about_us.id)
+        self.assertEqual(about_us_alias_copy.url_path, '/home/about-us-alias-copy/')
+
+        # The copy should just be a copy of the original page, not an alias
+        self.assertIsNone(about_us_alias_copy.alias_of)
+
 
 class TestCreateAlias(TestCase):
     fixtures = ['test.json']


### PR DESCRIPTION
Fixes https://github.com/wagtail/wagtail/issues/6758

This sets ``alias_of`` to null on all copied pages. So if someone copies an alias page, the new page will not be an alias.