### PR TITLE
Set default_auto_field on simple_translation app config

### DIFF
--- a/wagtail/contrib/simple_translation/apps.py
+++ b/wagtail/contrib/simple_translation/apps.py
@@ -6,3 +6,4 @@ class SimpleTranslationAppConfig(AppConfig):
     name = "wagtail.contrib.simple_translation"
     label = "simple_translation"
     verbose_name = _("Wagtail simple translation")
+    default_auto_field = 'django.db.models.AutoField'


### PR DESCRIPTION
Prevents the warning "simple_translation.SimpleTranslation: (models.W042) Auto-created primary key used when not defining a primary key type, by default 'django.db.models.AutoField'." when running under Django 3.2.
