### PR TITLE
Redirect to collection listing after editing/deleting an item from it

### DIFF
--- a/wagtail/documents/templates/wagtaildocs/documents/confirm_delete.html
+++ b/wagtail/documents/templates/wagtaildocs/documents/confirm_delete.html
@@ -17,6 +17,7 @@
         <p>{% trans "Are you sure you want to delete this document?" %}</p>
         <form action="{% url 'wagtaildocs:delete' document.id %}" method="POST">
             {% csrf_token %}
+            <input type="hidden" value="{{ next }}" name="next">
             <input type="submit" value='{% trans "Yes, delete" %}' class="button serious" />
             <a href="{% url 'wagtaildocs:index' %}" class="button button-secondary">{% trans "No, don't delete" %}</a>
         </form>

--- a/wagtail/documents/templates/wagtaildocs/documents/edit.html
+++ b/wagtail/documents/templates/wagtaildocs/documents/edit.html
@@ -47,7 +47,7 @@
                     <li>
                         <input type="submit" value="{% trans 'Save' %}" class="button" />
                         {% if user_can_delete %}
-                            <a href="{% url 'wagtaildocs:delete' document.id %}{% if next %}?next={{ next }}{% endif %}" class="button button-secondary no">{% trans "Delete document" %}</a>
+                            <a href="{% url 'wagtaildocs:delete' document.id %}{% if next %}?next={{ next|urlencode }}{% endif %}" class="button button-secondary no">{% trans "Delete document" %}</a>
                         {% endif %}
                     </li>
                 </ul>

--- a/wagtail/documents/templates/wagtaildocs/documents/edit.html
+++ b/wagtail/documents/templates/wagtaildocs/documents/edit.html
@@ -33,6 +33,7 @@
         <div class="col10 divider-after">
             <form action="{% url 'wagtaildocs:edit' document.id %}" method="POST" enctype="multipart/form-data" novalidate>
                 {% csrf_token %}
+                <input type="hidden" value="{{ next }}" name="next">
                 <ul class="fields">
                     {% for field in form %}
                         {% if field.name == 'file' %}

--- a/wagtail/documents/templates/wagtaildocs/documents/edit.html
+++ b/wagtail/documents/templates/wagtaildocs/documents/edit.html
@@ -47,7 +47,7 @@
                     <li>
                         <input type="submit" value="{% trans 'Save' %}" class="button" />
                         {% if user_can_delete %}
-                            <a href="{% url 'wagtaildocs:delete' document.id %}" class="button button-secondary no">{% trans "Delete document" %}</a>
+                            <a href="{% url 'wagtaildocs:delete' document.id %}{% if next %}?next={{ next }}{% endif %}" class="button button-secondary no">{% trans "Delete document" %}</a>
                         {% endif %}
                     </li>
                 </ul>

--- a/wagtail/documents/templates/wagtaildocs/documents/list.html
+++ b/wagtail/documents/templates/wagtaildocs/documents/list.html
@@ -40,7 +40,7 @@
             <tr>
                 {% include "wagtailadmin/bulk_actions/listing_checkbox_cell.html" with obj_type="document" obj=doc aria_labelledby_prefix="document_" aria_labelledby=doc.pk|unlocalize aria_labelledby_suffix="_title" %}
                 <td id="document_{{ doc.pk|unlocalize }}_title" class="title">
-                    <div class="title-wrapper"><a href="{% url 'wagtaildocs:edit' doc.id %}{% if next %}?next={{ next }}{% endif %}">{{ doc.title }}</a></div>
+                    <div class="title-wrapper"><a href="{% url 'wagtaildocs:edit' doc.id %}{% if next %}?next={{ next|urlencode }}{% endif %}">{{ doc.title }}</a></div>
                 </td>
                 <td><a href="{{ doc.url }}" class="nolink" download>{{ doc.filename }}</a></td>
                 {% if collections %}

--- a/wagtail/documents/templates/wagtaildocs/documents/list.html
+++ b/wagtail/documents/templates/wagtaildocs/documents/list.html
@@ -40,7 +40,7 @@
             <tr>
                 {% include "wagtailadmin/bulk_actions/listing_checkbox_cell.html" with obj_type="document" obj=doc aria_labelledby_prefix="document_" aria_labelledby=doc.pk|unlocalize aria_labelledby_suffix="_title" %}
                 <td id="document_{{ doc.pk|unlocalize }}_title" class="title">
