### PR TITLE
Commenting: refactoring

### DIFF
--- a/client/src/components/CommentApp/comments.js
+++ b/client/src/components/CommentApp/comments.js
@@ -1,29 +1,35 @@
 import { initCommentApp } from './main';
 import { STRINGS } from '../../config/wagtailConfig';
 
-function initComments() {
+function initComments(formElem) {
   window.commentApp = initCommentApp();
-  document.addEventListener('DOMContentLoaded', () => {
-    const commentsElement = document.getElementById('comments');
-    const commentsOutputElement = document.getElementById('comments-output');
-    const dataElement = document.getElementById('comments-data');
-    if (!commentsElement || !commentsOutputElement || !dataElement) {
-      throw new Error('Comments app failed to initialise. Missing HTML element');
-    }
-    const data = JSON.parse(dataElement.textContent);
-    window.commentApp.renderApp(
-      commentsElement, commentsOutputElement, data.user, data.comments, new Map(Object.entries(data.authors)), STRINGS
-    );
-  });
-}
 
-function attachTabNav(tabNavElem) {
-  // Attaches the commenting app to the given tab navigation element
-  window.commentApp.setCurrentTab(tabNavElem.dataset.currentTab);
+  // Attach the tab navigation, if the form has it
+  const tabNavElem = formElem.querySelector('.tab-nav');
+  if (tabNavElem) {
+    window.commentApp.setCurrentTab(tabNavElem.dataset.currentTab);
+    tabNavElem.addEventListener('switch', (e) => {
+      window.commentApp.setCurrentTab(e.detail.tab);
+    });
+  }
 
-  tabNavElem.addEventListener('switch', (e) => {
-    window.commentApp.setCurrentTab(e.detail.tab);
-  });
+  // Render the comments overlay
+  const commentsElement = document.getElementById('comments');
+  const commentsOutputElement = document.getElementById('comments-output');
+  const dataElement = document.getElementById('comments-data');
+  if (!commentsElement || !commentsOutputElement || !dataElement) {
+    throw new Error('Comments app failed to initialise. Missing HTML element');
+  }
+  const data = JSON.parse(dataElement.textContent);
+  window.commentApp.renderApp(
+    commentsElement, commentsOutputElement, data.user, data.comments, new Map(Object.entries(data.authors)), STRINGS
+  );
+
+  // Initialise annotations
+  // eslint-disable-next-line @typescript-eslint/no-use-before-define
+  formElem.querySelectorAll('[data-comment-add]').forEach(initAddCommentButton);
+
+  return window.commentApp;
 }
 
 export function getContentPath(fieldNode) {
@@ -245,5 +251,4 @@ export function initAddCommentButton(buttonElement) {
 export default {
   getContentPath,
   initComments,
-  attachTabNav,
 };

--- a/client/src/components/CommentApp/comments.js
+++ b/client/src/components/CommentApp/comments.js
@@ -29,6 +29,40 @@ function initComments(formElem) {
   // eslint-disable-next-line @typescript-eslint/no-use-before-define
   formElem.querySelectorAll('[data-comment-add]').forEach(initAddCommentButton);
 
+  // Initialise comments toggle
+  const commentsToggleElem = formElem.querySelector('.comments-toggle input[type=checkbox]');
+  const commentNotificationsToggleElem = formElem.querySelector('.comment-notifications-toggle');
+  const tabContentElem = formElem.querySelector('.tab-content');
+  commentsToggleElem.addEventListener('change', (e) => {
+    // Show/hide comments
+    window.commentApp.setVisible(e.target.checked);
+
+    // Show/hide comment notifications toggle
+    // Add/Remove tab-nav--comments-enabled class. This changes the size of streamfields
+    if (e.target.checked) {
+      $(commentNotificationsToggleElem).show();
+      tabContentElem.classList.add('tab-content--comments-enabled');
+    } else {
+      $(commentNotificationsToggleElem).hide();
+      tabContentElem.classList.remove('tab-content--comments-enabled');
+    }
+  });
+
+  // Keep number of comments up to date with comment app
+  const commentCountElem = formElem.querySelector('.comments-toggle__count');
+  const updateCommentCount = () => {
+    const commentCount = window.commentApp.selectors.selectCommentCount(window.commentApp.store.getState());
+
+    if (commentCount > 0) {
+      commentCountElem.innerText = commentCount.toString();
+    } else {
+      // Note: CSS will hide the circle when its content is empty
+      commentCountElem.innerText = '';
+    }
+  };
+  window.commentApp.store.subscribe(updateCommentCount);
+  updateCommentCount();
+
   return window.commentApp;
 }
 

--- a/client/src/components/CommentApp/comments.js
+++ b/client/src/components/CommentApp/comments.js
@@ -284,7 +284,23 @@ class FieldLevelCommentWidget {
   }
 }
 
-export function initAddCommentButton(buttonElement) {
+const initialisedAddCommentButtons = new Set();
+
+export function initAddCommentButton(buttonElement, skipDoubleInitialisedCheck = false) {
+  // Prevent double-initialisation of the same add button
+  if (!skipDoubleInitialisedCheck) {
+    if (initialisedAddCommentButtons.has(buttonElement)) {
+      return;
+    }
+    initialisedAddCommentButtons.add(buttonElement);
+  }
+
+  // If comment system not loaded yet, create a listener to set up this button when it loads
+  if (!window.commentApp) {
+    addOnInitCommentAppListener(() => initAddCommentButton(buttonElement, true));
+    return;
+  }
+
   const widget = new FieldLevelCommentWidget({
     fieldNode: buttonElement,
     commentAdditionNode: buttonElement,
@@ -300,4 +316,5 @@ export default {
   getContentPath,
   initComments,
   addOnInitCommentAppListener,
+  initAddCommentButton,
 };

--- a/client/src/components/CommentApp/comments.js
+++ b/client/src/components/CommentApp/comments.js
@@ -1,6 +1,8 @@
 import { initCommentApp } from './main';
 import { STRINGS } from '../../config/wagtailConfig';
 
+const onInitCommentAppListeners = [];
+
 function initComments(formElem) {
   window.commentApp = initCommentApp();
 
@@ -63,7 +65,19 @@ function initComments(formElem) {
   window.commentApp.store.subscribe(updateCommentCount);
   updateCommentCount();
 
+  // Run init event listeners
+  onInitCommentAppListeners.forEach(listener => listener(window.commentApp));
+
   return window.commentApp;
+}
+
+function addOnInitCommentAppListener(listener) {
+  onInitCommentAppListeners.push(listener);
+
+  // Call the listener immediately if the comment app is already initialised
+  if (window.commentApp) {
+    listener(window.commentApp);
+  }
 }
 
 export function getContentPath(fieldNode) {
@@ -285,4 +299,5 @@ export function initAddCommentButton(buttonElement) {
 export default {
   getContentPath,
   initComments,
+  addOnInitCommentAppListener,
 };

--- a/client/src/components/CommentApp/comments.js
+++ b/client/src/components/CommentApp/comments.js
@@ -312,9 +312,16 @@ export function initAddCommentButton(buttonElement, skipDoubleInitialisedCheck =
   }
 }
 
+function invalidateContentPath(contentPath) {
+  if (window.commentApp) {
+    window.commentApp.invalidateContentPath(contentPath);
+  }
+}
+
 export default {
   getContentPath,
   initComments,
   addOnInitCommentAppListener,
   initAddCommentButton,
+  invalidateContentPath,
 };

--- a/client/src/components/CommentApp/comments.js
+++ b/client/src/components/CommentApp/comments.js
@@ -230,10 +230,10 @@ class FieldLevelCommentWidget {
   }
 }
 
-function initFieldLevelCommentWidget(fieldElement) {
+export function initAddCommentButton(buttonElement) {
   const widget = new FieldLevelCommentWidget({
-    fieldNode: fieldElement,
-    commentAdditionNode: fieldElement.querySelector('[data-comment-add]'),
+    fieldNode: buttonElement,
+    commentAdditionNode: buttonElement,
     annotationTemplateNode: document.querySelector('#comment-icon'),
     commentApp: window.commentApp
   });
@@ -246,6 +246,4 @@ export default {
   getContentPath,
   initComments,
   attachTabNav,
-  FieldLevelCommentWidget,
-  initFieldLevelCommentWidget
 };

--- a/client/src/components/Draftail/index.js
+++ b/client/src/components/Draftail/index.js
@@ -126,24 +126,37 @@ const initEditor = (selector, options, currentScript) => {
   };
 
   // If the field has a valid contentpath - ie is not an InlinePanel or under a ListBlock -
-  // and the comments system is initialized then use CommentableEditor, otherwise plain DraftailEditor
-  const editor = (window.commentApp && contentPath !== '') ?
-    <Provider store={window.commentApp.store}>
-      <CommentableEditor
-        editorRef={editorRef}
-        commentApp={window.commentApp}
-        fieldNode={field.parentNode}
-        contentPath={contentPath}
-        colorConfig={colors}
-        {...sharedProps}
-      />
-    </Provider>
-    : <DraftailEditor
-      ref={editorRef}
-      {...sharedProps}
-    />;
-
-  ReactDOM.render(<EditorFallback field={field}>{editor}</EditorFallback>, editorWrapper);
+  // and the comments module has been loaded then use CommentableEditor, otherwise plain DraftailEditor
+  if (window.comments && contentPath !== '') {
+    window.comments.addOnInitCommentAppListener((commentApp) => {
+      ReactDOM.render(
+        <EditorFallback field={field}>
+          <Provider store={commentApp.store}>
+            <CommentableEditor
+              editorRef={editorRef}
+              commentApp={commentApp}
+              fieldNode={field.parentNode}
+              contentPath={contentPath}
+              colorConfig={colors}
+              {...sharedProps}
+            />
+          </Provider>
+        </EditorFallback>,
+        editorWrapper
+      );
+    });
+  } else {
+    // Render plain DraftailEditor
+    ReactDOM.render(
+      <EditorFallback field={field}>
+        <DraftailEditor
+          ref={editorRef}
+          {...sharedProps}
+        />
+      </EditorFallback>,
+      editorWrapper
+    );
+  }
 };
 
 export default {

--- a/client/src/components/StreamField/blocks/BaseSequenceBlock.js
+++ b/client/src/components/StreamField/blocks/BaseSequenceBlock.js
@@ -129,8 +129,8 @@ export class BaseSequenceChild {
     // Inform the comment app that the content path of this block is no longer valid
     // This will hide any comments that were previously on the block
     const contentPath = getContentPath(this.element);
-    if (contentPath && window.commentApp) {
-      window.commentApp.invalidateContentPath(contentPath);
+    if (contentPath && window.comments) {
+      window.comments.invalidateContentPath(contentPath);
     }
   }
 

--- a/client/src/components/StreamField/blocks/FieldBlock.js
+++ b/client/src/components/StreamField/blocks/FieldBlock.js
@@ -41,6 +41,18 @@ export class FieldBlock {
       this.element.querySelector('.field-content').appendChild(helpElement);
     }
 
+    if (window.comments && this.blockDef.meta.showAddCommentButton) {
+      const addCommentButtonElement = document.createElement('button');
+      addCommentButtonElement.type = 'button';
+      addCommentButtonElement.setAttribute('aria-label', blockDef.meta.strings.ADD_COMMENT);
+      addCommentButtonElement.classList.add('button');
+      addCommentButtonElement.classList.add('button-secondary');
+      addCommentButtonElement.classList.add('button-small');
+      addCommentButtonElement.innerHTML = '<svg class="icon icon-comment initial" aria-hidden="true" focusable="false"><use href="#icon-comment"></use></svg>';
+      this.element.querySelector('.field-content').appendChild(addCommentButtonElement);
+      window.comments.initAddCommentButton(addCommentButtonElement);
+    }
+
     if (initialError) {
       this.setError(initialError);
     }

--- a/client/src/components/StreamField/blocks/FieldBlock.test.js
+++ b/client/src/components/StreamField/blocks/FieldBlock.test.js
@@ -110,6 +110,52 @@ describe('telepath: wagtail.blocks.FieldBlock', () => {
   });
 });
 
+describe('telepath: wagtail.blocks.FieldBlock with comments enabled', () => {
+  let boundBlock;
+
+  window.comments = {
+    initAddCommentButton: jest.fn(),
+  };
+
+  beforeEach(() => {
+    // Create mocks for callbacks
+    constructor = jest.fn();
+    setState = jest.fn();
+    getState = jest.fn();
+    getValue = jest.fn();
+    focus = jest.fn();
+
+    // Define a test block
+    const blockDef = new FieldBlockDefinition(
+      'test_field',
+      new DummyWidgetDefinition('The widget'),
+      {
+        label: 'Test Field',
+        required: true,
+        icon: 'placeholder',
+        classname: 'field char_field widget-text_input fieldname-test_charblock',
+        helpText: 'drink <em>more</em> water',
+        showAddCommentButton: true,
+        strings: {
+          ADD_COMMENT: 'Add Comment'
+        }
+      }
+    );
+
+    // Render it
+    document.body.innerHTML = '<div id="placeholder"></div>';
+    boundBlock = blockDef.render(
+      $('#placeholder'),
+      'the-prefix',
+      'Test initial state'
+    );
+  });
+
+  test('it renders correctly', () => {
+    expect(document.body.innerHTML).toMatchSnapshot();
+  });
+});
+
 describe('telepath: wagtail.blocks.FieldBlock catches widget render errors', () => {
   let boundBlock;
 

--- a/client/src/components/StreamField/blocks/__snapshots__/FieldBlock.test.js.snap
+++ b/client/src/components/StreamField/blocks/__snapshots__/FieldBlock.test.js.snap
@@ -21,3 +21,14 @@ exports[`telepath: wagtail.blocks.FieldBlock it renders correctly 1`] = `
         <p class=\\"help\\">drink <em>more</em> water</p></div>
       </div>"
 `;
+
+exports[`telepath: wagtail.blocks.FieldBlock with comments enabled it renders correctly 1`] = `
+"<div class=\\"field char_field widget-text_input fieldname-test_charblock\\">
+        <div class=\\"field-content\\">
+          <div class=\\"input\\">
+            <p name=\\"the-prefix\\" id=\\"the-prefix\\">The widget</p>
+            <span></span>
+          </div>
+        <p class=\\"help\\">drink <em>more</em> water</p><button type=\\"button\\" aria-label=\\"Add Comment\\" class=\\"button button-secondary button-small\\"><svg class=\\"icon icon-comment initial\\" aria-hidden=\\"true\\" focusable=\\"false\\"><use href=\\"#icon-comment\\"></use></svg></button></div>
+      </div>"
+`;

--- a/client/src/entrypoints/admin/comments.js
+++ b/client/src/entrypoints/admin/comments.js
@@ -1,4 +1,4 @@
-import comments from '../../components/CommentApp/comments';
+import comments, { initAddCommentButton } from '../../components/CommentApp/comments';
 
 /**
  * Entry point loaded when the comments system is in use.
@@ -7,3 +7,7 @@ import comments from '../../components/CommentApp/comments';
 window.comments = comments;
 
 comments.initComments();
+
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('[data-comment-add]').forEach(initAddCommentButton);
+});

--- a/client/src/entrypoints/admin/comments.js
+++ b/client/src/entrypoints/admin/comments.js
@@ -1,13 +1,7 @@
-import comments, { initAddCommentButton } from '../../components/CommentApp/comments';
+import comments from '../../components/CommentApp/comments';
 
 /**
  * Entry point loaded when the comments system is in use.
  */
 // Expose module as a global.
 window.comments = comments;
-
-comments.initComments();
-
-document.addEventListener('DOMContentLoaded', () => {
-  document.querySelectorAll('[data-comment-add]').forEach(initAddCommentButton);
-});

--- a/client/src/entrypoints/admin/page-chooser.js
+++ b/client/src/entrypoints/admin/page-chooser.js
@@ -94,10 +94,6 @@ function createPageChooser(id, openAtParentId, options) {
     chooser.clear();
   });
 
-  if (window.comments) {
-    window.comments.initFieldLevelCommentWidget(chooserElement[0]);
-  }
-
   return chooser;
 }
 window.createPageChooser = createPageChooser;

--- a/client/src/entrypoints/admin/page-editor.js
+++ b/client/src/entrypoints/admin/page-editor.js
@@ -377,36 +377,6 @@ $(() => {
         $icon.addClass('icon-view').removeClass('icon-spinner');
       });
   });
-
-  // Comments toggle
-  $('.comments-toggle input[type=checkbox]').change((e) => {
-    // Show/hide comments
-    window.commentApp.setVisible(e.target.checked);
-
-    // Show/hide comment notifications toggle
-    // Add/Remove tab-nav--comments-enabled class. This changes the size of streamfields
-    if (e.target.checked) {
-      $('.comment-notifications-toggle').show();
-      $('.tab-content').addClass('tab-content--comments-enabled');
-    } else {
-      $('.comment-notifications-toggle').hide();
-      $('.tab-content').removeClass('tab-content--comments-enabled');
-    }
-  });
-
-  // Keep number of comments up to date with comment app
-  const updateCommentCount = () => {
-    const commentCount = window.commentApp.selectors.selectCommentCount(window.commentApp.store.getState());
-
-    if (commentCount > 0) {
-      $('.comments-toggle__count').text(commentCount);
-    } else {
-      // Note: CSS will hide the circle when its content is empty
-      $('.comments-toggle__count').text('');
-    }
-  };
-  window.commentApp.store.subscribe(updateCommentCount);
-  updateCommentCount();
 });
 
 let updateFooterTextTimeout = -1;

--- a/client/src/entrypoints/documents/document-chooser.js
+++ b/client/src/entrypoints/documents/document-chooser.js
@@ -80,10 +80,6 @@ function createDocumentChooser(id) {
     chooser.clear();
   });
 
-  if (window.comments) {
-    window.comments.initFieldLevelCommentWidget(chooserElement[0]);
-  }
-
   return chooser;
 }
 window.createDocumentChooser = createDocumentChooser;

--- a/client/src/entrypoints/images/image-chooser.js
+++ b/client/src/entrypoints/images/image-chooser.js
@@ -93,10 +93,6 @@ function createImageChooser(id) {
     chooser.clear();
   });
 
-  if (window.comments) {
-    window.comments.initFieldLevelCommentWidget(chooserElement[0]);
-  }
-
   return chooser;
 }
 window.createImageChooser = createImageChooser;

