### PR TITLE
Improve performance of new private pages in API functionality

### DIFF
--- a/wagtail/api/v2/tests/test_pages.py
+++ b/wagtail/api/v2/tests/test_pages.py
@@ -12,6 +12,7 @@ from rest_framework.test import APIClient
 
 from wagtail.api.v2 import signal_handlers
 from wagtail.core.models import Locale, Page, Site
+from wagtail.core.models.view_restrictions import BaseViewRestriction
 from wagtail.tests.demosite import models
 from wagtail.tests.testapp.models import StreamPage
 from wagtail.tests.utils import WagtailTestUtils
@@ -75,7 +76,7 @@ class TestPageListing(TestCase, WagtailTestUtils):
         total_count = get_total_page_count()
 
         page = models.BlogIndexPage.objects.get(id=5)
-        page.view_restrictions.create(password='test')
+        page.view_restrictions.create(restriction_type=BaseViewRestriction.PASSWORD, password='test')
 
         new_total_count = get_total_page_count()
         self.assertNotEqual(total_count, new_total_count)


### PR DESCRIPTION
Fixes #7924

This PR reimplements the improvement made in https://github.com/wagtail/wagtail/pull/7385 in a more performant way. Instead of iterating through all pages on a site and check each ones privacy settings, this iterates all the privacy settings that apply to the current request and constructs a queryset to exclude any affected pages.

This also has the side effect of allowing password protected pages to be fetched over the API too (but we haven't got an API version of the password form itself though)