### PR TITLE
Skip creating pipfile.lock on circleci for wagtail 2.11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
           keys:
             - pip-packages-v1-{{ .Branch }}
             - pip-packages-v1-
-      - run: pipenv install -e .[testing]
+      - run: pipenv install --skip-lock -e .[testing]
       - save_cache:
           paths:
             - ~/.local/


### PR DESCRIPTION
It appears that this step is ignoring python_requires specifiers, possibly because it's running under a newer python than we ultimately do the installation under, and as a result it's selecting incompatible package versions (asgiref 3.5, pillow 9.0)
