### PR TITLE
Fix: extra_fields now returns BoundField

### DIFF
--- a/wagtail/admin/forms/auth.py
+++ b/wagtail/admin/forms/auth.py
@@ -21,9 +21,9 @@ class LoginForm(AuthenticationForm):
 
     @property
     def extra_fields(self):
-        for field_name, field in self.fields.items():
+        for field_name in self.fields.keys():
             if field_name not in ['username', 'password']:
-                yield field_name, field
+                yield field_name, self[field_name]
 
 
 class PasswordResetForm(DjangoPasswordResetForm):


### PR DESCRIPTION
The `extra_fields` method was returning a `Field` instance but the template requires a `BoundField` for rendering.

When adding extra fields to the `LoginForm` for example, something like `<django.forms.fields.CharField object at XXXX>` will be rendered instead of the `Widget`.