### PR TITLE
[experimental] Bulk load all external references in streamfields

### DIFF
--- a/wagtail/core/blocks/field_block.py
+++ b/wagtail/core/blocks/field_block.py
@@ -665,6 +665,11 @@ class ChooserBlock(FieldBlock):
         # the incoming serialised value should be None or an ID
         if value is None:
             return value
+
+        elif isinstance(value, self.target_model):
+            # Value bulk loaded by streamfield
+            return value
+
         else:
             try:
                 return self.target_model.objects.get(pk=value)
@@ -684,7 +689,7 @@ class ChooserBlock(FieldBlock):
         if value is None:
             return None
         else:
-            return value.pk
+            return value
 
     def value_from_form(self, value):
         # ModelChoiceField sometimes returns an ID, and sometimes an instance; we want the instance
@@ -707,6 +712,9 @@ class ChooserBlock(FieldBlock):
         if isinstance(value, self.target_model):
             value = value.pk
         return super().clean(value)
+
+    def get_api_representation(self, value, context=None):
+        return value.pk if value else None
 
     class Meta:
         # No icon specified here, because that depends on the purpose that the

--- a/wagtail/core/fields.py
+++ b/wagtail/core/fields.py
@@ -112,7 +112,7 @@ class StreamField(models.Field):
                 # but better to handle it just in case...
                 return StreamValue(self.stream_block, [])
 
-            return self.stream_block.to_python(unpacked_value)
+            return self.stream_block.to_python(unpacked_value, root=True)
         else:
             # See if it looks like the standard non-smart representation of a
             # StreamField value: a list of (block_name, value) tuples
@@ -133,7 +133,7 @@ class StreamField(models.Field):
             # fields.)
             return value.raw_text
         else:
-            return json.dumps(self.stream_block.get_prep_value(value), cls=DjangoJSONEncoder)
+            return json.dumps(self.stream_block.get_prep_value(value, root=True), cls=DjangoJSONEncoder)
 
     def from_db_value(self, value, expression, connection):
         return self.to_python(value)

--- a/wagtail/core/tests/test_blocks.py
+++ b/wagtail/core/tests/test_blocks.py
@@ -3411,7 +3411,7 @@ class TestPageChooserBlock(TestCase):
         block = blocks.PageChooserBlock()
         christmas_page = Page.objects.get(slug='christmas')
 
-        self.assertEqual(block.get_prep_value(christmas_page), christmas_page.id)
+        self.assertEqual(block.get_prep_value(christmas_page), christmas_page)
 
         # None should serialize to None
         self.assertEqual(block.get_prep_value(None), None)
@@ -3422,6 +3422,8 @@ class TestPageChooserBlock(TestCase):
         christmas_page = Page.objects.get(slug='christmas')
 
         self.assertEqual(block.to_python(christmas_page.id), christmas_page)
+
+        self.assertEqual(block.to_python(christmas_page), christmas_page)
 
         # None should deserialize to None
         self.assertEqual(block.to_python(None), None)

--- a/wagtail/snippets/tests.py
+++ b/wagtail/snippets/tests.py
@@ -1366,7 +1366,7 @@ class TestSnippetChooserBlock(TestCase):
         block = SnippetChooserBlock(Advert)
         test_advert = Advert.objects.get(text='test_advert')
 
-        self.assertEqual(block.get_prep_value(test_advert), test_advert.id)
+        self.assertEqual(block.get_prep_value(test_advert), test_advert)
 
         # None should serialize to None
         self.assertEqual(block.get_prep_value(None), None)
@@ -1377,6 +1377,8 @@ class TestSnippetChooserBlock(TestCase):
         test_advert = Advert.objects.get(text='test_advert')
 
         self.assertEqual(block.to_python(test_advert.id), test_advert)
+
+        self.assertEqual(block.to_python(test_advert), test_advert)
 
         # None should deserialize to None
         self.assertEqual(block.to_python(None), None)
@@ -1549,7 +1551,7 @@ class TestSnippetChooserBlockWithCustomPrimaryKey(TestCase):
         block = SnippetChooserBlock(AdvertWithCustomPrimaryKey)
         test_advert = AdvertWithCustomPrimaryKey.objects.get(pk='advert/01')
 
-        self.assertEqual(block.get_prep_value(test_advert), test_advert.pk)
+        self.assertEqual(block.get_prep_value(test_advert), test_advert)
 
         # None should serialize to None
         self.assertEqual(block.get_prep_value(None), None)
@@ -1560,6 +1562,8 @@ class TestSnippetChooserBlockWithCustomPrimaryKey(TestCase):
         test_advert = AdvertWithCustomPrimaryKey.objects.get(pk='advert/01')
 
         self.assertEqual(block.to_python(test_advert.pk), test_advert)
+
+        self.assertEqual(block.to_python(test_advert), test_advert)
 
         # None should deserialize to None
         self.assertEqual(block.to_python(None), None)


### PR DESCRIPTION
The current ``bulk_to_python`` methods in streafields only bulk load on one field at a time. This PR is a possible replacement for this that supports bulk loading referenced instances in the entire streamfield in one go.

**How it works**

Currently, we insert the IDs into the object returned by `get_prep_value` and this is stored in the database without any further conversion.

    [
        {
            "type": "image",
            "value": 1,
        },
        {
            "type": "image",
            "value": 2,
        },
        {
            "type": "image",
            "value": 1,
        }
    ]

This PR changes the` get_prep_value` implentation on ``ChooserBlock`` to return actual instances, and these get handled in a separate step. So the example above becomes:

    [
        {
            "type": "image",
            "value": <Image id=1>,
        },
        {
            "type": "image",
            "value": <Image id=2>,
        },
        {
            "type": "image",
            "value": <Image id=1>,
        }
    ]

Before serializing into JSON, these instances are replaced with `_ref` objects which contain an index to a "refs" object at the top of the streamfield value:

    {
        "blocks": [
            {
                "type": "image",
                "value": { "_ref": 0 }
            },
            {
                "type": "image",
                "value": { "_ref": 1 }
            },
            {
                "type": "image",
                "value": { "_ref": 0 }
            }
        ],
        "refs": [
            ["wagtailimages.Image", 1],
            ["wagtailimages.Image", 2]
        ]
    }

On retrieval, we bulk load the objects in “refs” and reinsert them back into the JSON object, to get back to the state we had in step 2. We then pass this value into `to_python`.

This “refs” key could be used later for quickly calculating object usage from streamfields too.

This would replace the existing and rather complicated `bulk_to_python` methods, which could mean that this change would reduce the complexity of the code overall. However, since it might take some time for existing data to be updated, we should keep this around for a couple of releases.