### PR TITLE
Prefetch wagtail_userprofile when retrieving comment authors

### DIFF
--- a/wagtail/admin/edit_handlers.py
+++ b/wagtail/admin/edit_handlers.py
@@ -875,7 +875,10 @@ class CommentPanel(EditHandler):
             data['replies'] = replies
             serialized_comments.append(data)
 
-        authors = {user.pk: user_data(user) for user in get_user_model().objects.filter(pk__in=user_pks)}
+        authors = {
+            user.pk: user_data(user)
+            for user in get_user_model().objects.filter(pk__in=user_pks).select_related('wagtail_userprofile')
+        }
 
         comments_data = {
             'comments': serialized_comments,


### PR DESCRIPTION
avatar_url will access this, so this prevents an N+1 query.