### PR TITLE
fix issue where nested inline panel fix broke inline panel ordering/delete

### DIFF
--- a/client/src/entrypoints/admin/page-editor.js
+++ b/client/src/entrypoints/admin/page-editor.js
@@ -165,7 +165,7 @@ function InlinePanel(opts) {  // lgtm[js/unused-local-variable]
   // eslint-disable-next-line no-undef
   buildExpandingFormset(opts.formsetPrefix, {
     onAdd(formCount) {
-      const newChildPrefix = opts.emptyChildFormPrefix.replace(/__prefix__(.*?['"])/g, formCount + '$1');
+      const newChildPrefix = opts.emptyChildFormPrefix.replace(/__prefix__/g, formCount);
       self.initChildControls(newChildPrefix);
       if (opts.canOrder) {
         /* NB form hidden inputs use 0-based index and only increment formCount *after* this function is run.


### PR DESCRIPTION
* An issue with the fix for #5770  - 17be0765dbddfd9b998b732486d6ba9499a4c82f
* This fix also updated the `newChildPrefix` in the page editor js, but this reference was incorrect
* This meant that the page editor version of ALL inline panels would break the delete/ordering buttons for newly entered items
* I have reverted this fix and done a few more tests for the page editor versions of inline panels and it appears to have resolved it