### PR TITLE
Refine alias page logging

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -12,6 +12,8 @@ Changelog
  * Support pickling of StreamField values (pySilver)
  * Move `SnippetViewSet` template override mechanism to `ModelViewSet` (Sage Abdullah)
  * Move `SnippetViewSet.list_display` to `ModelViewSet` (Sage Abdullah)
+ * Remove `wagtail.publish` log action on aliases when they are created from live source pages or the source page is published (Dan Braghis)
+ * Remove `wagtail.unpublish` log action on aliases when source page is unpublished (Dan Braghis)
  * Fix: Ensure that StreamField's `FieldBlock`s correctly set the `required` and `aria-describedby` attributes (Storm Heg)
  * Docs: Document `WAGTAILADMIN_BASE_URL` on "Integrating Wagtail into a Django project" page (Shreshth Srivastava)
  * Docs: Replace incorrect screenshot for authors listing on tutorial (Shreshth Srivastava)

--- a/docs/releases/5.2.md
+++ b/docs/releases/5.2.md
@@ -22,6 +22,8 @@ depth: 1
  * Support pickling of StreamField values (pySilver)
  * Move `SnippetViewSet` template override mechanism to `ModelViewSet` (Sage Abdullah)
  * Move `SnippetViewSet.list_display` to `ModelViewSet` (Sage Abdullah)
+ * Remove `wagtail.publish` log action on aliases when they are created from live source pages or the source page is published (Dan Braghis)
+ * Remove `wagtail.unpublish` log action on aliases when source page is unpublished (Dan Braghis)
 
 ### Bug fixes
 

--- a/wagtail/actions/create_alias.py
+++ b/wagtail/actions/create_alias.py
@@ -199,13 +199,6 @@ class CreatePageAliasAction:
                     else None,
                 },
             )
-            if alias.live:
-                # Log the publish
-                log(
-                    instance=alias,
-                    action="wagtail.publish",
-                    user=user,
-                )
 
         logger.info(
             'Page alias created: "%s" id=%d from=%d', alias.title, alias.id, page.id

--- a/wagtail/actions/publish_page_revision.py
+++ b/wagtail/actions/publish_page_revision.py
@@ -32,7 +32,7 @@ class PublishPageRevisionAction(PublishRevisionAction):
     :param previous_revision: indicates a revision reversal. Should be set to the previous revision instance
     """
 
-    def check(self, skip_permission_checks=False):
+    def check(self, skip_permission_checks: bool = False):
         if (
             self.user
             and not skip_permission_checks
@@ -59,5 +59,5 @@ class PublishPageRevisionAction(PublishRevisionAction):
         super()._after_publish()
 
         self.object.update_aliases(
-            revision=self.revision, user=self.user, _content=self.revision.content
+            revision=self.revision, _content=self.revision.content
         )

--- a/wagtail/actions/publish_revision.py
+++ b/wagtail/actions/publish_revision.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 import logging
+from typing import TYPE_CHECKING, Optional
 
 from django.conf import settings
 from django.core.exceptions import PermissionDenied
@@ -8,6 +11,9 @@ from wagtail.log_actions import log
 from wagtail.permission_policies.base import ModelPermissionPolicy
 from wagtail.signals import published
 from wagtail.utils.timestamps import ensure_utc
+
+if TYPE_CHECKING:
+    from wagtail.models import Revision
 
 logger = logging.getLogger("wagtail")
 
@@ -36,7 +42,12 @@ class PublishRevisionAction:
     """
 
     def __init__(
-        self, revision, user=None, changed=True, log_action=True, previous_revision=None
+        self,
+        revision: Revision,
+        user=None,
+        changed: bool = True,
+        log_action: bool = True,
+        previous_revision: Optional[Revision] = None,
     ):
         self.revision = revision
         self.object = self.revision.as_object()
@@ -90,7 +101,13 @@ class PublishRevisionAction:
                 workflow_state.cancel(user=self.user)
 
     def _publish_revision(
-        self, revision, object, user, changed, log_action, previous_revision
+        self,
+        revision: Revision,
+        object,
+        user,
+        changed,
+        log_action: bool,
+        previous_revision: Optional[Revision] = None,
     ):
         from wagtail.models import Revision
 

--- a/wagtail/actions/unpublish_page.py
+++ b/wagtail/actions/unpublish_page.py
@@ -47,7 +47,7 @@ class UnpublishPageAction(UnpublishAction):
 
     def _after_unpublish(self, object):
         for alias in object.aliases.all():
-            alias.unpublish()
+            alias.unpublish(log_action=False)
 
         page_unpublished.send(sender=object.specific_class, instance=object.specific)
 

--- a/wagtail/models/__init__.py
+++ b/wagtail/models/__init__.py
@@ -1736,18 +1736,14 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
         else:
             return self.specific
 
-    def update_aliases(
-        self, *, revision=None, user=None, _content=None, _updated_ids=None
-    ):
+    def update_aliases(self, *, revision=None, _content=None, _updated_ids=None):
         """
         Publishes all aliases that follow this page with the latest content from this page.
 
         This is called by Wagtail whenever a page with aliases is published.
 
-        :param revision: The revision of the original page that we are updating to (used for logging purposes).
-        :type revision: Revision, optional
-        :param user: The user who is publishing (used for logging purposes).
-        :type user: User, optional
+        :param revision: The revision of the original page that we are updating to (used for logging purposes)
+        :type revision: PageRevision, optional
         """
         specific_self = self.specific
 
@@ -1836,13 +1832,6 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
                 instance=alias_updated,
                 revision=revision,
                 alias=True,
-            )
-
-            # Log the publish of the alias
-            log(
-                instance=alias_updated,
-                action="wagtail.publish",
-                user=user,
             )
 
             # Update any aliases of that alias

