### PR TITLE
Add titlesonly to reference / topics top-level TOCs

### DIFF
--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -4,6 +4,7 @@ Reference
 
 .. toctree::
     :maxdepth: 2
+    :titlesonly:
 
     pages/index
     streamfield/index

--- a/docs/topics/index.md
+++ b/docs/topics/index.md
@@ -3,6 +3,7 @@
 ```eval_rst
 .. toctree::
     :maxdepth: 2
+    :titlesonly:
 
     pages
     writing_templates


### PR DESCRIPTION
This prevents duplicated headings in places where the second-level index page has intro blurbs for each subsection (and also means we're not listing out long multi-section pages in full in the index, but given how big these indexes are that's probably not a bad thing).

topics (before):
![Screenshot 2021-05-04 at 16 10 08](https://user-images.githubusercontent.com/85097/117027777-ee9a0100-acf4-11eb-92fc-62824552f833.png)

reference (before):
![Screenshot 2021-05-04 at 16 10 27](https://user-images.githubusercontent.com/85097/117027786-f063c480-acf4-11eb-9b80-499a9a8d6fb9.png)
