### PR TITLE
Replacement for js_initialize: a hook to run custom form-side javascript upon StructBlock subclass render.

### DIFF
--- a/client/src/components/StreamField/blocks/StructBlock.js
+++ b/client/src/components/StreamField/blocks/StructBlock.js
@@ -147,6 +147,6 @@ export class StructBlockDefinition {
     if (this.meta.onBlockRender && typeof window[this.meta.onBlockRender] === 'function') {
       window[this.meta.onBlockRender](prefix, block);
     }
-    return block
+    return block;
   }
 }

--- a/client/src/components/StreamField/blocks/StructBlock.js
+++ b/client/src/components/StreamField/blocks/StructBlock.js
@@ -143,8 +143,8 @@ export class StructBlockDefinition {
 
   render(placeholder, prefix, initialState, initialError) {
     const block = new StructBlock(this, placeholder, prefix, initialState, initialError);
-    if (this.meta.onBlockRender) {
-      // If a function name was specified for onBlockRender, look it up in the window scope and call it.
+    // If meta.onBlockRender was specified, look it up in the window scope and call it if it's a function.
+    if (this.meta.onBlockRender && typeof window[this.meta.onBlockRender] === 'function') {
       window[this.meta.onBlockRender](prefix, block);
     }
     return block

--- a/client/src/components/StreamField/blocks/StructBlock.js
+++ b/client/src/components/StreamField/blocks/StructBlock.js
@@ -142,6 +142,11 @@ export class StructBlockDefinition {
   }
 
   render(placeholder, prefix, initialState, initialError) {
-    return new StructBlock(this, placeholder, prefix, initialState, initialError);
+    const block = new StructBlock(this, placeholder, prefix, initialState, initialError);
+    if (this.meta.onBlockRender) {
+      // If a function name was specified for onBlockRender, look it up in the window scope and call it.
+      window[this.meta.onBlockRender](prefix, block);
+    }
+    return block
   }
 }


### PR DESCRIPTION
I spoke with @gasman about this concept on Slack today, and he helped me a TON with getting the basic idea in place. This is all very preliminary at the moment, but my small amount of testing in Bakeydemo is very promising so far. 

With the following code added to their repo, and this PR's small tweak to StructBlock.js, developers can now get custom javascript to run after their StructBlock subclasses get rendered in the form.

This is added to base/blocks.py in Bakerdemo:
```python 
from django import forms
from django.templatetags.static import static
from django.utils.functional import cached_property
from wagtail.core.blocks.struct_block import StructBlockAdapter
from wagtail.core.telepath import register

class ImageBlockAdapter(StructBlockAdapter):

    def js_args(self, block):
        # Gets the base StructBlockAdapter args, then adds 'onBlockRender' to the meta arg.
        args = super().js_args(block)
        args[2]['onBlockRender'] = 'image_block_render_func'
        return args

    @cached_property
    def media(self):
        return forms.Media(js=[static('js/image-block.js')])


register(ImageBlockAdapter(), ImageBlock)
```

And here's `static/js/image-block.js` (just a proof of concept function):
```
function image_block_render_func(prefix, block) {
  alert('This is the prefix: ' + prefix);
  console.log(block);
}
```

This allows `image_block_render_func(prefix, block)` to trigger every time an ImageBlock gets added to a StreamField (or when the editor for a Page with a StreamField containing one or more ImageBlocks gets displayed). 

This is meant as a replacement for the old `js_initializer()` mechanism that StreamFields used to use for this purpose. Users who have implementations of that will need to be told that they will cease to function, and will need to be migrated to either this solution, or something like it. So this PR really needs at least that documentation added to it, plus tests, before it can be considered complete. I intend to add those next week.

