### PR TITLE
Update docs links to reference new domain

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thank you for considering to help Wagtail.
 
-We welcome all support, whether on bug reports, code, design, reviews, tests, 
+We welcome all support, whether on bug reports, code, design, reviews, tests,
 documentation, translations or just feature requests.
 
 ## Using the issue tracker
@@ -14,9 +14,9 @@ for support - use [the 'wagtail' tag on Stack Overflow](https://stackoverflow.co
 
 ## New code
 
-Please review the 
-[contributing guidelines](https://docs.wagtail.io/en/latest/contributing/index.html).
-You might like to start by checking issues with the 
+Please review the
+[contributing guidelines](https://docs.wagtail.org/en/latest/contributing/index.html).
+You might like to start by checking issues with the
 [good first issue](https://github.com/wagtail/wagtail/labels/good%20first%20issue) label.
 
 ## Code reviews
@@ -29,4 +29,4 @@ Please submit any new or improved translations through [Transifex](https://www.t
 
 ## Accessibility testing
 
-We’d love to get feedback on the accessibility of Wagtail. Get in touch with our [accessibility team](https://github.com/wagtail/wagtail/wiki/Accessibility-team) if you are testing Wagtail and want to report your findings, or have a look at our [backlog of accessibility issues and improvements](https://github.com/wagtail/wagtail/projects/5). We also document our [testing targets and known issues](https://docs.wagtail.io/en/latest/contributing/developing.html#accessibility-targets).
+We’d love to get feedback on the accessibility of Wagtail. Get in touch with our [accessibility team](https://github.com/wagtail/wagtail/wiki/Accessibility-team) if you are testing Wagtail and want to report your findings, or have a look at our [backlog of accessibility issues and improvements](https://github.com/wagtail/wagtail/projects/5). We also document our [testing targets and known issues](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,11 +1,11 @@
 Thanks for contributing to Wagtail! 🎉
 
-Before submitting, please review the contributor guidelines <https://docs.wagtail.io/en/latest/contributing/index.html> and check the following:
+Before submitting, please review the contributor guidelines <https://docs.wagtail.org/en/latest/contributing/index.html> and check the following:
 
-* Do the tests still pass? (https://docs.wagtail.io/en/latest/contributing/developing.html#testing)
+* Do the tests still pass? (https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
 * Does the code comply with the style guide? (Run `make lint` from the Wagtail root)
 * For Python changes: Have you added tests to cover the new/fixed behaviour?
-* For front-end changes: Did you test on all of [Wagtail’s supported environments](https://docs.wagtail.io/en/latest/contributing/developing.html#browser-and-device-support)?
+* For front-end changes: Did you test on all of [Wagtail’s supported environments](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)?
     * **Please list the exact browser and operating system versions you tested**.
     * **Please list which assistive technologies you tested**.
 * For new features: Has the documentation been updated accordingly?

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -27,6 +27,7 @@ Changelog
  * Add the user who submitted a page for moderation to the "Awaiting your review" homepage summary panel (Tidiane Dia)
  * When moving pages, default to the current parent section (Tidjani Dia)
  * `admin/expanding_formset.js` has been renamed to `admin/expanding-formset.js` (LB (Ben Johnston))
+ * Change docs URL to docs.wagtail.org (Jake Howard)
  * Fix: Accessibility fixes for Windows high contrast mode; Dashboard icons colour and contrast (Sakshi Uppoor)
  * Fix: Rename additional 'spin' CSS animations to avoid clashes with other libraries (Kevin Gutiérrez)
  * Fix: `default_app_config` deprecations for Django >= 3.2 (Tibor Leupold)

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ python manage.py createsuperuser
 python manage.py runserver
 ```
 
-For detailed installation and setup docs, see [docs.wagtail.io](https://docs.wagtail.io/).
+For detailed installation and setup docs, see [docs.wagtail.org](https://docs.wagtail.org/).
 
 ### Who’s using it?
 
@@ -48,11 +48,11 @@ Wagtail is used by [NASA](https://www.nasa.gov/), [Google](https://www.google.co
 
 ### Documentation
 
-[docs.wagtail.io](https://docs.wagtail.io/) is the full reference for Wagtail, and includes guides for developers, designers and editors, alongside release notes and our roadmap.
+[docs.wagtail.org](https://docs.wagtail.org/) is the full reference for Wagtail, and includes guides for developers, designers and editors, alongside release notes and our roadmap.
 
 ### Compatibility
 
-_(If you are reading this on GitHub, the details here may not be indicative of the current released version - please see [Compatible Django / Python versions](https://docs.wagtail.io/en/stable/releases/upgrading.html#compatible-django-python-versions) in the Wagtail documentation.)_
+_(If you are reading this on GitHub, the details here may not be indicative of the current released version - please see [Compatible Django / Python versions](https://docs.wagtail.org/en/stable/releases/upgrading.html#compatible-django-python-versions) in the Wagtail documentation.)_
 
 Wagtail supports:
 
@@ -60,7 +60,7 @@ Wagtail supports:
 * Python 3.7, 3.8, 3.9 and 3.10
 * PostgreSQL, MySQL and SQLite as database backends
 
-[Previous versions of Wagtail](https://docs.wagtail.io/en/stable/releases/upgrading.html#compatible-django-python-versions) additionally supported Python 2.7 and earlier Django versions.
+[Previous versions of Wagtail](https://docs.wagtail.org/en/stable/releases/upgrading.html#compatible-django-python-versions) additionally supported Python 2.7 and earlier Django versions.
 
 ---
 
@@ -96,7 +96,7 @@ To try out the latest features before a release, we also create builds from `mai
 
 If you're a Python or Django developer, fork the repo and get stuck in! We have several developer focused channels on the [Slack workspace](https://github.com/wagtail/wagtail/wiki/Slack).
 
-You might like to start by reviewing the [contributing guidelines](https://docs.wagtail.io/en/latest/contributing/index.html) and checking issues with the [good first issue](https://github.com/wagtail/wagtail/labels/good%20first%20issue) label.
+You might like to start by reviewing the [contributing guidelines](https://docs.wagtail.org/en/latest/contributing/index.html) and checking issues with the [good first issue](https://github.com/wagtail/wagtail/labels/good%20first%20issue) label.
 
 We also welcome translations for Wagtail's interface. Translation work should be submitted through [Transifex](https://www.transifex.com/projects/p/wagtail/).
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,12 +1,12 @@
 # Wagtail docs
 
-These are Sphinx docs, automatically built at https://docs.wagtail.io when the `main` branch is committed to Github. To build them locally, install Wagtail's development requirements (in the root Wagtail directory):
+These are Sphinx docs, automatically built at https://docs.wagtail.org when the `main` branch is committed to Github. To build them locally, install Wagtail's development requirements (in the root Wagtail directory):
 
     pip install -e .[testing,docs]
 
-To build the documentation for browsing, from this directory run: 
+To build the documentation for browsing, from this directory run:
 
-    make html 
+    make html
 
 then open ``_build/html/index.html`` in a browser.
 

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -9,7 +9,7 @@
 {% endblock %}
 
 {% block search %}
-<script async defer data-domain="docs.wagtail.io" src="https://plausible.io/js/plausible.js"></script>
+<script async defer data-domain="docs.wagtail.org" src="https://plausible.io/js/plausible.js"></script>
 <script src="{{ docsearch_base }}docsearch.min.js"></script>
 <script>
   /**

--- a/docs/releases/2.13.rst
+++ b/docs/releases/2.13.rst
@@ -46,7 +46,7 @@ The redirects module now includes support for exporting the list of redirects to
 Sphinx Wagtail Theme
 ~~~~~~~~~~~~~~~~~~~~
 
-The `documentation <https://docs.wagtail.io/>`_ now uses our brand new `Sphinx Wagtail Theme <https://github.com/wagtail/sphinx_wagtail_theme>`_, with a search feature powered by `Algolia DocSearch <https://docsearch.algolia.com/>`_.
+The `documentation <https://docs.wagtail.org/>`_ now uses our brand new `Sphinx Wagtail Theme <https://github.com/wagtail/sphinx_wagtail_theme>`_, with a search feature powered by `Algolia DocSearch <https://docsearch.algolia.com/>`_.
 
 Feedback and feature requests for the theme may be reported to the `sphinx_wagtail_theme issue list <https://github.com/wagtail/sphinx_wagtail_theme/issues>`_, and to Wagtail’s issues for the search.
 

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -2,4 +2,4 @@ User-agent: *
 
 Disallow: /*/pdf/
 
-Sitemap: https://docs.wagtail.io/sitemap.xml
+Sitemap: https://docs.wagtail.org/sitemap.xml

--- a/scripts/latest.txt
+++ b/scripts/latest.txt
@@ -1,10 +1,10 @@
 {
     "version": "2.15.1",
-    "url":     "https://docs.wagtail.io/en/stable/releases/2.15.1.html",
-    "minorUrl": "https://docs.wagtail.io/en/stable/releases/2.15.html",
+    "url":     "https://docs.wagtail.org/en/stable/releases/2.15.1.html",
+    "minorUrl": "https://docs.wagtail.org/en/stable/releases/2.15.html",
     "lts": {
         "version": "2.15.1",
-        "url": "https://docs.wagtail.io/en/stable/releases/2.15.1.html",
-        "minorUrl": "https://docs.wagtail.io/en/stable/releases/2.15.html"
+        "url": "https://docs.wagtail.org/en/stable/releases/2.15.1.html",
+        "minorUrl": "https://docs.wagtail.org/en/stable/releases/2.15.html"
     }
 }

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ setup(
     version=__version__,
     description='A Django content management system.',
     author='Wagtail core team + contributors',
-    author_email='hello@wagtail.io',  # For support queries, please see https://docs.wagtail.io/en/stable/support.html
+    author_email='hello@wagtail.io',  # For support queries, please see https://docs.wagtail.org/en/stable/support.html
     url='https://wagtail.io/',
     packages=find_packages(),
     include_package_data=True,
@@ -95,7 +95,7 @@ setup(
 system built on Django, with a strong community and commercial support. \
 It’s focused on user experience, and offers precise control for \
 designers and developers.\n\n\
-For more details, see https://wagtail.io, https://docs.wagtail.io and \
+For more details, see https://wagtail.io, https://docs.wagtail.org and \
 https://github.com/wagtail/wagtail/.",
     classifiers=[
         'Development Status :: 5 - Production/Stable',

--- a/wagtail/admin/action_menu.py
+++ b/wagtail/admin/action_menu.py
@@ -71,7 +71,7 @@ class ActionMenuItem(Component):
         if len(args) == 2:
             warn(
                 "ActionMenuItem.is_shown no longer takes a 'request' argument. "
-                "See https://docs.wagtail.io/en/stable/releases/2.15.html#template-components-2-15",
+                "See https://docs.wagtail.org/en/stable/releases/2.15.html#template-components-2-15",
                 category=RemovedInWagtail217Warning, stacklevel=2
             )
             request, context = args
@@ -97,7 +97,7 @@ class ActionMenuItem(Component):
         if requires_request_arg(self.get_url):
             warn(
                 "%s.get_url should no longer take a 'request' argument. "
-                "See https://docs.wagtail.io/en/stable/releases/2.15.html#template-components-2-15" % type(self).__name__,
+                "See https://docs.wagtail.org/en/stable/releases/2.15.html#template-components-2-15" % type(self).__name__,
                 category=RemovedInWagtail217Warning
             )
             url = self.get_url(parent_context['request'], parent_context)
@@ -130,7 +130,7 @@ class ActionMenuItem(Component):
         if len(args) == 2:
             warn(
                 "ActionMenuItem.render_html no longer takes a 'request' argument. "
-                "See https://docs.wagtail.io/en/stable/releases/2.15.html#template-components-2-15",
+                "See https://docs.wagtail.org/en/stable/releases/2.15.html#template-components-2-15",
                 category=RemovedInWagtail217Warning, stacklevel=2
             )
             request, parent_context = args
@@ -141,7 +141,7 @@ class ActionMenuItem(Component):
             # get_context has been overridden, so call it instead of get_context_data
             warn(
                 "%s should define get_context_data(self, parent_context) instead of get_context(self, request, get_context_data). "
-                "See https://docs.wagtail.io/en/stable/releases/2.15.html#template-components-2-15" % type(self).__name__,
+                "See https://docs.wagtail.org/en/stable/releases/2.15.html#template-components-2-15" % type(self).__name__,
                 category=RemovedInWagtail217Warning
             )
             context_data = self.get_context(parent_context['request'], parent_context)
@@ -151,7 +151,7 @@ class ActionMenuItem(Component):
         if self.template:
             warn(
                 "%s should define template_name instead of template. "
-                "See https://docs.wagtail.io/en/stable/releases/2.15.html#template-components-2-15" % type(self).__name__,
+                "See https://docs.wagtail.org/en/stable/releases/2.15.html#template-components-2-15" % type(self).__name__,
                 category=RemovedInWagtail217Warning
             )
             template_name = self.template
@@ -444,7 +444,7 @@ class PageActionMenu:
                     if requires_request_arg(item.is_shown):
                         warn(
                             "%s.is_shown should no longer take a 'request' argument. "
-                            "See https://docs.wagtail.io/en/stable/releases/2.15.html#template-components-2-15" % type(item).__name__,
+                            "See https://docs.wagtail.org/en/stable/releases/2.15.html#template-components-2-15" % type(item).__name__,
                             category=RemovedInWagtail217Warning
                         )
                         is_shown = item.is_shown(self.request, self.context)
@@ -459,7 +459,7 @@ class PageActionMenu:
             if requires_request_arg(menu_item.is_shown):
                 warn(
                     "%s.is_shown should no longer take a 'request' argument. "
-                    "See https://docs.wagtail.io/en/stable/releases/2.15.html#template-components-2-15" % type(menu_item).__name__,
+                    "See https://docs.wagtail.org/en/stable/releases/2.15.html#template-components-2-15" % type(menu_item).__name__,
                     category=RemovedInWagtail217Warning
                 )
                 is_shown = menu_item.is_shown(self.request, self.context)
@@ -485,7 +485,7 @@ class PageActionMenu:
             if requires_request_arg(menu_item.render_html):
                 warn(
                     "%s.render_html should no longer take a 'request' argument. "
-                    "See https://docs.wagtail.io/en/stable/releases/2.15.html#template-components-2-15" % type(menu_item).__name__,
+                    "See https://docs.wagtail.org/en/stable/releases/2.15.html#template-components-2-15" % type(menu_item).__name__,
                     category=RemovedInWagtail217Warning
                 )
                 rendered_menu_items.append(menu_item.render_html(self.request, self.context))
@@ -495,7 +495,7 @@ class PageActionMenu:
         if requires_request_arg(self.default_item.render_html):
             warn(
                 "%s.render_html should no longer take a 'request' argument. "
-                "See https://docs.wagtail.io/en/stable/releases/2.15.html#template-components-2-15" % type(self.default_item).__name__,
+                "See https://docs.wagtail.org/en/stable/releases/2.15.html#template-components-2-15" % type(self.default_item).__name__,
                 category=RemovedInWagtail217Warning
             )
             rendered_default_item = self.default_item.render_html(self.request, self.context)

--- a/wagtail/admin/checks.py
+++ b/wagtail/admin/checks.py
@@ -16,7 +16,7 @@ def css_install_check(app_configs, **kwargs):
         error_hint = """
             Most likely you are running a development (non-packaged) copy of
             Wagtail and have not built the static assets -
-            see https://docs.wagtail.io/en/latest/contributing/developing.html
+            see https://docs.wagtail.org/en/latest/contributing/developing.html
 
             File not found: %s
         """ % css_path

--- a/wagtail/admin/site_summary.py
+++ b/wagtail/admin/site_summary.py
@@ -37,7 +37,7 @@ class SummaryItem(Component):
             # preference to following the Component.render_html path
             message = (
                 "Summary item %r should provide render_html(self, parent_context) rather than render(self). "
-                "See https://docs.wagtail.io/en/stable/releases/2.15.html#template-components-2-15"
+                "See https://docs.wagtail.org/en/stable/releases/2.15.html#template-components-2-15"
                 % self
             )
             warn(message, category=RemovedInWagtail217Warning)
@@ -47,7 +47,7 @@ class SummaryItem(Component):
             # preference to Component.get_context_data
             message = (
                 "Summary item %r should provide get_context_data(self, parent_context) rather than get_context(self). "
-                "See https://docs.wagtail.io/en/stable/releases/2.15.html#template-components-2-15"
+                "See https://docs.wagtail.org/en/stable/releases/2.15.html#template-components-2-15"
                 % self
             )
             warn(message, category=RemovedInWagtail217Warning)
@@ -58,7 +58,7 @@ class SummaryItem(Component):
         if self.template is not None:
             warn(
                 "%s should define template_name instead of template. "
-                "See https://docs.wagtail.io/en/stable/releases/2.15.html#template-components-2-15" % type(self).__name__,
+                "See https://docs.wagtail.org/en/stable/releases/2.15.html#template-components-2-15" % type(self).__name__,
                 category=RemovedInWagtail217Warning
             )
             template_name = self.template

--- a/wagtail/admin/templates/wagtailadmin/skeleton.html
+++ b/wagtail/admin/templates/wagtailadmin/skeleton.html
@@ -84,7 +84,7 @@
     {% block ie11warning %}
         <div data-ie11-warning hidden>
             <div class="capabilitymessage">
-                {% blocktrans with url="https://docs.wagtail.io/en/stable/editor_manual/browser_issues.html#ie11" %}Wagtail has removed support for IE11. <a href="{{ url }}">Learn more about IE11 alternatives</a>.{% endblocktrans %}
+                {% blocktrans with url="https://docs.wagtail.org/en/stable/editor_manual/browser_issues.html#ie11" %}Wagtail has removed support for IE11. <a href="{{ url }}">Learn more about IE11 alternatives</a>.{% endblocktrans %}
             </div>
         </div>
     {% endblock %}

--- a/wagtail/admin/views/home.py
+++ b/wagtail/admin/views/home.py
@@ -188,7 +188,7 @@ def home(request):
             # wagtailadmin/home.html should be removed too
             message = (
                 "Homepage panel %r should provide a render_html method. "
-                "See https://docs.wagtail.io/en/stable/releases/2.15.html#template-components-2-15"
+                "See https://docs.wagtail.org/en/stable/releases/2.15.html#template-components-2-15"
                 % panel
             )
             warn(message, category=RemovedInWagtail217Warning)

--- a/wagtail/contrib/postgres_search/apps.py
+++ b/wagtail/contrib/postgres_search/apps.py
@@ -17,7 +17,7 @@ class PostgresSearchConfig(AppConfig):
         warnings.warn(
             "The wagtail.contrib.postgres_search backend is deprecated and has been replaced by "
             "wagtail.search.backends.database. "
-            "See https://docs.wagtail.io/en/stable/releases/2.15.html#database-search-backends-replaced",
+            "See https://docs.wagtail.org/en/stable/releases/2.15.html#database-search-backends-replaced",
             category=RemovedInWagtail217Warning
         )
 

--- a/wagtail/contrib/postgres_search/backend.py
+++ b/wagtail/contrib/postgres_search/backend.py
@@ -29,7 +29,7 @@ from .utils import (
 warnings.warn(
     "The wagtail.contrib.postgres_search backend is deprecated and has been replaced by "
     "wagtail.search.backends.database. "
-    "See https://docs.wagtail.io/en/stable/releases/2.15.html#database-search-backends-replaced",
+    "See https://docs.wagtail.org/en/stable/releases/2.15.html#database-search-backends-replaced",
     category=RemovedInWagtail217Warning
 )
 

--- a/wagtail/core/templatetags/wagtailcore_tags.py
+++ b/wagtail/core/templatetags/wagtailcore_tags.py
@@ -84,9 +84,9 @@ def wagtail_version():
 def wagtail_documentation_path():
     major, minor, patch, release, num = VERSION
     if release == 'final':
-        return 'https://docs.wagtail.io/en/v%s' % __version__
+        return 'https://docs.wagtail.org/en/v%s' % __version__
     else:
-        return 'https://docs.wagtail.io/en/latest'
+        return 'https://docs.wagtail.org/en/latest'
 
 
 @register.simple_tag

--- a/wagtail/images/templatetags/wagtailimages_tags.py
+++ b/wagtail/images/templatetags/wagtailimages_tags.py
@@ -125,5 +125,5 @@ def image_url(image, filter_spec, viewname='wagtailimages_serve'):
     except NoReverseMatch:
         raise ImproperlyConfigured(
             "'image_url' tag requires the " + viewname + " view to be configured. Please see "
-            "https://docs.wagtail.io/en/stable/advanced_topics/images/image_serve_view.html#setup for instructions."
+            "https://docs.wagtail.org/en/stable/advanced_topics/images/image_serve_view.html#setup for instructions."
         )

--- a/wagtail/project_template/project_name/settings/base.py
+++ b/wagtail/project_template/project_name/settings/base.py
@@ -158,7 +158,7 @@ MEDIA_URL = '/media/'
 WAGTAIL_SITE_NAME = "{{ project_name }}"
 
 # Search
-# https://docs.wagtail.io/en/stable/topics/search/backends.html
+# https://docs.wagtail.org/en/stable/topics/search/backends.html
 WAGTAILSEARCH_BACKENDS = {
     'default': {
         'BACKEND': 'wagtail.search.backends.database',

--- a/wagtail/search/backends/db.py
+++ b/wagtail/search/backends/db.py
@@ -8,6 +8,6 @@ from wagtail.utils.deprecation import RemovedInWagtail217Warning
 warn(
     "The wagtail.search.backends.db search backend is deprecated and has been replaced by "
     "wagtail.search.backends.database. "
-    "See https://docs.wagtail.io/en/stable/releases/2.15.html#database-search-backends-replaced",
+    "See https://docs.wagtail.org/en/stable/releases/2.15.html#database-search-backends-replaced",
     category=RemovedInWagtail217Warning
 )

--- a/wagtail/snippets/action_menu.py
+++ b/wagtail/snippets/action_menu.py
@@ -64,7 +64,7 @@ class ActionMenuItem(Component):
         if len(args) == 2:
             warn(
                 "ActionMenuItem.is_shown no longer takes a 'request' argument. "
-                "See https://docs.wagtail.io/en/stable/releases/2.15.html#template-components-2-15",
+                "See https://docs.wagtail.org/en/stable/releases/2.15.html#template-components-2-15",
                 category=RemovedInWagtail217Warning, stacklevel=2
             )
         return True
@@ -83,7 +83,7 @@ class ActionMenuItem(Component):
         if requires_request_arg(self.get_url):
             warn(
                 "%s.get_url should no longer take a 'request' argument. "
-                "See https://docs.wagtail.io/en/stable/releases/2.15.html#template-components-2-15" % type(self).__name__,
+                "See https://docs.wagtail.org/en/stable/releases/2.15.html#template-components-2-15" % type(self).__name__,
                 category=RemovedInWagtail217Warning
             )
             url = self.get_url(parent_context['request'], parent_context)
@@ -116,7 +116,7 @@ class ActionMenuItem(Component):
         if len(args) == 2:
             warn(
                 "ActionMenuItem.render_html no longer takes a 'request' argument. "
-                "See https://docs.wagtail.io/en/stable/releases/2.15.html#template-components-2-15",
+                "See https://docs.wagtail.org/en/stable/releases/2.15.html#template-components-2-15",
                 category=RemovedInWagtail217Warning, stacklevel=2
             )
             request, parent_context = args
@@ -127,7 +127,7 @@ class ActionMenuItem(Component):
             # get_context has been overridden, so call it instead of get_context_data
             warn(
                 "%s should define get_context_data(self, parent_context) instead of get_context(self, request, get_context_data). "
-                "See https://docs.wagtail.io/en/stable/releases/2.15.html#template-components-2-15" % type(self).__name__,
+                "See https://docs.wagtail.org/en/stable/releases/2.15.html#template-components-2-15" % type(self).__name__,
                 category=RemovedInWagtail217Warning
             )
             context_data = self.get_context(parent_context['request'], parent_context)
@@ -137,7 +137,7 @@ class ActionMenuItem(Component):
         if self.template:
             warn(
                 "%s should define template_name instead of template."
-                "See https://docs.wagtail.io/en/stable/releases/2.15.html#template-components-2-15" % type(self).__name__,
+                "See https://docs.wagtail.org/en/stable/releases/2.15.html#template-components-2-15" % type(self).__name__,
                 category=RemovedInWagtail217Warning
             )
             template_name = self.template
@@ -211,7 +211,7 @@ class SnippetActionMenu:
             if requires_request_arg(menu_item.is_shown):
                 warn(
                     "%s.is_shown should no longer take a 'request' argument. "
-                    "See https://docs.wagtail.io/en/stable/releases/2.15.html#template-components-2-15" % type(menu_item).__name__,
+                    "See https://docs.wagtail.org/en/stable/releases/2.15.html#template-components-2-15" % type(menu_item).__name__,
                     category=RemovedInWagtail217Warning
                 )
                 is_shown = menu_item.is_shown(self.request, self.context)
@@ -237,7 +237,7 @@ class SnippetActionMenu:
             if requires_request_arg(menu_item.render_html):
                 warn(
                     "%s.render_html should no longer take a 'request' argument. "
-                    "See https://docs.wagtail.io/en/stable/releases/2.15.html#template-components-2-15" % type(menu_item).__name__,
+                    "See https://docs.wagtail.org/en/stable/releases/2.15.html#template-components-2-15" % type(menu_item).__name__,
                     category=RemovedInWagtail217Warning
                 )
                 rendered_menu_items.append(menu_item.render_html(self.request, self.context))
@@ -247,7 +247,7 @@ class SnippetActionMenu:
         if requires_request_arg(self.default_item.render_html):
             warn(
                 "%s.render_html should no longer take a 'request' argument. "
-                "See https://docs.wagtail.io/en/stable/releases/2.15.html#template-components-2-15" % type(self.default_item).__name__,
+                "See https://docs.wagtail.org/en/stable/releases/2.15.html#template-components-2-15" % type(self.default_item).__name__,
                 category=RemovedInWagtail217Warning
             )
             rendered_default_item = self.default_item.render_html(self.request, self.context)

--- a/wagtail/tests/testapp/models.py
+++ b/wagtail/tests/testapp/models.py
@@ -476,7 +476,7 @@ class FormPage(AbstractEmailForm):
 
     # This is redundant (SubmissionsListView is the default view class), but importing
     # SubmissionsListView in this models.py helps us to confirm that this recipe
-    # https://docs.wagtail.io/en/stable/reference/contrib/forms/customisation.html#customise-form-submissions-listing-in-wagtail-admin
+    # https://docs.wagtail.org/en/stable/reference/contrib/forms/customisation.html#customise-form-submissions-listing-in-wagtail-admin
     # works without triggering circular dependency issues -
     # see https://github.com/wagtail/wagtail/issues/6265
     submissions_list_view_class = SubmissionsListView


### PR DESCRIPTION
As a part of https://github.com/wagtail/wagtail/issues/7841, we need to update which domain is primarily used to receive emails for the Wagtail project.

## To do

- Setup ReadTheDocs with an additional domain
- Deploy updated worker https://github.com/wagtail/wagtail.io/pull/124