### PR TITLE
Make StreamField block objects available globally

### DIFF
--- a/client/src/entrypoints/admin/telepath/blocks.js
+++ b/client/src/entrypoints/admin/telepath/blocks.js
@@ -1,8 +1,36 @@
-import { FieldBlockDefinition } from '../../../components/StreamField/blocks/FieldBlock';
-import { StaticBlockDefinition } from '../../../components/StreamField/blocks/StaticBlock';
-import { StructBlockDefinition, StructBlockValidationError } from '../../../components/StreamField/blocks/StructBlock';
-import { ListBlockDefinition, ListBlockValidationError } from '../../../components/StreamField/blocks/ListBlock';
-import { StreamBlockDefinition, StreamBlockValidationError } from '../../../components/StreamField/blocks/StreamBlock';
+import { FieldBlock, FieldBlockDefinition } from '../../../components/StreamField/blocks/FieldBlock';
+import { StaticBlock, StaticBlockDefinition } from '../../../components/StreamField/blocks/StaticBlock';
+import {
+  StructBlock, StructBlockDefinition, StructBlockValidationError
+} from '../../../components/StreamField/blocks/StructBlock';
+import {
+  ListBlock, ListBlockDefinition, ListBlockValidationError
+} from '../../../components/StreamField/blocks/ListBlock';
+import {
+  StreamBlock, StreamBlockDefinition, StreamBlockValidationError
+} from '../../../components/StreamField/blocks/StreamBlock';
+
+const wagtailStreamField = window.wagtailStreamField || {};
+
+wagtailStreamField.blocks = {
+  FieldBlock,
+  FieldBlockDefinition,
+
+  StaticBlock,
+  StaticBlockDefinition,
+
+  StructBlock,
+  StructBlockDefinition,
+  StructBlockValidationError,
+
+  ListBlock,
+  ListBlockDefinition,
+  ListBlockValidationError,
+
+  StreamBlock,
+  StreamBlockDefinition,
+  StreamBlockValidationError,
+};
 
 function initBlockWidget(id) {
   /*
@@ -36,3 +64,5 @@ window.telepath.register('wagtail.blocks.ListBlock', ListBlockDefinition);
 window.telepath.register('wagtail.blocks.ListBlockValidationError', ListBlockValidationError);
 window.telepath.register('wagtail.blocks.StreamBlock', StreamBlockDefinition);
 window.telepath.register('wagtail.blocks.StreamBlockValidationError', StreamBlockValidationError);
+
+window.wagtailStreamField = wagtailStreamField;


### PR DESCRIPTION
As discussed on #7094 - making these definitions available as global variables means that we can provide a reasonably simple upgrade path for people who previously customised StructBlock (or others) with custom JS via the `js_initializer` method.

(Would have liked to make these available under the `window.wagtail.blocks` namespace, but it seems there's a previously un-noticed issue where `window.wagtail` gets overwritten by the `<body id="wagtail">` element, so it's not available reliably. Doh!)

Will aim to get this properly documented in time for 2.13 final.