### PR TITLE
Add sidebar slim state preference

### DIFF
--- a/client/src/components/Sidebar/Sidebar.stories.tsx
+++ b/client/src/components/Sidebar/Sidebar.stories.tsx
@@ -11,6 +11,7 @@ import { initFocusOutline } from '../../utils/focus';
 
 import '../../../../wagtail/admin/static/wagtailadmin/css/sidebar.css';
 import { CustomBrandingModuleDefinition } from './modules/CustomBranding';
+import { SidebarPreferences, SidebarPreferencesDefinition } from './SidebarPreferences';
 
 export default { title: 'Sidebar/Sidebar', parameters: { layout: 'fullscreen' } };
 
@@ -28,6 +29,9 @@ function wagtailBrandingModule(): WagtailBrandingModuleDefinition {
     desktopLogoEyeOpen: 'https://wagtail.io/static/wagtailadmin/images/logo-eyeopen.svg',
     desktopLogoEyeClosed: 'https://wagtail.io/static/wagtailadmin/images/logo-eyeclosed.svg'
   });
+}
+function preferencesModule(): SidebarPreferencesDefinition {
+  return new SidebarPreferencesDefinition({ collapsed: false, preferencesUrl: '#' });
 }
 
 function searchModule(): SearchModuleDefinition {
@@ -207,6 +211,8 @@ function renderSidebarStory(
     initFocusOutline();
   }, []);
 
+  const [preferences, setPreferences] = React.useState(preferencesModule());
+
   // Simulate navigation
   const [currentPath, setCurrentPath] = React.useState('/admin/');
 
