### PR TITLE
Fix page editor errors in IE11

### DIFF
--- a/client/src/entrypoints/admin/lock-unlock-action.js
+++ b/client/src/entrypoints/admin/lock-unlock-action.js
@@ -1,7 +1,8 @@
 /* When a lock/unlock action button is clicked, make a POST request to the relevant view */
 
 function LockUnlockAction(csrfToken, next) {
-  document.querySelectorAll('[data-locking-action]').forEach((buttonElement) => {
+  const actionElements = document.querySelectorAll('[data-locking-action]');
+  [...actionElements].forEach((buttonElement) => {
     buttonElement.addEventListener('click', (e) => {
       // Stop the button from submitting the form
       e.preventDefault();

--- a/client/src/entrypoints/admin/telepath/widgets.js
+++ b/client/src/entrypoints/admin/telepath/widgets.js
@@ -155,7 +155,9 @@ class DraftailRichTextArea {
                 return result;
             },
             focus: () => {
-                input.draftailEditor.focus();
+                setTimeout(() => {
+                    input.draftailEditor.focus();
+                }, 50);
             },
         };
     }

--- a/client/src/entrypoints/admin/telepath/widgets.test.js
+++ b/client/src/entrypoints/admin/telepath/widgets.test.js
@@ -358,7 +358,10 @@ describe('telepath: wagtail.widgets.DraftailRichTextArea', () => {
   });
 
   test('focus() focuses the text input', () => {
+    // focus happens on a timeout, so use a mock to make it happen instantly
+    jest.useFakeTimers();
     boundWidget.focus();
+    jest.runAllTimers();
     expect(document.activeElement).toBe(document.querySelector('.public-DraftEditor-content'));
   });
 });

--- a/client/src/entrypoints/admin/workflow-action.js
+++ b/client/src/entrypoints/admin/workflow-action.js
@@ -12,7 +12,8 @@ window._addHiddenInput = addHiddenInput;
 
 /* When a workflow action button is clicked, either show a modal or make a POST request to the workflow action view */
 function ActivateWorkflowActionsForDashboard(csrfToken) {
-  document.querySelectorAll('[data-workflow-action-url]').forEach((buttonElement) => {
+  const workflowActionElements = document.querySelectorAll('[data-workflow-action-url]');
+  [...workflowActionElements].forEach((buttonElement) => {
     buttonElement.addEventListener('click', (e) => {
       // Stop the button from submitting the form
       e.preventDefault();
@@ -57,7 +58,8 @@ window.ActivateWorkflowActionsForDashboard = ActivateWorkflowActionsForDashboard
 function ActivateWorkflowActionsForEditView(formSelector) {
   const form = $(formSelector).get(0);
 
-  document.querySelectorAll('[data-workflow-action-name]').forEach((buttonElement) => {
+  const workflowActionElements = document.querySelectorAll('[data-workflow-action-name]');
+  [...workflowActionElements].forEach((buttonElement) => {
     buttonElement.addEventListener('click', (e) => {
       if ('workflowActionModalUrl' in buttonElement.dataset) {
         // This action requires opening a modal to collect additional data.


### PR DESCRIPTION
Fixes Draftail issue described at https://github.com/wagtail/wagtail/pull/6968#issuecomment-822591161 - apparently focus was called before the editor was fully initialised.

Also fixed a couple of occurrences of `querySelectorAll().forEach` which look like they've been around since 2.10 or earlier - as per #6109, these are invalid on IE11. Wasn't able to see what actually breaks here (beyond throwing an error when the debugger is open on page load) but it can't hurt to fix these...

Note: #5914 is still not fixed, and looks like it probably won't be fixed before we drop IE11 support in 2.14.