### PR TITLE
Avoid n+1 query on recent edits dashboard panel

### DIFF
--- a/wagtail/admin/views/home.py
+++ b/wagtail/admin/views/home.py
@@ -145,7 +145,7 @@ class RecentEditsPanel:
         page_keys = [pr.page_id for pr in last_edits]
         pages = Page.objects.specific().in_bulk(page_keys)
         self.last_edits = [
-            [review, pages.get(review.page.pk)] for review in last_edits
+            [revision, pages.get(revision.page_id)] for revision in last_edits
         ]
 
     def render(self):


### PR DESCRIPTION
The use of Page.objects.in_bulk to retrieve all page data for the panel in a single query was being thwarted by our use of revision.page.id when reading them back (which ends up loading the whole page object just to look at the id...)
