### PR TITLE
Fix bug that caused disconnect between ui and javascipt state in bulk action confirmation cancel

### DIFF
--- a/client/src/entrypoints/admin/bulk-actions.js
+++ b/client/src/entrypoints/admin/bulk-actions.js
@@ -168,6 +168,7 @@ function onClickActionButton(e) {
  * Adds all event listeners
  */
 function addBulkActionListeners() {
+  const changeEvent = new Event('change');
   document.querySelectorAll(`${BULK_ACTION_PAGE_CHECKBOX_INPUT}`)
     .forEach(el => {
       checkedState.numObjects++;
@@ -185,6 +186,12 @@ function addBulkActionListeners() {
   const selectAllInListingText = document.querySelector(`${BULK_ACTION_NUM_OBJECTS_IN_LISTING}`);
   if (selectAllInListingText) selectAllInListingText.addEventListener('click', onClickSelectAllInListing);
   else checkedState.shouldShowAllInListingText = false;
+  document.querySelectorAll(`${BULK_ACTION_PAGE_CHECKBOX_INPUT}`)
+    .forEach(el => {
+      if (el.checked) {
+        el.dispatchEvent(changeEvent);
+      }
+    });
 }
 
-addBulkActionListeners();
+window.addEventListener('load', addBulkActionListeners);


### PR DESCRIPTION
When using the navigate back button of the browser to cancel a bulk action from the confirmation page, the user landed on the previous page with the objects still checked, but the javascript state would be empty. This pr fixes this issue

## Before
https://user-images.githubusercontent.com/40872556/128392403-ca6d7f3e-0d3e-4300-916a-84a87fd9dac1.mp4

## After
https://user-images.githubusercontent.com/40872556/128392463-bc229769-384b-4824-a6ff-444b6e852ca8.mp4