### PR TITLE
Ordinary

### DIFF
--- a/docs/advanced_topics/amp.rst
+++ b/docs/advanced_topics/amp.rst
@@ -223,7 +223,7 @@ Using a different page template when AMP mode is active
 -------------------------------------------------------
 
 You're probably not going to want to use the same templates on the AMP site as
-you do on the regular web site. Let's add some logic in to make Wagtail use a
+you do on the normal web site. Let's add some logic in to make Wagtail use a
 separate template whenever a page is served with AMP enabled.
 
 We can use a mixin, which allows us to re-use the logic on different page types.

--- a/docs/editor_manual/copying_aliasing_existing_pages.rst
+++ b/docs/editor_manual/copying_aliasing_existing_pages.rst
@@ -70,8 +70,8 @@ Here is how to create an alias to an existing page:
    :alt: The aliased page appearing under the new parent page in the Explorer page.
 
 
-* When you try to edit the aliased page, you are notified that it is an alias of another page. You will then be offered two options: edit the original page (with changes appearing in both places) or convert the alias page into a regular page (i.e. a regular copy, not updated when the original changes).
+* When you try to edit the aliased page, you are notified that it is an alias of another page. You will then be offered two options: edit the original page (with changes appearing in both places) or convert the alias page into an ordinary page (i.e. a conventional copy, not updated when the original changes).
 
 
 .. image:: ../_static/images/screen12.7_4_alias_page_edit_notification.png
-   :alt: Editing an alias page notifies it is an alias and offers to either edit the original page or change the alias to a regular page.
+   :alt: Editing an alias page notifies it is an alias and offers to either edit the original page or change the alias to an ordinary page.

--- a/docs/reference/contrib/forms/index.rst
+++ b/docs/reference/contrib/forms/index.rst
@@ -85,7 +85,7 @@ You now need to create two templates named ``form_page.html`` and ``form_page_la
         </body>
     </html>
 
-``form_page_landing.html`` is a regular Wagtail template, displayed after the user makes a successful form submission, `form_submission` will available in this template. If you want to dynamically override the landing page template, you can do so with the ``get_landing_page_template`` method (in the same way that you would with ``get_template``).
+``form_page_landing.html`` is a standard Wagtail template, displayed after the user makes a successful form submission, `form_submission` will available in this template. If you want to dynamically override the landing page template, you can do so with the ``get_landing_page_template`` method (in the same way that you would with ``get_template``).
 
 
 .. _wagtailforms_formsubmissionpanel:

--- a/docs/reference/contrib/routablepage.rst
+++ b/docs/reference/contrib/routablepage.rst
@@ -10,7 +10,7 @@ The ``RoutablePageMixin`` mixin provides a convenient way for a page to respond 
 
 A ``Page`` using ``RoutablePageMixin`` exists within the page tree like any other page, but URL paths underneath it are checked against a list of patterns. If none of the patterns match, control is passed to subpages as usual (or failing that, a 404 error is thrown).
 
-By default a route for ``r'^$'`` exists, which serves the content exactly like a regular ``Page`` would. It can be overridden by using ``@route(r'^$')`` on any other method of the inheriting class.
+By default a route for ``r'^$'`` exists, which serves the content exactly like a normal ``Page`` would. It can be overridden by using ``@route(r'^$')`` on any other method of the inheriting class.
 
 
 Installation

--- a/docs/reference/contrib/settings.rst
+++ b/docs/reference/contrib/settings.rst
@@ -282,7 +282,7 @@ Utilising the ``page_url`` setting shortcut
 -------------------------------------------
 
 If, like in the previous section, your settings model references pages,
-and you regularly need to output the URLs of those pages in your project,
+and you often need to output the URLs of those pages in your project,
 you can likely use the setting model's ``page_url`` shortcut to do that more
 cleanly. For example, instead of doing the following:
 

