### PR TITLE
Spelling fixes

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -450,7 +450,7 @@ Changelog
  * FieldPanel now accepts a 'heading' argument (Jacob Topp-Mugglestone)
  * Replaced deprecated `ugettext` / `ungettext` calls with `gettext` / `ngettext` (Mohamed Feddad)
  * ListBlocks now call child block `bulk_to_python` if defined (Andy Chosak)
- * Site settings are now identifiable/cachable by request as well as site (Andy Babic)
+ * Site settings are now identifiable/cacheable by request as well as site (Andy Babic)
  * Added `select_related` attribute to site settings to enable more efficient fetching of foreign key values (Andy Babic)
  * Add caching of image renditions (Tom Dyson, Tim Kamanin)
  * Add documentation for reporting security issues and internationalisation (Matt Westcott)
@@ -668,7 +668,7 @@ Changelog
  * Fix: Revised test decorator to ensure TestPageEditHandlers test cases run correctly (Alex Tomkins)
  * Fix: Wagtail bird animation in admin now ends correctly on all browsers (Deniz Dogan)
  * Fix: Explorer menu no longer shows sibling pages for which the user does not have access (Mike Hearn)
- * Fix: Fixed occurences of invalid HTML across the CMS admin (Thibaud Colas)
+ * Fix: Fixed occurrences of invalid HTML across the CMS admin (Thibaud Colas)
  * Fix: Admin HTML now includes the correct `dir` attribute for the active language (Andreas Bernacca)
  * Fix: Fix type error when using `--chunk_size` argument on `./manage.py update_index` (Seb Brown)
  * Fix: Avoid rendering entire form in EditHandler's `repr` method (Alex Tomkins)
@@ -687,7 +687,7 @@ Changelog
  * Fix: Ensure the 'add child page' button displays when focused (Helen Chapman, Katie Locke)
  * Fix: Remove tab order customisations in CMS admin (Jordan Bauer)
  * Fix: Add labels to permission checkboxes for screen reader users (Helen Chapman, Katie Locke)
- * Fix: Page.copy() no longer copies child objects when the accesssor name is included in `exclude_fields_in_copy` (Karl Hobley)
+ * Fix: Page.copy() no longer copies child objects when the accessor name is included in `exclude_fields_in_copy` (Karl Hobley)
  * Fix: Move focus to the pages explorer menu when open (Helen Chapman)
  * Fix: Clicking the privacy toggle while the page is still loading no longer loads the wrong data in the page (Helen Chapman)
  * Fix: Added missing `is_stored_locally` method to `AbstractDocument` (jonny5532)
@@ -1764,7 +1764,7 @@ Changelog
  * Added classnames to Wagtail rich text editor buttons to aid custom styling (Rob Shelton)
  * Simplified body_class in default homepage template (Josh Barr)
  * page_published signal now called with the revision object that was published (Josh Barr)
- * Added an overrideable favicon to the admin interface
+ * Added an overridable favicon to the admin interface
  * Added spinner animations to long-running form submissions
  * The EMBEDLY_KEY setting has been renamed to WAGTAILEMBEDS_EMBEDLY_KEY (Anurag Sharma)
  * StreamField blocks are now added automatically, without showing the block types menu, if only one block type exists (Alex Gleason)

--- a/client/scss/components/_button.scss
+++ b/client/scss/components/_button.scss
@@ -636,7 +636,7 @@ button {
 
 }
 
