### PR TITLE
[slim-sidebar] Reinstate sidebar slim account menu css selector

### DIFF
--- a/client/src/components/Sidebar/modules/MainMenu.scss
+++ b/client/src/components/Sidebar/modules/MainMenu.scss
@@ -154,6 +154,10 @@
 
     @at-root .sidebar--slim #{&} {
         width: $menu-width-slim;
+
+        &__account em {
+            left: $menu-width-slim - $menu-width;
+        }
     }
 
     &--open {


### PR DESCRIPTION
It was still in use, oops...
