### PR TITLE
Support non-block validation errors on ListBlock

### DIFF
--- a/client/src/components/StreamField/blocks/ListBlock.js
+++ b/client/src/components/StreamField/blocks/ListBlock.js
@@ -6,8 +6,9 @@ import { escapeHtml as h } from '../../../utils/text';
 /* global $ */
 
 export class ListBlockValidationError {
-  constructor(blockErrors) {
+  constructor(blockErrors, nonBlockErrors) {
     this.blockErrors = blockErrors;
+    this.nonBlockErrors = nonBlockErrors;
   }
 }
 
@@ -87,6 +88,7 @@ export class ListBlock extends BaseSequenceBlock {
     this.blockCounter = 0;
     this.countInput = dom.find('[data-streamfield-list-count]');
     this.sequenceContainer = dom.find('[data-streamfield-list-container]');
+    this.container = dom;
     this.setState(initialState || []);
 
     if (initialError) {
@@ -129,6 +131,21 @@ export class ListBlock extends BaseSequenceBlock {
       return;
     }
     const error = errorList[0];
+
+    // Non block errors
+    const container = this.container[0];
+    container.querySelectorAll(':scope > .help-block.help-critical').forEach(element => element.remove());
+
+    if (error.nonBlockErrors.length > 0) {
+      // Add a help block for each error raised
+      error.nonBlockErrors.forEach(nonBlockError => {
+        const errorElement = document.createElement('p');
+        errorElement.classList.add('help-block');
+        errorElement.classList.add('help-critical');
+        errorElement.innerHTML = h(nonBlockError.messages[0]);
+        container.insertBefore(errorElement, container.childNodes[0]);
+      });
+    }
 
     // error.blockErrors = a list with the same length as the data,
     // with nulls for items without errors

--- a/client/src/components/StreamField/blocks/ListBlock.test.js
+++ b/client/src/components/StreamField/blocks/ListBlock.test.js
@@ -231,10 +231,25 @@ describe('telepath: wagtail.blocks.ListBlock', () => {
 
   test('setError passes error messages to children', () => {
     boundBlock.setError([
-      new ListBlockValidationError([
-        null,
-        [new ValidationError(['Not as good as the first one'])],
-      ]),
+      new ListBlockValidationError(
+        [
+          null,
+          [new ValidationError(['Not as good as the first one'])],
+        ],
+        []
+      ),
+    ]);
+    expect(document.body.innerHTML).toMatchSnapshot();
+  });
+
+  test('setError renders non-block errors', () => {
+    boundBlock.setError([
+      new ListBlockValidationError(
+        [null, null],
+        [
+          new ValidationError(['At least three blocks are required']),
+        ]
+      ),
     ]);
     expect(document.body.innerHTML).toMatchSnapshot();
   });

--- a/client/src/components/StreamField/blocks/__snapshots__/ListBlock.test.js.snap
+++ b/client/src/components/StreamField/blocks/__snapshots__/ListBlock.test.js.snap
@@ -700,3 +700,112 @@ exports[`telepath: wagtail.blocks.ListBlock setError passes error messages to ch
       </button></div>
       </div>"
 `;
+
+exports[`telepath: wagtail.blocks.ListBlock setError renders non-block errors 1`] = `
+"<span>
+          <div class=\\"help\\">
+            <div class=\\"icon-help\\">?</div>
+            use <strong>a few</strong> of these
+          </div>
+        </span><div class=\\"c-sf-container \\"><p class=\\"help-block help-critical\\">At least three blocks are required</p>
+        <input type=\\"hidden\\" name=\\"the-prefix-count\\" data-streamfield-list-count=\\"\\" value=\\"2\\">
+
+        <div data-streamfield-list-container=\\"\\"><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button c-sf-add-button--visible\\">
+        <i aria-hidden=\\"true\\">+</i>
+      </button><div aria-hidden=\\"false\\" data-contentpath-disabled=\\"\\">
+        <input type=\\"hidden\\" name=\\"the-prefix-0-deleted\\" value=\\"\\">
+        <input type=\\"hidden\\" name=\\"the-prefix-0-order\\" value=\\"0\\">
+        <input type=\\"hidden\\" name=\\"the-prefix-0-type\\" value=\\"\\">
+        <input type=\\"hidden\\" name=\\"the-prefix-0-id\\" value=\\"\\">
+
+        <div>
+          <div class=\\"c-sf-container__block-container\\">
+            <div class=\\"c-sf-block\\">
+              <div data-block-header=\\"\\" class=\\"c-sf-block__header c-sf-block__header--collapsible\\">
+                <span class=\\"c-sf-block__header__icon\\">
+                  <i class=\\"icon icon-pilcrow\\"></i>
+                </span>
+                <h3 data-block-title=\\"\\" class=\\"c-sf-block__header__title\\"></h3>
+                <div class=\\"c-sf-block__actions\\">
+                  <span class=\\"c-sf-block__type\\"></span>
+                  <button type=\\"button\\" data-move-up-button=\\"\\" class=\\"c-sf-block__actions__single\\" disabled=\\"\\" title=\\"Move up\\">
+                    <i class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\"></i>
+                  </button>
+                  <button type=\\"button\\" data-move-down-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Move down\\">
+                    <i class=\\"icon icon-arrow-down\\" aria-hidden=\\"true\\"></i>
+                  </button>
+                  <button type=\\"button\\" data-duplicate-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Duplicate\\">
+                    <i class=\\"icon icon-duplicate\\" aria-hidden=\\"true\\"></i>
+                  </button>
+                  <button type=\\"button\\" data-delete-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Delete\\">
+                    <i class=\\"icon icon-bin\\" aria-hidden=\\"true\\"></i>
+                  </button>
+                </div>
+              </div>
+              <div data-block-content=\\"\\" class=\\"c-sf-block__content\\" aria-hidden=\\"false\\">
+                <div class=\\"c-sf-block__content-inner\\">
+                  <div class=\\"field char_field widget-admin_auto_height_text_input fieldname-\\">
+        <div class=\\"field-content\\">
+          <div class=\\"input\\">
+            <p name=\\"the-prefix-0-value\\" id=\\"the-prefix-0-value\\">The widget</p>
+            <span></span>
+          </div>
+        </div>
+      </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button c-sf-add-button--visible\\">
+        <i aria-hidden=\\"true\\">+</i>
+      </button><div aria-hidden=\\"false\\" data-contentpath-disabled=\\"\\">
+        <input type=\\"hidden\\" name=\\"the-prefix-1-deleted\\" value=\\"\\">
+        <input type=\\"hidden\\" name=\\"the-prefix-1-order\\" value=\\"1\\">
+        <input type=\\"hidden\\" name=\\"the-prefix-1-type\\" value=\\"\\">
+        <input type=\\"hidden\\" name=\\"the-prefix-1-id\\" value=\\"\\">
+
+        <div>
+          <div class=\\"c-sf-container__block-container\\">
+            <div class=\\"c-sf-block\\">
+              <div data-block-header=\\"\\" class=\\"c-sf-block__header c-sf-block__header--collapsible\\">
+                <span class=\\"c-sf-block__header__icon\\">
+                  <i class=\\"icon icon-pilcrow\\"></i>
+                </span>
+                <h3 data-block-title=\\"\\" class=\\"c-sf-block__header__title\\"></h3>
+                <div class=\\"c-sf-block__actions\\">
+                  <span class=\\"c-sf-block__type\\"></span>
+                  <button type=\\"button\\" data-move-up-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Move up\\">
+                    <i class=\\"icon icon-arrow-up\\" aria-hidden=\\"true\\"></i>
+                  </button>
+                  <button type=\\"button\\" data-move-down-button=\\"\\" class=\\"c-sf-block__actions__single\\" disabled=\\"\\" title=\\"Move down\\">
+                    <i class=\\"icon icon-arrow-down\\" aria-hidden=\\"true\\"></i>
+                  </button>
+                  <button type=\\"button\\" data-duplicate-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Duplicate\\">
+                    <i class=\\"icon icon-duplicate\\" aria-hidden=\\"true\\"></i>
+                  </button>
+                  <button type=\\"button\\" data-delete-button=\\"\\" class=\\"c-sf-block__actions__single\\" title=\\"Delete\\">
+                    <i class=\\"icon icon-bin\\" aria-hidden=\\"true\\"></i>
+                  </button>
+                </div>
+              </div>
+              <div data-block-content=\\"\\" class=\\"c-sf-block__content\\" aria-hidden=\\"false\\">
+                <div class=\\"c-sf-block__content-inner\\">
+                  <div class=\\"field char_field widget-admin_auto_height_text_input fieldname-\\">
+        <div class=\\"field-content\\">
+          <div class=\\"input\\">
+            <p name=\\"the-prefix-1-value\\" id=\\"the-prefix-1-value\\">The widget</p>
+            <span></span>
+          </div>
+        </div>
+      </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button c-sf-add-button--visible\\">
+        <i aria-hidden=\\"true\\">+</i>
+      </button></div>
+      </div>"
+`;


### PR DESCRIPTION
Ref #5300 - allow non-field errors to be attached to ListBlock validation errors, as we do for StreamBlock. As it stands Wagtail will not generate any of these (but the next step will be to use this for min_num / max_num validation as per #3914). Tested against bakerydemo with this block definition:

```
from django.forms.utils import ErrorList
from wagtail.core.blocks import (
    CharBlock, StreamBlock,
    ListBlock, ListBlockValidationError
)


class FooListBlock(ListBlock):
    error = 'At least one block must say "foo"'

    def clean(self, value):
        value = super().clean(value)
        if not any(child == 'foo' for child in value):
            raise ListBlockValidationError(non_block_errors=ErrorList([self.error]))
        return value

class BaseStreamBlock(StreamBlock):
    # ...
    foo_list = FooListBlock(CharBlock())
```