### PR TITLE
Add a switch widget

### DIFF
--- a/client/scss/components/_switch.scss
+++ b/client/scss/components/_switch.scss
@@ -1,0 +1,84 @@
+$switch-width: 40px;
+$switch-height: 20px;
+$switch-border: 2px;
+$switch-outline: 3px;
+
+$switch-border-radius: ($switch-height + $switch-border * 2) / 2;
+$switch-outline-radius: $switch-border-radius + $switch-outline;
+
+// All the greys in Wagtail are really dark or really bright
+$switch-color-middle-grey: #777;
+
+.switch {
+    display: inline-flex;
+    align-items: center;
+    margin: 5px 0;
+
+    // Disable forms styling that's applied to the <label> tag
+    width: unset;
+    float: unset;
+
+    &__toggle {
+        position: relative;
+        cursor: pointer;
+
+        &::before,
+        &::after {
+            content: '';
+            transition: all 100ms cubic-bezier(0.4, 0, 0.2, 1);
+            display: block;
+        }
+
+        &::before {
+            height: $switch-height;
+            width: $switch-width;
+            border-radius: $switch-border-radius;
+            background: $switch-color-middle-grey;
+            border: $switch-border solid $switch-color-middle-grey;
+        }
+
+        &::after {
+            position: absolute;
+            top: 50%;
+            transform: translate($switch-border, -50%);
+            height: $switch-height;
+            width: $switch-height;
+            border-radius: 50%;
+            background-color: $color-white;
+        }
+    }
+
+    [type=checkbox]:checked + &__toggle::before {
+        background: $color-teal;
+        border-color: $color-teal;
+    }
+
+    [type=checkbox]:checked + &__toggle::after {
+        transform: translate(calc(#{$switch-width} + #{$switch-border} - 100%), -50%);
+    }
+
+    [type=checkbox]:disabled + &__toggle {
+        cursor: not-allowed;
+        filter: grayscale(100%);
+        opacity: 0.3;
+    }
+
+    [type=checkbox]:disabled + &__toggle::after {
+        opacity: 0.5;
+    }
+
+    [type=checkbox]:disabled + &__toggle::after {
+        box-shadow: none;
+    }
+
+    [type=checkbox]:focus + &__toggle {
+        outline: $color-focus-outline solid $switch-outline;
+        -moz-outline-radius: $switch-outline-radius;
+    }
+
+    [type=checkbox] {
+        position: absolute;
+        opacity: 0;
+        pointer-events: none;
+    }
+}

--- a/client/scss/styles.scss
+++ b/client/scss/styles.scss
@@ -132,6 +132,7 @@ These are classes for components.
 @import 'components/button-select';
 @import 'components/skiplink';
 @import 'components/workflow-tasks';
+@import 'components/switch';
 
 
 /* OVERRIDES

--- a/wagtail/admin/templates/wagtailadmin/widgets/switch.html
+++ b/wagtail/admin/templates/wagtailadmin/widgets/switch.html
@@ -1,0 +1,4 @@
+<label class="switch">
+    {% include "django/forms/widgets/input.html" %}
+    <span class="switch__toggle"></span>
+</label>

--- a/wagtail/admin/widgets/__init__.py
+++ b/wagtail/admin/widgets/__init__.py
@@ -4,4 +4,5 @@ from wagtail.admin.widgets.button_select import *  # NOQA
 from wagtail.admin.widgets.chooser import *  # NOQA
 from wagtail.admin.widgets.datetime import *  # NOQA
 from wagtail.admin.widgets.filtered_select import *  # NOQA
+from wagtail.admin.widgets.switch import *  # NOQA
 from wagtail.admin.widgets.tags import *  # NOQA

--- a/wagtail/admin/widgets/switch.py
+++ b/wagtail/admin/widgets/switch.py
@@ -1,0 +1,5 @@
+from django.forms import widgets
+
+
+class SwitchInput(widgets.CheckboxInput):
+    template_name = 'wagtailadmin/widgets/switch.html'

--- a/wagtail/contrib/styleguide/views.py
+++ b/wagtail/contrib/styleguide/views.py
@@ -7,7 +7,8 @@ from wagtail.admin import messages
 from wagtail.admin.forms.search import SearchForm
 from wagtail.admin.rich_text import get_rich_text_editor_widget
 from wagtail.admin.widgets import (
-    AdminAutoHeightTextInput, AdminDateInput, AdminDateTimeInput, AdminPageChooser, AdminTimeInput)
+    AdminAutoHeightTextInput, AdminDateInput, AdminDateTimeInput, AdminPageChooser, AdminTimeInput,
+    SwitchInput)
 from wagtail.core.models import Page
 from wagtail.documents.widgets import AdminDocumentChooser
 from wagtail.images.widgets import AdminImageChooser
@@ -26,6 +27,8 @@ class ExampleForm(forms.Form):
         self.fields['datetime'].widget = AdminDateTimeInput()
         self.fields['auto_height_text'].widget = AdminAutoHeightTextInput()
         self.fields['default_rich_text'].widget = get_rich_text_editor_widget('default')
+        self.fields['switch'].widget = SwitchInput()
+        self.fields['disabled_switch'].widget = SwitchInput(attrs={'disabled': True})
 
     CHOICES = (
         ('choice1', 'choice 1'),
@@ -43,6 +46,8 @@ class ExampleForm(forms.Form):
     select = forms.ChoiceField(choices=CHOICES)
     radio_select = forms.ChoiceField(choices=CHOICES, widget=forms.RadioSelect)
     boolean = forms.BooleanField(required=False)
+    switch = forms.BooleanField(required=False)
+    disabled_switch = forms.BooleanField(required=False)
     page_chooser = forms.BooleanField(required=True)
     image_chooser = forms.BooleanField(required=True)
     document_chooser = forms.BooleanField(required=True)

--- a/wagtail/users/forms.py
+++ b/wagtail/users/forms.py
@@ -18,7 +18,7 @@ from django.utils.html import mark_safe
 from django.utils.translation import gettext_lazy as _
 
 from wagtail.admin.localization import get_available_admin_languages, get_available_admin_time_zones
-from wagtail.admin.widgets import AdminPageChooser
+from wagtail.admin.widgets import AdminPageChooser, SwitchInput
 from wagtail.core import hooks
 from wagtail.core.models import (
     PAGE_PERMISSION_TYPE_CHOICES, PAGE_PERMISSION_TYPES, GroupPagePermission, Page,
@@ -385,7 +385,12 @@ class NotificationPreferencesForm(forms.ModelForm):
 
     class Meta:
         model = UserProfile
-        fields = ("submitted_notifications", "approved_notifications", "rejected_notifications")
+        fields = ['submitted_notifications', 'approved_notifications', 'rejected_notifications']
+        widgets = {
+            'submitted_notifications': SwitchInput(),
+            'approved_notifications': SwitchInput(),
+            'rejected_notifications': SwitchInput(),
+        }
 
 
 def _get_language_choices():


### PR DESCRIPTION
This PR adds a new switch widget for boolean fields, and makes use of it for notification preferences.

![image](https://user-images.githubusercontent.com/1093808/113732120-37a86680-96f1-11eb-908f-376f72189791.png)

![image](https://user-images.githubusercontent.com/1093808/113731935-134c8a00-96f1-11eb-88c5-39706c9209a8.png)

Design by @benenright 