### PR TITLE
Phase out special-purpose field panel types

### DIFF
--- a/docs/advanced_topics/customisation/page_editing_interface.rst
+++ b/docs/advanced_topics/customisation/page_editing_interface.rst
@@ -21,7 +21,7 @@ As standard, Wagtail organises panels for pages into three tabs: 'Content', 'Pro
             FieldPanel('body', classname="full"),
         ]
         sidebar_content_panels = [
-            SnippetChooserPanel('advert'),
+            FieldPanel('advert'),
             InlinePanel('related_links', label="Related links"),
         ]
 

--- a/docs/extending/forms.md
+++ b/docs/extending/forms.md
@@ -1,0 +1,58 @@
+# Forms
+
+[Django's forms framework](https://docs.djangoproject.com/en/stable/topics/forms/) can be used within Wagtail admin views just like in any other Django app. However, Wagtail also provides various admin-specific form widgets, such as date/time pickers and choosers for pages, documents, images and snippets. By constructing forms using `wagtail.admin.forms.models.WagtailAdminModelForm` as the base class instead of `django.forms.models.ModelForm`, the most appropriate widget will be selected for each model field. For example, given the model and form definition:
+
+```python
+from django.db import models
+
+from wagtail.admin.forms.models import WagtailAdminModelForm
+from wagtail.images.models import Image
+
+
+class FeaturedImage(models.Model):
+    date = models.DateField()
+    image = models.ForeignKey(Image, on_delete=models.CASCADE)
+
+
+class FeaturedImageForm(WagtailAdminModelForm):
+    class Meta:
+        model = FeaturedImage
+```
+
+the `date` and `image` fields on the form will use a date picker and image chooser widget respectively.
+
+
+## Defining admin form widgets
+
+If you have implemented a form widget of your own, you can configure `WagtailAdminModelForm` to select it for a given model field type. This is done by calling the `wagtail.admin.forms.models.register_form_field_override` function, typically in an `AppConfig.ready` method.
+
+```eval_rst
+.. function:: register_form_field_override(model_field_class, to=None, override=None, exact_class=False)
+
+   Specify a set of options that will override the form field's defaults when ``WagtailAdminModelForm`` encounters a given model field type.
+
+   :param model_field_class: Specifies a model field class, such as ``models.CharField``; the override will take effect on fields that are instances of this class.
+   :param to: For ``ForeignKey`` fields, indicates the model that the field must point to for the override to take effect.
+   :param override: A dict of keyword arguments to be passed to the form field's ``__init__`` method, such as ``widget``.
+   :param exact_class: If true, the override will only take effect for model fields that are of the exact type given by ``model_field_class``, and not a subclass of it.
+```
+
+For example, if the app `wagtail.videos` implements a `Video` model and a `VideoChooser` form widget, the following AppConfig definition will ensure that `WagtailAdminModelForm` selects `VideoChooser` as the form widget for any foreign keys pointing to `Video`:
+
+```python
+from django.apps import AppConfig
+from django.db.models import ForeignKey
+
+
+class WagtailVideosAppConfig(AppConfig):
+    name = 'wagtail.videos'
+    label = 'wagtailvideos'
+
+    def ready(self):
+        from wagtail.admin.forms.models import register_form_field_override
+        from .models import Video
+        from .widgets import VideoChooser
+        register_form_field_override(ForeignKey, to=Video, override={'widget': VideoChooser})
+```
+
+Wagtail's edit views for pages, snippets and ModelAdmin use `WagtailAdminModelForm` as standard, so this change will take effect across the Wagtail admin; a foreign key to `Video` on a page model will automatically use the `VideoChooser` widget, with no need to specify this explicitly.

--- a/docs/extending/forms.md
+++ b/docs/extending/forms.md
@@ -1,4 +1,4 @@
-# Forms
+# Using forms in admin views
 
 [Django's forms framework](https://docs.djangoproject.com/en/stable/topics/forms/) can be used within Wagtail admin views just like in any other Django app. However, Wagtail also provides various admin-specific form widgets, such as date/time pickers and choosers for pages, documents, images and snippets. By constructing forms using `wagtail.admin.forms.models.WagtailAdminModelForm` as the base class instead of `django.forms.models.ModelForm`, the most appropriate widget will be selected for each model field. For example, given the model and form definition:
 

--- a/docs/extending/index.rst
+++ b/docs/extending/index.rst
@@ -11,6 +11,7 @@ This section describes the various mechanisms that can be used to integrate your
 
     admin_views
     template_components
+    forms
     adding_reports
     custom_tasks
     audit_log

--- a/docs/getting_started/tutorial.md
+++ b/docs/getting_started/tutorial.md
@@ -466,14 +466,13 @@ Add a new `BlogPageGalleryImage` model to `models.py`:
 ```python
 from django.db import models
 
-# New imports added for ParentalKey, Orderable, InlinePanel, ImageChooserPanel
+# New imports added for ParentalKey, Orderable, InlinePanel
 
 from modelcluster.fields import ParentalKey
 
 from wagtail.core.models import Page, Orderable
 from wagtail.core.fields import RichTextField
 from wagtail.admin.edit_handlers import FieldPanel, InlinePanel
-from wagtail.images.edit_handlers import ImageChooserPanel
 from wagtail.search import index
 
 
@@ -506,7 +505,7 @@ class BlogPageGalleryImage(Orderable):
     caption = models.CharField(blank=True, max_length=250)
 
     panels = [
-        ImageChooserPanel('image'),
+        FieldPanel('image'),
         FieldPanel('caption'),
     ]
 ```
@@ -519,7 +518,7 @@ Inheriting from `Orderable` adds a `sort_order` field to the model, to keep trac
 
 The `ParentalKey` to `BlogPage` is what attaches the gallery images to a specific page. A `ParentalKey` works similarly to a `ForeignKey`, but also defines `BlogPageGalleryImage` as a "child" of the `BlogPage` model, so that it's treated as a fundamental part of the page in operations like submitting for moderation, and tracking revision history.
 
-`image` is a `ForeignKey` to Wagtail's built-in `Image` model, where the images themselves are stored. This comes with a dedicated panel type, `ImageChooserPanel`, which provides a pop-up interface for choosing an existing image or uploading a new one. This way, we allow an image to exist in multiple galleries - effectively, we've created a many-to-many relationship between pages and images.
+`image` is a `ForeignKey` to Wagtail's built-in `Image` model, where the images themselves are stored. This appears in the page editor as a pop-up interface for choosing an existing image or uploading a new one. This way, we allow an image to exist in multiple galleries - effectively, we've created a many-to-many relationship between pages and images.
 
 Specifying `on_delete=models.CASCADE` on the foreign key means that if the image is deleted from the system, the gallery entry is deleted as well. (In other situations, it might be appropriate to leave the entry in place - for example, if an "our staff" page included a list of people with headshots, and one of those photos was deleted, we'd rather leave the person in place on the page without a photo. In this case, we'd set the foreign key to `blank=True, null=True, on_delete=models.SET_NULL`.)
 
@@ -629,7 +628,6 @@ from taggit.models import TaggedItemBase
 from wagtail.core.models import Page, Orderable
 from wagtail.core.fields import RichTextField
 from wagtail.admin.edit_handlers import FieldPanel, InlinePanel, MultiFieldPanel
-from wagtail.images.edit_handlers import ImageChooserPanel
 from wagtail.search import index
 
 
@@ -787,7 +785,7 @@ class BlogCategory(models.Model):
 
     panels = [
         FieldPanel('name'),
-        ImageChooserPanel('icon'),
+        FieldPanel('icon'),
     ]
 
     def __str__(self):

--- a/docs/reference/contrib/forms/customisation.rst
+++ b/docs/reference/contrib/forms/customisation.rst
@@ -563,8 +563,7 @@ Finally, we add a URL param of `id` based on the ``form_submission`` if it exist
 .. code-block:: python
 
     from django.shortcuts import redirect
-    from wagtail.admin.edit_handlers import (
-        FieldPanel, FieldRowPanel, InlinePanel, MultiFieldPanel, PageChooserPanel)
+    from wagtail.admin.edit_handlers import FieldPanel, FieldRowPanel, InlinePanel, MultiFieldPanel
     from wagtail.contrib.forms.models import AbstractEmailForm
 
     class FormPage(AbstractEmailForm):
@@ -594,7 +593,7 @@ Finally, we add a URL param of `id` based on the ``form_submission`` if it exist
             FieldPanel('intro', classname='full'),
             InlinePanel('form_fields'),
             FieldPanel('thank_you_text', classname='full'),
-            PageChooserPanel('thank_you_page'),
+            FieldPanel('thank_you_page'),
             MultiFieldPanel([
                 FieldRowPanel([
                     FieldPanel('from_address', classname='col6'),

--- a/docs/reference/contrib/modeladmin/index.rst
+++ b/docs/reference/contrib/modeladmin/index.rst
@@ -83,7 +83,6 @@ to create, view, and edit ``Book`` entries.
 
     from django.db import models
     from wagtail.admin.edit_handlers import FieldPanel
-    from wagtail.images.edit_handlers import ImageChooserPanel
 
     class Book(models.Model):
         title = models.CharField(max_length=255)
@@ -98,15 +97,13 @@ to create, view, and edit ``Book`` entries.
         panels = [
             FieldPanel('title'),
             FieldPanel('author'),
-            ImageChooserPanel('cover_photo')
+            FieldPanel('cover_photo')
         ]
 
 .. tip::
 
-    You can specify ``FieldPanels`` like ``ImageChooserPanel``, ``PageChooserPanel``,
-    and ``DocumentChooserPanel`` within the ``panels`` attribute of the model.
-    This lets you use Wagtail-specific features in an otherwise traditional
-    Django model.
+    You can specify panels like ``MultiFieldPanel`` within the ``panels`` attribute of the model.
+    This lets you use Wagtail-specific layouts in an otherwise traditional Django model.
 
 
 ``wagtail_hooks.py`` in your app directory would look something like this:

--- a/docs/reference/contrib/settings.rst
+++ b/docs/reference/contrib/settings.rst
@@ -56,8 +56,8 @@ Settings use edit handlers much like the rest of Wagtail.  Add a ``panels`` sett
             'wagtailcore.Page', null=True, on_delete=models.SET_NULL, related_name='+')
 
         panels = [
-            PageChooserPanel('donate_page'),
-            PageChooserPanel('sign_up_page'),
+            FieldPanel('donate_page'),
+            FieldPanel('sign_up_page'),
         ]
 
 You can also customize the editor handlers :ref:`like you would do for Page model <customising_the_tabbed_interface>`
@@ -263,8 +263,8 @@ following shows how ``select_related`` can be set to improve efficiency:
             'wagtailcore.Page', null=True, on_delete=models.SET_NULL, related_name='+')
 
         panels = [
-            PageChooserPanel('donate_page'),
-            PageChooserPanel('sign_up_page'),
+            FieldPanel('donate_page'),
+            FieldPanel('sign_up_page'),
         ]
 
 With these additions, the following template code will now trigger

--- a/docs/reference/pages/panels.rst
+++ b/docs/reference/pages/panels.rst
@@ -48,17 +48,12 @@ StreamFieldPanel
 
 .. class:: StreamFieldPanel(field_name, classname=None, widget=None)
 
-    This is the panel used for Wagtail's StreamField type (see :ref:`streamfield`).
+    Deprecated; use ``FieldPanel`` instead.
 
-    .. attribute:: FieldPanel.field_name
+    .. versionchanged:: 2.17
 
-        This is the name of the class property used in your model definition.
+       ``StreamFieldPanel`` is no longer required for ``StreamField``.
 
-    .. attribute:: FieldPanel.classname (optional)
-
-        This is a string of optional CSS classes given to the panel which are used in formatting and scripted interactivity. By default, panels are formatted as inset fields.
-
-        The CSS class ``full`` can be used to format the panel so it covers the full width of the Wagtail page editor.
 
 MultiFieldPanel
 ~~~~~~~~~~~~~~~
@@ -166,6 +161,10 @@ PageChooserPanel
 
     Passing ``can_choose_root=True`` will allow the editor to choose the tree root as a page. Normally this would be undesirable, since the tree root is never a usable page, but in some specialised cases it may be appropriate; for example, a page with an automatic "related articles" feed could use a PageChooserPanel to select which subsection articles will be taken from, with the root corresponding to 'everywhere'.
 
+    .. versionchanged:: 2.17
+
+       ``FieldPanel`` now also provides a page chooser interface for foreign keys to page models. ``PageChooserPanel`` is only required when specifying the ``page_type`` or ``can_choose_root`` parameters.
+
 
 ImageChooserPanel
 ~~~~~~~~~~~~~~~~~
@@ -174,30 +173,12 @@ ImageChooserPanel
 
 .. class:: ImageChooserPanel(field_name)
 
-    Wagtail includes a unified image library, which you can access in your models through the :class:`~wagtail.images.models.Image` model and the ``ImageChooserPanel`` chooser. Here's how:
+    Deprecated; use ``FieldPanel`` instead.
 
-    .. code-block:: python
+    .. versionchanged:: 2.17
 
-      from wagtail.images.models import Image
-      from wagtail.images.edit_handlers import ImageChooserPanel
+       ``ImageChooserPanel`` is no longer required to obtain an image chooser interface.
 
-
-      class BookPage(Page):
-          cover = models.ForeignKey(
-              'wagtailimages.Image',
-              null=True,
-              blank=True,
-              on_delete=models.SET_NULL,
-              related_name='+'
-          )
-
-          content_panels = Page.content_panels + [
-              ImageChooserPanel('cover'),
-          ]
-
-    Django's default behaviour is to "cascade" deletions through a ForeignKey relationship, which may not be what you want. This is why the :attr:`~django.db.models.Field.null`, :attr:`~django.db.models.Field.blank`, and :attr:`~django.db.models.ForeignKey.on_delete` parameters should be set to allow for an empty field. ``ImageChooserPanel`` takes only one argument: the name of the field.
-
-    Displaying ``Image`` objects in a template requires the use of a template tag. See :ref:`image_tag`.
 
 FormSubmissionsPanel
 ~~~~~~~~~~~~~~~~~~~~
@@ -226,28 +207,12 @@ DocumentChooserPanel
 
 .. class:: DocumentChooserPanel(field_name)
 
-    For files in other formats, Wagtail provides a generic file store through the :class:`~wagtail.documents.models.Document` model:
+    Deprecated; use ``FieldPanel`` instead.
 
-    .. code-block:: python
+    .. versionchanged:: 2.17
 
-      from wagtail.documents.models import Document
-      from wagtail.documents.edit_handlers import DocumentChooserPanel
+       ``DocumentChooserPanel`` is no longer required to obtain a document chooser interface.
 
-
-      class BookPage(Page):
-          book_file = models.ForeignKey(
-              'wagtaildocs.Document',
-              null=True,
-              blank=True,
-              on_delete=models.SET_NULL,
-              related_name='+'
-          )
-
-          content_panels = Page.content_panels + [
-              DocumentChooserPanel('book_file'),
-          ]
-
-    As with images, Wagtail documents should also have the appropriate extra parameters to prevent cascade deletions across a ForeignKey relationship. ``DocumentChooserPanel`` takes only one argument: the name of the field.
 
 SnippetChooserPanel
 ~~~~~~~~~~~~~~~~~~~
@@ -256,26 +221,12 @@ SnippetChooserPanel
 
 .. class:: SnippetChooserPanel(field_name, snippet_type=None)
 
-    Snippets are vanilla Django models you create yourself without a Wagtail-provided base class. A chooser, ``SnippetChooserPanel``, is provided which takes the field name as an argument.
+    Deprecated; use ``FieldPanel`` instead.
 
-    .. code-block:: python
+    .. versionchanged:: 2.17
 
-      from wagtail.snippets.edit_handlers import SnippetChooserPanel
+       ``SnippetChooserPanel`` is no longer required to obtain a document chooser interface.
 
-      class BookPage(Page):
-          advert = models.ForeignKey(
-              'demo.Advert',
-              null=True,
-              blank=True,
-              on_delete=models.SET_NULL,
-              related_name='+'
-          )
-
-          content_panels = Page.content_panels + [
-              SnippetChooserPanel('advert'),
-          ]
-
-    See :ref:`snippets` for more information.
 
 Field Customisation
 -------------------

--- a/docs/releases/2.17.md
+++ b/docs/releases/2.17.md
@@ -66,6 +66,12 @@ Here are other changes related to the redesign:
 * We encourage all users of the Hallo editor to take steps to migrate to the new Draftail editor as this external package is unlikely to have ongoing maintenance.
 * `window.registerHalloPlugin` will no longer be created on the page editor load, unless the legacy package is installed.
 
-### Template context for `BaseChooserPanel`
+### Phasing-out of special-purpose field panel types
 
-`BaseChooserPanel` no longer passes the context variable `is_chosen`, or the variable name given by the panel's `object_type_name` property, to the panel's template. The only available variables are now `field` and `show_add_comment_button`. If you have subclassed `BaseChooserPanel` and provided a custom template (via the `field_template` attribute) that depends on additional context variables, you will need to pass them explicitly by overriding the `render_as_field` method.
+As of this release, the use of special-purpose field panel types such as `StreamFieldPanel` and `ImageChooserPanel` is being phased out, and developers will generally expect to be able to use a plain `FieldPanel` instead. For this reason, developers of third-party packages implementing their own field panel types are recommended to follow suit and ensure that their code also works with `FieldPanel`. The steps for doing this will depend on the package's functionality, but in general:
+
+ * If the panel sets a custom template, your code should instead define [a `Widget` class](https://docs.djangoproject.com/en/stable/ref/forms/widgets/) that produces your desired HTML rendering.
+ * If the panel provides a `widget_overrides` method, your code should instead call [`register_form_field_override`](/extending/forms) so that the desired widget is always selected for the relevant model field type.
+ * If the panel provides a `get_comparison_class` method, your code should instead call `wagtail.admin.compare.register_comparison_class` to register the comparison class against the relevant model field type.
+
+If you do continue to use a custom panel class, note that the template context for panels derived from `BaseChooserPanel` has changed - the context variable `is_chosen`, and the variable name given by the panel's `object_type_name` property, are no longer available on the template. The only available variables are now `field` and `show_add_comment_button`. If your template depends on these additional variables, you will need to pass them explicitly by overriding the `render_as_field` method.

--- a/docs/releases/2.17.md
+++ b/docs/releases/2.17.md
@@ -65,3 +65,7 @@ Here are other changes related to the redesign:
 * If you still require Hallo for your Wagtail installation, you will need to install the [Wagtail Hallo editor](https://github.com/wagtail/wagtail-hallo) legacy package.
 * We encourage all users of the Hallo editor to take steps to migrate to the new Draftail editor as this external package is unlikely to have ongoing maintenance.
 * `window.registerHalloPlugin` will no longer be created on the page editor load, unless the legacy package is installed.
+
+### Template context for `BaseChooserPanel`
+
+`BaseChooserPanel` no longer passes the context variable `is_chosen`, or the variable name given by the panel's `object_type_name` property, to the panel's template. The only available variables are now `field` and `show_add_comment_button`. If you have subclassed `BaseChooserPanel` and provided a custom template (via the `field_template` attribute) that depends on additional context variables, you will need to pass them explicitly by overriding the `render_as_field` method.

--- a/docs/topics/pages.md
+++ b/docs/topics/pages.md
@@ -27,7 +27,6 @@ from modelcluster.fields import ParentalKey
 from wagtail.core.models import Page, Orderable
 from wagtail.core.fields import RichTextField
 from wagtail.admin.edit_handlers import FieldPanel, MultiFieldPanel, InlinePanel
-from wagtail.images.edit_handlers import ImageChooserPanel
 from wagtail.search import index
 
 
@@ -64,7 +63,7 @@ class BlogPage(Page):
 
     promote_panels = [
         MultiFieldPanel(Page.promote_panels, "Common page configuration"),
-        ImageChooserPanel('feed_image'),
+        FieldPanel('feed_image'),
     ]
 
 
@@ -134,12 +133,17 @@ Here's a summary of the `EditHandler` classes that Wagtail provides out of the b
 
 **Basic**
 
-These allow editing of model fields. The `FieldPanel` class will choose the correct widget based on the type of the field, though `StreamField` fields need to use a specialised panel class.
+These allow editing of model fields. The `FieldPanel` class will choose the correct widget based on the type of the field, such as a rich text editor for `RichTextField`, or an image chooser for a `ForeignKey` to an image model. `FieldPanel` also provides a page chooser interface for `ForeignKey`s to page models, but for more fine-grained control over which page types can be chosen, `PageChooserPanel` provides additional configuration options.
 
 ```eval_rst
 -   :class:`~wagtail.admin.edit_handlers.FieldPanel`
--   :class:`~wagtail.admin.edit_handlers.StreamFieldPanel`
+-   :class:`~wagtail.admin.edit_handlers.PageChooserPanel`
+
+.. versionchanged:: 2.17
+
+   Previously, certain field types required special-purpose panels: ``StreamFieldPanel``, ``ImageChooserPanel``, ``DocumentChooserPanel`` and ``SnippetChooserPanel``. These are now all handled by ``FieldPanel``.
 ```
+
 
 **Structural**
 
@@ -149,23 +153,6 @@ These are used for structuring fields in the interface.
 -   :class:`~wagtail.admin.edit_handlers.MultiFieldPanel`
 -   :class:`~wagtail.admin.edit_handlers.InlinePanel`
 -   :class:`~wagtail.admin.edit_handlers.FieldRowPanel`
-```
-
-**Chooser**
-
-`ForeignKey` fields to certain models can use one of the below `ChooserPanel` classes. These add a nice modal chooser interface, and the image/document choosers also allow uploading new files without leaving the page editor.
-
-```eval_rst
--   :class:`~wagtail.admin.edit_handlers.PageChooserPanel`
--   :class:`~wagtail.images.edit_handlers.ImageChooserPanel`
--   :class:`~wagtail.documents.edit_handlers.DocumentChooserPanel`
--   :class:`~wagtail.snippets.edit_handlers.SnippetChooserPanel`
-
-.. note::
-
-    In order to use one of these choosers, the model being linked to must either be a page, image, document or snippet.
-
-    Linking to any other model type is currently unsupported, you will need to use ``FieldPanel`` which will create a dropdown box.
 ```
 
 

--- a/docs/topics/snippets.rst
+++ b/docs/topics/snippets.rst
@@ -97,11 +97,10 @@ Then, in your own page templates, you can include your snippet template tag with
 Binding Pages to Snippets
 -------------------------
 
-In the above example, the list of adverts is a fixed list that is displayed via the custom template tag independent of any other content on the page. This might be what you want for a common panel in a sidebar, but, in another scenario, you might wish to display just one specific instance of a snippet on a particular page. This can be accomplished by defining a foreign key to the snippet model within your page model and adding a ``SnippetChooserPanel`` to the page's ``content_panels`` list. For example, if you wanted to display a specific advert on a  ``BookPage`` instance:
+In the above example, the list of adverts is a fixed list that is displayed via the custom template tag independent of any other content on the page. This might be what you want for a common panel in a sidebar, but, in another scenario, you might wish to display just one specific instance of a snippet on a particular page. This can be accomplished by defining a foreign key to the snippet model within your page model and adding a ``FieldPanel`` to the page's ``content_panels`` list. For example, if you wanted to display a specific advert on a  ``BookPage`` instance:
 
 .. code-block:: python
 
-  from wagtail.snippets.edit_handlers import SnippetChooserPanel
   # ...
   class BookPage(Page):
       advert = models.ForeignKey(
@@ -113,14 +112,14 @@ In the above example, the list of adverts is a fixed list that is displayed via 
       )
 
       content_panels = Page.content_panels + [
-          SnippetChooserPanel('advert'),
+          FieldPanel('advert'),
           # ...
       ]
 
 
 The snippet could then be accessed within your template as ``page.advert``.
 
-To attach multiple adverts to a page, the ``SnippetChooserPanel`` can be placed on an inline child object of ``BookPage`` rather than on ``BookPage`` itself. Here, this child model is named ``BookPageAdvertPlacement`` (so called because there is one such object for each time that an advert is placed on a BookPage):
+To attach multiple adverts to a page, the ``FieldPanel`` can be placed on an inline child object of ``BookPage`` rather than on ``BookPage`` itself. Here, this child model is named ``BookPageAdvertPlacement`` (so called because there is one such object for each time that an advert is placed on a BookPage):
 
 
 .. code-block:: python
@@ -128,7 +127,6 @@ To attach multiple adverts to a page, the ``SnippetChooserPanel`` can be placed 
   from django.db import models
 
   from wagtail.core.models import Page, Orderable
-  from wagtail.snippets.edit_handlers import SnippetChooserPanel
 
   from modelcluster.fields import ParentalKey
 
@@ -143,7 +141,7 @@ To attach multiple adverts to a page, the ``SnippetChooserPanel`` can be placed 
           verbose_name_plural = "advert placements"
 
       panels = [
-          SnippetChooserPanel('advert'),
+          FieldPanel('advert'),
       ]
 
       def __str__(self):

--- a/wagtail/admin/compare.py
+++ b/wagtail/admin/compare.py
@@ -11,7 +11,7 @@ from django.utils.translation import gettext_lazy as _
 from taggit.managers import TaggableManager
 
 from wagtail.core import blocks
-from wagtail.core.fields import RichTextField
+from wagtail.core.fields import RichTextField, StreamField
 from wagtail.utils.registry import ModelFieldRegistry
 
 
@@ -317,6 +317,9 @@ class StreamFieldComparison(FieldComparison):
             return diff_text(
                 text_from_html(self.val_a), text_from_html(self.val_b)
             ).to_html()
+
+
+register_comparison_class(StreamField, comparison_class=StreamFieldComparison)
 
 
 class ChoiceFieldComparison(FieldComparison):

--- a/wagtail/admin/edit_handlers.py
+++ b/wagtail/admin/edit_handlers.py
@@ -1005,8 +1005,3 @@ class StreamFieldPanel(FieldPanel):
     def __init__(self, *args, **kwargs):
         disable_comments = kwargs.pop("disable_comments", True)
         super().__init__(*args, **kwargs, disable_comments=disable_comments)
-
-    def id_for_label(self):
-        # a StreamField may consist of many input fields, so it's not meaningful to
-        # attach the label to any specific one
-        return ""

--- a/wagtail/admin/edit_handlers.py
+++ b/wagtail/admin/edit_handlers.py
@@ -620,10 +620,9 @@ class BaseChooserPanel(FieldPanel):
     a database object such as an image, resulting in an ID that is used to populate
     a hidden foreign key input.
 
-    Subclasses provide:
-    * field_template (only required if the default template of field_panel_field.html is not usable)
-    * object_type_name - something like 'image' which will be used as the var name
-      for the object instance in the field_template
+    Subclasses can override field_template and render_as_field to customise the rendering, but
+    probably shouldn't - any custom rendering requirements are better implemented in the widget
+    rather than the panel, so that non-edit-handler-based forms can benefit from then too.
     """
 
     def get_chosen_item(self):
@@ -637,23 +636,8 @@ class BaseChooserPanel(FieldPanel):
             # like every other unpopulated field type. Yay consistency!
             return
 
-    def render_as_field(self):
-        instance_obj = self.get_chosen_item()
-        context = {
-            "field": self.bound_field,
-            self.object_type_name: instance_obj,
-            "is_chosen": bool(
-                instance_obj
-            ),  # DEPRECATED - passed to templates for backwards compatibility only
-            "show_add_comment_button": self.comments_enabled
-            and getattr(self.bound_field.field.widget, "show_add_comment_button", True),
-        }
-        return mark_safe(render_to_string(self.field_template, context))
-
 
 class PageChooserPanel(BaseChooserPanel):
-    object_type_name = "page"
-
     def __init__(self, field_name, page_type=None, can_choose_root=False):
         super().__init__(field_name=field_name)
 

--- a/wagtail/admin/edit_handlers.py
+++ b/wagtail/admin/edit_handlers.py
@@ -484,7 +484,13 @@ class FieldPanel(EditHandler):
 
         if self.bound_field.field.required:
             classes.append("required")
-        if self.bound_field.errors:
+
+        # If field has any errors, add the classname 'error' to enable error styling
+        # (e.g. red background), unless the widget has its own mechanism for rendering errors
+        # via the render_with_errors mechanism (as StreamField does).
+        if self.bound_field.errors and not hasattr(
+            self.bound_field.field.widget, "render_with_errors"
+        ):
             classes.append("error")
 
         classes.append(self.field_type())
@@ -1003,11 +1009,6 @@ class StreamFieldPanel(FieldPanel):
     def classes(self):
         classes = super().classes()
         classes.append("stream-field")
-
-        # In case of a validation error, BlockWidget will take care of outputting the error on the
-        # relevant sub-block, so we don't want the stream block as a whole to be wrapped in an 'error' class.
-        if "error" in classes:
-            classes.remove("error")
 
         return classes
 

--- a/wagtail/admin/edit_handlers.py
+++ b/wagtail/admin/edit_handlers.py
@@ -1006,12 +1006,6 @@ class StreamFieldPanel(FieldPanel):
         disable_comments = kwargs.pop("disable_comments", True)
         super().__init__(*args, **kwargs, disable_comments=disable_comments)
 
-    def classes(self):
-        classes = super().classes()
-        classes.append("stream-field")
-
-        return classes
-
     def id_for_label(self):
         # a StreamField may consist of many input fields, so it's not meaningful to
         # attach the label to any specific one

--- a/wagtail/admin/edit_handlers.py
+++ b/wagtail/admin/edit_handlers.py
@@ -19,6 +19,7 @@ from modelcluster.models import get_serializable_data_for_fields
 from wagtail.admin import compare, widgets
 from wagtail.admin.forms.comments import CommentForm, CommentReplyForm
 from wagtail.admin.templatetags.wagtailadmin_tags import avatar_url, user_display_name
+from wagtail.core.blocks import BlockField
 from wagtail.core.models import COMMENTS_RELATION_NAME, Page
 from wagtail.core.utils import camelcase_to_underscore
 from wagtail.utils.decorators import cached_classmethod
@@ -461,7 +462,7 @@ class FieldPanel(EditHandler):
         widget = kwargs.pop("widget", None)
         if widget is not None:
             self.widget = widget
-        self.comments_enabled = not kwargs.pop("disable_comments", False)
+        self.disable_comments = kwargs.pop("disable_comments", None)
         super().__init__(*args, **kwargs)
         self.field_name = field_name
 
@@ -502,6 +503,14 @@ class FieldPanel(EditHandler):
 
     def id_for_label(self):
         return self.bound_field.id_for_label
+
+    @property
+    def comments_enabled(self):
+        if self.disable_comments is None:
+            # by default, enable comments on all fields except StreamField (which has its own comment handling)
+            return not isinstance(self.bound_field.field, BlockField)
+        else:
+            return not self.disable_comments
 
     object_template = "wagtailadmin/edit_handlers/single_field_panel.html"
 
@@ -1002,6 +1011,4 @@ def reset_page_edit_handler_cache(**kwargs):
 
 
 class StreamFieldPanel(FieldPanel):
-    def __init__(self, *args, **kwargs):
-        disable_comments = kwargs.pop("disable_comments", True)
-        super().__init__(*args, **kwargs, disable_comments=disable_comments)
+    pass

--- a/wagtail/admin/edit_handlers.py
+++ b/wagtail/admin/edit_handlers.py
@@ -603,8 +603,7 @@ class FieldPanel(EditHandler):
 
 
 class RichTextFieldPanel(FieldPanel):
-    def get_comparison_class(self):
-        return compare.RichTextFieldComparison
+    pass
 
 
 class BaseChooserPanel(FieldPanel):
@@ -1011,9 +1010,6 @@ class StreamFieldPanel(FieldPanel):
             classes.remove("error")
 
         return classes
-
-    def get_comparison_class(self):
-        return compare.StreamFieldComparison
 
     def id_for_label(self):
         # a StreamField may consist of many input fields, so it's not meaningful to

--- a/wagtail/admin/edit_handlers.py
+++ b/wagtail/admin/edit_handlers.py
@@ -615,26 +615,9 @@ class RichTextFieldPanel(FieldPanel):
 
 
 class BaseChooserPanel(FieldPanel):
-    """
-    Abstract superclass for panels that provide a modal interface for choosing (or creating)
-    a database object such as an image, resulting in an ID that is used to populate
-    a hidden foreign key input.
-
-    Subclasses can override field_template and render_as_field to customise the rendering, but
-    probably shouldn't - any custom rendering requirements are better implemented in the widget
-    rather than the panel, so that non-edit-handler-based forms can benefit from then too.
-    """
-
-    def get_chosen_item(self):
-        field = self.instance._meta.get_field(self.field_name)
-        related_model = field.remote_field.model
-        try:
-            return getattr(self.instance, self.field_name)
-        except related_model.DoesNotExist:
-            # if the ForeignKey is null=False, Django decides to raise
-            # a DoesNotExist exception here, rather than returning None
-            # like every other unpopulated field type. Yay consistency!
-            return
+    # For backwards compatibility only - chooser panels no longer need any base functionality
+    # beyond FieldPanel.
+    pass
 
 
 class PageChooserPanel(BaseChooserPanel):

--- a/wagtail/admin/edit_handlers.py
+++ b/wagtail/admin/edit_handlers.py
@@ -7,7 +7,6 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.exceptions import FieldDoesNotExist, ImproperlyConfigured
 from django.core.signals import setting_changed
-from django.db.models.fields import CharField, TextField
 from django.dispatch import receiver
 from django.forms.formsets import DELETION_FIELD_NAME, ORDERING_FIELD_NAME
 from django.forms.models import fields_for_model
@@ -16,12 +15,10 @@ from django.utils.functional import cached_property
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy
 from modelcluster.models import get_serializable_data_for_fields
-from taggit.managers import TaggableManager
 
 from wagtail.admin import compare, widgets
 from wagtail.admin.forms.comments import CommentForm, CommentReplyForm
 from wagtail.admin.templatetags.wagtailadmin_tags import avatar_url, user_display_name
-from wagtail.core.fields import RichTextField
 from wagtail.core.models import COMMENTS_RELATION_NAME, Page
 from wagtail.core.utils import camelcase_to_underscore
 from wagtail.utils.decorators import cached_classmethod
@@ -550,19 +547,15 @@ class FieldPanel(EditHandler):
             if field.choices:
                 return compare.ChoiceFieldComparison
 
+            comparison_class = compare.comparison_class_registry.get(field)
+            if comparison_class:
+                return comparison_class
+
             if field.is_relation:
-                if isinstance(field, TaggableManager):
-                    return compare.TagsFieldComparison
-                elif field.many_to_many:
+                if field.many_to_many:
                     return compare.M2MFieldComparison
 
                 return compare.ForeignObjectComparison
-
-            if isinstance(field, RichTextField):
-                return compare.RichTextFieldComparison
-
-            if isinstance(field, (CharField, TextField)):
-                return compare.TextFieldComparison
 
         except FieldDoesNotExist:
             pass

--- a/wagtail/admin/forms/models.py
+++ b/wagtail/admin/forms/models.py
@@ -8,55 +8,14 @@ from taggit.managers import TaggableManager
 from wagtail.admin import widgets
 from wagtail.admin.forms.tags import TagField
 from wagtail.core.models import Page
+from wagtail.utils.registry import ModelFieldRegistry
 
-# Form field properties to override whenever we encounter a model field
-# that matches one of these types - including subclasses
+# Define a registry of form field properties to override for a given model field
+registry = ModelFieldRegistry()
 
-
-# Overrides that should take effect for foreign key fields to a given model
-def _get_page_chooser_overrides(db_field):
-    return {
-        "widget": widgets.AdminPageChooser(target_models=[db_field.remote_field.model])
-    }
-
-
-FOREIGN_KEY_MODEL_OVERRIDES = {
-    Page: _get_page_chooser_overrides,
-}
-
-
-def _get_foreign_key_overrides(db_field):
-    target_model = db_field.remote_field.model
-    for model in target_model.mro():
-        if model in FOREIGN_KEY_MODEL_OVERRIDES:
-            overrides = FOREIGN_KEY_MODEL_OVERRIDES[model]
-            if callable(overrides):
-                overrides = overrides(db_field)
-            return overrides
-
-    # no override found for the given model
-    return {}
-
-
-def _get_tag_field_overrides(db_field):
-    return {"form_class": TagField, "tag_model": db_field.related_model}
-
-
-FORM_FIELD_OVERRIDES = {
-    models.ForeignKey: _get_foreign_key_overrides,
-    models.DateField: {"widget": widgets.AdminDateInput},
-    models.TimeField: {"widget": widgets.AdminTimeInput},
-    models.DateTimeField: {"widget": widgets.AdminDateTimeInput},
-    TaggableManager: _get_tag_field_overrides,
-}
-
-# Form field properties to override whenever we encounter a model field
-# that matches one of these types exactly, ignoring subclasses.
-# (This allows us to override the widget for models.TextField, but leave
-# the RichTextField widget alone)
-DIRECT_FORM_FIELD_OVERRIDES = {
-    models.TextField: {"widget": widgets.AdminAutoHeightTextInput},
-}
+# Aliases to lookups in the overrides registry, for backwards compatibility
+FORM_FIELD_OVERRIDES = registry.values_by_class
+DIRECT_FORM_FIELD_OVERRIDES = registry.values_by_exact_class
 
 
 def register_form_field_override(
@@ -72,39 +31,56 @@ def register_form_field_override(
             "register_form_field_override must be passed an 'override' keyword argument"
         )
 
-    if to:
-        if db_field_class == models.ForeignKey:
-            FOREIGN_KEY_MODEL_OVERRIDES[to] = override
-        else:
-            raise ImproperlyConfigured(
-                "The 'to' argument on register_form_field_override is only valid for ForeignKey fields"
-            )
-    elif exact_class:
-        DIRECT_FORM_FIELD_OVERRIDES[db_field_class] = override
-    else:
-        FORM_FIELD_OVERRIDES[db_field_class] = override
+    if to and db_field_class != models.ForeignKey:
+        raise ImproperlyConfigured(
+            "The 'to' argument on register_form_field_override is only valid for ForeignKey fields"
+        )
+
+    registry.register(db_field_class, to=to, value=override, exact_class=exact_class)
+
+
+# Define built-in overrides
+
+# Date / time fields
+register_form_field_override(
+    models.DateField, override={"widget": widgets.AdminDateInput}
+)
+register_form_field_override(
+    models.TimeField, override={"widget": widgets.AdminTimeInput}
+)
+register_form_field_override(
+    models.DateTimeField, override={"widget": widgets.AdminDateTimeInput}
+)
+
+# Auto-height text fields (defined as exact_class=True so that it doesn't take effect for RichTextField)
+register_form_field_override(
+    models.TextField,
+    override={"widget": widgets.AdminAutoHeightTextInput},
+    exact_class=True,
+)
+
+# Page chooser
+register_form_field_override(
+    models.ForeignKey,
+    to=Page,
+    override=lambda db_field: {
+        "widget": widgets.AdminPageChooser(target_models=[db_field.remote_field.model])
+    },
+)
+
+# Tag fields
+register_form_field_override(
+    TaggableManager,
+    override=(
+        lambda db_field: {"form_class": TagField, "tag_model": db_field.related_model}
+    ),
+)
 
 
 # Callback to allow us to override the default form fields provided for each model field.
 def formfield_for_dbfield(db_field, **kwargs):
-    # adapted from django/contrib/admin/options.py
-
-    overrides = None
-
-    # If we've got overrides for the formfield defined, use 'em. **kwargs
-    # passed to formfield_for_dbfield override the defaults.
-    if db_field.__class__ in DIRECT_FORM_FIELD_OVERRIDES:
-        overrides = DIRECT_FORM_FIELD_OVERRIDES[db_field.__class__]
-    else:
-        for klass in db_field.__class__.mro():
-            if klass in FORM_FIELD_OVERRIDES:
-                overrides = FORM_FIELD_OVERRIDES[klass]
-                break
-
+    overrides = registry.get(db_field)
     if overrides:
-        if callable(overrides):
-            overrides = overrides(db_field)
-
         kwargs = dict(copy.deepcopy(overrides), **kwargs)
 
     return db_field.formfield(**kwargs)

--- a/wagtail/admin/forms/models.py
+++ b/wagtail/admin/forms/models.py
@@ -6,9 +6,26 @@ from taggit.managers import TaggableManager
 
 from wagtail.admin import widgets
 from wagtail.admin.forms.tags import TagField
+from wagtail.core.models import Page
 
 # Form field properties to override whenever we encounter a model field
 # that matches one of these types - including subclasses
+
+
+# Overrides that should take effect for foreign key fields to a given model
+FOREIGN_KEY_MODEL_OVERRIDES = {
+    Page: {"widget": widgets.AdminPageChooser},
+}
+
+
+def _get_foreign_key_overrides(db_field):
+    target_model = db_field.remote_field.model
+    for model in target_model.mro():
+        if model in FOREIGN_KEY_MODEL_OVERRIDES:
+            return FOREIGN_KEY_MODEL_OVERRIDES[model]
+
+    # no override found for the given model
+    return {}
 
 
 def _get_tag_field_overrides(db_field):
@@ -16,6 +33,7 @@ def _get_tag_field_overrides(db_field):
 
 
 FORM_FIELD_OVERRIDES = {
+    models.ForeignKey: _get_foreign_key_overrides,
     models.DateField: {"widget": widgets.AdminDateInput},
     models.TimeField: {"widget": widgets.AdminTimeInput},
     models.DateTimeField: {"widget": widgets.AdminDateTimeInput},

--- a/wagtail/admin/forms/models.py
+++ b/wagtail/admin/forms/models.py
@@ -14,8 +14,14 @@ from wagtail.core.models import Page
 
 
 # Overrides that should take effect for foreign key fields to a given model
+def _get_page_chooser_overrides(db_field):
+    return {
+        "widget": widgets.AdminPageChooser(target_models=[db_field.remote_field.model])
+    }
+
+
 FOREIGN_KEY_MODEL_OVERRIDES = {
-    Page: {"widget": widgets.AdminPageChooser},
+    Page: _get_page_chooser_overrides,
 }
 
 
@@ -23,7 +29,10 @@ def _get_foreign_key_overrides(db_field):
     target_model = db_field.remote_field.model
     for model in target_model.mro():
         if model in FOREIGN_KEY_MODEL_OVERRIDES:
-            return FOREIGN_KEY_MODEL_OVERRIDES[model]
+            overrides = FOREIGN_KEY_MODEL_OVERRIDES[model]
+            if callable(overrides):
+                overrides = overrides(db_field)
+            return overrides
 
     # no override found for the given model
     return {}

--- a/wagtail/admin/forms/models.py
+++ b/wagtail/admin/forms/models.py
@@ -83,13 +83,7 @@ class WagtailAdminModelFormMetaclass(ClusterFormMetaclass):
 
 
 class WagtailAdminModelForm(ClusterForm, metaclass=WagtailAdminModelFormMetaclass):
-    @property
-    def media(self):
-        # Include media from formsets forms. This allow StreamField in InlinePanel for example.
-        media = super().media
-        for formset in self.formsets.values():
-            media += formset.media
-        return media
+    pass
 
 
 # Now, any model forms built off WagtailAdminModelForm instead of ModelForm should pick up

--- a/wagtail/admin/forms/models.py
+++ b/wagtail/admin/forms/models.py
@@ -1,5 +1,6 @@
 import copy
 
+from django.core.exceptions import ImproperlyConfigured
 from django.db import models
 from modelcluster.forms import ClusterForm, ClusterFormMetaclass
 from taggit.managers import TaggableManager
@@ -47,6 +48,32 @@ FORM_FIELD_OVERRIDES = {
 DIRECT_FORM_FIELD_OVERRIDES = {
     models.TextField: {"widget": widgets.AdminAutoHeightTextInput},
 }
+
+
+def register_form_field_override(
+    db_field_class, to=None, override=None, exact_class=False
+):
+    """
+    Define parameters for form fields to be used by WagtailAdminModelForm for a given
+    database field.
+    """
+
+    if override is None:
+        raise ImproperlyConfigured(
+            "register_form_field_override must be passed an 'override' keyword argument"
+        )
+
+    if to:
+        if db_field_class == models.ForeignKey:
+            FOREIGN_KEY_MODEL_OVERRIDES[to] = override
+        else:
+            raise ImproperlyConfigured(
+                "The 'to' argument on register_form_field_override is only valid for ForeignKey fields"
+            )
+    elif exact_class:
+        DIRECT_FORM_FIELD_OVERRIDES[db_field_class] = override
+    else:
+        FORM_FIELD_OVERRIDES[db_field_class] = override
 
 
 # Callback to allow us to override the default form fields provided for each model field.

--- a/wagtail/admin/rich_text/editors/draftail/__init__.py
+++ b/wagtail/admin/rich_text/editors/draftail/__init__.py
@@ -4,7 +4,6 @@ import warnings
 from django.forms import Media, widgets
 from django.utils.functional import cached_property
 
-from wagtail.admin.edit_handlers import RichTextFieldPanel
 from wagtail.admin.rich_text.converters.contentstate import ContentstateConverter
 from wagtail.admin.staticfiles import versioned_static
 from wagtail.core.rich_text import features as feature_registry
@@ -21,9 +20,6 @@ class DraftailRichTextArea(widgets.HiddenInput):
 
     # Draftail has its own commenting
     show_add_comment_button = False
-
-    def get_panel(self):
-        return RichTextFieldPanel
 
     def __init__(self, *args, **kwargs):
         # note: this constructor will receive an 'options' kwarg taken from the WAGTAILADMIN_RICH_TEXT_EDITORS setting,

--- a/wagtail/admin/static_src/wagtailadmin/scss/layouts/page-editor.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/layouts/page-editor.scss
@@ -279,7 +279,7 @@
   }
 
   // cursory styling for streamfield. Main styling in client/src/components/StreamField/StreamField.scss
-  &.stream-field {
+  &.block_field {
     padding-left: 20px;
     padding-right: 20px;
 
@@ -523,7 +523,7 @@ footer .preview {
       opacity: 0;
     }
 
-    &.stream-field {
+    &.block_field {
       .object-help {
         padding-left: 6.4em;
       }

--- a/wagtail/admin/tests/pages/test_edit_page.py
+++ b/wagtail/admin/tests/pages/test_edit_page.py
@@ -1547,11 +1547,11 @@ class TestChildRelationsOnSuperclass(TestCase, WagtailTestUtils):
         # Response should include an advert_placements formset labelled Adverts
         self.assertContains(response, "Adverts")
         self.assertContains(response, "id_advert_placements-TOTAL_FORMS")
-        # the formset should be populated with an existing form
-        self.assertContains(response, "id_advert_placements-0-advert")
+        # the formset should be populated with an existing form (with a snippet chooser widget)
+        self.assertContains(response, '<span class="title">test_advert</span>')
         self.assertContains(
             response,
-            '<option value="1" selected="selected">test_advert</option>',
+            '<input type="hidden" name="advert_placements-0-advert" value="1" id="id_advert_placements-0-advert">',
             html=True,
         )
 

--- a/wagtail/admin/tests/test_edit_handlers.py
+++ b/wagtail/admin/tests/test_edit_handlers.py
@@ -35,7 +35,6 @@ from wagtail.admin.widgets import (
 from wagtail.core.models import Comment, CommentReply, Page, Site
 from wagtail.tests.testapp.forms import ValidatedPageForm
 from wagtail.tests.testapp.models import (
-    DefaultStreamPage,
     EventPage,
     EventPageChooserModel,
     EventPageSpeaker,
@@ -253,33 +252,6 @@ class TestPageEditHandlers(TestCase):
             errors.sort(key=lambda e: e.id)
 
             self.assertEqual(errors, [invalid_base_form, invalid_edit_handler])
-
-    @clear_edit_handler(DefaultStreamPage)
-    def test_check_invalid_streamfield_edit_handler(self):
-        """
-        Set the edit handler for body (a StreamField) to be
-        a FieldPanel instead of a StreamFieldPanel.
-        Check that the correct warning is raised.
-        """
-
-        invalid_edit_handler = checks.Warning(
-            "DefaultStreamPage.body is a StreamField, but uses FieldPanel",
-            hint="Ensure that it uses a StreamFieldPanel, or change the field type",
-            obj=DefaultStreamPage,
-            id="wagtailadmin.W003",
-        )
-
-        with mock.patch.object(
-            DefaultStreamPage, "content_panels", new=[FieldPanel("body")]
-        ):
-            checks_result = checks.run_checks(tags=["panels"])
-
-            # Only look at warnings for DefaultStreamPage
-            warning = [
-                warning for warning in checks_result if warning.obj == DefaultStreamPage
-            ]
-
-            self.assertEqual(warning, [invalid_edit_handler])
 
     @clear_edit_handler(ValidatedPage)
     def test_custom_edit_handler_form_class(self):

--- a/wagtail/admin/tests/test_edit_handlers.py
+++ b/wagtail/admin/tests/test_edit_handlers.py
@@ -979,22 +979,21 @@ class TestPageChooserPanel(TestCase):
         self.assertIn(expected_js, result)
 
     def test_target_models(self):
-        result = (
-            PageChooserPanel("page", "wagtailcore.site")
-            .bind_to(model=PageChooserModel)
-            .target_models()
-        )
-        self.assertEqual(result, [Site])
-
-    def test_target_models_malformed_type(self):
-        result = PageChooserPanel("page", "snowman").bind_to(model=PageChooserModel)
-        self.assertRaises(ImproperlyConfigured, result.target_models)
-
-    def test_target_models_nonexistent_type(self):
-        result = PageChooserPanel("page", "snowman.lorry").bind_to(
+        panel = PageChooserPanel("page", "wagtailcore.site").bind_to(
             model=PageChooserModel
         )
-        self.assertRaises(ImproperlyConfigured, result.target_models)
+        widget = panel.widget_overrides()["page"]
+        self.assertEqual(widget.target_models, [Site])
+
+    def test_target_models_malformed_type(self):
+        panel = PageChooserPanel("page", "snowman").bind_to(model=PageChooserModel)
+        self.assertRaises(ImproperlyConfigured, panel.widget_overrides)
+
+    def test_target_models_nonexistent_type(self):
+        panel = PageChooserPanel("page", "snowman.lorry").bind_to(
+            model=PageChooserModel
+        )
+        self.assertRaises(ImproperlyConfigured, panel.widget_overrides)
 
 
 class TestInlinePanel(TestCase, WagtailTestUtils):

--- a/wagtail/admin/tests/test_edit_handlers.py
+++ b/wagtail/admin/tests/test_edit_handlers.py
@@ -18,6 +18,7 @@ from wagtail.admin.edit_handlers import (
     FieldPanel,
     FieldRowPanel,
     InlinePanel,
+    MultiFieldPanel,
     ObjectList,
     PageChooserPanel,
     TabbedInterface,
@@ -32,7 +33,6 @@ from wagtail.admin.widgets import (
     AdminPageChooser,
 )
 from wagtail.core.models import Comment, CommentReply, Page, Site
-from wagtail.images.edit_handlers import ImageChooserPanel
 from wagtail.tests.testapp.forms import ValidatedPageForm
 from wagtail.tests.testapp.models import (
     DefaultStreamPage,
@@ -317,7 +317,7 @@ class TestExtractPanelDefinitionsFromModelClass(TestCase):
         # A class with a 'panels' property defined should return that list
         result = extract_panel_definitions_from_model_class(EventPageSpeaker)
         self.assertEqual(len(result), 5)
-        self.assertTrue(any([isinstance(panel, ImageChooserPanel) for panel in result]))
+        self.assertTrue(any([isinstance(panel, MultiFieldPanel) for panel in result]))
 
     def test_exclude(self):
         panels = extract_panel_definitions_from_model_class(Site, exclude=["hostname"])
@@ -804,7 +804,7 @@ class TestFieldRowPanelWithChooser(TestCase):
         self.dates_panel = FieldRowPanel(
             [
                 FieldPanel("date_from"),
-                ImageChooserPanel("feed_image"),
+                FieldPanel("feed_image"),
             ]
         ).bind_to(model=EventPage, request=self.request)
 
@@ -1063,7 +1063,7 @@ class TestInlinePanel(TestCase, WagtailTestUtils):
                     label="Speakers",
                     panels=[
                         FieldPanel("first_name", widget=forms.Textarea),
-                        ImageChooserPanel("image"),
+                        FieldPanel("image"),
                     ],
                 ),
             ]
@@ -1141,7 +1141,7 @@ class TestInlinePanel(TestCase, WagtailTestUtils):
                     label="Speakers",
                     panels=[
                         FieldPanel("first_name", widget=forms.Textarea),
-                        ImageChooserPanel("image"),
+                        FieldPanel("image"),
                     ],
                 ),
             ]

--- a/wagtail/admin/tests/test_edit_handlers.py
+++ b/wagtail/admin/tests/test_edit_handlers.py
@@ -20,7 +20,6 @@ from wagtail.admin.edit_handlers import (
     InlinePanel,
     ObjectList,
     PageChooserPanel,
-    RichTextFieldPanel,
     TabbedInterface,
     extract_panel_definitions_from_model_class,
     get_form_for_model,
@@ -333,16 +332,6 @@ class TestExtractPanelDefinitionsFromModelClass(TestCase):
             any(
                 [
                     isinstance(panel, FieldPanel) and panel.field_name == "date_from"
-                    for panel in panels
-                ]
-            )
-        )
-
-        # returned panel types should respect modelfield.get_panel() - used on RichTextField
-        self.assertTrue(
-            any(
-                [
-                    isinstance(panel, RichTextFieldPanel) and panel.field_name == "body"
                     for panel in panels
                 ]
             )

--- a/wagtail/admin/tests/test_edit_handlers.py
+++ b/wagtail/admin/tests/test_edit_handlers.py
@@ -905,10 +905,6 @@ class TestPageChooserPanel(TestCase):
         )
         self.assertIn(expected_js, result)
 
-    def test_get_chosen_item(self):
-        result = self.page_chooser_panel.get_chosen_item()
-        self.assertEqual(result, self.christmas_page)
-
     def test_render_as_field(self):
         result = self.page_chooser_panel.render_as_field()
         self.assertIn('<p class="help">help text</p>', result)

--- a/wagtail/admin/tests/test_widgets.py
+++ b/wagtail/admin/tests/test_widgets.py
@@ -116,8 +116,32 @@ class TestAdminPageChooserWidget(TestCase):
         html = widget.render("test", self.child_page, {"id": "test-id"})
         self.assertIn(">Choose a page (Simple Page)<", html)
 
+    def test_render_with_target_model_as_single_instance(self):
+        widget = widgets.AdminPageChooser(target_models=SimplePage)
+
+        html = widget.render("test", None, {"id": "test-id"})
+        self.assertIn(
+            'createPageChooser("test-id", null, {"model_names": ["tests.simplepage"], "can_choose_root": false, "user_perms": null});',
+            html,
+        )
+
+        html = widget.render("test", self.child_page, {"id": "test-id"})
+        self.assertIn(">Choose a page (Simple Page)<", html)
+
+    def test_render_with_target_model_as_single_string(self):
+        widget = widgets.AdminPageChooser(target_models="tests.SimplePage")
+
+        html = widget.render("test", None, {"id": "test-id"})
+        self.assertIn(
+            'createPageChooser("test-id", null, {"model_names": ["tests.simplepage"], "can_choose_root": false, "user_perms": null});',
+            html,
+        )
+
+        html = widget.render("test", self.child_page, {"id": "test-id"})
+        self.assertIn(">Choose a page (Simple Page)<", html)
+
     def test_render_with_multiple_target_models(self):
-        target_models = [SimplePage, EventPage]
+        target_models = [SimplePage, "tests.eventpage"]
         widget = widgets.AdminPageChooser(target_models=target_models)
 
         html = widget.render("test", None, {"id": "test-id"})

--- a/wagtail/core/blocks/base.py
+++ b/wagtail/core/blocks/base.py
@@ -522,6 +522,11 @@ class BlockWidget(forms.Widget):
 
         return self._block_json
 
+    def id_for_label(self, prefix):
+        # Delegate the job of choosing a label ID to the top-level block.
+        # (In practice, the top-level block will typically be a StreamBlock, which returns None.)
+        return self.block_def.id_for_label(prefix)
+
     def render_with_errors(self, name, value, attrs=None, errors=None, renderer=None):
         value_json = json.dumps(self.block_def.get_form_state(value))
 

--- a/wagtail/core/fields.py
+++ b/wagtail/core/fields.py
@@ -93,11 +93,6 @@ class StreamField(models.Field):
     def get_internal_type(self):
         return "TextField"
 
-    def get_panel(self):
-        from wagtail.admin.edit_handlers import StreamFieldPanel
-
-        return StreamFieldPanel
-
     def deconstruct(self):
         name, path, _, kwargs = super().deconstruct()
         block_types = list(self.stream_block.child_blocks.items())

--- a/wagtail/documents/apps.py
+++ b/wagtail/documents/apps.py
@@ -12,3 +12,13 @@ class WagtailDocsAppConfig(AppConfig):
         from wagtail.documents.signal_handlers import register_signal_handlers
 
         register_signal_handlers()
+
+        # Set up model forms to use AdminDocumentChooser for any ForeignKey to the document model
+        from wagtail.admin.forms.models import FOREIGN_KEY_MODEL_OVERRIDES
+
+        from . import get_document_model
+        from .widgets import AdminDocumentChooser
+
+        FOREIGN_KEY_MODEL_OVERRIDES[get_document_model()] = {
+            "widget": AdminDocumentChooser
+        }

--- a/wagtail/documents/apps.py
+++ b/wagtail/documents/apps.py
@@ -1,5 +1,8 @@
 from django.apps import AppConfig
+from django.db.models import ForeignKey
 from django.utils.translation import gettext_lazy as _
+
+from . import get_document_model
 
 
 class WagtailDocsAppConfig(AppConfig):
@@ -14,11 +17,11 @@ class WagtailDocsAppConfig(AppConfig):
         register_signal_handlers()
 
         # Set up model forms to use AdminDocumentChooser for any ForeignKey to the document model
-        from wagtail.admin.forms.models import FOREIGN_KEY_MODEL_OVERRIDES
+        from wagtail.admin.forms.models import register_form_field_override
 
-        from . import get_document_model
         from .widgets import AdminDocumentChooser
 
-        FOREIGN_KEY_MODEL_OVERRIDES[get_document_model()] = {
-            "widget": AdminDocumentChooser
-        }
+        Document = get_document_model()
+        register_form_field_override(
+            ForeignKey, to=Document, override={"widget": AdminDocumentChooser}
+        )

--- a/wagtail/documents/edit_handlers.py
+++ b/wagtail/documents/edit_handlers.py
@@ -1,8 +1,5 @@
 from wagtail.admin.edit_handlers import BaseChooserPanel
 
-from .widgets import AdminDocumentChooser
-
 
 class DocumentChooserPanel(BaseChooserPanel):
-    def widget_overrides(self):
-        return {self.field_name: AdminDocumentChooser}
+    pass

--- a/wagtail/documents/edit_handlers.py
+++ b/wagtail/documents/edit_handlers.py
@@ -4,7 +4,5 @@ from .widgets import AdminDocumentChooser
 
 
 class DocumentChooserPanel(BaseChooserPanel):
-    object_type_name = "document"
-
     def widget_overrides(self):
         return {self.field_name: AdminDocumentChooser}

--- a/wagtail/images/apps.py
+++ b/wagtail/images/apps.py
@@ -1,7 +1,9 @@
 from django.apps import AppConfig
+from django.db.models import ForeignKey
 from django.utils.translation import gettext_lazy as _
 
-from . import checks  # NOQA
+from . import checks, get_image_model  # NOQA
+from .signal_handlers import register_signal_handlers
 
 
 class WagtailImagesAppConfig(AppConfig):
@@ -11,14 +13,14 @@ class WagtailImagesAppConfig(AppConfig):
     default_auto_field = "django.db.models.AutoField"
 
     def ready(self):
-        from wagtail.images.signal_handlers import register_signal_handlers
-
         register_signal_handlers()
 
         # Set up model forms to use AdminImageChooser for any ForeignKey to the image model
-        from wagtail.admin.forms.models import FOREIGN_KEY_MODEL_OVERRIDES
+        from wagtail.admin.forms.models import register_form_field_override
 
-        from . import get_image_model
         from .widgets import AdminImageChooser
 
-        FOREIGN_KEY_MODEL_OVERRIDES[get_image_model()] = {"widget": AdminImageChooser}
+        Image = get_image_model()
+        register_form_field_override(
+            ForeignKey, to=Image, override={"widget": AdminImageChooser}
+        )

--- a/wagtail/images/apps.py
+++ b/wagtail/images/apps.py
@@ -24,3 +24,13 @@ class WagtailImagesAppConfig(AppConfig):
         register_form_field_override(
             ForeignKey, to=Image, override={"widget": AdminImageChooser}
         )
+
+        # Set up image ForeignKeys to use ImageFieldComparison as the comparison class
+        # when comparing page revisions
+        from wagtail.admin.compare import register_comparison_class
+
+        from .edit_handlers import ImageFieldComparison
+
+        register_comparison_class(
+            ForeignKey, to=Image, comparison_class=ImageFieldComparison
+        )

--- a/wagtail/images/apps.py
+++ b/wagtail/images/apps.py
@@ -14,3 +14,11 @@ class WagtailImagesAppConfig(AppConfig):
         from wagtail.images.signal_handlers import register_signal_handlers
 
         register_signal_handlers()
+
+        # Set up model forms to use AdminImageChooser for any ForeignKey to the image model
+        from wagtail.admin.forms.models import FOREIGN_KEY_MODEL_OVERRIDES
+
+        from . import get_image_model
+        from .widgets import AdminImageChooser
+
+        FOREIGN_KEY_MODEL_OVERRIDES[get_image_model()] = {"widget": AdminImageChooser}

--- a/wagtail/images/edit_handlers.py
+++ b/wagtail/images/edit_handlers.py
@@ -3,13 +3,8 @@ from django.template.loader import render_to_string
 from wagtail.admin.compare import ForeignObjectComparison
 from wagtail.admin.edit_handlers import BaseChooserPanel
 
-from .widgets import AdminImageChooser
-
 
 class ImageChooserPanel(BaseChooserPanel):
-    def widget_overrides(self):
-        return {self.field_name: AdminImageChooser}
-
     def get_comparison_class(self):
         return ImageFieldComparison
 

--- a/wagtail/images/edit_handlers.py
+++ b/wagtail/images/edit_handlers.py
@@ -7,8 +7,6 @@ from .widgets import AdminImageChooser
 
 
 class ImageChooserPanel(BaseChooserPanel):
-    object_type_name = "image"
-
     def widget_overrides(self):
         return {self.field_name: AdminImageChooser}
 

--- a/wagtail/images/edit_handlers.py
+++ b/wagtail/images/edit_handlers.py
@@ -5,8 +5,7 @@ from wagtail.admin.edit_handlers import BaseChooserPanel
 
 
 class ImageChooserPanel(BaseChooserPanel):
-    def get_comparison_class(self):
-        return ImageFieldComparison
+    pass
 
 
 class ImageFieldComparison(ForeignObjectComparison):

--- a/wagtail/snippets/edit_handlers.py
+++ b/wagtail/snippets/edit_handlers.py
@@ -1,12 +1,5 @@
 from wagtail.admin.edit_handlers import BaseChooserPanel
 
-from .widgets import AdminSnippetChooser
-
 
 class SnippetChooserPanel(BaseChooserPanel):
-    def widget_overrides(self):
-        return {self.field_name: AdminSnippetChooser(model=self.target_model)}
-
-    def on_model_bound(self):
-        super().on_model_bound()
-        self.target_model = self.db_field.remote_field.model
+    pass

--- a/wagtail/snippets/edit_handlers.py
+++ b/wagtail/snippets/edit_handlers.py
@@ -1,28 +1,11 @@
-from django.template.loader import render_to_string
-from django.utils.safestring import mark_safe
-
 from wagtail.admin.edit_handlers import BaseChooserPanel
 
 from .widgets import AdminSnippetChooser
 
 
 class SnippetChooserPanel(BaseChooserPanel):
-    object_type_name = "item"
-
     def widget_overrides(self):
         return {self.field_name: AdminSnippetChooser(model=self.target_model)}
-
-    def render_as_field(self):
-        instance_obj = self.get_chosen_item()
-        return mark_safe(
-            render_to_string(
-                self.field_template,
-                {
-                    "field": self.bound_field,
-                    self.object_type_name: instance_obj,
-                },
-            )
-        )
 
     def on_model_bound(self):
         super().on_model_bound()

--- a/wagtail/snippets/models.py
+++ b/wagtail/snippets/models.py
@@ -1,14 +1,14 @@
 from django.contrib.admin.utils import quote
 from django.core import checks
+from django.db.models import ForeignKey
 from django.urls import reverse
 
 from wagtail.admin.admin_url_finder import register_admin_url_finder
 from wagtail.admin.checks import check_panels_in_model
-from wagtail.admin.forms.models import FOREIGN_KEY_MODEL_OVERRIDES
+from wagtail.admin.forms.models import register_form_field_override
 from wagtail.admin.models import get_object_usage
 
 from .widgets import AdminSnippetChooser
-
 
 SNIPPET_MODELS = []
 
@@ -60,9 +60,9 @@ def register_snippet(model):
             return errors
 
         # Set up admin model forms to use AdminSnippetChooser for any ForeignKey to this model
-        FOREIGN_KEY_MODEL_OVERRIDES[model] = {
-            "widget": AdminSnippetChooser(model=model)
-        }
+        register_form_field_override(
+            ForeignKey, to=model, override={"widget": AdminSnippetChooser(model=model)}
+        )
 
     return model
 

--- a/wagtail/snippets/models.py
+++ b/wagtail/snippets/models.py
@@ -4,7 +4,11 @@ from django.urls import reverse
 
 from wagtail.admin.admin_url_finder import register_admin_url_finder
 from wagtail.admin.checks import check_panels_in_model
+from wagtail.admin.forms.models import FOREIGN_KEY_MODEL_OVERRIDES
 from wagtail.admin.models import get_object_usage
+
+from .widgets import AdminSnippetChooser
+
 
 SNIPPET_MODELS = []
 
@@ -54,6 +58,11 @@ def register_snippet(model):
         def modeladmin_model_check(app_configs, **kwargs):
             errors = check_panels_in_model(model, "snippets")
             return errors
+
+        # Set up admin model forms to use AdminSnippetChooser for any ForeignKey to this model
+        FOREIGN_KEY_MODEL_OVERRIDES[model] = {
+            "widget": AdminSnippetChooser(model=model)
+        }
 
     return model
 

--- a/wagtail/snippets/tests.py
+++ b/wagtail/snippets/tests.py
@@ -28,7 +28,6 @@ from wagtail.snippets.action_menu import (
     get_base_snippet_action_menu_items,
 )
 from wagtail.snippets.blocks import SnippetChooserBlock
-from wagtail.snippets.edit_handlers import SnippetChooserPanel
 from wagtail.snippets.models import SNIPPET_MODELS, register_snippet
 from wagtail.snippets.views.snippets import get_snippet_edit_handler
 from wagtail.snippets.widgets import (
@@ -1310,9 +1309,6 @@ class TestSnippetChooserPanel(TestCase, WagtailTestUtils):
             if getattr(panel, "field_name", None) == "advert"
         ][0]
 
-    def test_create_snippet_chooser_panel_class(self):
-        self.assertIsInstance(self.snippet_chooser_panel, SnippetChooserPanel)
-
     def test_render_as_field(self):
         field_html = self.snippet_chooser_panel.render_as_field()
         self.assertIn(self.advert_text, field_html)
@@ -1343,7 +1339,7 @@ class TestSnippetChooserPanel(TestCase, WagtailTestUtils):
         )
 
     def test_target_model_autodetected(self):
-        edit_handler = ObjectList([SnippetChooserPanel("advert")]).bind_to(
+        edit_handler = ObjectList([FieldPanel("advert")]).bind_to(
             model=SnippetChooserModel
         )
         form_class = edit_handler.get_form_class()
@@ -2168,9 +2164,6 @@ class TestSnippetChooserPanelWithCustomPrimaryKey(TestCase, WagtailTestUtils):
             if getattr(panel, "field_name", None) == "advertwithcustomprimarykey"
         ][0]
 
-    def test_create_snippet_chooser_panel_class(self):
-        self.assertIsInstance(self.snippet_chooser_panel, SnippetChooserPanel)
-
     def test_render_as_field(self):
         field_html = self.snippet_chooser_panel.render_as_field()
         self.assertIn(self.advert_text, field_html)
@@ -2201,9 +2194,9 @@ class TestSnippetChooserPanelWithCustomPrimaryKey(TestCase, WagtailTestUtils):
         )
 
     def test_target_model_autodetected(self):
-        edit_handler = ObjectList(
-            [SnippetChooserPanel("advertwithcustomprimarykey")]
-        ).bind_to(model=SnippetChooserModelWithCustomPrimaryKey)
+        edit_handler = ObjectList([FieldPanel("advertwithcustomprimarykey")]).bind_to(
+            model=SnippetChooserModelWithCustomPrimaryKey
+        )
         form_class = edit_handler.get_form_class()
         form = form_class()
         widget = form.fields["advertwithcustomprimarykey"].widget

--- a/wagtail/snippets/tests.py
+++ b/wagtail/snippets/tests.py
@@ -18,7 +18,7 @@ from django.utils.timezone import make_aware
 from taggit.models import Tag
 
 from wagtail.admin.admin_url_finder import AdminURLFinder
-from wagtail.admin.edit_handlers import FieldPanel
+from wagtail.admin.edit_handlers import FieldPanel, ObjectList
 from wagtail.admin.forms import WagtailAdminModelForm
 from wagtail.core import hooks
 from wagtail.core.blocks.field_block import FieldBlockAdapter
@@ -1343,12 +1343,14 @@ class TestSnippetChooserPanel(TestCase, WagtailTestUtils):
         )
 
     def test_target_model_autodetected(self):
-        result = (
-            SnippetChooserPanel("advert")
-            .bind_to(model=SnippetChooserModel)
-            .target_model
+        edit_handler = ObjectList([SnippetChooserPanel("advert")]).bind_to(
+            model=SnippetChooserModel
         )
-        self.assertEqual(result, Advert)
+        form_class = edit_handler.get_form_class()
+        form = form_class()
+        widget = form.fields["advert"].widget
+        self.assertIsInstance(widget, AdminSnippetChooser)
+        self.assertEqual(widget.target_model, Advert)
 
 
 class TestSnippetRegistering(TestCase):
@@ -2199,12 +2201,14 @@ class TestSnippetChooserPanelWithCustomPrimaryKey(TestCase, WagtailTestUtils):
         )
 
     def test_target_model_autodetected(self):
-        result = (
-            SnippetChooserPanel("advertwithcustomprimarykey")
-            .bind_to(model=SnippetChooserModelWithCustomPrimaryKey)
-            .target_model
-        )
-        self.assertEqual(result, AdvertWithCustomPrimaryKey)
+        edit_handler = ObjectList(
+            [SnippetChooserPanel("advertwithcustomprimarykey")]
+        ).bind_to(model=SnippetChooserModelWithCustomPrimaryKey)
+        form_class = edit_handler.get_form_class()
+        form = form_class()
+        widget = form.fields["advertwithcustomprimarykey"].widget
+        self.assertIsInstance(widget, AdminSnippetChooser)
+        self.assertEqual(widget.target_model, AdvertWithCustomPrimaryKey)
 
 
 class TestSnippetChooseWithCustomPrimaryKey(TestCase, WagtailTestUtils):

--- a/wagtail/tests/demosite/models.py
+++ b/wagtail/tests/demosite/models.py
@@ -7,18 +7,11 @@ from modelcluster.contrib.taggit import ClusterTaggableManager
 from modelcluster.fields import ParentalKey
 from taggit.models import TaggedItemBase
 
-from wagtail.admin.edit_handlers import (
-    FieldPanel,
-    InlinePanel,
-    MultiFieldPanel,
-    PageChooserPanel,
-)
+from wagtail.admin.edit_handlers import FieldPanel, InlinePanel, MultiFieldPanel
 from wagtail.api import APIField
 from wagtail.core.fields import RichTextField
 from wagtail.core.models import Orderable, Page
-from wagtail.documents.edit_handlers import DocumentChooserPanel
 from wagtail.images.api.fields import ImageRenditionField
-from wagtail.images.edit_handlers import ImageChooserPanel
 from wagtail.search import index
 
 # ABSTRACT MODELS
@@ -65,8 +58,8 @@ class AbstractLinkFields(models.Model):
 
     panels = [
         FieldPanel("link_external"),
-        PageChooserPanel("link_page"),
-        DocumentChooserPanel("link_document"),
+        FieldPanel("link_page"),
+        FieldPanel("link_document"),
     ]
 
     class Meta:
@@ -105,7 +98,7 @@ class AbstractCarouselItem(AbstractLinkFields):
     ) + AbstractLinkFields.api_fields
 
     panels = [
-        ImageChooserPanel("image"),
+        FieldPanel("image"),
         FieldPanel("embed_url"),
         FieldPanel("caption"),
         MultiFieldPanel(AbstractLinkFields.panels, "Link"),
@@ -246,7 +239,7 @@ StandardPage.content_panels = Page.content_panels + [
 
 StandardPage.promote_panels = [
     MultiFieldPanel(Page.promote_panels, "Common page configuration"),
-    ImageChooserPanel("feed_image"),
+    FieldPanel("feed_image"),
 ]
 
 
@@ -288,7 +281,7 @@ StandardIndexPage.content_panels = Page.content_panels + [
 
 StandardIndexPage.promote_panels = [
     MultiFieldPanel(Page.promote_panels, "Common page configuration"),
-    ImageChooserPanel("feed_image"),
+    FieldPanel("feed_image"),
 ]
 
 
@@ -360,7 +353,7 @@ BlogEntryPage.content_panels = Page.content_panels + [
 
 BlogEntryPage.promote_panels = [
     MultiFieldPanel(Page.promote_panels, "Common page configuration"),
-    ImageChooserPanel("feed_image"),
+    FieldPanel("feed_image"),
     FieldPanel("tags"),
 ]
 
@@ -513,7 +506,7 @@ class EventPageSpeaker(Orderable, AbstractLinkFields):
     panels = [
         FieldPanel("first_name"),
         FieldPanel("last_name"),
-        ImageChooserPanel("image"),
+        FieldPanel("image"),
         MultiFieldPanel(AbstractLinkFields.panels, "Link"),
     ]
 
@@ -536,7 +529,7 @@ EventPage.content_panels = Page.content_panels + [
 
 EventPage.promote_panels = [
     MultiFieldPanel(Page.promote_panels, "Common page configuration"),
-    ImageChooserPanel("feed_image"),
+    FieldPanel("feed_image"),
 ]
 
 
@@ -636,7 +629,7 @@ PersonPage.content_panels = Page.content_panels + [
     FieldPanel("last_name"),
     FieldPanel("intro", classname="full"),
     FieldPanel("biography", classname="full"),
-    ImageChooserPanel("image"),
+    FieldPanel("image"),
     MultiFieldPanel(ContactFieldsMixin.panels, "Contact"),
     InlinePanel("related_links", label="Related links"),
 ]
@@ -644,7 +637,7 @@ PersonPage.content_panels = Page.content_panels + [
 
 PersonPage.promote_panels = [
     MultiFieldPanel(Page.promote_panels, "Common page configuration"),
-    ImageChooserPanel("feed_image"),
+    FieldPanel("feed_image"),
 ]
 
 
@@ -682,5 +675,5 @@ ContactPage.content_panels = Page.content_panels + [
 
 ContactPage.promote_panels = [
     MultiFieldPanel(Page.promote_panels, "Common page configuration"),
-    ImageChooserPanel("feed_image"),
+    FieldPanel("feed_image"),
 ]

--- a/wagtail/tests/modeladmintest/models.py
+++ b/wagtail/tests/modeladmintest/models.py
@@ -4,7 +4,6 @@ from wagtail.admin.edit_handlers import (
     FieldPanel,
     MultiFieldPanel,
     ObjectList,
-    PageChooserPanel,
     TabbedInterface,
 )
 from wagtail.core.models import Page
@@ -150,7 +149,7 @@ class RelatedLink(models.Model):
         MultiFieldPanel(
             [
                 FieldPanel("title"),
-                PageChooserPanel("link"),
+                FieldPanel("link"),
             ],
             heading="Related Link",
         ),

--- a/wagtail/tests/testapp/models.py
+++ b/wagtail/tests/testapp/models.py
@@ -24,7 +24,6 @@ from wagtail.admin.edit_handlers import (
     InlinePanel,
     MultiFieldPanel,
     ObjectList,
-    PageChooserPanel,
     StreamFieldPanel,
     TabbedInterface,
 )
@@ -59,14 +58,11 @@ from wagtail.core.models import (
     TranslatableMixin,
 )
 from wagtail.documents import get_document_model
-from wagtail.documents.edit_handlers import DocumentChooserPanel
 from wagtail.documents.models import AbstractDocument, Document
 from wagtail.images import get_image_model
 from wagtail.images.blocks import ImageChooserBlock
-from wagtail.images.edit_handlers import ImageChooserPanel
 from wagtail.images.models import AbstractImage, AbstractRendition, Image
 from wagtail.search import index
-from wagtail.snippets.edit_handlers import SnippetChooserPanel
 from wagtail.snippets.models import register_snippet
 from wagtail.utils.decorators import cached_classmethod
 
@@ -117,8 +113,8 @@ class LinkFields(models.Model):
 
     panels = [
         FieldPanel("link_external"),
-        PageChooserPanel("link_page"),
-        DocumentChooserPanel("link_document"),
+        FieldPanel("link_page"),
+        FieldPanel("link_document"),
     ]
 
     class Meta:
@@ -140,7 +136,7 @@ class CarouselItem(LinkFields):
     caption = models.CharField(max_length=255, blank=True)
 
     panels = [
-        ImageChooserPanel("image"),
+        FieldPanel("image"),
         FieldPanel("embed_url"),
         FieldPanel("caption"),
         MultiFieldPanel(LinkFields.panels, "Link"),
@@ -278,7 +274,7 @@ class EventPageSpeaker(TranslatableMixin, Orderable, LinkFields, ClusterableMode
     panels = [
         FieldPanel("first_name"),
         FieldPanel("last_name"),
-        ImageChooserPanel("image"),
+        FieldPanel("image"),
         MultiFieldPanel(LinkFields.panels, "Link"),
         InlinePanel("awards", label="Awards"),
     ]
@@ -366,7 +362,7 @@ class EventPage(Page):
 
     promote_panels = [
         MultiFieldPanel(COMMON_PANELS, "Common page configuration"),
-        ImageChooserPanel("feed_image"),
+        FieldPanel("feed_image"),
     ]
 
 
@@ -592,7 +588,7 @@ class FormPageWithRedirect(AbstractEmailForm):
 
     content_panels = [
         FieldPanel("title", classname="full title"),
-        PageChooserPanel("thank_you_redirect_page"),
+        FieldPanel("thank_you_redirect_page"),
         InlinePanel("form_fields", label="Form fields"),
         MultiFieldPanel(
             [
@@ -1031,7 +1027,7 @@ class SnippetChooserModel(models.Model):
     advert = models.ForeignKey(Advert, help_text="help text", on_delete=models.CASCADE)
 
     panels = [
-        SnippetChooserPanel("advert"),
+        FieldPanel("advert"),
     ]
 
 
@@ -1041,7 +1037,7 @@ class SnippetChooserModelWithCustomPrimaryKey(models.Model):
     )
 
     panels = [
-        SnippetChooserPanel("advertwithcustomprimarykey"),
+        FieldPanel("advertwithcustomprimarykey"),
     ]
 
 

--- a/wagtail/tests/testapp/models.py
+++ b/wagtail/tests/testapp/models.py
@@ -24,7 +24,6 @@ from wagtail.admin.edit_handlers import (
     InlinePanel,
     MultiFieldPanel,
     ObjectList,
-    StreamFieldPanel,
     TabbedInterface,
 )
 from wagtail.admin.forms import WagtailAdminPageForm
@@ -1184,7 +1183,7 @@ class StreamPage(Page):
 
     content_panels = [
         FieldPanel("title"),
-        StreamFieldPanel("body"),
+        FieldPanel("body"),
     ]
 
     preview_modes = []
@@ -1202,7 +1201,7 @@ class DefaultStreamPage(Page):
 
     content_panels = [
         FieldPanel("title"),
-        StreamFieldPanel("body"),
+        FieldPanel("body"),
     ]
 
 
@@ -1400,7 +1399,7 @@ class DefaultRichBlockFieldPage(Page):
         ]
     )
 
-    content_panels = Page.content_panels + [StreamFieldPanel("body")]
+    content_panels = Page.content_panels + [FieldPanel("body")]
 
 
 class CustomRichTextFieldPage(Page):
@@ -1421,7 +1420,7 @@ class CustomRichBlockFieldPage(Page):
 
     content_panels = [
         FieldPanel("title", classname="full title"),
-        StreamFieldPanel("body"),
+        FieldPanel("body"),
     ]
 
 
@@ -1463,7 +1462,7 @@ class InlineStreamPageSection(Orderable):
             ("image", ImageChooserBlock()),
         ]
     )
-    panels = [StreamFieldPanel("body")]
+    panels = [FieldPanel("body")]
 
 
 class InlineStreamPage(Page):
@@ -1476,7 +1475,7 @@ class InlineStreamPage(Page):
 class TableBlockStreamPage(Page):
     table = StreamField([("table", TableBlock())])
 
-    content_panels = [StreamFieldPanel("table")]
+    content_panels = [FieldPanel("table")]
 
 
 class UserProfile(models.Model):
@@ -1701,7 +1700,7 @@ class DeadlyStreamPage(Page):
         ]
     )
     content_panels = Page.content_panels + [
-        StreamFieldPanel("body"),
+        FieldPanel("body"),
     ]
 
 

--- a/wagtail/tests/testapp/rich_text.py
+++ b/wagtail/tests/testapp/rich_text.py
@@ -2,14 +2,10 @@ import json
 
 from django.forms import Media, widgets
 
-from wagtail.admin.edit_handlers import RichTextFieldPanel
 from wagtail.utils.widgets import WidgetWithScript
 
 
 class CustomRichTextArea(WidgetWithScript, widgets.Textarea):
-    def get_panel(self):
-        return RichTextFieldPanel
-
     def render_js_init(self, id_, name, value):
         return "customEditorInitScript({0});".format(json.dumps(id_))
 
@@ -19,9 +15,6 @@ class CustomRichTextArea(WidgetWithScript, widgets.Textarea):
 
 
 class LegacyRichTextArea(WidgetWithScript, widgets.Textarea):
-    def get_panel(self):
-        return RichTextFieldPanel
-
     def render_js_init(self, id_, name, value):
         return "legacyEditorInitScript({0});".format(json.dumps(id_))
 

--- a/wagtail/utils/registry.py
+++ b/wagtail/utils/registry.py
@@ -1,0 +1,73 @@
+from django.core.exceptions import ImproperlyConfigured
+from django.db import models
+
+
+class ModelFieldRegistry:
+    """
+    Handles the recurring pattern where we need to register different values for different
+    model field types, and retrieve the one that most closely matches a given model field,
+    according to its type (taking inheritance into account), and in the case of foreign keys,
+    the type of the related model (again, taking inheritance into account).
+
+    For example, this is used by wagtail.admin.forms.models when constructing model forms:
+    we use such a registry to retrieve the appropriate dict of arguments to pass to the
+    form field constructor. A lookup for a models.TextField will return a dict specifying a
+    text area widget, and a lookup for a foreign key to Image will return a dict specifying
+    an image chooser widget.
+    """
+
+    def __init__(self):
+        # values in this dict will be returned if the field type exactly matches an item here
+        self.values_by_exact_class = {}
+
+        # values in this dict will be returned if any class in the field's inheritance chain
+        # matches, preferring more specific subclasses
+        self.values_by_class = {
+            models.ForeignKey: self.foreign_key_lookup,
+        }
+
+        # values in this dict will be returned if the field is a foreign key to a related
+        # model in here, matching most specific subclass first
+        self.values_by_fk_related_model = {}
+
+    def register(self, field_class, to=None, value=None, exact_class=False):
+        if to:
+            if field_class == models.ForeignKey:
+                self.values_by_fk_related_model[to] = value
+            else:
+                raise ImproperlyConfigured(
+                    "The 'to' argument on ModelFieldRegistry.register is only valid for ForeignKey fields"
+                )
+        elif exact_class:
+            self.values_by_exact_class[field_class] = value
+        else:
+            self.values_by_class[field_class] = value
+
+    def get(self, field):
+        value = None
+        if field.__class__ in self.values_by_exact_class:
+            value = self.values_by_exact_class[field.__class__]
+        else:
+            for klass in field.__class__.mro():
+                if klass in self.values_by_class:
+                    value = self.values_by_class[klass]
+                    break
+
+        if callable(value) and not isinstance(value, type):
+            value = value(field)
+
+        return value
+
+    def foreign_key_lookup(self, field):
+        value = None
+        target_model = field.remote_field.model
+
+        for model in target_model.mro():
+            if model in self.values_by_fk_related_model:
+                value = self.values_by_fk_related_model[model]
+                break
+
+        if callable(value) and not isinstance(value, type):
+            value = value(field)
+
+        return value

--- a/wagtail/utils/registry.py
+++ b/wagtail/utils/registry.py
@@ -22,15 +22,18 @@ class ObjectTypeRegistry:
         else:
             self.values_by_class[cls] = value
 
+    def get_by_type(self, cls):
+        try:
+            return self.values_by_exact_class[cls]
+        except KeyError:
+            for ancestor in cls.mro():
+                try:
+                    return self.values_by_class[ancestor]
+                except KeyError:
+                    pass
+
     def get(self, obj):
-        value = None
-        if obj.__class__ in self.values_by_exact_class:
-            value = self.values_by_exact_class[obj.__class__]
-        else:
-            for klass in obj.__class__.mro():
-                if klass in self.values_by_class:
-                    value = self.values_by_class[klass]
-                    break
+        value = self.get_by_type(obj.__class__)
 
         if callable(value) and not isinstance(value, type):
             value = value(obj)


### PR DESCRIPTION
This change makes it possible to use `FieldPanel` for all field types, making `StreamFieldPanel`, `RichTextFieldPanel`, `ImageChooserPanel`, `DocumentChooserPanel` and `SnippetChooserPanel` obsolete and `PageChooserPanel` _almost_ obsolete (it's still provided as a convenience for passing the `page_type` or `can_choose_root` arguments, although even this can be replaced with a `FieldPanel` with an appropriate `widget`). This is achieved in part by a new extension to `WagtailAdminModelForm`, where apps can register their own form widgets to be used for a given model field type (so that, for example, a foreign key to Image always uses the AdminImageChooser widget, without having to specify it explicitly via the form class or EditHandler definition).

One thing that might need more consideration is the removal of docs for ImageChooserPanel and DocumentChooserPanel - these currently seem to be written as if they're the first introduction to the image and document models. If this is indeed the case (which wouldn't be great, as these are reference docs rather than howto docs...) we should probably add them back as a new first section on topics/images, and a new topics/documents page.

We might also want to note that if people have _deliberately_ chosen to use FieldPanel instead of a chooser panel (or, for non-edit-handler-based forms, omitted specifying a chooser widget) because a plain dropdown works better for their use case, they'll now need to specify the Select widget explicitly.