### PR TITLE
Remove ability to add arbitrary classes to menu items from slim menu

### DIFF
--- a/client/src/components/Sidebar/menu/LinkMenuItem.tsx
+++ b/client/src/components/Sidebar/menu/LinkMenuItem.tsx
@@ -36,7 +36,7 @@ export const LinkMenuItem: React.FunctionComponent<MenuItemProps<LinkMenuItemDef
 
   return (
     <li className={className}>
-      <a href="#" onClick={onClick} className={item.classNames}>
+      <a href="#" onClick={onClick}>
         {item.iconName && <Icon name={item.iconName} className="icon--menuitem" />}
         <span className="menuitem-label">{item.label}</span>
       </a>
@@ -49,14 +49,12 @@ export class LinkMenuItemDefinition implements MenuItemDefinition {
   label: string;
   url: string;
   iconName: string | null;
-  classNames?: string;
 
-  constructor({ name, label, url, icon_name: iconName = null, classnames = undefined }) {
+  constructor({ name, label, url, icon_name: iconName = null }) {
     this.name = name;
     this.label = label;
     this.url = url;
     this.iconName = iconName;
-    this.classNames = classnames;
   }
 
   render({ path, state, dispatch, navigate }) {

--- a/client/src/components/Sidebar/menu/MenuItem.tsx
+++ b/client/src/components/Sidebar/menu/MenuItem.tsx
@@ -12,7 +12,6 @@ export interface MenuItemDefinition {
   name: string;
   label: string;
   iconName: string | null;
-  classNames?: string;
   render(context: MenuItemRenderContext): React.ReactFragment;
 }
 

--- a/client/src/components/Sidebar/menu/PageExplorerMenuItem.tsx
+++ b/client/src/components/Sidebar/menu/PageExplorerMenuItem.tsx
@@ -94,8 +94,8 @@ export const PageExplorerMenuItem: React.FunctionComponent<MenuItemProps<PageExp
 export class PageExplorerMenuItemDefinition extends LinkMenuItemDefinition {
   startPageId: number;
 
-  constructor({ name, label, url, icon_name: iconName = null, classnames = undefined }, startPageId: number) {
-    super({ name, label, url, icon_name: iconName, classnames });
+  constructor({ name, label, url, icon_name: iconName = null }, startPageId: number) {
+    super({ name, label, url, icon_name: iconName });
     this.startPageId = startPageId;
   }
 

--- a/client/src/components/Sidebar/menu/SubMenuItem.tsx
+++ b/client/src/components/Sidebar/menu/SubMenuItem.tsx
@@ -67,7 +67,6 @@ export const SubMenuItem: React.FunctionComponent<SubMenuItemProps> = (
       <a
         href="#"
         onClick={onClick}
-        className={item.classNames}
         aria-haspopup="true"
         aria-expanded={isOpen ? 'true' : 'false'}
       >
@@ -77,7 +76,7 @@ export const SubMenuItem: React.FunctionComponent<SubMenuItemProps> = (
       </a>
       <SidebarPanel isVisible={isVisible} isOpen={isOpen} depth={depth}>
         <div className="sidebar-sub-menu-panel">
-          <h2 id={`wagtail-sidebar-submenu${path.split('.').join('-')}-title`} className={item.classNames}>
+          <h2 id={`wagtail-sidebar-submenu${path.split('.').join('-')}-title`}>
             {item.iconName && <Icon name={item.iconName} className="icon--submenu-header" />}
             {item.label}
           </h2>
@@ -96,7 +95,6 @@ export class SubMenuItemDefinition implements MenuItemDefinition {
   label: string;
   menuItems: MenuItemDefinition[];
   iconName: string | null;
-  classNames?: string;
   footerText: string;
 
   constructor(
@@ -104,7 +102,6 @@ export class SubMenuItemDefinition implements MenuItemDefinition {
       name,
       label,
       icon_name: iconName = null,
-      classnames = undefined,
       footer_text: footerText = '',
     }: any,
     menuItems: MenuItemDefinition[]
@@ -113,7 +110,6 @@ export class SubMenuItemDefinition implements MenuItemDefinition {
     this.label = label;
     this.menuItems = menuItems;
     this.iconName = iconName;
-    this.classNames = classnames;
     this.footerText = footerText;
   }
 

--- a/wagtail/admin/menu.py
+++ b/wagtail/admin/menu.py
@@ -52,7 +52,7 @@ class MenuItem(metaclass=MediaDefiningClass):
         return render_to_string(self.template, context, request=request)
 
     def render_component(self, request):
-        return LinkMenuItemComponent(self.name, self.label, self.url, icon_name=self.icon_name, classnames=self.classnames)
+        return LinkMenuItemComponent(self.name, self.label, self.url, icon_name=self.icon_name)
 
 
 class Menu:
@@ -128,7 +128,7 @@ class SubmenuMenuItem(MenuItem):
         return context
 
     def render_component(self, request):
-        return SubMenuItemComponent(self.name, self.label, self.menu.render_component(request), icon_name=self.icon_name, classnames=self.classnames)
+        return SubMenuItemComponent(self.name, self.label, self.menu.render_component(request), icon_name=self.icon_name)
 
 
 class AdminOnlyMenuItem(MenuItem):

--- a/wagtail/admin/tests/ui/test_sidebar.py
+++ b/wagtail/admin/tests/ui/test_sidebar.py
@@ -19,7 +19,6 @@ class TestAdaptLinkMenuItem(TestCase):
             '_type': 'wagtail.sidebar.LinkMenuItem',
             '_args': [
                 {
-                    'classnames': '',
                     'icon_name': '',
                     'label': 'Link',
                     'name': 'link',
@@ -29,13 +28,12 @@ class TestAdaptLinkMenuItem(TestCase):
         })
 
     def test_adapt_with_classnames_and_icon(self):
-        packed = JSContext().pack(LinkMenuItem('link', "Link", '/link/', icon_name='link-icon', classnames='some classes'))
+        packed = JSContext().pack(LinkMenuItem('link', "Link", '/link/', icon_name='link-icon'))
 
         self.assertEqual(packed, {
             '_type': 'wagtail.sidebar.LinkMenuItem',
             '_args': [
                 {
-                    'classnames': 'some classes',
                     'icon_name': 'link-icon',
                     'label': 'Link',
                     'name': 'link',
@@ -60,7 +58,6 @@ class TestAdaptSubMenuItem(TestCase):
                     'name': 'sub-menu',
                     'label': 'Sub menu',
                     'icon_name': '',
-                    'classnames': '',
                     'footer_text': 'Footer text'
                 },
                 [
@@ -71,7 +68,6 @@ class TestAdaptSubMenuItem(TestCase):
                                 'name': 'link',
                                 'label': 'Link',
                                 'icon_name': 'link-icon',
-                                'classnames': '',
                                 'url': '/link/'
                             }
                         ]
@@ -94,7 +90,6 @@ class TestAdaptSubMenuItem(TestCase):
                     'name': 'sub-menu',
                     'label': 'Sub menu',
                     'icon_name': '',
-                    'classnames': '',
                     'footer_text': ''
                 },
                 [
@@ -105,7 +100,6 @@ class TestAdaptSubMenuItem(TestCase):
                                 'name': 'link',
                                 'label': 'Link',
                                 'icon_name': 'link-icon',
-                                'classnames': '',
                                 'url': '/link/'
                             }
                         ]
@@ -123,7 +117,6 @@ class TestAdaptPageExplorerMenuItem(TestCase):
             '_type': 'wagtail.sidebar.PageExplorerMenuItem',
             '_args': [
                 {
-                    'classnames': '',
                     'icon_name': '',
                     'label': 'Pages',
                     'name': 'pages',
@@ -206,7 +199,7 @@ class TestAdaptMainMenuModule(DjangoTestCase, WagtailTestUtils):
                     {
                         '_type': 'wagtail.sidebar.LinkMenuItem',
                         '_args': [
-                            {'name': 'pages', 'label': 'Pages', 'icon_name': '', 'classnames': '', 'url': '/pages/'}
+                            {'name': 'pages', 'label': 'Pages', 'icon_name': '', 'url': '/pages/'}
                         ]
                     }
                 ],
@@ -214,13 +207,13 @@ class TestAdaptMainMenuModule(DjangoTestCase, WagtailTestUtils):
                     {
                         '_type': 'wagtail.sidebar.LinkMenuItem',
                         '_args': [
-                            {'name': 'account', 'label': 'Account', 'icon_name': 'user', 'classnames': '', 'url': reverse('wagtailadmin_account')}
+                            {'name': 'account', 'label': 'Account', 'icon_name': 'user', 'url': reverse('wagtailadmin_account')}
                         ]
                     },
                     {
                         '_type': 'wagtail.sidebar.LinkMenuItem',
                         '_args': [
-                            {'name': 'logout', 'label': 'Logout', 'icon_name': 'logout', 'classnames': '', 'url': reverse('wagtailadmin_logout')}
+                            {'name': 'logout', 'label': 'Logout', 'icon_name': 'logout', 'url': reverse('wagtailadmin_logout')}
                         ]
                     }
                 ],

--- a/wagtail/admin/ui/sidebar.py
+++ b/wagtail/admin/ui/sidebar.py
@@ -19,11 +19,10 @@ class BaseSidebarAdapter(Adapter):
 # Main menu
 
 class MenuItem:
-    def __init__(self, name: str, label: str, icon_name: str = '', classnames: str = ''):
+    def __init__(self, name: str, label: str, icon_name: str = ''):
         self.name = name
         self.label = label
         self.icon_name = icon_name
-        self.classnames = classnames
 
     def js_args(self):
         return [
@@ -31,15 +30,14 @@ class MenuItem:
                 'name': self.name,
                 'label': self.label,
                 'icon_name': self.icon_name,
-                'classnames': self.classnames,
             }
         ]
 
 
 @adapter('wagtail.sidebar.LinkMenuItem', base=BaseSidebarAdapter)
 class LinkMenuItem(MenuItem):
-    def __init__(self, name: str, label: str, url: str, icon_name: str = '', classnames: str = ''):
-        super().__init__(name, label, icon_name=icon_name, classnames=classnames)
+    def __init__(self, name: str, label: str, url: str, icon_name: str = ''):
+        super().__init__(name, label, icon_name=icon_name)
         self.url = url
 
     def js_args(self):
@@ -54,14 +52,13 @@ class LinkMenuItem(MenuItem):
             and self.label == other.label
             and self.url == other.url
             and self.icon_name == other.icon_name
-            and self.classnames == other.classnames
         )
 
 
 @adapter('wagtail.sidebar.SubMenuItem', base=BaseSidebarAdapter)
 class SubMenuItem(MenuItem):
-    def __init__(self, name: str, label: str, menu_items: List[MenuItem], icon_name: str = '', classnames: str = '', footer_text: str = ''):
-        super().__init__(name, label, icon_name=icon_name, classnames=classnames)
+    def __init__(self, name: str, label: str, menu_items: List[MenuItem], icon_name: str = '', footer_text: str = ''):
+        super().__init__(name, label, icon_name=icon_name)
         self.menu_items = menu_items
         self.footer_text = footer_text
 
@@ -78,15 +75,14 @@ class SubMenuItem(MenuItem):
             and self.label == other.label
             and self.menu_items == other.menu_items
             and self.icon_name == other.icon_name
-            and self.classnames == other.classnames
             and self.footer_text == other.footer_text
         )
 
 
 @adapter('wagtail.sidebar.PageExplorerMenuItem', base=BaseSidebarAdapter)
 class PageExplorerMenuItem(LinkMenuItem):
-    def __init__(self, name: str, label: str, url: str, start_page_id: int, icon_name: str = '', classnames: str = ''):
-        super().__init__(name, label, url, icon_name=icon_name, classnames=classnames)
+    def __init__(self, name: str, label: str, url: str, start_page_id: int, icon_name: str = ''):
+        super().__init__(name, label, url, icon_name=icon_name)
         self.start_page_id = start_page_id
 
     def js_args(self):
@@ -102,7 +98,6 @@ class PageExplorerMenuItem(LinkMenuItem):
             and self.url == other.url
             and self.start_page_id == other.start_page_id
             and self.icon_name == other.icon_name
-            and self.classnames == other.classnames
         )
 
 

--- a/wagtail/admin/wagtail_hooks.py
+++ b/wagtail/admin/wagtail_hooks.py
@@ -52,7 +52,7 @@ class ExplorerMenuItem(MenuItem):
         start_page = get_explorable_root_page(request.user)
 
         if start_page:
-            return PageExplorerMenuItemComponent(self.name, self.label, self.url, start_page.id, icon_name=self.icon_name, classnames=self.classnames)
+            return PageExplorerMenuItemComponent(self.name, self.label, self.url, start_page.id, icon_name=self.icon_name)
         else:
             return super().render_component(request)
 
@@ -75,7 +75,6 @@ class SettingsMenuItem(SubmenuMenuItem):
             self.label,
             self.menu.render_component(request),
             icon_name=self.icon_name,
-            classnames=self.classnames,
             footer_text="Wagtail v." + __version__
         )
 


### PR DESCRIPTION
This was added to allow users to add custom icons to menu items. This is no longer needed as ``icon_name`` can be used to provide an icon now.

The slim menu won't become a mandatory feature until at least 2.16, so we don't need to deprecate this in the slim menu.

TODO:
 - [ ] Deprecation warning for people using custom classes on the non-slim menu