### PR TITLE
Fix comments list height to prevent grey bar at bottom

### DIFF
--- a/client/src/components/CommentApp/main.scss
+++ b/client/src/components/CommentApp/main.scss
@@ -143,7 +143,7 @@ $color-textarea-placeholder-text: $color-grey-2;
 }
 
 .comments-list {
-    height: 100%;
+    height: 100vh;
     width: 400px;
     position: absolute;
     top: 30px;


### PR DESCRIPTION
Previously on Chrome there was a grey bar visible at the very bottom of the edit view