### PR TITLE
Add locale labels in listings

### DIFF
--- a/client/scss/components/_status-tag.scss
+++ b/client/scss/components/_status-tag.scss
@@ -21,6 +21,13 @@
     &.disabled {
         pointer-events: none;
     }
+
+    &--label {
+        color: $color-grey-2;
+        background: $color-grey-4;
+        border: $color-grey-4;
+        font-weight: 500;
+    }
 }
 
 button.status-tag:hover,

--- a/wagtail/admin/static_src/wagtailadmin/scss/layouts/page-editor.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/layouts/page-editor.scss
@@ -18,18 +18,34 @@
 
     .modal .breadcrumb {
         margin: 0;
+        padding-left: 0.5em;
         background-color: transparent;
+
+        .breadcrumb-item {
+            padding-left: 0;
+            padding-right: 0;
+        }
 
         a {
             color: $color-grey-2;
+            padding-left: 0.5em;
+            padding-right: 0.5em;
+
+            &:hover {
+                color: $color-white;
+            }
         }
 
         li:hover {
-            background-color: $color-grey-4;
+            background-color: transparent;
         }
 
-        .home {
-            padding-left: 0;
+        .home_icon {
+            margin-left: 0;
+        }
+
+        .status-tag {
+            margin-bottom: 0;
         }
     }
 

--- a/wagtail/admin/templates/wagtailadmin/chooser/_browse_results.html
+++ b/wagtail/admin/templates/wagtailadmin/chooser/_browse_results.html
@@ -1,6 +1,5 @@
 {% load i18n wagtailadmin_tags %}
 
-<h2>{% trans "Explorer" %}</h2>
 {% include "wagtailadmin/shared/chooser_breadcrumb.html" with page=parent_page show_locale_labels=show_locale_labels %}
 
 {% if pages %}

--- a/wagtail/admin/templates/wagtailadmin/chooser/_browse_results.html
+++ b/wagtail/admin/templates/wagtailadmin/chooser/_browse_results.html
@@ -1,10 +1,10 @@
 {% load i18n wagtailadmin_tags %}
 
 <h2>{% trans "Explorer" %}</h2>
-{% include "wagtailadmin/shared/chooser_breadcrumb.html" with page=parent_page %}
+{% include "wagtailadmin/shared/chooser_breadcrumb.html" with page=parent_page show_locale_labels=show_locale_labels %}
 
 {% if pages %}
-    {% include "wagtailadmin/pages/listing/_list_choose.html" with allow_navigation=1 orderable=0 pages=pages parent_page=parent_page %}
+    {% include "wagtailadmin/pages/listing/_list_choose.html" with allow_navigation=1 orderable=0 pages=pages parent_page=parent_page show_locale_labels=show_locale_labels %}
 
     {% url 'wagtailadmin_choose_page_child' parent_page.id as pagination_base_url %}
     {% paginate pages base_url=pagination_base_url classnames="navigate-pages" %}

--- a/wagtail/admin/templates/wagtailadmin/chooser/_search_results.html
+++ b/wagtail/admin/templates/wagtailadmin/chooser/_search_results.html
@@ -9,7 +9,7 @@
 </h2>
 
 {% if pages %}
-    {% include "wagtailadmin/pages/listing/_list_choose.html" with show_parent=1 pages=pages parent_page=parent_page %}
+    {% include "wagtailadmin/pages/listing/_list_choose.html" with show_parent=1 pages=pages parent_page=parent_page show_locale_labels=show_locale_labels %}
 
     {% url 'wagtailadmin_choose_page_search' as pagination_base_url %}
     {% paginate pages base_url=pagination_base_url classnames="navigate-pages" %}

--- a/wagtail/admin/templates/wagtailadmin/pages/index.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/index.html
@@ -14,7 +14,7 @@
         {% csrf_token %}
 
         {% page_permissions parent_page as parent_page_perms %}
-        {% include "wagtailadmin/pages/listing/_list_explore.html" with sortable=1 sortable_by_type=1 full_width=1 show_ordering_column=show_ordering_column show_bulk_actions=show_bulk_actions parent_page=parent_page orderable=parent_page_perms.can_reorder_children %}
+        {% include "wagtailadmin/pages/listing/_list_explore.html" with sortable=1 sortable_by_type=1 full_width=1 show_ordering_column=show_ordering_column show_bulk_actions=show_bulk_actions parent_page=parent_page orderable=parent_page_perms.can_reorder_children show_locale_labels=show_locale_labels %}
 
         {% if do_paginate %}
             {% url 'wagtailadmin_explore' parent_page.id as pagination_base_url %}
@@ -31,7 +31,7 @@
     {% comment %} modal-workflow is required by the view restrictions interface {% endcomment %}
     <script src="{% versioned_static 'wagtailadmin/js/modal-workflow.js' %}"></script>
     <script src="{% versioned_static 'wagtailadmin/js/privacy-switch.js' %}"></script>
-    
+
     {% comment %}
     The first column will display checkboxes only if ordering is not being carried out, in which case
     that column will have the drag and drop buttons to enable ordering

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_list_choose.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_list_choose.html
@@ -30,7 +30,7 @@
 {% block page_row_classname %}{% if not page.can_choose %}disabled{% endif %}{% endblock %}
 
 {% block page_title %}
-    {% include "wagtailadmin/pages/listing/_page_title_choose.html" with page=page parent_page=parent_page show_locale_labels=show_locale_labels %}
+    {% include "wagtailadmin/pages/listing/_page_title_choose.html" with page=page show_locale_labels=show_locale_labels %}
 {% endblock %}
 
 {% block page_parent_page_title %}

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_list_choose.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_list_choose.html
@@ -30,11 +30,11 @@
 {% block page_row_classname %}{% if not page.can_choose %}disabled{% endif %}{% endblock %}
 
 {% block page_title %}
-    {% include "wagtailadmin/pages/listing/_page_title_choose.html" with page=page %}
+    {% include "wagtailadmin/pages/listing/_page_title_choose.html" with page=page parent_page=parent_page show_locale_labels=show_locale_labels %}
 {% endblock %}
 
 {% block page_parent_page_title %}
-    {% include "wagtailadmin/pages/listing/_page_parent_page_title_choose.html" with page=page %}
+    {% include "wagtailadmin/pages/listing/_page_parent_page_title_choose.html" with page=page show_locale_labels=show_locale_labels %}
 {% endblock %}
 
 {% block page_navigation %}

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_page_parent_page_title_choose.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_page_parent_page_title_choose.html
@@ -7,5 +7,6 @@ Expects a variable 'page', the page instance.
 {% with page.get_parent as parent %}
     {% if parent %}
         <a href="{% url 'wagtailadmin_choose_page_child' parent.id %}" class="navigate-parent">{{ parent.get_admin_display_title }}</a>
+        {% if show_locale_labels %}<span class="status-tag status-tag--label">{{ page.locale.get_display_name }}</span>{% endif %}
     {% endif %}
 {% endwith %}

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_page_title_choose.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_page_title_choose.html
@@ -12,7 +12,7 @@ Expects a variable 'page', the page instance.
     {% else %}
         {{ page.get_admin_display_title }}
     {% endif %}
-    {% if show_locale_labels and parent_page.is_root and not page.is_root %}
+    {% if show_locale_labels and page.depth == 2 %}
         <span class="status-tag status-tag--label">{{ page.locale.get_display_name }}</span>
     {% endif %}
 

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_page_title_choose.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_page_title_choose.html
@@ -12,6 +12,9 @@ Expects a variable 'page', the page instance.
     {% else %}
         {{ page.get_admin_display_title }}
     {% endif %}
+    {% if show_locale_labels and parent_page.is_root and not page.is_root %}
+        <span class="status-tag status-tag--label">{{ page.locale.get_display_name }}</span>
+    {% endif %}
 
     {% include "wagtailadmin/pages/listing/_privacy_indicator.html" with page=page %}
     {% include "wagtailadmin/pages/listing/_locked_indicator.html" with page=page %}

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_page_title_explore.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_page_title_explore.html
@@ -15,6 +15,10 @@
         {{ page.get_admin_display_title }}
     {% endif %}
 
+    {% if show_locale_labels %}
+        <span class="status-tag status-tag--label">{{ page.locale.get_display_name }}</span>
+    {% endif %}
+
     {% block pages_listing_title_extra %}{% endblock pages_listing_title_extra %}
 
     {% include "wagtailadmin/pages/listing/_privacy_indicator.html" with page=page %}

--- a/wagtail/admin/templates/wagtailadmin/pages/search_results.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/search_results.html
@@ -32,7 +32,7 @@
             </nav>
         {% endif %}
 
-        {% include "wagtailadmin/pages/listing/_list_explore.html" with show_parent=1 sortable=1 sortable_by_type=0 show_bulk_actions=1 %}
+        {% include "wagtailadmin/pages/listing/_list_explore.html" with show_parent=1 sortable=1 sortable_by_type=0 show_bulk_actions=1 show_locale_labels=show_locale_labels %}
 
         {% url 'wagtailadmin_pages:search' as pagination_base_url %}
         {% paginate pages base_url=pagination_base_url %}

--- a/wagtail/admin/templates/wagtailadmin/shared/chooser_breadcrumb.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/chooser_breadcrumb.html
@@ -3,6 +3,7 @@
 <ul class="breadcrumb">
     {% for page in page.get_ancestors.specific %}
         {% if page.is_root %}
+            {% if show_locale_labels %}<li><span class="status-tag primary">{{ page.locale.get_display_name }}</span></li>{% endif %}
             <li class="home"><a href="{% url 'wagtailadmin_choose_page_child' page.id %}{% querystring p=None %}" class="navigate-pages icon icon-home text-replace">{% trans 'Home' %}</a></li>
         {% else %}
             <li><a href="{% url 'wagtailadmin_choose_page_child' page.id %}{% querystring p=None %}" class="navigate-pages">{{ page.get_admin_display_title }}</a></li>

--- a/wagtail/admin/templates/wagtailadmin/shared/chooser_breadcrumb.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/chooser_breadcrumb.html
@@ -3,6 +3,7 @@
 <ul class="breadcrumb">
     {% for page in page.get_ancestors.specific %}
         {% if page.is_root %}
+            {% if show_locale_labels %}<li class="breadcrumb-item"><span class="status-tag primary">{{ page.locale.get_display_name }}</span></li>{% endif %}
             {% trans 'Home' as home %}
             <li class="breadcrumb-item home"><a href="{% url 'wagtailadmin_choose_page_child' page.id %}{% querystring p=None %}" class="breadcrumb-link navigate-pages">{% icon name="home" class_name="home_icon" title=home %}{% icon name="arrow-right" class_name="arrow_right_icon" %}</a></li>
         {% elif forloop.last %}

--- a/wagtail/admin/templates/wagtailadmin/shared/chooser_breadcrumb.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/chooser_breadcrumb.html
@@ -3,10 +3,12 @@
 <ul class="breadcrumb">
     {% for page in page.get_ancestors.specific %}
         {% if page.is_root %}
-            {% if show_locale_labels %}<li><span class="status-tag primary">{{ page.locale.get_display_name }}</span></li>{% endif %}
-            <li class="home"><a href="{% url 'wagtailadmin_choose_page_child' page.id %}{% querystring p=None %}" class="navigate-pages icon icon-home text-replace">{% trans 'Home' %}</a></li>
+            {% trans 'Home' as home %}
+            <li class="breadcrumb-item home"><a href="{% url 'wagtailadmin_choose_page_child' page.id %}{% querystring p=None %}" class="breadcrumb-link navigate-pages">{% icon name="home" class_name="home_icon" title=home %}{% icon name="arrow-right" class_name="arrow_right_icon" %}</a></li>
+        {% elif forloop.last %}
+            <li class="breadcrumb-item"><a href="{% url 'wagtailadmin_choose_page_child' page.id %}{% querystring p=None %}" class="breadcrumb-link navigate-pages">{{ page.get_admin_display_title }}</a></li>
         {% else %}
-            <li><a href="{% url 'wagtailadmin_choose_page_child' page.id %}{% querystring p=None %}" class="navigate-pages">{{ page.get_admin_display_title }}</a></li>
+            <li class="breadcrumb-item"><a href="{% url 'wagtailadmin_choose_page_child' page.id %}{% querystring p=None %}" class="breadcrumb-link navigate-pages"><span class="title">{{ page.get_admin_display_title }}</span>{% icon name="arrow-right" class_name="arrow_right_icon" %}</a></li>
         {% endif %}
     {% endfor %}
 </ul>

--- a/wagtail/admin/tests/test_page_chooser.py
+++ b/wagtail/admin/tests/test_page_chooser.py
@@ -245,11 +245,20 @@ class TestChooserBrowseChild(TestCase, WagtailTestUtils):
         self.assertTemplateUsed(response, 'wagtailadmin/chooser/browse.html')
 
         # Look for a link element in the breadcrumbs with the admin title
+        expected = """
+            <li class="breadcrumb-item">
+                <a href="/admin/choose-page/{page_id}/?" class="breadcrumb-link navigate-pages">{page_title}
+                    <svg class="icon icon-arrow-right arrow_right_icon" aria-hidden="true" focusable="false">
+                        <use href="#icon-arrow-right"></use>
+                    </svg>
+                </a>
+            </li>
+        """.format(
+            page_id=self.child_page.id,
+            page_title="foobarbaz (simple page)",
+        )
         self.assertTagInHTML(
-            '<li><a href="/admin/choose-page/{page_id}/?" class="navigate-pages">{page_title}</a></li>'.format(
-                page_id=self.child_page.id,
-                page_title="foobarbaz (simple page)",
-            ),
+            expected,
             response.json().get('html')
         )
 

--- a/wagtail/admin/views/chooser.py
+++ b/wagtail/admin/views/chooser.py
@@ -129,6 +129,10 @@ def browse(request, parent_page_id=None):
     parent_page.can_choose = can_choose_page(
         parent_page, permission_proxy, desired_classes, can_choose_root, user_perm, target_pages=target_pages, match_subclass=match_subclass)
 
+    show_locale_labels = getattr(settings, 'WAGTAIL_I18N_ENABLED', False)
+    if show_locale_labels:
+        pages = pages.select_related('locale')
+
     # Pagination
     # We apply pagination first so we don't need to walk the entire list
     # in the block below
@@ -148,7 +152,8 @@ def browse(request, parent_page_id=None):
         'search_form': SearchForm(),
         'page_type_string': page_type_string,
         'page_type_names': [desired_class.get_verbose_name() for desired_class in desired_classes],
-        'page_types_restricted': (page_type_string != 'wagtailcore.page')
+        'page_types_restricted': (page_type_string != 'wagtailcore.page'),
+        'show_locale_labels': show_locale_labels,
     })
 
     return render_modal_workflow(
@@ -169,6 +174,10 @@ def search(request, parent_page_id=None):
         raise Http404
 
     pages = Page.objects.all()
+    show_locale_labels = getattr(settings, 'WAGTAIL_I18N_ENABLED', False)
+    if show_locale_labels:
+        pages = pages.select_related('locale')
+
     # allow hooks to modify the queryset
     for hook in hooks.get_hooks('construct_page_chooser_queryset'):
         pages = hook(pages, request)
@@ -196,6 +205,7 @@ def search(request, parent_page_id=None):
             'searchform': search_form,
             'pages': pages,
             'page_type_string': page_type_string,
+            'show_locale_labels': show_locale_labels,
         })
     )
 

