### PR TITLE
Binding telepath widgets to already-rendered HTML

### DIFF
--- a/client/src/entrypoints/admin/telepath/widgets.js
+++ b/client/src/entrypoints/admin/telepath/widgets.js
@@ -48,6 +48,10 @@ class Widget {
         // eslint-disable-next-line new-cap
         return new this.boundWidgetClass(dom, name, idForLabel, initialState);
     }
+    bind(dom, name, id, initialState) {
+        // eslint-disable-next-line new-cap
+        return new this.boundWidgetClass($(dom), name, id, initialState);
+    }
 }
 window.telepath.register('wagtail.widgets.Widget', Widget);
 

--- a/client/src/entrypoints/images/image-chooser-telepath.js
+++ b/client/src/entrypoints/images/image-chooser-telepath.js
@@ -14,5 +14,11 @@ class ImageChooser {
     chooser.setState(initialState);
     return chooser;
   }
+  bind(dom, name, id, initialState) {
+    // eslint-disable-next-line no-undef
+    const chooser = createImageChooser(id);
+    chooser.setState(initialState);
+    return chooser;
+  }
 }
 window.telepath.register('wagtail.images.widgets.ImageChooser', ImageChooser);

--- a/client/src/entrypoints/images/image-chooser.js
+++ b/client/src/entrypoints/images/image-chooser.js
@@ -7,6 +7,8 @@ function createImageChooser(id) {
   const editLink = chooserElement.find('.edit-link');
   const chooserBaseUrl = chooserElement.data('chooserUrl');
 
+  const rawChooserElement = chooserElement.get(0);
+  if (rawChooserElement.widget) return rawChooserElement.widget;
   /*
   Construct initial state of the chooser from the rendered (static) HTML and arguments passed to
   createImageChooser. State is either null (= no image chosen) or a dict of id, edit_link,
@@ -93,6 +95,7 @@ function createImageChooser(id) {
     chooser.clear();
   });
 
+  rawChooserElement.widget = chooser;
   return chooser;
 }
 window.createImageChooser = createImageChooser;


### PR DESCRIPTION
A necessary step towards using telepath in forms beyond just StreamField (e.g. to fetch form data for posting to a JSON API in the background) is being able to access the client-side widget API for form elements that were previously rendered server-side - currently, methods such as `getState` / `setState` are only accessible on widgets that we have created client-side.

I propose adding a new `bind` method alongside `render` on the Widget object - this PR serves as a draft of how it might work. There's an extra subtlety around chooser widgets, since they'll usually have called `createImageChooser` from an inline `<script>` and created a widget object as a side effect - we don't want to initialise it twice, so instead we stash a reference to the widget on the container element and reuse it if it already exists.

I expect that we'll implement a Telepath adapter for `django.forms.Form` (and `Field`?) objects, so that we can do something like

    <form action="." id="my-form" data-form-definition="{{ packed_form_json }}">
        {{ form.as_p }}
    </form>

    <script>
        const formElem = document.getElementById('my-form');
        const formDefinition = telepath.unpack(JSON.parse(formElem.dataset.formDefinition));
        const form = formDefinition.bind(formElem);
        form.widgets['email'].setState('matthew@example.com');
    </script>

Open questions:

* Since this is a step towards formalising the `BoundWidget` constructor, would now be a good time to eliminate the dependency on jQuery in that interface?
* Passing the DOM element, name and id to `bind` is redundant (and the DOM element is a fudge since we don't know exactly which bit of the `{{ form.as_p }}` output corresponds to any given widget - luckily we can just pass the entire form, or even the entire document body, and BoundWidget will generally just look for an element with the expected name). Just the name ought to be enough, but will that paint us into a corner in a future scenario where names on inputs are optional (e.g. a react-streamfield setup where the full data of a StreamField is bundled into a single hidden JSON field, at which point we don't want the individual inputs to be included in the POST submission)?
* Can we make initialState optional (or remove it entirely) and get it to pick up the state embedded in the pre-rendered HTML instead? (We already have to do this for choosers, at least.)