### PR TITLE
Redirect to page edit view when submitting for a single locale

### DIFF
--- a/wagtail/contrib/simple_translation/tests/test_views.py
+++ b/wagtail/contrib/simple_translation/tests/test_views.py
@@ -150,15 +150,17 @@ class TestSubmitPageTranslationView(WagtailTestUtils, TestCase):
         de = Locale.objects.get(language_code="de").id
         data = {"locales": [de], "include_subtree": True}
         self.login()
-        response = self.client.post(url, data)
+        response = self.client.post(url, data, follow=True)
 
-        assert response.status_code == 302
-        assert response.url == f"/admin/pages/{self.en_blog_index.get_parent().id}/"
+        translated_page = self.en_blog_index.get_translation(de)
+        self.assertRedirects(
+            response, reverse("wagtailadmin_pages:edit", args=[translated_page.pk])
+        )
 
-        response = self.client.get(response.url)  # follow the redirect
-        assert [msg.message for msg in response.context["messages"]] == [
-            "The page 'Blog' was successfully created in German"
-        ]
+        self.assertIn(
+            "The page 'Blog' was successfully created in German",
+            [msg.message for msg in response.context["messages"]],
+        )
 
     def test_submit_page_translation_view_test_post_multiple_locales(self):
         # Needs an extra page to hit recursive function
@@ -238,6 +240,27 @@ class TestSubmitSnippetTranslationView(WagtailTestUtils, TestCase):
             "pk": 99,
         }
         self.assertEqual(view.get_success_url(), "/admin/snippets/some_app/some_model/edit/99/")
+
+    def test_get_success_url_for_single_locale(self):
+        view = SubmitSnippetTranslationView()
+        view.object = self.en_snippet
+        view.kwargs = {
+            "app_label": "some_app",
+            "model_name": "some_model",
+            "pk": 99,
+        }
+
+        self.assertEqual(
+            view.get_success_url(view.object),
+            reverse(
+                "wagtailsnippets:edit",
+                args=[
+                    "some_app",
+                    "some_model",
+                    view.object.pk,
+                ],
+            ),
+        )
 
     def test_get_success_message(self):
         view = SubmitSnippetTranslationView()


### PR DESCRIPTION
When an editor decides to submit a page for translation and only chooses one locale, they are redirected to the new translated page's edit view. This behaviour is the same for snippets.

The behaviour is unchanged when translating pages/snippets to multiple locales.

This is the `simple_translations` counterpart to this change on wagtail-localize: https://github.com/wagtail/wagtail-localize/pull/518