### PR TITLE
Fixes #7019: Change the padding to 0.75rem

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -22,6 +22,7 @@ Changelog
  * Fix: Refresh page from database on create before passing to hooks. Page aliases get correct `first_published_date` and `last_published_date` (Dan Braghis)
  * Fix: Additional login form fields from `WAGTAILADMIN_USER_LOGIN_FORM` are now rendered correctly (Michael Karamuth)
  * Fix: Icon only button styling issue on small devices where height would not be set correctly (Vu Pham)
+ * Fix: Add padding to the Draftail editor to ensure `ol` items are not cut off (Khanh Hoang)
 
 
 2.15.2 (xx.xx.xxxx) - IN DEVELOPMENT

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -556,6 +556,7 @@ Contributors
 * Md. Fahim Bin Amin
 * Michael Karamuth
 * Vu Pham
+* Khanh Hoang
 
 Translators
 ===========

--- a/client/src/components/Draftail/Draftail.scss
+++ b/client/src/components/Draftail/Draftail.scss
@@ -7,7 +7,7 @@ $draftail-editor-chrome-active: $color-grey-2;
 $draftail-editor-chrome-accent: transparent;
 
 $draftail-editor-border: 0;
-$draftail-editor-padding: 0;
+$draftail-editor-padding: 0.75rem;
 $draftail-editor-background: transparent;
 $draftail-toolbar-radius: 3px;
 $draftail-toolbar-icon-size: 1em;

--- a/docs/releases/2.16.md
+++ b/docs/releases/2.16.md
@@ -31,6 +31,7 @@
  * Pages are refreshed from database on create before passing to hooks. Page aliases get correct `first_published_date` and `last_published_date` (Dan Braghis)
  * Additional login form fields from `WAGTAILADMIN_USER_LOGIN_FORM` are now rendered correctly (Michael Karamuth)
  * Fix icon only button styling issue on small devices where height would not be set correctly (Vu Pham)
+ * Add padding to the Draftail editor to ensure `ol` items are not cut off (Khanh Hoang)
 
 ## Upgrade considerations
 


### PR DESCRIPTION
Fixes #7019:

* No extra tests error caused by the modification
* The code complies with the style guide - make lint ran well
* Tested on Firefox and Chrome on Ubuntu 20.04 and WSL2 Ubuntu 20.04, Docker Desktop on Windows
