### PR TITLE
Fix the DocSearch search input appearing smaller after initialization

### DIFF
--- a/docs/_static/css/docsearch.overrides.css
+++ b/docs/_static/css/docsearch.overrides.css
@@ -3,3 +3,7 @@
   color: #2980B9;
   background: #F1C40F;
 }
+
+.algolia-autocomplete {
+    width: 100%;
+}


### PR DESCRIPTION
Follow-up to #6833. This is pretty small so assuming it works I’ll merge right away.