### PR TITLE
Added more wrapping database transactions to the page admin (#7556)

### DIFF
--- a/wagtail/admin/views/pages/copy.py
+++ b/wagtail/admin/views/pages/copy.py
@@ -1,4 +1,5 @@
 from django.core.exceptions import PermissionDenied
+from django.db import transaction
 from django.shortcuts import redirect
 from django.template.response import TemplateResponse
 from django.utils.translation import gettext as _
@@ -26,70 +27,71 @@ def copy(request, page_id):
 
     next_url = get_valid_next_url_from_request(request)
 
-    for fn in hooks.get_hooks('before_copy_page'):
-        result = fn(request, page)
-        if hasattr(result, 'status_code'):
-            return result
+    with transaction.atomic():
+        for fn in hooks.get_hooks('before_copy_page'):
+            result = fn(request, page)
+            if hasattr(result, 'status_code'):
+                return result
 
-    # Check if user is submitting
-    if request.method == 'POST':
-        # Prefill parent_page in case the form is invalid (as prepopulated value for the form field,
-        # because ModelChoiceField seems to not fall back to the user given value)
-        parent_page = Page.objects.get(id=request.POST['new_parent_page'])
+        # Check if user is submitting
+        if request.method == 'POST':
+            # Prefill parent_page in case the form is invalid (as prepopulated value for the form field,
+            # because ModelChoiceField seems to not fall back to the user given value)
+            parent_page = Page.objects.get(id=request.POST['new_parent_page'])
 
-        if form.is_valid():
-            # Receive the parent page (this should never be empty)
-            if form.cleaned_data['new_parent_page']:
-                parent_page = form.cleaned_data['new_parent_page']
+            if form.is_valid():
+                # Receive the parent page (this should never be empty)
+                if form.cleaned_data['new_parent_page']:
+                    parent_page = form.cleaned_data['new_parent_page']
 
-            if not page.permissions_for_user(request.user).can_copy_to(parent_page,
-                                                                       form.cleaned_data.get('copy_subpages')):
-                raise PermissionDenied
+                if not page.permissions_for_user(request.user).can_copy_to(parent_page,
+                                                                           form.cleaned_data.get('copy_subpages')):
+                    raise PermissionDenied
 
-            # Re-check if the user has permission to publish subpages on the new parent
-            can_publish = parent_page.permissions_for_user(request.user).can_publish_subpage()
-            keep_live = can_publish and form.cleaned_data.get('publish_copies')
+                # Re-check if the user has permission to publish subpages on the new parent
+                can_publish = parent_page.permissions_for_user(request.user).can_publish_subpage()
+                keep_live = can_publish and form.cleaned_data.get('publish_copies')
 
-            # Copy the page
-            # Note that only users who can publish in the new parent page can create an alias.
-            # This is because alias pages must always match their original page's state.
-            if can_publish and form.cleaned_data.get('alias'):
-                new_page = page.specific.create_alias(
-                    recursive=form.cleaned_data.get('copy_subpages'),
-                    parent=parent_page,
-                    update_slug=form.cleaned_data['new_slug'],
-                    user=request.user,
-                )
-            else:
-                new_page = page.specific.copy(
-                    recursive=form.cleaned_data.get('copy_subpages'),
-                    to=parent_page,
-                    update_attrs={
-                        'title': form.cleaned_data['new_title'],
-                        'slug': form.cleaned_data['new_slug'],
-                    },
-                    keep_live=keep_live,
-                    user=request.user,
-                )
+                # Copy the page
+                # Note that only users who can publish in the new parent page can create an alias.
+                # This is because alias pages must always match their original page's state.
+                if can_publish and form.cleaned_data.get('alias'):
+                    new_page = page.specific.create_alias(
+                        recursive=form.cleaned_data.get('copy_subpages'),
+                        parent=parent_page,
+                        update_slug=form.cleaned_data['new_slug'],
+                        user=request.user,
+                    )
+                else:
+                    new_page = page.specific.copy(
+                        recursive=form.cleaned_data.get('copy_subpages'),
+                        to=parent_page,
+                        update_attrs={
+                            'title': form.cleaned_data['new_title'],
+                            'slug': form.cleaned_data['new_slug'],
+                        },
+                        keep_live=keep_live,
+                        user=request.user,
+                    )
 
-            # Give a success message back to the user
-            if form.cleaned_data.get('copy_subpages'):
-                messages.success(
-                    request,
-                    _("Page '{0}' and {1} subpages copied.").format(page.specific_deferred.get_admin_display_title(), new_page.get_descendants().count())
-                )
-            else:
-                messages.success(request, _("Page '{0}' copied.").format(page.specific_deferred.get_admin_display_title()))
+                # Give a success message back to the user
+                if form.cleaned_data.get('copy_subpages'):
+                    messages.success(
+                        request,
+                        _("Page '{0}' and {1} subpages copied.").format(page.specific_deferred.get_admin_display_title(), new_page.get_descendants().count())
+                    )
+                else:
+                    messages.success(request, _("Page '{0}' copied.").format(page.specific_deferred.get_admin_display_title()))
 
-            for fn in hooks.get_hooks('after_copy_page'):
-                result = fn(request, page, new_page)
-                if hasattr(result, 'status_code'):
-                    return result
+                for fn in hooks.get_hooks('after_copy_page'):
+                    result = fn(request, page, new_page)
+                    if hasattr(result, 'status_code'):
+                        return result
 
-            # Redirect to explore of parent page
-            if next_url:
-                return redirect(next_url)
-            return redirect('wagtailadmin_explore', parent_page.id)
+                # Redirect to explore of parent page
+                if next_url:
+                    return redirect(next_url)
+                return redirect('wagtailadmin_explore', parent_page.id)
 
     return TemplateResponse(request, 'wagtailadmin/pages/copy.html', {
         'page': page,

--- a/wagtail/admin/views/pages/create.py
+++ b/wagtail/admin/views/pages/create.py
@@ -3,6 +3,7 @@ from urllib.parse import quote, urlencode
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import PermissionDenied
+from django.db import transaction
 from django.http import Http404
 from django.shortcuts import get_object_or_404, redirect
 from django.template.response import TemplateResponse
@@ -103,7 +104,8 @@ class CreateView(TemplateResponseMixin, ContextMixin, HookResponseMixin, View):
         )
 
         if self.form.is_valid():
-            return self.form_valid(self.form)
+            with transaction.atomic():
+                return self.form_valid(self.form)
         else:
             return self.form_invalid(self.form)
 

--- a/wagtail/admin/views/pages/edit.py
+++ b/wagtail/admin/views/pages/edit.py
@@ -5,6 +5,7 @@ from urllib.parse import quote
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.exceptions import PermissionDenied
+from django.db import transaction
 from django.db.models import Prefetch, Q
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404, redirect
@@ -412,7 +413,8 @@ class EditView(TemplateResponseMixin, ContextMixin, HookResponseMixin, View):
         self.is_cancelling_workflow = bool(self.request.POST.get('action-cancel-workflow')) and self.workflow_state and self.workflow_state.user_can_cancel(self.request.user)
 
         if self.form.is_valid() and not self.page_perms.page_locked():
-            return self.form_valid(self.form)
+            with transaction.atomic():
+                return self.form_valid(self.form)
         else:
             return self.form_invalid(self.form)
 

--- a/wagtail/admin/views/pages/moderation.py
+++ b/wagtail/admin/views/pages/moderation.py
@@ -1,4 +1,5 @@
 from django.core.exceptions import PermissionDenied
+from django.db import transaction
 from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse
 from django.utils.translation import gettext as _
@@ -19,7 +20,8 @@ def approve_moderation(request, revision_id):
         return redirect('wagtailadmin_home')
 
     if request.method == 'POST':
-        revision.approve_moderation(user=request.user)
+        with transaction.atomic():
+            revision.approve_moderation(user=request.user)
 
         message = _("Page '{0}' published.").format(revision.page.specific_deferred.get_admin_display_title())
         buttons = []
@@ -44,7 +46,8 @@ def reject_moderation(request, revision_id):
         return redirect('wagtailadmin_home')
 
     if request.method == 'POST':
-        revision.reject_moderation(user=request.user)
+        with transaction.atomic():
+            revision.reject_moderation(user=request.user)
 
         messages.success(request, _("Page '{0}' rejected for publication.").format(revision.page.specific_deferred.get_admin_display_title()), buttons=[
             messages.button(reverse('wagtailadmin_pages:edit', args=(revision.page.id,)), _('Edit'))

--- a/wagtail/admin/views/pages/move.py
+++ b/wagtail/admin/views/pages/move.py
@@ -1,5 +1,6 @@
 from django.core.exceptions import PermissionDenied
 from django.core.paginator import Paginator
+from django.db import transaction
 from django.shortcuts import get_object_or_404, redirect
 from django.template.response import TemplateResponse
 from django.urls import reverse
@@ -61,26 +62,27 @@ def move_confirm(request, page_to_move_id, destination_id):
         )
         return redirect('wagtailadmin_pages:move_choose_destination', page_to_move.id, destination.id)
 
-    for fn in hooks.get_hooks('before_move_page'):
-        result = fn(request, page_to_move, destination)
-        if hasattr(result, 'status_code'):
-            return result
-
-    if request.method == 'POST':
-        # any invalid moves *should* be caught by the permission check above,
-        # so don't bother to catch InvalidMoveToDescendant
-        page_to_move.move(destination, pos='last-child', user=request.user)
-
-        messages.success(request, _("Page '{0}' moved.").format(page_to_move.get_admin_display_title()), buttons=[
-            messages.button(reverse('wagtailadmin_pages:edit', args=(page_to_move.id,)), _('Edit'))
-        ])
-
-        for fn in hooks.get_hooks('after_move_page'):
-            result = fn(request, page_to_move)
+    with transaction.atomic():
+        for fn in hooks.get_hooks('before_move_page'):
+            result = fn(request, page_to_move, destination)
             if hasattr(result, 'status_code'):
                 return result
 
-        return redirect('wagtailadmin_explore', destination.id)
+        if request.method == 'POST':
+            # any invalid moves *should* be caught by the permission check above,
+            # so don't bother to catch InvalidMoveToDescendant
+            page_to_move.move(destination, pos='last-child', user=request.user)
+
+            messages.success(request, _("Page '{0}' moved.").format(page_to_move.get_admin_display_title()), buttons=[
+                messages.button(reverse('wagtailadmin_pages:edit', args=(page_to_move.id,)), _('Edit'))
+            ])
+
+            for fn in hooks.get_hooks('after_move_page'):
+                result = fn(request, page_to_move)
+                if hasattr(result, 'status_code'):
+                    return result
+
+            return redirect('wagtailadmin_explore', destination.id)
 
     return TemplateResponse(request, 'wagtailadmin/pages/confirm_move.html', {
         'page_to_move': page_to_move,


### PR DESCRIPTION
To avoid too many changes I started with the page administration and added wrapping `transaction.atomic` calls.
This should avoid possible data inconsistencies and also allow developers to add `on_commit`-functionality, that is only executed on success of the whole transaction (see #7556).

**TBD:**
To be consistent with existing `transaction.atomic` usages, for example in [delete.py](https://github.com/wagtail/wagtail/blob/9aa2f68dfa04d5ab21eab059fc5432e7fcfee883/wagtail/admin/views/pages/delete.py#L18), I've wrapped the "before"-hooks too. This was easy for the function-based views, but for the class-based views, eg. the EditView, I basically would have to wrap the whole `dispatch()`-call with `@transaction.atomic`.
I avoided that for now, but that results in some minor inconsistencies, eg. using the `on_commit`-hook in `before_edit_page` won't be part of the newly added transaction. What do you think?