### PR TITLE
Add locale labels in reports

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/home/locked_pages.html
+++ b/wagtail/admin/templates/wagtailadmin/home/locked_pages.html
@@ -22,6 +22,12 @@
                         <td class="title" valign="top">
                             <div class="title-wrapper">
                                 <a href="{% url 'wagtailadmin_pages:edit' page.id %}" title="{% trans 'Edit this page' %}">{{ page.get_admin_display_title }}</a>
+
+                                {% i18n_enabled as show_locale_labels %}
+                                {% if show_locale_labels and page.locale_id %}
+                                    {% locale_label_from_id page.locale_id as locale_label %}
+                                    <span class="status-tag status-tag--label">{{ locale_label }}</span>
+                                {% endif %}
                                 {% include "wagtailadmin/pages/listing/_privacy_indicator.html" with page=page %}
                                 {% include "wagtailadmin/pages/listing/_locked_indicator.html" with page=page %}
                             </div>

--- a/wagtail/admin/templates/wagtailadmin/home/pages_for_moderation.html
+++ b/wagtail/admin/templates/wagtailadmin/home/pages_for_moderation.html
@@ -30,6 +30,11 @@
                                     {{ revision.page.specific_deferred.get_admin_display_title }}
                                 {% endif %}
 
+                                {% i18n_enabled as show_locale_labels %}
+                                {% if show_locale_labels and revision.page.locale_id %}
+                                    {% locale_label_from_id revision.page.locale_id as locale_label %}
+                                    <span class="status-tag status-tag--label">{{ locale_label }}</span>
+                                {% endif %}
                                 {% include "wagtailadmin/pages/listing/_privacy_indicator.html" with page=revision.page %}
                                 {% include "wagtailadmin/pages/listing/_locked_indicator.html" with page=revision.page %}
                             </div>

--- a/wagtail/admin/templates/wagtailadmin/home/recent_edits.html
+++ b/wagtail/admin/templates/wagtailadmin/home/recent_edits.html
@@ -21,6 +21,11 @@
                             <div class="title-wrapper">
                                 <a href="{% url 'wagtailadmin_pages:edit' page.id %}" title="{% trans 'Edit this page' %}">{{ page.get_admin_display_title }}</a>
 
+                                {% i18n_enabled as show_locale_labels %}
+                                {% if show_locale_labels and page.locale_id %}
+                                    {% locale_label_from_id page.locale_id as locale_label %}
+                                    <span class="status-tag status-tag--label">{{ locale_label }}</span>
+                                {% endif %}
                                 {% include "wagtailadmin/pages/listing/_privacy_indicator.html" with page=page %}
                                 {% include "wagtailadmin/pages/listing/_locked_indicator.html" with page=page %}
                             </div>

--- a/wagtail/admin/templates/wagtailadmin/home/user_pages_in_workflow_moderation.html
+++ b/wagtail/admin/templates/wagtailadmin/home/user_pages_in_workflow_moderation.html
@@ -27,6 +27,11 @@
                                 {{ workflow_state.page.specific_deferred.get_admin_display_title }}
                             {% endif %}
 
+                            {% i18n_enabled as show_locale_labels %}
+                            {% if show_locale_labels and workflow_state.page.locale_id %}
+                                {% locale_label_from_id workflow_state.page.locale_id as locale_label %}
+                                <span class="status-tag status-tag--label">{{ locale_label }}</span>
+                            {% endif %}
                             {% include "wagtailadmin/pages/listing/_privacy_indicator.html" with page=workflow_state.page %}
                             {% include "wagtailadmin/pages/listing/_locked_indicator.html" with page=workflow_state.page %}
                         </div>

--- a/wagtail/admin/templates/wagtailadmin/home/workflow_pages_to_moderate.html
+++ b/wagtail/admin/templates/wagtailadmin/home/workflow_pages_to_moderate.html
@@ -29,6 +29,11 @@
                                         {{ revision.page.specific_deferred.get_admin_display_title }}
                                     {% endif %}
 
+                                    {% i18n_enabled as show_locale_labels %}
+                                    {% if show_locale_labels and revision.page.locale_id %}
+                                        {% locale_label_from_id revision.page.locale_id as locale_label %}
+                                        <span class="status-tag status-tag--label">{{ locale_label }}</span>
+                                    {% endif %}
                                     {% include "wagtailadmin/pages/listing/_privacy_indicator.html" with page=revision.page %}
                                     {% include "wagtailadmin/pages/listing/_locked_indicator.html" with page=revision.page %}
                                 </div>

