### PR TITLE
Fix Uncaught ReferenceError when editing links in Hallo

### DIFF
--- a/client/src/entrypoints/admin/hallo-plugins/hallo-wagtaillink.js
+++ b/client/src/entrypoints/admin/hallo-plugins/hallo-wagtaillink.js
@@ -30,6 +30,7 @@ $.widget('IKS.hallowagtaillink', {
     addButton.on('click', () => {
       let href;
       let linkType;
+      let parentPageId;
 
       // Defaults.
       let url = window.chooserUrls.pageChooser;
@@ -45,15 +46,12 @@ $.widget('IKS.hallowagtaillink', {
 
       if (enclosingLink) {
         href = enclosingLink.getAttribute('href');
-        // eslint-disable-next-line no-undef
         parentPageId = enclosingLink.getAttribute('data-parent-id');
         linkType = enclosingLink.getAttribute('data-linktype');
 
         urlParams.link_text = enclosingLink.innerText;
 
-        // eslint-disable-next-line no-undef
         if (linkType === 'page' && parentPageId) {
-          // eslint-disable-next-line no-undef
           url = window.chooserUrls.pageChooser + parentPageId.toString() + '/';
         } else if (href.startsWith('mailto:')) {
           url = window.chooserUrls.emailLinkChooser;


### PR DESCRIPTION
When editing links with the hallo rich text editor, I get the following error if the link has been saved (either as draft or by publishing):

```javascript
Uncaught ReferenceError: assignment to undeclared variable parentPageId
    populateToolbar hallo-wagtaillink.js:48
```

I see this on Wagtail 2.14 and with all 3 browsers I have tried (Safari, Chrome, and Firefox). This PR fixes that problem by declaring the parentPageId variable. 

(I also see this problem on 2.12 and 2.13 but because those are not receiving support and Hallo is deprecated, I don't see that we need to backport to those releases. But if there is going to be a 2.14.1 release, I would be grateful if this could be included there.)