### PR TITLE
Change spin animation name to make it less prone to be overridden 

### DIFF
--- a/client/scss/components/_icons.scss
+++ b/client/scss/components/_icons.scss
@@ -77,12 +77,12 @@
 .icon-spinner:after,
 .icon-spinner:before {  // iconfont
     width: 1em;
-    animation: spin 0.5s infinite linear;
+    animation: spin-wag 0.5s infinite linear;
     display: inline-block;
 }
 
 svg.icon-spinner { // TODO: leave only class when iconfont styles are removed
-    animation: spin 0.5s infinite linear;
+    animation: spin-wag 0.5s infinite linear;
 }
 
 .icon-horizontalrule:before {
@@ -120,7 +120,7 @@ svg.icon-spinner { // TODO: leave only class when iconfont styles are removed
     }
 }
 
-@keyframes spin {
+@keyframes spin-wag {
     0% {
         transform: rotate(0deg);
     }


### PR DESCRIPTION
The animation `spin` is too generic, and it can be easily overridden by other libraries (eg. the code used in [django-json-widget](https://github.com/jmrivas86/django-json-widget/blob/master/django_json_widget/static/dist/jsoneditor.min.css)) or by custom code without intention, affecting some animations, like the saving animation.

Thanks for contributing to Wagtail! 🎉

Before submitting, please review the contributor guidelines <https://docs.wagtail.io/en/latest/contributing/index.html> and check the following:

* Do the tests still pass? (https://docs.wagtail.io/en/latest/contributing/developing.html#testing) yes
* Does the code comply with the style guide? (Run `make lint` from the Wagtail root) yes
* For Python changes: Have you added tests to cover the new/fixed behaviour? N/A
* For front-end changes: Did you test on all of [Wagtail’s supported environments](https://docs.wagtail.io/en/latest/contributing/developing.html#browser-and-device-support)?
    * **Please list the exact browser and operating system versions you tested**.
    * **Please list which assistive technologies you tested**.
* For new features: Has the documentation been updated accordingly? N/A
