### PR TITLE
Admin URL finder mechanism

### DIFF
--- a/wagtail/admin/admin_url_finder.py
+++ b/wagtail/admin/admin_url_finder.py
@@ -1,0 +1,107 @@
+from django.contrib.admin.utils import quote
+from django.core.exceptions import ImproperlyConfigured
+from django.urls import reverse
+
+from wagtail.core.hooks import search_for_hooks
+
+
+"""
+A mechanism for finding the admin edit URL for an arbitrary object instance, optionally applying
+permission checks.
+
+    url_finder = AdminURLFinder(request.user)
+    url_finder.get_edit_url(some_page)  # => "/admin/pages/123/edit/"
+    url_finder.get_edit_url(some_image)  # => "/admin/images/456/"
+    url_finder.get_edit_url(some_site)  # => None (user does not have edit permission for sites)
+
+If the user parameter is omitted, edit URLs are returned without considering permissions.
+
+Handlers for new models can be registered via register_admin_url_finder:
+
+    class SprocketAdminURLFinder(ModelAdminURLFinder):
+        edit_url_name = 'wagtailsprockets:edit'
+
+    register_admin_url_finder(Sprocket, SprocketAdminURLFinder)
+"""
+
+
+class ModelAdminURLFinder:
+    """
+    Handles admin edit URL lookups for an individual model
+    """
+    edit_url_name = None
+    permission_policy = None
+
+    def __init__(self, user=None):
+        self.user = user
+
+    def construct_edit_url(self, instance):
+        """
+        Return the edit URL for the given instance - regardless of whether the user can access it -
+        or None if no edit URL is available.
+        """
+        if self.edit_url_name is None:
+            raise ImproperlyConfigured("%r must define edit_url_name or override construct_edit_url" % type(self))
+        return reverse(self.edit_url_name, args=(quote(instance.pk), ))
+
+    def get_edit_url(self, instance):
+        """
+        Return the edit URL for the given instance if one exists and the user has permission for it,
+        or None otherwise.
+        """
+        if (
+            self.user and self.permission_policy
+            and not self.permission_policy.user_has_permission_for_instance(self.user, 'change', instance)
+        ):
+            return None
+        else:
+            return self.construct_edit_url(instance)
+
+
+class NullAdminURLFinder:
+    """
+    A dummy AdminURLFinder that always returns None
+    """
+    def __init__(self, user=None):
+        pass
+
+    def get_edit_url(self, instance):
+        return None
+
+
+FINDER_CLASSES_BY_MODEL = {}
+
+
+def register_admin_url_finder(model, handler):
+    global FINDER_CLASSES_BY_MODEL
+    FINDER_CLASSES_BY_MODEL[model] = handler
+
+
+class AdminURLFinder:
+    """
+    The 'main' admin URL finder, which searches across all registered models
+    """
+    def __init__(self, user=None):
+        search_for_hooks()  # ensure wagtail_hooks files have been loaded
+        self.user = user
+        self.finders_by_model = {}
+
+    def get_edit_url(self, instance):
+        model = type(instance)
+        try:
+            # do we already have a finder for this model and user?
+            finder = self.finders_by_model[model]
+        except KeyError:
+            finder_class = NullAdminURLFinder
+            # check all superclasses of model for a registered finder class
+            for cls in model.__mro__:
+                try:
+                    finder_class = FINDER_CLASSES_BY_MODEL[cls]
+                    break
+                except KeyError:
+                    continue
+
+            finder = finder_class(self.user)
+            self.finders_by_model[model] = finder
+
+        return finder.get_edit_url(instance)

