### PR TITLE
Fix page alias first/`last_published_at` when create through `after_create_page`

### DIFF
--- a/wagtail/admin/views/pages/create.py
+++ b/wagtail/admin/views/pages/create.py
@@ -170,6 +170,9 @@ class CreateView(TemplateResponseMixin, ContextMixin, HookResponseMixin, View):
 
         revision.publish(user=self.request.user)
 
+        # get a fresh copy so that any changes coming from revision.publish() are passed on
+        self.page.refresh_from_db()
+
         response = self.run_hook('after_publish_page', self.request, self.page)
         if response:
             return response


### PR DESCRIPTION
This PR is a fix for a variation of #7373

wagtail-localize provides a feature that keeps locale trees in sync. It accomplishes that by hooking into `after_create_page` and ultimately calls `page.copy_for_translation(locale, copy_parents=True, alias=True)`

When you create and publish a page, the aliases end up with null values for first/last published as the page instance sent to the `after_publish_page` and `after_create_page` is the one the create view is instantiated with. When publishing a page, `revision.publish()` updates the values and saves the page.

Here's a screencast https://youtu.be/uKEKS7CeA5s
