### PR TITLE
Give 404 pages a meaningful HTML title in project template

### DIFF
--- a/wagtail/project_template/project_name/templates/404.html
+++ b/wagtail/project_template/project_name/templates/404.html
@@ -1,5 +1,7 @@
 {% templatetag openblock %} extends "base.html" {% templatetag closeblock %}
 
+{% templatetag openblock %} block title {% templatetag closeblock %}Page not found{% templatetag openblock %} endblock {% templatetag closeblock %}
+
 {% templatetag openblock %} block body_class {% templatetag closeblock %}template-404{% templatetag openblock %} endblock {% templatetag closeblock %}
 
 {% templatetag openblock %} block content {% templatetag closeblock %}

--- a/wagtail/project_template/project_name/templates/base.html
+++ b/wagtail/project_template/project_name/templates/base.html
@@ -1,4 +1,4 @@
-{% templatetag openblock %} load static wagtailuserbar {% templatetag closeblock %}
+{% templatetag openblock %} load static wagtailcore_tags wagtailuserbar {% templatetag closeblock %}
 
 <!DOCTYPE html>
 <html class="no-js" lang="en">
@@ -6,12 +6,11 @@
         <meta charset="utf-8" />
         <title>
             {% templatetag openblock %} block title %}
-                {% templatetag openblock %} if self.seo_title %}{% templatetag openvariable %} self.seo_title {% templatetag closevariable %}{% templatetag openblock %} else %}{% templatetag openvariable %} self.title {% templatetag closevariable %}{% templatetag openblock %} endif %}
+                {% templatetag openblock %} if page.seo_title %}{% templatetag openvariable %} page.seo_title {% templatetag closevariable %}{% templatetag openblock %} else %}{% templatetag openvariable %} page.title {% templatetag closevariable %}{% templatetag openblock %} endif %}
             {% templatetag openblock %} endblock %}
             {% templatetag openblock %} block title_suffix %}
-                {% templatetag openblock %} with self.get_site.site_name as site_name %}
-                    {% templatetag openblock %} if site_name %}- {% templatetag openvariable %} site_name {% templatetag closevariable %}{% templatetag openblock %} endif %}
-                {% templatetag openblock %} endwith %}
+                {% templatetag openblock %} wagtail_site as current_site %}
+                {% templatetag openblock %} if current_site and current_site.site_name %}- {% templatetag openvariable %} current_site.site_name {% templatetag closevariable %}{% templatetag openblock %} endif %}
             {% templatetag openblock %} endblock %}
         </title>
         <meta name="description" content="" />


### PR DESCRIPTION
Improve the generation of `<title>` tags as follows:

* use `page` in preference to `self` (self has been semi-deprecated ever since we added jinja2 support)
* Retrieve current site with `{% wagtail_site %}` rather than page.get_site so that it works on non-pages such as 404s
* Fill in the 'title' block on 404.html