--- a/wagtail/admin/tests/pages/test_edit_page.py
+++ b/wagtail/admin/tests/pages/test_edit_page.py
@@ -13,6 +13,7 @@ from django.urls import reverse
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
+from wagtail.admin.admin_url_finder import AdminURLFinder
 from wagtail.admin.tests.pages.timestamps import submittable_timestamp
 from wagtail.core.exceptions import PageClassNotFoundError
 from wagtail.core.models import (
@@ -107,6 +108,11 @@ class TestPageEdit(TestCase, WagtailTestUtils):
         self.assertContains(
             response, '<button type="submit" name="action-submit" value="Submit to Moderators approval" class="button">'
         )
+
+        # test that AdminURLFinder returns the edit view for the page
+        url_finder = AdminURLFinder(self.user)
+        expected_url = '/admin/pages/%d/edit/' % self.event_page.id
+        self.assertEqual(url_finder.get_edit_url(self.event_page), expected_url)
 
     @override_settings(WAGTAIL_WORKFLOW_ENABLED=False)
     def test_workflow_buttons_not_shown_when_workflow_disabled(self):
@@ -208,6 +214,9 @@ class TestPageEdit(TestCase, WagtailTestUtils):
 
         # Check that the user received a 302 redirected response
         self.assertEqual(response.status_code, 302)
+
+        url_finder = AdminURLFinder(self.user)
+        self.assertEqual(url_finder.get_edit_url(self.event_page), None)
 
     def test_page_edit_post(self):
         # Tests simple editing

--- a/wagtail/admin/tests/test_collections_views.py
+++ b/wagtail/admin/tests/test_collections_views.py
@@ -1,6 +1,7 @@
 from django.test import TestCase
 from django.urls import reverse
 
+from wagtail.admin.admin_url_finder import AdminURLFinder
 from wagtail.core.models import Collection
 from wagtail.documents.models import Document
 from wagtail.tests.utils import WagtailTestUtils
@@ -97,7 +98,7 @@ class TestAddCollection(TestCase, WagtailTestUtils):
 
 class TestEditCollection(TestCase, WagtailTestUtils):
     def setUp(self):
-        self.login()
+        self.user = self.login()
         self.root_collection = Collection.get_first_root_node()
         self.collection = self.root_collection.add_child(name="Holiday snaps")
         self.l1 = self.root_collection.add_child(name="Level 1")
@@ -123,6 +124,11 @@ class TestEditCollection(TestCase, WagtailTestUtils):
     def test_cannot_edit_root_collection(self):
         response = self.get(collection_id=self.root_collection.id)
         self.assertEqual(response.status_code, 404)
+
+    def test_admin_url_finder(self):
+        expected_url = '/admin/collections/%d/' % self.l2.pk
+        url_finder = AdminURLFinder(self.user)
+        self.assertEqual(url_finder.get_edit_url(self.l2), expected_url)
 
     def test_get_nonexistent_collection(self):
         response = self.get(collection_id=100000)

--- a/wagtail/admin/tests/test_workflows.py
+++ b/wagtail/admin/tests/test_workflows.py
@@ -11,6 +11,7 @@ from django.test import TestCase, override_settings
 from django.urls import reverse
 from freezegun import freeze_time
 
+from wagtail.admin.admin_url_finder import AdminURLFinder
 from wagtail.core.models import (
     GroupApprovalTask, Page, Task, TaskState, Workflow, WorkflowPage, WorkflowState, WorkflowTask)
 from wagtail.core.signals import page_published
@@ -353,6 +354,13 @@ class TestWorkflowsEditView(TestCase, WagtailTestUtils):
         response = self.get()
         self.assertEqual(response.status_code, 200)
 
+    def test_admin_url_finder(self):
+        editor_url_finder = AdminURLFinder(self.editor)
+        self.assertEqual(editor_url_finder.get_edit_url(self.workflow), None)
+        moderator_url_finder = AdminURLFinder(self.moderator)
+        expected_url = '/admin/workflows/edit/%d/' % self.workflow.pk
+        self.assertEqual(moderator_url_finder.get_edit_url(self.workflow), expected_url)
+
     def test_duplicate_page_check(self):
         response = self.post({
             'name': [str(self.workflow.name)],
@@ -688,6 +696,13 @@ class TestEditTaskView(TestCase, WagtailTestUtils):
         self.login(user=self.moderator)
         response = self.get()
         self.assertEqual(response.status_code, 200)
+
+    def test_admin_url_finder(self):
+        editor_url_finder = AdminURLFinder(self.editor)
+        self.assertEqual(editor_url_finder.get_edit_url(self.task), None)
+        moderator_url_finder = AdminURLFinder(self.moderator)
+        expected_url = '/admin/workflows/tasks/edit/%d/' % self.task.pk
+        self.assertEqual(moderator_url_finder.get_edit_url(self.task), expected_url)
 
 
 class TestSubmitToWorkflow(TestCase, WagtailTestUtils):

--- a/wagtail/admin/viewsets/__init__.py
+++ b/wagtail/admin/viewsets/__init__.py
@@ -12,9 +12,10 @@ class ViewSetRegistry:
             viewset = fn()
             self.register(viewset)
 
-    def register(self, viewset_cls):
-        self.viewsets.append(viewset_cls)
-        return viewset_cls
+    def register(self, viewset):
+        self.viewsets.append(viewset)
+        viewset.on_register()
+        return viewset
 
     def get_urlpatterns(self):
         urlpatterns = []

--- a/wagtail/admin/viewsets/base.py
+++ b/wagtail/admin/viewsets/base.py
@@ -7,6 +7,9 @@ class ViewSet:
         for key, value in kwargs.items():
             setattr(self, key, value)
 
+    def on_register(self):
+        pass
+
     def get_urlpatterns(self):
         return []
 

--- a/wagtail/admin/viewsets/model.py
+++ b/wagtail/admin/viewsets/model.py
@@ -2,6 +2,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.forms.models import modelform_factory
 from django.urls import path
 
+from wagtail.admin.admin_url_finder import ModelAdminURLFinder, register_admin_url_finder
 from wagtail.admin.views import generic
 from wagtail.core.permissions import ModelPermissionPolicy
 
@@ -92,3 +93,11 @@ class ModelViewSet(ViewSet):
             path('<int:pk>/', self.edit_view, name='edit'),
             path('<int:pk>/delete/', self.delete_view, name='delete'),
         ]
+
+    def on_register(self):
+        super().on_register()
+        url_finder_class = type('_ModelAdminURLFinder', (ModelAdminURLFinder, ), {
+            'permission_policy': self.permission_policy,
+            'edit_url_name': self.get_url_name('edit')
+        })
+        register_admin_url_finder(self.model, url_finder_class)

--- a/wagtail/contrib/modeladmin/helpers/__init__.py
+++ b/wagtail/contrib/modeladmin/helpers/__init__.py
@@ -1,4 +1,4 @@
 from .button import ButtonHelper, PageButtonHelper  # NOQA
 from .permission import PagePermissionHelper, PermissionHelper  # NOQA
 from .search import DjangoORMSearchHandler, WagtailBackendSearchHandler  # NOQA
-from .url import AdminURLHelper, PageAdminURLHelper  # NOQA
+from .url import AdminURLHelper, ModelAdminURLFinder, PageAdminURLHelper  # NOQA

--- a/wagtail/contrib/modeladmin/helpers/url.py
+++ b/wagtail/contrib/modeladmin/helpers/url.py
@@ -1,3 +1,4 @@
+from django.contrib.admin.utils import quote
 from django.urls import reverse
 from django.utils.functional import cached_property
 from django.utils.http import urlquote
@@ -41,6 +42,17 @@ class AdminURLHelper:
     @cached_property
     def create_url(self):
         return self.get_action_url('create')
+
+
+# for registering with wagtail.admin.admin_url_finder.
+# Subclasses should define url_helper and permission_helper
+class ModelAdminURLFinder:
+    def __init__(self, user):
+        self.user = user
+
+    def get_edit_url(self, instance):
+        if self.permission_helper.user_can_edit_obj(self.user, instance):
+            return self.url_helper.get_action_url('edit', quote(instance.pk))
 
 
 class PageAdminURLHelper(AdminURLHelper):

--- a/wagtail/contrib/redirects/tests/test_redirects.py
+++ b/wagtail/contrib/redirects/tests/test_redirects.py
@@ -2,6 +2,7 @@
 from django.test import TestCase, override_settings
 from django.urls import reverse
 
+from wagtail.admin.admin_url_finder import AdminURLFinder
 from wagtail.contrib.redirects import models
 from wagtail.core.models import Page, Site
 from wagtail.tests.utils import WagtailTestUtils
@@ -518,7 +519,7 @@ class TestRedirectsEditView(TestCase, WagtailTestUtils):
         self.redirect.save()
 
         # Login
-        self.login()
+        self.user = self.login()
 
     def get(self, params={}, redirect_id=None):
         return self.client.get(reverse('wagtailredirects:edit', args=(redirect_id or self.redirect.id, )), params)
@@ -530,6 +531,10 @@ class TestRedirectsEditView(TestCase, WagtailTestUtils):
         response = self.get()
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, 'wagtailredirects/edit.html')
+
+        url_finder = AdminURLFinder(self.user)
+        expected_url = '/admin/redirects/%d/' % self.redirect.id
+        self.assertEqual(url_finder.get_edit_url(self.redirect), expected_url)
 
     def test_nonexistant_redirect(self):
         self.assertEqual(self.get(redirect_id=100000).status_code, 404)

--- a/wagtail/contrib/redirects/wagtail_hooks.py
+++ b/wagtail/contrib/redirects/wagtail_hooks.py
@@ -2,10 +2,13 @@ from django.contrib.auth.models import Permission
 from django.urls import include, path, reverse
 from django.utils.translation import gettext_lazy as _
 
+from wagtail.admin.admin_url_finder import ModelAdminURLFinder, register_admin_url_finder
 from wagtail.admin.menu import MenuItem
 from wagtail.contrib.redirects import urls
 from wagtail.contrib.redirects.permissions import permission_policy
 from wagtail.core import hooks
+
+from .models import Redirect
 
 
 @hooks.register('register_admin_urls')
@@ -33,3 +36,11 @@ def register_redirects_menu_item():
 def register_permissions():
     return Permission.objects.filter(content_type__app_label='wagtailredirects',
                                      codename__in=['add_redirect', 'change_redirect', 'delete_redirect'])
+
+
+class RedirectAdminURLFinder(ModelAdminURLFinder):
+    edit_url_name = 'wagtailredirects:edit'
+    permission_policy = permission_policy
+
+
+register_admin_url_finder(Redirect, RedirectAdminURLFinder)

--- a/wagtail/contrib/search_promotions/tests.py
+++ b/wagtail/contrib/search_promotions/tests.py
@@ -1,6 +1,7 @@
 from django.test import TestCase
 from django.urls import reverse
 
+from wagtail.admin.admin_url_finder import AdminURLFinder
 from wagtail.contrib.search_promotions.models import SearchPromotion
 from wagtail.contrib.search_promotions.templatetags.wagtailsearchpromotions_tags import (
     get_search_promotions)
@@ -268,7 +269,7 @@ class TestSearchPromotionsAddView(TestCase, WagtailTestUtils):
 
 class TestSearchPromotionsEditView(TestCase, WagtailTestUtils):
     def setUp(self):
-        self.login()
+        self.user = self.login()
 
         # Create an search pick to edit
         self.query = Query.get("Hello")
@@ -279,6 +280,10 @@ class TestSearchPromotionsEditView(TestCase, WagtailTestUtils):
         response = self.client.get(reverse('wagtailsearchpromotions:edit', args=(self.query.id, )))
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, 'wagtailsearchpromotions/edit.html')
+
+        url_finder = AdminURLFinder(self.user)
+        expected_url = '/admin/searchpicks/%d/' % self.query.id
+        self.assertEqual(url_finder.get_edit_url(self.search_pick), expected_url)
 
     def test_post(self):
         # Submit

