### PR TITLE
Add po files to simple_translation

### DIFF
--- a/wagtail/contrib/simple_translation/locale/ar/LC_MESSAGES/django.po
+++ b/wagtail/contrib/simple_translation/locale/ar/LC_MESSAGES/django.po
@@ -1,0 +1,79 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-04-21 09:33+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=6; plural=n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 "
+"&& n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5;\n"
+
+#: apps.py:8
+msgid "Wagtail simple translation"
+msgstr ""
+
+#: forms.py:10
+msgid "Select all"
+msgstr ""
+
+#: forms.py:12
+msgid "Locales"
+msgstr ""
+
+#: forms.py:17
+msgid "All child pages will be created."
+msgstr ""
+
+#: forms.py:31
+msgid "Include subtree ({} page)"
+msgid_plural "Include subtree ({} pages)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/simple_translation/admin/submit_translation.html:25
+msgid "Submit"
+msgstr ""
+
+#: tests/test_views.py:44 tests/test_views.py:45 views.py:21
+#: wagtail_hooks.py:55 wagtail_hooks.py:74
+msgid "Translate"
+msgstr ""
+
+#: views.py:73
+msgid "{} locales"
+msgstr ""
+
+#: views.py:91
+msgid "Translate page"
+msgstr ""
+
+#: views.py:110
+#, python-brace-format
+msgid "The page '{page_title}' was successfully created in {locales}"
+msgstr ""
+
+#: views.py:116
+#, python-brace-format
+msgid "Translate {model_name}"
+msgstr ""
+
+#: views.py:141
+#, python-brace-format
+msgid "Successfully created {locales} for {model_name} '{object}'"
+msgstr ""
+
+#: wagtail_hooks.py:76
+#, python-format
+msgid "Translate '%(title)s'"
+msgstr ""

--- a/wagtail/contrib/simple_translation/locale/be/LC_MESSAGES/django.po
+++ b/wagtail/contrib/simple_translation/locale/be/LC_MESSAGES/django.po
@@ -1,0 +1,80 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-04-21 09:33+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n"
+"%100>=11 && n%100<=14)? 2 : 3);\n"
+
+#: apps.py:8
+msgid "Wagtail simple translation"
+msgstr ""
+
+#: forms.py:10
+msgid "Select all"
+msgstr ""
+
+#: forms.py:12
+msgid "Locales"
+msgstr ""
+
+#: forms.py:17
+msgid "All child pages will be created."
+msgstr ""
+
+#: forms.py:31
+msgid "Include subtree ({} page)"
+msgid_plural "Include subtree ({} pages)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/simple_translation/admin/submit_translation.html:25
+msgid "Submit"
+msgstr ""
+
+#: tests/test_views.py:44 tests/test_views.py:45 views.py:21
+#: wagtail_hooks.py:55 wagtail_hooks.py:74
+msgid "Translate"
+msgstr ""
+
+#: views.py:73
+msgid "{} locales"
+msgstr ""
+
+#: views.py:91
+msgid "Translate page"
+msgstr ""
+
+#: views.py:110
+#, python-brace-format
+msgid "The page '{page_title}' was successfully created in {locales}"
+msgstr ""
+
+#: views.py:116
+#, python-brace-format
+msgid "Translate {model_name}"
+msgstr ""
+
+#: views.py:141
+#, python-brace-format
+msgid "Successfully created {locales} for {model_name} '{object}'"
+msgstr ""
+
+#: wagtail_hooks.py:76
+#, python-format
+msgid "Translate '%(title)s'"
+msgstr ""

--- a/wagtail/contrib/simple_translation/locale/bg/LC_MESSAGES/django.po
+++ b/wagtail/contrib/simple_translation/locale/bg/LC_MESSAGES/django.po
@@ -1,0 +1,78 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-04-21 09:33+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: apps.py:8
+msgid "Wagtail simple translation"
+msgstr ""
+
+#: forms.py:10
+msgid "Select all"
+msgstr ""
+
+#: forms.py:12
+msgid "Locales"
+msgstr ""
+
+#: forms.py:17
+msgid "All child pages will be created."
+msgstr ""
+
+#: forms.py:31
+msgid "Include subtree ({} page)"
+msgid_plural "Include subtree ({} pages)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/simple_translation/admin/submit_translation.html:25
+msgid "Submit"
+msgstr ""
+
+#: tests/test_views.py:44 tests/test_views.py:45 views.py:21
+#: wagtail_hooks.py:55 wagtail_hooks.py:74
+msgid "Translate"
+msgstr ""
+
+#: views.py:73
+msgid "{} locales"
+msgstr ""
+
+#: views.py:91
+msgid "Translate page"
+msgstr ""
+
+#: views.py:110
+#, python-brace-format
+msgid "The page '{page_title}' was successfully created in {locales}"
+msgstr ""
+
+#: views.py:116
+#, python-brace-format
+msgid "Translate {model_name}"
+msgstr ""
+
+#: views.py:141
+#, python-brace-format
+msgid "Successfully created {locales} for {model_name} '{object}'"
+msgstr ""
+
+#: wagtail_hooks.py:76
+#, python-format
+msgid "Translate '%(title)s'"
+msgstr ""

--- a/wagtail/contrib/simple_translation/locale/ca/LC_MESSAGES/django.po
+++ b/wagtail/contrib/simple_translation/locale/ca/LC_MESSAGES/django.po
@@ -1,0 +1,78 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-04-21 09:33+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: apps.py:8
+msgid "Wagtail simple translation"
+msgstr ""
+
+#: forms.py:10
+msgid "Select all"
+msgstr ""
+
+#: forms.py:12
+msgid "Locales"
+msgstr ""
+
+#: forms.py:17
+msgid "All child pages will be created."
+msgstr ""
+
+#: forms.py:31
+msgid "Include subtree ({} page)"
+msgid_plural "Include subtree ({} pages)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/simple_translation/admin/submit_translation.html:25
+msgid "Submit"
+msgstr ""
+
+#: tests/test_views.py:44 tests/test_views.py:45 views.py:21
+#: wagtail_hooks.py:55 wagtail_hooks.py:74
+msgid "Translate"
+msgstr ""
+
+#: views.py:73
+msgid "{} locales"
+msgstr ""
+
+#: views.py:91
+msgid "Translate page"
+msgstr ""
+
+#: views.py:110
+#, python-brace-format
+msgid "The page '{page_title}' was successfully created in {locales}"
+msgstr ""
+
+#: views.py:116
+#, python-brace-format
+msgid "Translate {model_name}"
+msgstr ""
+
+#: views.py:141
+#, python-brace-format
+msgid "Successfully created {locales} for {model_name} '{object}'"
+msgstr ""
+
+#: wagtail_hooks.py:76
+#, python-format
+msgid "Translate '%(title)s'"
+msgstr ""

