### PR TITLE
Fix Sqlite FTS5 compatibility check

### DIFF
--- a/wagtail/search/backends/database/sqlite/utils.py
+++ b/wagtail/search/backends/database/sqlite/utils.py
@@ -14,7 +14,7 @@ def fts5_available():
     tmp_db = sqlite3.connect(':memory:')
     try:
         tmp_db.execute('CREATE VIRTUAL TABLE fts5test USING fts5 (data);')
-    except OperationalError:
+    except sqlite3.OperationalError:
         return False
     finally:
         tmp_db.close()


### PR DESCRIPTION
As per https://github.com/wagtail/wagtail/issues/7798#issuecomment-1021544265 - the direct query against the sqlite3 library will fail with sqlite3.OperationalError, not django.db.OperationalError.
