### PR TITLE
Add border to help-block to make it more identifiable in high contrast mode

### DIFF
--- a/client/scss/components/_forms.scss
+++ b/client/scss/components/_forms.scss
@@ -128,6 +128,8 @@ select::-ms-expand {
 
 .help {
     color: $color-grey-2;
+    border: 1px solid $color-text-base;
+    padding-bottom: 1em;
 }
 
 fieldset:hover > .help,


### PR DESCRIPTION
Added a border to the help block for more visibility in high contrast mode. I used border conventions similar to other high contrast features in this project. Closes #7447
![help](https://user-images.githubusercontent.com/2559167/139171072-f324181d-b50c-470b-83a3-8febfdfb9358.png)
. 