### PR TITLE
Fix stray bulk action checkboxes on non-explorer page listings

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/chooser/_browse_results.html
+++ b/wagtail/admin/templates/wagtailadmin/chooser/_browse_results.html
@@ -4,7 +4,7 @@
 {% include "wagtailadmin/shared/chooser_breadcrumb.html" with page=parent_page %}
 
 {% if pages %}
-    {% include "wagtailadmin/pages/listing/_list_choose.html" with allow_navigation=1 orderable=0 pages=pages parent_page=parent_page hide_bulk_actions=1 %}
+    {% include "wagtailadmin/pages/listing/_list_choose.html" with allow_navigation=1 orderable=0 pages=pages parent_page=parent_page %}
 
     {% url 'wagtailadmin_choose_page_child' parent_page.id as pagination_base_url %}
     {% paginate pages base_url=pagination_base_url classnames="navigate-pages" %}

--- a/wagtail/admin/templates/wagtailadmin/pages/index.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/index.html
@@ -14,7 +14,7 @@
         {% csrf_token %}
 
         {% page_permissions parent_page as parent_page_perms %}
-        {% include "wagtailadmin/pages/listing/_list_explore.html" with sortable=1 sortable_by_type=1 full_width=1 show_ordering_column=show_ordering_column parent_page=parent_page orderable=parent_page_perms.can_reorder_children %}
+        {% include "wagtailadmin/pages/listing/_list_explore.html" with sortable=1 sortable_by_type=1 full_width=1 show_ordering_column=show_ordering_column show_bulk_actions=show_bulk_actions parent_page=parent_page orderable=parent_page_perms.can_reorder_children %}
 
         {% if do_paginate %}
             {% url 'wagtailadmin_explore' parent_page.id as pagination_base_url %}

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_list.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_list.html
@@ -2,7 +2,7 @@
 {% load l10n %}
 {% load wagtailadmin_tags %}
 <table class="listing {% if full_width %}full-width{% endif %} {% block table_classname %}{% endblock %}">
-    {% if show_ordering_column or not hide_bulk_actions %}
+    {% if show_ordering_column or show_bulk_actions %}
         <col width="10px" />
     {% endif %}
     <col />
@@ -20,7 +20,7 @@
         {% if parent_page %}
             {% page_permissions parent_page as parent_page_perms %}
             <tr class="index {% if not parent_page.live %} unpublished{% endif %} {% block parent_page_row_classname %}{% endblock %}">
-                <td class="title"{% if show_ordering_column or not hide_bulk_actions %} colspan="2"{% endif %}>
+                <td class="title"{% if show_ordering_column or show_bulk_actions %} colspan="2"{% endif %}>
                     {% block parent_page_title %}
                     {% endblock %}
                 </td>
@@ -50,7 +50,7 @@
                 <tr {% if ordering == "ord" %}id="page_{{ page.id|unlocalize }}" data-page-title="{{ page.get_admin_display_title }}"{% endif %} class="{% if not page.live %}unpublished{% endif %} {% block page_row_classname %}{% endblock %}">
                     {% if show_ordering_column %}
                         <td class="ord">{% if orderable and ordering == "ord" %}<div class="handle icon icon-grip text-replace">{% trans 'Drag' %}</div>{% endif %}</td>
-                    {% elif not hide_bulk_actions %}
+                    {% elif show_bulk_actions %}
                         {% include "wagtailadmin/bulk_actions/listing_checkbox_cell.html" with obj_type="page" obj=page aria_labelledby_prefix="page_" aria_labelledby=page.pk|unlocalize aria_labelledby_suffix="_title" %}
                     {% endif %}
                     <td id="page_{{ page.pk|unlocalize }}_title" class="title" valign="top" data-listing-page-title>

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_list_move.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_list_move.html
@@ -8,7 +8,6 @@
 
 {% block pre_parent_page_headers %}
     <tr class="table-headers">
-        <th></th>
         <th class="title">Title</th>
         {% if show_parent %}
             <th class="parent">{% trans 'Parent' %}</th>

--- a/wagtail/admin/templates/wagtailadmin/pages/search_results.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/search_results.html
@@ -32,7 +32,7 @@
             </nav>
         {% endif %}
 
-        {% include "wagtailadmin/pages/listing/_list_explore.html" with show_parent=1 sortable=1 sortable_by_type=0 %}
+        {% include "wagtailadmin/pages/listing/_list_explore.html" with show_parent=1 sortable=1 sortable_by_type=0 show_bulk_actions=1 %}
 
         {% url 'wagtailadmin_pages:search' as pagination_base_url %}
         {% paginate pages base_url=pagination_base_url %}

--- a/wagtail/admin/views/pages/listing.py
+++ b/wagtail/admin/views/pages/listing.py
@@ -95,6 +95,8 @@ def index(request, parent_page_id=None):
         paginator = Paginator(pages, per_page=50)
         pages = paginator.get_page(request.GET.get('p'))
 
+    show_ordering_column = request.GET.get('ordering') == 'ord'
+
     context = {
         'parent_page': parent_page.specific,
         'ordering': ordering,
@@ -103,7 +105,8 @@ def index(request, parent_page_id=None):
         'do_paginate': do_paginate,
         'locale': None,
         'translations': [],
-        'show_ordering_column': request.GET.get('ordering') == 'ord'
+        'show_ordering_column': show_ordering_column,
+        'show_bulk_actions': not show_ordering_column,
     }
 
     if getattr(settings, 'WAGTAIL_I18N_ENABLED', False) and not parent_page.is_root():


### PR DESCRIPTION
Fixes #7681. Rather than a hide_bulk_actions flag that non-explorer views have to add to get the old behaviour, use a show_bulk_actions flag that's enabled on the views that do want it.
