### PR TITLE
Implemented prefetch_renditions method on ImageQuerySet

### DIFF
--- a/wagtail/images/views/chooser.py
+++ b/wagtail/images/views/chooser.py
@@ -81,7 +81,7 @@ def chooser(request):
 
     images = permission_policy.instances_user_has_any_permission_for(
         request.user, ['choose']
-    ).order_by('-created_at')
+    ).order_by('-created_at').prefetch_renditions('max-165x165')
 
     # allow hooks to modify the queryset
     for hook in hooks.get_hooks('construct_image_chooser_queryset'):

--- a/wagtail/images/views/images.py
+++ b/wagtail/images/views/images.py
@@ -43,7 +43,7 @@ class BaseListingView(TemplateView):
         # Get images (filtered by user permission)
         images = permission_policy.instances_user_has_any_permission_for(
             self.request.user, ['change', 'delete']
-        ).order_by('-created_at')
+        ).order_by('-created_at').prefetch_renditions('max-165x165')
 
         # Search
         query_string = None


### PR DESCRIPTION
This should be useful for improving performance on listings with a lot of images. Instead of looking them up individually from a cache or by running lots of database queries, this method allows a developer to fetch many renditions for a queryset of images using just a single query.

In theory, this should be much faster than looking up each one from a cache as there will be fewer round-trips to an external server (the performance gain from this will be much higher in a production environment than locally). This is should also be a big improvement for those who don't use redis.