### PR TITLE
Improve admin listing performance

### DIFF
--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -204,17 +204,17 @@ def test_page_is_public(context, page):
     Usage: {% test_page_is_public page as is_public %}
     Sets 'is_public' to True iff there are no page view restrictions in place on
     this page.
-    Caches the list of page view restrictions in the context, to avoid repeated
+    Caches the list of page view restrictions on the request, to avoid repeated
     DB queries on repeated calls.
     """
-    if 'all_page_view_restriction_paths' not in context:
-        context['all_page_view_restriction_paths'] = PageViewRestriction.objects.select_related('page').values_list(
+    if not hasattr(context["request"], "all_page_view_restriction_paths"):
+        context['request'].all_page_view_restriction_paths = PageViewRestriction.objects.select_related('page').values_list(
             'page__path', flat=True
         )
 
     is_private = any([
         page.path.startswith(restricted_path)
-        for restricted_path in context['all_page_view_restriction_paths']
+        for restricted_path in context["request"].all_page_view_restriction_paths
     ])
 
     return not is_private

--- a/wagtail/admin/views/pages/listing.py
+++ b/wagtail/admin/views/pages/listing.py
@@ -84,6 +84,9 @@ def index(request, parent_page_id=None):
     for hook in hooks.get_hooks('construct_explorer_page_queryset'):
         pages = hook(parent_page, pages, request)
 
+    # Annotate queryset with various states to be used later for performance optimisations`
+    pages = pages.with_workflow_state().with_approved_schedule().with_site_root_state()
+
     # Pagination
     if do_paginate:
         paginator = Paginator(pages, per_page=50)

--- a/wagtail/admin/views/pages/listing.py
+++ b/wagtail/admin/views/pages/listing.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 from django.core.paginator import Paginator
-from django.db.models import Count
+from django.db.models import Count, Prefetch
+from django.db.models.expressions import Exists, OuterRef
 from django.shortcuts import get_object_or_404, redirect
 from django.template.response import TemplateResponse
 from django.urls import reverse
@@ -8,7 +9,54 @@ from django.urls import reverse
 from wagtail.admin.auth import user_has_any_page_permission, user_passes_test
 from wagtail.admin.navigation import get_explorable_root_page
 from wagtail.core import hooks
-from wagtail.core.models import Page, UserPagePermissionsProxy
+from wagtail.core.models import Page, PageRevision, UserPagePermissionsProxy, WorkflowState
+from wagtail.core.models.sites import Site
+
+
+def prefetch_workflow_states(queryset):
+    """
+    Performance optimisation for listing pages.
+    Prefetches the active workflow states on each page in this queryset.
+    """
+    workflow_states = WorkflowState.objects.active().select_related(
+        "current_task_state__task"
+    )
+
+    return queryset.prefetch_related(
+        Prefetch(
+            "workflow_states",
+            queryset=workflow_states,
+            to_attr="_current_workflow_states",
+        )
+    )
+
+
+def annotate_approved_schedule(queryset):
+    """
+    Performance optimisation for listing pages.
+    Annotates each page with the existence of an approved go live time.
+    """
+    return queryset.annotate(
+        _approved_schedule=Exists(
+            PageRevision.objects.exclude(approved_go_live_at__isnull=True).filter(
+                page__pk=OuterRef("pk")
+            )
+        )
+    )
+
+
+def annotate_site_root_state(queryset):
+    """
+    Performance optimisation for listing pages.
+    Annotates each object with whether it is a root page of any site.
+    """
+    return queryset.annotate(
+        _is_site_root=Exists(
+            Site.objects.filter(
+                root_page__translation_key=OuterRef("translation_key")
+            )
+        )
+    )
 
 
 @user_passes_test(user_has_any_page_permission)
@@ -84,8 +132,12 @@ def index(request, parent_page_id=None):
     for hook in hooks.get_hooks('construct_explorer_page_queryset'):
         pages = hook(parent_page, pages, request)
 
-    # Annotate queryset with various states to be used later for performance optimisations`
-    pages = pages.with_workflow_state().with_approved_schedule().with_site_root_state()
+    # Annotate queryset with various states to be used later for performance optimisations
+    pages = annotate_site_root_state(
+        annotate_approved_schedule(
+            prefetch_workflow_states(pages)
+        )
+    )
 
     # Pagination
     if do_paginate:

--- a/wagtail/core/models/__init__.py
+++ b/wagtail/core/models/__init__.py
@@ -450,7 +450,12 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
 
         This includes translations of site root pages as well.
         """