--- a/wagtail/contrib/search_promotions/wagtail_hooks.py
+++ b/wagtail/contrib/search_promotions/wagtail_hooks.py
@@ -2,9 +2,13 @@ from django.contrib.auth.models import Permission
 from django.urls import include, path, reverse
 from django.utils.translation import gettext_lazy as _
 
+from wagtail.admin.admin_url_finder import ModelAdminURLFinder, register_admin_url_finder
 from wagtail.admin.menu import MenuItem
 from wagtail.contrib.search_promotions import admin_urls
 from wagtail.core import hooks
+from wagtail.core.permission_policies import ModelPermissionPolicy
+
+from .models import SearchPromotion
 
 
 @hooks.register('register_admin_urls')
@@ -38,3 +42,13 @@ def register_permissions():
         content_type__app_label='wagtailsearchpromotions',
         codename__in=['add_searchpromotion', 'change_searchpromotion', 'delete_searchpromotion']
     )
+
+
+class SearchPromotionAdminURLFinder(ModelAdminURLFinder):
+    permission_policy = ModelPermissionPolicy(SearchPromotion)
+
+    def construct_edit_url(self, instance):
+        return reverse('wagtailsearchpromotions:edit', args=(instance.query.id, ))
+
+
+register_admin_url_finder(SearchPromotion, SearchPromotionAdminURLFinder)

