### PR TITLE
Fixed High-contrast mode: Breadcrumb separator should match link text…

### DIFF
--- a/client/scss/components/_breadcrumb.scss
+++ b/client/scss/components/_breadcrumb.scss
@@ -55,7 +55,7 @@
 
     .arrow_right_icon {
         @include svg-icon(1em);
-        color: $color-teal-dark;
+        color: LinkText;
         transform: scale(1.75) translate(0.3em, 0.1em);
     }
 


### PR DESCRIPTION
Fixed issue #7328 According to the Instructions
