### PR TITLE
Apply WidgetAdapter to CheckboxSelectMultiple.

### DIFF
--- a/wagtail/core/widget_adapters.py
+++ b/wagtail/core/widget_adapters.py
@@ -34,6 +34,7 @@ class WidgetAdapter(Adapter):
 register(WidgetAdapter(), forms.widgets.Input)
 register(WidgetAdapter(), forms.Textarea)
 register(WidgetAdapter(), forms.Select)
+register(WidgetAdapter(), forms.CheckboxSelectMultiple)
 
 
 class RadioSelectAdapter(WidgetAdapter):


### PR DESCRIPTION
Without this, any project that uses `django.forms.widgets.CheckboxSelectMultiple` crashes needlessly in any step that touches the database, because of Telepath's "don't know how to pack object" error.

Simply applying WidgetAdapter to CheckboxSelectMultiple seems to work fine, though I haven't tested it in any robust way. I just went in to my site that uses CheckboxSelectMultiple in several places, and confirmed that it still functions.