### PR TITLE
Cache modeladmin get_all_permissions query

### DIFF
--- a/wagtail/contrib/modeladmin/helpers/permission.py
+++ b/wagtail/contrib/modeladmin/helpers/permission.py
@@ -44,7 +44,14 @@ class PermissionHelper:
         Return a boolean to indicate whether `user` has any model-wide
         permissions
         """
-        for perm in self.get_all_model_permissions().values('codename'):
+
+        # Cache the lookup as this is called often in list views
+        model_perms = getattr(self, '_model_perms_cache', None)
+        if model_perms is None:
+            model_perms = self.get_all_model_permissions().values('codename')
+            self._model_perms_cache = model_perms
+
+        for perm in model_perms:
             if self.user_has_specific_permission(user, perm['codename']):
                 return True
         return False

--- a/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
+++ b/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
@@ -752,10 +752,10 @@ class TestPermissionsCached(TestCase, WagtailTestUtils):
     def setUp(self):
         self.login()
 
-    def test_inspect_view(self):
+    def test_permission_helper_cache(self):
         # Ensure that the permissions helper caches the model permissions
         # and only does one query per modeladmin
-        ContentType.clear_cache()
+        ContentType.objects.clear_cache()
         Site.get_site_root_paths()
         with self.assertNumQueries(35):
             self.client.get('/admin/modeladmintest/author/')

--- a/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
+++ b/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
@@ -757,11 +757,10 @@ class TestPermissionsCached(TestCase, WagtailTestUtils):
         # Ensure that the permissions helper caches the model permissions
         # and only does one query per modeladmin
         with CaptureQueriesContext(connection) as queries:
-            r = self.client.get('/admin/modeladmintest/author/')
+            self.client.get('/admin/modeladmintest/author/')
             count = 0
             for q in queries:
                 sql = q['sql']
-                if ('auth_permission"."codename"' in sql and
-                        '"django_content_type"."model" = \'author\'' in sql):
+                if 'codename' in sql and 'author' in sql:
                     count += 1
             self.assertEqual(count, 1)

--- a/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
+++ b/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
@@ -758,9 +758,12 @@ class TestPermissionsCached(TestCase, WagtailTestUtils):
         # and only does one query per modeladmin
         with CaptureQueriesContext(connection) as queries:
             self.client.get('/admin/modeladmintest/author/')
+            self.assertGreater(len(queries), 0)
+
             count = 0
             for q in queries:
                 sql = q['sql']
+                print(sql)
                 if 'codename' in sql and 'author' in sql:
                     count += 1
             self.assertEqual(count, 1)

--- a/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
+++ b/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
@@ -3,9 +3,7 @@ from unittest import mock
 
 from django.contrib.auth.models import Group
 from django.core import checks
-from django.db import connection
 from django.test import TestCase
-from django.test.utils import CaptureQueriesContext
 from openpyxl import load_workbook
 
 from wagtail.admin.edit_handlers import FieldPanel, TabbedInterface
@@ -756,14 +754,5 @@ class TestPermissionsCached(TestCase, WagtailTestUtils):
     def test_inspect_view(self):
         # Ensure that the permissions helper caches the model permissions
         # and only does one query per modeladmin
-        with CaptureQueriesContext(connection) as queries:
+        with self.assertNumQueries(35):
             self.client.get('/admin/modeladmintest/author/')
-            self.assertGreater(len(queries), 0)
-
-            count = 0
-            for q in queries:
-                sql = q['sql']
-                print(sql)
-                if 'codename' in sql and 'author' in sql:
-                    count += 1
-            self.assertEqual(count, 1)

--- a/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
+++ b/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
@@ -8,7 +8,7 @@ from openpyxl import load_workbook
 
 from wagtail.admin.edit_handlers import FieldPanel, TabbedInterface
 from wagtail.contrib.modeladmin.helpers.search import DjangoORMSearchHandler
-from wagtail.core.models import Page
+from wagtail.core.models import Page, Site
 from wagtail.images.models import Image
 from wagtail.images.tests.utils import get_test_image_file
 from wagtail.tests.modeladmintest.models import Author, Book, Publisher, RelatedLink, Token
@@ -755,4 +755,5 @@ class TestPermissionsCached(TestCase, WagtailTestUtils):
         # Ensure that the permissions helper caches the model permissions
         # and only does one query per modeladmin
         with self.assertNumQueries(35):
+            Site.get_site_root_paths()
             self.client.get('/admin/modeladmintest/author/')

--- a/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
+++ b/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
@@ -2,7 +2,6 @@ from io import BytesIO
 from unittest import mock
 
 from django.contrib.auth.models import Group
-from django.contrib.contenttypes.models import ContentType
 from django.core import checks
 from django.test import TestCase
 from openpyxl import load_workbook
@@ -755,7 +754,6 @@ class TestPermissionsCached(TestCase, WagtailTestUtils):
     def test_permission_helper_cache(self):
         # Ensure that the permissions helper caches the model permissions
         # and only does one query per modeladmin
-        ContentType.objects.clear_cache()
-        Site.get_site_root_paths()
-        with self.assertNumQueries(35):
+        self.client.get('/admin/modeladmintest/author/')
+        with self.assertNumQueries(25):
             self.client.get('/admin/modeladmintest/author/')

--- a/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
+++ b/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
@@ -754,6 +754,6 @@ class TestPermissionsCached(TestCase, WagtailTestUtils):
     def test_inspect_view(self):
         # Ensure that the permissions helper caches the model permissions
         # and only does one query per modeladmin
+        Site.get_site_root_paths()
         with self.assertNumQueries(35):
-            Site.get_site_root_paths()
             self.client.get('/admin/modeladmintest/author/')

--- a/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
+++ b/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
@@ -2,6 +2,7 @@ from io import BytesIO
 from unittest import mock
 
 from django.contrib.auth.models import Group
+from django.contrib.contenttypes.models import ContentType
 from django.core import checks
 from django.test import TestCase
 from openpyxl import load_workbook
@@ -754,6 +755,7 @@ class TestPermissionsCached(TestCase, WagtailTestUtils):
     def test_inspect_view(self):
         # Ensure that the permissions helper caches the model permissions
         # and only does one query per modeladmin
+        ContentType.clear_cache()
         Site.get_site_root_paths()
         with self.assertNumQueries(35):
             self.client.get('/admin/modeladmintest/author/')


### PR DESCRIPTION
This function is called on each row when checking the for the object's buttons. Caching the result saves anywhere from 50 to 140 queries (and about ~50-70ms) depending on the page and the inspect setting.

* Do the tests still pass? Yes
* Does the code comply with the style guide? Yes
* For Python changes: Have you added tests to cover the new/fixed behaviour?
* For front-end changes: N/A
* For new features: N/A

I tested by force evaluating the query to a list and adding an assertion to rerun the query against the  cache then loading several pages to ensure the assertion was not hit.

```python
        model_perms = getattr(self, '_model_perms_cache', None)
        if model_perms is None:
            model_perms = list(self.get_all_model_permissions().values('codename'))
            self._model_perms_cache = model_perms
        assert model_perms == list(self.get_all_model_permissions().values('codename'))
```



