### PR TITLE
Reduce page history queries

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/pages/history.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/history.html
@@ -40,7 +40,7 @@
                                 {% if entry.action == 'wagtail.publish' %}
                                     {% if entry.revision == page.live_revision %}<span class="status-tag primary">{% trans 'Live version' %}</span>{% endif %}
                                 {% elif entry.content_changed %}
-                                    {% if entry.revision == page.get_latest_revision %}<span class="status-tag primary">{% trans 'Current draft' %}</span>{% endif %}
+                                    {% if entry.revision == page_latest_revision %}<span class="status-tag primary">{% trans 'Current draft' %}</span>{% endif %}
                                     {% include "wagtailadmin/pages/revisions/_actions.html" with revision=entry.revision %}
                                 {% endif %}
                             {% endif %}

--- a/wagtail/admin/templates/wagtailadmin/pages/history.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/history.html
@@ -38,7 +38,7 @@
                             {% endwith %}
                             {% if entry.revision %}
                                 {% if entry.action == 'wagtail.publish' %}
-                                    {% if entry.revision == page.live_revision %}<span class="status-tag primary">{% trans 'Live version' %}</span>{% endif %}
+                                    {% if entry.revision_id == page.live_revision_id %}<span class="status-tag primary">{% trans 'Live version' %}</span>{% endif %}
                                 {% elif entry.content_changed %}
                                     {% if entry.revision == page_latest_revision %}<span class="status-tag primary">{% trans 'Current draft' %}</span>{% endif %}
                                     {% include "wagtailadmin/pages/revisions/_actions.html" with revision=entry.revision %}

--- a/wagtail/admin/views/pages/history.py
+++ b/wagtail/admin/views/pages/history.py
@@ -170,6 +170,7 @@ class PageHistoryView(ReportView):
         context = super().get_context_data(*args, object_list=object_list, **kwargs)
         context['page'] = self.page
         context['subtitle'] = self.page.get_admin_display_title()
+        context['page_latest_revision'] = self.page.get_latest_revision()
 
         return context
 

--- a/wagtail/admin/views/pages/history.py
+++ b/wagtail/admin/views/pages/history.py
@@ -174,4 +174,8 @@ class PageHistoryView(ReportView):
         return context
 
     def get_queryset(self):
-        return PageLogEntry.objects.filter(page=self.page)
+        return PageLogEntry.objects.filter(page=self.page).select_related(
+            'revision',
+            'user',
+            'user__wagtail_userprofile'
+        )


### PR DESCRIPTION
Reduce the number of queries used to render the "Page History" page.

Before: 66 queries
After: 48 queries

In my setup, I only had 5 items, so obviously this optimisation would get better with a full page (20)