### PR TITLE
Template components

### DIFF
--- a/docs/extending/index.rst
+++ b/docs/extending/index.rst
@@ -10,6 +10,7 @@ This section describes the various mechanisms that can be used to integrate your
     :maxdepth: 2
 
     admin_views
+    template_components
     adding_reports
     custom_tasks
     audit_log

--- a/docs/extending/template_components.rst
+++ b/docs/extending/template_components.rst
@@ -1,0 +1,165 @@
+Template components
+===================
+
+Working with objects that know how to render themselves as elements on an HTML template is a common pattern seen throughout the Wagtail admin. For example, the admin homepage is a view provided by the central ``wagtail.admin`` app, but brings together information panels sourced from various other modules of Wagtail, such as images and documents (potentially along with others provided by third-party packages). These panels are passed to the homepage via the :ref:`construct_homepage_panels` hook, and each one is responsible for providing its own HTML rendering. In this way, the module providing the panel has full control over how it appears on the homepage.
+
+Wagtail implements this pattern using a standard object type known as a **component**. A component is a Python object that provides the following methods and properties:
+
+.. method:: render_html(self, request, parent_context)
+
+Given a request object and a dict of context variables from the calling template, returns the string representation to be inserted into the template. This will be subject to Django's HTML escaping rules, so a return value consisting of HTML should typically be returned as a :py:mod:`SafeString <django.utils.safestring>` instance.
+
+.. attribute:: media
+
+A (possibly empty) :doc:`form media <django:topics/forms/media>` object defining JavaScript and CSS resources used by the component.
+
+.. note::
+   Any object implementing this API can be considered a valid component; it does not necessarily have to inherit from the ``Component`` class described below, and user code that works with components should not assume this (for example, it must not use ``instanceof`` to check whether a given value is a component).
+
+
+Creating components
+-------------------
+
+The simplest way to create a component is to define a subclass of ``wagtail.admin.components.Component`` and specify a ``template`` attribute on it. The rendered template will then be used as the component's HTML representation:
+
+.. code-block:: python
+
+    from wagtail.admin.components import Component
+
+    class WelcomePanel(Component):
+        template = 'my_app/panels/welcome.html'
+
+
+    my_welcome_panel = WelcomePanel()
+
+``my_app/templates/my_app/panels/welcome.html``:
+
+.. code-block:: html+django
+
+    <h1>Welcome to my app!</h1>
+
+
+For simple cases that don't require a template, the ``render_html`` method can be overridden instead:
+
+.. code-block:: python
+
+    from django.utils.html import format_html
+    from wagtail.admin.components import Component
+
+    class WelcomePanel(Component):
+        def render_html(self, request, parent_context):
+            return format_html("<h1>{}</h1>", "Welcome to my app!")
+
+
+Passing context to the template
+-------------------------------
+
+The ``get_context`` method can be overridden to pass additional context variables to the template. As with ``render_html``, this receives the request object and the context dictionary from the calling template:
+
+.. code-block:: python
+
+    from wagtail.admin.components import Component
+
+    class WelcomePanel(Component):
+        template = 'my_app/panels/welcome.html'
+
+        def get_context(self, request, parent_context):
+            context = super().get_context(request, parent_context)
+            context['username'] = request.user.username
+            return context
+
+``my_app/templates/my_app/panels/welcome.html``:
+
+.. code-block:: html+django
+
+    <h1>Welcome to my app, {{ username }}!</h1>
+
+
+Adding media definitions
+------------------------
+
+Like Django form widgets, components can specify associated JavaScript and CSS resources using either an inner ``Media`` class or a dynamic ``media`` property:
+
+.. code-block:: python
+
+    class WelcomePanel(Component):
+        template = 'my_app/panels/welcome.html'
+
+        class Media:
+            css = {
+                'all': ('my_app/css/welcome-panel.css',)
+            }
+
+
+Using components on your own templates
+--------------------------------------
+
+The ``wagtailadmin_tags`` tag library provides a ``{% component %}`` tag for including components on a template. This takes care of passing context variables from the calling template to the component (which would not be the case for a basic ``{{ ... }}`` variable tag). For example, given the view:
+
+
+.. code-block:: python
+
+    from django.shortcuts import render
+
+    def welcome_page(request):
+        panels = [
+            WelcomePanel(),
+        ]
+
+        render(request, 'my_app/welcome.html', {
+            'panels': panels,
+        })
+
+the ``my_app/welcome.html`` template could render the panels as follows:
+
+.. code-block:: html+django
+
+    {% load wagtailadmin_tags %}
+    {% for panel in panels %}
+        {% component panel %}
+    {% endfor %}
+
+
+Note that it is your template's responsibility to output any media declarations defined on the components. For a Wagtail admin view, this is best done by constructing a media object for the whole page within the view, passing this to the template, and outputting it via the base template's ``extra_js`` and ``extra_css`` blocks:
+
+.. code-block:: python
+
+    from django.forms import Media
+    from django.shortcuts import render
+
+    def welcome_page(request):
+        panels = [
+            WelcomePanel(),
+        ]
+
+        media = Media()
+        for panel in panels:
+            media += panel.media
+
+        render(request, 'my_app/welcome.html', {
+            'panels': panels,
+            'media': media,
+        })
+
+``my_app/welcome.html``:
+
+.. code-block:: html+django
+
+    {% extends "wagtailadmin/base.html" %}
+    {% load wagtailadmin_tags %}
+
+    {% block extra_js %}
+        {{ block.super }}
+        {{ media.js }}
+    {% endblock %}
+
+    {% block extra_css %}
+        {{ block.super }}
+        {{ media.css }}
+    {% endblock %}
+
+    {% block content %}
+        {% for panel in panels %}
+            {% component panel %}
+        {% endfor %}
+    {% endblock %}

