### PR TITLE
workflow - only show active Tasks in the chooser modal

### DIFF
--- a/wagtail/admin/views/workflows.py
+++ b/wagtail/admin/views/workflows.py
@@ -446,8 +446,8 @@ class DisableTask(DeleteView):
         context = super().get_context_data(**kwargs)
         states_in_progress = TaskState.objects.filter(status=TaskState.STATUS_IN_PROGRESS, task=self.get_object().pk).count()
         context['warning_message'] = ngettext(
-            'This task is in progress on %(states_in_progress)d page. Disabling this task will cause it to be skipped in the moderation workflow.',
-            'This task is in progress on %(states_in_progress)d pages. Disabling this task will cause it to be skipped in the moderation workflow.',
+            'This task is in progress on %(states_in_progress)d page. Disabling this task will cause it to be skipped in the moderation workflow and not be listed for selection when editing a workflow.',
+            'This task is in progress on %(states_in_progress)d pages. Disabling this task will cause it to be skipped in the moderation workflow and not be listed for selection when editing a workflow.',
             states_in_progress,
         ) % {
             'states_in_progress': states_in_progress,
@@ -550,7 +550,7 @@ def task_chooser(request):
     q = None
     if 'q' in request.GET or 'p' in request.GET or 'task_type' in request.GET:
         searchform = TaskChooserSearchForm(request.GET, task_type_choices=task_type_choices)
-        tasks = all_tasks = searchform.task_model.objects.order_by(Lower('name'))
+        tasks = all_tasks = searchform.task_model.objects.filter(active=True).order_by(Lower('name'))
         q = ''
 
         if searchform.is_searching():
@@ -599,7 +599,7 @@ def task_chooser(request):
             createform = None
 
         searchform = TaskChooserSearchForm(task_type_choices=task_type_choices)
-        tasks = searchform.task_model.objects.order_by(Lower('name'))
+        tasks = searchform.task_model.objects.filter(active=True).order_by(Lower('name'))
 
         paginator = Paginator(tasks, per_page=10)
         tasks = paginator.get_page(request.GET.get('p'))


### PR DESCRIPTION
* Implemented the desired solution (first part, simply not showing disabled tasks in the chooser modal), this is simpler to implement and makes more sense as adding a disabled task to a workflow will mean it always gets skipped.
* fixes #7401 
* When validating, be sure to also do a search in the chooser modal, the query code is different.
* Do the tests still pass? ✅ 
* Does the code comply with the style guide?  ✅ 
* For Python changes: Have you added tests to cover the new/fixed behaviour?  ✅ 
* For front-end changes: N/A
* For new features: Has the documentation been updated accordingly? N/A

Screenshot of functionality working
<img width="1671" alt="Screen Shot 2021-09-01 at 7 29 10 am" src="https://user-images.githubusercontent.com/1396140/131578405-03405640-574f-4a0f-addb-69fed9fed47a.png">