--- a/wagtail/admin/templates/wagtailadmin/reports/aging_pages.html
+++ b/wagtail/admin/templates/wagtailadmin/reports/aging_pages.html
@@ -28,6 +28,11 @@
                             <a href="{% url 'wagtailadmin_pages:edit' page.id %}">
                                 {{ page.specific_deferred.get_admin_display_title }}
                             </a>
+                            {% i18n_enabled as show_locale_labels %}
+                            {% if show_locale_labels %}
+                                {% locale_label_from_id page.locale_id as locale_label %}
+                                <span class="status-tag status-tag--label">{{ locale_label }}</span>
+                            {% endif %}
                         </td>
                         <td class="status" valign="top">
                             {% include "wagtailadmin/shared/page_status_tag.html" with page=page %}

--- a/wagtail/admin/templates/wagtailadmin/reports/listing/_list_page_report.html
+++ b/wagtail/admin/templates/wagtailadmin/reports/listing/_list_page_report.html
@@ -1,6 +1,6 @@
 {% extends "wagtailadmin/pages/listing/_list.html" %}
 
-{% load i18n %}
+{% load i18n wagtailadmin_tags %}
 
 {% block post_parent_page_headers %}
 <tr class="table-headers">
@@ -22,7 +22,8 @@
 {% endblock %}
 
 {% block page_title %}
-    {% include "wagtailadmin/pages/listing/_page_title_explore.html" %}
+    {% i18n_enabled as show_locale_labels %}
+    {% include "wagtailadmin/pages/listing/_page_title_explore.html" with show_locale_labels=show_locale_labels %}
 {% endblock %}
 
 {% block page_navigation %}

--- a/wagtail/admin/templates/wagtailadmin/reports/workflow.html
+++ b/wagtail/admin/templates/wagtailadmin/reports/workflow.html
@@ -43,6 +43,11 @@
                             <a href="{% url 'wagtailadmin_pages:edit' workflow_state.page.id %}">
                                 {{ workflow_state.page.specific_deferred.get_admin_display_title }}
                             </a>
+                            {% i18n_enabled as show_locale_labels %}
+                            {% if show_locale_labels %}
+                                {% locale_label_from_id workflow_state.page.locale_id as locale_label %}
+                                <span class="status-tag status-tag--label">{{ locale_label }}</span>
+                            {% endif %}
                         </td>
                         <td>
                             <a href="{% url 'wagtailadmin_pages:workflow_history_detail' workflow_state.page.id workflow_state.id %}" class="status-tag primary">

--- a/wagtail/admin/templates/wagtailadmin/reports/workflow_tasks.html
+++ b/wagtail/admin/templates/wagtailadmin/reports/workflow_tasks.html
@@ -41,6 +41,11 @@
                                 <a href="{% url 'wagtailadmin_pages:edit' page.id %}">
                                     {{ page.specific_deferred.get_admin_display_title }}
                                 </a>
+                                {% i18n_enabled as show_locale_labels %}
+                                {% if show_locale_labels %}
+                                    {% locale_label_from_id page.locale_id as locale_label %}
+                                    <span class="status-tag status-tag--label">{{ locale_label }}</span>
+                                {% endif %}
                             {% endwith %}
                         </td>
                         <td>

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -766,6 +766,24 @@ def locales():
     ])
 
 
+@register.simple_tag(takes_context=True)
+def locale_label_from_id(context, locale_id):
+    """
+    Returns the Locale display name given its id.
+    """
+    request = context['request']
+
+    # Cache the locale id -> locale display name mapping on the request
+    if not hasattr(request, '_wagtail_locales'):
+        locales_map = {}
+        for locale in Locale.objects.all():
+            locales_map[locale.pk] = locale.get_display_name()
+        setattr(request, '_wagtail_locales', locales_map)
+        context['request'] = request
+
+    return context['request']._wagtail_locales.get(locale_id)
+
+
 @register.simple_tag()
 def slim_sidebar_enabled():
     return getattr(settings, 'WAGTAIL_SLIM_SIDEBAR', True)

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -40,7 +40,7 @@ from wagtail.core.models import (
 from wagtail.core.telepath import JSContext
 from wagtail.core.utils import camelcase_to_underscore
 from wagtail.core.utils import cautious_slugify as _cautious_slugify
-from wagtail.core.utils import escape_script, get_content_type_label
+from wagtail.core.utils import escape_script, get_content_type_label, get_locales_display_names
 from wagtail.users.utils import get_gravatar_url
 
 
@@ -766,22 +766,12 @@ def locales():
     ])
 
 
-@register.simple_tag(takes_context=True)
-def locale_label_from_id(context, locale_id):
+@register.simple_tag
+def locale_label_from_id(locale_id):
     """
     Returns the Locale display name given its id.
     """
