### PR TITLE
Eliminate request.is_ajax from snippet listing view

### DIFF
--- a/wagtail/snippets/templates/wagtailsnippets/snippets/type_index.html
+++ b/wagtail/snippets/templates/wagtailsnippets/snippets/type_index.html
@@ -6,7 +6,7 @@
     {{ block.super }}
     <script>
         window.headerSearch = {
-            url: "{% url 'wagtailsnippets:list' model_opts.app_label model_opts.model_name %}",
+            url: "{% url 'wagtailsnippets:list_results' model_opts.app_label model_opts.model_name %}",
             termInput: "#id_q",
             targetOutput: "#snippet-results"
         }

--- a/wagtail/snippets/urls.py
+++ b/wagtail/snippets/urls.py
@@ -12,6 +12,7 @@ urlpatterns = [
     path('choose/<slug:app_label>/<slug:model_name>/<str:pk>/', chooser.chosen, name='chosen'),
 
     path('<slug:app_label>/<slug:model_name>/', snippets.ListView.as_view(), name='list'),
+    path('<slug:app_label>/<slug:model_name>/results/', snippets.ListResultsView.as_view(), name='list_results'),
     path('<slug:app_label>/<slug:model_name>/add/', snippets.create, name='add'),
     path('<slug:app_label>/<slug:model_name>/edit/<str:pk>/', snippets.edit, name='edit'),
     path('<slug:app_label>/<slug:model_name>/multiple/delete/', snippets.delete, name='delete-multiple'),

--- a/wagtail/snippets/urls.py
+++ b/wagtail/snippets/urls.py
@@ -12,7 +12,10 @@ urlpatterns = [
     path('choose/<slug:app_label>/<slug:model_name>/<str:pk>/', chooser.chosen, name='chosen'),
 
     path('<slug:app_label>/<slug:model_name>/', snippets.ListView.as_view(), name='list'),
-    path('<slug:app_label>/<slug:model_name>/results/', snippets.ListResultsView.as_view(), name='list_results'),
+    path(
+        '<slug:app_label>/<slug:model_name>/results/',
+        snippets.ListView.as_view(results_only=True), name='list_results'
+    ),
     path('<slug:app_label>/<slug:model_name>/add/', snippets.create, name='add'),
     path('<slug:app_label>/<slug:model_name>/edit/<str:pk>/', snippets.edit, name='edit'),
     path('<slug:app_label>/<slug:model_name>/multiple/delete/', snippets.delete, name='delete-multiple'),

--- a/wagtail/snippets/urls.py
+++ b/wagtail/snippets/urls.py
@@ -11,7 +11,7 @@ urlpatterns = [
     path('choose/<slug:app_label>/<slug:model_name>/', chooser.choose, name='choose'),
     path('choose/<slug:app_label>/<slug:model_name>/<str:pk>/', chooser.chosen, name='chosen'),
 
-    path('<slug:app_label>/<slug:model_name>/', snippets.list, name='list'),
+    path('<slug:app_label>/<slug:model_name>/', snippets.ListView.as_view(), name='list'),
     path('<slug:app_label>/<slug:model_name>/add/', snippets.create, name='add'),
     path('<slug:app_label>/<slug:model_name>/edit/<str:pk>/', snippets.edit, name='edit'),
     path('<slug:app_label>/<slug:model_name>/multiple/delete/', snippets.delete, name='delete-multiple'),

--- a/wagtail/snippets/views/snippets.py
+++ b/wagtail/snippets/views/snippets.py
@@ -75,7 +75,7 @@ def index(request):
         raise PermissionDenied
 
 
-class ListView(TemplateView):
+class BaseListView(TemplateView):
     def get(self, request, app_label, model_name):
         self.app_label = app_label
         self.model_name = model_name
@@ -168,11 +168,14 @@ class ListView(TemplateView):
 
         return context
 
-    def get_template_names(self):
-        if self.request.is_ajax():
-            return ['wagtailsnippets/snippets/results.html']
-        else:
-            return ['wagtailsnippets/snippets/type_index.html']
+
+class ListView(BaseListView):
+    template_name = 'wagtailsnippets/snippets/type_index.html'
+
+
+class ListResultsView(BaseListView):
+    # Returns just the 'results' include, for use in AJAX responses from search
+    template_name = 'wagtailsnippets/snippets/results.html'
 
 
 def create(request, app_label, model_name):

--- a/wagtail/snippets/views/snippets.py
+++ b/wagtail/snippets/views/snippets.py
@@ -75,7 +75,11 @@ def index(request):
         raise PermissionDenied
 
 
-class BaseListView(TemplateView):
+class ListView(TemplateView):
+
+    # If true, returns just the 'results' include, for use in AJAX responses from search
+    results_only = False
+
     def get(self, request, app_label, model_name):
         self.app_label = app_label
         self.model_name = model_name
@@ -168,14 +172,11 @@ class BaseListView(TemplateView):
 
         return context
 
-
-class ListView(BaseListView):
-    template_name = 'wagtailsnippets/snippets/type_index.html'
-
-
-class ListResultsView(BaseListView):
-    # Returns just the 'results' include, for use in AJAX responses from search
-    template_name = 'wagtailsnippets/snippets/results.html'
+    def get_template_names(self):
+        if self.results_only:
+            return ['wagtailsnippets/snippets/results.html']
+        else:
+            return ['wagtailsnippets/snippets/type_index.html']
 
 
 def create(request, app_label, model_name):


### PR DESCRIPTION
Django 4.0 [is dropping `request.is_ajax()`](https://docs.djangoproject.com/en/3.2/releases/3.1/#id2), so it's worth us making a start on removing it from the Wagtail admin. The snippet listing view currently makes use of it for the header search, returning just the 'results' include if the request comes from AJAX - this PR turns that into a class-based view so that we can easily split off a dedicated URL endpoint for that instead.

Incorporates #7208.