### PR TITLE
Add feedback section in the release notes

### DIFF
--- a/docs/releases/2.13.rst
+++ b/docs/releases/2.13.rst
@@ -164,3 +164,9 @@ change here) and want to use the new commenting system, your list of edit handle
             # My existing panels here
             CommentPanel(),
         ]
+
+
+Feedback
+========
+
+We would love to `receive your feedback <https://forms.gle/G5WYo6sLiZiwdfsQA>`_ on this release.


### PR DESCRIPTION
This PR adds a "feedback" section with a link to a simple Google form to gather feedback on the 2.13 release.