### PR TITLE
Use SVG icon in homepage's site summary items

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -33,6 +33,7 @@ Changelog
  * Set default submit button label on generic create views to 'Create' instead of 'Save' (Matt Westcott)
  * Improve display of image listing for long image titles (Krzysztof Jeziorny)
  * Use SVG icons in admin home page site summary items (Jérôme Lebleu)
+ * Ensure site summary items wrap on smaller devices on the admin home page (Jérôme Lebleu)
  * Fix: Accessibility fixes for Windows high contrast mode; Dashboard icons colour and contrast (Sakshi Uppoor)
  * Fix: Rename additional 'spin' CSS animations to avoid clashes with other libraries (Kevin Gutiérrez)
  * Fix: `default_app_config` deprecations for Django >= 3.2 (Tibor Leupold)

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -32,6 +32,7 @@ Changelog
  * Add borders to TypedTableBlock to help visualize rows and columns (Scott Cranfill)
  * Set default submit button label on generic create views to 'Create' instead of 'Save' (Matt Westcott)
  * Improve display of image listing for long image titles (Krzysztof Jeziorny)
+ * Use SVG icons in admin home page site summary items (Jérôme Lebleu)
  * Fix: Accessibility fixes for Windows high contrast mode; Dashboard icons colour and contrast (Sakshi Uppoor)
  * Fix: Rename additional 'spin' CSS animations to avoid clashes with other libraries (Kevin Gutiérrez)
  * Fix: `default_app_config` deprecations for Django >= 3.2 (Tibor Leupold)

--- a/docs/releases/2.16.md
+++ b/docs/releases/2.16.md
@@ -35,6 +35,7 @@
  * Add borders to TypedTableBlock to help visualize rows and columns (Scott Cranfill)
  * Set default submit button label on generic create views to 'Create' instead of 'Save' (Matt Westcott)
  * Improve display of image listing for long image titles (Krzysztof Jeziorny)
+ * Use SVG icons in admin home page site summary items (Jérôme Lebleu)
 
 ### Bug fixes
 

--- a/docs/releases/2.16.md
+++ b/docs/releases/2.16.md
@@ -36,6 +36,7 @@
  * Set default submit button label on generic create views to 'Create' instead of 'Save' (Matt Westcott)
  * Improve display of image listing for long image titles (Krzysztof Jeziorny)
  * Use SVG icons in admin home page site summary items (Jérôme Lebleu)
+ * Ensure site summary items wrap on smaller devices on the admin home page (Jérôme Lebleu)
 
 ### Bug fixes
 

--- a/wagtail/admin/static_src/wagtailadmin/scss/layouts/home.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/layouts/home.scss
@@ -48,6 +48,10 @@ header {
         li {
             @include column(4);
             margin-bottom: 2em;
+
+            @include media-breakpoint-down(sm) {
+                width: 50%;
+            }
         }
 
         li.icon::before,

--- a/wagtail/admin/static_src/wagtailadmin/scss/layouts/home.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/layouts/home.scss
@@ -50,7 +50,8 @@ header {
             margin-bottom: 2em;
         }
 
-        li:before {
+        li.icon::before,
+        li svg.icon {
             opacity: 0.2;
             font-size: 6em;
             float: left;
@@ -72,6 +73,12 @@ header {
                 color: $system-color-link-text;
                 opacity: 1;
             }
+        }
+
+        li svg.icon {
+            width: 1em;
+            height: 1em;
+            margin-right: 0.5em;
         }
 
         a {

--- a/wagtail/admin/templates/wagtailadmin/home/site_summary_pages.html
+++ b/wagtail/admin/templates/wagtailadmin/home/site_summary_pages.html
@@ -1,6 +1,7 @@
 {% load i18n wagtailadmin_tags %}
 
-<li class="icon icon-doc-empty-inverse">
+<li>
+    {% icon name="doc-empty-inverse" %}
     <a href="{% url 'wagtailadmin_explore' root_page.pk %}">
         {% blocktrans count counter=total_pages with total_pages|intcomma as total %}
             <span>{{ total }}</span> Page <span class="visuallyhidden">created in {{ site_name }}</span>

--- a/wagtail/documents/templates/wagtaildocs/homepage/site_summary_documents.html
+++ b/wagtail/documents/templates/wagtaildocs/homepage/site_summary_documents.html
@@ -1,6 +1,7 @@
 {% load i18n wagtailadmin_tags %}
 
-<li class="icon icon-doc-full-inverse">
+<li>
+    {% icon name="doc-full-inverse" %}
     <a href="{% url 'wagtaildocs:index' %}">
     {% blocktrans count counter=total_docs with total_docs|intcomma as total %}
         <span>{{ total }}</span> Document <span class="visuallyhidden">created in {{ site_name }}</span>

--- a/wagtail/images/templates/wagtailimages/homepage/site_summary_images.html
+++ b/wagtail/images/templates/wagtailimages/homepage/site_summary_images.html
@@ -1,6 +1,7 @@
 {% load i18n wagtailadmin_tags %}
 
-<li class="icon icon-image">
+<li>
+    {% icon name="image" %}
     <a href="{% url 'wagtailimages:index' %}">
     {% blocktrans count counter=total_images with total_images|intcomma as total %}
         <span>{{ total }}</span> Image <span class="visuallyhidden">created in {{ site_name }}</span>


### PR DESCRIPTION
To continue to contribute to #6107, this replace font icon by SVG icon in the site summary items of the homepage. As one may have defined custom items using `li.icon`, I kept those styles but tell me if you find that it can be removed.

This also changes the display of the items to have 2 of them per row on small screen instead of 3 - even it should be 4?