### PR TITLE
make Page.current_workflow_state a cached_property

### DIFF
--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -2786,9 +2786,9 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
     @property
     def workflow_in_progress(self):
         """Returns True if a workflow is in progress on the current page, otherwise False"""
-        return WorkflowState.objects.filter(page=self, status=WorkflowState.STATUS_IN_PROGRESS).exists()
+        return self.current_workflow_state is not None and self.current_workflow_state.status == WorkflowState.STATUS_IN_PROGRESS
 
-    @property
+    @cached_property
     def current_workflow_state(self):
         """Returns the in progress or needs changes workflow state on this page, if it exists"""
         try:


### PR DESCRIPTION
Trying to diagnose general slowness with the page editor I noticed many identical queries being issued in a row of the form

```
SELECT
   "wagtailcore_workflowstate"."id",
   ...
FROM
   "wagtailcore_workflowstate"
WHERE ((
      "wagtailcore_workflowstate"."status" = 'in_progress'
       OR "wagtailcore_workflowstate"."status" = 'needs_changes'
    ) AND "wagtailcore_workflowstate"."page_id" = 105
) LIMIT 21;
```

Which is generated by a query in `Page`'s `current_workflow_state` property.  This is compounded by the fact that the `current_workflow_task_state` property can reference it up to 4 times in a single call!  By making `current_workflow_state` a `@cached_property` the total number of queries is reduced dramatically.  There was also a very similar query used by the `workflow_in_progress` query, so that property has been rewritten to reuse the `current_workflow_state` rather than issuing its own query.

I don't see any obvious reason why this should break anything (assuming the page's workflowstate won't be changing in the middle of a request) and the core tests pass, but it's conceivable some explicit cache invalidation may need to be handled somewhere.
