### PR TITLE
Remove redundant 'filter_page_type' helper methods

### DIFF
--- a/wagtail/api/v2/utils.py
+++ b/wagtail/api/v2/utils.py
@@ -52,15 +52,6 @@ def page_models_from_string(string):
     return tuple(page_models)
 
 
-def filter_page_type(queryset, page_models):
-    qs = queryset.none()
-
-    for model in page_models:
-        qs |= queryset.type(model)
-
-    return qs
-
-
 class FieldsParameterParseError(ValueError):
     pass
 

--- a/wagtail/api/v2/views.py
+++ b/wagtail/api/v2/views.py
@@ -20,8 +20,7 @@ from .filters import (
 from .pagination import WagtailPagination
 from .serializers import BaseSerializer, PageSerializer, get_serializer_class
 from .utils import (
-    BadRequestError, filter_page_type, get_object_detail_url, page_models_from_string,
-    parse_fields_parameter)
+    BadRequestError, get_object_detail_url, page_models_from_string, parse_fields_parameter)
 
 
 class BaseAPIViewSet(GenericViewSet):
@@ -477,7 +476,7 @@ class PagesAPIViewSet(BaseAPIViewSet):
             return models[0].objects.filter(id__in=self.get_base_queryset().values_list('id', flat=True))
 
         else:  # len(models) > 1
-            return filter_page_type(self.get_base_queryset(), models)
+            return self.get_base_queryset().type(*models)
 
     def get_object(self):
         base = super().get_object()


### PR DESCRIPTION
#6850 updated the type() filter to support multiple models as arguments, so these views can utilise that now, instead of a custom `filter_page_type()` function.