### PR TITLE
Split up wagtail.core.models

### DIFF
--- a/wagtail/core/models/__init__.py
+++ b/wagtail/core/models/__init__.py
@@ -9,7 +9,6 @@ from urllib.parse import urlparse
 from django import forms
 from django.apps import apps
 from django.conf import settings
-from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group
 from django.contrib.contenttypes.models import ContentType
 from django.core import checks
@@ -52,6 +51,7 @@ from wagtail.core.utils import (
     get_supported_content_language_variant, resolve_model_string)
 from wagtail.search import index
 
+from .audit_log import BaseLogEntry, BaseLogEntryManager, LogEntryQuerySet  # noqa
 from .collections import (  # noqa
     BaseCollectionManager, Collection, CollectionManager, CollectionMember,
     CollectionViewRestriction, GroupCollectionPermission, GroupCollectionPermissionManager,
@@ -4316,65 +4316,6 @@ class TaskState(models.Model):
         verbose_name_plural = _('Task states')
 
 
-class LogEntryQuerySet(models.QuerySet):
-    def get_users(self):
-        """
-        Returns a QuerySet of Users who have created at least one log entry in this QuerySet.
-
-        The returned queryset is ordered by the username.
-        """
-        User = get_user_model()
-        return User.objects.filter(
-            pk__in=set(self.values_list('user__pk', flat=True))
-        ).order_by(User.USERNAME_FIELD)
-
-
-class BaseLogEntryManager(models.Manager):
-    def get_queryset(self):
-        return LogEntryQuerySet(self.model, using=self._db)
-
-    def get_instance_title(self, instance):
-        return str(instance)
-
-    def log_action(self, instance, action, **kwargs):
-        """
-        :param instance: The model instance we are logging an action for
-        :param action: The action. Should be namespaced to app (e.g. wagtail.create, wagtail.workflow.start)
-        :param kwargs: Addition fields to for the model deriving from BaseLogEntry
-            - user: The user performing the action
-            - title: the instance title
-            - data: any additional metadata
-            - content_changed, deleted - Boolean flags
-        :return: The new log entry
-        """
-        data = kwargs.pop('data', '')
-        title = kwargs.pop('title', None)
-        if not title:
-            title = self.get_instance_title(instance)
-
-        timestamp = kwargs.pop('timestamp', timezone.now())
-        return self.model.objects.create(
-            content_type=ContentType.objects.get_for_model(instance, for_concrete_model=False),
-            label=title,
-            action=action,
-            timestamp=timestamp,
-            data_json=json.dumps(data),
-            **kwargs,
-        )
-
-    def get_for_model(self, model):
-        # Return empty queryset if the given object is not valid.
-        if not issubclass(model, models.Model):
-            return self.none()
-
-        ct = ContentType.objects.get_for_model(model)
-
-        return self.filter(content_type=ct)
-
-    def get_for_user(self, user_id):
-        return self.filter(user=user_id)
-
-
 class PageLogEntryManager(BaseLogEntryManager):
 
     def get_instance_title(self, instance):
@@ -4383,113 +4324,6 @@ class PageLogEntryManager(BaseLogEntryManager):
     def log_action(self, instance, action, **kwargs):
         kwargs.update(page=instance)
         return super().log_action(instance, action, **kwargs)
-
-
-class BaseLogEntry(models.Model):
-    content_type = models.ForeignKey(
-        ContentType,
-        models.SET_NULL,
-        verbose_name=_('content type'),
-        blank=True, null=True,
-        related_name='+',
-    )
-    label = models.TextField()
-
-    action = models.CharField(max_length=255, blank=True, db_index=True)
-    data_json = models.TextField(blank=True)
-    timestamp = models.DateTimeField(verbose_name=_('timestamp (UTC)'))
-
-    user = models.ForeignKey(
-        settings.AUTH_USER_MODEL,
-        null=True,  # Null if actioned by system
-        blank=True,
-        on_delete=models.DO_NOTHING,
-        db_constraint=False,
-        related_name='+',
-    )
-
-    # Flags for additional context to the 'action' made by the user (or system).
-    content_changed = models.BooleanField(default=False, db_index=True)
-    deleted = models.BooleanField(default=False)
-
-    objects = BaseLogEntryManager()
-
-    action_registry = None
-
-    class Meta:
-        abstract = True
-        verbose_name = _('log entry')
-        verbose_name_plural = _('log entries')
-        ordering = ['-timestamp']
-
-    def save(self, *args, **kwargs):
-        self.full_clean()
-        return super().save(*args, **kwargs)
-
-    def clean(self):
-        self.action_registry.scan_for_actions()
-
-        if self.action not in self.action_registry.actions:
-            raise ValidationError({'action': _("The log action '{}' has not been registered.").format(self.action)})
-
-    def __str__(self):
-        return "LogEntry %d: '%s' on '%s'" % (
-            self.pk, self.action, self.object_verbose_name()
-        )
-
-    @cached_property
-    def user_display_name(self):
-        """
-        Returns the display name of the associated user;
-        get_full_name if available and non-empty, otherwise get_username.
-        Defaults to 'system' when none is provided
-        """
-        if self.user_id:
-            try:
-                user = self.user
-            except self._meta.get_field('user').related_model.DoesNotExist:
-                # User has been deleted
-                return _('user %(id)d (deleted)') % {'id': self.user_id}
-
-            try:
-                full_name = user.get_full_name().strip()
-            except AttributeError:
-                full_name = ''
-            return full_name or user.get_username()
-
-        else:
-            return _('system')
-
-    @cached_property
-    def data(self):
-        """
-        Provides deserialized data
-        """
-        if self.data_json:
-            return json.loads(self.data_json)
-        else:
-            return {}
-
-    @cached_property
-    def object_verbose_name(self):
-        model_class = self.content_type.model_class()
-        if model_class is None:
-            return self.content_type_id
-
-        return model_class._meta.verbose_name.title
-
-    def object_id(self):
-        raise NotImplementedError
-
-    def format_message(self):
-        return self.action_registry.format_message(self)
-
-    def format_comment(self):
-        return self.action_registry.format_comment(self)
-
-    @property
-    def comment(self):
-        return self.format_comment()
 
 
 class PageLogEntry(BaseLogEntry):

--- a/wagtail/core/models/__init__.py
+++ b/wagtail/core/models/__init__.py
@@ -3,7 +3,6 @@ import json
 import logging
 import uuid
 
-from collections import namedtuple
 from io import StringIO
 from urllib.parse import urlparse
 
@@ -21,11 +20,10 @@ from django.core.handlers.wsgi import WSGIRequest
 from django.db import migrations, models, transaction
 from django.db.models import DEFERRED, Q, Value
 from django.db.models.expressions import OuterRef, Subquery
-from django.db.models.functions import Concat, Lower, Substr
+from django.db.models.functions import Concat, Substr
 from django.db.models.signals import pre_save
 from django.dispatch import receiver
 from django.http import Http404
-from django.http.request import split_domain_port
 from django.template.response import TemplateResponse
 from django.urls import NoReverseMatch, reverse
 from django.utils import timezone, translation
@@ -49,13 +47,14 @@ from wagtail.core.signals import (
     page_published, page_unpublished, post_page_move, pre_page_move, task_approved, task_cancelled,
     task_rejected, task_submitted, workflow_approved, workflow_cancelled, workflow_rejected,
     workflow_submitted)
-from wagtail.core.sites import get_site_for_hostname
 from wagtail.core.treebeard import TreebeardPathFixMixin
 from wagtail.core.url_routing import RouteResult
 from wagtail.core.utils import (
     WAGTAIL_APPEND_SLASH, camelcase_to_underscore, find_available_slug, get_content_languages,
     get_supported_content_language_variant, resolve_model_string)
 from wagtail.search import index
+
+from .sites import Site, SiteManager, SiteRootPath  # noqa
 
 
 logger = logging.getLogger('wagtail.core')
@@ -154,172 +153,6 @@ def _copy(source, exclude_fields=None, update_attrs=None):
         child_object_map = {}
 
     return target, child_object_map
-
-
-class SiteManager(models.Manager):
-    def get_queryset(self):
-        return super(SiteManager, self).get_queryset().order_by(Lower("hostname"))
-
-    def get_by_natural_key(self, hostname, port):
-        return self.get(hostname=hostname, port=port)
-
-
-SiteRootPath = namedtuple('SiteRootPath', 'site_id root_path root_url language_code')
-
-
-class Site(models.Model):
-    hostname = models.CharField(verbose_name=_('hostname'), max_length=255, db_index=True)
-    port = models.IntegerField(
-        verbose_name=_('port'),
-        default=80,
-        help_text=_(
-            "Set this to something other than 80 if you need a specific port number to appear in URLs"
-            " (e.g. development on port 8000). Does not affect request handling (so port forwarding still works)."
-        )
-    )
-    site_name = models.CharField(
-        verbose_name=_('site name'),
-        max_length=255,
-        blank=True,
-        help_text=_("Human-readable name for the site.")
-    )
-    root_page = models.ForeignKey('Page', verbose_name=_('root page'), related_name='sites_rooted_here',
-                                  on_delete=models.CASCADE)
-    is_default_site = models.BooleanField(
-        verbose_name=_('is default site'),
-        default=False,
-        help_text=_(
-            "If true, this site will handle requests for all other hostnames that do not have a site entry of their own"
-        )
-    )
-
-    objects = SiteManager()
-
-    class Meta:
-        unique_together = ('hostname', 'port')
-        verbose_name = _('site')
-        verbose_name_plural = _('sites')
-
-    def natural_key(self):
-        return (self.hostname, self.port)
-
-    def __str__(self):
-        default_suffix = " [{}]".format(_("default"))
-        if self.site_name:
-            return (
-                self.site_name
-                + (default_suffix if self.is_default_site else "")
-            )
-        else:
-            return (
-                self.hostname
-                + ("" if self.port == 80 else (":%d" % self.port))
-                + (default_suffix if self.is_default_site else "")
-            )
-
-    @staticmethod
-    def find_for_request(request):
-        """
-        Find the site object responsible for responding to this HTTP
-        request object. Try:
-
-        * unique hostname first
-        * then hostname and port
-        * if there is no matching hostname at all, or no matching
-          hostname:port combination, fall back to the unique default site,
-          or raise an exception
-
-        NB this means that high-numbered ports on an extant hostname may
-        still be routed to a different hostname which is set as the default
-
-        The site will be cached via request._wagtail_site
-        """
-
-        if request is None:
-            return None
-
-        if not hasattr(request, '_wagtail_site'):
-            site = Site._find_for_request(request)
-            setattr(request, '_wagtail_site', site)
-        return request._wagtail_site
-
-    @staticmethod
-    def _find_for_request(request):
-        hostname = split_domain_port(request.get_host())[0]
-        port = request.get_port()
-        site = None
-        try:
-            site = get_site_for_hostname(hostname, port)
-        except Site.DoesNotExist:
-            pass
-            # copy old SiteMiddleware behavior
-        return site
-
-    @property
-    def root_url(self):
-        if self.port == 80:
-            return 'http://%s' % self.hostname
-        elif self.port == 443:
-            return 'https://%s' % self.hostname
-        else:
-            return 'http://%s:%d' % (self.hostname, self.port)
-
-    def clean_fields(self, exclude=None):
-        super().clean_fields(exclude)
-        # Only one site can have the is_default_site flag set
-        try:
-            default = Site.objects.get(is_default_site=True)
-        except Site.DoesNotExist:
-            pass
-        except Site.MultipleObjectsReturned:
-            raise
-        else:
-            if self.is_default_site and self.pk != default.pk:
-                raise ValidationError(
-                    {'is_default_site': [
-                        _(
-                            "%(hostname)s is already configured as the default site."
-                            " You must unset that before you can save this site as default."
-                        )
-                        % {'hostname': default.hostname}
-                    ]}
-                )
-
-    @staticmethod
-    def get_site_root_paths():
-        """
-        Return a list of `SiteRootPath` instances, most specific path
-        first - used to translate url_paths into actual URLs with hostnames
-
-        Each root path is an instance of the `SiteRootPath` named tuple,
-        and have the following attributes:
-
-        - `site_id` - The ID of the Site record
-        - `root_path` - The internal URL path of the site's home page (for example '/home/')
-        - `root_url` - The scheme/domain name of the site (for example 'https://www.example.com/')
-        - `language_code` - The language code of the site (for example 'en')
-        """
-        result = cache.get('wagtail_site_root_paths')
-
-        # Wagtail 2.11 changed the way site root paths were stored. This can cause an upgraded 2.11
-        # site to break when loading cached site root paths that were cached with 2.10.2 or older
-        # versions of Wagtail. The line below checks if the any of the cached site urls is consistent
-        # with an older version of Wagtail and invalidates the cache.
-        if result is None or any(len(site_record) == 3 for site_record in result):
-            result = []
-
-            for site in Site.objects.select_related('root_page', 'root_page__locale').order_by('-root_page__url_path', '-is_default_site', 'hostname'):
-                if getattr(settings, 'WAGTAIL_I18N_ENABLED', False):
-                    result.extend([
-                        SiteRootPath(site.id, root_page.url_path, site.root_url, root_page.locale.language_code)
-                        for root_page in site.root_page.get_translations(inclusive=True).select_related('locale')
-                    ])
-                else:
-                    result.append(SiteRootPath(site.id, site.root_page.url_path, site.root_url, site.root_page.locale.language_code))
-
-            cache.set('wagtail_site_root_paths', result, 3600)
-
-        return result
 
 
 def pk(obj):

--- a/wagtail/core/models/__init__.py
+++ b/wagtail/core/models/__init__.py
@@ -1,3 +1,14 @@
+"""
+wagtail.core.models is split into submodules for maintainability. All definitions intended as
+public should be imported here (with 'noqa' comments as required) and outside code should continue
+to import them from wagtail.core.models (e.g. `from wagtail.core.models import Site`, not
+`from wagtail.core.models.sites import Site`.)
+
+Submodules should take care to keep the direction of dependencies consistent; where possible they
+should implement low-level generic functionality which is then imported by higher-level models such
+as Page.
+"""
+
 import functools
 import json
 import logging

--- a/wagtail/core/models/__init__.py
+++ b/wagtail/core/models/__init__.py
@@ -10,7 +10,7 @@ from django import forms
 from django.apps import apps
 from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.contrib.auth.models import Group, Permission
+from django.contrib.auth.models import Group
 from django.contrib.contenttypes.models import ContentType
 from django.core import checks
 from django.core.cache import cache
@@ -30,9 +30,7 @@ from django.utils import timezone, translation
 from django.utils.cache import patch_cache_control
 from django.utils.encoding import force_str
 from django.utils.functional import cached_property
-from django.utils.html import format_html
 from django.utils.module_loading import import_string
-from django.utils.safestring import mark_safe
 from django.utils.text import capfirst, slugify
 from django.utils.translation import gettext_lazy as _
 from modelcluster.fields import ParentalKey, ParentalManyToManyField
@@ -42,7 +40,7 @@ from treebeard.mp_tree import MP_Node
 from wagtail.core.fields import StreamField
 from wagtail.core.forms import TaskStateCommentForm
 from wagtail.core.log_actions import page_log_action_registry
-from wagtail.core.query import PageQuerySet, TreeQuerySet
+from wagtail.core.query import PageQuerySet
 from wagtail.core.signals import (
     page_published, page_unpublished, post_page_move, pre_page_move, task_approved, task_cancelled,
     task_rejected, task_submitted, workflow_approved, workflow_cancelled, workflow_rejected,
@@ -54,6 +52,10 @@ from wagtail.core.utils import (
     get_supported_content_language_variant, resolve_model_string)
 from wagtail.search import index
 
+from .collections import (  # noqa
+    BaseCollectionManager, Collection, CollectionManager, CollectionMember,
+    CollectionViewRestriction, GroupCollectionPermission, GroupCollectionPermissionManager,
+    get_root_collection_id)
 from .sites import Site, SiteManager, SiteRootPath  # noqa
 from .view_restrictions import BaseViewRestriction
 
@@ -3488,166 +3490,6 @@ class PageViewRestriction(BaseViewRestriction):
                 }
             )
         return super().delete(**kwargs)
