### PR TITLE
Apply chevron padding fix to all applicable `select` elements

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -34,6 +34,7 @@ Changelog
  * Fix: Validate host/scheme of return URLs on password authentication forms (Susan Dreher)
  * Fix: Reordering a page now includes the correct user in the audit log (Storm Heg)
  * Fix: Reverse migration errors in images and documents (Mike Brown)
+ * Fix: Apply enough chevron padding to all applicable select elements (Scott Cranfill)
 
 
 2.12.3 (05.03.2021)

--- a/client/scss/components/_forms.scss
+++ b/client/scss/components/_forms.scss
@@ -107,11 +107,11 @@ select::-ms-expand {
             display: none;
         }
     }
-}
 
-// the site setting dropdown is auto width, so the chevron will overlap with text if not padded
-.choice_field .setting-site-switch-form .input select {
-    padding-right: 5em;
+    // Override default select padding so the chevron will overlap with long option text
+    select {
+        padding-right: 5em;
+    }
 }
 
 // Other text

--- a/docs/releases/2.13.rst
+++ b/docs/releases/2.13.rst
@@ -61,6 +61,7 @@ Bug fixes
 * Reordering a page now includes the correct user in the audit log (Storm Heg)
 * Fix reverse migration errors in images and documents (Mike Brown)
 * Make "Collection" and "Parent" form field labels translatable (Thibaud Colas)
+* Apply enough chevron padding to all applicable select elements (Scott Cranfill)
 
 
 Upgrade considerations


### PR DESCRIPTION
Most `select` elements in the admin do not currently have adequate padding on the right-hand side to avoid long text colliding with the down-pointing chevron icon. A fix was previously added for this, but it was too narrowly scoped. This PR should, I believe, apply it to all cases where the chevron appears.

### Before:

![Long select option text colliding with chevron icon](https://user-images.githubusercontent.com/1044670/113940204-14ea8080-97cb-11eb-9574-5daffec43099.png)

### After:

![The same long text is cut off before colliding with the icon](https://user-images.githubusercontent.com/1044670/113940352-4fecb400-97cb-11eb-94f8-50ad74cc7c03.png)

---

Also tagging for review: @rinti 