### PR TITLE
Slim sidebar UI and accessibility fixes, plus mobile support

### DIFF
--- a/client/scss/components/_messages.scss
+++ b/client/scss/components/_messages.scss
@@ -4,7 +4,6 @@
 // For inline help text, see typography.scss
 .messages {
     position: relative;
-    z-index: 5;
     background-color: $color-grey-1;
 
     .buttons {

--- a/client/scss/components/_skiplink.scss
+++ b/client/scss/components/_skiplink.scss
@@ -3,7 +3,7 @@
     position: fixed;
     top: -1000rem;
     left: 1rem;
-    z-index: 30;
+    z-index: 3000;
 
     &:focus {
         top: 1rem;

--- a/client/scss/settings/_variables.scss
+++ b/client/scss/settings/_variables.scss
@@ -108,6 +108,9 @@ $menu-width-max: 320px;
 
 $mobile-nav-indent: 50px;
 
+$sidebar-toggle-spacing: 12px;
+$sidebar-toggle-size: 35px;
+
 // transitions
 // Please keep in sync with SIDEBAR_TRANSITION_DURATION variable in `client/src/components/Sidebar/Sidebar.tsx`
 $menu-transition-duration: 150ms;

--- a/client/src/components/PageExplorer/PageExplorer.scss
+++ b/client/src/components/PageExplorer/PageExplorer.scss
@@ -62,7 +62,9 @@ $menu-footer-height: 50px;
 }
 
 .c-page-explorer__header {
-    display: block;
+    display: grid;
+    grid-template-columns: 1fr auto;
+    align-items: center;
     background-color: $c-page-explorer-bg-dark;
     border-bottom: 1px solid $c-page-explorer-bg-dark;
     color: $color-white;
@@ -87,8 +89,6 @@ $menu-footer-height: 50px;
 }
 
 .c-page-explorer__header__title__inner {
-    width: 70%;
-    float: left;
     padding: 1em 0.75em;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -115,16 +115,11 @@ $menu-footer-height: 50px;
 
 .c-page-explorer__header__select {
     $margin: 10px;
-    position: relative;
 
     > select {
-        width: calc(30% - #{$margin * 2});
-        height: calc(100% - #{$margin * 2});
-        margin-top: $margin;
-        margin-right: $margin;
-        float: right;
         padding: 0;
         padding-left: 10px;
+        padding-right: 30px;
 
         background-color: $c-page-explorer-bg-dark;
         border-radius: 0;

--- a/client/src/components/PageExplorer/PageExplorer.scss
+++ b/client/src/components/PageExplorer/PageExplorer.scss
@@ -28,7 +28,7 @@ $menu-footer-height: 50px;
     display: flex;
     flex-direction: column;
     height: 100%;
-    z-index: 150;
+    z-index: 350;
 }
 
 .c-page-explorer__close {

--- a/client/src/components/PageExplorer/PageExplorer.scss
+++ b/client/src/components/PageExplorer/PageExplorer.scss
@@ -8,7 +8,8 @@ $menu-footer-height: 50px;
 @import 'PageExplorerItem';
 
 .c-page-explorer {
-    width: 485px;
+    max-width: 485px;
+    width: 90vw;
     height: 100vh;
     background: $c-page-explorer-bg;
     overflow: hidden;
@@ -20,6 +21,7 @@ $menu-footer-height: 50px;
 
 
     @include media-breakpoint-up(sm) {
+        width: 485px;
         box-shadow: 2px 2px 5px $c-page-explorer-bg-active;
     }
 }
@@ -31,35 +33,13 @@ $menu-footer-height: 50px;
     z-index: 350;
 }
 
-.c-page-explorer__close {
-    padding: 1em;
-    color: $c-page-explorer-secondary;
-    border-bottom: 1px solid rgba(200, 200, 200, 0.1);
-    cursor: pointer;
-    display: none;
-
-    &:focus {
-        background-color: $c-page-explorer-bg-active;
-        color: $color-white;
-    }
-
-    // Overrides for default link hover.
-    &:hover {
-        color: $c-page-explorer-secondary;
-    }
-
-    @include media-breakpoint-down(xs) {
-        .explorer-open & {
-            display: block;
-        }
-    }
-}
-
 .c-page-explorer__drawer {
     flex: 1;
     overflow-y: auto;
     -webkit-overflow-scrolling: touch;
 }
+
+$explorer-header-horizontal-padding: 10px;
 
 .c-page-explorer__header {
     display: grid;
@@ -68,6 +48,13 @@ $menu-footer-height: 50px;
     background-color: $c-page-explorer-bg-dark;
     border-bottom: 1px solid $c-page-explorer-bg-dark;
     color: $color-white;
+    margin-inline-start: $sidebar-toggle-spacing * 2 + $sidebar-toggle-size;
+    height: $sidebar-toggle-spacing * 2 + $sidebar-toggle-size;
+
+    @include media-breakpoint-up(sm) {
+        margin-inline-start: initial;
+        height: initial;
+    }
 }
 
 .c-page-explorer__header__title {
@@ -89,7 +76,7 @@ $menu-footer-height: 50px;
 }
 
 .c-page-explorer__header__title__inner {
-    padding: 1em 0.75em;
+    padding: 1em $explorer-header-horizontal-padding;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;

--- a/client/src/components/PageExplorer/PageExplorerPanel.test.js
+++ b/client/src/components/PageExplorer/PageExplorerPanel.test.js
@@ -133,37 +133,4 @@ describe('PageExplorerPanel', () => {
       expect(wrapper.setProps({ depth: 0 }).state('transition')).toBe('pop');
     });
   });
-
-  describe('clickOutside', () => {
-    afterEach(() => {
-      mockProps.onClose.mockReset();
-    });
-
-    it('triggers onClose when click is outside', () => {
-      document.body.innerHTML = '<div data-explorer-menu-item></div><div data-explorer-menu></div><div id="t"></div>';
-      const wrapper = shallow(<PageExplorerPanel {...mockProps} />);
-      wrapper.instance().clickOutside({
-        target: document.querySelector('#t'),
-      });
-      expect(mockProps.onClose).toHaveBeenCalled();
-    });
-
-    it('does not trigger onClose when click is inside', () => {
-      document.body.innerHTML = '<div data-explorer-menu-item></div><div data-explorer-menu><div id="t"></div></div>';
-      const wrapper = shallow(<PageExplorerPanel {...mockProps} />);
-      wrapper.instance().clickOutside({
-        target: document.querySelector('#t'),
-      });
-      expect(mockProps.onClose).not.toHaveBeenCalled();
-    });
-
-    it('pauses focus trap inside toggle', () => {
-      document.body.innerHTML = '<div data-explorer-menu-item><div id="t"></div></div><div data-explorer-menu></div>';
-      const wrapper = shallow(<PageExplorerPanel {...mockProps} />);
-      wrapper.instance().clickOutside({
-        target: document.querySelector('#t'),
-      });
-      expect(wrapper.state('paused')).toEqual(true);
-    });
-  });
 });

--- a/client/src/components/PageExplorer/PageExplorerPanel.tsx
+++ b/client/src/components/PageExplorer/PageExplorerPanel.tsx
@@ -22,7 +22,6 @@ interface PageExplorerPanelProps {
 
 interface PageExplorerPanelState {
   transition: typeof PUSH | typeof POP;
-  paused: boolean;
 }
 
 /**
@@ -35,12 +34,10 @@ class PageExplorerPanel extends React.Component<PageExplorerPanelProps, PageExpl
 
     this.state = {
       transition: PUSH,
-      paused: false,
     };
 
     this.onItemClick = this.onItemClick.bind(this);
     this.onHeaderClick = this.onHeaderClick.bind(this);
-    this.clickOutside = this.clickOutside.bind(this);
   }
 
   componentWillReceiveProps(newProps) {
@@ -50,27 +47,6 @@ class PageExplorerPanel extends React.Component<PageExplorerPanelProps, PageExpl
     this.setState({
       transition: isPush ? PUSH : POP,
     });
-  }
-
-  clickOutside(e) {
-    const { onClose } = this.props;
-    const explorer = document.querySelector('[data-explorer-menu]');
-    const toggle = document.querySelector('[data-explorer-menu-item]');
-
-    if (!explorer || !toggle) {
-      return;
-    }
-
-    const isInside = explorer.contains(e.target) || toggle.contains(e.target);
-    if (!isInside) {
-      onClose();
-    }
-
-    if (toggle.contains(e.target)) {
-      this.setState({
-        paused: true,
-      });
-    }
   }
 
   onItemClick(id, e) {

--- a/client/src/components/Sidebar/Sidebar.scss
+++ b/client/src/components/Sidebar/Sidebar.scss
@@ -33,7 +33,7 @@
     flex-direction: column;
     height: 100%;
     background: $nav-grey-3;
-    z-index: 3;
+    z-index: 300;
 
     @include transition(width $menu-transition-duration ease, left $menu-transition-duration ease);
 
@@ -78,7 +78,7 @@
 .sidebar-nav-toggle {
     @include sidebar-toggle;
     display: none;  // Nav toggle is for mobile only
-    z-index: 5;
+    z-index: 305;
 
     &:hover {
         background: var(--color-primary-dark);

--- a/client/src/components/Sidebar/Sidebar.scss
+++ b/client/src/components/Sidebar/Sidebar.scss
@@ -2,11 +2,11 @@
     @include transition(background-color $menu-transition-duration ease);
 
     position: absolute;
-    top: 12px;
-    left: 12px;
+    top: $sidebar-toggle-spacing;
+    left: $sidebar-toggle-spacing;
     color: $color-white;
-    width: 35px;
-    height: 35px;
+    width: $sidebar-toggle-size;
+    height: $sidebar-toggle-size;
     background: transparent;
     border: 0;
     place-items: center;
@@ -67,7 +67,7 @@
     // This element should cover all the area beneath the collapse toggle
     // It's only used to attach mouse enter/exit event handlers to control peeking
     &__peek-hover-area {
-        margin-top: 35px;  // Match height of __collapse-toggle
+        margin-top: $sidebar-toggle-size;
         display: grid;
         grid-template-columns: 1fr;
         overflow-y: scroll;

--- a/client/src/components/Sidebar/Sidebar.scss
+++ b/client/src/components/Sidebar/Sidebar.scss
@@ -22,6 +22,14 @@
         width: 15px;
         height: 16px;
     }
+
+    .has-messages & {
+        top: $sidebar-toggle-spacing + 70px;
+
+        @include media-breakpoint-up(sm) {
+            top: $sidebar-toggle-spacing;
+        }
+    }
 }
 
 .sidebar {

--- a/client/src/components/Sidebar/Sidebar.tsx
+++ b/client/src/components/Sidebar/Sidebar.tsx
@@ -9,6 +9,8 @@ export interface Strings {
   DASHBOARD: string;
   EDIT_YOUR_ACCOUNT: string,
   SEARCH: string,
+  TOGGLE_SIDEBAR: string,
+  MAIN_MENU: string,
 }
 
 export interface ModuleRenderContext {
@@ -166,7 +168,7 @@ export const Sidebar: React.FunctionComponent<SidebarProps> = (
 
   return (
     <>
-      <aside
+      <div
         className={
           'sidebar'
           + (slim ? ' sidebar--slim' : '')
@@ -175,7 +177,12 @@ export const Sidebar: React.FunctionComponent<SidebarProps> = (
         }
       >
         <div className="sidebar__inner">
-          <button onClick={onClickCollapseToggle} className="button sidebar__collapse-toggle">
+          <button
+            onClick={onClickCollapseToggle}
+            aria-label={strings.TOGGLE_SIDEBAR}
+            aria-expanded={!slim}
+            className="button sidebar__collapse-toggle"
+          >
             {collapsed ? <Icon name="angle-double-right" /> : <Icon name="angle-double-left" />}
           </button>
 
@@ -189,9 +196,11 @@ export const Sidebar: React.FunctionComponent<SidebarProps> = (
             {renderedModules}
           </div>
         </div>
-      </aside>
+      </div>
       <button
         onClick={onClickOpenCloseToggle}
+        aria-label={strings.TOGGLE_SIDEBAR}
+        aria-expanded={visibleOnMobile}
         className={
           'button sidebar-nav-toggle'
           + (isMobile ? ' sidebar-nav-toggle--mobile' : '')

--- a/client/src/components/Sidebar/SidebarPanel.scss
+++ b/client/src/components/Sidebar/SidebarPanel.scss
@@ -8,32 +8,41 @@
     height: 100vh;
     padding: 0;
     top: 0;
-    left: calc(#{$menu-width} - var(--width));
+    left: 0;
+    z-index: 400;
     display: flex;
     flex-direction: column;
     overflow: hidden;
 
     @include transition(left $menu-transition-duration ease);
 
+    @include media-breakpoint-up(sm) {
+        z-index: var(--z-index);
+        width: var(--width);
+        left: calc(#{$menu-width} - var(--width));
+    }
+
     &--visible {
         visibility: visible;
         box-shadow: 2px 0 2px rgba(0, 0, 0, 0.35);
     }
 
-    @at-root .sidebar--slim #{&} {
-        left: calc(#{$menu-width-slim} - var(--width));
-    }
-    // Don't apply this to nested submenus though
-    @at-root .sidebar--slim .sidebar-panel #{&} {
-        left: 0;
-    }
-
-    &--open {
-        left: $menu-width;
-
+    @include media-breakpoint-up(sm) {
+        @at-root .sidebar--slim #{&} {
+            left: calc(#{$menu-width-slim} - var(--width));
+        }
         // Don't apply this to nested submenus though
         @at-root .sidebar--slim .sidebar-panel #{&} {
+            left: 0;
+        }
+
+        &--open {
             left: $menu-width;
+
+            // Don't apply this to nested submenus though
+            @at-root .sidebar--slim .sidebar-panel #{&} {
+                left: $menu-width;
+            }
         }
     }
 }

--- a/client/src/components/Sidebar/SidebarPanel.tsx
+++ b/client/src/components/Sidebar/SidebarPanel.tsx
@@ -17,13 +17,18 @@ export const SidebarPanel: React.FunctionComponent<SidebarPanelProps> = (
     + (isOpen ? ' sidebar-panel--open' : '')
   );
 
-  const style = { zIndex: -depth * 2 };
+  let zIndex = -depth * 2;
 
   const isClosing = isVisible && !isOpen;
   if (isClosing) {
     // When closing, make sure this panel displays behind any new panel that is opening
-    style.zIndex--;
+    zIndex--;
   }
+
+  const style = {
+    // See https://github.com/frenic/csstype#what-should-i-do-when-i-get-type-errors.
+    ['--z-index' as any]: zIndex,
+  };
 
   if (widthPx) {
     style['--width'] = widthPx + 'px';

--- a/client/src/components/Sidebar/menu/LinkMenuItem.tsx
+++ b/client/src/components/Sidebar/menu/LinkMenuItem.tsx
@@ -45,39 +45,8 @@ export const LinkMenuItem: React.FunctionComponent<MenuItemProps<LinkMenuItemDef
     + (isInSubMenu ? ' sidebar-menu-item--in-sub-menu' : '')
   );
 
-  const [peeking, setPeeking] = React.useState(false);
-  const wrapperRef = React.useRef<HTMLLIElement | null>(null);
-  React.useEffect(() => {
-    if (!wrapperRef.current) {
-      return;
-    }
-
-    const element = wrapperRef.current;
-    let startPeekingTimeout;
-    let stopPeekingTimeout;
-
-    const onMouseEnterHandler = () => {
-      clearTimeout(startPeekingTimeout);
-      clearTimeout(stopPeekingTimeout);
-      startPeekingTimeout = setTimeout(() => {
-        setPeeking(true);
-      }, 250);
-    };
-
-    const onMouseLeaveHandler = () => {
-      clearTimeout(startPeekingTimeout);
-      clearTimeout(stopPeekingTimeout);
-      stopPeekingTimeout = setTimeout(() => {
-        setPeeking(false);
-      }, 250);
-    };
-
-    element.addEventListener('mouseenter', onMouseEnterHandler);
-    element.addEventListener('mouseleave', onMouseLeaveHandler);
-  }, []);
-
   return (
-    <li className={className} ref={wrapperRef}>
+    <li className={className}>
       <a
         href={item.url}
         aria-current={isCurrent ? 'page' : undefined}
@@ -86,11 +55,6 @@ export const LinkMenuItem: React.FunctionComponent<MenuItemProps<LinkMenuItemDef
       >
         {item.iconName && <Icon name={item.iconName} className="icon--menuitem" />}
         <span className="menuitem-label">{item.label}</span>
-        <div className={'menuitem-tooltip' + (peeking ? ' menuitem-tooltip--visible' : '')}>
-          <div className="menuitem-tooltip__inner">
-            {item.label}
-          </div>
-        </div>
       </a>
     </li>
   );

--- a/client/src/components/Sidebar/menu/LinkMenuItem.tsx
+++ b/client/src/components/Sidebar/menu/LinkMenuItem.tsx
@@ -11,6 +11,16 @@ export const LinkMenuItem: React.FunctionComponent<MenuItemProps<LinkMenuItemDef
   const isInSubMenu = path.split('.').length > 2;
 
   const onClick = (e: React.MouseEvent) => {
+    // Do not capture click events with modifier keys or non-main buttons.
+    if (
+      e.ctrlKey ||
+      e.shiftKey ||
+      e.metaKey ||
+      (e.button && e.button !== 0)
+    ) {
+      return;
+    }
+
     e.preventDefault();
 
     navigate(item.url).then(() => {
@@ -67,7 +77,11 @@ export const LinkMenuItem: React.FunctionComponent<MenuItemProps<LinkMenuItemDef
 
   return (
     <li className={className} ref={wrapperRef}>
-      <a href="#" onClick={onClick} className={`sidebar-menu-item__link ${item.classNames}`}>
+      <a
+        href={item.url}
+        onClick={onClick}
+        className={`sidebar-menu-item__link ${item.classNames}`}
+      >
         {item.iconName && <Icon name={item.iconName} className="icon--menuitem" />}
         <span className="menuitem-label">{item.label}</span>
         <div className={'menuitem-tooltip' + (peeking ? ' menuitem-tooltip--visible' : '')}>

--- a/client/src/components/Sidebar/menu/LinkMenuItem.tsx
+++ b/client/src/components/Sidebar/menu/LinkMenuItem.tsx
@@ -7,6 +7,7 @@ import { MenuItemDefinition, MenuItemProps } from './MenuItem';
 
 export const LinkMenuItem: React.FunctionComponent<MenuItemProps<LinkMenuItemDefinition>> = (
   { item, path, state, dispatch, navigate }) => {
+  const isCurrent = state.activePath === path;
   const isActive = state.activePath.startsWith(path);
   const isInSubMenu = path.split('.').length > 2;
 
@@ -79,6 +80,7 @@ export const LinkMenuItem: React.FunctionComponent<MenuItemProps<LinkMenuItemDef
     <li className={className} ref={wrapperRef}>
       <a
         href={item.url}
+        aria-current={isCurrent ? 'page' : undefined}
         onClick={onClick}
         className={`sidebar-menu-item__link ${item.classNames}`}
       >

--- a/client/src/components/Sidebar/menu/MenuItem.scss
+++ b/client/src/components/Sidebar/menu/MenuItem.scss
@@ -9,6 +9,7 @@
         position: relative;
         display: block;
         width: 100%;
+        box-sizing: border-box;
         white-space: nowrap;
         border-left: 3px solid transparent;
 

--- a/client/src/components/Sidebar/menu/MenuItem.scss
+++ b/client/src/components/Sidebar/menu/MenuItem.scss
@@ -83,55 +83,6 @@
     margin-left: 0.5em;
 }
 
-.menuitem-tooltip {
-    position: absolute;
-    left: calc(100% + 5px);
-    z-index: 5;
-    top: 0;
-    bottom: 0;
-    margin: auto 0;
-    height: 27px;
-    pointer-events: none;
-    opacity: 0;
-    transform: translate3d(-20px, 0, 0);
-    transition: opacity $menu-transition-duration cubic-bezier(0.42, 0, 0.58, 1), transform $menu-transition-duration cubic-bezier(0.42, 0, 0.58, 1);
-
-    &__inner {
-        width: 100%;
-        box-sizing: border-box;
-        border-radius: 3px;
-        position: relative;
-        padding: 7px 9px;
-        color: #ccc;
-        height: 27px;
-        font-size: 12px;
-        line-height: 11px;
-        background: #262626;
-
-        &::before {
-            content: '';
-            position: absolute;
-            display: block;
-            width: 0;
-            left: 0;
-            top: 50%;
-            height: 0;
-            border-style: solid;
-            border-width: 5px 5px 5px 0;
-            border-color: transparent #262626 transparent transparent;
-            transform: translate(calc(-100%), -50%);
-        }
-    }
-
-    &--visible {
-        .sidebar-collapsed & {
-            pointer-events: initial;
-            opacity: 1;
-            transform: translate3d(0, 0, 0);
-        }
-    }
-}
-
 .sidebar--slim {
     .menuitem-label {
         opacity: 0;

--- a/client/src/components/Sidebar/menu/MenuItem.scss
+++ b/client/src/components/Sidebar/menu/MenuItem.scss
@@ -8,11 +8,14 @@
         @include transition(border-color $menu-transition-duration ease, background-color $menu-transition-duration ease);
         position: relative;
         display: block;
+        width: 100%;
         white-space: nowrap;
         border-left: 3px solid transparent;
 
         -webkit-font-smoothing: auto;
-        text-decoration: none;
+        border: 0;
+        background: transparent;
+        text-align: left;
         color: $color-menu-text;
         padding: 11px 20px;
         font-size: 13px;

--- a/client/src/components/Sidebar/menu/SubMenuItem.tsx
+++ b/client/src/components/Sidebar/menu/SubMenuItem.tsx
@@ -65,8 +65,7 @@ export const SubMenuItem: React.FunctionComponent<SubMenuItemProps> = (
 
   return (
     <li className={className}>
-      <a
-        href="#"
+      <button
         onClick={onClick}
         className={`sidebar-menu-item__link ${item.classNames}`}
         aria-haspopup="true"
@@ -75,7 +74,7 @@ export const SubMenuItem: React.FunctionComponent<SubMenuItemProps> = (
         {item.iconName && <Icon name={item.iconName} className="icon--menuitem" />}
         <span className="menuitem-label">{item.label}</span>
         <Icon className={sidebarTriggerIconClassName} name="arrow-right" />
-      </a>
+      </button>
       <SidebarPanel isVisible={isVisible} isOpen={isOpen} depth={depth}>
         <div className="sidebar-sub-menu-panel">
           <h2 id={`wagtail-sidebar-submenu${path.split('.').join('-')}-title`} className={item.classNames}>

--- a/client/src/components/Sidebar/modules/CustomBranding.tsx
+++ b/client/src/components/Sidebar/modules/CustomBranding.tsx
@@ -7,10 +7,17 @@ interface CustomBrandingProps {
   homeUrl: string;
   html: string;
   strings;
+  currentPath: string;
   navigate(url: string): void;
 }
 
-const CustomBranding: React.FunctionComponent<CustomBrandingProps> = ({ homeUrl, html, strings, navigate }) => {
+const CustomBranding: React.FunctionComponent<CustomBrandingProps> = ({
+  homeUrl,
+  html,
+  strings,
+  currentPath,
+  navigate,
+}) => {
   const onClick = (e: React.MouseEvent) => {
     // Do not capture click events with modifier keys or non-main buttons.
     if (
@@ -32,6 +39,7 @@ const CustomBranding: React.FunctionComponent<CustomBrandingProps> = ({ homeUrl,
       href={homeUrl}
       onClick={onClick}
       aria-label={strings.DASHBOARD}
+      aria-current={currentPath === homeUrl ? 'page' : undefined}
       dangerouslySetInnerHTML={{ __html: html }}
     />
   );
@@ -46,7 +54,14 @@ export class CustomBrandingModuleDefinition implements ModuleDefinition {
     this.html = html;
   }
 
-  render({ strings, navigate, key }) {
-    return <CustomBranding key={key} homeUrl={this.homeUrl} html={this.html} strings={strings} navigate={navigate} />;
+  render({ strings, currentPath, navigate, key }) {
+    return (<CustomBranding
+      key={key}
+      homeUrl={this.homeUrl}
+      html={this.html}
+      strings={strings}
+      currentPath={currentPath}
+      navigate={navigate}
+    />);
   }
 }

--- a/client/src/components/Sidebar/modules/CustomBranding.tsx
+++ b/client/src/components/Sidebar/modules/CustomBranding.tsx
@@ -12,6 +12,16 @@ interface CustomBrandingProps {
 
 const CustomBranding: React.FunctionComponent<CustomBrandingProps> = ({ homeUrl, html, strings, navigate }) => {
   const onClick = (e: React.MouseEvent) => {
+    // Do not capture click events with modifier keys or non-main buttons.
+    if (
+      e.ctrlKey ||
+      e.shiftKey ||
+      e.metaKey ||
+      (e.button && e.button !== 0)
+    ) {
+      return;
+    }
+
     e.preventDefault();
     navigate(homeUrl);
   };
@@ -19,7 +29,7 @@ const CustomBranding: React.FunctionComponent<CustomBrandingProps> = ({ homeUrl,
   return (
     <a
       className="sidebar-custom-branding"
-      href="#"
+      href={homeUrl}
       onClick={onClick}
       aria-label={strings.DASHBOARD}
       dangerouslySetInnerHTML={{ __html: html }}

--- a/client/src/components/Sidebar/modules/MainMenu.tsx
+++ b/client/src/components/Sidebar/modules/MainMenu.tsx
@@ -128,10 +128,26 @@ export const Menu: React.FunctionComponent<MenuProps> = (
       }
     };
 
+    const onClickOutside = (e: MouseEvent | TouchEvent) => {
+      const sidebar = document.querySelector('[data-wagtail-sidebar]');
+
+      const isInside = sidebar && sidebar.contains(e.target as Node);
+      if (!isInside) {
+        dispatch({
+          type: 'set-navigation-path',
+          path: ''
+        });
+      }
+    };
+
     document.addEventListener('keydown', onKeydown);
+    document.addEventListener('mousedown', onClickOutside);
+    document.addEventListener('touchend', onClickOutside);
 
     return () => {
       document.removeEventListener('keydown', onKeydown);
+      document.removeEventListener('mousedown', onClickOutside);
+      document.removeEventListener('touchend', onClickOutside);
     };
   }, []);
 

--- a/client/src/components/Sidebar/modules/MainMenu.tsx
+++ b/client/src/components/Sidebar/modules/MainMenu.tsx
@@ -96,6 +96,7 @@ export const Menu: React.FunctionComponent<MenuProps> = (
     };
 
     walkMenu('', menuItems);
+    walkMenu('', accountMenuItems);
 
     let bestMatch: [string, string] | null = null;
     urlPathsToNavigationPaths.forEach(([urlPath, navPath]) => {

--- a/client/src/components/Sidebar/modules/MainMenu.tsx
+++ b/client/src/components/Sidebar/modules/MainMenu.tsx
@@ -168,7 +168,7 @@ export const Menu: React.FunctionComponent<MenuProps> = (
 
   return (
     <>
-      <nav className={className}>
+      <nav className={className} aria-label={strings.MAIN_MENU}>
         <ul className="sidebar-main-menu__list">
           {renderMenu('', menuItems, slim, state, dispatch, navigate)}
         </ul>

--- a/client/src/components/Sidebar/modules/WagtailBranding.tsx
+++ b/client/src/components/Sidebar/modules/WagtailBranding.tsx
@@ -28,6 +28,16 @@ const WagtailBranding: React.FunctionComponent<WagtailBrandingProps> = ({ homeUr
 
 
   const onClick = (e: React.MouseEvent) => {
+    // Do not capture click events with modifier keys or non-main buttons.
+    if (
+      e.ctrlKey ||
+      e.shiftKey ||
+      e.metaKey ||
+      (e.button && e.button !== 0)
+    ) {
+      return;
+    }
+
     e.preventDefault();
     navigate(homeUrl);
   };
@@ -60,7 +70,7 @@ const WagtailBranding: React.FunctionComponent<WagtailBrandingProps> = ({ homeUr
 
   return (
     <a
-      className={desktopClassName} href="#" aria-label={strings.DASHBOARD}
+      className={desktopClassName} href={homeUrl} aria-label={strings.DASHBOARD}
       onClick={onClick} onMouseMove={onMouseMove} onMouseLeave={onMouseLeave}
     >
       <div className="sidebar-wagtail-branding__icon-wrapper">

--- a/client/src/components/Sidebar/modules/WagtailBranding.tsx
+++ b/client/src/components/Sidebar/modules/WagtailBranding.tsx
@@ -15,10 +15,17 @@ interface WagtailBrandingProps {
   homeUrl: string;
   images: LogoImages;
   strings: Strings;
+  currentPath: string;
   navigate(url: string): void;
 }
 
-const WagtailBranding: React.FunctionComponent<WagtailBrandingProps> = ({ homeUrl, images, strings, navigate }) => {
+const WagtailBranding: React.FunctionComponent<WagtailBrandingProps> = ({
+  homeUrl,
+  images,
+  strings,
+  currentPath,
+  navigate,
+}) => {
   // Tail wagging
   // If the pointer changes direction 8 or more times without leaving, wag the tail!
   const lastMouseX = React.useRef(0);
@@ -71,6 +78,7 @@ const WagtailBranding: React.FunctionComponent<WagtailBrandingProps> = ({ homeUr
   return (
     <a
       className={desktopClassName} href={homeUrl} aria-label={strings.DASHBOARD}
+      aria-current={currentPath === homeUrl ? 'page' : undefined}
       onClick={onClick} onMouseMove={onMouseMove} onMouseLeave={onMouseLeave}
     >
       <div className="sidebar-wagtail-branding__icon-wrapper">
@@ -95,10 +103,10 @@ export class WagtailBrandingModuleDefinition implements ModuleDefinition {
     this.images = images;
   }
 
-  render({ strings, key, navigate }) {
+  render({ strings, key, navigate, currentPath }) {
     return (<WagtailBranding
       key={key} homeUrl={this.homeUrl} images={this.images}
-      strings={strings} navigate={navigate}
+      strings={strings} navigate={navigate} currentPath={currentPath}
     />);
   }
 }

--- a/client/tests/stubs.js
+++ b/client/tests/stubs.js
@@ -65,6 +65,8 @@ global.wagtailConfig = {
     SAVE_PAGE_TO_ADD_COMMENT: 'Save the page to add this comment',
     SAVE_PAGE_TO_SAVE_COMMENT_CHANGES: 'Save the page to save this comment',
     SAVE_PAGE_TO_SAVE_REPLY: 'Save the page to save this reply',
+    TOGGLE_SIDEBAR: 'Toggle sidebar',
+    MAIN_MENU: 'Main menu',
   },
   WAGTAIL_I18N_ENABLED: true,
   LOCALES: [

--- a/wagtail/admin/localization.py
+++ b/wagtail/admin/localization.py
@@ -97,6 +97,8 @@ def get_js_translation_strings():
         'SAVE_PAGE_TO_ADD_COMMENT': _('Save the page to add this comment'),
         'SAVE_PAGE_TO_SAVE_COMMENT_CHANGES': _('Save the page to save this comment'),
         'SAVE_PAGE_TO_SAVE_REPLY': _('Save the page to save this reply'),
+        'TOGGLE_SIDEBAR': _('Toggle sidebar'),
+        'MAIN_MENU': _('Main menu'),
         'DASHBOARD': _('Dashboard'),
         'EDIT_YOUR_ACCOUNT': _('Edit your account'),
         'SEARCH': _('Search'),

--- a/wagtail/admin/templates/wagtailadmin/base.html
+++ b/wagtail/admin/templates/wagtailadmin/base.html
@@ -4,7 +4,7 @@
 {% block furniture %}
     {% slim_sidebar_enabled as slim_sidebar_enabled %}
     {% if slim_sidebar_enabled %}
-    <aside id="wagtail-sidebar" data-props="{% menu_props %}"></aside>
+    <aside id="wagtail-sidebar" data-wagtail-sidebar data-props="{% menu_props %}"></aside>
     {% else %}
     <aside id="wagtail-sidebar" class="nav-wrapper" data-nav-primary>
         <div class="inner">

--- a/wagtail/admin/ui/sidebar.py
+++ b/wagtail/admin/ui/sidebar.py
@@ -157,11 +157,16 @@ class MainMenuModule:
     def js_args(self):
         from wagtail.admin.templatetags.wagtailadmin_tags import avatar_url
 
+        try:
+            first_name = self.user.first_name
+        except AttributeError:
+            first_name = None
+
         return [
             self.menu_items,
             self.account_menu_items,
             {
-                'name': self.user.first_name or self.user.get_username(),
+                'name': first_name or self.user.get_username(),
                 'avatarUrl': avatar_url(self.user, size=50),
             }
         ]


### PR DESCRIPTION
Fixes all of the known issues I could find with the slim sidebar implementation, and adds the missing mobile support.

There are quite a lot of somewhat unrelated changes here, but I decided to keep it all as a single PR to simplify testing. For code review, I’ve kept each fix as a separate commit so it’s easier to understand the changes. They can be reviewed in order, or separately – here are thematic groupings with some extra info:

## Accessibility

- Support right-click and middle-click interactions with sidebar links 87020d1d7085e0f3d161e9a17f3ea5c5053da94b – by ensuring we only handle "left-click" events with no modifier keys, and adding a real `href` to menu items.
- Implement aria-current for sidebar links 87020d1d7085e0f3d161e9a17f3ea5c5053da94b
- Add ARIA markup for sidebar regions and toggle buttons 695f67f50279b3af9f8342461165e801fac60037 – straightforward addition of the relevant attributes and SR-only labels
- Render SubMenuItem toggles as buttons rather than `<a>` 1c3486450fbd4e825faef98b0a9ffd8c863bdb38 – nice screen reader and semantics improvement

## General UI

- Fix account menu items not being marked as active 599b37aebf2d6ad98633791a2c67b1239a7bf464 – we weren’t walking "account" menu items to mark them as active when opening the menu from there.
- Remove disused LinkMenuItem peeking and tooltip implementation a191e9aa5be3cdd28b53fa083d7af0234857bdd7 – I was seeing artifacts of this in the "Account" submenu items, and it seems like we fully replaced this with the full-sidebar peek behavior.
- Fix sidebar MenuItem rendering a6a607dfc576b01150f6209c0e3595704d8c4716 – the accounts menu items were overflowing, and the "Pages" menu item was missing its icon.
- Fix "click outside dismiss" implementation in slim sidebar 7f96828de347b2b5077a5784f983aecf0e2373ba – it was only there for the page explorer menu item, not the other sub-menus.
- Fix sidebar getting obscured by messages banners b5c19abf819dadbdc7a97f61b7becb1c2af26685 
- Fix sidebar sub-menus appearing below action footer 3be25b9b8d2334d9b8ce7fe20d7d2b22db24d130

## Wagtail customisations

- Fix slim sidebar rendering when User object has no attribute `first_name`. Fix #7716 7dce0c722970cda2c5d09bd6e51ef6e5ab532876 – note I don’t have a site to test this on so manually changed the code to check the different scenarios.
- Fix rendering of sidebar language picker in slim sidebar. Fix #7806 ff32cb8e367271da488086cad44a3e6ab31ffaff

## Mobile

- Add mobile support for sidebar sub-panels f9f1d8e53fbfa22c6f8ef38b94d12d7ad7637700 – support isn’t great, but should be good enough considering Wagtail’s overall level of support for mobile usage.
- Fix sidebar toggle compatibility with messages 290d93ece66aa1a64e0d20ce97d919a4fe013ce0 – this fix is a bit questionable (only looks good if the message is in a single line), but I think this is good enough considering we’re approaching a pretty big redesign of this header area anyway.

## wontfix?

- ~I wasn’t able to reproduce #7742 (tested in macOS Chrome, Safari, Firefox).~

Edit: take that back, I can reproduce in Windows.

---

* Do the tests still pass? (https://docs.wagtail.io/en/latest/contributing/developing.html#testing)
* Does the code comply with the style guide? (Run `make lint` from the Wagtail root)
* For Python changes: Have you added tests to cover the new/fixed behaviour?
* For front-end changes: Did you test on all of [Wagtail’s supported environments](https://docs.wagtail.io/en/latest/contributing/developing.html#browser-and-device-support)?
    * **Please list the exact browser and operating system versions you tested**.
    * **Please list which assistive technologies you tested**.
* For new features: Has the documentation been updated accordingly?
