### PR TITLE
Fix TableBlock -> TypedTableBlock in code samples

### DIFF
--- a/docs/reference/contrib/typed_table_block.md
+++ b/docs/reference/contrib/typed_table_block.md
@@ -30,7 +30,7 @@ from wagtail.images.blocks import ImageChooserBlock
 class DemoStreamBlock(blocks.StreamBlock):
     title = blocks.CharBlock()
     paragraph = blocks.RichTextBlock()
-    table = TableBlock([
+    table = TypedTableBlock([
         ('text', blocks.CharBlock()),
         ('numeric', blocks.FloatBlock()),
         ('rich_text', blocks.RichTextBlock()),
@@ -41,20 +41,20 @@ class DemoStreamBlock(blocks.StreamBlock):
 To keep the UI as simple as possible for authors, it's generally recommended to use Wagtail's basic built-in block types as column types, as above. However, all custom block types and parameters are supported. For example, to define a 'country' column type consisting of a dropdown of country choices:
 
 ```python
-    table = TableBlock([
-        ('text', blocks.CharBlock()),
-        ('numeric', blocks.FloatBlock()),
-        ('rich_text', blocks.RichTextBlock()),
-        ('image', ImageChooserBlock()),
-        ('country', ChoiceBlock(choices=[
-            ('be', 'Belgium'),
-            ('fr', 'France'),
-            ('de', 'Germany'),
-            ('nl', 'Netherlands'),
-            ('pl', 'Poland'),
-            ('uk', 'United Kingdom'),
-        ])),
-    ])
+table = TypedTableBlock([
+    ('text', blocks.CharBlock()),
+    ('numeric', blocks.FloatBlock()),
+    ('rich_text', blocks.RichTextBlock()),
+    ('image', ImageChooserBlock()),
+    ('country', ChoiceBlock(choices=[
+        ('be', 'Belgium'),
+        ('fr', 'France'),
+        ('de', 'Germany'),
+        ('nl', 'Netherlands'),
+        ('pl', 'Poland'),
+        ('uk', 'United Kingdom'),
+    ])),
+])
 ```
 
 On your page template, the `{% include_block %}` tag (called on either the individual block, or the StreamField value as a whole) will render any typed table blocks as an HTML `<table>` element.


### PR DESCRIPTION
Fix TableBlock -> TypedTableBlock in code samples.

This should also go into wagtail:stable/2.15.x