### PR TITLE
Draft: Feature/commenting responsive layout

### DIFF
--- a/client/scss/components/_forms.scss
+++ b/client/scss/components/_forms.scss
@@ -440,7 +440,11 @@ li.inline:first-child {
     }
 
     .field-content {
-        padding-right: 60px;
+        padding-right: 45px;
+
+        @include media-breakpoint-up(sm) {
+            padding-right: 60px;
+        }
     }
 
     .widget-draftail_rich_text_area .field-content {
@@ -448,6 +452,7 @@ li.inline:first-child {
     }
 
     .field-comment-control {
+        position: absolute;
         display: block;
         top: 0;
         right: 0;
@@ -462,10 +467,6 @@ li.inline:first-child {
             }
         }
 
-        @include media-breakpoint-up(md) {
-            position: absolute;
-        }
-
         button {
             @include transition(opacity 0.2s ease);
             border: 0;
@@ -476,7 +477,11 @@ li.inline:first-child {
             border-radius: 3px;
             position: absolute;
             top: 50%;
-            right: 10px;
+            right: 0;
+
+            @include media-breakpoint-up(sm) {
+                right: 10px;
+            }
 
             // Hide by default, reveal on hover of parent
             @include media-breakpoint-up(md) {

--- a/client/src/components/CommentApp/components/Comment/index.tsx
+++ b/client/src/components/CommentApp/components/Comment/index.tsx
@@ -629,7 +629,6 @@ export default class CommentComponent extends React.Component<CommentProps> {
         );
       }
     }
-
   }
 
   componentWillUnmount() {

--- a/client/src/components/CommentApp/components/Comment/index.tsx
+++ b/client/src/components/CommentApp/components/Comment/index.tsx
@@ -590,7 +590,7 @@ export default class CommentComponent extends React.Component<CommentProps> {
       this.props.comment.localId
     );
     const right = this.props.isFocused ? 50 : 0;
-    const mobileRight = this.props.isFocused ? 45 : -2000;
+    const mobileRight = this.props.isFocused ? 35 : -2000;
 
     return (
       <FocusTrap
@@ -614,9 +614,8 @@ export default class CommentComponent extends React.Component<CommentProps> {
             `comment comment--mode-${this.props.comment.mode} ${this.props.isFocused ? 'comment--focused' : ''}`
           }
           style={{
-            position: this.state.isMobile ? 'fixed' : 'absolute',
-            top: this.state.isMobile ? 'auto' : `${top}px`,
-            bottom: this.state.isMobile ? '40px' : 'auto',
+            position: 'absolute',
+            top: `${top}px`,
             right: this.state.isMobile ? `${mobileRight}px` : `${right}px`,
             display: this.props.isVisible ? 'block' : 'none',
           }}

--- a/client/src/components/CommentApp/components/Comment/index.tsx
+++ b/client/src/components/CommentApp/components/Comment/index.tsx
@@ -579,7 +579,7 @@ export default class CommentComponent extends React.Component<CommentProps> {
     const top = this.props.layout.getCommentPosition(
       this.props.comment.localId
     );
-    const right = this.props.isFocused ? 50 : 0;
+    const right = this.props.isFocused ? 10 : 0;
     return (
       <FocusTrap
         focusTrapOptions={{

--- a/client/src/components/CommentApp/components/Comment/index.tsx
+++ b/client/src/components/CommentApp/components/Comment/index.tsx
@@ -86,6 +86,16 @@ export interface CommentProps {
 }
 
 export default class CommentComponent extends React.Component<CommentProps> {
+  state = { isMobile: false };
+
+  updateDimensions = () => {
+    if (window.innerWidth < 800) {
+      this.setState({ isMobile: true });
+    } else {
+      this.setState({ isMobile: false });
+    }
+  };
+
   renderReplies({ hideNewReply = false } = {}): React.ReactFragment {
     const { comment, isFocused, store, user, strings } = this.props;
 
@@ -579,7 +589,9 @@ export default class CommentComponent extends React.Component<CommentProps> {
     const top = this.props.layout.getCommentPosition(
       this.props.comment.localId
     );
-    const right = this.props.isFocused ? 10 : 0;
+    const right = this.props.isFocused ? 50 : 0;
+    const mobileRight = this.props.isFocused ? 45 : -2000;
+
     return (
       <FocusTrap
         focusTrapOptions={{
@@ -602,9 +614,10 @@ export default class CommentComponent extends React.Component<CommentProps> {
             `comment comment--mode-${this.props.comment.mode} ${this.props.isFocused ? 'comment--focused' : ''}`
           }
           style={{
-            position: 'absolute',
-            top: `${top}px`,
-            right: `${right}px`,
+            position: this.state.isMobile ? 'fixed' : 'absolute',
+            top: this.state.isMobile ? 'auto' : `${top}px`,
+            bottom: this.state.isMobile ? '40px' : 'auto',
+            right: this.state.isMobile ? `${mobileRight}px` : `${right}px`,
             display: this.props.isVisible ? 'block' : 'none',
           }}
           data-comment-id={this.props.comment.localId}
@@ -630,10 +643,14 @@ export default class CommentComponent extends React.Component<CommentProps> {
         );
       }
     }
+
+    this.updateDimensions();
+    window.addEventListener('resize', this.updateDimensions);
   }
 
   componentWillUnmount() {
     this.props.layout.setCommentElement(this.props.comment.localId, null);
+    window.removeEventListener('resize', this.updateDimensions);
   }
 
   componentDidUpdate() {

--- a/client/src/components/CommentApp/components/Comment/index.tsx
+++ b/client/src/components/CommentApp/components/Comment/index.tsx
@@ -86,16 +86,6 @@ export interface CommentProps {
 }
 
 export default class CommentComponent extends React.Component<CommentProps> {
-  state = { isMobile: false };
-
-  updateDimensions = () => {
-    if (window.innerWidth < 800) {
-      this.setState({ isMobile: true });
-    } else {
-      this.setState({ isMobile: false });
-    }
-  };
-
   renderReplies({ hideNewReply = false } = {}): React.ReactFragment {
     const { comment, isFocused, store, user, strings } = this.props;
 
@@ -589,8 +579,6 @@ export default class CommentComponent extends React.Component<CommentProps> {
     const top = this.props.layout.getCommentPosition(
       this.props.comment.localId
     );
-    const right = this.props.isFocused ? 50 : 0;
-    const mobileRight = this.props.isFocused ? 35 : -2000;
 
     return (
       <FocusTrap
@@ -616,7 +604,6 @@ export default class CommentComponent extends React.Component<CommentProps> {
           style={{
             position: 'absolute',
             top: `${top}px`,
-            right: this.state.isMobile ? `${mobileRight}px` : `${right}px`,
             display: this.props.isVisible ? 'block' : 'none',
           }}
           data-comment-id={this.props.comment.localId}
@@ -643,13 +630,10 @@ export default class CommentComponent extends React.Component<CommentProps> {
       }
     }
 
-    this.updateDimensions();
-    window.addEventListener('resize', this.updateDimensions);
   }
 
   componentWillUnmount() {
     this.props.layout.setCommentElement(this.props.comment.localId, null);
-    window.removeEventListener('resize', this.updateDimensions);
   }
 
   componentDidUpdate() {

--- a/client/src/components/CommentApp/components/Comment/style.scss
+++ b/client/src/components/CommentApp/components/Comment/style.scss
@@ -1,9 +1,8 @@
 .comment {
     @include box;
 
-    bottom: 20px;
     width: calc(100vw - 40px);
-    max-width: 100%;
+    max-width: calc(100vw - 19%);
     display: block;
     transition: top 0.5s ease 0s, right 0.5s ease 0s, height 0.5s ease 0s;
     pointer-events: auto;

--- a/client/src/components/CommentApp/components/Comment/style.scss
+++ b/client/src/components/CommentApp/components/Comment/style.scss
@@ -1,12 +1,19 @@
 .comment {
     @include box;
 
-    width: 100%;
-    max-width: calc(100vw - 60px);
+    bottom: 20px;
+    width: calc(100vw - 40px);
+    max-width: 100%;
     display: block;
     transition: top 0.5s ease 0s, right 0.5s ease 0s, height 0.5s ease 0s;
     pointer-events: auto;
     box-sizing: border-box;
+
+    @include media-breakpoint-up(sm) {
+        width: calc(100vw - 40px);
+        max-width: 400px;
+        left: initial;
+    }
 
     @include media-breakpoint-up(md) {
         max-width: 200px;

--- a/client/src/components/CommentApp/components/Comment/style.scss
+++ b/client/src/components/CommentApp/components/Comment/style.scss
@@ -2,12 +2,13 @@
     @include box;
 
     width: 100%;
+    max-width: calc(100vw - 60px);
     display: block;
     transition: top 0.5s ease 0s, right 0.5s ease 0s, height 0.5s ease 0s;
     pointer-events: auto;
     box-sizing: border-box;
 
-    @include media-breakpoint-up(sm) {
+    @include media-breakpoint-up(md) {
         max-width: 200px;
     }
 

--- a/client/src/components/CommentApp/components/Comment/style.scss
+++ b/client/src/components/CommentApp/components/Comment/style.scss
@@ -7,6 +7,7 @@
     transition: top 0.5s ease 0s, right 0.5s ease 0s, height 0.5s ease 0s;
     pointer-events: auto;
     box-sizing: border-box;
+    right: -2000px;
 
     @include media-breakpoint-up(sm) {
         width: calc(100vw - 40px);
@@ -16,10 +17,19 @@
 
     @include media-breakpoint-up(md) {
         max-width: 200px;
+        right: 0;
     }
 
     @include media-breakpoint-up(lg) {
         max-width: 275px;
+    }
+
+    &--focused {
+        right: 35px;
+
+        @include media-breakpoint-up(md) {
+            right: 50px;
+        }
     }
 
     &__text {

--- a/wagtail/admin/static_src/wagtailadmin/scss/layouts/page-editor.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/layouts/page-editor.scss
@@ -566,17 +566,17 @@ footer .preview {
 
     // Make room for comments on the right when enabled
     .tab-content--comments-enabled .object {
-        padding-right: 100px;
+        padding-right: 27%;
 
         &.full {
-            padding-right: 100px;
+            padding-right: 36%;
         }
 
         @include media-breakpoint-up(lg) {
-            padding-right: 266px;
+            padding-right: 30%;
 
             &.full {
-                padding-right: 450px;
+                padding-right: 36%;
             }
         }
     }


### PR DESCRIPTION
This is far from perfect, but hopefully an improvement on what we have at the moment.

700 - 900px still iffy and we might have to drop to the mobile layout earlier. I was a bit limited by Wagtail's core UI layout.

The existing code didn't support toggling comments (show/hide), which the mobile designs assume we have. We can of course add this, but for now on mobile the only way to dismiss comments is to unfocus the comment in question (tap anywhere but the comment itself).