### PR TITLE
Fix comment buttons not displaying correctly in forced colors mode

### DIFF
--- a/client/scss/components/_forms.scss
+++ b/client/scss/components/_forms.scss
@@ -519,6 +519,11 @@ li.inline:first-child {
                 width: 30px;
                 height: 30px;
                 color: $color-teal;
+
+                @media (forced-colors: $media-forced-colours) {
+                    color: ButtonText;
+                    border: 1px solid;
+                }
             }
         }
     }


### PR DESCRIPTION
This fixes Issue #7459 

Tested on Chrome and Firefox, with results shown below. There is some other issues with firefox namely the comment 'dropdown' looking a bit out of place.

Chrome:
<img width="761" alt="onHighContrast" src="https://user-images.githubusercontent.com/1568832/138568436-65f0a7d8-ce66-4a81-b260-9f878ce66ac4.PNG">

Firefox:
<img width="1138" alt="firefoxHighContrast" src="https://user-images.githubusercontent.com/1568832/138568485-c61b44f9-61e9-4148-991d-6b8c992610d0.PNG">
These black backgrounds around the comment and dropdown are applied by firefox  and can't be overriden

Let me know if any additional changes are needed.
