### PR TITLE
Prevent StreamField initialisation from being broken by colliding HTML IDs

### DIFF
--- a/client/src/entrypoints/admin/telepath/blocks.js
+++ b/client/src/entrypoints/admin/telepath/blocks.js
@@ -43,7 +43,7 @@ function initBlockWidget(id) {
     data-value: JSON-encoded value for this block
   */
 
-  const body = document.getElementById(id);
+  const body = document.querySelector('#' + id + '[data-block]');
 
   // unpack the block definition and value
   const blockDefData = JSON.parse(body.dataset.block);


### PR DESCRIPTION
Fixes #7146 - the root StreamField element is now matched by ID _and_ having a data-block attribute. (Duplicate IDs are invalid HTML and the 'proper' fix would be to add a global prefix to form fields, particularly since this problem isn't necessarily specific to StreamFields - but that would be a bigger breaking change.)
