### PR TITLE
Fixed pagination url for 'view users in a group'

### DIFF
--- a/wagtail/users/templates/wagtailusers/users/results.html
+++ b/wagtail/users/templates/wagtailusers/users/results.html
@@ -14,7 +14,7 @@
 
     {% include "wagtailusers/users/list.html" %}
 
-    {% include "wagtailadmin/shared/pagination_nav.html" with items=users linkurl="wagtailusers_users:index" %}
+    {% include "wagtailadmin/shared/pagination_nav.html" with items=users linkurl="wagtailusers_groups:index group" %}
 {% else %}
     {% if is_searching %}
          <h2 role="alert">{% blocktrans %}Sorry, no users match "<em>{{ query_string }}</em>"{% endblocktrans %}</h2>


### PR DESCRIPTION
I too was able to reproduce this bug. 

Fixed it by changing pagination url of 'view users in a group' from 
`wagtailusers_users:index` to `wagtailusers_groups:index group`

Closes #6874 

@allcaps  Kindly review.