### PR TITLE
Improve CircleCI frontend & backend build caches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,20 +36,20 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          keys:
-            - node-v1-{{ .Branch }}-{{ checksum "package-lock.json" }}
-            - node-v1-{{ .Branch }}-
-            - node-v1-
-      - run: npm install --no-save
+          key: frontend-v1-{{ checksum "package-lock.json" }}
+      # Only install if node_modules wasn’t cached.
+      - run: |
+            if [[ ! -e "node_modules" ]]; then
+                npm install --no-save --no-optional --no-audit --no-fund --progress=false
+            fi
       - save_cache:
           paths:
-            - ~/project/node_modules/
-          key: node-v1-{{ .Branch }}-{{ checksum "package-lock.json" }}
-      - run: npm run build
+            - node_modules
+          key: frontend-v1-{{ checksum "package-lock.json" }}
+      - run: npm run dist
       - run: npm run lint:js
       - run: npm run lint:css
       - run: npm run test:unit:coverage -- --runInBand
-      - run: npm run dist
       - run: bash <(curl -s https://codecov.io/bash) -F frontend
 
   nightly-build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,17 +4,21 @@ jobs:
   backend:
     docker:
       - image: cimg/python:3.8.11
+    environment:
+      PIPENV_VENV_IN_PROJECT: true
     steps:
       - checkout
       - restore_cache:
-          keys:
-            - pip-packages-v1-{{ .Branch }}
-            - pip-packages-v1-
-      - run: pipenv install -e .[testing]
+          key: pipenv-v1-{{ checksum "setup.py" }}
+      # Only install if .venv wasn’t cached.
+      - run: |
+            if [[ ! -e ".venv" ]]; then
+                pipenv install -e .[testing]
+            fi
       - save_cache:
+          key: pipenv-v1-{{ checksum "setup.py" }}
           paths:
-            - ~/.local/
-          key: pip-package-v1-{{ .Branch }}
+            - .venv
       - run: pipenv run flake8
       - run: pipenv run isort --check-only --diff .
       # Filter out known false positives, while preserving normal output and error codes.

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,7 @@ python-tag = py3
 # W503: line break before binary operator (superseded by W504 line break after binary operator)
 # N806: Variable in function should be lowercase
 ignore = D100,D101,D102,D103,D105,E501,W503,N806
-exclude = wagtail/project_template/*,node_modules,venv
+exclude = wagtail/project_template/*,node_modules,venv,.venv
 max-line-length = 120
 
 [doc8]
@@ -21,7 +21,7 @@ ignore-path = _build,docs/_build
 [isort]
 line_length=100
 multi_line_output=4
-skip=migrations,project_template,node_modules,.git,__pycache__,LC_MESSAGES,venv
+skip=migrations,project_template,node_modules,.git,__pycache__,LC_MESSAGES,venv,.venv
 blocked_extensions=rst,html,js,svg,txt,css,scss,png,snap,tsx
 known_first_party=wagtail
 default_section=THIRDPARTY


### PR DESCRIPTION
This changes our CircleCI backend and frontend builds to make better use of the cache.

## backend

- The backend build had caching setup but it didn’t do anything – there’s a typo (missing `s`) between the cache key used for saving and that used for restoring.
- Even just fixing the typo, it doesn’t seem like we’d save much processing by caching the pip cache in `~/.local/` only

I’ve done three changes:

- The cache key is based on a hash of `setup.py`, rather than per-branch. So the cache will only be discarded when dependencies change, rather than for each and every branch / PR.
- We cache the contents of the virtual environment after installation rather than the pip dependencies cache.
- We completely skip the installation step if the `.venv` has been populated from the cache.

I would expect this will speed up `backend` jobs by 1 minute or so – from 1min 15s installing all dependencies afresh every time, to 2-5s restoring the cache.

## frontend

Changes aren’t so dramatic there since the cache was set up correctly. I’ve only made two of the above changes:

- Caching based on `package-lock.json` hash only, rather than per branch. The lockfile is the only thing that matters for `npm install`, so segregating caches per branch doesn’t achieve anything useful.
- We can also completely skip the installation step if `node_modules` was restored from cache.

In this case I’d expect the savings to be on the order of 30s per build – from 45s restoring cache, installing, saving cache – to 10-15s restoring the cache only.

---

Sample build with both improvements visible (on a fork): https://app.circleci.com/pipelines/github/thibaudcolas/wagtail-fork/58/workflows/59d0fe54-6ca7-4420-b195-ecbad3804f3e.