### PR TITLE
Feature/inline comment focus on add

### DIFF
--- a/client/src/components/CommentApp/components/Comment/index.tsx
+++ b/client/src/components/CommentApp/components/Comment/index.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/prop-types */
 
-import React from 'react';
+import React, { MutableRefObject } from 'react';
 import ReactDOM from 'react-dom';
 
 import type { Store } from '../../state';
@@ -84,6 +84,13 @@ export interface CommentProps {
 }
 
 export default class CommentComponent extends React.Component<CommentProps> {
+  focusTargetRef: MutableRefObject<HTMLTextAreaElement | null>
+  focusTimeoutId: number | undefined
+
+  constructor(props: CommentProps) {
+    super(props);
+    this.focusTargetRef = React.createRef();
+  }
   renderReplies({ hideNewReply = false } = {}): React.ReactFragment {
     const { comment, isFocused, store, user, strings } = this.props;
 
@@ -557,11 +564,14 @@ export default class CommentComponent extends React.Component<CommentProps> {
     if (element instanceof HTMLElement) {
       // If this is a new comment, focus in the edit box
       if (this.props.comment.mode === 'creating') {
-        const textAreaElement = element.querySelector('textarea');
-
-        if (textAreaElement instanceof HTMLTextAreaElement) {
-          textAreaElement.focus();
-        }
+        clearTimeout(this.focusTimeoutId)
+        this.focusTimeoutId = setTimeout(
+          () => {
+            if (this.focusTargetRef.current) {
+              this.focusTargetRef.current.focus()
+            }   
+          }
+        , 10);
       }
 
       this.props.layout.setCommentElement(this.props.comment.localId, element);
@@ -573,6 +583,7 @@ export default class CommentComponent extends React.Component<CommentProps> {
   }
 
   componentWillUnmount() {
+    clearTimeout(this.focusTimeoutId)
     this.props.layout.setCommentElement(this.props.comment.localId, null);
   }
 

--- a/client/src/components/CommentApp/components/Comment/index.tsx
+++ b/client/src/components/CommentApp/components/Comment/index.tsx
@@ -221,6 +221,7 @@ export default class CommentComponent extends React.Component<CommentProps> {
         <CommentHeader commentReply={comment} store={store} strings={strings} />
         <form onSubmit={onSave}>
           <TextArea
+            ref={this.focusTargetRef}
             className="comment__input"
             value={comment.newText}
             onChange={onChangeText}
@@ -279,6 +280,7 @@ export default class CommentComponent extends React.Component<CommentProps> {
         <CommentHeader commentReply={comment} store={store} strings={strings} />
         <form onSubmit={onSave}>
           <TextArea
+            ref={this.focusTargetRef}
             className="comment__input"
             value={comment.newText}
             onChange={onChangeText}

--- a/client/src/components/CommentApp/components/Comment/index.tsx
+++ b/client/src/components/CommentApp/components/Comment/index.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable react/prop-types */
-
 import React, { MutableRefObject } from 'react';
 import ReactDOM from 'react-dom';
 
@@ -564,14 +562,14 @@ export default class CommentComponent extends React.Component<CommentProps> {
     if (element instanceof HTMLElement) {
       // If this is a new comment, focus in the edit box
       if (this.props.comment.mode === 'creating') {
-        clearTimeout(this.focusTimeoutId)
+        clearTimeout(this.focusTimeoutId);
         this.focusTimeoutId = setTimeout(
           () => {
             if (this.focusTargetRef.current) {
-              this.focusTargetRef.current.focus()
-            }   
+              this.focusTargetRef.current.focus();
+            }
           }
-        , 10);
+          , 10);
       }
 
       this.props.layout.setCommentElement(this.props.comment.localId, element);
@@ -583,7 +581,7 @@ export default class CommentComponent extends React.Component<CommentProps> {
   }
 
   componentWillUnmount() {
-    clearTimeout(this.focusTimeoutId)
+    clearTimeout(this.focusTimeoutId);
     this.props.layout.setCommentElement(this.props.comment.localId, null);
   }
 

--- a/client/src/components/CommentApp/components/TextArea/index.tsx
+++ b/client/src/components/CommentApp/components/TextArea/index.tsx
@@ -10,13 +10,13 @@ export interface TextAreaProps {
   focusOnMount?: boolean;
 }
 
-const TextArea: FunctionComponent<TextAreaProps> = ({
+const TextArea: FunctionComponent<TextAreaProps> = React.forwardRef(({
   value,
   className,
   placeholder,
   onChange,
   focusOnMount
-}) => {
+}, ref) => {
   const onChangeValue = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     if (onChange) {
       onChange(e.target.value);
@@ -25,6 +25,8 @@ const TextArea: FunctionComponent<TextAreaProps> = ({
 
   // Resize the textarea whenever the value is changed
   const textAreaElement = React.useRef<HTMLTextAreaElement>(null);
+  React.useImperativeHandle(ref, () => textAreaElement.current);
+
   React.useEffect(() => {
     if (textAreaElement.current) {
       textAreaElement.current.style.height = '';
@@ -51,6 +53,6 @@ const TextArea: FunctionComponent<TextAreaProps> = ({
       value={value}
     />
   );
-};
+});
 
 export default TextArea;

--- a/client/src/components/CommentApp/components/TextArea/index.tsx
+++ b/client/src/components/CommentApp/components/TextArea/index.tsx
@@ -1,6 +1,4 @@
-/* eslint-disable react/prop-types */
-
-import React, { FunctionComponent } from 'react';
+import React from 'react';
 
 export interface TextAreaProps {
   value: string;
@@ -10,7 +8,7 @@ export interface TextAreaProps {
   focusOnMount?: boolean;
 }
 
-const TextArea: FunctionComponent<TextAreaProps> = React.forwardRef(({
+const TextArea = React.forwardRef<HTMLTextAreaElement | null, TextAreaProps>(({
   value,
   className,
   placeholder,
@@ -25,7 +23,7 @@ const TextArea: FunctionComponent<TextAreaProps> = React.forwardRef(({
 
   // Resize the textarea whenever the value is changed
   const textAreaElement = React.useRef<HTMLTextAreaElement>(null);
-  React.useImperativeHandle(ref, () => textAreaElement.current);
+  React.useImperativeHandle<HTMLTextAreaElement | null, HTMLTextAreaElement | null>(ref, () => textAreaElement.current);
 
   React.useEffect(() => {
     if (textAreaElement.current) {

--- a/client/src/components/CommentApp/main.tsx
+++ b/client/src/components/CommentApp/main.tsx
@@ -332,10 +332,10 @@ export class CommentApp {
     this.store.subscribe(render);
 
     // Unfocus when document body is clicked
-    document.body.addEventListener('click', (e) => {
+    document.body.addEventListener('mousedown', (e) => {
       if (e.target instanceof HTMLElement) {
         // ignore if click target is a comment or an annotation
-        if (!e.target.closest('#comments, [data-annotation]')) {
+        if (!e.target.closest('#comments, [data-annotation], [data-comment-add]')) {
           // Running store.dispatch directly here seems to prevent the event from being handled anywhere else
           setTimeout(() => {
             this.store.dispatch(setFocusedComment(null, { updatePinnedComment: true }));

--- a/client/src/components/Draftail/CommentableEditor/CommentableEditor.tsx
+++ b/client/src/components/Draftail/CommentableEditor/CommentableEditor.tsx
@@ -449,8 +449,6 @@ function CommentableEditor({
     comments,
   ]);
 
-  const controls = useMemo(() => (enabled ? [CommentControl] : []), [enabled, CommentControl]);
-
   const commentStyles: Array<InlineStyle> = useMemo(
     () =>
       ids.map((id) => ({
@@ -577,7 +575,7 @@ function CommentableEditor({
         setEditorState(newEditorState);
       }}
       editorState={editorState}
-      controls={controls}
+      controls={enabled ? [CommentControl] : []}
       decorators={
         enabled
           ? [

--- a/client/src/components/Draftail/CommentableEditor/CommentableEditor.tsx
+++ b/client/src/components/Draftail/CommentableEditor/CommentableEditor.tsx
@@ -174,7 +174,7 @@ interface ControlProps {
 
 function getCommentControl(commentApp: CommentApp, contentPath: string, fieldNode: Element) {
   return ({ getEditorState, onChange }: ControlProps) => (
-    <span className="Draftail-CommentControl">
+    <span className="Draftail-CommentControl" data-comment-add>
       <ToolbarButton
         name="comment"
         active={false}
@@ -183,10 +183,14 @@ function getCommentControl(commentApp: CommentApp, contentPath: string, fieldNod
         onClick={() => {
           const annotation = new DraftailInlineAnnotation(fieldNode);
           const commentId = commentApp.makeComment(annotation, contentPath, '[]');
+          const editorState = getEditorState();
           onChange(
-            RichUtils.toggleInlineStyle(
-              getEditorState(),
-              `${COMMENT_STYLE_IDENTIFIER}${commentId}`
+            EditorState.acceptSelection(
+              RichUtils.toggleInlineStyle(
+                editorState,
+                `${COMMENT_STYLE_IDENTIFIER}${commentId}`
+              ),
+              editorState.getSelection()
             )
           );
         }}
@@ -445,6 +449,8 @@ function CommentableEditor({
     comments,
   ]);
 
+  const controls = useMemo(() => (enabled ? [CommentControl] : []), [enabled, CommentControl]);
+
   const commentStyles: Array<InlineStyle> = useMemo(
     () =>
       ids.map((id) => ({
@@ -571,7 +577,7 @@ function CommentableEditor({
         setEditorState(newEditorState);
       }}
       editorState={editorState}
-      controls={enabled ? [CommentControl] : []}
+      controls={controls}
       decorators={
         enabled
           ? [


### PR DESCRIPTION
Ensures newly added comments in Draftail are focused and have keyboard focus moved to the text input

Focusing logic will be extended in accessibility pass