### PR TITLE
[slim-sidebar] Always display menu that is opening on top of menu that is closing

### DIFF
--- a/client/src/components/Sidebar/SidebarPanel.scss
+++ b/client/src/components/Sidebar/SidebarPanel.scss
@@ -31,9 +31,6 @@
     &--open {
         left: $menu-width;
 
-        // If another submenu is opening, display this menu behind it
-        z-index: -1;
-
         @at-root .sidebar--slim #{&} {
             left: $menu-width-slim;
         }

--- a/client/src/components/Sidebar/SidebarPanel.tsx
+++ b/client/src/components/Sidebar/SidebarPanel.tsx
@@ -17,7 +17,14 @@ export const SidebarPanel: React.FunctionComponent<SidebarPanelProps> = (
     + (isOpen ? ' sidebar-panel--open' : '')
   );
 
-  const style = { zIndex: -depth };
+  const style = { zIndex: -depth * 2 };
+
+  const isClosing = isVisible && !isOpen;
+  if (isClosing) {
+    // When closing, make sure this panel displays behind any new panel that is opening
+    style.zIndex--;
+  }
+
   if (widthPx) {
     style['--width'] = widthPx + 'px';
   }

--- a/client/src/components/Sidebar/menu/PageExplorerMenuItem.tsx
+++ b/client/src/components/Sidebar/menu/PageExplorerMenuItem.tsx
@@ -15,6 +15,7 @@ export const PageExplorerMenuItem: React.FunctionComponent<MenuItemProps<PageExp
   { path, item, state, dispatch, navigate }) => {
   const isOpen = state.navigationPath.startsWith(path);
   const isActive = isOpen || state.activePath.startsWith(path);
+  const depth = path.split('.').length;
   const isInSubMenu = path.split('.').length > 2;
   const [isVisible, setIsVisible] = React.useState(false);
 
@@ -79,7 +80,7 @@ export const PageExplorerMenuItem: React.FunctionComponent<MenuItemProps<PageExp
         <Icon className={sidebarTriggerIconClassName} name="arrow-right" />
       </Button>
       <div>
-        <SidebarPanel isVisible={isVisible} isOpen={isOpen} depth={1} widthPx={485}>
+        <SidebarPanel isVisible={isVisible} isOpen={isOpen} depth={depth} widthPx={485}>
           {store.current &&
             <Provider store={store.current}>
               <PageExplorer isVisible={isVisible} navigate={navigate} />


### PR DESCRIPTION
The z indexes of the panels that slide out for the page explorer and sub menus is currently calculated by depth, but this means all menus at the same depth have the same z index so the browser has to decide which is displayed in front when switching submenus.

This PR makes sure that the menu that is closing always has a lower z index than the menu that is opening, so the transition is always consistent.