### PR TITLE
Fix typo in StructBlock documentation

### DIFF
--- a/docs/advanced_topics/customisation/streamfield_blocks.rst
+++ b/docs/advanced_topics/customisation/streamfield_blocks.rst
@@ -241,7 +241,7 @@ Instead, you should define a subclass of ``StructValue`` that implements your cu
     from wagtail.core.blocks import StructValue
 
 
-    class LinkValue(StructValue):
+    class LinkStructValue(StructValue):
         def url(self):
             external_url = self.get('external_url')
             page = self.get('page')


### PR DESCRIPTION
The StructValue class `LinkValue` is refrerenced as `LinkStructValue` in the Meta class.