--- a/client/src/entrypoints/snippets/snippet-chooser.js
+++ b/client/src/entrypoints/snippets/snippet-chooser.js
@@ -80,10 +80,6 @@ function createSnippetChooser(id, modelString) {
     chooser.clear();
   });
 
-  if (window.comments) {
-    window.comments.initFieldLevelCommentWidget(chooserElement[0]);
-  }
-
   return chooser;
 }
 window.createSnippetChooser = createSnippetChooser;

--- a/wagtail/admin/edit_handlers.py
+++ b/wagtail/admin/edit_handlers.py
@@ -433,6 +433,7 @@ class FieldPanel(EditHandler):
             self.widget = widget
         super().__init__(*args, **kwargs)
         self.field_name = field_name
+        self.comments_enabled = not kwargs.pop('disable_comments', False)
 
     def clone_kwargs(self):
         kwargs = super().clone_kwargs()
@@ -481,6 +482,7 @@ class FieldPanel(EditHandler):
         return mark_safe(render_to_string(self.field_template, {
             'field': self.bound_field,
             'field_type': self.field_type(),
+            'show_add_comment_button': self.comments_enabled and getattr(self.bound_field.field.widget, 'show_add_comment_button', True),
         }))
 
     def required_fields(self):

--- a/wagtail/admin/rich_text/editors/draftail/__init__.py
+++ b/wagtail/admin/rich_text/editors/draftail/__init__.py
@@ -18,6 +18,9 @@ class DraftailRichTextArea(widgets.HiddenInput):
     # this class's constructor accepts a 'features' kwarg
     accepts_features = True
 