--- a/wagtail/contrib/settings/tests/test_admin.py
+++ b/wagtail/contrib/settings/tests/test_admin.py
@@ -3,6 +3,7 @@ from django.test import TestCase, override_settings
 from django.urls import reverse
 from django.utils.text import capfirst
 
+from wagtail.admin.admin_url_finder import AdminURLFinder
 from wagtail.admin.edit_handlers import FieldPanel, ObjectList, TabbedInterface
 from wagtail.contrib.settings.registry import SettingMenuItem
 from wagtail.contrib.settings.views import get_setting_edit_handler
@@ -65,7 +66,7 @@ class BaseTestSettingView(TestCase, WagtailTestUtils):
 
 class TestSettingCreateView(BaseTestSettingView):
     def setUp(self):
-        self.login()
+        self.user = self.login()
 
     def test_get_edit(self):
         response = self.get()
@@ -89,6 +90,10 @@ class TestSettingCreateView(BaseTestSettingView):
         setting = TestSetting.objects.get(site=default_site)
         self.assertEqual(setting.title, 'Edited site title')
         self.assertEqual(setting.email, 'test@example.com')
+
+        url_finder = AdminURLFinder(self.user)
+        expected_url = '/admin/settings/tests/testsetting/%d/' % default_site.pk
+        self.assertEqual(url_finder.get_edit_url(setting), expected_url)
 
     def test_file_upload_multipart(self):
         response = self.get(setting=FileUploadSetting)