--- a/wagtail/admin/views/pages/listing.py
+++ b/wagtail/admin/views/pages/listing.py
@@ -107,18 +107,22 @@ def index(request, parent_page_id=None):
         'translations': [],
         'show_ordering_column': show_ordering_column,
         'show_bulk_actions': not show_ordering_column,
+        'show_locale_labels': False,
     }
 
-    if getattr(settings, 'WAGTAIL_I18N_ENABLED', False) and not parent_page.is_root():
-        context.update({
-            'locale': parent_page.locale,
-            'translations': [
-                {
-                    'locale': translation.locale,
-                    'url': reverse('wagtailadmin_explore', args=[translation.id]),
-                }
-                for translation in parent_page.get_translations().only('id', 'locale').select_related('locale')
-            ],
-        })
+    if getattr(settings, 'WAGTAIL_I18N_ENABLED', False):
+        if not parent_page.is_root():
+            context.update({
+                'locale': parent_page.locale,
+                'translations': [
+                    {
+                        'locale': translation.locale,
+                        'url': reverse('wagtailadmin_explore', args=[translation.id]),
+                    }
+                    for translation in parent_page.get_translations().only('id', 'locale').select_related('locale')
+                ],
+            })
+        else:
+            context['show_locale_labels'] = True
 
     return TemplateResponse(request, 'wagtailadmin/pages/index.html', context)

