### PR TITLE
slim-sidebar right to left support

### DIFF
--- a/client/scss/components/_main-nav.scss
+++ b/client/scss/components/_main-nav.scss
@@ -299,16 +299,27 @@ body.explorer-open {
 }
 
 @include media-breakpoint-up(sm) {
+    .wrapper {
+        --sidebar-width: #{$menu-width};
+    }
+
     .wrapper,
     body.nav-open .wrapper {
         transform: none;
-        padding-left: $menu-width;
+        padding-left: var(--sidebar-width);
 
         @include transition(padding-left $menu-transition-duration ease);
+        @include transition(padding-right $menu-transition-duration ease);
+    }
+
+    [dir='rtl'] body .wrapper,
+    [dir='rtl'] body.nav-open .wrapper {
+        padding-left: unset;
+        padding-right: var(--sidebar-width);
     }
 
     body.sidebar-collapsed .wrapper {
-        padding-left: $menu-width-slim;
+        --sidebar-width: #{$menu-width-slim};
     }
 
     .nav-wrapper {

--- a/client/src/components/PageExplorer/PageExplorer.scss
+++ b/client/src/components/PageExplorer/PageExplorer.scss
@@ -66,6 +66,7 @@ $menu-footer-height: 50px;
     background-color: $c-page-explorer-bg-dark;
     border-bottom: 1px solid $c-page-explorer-bg-dark;
     color: $color-white;
+    text-align: left;
 }
 
 .c-page-explorer__header__title {

--- a/client/src/components/PageExplorer/PageExplorerPanel.tsx
+++ b/client/src/components/PageExplorer/PageExplorerPanel.tsx
@@ -143,7 +143,7 @@ class PageExplorerPanel extends React.Component<PageExplorerPanelProps, PageExpl
 
     return (
       <Transition name={transition} className="c-page-explorer" component="nav" label={STRINGS.PAGE_EXPLORER}>
-        <div key={depth} className="c-transition-group">
+        <div key={depth} className="c-transition-group" dir="ltr">
           <PageExplorerHeader
             depth={depth}
             page={page}

--- a/client/src/components/Sidebar/Sidebar.scss
+++ b/client/src/components/Sidebar/Sidebar.scss
@@ -22,11 +22,18 @@
         width: 15px;
         height: 16px;
     }
+
+    [dir='rtl'] & {
+        right: 12px;
+        left: unset;
+    }
 }
 
 .sidebar {
+    --offset: 0;
+
     position: fixed;
-    left: 0;
+    left: var(--offset);
     width: $menu-width;
     float: left;
     display: flex;
@@ -35,7 +42,7 @@
     background: $nav-grey-3;
     z-index: 3;
 
-    @include transition(width $menu-transition-duration ease, left $menu-transition-duration ease);
+    @include transition(width $menu-transition-duration ease, left $menu-transition-duration ease, right $menu-transition-duration ease);
 
     &--slim {
         width: $menu-width-slim;
@@ -43,7 +50,12 @@
 
     // The sidebar can move completely off-screen in mobile mode for extra room
     &--hidden {
-        left: -$menu-width;
+        --offset: -$menu-width;
+    }
+
+    [dir='rtl'] & {
+        left: unset;
+        right: var(--offset);
     }
 
     &__inner {
@@ -57,6 +69,10 @@
     &__collapse-toggle {
         @include sidebar-toggle;
         display: grid;
+
+        [dir='rtl'] & {
+            transform: scaleX(-1);
+        }
     }
 
     // When in mobile mode, hide the collapse-toggle and show the nav-toggle (which is defined in the .sidebar-nav-toggle class below)
@@ -69,7 +85,7 @@
     &__peek-hover-area {
         position: absolute;
         top: 35px;  // Match height of __collapse-toggle
-        left: 0;
+        --offset: 0;
         width: 100%;
     }
 }

--- a/client/src/components/Sidebar/SidebarPanel.scss
+++ b/client/src/components/Sidebar/SidebarPanel.scss
@@ -1,6 +1,8 @@
 .sidebar-panel {
     // With CSS variable allows panels with different widths to animate properly
+    --menu-width: #{$menu-width};
     --width: #{$menu-width};
+    --offset: calc(var(--menu-width) - var(--width));
 
     visibility: hidden;
     transform: translate3d(0, 0, 0);
@@ -8,12 +10,12 @@
     height: 100vh;
     padding: 0;
     top: 0;
-    left: calc(#{$menu-width} - var(--width));
+    left: var(--offset);
     display: flex;
     flex-direction: column;
     overflow: hidden;
 
-    @include transition(left $menu-transition-duration ease);
+    @include transition(left $menu-transition-duration ease, right $menu-transition-duration ease);
 
     &--visible {
         visibility: visible;
@@ -21,19 +23,24 @@
     }
 
     @at-root .sidebar--slim #{&} {
-        left: calc(#{$menu-width-slim} - var(--width));
+        --menu-width: $menu-width-slim;
     }
     // Don't apply this to nested submenus though
     @at-root .sidebar--slim .sidebar-panel #{&} {
-        left: 0;
+        --menu-width: $menu-width;
+    }
+
+    [dir='rtl'] & {
+        right: var(--offset);
+        left: unset;
     }
 
     &--open {
-        left: $menu-width;
+        --offset: var(--menu-width);
 
         // Don't apply this to nested submenus though
         @at-root .sidebar--slim .sidebar-panel #{&} {
-            left: $menu-width;
+            --offset: var(--menu-width);
         }
     }
 }

--- a/client/src/components/Sidebar/menu/MenuItem.scss
+++ b/client/src/components/Sidebar/menu/MenuItem.scss
@@ -78,6 +78,7 @@
 .menuitem-label {
     @include transition(opacity $menu-transition-duration ease);
     margin-left: 0.5em;
+    margin-right: 0.5em;
 }
 
 .menuitem-tooltip {

--- a/client/src/components/Sidebar/menu/SubMenuItem.scss
+++ b/client/src/components/Sidebar/menu/SubMenuItem.scss
@@ -1,4 +1,8 @@
 .sidebar-sub-menu-trigger-icon {
+    --rotation: 0;
+    --translation: 0;
+    --scale: 1;
+
     display: block;
     width: 20px;
     height: 20px;
@@ -7,18 +11,25 @@
     top: 0;
     bottom: 0;
     margin: auto 0;
+    transform-origin: 50% 50%;
+    transform: scaleX(var(--scale)) translate(var(--translation), 0) rotate(var(--rotation));
 
     @include transition(transform $menu-transition-duration ease, width $menu-transition-duration ease, height $menu-transition-duration ease);
 
     &--open {
-        transform-origin: 50% 50%;
-        transform: rotate(180deg);
+        --rotation: 180deg;
     }
 
     .sidebar--slim & {
         width: 16px;
         height: 16px;
-        transform: translate3d(13px, 0, 0);
+        --translation: 13px;
+    }
+
+    [dir='rtl'] & {
+        --scale: -1;
+        right: unset;
+        left: 15px;
     }
 }
 

--- a/client/src/components/Sidebar/modules/MainMenu.scss
+++ b/client/src/components/Sidebar/modules/MainMenu.scss
@@ -119,6 +119,7 @@
         }
 
         em {
+            --offset: 60px;  // Width of avatar
             box-sizing: border-box;
             padding-right: 1.8em;
             margin-top: 1.2em;
@@ -130,16 +131,13 @@
             white-space: nowrap;
             text-overflow: ellipsis;
             position: absolute;
-            left: 60px;  // Width of avatar
-            transition: left $menu-transition-duration ease;
-        }
-    }
+            left: var(--offset);
+            transition: left $menu-transition-duration ease, right $menu-transition-duration ease;
 
-    @at-root .sidebar--slim #{&} {
-        width: $menu-width-slim;
-
-        &__account em {
-            left: $menu-width-slim - $menu-width;
+            [dir='rtl'] & {
+                left: unset;
+                right: var(--offset);
+            }
         }
     }
 
