### PR TITLE
remove dateformat library usage

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -6,6 +6,7 @@ Changelog
 
 * Upgrade ESLint and Stylelint configurations to latest shared Wagtail configs (Thibaud Colas)
 * Major updates to frontend tooling; move Node tooling from Gulp to Webpack, upgrade to Node v16 and npm v8, eslint v8, stylelint v14 and others (Thibaud Colas)
+* Change comment headers’ date formatting to use browser APIs instead of requiring a library (LB (Ben Johnston))
 
 
 2.16 (xx.xx.xxxx) - IN DEVELOPMENT

--- a/client/src/components/CommentApp/components/CommentHeader/index.tsx
+++ b/client/src/components/CommentApp/components/CommentHeader/index.tsx
@@ -1,4 +1,3 @@
-import dateFormat from 'dateformat';
 import React, { FunctionComponent, useState, useEffect, useRef } from 'react';
 import Icon from '../../../Icon/Icon';
 import type { Store } from '../../state';
@@ -6,6 +5,12 @@ import { TranslatableStrings } from '../../main';
 import { IS_IE11 } from '../../../../config/wagtailConfig';
 
 import { Author } from '../../state/comments';
+
+const dateOptions: Intl.DateTimeFormatOptions | any = {
+  dateStyle: 'medium',
+  timeStyle: 'short',
+};
+const dateTimeFormat = new Intl.DateTimeFormat([], dateOptions);
 
 // Details/Summary components that just become <details>/<summary> tags
 // except for IE11 where they become <div> tags to allow us to style them
@@ -134,6 +139,8 @@ export const CommentHeader: FunctionComponent<CommentHeaderProps> = ({
     };
   }, []);
 
+  const dateISO = new Date(date).toISOString();
+
   return (
     <div className="comment-header">
       <div className="comment-header__actions">
@@ -192,7 +199,7 @@ export const CommentHeader: FunctionComponent<CommentHeaderProps> = ({
       <span id={descriptionId}>
         <p className="comment-header__author">{author ? author.name : ''}</p>
         <p className="comment-header__date">
-          {dateFormat(date, 'd mmm yyyy HH:MM')}
+          <time dateTime={dateISO}>{dateTimeFormat.format(date)}</time>
         </p>
       </span>
     </div>

--- a/docs/releases/2.17.md
+++ b/docs/releases/2.17.md
@@ -13,6 +13,7 @@
 
  * Upgrade ESLint and Stylelint configurations to latest shared Wagtail configs (Thibaud Colas)
  * Major updates to frontend tooling; move Node tooling from Gulp to Webpack, upgrade to Node v16 and npm v8, eslint v8, stylelint v14 and others (Thibaud Colas)
+ * Change comment headers’ date formatting to use browser APIs instead of requiring a library (LB (Ben Johnston))
 
 
 ### Bug fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,11 +5,9 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "wagtail",
       "version": "1.0.0",
       "dependencies": {
         "core-js": "^2.5.3",
-        "dateformat": "^2.2.0",
         "draft-js": "^0.10.5",
         "draftail": "^1.4.1",
         "draftjs-filters": "^2.5.0",
@@ -14123,14 +14121,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/dateformat": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
-      "integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI=",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/debug": {
@@ -40149,11 +40139,6 @@
         "whatwg-mimetype": "^2.3.0",
         "whatwg-url": "^8.0.0"
       }
-    },
-    "dateformat": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
-      "integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI="
     },
     "debug": {
       "version": "4.3.3",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,6 @@
   },
   "dependencies": {
     "core-js": "^2.5.3",
-    "dateformat": "^2.2.0",
     "draft-js": "^0.10.5",
     "draftail": "^1.4.1",
     "draftjs-filters": "^2.5.0",


### PR DESCRIPTION
* Fix for #7904 
* Do the tests still pass? ✅ 
* Does the code comply with the style guide? ✅ 
* For front-end changes;
  * Chrome 99 MacOS, Firefox 96 MacOS, Safari 15 MacOS, Edge 97 Windows 10
  * NVDA Windows 10
* Note: This will NOT work in IE11
* Had to use the any for the date format options due to this current ts issue https://github.com/microsoft/TypeScript/issues/38266#issuecomment-912508678 (while the issue is closed, reading the comments says the bug still exists)
* Update: added time element also for better screen reader support with no visual changes https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time

## Screenshots
**Edge / NVDA**
<img width="1607" alt="Screen Shot 2022-02-01 at 8 10 16 am" src="https://user-images.githubusercontent.com/1396140/151881844-405a8223-4eeb-45c7-9992-eabde4ca766f.png">

**Chrome**
<img width="648" alt="Screen Shot 2022-02-01 at 8 06 07 am" src="https://user-images.githubusercontent.com/1396140/151881878-93c508a9-17e4-4fcc-951f-4da4038a6fa2.png">

**Safari**
<img width="1436" alt="Screen Shot 2022-02-01 at 8 05 38 am" src="https://user-images.githubusercontent.com/1396140/151881920-35dbb76e-a00e-4fca-ba22-721ca1465893.png">

**Firefox**
<img width="307" alt="Screen Shot 2022-02-01 at 7 56 14 am" src="https://user-images.githubusercontent.com/1396140/151881943-4652e35b-844c-44d9-994a-a90c6fa94d40.png">

**Time element**
Reminder - ISO strings are always UTC

<img width="1286" alt="Screen Shot 2022-02-01 at 8 18 30 am" src="https://user-images.githubusercontent.com/1396140/151882849-783c6457-4ff9-4e38-8307-4433b467ee9a.png">



