### PR TITLE
Improve workflow modal formatting

### DIFF
--- a/wagtail/admin/static_src/wagtailadmin/scss/layouts/page-editor.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/layouts/page-editor.scss
@@ -623,6 +623,7 @@ footer .preview {
 
     .icon {
         fill: $color-grey-3;
+        padding-right: 0.5em;
     }
 
     .in_progress {


### PR DESCRIPTION
This is a little change adding some padding between the tick and the step name in the workflow modal. See images.

## Before:
![Screenshot from 2021-12-15 12-39-33](https://user-images.githubusercontent.com/71412737/146188266-12fa2f29-2dc0-4782-b903-7d672d2f00e2.png)


## After
![Screenshot from 2021-12-15 12-37-38](https://user-images.githubusercontent.com/71412737/146188065-168fb7cb-a9e6-4032-91e8-eb5c4a463581.png)


* For front-end changes: Did you test on all of [Wagtail’s supported environments](https://docs.wagtail.io/en/latest/contributing/developing.html#browser-and-device-support)? No
    * **Please list the exact browser and operating system versions you tested**. Firefox
    * **Please list which assistive technologies you tested**. None
