### PR TITLE
Fix/jinja2tags deprecations

### DIFF
--- a/wagtail/admin/jinja2tags.py
+++ b/wagtail/admin/jinja2tags.py
@@ -10,7 +10,7 @@ class WagtailUserbarExtension(Extension):
         super().__init__(environment)
 
         self.environment.globals.update({
-            'wagtailuserbar': jinja2.contextfunction(wagtailuserbar),
+            'wagtailuserbar': jinja2.pass_context(wagtailuserbar),
         })
 
 

--- a/wagtail/contrib/settings/jinja2tags.py
+++ b/wagtail/contrib/settings/jinja2tags.py
@@ -57,7 +57,7 @@ class SiteSettings(dict):
         return out
 
 
-@jinja2.contextfunction
+@jinja2.pass_context
 def get_setting(context, model_string, use_default_site=False):
     if use_default_site:
         site = Site.objects.get(is_default_site=True)

--- a/wagtail/core/jinja2tags.py
+++ b/wagtail/core/jinja2tags.py
@@ -13,8 +13,8 @@ class WagtailCoreExtension(Extension):
         super().__init__(environment)
 
         self.environment.globals.update({
-            'pageurl': jinja2.contextfunction(pageurl),
-            'slugurl': jinja2.contextfunction(slugurl),
+            'pageurl': jinja2.pass_context(pageurl),
+            'slugurl': jinja2.pass_context(slugurl),
             'wagtail_version': wagtail_version,
         })
         self.environment.filters.update({

--- a/wagtail/core/jinja2tags.py
+++ b/wagtail/core/jinja2tags.py
@@ -1,5 +1,6 @@
 import jinja2
 import jinja2.nodes
+import markupsafe
 
 from jinja2.ext import Extension
 
@@ -61,7 +62,7 @@ class WagtailCoreExtension(Extension):
             result = value
 
         if context.eval_ctx.autoescape:
-            return jinja2.escape(result)
+            return markupsafe.escape(result)
         else:
             return jinja2.Markup(result)
 


### PR DESCRIPTION
While running tests I ran into a couple of deprecation warnings.

```
~/wagtail/wagtail/core/jinja2tags.py:16: DeprecationWarning: 'contextfunction' is renamed to 'pass_context', the old name will be removed in Jinja 3.1.
  'pageurl': jinja2.contextfunction(pageurl),
~/wagtail/wagtail/core/jinja2tags.py:17: DeprecationWarning: 'contextfunction' is renamed to 'pass_context', the old name will be removed in Jinja 3.1.
  'slugurl': jinja2.contextfunction(slugurl),
~/wagtail/wagtail/admin/jinja2tags.py:13: DeprecationWarning: 'contextfunction' is renamed to 'pass_context', the old name will be removed in Jinja 3.1.
  'wagtailuserbar': jinja2.contextfunction(wagtailuserbar),
~/wagtail/wagtail/contrib/settings/jinja2tags.py:61: DeprecationWarning: 'contextfunction' is renamed to 'pass_context', the old name will be removed in Jinja 3.1.
  def get_setting(context, model_string, use_default_site=False):
```

This is my attempt to fix them, please let me know if I can do anything to help this along :) 