### PR TITLE
Show current page in breadcrumb

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/pages/create.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/create.html
@@ -8,7 +8,7 @@
 {% block content %}
 
     <header class="merged tab-merged">
-        {% explorer_breadcrumb parent_page include_self=1 %}
+        {% explorer_breadcrumb parent_page include_self=1 trailing_arrow=True %}
 
         <div class="row">
             <div class="left col9 header-title">

--- a/wagtail/admin/templates/wagtailadmin/shared/breadcrumb.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/breadcrumb.html
@@ -11,6 +11,12 @@
                 {# For limited-permission users whose breadcrumb starts further down from the root, the first item displays as a 'home' icon in place of the title #}
                 {% trans 'Home' as home %}
                 <li class="home"><a href="{% url 'wagtailadmin_explore' page.id %}" class="text-replace">{% icon name="site" class_name="home_icon" title=home %}</a>{% icon name="arrow-right" class_name="arrow_right_icon"%}</li>
+            {% elif forloop.last %}
+                <li><a href="{% url 'wagtailadmin_explore' page.id %}"><span class="title">{{ page.get_admin_display_title }}</span>
+                {% if trailing_arrow %}
+                    {% icon name="arrow-right" class_name="arrow_right_icon" %}
+                {% endif %}
+                </a></li>
             {% else %}
                 <li><a href="{% url 'wagtailadmin_explore' page.id %}"><span class="title">{{ page.get_admin_display_title }}</span>{% icon name="arrow-right" class_name="arrow_right_icon" %}</a></li>
             {% endif %}

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -65,7 +65,7 @@ def main_nav(context):
 
 
 @register.inclusion_tag('wagtailadmin/shared/breadcrumb.html', takes_context=True)
-def explorer_breadcrumb(context, page, include_self=False):
+def explorer_breadcrumb(context, page, include_self=True):
     user = context['request'].user
 
     # find the closest common ancestor of the pages that this user has direct explore permission

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -65,7 +65,7 @@ def main_nav(context):
 
 
 @register.inclusion_tag('wagtailadmin/shared/breadcrumb.html', takes_context=True)
-def explorer_breadcrumb(context, page, include_self=True):
+def explorer_breadcrumb(context, page, include_self=True, trailing_arrow=False):
     user = context['request'].user
 
     # find the closest common ancestor of the pages that this user has direct explore permission
@@ -75,7 +75,8 @@ def explorer_breadcrumb(context, page, include_self=True):
         return {'pages': Page.objects.none()}
 
     return {
-        'pages': page.get_ancestors(inclusive=include_self).descendant_of(cca, inclusive=True).specific()
+        'pages': page.get_ancestors(inclusive=include_self).descendant_of(cca, inclusive=True).specific(),
+        'trailing_arrow': trailing_arrow
     }
 
 


### PR DESCRIPTION
Enabled the current page to show up in the breadcrumb by default.

Example image:
![image](https://user-images.githubusercontent.com/4743971/111810768-fc5a0b00-889b-11eb-8908-89fd0f29b3a5.png)


* Do the tests still pass? Yes
* Does the code comply with the style guide? Yes
* For Python changes: N/A
* For front-end changes: Chrome, FF, Safari
* For new features: N/A
