### PR TITLE
Makes the title of ModelAdmin items into links

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -12,6 +12,7 @@ Changelog
  * Fix: Ensure that StreamBlock / ListBlock-level validation errors are counted towards error counts (Matt Westcott)
  * Fix: InlinePanel add button is now keyboard navigatable (Jesse Menn)
  * Fix: Remove redundant 'clear' button from site root page chooser (Matt Westcott)
+ * Fix: Make ModelAdmin IndexView keyboard-navigable (Saptak Sengupta)
 
 
 2.14 (02.08.2021)

--- a/docs/releases/2.15.rst
+++ b/docs/releases/2.15.rst
@@ -27,6 +27,7 @@ Bug fixes
  * Ensure that StreamBlock / ListBlock-level validation errors are counted towards error counts (Matt Westcott)
  * InlinePanel add button is now keyboard navigatable (Jesse Menn)
  * Remove redundant 'clear' button from site root page chooser (Matt Westcott)
+ * Make ModelAdmin IndexView keyboard-navigable (Saptak Sengupta)
 
 Upgrade considerations
 ======================

--- a/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
+++ b/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
@@ -184,7 +184,7 @@ class TestAuthorIndexView(TestCase, WagtailTestUtils):
         response = self.get()
         self.assertEqual(response.status_code, 200)
         test_html = """
-            <td class="field-first_book for-author-1">The Lord of the Rings</td>
+            <td class="field-first_book for-author-1 title">The Lord of the Rings</td>
         """
         self.assertContains(response, test_html, html=True)
 
@@ -192,7 +192,7 @@ class TestAuthorIndexView(TestCase, WagtailTestUtils):
         response = self.get()
         self.assertEqual(response.status_code, 200)
         test_html = """
-            <td class="field-last_book" data-for_author="1">The Hobbit</td>
+            <td class="field-last_book title" data-for_author="1">The Hobbit</td>
         """
         self.assertContains(response, test_html, html=True)
 


### PR DESCRIPTION
Fixes #7333 

As suggested by @thibaudcolas in the issue, I converted the title of the item into a link (structured it using the same HTML as page listing to maintain the same style). This allows for keyboard navigation to the action buttons for each item using the `:focus-within` like rest of admin.

* For front-end changes: Did you test on all of [Wagtail’s supported environments](https://docs.wagtail.io/en/latest/contributing/developing.html#browser-and-device-support)?
    * **Please list the exact browser and operating system versions you tested**.
      * Firefox, Chrome on Debian, safari on MacOS
    * **Please list which assistive technologies you tested**.
      * VoiceOver on MacOS

