### PR TITLE
Removed target: _blank and changed new_window to False in 'view live' and 'view draft' buttons #6123

### DIFF
--- a/wagtail/admin/views/pages/create.py
+++ b/wagtail/admin/views/pages/create.py
@@ -118,11 +118,11 @@ class CreateView(TemplateResponseMixin, ContextMixin, HookResponseMixin, View):
 
     def get_view_draft_message_button(self):
         return messages.button(
-            reverse('wagtailadmin_pages:view_draft', args=(self.page.id,)), _('View draft'), new_window=True
+            reverse('wagtailadmin_pages:view_draft', args=(self.page.id,)), _('View draft'), new_window=False
         )
 
     def get_view_live_message_button(self):
-        return messages.button(self.page.url, _('View live'), new_window=True)
+        return messages.button(self.page.url, _('View live'), new_window=False)
 
     def save_action(self):
         self.page = self.form.save(commit=False)

--- a/wagtail/admin/views/pages/edit.py
+++ b/wagtail/admin/views/pages/edit.py
@@ -65,11 +65,11 @@ class EditView(TemplateResponseMixin, ContextMixin, HookResponseMixin, View):
         return messages.button(
             reverse('wagtailadmin_pages:view_draft', args=(self.page.id,)),
             _('View draft'),
-            new_window=True
+            new_window=False
         )
 
     def get_view_live_message_button(self):
-        return messages.button(self.page.url, _('View live'), new_window=True)
+        return messages.button(self.page.url, _('View live'), new_window=False)
 
     def get_compare_with_live_message_button(self):
         return messages.button(

--- a/wagtail/admin/views/pages/moderation.py
+++ b/wagtail/admin/views/pages/moderation.py
@@ -24,7 +24,7 @@ def approve_moderation(request, revision_id):
         message = _("Page '{0}' published.").format(revision.page.specific_deferred.get_admin_display_title())
         buttons = []
         if revision.page.url is not None:
-            buttons.append(messages.button(revision.page.url, _('View live'), new_window=True))
+            buttons.append(messages.button(revision.page.url, _('View live'), new_window=False))
         buttons.append(messages.button(reverse('wagtailadmin_pages:edit', args=(revision.page.id,)), _('Edit')))
         messages.success(request, message, buttons=buttons)
 

--- a/wagtail/admin/wagtail_hooks.py
+++ b/wagtail/admin/wagtail_hooks.py
@@ -142,7 +142,7 @@ def page_listing_buttons(page, page_perms, is_parent=False, next_url=None):
             reverse('wagtailadmin_pages:view_draft', args=[page.id]),
             attrs={
                 'aria-label': _("Preview draft version of '%(title)s'") % {'title': page.get_admin_display_title()},
-                'target': '_blank', 'rel': 'noopener noreferrer'
+                'rel': 'noopener noreferrer'
             },
             priority=20
         )
@@ -151,7 +151,7 @@ def page_listing_buttons(page, page_perms, is_parent=False, next_url=None):
             _('View live'),
             page.url,
             attrs={
-                'target': "_blank", 'rel': 'noopener noreferrer',
+                'rel': 'noopener noreferrer',
                 'aria-label': _("View live version of '%(title)s'") % {'title': page.get_admin_display_title()},
             },
             priority=30


### PR DESCRIPTION
Removed `target: _blank` and changed `new_window=True` to `new_window=False` for the 'view live' and 'view draft' buttons.
This prevents 'view live' and 'view draft' from opening in a new window. 

@allcaps kindly review.

Closes #6123 