### PR TITLE
update documentation & 2.15 release to drop IE11 support

### DIFF
--- a/docs/advanced_topics/customisation/admin_templates.rst
+++ b/docs/advanced_topics/customisation/admin_templates.rst
@@ -98,8 +98,6 @@ Custom user interface colors
 
 
 .. warning::
-    CSS variables are not supported in Internet Explorer, so the admin will appear with the default colors when viewed in that browser.
-
     The default Wagtail colors conform to the WCAG2.1 AA level color contrast requirements. When customizing the admin colors you should test the contrast using tools like `Axe <https://www.deque.com/axe/browser-extensions/>`_.
 
 To customize the primary color used in the admin user interface, inject a CSS file using the hook :ref:`insert_global_admin_css` and override the variables within the ``:root`` selector:

--- a/docs/advanced_topics/customisation/streamfield_blocks.rst
+++ b/docs/advanced_topics/customisation/streamfield_blocks.rst
@@ -171,35 +171,6 @@ Here ``'myapp.blocks.AddressBlock'`` is the identifier for our JavaScript class 
     }
     window.telepath.register('myapp.blocks.AddressBlock', AddressBlockDefinition);
 
-Note that this code makes use of ES6 language features that are unavailable in IE11 - if IE11 support is required, this could be rewritten as:
-
-.. code-block:: javascript
-
-    function AddressBlockDefinition() {
-        window.wagtailStreamField.blocks.StructBlockDefinition.apply(this, arguments);
-    }
-
-    AddressBlockDefinition.prototype.render = function(placeholder, prefix, initialState, initialError) {
-        var block = window.wagtailStreamField.blocks.StructBlockDefinition.prototype.render.apply(
-            this, arguments
-        );
-
-        var stateField = $(document).find('#' + prefix + '-state');
-        var countryField = $(document).find('#' + prefix + '-country');
-        function updateStateInput() {
-            if (countryField.val() == 'us') {
-                stateField.removeAttr('disabled');
-            } else {
-                stateField.attr('disabled', true);
-            }
-        }
-        updateStateInput();
-        countryField.on('change', updateStateInput);
-
-        return block;
-    }
-    window.telepath.register('myapp.blocks.AddressBlock', AddressBlockDefinition);
-
 
 .. _custom_value_class_for_structblock:
 

--- a/docs/contributing/developing.rst
+++ b/docs/contributing/developing.rst
@@ -183,7 +183,6 @@ Browser        Device/OS      Version(s)
 Mobile Safari  iOS Phone      Last 2
 Mobile Safari  iOS Tablet     Last 2
 Chrome         Android        Last 2
-IE             Desktop        11
 Chrome         Desktop        Last 2
 MS Edge        Desktop        Last 2
 Firefox        Desktop        Latest
@@ -191,9 +190,9 @@ Firefox ESR    Desktop        Latest
 Safari         macOS          Last 2
 =============  =============  =============
 
-We aim for Wagtail to work in those environments. Our development standards ensure that the site is usable on other browsers **and will work on future browsers**. To test on IE, install virtual machines `made available by Microsoft <https://developer.microsoft.com/en-us/microsoft-edge/tools/vms/>`_.
+We aim for Wagtail to work in those environments. Our development standards ensure that the site is usable on other browsers **and will work on future browsers**.
 
-IE 11 is gradually falling out of use, and specific features are unsupported in this browser:
+IE 11 support has been officially dropped in 2.15 as it is gradually falling out of use. Features already known not to work include:
 
 * Rich text copy-paste in the rich text editor.
 * Sticky toolbar in the rich text editor.
@@ -206,7 +205,7 @@ IE 11 is gradually falling out of use, and specific features are unsupported in 
 Browser        Device/OS      Version(s)
 =============  =============  =============
 Stock browser  Android        All
-IE             Desktop        10 and below
+IE             Desktop        All
 Safari         Windows        All
 =============  =============  =============
 

--- a/docs/editor_manual/browser_issues.rst
+++ b/docs/editor_manual/browser_issues.rst
@@ -15,17 +15,15 @@ For the best experience and security, we recommend that you keep your browser up
 IE11
 ____
 
-Wagtail is gradually removing support for the legacy Internet Explorer browser over the course of `future releases <https://github.com/wagtail/wagtail/wiki/Release-schedule>`_.
+Wagtail has officially removed support for the legacy Internet Explorer browser in 2.15.
 
