### PR TITLE
Updated docs link to supported Django version

### DIFF
--- a/docs/topics/pages.md
+++ b/docs/topics/pages.md
@@ -4,7 +4,7 @@
 Each page type (a.k.a. content type) in Wagtail is represented by a Django model. All page models must inherit from the :class:`wagtail.core.models.Page` class.
 ```
 
-As all page types are Django models, you can use any field type that Django provides. See [Model field reference](https://docs.djangoproject.com/en/3.1/ref/models/fields/) for a complete list of field types you can use. Wagtail also provides `wagtail.core.fields.RichTextField` which provides a WYSIWYG editor for editing rich-text content.
+As all page types are Django models, you can use any field type that Django provides. See [Model field reference](https://docs.djangoproject.com/en/stable/ref/models/fields/) for a complete list of field types you can use. Wagtail also provides `wagtail.core.fields.RichTextField` which provides a WYSIWYG editor for editing rich-text content.
 
 ```eval_rst
 .. note::


### PR DESCRIPTION
Using the `stable` URL fragment will always point to the latest major version, whereas 3.1, which was linked, is now end of life.

Thanks for contributing to Wagtail! 🎉

Before submitting, please review the contributor guidelines <https://docs.wagtail.org/en/latest/contributing/index.html> and check the following:

* Do the tests still pass? (https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
* Does the code comply with the style guide? (Run `make lint` from the Wagtail root)
* For Python changes: Have you added tests to cover the new/fixed behaviour?
* For front-end changes: Did you test on all of [Wagtail’s supported environments](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)?
    * **Please list the exact browser and operating system versions you tested**.
    * **Please list which assistive technologies you tested**.
* For new features: Has the documentation been updated accordingly?
