### PR TITLE
Ensure bulk publish action picks up latest revisions

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/pages/bulk_actions/confirm_bulk_delete.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/bulk_actions/confirm_bulk_delete.html
@@ -14,7 +14,7 @@
         <ul>
             {% for page in items %}
             <li>
-                <a href="{% url 'wagtailadmin_pages:edit' page.item.id %}" target="_blank" rel="noopener noreferrer">{{page.item.title }}</a>
+                <a href="{% url 'wagtailadmin_pages:edit' page.item.id %}" target="_blank" rel="noopener noreferrer">{{ page.item.get_admin_display_title }}</a>
                 {% if page.descendant_count %}
                 <p>
                     {% blocktrans count counter=page.descendant_count %}

--- a/wagtail/admin/templates/wagtailadmin/pages/bulk_actions/confirm_bulk_move.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/bulk_actions/confirm_bulk_move.html
@@ -15,7 +15,7 @@
         <ul>
             {% for page in items %}
             <li>
-                <a href="{% url 'wagtailadmin_pages:edit' page.item.id %}" target="_blank" rel="noopener noreferrer">{{ page.item.title }}</a>
+                <a href="{% url 'wagtailadmin_pages:edit' page.item.id %}" target="_blank" rel="noopener noreferrer">{{ page.item.get_admin_display_title }}</a>
                 {% if not page.item.is_leaf %}
                 <p>
                     {% blocktrans count counter=page.child_pages %}

--- a/wagtail/admin/templates/wagtailadmin/pages/bulk_actions/confirm_bulk_publish.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/bulk_actions/confirm_bulk_publish.html
@@ -14,7 +14,7 @@
     <ul>
         {% for page in items %}
         <li>
-            <a href="{% url 'wagtailadmin_pages:edit' page.item.id %}" target="_blank" rel="noopener noreferrer">{{ page.item.title }}</a>
+            <a href="{% url 'wagtailadmin_pages:edit' page.item.id %}" target="_blank" rel="noopener noreferrer">{{ page.item.get_admin_display_title }}</a>
             {% if page.draft_descendant_count %}
             <p>
                 {% blocktrans count counter=page.draft_descendant_count %}

--- a/wagtail/admin/templates/wagtailadmin/pages/bulk_actions/confirm_bulk_unpublish.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/bulk_actions/confirm_bulk_unpublish.html
@@ -14,7 +14,7 @@
     <ul>
         {% for page in items %}
         <li>
-            <a href="{% url 'wagtailadmin_pages:edit' page.item.id %}" target="_blank" rel="noopener noreferrer">{{ page.item.title }}</a>
+            <a href="{% url 'wagtailadmin_pages:edit' page.item.id %}" target="_blank" rel="noopener noreferrer">{{ page.item.get_admin_display_title }}</a>
             <p>
                 {% if page.live_descendant_count %}
                     {% blocktrans count counter=page.live_descendant_count %}

--- a/wagtail/admin/templates/wagtailadmin/pages/bulk_actions/list_items_with_no_access.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/bulk_actions/list_items_with_no_access.html
@@ -3,8 +3,8 @@
 
 {% block per_item %}
 {% if item.can_edit %}
-    <a href="{% url 'wagtailadmin_pages:edit' item.item.id %}" target="_blank" rel="noopener noreferrer">{{ item.item.title }}</a>
+    <a href="{% url 'wagtailadmin_pages:edit' item.item.id %}" target="_blank" rel="noopener noreferrer">{{ item.item.get_admin_display_title }}</a>
 {% else %}
-    {{ item.item.title }}
+    {{ item.item.get_admin_display_title }}
 {% endif %}
 {% endblock per_item %}

--- a/wagtail/admin/tests/pages/test_bulk_actions/test_bulk_move.py
+++ b/wagtail/admin/tests/pages/test_bulk_actions/test_bulk_move.py
@@ -71,11 +71,9 @@ class TestBulkMove(TestCase, WagtailTestUtils):
 
         self.assertInHTML('<p>Are you sure you want to move these pages?</p>', html)
 
-        for child_page in self.pages_to_be_moved:
-            self.assertInHTML('<li><a href="{edit_page_url}" target="_blank" rel="noopener noreferrer">{page_title}</a></li>'.format(
-                edit_page_url=reverse('wagtailadmin_pages:edit', args=[child_page.id]),
-                page_title=child_page.title
-            ), html)
+        self.assertInHTML('<li><a href="{edit_page_url}" target="_blank" rel="noopener noreferrer">Hello world! (simple page)</a></li>'.format(
+            edit_page_url=reverse('wagtailadmin_pages:edit', args=[self.test_page_b.id]),
+        ), html)
 
     def test_bulk_move_bad_permissions(self):
         # Remove privileges from user

--- a/wagtail/admin/tests/pages/test_bulk_actions/test_bulk_publish.py
+++ b/wagtail/admin/tests/pages/test_bulk_actions/test_bulk_publish.py
@@ -50,6 +50,9 @@ class TestBulkPublish(TestCase, WagtailTestUtils):
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, 'wagtailadmin/pages/bulk_actions/confirm_bulk_publish.html')
 
+        # Page titles shown on the confirmation page should use SimplePage's custom get_admin_display_title method
+        self.assertContains(response, "Hello world!-1 (simple page)")
+
     def test_publish_view_invalid_page_id(self):
         """
         This tests that the publish view returns an error if the page id is invalid

--- a/wagtail/admin/views/pages/bulk_actions/page_bulk_action.py
+++ b/wagtail/admin/views/pages/bulk_actions/page_bulk_action.py
@@ -28,6 +28,12 @@ class PageBulkAction(BulkAction):
 
         return listing_objects
 
+    def object_context(self, obj):
+        context = super().object_context(obj)
+        # Make 'item' into the specific instance, so that custom get_admin_display_title methods are respected
+        context['item'] = context['item'].specific_deferred
+        return context
+
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context['items_with_no_access'] = [

--- a/wagtail/admin/views/pages/bulk_actions/publish.py
+++ b/wagtail/admin/views/pages/bulk_actions/publish.py
@@ -34,16 +34,13 @@ class PublishBulkAction(PageBulkAction):
     def execute_action(cls, objects, include_descendants=False, user=None, **kwargs):
         num_parent_objects, num_child_objects = 0, 0
         for page in objects:
-            page = page.specific
-            revision = page.save_revision(user=user)
-            revision.publish(user=user)
+            page.get_latest_revision().publish(user=user)
             num_parent_objects += 1
 
             if include_descendants:
                 for draft_descendant_page in page.get_descendants().not_live().defer_streamfields().specific():
                     if user is None or draft_descendant_page.permissions_for_user(user).can_publish():
-                        revision = draft_descendant_page.save_revision(user=user)
-                        revision.publish(user=user)
+                        draft_descendant_page.get_latest_revision().publish(user=user)
                         num_child_objects += 1
         return num_parent_objects, num_child_objects
 


### PR DESCRIPTION
Fixes #7690.

Also tweak the confirmation pages to show the draft title (via `get_admin_display_title`), to match the rest of the admin (because failing to do that looks particularly wrong when confirming the publish action).