### PR TITLE
Add keyboard and screen reader support to Wagtail user bar (#6994). Fix #6108

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -12,6 +12,7 @@ Changelog
  * Added `WAGTAIL_WORKFLOW_ENABLED` setting for enabling / disabling moderation workflows globally (Matt Westcott)
  * Allow specifying `max_width` and `max_height` on EmbedBlock (Petr Dlouhý)
  * Add warning when StreamField is used without a StreamFieldPanel (Naomi Morduch Toubman)
+ * Added keyboard and screen reader support to Wagtail user bar (LB Johnston, Storm Heg)
  * Fix: Invalid filter values for foreign key fields in the API now give an error instead of crashing (Tidjani Dia)
  * Fix: Ordering specified in `construct_explorer_page_queryset` hook is now taken into account again by the page explorer API (Andre Fonseca)
  * Fix: Deleting a page from its listing view no longer results in a 404 error (Tidjani Dia)

--- a/client/src/entrypoints/admin/userbar.js
+++ b/client/src/entrypoints/admin/userbar.js
@@ -9,6 +9,13 @@ document.addEventListener('DOMContentLoaded', () => {
   const listItems = list.querySelectorAll('li');
   const isActiveClass = 'is-active';
 
+  // querySelector for all items that can be focused.
+  // source: https://stackoverflow.com/questions/1599660/which-html-elements-can-receive-focus
+  const focusableItemSelector = `a[href]:not([tabindex='-1']),
+    button:not([disabled]):not([tabindex='-1']),
+    input:not([disabled]):not([tabindex='-1']),
+    [tabindex]:not([tabindex='-1'])`;
+
   // eslint-disable-next-line @typescript-eslint/no-use-before-define
   trigger.addEventListener('click', toggleUserbar, false);
 
@@ -37,9 +44,13 @@ document.addEventListener('DOMContentLoaded', () => {
     // For weird reasons shifting focus only works after some amount of delay
     // Which is why we are forced to use setTimeout
     if (shouldFocus) {
-      setTimeout(() => {
-        list.querySelector('a').focus();
-      }, 300); // Less than 300ms doesn't seem to work
+      // Find the first focusable element (if any) and focus it
+      if (list.querySelector(focusableItemSelector)) {
+        setTimeout(() => {
+          // eslint-disable-next-line @typescript-eslint/no-use-before-define
+          setFocusToFirstItem();
+        }, 300); // Less than 300ms doesn't seem to work
+      }
     }
   }
 
@@ -70,13 +81,7 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function isFocusOnItems() {
-    let isFocused = false;
-    list.querySelectorAll('a').forEach((element) => {
-      if (element === document.activeElement) {
-        isFocused = true;
-      }
-    });
-    return isFocused;
+    return document.activeElement && !!document.activeElement.closest('.wagtail-userbar-items');
   }
 
   function setFocusToFirstItem() {

--- a/client/src/entrypoints/admin/userbar.js
+++ b/client/src/entrypoints/admin/userbar.js
@@ -120,7 +120,6 @@ document.addEventListener('DOMContentLoaded', () => {
     // Only handle keyboard input if the userbar is open
     if (userbar.classList.contains(isActiveClass)) {
       if (event.key === 'Escape') {
-        // eslint-disable-next-line @typescript-eslint/no-use-before-define
         hideUserbar();
         setFocusToTrigger();
         return;

--- a/client/src/entrypoints/admin/userbar.js
+++ b/client/src/entrypoints/admin/userbar.js
@@ -20,6 +20,10 @@ document.addEventListener('DOMContentLoaded', (e) => {
   // Listen for keyboard events
   window.addEventListener('keydown', handleKeyDown);
 
+  function setFocusToTrigger() {
+    setTimeout(() => trigger.focus(), 300);
+  }
+
   function isFocusOnItems() {
     let isFocused = false;
     list.querySelectorAll('a').forEach((element) => {
@@ -80,6 +84,7 @@ document.addEventListener('DOMContentLoaded', (e) => {
       if (event.key === 'Escape') {
         // eslint-disable-next-line @typescript-eslint/no-use-before-define
         hideUserbar();
+        setFocusToTrigger();
         return;
       }
 

--- a/client/src/entrypoints/admin/userbar.js
+++ b/client/src/entrypoints/admin/userbar.js
@@ -95,6 +95,8 @@ document.addEventListener('DOMContentLoaded', () => {
           if (idx + 1 < listItems.length) {
             // Focus the next item
             listItems[idx + 1].firstElementChild.focus();
+          } else {
+            setFocusToFirstItem();
           }
         }, 100); // Workaround for focus bug
       }
@@ -109,6 +111,8 @@ document.addEventListener('DOMContentLoaded', () => {
           if (idx > 0) {
             // Focus the previous item
             listItems[idx - 1].firstElementChild.focus();
+          } else {
+            setFocusToLastItem();
           }
         }, 100); // Workaround for focus bug
       }

--- a/client/src/entrypoints/admin/userbar.js
+++ b/client/src/entrypoints/admin/userbar.js
@@ -8,22 +8,7 @@ document.addEventListener('DOMContentLoaded', (e) => {
   const list = userbar.querySelector('.wagtail-userbar-items');
   const listItems = list.querySelectorAll('li');
   const isActiveClass = 'is-active';
-  const hasTouch = 'ontouchstart' in window;
   const clickEvent = 'click';
-
-  if (hasTouch) {
-    userbar.classList.add('touch');
-
-    // Bind to touchend event, preventDefault to prevent DELAY and CLICK
-    // in accordance with: https://hacks.mozilla.org/2013/04/detecting-touch-its-the-why-not-the-how/
-    trigger.addEventListener('touchend', (e2) => {
-      e.preventDefault();
-      // eslint-disable-next-line @typescript-eslint/no-use-before-define
-      toggleUserbar(e2);
-    });
-  } else {
-    userbar.classList.add('no-touch');
-  }
 
   // eslint-disable-next-line @typescript-eslint/no-use-before-define
   trigger.addEventListener(clickEvent, toggleUserbar, false);

--- a/client/src/entrypoints/admin/userbar.js
+++ b/client/src/entrypoints/admin/userbar.js
@@ -117,7 +117,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function handleKeyDown(event) {
     // Only handle keyboard input if the userbar is open
-    if (userbar.classList.contains(isActiveClass)) {
+    if (trigger.getAttribute('aria-expanded')) {
       if (event.key === 'Escape') {
         hideUserbar();
         setFocusToTrigger();

--- a/client/src/entrypoints/admin/userbar.js
+++ b/client/src/entrypoints/admin/userbar.js
@@ -6,6 +6,7 @@ document.addEventListener('DOMContentLoaded', (e) => {
   const userbar = document.querySelector('[data-wagtail-userbar]');
   const trigger = userbar.querySelector('[data-wagtail-userbar-trigger]');
   const list = userbar.querySelector('.wagtail-userbar-items');
+  const listItems = list.querySelectorAll('li');
   const className = 'is-active';
   const hasTouch = 'ontouchstart' in window;
   const clickEvent = 'click';
@@ -31,6 +32,87 @@ document.addEventListener('DOMContentLoaded', (e) => {
   // eslint-disable-next-line @typescript-eslint/no-use-before-define
   window.addEventListener('pageshow', hideUserbar, false);
 
+  function isFocusOnItems() {
+    let isFocused = false;
+    list.querySelectorAll('a').forEach((element) => {
+      if (element === document.activeElement) {
+        isFocused = true;
+      }
+    });
+    return isFocused;
+  }
+
+  function setFocusToFirstItem() {
+    if (listItems.length > 0) {
+      setTimeout(() => {
+        listItems[0].firstElementChild.focus();
+      }, 100);
+    }
+  }
+
+  function setFocusToLastItem() {
+    if (listItems.length > 0) {
+      setTimeout(() => {
+        listItems[listItems.length - 1].firstElementChild.focus();
+      }, 100);
+    }
+  }
+
+  function setFocusToNextItem() {
+    listItems.forEach((element, idx) => {
+      if (element.firstElementChild === document.activeElement) {
+        setTimeout(() => {
+          if (idx + 1 < listItems.length) {
+            listItems[idx + 1].firstElementChild.focus();
+          }
+        }, 100);
+      }
+    });
+  }
+
+  function setFocusToPreviousItem() {
+    listItems.forEach((element, idx) => {
+      if (element.firstElementChild === document.activeElement) {
+        setTimeout(() => {
+          if (idx > 0) {
+            listItems[idx - 1].firstElementChild.focus();
+          }
+        }, 100);
+      }
+    });
+  }
+
+  function handleKeyDown(event) {
+    if (event.key === 'Escape') {
+      // eslint-disable-next-line @typescript-eslint/no-use-before-define
+      hideUserbar();
+      return;
+    }
+
+    if (isFocusOnItems()) {
+      switch (event.key) {
+      case 'ArrowDown':
+        event.preventDefault();
+        setFocusToNextItem();
+        break;
+      case 'ArrowUp':
+        event.preventDefault();
+        setFocusToPreviousItem();
+        break;
+      case 'Home':
+        event.preventDefault();
+        setFocusToFirstItem();
+        break;
+      case 'End':
+        event.preventDefault();
+        setFocusToLastItem();
+        break;
+      default:
+        break;
+      }
+    }
+  }
+
   function showUserbar() {
     userbar.classList.add(className);
     trigger.setAttribute('aria-expanded', 'true');
@@ -45,6 +127,8 @@ document.addEventListener('DOMContentLoaded', (e) => {
     setTimeout(() => {
       list.querySelector('a').focus();
     }, 300); // Less than 300ms doesn't seem to work
+
+    list.addEventListener('keydown', handleKeyDown);
   }
 
   function hideUserbar() {
@@ -54,6 +138,7 @@ document.addEventListener('DOMContentLoaded', (e) => {
     list.addEventListener(clickEvent, sandboxClick, false);
     // eslint-disable-next-line @typescript-eslint/no-use-before-define
     window.removeEventListener(clickEvent, clickOutside, false);
+    list.removeEventListener('keydown', handleKeyDown, false);
   }
 
   function toggleUserbar(e2) {

--- a/client/src/entrypoints/admin/userbar.js
+++ b/client/src/entrypoints/admin/userbar.js
@@ -158,12 +158,18 @@ document.addEventListener('DOMContentLoaded', () => {
       case 'ArrowUp':
         event.preventDefault();
         showUserbar(false);
-        setTimeout(() => setFocusToFirstItem(), 300); // Workaround for focus bug
+
+        // Workaround for focus bug
+        // Needs extra delay to account for the userbar open animation. Otherwise won't focus properly.
+        setTimeout(() => setFocusToLastItem(), 300);
         break;
       case 'ArrowDown':
         event.preventDefault();
         showUserbar(false);
-        setTimeout(() => setFocusToLastItem(), 300); // Workaround for focus bug
+
+        // Workaround for focus bug
+        // Needs extra delay to account for the userbar open animation. Otherwise won't focus properly.
+        setTimeout(() => setFocusToFirstItem(), 300);
         break;
       default:
         break;

--- a/client/src/entrypoints/admin/userbar.js
+++ b/client/src/entrypoints/admin/userbar.js
@@ -16,9 +16,9 @@ document.addEventListener('DOMContentLoaded', () => {
   // eslint-disable-next-line @typescript-eslint/no-use-before-define
   window.addEventListener('pageshow', hideUserbar, false);
 
-  // Listen for keyboard events
+  // Handle keyboard events on the trigger
   // eslint-disable-next-line @typescript-eslint/no-use-before-define
-  window.addEventListener('keydown', handleKeyDown);
+  userbar.addEventListener('keydown', handleTriggerKeyDown);
 
 
   function showUserbar(shouldFocus) {
@@ -28,6 +28,10 @@ document.addEventListener('DOMContentLoaded', () => {
     list.addEventListener('click', sandboxClick, false);
     // eslint-disable-next-line @typescript-eslint/no-use-before-define
     window.addEventListener('click', clickOutside, false);
+
+    // Start handling keyboard input now that the userbar is open.
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
+    userbar.addEventListener('keydown', handleUserbarItemsKeyDown, false);
 
     // The userbar has role=menu which means that the first link should be focused on popup
     // For weird reasons shifting focus only works after some amount of delay
@@ -46,6 +50,10 @@ document.addEventListener('DOMContentLoaded', () => {
     list.addEventListener('click', sandboxClick, false);
     // eslint-disable-next-line @typescript-eslint/no-use-before-define
     window.removeEventListener('click', clickOutside, false);
+
+    // Cease handling keyboard input now that the userbar is closed.
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
+    userbar.removeEventListener('keydown', handleUserbarItemsKeyDown, false);
   }
 
   function toggleUserbar(e2) {
@@ -119,7 +127,15 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
-  function handleKeyDown(event) {
+  /**
+    This handler is responsible for keyboard input when items inside the userbar are focused.
+    It should only listen when the userbar is open.
+
+    It is responsible for:
+    - Shifting focus using the arrow / home / end keys.
+    - Closing the menu when 'Escape' is pressed.
+  */
+  function handleUserbarItemsKeyDown(event) {
     // Only handle keyboard input if the userbar is open
     if (trigger.getAttribute('aria-expanded') === 'true') {
       if (event.key === 'Escape') {
@@ -152,8 +168,15 @@ document.addEventListener('DOMContentLoaded', () => {
       }
       return;
     }
+  }
+
+  /**
+    This handler is responsible for opening the userbar with the arrow keys
+    if it's focused and not open yet. It should always be listening.
+  */
+  function handleTriggerKeyDown(event) {
     // Check if the userbar is focused (but not open yet) and should be opened by keyboard input
-    if (trigger === document.activeElement) {
+    if (trigger === document.activeElement && trigger.getAttribute('aria-expanded') === 'false') {
       switch (event.key) {
       case 'ArrowUp':
         event.preventDefault();

--- a/client/src/entrypoints/admin/userbar.js
+++ b/client/src/entrypoints/admin/userbar.js
@@ -33,14 +33,23 @@ document.addEventListener('DOMContentLoaded', (e) => {
 
   function showUserbar() {
     userbar.classList.add(className);
+    trigger.setAttribute('aria-expanded', 'true');
     // eslint-disable-next-line @typescript-eslint/no-use-before-define
     list.addEventListener(clickEvent, sandboxClick, false);
     // eslint-disable-next-line @typescript-eslint/no-use-before-define
     window.addEventListener(clickEvent, clickOutside, false);
+
+    // The userbar has role=menu which means that the first link should be focused on popup
+    // For weird reasons shifting focus only works after some amount of delay
+    // Which is why we are forced to use setTimeout
+    setTimeout(() => {
+      list.querySelector('a').focus();
+    }, 300); // Less than 300ms doesn't seem to work
   }
 
   function hideUserbar() {
     userbar.classList.remove(className);
+    trigger.setAttribute('aria-expanded', 'false');
     // eslint-disable-next-line @typescript-eslint/no-use-before-define
     list.addEventListener(clickEvent, sandboxClick, false);
     // eslint-disable-next-line @typescript-eslint/no-use-before-define

--- a/client/src/entrypoints/admin/userbar.js
+++ b/client/src/entrypoints/admin/userbar.js
@@ -117,7 +117,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function handleKeyDown(event) {
     // Only handle keyboard input if the userbar is open
-    if (trigger.getAttribute('aria-expanded')) {
+    if (trigger.getAttribute('aria-expanded') === 'true') {
       if (event.key === 'Escape') {
         hideUserbar();
         setFocusToTrigger();

--- a/client/src/entrypoints/admin/userbar.js
+++ b/client/src/entrypoints/admin/userbar.js
@@ -5,13 +5,12 @@
 document.addEventListener('DOMContentLoaded', () => {
   const userbar = document.querySelector('[data-wagtail-userbar]');
   const trigger = userbar.querySelector('[data-wagtail-userbar-trigger]');
-  const list = userbar.querySelector('.wagtail-userbar-items');
+  const list = userbar.querySelector('[role=menu]');
   const listItems = list.querySelectorAll('li');
   const isActiveClass = 'is-active';
-  const clickEvent = 'click';
 
   // eslint-disable-next-line @typescript-eslint/no-use-before-define
-  trigger.addEventListener(clickEvent, toggleUserbar, false);
+  trigger.addEventListener('click', toggleUserbar, false);
 
   // make sure userbar is hidden when navigating back
   // eslint-disable-next-line @typescript-eslint/no-use-before-define
@@ -26,9 +25,9 @@ document.addEventListener('DOMContentLoaded', () => {
     userbar.classList.add(isActiveClass);
     trigger.setAttribute('aria-expanded', 'true');
     // eslint-disable-next-line @typescript-eslint/no-use-before-define
-    list.addEventListener(clickEvent, sandboxClick, false);
+    list.addEventListener('click', sandboxClick, false);
     // eslint-disable-next-line @typescript-eslint/no-use-before-define
-    window.addEventListener(clickEvent, clickOutside, false);
+    window.addEventListener('click', clickOutside, false);
 
     // The userbar has role=menu which means that the first link should be focused on popup
     // For weird reasons shifting focus only works after some amount of delay
@@ -44,9 +43,9 @@ document.addEventListener('DOMContentLoaded', () => {
     userbar.classList.remove(isActiveClass);
     trigger.setAttribute('aria-expanded', 'false');
     // eslint-disable-next-line @typescript-eslint/no-use-before-define
-    list.addEventListener(clickEvent, sandboxClick, false);
+    list.addEventListener('click', sandboxClick, false);
     // eslint-disable-next-line @typescript-eslint/no-use-before-define
-    window.removeEventListener(clickEvent, clickOutside, false);
+    window.removeEventListener('click', clickOutside, false);
   }
 
   function toggleUserbar(e2) {

--- a/client/src/entrypoints/admin/userbar.js
+++ b/client/src/entrypoints/admin/userbar.js
@@ -2,7 +2,7 @@
 // Please stick to old JS APIs and avoid importing anything that might require a vendored module
 // More background can be found in webpack.config.js
 
-document.addEventListener('DOMContentLoaded', (e) => {
+document.addEventListener('DOMContentLoaded', () => {
   const userbar = document.querySelector('[data-wagtail-userbar]');
   const trigger = userbar.querySelector('[data-wagtail-userbar-trigger]');
   const list = userbar.querySelector('.wagtail-userbar-items');
@@ -18,7 +18,45 @@ document.addEventListener('DOMContentLoaded', (e) => {
   window.addEventListener('pageshow', hideUserbar, false);
 
   // Listen for keyboard events
+  // eslint-disable-next-line @typescript-eslint/no-use-before-define
   window.addEventListener('keydown', handleKeyDown);
+
+
+  function showUserbar(shouldFocus) {
+    userbar.classList.add(isActiveClass);
+    trigger.setAttribute('aria-expanded', 'true');
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
+    list.addEventListener(clickEvent, sandboxClick, false);
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
+    window.addEventListener(clickEvent, clickOutside, false);
+
+    // The userbar has role=menu which means that the first link should be focused on popup
+    // For weird reasons shifting focus only works after some amount of delay
+    // Which is why we are forced to use setTimeout
+    if (shouldFocus) {
+      setTimeout(() => {
+        list.querySelector('a').focus();
+      }, 300); // Less than 300ms doesn't seem to work
+    }
+  }
+
+  function hideUserbar() {
+    userbar.classList.remove(isActiveClass);
+    trigger.setAttribute('aria-expanded', 'false');
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
+    list.addEventListener(clickEvent, sandboxClick, false);
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
+    window.removeEventListener(clickEvent, clickOutside, false);
+  }
+
+  function toggleUserbar(e2) {
+    e2.stopPropagation();
+    if (userbar.classList.contains(isActiveClass)) {
+      hideUserbar();
+    } else {
+      showUserbar(true);
+    }
+  }
 
   function setFocusToTrigger() {
     setTimeout(() => trigger.focus(), 300);
@@ -46,7 +84,7 @@ document.addEventListener('DOMContentLoaded', (e) => {
     if (listItems.length > 0) {
       setTimeout(() => {
         listItems[listItems.length - 1].firstElementChild.focus();
-      }, 100);  // Workaround for focus bug
+      }, 100); // Workaround for focus bug
     }
   }
 
@@ -73,14 +111,14 @@ document.addEventListener('DOMContentLoaded', (e) => {
             // Focus the previous item
             listItems[idx - 1].firstElementChild.focus();
           }
-        }, 100);  // Workaround for focus bug
+        }, 100); // Workaround for focus bug
       }
     });
   }
 
   function handleKeyDown(event) {
     // Only handle keyboard input if the userbar is open
-    if(userbar.classList.contains(isActiveClass)) {
+    if (userbar.classList.contains(isActiveClass)) {
       if (event.key === 'Escape') {
         // eslint-disable-next-line @typescript-eslint/no-use-before-define
         hideUserbar();
@@ -110,61 +148,24 @@ document.addEventListener('DOMContentLoaded', (e) => {
           break;
         }
       }
+      return;
     }
     // Check if the userbar is focused (but not open yet) and should be opened by keyboard input
-    else {
-      if(trigger === document.activeElement) {
-        switch (event.key) {
-          case "ArrowUp":
-            event.preventDefault();
-            showUserbar(false);
-            setTimeout(() => setFocusToFirstItem(), 300); // Workaround for focus bug
-            break;
-          case "ArrowDown":
-            event.preventDefault();
-            showUserbar(false);
-            setTimeout(() => setFocusToLastItem(), 300); // Workaround for focus bug
-            break;
-          default:
-            break;
-        }
+    if (trigger === document.activeElement) {
+      switch (event.key) {
+      case 'ArrowUp':
+        event.preventDefault();
+        showUserbar(false);
+        setTimeout(() => setFocusToFirstItem(), 300); // Workaround for focus bug
+        break;
+      case 'ArrowDown':
+        event.preventDefault();
+        showUserbar(false);
+        setTimeout(() => setFocusToLastItem(), 300); // Workaround for focus bug
+        break;
+      default:
+        break;
       }
-    }
-  }
-
-  function showUserbar(shouldFocus) {
-    userbar.classList.add(isActiveClass);
-    trigger.setAttribute('aria-expanded', 'true');
-    // eslint-disable-next-line @typescript-eslint/no-use-before-define
-    list.addEventListener(clickEvent, sandboxClick, false);
-    // eslint-disable-next-line @typescript-eslint/no-use-before-define
-    window.addEventListener(clickEvent, clickOutside, false);
-
-    // The userbar has role=menu which means that the first link should be focused on popup
-    // For weird reasons shifting focus only works after some amount of delay
-    // Which is why we are forced to use setTimeout
-    if(shouldFocus) {
-      setTimeout(() => {
-        list.querySelector('a').focus();
-      }, 300); // Less than 300ms doesn't seem to work
-    }
-  }
-
-  function hideUserbar() {
-    userbar.classList.remove(isActiveClass);
-    trigger.setAttribute('aria-expanded', 'false');
-    // eslint-disable-next-line @typescript-eslint/no-use-before-define
-    list.addEventListener(clickEvent, sandboxClick, false);
-    // eslint-disable-next-line @typescript-eslint/no-use-before-define
-    window.removeEventListener(clickEvent, clickOutside, false);
-  }
-
-  function toggleUserbar(e2) {
-    e2.stopPropagation();
-    if (userbar.classList.contains(isActiveClass)) {
-      hideUserbar();
-    } else {
-      showUserbar(true);
     }
   }
 

--- a/docs/reference/hooks.rst
+++ b/docs/reference/hooks.rst
@@ -817,7 +817,7 @@ Hooks for customising the way users are directed through the process of creating
     class UserbarPuppyLinkItem:
         def render(self, request):
             return '<li><a href="http://cuteoverload.com/tag/puppehs/" ' \
-                + 'target="_parent" class="action icon icon-wagtail">Puppies!</a></li>'
+                + 'target="_parent" role="menuitem" class="action icon icon-wagtail">Puppies!</a></li>'
 
     @hooks.register('construct_wagtail_userbar')
     def add_puppy_link_item(request, items):

--- a/docs/releases/2.14.rst
+++ b/docs/releases/2.14.rst
@@ -20,6 +20,7 @@ Other features
  * Added ``WAGTAIL_WORKFLOW_ENABLED`` setting for enabling / disabling moderation workflows globally (Matt Westcott)
  * Allow specifying ``max_width`` and ``max_height`` on EmbedBlock (Petr Dlouhý)
  * Add warning when StreamField is used without a StreamFieldPanel (Naomi Morduch Toubman)
+ * Added keyboard and screen reader support to Wagtail user bar (LB Johnston, Storm Heg)
 
 Bug fixes
 ~~~~~~~~~
@@ -44,3 +45,10 @@ Removed support for Django 2.2
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Django 2.2 is no longer supported as of this release; please upgrade to Django 3.0 or above before upgrading Wagtail.
+
+User bar with keyboard and screen reader support
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The Wagtail user bar (“edit bird”) widget now supports keyboard and screen reader navigation. To make the most of this, we now recommend placing the widget near the top of the page ``<body>``, so users can reach it without having to go through the whole page. See :ref:`wagtailuserbar_tag` for more information.
+
+For implementers of custom user bar menu items, we also now require the addition of ``role="menuitem"`` on the ``a`` element to provide the correct semantics. See :ref:`construct_wagtail_userbar` for more information.

--- a/docs/topics/writing_templates.rst
+++ b/docs/topics/writing_templates.rst
@@ -246,11 +246,22 @@ This tag provides a contextual flyout menu for logged-in users. The menu gives e
 
 This tag may be used on regular Django views, without page object. The user bar will contain one item pointing to the admin.
 
+We recommend putting the tag near the the top of the ``<body>`` element make to it easily discoverable for users using assistive technologies like screenreaders. You should consider putting the tag after any navigation and `skip links <https://webaim.org/techniques/skipnav/>`_ but before the main content of your page.
+
 .. code-block:: html+django
 
     {% load wagtailuserbar %}
     ...
-    {% wagtailuserbar %}
+    <body>
+      <a id="#content">Skip to content</a>
+      <nav>
+      ...
+      </nav>
+      {% wagtailuserbar %} {# This is a good place for the userbar #}
+      <main id="content>
+      ...
+      </main>
+    </body>
 
 By default the User Bar appears in the bottom right of the browser window, inset from the edge. If this conflicts with your design it can be moved by passing a parameter to the template tag. These examples show you how to position the userbar in each corner of the screen:
 

--- a/docs/topics/writing_templates.rst
+++ b/docs/topics/writing_templates.rst
@@ -246,7 +246,7 @@ This tag provides a contextual flyout menu for logged-in users. The menu gives e
 
 This tag may be used on regular Django views, without page object. The user bar will contain one item pointing to the admin.
 
-We recommend putting the tag near the top of the ``<body>`` element so keyboard users can reach it. You should consider putting the tag after any navigation and `skip links <https://webaim.org/techniques/skipnav/>`_ but before the main content of your page.
+We recommend putting the tag near the top of the ``<body>`` element so keyboard users can reach it. You should consider putting the tag after any `skip links <https://webaim.org/techniques/skipnav/>`_ but before the navigation and main content of your page.
 
 .. code-block:: html+django
 
@@ -254,11 +254,11 @@ We recommend putting the tag near the top of the ``<body>`` element so keyboard 
     ...
     <body>
       <a id="#content">Skip to content</a>
+      {% wagtailuserbar %} {# This is a good place for the userbar #}
       <nav>
       ...
       </nav>
-      {% wagtailuserbar %} {# This is a good place for the userbar #}
-      <main id="content>
+      <main id="content">
       ...
       </main>
     </body>

--- a/docs/topics/writing_templates.rst
+++ b/docs/topics/writing_templates.rst
@@ -246,7 +246,7 @@ This tag provides a contextual flyout menu for logged-in users. The menu gives e
 
 This tag may be used on regular Django views, without page object. The user bar will contain one item pointing to the admin.
 
-We recommend putting the tag near the the top of the ``<body>`` element make to it easily discoverable for users using assistive technologies like screenreaders. You should consider putting the tag after any navigation and `skip links <https://webaim.org/techniques/skipnav/>`_ but before the main content of your page.
+We recommend putting the tag near the top of the ``<body>`` element so keyboard users can reach it. You should consider putting the tag after any navigation and `skip links <https://webaim.org/techniques/skipnav/>`_ but before the main content of your page.
 
 .. code-block:: html+django
 

--- a/wagtail/admin/static_src/wagtailadmin/scss/userbar.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/userbar.scss
@@ -124,6 +124,7 @@ $positions: (
     margin: 0 !important;
     overflow: hidden;
     background-color: $color-white;
+    border: 2px solid transparent;
     border-radius: 50%;
     color: $color-black;
     padding: 0 !important;
@@ -150,6 +151,11 @@ $positions: (
         font-size: 32px;
         width: auto;
         margin: 0;
+    }
+
+    &:focus {
+        border-color: $color-black;
+        outline: none;
     }
 }
 
@@ -242,9 +248,12 @@ $positions: (
 
         &:hover,
         &:focus {
-            outline: none;
             color: $color-white;
             background-color: rgba(100, 100, 100, 0.15);
+        }
+
+        &:focus {
+            outline: $color-white 2px solid;
         }
 
         &-icon {

--- a/wagtail/admin/static_src/wagtailadmin/scss/userbar.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/userbar.scss
@@ -116,6 +116,7 @@ $positions: (
 
 // stylelint-disable declaration-no-important
 .#{$namespace}-userbar-trigger {
+    all: initial;
     display: flex;
     align-items: center;
     justify-content: center;

--- a/wagtail/admin/static_src/wagtailadmin/scss/userbar.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/userbar.scss
@@ -159,7 +159,7 @@ $positions: (
         margin: 0;
     }
 
-    &:focus {
+    &:focus-visible {
         outline: auto;
         outline-offset: 5px;
     }

--- a/wagtail/admin/static_src/wagtailadmin/scss/userbar.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/userbar.scss
@@ -154,9 +154,8 @@ $positions: (
         margin: 0;
     }
 
-    &:focus-visible {
-        outline: auto;
-        outline-offset: 5px;
+    &:focus {
+        outline: $color-focus-outline solid 3px;
     }
 }
 
@@ -254,7 +253,7 @@ $positions: (
         }
 
         &:focus {
-            outline: $color-white 2px solid;
+            outline: $color-focus-outline solid 3px;
         }
 
         &-icon {

--- a/wagtail/admin/static_src/wagtailadmin/scss/userbar.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/userbar.scss
@@ -136,11 +136,6 @@ $positions: (
     text-decoration: none !important;
     position: relative;
 
-    .#{$namespace}-userbar.touch.is-active &,
-    .#{$namespace}-userbar.no-touch &:hover {
-        box-shadow: $box-shadow-props, 0 3px 15px 0 rgba(107, 214, 230, 0.95);
-    }
-
     .#{$namespace}-userbar-help-text {
         // Visually hide the help text
         clip: rect(0 0 0 0);

--- a/wagtail/admin/static_src/wagtailadmin/scss/userbar.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/userbar.scss
@@ -142,9 +142,14 @@ $positions: (
     }
 
     .#{$namespace}-userbar-help-text {
+        // Visually hide the help text
+        clip: rect(0 0 0 0);
+        clip-path: inset(50%);
+        height: 1px;
+        overflow: hidden;
         position: absolute;
-        top: 100%;
-        left: 0;
+        white-space: nowrap;
+        width: 1px;
     }
 
     .#{$namespace}-icon:before {

--- a/wagtail/admin/static_src/wagtailadmin/scss/userbar.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/userbar.scss
@@ -160,6 +160,7 @@ $positions: (
 }
 
 .#{$namespace}-userbar-items {
+    all: revert;
     display: block;
     list-style: none;
     position: absolute;
@@ -188,7 +189,7 @@ $positions: (
     transition-duration: 0.15s;
     transition-timing-function: cubic-bezier(0.55, 0, 0.1, 1);
 
-    // TODO: disable stylelint warning in upstream package
+    // stylelint-disable-next-line scss/media-feature-value-dollar-variable
     @media (prefers-reduced-motion: reduce) {
         transition: none !important;
     }
@@ -216,6 +217,7 @@ $positions: (
 
 
 .#{$namespace}-userbar__item {
+    all: revert;
     margin: 0;
     background-color: $color-grey-1;
     opacity: 0;
@@ -226,7 +228,7 @@ $positions: (
     font-size: 16px !important;
     text-decoration: none !important;
 
-    // TODO: disable stylelint warning in upstream package
+    // stylelint-disable-next-line scss/media-feature-value-dollar-variable
     @media (prefers-reduced-motion: reduce) {
         transition: none !important;
 

--- a/wagtail/admin/static_src/wagtailadmin/scss/userbar.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/userbar.scss
@@ -155,8 +155,7 @@ $positions: (
     }
 
     &:focus {
-        border-color: $color-black;
-        outline: none;
+        outline: 5px auto -webkit-focus-ring-color;
     }
 }
 

--- a/wagtail/admin/static_src/wagtailadmin/scss/userbar.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/userbar.scss
@@ -160,7 +160,8 @@ $positions: (
     }
 
     &:focus {
-        outline: 5px auto -webkit-focus-ring-color;
+        outline: auto;
+        outline-offset: 5px;
     }
 }
 

--- a/wagtail/admin/static_src/wagtailadmin/scss/userbar.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/userbar.scss
@@ -188,6 +188,11 @@ $positions: (
     transition-duration: 0.15s;
     transition-timing-function: cubic-bezier(0.55, 0, 0.1, 1);
 
+    // TODO: disable stylelint warning in upstream package
+    @media (prefers-reduced-motion: reduce) {
+        transition: none !important;
+    }
+
     .#{$namespace}-userbar.is-active & {
         opacity: 1;
         transform: translateY(0);
@@ -220,6 +225,14 @@ $positions: (
     font-family: 'Open Sans', sans-serif;
     font-size: 16px !important;
     text-decoration: none !important;
+
+    // TODO: disable stylelint warning in upstream package
+    @media (prefers-reduced-motion: reduce) {
+        transition: none !important;
+
+        // Force disable transitions for all items
+        transition-delay: 0s !important;
+    }
 
     &:first-child {
         border-top-left-radius: $userbar-radius;

--- a/wagtail/admin/templates/wagtailadmin/userbar/base.html
+++ b/wagtail/admin/templates/wagtailadmin/userbar/base.html
@@ -24,7 +24,7 @@
                 {% endblock %}
                 <span class="wagtail-userbar-help-text">{% trans 'View Wagtail quick actions' %}</span>
             </button>
-            <ul aria-labelledby="wagtail-userbar-trigger" class="wagtail-userbar-items" role="menu">
+            <ul aria-labelledby="wagtail-userbar-trigger" class="wagtail-userbar-items" id="wagtail-userbar-items" role="menu">
                 {% for item in items %}
                     {{ item|safe }}
                 {% endfor %}

--- a/wagtail/admin/templates/wagtailadmin/userbar/base.html
+++ b/wagtail/admin/templates/wagtailadmin/userbar/base.html
@@ -4,7 +4,7 @@
     <div class="wagtail-userbar wagtail-userbar--{{ position|default:'bottom-right' }}" data-wagtail-userbar>
         <link rel="stylesheet" href="{% versioned_static 'wagtailadmin/css/userbar.css' %}" type="text/css" />
         <div class="wagtail-userbar-nav">
-            <div class="wagtail-userbar-trigger" data-wagtail-userbar-trigger>
+            <button aria-controls="wagtail-userbar-items" aria-haspopup="true" class="wagtail-userbar-trigger" id="wagtail-userbar-trigger" data-wagtail-userbar-trigger>
                 {% block branding_logo %}
                   <div style="display: none">
                     <svg>
@@ -22,13 +22,13 @@
                     <use href="#icon-wagtail-icon"></use>
                   </svg>
                 {% endblock %}
-                <span class="wagtail-userbar-help-text">{% trans 'Go to Wagtail admin interface' %}</span>
-            </div>
-            <div class='wagtail-userbar-items'>
+                <span class="wagtail-userbar-help-text">{% trans 'View Wagtail quick actions' %}</span>
+            </button>
+            <ul aria-labelledby="wagtail-userbar-trigger" class="wagtail-userbar-items" role="menu">
                 {% for item in items %}
                     {{ item|safe }}
                 {% endfor %}
-            </div>
+            </ul>
         </div>
         <script src="{% versioned_static 'wagtailadmin/js/userbar.js' %}"></script>
     </div>

--- a/wagtail/admin/templates/wagtailadmin/userbar/item_admin.html
+++ b/wagtail/admin/templates/wagtailadmin/userbar/item_admin.html
@@ -2,10 +2,8 @@
 {% load i18n wagtailadmin_tags %}
 
 {% block item_content %}
-    <div class="wagtail-action">
-        <a href="{% url 'wagtailadmin_home' %}" target="_parent" class="wagtail-userbar-link" role="menuitem">
-          {% icon name="wagtail-icon" class_name="wagtail-action-icon" %}
-          {% trans 'Go to Wagtail admin' %}
-        </a>
-    </div>
+    <a href="{% url 'wagtailadmin_home' %}" target="_parent" class="wagtail-userbar-link" role="menuitem">
+        {% icon name="wagtail-icon" class_name="wagtail-action-icon" %}
+        {% trans 'Go to Wagtail admin' %}
+    </a>
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/userbar/item_admin.html
+++ b/wagtail/admin/templates/wagtailadmin/userbar/item_admin.html
@@ -3,7 +3,7 @@
 
 {% block item_content %}
     <div class="wagtail-action">
-        <a href="{% url 'wagtailadmin_home' %}" target="_parent">
+        <a href="{% url 'wagtailadmin_home' %}" target="_parent" class="wagtail-userbar-link" role="menuitem">
           {% icon name="wagtail-icon" class_name="wagtail-action-icon" %}
           {% trans 'Go to Wagtail admin' %}
         </a>

--- a/wagtail/admin/templates/wagtailadmin/userbar/item_base.html
+++ b/wagtail/admin/templates/wagtailadmin/userbar/item_base.html
@@ -1,1 +1,3 @@
-<div class="wagtail-userbar__item {% block item_classes %}{% endblock %}">{% block item_content %}{% endblock %}</div>
+<li class="wagtail-userbar__item {% block item_classes %}{% endblock %}"  role="presentation">
+    {% block item_content %}{% endblock %}
+</li>

--- a/wagtail/admin/templates/wagtailadmin/userbar/item_base.html
+++ b/wagtail/admin/templates/wagtailadmin/userbar/item_base.html
@@ -1,3 +1,3 @@
-<li class="wagtail-userbar__item {% block item_classes %}{% endblock %}"  role="presentation">
+<li class="wagtail-userbar__item {% block item_classes %}{% endblock %}" role="presentation">
     {% block item_content %}{% endblock %}
 </li>

--- a/wagtail/admin/templates/wagtailadmin/userbar/item_page_add.html
+++ b/wagtail/admin/templates/wagtailadmin/userbar/item_page_add.html
@@ -2,10 +2,8 @@
 {% load i18n wagtailadmin_tags %}
 
 {% block item_content %}
-    <div class="wagtail-action">
-        <a href="{% url 'wagtailadmin_pages:add_subpage' self.page.id %}" target="_parent" role="menuitem">
-          {% icon name="plus" class_name="wagtail-action-icon" %}
-          {% trans 'Add a child page' %}
-        </a>
-    </div>
+    <a href="{% url 'wagtailadmin_pages:add_subpage' self.page.id %}" target="_parent" role="menuitem">
+      {% icon name="plus" class_name="wagtail-action-icon" %}
+      {% trans 'Add a child page' %}
+    </a>
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/userbar/item_page_add.html
+++ b/wagtail/admin/templates/wagtailadmin/userbar/item_page_add.html
@@ -3,7 +3,7 @@
 
 {% block item_content %}
     <div class="wagtail-action">
-        <a href="{% url 'wagtailadmin_pages:add_subpage' self.page.id %}" target="_parent">
+        <a href="{% url 'wagtailadmin_pages:add_subpage' self.page.id %}" target="_parent" role="menuitem">
           {% icon name="plus" class_name="wagtail-action-icon" %}
           {% trans 'Add a child page' %}
         </a>

--- a/wagtail/admin/templates/wagtailadmin/userbar/item_page_approve.html
+++ b/wagtail/admin/templates/wagtailadmin/userbar/item_page_approve.html
@@ -4,11 +4,9 @@
 {% block item_content %}
     <form action="{% url 'wagtailadmin_pages:approve_moderation' self.revision.id %}" target="_parent" method="post">
         {% csrf_token %}
-        <div class="wagtail-action">
-          <button type="submit" value="{% trans 'Approve' %}" class="button" role="menuitem">
-            {% icon name="tick" class_name="wagtail-action-icon" %}
-            {% trans 'Approve' %}
-          </button>
-        </div>
+        <button type="submit" value="{% trans 'Approve' %}" class="button" role="menuitem">
+          {% icon name="tick" class_name="wagtail-action-icon" %}
+          {% trans 'Approve' %}
+        </button>
     </form>
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/userbar/item_page_approve.html
+++ b/wagtail/admin/templates/wagtailadmin/userbar/item_page_approve.html
@@ -5,7 +5,7 @@
     <form action="{% url 'wagtailadmin_pages:approve_moderation' self.revision.id %}" target="_parent" method="post">
         {% csrf_token %}
         <div class="wagtail-action">
-          <button type="submit" value="{% trans 'Approve' %}" class="button">
+          <button type="submit" value="{% trans 'Approve' %}" class="button" role="menuitem">
             {% icon name="tick" class_name="wagtail-action-icon" %}
             {% trans 'Approve' %}
           </button>

--- a/wagtail/admin/templates/wagtailadmin/userbar/item_page_edit.html
+++ b/wagtail/admin/templates/wagtailadmin/userbar/item_page_edit.html
@@ -3,7 +3,7 @@
 
 {% block item_content %}
     <div class="wagtail-action">
-        <a href="{% url 'wagtailadmin_pages:edit' self.page.id %}" target="_parent">
+        <a href="{% url 'wagtailadmin_pages:edit' self.page.id %}" target="_parent" role="menuitem">
           {% icon name="edit" class_name="wagtail-action-icon" %}
           {% trans 'Edit this page' %}
         </a>

--- a/wagtail/admin/templates/wagtailadmin/userbar/item_page_edit.html
+++ b/wagtail/admin/templates/wagtailadmin/userbar/item_page_edit.html
@@ -2,10 +2,8 @@
 {% load i18n wagtailadmin_tags %}
 
 {% block item_content %}
-    <div class="wagtail-action">
-        <a href="{% url 'wagtailadmin_pages:edit' self.page.id %}" target="_parent" role="menuitem">
-          {% icon name="edit" class_name="wagtail-action-icon" %}
-          {% trans 'Edit this page' %}
-        </a>
-    </div>
+    <a href="{% url 'wagtailadmin_pages:edit' self.page.id %}" target="_parent" role="menuitem">
+      {% icon name="edit" class_name="wagtail-action-icon" %}
+      {% trans 'Edit this page' %}
+    </a>
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/userbar/item_page_explore.html
+++ b/wagtail/admin/templates/wagtailadmin/userbar/item_page_explore.html
@@ -3,7 +3,7 @@
 
 {% block item_content %}
     <div class="wagtail-action">
-        <a href="{% url 'wagtailadmin_explore' self.parent_page.id %}" target="_parent">
+        <a href="{% url 'wagtailadmin_explore' self.parent_page.id %}" target="_parent" role="menuitem">
           {% icon name="folder-open-inverse" class_name="wagtail-action-icon" %}
           {% trans 'Show in Explorer' %}
         </a>

--- a/wagtail/admin/templates/wagtailadmin/userbar/item_page_explore.html
+++ b/wagtail/admin/templates/wagtailadmin/userbar/item_page_explore.html
@@ -2,10 +2,8 @@
 {% load i18n wagtailadmin_tags %}
 
 {% block item_content %}
-    <div class="wagtail-action">
-        <a href="{% url 'wagtailadmin_explore' self.parent_page.id %}" target="_parent" role="menuitem">
-          {% icon name="folder-open-inverse" class_name="wagtail-action-icon" %}
-          {% trans 'Show in Explorer' %}
-        </a>
-    </div>
+    <a href="{% url 'wagtailadmin_explore' self.parent_page.id %}" target="_parent" role="menuitem">
+      {% icon name="folder-open-inverse" class_name="wagtail-action-icon" %}
+      {% trans 'Show in Explorer' %}
+    </a>
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/userbar/item_page_reject.html
+++ b/wagtail/admin/templates/wagtailadmin/userbar/item_page_reject.html
@@ -5,7 +5,7 @@
     <form action="{% url 'wagtailadmin_pages:reject_moderation' self.revision.id %}" target="_parent" method="post">
         {% csrf_token %}
         <div class="wagtail-action">
-          <button type="submit" value="{% trans 'Reject' %}" class="button">
+          <button type="submit" value="{% trans 'Reject' %}" class="button" role="menuitem">
             {% icon name="cross" class_name="wagtail-action-icon" %}
             {% trans 'Reject' %}
           </button>

--- a/wagtail/admin/templates/wagtailadmin/userbar/item_page_reject.html
+++ b/wagtail/admin/templates/wagtailadmin/userbar/item_page_reject.html
@@ -4,11 +4,9 @@
 {% block item_content %}
     <form action="{% url 'wagtailadmin_pages:reject_moderation' self.revision.id %}" target="_parent" method="post">
         {% csrf_token %}
-        <div class="wagtail-action">
-          <button type="submit" value="{% trans 'Reject' %}" class="button" role="menuitem">
-            {% icon name="cross" class_name="wagtail-action-icon" %}
-            {% trans 'Reject' %}
-          </button>
-        </div>
+        <button type="submit" value="{% trans 'Reject' %}" class="button" role="menuitem">
+          {% icon name="cross" class_name="wagtail-action-icon" %}
+          {% trans 'Reject' %}
+        </button>
     </form>
 {% endblock %}

--- a/wagtail/admin/tests/test_userbar.py
+++ b/wagtail/admin/tests/test_userbar.py
@@ -111,7 +111,7 @@ class TestUserbarAddLink(TestCase, WagtailTestUtils):
         # page allows subpages, so the 'add page' button should show
         expected_url = reverse('wagtailadmin_pages:add_subpage', args=(self.event_index.id, ))
         needle = f"""
-            <a href="{expected_url}" target="_parent">
+            <a href="{expected_url}" target="_parent" role="menuitem">
                 <svg class="icon icon-plus wagtail-action-icon" aria-hidden="true" focusable="false">
                     <use href="#icon-plus"></use>
                 </svg>


### PR DESCRIPTION
Based on work done by @lb- [here](https://github.com/wagtail/wagtail/issues/6108#issuecomment-638474271). Thanks LB! :pray: 

This will make the userbar accessible for users who navigate by keyboard and / or rely on screenreaders.

**Overview of changes**
* Make userbar trigger a `<button>` element for proper semantics and to allow it to be focused by keyboard.
* Use a more appropriate label for the trigger to make it clearer that it is a menu.
* Use outlines and borders to indicate the focused element. For example, the round trigger button will now have a yellow (/ orange?) outline when focused: 
![image](https://user-images.githubusercontent.com/13856515/122641824-e90f4380-d107-11eb-9a28-10a6211a0d49.png)

* Improve screen reader performance by hinting that the userbar is a menu.
* Opening the userbar will focus the first menu item. This is desired behaviour.
* Removed the touch detection code. It's quite old and no longer necessary. It caused the userbar to immediately close after activating it on mobile devices.

**Notes**
- Tested on:
   - NVDA 2020.4, Firefox 87 on Windows 10 :heavy_check_mark: 
   - VoiceOver on iPad (iPadOS 14.4) :heavy_check_mark: 
   - Edge 90 narrator on Windows 10 (using BrowserStack) :heavy_check_mark: 
   - VoiceOver, Safari 14 on macOS 'Big Sur' (using BrowserStack) :heavy_check_mark: 
   - TalkBack, Chrome 90 on Android 11 :heavy_check_mark: 
   - Internet Explorer 11 on Windows 10 (using BrowserStack) :no_entry_sign: _does not work on IE11!_
- There is some weirdness where setting focus using `myElement.focus()` does not work. Managed to get this working using setTimeout ~but not verified with other browsers~.
- This does not support IE11 but that's okay because [Wagtail 2.14 is dropping IE11 support completely](https://docs.wagtail.io/en/stable/editor_manual/browser_issues.html#ie11). For reference: incompatibility is mostly around  [`NodeList.forEach`](https://developer.mozilla.org/en-US/docs/Web/API/NodeList/forEach#browser_compatibility) and [`KeyboardEvent.key`](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key#browser_compatibility)
- I have changed the trigger label text to 'View Wagtail quick actions' instead of 'go to wagtail admin interface' because activating the trigger will open a menu, not take you to the admin. _Is this new label okay or could it be better?_

**Todo**

~This PR is not done yet - I intend to further improve keyboard support as described in the [W3 WAI actions menu button example](https://www.w3.org/TR/wai-aria-practices/examples/menu-button/menu-button-actions.html).~ _Done_ :heavy_check_mark: 

- [x] `Enter` and `Space` to open the menu.
- [x] `Escape` will close the menu and set focus to the trigger button.
- [x] `Up Arrow` to open menu and focus last menu item.
- [x] `Down Arrow` to open menu and focus first menu item.
- [x] `Up Arrow` and  `Down Arrow` to move focus between menu items when menu is opened.
- [x] `Home` focus first menu item if menu is open.
- [x] `End` focus first menu item if menu is open.
- [x] ~(possibly if good idea?) Focus menu item by pressing it's number on the keyboard. First menu item would be 1 etc.~ _Decided not to do this as the order of menu items is not fixed. There may be additional menu items depending on the context which would be confusing._

