### PR TITLE
Add `ever_live()` and `never_live()` filters to `PageQuerySet` (RFC 34) (2 of 3)

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -14,6 +14,8 @@ Changelog
  * Fix: Accessibility fixes for Windows high contrast mode; Dashboard icons colour and contrast (Sakshi Uppoor)
  * Fix: Rename additional 'spin' CSS animations to avoid clashes with other libraries (Kevin Gutiérrez)
  * Add `page_url_path_changed` signal for pages (Andy Babic)
+ * Fix: 'Page move' actions being incorrectly logged as 'Page reorder' under some circumstances (Andy Babic)
+ * Add `ever_live()` and `never_live()` filters to `PageQuerySet` (Andy Babic)
 
 
 2.15.2 (xx.xx.xxxx) - IN DEVELOPMENT

--- a/docs/reference/pages/queryset_reference.rst
+++ b/docs/reference/pages/queryset_reference.rst
@@ -50,6 +50,22 @@ Reference
 
             unpublished_pages = Page.objects.not_live()
 
+    .. automethod:: ever_live
+
+        Example:
+
+        .. code-block:: python
+
+            published_or_once_published_pages = Page.objects.ever_live()
+
+    .. automethod:: never_live
+
+        Example:
+
+        .. code-block:: python
+
+            never_published_pages = Page.objects.never_live()
+
     .. automethod:: in_menu
 
         Example:

--- a/docs/releases/2.16.md
+++ b/docs/releases/2.16.md
@@ -18,12 +18,14 @@
  * Added `alias_of` field to the pages API (Dmitrii Faiazov)
  * Add support for Azure CDN and Front Door front-end cache invalidation (Tomasz Knapik)
  * Add `page_url_path_changed` signal for Pages (Andy Babic)
+ * Add `ever_live()` and `never_live()` filters to `PageQuerySet` (Andy Babic)
 
 
 ### Bug fixes
 
  * Accessibility fixes for Windows high contrast mode; Dashboard icons colour and contrast (Sakshi Uppoor)
  * Rename additional 'spin' CSS animations to avoid clashes with other libraries (Kevin Gutiérrez)
+ * 'Page move' actions being incorrectly logged as 'Page reorder' under some circumstances (Andy Babic)
 
 
 ## Upgrade considerations

--- a/wagtail/core/query.py
+++ b/wagtail/core/query.py
@@ -164,6 +164,23 @@ class PageQuerySet(SearchableQuerySetMixin, TreeQuerySet):
         """
         return self.exclude(self.live_q())
 
+    def ever_live_q(self):
+        return Q(Q(last_published_at__isnull=False) | Q(live=True))
+
+    def ever_live(self):
+        """
+        This filters the QuerySet to only contain pages that have at some
+        point in their history been published.
+        """
+        return self.filter(self.ever_live_q())
+
+    def never_live(self):
+        """
+        This filters the QuerySet to only contain pages that have never
+        been published before (have always been drafts).
+        """
+        return self.exclude(self.ever_live_q())
+
     def in_menu_q(self):
         return Q(show_in_menus=True)
 

--- a/wagtail/core/tests/test_page_queryset.py
+++ b/wagtail/core/tests/test_page_queryset.py
@@ -35,6 +35,28 @@ class TestPageQuerySet(TestCase):
         event = Page.objects.get(url_path='/home/events/someone-elses-event/')
         self.assertTrue(pages.filter(id=event.id).exists())
 
+    def test_ever_live(self):
+        results = Page.objects.ever_live()
+
+        # Check for inclusions:
+        self.assertIn(Page.objects.get(slug="secret-plans", live=True), results)
+        self.assertIn(Page.objects.get(slug="businessy-events", live=False, first_published_at__isnull=True, last_published_at__isnull=False), results)
+
+        # Check for exclusions:
+        self.assertNotIn(Page.objects.get(slug="board-meetings", live=False, last_published_at__isnull=True), results)
+        self.assertNotIn(Page.objects.get(slug="tentative-unpublished-event", live=False, last_published_at__isnull=True), results)
+
+    def test_never_live(self):
+        results = Page.objects.never_live()
+
+        # Check for inclusions:
+        self.assertIn(Page.objects.get(slug="board-meetings", live=False, last_published_at__isnull=True), results)
+        self.assertIn(Page.objects.get(slug="tentative-unpublished-event", live=False, last_published_at__isnull=True), results)
+
+        # Check for exclusions:
+        self.assertNotIn(Page.objects.get(slug="secret-plans", live=True), results)
+        self.assertNotIn(Page.objects.get(slug="businessy-events", live=False, first_published_at__isnull=True, last_published_at__isnull=False), results)
+
     def test_in_menu(self):
         pages = Page.objects.in_menu()
 

--- a/wagtail/tests/testapp/fixtures/test.json
+++ b/wagtail/tests/testapp/fixtures/test.json
@@ -429,7 +429,8 @@
         "path": "0001000100010006",
         "url_path": "/home/events/businessy-events/",
         "slug": "businessy-events",
-        "owner": 2
+        "owner": 2,
+        "last_published_at": "2014-01-31T12:00:00.000Z"
     }
 },
 {


### PR DESCRIPTION
Part of: wagtail/rfcs#34

Dependant on (includes changes from): #7761

A pre-requisite for: #7774

These PageQuerySet methods are added to help identify pages that have 'ever been published' and 'never been published' (based on their history, and not just their current `live` value)