### PR TITLE
Introduce LogFormatter class for formatting 

### DIFF
--- a/docs/reference/hooks.rst
+++ b/docs/reference/hooks.rst
@@ -1379,8 +1379,27 @@ Audit log
         def additional_log_actions(actions):
             actions.register_action('wagtail_package.echo', _('Echo'), _('Sent an echo'))
 
-            def callback_message(data):
-                return _('Hello %(audience)s') % {
-                    'audience': data['audience'],
-                }
-            actions.register_action('wagtail_package.with_callback', _('Callback'), callback_message)
+
+    Alternatively, for a log message that varies according to the log entry's data, create a subclass of ``wagtail.core.log_actions.LogFormatter`` that overrides the ``format_message`` method, and use ``register_action`` as a decorator on that class:
+
+    .. code-block:: python
+
+        from django.utils.translation import gettext_lazy as _
+
+        from wagtail.core import hooks
+        from wagtail.core.log_actions import LogFormatter
+
+        @hooks.register('register_log_actions')
+        def additional_log_actions(actions):
+            @actions.register_action('wagtail_package.greet_audience')
+            class GreetingActionFormatter(LogFormatter):
+                label = _('Greet audience')
+
+                def format_message(self, log_entry):
+                    return _('Hello %(audience)s') % {
+                        'audience': log_entry.data['audience'],
+                    }
+
+    .. versionchanged:: 2.15
+
+      The LogFormatter class was introduced. Previously, dynamic messages were achieved by passing a callable as the ``message`` argument to ``register_action``.

--- a/docs/releases/2.15.rst
+++ b/docs/releases/2.15.rst
@@ -89,3 +89,43 @@ User code that creates these objects should be updated to follow the component A
    * Any ``template`` attribute should be changed to ``template_name``;
    * Any ``get_context`` method should be renamed to ``get_context_data``;
    * The ``get_url``, ``is_shown``, ``get_context_data`` and ``render_html`` methods no longer accept a ``request`` parameter. The request object is available in the context dictionary as ``context['request']``.
+
+
+Passing callables as messages in ``register_log_actions`` is deprecated
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When defining new action types for :ref:`audit logging <audit_log>` with the :ref:`register_log_actions` hook, it was previously possible to pass a callable as the message. This is now deprecated - to define a message that depends on the log entry's data, you should now create a subclass of ``wagtail.core.log_actions.LogFormatter``. For example:
+
+.. code-block:: python
+
+    from django.utils.translation import gettext_lazy as _
+    from wagtail.core import hooks
+
+    @hooks.register('register_log_actions')
+    def additional_log_actions(actions):
+
+        def greeting_message(data):
+            return _('Hello %(audience)s') % {
+                'audience': data['audience'],
+            }
+        actions.register_action('wagtail_package.greet_audience', _('Greet audience'), greeting_message)
+
+should now be rewritten as:
+
+.. code-block:: python
+
+    from django.utils.translation import gettext_lazy as _
+    from wagtail.core import hooks
+    from wagtail.core.log_actions import LogFormatter
+
+    @hooks.register('register_log_actions')
+    def additional_log_actions(actions):
+
+        @actions.register_action('wagtail_package.greet_audience')
+        class GreetingActionFormatter(LogFormatter):
+            label = _('Greet audience')
+
+            def format_message(self, log_entry):
+                return _('Hello %(audience)s') % {
+                    'audience': log_entry.data['audience'],
+                }

--- a/wagtail/admin/templates/wagtailadmin/pages/history.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/history.html
@@ -29,13 +29,11 @@
                     <tr>
                         <td>
                             {% if entry.revision %}<span class="report__results--text">{% endif %}
-                            {{ entry.format_message }}
+                            {{ entry.message }}
                             {% if entry.revision %}</span>{% endif %}
-                            {% with entry.format_comment as comment %}
-                                {% if comment %}
-                                    <span class="report__results--comment">{% trans "Comment" %}: <em>{{ comment }}</em></span>
-                                {% endif %}
-                            {% endwith %}
+                            {% if entry.comment %}
+                                <span class="report__results--comment">{% trans "Comment" %}: <em>{{ entry.comment }}</em></span>
+                            {% endif %}
                             {% if entry.revision %}
                                 {% if entry.action == 'wagtail.publish' %}
                                     {% if entry.revision_id == page.live_revision_id %}<span class="status-tag primary">{% trans 'Live version' %}</span>{% endif %}

