### PR TITLE
Prevent JS error on URL hashes that are not tabs

### DIFF
--- a/client/src/entrypoints/admin/core.js
+++ b/client/src/entrypoints/admin/core.js
@@ -308,8 +308,10 @@ $(() => {
   };
 
   if (window.location.hash) {
+    /* look for a tab matching the URL hash and activate it if found */
     const cleanedHash = window.location.hash.replace(/[^\w\-#]/g, '');
-    showTab(document.querySelector('a[href="' + cleanedHash + '"]'));
+    const tab = document.querySelector('a[href="' + cleanedHash + '"][data-tab]');
+    if (tab) showTab(tab);
   }
 
   // eslint-disable-next-line func-names


### PR DESCRIPTION
Fixes a bug introduced in e0d4381661ea81394b3558cf33a4a2f18b42d9d2.

The tab code looks for the presence of a URL hash and calls showTab on a link with that href, without checking that the link A) actually exists and B) is a tab as identified by the data-tab attribute. As a result, non-tab-related uses of URL hashes (such as simply visiting `/admin/#foo`) throw a JS error.