### PR TITLE
Fix link to node.js download

### DIFF
--- a/docs/contributing/developing.rst
+++ b/docs/contributing/developing.rst
@@ -15,7 +15,7 @@ If you'd prefer to set up all the components manually, read on. These instructio
 Setting up the Wagtail codebase
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Install Node.js, version 14. Instructions for installing Node.js can be found on the `Node.js download page <https://nodejs.org/download/>`_.
+Install `Node.js <https://nodejs.org/>`_, version 14.
 You can also use Node version manager (nvm) since Wagtail supplies a ``.nvmrc`` file in the root of the project with the minimum required Node version - see nvm's `installation instructions <https://github.com/creationix/nvm>`_.
 
 You will also need to install the **libjpeg** and **zlib** libraries, if you haven't done so already - see Pillow's `platform-specific installation instructions <https://pillow.readthedocs.org/en/latest/installation.html#external-libraries>`_.


### PR DESCRIPTION
https://nodejs.org/download/ just points to a directory listing now; the download link is now on the https://nodejs.org/ homepage, and there are no instructions to speak of.