-
-
-class BaseCollectionManager(models.Manager):
-    def get_queryset(self):
-        return TreeQuerySet(self.model).order_by('path')
-
-
-CollectionManager = BaseCollectionManager.from_queryset(TreeQuerySet)
-
-
-class CollectionViewRestriction(BaseViewRestriction):
-    collection = models.ForeignKey(
-        'Collection',
-        verbose_name=_('collection'),
-        related_name='view_restrictions',
-        on_delete=models.CASCADE
-    )
-
-    passed_view_restrictions_session_key = 'passed_collection_view_restrictions'
-
-    class Meta:
-        verbose_name = _('collection view restriction')
-        verbose_name_plural = _('collection view restrictions')
-
-
-class Collection(TreebeardPathFixMixin, MP_Node):
-    """
-    A location in which resources such as images and documents can be grouped
-    """
-    name = models.CharField(max_length=255, verbose_name=_('name'))
-
-    objects = CollectionManager()
-    # Tell treebeard to order Collections' paths such that they are ordered by name at each level.
-    node_order_by = ['name']
-
-    def __str__(self):
-        return self.name
-
-    def get_ancestors(self, inclusive=False):
-        return Collection.objects.ancestor_of(self, inclusive)
-
-    def get_descendants(self, inclusive=False):
-        return Collection.objects.descendant_of(self, inclusive)
-
-    def get_siblings(self, inclusive=True):
-        return Collection.objects.sibling_of(self, inclusive)
-
-    def get_next_siblings(self, inclusive=False):
-        return self.get_siblings(inclusive).filter(path__gte=self.path).order_by('path')
-
-    def get_prev_siblings(self, inclusive=False):
-        return self.get_siblings(inclusive).filter(path__lte=self.path).order_by('-path')
-
-    def get_view_restrictions(self):
-        """Return a query set of all collection view restrictions that apply to this collection"""
-        return CollectionViewRestriction.objects.filter(collection__in=self.get_ancestors(inclusive=True))
-
-    def get_indented_name(self, indentation_start_depth=2, html=False):
-        """
-        Renders this Collection's name as a formatted string that displays its hierarchical depth via indentation.
-        If indentation_start_depth is supplied, the Collection's depth is rendered relative to that depth.
-        indentation_start_depth defaults to 2, the depth of the first non-Root Collection.
-        Pass html=True to get a HTML representation, instead of the default plain-text.
-
-        Example text output: "    ↳ Pies"
-        Example HTML output: "&nbsp;&nbsp;&nbsp;&nbsp;&#x21b3 Pies"
-        """
-        display_depth = self.depth - indentation_start_depth
-        # A Collection with a display depth of 0 or less (Root's can be -1), should have no indent.
-        if display_depth <= 0:
-            return self.name
-
-        # Indent each level of depth by 4 spaces (the width of the ↳ character in our admin font), then add ↳
-        # before adding the name.
-        if html:
-            # NOTE: &#x21b3 is the hex HTML entity for ↳.
-            return format_html(
-                "{indent}{icon} {name}",
-                indent=mark_safe('&nbsp;' * 4 * display_depth),
-                icon=mark_safe('&#x21b3'),
-                name=self.name
-            )
-        # Output unicode plain-text version
-        return "{}↳ {}".format(' ' * 4 * display_depth, self.name)
-
-    class Meta:
-        verbose_name = _('collection')
-        verbose_name_plural = _('collections')
-
-
-def get_root_collection_id():
-    return Collection.get_first_root_node().id
-
-
-class CollectionMember(models.Model):
-    """
-    Base class for models that are categorised into collections
-    """
-    collection = models.ForeignKey(
-        Collection,
-        default=get_root_collection_id,
-        verbose_name=_('collection'),
-        related_name='+',
-        on_delete=models.CASCADE
-    )
-
-    search_fields = [
-        index.FilterField('collection'),
-    ]
-
-    class Meta:
-        abstract = True
-
-
-class GroupCollectionPermissionManager(models.Manager):
-    def get_by_natural_key(self, group, collection, permission):
-        return self.get(group=group,
-                        collection=collection,
-                        permission=permission)
-
-
-class GroupCollectionPermission(models.Model):
-    """
-    A rule indicating that a group has permission for some action (e.g. "create document")
-    within a specified collection.
-    """
-    group = models.ForeignKey(
-        Group,
-        verbose_name=_('group'),
-        related_name='collection_permissions',
-        on_delete=models.CASCADE
-    )
-    collection = models.ForeignKey(
-        Collection,
-        verbose_name=_('collection'),
-        related_name='group_permissions',
-        on_delete=models.CASCADE
-    )
-    permission = models.ForeignKey(
-        Permission,
-        verbose_name=_('permission'),
-        on_delete=models.CASCADE
-    )
-
-    def __str__(self):
-        return "Group %d ('%s') has permission '%s' on collection %d ('%s')" % (
-            self.group.id, self.group,
-            self.permission,
-            self.collection.id, self.collection
-        )
-
-    def natural_key(self):
-        return (self.group, self.collection, self.permission)
-
-    objects = GroupCollectionPermissionManager()
-
-    class Meta:
-        unique_together = ('group', 'collection', 'permission')
-        verbose_name = _('group collection permission')
-        verbose_name_plural = _('group collection permissions')
 
 
 class WorkflowPage(models.Model):

