### PR TITLE
Shortcut for accessing StreamField blocks by block name/type

### DIFF
--- a/wagtail/core/blocks/stream_block.py
+++ b/wagtail/core/blocks/stream_block.py
@@ -544,13 +544,13 @@ class StreamValue(MutableSequence):
         return prep_value
 
     def blocks_by_name(self, block_name=None):
-        blocks = defaultdict(list)
+        blocks = {block: [] for block in self.stream_block.child_blocks}
         for item in self:
             blocks[item.block_type].append(item)
 
         if block_name is None:
             return blocks
-        return blocks[block_name]
+        return blocks.get(block_name, [])
 
     def first_block_by_name(self, block_name):
         if block_name not in self.stream_block.child_blocks:

--- a/wagtail/core/blocks/stream_block.py
+++ b/wagtail/core/blocks/stream_block.py
@@ -547,12 +547,10 @@ class StreamValue(MutableSequence):
         blocks = {}
         for item in self:
             block_type = item.block_type
-            block_value = item.value
-
             if block_type in blocks:
-                blocks[block_type].append(block_value)
+                blocks[block_type].append(item)
             else:
-                blocks[block_type] = [block_value]
+                blocks[block_type] = [item]
 
         return blocks
 
@@ -568,7 +566,7 @@ class StreamValue(MutableSequence):
 
         for item in self:
             if item.block_type == block_type:
-                return item.value
+                return item
 
     def __eq__(self, other):
         if not isinstance(other, StreamValue) or len(other) != len(self):

--- a/wagtail/core/blocks/stream_block.py
+++ b/wagtail/core/blocks/stream_block.py
@@ -558,7 +558,7 @@ class StreamValue(MutableSequence):
         if block_type not in self.stream_block.child_blocks:
             return []
 
-        return self.blocks_by_type()[block_type]
+        return self.blocks_by_type().get(block_type, [])
 
     def first_block_of_type(self, block_type):
         if block_type not in self.stream_block.child_blocks:

--- a/wagtail/core/blocks/stream_block.py
+++ b/wagtail/core/blocks/stream_block.py
@@ -588,9 +588,21 @@ class StreamValue(MutableSequence):
         if block_name not in self.stream_block.child_blocks:
             return
 
-        for item in self:
-            if item.block_type == block_name:
-                return item
+        for i in range(len(self)):
+            if self._bound_blocks[i] is None:
+                # Avoid block evaluation if possible
+                if self._raw_data[i]["type"] != block_name:
+                    continue
+
+                # Avoid bulk evaluation
+                raw_value = self._raw_data[i]
+                self._bound_blocks[i] = self._construct_stream_child(
+                    (raw_value["type"], raw_value["value"], raw_value.get("id", None))
+                )
+
+            block = self[i]
+            if block.block_type == block_name:
+                return block
 
     def __eq__(self, other):
         if not isinstance(other, StreamValue) or len(other) != len(self):

--- a/wagtail/core/blocks/stream_block.py
+++ b/wagtail/core/blocks/stream_block.py
@@ -543,6 +543,33 @@ class StreamValue(MutableSequence):
 
         return prep_value
 
+    def blocks_by_type(self):
+        blocks = {}
+        for item in self:
+            block_type = item.block_type
+            block_value = item.value
+
+            if block_type in blocks:
+                blocks[block_type].append(block_value)
+            else:
+                blocks[block_type] = [block_value]
+
+        return blocks
+
+    def blocks_of_type(self, block_type):
+        if block_type not in self.stream_block.child_blocks:
+            return []
+
+        return self.blocks_by_type()[block_type]
+
+    def first_block_of_type(self, block_type):
+        if block_type not in self.stream_block.child_blocks:
+            return
+
+        for item in self:
+            if item.block_type == block_type:
+                return item.value
+
     def __eq__(self, other):
         if not isinstance(other, StreamValue) or len(other) != len(self):
             return False

