### PR TITLE
Fix #7884 Redirects: 'target page route' with non-RoutablePageMixin pages

### DIFF
--- a/wagtail/contrib/redirects/forms.py
+++ b/wagtail/contrib/redirects/forms.py
@@ -43,7 +43,7 @@ class RedirectForm(forms.ModelForm):
 
     class Meta:
         model = Redirect
-        fields = ('old_path', 'site', 'is_permanent', 'redirect_page', 'redirect_page_route_path', 'redirect_link')
+        fields = ('old_path', 'site', 'is_permanent', 'redirect_page', 'redirect_link')
 
 
 class ImportForm(forms.Form):

--- a/wagtail/contrib/redirects/models.py
+++ b/wagtail/contrib/redirects/models.py
@@ -60,7 +60,7 @@ class Redirect(models.Model):
                 return base_url
             try:
                 page.resolve_subpage(self.redirect_page_route_path)
-            except Resolver404:
+            except (AttributeError, Resolver404):
                 return base_url
             return base_url.rstrip("/") + self.redirect_page_route_path
         elif self.redirect_link:

--- a/wagtail/contrib/redirects/tests/test_redirects.py
+++ b/wagtail/contrib/redirects/tests/test_redirects.py
@@ -170,6 +170,7 @@ class TestRedirects(TestCase):
             title="Routable Page",
             live=True,
         ))
+        contact_page = Page.objects.get(url_path='/home/contact-us/')
 
         # test redirect with a VALID route path
         models.Redirect.add_redirect(old_path='/old-path-one', redirect_to=routable_page, page_route_path='/render-method-test-custom-template/')
@@ -179,7 +180,14 @@ class TestRedirects(TestCase):
         # test redirect with an INVALID route path
         models.Redirect.add_redirect(old_path='/old-path-two', redirect_to=routable_page, page_route_path='/invalid-route/')
         response = self.client.get('/old-path-two/', HTTP_HOST='test.example.com')
+        # we should still make it to the correct page
         self.assertRedirects(response, '/routable-page/', status_code=301, fetch_redirect_response=False)
+
+        # test redirect with route path for a non-routable page
+        models.Redirect.add_redirect(old_path="/old-path-three", redirect_to=contact_page, page_route_path="/route-to-nowhere/")
+        response = self.client.get('/old-path-three/', HTTP_HOST='test.example.com')
+        # we should still make it to the correct page
+        self.assertRedirects(response, "/contact-us/", status_code=301, fetch_redirect_response=False)
 
     def test_redirect_from_any_site(self):
         contact_page = Page.objects.get(url_path='/home/contact-us/')


### PR DESCRIPTION
Resolves #7884

There's no easy way to toggle fields based on chooser selection, so it makes sense for the field to be hidden for now (as per @gasman's [comment](https://github.com/wagtail/wagtail/issues/7884#issuecomment-1023213355)).

It should no longer be possible to created an invalid redirect from within the UI, but have accounted for the `AttributeError` anyway, as there are other potential ways to bump into that (e.g. switching to a branch where the specific page type is missing) 

The UI should be looked at more holistically, as the issues are bigger than just this one field.