### PR TITLE
Update _dropdown.legacy.scss - Styling for the dropdown

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -33,7 +33,7 @@ Changelog
  * Fix: Remove redundant 'clear' button from site root page chooser (Matt Westcott)
  * Fix: Make ModelAdmin IndexView keyboard-navigable (Saptak Sengupta)
  * Fix: Prevent error on refreshing page previews when multiple preview tabs are open (Alex Tomkins)
- * Fix: Multiple accessibility fixes for Windows high contrast mode; Admin fields, Icon visibility, Page Editor field panels, sidebar menu, sidebar hamburger icon (Dmitrii Faiazov, Chakita Muttaraju, Onkar Apte, Desai Akshata, LB (Ben Johnston), Amy Chan, Dan Braghis)
+ * Fix: Multiple accessibility fixes for Windows high contrast mode; Admin fields, Dropdown button, Icon visibility, Page Editor field panels, sidebar menu, sidebar hamburger icon (Dmitrii Faiazov, Chakita Muttaraju, Onkar Apte, Desai Akshata, LB (Ben Johnston), Amy Chan, Dan Braghis, Desai Akshata)
  * Fix: Menu sidebar hamburger icon on smaller viewports now correctly indicates it is a button to screen readers and can be accessed via keyboard (Amy Chan, Dan Braghis)
  * Fix: `blocks.MultipleChoiceBlock`, `forms.CheckboxSelectMultiple` and `ArrayField` checkboxes will now stack instead of display inline to align with all other checkboxes fields (Seb Brown)
  * Fix: Screen readers can now access login screen field labels (Amy Chan)

--- a/client/scss/components/_dropdown.legacy.scss
+++ b/client/scss/components/_dropdown.legacy.scss
@@ -43,6 +43,30 @@
             border-style: solid;
             border-width: 1px 0 0;
             overflow: hidden;
+
+            a:focus,
+            button:focus {
+                border: 3px solid $color-focus-outline;
+            }
+        }
+
+        // Media for Windows High Contrast
+        @media (forced-colors: $media-forced-colours) {
+            li a,
+            li button {
+                forced-color-adjust: none;
+                background-color: $color-black;
+                border-color: $color-white;
+                color: $color-white;
+            }
+
+            li a:focus,
+            li button:focus {
+                background-color: $color-black;
+                forced-color-adjust: none;
+                border: 4px solid #0ff;
+                color: $color-white;
+            }
         }
 
         a {

--- a/docs/releases/2.15.rst
+++ b/docs/releases/2.15.rst
@@ -48,7 +48,7 @@ Bug fixes
  * Remove redundant 'clear' button from site root page chooser (Matt Westcott)
  * Make ModelAdmin IndexView keyboard-navigable (Saptak Sengupta)
  * Prevent error on refreshing page previews when multiple preview tabs are open (Alex Tomkins)
- * Multiple accessibility fixes for Windows high contrast mode; Admin fields, Icon visibility, Page Editor field panels, sidebar menu, sidebar hamburger icon (Dmitrii Faiazov, Chakita Muttaraju, Onkar Apte, Desai Akshata, LB (Ben Johnston), Amy Chan, Dan Braghis)
+ * Multiple accessibility fixes for Windows high contrast mode; Admin fields, Dropdown button, Icon visibility, Page Editor field panels, sidebar menu, sidebar hamburger icon (Dmitrii Faiazov, Chakita Muttaraju, Onkar Apte, Desai Akshata, LB (Ben Johnston), Amy Chan, Dan Braghis)
  * Menu sidebar hamburger icon on smaller viewports now correctly indicates it is a button to screen readers and can be accessed via keyboard (Amy Chan, Dan Braghis)
  * ``blocks.MultipleChoiceBlock``, ``forms.CheckboxSelectMultiple`` and ``ArrayField`` checkboxes will now stack instead of display inline to align with all other checkboxes fields (Seb Brown)
  * Screen readers can now access login screen field labels (Amy Chan)


### PR DESCRIPTION
Tested on:
Google Chrome and Microsoft Edge : Latest version

This issue is a part of PR https://github.com/wagtail/wagtail/pull/7525#

Updates the styling for dropdown on the edit page.
Creates styling for media forced-colors mode.