### PR TITLE
Use correct syntax for image debug logging

### DIFF
--- a/wagtail/images/models.py
+++ b/wagtail/images/models.py
@@ -311,19 +311,21 @@ class AbstractImage(ImageFileMixin, CollectionMember, index.Indexed, models.Mode
         except Rendition.DoesNotExist:
             # Generate the rendition image
             try:
-                logger.debug("Generating '%s' rendition for image %d", (
+                logger.debug(
+                    "Generating '%s' rendition for image %d",
                     filter.spec,
                     self.pk,
-                ))
+                )
 
                 start_time = time.time()
                 generated_image = filter.run(self, BytesIO())
 
-                logger.debug("Generated '%s' rendition for image %d in %.1fms", (
+                logger.debug(
+                    "Generated '%s' rendition for image %d in %.1fms",
                     filter.spec,
                     self.pk,
                     (time.time() - start_time) * 1000
-                ))
+                )
             except:  # noqa:B901,E722
                 logger.debug("Failed to generate '%s' rendition for image %d: %s", filter.spec, self.pk)
                 raise

--- a/wagtail/images/models.py
+++ b/wagtail/images/models.py
@@ -327,7 +327,7 @@ class AbstractImage(ImageFileMixin, CollectionMember, index.Indexed, models.Mode
                     (time.time() - start_time) * 1000
                 )
             except:  # noqa:B901,E722
-                logger.debug("Failed to generate '%s' rendition for image %d: %s", filter.spec, self.pk)
+                logger.debug("Failed to generate '%s' rendition for image %d", filter.spec, self.pk)
                 raise
 
             # Generate filename


### PR DESCRIPTION
Fixes an issue in #7391 which used the incorrect logging syntax

This should only affect users which have debug logging enabled for wagtail. I don't believe it affects all users.