### PR TITLE
Make wagtail compatible with django 4.0

### DIFF
--- a/wagtail/admin/auth.py
+++ b/wagtail/admin/auth.py
@@ -35,7 +35,7 @@ def users_with_page_permission(page, permission_type, include_superusers=True):
 
 def permission_denied(request):
     """Return a standard 'permission denied' response"""
-    if request.headers.get('x-requested-with') == 'XMLHttpRequest' 
+    if request.headers.get('x-requested-with') == 'XMLHttpRequest':
         raise PermissionDenied
 
     from wagtail.admin import messages

--- a/wagtail/admin/auth.py
+++ b/wagtail/admin/auth.py
@@ -35,7 +35,7 @@ def users_with_page_permission(page, permission_type, include_superusers=True):
 
 def permission_denied(request):
     """Return a standard 'permission denied' response"""
-    if request.is_ajax():
+    if request.headers.get('x-requested-with') == 'XMLHttpRequest' 
         raise PermissionDenied
 
     from wagtail.admin import messages
@@ -141,7 +141,7 @@ def user_has_any_page_permission(user):
 
 
 def reject_request(request):
-    if request.is_ajax():
+    if request.headers.get('x-requested-with') == 'XMLHttpRequest':
         raise PermissionDenied
 
     # import redirect_to_login here to avoid circular imports on model files that import
@@ -193,12 +193,12 @@ def require_admin_access(view_func):
                     return view_func(request, *args, **kwargs)
 
             except PermissionDenied:
-                if request.is_ajax():
+                if request.headers.get('x-requested-with') == 'XMLHttpRequest':
                     raise
 
                 return permission_denied(request)
 
-        if not request.is_ajax():
+        if not request.headers.get('x-requested-with') == 'XMLHttpRequest':
             messages.error(request, _('You do not have permission to access the admin'))
 
         return reject_request(request)

--- a/wagtail/admin/views/pages/create.py
+++ b/wagtail/admin/views/pages/create.py
@@ -1,4 +1,4 @@
-from urllib.parse import urlencode, quote
+from urllib.parse import quote, urlencode
 
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType

--- a/wagtail/admin/views/pages/create.py
+++ b/wagtail/admin/views/pages/create.py
@@ -1,4 +1,4 @@
-from urllib.parse import urlencode
+from urllib.parse import urlencode, quote
 
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
@@ -8,7 +8,6 @@ from django.shortcuts import get_object_or_404, redirect
 from django.template.response import TemplateResponse
 from django.urls import reverse
 from django.utils import timezone
-from django.utils.http import urlquote
 from django.utils.translation import gettext as _
 from django.views.generic.base import ContextMixin, TemplateResponseMixin, View
 
@@ -248,7 +247,7 @@ class CreateView(TemplateResponseMixin, ContextMixin, HookResponseMixin, View):
         target_url = reverse('wagtailadmin_pages:edit', args=[self.page.id])
         if self.next_url:
             # Ensure the 'next' url is passed through again if present
-            target_url += '?next=%s' % urlquote(self.next_url)
+            target_url += '?next=%s' % quote(self.next_url)
         return redirect(target_url)
 
     def form_invalid(self, form):

--- a/wagtail/admin/views/pages/edit.py
+++ b/wagtail/admin/views/pages/edit.py
@@ -9,7 +9,6 @@ from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.html import format_html
-from django.utils.http import urlquote
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext as _
 from django.views.generic.base import ContextMixin, TemplateResponseMixin, View

--- a/wagtail/admin/views/pages/edit.py
+++ b/wagtail/admin/views/pages/edit.py
@@ -1,5 +1,7 @@
 import json
 
+from urllib.parse import quote
+
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.exceptions import PermissionDenied
@@ -713,7 +715,7 @@ class EditView(TemplateResponseMixin, ContextMixin, HookResponseMixin, View):
         target_url = reverse('wagtailadmin_pages:edit', args=[self.page.id])
         if self.next_url:
             # Ensure the 'next' url is passed through again if present
-            target_url += '?next=%s' % urlquote(self.next_url)
+            target_url += '?next=%s' % quote(self.next_url)
         return redirect(target_url)
 
     def form_invalid(self, form):

--- a/wagtail/admin/views/pages/search.py
+++ b/wagtail/admin/views/pages/search.py
@@ -93,7 +93,7 @@ def search(request):
     paginator = Paginator(pages, per_page=20)
     pages = paginator.get_page(request.GET.get('p'))
 
