### PR TITLE
Apply semver naming for minor release url

### DIFF
--- a/scripts/latest.txt
+++ b/scripts/latest.txt
@@ -1,10 +1,10 @@
 {
     "version": "2.14.2",
     "url":     "https://docs.wagtail.io/en/stable/releases/2.14.2.html",
-    "majorUrl": "https://docs.wagtail.io/en/stable/releases/2.14.html",
+    "minorUrl": "https://docs.wagtail.io/en/stable/releases/2.14.html",
     "lts": {
         "version": "2.11.8",
         "url": "https://docs.wagtail.io/en/stable/releases/2.11.8.html",
-        "majorUrl": "https://docs.wagtail.io/en/stable/releases/2.11.html"
+        "minorUrl": "https://docs.wagtail.io/en/stable/releases/2.11.html"
     }
 }


### PR DESCRIPTION
The current naming is conflicting with how the version number parts are
called accoring to semantic versioning. Wagtail does not strictly follow
semantic versioning, but it still seems reasonable to adopt the same
terminology as the rest of the world.

See related discussion in #7336 (in particular [this comment by @gasman](https://github.com/wagtail/wagtail/issues/7336#issuecomment-954223018))