### PR TITLE
Revert "Support skipping CI" – now supported natively in GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,6 @@ on:
 
 jobs:
   test-sqlite:
-    if: "!contains(github.event.head_commit.message, '[skip ci]')"
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -61,7 +60,6 @@ jobs:
           DATABASE_ENGINE: django.db.backends.sqlite3
 
   test-postgres:
-    if: "!contains(github.event.head_commit.message, '[skip ci]')"
     runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.experimental }}
     strategy:
@@ -116,7 +114,6 @@ jobs:
           DISABLE_TIMEZONE: ${{ matrix.notz }}
 
   test-mysql:
-    if: "!contains(github.event.head_commit.message, '[skip ci]')"
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -159,7 +156,6 @@ jobs:
   # https://github.com/elastic/elastic-github-actions doesn't work for Elasticsearch 5,
   # but https://github.com/getong/elasticsearch-action does
   test-sqlite-elasticsearch5:
-    if: "!contains(github.event.head_commit.message, '[skip ci]')"
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -200,7 +196,6 @@ jobs:
           DATABASE_ENGINE: django.db.backends.sqlite3
 
   test-sqlite-elasticsearch7:
-    if: "!contains(github.event.head_commit.message, '[skip ci]')"
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -245,7 +240,6 @@ jobs:
   # https://github.com/getong/elasticsearch-action doesn't work for Elasticsearch 6,
   # but https://github.com/elastic/elastic-github-actions does
   test-postgres-elasticsearch6:
-    if: "!contains(github.event.head_commit.message, '[skip ci]')"
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -294,7 +288,6 @@ jobs:
           USE_EMAIL_USER_MODEL: ${{ matrix.emailuser }}
 
   test-postgres-elasticsearch7:
-    if: "!contains(github.event.head_commit.message, '[skip ci]')"
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
Reverts wagtail/wagtail#6770, as [GitHub Actions now offers native `[skip-ci]` support](https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/).