### PR TITLE
Eliminate use of re_path from integration docs

### DIFF
--- a/docs/getting_started/integrating_into_django.md
+++ b/docs/getting_started/integrating_into_django.md
@@ -66,7 +66,7 @@ Various other settings are available to configure Wagtail's behaviour - see [Set
 Now make the following additions to your `urls.py` file:
 
 ```python
-from django.urls import path, re_path, include
+from django.urls import path, include
 
 from wagtail.admin import urls as wagtailadmin_urls
 from wagtail.core import urls as wagtail_urls
@@ -90,7 +90,7 @@ The URL paths here can be altered as necessary to fit your project's URL scheme.
 `wagtail_urls` is the base location from where the pages of your Wagtail site will be served. In the above example, Wagtail will handle URLs under `/pages/`, leaving the root URL and other paths to be handled as normal by your Django project. If you want Wagtail to handle the entire URL space including the root URL, this can be replaced with:
 
 ```python
-re_path(r'', include(wagtail_urls)),
+path('', include(wagtail_urls)),
 ```
 
 In this case, this should be placed at the end of the `urlpatterns` list, so that it does not override more specific URL patterns.


### PR DESCRIPTION
Using `re_path` for the page serve view is unnecessary (the project template doesn't do it) and will be increasingly unfamiliar to new Django devs as `path` becomes more widespread.
