### PR TITLE
Move page default level

### DIFF
--- a/client/scss/components/_header.scss
+++ b/client/scss/components/_header.scss
@@ -59,6 +59,15 @@ header {
         }
     }
 
+    &.header-with-breadcrumb {
+        padding-top: 0;
+
+        .breadcrumb {
+            margin-bottom: 1rem;
+            padding-left: revert;
+        }
+    }
+
     &.tab-merged,
     &.no-border {
         border: 0;

--- a/wagtail/admin/templates/wagtailadmin/pages/move_choose_destination.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/move_choose_destination.html
@@ -2,13 +2,13 @@
 {% load i18n wagtailadmin_tags %}
 {% block titletag %}{% blocktrans with title=page_to_move.specific_deferred.get_admin_display_title %}Select a new parent page for {{ title }}{% endblocktrans %}{% endblock %}
 {% block content %}
-    <header class="nice-padding">
+    <header class="nice-padding header-with-breadcrumb">
+        {% move_breadcrumb page_to_move viewed_page %}
         <h1>
           {% icon name="doc-empty-inverse" class_name="header-title-icon" %}
           {% blocktrans with title=page_to_move.specific_deferred.get_admin_display_title %}Select a new parent page for <span>{{ title }}</span>{% endblocktrans %}
         </h1>
     </header>
-
     <div class="nice-padding">
         {% include "wagtailadmin/pages/listing/_list_move.html" with pages=child_pages parent_page=viewed_page %}
         {% url 'wagtailadmin_pages:move_choose_destination' page_to_move.id viewed_page.id as pagination_base_url %}

--- a/wagtail/admin/templates/wagtailadmin/shared/move_breadcrumb.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/move_breadcrumb.html
@@ -1,0 +1,14 @@
+{% load i18n wagtailadmin_tags %}
+
+<nav aria-label="{% trans 'Breadcrumb' %}">
+    <ul class="breadcrumb">
+        {% for page in pages %}
+            <li>
+                <a href="{% url 'wagtailadmin_pages:move_choose_destination' page_to_move_id page.id %}">
+                    <span class="title">{{ page.get_admin_display_title }}</span>
+                    {% icon name="arrow-right" class_name="arrow_right_icon" %}
+                </a>
+            </li>
+        {% endfor %}
+    </ul>
+</nav>

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -101,7 +101,7 @@ def move_breadcrumb(context, page_to_move, viewed_page):
         return {'pages': Page.objects.none()}
 
     return {
-        'pages': viewed_page.get_ancestors(inclusive=False).descendant_of(cca).specific(),
+        'pages': viewed_page.get_ancestors(inclusive=True).descendant_of(cca, inclusive=True).specific(),
         'page_to_move_id': page_to_move.id,
     }
 

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -93,6 +93,19 @@ def explorer_breadcrumb(context, page, page_perms=None, include_self=True, trail
     }
 
 
+@register.inclusion_tag('wagtailadmin/shared/move_breadcrumb.html', takes_context=True)
+def move_breadcrumb(context, page_to_move, viewed_page):
+    user = context['request'].user
+    cca = get_explorable_root_page(user)
+    if not cca:
+        return {'pages': Page.objects.none()}
+
+    return {
+        'pages': viewed_page.get_ancestors(inclusive=False).descendant_of(cca).specific(),
+        'page_to_move_id': page_to_move.id,
+    }
+
+
 @register.inclusion_tag('wagtailadmin/shared/search_other.html', takes_context=True)
 def search_other(context, current=None):
     request = context['request']

--- a/wagtail/admin/views/pages/move.py
+++ b/wagtail/admin/views/pages/move.py
@@ -20,7 +20,7 @@ def move_choose_destination(request, page_to_move_id, viewed_page_id=None):
     if viewed_page_id:
         viewed_page = get_object_or_404(Page, id=viewed_page_id)
     else:
-        viewed_page = Page.get_first_root_node()
+        viewed_page = page_to_move.get_parent()
 
     viewed_page.can_choose = page_perms.can_move_to(viewed_page)
 


### PR DESCRIPTION
When moving a page, we must select a destination. Currently, the default destination is the root level. This PR aims to set the default destination level to the parent of the page being moved.

A breadcrumb is added at the top of the page to navigate backwards.

![Screenshot from 2021-12-21 11-26-37](https://user-images.githubusercontent.com/71412737/146922813-caa13c81-57c4-4607-a3a2-d6c1ad73541a.png)

* Do the tests still pass? Yes
* Does the code comply with the style guide? Yes
* For Python changes: Have you added tests to cover the new/fixed behaviour? Yes
* For front-end changes: Did you test on all of [Wagtail’s supported environments]? No
    * **Please list the exact browser and operating system versions you tested**. Firefox
    * **Please list which assistive technologies you tested**.
* For new features: Has the documentation been updated accordingly? No
