### PR TITLE
Expose preview mode to page and template rendering

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -43,6 +43,7 @@ Changelog
  * Use SVG icons in modeladmin headers and StreamField buttons/headers (Jérôme Lebleu)
  * Add tags to existing Django registered checks (LB Johnston)
  * Upgrade admin frontend JS libraries jQuery to 3.6.0 and Modernizr to 2.8.3 (Fabien Le Frapper)
+ * Added `request.preview_mode` so that template rendering can vary based on preview mode (Andy Chosak)
  * Fix: Delete button is now correct colour on snippets and modeladmin listings (Brandon Murch)
  * Fix: Ensure that StreamBlock / ListBlock-level validation errors are counted towards error counts (Matt Westcott)
  * Fix: InlinePanel add button is now keyboard navigatable (Jesse Menn)

--- a/docs/releases/2.15.rst
+++ b/docs/releases/2.15.rst
@@ -59,6 +59,7 @@ Other features
  * Use SVG icons in modeladmin headers and StreamField buttons/headers (Jérôme Lebleu)
  * Add tags to existing Django registered checks (LB Johnston)
  * Upgrade admin frontend JS libraries jQuery to 3.6.0 and Modernizr to 2.8.3 (Fabien Le Frapper)
+ * Added ``request.preview_mode`` so that template rendering can vary based on preview mode (Andy Chosak)
 
 Bug fixes
 ~~~~~~~~~

--- a/docs/topics/writing_templates.rst
+++ b/docs/topics/writing_templates.rst
@@ -297,3 +297,6 @@ Sometimes you may wish to vary the template output depending on whether the page
           ...
         </script>
     {% endif %}
+
+If the page is being previewed, ``request.preview_mode`` can be used to determine the specific preview mode being used,
+if the page supports :attr:`multiple preview modes <wagtail.core.models.Page.preview_modes>`.

--- a/wagtail/contrib/forms/models.py
+++ b/wagtail/contrib/forms/models.py
@@ -318,6 +318,7 @@ class AbstractForm(Page):
     def serve_preview(self, request, mode_name):
         if mode_name == 'landing':
             request.is_preview = True
+            request.preview_mode = mode_name
             return self.render_landing_page(request)
         else:
             return super().serve_preview(request, mode_name)

--- a/wagtail/contrib/routable_page/models.py
+++ b/wagtail/contrib/routable_page/models.py
@@ -166,6 +166,7 @@ class RoutablePageMixin:
     def serve_preview(self, request, mode_name):
         view, args, kwargs = self.resolve_subpage('/')
         request.is_preview = True
+        request.preview_mode = mode_name
 
         return view(request, *args, **kwargs)
 

--- a/wagtail/core/models/__init__.py
+++ b/wagtail/core/models/__init__.py
@@ -2131,6 +2131,7 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
         the wagtail user bar to be displayed. This request will always be a GET.
         """
         request.is_preview = True
+        request.preview_mode = mode_name
 
         response = self.serve(request)
         patch_cache_control(response, private=True)


### PR DESCRIPTION
Currently Wagtail defines `request.is_preview` as a way for both page rendering and template rendering to modify logic based on whether the page is being previewed.

If a page supports multiple preview modes, though, the information about which mode is being previewed isn't made available. So, for example, it's not possible to customize `Page.serve` or `Page.get_context` based on a different preview mode. Or, consider customizing `Page.get_template` so that it uses a different page template depending on the mode being previewed.

This commit adds `request.preview_mode` so that the mode is available downstream of previews, both in the page rendering logic and also in the template itself.

A minor documentation change ([preview](https://wagtail--7596.org.readthedocs.build/en/7596/topics/writing_templates.html#varying-output-between-preview-and-live)) mentions this new property:

![image](https://user-images.githubusercontent.com/654645/137198734-2683b8f5-a81d-4115-9425-ceb6003df41b.png)