### PR TITLE
Use specific_deferred when generating links to pages in rich text

### DIFF
--- a/wagtail/core/rich_text/pages.py
+++ b/wagtail/core/rich_text/pages.py
@@ -13,12 +13,12 @@ class PageLinkHandler(LinkHandler):
 
     @classmethod
     def get_instance(cls, attrs):
-        return super().get_instance(attrs).specific
+        return super().get_instance(attrs).specific_deferred
 
     @classmethod
     def expand_db_attributes(cls, attrs):
         try:
             page = cls.get_instance(attrs)
-            return '<a href="%s">' % escape(page.localized.specific.url)
+            return '<a href="%s">' % escape(page.localized.specific_deferred.url)
         except Page.DoesNotExist:
             return "<a>"


### PR DESCRIPTION
Currently, we fetch whole page objects when generating URLs to them in rich text. This can generate a lot of unnecessary large queries (especially if those pages have a lot of content).

This PR makes these queries use specific_deferred instead. This will cause a performance disadvantage for those who have overridden the URL generation logic though. But this is generally rare and I think we should discourage this.