### PR TITLE
[slim-sidebar] styling cherry picks part 1

### DIFF
--- a/client/scss/settings/_variables.scss
+++ b/client/scss/settings/_variables.scss
@@ -112,6 +112,7 @@ $object-title-height: 40px;
 // Nav
 $nav-grey-1: darken($color-white, 80);
 $nav-grey-2: darken($color-white, 60);
+$nav-grey-3: #262626;
 $nav-item-hover-bg: rgba(100, 100, 100, 0.15);
 $nav-item-active-bg: darken($color-white, 90);
 $nav-submenu-bg: darken($color-white, 85);

--- a/client/scss/settings/_variables.scss
+++ b/client/scss/settings/_variables.scss
@@ -97,7 +97,7 @@ $font-serif: Roboto Slab, Georgia, serif;
 // misc sizing
 $thumbnail-width: 130px;
 $menu-width: 200px;
-$menu-width-slim: 50px;
+$menu-width-slim: 60px;
 
 $menu-width-max: 320px;
 $mobile-nav-indent: 50px;

--- a/client/src/components/Sidebar/Sidebar.scss
+++ b/client/src/components/Sidebar/Sidebar.scss
@@ -24,24 +24,30 @@
     }
 
     &__collapse-toggle {
+        @include transition(background-color 150ms ease);
         position: absolute;
-        top: 0;
-        left: 0;
+        top: 12px;
+        left: 12px;
         color: #ccc;
-        background-color: transparent;
+        width: 35px;
+        height: 35px;
+        background: transparent;
         border: 0;
-        padding: 7px;
-        margin: 2px;
-        margin-left: 7px;
-        border-radius: 3px;
+        display: grid;
+        place-items: center;
+        padding: 0;
+        border-radius: 50%;
 
-        &:hover {
-            background-color: rgba(100, 100, 100, 0.15);
+        @include media-breakpoint-up(sm) {
+            &:hover {
+                background-color: #3a3a3a;
+                color: #ccc;
+            }
         }
 
         svg {
-            width: 20px;
-            height: 20px;
+            width: 15px;
+            height: 16px;
         }
     }
 }

--- a/client/src/components/Sidebar/Sidebar.scss
+++ b/client/src/components/Sidebar/Sidebar.scss
@@ -6,7 +6,7 @@
     display: flex;
     flex-direction: column;
     height: 100%;
-    background: $nav-grey-1;
+    background: $nav-grey-3;
     z-index: 1;
 
     @include transition(width 0.3s ease);
@@ -17,7 +17,7 @@
 
     &__inner {
         height: 100%;
-        background: $nav-grey-1;
+        background: $nav-grey-3;
         // On medium, make it possible for the nav links to scroll.
         display: flex;
         flex-flow: column nowrap;


### PR DESCRIPTION
Contains styling changes for the new sidebar cherry-picked from #7245

- Increase width of the collapsed slim sidebar
- Use darker shade for the sidebar background
- Nicer look for the slim sidebar toggle
