### PR TITLE
Fix Dashboard icons in high-contrast mode

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -6,6 +6,7 @@ Changelog
 
  * Added Aging Pages report (Tidjani Dia)
  * Add more SketchFab oEmbed patterns for models (Tom Usher)
+ * Fix: Accessibility fixes for Windows high contrast mode; Dashboard icons colour and contrast (Sakshi Uppoor)
 
 
 2.15.1 (11.11.2021)

--- a/docs/releases/2.16.md
+++ b/docs/releases/2.16.md
@@ -17,7 +17,7 @@
 
 ### Bug fixes
 
- * ...
+ * Accessibility fixes for Windows high contrast mode; Dashboard icons colour and contrast (Sakshi Uppoor)
 
 
 ## Upgrade considerations

--- a/wagtail/admin/static_src/wagtailadmin/scss/layouts/home.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/layouts/home.scss
@@ -66,6 +66,12 @@ header {
             @include media-breakpoint-down(xs) {
                 font-size: 4em;
             }
+
+            // Media for Windows High Contrast Mode
+            @media (forced-colors: $media-forced-colours) {
+                color: $system-color-link-text;
+                opacity: 1;
+            }
         }
 
         a {


### PR DESCRIPTION
Fixes #7325 

Screenshots:
Before:
![image](https://user-images.githubusercontent.com/46474346/138129576-0bc81f64-a2dc-4163-a6c1-77bc52a3e55a.png)

After:
![image](https://user-images.githubusercontent.com/46474346/138129652-2d3dd5e3-418e-4981-a7c5-2770dca01ab8.png)

Tested on:

OS: Windows 10 Normal & High-Contrast mode
Browsers:
Google Chrome - Version 94.0.4606.81 (Official Build) (64-bit)
Mozilla Firefox - Version 92.0.1 (64-bit)
Microsoft Edge - Version 94.0.992.50 (Official build) (64-bit)