### PR TITLE
Fix: Define default_app_config only for Django < 3.2

### DIFF
--- a/docs/extending/custom_tasks.rst
+++ b/docs/extending/custom_tasks.rst
@@ -302,8 +302,7 @@ Next, you need to instantiate the notifier, and connect it to the ``task_submitt
     def register_signal_handlers():
         task_submitted.connect(user_approval_task_submission_email_notifier, dispatch_uid='user_approval_task_submitted_email_notification')
 
-``register_signal_handlers()`` should then be run on loading the app: for example, by adding it to the ``ready()`` method in your ``AppConfig``
-(and making sure this config is set as ``default_app_config`` in ``<project>/__init__.py``).
+``register_signal_handlers()`` should then be run on loading the app: for example, by adding it to the ``ready()`` method in your ``AppConfig``.
 
 .. code-block:: python
 
@@ -319,3 +318,8 @@ Next, you need to instantiate the notifier, and connect it to the ``task_submitt
         def ready(self):
             from .signal_handlers import register_signal_handlers
             register_signal_handlers()
+
+.. note::
+   In Django versions before 3.2 your ``AppConfig`` subclass needs to be set as ``default_app_config`` in ``<project>/__init__.py``.
+   See the `relevant section in the Django docs <https://docs.djangoproject.com/en/3.1/ref/applications/#for-application-authors>`_ for the version you are using.
+

--- a/wagtail/admin/__init__.py
+++ b/wagtail/admin/__init__.py
@@ -1,1 +1,8 @@
-default_app_config = 'wagtail.admin.apps.WagtailAdminAppConfig'
+import django
+
+
+if django.VERSION >= (3, 2):
+    # The declaration is only needed for older Django versions
+    pass
+else:
+    default_app_config = 'wagtail.admin.apps.WagtailAdminAppConfig'

--- a/wagtail/api/v2/__init__.py
+++ b/wagtail/api/v2/__init__.py
@@ -1,1 +1,8 @@
-default_app_config = 'wagtail.api.v2.apps.WagtailAPIV2AppConfig'
+import django
+
+
+if django.VERSION >= (3, 2):
+    # The declaration is only needed for older Django versions
+    pass
+else:
+    default_app_config = 'wagtail.api.v2.apps.WagtailAPIV2AppConfig'

--- a/wagtail/contrib/forms/__init__.py
+++ b/wagtail/contrib/forms/__init__.py
@@ -1,1 +1,8 @@
-default_app_config = 'wagtail.contrib.forms.apps.WagtailFormsAppConfig'
+import django
+
+
+if django.VERSION >= (3, 2):
+    # The declaration is only needed for older Django versions
+    pass
+else:
+    default_app_config = 'wagtail.contrib.forms.apps.WagtailFormsAppConfig'

--- a/wagtail/contrib/frontend_cache/__init__.py
+++ b/wagtail/contrib/frontend_cache/__init__.py
@@ -1,1 +1,8 @@
-default_app_config = 'wagtail.contrib.frontend_cache.apps.WagtailFrontendCacheAppConfig'
+import django
+
+
+if django.VERSION >= (3, 2):
+    # The declaration is only needed for older Django versions
+    pass
+else:
+    default_app_config = 'wagtail.contrib.frontend_cache.apps.WagtailFrontendCacheAppConfig'

--- a/wagtail/contrib/modeladmin/__init__.py
+++ b/wagtail/contrib/modeladmin/__init__.py
@@ -1,1 +1,8 @@
-default_app_config = 'wagtail.contrib.modeladmin.apps.WagtailModelAdminAppConfig'
+import django
+
+
+if django.VERSION >= (3, 2):
+    # The declaration is only needed for older Django versions
+    pass
+else:
+    default_app_config = 'wagtail.contrib.modeladmin.apps.WagtailModelAdminAppConfig'

--- a/wagtail/contrib/postgres_search/__init__.py
+++ b/wagtail/contrib/postgres_search/__init__.py
@@ -1,1 +1,8 @@
-default_app_config = 'wagtail.contrib.postgres_search.apps.PostgresSearchConfig'
+import django
+
+
+if django.VERSION >= (3, 2):
+    # The declaration is only needed for older Django versions
+    pass
+else:
+    default_app_config = 'wagtail.contrib.postgres_search.apps.PostgresSearchConfig'

--- a/wagtail/contrib/redirects/__init__.py
+++ b/wagtail/contrib/redirects/__init__.py
@@ -1,1 +1,8 @@
-default_app_config = 'wagtail.contrib.redirects.apps.WagtailRedirectsAppConfig'
+import django
+
+
+if django.VERSION >= (3, 2):
+    # The declaration is only needed for older Django versions
+    pass
+else:
+    default_app_config = 'wagtail.contrib.redirects.apps.WagtailRedirectsAppConfig'

