### PR TITLE
Use gettext_lazy in modeladmin views where required

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -40,6 +40,7 @@ Changelog
  * Fix: `EmailNotificationMixin` and `send_notification` should only send emails to active users (Bryan Williams)
  * Fix: Disable Task confirmation now shows the correct value for quantity of tasks in progress (LB Johnston)
  * Fix: Page history now works correctly when it contains changes by a deleted user (Dan Braghis)
+ * Fix: Add `gettext_lazy` to `ModelAdmin` built in view titles so that language settings are correctly used (Matt Westcott)
 
 
 2.14.1 (12.08.2021)

--- a/docs/releases/2.15.rst
+++ b/docs/releases/2.15.rst
@@ -52,9 +52,10 @@ Bug fixes
  * Ensure comment notifications dropdown handles longer translations without overflowing content (Krzysztof Jeziorny)
  * Set ``default_auto_field`` in ``postgres_search`` ``AppConfig`` (Nick Moreton)
  * Ensure admin tab JS events are handled on page load (Andrew Stone)
- * `EmailNotificationMixin` and `send_notification` should only send emails to active users (Bryan Williams)
+ * ``EmailNotificationMixin`` and ``send_notification`` should only send emails to active users (Bryan Williams)
  * Disable Task confirmation now shows the correct value for quantity of tasks in progress (LB Johnston)
  * Page history now works correctly when it contains changes by a deleted user (Dan Braghis)
+ * Add ``gettext_lazy`` to ``ModelAdmin`` built in view titles so that language settings are correctly used (Matt Westcott)
 
 Upgrade considerations
 ======================

--- a/wagtail/contrib/modeladmin/views.py
+++ b/wagtail/contrib/modeladmin/views.py
@@ -24,6 +24,7 @@ from django.utils.http import urlencode
 from django.utils.safestring import mark_safe
 from django.utils.text import capfirst
 from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy
 from django.views.generic import TemplateView
 from django.views.generic.edit import FormView
 
@@ -647,7 +648,7 @@ class IndexView(SpreadsheetExportMixin, WMABaseView):
 
 
 class CreateView(ModelFormView):
-    page_title = _('New')
+    page_title = gettext_lazy('New')
 
     def check_action_permitted(self, user):
         return self.permission_helper.user_can_create(user)
@@ -682,7 +683,7 @@ class CreateView(ModelFormView):
 
 
 class EditView(ModelFormView, InstanceSpecificView):
-    page_title = _('Editing')
+    page_title = gettext_lazy('Editing')
 
     def check_action_permitted(self, user):
         return self.permission_helper.user_can_edit_obj(user, self.instance)
@@ -757,7 +758,7 @@ class ChooseParentView(WMABaseView):
 
 
 class DeleteView(InstanceSpecificView):
-    page_title = _('Delete')
+    page_title = gettext_lazy('Delete')
 
     def check_action_permitted(self, user):
         return self.permission_helper.user_can_delete_obj(user, self.instance)
@@ -822,7 +823,7 @@ class DeleteView(InstanceSpecificView):
 
 class InspectView(InstanceSpecificView):
 
-    page_title = _('Inspecting')
+    page_title = gettext_lazy('Inspecting')
 
     def check_action_permitted(self, user):
         return self.permission_helper.user_can_inspect_obj(user, self.instance)


### PR DESCRIPTION
Class-level strings were using gettext, which meant that they were not respecting user language settings.
