### PR TITLE
Clean up document chooser modal

### DIFF
--- a/client/src/entrypoints/documents/document-chooser.js
+++ b/client/src/entrypoints/documents/document-chooser.js
@@ -12,7 +12,7 @@ function createDocumentChooser(id) {
   createDocumentChooser. State is either null (= no document chosen) or a dict of id, title and
   edit_link.
 
-  The result returned from the document chooser modal (see get_document_result_data in
+  The result returned from the document chooser modal (see get_document_chosen_response in
   wagtail.documents.views.chooser) is a superset of this, and can therefore be passed directly to
   chooser.setState.
   */

--- a/wagtail/documents/admin_urls.py
+++ b/wagtail/documents/admin_urls.py
@@ -17,7 +17,7 @@ urlpatterns = [
     path('multiple/<int:doc_id>/delete/', multiple.DeleteView.as_view(), name='delete_multiple'),
     path('multiple/delete_upload/<int:uploaded_document_id>/', multiple.DeleteUploadView.as_view(), name='delete_upload_multiple'),
 
-    path('chooser/', chooser.chooser, name='chooser'),
+    path('chooser/', chooser.ChooseView.as_view(), name='chooser'),
     path('chooser/<int:document_id>/', chooser.document_chosen, name='document_chosen'),
     path('chooser/upload/', chooser.chooser_upload, name='chooser_upload'),
     path('usage/<int:document_id>/', documents.usage, name='document_usage'),

--- a/wagtail/documents/admin_urls.py
+++ b/wagtail/documents/admin_urls.py
@@ -18,6 +18,7 @@ urlpatterns = [
     path('multiple/delete_upload/<int:uploaded_document_id>/', multiple.DeleteUploadView.as_view(), name='delete_upload_multiple'),
 
     path('chooser/', chooser.ChooseView.as_view(), name='chooser'),
+    path('chooser/results/', chooser.ChooseResultsView.as_view(), name='chooser_results'),
     path('chooser/<int:document_id>/', chooser.document_chosen, name='document_chosen'),
     path('chooser/upload/', chooser.chooser_upload, name='chooser_upload'),
     path('usage/<int:document_id>/', documents.usage, name='document_usage'),

--- a/wagtail/documents/static_src/wagtaildocs/js/document-chooser-modal.js
+++ b/wagtail/documents/static_src/wagtaildocs/js/document-chooser-modal.js
@@ -1,3 +1,27 @@
+function ajaxifyDocumentUploadForm(modal) {
+    $('form.document-upload', modal.body).on('submit', function() {
+        var formdata = new FormData(this);
+
+        $.ajax({
+            url: this.action,
+            data: formdata,
+            processData: false,
+            contentType: false,
+            type: 'POST',
+            dataType: 'text',
+            success: modal.loadResponseText,
+            error: function(response, textStatus, errorThrown) {
+                var message = jsonData['error_message'] + '<br />' + errorThrown + ' - ' + response.status;
+                $('#upload', modal.body).append(
+                    '<div class="help-block help-critical">' +
+                    '<strong>' + jsonData['error_label'] + ': </strong>' + message + '</div>');
+            }
+        });
+
+        return false;
+    });
+}
+
 DOCUMENT_CHOOSER_MODAL_ONLOAD_HANDLERS = {
     'chooser': function(modal, jsonData) {
         function ajaxifyLinks (context) {
@@ -51,28 +75,7 @@ DOCUMENT_CHOOSER_MODAL_ONLOAD_HANDLERS = {
         }
 
         ajaxifyLinks(modal.body);
-
-        $('form.document-upload', modal.body).on('submit', function() {
-            var formdata = new FormData(this);
-
-            $.ajax({
-                url: this.action,
-                data: formdata,
-                processData: false,
-                contentType: false,
-                type: 'POST',
-                dataType: 'text',
-                success: modal.loadResponseText,
-                error: function(response, textStatus, errorThrown) {
-                    var message = jsonData['error_message'] + '<br />' + errorThrown + ' - ' + response.status;
-                    $('#upload').append(
-                        '<div class="help-block help-critical">' +
-                        '<strong>' + jsonData['error_label'] + ': </strong>' + message + '</div>');
-                }
-            });
-
-            return false;
-        });
+        ajaxifyDocumentUploadForm(modal);
 
         $('form.document-search', modal.body).on('submit', search);
 
@@ -90,5 +93,9 @@ DOCUMENT_CHOOSER_MODAL_ONLOAD_HANDLERS = {
     'document_chosen': function(modal, jsonData) {
         modal.respond('documentChosen', jsonData['result']);
         modal.close();
+    },
+    'reshow_upload_form': function(modal, jsonData) {
+        $('#upload', modal.body).html(jsonData.htmlFragment);
+        ajaxifyDocumentUploadForm(modal);
     }
 };

--- a/wagtail/documents/static_src/wagtaildocs/js/document-chooser-modal.js
+++ b/wagtail/documents/static_src/wagtaildocs/js/document-chooser-modal.js
@@ -7,8 +7,7 @@ DOCUMENT_CHOOSER_MODAL_ONLOAD_HANDLERS = {
             });
 
             $('.pagination a', context).on('click', function() {
-                var page = this.getAttribute("data-page");
-                setPage(page);
+                loadResults(this.href);
                 return false;
             });
 
@@ -28,37 +27,16 @@ DOCUMENT_CHOOSER_MODAL_ONLOAD_HANDLERS = {
         var searchUrl = $('form.document-search', modal.body).attr('action');
         var request;
         function search() {
-            request = $.ajax({
-                url: searchUrl,
-                data: {
-                    q: $('#id_q').val(),
-                    collection_id: $('#collection_chooser_collection_id').val()
-                },
-                success: function(data, status) {
-                    request = null;
-                    $('#search-results').html(data);
-                    ajaxifyLinks($('#search-results'));
-                },
-                error: function() {
-                    request = null;
-                }
+            loadResults(searchUrl, {
+                q: $('#id_q').val(),
+                collection_id: $('#collection_chooser_collection_id').val()
             });
             return false;
         };
-        function setPage(page) {
-            var dataObj;
 
-            if($('#id_q').val().length){
-                dataObj = {q: $('#id_q').val(), p: page};
-            }else{
-                dataObj = {p: page};
-            }
-
-            dataObj.collection_id = $('#collection_chooser_collection_id').val();
-
-            request = $.ajax({
-                url: searchUrl,
-                data: dataObj,
+        function loadResults(url, data) {
+            var opts = {
+                url: url,
                 success: function(data, status) {
                     request = null;
                     $('#search-results').html(data);
@@ -67,8 +45,11 @@ DOCUMENT_CHOOSER_MODAL_ONLOAD_HANDLERS = {
                 error: function() {
                     request = null;
                 }
-            });
-            return false;
+            };
+            if (data) {
+                opts.data = data;
+            }
+            request = $.ajax(opts);
         }
 
         ajaxifyLinks(modal.body);

--- a/wagtail/documents/static_src/wagtaildocs/js/document-chooser-modal.js
+++ b/wagtail/documents/static_src/wagtaildocs/js/document-chooser-modal.js
@@ -24,13 +24,11 @@ DOCUMENT_CHOOSER_MODAL_ONLOAD_HANDLERS = {
             });
         };
 
-        var searchUrl = $('form.document-search', modal.body).attr('action');
+        var searchForm = $('form.document-search', modal.body);
+        var searchUrl = searchForm.attr('action');
         var request;
         function search() {
-            loadResults(searchUrl, {
-                q: $('#id_q').val(),
-                collection_id: $('#collection_chooser_collection_id').val()
-            });
+            loadResults(searchUrl, searchForm.serialize());
             return false;
         };
 

--- a/wagtail/documents/templates/wagtaildocs/chooser/chooser.html
+++ b/wagtail/documents/templates/wagtaildocs/chooser/chooser.html
@@ -29,23 +29,6 @@
         </div>
     </section>
     {% if uploadform %}
-        <section id="upload" class="{% if uploadform.errors %}active {% endif %}nice-padding">
-            {% include "wagtailadmin/shared/non_field_errors.html" with form=uploadform %}
-            <form class="document-upload" action="{% url 'wagtaildocs:chooser_upload' %}" method="POST" enctype="multipart/form-data" novalidate>
-                {% csrf_token %}
-                <ul class="fields">
-                    {% for field in uploadform %}
-                        {% if field.is_hidden %}
-                            {{ field }}
-                        {% else %}
-                            {% include "wagtailadmin/shared/field_as_li.html" with field=field %}
-                        {% endif %}
-                    {% endfor %}
-                    <li>
-                        <button type="submit" class="button button-longrunning" data-clicked-text="{% trans 'Uploading…' %}">{% icon name="spinner" %}<em>{% trans 'Upload' %}</em></button>
-                    </li>
-                </ul>
-            </form>
-        </section>
+        {% include "wagtaildocs/chooser/upload_form.html" with form=uploadform %}
     {% endif %}
 </div>

--- a/wagtail/documents/templates/wagtaildocs/chooser/chooser.html
+++ b/wagtail/documents/templates/wagtaildocs/chooser/chooser.html
@@ -14,7 +14,7 @@
 
 <div class="tab-content">
     <section id="search" class="{% if not uploadform.errors %}active {% endif %}nice-padding">
-        <form class="document-search search-bar" action="{% url 'wagtaildocs:chooser' %}" method="GET" novalidate>
+        <form class="document-search search-bar" action="{% url 'wagtaildocs:chooser_results' %}" method="GET" novalidate>
             <ul class="fields">
                 {% for field in searchform %}
                     {% include "wagtailadmin/shared/field_as_li.html" with field=field %}

--- a/wagtail/documents/templates/wagtaildocs/chooser/results.html
+++ b/wagtail/documents/templates/wagtaildocs/chooser/results.html
@@ -49,7 +49,7 @@
         </tbody>
     </table>
 
-    {% include "wagtailadmin/shared/ajax_pagination_nav.html" with items=documents %}
+    {% include "wagtailadmin/shared/pagination_nav.html" with items=documents linkurl='wagtaildocs:chooser_results' %}
 {% else %}
     {% if documents_exist %}
         <p role="alert">{% blocktrans %}Sorry, no documents match "<em>{{ query_string }}</em>"{% endblocktrans %}</p>

--- a/wagtail/documents/templates/wagtaildocs/chooser/results.html
+++ b/wagtail/documents/templates/wagtaildocs/chooser/results.html
@@ -12,7 +12,42 @@
         <h2>{% trans "Latest documents" %}</h2>
     {% endif %}
 
-    {% include "wagtaildocs/documents/list.html" with choosing=1 %}
+    <table class="listing">
+        <col />
+        <col  />
+        {% if collections %}
+            <col />
+        {% endif %}
+        <col width="16%" />
+        <thead>
+            <tr class="table-headers">
+                <th>{% trans "Title" %}</th>
+                <th>{% trans "File" %}</th>
+                {% if collections %}
+                    <th>{% trans "Collection" %}</th>
+                {% endif %}
+                <th>{% trans "Created" %}</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for doc in documents %}
+                <tr>
+                    <td class="title">
+                        <div class="title-wrapper"><a href="{% url 'wagtaildocs:document_chosen' doc.id %}" class="document-choice">{{ doc.title }}</a></div>
+                    </td>
+                    <td><a href="{{ doc.url }}" class="nolink" download>{{ doc.filename }}</a></td>
+                    {% if collections %}
+                        <td>{{ doc.collection.name }}</td>
+                    {% endif %}
+                    <td>
+                        <div class="human-readable-date" title="{{ doc.created_at|date:"DATETIME_FORMAT" }}">
+                            {% blocktrans with time_period=doc.created_at|timesince %}{{ time_period }} ago{% endblocktrans %}
+                        </div>
+                    </td>
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
 
     {% include "wagtailadmin/shared/ajax_pagination_nav.html" with items=documents %}
 {% else %}

--- a/wagtail/documents/templates/wagtaildocs/chooser/upload_form.html
+++ b/wagtail/documents/templates/wagtaildocs/chooser/upload_form.html
@@ -1,0 +1,19 @@
+{% load i18n wagtailadmin_tags %}
+<section id="upload" class="{% if form.errors %}active {% endif %}nice-padding">
+    {% include "wagtailadmin/shared/non_field_errors.html" with form=form %}
+    <form class="document-upload" action="{% url 'wagtaildocs:chooser_upload' %}" method="POST" enctype="multipart/form-data" novalidate>
+        {% csrf_token %}
+        <ul class="fields">
+            {% for field in form %}
+                {% if field.is_hidden %}
+                    {{ field }}
+                {% else %}
+                    {% include "wagtailadmin/shared/field_as_li.html" with field=field %}
+                {% endif %}
+            {% endfor %}
+            <li>
+                <button type="submit" class="button button-longrunning" data-clicked-text="{% trans 'Uploading…' %}">{% icon name="spinner" %}<em>{% trans 'Upload' %}</em></button>
+            </li>
+        </ul>
+    </form>
+</section>

--- a/wagtail/documents/templates/wagtaildocs/documents/list.html
+++ b/wagtail/documents/templates/wagtaildocs/documents/list.html
@@ -36,11 +36,7 @@
         {% for doc in documents %}
             <tr>
                 <td class="title">
-                    {% if choosing %}
-                        <div class="title-wrapper"><a href="{% url 'wagtaildocs:document_chosen' doc.id %}" class="document-choice">{{ doc.title }}</a></div>
-                    {% else %}
-                        <div class="title-wrapper"><a href="{% url 'wagtaildocs:edit' doc.id %}">{{ doc.title }}</a></div>
-                    {% endif %}
+                    <div class="title-wrapper"><a href="{% url 'wagtaildocs:edit' doc.id %}">{{ doc.title }}</a></div>
                 </td>
                 <td><a href="{{ doc.url }}" class="nolink" download>{{ doc.filename }}</a></td>
                 {% if collections %}

--- a/wagtail/documents/tests/test_admin_views.py
+++ b/wagtail/documents/tests/test_admin_views.py
@@ -1261,9 +1261,9 @@ class TestDocumentChooserUploadView(TestCase, WagtailTestUtils):
     def test_simple(self):
         response = self.client.get(reverse('wagtaildocs:chooser_upload'))
         self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, 'wagtaildocs/chooser/chooser.html')
+        self.assertTemplateUsed(response, 'wagtaildocs/chooser/upload_form.html')
         response_json = json.loads(response.content.decode())
-        self.assertEqual(response_json['step'], 'chooser')
+        self.assertEqual(response_json['step'], 'reshow_upload_form')
 
     def test_post(self):
         # Build a fake file
@@ -1302,7 +1302,7 @@ class TestDocumentChooserUploadView(TestCase, WagtailTestUtils):
 
         # Shouldn't redirect anywhere
         self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, 'wagtaildocs/chooser/chooser.html')
+        self.assertTemplateUsed(response, 'wagtaildocs/chooser/upload_form.html')
 
         # The form should have an error
         self.assertContains(response, "Custom document with this Title and Collection already exists.")
@@ -1340,12 +1340,12 @@ class TestDocumentChooserUploadViewWithLimitedPermissions(TestCase, WagtailTestU
     def test_simple(self):
         response = self.client.get(reverse('wagtaildocs:chooser_upload'))
         self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, 'wagtaildocs/chooser/chooser.html')
+        self.assertTemplateUsed(response, 'wagtaildocs/chooser/upload_form.html')
         response_json = json.loads(response.content.decode())
-        self.assertEqual(response_json['step'], 'chooser')
+        self.assertEqual(response_json['step'], 'reshow_upload_form')
 
         # user only has access to one collection -> should not see the collections field
-        self.assertNotIn('id_collection', response_json['html'])
+        self.assertNotIn('id_collection', response_json['htmlFragment'])
 
     def test_chooser_view(self):
         # The main chooser view also includes the form, so need to test there too

--- a/wagtail/documents/tests/test_admin_views.py
+++ b/wagtail/documents/tests/test_admin_views.py
@@ -1139,7 +1139,7 @@ class TestDocumentChooserView(TestCase, WagtailTestUtils):
         self.assertIn('wagtailadmin/js/draftail.js', response_json['html'])
 
     def test_search(self):
-        response = self.client.get(reverse('wagtaildocs:chooser'), {'q': "Hello"})
+        response = self.client.get(reverse('wagtaildocs:chooser_results'), {'q': "Hello"})
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context['query_string'], "Hello")
 
@@ -1151,7 +1151,7 @@ class TestDocumentChooserView(TestCase, WagtailTestUtils):
     def test_pagination(self):
         self.make_docs()
 
-        response = self.client.get(reverse('wagtaildocs:chooser'), {'p': 2})
+        response = self.client.get(reverse('wagtaildocs:chooser_results'), {'p': 2})
 
         # Check response
         self.assertEqual(response.status_code, 200)
@@ -1163,7 +1163,7 @@ class TestDocumentChooserView(TestCase, WagtailTestUtils):
     def test_pagination_invalid(self):
         self.make_docs()
 
-        response = self.client.get(reverse('wagtaildocs:chooser'), {'p': 'Hello World!'})
+        response = self.client.get(reverse('wagtaildocs:chooser_results'), {'p': 'Hello World!'})
 
         # Check response
         self.assertEqual(response.status_code, 200)
@@ -1175,7 +1175,7 @@ class TestDocumentChooserView(TestCase, WagtailTestUtils):
     def test_pagination_out_of_range(self):
         self.make_docs()
 
-        response = self.client.get(reverse('wagtaildocs:chooser'), {'p': 99999})
+        response = self.client.get(reverse('wagtaildocs:chooser_results'), {'p': 99999})
 
         # Check response
         self.assertEqual(response.status_code, 200)
@@ -1218,7 +1218,7 @@ class TestDocumentChooserView(TestCase, WagtailTestUtils):
             return documents.filter(uploaded_by_user=self.user)
 
         with self.register_hook('construct_document_chooser_queryset', filter_documents):
-            response = self.client.get(reverse('wagtaildocs:chooser'), {'q': 'Test'})
+            response = self.client.get(reverse('wagtaildocs:chooser_results'), {'q': 'Test'})
         self.assertEqual(len(response.context['documents']), 1)
         self.assertEqual(response.context['documents'][0], document)
 

--- a/wagtail/documents/tests/test_admin_views.py
+++ b/wagtail/documents/tests/test_admin_views.py
@@ -1155,7 +1155,7 @@ class TestDocumentChooserView(TestCase, WagtailTestUtils):
 
         # Check response
         self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, 'wagtaildocs/documents/list.html')
+        self.assertTemplateUsed(response, 'wagtaildocs/chooser/results.html')
 
         # Check that we got the correct page
         self.assertEqual(response.context['documents'].number, 2)
@@ -1167,7 +1167,7 @@ class TestDocumentChooserView(TestCase, WagtailTestUtils):
 
         # Check response
         self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, 'wagtaildocs/documents/list.html')
+        self.assertTemplateUsed(response, 'wagtaildocs/chooser/results.html')
 
         # Check that we got page one
         self.assertEqual(response.context['documents'].number, 1)
@@ -1179,7 +1179,7 @@ class TestDocumentChooserView(TestCase, WagtailTestUtils):
 
         # Check response
         self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, 'wagtaildocs/documents/list.html')
+        self.assertTemplateUsed(response, 'wagtaildocs/chooser/results.html')
 
         # Check that we got the last page
         self.assertEqual(response.context['documents'].number, response.context['documents'].paginator.num_pages)

--- a/wagtail/documents/views/chooser.py
+++ b/wagtail/documents/views/chooser.py
@@ -86,13 +86,8 @@ class BaseChooseView(View):
 
         return self.render_to_response()
 
-    def render_to_response(self):
-        raise NotImplementedError()
-
-
-class ChooseView(BaseChooseView):
-    def render_to_response(self):
-        return render_modal_workflow(self.request, 'wagtaildocs/chooser/chooser.html', None, {
+    def get_context_data(self):
+        return {
             'documents': self.documents,
             'documents_exist': self.documents_exist,
             'uploadform': self.uploadform,
@@ -101,25 +96,28 @@ class ChooseView(BaseChooseView):
             'collections': self.collections,
             'is_searching': self.is_searching,
             'collection_id': self.collection_id,
-        }, json_data={
-            'step': 'chooser',
-            'error_label': _("Server Error"),
-            'error_message': _("Report this error to your webmaster with the following information:"),
-            'tag_autocomplete_url': reverse('wagtailadmin_tag_autocomplete'),
-        })
+        }
+
+    def render_to_response(self):
+        raise NotImplementedError()
+
+
+class ChooseView(BaseChooseView):
+    def render_to_response(self):
+        return render_modal_workflow(
+            self.request, 'wagtaildocs/chooser/chooser.html', None, self.get_context_data(),
+            json_data={
+                'step': 'chooser',
+                'error_label': _("Server Error"),
+                'error_message': _("Report this error to your webmaster with the following information:"),
+                'tag_autocomplete_url': reverse('wagtailadmin_tag_autocomplete'),
+            }
+        )
 
 
 class ChooseResultsView(BaseChooseView):
     def render_to_response(self):
-        return TemplateResponse(self.request, "wagtaildocs/chooser/results.html", {
-            'documents': self.documents,
-            'documents_exist': self.documents_exist,
-            'uploadform': self.uploadform,
-            'query_string': self.q,
-            'collections': self.collections,
-            'is_searching': self.is_searching,
-            'collection_id': self.collection_id,
-        })
+        return TemplateResponse(self.request, "wagtaildocs/chooser/results.html", self.get_context_data())
 
 
 def document_chosen(request, document_id):

--- a/wagtail/documents/views/chooser.py
+++ b/wagtail/documents/views/chooser.py
@@ -1,5 +1,6 @@
 from django.core.paginator import Paginator
 from django.shortcuts import get_object_or_404
+from django.template.loader import render_to_string
 from django.template.response import TemplateResponse
 from django.urls import reverse
 from django.utils.translation import gettext as _
@@ -164,10 +165,10 @@ def chooser_upload(request):
     else:
         form = DocumentForm(user=request.user, prefix='document-chooser-upload')
 
-    documents = Document.objects.order_by('title')
-
     return render_modal_workflow(
-        request, 'wagtaildocs/chooser/chooser.html', None,
-        {'documents': documents, 'uploadform': form},
-        json_data=get_chooser_context()
+        request, None, None,
+        None, json_data={
+            'step': 'reshow_upload_form',
+            'htmlFragment': render_to_string('wagtaildocs/chooser/upload_form.html', {'form': form}, request),
+        }
     )

--- a/wagtail/documents/views/chooser.py
+++ b/wagtail/documents/views/chooser.py
@@ -84,6 +84,13 @@ class BaseChooseView(View):
 
         paginator = Paginator(documents, per_page=10)
         self.documents = paginator.get_page(request.GET.get('p'))
+
+        self.collections = permission_policy.collections_user_has_permission_for(
+            request.user, 'choose'
+        )
+        if len(self.collections) < 2:
+            self.collections = None
+
         return self.render_to_response()
 
     def render_to_response(self):
@@ -92,19 +99,13 @@ class BaseChooseView(View):
 
 class ChooseView(BaseChooseView):
     def render_to_response(self):
-        collections = permission_policy.collections_user_has_permission_for(
-            self.request.user, 'choose'
-        )
-        if len(collections) < 2:
-            collections = None
-
         return render_modal_workflow(self.request, 'wagtaildocs/chooser/chooser.html', None, {
             'documents': self.documents,
             'documents_exist': self.documents_exist,
             'uploadform': self.uploadform,
             'query_string': self.q,
             'searchform': self.searchform,
-            'collections': collections,
+            'collections': self.collections,
             'is_searching': self.is_searching,
             'collection_id': self.collection_id,
         }, json_data=get_chooser_context())
@@ -117,6 +118,7 @@ class ChooseResultsView(BaseChooseView):
             'documents_exist': self.documents_exist,
             'uploadform': self.uploadform,
             'query_string': self.q,
+            'collections': self.collections,
             'is_searching': self.is_searching,
             'collection_id': self.collection_id,
         })


### PR DESCRIPTION
Eliminate a lot of the spaghetti code in the document chooser modal (and fix a few bugs that were caused by said spaghetti), following the strategy previously used for the snippet chooser in #7379:

* the listing template no longer piggybacks on the index page's listing template (which means it no longer has column reordering links that point to the wrong URL, and will make both views easier to convert to the generic listing framework #7409)
* the 'results HTML fragment only' endpoint used when paginating / searching is now a distinct view, rather than an alternative behaviour that kicks in in the presence of certain URL parameters (and the contexts of those two cases have been made consistent so that the Collection column doesn't disappear when you start searching / paginating)
* pagination links now use the standard pagination_nav.html include, instead of the hacky ajax_pagination_nav.html that needs a bunch of supporting JS
* the upload form only re-renders its own tab on validation errors, rather than the whole modal (which meant having to replicate the state of the listing - which it did very badly, and which has led to wagtail-generic-chooser becoming way too overengineered while trying to replicate this pattern...)