### PR TITLE
Ensure comparison view picks up request/instance-specific EditHandler customisations

### DIFF
--- a/wagtail/admin/views/pages/revisions.py
+++ b/wagtail/admin/views/pages/revisions.py
@@ -139,7 +139,7 @@ def revisions_compare(request, page_id, revision_id_a, revision_id_b):
         revision_b = get_object_or_404(page.revisions, id=revision_id_b).as_page_object()
         revision_b_heading = str(get_object_or_404(page.revisions, id=revision_id_b).created_at)
 
-    comparison = page.get_edit_handler().get_comparison()
+    comparison = page.get_edit_handler().bind_to(instance=page, request=request).get_comparison()
     comparison = [comp(revision_a, revision_b) for comp in comparison]
     comparison = [comp for comp in comparison if comp.has_changed()]
 


### PR DESCRIPTION
Some edit handlers, such as the 'unofficial' PerUserContentPanels recipe from #4749, vary their field list according to the current request/instance by hooking into bind_to. This was not being called on the comparison view, meaning that when these edit handlers are in use, the field list was never getting populated and so the view was wrongly reporting no changes.

Note that the bind_to method also allows binding a form, which we do still skip (since the comparison view doesn't construct one).