### PR TITLE
Add missing block.super in extra_css/extra_js blocks

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/account/account.html
+++ b/wagtail/admin/templates/wagtailadmin/account/account.html
@@ -64,6 +64,7 @@
 {% endblock %}
 
 {% block extra_css %}
+    {{ block.super }}
     {% include "wagtailadmin/pages/_editor_css.html" %}
     <link rel="stylesheet" href="{% versioned_static 'wagtailadmin/css/layouts/account.css' %}" type="text/css" />
     {{ media.css }}

--- a/wagtail/admin/templates/wagtailadmin/home.html
+++ b/wagtail/admin/templates/wagtailadmin/home.html
@@ -33,6 +33,7 @@
 {% endblock %}
 
 {% block extra_js %}
+{{ block.super }}
 <script>
 $(function() {
     $('.object.collapsible').each(function() {

--- a/wagtail/admin/templates/wagtailadmin/reports/base_report.html
+++ b/wagtail/admin/templates/wagtailadmin/reports/base_report.html
@@ -56,11 +56,13 @@
 {% endblock %}
 
 {% block extra_css %}
+    {{ block.super }}
     <link rel="stylesheet" href="{% versioned_static 'wagtailadmin/css/layouts/report.css' %}" type="text/css" />
 
     {{ filters.form.media.css }}
 {% endblock %}
 
 {% block extra_js %}
+    {{ block.super }}
     {{ filters.form.media.js }}
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/workflows/create.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/create.html
@@ -4,6 +4,7 @@
 {% block titletag %}{{ view.page_title }}{% endblock %}
 
 {% block extra_css %}
+    {{ block.super }}
     {% include "wagtailadmin/pages/_editor_css.html" %}
     <link rel="stylesheet" href="{% versioned_static 'wagtailadmin/css/layouts/workflow-edit.css' %}" type="text/css" />
     {{ edit_handler.form.media.css }}
@@ -13,6 +14,7 @@
 {% endblock %}
 
 {% block extra_js %}
+    {{ block.super }}
     {% include "wagtailadmin/pages/_editor_js.html" %}
     {{ edit_handler.form.media.js }}
     {{ pages_formset.media.js }}

--- a/wagtail/admin/templates/wagtailadmin/workflows/create_task.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/create_task.html
@@ -4,6 +4,7 @@
 {% block titletag %}{{ view.page_title }}{% endblock %}
 
 {% block extra_css %}
+    {{ block.super }}
     {% include "wagtailadmin/pages/_editor_css.html" %}
     {{ edit_handler.form.media.css }}
 
@@ -11,6 +12,7 @@
 {% endblock %}
 
 {% block extra_js %}
+    {{ block.super }}
     {% include "wagtailadmin/pages/_editor_js.html" %}
     {{ edit_handler.form.media.js }}
     {{ edit_handler.html_declarations }}

--- a/wagtail/admin/templates/wagtailadmin/workflows/edit.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/edit.html
@@ -4,6 +4,7 @@
 {% block titletag %}{{ view.page_title }}{% endblock %}
 
 {% block extra_css %}
+    {{ block.super }}
     {% include "wagtailadmin/pages/_editor_css.html" %}
     {{ edit_handler.form.media.css }}
     {{ pages_formset.media.css }}
@@ -13,6 +14,7 @@
 {% endblock %}
 
 {% block extra_js %}
+    {{ block.super }}
     {% include "wagtailadmin/pages/_editor_js.html" %}
     {{ edit_handler.form.media.js }}
     {{ pages_formset.media.js }}

--- a/wagtail/admin/templates/wagtailadmin/workflows/edit_task.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/edit_task.html
@@ -4,6 +4,7 @@
 {% block titletag %}{{ view.page_title }}{% endblock %}
 
 {% block extra_css %}
+    {{ block.super }}
     {% include "wagtailadmin/pages/_editor_css.html" %}
     {{ edit_handler.form.media.css }}
 
@@ -11,6 +12,7 @@
 {% endblock %}
 
 {% block extra_js %}
+    {{ block.super }}
     {% include "wagtailadmin/pages/_editor_js.html" %}
     {{ edit_handler.form.media.js }}
     {{ edit_handler.html_declarations }}


### PR DESCRIPTION
Just ran into a situation similar to #5708. This adds `{{ block.super }}` to all `extra_{css,js}` blocks that are missing it.