### PR TITLE
Remove is_ajax checks from multiple upload views

### DIFF
--- a/wagtail/admin/views/generic/multiple_upload.py
+++ b/wagtail/admin/views/generic/multiple_upload.py
@@ -119,9 +119,6 @@ class AddView(PermissionCheckedMixin, TemplateView):
         }
 
     def post(self, request):
-        if not request.is_ajax():
-            return HttpResponseBadRequest("Cannot POST to this view without AJAX")
-
         if not request.FILES:
             return HttpResponseBadRequest("Must upload a file")
 
@@ -204,9 +201,6 @@ class EditView(View):
 
         self.object = get_object_or_404(self.model, id=object_id)
 
-        if not request.is_ajax():
-            return HttpResponseBadRequest("Cannot POST to this view without AJAX")
-
         if not self.permission_policy.user_has_permission_for_instance(request.user, 'change', self.object):
             raise PermissionDenied
 
@@ -250,9 +244,6 @@ class DeleteView(View):
         self.model = self.get_model()
         self.object = get_object_or_404(self.model, id=object_id)
 
-        if not request.is_ajax():
-            return HttpResponseBadRequest("Cannot POST to this view without AJAX")
-
         if not self.permission_policy.user_has_permission_for_instance(request.user, 'delete', self.object):
             raise PermissionDenied
 
@@ -290,9 +281,6 @@ class CreateFromUploadView(View):
         self.form_class = self.get_edit_form_class()
 
         self.upload = get_object_or_404(self.upload_model, id=upload_id)
-
-        if not request.is_ajax():
-            return HttpResponseBadRequest("Cannot POST to this view without AJAX")
 
         if self.upload.uploaded_by_user != request.user:
             raise PermissionDenied
@@ -336,9 +324,6 @@ class DeleteUploadView(View):
     def post(self, request, *args, **kwargs):
         upload_id = kwargs[self.upload_pk_url_kwarg]
         upload = get_object_or_404(self.upload_model, id=upload_id)
-
-        if not request.is_ajax():
-            return HttpResponseBadRequest("Cannot POST to this view without AJAX")
 
         if upload.uploaded_by_user != request.user:
             raise PermissionDenied

--- a/wagtail/documents/tests/test_admin_views.py
+++ b/wagtail/documents/tests/test_admin_views.py
@@ -640,7 +640,7 @@ class TestMultipleDocumentUploader(TestCase, WagtailTestUtils):
         """
         response = self.client.post(reverse('wagtaildocs:add_multiple'), {
             'files[]': SimpleUploadedFile('test.png', b"Simple text document"),
-        }, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        })
 
         # Check response
         self.assertEqual(response.status_code, 200)
@@ -691,7 +691,7 @@ class TestMultipleDocumentUploader(TestCase, WagtailTestUtils):
         response = self.client.post(reverse('wagtaildocs:add_multiple'), {
             'files[]': SimpleUploadedFile('test.png', b"Simple text document"),
             'collection': evil_plans_collection.id
-        }, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        })
 
         # Check response
         self.assertEqual(response.status_code, 200)
@@ -728,20 +728,11 @@ class TestMultipleDocumentUploader(TestCase, WagtailTestUtils):
         # form should contain a collection chooser
         self.assertIn('Collection', response_json['form'])
 
-    def test_add_post_noajax(self):
-        """
-        This tests that only AJAX requests are allowed to POST to the add view
-        """
-        response = self.client.post(reverse('wagtaildocs:add_multiple'))
-
-        # Check response
-        self.assertEqual(response.status_code, 400)
-
     def test_add_post_nofile(self):
         """
         This tests that the add view checks for a file when a user POSTs to it
         """
-        response = self.client.post(reverse('wagtaildocs:add_multiple'), HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        response = self.client.post(reverse('wagtaildocs:add_multiple'))
 
         # Check response
         self.assertEqual(response.status_code, 400)
@@ -764,7 +755,6 @@ class TestMultipleDocumentUploader(TestCase, WagtailTestUtils):
         response = self.client.post(
             reverse('wagtaildocs:edit_multiple', args=(self.doc.id, )),
             {'doc-%d-%s' % (self.doc.id, field): data for field, data in self.edit_post_data.items()},
-            HTTP_X_REQUESTED_WITH='XMLHttpRequest',
         )
 
         # Check response
@@ -781,19 +771,6 @@ class TestMultipleDocumentUploader(TestCase, WagtailTestUtils):
 
         self.check_doc_after_edit()
 
-    def test_edit_post_noajax(self):
-        """
-        This tests that a POST request to the edit view without AJAX returns a 400 response
-        """
-        # Send request
-        response = self.client.post(reverse('wagtaildocs:edit_multiple', args=(self.doc.id, )), {
-            ('doc-%d-title' % self.doc.id): "New title!",
-            ('doc-%d-tags' % self.doc.id): "",
-        })
-
-        # Check response
-        self.assertEqual(response.status_code, 400)
-
     def test_edit_post_validation_error(self):
         """
         This tests that a POST request to the edit page returns a json document with "success=False"
