### PR TITLE
Update browser support targets following UI team discussion

### DIFF
--- a/docs/contributing/developing.rst
+++ b/docs/contributing/developing.rst
@@ -184,10 +184,10 @@ Mobile Safari  iOS Phone      Last 2
 Mobile Safari  iOS Tablet     Last 2
 Chrome         Android        Last 2
 Chrome         Desktop        Last 2
-MS Edge        Desktop        Last 2
+MS Edge        Windows        Last 2
 Firefox        Desktop        Latest
 Firefox ESR    Desktop        Latest
-Safari         macOS          Last 2
+Safari         macOS          Last 3
 =============  =============  =============
 
 We aim for Wagtail to work in those environments. Our development standards ensure that the site is usable on other browsers **and will work on future browsers**.


### PR DESCRIPTION
Following @wagtail/ui discussion. Small but important changes:

- We should always be testing in Windows, even if MS Edge is now available on macOS as well.
- We should make a better effort to support older Safari releases, as Safari is tied to OS updates, and device management isn’t always keeping up with releases

For reference, here is the difference in browser APIs support between Safari 14 and 13: https://caniuse.com/?compare=safari+13,safari+14&compareCats=all. There are a few mainstream ones on there we wouldn’t be able to use, but nothing that should be a blocker.