### PR TITLE
Fix typo in site settings documentation example

### DIFF
--- a/docs/reference/contrib/settings.rst
+++ b/docs/reference/contrib/settings.rst
@@ -214,7 +214,7 @@ You can store the settings instance in a variable to save some typing, if you ha
 
     {% with social_settings=settings("app_label.SocialMediaSettings") %}
         Follow us on Twitter at @{{ social_settings.twitter }},
-        or Instagram at @{{ social_settings.Instagram }}.
+        or Instagram at @{{ social_settings.instagram }}.
     {% endwith %}
 
 Or, alternately, using the ``set`` tag:


### PR DESCRIPTION
Lowercase `i` is used in the model definition and in other examples.
