### PR TITLE
Ignore venv from stylelint

### DIFF
--- a/.stylelintrc.yaml
+++ b/.stylelintrc.yaml
@@ -1,5 +1,6 @@
 ignoreFiles:
   - node_modules
   - build/**/*
+  - venv/**/*
 extends:
   - '@wagtail/stylelint-config-wagtail'


### PR DESCRIPTION
`coverage` ships with a `style.scss`, which `stylelint` attempts to lint.

https://github.com/nedbat/coveragepy/tree/master/coverage/htmlfiles