--- a/wagtail/tests/test_audit_log.py
+++ b/wagtail/tests/test_audit_log.py
@@ -93,7 +93,9 @@ class TestAuditLog(TestCase):
         self.home_page.save()
         alias = self.home_page.create_alias(update_slug="the-alias")
         self.assertTrue(alias.live)
-        self.assertEqual(PageLogEntry.objects.filter(action='wagtail.publish').count(), 0)
+        self.assertEqual(
+            PageLogEntry.objects.filter(action="wagtail.publish").count(), 0
+        )
 
     def test_page_edit(self):
         # Directly saving a revision should not yield a log entry
@@ -123,7 +125,9 @@ class TestAuditLog(TestCase):
         self.home_page.create_alias(update_slug="the-alias")
         revision = self.home_page.save_revision()
         revision.publish()
-        self.assertEqual(PageLogEntry.objects.filter(action='wagtail.publish').count(), 1)
+        self.assertEqual(
+            PageLogEntry.objects.filter(action="wagtail.publish").count(), 1
+        )
 
     def test_page_rename(self):
         # Should not log a name change when publishing the first revision
@@ -156,6 +160,13 @@ class TestAuditLog(TestCase):
     def test_page_unpublish(self):
         self.home_page.unpublish()
         self.assertEqual(PageLogEntry.objects.count(), 1)
+        self.assertEqual(
+            PageLogEntry.objects.filter(action="wagtail.unpublish").count(), 1
+        )
+
+    def test_page_unpublish_doesnt_log_for_aliases(self):
+        self.home_page.create_alias(update_slug="the-alias")
+        self.home_page.unpublish()
         self.assertEqual(
             PageLogEntry.objects.filter(action="wagtail.unpublish").count(), 1
         )

--- a/wagtail/tests/test_audit_log.py
+++ b/wagtail/tests/test_audit_log.py
@@ -112,6 +112,12 @@ class TestAuditLog(TestCase):
             PageLogEntry.objects.filter(action="wagtail.publish").count(), 1
         )
 
+    def test_page_publish_doesnt_log_for_aliases(self):
+        self.home_page.create_alias(update_slug="the-alias")
+        revision = self.home_page.save_revision()
+        revision.publish()
+        self.assertEqual(PageLogEntry.objects.filter(action='wagtail.publish').count(), 1)
+
     def test_page_rename(self):
         # Should not log a name change when publishing the first revision
         revision = self.home_page.save_revision()

--- a/wagtail/tests/test_audit_log.py
+++ b/wagtail/tests/test_audit_log.py
@@ -88,6 +88,13 @@ class TestAuditLog(TestCase):
         self.assertEqual(log_entry.content_type, page.content_type)
         self.assertEqual(log_entry.label, page.get_admin_display_title())
 
+    def test_alias_create_from_published_page_doesnt_log_publish_action(self):
+        self.home_page.live = True
+        self.home_page.save()
+        alias = self.home_page.create_alias(update_slug="the-alias")
+        self.assertTrue(alias.live)
+        self.assertEqual(PageLogEntry.objects.filter(action='wagtail.publish').count(), 0)
+
     def test_page_edit(self):
         # Directly saving a revision should not yield a log entry
         self.home_page.save_revision()

--- a/wagtail/tests/test_page_model.py
+++ b/wagtail/tests/test_page_model.py
@@ -2770,11 +2770,11 @@ class TestUpdateAliases(TestCase):
         self.assertEqual(alias.draft_title, "Updated title")
         self.assertEqual(alias_alias.draft_title, "Updated title")
 
-        # Check log entries were created
-        self.assertTrue(
+        # Check no log entries were created for the aliases
+        self.assertFalse(
             PageLogEntry.objects.filter(page=alias, action="wagtail.publish").exists()
         )
-        self.assertTrue(
+        self.assertFalse(
             PageLogEntry.objects.filter(
                 page=alias_alias, action="wagtail.publish"
             ).exists()
@@ -2815,11 +2815,11 @@ class TestUpdateAliases(TestCase):
         self.assertTrue(alias.live)
         self.assertTrue(alias_alias.live)
 
-        # Check log entries were created
-        self.assertTrue(
+        # Check no log entries were created for the aliases
+        self.assertFalse(
             PageLogEntry.objects.filter(page=alias, action="wagtail.publish").exists()
         )
-        self.assertTrue(
+        self.assertFalse(
             PageLogEntry.objects.filter(
                 page=alias_alias, action="wagtail.publish"
             ).exists()
@@ -3595,11 +3595,11 @@ class TestUnpublish(TestCase):
         self.assertFalse(alias.live)
         self.assertFalse(alias_alias.live)
 
-        # Check log entries were created for the aliases
-        self.assertTrue(
+        # Check no log entries were created for the aliases
+        self.assertFalse(
             PageLogEntry.objects.filter(page=alias, action="wagtail.unpublish").exists()
         )
-        self.assertTrue(
+        self.assertFalse(
             PageLogEntry.objects.filter(
                 page=alias_alias, action="wagtail.unpublish"
             ).exists()


### PR DESCRIPTION
This PR fixes #7593 and removes:

* `wagtail.publish` log action on aliases when 
   * they are created from live source pages
   * source page is published
* `wagtail.unpublish` log action on aliases when source page is unpublished

