### PR TITLE
Template components (take 2)

### DIFF
--- a/docs/extending/index.rst
+++ b/docs/extending/index.rst
@@ -10,6 +10,7 @@ This section describes the various mechanisms that can be used to integrate your
     :maxdepth: 2
 
     admin_views
+    template_components
     adding_reports
     custom_tasks
     audit_log

--- a/docs/extending/template_components.md
+++ b/docs/extending/template_components.md
@@ -1,0 +1,159 @@
+# Template components
+
+Working with objects that know how to render themselves as elements on an HTML template is a common pattern seen throughout the Wagtail admin. For example, the admin homepage is a view provided by the central `wagtail.admin` app, but brings together information panels sourced from various other modules of Wagtail, such as images and documents (potentially along with others provided by third-party packages). These panels are passed to the homepage via the [`construct_homepage_panels`](../reference/hooks.html#construct-homepage-panels) hook, and each one is responsible for providing its own HTML rendering. In this way, the module providing the panel has full control over how it appears on the homepage.
+
+Wagtail implements this pattern using a standard object type known as a **component**. A component is a Python object that provides the following methods and properties:
+
+```eval_rst
+.. method:: render_html(self, parent_context=None)
+
+Given a context dictionary from the calling template (which may be a :py:class:`Context <django.template.Context>` object or a plain ``dict`` of context variables), returns the string representation to be inserted into the template. This will be subject to Django's HTML escaping rules, so a return value consisting of HTML should typically be returned as a :py:mod:`SafeString <django.utils.safestring>` instance.
+
+.. attribute:: media
+
+A (possibly empty) :doc:`form media <django:topics/forms/media>` object defining JavaScript and CSS resources used by the component.
+
+.. note::
+   Any object implementing this API can be considered a valid component; it does not necessarily have to inherit from the ``Component`` class described below, and user code that works with components should not assume this (for example, it must not use ``isinstance`` to check whether a given value is a component).
+```
+
+
+## Creating components
+
+The simplest way to create a component is to define a subclass of `wagtail.admin.ui.components.Component` and specify a `template_name` attribute on it. The rendered template will then be used as the component's HTML representation:
+
+```python
+from wagtail.admin.ui.components import Component
+
+class WelcomePanel(Component):
+    template_name = 'my_app/panels/welcome.html'
+
+
+my_welcome_panel = WelcomePanel()
+```
+
+`my_app/templates/my_app/panels/welcome.html`:
+
+```html+django
+<h1>Welcome to my app!</h1>
+```
+
+For simple cases that don't require a template, the `render_html` method can be overridden instead:
+
+```python
+from django.utils.html import format_html
+from wagtail.admin.components import Component
+
+class WelcomePanel(Component):
+    def render_html(self, parent_context):
+        return format_html("<h1>{}</h1>", "Welcome to my app!")
+```
+
+
+## Passing context to the template
+
+The `get_context_data` method can be overridden to pass context variables to the template. As with `render_html`, this receives the context dictionary from the calling template:
+
+```python
+from wagtail.admin.ui.components import Component
+
+class WelcomePanel(Component):
+    template_name = 'my_app/panels/welcome.html'
+
+    def get_context_data(self, parent_context):
+        context = super().get_context_data(parent_context)
+        context['username'] = parent_context['request'].user.username
+        return context
+```
+
+`my_app/templates/my_app/panels/welcome.html`:
+
+```html+django
+<h1>Welcome to my app, {{ username }}!</h1>
+```
+
+
+## Adding media definitions
+
+Like Django form widgets, components can specify associated JavaScript and CSS resources using either an inner `Media` class or a dynamic `media` property:
+
+```python
+class WelcomePanel(Component):
+    template_name = 'my_app/panels/welcome.html'
+
+    class Media:
+        css = {
+            'all': ('my_app/css/welcome-panel.css',)
+        }
+```
+
+
+## Using components on your own templates
+
+The `wagtailadmin_tags` tag library provides a `{% component %}` tag for including components on a template. This takes care of passing context variables from the calling template to the component (which would not be the case for a basic `{{ ... }}` variable tag). For example, given the view:
+
+```python
+from django.shortcuts import render
+
+def welcome_page(request):
+    panels = [
+        WelcomePanel(),
+    ]
+
+    render(request, 'my_app/welcome.html', {
+        'panels': panels,
+    })
+```
+
+the `my_app/welcome.html` template could render the panels as follows:
+
+```html+django
+{% load wagtailadmin_tags %}
+{% for panel in panels %}
+    {% component panel %}
+{% endfor %}
+```
+
+Note that it is your template's responsibility to output any media declarations defined on the components. For a Wagtail admin view, this is best done by constructing a media object for the whole page within the view, passing this to the template, and outputting it via the base template's `extra_js` and `extra_css` blocks:
+
+```python
+from django.forms import Media
+from django.shortcuts import render
+
+def welcome_page(request):
+    panels = [
+        WelcomePanel(),
+    ]
+
+    media = Media()
+    for panel in panels:
+        media += panel.media
+
+    render(request, 'my_app/welcome.html', {
+        'panels': panels,
+        'media': media,
+    })
+```
+
+``my_app/welcome.html``:
+
+```html+django
+{% extends "wagtailadmin/base.html" %}
+{% load wagtailadmin_tags %}
+
+{% block extra_js %}
+    {{ block.super }}
+    {{ media.js }}
+{% endblock %}
+
+{% block extra_css %}
+    {{ block.super }}
+    {{ media.css }}
+{% endblock %}
+
+{% block content %}
+    {% for panel in panels %}
+        {% component panel %}
+    {% endfor %}
+{% endblock %}
+```

--- a/docs/extending/template_components.md
+++ b/docs/extending/template_components.md
@@ -17,7 +17,9 @@ A (possibly empty) :doc:`form media <django:topics/forms/media>` object defining
    Any object implementing this API can be considered a valid component; it does not necessarily have to inherit from the ``Component`` class described below, and user code that works with components should not assume this (for example, it must not use ``isinstance`` to check whether a given value is a component).
 ```
 
-
+```eval_rst
+.. _creating_template_components:
+```
 ## Creating components
 
 The simplest way to create a component is to define a subclass of `wagtail.admin.ui.components.Component` and specify a `template_name` attribute on it. The rendered template will then be used as the component's HTML representation:

--- a/docs/extending/template_components.md
+++ b/docs/extending/template_components.md
@@ -22,7 +22,7 @@ A (possibly empty) :doc:`form media <django:topics/forms/media>` object defining
 ```
 ## Creating components
 
-The simplest way to create a component is to define a subclass of `wagtail.admin.ui.components.Component` and specify a `template_name` attribute on it. The rendered template will then be used as the component's HTML representation:
+The preferred way to create a component is to define a subclass of `wagtail.admin.ui.components.Component` and specify a `template_name` attribute on it. The rendered template will then be used as the component's HTML representation:
 
 ```python
 from wagtail.admin.ui.components import Component

--- a/docs/reference/hooks.rst
+++ b/docs/reference/hooks.rst
@@ -113,18 +113,19 @@ Hooks for building new areas of the admin interface (alongside pages, images, do
 ``construct_homepage_panels``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-  Add or remove panels from the Wagtail admin homepage. The callable passed into this hook should take a ``request`` object and a list of ``panels``, objects which have a ``render()`` method returning a string. The objects also have an ``order`` property, an integer used for ordering the panels. The default panels use integers between ``100`` and ``300``. Hook functions should modify the ``panels`` list in-place as required.
+  Add or remove panels from the Wagtail admin homepage. The callable passed into this hook should take a ``request`` object and a list of panel objects, and should modify this list in-place as required. Panel objects are :doc:`components </extending/template_components>` with an additional ``order`` property, an integer that determines the panel's position in the final ordered list. The default panels use integers between ``100`` and ``300``.
 
   .. code-block:: python
 
     from django.utils.safestring import mark_safe
 
+    from wagtail.admin.ui.components import Component
     from wagtail.core import hooks
 
-    class WelcomePanel:
+    class WelcomePanel(Component):
         order = 50
 
-        def render(self):
+        def render_html(self, parent_context):
             return mark_safe("""
             <section class="panel summary nice-padding">
               <h3>No, but seriously -- welcome to the admin homepage.</h3>
@@ -141,7 +142,19 @@ Hooks for building new areas of the admin interface (alongside pages, images, do
 ``construct_homepage_summary_items``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-  Add or remove items from the 'site summary' bar on the admin homepage (which shows the number of pages and other object that exist on the site). The callable passed into this hook should take a ``request`` object and a list of ``SummaryItem`` objects to be modified as required. These objects have a ``render()`` method, which returns an HTML string, and an ``order`` property, which is an integer that specifies the order in which the items will appear.
+  Add or remove items from the 'site summary' bar on the admin homepage (which shows the number of pages and other object that exist on the site). The callable passed into this hook should take a ``request`` object and a list of summary item objects, and should modify this list in-place as required. Summary item objects are instances of ``wagtail.admin.site_summary.SummaryItem``, which extends :ref:`the Component class <creating_template_components>` with the following additional methods and properties:
+
+  .. method:: SummaryItem(request)
+
+    Constructor; receives the request object its argument
+
+  .. attribute:: order
+
+    An integer that specifies the item's position in the sequence.
+
+  .. method:: is_shown()
+
+    Returns a boolean indicating whether the summary item should be shown on this request.
 
 
 .. _construct_main_menu:

--- a/docs/reference/hooks.rst
+++ b/docs/reference/hooks.rst
@@ -730,7 +730,7 @@ Hooks for customising the way users are directed through the process of creating
 ``register_page_action_menu_item``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-  Add an item to the popup menu of actions on the page creation and edit views. The callable passed to this hook must return an instance of ``wagtail.admin.action_menu.ActionMenuItem``. The following attributes and methods are available to be overridden on subclasses of ``ActionMenuItem``:
+  Add an item to the popup menu of actions on the page creation and edit views. The callable passed to this hook must return an instance of ``wagtail.admin.action_menu.ActionMenuItem``. ``ActionMenuItem`` is a subclass of :ref:`Component <creating_template_components>` and so the rendering of the menu item can be customised through ``template_name``, ``get_context_data``, ``render_html`` and ``Media``. In addition, the following attributes and methods are available to be overridden:
 
   :order: an integer (default 100) which determines the item's position in the menu. Can also be passed as a keyword argument to the object constructor. The lowest-numbered item in this sequence will be selected as the default menu item; as standard, this is "Save draft" (which has an ``order`` of 0).
   :label: the displayed text of the menu item
@@ -739,16 +739,13 @@ Hooks for customising the way users are directed through the process of creating
   :icon_name: icon to display against the menu item
   :classname: a ``class`` attribute value to add to the button element
   :is_shown: a method which returns a boolean indicating whether the menu item should be shown; by default, true except when editing a locked page
-  :template: path to a template to render to produce the menu item HTML
-  :get_context: a method that returns a context dictionary to pass to the template
-  :render_html: a method that returns the menu item HTML; by default, renders ``template`` with the context returned from ``get_context``
-  :Media: an inner class defining JavaScript and CSS to import when this menu item is shown - see `Django form media <https://docs.djangoproject.com/en/stable/topics/forms/media/>`_
 
-  The ``get_url``, ``is_shown``, ``get_context`` and ``render_html`` methods all accept a request object and a context dictionary containing the following fields:
+  The ``get_url``, ``is_shown``, ``get_context_data`` and ``render_html`` methods all accept a context dictionary containing the following fields:
 
   :view: name of the current view: ``'create'``, ``'edit'`` or ``'revisions_revert'``
   :page: For ``view`` = ``'edit'`` or ``'revisions_revert'``, the page being edited
   :parent_page: For ``view`` = ``'create'``, the parent page of the page being created
+  :request: The current request object
   :user_page_permissions: a ``UserPagePermissionsProxy`` object for the current user, to test permissions against
 
   .. code-block:: python
@@ -760,7 +757,7 @@ Hooks for customising the way users are directed through the process of creating
         name = 'action-guacamole'
         label = "Guacamole"
 
-        def get_url(self, request, context):
+        def get_url(self, context):
             return "https://www.youtube.com/watch?v=dNJdJIwCF_Y"
 
 
@@ -1247,8 +1244,7 @@ Hooks for working with registered Snippets.
 
   Add an item to the popup menu of actions on the snippet creation and edit views.
   The callable passed to this hook must return an instance of
-  ``wagtail.snippets.action_menu.ActionMenuItem``. The following attributes and
-  methods are available to be overridden on subclasses of ``ActionMenuItem``:
+  ``wagtail.snippets.action_menu.ActionMenuItem``. ``ActionMenuItem`` is a subclass of :ref:`Component <creating_template_components>` and so the rendering of the menu item can be customised through ``template_name``, ``get_context_data``, ``render_html`` and ``Media``. In addition, the following attributes and methods are available to be overridden:
 
   :order: an integer (default 100) which determines the item's position in the menu. Can also be passed as a keyword argument to the object constructor. The lowest-numbered item in this sequence will be selected as the default menu item; as standard, this is "Save draft" (which has an ``order`` of 0).
   :label: the displayed text of the menu item
@@ -1257,16 +1253,13 @@ Hooks for working with registered Snippets.
   :icon_name: icon to display against the menu item
   :classname: a ``class`` attribute value to add to the button element
   :is_shown: a method which returns a boolean indicating whether the menu item should be shown; by default, true except when editing a locked page
-  :template: the path to a template to render to produce the menu item HTML
-  :get_context: a method that returns a context dictionary to pass to the template
-  :render_html: a method that returns the menu item HTML; by default, renders ``template`` with the context returned from ``get_context``
-  :Media: an inner class defining Javascript and CSS to import when this menu item is shown - see `Django form media <https://docs.djangoproject.com/en/stable/topics/forms/media/>`_
 
-  The ``get_url``, ``is_shown``, ``get_context`` and ``render_html`` methods all accept a request object and a context dictionary containing the following fields:
+  The ``get_url``, ``is_shown``, ``get_context_data`` and ``render_html`` methods all accept a context dictionary containing the following fields:
 
   :view: name of the current view: ``'create'`` or ``'edit'``
-  :model: The snippets model class
+  :model: The snippet's model class
   :instance: For ``view`` = ``'edit'``, the instance being edited
+  :request: The current request object
 
   .. code-block:: python
 
@@ -1277,7 +1270,7 @@ Hooks for working with registered Snippets.
         name = 'action-guacamole'
         label = "Guacamole"
 
-        def get_url(self, request, context):
+        def get_url(self, context):
             return "https://www.youtube.com/watch?v=dNJdJIwCF_Y"
 
 

--- a/docs/releases/2.15.rst
+++ b/docs/releases/2.15.rst
@@ -31,3 +31,14 @@ Bug fixes
 
 Upgrade considerations
 ======================
+
+Admin homepage panels and summary items now use components
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Admin homepage panels (as registered with the :ref:`construct_homepage_panels` hook) and summary items (as registered with :ref:`construct_homepage_summary_items`) have been updated to adopt the :doc:`template components </extending/template_components>` pattern. User code that creates these object should be updated to ensure that they follow the component API. This will typically require the following changes:
+
+ * Classes defined for use as homepage panels should be made subclasses of ``wagtail.admin.components.Component``, and the ``render(self)`` method should be changed to ``render_html(self, parent_context)``. (Alternatively, rather than defining ``render_html``, it may be more convenient to reimplement it with a template, as per :ref:`creating_template_components`.)
+ * Summary item classes can continue to inherit from ``wagtail.admin.site_summary.SummaryItem`` (which is now a subclass of ``Component``) as before, but:
+   * Any ``template`` attribute should be changed to ``template_name``;
+   * Any place where the ``render(self)`` method is overridden should be changed to ``render_html(self, parent_context)``;
+   * Any place where the ``get_context(self)`` method is overridden should be changed to ``get_context_data(self, parent_context)``.

--- a/docs/releases/2.15.rst
+++ b/docs/releases/2.15.rst
@@ -35,10 +35,13 @@ Upgrade considerations
 Admin homepage panels and summary items now use components
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. _template_components_2_15:
+
 Admin homepage panels (as registered with the :ref:`construct_homepage_panels` hook) and summary items (as registered with :ref:`construct_homepage_summary_items`) have been updated to adopt the :doc:`template components </extending/template_components>` pattern. User code that creates these object should be updated to ensure that they follow the component API. This will typically require the following changes:
 
  * Classes defined for use as homepage panels should be made subclasses of ``wagtail.admin.components.Component``, and the ``render(self)`` method should be changed to ``render_html(self, parent_context)``. (Alternatively, rather than defining ``render_html``, it may be more convenient to reimplement it with a template, as per :ref:`creating_template_components`.)
  * Summary item classes can continue to inherit from ``wagtail.admin.site_summary.SummaryItem`` (which is now a subclass of ``Component``) as before, but:
+
    * Any ``template`` attribute should be changed to ``template_name``;
    * Any place where the ``render(self)`` method is overridden should be changed to ``render_html(self, parent_context)``;
    * Any place where the ``get_context(self)`` method is overridden should be changed to ``get_context_data(self, parent_context)``.

--- a/docs/releases/2.15.rst
+++ b/docs/releases/2.15.rst
@@ -32,16 +32,29 @@ Bug fixes
 Upgrade considerations
 ======================
 
-Admin homepage panels and summary items now use components
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Admin homepage panels, summary items and action menu items now use components
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. _template_components_2_15:
 
-Admin homepage panels (as registered with the :ref:`construct_homepage_panels` hook) and summary items (as registered with :ref:`construct_homepage_summary_items`) have been updated to adopt the :doc:`template components </extending/template_components>` pattern. User code that creates these object should be updated to ensure that they follow the component API. This will typically require the following changes:
+Several Wagtail hooks provide a mechanism for passing Python objects to be rendered as HTML inside admin views, and the APIs for these objects have been updated to adopt a common :doc:`template components </extending/template_components>` pattern. The affected objects are:
 
- * Classes defined for use as homepage panels should be made subclasses of ``wagtail.admin.components.Component``, and the ``render(self)`` method should be changed to ``render_html(self, parent_context)``. (Alternatively, rather than defining ``render_html``, it may be more convenient to reimplement it with a template, as per :ref:`creating_template_components`.)
+ * Homepage panels (as registered with the :ref:`construct_homepage_panels` hook)
+ * Homepage summary items (as registered with the :ref:`construct_homepage_summary_items` hook)
+ * Page action menu items (as registered with the :ref:`register_page_action_menu_item` and :ref:`construct_page_action_menu` hooks)
+ * Snippet action menu items (as registered with the :ref:`register_snippet_action_menu_item` and :ref:`construct_snippet_action_menu` hooks)
+
+User code that creates these objects should be updated to follow the component API. This will typically require the following changes:
+
+ * Homepage panels should be made subclasses of ``wagtail.admin.ui.components.Component``, and the ``render(self)`` method should be changed to ``render_html(self, parent_context)``. (Alternatively, rather than defining ``render_html``, it may be more convenient to reimplement it with a template, as per :ref:`creating_template_components`.)
  * Summary item classes can continue to inherit from ``wagtail.admin.site_summary.SummaryItem`` (which is now a subclass of ``Component``) as before, but:
 
    * Any ``template`` attribute should be changed to ``template_name``;
    * Any place where the ``render(self)`` method is overridden should be changed to ``render_html(self, parent_context)``;
    * Any place where the ``get_context(self)`` method is overridden should be changed to ``get_context_data(self, parent_context)``.
+
+ * Action menu items for pages and snippets can continue to inherit from ``wagtail.admin.action_menu.ActionMenuItem`` and ``wagtail.snippets.action_menu.ActionMenuItem`` respectively - these are now subclasses of ``Component`` - but:
+
+   * Any ``template`` attribute should be changed to ``template_name``;
+   * Any ``get_context`` method should be renamed to ``get_context_data``;
+   * The ``get_url``, ``is_shown``, ``get_context_data`` and ``render_html`` methods no longer accept a ``request`` parameter. The request object is available in the context dictionary as ``context['request']``.

--- a/wagtail/admin/action_menu.py
+++ b/wagtail/admin/action_menu.py
@@ -70,7 +70,8 @@ class ActionMenuItem(Component):
         """
         if len(args) == 2:
             warn(
-                "ActionMenuItem.is_shown no longer takes a 'request' argument",
+                "ActionMenuItem.is_shown no longer takes a 'request' argument. "
+                "See https://docs.wagtail.io/en/stable/releases/2.15.html#template-components-2-15",
                 category=RemovedInWagtail217Warning, stacklevel=2
             )
             request, context = args
@@ -95,7 +96,8 @@ class ActionMenuItem(Component):
 
         if requires_request_arg(self.get_url):
             warn(
-                "%s.get_url should no longer take a 'request' argument" % type(self).__name__,
+                "%s.get_url should no longer take a 'request' argument. "
+                "See https://docs.wagtail.io/en/stable/releases/2.15.html#template-components-2-15" % type(self).__name__,
                 category=RemovedInWagtail217Warning
             )
             url = self.get_url(parent_context['request'], parent_context)
@@ -127,7 +129,8 @@ class ActionMenuItem(Component):
 
         if len(args) == 2:
             warn(
-                "ActionMenuItem.render_html no longer takes a 'request' argument",
+                "ActionMenuItem.render_html no longer takes a 'request' argument. "
+                "See https://docs.wagtail.io/en/stable/releases/2.15.html#template-components-2-15",
                 category=RemovedInWagtail217Warning, stacklevel=2
             )
             request, parent_context = args
@@ -137,8 +140,8 @@ class ActionMenuItem(Component):
         if not getattr(self.get_context, 'is_base_method', False):
             # get_context has been overridden, so call it instead of get_context_data
             warn(
-                "%s should define get_context_data(self, parent_context) instead of "
-                "get_context(self, request, get_context_data)" % type(self).__name__,
+                "%s should define get_context_data(self, parent_context) instead of get_context(self, request, get_context_data). "
+                "See https://docs.wagtail.io/en/stable/releases/2.15.html#template-components-2-15" % type(self).__name__,
                 category=RemovedInWagtail217Warning
             )
             context_data = self.get_context(parent_context['request'], parent_context)
@@ -147,7 +150,8 @@ class ActionMenuItem(Component):
 
         if self.template:
             warn(
-                "%s should define template_name instead of template" % type(self).__name__,
+                "%s should define template_name instead of template. "
+                "See https://docs.wagtail.io/en/stable/releases/2.15.html#template-components-2-15" % type(self).__name__,
                 category=RemovedInWagtail217Warning
             )
             template_name = self.template
@@ -439,7 +443,8 @@ class PageActionMenu:
 
                     if requires_request_arg(item.is_shown):
                         warn(
-                            "%s.is_shown should no longer take a 'request' argument" % type(item).__name__,
+                            "%s.is_shown should no longer take a 'request' argument. "
+                            "See https://docs.wagtail.io/en/stable/releases/2.15.html#template-components-2-15" % type(item).__name__,
                             category=RemovedInWagtail217Warning
                         )
                         is_shown = item.is_shown(self.request, self.context)
@@ -453,7 +458,8 @@ class PageActionMenu:
         for menu_item in _get_base_page_action_menu_items():
             if requires_request_arg(menu_item.is_shown):
                 warn(
-                    "%s.is_shown should no longer take a 'request' argument" % type(menu_item).__name__,
+                    "%s.is_shown should no longer take a 'request' argument. "
+                    "See https://docs.wagtail.io/en/stable/releases/2.15.html#template-components-2-15" % type(menu_item).__name__,
                     category=RemovedInWagtail217Warning
                 )
                 is_shown = menu_item.is_shown(self.request, self.context)
@@ -478,7 +484,8 @@ class PageActionMenu:
         for menu_item in self.menu_items:
             if requires_request_arg(menu_item.render_html):
                 warn(
-                    "%s.render_html should no longer take a 'request' argument" % type(menu_item).__name__,
+                    "%s.render_html should no longer take a 'request' argument. "
+                    "See https://docs.wagtail.io/en/stable/releases/2.15.html#template-components-2-15" % type(menu_item).__name__,
                     category=RemovedInWagtail217Warning
                 )
                 rendered_menu_items.append(menu_item.render_html(self.request, self.context))
@@ -487,7 +494,8 @@ class PageActionMenu:
 
         if requires_request_arg(self.default_item.render_html):
             warn(
-                "%s.render_html should no longer take a 'request' argument" % type(self.default_item).__name__,
+                "%s.render_html should no longer take a 'request' argument. "
+                "See https://docs.wagtail.io/en/stable/releases/2.15.html#template-components-2-15" % type(self.default_item).__name__,
                 category=RemovedInWagtail217Warning
             )
             rendered_default_item = self.default_item.render_html(self.request, self.context)

--- a/wagtail/admin/site_summary.py
+++ b/wagtail/admin/site_summary.py
@@ -1,22 +1,70 @@
-from django.template.loader import render_to_string
+from warnings import warn
+
+from django.template.loader import get_template, render_to_string
 
 from wagtail.admin.auth import user_has_any_page_permission
 from wagtail.admin.navigation import get_site_for_user
+from wagtail.admin.ui.components import Component
 from wagtail.core import hooks
 from wagtail.core.models import Page, Site
+from wagtail.utils.deprecation import RemovedInWagtail217Warning
 
 
-class SummaryItem:
+class SummaryItem(Component):
     order = 100
+    template = None  # RemovedInWagtail217Warning - should set template_name instead
 
     def __init__(self, request):
         self.request = request
 
     def get_context(self):
+        # RemovedInWagtail217Warning:
+        # old get_context method deprecated in 2.15; provided here in case subclasses call it from
+        # overridden render() methods or via super()
         return {}
+    get_context.is_base_method = True
 
     def render(self):
+        # RemovedInWagtail217Warning:
+        # old render method deprecated in 2.15; provided here in case subclasses call it via super()
         return render_to_string(self.template, self.get_context(), request=self.request)
+    render.is_base_method = True
+
+    def render_html(self, parent_context=None):
+        if not getattr(self.render, 'is_base_method', False):
+            # this SummaryItem subclass has overridden render() - use their implementation in
+            # preference to following the Component.render_html path
+            message = (
+                "Summary item %r registered with construct_homepage_summary_items must be updated "
+                "to override render_html(self, parent_context) rather than render(self)"
+                % self
+            )
+            warn(message, category=RemovedInWagtail217Warning)
+            return self.render()
+        elif not getattr(self.get_context, 'is_base_method', False):
+            # this SummaryItem subclass has overridden get_context() - use their implementation in
+            # preference to Component.get_context_data
+            message = (
+                "Summary item %r registered with construct_homepage_summary_items must be updated "
+                "to override get_context_data(self, parent_context) rather than get_context(self)"
+                % self
+            )
+            warn(message, category=RemovedInWagtail217Warning)
+            context_data = self.get_context()
+        else:
+            context_data = self.get_context_data(parent_context)
+
+        if self.template is not None:
+            warn(
+                "%s should define template_name instead of template" % type(self).__name__,
+                category=RemovedInWagtail217Warning
+            )
+            template_name = self.template
+        else:
+            template_name = self.template_name
+
+        template = get_template(template_name)
+        return template.render(context_data)
 
     def is_shown(self):
         return True

--- a/wagtail/admin/site_summary.py
+++ b/wagtail/admin/site_summary.py
@@ -36,8 +36,8 @@ class SummaryItem(Component):
             # this SummaryItem subclass has overridden render() - use their implementation in
             # preference to following the Component.render_html path
             message = (
-                "Summary item %r registered with construct_homepage_summary_items must be updated "
-                "to override render_html(self, parent_context) rather than render(self)"
+                "Summary item %r should provide render_html(self, parent_context) rather than render(self). "
+                "See https://docs.wagtail.io/en/stable/releases/2.15.html#template-components-2-15"
                 % self
             )
             warn(message, category=RemovedInWagtail217Warning)
@@ -46,8 +46,8 @@ class SummaryItem(Component):
             # this SummaryItem subclass has overridden get_context() - use their implementation in
             # preference to Component.get_context_data
             message = (
-                "Summary item %r registered with construct_homepage_summary_items must be updated "
-                "to override get_context_data(self, parent_context) rather than get_context(self)"
+                "Summary item %r should provide get_context_data(self, parent_context) rather than get_context(self). "
+                "See https://docs.wagtail.io/en/stable/releases/2.15.html#template-components-2-15"
                 % self
             )
             warn(message, category=RemovedInWagtail217Warning)
@@ -57,7 +57,8 @@ class SummaryItem(Component):
 
         if self.template is not None:
             warn(
-                "%s should define template_name instead of template" % type(self).__name__,
+                "%s should define template_name instead of template. "
+                "See https://docs.wagtail.io/en/stable/releases/2.15.html#template-components-2-15" % type(self).__name__,
                 category=RemovedInWagtail217Warning
             )
             template_name = self.template

--- a/wagtail/admin/site_summary.py
+++ b/wagtail/admin/site_summary.py
@@ -72,9 +72,9 @@ class SummaryItem(Component):
 
 class PagesSummaryItem(SummaryItem):
     order = 100
-    template = 'wagtailadmin/home/site_summary_pages.html'
+    template_name = 'wagtailadmin/home/site_summary_pages.html'
 
-    def get_context(self):
+    def get_context_data(self, parent_context):
         site_details = get_site_for_user(self.request.user)
         root_page = site_details['root_page']
         site_name = site_details['site_name']

--- a/wagtail/admin/templates/wagtailadmin/home.html
+++ b/wagtail/admin/templates/wagtailadmin/home.html
@@ -8,6 +8,7 @@
 
     <link rel="stylesheet" href="{% versioned_static 'wagtailadmin/css/layouts/home.css' %}" type="text/css" />
     <link rel="stylesheet" href="{% versioned_static 'wagtailadmin/css/layouts/page-editor.css' %}" />
+    {{ media.css }}
 {% endblock %}
 
 {% block content %}
@@ -55,4 +56,5 @@ $(function() {
     });
 });
 </script>
+{{ media.js }}
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/home.html
+++ b/wagtail/admin/templates/wagtailadmin/home.html
@@ -25,7 +25,7 @@
 
     {% if panels %}
         {% for panel in panels %}
-            {{ panel.render }}
+            {% component panel fallback_render_method=True %}
         {% endfor %}
     {% else %}
         <p>{% trans "This is your dashboard on which helpful information about content you've created will be displayed." %}</p>

--- a/wagtail/admin/templates/wagtailadmin/home/site_summary.html
+++ b/wagtail/admin/templates/wagtailadmin/home/site_summary.html
@@ -1,9 +1,11 @@
 {% load i18n wagtailadmin_tags %}
-<section class="panel summary nice-padding">
-    <h2 class="visuallyhidden">{% trans "Site summary" %}</h2>
-    <ul class="stats">
-        {% for item in summary_items %}
-            {% component item %}
-        {% endfor %}
-    </ul>
-</section>
+{% if summary_items %}
+    <section class="panel summary nice-padding">
+        <h2 class="visuallyhidden">{% trans "Site summary" %}</h2>
+        <ul class="stats">
+            {% for item in summary_items %}
+                {% component item %}
+            {% endfor %}
+        </ul>
+    </section>
+{% endif %}

--- a/wagtail/admin/templates/wagtailadmin/home/site_summary.html
+++ b/wagtail/admin/templates/wagtailadmin/home/site_summary.html
@@ -3,7 +3,7 @@
     <h2 class="visuallyhidden">{% trans "Site summary" %}</h2>
     <ul class="stats">
         {% for item in summary_items %}
-            {{ item.render }}
+            {% component item %}
         {% endfor %}
     </ul>
 </section>

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -739,7 +739,10 @@ def component(context, obj, fallback_render_method=False):
     # called instead (with no arguments) - this is to provide deprecation path for things that have
     # been newly upgraded to use the component pattern.
 
-    if fallback_render_method and not hasattr(obj, 'render_html') and hasattr(obj, 'render'):
+    has_render_html_method = hasattr(obj, 'render_html')
+    if fallback_render_method and not has_render_html_method and hasattr(obj, 'render'):
         return obj.render()
+    elif not has_render_html_method:
+        raise ValueError("Cannot render %r as a component" % (obj,))
 
     return obj.render_html(context)

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -729,3 +729,17 @@ def resolve_url(url):
         return resolve_url_func(url)
     except NoReverseMatch:
         return ''
+
+
+@register.simple_tag(takes_context=True)
+def component(context, obj, fallback_render_method=False):
+    # Render a component by calling its render_html method, passing request and context from the
+    # calling template.
+    # If fallback_render_method is true, objects without a render_html method will have render()
+    # called instead (with no arguments) - this is to provide deprecation path for things that have
+    # been newly upgraded to use the component pattern.
+
+    if fallback_render_method and not hasattr(obj, 'render_html') and hasattr(obj, 'render'):
+        return obj.render()
+
+    return obj.render_html(context)

--- a/wagtail/admin/tests/test_site_summary.py
+++ b/wagtail/admin/tests/test_site_summary.py
@@ -36,7 +36,7 @@ class TestPagesSummary(TestCase, WagtailTestUtils):
         self.request = self.client.get('/').wsgi_request
 
     def assertSummaryContains(self, content):
-        summary = PagesSummaryItem(self.request).render()
+        summary = PagesSummaryItem(self.request).render_html()
         self.assertIn(content, summary)
 
     def assertSummaryContainsLinkToPage(self, page_pk):

--- a/wagtail/admin/tests/test_templatetags.py
+++ b/wagtail/admin/tests/test_templatetags.py
@@ -149,3 +149,12 @@ class TestComponentTag(TestCase):
         )
         html = template.render(Context({'my_component': MyComponent()}))
         self.assertEqual(html, "<h1>Look, I&#x27;m running with scissors! 8&lt; 8&lt; 8&lt;</h1>")
+
+    def test_error_on_rendering_non_component(self):
+        template = Template(
+            "{% load wagtailadmin_tags %}<h1>{% component my_component %}</h1>"
+        )
+
+        with self.assertRaises(ValueError) as cm:
+            template.render(Context({'my_component': "hello"}))
+        self.assertEqual(str(cm.exception), "Cannot render 'hello' as a component")

--- a/wagtail/admin/tests/tests.py
+++ b/wagtail/admin/tests/tests.py
@@ -68,6 +68,25 @@ class TestHome(TestCase, WagtailTestUtils):
             '<a href="http://www.tomroyal.com/teaandkittens/" class="icon icon-kitten" data-fluffy="yes">Kittens!</a>'
         )
 
+    def test_dashboard_panels(self):
+        response = self.client.get(reverse('wagtailadmin_home'))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "<p>It looks like you're making a website. Would you like some help?</p>")
+
+        # check that media attached to dashboard panels is correctly pulled in
+        if DJANGO_VERSION >= (3, 1):
+            self.assertContains(
+                response,
+                '<script src="/static/testapp/js/clippy.js"></script>',
+                html=True
+            )
+        else:
+            self.assertContains(
+                response,
+                '<script type="text/javascript" src="/static/testapp/js/clippy.js"></script>',
+                html=True
+            )
+
     def test_never_cache_header(self):
         # This tests that wagtailadmins global cache settings have been applied correctly
         response = self.client.get(reverse('wagtailadmin_home'))

--- a/wagtail/admin/tests/tests.py
+++ b/wagtail/admin/tests/tests.py
@@ -87,6 +87,18 @@ class TestHome(TestCase, WagtailTestUtils):
                 html=True
             )
 
+    def test_summary_items(self):
+        response = self.client.get(reverse('wagtailadmin_home'))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "<p>0 broken links</p>")
+
+        # check that media attached to summary items is correctly pulled in
+        self.assertContains(
+            response,
+            '<link href="/static/testapp/css/broken-links.css" type="text/css" media="all" rel="stylesheet">',
+            html=True
+        )
+
     def test_never_cache_header(self):
         # This tests that wagtailadmins global cache settings have been applied correctly
         response = self.client.get(reverse('wagtailadmin_home'))

--- a/wagtail/admin/ui/components.py
+++ b/wagtail/admin/ui/components.py
@@ -1,0 +1,20 @@
+from typing import Any, Mapping
+
+from django.forms import MediaDefiningClass
+from django.template import Context
+from django.template.loader import get_template
+
+
+class Component(metaclass=MediaDefiningClass):
+    def get_context_data(self, parent_context: Mapping[str, Any]) -> Mapping[str, Any]:
+        return {}
+
+    def render_html(self, parent_context: Mapping[str, Any] = None) -> str:
+        if parent_context is None:
+            parent_context = Context()
+        context_data = self.get_context_data(parent_context)
+        if context_data is None:
+            raise TypeError("Expected a dict from get_context_data, got None")
+
+        template = get_template(self.template_name)
+        return template.render(context_data)

--- a/wagtail/admin/views/home.py
+++ b/wagtail/admin/views/home.py
@@ -184,7 +184,8 @@ def home(request):
             # NOTE: when this deprecation warning is removed the 'fallback_render_method=True' in
             # wagtailadmin/home.html should be removed too
             message = (
-                "Panel %r registered with construct_homepage_panels must be updated to provide a render_html method"
+                "Homepage panel %r should provide a render_html method. "
+                "See https://docs.wagtail.io/en/stable/releases/2.15.html#template-components-2-15"
                 % panel
             )
             warn(message, category=RemovedInWagtail217Warning)

--- a/wagtail/admin/views/home.py
+++ b/wagtail/admin/views/home.py
@@ -7,6 +7,7 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.decorators import permission_required
 from django.db import connection
 from django.db.models import Max, Q
+from django.forms import Media
 from django.http import Http404, HttpResponse
 from django.template.loader import render_to_string
 from django.template.response import TemplateResponse
@@ -176,6 +177,8 @@ def home(request):
     for fn in hooks.get_hooks('construct_homepage_panels'):
         fn(request, panels)
 
+    media = Media()
+
     for panel in panels:
         if hasattr(panel, 'render') and not hasattr(panel, 'render_html'):
             # NOTE: when this deprecation warning is removed the 'fallback_render_method=True' in
@@ -186,6 +189,11 @@ def home(request):
             )
             warn(message, category=RemovedInWagtail217Warning)
 
+        # RemovedInWagtail217Warning: this hasattr check can be removed when support for
+        # non-component-based panels ends
+        if hasattr(panel, 'media'):
+            media += panel.media
+
     site_details = get_site_for_user(request.user)
 
     return TemplateResponse(request, "wagtailadmin/home.html", {
@@ -193,7 +201,8 @@ def home(request):
         'root_site': site_details['root_site'],
         'site_name': site_details['site_name'],
         'panels': sorted(panels, key=lambda p: p.order),
-        'user': request.user
+        'user': request.user,
+        'media': media,
     })
 
 

--- a/wagtail/admin/views/home.py
+++ b/wagtail/admin/views/home.py
@@ -1,5 +1,7 @@
 import itertools
 
+from warnings import warn
+
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.decorators import permission_required
@@ -11,9 +13,11 @@ from django.template.response import TemplateResponse
 
 from wagtail.admin.navigation import get_site_for_user
 from wagtail.admin.site_summary import SiteSummaryPanel
+from wagtail.admin.ui.components import Component
 from wagtail.core import hooks
 from wagtail.core.models import (
     Page, PageRevision, TaskState, UserPagePermissionsProxy, WorkflowState)
+from wagtail.utils.deprecation import RemovedInWagtail217Warning
 
 
 User = get_user_model()
@@ -21,45 +25,45 @@ User = get_user_model()
 
 # Panels for the homepage
 
-class UpgradeNotificationPanel:
+class UpgradeNotificationPanel(Component):
     name = 'upgrade_notification'
+    template_name = 'wagtailadmin/home/upgrade_notification.html'
     order = 100
 
-    def __init__(self, request):
-        self.request = request
-
-    def render(self):
-        if self.request.user.is_superuser and getattr(settings, "WAGTAIL_ENABLE_UPDATE_CHECK", True):
-            return render_to_string('wagtailadmin/home/upgrade_notification.html', {}, request=self.request)
+    def render_html(self, parent_context):
+        if parent_context['request'].user.is_superuser and getattr(settings, "WAGTAIL_ENABLE_UPDATE_CHECK", True):
+            return super().render_html(parent_context)
         else:
             return ""
 
 
-class PagesForModerationPanel:
+class PagesForModerationPanel(Component):
     name = 'pages_for_moderation'
+    template_name = 'wagtailadmin/home/pages_for_moderation.html'
     order = 200
 
-    def __init__(self, request):
-        self.request = request
+    def get_context_data(self, parent_context):
+        request = parent_context['request']
+        context = super().get_context_data(parent_context)
         user_perms = UserPagePermissionsProxy(request.user)
-        self.page_revisions_for_moderation = (user_perms.revisions_for_moderation()
-                                              .select_related('page', 'user').order_by('-created_at'))
-
-    def render(self):
-        return render_to_string('wagtailadmin/home/pages_for_moderation.html', {
-            'page_revisions_for_moderation': self.page_revisions_for_moderation,
-        }, request=self.request)
+        context['page_revisions_for_moderation'] = (
+            user_perms.revisions_for_moderation().select_related('page', 'user').order_by('-created_at')
+        )
+        context['request'] = request
+        return context
 
 
-class UserPagesInWorkflowModerationPanel:
+class UserPagesInWorkflowModerationPanel(Component):
     name = 'user_pages_in_workflow_moderation'
+    template_name = 'wagtailadmin/home/user_pages_in_workflow_moderation.html'
     order = 210
 
-    def __init__(self, request):
-        self.request = request
+    def get_context_data(self, parent_context):
+        request = parent_context['request']
+        context = super().get_context_data(parent_context)
         if getattr(settings, 'WAGTAIL_WORKFLOW_ENABLED', True):
             # Find in progress workflow states which are either requested by the user or on pages owned by the user
-            self.workflow_states = (
+            context['workflow_states'] = (
                 WorkflowState.objects.active()
                 .filter(Q(page__owner=request.user) | Q(requested_by=request.user))
                 .select_related(
@@ -68,62 +72,62 @@ class UserPagesInWorkflowModerationPanel:
                 .order_by('-current_task_state__started_at')
             )
         else:
-            self.workflow_states = WorkflowState.objects.none()
-
-    def render(self):
-        return render_to_string('wagtailadmin/home/user_pages_in_workflow_moderation.html', {
-            'workflow_states': self.workflow_states
-        }, request=self.request)
+            context['workflow_states'] = WorkflowState.objects.none()
+        context['request'] = request
+        return context
 
 
-class WorkflowPagesToModeratePanel:
+class WorkflowPagesToModeratePanel(Component):
     name = 'workflow_pages_to_moderate'
+    template_name = 'wagtailadmin/home/workflow_pages_to_moderate.html'
     order = 220
 
-    def __init__(self, request):
-        self.request = request
+    def get_context_data(self, parent_context):
+        request = parent_context['request']
+        context = super().get_context_data(parent_context)
         if getattr(settings, 'WAGTAIL_WORKFLOW_ENABLED', True):
             states = (
                 TaskState.objects.reviewable_by(request.user)
                 .select_related('page_revision', 'task', 'page_revision__page')
                 .order_by('-started_at')
             )
-            self.states = [
+            context['states'] = [
                 (state, state.task.specific.get_actions(page=state.page_revision.page, user=request.user), state.workflow_state.all_tasks_with_status())
                 for state in states
             ]
         else:
-            self.states = []
-
-    def render(self):
-        return render_to_string('wagtailadmin/home/workflow_pages_to_moderate.html', {
-            'states': self.states
-        }, request=self.request)
+            context['states'] = []
+        context['request'] = request
+        return context
 
 
-class LockedPagesPanel:
+class LockedPagesPanel(Component):
     name = 'locked_pages'
+    template_name = 'wagtailadmin/home/locked_pages.html'
     order = 300
 
-    def __init__(self, request):
-        self.request = request
-
-    def render(self):
-        return render_to_string('wagtailadmin/home/locked_pages.html', {
+    def get_context_data(self, parent_context):
+        request = parent_context['request']
+        context = super().get_context_data(parent_context)
+        context.update({
             'locked_pages': Page.objects.filter(
                 locked=True,
-                locked_by=self.request.user,
+                locked_by=request.user,
             ),
-            'can_remove_locks': UserPagePermissionsProxy(self.request.user).can_remove_locks()
-        }, request=self.request)
+            'can_remove_locks': UserPagePermissionsProxy(request.user).can_remove_locks(),
+            'request': request,
+        })
+        return context
 
 
-class RecentEditsPanel:
+class RecentEditsPanel(Component):
     name = 'recent_edits'
+    template_name = 'wagtailadmin/home/recent_edits.html'
     order = 250
 
-    def __init__(self, request):
-        self.request = request
+    def get_context_data(self, parent_context):
+        request = parent_context['request']
+        context = super().get_context_data(parent_context)
 
         # Last n edited pages
         edit_count = getattr(settings, 'WAGTAILADMIN_RECENT_EDITS_LIMIT', 5)
@@ -138,42 +142,49 @@ class RecentEditsPanel:
                             wagtailcore_pagerevision WHERE user_id = %s GROUP BY page_id ORDER BY max_created_at DESC LIMIT %s
                     ) AS max_rev ON max_rev.max_created_at = wp.created_at ORDER BY wp.created_at DESC
                  """, [
-                    User._meta.pk.get_db_prep_value(self.request.user.pk, connection),
+                    User._meta.pk.get_db_prep_value(request.user.pk, connection),
                     edit_count
                 ]
             )
         else:
