### PR TITLE
Sidebar overlays to make page explorer usable on mobile

### DIFF
--- a/client/src/components/PageExplorer/PageExplorer.scss
+++ b/client/src/components/PageExplorer/PageExplorer.scss
@@ -8,8 +8,10 @@ $menu-footer-height: 50px;
 @import 'PageExplorerItem';
 
 .c-page-explorer {
-    width: 485px;
+    position: relative;
+    width: 100vw;
     height: 100vh;
+    max-width: 485px;
     background: $c-page-explorer-bg;
     overflow: hidden;
     flex: 1;
@@ -17,7 +19,6 @@ $menu-footer-height: 50px;
     *:focus {
         @include show-focus-outline-inside;
     }
-
 
     @include media-breakpoint-up(sm) {
         box-shadow: 2px 2px 5px $c-page-explorer-bg-active;

--- a/client/src/components/Sidebar/Sidebar.scss
+++ b/client/src/components/Sidebar/Sidebar.scss
@@ -33,7 +33,7 @@
     flex-direction: column;
     height: 100%;
     background: $nav-grey-3;
-    z-index: 3;
+    z-index: 1000;
 
     @include transition(width $menu-transition-duration ease, left $menu-transition-duration ease);
 
@@ -77,8 +77,9 @@
 // This is a separate component as it needs to display in the header
 .sidebar-nav-toggle {
     @include sidebar-toggle;
+    position: fixed;
     display: none;  // Nav toggle is for mobile only
-    z-index: 5;
+    z-index: 1000;
 
     &:hover {
         background: var(--color-primary-dark);

--- a/client/src/components/Sidebar/Sidebar.scss
+++ b/client/src/components/Sidebar/Sidebar.scss
@@ -101,6 +101,7 @@
 
 
 @import 'SidebarPanel';
+@import 'SidebarOverlay';
 @import 'menu/MenuItem';
 @import 'menu/SubMenuItem';
 @import 'modules/CustomBranding';

--- a/client/src/components/Sidebar/Sidebar.tsx
+++ b/client/src/components/Sidebar/Sidebar.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import * as React from 'react';
 
 import Icon from '../Icon/Icon';
@@ -165,31 +166,29 @@ export const Sidebar: React.FunctionComponent<SidebarProps> = (
   );
 
   return (
-    <>
-      <aside
-        className={
-          'sidebar'
-          + (slim ? ' sidebar--slim' : '')
-          + (isMobile ? ' sidebar--mobile' : '')
-          + ((isMobile && !visibleOnMobile) ? ' sidebar--hidden' : '')
-        }
-      >
-        <div className="sidebar__inner">
-          <button onClick={onClickCollapseToggle} className="button sidebar__collapse-toggle">
-            {collapsed ? <Icon name="angle-double-right" /> : <Icon name="angle-double-left" />}
-          </button>
+    <aside
+      className={
+        'sidebar'
+        + (slim ? ' sidebar--slim' : '')
+        + (isMobile ? ' sidebar--mobile' : '')
+        + ((isMobile && !visibleOnMobile) ? ' sidebar--hidden' : '')
+      }
+    >
+      <div className="sidebar__inner">
+        <button onClick={onClickCollapseToggle} className="button sidebar__collapse-toggle">
+          {collapsed ? <Icon name="angle-double-right" /> : <Icon name="angle-double-left" />}
+        </button>
 
-          <div
-            className="sidebar__peek-hover-area"
-            onMouseEnter={onMouseEnterHandler}
-            onMouseLeave={onMouseLeaveHandler}
-            onFocus={onFocusHandler}
-            onBlur={onBlurHandler}
-          >
-            {renderedModules}
-          </div>
+        <div
+          className="sidebar__peek-hover-area"
+          onMouseEnter={onMouseEnterHandler}
+          onMouseLeave={onMouseLeaveHandler}
+          onFocus={onFocusHandler}
+          onBlur={onBlurHandler}
+        >
+          {renderedModules}
         </div>
-      </aside>
+      </div>
       <button
         onClick={onClickOpenCloseToggle}
         className={
@@ -200,6 +199,6 @@ export const Sidebar: React.FunctionComponent<SidebarProps> = (
       >
         {visibleOnMobile ? <Icon name="cross" /> : <Icon name="bars" />}
       </button>
-    </>
+    </aside>
   );
 };

--- a/client/src/components/Sidebar/SidebarOverlay.scss
+++ b/client/src/components/Sidebar/SidebarOverlay.scss
@@ -1,0 +1,27 @@
+.sidebar-overlay {
+    z-index: 1100;
+    width: 100vw;
+    position: fixed;
+    inset: 0;
+    visibility: hidden;
+
+    &--open {
+        visibility: visible;
+    }
+
+    &__close-button {
+        padding: 1em;
+        color: #a5a5a5;
+        border-bottom: 1px solid rgba(200, 200, 200, 0.1);
+        cursor: pointer;
+        display: block;
+        background-color: #333;
+        text-align: center;
+
+        // Overrides for default link hover.
+        &:hover {
+            color: #a5a5a5;
+            background-color: #222;
+        }
+    }
+}

--- a/client/src/components/Sidebar/SidebarOverlay.tsx
+++ b/client/src/components/Sidebar/SidebarOverlay.tsx
@@ -1,0 +1,39 @@
+/* eslint-disable react/prop-types */
+
+import * as React from 'react';
+import FocusTrap from 'focus-trap-react';
+
+import Button from '../Button/Button';
+
+
+export interface SidebarOverlayProps {
+  isVisible: boolean;
+  isOpen: boolean;
+  onClose();
+}
+
+export const SidebarOverlay: React.FunctionComponent<SidebarOverlayProps> = (
+  { isVisible, isOpen, onClose, children }) => {
+  const className = (
+    'sidebar-overlay'
+    + (isVisible ? ' sidebar-overlay--visible' : '')
+    + (isOpen ? ' sidebar-overlay--open' : '')
+  );
+
+  return (
+    <FocusTrap
+      paused={!isOpen}
+      focusTrapOptions={{
+        onDeactivate: onClose,
+        fallbackFocus: '.sidebar-overlay__close-button'
+      }}
+    >
+      <div role="dialog" className={className}>
+        <Button onClick={onClose} className="sidebar-overlay__close-button">
+          Close
+        </Button>
+        {children}
+      </div>
+    </FocusTrap>
+  );
+};

--- a/client/src/components/Sidebar/menu/PageExplorerMenuItem.tsx
+++ b/client/src/components/Sidebar/menu/PageExplorerMenuItem.tsx
@@ -10,6 +10,7 @@ import { Provider } from 'react-redux';
 import PageExplorer, { initPageExplorerStore } from '../../PageExplorer';
 import { openPageExplorer, closePageExplorer } from '../../PageExplorer/actions';
 import { SidebarPanel } from '../SidebarPanel';
+import { SidebarOverlay } from '../SidebarOverlay';
 import { SIDEBAR_TRANSITION_DURATION } from '../Sidebar';
 
 export const PageExplorerMenuItem: React.FunctionComponent<MenuItemProps<PageExplorerMenuItemDefinition>> = (
@@ -24,6 +25,21 @@ export const PageExplorerMenuItem: React.FunctionComponent<MenuItemProps<PageExp
   if (!store.current) {
     store.current = initPageExplorerStore();
   }
+
+  const [isMobile, setIsMobile] = React.useState(false);
+
+  React.useEffect(() => {
+    function handleResize() {
+      if (window.innerWidth < 800) {
+        setIsMobile(true);
+      } else {
+        setIsMobile(false);
+      }
+    }
+    window.addEventListener('resize', handleResize);
+    handleResize();
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
 
   React.useEffect(() => {
     if (isOpen) {
@@ -62,6 +78,13 @@ export const PageExplorerMenuItem: React.FunctionComponent<MenuItemProps<PageExp
     }
   };
 
+  const onCloseOverlay = () => {
+    dispatch({
+      type: 'set-navigation-path',
+      path: '',
+    });
+  };
+
   const className = (
     'sidebar-menu-item'
     + (isActive ? ' sidebar-menu-item--active' : '')
@@ -81,13 +104,19 @@ export const PageExplorerMenuItem: React.FunctionComponent<MenuItemProps<PageExp
         <Icon className={sidebarTriggerIconClassName} name="arrow-right" />
       </Button>
       <div>
-        <SidebarPanel isVisible={isVisible} isOpen={isOpen} depth={depth} widthPx={485}>
-          {store.current &&
-            <Provider store={store.current}>
-              <PageExplorer isVisible={isVisible} navigate={navigate} />
-            </Provider>
-          }
-        </SidebarPanel>
+        {store.current &&
+          <Provider store={store.current}>
+            {isMobile ? (
+              <SidebarOverlay isVisible={isVisible} isOpen={isOpen} onClose={onCloseOverlay}>
+                <PageExplorer isVisible={isVisible} navigate={navigate} />
+              </SidebarOverlay>
+            ) : (
+              <SidebarPanel isVisible={isVisible} isOpen={isOpen} depth={depth} widthPx={485}>
+                <PageExplorer isVisible={isVisible} navigate={navigate} />
+              </SidebarPanel>
+            )}
+          </Provider>
+        }
       </div>
     </li>
   );


### PR DESCRIPTION
This PR implements an overlays feature that allows the page explorer menu to display on top of everything if the screen size is too small to display it alongside

![Screen Shot 2021-09-02 at 18 01 54](https://user-images.githubusercontent.com/1093808/131886454-ec7670c6-a1c6-4000-9283-ef61466b4576.png)
