### PR TITLE
Use django.shortcuts.resolve_url() instead of reverse() for pageurl fallbacks

### DIFF
--- a/wagtail/core/templatetags/wagtailcore_tags.py
+++ b/wagtail/core/templatetags/wagtailcore_tags.py
@@ -1,5 +1,5 @@
 from django import template
-from django.shortcuts import reverse
+from django.shortcuts import resolve_url
 from django.template.defaulttags import token_kwargs
 from django.template.loader import render_to_string
 from django.utils.encoding import force_str
@@ -21,7 +21,7 @@ def pageurl(context, page, fallback=None):
     If kwargs contains a fallback view name and page is None, the fallback view url will be returned.
     """
     if page is None and fallback:
-        return reverse(fallback)
+        return resolve_url(fallback)
 
     if not hasattr(page, 'relative_url'):
         raise ValueError("pageurl tag expected a Page object, got %r" % page)


### PR DESCRIPTION
`reverse()` will only work for named Django urls (anything else fails with a `django.urls.exceptions.NoReverseMatch` exception)

I think it's quite common to just want to specify a fallback string (e.g. `"/"` or `"."`) that will be taken as is.

`django.shortcuts.resolve_url()` is what gives `redirect()` it's nice, non-fussy logic, which can be reused here, allowing the fallback to be any of the following:
1. A model instance with a `get_absolute_url()` method
2. A named url pattern string
3. A string containing `"/"` or `"."`
4. A Promise that evaluates to a string meeting the requirements of 2 or 3