### PR TITLE
Documentation - Update blocks.rst to include `rows` kwarg for TextBlock

### DIFF
--- a/docs/reference/streamfield/blocks.rst
+++ b/docs/reference/streamfield/blocks.rst
@@ -77,6 +77,7 @@ Field block types
    :param max_length: The maximum allowed length of the field.
    :param min_length: The minimum allowed length of the field.
    :param help_text: Help text to display alongside the field.
+   :param rows: Number of rows to show on the textarea (defaults to 1).
    :param validators: A list of validation functions for the field (see `Django Validators <https://docs.djangoproject.com/en/stable/ref/validators/>`__).
    :param form_classname: A value to add to the form field's ``class`` attribute when rendered on the page editing form.
 


### PR DESCRIPTION
Docs does not currently include the `rows` kwarg that is available on `TextBlock`.
See Question on slack https://wagtailcms.slack.com/archives/C81FGJR2S/p1635825388225100

However, this is supported in the code - core/blocks/field_block.py - and works.
<img width="1466" alt="Screen Shot 2021-11-02 at 9 23 26 pm" src="https://user-images.githubusercontent.com/1396140/139837727-16f7ddb7-cf16-4bca-8359-4eba3e41c70a.png">

