### PR TITLE
High-contrast mode: restored vertical separation between field panels

### DIFF
--- a/wagtail/admin/static_src/wagtailadmin/scss/layouts/page-editor.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/layouts/page-editor.scss
@@ -117,6 +117,7 @@
 .object {
     @include nice-padding();
     position: relative;
+    border-top: 1px solid GrayText;
 
     &:first-child {
         border: 0;


### PR DESCRIPTION
Solves Issue #7455 - High-contrast mode: vertical separation between field panels is lost.

- Added border to styling to restore vertical seperation.
- Tested on Windows 10, High Contrast mode on. 
- Tested on Chrome and MS Edge browsers