### PR TITLE
Document how to limit a page parent to root

### DIFF
--- a/docs/reference/pages/model_reference.rst
+++ b/docs/reference/pages/model_reference.rst
@@ -256,6 +256,13 @@ In addition to the model fields provided, ``Page`` has many properties and metho
             class HiddenPage(Page):
                 parent_page_types = []
 
+        To allow for a page to be only created under the root page (e.g. for ``HomePage`` models) set the ``parent_page_type`` to ``['wagtailcore.Page']``.
+
+        .. code-block:: python
+
+            class HomePage(Page):
+                parent_page_types = ['wagtailcore.Page']
+
     .. automethod:: can_exist_under
 
     .. automethod:: can_create_at


### PR DESCRIPTION
Closes #2768

Issue #2768 was created because a way how to limit a page to be only
available under the root page was unknown.

The implementation has allowed this for a while now, but the issue was
not closed (presumably due to missing documentation).

The documentation of the `parent_page_types` filed now includes this
"special" case.

Thanks for contributing to Wagtail! 🎉

Before submitting, please review the contributor guidelines <https://docs.wagtail.io/en/latest/contributing/index.html> and check the following:

* Do the tests still pass? (https://docs.wagtail.io/en/latest/contributing/developing.html#testing)
* Does the code comply with the style guide? (Run `make lint` from the Wagtail root)
* For Python changes: Have you added tests to cover the new/fixed behaviour?
* For front-end changes: Did you test on all of [Wagtail’s supported environments](https://docs.wagtail.io/en/latest/contributing/developing.html#browser-and-device-support)?
    * **Please list the exact browser and operating system versions you tested**.
    * **Please list which assistive technologies you tested**.
* For new features: Has the documentation been updated accordingly?
