### PR TITLE
Don't focus comments on menu click to avoid movement

### DIFF
--- a/client/src/components/CommentApp/components/CommentHeader/index.tsx
+++ b/client/src/components/CommentApp/components/CommentHeader/index.tsx
@@ -101,6 +101,7 @@ export const CommentHeader: FunctionComponent<CommentHeaderProps> = ({
 
   const toggleMenu = (e: React.MouseEvent) => {
     e.preventDefault();
+    e.stopPropagation();
     setMenuOpen(!menuOpen);
   };
   useEffect(() => {


### PR DESCRIPTION
Avoids "chasing down the comment" when you click the menu to open it, causing it to focus and move away from the cursor