--- a/wagtail/contrib/simple_translation/locale/cs/LC_MESSAGES/django.po
+++ b/wagtail/contrib/simple_translation/locale/cs/LC_MESSAGES/django.po
@@ -1,0 +1,79 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-04-21 09:33+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=4; plural=(n == 1 && n % 1 == 0) ? 0 : (n >= 2 && n "
+"<= 4 && n % 1 == 0) ? 1: (n % 1 != 0 ) ? 2 : 3;\n"
+
+#: apps.py:8
+msgid "Wagtail simple translation"
+msgstr ""
+
+#: forms.py:10
+msgid "Select all"
+msgstr ""
+
+#: forms.py:12
+msgid "Locales"
+msgstr ""
+
+#: forms.py:17
+msgid "All child pages will be created."
+msgstr ""
+
+#: forms.py:31
+msgid "Include subtree ({} page)"
+msgid_plural "Include subtree ({} pages)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/simple_translation/admin/submit_translation.html:25
+msgid "Submit"
+msgstr ""
+
+#: tests/test_views.py:44 tests/test_views.py:45 views.py:21
+#: wagtail_hooks.py:55 wagtail_hooks.py:74
+msgid "Translate"
+msgstr ""
+
+#: views.py:73
+msgid "{} locales"
+msgstr ""
+
+#: views.py:91
+msgid "Translate page"
+msgstr ""
+
+#: views.py:110
+#, python-brace-format
+msgid "The page '{page_title}' was successfully created in {locales}"
+msgstr ""
+
+#: views.py:116
+#, python-brace-format
+msgid "Translate {model_name}"
+msgstr ""
+
+#: views.py:141
+#, python-brace-format
+msgid "Successfully created {locales} for {model_name} '{object}'"
+msgstr ""
+
+#: wagtail_hooks.py:76
+#, python-format
+msgid "Translate '%(title)s'"
+msgstr ""

--- a/wagtail/contrib/simple_translation/locale/de/LC_MESSAGES/django.po
+++ b/wagtail/contrib/simple_translation/locale/de/LC_MESSAGES/django.po
@@ -1,0 +1,78 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-04-21 09:33+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: apps.py:8
+msgid "Wagtail simple translation"
+msgstr ""
+
+#: forms.py:10
+msgid "Select all"
+msgstr ""
+
+#: forms.py:12
+msgid "Locales"
+msgstr ""
+
+#: forms.py:17
+msgid "All child pages will be created."
+msgstr ""
+
+#: forms.py:31
+msgid "Include subtree ({} page)"
+msgid_plural "Include subtree ({} pages)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/simple_translation/admin/submit_translation.html:25
+msgid "Submit"
+msgstr ""
+
+#: tests/test_views.py:44 tests/test_views.py:45 views.py:21
+#: wagtail_hooks.py:55 wagtail_hooks.py:74
+msgid "Translate"
+msgstr ""
+
+#: views.py:73
+msgid "{} locales"
+msgstr ""
+
+#: views.py:91
+msgid "Translate page"
+msgstr ""
+
+#: views.py:110
+#, python-brace-format
+msgid "The page '{page_title}' was successfully created in {locales}"
+msgstr ""
+
+#: views.py:116
+#, python-brace-format
+msgid "Translate {model_name}"
+msgstr ""
+
+#: views.py:141
+#, python-brace-format
+msgid "Successfully created {locales} for {model_name} '{object}'"
+msgstr ""
+
+#: wagtail_hooks.py:76
+#, python-format
+msgid "Translate '%(title)s'"
+msgstr ""

--- a/wagtail/contrib/simple_translation/locale/el/LC_MESSAGES/django.po
+++ b/wagtail/contrib/simple_translation/locale/el/LC_MESSAGES/django.po
@@ -1,0 +1,78 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-04-21 09:33+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: apps.py:8
+msgid "Wagtail simple translation"
+msgstr ""
+
+#: forms.py:10
+msgid "Select all"
+msgstr ""
+
+#: forms.py:12
+msgid "Locales"
+msgstr ""
+
+#: forms.py:17
+msgid "All child pages will be created."
+msgstr ""
+
+#: forms.py:31
+msgid "Include subtree ({} page)"
+msgid_plural "Include subtree ({} pages)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/simple_translation/admin/submit_translation.html:25
+msgid "Submit"
+msgstr ""
+
+#: tests/test_views.py:44 tests/test_views.py:45 views.py:21
+#: wagtail_hooks.py:55 wagtail_hooks.py:74
+msgid "Translate"
+msgstr ""
+
+#: views.py:73
+msgid "{} locales"
+msgstr ""
+
+#: views.py:91
+msgid "Translate page"
+msgstr ""
+
+#: views.py:110
+#, python-brace-format
+msgid "The page '{page_title}' was successfully created in {locales}"
+msgstr ""
+
+#: views.py:116
+#, python-brace-format
+msgid "Translate {model_name}"
+msgstr ""
+
+#: views.py:141
+#, python-brace-format
+msgid "Successfully created {locales} for {model_name} '{object}'"
+msgstr ""
+
+#: wagtail_hooks.py:76
+#, python-format
+msgid "Translate '%(title)s'"
+msgstr ""

--- a/wagtail/contrib/simple_translation/locale/en/LC_MESSAGES/django.po
+++ b/wagtail/contrib/simple_translation/locale/en/LC_MESSAGES/django.po
@@ -1,0 +1,78 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-04-21 09:27+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: apps.py:8
+msgid "Wagtail simple translation"
+msgstr ""
+
+#: forms.py:10
+msgid "Select all"
+msgstr ""
+
+#: forms.py:12
+msgid "Locales"
+msgstr ""
+
+#: forms.py:17
+msgid "All child pages will be created."
+msgstr ""
+
+#: forms.py:31
+msgid "Include subtree ({} page)"
+msgid_plural "Include subtree ({} pages)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/simple_translation/admin/submit_translation.html:25
+msgid "Submit"
+msgstr ""
+
+#: tests/test_views.py:44 tests/test_views.py:45 views.py:21
+#: wagtail_hooks.py:55 wagtail_hooks.py:74
+msgid "Translate"
+msgstr ""
+
+#: views.py:73
+msgid "{} locales"
+msgstr ""
+
+#: views.py:91
+msgid "Translate page"
+msgstr ""
+
+#: views.py:110
+#, python-brace-format
+msgid "The page '{page_title}' was successfully created in {locales}"
+msgstr ""
+
+#: views.py:116
+#, python-brace-format
+msgid "Translate {model_name}"
+msgstr ""
+
+#: views.py:141
+#, python-brace-format
+msgid "Successfully created {locales} for {model_name} '{object}'"
+msgstr ""
+
+#: wagtail_hooks.py:76
+#, python-format
+msgid "Translate '%(title)s'"
+msgstr ""

--- a/wagtail/contrib/simple_translation/locale/es/LC_MESSAGES/django.po
+++ b/wagtail/contrib/simple_translation/locale/es/LC_MESSAGES/django.po
@@ -1,0 +1,78 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-04-21 09:33+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: apps.py:8
+msgid "Wagtail simple translation"
+msgstr ""
+
+#: forms.py:10
+msgid "Select all"
+msgstr ""
+
+#: forms.py:12
+msgid "Locales"
+msgstr ""
+
+#: forms.py:17
+msgid "All child pages will be created."
+msgstr ""
+
+#: forms.py:31
+msgid "Include subtree ({} page)"
+msgid_plural "Include subtree ({} pages)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/simple_translation/admin/submit_translation.html:25
+msgid "Submit"
+msgstr ""
+
+#: tests/test_views.py:44 tests/test_views.py:45 views.py:21
+#: wagtail_hooks.py:55 wagtail_hooks.py:74
+msgid "Translate"
+msgstr ""
+
+#: views.py:73
+msgid "{} locales"
+msgstr ""
+
+#: views.py:91
+msgid "Translate page"
+msgstr ""
+
+#: views.py:110
+#, python-brace-format
+msgid "The page '{page_title}' was successfully created in {locales}"
+msgstr ""
+
+#: views.py:116
+#, python-brace-format
+msgid "Translate {model_name}"
+msgstr ""
+
+#: views.py:141
+#, python-brace-format
+msgid "Successfully created {locales} for {model_name} '{object}'"
+msgstr ""
+
+#: wagtail_hooks.py:76
+#, python-format
+msgid "Translate '%(title)s'"
+msgstr ""

--- a/wagtail/contrib/simple_translation/locale/et/LC_MESSAGES/django.po
+++ b/wagtail/contrib/simple_translation/locale/et/LC_MESSAGES/django.po
@@ -1,0 +1,78 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-04-21 09:33+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: apps.py:8
+msgid "Wagtail simple translation"
+msgstr ""
+
+#: forms.py:10
+msgid "Select all"
+msgstr ""
+
+#: forms.py:12
+msgid "Locales"
+msgstr ""
+
+#: forms.py:17
+msgid "All child pages will be created."
+msgstr ""
+
+#: forms.py:31
+msgid "Include subtree ({} page)"
+msgid_plural "Include subtree ({} pages)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/simple_translation/admin/submit_translation.html:25
+msgid "Submit"
+msgstr ""
+
+#: tests/test_views.py:44 tests/test_views.py:45 views.py:21
+#: wagtail_hooks.py:55 wagtail_hooks.py:74
+msgid "Translate"
+msgstr ""
+
+#: views.py:73
+msgid "{} locales"
+msgstr ""
+
+#: views.py:91
+msgid "Translate page"
+msgstr ""
+
+#: views.py:110
+#, python-brace-format
+msgid "The page '{page_title}' was successfully created in {locales}"
+msgstr ""
+
+#: views.py:116
+#, python-brace-format
+msgid "Translate {model_name}"
+msgstr ""
+
+#: views.py:141
+#, python-brace-format
+msgid "Successfully created {locales} for {model_name} '{object}'"
+msgstr ""
+
+#: wagtail_hooks.py:76
+#, python-format
+msgid "Translate '%(title)s'"
+msgstr ""

--- a/wagtail/contrib/simple_translation/locale/fa/LC_MESSAGES/django.po
+++ b/wagtail/contrib/simple_translation/locale/fa/LC_MESSAGES/django.po
@@ -1,0 +1,78 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-04-21 09:33+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#: apps.py:8
+msgid "Wagtail simple translation"
+msgstr ""
+
+#: forms.py:10
+msgid "Select all"
+msgstr ""
+
+#: forms.py:12
+msgid "Locales"
+msgstr ""
+
+#: forms.py:17
+msgid "All child pages will be created."
+msgstr ""
+
+#: forms.py:31
+msgid "Include subtree ({} page)"
+msgid_plural "Include subtree ({} pages)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/simple_translation/admin/submit_translation.html:25
+msgid "Submit"
+msgstr ""
+
+#: tests/test_views.py:44 tests/test_views.py:45 views.py:21
+#: wagtail_hooks.py:55 wagtail_hooks.py:74
+msgid "Translate"
+msgstr ""
+
+#: views.py:73
+msgid "{} locales"
+msgstr ""
+
+#: views.py:91
+msgid "Translate page"
+msgstr ""
+
+#: views.py:110
+#, python-brace-format
+msgid "The page '{page_title}' was successfully created in {locales}"
+msgstr ""
+
+#: views.py:116
+#, python-brace-format
+msgid "Translate {model_name}"
+msgstr ""
+
+#: views.py:141
+#, python-brace-format
+msgid "Successfully created {locales} for {model_name} '{object}'"
+msgstr ""
+
+#: wagtail_hooks.py:76
+#, python-format
+msgid "Translate '%(title)s'"
+msgstr ""

--- a/wagtail/contrib/simple_translation/locale/fi/LC_MESSAGES/django.po
+++ b/wagtail/contrib/simple_translation/locale/fi/LC_MESSAGES/django.po
@@ -1,0 +1,78 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-04-21 09:33+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: apps.py:8
+msgid "Wagtail simple translation"
+msgstr ""
+
+#: forms.py:10
+msgid "Select all"
+msgstr ""
+
+#: forms.py:12
+msgid "Locales"
+msgstr ""
+
+#: forms.py:17
+msgid "All child pages will be created."
+msgstr ""
+
+#: forms.py:31
+msgid "Include subtree ({} page)"
+msgid_plural "Include subtree ({} pages)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/simple_translation/admin/submit_translation.html:25
+msgid "Submit"
+msgstr ""
+
+#: tests/test_views.py:44 tests/test_views.py:45 views.py:21
+#: wagtail_hooks.py:55 wagtail_hooks.py:74
+msgid "Translate"
+msgstr ""
+
+#: views.py:73
+msgid "{} locales"
+msgstr ""
+
+#: views.py:91
+msgid "Translate page"
+msgstr ""
+
+#: views.py:110
+#, python-brace-format
+msgid "The page '{page_title}' was successfully created in {locales}"
+msgstr ""
+
+#: views.py:116
+#, python-brace-format
+msgid "Translate {model_name}"
+msgstr ""
+
+#: views.py:141
+#, python-brace-format
+msgid "Successfully created {locales} for {model_name} '{object}'"
+msgstr ""
+
+#: wagtail_hooks.py:76
+#, python-format
+msgid "Translate '%(title)s'"
+msgstr ""

--- a/wagtail/contrib/simple_translation/locale/fr/LC_MESSAGES/django.po
+++ b/wagtail/contrib/simple_translation/locale/fr/LC_MESSAGES/django.po
@@ -1,0 +1,78 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-04-21 09:33+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#: apps.py:8
+msgid "Wagtail simple translation"
+msgstr ""
+
+#: forms.py:10
+msgid "Select all"
+msgstr ""
+
+#: forms.py:12
+msgid "Locales"
+msgstr ""
+
+#: forms.py:17
+msgid "All child pages will be created."
+msgstr ""
+
+#: forms.py:31
+msgid "Include subtree ({} page)"
+msgid_plural "Include subtree ({} pages)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/simple_translation/admin/submit_translation.html:25
+msgid "Submit"
+msgstr ""
+
+#: tests/test_views.py:44 tests/test_views.py:45 views.py:21
+#: wagtail_hooks.py:55 wagtail_hooks.py:74
+msgid "Translate"
+msgstr ""
+
+#: views.py:73
+msgid "{} locales"
+msgstr ""
+
+#: views.py:91
+msgid "Translate page"
+msgstr ""
+
+#: views.py:110
+#, python-brace-format
+msgid "The page '{page_title}' was successfully created in {locales}"
+msgstr ""
+
+#: views.py:116
+#, python-brace-format
+msgid "Translate {model_name}"
+msgstr ""
+
+#: views.py:141
+#, python-brace-format
+msgid "Successfully created {locales} for {model_name} '{object}'"
+msgstr ""
+
+#: wagtail_hooks.py:76
+#, python-format
+msgid "Translate '%(title)s'"
+msgstr ""

--- a/wagtail/contrib/simple_translation/locale/gl/LC_MESSAGES/django.po
+++ b/wagtail/contrib/simple_translation/locale/gl/LC_MESSAGES/django.po
@@ -1,0 +1,78 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-04-21 09:33+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: apps.py:8
+msgid "Wagtail simple translation"
+msgstr ""
+
+#: forms.py:10
+msgid "Select all"
+msgstr ""
+
+#: forms.py:12
+msgid "Locales"
+msgstr ""
+
+#: forms.py:17
+msgid "All child pages will be created."
+msgstr ""
+
+#: forms.py:31
+msgid "Include subtree ({} page)"
+msgid_plural "Include subtree ({} pages)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/simple_translation/admin/submit_translation.html:25
+msgid "Submit"
+msgstr ""
+
+#: tests/test_views.py:44 tests/test_views.py:45 views.py:21
+#: wagtail_hooks.py:55 wagtail_hooks.py:74
+msgid "Translate"
+msgstr ""
+
+#: views.py:73
+msgid "{} locales"
+msgstr ""
+
+#: views.py:91
+msgid "Translate page"
+msgstr ""
+
+#: views.py:110
+#, python-brace-format
+msgid "The page '{page_title}' was successfully created in {locales}"
+msgstr ""
+
+#: views.py:116
+#, python-brace-format
+msgid "Translate {model_name}"
+msgstr ""
+
+#: views.py:141
+#, python-brace-format
+msgid "Successfully created {locales} for {model_name} '{object}'"
+msgstr ""
+
+#: wagtail_hooks.py:76
+#, python-format
+msgid "Translate '%(title)s'"
+msgstr ""

--- a/wagtail/contrib/simple_translation/locale/he_IL/LC_MESSAGES/django.po
+++ b/wagtail/contrib/simple_translation/locale/he_IL/LC_MESSAGES/django.po
@@ -1,0 +1,78 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-04-21 09:34+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+
+#: apps.py:8
+msgid "Wagtail simple translation"
+msgstr ""
+
+#: forms.py:10
+msgid "Select all"
+msgstr ""
+
+#: forms.py:12
+msgid "Locales"
+msgstr ""
+
+#: forms.py:17
+msgid "All child pages will be created."
+msgstr ""
+
+#: forms.py:31
+msgid "Include subtree ({} page)"
+msgid_plural "Include subtree ({} pages)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/simple_translation/admin/submit_translation.html:25
+msgid "Submit"
+msgstr ""
+
+#: tests/test_views.py:44 tests/test_views.py:45 views.py:21
+#: wagtail_hooks.py:55 wagtail_hooks.py:74
+msgid "Translate"
+msgstr ""
+
+#: views.py:73
+msgid "{} locales"
+msgstr ""
+
+#: views.py:91
+msgid "Translate page"
+msgstr ""
+
+#: views.py:110
+#, python-brace-format
+msgid "The page '{page_title}' was successfully created in {locales}"
+msgstr ""
+
+#: views.py:116
+#, python-brace-format
+msgid "Translate {model_name}"
+msgstr ""
+
+#: views.py:141
+#, python-brace-format
+msgid "Successfully created {locales} for {model_name} '{object}'"
+msgstr ""
+
+#: wagtail_hooks.py:76
+#, python-format
+msgid "Translate '%(title)s'"
+msgstr ""

--- a/wagtail/contrib/simple_translation/locale/hr_HR/LC_MESSAGES/django.po
+++ b/wagtail/contrib/simple_translation/locale/hr_HR/LC_MESSAGES/django.po
@@ -1,0 +1,78 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-04-21 09:34+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+
+#: apps.py:8
+msgid "Wagtail simple translation"
+msgstr ""
+
+#: forms.py:10
+msgid "Select all"
+msgstr ""
+
+#: forms.py:12
+msgid "Locales"
+msgstr ""
+
+#: forms.py:17
+msgid "All child pages will be created."
+msgstr ""
+
+#: forms.py:31
+msgid "Include subtree ({} page)"
+msgid_plural "Include subtree ({} pages)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/simple_translation/admin/submit_translation.html:25
+msgid "Submit"
+msgstr ""
+
+#: tests/test_views.py:44 tests/test_views.py:45 views.py:21
+#: wagtail_hooks.py:55 wagtail_hooks.py:74
+msgid "Translate"
+msgstr ""
+
+#: views.py:73
+msgid "{} locales"
+msgstr ""
+
+#: views.py:91
+msgid "Translate page"
+msgstr ""
+
+#: views.py:110
+#, python-brace-format
+msgid "The page '{page_title}' was successfully created in {locales}"
+msgstr ""
+
+#: views.py:116
+#, python-brace-format
+msgid "Translate {model_name}"
+msgstr ""
+
+#: views.py:141
+#, python-brace-format
+msgid "Successfully created {locales} for {model_name} '{object}'"
+msgstr ""
+
+#: wagtail_hooks.py:76
+#, python-format
+msgid "Translate '%(title)s'"
+msgstr ""

--- a/wagtail/contrib/simple_translation/locale/hu/LC_MESSAGES/django.po
+++ b/wagtail/contrib/simple_translation/locale/hu/LC_MESSAGES/django.po
@@ -1,0 +1,78 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-04-21 09:34+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: apps.py:8
+msgid "Wagtail simple translation"
+msgstr ""
+
+#: forms.py:10
+msgid "Select all"
+msgstr ""
+
+#: forms.py:12
+msgid "Locales"
+msgstr ""
+
+#: forms.py:17
+msgid "All child pages will be created."
+msgstr ""
+
+#: forms.py:31
+msgid "Include subtree ({} page)"
+msgid_plural "Include subtree ({} pages)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/simple_translation/admin/submit_translation.html:25
+msgid "Submit"
+msgstr ""
+
+#: tests/test_views.py:44 tests/test_views.py:45 views.py:21
+#: wagtail_hooks.py:55 wagtail_hooks.py:74
+msgid "Translate"
+msgstr ""
+
+#: views.py:73
+msgid "{} locales"
+msgstr ""
+
+#: views.py:91
+msgid "Translate page"
+msgstr ""
+
+#: views.py:110
+#, python-brace-format
+msgid "The page '{page_title}' was successfully created in {locales}"
+msgstr ""
+
+#: views.py:116
+#, python-brace-format
+msgid "Translate {model_name}"
+msgstr ""
+
+#: views.py:141
+#, python-brace-format
+msgid "Successfully created {locales} for {model_name} '{object}'"
+msgstr ""
+
+#: wagtail_hooks.py:76
+#, python-format
+msgid "Translate '%(title)s'"
+msgstr ""

--- a/wagtail/contrib/simple_translation/locale/id_ID/LC_MESSAGES/django.po
+++ b/wagtail/contrib/simple_translation/locale/id_ID/LC_MESSAGES/django.po
@@ -1,0 +1,78 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-04-21 09:34+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+
+#: apps.py:8
+msgid "Wagtail simple translation"
+msgstr ""
+
+#: forms.py:10
+msgid "Select all"
+msgstr ""
+
+#: forms.py:12
+msgid "Locales"
+msgstr ""
+
+#: forms.py:17
+msgid "All child pages will be created."
+msgstr ""
+
+#: forms.py:31
+msgid "Include subtree ({} page)"
+msgid_plural "Include subtree ({} pages)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/simple_translation/admin/submit_translation.html:25
+msgid "Submit"
+msgstr ""
+
+#: tests/test_views.py:44 tests/test_views.py:45 views.py:21
+#: wagtail_hooks.py:55 wagtail_hooks.py:74
+msgid "Translate"
+msgstr ""
+
+#: views.py:73
+msgid "{} locales"
+msgstr ""
+
+#: views.py:91
+msgid "Translate page"
+msgstr ""
+
+#: views.py:110
+#, python-brace-format
+msgid "The page '{page_title}' was successfully created in {locales}"
+msgstr ""
+
+#: views.py:116
+#, python-brace-format
+msgid "Translate {model_name}"
+msgstr ""
+
+#: views.py:141
+#, python-brace-format
+msgid "Successfully created {locales} for {model_name} '{object}'"
+msgstr ""
+
+#: wagtail_hooks.py:76
+#, python-format
+msgid "Translate '%(title)s'"
+msgstr ""

--- a/wagtail/contrib/simple_translation/locale/is_IS/LC_MESSAGES/django.po
+++ b/wagtail/contrib/simple_translation/locale/is_IS/LC_MESSAGES/django.po
@@ -1,0 +1,78 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-04-21 09:34+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+
+#: apps.py:8
+msgid "Wagtail simple translation"
+msgstr ""
+
+#: forms.py:10
+msgid "Select all"
+msgstr ""
+
+#: forms.py:12
+msgid "Locales"
+msgstr ""
+
+#: forms.py:17
+msgid "All child pages will be created."
+msgstr ""
+
+#: forms.py:31
+msgid "Include subtree ({} page)"
+msgid_plural "Include subtree ({} pages)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/simple_translation/admin/submit_translation.html:25
+msgid "Submit"
+msgstr ""
+
+#: tests/test_views.py:44 tests/test_views.py:45 views.py:21
+#: wagtail_hooks.py:55 wagtail_hooks.py:74
+msgid "Translate"
+msgstr ""
+
+#: views.py:73
+msgid "{} locales"
+msgstr ""
+
+#: views.py:91
+msgid "Translate page"
+msgstr ""
+
+#: views.py:110
+#, python-brace-format
+msgid "The page '{page_title}' was successfully created in {locales}"
+msgstr ""
+
+#: views.py:116
+#, python-brace-format
+msgid "Translate {model_name}"
+msgstr ""
+
+#: views.py:141
+#, python-brace-format
+msgid "Successfully created {locales} for {model_name} '{object}'"
+msgstr ""
+
+#: wagtail_hooks.py:76
+#, python-format
+msgid "Translate '%(title)s'"
+msgstr ""

--- a/wagtail/contrib/simple_translation/locale/it/LC_MESSAGES/django.po
+++ b/wagtail/contrib/simple_translation/locale/it/LC_MESSAGES/django.po
@@ -1,0 +1,78 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-04-21 09:34+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: apps.py:8
+msgid "Wagtail simple translation"
+msgstr ""
+
+#: forms.py:10
+msgid "Select all"
+msgstr ""
+
+#: forms.py:12
+msgid "Locales"
+msgstr ""
+
+#: forms.py:17
+msgid "All child pages will be created."
+msgstr ""
+
+#: forms.py:31
+msgid "Include subtree ({} page)"
+msgid_plural "Include subtree ({} pages)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/simple_translation/admin/submit_translation.html:25
+msgid "Submit"
+msgstr ""
+
+#: tests/test_views.py:44 tests/test_views.py:45 views.py:21
+#: wagtail_hooks.py:55 wagtail_hooks.py:74
+msgid "Translate"
+msgstr ""
+
+#: views.py:73
+msgid "{} locales"
+msgstr ""
+
+#: views.py:91
+msgid "Translate page"
+msgstr ""
+
+#: views.py:110
+#, python-brace-format
+msgid "The page '{page_title}' was successfully created in {locales}"
+msgstr ""
+
+#: views.py:116
+#, python-brace-format
+msgid "Translate {model_name}"
+msgstr ""
+
+#: views.py:141
+#, python-brace-format
+msgid "Successfully created {locales} for {model_name} '{object}'"
+msgstr ""
+
+#: wagtail_hooks.py:76
+#, python-format
+msgid "Translate '%(title)s'"
+msgstr ""

--- a/wagtail/contrib/simple_translation/locale/ja/LC_MESSAGES/django.po
+++ b/wagtail/contrib/simple_translation/locale/ja/LC_MESSAGES/django.po
@@ -1,0 +1,78 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-04-21 09:34+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#: apps.py:8
+msgid "Wagtail simple translation"
+msgstr ""
+
+#: forms.py:10
+msgid "Select all"
+msgstr ""
+
+#: forms.py:12
+msgid "Locales"
+msgstr ""
+
+#: forms.py:17
+msgid "All child pages will be created."
+msgstr ""
+
+#: forms.py:31
+msgid "Include subtree ({} page)"
+msgid_plural "Include subtree ({} pages)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/simple_translation/admin/submit_translation.html:25
+msgid "Submit"
+msgstr ""
+
+#: tests/test_views.py:44 tests/test_views.py:45 views.py:21
+#: wagtail_hooks.py:55 wagtail_hooks.py:74
+msgid "Translate"
+msgstr ""
+
+#: views.py:73
+msgid "{} locales"
+msgstr ""
+
+#: views.py:91
+msgid "Translate page"
+msgstr ""
+
+#: views.py:110
+#, python-brace-format
+msgid "The page '{page_title}' was successfully created in {locales}"
+msgstr ""
+
+#: views.py:116
+#, python-brace-format
+msgid "Translate {model_name}"
+msgstr ""
+
+#: views.py:141
+#, python-brace-format
+msgid "Successfully created {locales} for {model_name} '{object}'"
+msgstr ""
+
+#: wagtail_hooks.py:76
+#, python-format
+msgid "Translate '%(title)s'"
+msgstr ""

--- a/wagtail/contrib/simple_translation/locale/ka/LC_MESSAGES/django.po
+++ b/wagtail/contrib/simple_translation/locale/ka/LC_MESSAGES/django.po
@@ -1,0 +1,78 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-04-21 09:34+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n!=1);\n"
+
+#: apps.py:8
+msgid "Wagtail simple translation"
+msgstr ""
+
+#: forms.py:10
+msgid "Select all"
+msgstr ""
+
+#: forms.py:12
+msgid "Locales"
+msgstr ""
+
+#: forms.py:17
+msgid "All child pages will be created."
+msgstr ""
+
+#: forms.py:31
+msgid "Include subtree ({} page)"
+msgid_plural "Include subtree ({} pages)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/simple_translation/admin/submit_translation.html:25
+msgid "Submit"
+msgstr ""
+
+#: tests/test_views.py:44 tests/test_views.py:45 views.py:21
+#: wagtail_hooks.py:55 wagtail_hooks.py:74
+msgid "Translate"
+msgstr ""
+
+#: views.py:73
+msgid "{} locales"
+msgstr ""
+
+#: views.py:91
+msgid "Translate page"
+msgstr ""
+
+#: views.py:110
+#, python-brace-format
+msgid "The page '{page_title}' was successfully created in {locales}"
+msgstr ""
+
+#: views.py:116
+#, python-brace-format
+msgid "Translate {model_name}"
+msgstr ""
+
+#: views.py:141
+#, python-brace-format
+msgid "Successfully created {locales} for {model_name} '{object}'"
+msgstr ""
+
+#: wagtail_hooks.py:76
+#, python-format
+msgid "Translate '%(title)s'"
+msgstr ""

