### PR TITLE
slim sidebar - use sameSite lax by default

### DIFF
--- a/client/src/components/Sidebar/index.tsx
+++ b/client/src/components/Sidebar/index.tsx
@@ -7,6 +7,7 @@ import { Sidebar } from './Sidebar';
 export const SIDEBAR_COLLAPSED_COOKIE_NAME = 'wagtail_sidebar_collapsed';
 
 export function initSidebar() {
+  const cookieOptions = { sameSite: 'lax' };
   const element = document.getElementById('wagtail-sidebar');
   const rawProps = document.getElementById('wagtail-sidebar-props');
 
@@ -33,10 +34,10 @@ export function initSidebar() {
     const onExpandCollapse = (_collapsed: boolean) => {
       if (_collapsed) {
         document.body.classList.add('sidebar-collapsed');
-        Cookies.set(SIDEBAR_COLLAPSED_COOKIE_NAME, 1);
+        Cookies.set(SIDEBAR_COLLAPSED_COOKIE_NAME, 1, cookieOptions);
       } else {
         document.body.classList.remove('sidebar-collapsed');
-        Cookies.set(SIDEBAR_COLLAPSED_COOKIE_NAME, 0);
+        Cookies.set(SIDEBAR_COLLAPSED_COOKIE_NAME, 0, cookieOptions);
       }
     };
 


### PR DESCRIPTION
- this will ensure that the cookie will work as expected in future browser changes on HTTP or HTTPS setups
- fixes https://github.com/wagtail/wagtail/issues/7910


* Does the code comply with the style guide? 👍 
* For front-end changes: manually tested on Chrome 99, Safari 15, Firefox 96 on macOS
* I tried to add a unit test for this but kept running into ts-jest errors

caniuse - samesite
![Screen Shot 2022-02-10 at 7 19 24 am](https://user-images.githubusercontent.com/1396140/153301963-428d6866-8e42-4f5d-878d-2adb5429382b.png)

Browser validation
![Screen Shot 2022-02-10 at 7 15 42 am](https://user-images.githubusercontent.com/1396140/153302009-497e2bed-98bb-4754-82db-aef3ec83a8ad.png)


<img width="1698" alt="Screen Shot 2022-02-10 at 7 18 37 am" src="https://user-images.githubusercontent.com/1396140/153301995-4145f996-0b20-46d8-b0b9-5323f22319d1.png">

