### PR TITLE
Remove stray `urlencode`

### DIFF
--- a/wagtail/admin/wagtail_hooks.py
+++ b/wagtail/admin/wagtail_hooks.py
@@ -204,7 +204,6 @@ def page_listing_more_buttons(page, page_perms, is_parent=False, next_url=None):
         if next_url:
             url += '?' + urlencode({'next': next_url})
 
-        urlencode
         yield Button(
             _('Copy'),
             url,


### PR DESCRIPTION
Fixes https://github.com/wagtail/wagtail/issues/6832

Looks like this was accidentally introduced in e1a8dbf09e45e749d424cdc475711d63679f446a

