### PR TITLE
Update accessibility contribution guidance in bug report and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -30,4 +30,4 @@ Any other relevant information. For example, why do you consider this a bug and 
 * Python version: Run `python --version`.
 * Django version: Look in your requirements.txt, or run `pip show django | grep Version`.
 * Wagtail version: Look at the bottom of the Settings menu in the Wagtail admin, or run `pip show wagtail | grep Version:`.
-* Browser version: You can use https://www.whatsmybrowser.org/ to find this out.
+* Browser / operating system / assistive technology versions: You can use https://www.whatsmybrowser.org/ to find this out.

--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -30,4 +30,4 @@ Any other relevant information. For example, why do you consider this a bug and 
 * Python version: Run `python --version`.
 * Django version: Look in your requirements.txt, or run `pip show django | grep Version`.
 * Wagtail version: Look at the bottom of the Settings menu in the Wagtail admin, or run `pip show wagtail | grep Version:`.
-* Browser / operating system / assistive technology versions: You can use https://www.whatsmybrowser.org/ to find out more about your browser environment.
+* Browser version: You can use https://www.whatsmybrowser.org/ to find this out.

--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -30,4 +30,4 @@ Any other relevant information. For example, why do you consider this a bug and 
 * Python version: Run `python --version`.
 * Django version: Look in your requirements.txt, or run `pip show django | grep Version`.
 * Wagtail version: Look at the bottom of the Settings menu in the Wagtail admin, or run `pip show wagtail | grep Version:`.
-* Browser / operating system / assistive technology versions: You can use https://www.whatsmybrowser.org/ to find this out.
+* Browser / operating system / assistive technology versions: You can use https://www.whatsmybrowser.org/ to find out more about your browser environment.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,7 @@ Before submitting, please review the contributor guidelines <https://docs.wagtai
 * Do the tests still pass? (https://docs.wagtail.io/en/latest/contributing/developing.html#testing)
 * Does the code comply with the style guide? (Run `make lint` from the Wagtail root)
 * For Python changes: Have you added tests to cover the new/fixed behaviour?
-* For front-end changes: Did you test on all of Wagtail’s supported environments? (https://docs.wagtail.io/en/latest/contributing/developing.html#browser-and-device-support)
+* For front-end changes: Did you test on all of [Wagtail’s supported environments](https://docs.wagtail.io/en/latest/contributing/developing.html#browser-and-device-support)?
     * **Please list the exact browser and operating system versions you tested**.
     * **Please list which assistive technologies you tested**.
 * For new features: Has the documentation been updated accordingly?

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,5 +5,7 @@ Before submitting, please review the contributor guidelines <https://docs.wagtai
 * Do the tests still pass? (https://docs.wagtail.io/en/latest/contributing/developing.html#testing)
 * Does the code comply with the style guide? (Run `make lint` from the Wagtail root)
 * For Python changes: Have you added tests to cover the new/fixed behaviour?
-* For front-end changes: Did you test on all of Wagtail’s supported browsers? **Please list the exact versions you tested**.
+* For front-end changes: Did you test on all of Wagtail’s supported environments? (https://docs.wagtail.io/en/latest/contributing/developing.html#browser-and-device-support)
+    * **Please list the exact browser and operating system versions you tested**.
+    * **Please list which assistive technologies you tested**.
 * For new features: Has the documentation been updated accordingly?

--- a/docs/contributing/html_guidelines.rst
+++ b/docs/contributing/html_guidelines.rst
@@ -13,6 +13,6 @@ Principles
 
 * Write `valid HTML <https://validator.w3.org/nu/>`_. We target the HTML5 doctype.
 * Write `semantic HTML <https://html5doctor.com/element-index/>`_.
-* Follow `ARIA Authoring Practices <https://w3c.github.io/aria-practices/>`_.
+* Consult `ARIA Authoring Practices <https://w3c.github.io/aria-practices/>`_, in particular `No ARIA is better than Bad ARIA <https://w3c.github.io/aria-practices/#no_aria_better_bad_aria>`_.
 * Attach JavaScript behavior with ``data-`` attributes, rather than classes or IDs.
 * For comments, use Django templates syntax instead of HTML.

--- a/docs/contributing/html_guidelines.rst
+++ b/docs/contributing/html_guidelines.rst
@@ -13,5 +13,6 @@ Principles
 
 * Write `valid HTML <https://validator.w3.org/nu/>`_. We target the HTML5 doctype.
 * Write `semantic HTML <https://html5doctor.com/element-index/>`_.
+* Follow `ARIA Authoring Practices <https://w3c.github.io/aria-practices/>`_.
 * Attach JavaScript behavior with ``data-`` attributes, rather than classes or IDs.
 * For comments, use Django templates syntax instead of HTML.


### PR DESCRIPTION
Following a @wagtail/accessibility team discussion. This is to reflect our [accessibility support targets](https://docs.wagtail.io/en/stable/contributing/developing.html#accessibility-targets) as introduced a year or so ago. Just like for browser support, we need to ensure every code change to Wagtail is appropriately tested for compatibility issues.

Tagging @wagtail/wagtail-core-team as well because it does mean we expect the core team all reviewers with merge rights to either:

- Ensure the change has been appropriately tested, and do all additional testing required before merging
- Get in touch with @wagtail/accessibility for anything that requires particular attention / expertise
