### PR TITLE
6853 allow search user with custom fields

### DIFF
--- a/wagtail/tests/customuser/models.py
+++ b/wagtail/tests/customuser/models.py
@@ -7,6 +7,8 @@ from django.db import models
 from wagtail.admin.auth import permission_denied  # noqa
 from wagtail.admin.edit_handlers import FieldPanel
 
+from wagtail.search import index
+
 from .fields import ConvertedValueField
 
 
@@ -35,7 +37,7 @@ class CustomUserManager(BaseUserManager):
                                  **extra_fields)
 
 
-class CustomUser(AbstractBaseUser, PermissionsMixin):
+class CustomUser(index.Indexed, AbstractBaseUser, PermissionsMixin):
     identifier = ConvertedValueField(primary_key=True)
     username = models.CharField(max_length=100, unique=True)
     email = models.EmailField(max_length=255, blank=True)
@@ -60,4 +62,8 @@ class CustomUser(AbstractBaseUser, PermissionsMixin):
     panels = [
         FieldPanel('first_name'),
         FieldPanel('last_name'),
+    ]
+
+    search_fields = [
+        index.SearchField('country', partial_match=True, boost=10)
     ]

--- a/wagtail/tests/customuser/models.py
+++ b/wagtail/tests/customuser/models.py
@@ -6,7 +6,6 @@ from django.db import models
 # on the user model)
 from wagtail.admin.auth import permission_denied  # noqa
 from wagtail.admin.edit_handlers import FieldPanel
-
 from wagtail.search import index
 
 from .fields import ConvertedValueField

--- a/wagtail/users/tests.py
+++ b/wagtail/users/tests.py
@@ -165,6 +165,35 @@ class TestUserIndexView(TestCase, WagtailTestUtils):
         results = response.context['users'].object_list
         self.assertIn(self.test_user, results)
 
+    def test_search_query_one_searchable_field(self):
+        custom_user_with_country = self.create_user(
+            username='testjoe',
+            email='testjoe@email.com',
+            password='password',
+            first_name='Joe',
+            last_name='Doe',
+            country="testcountry"
+        )
+        response = self.get({'q': "country"})
+        self.assertEqual(response.status_code, 200)
+        results = response.context['users'].object_list
+        self.assertIn(custom_user_with_country, results)
+
+    def test_search_query_searchable_multiple_fields(self):
+        custom_user_with_country = self.create_user(
+            username='testjoe',
+            email='testjoe@email.com',
+            password='password',
+            first_name='Joe',
+            last_name='Doe',
+            country="testcountry"
+        )
+        response = self.get({'q': "country first name last name"})
+        self.assertEqual(response.status_code, 200)
+        results = response.context['users'].object_list
+        self.assertIn(custom_user_with_country, results)
+        self.assertIn(self.test_user, results)
+
     def test_search_query_multiple_fields(self):
         response = self.get({'q': "first name last name"})
         self.assertEqual(response.status_code, 200)

--- a/wagtail/users/tests.py
+++ b/wagtail/users/tests.py
@@ -165,6 +165,11 @@ class TestUserIndexView(TestCase, WagtailTestUtils):
         results = response.context['users'].object_list
         self.assertIn(self.test_user, results)
 
+    @unittest.skipUnless(settings.AUTH_USER_MODEL == 'customuser.CustomUser', "Only applicable to CustomUser")
+    @override_settings(
+        WAGTAIL_USER_CREATION_FORM='wagtail.users.tests.CustomUserCreationForm',
+        WAGTAIL_USER_CUSTOM_FIELDS=['country', 'document'],
+    )
     def test_search_query_one_searchable_field(self):
         custom_user_with_country = self.create_user(
             username='testjoe',
@@ -179,6 +184,11 @@ class TestUserIndexView(TestCase, WagtailTestUtils):
         results = response.context['users'].object_list
         self.assertIn(custom_user_with_country, results)
 
+    @unittest.skipUnless(settings.AUTH_USER_MODEL == 'customuser.CustomUser', "Only applicable to CustomUser")
+    @override_settings(
+        WAGTAIL_USER_CREATION_FORM='wagtail.users.tests.CustomUserCreationForm',
+        WAGTAIL_USER_CUSTOM_FIELDS=['country', 'document'],
+    )
     def test_search_query_searchable_multiple_fields(self):
         custom_user_with_country = self.create_user(
             username='testjoe',

--- a/wagtail/users/views/users.py
+++ b/wagtail/users/views/users.py
@@ -1,3 +1,7 @@
+import operator
+
+from functools import reduce
+
 from django.conf import settings
 from django.contrib.auth import get_user_model, update_session_auth_hash
 from django.contrib.auth.models import Group


### PR DESCRIPTION
Resolves: #6853 
With this PR, you can search users by custom fields using `search_fields`, the functionality is showing in the gif below.

- Add the `search_fields` to the custom user for use in the tests.
- Add the tests to verify the functionality.
- Add the code to search using `search_fields`

**Note**
The functionality works but developers can just override the list.html to show custom fields in the content.

**User 1**
![Screenshot from 2021-03-14 18-11-11](https://user-images.githubusercontent.com/6761059/111086280-a24ef380-84f1-11eb-8ca6-a9bbf323c1fd.png)

**User 2**
![Screenshot from 2021-03-14 18-10-39](https://user-images.githubusercontent.com/6761059/111086282-a4b14d80-84f1-11eb-96df-37b01a1638d5.png)

**User 3**
![Screenshot from 2021-03-14 18-10-11](https://user-images.githubusercontent.com/6761059/111086284-a549e400-84f1-11eb-8df2-ba99b4a74c76.png)

**Functionality**


https://user-images.githubusercontent.com/6761059/111086904-25be1400-84f5-11eb-8074-e24905f72280.mp4

