### PR TITLE
Update form label css to be readable by screen reader

### DIFF
--- a/wagtail/admin/static_src/wagtailadmin/scss/layouts/login.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/layouts/login.scss
@@ -82,12 +82,7 @@ input[type=checkbox]:before {
         padding: 0;
 
         label {
-            position: absolute;
-            left: -10000px;
-            top: auto;
-            width: 1px;
-            height: 1px;
-            overflow: hidden;
+            @include visuallyhidden;
         }
 
         input {

--- a/wagtail/admin/static_src/wagtailadmin/scss/layouts/login.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/layouts/login.scss
@@ -82,7 +82,12 @@ input[type=checkbox]:before {
         padding: 0;
 
         label {
-            display: none;
+            position: absolute;
+            left: -10000px;
+            top: auto;
+            width: 1px;
+            height: 1px;
+            overflow: hidden;
         }
 
         input {


### PR DESCRIPTION
Fixes #7432
The label can't be read by screen reader since it was set to display none. This hides it without using display none.

* Do the tests still pass? Yes
* Does the code comply with the style guide? Yes
* For front-end changes:
    * Please list the exact browser and operating system versions you tested.
      * Firefox, Chrome, and Safari on MacOS
    * Please list which assistive technologies you tested.
      * VoiceOver and Firefox accessibility inspector.
