### PR TITLE
Use admin tables framework on snippet and document choosers

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/tables/table.html
+++ b/wagtail/admin/templates/wagtailadmin/tables/table.html
@@ -1,6 +1,11 @@
 {% load wagtailadmin_tags %}
 
 <table {% if table.classname %}class="{{ table.classname }}"{% endif %}>
+    {% if table.has_column_widths %}
+        {% for column in table.columns.values %}
+            <col {% if column.width %}width="{{ column.width }}"{% endif %} />
+        {% endfor %}
+    {% endif %}
     <thead>
         <tr>
             {% for column in table.columns.values %}

--- a/wagtail/admin/templates/wagtailadmin/tables/table.html
+++ b/wagtail/admin/templates/wagtailadmin/tables/table.html
@@ -7,7 +7,7 @@
         {% endfor %}
     {% endif %}
     <thead>
-        <tr>
+        <tr {% if table.header_row_classname %}class="{{ table.header_row_classname }}"{% endif %}>
             {% for column in table.columns.values %}
                 {% component column.header %}
             {% endfor %}

--- a/wagtail/admin/templates/wagtailadmin/tables/title_cell.html
+++ b/wagtail/admin/templates/wagtailadmin/tables/title_cell.html
@@ -1,7 +1,7 @@
 <td class="{% if column.classname %}{{ column.classname }} {% endif %}title">
     <div class="title-wrapper">
         {% if link_url %}
-            <a href="{{ link_url }}">{{ value }}</a>
+            <a href="{{ link_url }}" {% if link_classname %}class="{{ link_classname }}"{% endif %}>{{ value }}</a>
         {% else %}
             {{ value }}
         {% endif %}

--- a/wagtail/admin/tests/ui/test_tables.py
+++ b/wagtail/admin/tests/ui/test_tables.py
@@ -73,7 +73,7 @@ class TestTable(TestCase):
         data = [blog, gallery]
 
         table = Table([
-            TitleColumn('hostname', url_name='wagtailsites:edit'),
+            TitleColumn('hostname', url_name='wagtailsites:edit', link_classname='choose-site'),
             Column('site_name', label="Site name"),
         ], data)
 
@@ -87,7 +87,7 @@ class TestTable(TestCase):
                     <tr>
                         <td class="title">
                             <div class="title-wrapper">
-                                <a href="/admin/sites/%d/">blog.example.com</a>
+                                <a href="/admin/sites/%d/" class="choose-site">blog.example.com</a>
                             </div>
                         </td>
                         <td>My blog</td>
@@ -95,7 +95,7 @@ class TestTable(TestCase):
                     <tr>
                         <td class="title">
                             <div class="title-wrapper">
-                                <a href="/admin/sites/%d/">gallery.example.com</a>
+                                <a href="/admin/sites/%d/" class="choose-site">gallery.example.com</a>
                             </div>
                         </td>
                         <td>My gallery</td>