--- a/wagtail/contrib/routable_page/__init__.py
+++ b/wagtail/contrib/routable_page/__init__.py
@@ -1,1 +1,8 @@
-default_app_config = 'wagtail.contrib.routable_page.apps.WagtailRoutablePageAppConfig'
+import django
+
+
+if django.VERSION >= (3, 2):
+    # The declaration is only needed for older Django versions
+    pass
+else:
+    default_app_config = 'wagtail.contrib.routable_page.apps.WagtailRoutablePageAppConfig'

--- a/wagtail/contrib/search_promotions/__init__.py
+++ b/wagtail/contrib/search_promotions/__init__.py
@@ -1,1 +1,8 @@
-default_app_config = 'wagtail.contrib.search_promotions.apps.WagtailSearchPromotionsAppConfig'
+import django
+
+
+if django.VERSION >= (3, 2):
+    # The declaration is only needed for older Django versions
+    pass
+else:
+    default_app_config = 'wagtail.contrib.search_promotions.apps.WagtailSearchPromotionsAppConfig'

--- a/wagtail/contrib/settings/__init__.py
+++ b/wagtail/contrib/settings/__init__.py
@@ -1,1 +1,8 @@
-default_app_config = 'wagtail.contrib.settings.apps.WagtailSettingsAppConfig'
+import django
+
+
+if django.VERSION >= (3, 2):
+    # The declaration is only needed for older Django versions
+    pass
+else:
+    default_app_config = 'wagtail.contrib.settings.apps.WagtailSettingsAppConfig'

--- a/wagtail/contrib/simple_translation/__init__.py
+++ b/wagtail/contrib/simple_translation/__init__.py
@@ -1,3 +1,10 @@
-default_app_config = (
-    "wagtail.contrib.simple_translation.apps.SimpleTranslationAppConfig"
-)
+import django
+
+
+if django.VERSION >= (3, 2):
+    # The declaration is only needed for older Django versions
+    pass
+else:
+    default_app_config = (
+        "wagtail.contrib.simple_translation.apps.SimpleTranslationAppConfig"
+    )

--- a/wagtail/contrib/sitemaps/__init__.py
+++ b/wagtail/contrib/sitemaps/__init__.py
@@ -1,4 +1,10 @@
+import django
+
 from .sitemap_generator import Sitemap  # noqa
 
 
-default_app_config = 'wagtail.contrib.sitemaps.apps.WagtailSitemapsAppConfig'
+if django.VERSION >= (3, 2):
+    # The declaration is only needed for older Django versions
+    pass
+else:
+    default_app_config = 'wagtail.contrib.sitemaps.apps.WagtailSitemapsAppConfig'

--- a/wagtail/contrib/styleguide/__init__.py
+++ b/wagtail/contrib/styleguide/__init__.py
@@ -1,1 +1,8 @@
-default_app_config = 'wagtail.contrib.styleguide.apps.WagtailStyleGuideAppConfig'
+import django
+
+
+if django.VERSION >= (3, 2):
+    # The declaration is only needed for older Django versions
+    pass
+else:
+    default_app_config = 'wagtail.contrib.styleguide.apps.WagtailStyleGuideAppConfig'

--- a/wagtail/contrib/table_block/__init__.py
+++ b/wagtail/contrib/table_block/__init__.py
@@ -1,1 +1,8 @@
-default_app_config = 'wagtail.contrib.table_block.apps.WagtailTableBlockAppConfig'
+import django
+
+
+if django.VERSION >= (3, 2):
+    # The declaration is only needed for older Django versions
+    pass
+else:
+    default_app_config = 'wagtail.contrib.table_block.apps.WagtailTableBlockAppConfig'

--- a/wagtail/core/__init__.py
+++ b/wagtail/core/__init__.py
@@ -1,8 +1,13 @@
+import django
 # Imported for historical reasons
 from wagtail import __semver__, __version__  # noqa
 
 
-default_app_config = 'wagtail.core.apps.WagtailCoreAppConfig'
+if django.VERSION >= (3, 2):
+    # The declaration is only needed for older Django versions
+    pass
+else:
+    default_app_config = 'wagtail.core.apps.WagtailCoreAppConfig'
 
 
 def setup():

--- a/wagtail/core/__init__.py
+++ b/wagtail/core/__init__.py
@@ -1,4 +1,5 @@
 import django
+
 # Imported for historical reasons
 from wagtail import __semver__, __version__  # noqa
 

--- a/wagtail/documents/__init__.py
+++ b/wagtail/documents/__init__.py
@@ -1,8 +1,13 @@
+import django
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 
 
-default_app_config = 'wagtail.documents.apps.WagtailDocsAppConfig'
+if django.VERSION >= (3, 2):
+    # The declaration is only needed for older Django versions
+    pass
+else:
+    default_app_config = 'wagtail.documents.apps.WagtailDocsAppConfig'
 
 
 def get_document_model_string():

