### PR TITLE
Add a debug logger around rendition generation

### DIFF
--- a/wagtail/images/models.py
+++ b/wagtail/images/models.py
@@ -1,5 +1,7 @@
 import hashlib
+import logging
 import os.path
+import time
 
 from collections import OrderedDict
 from contextlib import contextmanager
@@ -27,6 +29,9 @@ from wagtail.images.image_operations import FilterOperation, ImageTransform, Tra
 from wagtail.images.rect import Rect
 from wagtail.search import index
 from wagtail.search.queryset import SearchableQuerySetMixin
+
+
+LOGGER = logging.getLogger("wagtail.images")
 
 
 class SourceImageIOError(IOError):
@@ -303,7 +308,23 @@ class AbstractImage(CollectionMember, index.Indexed, models.Model):
             )
         except Rendition.DoesNotExist:
             # Generate the rendition image
-            generated_image = filter.run(self, BytesIO())
+            try:
+                LOGGER.debug("Generating '%s' rendition for image %d", (
+                    filter.spec,
+                    self.pk,
+                ))
+
+                start_time = time.time()
+                generated_image = filter.run(self, BytesIO())
+
+                LOGGER.debug("Generated '%s' rendition for image %d in %.1fms", (
+                    filter.spec,
+                    self.pk,
+                    (time.time() - start_time) * 1000
+                ))
+            except:  # noqa:B901,E722
+                LOGGER.debug("Failed to generate '%s' rendition for image %d: %s", filter.spec, self.pk)
+                raise
 
             # Generate filename
             input_filename = os.path.basename(self.file.name)

--- a/wagtail/images/models.py
+++ b/wagtail/images/models.py
@@ -31,7 +31,7 @@ from wagtail.search import index
 from wagtail.search.queryset import SearchableQuerySetMixin
 
 
-LOGGER = logging.getLogger("wagtail.images")
+logger = logging.getLogger("wagtail.images")
 
 
 class SourceImageIOError(IOError):
@@ -309,7 +309,7 @@ class AbstractImage(CollectionMember, index.Indexed, models.Model):
         except Rendition.DoesNotExist:
             # Generate the rendition image
             try:
-                LOGGER.debug("Generating '%s' rendition for image %d", (
+                logger.debug("Generating '%s' rendition for image %d", (
                     filter.spec,
                     self.pk,
                 ))
@@ -317,13 +317,13 @@ class AbstractImage(CollectionMember, index.Indexed, models.Model):
                 start_time = time.time()
                 generated_image = filter.run(self, BytesIO())
 
-                LOGGER.debug("Generated '%s' rendition for image %d in %.1fms", (
+                logger.debug("Generated '%s' rendition for image %d in %.1fms", (
                     filter.spec,
                     self.pk,
                     (time.time() - start_time) * 1000
                 ))
             except:  # noqa:B901,E722
-                LOGGER.debug("Failed to generate '%s' rendition for image %d: %s", filter.spec, self.pk)
+                logger.debug("Failed to generate '%s' rendition for image %d: %s", filter.spec, self.pk)
                 raise
 
             # Generate filename


### PR DESCRIPTION
This allows insight into which images are taking the longest to generate, which fail to render at all, and potentially which images are causing crashes (as in they start, but never stop).

The logging is intentionally only on DEBUG level, so it's opt-in, and is also reasonably quiet so it doesn't bloat logs.

Relevant Slack discussion: https://wagtailcms.slack.com/archives/C023WG6FB7C/p1627922996003600.