### PR TITLE
Add object count to modeladmin

### DIFF
--- a/wagtail/contrib/modeladmin/static_src/wagtailmodeladmin/scss/index.scss
+++ b/wagtail/contrib/modeladmin/static_src/wagtailmodeladmin/scss/index.scss
@@ -5,14 +5,19 @@
 }
 
 .result-count {
+    display: block;
     font-weight: 500;
-    margin-left: 0.25em;
 
     &:before {
         content: "(";
     }
     &:after {
         content: ")";
+    }
+    
+    @include media-breakpoint-up(lg) {
+        display: inline-block;
+        margin-left: 0.25em;        
     }
 }
 

--- a/wagtail/contrib/modeladmin/static_src/wagtailmodeladmin/scss/index.scss
+++ b/wagtail/contrib/modeladmin/static_src/wagtailmodeladmin/scss/index.scss
@@ -6,7 +6,8 @@
 
 .result-count {
     font-weight: 500;
-    
+    margin-left: 0.25em;
+
     &:before {
         content: "(";
     }

--- a/wagtail/contrib/modeladmin/static_src/wagtailmodeladmin/scss/index.scss
+++ b/wagtail/contrib/modeladmin/static_src/wagtailmodeladmin/scss/index.scss
@@ -9,15 +9,16 @@
     font-weight: 500;
 
     &:before {
-        content: "(";
+        content: '(';
     }
+
     &:after {
-        content: ")";
+        content: ')';
     }
-    
+
     @include media-breakpoint-up(lg) {
         display: inline-block;
-        margin-left: 0.25em;        
+        margin-left: 0.25em;
     }
 }
 

--- a/wagtail/contrib/modeladmin/static_src/wagtailmodeladmin/scss/index.scss
+++ b/wagtail/contrib/modeladmin/static_src/wagtailmodeladmin/scss/index.scss
@@ -4,6 +4,16 @@
     margin-bottom: 0;
 }
 
+.result-count {
+    font-weight: 500;
+    
+    &:before {
+        content: "(";
+    }
+    &:after {
+        content: ")";
+    }
+}
 
 .result-list {
     margin-bottom: 0;

--- a/wagtail/contrib/modeladmin/templates/modeladmin/includes/result_count.html
+++ b/wagtail/contrib/modeladmin/templates/modeladmin/includes/result_count.html
@@ -1,0 +1,4 @@
+{% load i18n %}
+{% block result_count %}
+<span class="result-count">{{ result_count }} {% trans "out of" %} {{ all_count }}</span>
+{% endblock %}

--- a/wagtail/contrib/modeladmin/templates/modeladmin/index.html
+++ b/wagtail/contrib/modeladmin/templates/modeladmin/index.html
@@ -16,15 +16,20 @@
 {% block content %}
     {% block header %}
         <header class="nice-padding hasform">
-            <div class="row header-title">
-                <div class="left">
-                    <div class="col">
-                        {% block h1 %}<h1 {% if view.header_icon %}class="icon icon-{{ view.header_icon }}"{% endif %}>{{ view.get_page_title }}<span></span></h1>{% endblock %}
+            <div class="row">
+                <div class="left header-left">
+                    <div class="col header-title">
+                        {% block h1 %}
+                        <h1 {% if view.header_icon %}class="icon icon-{{ view.header_icon }}"{% endif %}>
+                            {{ view.get_page_title }}
+                            {% include 'modeladmin/includes/result_count.html' %}<span></span>
+                        </h1>
+                        {% endblock %}
                     </div>
                     {% block search %}{% search_form %}{% endblock %}
                 </div>
                 {% block header_extra %}
-                    <div class="right">
+                    <div class="right header-right">
                         {% if user_can_create %}
                             <div class="actionbutton">
                                 {% include 'modeladmin/includes/button.html' with button=view.button_helper.add_button %}
@@ -46,7 +51,7 @@
     {% endblock %}
 
     {% block content_main %}
-        <div>
+        <div class="main-content">
             <div class="row">
                 {% block content_cols %}
 


### PR DESCRIPTION
Adds object counts _(# out of ##)_ to the modeladmin for custom models.

**Desktop:**
![Screen Shot 2021-07-31 at 10 49 01 AM](https://user-images.githubusercontent.com/104602/127743709-1e520b86-58a0-4362-8c29-1acd8831d73d.png)

**Mobile:**
![Screen Shot 2021-07-31 at 10 49 20 AM](https://user-images.githubusercontent.com/104602/127743710-7deb8b39-fd14-4619-b654-41078101b7da.png)

**Tested in:**
Chrome 92.0.4515.107 (and using smaller device sizes)
Safari 14.1.1 (16611.2.7.1.4)

**Note:** Does *not* include object counts for pages, documents, images, or snippets (or other models that have their own views+templates.