--- a/docs/extending/template_components.rst
+++ b/docs/extending/template_components.rst
@@ -17,6 +17,8 @@ A (possibly empty) :doc:`form media <django:topics/forms/media>` object defining
    Any object implementing this API can be considered a valid component; it does not necessarily have to inherit from the ``Component`` class described below, and user code that works with components should not assume this (for example, it must not use ``instanceof`` to check whether a given value is a component).
 
 
+.. _creating_template_components:
+
 Creating components
 -------------------
 

--- a/docs/extending/template_components.rst
+++ b/docs/extending/template_components.rst
@@ -14,7 +14,7 @@ Given a request object and a dict of context variables from the calling template
 A (possibly empty) :doc:`form media <django:topics/forms/media>` object defining JavaScript and CSS resources used by the component.
 
 .. note::
-   Any object implementing this API can be considered a valid component; it does not necessarily have to inherit from the ``Component`` class described below, and user code that works with components should not assume this (for example, it must not use ``instanceof`` to check whether a given value is a component).
+   Any object implementing this API can be considered a valid component; it does not necessarily have to inherit from the ``Component`` class described below, and user code that works with components should not assume this (for example, it must not use ``isinstance`` to check whether a given value is a component).
 
 
 .. _creating_template_components:

--- a/docs/reference/hooks.rst
+++ b/docs/reference/hooks.rst
@@ -730,7 +730,7 @@ Hooks for customising the way users are directed through the process of creating
 ``register_page_action_menu_item``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-  Add an item to the popup menu of actions on the page creation and edit views. The callable passed to this hook must return an instance of ``wagtail.admin.action_menu.ActionMenuItem``. The following attributes and methods are available to be overridden on subclasses of ``ActionMenuItem``:
+  Add an item to the popup menu of actions on the page creation and edit views. The callable passed to this hook must return an instance of ``wagtail.admin.action_menu.ActionMenuItem``. ``ActionMenuItem`` is a subclass of :ref:`Component <creating_template_components>` and so the rendering of the menu item can be customised through ``template``, ``get_context``, ``render_html`` and ``Media``. In addition, the following attributes and methods are available to be overridden:
 
   :order: an integer (default 100) which determines the item's position in the menu. Can also be passed as a keyword argument to the object constructor. The lowest-numbered item in this sequence will be selected as the default menu item; as standard, this is "Save draft" (which has an ``order`` of 0).
   :label: the displayed text of the menu item
@@ -739,10 +739,6 @@ Hooks for customising the way users are directed through the process of creating
   :icon_name: icon to display against the menu item
   :classname: a ``class`` attribute value to add to the button element
   :is_shown: a method which returns a boolean indicating whether the menu item should be shown; by default, true except when editing a locked page
-  :template: path to a template to render to produce the menu item HTML
-  :get_context: a method that returns a context dictionary to pass to the template
-  :render_html: a method that returns the menu item HTML; by default, renders ``template`` with the context returned from ``get_context``
-  :Media: an inner class defining JavaScript and CSS to import when this menu item is shown - see `Django form media <https://docs.djangoproject.com/en/stable/topics/forms/media/>`_
 
   The ``get_url``, ``is_shown``, ``get_context`` and ``render_html`` methods all accept a request object and a context dictionary containing the following fields:
 
@@ -1247,8 +1243,7 @@ Hooks for working with registered Snippets.
 
   Add an item to the popup menu of actions on the snippet creation and edit views.
   The callable passed to this hook must return an instance of
-  ``wagtail.snippets.action_menu.ActionMenuItem``. The following attributes and
-  methods are available to be overridden on subclasses of ``ActionMenuItem``:
+  ``wagtail.snippets.action_menu.ActionMenuItem``. ``ActionMenuItem`` is a subclass of :ref:`Component <creating_template_components>` and so the rendering of the menu item can be customised through ``template``, ``get_context``, ``render_html`` and ``Media``. In addition, the following attributes and methods are available to be overridden:
 
   :order: an integer (default 100) which determines the item's position in the menu. Can also be passed as a keyword argument to the object constructor. The lowest-numbered item in this sequence will be selected as the default menu item; as standard, this is "Save draft" (which has an ``order`` of 0).
   :label: the displayed text of the menu item
