### PR TITLE
Remove explicit height from comment-list to stop overflow on short pages

### DIFF
--- a/client/src/components/CommentApp/main.scss
+++ b/client/src/components/CommentApp/main.scss
@@ -176,7 +176,6 @@ $box-padding: 10px;
 }
 
 .comments-list {
-    height: 100vh;
     width: 400px;
     position: absolute;
     top: 30px;


### PR DESCRIPTION
On very short pages in the page edit view, the `height` of the `comments-list` would cause a grey bar to appear at the bottom of the page. This removes that explicit height to prevent an overflow.

To reproduce the error/fix, view the `Blog` page on the bakerydemo site before and after this commit is applied.
