### PR TITLE
Search with MySQL backend errors if query has more than 2 words

### DIFF
--- a/wagtail/search/tests/test_backends.py
+++ b/wagtail/search/tests/test_backends.py
@@ -82,7 +82,7 @@ class BackendTests(WagtailTestUtils):
 
     def test_ranking(self):
         # Note: also tests the "or" operator
-        results = list(self.backend.search("JavaScript The Definitive", models.Book, operator='or'))
+        results = list(self.backend.search("JavaScript Definitive", models.Book, operator='or'))
         self.assertUnsortedListEqual([r.title for r in results], [
             "JavaScript: The good parts",
             "JavaScript: The Definitive Guide"

--- a/wagtail/search/tests/test_backends.py
+++ b/wagtail/search/tests/test_backends.py
@@ -82,7 +82,7 @@ class BackendTests(WagtailTestUtils):
 
     def test_ranking(self):
         # Note: also tests the "or" operator
-        results = list(self.backend.search("JavaScript Definitive", models.Book, operator='or'))
+        results = list(self.backend.search("JavaScript The Definitive", models.Book, operator='or'))
         self.assertUnsortedListEqual([r.title for r in results], [
             "JavaScript: The good parts",
             "JavaScript: The Definitive Guide"
@@ -106,7 +106,7 @@ class BackendTests(WagtailTestUtils):
 
     def test_search_and_operator(self):
         # Should not return "JavaScript: The good parts" as it does not have "Definitive"
-        results = self.backend.search("JavaScript Definitive", models.Book, operator='and')
+        results = self.backend.search("JavaScript The Definitive", models.Book, operator='and')
         self.assertUnsortedListEqual([r.title for r in results], [
             "JavaScript: The Definitive Guide"
         ])


### PR DESCRIPTION
When using the new MySQL search backend, the search throws the following exception if my search contains more than 2 words. Works fine if those words are a phrase (enclosed in double quotes). I am opening this PR to see if I can replicate the behavior I am seeing locally in our TOX suite - 3 word search works OK in Postgres and SQLite but not in MySQL.

One other odd thing, self.connector always seems to be empty. 

```
  File "/vote-ve/lib64/python3.7/site-packages/django/db/models/expressions.py", line 480, in as_sql
    sql, params = compiler.compile(self.lhs)
  File "/vote-ve/lib64/python3.7/site-packages/django/db/models/sql/compiler.py", line 445, in compile
    sql, params = node.as_sql(self, self.connection)
  File "/vote-ve/lib64/python3.7/site-packages/wagtail/search/backends/database/mysql/query.py", line 206, in as_sql
    compiled_query = compiler.compile(self.query)  # Compile the query to a string
  File "/vote-ve/lib64/python3.7/site-packages/django/db/models/sql/compiler.py", line 445, in compile
    sql, params = node.as_sql(self, self.connection)
  File "/vote-ve/lib64/python3.7/site-packages/wagtail/search/backends/database/mysql/query.py", line 153, in as_sql
    sql, params = compiler.compile(self.value)
  File "/vote-ve/lib64/python3.7/site-packages/django/db/models/sql/compiler.py", line 445, in compile
    sql, params = node.as_sql(self, self.connection)
  File "/vote-ve/lib64/python3.7/site-packages/wagtail/search/backends/database/mysql/query.py", line 87, in as_sql
    if self.lhs.invert and self.connector == '+':  # NOTE: This is a special case for MySQL. If either side's operator is AND (+), and it is inverted, the operator should become NOT (-). If we did nothing, the result could would be '+X +(-Y)' for And(X, Not(Y)), which seems correct, but produces a wrong result. The solution is to turn the query into '+X -Y', which does work, and therefore this is done here.

Exception Type: AttributeError at /search/
Exception Value: 'CombinedLexeme' object has no attribute 'invert'
```