@@ -803,7 +780,7 @@ class TestMultipleDocumentUploader(TestCase, WagtailTestUtils):
         response = self.client.post(reverse('wagtaildocs:edit_multiple', args=(self.doc.id, )), {
             ('doc-%d-title' % self.doc.id): "",  # Required
             ('doc-%d-tags' % self.doc.id): "",
-        }, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        })
 
         # Check response
         self.assertEqual(response.status_code, 200)
@@ -836,7 +813,7 @@ class TestMultipleDocumentUploader(TestCase, WagtailTestUtils):
         This tests that a POST request to the delete view deletes the document
         """
         # Send request
-        response = self.client.post(reverse('wagtaildocs:delete_multiple', args=(self.doc.id, )), HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        response = self.client.post(reverse('wagtaildocs:delete_multiple', args=(self.doc.id, )))
 
         # Check response
         self.assertEqual(response.status_code, 200)
@@ -851,16 +828,6 @@ class TestMultipleDocumentUploader(TestCase, WagtailTestUtils):
         self.assertIn('success', response_json)
         self.assertEqual(response_json['doc_id'], self.doc.id)
         self.assertTrue(response_json['success'])
-
-    def test_delete_post_noajax(self):
-        """
-        This tests that a POST request to the delete view without AJAX returns a 400 response
-        """
-        # Send request
-        response = self.client.post(reverse('wagtaildocs:delete_multiple', args=(self.doc.id, )))
-
-        # Check response
-        self.assertEqual(response.status_code, 400)
 
 
 @override_settings(WAGTAILDOCS_DOCUMENT_MODEL='tests.CustomDocument')
@@ -911,7 +878,7 @@ class TestMultipleCustomDocumentUploaderWithRequiredField(TestMultipleDocumentUp
         """
         response = self.client.post(reverse('wagtaildocs:add_multiple'), {
             'files[]': SimpleUploadedFile('test.png', b"Simple text document"),
-        }, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        })
 
         # Check response
         self.assertEqual(response.status_code, 200)
@@ -961,7 +928,7 @@ class TestMultipleCustomDocumentUploaderWithRequiredField(TestMultipleDocumentUp
         response = self.client.post(reverse('wagtaildocs:add_multiple'), {
             'files[]': SimpleUploadedFile('test.png', b"Simple text document"),
             'collection': evil_plans_collection.id
-        }, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        })
 
         # Check response
         self.assertEqual(response.status_code, 200)
@@ -1016,7 +983,7 @@ class TestMultipleCustomDocumentUploaderWithRequiredField(TestMultipleDocumentUp
             ('uploaded-document-%d-title' % self.uploaded_document.id): "New title!",
             ('uploaded-document-%d-tags' % self.uploaded_document.id): "",
             ('uploaded-document-%d-author' % self.uploaded_document.id): "",
-        }, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        })
 
         doc_count_after = CustomDocumentWithAuthor.objects.count()
         uploaded_doc_count_after = models.UploadedDocument.objects.count()
@@ -1054,7 +1021,7 @@ class TestMultipleCustomDocumentUploaderWithRequiredField(TestMultipleDocumentUp
             ('uploaded-document-%d-title' % self.uploaded_document.id): "New title!",
             ('uploaded-document-%d-tags' % self.uploaded_document.id): "fairies, donkey",
             ('uploaded-document-%d-author' % self.uploaded_document.id): "William Shakespeare",
-        }, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        })
 
         doc_count_after = CustomDocumentWithAuthor.objects.count()
         uploaded_doc_count_after = models.UploadedDocument.objects.count()
@@ -1087,7 +1054,7 @@ class TestMultipleCustomDocumentUploaderWithRequiredField(TestMultipleDocumentUp
         # Send request
         response = self.client.post(reverse(
             'wagtaildocs:delete_upload_multiple', args=(self.uploaded_document.id, )
-        ), HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        ))
 
         # Check response
         self.assertEqual(response.status_code, 200)

