### PR TITLE
Fix/active tab line

### DIFF
--- a/client/scss/components/_comments-controls.scss
+++ b/client/scss/components/_comments-controls.scss
@@ -4,7 +4,6 @@
     justify-content: flex-end;
     padding-right: 2px;
     height: 42px;
-    padding-bottom: 8px;
     box-sizing: border-box;
 
     @include media-breakpoint-up(sm) {

--- a/client/scss/components/_tabs.scss
+++ b/client/scss/components/_tabs.scss
@@ -82,6 +82,11 @@
     li.wide {
         width: unset;
     }
+
+    .right {
+        max-height: 1.44em;
+        overflow: visible;
+    }
 }
 
 .tab-content {

--- a/wagtail/admin/templates/wagtailadmin/pages/_unsaved_changes_warning.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/_unsaved_changes_warning.html
@@ -1,6 +1,6 @@
 {% load wagtailadmin_tags i18n %}
 <li class="footer__container footer__container--hidden footer__save-warning" data-unsaved-warning>
-    <div hidden data-unsaved-type="any" class="footer__save-warning footer__emphasise-span-tags">
+    <div hidden data-unsaved-type="any" class="footer__emphasise-span-tags">
         <div>
             <b hidden data-unsaved-type="edits">{% blocktrans %}You have <span>unsaved edits</span>{% endblocktrans %}</b>
             <b hidden data-unsaved-type="comments">{% blocktrans %}You have <span>unsaved comments</span>{% endblocktrans %}</b>


### PR DESCRIPTION
Styling improvements for comments:
- Removes small teal line under active tab caused by comments toggle
- Fixes unsaved comments warning not hiding properly on mobile