### PR TITLE
Add more SketchFab oembed patterns

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,6 +5,7 @@ Changelog
 ~~~~~~~~~~~~~~~~~
 
  * Added Aging Pages report (Tidjani Dia)
+ * Add more SketchFab oEmbed patterns for models (Tom Usher)
 
 
 2.15.1 (11.11.2021)

--- a/docs/releases/2.16.md
+++ b/docs/releases/2.16.md
@@ -12,6 +12,7 @@
 ### Other features
 
  * Added Aging Pages report (Tidjani Dia)
+ * Add more SketchFab oEmbed patterns for models (Tom Usher)
 
 
 ### Bug fixes

--- a/wagtail/embeds/oembed_providers.py
+++ b/wagtail/embeds/oembed_providers.py
@@ -545,6 +545,8 @@ sketchfab = {
     "endpoint": "https://sketchfab.com/oembed",
     "urls": [
         r'^https?://sketchfab\.com/show/.+$',
+        r'^https?://sketchfab\.com/models/.+$',
+        r'^https?://sketchfab\.com/3d-models/.+$',
     ],
 }
 


### PR DESCRIPTION
Adding a few additional patterns for the Sketchfab oEmbed provider.

- The existing `/show` pattern is not referenced anywhere on the Sketchfab site, but still seems to work when passed to the oEmbed endpoint.
- The `/models` pattern is what is documented in the [Sketchfab oEmbed docs](https://sketchfab.com/developers/oembed).
- The `/3d-models` pattern is what you'd get by copying and pasting the URL from browsing the site - this seems to work when passed to the oEmbed endpoint too.