### PR TITLE
Make WagtailAPIRouter obey WAGTAIL_APPEND_SLASH.

### DIFF
--- a/wagtail/api/v2/router.py
+++ b/wagtail/api/v2/router.py
@@ -2,6 +2,7 @@ import functools
 
 from django.urls import include, re_path
 
+from wagtai.core.utils import WAGTAIL_APPEND_SLASH
 from wagtail.utils.urlpatterns import decorate_urlpatterns
 
 
@@ -68,8 +69,12 @@ class WagtailAPIRouter:
         urlpatterns = []
 
         for name, class_ in self._endpoints.items():
+            if WAGTAIL_APPEND_SLASH:
+                path_regex = r'^{}/'.format(name)
+            else:
+                path_regex = r'^{}'.format(name)
             pattern = re_path(
-                r'^{}/'.format(name),
+                path_regex,
                 include((class_.get_urlpatterns(), name), namespace=name)
             )
             urlpatterns.append(pattern)

--- a/wagtail/api/v2/router.py
+++ b/wagtail/api/v2/router.py
@@ -2,7 +2,7 @@ import functools
 
 from django.urls import include, re_path
 
-from wagtai.core.utils import WAGTAIL_APPEND_SLASH
+from wagtail.core.utils import WAGTAIL_APPEND_SLASH
 from wagtail.utils.urlpatterns import decorate_urlpatterns
 
 

--- a/wagtail/api/v2/tests/test_pages.py
+++ b/wagtail/api/v2/tests/test_pages.py
@@ -30,6 +30,14 @@ class TestPageListing(TestCase):
 
     # BASIC TESTS
 
+    def test_slashes(self):
+        self.assertEqual(reverse('wagtailapi_v2:pages:listing'), '/api/main/pages/')
+        self.assertEqual(self.client.get('/api/main/pages').status_code, 404)
+
+    @override_settings(WAGTAIL_APPEND_SLASH=False)
+    def test_no_slashes(self):
+        self.assertEqual(self.client.get('/api/main/pages').status_code, 301)
+
     def test_basic(self):
         response = self.get_response()
 

--- a/wagtail/api/v2/views.py
+++ b/wagtail/api/v2/views.py
@@ -13,6 +13,7 @@ from rest_framework.viewsets import GenericViewSet
 
 from wagtail.api import APIField
 from wagtail.core.models import Page, Site
+from wagtail.core.utils import WAGTAIL_APPEND_SLASH
 
 from .filters import (
     AncestorOfFilter, ChildOfFilter, DescendantOfFilter, FieldsFilter, LocaleFilter, OrderingFilter,
@@ -336,10 +337,16 @@ class BaseAPIViewSet(GenericViewSet):
         """
         This returns a list of URL patterns for the endpoint
         """
+        if WAGTAIL_APPEND_SLASH:
+            detail_path = '<int:pk>/'
+            find_path = 'find/'
+        else:
+            detail_path = '/<int:pk>'
+            find_path = '/find'
         return [
             path('', cls.as_view({'get': 'listing_view'}), name='listing'),
-            path('<int:pk>/', cls.as_view({'get': 'detail_view'}), name='detail'),
-            path('find/', cls.as_view({'get': 'find_view'}), name='find'),
+            path(detail_path, cls.as_view({'get': 'detail_view'}), name='detail'),
+            path(find_path, cls.as_view({'get': 'find_view'}), name='find'),
         ]
 
     @classmethod


### PR DESCRIPTION
WagtailAPIRouter assumes that all API urls have to end in `/`, which should not be true when `WAGTAIL_APPEND_SLASH=False`. This PR fixes that assumption.

The tests I added are not the best... but I couldn't come up with a better way to confirm that the end-`/` is not necessary in the URL when `WAGTAIL_APPEND_SLASH=False`. I'm sure there's a better way to do this.