### PR TITLE
[Docs] Incorrect field name in example (tiny)

### DIFF
--- a/docs/advanced_topics/customisation/page_editing_interface.rst
+++ b/docs/advanced_topics/customisation/page_editing_interface.rst
@@ -47,7 +47,7 @@ Wagtail provides a general-purpose WYSIWYG editor for creating rich text content
 
 
     class BookPage(Page):
-        book_text = RichTextField()
+        body = RichTextField()
 
         content_panels = Page.content_panels + [
             FieldPanel('body', classname="full"),


### PR DESCRIPTION
Tiny documentation fix, `body` instead of `book_text` - as referenced by the `content_panels` line straight afterwards.