### PR TITLE
Fixes #7241 and improves error visibility in high-contrast

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -19,6 +19,7 @@ Changelog
  * Improve CircleCI frontend & backend build caches (Thibaud Colas)
  * Add a 'remember me' checkbox to the admin sign in form, if unticked (default) the auth session will expire if the browser is closed (Michael Karamuth, Jake Howard)
  * When returning to image or document listing views after editing, filters (collection or tag) are now remembered (Tidjani Dia)
+ * Improve the visibility of field error messages, in Windows high-contrast mode and out (Jason Attwood)
  * Fix: Accessibility fixes for Windows high contrast mode; Dashboard icons colour and contrast (Sakshi Uppoor)
  * Fix: Rename additional 'spin' CSS animations to avoid clashes with other libraries (Kevin Gutiérrez)
  * Fix: `default_app_config` deprecations for Django >= 3.2 (Tibor Leupold)

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -557,6 +557,7 @@ Contributors
 * Michael Karamuth
 * Vu Pham
 * Khanh Hoang
+* Jason Attwood
 
 Translators
 ===========

--- a/client/scss/components/_forms.scss
+++ b/client/scss/components/_forms.scss
@@ -123,7 +123,20 @@ select::-ms-expand {
 }
 
 .error-message {
-    color: $color-red;
+    font-size: 1em;
+    font-weight: bold;
+    color: $color-text-error;
+
+    @media (forced-colors: $media-forced-colours) {
+        forced-color-adjust: none;
+        color: $color-text-error-forced-color;
+    }
+
+    &::before {
+        font-family: wagtail;
+        vertical-align: -10%;
+        content: map-get($icons, 'cross');
+    }
 }
 
 .help {

--- a/client/scss/settings/_variables.scss
+++ b/client/scss/settings/_variables.scss
@@ -142,3 +142,7 @@ $nav-search-bg: $nav-grey-1;
 $nav-search-hover-bg: $nav-item-hover-bg;
 $nav-search-focus-color: $color-white;
 $nav-search-focus-bg: $nav-item-hover-bg;
+
+// Form Errors
+$color-text-error: change-color($color-red, $saturation: 69, $lightness: 52);
+$color-text-error-forced-color: change-color($color-red, $saturation: 100, $lightness: 50);

--- a/docs/releases/2.16.md
+++ b/docs/releases/2.16.md
@@ -26,6 +26,7 @@
  * Improve CircleCI frontend & backend build caches (Thibaud Colas)
  * Add a 'remember me' checkbox to the admin sign in form, if unticked (default) the auth session will expire if the browser is closed (Michael Karamuth, Jake Howard)
  * When returning to image or document listing views after editing, filters (collection or tag) are now remembered (Tidjani Dia)
+ * Improve the visibility of field error messages, in Windows high-contrast mode and out (Jason Attwood)
 
 ### Bug fixes
 


### PR DESCRIPTION
This fixes the accessibility issue mentioned in #7241 and also fixes issue with error visibility in high-contrast mode (before this the message was white and indistinguishable from other text on the page)

Before:
![image](https://user-images.githubusercontent.com/1568832/139462618-32289701-8976-46a0-a93e-b17f4e4f5846.png)
![image](https://user-images.githubusercontent.com/1568832/139462475-40021f43-0e03-45c4-956f-630f50f03e26.png)

After:
![image](https://user-images.githubusercontent.com/1568832/139462157-3a493351-0d94-433d-a425-849272e40dca.png)
![image](https://user-images.githubusercontent.com/1568832/139462294-c2410920-dcdf-4e07-a397-e538372a57ae.png)
