### PR TITLE
Check that page.save_revision() was given a specific page object

### DIFF
--- a/wagtail/admin/tests/api/test_pages.py
+++ b/wagtail/admin/tests/api/test_pages.py
@@ -618,7 +618,7 @@ class TestAdminPageDetail(AdminAPITestCase, TestPageDetail):
 
     def test_meta_status_live_draft(self):
         # Save revision without republish
-        Page.objects.get(id=16).save_revision()
+        Page.objects.get(id=16).specific.save_revision()
 
         response = self.get_response(16)
         content = json.loads(response.content.decode('UTF-8'))
@@ -634,7 +634,7 @@ class TestAdminPageDetail(AdminAPITestCase, TestPageDetail):
         # Unpublish and save revision with go live date in the future
         Page.objects.get(id=16).unpublish()
         tomorrow = timezone.now() + datetime.timedelta(days=1)
-        Page.objects.get(id=16).save_revision(approved_go_live_at=tomorrow)
+        Page.objects.get(id=16).specific.save_revision(approved_go_live_at=tomorrow)
 
         response = self.get_response(16)
         content = json.loads(response.content.decode('UTF-8'))

--- a/wagtail/admin/tests/pages/test_workflow_history.py
+++ b/wagtail/admin/tests/pages/test_workflow_history.py
@@ -13,7 +13,7 @@ class TestWorkflowHistoryDetail(TestCase, WagtailTestUtils):
         self.user = self.create_test_user()
         self.login(self.user)
 
-        self.christmas_event = Page.objects.get(url_path='/home/events/christmas/')
+        self.christmas_event = Page.objects.get(url_path='/home/events/christmas/').specific
         self.christmas_event.save_revision()
 
         workflow = self.christmas_event.get_workflow()

--- a/wagtail/api/v2/tests/test_pages.py
+++ b/wagtail/api/v2/tests/test_pages.py
@@ -1340,7 +1340,7 @@ class TestPageCacheInvalidation(TestCase):
         signal_handlers.unregister_signal_handlers()
 
     def test_republish_page_purges(self, purge):
-        Page.objects.get(id=2).save_revision().publish()
+        Page.objects.get(id=2).specific.save_revision().publish()
 
         purge.assert_any_call('http://api.example.com/api/main/pages/2/')
 
@@ -1355,6 +1355,6 @@ class TestPageCacheInvalidation(TestCase):
         purge.assert_any_call('http://api.example.com/api/main/pages/16/')
 
     def test_save_draft_doesnt_purge(self, purge):
-        Page.objects.get(id=2).save_revision()
+        Page.objects.get(id=2).specific.save_revision()
 
         purge.assert_not_called()

--- a/wagtail/core/models/__init__.py
+++ b/wagtail/core/models/__init__.py
@@ -853,10 +853,17 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
         :param clean: Set this to False to skip cleaning page content before saving this revision
         :return: the newly created revision
         """
+        # Raise error if this is not the specific version of the page
+        if not isinstance(self, self.specific_class):
+            raise RuntimeError(
+                "page.save_revision() must be called on the specific version of the page. "
+                "Call page.specific.save_revision() instead."
+            )
+
         # Raise an error if this page is an alias.
         if self.alias_of_id:
             raise RuntimeError(
-                "save_revision() was called on an alias page. "
+                "page.save_revision() was called on an alias page. "
                 "Revisions are not required for alias pages as they are an exact copy of another page."
             )
 

--- a/wagtail/core/tests/test_page_model.py
+++ b/wagtail/core/tests/test_page_model.py
@@ -817,6 +817,18 @@ class TestPrevNextSiblings(TestCase):
         self.assertEqual(final_event.get_prev_siblings(inclusive=True).first(), final_event)
 
 
+class TestSaveRevision(TestCase):
+    fixtures = ['test.json']
+
+    def test_raises_error_if_non_specific_page_used(self):
+        christmas_event = Page.objects.get(url_path='/home/events/christmas/')
+
+        with self.assertRaises(RuntimeError) as e:
+            christmas_event.save_revision()
+
+        self.assertEqual(e.exception.args[0], 'page.save_revision() must be called on the specific version of the page. Call page.specific.save_revision() instead.')
+
+
 class TestLiveRevision(TestCase):
     fixtures = ['test.json']
 
@@ -1430,7 +1442,7 @@ class TestCopyPage(TestCase):
     def test_copy_page_copies_recursively_but_doesnt_copy_revisions_if_told_not_to_do_so(self):
         events_index = EventIndex.objects.get(url_path='/home/events/')
         old_christmas_event = events_index.get_children().filter(slug='christmas').first()
-        old_christmas_event.save_revision()
+        old_christmas_event.specific.save_revision()
 
         # Copy it
         new_events_index = events_index.copy(
@@ -2462,7 +2474,7 @@ class TestIssue735(TestCase):
     fixtures = ['test.json']
 
     def test_child_urls_updated_on_parent_publish(self):
-        event_index = Page.objects.get(url_path='/home/events/')
+        event_index = Page.objects.get(url_path='/home/events/').specific
         christmas_event = EventPage.objects.get(url_path='/home/events/christmas/')
 
         # Change the event index slug and publish it
@@ -2500,8 +2512,8 @@ class TestIssue1216(TestCase):
     fixtures = ['test.json']
 
     def test_url_path_can_exceed_255_characters(self):
-        event_index = Page.objects.get(url_path='/home/events/')
-        christmas_event = EventPage.objects.get(url_path='/home/events/christmas/')
+        event_index = Page.objects.get(url_path='/home/events/').specific
+        christmas_event = EventPage.objects.get(url_path='/home/events/christmas/').specific
 
         # Change the christmas_event slug first - this way, we test that the process for
         # updating child url paths also handles >255 character paths correctly

--- a/wagtail/core/tests/test_page_queryset.py
+++ b/wagtail/core/tests/test_page_queryset.py
@@ -754,8 +754,8 @@ class TestSpecificQuery(TestCase):
         # Ensure annotations are reapplied to specific() page queries
 
         pages = Page.objects.live()
-        pages.first().save_revision()
-        pages.last().save_revision()
+        pages.first().specific.save_revision()
+        pages.last().specific.save_revision()
 
         results = Page.objects.live().specific().annotate(revision_count=Count('revisions'))
 


### PR DESCRIPTION
Currently it's possible to call `.save_revision()` on the generic version of the page. This results in all the specific content being deleted.

This PR adds a check to make sure the specific page is always used.