### PR TITLE
Pin psycopg2 to <2.9 to fix ci on stable/2.11.x

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,7 +95,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install "psycopg2>=2.6"
+          pip install "psycopg2>=2.6,<2.9"
           pip install "${{ matrix.django }}"
           pip install -e .[testing]
       - name: Test
@@ -268,7 +268,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install "psycopg2>=2.6"
+          pip install "psycopg2>=2.6,<2.9"
           pip install "${{ matrix.django }}"
           pip install -e .[testing]
           pip install "elasticsearch>=6,<7"
@@ -316,7 +316,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install "psycopg2>=2.6"
+          pip install "psycopg2>=2.6,<2.9"
           pip install "${{ matrix.django }}"
           pip install -e .[testing]
           pip install "elasticsearch>=7,<8"


### PR DESCRIPTION
As per https://github.com/psycopg/psycopg2/issues/1293#issuecomment-974636535 - to get CI working correctly on Wagtail 2.11 (which still specifies Django 2.x support), we need to pin psycopg2 to <2.9.