-        return Site.objects.filter(root_page__translation_key=self.translation_key).exists()
+        if hasattr(self, "_is_site_root"):
+            return self._is_site_root
+
+        return Site.objects.filter(
+            root_page__translation_key=self.translation_key
+        ).exists()
 
     @transaction.atomic
     # ensure that changes are only committed when we have updated all descendant URL paths, to preserve consistency
@@ -1451,6 +1456,9 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
 
     @property
     def approved_schedule(self):
+        if hasattr(self, "_approved_schedule"):
+            return self._approved_schedule
+
         return self.revisions.exclude(approved_go_live_at__isnull=True).exists()
 
     def has_unpublished_subtree(self):
@@ -2308,6 +2316,13 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
         """Returns True if a workflow is in progress on the current page, otherwise False"""
         if not getattr(settings, 'WAGTAIL_WORKFLOW_ENABLED', True):
             return False
+
+        if hasattr(self, "_current_workflow_states"):
+            for state in self._current_workflow_states:
+                if state.status == WorkflowState.STATUS_IN_PROGRESS:
+                    return True
+            return False
+
         return WorkflowState.objects.filter(page=self, status=WorkflowState.STATUS_IN_PROGRESS).exists()
 
     @property
@@ -2315,6 +2330,13 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
         """Returns the in progress or needs changes workflow state on this page, if it exists"""
         if not getattr(settings, 'WAGTAIL_WORKFLOW_ENABLED', True):
             return None
+
+        if hasattr(self, "_current_workflow_states"):
+            try:
+                return self._current_workflow_states[0]
+            except IndexError:
+                return
+
         try:
             return WorkflowState.objects.active().select_related("current_task_state__task").get(page=self)
         except WorkflowState.DoesNotExist:

--- a/wagtail/core/models/__init__.py
+++ b/wagtail/core/models/__init__.py
@@ -450,6 +450,8 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
 
         This includes translations of site root pages as well.
         """
+        # `_is_site_root` may be populated by `annotate_site_root_state` on `PageQuerySet` as a
+        # performance optimisation
         if hasattr(self, "_is_site_root"):
             return self._is_site_root
 
@@ -1456,6 +1458,8 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
 
     @property
     def approved_schedule(self):
+        # `_approved_schedule` may be populated by `annotate_approved_schedule` on `PageQuerySet` as a
+        # performance optimisation
         if hasattr(self, "_approved_schedule"):
             return self._approved_schedule
 
@@ -2317,6 +2321,8 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
         if not getattr(settings, 'WAGTAIL_WORKFLOW_ENABLED', True):
             return False
 
+        # `_current_workflow_states` may be populated by `prefetch_workflow_states` on `PageQuerySet` as a
+        # performance optimisation
         if hasattr(self, "_current_workflow_states"):
             for state in self._current_workflow_states:
                 if state.status == WorkflowState.STATUS_IN_PROGRESS:
@@ -2331,6 +2337,8 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
         if not getattr(settings, 'WAGTAIL_WORKFLOW_ENABLED', True):
             return None
 
+        # `_current_workflow_states` may be populated by `prefetch_workflow_states` on `pagequeryset` as a
+        # performance optimisation
         if hasattr(self, "_current_workflow_states"):
             try:
                 return self._current_workflow_states[0]

--- a/wagtail/core/query.py
+++ b/wagtail/core/query.py
@@ -5,13 +5,11 @@ from collections import defaultdict
 
 from django.apps import apps
 from django.contrib.contenttypes.models import ContentType
-from django.db.models import CharField, Prefetch, Q
-from django.db.models.expressions import Exists, OuterRef
+from django.db.models import CharField, Q
 from django.db.models.functions import Length, Substr
 from django.db.models.query import BaseIterable, ModelIterable
 from treebeard.mp_tree import MP_NodeQuerySet
 
-from wagtail.core.models.sites import Site
 from wagtail.search.queryset import SearchableQuerySetMixin
 
 
@@ -419,53 +417,6 @@ class PageQuerySet(SearchableQuerySetMixin, TreeQuerySet):
         from the results.
         """
         return self.exclude(self.translation_of_q(page, inclusive))
