### PR TITLE
Change webmaster to admin

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -38,6 +38,7 @@ Changelog
  * Implemented a locale switcher on the forms listing page in the admin (Dan Braghis)
  * Implemented a locale switcher on the page chooser modal (Dan Braghis)
  * Implemented the `wagtail_site` template tag for Jinja2 (Vladimir Tananko)
+ * Change webmaster to website administrator in the admin (Naomi Morduch Toubman)
  * Fix: Accessibility fixes for Windows high contrast mode; Dashboard icons colour and contrast, help/error/warning blocks for fields and general content, side comment buttons within the page editor, dropdown buttons (Sakshi Uppoor, Shariq Jamil, LB (Ben Johnston), Jason Attwood)
  * Fix: Rename additional 'spin' CSS animations to avoid clashes with other libraries (Kevin Gutiérrez)
  * Fix: `default_app_config` deprecations for Django >= 3.2 (Tibor Leupold)

--- a/docs/reference/settings.rst
+++ b/docs/reference/settings.rst
@@ -449,7 +449,7 @@ Email Notifications
 
   WAGTAILADMIN_NOTIFICATION_FROM_EMAIL = 'wagtail@myhost.io'
 
-Wagtail sends email notifications when content is submitted for moderation, and when the content is accepted or rejected. This setting lets you pick which email address these automatic notifications will come from. If omitted, Wagtail will fall back to using Django's ``DEFAULT_FROM_EMAIL`` setting if set, or ``webmaster@localhost`` if not.
+Wagtail sends email notifications when content is submitted for moderation, and when the content is accepted or rejected. This setting lets you pick which email address these automatic notifications will come from. If omitted, Wagtail will fall back to using Django's ``DEFAULT_FROM_EMAIL`` setting.
 
 ``WAGTAILADMIN_NOTIFICATION_USE_HTML``
 --------------------------------------

--- a/docs/releases/2.16.md
+++ b/docs/releases/2.16.md
@@ -41,6 +41,7 @@
  * Implemented a locale switcher on the forms listing page in the admin (Dan Braghis)
  * Implemented a locale switcher on the page chooser modal (Dan Braghis)
  * Implemented the `wagtail_site` template tag for Jinja2 (Vladimir Tananko)
+ * Change webmaster to website administrator in the admin (Naomi Morduch Toubman)
 
 ### Bug fixes
 

--- a/wagtail/admin/mail.py
+++ b/wagtail/admin/mail.py
@@ -41,6 +41,7 @@ def send_mail(subject, message, recipient_list, from_email=None, **kwargs):
         elif hasattr(settings, 'DEFAULT_FROM_EMAIL'):
             from_email = settings.DEFAULT_FROM_EMAIL
         else:
+            # We are no longer using the term `webmaster` except in this case, where we continue to match Django's default: https://github.com/django/django/blob/stable/3.2.x/django/conf/global_settings.py#L223
             from_email = 'webmaster@localhost'
 
     connection = kwargs.get('connection', False) or get_connection(

--- a/wagtail/admin/views/workflows.py
+++ b/wagtail/admin/views/workflows.py
@@ -571,7 +571,7 @@ class BaseTaskChooserView(TemplateView):
     def get_form_js_context(self):
         return {
             'error_label': _("Server Error"),
-            'error_message': _("Report this error to your webmaster with the following information:"),
+            'error_message': _("Report this error to your website administrator with the following information:"),
         }
 
     def get_task_listing_context_data(self):

--- a/wagtail/documents/views/chooser.py
+++ b/wagtail/documents/views/chooser.py
@@ -109,7 +109,7 @@ class ChooseView(BaseChooseView):
             json_data={
                 'step': 'chooser',
                 'error_label': _("Server Error"),
-                'error_message': _("Report this error to your webmaster with the following information:"),
+                'error_message': _("Report this error to your website administrator with the following information:"),
                 'tag_autocomplete_url': reverse('wagtailadmin_tag_autocomplete'),
             }
         )

--- a/wagtail/images/templates/wagtailimages/multiple/add.html
+++ b/wagtail/images/templates/wagtailimages/multiple/add.html
@@ -72,7 +72,7 @@
                 <p class="status-msg failure">{% trans "Sorry, upload failed." %}</p>
                 <p class="status-msg server-error">
                     <strong>{% trans "Server Error" %}</strong>
-                    {% trans "Report this error to your webmaster with the following information:"%}
+                    {% trans "Report this error to your website administrator with the following information:"%}
                     <br /><span class="error-text"></span> - <span class="error-code"></span>
                 </p>
                 <p class="status-msg update-success">{% trans "Image updated." %}</p>

--- a/wagtail/images/views/chooser.py
+++ b/wagtail/images/views/chooser.py
@@ -123,7 +123,7 @@ class ChooseView(BaseChooseView):
             json_data={
                 'step': 'chooser',
                 'error_label': _("Server Error"),
-                'error_message': _("Report this error to your webmaster with the following information:"),
+                'error_message': _("Report this error to your website administrator with the following information:"),
                 'tag_autocomplete_url': reverse('wagtailadmin_tag_autocomplete'),
             }
         )


### PR DESCRIPTION
Working to decrease potentially-insensitive language as per [RFC 63](https://github.com/wagtail/rfcs/blob/master/text/063-avoid-insensitive-language.md).

The primary change here is `contact your webmaster` → `contact your website administrator`. `webmaster` contains `master` and is also a title that is increasingly outdated; `website administrator` is still not a very precise term, but I think it should work fine for this. I'm not confident that `admin@localhost` is an amazing name choice, but I also don't think that matters enormously.

## Updating for translation

I did not change the translated versions of this phrase, so some of them still have variations on 'webmaster', but some of them already had some variation on 'administrator'. Retranslating this phrase may not be a high priority, given that only the wording has changed, not the meaning.

**After merging this PR, push changes to Transifex.**

## Checks

* [x] Do the tests still pass? Yes
* [x] Does the code comply with the style guide? No linting errors in things I changed
* [x] For Python changes: I updated tests
* ~~For front-end changes: Did you test on all of Wagtail’s supported browsers?~~
* ~~For new features: Has the documentation been updated accordingly?~~