### PR TITLE
Added type="button" to 'set privacy button'

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/pages/privacy_switch_panel.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/privacy_switch_panel.html
@@ -20,7 +20,7 @@
         </p>
 
         {% if page.id and page_perms.can_set_view_restrictions %}
-            <button data-url="{% url 'wagtailadmin_pages:set_privacy' page.id %}" class="button action-set-privacy">
+            <button type="button" data-url="{% url 'wagtailadmin_pages:set_privacy' page.id %}" class="button action-set-privacy">
                 {% trans "Set page privacy" %}
             </button>
         {% endif %}


### PR DESCRIPTION
Added `type="button"` to 'set privacy button'  to fix the opening of page privacy menu on hitting enter in a char block in edit stream-page page.

Closes #6592 