### PR TITLE
Draft: Feature/commenting Implement scrollable comment blocks

### DIFF
--- a/client/scss/components/_comments-controls.scss
+++ b/client/scss/components/_comments-controls.scss
@@ -27,8 +27,10 @@
 
     &--active,
     &:hover {
-        #{$root}__label {
-            opacity: 1;
+        @include media-breakpoint-up(md) {
+            #{$root}__label {
+                opacity: 1;
+            }
         }
 
         #{$root}__icon {

--- a/client/src/components/CommentApp/components/Comment/index.tsx
+++ b/client/src/components/CommentApp/components/Comment/index.tsx
@@ -87,6 +87,16 @@ export interface CommentProps {
 }
 
 export default class CommentComponent extends React.Component<CommentProps> {
+  state = { isMobile: false };
+
+  updateDimensions = () => {
+    if (window.innerWidth < 800) {
+      this.setState({ isMobile: true });
+    } else {
+      this.setState({ isMobile: false });
+    }
+  };
+
   renderReplies({ hideNewReply = false } = {}): React.ReactFragment {
     const { comment, isFocused, store, user, strings } = this.props;
 
@@ -624,8 +634,9 @@ export default class CommentComponent extends React.Component<CommentProps> {
             `comment comment--mode-${this.props.comment.mode} ${this.props.isFocused ? 'comment--focused' : ''}`
           }
           style={{
-            position: 'absolute',
-            top: `${top}px`,
+            position: this.state.isMobile ? 'fixed' : 'absolute',
+            top: this.state.isMobile ? '' : `${top}px`,
+            bottom: this.state.isMobile ? '30px' : '',
             display: this.props.isVisible ? 'block' : 'none',
           }}
           data-comment-id={this.props.comment.localId}
@@ -651,10 +662,14 @@ export default class CommentComponent extends React.Component<CommentProps> {
         );
       }
     }
+
+    this.updateDimensions();
+    window.addEventListener('resize', this.updateDimensions);
   }
 
   componentWillUnmount() {
     this.props.layout.setCommentElement(this.props.comment.localId, null);
+    window.removeEventListener('resize', this.updateDimensions);
   }
 
   componentDidUpdate() {

--- a/client/src/components/CommentApp/components/Comment/style.scss
+++ b/client/src/components/CommentApp/components/Comment/style.scss
@@ -1,13 +1,26 @@
 .comment {
     @include box;
 
-    width: calc(100vw - 40px);
-    max-width: calc(100vw - 19%);
     display: block;
     transition: top 0.5s ease 0s, right 0.5s ease 0s, height 0.5s ease 0s;
     pointer-events: auto;
     box-sizing: border-box;
     right: -2000px;
+    min-height: 130px;
+    max-height: 300px;
+    width: calc(100vw - 70px);
+    max-width: initial;
+    overflow: auto;
+
+    // Scroll shadows
+    background: linear-gradient($color-white 30%, rgba(255, 255, 255, 0)),
+        linear-gradient(rgba(255, 255, 255, 0), $color-white 70%) 0 100%,
+        radial-gradient(farthest-side at 50% 0, rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0)),
+        radial-gradient(farthest-side at 50% 100%, rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0)) 0 100%;
+    background-repeat: no-repeat;
+    background-color: $color-white;
+    background-size: 100% 40px, 100% 40px, 100% 14px, 100% 14px;
+    background-attachment: local, local, scroll, scroll;
 
     @include media-breakpoint-up(sm) {
         width: calc(100vw - 40px);


### PR DESCRIPTION
Forces a max height on comment blocks on all screen sizes/devices.

This can be removed on desktop, but it seemed sensible to keep it - it was previously possible to create an overflow of content if enough comments were added.