### PR TITLE
Docs: Update sphinx-wagtail-theme to 5.0.4

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,2 @@
 docutils==0.16  # Pinned to work around https://github.com/sphinx-doc/sphinx/issues/9049
-sphinx-wagtail-theme==5.0.3
+sphinx-wagtail-theme==5.0.4

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ documentation_extras = [
     'sphinxcontrib-spelling>=5.4.0,<6',
     'Sphinx>=1.5.2',
     'sphinx-autobuild>=0.6.0',
-    'sphinx-wagtail-theme==5.0.3',
+    'sphinx-wagtail-theme==5.0.4',
     'recommonmark>=0.7.1',
 ]
 


### PR DESCRIPTION
Update our docs theme to 5.0.4, which includes:

- Accessibility fixes and an improvement to the header layout on small screens: https://github.com/wagtail/sphinx_wagtail_theme/pull/109
- A trial setup for translating the docs: https://github.com/wagtail/sphinx_wagtail_theme/commit/026509dbef7afb8627bb36e97e8237a5751eb277