### PR TITLE
Make wagtail admin icon visable

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/userbar/base.html
+++ b/wagtail/admin/templates/wagtailadmin/userbar/base.html
@@ -18,7 +18,7 @@
                         </defs>
                     </svg>
                   </div>
-                  <svg class="wagtail-userbar-icon" aria-hidden="true" focusable="false">
+                  <svg class="wagtail-userbar-icon" aria-hidden="false" focusable="false">
                     <use href="#icon-wagtail-icon"></use>
                   </svg>
                 {% endblock %}


### PR DESCRIPTION
When we upgraded to Wagtail version 2.11, we noticed that the Wagtail admin icon was missing. I saw that there was a fix in the [2.10 release version](https://github.com/wagtail/wagtail/commit/884c78aa530539d884b5c67aae9f96e8e2cd919c) but then noticed that the fix had the SVG hidden by default. When I switch aria-hidden to false, the icon appears as expected. 

No additional tests needed as this is a cosmetic change that I'm requesting. Thank you!

## Before
![Screen Shot 2021-04-13 at 2 43 57 PM](https://user-images.githubusercontent.com/12799132/114604295-b6a81c80-9c66-11eb-9ac9-9c9d568da67f.png)

## After
![Screen Shot 2021-04-13 at 2 44 55 PM](https://user-images.githubusercontent.com/12799132/114604407-d5a6ae80-9c66-11eb-99d2-ccfaba2968eb.png)


