### PR TITLE
Fixes #7450 Issues with Dropdowns in High contrast mode

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -34,7 +34,7 @@ Changelog
  * Improve display of image listing for long image titles (Krzysztof Jeziorny)
  * Use SVG icons in admin home page site summary items (Jérôme Lebleu)
  * Ensure site summary items wrap on smaller devices on the admin home page (Jérôme Lebleu)
- * Fix: Accessibility fixes for Windows high contrast mode; Dashboard icons colour and contrast, help/error/warning blocks for fields and general content, side comment buttons within the page editor (Sakshi Uppoor, Shariq Jamil, LB (Ben Johnston), Jason Attwood)
+ * Fix: Accessibility fixes for Windows high contrast mode; Dashboard icons colour and contrast, help/error/warning blocks for fields and general content, side comment buttons within the page editor, dropdown buttons (Sakshi Uppoor, Shariq Jamil, LB (Ben Johnston), Jason Attwood)
  * Fix: Rename additional 'spin' CSS animations to avoid clashes with other libraries (Kevin Gutiérrez)
  * Fix: `default_app_config` deprecations for Django >= 3.2 (Tibor Leupold)
  * Fix: Refresh page from database on create before passing to hooks. Page aliases get correct `first_published_date` and `last_published_date` (Dan Braghis)

--- a/client/scss/components/_dropdown.legacy.scss
+++ b/client/scss/components/_dropdown.legacy.scss
@@ -52,6 +52,14 @@
 
         // Media for Windows High Contrast
         @media (forced-colors: $media-forced-colours) {
+            li {
+                border-width: 1px;
+            }
+
+            li:hover {
+                border-color: Highlight;
+            }
+
             li a,
             li button {
                 forced-color-adjust: none;
@@ -200,8 +208,37 @@
 
     // Styles for dropdowns which are also buttons e.g page editor
     &.dropdown-button {
+        // Media for Windows High Contrast
+        @media (forced-colors: $media-forced-colours) {
+            button {
+                border-color: ActiveText;
+            }
+
+            button:hover {
+                border-color: Highlight;
+            }
+
+            a.button.bicolor.button:hover {
+                border-color: Highlight;
+            }
+        }
+
         .dropdown-toggle {
             border-radius: 0 3px 3px 0;
+            // Media for Windows High Contrast
+            @media (forced-colors: $media-forced-colours) {
+                background: transparent;
+                box-sizing: border-box;
+                border: 1px solid ActiveText;
+            }
+        }
+
+        .dropdown-toggle:hover {
+            // Media for Windows High Contrast
+            @media (forced-colors: $media-forced-colours) {
+                background-color: transparent;
+                border: 1px solid Highlight;
+            }
         }
 
         &.open {

--- a/docs/releases/2.16.md
+++ b/docs/releases/2.16.md
@@ -40,7 +40,7 @@
 
 ### Bug fixes
 
- * Accessibility fixes for Windows high contrast mode; Dashboard icons colour and contrast, help/error/warning blocks for fields and general content, side comment buttons within the page editor (Sakshi Uppoor, Shariq Jamil, LB (Ben Johnston), Jason Attwood)
+ * Accessibility fixes for Windows high contrast mode; Dashboard icons colour and contrast, help/error/warning blocks for fields and general content, side comment buttons within the page editor, dropdown buttons (Sakshi Uppoor, Shariq Jamil, LB (Ben Johnston), Jason Attwood)
  * Rename additional 'spin' CSS animations to avoid clashes with other libraries (Kevin Gutiérrez)
  * Pages are refreshed from database on create before passing to hooks. Page aliases get correct `first_published_date` and `last_published_date` (Dan Braghis)
  * Additional login form fields from `WAGTAILADMIN_USER_LOGIN_FORM` are now rendered correctly (Michael Karamuth)


### PR DESCRIPTION
Fixes #7450 Issue with high contrast examples of how the changes look are shown below:
Chrome:
![DropdownFix](https://user-images.githubusercontent.com/1568832/138866562-2478609d-bfeb-43ff-a0e5-c240bc817e77.gif)

![DropdownFix2](https://user-images.githubusercontent.com/1568832/138866572-fa5aefc2-c50a-403b-9950-3c02ac002829.gif)

As with my previous MR its worth noting there are significant differences in Firefox as it seems to be a lot more restrictive with what custom styling it allows, which is seemingly due to the fact it doesn't currently support forced-color-adjust. (Although hopefully once it begins to support that all the changes that apply to Chrome/Safari should easily transfer over)



