### PR TITLE
Fix for CheckboxSelectMultiple widget

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -104,3 +104,8 @@ source_file = wagtail/contrib/table_block/locale/en/LC_MESSAGES/django.po
 source_lang = en
 type = PO
 
+[wagtail.wagtailsimpletranslation]
+file_filter = wagtail/contrib/simple_translation/locale/<lang>/LC_MESSAGES/django.po
+source_file = wagtail/contrib/simple_translation/locale/en/LC_MESSAGES/django.po
+source_lang = en
+type = PO

--- a/client/scss/components/_forms.scss
+++ b/client/scss/components/_forms.scss
@@ -503,6 +503,11 @@ li.inline:first-child {
                 }
             }
 
+            &:focus {
+                opacity: 1;
+                pointer-events: initial;
+            }
+
             > svg {
                 width: 30px;
                 height: 30px;

--- a/client/src/components/CommentApp/components/CommentHeader/index.tsx
+++ b/client/src/components/CommentApp/components/CommentHeader/index.tsx
@@ -82,7 +82,7 @@ export const CommentHeader: FunctionComponent<CommentHeaderProps> = ({
         <img className="comment-header__avatar" src={author.avatarUrl} role="presentation" />}
       <span id={descriptionId}>
         <p className="comment-header__author">{author ? author.name : ''}</p>
-        <p className="comment-header__date">{dateFormat(date, 'h:MM mmmm d')}</p>
+        <p className="comment-header__date">{dateFormat(date, 'd mmm yyyy HH:MM')}</p>
       </span>
     </div>
   );

--- a/docs/releases/2.13.rst
+++ b/docs/releases/2.13.rst
@@ -46,11 +46,11 @@ The redirects module now includes support for exporting the list of redirects to
 Sphinx Wagtail Theme
 ~~~~~~~~~~~~~~~~~~~~
 
-The `documentation <https://docs.wagtail.io/>`_ now uses `Sphinx Wagtail Theme <https://github.com/wagtail/sphinx_wagtail_theme>`_.
+The `documentation <https://docs.wagtail.io/>`_ now uses our brand new `Sphinx Wagtail Theme <https://github.com/wagtail/sphinx_wagtail_theme>`_, with a search feature powered by `Algolia DocSearch <https://docsearch.algolia.com/>`_.
 
-Feedback and feature requests may be reported to the `theme issue list <https://github.com/wagtail/sphinx_wagtail_theme/issues>`_.
+Feedback and feature requests for the theme may be reported to the `sphinx_wagtail_theme issue list <https://github.com/wagtail/sphinx_wagtail_theme/issues>`_, and to Wagtail’s issues for the search.
 
-This theme is developed by Storm Heg, Tibor Leupold, Thibaud Colas and Coen van der Kamp.
+Thank you to Storm Heg, Tibor Leupold, Thibaud Colas, Coen van der Kamp, Olly Willans, Naomi Morduch Toubman, Scott Cranfill, and Andy Chosak for making this happen!
 
 Other features
 ~~~~~~~~~~~~~~

--- a/wagtail/__init__.py
+++ b/wagtail/__init__.py
@@ -7,7 +7,7 @@ from wagtail.utils.version import get_semver_version, get_version
 
 # major.minor.patch.release.number
 # release must be one of alpha, beta, rc, or final
-VERSION = (2, 13, 0, 'alpha', 0)
+VERSION = (2, 13, 0, 'rc', 1)
 
 __version__ = get_version(VERSION)
 

--- a/wagtail/contrib/simple_translation/locale/en/LC_MESSAGES/django.po
+++ b/wagtail/contrib/simple_translation/locale/en/LC_MESSAGES/django.po
@@ -1,0 +1,75 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-04-21 09:32+0100\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: apps.py:8
+msgid "Wagtail simple translation"
+msgstr ""
+
+#: forms.py:10
+msgid "Select all"
+msgstr ""
+
+#: forms.py:12
+msgid "Locales"
+msgstr ""
+
+#: forms.py:17
+msgid "All child pages will be created."
+msgstr ""
+
+#: forms.py:31
+msgid "Include subtree ({} page)"
+msgid_plural "Include subtree ({} pages)"
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/simple_translation/admin/submit_translation.html:25
+msgid "Submit"
+msgstr ""
+
+#: tests/test_views.py:44 tests/test_views.py:45 views.py:21
+#: wagtail_hooks.py:55 wagtail_hooks.py:74
+msgid "Translate"
+msgstr ""
+
+#: views.py:73
+msgid "{} locales"
+msgstr ""
+
+#: views.py:91
+msgid "Translate page"
+msgstr ""
+
+#: views.py:110
+msgid "The page '{page_title}' was successfully created in {locales}"
+msgstr ""
+
+#: views.py:116
+msgid "Translate {model_name}"
+msgstr ""
+
+#: views.py:141
+msgid "Successfully created {locales} for {model_name} '{object}'"
+msgstr ""
+
+#: wagtail_hooks.py:76
+#, python-format
+msgid "Translate '%(title)s'"
+msgstr ""

--- a/wagtail/core/widget_adapters.py
+++ b/wagtail/core/widget_adapters.py
@@ -34,6 +34,7 @@ class WidgetAdapter(Adapter):
 register(WidgetAdapter(), forms.widgets.Input)
 register(WidgetAdapter(), forms.Textarea)
 register(WidgetAdapter(), forms.Select)
+register(WidgetAdapter(), forms.CheckboxSelectMultiple)
 
 
 class RadioSelectAdapter(WidgetAdapter):

--- a/wagtail/project_template/requirements.txt
+++ b/wagtail/project_template/requirements.txt
@@ -1,2 +1,2 @@
 Django>=3.1,<3.2
-wagtail==2.13a0
+wagtail==2.13rc1

--- a/wagtail/project_template/requirements.txt
+++ b/wagtail/project_template/requirements.txt
@@ -1,2 +1,2 @@
-Django>=3.1,<3.2
+Django>=3.2,<3.3
 wagtail==2.13rc1


### PR DESCRIPTION
Without this, any project that uses `django.forms.widgets.CheckboxSelectMultiple` crashes needlessly in any step that touches the database, because of Telepath's "don't know how to pack object" error. 

Simply applying WidgetAdapter to CheckboxSelectMultiple seems to work fine, though I haven't tested it in any robust way. I just went in to my site that uses CheckboxSelectMultiple in several places, and confirmed that it still works.