### PR TITLE
Make chooser convert external to internal links

### DIFF
--- a/client/src/entrypoints/admin/page-chooser-modal.js
+++ b/client/src/entrypoints/admin/page-chooser-modal.js
@@ -179,5 +179,19 @@ const PAGE_CHOOSER_MODAL_ONLOAD_HANDLERS = {
     modal.respond('pageChosen', jsonData.result);
     modal.close();
   },
+  confirm_external_to_internal(modal, jsonData) {
+    // eslint-disable-next-line func-names, prefer-arrow-callback
+    $('[data-action-confirm]', modal.body).on('click', function () {
+      modal.respond('pageChosen', jsonData.internal);
+      modal.close();
+      return false;
+    });
+    // eslint-disable-next-line func-names, prefer-arrow-callback
+    $('[data-action-deny]', modal.body).on('click', function () {
+      modal.respond('pageChosen', jsonData.external);
+      modal.close();
+      return false;
+    });
+  },
 };
 window.PAGE_CHOOSER_MODAL_ONLOAD_HANDLERS = PAGE_CHOOSER_MODAL_ONLOAD_HANDLERS;

--- a/docs/reference/settings.rst
+++ b/docs/reference/settings.rst
@@ -826,6 +826,19 @@ Customise the behaviour of rich text fields. By default, ``RichTextField`` and `
 
 If a ``'default'`` editor is not specified, rich text fields that do not specify an ``editor`` argument will use the Draftail editor with the default feature set enabled.
 
+``WAGTAILADMIN_EXTERNAL_LINK_CONVERSION``
+-----------------------------------------
+
+.. code-block:: python
+
+    WAGTAILADMIN_EXTERNAL_LINK_CONVERSION = 'exact'
+
+Customise Wagtail's behaviour when an internal page url is entered in the external link chooser. Possible values for this setting are
+``'all'``, ``'exact'``, ``'confirm``, or ``''``. The default, ``'all'``, means that Wagtail will automatically convert submitted urls that exactly match
+page urls to the corresponding internal links. If the url is an inexact match - for example, the submitted url has query parameters - then
+Wagtail will confirm the conversion with the user. ``'exact'`` means that any inexact matches will be left as external urls, and the confirmation
+step will be skipped. ``'confirm'`` means that every link conversion will be confirmed with the user, even if the match is exact. ``''``  means
+that Wagtail will not attempt to convert any urls entered to internal page links.
 
 .. _WAGTAILADMIN_GLOBAL_PAGE_EDIT_LOCK:
 

--- a/wagtail/admin/templates/wagtailadmin/chooser/confirm_external_to_internal.html
+++ b/wagtail/admin/templates/wagtailadmin/chooser/confirm_external_to_internal.html
@@ -1,0 +1,21 @@
+{% load i18n wagtailadmin_tags %}
+{% trans "Convert to internal link" as convert_str %}
+{% include "wagtailadmin/shared/header.html" with title=convert_str %}
+
+<div class="nice-padding">
+        <p>
+            {% blocktrans %}
+                The URL you entered, <a target="_blank" rel="noreferrer noopener" href="{{ submitted_url }}">{{ submitted_url }}</a>,
+                looks like it matches the internal page {{ page }}, which has the URL
+                <a target="_blank" rel="noreferrer noopener" href="{{ internal_url }}">{{ internal_url }}</a>.
+            {% endblocktrans %}
+        </p>
+        <p>
+            {% blocktrans %}
+                Converting this to an internal link to {{ page }} would make the link more robust.
+                Would you like to do this?
+            {% endblocktrans %}
+        </p>
+    <button type="button" data-action-confirm class="button button-primary">{% trans 'Convert to internal link' %}</button>
+    <button type="button" data-action-deny class="button button-secondary">{% trans 'Use external link' %}</button>
+</div>


### PR DESCRIPTION
This PR adds the ability for the external link chooser to detect when a url entered matches a page. As internal links are more stable than external (they won't break when pages are moved or renamed), any identical matches are converted to internal links automatically.

However, currently we don't have any way of appending query, fragment links, or routable page parameters to urls. If a link matches a page but not exactly - ie with extra information - the conversion is confirmed explicitly with the user.

(In the future, it would be good if we could include this information directly in an internal link rather than needing to keep these sorts as external, but that change will need more discussion as to how exactly we do this, and expose this functionality in the internal chooser - ie an extra field for query parameters?)