--- a/wagtail/documents/tests/test_admin_views.py
+++ b/wagtail/documents/tests/test_admin_views.py
@@ -8,6 +8,7 @@ from django.test import TestCase
 from django.test.utils import override_settings
 from django.urls import reverse
 
+from wagtail.admin.admin_url_finder import AdminURLFinder
 from wagtail.core.models import Collection, GroupCollectionPermission, Page
 from wagtail.documents import get_document_model, models
 from wagtail.documents.tests.utils import get_test_document_file
@@ -334,6 +335,9 @@ class TestDocumentEditView(TestCase, WagtailTestUtils):
         response = self.client.get(reverse('wagtaildocs:edit', args=(self.document.id, )))
         self.assertEqual(response.status_code, 302)
 
+        url_finder = AdminURLFinder(self.user)
+        self.assertEqual(url_finder.get_edit_url(self.document), None)
+
     def test_post_with_limited_permissions(self):
         self.user.is_superuser = False
         self.user.user_permissions.add(
@@ -362,6 +366,10 @@ class TestDocumentEditView(TestCase, WagtailTestUtils):
         # (see TestDocumentEditViewWithCustomDocumentModel - this confirms that form media
         # definitions are being respected)
         self.assertNotContains(response, 'wagtailadmin/js/draftail.js')
+
+        url_finder = AdminURLFinder(self.user)
+        expected_url = '/admin/documents/edit/%d/' % self.document.id
+        self.assertEqual(url_finder.get_edit_url(self.document), expected_url)
 
     def test_simple_with_collection_nesting(self):
         root_collection = Collection.get_first_root_node()

--- a/wagtail/documents/wagtail_hooks.py
+++ b/wagtail/documents/wagtail_hooks.py
@@ -8,6 +8,7 @@ from django.utils.translation import ngettext
 
 import wagtail.admin.rich_text.editors.draftail.features as draftail_features
 
+from wagtail.admin.admin_url_finder import ModelAdminURLFinder, register_admin_url_finder
 from wagtail.admin.menu import MenuItem
 from wagtail.admin.navigation import get_site_for_user
 from wagtail.admin.rich_text import HalloPlugin
@@ -186,3 +187,11 @@ def check_view_restrictions(document, request):
 
             elif restriction.restriction_type in [BaseViewRestriction.LOGIN, BaseViewRestriction.GROUPS]:
                 return require_wagtail_login(next=request.get_full_path())
+
+
+class DocumentAdminURLFinder(ModelAdminURLFinder):
+    edit_url_name = 'wagtaildocs:edit'
+    permission_policy = permission_policy
+
+
+register_admin_url_finder(get_document_model(), DocumentAdminURLFinder)

--- a/wagtail/images/tests/test_admin_views.py
+++ b/wagtail/images/tests/test_admin_views.py
@@ -11,6 +11,7 @@ from django.utils.html import escapejs
 from django.utils.http import RFC3986_SUBDELIMS, urlquote
 from django.utils.safestring import mark_safe
 
+from wagtail.admin.admin_url_finder import AdminURLFinder
 from wagtail.core.models import Collection, GroupCollectionPermission, get_root_collection_id
 from wagtail.images.models import UploadedImage
 from wagtail.images.utils import generate_signature
@@ -524,6 +525,10 @@ class TestImageEditView(TestCase, WagtailTestUtils):
         self.update_from_db()
         self.assertEqual(self.image.title, "Edited")
 
+        url_finder = AdminURLFinder(self.user)
+        expected_url = '/admin/images/%d/' % self.image.id
+        self.assertEqual(url_finder.get_edit_url(self.image), expected_url)
+
     def test_edit_with_limited_permissions(self):
         self.user.is_superuser = False
         self.user.user_permissions.add(
@@ -535,6 +540,9 @@ class TestImageEditView(TestCase, WagtailTestUtils):
             'title': "Edited",
         })
         self.assertEqual(response.status_code, 302)
