### PR TITLE
Namespace data attributes for bulk actions

### DIFF
--- a/client/src/entrypoints/admin/bulk-actions.js
+++ b/client/src/entrypoints/admin/bulk-actions.js
@@ -2,11 +2,11 @@
 
 const BULK_ACTION_PAGE_CHECKBOX_INPUT = '[data-bulk-action-checkbox]';
 const BULK_ACTION_SELECT_ALL_CHECKBOX = '[data-bulk-action-select-all-checkbox]';
-const BULK_ACTIONS_CHECKBOX_PARENT = '[data-parent-id]';
-const BULK_ACTION_FILTERS_CLASS = '[data-filter]';
+const BULK_ACTIONS_CHECKBOX_PARENT = '[data-bulk-action-parent-id]';
+const BULK_ACTION_FILTERS_CLASS = '[data-bulk-action-filter]';
 const BULK_ACTION_CHOICES_DIV = '[data-bulk-actions-footer]';
-const BULK_ACTION_NUM_OBJECTS_SPAN = '[data-num-objects]';
-const BULK_ACTION_NUM_OBJECTS_IN_LISTING = '[data-num-objects-in-listing]';
+const BULK_ACTION_NUM_OBJECTS_SPAN = '[data-bulk-action-num-objects]';
+const BULK_ACTION_NUM_OBJECTS_IN_LISTING = '[data-bulk-action-num-objects-in-listing]';
 
 const checkedState = {
   checkedObjects: new Set(),
@@ -112,7 +112,7 @@ function onClickSelectAllInListing(e) {
  */
 function onClickFilter(e) {
   e.preventDefault();
-  const filter = e.target.dataset.filter || '';
+  const filter = e.target.dataset.bulkActionFilter || '';
   const changeEvent = new Event('change');
   if (filter.length) {
     /* split the filter string into [key,value] pairs and check for the values in the
@@ -152,7 +152,7 @@ function onClickActionButton(e) {
   const urlParams = new URLSearchParams();
   const parentElement = document.querySelector(`${BULK_ACTIONS_CHECKBOX_PARENT}`);
   if (checkedState.selectAllInListing && parentElement) {
-    const parentPageId = parentElement.dataset.parentId;
+    const parentPageId = parentElement.dataset.bulkActionParentId;
     urlParams.append('id', 'all');
     urlParams.append('childOf', parentPageId);
   } else {

--- a/client/src/entrypoints/admin/bulk-actions.js
+++ b/client/src/entrypoints/admin/bulk-actions.js
@@ -4,7 +4,7 @@ const BULK_ACTION_PAGE_CHECKBOX_INPUT = '[data-bulk-action-checkbox]';
 const BULK_ACTION_SELECT_ALL_CHECKBOX = '[data-bulk-action-select-all-checkbox]';
 const BULK_ACTIONS_CHECKBOX_PARENT = '[data-bulk-action-parent-id]';
 const BULK_ACTION_FILTERS_CLASS = '[data-bulk-action-filter]';
-const BULK_ACTION_CHOICES_DIV = '[data-bulk-actions-footer]';
+const BULK_ACTION_CHOICES_DIV = '[data-bulk-action-footer]';
 const BULK_ACTION_NUM_OBJECTS_SPAN = '[data-bulk-action-num-objects]';
 const BULK_ACTION_NUM_OBJECTS_IN_LISTING = '[data-bulk-action-num-objects-in-listing]';
 

--- a/wagtail/admin/templates/wagtailadmin/bulk_actions/footer.html
+++ b/wagtail/admin/templates/wagtailadmin/bulk_actions/footer.html
@@ -3,9 +3,9 @@
     <div class="footer__container">
         <input data-bulk-action-select-all-checkbox type="checkbox" aria-label='{% trans "Select all" %}' />
         <ul>{% bulk_action_choices bulk_action_register_hook %}</ul>
-        <span data-num-objects class="num-objects"></span>
+        <span data-bulk-action-num-objects class="num-objects"></span>
         {% if select_all_obj_text and objects.has_other_pages %}
-        <button data-num-objects-in-listing class="num-objects-in-listing u-hidden">{{ select_all_obj_text }}</button>
+        <button data-bulk-action-num-objects-in-listing class="num-objects-in-listing u-hidden">{{ select_all_obj_text }}</button>
         {% endif %}
     </div>
 </footer>

--- a/wagtail/admin/templates/wagtailadmin/bulk_actions/footer.html
+++ b/wagtail/admin/templates/wagtailadmin/bulk_actions/footer.html
@@ -1,5 +1,5 @@
 {% load wagtailadmin_tags i18n %}
-<footer class="footer bulk-actions-choices hidden" data-bulk-actions-footer>
+<footer class="footer bulk-actions-choices hidden" data-bulk-action-footer>
     <div class="footer__container">
         <input data-bulk-action-select-all-checkbox type="checkbox" aria-label='{% trans "Select all" %}' />
         <ul>{% bulk_action_choices bulk_action_register_hook %}</ul>

--- a/wagtail/admin/templates/wagtailadmin/bulk_actions/select_all_checkbox_cell.html
+++ b/wagtail/admin/templates/wagtailadmin/bulk_actions/select_all_checkbox_cell.html
@@ -1,5 +1,5 @@
 {% load i18n wagtailadmin_tags %}
-<th class="bulk-actions-filter-checkbox" data-parent-id="{{ parent.id }}">
+<th class="bulk-actions-filter-checkbox" data-bulk-action-parent-id="{{ parent.id }}">
     <div>
         {% trans "Select all" as aria_label %}
         <input data-bulk-action-select-all-checkbox type="checkbox" aria-label="{{aria_label}}" />

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_button_with_dropdown.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_button_with_dropdown.html
@@ -10,7 +10,7 @@
         <ul class="c-dropdown__menu u-toggle  u-arrow u-arrow--tl u-background">
         {% for button in buttons %}
             <li class="c-dropdown__item ">
-                <a href="{{ button.url }}" {% if button.attrs.filter %}data-filter={{button.attrs.filter}}{% endif %} aria-label="{{ button.attrs.title }}" class="u-link is-live {{ button.classes|join:' ' }}">
+                <a href="{{ button.url }}" {% if button.attrs.filter %}data-bulk-action-filter={{button.attrs.filter}}{% endif %} aria-label="{{ button.attrs.title }}" class="u-link is-live {{ button.classes|join:' ' }}">
                     {{ button.label }}
                 </a>
             </li>

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_button_with_dropdown.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_button_with_dropdown.html
@@ -10,7 +10,13 @@
         <ul class="c-dropdown__menu u-toggle  u-arrow u-arrow--tl u-background">
         {% for button in buttons %}
             <li class="c-dropdown__item ">
-                <a href="{{ button.url }}" {% if button.attrs.filter %}data-bulk-action-filter={{button.attrs.filter}}{% endif %} aria-label="{{ button.attrs.title }}" class="u-link is-live {{ button.classes|join:' ' }}">
+                <a href="{{ button.url }}" aria-label="{{ button.attrs.title }}"
+                {% if button.attrs.data %}
+                    {% for data_key, data_value in button.attrs.data.items %}
+                        data-{{data_key}}="{{data_value}}"
+                    {% endfor %}
+                {% endif %}
+                 class="u-link is-live {{ button.classes|join:' ' }}">
                     {{ button.label }}
                 </a>
             </li>

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_page_title_choose.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_page_title_choose.html
@@ -8,7 +8,7 @@ Expects a variable 'page', the page instance.
 
 <div class="title-wrapper">
     {% if page.can_choose %}
-        <a class="choose-page" href="#{{ page.id|unlocalize }}" data-id="{{ page.id|unlocalize }}" data-title="{{ page.title }}" data-admin-title="{{ page.get_admin_display_title }}" data-url="{{ page.url }}" data-parent-id="{{ page.get_parent.id|unlocalize }}" data-edit-url="{% url 'wagtailadmin_pages:edit' page.id %}">{{ page.get_admin_display_title }}</a>
+        <a class="choose-page" href="#{{ page.id|unlocalize }}" data-id="{{ page.id|unlocalize }}" data-title="{{ page.title }}" data-admin-title="{{ page.get_admin_display_title }}" data-url="{{ page.url }}" data-bulk-action-parent-id="{{ page.get_parent.id|unlocalize }}" data-edit-url="{% url 'wagtailadmin_pages:edit' page.id %}">{{ page.get_admin_display_title }}</a>
     {% else %}
         {{ page.get_admin_display_title }}
     {% endif %}

--- a/wagtail/admin/wagtail_hooks.py
+++ b/wagtail/admin/wagtail_hooks.py
@@ -158,21 +158,21 @@ def bulk_action_filters():
     yield Button(
         _('All'),
         '?filters=',
-        attrs={'title': _("All pages"), 'filter': _("")},
+        attrs={'title': _("All pages"), 'data': {'bulk-action-filter': _("")}},
         priority=10
     )
 
     yield Button(
         _('Status: Draft'),
         '?filters=status:draft',
-        attrs={'title': _("Draft pages"), 'filter': _("status:draft")},
+        attrs={'title': _("Draft pages"), 'data': {'bulk-action-filter': _("status:draft")}},
         priority=20
     )
 
     yield Button(
         _('Status: Live'),
         '?filters=status:live',
-        attrs={'title': _("Live pages"), 'filter': _("status:live")},
+        attrs={'title': _("Live pages"), 'data': {'bulk-action-filter': _("status:live")}},
         priority=30
     )
 


### PR DESCRIPTION
All `data-` attributes required for bulk actions are namespaced with `data-bulk-action-` as discussed [here](https://github.com/wagtail/wagtail/pull/7340#discussion_r677222405)