### PR TITLE
Fix checkboxes appearing always checked in Windows high contrast mode

### DIFF
--- a/client/scss/elements/_forms.scss
+++ b/client/scss/elements/_forms.scss
@@ -227,17 +227,17 @@ input[type=checkbox]:before {
     top: -5px;
     cursor: pointer;
     display: block;
-    content: map-get($icons, 'tick');
+    content: '';
     line-height: 20px;
     width: 20px;
     height: 20px;
     background-color: $color-white;
     border: 1px solid $color-grey-4;
-    color: $color-white;
+    color: $color-teal;
 }
 
 input[type=checkbox]:checked:before {
-    color: $color-teal;
+    content: map-get($icons, 'tick');
 }
 
 input[type=checkbox][disabled]:before {


### PR DESCRIPTION
Spotted as part of testing bulk actions (#7573). Checkboxes appeared always checked regardless of their state, due to how they were styled. This issue is present on all checkboxes in Wagtail, but becomes much more apparent with bulk actions adding checkboxes to all listing views.

Screenshot in Windows high contrast mode:

![screenshot of wagtail checkboxes in windows high contrast mode](https://user-images.githubusercontent.com/877585/137342969-7fb8ff64-9819-4a3e-8208-927b2b652601.png)

Additionally I’ve slightly improved the focus outline for checkboxes – it’s still not what we’d ideally want, but the vertical positioning of checkboxes is done very strangely, and I didn’t want to risk shifting page layouts by changing that. The proposed changes only affect the focus outline, with layout being identical before/after.

---

Tested in:

- Google Chrome macOS
- Firefox macOS
- Safari macOS
- Google Chrome Windows 10
- Microsoft Edge macOS
- Safari iOS 14
- Google Chrome Android 11