### PR TITLE
fix: Replacement file deletion in document edit

### DIFF
--- a/wagtail/documents/views/documents.py
+++ b/wagtail/documents/views/documents.py
@@ -162,10 +162,13 @@ def edit(request, document_id):
                 doc.save()
                 form.save_m2m()
 
-                # If providing a new document file, delete the old one.
-                # NB Doing this via original_file.delete() clears the file field,
-                # which definitely isn't what we want...
-                original_file.storage.delete(original_file.name)
+                # Only delete the original file if it was uploaded to a different path.
+                if original_file.name != doc.file.name:
+                    # If providing a new document file, delete the old one.
+                    # NB Doing this via original_file.delete() clears the file field,
+                    # which definitely isn't what we want...
+                    original_file.storage.delete(original_file.name)
+
             else:
                 doc = form.save()
 


### PR DESCRIPTION
Fixes a bug in document edit where uploading a new file with the same filename will cause the new upload to be deleted
from storage.

Thanks for contributing to Wagtail! 🎉

Before submitting, please review the contributor guidelines <https://docs.wagtail.io/en/latest/contributing/index.html> and check the following:

* Do the tests still pass? (https://docs.wagtail.io/en/latest/contributing/developing.html#testing)
* Does the code comply with the style guide? (Run `make lint` from the Wagtail root)
* For Python changes: Have you added tests to cover the new/fixed behaviour?
* For front-end changes: Did you test on all of [Wagtail’s supported environments](https://docs.wagtail.io/en/latest/contributing/developing.html#browser-and-device-support)?
    * **Please list the exact browser and operating system versions you tested**.
    * **Please list which assistive technologies you tested**.
* For new features: Has the documentation been updated accordingly?
