### PR TITLE
Update setup.py to use django-filter latest version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ install_requires = [
     "django-taggit>=1.0,<2.0",
     "django-treebeard>=4.2.0,<5.0,!=4.5",
     "djangorestframework>=3.11.1,<4.0",
-    "django-filter>=2.2,<3.0",
+    "django-filter>=2.2,<22",
     "draftjs_exporter>=2.1.5,<3.0",
     "Pillow>=4.0.0,<9.0.0",
     "beautifulsoup4>=4.8,<4.10",


### PR DESCRIPTION
The django-filter package has changed its versioning from a semver to a year based one. The latest version (21.1) is the same as the old one that wagtail supported (2.4): https://github.com/carltongibson/django-filter/blob/main/CHANGES.rst 

So we could just bumb the requirement to `<=22` (I think it's fine to use that because the readme claims that breaking changes will be introduced to version+2 so breaking versions for v.21 will be introduced to v.23)