+
+        url_finder = AdminURLFinder(self.user)
+        self.assertEqual(url_finder.get_edit_url(self.image), None)
 
     def test_edit_with_new_image_file(self):
         file_content = get_test_image_file().file.getvalue()

--- a/wagtail/images/wagtail_hooks.py
+++ b/wagtail/images/wagtail_hooks.py
@@ -6,6 +6,7 @@ from django.utils.translation import ngettext
 
 import wagtail.admin.rich_text.editors.draftail.features as draftail_features
 
+from wagtail.admin.admin_url_finder import ModelAdminURLFinder, register_admin_url_finder
 from wagtail.admin.menu import MenuItem
 from wagtail.admin.navigation import get_site_for_user
 from wagtail.admin.rich_text import HalloPlugin
@@ -182,3 +183,11 @@ def describe_collection_docs(collection):
             ) % {'count': images_count},
             'url': url,
         }
+
+
+class ImageAdminURLFinder(ModelAdminURLFinder):
+    edit_url_name = 'wagtailimages:edit'
+    permission_policy = permission_policy
+
+
+register_admin_url_finder(get_image_model(), ImageAdminURLFinder)

--- a/wagtail/locales/tests.py
+++ b/wagtail/locales/tests.py
@@ -2,6 +2,7 @@ from django.contrib.messages import get_messages
 from django.test import TestCase, override_settings
 from django.urls import reverse
 
+from wagtail.admin.admin_url_finder import AdminURLFinder
 from wagtail.core.models import Locale, Page
 from wagtail.tests.utils import WagtailTestUtils
 
@@ -76,7 +77,7 @@ class TestLocaleCreateView(TestCase, WagtailTestUtils):
 
 class TestLocaleEditView(TestCase, WagtailTestUtils):
     def setUp(self):
-        self.login()
+        self.user = self.login()
         self.english = Locale.objects.get()
 
     def get(self, params=None, locale=None):
@@ -98,6 +99,10 @@ class TestLocaleEditView(TestCase, WagtailTestUtils):
             ('en', 'English'),  # Note: Current value is displayed even though it's in use
             ('fr', 'French')
         ])
+
+        url_finder = AdminURLFinder(self.user)
+        expected_url = '/admin/locales/%d/' % self.english.id
+        self.assertEqual(url_finder.get_edit_url(self.english), expected_url)
 
     def test_invalid_language(self):
         invalid = Locale.objects.create(language_code='foo')

--- a/wagtail/sites/tests.py
+++ b/wagtail/sites/tests.py
@@ -2,6 +2,7 @@ from django.contrib.auth.models import Permission
 from django.test import TestCase
 from django.urls import reverse
 
+from wagtail.admin.admin_url_finder import AdminURLFinder
 from wagtail.core.models import Page, Site
 from wagtail.tests.utils import WagtailTestUtils
 
@@ -120,7 +121,7 @@ class TestSiteCreateView(TestCase, WagtailTestUtils):
 
 class TestSiteEditView(TestCase, WagtailTestUtils):
     def setUp(self):
-        self.login()
+        self.user = self.login()
         self.home_page = Page.objects.get(id=2)
         self.localhost = Site.objects.all()[0]
 
