### PR TITLE
Automatically fetch specific page when an overridden method is called

### DIFF
--- a/wagtail/admin/navigation.py
+++ b/wagtail/admin/navigation.py
@@ -33,7 +33,7 @@ def get_explorable_root_page(user):
 def get_site_for_user(user):
     root_page = get_explorable_root_page(user)
     if root_page:
-        root_site = root_page.get_site()
+        root_site = root_page.specific_deferred.get_site()
     else:
         root_site = None
     real_site_name = None

--- a/wagtail/admin/templates/wagtailadmin/home/locked_pages.html
+++ b/wagtail/admin/templates/wagtailadmin/home/locked_pages.html
@@ -21,7 +21,7 @@
                     <tr>
                         <td class="title" valign="top">
                             <div class="title-wrapper">
-                                <a href="{% url 'wagtailadmin_pages:edit' page.id %}" title="{% trans 'Edit this page' %}">{{ page.get_admin_display_title }}</a>
+                                <a href="{% url 'wagtailadmin_pages:edit' page.id %}" title="{% trans 'Edit this page' %}">{{ page.specific_deferred.get_admin_display_title }}</a>
                                 {% include "wagtailadmin/pages/listing/_privacy_indicator.html" with page=page %}
                                 {% include "wagtailadmin/pages/listing/_locked_indicator.html" with page=page %}
                             </div>

--- a/wagtail/admin/templates/wagtailadmin/notifications/approved.html
+++ b/wagtail/admin/templates/wagtailadmin/notifications/approved.html
@@ -3,5 +3,5 @@
 
 {% block content %}
     <p>{% blocktrans with title=revision.page.specific_deferred.get_admin_display_title|safe %}The page "{{ title }}" has been approved.{% endblocktrans %}</p>
-    <p>{% trans "You can view the page here:" %} <a href="{{ revision.page.full_url }}">{{ revision.page.full_url }}</a></p>
+    <p>{% trans "You can view the page here:" %} <a href="{{ revision.page.specific_deferred.full_url }}">{{ revision.page.specific_deferred.full_url }}</a></p>
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/approved.html
+++ b/wagtail/admin/templates/wagtailadmin/notifications/approved.html
@@ -2,6 +2,6 @@
 {% load i18n %}
 
 {% block content %}
-    <p>{% blocktrans with title=revision.page.get_admin_display_title|safe %}The page "{{ title }}" has been approved.{% endblocktrans %}</p>
+    <p>{% blocktrans with title=revision.page.specific_deferred.get_admin_display_title|safe %}The page "{{ title }}" has been approved.{% endblocktrans %}</p>
     <p>{% trans "You can view the page here:" %} <a href="{{ revision.page.full_url }}">{{ revision.page.full_url }}</a></p>
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/approved.txt
+++ b/wagtail/admin/templates/wagtailadmin/notifications/approved.txt
@@ -2,7 +2,7 @@
 {% load i18n %}
 
 {% block content %}
-{% blocktrans with title=revision.page.get_admin_display_title|safe %}The page "{{ title }}" has been approved.{% endblocktrans %}
+{% blocktrans with title=revision.page.specific_deferred.get_admin_display_title|safe %}The page "{{ title }}" has been approved.{% endblocktrans %}
 
 {% trans "You can view the page here:" %} {{ revision.page.specific_deferred.full_url }}
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/approved.txt
+++ b/wagtail/admin/templates/wagtailadmin/notifications/approved.txt
@@ -4,5 +4,5 @@
 {% block content %}
 {% blocktrans with title=revision.page.get_admin_display_title|safe %}The page "{{ title }}" has been approved.{% endblocktrans %}
 
-{% trans "You can view the page here:" %} {{ revision.page.full_url }}
+{% trans "You can view the page here:" %} {{ revision.page.specific_deferred.full_url }}
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/approved_subject.txt
+++ b/wagtail/admin/templates/wagtailadmin/notifications/approved_subject.txt
@@ -1,3 +1,3 @@
 {% load i18n %}
 