-// wrapper around add button for mutliple objects
+// wrapper around add button for multiple objects
 .add {
     font-weight: 700;
     cursor: pointer;

--- a/client/scss/components/_chooser.scss
+++ b/client/scss/components/_chooser.scss
@@ -5,7 +5,7 @@ own less files in each app directory (and since deleted). It would be best if
 an admin 'theme' provided all the design for a UI in a single place, but
 should that be a series of overrides to the css provided from an app? If so,
 perhaps those two previous less files should be re-instated and then
-overriden here? hmm.
+overridden here? hmm.
 */
 
 .chooser {

--- a/client/scss/overrides/_vendor.tagit.scss
+++ b/client/scss/overrides/_vendor.tagit.scss
@@ -8,13 +8,13 @@
 }
 
 // Additional specificity (.admin_tag_widget ) required to override tagit stylesheets,
-// which get added after the core CSS, and otherweise trump our styles.
+// which get added after the core CSS, and otherwise trump our styles.
 .admin_tag_widget ul.tagit input[type='text'] {
     padding: 0.2em 0.5em;
 }
 
 // Additional specificity (.admin_tag_widget ) required to override tagit stylesheets,
-// which get added after the core CSS, and otherweise trump our styles.
+// which get added after the core CSS, and otherwise trump our styles.
 .admin_tag_widget ul.tagit li.tagit-choice-editable {
     padding: 0 23px 0 0;
 }

--- a/client/src/components/Button/Button.tsx
+++ b/client/src/components/Button/Button.tsx
@@ -18,7 +18,7 @@ const handleClick = (
     onClick(e);
   }
 
-  // If a navigate hander has been specified, replace the default behaviour
+  // If a navigate handler has been specified, replace the default behaviour
   if (navigate && !e.defaultPrevented) {
     e.preventDefault();
     navigate(href);

--- a/client/src/components/CommentApp/main.scss
+++ b/client/src/components/CommentApp/main.scss
@@ -128,7 +128,7 @@ $box-padding: 10px;
         opacity: 0.3;
     }
 
-    // Disable Firefox's focus styling becase we add our own.
+    // Disable Firefox's focus styling because we add our own.
     &::-moz-focus-inner {
         border: 0;
     }

--- a/client/src/components/Draftail/CommentableEditor/CommentableEditor.tsx
+++ b/client/src/components/Draftail/CommentableEditor/CommentableEditor.tsx
@@ -107,7 +107,7 @@ export class DraftailInlineAnnotation implements Annotation {
     let medianRef: null | DecoratorRef = null;
     if (focused) {
       // If the comment is focused, calculate the median of refs only
-      // within the focused block, to ensure the comment is visisble
+      // within the focused block, to ensure the comment is visible
       // if the highlight has somehow been split up
       medianRef = DraftailInlineAnnotation.getMedianRef(
         Array.from(this.decoratorRefs.keys()).filter(

--- a/client/src/components/StreamField/blocks/StaticBlock.test.js
+++ b/client/src/components/StreamField/blocks/StaticBlock.test.js
@@ -58,7 +58,7 @@ describe('telepath: wagtail.blocks.StaticBlock HTML escaping', () => {
     expect(document.body.innerHTML).toMatchSnapshot();
   });
 
-  test('javascript cant execute', () => {
+  test('javascript can\'t execute', () => {
     expect(window.somethingBad.mock.calls.length).toBe(0);
   });
 });

--- a/client/src/components/StreamField/scss/components/c-sf-container.scss
+++ b/client/src/components/StreamField/scss/components/c-sf-container.scss
@@ -33,7 +33,7 @@
     }
 
     // TODO: Remove these references to classes that are styled by core Wagtail CSS. The best
-    // opportunity for this is propably as part of Wagtails general CSS overhaul. -@jonnyscholes
+    // opportunity for this is probably as part of Wagtails general CSS overhaul. -@jonnyscholes
     .field {
         + .field {
             padding-top: $grid-gutter-width / 2;

--- a/client/src/components/Transition/Transition.js
+++ b/client/src/components/Transition/Transition.js
@@ -10,7 +10,7 @@ export const PUSH = 'push';
 export const POP = 'pop';
 
 /**
- * Wrapper arround react-transition-group with default values.
+ * Wrapper around react-transition-group with default values.
  */
 const Transition = ({
   name,

--- a/docs/editor_manual/administrator_tasks/promoted_search_results.rst
+++ b/docs/editor_manual/administrator_tasks/promoted_search_results.rst
@@ -5,7 +5,7 @@ Promoted search results
     Promoted search results are an optional Wagtail feature. For details of how to enable them on a Wagtail installation, see :mod:`~wagtail.contrib.search_promotions`
 
 
-Wagtail allows you to promote certain search results dependant on the keyword or phrase entered by the user when searching. This can be particularly useful when users commonly refer to parts of your organisation via an acronym that isn't in official use, or if you want to direct users to a page when they enter a certain term related to the page but not included in the text of the page itself.
+Wagtail allows you to promote certain search results dependent on the keyword or phrase entered by the user when searching. This can be particularly useful when users commonly refer to parts of your organisation via an acronym that isn't in official use, or if you want to direct users to a page when they enter a certain term related to the page but not included in the text of the page itself.
 
 As a concrete example, one of our clients wanted to direct people who searched for 'finances' to their 'Annual budget review' page. The word 'finances' is not mentioned in either the title or the body of the target page, so they created a promoted search result for the word 'finances' that pushed the budget page to the very top of the results.
 

--- a/docs/extending/rich_text_internals.rst
+++ b/docs/extending/rich_text_internals.rst
@@ -109,7 +109,7 @@ You can create custom rewrite handlers to support your own new ``linktype`` and 
 
         For example, ``PageLinkHandler.get_instance`` might receive ``{'id': 123}`` and return the instance of the Wagtail ``Page`` class with ID 123.
 
-        If left undefined, a default implementation of this method will query the ``id`` model field on the class returned by ``get_model`` using the provided ``id`` attribute; this can be overriden in your own handlers should you want to use some other model field.
+        If left undefined, a default implementation of this method will query the ``id`` model field on the class returned by ``get_model`` using the provided ``id`` attribute; this can be overridden in your own handlers should you want to use some other model field.
 
 Below is an example custom rewrite handler that implements these methods to add support for rich text linking to user email addresses. It supports the conversion of rich text tags like ``<a linktype="user" username="wagtail">`` to valid HTML like ``<a href="mailto:hello@wagtail.io">``. This example assumes that equivalent front-end functionality has been added to allow users to insert these kinds of links into their rich text editor.
 

--- a/docs/reference/contrib/modeladmin/primer.rst
+++ b/docs/reference/contrib/modeladmin/primer.rst
@@ -213,7 +213,7 @@ For example, if you'd like to create your own view class and use it for the
     from .models import MyModel
 
     class MyCustomIndexView(IndexView):
-        # New functionality and exising method overrides added here
+        # New functionality and existing method overrides added here
         ...
 
 

--- a/docs/releases/2.9.rst
+++ b/docs/releases/2.9.rst
@@ -44,7 +44,7 @@ Other features
 * FieldPanel now accepts a 'heading' argument (Jacob Topp-Mugglestone)
 * Replaced deprecated ``ugettext`` / ``ungettext`` calls with ``gettext`` / ``ngettext`` (Mohamed Feddad)
 * ListBlocks now call child block ``bulk_to_python`` if defined (Andy Chosak)
-* Site settings are now identifiable/cachable by request as well as site (Andy Babic)
+* Site settings are now identifiable/cacheable by request as well as site (Andy Babic)
 * Added ``select_related`` attribute to site settings to enable more efficient fetching of foreign key values (Andy Babic)
 * Add caching of image renditions (Tom Dyson, Tim Kamanin)
 * Add documentation for reporting security issues and internationalisation (Matt Westcott)

--- a/wagtail/admin/auth.py
+++ b/wagtail/admin/auth.py
@@ -121,7 +121,7 @@ def user_has_any_page_permission(user):
     Check if a user has any permission to add, edit, or otherwise manage any
     page.
     """
-    # Can't do nothin if you're not active.
+    # Can't do nothin' if you're not active.
     if not user.is_active:
         return False
 

--- a/wagtail/admin/compare.py
+++ b/wagtail/admin/compare.py
@@ -608,7 +608,7 @@ def diff_text(a, b):
     """
     def tokenise(text):
         """
-        Tokenises a string by spliting it into individual characters
+        Tokenises a string by splitting it into individual characters
         and grouping the alphanumeric ones together.
 
         This means that punctuation, whitespace, CJK characters, etc
@@ -658,7 +658,7 @@ def diff_text(a, b):
             for token in a_tok[i1:i2]:
                 changes.append(('equal', token))
 
-    # Merge ajacent changes which have the same type. This just cleans up the HTML a bit
+    # Merge adjacent changes which have the same type. This just cleans up the HTML a bit
     merged_changes = []
     current_value = []
     current_change_type = None

--- a/wagtail/admin/edit_handlers.py
+++ b/wagtail/admin/edit_handlers.py
@@ -378,7 +378,7 @@ class TabbedInterface(BaseFormEditHandler):
     def get_form_class(self):
         form_class = super().get_form_class()
 
-        # Set show_comments_toggle attibute on form class
+        # Set show_comments_toggle attribute on form class
         return type(
             form_class.__name__,
             (form_class, ),

--- a/wagtail/admin/forms/comments.py
+++ b/wagtail/admin/forms/comments.py
@@ -28,7 +28,7 @@ class CommentReplyForm(WagtailAdminModelForm):
 
 class CommentForm(WagtailAdminModelForm):
     """
-    This is designed to be subclassed and have the user overidden to enable user-based validation within the edit handler system
+    This is designed to be subclassed and have the user overridden to enable user-based validation within the edit handler system
     """
     user = None
 

--- a/wagtail/admin/static_src/wagtailadmin/scss/layouts/login.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/layouts/login.scss
@@ -118,7 +118,7 @@ input[type=checkbox]:before {
     line-height: 1.6em;
 }
 
-// Forgotten pasword link
+// Forgotten password link
 .help {
     font-size: 1.3em;
     margin-top: 0;

--- a/wagtail/admin/static_src/wagtailadmin/scss/layouts/page-editor.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/layouts/page-editor.scss
@@ -335,7 +335,7 @@
             border-bottom: 1px solid $color-white;
         }
 
-        // wrapper around add button for mutliple objects. Default version is wordless plus button for contracted groups of fields
+        // wrapper around add button for multiple objects. Default version is wordless plus button for contracted groups of fields
         .add {
             @include transition(background-color 0.2s ease);
             position: relative;
@@ -420,7 +420,7 @@
     }
 }
 
-// Footer control bar for perfoming actions on the page
+// Footer control bar for performing actions on the page
 footer .actions {
     .button {
         font-weight: 600;

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -513,7 +513,7 @@ def admin_urlquote(value):
 def avatar_url(user, size=50, gravatar_only=False):
     """
     A template tag that receives a user and size and return
-    the appropiate avatar url for that user.
+    the appropriate avatar url for that user.
     Example usage: {% avatar_url request.user 50 %}
     """
 
@@ -596,7 +596,7 @@ def timesince_last_update(last_update, time_prefix='', use_shorthand=True):
     """
     Returns:
          - the time of update if last_update is today, if any prefix is supplied, the output will use it
-         - time since last update othewise. Defaults to the simplified timesince,
+         - time since last update otherwise. Defaults to the simplified timesince,
            but can return the full string if needed
     """
     if last_update.date() == datetime.today().date():

--- a/wagtail/admin/tests/api/test_pages.py
+++ b/wagtail/admin/tests/api/test_pages.py
@@ -568,7 +568,7 @@ class TestAdminPageDetail(AdminAPITestCase, TestPageDetail):
         self.assertEqual(content['__types']['demosite.BlogIndexPage']['verbose_name'], 'blog index page')
         self.assertEqual(content['__types']['demosite.BlogIndexPage']['verbose_name_plural'], 'blog index pages')
 
-    # Overriden from public API tests
+    # overridden from public API tests
     def test_meta_parent_id_doesnt_show_root_page(self):
         # Root page is visible in the admin API
         response = self.get_response(2)

--- a/wagtail/admin/tests/pages/test_edit_page.py
+++ b/wagtail/admin/tests/pages/test_edit_page.py
@@ -661,7 +661,7 @@ class TestPageEdit(TestCase, WagtailTestUtils):
         self.child_page = SimplePage(title="Hello world 2", slug="hello-world2", content="hello")
         self.root_page.add_child(instance=self.child_page)
 
-        # Attempt to change the slug to one thats already in use
+        # Attempt to change the slug to one that's already in use
         post_data = {
             'title': "Hello world 2",
             'slug': 'hello-world',

--- a/wagtail/admin/tests/test_account_management.py
+++ b/wagtail/admin/tests/test_account_management.py
@@ -689,7 +689,7 @@ class TestPasswordReset(TestCase, WagtailTestUtils):
 
     def test_password_reset_view_post_invalid_email(self):
         """
-        This posts an incalid email address to the password reset view and
+        This posts an invalid email address to the password reset view and
         checks that the password reset form raises a validation error
         """
         post_data = {

--- a/wagtail/admin/tests/tests.py
+++ b/wagtail/admin/tests/tests.py
@@ -170,7 +170,7 @@ class TestSendMail(TestCase):
         email_message = mail.outbox[0]
         self.assertEqual(email_message.subject, "Test HTML subject")
         self.assertEqual(email_message.alternatives, [('<h2>Test HTML content</h2>', 'text/html')])
-        self.assertEqual(email_message.body, "TEXT content")  # note: plain text will alwasy be added to body, even with alternatives
+        self.assertEqual(email_message.body, "TEXT content")  # note: plain text will always be added to body, even with alternatives
         self.assertEqual(email_message.to, ["has.html@email.com"])
 
         # confirm that without html_message kwarg we do not get 'alternatives'

--- a/wagtail/admin/views/pages/ordering.py
+++ b/wagtail/admin/views/pages/ordering.py
@@ -16,7 +16,7 @@ def set_page_position(request, page_to_move_id):
         # Get position parameter
         position = request.GET.get('position', None)
 
-        # Find page thats already in this position
+        # Find page that's already in this position
         position_page = None
         if position is not None:
             try:

--- a/wagtail/api/v2/tests/test_pages.py
+++ b/wagtail/api/v2/tests/test_pages.py
@@ -611,7 +611,7 @@ class TestPageListing(TestCase):
         self.assertEqual(page_id_list, [10, 15, 17, 21, 22, 23])
 
     def test_descendant_of_root(self):
-        # "root" gets decendants of the homepage of the current site
+        # "root" gets descendants of the homepage of the current site
         # Basically returns every page except the homepage
         response = self.get_response(descendant_of='root')
         content = json.loads(response.content.decode('UTF-8'))

--- a/wagtail/api/v2/views.py
+++ b/wagtail/api/v2/views.py
@@ -181,11 +181,11 @@ class BaseAPIViewSet(GenericViewSet):
 
     def check_query_parameters(self, queryset):
         """
-        Ensure that only valid query paramters are included in the URL.
+        Ensure that only valid query parameters are included in the URL.
         """
         query_parameters = set(self.request.GET.keys())
 
-        # All query paramters must be either a database field or an operation
+        # All query parameters must be either a database field or an operation
         allowed_query_parameters = set(self.get_available_fields(queryset.model, db_fields_only=True)).union(self.known_query_parameters)
         unknown_parameters = query_parameters - allowed_query_parameters
         if unknown_parameters:

--- a/wagtail/contrib/forms/tests/test_views.py
+++ b/wagtail/contrib/forms/tests/test_views.py
@@ -284,7 +284,7 @@ class TestFormsSubmissionsList(TestCase, WagtailTestUtils):
         with self.register_hook('filter_form_submissions_for_user', construct_forms_for_user):
             response = self.client.get(reverse('wagtailforms:list_submissions', args=(self.form_page.id,)))
 
-        # An user cant' see form submissions with the hook
+        # An user can't see form submissions with the hook
         self.assertRedirects(response, '/admin/')
 
     def test_list_submissions_filtering_date_from(self):
@@ -1267,7 +1267,7 @@ class TestFormsWithCustomSubmissionsList(TestCase, WagtailTestUtils):
         form_submission.submit_time = '2016-01-01T12:00:00.000Z'
         form_submission.save()
 
-        # check ordering matches default which is overriden to be 'submit_time' (oldest first)
+        # check ordering matches default which is overridden to be 'submit_time' (oldest first)
         response = self.client.get(reverse('wagtailforms:list_submissions', args=(self.form_page.id,)))
         first_row_values = response.context['data_rows'][0]['fields']
         self.assertTrue('Old chocolate idea' in first_row_values)

--- a/wagtail/contrib/modeladmin/options.py
+++ b/wagtail/contrib/modeladmin/options.py
@@ -593,7 +593,7 @@ class ModelAdminGroup(WagtailRegisterable):
     def __init__(self):
         """
         When initialising, instantiate the classes within 'items', and assign
-        the instances to a 'modeladmin_instances' attribute for convienient
+        the instances to a 'modeladmin_instances' attribute for convenient
         access later
         """
         self.modeladmin_instances = []

--- a/wagtail/contrib/modeladmin/views.py
+++ b/wagtail/contrib/modeladmin/views.py
@@ -926,7 +926,7 @@ class InspectView(InstanceSpecificView):
     def get_fields_dict(self):
         """
         Return a list of `label`/`value` dictionaries to represent the
-        fiels named by the model_admin class's `get_inspect_view_fields` method
+        fields named by the model_admin class's `get_inspect_view_fields` method
         """
         fields = []
         for field_name in self.model_admin.get_inspect_view_fields():

--- a/wagtail/contrib/redirects/management/commands/import_redirects.py
+++ b/wagtail/contrib/redirects/management/commands/import_redirects.py
@@ -67,7 +67,7 @@ class Command(BaseCommand):
         from_index = options.pop("from")
         to_index = options.pop("to")
         site_id = options.pop("site", None)
-        permament = options.pop("permanent")
+        permanent = options.pop("permanent")
 
         dry_run = options.pop("dry_run", False) or options.pop("dry-run", False)
         format_ = options.pop("format", None)
@@ -139,7 +139,7 @@ class Command(BaseCommand):
                 data = {
                     "old_path": from_link,
                     "redirect_link": to_link,
-                    "is_permanent": permament,
+                    "is_permanent": permanent,
                 }
 
                 if site:

--- a/wagtail/contrib/redirects/tests/test_redirects.py
+++ b/wagtail/contrib/redirects/tests/test_redirects.py
@@ -18,7 +18,7 @@ class TestRedirects(TestCase):
         # Create a path
         path = normalise_path('/Hello/world.html;fizz=three;buzz=five?foo=Bar&Baz=quux2')
 
-        # Test against equivalant paths
+        # Test against equivalent paths
         self.assertEqual(path, normalise_path(  # The exact same URL
             '/Hello/world.html;fizz=three;buzz=five?foo=Bar&Baz=quux2'
         ))

--- a/wagtail/contrib/search_promotions/tests.py
+++ b/wagtail/contrib/search_promotions/tests.py
@@ -178,7 +178,7 @@ class TestSearchPromotionsIndexView(TestCase, WagtailTestUtils):
             query=popularQuery,
             page_id=1,
             sort_order=15,
-            description="An odly popular search term?",
+            description="An oddly popular search term?",
         )
 
         popularQuery = Query.get("suboptimal")

--- a/wagtail/contrib/table_block/blocks.py
+++ b/wagtail/contrib/table_block/blocks.py
@@ -157,14 +157,14 @@ class TableBlock(FieldBlock):
         table_options can contain any valid handsontable options:
         https://handsontable.com/docs/6.2.2/Options.html
         contextMenu: if value from table_options is True, still use default
-        language: if value is not in table_options, attempt to get from envrionment
+        language: if value is not in table_options, attempt to get from environment
         """
 
         collected_table_options = DEFAULT_TABLE_OPTIONS.copy()
 
         if table_options is not None:
             if table_options.get('contextMenu', None) is True:
-                # explicity check for True, as value could also be array
+                # explicitly check for True, as value could also be array
                 # delete to ensure the above default is kept for contextMenu
                 del table_options['contextMenu']
             collected_table_options.update(table_options)

--- a/wagtail/contrib/table_block/tests.py
+++ b/wagtail/contrib/table_block/tests.py
@@ -301,7 +301,7 @@ class TestTableBlockForm(WagtailTestUtils, SimpleTestCase):
                 ['Brenik', 'Small Military Vessel', 'Destroyed'],
             ]
         }
-        # set language from testing envrionment
+        # set language from testing environment
         language = translation.get_language()
 
         self.default_table_options = DEFAULT_TABLE_OPTIONS.copy()
@@ -325,7 +325,7 @@ class TestTableBlockForm(WagtailTestUtils, SimpleTestCase):
 
     def test_table_options_language(self):
         """
-        Test that the envrionment's language is used if no language provided.
+        Test that the environment's language is used if no language provided.
         """
         # default must always contain a language value
         block = TableBlock()
@@ -338,7 +338,7 @@ class TestTableBlockForm(WagtailTestUtils, SimpleTestCase):
         # Italian
         block_it = TableBlock()
         self.assertEqual('it', block_it.table_options['language'])
-        # table_options with language provided, different to envrionment
+        # table_options with language provided, different to environment
         block_with_lang = TableBlock(table_options={'language': 'ja'})
         self.assertNotEqual('it', block_with_lang.table_options['language'])
         self.assertEqual('ja', block_with_lang.table_options['language'])

--- a/wagtail/core/blocks/base.py
+++ b/wagtail/core/blocks/base.py
@@ -289,7 +289,7 @@ class Block(metaclass=BaseBlock):
             errors.append(checks.Error(
                 "Block name %r is invalid" % self.name,
                 "Block names should follow standard Python conventions for "
-                "variable names: alpha-numeric and underscores, and cannot "
+                "variable names: alphanumeric and underscores, and cannot "
                 "begin with a digit",
                 obj=kwargs.get('field', self),
                 id='wagtailcore.E001',

--- a/wagtail/core/log_actions.py
+++ b/wagtail/core/log_actions.py
@@ -20,7 +20,7 @@ class LogActionRegistry:
         # Holds a list of action, action label tuples for use in filters
         self.choices = []
 
-        # Holds the action messsages, keyed by action
+        # Holds the action messages, keyed by action
         self.messages = {}
 
         # Holds the comments, keyed by action

--- a/wagtail/core/models/__init__.py
+++ b/wagtail/core/models/__init__.py
@@ -1742,7 +1742,7 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
         An alias is like a copy, but an alias remains in sync with the original page. They
         are not directly editable and do not have revisions.
 
-        You can convert an alias into a regular page by setting the .alias_of attibute to None
+        You can convert an alias into a regular page by setting the .alias_of attribute to None
         and creating an initial revision.
 
         :param recursive: create aliases of the page's subtree, defaults to False

--- a/wagtail/core/sites.py
+++ b/wagtail/core/sites.py
@@ -37,7 +37,7 @@ def get_site_for_hostname(hostname, port):
     ))
 
     if sites:
-        # if theres a unique match or hostname (with port or default) match
+        # if there's a unique match or hostname (with port or default) match
         if len(sites) == 1 or sites[0].match in (MATCH_HOSTNAME_PORT, MATCH_HOSTNAME_DEFAULT):
             return sites[0]
 

--- a/wagtail/core/tests/test_blocks.py
+++ b/wagtail/core/tests/test_blocks.py
@@ -3831,7 +3831,7 @@ class TestSystemCheck(TestCase):
         errors = block.check()
         self.assertEqual(len(errors), 1)
         self.assertEqual(errors[0].id, 'wagtailcore.E001')
-        self.assertEqual(errors[0].hint, "Block names should follow standard Python conventions for variable names: alpha-numeric and underscores, and cannot begin with a digit")
+        self.assertEqual(errors[0].hint, "Block names should follow standard Python conventions for variable names: alphanumeric and underscores, and cannot begin with a digit")
         self.assertEqual(errors[0].obj, block.child_blocks['rich+text'])
 
     def test_name_must_be_nonempty(self):
@@ -4132,7 +4132,7 @@ class BlockUsingGetTemplateMethod(blocks.Block):
 
 
 class TestOverriddenGetTemplateBlockTag(TestCase):
-    def test_template_is_overriden_by_get_template(self):
+    def test_template_is_overridden_by_get_template(self):
 
         block = BlockUsingGetTemplateMethod(template='tests/blocks/this_shouldnt_be_used.html')
         template = block.get_template()

--- a/wagtail/core/tests/test_locale_model.py
+++ b/wagtail/core/tests/test_locale_model.py
@@ -40,7 +40,7 @@ class TestLocaleModel(TestCase):
         locale = Locale.objects.get(language_code="en")
         self.assertEqual(locale.get_display_name(), "English")
 
-    def test_get_display_name_for_unconfigured_langauge(self):
+    def test_get_display_name_for_unconfigured_language(self):
         # This language is not in LANGUAGES so it should just return the language code
         locale = Locale.objects.create(language_code="foo")
         self.assertIsNone(locale.get_display_name())
@@ -49,7 +49,7 @@ class TestLocaleModel(TestCase):
         locale = Locale.objects.get(language_code="en")
         self.assertEqual(str(locale), "English")
 
-    def test_str_for_unconfigured_langauge(self):
+    def test_str_for_unconfigured_language(self):
         # This language is not in LANGUAGES so it should just return the language code
         locale = Locale.objects.create(language_code="foo")
         self.assertEqual(str(locale), "foo")

--- a/wagtail/core/tests/test_page_model.py
+++ b/wagtail/core/tests/test_page_model.py
@@ -191,7 +191,7 @@ class TestSiteRouting(TestCase):
 
     def test_unrecognised_port_and_unrecognised_host_routes_to_default_site(self):
         # requests with an unrecognised Host: header _and_ an unrecognised port
-        # hould be directed to the default site
+        # should be directed to the default site
         request = HttpRequest()
         request.path = '/'
         request.META['HTTP_HOST'] = self.unrecognised_hostname
@@ -2219,7 +2219,7 @@ class TestCopyForTranslation(TestCase):
         self.assertEqual(fr_homepage.locale, self.fr_locale)
         self.assertEqual(fr_homepage.translation_key, self.en_homepage.translation_key)
 
-        # At the top level, the langauge code should be appended to the slug
+        # At the top level, the language code should be appended to the slug
         self.assertEqual(fr_homepage.slug, "home-fr")
 
         # Translation must be in draft
@@ -2421,7 +2421,7 @@ class TestSubpageTypeBusinessRules(TestCase, WagtailTestUtils):
         parent1.add_child(instance=SimpleChildPage(title='simple child', slug='simple-child'))
 
         # We already have a `SimpleChildPage` as a child of `parent1`, and since it is limited
-        # to have only 1 child page, we cannot create anoter one. However, we should still be able
+        # to have only 1 child page, we cannot create another one. However, we should still be able
         # to create an instance for this page at a different location (as child of `parent2`)
         self.assertFalse(SimpleChildPage.can_create_at(parent1))
         self.assertTrue(SimpleChildPage.can_create_at(parent2))

--- a/wagtail/core/tests/test_page_permissions.py
+++ b/wagtail/core/tests/test_page_permissions.py
@@ -770,7 +770,7 @@ class TestPagePermissionTesterCanCopyTo(TestCase):
         event_page_perms = self.event_page.permissions_for_user(user)
         singleton_page_perms = self.singleton_page.permissions_for_user(user)
 
-        # A superuser has full permissions, so these are self explainatory
+        # A superuser has full permissions, so these are self explanatory
         self.assertTrue(event_page_perms.can_copy_to(self.event_page.get_parent()))
         self.assertTrue(board_meetings_page_perms.can_copy_to(self.board_meetings_page.get_parent()))
         # However, SingletonPageViaMaxCount.can_create_at() prevents copying, regardless of a user's permissions

--- a/wagtail/core/tests/test_translatablemixin.py
+++ b/wagtail/core/tests/test_translatablemixin.py
@@ -146,7 +146,7 @@ class TestTranslatableMixin(TestCase):
         self.assertNotEqual(copy_translatable_child, instance_translatable_child)
         self.assertEqual(copy_translatable_child.field, "A translatable child object")
 
-        # Check the translatable childs locale was updated but translation key is the same
+        # Check the translatable child's locale was updated but translation key is the same
         self.assertEqual(copy_translatable_child.translation_key, instance_translatable_child.translation_key)
         self.assertEqual(copy_translatable_child.locale, self.another_locale)
 

--- a/wagtail/core/tests/test_whitelist.py
+++ b/wagtail/core/tests/test_whitelist.py
@@ -37,7 +37,7 @@ class TestAttributeRule(TestCase):
 
     def test_rule_true_for_attr(self):
         """
-        Test that attribute_rule() does not change atrributes
+        Test that attribute_rule() does not change attributes
         when the corresponding rule returns True
         """
         tag = self.soup.b
@@ -47,7 +47,7 @@ class TestAttributeRule(TestCase):
 
     def test_rule_false_for_attr(self):
         """
-        Test that attribute_rule() drops atrributes
+        Test that attribute_rule() drops attributes
         when the corresponding rule returns False
         """
         tag = self.soup.b

--- a/wagtail/documents/__init__.py
+++ b/wagtail/documents/__init__.py
@@ -17,7 +17,7 @@ def get_document_model_string():
 def get_document_model():
     """
     Get the document model from the ``WAGTAILDOCS_DOCUMENT_MODEL`` setting.
-    Defauts to the standard :class:`~wagtail.documents.models.Document` model
+    Defaults to the standard :class:`~wagtail.documents.models.Document` model
     if no custom model is defined.
     """
     from django.apps import apps

--- a/wagtail/images/static_src/wagtailimages/js/focal-point-chooser.js
+++ b/wagtail/images/static_src/wagtailimages/js/focal-point-chooser.js
@@ -72,7 +72,7 @@ $(function() {
     $(window).on('resize', $.debounce(300, function() {
         // jcrop doesn't support responsive images so to cater for resizing the browser
         // we have to destroy() it, which doesn't properly do it,
-        // so destory it some more, then re-apply it
+        // so destroy it some more, then re-apply it
         jcropapi.destroy();
         $image.removeAttr('style');
         $('.jcrop-holder').remove();

--- a/wagtail/images/static_src/wagtailimages/js/vendor/jquery.fileupload-validate.js
+++ b/wagtail/images/static_src/wagtailimages/js/vendor/jquery.fileupload-validate.js
@@ -33,7 +33,7 @@
         {
             action: 'validate',
             // Always trigger this action,
-            // even if the previous action was rejected: 
+            // even if the previous action was rejected:
             always: true,
             // Options taken from the global options map:
             acceptFileTypes: '@',
@@ -62,7 +62,7 @@
             */
 
             // Function returning the current number of files,
-            // has to be overriden for maxNumberOfFiles validation:
+            // has to be overridden for maxNumberOfFiles validation:
             getNumberOfFiles: $.noop,
 
             // Error and info messages:

--- a/wagtail/images/tests/test_admin_views.py
+++ b/wagtail/images/tests/test_admin_views.py
@@ -499,10 +499,10 @@ class TestImageEditView(TestCase, WagtailTestUtils):
     @override_settings(DEFAULT_FILE_STORAGE='wagtail.tests.dummy_external_storage.DummyExternalStorage')
     def test_simple_with_external_storage(self):
         # The view calls get_file_size on the image that closes the file if
-        # file_size wasn't prevously populated.
+        # file_size wasn't previously populated.
 
         # The view then attempts to reopen the file when rendering the template
-        # which caused crashes when certian storage backends were in use.
+        # which caused crashes when certain storage backends were in use.
         # See #1397
 
         response = self.get()
@@ -1965,7 +1965,7 @@ class TestURLGeneratorView(TestCase, WagtailTestUtils):
     def test_get_bad_permissions(self):
         """
         This tests that the view returns a "permission denied" redirect if a user without correct
-        permissions attemts to access it
+        permissions attempts to access it
         """
         # Remove privileges from user
         self.user.is_superuser = False
@@ -2019,7 +2019,7 @@ class TestGenerateURLView(TestCase, WagtailTestUtils):
 
     def test_get_bad_permissions(self):
         """
-        This tests that the view gives a 403 if a user without correct permissions attemts to access it
+        This tests that the view gives a 403 if a user without correct permissions attempts to access it
         """
         # Remove privileges from user
         self.user.is_superuser = False

--- a/wagtail/search/backends/__init__.py
+++ b/wagtail/search/backends/__init__.py
@@ -26,7 +26,7 @@ def get_search_backend_config():
 
 def import_backend(dotted_path):
     """
-    Theres two formats for the dotted_path.
+    There's two formats for the dotted_path.
     One with the backend class (old) and one without (new)
     eg:
       old: wagtail.search.backends.elasticsearch.ElasticsearchSearchBackend

--- a/wagtail/search/backends/base.py
+++ b/wagtail/search/backends/base.py
@@ -357,7 +357,7 @@ class BaseSearchBackend:
         if not class_is_indexed(model):
             return EmptySearchResults()
 
-        # Check that theres still a query string after the clean up
+        # Check that there's still a query string after the clean up
         if query == "":
             return EmptySearchResults()
 

--- a/wagtail/search/management/commands/update_index.py
+++ b/wagtail/search/management/commands/update_index.py
@@ -152,7 +152,7 @@ class Command(BaseCommand):
 
             self.stdout.flush()
 
-    # Atomic so the count of models doesnt change as it is iterated
+    # Atomic so the count of models doesn't change as it is iterated
     @transaction.atomic
     def queryset_chunks(self, qs, chunk_size=DEFAULT_CHUNK_SIZE):
         """

--- a/wagtail/tests/settings.py
+++ b/wagtail/tests/settings.py
@@ -111,7 +111,7 @@ MIDDLEWARE = (
 
 INSTALLED_APPS = [
     # Install wagtailredirects with its appconfig
-    # Theres nothing special about wagtailredirects, we just need to have one
+    # There's nothing special about wagtailredirects, we just need to have one
     # app which uses AppConfigs to test that hooks load properly
     'wagtail.contrib.redirects.apps.WagtailRedirectsAppConfig',
 

--- a/wagtail/tests/snippets/models.py
+++ b/wagtail/tests/snippets/models.py
@@ -13,7 +13,7 @@ from .forms import FancySnippetForm
 
 # AlphaSnippet and ZuluSnippet are for testing ordering of
 # snippets when registering.  They are named as such to ensure
-# thier ordering is clear.  They are registered during testing
+# their ordering is clear.  They are registered during testing
 # to ensure specific [in]correct register ordering
 
 # AlphaSnippet is registered during TestSnippetOrdering

--- a/wagtail/tests/testapp/models.py
+++ b/wagtail/tests/testapp/models.py
@@ -681,7 +681,7 @@ class FormPageWithCustomSubmissionListView(AbstractEmailForm):
     ]
 
 
-# FormPage with cutom FormBuilder
+# FormPage with custom FormBuilder
 
 EXTENDED_CHOICES = FORM_FIELD_CHOICES + (('ipaddress', 'IP Address'),)
 

--- a/wagtail/tests/utils/page_tests.py
+++ b/wagtail/tests/utils/page_tests.py
@@ -81,7 +81,7 @@ class WagtailPageTests(WagtailTestUtils, TestCase):
 
         explore_url = reverse('wagtailadmin_explore', args=[parent.pk])
         if response.redirect_chain != [(explore_url, 302)]:
-            msg = self._formatMessage(msg, 'Creating a page %s.%s didnt redirect the user to the explorer, but to %s' % (
+            msg = self._formatMessage(msg, 'Creating a page %s.%s didn\'t redirect the user to the explorer, but to %s' % (
                 child_model._meta.app_label, child_model._meta.model_name,
                 response.redirect_chain))
             raise self.failureException(msg)

--- a/wagtail/users/tests.py
+++ b/wagtail/users/tests.py
@@ -1557,7 +1557,7 @@ class TestGroupEditView(TestCase, WagtailTestUtils):
         self.add_non_registered_perm()
         original_permissions = list(self.test_group.permissions.all())  # list() to force evaluation
 
-        # submit the form with no changes (only submitting the exsisting
+        # submit the form with no changes (only submitting the existing
         # permission, as in the self.post function definition)
         self.post()
 


### PR DESCRIPTION
These spelling fixes were made manually following suggestions from ``codespell``

To run ``codespell`` yourself:

```
pip install codespell
codespell -S *.po,*.map,*/vendor/*,*vendor.js*,./node_modules/*,./docs/_build/*,./storybook-static/*,./wagtail/admin/static/wagtailadmin/js/*,./package-lock.json
```