### PR TITLE
Restore delete button in main actions menu

### DIFF
--- a/wagtail/admin/action_menu.py
+++ b/wagtail/admin/action_menu.py
@@ -292,6 +292,24 @@ class UnpublishMenuItem(ActionMenuItem):
         return reverse('wagtailadmin_pages:unpublish', args=(context['page'].id,))
 
 
+class DeleteMenuItem(ActionMenuItem):
+    name = 'action-delete'
+    label = _("Delete")
+    icon_name = 'bin'
+    classname = 'action-secondary'
+
+    def is_shown(self, context):
+        if context['view'] == 'edit':
+            perms_tester = self.get_user_page_permissions_tester(context)
+            return (
+                not perms_tester.page_locked()
+                and perms_tester.can_delete()
+            )
+
+    def get_url(self, context):
+        return reverse('wagtailadmin_pages:delete', args=(context['page'].id,))
+
+
 class LockMenuItem(ActionMenuItem):
     name = 'action-lock'
     label = _("Lock")
@@ -374,6 +392,7 @@ def _get_base_page_action_menu_items():
     if BASE_PAGE_ACTION_MENU_ITEMS is None:
         BASE_PAGE_ACTION_MENU_ITEMS = [
             SaveDraftMenuItem(order=0),
+            DeleteMenuItem(order=10),
             LockMenuItem(order=15),
             UnlockMenuItem(order=15),
             UnpublishMenuItem(order=20),

--- a/wagtail/admin/wagtail_hooks.py
+++ b/wagtail/admin/wagtail_hooks.py
@@ -319,23 +319,6 @@ def page_header_buttons(page, page_perms, next_url=None):
             priority=30
         )
 
-    if page_perms.can_delete():
-        url = reverse('wagtailadmin_pages:delete', args=[page.id])
-
-        # After deleting the page, it is impossible to redirect to it.
-        if next_url == reverse('wagtailadmin_explore', args=[page.id]):
-            next_url = None
-
-        if next_url:
-            url += '?' + urlencode({'next': next_url})
-
-        yield Button(
-            _('Delete'),
-            url,
-            attrs={'title': _("Delete page '%(title)s'") % {'title': page.get_admin_display_title()}},
-            priority=40
-        )
-
 
 @hooks.register('register_admin_urls')
 def register_viewsets_urls():


### PR DESCRIPTION
After user testing the secondary menu from #7783:

> We think for now, we should put it (the delete button) back in the main bottom drop-up menu. This avoids people missing it, and means the new menu just adds functionality for power users.
