### PR TITLE
Use date format from current locale for xlsx export

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -23,6 +23,7 @@ Changelog
  * Support calling `get_image_model` and `get_document_model` at import time (Matt Westcott)
  * When copying a page, default the 'Publish copied page' field to false (Justin Slay)
  * Open Preview and Live page links in the same tab, except where it would interrupt editing a Page (Sagar Agarwal)
+ * Added `ExcelDateFormatter` to `wagtail.admin.views.mixins` so that dates in Excel exports will appear in the locale's `SHORT_DATETIME_FORMAT` (Andrew Stone)
  * Fix: Delete button is now correct colour on snippets and modeladmin listings (Brandon Murch)
  * Fix: Ensure that StreamBlock / ListBlock-level validation errors are counted towards error counts (Matt Westcott)
  * Fix: InlinePanel add button is now keyboard navigatable (Jesse Menn)

--- a/docs/releases/2.15.rst
+++ b/docs/releases/2.15.rst
@@ -34,6 +34,7 @@ Other features
  * Support calling ``get_image_model`` and ``get_document_model`` at import time (Matt Westcott)
  * When copying a page, default the 'Publish copied page' field to false (Justin Slay)
  * Open Preview and Live page links in the same tab, except where it would interrupt editing a Page (Sagar Agarwal)
+ * Added ``ExcelDateFormatter`` to ``wagtail.admin.views.mixins`` so that dates in Excel exports will appear in the locale's ``SHORT_DATETIME_FORMAT`` (Andrew Stone)
 
 Bug fixes
 ~~~~~~~~~

--- a/wagtail/admin/tests/test_reports_views.py
+++ b/wagtail/admin/tests/test_reports_views.py
@@ -3,11 +3,14 @@ import datetime
 from io import BytesIO
 
 from django.conf import settings
+from django.conf.locale import LANG_INFO
 from django.test import TestCase
+from django.test.utils import override_settings
 from django.urls import reverse
-from django.utils import timezone
+from django.utils import timezone, translation
 from openpyxl import load_workbook
 
+from wagtail.admin.views.mixins import ExcelDateFormatter
 from wagtail.core.models import Page, PageLogEntry
 from wagtail.tests.utils import WagtailTestUtils
 
@@ -194,3 +197,15 @@ class TestFilteredLogEntriesView(TestCase, WagtailTestUtils):
             self.edit_log_2,
             self.edit_log_3,
         ])
+
+
+@override_settings(
+    USE_L10N=True,
+)
+class TestExcelDateFormatter(TestCase):
+    def test_all_locales(self):
+        formatter = ExcelDateFormatter()
+
+        for lang in LANG_INFO.keys():
+            with self.subTest(lang), translation.override(lang):
+                self.assertNotEqual(formatter.get(), "")


### PR DESCRIPTION
The current default looked broken to me when I opened up a report in Excel. Django has locales with date formats, so it might be a good idea to use that instead of a hard-coded default.

Some implementation notes:

* Excel has very limited date formatting capabilities, so some cases that django provides can't be covered.
* `SHORT_DATETIME_FORMAT` seems to provide a reasonable middle ground for coverage and usability.
* flake8 hated the new class, but this is the most readable version I could come up with (that didn't use `__getattr__`).