-    if request.is_ajax():
+    if request.headers.get('x-requested-with') == 'XMLHttpRequest':
         return TemplateResponse(request, "wagtailadmin/pages/search_results.html", {
             'pages': pages,
             'all_pages': all_pages,

--- a/wagtail/admin/views/pages/workflow.py
+++ b/wagtail/admin/views/pages/workflow.py
@@ -88,13 +88,13 @@ class WorkflowAction(BaseWorkflowFormView):
             form = self.form_class(request.POST)
             if form.is_valid():
                 redirect_to = self.task.on_action(self.task_state, request.user, self.action_name, **form.cleaned_data) or self.redirect_to
-            elif self.action_modal and request.is_ajax():
+            elif self.action_modal and request.headers.get('x-requested-with') == 'XMLHttpRequest':
                 # show form errors
                 return self.render_modal_form(request, form)
         else:
             redirect_to = self.task.on_action(self.task_state, request.user, self.action_name) or self.redirect_to
 
-        if request.is_ajax():
+        if request.headers.get('x-requested-with') == 'XMLHttpRequest':
             return render_modal_workflow(request, '', None, {}, json_data={'step': 'success', 'redirect': redirect_to})
         return redirect(redirect_to)
 
@@ -113,7 +113,7 @@ class CollectWorkflowActionData(BaseWorkflowFormView):
         form = self.form_class(request.POST)
         if form.is_valid():
             return render_modal_workflow(request, '', None, {}, json_data={'step': 'success', 'cleaned_data': form.cleaned_data})
-        elif self.action_modal and request.is_ajax():
+        elif self.action_modal and request.headers.get('x-requested-with') == 'XMLHttpRequest':
             # show form errors
             return self.render_modal_form(request, form)
 

--- a/wagtail/contrib/modeladmin/helpers/url.py
+++ b/wagtail/contrib/modeladmin/helpers/url.py
@@ -1,7 +1,8 @@
-from django.contrib.admin.utils import quote
+from urllib.parse import quote
+
+from django.contrib.admin.utils import quote as admin_quote
 from django.urls import reverse
 from django.utils.functional import cached_property
-from django.utils.http import urlquote
 
 
 class AdminURLHelper:
@@ -52,7 +53,7 @@ class ModelAdminURLFinder:
 
     def get_edit_url(self, instance):
         if self.permission_helper.user_can_edit_obj(self.user, instance):
-            return self.url_helper.get_action_url('edit', quote(instance.pk))
+            return self.url_helper.get_action_url('edit', admin_quote(instance.pk))
 
 
 class PageAdminURLHelper(AdminURLHelper):
@@ -61,5 +62,5 @@ class PageAdminURLHelper(AdminURLHelper):
         if action in ('add', 'edit', 'delete', 'unpublish', 'copy'):
             url_name = 'wagtailadmin_pages:%s' % action
             target_url = reverse(url_name, args=args, kwargs=kwargs)
-            return '%s?next=%s' % (target_url, urlquote(self.index_url))
+            return '%s?next=%s' % (target_url, quote(self.index_url))
         return super().get_action_url(action, *args, **kwargs)

--- a/wagtail/contrib/redirects/views.py
+++ b/wagtail/contrib/redirects/views.py
@@ -54,7 +54,7 @@ def index(request):
     redirects = paginator.get_page(request.GET.get('p'))
 
     # Render template
-    if request.is_ajax():
+    if request.headers.get('x-requested-with') == 'XMLHttpRequest':
         return TemplateResponse(request, "wagtailredirects/results.html", {
             'ordering': ordering,
             'redirects': redirects,

--- a/wagtail/contrib/search_promotions/views.py
+++ b/wagtail/contrib/search_promotions/views.py
@@ -48,7 +48,7 @@ def index(request):
     paginator = Paginator(queries, per_page=20)
     queries = paginator.get_page(request.GET.get('p'))
 
-    if request.is_ajax():
+    if request.headers.get('x-requested-with') == 'XMLHttpRequest':
         return TemplateResponse(request, "wagtailsearchpromotions/results.html", {
             'is_searching': is_searching,
             'ordering': ordering,

--- a/wagtail/core/models/__init__.py
+++ b/wagtail/core/models/__init__.py
@@ -1102,7 +1102,7 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
         return context
 
     def get_template(self, request, *args, **kwargs):
-        if request.is_ajax():
+        if request.headers.get('x-requested-with') == 'XMLHttpRequest':
             return self.ajax_template or self.template
         else:
             return self.template

--- a/wagtail/users/views/groups.py
+++ b/wagtail/users/views/groups.py
@@ -61,7 +61,7 @@ class IndexView(mixins.SearchableListMixin, generic.IndexView):
     ordering = ['name']
 
     def get_template_names(self):
-        if self.request.is_ajax():
+        if self.request.headers.get('x-requested-with') == 'XMLHttpRequest':
             return ['wagtailusers/groups/results.html']
         else:
             return ['wagtailusers/groups/index.html']

--- a/wagtail/users/views/users.py
+++ b/wagtail/users/views/users.py
@@ -101,7 +101,7 @@ def index(request, *args):
     paginator = Paginator(users.select_related('wagtail_userprofile'), per_page=20)
     users = paginator.get_page(request.GET.get('p'))
 
-    if request.is_ajax():
+    if request.headers.get('x-requested-with') == 'XMLHttpRequest':
         return TemplateResponse(request, "wagtailusers/users/results.html", {
             'users': users,
             'is_searching': is_searching,

--- a/wagtail/utils/sendfile.py
+++ b/wagtail/utils/sendfile.py
@@ -83,9 +83,9 @@ def sendfile(request, filename, attachment=False, attachment_filename=None, mime
             parts.append('filename="%s"' % ascii_filename)
 
             if ascii_filename != attachment_filename:
-                from django.utils.http import urlquote
+                from urllib.parse import quote
 
-                quoted_filename = urlquote(attachment_filename)
+                quoted_filename = quote(attachment_filename)
                 parts.append('filename*=UTF-8\'\'%s' % quoted_filename)
 
         response['Content-Disposition'] = '; '.join(parts)


### PR DESCRIPTION
The two points I tried to fix were:

* Replaced django.utils.http.urlquote with urllib.parse.quote
* Replaced request.is_ajax() with request.headers.get('x-requested-with') == 'XMLHttpRequest'

All tests run by `python runtests.py` passed, but some were expected failures (didn't install all the javascript stuff etc..).