--- a/wagtail/documents/__init__.py
+++ b/wagtail/documents/__init__.py
@@ -1,4 +1,5 @@
 import django
+
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 

--- a/wagtail/embeds/__init__.py
+++ b/wagtail/embeds/__init__.py
@@ -1,1 +1,8 @@
-default_app_config = 'wagtail.embeds.apps.WagtailEmbedsAppConfig'
+import django
+
+
+if django.VERSION >= (3, 2):
+    # The declaration is only needed for older Django versions
+    pass
+else:
+    default_app_config = 'wagtail.embeds.apps.WagtailEmbedsAppConfig'

--- a/wagtail/images/__init__.py
+++ b/wagtail/images/__init__.py
@@ -1,8 +1,13 @@
+import django
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 
 
-default_app_config = 'wagtail.images.apps.WagtailImagesAppConfig'
+if django.VERSION >= (3, 2):
+    # The declaration is only needed for older Django versions
+    pass
+else:
+    default_app_config = 'wagtail.images.apps.WagtailImagesAppConfig'
 
 
 def get_image_model_string():

--- a/wagtail/images/__init__.py
+++ b/wagtail/images/__init__.py
@@ -1,4 +1,5 @@
 import django
+
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 

--- a/wagtail/locales/__init__.py
+++ b/wagtail/locales/__init__.py
@@ -1,1 +1,8 @@
-default_app_config = 'wagtail.locales.apps.WagtailLocalesAppConfig'
+import django
+
+
+if django.VERSION >= (3, 2):
+    # The declaration is only needed for older Django versions
+    pass
+else:
+    default_app_config = 'wagtail.locales.apps.WagtailLocalesAppConfig'

--- a/wagtail/search/__init__.py
+++ b/wagtail/search/__init__.py
@@ -1,1 +1,8 @@
-default_app_config = 'wagtail.search.apps.WagtailSearchAppConfig'
+import django
+
+
+if django.VERSION >= (3, 2):
+    # The declaration is only needed for older Django versions
+    pass
+else:
+    default_app_config = 'wagtail.search.apps.WagtailSearchAppConfig'

--- a/wagtail/sites/__init__.py
+++ b/wagtail/sites/__init__.py
@@ -1,1 +1,8 @@
-default_app_config = 'wagtail.sites.apps.WagtailSitesAppConfig'
+import django
+
+
+if django.VERSION >= (3, 2):
+    # The declaration is only needed for older Django versions
+    pass
+else:
+    default_app_config = 'wagtail.sites.apps.WagtailSitesAppConfig'

--- a/wagtail/snippets/__init__.py
+++ b/wagtail/snippets/__init__.py
@@ -1,1 +1,8 @@
-default_app_config = 'wagtail.snippets.apps.WagtailSnippetsAppConfig'
+import django
+
+
+if django.VERSION >= (3, 2):
+    # The declaration is only needed for older Django versions
+    pass
+else:
+    default_app_config = 'wagtail.snippets.apps.WagtailSnippetsAppConfig'

--- a/wagtail/users/__init__.py
+++ b/wagtail/users/__init__.py
@@ -1,1 +1,8 @@
-default_app_config = 'wagtail.users.apps.WagtailUsersAppConfig'
+import django
+
+
+if django.VERSION >= (3, 2):
+    # The declaration is only needed for older Django versions
+    pass
+else:
+    default_app_config = 'wagtail.users.apps.WagtailUsersAppConfig'


### PR DESCRIPTION
Since Django 3.2 it is not necessary anymore to declare a `default_app_config` if only a single app config is present in the `apps.py`. 

With that declaration, Django throws deprecation warnings like so:
```
/venv/lib/python3.8/site-packages/django/apps/registry.py:91: RemovedInDjango41Warning: 'wagtail.core' defines default_app_config = 'wagtail.core.apps.WagtailCoreAppConfig'. Django now detects this configuration automatically. You can remove default_app_config.
```

This PR adds version checks and only declares the `default_app_config` for Django versions before 3.2. 

There was also a section in the docs that was referencing the need to set `default_app_config`. That section has been adjusted to make clear that `default_app_config` is only needed for Django < 3.2.

Closes #7692

***

Thanks for contributing to Wagtail! 🎉

Before submitting, please review the contributor guidelines <https://docs.wagtail.io/en/latest/contributing/index.html> and check the following:

* Do the tests still pass? (https://docs.wagtail.io/en/latest/contributing/developing.html#testing) -> yes
* Does the code comply with the style guide? (Run `make lint` from the Wagtail root)
* For Python changes: Have you added tests to cover the new/fixed behaviour? -> Tested via test matrix.
* For front-end changes: Did you test on all of [Wagtail’s supported environments](https://docs.wagtail.io/en/latest/contributing/developing.html#browser-and-device-support)? -> n/a
* For new features: Has the documentation been updated accordingly? -> Not a new feature, but documentation has been update. 
