### PR TITLE
Make breadcrumbs styling backwards compatible with old markup

### DIFF
--- a/client/scss/components/_breadcrumb.scss
+++ b/client/scss/components/_breadcrumb.scss
@@ -7,6 +7,7 @@
     margin-left: 2em;
     background: $color-teal;
 
+    li,
     .breadcrumb-item {
         display: block;
         float: left;
@@ -33,6 +34,7 @@
         }
     }
 
+    li > a,
     .breadcrumb-link {
         color: $color-white;
         display: block;

--- a/client/scss/components/_header.scss
+++ b/client/scss/components/_header.scss
@@ -57,6 +57,19 @@ header {
         .right:last-child {
             padding-right: 0;
         }
+
+        @include media-breakpoint-down(xs) {
+            .breadcrumb {
+                padding-left: calc(#{$desktop-nice-padding} - 8px);
+            }
+        }
+        @include media-breakpoint-up(sm) {
+            .breadcrumb {
+                margin-left: -$desktop-nice-padding;
+                margin-right: -$desktop-nice-padding;
+                padding-left: $desktop-nice-padding / 2;
+            }
+        }
     }
 
     &.header-with-breadcrumb {

--- a/client/scss/components/_header.scss
+++ b/client/scss/components/_header.scss
@@ -77,7 +77,7 @@ header {
 
         .breadcrumb {
             margin-bottom: 1rem;
-            padding-left: revert;
+            padding-left: $desktop-nice-padding / 2; // rather than padding-left: revert;
         }
     }
 

--- a/wagtail/admin/templates/wagtailadmin/shared/move_breadcrumb.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/move_breadcrumb.html
@@ -3,8 +3,8 @@
 <nav aria-label="{% trans 'Breadcrumb' %}">
     <ul class="breadcrumb">
         {% for page in pages %}
-            <li>
-                <a href="{% url 'wagtailadmin_pages:move_choose_destination' page_to_move_id page.id %}">
+            <li class="breadcrumb-item">
+                <a href="{% url 'wagtailadmin_pages:move_choose_destination' page_to_move_id page.id %}" class="breadcrumb-link">
                     {% if forloop.first %}
                         {% if page.is_root %}{% trans "Root" as label %}{% else %}{% trans 'Home' as label %}{% endif %}
                         {% icon name="site" class_name="home_icon" title=label %}

--- a/wagtail/contrib/modeladmin/templates/modeladmin/includes/breadcrumb.html
+++ b/wagtail/contrib/modeladmin/templates/modeladmin/includes/breadcrumb.html
@@ -1,6 +1,6 @@
 {% load i18n wagtailadmin_tags %}
 <ul class="breadcrumb">
     {% trans 'Home' as home %}
-    <li class="home"><a href="{% url 'wagtailadmin_home' %}">{% icon name="home" class_name="home_icon" title=home %}{% icon name="arrow-right" class_name="arrow_right_icon" %}</a></li>
-    <li><a href="{{ view.index_url }}">{{ view.verbose_name_plural|capfirst }}</a></li>
+    <li class="breadcrumb-item home"><a href="{% url 'wagtailadmin_home' %}" class="breadcrumb-link">{% icon name="home" class_name="home_icon" title=home %}{% icon name="arrow-right" class_name="arrow_right_icon" %}</a></li>
+    <li class="breadcrumb-item"><a href="{{ view.index_url }}" class="breadcrumb-link">{{ view.verbose_name_plural|capfirst }}</a></li>
 </ul>

--- a/wagtail/contrib/modeladmin/tests/test_page_modeladmin.py
+++ b/wagtail/contrib/modeladmin/tests/test_page_modeladmin.py
@@ -345,8 +345,8 @@ class TestHeaderBreadcrumbs(TestCase, WagtailTestUtils):
 
         # check that home breadcrumb link exists
         expected = """
-            <li class="home">
-                <a href="/admin/">
+            <li class="breadcrumb-item home">
+                <a href="/admin/" class="breadcrumb-link">
                     <svg class="icon icon-home home_icon" aria-hidden="true" focusable="false">
                         <use href="#icon-home"></use>
                     </svg>
@@ -374,8 +374,8 @@ class TestHeaderBreadcrumbs(TestCase, WagtailTestUtils):
 
         # check that home breadcrumb link exists
         expected = """
-            <li class="home">
-                <a href="/admin/">
+            <li class="breadcrumb-item home">
+                <a href="/admin/" class="breadcrumb-link">
                     <svg class="icon icon-home home_icon" aria-hidden="true" focusable="false">
                         <use href="#icon-home"></use>
                     </svg>

--- a/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
+++ b/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
@@ -702,8 +702,8 @@ class TestHeaderBreadcrumbs(TestCase, WagtailTestUtils):
 
         # check that home breadcrumb link exists
         expected = """
-            <li class="home">
-                <a href="/admin/">
+            <li class="breadcrumb-item home">
+                <a href="/admin/" class="breadcrumb-link">
                     <svg class="icon icon-home home_icon" aria-hidden="true" focusable="false">
                         <use href="#icon-home"></use>
                     </svg>

--- a/wagtail/contrib/styleguide/templates/wagtailstyleguide/base.html
+++ b/wagtail/contrib/styleguide/templates/wagtailstyleguide/base.html
@@ -736,10 +736,10 @@
 
             <ul class="breadcrumb">
                 {% trans 'Home' as home %}
-                <li class="home"><a href="{% url 'wagtailadmin_home' %}">{% icon name="home" class_name="home_icon" title=home %}{% icon name="arrow-right" class_name="arrow_right_icon" %}</a></li>
-                <li><a href="#"><span class="title">Various</span>{% icon name="arrow-right" class_name="arrow_right_icon" %}</a></li>
-                <li><a href="#"><span class="title">Subpages</span>{% icon name="arrow-right" class_name="arrow_right_icon" %}</a></li>
-                <li><a href="#"><span class="title">There is a max length of this many</span>{% icon name="arrow-right" class_name="arrow_right_icon" %}</a></li>
+                <li class="breadcrumb-item home"><a href="{% url 'wagtailadmin_home' %}" class="breadcrumb-link">{% icon name="home" class_name="home_icon" title=home %}{% icon name="arrow-right" class_name="arrow_right_icon" %}</a></li>
+                <li class="breadcrumb-item "><a href="#" class="breadcrumb-link"><span class="title">Various</span>{% icon name="arrow-right" class_name="arrow_right_icon" %}</a></li>
+                <li class="breadcrumb-item "><a href="#" class="breadcrumb-link"><span class="title">Subpages</span>{% icon name="arrow-right" class_name="arrow_right_icon" %}</a></li>
+                <li class="breadcrumb-item "><a href="#" class="breadcrumb-link"><span class="title">There is a max length of this many</span>{% icon name="arrow-right" class_name="arrow_right_icon" %}</a></li>
             </ul>
 
         </section>


### PR DESCRIPTION
Fixes #7866 

Broke this in 3 commits:

* 1c41286298f2f46e8e84ba34c2901099fc09adc4 adds the backwards compatibility
* f3e2d9ca5d32daf0f89862d623eaf74c67bd0ead tidies up the breadcrumb display in ModelAdmin

<details>
<summary>Results 📸</summary>
![Screenshot 2022-01-14 at 17 12 50](https://user-images.githubusercontent.com/31622/149557626-0c24416e-93e1-4d37-ba15-47ae4ad64bb2.png)
![Screenshot 2022-01-14 at 17 13 06](https://user-images.githubusercontent.com/31622/149557629-dab46c24-4c34-413f-a4da-c4c0797c84f4.png)
![Screenshot 2022-01-14 at 17 13 14](https://user-images.githubusercontent.com/31622/149557630-01c9f579-b6ed-4bd2-a4d8-568e8a796c36.png)
</details>


Finally 85a15bf57d42606041ce928253f7a346cc7a84dd brings the modeladmin/styleguide breadcrumb markup to date

