### PR TITLE
Handle cache_until being returned as a string in oembed responses

### DIFF
--- a/wagtail/embeds/finders/oembed.py
+++ b/wagtail/embeds/finders/oembed.py
@@ -87,8 +87,11 @@ class OEmbedFinder(EmbedFinder):
             'html': html,
         }
 
-        cache_age = oembed.get('cache_age')
-        if cache_age is not None:
+        try:
+            cache_age = int(oembed['cache_age'])
+        except (KeyError, TypeError, ValueError):
+            pass
+        else:
             result['cache_until'] = timezone.now() + timedelta(seconds=cache_age)
 
         return result

--- a/wagtail/embeds/tests/test_embeds.py
+++ b/wagtail/embeds/tests/test_embeds.py
@@ -490,6 +490,37 @@ class TestOembed(TestCase):
             'cache_until': make_aware(datetime.datetime(2001, 2, 3, hour=1))
         })
 
+    @patch('django.utils.timezone.now')
+    @patch('urllib.request.urlopen')
+    @patch('json.loads')
+    def test_oembed_cache_until_as_string(self, loads, urlopen, now):
+        urlopen.return_value = self.dummy_response
+        loads.return_value = {
+            'type': 'something',
+            'url': 'http://www.example.com',
+            'title': 'test_title',
+            'author_name': 'test_author',
+            'provider_name': 'test_provider_name',
+            'thumbnail_url': 'test_thumbail_url',
+            'width': 'test_width',
+            'height': 'test_height',
+            'html': 'test_html',
+            'cache_age': '3600'
+        }
+        now.return_value = make_aware(datetime.datetime(2001, 2, 3))
+        result = OEmbedFinder().find_embed("http://www.youtube.com/watch/")
+        self.assertEqual(result, {
+            'type': 'something',
+            'title': 'test_title',
+            'author_name': 'test_author',
+            'provider_name': 'test_provider_name',
+            'thumbnail_url': 'test_thumbail_url',
+            'width': 'test_width',
+            'height': 'test_height',
+            'html': 'test_html',
+            'cache_until': make_aware(datetime.datetime(2001, 2, 3, hour=1))
+        })
+
     def test_oembed_accepts_known_provider(self):
         finder = OEmbedFinder(providers=[oembed_providers.youtube])
         self.assertTrue(finder.accept("http://www.youtube.com/watch/"))


### PR DESCRIPTION
Fixes #7415
