### PR TITLE
Do not use extras in install_requires.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,9 +34,11 @@ install_requires = [
     "requests>=2.11.1,<3.0",
     "l18n>=2018.5",
     "xlsxwriter>=1.2.8,<4.0",
-    "tablib[xls,xlsx]>=0.14.0",
     "anyascii>=0.1.5",
     "telepath>=0.1.1,<1",
+    "tablib>=0.14.0",
+    # optional tablib dependencies
+    "xlrd", "xlwt", "openpyxl>=2.6.0",
 ]
 
 # Testing dependencies


### PR DESCRIPTION
Since we are not depending on a certain version of setuptools, don't use
extras syntax when stating dependencies in install_requires. This feature
does not work in all relevant setuptools versions that are in default installs.
These kind of dependencies are incorrectly resolved as 'openpyxl>=2.6.0; extra == "xlsx"':
```
    pkg_resources.DistributionNotFound: The 'openpyxl>=2.6.0; extra == "xlsx"' distribution was not found and is required by tablib
```
By older versions of setuptools.