@@ -148,6 +149,10 @@ class TestSiteEditView(TestCase, WagtailTestUtils):
         response = self.get()
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, 'wagtailsites/edit.html')
+
+        url_finder = AdminURLFinder(self.user)
+        expected_url = '/admin/sites/%d/' % self.localhost.id
+        self.assertEqual(url_finder.get_edit_url(self.localhost), expected_url)
 
     def test_nonexistant_redirect(self):
         self.assertEqual(self.get(site_id=100000).status_code, 404)

--- a/wagtail/snippets/models.py
+++ b/wagtail/snippets/models.py
@@ -2,6 +2,7 @@ from django.contrib.admin.utils import quote
 from django.core import checks
 from django.urls import reverse
 
+from wagtail.admin.admin_url_finder import register_admin_url_finder
 from wagtail.admin.checks import check_panels_in_model
 from wagtail.admin.models import get_object_usage
 
@@ -13,12 +14,32 @@ def get_snippet_models():
     return SNIPPET_MODELS
 
 
+class SnippetAdminURLFinder:
+    # subclasses should define a 'model' attribute
+    def __init__(self, user=None):
+        if user:
+            from wagtail.snippets.permissions import get_permission_name
+            self.user_can_edit = user.has_perm(get_permission_name('change', self.model))
+        else:
+            # skip permission checks
+            self.user_can_edit = True
+
+    def get_edit_url(self, instance):
+        if self.user_can_edit:
+            return reverse('wagtailsnippets:edit', args=(
+                self.model._meta.app_label, self.model._meta.model_name, quote(instance.pk)
+            ))
+
+
 def register_snippet(model):
     if model not in SNIPPET_MODELS:
         model.get_usage = get_object_usage
         model.usage_url = get_snippet_usage_url
         SNIPPET_MODELS.append(model)
         SNIPPET_MODELS.sort(key=lambda x: x._meta.verbose_name)
+
+        url_finder_class = type('_SnippetAdminURLFinder', (SnippetAdminURLFinder, ), {'model': model})
+        register_admin_url_finder(model, url_finder_class)
 
         @checks.register('panels')
         def modeladmin_model_check(app_configs, **kwargs):

--- a/wagtail/snippets/tests.py
+++ b/wagtail/snippets/tests.py
@@ -14,6 +14,7 @@ from django.test.utils import override_settings
 from django.urls import reverse
 from taggit.models import Tag
 
+from wagtail.admin.admin_url_finder import AdminURLFinder
 from wagtail.admin.edit_handlers import FieldPanel
 from wagtail.admin.forms import WagtailAdminModelForm
 from wagtail.core import hooks
@@ -546,6 +547,10 @@ class TestSnippetEditView(BaseTestSnippetEditView):
         self.assertNotContains(response, '<a href="#advert" class="active" data-tab="advert">Advert</a>', html=True)
         self.assertNotContains(response, '<a href="#other" class="" data-tab="other">Other</a>', html=True)
 
+        url_finder = AdminURLFinder(self.user)
+        expected_url = '/admin/snippets/tests/advert/edit/%d/' % self.test_snippet.pk
+        self.assertEqual(url_finder.get_edit_url(self.test_snippet), expected_url)
+
     def test_non_existant_model(self):
         response = self.client.get(reverse('wagtailsnippets:edit', args=('tests', 'foo', quote(self.test_snippet.pk))))
         self.assertEqual(response.status_code, 404)
@@ -564,6 +569,9 @@ class TestSnippetEditView(BaseTestSnippetEditView):
         response = self.post(post_data={'text': 'test text',
                                         'url': 'http://www.example.com/'})
         self.assertEqual(response.status_code, 302)
+
+        url_finder = AdminURLFinder(self.user)
+        self.assertEqual(url_finder.get_edit_url(self.test_snippet), None)
 
     def test_edit_invalid(self):
         response = self.post(post_data={'foo': 'bar'})

--- a/wagtail/users/tests.py
+++ b/wagtail/users/tests.py
@@ -11,6 +11,7 @@ from django.http import HttpRequest, HttpResponse
 from django.test import TestCase, override_settings
 from django.urls import reverse
 
+from wagtail.admin.admin_url_finder import AdminURLFinder
 from wagtail.core import hooks
 from wagtail.core.compat import AUTH_USER_APP_LABEL, AUTH_USER_MODEL_NAME
 from wagtail.core.models import Collection, GroupCollectionPermission, GroupPagePermission, Page
