### PR TITLE
Converts inline panel anchor to button to make keyboard focusable.

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -8,6 +8,7 @@ Changelog
  * Added a distinct `wagtail.copy_for_translation` log action type (Karl Hobley)
  * Fix: Delete button is now correct colour on snippets and modeladmin listings (Brandon Murch)
  * Fix: Ensure that StreamBlock / ListBlock-level validation errors are counted towards error counts (Matt Westcott)
+ * Fix: InlinePanel add button is now keyboard navigatable (Jesse Menn)
 
 
 2.14 (xx.xx.xxxx) - IN DEVELOPMENT

--- a/client/src/entrypoints/admin/expanding_formset.js
+++ b/client/src/entrypoints/admin/expanding_formset.js
@@ -20,8 +20,9 @@ function buildExpandingFormset(prefix, opts = {}) {
   }
 
   // eslint-disable-next-line consistent-return
-  addButton.on('click', () => {
+  addButton.on('click', (e) => {
     if (addButton.hasClass('disabled')) return false;
+    e.preventDefault();
     const newFormHtml = emptyFormTemplate
       .replace(/__prefix__/g, formCount)
       .replace(/<-(-*)\/script>/g, '<$1/script>');

--- a/client/src/entrypoints/admin/expanding_formset.js
+++ b/client/src/entrypoints/admin/expanding_formset.js
@@ -20,9 +20,8 @@ function buildExpandingFormset(prefix, opts = {}) {
   }
 
   // eslint-disable-next-line consistent-return
-  addButton.on('click', (e) => {
+  addButton.on('click', () => {
     if (addButton.hasClass('disabled')) return false;
-    e.preventDefault();
     const newFormHtml = emptyFormTemplate
       .replace(/__prefix__/g, formCount)
       .replace(/<-(-*)\/script>/g, '<$1/script>');

--- a/docs/releases/2.15.rst
+++ b/docs/releases/2.15.rst
@@ -23,6 +23,7 @@ Bug fixes
 
  * Delete button is now correct colour on snippets and modeladmin listings (Brandon Murch)
  * Ensure that StreamBlock / ListBlock-level validation errors are counted towards error counts (Matt Westcott)
+ * InlinePanel add button is now keyboard navigatable (Jesse Menn)
 
 Upgrade considerations
 ======================

--- a/wagtail/admin/templates/wagtailadmin/edit_handlers/inline_panel.html
+++ b/wagtail/admin/templates/wagtailadmin/edit_handlers/inline_panel.html
@@ -24,8 +24,8 @@
 </script>
 
 <p class="add">
-    <a class="button bicolor button--icon" id="id_{{ self.formset.prefix }}-ADD">
+    <button class="button bicolor button--icon" id="id_{{ self.formset.prefix }}-ADD">
         {% icon name="plus" wrapped=1 %}
         {% blocktrans with label=self.label|lower %}Add {{ label }}{% endblocktrans %}
-    </a>
+    </button>
 </p>

--- a/wagtail/admin/templates/wagtailadmin/edit_handlers/inline_panel.html
+++ b/wagtail/admin/templates/wagtailadmin/edit_handlers/inline_panel.html
@@ -24,7 +24,7 @@
 </script>
 
 <p class="add">
-    <button class="button bicolor button--icon" id="id_{{ self.formset.prefix }}-ADD">
+    <button type="button" class="button bicolor button--icon" id="id_{{ self.formset.prefix }}-ADD">
         {% icon name="plus" wrapped=1 %}
         {% blocktrans with label=self.label|lower %}Add {{ label }}{% endblocktrans %}
     </button>


### PR DESCRIPTION
This allows the InlinePanel button to be keyboard navigable and targetable with VoiceOver.

Before submitting, please review the contributor guidelines <https://docs.wagtail.io/en/latest/contributing/index.html> and check the following:

* For front-end changes: Did you test on all of [Wagtail’s supported environments](https://docs.wagtail.io/en/latest/contributing/developing.html#browser-and-device-support)?
    * **Please list the exact browser and operating system versions you tested**.
        * macOS Chrome, Firefox ESR, Safari
    * **Please list which assistive technologies you tested**.
        * VoiceOver on macOS with Safari
