### PR TITLE
Adding anchor link to list of documented links in the editor manual 

### DIFF
--- a/docs/editor_manual/new_pages/inserting_links.rst
+++ b/docs/editor_manual/new_pages/inserting_links.rst
@@ -16,6 +16,7 @@ Whichever way you insert a link, you will be presented with the form displayed b
   * External link: A link to a page on another website.
   * Email link: A link that will open the user's default email client with the email address prepopulated.
   * Phone link: A link that will open the user's default client for initiating audio calls, with the phone number prepopulated.
+  * Anchor link: A link that will scroll to a given hash id elsewhere on the same page.
 
 * You can also navigate through the website to find an internal link via the explorer.
 


### PR DESCRIPTION
Anchor links are another option included by Wagtail by default now ( I believe?) . I had some editors who were not aware of that, and noticed this missing from the docs.

Thanks for contributing to Wagtail! 🎉

Before submitting, please review the contributor guidelines <https://docs.wagtail.io/en/latest/contributing/index.html> and check the following:

* Do the tests still pass? (https://docs.wagtail.io/en/latest/contributing/developing.html#testing)
* Does the code comply with the style guide? (Run `make lint` from the Wagtail root)
* For Python changes: Have you added tests to cover the new/fixed behaviour?
* For front-end changes: Did you test on all of [Wagtail’s supported environments](https://docs.wagtail.io/en/latest/contributing/developing.html#browser-and-device-support)?
    * **Please list the exact browser and operating system versions you tested**.
    * **Please list which assistive technologies you tested**.
* For new features: Has the documentation been updated accordingly?