--- a/wagtail/core/blocks/stream_block.py
+++ b/wagtail/core/blocks/stream_block.py
@@ -543,29 +543,21 @@ class StreamValue(MutableSequence):
 
         return prep_value
 
-    def blocks_by_type(self):
-        blocks = {}
+    def blocks_by_name(self, block_name=None):
+        blocks = defaultdict(list)
         for item in self:
-            block_type = item.block_type
-            if block_type in blocks:
-                blocks[block_type].append(item)
-            else:
-                blocks[block_type] = [item]
+            blocks[item.block_type].append(item)
 
-        return blocks
+        if block_name is None:
+            return blocks
+        return blocks[block_name]
 
-    def blocks_of_type(self, block_type):
-        if block_type not in self.stream_block.child_blocks:
-            return []
-
-        return self.blocks_by_type().get(block_type, [])
-
-    def first_block_of_type(self, block_type):
-        if block_type not in self.stream_block.child_blocks:
+    def first_block_by_name(self, block_name):
+        if block_name not in self.stream_block.child_blocks:
             return
 
         for item in self:
-            if item.block_type == block_type:
+            if item.block_type == block_name:
                 return item
 
     def __eq__(self, other):

--- a/wagtail/core/tests/test_blocks.py
+++ b/wagtail/core/tests/test_blocks.py
@@ -3361,11 +3361,12 @@ class TestStreamBlock(WagtailTestUtils, SimpleTestCase):
                 'value': 'My second paragraph',
             },
         ])
-
         blocks_by_name = value.blocks_by_name()
+        assert isinstance(blocks_by_name, blocks.StreamValue.lazy_callable_stream)
+
         result_types = [
             [type(el) for el in block]
-            for block in blocks_by_name.values()
+            for block in blocks_by_name
         ]
         self.assertEqual(result_types, [
             [blocks.StreamValue.StreamChild],       # One `heading block`
@@ -3374,6 +3375,9 @@ class TestStreamBlock(WagtailTestUtils, SimpleTestCase):
         ])
 
         paragraph_blocks = value.blocks_by_name(block_name="paragraph")
+        # We can also access by indexing on the stream
+        self.assertEqual(paragraph_blocks, value.blocks_by_name()["paragraph"])
+
         self.assertEqual(len(paragraph_blocks), 2)
         for block in paragraph_blocks:
             self.assertEqual(block.block_type, 'paragraph')

--- a/wagtail/core/tests/test_blocks.py
+++ b/wagtail/core/tests/test_blocks.py
@@ -3340,6 +3340,48 @@ class TestStreamBlock(WagtailTestUtils, SimpleTestCase):
             },
         })
 
+    def test_block_types(self):
+        class ArticleBlock(blocks.StreamBlock):
+            heading = blocks.CharBlock()
+            paragraph = blocks.CharBlock()
+
+        block = ArticleBlock()
+        value = block.to_python([
+            {
+                'type': 'heading',
+                'value': "My title",
+            },
+            {
+                'type': 'paragraph',
+                'value': 'My first paragraph',
+            },
+            {
+                'type': 'paragraph',
+                'value': 'My second paragraph',
+            },
+        ])
+
+        self.assertEqual(
+            value.blocks_by_type(),
+            {
+                "heading": ["My title"],
+                "paragraph": ['My first paragraph', 'My second paragraph']
+            }
+        )
+
+        self.assertEqual(
+            value.blocks_of_type(block_type="paragraph"),
+            ['My first paragraph', 'My second paragraph']
+        )
+
+        self.assertEqual(
+            value.blocks_of_type(block_type="invalid_type"),
+            []
+        )
+
+        self.assertEqual(value.first_block_of_type(block_type="heading"), "My title")
+        self.assertIs(value.first_block_of_type(block_type="invalid_type"), None)
+
     def test_adapt_with_classname_via_class_meta(self):
         """form_classname from meta to be used as an additional class when rendering stream block"""
 

