### PR TITLE
Fix BooleanBlock for telepath

### DIFF
--- a/client/src/entrypoints/admin/telepath/__snapshots__/widgets.test.js.snap
+++ b/client/src/entrypoints/admin/telepath/__snapshots__/widgets.test.js.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`telepath: wagtail.widgets.CheckboxInput it renders correctly 1`] = `"<input type=\\"checkbox\\" name=\\"sugar\\" id=\\"id-sugar\\" checked=\\"checked\\">"`;
+
 exports[`telepath: wagtail.widgets.PageChooser it renders correctly 1`] = `
 "<div id=\\"the-id-chooser\\" class=\\"chooser page-chooser\\" data-chooser-url=\\"/admin/choose-page/\\">
           <div class=\\"chosen\\">

--- a/client/src/entrypoints/admin/telepath/widgets.js
+++ b/client/src/entrypoints/admin/telepath/widgets.js
@@ -52,6 +52,26 @@ class Widget {
 window.telepath.register('wagtail.widgets.Widget', Widget);
 
 
+class BoundCheckboxInput extends BoundWidget {
+    getValue() {
+        return this.input.is(':checked');
+    }
+    getState() {
+        return this.input.is(':checked');
+    }
+    setState(state) {
+        // if false, set attribute value to null to remove it
+        this.input.attr('checked', state || null);
+    }
+}
+
+
+class CheckboxInput extends Widget {
+    boundWidgetClass = BoundCheckboxInput;
+}
+window.telepath.register('wagtail.widgets.CheckboxInput', CheckboxInput);
+
+
 class BoundRadioSelect {
     constructor(element, name, idForLabel, initialState) {
         this.element = element;

--- a/client/src/entrypoints/admin/telepath/widgets.test.js
+++ b/client/src/entrypoints/admin/telepath/widgets.test.js
@@ -107,6 +107,51 @@ describe('telepath: wagtail.widgets.RadioSelect', () => {
   });
 });
 
+describe('telepath: wagtail.widgets.CheckboxInput', () => {
+  let boundWidget;
+
+  beforeEach(() => {
+    // Create a placeholder to render the widget
+    document.body.innerHTML = '<div id="placeholder"></div>';
+
+    // Unpack and render a radio select widget
+    const widgetDef = window.telepath.unpack({
+      _type: 'wagtail.widgets.CheckboxInput',
+      _args: [
+        '<input type="checkbox" name="__NAME__" id="__ID__">',
+        '__ID__'
+      ]
+    });
+    boundWidget = widgetDef.render($('#placeholder'), 'sugar', 'id-sugar', true);
+  });
+
+  test('it renders correctly', () => {
+    expect(document.body.innerHTML).toMatchSnapshot();
+    expect(document.querySelector('input[id="id-sugar"]').checked).toBe(true);
+  });
+
+  test('getValue() returns the current value', () => {
+    expect(boundWidget.getValue()).toBe(true);
+  });
+
+  test('getState() returns the current state', () => {
+    expect(boundWidget.getState()).toBe(true);
+  });
+
+  test('setState() changes the current state', () => {
+    boundWidget.setState(false);
+    expect(document.querySelector('input[id="id-sugar"]').checked).toBe(false);
+    boundWidget.setState(true);
+    expect(document.querySelector('input[id="id-sugar"]').checked).toBe(true);
+  });
+
+  test('focus() focuses the checkbox', () => {
+    boundWidget.focus();
+
+    expect(document.activeElement).toBe(document.querySelector('input[id="id-sugar"]'));
+  });
+});
+
 describe('telepath: wagtail.widgets.PageChooser', () => {
   let boundWidget;
 

--- a/wagtail/core/blocks/field_block.py
+++ b/wagtail/core/blocks/field_block.py
@@ -258,6 +258,12 @@ class BooleanBlock(FieldBlock):
         self.field = forms.BooleanField(required=required, help_text=help_text)
         super().__init__(**kwargs)
 
+    def get_form_state(self, value):
+        # Bypass widget.format_value, because CheckboxInput uses that to prepare the "value"
+        # attribute (as distinct from the "checked" attribute that represents the actual checkbox
+        # state, which it handles in get_context).
+        return bool(value)
+
     class Meta:
         icon = "tick-inverse"
 

--- a/wagtail/core/tests/test_blocks.py
+++ b/wagtail/core/tests/test_blocks.py
@@ -321,6 +321,15 @@ class TestEmailBlock(unittest.TestCase):
             block.clean("foo@example.net")
 
 
+class TestBooleanBlock(unittest.TestCase):
+    def test_get_form_state(self):
+        block = blocks.BooleanBlock(required=False)
+        form_state = block.get_form_state(True)
+        self.assertEqual(form_state, True)
+        form_state = block.get_form_state(False)
+        self.assertEqual(form_state, False)
+
+
 class TestBlockQuoteBlock(unittest.TestCase):
     def test_render(self):
         block = blocks.BlockQuoteBlock()

--- a/wagtail/core/widget_adapters.py
+++ b/wagtail/core/widget_adapters.py
@@ -37,6 +37,13 @@ register(WidgetAdapter(), forms.Select)
 register(WidgetAdapter(), forms.CheckboxSelectMultiple)
 
 
+class CheckboxInputAdapter(WidgetAdapter):
+    js_constructor = 'wagtail.widgets.CheckboxInput'
+
+
+register(CheckboxInputAdapter(), forms.CheckboxInput)
+
+
 class RadioSelectAdapter(WidgetAdapter):
     js_constructor = 'wagtail.widgets.RadioSelect'
 


### PR DESCRIPTION
Fixes #7083. Override default FieldBlock / BoundWidget behaviour so that:

* BooleanBlock.get_form_state bypasses CheckboxInput.format_value (which Django uses to determine the 'value' HTML attribute rather than the checked state)
* BoundCheckboxInput.get_state / set_state / get_value work with the 'checked' attribute rather than 'value'
