### PR TITLE
Tiny cleanup for site root page chooser

### DIFF
--- a/wagtail/sites/forms.py
+++ b/wagtail/sites/forms.py
@@ -9,7 +9,8 @@ class SiteForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.fields['root_page'].widget = AdminPageChooser(
-            choose_one_text=_('Choose a root page'), choose_another_text=_('Choose a different root page')
+            choose_one_text=_('Choose a root page'), choose_another_text=_('Choose a different root page'),
+            show_clear_link=False
         )
 
     required_css_class = "required"

--- a/wagtail/sites/templates/wagtailsites/create.html
+++ b/wagtail/sites/templates/wagtailsites/create.html
@@ -1,6 +1,7 @@
 {% extends "wagtailadmin/generic/create.html" %}
+{% load wagtailadmin_tags %}
 
 {% block extra_js %}
     {{ block.super }}
-    {% include "wagtailadmin/pages/_editor_js.html" %}
+    <script src="{% versioned_static 'wagtailadmin/js/modal-workflow.js' %}"></script>
 {% endblock %}

--- a/wagtail/sites/templates/wagtailsites/edit.html
+++ b/wagtail/sites/templates/wagtailsites/edit.html
@@ -1,6 +1,7 @@
 {% extends "wagtailadmin/generic/edit.html" %}
+{% load wagtailadmin_tags %}
 
 {% block extra_js %}
     {{ block.super }}
-    {% include "wagtailadmin/pages/_editor_js.html" %}
+    <script src="{% versioned_static 'wagtailadmin/js/modal-workflow.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
* Pulling in _editor_js.html is unnecessary - the only JS dependency that isn't in form media is now modal_workflow.js. (So close to being able to ditch the template override entirely!)
* Omit the 'clear' button, as this is a required field.