--- a/wagtail/admin/views/pages/search.py
+++ b/wagtail/admin/views/pages/search.py
@@ -45,7 +45,6 @@ def search(request):
     show_locale_labels = getattr(settings, 'WAGTAIL_I18N_ENABLED', False)
     if show_locale_labels:
         pages = pages.select_related('locale')
-        all_pages = all_pages.select_related('locale')
 
     q = MATCH_ALL
     content_types = []

--- a/wagtail/admin/views/pages/search.py
+++ b/wagtail/admin/views/pages/search.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.core.paginator import Paginator
 from django.http import Http404
@@ -41,6 +42,11 @@ def page_filter_search(q, pages, all_pages=None, ordering=None):
 @user_passes_test(user_has_any_page_permission)
 def search(request):
     pages = all_pages = Page.objects.all().prefetch_related('content_type').specific()
+    show_locale_labels = getattr(settings, 'WAGTAIL_I18N_ENABLED', False)
+    if show_locale_labels:
+        pages = pages.select_related('locale')
+        all_pages = all_pages.select_related('locale')
+
     q = MATCH_ALL
     content_types = []
     pagination_query_params = QueryDict({}, mutable=True)
@@ -113,6 +119,7 @@ def search(request):
             'selected_content_type': selected_content_type,
             'ordering': ordering,
             'pagination_query_params': pagination_query_params.urlencode(),
