### PR TITLE
Fix page history with delete user

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -39,6 +39,7 @@ Changelog
  * Fix: Ensure admin tab JS events are handled on page load (Andrew Stone)
  * Fix: `EmailNotificationMixin` and `send_notification` should only send emails to active users (Bryan Williams)
  * Fix: Disable Task confirmation now shows the correct value for quantity of tasks in progress (LB Johnston)
+ * Fix: Page history now works correctly when it contains changes by a deleted user (Dan Braghis)
 
 
 2.14.1 (12.08.2021)

--- a/docs/releases/2.15.rst
+++ b/docs/releases/2.15.rst
@@ -54,6 +54,7 @@ Bug fixes
  * Ensure admin tab JS events are handled on page load (Andrew Stone)
  * `EmailNotificationMixin` and `send_notification` should only send emails to active users (Bryan Williams)
  * Disable Task confirmation now shows the correct value for quantity of tasks in progress (LB Johnston)
+ * Page history now works correctly when it contains changes by a deleted user (Dan Braghis)
 
 Upgrade considerations
 ======================

--- a/wagtail/admin/tests/test_audit_log.py
+++ b/wagtail/admin/tests/test_audit_log.py
@@ -151,6 +151,24 @@ class TestAuditLogAdmin(TestCase, WagtailTestUtils):
         self.assertContains(response, 'About', 3)  # create, save draft, delete
         self.assertContains(response, 'Deleted', 2)
 
+    def test_history_with_deleted_user(self):
+        self._update_page(self.hello_page)
+
+        expected_deleted_string = f"user {self.editor.pk} (deleted)"
+        self.editor.delete()
+
+        self.login(user=self.administrator)
+
+        # check page history
+        response = self.client.get(
+            reverse('wagtailadmin_pages:history', kwargs={'page_id': self.hello_page.id})
+        )
+        self.assertContains(response, expected_deleted_string)
+
+        # check site history
+        response = self.client.get(reverse('wagtailadmin_reports:site_history'))
+        self.assertContains(response, expected_deleted_string)
+
     def test_edit_form_has_history_link(self):
         self.hello_page.save_revision()
         self.login(user=self.editor)

--- a/wagtail/core/models/audit_log.py
+++ b/wagtail/core/models/audit_log.py
@@ -135,11 +135,10 @@ class BaseLogEntry(models.Model):
         Defaults to 'system' when none is provided
         """
         if self.user_id:
-            try:
-                user = self.user
-            except self._meta.get_field('user').related_model.DoesNotExist:
-                # User has been deleted
-                return _('user %(id)d (deleted)') % {'id': self.user_id}
+            user = self.user
+            if user is None:
+                # User has been deleted. Using a string placeholder as the user id could be non-numeric
+                return _('user %(id)s (deleted)') % {'id': self.user_id}
 
             try:
                 full_name = user.get_full_name().strip()


### PR DESCRIPTION
From [Slack message in the #support channel](https://wagtailcms.slack.com/archives/C81FGJR2S/p1631891808385600):

> We're currently working on a site and have found that if a user has edited a page, and then the user is deleted, then we can no longer view the pages history. Rather we get the following exception 'NoneType' object has no attribute 'get_username' .

Upon checking it looks like `self._meta.get_field('user').related_model.DoesNotExist` doesn't get raised, so changed the approach and added tests for page and site history.

Of note is the change of the user id placeholder to a string one to accomodate for non-integer IDs