### PR TITLE
Add `Page.get_root_relative_url()` and improve `Page.get_url_parts()`

### DIFF
--- a/docs/reference/pages/model_reference.rst
+++ b/docs/reference/pages/model_reference.rst
@@ -180,6 +180,8 @@ In addition to the model fields provided, ``Page`` has many properties and metho
 
     .. automethod:: get_url_parts
 
+    .. automethod:: get_root_relative_url
+
     .. automethod:: route
 
     .. automethod:: serve

--- a/docs/topics/pages.md
+++ b/docs/topics/pages.md
@@ -200,25 +200,26 @@ Page models also include several low-level methods for overriding or accessing p
 
 #### Customising URL patterns for a page model
 
-The `Page.get_url_parts(request)` method will not typically be called directly, but may be overridden to define custom URL routing for a given page model. It should return a tuple of `(site_id, root_url, page_path)`, which are used by `get_url` and `get_full_url` (see below) to construct the given type of page URL.
+The `Page.get_root_relative_url(site_root_path)` method will not typically be called directly, but may be overridden to define custom URL routing for a given page model.
 
-When overriding `get_url_parts()`, you should accept `*args, **kwargs`:
+The method receives a `SiteRootPath` named tuple instance, and should return the page's URL relative to this.
 
-```python
-def get_url_parts(self, *args, **kwargs):
-```
-
-and pass those through at the point where you are calling `get_url_parts` on `super` (if applicable), e.g.:
+When overriding, you only really need to worry about the `site_root_path` value for projects where you have 'overlapping' sites that feature the same pages at different URLs (e.g. a main site, and a sub-site that are viewed at separate domains). If this does not apply, you can get away with just returning a path that is always relative to the site root. e.g.:
 
 ```python
-super().get_url_parts(*args, **kwargs)
+def get_root_relative_url(self, site_root_path, *args, **kwargs):
+    return "/custom-path/"
 ```
 
-While you could pass only the `request` keyword argument, passing all arguments as-is ensures compatibility with any
-future changes to these method signatures.
+As suggested in the above example, you should include `*args` and `**kwargs` in your overriding method, and pass all values on to `super` where relevant. This will help to ensure your customisations remain compatible with future changes to original method signature. For example:
+
+```python
+def get_root_relative_url(self, site_root_path, *args, **kwargs):
+    return super().get_root_relative_url(site_root_path, *args, **kwargs) + "/custom-addition/"
+```
 
 ```eval_rst
-For more information, please see :meth:`wagtail.core.models.Page.get_url_parts`.
+For more information, please see :meth:`wagtail.core.models.Page.get_root_relative_url`.
 ```
 
 #### Obtaining URLs for page instances

--- a/wagtail/core/tests/test_page_model.py
+++ b/wagtail/core/tests/test_page_model.py
@@ -23,6 +23,7 @@ from wagtail.core.models import (
     Comment, Locale, Page, PageLogEntry, PageManager, Site, get_page_models,
     get_translatable_models)
 from wagtail.core.signals import page_published
+from wagtail.core.utils import get_dummy_request
 from wagtail.tests.testapp.models import (
     AbstractPage, Advert, AlwaysShowInMenusPage, BlogCategory, BlogCategoryBlogPage, BusinessChild,
     BusinessIndex, BusinessNowherePage, BusinessSubIndex, CustomManager, CustomManagerPage,
@@ -253,6 +254,7 @@ class TestRouting(TestCase):
             homepage.get_url_parts(),
             (default_site.id, 'http://localhost', '/')
         )
+        self.assertEqual(homepage.get_root_relative_url(default_site.root_path), "/")
         self.assertEqual(homepage.full_url, 'http://localhost/')
         self.assertEqual(homepage.url, '/')
         self.assertEqual(homepage.relative_url(default_site), '/')
@@ -265,17 +267,18 @@ class TestRouting(TestCase):
         self.assertEqual(christmas_page.full_url, 'http://localhost/events/christmas/')
         self.assertEqual(christmas_page.url, '/events/christmas/')
         self.assertEqual(christmas_page.relative_url(default_site), '/events/christmas/')
+        self.assertEqual(christmas_page.get_root_relative_url(default_site.root_path), '/events/christmas/')
         self.assertEqual(christmas_page.get_site(), default_site)
 
     def test_page_with_no_url(self):
         root = Page.objects.get(url_path='/')
         default_site = Site.objects.get(is_default_site=True)
 
-        self.assertEqual(root.get_url_parts(), None)
-        self.assertEqual(root.full_url, None)
-        self.assertEqual(root.url, None)
-        self.assertEqual(root.relative_url(default_site), None)
-        self.assertEqual(root.get_site(), None)
+        self.assertIsNone(root.get_url_parts())
+        self.assertIsNone(root.full_url)
+        self.assertIsNone(root.url)
+        self.assertIsNone(root.relative_url(default_site))
+        self.assertIsNone(root.get_site())
 
     @override_settings(ALLOWED_HOSTS=['localhost', 'testserver', 'events.example.com', 'second-events.example.com'])
     def test_urls_with_multiple_sites(self):
@@ -301,6 +304,7 @@ class TestRouting(TestCase):
         self.assertEqual(homepage.url, 'http://localhost/')
         self.assertEqual(homepage.relative_url(default_site), '/')
         self.assertEqual(homepage.relative_url(events_site), 'http://localhost/')
