### PR TITLE
Provide and use get_add_url method in generic index view

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/generic/index.html
+++ b/wagtail/admin/templates/wagtailadmin/generic/index.html
@@ -4,9 +4,8 @@
 {% block titletag %}{{ page_title }} {{ page_subtitle }}{% endblock %}
 
 {% block content %}
-    {% if can_add %}
-        {% url view.add_url_name as add_link %}
-        {% include "wagtailadmin/shared/header.html" with title=page_title subtitle=page_subtitle action_url=add_link action_text=view.add_item_label icon=header_icon only %}
+    {% if can_add and add_url %}
+        {% include "wagtailadmin/shared/header.html" with title=page_title subtitle=page_subtitle action_url=add_url action_text=view.add_item_label icon=header_icon only %}
     {% else %}
         {% include "wagtailadmin/shared/header.html" with title=page_title subtitle=page_subtitle icon=header_icon only %}
     {% endif %}

--- a/wagtail/admin/views/generic/models.py
+++ b/wagtail/admin/views/generic/models.py
@@ -46,6 +46,10 @@ class IndexView(PermissionCheckedMixin, WagtailAdminTemplateMixin, BaseListView)
         if self.index_url_name:
             return reverse(self.index_url_name)
 
+    def get_add_url(self):
+        if self.add_url_name:
+            return reverse(self.add_url_name)
+
     def get_edit_url(self, instance):
         if self.edit_url_name:
             return reverse(self.edit_url_name, args=(instance.pk,))
@@ -75,6 +79,7 @@ class IndexView(PermissionCheckedMixin, WagtailAdminTemplateMixin, BaseListView)
             self.permission_policy is None
             or self.permission_policy.user_has_permission(self.request.user, 'add')
         )
+        context['add_url'] = self.get_add_url()
         context['table'] = table
         context['media'] = table.media
         context['index_url'] = index_url


### PR DESCRIPTION
This will allow one to have more control over the `add_url` construction - e.g. reverse the URL with arguments - and comply with other URLs resolution - i.e. a `get_<view>_url` is always used instead of accessing `<view>_url_name` directly.