### PR TITLE
Make API representation of Page.alias_of more consistent

### DIFF
--- a/wagtail/api/v2/serializers.py
+++ b/wagtail/api/v2/serializers.py
@@ -146,16 +146,12 @@ class PageAliasOfField(relations.RelatedField):
     Serializes the "alias_of" field on Page objects.
     """
     def get_attribute(self, instance):
-        return instance
+        return instance.alias_of
 
-    def to_representation(self, page):
-        if page.alias_of is None:
-            return None
-        data = OrderedDict()
-        data['id'] = page.alias_of.id
-        data['full_url'] = page.alias_of.full_url
-
-        return data
+    def to_representation(self, value):
+        serializer_class = get_serializer_class(value.__class__, ['id', 'type', 'detail_url', 'html_url', 'title'], meta_fields=['type', 'detail_url', 'html_url'], base=PageSerializer)
+        serializer = serializer_class(context=self.context)
+        return serializer.to_representation(value)
 
 
 class ChildRelationField(Field):


### PR DESCRIPTION
Fixes #7852

This commit changes the API representation of Page.alias_of to match Page.parent to improve consistency.

As the current implementation of Page.alias_of isn't released yet, we can update this without concern for backwards compatibility.