@@ -1263,7 +1264,7 @@ class TestGroupEditView(TestCase, WagtailTestUtils):
         )
 
         # Login
-        self.login()
+        self.user = self.login()
 
     def get(self, params={}, group_id=None):
         return self.client.get(reverse('wagtailusers_groups:edit', args=(group_id or self.test_group.pk, )), params)
@@ -1305,6 +1306,10 @@ class TestGroupEditView(TestCase, WagtailTestUtils):
         response = self.get()
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, 'wagtailusers/groups/edit.html')
+
+        url_finder = AdminURLFinder(self.user)
+        expected_url = '/admin/groups/%d/' % self.test_group.id
+        self.assertEqual(url_finder.get_edit_url(self.test_group), expected_url)
 
     def test_nonexistant_group_redirect(self):
         self.assertEqual(self.get(group_id=100000).status_code, 404)

--- a/wagtail/users/tests.py
+++ b/wagtail/users/tests.py
@@ -659,6 +659,10 @@ class TestUserEditView(TestCase, WagtailTestUtils):
         self.assertContains(response, 'Password:')
         self.assertContains(response, 'Password confirmation:')
 
+        url_finder = AdminURLFinder(self.current_user)
+        expected_url = '/admin/users/%s/' % self.test_user.pk
+        self.assertEqual(url_finder.get_edit_url(self.test_user), expected_url)
+
     def test_nonexistant_redirect(self):
         invalid_id = '99999999-9999-9999-9999-999999999999' if settings.AUTH_USER_MODEL == 'emailuser.EmailUser' else 100000
         self.assertEqual(self.get(user_id=invalid_id).status_code, 404)

--- a/wagtail/users/wagtail_hooks.py
+++ b/wagtail/users/wagtail_hooks.py
@@ -1,4 +1,5 @@
 from django.apps import apps
+from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Permission
 from django.core.exceptions import ImproperlyConfigured
 from django.db.models import Q
@@ -6,10 +7,12 @@ from django.urls import include, path, reverse
 from django.utils.module_loading import import_string
 from django.utils.translation import gettext_lazy as _
 
+from wagtail.admin.admin_url_finder import ModelAdminURLFinder, register_admin_url_finder
 from wagtail.admin.menu import MenuItem
 from wagtail.admin.search import SearchArea
 from wagtail.core import hooks
 from wagtail.core.compat import AUTH_USER_APP_LABEL, AUTH_USER_MODEL_NAME
+from wagtail.core.permission_policies import ModelPermissionPolicy
 from wagtail.users.urls import users
 from wagtail.users.utils import user_can_delete_user
 from wagtail.users.widgets import UserListingButton
@@ -123,3 +126,14 @@ def user_listing_buttons(context, user):
     yield UserListingButton(_('Edit'), reverse('wagtailusers_users:edit', args=[user.pk]), attrs={'title': _('Edit this user')}, priority=10)
     if user_can_delete_user(context.request.user, user):
         yield UserListingButton(_('Delete'), reverse('wagtailusers_users:delete', args=[user.pk]), classes={'no'}, attrs={'title': _('Delete this user')}, priority=20)
+
+
+User = get_user_model()
+
+
+class UserAdminURLFinder(ModelAdminURLFinder):
+    edit_url_name = 'wagtailusers_users:edit'
+    permission_policy = ModelPermissionPolicy(User)
+
+
+register_admin_url_finder(User, UserAdminURLFinder)


### PR DESCRIPTION
A mechanism for obtaining the admin edit URL for an arbitrary model instance, optionally applying permission checks. 

    url_finder = AdminURLFinder(request.user)
    url_finder.get_edit_url(some_page)  # => "/admin/pages/123/edit/"
    url_finder.get_edit_url(some_image)  # => "/admin/images/456/"
    url_finder.get_edit_url(some_site)  # => None (user does not have edit permission for sites)

Handlers for new models can be registered via register_admin_url_finder:

    class SprocketAdminURLFinder(ModelAdminURLFinder):
        edit_url_name = 'wagtailsprockets:edit'

    register_admin_url_finder(Sprocket, SprocketAdminURLFinder)

I haven't added any documentation yet, as nothing is making use of AdminURLFinder yet (other than tests) - but the extended Site History report will make use of this, and it'll also be useful for things like "deleting this object will also delete the following..." prompts (#6129).