### PR TITLE
Add a log action for copy_for_translation operation

### DIFF
--- a/docs/advanced_topics/audit_log.rst
+++ b/docs/advanced_topics/audit_log.rst
@@ -71,6 +71,7 @@ Action                               Notes
 ``wagtail.rename``                   A page was renamed
 ``wagtail.revert``                   The page was reverted to a previous draft
 ``wagtail.copy``                     The page was copied to a new location
+``wagtail.copy_for_translation``     The page was copied into a new locale for translation
 ``wagtail.move``                     The page was moved to a new location
 ``wagtail.reorder``                  The order of the page under it's parent was changed
 ``wagtail.view_restriction.create``  The page was restricted

--- a/wagtail/core/models/__init__.py
+++ b/wagtail/core/models/__init__.py
@@ -1681,11 +1681,19 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
                 data={
                     'page': {
                         'id': page_copy.id,
-                        'title': page_copy.get_admin_display_title()
+                        'title': page_copy.get_admin_display_title(),
+                        'locale': {
+                            'id': page_copy.locale_id,
+                            'language_code': page_copy.locale.language_code
+                        }
                     },
                     'source': {'id': parent.id, 'title': parent.specific_deferred.get_admin_display_title()} if parent else None,
                     'destination': {'id': to.id, 'title': to.specific_deferred.get_admin_display_title()} if to else None,
-                    'keep_live': page_copy.live and keep_live
+                    'keep_live': page_copy.live and keep_live,
+                    'source_locale': {
+                        'id': self.locale_id,
+                        'language_code': self.locale.language_code
+                    }
                 },
             )
             if page_copy.live and keep_live:
@@ -1942,6 +1950,7 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
                 reset_translation_key=False,
                 process_child_object=process_child_object,
                 exclude_fields=exclude_fields,
+                log_action='wagtail.copy_for_translation',
             )
 
     copy_for_translation.alters_data = True

--- a/wagtail/core/wagtail_hooks.py
+++ b/wagtail/core/wagtail_hooks.py
@@ -9,6 +9,7 @@ from django.utils.translation import ngettext
 from wagtail.core import hooks
 from wagtail.core.models import PageViewRestriction
 from wagtail.core.rich_text.pages import PageLinkHandler
+from wagtail.core.utils import get_content_languages
 
 
 def require_wagtail_login(next):
@@ -126,6 +127,15 @@ def register_core_log_actions(actions):
             }
         except KeyError:
             return _("Copied")
+
+    def copy_for_translation_message(data):
+        try:
+            return _('Copied for translation from %(title)s (%(locale)s)') % {
+                'title': data['source']['title'],
+                'locale': get_content_languages().get(data['source_locale']['language_code']) or '',
+            }
+        except KeyError:
+            return _("Copied for translation")
 
     def create_alias_message(data):
         try:
@@ -312,6 +322,7 @@ def register_core_log_actions(actions):
     actions.register_action('wagtail.rename', _('Rename'), rename_message)
     actions.register_action('wagtail.revert', _('Revert'), revert_message)
     actions.register_action('wagtail.copy', _('Copy'), copy_message)
+    actions.register_action('wagtail.copy_for_translation', _('Copy for translation'), copy_for_translation_message)
     actions.register_action('wagtail.create_alias', _('Create alias'), create_alias_message)
     actions.register_action('wagtail.convert_alias', _('Convert alias into ordinary page'), convert_alias_message)
     actions.register_action('wagtail.move', _('Move'), move_message)


### PR DESCRIPTION
Currently, when a user copies a page for translation, the 'copy' log action is used.

This adds a more specific 'copy_for_translation' operation to be used instead when the user is translating.