+    # Draftail has its own commenting
+    show_add_comment_button = False
+
     def get_panel(self):
         return RichTextFieldPanel
 

--- a/wagtail/admin/templates/wagtailadmin/pages/create.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/create.html
@@ -106,6 +106,9 @@
         $(function(){
             $('#page-edit-form .tab-content section.active input').first().trigger('focus');
 
+            // Enable comments
+            const commentApp = window.comments.initComments(document.getElementById('page-edit-form'));
+
             /* Make user confirm before leaving the editor if there are unsaved changes */
             {% trans "This page has unsaved changes." as confirmation_message %}
             enableDirtyFormCheck(
@@ -116,13 +119,13 @@
                     {% if has_unsaved_changes %}
                         alwaysDirty: true,
                     {% endif %}
-                    commentApp: window.commentApp,
+                    commentApp: commentApp,
                     callback: window.updateFooterSaveWarning
                 }
             );
 
-            // Enable tabbing of comments
-            window.comments.attachTabNav(document.querySelector('.tab-nav'));
+            // Enable comments
+            window.comments.initComments(document.getElementById('page-edit-form'));
         });
     </script>
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/pages/create.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/create.html
@@ -88,6 +88,9 @@
 {% endblock %}
 
 {% block extra_js %}
+    <script>
+
+    </script>
     {{ block.super }}
     {% include "wagtailadmin/pages/_editor_js.html" %}
 