-
-    def with_workflow_state(self):
-        """
-        Performance optimisation for listing pages.
-        Prefetches the active workflow states on each page in this queryset.
-        """
-        from .models import WorkflowState
-
-        workflow_states = WorkflowState.objects.active().select_related(
-            "current_task_state__task"
-        )
-
-        return self.prefetch_related(
-            Prefetch(
-                "workflow_states",
-                queryset=workflow_states,
-                to_attr="_current_workflow_states",
-            )
-        )
-
-    def with_approved_schedule(self):
-        """
-        Performance optimisation for listing pages.
-        Annotates each page with the existence of an approved go live time.
-        """
-        from .models import PageRevision
-
-        return self.annotate(
-            _approved_schedule=Exists(
-                PageRevision.objects.exclude(approved_go_live_at__isnull=True).filter(
-                    page__pk=OuterRef("pk")
-                )
-            )
-        )
-
-    def with_site_root_state(self):
-        """
-        Performance optimisation for listing pages.
-        Annotates each object with whether it is a root page of any site.
-        """
-        return self.annotate(
-            _is_site_root=Exists(
-                Site.objects.filter(
-                    root_page__translation_key=OuterRef("translation_key")
-                )
-            )
-        )
 
 
 def specific_iterator(qs, defer=False):

--- a/wagtail/core/query.py
+++ b/wagtail/core/query.py
@@ -5,11 +5,13 @@ from collections import defaultdict
 
 from django.apps import apps
 from django.contrib.contenttypes.models import ContentType
-from django.db.models import CharField, Q
+from django.db.models import CharField, Prefetch, Q
+from django.db.models.expressions import Exists, OuterRef
 from django.db.models.functions import Length, Substr
 from django.db.models.query import BaseIterable, ModelIterable
 from treebeard.mp_tree import MP_NodeQuerySet
 
+from wagtail.core.models.sites import Site
 from wagtail.search.queryset import SearchableQuerySetMixin
 
 
@@ -417,6 +419,53 @@ class PageQuerySet(SearchableQuerySetMixin, TreeQuerySet):
         from the results.
         """
         return self.exclude(self.translation_of_q(page, inclusive))
+
+    def with_workflow_state(self):
+        """
+        Performance optimisation for listing pages.
+        Prefetches the active workflow states on each page in this queryset.
+        """
+        from .models import WorkflowState
+
+        workflow_states = WorkflowState.objects.active().select_related(
+            "current_task_state__task"
+        )
+
+        return self.prefetch_related(
+            Prefetch(
+                "workflow_states",
+                queryset=workflow_states,
+                to_attr="_current_workflow_states",
+            )
+        )
+
+    def with_approved_schedule(self):
+        """
+        Performance optimisation for listing pages.
+        Annotates each page with the existence of an approved go live time.
+        """
+        from .models import PageRevision
+
+        return self.annotate(
+            _approved_schedule=Exists(
+                PageRevision.objects.exclude(approved_go_live_at__isnull=True).filter(
+                    page__pk=OuterRef("pk")
+                )
+            )
+        )
+
+    def with_site_root_state(self):
+        """
+        Performance optimisation for listing pages.
+        Annotates each object with whether it is a root page of any site.
+        """
+        return self.annotate(
+            _is_site_root=Exists(
+                Site.objects.filter(
+                    root_page__translation_key=OuterRef("translation_key")
+                )
+            )
+        )
 
 
 def specific_iterator(qs, defer=False):


### PR DESCRIPTION
This change removes 4 N+1 queries on Wagtail admin page listings, reducing the number of queries on a 'fully loaded' (50 items) listing view in my bakerydemo test from 300+ to 46.

With Workflow disabled, there is still a notable improvement here, reducing from ~200 queries to 44.

I am not a huge fan of the pattern of annotating querysets and later accessing these 'cached' values in properties later on, which introduces duplication and indirection, so I'm hoping for some feedback on the implementation here.

* Do the tests still pass? Yes
* Does the code comply with the style guide? Yes
* For Python changes: Have you added tests to cover the new/fixed behaviour? No, pending discussion
