### PR TITLE
Detect duplicates when uploading an image

### DIFF
--- a/client/scss/components/_messages.status.scss
+++ b/client/scss/components/_messages.status.scss
@@ -3,6 +3,10 @@
         color: $color-green-dark;
     }
 
+    &.duplicate {
+        color: $color-orange;
+    }
+
     &.failure {
         color: $color-red-dark;
     }

--- a/wagtail/images/static_src/wagtailimages/js/add-multiple.js
+++ b/wagtail/images/static_src/wagtailimages/js/add-multiple.js
@@ -131,7 +131,11 @@ $(function() {
             var response = JSON.parse(data.result);
 
             if (response.success) {
-                itemElement.addClass('upload-success')
+                if (response.duplicate) {
+                    itemElement.addClass('upload-duplicate')
+                } else {
+                    itemElement.addClass('upload-success')
+                }
 
                 $('.right', itemElement).append(response.form);
             } else {

--- a/wagtail/images/static_src/wagtailimages/scss/add-multiple.scss
+++ b/wagtail/images/static_src/wagtailimages/scss/add-multiple.scss
@@ -124,6 +124,12 @@
         }
     }
 
+    .upload-duplicate {
+        .status-msg.duplicate {
+            display: block;
+        }
+    }
+
     .upload-failure {
         border-color: $color-red;
 

--- a/wagtail/images/templates/wagtailimages/multiple/add.html
+++ b/wagtail/images/templates/wagtailimages/multiple/add.html
@@ -69,6 +69,7 @@
             </div>
             <div class="right col9">
                 <p class="status-msg success">{% trans "Upload successful. Please update this image with a more appropriate title, if necessary. You may also delete the image completely if the upload wasn't required." %}</p>
+                <p class="status-msg duplicate">{% trans "Upload successful. However, this image seems to be a duplicate. You may delete it completely if the upload wasn't required." %}</p>
                 <p class="status-msg failure">{% trans "Sorry, upload failed." %}</p>
                 <p class="status-msg server-error">
                     <strong>{% trans "Server Error" %}</strong>

--- a/wagtail/images/views/multiple.py
+++ b/wagtail/images/views/multiple.py
@@ -40,6 +40,11 @@ class AddView(BaseAddView):
     def get_edit_form_class(self):
         return get_image_multi_form(self.model)
 
+    def get_edit_object_response_data(self):
+        data = super().get_edit_object_response_data()
+        data["duplicate"] = self.is_duplicate
+        return data
+
     def save_object(self, form):
         image = form.save(commit=False)
         image.uploaded_by_user = self.request.user
@@ -47,6 +52,9 @@ class AddView(BaseAddView):
         image.file.seek(0)
         image._set_file_hash(image.file.read())
         image.file.seek(0)
+        self.is_duplicate = (
+            self.get_model().objects.filter(file_hash=image.file_hash).exists()
+        )
         image.save()
         return image
 


### PR DESCRIPTION
The goal of this PR is to detect duplicates when uploading an image.

For now, we just detect exact file duplicates. More sophisticated duplicates finding techniques are planned for the future.

When a duplicate is detected, a message is shown to indicate it (See images below).

**Upload single image view**

![Screenshot from 2022-01-04 11-37-11](https://user-images.githubusercontent.com/71412737/148053608-5a640653-b46c-44de-8b45-1bf6219b0c6f.png)

**Upload multiples images view**

![Screenshot from 2022-01-04 11-05-00](https://user-images.githubusercontent.com/71412737/148050132-66e372ba-5133-44df-a0a4-9bf60e52ccc8.png)



* Do the tests still pass? Yes
* Does the code comply with the style guide? Yes
* For Python changes: Have you added tests to cover the new/fixed behaviour? Yes
* For front-end changes: Did you test on all of [Wagtail’s supported environments]? No
    * **Please list the exact browser and operating system versions you tested**. Firefox
    * **Please list which assistive technologies you tested**. None
* For new features: Has the documentation been updated accordingly? No