@@ -123,9 +126,6 @@
                     callback: window.updateFooterSaveWarning
                 }
             );
-
-            // Enable comments
-            window.comments.initComments(document.getElementById('page-edit-form'));
         });
     </script>
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/pages/edit.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/edit.html
@@ -153,6 +153,9 @@
             });
             {% endif %}
 
+            // Enable comments
+            const commentApp = window.comments.initComments(document.getElementById('page-edit-form'));
+
             /* Make user confirm before leaving the editor if there are unsaved changes */
             {% trans "This page has unsaved changes." as confirmation_message %}
             enableDirtyFormCheck(
@@ -164,7 +167,7 @@
                         alwaysDirty: true,
                     {% endif %}
 
-                    commentApp: window.commentApp,
+                    commentApp: commentApp,
                     callback: window.updateFooterSaveWarning
                 }
             );
@@ -181,9 +184,6 @@
 
             ActivateWorkflowActionsForEditView('#page-edit-form');
             LockUnlockAction('{{ csrf_token|escapejs }}', '{% url 'wagtailadmin_pages:edit' page.id %}');
-
-            // Enable tabbing of comments
-            window.comments.attachTabNav(document.querySelector('.tab-nav'));
         });
     </script>
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/shared/field.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/field.html
@@ -1,4 +1,4 @@
-{% load wagtailadmin_tags %}
+{% load wagtailadmin_tags i18n %}
 <div class="field {{ field|fieldtype }} {{ field|widgettype }} {{ field_classes }}" data-contentpath="{{ field.name }}">
     {% if show_label|default_if_none:True %}{{ field.label_tag }}{% endif %}
     <div class="field-content">
