### PR TITLE
Update Circle CI base image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   backend:
     docker:
-      - image: circleci/python:3.7.3
+      - image: cimg/python:3.8.11
     steps:
       - checkout
       - restore_cache:
@@ -50,7 +50,7 @@ jobs:
 
   nightly-build:
     docker:
-      - image: circleci/python:3.7.3
+      - image: cimg/python:3.8.11
     steps:
       - checkout
       - run: cd ~ && wget https://nodejs.org/dist/v14.17.5/node-v14.17.5-linux-x64.tar.gz


### PR DESCRIPTION
CircleCI sent me an email:

```
You're currently using a legacy image that is not optimized for performance on CircleCI on the following project(s): 

['https://github.com/kaedroho/wagtail'] 

Today we want to introduce our newest Python image, now available for all your Python projects. 

CircleCI’s latest pre-built container images were designed from the ground up to help your team build more reliably. Our new images were built specifically for continuous integration projects and they are our most deterministic, performant, and efficient images yet.
```

This updates our CircleCI base image to the new one