### PR TITLE
Include submitter in workflow submitted email notification

### DIFF
--- a/wagtail/admin/mail.py
+++ b/wagtail/admin/mail.py
@@ -331,6 +331,11 @@ class WorkflowStateSubmissionEmailNotifier(BaseWorkflowStateEmailNotifier):
 
         return recipients
 
+    def get_context(self, workflow_state, **kwargs):
+        context = super().get_context(workflow_state, **kwargs)
+        context['requested_by'] = workflow_state.requested_by
+        return context
+
 
 class BaseGroupApprovalTaskStateEmailNotifier(EmailNotificationMixin, Notifier):
     """A base notifier to send email updates for GroupApprovalTask events"""

--- a/wagtail/admin/templates/wagtailadmin/notifications/workflow_state_submitted.html
+++ b/wagtail/admin/templates/wagtailadmin/notifications/workflow_state_submitted.html
@@ -1,9 +1,13 @@
 {% extends 'wagtailadmin/notifications/base.html' %}
 
-{% load i18n %}
+{% load wagtailadmin_tags i18n %}
 
 {% block content %}
-    <p>{% blocktrans with workflow=workflow.name title=page.get_admin_display_title %}The page "{{ title }}" has been submitted for moderation to workflow "{{ workflow }}".{% endblocktrans %}</p>
+    {% if requested_by %}
+        <p>{% blocktrans with workflow=workflow.name title=page.get_admin_display_title requester=requested_by|user_display_name %}The page "{{ title }}" has been submitted for moderation to workflow "{{ workflow }}" by {{ requester }}.{% endblocktrans %}</p>
+    {% else %}
+        <p>{% blocktrans with workflow=workflow.name title=page.get_admin_display_title %}The page "{{ title }}" has been submitted for moderation to workflow "{{ workflow }}".{% endblocktrans %}</p>
+    {% endif %}
 
     <p>
         {% trans "You can edit the page here:" %} <a href="{{ settings.BASE_URL }}{% url 'wagtailadmin_pages:edit' page.id %}">{{ settings.BASE_URL }}{% url 'wagtailadmin_pages:edit' page.id %}</a>

--- a/wagtail/admin/templates/wagtailadmin/notifications/workflow_state_submitted.txt
+++ b/wagtail/admin/templates/wagtailadmin/notifications/workflow_state_submitted.txt
@@ -1,10 +1,11 @@
 {% extends 'wagtailadmin/notifications/base.txt' %}
 
-{% load i18n %}
+{% load wagtailadmin_tags i18n %}
 
 {% block content %}
-{% blocktrans with workflow=workflow.name|safe title=page.get_admin_display_title|safe %}The page "{{ title }}" has been submitted for moderation to workflow "{{ workflow }}".{% endblocktrans %}
-
+{% if requested_by %}{% blocktrans with workflow=workflow.name|safe title=page.get_admin_display_title|safe requester=requested_by|user_display_name|safe %}The page "{{ title }}" has been submitted for moderation to workflow "{{ workflow }}" by {{ requester }}.{% endblocktrans %}
+{% else %}{% blocktrans with workflow=workflow.name|safe title=page.get_admin_display_title|safe %}The page "{{ title }}" has been submitted for moderation to workflow "{{ workflow }}".{% endblocktrans %}
+{% endif %}
 
 {% trans "You can edit the page here:" %} {{ settings.BASE_URL }}{% url 'wagtailadmin_pages:edit' page.id %}
 


### PR DESCRIPTION
Add back the name of the submitter to the "submitted for moderation" email - this was present in the pre-workflow implementation.