### PR TITLE
Fix DocSearch widget initialisation JS error

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -50,7 +50,7 @@
     return debug
   }
 
-  function docSearchReady(script) {
+  function docSearchReady() {
     /**
     * Configure Algolia DocSearch.
     * See https://github.com/algolia/docsearch-configs/blob/master/configs/wagtail.json for index configuration.
@@ -73,6 +73,6 @@
     return search
   }
 
-  window.onload(docSearchReady())
+  docSearchReady();
 </script>
 {% endblock %}

--- a/docs/_templates/search.html
+++ b/docs/_templates/search.html
@@ -19,7 +19,7 @@
 {{ super() }}
 <script>
 
-function runSearchPageSearch(event) {
+function runSearchPageSearch() {
   const urlParams = new URLSearchParams(window.location.search)
   const query = urlParams.get('q')
 


### PR DESCRIPTION
I just noticed this after merging #6833 – the JS error doesn’t prevent initialization of the search, but still would be better without. 