-* In Wagtail 2.11 (LTS), there will be a warning message displayed on the Wagtail dashboard for IE11 users with administrator role.
-* In Wagtail 2.12, the message will be displayed to all users regardless of their role.
-* In Wagtail 2.13, the message will be displayed at the top of all pages.
-* Wagtail will no longer support IE11 starting in version 2.14.
+* In Wagtail 2.11 (LTS), there was be a warning message displayed on the Wagtail dashboard for IE11 users with administrator role.
+* In Wagtail 2.12, the message was displayed to all users regardless of their role.
+* In Wagtail 2.13, the message was displayed at the top of all pages.
+* Wagtail will no longer support IE11 as of version 2.15 and beyond.
 
 If this affects you or your organisation, consider which alternative browsers you may be able to use.
 Wagtail is fully compatible with Microsoft Edge, Microsoft’s replacement for Internet Explorer. You may consider using its `IE mode <https://docs.microsoft.com/en-us/deployedge/edge-ie-mode>`_ to keep access to IE11-only sites, while other sites and apps like Wagtail can leverage modern browser capabilities.
-
-We are looking for feedback on this change to our support policy, please `get in touch <https://github.com/wagtail/wagtail/issues/6170>`_ if it affects you and there are no clear alternatives.
 
 Assistive technologies
 ______________________

--- a/docs/extending/extending_draftail.rst
+++ b/docs/extending/extending_draftail.rst
@@ -290,7 +290,7 @@ We then create the decorator component:
         }, props.children);
     };
 
-This is a straightforward React component. It does not use JSX since we do not want to have to use a build step for our JavaScript. It uses ES6 syntax – this would not work in IE11 unless it was converted back to ES5 with a build step.
+This is a straightforward React component. It does not use JSX since we do not want to have to use a build step for our JavaScript.
 
 Finally, we register the JS components of our plugin:
 

--- a/docs/releases/2.15.rst
+++ b/docs/releases/2.15.rst
@@ -152,3 +152,10 @@ calls ``PageLogEntry.objects.log_action`` should now import the ``log`` function
 call this instead (all arguments are unchanged).
 
 Additionally, for logging actions on non-Page models, it is generally no longer necessary to subclass ``BaseLogEntry``; see :ref:`audit_log` for further details.
+
+
+Removed support for Internet Explorer (IE11)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If this affects you or your organisation, consider which alternative browsers you may be able to use.
+Wagtail is fully compatible with Microsoft Edge, Microsoft’s replacement for Internet Explorer. You may consider using its `IE mode <https://docs.microsoft.com/en-us/deployedge/edge-ie-mode>`_ to keep access to IE11-only sites, while other sites and apps like Wagtail can leverage modern browser capabilities.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   },
   "browserslist": [
     "Firefox ESR",
-    "ie 11",
     "last 2 Chrome versions",
     "last 2 ChromeAndroid versions",
     "last 2 Edge versions",

--- a/wagtail/admin/templates/wagtailadmin/skeleton.html
+++ b/wagtail/admin/templates/wagtailadmin/skeleton.html
@@ -84,7 +84,7 @@
     {% block ie11warning %}
         <div data-ie11-warning hidden>
             <div class="capabilitymessage">
-                {% blocktrans with url="https://docs.wagtail.io/en/stable/editor_manual/browser_issues.html#ie11" %}Wagtail is gradually removing support for IE11, which may affect you or your organisation. <a href="{{ url }}">Learn more about our IE11 support plans</a>.{% endblocktrans %}
+                {% blocktrans with url="https://docs.wagtail.io/en/stable/editor_manual/browser_issues.html#ie11" %}Wagtail has removed support for IE11. <a href="{{ url }}">Learn more about IE11 alternatives</a>.{% endblocktrans %}
             </div>
         </div>
     {% endblock %}


### PR DESCRIPTION
Our docs previously stated that IE11 browser support would be dropped in 2.14, however we never added that to the release notes.

We want to ensure that this gets put into 2.15 as it is an LTS.

Beyond docs changes & `browserslist` there are no actual JS changes done in this PR, I think it would be best to pull out IE11 specific work-arounds on a case by case basis as other code is cleaned up and worked on.

- fixes #6170
- note for any backport fixes - v2.11 LTS, supports IE11, and will be supported until February 2022
- as of August 2021, IE11 usage is at 0.58% https://gs.statcounter.com/browser-market-share
