### PR TITLE
Change initial value of publish_copies to False

### DIFF
--- a/wagtail/admin/forms/pages.py
+++ b/wagtail/admin/forms/pages.py
@@ -53,7 +53,7 @@ class CopyForm(forms.Form):
                         pages_to_publish_count) % {'count': pages_to_publish_count}
 
                 self.fields['publish_copies'] = forms.BooleanField(
-                    required=False, initial=True, label=label, help_text=help_text
+                    required=False, initial=False, label=label, help_text=help_text
                 )
 
             # Note that only users who can publish in the new parent page can create an alias.


### PR DESCRIPTION
When copying a live page, it is more likely that one would not like to publish on copy, therefore, this PR changes the initial value of `publish_copies`/"Publish copied page" to `False`. Opening PR for discussion and consideration. 

![image](https://user-images.githubusercontent.com/59629491/131568013-c7750c75-da10-4c30-9c95-974412155b68.png)