-                    <div class="title-wrapper"><a href="{% url 'wagtaildocs:edit' doc.id %}">{{ doc.title }}</a></div>
+                    <div class="title-wrapper"><a href="{% url 'wagtaildocs:edit' doc.id %}{% if next %}?next={{ next }}{% endif %}">{{ doc.title }}</a></div>
                 </td>
                 <td><a href="{{ doc.url }}" class="nolink" download>{{ doc.filename }}</a></td>
                 {% if collections %}

--- a/wagtail/documents/tests/test_admin_views.py
+++ b/wagtail/documents/tests/test_admin_views.py
@@ -1,6 +1,7 @@
 import json
 
 from unittest import mock
+from urllib.parse import quote
 
 from django.contrib.auth.models import Group, Permission
 from django.core.files.uploadedfile import SimpleUploadedFile
@@ -126,8 +127,8 @@ class TestDocumentIndexView(TestCase, WagtailTestUtils):
         self.assertEqual(response.status_code, 200)
 
         edit_url = reverse('wagtaildocs:edit', args=(doc.id,))
-        edit_next_url = reverse('wagtaildocs:index') + "?" + urlencode({"collection_id": evil_plans_collection.id})
-        self.assertContains(response, '%s?next=%s' % (edit_url, edit_next_url))
+        next_url = quote(response._request.get_full_path())
+        self.assertContains(response, '%s?next=%s' % (edit_url, next_url))
 
 
 class TestDocumentAddView(TestCase, WagtailTestUtils):

--- a/wagtail/documents/tests/test_admin_views.py
+++ b/wagtail/documents/tests/test_admin_views.py
@@ -7,6 +7,7 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase
 from django.test.utils import override_settings
 from django.urls import reverse
+from django.utils.http import urlencode
 
 from wagtail.admin.admin_url_finder import AdminURLFinder
 from wagtail.core.models import Collection, GroupCollectionPermission, Page
@@ -21,14 +22,17 @@ class TestDocumentIndexView(TestCase, WagtailTestUtils):
     def setUp(self):
         self.login()
 
+    def get(self, params={}):
+        return self.client.get(reverse('wagtaildocs:index'), params)
+
     def test_simple(self):
-        response = self.client.get(reverse('wagtaildocs:index'))
+        response = self.get()
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, 'wagtaildocs/documents/index.html')
         self.assertContains(response, "Add a document")
 
     def test_search(self):
-        response = self.client.get(reverse('wagtaildocs:index'), {'q': "Hello"})
+        response = self.get({'q': "Hello"})
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context['query_string'], "Hello")
 
@@ -52,7 +56,7 @@ class TestDocumentIndexView(TestCase, WagtailTestUtils):
     def test_pagination_invalid(self):
         self.make_docs()
 
-        response = self.client.get(reverse('wagtaildocs:index'), {'p': 'Hello World!'})
+        response = self.get({'p': 'Hello World!'})
 
         # Check response
         self.assertEqual(response.status_code, 200)
@@ -64,7 +68,7 @@ class TestDocumentIndexView(TestCase, WagtailTestUtils):
     def test_pagination_out_of_range(self):
         self.make_docs()
 
-        response = self.client.get(reverse('wagtaildocs:index'), {'p': 99999})
+        response = self.get({'p': 99999})
 
         # Check response
         self.assertEqual(response.status_code, 200)
@@ -76,13 +80,13 @@ class TestDocumentIndexView(TestCase, WagtailTestUtils):
     def test_ordering(self):
         orderings = ['title', '-created_at']
         for ordering in orderings:
-            response = self.client.get(reverse('wagtaildocs:index'), {'ordering': ordering})
+            response = self.get({'ordering': ordering})
             self.assertEqual(response.status_code, 200)
 
     def test_index_without_collections(self):
         self.make_docs()
 
-        response = self.client.get(reverse('wagtaildocs:index'))
+        response = self.get()
         self.assertNotContains(response, '<th>Collection</th>')
         self.assertNotContains(response, '<td>Root</td>')
 
@@ -93,7 +97,7 @@ class TestDocumentIndexView(TestCase, WagtailTestUtils):
 
         self.make_docs()
 
