### PR TITLE
add support for non_field_errors rendering in workflow action modal

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/pages/workflow_action_modal.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/workflow_action_modal.html
@@ -2,6 +2,8 @@
 {% include "wagtailadmin/shared/header.html" with title=action_verbose icon="clipboard-list" %}
 
 <div class="nice-padding">
+    {% include "wagtailadmin/shared/non_field_errors.html" %}
+    
     <form action="{{ submit_url }}" method="POST" novalidate>
         {% csrf_token %}
         <ul class="fields">

--- a/wagtail/admin/tests/test_workflows.py
+++ b/wagtail/admin/tests/test_workflows.py
@@ -1100,6 +1100,7 @@ class TestApproveRejectWorkflow(TestCase, WagtailTestUtils):
         response = self.client.get(reverse('wagtailadmin_pages:collect_workflow_action_data', args=(self.page.id, 'approve', self.page.current_workflow_task_state.id)))
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, 'wagtailadmin/pages/workflow_action_modal.html')
+        self.assertTemplateUsed(response, 'wagtailadmin/shared/non_field_errors.html')
         html = json.loads(response.content)['html']
         self.assertTagInHTML('<form action="' + reverse('wagtailadmin_pages:collect_workflow_action_data', args=(self.page.id, 'approve', self.page.current_workflow_task_state.id)) + '" method="POST" novalidate>', html)
         self.assertIn('Comment', html)


### PR DESCRIPTION
* fixes #7479
* Do the tests still pass? 👍 
* Does the code comply with the style guide? 👍 
* For Python changes: Have you added tests to cover the new/fixed behaviour? 👍 
* Note: I tried for a while to get a basic scenario working in the tests for failed form submission but could not, hopefully the test added (which checks that the template is included) is sufficient.