### PR TITLE
Deployment docs - update wagtail getting started

### DIFF
--- a/docs/advanced_topics/deploying.rst
+++ b/docs/advanced_topics/deploying.rst
@@ -12,7 +12,7 @@ On Divio Cloud
 `Divio Cloud <https://divio.com/>`_ is a Dockerised cloud hosting platform for Python/Django that allows you to launch and deploy Wagtail projects in minutes. With a free account, you can create a Wagtail project. Choose from a:
 
 * `site based on the Wagtail Bakery project <https://divio.com/wagtail>`_, or
-* `brand new Wagtail project <https://control.divio.com/control/project/create>`_ (see the `how to get started notes <https://support.divio.com/project-types/wagtail/get-started-with-wagtail-on-divio-cloud>`_).
+* `brand new Wagtail project <https://control.divio.com/control/project/create>`_ (see the `how to get started notes <https://docs.divio.com/en/latest/introduction/wagtail/>`_).
 
 Divio Cloud also hosts a `live Wagtail Bakery demo <https://divio.com/wagtail>`_ (no account required).
 


### PR DESCRIPTION
* existing link does not work, just redirects to div.io home page
* New link https://docs.divio.com/en/latest/introduction/wagtail/