### PR TITLE
Tweak whitespace in text emails

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/notifications/base.txt
+++ b/wagtail/admin/templates/wagtailadmin/notifications/base.txt
@@ -3,10 +3,8 @@
 {% block greeting %}
 {% blocktrans with username=user.get_short_name|default:user.get_username %}Hello {{ username }},{% endblocktrans %}
 {% endblock %}
-
 {% block content %}
 {% endblock %}
-
 {% block preferences %}
 {% trans "Edit your notification preferences here:" %} {{ settings.BASE_URL }}{% url 'wagtailadmin_account_notification_preferences' %}
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/updated_comments.txt
+++ b/wagtail/admin/templates/wagtailadmin/notifications/updated_comments.txt
@@ -1,31 +1,34 @@
 {% extends 'wagtailadmin/notifications/base.txt' %}
 {% load i18n wagtailadmin_tags %}
 
-{% block content %}
-{% blocktrans with title=page.get_admin_display_title|safe editor=editor|user_display_name|safe %}{{ editor }} has updated comments on "{{ title }}".{% endblocktrans %}
+{% block content %}{% blocktrans with title=page.get_admin_display_title|safe editor=editor|user_display_name|safe %}{{ editor }} has updated comments on "{{ title }}".{% endblocktrans %}
+{% spaceless %}
 
-{% if new_comments %}{% trans "New comments:" %}
-{% for comment in new_comments %}
+{% endspaceless %}{% if new_comments %}
+
+{% trans "New comments:" %}{% for comment in new_comments %}
  - "{{ comment.text|safe }}"
-{% endfor %}{% endif %}
+{% endfor %}{% endif %}{% spaceless %}
 
-{% if resolved_comments %}{% trans "Resolved comments:" %}
-{% for comment in resolved_comments %}
+{% endspaceless %}{% if resolved_comments %}
+
+{% trans "Resolved comments:" %}{% for comment in resolved_comments %}
  - "{{ comment.text|safe }}"
-{% endfor %}{% endif %}
+{% endfor %}{% endif %}{% spaceless %}
 
-{% if deleted_comments %}{% trans "Deleted comments:" %}
-{% for comment in deleted_comments %}
+{% endspaceless %}{% if deleted_comments %}
+
+{% trans "Deleted comments:" %}{% for comment in deleted_comments %}
  - "{{ comment.text|safe }}"
-{% endfor %}{% endif %}
+{% endfor %}{% endif %}{% spaceless %}
 
-{% if replied_comments %}
-{% trans "New replies" %}
-{% for thread in replied_comments %}
-{% trans 'New replies to:' %} {{ thread.comment.text }}
-{% for reply in thread.replies %}
-   - {{ reply.text }}
-{% endfor %}{% endfor %}{% endif %}
+{% endspaceless %}{% if replied_comments %}
+
+{% trans "New replies:" %}{% for thread in replied_comments %}
+
+  {% trans 'New replies to:' %} "{{ thread.comment.text }}"{% for reply in thread.replies %}
+   - "{{ reply.text }}"{% endfor %}{% endfor %}{% endif %}
+
 
 {% trans "You can edit the page here:" %} {{ settings.BASE_URL }}{% url 'wagtailadmin_pages:edit' page.id %}
 {% endblock %}

--- a/wagtail/admin/tests/pages/test_edit_page.py
+++ b/wagtail/admin/tests/pages/test_edit_page.py
@@ -2121,7 +2121,7 @@ class TestCommentingNotifications(TestCase, WagtailTestUtils):
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(mail.outbox[0].to, [self.subscriber.email])
         self.assertEqual(mail.outbox[0].subject, 'test@email.com has updated comments on "I\'ve been edited! (simple page)"')
-        self.assertIn('New comments:\n\n - "A test comment"\n\n', mail.outbox[0].body)
+        self.assertIn('New comments:\n - "A test comment"\n\n', mail.outbox[0].body)
 
     def test_notification_on_resolved_comment(self):
         comment = Comment.objects.create(
@@ -2165,10 +2165,10 @@ class TestCommentingNotifications(TestCase, WagtailTestUtils):
         # The non subscriber created the comment, so should also get an email
         self.assertEqual(mail.outbox[0].to, [self.non_subscriber.email])
         self.assertEqual(mail.outbox[0].subject, 'test@email.com has updated comments on "I\'ve been edited! (simple page)"')
-        self.assertIn('Resolved comments:\n\n - "A test comment"\n\n', mail.outbox[0].body)
+        self.assertIn('Resolved comments:\n - "A test comment"\n\n', mail.outbox[0].body)
         self.assertEqual(mail.outbox[1].to, [self.subscriber.email])
         self.assertEqual(mail.outbox[1].subject, 'test@email.com has updated comments on "I\'ve been edited! (simple page)"')
-        self.assertIn('Resolved comments:\n\n - "A test comment"\n\n', mail.outbox[1].body)
+        self.assertIn('Resolved comments:\n - "A test comment"\n\n', mail.outbox[1].body)
 
     def test_notification_on_new_reply(self):
         comment = Comment.objects.create(
@@ -2228,7 +2228,7 @@ class TestCommentingNotifications(TestCase, WagtailTestUtils):
 
         self.assertIn([self.subscriber.email], recipients)
         self.assertEqual(mail.outbox[2].subject, 'test@email.com has updated comments on "I\'ve been edited! (simple page)"')
-        self.assertIn('New replies to: A test comment\n\n   - a new reply', mail.outbox[2].body)
+        self.assertIn('  New replies to: "A test comment"\n   - "a new reply"', mail.outbox[2].body)
 
     def test_notification_on_deleted_comment(self):
         comment = Comment.objects.create(
@@ -2269,7 +2269,7 @@ class TestCommentingNotifications(TestCase, WagtailTestUtils):
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(mail.outbox[0].to, [self.subscriber.email])
         self.assertEqual(mail.outbox[0].subject, 'test@email.com has updated comments on "I\'ve been edited! (simple page)"')
-        self.assertIn('Deleted comments:\n\n - "A test comment"\n\n', mail.outbox[0].body)
+        self.assertIn('Deleted comments:\n - "A test comment"\n\n', mail.outbox[0].body)
 
     def test_updated_comments_notifications_profile_setting(self):
         # Users can disable commenting notifications globally from account settings


### PR DESCRIPTION
Example:

```
Hello Karl,

Test User has updated comments on "Welcome to the Wagtail Bakery!".


New comments:
 - "Test"


Resolved comments:
 - "Test"


Deleted comments:
 - "Test"


New replies:

  New replies to: "Test"
   - "Test"

You can edit the page here: http://localhost:8000/admin/pages/60/edit/


Edit your notification preferences here: http://localhost:8000/admin/account/notification_preferences/
```