### PR TITLE
Explicitly use port 80 for squash.io

### DIFF
--- a/.squash.yml
+++ b/.squash.yml
@@ -7,7 +7,7 @@ deployments:
       - apt install -y nodejs
       - pip install setuptools pip --upgrade --force-reinstall
       - cd /code
-    post_build_steps:  
+    post_build_steps:
       - npm install --no-save --no-audit --progress=false
       - npm run dist
       - pip install /code
@@ -17,8 +17,9 @@ deployments:
       - cd /myproject/mysite
       - python manage.py migrate
       - echo "<br><h1>Wagtail test instance</h1><p>Log into <a href='/admin/'>/admin/</a> with 'admin' / 'changeme'.</p>" > home/templates/home/welcome_page.html
-      - echo "from django.contrib.auth import get_user_model; User = get_user_model(); User.objects.create_superuser('admin', 'admin@example.com', 'changeme')" | python manage.py shell    
+      - echo "from django.contrib.auth import get_user_model; User = get_user_model(); User.objects.create_superuser('admin', 'admin@example.com', 'changeme')" | python manage.py shell
     launch_steps:
       - cd /myproject/mysite
       - python manage.py runserver 0.0.0.0:80
+    port_forwarding: 80:80
     run_options: -v ~/code:/code


### PR DESCRIPTION
Hopefully prevents scenarios where Squash prompts for a port number and a
wrong port number is entered. This leads to the Squash deployment never finishing and eventually timing out.