--- a/docs/reference/jinja2.rst
+++ b/docs/reference/jinja2.rst
@@ -9,7 +9,7 @@ Wagtail supports Jinja2 templating for all front end features. More information 
 Configuring Django
 ==================
 
-Django needs to be configured to support Jinja2 templates. As the Wagtail admin is written using regular Django templates, Django has to be configured to use both templating engines. Add the following configuration to the ``TEMPLATES`` setting for your app:
+Django needs to be configured to support Jinja2 templates. As the Wagtail admin is written using standard Django templates, Django has to be configured to use both templating engines. Add the following configuration to the ``TEMPLATES`` setting for your app:
 
 .. code-block:: python
 

--- a/docs/topics/writing_templates.rst
+++ b/docs/topics/writing_templates.rst
@@ -244,7 +244,7 @@ Wagtail User Bar
 
 This tag provides a contextual flyout menu for logged-in users. The menu gives editors the ability to edit the current page or add a child page, besides the options to show the page in the Wagtail page explorer or jump to the Wagtail admin dashboard. Moderators are also given the ability to accept or reject a page being previewed as part of content moderation.
 
-This tag may be used on regular Django views, without page object. The user bar will contain one item pointing to the admin.
+This tag may be used on standard Django views, without page object. The user bar will contain one item pointing to the admin.
 
 We recommend putting the tag near the top of the ``<body>`` element so keyboard users can reach it. You should consider putting the tag after any `skip links <https://webaim.org/techniques/skipnav/>`_ but before the navigation and main content of your page.
 

--- a/wagtail/admin/templates/wagtailadmin/pages/confirm_convert_alias.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/confirm_convert_alias.html
@@ -8,7 +8,7 @@
 
     <div class="nice-padding">
         <p>
-            {% trans 'Are you sure you want to convert this alias into a regular page?' %}
+            {% trans 'Are you sure you want to convert this alias into an ordinary page?' %}
         </p>
 
         <p>

--- a/wagtail/admin/templates/wagtailadmin/pages/edit_alias.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/edit_alias.html
@@ -9,7 +9,7 @@
             <a class="button button-secondary" href="{% url 'wagtailadmin_pages:edit' page.alias_of_id %}">{% trans "Edit original page" %}</a>
 
             {% url 'wagtailadmin_pages:edit' page.id as this_url %}
-            <a class="button button-secondary" href="{% url 'wagtailadmin_pages:convert_alias' page.id %}?next={{ this_url|urlencode }}">{% trans "Convert this alias into a regular page" %}</a>
+            <a class="button button-secondary" href="{% url 'wagtailadmin_pages:convert_alias' page.id %}?next={{ this_url|urlencode }}">{% trans "Convert this alias into an ordinary page" %}</a>
         </p>
     </div>
 {% endblock %}

--- a/wagtail/admin/views/pages/convert_alias.py
+++ b/wagtail/admin/views/pages/convert_alias.py
@@ -48,7 +48,7 @@ def convert_alias(request, page_id):
                 },
             )
 
-            messages.success(request, _("Page '{0}' has been converted into a regular page.").format(page.get_admin_display_title()))
+            messages.success(request, _("Page '{0}' has been converted into an ordinary page.").format(page.get_admin_display_title()))
 
             for fn in hooks.get_hooks('after_convert_alias_page'):
                 result = fn(request, page)

--- a/wagtail/contrib/styleguide/templates/wagtailstyleguide/base.html
+++ b/wagtail/contrib/styleguide/templates/wagtailstyleguide/base.html
@@ -288,22 +288,22 @@
                         <td class="title">
                             <h2><a href="">TD with title class</a></h2>
                         </td>
-                        <td>Regular listing TD</td>
-                        <td>Regular listing TD</td>
+                        <td>Standard TD</td>
+                        <td>Standard TD</td>
                     </tr>
                     <tr class="unpublished">
                         <td class="title">
                             <h2><a href="">Unpublished TD with title class</a></h2>
                         </td>