@@ -6,7 +6,7 @@
             {% block form_field %}
                 {{ field|render_with_errors }}
             {% endblock %}
-            
+
             {# This span only used on rare occasions by certain types of input #}
             <span></span>
         </div>
@@ -20,6 +20,10 @@
                     <span>{{ error|escape }}</span>
                 {% endfor %}
             </p>
+        {% endif %}
+
+        {% if show_add_comment_button %}
+            <button type="button" data-comment-add="" class="button button-secondary button-small" aria-label="{% trans 'Add comment' %}"><svg class="icon icon-comment initial" aria-hidden="true" focusable="false"><use href="#icon-comment"></use></svg></button>
         {% endif %}
     </div>
 </div>

--- a/wagtail/admin/templates/wagtailadmin/widgets/chooser.html
+++ b/wagtail/admin/templates/wagtailadmin/widgets/chooser.html
@@ -33,8 +33,6 @@
     <div class="unchosen">
         <button type="button" class="button action-choose button-small button-secondary">{{ widget.choose_one_text }}</button>
     </div>
-
-    <button type="button" data-comment-add class="button button-secondary button-small u-hidden" aria-label="{% trans 'Add comment' %}">{% icon name='comment' class_name='initial' %}</button>
 </div>
 
 {{ original_field_html }}

--- a/wagtail/contrib/table_block/tests.py
+++ b/wagtail/contrib/table_block/tests.py
@@ -392,7 +392,9 @@ class TestTableBlockForm(WagtailTestUtils, SimpleTestCase):
             'label': 'Test tableblock',
             'required': True,
             'icon': 'table',
-            'classname': 'field char_field widget-table_input fieldname-test_tableblock'
+            'classname': 'field char_field widget-table_input fieldname-test_tableblock',
+            'showAddCommentButton': True,
+            'strings': {'ADD_COMMENT': 'Add Comment'}
         })
 
     def test_searchable_content(self):

