### PR TITLE
Emit a warning when trying to load a Draftail plugin which doesn't exist

### DIFF
--- a/wagtail/admin/rich_text/editors/draftail/__init__.py
+++ b/wagtail/admin/rich_text/editors/draftail/__init__.py
@@ -1,4 +1,5 @@
 import json
+import warnings
 
 from django.forms import Media, widgets
 from django.utils.functional import cached_property
@@ -32,7 +33,12 @@ class DraftailRichTextArea(widgets.HiddenInput):
 
         for feature in self.features:
             plugin = feature_registry.get_editor_plugin('draftail', feature)
-            if plugin:
+            if plugin is None:
+                warnings.warn(
+                    f"Draftail received an unknown feature '{feature}'.",
+                    category=RuntimeWarning
+                )
+            else:
                 plugin.construct_options(self.options)
                 self.plugins.append(plugin)
 


### PR DESCRIPTION
This mostly catches the case of typos, or forgetting to actually register the feature.

I'm not especially happy with the wording - input appreciated!