### PR TITLE
Add missing max_length on temporary thumbnail_url migration

### DIFF
--- a/wagtail/embeds/migrations/0008_allow_long_urls.py
+++ b/wagtail/embeds/migrations/0008_allow_long_urls.py
@@ -34,6 +34,7 @@ class Migration(migrations.Migration):
             field=models.URLField(
                 blank=True,
                 default="",
+                max_length=255,
             ),
             preserve_default=False,
         ),


### PR DESCRIPTION
Fixes #7323 - my previous fix in #6999 annoyingly missed [the `max_length=255` on the CharField](https://github.com/wagtail/wagtail/blob/4eb7c2c0198d786d33e2257436d346774de21698/wagtail/embeds/migrations/0005_specify_thumbnail_url_max_length.py#L16), so while the whole intent of this migration is to change the field to a TextField where max_length isn't an issue, it introduced a brief window where 200-255 char URLs became invalid. 😖 