### PR TITLE
Fix session key generation for wagtail previews

### DIFF
--- a/wagtail/admin/tests/pages/test_preview.py
+++ b/wagtail/admin/tests/pages/test_preview.py
@@ -112,6 +112,10 @@ class TestPreview(TestCase, WagtailTestUtils):
         self.assertEqual(response.status_code, 200)
         self.assertJSONEqual(response.content.decode(), {'is_valid': True})
 
+        # Check the user can refresh the preview
+        preview_session_key = 'wagtail-preview-tests-eventpage-{}'.format(self.home_page.id)
+        self.assertTrue(preview_session_key in self.client.session)
+
         response = self.client.get(preview_url)
 
         # Check the HTML response
@@ -129,6 +133,10 @@ class TestPreview(TestCase, WagtailTestUtils):
         # Check the JSON response
         self.assertEqual(response.status_code, 200)
         self.assertJSONEqual(response.content.decode(), {'is_valid': True})
+
+        # Check the user can refresh the preview
+        preview_session_key = 'wagtail-preview-{}'.format(self.event_page.id)
+        self.assertTrue(preview_session_key in self.client.session)
 
         response = self.client.get(preview_url)
 

--- a/wagtail/admin/views/pages/preview.py
+++ b/wagtail/admin/views/pages/preview.py
@@ -41,7 +41,7 @@ class PreviewOnEdit(View):
 
     @property
     def session_key(self):
-        return self.session_key_prefix + ','.join(self.args)
+        return '{}{}'.format(self.session_key_prefix, self.kwargs['page_id'])
 
     def get_page(self):
         return get_object_or_404(Page,
@@ -93,6 +93,15 @@ class PreviewOnEdit(View):
 
 
 class PreviewOnCreate(PreviewOnEdit):
+    @property
+    def session_key(self):
+        return '{}{}-{}-{}'.format(
+            self.session_key_prefix,
+            self.kwargs['content_type_app_name'],
+            self.kwargs['content_type_model_name'],
+            self.kwargs['parent_page_id'],
+        )
+
     def get_page(self):
         content_type_app_name = self.kwargs["content_type_app_name"]
         content_type_model_name = self.kwargs["content_type_model_name"]


### PR DESCRIPTION
Closes #7392

To test:

- Try and preview the creation of two different page types and refresh the preview pages
- Repeat the same for previewing an edit of a page

Preview session keys will now be unique again.