+        self.assertEqual(homepage.get_root_relative_url(default_site.root_path), '/')
         self.assertEqual(homepage.get_site(), default_site)
 
         self.assertEqual(
@@ -311,23 +315,81 @@ class TestRouting(TestCase):
         self.assertEqual(christmas_page.url, 'http://events.example.com/christmas/')
         self.assertEqual(christmas_page.relative_url(default_site), 'http://events.example.com/christmas/')
         self.assertEqual(christmas_page.relative_url(events_site), '/christmas/')
+        self.assertEqual(christmas_page.get_root_relative_url(default_site.root_path), "/events/christmas/")
+        self.assertEqual(christmas_page.get_root_relative_url(events_site.root_path), "/christmas/")
+        self.assertEqual(christmas_page.get_root_relative_url(second_events_site.root_path), "/christmas/")
         self.assertEqual(christmas_page.get_site(), events_site)
 
-        request = HttpRequest()
-        request.META['HTTP_HOST'] = events_site.hostname
-        request.META['SERVER_PORT'] = events_site.port
-
+        # `site` can be used to influence the return value of `get_url_parts()`
+        events_site_parts = christmas_page.get_url_parts(site=events_site)
         self.assertEqual(
-            christmas_page.get_url_parts(request=request),
+            events_site_parts,
             (events_site.id, 'http://events.example.com', '/christmas/')
         )
 
-        request2 = HttpRequest()
-        request2.META['HTTP_HOST'] = second_events_site.hostname
-        request2.META['SERVER_PORT'] = second_events_site.port
+        second_event_site_parts = christmas_page.get_url_parts(site=second_events_site)
         self.assertEqual(
-            christmas_page.get_url_parts(request=request2),
+            second_event_site_parts,
             (second_events_site.id, 'http://second-events.example.com', '/christmas/')
+        )
+
+        # we get the same results when providing just the site pk
+        self.assertEqual(
+            christmas_page.get_url_parts(site=events_site.pk),
+            events_site_parts
+        )
+        self.assertEqual(
+            christmas_page.get_url_parts(site=second_events_site.pk),
+            second_event_site_parts
+        )
+
+        # if the page isn't 'in' the provided site, an error will be raised
+        with self.assertRaises(ValueError):
+            homepage.get_url_parts(site=events_site)
+
+        # non `HttpRequest` values are acceptable for `request`, and
+        # do not affect the result
+        for request_value in (events_page, default_site, events_site):
+            self.assertEqual(
+                christmas_page.get_url_parts(request=request_value),
+                (events_site.id, 'http://events.example.com', '/christmas/')
+            )
+
+        # When `request` is a `HttpRequest` from a site, the result is flavoured to
+        # the relevant site
+        default_site_request = get_dummy_request(site=default_site)
+        events_site_request = get_dummy_request(site=events_site)
+        second_events_site_request = get_dummy_request(site=second_events_site)
+
+        self.assertEqual(
+            christmas_page.get_url_parts(request=default_site_request),
+            (default_site.id, 'http://localhost', '/events/christmas/')
+        )
+        self.assertEqual(
+            christmas_page.get_url_parts(request=events_site_request),
+            (events_site.id, 'http://events.example.com', '/christmas/')
+        )
+        self.assertEqual(
+            christmas_page.get_url_parts(request=second_events_site_request),
+            (second_events_site.id, 'http://second-events.example.com', '/christmas/')
+        )
+
+        # When `request` is a `HttpRequest` from some other domain, details for the
+        # 'default' site root path are returned
+        request = HttpRequest()
+        request.META['HTTP_HOST'] = 'testserver'
+        request.META['SERVER_PORT'] = 80
+
+        self.assertEqual(
+            christmas_page.get_url_parts(request=request),
+            (default_site.id, 'http://localhost', '/events/christmas/')
+        )
+
+        # When `site` and `request` are both used, the influence of
+        # the `site` over the return value is greater
+        self.assertEqual(
+            christmas_page.get_url_parts(request=second_events_site_request, site=events_site.pk),
+            (events_site.id, 'http://events.example.com', '/christmas/')
         )
 
     @override_settings(ROOT_URLCONF='wagtail.tests.non_root_urls')
@@ -366,8 +428,8 @@ class TestRouting(TestCase):
             homepage.get_url_parts(),
             (default_site.id, None, None)
         )
-        self.assertEqual(homepage.full_url, None)
-        self.assertEqual(homepage.url, None)
+        self.assertIsNone(homepage.full_url)
+        self.assertIsNone(homepage.url)
 
     def test_request_routing(self):
         homepage = Page.objects.get(url_path='/home/')


### PR DESCRIPTION
Related issue: #7878

Originally implemented in #7809, but broken out here for better visibility and to avoid blocking other work.

The overarching aim of this PR is to make url logic in Wagtail easier to override (beyond the scope being discussed in https://github.com/wagtail/wagtail/discussions/7812). Below is a full list of changes:

- Adds `Page.get_root_relative_url()` to facilitate overriding of page paths without the complication of the other values returned by `get_url_parts()`.
- Updates documentation on overriding page urls to recommend overriding `Page.get_root_relative_url()` instead of `Page.get_url_parts()`
- Updates `Page.get_url_parts()` to no longer break when `request` is not a `HttpRequest` instance
- Updates `Page.get_url_parts()` to no longer attempt to derive a `Site` from `request` if it cannot influence the return value
- Documents the impact of the `request` value on the return value of `Page.get_url_parts()`
- Uses a custom `NoReverseMatch` exception to indicate when `wagtail_serve` is not registered (to avoid swallowing other potential `NoReverseMatch` exceptions triggered by overrides)
-  Improve readability of `Page.get_url_parts()` by embracing the `SiteRootPath` namedtuple as a value in its own right (instead of only using it as a `tuple`)