-    request = context['request']
-
-    # Cache the locale id -> locale display name mapping on the request
-    if not hasattr(request, '_wagtail_locales'):
-        locales_map = {}
-        for locale in Locale.objects.all():
-            locales_map[locale.pk] = locale.get_display_name()
-        setattr(request, '_wagtail_locales', locales_map)
-        context['request'] = request
-
-    return context['request']._wagtail_locales.get(locale_id)
+    return get_locales_display_names().get(locale_id)
 
 
 @register.simple_tag()

--- a/wagtail/admin/tests/test_templatetags.py
+++ b/wagtail/admin/tests/test_templatetags.py
@@ -4,7 +4,6 @@ from datetime import timedelta
 from unittest import mock
 
 from django.conf import settings
-from django.http import HttpRequest
 from django.template import Context, Template
 from django.test import TestCase
 from django.test.utils import override_settings
@@ -196,16 +195,12 @@ class TestInternationalisationTags(TestCase):
         )
 
     def test_locale_label_from_id(self):
-        context = {
-            "request": HttpRequest()
-        }
-
         with self.assertNumQueries(1):
-            self.assertEqual(locale_label_from_id(context, self.locale_ids[0]), "English")
+            self.assertEqual(locale_label_from_id(self.locale_ids[0]), "English")
 
         with self.assertNumQueries(0):
-            self.assertEqual(locale_label_from_id(context, self.locale_ids[1]), "French")
+            self.assertEqual(locale_label_from_id(self.locale_ids[1]), "French")
 
         # check with an invalid id
         with self.assertNumQueries(0):
-            self.assertIsNone(locale_label_from_id(context, self.locale_ids[-1] + 100), None)
+            self.assertIsNone(locale_label_from_id(self.locale_ids[-1] + 100), None)

--- a/wagtail/admin/views/reports/locked_pages.py
+++ b/wagtail/admin/views/reports/locked_pages.py
@@ -2,6 +2,7 @@ import datetime
 
 import django_filters
 
+from django.conf import settings
 from django.core.exceptions import PermissionDenied
 from django.utils.translation import gettext_lazy as _
 
@@ -39,6 +40,10 @@ class LockedPagesView(PageReportView):
             UserPagePermissionsProxy(self.request.user).editable_pages()
             | Page.objects.filter(locked_by=self.request.user)
         ).filter(locked=True).specific(defer=True)
+
+        if getattr(settings, 'WAGTAIL_I18N_ENABLED', False):
+            pages = pages.select_related('locale')
+
         self.queryset = pages
         return super().get_queryset()
 

--- a/wagtail/core/signal_handlers.py
+++ b/wagtail/core/signal_handlers.py
@@ -3,7 +3,8 @@ import logging
 from django.core.cache import cache
 from django.db.models.signals import post_delete, post_save, pre_delete
 
-from wagtail.core.models import Page, Site
+from wagtail.core.models import Locale, Page, Site
+from wagtail.core.utils import get_locales_display_names
 
 
 logger = logging.getLogger('wagtail.core')
@@ -29,9 +30,16 @@ def post_delete_page_log_deletion(sender, instance, **kwargs):
     logger.info("Page deleted: \"%s\" id=%d", instance.title, instance.id)
 
 
+def reset_locales_display_names_cache(sender, instance, **kwargs):
+    get_locales_display_names.cache_clear()
+
+
 def register_signal_handlers():
     post_save.connect(post_save_site_signal_handler, sender=Site)
     post_delete.connect(post_delete_site_signal_handler, sender=Site)
 
     pre_delete.connect(pre_delete_page_unpublish, sender=Page)
     post_delete.connect(post_delete_page_log_deletion, sender=Page)
+
+    post_save.connect(reset_locales_display_names_cache, sender=Locale)
+    post_delete.connect(reset_locales_display_names_cache, sender=Locale)

--- a/wagtail/core/utils.py
+++ b/wagtail/core/utils.py
@@ -309,6 +309,20 @@ def get_supported_content_language_variant(lang_code, strict=False):
     raise LookupError(lang_code)
 
 
+@functools.lru_cache()
+def get_locales_display_names() -> dict:
+    """
+    Cache of the locale id -> locale display name mapping
+    """
+    from wagtail.core.models import Locale  # inlined to avoid circular imports
+
+    locales_map = {
+        locale.pk: locale.get_display_name()
+        for locale in Locale.objects.all()
+    }
+    return locales_map
+
+
 @receiver(setting_changed)
 def reset_cache(**kwargs):
     """


### PR DESCRIPTION
This builds on #7837 and adds the locale label to the:

* ~site history report~
* workflow/workflow tasks reports
* locked pages report
* aging pages report
* dashboard summary panels.

Note: so far added a test to check for the existence of the labels in the site history view. Shall I add them for all the rest?