### PR TITLE
Make use of listing button attrs in ButtonWithDropdownFromHook

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_button_with_dropdown.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_button_with_dropdown.html
@@ -1,6 +1,6 @@
 {% load wagtailadmin_tags %}
-<div {{ self.attrs }} class="c-dropdown  {% if is_parent %}t-inverted{% else %}t-default{% endif %}" data-dropdown>
-    <a href="javascript:void(0)" aria-label="{{ title }}" class="c-dropdown__button  u-btn-current">
+<div class="c-dropdown  {% if is_parent %}t-inverted{% else %}t-default{% endif %}" data-dropdown>
+    <a href="javascript:void(0)" class="c-dropdown__button  u-btn-current" {{ extra_attrs }}>
         {{ label }}
         <div data-dropdown-toggle class="o-icon c-dropdown__toggle c-dropdown__togle--icon [ icon icon-arrow-down ]">
             {% icon name="arrow-down" %}{% icon name="arrow-up" %}
@@ -10,9 +10,7 @@
         <ul class="c-dropdown__menu u-toggle  u-arrow u-arrow--tl u-background">
         {% for button in buttons %}
             <li class="c-dropdown__item ">
-                <a href="{{ button.url }}" aria-label="{{ button.attrs.title }}" class="u-link is-live {{ button.classes|join:' ' }}">
-                    {{ button.label }}
-                </a>
+                {{ button.render }}
             </li>
         {% endfor %}
         </ul>

--- a/wagtail/admin/wagtail_hooks.py
+++ b/wagtail/admin/wagtail_hooks.py
@@ -184,8 +184,9 @@ def page_listing_buttons(page, page_perms, is_parent=False, next_url=None):
         next_url=next_url,
         attrs={
             'target': '_blank', 'rel': 'noopener noreferrer',
-            'title': _("View more options for '%(title)s'") % {'title': page.get_admin_display_title()}
+            'aria-label': _("View more options for '%(title)s'") % {'title': page.get_admin_display_title()}
         },
+        extra_button_classes=['u-link', 'is-live'],
         priority=50
     )
 
@@ -196,7 +197,7 @@ def page_listing_more_buttons(page, page_perms, is_parent=False, next_url=None):
         yield Button(
             _('Move'),
             reverse('wagtailadmin_pages:move', args=[page.id]),
-            attrs={"title": _("Move page '%(title)s'") % {'title': page.get_admin_display_title()}},
+            attrs={"aria-label": _("Move page '%(title)s'") % {'title': page.get_admin_display_title()}},
             priority=10
         )
     if page_perms.can_copy():
@@ -207,7 +208,7 @@ def page_listing_more_buttons(page, page_perms, is_parent=False, next_url=None):
         yield Button(
             _('Copy'),
             url,
-            attrs={'title': _("Copy page '%(title)s'") % {'title': page.get_admin_display_title()}},
+            attrs={'aria-label': _("Copy page '%(title)s'") % {'title': page.get_admin_display_title()}},
             priority=20
         )
     if page_perms.can_delete():
@@ -218,7 +219,7 @@ def page_listing_more_buttons(page, page_perms, is_parent=False, next_url=None):
         yield Button(
             _('Delete'),
             url,
-            attrs={'title': _("Delete page '%(title)s'") % {'title': page.get_admin_display_title()}},
+            attrs={'aria-label': _("Delete page '%(title)s'") % {'title': page.get_admin_display_title()}},
             priority=30
         )
     if page_perms.can_unpublish():
@@ -229,7 +230,7 @@ def page_listing_more_buttons(page, page_perms, is_parent=False, next_url=None):
         yield Button(
             _('Unpublish'),
             url,
-            attrs={'title': _("Unpublish page '%(title)s'") % {'title': page.get_admin_display_title()}},
+            attrs={'aria-label': _("Unpublish page '%(title)s'") % {'title': page.get_admin_display_title()}},
             priority=40
         )
 
@@ -237,7 +238,7 @@ def page_listing_more_buttons(page, page_perms, is_parent=False, next_url=None):
         yield Button(
             _('History'),
             reverse('wagtailadmin_pages:history', args=[page.id]),
-            attrs={'title': _("View page history for '%(title)s'") % {'title': page.get_admin_display_title()}},
+            attrs={'aria-label': _("View page history for '%(title)s'") % {'title': page.get_admin_display_title()}},
             priority=50
         )
 

--- a/wagtail/admin/widgets/button.py
+++ b/wagtail/admin/widgets/button.py
@@ -69,19 +69,20 @@ class BaseDropdownMenuButton(Button):
         return render_to_string(self.template_name, {
             'buttons': self.dropdown_buttons,
             'label': self.label,
-            'title': self.attrs.get('title'),
+            'extra_attrs': flatatt(self.attrs),
             'is_parent': self.is_parent})
 
 
 class ButtonWithDropdownFromHook(BaseDropdownMenuButton):
     template_name = 'wagtailadmin/pages/listing/_button_with_dropdown.html'
 
-    def __init__(self, label, hook_name, page, page_perms, is_parent, next_url=None, **kwargs):
+    def __init__(self, label, hook_name, page, page_perms, is_parent, next_url=None, extra_button_classes=None, **kwargs):
         self.hook_name = hook_name
         self.page = page
         self.page_perms = page_perms
         self.is_parent = is_parent
         self.next_url = next_url
+        self.extra_button_classes = extra_button_classes or []
 
         super().__init__(label, **kwargs)
 
@@ -98,4 +99,9 @@ class ButtonWithDropdownFromHook(BaseDropdownMenuButton):
             buttons.extend(hook(self.page, self.page_perms, self.is_parent, self.next_url))
 
         buttons.sort()
+
+        if self.extra_button_classes:
+            for button in buttons:
+                button.classes.update(self.extra_button_classes)
+
         return buttons


### PR DESCRIPTION
The ``attrs`` attribute on ``ButtonWithDropdownFromHook`` and all buttons within it was being ignored, which makes it impossible to do things like make an item in the "more" menu open something in a new tab.

This PR makes it pass through all ``attrs`` to the HTML. It also renames the ``title`` attr to ``aria-label`` for consistency with the other page listing buttons that are not in the "more" menu