### PR TITLE
Update the release URL to the new .org domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Wagtail is an open source content management system built on Django, with a stro
 * Scales to millions of pages and thousands of editors
 * Fast out of the box, cache-friendly when you need it
 * Content API for 'headless' sites with de-coupled front-end
-* Runs on a Raspberry Pi or a multi-datacenter cloud platform 
+* Runs on a Raspberry Pi or a multi-datacenter cloud platform
 * StreamField encourages flexible content without compromising structure
 * Powerful, integrated search, using Elasticsearch or PostgreSQL
 * Excellent support for images and embedded content
@@ -70,7 +70,7 @@ There is an active community of Wagtail users and developers responding to quest
 
 For topics and discussions that do not fit Stack Overflow's question and answer format, we have a [Slack workspace](https://github.com/wagtail/wagtail/wiki/Slack) and a [Wagtail Support mailing list](https://groups.google.com/forum/#!forum/wagtail). Please respect the time and effort of volunteers by not asking the same question in multiple places.
 
-Our [Github discussion boards](https://github.com/wagtail/wagtail/discussions) are open for sharing ideas and plans for the Wagtail project. 
+Our [Github discussion boards](https://github.com/wagtail/wagtail/discussions) are open for sharing ideas and plans for the Wagtail project.
 
 We maintain a curated list of third party packages, articles and other resources at [Awesome Wagtail](https://github.com/springload/awesome-wagtail).
 
@@ -90,7 +90,7 @@ Feature releases of Wagtail are released every three months. Selected releases a
 
 #### Nightly releases
 
-To try out the latest features before a release, we also create builds from `main` every night. You can find instructions on how to install the latest nightly release at https://releases.wagtail.io/nightly/index.html
+To try out the latest features before a release, we also create builds from `main` every night. You can find instructions on how to install the latest nightly release at https://releases.wagtail.org/nightly/index.html
 
 ### Contributing
 
@@ -118,7 +118,7 @@ We thank the following organisations for their services used in Wagtail's develo
 
 [![Build Status](https://github.com/wagtail/wagtail/workflows/Wagtail%20CI/badge.svg)](https://github.com/wagtail/wagtail/actions)
 [![License](https://img.shields.io/badge/license-BSD-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
-[![Version](https://img.shields.io/pypi/v/wagtail.svg)](https://pypi.python.org/pypi/wagtail/) 
+[![Version](https://img.shields.io/pypi/v/wagtail.svg)](https://pypi.python.org/pypi/wagtail/)
 [![Total alerts](https://img.shields.io/lgtm/alerts/g/wagtail/wagtail.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/wagtail/wagtail/alerts/)
 [![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/wagtail/wagtail.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/wagtail/wagtail/context:python)
 [![Language grade: JavaScript](https://img.shields.io/lgtm/grade/javascript/g/wagtail/wagtail.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/wagtail/wagtail/context:javascript)

--- a/client/src/components/UpgradeNotification/index.js
+++ b/client/src/components/UpgradeNotification/index.js
@@ -14,7 +14,7 @@ const initUpgradeNotification = () => {
   *       "url" : "https://wagtail.io"  // Absolute URL to page/file containing release notes or actual package. It's up to you.
   *   }
   */
-  const releasesUrl = 'https://releases.wagtail.io/latest.txt';
+  const releasesUrl = 'https://releases.wagtail.org/latest.txt';
   const currentVersion = container.dataset.wagtailVersion;
 
   fetch(releasesUrl).then(response => {

--- a/scripts/latest.sh
+++ b/scripts/latest.sh
@@ -1,7 +1,7 @@
 #! /bin/sh
 # vim:sw=4 ts=4 et:
 
-BUCKET=releases.wagtail.io
+BUCKET=releases.wagtail.org
 REGION=eu-west-1
 CF_DISTRIBUTION=E283SZ5CB4MDM0
 
@@ -107,7 +107,7 @@ elif [ "$1" = "edit" -o "$1" = "vi" ]; then
     if ! _get "${LTMP}"; then
         exit 1
     fi
-    
+
     cp "${LTMP}" "${LTMP2}"
 
     if [ ! -z "${VISUAL}" ]; then

--- a/scripts/latest.sh
+++ b/scripts/latest.sh
@@ -1,7 +1,7 @@
 #! /bin/sh
 # vim:sw=4 ts=4 et:
 
-BUCKET=releases.wagtail.org
+BUCKET=releases.wagtail.io
 REGION=eu-west-1
 CF_DISTRIBUTION=E283SZ5CB4MDM0
 

--- a/scripts/nightly/upload.py
+++ b/scripts/nightly/upload.py
@@ -15,13 +15,13 @@ except StopIteration:
 
 print("Uploading", f.name)
 s3 = boto3.client('s3')
-s3.upload_file(str(f), 'releases.wagtail.io', 'nightly/dist/' + f.name, ExtraArgs={'ACL': 'public-read'})
+s3.upload_file(str(f), 'releases.wagtail.org', 'nightly/dist/' + f.name, ExtraArgs={'ACL': 'public-read'})
 
 print("Updating latest.json")
 
-boto3.resource('s3').Object('releases.wagtail.io', 'nightly/latest.json').put(
+boto3.resource('s3').Object('releases.wagtail.org', 'nightly/latest.json').put(
     ACL='public-read',
     Body=json.dumps({
-        "url": 'https://releases.wagtail.io/nightly/dist/' + f.name,
+        "url": 'https://releases.wagtail.org/nightly/dist/' + f.name,
     })
 )


### PR DESCRIPTION
As a part of https://github.com/wagtail/wagtail/issues/7841, we need to update which domain is primarily used to receive emails for the Wagtail project.

Note: There may be CSP ramifications of changing this domain, which will need to be made obvious in the release notes

## To do

- [x] Create new infrastructure to serve `releases.wagtail.org`, ensuring existing permissions and access are maintained.
- [x] ~~Confirm `latest.sh` is runnable by those who need to, and makes the relevant changes.~~ No changes necessary, see below
- [x] ~~Confirm frontend code will transparently deal with redirects to new domain~~ Old domain will not redirect due to CORS issue, will continue to serve assets normally as before.
