### PR TITLE
Removing restrictions should not show "Removed Public restriction"

### DIFF
--- a/wagtail/core/wagtail_hooks.py
+++ b/wagtail/core/wagtail_hooks.py
@@ -280,9 +280,8 @@ def register_core_log_actions(actions):
 
         def format_message(self, log_entry):
             try:
-                return _("Removed the '%(restriction)s' view restriction") % {
-                    'restriction': log_entry.data['restriction']['title'],
-                }
+                return _("Removed the page view restrictions (now it is public)")
+        
             except KeyError:
                 return _('Removed view restriction')
 


### PR DESCRIPTION
currently when the page editor removes the restrictions, the page and site history shows like (Removed the 'Public' view restriction), and this off course is not making any sense, this PR is just simply removing the variables and shows that the restrictions are removed
