### PR TITLE
Allow a `ModelAdmin` to handle root pages

### DIFF
--- a/wagtail/contrib/modeladmin/options.py
+++ b/wagtail/contrib/modeladmin/options.py
@@ -240,6 +240,9 @@ class ModelAdmin(WagtailRegisterable):
         ordering = self.get_ordering(request)
         if ordering:
             qs = qs.order_by(*ordering)
+        if self.is_pagemodel:
+            # If we're listing pages, exclude the root page
+            qs = qs.exclude(depth=1)
         return qs
 
     def get_search_fields(self, request):

--- a/wagtail/contrib/modeladmin/tests/test_page_modeladmin.py
+++ b/wagtail/contrib/modeladmin/tests/test_page_modeladmin.py
@@ -54,6 +54,11 @@ class TestIndexView(TestCase, WagtailTestUtils):
         # There should still be four results
         self.assertEqual(response.context['result_count'], 4)
 
+    def test_using_core_page(self):
+        # The core page is slightly different to other pages
+        response = self.client.get('/admin/wagtailcore/page/')
+        self.assertEqual(response.status_code, 200)
+
 
 class TestExcludeFromExplorer(TestCase, WagtailTestUtils):
     fixtures = ['modeladmintest_test.json']

--- a/wagtail/contrib/modeladmin/tests/test_page_modeladmin.py
+++ b/wagtail/contrib/modeladmin/tests/test_page_modeladmin.py
@@ -55,9 +55,12 @@ class TestIndexView(TestCase, WagtailTestUtils):
         self.assertEqual(response.context['result_count'], 4)
 
     def test_using_core_page(self):
-        # The core page is slightly different to other pages
+        # The core page is slightly different to other pages, so exclude it
         response = self.client.get('/admin/wagtailcore/page/')
         self.assertEqual(response.status_code, 200)
+
+        root_page = Page.objects.get(depth=1)
+        self.assertNotIn(root_page, response.context['paginator'].object_list)
 
 
 class TestExcludeFromExplorer(TestCase, WagtailTestUtils):
@@ -191,6 +194,12 @@ class TestEditView(TestCase, WagtailTestUtils):
     def test_non_existent(self):
         response = self.get(100)
 
+        self.assertEqual(response.status_code, 404)
+
+    def test_using_core_page(self):
+        # The core page is slightly different to other pages, so exclude it
+        root_page = Page.objects.get(depth=1)
+        response = self.client.get('/admin/wagtailcore/page/{}/'.format(root_page.id))
         self.assertEqual(response.status_code, 404)
 
 

--- a/wagtail/tests/modeladmintest/wagtail_hooks.py
+++ b/wagtail/tests/modeladmintest/wagtail_hooks.py
@@ -3,6 +3,7 @@ from wagtail.contrib.modeladmin.helpers import WagtailBackendSearchHandler
 from wagtail.contrib.modeladmin.options import (
     ModelAdmin, ModelAdminGroup, ThumbnailMixin, modeladmin_register)
 from wagtail.contrib.modeladmin.views import CreateView, EditView, IndexView
+from wagtail.core.models import Page
 from wagtail.tests.testapp.models import BusinessChild, EventPage, SingleEventPage
 
 from .forms import PublisherModelAdminForm
@@ -171,6 +172,11 @@ class RelatedLinkAdmin(ModelAdmin):
     menu_label = "Related Links"
 
 
+class PageAdmin(ModelAdmin):
+    model = Page
+    menu_label = "Page"
+
+
 modeladmin_register(AuthorModelAdmin)
 modeladmin_register(BookModelAdmin)
 modeladmin_register(TokenModelAdmin)
@@ -182,3 +188,4 @@ modeladmin_register(FriendAdmin)
 modeladmin_register(VisitorAdmin)
 modeladmin_register(ContributorAdmin)
 modeladmin_register(RelatedLinkAdmin)
+modeladmin_register(PageAdmin)


### PR DESCRIPTION
Previously, `user_can_copy_obj` would raise an exception, as `parent_page` would be `None`. Now it handles that, and assumes it can copy.

Fixes an issue discovered in the [Wagtail Slack](https://wagtailcms.slack.com/archives/C81FGJR2S/p1621923985127700).