### PR TITLE
Update accessibility targets with links to known issues & audit

### DIFF
--- a/docs/contributing/developing.rst
+++ b/docs/contributing/developing.rst
@@ -213,25 +213,30 @@ Safari         Windows        All
 Accessibility targets
 ---------------------
 
-We want to make Wagtail accessible for users of a wide variety of assistive technologies. The specific standard we aim for is `WCAG2.1 <https://www.w3.org/TR/WCAG21/>`_, AA level. Wagtail’s administration user interface isn’t accessible at the moment (see `issue #4199 <https://github.com/wagtail/wagtail/issues/4199>`_), but here are specific assistive technologies we aim to test for, and ultimately support:
+We want to make Wagtail accessible for users of a wide variety of assistive technologies. The specific standard we aim for is `WCAG2.1 <https://www.w3.org/TR/WCAG21/>`_, AA level. Here are specific assistive technologies we aim to test for, and ultimately support:
 
-=============  ====================
-Type           Assistive technology
-=============  ====================
-Screen reader  `NVDA <https://www.nvaccess.org/download/>`_ on Windows with Firefox ESR
-Screen reader  `VoiceOver <https://support.apple.com/en-gb/guide/voiceover-guide/welcome/web>`_ on macOS with Safari
-Magnification  `Windows Magnifier <https://support.microsoft.com/en-gb/help/11542/windows-use-magnifier>`_
-Magnification  macOS Zoom
-Voice control  Windows Speech Recognition
-Voice control  macOS Dictation
-Screen reader  Mobile `VoiceOver <https://support.apple.com/en-gb/guide/voiceover-guide/welcome/web>`_ on iOS, or `TalkBack <https://support.google.com/accessibility/android/answer/6283677?hl=en-GB>`_ on Android
-=============  ====================
+* `NVDA <https://www.nvaccess.org/download/>`_ on Windows with Firefox ESR
+* `VoiceOver <https://support.apple.com/en-gb/guide/voiceover-guide/welcome/web>`_ on macOS with Safari
+* `Windows Magnifier <https://support.microsoft.com/en-gb/help/11542/windows-use-magnifier>`_ and macOS Zoom
+* Windows Speech Recognition and macOS Dictation
+* Mobile `VoiceOver <https://support.apple.com/en-gb/guide/voiceover-guide/welcome/web>`_ on iOS, or `TalkBack <https://support.google.com/accessibility/android/answer/6283677?hl=en-GB>`_ on Android
+* Windows `High-contrast mode <https://support.microsoft.com/en-us/windows/use-high-contrast-mode-in-windows-10-fedc744c-90ac-69df-aed5-c8a90125e696>`_
 
 We aim for Wagtail to work in those environments. Our development standards ensure that the site is usable with other assistive technologies. In practice, testing with assistive technology can be a daunting task that requires specialised training – here are tools we rely on to help identify accessibility issues, to use during development and code reviews:
 
 * `react-axe <https://github.com/dequelabs/react-axe>`_ integrated directly in our build tools, to identify actionable issues. Logs its results in the browser console.
 * `Axe <https://chrome.google.com/webstore/detail/axe/lhdoppojpmngadmnindnejefpokejbdd>`_ Chrome extension for more comprehensive automated tests of a given page.
 * `Accessibility Insights for Web <https://accessibilityinsights.io/docs/en/web/overview>`_ Chrome extension for semi-automated tests, and manual audits.
+
+Known accessibility issues
+--------------------------
+
+Wagtail’s administration interface isn’t fully accessible at the moment. We actively work on fixing issues both as part of ongoing maintenance and bigger overhauls. To learn about known issues, check out:
+
+* The `WCAG2.1 AA for CMS admin <https://github.com/wagtail/wagtail/projects/5>`_ issues backlog.
+* Our `2021 accessibility audit <https://docs.google.com/spreadsheets/d/1l7tnpEyJiC5BWE_JX0XCkknyrjxYA5T2aee5JgPnmi4/edit>`_.
+
+The audit also states which parts of Wagtail have and haven’t been tested, how issues affect WCAG 2.1 compliance, and the likely impact on users.
 
 Compiling static assets
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/editor_manual/browser_issues.rst
+++ b/docs/editor_manual/browser_issues.rst
@@ -26,3 +26,8 @@ If this affects you or your organisation, consider which alternative browsers yo
 Wagtail is fully compatible with Microsoft Edge, Microsoft’s replacement for Internet Explorer. You may consider using its `IE mode <https://docs.microsoft.com/en-us/deployedge/edge-ie-mode>`_ to keep access to IE11-only sites, while other sites and apps like Wagtail can leverage modern browser capabilities.
 
 We are looking for feedback on this change to our support policy, please `get in touch <https://github.com/wagtail/wagtail/issues/6170>`_ if it affects you and there are no clear alternatives.
+
+Assistive technologies
+______________________
+
+We want Wagtail to be accessible for users of a wide range of assistive technologies, but are aware of many blockers currently. For an overview, see our `public accessibility audit <https://docs.google.com/spreadsheets/d/1l7tnpEyJiC5BWE_JX0XCkknyrjxYA5T2aee5JgPnmi4/edit>`_.


### PR DESCRIPTION
This updates documentation we had already:

- Converts the table of assistive technologies to a list to hopefully make it a bit easier to understand, and add to.
- Adds Windows high-contrast mode, as we’re now testing with it and treating any issues as bugs

And the bigger change – moving our current progress to its own section, with different links. This is primarily intended so people contributing to Wagtail know where we’re at – there is a place to check what we want to support, and also links to what problems we know about already, and what we haven’t tested yet (in the audit).

The intention is also to make the work of the @wagtail/accessibility more transparent – having the majority of our progress in a spreadsheet is nice for auditing and reporting, but falls a bit short in openness compared to how we normally manage Wagtail work.

cc @wagtail/accessibility who I’d like to give feedback on this.

Preview link: [contributors – accessibility targets](https://wagtail--7330.org.readthedocs.build/en/7330/contributing/developing.html#accessibility-targets), [editor’s guide – assistive technologies](https://wagtail--7330.org.readthedocs.build/en/7330/editor_manual/browser_issues.html#assistive-technologies).