### PR TITLE
TypedTableBlock: Add borders to help visualize rows and columns

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -29,6 +29,7 @@ Changelog
  * `admin/expanding_formset.js` has been renamed to `admin/expanding-formset.js` (LB (Ben Johnston))
  * Change docs URL to docs.wagtail.org (Jake Howard)
  * Update links to wagtail.io to point to new domain wagtail.org (Jake Howard)
+ * Add borders to TypedTableBlock to help visualize rows and columns (Scott Cranfill)
  * Fix: Accessibility fixes for Windows high contrast mode; Dashboard icons colour and contrast (Sakshi Uppoor)
  * Fix: Rename additional 'spin' CSS animations to avoid clashes with other libraries (Kevin Gutiérrez)
  * Fix: `default_app_config` deprecations for Django >= 3.2 (Tibor Leupold)

--- a/docs/releases/2.16.md
+++ b/docs/releases/2.16.md
@@ -32,6 +32,7 @@
  * Change release check domain to releases.wagtail.org (Jake Howard)
  * Add the user who submitted a page for moderation to the "Awaiting your review" homepage summary panel (Tidiane Dia)
  * When moving pages, default to the current parent section (Tidjani Dia)
+ * Add borders to TypedTableBlock to help visualize rows and columns (Scott Cranfill)
 
 ### Bug fixes
 

--- a/wagtail/contrib/typed_table_block/static_src/typed_table_block/scss/typed_table_block.scss
+++ b/wagtail/contrib/typed_table_block/static_src/typed_table_block/scss/typed_table_block.scss
@@ -11,8 +11,14 @@
         margin: 2.5rem 0 1rem 2.5rem;
     }
 
+    th,
+    td {
+        padding: 0.25rem;
+    }
+
     th {
         position: relative;
+        border: 2px solid $color-grey-2;
 
         button.prepend-column,
         button.append-column {
@@ -29,16 +35,25 @@
 
         input.column-heading {
             padding-right: 3rem;
+            font-weight: bold;
         }
     }
 
     td {
         position: relative;
+        border-left: 1px solid $color-grey-2;
+    }
+
+    th:first-child,
+    th:last-child,
+    td:first-child {
+        border-width: 0;
     }
 
     tbody tr,
     tfoot tr {
         position: relative;
+        border-top: 1px dotted $color-grey-2;
 
         button.prepend-row {
             left: -2rem;


### PR DESCRIPTION
Adds some borders to help define the rows and columns in a TypedTableBlock and make it easier to see where add/remove buttons apply.

(Part of #7646)

Screenshot:

![TypedTableBlock showing proposed borders](https://user-images.githubusercontent.com/1044670/139613598-58f516cb-5cbd-4397-9da3-dee1a3f8eec3.png)


---

* [x] Do the tests still pass? (https://docs.wagtail.io/en/latest/contributing/developing.html#testing)
* [x] Does the code comply with the style guide? (Run `make lint` from the Wagtail root)
* ~~For Python changes: Have you added tests to cover the new/fixed behaviour?~~
* For front-end changes: Did you test on all of [Wagtail’s supported environments](https://docs.wagtail.io/en/latest/contributing/developing.html#browser-and-device-support)?
  * **Please list the exact browser and operating system versions you tested**.
    * Firefox 88 on macOS 10.15.7
  * **Please list which assistive technologies you tested**.
* ~~For new features: Has the documentation been updated accordingly?~~
