### PR TITLE
feature/commenting-js-move

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/edit_handlers/comments/comment_panel.html
+++ b/wagtail/admin/templates/wagtailadmin/edit_handlers/comments/comment_panel.html
@@ -1,4 +1,3 @@
 {% load wagtailadmin_tags %}
 {{ comments_data|json_script:"comments-data" }}
 <div id="comments-output" hidden></div>
-<script src="{% versioned_static 'wagtailadmin/js/comments.js' %}"></script>

--- a/wagtail/admin/templates/wagtailadmin/pages/_editor_js.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/_editor_js.html
@@ -16,6 +16,7 @@
     window.unicodeSlugsEnabled = {% if unicode_slugs_enabled %}true{% else %}false{% endif %};
 </script>
 
+<script src="{% versioned_static 'wagtailadmin/js/comments.js' %}"></script>
 <script src="{% versioned_static 'wagtailadmin/js/vendor/rangy-core.js' %}"></script>
 <script src="{% versioned_static 'wagtailadmin/js/vendor/mousetrap.min.js' %}"></script>
 <script src="{% versioned_static 'wagtailadmin/js/expanding_formset.js' %}"></script>


### PR DESCRIPTION
The previous declaration broke Draftail commenting due to moving `CommentPanel` to `settings_panels` changing initialisation order - this should remove such problems in future
