### PR TITLE
Update core team

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -6,6 +6,7 @@ Core team
 * Bertrand Bordage (NoriPyt)
 * Codie Roelf (Praekelt)
 * Coen van der Kamp (Four Digits)
+* Cynthia Kiser (Caltech)
 * Dan Braghis (Torchbox)
 * Dawn Wages
 * Jacob Topp-Mugglestone (Torchbox)
@@ -16,10 +17,12 @@ Core team
 * LB Johnston
 * Lisa Adams (Praekelt)
 * Loïc Teixeira (Springload)
+* Martin Sandström (Fröjd)
 * Matthew Westcott (Torchbox)
 * Mike Dingjan (Lab Digital)
 * Naomi Morduch Toubman
 * Scott Cranfill (consumerfinance.gov)
+* Storm Heg
 * Thibaud Colas (Torchbox)
 * Tom Dyson (Torchbox)
 

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -1,34 +1,34 @@
 Core team
 =========
 
-* Matthew Westcott (Torchbox)
-* Karl Hobley (Torchbox)
-* Tom Dyson (Torchbox)
-* Thibaud Colas (Torchbox)
-* Janneke Janssen (Lukkien)
-* Mike Dingjan (Lab Digital)
-* Bertrand Bordage (NoriPyt)
-* Loïc Teixeira (Springload)
-* Andy Chosak (consumerfinance.gov)
-* Will Barton (consumerfinance.gov)
-* LB Johnston
-* Coen van der Kamp (Four Digits)
-* Codie Roelf (Praekelt)
-* Lisa Adams (Praekelt)
-* Naomi Morduch Toubman
-* Kalob Taulien
-* Jonny Scholes (Neon Jungle)
 * Andy Babic (Torchbox)
+* Andy Chosak (consumerfinance.gov)
+* Bertrand Bordage (NoriPyt)
+* Codie Roelf (Praekelt)
+* Coen van der Kamp (Four Digits)
 * Dan Braghis (Torchbox)
 * Dawn Wages
 * Jacob Topp-Mugglestone (Torchbox)
+* Janneke Janssen (Lukkien)
+* Jonny Scholes (Neon Jungle)
+* Kalob Taulien
+* Karl Hobley (Torchbox)
+* LB Johnston
+* Lisa Adams (Praekelt)
+* Loïc Teixeira (Springload)
+* Matthew Westcott (Torchbox)
+* Mike Dingjan (Lab Digital)
+* Naomi Morduch Toubman
+* Thibaud Colas (Torchbox)
+* Tom Dyson (Torchbox)
+* Will Barton (consumerfinance.gov)
 
 Core team alumni
 ================
 
 * Josh Barr
-* Tim Heap
 * Mikalai Radchuk
+* Tim Heap
 
 Contributors
 ============

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -19,16 +19,19 @@ Core team
 * Matthew Westcott (Torchbox)
 * Mike Dingjan (Lab Digital)
 * Naomi Morduch Toubman
+* Scott Cranfill (consumerfinance.gov)
 * Thibaud Colas (Torchbox)
 * Tom Dyson (Torchbox)
-* Will Barton (consumerfinance.gov)
 
 Core team alumni
 ================
 
+* Emily Horsman
 * Josh Barr
 * Mikalai Radchuk
+* Rob Moorman
 * Tim Heap
+* Will Barton
 
 Contributors
 ============


### PR DESCRIPTION
1. alphabetized the core team and core team alumni lists (this is in its own commit and was done automatically, so there shouldn't be any changes in that commit other than the alphabetizing)
2. updated the current list to match the [wiki page](https://github.com/wagtail/wagtail/wiki/Wagtail-core-team), and the alumni list to include people who'd been removed in the wiki page change history

there are probably people missing here, but the wiki list seems to be the most canonical so this is at least a start