### PR TITLE
Render horizontal listing as a flex container

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -31,6 +31,7 @@ Changelog
  * Update links to wagtail.io to point to new domain wagtail.org (Jake Howard)
  * Add borders to TypedTableBlock to help visualize rows and columns (Scott Cranfill)
  * Set default submit button label on generic create views to 'Create' instead of 'Save' (Matt Westcott)
+ * Improve display of image listing for long image titles (Krzysztof Jeziorny)
  * Fix: Accessibility fixes for Windows high contrast mode; Dashboard icons colour and contrast (Sakshi Uppoor)
  * Fix: Rename additional 'spin' CSS animations to avoid clashes with other libraries (Kevin Gutiérrez)
  * Fix: `default_app_config` deprecations for Django >= 3.2 (Tibor Leupold)

--- a/client/scss/components/_listing.scss
+++ b/client/scss/components/_listing.scss
@@ -600,19 +600,19 @@ table.listing {
 
 @include media-breakpoint-up(sm) {
     .listing {
-        &.horiz > li {
-            float: left;
+        &.horiz {
+            display: flex;
+            flex-wrap: wrap;
         }
 
         &.images {
-            @include clearfix();
             border: 1px solid $color-grey-4;
             border-width: 0 0 0 1px;
 
             > li {
                 padding: 1.5em;
                 width: 200px;
-                height: 220px;
+                height: auto;
                 text-align: center;
                 margin-top: -1px;
                 border: 1px solid $color-grey-4;

--- a/docs/releases/2.16.md
+++ b/docs/releases/2.16.md
@@ -34,6 +34,7 @@
  * When moving pages, default to the current parent section (Tidjani Dia)
  * Add borders to TypedTableBlock to help visualize rows and columns (Scott Cranfill)
  * Set default submit button label on generic create views to 'Create' instead of 'Save' (Matt Westcott)
+ * Improve display of image listing for long image titles (Krzysztof Jeziorny)
 
 ### Bug fixes
 


### PR DESCRIPTION
A proposal to display the image list as a flex container, without floats. Also the image height is not set to a fix height to avoid overlfowing when the image title is longer.

I think it's safe to use flexbox (or css grid), as the support for IE 11 was [removed](https://docs.wagtail.io/en/latest/releases/2.15.html#removed-support-for-internet-explorer-ie11) in 2.15 and any other modern browser [should come clear](https://caniuse.com/flexbox) with flexbox. Testing would surely be needed.

Currently as a list with floats:
<img width="748" alt="list" src="https://user-images.githubusercontent.com/872730/148606536-489f0214-3997-411d-8c07-4a6d1d4d9aa9.png">

As a flexbox:
<img width="981" alt="flexbox" src="https://user-images.githubusercontent.com/872730/148606581-cd5426e1-2016-4b70-a997-75b35d594c56.png">