### PR TITLE
Capture log output from style fallback unit test

### DIFF
--- a/wagtail/admin/rich_text/converters/contentstate.py
+++ b/wagtail/admin/rich_text/converters/contentstate.py
@@ -43,13 +43,13 @@ def block_fallback(props):
 
 def entity_fallback(props):
     type_ = props['entity']['type']
-    logging.warn('Missing config for "%s". Deleting entity' % type_)
+    logging.warning('Missing config for "%s". Deleting entity' % type_)
     return None
 
 
 def style_fallback(props):
     type_ = props['inline_style_range']['style']
-    logging.warn('Missing config for "%s". Deleting style.' % type_)
+    logging.warning('Missing config for "%s". Deleting style.' % type_)
     return props['children']
 
 


### PR DESCRIPTION
For some reason the log output generated during the test added in #7388 causes subsequent tests to be much more noisy - wrap it in self.assertLogs to silence this.

(also change logging.warn to logging.warning - the former is obsolete as per https://docs.python.org/3.10/library/logging.html#logging.warning )
