### PR TITLE
fix warning message for disabling workflow task view

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -38,6 +38,7 @@ Changelog
  * Fix: Set `default_auto_field` in `postgres_search` `AppConfig` (Nick Moreton)
  * Fix: Ensure admin tab JS events are handled on page load (Andrew Stone)
  * Fix: `EmailNotificationMixin` and `send_notification` should only send emails to active users (Bryan Williams)
+ * Fix: Disable Task confirmation now shows the correct value for quantity of tasks in progress (LB Johnston)
 
 
 2.14.1 (12.08.2021)

--- a/docs/releases/2.15.rst
+++ b/docs/releases/2.15.rst
@@ -53,6 +53,7 @@ Bug fixes
  * Set ``default_auto_field`` in ``postgres_search`` ``AppConfig`` (Nick Moreton)
  * Ensure admin tab JS events are handled on page load (Andrew Stone)
  * `EmailNotificationMixin` and `send_notification` should only send emails to active users (Bryan Williams)
+ * Disable Task confirmation now shows the correct value for quantity of tasks in progress (LB Johnston)
 
 Upgrade considerations
 ======================

--- a/wagtail/admin/views/workflows.py
+++ b/wagtail/admin/views/workflows.py
@@ -444,7 +444,7 @@ class DisableTask(DeleteView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        states_in_progress = TaskState.objects.filter(status=TaskState.STATUS_IN_PROGRESS).count()
+        states_in_progress = TaskState.objects.filter(status=TaskState.STATUS_IN_PROGRESS, task=self.get_object().pk).count()
         context['warning_message'] = ngettext(
             'This task is in progress on %(states_in_progress)d page. Disabling this task will cause it to be skipped in the moderation workflow.',
             'This task is in progress on %(states_in_progress)d pages. Disabling this task will cause it to be skipped in the moderation workflow.',


### PR DESCRIPTION
- show the states_in_progress number based on the current Task only, not all tasks
- fixes #7492
* Do the tests still pass? 👍 
* Does the code comply with the style guide? 👍 
* For Python changes: Have you added tests to cover the new/fixed behaviour? 👍 
