### PR TITLE
Simplify oembed dict missing key fallback

### DIFF
--- a/wagtail/embeds/finders/oembed.py
+++ b/wagtail/embeds/finders/oembed.py
@@ -72,9 +72,9 @@ class OEmbedFinder(EmbedFinder):
 
         # Return embed as a dict
         return {
-            'title': oembed['title'] if 'title' in oembed else '',
-            'author_name': oembed['author_name'] if 'author_name' in oembed else '',
-            'provider_name': oembed['provider_name'] if 'provider_name' in oembed else '',
+            'title': oembed.get('title', ''),
+            'author_name': oembed.get('author_name', ''),
+            'provider_name': oembed.get('provider_name', ''),
             'type': oembed['type'],
             'thumbnail_url': oembed.get('thumbnail_url'),
             'width': oembed.get('width'),


### PR DESCRIPTION
Minor cleanup of fallback to empty string using the default fallback of `dict.get`.

This could also be written as `oembed.get('title') or ''` if `None` values are prohibited. However that would be a change is behaviour. They way it is written now, `None` values can pass through if the key is present in the `oembed` dict and the value is `None`.