### PR TITLE
Fix: Incorrect logging of 'move' actions as 'reorder' when the target is an intended sibling

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -43,6 +43,7 @@ Changelog
  * Fix: Add padding to the Draftail editor to ensure `ol` items are not cut off (Khanh Hoang)
  * Fix: Prevent opening choosers multiple times for Image, Page, Document, Snippet (LB (Ben Johnston))
  * Fix: Ensure subsequent changes to styles files are picked up by Gulp watch (Jason Attwood)
+ * Fix: Ensure that programmatic page moves are correctly logged as 'move' and not 'reorder' in some cases (Andy Babic)
 
 
 2.15.2 (xx.xx.xxxx) - IN DEVELOPMENT

--- a/docs/releases/2.16.md
+++ b/docs/releases/2.16.md
@@ -48,6 +48,7 @@
  * Add padding to the Draftail editor to ensure `ol` items are not cut off (Khanh Hoang)
  * Prevent opening choosers multiple times for Image, Page, Document, Snippet (LB (Ben Johnston))
  * Ensure subsequent changes to styles files are picked up by Gulp watch (Jason Attwood)
+ * Ensure that programmatic page moves are correctly logged as 'move' and not 'reorder' in some cases (Andy Babic)
 
 ## Upgrade considerations
 

--- a/wagtail/core/tests/test_audit_log.py
+++ b/wagtail/core/tests/test_audit_log.py
@@ -209,7 +209,10 @@ class TestAuditLog(TestCase):
             instance=SimplePage(title="About us", slug="about", content="hello")
         )
         user = get_user_model().objects.first()
-        section.move(self.home_page, user=user)
+        # move() interprets `target` as an intended 'sibling' by default, so
+        # we must use `pos` to indicate that `self.home_page` should be the
+        # new 'parent'
+        section.move(self.home_page, pos="last-child", user=user)
 
         self.assertEqual(PageLogEntry.objects.filter(action='wagtail.move', user=user).count(), 1)
         self.assertEqual(PageLogEntry.objects.filter(action='wagtail.reorder', user=user).count(), 0)


### PR DESCRIPTION
Small bug fix that was originally included in #7761 and later removed.

This isn't dangerous or urgent, as Wagtail's move view provides the correct argument combination. Was just something I noticed while poking around in the tests, and realised the false-positive.