### PR TITLE
Streamfield design tweaks

### DIFF
--- a/client/src/components/StreamField/scss/_variables.scss
+++ b/client/src/components/StreamField/scss/_variables.scss
@@ -2,6 +2,7 @@ $grid-gutter-width: 30px !default;
 $header-padding-horizontal: 4px !default;
 $header-padding-vertical: 6px;
 $header-gutter: 8px !default;
+$header-background: #fbfbfb;
 $block-margin-vertical: 4px !default;
 $block-margin-horizontal: 0 !default;
 $add-button-size: 34px !default;

--- a/client/src/components/StreamField/scss/components/c-sf-block.scss
+++ b/client/src/components/StreamField/scss/components/c-sf-block.scss
@@ -28,6 +28,7 @@
         border-top-left-radius: $border-radius;
         border-top-right-radius: $border-radius;
         min-height: 30px;
+        background: $header-background;
 
         @media (min-width: $screen-sm-min) {
             padding-left: $content-padding-horizontal - $header-gutter;

--- a/wagtail/admin/static_src/wagtailadmin/scss/layouts/page-editor.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/layouts/page-editor.scss
@@ -270,7 +270,6 @@
 
     // cursory styling for streamfield. Main styling in client/src/components/StreamField/StreamField.scss
     &.stream-field {
-        background-color: #f6f6f6;
         padding-left: 20px;
         padding-right: 20px;
 


### PR DESCRIPTION
- Remove the grey background
- Add a faint background colour to the block header

![image](https://user-images.githubusercontent.com/1093808/113279625-3df6a700-92db-11eb-8b3c-7d2607167c8a.png)
