### PR TITLE
Allow subclasses of PagesAPIViewSet override default Page model.

### DIFF
--- a/wagtail/api/v2/views.py
+++ b/wagtail/api/v2/views.py
@@ -441,7 +441,7 @@ class PagesAPIViewSet(BaseAPIViewSet):
         parent pages when using the child_of and descendant_of filters as well.
         """
         # Get live pages that are not in a private section
-        queryset = Page.objects.all().public().live()
+        queryset = self.model.objects.all().public().live()
 
         # Filter by site
         site = Site.find_for_request(self.request)
@@ -465,7 +465,8 @@ class PagesAPIViewSet(BaseAPIViewSet):
 
         # Allow pages to be filtered to a specific type
         try:
-            models = page_models_from_string(request.GET.get('type', 'wagtailcore.Page'))
+            models_type = request.GET.get('type', None)
+            models = models_type and page_models_from_string(models_type) or []
         except (LookupError, ValueError):
             raise BadRequestError("type doesn't exist")
 


### PR DESCRIPTION
I wanted to create an API endpoint with custom filtering for a specific page type. I thought the easiest would be to subclass `PagesAPIViewSet` - the only problem is that it would always use `Page` object even when overriding `get_base_queryset` or setting the `model` attribute.

imho it is also sub-optimal that when no `type` GET parameter is given, it still dynamically looks up `wagtailcore.Page` - imho this created a completely unused code fragment, because i don't see how `page_models_from_string(request.GET.get('type', 'wagtailcore.Page'))` could possibly return an False/empty value in the current implementation.
