### PR TITLE
Add TIDAL support to oembed

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -24,6 +24,7 @@ Changelog
  * When copying a page, default the 'Publish copied page' field to false (Justin Slay)
  * Open Preview and Live page links in the same tab, except where it would interrupt editing a Page (Sagar Agarwal)
  * Added `ExcelDateFormatter` to `wagtail.admin.views.mixins` so that dates in Excel exports will appear in the locale's `SHORT_DATETIME_FORMAT` (Andrew Stone)
+ * Add TIDAL support to the list of oEmbed providers (Wout De Puysseleir)
  * Fix: Delete button is now correct colour on snippets and modeladmin listings (Brandon Murch)
  * Fix: Ensure that StreamBlock / ListBlock-level validation errors are counted towards error counts (Matt Westcott)
  * Fix: InlinePanel add button is now keyboard navigatable (Jesse Menn)

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -539,6 +539,7 @@ Contributors
 * Krzysztof Jeziorny
 * Nick Moreton
 * Bryan Williams
+* Wout De Puysseleir
 
 Translators
 ===========

--- a/docs/releases/2.15.rst
+++ b/docs/releases/2.15.rst
@@ -35,6 +35,7 @@ Other features
  * When copying a page, default the 'Publish copied page' field to false (Justin Slay)
  * Open Preview and Live page links in the same tab, except where it would interrupt editing a Page (Sagar Agarwal)
  * Added ``ExcelDateFormatter`` to ``wagtail.admin.views.mixins`` so that dates in Excel exports will appear in the locale's ``SHORT_DATETIME_FORMAT`` (Andrew Stone)
+ * Add TIDAL support to the list of oEmbed providers (Wout De Puysseleir)
 
 Bug fixes
 ~~~~~~~~~

--- a/wagtail/embeds/oembed_providers.py
+++ b/wagtail/embeds/oembed_providers.py
@@ -634,6 +634,13 @@ reddit = {
     ]
 }
 
+tidal = {
+    'endpoint': 'https://oembed.tidal.com/',
+    'urls': [
+        r'^https?://(?:www\.)?tidal\.com/.+$'
+    ]
+}
+
 all_providers = [
     speakerdeck, app_net, youtube, datastudio, deviantart, blip_tv, dailymotion, flikr,
     hulu, nfb, qik, revision3, scribd, viddler, vimeo, dotsub, yfrog,
@@ -646,5 +653,5 @@ all_providers = [
     vhx_tv, justin_tv, official_fm, huffduffer, spotify, shoudio, mobypicture,
     twenty_three_hq, gmep, urtak, cacoo, dailymile, dipity, sketchfab, meetup,
     roomshare, crowd_ranking, etsy, audioboom, clikthrough, ifttt, issuu, tumblr, vidyard,
-    reddit
+    reddit, tidal
 ]


### PR DESCRIPTION
This adds TIDAL support for embedding playlists/tracks.

An example of a TIDAL link is:
- https://tidal.com/browse/playlist/1d71b4bb-db33-4bfd-b7c9-135b9b67f3a7
- https://tidal.com/browse/track/593849

Unrelated to this change:
I also was looking into Apple Music, but couldn't find the oembed endpoint. Might do in a different PR if I find it. If anyone else finds it, please let me know or create a PR :)