### PR TITLE
Use `select_related` when viewing the Site History report

### DIFF
--- a/wagtail/admin/views/reports/audit_logging.py
+++ b/wagtail/admin/views/reports/audit_logging.py
@@ -88,7 +88,7 @@ class LogEntriesView(ReportView):
                 PageLogEntry.objects.filter(deleted=True).values('page_id')
             ))
 
-        return PageLogEntry.objects.filter(q)
+        return PageLogEntry.objects.filter(q).select_related('page', 'user', 'user__wagtail_userprofile')
 
     def get_action_label(self, action):
         from wagtail.core.log_actions import page_log_action_registry


### PR DESCRIPTION
Fixes #7284

With the build that generated the n+1 trace from #7284 (my local build still at 2.12). Before:
~1s overall
163ms on queries
196 queries

after:
528ms overall
101ms on queries
46 queries

With my bakery setup. Before:

1090ms overall
165ms on queries
170 queries

After:
649ms overall
38ms on queries
31 queries
