### PR TITLE
Prevent duplicate nested streamblocks to have duplicated UUIDs - Fix #7712

### DIFF
--- a/client/src/components/StreamField/blocks/StreamBlock.js
+++ b/client/src/components/StreamField/blocks/StreamBlock.js
@@ -292,13 +292,12 @@ export class StreamBlock extends BaseSequenceBlock {
     Object.keys(childState).forEach(key => {
       const value = childState[key]
       if (Array.isArray(value)) {
-        // In case the child is an array, like a list of blocks
+        // The value can contain a list of blocks in which we need to set id to null.
         newChildState[key] = value.map(item => this._removeIdsFromChildState(item));
       } else if (typeof value === 'object' && value !== null) {
-        // In case the child is an object, like a structblock
+        // The value can be an object, a StructBlock for example.
         newChildState[key] = this._removeIdsFromChildState(childState[key]);
       } else if (key === 'id' && !!childState[key]) {
-        // In case the key is "id", we remove it
         newChildState[key] = null;
       }
     });

--- a/client/src/components/StreamField/blocks/StreamBlock.js
+++ b/client/src/components/StreamField/blocks/StreamBlock.js
@@ -289,16 +289,17 @@ export class StreamBlock extends BaseSequenceBlock {
 
   _removeIdsFromChildState(childState) {
     const newChildState = { ...childState };
-    Object.keys(childState).forEach(i => {
-      if (Array.isArray(childState[i])) {
+    Object.keys(childState).forEach(key => {
+      const value = childState[key]
+      if (Array.isArray(value)) {
         // In case the child is an array, like a list of blocks
-        newChildState[i] = childState[i].map(item => this._removeIdsFromChildState(item));
-      } else if (typeof childState[i] === 'object' && childState[i] !== null) {
+        newChildState[key] = value.map(item => this._removeIdsFromChildState(item));
+      } else if (typeof value === 'object' && value !== null) {
         // In case the child is an object, like a structblock
-        newChildState[i] = this._removeIdsFromChildState(childState[i]);
-      } else if (i === 'id' && !!childState[i]) {
+        newChildState[key] = this._removeIdsFromChildState(childState[key]);
+      } else if (key === 'id' && !!childState[key]) {
         // In case the key is "id", we remove it
-        newChildState[i] = null;
+        newChildState[key] = null;
       }
     });
 

--- a/client/src/components/StreamField/blocks/StreamBlock.js
+++ b/client/src/components/StreamField/blocks/StreamBlock.js
@@ -290,7 +290,7 @@ export class StreamBlock extends BaseSequenceBlock {
   _removeIdsFromChildState(childState) {
     const newChildState = { ...childState };
     Object.keys(childState).forEach(key => {
-      const value = childState[key]
+      const value = childState[key];
       if (Array.isArray(value)) {
         // The value can contain a list of blocks in which we need to set id to null.
         newChildState[key] = value.map(item => this._removeIdsFromChildState(item));


### PR DESCRIPTION
Fix #7712 

# Description
When duplicating a block in a StreamField, nested StreamBlock UUIDs remain. 
This change removes the UUIDs from nested blocks so that they are generated server-side on Page's save. 

This is still a work in progress as I am not sure if I made this change in the right place. Once I get confirmation that this properly fixes the issue, I will add some tests. 

# TODO
- [x] Add a description
- [ ] Write tests