### PR TITLE
Fix reverse migration errors in images and documents

### DIFF
--- a/wagtail/documents/migrations/0011_add_choose_permissions.py
+++ b/wagtail/documents/migrations/0011_add_choose_permissions.py
@@ -77,7 +77,7 @@ def remove_choose_permission_from_collections(apps, _schema_editor):
     GroupCollectionPermission = apps.get_model('wagtailcore.GroupCollectionPermission')
     choose_permission = get_choose_permission(apps)
 
-    GroupCollectionPermission.objects.filter(permission=choose_permission).delete()
+    GroupCollectionPermission.objects.filter(permission__in=choose_permission).delete()
 
 
 class Migration(migrations.Migration):

--- a/wagtail/documents/migrations/0011_add_choose_permissions.py
+++ b/wagtail/documents/migrations/0011_add_choose_permissions.py
@@ -54,7 +54,7 @@ def get_choose_permission(apps):
     return Permission.objects.filter(
         content_type=document_content_type,
         codename__in=['choose_document']
-    )
+    ).first()
 
 
 def copy_choose_permission_to_collections(apps, _schema_editor):
@@ -64,7 +64,8 @@ def copy_choose_permission_to_collections(apps, _schema_editor):
 
     root_collection = Collection.objects.get(depth=1)
 
-    for permission in get_choose_permission(apps):
+    permission = get_choose_permission(apps)
+    if permission:
         for group in Group.objects.filter(permissions=permission):
             GroupCollectionPermission.objects.create(
                 group=group,
@@ -76,8 +77,8 @@ def copy_choose_permission_to_collections(apps, _schema_editor):
 def remove_choose_permission_from_collections(apps, _schema_editor):
     GroupCollectionPermission = apps.get_model('wagtailcore.GroupCollectionPermission')
     choose_permission = get_choose_permission(apps)
-
-    GroupCollectionPermission.objects.filter(permission__in=choose_permission).delete()
+    if choose_permission:
+        GroupCollectionPermission.objects.filter(permission=choose_permission).delete()
 
 
 class Migration(migrations.Migration):

--- a/wagtail/images/migrations/0023_add_choose_permissions.py
+++ b/wagtail/images/migrations/0023_add_choose_permissions.py
@@ -77,7 +77,7 @@ def remove_choose_permission_from_collections(apps, _schema_editor):
     GroupCollectionPermission = apps.get_model('wagtailcore.GroupCollectionPermission')
     choose_permission = get_choose_permission(apps)
 
-    GroupCollectionPermission.objects.filter(permission=choose_permission).delete()
+    GroupCollectionPermission.objects.filter(permission__in=choose_permission).delete()
 
 
 class Migration(migrations.Migration):

--- a/wagtail/images/migrations/0023_add_choose_permissions.py
+++ b/wagtail/images/migrations/0023_add_choose_permissions.py
@@ -54,7 +54,7 @@ def get_choose_permission(apps):
     return Permission.objects.filter(
         content_type=image_content_type,
         codename__in=['choose_image']
-    )
+    ).first()
 
 
 def copy_choose_permission_to_collections(apps, _schema_editor):
@@ -64,7 +64,8 @@ def copy_choose_permission_to_collections(apps, _schema_editor):
 
     root_collection = Collection.objects.get(depth=1)
 
-    for permission in get_choose_permission(apps):
+    permission = get_choose_permission(apps)
+    if permission:
         for group in Group.objects.filter(permissions=permission):
             GroupCollectionPermission.objects.create(
                 group=group,
@@ -76,8 +77,8 @@ def copy_choose_permission_to_collections(apps, _schema_editor):
 def remove_choose_permission_from_collections(apps, _schema_editor):
     GroupCollectionPermission = apps.get_model('wagtailcore.GroupCollectionPermission')
     choose_permission = get_choose_permission(apps)
-
-    GroupCollectionPermission.objects.filter(permission__in=choose_permission).delete()
+    if choose_permission:
+        GroupCollectionPermission.objects.filter(permission=choose_permission).delete()
 
 
 class Migration(migrations.Migration):


### PR DESCRIPTION
This PR resolves #6907 

The root of the issue is that get_choose_permission() returns a Queryset.