### PR TITLE
Apply list styles for MultipleChoiceFields

### DIFF
--- a/client/scss/components/_forms.scss
+++ b/client/scss/components/_forms.scss
@@ -254,8 +254,9 @@ label.required:after {
     }
 }
 
-// This is specifically for model that are a generated set of checkboxes/radios
+// This is specifically for list of radios/checkboxes
 .model_multiple_choice_field .input li,
+.multiple_choice_field .input li,
 .choice_field .input li {
     label {
         display: block;

--- a/client/scss/elements/_forms.scss
+++ b/client/scss/elements/_forms.scss
@@ -55,6 +55,7 @@ label,
         padding-left: 0;
 
         .radio_select &,
+        .multiple_choice_field &,
         .model_multiple_choice_field &,
         .boolean_field &,
         .model_choice_field &,


### PR DESCRIPTION
I use `MultipleChoiceField` sometimes to display a `ArrayField` of choices. It doesn't render very nicely:
![image](https://user-images.githubusercontent.com/1635388/129507314-0530b874-19f6-4e17-b6ad-5fb57db9e6d6.png)

The underlying field class is a `MultipleChoiceField`, so adding the class modelname to the css rules lets it render a lot nicer:

![image](https://user-images.githubusercontent.com/1635388/129507431-b90bd76e-d0d6-42c7-b87f-7450e3966f30.png)

