### PR TITLE
Label edit actions as 'Edited' instead of 'Draft saved' for non Page models

### DIFF
--- a/docs/extending/audit_log.rst
+++ b/docs/extending/audit_log.rst
@@ -61,9 +61,9 @@ Log actions provided by Wagtail
 ===================================  =====
 Action                               Notes
 ===================================  =====
-``wagtail.create``                   The page was created
-``wagtail.edit``                     A draft was saved
-``wagtail.delete``                   The page was deleted. Will only surface in the Site History for administrators
+``wagtail.create``                   The object was created
+``wagtail.edit``                     The object was edited (for pages, saved as draft)
+``wagtail.delete``                   The object was deleted. Will only surface in the Site History for administrators
 ``wagtail.publish``                  The page was published
 ``wagtail.publish.schedule``         Draft is scheduled for publishing
 ``wagtail.publish.scheduled``        Draft published via ``publish_scheduled_pages`` management command

--- a/wagtail/core/models/__init__.py
+++ b/wagtail/core/models/__init__.py
@@ -4063,6 +4063,14 @@ class PageLogEntry(BaseLogEntry):
     def object_id(self):
         return self.page_id
 
+    @cached_property
+    def message(self):
+        # for page log entries, the 'edit' action should show as 'Draft saved'
+        if self.action == 'wagtail.edit':
+            return _("Draft saved")
+        else:
+            return super().message
+
 
 class Comment(ClusterableModel):
     """

--- a/wagtail/core/wagtail_hooks.py
+++ b/wagtail/core/wagtail_hooks.py
@@ -97,7 +97,7 @@ def register_core_log_actions(actions):
     actions.register_model(Page, PageLogEntry)
 
     actions.register_action('wagtail.create', _('Create'), _('Created'))
-    actions.register_action('wagtail.edit', _('Save draft'), _('Draft saved'))
+    actions.register_action('wagtail.edit', _('Edit'), _('Edited'))
     actions.register_action('wagtail.delete', _('Delete'), _('Deleted'))
     actions.register_action('wagtail.publish', _('Publish'), _('Published'))
     actions.register_action('wagtail.publish.scheduled', _("Publish scheduled draft"), _('Published scheduled draft'))


### PR DESCRIPTION
Fixes #7622
