### PR TITLE
Feature/commenting make comment buttons focusable

### DIFF
--- a/client/scss/components/_forms.scss
+++ b/client/scss/components/_forms.scss
@@ -503,6 +503,11 @@ li.inline:first-child {
                 }
             }
 
+            &:focus {
+                opacity: 1;
+                pointer-events: initial;
+            }
+
             > svg {
                 width: 30px;
                 height: 30px;


### PR DESCRIPTION
@jacobtoppm it doesn't look like the button inside Draftail's toolbar is reachable, but I think that's likely a separate issue or user error on my part - I can't tab to any of Draftail's toolbar buttons.