+            'show_locale_labels': show_locale_labels,
         })
     else:
         return TemplateResponse(request, "wagtailadmin/pages/search.html", {
@@ -124,4 +131,5 @@ def search(request):
             'selected_content_type': selected_content_type,
             'ordering': ordering,
             'pagination_query_params': pagination_query_params.urlencode(),
+            'show_locale_labels': show_locale_labels,
         })


### PR DESCRIPTION
This PR adds locale labels in

<details>
<summary>Explorer root 📸</summary>

Before:
![root-before](https://user-images.githubusercontent.com/31622/148797490-7c6a0724-b692-46b5-b9ab-098b715a11b9.png)
After:
![root-after](https://user-images.githubusercontent.com/31622/148797555-dae3bd70-8c82-40af-b10f-69412ae37260.png)
</details>

<details>
<summary>Search results 📸</summary>

Before:
![search-before](https://user-images.githubusercontent.com/31622/148797587-5fdd598b-5b43-4fcd-a56e-3a762d4cdf23.png)

After:
![search-after](https://user-images.githubusercontent.com/31622/148797590-82297c9b-a787-47da-acdc-a3e81556a30d.png)
</details>

<details>
<summary>Page chooser 📸

With breadcrumb tidy-ups especially after #7783
</summary>

Page chooser root, before:
![page-chooser-root-before](https://user-images.githubusercontent.com/31622/148797957-d3e71c79-e4ba-4a27-93ce-e093f9e1de2e.png)
Page chooser root, after:
![page-chooser-root-after](https://user-images.githubusercontent.com/31622/148797961-dce45897-42b4-4823-b7d9-89738d787373.png)

Page chooser search, after:
![page-chooser-root-search-after](https://user-images.githubusercontent.com/31622/148797963-ef80e1d8-153c-4660-af20-374964a02bf0.png)


Page chooser breadcrumb, before:
![page-chooser-breadcrumb-hover-before](https://user-images.githubusercontent.com/31622/148797966-d957e8fd-064e-4128-b965-12bd16bd2003.png)
![page-chooser-breadcrumb-before](https://user-images.githubusercontent.com/31622/148797965-aec7ff83-18c6-4a11-962e-45e00888e162.png)


Page chooser breadcrumb, after:
![page-chooser-breadcrumb-after](https://user-images.githubusercontent.com/31622/148797968-e07d528e-0f78-427c-92ea-9ca777014813.png)
![page-chooser-breadcrumb-hover-after](https://user-images.githubusercontent.com/31622/148797969-54dd9ef5-9eff-4d32-84bc-ae8c867b7873.png)
</details>