--- a/wagtail/core/blocks/field_block.py
+++ b/wagtail/core/blocks/field_block.py
@@ -8,6 +8,7 @@ from django.utils.encoding import force_str
 from django.utils.functional import cached_property
 from django.utils.html import format_html
 from django.utils.safestring import mark_safe
+from django.utils.translation import gettext as _
 
 from wagtail.admin.staticfiles import versioned_static
 from wagtail.core.rich_text import RichText, get_text_for_indexing
@@ -96,6 +97,10 @@ class FieldBlockAdapter(Adapter):
             'required': block.required,
             'icon': block.meta.icon,
             'classname': ' '.join(classname),
+            'showAddCommentButton': getattr(block.field.widget, 'show_add_comment_button', True),
+            'strings': {
+                'ADD_COMMENT': _('Add Comment')
+            },
         }
         if block.field.help_text:
             meta['helpText'] = block.field.help_text

--- a/wagtail/core/tests/test_blocks.py
+++ b/wagtail/core/tests/test_blocks.py
@@ -72,7 +72,9 @@ class TestFieldBlock(WagtailTestUtils, SimpleTestCase):
             'helpText': 'Some helpful text',
             'required': True,
             'icon': 'placeholder',
-            'classname': 'field char_field widget-text_input fieldname-test_block'
+            'classname': 'field char_field widget-text_input fieldname-test_block',
+            'showAddCommentButton': True,
+            'strings': {'ADD_COMMENT': 'Add Comment'}
         })
 
     def test_charblock_adapter_form_classname(self):