--- a/wagtail/core/models/__init__.py
+++ b/wagtail/core/models/__init__.py
@@ -52,11 +52,10 @@ from wagtail.core.signals import (
 from wagtail.core.sites import get_site_for_hostname
 from wagtail.core.treebeard import TreebeardPathFixMixin
 from wagtail.core.url_routing import RouteResult
-from wagtail.core.utils import WAGTAIL_APPEND_SLASH, camelcase_to_underscore, resolve_model_string
+from wagtail.core.utils import (
+    WAGTAIL_APPEND_SLASH, camelcase_to_underscore, find_available_slug, get_content_languages,
+    get_supported_content_language_variant, resolve_model_string)
 from wagtail.search import index
-
-from .utils import (
-    find_available_slug, get_content_languages, get_supported_content_language_variant)
 
 
 logger = logging.getLogger('wagtail.core')

--- a/wagtail/core/models/__init__.py
+++ b/wagtail/core/models/__init__.py
@@ -55,6 +55,7 @@ from wagtail.core.utils import (
 from wagtail.search import index
 
 from .sites import Site, SiteManager, SiteRootPath  # noqa
+from .view_restrictions import BaseViewRestriction
 
 
 logger = logging.getLogger('wagtail.core')
@@ -3431,64 +3432,6 @@ class PagePermissionTester:
 
     def can_view_revisions(self):
         return not self.page_is_root
-
-
-class BaseViewRestriction(models.Model):
-    NONE = 'none'
-    PASSWORD = 'password'
-    GROUPS = 'groups'
-    LOGIN = 'login'
-
-    RESTRICTION_CHOICES = (
-        (NONE, _("Public")),
-        (LOGIN, _("Private, accessible to logged-in users")),
-        (PASSWORD, _("Private, accessible with the following password")),
-        (GROUPS, _("Private, accessible to users in specific groups")),
-    )
-
-    restriction_type = models.CharField(
-        max_length=20, choices=RESTRICTION_CHOICES)
-    password = models.CharField(verbose_name=_('password'), max_length=255, blank=True)
-    groups = models.ManyToManyField(Group, verbose_name=_('groups'), blank=True)
-
-    def accept_request(self, request):
-        if self.restriction_type == BaseViewRestriction.PASSWORD:
-            passed_restrictions = request.session.get(self.passed_view_restrictions_session_key, [])
-            if self.id not in passed_restrictions:
-                return False
-
-        elif self.restriction_type == BaseViewRestriction.LOGIN:
-            if not request.user.is_authenticated:
-                return False
-
-        elif self.restriction_type == BaseViewRestriction.GROUPS:
-            if not request.user.is_superuser:
-                current_user_groups = request.user.groups.all()
-
-                if not any(group in current_user_groups for group in self.groups.all()):
-                    return False
-
-        return True
-
-    def mark_as_passed(self, request):
-        """
-        Update the session data in the request to mark the user as having passed this
-        view restriction
-        """
-        has_existing_session = (settings.SESSION_COOKIE_NAME in request.COOKIES)
-        passed_restrictions = request.session.setdefault(self.passed_view_restrictions_session_key, [])
-        if self.id not in passed_restrictions:
-            passed_restrictions.append(self.id)
-            request.session[self.passed_view_restrictions_session_key] = passed_restrictions
-        if not has_existing_session:
-            # if this is a session we've created, set it to expire at the end
-            # of the browser session
-            request.session.set_expiry(0)
-
-    class Meta:
-        abstract = True
-        verbose_name = _('view restriction')
-        verbose_name_plural = _('view restrictions')
 
 
 class PageViewRestriction(BaseViewRestriction):

--- a/wagtail/core/models/__init__.py
+++ b/wagtail/core/models/__init__.py
@@ -4333,6 +4333,9 @@ class BaseLogEntryManager(models.Manager):
     def get_queryset(self):
         return LogEntryQuerySet(self.model, using=self._db)
 
+    def get_instance_title(self, instance):
+        return str(instance)
+
     def log_action(self, instance, action, **kwargs):
         """
         :param instance: The model instance we are logging an action for
@@ -4347,10 +4350,7 @@ class BaseLogEntryManager(models.Manager):
         data = kwargs.pop('data', '')
         title = kwargs.pop('title', None)
         if not title:
-            if isinstance(instance, Page):
-                title = instance.specific_deferred.get_admin_display_title()
-            else:
-                title = str(instance)
+            title = self.get_instance_title(instance)
 
         timestamp = kwargs.pop('timestamp', timezone.now())
         return self.model.objects.create(
@@ -4376,6 +4376,9 @@ class BaseLogEntryManager(models.Manager):
 
 
 class PageLogEntryManager(BaseLogEntryManager):
+
+    def get_instance_title(self, instance):
+        return instance.specific_deferred.get_admin_display_title()
 
     def log_action(self, instance, action, **kwargs):
         kwargs.update(page=instance)

--- a/wagtail/core/models/audit_log.py
+++ b/wagtail/core/models/audit_log.py
@@ -1,0 +1,176 @@
+import json
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.contrib.contenttypes.models import ContentType
+from django.core.exceptions import ValidationError
+from django.db import models
+from django.utils import timezone
+from django.utils.functional import cached_property
+from django.utils.translation import gettext_lazy as _
+
+
+class LogEntryQuerySet(models.QuerySet):
+    def get_users(self):
+        """
+        Returns a QuerySet of Users who have created at least one log entry in this QuerySet.
+
+        The returned queryset is ordered by the username.
+        """
+        User = get_user_model()
+        return User.objects.filter(
+            pk__in=set(self.values_list('user__pk', flat=True))
+        ).order_by(User.USERNAME_FIELD)
+
+
+class BaseLogEntryManager(models.Manager):
+    def get_queryset(self):
+        return LogEntryQuerySet(self.model, using=self._db)
+
+    def get_instance_title(self, instance):
+        return str(instance)
+
+    def log_action(self, instance, action, **kwargs):
+        """
+        :param instance: The model instance we are logging an action for
+        :param action: The action. Should be namespaced to app (e.g. wagtail.create, wagtail.workflow.start)
+        :param kwargs: Addition fields to for the model deriving from BaseLogEntry
+            - user: The user performing the action
+            - title: the instance title
+            - data: any additional metadata
+            - content_changed, deleted - Boolean flags
+        :return: The new log entry
+        """
+        data = kwargs.pop('data', '')
+        title = kwargs.pop('title', None)
+        if not title:
+            title = self.get_instance_title(instance)
+
+        timestamp = kwargs.pop('timestamp', timezone.now())
+        return self.model.objects.create(
+            content_type=ContentType.objects.get_for_model(instance, for_concrete_model=False),
+            label=title,
+            action=action,
+            timestamp=timestamp,
+            data_json=json.dumps(data),
+            **kwargs,
+        )
+
+    def get_for_model(self, model):
+        # Return empty queryset if the given object is not valid.
+        if not issubclass(model, models.Model):
+            return self.none()
+
+        ct = ContentType.objects.get_for_model(model)
+
+        return self.filter(content_type=ct)
+
+    def get_for_user(self, user_id):
+        return self.filter(user=user_id)
+
+
+class BaseLogEntry(models.Model):
+    content_type = models.ForeignKey(
+        ContentType,
+        models.SET_NULL,
+        verbose_name=_('content type'),
+        blank=True, null=True,
+        related_name='+',
+    )
+    label = models.TextField()
+
+    action = models.CharField(max_length=255, blank=True, db_index=True)
+    data_json = models.TextField(blank=True)
+    timestamp = models.DateTimeField(verbose_name=_('timestamp (UTC)'))
+
+    user = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        null=True,  # Null if actioned by system
+        blank=True,
+        on_delete=models.DO_NOTHING,
+        db_constraint=False,
+        related_name='+',
+    )
+
+    # Flags for additional context to the 'action' made by the user (or system).
+    content_changed = models.BooleanField(default=False, db_index=True)
+    deleted = models.BooleanField(default=False)
+
+    objects = BaseLogEntryManager()
+
+    action_registry = None
+
+    class Meta:
+        abstract = True
+        verbose_name = _('log entry')
+        verbose_name_plural = _('log entries')
+        ordering = ['-timestamp']
+
+    def save(self, *args, **kwargs):
+        self.full_clean()
+        return super().save(*args, **kwargs)
+
+    def clean(self):
+        self.action_registry.scan_for_actions()
+
+        if self.action not in self.action_registry.actions:
+            raise ValidationError({'action': _("The log action '{}' has not been registered.").format(self.action)})
+
+    def __str__(self):
+        return "LogEntry %d: '%s' on '%s'" % (
+            self.pk, self.action, self.object_verbose_name()
+        )
+
+    @cached_property
+    def user_display_name(self):
+        """
+        Returns the display name of the associated user;
+        get_full_name if available and non-empty, otherwise get_username.
+        Defaults to 'system' when none is provided
+        """
+        if self.user_id:
+            try:
+                user = self.user
+            except self._meta.get_field('user').related_model.DoesNotExist:
+                # User has been deleted
+                return _('user %(id)d (deleted)') % {'id': self.user_id}
+
+            try:
+                full_name = user.get_full_name().strip()
+            except AttributeError:
+                full_name = ''
+            return full_name or user.get_username()
+
+        else:
+            return _('system')
+
+    @cached_property
+    def data(self):
+        """
+        Provides deserialized data
+        """
+        if self.data_json:
+            return json.loads(self.data_json)
+        else:
+            return {}
+
+    @cached_property
+    def object_verbose_name(self):
+        model_class = self.content_type.model_class()
+        if model_class is None:
+            return self.content_type_id
+
+        return model_class._meta.verbose_name.title
+
+    def object_id(self):
+        raise NotImplementedError
+
+    def format_message(self):
+        return self.action_registry.format_message(self)
+
+    def format_comment(self):
+        return self.action_registry.format_comment(self)
+
+    @property
+    def comment(self):
+        return self.format_comment()

--- a/wagtail/core/models/audit_log.py
+++ b/wagtail/core/models/audit_log.py
@@ -1,3 +1,9 @@
+"""
+Base model definitions for audit logging. These may be subclassed to accommodate specific models
+such as Page, but the definitions here should remain generic and not depend on the base
+wagtail.core.models module or specific models such as Page.
+"""
+
 import json
 
 from django.conf import settings

--- a/wagtail/core/models/collections.py
+++ b/wagtail/core/models/collections.py
@@ -1,0 +1,172 @@
+from django.contrib.auth.models import Group, Permission
+from django.db import models
+from django.utils.html import format_html
+from django.utils.safestring import mark_safe
+from django.utils.translation import gettext_lazy as _
+from treebeard.mp_tree import MP_Node
+
+from wagtail.core.query import TreeQuerySet
+from wagtail.core.treebeard import TreebeardPathFixMixin
+from wagtail.search import index
+
+from .view_restrictions import BaseViewRestriction
+
+
+class BaseCollectionManager(models.Manager):
+    def get_queryset(self):
+        return TreeQuerySet(self.model).order_by('path')
+
+
+CollectionManager = BaseCollectionManager.from_queryset(TreeQuerySet)
+
+
+class CollectionViewRestriction(BaseViewRestriction):
+    collection = models.ForeignKey(
+        'Collection',
+        verbose_name=_('collection'),
+        related_name='view_restrictions',
+        on_delete=models.CASCADE
+    )
+
+    passed_view_restrictions_session_key = 'passed_collection_view_restrictions'
+
+    class Meta:
+        verbose_name = _('collection view restriction')
+        verbose_name_plural = _('collection view restrictions')
+
+
+class Collection(TreebeardPathFixMixin, MP_Node):
+    """
+    A location in which resources such as images and documents can be grouped
+    """
+    name = models.CharField(max_length=255, verbose_name=_('name'))
+
+    objects = CollectionManager()
+    # Tell treebeard to order Collections' paths such that they are ordered by name at each level.
+    node_order_by = ['name']
+
+    def __str__(self):
+        return self.name
+
+    def get_ancestors(self, inclusive=False):
+        return Collection.objects.ancestor_of(self, inclusive)
+
+    def get_descendants(self, inclusive=False):
+        return Collection.objects.descendant_of(self, inclusive)
+
+    def get_siblings(self, inclusive=True):
+        return Collection.objects.sibling_of(self, inclusive)
+
+    def get_next_siblings(self, inclusive=False):
+        return self.get_siblings(inclusive).filter(path__gte=self.path).order_by('path')
+
+    def get_prev_siblings(self, inclusive=False):
+        return self.get_siblings(inclusive).filter(path__lte=self.path).order_by('-path')
+
+    def get_view_restrictions(self):
+        """Return a query set of all collection view restrictions that apply to this collection"""
+        return CollectionViewRestriction.objects.filter(collection__in=self.get_ancestors(inclusive=True))
+
+    def get_indented_name(self, indentation_start_depth=2, html=False):
+        """
+        Renders this Collection's name as a formatted string that displays its hierarchical depth via indentation.
+        If indentation_start_depth is supplied, the Collection's depth is rendered relative to that depth.
+        indentation_start_depth defaults to 2, the depth of the first non-Root Collection.
+        Pass html=True to get a HTML representation, instead of the default plain-text.
+
+        Example text output: "    ↳ Pies"
+        Example HTML output: "&nbsp;&nbsp;&nbsp;&nbsp;&#x21b3 Pies"
+        """
+        display_depth = self.depth - indentation_start_depth
+        # A Collection with a display depth of 0 or less (Root's can be -1), should have no indent.
+        if display_depth <= 0:
+            return self.name
+
+        # Indent each level of depth by 4 spaces (the width of the ↳ character in our admin font), then add ↳
+        # before adding the name.
+        if html:
+            # NOTE: &#x21b3 is the hex HTML entity for ↳.
+            return format_html(
+                "{indent}{icon} {name}",
+                indent=mark_safe('&nbsp;' * 4 * display_depth),
+                icon=mark_safe('&#x21b3'),
+                name=self.name
+            )
+        # Output unicode plain-text version
+        return "{}↳ {}".format(' ' * 4 * display_depth, self.name)
+
+    class Meta:
+        verbose_name = _('collection')
+        verbose_name_plural = _('collections')
+
+
+def get_root_collection_id():
+    return Collection.get_first_root_node().id
+
+
+class CollectionMember(models.Model):
+    """
+    Base class for models that are categorised into collections
+    """
+    collection = models.ForeignKey(
+        Collection,
+        default=get_root_collection_id,
+        verbose_name=_('collection'),
+        related_name='+',
+        on_delete=models.CASCADE
+    )
+
+    search_fields = [
+        index.FilterField('collection'),
+    ]
+
+    class Meta:
+        abstract = True
+
+
+class GroupCollectionPermissionManager(models.Manager):
+    def get_by_natural_key(self, group, collection, permission):
+        return self.get(group=group,
+                        collection=collection,
+                        permission=permission)
+
+
+class GroupCollectionPermission(models.Model):
+    """
+    A rule indicating that a group has permission for some action (e.g. "create document")
+    within a specified collection.
+    """
+    group = models.ForeignKey(
+        Group,
+        verbose_name=_('group'),
+        related_name='collection_permissions',
+        on_delete=models.CASCADE
+    )
+    collection = models.ForeignKey(
+        Collection,
+        verbose_name=_('collection'),
+        related_name='group_permissions',
+        on_delete=models.CASCADE
+    )
+    permission = models.ForeignKey(
+        Permission,
+        verbose_name=_('permission'),
+        on_delete=models.CASCADE
+    )
+
+    def __str__(self):
+        return "Group %d ('%s') has permission '%s' on collection %d ('%s')" % (
+            self.group.id, self.group,
+            self.permission,
+            self.collection.id, self.collection
+        )
+
+    def natural_key(self):
+        return (self.group, self.collection, self.permission)
+
+    objects = GroupCollectionPermissionManager()
+
+    class Meta:
+        unique_together = ('group', 'collection', 'permission')
+        verbose_name = _('group collection permission')
+        verbose_name_plural = _('group collection permissions')

--- a/wagtail/core/models/sites.py
+++ b/wagtail/core/models/sites.py
@@ -1,0 +1,177 @@
+from collections import namedtuple
+
+from django.conf import settings
+from django.core.cache import cache
+from django.core.exceptions import ValidationError
+from django.db import models
+from django.db.models.functions import Lower
+from django.http.request import split_domain_port
+from django.utils.translation import gettext_lazy as _
+
+from wagtail.core.sites import get_site_for_hostname
+
+
+class SiteManager(models.Manager):
+    def get_queryset(self):
+        return super(SiteManager, self).get_queryset().order_by(Lower("hostname"))
+
+    def get_by_natural_key(self, hostname, port):
+        return self.get(hostname=hostname, port=port)
+
+
+SiteRootPath = namedtuple('SiteRootPath', 'site_id root_path root_url language_code')
+
+
+class Site(models.Model):
+    hostname = models.CharField(verbose_name=_('hostname'), max_length=255, db_index=True)
+    port = models.IntegerField(
+        verbose_name=_('port'),
+        default=80,
+        help_text=_(
+            "Set this to something other than 80 if you need a specific port number to appear in URLs"
+            " (e.g. development on port 8000). Does not affect request handling (so port forwarding still works)."
+        )
+    )
+    site_name = models.CharField(
+        verbose_name=_('site name'),
+        max_length=255,
+        blank=True,
+        help_text=_("Human-readable name for the site.")
+    )
+    root_page = models.ForeignKey('Page', verbose_name=_('root page'), related_name='sites_rooted_here',
+                                  on_delete=models.CASCADE)
+    is_default_site = models.BooleanField(
+        verbose_name=_('is default site'),
+        default=False,
+        help_text=_(
+            "If true, this site will handle requests for all other hostnames that do not have a site entry of their own"
+        )
+    )
+
+    objects = SiteManager()
+
+    class Meta:
+        unique_together = ('hostname', 'port')
+        verbose_name = _('site')
+        verbose_name_plural = _('sites')
+
+    def natural_key(self):
+        return (self.hostname, self.port)
+
+    def __str__(self):
+        default_suffix = " [{}]".format(_("default"))
+        if self.site_name:
+            return (
+                self.site_name
+                + (default_suffix if self.is_default_site else "")
+            )
+        else:
+            return (
+                self.hostname
+                + ("" if self.port == 80 else (":%d" % self.port))
+                + (default_suffix if self.is_default_site else "")
+            )
+
+    @staticmethod
+    def find_for_request(request):
+        """
+        Find the site object responsible for responding to this HTTP
+        request object. Try:
+
+        * unique hostname first
+        * then hostname and port
+        * if there is no matching hostname at all, or no matching
+          hostname:port combination, fall back to the unique default site,
+          or raise an exception
+
+        NB this means that high-numbered ports on an extant hostname may
+        still be routed to a different hostname which is set as the default
+
+        The site will be cached via request._wagtail_site
+        """
+
+        if request is None:
+            return None
+
+        if not hasattr(request, '_wagtail_site'):
+            site = Site._find_for_request(request)
+            setattr(request, '_wagtail_site', site)
+        return request._wagtail_site
+
+    @staticmethod
+    def _find_for_request(request):
+        hostname = split_domain_port(request.get_host())[0]
+        port = request.get_port()
+        site = None
+        try:
+            site = get_site_for_hostname(hostname, port)
+        except Site.DoesNotExist:
+            pass
+            # copy old SiteMiddleware behavior
+        return site
+
+    @property
+    def root_url(self):
+        if self.port == 80:
+            return 'http://%s' % self.hostname
+        elif self.port == 443:
+            return 'https://%s' % self.hostname
+        else:
+            return 'http://%s:%d' % (self.hostname, self.port)
+
+    def clean_fields(self, exclude=None):
+        super().clean_fields(exclude)
+        # Only one site can have the is_default_site flag set
+        try:
+            default = Site.objects.get(is_default_site=True)
+        except Site.DoesNotExist:
+            pass
+        except Site.MultipleObjectsReturned:
+            raise
+        else:
+            if self.is_default_site and self.pk != default.pk:
+                raise ValidationError(
+                    {'is_default_site': [
+                        _(
+                            "%(hostname)s is already configured as the default site."
+                            " You must unset that before you can save this site as default."
+                        )
+                        % {'hostname': default.hostname}
+                    ]}
+                )
+
+    @staticmethod
+    def get_site_root_paths():
+        """
+        Return a list of `SiteRootPath` instances, most specific path
+        first - used to translate url_paths into actual URLs with hostnames
+
+        Each root path is an instance of the `SiteRootPath` named tuple,
+        and have the following attributes:
+
+        - `site_id` - The ID of the Site record
+        - `root_path` - The internal URL path of the site's home page (for example '/home/')
+        - `root_url` - The scheme/domain name of the site (for example 'https://www.example.com/')
+        - `language_code` - The language code of the site (for example 'en')
+        """
+        result = cache.get('wagtail_site_root_paths')
+
+        # Wagtail 2.11 changed the way site root paths were stored. This can cause an upgraded 2.11
+        # site to break when loading cached site root paths that were cached with 2.10.2 or older
+        # versions of Wagtail. The line below checks if the any of the cached site urls is consistent
+        # with an older version of Wagtail and invalidates the cache.
+        if result is None or any(len(site_record) == 3 for site_record in result):
+            result = []
+
+            for site in Site.objects.select_related('root_page', 'root_page__locale').order_by('-root_page__url_path', '-is_default_site', 'hostname'):
+                if getattr(settings, 'WAGTAIL_I18N_ENABLED', False):
+                    result.extend([
+                        SiteRootPath(site.id, root_page.url_path, site.root_url, root_page.locale.language_code)
+                        for root_page in site.root_page.get_translations(inclusive=True).select_related('locale')
+                    ])
+                else:
+                    result.append(SiteRootPath(site.id, site.root_page.url_path, site.root_url, site.root_page.locale.language_code))
+
+            cache.set('wagtail_site_root_paths', result, 3600)
+
+        return result

--- a/wagtail/core/models/view_restrictions.py
+++ b/wagtail/core/models/view_restrictions.py
@@ -1,0 +1,62 @@
+from django.conf import settings
+from django.contrib.auth.models import Group
+from django.db import models
+from django.utils.translation import gettext_lazy as _
+
+
+class BaseViewRestriction(models.Model):
+    NONE = 'none'
+    PASSWORD = 'password'
+    GROUPS = 'groups'
+    LOGIN = 'login'
+
+    RESTRICTION_CHOICES = (
+        (NONE, _("Public")),
+        (LOGIN, _("Private, accessible to logged-in users")),
+        (PASSWORD, _("Private, accessible with the following password")),
+        (GROUPS, _("Private, accessible to users in specific groups")),
+    )
+
+    restriction_type = models.CharField(
+        max_length=20, choices=RESTRICTION_CHOICES)
+    password = models.CharField(verbose_name=_('password'), max_length=255, blank=True)
+    groups = models.ManyToManyField(Group, verbose_name=_('groups'), blank=True)
+
+    def accept_request(self, request):
+        if self.restriction_type == BaseViewRestriction.PASSWORD:
+            passed_restrictions = request.session.get(self.passed_view_restrictions_session_key, [])
+            if self.id not in passed_restrictions:
+                return False
+
+        elif self.restriction_type == BaseViewRestriction.LOGIN:
+            if not request.user.is_authenticated:
+                return False
+
+        elif self.restriction_type == BaseViewRestriction.GROUPS:
+            if not request.user.is_superuser:
+                current_user_groups = request.user.groups.all()
+
+                if not any(group in current_user_groups for group in self.groups.all()):
+                    return False
+
+        return True
+
+    def mark_as_passed(self, request):
+        """
+        Update the session data in the request to mark the user as having passed this
+        view restriction
+        """
+        has_existing_session = (settings.SESSION_COOKIE_NAME in request.COOKIES)
+        passed_restrictions = request.session.setdefault(self.passed_view_restrictions_session_key, [])
+        if self.id not in passed_restrictions:
+            passed_restrictions.append(self.id)
+            request.session[self.passed_view_restrictions_session_key] = passed_restrictions
+        if not has_existing_session:
+            # if this is a session we've created, set it to expire at the end
+            # of the browser session
+            request.session.set_expiry(0)
+
+    class Meta:
+        abstract = True
+        verbose_name = _('view restriction')
+        verbose_name_plural = _('view restrictions')

--- a/wagtail/core/models/view_restrictions.py
+++ b/wagtail/core/models/view_restrictions.py
@@ -1,3 +1,10 @@
+"""
+Base model definitions for validating front-end user access to resources such as pages and
+documents. These may be subclassed to accommodate specific models such as Page or Collection,
+but the definitions here should remain generic and not depend on the base wagtail.core.models
+module or specific models defined there.
+"""
+
 from django.conf import settings
 from django.contrib.auth.models import Group
 from django.db import models


### PR DESCRIPTION
About time, I think. :-)

Everything page-related is still in the top-level module (which will hopefully reduce the number of merge conflicts with current PRs), and 'noqa' imports have been added to ensure that everything is still importable from their old locations. (Third-party code could still potentially break if tries to import things from wagtail.core.models that actually exist in e.g. wagtail.core.utils, but at least it will break in an obvious way...)