### PR TITLE
Use Wagtail’s default disabled button style on comments

### DIFF
--- a/client/src/components/CommentApp/main.scss
+++ b/client/src/components/CommentApp/main.scss
@@ -160,7 +160,10 @@ $box-border-radius: 5px;
     }
 
     &:disabled {
-        opacity: 0.3;
+        background-color: $color-grey-3;
+        border-color: $color-grey-3;
+        color: $color-grey-2;
+        cursor: default;
     }
 
     // Disable Firefox's focus styling becase we add our own.


### PR DESCRIPTION
Current disabled button:
<img width="287" alt="Screenshot 2021-04-26 at 16 23 11" src="https://user-images.githubusercontent.com/2553896/116108419-cafb0900-a6ab-11eb-89c6-7be50fa08258.png">

Updated to Wagtail default disabled button style:
<img width="286" alt="Screenshot 2021-04-26 at 16 22 50" src="https://user-images.githubusercontent.com/2553896/116108413-c9c9dc00-a6ab-11eb-92b9-38eb519beaa0.png">

