### PR TITLE
Apply unlocalize filter to bulk action object ids

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -8,6 +8,7 @@ Changelog
  * Major updates to frontend tooling; move Node tooling from Gulp to Webpack, upgrade to Node v16 and npm v8, eslint v8, stylelint v14 and others (Thibaud Colas)
  * Change comment headers’ date formatting to use browser APIs instead of requiring a library (LB (Ben Johnston))
  * Fix issue where invalid bulk action URLs would incorrectly trigger a server error (500) instead of a valid not found (404) (Ihor Marhitych)
+ * Fix issue where bulk actions would not work for object IDs greater than 999 when `USE_THOUSAND_SEPARATOR` (Dennis McGregor)
 
 
 2.16.1 (xx.xx.xxxx) - IN DEVELOPMENT

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -560,6 +560,7 @@ Contributors
 * Jason Attwood
 * Vladimir Tananko
 * Rizwan Mansuri
+* Dennis McGregor
 
 Translators
 ===========

--- a/docs/releases/2.17.md
+++ b/docs/releases/2.17.md
@@ -19,6 +19,7 @@
 ### Bug fixes
 
  * Fix issue where invalid bulk action URLs would incorrectly trigger a server error (500) instead of a valid not found (404) (Ihor Marhitych)
+ * Fix issue where bulk actions would not work for object IDs greater than 999 when `USE_THOUSAND_SEPARATOR` (Dennis McGregor)
 
 
 ## Upgrade considerations

--- a/wagtail/admin/templates/wagtailadmin/bulk_actions/listing_checkbox_cell.html
+++ b/wagtail/admin/templates/wagtailadmin/bulk_actions/listing_checkbox_cell.html
@@ -1,8 +1,8 @@
-{% load i18n wagtailadmin_tags %}
+{% load i18n l10n wagtailadmin_tags %}
 <td>
     <input type="checkbox"
     {% if obj_type == 'page' %}data-page-status="{% if obj.live %}live{% else %}draft{% endif %}"{% endif %}
-    data-object-id="{{obj.id}}" data-bulk-action-checkbox class="bulk-action-checkbox"
+    data-object-id="{{obj.id|unlocalize}}" data-bulk-action-checkbox class="bulk-action-checkbox"
     {% if checkbox_aria_label %}aria-label="{{checkbox_aria_label}}"{% endif %}
     {% if aria_labelledby %}aria-labelledby="{{ aria_labelledby_prefix }}{{ aria_labelledby }}{{ aria_labelledby_suffix }}"{% endif %}
     />

--- a/wagtail/admin/tests/pages/test_explorer_view.py
+++ b/wagtail/admin/tests/pages/test_explorer_view.py
@@ -220,6 +220,22 @@ class TestPageExplorer(TestCase, WagtailTestUtils):
         # Check that we got the last page
         self.assertEqual(response.context['pages'].number, response.context['pages'].paginator.num_pages)
 
+    @override_settings(USE_L10N=True, USE_THOUSAND_SEPARATOR=True)
+    def test_no_thousand_separators_in_bulk_action_checkbox(self):
+        """
+        Test that the USE_THOUSAND_SEPARATOR setting does mess up object IDs in
+        bulk actions checkboxes
+        """
+        self.root_page.add_child(instance=SimplePage(
+            pk=1000,
+            title="Page 1000",
+            slug="page-1000",
+            content="hello",
+        ))
+        response = self.client.get(reverse('wagtailadmin_explore', args=(self.root_page.id, )))
+        expected = 'data-object-id="1000"'
+        self.assertContains(response, expected)
+
     def test_listing_uses_specific_models(self):
         # SingleEventPage has custom URL routing; the 'live' link in the listing
         # should show the custom URL, which requires us to use the specific version


### PR DESCRIPTION
Bulk Actions were failing for objects with id > 999 in projects with Django settings `USE_L10N` and `USE_THOUSAND_SEPARATOR` enabled.

Thanks for contributing to Wagtail! 🎉

Before submitting, please review the contributor guidelines <https://docs.wagtail.org/en/latest/contributing/index.html> and check the following:

* Do the tests still pass? (https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
* Does the code comply with the style guide? (Run `make lint` from the Wagtail root)
* For Python changes: Have you added tests to cover the new/fixed behaviour?
* For front-end changes: Did you test on all of [Wagtail’s supported environments](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)?
    * **Please list the exact browser and operating system versions you tested**.
    * **Please list which assistive technologies you tested**.
* For new features: Has the documentation been updated accordingly?
