### PR TITLE
Fix login form

### DIFF
--- a/wagtail/admin/forms/auth.py
+++ b/wagtail/admin/forms/auth.py
@@ -21,9 +21,9 @@ class LoginForm(AuthenticationForm):
 
     @property
     def extra_fields(self):
-        for field_name, field in self.fields.items():
+        for field_name in self.fields.keys():
             if field_name not in ['username', 'password']:
-                yield field_name, field
+                yield field_name, self[field_name]
 
 
 class PasswordResetForm(DjangoPasswordResetForm):

--- a/wagtail/admin/tests/test_forms.py
+++ b/wagtail/admin/tests/test_forms.py
@@ -14,5 +14,5 @@ class TestLoginForm(TestCase):
     def test_extra_fields(self):
         form = CustomLoginForm()
         self.assertEqual(list(form.extra_fields), [
-            ('captcha', form.fields['captcha'])
+            ('captcha', form['captcha'])
         ])

--- a/wagtail/admin/tests/test_views.py
+++ b/wagtail/admin/tests/test_views.py
@@ -60,3 +60,11 @@ class TestLoginView(TestCase, WagtailTestUtils):
     def test_bidi_language_changes_dir_attribute(self):
         response = self.client.get(reverse('wagtailadmin_login'))
         self.assertContains(response, '<html class="no-js" lang="he" dir="rtl">')
+
+    @override_settings(WAGTAILADMIN_USER_LOGIN_FORM="wagtail.admin.tests.test_forms.CustomLoginForm")
+    def test_login_page_renders_extra_fields(self):
+
+        response = self.client.get(reverse('wagtailadmin_login'))
+        form = response.context['form']
+        expected_widget = str(form['captcha'])
+        self.assertInHTML(expected_widget, str(response.content))


### PR DESCRIPTION
The `extra_fields` property of the LoginForm was returning a Field instance instead of BoundField but the login template expects a BoundField so that the widget can be rendered.

If someone extends the LoginForm to provide extra fields, they will be rendered as so:

`<django.forms.fields.CharField object at XXXX>`

Instead of rendering the widget.