### PR TITLE
Fix `assertQuerysetEqual` failures in Django main

### DIFF
--- a/wagtail/snippets/tests.py
+++ b/wagtail/snippets/tests.py
@@ -858,7 +858,7 @@ class TestSnippetDelete(TestCase, WagtailTestUtils):
 
         def hook_func(request, instances):
             self.assertIsInstance(request, HttpRequest)
-            self.assertQuerysetEqual(instances, ["<Advert: Test hook>"])
+            self.assertQuerysetEqual(instances, ["<Advert: Test hook>"], transform=repr)
             return HttpResponse("Overridden!")
 
         with self.register_hook('before_delete_snippet', hook_func):
@@ -875,7 +875,7 @@ class TestSnippetDelete(TestCase, WagtailTestUtils):
 
         def hook_func(request, instances):
             self.assertIsInstance(request, HttpRequest)
-            self.assertQuerysetEqual(instances, ["<Advert: Test hook>"])
+            self.assertQuerysetEqual(instances, ["<Advert: Test hook>"], transform=repr)
             return HttpResponse("Overridden!")
 
         with self.register_hook('before_delete_snippet', hook_func):
@@ -897,7 +897,7 @@ class TestSnippetDelete(TestCase, WagtailTestUtils):
 
         def hook_func(request, instances):
             self.assertIsInstance(request, HttpRequest)
-            self.assertQuerysetEqual(instances, ["<Advert: Test hook>"])
+            self.assertQuerysetEqual(instances, ["<Advert: Test hook>"], transform=repr)
             return HttpResponse("Overridden!")
 
         with self.register_hook('after_delete_snippet', hook_func):


### PR DESCRIPTION
Django 4.1 deprecates handling of repr comparison without an explicit transform kwarg

Ref: https://github.com/django/django/blob/stable/3.2.x/django/test/testcases.py#L1045-L1061
https://github.com/django/django/blob/stable/4.0.x/django/test/testcases.py#L1062-L1078