### PR TITLE
Remove spurious action button on 'create workflow task' view

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/workflows/create_task.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/create_task.html
@@ -22,7 +22,7 @@
 
 {% block content %}
 
-    {% include "wagtailadmin/shared/header.html" with title=view.page_title icon=view.header_icon merged=1 %}
+    {% include "wagtailadmin/shared/header.html" with title=view.page_title icon=view.header_icon merged=1 only %}
 
     <form action="{{ view.get_add_url }}" enctype="multipart/form-data" method="POST" novalidate>
         {% csrf_token %}

--- a/wagtail/admin/templates/wagtailadmin/workflows/edit.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/edit.html
@@ -26,7 +26,7 @@
 {% endblock %}
 
 {% block content %}
-    {% include "wagtailadmin/shared/header.html" with title=view.page_title subtitle=object.name icon=view.header_icon merged=1 %}
+    {% include "wagtailadmin/shared/header.html" with title=view.page_title subtitle=object.name icon=view.header_icon merged=1 only %}
 
     <form action="{% block form_action %}{{ view.edit_url }}{% endblock %}"{% if is_multipart %} enctype="multipart/form-data"{% endif %} method="POST" novalidate>
         {% csrf_token %}

--- a/wagtail/admin/templates/wagtailadmin/workflows/edit_task.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/edit_task.html
@@ -23,7 +23,7 @@
 {% endblock %}
 
 {% block content %}
-    {% include "wagtailadmin/shared/header.html" with title=view.page_title subtitle=object.name icon=view.header_icon merged=1 %}
+    {% include "wagtailadmin/shared/header.html" with title=view.page_title subtitle=object.name icon=view.header_icon merged=1 only %}
 
     <form action="{{ view.edit_url }}" enctype="multipart/form-data" method="POST" novalidate>
         {% csrf_token %}


### PR DESCRIPTION
Fixes #7758. 1fe36d2597dfae558c979150651feff0f949ca03 fixed the generic base template to stop the `action_url` from leaking into the header, but create_task.html bypasses the base template so needs the fix applying separately.

(it would probably make sense to improve the template inheritance so that we're not repeating so much boilerplate, since this looks like a pretty much vanilla form - but since this is targeting a patch release I've kept the change minimal here.)