### PR TITLE
Added 'PUBLISH' when making new child pages #7430

### DIFF
--- a/docs/getting_started/tutorial.md
+++ b/docs/getting_started/tutorial.md
@@ -349,6 +349,9 @@ other page type.
 
 ![](../_static/images/tutorial/tutorial_5.png)
 
+Make sure you specify 'PUBLISH' when making new blog posts instead of
+'SAVE DRAFT' for this tutorial at the bottom of the page.
+
 You should now have the very beginnings of a working blog.
 Access the `/blog` URL and you should see something like this:
 

--- a/docs/getting_started/tutorial.md
+++ b/docs/getting_started/tutorial.md
@@ -159,7 +159,7 @@ Run `python manage.py makemigrations` (this will create the migrations file), th
 changes). You must run the above commands each time you make changes to
 the model definition.
 
-You can now edit the homepage within the Wagtail admin area (go to Pages, Homepage, then Edit) to see the new body field. Enter some text into the body field, and publish the page.
+You can now edit the homepage within the Wagtail admin area (go to Pages, Homepage, then Edit) to see the new body field. Enter some text into the body field, and publish the page by selecting *Publish* at the bottom of the page editor, rather than *Save Draft*.
 
 The page template now needs to be updated to reflect the changes made
 to the model. Wagtail uses normal Django templates to render each page
@@ -349,8 +349,7 @@ other page type.
 
 ![](../_static/images/tutorial/tutorial_5.png)
 
-Make sure you specify 'PUBLISH' when making new blog posts instead of
-'SAVE DRAFT' for this tutorial at the bottom of the page.
+Be sure to *Publish* the blog post after you are done.
 
 You should now have the very beginnings of a working blog.
 Access the `/blog` URL and you should see something like this:

--- a/docs/getting_started/tutorial.md
+++ b/docs/getting_started/tutorial.md
@@ -159,7 +159,8 @@ Run `python manage.py makemigrations` (this will create the migrations file), th
 changes). You must run the above commands each time you make changes to
 the model definition.
 
-You can now edit the homepage within the Wagtail admin area (go to Pages, Homepage, then Edit) to see the new body field. Enter some text into the body field, and publish the page by selecting *Publish* at the bottom of the page editor, rather than *Save Draft*.
+You can now edit the homepage within the Wagtail admin area (go to Pages, Homepage, then Edit) to see the new body field. Enter some text into the body field, and 
+the page by selecting *Publish* at the bottom of the page editor, rather than *Save Draft*.
 
 The page template now needs to be updated to reflect the changes made
 to the model. Wagtail uses normal Django templates to render each page
@@ -349,7 +350,7 @@ other page type.
 
 ![](../_static/images/tutorial/tutorial_5.png)
 
-Be sure to *Publish* the blog post after you are done.
+Be sure to *Publish* each blog post after you are done editing.
 
 You should now have the very beginnings of a working blog.
 Access the `/blog` URL and you should see something like this:


### PR DESCRIPTION
Added extra instruction to publish a blog post rather than save as a draft for the overriding section.

Aims to solve issue #7430 
