### PR TITLE
Add WAGTAILADMIN_COMMENTS_ENABLED default to docs

### DIFF
--- a/docs/reference/settings.rst
+++ b/docs/reference/settings.rst
@@ -203,12 +203,14 @@ Changes whether the Submit for Moderation button is displayed in the action menu
 Comments
 ========
 
+.. versionadded:: 2.13
+
 .. code-block:: python
 
   # Disable commenting
   WAGTAILADMIN_COMMENTS_ENABLED = False
 
-Sets whether commenting is enabled for pages.
+Sets whether commenting is enabled for pages (``True`` by default).
 
 Images
 ======


### PR DESCRIPTION
We don't seem to have a standard convention for specifying the default, but we usually do it in the text following a setting's code example, so have added this for ``WAGTAILADMIN_COMMENTS_ENABLED`` as well. I do think it would be good to standardise this - it has confused at least one person that our code examples actually specify non-default examples!