-                        <td>Regular listing TD</td>
-                        <td>Regular listing TD</td>
+                        <td>Standard TD</td>
+                        <td>Standard TD</td>
                     </tr>
                     <tr>
                         <td class="title">
                             <h2><a href="">TD with title class</a></h2>
                         </td>
-                        <td>Regular listing TD</td>
-                        <td>Regular listing TD</td>
+                        <td>Standard TD</td>
+                        <td>Standard TD</td>
                     </tr>
                 </tbody>
             </table>
@@ -361,22 +361,22 @@
                         <td class="title">
                             <h2><a href="#">TD with title class</a></h2>
                         </td>
-                        <td>Regular listing TD</td>
-                        <td>Regular listing TD</td>
+                        <td>Standard TD</td>
+                        <td>Standard TD</td>
                     </tr>
                     <tr class="disabled">
                         <td class="title">
                             <h2>Disabled TD with title class</h2>
                         </td>
-                        <td>Regular listing TD</td>
-                        <td>Regular listing TD</td>
+                        <td>Standard TD</td>
+                        <td>Standard TD</td>
                     </tr>
                     <tr>
                         <td class="title">
                             <h2><a href="">TD with title class</a></h2>
                         </td>
-                        <td>Regular listing TD</td>
-                        <td>Regular listing TD</td>
+                        <td>Standard TD</td>
+                        <td>Standard TD</td>
                     </tr>
                 </tbody>
             </table>
@@ -394,7 +394,7 @@
 
             <p>Buttons must have interaction possible (i.e be an input or button element) to get a suitable hover cursor</p>
 
-            <h3>Regular buttons</h3>
+            <h3>Basic buttons</h3>
 
             <a href="#" class="button">button link</a>
             <button class="button">button element</button>

--- a/wagtail/core/wagtail_hooks.py
+++ b/wagtail/core/wagtail_hooks.py
@@ -137,11 +137,11 @@ def register_core_log_actions(actions):
 
     def convert_alias_message(data):
         try:
-            return _("Converted the alias '%(title)s' into a regular page") % {
+            return _("Converted the alias '%(title)s' into an ordinary page") % {
                 'title': data['page']['title'],
             }
         except KeyError:
-            return _("Converted an alias into a regular page")
+            return _("Converted an alias into an ordinary page")
 
     def move_message(data):
         try:
@@ -313,7 +313,7 @@ def register_core_log_actions(actions):
     actions.register_action('wagtail.revert', _('Revert'), revert_message)
     actions.register_action('wagtail.copy', _('Copy'), copy_message)
     actions.register_action('wagtail.create_alias', _('Create alias'), create_alias_message)
-    actions.register_action('wagtail.convert_alias', _('Convert alias into regular page'), convert_alias_message)
+    actions.register_action('wagtail.convert_alias', _('Convert alias into ordinary page'), convert_alias_message)
     actions.register_action('wagtail.move', _('Move'), move_message)
     actions.register_action('wagtail.reorder', _('Reorder'), reorder_message)
     actions.register_action('wagtail.publish.schedule', _("Schedule publication"), schedule_publish_message)


### PR DESCRIPTION
This is a pedantic submission of some documentation and UI wording changes, based on the language guidance at https://docs.wagtail.io/en/latest/contributing/general_guidelines.html which prefers British English for user-facing text. _Regular_ in British English doesn't have the US English meaning of _usual_ or _ordinary_.

The page aliases UI uses the term "regular page" to refer to a page that is not an alias. This MR changes the terminology to refer to _ordinary_ pages. Elsewhere  I have also replaced some uses of _regular_ with _normal_, _basic_, _ordinary_, _conventional_, or _standard_, depending on the context.

One use of _regularly_ has been changed with _often_, based more on context than on a dialect difference.

The guidance on language is slightly more ambiguous about dialect choice for text that is not user facing and not a built-in language keyword. I've been conservative, so this MR does not include changes to:

- comments and docstrings in Python code
- strings in test suites
- Python variable names
- text in release notes, as they might be considered immutable