-            last_edits_dates = (PageRevision.objects.filter(user=self.request.user)
+            last_edits_dates = (PageRevision.objects.filter(user=request.user)
                                 .values('page_id').annotate(latest_date=Max('created_at'))
                                 .order_by('-latest_date').values('latest_date')[:edit_count])
             last_edits = PageRevision.objects.filter(created_at__in=last_edits_dates).order_by('-created_at')
 
         page_keys = [pr.page_id for pr in last_edits]
         pages = Page.objects.specific().in_bulk(page_keys)
-        self.last_edits = [
+        context['last_edits'] = [
             [revision, pages.get(revision.page_id)] for revision in last_edits
         ]
-
-    def render(self):
-        return render_to_string('wagtailadmin/home/recent_edits.html', {
-            'last_edits': list(self.last_edits),
-        }, request=self.request)
+        context['request'] = request
+        return context
 
 
 def home(request):
 
     panels = [
         SiteSummaryPanel(request),
-        UpgradeNotificationPanel(request),
-        WorkflowPagesToModeratePanel(request),
-        PagesForModerationPanel(request),
-        UserPagesInWorkflowModerationPanel(request),
-        RecentEditsPanel(request),
-        LockedPagesPanel(request),
+        UpgradeNotificationPanel(),
+        WorkflowPagesToModeratePanel(),
+        PagesForModerationPanel(),
+        UserPagesInWorkflowModerationPanel(),
+        RecentEditsPanel(),
+        LockedPagesPanel(),
     ]
 
     for fn in hooks.get_hooks('construct_homepage_panels'):
         fn(request, panels)
+
+    for panel in panels:
+        if hasattr(panel, 'render') and not hasattr(panel, 'render_html'):
+            # NOTE: when this deprecation warning is removed the 'fallback_render_method=True' in
+            # wagtailadmin/home.html should be removed too
+            message = (
+                "Panel %r registered with construct_homepage_panels must be updated to provide a render_html method"
+                % panel
+            )
+            warn(message, category=RemovedInWagtail217Warning)
 
     site_details = get_site_for_user(request.user)
 

--- a/wagtail/documents/wagtail_hooks.py
+++ b/wagtail/documents/wagtail_hooks.py
@@ -101,9 +101,9 @@ def register_document_feature(features):
 
 class DocumentsSummaryItem(SummaryItem):
     order = 300
-    template = 'wagtaildocs/homepage/site_summary_documents.html'
+    template_name = 'wagtaildocs/homepage/site_summary_documents.html'
 
-    def get_context(self):
+    def get_context_data(self, parent_context):
         site_name = get_site_for_user(self.request.user)['site_name']
 
         return {

--- a/wagtail/images/wagtail_hooks.py
+++ b/wagtail/images/wagtail_hooks.py
@@ -126,9 +126,9 @@ def register_image_operations():
 
 class ImagesSummaryItem(SummaryItem):
     order = 200
-    template = 'wagtailimages/homepage/site_summary_images.html'
+    template_name = 'wagtailimages/homepage/site_summary_images.html'
 
-    def get_context(self):
+    def get_context_data(self, parent_context):
         site_name = get_site_for_user(self.request.user)['site_name']
 
         return {

--- a/wagtail/snippets/action_menu.py
+++ b/wagtail/snippets/action_menu.py
@@ -1,22 +1,41 @@
 """Handles rendering of the list of actions in the footer of the snippet create/edit views."""
+import inspect
 
 from functools import lru_cache
+from warnings import warn
 
 from django.contrib.admin.utils import quote
-from django.forms import Media, MediaDefiningClass
-from django.template.loader import render_to_string
+from django.forms import Media
+from django.template.loader import get_template, render_to_string
 from django.urls import reverse
 from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 
+from wagtail.admin.ui.components import Component
 from wagtail.core import hooks
 from wagtail.snippets.permissions import get_permission_name
+from wagtail.utils.deprecation import RemovedInWagtail217Warning
 
 
-class ActionMenuItem(metaclass=MediaDefiningClass):
+def requires_request_arg(method):
+    """
+    Helper function to handle deprecation of old ActionMenuItem API where get_url, is_show,
+    get_context and render_html all accepted both 'request' and 'parent_context' as arguments
+    """
+    try:
+        # see if this is a pre-2.15 get_url method that takes both request and context kwargs
+        inspect.signature(method).bind({})
+    except TypeError:
+        return True
+    else:
+        return False
+
+
+class ActionMenuItem(Component):
     """Defines an item in the actions drop-up on the snippet creation/edit view"""
     order = 100  # default order index if one is not specified on init
-    template = 'wagtailsnippets/snippets/action_menu/menu_item.html'
+    template_name = 'wagtailsnippets/snippets/action_menu/menu_item.html'
+    template = None  # RemovedInWagtail217Warning
 
     label = ''
     name = None
@@ -27,7 +46,11 @@ class ActionMenuItem(metaclass=MediaDefiningClass):
         if order is not None:
             self.order = order
 
-    def is_shown(self, request, context):
+    def is_shown(self, *args):
+        # accepts both is_shown(request, context) (pre-2.15 signature)
+        # and is_shown(context) (signature as of 2.15)
+        # to allow for pre-2.15 ActionMenuItem subclasses calling super().
+        # RemovedInWagtail217Warning: signature should become is_shown(self, context)
         """
         Whether this action should be shown on this request; permission checks etc should go here.
 
@@ -38,26 +61,87 @@ class ActionMenuItem(metaclass=MediaDefiningClass):
             'model' = the model of the snippet being created/edited
             'instance' (if view = 'edit') = the snippet being edited
         """
+        if len(args) == 2:
+            warn(
+                "ActionMenuItem.is_shown no longer takes a 'request' argument",
+                category=RemovedInWagtail217Warning, stacklevel=2
+            )
         return True
 
     def get_context(self, request, parent_context):
+        # Obsolete - included here for pre-2.15 subclasses that override this and call super().
+        # RemovedInWagtail217Warning
+        return self.get_context_data(parent_context)
+
+    get_context.is_base_method = True
+
+    def get_context_data(self, parent_context):
         """Defines context for the template, overridable to use more data"""
         context = parent_context.copy()
+
+        if requires_request_arg(self.get_url):
+            warn(
+                "%s.get_url should no longer take a 'request' argument" % type(self).__name__,
+                category=RemovedInWagtail217Warning
+            )
+            url = self.get_url(parent_context['request'], parent_context)
+        else:
+            url = self.get_url(parent_context)
+
         context.update({
             'label': self.label,
-            'url': self.get_url(request, context),
+            'url': url,
             'name': self.name,
             'classname': self.classname,
             'icon_name': self.icon_name,
+            'request': parent_context['request'],
         })
         return context
 
-    def get_url(self, request, context):
+    def get_url(self, *args):
+        # accepts both get_url(request, parent_context) (pre-2.15 signature)
+        # and get_url(parent_context) (signature as of 2.15)
+        # to allow for pre-2.15 ActionMenuItem subclasses calling super().
+        # RemovedInWagtail217Warning: signature should become get_url(self, parent_context)
         return None
 
-    def render_html(self, request, parent_context):
-        context = self.get_context(request, parent_context)
-        return render_to_string(self.template, context, request=request)
+    def render_html(self, *args):
+        # accepts both render_html(request, parent_context) (pre-2.15 signature)
+        # and render_html(parent_context) (signature as of 2.15)
+        # to allow for pre-2.15 ActionMenuItem subclasses calling super().
+        # RemovedInWagtail217Warning: signature should become render_html(self, parent_context)
+
+        if len(args) == 2:
+            warn(
+                "ActionMenuItem.render_html no longer takes a 'request' argument",
+                category=RemovedInWagtail217Warning, stacklevel=2
+            )
+            request, parent_context = args
+        else:
+            parent_context, = args
+
+        if not getattr(self.get_context, 'is_base_method', False):
+            # get_context has been overridden, so call it instead of get_context_data
+            warn(
+                "%s should define get_context_data(self, parent_context) instead of "
+                "get_context(self, request, get_context_data)" % type(self).__name__,
+                category=RemovedInWagtail217Warning
+            )
+            context_data = self.get_context(parent_context['request'], parent_context)
+        else:
+            context_data = self.get_context_data(parent_context)
+
+        if self.template:
+            warn(
+                "%s should define template_name instead of template" % type(self).__name__,
+                category=RemovedInWagtail217Warning
+            )
+            template_name = self.template
+        else:
+            template_name = self.template_name
+
+        template = get_template(template_name)
+        return template.render(context_data)
 
 
 class DeleteMenuItem(ActionMenuItem):
@@ -66,15 +150,15 @@ class DeleteMenuItem(ActionMenuItem):
     icon_name = 'bin'
     classname = 'action-secondary'
 
-    def is_shown(self, request, context):
+    def is_shown(self, context):
         delete_permission = get_permission_name('delete', context['model'])
 
         return (
             context['view'] == 'edit'
-            and request.user.has_perm(delete_permission)
+            and context['request'].user.has_perm(delete_permission)
         )
 
-    def get_url(self, request, context):
+    def get_url(self, context):
         return reverse('wagtailsnippets:delete', args=[
             context['model']._meta.app_label,
             context['model']._meta.model_name,
@@ -85,7 +169,7 @@ class DeleteMenuItem(ActionMenuItem):
 class SaveMenuItem(ActionMenuItem):
     name = 'action-save'
     label = _("Save")
-    template = 'wagtailsnippets/snippets/action_menu/save.html'
+    template_name = 'wagtailsnippets/snippets/action_menu/save.html'
 
 
 @lru_cache(maxsize=None)
@@ -113,16 +197,24 @@ class SnippetActionMenu:
     def __init__(self, request, **kwargs):
         self.request = request
         self.context = kwargs
+        self.context['request'] = request
         self.menu_items = []
 
         if 'instance' in self.context:
             self.context['model'] = self.context['instance'].__class__
 
-        self.menu_items.extend([
-            menu_item
-            for menu_item in get_base_snippet_action_menu_items(self.context['model'])
-            if menu_item.is_shown(self.request, self.context)
-        ])
+        for menu_item in get_base_snippet_action_menu_items(self.context['model']):
+            if requires_request_arg(menu_item.is_shown):
+                warn(
+                    "%s.is_shown should no longer take a 'request' argument" % type(menu_item).__name__,
+                    category=RemovedInWagtail217Warning
+                )
+                is_shown = menu_item.is_shown(self.request, self.context)
+            else:
+                is_shown = menu_item.is_shown(self.context)
+
+            if is_shown:
+                self.menu_items.append(menu_item)
 
         self.menu_items.sort(key=lambda item: item.order)
 
@@ -135,13 +227,30 @@ class SnippetActionMenu:
             self.default_item = None
 
     def render_html(self):
+        rendered_menu_items = []
+        for menu_item in self.menu_items:
+            if requires_request_arg(menu_item.render_html):
+                warn(
+                    "%s.render_html should no longer take a 'request' argument" % type(menu_item).__name__,
+                    category=RemovedInWagtail217Warning
+                )
+                rendered_menu_items.append(menu_item.render_html(self.request, self.context))
+            else:
+                rendered_menu_items.append(menu_item.render_html(self.context))
+
+        if requires_request_arg(self.default_item.render_html):
+            warn(
+                "%s.render_html should no longer take a 'request' argument" % type(self.default_item).__name__,
+                category=RemovedInWagtail217Warning
+            )
+            rendered_default_item = self.default_item.render_html(self.request, self.context)
+        else:
+            rendered_default_item = self.default_item.render_html(self.context)
+
         return render_to_string(self.template, {
-            'default_menu_item': self.default_item.render_html(self.request, self.context),
+            'default_menu_item': rendered_default_item,
             'show_menu': bool(self.menu_items),
-            'rendered_menu_items': [
-                menu_item.render_html(self.request, self.context)
-                for menu_item in self.menu_items
-            ],
+            'rendered_menu_items': rendered_menu_items,
         }, request=self.request)
 
     @cached_property

--- a/wagtail/snippets/action_menu.py
+++ b/wagtail/snippets/action_menu.py
@@ -63,7 +63,8 @@ class ActionMenuItem(Component):
         """
         if len(args) == 2:
             warn(
-                "ActionMenuItem.is_shown no longer takes a 'request' argument",
+                "ActionMenuItem.is_shown no longer takes a 'request' argument. "
+                "See https://docs.wagtail.io/en/stable/releases/2.15.html#template-components-2-15",
                 category=RemovedInWagtail217Warning, stacklevel=2
             )
         return True
@@ -81,7 +82,8 @@ class ActionMenuItem(Component):
 
         if requires_request_arg(self.get_url):
             warn(
-                "%s.get_url should no longer take a 'request' argument" % type(self).__name__,
+                "%s.get_url should no longer take a 'request' argument. "
+                "See https://docs.wagtail.io/en/stable/releases/2.15.html#template-components-2-15" % type(self).__name__,
                 category=RemovedInWagtail217Warning
             )
             url = self.get_url(parent_context['request'], parent_context)
@@ -113,7 +115,8 @@ class ActionMenuItem(Component):
 
         if len(args) == 2:
             warn(
-                "ActionMenuItem.render_html no longer takes a 'request' argument",
+                "ActionMenuItem.render_html no longer takes a 'request' argument. "
+                "See https://docs.wagtail.io/en/stable/releases/2.15.html#template-components-2-15",
                 category=RemovedInWagtail217Warning, stacklevel=2
             )
             request, parent_context = args
@@ -123,8 +126,8 @@ class ActionMenuItem(Component):
         if not getattr(self.get_context, 'is_base_method', False):
             # get_context has been overridden, so call it instead of get_context_data
             warn(
-                "%s should define get_context_data(self, parent_context) instead of "
-                "get_context(self, request, get_context_data)" % type(self).__name__,
+                "%s should define get_context_data(self, parent_context) instead of get_context(self, request, get_context_data). "
+                "See https://docs.wagtail.io/en/stable/releases/2.15.html#template-components-2-15" % type(self).__name__,
                 category=RemovedInWagtail217Warning
             )
             context_data = self.get_context(parent_context['request'], parent_context)
@@ -133,7 +136,8 @@ class ActionMenuItem(Component):
 
         if self.template:
             warn(
-                "%s should define template_name instead of template" % type(self).__name__,
+                "%s should define template_name instead of template."
+                "See https://docs.wagtail.io/en/stable/releases/2.15.html#template-components-2-15" % type(self).__name__,
                 category=RemovedInWagtail217Warning
             )
             template_name = self.template
@@ -206,7 +210,8 @@ class SnippetActionMenu:
         for menu_item in get_base_snippet_action_menu_items(self.context['model']):
             if requires_request_arg(menu_item.is_shown):
                 warn(
-                    "%s.is_shown should no longer take a 'request' argument" % type(menu_item).__name__,
+                    "%s.is_shown should no longer take a 'request' argument. "
+                    "See https://docs.wagtail.io/en/stable/releases/2.15.html#template-components-2-15" % type(menu_item).__name__,
                     category=RemovedInWagtail217Warning
                 )
                 is_shown = menu_item.is_shown(self.request, self.context)
@@ -231,7 +236,8 @@ class SnippetActionMenu:
         for menu_item in self.menu_items:
             if requires_request_arg(menu_item.render_html):
                 warn(
-                    "%s.render_html should no longer take a 'request' argument" % type(menu_item).__name__,
+                    "%s.render_html should no longer take a 'request' argument. "
+                    "See https://docs.wagtail.io/en/stable/releases/2.15.html#template-components-2-15" % type(menu_item).__name__,
                     category=RemovedInWagtail217Warning
                 )
                 rendered_menu_items.append(menu_item.render_html(self.request, self.context))
@@ -240,7 +246,8 @@ class SnippetActionMenu:
 
         if requires_request_arg(self.default_item.render_html):
             warn(
-                "%s.render_html should no longer take a 'request' argument" % type(self.default_item).__name__,
+                "%s.render_html should no longer take a 'request' argument. "
+                "See https://docs.wagtail.io/en/stable/releases/2.15.html#template-components-2-15" % type(self.default_item).__name__,
                 category=RemovedInWagtail217Warning
             )
             rendered_default_item = self.default_item.render_html(self.request, self.context)

--- a/wagtail/snippets/tests.py
+++ b/wagtail/snippets/tests.py
@@ -416,7 +416,7 @@ class TestSnippetCreateView(TestCase, WagtailTestUtils):
             icon_name = "undo"
             classname = 'action-secondary'
 
-            def is_shown(self, request, context):
+            def is_shown(self, context):
                 return True
 
         def hook_func(model):
@@ -450,7 +450,7 @@ class TestSnippetCreateView(TestCase, WagtailTestUtils):
             icon_name = "undo"
             classname = 'action-secondary'
 
-            def is_shown(self, request, context):
+            def is_shown(self, context):
                 return True
 
         def hook_func(menu_items, request, context):
@@ -655,7 +655,7 @@ class TestSnippetEditView(BaseTestSnippetEditView):
             icon_name = "undo"
             classname = 'action-secondary'
 
-            def is_shown(self, request, context):
+            def is_shown(self, context):
                 return True
 
         def hook_func(model):

--- a/wagtail/tests/testapp/wagtail_hooks.py
+++ b/wagtail/tests/testapp/wagtail_hooks.py
@@ -1,6 +1,7 @@
 from django import forms
 from django.http import HttpResponse
 from django.templatetags.static import static
+from django.utils.safestring import mark_safe
 
 import wagtail.admin.rich_text.editors.draftail.features as draftail_features
 
@@ -9,6 +10,7 @@ from wagtail.admin.menu import MenuItem
 from wagtail.admin.rich_text import HalloPlugin
 from wagtail.admin.rich_text.converters.html_to_contentstate import BlockElementHandler
 from wagtail.admin.search import SearchArea
+from wagtail.admin.ui.components import Component
 from wagtail.admin.views.account import BaseSettingsPanel
 from wagtail.admin.widgets import Button
 from wagtail.core import hooks
@@ -189,3 +191,18 @@ class FavouriteColourPanel(BaseSettingsPanel):
     order = 500
     form_class = FavouriteColourForm
     form_object = 'user'
+
+
+class ClippyPanel(Component):
+    order = 50
+
+    def render_html(self, parent_context):
+        return mark_safe("<p>It looks like you're making a website. Would you like some help?</p>")
+
+    class Media:
+        js = ['testapp/js/clippy.js']
+
+
+@hooks.register('construct_homepage_panels')
+def add_clippy_panel(request, panels):
+    panels.append(ClippyPanel())

--- a/wagtail/tests/testapp/wagtail_hooks.py
+++ b/wagtail/tests/testapp/wagtail_hooks.py
@@ -10,6 +10,7 @@ from wagtail.admin.menu import MenuItem
 from wagtail.admin.rich_text import HalloPlugin
 from wagtail.admin.rich_text.converters.html_to_contentstate import BlockElementHandler
 from wagtail.admin.search import SearchArea
+from wagtail.admin.site_summary import SummaryItem
 from wagtail.admin.ui.components import Component
 from wagtail.admin.views.account import BaseSettingsPanel
 from wagtail.admin.widgets import Button
@@ -206,3 +207,18 @@ class ClippyPanel(Component):
 @hooks.register('construct_homepage_panels')
 def add_clippy_panel(request, panels):
     panels.append(ClippyPanel())
+
+
+class BrokenLinksSummaryItem(SummaryItem):
+    order = 100
+
+    def render_html(self, parent_context):
+        return mark_safe("<p>0 broken links</p>")
+
+    class Media:
+        css = {'all': ['testapp/css/broken-links.css']}
+
+
+@hooks.register('construct_homepage_summary_items')
+def add_broken_links_summary_item(request, items):
+    items.append(BrokenLinksSummaryItem(request))


### PR DESCRIPTION
Rebuild of #7397 with feedback applied as summarised in https://github.com/wagtail/wagtail/pull/7397#issuecomment-894325899.

Implements a standard documented pattern for "objects that know how to render themselves onto templates". This pattern has been reimplemented numerous times throughout Wagtail's development, for things like homepage panels and action buttons, in various levels of completeness - and as a result, some of them provide ready-made mechanisms for rendering templates, some provide a get_context method, some allow specifying external css / js, some of them can pick up context variables from the calling template, and so on... Standardising these will make these features consistently available, and make our APIs easier to learn (no more "is it `render` or `render_html`?")

Things that use components as of this PR:

* Page action menu items (register_page_action_menu_item)
* Snippet action menu items (register_snippet_action_menu_item)
* Homepage panels (construct_homepage_panels)
* Summary items (construct_homepage_summary_items)

Other things that could potentially be migrated to components in future:

* Sidebar menu items (need to consider how this aligns with the telepath / slim sidebar rewrite, but I believe these concepts can coexist)
* the page / snippet action menus as a whole (PageActionMenu, SnippetActionMenu as distinct from ActionMenuItem)
* Userbar / edit bird menu items
* User account settings panels
* Search areas (wagtail.admin.search)
* wagtail.admin.widgets.button (as used for buttons / button menus within listings)