--- a/wagtail/admin/templates/wagtailadmin/reports/site_history.html
+++ b/wagtail/admin/templates/wagtailadmin/reports/site_history.html
@@ -36,7 +36,7 @@
                             {% endif %}
                         </td>
                         <td>
-                            {{ entry.format_message }}
+                            {{ entry.message }}
                         </td>
                         <td>
                             {% include "wagtailadmin/shared/user_avatar.html" with user=entry.user username=entry.user_display_name %}

--- a/wagtail/core/log_actions.py
+++ b/wagtail/core/log_actions.py
@@ -3,6 +3,31 @@ from django.utils.translation import gettext_lazy as _
 from wagtail.core import hooks
 
 
+class LogFormatter:
+    """
+    Defines how to format log messages / comments for a particular action type. Messages that depend on
+    log entry data should override format_message / format_comment; static messages can just be set as the
+    'message' / 'comment' attribute.
+
+    To be registered with log_registry.register_action.
+    """
+    label = ''
+    message = ''
+    comment = ''
+
+    def format_message(self, log_entry):
+        if callable(self.message):
+            # For Wagtail <2.15, a callable passed as 'message' will be called with the log entry's 'data' property.
+            # (In 2.14 there was also a takes_log_entry attribute on the callable to specify passing the whole
+            # log entry object rather than just data, but this was undocumented)
+            return self.message(log_entry.data)
+        else:
+            return self.message
+
+    def format_comment(self, log_entry):
+        return self.comment
+
+
 class LogActionRegistry:
     """
     A central store for log actions.
@@ -14,17 +39,11 @@ class LogActionRegistry:
         # Has the hook been run for this registry?
         self.has_scanned_for_actions = False
 
-        # Holds the actions.
-        self.actions = {}
+        # Holds the formatter objects, keyed by action
+        self.formatters = {}
 
         # Holds a list of action, action label tuples for use in filters
         self.choices = []
-
-        # Holds the action messages, keyed by action
-        self.messages = {}
-
-        # Holds the comments, keyed by action
-        self.comments = {}
 
     def scan_for_actions(self):
         if not self.has_scanned_for_actions:
@@ -33,54 +52,52 @@ class LogActionRegistry:
 
             self.has_scanned_for_actions = True
 
-        return self.actions
+    def register_action(self, action, *args):
 
-    def get_actions(self):
-        return self.scan_for_actions()
+        def register_formatter_class(formatter_cls):
+            formatter = formatter_cls()
+            self.formatters[action] = formatter
+            self.choices.append((action, formatter.label))
 
-    def register_action(self, action, label, message, comment=None):
-        self.actions[action] = (label, message)
-        self.messages[action] = message
-        if comment:
-            self.comments[action] = comment
-        self.choices.append((action, label))
+        if args:
+            # register_action has been invoked as register_action(action, label, message); create a LogFormatter
+            # subclass and register that
+            label, message = args
+            formatter_cls = type('_LogFormatter', (LogFormatter, ), {'label': label, 'message': message})
+            register_formatter_class(formatter_cls)
+        else:
+            # register_action has been invoked as a @register_action(action) decorator; return the function that
+            # will register the class
+            return register_formatter_class
 
     def get_choices(self):
         self.scan_for_actions()
         return self.choices
 
-    def get_messages(self):
+    def get_formatter(self, log_entry):
         self.scan_for_actions()
-        return self.messages
-
-    def get_comments(self):
-        self.scan_for_actions()
-        return self.comments
+        return self.formatters.get(log_entry.action)
 
     def format_message(self, log_entry):
-        message = self.get_messages().get(log_entry.action, _('Unknown %(action)s') % {'action': log_entry.action})
-        if callable(message):
-            if getattr(message, 'takes_log_entry', False):
-                message = message(log_entry)
-            else:
-                # Pre Wagtail 2.14, we only passed the data into the message generator
-                message = message(log_entry.data)
-
-        return message
+        formatter = self.get_formatter(log_entry)
+        if formatter:
+            return formatter.format_message(log_entry)
+        else:
+            return _('Unknown %(action)s') % {'action': log_entry.action}
 
     def format_comment(self, log_entry):
-        message = self.get_comments().get(log_entry.action, '')
-        if callable(message):
-            if getattr(message, 'takes_log_entry', False):
-                message = message(log_entry)
-            else:
-                # Pre Wagtail 2.14, we only passed the data into the message generator
-                message = message(log_entry.data)
+        formatter = self.get_formatter(log_entry)
+        if formatter:
+            return formatter.format_comment(log_entry)
+        else:
+            return ''
 
-        return message
+    def action_exists(self, action):
+        self.scan_for_actions()
+        return action in self.formatters
 
     def get_action_label(self, action):
-        return self.get_actions()[action][0]
+        return self.formatters[action].label
 
 
 # For historical reasons, pages use the 'register_log_actions' hook

--- a/wagtail/core/log_actions.py
+++ b/wagtail/core/log_actions.py
@@ -1,5 +1,3 @@
-from django.utils.translation import gettext_lazy as _
-
 from wagtail.core import hooks
 
 
@@ -77,20 +75,6 @@ class LogActionRegistry:
     def get_formatter(self, log_entry):
         self.scan_for_actions()
         return self.formatters.get(log_entry.action)
-
-    def format_message(self, log_entry):
-        formatter = self.get_formatter(log_entry)
-        if formatter:
-            return formatter.format_message(log_entry)
-        else:
-            return _('Unknown %(action)s') % {'action': log_entry.action}
-
-    def format_comment(self, log_entry):
-        formatter = self.get_formatter(log_entry)
-        if formatter:
-            return formatter.format_comment(log_entry)
-        else:
-            return ''
 
     def action_exists(self, action):
         self.scan_for_actions()

--- a/wagtail/core/log_actions.py
+++ b/wagtail/core/log_actions.py
@@ -1,4 +1,7 @@
+from warnings import warn
+
 from wagtail.core import hooks
+from wagtail.utils.deprecation import RemovedInWagtail217Warning
 
 
 class LogFormatter:
@@ -15,6 +18,7 @@ class LogFormatter:
 
     def format_message(self, log_entry):
         if callable(self.message):
+            # RemovedInWagtail217Warning - support for callable messages will be dropped.
             # For Wagtail <2.15, a callable passed as 'message' will be called with the log entry's 'data' property.
             # (In 2.14 there was also a takes_log_entry attribute on the callable to specify passing the whole
             # log entry object rather than just data, but this was undocumented)
@@ -61,6 +65,13 @@ class LogActionRegistry:
             # register_action has been invoked as register_action(action, label, message); create a LogFormatter
             # subclass and register that
             label, message = args
+
+            if callable(message):
+                warn(
+                    "Passing a callable message to register_action is deprecated; create a LogFormatter subclass instead.",
+                    category=RemovedInWagtail217Warning
+                )
+
             formatter_cls = type('_LogFormatter', (LogFormatter, ), {'label': label, 'message': message})
             register_formatter_class(formatter_cls)
         else:

--- a/wagtail/core/models/audit_log.py
+++ b/wagtail/core/models/audit_log.py
@@ -168,12 +168,20 @@ class BaseLogEntry(models.Model):
     def object_id(self):
         raise NotImplementedError
 
-    def format_message(self):
-        return self.action_registry.format_message(self)
+    @cached_property
+    def formatter(self):
+        return self.action_registry.get_formatter(self)
 
-    def format_comment(self):
-        return self.action_registry.format_comment(self)
+    @cached_property
+    def message(self):
+        if self.formatter:
+            return self.formatter.format_message(self)
+        else:
+            return _('Unknown %(action)s') % {'action': self.action}
 
-    @property
+    @cached_property
     def comment(self):
-        return self.format_comment()
+        if self.formatter:
+            return self.formatter.format_comment(self)
+        else:
+            return ''

--- a/wagtail/core/models/audit_log.py
+++ b/wagtail/core/models/audit_log.py
@@ -117,9 +117,7 @@ class BaseLogEntry(models.Model):
         return super().save(*args, **kwargs)
 
     def clean(self):
-        self.action_registry.scan_for_actions()
-
-        if self.action not in self.action_registry.actions:
+        if not self.action_registry.action_exists(self.action):
             raise ValidationError({'action': _("The log action '{}' has not been registered.").format(self.action)})
 
     def __str__(self):

--- a/wagtail/core/tests/test_audit_log.py
+++ b/wagtail/core/tests/test_audit_log.py
@@ -343,11 +343,11 @@ class TestAuditLogHooks(TestCase, WagtailTestUtils):
         log_entry.refresh_from_db()
 
         log_actions = LogActionRegistry('register_log_actions')
-        self.assertEqual(log_actions.format_message(log_entry), "Unknown test.custom_action")
+        self.assertEqual(log_entry.message, "Unknown test.custom_action")
         self.assertFalse(log_actions.action_exists('test.custom_action'))
 
         with self.register_hook('register_log_actions', test_hook):
             log_actions = LogActionRegistry('register_log_actions')
             self.assertTrue(log_actions.action_exists('test.custom_action'))
-            self.assertEqual(log_actions.format_message(log_entry), "Tested!")
+            self.assertEqual(log_actions.get_formatter(log_entry).format_message(log_entry), "Tested!")
             self.assertEqual(log_actions.get_action_label('test.custom_action'), 'Custom action')

--- a/wagtail/core/tests/test_audit_log.py
+++ b/wagtail/core/tests/test_audit_log.py
@@ -321,11 +321,8 @@ class TestAuditLogHooks(TestCase, WagtailTestUtils):
         self.root_page = Page.objects.get(id=2)
 
     def test_register_log_actions_hook(self):
-        # testapp/wagtail_hooks.py defines a 'blockquote' rich text feature with a hallo.js
-        # plugin, via the register_rich_text_features hook; test that we can retrieve it here
         log_actions = LogActionRegistry('register_log_actions')
-        actions = log_actions.get_actions()
-        self.assertIn('wagtail.create', actions)
+        self.assertTrue(log_actions.action_exists('wagtail.create'))
 
     def test_action_must_be_registered(self):
         # We check actions are registered to let developers know if they have forgotten to register
@@ -347,10 +344,10 @@ class TestAuditLogHooks(TestCase, WagtailTestUtils):
 
         log_actions = LogActionRegistry('register_log_actions')
         self.assertEqual(log_actions.format_message(log_entry), "Unknown test.custom_action")
-        self.assertNotIn('test.custom_action', log_actions.get_actions())
+        self.assertFalse(log_actions.action_exists('test.custom_action'))
 
         with self.register_hook('register_log_actions', test_hook):
             log_actions = LogActionRegistry('register_log_actions')
-            self.assertIn('test.custom_action', log_actions.get_actions())
+            self.assertTrue(log_actions.action_exists('test.custom_action'))
             self.assertEqual(log_actions.format_message(log_entry), "Tested!")
             self.assertEqual(log_actions.get_action_label('test.custom_action'), 'Custom action')

--- a/wagtail/core/tests/test_page_model.py
+++ b/wagtail/core/tests/test_page_model.py
@@ -18,7 +18,6 @@ from django.test.utils import override_settings
 from django.utils import timezone, translation
 from freezegun import freeze_time
 
-from wagtail.core.log_actions import page_log_action_registry
 from wagtail.core.models import (
     Comment, Locale, Page, PageLogEntry, PageManager, ParentNotTranslatedError, Site,
     get_page_models, get_translatable_models)
@@ -2230,7 +2229,7 @@ class TestCopyForTranslation(TestCase):
         log_entry = PageLogEntry.objects.get(action='wagtail.copy_for_translation')
         self.assertEqual(log_entry.data['source_locale']['language_code'], 'en')
         self.assertEqual(log_entry.data['page']['locale']['language_code'], 'fr')
-        self.assertEqual(page_log_action_registry.format_message(log_entry), "Copied for translation from Root (English)")
+        self.assertEqual(log_entry.message, "Copied for translation from Root (English)")
 
     def test_copy_homepage_slug_exists(self):
         # This test is the same as test_copy_homepage, but we will create another page with
@@ -2265,7 +2264,7 @@ class TestCopyForTranslation(TestCase):
         log_entry = PageLogEntry.objects.get(action='wagtail.copy_for_translation')
         self.assertEqual(log_entry.data['source_locale']['language_code'], 'en')
         self.assertEqual(log_entry.data['page']['locale']['language_code'], 'fr')
-        self.assertEqual(page_log_action_registry.format_message(log_entry), "Copied for translation from Welcome to the Wagtail test site! (English)")
+        self.assertEqual(log_entry.message, "Copied for translation from Welcome to the Wagtail test site! (English)")
 
     def test_copy_childpage_without_parent(self):
         # This test is the same as test_copy_childpage but we won't create the parent page first


### PR DESCRIPTION
An API improvement as part of model audit logging - rather than the log action registry keeping track of several lookups for log action labels, messages and comments, define a LogFormatter object for each action type. Code that uses log messages (e.g. reports) can now access the `message` and `comment` properties on the LogEntry object, rather than having to work with the registry.

Note: I haven't preserved undocumented behaviour, specifically the `comments` kwarg on register_log_action and the `takes_log_entry` flag.