### PR TITLE
Replace unneeded length filter

### DIFF
--- a/docs/getting_started/tutorial.md
+++ b/docs/getting_started/tutorial.md
@@ -731,7 +731,7 @@ you need to create a template `blog/blog_tag_index_page.html`:
 
 {% block content %}
 
-    {% if request.GET.tag|length %}
+    {% if request.GET.tag %}
         <h4>Showing pages tagged "{{ request.GET.tag }}"</h4>
     {% endif %}
 


### PR DESCRIPTION
I asked the question about using the `length` filter in https://github.com/wagtail/wagtail/discussions/7598 and I'm thinking it may not be needed anymore with the current version of Django that Wagtail supports.