### PR TITLE
Change `master` to `main` (in more places)

### DIFF
--- a/docs/advanced_topics/api/index.rst
+++ b/docs/advanced_topics/api/index.rst
@@ -7,7 +7,7 @@ content as raw field data. This is useful for cases like serving content to
 non-web clients (such as a mobile phone app) or pulling content out of Wagtail
 for use in another site.
 
-See `RFC 8: Wagtail API <https://github.com/wagtail/rfcs/blob/master/text/008-wagtail-api.md#12---stable-and-unstable-versions>`_
+See `RFC 8: Wagtail API <https://github.com/wagtail/rfcs/blob/main/text/008-wagtail-api.md#12---stable-and-unstable-versions>`_
 for full details on our stabilisation policy.
 
 .. toctree::

--- a/docs/releases/1.8.rst
+++ b/docs/releases/1.8.rst
@@ -221,4 +221,4 @@ As ``connection_class`` needs to be passed through to the Elasticsearch connecto
         }
     }
 
-.. _connector: https://elasticsearch-py.readthedocs.io/en/master/api.html#elasticsearch
+.. _connector: https://elasticsearch-py.readthedocs.io/en/5.0.0/api.html#elasticsearch

--- a/wagtail/admin/rich_text/converters/editor_html.py
+++ b/wagtail/admin/rich_text/converters/editor_html.py
@@ -120,7 +120,7 @@ class EditorHTMLConverter:
             rule = feature_registry.get_converter_rule('editorhtml', feature)
             if rule is not None:
                 # rule should be a list of WhitelistRule() instances - append this to
-                # the master converter_rules list
+                # the main converter_rules list
                 self.converter_rules.extend(rule)
 
     @cached_property

--- a/wagtail/contrib/redirects/base_formats.py
+++ b/wagtail/contrib/redirects/base_formats.py
@@ -23,7 +23,7 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
-# https://raw.githubusercontent.com/django-import-export/django-import-export/master/import_export/formats/base_formats.py
+# https://raw.githubusercontent.com/django-import-export/django-import-export/main/import_export/formats/base_formats.py
 from importlib import import_module
 
 import tablib

--- a/wagtail/contrib/redirects/middleware.py
+++ b/wagtail/contrib/redirects/middleware.py
@@ -30,7 +30,7 @@ def get_redirect(request, path):
     return redirect
 
 
-# Originally pinched from: https://github.com/django/django/blob/master/django/contrib/redirects/middleware.py
+# Originally pinched from: https://github.com/django/django/blob/main/django/contrib/redirects/middleware.py
 class RedirectMiddleware(MiddlewareMixin):
     def process_response(self, request, response):
         # No need to check for a redirect for non-404 responses.

--- a/wagtail/core/blocks/base.py
+++ b/wagtail/core/blocks/base.py
@@ -432,7 +432,7 @@ class BoundBlock:
 class DeclarativeSubBlocksMetaclass(BaseBlock):
     """
     Metaclass that collects sub-blocks declared on the base classes.
-    (cheerfully stolen from https://github.com/django/django/blob/master/django/forms/forms.py)
+    (cheerfully stolen from https://github.com/django/django/blob/main/django/forms/forms.py)
     """
     def __new__(mcs, name, bases, attrs):
         # Collect sub-blocks declared on the current class.


### PR DESCRIPTION
More places have changed their `master` branch to be called `main`! I've updated some things accordingly (and changed two other avoidable instances of `master`.