--- a/wagtail/core/tests/test_blocks.py
+++ b/wagtail/core/tests/test_blocks.py
@@ -3368,8 +3368,9 @@ class TestStreamBlock(WagtailTestUtils, SimpleTestCase):
             for block in blocks_by_name.values()
         ]
         self.assertEqual(result_types, [
-            [blocks.StreamValue.StreamChild],
-            [blocks.StreamValue.StreamChild] * 2
+            [blocks.StreamValue.StreamChild],       # One `heading block`
+            [blocks.StreamValue.StreamChild] * 2,   # Two `paragraph` blocks
+            [],                                     # Zero `date` block
         ])
 
         paragraph_blocks = value.blocks_by_name(block_name="paragraph")

--- a/wagtail/core/tests/test_blocks.py
+++ b/wagtail/core/tests/test_blocks.py
@@ -3340,7 +3340,7 @@ class TestStreamBlock(WagtailTestUtils, SimpleTestCase):
             },
         })
 
-    def test_block_types(self):
+    def test_block_names(self):
         class ArticleBlock(blocks.StreamBlock):
             heading = blocks.CharBlock()
             paragraph = blocks.RichTextBlock()
@@ -3362,30 +3362,30 @@ class TestStreamBlock(WagtailTestUtils, SimpleTestCase):
             },
         ])
 
-        blocks_by_type = value.blocks_by_type()
+        blocks_by_name = value.blocks_by_name()
         result_types = [
             [type(el) for el in block]
-            for block in blocks_by_type.values()
+            for block in blocks_by_name.values()
         ]
         self.assertEqual(result_types, [
             [blocks.StreamValue.StreamChild],
             [blocks.StreamValue.StreamChild] * 2
         ])
 
-        paragraph_blocks = value.blocks_of_type(block_type="paragraph")
+        paragraph_blocks = value.blocks_by_name(block_name="paragraph")
         self.assertEqual(len(paragraph_blocks), 2)
         for block in paragraph_blocks:
             self.assertEqual(block.block_type, 'paragraph')
 
-        self.assertEqual(value.blocks_of_type(block_type="date"), [])
-        self.assertEqual(value.blocks_of_type(block_type="invalid_type"), [])
+        self.assertEqual(value.blocks_by_name(block_name="date"), [])
+        self.assertEqual(value.blocks_by_name(block_name="invalid_name"), [])
 
-        first_heading_block = value.first_block_of_type(block_type="heading")
+        first_heading_block = value.first_block_by_name(block_name="heading")
         self.assertEqual(first_heading_block.block_type, "heading")
         self.assertEqual(first_heading_block.value, "My title")
 
-        self.assertIs(value.first_block_of_type(block_type="date"), None)
-        self.assertIs(value.first_block_of_type(block_type="invalid_type"), None)
+        self.assertIs(value.first_block_by_name(block_name="date"), None)
+        self.assertIs(value.first_block_by_name(block_name="invalid_name"), None)
 
     def test_adapt_with_classname_via_class_meta(self):
         """form_classname from meta to be used as an additional class when rendering stream block"""


### PR DESCRIPTION
See #7240 

This PR adds three methods/shortcuts to `StreamValue` class.
- `blocks_by_type` Arguments: None
This method returns a  dict consisting of all blocks organised by type.
It allows writing something like the following in templates:
`<h1>{{ page.body.blocks_by_type.heading.0 }}</h1>
`

- `blocks_of_type` Arguments: `block_type`
This method returns all blocks of type `block_type`.

- `first_block_of_type` Arguments: `block_type`
This method returns the first block of type `block_type`

* Do the tests still pass?
  Yes
* Does the code comply with the style guide? 
  Yes
* For Python changes: Have you added tests to cover the new/fixed behaviour?
  Yes
* For new features: Has the documentation been updated accordingly?
  Not yet. I will add it if the implementation is approved.
