### PR TITLE
Fix ordering behaviour when using construct_explorer_page_queryset hook

### DIFF
--- a/wagtail/admin/api/filters.py
+++ b/wagtail/admin/api/filters.py
@@ -36,6 +36,6 @@ class ForExplorerFilter(BaseFilterBackend):
                 queryset = hook(parent_page, queryset, request)
 
             user_perms = UserPagePermissionsProxy(request.user)
-            queryset = queryset & user_perms.explorable_pages()
+            queryset = user_perms.explorable_pages() & queryset
 
         return queryset


### PR DESCRIPTION
Fixes https://github.com/wagtail/wagtail/issues/6848

Since wagtail 2.8 the behaviour of doing `queryset.order_by('some_field')` inside a **construct_explorer_page_queryset** hook handler is broken (at least partially, depending if they are returned through the template or API).

This was introduced when migrating the backend API for the page explorer.

At this moment any ordering preference that is set on the queryset is lost. This is caused by the `queryset & user_perms.explorable_pages()` operation on the **ForExplorerFilter** class. Since the `explorable_pages()` returns some default ordering, this always takes precedence over the now modified queryset.

The pragmatic approach here was to simply reverse the operands. This has no effect on the filtering behaviour part of the operation, since the `&` operator is commutative (`A & B <=> B & A`). But now the **order_by** information of the rightmost operator is taken instead. In the situation that no **order_by** is present, then the one from the leftmost operator is still taken, so no breaking changes are being introduced.

This is a bit of a edge case, because sorting on that hook is not a common pattern.  But some users really want different default ordering of the explorer pages depending on the parent page type (for example, blog posts being sorted by publish date, but the other pages being sorted by creation date). This was always possible, but since the recent versions it completely broke. And since the hook takes and returns a queryset, it makes sense that none of the information is not silently discarded (like is currently happening with the **order_by**).


Before submitting, please review the contributor guidelines <https://docs.wagtail.io/en/latest/contributing/index.html> and check the following:

* Do the tests still pass? (https://docs.wagtail.io/en/latest/contributing/developing.html#testing) ✅ 
* Does the code comply with the style guide? (Run `make lint` from the Wagtail root) ✅
* For Python changes: Have you added tests to cover the new/fixed behaviour? ✅
* For front-end changes: Did you test on all of Wagtail’s supported browsers? **N/A**
* For new features: Has the documentation been updated accordingly? **N/A**
