### PR TITLE
Sanitize return_url in authenticate_with_password functions

### DIFF
--- a/wagtail/core/tests/test_page_privacy.py
+++ b/wagtail/core/tests/test_page_privacy.py
@@ -48,6 +48,16 @@ class TestPagePrivacy(TestCase, WagtailTestUtils):
         response = self.client.get('/secret-plans/')
         self.assertEqual(response.templates[0].name, 'tests/simple_page.html')
 
+        self.client.logout()
+
+        # posting an invalid return_url will redirect to default login redirect
+        with self.settings(LOGIN_REDIRECT_URL='/'):
+            response = self.client.post(submit_url, {
+                    'password': 'swordfish',
+                    'return_url': 'https://invaliddomain.com',
+                })
+            self.assertRedirects(response, '/')
+
     def test_view_restrictions_apply_to_subpages(self):
         underpants_page = Page.objects.get(url_path='/home/secret-plans/steal-underpants/')
         response = self.client.get('/secret-plans/steal-underpants/')

--- a/wagtail/core/tests/test_page_privacy.py
+++ b/wagtail/core/tests/test_page_privacy.py
@@ -53,9 +53,9 @@ class TestPagePrivacy(TestCase, WagtailTestUtils):
         # posting an invalid return_url will redirect to default login redirect
         with self.settings(LOGIN_REDIRECT_URL='/'):
             response = self.client.post(submit_url, {
-                    'password': 'swordfish',
-                    'return_url': 'https://invaliddomain.com',
-                })
+                'password': 'swordfish',
+                'return_url': 'https://invaliddomain.com',
+            })
             self.assertRedirects(response, '/')
 
     def test_view_restrictions_apply_to_subpages(self):

--- a/wagtail/documents/tests/test_collection_privacy.py
+++ b/wagtail/documents/tests/test_collection_privacy.py
@@ -77,9 +77,9 @@ class TestCollectionPrivacyDocument(TestCase, WagtailTestUtils):
         # posting an invalid return_url will redirect to default login redirect
         with self.settings(LOGIN_REDIRECT_URL='/'):
             response = self.client.post(submit_url, {
-                    'password': 'swordfish',
-                    'return_url': 'https://invaliddomain.com',
-                })
+                'password': 'swordfish',
+                'return_url': 'https://invaliddomain.com',
+            })
             self.assertRedirects(response, '/')
 
     def test_group_restriction_with_anonymous_user(self):

--- a/wagtail/documents/tests/test_collection_privacy.py
+++ b/wagtail/documents/tests/test_collection_privacy.py
@@ -72,6 +72,16 @@ class TestCollectionPrivacyDocument(TestCase, WagtailTestUtils):
         # now requests to the documents url should pass authentication
         response = self.client.get(doc_url)
 
+        self.client.logout()
+
+        # posting an invalid return_url will redirect to default login redirect
+        with self.settings(LOGIN_REDIRECT_URL='/'):
+            response = self.client.post(submit_url, {
+                    'password': 'swordfish',
+                    'return_url': 'https://invaliddomain.com',
+                })
+            self.assertRedirects(response, '/')
+
     def test_group_restriction_with_anonymous_user(self):
         response, url = self.get_document(self.group_collection)
         self.assertRedirects(response, '/_util/login/?next={}'.format(url))

--- a/wagtail/documents/views/serve.py
+++ b/wagtail/documents/views/serve.py
@@ -5,6 +5,7 @@ from django.http import Http404, HttpResponse, StreamingHttpResponse
 from django.shortcuts import get_object_or_404, redirect
 from django.template.response import TemplateResponse
 from django.urls import reverse
+from django.utils.http import is_safe_url
 from django.views.decorators.cache import cache_control
 from django.views.decorators.http import etag
 
@@ -120,9 +121,13 @@ def authenticate_with_password(request, restriction_id):
     if request.method == 'POST':
         form = PasswordViewRestrictionForm(request.POST, instance=restriction)
         if form.is_valid():
-            restriction.mark_as_passed(request)
+            return_url = form.cleaned_data['return_url']
 
-            return redirect(form.cleaned_data['return_url'])
+            if not is_safe_url(return_url, request.get_host(), request.is_secure()):
+                return_url = settings.LOGIN_REDIRECT_URL
+
+            restriction.mark_as_passed(request)
+            return redirect(return_url)
     else:
         form = PasswordViewRestrictionForm(instance=restriction)
 


### PR DESCRIPTION
Addressing unvalidated url redirects in the `authenticate_with_password` functions in the `core` and `documents` modules. I'm following Django's pattern in [LoginView](https://github.com/django/django/blob/stable/2.2.x/django/contrib/auth/views.py#L65) by first checking to see if the `return_url` [is safe](https://github.com/django/django/blob/stable/2.2.x/django/contrib/auth/views.py#L73), and if not, redirecting to the `LOGIN_REDIRECT_URL`.

Note:  [is_safe_url](https://github.com/django/django/blob/stable/3.0.x/django/utils/http.py#L330) is deprecated as of Django 3.0 and will be removed in Django 4.0. `is_safe_url` should be updated to [url_has_allowed_host_and_scheme](https://github.com/django/django/blob/stable/3.0.x/django/utils/http.py#L301) when Django 2.2 support is dropped.

### Checks
 
√ Do the tests still pass? (https://docs.wagtail.io/en/latest/contributing/developing.html#testing)
√ Does the code comply with the style guide? (Run `make lint` from the Wagtail root)
√ For Python changes: Have you added tests to cover the new/fixed behaviour?
~~For front-end changes: Did you test on all of Wagtail’s supported browsers? **Please list the exact versions you tested**.~~
~~For new features: Has the documentation been updated accordingly?~~
