### PR TITLE
Move the IE11 support warning to the top of all Wagtail pages

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/home/ie11_warning.html
+++ b/wagtail/admin/templates/wagtailadmin/home/ie11_warning.html
@@ -1,5 +1,0 @@
-{% load i18n wagtailcore_tags %}
-
-<div data-ie11-warning hidden class="panel nice-padding">
-    <div class="help-block help-info">{% blocktrans with url="https://docs.wagtail.io/en/stable/editor_manual/browser_issues.html#ie11" %}Wagtail is gradually removing support for IE11, which may affect you or your organisation. <a href="{{ url }}">Learn more about our IE11 support plans</a>.{% endblocktrans %}</div>
-</div>

--- a/wagtail/admin/templates/wagtailadmin/skeleton.html
+++ b/wagtail/admin/templates/wagtailadmin/skeleton.html
@@ -79,6 +79,12 @@
         {% endblocktrans %}
     </noscript>
 
+    <div data-ie11-warning hidden>
+        <div class="capabilitymessage">
+            {% blocktrans with url="https://docs.wagtail.io/en/stable/editor_manual/browser_issues.html#ie11" %}Wagtail is gradually removing support for IE11, which may affect you or your organisation. <a href="{{ url }}">Learn more about our IE11 support plans</a>.{% endblocktrans %}
+        </div>
+    </div>
+
     {% block js %}{% endblock %}
 
     <a class="skiplink button" href="#main" data-skiplink>{% trans 'Skip to main content' %}</a>

--- a/wagtail/admin/views/home.py
+++ b/wagtail/admin/views/home.py
@@ -35,17 +35,6 @@ class UpgradeNotificationPanel:
             return ""
 
 
-class IE11WarningPanel:
-    name = 'ie11_warning'
-    order = 110
-
-    def __init__(self, request):
-        self.request = request
-
-    def render(self):
-        return render_to_string('wagtailadmin/home/ie11_warning.html', {}, request=self.request)
-
-
 class PagesForModerationPanel:
     name = 'pages_for_moderation'
     order = 200
@@ -170,7 +159,6 @@ def home(request):
     panels = [
         SiteSummaryPanel(request),
         UpgradeNotificationPanel(request),
-        IE11WarningPanel(request),
         WorkflowPagesToModeratePanel(request),
         PagesForModerationPanel(request),
         UserPagesInWorkflowModerationPanel(request),


### PR DESCRIPTION
This implements step 3 of our [gradual IE11 support removal](https://docs.wagtail.io/en/stable/editor_manual/browser_issues.html#ie11) (#6170):

> - In Wagtail 2.11 (LTS), there will be a warning message displayed on the Wagtail dashboard for IE11 users with administrator role.
> - In Wagtail 2.12, the message will be displayed to all users regardless of their role.
> - **In Wagtail 2.13, the message will be displayed at the top of all pages.**
> - Wagtail will no longer support IE11 starting in version 2.14.

Here is what the message now looks like:

![ie11-capabilitymessage](https://user-images.githubusercontent.com/877585/112271235-94783b80-8c72-11eb-95db-506024d57871.png)

* Do the tests still pass? (https://docs.wagtail.io/en/latest/contributing/developing.html#testing) Yes
* Does the code comply with the style guide? (Run `make lint` from the Wagtail root) Yes
* For Python changes: Have you added tests to cover the new/fixed behaviour? No tests to update.
* For front-end changes: Did you test on all of Wagtail’s supported browsers? **Please list the exact versions you tested**. Latest Chrome, Firefox, Safari TP on macOS. IE11 in Windows 10.
* For new features: Has the documentation been updated accordingly? No docs to update.
