### PR TITLE
Navigation support for page-editing dropdown

### DIFF
--- a/client/scss/components/_dropdown.legacy.scss
+++ b/client/scss/components/_dropdown.legacy.scss
@@ -9,7 +9,7 @@
     .button {
         padding: 0 5em 0 1em;
         display: block;
-        width: 100%;
+        width: 300px;
         height: 3em;
         line-height: 3em;
         text-align: left;
@@ -158,7 +158,9 @@
         cursor: pointer;
         height: 100%;
         border-left: 1px solid rgba(255, 255, 255, 0.2);
-        position: absolute;
+        position: relative;
+        float: right;
+        width: 15px;
         right: 0;
         padding: 0 0.5em;
         text-align: center;

--- a/client/src/entrypoints/admin/dropdown.js
+++ b/client/src/entrypoints/admin/dropdown.js
@@ -1,0 +1,87 @@
+// JavaScript source code
+import $ from 'jquery';
+
+$('.dropdown').each(function () {
+  const $dropdown = $(this);
+
+  $('.dropdown-toggle', $dropdown).on('click', (e) => {
+    e.stopPropagation();
+    $dropdown.toggleClass('open');
+    if ($dropdown.hasClass('open')) {
+      // If a dropdown is opened, add an event listener for document clicks to close it
+      $(document).on('click.dropdown.cancel', (e2) => {
+        const relTarg = e2.relatedTarget || e2.toElement;
+
+        // Only close dropdown if the click target wasn't a child of this dropdown
+        if (!$(relTarg).parents().is($dropdown)) {
+          $dropdown.removeClass('open');
+          $(document).off('click.dropdown.cancel');
+        }
+      });
+    } else {
+      $(document).off('click.dropdown.cancel');
+    }
+  });
+});
+
+function controlbykey(event, listItems, currentIndex) {
+  const $dropdown = $(document.querySelectorAll('.dropdown')[0]);
+  var Items = listItems;
+  var prevIndex = Math.max(0, currentIndex - 1);
+  var nextIndex = Math.min(listItems.length - 1, currentIndex + 1);
+
+  // Control closes dropdown when Escape keydown
+  if (event.key === 'Escape') {
+    $dropdown.removeClass('open');
+  }
+
+  // Control By Arrow Up, Down, Home, End
+  switch (event.key) {
+  case 'ArrowUp':
+    event.preventDefault();
+    Items[prevIndex].firstElementChild.tabIndex = 0;
+    Items[prevIndex].firstElementChild.focus();
+    break;
+  case 'ArrowDown':
+    event.preventDefault();
+    Items[nextIndex].firstElementChild.tabIndex = 0;
+    Items[nextIndex].firstElementChild.focus();
+    break;
+  case 'Home':
+    event.preventDefault();
+    Items[0].firstElementChild.tabIndex = 0;
+    Items[0].firstElementChild.focus();
+    break;
+  case 'End':
+    event.preventDefault();
+    Items[listItems.length - 1].firstElementChild.tabIndex = 0;
+    Items[listItems.length - 1].firstElementChild.focus();
+    break;
+  default:
+    break;
+  }
+}
+
+// Invoke on: dropdown toggle button keydown
+$('.dropdown-toggle').on('keydown', (e) => {
+  const $dropdown = $(document.querySelectorAll('.dropdown')[0]);
+  const listItems = document.querySelectorAll('.dropdown li');
+  const currentIndex = -1;
+  e.stopPropagation();
+  if ($dropdown.hasClass('open')) {
+    controlbykey(e, listItems, currentIndex);
+  }
+});
+
+// Invoke on: dropdown item keydown
+$('.dropdown ul li a, .dropdown ul li button').on('keydown', (e) => {
+  const $dropdown = $(document.querySelectorAll('.dropdown')[0]);
+  const listitems = Array.prototype.slice.call(document.querySelectorAll('.dropdown li'));
+  var currentIndex = listitems.indexOf(document.activeElement.parentElement);
+  e.stopPropagation();
+  if ($dropdown.hasClass('open')) {
+    controlbykey(e, listitems, currentIndex);
+  } else {
+    $dropdown.toggleClass('open');
+  }
+});

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -33,6 +33,7 @@ module.exports = function exports() {
       'core',
       'date-time-chooser',
       'draftail',
+      'dropdown',
       'expanding_formset',
       'filtered-select',
       'hallo-bootstrap',

--- a/wagtail/admin/templates/wagtailadmin/admin_base.html
+++ b/wagtail/admin/templates/wagtailadmin/admin_base.html
@@ -50,6 +50,7 @@
     <script src="{% versioned_static 'wagtailadmin/js/vendor/bootstrap-tab.js' %}"></script>
     <script src="{% versioned_static 'wagtailadmin/js/vendor/tag-it.js' %}"></script>
     <script src="{% versioned_static 'wagtailadmin/js/core.js' %}"></script>
+    <script src="{% versioned_static 'wagtailadmin/js/dropdown.js' %}"></script>
     <script src="{% versioned_static 'wagtailadmin/js/vendor.js' %}"></script>
     <script src="{% versioned_static 'wagtailadmin/js/wagtailadmin.js' %}"></script>
     {% hook_output 'insert_global_admin_js' %}

--- a/wagtail/admin/templates/wagtailadmin/pages/action_menu/menu.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/action_menu/menu.html
@@ -3,7 +3,7 @@
     {{ default_menu_item }}
 {% endif %}
 {% if show_menu %}
-    <div class="dropdown-toggle">{% icon name="arrow-up" %}</div>
+    <button type="button" class="dropdown-toggle">{% icon name="arrow-up" %}</button>
     <ul>
         {% for item in rendered_menu_items %}
             <li>


### PR DESCRIPTION
Follow up for #7525
Tested on: Windows 10
Google Chrome: Latest version
Frontend tests pass

Added keyboard navigation to the edit page actions dropdown. 
Added a separate file for dropdowns
