### PR TITLE
Add border to comments dropdown

### DIFF
--- a/client/scss/components/_comments-notification-dropdown.scss
+++ b/client/scss/components/_comments-notification-dropdown.scss
@@ -38,7 +38,7 @@
     border-radius: 6px;
     min-width: 260px;
     box-sizing: border-box;
-    border: 1px solid $color-text-base
+    border: 1px solid $color-text-base;
 
     &__title {
         font-size: 12px;


### PR DESCRIPTION
Added a border to the comments drop-down. Cannot test against Windows high contrast because I do not have access to a Windows machine or the Edge browser. Can someone validate? This is a simple change, so a border should have been added. 

Closes  #7458. 