### PR TITLE
Fix  reference after_bulk_action

### DIFF
--- a/docs/releases/2.15.rst
+++ b/docs/releases/2.15.rst
@@ -298,5 +298,5 @@ Bulk action views provide alternative routes to actions like publishing or copyi
 If your site relies on hooks like ``before_publish_page`` or ``before_copy_page`` to perform
 checks, or add additional functionality, those hooks will not be called on the
 corresponding bulk action views. If you want to add this to the bulk action views as well,
-use the new bulk action hooks: :ref:`before_bulk_action` and :ref:`after bulk actions`.
+use the new bulk action hooks: :ref:`before_bulk_action` and :ref:`after_bulk_action`.
 


### PR DESCRIPTION
Fix ref, `.. _after_bulk_action:` is at docs/reference/hooks.rst:1449

This should also go into wagtail:stable/2.15.x