### PR TITLE
TypedTableBlock: Add `aria-expanded` attribute to add new column button

### DIFF
--- a/client/src/entrypoints/contrib/typed_table_block/__snapshots__/typed_table_block.test.js.snap
+++ b/client/src/entrypoints/contrib/typed_table_block/__snapshots__/typed_table_block.test.js.snap
@@ -8,11 +8,11 @@ exports[`wagtail.contrib.typed_table_block.blocks.TypedTableBlock it renders cor
         <div class=\\"typed-table-block__wrapper\\">
           <table>
             <thead>
-              <tr><th></th><th><input type=\\"hidden\\" name=\\"mytable-column-0-type\\" value=\\"test_block_a\\"><input type=\\"hidden\\" name=\\"mytable-column-0-order\\" value=\\"0\\"><button type=\\"button\\" class=\\"button button-secondary button-small button--icon text-replace prepend-column\\" aria-label=\\"Insert column\\" title=\\"Insert column\\">
+              <tr><th></th><th><input type=\\"hidden\\" name=\\"mytable-column-0-type\\" value=\\"test_block_a\\"><input type=\\"hidden\\" name=\\"mytable-column-0-order\\" value=\\"0\\"><button type=\\"button\\" class=\\"button button-secondary button-small button--icon text-replace prepend-column\\" aria-label=\\"Insert column\\" title=\\"Insert column\\" aria-expanded=\\"false\\">
         <svg class=\\"icon icon-plus icon\\" aria-hidden=\\"true\\" focusable=\\"false\\"><use href=\\"#icon-plus\\"></use></svg>
       </button><input name=\\"mytable-column-0-heading\\" class=\\"column-heading\\" placeholder=\\"Column heading\\"><button type=\\"button\\" class=\\"button button-secondary button-small button--icon text-replace no delete-column\\" aria-label=\\"Delete column\\" title=\\"Delete column\\">
         <svg class=\\"icon icon-bin icon\\" aria-hidden=\\"true\\" focusable=\\"false\\"><use href=\\"#icon-bin\\"></use></svg>
-      </button></th><th><input type=\\"hidden\\" name=\\"mytable-column-1-type\\" value=\\"test_block_b\\"><input type=\\"hidden\\" name=\\"mytable-column-1-order\\" value=\\"1\\"><button type=\\"button\\" class=\\"button button-secondary button-small button--icon text-replace prepend-column\\" aria-label=\\"Insert column\\" title=\\"Insert column\\">
+      </button></th><th><input type=\\"hidden\\" name=\\"mytable-column-1-type\\" value=\\"test_block_b\\"><input type=\\"hidden\\" name=\\"mytable-column-1-order\\" value=\\"1\\"><button type=\\"button\\" class=\\"button button-secondary button-small button--icon text-replace prepend-column\\" aria-label=\\"Insert column\\" title=\\"Insert column\\" aria-expanded=\\"false\\">
         <svg class=\\"icon icon-plus icon\\" aria-hidden=\\"true\\" focusable=\\"false\\"><use href=\\"#icon-plus\\"></use></svg>
       </button><input name=\\"mytable-column-1-heading\\" class=\\"column-heading\\" placeholder=\\"Column heading\\"><button type=\\"button\\" class=\\"button button-secondary button-small button--icon text-replace no delete-column\\" aria-label=\\"Delete column\\" title=\\"Delete column\\">
         <svg class=\\"icon icon-bin icon\\" aria-hidden=\\"true\\" focusable=\\"false\\"><use href=\\"#icon-bin\\"></use></svg>

--- a/client/src/entrypoints/contrib/typed_table_block/typed_table_block.js
+++ b/client/src/entrypoints/contrib/typed_table_block/typed_table_block.js
@@ -141,6 +141,7 @@ export class TypedTableBlock {
   showAddColumnMenu(baseElement, callback) {
     this.addColumnMenuBaseElement = baseElement;
     baseElement.after(this.addColumnMenu);
+    baseElement.attr('aria-expanded', 'true');
     this.addColumnMenu.show();
     this.addColumnCallback = callback;
   }
@@ -221,7 +222,8 @@ export class TypedTableBlock {
     const prependColumnButton = $(`<button type="button"
       class="button button-secondary button-small button--icon text-replace prepend-column"
       aria-label="${h(this.blockDef.meta.strings.INSERT_COLUMN)}"
-      title="${h(this.blockDef.meta.strings.INSERT_COLUMN)}">
+      title="${h(this.blockDef.meta.strings.INSERT_COLUMN)}"
+      aria-expanded="false">
         <svg class="icon icon-plus icon" aria-hidden="true" focusable="false"><use href="#icon-plus"></use></svg>
       </button>`);
     $(newHeaderCell).append(prependColumnButton);


### PR DESCRIPTION
Adding `aria-expanded` attribute to the add new column menu trigger button so that assistive technology knows when it has opened its menu.

(Part of #7646)

---

* [x] Do the tests still pass? (https://docs.wagtail.io/en/latest/contributing/developing.html#testing)
* [x] Does the code comply with the style guide? (Run `make lint` from the Wagtail root)
* ~~For Python changes: Have you added tests to cover the new/fixed behaviour?~~
* For front-end changes: Did you test on all of [Wagtail’s supported environments](https://docs.wagtail.io/en/latest/contributing/developing.html#browser-and-device-support)?
  * **Please list the exact browser and operating system versions you tested**.
    * Firefox 88 on macOS 10.15.7
  * **Please list which assistive technologies you tested**.
* ~~For new features: Has the documentation been updated accordingly?~~
