### PR TITLE
Replace example YouTube url with a working one

### DIFF
--- a/docs/advanced_topics/embeds.rst
+++ b/docs/advanced_topics/embeds.rst
@@ -59,7 +59,7 @@ The ``max_width`` argument is sent to the provider when fetching the embed code.
     {% load wagtailembeds_tags %}
 
     {# Embed a YouTube video #}
-    {% embed 'https://www.youtube.com/watch?v=SJXMTtvCxRo' %}
+    {% embed 'https://www.youtube.com/watch?v=Ffu-2jEdLPw' %}
 
     {# This tag can also take the URL from a variable #}
     {% embed page.video_url %}
@@ -78,7 +78,7 @@ fetching the embed code.
     from wagtail.embeds.exceptions import EmbedException
 
     try:
-        embed = get_embed('https://www.youtube.com/watch?v=SJXMTtvCxRo')
+        embed = get_embed('https://www.youtube.com/watch?v=Ffu-2jEdLPw')
 
         print(embed.html)
     except EmbedException:


### PR DESCRIPTION
The previous example doesn't work because the YouTube oembed endpoint returns a 401 for that specific url:
https://www.youtube.com/oembed?url=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3DSJXMTtvCxRo

The proposed video does work (and is still a video of a Wagtail):
https://www.youtube.com/oembed?url=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3DFfu-2jEdLPw