-{% blocktrans with title=revision.page.get_admin_display_title|safe %}The page "{{ title }}" has been approved{% endblocktrans %}
+{% blocktrans with title=revision.page.specific_deferred.get_admin_display_title|safe %}The page "{{ title }}" has been approved{% endblocktrans %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/rejected.html
+++ b/wagtail/admin/templates/wagtailadmin/notifications/rejected.html
@@ -2,6 +2,6 @@
 {% load i18n %}
 
 {% block content %}
-    <p>{% blocktrans with title=revision.page.get_admin_display_title|safe %}The page "{{ title }}" has been rejected.{% endblocktrans %}</p>
+    <p>{% blocktrans with title=revision.page.specific_deferred.get_admin_display_title|safe %}The page "{{ title }}" has been rejected.{% endblocktrans %}</p>
     <p>{% trans "You can edit the page here:"%} <a href="{{ settings.BASE_URL }}{% url 'wagtailadmin_pages:edit' revision.page.id %}">{{ settings.BASE_URL }}{% url 'wagtailadmin_pages:edit' revision.page.id %}</a></p>
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/rejected.txt
+++ b/wagtail/admin/templates/wagtailadmin/notifications/rejected.txt
@@ -2,7 +2,7 @@
 {% load i18n %}
 
 {% block content %}
-{% blocktrans with title=revision.page.get_admin_display_title|safe %}The page "{{ title }}" has been rejected.{% endblocktrans %}
+{% blocktrans with title=revision.page.specific_deferred.get_admin_display_title|safe %}The page "{{ title }}" has been rejected.{% endblocktrans %}
 
 {% trans "You can edit the page here:"%} {{ settings.BASE_URL }}{% url 'wagtailadmin_pages:edit' revision.page.id %}
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/rejected_subject.txt
+++ b/wagtail/admin/templates/wagtailadmin/notifications/rejected_subject.txt
@@ -1,3 +1,3 @@
 {% load i18n %}
 
-{% blocktrans with title=revision.page.get_admin_display_title|safe %}The page "{{ title }}" has been rejected{% endblocktrans %}
+{% blocktrans with title=revision.page.specific_deferred.get_admin_display_title|safe %}The page "{{ title }}" has been rejected{% endblocktrans %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/submitted.html
+++ b/wagtail/admin/templates/wagtailadmin/notifications/submitted.html
@@ -3,7 +3,7 @@
 {% load wagtailadmin_tags i18n %}
 
 {% block content %}
-    <p>{% blocktrans with page=revision.page|safe editor=revision.user|user_display_name %}The page "{{ page }}" has been submitted for moderation by {{ editor }}.{% endblocktrans %}</p>
+    <p>{% blocktrans with page=revision.page.specific_deferred.get_admin_display_title|safe editor=revision.user|user_display_name %}The page "{{ page }}" has been submitted for moderation by {{ editor }}.{% endblocktrans %}</p>
 
     <p>
         {% if revision.page.is_previewable %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/submitted.txt
+++ b/wagtail/admin/templates/wagtailadmin/notifications/submitted.txt
@@ -2,7 +2,7 @@
 {% load wagtailadmin_tags i18n %}
 
 {% block content %}
-{% blocktrans with page=revision.page|safe editor=revision.user|user_display_name %}The page "{{ page }}" has been submitted for moderation by {{ editor }}.{% endblocktrans %}
+{% blocktrans with page=revision.page.specific_deferred.get_admin_display_title|safe editor=revision.user|user_display_name %}The page "{{ page }}" has been submitted for moderation by {{ editor }}.{% endblocktrans %}
 
 {% if revision.page.is_previewable %}{% trans "You can preview the page here:" %} {{ settings.BASE_URL }}{% url 'wagtailadmin_pages:preview_for_moderation' revision.id %}{% endif %}
 {% trans "You can edit the page here:" %} {{ settings.BASE_URL }}{% url 'wagtailadmin_pages:edit' revision.page.id %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/submitted_subject.txt
+++ b/wagtail/admin/templates/wagtailadmin/notifications/submitted_subject.txt
@@ -1,3 +1,3 @@
 {% load i18n %}
 
-{% blocktrans with page=revision.page|safe %}The page "{{ page }}" has been submitted for moderation{% endblocktrans %}
+{% blocktrans with page=revision.page.specific_deferred.get_admin_display_title|safe %}The page "{{ page }}" has been submitted for moderation{% endblocktrans %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/task_state_approved.html
+++ b/wagtail/admin/templates/wagtailadmin/notifications/task_state_approved.html
@@ -2,6 +2,6 @@
 {% load i18n %}
 
 {% block content %}
-    <p>{% blocktrans with title=page.get_admin_display_title task=task.name %}The page "{{ title }}" has been approved in moderation stage "{{ task }}".{% endblocktrans %}</p>
+    <p>{% blocktrans with title=page.specific_deferred.get_admin_display_title task=task.name %}The page "{{ title }}" has been approved in moderation stage "{{ task }}".{% endblocktrans %}</p>
     <p>{% trans "You can edit the page here:"%} <a href="{{ settings.BASE_URL }}{% url 'wagtailadmin_pages:edit' page.id %}">{{ settings.BASE_URL }}{% url 'wagtailadmin_pages:edit' page.id %}</a></p>
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/task_state_approved.txt
+++ b/wagtail/admin/templates/wagtailadmin/notifications/task_state_approved.txt
@@ -2,6 +2,6 @@
 {% load i18n %}
 
 {% block content %}
-{% blocktrans with title=page.get_admin_display_title|safe task=task.name|safe %}The page "{{ title }}" has been approved in moderation stage "{{ task }}".{% endblocktrans %}
+{% blocktrans with title=page.specific_deferred.get_admin_display_title|safe task=task.name|safe %}The page "{{ title }}" has been approved in moderation stage "{{ task }}".{% endblocktrans %}
 {% trans "You can edit the page here:"%} {{ settings.BASE_URL }}{% url 'wagtailadmin_pages:edit' page.id %}
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/task_state_approved_subject.txt
+++ b/wagtail/admin/templates/wagtailadmin/notifications/task_state_approved_subject.txt
@@ -1,3 +1,3 @@
 {% load i18n %}
 
-{% blocktrans with title=page.get_admin_display_title|safe task=task.name|safe %}The page "{{ title }}" has been approved in "{{ task }}".{% endblocktrans %}
+{% blocktrans with title=page.specific_deferred.get_admin_display_title|safe task=task.name|safe %}The page "{{ title }}" has been approved in "{{ task }}".{% endblocktrans %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/task_state_rejected.html
+++ b/wagtail/admin/templates/wagtailadmin/notifications/task_state_rejected.html
@@ -2,6 +2,6 @@
 {% load i18n %}
 
 {% block content %}
-    <p>{% blocktrans with title=page.get_admin_display_title task=task.name %}The page "{{ title }}" has been rejected in moderation stage "{{ task }}".{% endblocktrans %}</p>
+    <p>{% blocktrans with title=page.specific_deferred.get_admin_display_title task=task.name %}The page "{{ title }}" has been rejected in moderation stage "{{ task }}".{% endblocktrans %}</p>
     <p>{% trans "You can edit the page here:"%} <a href="{{ settings.BASE_URL }}{% url 'wagtailadmin_pages:edit' page.id %}">{{ settings.BASE_URL }}{% url 'wagtailadmin_pages:edit' page.id %}</a></p>
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/task_state_rejected.txt
+++ b/wagtail/admin/templates/wagtailadmin/notifications/task_state_rejected.txt
@@ -2,6 +2,6 @@
 {% load i18n %}
 
 {% block content %}
-{% blocktrans with title=page.get_admin_display_title|safe task=task.name|safe %}The page "{{ title }}" has been rejected in moderation stage "{{ task }}".{% endblocktrans %}
+{% blocktrans with title=page.specific_deferred.get_admin_display_title|safe task=task.name|safe %}The page "{{ title }}" has been rejected in moderation stage "{{ task }}".{% endblocktrans %}
 {% trans "You can edit the page here:"%} {{ settings.BASE_URL }}{% url 'wagtailadmin_pages:edit' page.id %}
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/task_state_rejected_subject.txt
+++ b/wagtail/admin/templates/wagtailadmin/notifications/task_state_rejected_subject.txt
@@ -1,3 +1,3 @@
 {% load i18n %}
 
-{% blocktrans with title=page.get_admin_display_title|safe task=task.name|safe %}The page "{{ title }}" has been rejected during "{{ task }}".{% endblocktrans %}
+{% blocktrans with title=page.specific_deferred.get_admin_display_title|safe task=task.name|safe %}The page "{{ title }}" has been rejected during "{{ task }}".{% endblocktrans %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/task_state_submitted.html
+++ b/wagtail/admin/templates/wagtailadmin/notifications/task_state_submitted.html
@@ -3,7 +3,7 @@
 {% load i18n %}
 
 {% block content %}
-    <p>{% blocktrans with task=task.name title=page.get_admin_display_title %}The page "{{ title }}" has been submitted for approval in moderation stage "{{ task }}".{% endblocktrans %}</p>
+    <p>{% blocktrans with task=task.name title=page.specific_deferred.get_admin_display_title %}The page "{{ title }}" has been submitted for approval in moderation stage "{{ task }}".{% endblocktrans %}</p>
 
     <p>
         {% trans "You can preview the page here:" %} <a href="{{ settings.BASE_URL }}{% url 'wagtailadmin_pages:workflow_preview' page.id task.id %}">{{ settings.BASE_URL }}{% url 'wagtailadmin_pages:workflow_preview' page.id task.id %}</a><br/>

--- a/wagtail/admin/templates/wagtailadmin/notifications/task_state_submitted.txt
+++ b/wagtail/admin/templates/wagtailadmin/notifications/task_state_submitted.txt
@@ -3,7 +3,7 @@
 {% load i18n %}
 
 {% block content %}
-{% blocktrans with task=task.name|safe title=page.get_admin_display_title|safe %}The page "{{ title }}" has been submitted for approval to moderation stage "{{ task }}".{% endblocktrans %}
+{% blocktrans with task=task.name|safe title=page.specific_deferred.get_admin_display_title|safe %}The page "{{ title }}" has been submitted for approval to moderation stage "{{ task }}".{% endblocktrans %}
 
 
 {% trans "You can preview the page here:" %} {{ settings.BASE_URL }}{% url 'wagtailadmin_pages:workflow_preview' page.id task.id %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/task_state_submitted_subject.txt
+++ b/wagtail/admin/templates/wagtailadmin/notifications/task_state_submitted_subject.txt
@@ -1,3 +1,3 @@
 {% load i18n %}
 
-{% blocktrans with title=page.get_admin_display_title|safe task=task.name|safe %}The page "{{ title }}" has been submitted for approval in moderation stage "{{ task }}" {% endblocktrans %}
+{% blocktrans with title=page.specific_deferred.get_admin_display_title|safe task=task.name|safe %}The page "{{ title }}" has been submitted for approval in moderation stage "{{ task }}" {% endblocktrans %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/updated_comments.html
+++ b/wagtail/admin/templates/wagtailadmin/notifications/updated_comments.html
@@ -3,7 +3,7 @@
 
 {% block content %}
     <p>
-        {% blocktrans with title=page.get_admin_display_title editor=editor|user_display_name %}{{ editor }} has updated comments on "{{ title }}".{% endblocktrans %}
+        {% blocktrans with title=page.specific_deferred.get_admin_display_title editor=editor|user_display_name %}{{ editor }} has updated comments on "{{ title }}".{% endblocktrans %}
     </p>
 
     {% if new_comments %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/updated_comments.txt
+++ b/wagtail/admin/templates/wagtailadmin/notifications/updated_comments.txt
@@ -1,7 +1,7 @@
 {% extends 'wagtailadmin/notifications/base.txt' %}
 {% load i18n wagtailadmin_tags %}
 
-{% block content %}{% blocktrans with title=page.get_admin_display_title|safe editor=editor|user_display_name|safe %}{{ editor }} has updated comments on "{{ title }}".{% endblocktrans %}
+{% block content %}{% blocktrans with title=page.specific_deferred.get_admin_display_title|safe editor=editor|user_display_name|safe %}{{ editor }} has updated comments on "{{ title }}".{% endblocktrans %}
 {% spaceless %}
 
 {% endspaceless %}{% if new_comments %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/updated_comments_subject.txt
+++ b/wagtail/admin/templates/wagtailadmin/notifications/updated_comments_subject.txt
@@ -1,3 +1,3 @@
 {% load i18n wagtailadmin_tags %}
 
-{% blocktrans with title=page.get_admin_display_title|safe editor=editor|user_display_name|safe %}{{ editor }} has updated comments on "{{ title }}"{% endblocktrans %}
+{% blocktrans with title=page.specific_deferred.get_admin_display_title|safe editor=editor|user_display_name|safe %}{{ editor }} has updated comments on "{{ title }}"{% endblocktrans %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/workflow_state_approved.html
+++ b/wagtail/admin/templates/wagtailadmin/notifications/workflow_state_approved.html
@@ -3,5 +3,5 @@
 
 {% block content %}
     <p>{% blocktrans with title=page.get_admin_display_title workflow=workflow.name %}The page "{{ title }}" has been approved in workflow "{{ workflow }}".{% endblocktrans %}</p>
-    <p>{% trans "You can view the page here:" %} <a href="{{ page.full_url }}">{{ page.full_url }}</a></p>
+    <p>{% trans "You can view the page here:" %} <a href="{{ page.specific_deferred.full_url }}">{{ page.specific_deferred.full_url }}</a></p>
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/workflow_state_approved.html
+++ b/wagtail/admin/templates/wagtailadmin/notifications/workflow_state_approved.html
@@ -2,6 +2,6 @@
 {% load i18n %}
 
 {% block content %}
-    <p>{% blocktrans with title=page.get_admin_display_title workflow=workflow.name %}The page "{{ title }}" has been approved in workflow "{{ workflow }}".{% endblocktrans %}</p>
+    <p>{% blocktrans with title=page.specific_deferred.get_admin_display_title workflow=workflow.name %}The page "{{ title }}" has been approved in workflow "{{ workflow }}".{% endblocktrans %}</p>
     <p>{% trans "You can view the page here:" %} <a href="{{ page.specific_deferred.full_url }}">{{ page.specific_deferred.full_url }}</a></p>
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/workflow_state_approved.txt
+++ b/wagtail/admin/templates/wagtailadmin/notifications/workflow_state_approved.txt
@@ -3,5 +3,5 @@
 
 {% block content %}
 {% blocktrans with title=page.get_admin_display_title|safe workflow=workflow.name|safe %}The page "{{ title }}" has been approved in workflow "{{ workflow }}".{% endblocktrans %}
-{% trans "You can view the page here:" %} {{ page.full_url }}
+{% trans "You can view the page here:" %} {{ page.specific_deferred.full_url }}
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/workflow_state_approved.txt
+++ b/wagtail/admin/templates/wagtailadmin/notifications/workflow_state_approved.txt
@@ -2,6 +2,6 @@
 {% load i18n %}
 
 {% block content %}
-{% blocktrans with title=page.get_admin_display_title|safe workflow=workflow.name|safe %}The page "{{ title }}" has been approved in workflow "{{ workflow }}".{% endblocktrans %}
+{% blocktrans with title=page.specific_deferred.get_admin_display_title|safe workflow=workflow.name|safe %}The page "{{ title }}" has been approved in workflow "{{ workflow }}".{% endblocktrans %}
 {% trans "You can view the page here:" %} {{ page.specific_deferred.full_url }}
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/workflow_state_approved_subject.txt
+++ b/wagtail/admin/templates/wagtailadmin/notifications/workflow_state_approved_subject.txt
@@ -1,3 +1,3 @@
 {% load i18n %}
 
-{% blocktrans with title=page.get_admin_display_title|safe workflow=workflow.name|safe %}The page "{{ title }}" has been approved in "{{ workflow }}".{% endblocktrans %}
+{% blocktrans with title=page.specific_deferred.get_admin_display_title|safe workflow=workflow.name|safe %}The page "{{ title }}" has been approved in "{{ workflow }}".{% endblocktrans %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/workflow_state_rejected.html
+++ b/wagtail/admin/templates/wagtailadmin/notifications/workflow_state_rejected.html
@@ -3,9 +3,9 @@
 
 {% block content %}
     {% if task_state.finished_by %}
-        <p>{% blocktrans with title=page.get_admin_display_title workflow=workflow.name task=task.name rejector=task_state.finished_by|user_display_name %}The page "{{ title }}" has been rejected during "{{ task }}" in workflow "{{ workflow }}" by {{ rejector }}.{% endblocktrans %}</p>
+        <p>{% blocktrans with title=page.specific_deferred.get_admin_display_title workflow=workflow.name task=task.name rejector=task_state.finished_by|user_display_name %}The page "{{ title }}" has been rejected during "{{ task }}" in workflow "{{ workflow }}" by {{ rejector }}.{% endblocktrans %}</p>
     {% else %}
-        <p>{% blocktrans with title=page.get_admin_display_title workflow=workflow.name task=task.name %}The page "{{ title }}" has been rejected during "{{ task }}" in workflow "{{ workflow }}".{% endblocktrans %}</p>
+        <p>{% blocktrans with title=page.specific_deferred.get_admin_display_title workflow=workflow.name task=task.name %}The page "{{ title }}" has been rejected during "{{ task }}" in workflow "{{ workflow }}".{% endblocktrans %}</p>
     {% endif %}
     {% if comment %}
         <p>{% blocktrans %}The following comment was left: "{{ comment }}"{% endblocktrans %}</p>

--- a/wagtail/admin/templates/wagtailadmin/notifications/workflow_state_rejected.txt
+++ b/wagtail/admin/templates/wagtailadmin/notifications/workflow_state_rejected.txt
@@ -3,9 +3,9 @@
 
 {% block content %}
 {% if task_state.finished_by %}
-    {% blocktrans with title=page.get_admin_display_title|safe workflow=workflow.name|safe task=task.name|safe rejector=task_state.finished_by|user_display_name %}The page "{{ title }}" has been rejected during "{{ task }}" in workflow "{{ workflow }}" by {{ rejector }}.{% endblocktrans %}
+    {% blocktrans with title=page.specific_deferred.get_admin_display_title|safe workflow=workflow.name|safe task=task.name|safe rejector=task_state.finished_by|user_display_name %}The page "{{ title }}" has been rejected during "{{ task }}" in workflow "{{ workflow }}" by {{ rejector }}.{% endblocktrans %}
 {% else %}
-    {% blocktrans with title=page.get_admin_display_title|safe workflow=workflow.name|safe task=task.name|safe %}The page "{{ title }}" has been rejected during "{{ task }}" in workflow "{{ workflow }}".{% endblocktrans %}
+    {% blocktrans with title=page.specific_deferred.get_admin_display_title|safe workflow=workflow.name|safe task=task.name|safe %}The page "{{ title }}" has been rejected during "{{ task }}" in workflow "{{ workflow }}".{% endblocktrans %}
 {% endif %}
 {% if comment %}
     {% blocktrans with comment=comment|safe %}The following comment was left: "{{ comment }}"{% endblocktrans %}</p>

--- a/wagtail/admin/templates/wagtailadmin/notifications/workflow_state_rejected_subject.txt
+++ b/wagtail/admin/templates/wagtailadmin/notifications/workflow_state_rejected_subject.txt
@@ -1,3 +1,3 @@
 {% load i18n %}
 
-{% blocktrans with title=page.get_admin_display_title|safe workflow=workflow.name|safe %}The page "{{ title }}" has been rejected during "{{ workflow }}".{% endblocktrans %}
+{% blocktrans with title=page.specific_deferred.get_admin_display_title|safe workflow=workflow.name|safe %}The page "{{ title }}" has been rejected during "{{ workflow }}".{% endblocktrans %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/workflow_state_submitted.html
+++ b/wagtail/admin/templates/wagtailadmin/notifications/workflow_state_submitted.html
@@ -4,9 +4,9 @@
 
 {% block content %}
     {% if requested_by %}
-        <p>{% blocktrans with workflow=workflow.name title=page.get_admin_display_title requester=requested_by|user_display_name %}The page "{{ title }}" has been submitted for moderation to workflow "{{ workflow }}" by {{ requester }}.{% endblocktrans %}</p>
+        <p>{% blocktrans with workflow=workflow.name title=page.specific_deferred.get_admin_display_title requester=requested_by|user_display_name %}The page "{{ title }}" has been submitted for moderation to workflow "{{ workflow }}" by {{ requester }}.{% endblocktrans %}</p>
     {% else %}
-        <p>{% blocktrans with workflow=workflow.name title=page.get_admin_display_title %}The page "{{ title }}" has been submitted for moderation to workflow "{{ workflow }}".{% endblocktrans %}</p>
+        <p>{% blocktrans with workflow=workflow.name title=page.specific_deferred.get_admin_display_title %}The page "{{ title }}" has been submitted for moderation to workflow "{{ workflow }}".{% endblocktrans %}</p>
     {% endif %}
 
     <p>

--- a/wagtail/admin/templates/wagtailadmin/notifications/workflow_state_submitted.txt
+++ b/wagtail/admin/templates/wagtailadmin/notifications/workflow_state_submitted.txt
@@ -3,8 +3,8 @@
 {% load wagtailadmin_tags i18n %}
 
 {% block content %}
-{% if requested_by %}{% blocktrans with workflow=workflow.name|safe title=page.get_admin_display_title|safe requester=requested_by|user_display_name|safe %}The page "{{ title }}" has been submitted for moderation to workflow "{{ workflow }}" by {{ requester }}.{% endblocktrans %}
-{% else %}{% blocktrans with workflow=workflow.name|safe title=page.get_admin_display_title|safe %}The page "{{ title }}" has been submitted for moderation to workflow "{{ workflow }}".{% endblocktrans %}
+{% if requested_by %}{% blocktrans with workflow=workflow.name|safe title=page.specific_deferred.get_admin_display_title|safe requester=requested_by|user_display_name|safe %}The page "{{ title }}" has been submitted for moderation to workflow "{{ workflow }}" by {{ requester }}.{% endblocktrans %}
+{% else %}{% blocktrans with workflow=workflow.name|safe title=page.specific_deferred.get_admin_display_title|safe %}The page "{{ title }}" has been submitted for moderation to workflow "{{ workflow }}".{% endblocktrans %}
 {% endif %}
 
 {% trans "You can edit the page here:" %} {{ settings.BASE_URL }}{% url 'wagtailadmin_pages:edit' page.id %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/workflow_state_submitted_subject.txt
+++ b/wagtail/admin/templates/wagtailadmin/notifications/workflow_state_submitted_subject.txt
@@ -1,3 +1,3 @@
 {% load i18n %}
 
-{% blocktrans with title=page.get_admin_display_title|safe workflow=workflow.name|safe %}The page "{{ title }}" has been submitted to workflow "{{ workflow }}" {% endblocktrans %}
+{% blocktrans with title=page.specific_deferred.get_admin_display_title|safe workflow=workflow.name|safe %}The page "{{ title }}" has been submitted to workflow "{{ workflow }}" {% endblocktrans %}

--- a/wagtail/admin/templates/wagtailadmin/reports/aging_pages.html
+++ b/wagtail/admin/templates/wagtailadmin/reports/aging_pages.html
@@ -30,7 +30,7 @@
                             </a>
                         </td>
                         <td class="status" valign="top">
-                            {% include "wagtailadmin/shared/page_status_tag.html" with page=page %}
+                            {% include "wagtailadmin/shared/page_status_tag.html" with page=page.specific_deferred %}
                         </td>
                         <td class="updated" valign="top">
                             <div class="human-readable-date" title="{{ page.last_published_at|date:'DATETIME_FORMAT' }}">

--- a/wagtail/admin/tests/pages/test_moderation.py
+++ b/wagtail/admin/tests/pages/test_moderation.py
@@ -239,7 +239,7 @@ class TestNotificationPreferences(TestCase, WagtailTestUtils):
         # Submitter must receive an approved email
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(mail.outbox[0].to, ['submitter@email.com'])
-        self.assertEqual(mail.outbox[0].subject, 'The page "Hello world!" has been approved')
+        self.assertEqual(mail.outbox[0].subject, 'The page "Hello world! (simple page)" has been approved')
 
     def test_approved_notifications_preferences_respected(self):
         # Submitter doesn't want 'approved' emails
@@ -263,7 +263,7 @@ class TestNotificationPreferences(TestCase, WagtailTestUtils):
         # Submitter must receive a rejected email
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(mail.outbox[0].to, ['submitter@email.com'])
-        self.assertEqual(mail.outbox[0].subject, 'The page "Hello world!" has been rejected')
+        self.assertEqual(mail.outbox[0].subject, 'The page "Hello world! (simple page)" has been rejected')
 
     def test_rejected_notification_preferences_respected(self):
         # Submitter doesn't want 'rejected' emails

--- a/wagtail/admin/views/pages/moderation.py
+++ b/wagtail/admin/views/pages/moderation.py
@@ -23,8 +23,8 @@ def approve_moderation(request, revision_id):
 
         message = _("Page '{0}' published.").format(revision.page.specific_deferred.get_admin_display_title())
         buttons = []
-        if revision.page.url is not None:
-            buttons.append(messages.button(revision.page.url, _('View live'), new_window=False))
+        if revision.page.specific_deferred.url is not None:
+            buttons.append(messages.button(revision.page.specific_deferred.url, _('View live'), new_window=False))
         buttons.append(messages.button(reverse('wagtailadmin_pages:edit', args=(revision.page.id,)), _('Edit')))
         messages.success(request, message, buttons=buttons)
 

--- a/wagtail/api/v2/serializers.py
+++ b/wagtail/api/v2/serializers.py
@@ -59,7 +59,7 @@ class PageHtmlUrlField(Field):
 
     def to_representation(self, page):
         try:
-            return page.full_url
+            return page.specific_deferred.full_url
         except NoReverseMatch:
             return None
 

--- a/wagtail/contrib/redirects/models.py
+++ b/wagtail/contrib/redirects/models.py
@@ -38,7 +38,7 @@ class Redirect(models.Model):
     @property
     def link(self):
         if self.redirect_page:
-            return self.redirect_page.url
+            return self.redirect_page.specific_deferred.url
         elif self.redirect_link:
             return self.redirect_link
 

--- a/wagtail/core/models/__init__.py
+++ b/wagtail/core/models/__init__.py
@@ -812,6 +812,7 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
 
         return localized
 
+    @overridable
     def route(self, request, path_components):
         if path_components:
             # request is for a child of this page
@@ -1092,6 +1093,7 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
 
     context_object_name = None
 
+    @overridable
     def get_context(self, request, *args, **kwargs):
         context = {
             PAGE_TEMPLATE_VAR: self,
@@ -1104,12 +1106,14 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
 
         return context
 
+    @overridable
     def get_template(self, request, *args, **kwargs):
         if request.headers.get('x-requested-with') == 'XMLHttpRequest':
             return self.ajax_template or self.template
         else:
             return self.template
 
+    @overridable
     def serve(self, request, *args, **kwargs):
         request.is_preview = getattr(request, 'is_preview', False)
 

--- a/wagtail/core/models/__init__.py
+++ b/wagtail/core/models/__init__.py
@@ -1422,6 +1422,7 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
 
         return can_create
 
+    @overridable
     def can_move_to(self, parent):
         """
         Checks if this page instance can be moved to be a subpage of a parent

--- a/wagtail/core/models/__init__.py
+++ b/wagtail/core/models/__init__.py
@@ -1145,6 +1145,7 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
             cache_object._wagtail_cached_site_root_paths = Site.get_site_root_paths()
             return cache_object._wagtail_cached_site_root_paths
 
+    @overridable
     def get_url_parts(self, request=None):
         """
         Determine the URL for this page and return it as a tuple of

--- a/wagtail/core/models/__init__.py
+++ b/wagtail/core/models/__init__.py
@@ -833,6 +833,7 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
             else:
                 raise Http404
 
+    @overridable
     def get_admin_display_title(self):
         """
         Return the title for this page as it should appear in the admin backend;

--- a/wagtail/core/templatetags/wagtailcore_tags.py
+++ b/wagtail/core/templatetags/wagtailcore_tags.py
@@ -32,17 +32,17 @@ def pageurl(context, page, fallback=None):
         current_site = site
     except KeyError:
         # request not available in the current context; fall back on page.url
-        return page.url
+        return page.specific_deferred.url
 
     if current_site is None:
         # request does not correspond to a recognised site; fall back on page.url
-        return page.url
+        return page.specific_deferred.url
 
     # Pass page.relative_url the request object, which may contain a cached copy of
     # Site.get_site_root_paths()
     # This avoids page.relative_url having to make a database/cache fetch for this list
     # each time it's called.
-    return page.relative_url(current_site, request=context.get('request'))
+    return page.specific_deferred.relative_url(current_site, request=context.get('request'))
 
 
 @register.simple_tag(takes_context=True)

--- a/wagtail/core/tests/test_page_model.py
+++ b/wagtail/core/tests/test_page_model.py
@@ -245,7 +245,7 @@ class TestRouting(TestCase):
     def test_urls(self):
         default_site = Site.objects.get(is_default_site=True)
         homepage = Page.objects.get(url_path='/home/')
-        christmas_page = Page.objects.get(url_path='/home/events/christmas/')
+        christmas_page = Page.objects.get(url_path='/home/events/christmas/').specific
 
         # Basic installation only has one site configured, so page.url will return local URLs
         self.assertEqual(
@@ -288,7 +288,7 @@ class TestRouting(TestCase):
 
         default_site = Site.objects.get(is_default_site=True)
         homepage = Page.objects.get(url_path='/home/')
-        christmas_page = Page.objects.get(url_path='/home/events/christmas/')
+        christmas_page = Page.objects.get(url_path='/home/events/christmas/').specific
 
         # with multiple sites, page.url will return full URLs to ensure that
         # they work across sites
@@ -333,7 +333,7 @@ class TestRouting(TestCase):
     def test_urls_with_non_root_urlconf(self):
         default_site = Site.objects.get(is_default_site=True)
         homepage = Page.objects.get(url_path='/home/')
-        christmas_page = Page.objects.get(url_path='/home/events/christmas/')
+        christmas_page = Page.objects.get(url_path='/home/events/christmas/').specific
 
         # Basic installation only has one site configured, so page.url will return local URLs
         self.assertEqual(
@@ -451,7 +451,7 @@ class TestRoutingWithI18N(TestRouting):
     def test_urls(self, expected_language_code='en'):
         default_site = Site.objects.get(is_default_site=True)
         homepage = Page.objects.get(url_path='/home/')
-        christmas_page = Page.objects.get(url_path='/home/events/christmas/')
+        christmas_page = Page.objects.get(url_path='/home/events/christmas/').specific
 
         # Basic installation only has one site configured, so page.url will return local URLs
         # self.assertEqual(
@@ -508,11 +508,11 @@ class TestRoutingWithI18N(TestRouting):
     def test_urls_with_different_language_tree(self):
         default_site = Site.objects.get(is_default_site=True)
         homepage = Page.objects.get(url_path='/home/')
-        christmas_page = Page.objects.get(url_path='/home/events/christmas/')
+        christmas_page = Page.objects.get(url_path='/home/events/christmas/').specific
 
         fr_locale = Locale.objects.create(language_code="fr")
-        fr_homepage = homepage.copy_for_translation(fr_locale)
-        fr_christmas_page = christmas_page.copy_for_translation(fr_locale, copy_parents=True)
+        fr_homepage = homepage.copy_for_translation(fr_locale).specific
+        fr_christmas_page = christmas_page.copy_for_translation(fr_locale, copy_parents=True).specific
         fr_christmas_page.slug = 'noel'
         fr_christmas_page.save(update_fields=['slug'])
 
@@ -547,7 +547,7 @@ class TestRoutingWithI18N(TestRouting):
 
         default_site = Site.objects.get(is_default_site=True)
         homepage = Page.objects.get(url_path='/home/')
-        christmas_page = Page.objects.get(url_path='/home/events/christmas/')
+        christmas_page = Page.objects.get(url_path='/home/events/christmas/').specific
 
         # with multiple sites, page.url will return full URLs to ensure that
         # they work across sites
@@ -2628,7 +2628,7 @@ class TestMakePreviewRequest(TestCase):
 
     def test_make_preview_request_for_accessible_page(self):
         event_index = Page.objects.get(url_path='/home/events/')
-        response = event_index.make_preview_request()
+        response = event_index.specific.make_preview_request()
         self.assertEqual(response.status_code, 200)
         request = response.context_data['request']
 
@@ -2655,7 +2655,7 @@ class TestMakePreviewRequest(TestCase):
         Site.objects.update(port=443)
 
         event_index = Page.objects.get(url_path='/home/events/')
-        response = event_index.make_preview_request()
+        response = event_index.specific.make_preview_request()
         self.assertEqual(response.status_code, 200)
         request = response.context_data['request']
 
@@ -2682,7 +2682,7 @@ class TestMakePreviewRequest(TestCase):
         Site.objects.update(port=8888)
 
         event_index = Page.objects.get(url_path='/home/events/')
-        response = event_index.make_preview_request()
+        response = event_index.specific.make_preview_request()
         self.assertEqual(response.status_code, 200)
         request = response.context_data['request']
 
@@ -2716,7 +2716,7 @@ class TestMakePreviewRequest(TestCase):
         }
         factory = RequestFactory(**original_headers)
         original_request = factory.get('/home/events/')
-        response = event_index.make_preview_request(original_request)
+        response = event_index.specific.make_preview_request(original_request)
         self.assertEqual(response.status_code, 200)
         request = response.context_data['request']
 
@@ -2745,7 +2745,7 @@ class TestMakePreviewRequest(TestCase):
     @override_settings(ALLOWED_HOSTS=['production.example.com'])
     def test_make_preview_request_for_inaccessible_page_should_use_valid_host(self):
         root_page = Page.objects.get(url_path='/')
-        response = root_page.make_preview_request()
+        response = root_page.specific.make_preview_request()
         self.assertEqual(response.status_code, 200)
         request = response.context_data['request']
 
@@ -2757,7 +2757,7 @@ class TestMakePreviewRequest(TestCase):
     @override_settings(ALLOWED_HOSTS=['*'])
     def test_make_preview_request_for_inaccessible_page_with_wildcard_allowed_hosts(self):
         root_page = Page.objects.get(url_path='/')
-        response = root_page.make_preview_request()
+        response = root_page.specific.make_preview_request()
         self.assertEqual(response.status_code, 200)
         request = response.context_data['request']
 

--- a/wagtail/core/tests/test_views.py
+++ b/wagtail/core/tests/test_views.py
@@ -10,7 +10,7 @@ class TestLoginView(TestCase, WagtailTestUtils):
 
     def setUp(self):
         self.user = self.create_test_user()
-        self.events_index = Page.objects.get(url_path='/home/events/')
+        self.events_index = Page.objects.get(url_path='/home/events/').specific
 
     def test_get(self):
         response = self.client.get(reverse('wagtailcore_login'))

--- a/wagtail/core/tests/tests.py
+++ b/wagtail/core/tests/tests.py
@@ -266,7 +266,7 @@ class TestSiteRootPathsCache(TestCase):
         new_homepage.move(root_page, pos='last-child')
 
         # Get fresh instance of new_homepage
-        new_homepage = Page.objects.get(id=new_homepage.id)
+        new_homepage = Page.objects.get(id=new_homepage.id).specific
 
         # Check url
         self.assertEqual(new_homepage.url, '/')

--- a/wagtail/documents/templates/wagtaildocs/documents/usage.html
+++ b/wagtail/documents/templates/wagtaildocs/documents/usage.html
@@ -23,12 +23,14 @@
                 {% for page in used_by %}
                     <tr>
                         <td class="title" valign="top">
-                            <div class="title-wrapper"><a href="{% url 'wagtailadmin_pages:edit' page.id %}" title="{% trans 'Edit this page' %}">{{ page.title }}</a></div>
+                            <div class="title-wrapper"><a href="{% url 'wagtailadmin_pages:edit' page.id %}" title="{% trans 'Edit this page' %}">{{ page.get_admin_display_title }}</a></div>
                         </td>
                         <td>
-                            {% if page.get_parent %}
-                                <a href="{% url 'wagtailadmin_explore' page.get_parent.id %}">{{ page.get_parent.title }}</a>
+                            {% with page.get_parent.specific_deferred as parent %}
+                            {% if parent %}
+                                <a href="{% url 'wagtailadmin_explore' parent.id %}">{{ parent.get_admin_display_title }}</a>
                             {% endif %}
+                            {% endwith %}
                         </td>
                         <td>
                             {{ page.content_type.model_class.get_verbose_name }}

--- a/wagtail/documents/views/documents.py
+++ b/wagtail/documents/views/documents.py
@@ -232,7 +232,7 @@ def usage(request, document_id):
     Document = get_document_model()
     doc = get_object_or_404(Document, id=document_id)
 
-    paginator = Paginator(doc.get_usage(), per_page=20)
+    paginator = Paginator(doc.get_usage().specific(defer=True), per_page=20)
     used_by = paginator.get_page(request.GET.get('p'))
 
     return TemplateResponse(request, "wagtaildocs/documents/usage.html", {

--- a/wagtail/images/templates/wagtailimages/images/usage.html
+++ b/wagtail/images/templates/wagtailimages/images/usage.html
@@ -23,12 +23,14 @@
                 {% for page in used_by %}
                     <tr>
                         <td class="title" valign="top">
-                            <div class="title-wrapper"><a href="{% url 'wagtailadmin_pages:edit' page.id %}" title="{% trans 'Edit this page' %}">{{ page.title }}</a></div>
+                            <div class="title-wrapper"><a href="{% url 'wagtailadmin_pages:edit' page.id %}" title="{% trans 'Edit this page' %}">{{ page.get_admin_display_title }}</a></div>
                         </td>
                         <td>
-                            {% if page.get_parent %}
-                                <a href="{% url 'wagtailadmin_explore' page.get_parent.id %}">{{ page.get_parent.title }}</a>
+                            {% with page.get_parent.specific_deferred as parent %}
+                            {% if parent %}
+                                <a href="{% url 'wagtailadmin_explore' parent.id %}">{{ parent.get_admin_display_title }}</a>
                             {% endif %}
+                            {% endwith %}
                         </td>
                         <td>
                             {{ page.content_type.model_class.get_verbose_name }}

--- a/wagtail/images/views/images.py
+++ b/wagtail/images/views/images.py
@@ -319,7 +319,7 @@ def add(request):
 def usage(request, image_id):
     image = get_object_or_404(get_image_model(), id=image_id)
 
-    paginator = Paginator(image.get_usage(), per_page=USAGE_PAGE_SIZE)
+    paginator = Paginator(image.get_usage().specific(defer=True), per_page=USAGE_PAGE_SIZE)
     used_by = paginator.get_page(request.GET.get('p'))
 
     return TemplateResponse(request, "wagtailimages/images/usage.html", {


### PR DESCRIPTION
This PR introduces a decorator for page methods called ``@overridable``. When appended to a method, this decorator will insert a check to see if that method has been overridden in the subclass. If it's been overridden on the subclass, it'll call the sub-classes implementation with ``self.specific_deferred``.

This behaviour is a bit magical, but I think it solves a common problem that we currently have with methods like ``get_admin_display_title`` where a developer might forget to call ``specific``/``specific_deferred`` before calling it (see my [previous PR](https://github.com/wagtail/wagtail/pull/6678) that solved a bunch of these, and also the couple of tests I had to fix in this PR).