### PR TITLE
Informative validation: Tell users/devs which slug that is offending

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -12,6 +12,7 @@ Changelog
  * Make it possible to resize the page editor’s side panels (Sage Abdullah)
  * Add ability to include `form_fields` as an APIField on `FormPage` (Sævar Öfjörð Magnússon, Suyash Singh, LB (Ben) Johnston)
  * Ensure that images listings are more consistently aligned when there are fewer images uploaded (Theresa Okoro)
+ * Add more informative validation error messages for non-unique slugs within the admin interface and for programmatic page creation (Benjamin Bach)
  * Fix: Make sure workflow timeline icons are visible in high-contrast mode (Loveth Omokaro)
  * Fix: Ensure authentication forms (login, password reset) have a visible border in Windows high-contrast mode (Loveth Omokaro)
  * Fix: Ensure visual consistency between buttons and links as buttons in Windows high-contrast mode (Albina Starykova)

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -22,6 +22,7 @@ depth: 1
  * Make it possible to resize the page editor’s side panels (Sage Abdullah)
  * Add ability to include [`form_fields` as an APIField](form_page_fields_api_field) on `FormPage` (Sævar Öfjörð Magnússon, Suyash Singh, LB (Ben) Johnston)
  * Ensure that images listings are more consistently aligned when there are fewer images uploaded (Theresa Okoro)
+ * Add more informative validation error messages for non-unique slugs within the admin interface and for programmatic page creation (Benjamin Bach)
 
 ### Bug fixes
 

--- a/wagtail/admin/forms/account.py
+++ b/wagtail/admin/forms/account.py
@@ -51,7 +51,10 @@ def _get_language_choices():
         (lang_code, get_language_info(lang_code)["name_local"])
         for lang_code, lang_name in get_available_admin_languages()
     ]
-    return sorted(BLANK_CHOICE_DASH + language_choices, key=lambda l: l[1].lower())
+    return sorted(
+        BLANK_CHOICE_DASH + language_choices,
+        key=lambda language_choice: language_choice[1].lower(),
+    )
 
 
 def _get_time_zone_choices():

--- a/wagtail/admin/forms/pages.py
+++ b/wagtail/admin/forms/pages.py
@@ -178,11 +178,16 @@ class WagtailAdminPageForm(WagtailAdminModelForm):
     def clean(self):
         cleaned_data = super().clean()
         if "slug" in self.cleaned_data:
-            if not Page._slug_is_available(
-                cleaned_data["slug"], self.parent_page, self.instance
-            ):
+            page_slug = cleaned_data["slug"]
+            if not Page._slug_is_available(page_slug, self.parent_page, self.instance):
                 self.add_error(
-                    "slug", forms.ValidationError(_("This slug is already in use"))
+                    "slug",
+                    forms.ValidationError(
+                        _(
+                            "The slug '%(page_slug)s' is already in use in use within the parent page"
+                        )
+                        % {"page_slug": page_slug}
+                    ),
                 )
 
         return cleaned_data

--- a/wagtail/admin/tests/api/test_pages.py
+++ b/wagtail/admin/tests/api/test_pages.py
@@ -1379,7 +1379,14 @@ class TestCopyPageAction(AdminAPITestCase):
 
         self.assertEqual(response.status_code, 400)
         content = json.loads(response.content.decode("utf-8"))
-        self.assertEqual(content, {"slug": ["This slug is already in use"]})
+        self.assertEqual(
+            content,
+            {
+                "slug": [
+                    "The slug 'events' is already in use in use within the parent page at '/'"
+                ]
+            },
+        )
 
 
 class TestConvertAliasPageAction(AdminAPITestCase):

--- a/wagtail/admin/tests/pages/test_create_page.py
+++ b/wagtail/admin/tests/pages/test_create_page.py
@@ -713,7 +713,12 @@ class TestPageCreation(TestCase, WagtailTestUtils):
         self.assertEqual(response.status_code, 200)
 
         # Check that a form error was raised
-        self.assertFormError(response, "form", "slug", "This slug is already in use")
+        self.assertFormError(
+            response,
+            "form",
+            "slug",
+            "The slug 'hello-world' is already in use in use within the parent page",
+        )
 
         # form should be marked as having unsaved changes for the purposes of the dirty-forms warning
         self.assertContains(response, "alwaysDirty: true")

--- a/wagtail/admin/tests/pages/test_edit_page.py
+++ b/wagtail/admin/tests/pages/test_edit_page.py
@@ -1281,7 +1281,12 @@ class TestPageEdit(TestCase, WagtailTestUtils):
         self.assertEqual(response.status_code, 200)
 
         # Check that a form error was raised
-        self.assertFormError(response, "form", "slug", "This slug is already in use")
+        self.assertFormError(
+            response,
+            "form",
+            "slug",
+            "The slug 'hello-world' is already in use in use within the parent page",
+        )
 
     def test_preview_on_edit(self):
         post_data = {

--- a/wagtail/models/__init__.py
+++ b/wagtail/models/__init__.py
@@ -1098,8 +1098,16 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
 
     def clean(self):
         super().clean()
-        if not Page._slug_is_available(self.slug, self.get_parent(), self):
-            raise ValidationError({"slug": _("This slug is already in use")})
+        parent_page = self.get_parent()
+        if not Page._slug_is_available(self.slug, parent_page, self):
+            raise ValidationError(
+                {
+                    "slug": _(
+                        "The slug '%(page_slug)s' is already in use in use within the parent page at '%(parent_url_path)s'"
+                    )
+                    % {"page_slug": self.slug, "parent_url_path": parent_page.url}
+                }
+            )
 
     def is_site_root(self):
         """


### PR DESCRIPTION
This change will require translation updates, so I'm not sure if it's desirable. The intention is the following:

If you are creating programmatic updates and the likes, you may be met with the following:

```
(snip)
  File "/usr/lib/python3.8/contextlib.py", line 75, in inner
    return func(*args, **kwds)
  File "/home/user/.virtualenvs/project/lib/python3.8/site-packages/wagtail/core/models/__init__.py", line 482, in save
    self.full_clean()
  File "/home/user/.virtualenvs/project/lib/python3.8/site-packages/wagtail/core/models/__init__.py", line 441, in full_clean
    super().full_clean(*args, **kwargs)
  File "/home/user/.virtualenvs/project/lib/python3.8/site-packages/django/db/models/base.py", line 1238, in full_clean
    raise ValidationError(errors)
django.core.exceptions.ValidationError: {'slug': ['This slug is already in use']}
```

...which isn't very useful. So instead this PR proposes to add the slug and the URL hierarchy in which it's being created:

```
django.core.exceptions.ValidationError: {'slug': ["The slug 'foobar' is already in use in '/en/kitchen'"]}
```

This may or may not be handy for more complex translation workflows, I can't quite tell if I'm adding the URL in a helpful or confusing way.


* [x] Do the tests still pass? (https://docs.wagtail.io/en/latest/contributing/developing.html#testing)
* [x] Does the code comply with the style guide? (Run `make lint` from the Wagtail root) 
* ~For Python changes: Have you added tests to cover the new/fixed behaviour?~
* ~For front-end changes: Did you test on all of [Wagtail’s supported environments](https://docs.wagtail.io/en/latest/contributing/developing.html#browser-and-device-support)?~
* ~For new features: Has the documentation been updated accordingly?~