@@ -151,7 +149,11 @@
         }
     }
 
-    &--open &__account em {
-        left: 60px !important;
+    .sidebar--slim & {
+        width: $menu-width-slim;
+
+        em {
+            --offset: #{$menu-width-slim - $menu-width};
+        }
     }
 }

--- a/client/src/components/Sidebar/modules/Search.scss
+++ b/client/src/components/Sidebar/modules/Search.scss
@@ -41,6 +41,8 @@
     }
 
     &__submit {
+        --svg-margin: 15px;
+
         position: absolute;
         right: 0;
         top: 0;
@@ -53,15 +55,25 @@
         transition: opacity $menu-transition-duration ease, width $menu-transition-duration ease;
 
         svg {
-            margin-right: 15px;
-            transition: margin-right $menu-transition-duration ease;
+            margin-right: var(--svg-margin);
+            transition: margin-right $menu-transition-duration ease, margin-left $menu-transition-duration ease;
         }
 
         .sidebar--slim & {
             width: 100%;
 
             svg {
-                margin-right: 0;
+                --svg-margin: 0;
+            }
+        }
+
+        [dir='rtl'] & {
+            right: unset;
+            left: 0;
+
+            svg {
+                margin-right: unset;
+                margin-left: var(--svg-margin);
             }
         }
 

--- a/wagtail/admin/wagtail_hooks.py
+++ b/wagtail/admin/wagtail_hooks.py
@@ -85,6 +85,7 @@ def register_settings_menu():
     return SettingsMenuItem(
         _('Settings'),
         settings_menu,
+        name='settings',
         icon_name='cogs',
         order=10000)
 
@@ -663,7 +664,7 @@ def register_site_history_report_menu_item():
 @hooks.register('register_admin_menu_item')
 def register_reports_menu():
     return ReportsMenuItem(
-        _('Reports'), reports_menu, icon_name='site', order=9000)
+        _('Reports'), reports_menu, name='reports', icon_name='site', order=9000)
 
 
 @hooks.register('register_icons')


### PR DESCRIPTION
This PR adds right to left support for the sidebar. Note that I've kept the page explorer LTR for now:

![image](https://user-images.githubusercontent.com/1093808/135621023-778a34db-e25c-4e36-ac39-33781bf5f366.png)
