### PR TITLE
Fix home icon in breadcrumbs for limited-permission users, fixes #7348

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -24,6 +24,7 @@ Changelog
  * Fix: Admin fields and Icon visibility issues in Windows high contrast mode (Dmitrii Faiazov)
  * Fix: `blocks.MultipleChoiceBlock`, `forms.CheckboxSelectMultiple` and `ArrayField` checkboxes will now stack instead of display inline to align with all other checkboxes fields (Seb Brown)
  * Fix: Screen readers can now access login screen field labels (Amy Chan)
+ * Fix: Admin breadcrumbs home icon now shows for users with access to a subtree only (Stefan Hammer)
 
 
 2.14.1 (12.08.2021)

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -529,6 +529,7 @@ Contributors
 * Jannis Vajen
 * Dmitrii Faiazov
 * Amy Chan
+* Stefan Hammer
 
 Translators
 ===========

--- a/docs/releases/2.15.rst
+++ b/docs/releases/2.15.rst
@@ -39,6 +39,7 @@ Bug fixes
  * Admin fields and Icon visibility issues in Windows high contrast mode (Dmitrii Faiazov)
  * ``blocks.MultipleChoiceBlock``, ``forms.CheckboxSelectMultiple`` and ``ArrayField`` checkboxes will now stack instead of display inline to align with all other checkboxes fields (Seb Brown)
  * Screen readers can now access login screen field labels (Amy Chan)
+ * Admin breadcrumbs home icon now shows for users with access to a subtree only (Stefan Hammer)
 
 Upgrade considerations
 ======================

--- a/wagtail/admin/templates/wagtailadmin/shared/breadcrumb.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/breadcrumb.html
@@ -10,7 +10,7 @@
             {% elif forloop.first %}
                 {# For limited-permission users whose breadcrumb starts further down from the root, the first item displays as a 'home' icon in place of the title #}
                 {% trans 'Home' as home %}
-                <li class="home"><a href="{% url 'wagtailadmin_explore' page.id %}" class="text-replace">{% icon name="site" class_name="home_icon" title=home %}</a>{% icon name="arrow-right" class_name="arrow_right_icon"%}</li>
+                <li class="home"><a href="{% url 'wagtailadmin_explore' page.id %}">{% icon name="site" class_name="home_icon" title=home %}{% icon name="arrow-right" class_name="arrow_right_icon"%}</a></li>
             {% elif forloop.last %}
                 <li><a href="{% url 'wagtailadmin_explore' page.id %}"><span class="title">{{ page.get_admin_display_title }}</span>
                 {% if trailing_arrow %}

--- a/wagtail/admin/tests/pages/test_explorer_view.py
+++ b/wagtail/admin/tests/pages/test_explorer_view.py
@@ -559,15 +559,15 @@ class TestExplorablePageVisibility(TestCase, WagtailTestUtils):
         # since it's his Closest Common Ancestor.
         expected = """
             <li class="home">
-                <a href="/admin/pages/4/" class="text-replace">
+                <a href="/admin/pages/4/">
                     <svg class="icon icon-site home_icon" aria-hidden="true" focusable="false">
                         <use href="#icon-site"></use>
                     </svg>
                     <span class="visuallyhidden">Home</span>
+                    <svg class="icon icon-arrow-right arrow_right_icon" aria-hidden="true" focusable="false">
+                        <use href="#icon-arrow-right"></use>
+                    </svg>
                 </a>
-                <svg class="icon icon-arrow-right arrow_right_icon" aria-hidden="true" focusable="false">
-                    <use href="#icon-arrow-right"></use>
-                </svg>
             </li>
         """
         self.assertContains(response, expected, html=True)


### PR DESCRIPTION
The html has just been synced with the html for unlimited users.

See #7348 
