### PR TITLE
Set the bound field label of FieldPanel with the heading argument

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -75,6 +75,7 @@ Changelog
  * Fix: Nested InlinePanel usage no longer fails to save when creating two or more items (Indresh P, Rinish Sam, Anirudh V S)
  * Fix: Changed relation name used for admin commenting from `comments` to `wagtail_admin_comments` to avoid conflicts with third-party commenting apps (Matt Westcott)
  * Fix: CSS variables are now correctly used for the filtering menu in modeladmin (Noah H)
+ * Fix: Panel heading attribute is no longer ignored when nested inside a `MultiFieldPanel` (Jérôme Lebleu)
 
 
 2.14.2 (14.10.2021)

--- a/docs/releases/2.15.rst
+++ b/docs/releases/2.15.rst
@@ -116,6 +116,7 @@ Bug fixes
  * Nested InlinePanel usage no longer fails to save when creating two or more items (Indresh P, Rinish Sam, Anirudh V S)
  * Changed relation name used for admin commenting from ``comments`` to ``wagtail_admin_comments`` to avoid conflicts with third-party commenting apps (Matt Westcott)
  * CSS variables are now correctly used for the filtering menu in modeladmin (Noah H)
+ * Panel heading attribute is no longer ignored when nested inside a ``MultiFieldPanel`` (Jérôme Lebleu)
 
 Upgrade considerations
 ======================

--- a/wagtail/admin/edit_handlers.py
+++ b/wagtail/admin/edit_handlers.py
@@ -560,7 +560,10 @@ class FieldPanel(EditHandler):
 
     def on_form_bound(self):
         self.bound_field = self.form[self.field_name]
-        self.heading = self.heading or self.bound_field.label
+        if self.heading:
+            self.bound_field.label = self.heading
+        else:
+            self.heading = self.bound_field.label
         self.help_text = self.bound_field.help_text
 
     def __repr__(self):

--- a/wagtail/admin/tests/test_edit_handlers.py
+++ b/wagtail/admin/tests/test_edit_handlers.py
@@ -457,6 +457,7 @@ class TestFieldPanel(TestCase):
         end_date_panel_with_overridden_heading = (FieldPanel('date_to', classname='full-width', heading="New heading")
                                                   .bind_to(model=EventPage, request=self.request, form=self.EventPageForm()))
         self.assertEqual(end_date_panel_with_overridden_heading.heading, "New heading")
+        self.assertEqual(end_date_panel_with_overridden_heading.bound_field.label, "New heading")
 
     def test_render_as_object(self):
         form = self.EventPageForm(
@@ -557,7 +558,7 @@ class TestFieldRowPanel(TestCase):
                                date_from=date(2014, 7, 20), date_to=date(2014, 7, 21))
 
         self.dates_panel = FieldRowPanel([
-            FieldPanel('date_from', classname='col4'),
+            FieldPanel('date_from', classname='col4', heading="Start"),
             FieldPanel('date_to', classname='coltwo'),
         ]).bind_to(model=EventPage, request=self.request)
 
@@ -596,6 +597,9 @@ class TestFieldRowPanel(TestCase):
         # check that label is output in the 'field' style
         self.assertIn('<label for="id_date_to">End date:</label>', result)
         self.assertNotIn('<legend>End date</legend>', result)
+
+        # check that label is overridden with the 'heading' argument
+        self.assertIn('<label for="id_date_from">Start:</label>', result)
 
         # check that help text is included
         self.assertIn('Not required if event is on a single day', result)


### PR DESCRIPTION
When a FielPanel is rendered as a field, the label is outputted with the
`bound_field.label_tag()` method. Thus, the field's label is not
overridden with the `heading` argument.

This attempts to fix that by set the `bound_field.label` property with
the `heading` argument.

Fix #6855.