-        response = self.client.get(reverse('wagtaildocs:index'))
+        response = self.get()
         self.assertContains(response, '<th>Collection</th>')
         self.assertContains(response, '<td>Root</td>')
         self.assertEqual(
@@ -105,9 +109,25 @@ class TestDocumentIndexView(TestCase, WagtailTestUtils):
         evil_plans = root_collection.add_child(name="Evil plans")
         evil_plans.add_child(name="Eviler plans")
 
-        response = self.client.get(reverse('wagtaildocs:index'))
+        response = self.get()
         # "Eviler Plans" should be prefixed with &#x21b3 (↳) and 4 non-breaking spaces.
         self.assertContains(response, '&nbsp;&nbsp;&nbsp;&nbsp;&#x21b3 Eviler plans')
+
+    def test_edit_document_link_contains_next_url(self):
+        root_collection = Collection.get_first_root_node()
+        evil_plans_collection = root_collection.add_child(name="Evil plans")
+
+        doc = models.Document.objects.create(
+            title="Test doc",
+            collection=evil_plans_collection
+        )
+
+        response = self.get({'collection_id': evil_plans_collection.id})
+        self.assertEqual(response.status_code, 200)
+
+        edit_url = reverse('wagtaildocs:edit', args=(doc.id,))
+        edit_next_url = reverse('wagtaildocs:index') + "?" + urlencode({"collection_id": evil_plans_collection.id})
+        self.assertContains(response, '%s?next=%s' % (edit_url, edit_next_url))
 
 
 class TestDocumentAddView(TestCase, WagtailTestUtils):
@@ -380,6 +400,27 @@ class TestDocumentEditView(TestCase, WagtailTestUtils):
         # "Eviler Plans" should be prefixed with &#x21b3 (↳) and 4 non-breaking spaces.
         self.assertContains(response, '&nbsp;&nbsp;&nbsp;&nbsp;&#x21b3 Eviler plans')
 
+    def test_next_url_is_present_in_edit_form(self):
+        root_collection = Collection.get_first_root_node()
+        evil_plans_collection = root_collection.add_child(name="Evil plans")
+        doc = models.Document.objects.create(
+            title="Test doc",
+            file=get_test_document_file(),
+            collection=evil_plans_collection
+        )
+        expected_next_url = (
+            reverse('wagtaildocs:index')
+            + "?"
+            + urlencode({"collection_id": evil_plans_collection.id})
+        )
+
+        response = self.client.get(
+            reverse('wagtaildocs:edit', args=(doc.id,)),
+            {"next": expected_next_url}
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, f'<input type="hidden" value="{expected_next_url}" name="next">')
+
     def test_post(self):
         # Build a fake file
         fake_file = get_test_document_file()
@@ -396,6 +437,33 @@ class TestDocumentEditView(TestCase, WagtailTestUtils):
 
         # Document title should be changed
         self.assertEqual(models.Document.objects.get(id=self.document.id).title, "Test document changed!")
+
+    def test_edit_with_next_url(self):
+        root_collection = Collection.get_first_root_node()
+        evil_plans_collection = root_collection.add_child(name="Evil plans")
+        doc = models.Document.objects.create(
+            title="Test doc",
+            file=get_test_document_file(),
+            collection=evil_plans_collection
+        )
+        expected_next_url = (
+            reverse('wagtaildocs:index')
+            + "?"
+            + urlencode({"collection_id": evil_plans_collection.id})
+        )
+
+        response = self.client.post(
+            reverse('wagtaildocs:edit', args=(doc.id,)),
+            {
+                "title": "Edited",
+                "collection": evil_plans_collection.id,
+                "next": expected_next_url,
+            }
+        )
+        self.assertRedirects(response, expected_next_url)
+
+        doc.refresh_from_db()
+        self.assertEqual(doc.title, "Edited")
 
     def test_with_missing_source_file(self):
         # Build a fake file

--- a/wagtail/documents/views/documents.py
+++ b/wagtail/documents/views/documents.py
@@ -232,13 +232,16 @@ def delete(request, document_id):
     if not permission_policy.user_has_permission_for_instance(request.user, 'delete', doc):
         raise PermissionDenied
 
+    next_url = get_valid_next_url_from_request(request)
+
     if request.method == 'POST':
         doc.delete()
         messages.success(request, _("Document '{0}' deleted.").format(doc.title))
-        return redirect('wagtaildocs:index')
+        return redirect(next_url) if next_url else redirect('wagtaildocs:index')
 
     return TemplateResponse(request, "wagtaildocs/documents/confirm_delete.html", {
         'document': doc,
+        'next': next_url,
     })
 
 

--- a/wagtail/documents/views/documents.py
+++ b/wagtail/documents/views/documents.py
@@ -47,13 +47,11 @@ class BaseListingView(TemplateView):
 
         # Filter by collection
         self.current_collection = None
-        next_url = None
         collection_id = self.request.GET.get('collection_id')
         if collection_id:
             try:
                 self.current_collection = Collection.objects.get(id=collection_id)
                 documents = documents.filter(collection=self.current_collection)
-                next_url = reverse('wagtaildocs:index') + "?" + urlencode({"collection_id": collection_id})
             except (ValueError, Collection.DoesNotExist):
                 pass
 
@@ -76,7 +74,7 @@ class BaseListingView(TemplateView):
             'documents': documents,
             'query_string': query_string,
             'is_searching': bool(query_string),
-            'next': next_url,
+            'next': self.request.get_full_path(),
         })
         return context
 

