### PR TITLE
Lock nav and page scroll together only when search autocomplete is open. Fix #6935

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -7,12 +7,15 @@ body.wy-body-for-nav {
 
 nav.wy-nav-side {
     background-color: #333;  /*color-grey-1*/
-    position: absolute;
-    overflow: inherit;
 }
 
-div.wy-side-scroll {
-    overflow: inherit;
+.body--autocomplete-open .wy-nav-side {
+    position: absolute;
+    overflow: visible;
+}
+
+.body--autocomplete-open .wy-side-scroll {
+    overflow: visible;
 }
 
 div.wy-side-nav-search {

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -70,6 +70,14 @@
       debug: getSearchDebugMode(),
     })
 
+    // Change page styles when the dropdown is open, to lock scrolling.
+    search.autocomplete.on('autocomplete:updated', function (event) {
+      const isOpen = event.target.value.trim() !== '';
+      document.body.classList.toggle('body--autocomplete-open', isOpen);
+    });
+    search.autocomplete.on('autocomplete:closed', function (event) {
+      document.body.classList.toggle('body--autocomplete-open', false);
+    });
     return search
   }
 


### PR DESCRIPTION
Fixes #6935, and helps a bit with #7004.

This re-establishes the sidebar’s behavior prior to #6883 by default, and implements our changes to tie the scrolling of the sidebar and page together only when the search autocomplete dropdown is open.

Tested in latest Chrome, Firefox, Safari on macOS.