### PR TITLE
Add a style fallback to avoid invalid inline styles

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -29,6 +29,7 @@ Changelog
  * Fix: `blocks.MultipleChoiceBlock`, `forms.CheckboxSelectMultiple` and `ArrayField` checkboxes will now stack instead of display inline to align with all other checkboxes fields (Seb Brown)
  * Fix: Screen readers can now access login screen field labels (Amy Chan)
  * Fix: Admin breadcrumbs home icon now shows for users with access to a subtree only (Stefan Hammer)
+ * Fix: Add handling of invalid inline styles submitted to `RichText` so `ConfigException` is not thrown (Alex Tomkins)
 
 
 2.14.1 (12.08.2021)

--- a/docs/releases/2.15.rst
+++ b/docs/releases/2.15.rst
@@ -44,6 +44,7 @@ Bug fixes
  * ``blocks.MultipleChoiceBlock``, ``forms.CheckboxSelectMultiple`` and ``ArrayField`` checkboxes will now stack instead of display inline to align with all other checkboxes fields (Seb Brown)
  * Screen readers can now access login screen field labels (Amy Chan)
  * Admin breadcrumbs home icon now shows for users with access to a subtree only (Stefan Hammer)
+ * Add handling of invalid inline styles submitted to ``RichText`` so ``ConfigException`` is not thrown (Alex Tomkins)
 
 Upgrade considerations
 ======================

--- a/wagtail/admin/rich_text/converters/contentstate.py
+++ b/wagtail/admin/rich_text/converters/contentstate.py
@@ -47,6 +47,12 @@ def entity_fallback(props):
     return None
 
 
+def style_fallback(props):
+    type_ = props['inline_style_range']['style']
+    logging.warn('Missing config for "%s". Deleting style.' % type_)
+    return props['children']
+
+
 def persist_key_for_block(config):
     # For any block level element config for draft js exporter, return a config that retains the
     # block key in a data attribute
@@ -90,7 +96,9 @@ class ContentstateConverter():
                 'atomic': render_children,
                 'fallback': block_fallback,
             },
-            'style_map': {},
+            'style_map': {
+                'FALLBACK': style_fallback,
+            },
             'entity_decorators': {
                 'FALLBACK': entity_fallback,
             },

--- a/wagtail/admin/tests/test_contentstate.py
+++ b/wagtail/admin/tests/test_contentstate.py
@@ -1036,3 +1036,21 @@ class TestContentStateToHtml(TestCase):
             <p data-block-key='00000'>Hello world!</p>
             <p data-block-key='00001'>Goodbye world!</p>
             ''')
+
+    def test_style_fallback(self):
+        # Test a block which uses an invalid inline style, and will be removed
+        converter = ContentstateConverter(features=[])
+        result = converter.to_database_format(json.dumps({
+            'entityMap': {},
+            'blocks': [
+                {
+                    'inlineStyleRanges': [{'offset': 0, 'length': 12, 'style': 'UNDERLINE'}],
+                    'text': 'Hello world!', 'depth': 0, 'type': 'unstyled', 'key': '00000', 'entityRanges': []
+                },
+            ]
+        }))
+        self.assertHTMLEqual(result, '''
+            <p data-block-key="00000">
+                Hello world!
+            </p>
+        ''')


### PR DESCRIPTION
Closes #7387

This is mostly copying the behaviour of https://github.com/springload/draftjs_exporter/blob/v2.1.7/example.py#L130 - if an inline style has been added which isn't valid with the site configuration, then the style will be dropped and the contents will be kept.

To test:

- Try and hack in an underline block (similar to #7387)
- A couple of warnings will appear on save:
```
WARNING:root:Missing config for "UNDERLINE". Deleting style.
WARNING:root:Missing config for "UNDERLINE". Deleting style.
[01/Aug/2021 21:42:01] "POST /admin/pages/4/edit/ HTTP/1.1" 302 0
```
- Content will appear without inline style:
<img width="1122" alt="Screenshot 2021-08-01 at 22 42 51" src="https://user-images.githubusercontent.com/177332/127786152-39bd65aa-a3ac-4abe-b0d0-bba7a9df9140.png">