--- a/wagtail/admin/tests/ui/test_tables.py
+++ b/wagtail/admin/tests/ui/test_tables.py
@@ -40,6 +40,32 @@ class TestTable(TestCase):
             </table>
         ''')
 
+    def test_table_render_with_width(self):
+        data = [
+            {'first_name': 'Paul', 'last_name': 'Simon'},
+            {'first_name': 'Art', 'last_name': 'Garfunkel'},
+        ]
+
+        table = Table([
+            Column('first_name'),
+            Column('last_name', width='75%'),
+        ], data)
+
+        html = self.render_component(table)
+        self.assertHTMLEqual(html, '''
+            <table class="listing">
+                <col />
+                <col width="75%" />
+                <thead>
+                    <tr><th>First name</th><th>Last name</th></tr>
+                </thead>
+                <tbody>
+                    <tr><td>Paul</td><td>Simon</td></tr>
+                    <tr><td>Art</td><td>Garfunkel</td></tr>
+                </tbody>
+            </table>
+        ''')
+
     def test_title_column(self):
         root_page = Page.objects.filter(depth=2).first()
         blog = Site.objects.create(hostname='blog.example.com', site_name='My blog', root_page=root_page)

--- a/wagtail/admin/ui/tables.py
+++ b/wagtail/admin/ui/tables.py
@@ -179,6 +179,7 @@ class UserColumn(Column):
 class Table(Component):
     template_name = "wagtailadmin/tables/table.html"
     classname = 'listing'
+    header_row_classname = ''
 
     def __init__(self, columns, data, template_name=None, base_url=None, ordering=None):
         self.columns = OrderedDict([

--- a/wagtail/admin/ui/tables.py
+++ b/wagtail/admin/ui/tables.py
@@ -39,13 +39,14 @@ class Column(metaclass=MediaDefiningClass):
     header_template_name = "wagtailadmin/tables/column_header.html"
     cell_template_name = "wagtailadmin/tables/cell.html"
 
-    def __init__(self, name, label=None, accessor=None, classname=None, sort_key=None):
+    def __init__(self, name, label=None, accessor=None, classname=None, sort_key=None, width=None):
         self.name = name
         self.accessor = accessor or name
         self.label = label or capfirst(name.replace('_', ' '))
         self.classname = classname
         self.sort_key = sort_key
         self.header = Column.Header(self)
+        self.width = width
 
     def get_header_context_data(self, parent_context):
         """
@@ -207,6 +208,9 @@ class Table(Component):
     def rows(self):
         for instance in self.data:
             yield Table.Row(self.columns, instance)
+
+    def has_column_widths(self):
+        return any(column.width for column in self.columns.values())
 
     class Row(Mapping):
         # behaves as an OrderedDict whose items are the rendered results of

--- a/wagtail/admin/ui/tables.py
+++ b/wagtail/admin/ui/tables.py
@@ -121,14 +121,16 @@ class TitleColumn(Column):
     """A column where data is styled as a title and wrapped in a link"""
     cell_template_name = "wagtailadmin/tables/title_cell.html"
 
-    def __init__(self, name, url_name=None, get_url=None, **kwargs):
+    def __init__(self, name, url_name=None, get_url=None, link_classname=None, **kwargs):
         super().__init__(name, **kwargs)
         self.url_name = url_name
         self._get_url_func = get_url
+        self.link_classname = link_classname
 
     def get_cell_context_data(self, instance, parent_context):
         context = super().get_cell_context_data(instance, parent_context)
         context['link_url'] = self.get_link_url(instance, parent_context)
+        context['link_classname'] = self.link_classname
         return context
 
     def get_link_url(self, instance, parent_context):

--- a/wagtail/documents/templates/wagtaildocs/chooser/results.html
+++ b/wagtail/documents/templates/wagtaildocs/chooser/results.html
@@ -1,4 +1,4 @@
-{% load i18n %}
+{% load i18n wagtailadmin_tags %}
 {% if documents %}
     {% if is_searching %}
         <h2 role="alert">
@@ -12,43 +12,7 @@
         <h2>{% trans "Latest documents" %}</h2>
     {% endif %}
 
-    <table class="listing">
-        <col />
-        <col  />
-        {% if collections %}
-            <col />
-        {% endif %}
-        <col width="16%" />
-        <thead>
-            <tr class="table-headers">
-                <th>{% trans "Title" %}</th>
-                <th>{% trans "File" %}</th>
-                {% if collections %}
-                    <th>{% trans "Collection" %}</th>
-                {% endif %}
-                <th>{% trans "Created" %}</th>
-            </tr>
-        </thead>
-        <tbody>
-            {% for doc in documents %}
-                <tr>
-                    <td class="title">
-                        <div class="title-wrapper"><a href="{% url 'wagtaildocs:document_chosen' doc.id %}" class="document-choice">{{ doc.title }}</a></div>
-                    </td>
-                    <td><a href="{{ doc.url }}" class="nolink" download>{{ doc.filename }}</a></td>
-                    {% if collections %}
-                        <td>{{ doc.collection.name }}</td>
-                    {% endif %}
-                    <td>
-                        <div class="human-readable-date" title="{{ doc.created_at|date:"DATETIME_FORMAT" }}">
-                            {% blocktrans with time_period=doc.created_at|timesince %}{{ time_period }} ago{% endblocktrans %}
-                        </div>
-                    </td>
-                </tr>
-            {% endfor %}
-        </tbody>
-    </table>
-
+    {% component table %}
     {% include "wagtailadmin/shared/pagination_nav.html" with items=documents linkurl='wagtaildocs:chooser_results' %}
 {% else %}
     {% if documents_exist %}

--- a/wagtail/documents/templates/wagtaildocs/tables/download_cell.html
+++ b/wagtail/documents/templates/wagtaildocs/tables/download_cell.html
@@ -1,0 +1,1 @@
+<td><a href="{{ download_url }}" class="nolink" download>{{ value }}</a></td>

--- a/wagtail/documents/views/chooser.py
+++ b/wagtail/documents/views/chooser.py
@@ -46,10 +46,6 @@ class DownloadColumn(Column):
         return context
 
 
-class ResultsTable(Table):
-    header_row_classname = 'table-headers'
-
-
 class BaseChooseView(View):
     def get(self, request):
         Document = get_document_model()
@@ -109,7 +105,7 @@ class BaseChooseView(View):
         if self.collections:
             columns.insert(2, Column('collection', label=_("Collection")))
 
-        self.table = ResultsTable(columns, self.documents)
+        self.table = Table(columns, self.documents)
 
         return self.render_to_response()
 

--- a/wagtail/snippets/templates/wagtailsnippets/chooser/results.html
+++ b/wagtail/snippets/templates/wagtailsnippets/chooser/results.html
@@ -1,4 +1,4 @@
-{% load i18n wagtailadmin_tags wagtailsnippets_admin_tags %}
+{% load i18n wagtailadmin_tags %}
 {% if items %}
     {% if is_searching %}
         <h2 role="alert">
@@ -10,23 +10,7 @@
         </h2>
     {% endif %}
 
-    <table class="listing">
-        <col />
-        <thead>
-            <tr class="table-headers">
-                <th>{% trans "Title" %}</th>
-            </tr>
-        </thead>
-        <tbody>
-            {% for snippet in items %}
-                <tr>
-                    <td class="title">
-                        <div class="title-wrapper"><a class="snippet-choice" href="{% url 'wagtailsnippets:chosen' model_opts.app_label model_opts.model_name snippet.pk|admin_urlquote %}">{{ snippet }}</a></div>
-                    </td>
-                </tr>
-            {% endfor %}
-        </tbody>
-    </table>
+    {% component table %}
 
     {% url 'wagtailsnippets:choose_results' model_opts.app_label model_opts.model_name as pagination_base_url %}
     {% include "wagtailadmin/shared/pagination_nav.html" with items=items linkurl=pagination_base_url %}

--- a/wagtail/snippets/templates/wagtailsnippets/chooser/results.html
+++ b/wagtail/snippets/templates/wagtailsnippets/chooser/results.html
@@ -19,7 +19,7 @@
         </thead>
         <tbody>
             {% for snippet in items %}
-                <tr id="snippet-row-{{ snippet.pk }}">
+                <tr>
                     <td class="title">
                         <div class="title-wrapper"><a class="snippet-choice" href="{% url 'wagtailsnippets:chosen' model_opts.app_label model_opts.model_name snippet.pk|admin_urlquote %}">{{ snippet }}</a></div>
                     </td>

--- a/wagtail/snippets/views/chooser.py
+++ b/wagtail/snippets/views/chooser.py
@@ -8,10 +8,29 @@ from django.views.generic.base import View
 
 from wagtail.admin.forms.search import SearchForm
 from wagtail.admin.modal_workflow import render_modal_workflow
+from wagtail.admin.ui.tables import Table, TitleColumn
 from wagtail.core.models import Locale, TranslatableMixin
 from wagtail.search.backends import get_search_backend
 from wagtail.search.index import class_is_indexed
 from wagtail.snippets.views.snippets import get_snippet_model_from_url_params
+
+
+class ResultsTable(Table):
+    header_row_classname = 'table-headers'
+
+
+class SnippetTitleColumn(TitleColumn):
+    def __init__(self, name, model, **kwargs):
+        self.model_opts = model._meta
+        super().__init__(name, **kwargs)
+
+    def get_value(self, instance):
+        return str(instance)
+
+    def get_link_url(self, instance, parent_context):
+        return reverse(
+            'wagtailsnippets:chosen', args=[self.model_opts.app_label, self.model_opts.model_name, quote(instance.pk)]
+        )
 
 
 class BaseChooseView(View):
@@ -68,6 +87,10 @@ class BaseChooseView(View):
         paginator = Paginator(items, per_page=25)
         self.paginated_items = paginator.get_page(request.GET.get('p'))
 
+        self.table = ResultsTable([
+            SnippetTitleColumn('title', self.model, label=_('Title'), link_classname='snippet-choice'),
+        ], self.paginated_items)
+
         return self.render_to_response()
 
     def render_to_response(self):
@@ -83,6 +106,7 @@ class ChooseView(BaseChooseView):
             {
                 'model_opts': self.model._meta,
                 'items': self.paginated_items,
+                'table': self.table,
                 'is_searchable': self.is_searchable,
                 'search_form': self.search_form,
                 'query_string': self.search_query,
@@ -101,6 +125,7 @@ class ChooseResultsView(BaseChooseView):
         return TemplateResponse(self.request, "wagtailsnippets/chooser/results.html", {
             'model_opts': self.model._meta,
             'items': self.paginated_items,
+            'table': self.table,
             'query_string': self.search_query,
             'is_searching': self.is_searching,
         })

--- a/wagtail/snippets/views/chooser.py
+++ b/wagtail/snippets/views/chooser.py
@@ -15,10 +15,6 @@ from wagtail.search.index import class_is_indexed
 from wagtail.snippets.views.snippets import get_snippet_model_from_url_params
 
 
-class ResultsTable(Table):
-    header_row_classname = 'table-headers'
-
-
 class SnippetTitleColumn(TitleColumn):
     def __init__(self, name, model, **kwargs):
         self.model_opts = model._meta
@@ -87,7 +83,7 @@ class BaseChooseView(View):
         paginator = Paginator(items, per_page=25)
         self.paginated_items = paginator.get_page(request.GET.get('p'))
 
-        self.table = ResultsTable([
+        self.table = Table([
             SnippetTitleColumn('title', self.model, label=_('Title'), link_classname='snippet-choice'),
         ], self.paginated_items)
 


### PR DESCRIPTION
Migrate the snippet and document choosers to use the `wagtail.admin.ui.tables` framework introduced in #7409, so that we can avoid having a load of `<table>` boilerplate in the template. Along the way we extend the functionality of the tables framework, notably adding the ability to specify column widths.