### PR TITLE
feature: Login remember me functionality

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -17,6 +17,7 @@ Changelog
  * Removed WOFF fonts
  * Add system check for missing core Page fields in `search_fields` (LB (Ben Johnston))
  * Improve CircleCI frontend & backend build caches (Thibaud Colas)
+ * Add a 'remember me' checkbox to the admin sign in form, if unticked (default) the auth session will expire if the browser is closed (Michael Karamuth, Jake Howard)
  * Fix: Accessibility fixes for Windows high contrast mode; Dashboard icons colour and contrast (Sakshi Uppoor)
  * Fix: Rename additional 'spin' CSS animations to avoid clashes with other libraries (Kevin Gutiérrez)
  * Fix: `default_app_config` deprecations for Django >= 3.2 (Tibor Leupold)

--- a/docs/releases/2.16.md
+++ b/docs/releases/2.16.md
@@ -24,6 +24,7 @@
  * Add secondary actions menu in edit page headers (Tidjani Dia)
  * Add system check for missing core Page fields in `search_fields` (LB (Ben Johnston))
  * Improve CircleCI frontend & backend build caches (Thibaud Colas)
+ * Add a 'remember me' checkbox to the admin sign in form, if unticked (default) the auth session will expire if the browser is closed (Michael Karamuth, Jake Howard)
 
 ### Bug fixes
 

--- a/wagtail/admin/forms/auth.py
+++ b/wagtail/admin/forms/auth.py
@@ -14,6 +14,8 @@ class LoginForm(AuthenticationForm):
             'placeholder': gettext_lazy("Enter password"),
         }))
 
+    remember = forms.BooleanField(required=False)
+
     def __init__(self, request=None, *args, **kwargs):
         super().__init__(request=request, *args, **kwargs)
         self.fields['username'].widget.attrs['placeholder'] = (
@@ -21,9 +23,9 @@ class LoginForm(AuthenticationForm):
 
     @property
     def extra_fields(self):
-        for field_name in self.fields.keys():
-            if field_name not in ['username', 'password']:
-                yield field_name, self[field_name]
+        for field_name, field in self.fields.items():
+            if field_name not in ['username', 'password', 'remember']:
+                yield field_name, field
 
 
 class PasswordResetForm(DjangoPasswordResetForm):

--- a/wagtail/admin/templates/wagtailadmin/login.html
+++ b/wagtail/admin/templates/wagtailadmin/login.html
@@ -66,14 +66,11 @@
                     {% endfor %}
                     {% endblock extra_fields %}
 
-                    {% comment %}
-                        Removed until functionality exists
-                        <li class="checkbox">
-                            <div class="field">
-                                <label><input type="checkbox" />{% trans "Remember me" %}</label>
-                            </div>
-                        </li>
-                    {% endcomment %}
+                    <li class="checkbox">
+                        <div class="field">
+                            <label><input name="remember" type="checkbox" />{% trans "Remember me" %}</label>
+                        </div>
+                    </li>
                     {% endblock %}
 
                     <li class="submit">

--- a/wagtail/admin/tests/test_views.py
+++ b/wagtail/admin/tests/test_views.py
@@ -65,3 +65,20 @@ class TestLoginView(TestCase, WagtailTestUtils):
     def test_login_page_renders_extra_fields(self):
         response = self.client.get(reverse('wagtailadmin_login'))
         self.assertContains(response, '<input type="text" name="captcha" required id="id_captcha">')
+
+    def test_session_expire_on_browser_close(self):
+        self.client.post(reverse('wagtailadmin_login'), {
+            'username': 'test@email.com',
+            'password': 'password',
+        })
+        self.assertTrue(self.client.session.get_expire_at_browser_close())
+
+    @override_settings(SESSION_COOKIE_AGE=7)
+    def test_session_expiry_remember(self):
+        self.client.post(reverse('wagtailadmin_login'), {
+            'username': 'test@email.com',
+            'password': 'password',
+            'remember': True
+        })
+        self.assertFalse(self.client.session.get_expire_at_browser_close())
+        self.assertEqual(self.client.session.get_expiry_age(), 7)

--- a/wagtail/admin/views/account.py
+++ b/wagtail/admin/views/account.py
@@ -312,6 +312,17 @@ class LoginView(auth_views.LoginView):
     def get_form_class(self):
         return get_user_login_form()
 
+    def form_valid(self, form):
+        response = super().form_valid(form)
+
+        remember = form.cleaned_data.get('remember')
+        if remember:
+            self.request.session.set_expiry(settings.SESSION_COOKIE_AGE)
+        else:
+            self.request.session.set_expiry(0)
+
+        return response
+
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
 


### PR DESCRIPTION
Allow users logging into the admin to specify whether they want to be remembered or not.

Instead of remembering users all the time, from now on:

- Sessions expire on browser close if *Remember me* checkbox is unchecked.

- Otherwise, they're set to expire after SESSION_COOKIE_AGE.