--- a/wagtail/images/tests/test_admin_views.py
+++ b/wagtail/images/tests/test_admin_views.py
@@ -1335,7 +1335,7 @@ class TestMultipleImageUploader(TestCase, WagtailTestUtils):
         """
         response = self.client.post(reverse('wagtailimages:add_multiple'), {
             'files[]': SimpleUploadedFile('test.png', get_test_image_file().file.getvalue()),
-        }, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        })
 
         # Check response
         self.assertEqual(response.status_code, 200)
@@ -1360,20 +1360,11 @@ class TestMultipleImageUploader(TestCase, WagtailTestUtils):
         self.assertIn('success', response_json)
         self.assertTrue(response_json['success'])
 
-    def test_add_post_noajax(self):
-        """
-        This tests that only AJAX requests are allowed to POST to the add view
-        """
-        response = self.client.post(reverse('wagtailimages:add_multiple'), {})
-
-        # Check response
-        self.assertEqual(response.status_code, 400)
-
     def test_add_post_nofile(self):
         """
         This tests that the add view checks for a file when a user POSTs to it
         """
-        response = self.client.post(reverse('wagtailimages:add_multiple'), {}, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        response = self.client.post(reverse('wagtailimages:add_multiple'), {})
 
         # Check response
         self.assertEqual(response.status_code, 400)
@@ -1384,7 +1375,7 @@ class TestMultipleImageUploader(TestCase, WagtailTestUtils):
         """
         response = self.client.post(reverse('wagtailimages:add_multiple'), {
             'files[]': SimpleUploadedFile('test.png', b"This is not an image!"),
-        }, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        })
 
         # Check response
         self.assertEqual(response.status_code, 200)
@@ -1407,7 +1398,7 @@ class TestMultipleImageUploader(TestCase, WagtailTestUtils):
         """
         response = self.client.post(reverse('wagtailimages:add_multiple'), {
             'files[]': SimpleUploadedFile('test.txt', get_test_image_file().file.getvalue()),
-        }, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        })
 
         # Check response
         self.assertEqual(response.status_code, 200)
@@ -1442,7 +1433,7 @@ class TestMultipleImageUploader(TestCase, WagtailTestUtils):
         response = self.client.post(reverse('wagtailimages:edit_multiple', args=(self.image.id, )), {
             ('image-%d-title' % self.image.id): "New title!",
             ('image-%d-tags' % self.image.id): "cromarty, finisterre",
-        }, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        })
 
         # Check response
         self.assertEqual(response.status_code, 200)
@@ -1461,19 +1452,6 @@ class TestMultipleImageUploader(TestCase, WagtailTestUtils):
         self.assertEqual(image.title, "New title!")
         self.assertIn('cromarty', image.tags.names())
 
-    def test_edit_post_noajax(self):
-        """
-        This tests that a POST request to the edit view without AJAX returns a 400 response
-        """
-        # Send request
-        response = self.client.post(reverse('wagtailimages:edit_multiple', args=(self.image.id, )), {
-            ('image-%d-title' % self.image.id): "New title!",
-            ('image-%d-tags' % self.image.id): "",
-        })
-
-        # Check response
-        self.assertEqual(response.status_code, 400)
-
     def test_edit_post_validation_error(self):
         """
         This tests that a POST request to the edit page returns a json document with "success=False"
@@ -1483,7 +1461,7 @@ class TestMultipleImageUploader(TestCase, WagtailTestUtils):
         response = self.client.post(reverse('wagtailimages:edit_multiple', args=(self.image.id, )), {
             ('image-%d-title' % self.image.id): "",  # Required
             ('image-%d-tags' % self.image.id): "",
-        }, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        })
 
         # Check response
         self.assertEqual(response.status_code, 200)
@@ -1518,7 +1496,7 @@ class TestMultipleImageUploader(TestCase, WagtailTestUtils):
         # Send request
         response = self.client.post(reverse(
             'wagtailimages:delete_multiple', args=(self.image.id, )
-        ), HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        ))
 
         # Check response
         self.assertEqual(response.status_code, 200)
@@ -1533,16 +1511,6 @@ class TestMultipleImageUploader(TestCase, WagtailTestUtils):
         self.assertIn('success', response_json)
         self.assertEqual(response_json['image_id'], self.image.id)
         self.assertTrue(response_json['success'])
-
-    def test_delete_post_noajax(self):
-        """
-        This tests that a POST request to the delete view without AJAX returns a 400 response
-        """
-        # Send request
-        response = self.client.post(reverse('wagtailimages:delete_multiple', args=(self.image.id, )))
-
-        # Check response
-        self.assertEqual(response.status_code, 400)
 
 
 @override_settings(WAGTAILIMAGES_IMAGE_MODEL='tests.CustomImage')
@@ -1580,7 +1548,7 @@ class TestMultipleImageUploaderWithCustomImageModel(TestCase, WagtailTestUtils):
         """
         response = self.client.post(reverse('wagtailimages:add_multiple'), {
             'files[]': SimpleUploadedFile('test.png', get_test_image_file().file.getvalue()),
-        }, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        })
 
         # Check response
         self.assertEqual(response.status_code, 200)
@@ -1613,7 +1581,7 @@ class TestMultipleImageUploaderWithCustomImageModel(TestCase, WagtailTestUtils):
         """
         response = self.client.post(reverse('wagtailimages:add_multiple'), {
             'files[]': SimpleUploadedFile('test.png', b"This is not an image!"),
-        }, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        })
 
         # Check response
         self.assertEqual(response.status_code, 200)
