### PR TITLE
Add option to set name to MenuItems generated by modeladmin

### DIFF
--- a/docs/reference/contrib/modeladmin/menu_item.rst
+++ b/docs/reference/contrib/modeladmin/menu_item.rst
@@ -73,3 +73,13 @@ This will only work for individual ``ModelAdmin`` classes registered with their
 own ``modeladmin_register`` call. It won't work for members of a
 ``ModelAdminGroup``.
 
+.. _modeladmin_menu_name:
+
+-----------------------------------
+``ModelAdmin.menu_name``
+-----------------------------------
+
+**Expected value**: A string or ``None``
+
+This will be passed to the ``name`` attribute of the corresponding ``MenuItem``.
+

--- a/wagtail/contrib/modeladmin/menus.py
+++ b/wagtail/contrib/modeladmin/menus.py
@@ -18,6 +18,7 @@ class ModelAdminMenuItem(MenuItem):
             icon_name = menu_icon
         super().__init__(
             label=model_admin.get_menu_label(), url=url,
+            name=model_admin.get_menu_name(),
             classnames=classnames, icon_name=icon_name, order=order)
 
     def is_shown(self, request):
@@ -40,6 +41,7 @@ class GroupMenuItem(SubmenuMenuItem):
             icon_name = menu_icon
         super().__init__(
             label=modeladmingroup.get_menu_label(), menu=menu,
+            name=modeladmingroup.get_menu_name(),
             classnames=classnames, icon_name=icon_name, order=order, )
 
     def is_shown(self, request):

--- a/wagtail/contrib/modeladmin/options.py
+++ b/wagtail/contrib/modeladmin/options.py
@@ -70,6 +70,7 @@ class ModelAdmin(WagtailRegisterable):
 
     model = None
     menu_label = None
+    menu_name = None
     menu_icon = None
     menu_order = None
     list_display = ('__str__',)
@@ -164,6 +165,12 @@ class ModelAdmin(WagtailRegisterable):
         Returns the label text to be used for the menu item.
         """
         return self.menu_label or self.opts.verbose_name_plural.title()
+
+    def get_menu_name(self):
+        """
+        Returns the name of the menu item.
+        """
+        return self.menu_name
 
     def get_menu_icon(self):
         """
@@ -584,6 +591,7 @@ class ModelAdminGroup(WagtailRegisterable):
     """
     items = ()
     menu_label = None
+    menu_name = None
     menu_order = None
     menu_icon = None
 
@@ -599,6 +607,12 @@ class ModelAdminGroup(WagtailRegisterable):
 
     def get_menu_label(self):
         return self.menu_label or self.get_app_label_from_subitems()
+
+    def get_menu_name(self):
+        """
+        Returns the name of the menu item representing this group.
+        """
+        return self.menu_name
 
     def get_app_label_from_subitems(self):
         for instance in self.modeladmin_instances:


### PR DESCRIPTION
This PR fixes #6859 by adding a `menu_name` attribute to `ModelAdmin` (and to `ModelAdminGroup`)