### PR TITLE
Refactor StreamField action buttons into their own objects

### DIFF
--- a/client/src/components/StreamField/blocks/BaseSequenceBlock.js
+++ b/client/src/components/StreamField/blocks/BaseSequenceBlock.js
@@ -22,6 +22,22 @@ class ActionButton {
 
   render(container) {
     $(container).append(this.dom);
+
+    if (this.enableEvent) {
+      this.sequenceChild.on(this.enableEvent, () => {
+        this.enable();
+      });
+    }
+
+    if (this.disableEvent) {
+      this.sequenceChild.on(this.disableEvent, () => {
+        this.disable();
+      });
+    }
+
+    if (this.initiallyDisabled) {
+      this.disable();
+    }
   }
 
   enable() {
@@ -33,17 +49,9 @@ class ActionButton {
 }
 
 class MoveUpButton extends ActionButton {
-  render(container) {
-    super.render(container);
-    this.disable();
-
-    this.sequenceChild.on('enableMoveUp', () => {
-      this.enable();
-    });
-    this.sequenceChild.on('disableMoveUp', () => {
-      this.disable();
-    });
-  }
+  enableEvent = 'enableMoveUp';
+  disableEvent = 'disableMoveUp';
+  initiallyDisabled = true;
 
   onClick() {
     this.sequenceChild.moveUp();
@@ -51,17 +59,9 @@ class MoveUpButton extends ActionButton {
 }
 
 class MoveDownButton extends ActionButton {
-  render(container) {
-    super.render(container);
-    this.disable();
-
-    this.sequenceChild.on('enableMoveDown', () => {
-      this.enable();
-    });
-    this.sequenceChild.on('disableMoveDown', () => {
-      this.disable();
-    });
-  }
+  enableEvent = 'enableMoveDown';
+  disableEvent = 'disableMoveDown';
+  initiallyDisabled = true;
 
   onClick() {
     this.sequenceChild.moveDown();
@@ -69,16 +69,8 @@ class MoveDownButton extends ActionButton {
 }
 
 class DuplicateButton extends ActionButton {
-  render(container) {
-    super.render(container);
-
-    this.sequenceChild.on('enableDuplication', () => {
-      this.enable();
-    });
-    this.sequenceChild.on('disableDuplication', () => {
-      this.disable();
-    });
-  }
+  enableEvent = 'enableDuplication';
+  disableEvent = 'disableDuplication';
 
   onClick() {
     this.sequenceChild.duplicate({ animate: true });

--- a/client/src/components/StreamField/blocks/BaseSequenceBlock.js
+++ b/client/src/components/StreamField/blocks/BaseSequenceBlock.js
@@ -6,11 +6,16 @@ import EventEmitter from 'events';
 import { escapeHtml as h } from '../../../utils/text';
 
 class ActionButton {
-  constructor(sequenceChild, iconName, label) {
+  constructor(sequenceChild) {
     this.sequenceChild = sequenceChild;
+  }
+
+  render(container) {
+    const label = this.sequenceChild.strings[this.labelIdentifier] || this.labelIdentifier;
+
     this.dom = $(`
       <button type="button" class="c-sf-block__actions__single" title="${h(label)}">
-        <i class="icon icon-${h(iconName)}" aria-hidden="true"></i>
+        <i class="icon icon-${h(this.icon)}" aria-hidden="true"></i>
       </button>
     `);
 
@@ -18,9 +23,7 @@ class ActionButton {
       if (this.onClick) this.onClick();
       return false;  // don't propagate to header's onclick event (which collapses the block)
     });
-  }
 
-  render(container) {
     $(container).append(this.dom);
 
     if (this.enableEvent) {
@@ -52,6 +55,8 @@ class MoveUpButton extends ActionButton {
   enableEvent = 'enableMoveUp';
   disableEvent = 'disableMoveUp';
   initiallyDisabled = true;
+  icon = 'arrow-up';
+  labelIdentifier = 'MOVE_UP';
 
   onClick() {
     this.sequenceChild.moveUp();
@@ -62,6 +67,8 @@ class MoveDownButton extends ActionButton {
   enableEvent = 'enableMoveDown';
   disableEvent = 'disableMoveDown';
   initiallyDisabled = true;
+  icon = 'arrow-down';
+  labelIdentifier = 'MOVE_DOWN';
 
   onClick() {
     this.sequenceChild.moveDown();
@@ -71,6 +78,8 @@ class MoveDownButton extends ActionButton {
 class DuplicateButton extends ActionButton {
   enableEvent = 'enableDuplication';
   disableEvent = 'disableDuplication';
+  icon = 'duplicate';
+  labelIdentifier = 'DUPLICATE';
 
   onClick() {
     this.sequenceChild.duplicate({ animate: true });
@@ -78,6 +87,9 @@ class DuplicateButton extends ActionButton {
 }
 
 class DeleteButton extends ActionButton {
+  icon = 'bin';
+  labelIdentifier = 'DELETE';
+
   onClick() {
     this.sequenceChild.delete({ animate: true });
   }
@@ -94,7 +106,7 @@ export class BaseSequenceChild extends EventEmitter {
 
     const animate = opts && opts.animate;
     this.collapsed = opts && opts.collapsed;
-    const strings = (opts && opts.strings) || {};
+    this.strings = (opts && opts.strings) || {};
 
     const dom = $(`
       <div aria-hidden="false" ${this.id ? `data-contentpath="${h(this.id)}"` : 'data-contentpath-disabled'}>
@@ -139,10 +151,10 @@ export class BaseSequenceChild extends EventEmitter {
       this.toggleCollapsedState();
     });
 
-    this.addActionButton(new MoveUpButton(this, 'arrow-up', strings.MOVE_UP));
-    this.addActionButton(new MoveDownButton(this, 'arrow-down', strings.MOVE_DOWN));
-    this.addActionButton(new DuplicateButton(this, 'duplicate', strings.DUPLICATE));
-    this.addActionButton(new DeleteButton(this, 'bin', strings.DELETE));
+    this.addActionButton(new MoveUpButton(this));
+    this.addActionButton(new MoveDownButton(this));
+    this.addActionButton(new DuplicateButton(this));
+    this.addActionButton(new DeleteButton(this));
 
     this.block = this.blockDef.render(blockElement, this.prefix + '-value', initialState);
 

--- a/client/src/components/StreamField/blocks/BaseSequenceBlock.js
+++ b/client/src/components/StreamField/blocks/BaseSequenceBlock.js
@@ -2,6 +2,7 @@
 
 /* global $ */
 
+import EventEmitter from 'events';
 import { escapeHtml as h } from '../../../utils/text';
 
 class ActionButton {
@@ -33,7 +34,7 @@ class ActionButton {
   }
 }
 
-export class BaseSequenceChild {
+export class BaseSequenceChild extends EventEmitter {
   constructor(blockDef, placeholder, prefix, index, id, initialState, sequence, opts) {
     this.blockDef = blockDef;
     this.type = blockDef.name;
@@ -89,27 +90,46 @@ export class BaseSequenceChild {
       this.toggleCollapsedState();
     });
 
-    this.moveUpButton = new ActionButton(actionsContainer, 'arrow-up', strings.MOVE_UP, {
+    const moveUpButton = new ActionButton(actionsContainer, 'arrow-up', strings.MOVE_UP, {
       disabled: true,
       onClick: () => {
         this.sequence.moveBlockUp(this.index);
       }
     });
+    this.on('enableMoveUp', () => {
+      moveUpButton.enable();
+    });
+    this.on('disableMoveUp', () => {
+      moveUpButton.disable();
+    });
 
-    this.moveDownButton = new ActionButton(actionsContainer, 'arrow-down', strings.MOVE_DOWN, {
+    const moveDownButton = new ActionButton(actionsContainer, 'arrow-down', strings.MOVE_DOWN, {
       disabled: true,
       onClick: () => {
         this.sequence.moveBlockDown(this.index);
       }
     });
+    this.on('enableMoveDown', () => {
+      moveDownButton.enable();
+    });
+    this.on('disableMoveDown', () => {
+      moveDownButton.disable();
+    });
 
-    this.duplicateButton = new ActionButton(actionsContainer, 'duplicate', strings.DUPLICATE, {
+    const duplicateButton = new ActionButton(actionsContainer, 'duplicate', strings.DUPLICATE, {
       onClick: () => {
         this.sequence.duplicateBlock(this.index, { animate: true });
       }
     });
+    this.on('enableDuplication', () => {
+      duplicateButton.enable();
+    });
+    this.on('disableDuplication', () => {
+      duplicateButton.disable();
+    });
 
-    this.deleteButton = new ActionButton(actionsContainer, 'bin', strings.DELETE, {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const deleteButton = new ActionButton(actionsContainer, 'bin', strings.DELETE, {
       onClick: () => {
         this.sequence.deleteBlock(this.index, { animate: true });
       }
@@ -148,22 +168,22 @@ export class BaseSequenceChild {
   }
 
   enableDuplication() {
-    this.duplicateButton.enable();
+    this.emit('enableDuplication');
   }
   disableDuplication() {
-    this.duplicateButton.disable();
+    this.emit('disableDuplication');
   }
   enableMoveUp() {
-    this.moveUpButton.enable();
+    this.emit('enableMoveUp');
   }
   disableMoveUp() {
-    this.moveUpButton.disable();
+    this.emit('disableMoveUp');
   }
   enableMoveDown() {
-    this.moveDownButton.enable();
+    this.emit('enableMoveDown');
   }
   disableMoveDown() {
-    this.moveDownButton.disable();
+    this.emit('disableMoveDown');
   }
 
   setIndex(newIndex) {

--- a/client/src/components/StreamField/blocks/ListBlock.js
+++ b/client/src/components/StreamField/blocks/ListBlock.js
@@ -104,8 +104,8 @@ export class ListBlock extends BaseSequenceBlock {
     return [blockDef, initialState];
   }
 
-  _createChild(blockDef, placeholder, prefix, index, id, initialState, opts) {
-    return new ListChild(blockDef, placeholder, prefix, index, id, initialState, opts);
+  _createChild(blockDef, placeholder, prefix, index, id, initialState, sequence, opts) {
+    return new ListChild(blockDef, placeholder, prefix, index, id, initialState, sequence, opts);
   }
 
   _createInsertionControl(placeholder, opts) {

--- a/client/src/components/StreamField/blocks/StreamBlock.js
+++ b/client/src/components/StreamField/blocks/StreamBlock.js
@@ -261,8 +261,8 @@ export class StreamBlock extends BaseSequenceBlock {
     }
   }
 
-  _createChild(blockDef, placeholder, prefix, index, id, initialState, opts) {
-    return new StreamChild(blockDef, placeholder, prefix, index, id, initialState, opts);
+  _createChild(blockDef, placeholder, prefix, index, id, initialState, sequence, opts) {
+    return new StreamChild(blockDef, placeholder, prefix, index, id, initialState, sequence, opts);
   }
 
   _createInsertionControl(placeholder, opts) {

--- a/client/src/components/StreamField/blocks/StreamBlock.test.js
+++ b/client/src/components/StreamField/blocks/StreamBlock.test.js
@@ -434,7 +434,7 @@ describe('telepath: wagtail.blocks.StreamBlock with maxNum set', () => {
   const assertCanAddBlock = () => {
     // Test duplicate button
     // querySelector always returns the first element it sees so this only checks the first block
-    expect(document.querySelector('button[data-duplicate-button]').getAttribute('disabled')).toBe(null);
+    expect(document.querySelector('button[title="Duplicate"]').getAttribute('disabled')).toBe(null);
 
     // Test menu
     expect(document.querySelector('button[data-streamblock-menu-open]').getAttribute('disabled')).toBe(null);
@@ -443,7 +443,7 @@ describe('telepath: wagtail.blocks.StreamBlock with maxNum set', () => {
   const assertCannotAddBlock = () => {
     // Test duplicate button
     // querySelector always returns the first element it sees so this only checks the first block
-    expect(document.querySelector('button[data-duplicate-button]').getAttribute('disabled')).toEqual('disabled');
+    expect(document.querySelector('button[title="Duplicate"]').getAttribute('disabled')).toEqual('disabled');
 
     // Test menu
     expect(document.querySelector('button[data-streamblock-menu-open]').getAttribute('disabled')).toEqual('disabled');
@@ -607,7 +607,7 @@ describe('telepath: wagtail.blocks.StreamBlock with blockCounts.max_num set', ()
   const assertCanAddBlock = () => {
     // Test duplicate button
     // querySelector always returns the first element it sees so this only checks the first block
-    expect(document.querySelector('button[data-duplicate-button]').getAttribute('disabled')).toBe(null);
+    expect(document.querySelector('button[title="Duplicate"]').getAttribute('disabled')).toBe(null);
 
     // Test menu item
     expect(document.querySelector('button.action-add-block-test_block_a').getAttribute('disabled')).toBe(null);
@@ -616,7 +616,7 @@ describe('telepath: wagtail.blocks.StreamBlock with blockCounts.max_num set', ()
   const assertCannotAddBlock = () => {
     // Test duplicate button
     // querySelector always returns the first element it sees so this only checks the first block
-    expect(document.querySelector('button[data-duplicate-button]').getAttribute('disabled')).toEqual('disabled');
+    expect(document.querySelector('button[title="Duplicate"]').getAttribute('disabled')).toEqual('disabled');
 
     // Test menu item
     expect(document.querySelector('button.action-add-block-test_block_a').getAttribute('disabled')).toEqual('disabled');

--- a/client/src/components/StreamField/blocks/__snapshots__/ListBlock.test.js.snap
+++ b/client/src/components/StreamField/blocks/__snapshots__/ListBlock.test.js.snap
@@ -25,21 +25,17 @@ exports[`telepath: wagtail.blocks.ListBlock blocks can be duplicated 1`] = `
                   <i class=\\"icon icon-pilcrow\\"></i>
                 </span>
                 <h3 data-block-title=\\"\\" class=\\"c-sf-block__header__title\\"></h3>
-                <div class=\\"c-sf-block__actions\\">
+                <div class=\\"c-sf-block__actions\\" data-block-actions=\\"\\">
                   <span class=\\"c-sf-block__type\\"></span>
-                  <button type=\\"button\\" data-move-up-button=\\"\\" class=\\"c-sf-block__actions__single\\" disabled=\\"\\" title=\\"Move up\\">
-                    <i class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-move-down-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Move down\\">
-                    <i class=\\"icon icon-arrow-down\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-duplicate-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Duplicate\\">
-                    <i class=\\"icon icon-duplicate\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-delete-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Delete\\">
-                    <i class=\\"icon icon-bin\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                </div>
+                <button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Move up\\" disabled=\\"disabled\\">
+        <i class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Move down\\">
+        <i class=\\"icon icon-arrow-down\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Duplicate\\">
+        <i class=\\"icon icon-duplicate\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Delete\\">
+        <i class=\\"icon icon-bin\\" aria-hidden=\\"true\\"></i>
+      </button></div>
               </div>
               <div data-block-content=\\"\\" class=\\"c-sf-block__content\\" aria-hidden=\\"false\\">
                 <div class=\\"c-sf-block__content-inner\\">
@@ -72,21 +68,17 @@ exports[`telepath: wagtail.blocks.ListBlock blocks can be duplicated 1`] = `
                   <i class=\\"icon icon-pilcrow\\"></i>
                 </span>
                 <h3 data-block-title=\\"\\" class=\\"c-sf-block__header__title\\"></h3>
-                <div class=\\"c-sf-block__actions\\">
+                <div class=\\"c-sf-block__actions\\" data-block-actions=\\"\\">
                   <span class=\\"c-sf-block__type\\"></span>
-                  <button type=\\"button\\" data-move-up-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Move up\\">
-                    <i class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-move-down-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Move down\\">
-                    <i class=\\"icon icon-arrow-down\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-duplicate-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Duplicate\\">
-                    <i class=\\"icon icon-duplicate\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-delete-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Delete\\">
-                    <i class=\\"icon icon-bin\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                </div>
+                <button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Move up\\">
+        <i class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Move down\\">
+        <i class=\\"icon icon-arrow-down\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Duplicate\\">
+        <i class=\\"icon icon-duplicate\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Delete\\">
+        <i class=\\"icon icon-bin\\" aria-hidden=\\"true\\"></i>
+      </button></div>
               </div>
               <div data-block-content=\\"\\" class=\\"c-sf-block__content\\" aria-hidden=\\"false\\">
                 <div class=\\"c-sf-block__content-inner\\">
@@ -119,21 +111,17 @@ exports[`telepath: wagtail.blocks.ListBlock blocks can be duplicated 1`] = `
                   <i class=\\"icon icon-pilcrow\\"></i>
                 </span>
                 <h3 data-block-title=\\"\\" class=\\"c-sf-block__header__title\\"></h3>
-                <div class=\\"c-sf-block__actions\\">
+                <div class=\\"c-sf-block__actions\\" data-block-actions=\\"\\">
                   <span class=\\"c-sf-block__type\\"></span>
-                  <button type=\\"button\\" data-move-up-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Move up\\">
-                    <i class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-move-down-button=\\"\\" class=\\"c-sf-block__actions__single\\" disabled=\\"\\" title=\\"Move down\\">
-                    <i class=\\"icon icon-arrow-down\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-duplicate-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Duplicate\\">
-                    <i class=\\"icon icon-duplicate\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-delete-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Delete\\">
-                    <i class=\\"icon icon-bin\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                </div>
+                <button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Move up\\">
+        <i class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Move down\\" disabled=\\"disabled\\">
+        <i class=\\"icon icon-arrow-down\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Duplicate\\">
+        <i class=\\"icon icon-duplicate\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Delete\\">
+        <i class=\\"icon icon-bin\\" aria-hidden=\\"true\\"></i>
+      </button></div>
               </div>
               <div data-block-content=\\"\\" class=\\"c-sf-block__content\\" aria-hidden=\\"false\\">
                 <div class=\\"c-sf-block__content-inner\\">
@@ -181,21 +169,17 @@ exports[`telepath: wagtail.blocks.ListBlock blocks can be reordered downward 1`]
                   <i class=\\"icon icon-pilcrow\\"></i>
                 </span>
                 <h3 data-block-title=\\"\\" class=\\"c-sf-block__header__title\\"></h3>
-                <div class=\\"c-sf-block__actions\\">
+                <div class=\\"c-sf-block__actions\\" data-block-actions=\\"\\">
                   <span class=\\"c-sf-block__type\\"></span>
-                  <button type=\\"button\\" data-move-up-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Move up\\" disabled=\\"disabled\\">
-                    <i class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-move-down-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Move down\\">
-                    <i class=\\"icon icon-arrow-down\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-duplicate-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Duplicate\\">
-                    <i class=\\"icon icon-duplicate\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-delete-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Delete\\">
-                    <i class=\\"icon icon-bin\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                </div>
+                <button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Move up\\" disabled=\\"disabled\\">
+        <i class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Move down\\">
+        <i class=\\"icon icon-arrow-down\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Duplicate\\">
+        <i class=\\"icon icon-duplicate\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Delete\\">
+        <i class=\\"icon icon-bin\\" aria-hidden=\\"true\\"></i>
+      </button></div>
               </div>
               <div data-block-content=\\"\\" class=\\"c-sf-block__content\\" aria-hidden=\\"false\\">
                 <div class=\\"c-sf-block__content-inner\\">
@@ -228,21 +212,17 @@ exports[`telepath: wagtail.blocks.ListBlock blocks can be reordered downward 1`]
                   <i class=\\"icon icon-pilcrow\\"></i>
                 </span>
                 <h3 data-block-title=\\"\\" class=\\"c-sf-block__header__title\\"></h3>
-                <div class=\\"c-sf-block__actions\\">
+                <div class=\\"c-sf-block__actions\\" data-block-actions=\\"\\">
                   <span class=\\"c-sf-block__type\\"></span>
-                  <button type=\\"button\\" data-move-up-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Move up\\">
-                    <i class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-move-down-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Move down\\" disabled=\\"disabled\\">
-                    <i class=\\"icon icon-arrow-down\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-duplicate-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Duplicate\\">
-                    <i class=\\"icon icon-duplicate\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-delete-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Delete\\">
-                    <i class=\\"icon icon-bin\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                </div>
+                <button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Move up\\">
+        <i class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Move down\\" disabled=\\"disabled\\">
+        <i class=\\"icon icon-arrow-down\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Duplicate\\">
+        <i class=\\"icon icon-duplicate\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Delete\\">
+        <i class=\\"icon icon-bin\\" aria-hidden=\\"true\\"></i>
+      </button></div>
               </div>
               <div data-block-content=\\"\\" class=\\"c-sf-block__content\\" aria-hidden=\\"false\\">
                 <div class=\\"c-sf-block__content-inner\\">
@@ -290,21 +270,17 @@ exports[`telepath: wagtail.blocks.ListBlock blocks can be reordered upward 1`] =
                   <i class=\\"icon icon-pilcrow\\"></i>
                 </span>
                 <h3 data-block-title=\\"\\" class=\\"c-sf-block__header__title\\"></h3>
-                <div class=\\"c-sf-block__actions\\">
+                <div class=\\"c-sf-block__actions\\" data-block-actions=\\"\\">
                   <span class=\\"c-sf-block__type\\"></span>
-                  <button type=\\"button\\" data-move-up-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Move up\\" disabled=\\"disabled\\">
-                    <i class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-move-down-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Move down\\">
-                    <i class=\\"icon icon-arrow-down\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-duplicate-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Duplicate\\">
-                    <i class=\\"icon icon-duplicate\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-delete-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Delete\\">
-                    <i class=\\"icon icon-bin\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                </div>
+                <button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Move up\\" disabled=\\"disabled\\">
+        <i class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Move down\\">
+        <i class=\\"icon icon-arrow-down\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Duplicate\\">
+        <i class=\\"icon icon-duplicate\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Delete\\">
+        <i class=\\"icon icon-bin\\" aria-hidden=\\"true\\"></i>
+      </button></div>
               </div>
               <div data-block-content=\\"\\" class=\\"c-sf-block__content\\" aria-hidden=\\"false\\">
                 <div class=\\"c-sf-block__content-inner\\">
@@ -337,21 +313,17 @@ exports[`telepath: wagtail.blocks.ListBlock blocks can be reordered upward 1`] =
                   <i class=\\"icon icon-pilcrow\\"></i>
                 </span>
                 <h3 data-block-title=\\"\\" class=\\"c-sf-block__header__title\\"></h3>
-                <div class=\\"c-sf-block__actions\\">
+                <div class=\\"c-sf-block__actions\\" data-block-actions=\\"\\">
                   <span class=\\"c-sf-block__type\\"></span>
-                  <button type=\\"button\\" data-move-up-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Move up\\">
-                    <i class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-move-down-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Move down\\" disabled=\\"disabled\\">
-                    <i class=\\"icon icon-arrow-down\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-duplicate-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Duplicate\\">
-                    <i class=\\"icon icon-duplicate\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-delete-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Delete\\">
-                    <i class=\\"icon icon-bin\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                </div>
+                <button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Move up\\">
+        <i class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Move down\\" disabled=\\"disabled\\">
+        <i class=\\"icon icon-arrow-down\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Duplicate\\">
+        <i class=\\"icon icon-duplicate\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Delete\\">
+        <i class=\\"icon icon-bin\\" aria-hidden=\\"true\\"></i>
+      </button></div>
               </div>
               <div data-block-content=\\"\\" class=\\"c-sf-block__content\\" aria-hidden=\\"false\\">
                 <div class=\\"c-sf-block__content-inner\\">
@@ -399,21 +371,17 @@ exports[`telepath: wagtail.blocks.ListBlock deleteBlock() deletes a block 1`] = 
                   <i class=\\"icon icon-pilcrow\\"></i>
                 </span>
                 <h3 data-block-title=\\"\\" class=\\"c-sf-block__header__title\\"></h3>
-                <div class=\\"c-sf-block__actions\\">
+                <div class=\\"c-sf-block__actions\\" data-block-actions=\\"\\">
                   <span class=\\"c-sf-block__type\\"></span>
-                  <button type=\\"button\\" data-move-up-button=\\"\\" class=\\"c-sf-block__actions__single\\" disabled=\\"\\" title=\\"Move up\\">
-                    <i class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-move-down-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Move down\\" disabled=\\"disabled\\">
-                    <i class=\\"icon icon-arrow-down\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-duplicate-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Duplicate\\">
-                    <i class=\\"icon icon-duplicate\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-delete-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Delete\\">
-                    <i class=\\"icon icon-bin\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                </div>
+                <button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Move up\\" disabled=\\"disabled\\">
+        <i class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Move down\\" disabled=\\"disabled\\">
+        <i class=\\"icon icon-arrow-down\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Duplicate\\">
+        <i class=\\"icon icon-duplicate\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Delete\\">
+        <i class=\\"icon icon-bin\\" aria-hidden=\\"true\\"></i>
+      </button></div>
               </div>
               <div data-block-content=\\"\\" class=\\"c-sf-block__content\\" aria-hidden=\\"false\\">
                 <div class=\\"c-sf-block__content-inner\\">
@@ -446,21 +414,17 @@ exports[`telepath: wagtail.blocks.ListBlock deleteBlock() deletes a block 1`] = 
                   <i class=\\"icon icon-pilcrow\\"></i>
                 </span>
                 <h3 data-block-title=\\"\\" class=\\"c-sf-block__header__title\\"></h3>
-                <div class=\\"c-sf-block__actions\\">
+                <div class=\\"c-sf-block__actions\\" data-block-actions=\\"\\">
                   <span class=\\"c-sf-block__type\\"></span>
-                  <button type=\\"button\\" data-move-up-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Move up\\">
-                    <i class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-move-down-button=\\"\\" class=\\"c-sf-block__actions__single\\" disabled=\\"\\" title=\\"Move down\\">
-                    <i class=\\"icon icon-arrow-down\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-duplicate-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Duplicate\\">
-                    <i class=\\"icon icon-duplicate\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-delete-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Delete\\">
-                    <i class=\\"icon icon-bin\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                </div>
+                <button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Move up\\">
+        <i class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Move down\\" disabled=\\"disabled\\">
+        <i class=\\"icon icon-arrow-down\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Duplicate\\">
+        <i class=\\"icon icon-duplicate\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Delete\\">
+        <i class=\\"icon icon-bin\\" aria-hidden=\\"true\\"></i>
+      </button></div>
               </div>
               <div data-block-content=\\"\\" class=\\"c-sf-block__content\\" aria-hidden=\\"false\\">
                 <div class=\\"c-sf-block__content-inner\\">
@@ -508,21 +472,17 @@ exports[`telepath: wagtail.blocks.ListBlock it renders correctly 1`] = `
                   <i class=\\"icon icon-pilcrow\\"></i>
                 </span>
                 <h3 data-block-title=\\"\\" class=\\"c-sf-block__header__title\\"></h3>
-                <div class=\\"c-sf-block__actions\\">
+                <div class=\\"c-sf-block__actions\\" data-block-actions=\\"\\">
                   <span class=\\"c-sf-block__type\\"></span>
-                  <button type=\\"button\\" data-move-up-button=\\"\\" class=\\"c-sf-block__actions__single\\" disabled=\\"\\" title=\\"Move up\\">
-                    <i class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-move-down-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Move down\\">
-                    <i class=\\"icon icon-arrow-down\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-duplicate-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Duplicate\\">
-                    <i class=\\"icon icon-duplicate\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-delete-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Delete\\">
-                    <i class=\\"icon icon-bin\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                </div>
+                <button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Move up\\" disabled=\\"disabled\\">
+        <i class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Move down\\">
+        <i class=\\"icon icon-arrow-down\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Duplicate\\">
+        <i class=\\"icon icon-duplicate\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Delete\\">
+        <i class=\\"icon icon-bin\\" aria-hidden=\\"true\\"></i>
+      </button></div>
               </div>
               <div data-block-content=\\"\\" class=\\"c-sf-block__content\\" aria-hidden=\\"false\\">
                 <div class=\\"c-sf-block__content-inner\\">
@@ -555,21 +515,17 @@ exports[`telepath: wagtail.blocks.ListBlock it renders correctly 1`] = `
                   <i class=\\"icon icon-pilcrow\\"></i>
                 </span>
                 <h3 data-block-title=\\"\\" class=\\"c-sf-block__header__title\\"></h3>
-                <div class=\\"c-sf-block__actions\\">
+                <div class=\\"c-sf-block__actions\\" data-block-actions=\\"\\">
                   <span class=\\"c-sf-block__type\\"></span>
-                  <button type=\\"button\\" data-move-up-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Move up\\">
-                    <i class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-move-down-button=\\"\\" class=\\"c-sf-block__actions__single\\" disabled=\\"\\" title=\\"Move down\\">
-                    <i class=\\"icon icon-arrow-down\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-duplicate-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Duplicate\\">
-                    <i class=\\"icon icon-duplicate\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-delete-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Delete\\">
-                    <i class=\\"icon icon-bin\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                </div>
+                <button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Move up\\">
+        <i class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Move down\\" disabled=\\"disabled\\">
+        <i class=\\"icon icon-arrow-down\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Duplicate\\">
+        <i class=\\"icon icon-duplicate\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Delete\\">
+        <i class=\\"icon icon-bin\\" aria-hidden=\\"true\\"></i>
+      </button></div>
               </div>
               <div data-block-content=\\"\\" class=\\"c-sf-block__content\\" aria-hidden=\\"false\\">
                 <div class=\\"c-sf-block__content-inner\\">
@@ -617,21 +573,17 @@ exports[`telepath: wagtail.blocks.ListBlock setError passes error messages to ch
                   <i class=\\"icon icon-pilcrow\\"></i>
                 </span>
                 <h3 data-block-title=\\"\\" class=\\"c-sf-block__header__title\\"></h3>
-                <div class=\\"c-sf-block__actions\\">
+                <div class=\\"c-sf-block__actions\\" data-block-actions=\\"\\">
                   <span class=\\"c-sf-block__type\\"></span>
-                  <button type=\\"button\\" data-move-up-button=\\"\\" class=\\"c-sf-block__actions__single\\" disabled=\\"\\" title=\\"Move up\\">
-                    <i class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-move-down-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Move down\\">
-                    <i class=\\"icon icon-arrow-down\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-duplicate-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Duplicate\\">
-                    <i class=\\"icon icon-duplicate\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-delete-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Delete\\">
-                    <i class=\\"icon icon-bin\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                </div>
+                <button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Move up\\" disabled=\\"disabled\\">
+        <i class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Move down\\">
+        <i class=\\"icon icon-arrow-down\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Duplicate\\">
+        <i class=\\"icon icon-duplicate\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Delete\\">
+        <i class=\\"icon icon-bin\\" aria-hidden=\\"true\\"></i>
+      </button></div>
               </div>
               <div data-block-content=\\"\\" class=\\"c-sf-block__content\\" aria-hidden=\\"false\\">
                 <div class=\\"c-sf-block__content-inner\\">
@@ -664,21 +616,17 @@ exports[`telepath: wagtail.blocks.ListBlock setError passes error messages to ch
                   <i class=\\"icon icon-pilcrow\\"></i>
                 </span>
                 <h3 data-block-title=\\"\\" class=\\"c-sf-block__header__title\\"></h3>
-                <div class=\\"c-sf-block__actions\\">
+                <div class=\\"c-sf-block__actions\\" data-block-actions=\\"\\">
                   <span class=\\"c-sf-block__type\\"></span>
-                  <button type=\\"button\\" data-move-up-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Move up\\">
-                    <i class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-move-down-button=\\"\\" class=\\"c-sf-block__actions__single\\" disabled=\\"\\" title=\\"Move down\\">
-                    <i class=\\"icon icon-arrow-down\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-duplicate-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Duplicate\\">
-                    <i class=\\"icon icon-duplicate\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-delete-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Delete\\">
-                    <i class=\\"icon icon-bin\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                </div>
+                <button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Move up\\">
+        <i class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Move down\\" disabled=\\"disabled\\">
+        <i class=\\"icon icon-arrow-down\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Duplicate\\">
+        <i class=\\"icon icon-duplicate\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Delete\\">
+        <i class=\\"icon icon-bin\\" aria-hidden=\\"true\\"></i>
+      </button></div>
               </div>
               <div data-block-content=\\"\\" class=\\"c-sf-block__content\\" aria-hidden=\\"false\\">
                 <div class=\\"c-sf-block__content-inner\\">

--- a/client/src/components/StreamField/blocks/__snapshots__/StreamBlock.test.js.snap
+++ b/client/src/components/StreamField/blocks/__snapshots__/StreamBlock.test.js.snap
@@ -29,21 +29,17 @@ exports[`telepath: wagtail.blocks.StreamBlock blocks can be duplicated 1`] = `
                   <i class=\\"icon icon-placeholder\\"></i>
                 </span>
                 <h3 data-block-title=\\"\\" class=\\"c-sf-block__header__title\\"></h3>
-                <div class=\\"c-sf-block__actions\\">
+                <div class=\\"c-sf-block__actions\\" data-block-actions=\\"\\">
                   <span class=\\"c-sf-block__type\\">Test Block A</span>
-                  <button type=\\"button\\" data-move-up-button=\\"\\" class=\\"c-sf-block__actions__single\\" disabled=\\"\\" title=\\"Move up\\">
-                    <i class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-move-down-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Move down\\">
-                    <i class=\\"icon icon-arrow-down\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-duplicate-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Duplicate\\">
-                    <i class=\\"icon icon-duplicate\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-delete-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Delete\\">
-                    <i class=\\"icon icon-bin\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                </div>
+                <button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Move up\\" disabled=\\"disabled\\">
+        <i class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Move down\\">
+        <i class=\\"icon icon-arrow-down\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Duplicate\\">
+        <i class=\\"icon icon-duplicate\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Delete\\">
+        <i class=\\"icon icon-bin\\" aria-hidden=\\"true\\"></i>
+      </button></div>
               </div>
               <div data-block-content=\\"\\" class=\\"c-sf-block__content\\" aria-hidden=\\"false\\">
                 <div class=\\"c-sf-block__content-inner\\">
@@ -81,21 +77,17 @@ exports[`telepath: wagtail.blocks.StreamBlock blocks can be duplicated 1`] = `
                   <i class=\\"icon icon-pilcrow\\"></i>
                 </span>
                 <h3 data-block-title=\\"\\" class=\\"c-sf-block__header__title\\"></h3>
-                <div class=\\"c-sf-block__actions\\">
+                <div class=\\"c-sf-block__actions\\" data-block-actions=\\"\\">
                   <span class=\\"c-sf-block__type\\">Test Block B</span>
-                  <button type=\\"button\\" data-move-up-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Move up\\">
-                    <i class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-move-down-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Move down\\">
-                    <i class=\\"icon icon-arrow-down\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-duplicate-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Duplicate\\">
-                    <i class=\\"icon icon-duplicate\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-delete-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Delete\\">
-                    <i class=\\"icon icon-bin\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                </div>
+                <button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Move up\\">
+        <i class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Move down\\">
+        <i class=\\"icon icon-arrow-down\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Duplicate\\">
+        <i class=\\"icon icon-duplicate\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Delete\\">
+        <i class=\\"icon icon-bin\\" aria-hidden=\\"true\\"></i>
+      </button></div>
               </div>
               <div data-block-content=\\"\\" class=\\"c-sf-block__content\\" aria-hidden=\\"false\\">
                 <div class=\\"c-sf-block__content-inner\\">
@@ -133,21 +125,17 @@ exports[`telepath: wagtail.blocks.StreamBlock blocks can be duplicated 1`] = `
                   <i class=\\"icon icon-pilcrow\\"></i>
                 </span>
                 <h3 data-block-title=\\"\\" class=\\"c-sf-block__header__title\\"></h3>
-                <div class=\\"c-sf-block__actions\\">
+                <div class=\\"c-sf-block__actions\\" data-block-actions=\\"\\">
                   <span class=\\"c-sf-block__type\\">Test Block B</span>
-                  <button type=\\"button\\" data-move-up-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Move up\\">
-                    <i class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-move-down-button=\\"\\" class=\\"c-sf-block__actions__single\\" disabled=\\"\\" title=\\"Move down\\">
-                    <i class=\\"icon icon-arrow-down\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-duplicate-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Duplicate\\">
-                    <i class=\\"icon icon-duplicate\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-delete-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Delete\\">
-                    <i class=\\"icon icon-bin\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                </div>
+                <button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Move up\\">
+        <i class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Move down\\" disabled=\\"disabled\\">
+        <i class=\\"icon icon-arrow-down\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Duplicate\\">
+        <i class=\\"icon icon-duplicate\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Delete\\">
+        <i class=\\"icon icon-bin\\" aria-hidden=\\"true\\"></i>
+      </button></div>
               </div>
               <div data-block-content=\\"\\" class=\\"c-sf-block__content\\" aria-hidden=\\"false\\">
                 <div class=\\"c-sf-block__content-inner\\">
@@ -204,21 +192,17 @@ exports[`telepath: wagtail.blocks.StreamBlock blocks can be reordered downward 1
                   <i class=\\"icon icon-pilcrow\\"></i>
                 </span>
                 <h3 data-block-title=\\"\\" class=\\"c-sf-block__header__title\\"></h3>
-                <div class=\\"c-sf-block__actions\\">
+                <div class=\\"c-sf-block__actions\\" data-block-actions=\\"\\">
                   <span class=\\"c-sf-block__type\\">Test Block B</span>
-                  <button type=\\"button\\" data-move-up-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Move up\\" disabled=\\"disabled\\">
-                    <i class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-move-down-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Move down\\">
-                    <i class=\\"icon icon-arrow-down\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-duplicate-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Duplicate\\">
-                    <i class=\\"icon icon-duplicate\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-delete-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Delete\\">
-                    <i class=\\"icon icon-bin\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                </div>
+                <button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Move up\\" disabled=\\"disabled\\">
+        <i class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Move down\\">
+        <i class=\\"icon icon-arrow-down\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Duplicate\\">
+        <i class=\\"icon icon-duplicate\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Delete\\">
+        <i class=\\"icon icon-bin\\" aria-hidden=\\"true\\"></i>
+      </button></div>
               </div>
               <div data-block-content=\\"\\" class=\\"c-sf-block__content\\" aria-hidden=\\"false\\">
                 <div class=\\"c-sf-block__content-inner\\">
@@ -256,21 +240,17 @@ exports[`telepath: wagtail.blocks.StreamBlock blocks can be reordered downward 1
                   <i class=\\"icon icon-placeholder\\"></i>
                 </span>
                 <h3 data-block-title=\\"\\" class=\\"c-sf-block__header__title\\"></h3>
-                <div class=\\"c-sf-block__actions\\">
+                <div class=\\"c-sf-block__actions\\" data-block-actions=\\"\\">
                   <span class=\\"c-sf-block__type\\">Test Block A</span>
-                  <button type=\\"button\\" data-move-up-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Move up\\">
-                    <i class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-move-down-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Move down\\" disabled=\\"disabled\\">
-                    <i class=\\"icon icon-arrow-down\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-duplicate-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Duplicate\\">
-                    <i class=\\"icon icon-duplicate\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-delete-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Delete\\">
-                    <i class=\\"icon icon-bin\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                </div>
+                <button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Move up\\">
+        <i class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Move down\\" disabled=\\"disabled\\">
+        <i class=\\"icon icon-arrow-down\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Duplicate\\">
+        <i class=\\"icon icon-duplicate\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Delete\\">
+        <i class=\\"icon icon-bin\\" aria-hidden=\\"true\\"></i>
+      </button></div>
               </div>
               <div data-block-content=\\"\\" class=\\"c-sf-block__content\\" aria-hidden=\\"false\\">
                 <div class=\\"c-sf-block__content-inner\\">
@@ -327,21 +307,17 @@ exports[`telepath: wagtail.blocks.StreamBlock blocks can be reordered upward 1`]
                   <i class=\\"icon icon-pilcrow\\"></i>
                 </span>
                 <h3 data-block-title=\\"\\" class=\\"c-sf-block__header__title\\"></h3>
-                <div class=\\"c-sf-block__actions\\">
+                <div class=\\"c-sf-block__actions\\" data-block-actions=\\"\\">
                   <span class=\\"c-sf-block__type\\">Test Block B</span>
-                  <button type=\\"button\\" data-move-up-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Move up\\" disabled=\\"disabled\\">
-                    <i class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-move-down-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Move down\\">
-                    <i class=\\"icon icon-arrow-down\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-duplicate-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Duplicate\\">
-                    <i class=\\"icon icon-duplicate\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-delete-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Delete\\">
-                    <i class=\\"icon icon-bin\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                </div>
+                <button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Move up\\" disabled=\\"disabled\\">
+        <i class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Move down\\">
+        <i class=\\"icon icon-arrow-down\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Duplicate\\">
+        <i class=\\"icon icon-duplicate\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Delete\\">
+        <i class=\\"icon icon-bin\\" aria-hidden=\\"true\\"></i>
+      </button></div>
               </div>
               <div data-block-content=\\"\\" class=\\"c-sf-block__content\\" aria-hidden=\\"false\\">
                 <div class=\\"c-sf-block__content-inner\\">
@@ -379,21 +355,17 @@ exports[`telepath: wagtail.blocks.StreamBlock blocks can be reordered upward 1`]
                   <i class=\\"icon icon-placeholder\\"></i>
                 </span>
                 <h3 data-block-title=\\"\\" class=\\"c-sf-block__header__title\\"></h3>
-                <div class=\\"c-sf-block__actions\\">
+                <div class=\\"c-sf-block__actions\\" data-block-actions=\\"\\">
                   <span class=\\"c-sf-block__type\\">Test Block A</span>
-                  <button type=\\"button\\" data-move-up-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Move up\\">
-                    <i class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-move-down-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Move down\\" disabled=\\"disabled\\">
-                    <i class=\\"icon icon-arrow-down\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-duplicate-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Duplicate\\">
-                    <i class=\\"icon icon-duplicate\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-delete-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Delete\\">
-                    <i class=\\"icon icon-bin\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                </div>
+                <button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Move up\\">
+        <i class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Move down\\" disabled=\\"disabled\\">
+        <i class=\\"icon icon-arrow-down\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Duplicate\\">
+        <i class=\\"icon icon-duplicate\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Delete\\">
+        <i class=\\"icon icon-bin\\" aria-hidden=\\"true\\"></i>
+      </button></div>
               </div>
               <div data-block-content=\\"\\" class=\\"c-sf-block__content\\" aria-hidden=\\"false\\">
                 <div class=\\"c-sf-block__content-inner\\">
@@ -450,21 +422,17 @@ exports[`telepath: wagtail.blocks.StreamBlock it renders correctly 1`] = `
                   <i class=\\"icon icon-placeholder\\"></i>
                 </span>
                 <h3 data-block-title=\\"\\" class=\\"c-sf-block__header__title\\"></h3>
-                <div class=\\"c-sf-block__actions\\">
+                <div class=\\"c-sf-block__actions\\" data-block-actions=\\"\\">
                   <span class=\\"c-sf-block__type\\">Test Block A</span>
-                  <button type=\\"button\\" data-move-up-button=\\"\\" class=\\"c-sf-block__actions__single\\" disabled=\\"\\" title=\\"Move up\\">
-                    <i class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-move-down-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Move down\\">
-                    <i class=\\"icon icon-arrow-down\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-duplicate-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Duplicate\\">
-                    <i class=\\"icon icon-duplicate\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-delete-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Delete\\">
-                    <i class=\\"icon icon-bin\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                </div>
+                <button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Move up\\" disabled=\\"disabled\\">
+        <i class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Move down\\">
+        <i class=\\"icon icon-arrow-down\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Duplicate\\">
+        <i class=\\"icon icon-duplicate\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Delete\\">
+        <i class=\\"icon icon-bin\\" aria-hidden=\\"true\\"></i>
+      </button></div>
               </div>
               <div data-block-content=\\"\\" class=\\"c-sf-block__content\\" aria-hidden=\\"false\\">
                 <div class=\\"c-sf-block__content-inner\\">
@@ -502,21 +470,17 @@ exports[`telepath: wagtail.blocks.StreamBlock it renders correctly 1`] = `
                   <i class=\\"icon icon-pilcrow\\"></i>
                 </span>
                 <h3 data-block-title=\\"\\" class=\\"c-sf-block__header__title\\"></h3>
-                <div class=\\"c-sf-block__actions\\">
+                <div class=\\"c-sf-block__actions\\" data-block-actions=\\"\\">
                   <span class=\\"c-sf-block__type\\">Test Block B</span>
-                  <button type=\\"button\\" data-move-up-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Move up\\">
-                    <i class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-move-down-button=\\"\\" class=\\"c-sf-block__actions__single\\" disabled=\\"\\" title=\\"Move down\\">
-                    <i class=\\"icon icon-arrow-down\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-duplicate-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Duplicate\\">
-                    <i class=\\"icon icon-duplicate\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-delete-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Delete\\">
-                    <i class=\\"icon icon-bin\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                </div>
+                <button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Move up\\">
+        <i class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Move down\\" disabled=\\"disabled\\">
+        <i class=\\"icon icon-arrow-down\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Duplicate\\">
+        <i class=\\"icon icon-duplicate\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Delete\\">
+        <i class=\\"icon icon-bin\\" aria-hidden=\\"true\\"></i>
+      </button></div>
               </div>
               <div data-block-content=\\"\\" class=\\"c-sf-block__content\\" aria-hidden=\\"false\\">
                 <div class=\\"c-sf-block__content-inner\\">
@@ -573,21 +537,17 @@ exports[`telepath: wagtail.blocks.StreamBlock it renders menus on opening 1`] = 
                   <i class=\\"icon icon-placeholder\\"></i>
                 </span>
                 <h3 data-block-title=\\"\\" class=\\"c-sf-block__header__title\\"></h3>
-                <div class=\\"c-sf-block__actions\\">
+                <div class=\\"c-sf-block__actions\\" data-block-actions=\\"\\">
                   <span class=\\"c-sf-block__type\\">Test Block A</span>
-                  <button type=\\"button\\" data-move-up-button=\\"\\" class=\\"c-sf-block__actions__single\\" disabled=\\"\\" title=\\"Move up\\">
-                    <i class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-move-down-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Move down\\">
-                    <i class=\\"icon icon-arrow-down\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-duplicate-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Duplicate\\">
-                    <i class=\\"icon icon-duplicate\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-delete-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Delete\\">
-                    <i class=\\"icon icon-bin\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                </div>
+                <button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Move up\\" disabled=\\"disabled\\">
+        <i class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Move down\\">
+        <i class=\\"icon icon-arrow-down\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Duplicate\\">
+        <i class=\\"icon icon-duplicate\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Delete\\">
+        <i class=\\"icon icon-bin\\" aria-hidden=\\"true\\"></i>
+      </button></div>
               </div>
               <div data-block-content=\\"\\" class=\\"c-sf-block__content\\" aria-hidden=\\"false\\">
                 <div class=\\"c-sf-block__content-inner\\">
@@ -635,21 +595,17 @@ exports[`telepath: wagtail.blocks.StreamBlock it renders menus on opening 1`] = 
                   <i class=\\"icon icon-pilcrow\\"></i>
                 </span>
                 <h3 data-block-title=\\"\\" class=\\"c-sf-block__header__title\\"></h3>
-                <div class=\\"c-sf-block__actions\\">
+                <div class=\\"c-sf-block__actions\\" data-block-actions=\\"\\">
                   <span class=\\"c-sf-block__type\\">Test Block B</span>
-                  <button type=\\"button\\" data-move-up-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Move up\\">
-                    <i class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-move-down-button=\\"\\" class=\\"c-sf-block__actions__single\\" disabled=\\"\\" title=\\"Move down\\">
-                    <i class=\\"icon icon-arrow-down\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-duplicate-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Duplicate\\">
-                    <i class=\\"icon icon-duplicate\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-delete-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Delete\\">
-                    <i class=\\"icon icon-bin\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                </div>
+                <button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Move up\\">
+        <i class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Move down\\" disabled=\\"disabled\\">
+        <i class=\\"icon icon-arrow-down\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Duplicate\\">
+        <i class=\\"icon icon-duplicate\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Delete\\">
+        <i class=\\"icon icon-bin\\" aria-hidden=\\"true\\"></i>
+      </button></div>
               </div>
               <div data-block-content=\\"\\" class=\\"c-sf-block__content\\" aria-hidden=\\"false\\">
                 <div class=\\"c-sf-block__content-inner\\">
@@ -706,21 +662,17 @@ exports[`telepath: wagtail.blocks.StreamBlock setError renders error messages 1`
                   <i class=\\"icon icon-placeholder\\"></i>
                 </span>
                 <h3 data-block-title=\\"\\" class=\\"c-sf-block__header__title\\"></h3>
-                <div class=\\"c-sf-block__actions\\">
+                <div class=\\"c-sf-block__actions\\" data-block-actions=\\"\\">
                   <span class=\\"c-sf-block__type\\">Test Block A</span>
-                  <button type=\\"button\\" data-move-up-button=\\"\\" class=\\"c-sf-block__actions__single\\" disabled=\\"\\" title=\\"Move up\\">
-                    <i class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-move-down-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Move down\\">
-                    <i class=\\"icon icon-arrow-down\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-duplicate-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Duplicate\\">
-                    <i class=\\"icon icon-duplicate\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-delete-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Delete\\">
-                    <i class=\\"icon icon-bin\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                </div>
+                <button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Move up\\" disabled=\\"disabled\\">
+        <i class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Move down\\">
+        <i class=\\"icon icon-arrow-down\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Duplicate\\">
+        <i class=\\"icon icon-duplicate\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Delete\\">
+        <i class=\\"icon icon-bin\\" aria-hidden=\\"true\\"></i>
+      </button></div>
               </div>
               <div data-block-content=\\"\\" class=\\"c-sf-block__content\\" aria-hidden=\\"false\\">
                 <div class=\\"c-sf-block__content-inner\\">
@@ -758,21 +710,17 @@ exports[`telepath: wagtail.blocks.StreamBlock setError renders error messages 1`
                   <i class=\\"icon icon-pilcrow\\"></i>
                 </span>
                 <h3 data-block-title=\\"\\" class=\\"c-sf-block__header__title\\"></h3>
-                <div class=\\"c-sf-block__actions\\">
+                <div class=\\"c-sf-block__actions\\" data-block-actions=\\"\\">
                   <span class=\\"c-sf-block__type\\">Test Block B</span>
-                  <button type=\\"button\\" data-move-up-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Move up\\">
-                    <i class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-move-down-button=\\"\\" class=\\"c-sf-block__actions__single\\" disabled=\\"\\" title=\\"Move down\\">
-                    <i class=\\"icon icon-arrow-down\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-duplicate-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Duplicate\\">
-                    <i class=\\"icon icon-duplicate\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-delete-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Delete\\">
-                    <i class=\\"icon icon-bin\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                </div>
+                <button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Move up\\">
+        <i class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Move down\\" disabled=\\"disabled\\">
+        <i class=\\"icon icon-arrow-down\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Duplicate\\">
+        <i class=\\"icon icon-duplicate\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Delete\\">
+        <i class=\\"icon icon-bin\\" aria-hidden=\\"true\\"></i>
+      </button></div>
               </div>
               <div data-block-content=\\"\\" class=\\"c-sf-block__content\\" aria-hidden=\\"false\\">
                 <div class=\\"c-sf-block__content-inner\\">
@@ -839,21 +787,17 @@ exports[`telepath: wagtail.blocks.StreamBlock with labels that need escaping it 
                   <i class=\\"icon icon-placeholder\\"></i>
                 </span>
                 <h3 data-block-title=\\"\\" class=\\"c-sf-block__header__title\\"></h3>
-                <div class=\\"c-sf-block__actions\\">
+                <div class=\\"c-sf-block__actions\\" data-block-actions=\\"\\">
                   <span class=\\"c-sf-block__type\\">Test Block &lt;A&gt;</span>
-                  <button type=\\"button\\" data-move-up-button=\\"\\" class=\\"c-sf-block__actions__single\\" disabled=\\"\\" title=\\"Move up\\">
-                    <i class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-move-down-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Move down\\">
-                    <i class=\\"icon icon-arrow-down\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-duplicate-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Duplicate\\">
-                    <i class=\\"icon icon-duplicate\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-delete-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Delete &amp; kill with fire\\">
-                    <i class=\\"icon icon-bin\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                </div>
+                <button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Move up\\" disabled=\\"disabled\\">
+        <i class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Move down\\">
+        <i class=\\"icon icon-arrow-down\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Duplicate\\">
+        <i class=\\"icon icon-duplicate\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Delete &amp; kill with fire\\">
+        <i class=\\"icon icon-bin\\" aria-hidden=\\"true\\"></i>
+      </button></div>
               </div>
               <div data-block-content=\\"\\" class=\\"c-sf-block__content\\" aria-hidden=\\"false\\">
                 <div class=\\"c-sf-block__content-inner\\">
@@ -891,21 +835,17 @@ exports[`telepath: wagtail.blocks.StreamBlock with labels that need escaping it 
                   <i class=\\"icon icon-pilcrow\\"></i>
                 </span>
                 <h3 data-block-title=\\"\\" class=\\"c-sf-block__header__title\\"></h3>
-                <div class=\\"c-sf-block__actions\\">
+                <div class=\\"c-sf-block__actions\\" data-block-actions=\\"\\">
                   <span class=\\"c-sf-block__type\\">Test Block &lt;B&gt;</span>
-                  <button type=\\"button\\" data-move-up-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Move up\\">
-                    <i class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-move-down-button=\\"\\" class=\\"c-sf-block__actions__single\\" disabled=\\"\\" title=\\"Move down\\">
-                    <i class=\\"icon icon-arrow-down\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-duplicate-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Duplicate\\">
-                    <i class=\\"icon icon-duplicate\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                  <button type=\\"button\\" data-delete-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Delete &amp; kill with fire\\">
-                    <i class=\\"icon icon-bin\\" aria-hidden=\\"true\\"></i>
-                  </button>
-                </div>
+                <button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Move up\\">
+        <i class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Move down\\" disabled=\\"disabled\\">
+        <i class=\\"icon icon-arrow-down\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Duplicate\\">
+        <i class=\\"icon icon-duplicate\\" aria-hidden=\\"true\\"></i>
+      </button><button type=\\"button\\" class=\\"c-sf-block__actions__single\\" title=\\"Delete &amp; kill with fire\\">
+        <i class=\\"icon icon-bin\\" aria-hidden=\\"true\\"></i>
+      </button></div>
               </div>
               <div data-block-content=\\"\\" class=\\"c-sf-block__content\\" aria-hidden=\\"false\\">
                 <div class=\\"c-sf-block__content-inner\\">


### PR DESCRIPTION
Refactor the implementations of the move-up / move-down / duplicate / delete buttons on StreamBlock / ListBlock children so that they exist as distinct objects, rather than being hard-coded in BaseSequenceChild. This will potentially make it possible for external code to define additional action buttons (although I've not yet decided on the neatest way to expose this as an external API - a global `window.wagtailStreamField.ACTION_BUTTONS` array that third-party code can append to perhaps?)