### PR TITLE
`select_related` collection on image listing

### DIFF
--- a/wagtail/images/views/images.py
+++ b/wagtail/images/views/images.py
@@ -43,7 +43,7 @@ class BaseListingView(TemplateView):
         # Get images (filtered by user permission)
         images = permission_policy.instances_user_has_any_permission_for(
             self.request.user, ['change', 'delete']
-        ).order_by('-created_at')
+        ).order_by('-created_at').select_related('collection')
 
         # Search
         query_string = None


### PR DESCRIPTION
`images/results.html` shows the collection if it's available, which results in `O(n)` queries.

Before: 70 queries
After: 50 queries

(20 being the page size, so definitely working)

Makes a minimal difference to performance (~200ms locally), but hey, every little helps!
