### PR TITLE
High-constrat mode: Added sidebar vertical seperation with main content

### DIFF
--- a/client/scss/components/_main-nav.scss
+++ b/client/scss/components/_main-nav.scss
@@ -15,6 +15,7 @@
             // On medium, make it possible for the nav links to scroll.
             display: flex;
             flex-flow: column nowrap;
+            border-right: 1px solid transparent;
         }
     }
 }


### PR DESCRIPTION
Solved Issue #7456 - High-contrast mode: sidebar needs vertical seperation with main content.

- Added seperation between sidebar and main content.
- Added styling doesn't affect the normal view and shows clear seperation in Windows high-contrast mode.
- Tested on windows 10, High-Contrast mode on.
- Tested in Chrome and Edge browsers.