@@ -161,7 +163,9 @@ class TestFieldBlock(WagtailTestUtils, SimpleTestCase):
             'label': 'Test choiceblock',
             'required': True,
             'icon': 'placeholder',
-            'classname': 'field choice_field widget-select fieldname-test_choiceblock'
+            'classname': 'field choice_field widget-select fieldname-test_choiceblock',
+            'showAddCommentButton': True,
+            'strings': {'ADD_COMMENT': 'Add Comment'}
         })
 
     def test_searchable_content(self):
@@ -526,7 +530,28 @@ class TestRichTextBlock(TestCase):
             'label': 'Test richtextblock',
             'required': True,
             'icon': 'doc-full',
-            'classname': 'field char_field widget-hallo_rich_text_area fieldname-test_richtextblock'
+            'classname': 'field char_field widget-hallo_rich_text_area fieldname-test_richtextblock',
+            'showAddCommentButton': True,
+            'strings': {'ADD_COMMENT': 'Add Comment'}
+        })
+
+    def test_adapter_with_draftail(self):
+        from wagtail.admin.rich_text import DraftailRichTextArea
+
+        block = blocks.RichTextBlock()
+
+        block.set_name('test_richtextblock')
+        js_args = FieldBlockAdapter().js_args(block)
+
+        self.assertEqual(js_args[0], 'test_richtextblock')
+        self.assertIsInstance(js_args[1], DraftailRichTextArea)
+        self.assertEqual(js_args[2], {
+            'label': 'Test richtextblock',
+            'required': True,
+            'icon': 'doc-full',
+            'classname': 'field char_field widget-draftail_rich_text_area fieldname-test_richtextblock',
+            'showAddCommentButton': False,  # Draftail manages its own comments
+            'strings': {'ADD_COMMENT': 'Add Comment'}
         })
 
     def test_get_form_state(self):
@@ -604,7 +629,9 @@ class TestChoiceBlock(WagtailTestUtils, SimpleTestCase):
             'label': 'Test choiceblock',
             'required': True,
             'icon': 'placeholder',
-            'classname': 'field choice_field widget-select fieldname-test_choiceblock'
+            'classname': 'field choice_field widget-select fieldname-test_choiceblock',
+            'showAddCommentButton': True,
+            'strings': {'ADD_COMMENT': 'Add Comment'}
         })
 
     def test_choice_block_with_default(self):
@@ -917,7 +944,9 @@ class TestMultipleChoiceBlock(WagtailTestUtils, SimpleTestCase):
             'label': 'Test choiceblock',
             'required': True,
             'icon': 'placeholder',
-            'classname': 'field multiple_choice_field widget-select_multiple fieldname-test_choiceblock'
+            'classname': 'field multiple_choice_field widget-select_multiple fieldname-test_choiceblock',
+            'showAddCommentButton': True,
+            'strings': {'ADD_COMMENT': 'Add Comment'}
         })
 
     def test_multiple_choice_block_with_default(self):