@@ -1646,7 +1614,7 @@ class TestMultipleImageUploaderWithCustomImageModel(TestCase, WagtailTestUtils):
         response = self.client.post(reverse('wagtailimages:add_multiple'), {
             'files[]': SimpleUploadedFile('test-image.png', get_test_image_file().file.getvalue()),
             'collection': new_collection.id,
-        }, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        })
 
         image_count_after = CustomImage.objects.count()
         uploaded_image_count_after = UploadedImage.objects.count()
@@ -1669,7 +1637,7 @@ class TestMultipleImageUploaderWithCustomImageModel(TestCase, WagtailTestUtils):
             ('image-%d-title' % self.image.id): "New title!",
             ('image-%d-tags' % self.image.id): "footwear, dystopia",
             ('image-%d-caption' % self.image.id): "a boot stamping on a human face, forever",
-        }, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        })
 
         # Check response
         self.assertEqual(response.status_code, 200)
@@ -1708,7 +1676,7 @@ class TestMultipleImageUploaderWithCustomImageModel(TestCase, WagtailTestUtils):
             ('image-%d-collection' % self.image.id): new_collection.id,
             ('image-%d-tags' % self.image.id): "",
             ('image-%d-caption' % self.image.id): "ooh la la",
-        }, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        })
 
         # Check response
         self.assertEqual(response.status_code, 200)
@@ -1730,7 +1698,7 @@ class TestMultipleImageUploaderWithCustomImageModel(TestCase, WagtailTestUtils):
         # Send request
         response = self.client.post(reverse(
             'wagtailimages:delete_multiple', args=(self.image.id, )
-        ), HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        ))
 
         # Check response
         self.assertEqual(response.status_code, 200)
@@ -1786,7 +1754,7 @@ class TestMultipleImageUploaderWithCustomRequiredFields(TestCase, WagtailTestUti
 
         response = self.client.post(reverse('wagtailimages:add_multiple'), {
             'files[]': SimpleUploadedFile('test.png', get_test_image_file().file.getvalue()),
-        }, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        })
 
         image_count_after = CustomImageWithAuthor.objects.count()
         uploaded_image_count_after = UploadedImage.objects.count()
@@ -1823,7 +1791,7 @@ class TestMultipleImageUploaderWithCustomRequiredFields(TestCase, WagtailTestUti
         """
         response = self.client.post(reverse('wagtailimages:add_multiple'), {
             'files[]': SimpleUploadedFile('test.png', b"This is not an image!"),
-        }, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        })
 
         # Check response
         self.assertEqual(response.status_code, 200)
@@ -1853,7 +1821,7 @@ class TestMultipleImageUploaderWithCustomRequiredFields(TestCase, WagtailTestUti
             ('uploaded-image-%d-title' % self.uploaded_image.id): "New title!",
             ('uploaded-image-%d-tags' % self.uploaded_image.id): "",
             ('uploaded-image-%d-author' % self.uploaded_image.id): "",
-        }, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        })
 
         image_count_after = CustomImageWithAuthor.objects.count()
         uploaded_image_count_after = UploadedImage.objects.count()
@@ -1891,7 +1859,7 @@ class TestMultipleImageUploaderWithCustomRequiredFields(TestCase, WagtailTestUti
             ('uploaded-image-%d-title' % self.uploaded_image.id): "New title!",
             ('uploaded-image-%d-tags' % self.uploaded_image.id): "abstract, squares",
             ('uploaded-image-%d-author' % self.uploaded_image.id): "Piet Mondrian",
-        }, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        })
 
         image_count_after = CustomImageWithAuthor.objects.count()
         uploaded_image_count_after = UploadedImage.objects.count()
@@ -1926,7 +1894,7 @@ class TestMultipleImageUploaderWithCustomRequiredFields(TestCase, WagtailTestUti
         # Send request
         response = self.client.post(reverse(
             'wagtailimages:delete_upload_multiple', args=(self.uploaded_image.id, )
-        ), HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        ))
 
         # Check response
         self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
is_ajax is scheduled for removal in Django 4.0, since Django no longer considers the X-Requested-With header as a definitive indicator of whether the request came from Javascript. (See under https://docs.djangoproject.com/en/3.2/releases/3.1/#id2.) On that logic, there is no real value in enforcing it in our AJAX-only views, and there's no harm in removing it (it just means that if anyone ever does make a non-AJAX request to that URL, they'll get an HTML fragment back rather than a 400 error, which is equally good at communicating the message that the URL endpoint isn't directly usable in the browser).
