### PR TITLE
Formally define / use COMMENTS_RELATION_NAME as a constant on wagtail.core.models

### DIFF
--- a/docs/releases/2.15.rst
+++ b/docs/releases/2.15.rst
@@ -200,3 +200,13 @@ that implement commenting. If you have any code that references the ``comments``
 (including fixture files), this should be updated to refer to ``wagtail_admin_comments`` instead.
 If this is not feasible, the previous behaviour can be restored by adding
 ``WAGTAIL_COMMENTS_RELATION_NAME = 'comments'`` to your project's settings.
+
+Reusable library code that needs to preserve backwards compatibility with previous Wagtail versions
+can find out the relation name as follows:
+
+.. code-block:: python
+
+    try:
+        from wagtail.core.models import COMMENTS_RELATION_NAME
+    except ImportError:
+        COMMENTS_RELATION_NAME = 'comments'

--- a/wagtail/admin/edit_handlers.py
+++ b/wagtail/admin/edit_handlers.py
@@ -22,7 +22,7 @@ from wagtail.admin import compare, widgets
 from wagtail.admin.forms.comments import CommentForm, CommentReplyForm
 from wagtail.admin.templatetags.wagtailadmin_tags import avatar_url, user_display_name
 from wagtail.core.fields import RichTextField
-from wagtail.core.models import Page
+from wagtail.core.models import COMMENTS_RELATION_NAME, Page
 from wagtail.core.utils import camelcase_to_underscore, resolve_model_string
 from wagtail.utils.decorators import cached_classmethod
 
@@ -32,9 +32,6 @@ from wagtail.utils.decorators import cached_classmethod
 from .forms.models import (  # NOQA
     DIRECT_FORM_FIELD_OVERRIDES, FORM_FIELD_OVERRIDES, WagtailAdminModelForm, formfield_for_dbfield)
 from .forms.pages import WagtailAdminPageForm
-
-
-COMMENTS_RELATION_NAME = getattr(settings, 'WAGTAIL_COMMENTS_RELATION_NAME', 'wagtail_admin_comments')
 
 
 def widget_with_script(widget, script):

--- a/wagtail/admin/views/pages/edit.py
+++ b/wagtail/admin/views/pages/edit.py
@@ -22,10 +22,8 @@ from wagtail.admin.views.generic import HookResponseMixin
 from wagtail.admin.views.pages.utils import get_valid_next_url_from_request
 from wagtail.core.exceptions import PageClassNotFoundError
 from wagtail.core.models import (
-    Comment, CommentReply, Page, PageSubscription, UserPagePermissionsProxy, WorkflowState)
-
-
-COMMENTS_RELATION_NAME = getattr(settings, 'WAGTAIL_COMMENTS_RELATION_NAME', 'wagtail_admin_comments')
+    COMMENTS_RELATION_NAME, Comment, CommentReply, Page, PageSubscription, UserPagePermissionsProxy,
+    WorkflowState)
 
 
 class EditView(TemplateResponseMixin, ContextMixin, HookResponseMixin, View):

--- a/wagtail/core/migrations/0062_comment_models_and_pagesubscription.py
+++ b/wagtail/core/migrations/0062_comment_models_and_pagesubscription.py
@@ -4,9 +4,7 @@ from django.conf import settings
 from django.db import migrations, models
 import django.db.models.deletion
 import modelcluster.fields
-
-
-COMMENTS_RELATION_NAME = getattr(settings, 'WAGTAIL_COMMENTS_RELATION_NAME', 'wagtail_admin_comments')
+from wagtail.core.models import COMMENTS_RELATION_NAME
 
 
 class Migration(migrations.Migration):


### PR DESCRIPTION
Follow-up to #7591 as per https://github.com/wagtail/wagtail/pull/7591#issuecomment-943217628