--- a/wagtail/contrib/simple_translation/locale/ko/LC_MESSAGES/django.po
+++ b/wagtail/contrib/simple_translation/locale/ko/LC_MESSAGES/django.po
@@ -1,0 +1,78 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-04-21 09:34+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#: apps.py:8
+msgid "Wagtail simple translation"
+msgstr ""
+
+#: forms.py:10
+msgid "Select all"
+msgstr ""
+
+#: forms.py:12
+msgid "Locales"
+msgstr ""
+
+#: forms.py:17
+msgid "All child pages will be created."
+msgstr ""
+
+#: forms.py:31
+msgid "Include subtree ({} page)"
+msgid_plural "Include subtree ({} pages)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/simple_translation/admin/submit_translation.html:25
+msgid "Submit"
+msgstr ""
+
+#: tests/test_views.py:44 tests/test_views.py:45 views.py:21
+#: wagtail_hooks.py:55 wagtail_hooks.py:74
+msgid "Translate"
+msgstr ""
+
+#: views.py:73
+msgid "{} locales"
+msgstr ""
+
+#: views.py:91
+msgid "Translate page"
+msgstr ""
+
+#: views.py:110
+#, python-brace-format
+msgid "The page '{page_title}' was successfully created in {locales}"
+msgstr ""
+
+#: views.py:116
+#, python-brace-format
+msgid "Translate {model_name}"
+msgstr ""
+
+#: views.py:141
+#, python-brace-format
+msgid "Successfully created {locales} for {model_name} '{object}'"
+msgstr ""
+
+#: wagtail_hooks.py:76
+#, python-format
+msgid "Translate '%(title)s'"
+msgstr ""

