### PR TITLE
Fix userbar tabbing behaviour

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -43,6 +43,7 @@ Changelog
  * Fix: Disable Task confirmation now shows the correct value for quantity of tasks in progress (LB Johnston)
  * Fix: Page history now works correctly when it contains changes by a deleted user (Dan Braghis)
  * Fix: Add `gettext_lazy` to `ModelAdmin` built in view titles so that language settings are correctly used (Matt Westcott)
+ * Fix: Tabbing and keyboard interaction on the Wagtail userbar now aligns with ARIA best practices (Storm Heg)
 
 
 2.14.1 (12.08.2021)

--- a/docs/releases/2.15.rst
+++ b/docs/releases/2.15.rst
@@ -58,6 +58,7 @@ Bug fixes
  * Disable Task confirmation now shows the correct value for quantity of tasks in progress (LB Johnston)
  * Page history now works correctly when it contains changes by a deleted user (Dan Braghis)
  * Add ``gettext_lazy`` to ``ModelAdmin`` built in view titles so that language settings are correctly used (Matt Westcott)
+ * Tabbing and keyboard interaction on the Wagtail userbar now aligns with ARIA best practices (Storm Heg)
 
 Upgrade considerations
 ======================


### PR DESCRIPTION
Tabbing (navigation using Tab or Shift + Tab keys) will now close
the menu and move to the next focusable element on the page instead
of focusing on the next menu item.

The previous behaviour was a deviation from the ARIA menu practices:
https://w3c.github.io/aria-practices/#menu

Further changes/cleanup:

* Consume keyboard events like arrow down to prevent the browser from interpreting them. See: https://developer.mozilla.org/en-US/docs/Web/Accessibility/Keyboard-navigable_JavaScript_widgets#prevent_used_key_events_from_performing_browser_functions
* Refactor repeated setTimeout and `.focus()` calls into single
  `focusElement(el)` function. Let's keep it DRY!

Fixes #7290 