### PR TITLE
Remove redundant badges from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,8 +115,6 @@ We thank the following organisations for their services used in Wagtail's develo
 [![Build Status](https://github.com/wagtail/wagtail/workflows/Wagtail%20CI/badge.svg)](https://github.com/wagtail/wagtail/actions)
 [![License](https://img.shields.io/badge/license-BSD-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 [![Version](https://img.shields.io/pypi/v/wagtail.svg)](https://pypi.python.org/pypi/wagtail/) 
-[![Coverage](https://codecov.io/github/wagtail/wagtail/coverage.svg?branch=main)](https://codecov.io/github/wagtail/wagtail?branch=main)
 [![Total alerts](https://img.shields.io/lgtm/alerts/g/wagtail/wagtail.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/wagtail/wagtail/alerts/)
 [![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/wagtail/wagtail.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/wagtail/wagtail/context:python)
 [![Language grade: JavaScript](https://img.shields.io/lgtm/grade/javascript/g/wagtail/wagtail.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/wagtail/wagtail/context:javascript)
-[![Slack](https://wagtail-slack.now.sh/badge.svg)](https://wagtail-slack.now.sh)


### PR DESCRIPTION
* Codecov is only tracking JS coverage, so displaying a coverage figure for the whole project is misleading
* wagtail-slack.now.sh appears to be dead