### PR TITLE
Make streamfields the same size as everything else

### DIFF
--- a/wagtail/admin/static_src/wagtailadmin/scss/layouts/page-editor.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/layouts/page-editor.scss
@@ -271,8 +271,6 @@
     // cursory styling for streamfield. Main styling in client/src/components/StreamField/StreamField.scss
     &.stream-field {
         background-color: #f6f6f6;
-        padding-left: 20px;
-        padding-right: 20px;
 
         .object-layout_big-part {
             max-width: 100%;
@@ -280,7 +278,6 @@
 
         fieldset {
             padding-bottom: 0;
-            max-width: unset;
             // Workaround to make sure blocks do not overflow horizontally.
             min-width: 0;
         }


### PR DESCRIPTION
To provide room for comments to be added on the right

![image](https://user-images.githubusercontent.com/1093808/111497269-dff18d80-8738-11eb-8162-5f993de3fe4d.png)

