### PR TITLE
Fix: Remove 'gs' characters

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/login.html
+++ b/wagtail/admin/templates/wagtailadmin/login.html
@@ -56,7 +56,7 @@
                     </li>
 
                     {% block extra_fields %}
-                    {% for field_name, field in form.extra_fields %}gs
+                    {% for field_name, field in form.extra_fields %}
                     <li class="full">
                         {{ field.label_tag }}
                         <div class="field iconfield">


### PR DESCRIPTION
For some reason, the characters  *gs* were typed inside the for loop in the `extra_fields` block.

I believe this is a bug unless there's an explanation somewhere that I missed.