### PR TITLE
`select_related` user profile when listing users

### DIFF
--- a/wagtail/users/views/users.py
+++ b/wagtail/users/views/users.py
@@ -98,7 +98,7 @@ def index(request, *args):
     else:
         ordering = 'name'
 
-    paginator = Paginator(users, per_page=20)
+    paginator = Paginator(users.select_related('wagtail_userprofile'), per_page=20)
     users = paginator.get_page(request.GET.get('p'))
 
     if request.is_ajax():


### PR DESCRIPTION
The `avatar_url` template tag uses the `wagtail_userprofile` to find an attached avatar (if there is one), which was resulting in `n` queries.

Before: 45 queries in 1.06s
After: 26 queries in 0.63s