### PR TITLE
Fix eslint/csslint warnings about line length / indenting

### DIFF
--- a/client/src/components/CommentApp/components/CommentHeader/index.tsx
+++ b/client/src/components/CommentApp/components/CommentHeader/index.tsx
@@ -11,21 +11,23 @@ import { Author } from '../../state/comments';
 
 // Details/Summary components that just become <details>/<summary> tags
 // except for IE11 where they become <div> tags to allow us to style them
-const Details: React.FunctionComponent<React.ComponentPropsWithoutRef<'details'>> = ({ children, open, ...extraProps }) => {
-  if (IS_IE11) {
+const Details: React.FunctionComponent<React.ComponentPropsWithoutRef<'details'>> = (
+  ({ children, open, ...extraProps }) => {
+    if (IS_IE11) {
+      return (
+        <div className={'details-fallback' + (open ? ' details-fallback--open' : '')} {...extraProps}>
+          {children}
+        </div>
+      );
+    }
+
     return (
-      <div className={'details-fallback' + (open ? ' details-fallback--open' : '')} {...extraProps}>
+      <details open={open} {...extraProps}>
         {children}
-      </div>
+      </details>
     );
   }
-
-  return (
-    <details open={open} {...extraProps}>
-      {children}
-    </details>
-  );
-};
+);
 
 const Summary: React.FunctionComponent<React.ComponentPropsWithoutRef<'summary'>> = ({ children, ...extraProps }) => {
   if (IS_IE11) {

--- a/client/src/components/CommentApp/components/CommentHeader/style.scss
+++ b/client/src/components/CommentApp/components/CommentHeader/style.scss
@@ -83,7 +83,7 @@
             > .details-fallback > .details-fallback__summary {  // IE11 uses divs instead with these classes
                 color: #767676;
 
-                 // stylelint-disable-next-line max-nesting-depth
+                // stylelint-disable-next-line max-nesting-depth
                 &:hover {
                     color: $color-grey-25;
                 }

--- a/client/src/components/StreamField/blocks/FieldBlock.js
+++ b/client/src/components/StreamField/blocks/FieldBlock.js
@@ -54,7 +54,12 @@ export class FieldBlock {
       addCommentButtonElement.classList.add('button-secondary');
       addCommentButtonElement.classList.add('button-small');
       addCommentButtonElement.classList.add('u-hidden');
-      addCommentButtonElement.innerHTML = '<svg class="icon icon-comment-add initial icon-default" aria-hidden="true" focusable="false"><use href="#icon-comment-add"></use></svg><svg class="icon icon-comment-add initial icon-reversed" aria-hidden="true" focusable="false"><use href="#icon-comment-add-reversed"></use></svg>';
+      addCommentButtonElement.innerHTML = (
+        '<svg class="icon icon-comment-add initial icon-default" aria-hidden="true" focusable="false">'
+        + '<use href="#icon-comment-add"></use></svg>'
+        + '<svg class="icon icon-comment-add initial icon-reversed" aria-hidden="true" focusable="false">'
+        + '<use href="#icon-comment-add-reversed"></use></svg>'
+      );
       fieldCommentControlElement.appendChild(addCommentButtonElement);
       window.comments.initAddCommentButton(addCommentButtonElement);
     }

--- a/client/src/entrypoints/admin/page-editor.js
+++ b/client/src/entrypoints/admin/page-editor.js
@@ -264,7 +264,9 @@ function initCollapsibleBlocks() {
   $('.object.multi-field.collapsible').each(function () {
     const $li = $(this);
     const $fieldset = $li.find('fieldset');
-    const onAnimationComplete = () => $fieldset.get(0).dispatchEvent(new CustomEvent('commentAnchorVisibilityChange', { bubbles: true }));
+    const onAnimationComplete = () => $fieldset.get(0).dispatchEvent(
+      new CustomEvent('commentAnchorVisibilityChange', { bubbles: true })
+    );
     if ($li.hasClass('collapsed') && $li.find('.error-message').length === 0) {
       $fieldset.hide({
         complete: onAnimationComplete


### PR DESCRIPTION
Fix csslint / eslint warnings being thrown on current main:

```
client/src/components/CommentApp/components/CommentHeader/style.scss
 86:18  ⚠  Expected indentation of 16 spaces   indentation

/Users/matthew/Development/tbx/wagtail/devscript/wagtail/client/src/components/CommentApp/components/CommentHeader/index.tsx
  14:1  warning  This line has a length of 124. Maximum allowed is 120  max-len

/Users/matthew/Development/tbx/wagtail/devscript/wagtail/client/src/components/StreamField/blocks/FieldBlock.js
  57:1  warning  This line has a length of 325. Maximum allowed is 120  max-len

/Users/matthew/Development/tbx/wagtail/devscript/wagtail/client/src/entrypoints/admin/page-editor.js
  267:1  warning  This line has a length of 138. Maximum allowed is 120  max-len
```

The remaining items are about TODO comments (to be fixed by https://github.com/wagtail/eslint-config-wagtail/pull/8) and an unused `eslint-disable import/no-unresolved` directive (see #7177).