--- a/wagtail/contrib/simple_translation/locale/lt/LC_MESSAGES/django.po
+++ b/wagtail/contrib/simple_translation/locale/lt/LC_MESSAGES/django.po
@@ -1,0 +1,80 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-04-21 09:34+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=4; plural=(n % 10 == 1 && (n % 100 > 19 || n % 100 < "
+"11) ? 0 : (n % 10 >= 2 && n % 10 <=9) && (n % 100 > 19 || n % 100 < 11) ? "
+"1 : n % 1 != 0 ? 2: 3);\n"
+
+#: apps.py:8
+msgid "Wagtail simple translation"
+msgstr ""
+
+#: forms.py:10
+msgid "Select all"
+msgstr ""
+
+#: forms.py:12
+msgid "Locales"
+msgstr ""
+
+#: forms.py:17
+msgid "All child pages will be created."
+msgstr ""
+
+#: forms.py:31
+msgid "Include subtree ({} page)"
+msgid_plural "Include subtree ({} pages)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/simple_translation/admin/submit_translation.html:25
+msgid "Submit"
+msgstr ""
+
+#: tests/test_views.py:44 tests/test_views.py:45 views.py:21
+#: wagtail_hooks.py:55 wagtail_hooks.py:74
+msgid "Translate"
+msgstr ""
+
+#: views.py:73
+msgid "{} locales"
+msgstr ""
+
+#: views.py:91
+msgid "Translate page"
+msgstr ""
+
+#: views.py:110
+#, python-brace-format
+msgid "The page '{page_title}' was successfully created in {locales}"
+msgstr ""
+
+#: views.py:116
+#, python-brace-format
+msgid "Translate {model_name}"
+msgstr ""
+
+#: views.py:141
+#, python-brace-format
+msgid "Successfully created {locales} for {model_name} '{object}'"
+msgstr ""
+
+#: wagtail_hooks.py:76
+#, python-format
+msgid "Translate '%(title)s'"
+msgstr ""

--- a/wagtail/contrib/simple_translation/locale/lv/LC_MESSAGES/django.po
+++ b/wagtail/contrib/simple_translation/locale/lv/LC_MESSAGES/django.po
@@ -1,0 +1,79 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-04-21 09:34+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n != 0 ? 1 : "
+"2);\n"
+
+#: apps.py:8
+msgid "Wagtail simple translation"
+msgstr ""
+
+#: forms.py:10
+msgid "Select all"
+msgstr ""
+
+#: forms.py:12
+msgid "Locales"
+msgstr ""
+
+#: forms.py:17
+msgid "All child pages will be created."
+msgstr ""
+
+#: forms.py:31
+msgid "Include subtree ({} page)"
+msgid_plural "Include subtree ({} pages)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/simple_translation/admin/submit_translation.html:25
+msgid "Submit"
+msgstr ""
+
+#: tests/test_views.py:44 tests/test_views.py:45 views.py:21
+#: wagtail_hooks.py:55 wagtail_hooks.py:74
+msgid "Translate"
+msgstr ""
+
+#: views.py:73
+msgid "{} locales"
+msgstr ""
+
+#: views.py:91
+msgid "Translate page"
+msgstr ""
+
+#: views.py:110
+#, python-brace-format
+msgid "The page '{page_title}' was successfully created in {locales}"
+msgstr ""
+
+#: views.py:116
+#, python-brace-format
+msgid "Translate {model_name}"
+msgstr ""
+
+#: views.py:141
+#, python-brace-format
+msgid "Successfully created {locales} for {model_name} '{object}'"
+msgstr ""
+
+#: wagtail_hooks.py:76
+#, python-format
+msgid "Translate '%(title)s'"
+msgstr ""

--- a/wagtail/contrib/simple_translation/locale/mi/LC_MESSAGES/django.po
+++ b/wagtail/contrib/simple_translation/locale/mi/LC_MESSAGES/django.po
@@ -1,0 +1,78 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-04-21 09:34+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+
+#: apps.py:8
+msgid "Wagtail simple translation"
+msgstr ""
+
+#: forms.py:10
+msgid "Select all"
+msgstr ""
+
+#: forms.py:12
+msgid "Locales"
+msgstr ""
+
+#: forms.py:17
+msgid "All child pages will be created."
+msgstr ""
+
+#: forms.py:31
+msgid "Include subtree ({} page)"
+msgid_plural "Include subtree ({} pages)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/simple_translation/admin/submit_translation.html:25
+msgid "Submit"
+msgstr ""
+
+#: tests/test_views.py:44 tests/test_views.py:45 views.py:21
+#: wagtail_hooks.py:55 wagtail_hooks.py:74
+msgid "Translate"
+msgstr ""
+
+#: views.py:73
+msgid "{} locales"
+msgstr ""
+
+#: views.py:91
+msgid "Translate page"
+msgstr ""
+
+#: views.py:110
+#, python-brace-format
+msgid "The page '{page_title}' was successfully created in {locales}"
+msgstr ""
+
+#: views.py:116
+#, python-brace-format
+msgid "Translate {model_name}"
+msgstr ""
+
+#: views.py:141
+#, python-brace-format
+msgid "Successfully created {locales} for {model_name} '{object}'"
+msgstr ""
+
+#: wagtail_hooks.py:76
+#, python-format
+msgid "Translate '%(title)s'"
+msgstr ""

--- a/wagtail/contrib/simple_translation/locale/mn/LC_MESSAGES/django.po
+++ b/wagtail/contrib/simple_translation/locale/mn/LC_MESSAGES/django.po
@@ -1,0 +1,78 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-04-21 09:34+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: apps.py:8
+msgid "Wagtail simple translation"
+msgstr ""
+
+#: forms.py:10
+msgid "Select all"
+msgstr ""
+
+#: forms.py:12
+msgid "Locales"
+msgstr ""
+
+#: forms.py:17
+msgid "All child pages will be created."
+msgstr ""
+
+#: forms.py:31
+msgid "Include subtree ({} page)"
+msgid_plural "Include subtree ({} pages)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/simple_translation/admin/submit_translation.html:25
+msgid "Submit"
+msgstr ""
+
+#: tests/test_views.py:44 tests/test_views.py:45 views.py:21
+#: wagtail_hooks.py:55 wagtail_hooks.py:74
+msgid "Translate"
+msgstr ""
+
+#: views.py:73
+msgid "{} locales"
+msgstr ""
+
+#: views.py:91
+msgid "Translate page"
+msgstr ""
+
+#: views.py:110
+#, python-brace-format
+msgid "The page '{page_title}' was successfully created in {locales}"
+msgstr ""
+
+#: views.py:116
+#, python-brace-format
+msgid "Translate {model_name}"
+msgstr ""
+
+#: views.py:141
+#, python-brace-format
+msgid "Successfully created {locales} for {model_name} '{object}'"
+msgstr ""
+
+#: wagtail_hooks.py:76
+#, python-format
+msgid "Translate '%(title)s'"
+msgstr ""

--- a/wagtail/contrib/simple_translation/locale/nb/LC_MESSAGES/django.po
+++ b/wagtail/contrib/simple_translation/locale/nb/LC_MESSAGES/django.po
@@ -1,0 +1,78 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-04-21 09:34+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: apps.py:8
+msgid "Wagtail simple translation"
+msgstr ""
+
+#: forms.py:10
+msgid "Select all"
+msgstr ""
+
+#: forms.py:12
+msgid "Locales"
+msgstr ""
+
+#: forms.py:17
+msgid "All child pages will be created."
+msgstr ""
+
+#: forms.py:31
+msgid "Include subtree ({} page)"
+msgid_plural "Include subtree ({} pages)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/simple_translation/admin/submit_translation.html:25
+msgid "Submit"
+msgstr ""
+
+#: tests/test_views.py:44 tests/test_views.py:45 views.py:21
+#: wagtail_hooks.py:55 wagtail_hooks.py:74
+msgid "Translate"
+msgstr ""
+
+#: views.py:73
+msgid "{} locales"
+msgstr ""
+
+#: views.py:91
+msgid "Translate page"
+msgstr ""
+
+#: views.py:110
+#, python-brace-format
+msgid "The page '{page_title}' was successfully created in {locales}"
+msgstr ""
+
+#: views.py:116
+#, python-brace-format
+msgid "Translate {model_name}"
+msgstr ""
+
+#: views.py:141
+#, python-brace-format
+msgid "Successfully created {locales} for {model_name} '{object}'"
+msgstr ""
+
+#: wagtail_hooks.py:76
+#, python-format
+msgid "Translate '%(title)s'"
+msgstr ""

--- a/wagtail/contrib/simple_translation/locale/nl/LC_MESSAGES/django.po
+++ b/wagtail/contrib/simple_translation/locale/nl/LC_MESSAGES/django.po
@@ -1,0 +1,78 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-04-21 09:34+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: apps.py:8
+msgid "Wagtail simple translation"
+msgstr ""
+
+#: forms.py:10
+msgid "Select all"
+msgstr ""
+
+#: forms.py:12
+msgid "Locales"
+msgstr ""
+
+#: forms.py:17
+msgid "All child pages will be created."
+msgstr ""
+
+#: forms.py:31
+msgid "Include subtree ({} page)"
+msgid_plural "Include subtree ({} pages)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/simple_translation/admin/submit_translation.html:25
+msgid "Submit"
+msgstr ""
+
+#: tests/test_views.py:44 tests/test_views.py:45 views.py:21
+#: wagtail_hooks.py:55 wagtail_hooks.py:74
+msgid "Translate"
+msgstr ""
+
+#: views.py:73
+msgid "{} locales"
+msgstr ""
+
+#: views.py:91
+msgid "Translate page"
+msgstr ""
+
+#: views.py:110
+#, python-brace-format
+msgid "The page '{page_title}' was successfully created in {locales}"
+msgstr ""
+
+#: views.py:116
+#, python-brace-format
+msgid "Translate {model_name}"
+msgstr ""
+
+#: views.py:141
+#, python-brace-format
+msgid "Successfully created {locales} for {model_name} '{object}'"
+msgstr ""
+
+#: wagtail_hooks.py:76
+#, python-format
+msgid "Translate '%(title)s'"
+msgstr ""

--- a/wagtail/contrib/simple_translation/locale/nl_NL/LC_MESSAGES/django.po
+++ b/wagtail/contrib/simple_translation/locale/nl_NL/LC_MESSAGES/django.po
@@ -1,0 +1,78 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-04-21 09:34+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+
+#: apps.py:8
+msgid "Wagtail simple translation"
+msgstr ""
+
+#: forms.py:10
+msgid "Select all"
+msgstr ""
+
+#: forms.py:12
+msgid "Locales"
+msgstr ""
+
+#: forms.py:17
+msgid "All child pages will be created."
+msgstr ""
+
+#: forms.py:31
+msgid "Include subtree ({} page)"
+msgid_plural "Include subtree ({} pages)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/simple_translation/admin/submit_translation.html:25
+msgid "Submit"
+msgstr ""
+
+#: tests/test_views.py:44 tests/test_views.py:45 views.py:21
+#: wagtail_hooks.py:55 wagtail_hooks.py:74
+msgid "Translate"
+msgstr ""
+
+#: views.py:73
+msgid "{} locales"
+msgstr ""
+
+#: views.py:91
+msgid "Translate page"
+msgstr ""
+
+#: views.py:110
+#, python-brace-format
+msgid "The page '{page_title}' was successfully created in {locales}"
+msgstr ""
+
+#: views.py:116
+#, python-brace-format
+msgid "Translate {model_name}"
+msgstr ""
+
+#: views.py:141
+#, python-brace-format
+msgid "Successfully created {locales} for {model_name} '{object}'"
+msgstr ""
+
+#: wagtail_hooks.py:76
+#, python-format
+msgid "Translate '%(title)s'"
+msgstr ""

--- a/wagtail/contrib/simple_translation/locale/pl/LC_MESSAGES/django.po
+++ b/wagtail/contrib/simple_translation/locale/pl/LC_MESSAGES/django.po
@@ -1,0 +1,80 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-04-21 09:34+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=4; plural=(n==1 ? 0 : (n%10>=2 && n%10<=4) && (n"
+"%100<12 || n%100>14) ? 1 : n!=1 && (n%10>=0 && n%10<=1) || (n%10>=5 && n"
+"%10<=9) || (n%100>=12 && n%100<=14) ? 2 : 3);\n"
+
+#: apps.py:8
+msgid "Wagtail simple translation"
+msgstr ""
+
+#: forms.py:10
+msgid "Select all"
+msgstr ""
+
+#: forms.py:12
+msgid "Locales"
+msgstr ""
+
+#: forms.py:17
+msgid "All child pages will be created."
+msgstr ""
+
+#: forms.py:31
+msgid "Include subtree ({} page)"
+msgid_plural "Include subtree ({} pages)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/simple_translation/admin/submit_translation.html:25
+msgid "Submit"
+msgstr ""
+
+#: tests/test_views.py:44 tests/test_views.py:45 views.py:21
+#: wagtail_hooks.py:55 wagtail_hooks.py:74
+msgid "Translate"
+msgstr ""
+
+#: views.py:73
+msgid "{} locales"
+msgstr ""
+
+#: views.py:91
+msgid "Translate page"
+msgstr ""
+
+#: views.py:110
+#, python-brace-format
+msgid "The page '{page_title}' was successfully created in {locales}"
+msgstr ""
+
+#: views.py:116
+#, python-brace-format
+msgid "Translate {model_name}"
+msgstr ""
+
+#: views.py:141
+#, python-brace-format
+msgid "Successfully created {locales} for {model_name} '{object}'"
+msgstr ""
+
+#: wagtail_hooks.py:76
+#, python-format
+msgid "Translate '%(title)s'"
+msgstr ""

--- a/wagtail/contrib/simple_translation/locale/pt_BR/LC_MESSAGES/django.po
+++ b/wagtail/contrib/simple_translation/locale/pt_BR/LC_MESSAGES/django.po
@@ -1,0 +1,78 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-04-21 09:34+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#: apps.py:8
+msgid "Wagtail simple translation"
+msgstr ""
+
+#: forms.py:10
+msgid "Select all"
+msgstr ""
+
+#: forms.py:12
+msgid "Locales"
+msgstr ""
+
+#: forms.py:17
+msgid "All child pages will be created."
+msgstr ""
+
+#: forms.py:31
+msgid "Include subtree ({} page)"
+msgid_plural "Include subtree ({} pages)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/simple_translation/admin/submit_translation.html:25
+msgid "Submit"
+msgstr ""
+
+#: tests/test_views.py:44 tests/test_views.py:45 views.py:21
+#: wagtail_hooks.py:55 wagtail_hooks.py:74
+msgid "Translate"
+msgstr ""
+
+#: views.py:73
+msgid "{} locales"
+msgstr ""
+
+#: views.py:91
+msgid "Translate page"
+msgstr ""
+
+#: views.py:110
+#, python-brace-format
+msgid "The page '{page_title}' was successfully created in {locales}"
+msgstr ""
+
+#: views.py:116
+#, python-brace-format
+msgid "Translate {model_name}"
+msgstr ""
+
+#: views.py:141
+#, python-brace-format
+msgid "Successfully created {locales} for {model_name} '{object}'"
+msgstr ""
+
+#: wagtail_hooks.py:76
+#, python-format
+msgid "Translate '%(title)s'"
+msgstr ""

--- a/wagtail/contrib/simple_translation/locale/pt_PT/LC_MESSAGES/django.po
+++ b/wagtail/contrib/simple_translation/locale/pt_PT/LC_MESSAGES/django.po
@@ -1,0 +1,78 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-04-21 09:34+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+
+#: apps.py:8
+msgid "Wagtail simple translation"
+msgstr ""
+
+#: forms.py:10
+msgid "Select all"
+msgstr ""
+
+#: forms.py:12
+msgid "Locales"
+msgstr ""
+
+#: forms.py:17
+msgid "All child pages will be created."
+msgstr ""
+
+#: forms.py:31
+msgid "Include subtree ({} page)"
+msgid_plural "Include subtree ({} pages)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/simple_translation/admin/submit_translation.html:25
+msgid "Submit"
+msgstr ""
+
+#: tests/test_views.py:44 tests/test_views.py:45 views.py:21
+#: wagtail_hooks.py:55 wagtail_hooks.py:74
+msgid "Translate"
+msgstr ""
+
+#: views.py:73
+msgid "{} locales"
+msgstr ""
+
+#: views.py:91
+msgid "Translate page"
+msgstr ""
+
+#: views.py:110
+#, python-brace-format
+msgid "The page '{page_title}' was successfully created in {locales}"
+msgstr ""
+
+#: views.py:116
+#, python-brace-format
+msgid "Translate {model_name}"
+msgstr ""
+
+#: views.py:141
+#, python-brace-format
+msgid "Successfully created {locales} for {model_name} '{object}'"
+msgstr ""
+
+#: wagtail_hooks.py:76
+#, python-format
+msgid "Translate '%(title)s'"
+msgstr ""

--- a/wagtail/contrib/simple_translation/locale/ro/LC_MESSAGES/django.po
+++ b/wagtail/contrib/simple_translation/locale/ro/LC_MESSAGES/django.po
@@ -1,0 +1,79 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-04-21 09:34+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n==1?0:(((n%100>19)||((n%100==0)&&(n!=0)))?"
+"2:1));\n"
+
+#: apps.py:8
+msgid "Wagtail simple translation"
+msgstr ""
+
+#: forms.py:10
+msgid "Select all"
+msgstr ""
+
+#: forms.py:12
+msgid "Locales"
+msgstr ""
+
+#: forms.py:17
+msgid "All child pages will be created."
+msgstr ""
+
+#: forms.py:31
+msgid "Include subtree ({} page)"
+msgid_plural "Include subtree ({} pages)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/simple_translation/admin/submit_translation.html:25
+msgid "Submit"
+msgstr ""
+
+#: tests/test_views.py:44 tests/test_views.py:45 views.py:21
+#: wagtail_hooks.py:55 wagtail_hooks.py:74
+msgid "Translate"
+msgstr ""
+
+#: views.py:73
+msgid "{} locales"
+msgstr ""
+
+#: views.py:91
+msgid "Translate page"
+msgstr ""
+
+#: views.py:110
+#, python-brace-format
+msgid "The page '{page_title}' was successfully created in {locales}"
+msgstr ""
+
+#: views.py:116
+#, python-brace-format
+msgid "Translate {model_name}"
+msgstr ""
+
+#: views.py:141
+#, python-brace-format
+msgid "Successfully created {locales} for {model_name} '{object}'"
+msgstr ""
+
+#: wagtail_hooks.py:76
+#, python-format
+msgid "Translate '%(title)s'"
+msgstr ""

--- a/wagtail/contrib/simple_translation/locale/ru/LC_MESSAGES/django.po
+++ b/wagtail/contrib/simple_translation/locale/ru/LC_MESSAGES/django.po
@@ -1,0 +1,80 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-04-21 09:34+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n"
+"%100>=11 && n%100<=14)? 2 : 3);\n"
+
+#: apps.py:8
+msgid "Wagtail simple translation"
+msgstr ""
+
+#: forms.py:10
+msgid "Select all"
+msgstr ""
+
+#: forms.py:12
+msgid "Locales"
+msgstr ""
+
+#: forms.py:17
+msgid "All child pages will be created."
+msgstr ""
+
+#: forms.py:31
+msgid "Include subtree ({} page)"
+msgid_plural "Include subtree ({} pages)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/simple_translation/admin/submit_translation.html:25
+msgid "Submit"
+msgstr ""
+
+#: tests/test_views.py:44 tests/test_views.py:45 views.py:21
+#: wagtail_hooks.py:55 wagtail_hooks.py:74
+msgid "Translate"
+msgstr ""
+
+#: views.py:73
+msgid "{} locales"
+msgstr ""
+
+#: views.py:91
+msgid "Translate page"
+msgstr ""
+
+#: views.py:110
+#, python-brace-format
+msgid "The page '{page_title}' was successfully created in {locales}"
+msgstr ""
+
+#: views.py:116
+#, python-brace-format
+msgid "Translate {model_name}"
+msgstr ""
+
+#: views.py:141
+#, python-brace-format
+msgid "Successfully created {locales} for {model_name} '{object}'"
+msgstr ""
+
+#: wagtail_hooks.py:76
+#, python-format
+msgid "Translate '%(title)s'"
+msgstr ""

--- a/wagtail/contrib/simple_translation/locale/sk_SK/LC_MESSAGES/django.po
+++ b/wagtail/contrib/simple_translation/locale/sk_SK/LC_MESSAGES/django.po
@@ -1,0 +1,78 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-04-21 09:34+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+
+#: apps.py:8
+msgid "Wagtail simple translation"
+msgstr ""
+
+#: forms.py:10
+msgid "Select all"
+msgstr ""
+
+#: forms.py:12
+msgid "Locales"
+msgstr ""
+
+#: forms.py:17
+msgid "All child pages will be created."
+msgstr ""
+
+#: forms.py:31
+msgid "Include subtree ({} page)"
+msgid_plural "Include subtree ({} pages)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/simple_translation/admin/submit_translation.html:25
+msgid "Submit"
+msgstr ""
+
+#: tests/test_views.py:44 tests/test_views.py:45 views.py:21
+#: wagtail_hooks.py:55 wagtail_hooks.py:74
+msgid "Translate"
+msgstr ""
+
+#: views.py:73
+msgid "{} locales"
+msgstr ""
+
+#: views.py:91
+msgid "Translate page"
+msgstr ""
+
+#: views.py:110
+#, python-brace-format
+msgid "The page '{page_title}' was successfully created in {locales}"
+msgstr ""
+
+#: views.py:116
+#, python-brace-format
+msgid "Translate {model_name}"
+msgstr ""
+
+#: views.py:141
+#, python-brace-format
+msgid "Successfully created {locales} for {model_name} '{object}'"
+msgstr ""
+
+#: wagtail_hooks.py:76
+#, python-format
+msgid "Translate '%(title)s'"
+msgstr ""

--- a/wagtail/contrib/simple_translation/locale/sl/LC_MESSAGES/django.po
+++ b/wagtail/contrib/simple_translation/locale/sl/LC_MESSAGES/django.po
@@ -1,0 +1,79 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-04-21 09:34+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n"
+"%100==4 ? 2 : 3);\n"
+
+#: apps.py:8
+msgid "Wagtail simple translation"
+msgstr ""
+
+#: forms.py:10
+msgid "Select all"
+msgstr ""
+
+#: forms.py:12
+msgid "Locales"
+msgstr ""
+
+#: forms.py:17
+msgid "All child pages will be created."
+msgstr ""
+
+#: forms.py:31
+msgid "Include subtree ({} page)"
+msgid_plural "Include subtree ({} pages)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/simple_translation/admin/submit_translation.html:25
+msgid "Submit"
+msgstr ""
+
+#: tests/test_views.py:44 tests/test_views.py:45 views.py:21
+#: wagtail_hooks.py:55 wagtail_hooks.py:74
+msgid "Translate"
+msgstr ""
+
+#: views.py:73
+msgid "{} locales"
+msgstr ""
+
+#: views.py:91
+msgid "Translate page"
+msgstr ""
+
+#: views.py:110
+#, python-brace-format
+msgid "The page '{page_title}' was successfully created in {locales}"
+msgstr ""
+
+#: views.py:116
+#, python-brace-format
+msgid "Translate {model_name}"
+msgstr ""
+
+#: views.py:141
+#, python-brace-format
+msgid "Successfully created {locales} for {model_name} '{object}'"
+msgstr ""
+
+#: wagtail_hooks.py:76
+#, python-format
+msgid "Translate '%(title)s'"
+msgstr ""

--- a/wagtail/contrib/simple_translation/locale/sv/LC_MESSAGES/django.po
+++ b/wagtail/contrib/simple_translation/locale/sv/LC_MESSAGES/django.po
@@ -1,0 +1,78 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-04-21 09:34+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: apps.py:8
+msgid "Wagtail simple translation"
+msgstr ""
+
+#: forms.py:10
+msgid "Select all"
+msgstr ""
+
+#: forms.py:12
+msgid "Locales"
+msgstr ""
+
+#: forms.py:17
+msgid "All child pages will be created."
+msgstr ""
+
+#: forms.py:31
+msgid "Include subtree ({} page)"
+msgid_plural "Include subtree ({} pages)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/simple_translation/admin/submit_translation.html:25
+msgid "Submit"
+msgstr ""
+
+#: tests/test_views.py:44 tests/test_views.py:45 views.py:21
+#: wagtail_hooks.py:55 wagtail_hooks.py:74
+msgid "Translate"
+msgstr ""
+
+#: views.py:73
+msgid "{} locales"
+msgstr ""
+
+#: views.py:91
+msgid "Translate page"
+msgstr ""
+
+#: views.py:110
+#, python-brace-format
+msgid "The page '{page_title}' was successfully created in {locales}"
+msgstr ""
+
+#: views.py:116
+#, python-brace-format
+msgid "Translate {model_name}"
+msgstr ""
+
+#: views.py:141
+#, python-brace-format
+msgid "Successfully created {locales} for {model_name} '{object}'"
+msgstr ""
+
+#: wagtail_hooks.py:76
+#, python-format
+msgid "Translate '%(title)s'"
+msgstr ""

--- a/wagtail/contrib/simple_translation/locale/tet/LC_MESSAGES/django.po
+++ b/wagtail/contrib/simple_translation/locale/tet/LC_MESSAGES/django.po
@@ -1,0 +1,78 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-04-21 09:34+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+
+#: apps.py:8
+msgid "Wagtail simple translation"
+msgstr ""
+
+#: forms.py:10
+msgid "Select all"
+msgstr ""
+
+#: forms.py:12
+msgid "Locales"
+msgstr ""
+
+#: forms.py:17
+msgid "All child pages will be created."
+msgstr ""
+
+#: forms.py:31
+msgid "Include subtree ({} page)"
+msgid_plural "Include subtree ({} pages)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/simple_translation/admin/submit_translation.html:25
+msgid "Submit"
+msgstr ""
+
+#: tests/test_views.py:44 tests/test_views.py:45 views.py:21
+#: wagtail_hooks.py:55 wagtail_hooks.py:74
+msgid "Translate"
+msgstr ""
+
+#: views.py:73
+msgid "{} locales"
+msgstr ""
+
+#: views.py:91
+msgid "Translate page"
+msgstr ""
+
+#: views.py:110
+#, python-brace-format
+msgid "The page '{page_title}' was successfully created in {locales}"
+msgstr ""
+
+#: views.py:116
+#, python-brace-format
+msgid "Translate {model_name}"
+msgstr ""
+
+#: views.py:141
+#, python-brace-format
+msgid "Successfully created {locales} for {model_name} '{object}'"
+msgstr ""
+
+#: wagtail_hooks.py:76
+#, python-format
+msgid "Translate '%(title)s'"
+msgstr ""

--- a/wagtail/contrib/simple_translation/locale/th/LC_MESSAGES/django.po
+++ b/wagtail/contrib/simple_translation/locale/th/LC_MESSAGES/django.po
@@ -1,0 +1,78 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-04-21 09:34+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#: apps.py:8
+msgid "Wagtail simple translation"
+msgstr ""
+
+#: forms.py:10
+msgid "Select all"
+msgstr ""
+
+#: forms.py:12
+msgid "Locales"
+msgstr ""
+
+#: forms.py:17
+msgid "All child pages will be created."
+msgstr ""
+
+#: forms.py:31
+msgid "Include subtree ({} page)"
+msgid_plural "Include subtree ({} pages)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/simple_translation/admin/submit_translation.html:25
+msgid "Submit"
+msgstr ""
+
+#: tests/test_views.py:44 tests/test_views.py:45 views.py:21
+#: wagtail_hooks.py:55 wagtail_hooks.py:74
+msgid "Translate"
+msgstr ""
+
+#: views.py:73
+msgid "{} locales"
+msgstr ""
+
+#: views.py:91
+msgid "Translate page"
+msgstr ""
+
+#: views.py:110
+#, python-brace-format
+msgid "The page '{page_title}' was successfully created in {locales}"
+msgstr ""
+
+#: views.py:116
+#, python-brace-format
+msgid "Translate {model_name}"
+msgstr ""
+
+#: views.py:141
+#, python-brace-format
+msgid "Successfully created {locales} for {model_name} '{object}'"
+msgstr ""
+
+#: wagtail_hooks.py:76
+#, python-format
+msgid "Translate '%(title)s'"
+msgstr ""

--- a/wagtail/contrib/simple_translation/locale/tr/LC_MESSAGES/django.po
+++ b/wagtail/contrib/simple_translation/locale/tr/LC_MESSAGES/django.po
@@ -1,0 +1,78 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-04-21 09:34+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#: apps.py:8
+msgid "Wagtail simple translation"
+msgstr ""
+
+#: forms.py:10
+msgid "Select all"
+msgstr ""
+
+#: forms.py:12
+msgid "Locales"
+msgstr ""
+
+#: forms.py:17
+msgid "All child pages will be created."
+msgstr ""
+
+#: forms.py:31
+msgid "Include subtree ({} page)"
+msgid_plural "Include subtree ({} pages)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/simple_translation/admin/submit_translation.html:25
+msgid "Submit"
+msgstr ""
+
+#: tests/test_views.py:44 tests/test_views.py:45 views.py:21
+#: wagtail_hooks.py:55 wagtail_hooks.py:74
+msgid "Translate"
+msgstr ""
+
+#: views.py:73
+msgid "{} locales"
+msgstr ""
+
+#: views.py:91
+msgid "Translate page"
+msgstr ""
+
+#: views.py:110
+#, python-brace-format
+msgid "The page '{page_title}' was successfully created in {locales}"
+msgstr ""
+
+#: views.py:116
+#, python-brace-format
+msgid "Translate {model_name}"
+msgstr ""
+
+#: views.py:141
+#, python-brace-format
+msgid "Successfully created {locales} for {model_name} '{object}'"
+msgstr ""
+
+#: wagtail_hooks.py:76
+#, python-format
+msgid "Translate '%(title)s'"
+msgstr ""

--- a/wagtail/contrib/simple_translation/locale/tr_TR/LC_MESSAGES/django.po
+++ b/wagtail/contrib/simple_translation/locale/tr_TR/LC_MESSAGES/django.po
@@ -1,0 +1,78 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-04-21 09:34+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+
+#: apps.py:8
+msgid "Wagtail simple translation"
+msgstr ""
+
+#: forms.py:10
+msgid "Select all"
+msgstr ""
+
+#: forms.py:12
+msgid "Locales"
+msgstr ""
+
+#: forms.py:17
+msgid "All child pages will be created."
+msgstr ""
+
+#: forms.py:31
+msgid "Include subtree ({} page)"
+msgid_plural "Include subtree ({} pages)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/simple_translation/admin/submit_translation.html:25
+msgid "Submit"
+msgstr ""
+
+#: tests/test_views.py:44 tests/test_views.py:45 views.py:21
+#: wagtail_hooks.py:55 wagtail_hooks.py:74
+msgid "Translate"
+msgstr ""
+
+#: views.py:73
+msgid "{} locales"
+msgstr ""
+
+#: views.py:91
+msgid "Translate page"
+msgstr ""
+
+#: views.py:110
+#, python-brace-format
+msgid "The page '{page_title}' was successfully created in {locales}"
+msgstr ""
+
+#: views.py:116
+#, python-brace-format
+msgid "Translate {model_name}"
+msgstr ""
+
+#: views.py:141
+#, python-brace-format
+msgid "Successfully created {locales} for {model_name} '{object}'"
+msgstr ""
+
+#: wagtail_hooks.py:76
+#, python-format
+msgid "Translate '%(title)s'"
+msgstr ""

--- a/wagtail/contrib/simple_translation/locale/uk/LC_MESSAGES/django.po
+++ b/wagtail/contrib/simple_translation/locale/uk/LC_MESSAGES/django.po
@@ -1,0 +1,81 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-04-21 09:34+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=4; plural=(n % 1 == 0 && n % 10 == 1 && n % 100 != "
+"11 ? 0 : n % 1 == 0 && n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 12 || n % "
+"100 > 14) ? 1 : n % 1 == 0 && (n % 10 ==0 || (n % 10 >=5 && n % 10 <=9) || "
+"(n % 100 >=11 && n % 100 <=14 )) ? 2: 3);\n"
+
+#: apps.py:8
+msgid "Wagtail simple translation"
+msgstr ""
+
+#: forms.py:10
+msgid "Select all"
+msgstr ""
+
+#: forms.py:12
+msgid "Locales"
+msgstr ""
+
+#: forms.py:17
+msgid "All child pages will be created."
+msgstr ""
+
+#: forms.py:31
+msgid "Include subtree ({} page)"
+msgid_plural "Include subtree ({} pages)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/simple_translation/admin/submit_translation.html:25
+msgid "Submit"
+msgstr ""
+
+#: tests/test_views.py:44 tests/test_views.py:45 views.py:21
+#: wagtail_hooks.py:55 wagtail_hooks.py:74
+msgid "Translate"
+msgstr ""
+
+#: views.py:73
+msgid "{} locales"
+msgstr ""
+
+#: views.py:91
+msgid "Translate page"
+msgstr ""
+
+#: views.py:110
+#, python-brace-format
+msgid "The page '{page_title}' was successfully created in {locales}"
+msgstr ""
+
+#: views.py:116
+#, python-brace-format
+msgid "Translate {model_name}"
+msgstr ""
+
+#: views.py:141
+#, python-brace-format
+msgid "Successfully created {locales} for {model_name} '{object}'"
+msgstr ""
+
+#: wagtail_hooks.py:76
+#, python-format
+msgid "Translate '%(title)s'"
+msgstr ""

--- a/wagtail/contrib/simple_translation/locale/zh/LC_MESSAGES/django.po
+++ b/wagtail/contrib/simple_translation/locale/zh/LC_MESSAGES/django.po
@@ -1,0 +1,78 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-04-21 09:34+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+
+#: apps.py:8
+msgid "Wagtail simple translation"
+msgstr ""
+
+#: forms.py:10
+msgid "Select all"
+msgstr ""
+
+#: forms.py:12
+msgid "Locales"
+msgstr ""
+
+#: forms.py:17
+msgid "All child pages will be created."
+msgstr ""
+
+#: forms.py:31
+msgid "Include subtree ({} page)"
+msgid_plural "Include subtree ({} pages)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/simple_translation/admin/submit_translation.html:25
+msgid "Submit"
+msgstr ""
+
+#: tests/test_views.py:44 tests/test_views.py:45 views.py:21
+#: wagtail_hooks.py:55 wagtail_hooks.py:74
+msgid "Translate"
+msgstr ""
+
+#: views.py:73
+msgid "{} locales"
+msgstr ""
+
+#: views.py:91
+msgid "Translate page"
+msgstr ""
+
+#: views.py:110
+#, python-brace-format
+msgid "The page '{page_title}' was successfully created in {locales}"
+msgstr ""
+
+#: views.py:116
+#, python-brace-format
+msgid "Translate {model_name}"
+msgstr ""
+
+#: views.py:141
+#, python-brace-format
+msgid "Successfully created {locales} for {model_name} '{object}'"
+msgstr ""
+
+#: wagtail_hooks.py:76
+#, python-format
+msgid "Translate '%(title)s'"
+msgstr ""

--- a/wagtail/contrib/simple_translation/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/wagtail/contrib/simple_translation/locale/zh_Hans/LC_MESSAGES/django.po
@@ -1,0 +1,78 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-04-21 09:34+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#: apps.py:8
+msgid "Wagtail simple translation"
+msgstr ""
+
+#: forms.py:10
+msgid "Select all"
+msgstr ""
+
+#: forms.py:12
+msgid "Locales"
+msgstr ""
+
+#: forms.py:17
+msgid "All child pages will be created."
+msgstr ""
+
+#: forms.py:31
+msgid "Include subtree ({} page)"
+msgid_plural "Include subtree ({} pages)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/simple_translation/admin/submit_translation.html:25
+msgid "Submit"
+msgstr ""
+
+#: tests/test_views.py:44 tests/test_views.py:45 views.py:21
+#: wagtail_hooks.py:55 wagtail_hooks.py:74
+msgid "Translate"
+msgstr ""
+
+#: views.py:73
+msgid "{} locales"
+msgstr ""
+
+#: views.py:91
+msgid "Translate page"
+msgstr ""
+
+#: views.py:110
+#, python-brace-format
+msgid "The page '{page_title}' was successfully created in {locales}"
+msgstr ""
+
+#: views.py:116
+#, python-brace-format
+msgid "Translate {model_name}"
+msgstr ""
+
+#: views.py:141
+#, python-brace-format
+msgid "Successfully created {locales} for {model_name} '{object}'"
+msgstr ""
+
+#: wagtail_hooks.py:76
+#, python-format
+msgid "Translate '%(title)s'"
+msgstr ""

--- a/wagtail/contrib/simple_translation/locale/zh_Hant/LC_MESSAGES/django.po
+++ b/wagtail/contrib/simple_translation/locale/zh_Hant/LC_MESSAGES/django.po
@@ -1,0 +1,78 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-04-21 09:34+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#: apps.py:8
+msgid "Wagtail simple translation"
+msgstr ""
+
+#: forms.py:10
+msgid "Select all"
+msgstr ""
+
+#: forms.py:12
+msgid "Locales"
+msgstr ""
+
+#: forms.py:17
+msgid "All child pages will be created."
+msgstr ""
+
+#: forms.py:31
+msgid "Include subtree ({} page)"
+msgid_plural "Include subtree ({} pages)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/simple_translation/admin/submit_translation.html:25
+msgid "Submit"
+msgstr ""
+
+#: tests/test_views.py:44 tests/test_views.py:45 views.py:21
+#: wagtail_hooks.py:55 wagtail_hooks.py:74
+msgid "Translate"
+msgstr ""
+
+#: views.py:73
+msgid "{} locales"
+msgstr ""
+
+#: views.py:91
+msgid "Translate page"
+msgstr ""
+
+#: views.py:110
+#, python-brace-format
+msgid "The page '{page_title}' was successfully created in {locales}"
+msgstr ""
+
+#: views.py:116
+#, python-brace-format
+msgid "Translate {model_name}"
+msgstr ""
+
+#: views.py:141
+#, python-brace-format
+msgid "Successfully created {locales} for {model_name} '{object}'"
+msgstr ""
+
+#: wagtail_hooks.py:76
+#, python-format
+msgid "Translate '%(title)s'"
+msgstr ""


### PR DESCRIPTION
Added the locales to simple_translation. I took the same locales as in `wagtail/core/locale`.

@gasman These need to be synced with Transifex. Since there are no changes to main that mutate translation keys, that should not be a problem. Maybe there is a way to only sync `wagtail.contrib.simple_translation`?

* Do the tests still pass? (https://docs.wagtail.io/en/latest/contributing/developing.html#testing) YES
* Does the code comply with the style guide? (Run `make lint` from the Wagtail root) N/A
* For Python changes: Have you added tests to cover the new/fixed behaviour? N/A
* For front-end changes: Did you test on all of Wagtail’s supported browsers? **Please list the exact versions you tested**. N/A
* For new features: Has the documentation been updated accordingly? N/A
