### PR TITLE
Ensure error count badge counts StreamField non-block errors

### DIFF
--- a/client/src/entrypoints/admin/page-editor.js
+++ b/client/src/entrypoints/admin/page-editor.js
@@ -222,7 +222,7 @@ function initErrorDetection() {
 
   // first count up all the errors
   // eslint-disable-next-line func-names
-  $('.error-message').each(function () {
+  $('.error-message,.help-critical').each(function () {
     const parentSection = $(this).closest('section');
 
     if (!errorSections[parentSection.attr('id')]) {


### PR DESCRIPTION
Fixes #7353

The error counter was only counting elements with class error-message, but non-block errors on ListBlock / StreamBlock use a different styling, help-critical.

(For the record, I've checked that the uses of help-critical elsewhere in the codebase are also error messages, so this selector isn't being over-broad. Although hypothetically if there were any items that weren't actual error messages but warranted an "it's critically important that you read this advice" class, flagging them up via the badge is probably the right thing anyway...)