### PR TITLE
Telepath integration for commenting

### DIFF
--- a/client/src/components/StreamField/blocks/BaseSequenceBlock.js
+++ b/client/src/components/StreamField/blocks/BaseSequenceBlock.js
@@ -20,7 +20,7 @@ export class BaseSequenceChild {
     const strings = (opts && opts.strings) || {};
 
     const dom = $(`
-      <div aria-hidden="false">
+      <div aria-hidden="false" ${this.id ? `data-contentpath="${h(this.id)}"` : 'data-contentpath-disabled'}>
         <input type="hidden"  name="${this.prefix}-deleted" value="">
         <input type="hidden" name="${this.prefix}-order" value="${index}">
         <input type="hidden" name="${this.prefix}-type" value="${h(this.type || '')}">

--- a/client/src/components/StreamField/blocks/BaseSequenceBlock.js
+++ b/client/src/components/StreamField/blocks/BaseSequenceBlock.js
@@ -209,8 +209,8 @@ export class BaseSequenceBlock {
 
   _onRequestInsert(index, opts) {
     /* handler for an 'insert new block' action */
-    const [blockDef, initialState] = this._getChildDataForInsertion(opts);
-    const newChild = this._insert(blockDef, initialState, null, index, { animate: true });
+    const [blockDef, initialState, id] = this._getChildDataForInsertion(opts);
+    const newChild = this._insert(blockDef, initialState, id || null, index, { animate: true });
     // focus the newly added field if we can do so without obtrusive UI behaviour
     newChild.focus({ soft: true });
   }

--- a/client/src/components/StreamField/blocks/StreamBlock.js
+++ b/client/src/components/StreamField/blocks/StreamBlock.js
@@ -1,5 +1,7 @@
 /* eslint-disable no-underscore-dangle */
 
+import { v4 as uuidv4 } from 'uuid';
+
 import { BaseSequenceBlock, BaseSequenceChild, BaseInsertionControl } from './BaseSequenceBlock';
 import { escapeHtml as h } from '../../../utils/text';
 
@@ -287,7 +289,7 @@ export class StreamBlock extends BaseSequenceBlock {
     */
     const blockDef = this.blockDef.childBlockDefsByName[type];
     const initialState = this.blockDef.initialChildStates[type];
-    return [blockDef, initialState];
+    return [blockDef, initialState, uuidv4()];
   }
 
   clear() {

--- a/client/src/components/StreamField/blocks/StructBlock.js
+++ b/client/src/components/StreamField/blocks/StructBlock.js
@@ -51,7 +51,7 @@ export class StructBlock {
 
       this.blockDef.childBlockDefs.forEach(childBlockDef => {
         const childDom = $(`
-          <div class="field ${childBlockDef.meta.required ? 'required' : ''}">
+          <div class="field ${childBlockDef.meta.required ? 'required' : ''}" data-contentpath="${childBlockDef.name}">
             <label class="field__label">${h(childBlockDef.meta.label)}</label>
             <div data-streamfield-block></div>
           </div>

--- a/client/src/components/StreamField/blocks/__snapshots__/ListBlock.test.js.snap
+++ b/client/src/components/StreamField/blocks/__snapshots__/ListBlock.test.js.snap
@@ -11,7 +11,7 @@ exports[`telepath: wagtail.blocks.ListBlock blocks can be duplicated 1`] = `
 
         <div data-streamfield-list-container=\\"\\"><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button c-sf-add-button--visible\\">
         <i aria-hidden=\\"true\\">+</i>
-      </button><div aria-hidden=\\"false\\">
+      </button><div aria-hidden=\\"false\\" data-contentpath-disabled=\\"\\">
         <input type=\\"hidden\\" name=\\"the-prefix-0-deleted\\" value=\\"\\">
         <input type=\\"hidden\\" name=\\"the-prefix-0-order\\" value=\\"0\\">
         <input type=\\"hidden\\" name=\\"the-prefix-0-type\\" value=\\"\\">
@@ -58,7 +58,7 @@ exports[`telepath: wagtail.blocks.ListBlock blocks can be duplicated 1`] = `
         </div>
       </div><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button c-sf-add-button--visible\\">
         <i aria-hidden=\\"true\\">+</i>
-      </button><div aria-hidden=\\"false\\">
+      </button><div aria-hidden=\\"false\\" data-contentpath-disabled=\\"\\">
         <input type=\\"hidden\\" name=\\"the-prefix-1-deleted\\" value=\\"\\">
         <input type=\\"hidden\\" name=\\"the-prefix-1-order\\" value=\\"1\\">
         <input type=\\"hidden\\" name=\\"the-prefix-1-type\\" value=\\"\\">
@@ -105,7 +105,7 @@ exports[`telepath: wagtail.blocks.ListBlock blocks can be duplicated 1`] = `
         </div>
       </div><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button c-sf-add-button--visible\\">
         <i aria-hidden=\\"true\\">+</i>
-      </button><div aria-hidden=\\"false\\">
+      </button><div aria-hidden=\\"false\\" data-contentpath-disabled=\\"\\">
         <input type=\\"hidden\\" name=\\"the-prefix-2-deleted\\" value=\\"\\">
         <input type=\\"hidden\\" name=\\"the-prefix-2-order\\" value=\\"2\\">
         <input type=\\"hidden\\" name=\\"the-prefix-2-type\\" value=\\"\\">
@@ -167,7 +167,7 @@ exports[`telepath: wagtail.blocks.ListBlock blocks can be reordered downward 1`]
 
         <div data-streamfield-list-container=\\"\\"><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button c-sf-add-button--visible\\">
         <i aria-hidden=\\"true\\">+</i>
-      </button><div aria-hidden=\\"false\\">
+      </button><div aria-hidden=\\"false\\" data-contentpath-disabled=\\"\\">
         <input type=\\"hidden\\" name=\\"the-prefix-1-deleted\\" value=\\"\\">
         <input type=\\"hidden\\" name=\\"the-prefix-1-order\\" value=\\"0\\">
         <input type=\\"hidden\\" name=\\"the-prefix-1-type\\" value=\\"\\">
@@ -214,7 +214,7 @@ exports[`telepath: wagtail.blocks.ListBlock blocks can be reordered downward 1`]
         </div>
       </div><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button c-sf-add-button--visible\\">
         <i aria-hidden=\\"true\\">+</i>
-      </button><div aria-hidden=\\"false\\">
+      </button><div aria-hidden=\\"false\\" data-contentpath-disabled=\\"\\">
         <input type=\\"hidden\\" name=\\"the-prefix-0-deleted\\" value=\\"\\">
         <input type=\\"hidden\\" name=\\"the-prefix-0-order\\" value=\\"1\\">
         <input type=\\"hidden\\" name=\\"the-prefix-0-type\\" value=\\"\\">
@@ -276,7 +276,7 @@ exports[`telepath: wagtail.blocks.ListBlock blocks can be reordered upward 1`] =
 
         <div data-streamfield-list-container=\\"\\"><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button c-sf-add-button--visible\\">
         <i aria-hidden=\\"true\\">+</i>
-      </button><div aria-hidden=\\"false\\">
+      </button><div aria-hidden=\\"false\\" data-contentpath-disabled=\\"\\">
         <input type=\\"hidden\\" name=\\"the-prefix-1-deleted\\" value=\\"\\">
         <input type=\\"hidden\\" name=\\"the-prefix-1-order\\" value=\\"0\\">
         <input type=\\"hidden\\" name=\\"the-prefix-1-type\\" value=\\"\\">
@@ -323,7 +323,7 @@ exports[`telepath: wagtail.blocks.ListBlock blocks can be reordered upward 1`] =
         </div>
       </div><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button c-sf-add-button--visible\\">
         <i aria-hidden=\\"true\\">+</i>
-      </button><div aria-hidden=\\"false\\">
+      </button><div aria-hidden=\\"false\\" data-contentpath-disabled=\\"\\">
         <input type=\\"hidden\\" name=\\"the-prefix-0-deleted\\" value=\\"\\">
         <input type=\\"hidden\\" name=\\"the-prefix-0-order\\" value=\\"1\\">
         <input type=\\"hidden\\" name=\\"the-prefix-0-type\\" value=\\"\\">
@@ -385,7 +385,7 @@ exports[`telepath: wagtail.blocks.ListBlock deleteBlock() deletes a block 1`] = 
 
         <div data-streamfield-list-container=\\"\\"><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button c-sf-add-button--visible\\">
         <i aria-hidden=\\"true\\">+</i>
-      </button><div aria-hidden=\\"false\\">
+      </button><div aria-hidden=\\"false\\" data-contentpath-disabled=\\"\\">
         <input type=\\"hidden\\" name=\\"the-prefix-0-deleted\\" value=\\"\\">
         <input type=\\"hidden\\" name=\\"the-prefix-0-order\\" value=\\"0\\">
         <input type=\\"hidden\\" name=\\"the-prefix-0-type\\" value=\\"\\">
@@ -432,7 +432,7 @@ exports[`telepath: wagtail.blocks.ListBlock deleteBlock() deletes a block 1`] = 
         </div>
       </div><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button c-sf-add-button--visible\\" style=\\"display: none;\\" aria-hidden=\\"true\\">
         <i aria-hidden=\\"true\\">+</i>
-      </button><div aria-hidden=\\"true\\" style=\\"display: none;\\">
+      </button><div aria-hidden=\\"true\\" data-contentpath-disabled=\\"\\" style=\\"display: none;\\">
         <input type=\\"hidden\\" name=\\"the-prefix-1-deleted\\" value=\\"1\\">
         <input type=\\"hidden\\" name=\\"the-prefix-1-order\\" value=\\"1\\">
         <input type=\\"hidden\\" name=\\"the-prefix-1-type\\" value=\\"\\">
@@ -494,7 +494,7 @@ exports[`telepath: wagtail.blocks.ListBlock it renders correctly 1`] = `
 
         <div data-streamfield-list-container=\\"\\"><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button c-sf-add-button--visible\\">
         <i aria-hidden=\\"true\\">+</i>
-      </button><div aria-hidden=\\"false\\">
+      </button><div aria-hidden=\\"false\\" data-contentpath-disabled=\\"\\">
         <input type=\\"hidden\\" name=\\"the-prefix-0-deleted\\" value=\\"\\">
         <input type=\\"hidden\\" name=\\"the-prefix-0-order\\" value=\\"0\\">
         <input type=\\"hidden\\" name=\\"the-prefix-0-type\\" value=\\"\\">
@@ -541,7 +541,7 @@ exports[`telepath: wagtail.blocks.ListBlock it renders correctly 1`] = `
         </div>
       </div><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button c-sf-add-button--visible\\">
         <i aria-hidden=\\"true\\">+</i>
-      </button><div aria-hidden=\\"false\\">
+      </button><div aria-hidden=\\"false\\" data-contentpath-disabled=\\"\\">
         <input type=\\"hidden\\" name=\\"the-prefix-1-deleted\\" value=\\"\\">
         <input type=\\"hidden\\" name=\\"the-prefix-1-order\\" value=\\"1\\">
         <input type=\\"hidden\\" name=\\"the-prefix-1-type\\" value=\\"\\">

--- a/client/src/components/StreamField/blocks/__snapshots__/StreamBlock.test.js.snap
+++ b/client/src/components/StreamField/blocks/__snapshots__/StreamBlock.test.js.snap
@@ -15,7 +15,7 @@ exports[`telepath: wagtail.blocks.StreamBlock blocks can be duplicated 1`] = `
         <div data-streamblock-menu-outer=\\"\\" style=\\"display: none;\\" aria-hidden=\\"true\\">
           <div data-streamblock-menu-inner=\\"\\" class=\\"c-sf-add-panel\\"></div>
         </div>
-      </div><div aria-hidden=\\"false\\">
+      </div><div aria-hidden=\\"false\\" data-contentpath=\\"1\\">
         <input type=\\"hidden\\" name=\\"the-prefix-0-deleted\\" value=\\"\\">
         <input type=\\"hidden\\" name=\\"the-prefix-0-order\\" value=\\"0\\">
         <input type=\\"hidden\\" name=\\"the-prefix-0-type\\" value=\\"test_block_a\\">
@@ -67,7 +67,7 @@ exports[`telepath: wagtail.blocks.StreamBlock blocks can be duplicated 1`] = `
         <div data-streamblock-menu-outer=\\"\\" style=\\"display: none;\\" aria-hidden=\\"true\\">
           <div data-streamblock-menu-inner=\\"\\" class=\\"c-sf-add-panel\\"></div>
         </div>
-      </div><div aria-hidden=\\"false\\">
+      </div><div aria-hidden=\\"false\\" data-contentpath=\\"2\\">
         <input type=\\"hidden\\" name=\\"the-prefix-1-deleted\\" value=\\"\\">
         <input type=\\"hidden\\" name=\\"the-prefix-1-order\\" value=\\"1\\">
         <input type=\\"hidden\\" name=\\"the-prefix-1-type\\" value=\\"test_block_b\\">
@@ -119,7 +119,7 @@ exports[`telepath: wagtail.blocks.StreamBlock blocks can be duplicated 1`] = `
         <div data-streamblock-menu-outer=\\"\\" style=\\"display: none;\\" aria-hidden=\\"true\\">
           <div data-streamblock-menu-inner=\\"\\" class=\\"c-sf-add-panel\\"></div>
         </div>
-      </div><div aria-hidden=\\"false\\">
+      </div><div aria-hidden=\\"false\\" data-contentpath-disabled=\\"\\">
         <input type=\\"hidden\\" name=\\"the-prefix-2-deleted\\" value=\\"\\">
         <input type=\\"hidden\\" name=\\"the-prefix-2-order\\" value=\\"2\\">
         <input type=\\"hidden\\" name=\\"the-prefix-2-type\\" value=\\"test_block_b\\">
@@ -190,7 +190,7 @@ exports[`telepath: wagtail.blocks.StreamBlock blocks can be reordered downward 1
         <div data-streamblock-menu-outer=\\"\\" style=\\"display: none;\\" aria-hidden=\\"true\\">
           <div data-streamblock-menu-inner=\\"\\" class=\\"c-sf-add-panel\\"></div>
         </div>
-      </div><div aria-hidden=\\"false\\">
+      </div><div aria-hidden=\\"false\\" data-contentpath=\\"2\\">
         <input type=\\"hidden\\" name=\\"the-prefix-1-deleted\\" value=\\"\\">
         <input type=\\"hidden\\" name=\\"the-prefix-1-order\\" value=\\"0\\">
         <input type=\\"hidden\\" name=\\"the-prefix-1-type\\" value=\\"test_block_b\\">
@@ -242,7 +242,7 @@ exports[`telepath: wagtail.blocks.StreamBlock blocks can be reordered downward 1
         <div data-streamblock-menu-outer=\\"\\" style=\\"display: none;\\" aria-hidden=\\"true\\">
           <div data-streamblock-menu-inner=\\"\\" class=\\"c-sf-add-panel\\"></div>
         </div>
-      </div><div aria-hidden=\\"false\\">
+      </div><div aria-hidden=\\"false\\" data-contentpath=\\"1\\">
         <input type=\\"hidden\\" name=\\"the-prefix-0-deleted\\" value=\\"\\">
         <input type=\\"hidden\\" name=\\"the-prefix-0-order\\" value=\\"1\\">
         <input type=\\"hidden\\" name=\\"the-prefix-0-type\\" value=\\"test_block_a\\">
@@ -313,7 +313,7 @@ exports[`telepath: wagtail.blocks.StreamBlock blocks can be reordered upward 1`]
         <div data-streamblock-menu-outer=\\"\\" style=\\"display: none;\\" aria-hidden=\\"true\\">
           <div data-streamblock-menu-inner=\\"\\" class=\\"c-sf-add-panel\\"></div>
         </div>
-      </div><div aria-hidden=\\"false\\">
+      </div><div aria-hidden=\\"false\\" data-contentpath=\\"2\\">
         <input type=\\"hidden\\" name=\\"the-prefix-1-deleted\\" value=\\"\\">
         <input type=\\"hidden\\" name=\\"the-prefix-1-order\\" value=\\"0\\">
         <input type=\\"hidden\\" name=\\"the-prefix-1-type\\" value=\\"test_block_b\\">
@@ -365,7 +365,7 @@ exports[`telepath: wagtail.blocks.StreamBlock blocks can be reordered upward 1`]
         <div data-streamblock-menu-outer=\\"\\" style=\\"display: none;\\" aria-hidden=\\"true\\">
           <div data-streamblock-menu-inner=\\"\\" class=\\"c-sf-add-panel\\"></div>
         </div>
-      </div><div aria-hidden=\\"false\\">
+      </div><div aria-hidden=\\"false\\" data-contentpath=\\"1\\">
         <input type=\\"hidden\\" name=\\"the-prefix-0-deleted\\" value=\\"\\">
         <input type=\\"hidden\\" name=\\"the-prefix-0-order\\" value=\\"1\\">
         <input type=\\"hidden\\" name=\\"the-prefix-0-type\\" value=\\"test_block_a\\">
@@ -436,7 +436,7 @@ exports[`telepath: wagtail.blocks.StreamBlock it renders correctly 1`] = `
         <div data-streamblock-menu-outer=\\"\\" style=\\"display: none;\\" aria-hidden=\\"true\\">
           <div data-streamblock-menu-inner=\\"\\" class=\\"c-sf-add-panel\\"></div>
         </div>
-      </div><div aria-hidden=\\"false\\">
+      </div><div aria-hidden=\\"false\\" data-contentpath=\\"1\\">
         <input type=\\"hidden\\" name=\\"the-prefix-0-deleted\\" value=\\"\\">
         <input type=\\"hidden\\" name=\\"the-prefix-0-order\\" value=\\"0\\">
         <input type=\\"hidden\\" name=\\"the-prefix-0-type\\" value=\\"test_block_a\\">
@@ -488,7 +488,7 @@ exports[`telepath: wagtail.blocks.StreamBlock it renders correctly 1`] = `
         <div data-streamblock-menu-outer=\\"\\" style=\\"display: none;\\" aria-hidden=\\"true\\">
           <div data-streamblock-menu-inner=\\"\\" class=\\"c-sf-add-panel\\"></div>
         </div>
-      </div><div aria-hidden=\\"false\\">
+      </div><div aria-hidden=\\"false\\" data-contentpath=\\"2\\">
         <input type=\\"hidden\\" name=\\"the-prefix-1-deleted\\" value=\\"\\">
         <input type=\\"hidden\\" name=\\"the-prefix-1-order\\" value=\\"1\\">
         <input type=\\"hidden\\" name=\\"the-prefix-1-type\\" value=\\"test_block_b\\">
@@ -559,7 +559,7 @@ exports[`telepath: wagtail.blocks.StreamBlock it renders menus on opening 1`] = 
         <div data-streamblock-menu-outer=\\"\\" style=\\"display: none;\\" aria-hidden=\\"true\\">
           <div data-streamblock-menu-inner=\\"\\" class=\\"c-sf-add-panel\\"></div>
         </div>
-      </div><div aria-hidden=\\"false\\">
+      </div><div aria-hidden=\\"false\\" data-contentpath=\\"1\\">
         <input type=\\"hidden\\" name=\\"the-prefix-0-deleted\\" value=\\"\\">
         <input type=\\"hidden\\" name=\\"the-prefix-0-order\\" value=\\"0\\">
         <input type=\\"hidden\\" name=\\"the-prefix-0-type\\" value=\\"test_block_a\\">
@@ -621,7 +621,7 @@ exports[`telepath: wagtail.blocks.StreamBlock it renders menus on opening 1`] = 
             <span class=\\"c-sf-button__label\\">Test Block B</span>
           </button></div></div>
         </div>
-      </div><div aria-hidden=\\"false\\">
+      </div><div aria-hidden=\\"false\\" data-contentpath=\\"2\\">
         <input type=\\"hidden\\" name=\\"the-prefix-1-deleted\\" value=\\"\\">
         <input type=\\"hidden\\" name=\\"the-prefix-1-order\\" value=\\"1\\">
         <input type=\\"hidden\\" name=\\"the-prefix-1-type\\" value=\\"test_block_b\\">
@@ -702,7 +702,7 @@ exports[`telepath: wagtail.blocks.StreamBlock with labels that need escaping it 
             <span class=\\"c-sf-button__label\\">Test Block &lt;B&gt;</span>
           </button></div></div>
         </div>
-      </div><div aria-hidden=\\"false\\">
+      </div><div aria-hidden=\\"false\\" data-contentpath=\\"1\\">
         <input type=\\"hidden\\" name=\\"the-prefix-0-deleted\\" value=\\"\\">
         <input type=\\"hidden\\" name=\\"the-prefix-0-order\\" value=\\"0\\">
         <input type=\\"hidden\\" name=\\"the-prefix-0-type\\" value=\\"test_block_a\\">
@@ -754,7 +754,7 @@ exports[`telepath: wagtail.blocks.StreamBlock with labels that need escaping it 
         <div data-streamblock-menu-outer=\\"\\" style=\\"display: none;\\" aria-hidden=\\"true\\">
           <div data-streamblock-menu-inner=\\"\\" class=\\"c-sf-add-panel\\"></div>
         </div>
-      </div><div aria-hidden=\\"false\\">
+      </div><div aria-hidden=\\"false\\" data-contentpath=\\"2\\">
         <input type=\\"hidden\\" name=\\"the-prefix-1-deleted\\" value=\\"\\">
         <input type=\\"hidden\\" name=\\"the-prefix-1-order\\" value=\\"1\\">
         <input type=\\"hidden\\" name=\\"the-prefix-1-type\\" value=\\"test_block_b\\">

--- a/client/src/components/StreamField/blocks/__snapshots__/StructBlock.test.js.snap
+++ b/client/src/components/StreamField/blocks/__snapshots__/StructBlock.test.js.snap
@@ -9,7 +9,7 @@ exports[`telepath: wagtail.blocks.StructBlock it renders correctly 1`] = `
               use <strong>lots</strong> of these
             </div>
           </span>
-        <div class=\\"field required\\">
+        <div class=\\"field required\\" data-contentpath=\\"heading_text\\">
             <label class=\\"field__label\\" for=\\"the-prefix-heading_text\\">Heading text</label>
             <div class=\\"field char_field widget-text_input fieldname-heading_text\\">
         <div class=\\"field-content\\">
@@ -19,7 +19,7 @@ exports[`telepath: wagtail.blocks.StructBlock it renders correctly 1`] = `
           </div>
         </div>
       </div>
-          </div><div class=\\"field \\">
+          </div><div class=\\"field \\" data-contentpath=\\"size\\">
             <label class=\\"field__label\\" for=\\"the-prefix-size\\">Size</label>
             <div class=\\"field choice_field widget-select fieldname-size\\">
         <div class=\\"field-content\\">

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "redux": "^4.0.0",
     "redux-thunk": "^2.3.0",
     "telepath-unpack": "^0.0.2",
+    "uuid": "^8.3.2",
     "wagtail-comment-frontend": "0.0.6",
     "whatwg-fetch": "^2.0.3"
   },


### PR DESCRIPTION
This is the simplest approach by adding ``data-contentpath`` attributes to streamfield blocks which are currently picked up by the commenting system.