### PR TITLE
RichTextField when cloned should include features & editor settings

### DIFF
--- a/wagtail/core/fields.py
+++ b/wagtail/core/fields.py
@@ -13,12 +13,12 @@ class RichTextField(models.TextField):
         self.editor = kwargs.pop('editor', 'default')
         self.features = kwargs.pop('features', None)
         super().__init__(*args, **kwargs)
-        
-    def deconstruct(self):
-        name, path, args, kwargs = super().deconstruct()
-        kwargs['features'] = self.features
-        kwargs['editor'] = self.editor
-        return name, path, args, kwargs
+
+    def clone(self):
+        name, path, args, kwargs = self.deconstruct()
+        kwargs["features"] = self.features
+        kwargs["editor"] = self.editor
+        return self.__class__(*args, **kwargs)
 
     def formfield(self, **kwargs):
         from wagtail.admin.rich_text import get_rich_text_editor_widget

--- a/wagtail/core/fields.py
+++ b/wagtail/core/fields.py
@@ -12,8 +12,13 @@ class RichTextField(models.TextField):
     def __init__(self, *args, **kwargs):
         self.editor = kwargs.pop('editor', 'default')
         self.features = kwargs.pop('features', None)
-        # TODO: preserve 'editor' and 'features' when deconstructing for migrations
         super().__init__(*args, **kwargs)
+        
+    def deconstruct(self):
+        name, path, args, kwargs = super().deconstruct()
+        kwargs['features'] = self.features
+        kwargs['editor'] = self.editor
+        return name, path, args, kwargs
 
     def formfield(self, **kwargs):
         from wagtail.admin.rich_text import get_rich_text_editor_widget


### PR DESCRIPTION
A `RichTextField` when `clone`d should also include the `features` & `editor` kwargs it was originally created with.