@@ -1257,10 +1252,6 @@ Hooks for working with registered Snippets.
   :icon_name: icon to display against the menu item
   :classname: a ``class`` attribute value to add to the button element
   :is_shown: a method which returns a boolean indicating whether the menu item should be shown; by default, true except when editing a locked page
-  :template: the path to a template to render to produce the menu item HTML
-  :get_context: a method that returns a context dictionary to pass to the template
-  :render_html: a method that returns the menu item HTML; by default, renders ``template`` with the context returned from ``get_context``
-  :Media: an inner class defining Javascript and CSS to import when this menu item is shown - see `Django form media <https://docs.djangoproject.com/en/stable/topics/forms/media/>`_
 
   The ``get_url``, ``is_shown``, ``get_context`` and ``render_html`` methods all accept a request object and a context dictionary containing the following fields:
 

--- a/docs/reference/hooks.rst
+++ b/docs/reference/hooks.rst
@@ -113,18 +113,19 @@ Hooks for building new areas of the admin interface (alongside pages, images, do
 ``construct_homepage_panels``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-  Add or remove panels from the Wagtail admin homepage. The callable passed into this hook should take a ``request`` object and a list of ``panels``, objects which have a ``render()`` method returning a string. The objects also have an ``order`` property, an integer used for ordering the panels. The default panels use integers between ``100`` and ``300``. Hook functions should modify the ``panels`` list in-place as required.
+  Add or remove panels from the Wagtail admin homepage. The callable passed into this hook should take a ``request`` object and a list of panel objects, and should modify this list in-place as required. Panel objects are :doc:`components </extending/template_components>` with an additional ``order`` property, an integer that determines the panel's position in the final ordered list. The default panels use integers between ``100`` and ``300``.
 
   .. code-block:: python
 
     from django.utils.safestring import mark_safe
 
+    from wagtail.admin.components import Component
     from wagtail.core import hooks
 
-    class WelcomePanel:
+    class WelcomePanel(Component):
         order = 50
 
-        def render(self):
+        def render_html(self, request, parent_context):
             return mark_safe("""
             <section class="panel summary nice-padding">
               <h3>No, but seriously -- welcome to the admin homepage.</h3>
@@ -141,7 +142,19 @@ Hooks for building new areas of the admin interface (alongside pages, images, do
 ``construct_homepage_summary_items``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-  Add or remove items from the 'site summary' bar on the admin homepage (which shows the number of pages and other object that exist on the site). The callable passed into this hook should take a ``request`` object and a list of ``SummaryItem`` objects to be modified as required. These objects have a ``render()`` method, which returns an HTML string, and an ``order`` property, which is an integer that specifies the order in which the items will appear.
+  Add or remove items from the 'site summary' bar on the admin homepage (which shows the number of pages and other object that exist on the site). The callable passed into this hook should take a ``request`` object and a list of summary item objects, and should modify this list in-place as required. Summary item objects are instances of ``wagtail.admin.site_summary.SummaryItem``, which extends :ref:`the Component class <creating_template_components>` with the following additional methods and properties:
+
+  .. method:: SummaryItem(request)
+
+    Constructor; receives the request object its argument
+
+  .. attribute:: order
+
+    An integer that specifies the item's position in the sequence.
+
+  .. method:: is_shown()
+
+    Returns a boolean indicating whether the summary item should be shown on this request.
 
 
 .. _construct_main_menu:

--- a/docs/releases/2.15.rst
+++ b/docs/releases/2.15.rst
@@ -29,3 +29,11 @@ Bug fixes
 
 Upgrade considerations
 ======================
+
+Admin homepage panels and summary items now use components
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Admin homepage panels (as registered with the :ref:`construct_homepage_panels` hook) and summary items (as registered with :ref:`construct_homepage_summary_items`) have been updated to adopt the :doc:`template components </extending/template_components>` pattern. User code that creates these object should be updated to ensure that they follow the component API. This will typically require the following changes:
+
+ * Classes defined for use as homepage panels should be made subclasses of ``wagtail.admin.components.Component``, and the ``render(self)`` method should be changed to ``render_html(self, request, parent_context)``. (Alternatively, rather than defining ``render_html``, it may be more convenient to reimplement it with a template, as per :ref:`creating_template_components`.)
+ * Summary item classes can continue to inherit from ``wagtail.admin.site_summary.SummaryItem`` (which is now a subclass of ``Component``) as before, but any places where the ``render(self)`` method is overridden should be changed to ``render_html(self, request, parent_context)``, and any places where the ``get_context(self)`` method is overridden should be changed to ``get_context(self, request, parent_context)``.

--- a/wagtail/admin/action_menu.py
+++ b/wagtail/admin/action_menu.py
@@ -1,17 +1,18 @@
 """Handles rendering of the list of actions in the footer of the page create/edit views."""
 
 from django.conf import settings
-from django.forms import Media, MediaDefiningClass
+from django.forms import Media
 from django.template.loader import render_to_string
 from django.urls import reverse
 from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 
+from wagtail.admin.components import Component
 from wagtail.core import hooks
 from wagtail.core.models import UserPagePermissionsProxy
 
 
-class ActionMenuItem(metaclass=MediaDefiningClass):
+class ActionMenuItem(Component):
     """Defines an item in the actions drop-up on the page creation/edit view"""
     order = 100  # default order index if one is not specified on init
     template = 'wagtailadmin/pages/action_menu/menu_item.html'
@@ -52,7 +53,7 @@ class ActionMenuItem(metaclass=MediaDefiningClass):
 
     def get_context(self, request, parent_context):
         """Defines context for the template, overridable to use more data"""
-        context = parent_context.copy()
+        context = super().get_context(request, parent_context)
         context.update({
             'label': self.label,
             'url': self.get_url(request, context),
@@ -64,10 +65,6 @@ class ActionMenuItem(metaclass=MediaDefiningClass):
 
     def get_url(self, request, context):
         return None
-
-    def render_html(self, request, parent_context):
-        context = self.get_context(request, parent_context)
-        return render_to_string(self.template, context, request=request)
 
 
 class PublishMenuItem(ActionMenuItem):

--- a/wagtail/admin/components.py
+++ b/wagtail/admin/components.py
@@ -1,0 +1,16 @@
+from django.forms import MediaDefiningClass
+from django.template.loader import render_to_string
+
+
+class Component(metaclass=MediaDefiningClass):
+    """
+    Implements the common pattern of an object that knows how to render itself to an HTML page.
+
+    Subclasses should provide a 'template' attribute, or override render_html.
+    """
+    def get_context(self, request, parent_context):
+        return parent_context.copy()
+
+    def render_html(self, request, parent_context):
+        context = self.get_context(request, parent_context)
+        return render_to_string(self.template, context, request=request)

--- a/wagtail/admin/site_summary.py
+++ b/wagtail/admin/site_summary.py
@@ -71,8 +71,8 @@ class PagesSummaryItem(SummaryItem):
     order = 100
     template = 'wagtailadmin/home/site_summary_pages.html'
 
-    def get_context(self):
-        site_details = get_site_for_user(self.request.user)
+    def get_context(self, request, parent_context):
+        site_details = get_site_for_user(request.user)
         root_page = site_details['root_page']
         site_name = site_details['site_name']
 

--- a/wagtail/admin/site_summary.py
+++ b/wagtail/admin/site_summary.py
@@ -2,6 +2,7 @@ import inspect
 
 from warnings import warn
 
+from django.forms import Media
 from django.template.loader import render_to_string
 
 from wagtail.admin.auth import user_has_any_page_permission
@@ -104,21 +105,27 @@ class PagesSummaryItem(SummaryItem):
         return user_has_any_page_permission(self.request.user)
 
 
-class SiteSummaryPanel:
+class SiteSummaryPanel(Component):
+    template = 'wagtailadmin/home/site_summary.html'
     name = 'site_summary'
     order = 100
 
     def __init__(self, request):
         self.request = request
-        self.summary_items = []
+        summary_items = []
         for fn in hooks.get_hooks('construct_homepage_summary_items'):
-            fn(request, self.summary_items)
+            fn(request, summary_items)
+        self.summary_items = [s for s in summary_items if s.is_shown()]
+        self.summary_items.sort(key=lambda p: p.order)
 
-    def render(self):
-        summary_items = [s for s in self.summary_items if s.is_shown()]
-        if not summary_items:
-            return ''
+    def get_context(self, request, parent_context):
+        context = super().get_context(request, parent_context)
+        context['summary_items'] = self.summary_items
+        return context
 
-        return render_to_string('wagtailadmin/home/site_summary.html', {
-            'summary_items': sorted(summary_items, key=lambda p: p.order),
-        }, request=self.request)
+    @property
+    def media(self):
+        media = Media()
+        for item in self.summary_items:
+            media += item.media
+        return media

--- a/wagtail/admin/site_summary.py
+++ b/wagtail/admin/site_summary.py
@@ -41,8 +41,8 @@ class SummaryItem(Component):
             # this SummaryItem subclass has overridden render() - use their implementation in
             # preference to following the Component.render_html path
             message = (
-                "Summary item %r registered with construct_homepage_summary_items must be updated "
-                "to override render_html(self, request, parent_context) rather than render(self)"
+                "Summary item %r should provide render_html(self, request, parent_context) rather than render(self). "
+                "See https://docs.wagtail.io/en/stable/releases/2.15.html#admin-homepage-panels-and-summary-items-now-use-components"
                 % self
             )
             warn(message, category=RemovedInWagtail217Warning)
@@ -52,8 +52,8 @@ class SummaryItem(Component):
             # get_context has been overridden with a version that doesn't accept the
             # request / parent_context arguments passed by Component.render_html
             message = (
-                "%s.get_context() (on summary item %r registered with construct_homepage_summary_items) "
-                "must be updated to accept parameters 'request' and 'parent_context'"
+                "%s.get_context() (on summary item %r) should accept parameters 'request' and 'parent_context'. "
+                "See https://docs.wagtail.io/en/stable/releases/2.15.html#admin-homepage-panels-and-summary-items-now-use-components"
                 % (type(self).__name__, self)
             )
             warn(message, category=RemovedInWagtail217Warning)

--- a/wagtail/admin/templates/wagtailadmin/home.html
+++ b/wagtail/admin/templates/wagtailadmin/home.html
@@ -8,6 +8,7 @@
 
     <link rel="stylesheet" href="{% versioned_static 'wagtailadmin/css/layouts/home.css' %}" type="text/css" />
     <link rel="stylesheet" href="{% versioned_static 'wagtailadmin/css/layouts/page-editor.css' %}" />
+    {{ media.css }}
 {% endblock %}
 
 {% block content %}
@@ -55,4 +56,5 @@ $(function() {
     });
 });
 </script>
+{{ media.js }}
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/home.html
+++ b/wagtail/admin/templates/wagtailadmin/home.html
@@ -25,7 +25,7 @@
 
     {% if panels %}
         {% for panel in panels %}
-            {{ panel.render }}
+            {% component panel fallback_render_method=True %}
         {% endfor %}
     {% else %}
         <p>{% trans "This is your dashboard on which helpful information about content you've created will be displayed." %}</p>

--- a/wagtail/admin/templates/wagtailadmin/home/site_summary.html
+++ b/wagtail/admin/templates/wagtailadmin/home/site_summary.html
@@ -1,9 +1,11 @@
 {% load i18n wagtailadmin_tags %}
-<section class="panel summary nice-padding">
-    <h2 class="visuallyhidden">{% trans "Site summary" %}</h2>
-    <ul class="stats">
-        {% for item in summary_items %}
-            {% component item %}
-        {% endfor %}
-    </ul>
-</section>
+{% if summary_items %}
+    <section class="panel summary nice-padding">
+        <h2 class="visuallyhidden">{% trans "Site summary" %}</h2>
+        <ul class="stats">
+            {% for item in summary_items %}
+                {% component item %}
+            {% endfor %}
+        </ul>
+    </section>
+{% endif %}

--- a/wagtail/admin/templates/wagtailadmin/home/site_summary.html
+++ b/wagtail/admin/templates/wagtailadmin/home/site_summary.html
@@ -3,7 +3,7 @@
     <h2 class="visuallyhidden">{% trans "Site summary" %}</h2>
     <ul class="stats">
         {% for item in summary_items %}
-            {{ item.render }}
+            {% component item %}
         {% endfor %}
     </ul>
 </section>

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -729,3 +729,18 @@ def resolve_url(url):
         return resolve_url_func(url)
     except NoReverseMatch:
         return ''
+
+
+@register.simple_tag(takes_context=True)
+def component(context, obj, fallback_render_method=False):
+    # Render a component by calling its render_html method, passing request and context from the
+    # calling template.
+    # If fallback_render_method is true, objects without a render_html method will have render()
+    # called instead (with no arguments) - this is to provide deprecation path for things that have
+    # been newly upgraded to use the component pattern.
+
+    if fallback_render_method and not hasattr(obj, 'render_html') and hasattr(obj, 'render'):
+        return obj.render()
+
+    request = context.get('request')
+    return obj.render_html(request, context.flatten())

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -739,8 +739,11 @@ def component(context, obj, fallback_render_method=False):
     # called instead (with no arguments) - this is to provide deprecation path for things that have
     # been newly upgraded to use the component pattern.
 
-    if fallback_render_method and not hasattr(obj, 'render_html') and hasattr(obj, 'render'):
+    has_render_html_method = hasattr(obj, 'render_html')
+    if fallback_render_method and not has_render_html_method and hasattr(obj, 'render'):
         return obj.render()
+    elif not has_render_html_method:
+        raise ValueError("Cannot render %r as a component" % (obj,))
 
     request = context.get('request')
     return obj.render_html(request, context.flatten())

--- a/wagtail/admin/tests/pages/test_dashboard.py
+++ b/wagtail/admin/tests/pages/test_dashboard.py
@@ -85,11 +85,12 @@ class TestRecentEditsPanel(TestCase, WagtailTestUtils):
         # set a user to 'mock' a request
         self.client.user = get_user_model().objects.get(email='bob@example.com')
         # get the panel to get the last edits
-        panel = RecentEditsPanel(self.client)
+        panel = RecentEditsPanel()
+        ctx = panel.get_context(self.client, {})
         # check if the revision is the revision of edited Page
-        self.assertEqual(panel.last_edits[0][0].page, Page.objects.get(pk=self.child_page.id))
+        self.assertEqual(ctx['last_edits'][0][0].page, Page.objects.get(pk=self.child_page.id))
         # check if the page in this list is the specific page of this revision
-        self.assertEqual(panel.last_edits[0][1], Page.objects.get(pk=self.child_page.id).specific)
+        self.assertEqual(ctx['last_edits'][0][1], Page.objects.get(pk=self.child_page.id).specific)
 
 
 class TestRecentEditsQueryCount(TestCase, WagtailTestUtils):
@@ -108,10 +109,11 @@ class TestRecentEditsQueryCount(TestCase, WagtailTestUtils):
         # fake a request object with bob as the user
         self.client.user = self.bob
         with self.assertNumQueries(4):
-            # Instantiating RecentEditsPanel should not generate N+1 queries -
+            # Instantiating/getting context of RecentEditsPanel should not generate N+1 queries -
             # i.e. any number less than 6 would be reasonable here
-            panel = RecentEditsPanel(self.client)
+            panel = RecentEditsPanel()
+            panel.get_context(self.client, {})
 
         # check that the panel is still actually returning results
-        html = panel.render()
+        html = panel.render_html(self.client, {})
         self.assertIn("Ameristralia Day", html)

--- a/wagtail/admin/tests/test_site_summary.py
+++ b/wagtail/admin/tests/test_site_summary.py
@@ -36,7 +36,7 @@ class TestPagesSummary(TestCase, WagtailTestUtils):
         self.request = self.client.get('/').wsgi_request
 
     def assertSummaryContains(self, content):
-        summary = PagesSummaryItem(self.request).render()
+        summary = PagesSummaryItem(self.request).render_html(self.request, {})
         self.assertIn(content, summary)
 
     def assertSummaryContainsLinkToPage(self, page_pk):

--- a/wagtail/admin/tests/test_templatetags.py
+++ b/wagtail/admin/tests/test_templatetags.py
@@ -149,3 +149,12 @@ class TestComponentTag(TestCase):
         )
         html = template.render(Context({'my_component': MyComponent()}))
         self.assertEqual(html, "<h1>Look, I&#x27;m running with scissors! 8&lt; 8&lt; 8&lt;</h1>")
+
+    def test_error_on_rendering_non_component(self):
+        template = Template(
+            "{% load wagtailadmin_tags %}<h1>{% component my_component %}</h1>"
+        )
+
+        with self.assertRaises(ValueError) as cm:
+            template.render(Context({'my_component': "hello"}))
+        self.assertEqual(str(cm.exception), "Cannot render 'hello' as a component")

--- a/wagtail/admin/tests/test_templatetags.py
+++ b/wagtail/admin/tests/test_templatetags.py
@@ -2,11 +2,14 @@ from datetime import timedelta
 from unittest import mock
 
 from django.conf import settings
+from django.template import Context, Template
 from django.test import TestCase
 from django.test.utils import override_settings
 from django.utils import timezone
+from django.utils.html import format_html
 from freezegun import freeze_time
 
+from wagtail.admin.components import Component
 from wagtail.admin.staticfiles import versioned_static
 from wagtail.admin.templatetags.wagtailadmin_tags import (
     avatar_url, notification_static, timesince_last_update, timesince_simple)
@@ -122,3 +125,27 @@ class TestTimesinceTags(TestCase):
 
         timesince = timesince_last_update(dt)
         self.assertEqual(timesince, '1\xa0week ago')
+
+
+class TestComponentTag(TestCase):
+    def test_passing_context_to_component(self):
+        class MyComponent(Component):
+            def render_html(self, request, parent_context):
+                return format_html("<h1>{} was here</h1>", parent_context.get('first_name'))
+
+        template = Template(
+            "{% load wagtailadmin_tags %}{% with first_name='Kilroy' %}{% component my_component %}{% endwith %}"
+        )
+        html = template.render(Context({'my_component': MyComponent()}))
+        self.assertEqual(html, "<h1>Kilroy was here</h1>")
+
+    def test_component_escapes_unsafe_strings(self):
+        class MyComponent(Component):
+            def render_html(self, request, parent_context):
+                return "Look, I'm running with scissors! 8< 8< 8<"
+
+        template = Template(
+            "{% load wagtailadmin_tags %}<h1>{% component my_component %}</h1>"
+        )
+        html = template.render(Context({'my_component': MyComponent()}))
+        self.assertEqual(html, "<h1>Look, I&#x27;m running with scissors! 8&lt; 8&lt; 8&lt;</h1>")

--- a/wagtail/admin/tests/tests.py
+++ b/wagtail/admin/tests/tests.py
@@ -68,6 +68,25 @@ class TestHome(TestCase, WagtailTestUtils):
             '<a href="http://www.tomroyal.com/teaandkittens/" class="icon icon-kitten" data-fluffy="yes">Kittens!</a>'
         )
 
+    def test_dashboard_panels(self):
+        response = self.client.get(reverse('wagtailadmin_home'))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "<p>It looks like you're making a website. Would you like some help?</p>")
+
+        # check that media attached to dashboard panels is correctly pulled in
+        if DJANGO_VERSION >= (3, 1):
+            self.assertContains(
+                response,
+                '<script src="/static/testapp/js/clippy.js"></script>',
+                html=True
+            )
+        else:
+            self.assertContains(
+                response,
+                '<script type="text/javascript" src="/static/testapp/js/clippy.js"></script>',
+                html=True
+            )
+
     def test_never_cache_header(self):
         # This tests that wagtailadmins global cache settings have been applied correctly
         response = self.client.get(reverse('wagtailadmin_home'))

--- a/wagtail/admin/tests/tests.py
+++ b/wagtail/admin/tests/tests.py
@@ -87,6 +87,18 @@ class TestHome(TestCase, WagtailTestUtils):
                 html=True
             )
 
+    def test_summary_items(self):
+        response = self.client.get(reverse('wagtailadmin_home'))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "<p>0 broken links</p>")
+
+        # check that media attached to summary items is correctly pulled in
+        self.assertContains(
+            response,
+            '<link href="/static/testapp/css/broken-links.css" type="text/css" media="all" rel="stylesheet">',
+            html=True
+        )
+
     def test_never_cache_header(self):
         # This tests that wagtailadmins global cache settings have been applied correctly
         response = self.client.get(reverse('wagtailadmin_home'))

--- a/wagtail/admin/views/home.py
+++ b/wagtail/admin/views/home.py
@@ -7,6 +7,7 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.decorators import permission_required
 from django.db import connection
 from django.db.models import Max, Q
+from django.forms import Media
 from django.http import Http404, HttpResponse
 from django.template.loader import render_to_string
 from django.template.response import TemplateResponse
@@ -170,6 +171,8 @@ def home(request):
     for fn in hooks.get_hooks('construct_homepage_panels'):
         fn(request, panels)
 
+    media = Media()
+
     for panel in panels:
         if hasattr(panel, 'render') and not hasattr(panel, 'render_html'):
             # NOTE: when this deprecation warning is removed the 'fallback_render_method=True' in
@@ -180,6 +183,9 @@ def home(request):
             )
             warn(message, category=RemovedInWagtail217Warning)
 
+        if hasattr(panel, 'media'):
+            media += panel.media
+
     site_details = get_site_for_user(request.user)
 
     return TemplateResponse(request, "wagtailadmin/home.html", {
@@ -187,7 +193,8 @@ def home(request):
         'root_site': site_details['root_site'],
         'site_name': site_details['site_name'],
         'panels': sorted(panels, key=lambda p: p.order),
-        'user': request.user
+        'user': request.user,
+        'media': media,
     })
 
 

--- a/wagtail/admin/views/home.py
+++ b/wagtail/admin/views/home.py
@@ -178,7 +178,8 @@ def home(request):
             # NOTE: when this deprecation warning is removed the 'fallback_render_method=True' in
             # wagtailadmin/home.html should be removed too
             message = (
-                "Panel %r registered with construct_homepage_panels must be updated to provide a render_html method"
+                "Homepage panel %r should provide a render_html method. "
+                "See https://docs.wagtail.io/en/stable/releases/2.15.html#admin-homepage-panels-and-summary-items-now-use-components"
                 % panel
             )
             warn(message, category=RemovedInWagtail217Warning)

--- a/wagtail/admin/views/home.py
+++ b/wagtail/admin/views/home.py
@@ -183,6 +183,8 @@ def home(request):
             )
             warn(message, category=RemovedInWagtail217Warning)
 
+        # RemovedInWagtail217Warning: this hasattr check can be removed when support for
+        # non-component-based panels ends
         if hasattr(panel, 'media'):
             media += panel.media
 

--- a/wagtail/documents/wagtail_hooks.py
+++ b/wagtail/documents/wagtail_hooks.py
@@ -103,8 +103,8 @@ class DocumentsSummaryItem(SummaryItem):
     order = 300
     template = 'wagtaildocs/homepage/site_summary_documents.html'
 
-    def get_context(self):
-        site_name = get_site_for_user(self.request.user)['site_name']
+    def get_context(self, request, parent_context):
+        site_name = get_site_for_user(request.user)['site_name']
 
         return {
             'total_docs': get_document_model().objects.count(),

--- a/wagtail/images/wagtail_hooks.py
+++ b/wagtail/images/wagtail_hooks.py
@@ -128,8 +128,8 @@ class ImagesSummaryItem(SummaryItem):
     order = 200
     template = 'wagtailimages/homepage/site_summary_images.html'
 
-    def get_context(self):
-        site_name = get_site_for_user(self.request.user)['site_name']
+    def get_context(self, request, parent_context):
+        site_name = get_site_for_user(request.user)['site_name']
 
         return {
             'total_images': get_image_model().objects.count(),

--- a/wagtail/snippets/action_menu.py
+++ b/wagtail/snippets/action_menu.py
@@ -3,17 +3,18 @@
 from functools import lru_cache
 
 from django.contrib.admin.utils import quote
-from django.forms import Media, MediaDefiningClass
+from django.forms import Media
 from django.template.loader import render_to_string
 from django.urls import reverse
 from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 
+from wagtail.admin.components import Component
 from wagtail.core import hooks
 from wagtail.snippets.permissions import get_permission_name
 
 
-class ActionMenuItem(metaclass=MediaDefiningClass):
+class ActionMenuItem(Component):
     """Defines an item in the actions drop-up on the snippet creation/edit view"""
     order = 100  # default order index if one is not specified on init
     template = 'wagtailsnippets/snippets/action_menu/menu_item.html'
@@ -42,7 +43,7 @@ class ActionMenuItem(metaclass=MediaDefiningClass):
 
     def get_context(self, request, parent_context):
         """Defines context for the template, overridable to use more data"""
-        context = parent_context.copy()
+        context = super().get_context(request, parent_context)
         context.update({
             'label': self.label,
             'url': self.get_url(request, context),
@@ -54,10 +55,6 @@ class ActionMenuItem(metaclass=MediaDefiningClass):
 
     def get_url(self, request, context):
         return None
-
-    def render_html(self, request, parent_context):
-        context = self.get_context(request, parent_context)
-        return render_to_string(self.template, context, request=request)
 
 
 class DeleteMenuItem(ActionMenuItem):

--- a/wagtail/tests/testapp/wagtail_hooks.py
+++ b/wagtail/tests/testapp/wagtail_hooks.py
@@ -1,10 +1,12 @@
 from django import forms
 from django.http import HttpResponse
 from django.templatetags.static import static
+from django.utils.safestring import mark_safe
 
 import wagtail.admin.rich_text.editors.draftail.features as draftail_features
 
 from wagtail.admin.action_menu import ActionMenuItem
+from wagtail.admin.components import Component
 from wagtail.admin.menu import MenuItem
 from wagtail.admin.rich_text import HalloPlugin
 from wagtail.admin.rich_text.converters.html_to_contentstate import BlockElementHandler
@@ -189,3 +191,18 @@ class FavouriteColourPanel(BaseSettingsPanel):
     order = 500
     form_class = FavouriteColourForm
     form_object = 'user'
+
+
+class ClippyPanel(Component):
+    order = 50
+
+    def render_html(self, request, parent_context):
+        return mark_safe("<p>It looks like you're making a website. Would you like some help?</p>")
+
+    class Media:
+        js = ['testapp/js/clippy.js']
+
+
+@hooks.register('construct_homepage_panels')
+def add_clippy_panel(request, panels):
+    panels.append(ClippyPanel())

--- a/wagtail/tests/testapp/wagtail_hooks.py
+++ b/wagtail/tests/testapp/wagtail_hooks.py
@@ -11,6 +11,7 @@ from wagtail.admin.menu import MenuItem
 from wagtail.admin.rich_text import HalloPlugin
 from wagtail.admin.rich_text.converters.html_to_contentstate import BlockElementHandler
 from wagtail.admin.search import SearchArea
+from wagtail.admin.site_summary import SummaryItem
 from wagtail.admin.views.account import BaseSettingsPanel
 from wagtail.admin.widgets import Button
 from wagtail.core import hooks
@@ -206,3 +207,18 @@ class ClippyPanel(Component):
 @hooks.register('construct_homepage_panels')
 def add_clippy_panel(request, panels):
     panels.append(ClippyPanel())
+
+
+class BrokenLinksSummaryItem(SummaryItem):
+    order = 100
+
+    def render_html(self, request, parent_context):
+        return mark_safe("<p>0 broken links</p>")
+
+    class Media:
+        css = {'all': ['testapp/css/broken-links.css']}
+
+
+@hooks.register('construct_homepage_summary_items')
+def add_broken_links_summary_item(request, items):
+    items.append(BrokenLinksSummaryItem(request))


### PR DESCRIPTION
Implements a standard documented pattern for "objects that know how to render themselves onto templates". This pattern has been reimplemented numerous times throughout Wagtail's development, for things like homepage panels and action buttons, in various levels of completeness - and as a result, some of them provide ready-made mechanisms for rendering templates, some provide a get_context method, some allow specifying external css / js, some of them can pick up context variables from the calling template, and so on... Standardising these will make these features consistently available, and make our APIs easier to learn (no more "is it `render` or `render_html`?")

Things that use components as of this PR:
* Page action menu items (register_page_action_menu_item)
* Snippet action menu items (register_snippet_action_menu_item)
* Homepage panels (construct_homepage_panels)
* Summary items (construct_homepage_summary_items)

Other things that could potentially be migrated to components in future:
* Sidebar menu items (need to consider how this aligns with the telepath / slim sidebar rewrite, but I believe these concepts can coexist)
* the page / snippet action menus as a whole (PageActionMenu, SnippetActionMenu as distinct from ActionMenuItem)
* Userbar / edit bird menu items
* User account settings panels
* Search areas (wagtail.admin.search)
* wagtail.admin.widgets.button (as used for buttons / button menus within listings)