@@ -237,6 +243,7 @@ function renderSidebarStory(
   return (
     <div className="wrapper">
       <Sidebar
+        preferences={preferences}
         modules={modules}
         currentPath={currentPath}
         strings={strings || STRINGS}

--- a/client/src/components/Sidebar/Sidebar.tsx
+++ b/client/src/components/Sidebar/Sidebar.tsx
@@ -3,6 +3,7 @@
 import * as React from 'react';
 
 import Icon from '../Icon/Icon';
+import { SidebarPreferences, SidebarPreferencesDefinition } from './SidebarPreferences';
 
 // Please keep in sync with $menu-transition-duration variable in `client/scss/settings/_variables.scss`
 export const SIDEBAR_TRANSITION_DURATION = 150;
@@ -30,17 +31,27 @@ export interface SidebarProps {
   modules: ModuleDefinition[];
   currentPath: string;
   strings: Strings;
+  preferences: SidebarPreferencesDefinition;
   navigate(url: string): Promise<void>;
   onExpandCollapse?(collapsed: boolean);
 }
 
 export const Sidebar: React.FunctionComponent<SidebarProps> = (
-  { modules, currentPath, strings, navigate, onExpandCollapse }) => {
+  { modules, currentPath, preferences, strings, navigate, onExpandCollapse }) => {
   // 'collapsed' is a persistent state that is controlled by the arrow icon at the top
   // It records the user's general preference for a collapsed/uncollapsed menu
   // This is just a hint though, and we may still collapse the menu if the screen is too small
   // Also, we may display the full menu temporarily in collapsed mode (see 'peeking' below)
-  const [collapsed, setCollapsed] = React.useState(window.innerWidth < 800);
+  const [collapsed, setCollapsed] = React.useState((): boolean => {
+    if (window.innerWidth < 800 || preferences.collapsed) {
+      return true;
+    }
+    return false;
+  });
+
+  const [preferencesController] = React.useState(
+    (): SidebarPreferences => new SidebarPreferences(preferences)
+  );
 
   // Call onExpandCollapse(true) if menu is initialised in collapsed state
   React.useEffect(() => {
@@ -85,6 +96,7 @@ export const Sidebar: React.FunctionComponent<SidebarProps> = (
     if (onExpandCollapse) {
       onExpandCollapse(!collapsed);
     }
+    preferencesController.update({ collapsed: !collapsed });
   };
 
   // Switch peeking on/off when the mouse cursor hovers the sidebar

--- a/client/src/components/Sidebar/SidebarPreferences.ts
+++ b/client/src/components/Sidebar/SidebarPreferences.ts
@@ -1,0 +1,33 @@
+export class SidebarPreferencesDefinition {
+    collapsed: boolean;
+    preferencesUrl: string;
+
+    constructor({ collapsed, preferencesUrl }) {
+      this.collapsed = collapsed;
+      this.preferencesUrl = preferencesUrl;
+    }
+}
+
+type UpdatableSidebarPreferences = {
+  collapsed: boolean;
+}
+
+export class SidebarPreferences extends SidebarPreferencesDefinition {
+  getCSRFToken = (): string => wagtailConfig.CSRF_TOKEN;
+
+  update = (prefs: UpdatableSidebarPreferences): void => {
+    const fetch = global.fetch;
+
+    fetch(this.preferencesUrl, {
+      method: 'POST',
+      credentials: 'include',
+      mode: 'same-origin',
+      headers: {
+        'X-CSRFToken': this.getCSRFToken(),
+        'Accept': 'application/json',
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(prefs),
+    });
+  };
+}

--- a/client/src/components/Sidebar/index.tsx
+++ b/client/src/components/Sidebar/index.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import ReactDOM from 'react-dom';
 
 import { Sidebar } from './Sidebar';
+import { SidebarPreferencesDefinition } from './SidebarPreferences';
 
 export function initSidebar() {
   const element = document.getElementById('wagtail-sidebar');
@@ -20,6 +21,12 @@ export function initSidebar() {
   if (element instanceof HTMLElement && element.dataset.props) {
     const props = window.telepath.unpack(JSON.parse(element.dataset.props));
 
+    const preferences: SidebarPreferencesDefinition = props.preferences;
+
+    if (preferences.collapsed) {
+      document.body.classList.add('sidebar-collapsed');
+    }
+
     const onExpandCollapse = (collapsed: boolean) => {
       if (collapsed) {
         document.body.classList.add('sidebar-collapsed');
@@ -33,6 +40,7 @@ export function initSidebar() {
         modules={props.modules}
         strings={wagtailConfig.STRINGS}
         currentPath={window.location.pathname}
+        preferences={preferences}
         navigate={navigate}
         onExpandCollapse={onExpandCollapse}
       />,

--- a/client/src/custom.d.ts
+++ b/client/src/custom.d.ts
@@ -26,7 +26,7 @@ declare global {
             /* eslint-disable-next-line camelcase */
             display_name: string;
         }[];
-
+        CSRF_TOKEN: string;
         STRINGS: any;
     }
     const wagtailConfig: WagtailConfig;

--- a/client/src/entrypoints/admin/sidebar.js
+++ b/client/src/entrypoints/admin/sidebar.js
@@ -7,7 +7,9 @@ import { CustomBrandingModuleDefinition } from '../../components/Sidebar/modules
 import { WagtailBrandingModuleDefinition } from '../../components/Sidebar/modules/WagtailBranding';
 import { SearchModuleDefinition } from '../../components/Sidebar/modules/Search';
 import { MainMenuModuleDefinition } from '../../components/Sidebar/modules/MainMenu';
+import { SidebarPreferencesDefinition } from '../../components/Sidebar/SidebarPreferences.ts';
 
+window.telepath.register('wagtail.sidebar.SidebarPreferences', SidebarPreferencesDefinition);
 window.telepath.register('wagtail.sidebar.LinkMenuItem', LinkMenuItemDefinition);
 window.telepath.register('wagtail.sidebar.SubMenuItem', SubMenuItemDefinition);
 window.telepath.register('wagtail.sidebar.PageExplorerMenuItem', PageExplorerMenuItemDefinition);

--- a/wagtail/admin/templates/wagtailadmin/admin_base.html
+++ b/wagtail/admin/templates/wagtailadmin/admin_base.html
@@ -35,6 +35,7 @@
             wagtailConfig.LOCALES = {{ locales|safe }};
 
             wagtailConfig.STRINGS = {% js_translation_strings %};
+            wagtailConfig.CSRF_TOKEN = '{{ csrf_token }}'
 
             wagtailConfig.ADMIN_URLS = {
                 PAGES: '{% url "wagtailadmin_explore_root" %}'

--- a/wagtail/admin/templates/wagtailadmin/base.html
+++ b/wagtail/admin/templates/wagtailadmin/base.html
@@ -3,30 +3,30 @@
 
 {% block furniture %}
     {% slim_sidebar_enabled as slim_sidebar_enabled %}
-    <aside id="wagtail-sidebar" class="nav-wrapper" {% if slim_sidebar_enabled %}data-props="{% menu_props %}"{% else %}data-nav-primary{% endif %}>
+    {% if slim_sidebar_enabled %}
+    <aside id="wagtail-sidebar" data-props="{% menu_props %}"></aside>
+    {% else %}
+    <aside id="wagtail-sidebar" class="nav-wrapper" data-nav-primary>
         <div class="inner">
             <a href="{% url 'wagtailadmin_home' %}" class="logo" aria-label="{% trans 'Dashboard' %}">
                 {% block branding_logo %}
-                    {% if not slim_sidebar_enabled %}
-                        {# Mobile-only logo: #}
-                        <div class="wagtail-logo-container__mobile u-hidden@sm">
-                            <img class="wagtail-logo wagtail-logo__full" src="{% versioned_static 'wagtailadmin/images/wagtail-logo.svg' %}" alt="" width="80" />
-                        </div>
+                    {# Mobile-only logo: #}
+                    <div class="wagtail-logo-container__mobile u-hidden@sm">
+                        <img class="wagtail-logo wagtail-logo__full" src="{% versioned_static 'wagtailadmin/images/wagtail-logo.svg' %}" alt="" width="80" />
+                    </div>
 
-                        {# Desktop logo (animated): #}
-                        {% include "wagtailadmin/shared/animated_logo.html" %}
-                    {% endif %}
+                    {# Desktop logo (animated): #}
+                    {% include "wagtailadmin/shared/animated_logo.html" %}
                 {% endblock %}
                 <span class="u-hidden@sm">{% trans "Dashboard" %}</span>
             </a>
 
-            {% if not slim_sidebar_enabled %}
-                {% menu_search %}
-                {% main_nav %}
-            {% endif %}
+            {% menu_search %}
+            {% main_nav %}
         </div>
         <div class="explorer__wrapper" data-explorer-menu></div>
     </aside>
+    {% endif %}
 
     <main class="content-wrapper" role="main" id="main">
         <div class="content">

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -15,6 +15,7 @@ from django.template.defaultfilters import stringfilter
 from django.template.loader import render_to_string
 from django.templatetags.static import static
 from django.urls import reverse
+from django.urls.base import reverse_lazy
 from django.utils import timezone
 from django.utils.encoding import force_str
 from django.utils.html import avoid_wrapping, format_html, format_html_join
@@ -28,6 +29,7 @@ from wagtail.admin.navigation import get_explorable_root_page
 from wagtail.admin.search import admin_search_areas
 from wagtail.admin.staticfiles import versioned_static as versioned_static_func
 from wagtail.admin.ui import sidebar
+from wagtail.admin.views.sidebar import SidebarPreferencesSerializer
 from wagtail.core import hooks
 from wagtail.core.models import (
     Collection, CollectionViewRestriction, Locale, Page, PageViewRestriction,
@@ -687,6 +689,14 @@ def menu_props(context):
     else:
         search_area = None
 
+    ser = SidebarPreferencesSerializer(data=request.session.get('sidebar_preferences', None))
+    ser.is_valid()
+
+    preferences = sidebar.SidebarPreferences(
+        collapsed=ser.data.get('collapsed', False),
+        preferences_url=reverse_lazy('wagtailadmin_sidebar_preferences'),
+    )
+
     account_menu = [
         sidebar.LinkMenuItem('account', _("Account"), reverse('wagtailadmin_account'), icon_name='user'),
         sidebar.LinkMenuItem('logout', _("Log out"), reverse('wagtailadmin_logout'), icon_name='logout'),
@@ -701,6 +711,7 @@ def menu_props(context):
 
     return json.dumps({
         'modules': JSContext().pack(modules),
+        'preferences': JSContext().pack(preferences),
     }, cls=DjangoJSONEncoder)
 
 

--- a/wagtail/admin/ui/sidebar.py
+++ b/wagtail/admin/ui/sidebar.py
@@ -16,6 +16,22 @@ class BaseSidebarAdapter(Adapter):
         ])
 
 
+# Preferences
+@adapter('wagtail.sidebar.SidebarPreferences', base=BaseSidebarAdapter)
+class SidebarPreferences:
+    def __init__(self, collapsed: bool, preferences_url: str):
+        self.collapsed = collapsed
+        self.preferences_url = preferences_url
+
+    def js_args(self):
+        return [
+            {
+                'collapsed': self.collapsed,
+                'preferencesUrl': self.preferences_url,
+            }
+        ]
+
+
 # Main menu
 
 class MenuItem:

--- a/wagtail/admin/urls/__init__.py
+++ b/wagtail/admin/urls/__init__.py
@@ -15,7 +15,7 @@ from wagtail.admin.urls import pages as wagtailadmin_pages_urls
 from wagtail.admin.urls import password_reset as wagtailadmin_password_reset_urls
 from wagtail.admin.urls import reports as wagtailadmin_reports_urls
 from wagtail.admin.urls import workflows as wagtailadmin_workflows_urls
-from wagtail.admin.views import account, chooser, home, tags, userbar
+from wagtail.admin.views import account, chooser, home, sidebar, tags, userbar
 from wagtail.admin.views.pages import listing
 from wagtail.core import hooks
 from wagtail.utils.urlpatterns import decorate_urlpatterns
@@ -54,6 +54,7 @@ urlpatterns = [
 
     path('account/', account.account, name='wagtailadmin_account'),
     path('logout/', account.LogoutView.as_view(), name='wagtailadmin_logout'),
+    path('sidebar/update-preferences/', sidebar.SetSidebarPreferencesView.as_view(), name='wagtailadmin_sidebar_preferences'),
 ]
 
 

--- a/wagtail/admin/views/sidebar.py
+++ b/wagtail/admin/views/sidebar.py
@@ -1,0 +1,18 @@
+from rest_framework import serializers
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+
+class SidebarPreferencesSerializer(serializers.Serializer):
+    collapsed = serializers.BooleanField(initial=False)
+
+
+class SetSidebarPreferencesView(APIView):
+    http_method_names = ['post']
+
+    def post(self, request):
+        ser = SidebarPreferencesSerializer(data=request.data)
+        ser.is_valid(raise_exception=True)
+
+        request.session['sidebar_preferences'] = ser.data
+        return Response(data=ser.data)


### PR DESCRIPTION
The slim sidebar will now remember if it is collapsed ('slim') or not when the page is loaded.

Preferences are saved in the session.

**Note:** I've added `window.wagtailConfig.CSRF_TOKEN` as an easy way to get the CSRF token. Another way would be to read the `csrftoken` cookie set by Django but that could be set to httponly, making it impossible to read from JS.