### PR TITLE
Make cross-link URLs on generic model views optional

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -15,6 +15,7 @@ Changelog
  * Add informational Codecov status checks for GitHub CI pipelines (Tom Hu)
  * Replace `PageRevision` with generic `Revision` model (Sage Abdullah)
  * Make it possible to reuse and customise Wagtail’s fonts with CSS variables (LB (Ben) Johnston)
+ * Add better handling and informative developer errors for cross linking URLS (e.g. success after add) in generic views `wagtail.admin.views.generic` (Matt Westcott)
  * Fix: Typo in `ResumeWorkflowActionFormatter` message (Stefan Hammer)
  * Fix: Throw a meaningful error when saving an image to an unrecognised image format (Christian Franke)
  * Fix: Remove extra padding for headers with breadcrumbs on mobile viewport (Steven Steinwand)

--- a/docs/releases/4.0.md
+++ b/docs/releases/4.0.md
@@ -20,6 +20,7 @@ depth: 1
  * Use `FormData` instead of jQuery's `form.serialize` when editing documents or images just added so that additional fields can be better supported (Stefan Hammer)
  * Add informational Codecov status checks for GitHub CI pipelines (Tom Hu)
  * Make it possible to reuse and customise Wagtail’s fonts with CSS variables (LB (Ben) Johnston)
+ * Add better handling and informative developer errors for cross linking URLS (e.g. success after add) in generic views `wagtail.admin.views.generic` (Matt Westcott)
 
 ### Bug fixes
 

--- a/wagtail/admin/templates/wagtailadmin/generic/edit.html
+++ b/wagtail/admin/templates/wagtailadmin/generic/edit.html
@@ -3,7 +3,7 @@
 
 {% block actions %}
     <input type="submit" value="{% trans 'Save' %}" class="button" />
-    {% if can_delete %}
+    {% if delete_url %}
         <a href="{{ delete_url }}" class="button button-secondary no">{{ delete_item_label }}</a>
     {% endif %}
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/generic/index.html
+++ b/wagtail/admin/templates/wagtailadmin/generic/index.html
@@ -4,9 +4,8 @@
 {% block titletag %}{{ page_title }} {{ page_subtitle }}{% endblock %}
 
 {% block content %}
-    {% if can_add %}
-        {% url view.add_url_name as add_link %}
-        {% include "wagtailadmin/shared/header.html" with title=page_title subtitle=page_subtitle action_url=add_link action_text=view.add_item_label icon=header_icon only %}
+    {% if add_url %}
+        {% include "wagtailadmin/shared/header.html" with title=page_title subtitle=page_subtitle action_url=add_url action_text=add_item_label icon=header_icon only %}
     {% else %}
         {% include "wagtailadmin/shared/header.html" with title=page_title subtitle=page_subtitle icon=header_icon only %}
     {% endif %}


### PR DESCRIPTION
Normally, generic model views will be spun up through wagtail.admin.viewsets, which takes care of configuring the add_url_name / edit_url_name etc attributes to ensure that they are cross-linked appropriately. But if you're defining one in isolation, that's an unnecessary hoop to jump through, and the error messages if you don't specify them are fairly opaque. Fix this so that:

1. Non-essential cross-links (e.g. the Add button on the index view, and the Delete button on the edit view) are gracefully omitted if the URLs are undefined;
2. Essential cross-links (e.g. the destination of the redirect after a successful form submission) raise an informative error telling the developer what needs to be defined.
