### PR TITLE
Ensure admin tab events are handled on page load

### DIFF
--- a/client/src/entrypoints/admin/core.js
+++ b/client/src/entrypoints/admin/core.js
@@ -295,6 +295,16 @@ $(() => {
     $(this).closest('li').removeClass('focused');
   });
 
+  /* Functions that need to run/rerun when active tabs are changed */
+  $(document).on('shown.bs.tab', () => {
+    // Resize autosize textareas
+    // eslint-disable-next-line func-names
+    $('textarea[data-autosize-on]').each(function () {
+      // eslint-disable-next-line no-undef
+      autosize.update($(this).get());
+    });
+  });
+
   /* tabs */
   const showTab = (tabButtonElem) => {
     $(tabButtonElem).tab('show');
@@ -418,16 +428,6 @@ $(() => {
       return '';
     };
   }
-
-  /* Functions that need to run/rerun when active tabs are changed */
-  $(document).on('shown.bs.tab', () => {
-    // Resize autosize textareas
-    // eslint-disable-next-line func-names
-    $('textarea[data-autosize-on]').each(function () {
-      // eslint-disable-next-line no-undef
-      autosize.update($(this).get());
-    });
-  });
 
   /* Debounce submission of long-running forms and add spinner to give sense of activity */
   // eslint-disable-next-line func-names


### PR DESCRIPTION
The `shown.bs.tab` event was being bound after showTab() was already called, so on page load, the tabs weren't being updated correctly.