### PR TITLE
Improve API / documentation for site root paths

### DIFF
--- a/docs/reference/pages/model_reference.md
+++ b/docs/reference/pages/model_reference.md
@@ -401,6 +401,12 @@ The {meth}`~wagtail.models.Site.find_for_request` function returns the Site obje
         - 443 = ``https://``
         - Everything else will use the ``http://`` scheme and the port will be appended to the end of the hostname (for example ``http://mysite.com:8000/``)
 
+    .. autoattribute:: root_paths
+
+    .. autoattribute:: default_root_path
+
+    .. automethod:: get_root_path
+
     .. automethod:: get_site_root_paths
 ```
 


### PR DESCRIPTION
Having done a lot of work with page URLs recently, I've found the concept of 'Site root paths' a bit tricky to get my head around. I feel like a lot of this has to do with their 'private-ish' nature, and the single route to those values: `Site.get_site_root_paths()`; which is documented in the model reference, but not really mentioned elsewhere.

This PR is an attempt to make the API a little more accessible, by bringing the logic onto `Site` instances using regular instance methods. I believe these changes:

- Make the code easier to explain, read and understand: Helping to bridge a gap in clarity between `Site` and `SiteRoutePath`
- Allow us to more clearly test the logic against certain conditions
- In places where we already know the `Site` we're interested in (e.g. `Page.get_url_parts()`, automatic redirect creation), accessing the values is much simpler... allowing for cleaner code in both the core app, and in tests

Another thing I've done here is establish a 'guaranteed order' for site root paths when there are roots for multiple locales. Without this, it would be quite easy to break `Page.get_url_parts()` with a bit of harmless reordering. It's only really by chance that the `SiteRootPath` for `Site.root_path` usually comes first in `Site.get_site_root_paths()` - its `path` value is not guaranteed to come before the others alphabetically.