@@ -1265,7 +1294,9 @@ class TestRawHTMLBlock(unittest.TestCase):
             'label': 'Test rawhtmlblock',
             'required': True,
             'icon': 'code',
-            'classname': 'field char_field widget-textarea fieldname-test_rawhtmlblock'
+            'classname': 'field char_field widget-textarea fieldname-test_rawhtmlblock',
+            'showAddCommentButton': True,
+            'strings': {'ADD_COMMENT': 'Add Comment'}
         })
 
     def test_form_response(self):
@@ -3403,7 +3434,9 @@ class TestPageChooserBlock(TestCase):
             'required': True,
             'icon': 'redirect',
             'helpText': 'pick a page, any page',
-            'classname': 'field model_choice_field widget-admin_page_chooser fieldname-test_pagechooserblock'
+            'classname': 'field model_choice_field widget-admin_page_chooser fieldname-test_pagechooserblock',
+            'showAddCommentButton': True,
+            'strings': {'ADD_COMMENT': 'Add Comment'}
         })
 
     def test_adapt_with_target_model_string(self):
@@ -3649,7 +3682,9 @@ class TestDateBlock(TestCase):
             'label': 'Test dateblock',
             'required': True,
             'icon': 'date',
-            'classname': 'field date_field widget-admin_date_input fieldname-test_dateblock'
+            'classname': 'field date_field widget-admin_date_input fieldname-test_dateblock',
+            'showAddCommentButton': True,
+            'strings': {'ADD_COMMENT': 'Add Comment'}
         })
 
     def test_adapt_with_format(self):
@@ -3678,7 +3713,9 @@ class TestTimeBlock(TestCase):
             'label': 'Test timeblock',
             'required': True,
             'icon': 'time',
-            'classname': 'field time_field widget-admin_time_input fieldname-test_timeblock'
+            'classname': 'field time_field widget-admin_time_input fieldname-test_timeblock',
+            'showAddCommentButton': True,
+            'strings': {'ADD_COMMENT': 'Add Comment'}
         })
 
     def test_adapt_with_format(self):
@@ -3707,7 +3744,9 @@ class TestDateTimeBlock(TestCase):
             'label': 'Test datetimeblock',
             'required': True,
             'icon': 'date',
-            'classname': 'field date_time_field widget-admin_date_time_input fieldname-test_datetimeblock'
+            'classname': 'field date_time_field widget-admin_date_time_input fieldname-test_datetimeblock',
+            'showAddCommentButton': True,
+            'strings': {'ADD_COMMENT': 'Add Comment'}
         })
 
     def test_adapt_with_format(self):

--- a/wagtail/snippets/tests.py
+++ b/wagtail/snippets/tests.py
@@ -1372,7 +1372,9 @@ class TestSnippetChooserBlock(TestCase):
             'required': True,
             'icon': 'snippet',
             'helpText': 'pick an advert, any advert',
-            'classname': 'field model_choice_field widget-admin_snippet_chooser fieldname-test_snippetchooserblock'
+            'classname': 'field model_choice_field widget-admin_snippet_chooser fieldname-test_snippetchooserblock',
+            'showAddCommentButton': True,
+            'strings': {'ADD_COMMENT': 'Add Comment'}
         })
 
     def test_form_response(self):
@@ -1535,7 +1537,9 @@ class TestSnippetChooserBlockWithCustomPrimaryKey(TestCase):
             'required': True,
             'icon': 'snippet',
             'helpText': 'pick an advert, any advert',
-            'classname': 'field model_choice_field widget-admin_snippet_chooser fieldname-test_snippetchooserblock'
+            'classname': 'field model_choice_field widget-admin_snippet_chooser fieldname-test_snippetchooserblock',
+            'showAddCommentButton': True,
+            'strings': {'ADD_COMMENT': 'Add Comment'}
         })
 
     def test_form_response(self):


### PR DESCRIPTION
See commit log for details. Main changes are:

 - Moved ``initComments`` to run after the form is rendered
 - Moved field level annotations to the ``FieldPanel``/``FieldBlock`` level rather than on widgets