### PR TITLE
Fix gulp watch to correctly watch files

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -39,6 +39,7 @@ Changelog
  * Fix: Icon only button styling issue on small devices where height would not be set correctly (Vu Pham)
  * Fix: Add padding to the Draftail editor to ensure `ol` items are not cut off (Khanh Hoang)
  * Fix: Prevent opening choosers multiple times for Image, Page, Document, Snippet (LB (Ben Johnston))
+ * Fix: Ensure subsequent changes to styles files are picked up wby Gulp watch (Jason Attwood)
 
 
 2.15.2 (xx.xx.xxxx) - IN DEVELOPMENT

--- a/docs/releases/2.16.md
+++ b/docs/releases/2.16.md
@@ -44,6 +44,7 @@
  * Fix icon only button styling issue on small devices where height would not be set correctly (Vu Pham)
  * Add padding to the Draftail editor to ensure `ol` items are not cut off (Khanh Hoang)
  * Prevent opening choosers multiple times for Image, Page, Document, Snippet (LB (Ben Johnston))
+ * Ensure subsequent changes to styles files are picked up wby Gulp watch (Jason Attwood)
 
 ## Upgrade considerations
 

--- a/gulpfile.js/tasks/watch.js
+++ b/gulpfile.js/tasks/watch.js
@@ -1,23 +1,40 @@
-var gulp = require('gulp');
-var path = require('path');
-var config = require('../config');
+var gulp = require("gulp");
+var path = require("path");
+var config = require("../config");
 
+const paths = config.apps.reduce(
+  (_, app) => ({
+    "styles:sass": [
+      ...(_["styles:sass"] || []),
+      path.join(app.sourceFiles, "*/scss/**"),
+    ],
+    "styles:css": [
+      ...(_["styles:css"] || []),
+      path.join(app.sourceFiles, "*/css/**"),
+    ],
+    scripts: [...(_["scripts"] || []), path.join(app.sourceFiles, "*/js/**")],
+    images: [...(_["images"] || []), path.join(app.sourceFiles, "*/images/**")],
+    fonts: [...(_["fonts"] || []), path.join(app.sourceFiles, "*/fonts/**")],
+  }),
+  {}
+);
 
-const paths = config.apps.reduce((_, app) => ({
-    'styles:sass': [...(_['styles:sass'] || []), path.join('./client/**/*.scss'), path.join(app.sourceFiles, '*/scss/**')],
-    'styles:css': [...(_['styles:css'] || []), path.join(app.sourceFiles, '*/css/**')],
-    'scripts': [...(_['scripts'] || []), path.join(app.sourceFiles, '*/js/**')],
-    'images': [...(_['images'] || []), path.join(app.sourceFiles, '*/images/**')],
-    'fonts': [...(_['fonts'] || []), path.join(app.sourceFiles, '*/fonts/**')],
-}), {});
+paths["styles:sass"] = [...paths["styles:sass"], "./client/**/*.scss"];
+
+var gulpOptions = {
+  cwd: path.resolve("."),
+};
 
 /*
  * Watch - Watch files, trigger tasks when they are modified
  */
-gulp.task('watch', gulp.series('build', function (cb) {
-    gulp.watch(paths['styles:sass'], gulp.series('styles:sass'));
-    gulp.watch(paths['styles:css'], gulp.series('styles:css'));
-    gulp.watch(paths['scripts'], gulp.series('scripts'));
-    gulp.watch(paths['images' ], gulp.series('images' ));
-    gulp.watch(paths['fonts' ], gulp.series('fonts' ));    
-}));
+gulp.task(
+  "watch",
+  gulp.series("build", function (cb) {
+    gulp.watch(paths["styles:sass"], gulpOptions, gulp.series("styles:sass"));
+    gulp.watch(paths["styles:css"], gulpOptions, gulp.series("styles:css"));
+    gulp.watch(paths["scripts"], gulpOptions, gulp.series("scripts"));
+    gulp.watch(paths["images"], gulpOptions, gulp.series("images"));
+    gulp.watch(paths["fonts"], gulpOptions, gulp.series("fonts"));
+  })
+);


### PR DESCRIPTION
This is an issue I ran into while trying to modify the style for some of the high contrast issues. Gulp didn't seem to be watching files correctly (it was correctly building them on the first time around but any subsequent changes weren't picked up). This turned out to be down to the cwd not being set correctly. 

Also the client styles path was being added numerous times due to it being used in a reduce statement, so I pulled it out and just added it once after the reduce is done.

Let me know if there is any concerns with the changes below!