### PR TITLE
Add Sphinx Wagtail Theme

### DIFF
--- a/docs/_static/css/docsearch.overrides.css
+++ b/docs/_static/css/docsearch.overrides.css
@@ -7,3 +7,11 @@
 .algolia-autocomplete {
     width: 100%;
 }
+
+#search-results a,
+a.algolia-docsearch-suggestion {
+    border-bottom: 0;
+}
+#search-results  h2 {
+    display: none;
+}

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -8,8 +8,7 @@
 <link rel="stylesheet" href="{{ pathto('_static/css/docsearch.overrides.css', 1) }}" />
 {% endblock %}
 
-{% block footer %}
-{{ super() }}
+{% block search %}
 <script async defer data-domain="docs.wagtail.io" src="https://plausible.io/js/plausible.js"></script>
 <script src="{{ docsearch_base }}docsearch.min.js"></script>
 <script>

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -58,7 +58,7 @@
     const search = docsearch({
       apiKey: '8325c57d16798633e29d211c26c7b6f9',
       indexName: 'wagtail',
-      inputSelector: '#rtd-search-form [name="q"]',
+      inputSelector: '#searchbox [name="q"]',
       algoliaOptions: {
         facetFilters: [getVersionFacetFilter()],
       },

--- a/docs/_templates/searchbox.html
+++ b/docs/_templates/searchbox.html
@@ -1,0 +1,4 @@
+<form id="rtd-search-form" class="wy-form" action="{{ pathto('search') }}" method="get" role="search">
+  <input type="text" name="q" placeholder="{{ _('Search docs') }}" />
+  <input type="submit" style="visibility:hidden;position:absolute">
+</form>

--- a/docs/_templates/searchbox.html
+++ b/docs/_templates/searchbox.html
@@ -1,4 +1,8 @@
-<form id="rtd-search-form" class="wy-form" action="{{ pathto('search') }}" method="get" role="search">
-  <input type="text" name="q" placeholder="{{ _('Search docs') }}" />
-  <input type="submit" style="visibility:hidden;position:absolute">
-</form>
+{%- if builder != "singlehtml" %}
+<div id="searchbox" class="" role="search">
+    <form id="search-form" action="{{ pathto('search') }}" autocomplete="off" method="get">
+        <input class="form-control p-3 h-100" type="text" name="q" placeholder="Search" aria-label="Search" id="searchinput" />
+        <input type="submit" style="visibility:hidden;position:absolute">
+    </form>
+</div>
+{%- endif %}

--- a/docs/_templates/searchbox.html
+++ b/docs/_templates/searchbox.html
@@ -1,4 +1,0 @@
-<form id="rtd-search-form" class="wy-form" action="{{ pathto('search') }}" method="get" role="search">
-  <input type="text" name="q" placeholder="{{ _('Search docs') }}" />
-  <input type="submit" style="visibility:hidden;position:absolute">
-</form>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -80,7 +80,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'Wagtail Documentation'
-copyright = '{year:d}, Torchbox'.format(year=datetime.now().year)
+copyright = f'{datetime.now().year}, Torchbox and contributors'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,6 +31,10 @@ on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 html_theme = 'sphinx_wagtail_theme'
 html_theme_path = [sphinx_wagtail_theme.get_html_theme_path()]
 
+html_theme_options = dict(
+    project_name="Wagtail Documentation",
+)
+
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,7 +33,7 @@ html_theme_path = [sphinx_wagtail_theme.get_html_theme_path()]
 
 html_theme_options = dict(
     project_name="Wagtail Documentation",
-    github_url="https://github.com/wagtail/sphinx_wagtail_theme/blob/main/docs/"
+    github_url="https://github.com/wagtail/wagtail/blob/main/docs/"
 )
 
 # If extensions (or modules to document with autodoc) are in another directory,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,6 +18,7 @@ import sys
 from datetime import datetime
 
 import django
+import sphinx_wagtail_theme
 
 from recommonmark.transform import AutoStructify
 
@@ -27,10 +28,8 @@ from wagtail import VERSION, __version__
 # on_rtd is whether we are on readthedocs.org, this line of code grabbed from docs.readthedocs.org
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 
-if not on_rtd:  # only import and set the theme if we're building docs locally
-    import sphinx_rtd_theme
-    html_theme = 'sphinx_rtd_theme'
-    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+html_theme = 'sphinx_wagtail_theme'
+html_theme_path = [sphinx_wagtail_theme.get_html_theme_path()]
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -57,6 +56,7 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.intersphinx',
     'recommonmark',
+    'sphinx_wagtail_theme',
 ]
 
 if not on_rtd:
@@ -75,7 +75,7 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = 'Wagtail'
+project = 'Wagtail Documentation'
 copyright = '{year:d}, Torchbox'.format(year=datetime.now().year)
 
 # The version info for the project you're documenting, acts as replacement for
@@ -151,7 +151,7 @@ intersphinx_mapping = {
 
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.
-html_logo = 'logo.png'
+# html_logo = 'logo.png'
 
 # The name of an image file (within the static path) to use as favicon of the
 # docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,6 +33,7 @@ html_theme_path = [sphinx_wagtail_theme.get_html_theme_path()]
 
 html_theme_options = dict(
     project_name="Wagtail Documentation",
+    github_url="https://github.com/wagtail/sphinx_wagtail_theme/blob/main/docs/"
 )
 
 # If extensions (or modules to document with autodoc) are in another directory,

--- a/docs/getting_started/index.md
+++ b/docs/getting_started/index.md
@@ -1,3 +1,7 @@
+```eval_rst
+:hidetoc: 1
+```
+
 # Getting started
 
 ```eval_rst

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,3 +1,5 @@
+:hidetoc: 1
+
 Welcome to Wagtail's documentation
 ==================================
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,2 @@
 docutils==0.16  # Pinned to work around https://github.com/sphinx-doc/sphinx/issues/9049
-sphinx-wagtail-theme==5.0.0a5
+sphinx-wagtail-theme==5.0.0a6

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,2 @@
 docutils==0.16  # Pinned to work around https://github.com/sphinx-doc/sphinx/issues/9049
+sphinx-wagtail-theme==5.0.0a2

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,2 @@
 docutils==0.16  # Pinned to work around https://github.com/sphinx-doc/sphinx/issues/9049
-sphinx-wagtail-theme==5.0.0a6
+sphinx-wagtail-theme==5.0.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,2 @@
 docutils==0.16  # Pinned to work around https://github.com/sphinx-doc/sphinx/issues/9049
-sphinx-wagtail-theme==5.0.1
+sphinx-wagtail-theme==5.0.2

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,2 @@
 docutils==0.16  # Pinned to work around https://github.com/sphinx-doc/sphinx/issues/9049
-sphinx-wagtail-theme==5.0.2
+sphinx-wagtail-theme==5.0.3

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,2 @@
 docutils==0.16  # Pinned to work around https://github.com/sphinx-doc/sphinx/issues/9049
-sphinx-wagtail-theme==5.0.0a4
+sphinx-wagtail-theme==5.0.0a5

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,2 @@
 docutils==0.16  # Pinned to work around https://github.com/sphinx-doc/sphinx/issues/9049
-sphinx-wagtail-theme==5.0.0
+sphinx-wagtail-theme==5.0.1

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,2 @@
 docutils==0.16  # Pinned to work around https://github.com/sphinx-doc/sphinx/issues/9049
-sphinx-wagtail-theme==5.0.0a2
+sphinx-wagtail-theme==5.0.0a4

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ documentation_extras = [
     'sphinxcontrib-spelling>=5.4.0,<6',
     'Sphinx>=1.5.2',
     'sphinx-autobuild>=0.6.0',
-    'sphinx_rtd_theme>=0.1.9',
+    'sphinx-wagtail-theme==5.0.0a2',
     'recommonmark>=0.7.1',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ documentation_extras = [
     'sphinxcontrib-spelling>=5.4.0,<6',
     'Sphinx>=1.5.2',
     'sphinx-autobuild>=0.6.0',
-    'sphinx-wagtail-theme==5.0.0a3',
+    'sphinx-wagtail-theme==5.0.0a4',
     'recommonmark>=0.7.1',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ documentation_extras = [
     'sphinxcontrib-spelling>=5.4.0,<6',
     'Sphinx>=1.5.2',
     'sphinx-autobuild>=0.6.0',
-    'sphinx-wagtail-theme==5.0.0a5',
+    'sphinx-wagtail-theme==5.0.0a6',
     'recommonmark>=0.7.1',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ documentation_extras = [
     'sphinxcontrib-spelling>=5.4.0,<6',
     'Sphinx>=1.5.2',
     'sphinx-autobuild>=0.6.0',
-    'sphinx-wagtail-theme==5.0.0a6',
+    'sphinx-wagtail-theme==5.0.0',
     'recommonmark>=0.7.1',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ documentation_extras = [
     'sphinxcontrib-spelling>=5.4.0,<6',
     'Sphinx>=1.5.2',
     'sphinx-autobuild>=0.6.0',
-    'sphinx-wagtail-theme==5.0.2',
+    'sphinx-wagtail-theme==5.0.3',
     'recommonmark>=0.7.1',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ documentation_extras = [
     'sphinxcontrib-spelling>=5.4.0,<6',
     'Sphinx>=1.5.2',
     'sphinx-autobuild>=0.6.0',
-    'sphinx-wagtail-theme==5.0.0a4',
+    'sphinx-wagtail-theme==5.0.0a5',
     'recommonmark>=0.7.1',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ documentation_extras = [
     'sphinxcontrib-spelling>=5.4.0,<6',
     'Sphinx>=1.5.2',
     'sphinx-autobuild>=0.6.0',
-    'sphinx-wagtail-theme==5.0.1',
+    'sphinx-wagtail-theme==5.0.2',
     'recommonmark>=0.7.1',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ documentation_extras = [
     'sphinxcontrib-spelling>=5.4.0,<6',
     'Sphinx>=1.5.2',
     'sphinx-autobuild>=0.6.0',
-    'sphinx-wagtail-theme==5.0.0a2',
+    'sphinx-wagtail-theme==5.0.0a3',
     'recommonmark>=0.7.1',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ documentation_extras = [
     'sphinxcontrib-spelling>=5.4.0,<6',
     'Sphinx>=1.5.2',
     'sphinx-autobuild>=0.6.0',
-    'sphinx-wagtail-theme==5.0.0',
+    'sphinx-wagtail-theme==5.0.1',
     'recommonmark>=0.7.1',
 ]
 


### PR DESCRIPTION
This PR adds [Sphinx Wagtail Theme](https://github.com/wagtail/sphinx_wagtail_theme).

Preview: https://wagtail--6930.org.readthedocs.build/en/6930/index.html

- The theme is pinned in setup.py AND docs/requirements.txt (RTD doesn't read the setup.py)
- The title reads 'Wagtail Documentation' instead of 'Wagtail'
- Copyright is 'YYYY, Torchbox and contributors' instead of 'YYYY, Torchbox' (like the licence)
- Searchbox template is updated to reflect the theme (Bootstrap) markup
- Sphinx disables the TOC on pages that have a single heading. We added `:hidetoc: 1` to disable the TOC on pages with multiple headings, but where a TOC is still redundant.

<img width="1792" alt="Screenshot 2021-04-18 at 22 07 06" src="https://user-images.githubusercontent.com/1969342/115159430-587a9f80-a093-11eb-9276-e57aba0fec52.png">

Most work is done on the [theme](https://github.com/wagtail/sphinx_wagtail_theme) and according to the [design prototype](https://www.figma.com/proto/hFjWqQeEjGd8NtTsEHcc4i/Wagtail-Documentation-(wagtail.io)?node-id=1%3A2&viewport=983%2C953%2C1&scaling=min-zoom&hide-ui=1)

The new theme:
- is based on Bootstrap
- is responsive
- takes 100% of the viewport
- has a table of contents
- does not reload the page when open/close main menu items

I expect the commits to be squashed on merge.

* Do the tests still pass? (https://docs.wagtail.io/en/latest/contributing/developing.html#testing) YES
* Does the code comply with the style guide? (Run `make lint` from the Wagtail root) YES
* For Python changes: Have you added tests to cover the new/fixed behaviour? N/A
* For front-end changes: Did you test on all of Wagtail’s supported browsers? **Please list the exact versions you tested**.
- Edge 89
- IE 11 ([search doesn't work](https://discourse.algolia.com/t/algolia-instant-search-v4-5-0-not-working-in-ie11/10492)) Note [the latest docs](https://docs.wagtail.io/en/latest/search.html?q=foo#) also doesn't work on IE11.
- Chrome  90.0.4430.72 OSX
- FireFox 86 OSX
- FireFox 87.0 OSX
- IPad Pro 12.9
* For new features: Has the documentation been updated accordingly? N/A