--- a/wagtail/documents/views/documents.py
+++ b/wagtail/documents/views/documents.py
@@ -186,7 +186,7 @@ def edit(request, document_id):
             edit_url = reverse('wagtaildocs:edit', args=(doc.id,))
             redirect_url = 'wagtaildocs:index'
             if next_url:
-                edit_url += "?" + urlencode({"next": next_url})
+                edit_url = f"{edit_url}?{urlencode({'next': next_url})}"
                 redirect_url = next_url
 
             messages.success(request, _("Document '{0}' updated").format(doc.title), buttons=[

--- a/wagtail/images/templates/wagtailimages/images/confirm_delete.html
+++ b/wagtail/images/templates/wagtailimages/images/confirm_delete.html
@@ -20,6 +20,7 @@
             <p>{% trans "Are you sure you want to delete this image?" %}</p>
             <form action="{% url 'wagtailimages:delete' image.id %}" method="POST">
                 {% csrf_token %}
+                <input type="hidden" value="{{ next }}" name="next">
                 <input type="submit" value="{% trans 'Yes, delete' %}" class="button serious" />
                 <a href="{% url 'wagtailimages:index' %}" class="button button-secondary">{% trans "No, don't delete" %}</a>
             </form>

--- a/wagtail/images/templates/wagtailimages/images/edit.html
+++ b/wagtail/images/templates/wagtailimages/images/edit.html
@@ -55,7 +55,7 @@
                 <div class="u-hidden@xs">
                     <input type="submit" value="{% trans 'Save' %}" class="button" />
                     {% if user_can_delete %}
-                        <a href="{% url 'wagtailimages:delete' image.id %}{% if next %}?next={{ next }}{% endif %}" class="button button-secondary no">{% trans "Delete image" %}</a>
+                        <a href="{% url 'wagtailimages:delete' image.id %}{% if next %}?next={{ next|urlencode }}{% endif %}" class="button button-secondary no">{% trans "Delete image" %}</a>
                     {% endif %}
                 </div>
             </div>

--- a/wagtail/images/templates/wagtailimages/images/edit.html
+++ b/wagtail/images/templates/wagtailimages/images/edit.html
@@ -55,7 +55,7 @@
                 <div class="u-hidden@xs">
                     <input type="submit" value="{% trans 'Save' %}" class="button" />
                     {% if user_can_delete %}
-                        <a href="{% url 'wagtailimages:delete' image.id %}" class="button button-secondary no">{% trans "Delete image" %}</a>
+                        <a href="{% url 'wagtailimages:delete' image.id %}{% if next %}?next={{ next }}{% endif %}" class="button button-secondary no">{% trans "Delete image" %}</a>
                     {% endif %}
                 </div>
             </div>
@@ -112,7 +112,7 @@
             <div class="col5">
                 <input type="submit" value="{% trans 'Save' %}" class="button" />
                 {% if user_can_delete %}
-                    <a href="{% url 'wagtailimages:delete' image.id %}" class="button button-secondary no">{% trans "Delete image" %}</a>
+                    <a href="{% url 'wagtailimages:delete' image.id %}{% if next %}?next={{ next }}{% endif %}" class="button button-secondary no">{% trans "Delete image" %}</a>
                 {% endif %}
             </div>
         </div>

--- a/wagtail/images/templates/wagtailimages/images/edit.html
+++ b/wagtail/images/templates/wagtailimages/images/edit.html
@@ -38,6 +38,7 @@
 
     <form action="{% url 'wagtailimages:edit' image.id %}" method="POST" enctype="multipart/form-data" novalidate>
         {% csrf_token %}
+        <input type="hidden" value="{{ next }}" name="next">
         <div class="row row-flush nice-padding">
             <div class="col6">
                 <ul class="fields">

--- a/wagtail/images/templates/wagtailimages/images/results.html
+++ b/wagtail/images/templates/wagtailimages/images/results.html
@@ -22,7 +22,7 @@
         {% for image in images %}
             <li>
                 {% include "wagtailadmin/bulk_actions/listing_checkbox_cell.html" with obj_type="image" obj=image aria_labelledby_prefix="select-image-label image_" aria_labelledby=image.pk|unlocalize aria_labelledby_suffix="_title" %}
-                <a class="image-choice" title="{% if collections %}{{ image.collection.name }} » {% endif %}{{ image.title }}" href="{% url 'wagtailimages:edit' image.id %}{% if next %}?next={{ next }}{% endif %}">
+                <a class="image-choice" title="{% if collections %}{{ image.collection.name }} » {% endif %}{{ image.title }}" href="{% url 'wagtailimages:edit' image.id %}{% if next %}?next={{ next|urlencode }}{% endif %}">
                     <figure>
                         {% include "wagtailimages/images/results_image.html" %}
                         {% trans "pixels" as translated_pixels %}

--- a/wagtail/images/templates/wagtailimages/images/results.html
+++ b/wagtail/images/templates/wagtailimages/images/results.html
@@ -22,7 +22,7 @@
         {% for image in images %}
             <li>
                 {% include "wagtailadmin/bulk_actions/listing_checkbox_cell.html" with obj_type="image" obj=image aria_labelledby_prefix="select-image-label image_" aria_labelledby=image.pk|unlocalize aria_labelledby_suffix="_title" %}
-                <a class="image-choice" title="{% if collections %}{{ image.collection.name }} » {% endif %}{{ image.title }}" href="{% url 'wagtailimages:edit' image.id %}">
+                <a class="image-choice" title="{% if collections %}{{ image.collection.name }} » {% endif %}{{ image.title }}" href="{% url 'wagtailimages:edit' image.id %}{% if next %}?next={{ next }}{% endif %}">
                     <figure>
                         {% include "wagtailimages/images/results_image.html" %}
                         {% trans "pixels" as translated_pixels %}

--- a/wagtail/images/tests/test_admin_views.py
+++ b/wagtail/images/tests/test_admin_views.py
@@ -8,7 +8,7 @@ from django.test import RequestFactory, TestCase, override_settings
 from django.urls import reverse
 from django.utils.encoding import force_str
 from django.utils.html import escapejs
-from django.utils.http import RFC3986_SUBDELIMS, urlquote
+from django.utils.http import RFC3986_SUBDELIMS, urlencode, urlquote
 from django.utils.safestring import mark_safe
 
 from wagtail.admin.admin_url_finder import AdminURLFinder
@@ -101,6 +101,23 @@ class TestImageIndexView(TestCase, WagtailTestUtils):
         response = self.get()
         # "Eviler Plans" should be prefixed with &#x21b3 (↳) and 4 non-breaking spaces.
         self.assertContains(response, '&nbsp;&nbsp;&nbsp;&nbsp;&#x21b3 Eviler plans')
+
+    def test_edit_image_link_contains_next_url(self):
+        root_collection = Collection.get_first_root_node()
+        evil_plans_collection = root_collection.add_child(name="Evil plans")
+
+        image = Image.objects.create(
+            title="Test image",
+            file=get_test_image_file(size=(1, 1)),
+            collection=evil_plans_collection
+        )
+
+        response = self.get({'collection_id': evil_plans_collection.id})
+        self.assertEqual(response.status_code, 200)
+
+        edit_url = reverse('wagtailimages:edit', args=(image.id,))
+        edit_next_url = reverse('wagtailimages:index') + "?" + urlencode({"collection_id": evil_plans_collection.id})
+        self.assertContains(response, '%s?next=%s' % (edit_url, edit_next_url))
 
     def test_tags(self):
         image_two_tags = Image.objects.create(
@@ -493,6 +510,20 @@ class TestImageEditView(TestCase, WagtailTestUtils):
         # "Eviler Plans" should be prefixed with &#x21b3 (↳) and 4 non-breaking spaces.
         self.assertContains(response, '&nbsp;&nbsp;&nbsp;&nbsp;&#x21b3 Eviler plans')
 
+    def test_next_url_is_present_in_edit_form(self):
+        root_collection = Collection.get_first_root_node()
+        evil_plans_collection = root_collection.add_child(name="Evil plans")
+        image = Image.objects.create(
+            title="Test image",
+            file=get_test_image_file(size=(1, 1)),
+            collection=evil_plans_collection
+        )
+        expected_next_url = reverse('wagtailimages:index') + "?" + urlencode({"collection_id": evil_plans_collection.id})
+
+        response = self.client.get(reverse('wagtailimages:edit', args=(image.id,)), {"next": expected_next_url})
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, f'<input type="hidden" value="{expected_next_url}" name="next">')
+
     @override_settings(WAGTAIL_USAGE_COUNT_ENABLED=True)
     def test_with_usage_count(self):
         response = self.get()
@@ -529,6 +560,33 @@ class TestImageEditView(TestCase, WagtailTestUtils):
         url_finder = AdminURLFinder(self.user)
         expected_url = '/admin/images/%d/' % self.image.id
         self.assertEqual(url_finder.get_edit_url(self.image), expected_url)
+
+    def test_edit_with_next_url(self):
+        root_collection = Collection.get_first_root_node()
+        evil_plans_collection = root_collection.add_child(name="Evil plans")
+        image = Image.objects.create(
+            title="Test image",
+            file=get_test_image_file(size=(1, 1)),
+            collection=evil_plans_collection
+        )
+        expected_next_url = (
+            reverse('wagtailimages:index')
+            + "?"
+            + urlencode({"collection_id": evil_plans_collection.id})
+        )
+
+        response = self.client.post(
+            reverse('wagtailimages:edit', args=(image.id,)),
+            {
+                "title": "Edited",
+                "collection": evil_plans_collection.id,
+                "next": expected_next_url,
+            }
+        )
+        self.assertRedirects(response, expected_next_url)
+
+        image.refresh_from_db()
+        self.assertEqual(image.title, "Edited")
 
     def test_edit_with_limited_permissions(self):
         self.user.is_superuser = False

--- a/wagtail/images/tests/test_admin_views.py
+++ b/wagtail/images/tests/test_admin_views.py
@@ -1,5 +1,7 @@
 import json
 
+from urllib.parse import quote
+
 from django.contrib.auth.models import Group, Permission
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.template.defaultfilters import filesizeformat
@@ -116,8 +118,8 @@ class TestImageIndexView(TestCase, WagtailTestUtils):
         self.assertEqual(response.status_code, 200)
 
         edit_url = reverse('wagtailimages:edit', args=(image.id,))
-        edit_next_url = reverse('wagtailimages:index') + "?" + urlencode({"collection_id": evil_plans_collection.id})
-        self.assertContains(response, '%s?next=%s' % (edit_url, edit_next_url))
+        next_url = quote(response._request.get_full_path())
+        self.assertContains(response, '%s?next=%s' % (edit_url, next_url))
 
     def test_tags(self):
         image_two_tags = Image.objects.create(

--- a/wagtail/images/views/images.py
+++ b/wagtail/images/views/images.py
@@ -284,13 +284,16 @@ def delete(request, image_id):
     if not permission_policy.user_has_permission_for_instance(request.user, 'delete', image):
         raise PermissionDenied
 
+    next_url = get_valid_next_url_from_request(request)
+
     if request.method == 'POST':
         image.delete()
         messages.success(request, _("Image '{0}' deleted.").format(image.title))
-        return redirect('wagtailimages:index')
+        return redirect(next_url) if next_url else redirect('wagtailimages:index')
 
     return TemplateResponse(request, "wagtailimages/images/confirm_delete.html", {
         'image': image,
+        'next': next_url,
     })
 
 

--- a/wagtail/images/views/images.py
+++ b/wagtail/images/views/images.py
@@ -162,7 +162,7 @@ def edit(request, image_id):
             edit_url = reverse('wagtailimages:edit', args=(image.id,))
             redirect_url = 'wagtailimages:index'
             if next_url:
-                edit_url += "?" + urlencode({"next": next_url})
+                edit_url = f"{edit_url}?{urlencode({'next': next_url})}"
                 redirect_url = next_url
 
             messages.success(request, _("Image '{0}' updated.").format(image.title), buttons=[

--- a/wagtail/images/views/images.py
+++ b/wagtail/images/views/images.py
@@ -9,6 +9,7 @@ from django.template.response import TemplateResponse
 from django.urls import reverse
 from django.urls.exceptions import NoReverseMatch
 from django.utils.decorators import method_decorator
+from django.utils.http import urlencode
 from django.utils.translation import gettext as _
 from django.views.generic import TemplateView
 
@@ -16,6 +17,7 @@ from wagtail.admin import messages
 from wagtail.admin.auth import PermissionPolicyChecker
 from wagtail.admin.forms.search import SearchForm
 from wagtail.admin.models import popular_tags_for_model
+from wagtail.admin.views.pages.utils import get_valid_next_url_from_request
 from wagtail.core.models import Collection, Site
 from wagtail.images import get_image_model
 from wagtail.images.exceptions import InvalidFilterSpecError
@@ -58,11 +60,13 @@ class BaseListingView(TemplateView):
 
         # Filter by collection
         self.current_collection = None
+        next_url = None
         collection_id = self.request.GET.get('collection_id')
         if collection_id:
             try:
                 self.current_collection = Collection.objects.get(id=collection_id)
                 images = images.filter(collection=self.current_collection)
+                next_url = reverse('wagtailimages:index') + "?" + urlencode({"collection_id": collection_id})
             except (ValueError, Collection.DoesNotExist):
                 pass
 
@@ -81,6 +85,7 @@ class BaseListingView(TemplateView):
             'images': images,
             'query_string': query_string,
             'is_searching': bool(query_string),
+            'next': next_url,
         })
 
         return context
@@ -127,6 +132,8 @@ def edit(request, image_id):
     if not permission_policy.user_has_permission_for_instance(request.user, 'change', image):
         raise PermissionDenied
 
+    next_url = get_valid_next_url_from_request(request)
+
     if request.method == 'POST':
         original_file = image.file
         form = ImageForm(request.POST, request.FILES, instance=image, user=request.user)
@@ -152,10 +159,16 @@ def edit(request, image_id):
             # Reindex the image to make sure all tags are indexed
             search_index.insert_or_update_object(image)
 
+            edit_url = reverse('wagtailimages:edit', args=(image.id,))
+            redirect_url = 'wagtailimages:index'
+            if next_url:
+                edit_url += "?" + urlencode({"next": next_url})
+                redirect_url = next_url
+
             messages.success(request, _("Image '{0}' updated.").format(image.title), buttons=[
-                messages.button(reverse('wagtailimages:edit', args=(image.id,)), _('Edit again'))
+                messages.button(edit_url, _('Edit again'))
             ])
-            return redirect('wagtailimages:index')
+            return redirect(redirect_url)
         else:
             messages.error(request, _("The image could not be saved due to errors."))
     else:
@@ -190,6 +203,7 @@ def edit(request, image_id):
         'user_can_delete': permission_policy.user_has_permission_for_instance(
             request.user, 'delete', image
         ),
+        'next': next_url,
     })
 
 

--- a/wagtail/images/views/images.py
+++ b/wagtail/images/views/images.py
@@ -60,13 +60,11 @@ class BaseListingView(TemplateView):
 
         # Filter by collection
         self.current_collection = None
-        next_url = None
         collection_id = self.request.GET.get('collection_id')
         if collection_id:
             try:
                 self.current_collection = Collection.objects.get(id=collection_id)
                 images = images.filter(collection=self.current_collection)
-                next_url = reverse('wagtailimages:index') + "?" + urlencode({"collection_id": collection_id})
             except (ValueError, Collection.DoesNotExist):
                 pass
 
@@ -85,7 +83,7 @@ class BaseListingView(TemplateView):
             'images': images,
             'query_string': query_string,
             'is_searching': bool(query_string),
-            'next': next_url,
+            'next': self.request.get_full_path(),
         })
 
         return context


### PR DESCRIPTION
When a user selects a collection to browse in the admin and opens a file to make some changes to it, on save, the admin browser defaults back to a default view of documents/images instead of staying on the collection and the page of the collection the users was on when they clicked on the file to make changes.

The goal of this PR is to make the view remember the collection users were exploring before editing one item from that collection.

* Do the tests still pass? Yes
* Does the code comply with the style guide? Yes
* For Python changes: Have you added tests to cover the new/fixed behaviour? Yes
* For new features: Has the documentation been updated accordingly? No
