### PR TITLE
Fix delete button color with no class (#7143)

### DIFF
--- a/client/scss/components/_listing.scss
+++ b/client/scss/components/_listing.scss
@@ -241,6 +241,12 @@ ul.listing {
         border-color: $color-grey-3;
         background: $color-white;
 
+        &.no:hover {
+            border-color: $color-button-no-hover;
+            background-color: $color-button-no-hover;
+            color: $color-white;
+        }
+
         &:hover {
             border-color: $color-teal;
             background-color: $color-teal;

--- a/wagtail/snippets/wagtail_hooks.py
+++ b/wagtail/snippets/wagtail_hooks.py
@@ -58,5 +58,6 @@ def register_snippet_listing_buttons(snippet, user, next_url=None):
             _('Delete'),
             reverse('wagtailsnippets:delete', args=[model._meta.app_label, model._meta.model_name, quote(snippet.pk)]),
             attrs={'aria-label': _("Delete '%(title)s'") % {'title': str(snippet)}},
-            priority=20
+            priority=20,
+            classes={'no'}
         )

--- a/wagtail/snippets/wagtail_hooks.py
+++ b/wagtail/snippets/wagtail_hooks.py
@@ -59,5 +59,5 @@ def register_snippet_listing_buttons(snippet, user, next_url=None):
             reverse('wagtailsnippets:delete', args=[model._meta.app_label, model._meta.model_name, quote(snippet.pk)]),
             attrs={'aria-label': _("Delete '%(title)s'") % {'title': str(snippet)}},
             priority=20,
-            classes={'no'}
+            classes=['no']
         )


### PR DESCRIPTION
This pull request is to fix bug #7143.  Building on #7184 from @mcmikashi . I added the no class to the delete button within the snippets list. This allows the delete button to have the proper color both when hovered and not.

