### PR TITLE
Refactor get_settings template tag to return a value instead of writing directly to the context.

### DIFF
--- a/docs/reference/contrib/settings.rst
+++ b/docs/reference/contrib/settings.rst
@@ -170,6 +170,15 @@ If there is no ``request`` available in the template at all, you can use the set
 
 .. note:: You can not reliably get the correct settings instance for the current site from this template tag if the request object is not available. This is only relevant for multisite instances of Wagtail.
 
+By default, the tag will create or update a ``settings`` variable in the context. If you want to
+assign to a different context variable instead, use ``{% get_settings as other_variable_name %}``:
+
+.. code-block:: html+django
+
+    {% load wagtailsettings_tags %}
+    {% get_settings as wagtail_settings %}
+    {{ wagtail_settings.app_label.SocialMediaSettings.instagram }}
+
 .. _settings_tag_jinja2:
 
 Using in Jinja2 templates

--- a/wagtail/contrib/settings/templatetags/wagtailsettings_tags.py
+++ b/wagtail/contrib/settings/templatetags/wagtailsettings_tags.py
@@ -1,4 +1,5 @@
-from django.template import Library
+from django.template import Library, Node
+from django.template.defaulttags import token_kwargs
 
 from wagtail.core.models import Site
 
@@ -8,14 +9,33 @@ from ..context_processors import SettingsProxy
 register = Library()
 
 
-@register.simple_tag(takes_context=True)
-def get_settings(context, use_default_site=False):
-    if use_default_site:
-        site = Site.objects.get(is_default_site=True)
-        context['settings'] = SettingsProxy(site)
-    elif 'request' in context:
-        context['settings'] = SettingsProxy(context['request'])
-    else:
-        raise RuntimeError('No request found in context, and use_default_site '
-                           'flag not set')
-    return ''
+class GetSettingsNode(Node):
+    def __init__(self, kwargs, target_var):
+        self.kwargs = kwargs
+        self.target_var = target_var
+
+    @staticmethod
+    def get_settings_object(context, use_default_site=False):
+        if use_default_site:
+            site = Site.objects.get(is_default_site=True)
+            return SettingsProxy(site)
+        if 'request' in context:
+            return SettingsProxy(context['request'])
+
+        raise RuntimeError('No request found in context, and use_default_site flag not set')
+
+    def render(self, context):
+        resolved_kwargs = {k: v.resolve(context) for k, v in self.kwargs.items()}
+        context[self.target_var] = self.get_settings_object(context, **resolved_kwargs)
+        return ''
+
+
+@register.tag
+def get_settings(parser, token):
+    bits = token.split_contents()[1:]
+    target_var = 'settings'
+    if len(bits) >= 2 and bits[-2] == 'as':
+        target_var = bits[-1]
+        bits = bits[:-2]
+    kwargs = token_kwargs(bits, parser) if bits else {}
+    return GetSettingsNode(kwargs, target_var)

--- a/wagtail/contrib/settings/tests/test_templates.py
+++ b/wagtail/contrib/settings/tests/test_templates.py
@@ -138,6 +138,37 @@ class TestTemplateTag(TemplateTestCase):
         with self.assertRaises(RuntimeError):
             template.render(context)
 
+    def test_get_settings_variable_assignment_request_context(self):
+        """
+        Check that assigning the setting to a context variable with
+        {% get_settings as wagtail_settings %} works.
+        """
+        request = self.get_request(site=self.other_site)
+        context = Context({'request': request})
+        template = Template('{% load wagtailsettings_tags %}'
+                            '{% get_settings as wagtail_settings %}'
+                            '{{ wagtail_settings.tests.testsetting.title}}')
+
+        self.assertEqual(template.render(context), self.other_site_settings.title)
+        # Also check that the default 'settings' variable hasn't been set
+        template = Template('{% load wagtailsettings_tags %}'
+                            '{% get_settings as wagtail_settings %}'
+                            '{{ settings.tests.testsetting.title}}')
+
+        self.assertEqual(template.render(context), '')
+
+    def test_get_settings_variable_assigment_use_default(self):
+        """
+        Check that assigning the setting to a context variable with
+        {% get_settings use_default_site=True as wagtail_settings %} works.
+        """
+        context = Context()
+        template = Template('{% load wagtailsettings_tags %}'
+                            '{% get_settings use_default_site=True as wagtail_settings %}'
+                            '{{ wagtail_settings.tests.testsetting.title }}')
+
+        self.assertEqual(template.render(context), self.default_site_settings.title)
+
 
 class TestSettingsJinja(TemplateTestCase):
 


### PR DESCRIPTION
Fixes #4753, and addresses #4753 for Django's template engine (not for Jinja2 though - I'm not sure it is possible there).

This PR changes `get_settings` to return a value (which can be assigned in the template) instead of writing directly to the context. This avoids the risk of collisions with other context variables ([example](https://github.com/pydata/conf_site/pull/320)). Thus the recommended usage of the tag changes to:

```
{% load wagtailsettings_tags %}

{% get_settings as wagtail_settings %}
{{ wagtail_settings.foo.SomeClass.text }}
```

In order to preserve some degree of backward compatibility, it's still writing to the context if no `settings` variable already exists - I've documented this as deprecated behaviour (but welcome input on whether this is the right approach).

Also refactored the tests to directly test the return value of the function instead of Django's template rendering.
