### PR TITLE
Add script for finding translated strings with broken placeholders

### DIFF
--- a/scripts/check-translation-strings.py
+++ b/scripts/check-translation-strings.py
@@ -1,0 +1,22 @@
+import re
+
+from pathlib import Path
+
+import polib
+
+
+placeholder_regexp = re.compile(r'\{[^\}]*?\}')
+
+for path in Path(__file__).parent.resolve().parent.rglob('LC_MESSAGES/*.po'):
+    po = polib.pofile(path)
+    for entry in po:
+        if not entry.msgstr:
+            continue  # ignore untranslated strings
+
+        expected_placeholders = set(placeholder_regexp.findall(entry.msgid))
+        actual_placeholders = set(placeholder_regexp.findall(entry.msgstr))
+        if expected_placeholders != actual_placeholders:
+            print("Invalid string at %s line %d:" % (path, entry.linenum))
+            print("\toriginal string %r has placeholders: %r" % (entry.msgid, expected_placeholders))
+            print("\ttranslated string %r has placeholders: %r" % (entry.msgstr, actual_placeholders))
+            print()

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,9 @@ testing_extras = [
     # django-taggit 1.3.0 made changes to verbose_name which affect migrations;
     # the test suite migrations correspond to >=1.3.0
     'django-taggit>=1.3.0,<2.0',
+
+    # for validating string formats in .po translation files
+    'polib>=1.1,<2.0',
 ]
 
 # Documentation dependencies


### PR DESCRIPTION
Transifex does not validate new-style format strings with braces, only old-style %s strings, so it's common for inconsistencies between the original and translated strings to arise, causing hard errors which won't get caught in our pre-release testing unless we happen to be using that language. This script finds them.

Current output when run against current main:
```
Invalid string at /Users/matthew/Development/tbx/wagtail/devscript/wagtail/wagtail/admin/locale/mi/LC_MESSAGES/django.po line 325:
	original string "Edit '{title}'" has placeholders: {'{title}'}
	translated string "Whakarerekē '{taitara}'" has placeholders: {'{taitara}'}

Invalid string at /Users/matthew/Development/tbx/wagtail/devscript/wagtail/wagtail/admin/locale/mi/LC_MESSAGES/django.po line 328:
	original string "View child pages of '{title}'" has placeholders: {'{title}'}
	translated string "Tirohia ki ngā whārangi tamariki ō '{taitara}'" has placeholders: {'{taitara}'}

Invalid string at /Users/matthew/Development/tbx/wagtail/devscript/wagtail/wagtail/admin/locale/hr_HR/LC_MESSAGES/django.po line 1801:
	original string "<b>Page '{}' was locked</b> by <b>you</b> on <b>{}</b>." has placeholders: set()
	translated string "<b>Stranicu '{0}' ste zaključali</b> <b>vi</b> na dan <b>{}</b>." has placeholders: {'{0}'}

Invalid string at /Users/matthew/Development/tbx/wagtail/devscript/wagtail/wagtail/admin/locale/hr_HR/LC_MESSAGES/django.po line 1804:
	original string "<b>Page '{}' is locked</b> by <b>you</b>." has placeholders: set()
	translated string "<b>Stranicu '{0}' ste zaključali</b> <b>vi</b>." has placeholders: {'{0}'}

Invalid string at /Users/matthew/Development/tbx/wagtail/devscript/wagtail/wagtail/admin/locale/hr_HR/LC_MESSAGES/django.po line 1807:
	original string "<b>Page '{}' was locked</b> by <b>{}</b> on <b>{}</b>." has placeholders: set()
	translated string "<b>Stranicu '{0}' je zaključao</b> korisnik <b>{}</b> na dan <b>{}</b>." has placeholders: {'{0}'}

Invalid string at /Users/matthew/Development/tbx/wagtail/devscript/wagtail/wagtail/admin/locale/tet/LC_MESSAGES/django.po line 266:
	original string "Edit '{title}'" has placeholders: {'{title}'}
	translated string " Edit '{titulu}'" has placeholders: {'{titulu}'}

Invalid string at /Users/matthew/Development/tbx/wagtail/devscript/wagtail/wagtail/contrib/search_promotions/locale/tet/LC_MESSAGES/django.po line 118:
	original string "Editor's picks for '{0}' updated." has placeholders: {'{0}'}
	translated string 'Hadia nain hatudu katak ba 0 atualiza.' has placeholders: set()

Invalid string at /Users/matthew/Development/tbx/wagtail/devscript/wagtail/wagtail/contrib/search_promotions/locale/gl/LC_MESSAGES/django.po line 167:
	original string "Editor's picks deleted." has placeholders: set()
	translated string "Seleccións do editor para '{0}' eliminadas." has placeholders: {'{0}'}

Invalid string at /Users/matthew/Development/tbx/wagtail/devscript/wagtail/wagtail/contrib/search_promotions/locale/es/LC_MESSAGES/django.po line 204:
	original string "Editor's picks deleted." has placeholders: set()
	translated string "Selecciones del editor para '{0}' eliminadas." has placeholders: {'{0}'}

Invalid string at /Users/matthew/Development/tbx/wagtail/devscript/wagtail/wagtail/users/locale/hr_HR/LC_MESSAGES/django.po line 331:
	original string "User '{0}' created." has placeholders: {'{0}'}
	translated string "Korisnik '{0'} je stvoren." has placeholders: {"{0'}"}
```