### PR TITLE
Fix: Update elasticsearch path in documentation

### DIFF
--- a/docs/topics/search/backends.rst
+++ b/docs/topics/search/backends.rst
@@ -149,7 +149,7 @@ A username and password may be optionally be supplied to the ``URL`` field to pr
       }
   }
 
-``INDEX_SETTINGS`` is a dictionary used to override the default settings to create the index. The default settings are defined inside the ``ElasticsearchSearchBackend`` class in the module ``wagtail/wagtail/wagtailsearch/backends/elasticsearch.py``. Any new key is added, any existing key, if not a dictionary, is replaced with the new value. Here's a sample on how to configure the number of shards and setting the Italian LanguageAnalyzer as the default analyzer:
+``INDEX_SETTINGS`` is a dictionary used to override the default settings to create the index. The default settings are defined inside the ``ElasticsearchSearchBackend`` class in the module ``wagtail/wagtail/search/backends/elasticsearch7.py``. Any new key is added, any existing key, if not a dictionary, is replaced with the new value. Here's a sample on how to configure the number of shards and setting the Italian LanguageAnalyzer as the default analyzer:
 
 .. code-block:: python
 


### PR DESCRIPTION
New location: https://github.com/wagtail/wagtail/blob/main/wagtail/search/backends/elasticsearch7.py
