### PR TITLE
Fix eslint warnings/errors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,7 @@ jobs:
           paths:
             - ~/project/node_modules/
           key: node-v1-{{ .Branch }}-{{ checksum "package-lock.json" }}
+      - run: npm run build
       - run: npm run lint:js
       - run: npm run lint:css
       - run: npm run test:unit:coverage -- --runInBand

--- a/client/src/components/CommentApp/main.tsx
+++ b/client/src/components/CommentApp/main.tsx
@@ -338,6 +338,7 @@ export class CommentApp {
       }
 
       // If this is the initial focused comment. Focus and pin it
+      // eslint-disable-next-line no-warning-comments
       // TODO: Scroll to this comment
       if (initialFocusedCommentId && comment.pk === initialFocusedCommentId) {
         this.store.dispatch(setFocusedComment(commentId, { updatePinnedComment: true, forceFocus: true }));

--- a/client/src/components/CommentApp/utils/storybook.tsx
+++ b/client/src/components/CommentApp/utils/storybook.tsx
@@ -20,8 +20,7 @@ import { defaultStrings } from '../main';
 
 import CommentComponent from '../components/Comment/index';
 
-// Requires Wagtail static to be built, so raises error on CI
-// eslint-disable-next-line import/no-unresolved
+// Requires Wagtail static to be built
 import '../../../../../wagtail/admin/static/wagtailadmin/css/core.css';
 
 export function RenderCommentsForStorybook({

--- a/client/src/components/Sidebar/Sidebar.stories.tsx
+++ b/client/src/components/Sidebar/Sidebar.stories.tsx
@@ -9,7 +9,6 @@ import { LinkMenuItemDefinition } from './menu/LinkMenuItem';
 import { SubMenuItemDefinition } from './menu/SubMenuItem';
 import { initFocusOutline } from '../../utils/focus';
 
-// eslint-disable-next-line import/no-unresolved
 import '../../../../wagtail/admin/static/wagtailadmin/css/sidebar.css';
 import { CustomBrandingModuleDefinition } from './modules/CustomBranding';
 

--- a/client/src/components/Sidebar/Sidebar.stories.tsx
+++ b/client/src/components/Sidebar/Sidebar.stories.tsx
@@ -200,7 +200,9 @@ interface RenderSidebarStoryOptions {
   strings?: Strings;
 }
 
-function renderSidebarStory(modules: ModuleDefinition[], { rtl = false, strings = null }: RenderSidebarStoryOptions = {}) {
+function renderSidebarStory(
+  modules: ModuleDefinition[], { rtl = false, strings = null }: RenderSidebarStoryOptions = {}
+) {
   // Enable focus outlines so we can test them
   React.useEffect(() => {
     initFocusOutline();

--- a/client/src/components/Sidebar/Sidebar.tsx
+++ b/client/src/components/Sidebar/Sidebar.tsx
@@ -115,7 +115,10 @@ export const Sidebar: React.FunctionComponent<SidebarProps> = (
   );
 
   return (
-    <aside className={'sidebar' + (slim ? ' sidebar--slim' : '')} onMouseEnter={onMouseEnterHandler} onMouseLeave={onMouseLeaveHandler}>
+    <aside
+      className={'sidebar' + (slim ? ' sidebar--slim' : '')}
+      onMouseEnter={onMouseEnterHandler} onMouseLeave={onMouseLeaveHandler}
+    >
       <div className="sidebar__inner">
         <button onClick={onClickCollapseToggle} className="button sidebar__collapse-toggle">
           {collapsed ? <Icon name="angle-double-right" /> : <Icon name="angle-double-left" />}

--- a/client/src/entrypoints/admin/comments.js
+++ b/client/src/entrypoints/admin/comments.js
@@ -112,6 +112,7 @@ window.comments = (() => {
     onUnfocus() {
       this.node.classList.add('button-secondary');
       this.node.ariaLabel = STRINGS.FOCUS_COMMENT;
+      // eslint-disable-next-line no-warning-comments
       // TODO: ensure comment is focused accessibly when this is clicked,
       // and that screenreader users can return to the annotation point when desired
     }
@@ -213,6 +214,7 @@ window.comments = (() => {
           }
         }
       });
+      // eslint-disable-next-line no-warning-comments
       return unsubscribeWidget; // TODO: listen for widget deletion and use this
     }
     updateVisibility(newShown) {

--- a/client/src/entrypoints/admin/page-editor.js
+++ b/client/src/entrypoints/admin/page-editor.js
@@ -1,4 +1,5 @@
 import $ from 'jquery';
+import { cleanForSlug } from '../../utils/cleanForSlug';
 
 window.halloPlugins = {};
 
@@ -184,26 +185,6 @@ function InlinePanel(opts) {  // lgtm[js/unused-local-variable]
 }
 window.InlinePanel = InlinePanel;
 
-function cleanForSlug(val, useURLify) {
-  if (useURLify) {
-    // URLify performs extra processing on the string (e.g. removing stopwords) and is more suitable
-    // for creating a slug from the title, rather than sanitising a slug entered manually
-    // eslint-disable-next-line no-undef, new-cap
-    const cleaned = URLify(val, 255, window.unicodeSlugsEnabled);
-
-    // if the result is blank (e.g. because the title consisted entirely of stopwords),
-    // fall through to the non-URLify method
-    if (cleaned) {
-      return cleaned;
-    }
-  }
-
-  // just do the "replace"
-  if (window.unicodeSlugsEnabled) {
-    return val.replace(/\s/g, '-').replace(/[&/\\#,+()$~%.'":`@^!*?<>{}]/g, '').toLowerCase();
-  }
-  return val.replace(/\s/g, '-').replace(/[^A-Za-z0-9\-_]/g, '').toLowerCase();
-}
 window.cleanForSlug = cleanForSlug;
 
 function initSlugAutoPopulate() {
@@ -425,7 +406,3 @@ window.updateFooterSaveWarning = (formDirty, commentsDirty) => {
     updateWarnings();
   }
 };
-
-if (typeof module !== 'undefined' && module.exports) {
-  module.exports.cleanForSlug = cleanForSlug;
-}

--- a/client/src/entrypoints/admin/wagtailadmin.test.js
+++ b/client/src/entrypoints/admin/wagtailadmin.test.js
@@ -1,7 +1,5 @@
 jest.mock('../..');
 
-const wagtail = require('../..');
-
 document.addEventListener = jest.fn();
 
 require('./wagtailadmin');

--- a/client/src/utils/cleanForSlug.js
+++ b/client/src/utils/cleanForSlug.js
@@ -1,0 +1,20 @@
+export function cleanForSlug(val, useURLify) {
+  if (useURLify) {
+    // URLify performs extra processing on the string (e.g. removing stopwords) and is more suitable
+    // for creating a slug from the title, rather than sanitising a slug entered manually
+    // eslint-disable-next-line no-undef, new-cap
+    const cleaned = URLify(val, 255, window.unicodeSlugsEnabled);
+
+    // if the result is blank (e.g. because the title consisted entirely of stopwords),
+    // fall through to the non-URLify method
+    if (cleaned) {
+      return cleaned;
+    }
+  }
+
+  // just do the "replace"
+  if (window.unicodeSlugsEnabled) {
+    return val.replace(/\s/g, '-').replace(/[&/\\#,+()$~%.'":`@^!*?<>{}]/g, '').toLowerCase();
+  }
+  return val.replace(/\s/g, '-').replace(/[^A-Za-z0-9\-_]/g, '').toLowerCase();
+}

--- a/client/src/utils/cleanForSlug.test.js
+++ b/client/src/utils/cleanForSlug.test.js
@@ -1,12 +1,6 @@
-window.$ = require('../../../../wagtail/admin/static_src/wagtailadmin/js/vendor/jquery-3.5.1.min');
 // eslint-disable-next-line no-unused-expressions
-require('../../../../wagtail/admin/static_src/wagtailadmin/js/vendor/urlify').default;
-
-window.comments = {
-  getContentPath: jest.fn(),
-};
-
-const cleanForSlug = require('./page-editor').cleanForSlug;
+require('../../../wagtail/admin/static_src/wagtailadmin/js/vendor/urlify').default;
+import { cleanForSlug } from './cleanForSlug';
 
 describe('page-editor tests', () => {
   describe('cleanForSlug without unicode slugs enabled', () => {


### PR DESCRIPTION
I tried and failed to upgrade to eslint-config-wagtail 0.3.0 (I suspect packaging issues with eslint-config-airbnb et al due to them being moved from dependencies to devDependencies...) so as a stopgap to make our linting usable again, I've fixed the code to comply with our existing rules (including `eslint-disable-next-line no-warning-comments` against the TODO lines, which I think is a necessary evil at this point).

Have also added an `npm run build` step to CircleCI to fix #7177 (but will only be able to test that at the point of opening this PR, so here's hoping...)