### PR TITLE
feature: Login remember me functionality

### DIFF
--- a/wagtail/admin/forms/auth.py
+++ b/wagtail/admin/forms/auth.py
@@ -14,6 +14,8 @@ class LoginForm(AuthenticationForm):
             'placeholder': gettext_lazy("Enter password"),
         }))
 
+    remember = forms.BooleanField(required=False)
+
     def __init__(self, request=None, *args, **kwargs):
         super().__init__(request=request, *args, **kwargs)
         self.fields['username'].widget.attrs['placeholder'] = (
@@ -22,7 +24,7 @@ class LoginForm(AuthenticationForm):
     @property
     def extra_fields(self):
         for field_name, field in self.fields.items():
-            if field_name not in ['username', 'password']:
+            if field_name not in ['username', 'password', 'remember']:
                 yield field_name, field
 
 

--- a/wagtail/admin/templates/wagtailadmin/login.html
+++ b/wagtail/admin/templates/wagtailadmin/login.html
@@ -66,14 +66,11 @@
                     {% endfor %}
                     {% endblock extra_fields %}
 
-                    {% comment %}
-                        Removed until functionality exists
-                        <li class="checkbox">
-                            <div class="field">
-                                <label><input type="checkbox" />{% trans "Remember me" %}</label>
-                            </div>
-                        </li>
-                    {% endcomment %}
+                    <li class="checkbox">
+                        <div class="field">
+                            <label><input name="remember" type="checkbox" />{% trans "Remember me" %}</label>
+                        </div>
+                    </li>
                     {% endblock %}
 
                     <li class="submit">

--- a/wagtail/admin/tests/test_views.py
+++ b/wagtail/admin/tests/test_views.py
@@ -51,6 +51,22 @@ class TestLoginView(TestCase, WagtailTestUtils):
         response = self.client.get(login_url)
         self.assertRedirects(response, homepage_admin_url)
 
+    def test_session_expire_on_browser_close(self):
+        self.client.post(reverse('wagtailadmin_login'), {
+            'username': 'test@email.com',
+            'password': 'password',
+        })
+        self.assertTrue(self.client.session.get_expire_at_browser_close())
+
+    @override_settings(SESSION_COOKIE_AGE=7)
+    def test_session_expiry_remember(self):
+        self.client.post(reverse('wagtailadmin_login'), {
+            'username': 'test@email.com',
+            'password': 'password',
+            'remember': True
+        })
+        self.assertEqual(self.client.session.get_expiry_age(), 7)
+
     @override_settings(LANGUAGE_CODE='de')
     def test_language_code(self):
         response = self.client.get(reverse('wagtailadmin_login'))

--- a/wagtail/admin/views/account.py
+++ b/wagtail/admin/views/account.py
@@ -2,11 +2,11 @@ from collections import OrderedDict
 
 from django.conf import settings
 from django.contrib import messages
-from django.contrib.auth import update_session_auth_hash
+from django.contrib.auth import update_session_auth_hash, login
 from django.contrib.auth import views as auth_views
 from django.db import transaction
 from django.forms import Media
-from django.http import Http404
+from django.http import Http404, HttpResponseRedirect
 from django.shortcuts import redirect
 from django.template.loader import render_to_string
 from django.template.response import TemplateResponse
@@ -311,6 +311,16 @@ class LoginView(auth_views.LoginView):
 
     def get_form_class(self):
         return get_user_login_form()
+
+    def form_valid(self, form):
+        login(self.request, form.get_user())
+        remember = form.cleaned_data.get('remember')
+        if remember:
+            self.request.session.set_expiry(settings.SESSION_COOKIE_AGE)
+        else:
+            self.request.session.set_expiry(0)
+
+        return HttpResponseRedirect(self.get_success_url())
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)


### PR DESCRIPTION
Allow users logging into the admin to specify whether they want to be remembered or not.

Instead of remembering users all the time, from now on:

- Sessions expire on browser close if *Remember me* checkbox is unchecked.

- Otherwise, they're set to expire after SESSION_COOKIE_AGE.