### PR TITLE
Fix wagtailembeds thumbnail_url migration for MySQL 8.0.13

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -125,7 +125,7 @@ jobs:
 
     services:
       mysql:
-        image: mysql:5.7
+        image: mysql:8.0.23
         env:
           MYSQL_ALLOW_EMPTY_PASSWORD: yes
           MYSQL_DATABASE: wagtail

--- a/wagtail/embeds/migrations/0008_allow_long_urls.py
+++ b/wagtail/embeds/migrations/0008_allow_long_urls.py
@@ -24,13 +24,24 @@ class Migration(migrations.Migration):
             name="url",
             field=models.TextField(),
         ),
+        # Converting URLField to TextField with a default specified (even with preserve_default=False)
+        # fails with Django 3.0 and MySQL >=8.0.13 (see https://code.djangoproject.com/ticket/32503) -
+        # work around this by altering in two stages, first making the URLField non-null then converting
+        # to TextField
+        migrations.AlterField(
+            model_name="embed",
+            name="thumbnail_url",
+            field=models.URLField(
+                blank=True,
+                default="",
+            ),
+            preserve_default=False,
+        ),
         migrations.AlterField(
             model_name="embed",
             name="thumbnail_url",
             field=models.TextField(
                 blank=True,
-                default="",
             ),
-            preserve_default=False,
         ),
     ]


### PR DESCRIPTION
Fixes #6836 

An unresolved issue in Django >=3.0 https://code.djangoproject.com/ticket/32503 causes the conversion of Embed.thumbnail_url from URLField to TextField to fail on MySQL 8.0.13 and above. This can be worked around by splitting the AlterField operation into two stages: first drop the null=True while it's still a URLField, then convert to TextField.

To confirm that databases are OK with multiple AlterField operations on the same field in a single migration, I successfully tested it against sqlite, mysql and postgres with the following procedure:

* Create a wagtail project with `wagtail start`, with `stable/2.11.x` checked out, and set the DATABASES setting appropriately
* `./manage.py migrate`
* Within `./manage.py shell`, add a record to the embeds table as follows:

      from wagtail.embeds.embeds import get_embed
      ebd = get_embed('https://www.youtube.com/watch?v=97xfV6yXcrk')

* Switch to this `admin/mysql-8` branch and run `./manage.py migrate`
* From `./manage.py dbshell`, verify that the record still exists in `wagtailembeds_embed` and that `thumbnail_url` is now a TEXT field