### PR TITLE
Disable options without translated parent. Add help text.

### DIFF
--- a/client/scss/elements/_forms.scss
+++ b/client/scss/elements/_forms.scss
@@ -44,6 +44,11 @@ label,
         float: none;
     }
 
+    &.disabled {
+        opacity: 0.7;
+        cursor: not-allowed;
+    }
+
     @include media-breakpoint-up(sm) {
         @include column(2);
         padding-top: 1.2em;
@@ -215,6 +220,10 @@ input[type=checkbox]:before {
 
 input[type=checkbox]:checked:before {
     color: $color-teal;
+}
+
+input[type=checkbox][disabled]:before {
+    cursor: not-allowed;
 }
 
 

--- a/client/src/components/CommentApp/components/CommentHeader/style.scss
+++ b/client/src/components/CommentApp/components/CommentHeader/style.scss
@@ -83,7 +83,7 @@
             > .details-fallback > .details-fallback__summary {  // IE11 uses divs instead with these classes
                 color: #767676;
 
-                 // stylelint-disable-next-line max-nesting-depth
+                // stylelint-disable-next-line max-nesting-depth
                 &:hover {
                     color: $color-grey-25;
                 }

--- a/wagtail/contrib/simple_translation/forms.py
+++ b/wagtail/contrib/simple_translation/forms.py
@@ -1,7 +1,20 @@
 from django import forms
+from django.urls import reverse
+from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy, ngettext
 
 from wagtail.core.models import Locale, Page
+
+
+class CheckboxSelectMultipleWithDisabledOptions(forms.CheckboxSelectMultiple):
+    option_template_name = "simple_translation/admin/input_option.html"
+    disabled_values = []
+
+    def create_option(self, *args, **kwargs):
+        option = super().create_option(*args, **kwargs)
+        if option["value"] in self.disabled_values:
+            option["attrs"]["disabled"] = True
+        return option
 
 
 class SubmitTranslationForm(forms.Form):
@@ -11,7 +24,7 @@ class SubmitTranslationForm(forms.Form):
     locales = forms.ModelMultipleChoiceField(
         label=gettext_lazy("Locales"),
         queryset=Locale.objects.none(),
-        widget=forms.CheckboxSelectMultiple,
+        widget=CheckboxSelectMultipleWithDisabledOptions,
     )
     include_subtree = forms.BooleanField(
         required=False, help_text=gettext_lazy("All child pages will be created.")
@@ -21,6 +34,7 @@ class SubmitTranslationForm(forms.Form):
         super().__init__(*args, **kwargs)
 
         hide_include_subtree = True
+        self.show_submit = True
 
         if isinstance(instance, Page):
             descendant_count = instance.get_descendants().count()
@@ -36,13 +50,69 @@ class SubmitTranslationForm(forms.Form):
         if hide_include_subtree:
             self.fields["include_subtree"].widget = forms.HiddenInput()
 
-        self.fields["locales"].queryset = Locale.objects.exclude(
+        untranslated_locales = Locale.objects.exclude(
             id__in=instance.get_translations(inclusive=True).values_list(
                 "locale_id", flat=True
             )
         )
+        self.fields["locales"].queryset = untranslated_locales
 
+        # For snippets, hide select all if there is one option.
         # Using len() instead of count() here as we're going to evaluate this queryset
         # anyway and it gets cached so it'll only have one query in the end.
-        if len(self.fields["locales"].queryset) < 2:
+        hide_select_all = len(untranslated_locales) < 2
+
+        if isinstance(instance, Page):
+            parent = instance.get_parent()
+
+            # Find allowed locale options.
+            if parent.is_root():
+                # All locale options are allowed.
+                allowed_locale_ids = Locale.objects.all().values_list("id", flat=True)
+            else:
+                # Only the locale options that have a translated parent are allowed.
+                allowed_locale_ids = (
+                    instance.get_parent()
+                    .get_translations(inclusive=True)
+                    .values_list("locale_id", flat=True)
+                )
+
+            # Get and set the locale options that are disabled.
+            disabled_locales = Locale.objects.exclude(
+                id__in=allowed_locale_ids
+            ).values_list("id", flat=True)
+            self.fields["locales"].widget.disabled_values = disabled_locales
+
+            if disabled_locales:
+                # Display a help text.
+                url = reverse(
+                    "simple_translation:submit_page_translation", args=[parent.id]
+                )
+                help_text = ngettext(
+                    "A locale is disabled because a parent page is not translated.",
+                    "Some locales are disabled because some parent pages are not translated.",
+                    len(disabled_locales),
+                )
+                help_text += "<br>"
+                help_text += '<a href="{}">'.format(url)
+                help_text += ngettext(
+                    "Translate the parent page.",
+                    "Translate the parent pages.",
+                    len(disabled_locales),
+                )
+                help_text += "</a>"
+                self.fields["locales"].help_text = mark_safe(help_text)
+
+            # For pages, if there is one locale or all locales are disabled.
+            hide_select_all = (
+                len(untranslated_locales) == 1
+                or len(untranslated_locales) - len(disabled_locales) == 0
+            )
+
+            # Hide the submit if all untranslated locales are disabled.
+            # This property is used in the template.
+            if len(untranslated_locales) == len(disabled_locales):
+                self.show_submit = False
+
+        if hide_select_all:
             self.fields["select_all"].widget = forms.HiddenInput()

--- a/wagtail/contrib/simple_translation/templates/simple_translation/admin/input_option.html
+++ b/wagtail/contrib/simple_translation/templates/simple_translation/admin/input_option.html
@@ -1,0 +1,7 @@
+{% if widget.wrap_label %}
+    <label{% if widget.attrs.id %} for="{{ widget.attrs.id }}"{% endif %}{% if widget.attrs.disabled %} class="disabled"{% endif %}>
+        {% include "django/forms/widgets/input.html" %} {{ widget.label }}
+    </label>
+{% else %}
+    {% include "django/forms/widgets/input.html" %} {{ widget.label }}
+{% endif %}

--- a/wagtail/contrib/simple_translation/templates/simple_translation/admin/submit_translation.html
+++ b/wagtail/contrib/simple_translation/templates/simple_translation/admin/submit_translation.html
@@ -21,9 +21,11 @@
                         {% include "wagtailadmin/shared/field_as_li.html" %}
                     {% endfor %}
                 {% endblock %}
-                <li>
-                    <input type="submit" value="{% trans 'Submit' %}" class="button" />
-                </li>
+                {% if form.show_submit %}
+                    <li>
+                        <input type="submit" value="{% trans 'Submit' %}" class="button" />
+                    </li>
+                {% endif %}
             </ul>
         </form>
     </div>
@@ -40,7 +42,9 @@
 
             selectAll.addEventListener('change', function() {
                 for (var i = 0; i < locales.length; i++) {
-                    locales[i].checked = selectAll.checked;
+                    if (locales[i].disabled === false) {
+                        locales[i].checked = selectAll.checked;
+                    }
                 }
             });
         });


### PR DESCRIPTION
Resolves https://github.com/wagtail/wagtail/issues/7159

- If a parent is not available in the target locale, then the option is disabled.
- If all options are disabled, the submit button is removed.
- A help text with link to the parent translation page is displayed.
- Help text is singular or plural.
- Select all is displayed as soon as there are multiple items (disabled or not) minimal one item needs to be translatable.

Starting point for the screenshots:
- 3 locales EN, DE, FR
- Homepage in EN and a child content page in EN.

# All options are disabled, help text is plural, submit button is removed.
<img width="952" alt="Screenshot 2021-05-10 at 22 30 24" src="https://user-images.githubusercontent.com/1969342/117720737-52ce3080-b1df-11eb-9ee1-0f8bc6e16466.png">

# Translate home to German, no subtree.
<img width="952" alt="Screenshot 2021-05-10 at 22 31 02" src="https://user-images.githubusercontent.com/1969342/117720819-6a0d1e00-b1df-11eb-929c-9b84703fbda4.png">

# Content page can be translated to German, French is disabled, select all and submit are displayed. Help text is singular
<img width="952" alt="Screenshot 2021-05-10 at 22 32 53" src="https://user-images.githubusercontent.com/1969342/117721031-ab9dc900-b1df-11eb-9e3d-34e0bf48ebf0.png">


 # Translate home to French, no subtree.
<img width="952" alt="Screenshot 2021-05-10 at 22 34 03" src="https://user-images.githubusercontent.com/1969342/117721182-d556f000-b1df-11eb-9beb-16ae42042919.png">

# Content page can be translated to all options. No help text.
<img width="952" alt="Screenshot 2021-05-10 at 22 34 54" src="https://user-images.githubusercontent.com/1969342/117721286-f3bceb80-b1df-11eb-99f0-9a2f5568ddd8.png">

# Checklist
* Do the tests still pass? YES
* Does the code comply with the style guide? YES
* For Python changes: Have you added tests to cover the new/fixed behaviour? YES
* For front-end changes: Did you test on all of Wagtail’s supported browsers? YES 
  * OSX Chrome Version 90.0.4430.72
  * Edge 90
  * Explorer 11 on Windows 10
  * Firefox 88 on Windows 10
  * Safari on iPhone 12 Pro Max
* For new features: Has the documentation been updated accordingly? N/A
