### PR TITLE
Tweak comment warnings

### DIFF
--- a/client/src/components/CommentApp/components/Comment/index.tsx
+++ b/client/src/components/CommentApp/components/Comment/index.tsx
@@ -519,7 +519,7 @@ export default class CommentComponent extends React.Component<CommentProps> {
       // Save the page to add this comment
       notice = strings.SAVE_PAGE_TO_ADD_COMMENT;
     } else if (comment.text !== comment.originalText) {
-      // Save the page to save changes to this comment
+      // Save the page to save this comment
       notice = strings.SAVE_PAGE_TO_SAVE_COMMENT_CHANGES;
     } else if (hasUnsavedReplies) {
       // Save the page to save replies

--- a/client/src/components/CommentApp/components/CommentReply/style.scss
+++ b/client/src/components/CommentApp/components/CommentReply/style.scss
@@ -54,7 +54,7 @@
     &__error {
         color: $color-box-text;
         font-weight: bold;
-        font-size: 0.8em;
+        font-size: 13px;
 
         button {
             margin-left: 10px;

--- a/client/src/components/CommentApp/main.scss
+++ b/client/src/components/CommentApp/main.scss
@@ -108,7 +108,7 @@ $box-border-radius: 5px;
     }
 
     &__notice-placeholder {
-        padding-bottom: 60px;
+        padding-bottom: 40px;
     }
 
     &__notice {
@@ -117,7 +117,7 @@ $box-border-radius: 5px;
         left: 0;
         bottom: 0;
         width: 100%;
-        padding: 10px;
+        padding: 5px 10px;
         box-sizing: border-box;
         border-bottom-left-radius: $box-border-radius;
         border-bottom-right-radius: $box-border-radius;

--- a/client/src/components/CommentApp/main.tsx
+++ b/client/src/components/CommentApp/main.tsx
@@ -68,7 +68,7 @@ export const defaultStrings = {
   SAVE_ERROR: 'Save error',
   MORE_ACTIONS: 'More actions',
   SAVE_PAGE_TO_ADD_COMMENT: 'Save the page to add this comment',
-  SAVE_PAGE_TO_SAVE_COMMENT_CHANGES: 'Save the page to save changes to this comment',
+  SAVE_PAGE_TO_SAVE_COMMENT_CHANGES: 'Save the page to save this comment',
   SAVE_PAGE_TO_SAVE_REPLY: 'Save the page to save replies',
 };
 

--- a/client/tests/stubs.js
+++ b/client/tests/stubs.js
@@ -63,7 +63,7 @@ global.wagtailConfig = {
     FOCUS_COMMENT: 'Focus comment',
     UNFOCUS_COMMENT: 'Unfocus comment',
     SAVE_PAGE_TO_ADD_COMMENT: 'Save the page to add this comment',
-    SAVE_PAGE_TO_SAVE_COMMENT_CHANGES: 'Save the page to save changes to this comment',
+    SAVE_PAGE_TO_SAVE_COMMENT_CHANGES: 'Save the page to save this comment',
     SAVE_PAGE_TO_SAVE_REPLY: 'Save the page to save replies',
   },
   WAGTAIL_I18N_ENABLED: true,

--- a/wagtail/admin/localization.py
+++ b/wagtail/admin/localization.py
@@ -95,7 +95,7 @@ def get_js_translation_strings():
         'COMMENT': _('Comment'),
         'MORE_ACTIONS': _('More actions'),
         'SAVE_PAGE_TO_ADD_COMMENT': _('Save the page to add this comment'),
-        'SAVE_PAGE_TO_SAVE_COMMENT_CHANGES': _('Save the page to save changes to this comment'),
+        'SAVE_PAGE_TO_SAVE_COMMENT_CHANGES': _('Save the page to save this comment'),
         'SAVE_PAGE_TO_SAVE_REPLY': _('Save the page to save replies'),
 
         'MONTHS': [str(m) for m in MONTHS.values()],


### PR DESCRIPTION
Reduces the vertical padding on comment warnings. Rewords the edit comment warning so it fits on one line.

![image](https://user-images.githubusercontent.com/1093808/116091373-a8adbf00-a69c-11eb-9c78-c4f129db412f.png)