### PR TITLE
Add UUIDs to ListBlock items (RFC 65)

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,6 +5,7 @@ Changelog
 ~~~~~~~~~~~~~~~~~
 
  * Removed support for Python 3.6
+ * Added persistent IDs for ListBlock items, allowing commenting and improvements to revision comparisons (Matt Westcott, Tidjani Dia)
  * Added Aging Pages report (Tidjani Dia)
  * Add more SketchFab oEmbed patterns for models (Tom Usher)
  * Add collapse option to `StreamField`, `StreamBlock`, and `ListBlock` which will load all sub-blocks initially collapsed (Matt Westcott)

--- a/client/src/components/StreamField/blocks/ListBlock.test.js
+++ b/client/src/components/StreamField/blocks/ListBlock.test.js
@@ -107,8 +107,8 @@ describe('telepath: wagtail.blocks.ListBlock', () => {
     // Render it
     document.body.innerHTML = '<div id="placeholder"></div>';
     boundBlock = blockDef.render($('#placeholder'), 'the-prefix', [
-      'First value',
-      'Second value'
+      {'value': 'First value', 'id': '11111111-1111-1111-1111-111111111111'},
+      {'value': 'Second value', 'id': '22222222-2222-2222-2222-222222222222'},
     ]);
   });
 
@@ -147,16 +147,16 @@ describe('telepath: wagtail.blocks.ListBlock', () => {
     const state = boundBlock.getState();
     expect(getState.mock.calls.length).toBe(2);
     expect(state).toEqual([
-      'state: The widget - the-prefix-0-value',
-      'state: The widget - the-prefix-1-value'
+      {value: 'state: The widget - the-prefix-0-value', id: '11111111-1111-1111-1111-111111111111'},
+      {value: 'state: The widget - the-prefix-1-value', id: '22222222-2222-2222-2222-222222222222'},
     ]);
   });
 
   test('setState() creates new widgets', () => {
     boundBlock.setState([
-      'Changed first value',
-      'Changed second value',
-      'Third value'
+      {value: 'Changed first value', id: '11111111-1111-1111-1111-111111111111'},
+      {value: 'Changed second value', id: '22222222-2222-2222-2222-222222222222'},
+      {value: 'Third value', id: '33333333-3333-3333-3333-333333333333'},
     ]);
 
     // Includes the two initial calls, plus the three new ones
@@ -187,9 +187,9 @@ describe('telepath: wagtail.blocks.ListBlock', () => {
     const state = boundBlock.getState();
     expect(getState.mock.calls.length).toBe(3);
     expect(state).toEqual([
-      'state: The widget - the-prefix-0-value',
-      'state: The widget - the-prefix-1-value',
-      'state: The widget - the-prefix-2-value'
+      {value: 'state: The widget - the-prefix-0-value', id: '11111111-1111-1111-1111-111111111111'},
+      {value: 'state: The widget - the-prefix-1-value', id: '22222222-2222-2222-2222-222222222222'},
+      {value: 'state: The widget - the-prefix-2-value', id: '33333333-3333-3333-3333-333333333333'},
     ]);
   });
 
@@ -308,8 +308,8 @@ describe('telepath: wagtail.blocks.ListBlock with maxNum set', () => {
   test('test can add block when under limit', () => {
     document.body.innerHTML = '<div id="placeholder"></div>';
     const boundBlock = blockDef.render($('#placeholder'), 'the-prefix', [
-      'First value',
-      'Second value',
+      {'value': 'First value', 'id': '11111111-1111-1111-1111-111111111111'},
+      {'value': 'Second value', 'id': '22222222-2222-2222-2222-222222222222'},
     ]);
 
     assertCanAddBlock();
@@ -318,9 +318,9 @@ describe('telepath: wagtail.blocks.ListBlock with maxNum set', () => {
   test('initialising at maxNum disables adding new block and duplication', () => {
     document.body.innerHTML = '<div id="placeholder"></div>';
     const boundBlock = blockDef.render($('#placeholder'), 'the-prefix', [
-      'First value',
-      'Second value',
-      'Third value',
+      {'value': 'First value', 'id': '11111111-1111-1111-1111-111111111111'},
+      {'value': 'Second value', 'id': '22222222-2222-2222-2222-222222222222'},
+      {'value': 'Third value', 'id': '33333333-3333-3333-3333-333333333333'},
     ]);
 
     assertCannotAddBlock();
@@ -329,8 +329,8 @@ describe('telepath: wagtail.blocks.ListBlock with maxNum set', () => {
   test('insert disables new block', () => {
     document.body.innerHTML = '<div id="placeholder"></div>';
     const boundBlock = blockDef.render($('#placeholder'), 'the-prefix', [
-      'First value',
-      'Second value',
+      {'value': 'First value', 'id': '11111111-1111-1111-1111-111111111111'},
+      {'value': 'Second value', 'id': '22222222-2222-2222-2222-222222222222'},
     ]);
 
     assertCanAddBlock();
@@ -343,9 +343,9 @@ describe('telepath: wagtail.blocks.ListBlock with maxNum set', () => {
   test('delete enables new block', () => {
     document.body.innerHTML = '<div id="placeholder"></div>';
     const boundBlock = blockDef.render($('#placeholder'), 'the-prefix', [
-      'First value',
-      'Second value',
-      'Third value',
+      {'value': 'First value', 'id': '11111111-1111-1111-1111-111111111111'},
+      {'value': 'Second value', 'id': '22222222-2222-2222-2222-222222222222'},
+      {'value': 'Third value', 'id': '33333333-3333-3333-3333-333333333333'},
     ]);
 
     assertCannotAddBlock();

--- a/client/src/components/StreamField/blocks/ListBlock.test.js
+++ b/client/src/components/StreamField/blocks/ListBlock.test.js
@@ -107,8 +107,8 @@ describe('telepath: wagtail.blocks.ListBlock', () => {
     // Render it
     document.body.innerHTML = '<div id="placeholder"></div>';
     boundBlock = blockDef.render($('#placeholder'), 'the-prefix', [
-      {'value': 'First value', 'id': '11111111-1111-1111-1111-111111111111'},
-      {'value': 'Second value', 'id': '22222222-2222-2222-2222-222222222222'},
+      { value: 'First value', id: '11111111-1111-1111-1111-111111111111' },
+      { value: 'Second value', id: '22222222-2222-2222-2222-222222222222' },
     ]);
   });
 
@@ -147,16 +147,16 @@ describe('telepath: wagtail.blocks.ListBlock', () => {
     const state = boundBlock.getState();
     expect(getState.mock.calls.length).toBe(2);
     expect(state).toEqual([
-      {value: 'state: The widget - the-prefix-0-value', id: '11111111-1111-1111-1111-111111111111'},
-      {value: 'state: The widget - the-prefix-1-value', id: '22222222-2222-2222-2222-222222222222'},
+      { value: 'state: The widget - the-prefix-0-value', id: '11111111-1111-1111-1111-111111111111' },
+      { value: 'state: The widget - the-prefix-1-value', id: '22222222-2222-2222-2222-222222222222' },
     ]);
   });
 
   test('setState() creates new widgets', () => {
     boundBlock.setState([
-      {value: 'Changed first value', id: '11111111-1111-1111-1111-111111111111'},
-      {value: 'Changed second value', id: '22222222-2222-2222-2222-222222222222'},
-      {value: 'Third value', id: '33333333-3333-3333-3333-333333333333'},
+      { value: 'Changed first value', id: '11111111-1111-1111-1111-111111111111' },
+      { value: 'Changed second value', id: '22222222-2222-2222-2222-222222222222' },
+      { value: 'Third value', id: '33333333-3333-3333-3333-333333333333' },
     ]);
 
     // Includes the two initial calls, plus the three new ones
@@ -187,9 +187,9 @@ describe('telepath: wagtail.blocks.ListBlock', () => {
     const state = boundBlock.getState();
     expect(getState.mock.calls.length).toBe(3);
     expect(state).toEqual([
-      {value: 'state: The widget - the-prefix-0-value', id: '11111111-1111-1111-1111-111111111111'},
-      {value: 'state: The widget - the-prefix-1-value', id: '22222222-2222-2222-2222-222222222222'},
-      {value: 'state: The widget - the-prefix-2-value', id: '33333333-3333-3333-3333-333333333333'},
+      { value: 'state: The widget - the-prefix-0-value', id: '11111111-1111-1111-1111-111111111111' },
+      { value: 'state: The widget - the-prefix-1-value', id: '22222222-2222-2222-2222-222222222222' },
+      { value: 'state: The widget - the-prefix-2-value', id: '33333333-3333-3333-3333-333333333333' },
     ]);
   });
 
@@ -308,8 +308,8 @@ describe('telepath: wagtail.blocks.ListBlock with maxNum set', () => {
   test('test can add block when under limit', () => {
     document.body.innerHTML = '<div id="placeholder"></div>';
     const boundBlock = blockDef.render($('#placeholder'), 'the-prefix', [
-      {'value': 'First value', 'id': '11111111-1111-1111-1111-111111111111'},
-      {'value': 'Second value', 'id': '22222222-2222-2222-2222-222222222222'},
+      { value: 'First value', id: '11111111-1111-1111-1111-111111111111' },
+      { value: 'Second value', id: '22222222-2222-2222-2222-222222222222' },
     ]);
 
     assertCanAddBlock();
@@ -318,9 +318,9 @@ describe('telepath: wagtail.blocks.ListBlock with maxNum set', () => {
   test('initialising at maxNum disables adding new block and duplication', () => {
     document.body.innerHTML = '<div id="placeholder"></div>';
     const boundBlock = blockDef.render($('#placeholder'), 'the-prefix', [
-      {'value': 'First value', 'id': '11111111-1111-1111-1111-111111111111'},
-      {'value': 'Second value', 'id': '22222222-2222-2222-2222-222222222222'},
-      {'value': 'Third value', 'id': '33333333-3333-3333-3333-333333333333'},
+      { value: 'First value', id: '11111111-1111-1111-1111-111111111111' },
+      { value: 'Second value', id: '22222222-2222-2222-2222-222222222222' },
+      { value: 'Third value', id: '33333333-3333-3333-3333-333333333333' },
     ]);
 
     assertCannotAddBlock();
@@ -329,8 +329,8 @@ describe('telepath: wagtail.blocks.ListBlock with maxNum set', () => {
   test('insert disables new block', () => {
     document.body.innerHTML = '<div id="placeholder"></div>';
     const boundBlock = blockDef.render($('#placeholder'), 'the-prefix', [
-      {'value': 'First value', 'id': '11111111-1111-1111-1111-111111111111'},
-      {'value': 'Second value', 'id': '22222222-2222-2222-2222-222222222222'},
+      { value: 'First value', id: '11111111-1111-1111-1111-111111111111' },
+      { value: 'Second value', id: '22222222-2222-2222-2222-222222222222' },
     ]);
 
     assertCanAddBlock();
@@ -343,9 +343,9 @@ describe('telepath: wagtail.blocks.ListBlock with maxNum set', () => {
   test('delete enables new block', () => {
     document.body.innerHTML = '<div id="placeholder"></div>';
     const boundBlock = blockDef.render($('#placeholder'), 'the-prefix', [
-      {'value': 'First value', 'id': '11111111-1111-1111-1111-111111111111'},
-      {'value': 'Second value', 'id': '22222222-2222-2222-2222-222222222222'},
-      {'value': 'Third value', 'id': '33333333-3333-3333-3333-333333333333'},
+      { value: 'First value', id: '11111111-1111-1111-1111-111111111111' },
+      { value: 'Second value', id: '22222222-2222-2222-2222-222222222222' },
+      { value: 'Third value', id: '33333333-3333-3333-3333-333333333333' },
     ]);
 
     assertCannotAddBlock();

--- a/client/src/components/StreamField/blocks/__snapshots__/ListBlock.test.js.snap
+++ b/client/src/components/StreamField/blocks/__snapshots__/ListBlock.test.js.snap
@@ -11,11 +11,11 @@ exports[`telepath: wagtail.blocks.ListBlock blocks can be duplicated 1`] = `
 
         <div data-streamfield-list-container=\\"\\"><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button c-sf-add-button--visible\\">
         <i aria-hidden=\\"true\\">+</i>
-      </button><div aria-hidden=\\"false\\" data-contentpath-disabled=\\"\\">
+      </button><div aria-hidden=\\"false\\" data-contentpath=\\"11111111-1111-1111-1111-111111111111\\">
         <input type=\\"hidden\\" name=\\"the-prefix-0-deleted\\" value=\\"\\">
         <input type=\\"hidden\\" name=\\"the-prefix-0-order\\" value=\\"0\\">
         <input type=\\"hidden\\" name=\\"the-prefix-0-type\\" value=\\"\\">
-        <input type=\\"hidden\\" name=\\"the-prefix-0-id\\" value=\\"\\">
+        <input type=\\"hidden\\" name=\\"the-prefix-0-id\\" value=\\"11111111-1111-1111-1111-111111111111\\">
 
         <div>
           <div class=\\"c-sf-container__block-container\\">
@@ -62,11 +62,11 @@ exports[`telepath: wagtail.blocks.ListBlock blocks can be duplicated 1`] = `
         </div>
       </div><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button c-sf-add-button--visible\\">
         <i aria-hidden=\\"true\\">+</i>
-      </button><div aria-hidden=\\"false\\" data-contentpath-disabled=\\"\\">
+      </button><div aria-hidden=\\"false\\" data-contentpath=\\"22222222-2222-2222-2222-222222222222\\">
         <input type=\\"hidden\\" name=\\"the-prefix-1-deleted\\" value=\\"\\">
         <input type=\\"hidden\\" name=\\"the-prefix-1-order\\" value=\\"1\\">
         <input type=\\"hidden\\" name=\\"the-prefix-1-type\\" value=\\"\\">
-        <input type=\\"hidden\\" name=\\"the-prefix-1-id\\" value=\\"\\">
+        <input type=\\"hidden\\" name=\\"the-prefix-1-id\\" value=\\"22222222-2222-2222-2222-222222222222\\">
 
         <div>
           <div class=\\"c-sf-container__block-container\\">
@@ -179,11 +179,11 @@ exports[`telepath: wagtail.blocks.ListBlock blocks can be reordered downward 1`]
 
         <div data-streamfield-list-container=\\"\\"><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button c-sf-add-button--visible\\">
         <i aria-hidden=\\"true\\">+</i>
-      </button><div aria-hidden=\\"false\\" data-contentpath-disabled=\\"\\">
+      </button><div aria-hidden=\\"false\\" data-contentpath=\\"22222222-2222-2222-2222-222222222222\\">
         <input type=\\"hidden\\" name=\\"the-prefix-1-deleted\\" value=\\"\\">
         <input type=\\"hidden\\" name=\\"the-prefix-1-order\\" value=\\"0\\">
         <input type=\\"hidden\\" name=\\"the-prefix-1-type\\" value=\\"\\">
-        <input type=\\"hidden\\" name=\\"the-prefix-1-id\\" value=\\"\\">
+        <input type=\\"hidden\\" name=\\"the-prefix-1-id\\" value=\\"22222222-2222-2222-2222-222222222222\\">
 
         <div>
           <div class=\\"c-sf-container__block-container\\">
@@ -230,11 +230,11 @@ exports[`telepath: wagtail.blocks.ListBlock blocks can be reordered downward 1`]
         </div>
       </div><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button c-sf-add-button--visible\\">
         <i aria-hidden=\\"true\\">+</i>
-      </button><div aria-hidden=\\"false\\" data-contentpath-disabled=\\"\\">
+      </button><div aria-hidden=\\"false\\" data-contentpath=\\"11111111-1111-1111-1111-111111111111\\">
         <input type=\\"hidden\\" name=\\"the-prefix-0-deleted\\" value=\\"\\">
         <input type=\\"hidden\\" name=\\"the-prefix-0-order\\" value=\\"1\\">
         <input type=\\"hidden\\" name=\\"the-prefix-0-type\\" value=\\"\\">
-        <input type=\\"hidden\\" name=\\"the-prefix-0-id\\" value=\\"\\">
+        <input type=\\"hidden\\" name=\\"the-prefix-0-id\\" value=\\"11111111-1111-1111-1111-111111111111\\">
 
         <div>
           <div class=\\"c-sf-container__block-container\\">
@@ -296,11 +296,11 @@ exports[`telepath: wagtail.blocks.ListBlock blocks can be reordered upward 1`] =
 
         <div data-streamfield-list-container=\\"\\"><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button c-sf-add-button--visible\\">
         <i aria-hidden=\\"true\\">+</i>
-      </button><div aria-hidden=\\"false\\" data-contentpath-disabled=\\"\\">
+      </button><div aria-hidden=\\"false\\" data-contentpath=\\"22222222-2222-2222-2222-222222222222\\">
         <input type=\\"hidden\\" name=\\"the-prefix-1-deleted\\" value=\\"\\">
         <input type=\\"hidden\\" name=\\"the-prefix-1-order\\" value=\\"0\\">
         <input type=\\"hidden\\" name=\\"the-prefix-1-type\\" value=\\"\\">
-        <input type=\\"hidden\\" name=\\"the-prefix-1-id\\" value=\\"\\">
+        <input type=\\"hidden\\" name=\\"the-prefix-1-id\\" value=\\"22222222-2222-2222-2222-222222222222\\">
 
         <div>
           <div class=\\"c-sf-container__block-container\\">
@@ -347,11 +347,11 @@ exports[`telepath: wagtail.blocks.ListBlock blocks can be reordered upward 1`] =
         </div>
       </div><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button c-sf-add-button--visible\\">
         <i aria-hidden=\\"true\\">+</i>
-      </button><div aria-hidden=\\"false\\" data-contentpath-disabled=\\"\\">
+      </button><div aria-hidden=\\"false\\" data-contentpath=\\"11111111-1111-1111-1111-111111111111\\">
         <input type=\\"hidden\\" name=\\"the-prefix-0-deleted\\" value=\\"\\">
         <input type=\\"hidden\\" name=\\"the-prefix-0-order\\" value=\\"1\\">
         <input type=\\"hidden\\" name=\\"the-prefix-0-type\\" value=\\"\\">
-        <input type=\\"hidden\\" name=\\"the-prefix-0-id\\" value=\\"\\">
+        <input type=\\"hidden\\" name=\\"the-prefix-0-id\\" value=\\"11111111-1111-1111-1111-111111111111\\">
 
         <div>
           <div class=\\"c-sf-container__block-container\\">
@@ -413,11 +413,11 @@ exports[`telepath: wagtail.blocks.ListBlock deleteBlock() deletes a block 1`] = 
 
         <div data-streamfield-list-container=\\"\\"><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button c-sf-add-button--visible\\">
         <i aria-hidden=\\"true\\">+</i>
-      </button><div aria-hidden=\\"false\\" data-contentpath-disabled=\\"\\">
+      </button><div aria-hidden=\\"false\\" data-contentpath=\\"11111111-1111-1111-1111-111111111111\\">
         <input type=\\"hidden\\" name=\\"the-prefix-0-deleted\\" value=\\"\\">
         <input type=\\"hidden\\" name=\\"the-prefix-0-order\\" value=\\"0\\">
         <input type=\\"hidden\\" name=\\"the-prefix-0-type\\" value=\\"\\">
-        <input type=\\"hidden\\" name=\\"the-prefix-0-id\\" value=\\"\\">
+        <input type=\\"hidden\\" name=\\"the-prefix-0-id\\" value=\\"11111111-1111-1111-1111-111111111111\\">
 
         <div>
           <div class=\\"c-sf-container__block-container\\">
@@ -464,11 +464,11 @@ exports[`telepath: wagtail.blocks.ListBlock deleteBlock() deletes a block 1`] = 
         </div>
       </div><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button c-sf-add-button--visible\\" style=\\"display: none;\\" aria-hidden=\\"true\\">
         <i aria-hidden=\\"true\\">+</i>
-      </button><div aria-hidden=\\"true\\" data-contentpath-disabled=\\"\\" style=\\"display: none;\\">
+      </button><div aria-hidden=\\"true\\" data-contentpath=\\"22222222-2222-2222-2222-222222222222\\" style=\\"display: none;\\">
         <input type=\\"hidden\\" name=\\"the-prefix-1-deleted\\" value=\\"1\\">
         <input type=\\"hidden\\" name=\\"the-prefix-1-order\\" value=\\"1\\">
         <input type=\\"hidden\\" name=\\"the-prefix-1-type\\" value=\\"\\">
-        <input type=\\"hidden\\" name=\\"the-prefix-1-id\\" value=\\"\\">
+        <input type=\\"hidden\\" name=\\"the-prefix-1-id\\" value=\\"22222222-2222-2222-2222-222222222222\\">
 
         <div>
           <div class=\\"c-sf-container__block-container\\">
@@ -530,11 +530,11 @@ exports[`telepath: wagtail.blocks.ListBlock it renders correctly 1`] = `
 
         <div data-streamfield-list-container=\\"\\"><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button c-sf-add-button--visible\\">
         <i aria-hidden=\\"true\\">+</i>
-      </button><div aria-hidden=\\"false\\" data-contentpath-disabled=\\"\\">
+      </button><div aria-hidden=\\"false\\" data-contentpath=\\"11111111-1111-1111-1111-111111111111\\">
         <input type=\\"hidden\\" name=\\"the-prefix-0-deleted\\" value=\\"\\">
         <input type=\\"hidden\\" name=\\"the-prefix-0-order\\" value=\\"0\\">
         <input type=\\"hidden\\" name=\\"the-prefix-0-type\\" value=\\"\\">
-        <input type=\\"hidden\\" name=\\"the-prefix-0-id\\" value=\\"\\">
+        <input type=\\"hidden\\" name=\\"the-prefix-0-id\\" value=\\"11111111-1111-1111-1111-111111111111\\">
 
         <div>
           <div class=\\"c-sf-container__block-container\\">
@@ -581,11 +581,11 @@ exports[`telepath: wagtail.blocks.ListBlock it renders correctly 1`] = `
         </div>
       </div><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button c-sf-add-button--visible\\">
         <i aria-hidden=\\"true\\">+</i>
-      </button><div aria-hidden=\\"false\\" data-contentpath-disabled=\\"\\">
+      </button><div aria-hidden=\\"false\\" data-contentpath=\\"22222222-2222-2222-2222-222222222222\\">
         <input type=\\"hidden\\" name=\\"the-prefix-1-deleted\\" value=\\"\\">
         <input type=\\"hidden\\" name=\\"the-prefix-1-order\\" value=\\"1\\">
         <input type=\\"hidden\\" name=\\"the-prefix-1-type\\" value=\\"\\">
-        <input type=\\"hidden\\" name=\\"the-prefix-1-id\\" value=\\"\\">
+        <input type=\\"hidden\\" name=\\"the-prefix-1-id\\" value=\\"22222222-2222-2222-2222-222222222222\\">
 
         <div>
           <div class=\\"c-sf-container__block-container\\">
@@ -647,11 +647,11 @@ exports[`telepath: wagtail.blocks.ListBlock setError passes error messages to ch
 
         <div data-streamfield-list-container=\\"\\"><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button c-sf-add-button--visible\\">
         <i aria-hidden=\\"true\\">+</i>
-      </button><div aria-hidden=\\"false\\" data-contentpath-disabled=\\"\\">
+      </button><div aria-hidden=\\"false\\" data-contentpath=\\"11111111-1111-1111-1111-111111111111\\">
         <input type=\\"hidden\\" name=\\"the-prefix-0-deleted\\" value=\\"\\">
         <input type=\\"hidden\\" name=\\"the-prefix-0-order\\" value=\\"0\\">
         <input type=\\"hidden\\" name=\\"the-prefix-0-type\\" value=\\"\\">
-        <input type=\\"hidden\\" name=\\"the-prefix-0-id\\" value=\\"\\">
+        <input type=\\"hidden\\" name=\\"the-prefix-0-id\\" value=\\"11111111-1111-1111-1111-111111111111\\">
 
         <div>
           <div class=\\"c-sf-container__block-container\\">
@@ -698,11 +698,11 @@ exports[`telepath: wagtail.blocks.ListBlock setError passes error messages to ch
         </div>
       </div><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button c-sf-add-button--visible\\">
         <i aria-hidden=\\"true\\">+</i>
-      </button><div aria-hidden=\\"false\\" data-contentpath-disabled=\\"\\">
+      </button><div aria-hidden=\\"false\\" data-contentpath=\\"22222222-2222-2222-2222-222222222222\\">
         <input type=\\"hidden\\" name=\\"the-prefix-1-deleted\\" value=\\"\\">
         <input type=\\"hidden\\" name=\\"the-prefix-1-order\\" value=\\"1\\">
         <input type=\\"hidden\\" name=\\"the-prefix-1-type\\" value=\\"\\">
-        <input type=\\"hidden\\" name=\\"the-prefix-1-id\\" value=\\"\\">
+        <input type=\\"hidden\\" name=\\"the-prefix-1-id\\" value=\\"22222222-2222-2222-2222-222222222222\\">
 
         <div>
           <div class=\\"c-sf-container__block-container\\">
@@ -764,11 +764,11 @@ exports[`telepath: wagtail.blocks.ListBlock setError renders non-block errors 1`
 
         <div data-streamfield-list-container=\\"\\"><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button c-sf-add-button--visible\\">
         <i aria-hidden=\\"true\\">+</i>
-      </button><div aria-hidden=\\"false\\" data-contentpath-disabled=\\"\\">
+      </button><div aria-hidden=\\"false\\" data-contentpath=\\"11111111-1111-1111-1111-111111111111\\">
         <input type=\\"hidden\\" name=\\"the-prefix-0-deleted\\" value=\\"\\">
         <input type=\\"hidden\\" name=\\"the-prefix-0-order\\" value=\\"0\\">
         <input type=\\"hidden\\" name=\\"the-prefix-0-type\\" value=\\"\\">
-        <input type=\\"hidden\\" name=\\"the-prefix-0-id\\" value=\\"\\">
+        <input type=\\"hidden\\" name=\\"the-prefix-0-id\\" value=\\"11111111-1111-1111-1111-111111111111\\">
 
         <div>
           <div class=\\"c-sf-container__block-container\\">
@@ -815,11 +815,11 @@ exports[`telepath: wagtail.blocks.ListBlock setError renders non-block errors 1`
         </div>
       </div><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button c-sf-add-button--visible\\">
         <i aria-hidden=\\"true\\">+</i>
-      </button><div aria-hidden=\\"false\\" data-contentpath-disabled=\\"\\">
+      </button><div aria-hidden=\\"false\\" data-contentpath=\\"22222222-2222-2222-2222-222222222222\\">
         <input type=\\"hidden\\" name=\\"the-prefix-1-deleted\\" value=\\"\\">
         <input type=\\"hidden\\" name=\\"the-prefix-1-order\\" value=\\"1\\">
         <input type=\\"hidden\\" name=\\"the-prefix-1-type\\" value=\\"\\">
-        <input type=\\"hidden\\" name=\\"the-prefix-1-id\\" value=\\"\\">
+        <input type=\\"hidden\\" name=\\"the-prefix-1-id\\" value=\\"22222222-2222-2222-2222-222222222222\\">
 
         <div>
           <div class=\\"c-sf-container__block-container\\">

--- a/docs/advanced_topics/boundblocks_and_values.rst
+++ b/docs/advanced_topics/boundblocks_and_values.rst
@@ -109,5 +109,9 @@ In summary, interactions between BoundBlocks and plain values work according to 
 1. When iterating over the value of a StreamField or StreamBlock (as in ``{% for block in page.body %}``), you will get back a sequence of BoundBlocks.
 2. If you have a BoundBlock instance, you can access the plain value as ``block.value``.
 3. Accessing a child of a StructBlock (as in ``value.heading``) will return a plain value; to retrieve the BoundBlock instead, use ``value.bound_blocks.heading``.
-4. The value of a ListBlock is a plain Python list; iterating over it returns plain child values.
+4. Likewise, accessing children of a ListBlock (e.g. ``for item in value``) will return plain values; to retrieve BoundBlocks instead, use ``value.bound_blocks``.
 5. StructBlock and StreamBlock values always know how to render their own templates, even if you only have the plain value rather than the BoundBlock.
+
+.. versionchanged:: 2.16
+
+  The value of a ListBlock now provides a ``bound_blocks`` property; previously it was a plain Python list of child values.

--- a/docs/releases/2.16.md
+++ b/docs/releases/2.16.md
@@ -11,6 +11,7 @@
 
 ### Other features
 
+ * Added persistent IDs for ListBlock items, allowing commenting and improvements to revision comparisons (Matt Westcott, Tidjani Dia)
  * Added Aging Pages report (Tidjani Dia)
  * Add more SketchFab oEmbed patterns for models (Tom Usher)
  * Add collapse option to `StreamField`, `StreamBlock`, and `ListBlock` which will load all sub-blocks initially collapsed (Matt Westcott)

--- a/docs/releases/2.16.md
+++ b/docs/releases/2.16.md
@@ -31,3 +31,17 @@
 ### Removed support for Python 3.6
 
 Python 3.6 is no longer supported as of this release; please upgrade to Python 3.7 or above before upgrading Wagtail.
+
+### StreamField ListBlock now returns `ListValue` rather than a list instance
+
+The data type returned as the value of a ListBlock is now a custom class, `ListValue`, rather than a Python `list` object. This change allows it to provide a `bound_blocks` property that exposes the list items as [`BoundBlock` objects](../advanced_topics/boundblocks_and_values) rather than plain values. `ListValue` objects are mutable sequences that behave similarly to lists, and so all code that iterates over them, accesses individual elements, or manipulates them should continue to work. However, code that specifically expects a `list` object (e.g. using `isinstance` or testing for equality against a list) may need to be updated. For example, a unit test that tests the value of a `ListBlock` as follows:
+
+```python
+    self.assertEqual(page.body[0].value, ['hello', 'goodbye'])
+```
+
+should be rewritten as:
+
+```python
+    self.assertEqual(list(page.body[0].value), ['hello', 'goodbye'])
+```

--- a/wagtail/core/blocks/list_block.py
+++ b/wagtail/core/blocks/list_block.py
@@ -204,9 +204,9 @@ class ListBlock(Block):
         for list_stream in values:
             lengths.append(len(list_stream))
             for list_child in list_stream:
-                try:
+                if self._item_is_in_block_format(list_child):
                     raw_values.append(list_child["value"])
-                except TypeError:
+                else:
                     raw_values.append(list_child)
 
         converted_values = self.child_block.bulk_to_python(raw_values)
@@ -218,9 +218,9 @@ class ListBlock(Block):
         for i, sublist_len in enumerate(lengths):
             bound_blocks = []
             for j in range(sublist_len):
-                try:
-                    list_item_id = values[i][j].get("id")
-                except AttributeError:
+                if self._item_is_in_block_format(values[i][j]):
+                    list_item_id = values[i][j]["id"]
+                else:
                     list_item_id = None
                 bound_blocks.append(
                     ListValue.ListChild(self.child_block, converted_values[offset + j], id=list_item_id)

--- a/wagtail/core/blocks/list_block.py
+++ b/wagtail/core/blocks/list_block.py
@@ -188,8 +188,11 @@ class ListBlock(Block):
 
     def get_form_state(self, value):
         return [
-            self.child_block.get_form_state(item)
-            for item in value
+            {
+                'value': self.child_block.get_form_state(block.value),
+                'id': block.id,
+            }
+            for block in value.bound_blocks
         ]
 
     def get_api_representation(self, value, context=None):

--- a/wagtail/core/blocks/list_block.py
+++ b/wagtail/core/blocks/list_block.py
@@ -143,6 +143,11 @@ class ListBlock(Block):
         return ('%s-count' % prefix) not in data
 
     def clean(self, value):
+        # value is expected to be a ListValue, but if it's been assigned through external code it might
+        # be a plain list; normalise it to a ListValue
+        if not isinstance(value, ListValue):
+            value = ListValue(self, values=value)
+
         result = []
         errors = []
         non_block_errors = ErrorList()
@@ -238,6 +243,11 @@ class ListBlock(Block):
         return result
 
     def get_prep_value(self, value):
+        # value is expected to be a ListValue, but if it's been assigned through external code it might
+        # be a plain list; normalise it to a ListValue
+        if not isinstance(value, ListValue):
+            value = ListValue(self, values=value)
+
         prep_value = []
 
         for item in value.bound_blocks:
@@ -248,6 +258,11 @@ class ListBlock(Block):
         return prep_value
 
     def get_form_state(self, value):
+        # value is expected to be a ListValue, but if it's been assigned through external code it might
+        # be a plain list; normalise it to a ListValue
+        if not isinstance(value, ListValue):
+            value = ListValue(self, values=value)
+
         return [
             {
                 'value': self.child_block.get_form_state(block.value),

--- a/wagtail/core/blocks/list_block.py
+++ b/wagtail/core/blocks/list_block.py
@@ -146,9 +146,11 @@ class ListBlock(Block):
         result = []
         errors = []
         non_block_errors = ErrorList()
-        for child_val in value:
+        for bound_block in value.bound_blocks:
             try:
-                result.append(self.child_block.clean(child_val))
+                result.append(ListValue.ListChild(
+                    self.child_block, self.child_block.clean(bound_block.value), id=bound_block.id
+                ))
             except ValidationError as e:
                 errors.append(ErrorList([e]))
             else:
@@ -167,7 +169,7 @@ class ListBlock(Block):
         if any(errors) or non_block_errors:
             raise ListBlockValidationError(block_errors=errors, non_block_errors=non_block_errors)
 
-        return ListValue(self, values=result)
+        return ListValue(self, bound_blocks=result)
 
     def _item_is_in_block_format(self, item):
         # check a list item retrieved from the database JSON representation to see whether it follows

--- a/wagtail/core/blocks/list_block.py
+++ b/wagtail/core/blocks/list_block.py
@@ -121,19 +121,23 @@ class ListBlock(Block):
 
     def value_from_datadict(self, data, files, prefix):
         count = int(data['%s-count' % prefix])
-        values_with_indexes = []
+        child_blocks_with_indexes = []
         for i in range(0, count):
             if data['%s-%d-deleted' % (prefix, i)]:
                 continue
-            values_with_indexes.append(
+            child_blocks_with_indexes.append(
                 (
                     int(data['%s-%d-order' % (prefix, i)]),
-                    self.child_block.value_from_datadict(data, files, '%s-%d-value' % (prefix, i))
+                    ListValue.ListChild(
+                        self.child_block,
+                        self.child_block.value_from_datadict(data, files, '%s-%d-value' % (prefix, i)),
+                        id=data.get('%s-%d-id' % (prefix, i)),
+                    )
                 )
             )
 
-        values_with_indexes.sort()
-        return ListValue(self, values=[v for (i, v) in values_with_indexes])
+        child_blocks_with_indexes.sort()
+        return ListValue(self, bound_blocks=[b for (i, b) in child_blocks_with_indexes])
 
     def value_omitted_from_data(self, data, files, prefix):
         return ('%s-count' % prefix) not in data

--- a/wagtail/core/tests/test_blocks.py
+++ b/wagtail/core/tests/test_blocks.py
@@ -2382,31 +2382,44 @@ class TestListBlock(WagtailTestUtils, SimpleTestCase):
             },
         })
 
+    def test_clean_preserves_block_ids(self):
+        block = blocks.ListBlock(blocks.CharBlock())
+        block_val = block.to_python([
+            {'type': 'item', 'value': 'foo', 'id': '11111111-1111-1111-1111-111111111111'},
+            {'type': 'item', 'value': 'bar', 'id': '22222222-2222-2222-2222-222222222222'},
+        ])
+        cleaned_block_val = block.clean(block_val)
+        self.assertEqual(cleaned_block_val.bound_blocks[0].id, '11111111-1111-1111-1111-111111111111')
+
     def test_min_num_validation_errors(self):
         block = blocks.ListBlock(blocks.CharBlock(), min_num=2)
+        block_val = block.to_python(['foo'])
 
         with self.assertRaises(ValidationError) as catcher:
-            block.clean(['foo'])
+            block.clean(block_val)
         self.assertEqual(catcher.exception.params, {
             'block_errors': [None],
             'non_block_errors': ['The minimum number of items is 2']
         })
 
         # a value with >= 2 blocks should pass validation
-        self.assertTrue(block.clean(['foo', 'bar']))
+        block_val = block.to_python(['foo', 'bar'])
+        self.assertTrue(block.clean(block_val))
 
     def test_max_num_validation_errors(self):
         block = blocks.ListBlock(blocks.CharBlock(), max_num=2)
+        block_val = block.to_python(['foo', 'bar', 'baz'])
 
         with self.assertRaises(ValidationError) as catcher:
-            block.clean(['foo', 'bar', 'baz'])
+            block.clean(block_val)
         self.assertEqual(catcher.exception.params, {
             'block_errors': [None, None, None],
             'non_block_errors': ['The maximum number of items is 2']
         })
 
         # a value with <= 2 blocks should pass validation
-        self.assertTrue(block.clean(['foo', 'bar']))
+        block_val = block.to_python(['foo', 'bar'])
+        self.assertTrue(block.clean(block_val))
 
     def test_unpack_old_database_format(self):
         block = blocks.ListBlock(blocks.CharBlock())

--- a/wagtail/core/tests/test_blocks.py
+++ b/wagtail/core/tests/test_blocks.py
@@ -2239,6 +2239,22 @@ class TestListBlock(WagtailTestUtils, SimpleTestCase):
         }, {}, 'mylist'))
         self.assertTrue(block.value_omitted_from_data({'nothing-here': 'nope'}, {}, 'mylist'))
 
+    def test_id_from_form_submission_is_preserved(self):
+        block = blocks.ListBlock(blocks.CharBlock())
+
+        post_data = {'shoppinglist-count': '3'}
+        for i in range(0, 3):
+            post_data.update({
+                'shoppinglist-%d-deleted' % i: '',
+                'shoppinglist-%d-order' % i: str(i),
+                'shoppinglist-%d-value' % i: "item %d" % i,
+                'shoppinglist-%d-id' % i: "0000000%d" % i,
+            })
+
+        block_value = block.value_from_datadict(post_data, {}, 'shoppinglist')
+        self.assertEqual(block_value.bound_blocks[1].value, "item 1")
+        self.assertEqual(block_value.bound_blocks[1].id, "00000001")
+
     def test_ordering_in_form_submission_uses_order_field(self):
         block = blocks.ListBlock(blocks.CharBlock())
 
@@ -2248,7 +2264,8 @@ class TestListBlock(WagtailTestUtils, SimpleTestCase):
             post_data.update({
                 'shoppinglist-%d-deleted' % i: '',
                 'shoppinglist-%d-order' % i: str(2 - i),
-                'shoppinglist-%d-value' % i: "item %d" % i
+                'shoppinglist-%d-value' % i: "item %d" % i,
+                'shoppinglist-%d-id' % i: "0000000%d" % i,
             })
 
         block_value = block.value_from_datadict(post_data, {}, 'shoppinglist')
@@ -2263,7 +2280,8 @@ class TestListBlock(WagtailTestUtils, SimpleTestCase):
             post_data.update({
                 'shoppinglist-%d-deleted' % i: '',
                 'shoppinglist-%d-order' % i: str(i),
-                'shoppinglist-%d-value' % i: "item %d" % i
+                'shoppinglist-%d-value' % i: "item %d" % i,
+                'shoppinglist-%d-id' % i: "0000000%d" % i,
             })
 
         block_value = block.value_from_datadict(post_data, {}, 'shoppinglist')

--- a/wagtail/core/tests/test_blocks.py
+++ b/wagtail/core/tests/test_blocks.py
@@ -1823,9 +1823,9 @@ class TestStructBlock(SimpleTestCase):
         ])
 
         shopping_lists[0]['items'].append('cake')
-        self.assertEqual(shopping_lists[0]['items'], ['chocolate', 'cake'])
+        self.assertEqual(list(shopping_lists[0]['items']), ['chocolate', 'cake'])
         # shopping_lists[1] should not be updated
-        self.assertEqual(shopping_lists[1]['items'], ['chocolate'])
+        self.assertEqual(list(shopping_lists[1]['items']), ['chocolate'])
 
     def test_clean(self):
         block = blocks.StructBlock([
@@ -2272,7 +2272,7 @@ class TestListBlock(WagtailTestUtils, SimpleTestCase):
     def test_can_specify_default(self):
         block = blocks.ListBlock(blocks.CharBlock(), default=['peas', 'beans', 'carrots'])
 
-        self.assertEqual(block.get_default(), ['peas', 'beans', 'carrots'])
+        self.assertEqual(list(block.get_default()), ['peas', 'beans', 'carrots'])
 
     def test_default_default(self):
         """
@@ -2281,7 +2281,7 @@ class TestListBlock(WagtailTestUtils, SimpleTestCase):
         """
         block = blocks.ListBlock(blocks.CharBlock(default='chocolate'))
 
-        self.assertEqual(block.get_default(), ['chocolate'])
+        self.assertEqual(list(block.get_default()), ['chocolate'])
 
         block.set_name('test_shoppinglistblock')
         js_args = ListBlockAdapter().js_args(block)
@@ -2303,9 +2303,9 @@ class TestListBlock(WagtailTestUtils, SimpleTestCase):
         asda_shopping = block.to_python({'shop': 'Asda'})  # 'items' will default to ['chocolate'], but a distinct instance
 
         tesco_shopping['items'].append('cake')
-        self.assertEqual(tesco_shopping['items'], ['chocolate', 'cake'])
+        self.assertEqual(list(tesco_shopping['items']), ['chocolate', 'cake'])
         # asda_shopping should not be modified
-        self.assertEqual(asda_shopping['items'], ['chocolate'])
+        self.assertEqual(list(asda_shopping['items']), ['chocolate'])
 
     def test_adapt_with_classname_via_kwarg(self):
         """form_classname from kwargs to be used as an additional class when rendering list block"""
@@ -2409,8 +2409,10 @@ class TestListBlockWithFixtures(TestCase):
 
         with self.assertNumQueries(1):
             result = block.bulk_to_python([[4, 5], [], [2]])
+            # result will be a list of ListValues - convert to lists for equality check
+            clean_result = [list(val) for val in result]
 
-        self.assertEqual(result, [
+        self.assertEqual(clean_result, [
             [Page.objects.get(id=4), Page.objects.get(id=5)],
             [],
             [Page.objects.get(id=2)],

--- a/wagtail/core/tests/test_blocks.py
+++ b/wagtail/core/tests/test_blocks.py
@@ -2390,6 +2390,21 @@ class TestListBlock(WagtailTestUtils, SimpleTestCase):
         # a value with <= 2 blocks should pass validation
         self.assertTrue(block.clean(['foo', 'bar']))
 
+    def test_blocks_are_assigned_ids(self):
+        block = blocks.ListBlock(blocks.CharBlock())
+        list_val = block.to_python(['foo', 'bar'])
+
+        # list_val should behave as a list
+        self.assertEqual(len(list_val), 2)
+        self.assertEqual(list_val[0], 'foo')
+
+        # but also provide a bound_blocks property
+        self.assertEqual(len(list_val.bound_blocks), 2)
+        self.assertEqual(list_val.bound_blocks[0].value, 'foo')
+
+        # Bound blocks should be assigned UUIDs
+        self.assertRegex(list_val.bound_blocks[0].id, r'[0-9a-f-]+')
+
 
 class TestListBlockWithFixtures(TestCase):
     fixtures = ['test.json']

--- a/wagtail/core/tests/test_blocks.py
+++ b/wagtail/core/tests/test_blocks.py
@@ -2490,6 +2490,19 @@ class TestListBlock(WagtailTestUtils, SimpleTestCase):
         self.assertEqual(list_1.bound_blocks[0].value, 'foo')
         self.assertEqual(list_1.bound_blocks[0].id, '11111111-1111-1111-1111-111111111111')
 
+    def test_assign_listblock_with_list(self):
+        stream_block = blocks.StreamBlock([
+            ('bullet_list', blocks.ListBlock(blocks.CharBlock())),
+        ])
+        stream_value = stream_block.to_python([])
+        stream_value.append(('bullet_list', ['foo', 'bar']))
+
+        clean_stream_value = stream_block.clean(stream_value)
+        result = stream_block.get_prep_value(clean_stream_value)
+        self.assertEqual(result[0]['type'], 'bullet_list')
+        self.assertEqual(len(result[0]['value']), 2)
+        self.assertEqual(result[0]['value'][0]['value'], 'foo')
+
 
 class TestListBlockWithFixtures(TestCase):
     fixtures = ['test.json']


### PR DESCRIPTION
Implements [RFC 65](https://github.com/wagtail/rfcs/blob/main/text/065-listblock.md) - the database representation of a ListBlock value now saves an id alongside the value of each child. To preserve these IDs during Python-side processing, we introduce a new `ListValue` type; this behaves like a list of child values (so code that iterates over it or performs indexing on it should continue to work, provided it doesn't explicitly expect a `list` instance e.g. `isinstance(value, list)` or `value == ['foo', 'bar']`) but additionally provides a `bound_blocks` property to access the bound block objects with IDs.

Note: the RFC proposed `data` as the name of this property; I went with `bound_blocks` for consistency with StructValue.