### PR TITLE
Add missing args/kwargs to Page documentation

### DIFF
--- a/docs/topics/pages.md
+++ b/docs/topics/pages.md
@@ -252,8 +252,8 @@ To add more variables to the template context, you can override this method:
 class BlogIndexPage(Page):
     ...
 
-    def get_context(self, request):
-        context = super().get_context(request)
+    def get_context(self, request, *args, **kwargs):
+        context = super().get_context(request, *args, **kwargs)
 
         # Add extra variables and return the updated context
         context['blog_entries'] = BlogPage.objects.child_of(self).live()
@@ -291,7 +291,7 @@ class BlogPage(Page):
 
     use_other_template = models.BooleanField()
 
-    def get_template(self, request):
+    def get_template(self, request, *args, **kwargs):
         if self.use_other_template:
             return 'blog/other_blog_page.html'
 


### PR DESCRIPTION
Documentation examples of `Page.get_context` and `Page.get_template` lack `*args` and `**kwargs` parameters (which were added way back in 8c4c26864103890897ca63708867621f16938a25).

This commit adds those missing parameters.

See live documentation page [here](https://docs.wagtail.io/en/stable/topics/pages.html#customising-template-context) and [here](https://docs.wagtail.io/en/stable/topics/pages.html#dynamically-choosing-the-template). Edit: and compare to the documentation page for this PR [here](https://wagtail--7398.org.readthedocs.build/en/7398/topics/pages.html#customising-template-context) and [here](https://wagtail--7398.org.readthedocs.build/en/7398/topics/pages.html#dynamically-choosing-the-template).