### PR TITLE
Fixes #6618: Modify responsive setting for buttons on mobile

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -21,6 +21,7 @@ Changelog
  * Fix: `default_app_config` deprecations for Django >= 3.2 (Tibor Leupold)
  * Fix: Refresh page from database on create before passing to hooks. Page aliases get correct `first_published_date` and `last_published_date` (Dan Braghis)
  * Fix: Additional login form fields from `WAGTAILADMIN_USER_LOGIN_FORM` are now rendered correctly (Michael Karamuth)
+ * Fix: Icon only button styling issue on small devices where height would not be set correctly (Vu Pham)
 
 
 2.15.2 (xx.xx.xxxx) - IN DEVELOPMENT

--- a/client/scss/components/_button.scss
+++ b/client/scss/components/_button.scss
@@ -406,6 +406,8 @@
 
     &.button-small {
         line-height: 1.7rem;
+        height: 1.8rem;
+        width: 1.8rem;
 
         .icon {
             padding: 0.25em;
@@ -415,11 +417,6 @@
     @include media-breakpoint-up(sm) {
         width: 2.2rem;
         height: 2.2rem;
-
-        &.button-small {
-            height: 1.8rem;
-            width: 1.8rem;
-        }
     }
 }
 

--- a/docs/releases/2.16.md
+++ b/docs/releases/2.16.md
@@ -30,6 +30,7 @@
  * Rename additional 'spin' CSS animations to avoid clashes with other libraries (Kevin Gutiérrez)
  * Pages are refreshed from database on create before passing to hooks. Page aliases get correct `first_published_date` and `last_published_date` (Dan Braghis)
  * Additional login form fields from `WAGTAILADMIN_USER_LOGIN_FORM` are now rendered correctly (Michael Karamuth)
+ * Fix icon only button styling issue on small devices where height would not be set correctly (Vu Pham)
 
 ## Upgrade considerations
 


### PR DESCRIPTION
Fix #6618 

Before, the buttons appear like this on mobile ratio:
![image](https://user-images.githubusercontent.com/46913707/145734709-ddac7d98-f8f5-4f79-930f-d5f7a7ee935a.png)

After the fix, the buttons appear like this:
![image](https://user-images.githubusercontent.com/46913707/145734725-ef2aa257-f0be-49d1-b951-8e486292eb3a.png)

Because the button seems to have an appropriate size even for mobile, so I just scrap the responsive settings for the buttons. Now the buttons will be in the same size for both Mobile and Desktop

* No additional failed test
* The code comply with the style guide
* For front-end changes: Tested on Chrome, using Inspect, with multiple mobile ratio
