### PR TITLE
Remove bogus workflow_history filtering tests

### DIFF
--- a/wagtail/admin/tests/pages/test_workflow_history.py
+++ b/wagtail/admin/tests/pages/test_workflow_history.py
@@ -2,7 +2,7 @@ from django.contrib.auth.models import Permission
 from django.test import TestCase
 from django.urls import reverse
 
-from wagtail.core.models import Page, PageLogEntry
+from wagtail.core.models import Page
 from wagtail.tests.utils import WagtailTestUtils
 
 
@@ -64,75 +64,3 @@ class TestWorkflowHistoryDetail(TestCase, WagtailTestUtils):
         )
 
         self.assertEqual(response.status_code, 302)
-
-
-class TestFiltering(TestCase, WagtailTestUtils):
-    fixtures = ['test.json']
-
-    def setUp(self):
-        self.user = self.login()
-        self.home_page = Page.objects.get(url_path='/home/')
-
-        self.create_log = PageLogEntry.objects.log_action(self.home_page, 'wagtail.create')
-        self.edit_log_1 = PageLogEntry.objects.log_action(self.home_page, 'wagtail.edit')
-        self.edit_log_2 = PageLogEntry.objects.log_action(self.home_page, 'wagtail.edit')
-        self.edit_log_3 = PageLogEntry.objects.log_action(self.home_page, 'wagtail.edit')
-
-        self.create_comment_log = PageLogEntry.objects.log_action(self.home_page, 'wagtail.comments.create', data={
-            'comment': {
-                'contentpath': 'title',
-                'text': 'Foo',
-            }
-        })
-        self.edit_comment_log = PageLogEntry.objects.log_action(self.home_page, 'wagtail.comments.edit', data={
-            'comment': {
-                'contentpath': 'title',
-                'text': 'Edited',
-            }
-        })
-        self.create_reply_log = PageLogEntry.objects.log_action(self.home_page, 'wagtail.comments.create_reply', data={
-            'comment': {
-                'contentpath': 'title',
-                'text': 'Foo',
-            }
-        })
-
-    def get(self, params={}):
-        return self.client.get(reverse('wagtailadmin_reports:site_history'), params)
-        return self.client.get(reverse('wagtailadmin_pages:workflow_history', args=[self.home_page.id]), params)
-
-    def assert_log_entries(self, response, expected):
-        actual = set(response.context['object_list'])
-        self.assertSetEqual(actual, set(expected))
-
-    def test_unfiltered(self):
-        response = self.get()
-        self.assertEqual(response.status_code, 200)
-        self.assert_log_entries(response, [
-            self.create_log,
-            self.edit_log_1,
-            self.edit_log_2,
-            self.edit_log_3,
-            self.create_comment_log,
-            self.edit_comment_log,
-            self.create_reply_log,
-        ])
-
-    def test_filter_by_action(self):
-        response = self.get(params={'action': 'wagtail.edit'})
-        self.assertEqual(response.status_code, 200)
-        self.assert_log_entries(response, [
-            self.edit_log_1,
-            self.edit_log_2,
-            self.edit_log_3,
-        ])
-
-    def test_hide_commenting_actions(self):
-        response = self.get(params={'hide_commenting_actions': 'on'})
-        self.assertEqual(response.status_code, 200)
-        self.assert_log_entries(response, [
-            self.create_log,
-            self.edit_log_1,
-            self.edit_log_2,
-            self.edit_log_3,
-        ])


### PR DESCRIPTION
This test class is mistakenly testing the site_history view - see the `get()` method. The workflow_history view doesn't have any filtering options, so there's nothing to test here.

(To be honest, I'm wondering if this view is even meant to exist or whether it's just a relic from before audit logs were added - it seems that the only way to get to it is Reports -> Workflows -> click on a status button -> Workflow history. All other places that might be expected to link to it go to the general Page History instead...)