### PR TITLE
Replace is_safe_url with url_has_allowed_host_and_scheme

### DIFF
--- a/wagtail/admin/views/pages/lock.py
+++ b/wagtail/admin/views/pages/lock.py
@@ -1,7 +1,7 @@
 from django.core.exceptions import PermissionDenied
 from django.shortcuts import get_object_or_404, redirect
 from django.utils import timezone
-from django.utils.http import is_safe_url
+from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.translation import gettext as _
 from django.views.decorators.http import require_POST
 
@@ -26,7 +26,7 @@ def lock(request, page_id):
 
     # Redirect
     redirect_to = request.POST.get('next', None)
-    if redirect_to and is_safe_url(url=redirect_to, allowed_hosts={request.get_host()}):
+    if redirect_to and url_has_allowed_host_and_scheme(url=redirect_to, allowed_hosts={request.get_host()}):
         return redirect(redirect_to)
     else:
         return redirect('wagtailadmin_explore', page.get_parent().id)
@@ -52,7 +52,7 @@ def unlock(request, page_id):
 
     # Redirect
     redirect_to = request.POST.get('next', None)
-    if redirect_to and is_safe_url(url=redirect_to, allowed_hosts={request.get_host()}):
+    if redirect_to and url_has_allowed_host_and_scheme(url=redirect_to, allowed_hosts={request.get_host()}):
         return redirect(redirect_to)
     else:
         return redirect('wagtailadmin_explore', page.get_parent().id)

--- a/wagtail/admin/views/pages/utils.py
+++ b/wagtail/admin/views/pages/utils.py
@@ -1,8 +1,8 @@
-from django.utils.http import is_safe_url
+from django.utils.http import url_has_allowed_host_and_scheme
 
 
 def get_valid_next_url_from_request(request):
     next_url = request.POST.get('next') or request.GET.get('next')
-    if not next_url or not is_safe_url(url=next_url, allowed_hosts={request.get_host()}):
+    if not next_url or not url_has_allowed_host_and_scheme(url=next_url, allowed_hosts={request.get_host()}):
         return ''
     return next_url

--- a/wagtail/admin/views/pages/workflow.py
+++ b/wagtail/admin/views/pages/workflow.py
@@ -2,7 +2,7 @@ from django.conf import settings
 from django.core.exceptions import PermissionDenied
 from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse
-from django.utils.http import is_safe_url
+from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.translation import gettext as _
 from django.views.decorators.http import require_GET
 from django.views.generic import View
@@ -24,7 +24,7 @@ class BaseWorkflowFormView(View):
         self.action_name = action_name
 
         self.redirect_to = request.POST.get('next', None)
-        if not self.redirect_to or not is_safe_url(url=self.redirect_to, allowed_hosts={request.get_host()}):
+        if not self.redirect_to or not url_has_allowed_host_and_scheme(url=self.redirect_to, allowed_hosts={request.get_host()}):
             self.redirect_to = reverse('wagtailadmin_pages:edit', args=[page_id])
 
         if not self.page.workflow_in_progress:

--- a/wagtail/admin/views/workflows.py
+++ b/wagtail/admin/views/workflows.py
@@ -8,7 +8,7 @@ from django.shortcuts import get_object_or_404, redirect, render
 from django.template.response import TemplateResponse
 from django.urls import reverse
 from django.utils.functional import cached_property
-from django.utils.http import is_safe_url
+from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.translation import gettext_lazy as _
 from django.utils.translation import ngettext
 from django.views.decorators.http import require_POST
@@ -269,7 +269,7 @@ def enable_workflow(request, pk):
 
     # Redirect
     redirect_to = request.POST.get('next', None)
-    if redirect_to and is_safe_url(url=redirect_to, allowed_hosts={request.get_host()}):
+    if redirect_to and url_has_allowed_host_and_scheme(url=redirect_to, allowed_hosts={request.get_host()}):
         return redirect(redirect_to)
     else:
         return redirect('wagtailadmin_workflows:edit', workflow.id)
@@ -294,7 +294,7 @@ def remove_workflow(request, page_pk, workflow_pk=None):
 
     # Redirect
     redirect_to = request.POST.get('next', None)
-    if redirect_to and is_safe_url(url=redirect_to, allowed_hosts={request.get_host()}):
+    if redirect_to and url_has_allowed_host_and_scheme(url=redirect_to, allowed_hosts={request.get_host()}):
         return redirect(redirect_to)
     else:
         return redirect('wagtailadmin_explore', page.id)
@@ -482,7 +482,7 @@ def enable_task(request, pk):
 
     # Redirect
     redirect_to = request.POST.get('next', None)
-    if redirect_to and is_safe_url(url=redirect_to, allowed_hosts={request.get_host()}):
+    if redirect_to and url_has_allowed_host_and_scheme(url=redirect_to, allowed_hosts={request.get_host()}):
         return redirect(redirect_to)
     else:
         return redirect('wagtailadmin_workflows:edit_task', task.id)


### PR DESCRIPTION
As per https://docs.djangoproject.com/en/3.2/releases/3.0/#id3 - is_safe_url was deprecated in Django 3.0 (which is now the minimum version supported by Wagtail).
