### PR TITLE
Correct typo and update sample code in docs

### DIFF
--- a/docs/extending/custom_tasks.rst
+++ b/docs/extending/custom_tasks.rst
@@ -244,14 +244,14 @@ As an example, we'll add email notifications for when our new task is started.
 
     # <project>/mail.py
 
-    from wagtail.admin.mail import EmailNotifier
+    from wagtail.admin.mail import EmailNotificationMixin, Notifier
     from wagtail.core.models import TaskState
 
     from .models import UserApprovalTaskState
 
 
-    class BaseUserApprovalTaskStateEmailNotifier(EmailNotifier):
-        """A base EmailNotifier to send updates for UserApprovalTask events"""
+    class BaseUserApprovalTaskStateEmailNotifier(EmailNotificationMixin, Notifier):
+        """A base notifier to send updates for UserApprovalTask events"""
 
         def __init__(self):
             # Allow UserApprovalTaskState and TaskState to send notifications
@@ -278,13 +278,9 @@ As an example, we'll add email notifications for when our new task is started.
 
             return recipients
 
-        def get_template_base_prefix(self, instance, **kwargs):
-            # Get the template base prefix for TaskState, so use the ``wagtailadmin/notifications/task_state_`` set of notification templates
-            return super().get_template_base_prefix(self, instance.task_state_ptr, **kwargs)
-
 
     class UserApprovalTaskStateSubmissionEmailNotifier(BaseUserApprovalTaskStateEmailNotifier):
-        """An EmailNotifier to send updates for UserApprovalTask submission events"""
+        """A notifier to send updates for UserApprovalTask submission events"""
 
         notification = 'submitted'
 

--- a/docs/reference/pages/model_reference.rst
+++ b/docs/reference/pages/model_reference.rst
@@ -826,7 +826,7 @@ Database fields
 
         The workflow state which started this task state.
 
-    .. attribute:: page revision
+    .. attribute:: page_revision
 
         (foreign key to ``PageRevision``)
 


### PR DESCRIPTION
This PR provides two commits that update the docs as follows:

1. [change `page revision` to `page_revision` on the `TaskState` model](https://docs.wagtail.io/en/stable/reference/pages/model_reference.html#id16).
2. Update sample code in the section [**Extending Wagtail -> Adding new Task types -> Adding notifications**](https://docs.wagtail.io/en/latest/extending/custom_tasks.html#adding-notifications)