### PR TITLE
Switch slim sidebar to be on by default

### DIFF
--- a/client/src/components/Sidebar/index.tsx
+++ b/client/src/components/Sidebar/index.tsx
@@ -8,6 +8,7 @@ export const SIDEBAR_COLLAPSED_COOKIE_NAME = 'wagtail_sidebar_collapsed';
 
 export function initSidebar() {
   const element = document.getElementById('wagtail-sidebar');
+  const rawProps = document.getElementById('wagtail-sidebar-props');
 
   const navigate = (url: string) => {
     window.location.href = url;
@@ -20,8 +21,8 @@ export function initSidebar() {
     return new Promise<void>(() => {});
   };
 
-  if (element instanceof HTMLElement && element.dataset.props) {
-    const props = window.telepath.unpack(JSON.parse(element.dataset.props));
+  if (element && rawProps?.textContent) {
+    const props = window.telepath.unpack(JSON.parse(rawProps.textContent));
 
     const collapsedCookie: any = Cookies.get(SIDEBAR_COLLAPSED_COOKIE_NAME);
     // Cast to boolean

--- a/docs/reference/hooks.rst
+++ b/docs/reference/hooks.rst
@@ -162,7 +162,7 @@ Hooks for building new areas of the admin interface (alongside pages, images, do
 ``construct_main_menu``
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-  Called just before the Wagtail admin menu is output, to allow the list of menu items to be modified. The callable passed to this hook will receive a ``request`` object and a list of ``menu_items``, and should modify ``menu_items`` in-place as required. Adding menu items should generally be done through the ``register_admin_menu_item`` hook instead - items added through ``construct_main_menu`` will be missing any associated JavaScript includes, and their ``is_shown`` check will not be applied.
+  Called just before the Wagtail admin menu is output, to allow the list of menu items to be modified. The callable passed to this hook will receive a ``request`` object and a list of ``menu_items``, and should modify ``menu_items`` in-place as required. Adding menu items should generally be done through the ``register_admin_menu_item`` hook instead - items added through ``construct_main_menu`` will not have their ``is_shown`` check applied.
 
   .. code-block:: python
 
@@ -262,14 +262,13 @@ More details about the options that are available can be found at :doc:`/extendi
   Add an item to the Wagtail admin menu. The callable passed to this hook must return an instance of ``wagtail.admin.menu.MenuItem``. New items can be constructed from the ``MenuItem`` class by passing in a ``label`` which will be the text in the menu item, and the URL of the admin page you want the menu item to link to (usually by calling ``reverse()`` on the admin view you've set up). Additionally, the following keyword arguments are accepted:
 
   :name: an internal name used to identify the menu item; defaults to the slugified form of the label.
-  :icon_name: icon to display against the menu item
+  :icon_name: icon to display against the menu item; no defaults, optional, but should be set for top-level menu items so they can be identified when collapsed.
   :classnames: additional classnames applied to the link
-  :attrs: additional HTML attributes to apply to the link
   :order: an integer which determines the item's position in the menu
 
   For menu items that are only available to superusers, the subclass ``wagtail.admin.menu.AdminOnlyMenuItem`` can be used in place of ``MenuItem``.
 
-  ``MenuItem`` can be further subclassed to customise the HTML output, specify JavaScript files required by the menu item, or conditionally show or hide the item for specific requests (for example, to apply permission checks); see the source code (``wagtail/admin/menu.py``) for details.
+  ``MenuItem`` can be further subclassed to customise its initialisation or conditionally show or hide the item for specific requests (for example, to apply permission checks); see the source code (``wagtail/admin/menu.py``) for details.
 
   .. code-block:: python
 

--- a/docs/reference/settings.rst
+++ b/docs/reference/settings.rst
@@ -217,6 +217,15 @@ If a user has not uploaded a profile picture, Wagtail will look for an avatar li
 
 Changes whether the Submit for Moderation button is displayed in the action menu.
 
+``WAGTAIL_SLIM_SIDEBAR``
+------------------------
+
+.. code-block:: python
+
+  WAGTAIL_SLIM_SIDEBAR = False
+
+Disables Wagtail’s slim sidebar to use the legacy sidebar instead.
+
 Comments
 ========
 

--- a/docs/reference/settings.rst
+++ b/docs/reference/settings.rst
@@ -224,7 +224,7 @@ Changes whether the Submit for Moderation button is displayed in the action menu
 
   WAGTAIL_SLIM_SIDEBAR = False
 
-Disables Wagtail’s slim sidebar to use the legacy sidebar instead.
+Disables Wagtail’s slim sidebar to use the legacy sidebar instead. The legacy sidebar and this setting will be removed in Wagtail 2.18.
 
 Comments
 ========

--- a/docs/releases/2.16.md
+++ b/docs/releases/2.16.md
@@ -8,6 +8,9 @@
 
 ## What's new
 
+### Slim sidebar
+
+As part of a [wider redesign](https://github.com/wagtail/wagtail/discussions/7739) of Wagtail’s administration interface, we have replaced the sidebar with a slim, keyboard-friendly version. This re-implementation comes with significant accessibility improvements for keyboard and screen reader users, and will enable us to make navigation between views much snappier in the future. Please have a look at [upgrade considerations](#upgrade-considerations) for more details on differences with the previous version.
 
 ### Other features
 
@@ -90,3 +93,13 @@ The internal (undocumented) class-based view `wagtail.admin.views.generic.Delete
 ### Renamed admin/expanding-formset.js
 
 `admin/expanding_formset.js` has been renamed to `admin/expanding-formset.js` as part of frontend code clean up work. Check for any customised admin views that are extending expanding formsets, or have overridden template and copied the previous file name used in an import as these may need updating.
+
+### Deprecated sidebar capabilities
+
+The new sidebar largely supports the same customisations as its predecessor, with a few exceptions:
+
+- Top-level menu items should now always provide an `icon_name`, so they can be visually distinguished when the sidebar is collapsed.
+- `MenuItem` and its sub-classes no longer supports customizing arbitrary HTML attributes.
+- `MenuItem` can no longer be sub-classed to customise its HTML output or load additional JavaScript
+
+For sites relying on those capabilities, we provide a [`WAGTAIL_SLIM_SIDEBAR = False`](../reference/settings/#WAGTAIL_SLIM_SIDEBAR) setting to switch back to the legacy sidebar. The legacy sidebar and this setting will be removed in Wagtail 2.18.

--- a/wagtail/admin/templates/wagtailadmin/base.html
+++ b/wagtail/admin/templates/wagtailadmin/base.html
@@ -27,7 +27,7 @@
         <div class="explorer__wrapper" data-explorer-menu></div>
     </aside>
     {# Backwards-compatibility for branding_logo customisations in legacy sidebar. #}
-    {# TODO RemovedInWagtail217Warning Remove in Wagtail 2.17 #}
+    {# RemovedInWagtail218Warning Remove when removing the legacy sidebar. #}
     <script>
         const branding_logo = document.querySelector('[data-wagtail-sidebar-branding-logo]');
         const legacySidebar = document.querySelector('[data-nav-primary]');

--- a/wagtail/admin/templates/wagtailadmin/base.html
+++ b/wagtail/admin/templates/wagtailadmin/base.html
@@ -5,7 +5,7 @@
     {% slim_sidebar_enabled as slim_sidebar_enabled %}
     <template data-wagtail-sidebar-branding-logo>{% block branding_logo %}{% endblock %}</template>
     {% if slim_sidebar_enabled %}
-    <script id="wagtail-sidebar-props" type="application/json">{% autoescape off %}{% menu_props %}{% endautoescape %}</script>
+    {% sidebar_props %}
     <aside id="wagtail-sidebar" data-wagtail-sidebar></aside>
     {% else %}
     <aside id="wagtail-sidebar" class="nav-wrapper" data-nav-primary>

--- a/wagtail/admin/templates/wagtailadmin/base.html
+++ b/wagtail/admin/templates/wagtailadmin/base.html
@@ -5,7 +5,8 @@
     {% slim_sidebar_enabled as slim_sidebar_enabled %}
     <template data-wagtail-sidebar-branding-logo>{% block branding_logo %}{% endblock %}</template>
     {% if slim_sidebar_enabled %}
-    <aside id="wagtail-sidebar" data-wagtail-sidebar data-props="{% menu_props %}"></aside>
+    <script id="wagtail-sidebar-props" type="application/json">{% autoescape off %}{% menu_props %}{% endautoescape %}</script>
+    <aside id="wagtail-sidebar" data-wagtail-sidebar></aside>
     {% else %}
     <aside id="wagtail-sidebar" class="nav-wrapper" data-nav-primary>
         <div class="inner">

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -769,7 +769,7 @@ def locales():
 
 @register.simple_tag()
 def slim_sidebar_enabled():
-    return 'legacy-sidebar' not in getattr(settings, 'WAGTAIL_EXPERIMENTAL_FEATURES', [])
+    return getattr(settings, 'WAGTAIL_SLIM_SIDEBAR', True)
 
 
 @register.simple_tag(takes_context=True)

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -8,7 +8,6 @@ from django.conf import settings
 from django.contrib.admin.utils import quote
 from django.contrib.humanize.templatetags.humanize import intcomma
 from django.contrib.messages.constants import DEFAULT_TAGS as MESSAGE_TAGS
-from django.core.serializers.json import DjangoJSONEncoder
 from django.db.models import Min, QuerySet
 from django.forms import Media
 from django.shortcuts import resolve_url as resolve_url_func
@@ -19,7 +18,7 @@ from django.urls import reverse
 from django.urls.exceptions import NoReverseMatch
 from django.utils import timezone
 from django.utils.encoding import force_str
-from django.utils.html import avoid_wrapping, format_html, format_html_join
+from django.utils.html import avoid_wrapping, format_html, format_html_join, json_script
 from django.utils.http import urlencode
 from django.utils.safestring import mark_safe
 from django.utils.timesince import timesince
@@ -782,7 +781,7 @@ def sidebar_collapsed(context):
 
 
 @register.simple_tag(takes_context=True)
-def menu_props(context):
+def sidebar_props(context):
     request = context['request']
     search_areas = admin_search_areas.search_items_for_request(request)
     if search_areas:
@@ -802,9 +801,9 @@ def menu_props(context):
     ]
     modules = [module for module in modules if module is not None]
 
-    return json.dumps({
+    return json_script({
         'modules': JSContext().pack(modules),
-    }, cls=DjangoJSONEncoder)
+    }, element_id="wagtail-sidebar-props")
 
 
 @register.simple_tag

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -769,7 +769,7 @@ def locales():
 
 @register.simple_tag()
 def slim_sidebar_enabled():
-    return 'slim-sidebar' in getattr(settings, 'WAGTAIL_EXPERIMENTAL_FEATURES', [])
+    return 'legacy-sidebar' not in getattr(settings, 'WAGTAIL_EXPERIMENTAL_FEATURES', [])
 
 
 @register.simple_tag(takes_context=True)

--- a/wagtail/admin/tests/test_admin_search.py
+++ b/wagtail/admin/tests/test_admin_search.py
@@ -92,7 +92,7 @@ class TestSearchAreaNoPagePermissions(BaseSearchAreaTestCase):
         response = self.client.get('/admin/')
         # The menu search bar should go to /customsearch/, not /admin/pages/search/
         self.assertNotContains(response, reverse('wagtailadmin_pages:search'))
-        self.assertContains(response, 'action="/customsearch/"')
+        self.assertContains(response, '{"_type": "wagtail.sidebar.SearchModule", "_args": ["/customsearch/"]}')
 
     def test_menu_search(self):
         """

--- a/wagtail/admin/tests/test_menu.py
+++ b/wagtail/admin/tests/test_menu.py
@@ -20,7 +20,6 @@ class TestMenuRendering(TestCase, WagtailTestUtils):
         self.request.user = self.create_superuser(username='admin')
         self.user = self.login()
 
-    @override_settings(WAGTAIL_EXPERIMENTAL_FEATURES={"slim-sidebar"})
     def test_remember_collapsed(self):
         '''Sidebar should render with collapsed class applied.'''
         # Sidebar should not be collapsed
@@ -33,9 +32,9 @@ class TestMenuRendering(TestCase, WagtailTestUtils):
         response = self.client.get(reverse('wagtailadmin_home'))
         self.assertContains(response, 'sidebar-collapsed')
 
-    @override_settings(WAGTAIL_EXPERIMENTAL_FEATURES={})
-    def test_collapsed_only_with_feature_flag(self):
-        '''Sidebar should only remember its collapsed state with the right feature flag set.'''
+    @override_settings(WAGTAIL_EXPERIMENTAL_FEATURES={'legacy-sidebar'})
+    def test_not_collapsed_with_legacy(self):
+        '''Sidebar should only remember its collapsed state with the slim implementation.'''
         # Sidebar should not be collapsed because the feature flag is not enabled
         self.client.cookies['wagtail_sidebar_collapsed'] = '1'
         response = self.client.get(reverse('wagtailadmin_home'))

--- a/wagtail/admin/tests/test_menu.py
+++ b/wagtail/admin/tests/test_menu.py
@@ -32,7 +32,7 @@ class TestMenuRendering(TestCase, WagtailTestUtils):
         response = self.client.get(reverse('wagtailadmin_home'))
         self.assertContains(response, 'sidebar-collapsed')
 
-    @override_settings(WAGTAIL_EXPERIMENTAL_FEATURES={'legacy-sidebar'})
+    @override_settings(WAGTAIL_SLIM_SIDEBAR=False)
     def test_not_collapsed_with_legacy(self):
         '''Sidebar should only remember its collapsed state with the slim implementation.'''
         # Sidebar should not be collapsed because the feature flag is not enabled

--- a/wagtail/admin/tests/test_workflows.py
+++ b/wagtail/admin/tests/test_workflows.py
@@ -41,26 +41,26 @@ class TestWorkflowMenus(TestCase, WagtailTestUtils):
 
     def test_workflow_settings_and_reports_menus_are_shown_to_admin(self):
         response = self.client.get('/admin/')
-        self.assertContains(response, 'href="/admin/workflows/list/"')
-        self.assertContains(response, 'href="/admin/workflows/tasks/index/"')
-        self.assertContains(response, 'href="/admin/reports/workflow/"')
-        self.assertContains(response, 'href="/admin/reports/workflow_tasks/"')
+        self.assertContains(response, '"url": "/admin/workflows/list/"')
+        self.assertContains(response, '"url": "/admin/workflows/tasks/index/"')
+        self.assertContains(response, '"url": "/admin/reports/workflow/"')
+        self.assertContains(response, '"url": "/admin/reports/workflow_tasks/"')
 
     def test_workflow_settings_menus_are_not_shown_to_editor(self):
         self.login(user=self.editor)
         response = self.client.get('/admin/')
-        self.assertNotContains(response, 'href="/admin/workflows/list/"')
-        self.assertNotContains(response, 'href="/admin/workflows/tasks/index/"')
-        self.assertContains(response, 'href="/admin/reports/workflow/"')
-        self.assertContains(response, 'href="/admin/reports/workflow_tasks/"')
+        self.assertNotContains(response, '"url": "/admin/workflows/list/"')
+        self.assertNotContains(response, '"url": "/admin/workflows/tasks/index/"')
+        self.assertContains(response, '"url": "/admin/reports/workflow/"')
+        self.assertContains(response, '"url": "/admin/reports/workflow_tasks/"')
 
     @override_settings(WAGTAIL_WORKFLOW_ENABLED=False)
     def test_workflow_menus_are_hidden_when_workflows_are_disabled(self):
         response = self.client.get('/admin/')
-        self.assertNotContains(response, 'href="/admin/workflows/list/"')
-        self.assertNotContains(response, 'href="/admin/workflows/tasks/index/"')
-        self.assertNotContains(response, 'href="/admin/reports/workflow/"')
-        self.assertNotContains(response, 'href="/admin/reports/workflow_tasks/"')
+        self.assertNotContains(response, '"url": "/admin/workflows/list/"')
+        self.assertNotContains(response, '"url": "/admin/workflows/tasks/index/"')
+        self.assertNotContains(response, '"url": "/admin/reports/workflow/"')
+        self.assertNotContains(response, '"url": "/admin/reports/workflow_tasks/"')
 
 
 class TestWorkflowsIndexView(TestCase, WagtailTestUtils):

--- a/wagtail/admin/tests/tests.py
+++ b/wagtail/admin/tests/tests.py
@@ -33,31 +33,23 @@ class TestHome(TestCase, WagtailTestUtils):
     def test_admin_menu(self):
         response = self.client.get(reverse('wagtailadmin_home'))
         self.assertEqual(response.status_code, 200)
-        # check that media attached to menu items is correctly pulled in
+        # check that custom menu items (including classname / icon_name) are pulled in
         self.assertContains(
             response,
-            '<script src="/static/testapp/js/kittens.js"></script>',
-            html=True
-        )
-
-        # check that custom menu items (including classname / attrs parameters) are pulled in
-        self.assertContains(
-            response,
-            '<a href="http://www.tomroyal.com/teaandkittens/" class="icon icon-kitten" data-fluffy="yes">Kittens!</a>',
-            html=True
+            '{"name": "kittens", "label": "Kittens!", "icon_name": "kitten", "classnames": "kitten--test", "url": "http://www.tomroyal.com/teaandkittens/"}',
         )
 
         # Check that the explorer menu item is here, with the right start page.
         self.assertContains(
             response,
-            'data-explorer-start-page="1"'
+            '{"name": "explorer", "label": "Pages", "icon_name": "folder-open-inverse", "classnames": "", "url": "/admin/pages/"}, 1]'
         )
 
         # check that is_shown is respected on menu items
         response = self.client.get(reverse('wagtailadmin_home') + '?hide-kittens=true')
         self.assertNotContains(
             response,
-            '<a href="http://www.tomroyal.com/teaandkittens/" class="icon icon-kitten" data-fluffy="yes">Kittens!</a>'
+            '{"name": "kittens", "label": "Kittens!", "icon_name": "kitten", "classnames": "kitten--test", "url": "http://www.tomroyal.com/teaandkittens/"}'
         )
 
     def test_dashboard_panels(self):

--- a/wagtail/contrib/settings/tests/test_admin.py
+++ b/wagtail/contrib/settings/tests/test_admin.py
@@ -71,8 +71,6 @@ class TestSettingCreateView(BaseTestSettingView):
     def test_get_edit(self):
         response = self.get()
         self.assertEqual(response.status_code, 200)
-        # there should be a menu item highlighted as active
-        self.assertContains(response, "menu-active")
 
     def test_edit_invalid(self):
         response = self.post(post_data={'foo': 'bar'})
@@ -116,8 +114,6 @@ class TestSettingEditView(BaseTestSettingView):
     def test_get_edit(self):
         response = self.get()
         self.assertEqual(response.status_code, 200)
-        # there should be a menu item highlighted as active
-        self.assertContains(response, "menu-active")
 
     def test_non_existant_model(self):
         response = self.client.get(reverse('wagtailsettings:edit', args=['test', 'foo', 1]))

--- a/wagtail/contrib/settings/tests/test_register.py
+++ b/wagtail/contrib/settings/tests/test_register.py
@@ -19,4 +19,4 @@ class TestRegister(TestCase, WagtailTestUtils):
 
     def test_icon(self):
         admin = self.client.get(reverse('wagtailadmin_home'))
-        self.assertContains(admin, 'icon icon-tag')
+        self.assertContains(admin, 'icon-setting-tag')

--- a/wagtail/tests/testapp/models.py
+++ b/wagtail/tests/testapp/models.py
@@ -1124,7 +1124,7 @@ class ImportantPages(BaseSetting):
         'wagtailcore.Page', related_name="+", null=True, on_delete=models.SET_NULL)
 
 
-@register_setting(icon="tag")
+@register_setting(icon="icon-setting-tag")
 class IconSetting(BaseSetting):
     pass
 

--- a/wagtail/tests/testapp/wagtail_hooks.py
+++ b/wagtail/tests/testapp/wagtail_hooks.py
@@ -1,6 +1,4 @@
-from django import forms
 from django.http import HttpResponse
-from django.templatetags.static import static
 from django.utils.safestring import mark_safe
 
 import wagtail.admin.rich_text.editors.draftail.features as draftail_features
@@ -42,10 +40,6 @@ hooks.register('before_serve_page', block_googlebot)
 
 
 class KittensMenuItem(MenuItem):
-    @property
-    def media(self):
-        return forms.Media(js=[static('testapp/js/kittens.js')])
-
     def is_shown(self, request):
         return not request.GET.get('hide-kittens', False)
 
@@ -55,8 +49,8 @@ def register_kittens_menu_item():
     return KittensMenuItem(
         'Kittens!',
         'http://www.tomroyal.com/teaandkittens/',
-        classnames='icon icon-kitten',
-        attrs={'data-fluffy': 'yes'},
+        classnames='kitten--test',
+        icon_name='kitten',
         order=10000
     )
 


### PR DESCRIPTION
Changes our settings so the slim sidebar is on by default. Fixes #5337. This includes:

- Changing how the feature flag works so it’s opt-out rather than opt-in, with a new `WAGTAIL_SLIM_SIDEBAR` setting to opt out.
- Updating the documentation to match what the slim sidebar provides.
- Updating the release notes, with upgrade consideration notes for anything that’s no longer supported.
- Updating our tests which relied on implementation details of the sidebar.

For this last point, I decided to refactor how the sidebar’s data is transferred client-side a bit, moving to a separate JSON script tag so it’s more readable when troubleshooting and when used in tests.

I’ve also updated the `RemovedInWagtail217Warning` I had added, as indeed upon checking with our deprecation policy it should be `RemovedInWagtail218Warning`.

---

* [x] Do the tests still pass? (https://docs.wagtail.io/en/latest/contributing/developing.html#testing)
* [x] Does the code comply with the style guide? (Run `make lint` from the Wagtail root)
* [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
* [x] For front-end changes: Did you test on all of [Wagtail’s supported environments](https://docs.wagtail.io/en/latest/contributing/developing.html#browser-and-device-support)?
    * **Please list the exact browser and operating system versions you tested**. Chrome, Safari macOS
    * **Please list which assistive technologies you tested**. N/A
* [x] For new features: Has the documentation been updated accordingly?
