### PR TITLE
Improve asserts in wagtail.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ testing_extras = [
     'flake8-blind-except==0.1.1',
     'flake8-print==2.0.2',
     'doc8==0.8.1',
+    'flake8-assertive==2.0.0',
 
     # For templates linting
     'jinjalint>=0.5',

--- a/wagtail/admin/tests/api/test_pages.py
+++ b/wagtail/admin/tests/api/test_pages.py
@@ -1136,21 +1136,21 @@ class TestPublishPageAction(AdminAPITestCase):
 
     def test_publish_page(self):
         unpublished_page = Page.objects.get(slug="tentative-unpublished-event")
-        self.assertEqual(unpublished_page.first_published_at, None)
+        self.assertIsNone(unpublished_page.first_published_at)
         self.assertEqual(
             unpublished_page.first_published_at, unpublished_page.last_published_at
         )
-        self.assertEqual(unpublished_page.live, False)
+        self.assertIs(unpublished_page.live, False)
 
         response = self.get_response(unpublished_page.id)
         self.assertEqual(response.status_code, 200)
 
         unpublished_page.refresh_from_db()
-        self.assertNotEqual(unpublished_page.first_published_at, None)
+        self.assertIsNotNone(unpublished_page.first_published_at)
         self.assertEqual(
             unpublished_page.first_published_at, unpublished_page.last_published_at
         )
-        self.assertEqual(unpublished_page.live, True)
+        self.assertIs(unpublished_page.live, True)
 
     def test_publish_insufficient_permissions(self):
         self.user.is_superuser = False
@@ -1446,9 +1446,9 @@ class TestCreatePageAliasAction(AdminAPITestCase):
         )
 
         # Check that the event exists in both places
-        self.assertNotEqual(new_christmas_event, None, "Child pages weren't copied")
-        self.assertNotEqual(
-            old_christmas_event, None, "Child pages were removed from original page"
+        self.assertIsNotNone(new_christmas_event, "Child pages weren't copied")
+        self.assertIsNotNone(
+            old_christmas_event, "Child pages were removed from original page"
         )
 
         # Check that the url path was updated

--- a/wagtail/admin/tests/pages/test_copy_page.py
+++ b/wagtail/admin/tests/pages/test_copy_page.py
@@ -99,7 +99,7 @@ class TestPageCopy(TestCase, WagtailTestUtils):
         response = self.client.post(reverse('wagtailadmin_pages:copy', args=(self.test_page.id, )), post_data)
         form = response.context['form']
         self.assertFalse(form.is_valid())
-        self.assertTrue('new_parent_page' in form.errors)
+        self.assertIn('new_parent_page', form.errors)
 
     def test_page_copy_post(self):
         post_data = {
@@ -119,7 +119,7 @@ class TestPageCopy(TestCase, WagtailTestUtils):
         page_copy = self.root_page.get_children().filter(slug='hello-world-2').first()
 
         # Check that the copy exists
-        self.assertNotEqual(page_copy, None)
+        self.assertIsNotNone(page_copy)
 
         # Check that the copy is not live
         self.assertFalse(page_copy.live)
@@ -152,7 +152,7 @@ class TestPageCopy(TestCase, WagtailTestUtils):
         page_copy = self.root_page.get_children().filter(slug='hello-world-2').first()
 
         # Check that the copy exists
-        self.assertNotEqual(page_copy, None)
+        self.assertIsNotNone(page_copy)
 
         # Check that the copy is not live
         self.assertFalse(page_copy.live)
@@ -167,12 +167,12 @@ class TestPageCopy(TestCase, WagtailTestUtils):
         # Check the the child pages
         # Neither of them should be live
         child_copy = page_copy.get_children().filter(slug='child-page').first()
-        self.assertNotEqual(child_copy, None)
+        self.assertIsNotNone(child_copy)
         self.assertFalse(child_copy.live)
         self.assertTrue(child_copy.has_unpublished_changes)
 
         unpublished_child_copy = page_copy.get_children().filter(slug='unpublished-child-page').first()
-        self.assertNotEqual(unpublished_child_copy, None)
+        self.assertIsNotNone(unpublished_child_copy)
         self.assertFalse(unpublished_child_copy.live)
         self.assertTrue(unpublished_child_copy.has_unpublished_changes)
 
@@ -197,7 +197,7 @@ class TestPageCopy(TestCase, WagtailTestUtils):
         page_copy = self.root_page.get_children().filter(slug='hello-world-2').first()
 
         # Check that the copy exists
-        self.assertNotEqual(page_copy, None)
+        self.assertIsNotNone(page_copy)
 
         # Check that the copy is live
         self.assertTrue(page_copy.live)
@@ -212,12 +212,12 @@ class TestPageCopy(TestCase, WagtailTestUtils):
         # Check the the child pages
         # The child_copy should be live but the unpublished_child_copy shouldn't
         child_copy = page_copy.get_children().filter(slug='child-page').first()
-        self.assertNotEqual(child_copy, None)
+        self.assertIsNotNone(child_copy)
         self.assertTrue(child_copy.live)
         self.assertTrue(child_copy.has_unpublished_changes)
 
         unpublished_child_copy = page_copy.get_children().filter(slug='unpublished-child-page').first()
-        self.assertNotEqual(unpublished_child_copy, None)
+        self.assertIsNotNone(unpublished_child_copy)
         self.assertFalse(unpublished_child_copy.live)
         self.assertTrue(unpublished_child_copy.has_unpublished_changes)
 
@@ -339,7 +339,7 @@ class TestPageCopy(TestCase, WagtailTestUtils):
         page_copy = self.test_page.get_children().filter(slug=post_data['new_slug']).first()
 
         # Check that the copy exists with the good slug
-        self.assertNotEqual(page_copy, None)
+        self.assertIsNotNone(page_copy)
         self.assertEqual(page_copy.slug, post_data['new_slug'])
 
     def test_page_copy_no_publish_permission(self):
@@ -388,7 +388,7 @@ class TestPageCopy(TestCase, WagtailTestUtils):
         page_copy = self.root_page.get_children().filter(slug='hello-world-2').first()
 
         # Check that the copy exists
-        self.assertNotEqual(page_copy, None)
+        self.assertIsNotNone(page_copy)
 
         # Check that the copy is not live
         self.assertFalse(page_copy.live)
@@ -402,11 +402,11 @@ class TestPageCopy(TestCase, WagtailTestUtils):
         # Check the the child pages
         # Neither of them should be live
         child_copy = page_copy.get_children().filter(slug='child-page').first()
-        self.assertNotEqual(child_copy, None)
+        self.assertIsNotNone(child_copy)
         self.assertFalse(child_copy.live)
 
         unpublished_child_copy = page_copy.get_children().filter(slug='unpublished-child-page').first()
-        self.assertNotEqual(unpublished_child_copy, None)
+        self.assertIsNotNone(unpublished_child_copy)
         self.assertFalse(unpublished_child_copy.live)
 
         # treebeard should report no consistency problems with the tree
@@ -542,13 +542,13 @@ class TestPageCopy(TestCase, WagtailTestUtils):
         # Check the the child pages
         # Neither of them should be live
         child_copy = page_copy.get_children().filter(slug='child-page').first()
-        self.assertNotEqual(child_copy, None)
+        self.assertIsNotNone(child_copy)
         self.assertEqual(child_copy.alias_of, self.test_child_page.page_ptr)
         self.assertTrue(child_copy.live)
         self.assertFalse(child_copy.has_unpublished_changes)
 
         unpublished_child_copy = page_copy.get_children().filter(slug='unpublished-child-page').first()
-        self.assertNotEqual(unpublished_child_copy, None)
+        self.assertIsNotNone(unpublished_child_copy)
         self.assertEqual(unpublished_child_copy.alias_of, self.test_unpublished_child_page.page_ptr)
         self.assertFalse(unpublished_child_copy.live)
         self.assertTrue(unpublished_child_copy.has_unpublished_changes)

--- a/wagtail/admin/tests/pages/test_create_page.py
+++ b/wagtail/admin/tests/pages/test_create_page.py
@@ -321,7 +321,7 @@ class TestPageCreation(TestCase, WagtailTestUtils):
         page = Page.objects.get(path__startswith=self.root_page.path, slug='hello-world').specific
         self.assertEqual(page.go_live_at.date(), go_live_at.date())
         self.assertEqual(page.expire_at.date(), expire_at.date())
-        self.assertEqual(page.expired, False)
+        self.assertIs(page.expired, False)
         self.assertTrue(page.status_string, "draft")
 
         # No revisions with approved_go_live_at
@@ -428,7 +428,7 @@ class TestPageCreation(TestCase, WagtailTestUtils):
         page = Page.objects.get(path__startswith=self.root_page.path, slug='hello-world').specific
         self.assertEqual(page.go_live_at.date(), go_live_at.date())
         self.assertEqual(page.expire_at.date(), expire_at.date())
-        self.assertEqual(page.expired, False)
+        self.assertIs(page.expired, False)
 
         # A revision with approved_go_live_at should exist now
         self.assertTrue(PageRevision.objects.filter(page=page).exclude(approved_go_live_at__isnull=True).exists())

--- a/wagtail/admin/tests/pages/test_edit_page.py
+++ b/wagtail/admin/tests/pages/test_edit_page.py
@@ -216,7 +216,7 @@ class TestPageEdit(TestCase, WagtailTestUtils):
         self.assertEqual(response.status_code, 302)
 
         url_finder = AdminURLFinder(self.user)
-        self.assertEqual(url_finder.get_edit_url(self.event_page), None)
+        self.assertIsNone(url_finder.get_edit_url(self.event_page))
 
     def test_page_edit_post(self):
         # Tests simple editing

--- a/wagtail/admin/tests/pages/test_moderation.py
+++ b/wagtail/admin/tests/pages/test_moderation.py
@@ -225,10 +225,10 @@ class TestNotificationPreferences(TestCase, WagtailTestUtils):
 
     def test_vanilla_profile(self):
         # Check that the vanilla profile has rejected notifications on
-        self.assertEqual(self.submitter_profile.rejected_notifications, True)
+        self.assertIs(self.submitter_profile.rejected_notifications, True)
 
         # Check that the vanilla profile has approved notifications on
-        self.assertEqual(self.submitter_profile.approved_notifications, True)
+        self.assertIs(self.submitter_profile.approved_notifications, True)
 
     def test_approved_notifications(self):
         # Set up the page version

--- a/wagtail/admin/tests/pages/test_preview.py
+++ b/wagtail/admin/tests/pages/test_preview.py
@@ -133,7 +133,7 @@ class TestPreview(TestCase, WagtailTestUtils):
 
         # Check the user can refresh the preview
         preview_session_key = 'wagtail-preview-tests-eventpage-{}'.format(self.home_page.id)
-        self.assertTrue(preview_session_key in self.client.session)
+        self.assertIn(preview_session_key, self.client.session)
 
         response = self.client.get(preview_url)
 
@@ -155,7 +155,7 @@ class TestPreview(TestCase, WagtailTestUtils):
 
         # Check the user can refresh the preview
         preview_session_key = 'wagtail-preview-{}'.format(self.event_page.id)
-        self.assertTrue(preview_session_key in self.client.session)
+        self.assertIn(preview_session_key, self.client.session)
 
         response = self.client.get(preview_url)
 
@@ -238,7 +238,7 @@ class TestPreview(TestCase, WagtailTestUtils):
 
             # Check the user can refresh the preview
             preview_session_key = 'wagtail-preview-tests-eventpage-{}'.format(self.home_page.id)
-            self.assertTrue(preview_session_key in self.client.session)
+            self.assertIn(preview_session_key, self.client.session)
 
             response = self.client.get(preview_url)
 
@@ -259,7 +259,7 @@ class TestPreview(TestCase, WagtailTestUtils):
 
             # Check the user can refresh the preview
             preview_session_key = 'wagtail-preview-tests-eventpage-{}'.format(self.home_page.id)
-            self.assertTrue(preview_session_key in self.client.session)
+            self.assertIn(preview_session_key, self.client.session)
 
             response = self.client.get(preview_url)
 

--- a/wagtail/admin/tests/test_account_management.py
+++ b/wagtail/admin/tests/test_account_management.py
@@ -56,7 +56,7 @@ class TestAuthentication(TestCase, WagtailTestUtils):
         self.assertRedirects(response, reverse('wagtailadmin_home'))
 
         # Check that the user was logged in
-        self.assertTrue('_auth_user_id' in self.client.session)
+        self.assertIn('_auth_user_id', self.client.session)
         self.assertEqual(
             str(self.client.session['_auth_user_id']),
             str(get_user_model().objects.get(email='test@email.com').pk)
@@ -109,7 +109,7 @@ class TestAuthentication(TestCase, WagtailTestUtils):
         self.assertRedirects(response, reverse('wagtailadmin_login'))
 
         # Check that the user was logged out
-        self.assertFalse('_auth_user_id' in self.client.session)
+        self.assertNotIn('_auth_user_id', self.client.session)
 
     def test_not_logged_in_redirect(self):
         """
@@ -275,7 +275,7 @@ class TestAccountSection(TestCase, WagtailTestUtils, TestAccountSectionUtilsMixi
         self.assertEqual(response.status_code, 200)
 
         # Check that a validation error was raised
-        self.assertTrue('email' in response.context['panels_by_tab'][profile_tab][0].get_form().errors.keys())
+        self.assertIn('email', response.context['panels_by_tab'][profile_tab][0].get_form().errors.keys())
 
         # Check that the email was not changed
         self.user.refresh_from_db()
@@ -339,8 +339,8 @@ class TestAccountSection(TestCase, WagtailTestUtils, TestAccountSectionUtilsMixi
 
         # Check that a validation error was raised
         password_form = password_panel.get_form()
-        self.assertTrue('new_password2' in password_form.errors.keys())
-        self.assertTrue("The two password fields didn’t match." in password_form.errors['new_password2'])
+        self.assertIn('new_password2', password_form.errors.keys())
+        self.assertIn("The two password fields didn’t match.", password_form.errors['new_password2'])
 
         # Check that the password was not changed
         self.user.refresh_from_db()
@@ -695,8 +695,8 @@ class TestPasswordReset(TestCase, WagtailTestUtils):
         self.assertEqual(response.status_code, 200)
 
         # Check that a validation error was raised
-        self.assertTrue('email' in response.context['form'].errors.keys())
-        self.assertTrue("Enter a valid email address." in response.context['form'].errors['email'])
+        self.assertIn('email', response.context['form'].errors.keys())
+        self.assertIn("Enter a valid email address.", response.context['form'].errors['email'])
 
         # Check that an email was not sent
         self.assertEqual(len(mail.outbox), 0)
@@ -796,8 +796,8 @@ class TestPasswordReset(TestCase, WagtailTestUtils):
         self.assertEqual(response.status_code, 200)
 
         # Check that a validation error was raised
-        self.assertTrue('new_password2' in response.context['form'].errors.keys())
-        self.assertTrue("The two password fields didn’t match." in response.context['form'].errors['new_password2'])
+        self.assertIn('new_password2', response.context['form'].errors.keys())
+        self.assertIn("The two password fields didn’t match.", response.context['form'].errors['new_password2'])
 
         # Check that the password was not changed
         self.assertTrue(get_user_model().objects.get(email='test@email.com').check_password('password'))

--- a/wagtail/admin/tests/test_html_ruleset.py
+++ b/wagtail/admin/tests/test_html_ruleset.py
@@ -13,12 +13,12 @@ class TestHTMLRuleset(TestCase):
             "a[linktype='sensible page']": 'sensible-page-link',
         })
 
-        self.assertEqual(ruleset.match('div', {}), None)
+        self.assertIsNone(ruleset.match('div', {}))
         self.assertEqual(ruleset.match('p', {}), 'paragraph')
         self.assertEqual(ruleset.match('p', {'class': 'intro'}), 'paragraph')
-        self.assertEqual(ruleset.match('a', {'class': 'button'}), None)
+        self.assertIsNone(ruleset.match('a', {'class': 'button'}))
         self.assertEqual(ruleset.match('a', {'class': 'button', 'href': 'http://wagtail.org'}), 'link')
-        self.assertEqual(ruleset.match('a', {'class': 'button', 'linktype': 'document'}), None)
+        self.assertIsNone(ruleset.match('a', {'class': 'button', 'linktype': 'document'}))
         self.assertEqual(ruleset.match('a', {'class': 'button', 'linktype': 'page'}), 'page-link')
         self.assertEqual(ruleset.match('a', {'class': 'button', 'linktype': 'silly page'}), 'silly-page-link')
         self.assertEqual(ruleset.match('a', {'class': 'button', 'linktype': 'sensible page'}), 'sensible-page-link')

--- a/wagtail/admin/tests/test_icon_sprite.py
+++ b/wagtail/admin/tests/test_icon_sprite.py
@@ -12,8 +12,8 @@ class TestIconSprite(TestCase):
         self.assertTrue(bool(re.match(r"^[a-z0-9]{8}$", result)))
 
     def test_hash_var(self):
-        self.assertTrue(isinstance(sprite_hash, str))
-        self.assertTrue(len(sprite_hash) == 8)
+        self.assertIsInstance(sprite_hash, str)
+        self.assertEqual(len(sprite_hash), 8)
 
     def test_url(self):
         url = reverse("wagtailadmin_sprite")
@@ -21,4 +21,4 @@ class TestIconSprite(TestCase):
 
     def test_view(self):
         response = self.client.get(reverse("wagtailadmin_sprite"))
-        self.assertTrue("Content-Type: text/html; charset=utf-8" in str(response.serialize_headers()))
+        self.assertIn("Content-Type: text/html; charset=utf-8", str(response.serialize_headers()))

--- a/wagtail/admin/tests/test_navigation.py
+++ b/wagtail/admin/tests/test_navigation.py
@@ -82,4 +82,4 @@ class TestExplorablePages(TestCase, WagtailTestUtils):
     def test_nonadmin_with_no_page_perms_cannot_explore(self):
         User = get_user_model()
         user = User.objects.get(email='mary@example.com')
-        self.assertEqual(get_explorable_root_page(user), None)
+        self.assertIsNone(get_explorable_root_page(user))

--- a/wagtail/admin/tests/test_page_chooser.py
+++ b/wagtail/admin/tests/test_page_chooser.py
@@ -538,7 +538,7 @@ class TestChooserExternalLink(TestCase, WagtailTestUtils):
         self.assertEqual(response_json['step'], 'external_link_chosen')
         self.assertEqual(response_json['result']['url'], "http://www.example.com/")
         self.assertEqual(response_json['result']['title'], "example")  # When link text is given, it is used
-        self.assertEqual(response_json['result']['prefer_this_title_as_link_text'], True)
+        self.assertIs(response_json['result']['prefer_this_title_as_link_text'], True)
 
     def test_create_link_without_text(self):
         response = self.post({'external-link-chooser-url': 'http://www.example.com/'})
@@ -547,7 +547,7 @@ class TestChooserExternalLink(TestCase, WagtailTestUtils):
         self.assertEqual(response_json['step'], 'external_link_chosen')
         self.assertEqual(response_json['result']['url'], "http://www.example.com/")
         self.assertEqual(response_json['result']['title'], "http://www.example.com/")  # When no text is given, it uses the url
-        self.assertEqual(response_json['result']['prefer_this_title_as_link_text'], False)
+        self.assertIs(response_json['result']['prefer_this_title_as_link_text'], False)
 
     def test_notice_changes_to_link_text(self):
         response = self.post(
@@ -558,7 +558,7 @@ class TestChooserExternalLink(TestCase, WagtailTestUtils):
         self.assertEqual(result['url'], "http://www.example.com/")
         self.assertEqual(result['title'], "example")
         # no change to link text, so prefer the existing link/selection content where available
-        self.assertEqual(result['prefer_this_title_as_link_text'], False)
+        self.assertIs(result['prefer_this_title_as_link_text'], False)
 
         response = self.post(
             {'external-link-chooser-url': 'http://www.example.com/', 'external-link-chooser-link_text': 'new example'},  # POST data
@@ -568,7 +568,7 @@ class TestChooserExternalLink(TestCase, WagtailTestUtils):
         self.assertEqual(result['url'], "http://www.example.com/")
         self.assertEqual(result['title'], "new example")
         # link text has changed, so tell the caller to use it
-        self.assertEqual(result['prefer_this_title_as_link_text'], True)
+        self.assertIs(result['prefer_this_title_as_link_text'], True)
 
     def test_invalid_url(self):
         response = self.post({'external-link-chooser-url': 'ntp://www.example.com', 'external-link-chooser-link_text': 'example'})
@@ -681,14 +681,14 @@ class TestChooserAnchorLink(TestCase, WagtailTestUtils):
         result = json.loads(response.content.decode())['result']
         self.assertEqual(result['url'], "#exampleanchor")
         self.assertEqual(result['title'], "Example Anchor Text")  # When link text is given, it is used
-        self.assertEqual(result['prefer_this_title_as_link_text'], True)
+        self.assertIs(result['prefer_this_title_as_link_text'], True)
 
     def test_create_link_without_text(self):
         response = self.post({'anchor-link-chooser-url': 'exampleanchor'})
         result = json.loads(response.content.decode())['result']
         self.assertEqual(result['url'], "#exampleanchor")
         self.assertEqual(result['title'], "exampleanchor")  # When no link text is given, it uses anchor
-        self.assertEqual(result['prefer_this_title_as_link_text'], False)
+        self.assertIs(result['prefer_this_title_as_link_text'], False)
 
     def test_notice_changes_to_link_text(self):
         response = self.post(
@@ -699,7 +699,7 @@ class TestChooserAnchorLink(TestCase, WagtailTestUtils):
         self.assertEqual(result['url'], "#exampleanchor2")
         self.assertEqual(result['title'], "exampleanchor2")
         # no change to link text, so prefer the existing link/selection content where available
-        self.assertEqual(result['prefer_this_title_as_link_text'], True)
+        self.assertIs(result['prefer_this_title_as_link_text'], True)
 
         response = self.post(
             {'anchor-link-chooser-url': 'exampleanchor2', 'anchor-link-chooser-link_text': 'Example Anchor Test 2.1'},  # POST data
@@ -709,7 +709,7 @@ class TestChooserAnchorLink(TestCase, WagtailTestUtils):
         self.assertEqual(result['url'], "#exampleanchor2")
         self.assertEqual(result['title'], "Example Anchor Test 2.1")
         # link text has changed, so tell the caller to use it
-        self.assertEqual(result['prefer_this_title_as_link_text'], True)
+        self.assertIs(result['prefer_this_title_as_link_text'], True)
 
 
 class TestChooserEmailLink(TestCase, WagtailTestUtils):
@@ -741,14 +741,14 @@ class TestChooserEmailLink(TestCase, WagtailTestUtils):
         result = json.loads(response.content.decode())['result']
         self.assertEqual(result['url'], "mailto:example@example.com")
         self.assertEqual(result['title'], "contact")  # When link text is given, it is used
-        self.assertEqual(result['prefer_this_title_as_link_text'], True)
+        self.assertIs(result['prefer_this_title_as_link_text'], True)
 
     def test_create_link_without_text(self):
         response = self.post({'email-link-chooser-email_address': 'example@example.com'})
         result = json.loads(response.content.decode())['result']
         self.assertEqual(result['url'], "mailto:example@example.com")
         self.assertEqual(result['title'], "example@example.com")  # When no link text is given, it uses the email
-        self.assertEqual(result['prefer_this_title_as_link_text'], False)
+        self.assertIs(result['prefer_this_title_as_link_text'], False)
 
     def test_notice_changes_to_link_text(self):
         response = self.post(
@@ -759,7 +759,7 @@ class TestChooserEmailLink(TestCase, WagtailTestUtils):
         self.assertEqual(result['url'], "mailto:example2@example.com")
         self.assertEqual(result['title'], "example")
         # no change to link text, so prefer the existing link/selection content where available
-        self.assertEqual(result['prefer_this_title_as_link_text'], False)
+        self.assertIs(result['prefer_this_title_as_link_text'], False)
 
         response = self.post(
             {'email-link-chooser-email_address': 'example2@example.com', 'email-link-chooser-link_text': 'new example'},  # POST data
@@ -769,7 +769,7 @@ class TestChooserEmailLink(TestCase, WagtailTestUtils):
         self.assertEqual(result['url'], "mailto:example2@example.com")
         self.assertEqual(result['title'], "new example")
         # link text has changed, so tell the caller to use it
-        self.assertEqual(result['prefer_this_title_as_link_text'], True)
+        self.assertIs(result['prefer_this_title_as_link_text'], True)
 
 
 class TestChooserPhoneLink(TestCase, WagtailTestUtils):
@@ -801,14 +801,14 @@ class TestChooserPhoneLink(TestCase, WagtailTestUtils):
         result = json.loads(response.content.decode())['result']
         self.assertEqual(result['url'], "tel:+123456789")
         self.assertEqual(result['title'], "call")
-        self.assertEqual(result['prefer_this_title_as_link_text'], True)
+        self.assertIs(result['prefer_this_title_as_link_text'], True)
 
     def test_create_link_without_text(self):
         response = self.post({'phone-link-chooser-phone_number': '+123456789'})
         result = json.loads(response.content.decode())['result']
         self.assertEqual(result['url'], "tel:+123456789")
         self.assertEqual(result['title'], "+123456789")  # When no link text is given, it uses the phone number
-        self.assertEqual(result['prefer_this_title_as_link_text'], False)
+        self.assertIs(result['prefer_this_title_as_link_text'], False)
 
     def test_notice_changes_to_link_text(self):
         response = self.post(
@@ -819,7 +819,7 @@ class TestChooserPhoneLink(TestCase, WagtailTestUtils):
         self.assertEqual(result['url'], "tel:+222222222")
         self.assertEqual(result['title'], "example")
         # no change to link text, so prefer the existing link/selection content where available
-        self.assertEqual(result['prefer_this_title_as_link_text'], False)
+        self.assertIs(result['prefer_this_title_as_link_text'], False)
 
         response = self.post(
             {'phone-link-chooser-phone_number': '+222222222', 'phone-link-chooser-link_text': 'new example'},  # POST data
@@ -829,7 +829,7 @@ class TestChooserPhoneLink(TestCase, WagtailTestUtils):
         self.assertEqual(result['url'], "tel:+222222222")
         self.assertEqual(result['title'], "new example")
         # link text has changed, so tell the caller to use it
-        self.assertEqual(result['prefer_this_title_as_link_text'], True)
+        self.assertIs(result['prefer_this_title_as_link_text'], True)
 
 
 class TestCanChoosePage(TestCase, WagtailTestUtils):

--- a/wagtail/admin/tests/test_templatetags.py
+++ b/wagtail/admin/tests/test_templatetags.py
@@ -183,7 +183,7 @@ class TestInternationalisationTags(TestCase):
 
     def test_locales(self):
         locales_output = locales_tag()
-        self.assertTrue(isinstance(locales_output, str))
+        self.assertIsInstance(locales_output, str)
         self.assertEqual(
             json.loads(locales_output),
             [

--- a/wagtail/admin/tests/test_workflows.py
+++ b/wagtail/admin/tests/test_workflows.py
@@ -356,7 +356,7 @@ class TestWorkflowsEditView(TestCase, WagtailTestUtils):
 
     def test_admin_url_finder(self):
         editor_url_finder = AdminURLFinder(self.editor)
-        self.assertEqual(editor_url_finder.get_edit_url(self.workflow), None)
+        self.assertIsNone(editor_url_finder.get_edit_url(self.workflow))
         moderator_url_finder = AdminURLFinder(self.moderator)
         expected_url = '/admin/workflows/edit/%d/' % self.workflow.pk
         self.assertEqual(moderator_url_finder.get_edit_url(self.workflow), expected_url)
@@ -699,7 +699,7 @@ class TestEditTaskView(TestCase, WagtailTestUtils):
 
     def test_admin_url_finder(self):
         editor_url_finder = AdminURLFinder(self.editor)
-        self.assertEqual(editor_url_finder.get_edit_url(self.task), None)
+        self.assertIsNone(editor_url_finder.get_edit_url(self.task))
         moderator_url_finder = AdminURLFinder(self.moderator)
         expected_url = '/admin/workflows/tasks/edit/%d/' % self.task.pk
         self.assertEqual(moderator_url_finder.get_edit_url(self.task), expected_url)
@@ -1284,10 +1284,10 @@ class TestNotificationPreferences(TestCase, WagtailTestUtils):
 
     def test_vanilla_profile(self):
         # Check that the vanilla profile has rejected notifications on
-        self.assertEqual(self.submitter_profile.rejected_notifications, True)
+        self.assertIs(self.submitter_profile.rejected_notifications, True)
 
         # Check that the vanilla profile has approved notifications on
-        self.assertEqual(self.submitter_profile.approved_notifications, True)
+        self.assertIs(self.submitter_profile.approved_notifications, True)
 
     @override_settings(WAGTAILADMIN_NOTIFICATION_INCLUDE_SUPERUSERS=True)
     def test_submitted_email_notifications_sent(self):
@@ -1522,7 +1522,7 @@ class TestDisableViews(TestCase, WagtailTestUtils):
         response = self.client.post(reverse('wagtailadmin_workflows:disable', args=(self.workflow.pk,)))
         self.assertEqual(response.status_code, 302)
         self.workflow.refresh_from_db()
-        self.assertEqual(self.workflow.active, False)
+        self.assertIs(self.workflow.active, False)
         states = WorkflowState.objects.filter(page=self.page, workflow=self.workflow)
         self.assertEqual(states.filter(status=WorkflowState.STATUS_IN_PROGRESS).count(), 0)
         self.assertEqual(states.filter(status=WorkflowState.STATUS_CANCELLED).count(), 1)
@@ -1559,7 +1559,7 @@ class TestDisableViews(TestCase, WagtailTestUtils):
         response = self.client.post(reverse('wagtailadmin_workflows:disable_task', args=(self.task_1.pk,)))
         self.assertEqual(response.status_code, 302)
         self.task_1.refresh_from_db()
-        self.assertEqual(self.task_1.active, False)
+        self.assertIs(self.task_1.active, False)
         states = TaskState.objects.filter(workflow_state__page=self.page, task=self.task_1.task_ptr)
         self.assertEqual(states.filter(status=TaskState.STATUS_IN_PROGRESS).count(), 0)
         self.assertEqual(states.filter(status=TaskState.STATUS_CANCELLED).count(), 1)
@@ -1575,7 +1575,7 @@ class TestDisableViews(TestCase, WagtailTestUtils):
         response = self.client.post(reverse('wagtailadmin_workflows:enable', args=(self.workflow.pk,)))
         self.assertEqual(response.status_code, 302)
         self.workflow.refresh_from_db()
-        self.assertEqual(self.workflow.active, True)
+        self.assertIs(self.workflow.active, True)
 
     def test_enable_task(self):
         self.login(self.superuser)
@@ -1585,7 +1585,7 @@ class TestDisableViews(TestCase, WagtailTestUtils):
         response = self.client.post(reverse('wagtailadmin_workflows:enable_task', args=(self.task_1.pk,)))
         self.assertEqual(response.status_code, 302)
         self.task_1.refresh_from_db()
-        self.assertEqual(self.task_1.active, True)
+        self.assertIs(self.task_1.active, True)
 
 
 class TestTaskChooserView(TestCase, WagtailTestUtils):

--- a/wagtail/admin/tests/tests.py
+++ b/wagtail/admin/tests/tests.py
@@ -270,7 +270,7 @@ class TestMenuItem(TestCase, WagtailTestUtils):
 
     def test_menuitem_reverse_lazy_url_pass(self):
         menuitem = MenuItem(_('Test'), reverse_lazy('wagtailadmin_home'))
-        self.assertEqual(menuitem.is_active(self.request), True)
+        self.assertIs(menuitem.is_active(self.request), True)
 
 
 class TestUserPassesTestPermissionDecorator(TestCase, WagtailTestUtils):

--- a/wagtail/api/v2/tests/test_pages.py
+++ b/wagtail/api/v2/tests/test_pages.py
@@ -1082,7 +1082,7 @@ class TestPageDetail(TestCase):
         content = json.loads(response.content.decode('UTF-8'))
 
         self.assertIn('related_links', content)
-        self.assertEqual(content['feed_image'], None)
+        self.assertIsNone(content['feed_image'])
 
     def test_page_with_missing_page_model(self):
         # Create a ContentType that doesn't correspond to a real model

--- a/wagtail/api/v2/tests/tests.py
+++ b/wagtail/api/v2/tests/tests.py
@@ -318,22 +318,22 @@ class TestParseBoolean(TestCase):
     def test_valid_true(self):
         parsed = parse_boolean('true')
 
-        self.assertEqual(parsed, True)
+        self.assertIs(parsed, True)
 
     def test_valid_false(self):
         parsed = parse_boolean('false')
 
-        self.assertEqual(parsed, False)
+        self.assertIs(parsed, False)
 
     def test_valid_1(self):
         parsed = parse_boolean('1')
 
-        self.assertEqual(parsed, True)
+        self.assertIs(parsed, True)
 
     def test_valid_0(self):
         parsed = parse_boolean('0')
 
-        self.assertEqual(parsed, False)
+        self.assertIs(parsed, False)
 
     # BAD STUFF
 

--- a/wagtail/contrib/forms/tests/test_views.py
+++ b/wagtail/contrib/forms/tests/test_views.py
@@ -183,7 +183,7 @@ class TestFormsIndex(TestCase, WagtailTestUtils):
         response = self.client.get(reverse('wagtailforms:index'))
 
         # Check that the user cannot see the form page
-        self.assertFalse(self.form_page in response.context['form_pages'])
+        self.assertNotIn(self.form_page, response.context['form_pages'])
 
     def test_can_see_forms_with_permission(self):
         response = self.client.get(reverse('wagtailforms:index'))
@@ -443,7 +443,7 @@ class TestFormsSubmissionsList(TestCase, WagtailTestUtils):
             'wagtailforms:list_submissions', args=(self.form_page.id,)))
         # check default ordering, most recent responses first
         first_row_values = response.context['data_rows'][0]['fields']
-        self.assertTrue('this is a fairly new message' in first_row_values)
+        self.assertIn('this is a fairly new message', first_row_values)
 
     def test_list_submissions_url_params_ordering_recent_first(self):
         response = self.client.get(reverse(
@@ -453,7 +453,7 @@ class TestFormsSubmissionsList(TestCase, WagtailTestUtils):
         )
         # check ordering matches '-submit_time' (most recent first)
         first_row_values = response.context['data_rows'][0]['fields']
-        self.assertTrue('this is a fairly new message' in first_row_values)
+        self.assertIn('this is a fairly new message', first_row_values)
 
     def test_list_submissions_url_params_ordering_oldest_first(self):
         response = self.client.get(reverse(
@@ -463,7 +463,7 @@ class TestFormsSubmissionsList(TestCase, WagtailTestUtils):
         )
         # check ordering matches 'submit_time' (oldest first)
         first_row_values = response.context['data_rows'][0]['fields']
-        self.assertTrue('this is a really old message' in first_row_values)
+        self.assertIn('this is a really old message', first_row_values)
 
 
 class TestFormsSubmissionsListLegacyFieldName(TestCase, WagtailTestUtils):
@@ -1352,7 +1352,7 @@ class TestFormsWithCustomSubmissionsList(TestCase, WagtailTestUtils):
         # check ordering matches default which is overridden to be 'submit_time' (oldest first)
         response = self.client.get(reverse('wagtailforms:list_submissions', args=(self.form_page.id,)))
         first_row_values = response.context['data_rows'][0]['fields']
-        self.assertTrue('Old chocolate idea' in first_row_values)
+        self.assertIn('Old chocolate idea', first_row_values)
 
 
 class TestFormsWithCustomFormBuilderSubmissionsList(TestCase, WagtailTestUtils):

--- a/wagtail/contrib/modeladmin/tests/test_page_modeladmin.py
+++ b/wagtail/contrib/modeladmin/tests/test_page_modeladmin.py
@@ -24,7 +24,7 @@ class TestIndexView(TestCase, WagtailTestUtils):
         self.assertEqual(response.context['result_count'], 4)
 
         # User has add permission
-        self.assertEqual(response.context['user_can_create'], True)
+        self.assertIs(response.context['user_can_create'], True)
 
     def test_filter(self):
         # Filter by audience

--- a/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
+++ b/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
@@ -50,7 +50,7 @@ class TestBookIndexView(TestCase, WagtailTestUtils):
         self.assertContains(response, '<span class="result-count">4 out of 4</span>', html=True)
 
         # User has add permission
-        self.assertEqual(response.context['user_can_create'], True)
+        self.assertIs(response.context['user_can_create'], True)
 
     def test_csv_export(self):
         # Export the whole queryset
@@ -253,7 +253,7 @@ class TestCreateView(TestCase, WagtailTestUtils):
             'name': 'Sharper Collins'
         })
         publisher = Publisher.objects.get(name='Sharper Collins')
-        self.assertEqual(publisher.headquartered_in, None)
+        self.assertIsNone(publisher.headquartered_in)
 
     def test_post_invalid(self):
         initial_book_count = Book.objects.count()
@@ -628,7 +628,7 @@ class TestEditorAccess(TestCase, WagtailTestUtils):
         self.assertRedirects(response, '/admin/')
 
         url_finder = AdminURLFinder(self.user)
-        self.assertEqual(url_finder.get_edit_url(Book.objects.get(id=2)), None)
+        self.assertIsNone(url_finder.get_edit_url(Book.objects.get(id=2)))
 
     def test_delete_get_permitted(self):
         response = self.client.get('/admin/modeladmintest/book/delete/2/')

--- a/wagtail/contrib/redirects/tests/test_import_admin_views.py
+++ b/wagtail/contrib/redirects/tests/test_import_admin_views.py
@@ -44,7 +44,7 @@ class TestImportAdminViews(TestCase, WagtailTestUtils):
             "input_format": "0",
         })
 
-        self.assertTrue("import_file" in response.context["form"].errors)
+        self.assertIn("import_file", response.context["form"].errors)
 
     def test_non_valid_format_returns_error(self):
         f = "{}/files/example.yaml".format(TEST_ROOT)
@@ -246,8 +246,8 @@ class TestImportAdminViews(TestCase, WagtailTestUtils):
                 },
                 follow=True,
             )
-            self.assertTrue(
-                b"Imported file has a wrong encoding:" in response.content
+            self.assertIn(
+                b"Imported file has a wrong encoding:", response.content
             )
 
     def test_not_valid_method_for_import_file(self):

--- a/wagtail/contrib/redirects/tests/test_import_command.py
+++ b/wagtail/contrib/redirects/tests/test_import_command.py
@@ -83,7 +83,7 @@ class TestImportCommand(TestCase):
         redirect = Redirect.objects.first()
         self.assertEqual(redirect.old_path, "/alpha")
         self.assertEqual(redirect.redirect_link, "http://omega.test/")
-        self.assertEqual(redirect.is_permanent, True)
+        self.assertIs(redirect.is_permanent, True)
 
     def test_trailing_slash_gets_stripped(self):
         invalid_file = tempfile.NamedTemporaryFile(mode="w+", encoding="utf-8")
@@ -148,7 +148,7 @@ class TestImportCommand(TestCase):
         redirect = Redirect.objects.first()
         self.assertEqual(redirect.old_path, "/alpha")
         self.assertEqual(redirect.redirect_link, "http://omega.test/")
-        self.assertEqual(redirect.is_permanent, False)
+        self.assertIs(redirect.is_permanent, False)
 
     def test_duplicate_from_links_get_skipped(self):
         invalid_file = tempfile.NamedTemporaryFile(mode="w+", encoding="utf-8")
@@ -222,7 +222,7 @@ class TestImportCommand(TestCase):
         redirect = Redirect.objects.first()
         self.assertEqual(redirect.old_path, "/alpha")
         self.assertEqual(redirect.redirect_link, "http://omega.test/")
-        self.assertEqual(redirect.is_permanent, True)
+        self.assertIs(redirect.is_permanent, True)
 
     def test_nothing_gets_saved_on_dry_run(self):
         invalid_file = tempfile.NamedTemporaryFile(mode="w+", encoding="utf-8")
@@ -306,7 +306,7 @@ class TestImportCommand(TestCase):
         self.assertEqual(len(redirects), 2)
         self.assertEqual(redirects[0].old_path, "/three")
         self.assertEqual(redirects[0].redirect_link, "http://three.test/")
-        self.assertEqual(redirects[0].is_permanent, True)
+        self.assertIs(redirects[0].is_permanent, True)
         self.assertEqual(redirects[1].old_path, "/four")
         self.assertEqual(redirects[1].redirect_link, "http://four.test/")
 
@@ -333,4 +333,4 @@ class TestImportCommand(TestCase):
         self.assertEqual(len(redirects), 1)
         self.assertEqual(redirects[0].old_path, "/one")
         self.assertEqual(redirects[0].redirect_link, "http://one.test/")
-        self.assertEqual(redirects[0].is_permanent, True)
+        self.assertIs(redirects[0].is_permanent, True)

--- a/wagtail/contrib/redirects/tests/test_redirects.py
+++ b/wagtail/contrib/redirects/tests/test_redirects.py
@@ -362,7 +362,7 @@ class TestRedirects(TestCase):
         self.assertEqual(redirect.link, redirect_to)
 
         # should use is_permanent kwarg
-        self.assertEqual(redirect.is_permanent, False)
+        self.assertIs(redirect.is_permanent, False)
 
     def test_add_redirect_with_page(self):
         add_redirect = models.Redirect.add_redirect
@@ -383,7 +383,7 @@ class TestRedirects(TestCase):
         self.assertEqual(redirect.link, redirect_to.url)
 
         # should default is_permanent to True
-        self.assertEqual(redirect.is_permanent, True)
+        self.assertIs(redirect.is_permanent, True)
 
 
 class TestRedirectsIndexView(TestCase, WagtailTestUtils):
@@ -458,7 +458,7 @@ class TestRedirectsAddView(TestCase, WagtailTestUtils):
         redirects = models.Redirect.objects.filter(old_path='/test')
         self.assertEqual(redirects.count(), 1)
         self.assertEqual(redirects.first().redirect_link, 'http://www.test.com/')
-        self.assertEqual(redirects.first().site, None)
+        self.assertIsNone(redirects.first().site)
 
     def test_add_with_site(self):
         localhost = Site.objects.get(hostname='localhost')
@@ -549,7 +549,7 @@ class TestRedirectsAddView(TestCase, WagtailTestUtils):
         redirects = models.Redirect.objects.filter(old_path='/test')
         self.assertEqual(redirects.count(), 1)
         self.assertEqual(redirects.first().redirect_link, 'https://www.google.com/search?q=this+is+a+very+long+url+because+it+has+a+huge+search+term+appended+to+the+end+of+it+even+though+someone+should+really+not+be+doing+something+so+crazy+without+first+seeing+a+psychiatrist')
-        self.assertEqual(redirects.first().site, None)
+        self.assertIsNone(redirects.first().site)
 
 
 class TestRedirectsEditView(TestCase, WagtailTestUtils):
@@ -594,7 +594,7 @@ class TestRedirectsEditView(TestCase, WagtailTestUtils):
         redirects = models.Redirect.objects.filter(old_path='/test')
         self.assertEqual(redirects.count(), 1)
         self.assertEqual(redirects.first().redirect_link, 'http://www.test.com/ive-been-edited')
-        self.assertEqual(redirects.first().site, None)
+        self.assertIsNone(redirects.first().site)
 
     def test_edit_with_site(self):
         localhost = Site.objects.get(hostname='localhost')

--- a/wagtail/contrib/simple_translation/tests/test_views.py
+++ b/wagtail/contrib/simple_translation/tests/test_views.py
@@ -70,7 +70,7 @@ class TestSubmitTranslationView(WagtailTestUtils, TestCase):
         view.request = self.factory.get("/path/does/not/matter/")
         view.object = self.en_homepage
         context = view.get_context_data()
-        self.assertTrue("form" in context.keys())
+        self.assertIn("form", context.keys())
         self.assertIsInstance(context["form"], SubmitTranslationForm)
 
     def test_dispatch_as_anon(self):

--- a/wagtail/contrib/table_block/tests.py
+++ b/wagtail/contrib/table_block/tests.py
@@ -212,13 +212,13 @@ class TestTableBlock(TestCase):
         """
         # TableBlock with default table_options
         block1 = TableBlock()
-        self.assertEqual(block1.is_html_renderer(), False)
+        self.assertIs(block1.is_html_renderer(), False)
 
         # TableBlock with altered table_options
         new_options = self.default_table_options.copy()
         new_options['renderer'] = 'html'
         block2 = TableBlock(table_options=new_options)
-        self.assertEqual(block2.is_html_renderer(), True)
+        self.assertIs(block2.is_html_renderer(), True)
 
     def test_searchable_content(self):
         value = {'first_row_is_table_header': False, 'first_col_is_header': False,
@@ -357,7 +357,7 @@ class TestTableBlockForm(WagtailTestUtils, SimpleTestCase):
         self.assertEqual(table_options_menu_true['contextMenu'], default_context_menu)
         # confirm menu is removed if False is passed in
         table_options_menu_false = TableBlock(table_options={'contextMenu': False}).table_options
-        self.assertEqual(table_options_menu_false['contextMenu'], False)
+        self.assertIs(table_options_menu_false['contextMenu'], False)
         # confirm if list passed in, it is used
         table_options_menu_list = TableBlock(table_options={'contextMenu': ['undo', 'redo']}).table_options
         self.assertEqual(table_options_menu_list['contextMenu'], ['undo', 'redo'])
@@ -378,7 +378,7 @@ class TestTableBlockForm(WagtailTestUtils, SimpleTestCase):
 
         # check value that is not part of the defaults
         block_3_opts = TableBlock(table_options={'allowEmpty': False}).table_options
-        self.assertEqual(block_3_opts['allowEmpty'], False)
+        self.assertIs(block_3_opts['allowEmpty'], False)
 
     def test_adapt(self):
         block = TableBlock()

--- a/wagtail/core/tests/test_blocks.py
+++ b/wagtail/core/tests/test_blocks.py
@@ -325,9 +325,9 @@ class TestBooleanBlock(unittest.TestCase):
     def test_get_form_state(self):
         block = blocks.BooleanBlock(required=False)
         form_state = block.get_form_state(True)
-        self.assertEqual(form_state, True)
+        self.assertIs(form_state, True)
         form_state = block.get_form_state(False)
-        self.assertEqual(form_state, False)
+        self.assertIs(form_state, False)
 
 
 class TestBlockQuoteBlock(unittest.TestCase):
@@ -1592,11 +1592,11 @@ class TestStructBlock(SimpleTestCase):
             'link': 'http://www.wagtail.org',
         }), prefix='mylink')
 
-        self.assertTrue(isinstance(context['children'], collections.OrderedDict))
+        self.assertIsInstance(context['children'], collections.OrderedDict)
         self.assertEqual(len(context['children']), 2)
-        self.assertTrue(isinstance(context['children']['title'], blocks.BoundBlock))
+        self.assertIsInstance(context['children']['title'], blocks.BoundBlock)
         self.assertEqual(context['children']['title'].value, "Wagtail site")
-        self.assertTrue(isinstance(context['children']['link'], blocks.BoundBlock))
+        self.assertIsInstance(context['children']['link'], blocks.BoundBlock)
         self.assertEqual(context['children']['link'].value, 'http://www.wagtail.org')
         self.assertEqual(context['block_definition'], block)
         self.assertEqual(context['prefix'], 'mylink')
@@ -1749,8 +1749,8 @@ class TestStructBlock(SimpleTestCase):
 
         self.assertEqual(struct_val['title'], "Torchbox")
         self.assertEqual(struct_val['link'], "http://www.torchbox.com")
-        self.assertTrue(isinstance(struct_val, blocks.StructValue))
-        self.assertTrue(isinstance(struct_val.bound_blocks['link'].block, blocks.URLBlock))
+        self.assertIsInstance(struct_val, blocks.StructValue)
+        self.assertIsInstance(struct_val.bound_blocks['link'].block, blocks.URLBlock)
 
     def test_value_omitted_from_data(self):
         block = blocks.StructBlock([
@@ -1779,7 +1779,7 @@ class TestStructBlock(SimpleTestCase):
         event = event_block.to_python({'title': 'Birthday party'})
 
         self.assertEqual(event['guest_speaker']['first_name'], 'Ed')
-        self.assertTrue(isinstance(event['guest_speaker'], blocks.StructValue))
+        self.assertIsInstance(event['guest_speaker'], blocks.StructValue)
 
     def test_default_value_is_distinct_instance(self):
         """
@@ -1835,7 +1835,7 @@ class TestStructBlock(SimpleTestCase):
 
         value = block.to_python({'title': 'Torchbox', 'link': 'http://www.torchbox.com/'})
         clean_value = block.clean(value)
-        self.assertTrue(isinstance(clean_value, blocks.StructValue))
+        self.assertIsInstance(clean_value, blocks.StructValue)
         self.assertEqual(clean_value['title'], 'Torchbox')
 
         value = block.to_python({'title': 'Torchbox', 'link': 'not a url'})
@@ -1927,7 +1927,7 @@ class TestStructBlockWithCustomStructValue(SimpleTestCase):
 
         value = block.to_python({'title': 'Torchbox', 'link': 'http://www.torchbox.com/'})
         clean_value = block.clean(value)
-        self.assertTrue(isinstance(clean_value, CustomStructValue))
+        self.assertIsInstance(clean_value, CustomStructValue)
         self.assertEqual(clean_value['title'], 'Torchbox')
 
         value = block.to_python({'title': 'Torchbox', 'link': 'not a url'})
@@ -3077,7 +3077,7 @@ class TestStreamBlock(WagtailTestUtils, SimpleTestCase):
         struct_value = block.to_python({'author': 'Bob'})
         stream_value = struct_value['article']
 
-        self.assertTrue(isinstance(stream_value, blocks.StreamValue))
+        self.assertIsInstance(stream_value, blocks.StreamValue)
         self.assertEqual(len(stream_value), 1)
         self.assertEqual(stream_value[0].block_type, 'heading')
         self.assertEqual(stream_value[0].value, 'A default heading')
@@ -3102,7 +3102,7 @@ class TestStreamBlock(WagtailTestUtils, SimpleTestCase):
         struct_value = block.to_python({'author': 'Bob'})
         stream_value = struct_value['article']
 
-        self.assertTrue(isinstance(stream_value, blocks.StreamValue))
+        self.assertIsInstance(stream_value, blocks.StreamValue)
         self.assertEqual(len(stream_value), 1)
         self.assertEqual(stream_value[0].block_type, 'heading')
         self.assertEqual(stream_value[0].value, 'A different default heading')
@@ -3115,11 +3115,11 @@ class TestStreamBlock(WagtailTestUtils, SimpleTestCase):
         value2 = block.to_python([{'type': 'text', 'value': 'hello'}])
         value3 = block.to_python([{'type': 'text', 'value': 'goodbye'}])
 
-        self.assertTrue(value1 == value2)
-        self.assertFalse(value1 != value2)
+        self.assertEqual(value1, value2)
+        self.assertNotEqual(value1, value2)
 
-        self.assertFalse(value1 == value3)
-        self.assertTrue(value1 != value3)
+        self.assertEqual(value1, value3)
+        self.assertNotEqual(value1, value3)
 
     def test_adapt_considers_group_attribute(self):
         """If group attributes are set in Block Meta classes, make sure the blocks are grouped together"""
@@ -3590,7 +3590,7 @@ class TestPageChooserBlock(TestCase):
         self.assertEqual(block.get_prep_value(christmas_page), christmas_page.id)
 
         # None should serialize to None
-        self.assertEqual(block.get_prep_value(None), None)
+        self.assertIsNone(block.get_prep_value(None))
 
     def test_deserialize(self):
         """The serialized value of a PageChooserBlock (an ID) should deserialize to a Page object"""
@@ -3600,7 +3600,7 @@ class TestPageChooserBlock(TestCase):
         self.assertEqual(block.to_python(christmas_page.id), christmas_page)
 
         # None should deserialize to None
-        self.assertEqual(block.to_python(None), None)
+        self.assertIsNone(block.to_python(None))
 
     def test_adapt(self):
         from wagtail.admin.widgets.chooser import AdminPageChooser
@@ -3672,7 +3672,7 @@ class TestPageChooserBlock(TestCase):
         self.assertEqual(value, christmas_page)
 
         empty_value = block.value_from_datadict({'page': ''}, {}, 'page')
-        self.assertEqual(empty_value, None)
+        self.assertIsNone(empty_value)
 
     def test_clean(self):
         required_block = blocks.PageChooserBlock()
@@ -3684,7 +3684,7 @@ class TestPageChooserBlock(TestCase):
             required_block.clean(None)
 
         self.assertEqual(nonrequired_block.clean(christmas_page), christmas_page)
-        self.assertEqual(nonrequired_block.clean(None), None)
+        self.assertIsNone(nonrequired_block.clean(None))
 
     def test_target_model_default(self):
         block = blocks.PageChooserBlock()
@@ -3832,7 +3832,7 @@ class TestStaticBlock(unittest.TestCase):
     def test_get_default(self):
         block = blocks.StaticBlock()
         default_value = block.get_default()
-        self.assertEqual(default_value, None)
+        self.assertIsNone(default_value)
 
     def test_render(self):
         block = blocks.StaticBlock(template='tests/blocks/posts_static_block.html')
@@ -3842,12 +3842,12 @@ class TestStaticBlock(unittest.TestCase):
     def test_serialize(self):
         block = blocks.StaticBlock()
         result = block.get_prep_value(None)
-        self.assertEqual(result, None)
+        self.assertIsNone(result)
 
     def test_deserialize(self):
         block = blocks.StaticBlock()
         result = block.to_python(None)
-        self.assertEqual(result, None)
+        self.assertIsNone(result)
 
 
 class TestDateBlock(TestCase):

--- a/wagtail/core/tests/test_blocks.py
+++ b/wagtail/core/tests/test_blocks.py
@@ -3116,9 +3116,7 @@ class TestStreamBlock(WagtailTestUtils, SimpleTestCase):
         value3 = block.to_python([{'type': 'text', 'value': 'goodbye'}])
 
         self.assertEqual(value1, value2)
-        self.assertNotEqual(value1, value2)
 
-        self.assertEqual(value1, value3)
         self.assertNotEqual(value1, value3)
 
     def test_adapt_considers_group_attribute(self):

--- a/wagtail/core/tests/test_page_model.py
+++ b/wagtail/core/tests/test_page_model.py
@@ -271,11 +271,11 @@ class TestRouting(TestCase):
         root = Page.objects.get(url_path='/')
         default_site = Site.objects.get(is_default_site=True)
 
-        self.assertEqual(root.get_url_parts(), None)
-        self.assertEqual(root.full_url, None)
-        self.assertEqual(root.url, None)
-        self.assertEqual(root.relative_url(default_site), None)
-        self.assertEqual(root.get_site(), None)
+        self.assertIsNone(root.get_url_parts())
+        self.assertIsNone(root.full_url)
+        self.assertIsNone(root.url)
+        self.assertIsNone(root.relative_url(default_site))
+        self.assertIsNone(root.get_site())
 
     @override_settings(ALLOWED_HOSTS=['localhost', 'testserver', 'events.example.com', 'second-events.example.com'])
     def test_urls_with_multiple_sites(self):
@@ -366,8 +366,8 @@ class TestRouting(TestCase):
             homepage.get_url_parts(),
             (default_site.id, None, None)
         )
-        self.assertEqual(homepage.full_url, None)
-        self.assertEqual(homepage.url, None)
+        self.assertIsNone(homepage.full_url)
+        self.assertIsNone(homepage.url)
 
     def test_request_routing(self):
         homepage = Page.objects.get(url_path='/home/')
@@ -1334,7 +1334,7 @@ class TestCopyPage(TestCase):
             )
 
         # Check that the new revision is not scheduled
-        self.assertEqual(new_christmas_event.revisions.order_by('created_at').first().approved_go_live_at, None)
+        self.assertIsNone(new_christmas_event.revisions.order_by('created_at').first().approved_go_live_at)
 
     def test_copy_page_doesnt_copy_revisions_if_told_not_to_do_so(self):
         christmas_event = EventPage.objects.get(url_path='/home/events/christmas/')
@@ -1380,8 +1380,8 @@ class TestCopyPage(TestCase):
         new_christmas_event = new_events_index.get_children().filter(slug='christmas').first()
 
         # Check that the event exists in both places
-        self.assertNotEqual(new_christmas_event, None, "Child pages weren't copied")
-        self.assertNotEqual(old_christmas_event, None, "Child pages were removed from original page")
+        self.assertIsNotNone(new_christmas_event, "Child pages weren't copied")
+        self.assertIsNotNone(old_christmas_event, "Child pages were removed from original page")
 
         # Check that the url path was updated
         self.assertEqual(new_christmas_event.url_path, '/home/new-events-index/christmas/')
@@ -1887,8 +1887,8 @@ class TestCreateAlias(TestCase):
         new_christmas_event = new_events_index.get_children().filter(slug='christmas').first()
 
         # Check that the event exists in both places
-        self.assertNotEqual(new_christmas_event, None, "Child pages weren't copied")
-        self.assertNotEqual(old_christmas_event, None, "Child pages were removed from original page")
+        self.assertIsNotNone(new_christmas_event, "Child pages weren't copied")
+        self.assertIsNotNone(old_christmas_event, "Child pages were removed from original page")
 
         # Check that the url path was updated
         self.assertEqual(new_christmas_event.url_path, '/home/new-events-index/christmas/')

--- a/wagtail/core/tests/test_page_queryset.py
+++ b/wagtail/core/tests/test_page_queryset.py
@@ -345,7 +345,7 @@ class TestPageQuerySet(TestCase):
 
         # Check that no objects are EventPages or SimplePages
         for page in pages:
-            self.assertIsNotInstance(page.specific, (EventPage, SimplePage))
+            self.assertNotIsInstance(page.specific, (EventPage, SimplePage))
 
         # Check that "About us" is NOT in the results
         about_us = Page.objects.get(url_path='/home/about-us/')

--- a/wagtail/core/tests/test_page_queryset.py
+++ b/wagtail/core/tests/test_page_queryset.py
@@ -310,9 +310,7 @@ class TestPageQuerySet(TestCase):
 
         # Check that all objects are EventPages or SimplePages
         for page in pages:
-            self.assertTrue(
-                isinstance(page.specific, (EventPage, SimplePage))
-            )
+            self.assertIsInstance(page.specific, (EventPage, SimplePage))
 
         # Check that "someone elses event" is in the results
         event = Page.objects.get(url_path='/home/events/someone-elses-event/')
@@ -347,9 +345,7 @@ class TestPageQuerySet(TestCase):
 
         # Check that no objects are EventPages or SimplePages
         for page in pages:
-            self.assertFalse(
-                isinstance(page.specific, (EventPage, SimplePage))
-            )
+            self.assertIsNotInstance(page.specific, (EventPage, SimplePage))
 
         # Check that "About us" is NOT in the results
         about_us = Page.objects.get(url_path='/home/about-us/')

--- a/wagtail/core/tests/test_streamfield.py
+++ b/wagtail/core/tests/test_streamfield.py
@@ -500,6 +500,6 @@ class TestStreamFieldCountValidation(TestCase):
 
         # passing None from StreamField should cancel limits set at the block level
         field = StreamField(TestStreamBlock, min_num=None, max_num=None, block_counts=None)
-        self.assertEqual(field.stream_block.meta.min_num, None)
-        self.assertEqual(field.stream_block.meta.max_num, None)
-        self.assertEqual(field.stream_block.meta.block_counts, None)
+        self.assertIsNone(field.stream_block.meta.min_num)
+        self.assertIsNone(field.stream_block.meta.max_num)
+        self.assertIsNone(field.stream_block.meta.block_counts)

--- a/wagtail/core/tests/test_translatablemixin.py
+++ b/wagtail/core/tests/test_translatablemixin.py
@@ -80,8 +80,8 @@ class TestTranslatableMixin(TestCase):
             self.main_instance, "get_translation"
         ) as mock_get_translation:
             mock_get_translation.side_effect = self.main_instance.DoesNotExist
-            self.assertEqual(
-                self.main_instance.get_translation_or_none(self.another_locale), None
+            self.assertIsNone(
+                self.main_instance.get_translation_or_none(self.another_locale)
             )
 
     def test_has_translation_when_exists(self):

--- a/wagtail/core/tests/test_workflow.py
+++ b/wagtail/core/tests/test_workflow.py
@@ -106,22 +106,22 @@ class TestWorkflows(TestCase):
     def test_workflow_methods_generate_no_queries_when_disabled(self):
         homepage = Page.objects.get(url_path='/home/')
         with self.assertNumQueries(0):
-            self.assertEqual(homepage.has_workflow, False)
+            self.assertIs(homepage.has_workflow, False)
 
         with self.assertNumQueries(0):
-            self.assertEqual(homepage.get_workflow(), None)
+            self.assertIsNone(homepage.get_workflow())
 
         with self.assertNumQueries(0):
-            self.assertEqual(homepage.workflow_in_progress, False)
+            self.assertIs(homepage.workflow_in_progress, False)
 
         with self.assertNumQueries(0):
-            self.assertEqual(homepage.current_workflow_state, None)
+            self.assertIsNone(homepage.current_workflow_state)
 
         with self.assertNumQueries(0):
-            self.assertEqual(homepage.current_workflow_task_state, None)
+            self.assertIsNone(homepage.current_workflow_task_state)
 
         with self.assertNumQueries(0):
-            self.assertEqual(homepage.current_workflow_task, None)
+            self.assertIsNone(homepage.current_workflow_task)
 
     @freeze_time("2017-01-01 12:00:00")
     def test_start_workflow_on_page(self):
@@ -148,7 +148,7 @@ class TestWorkflows(TestCase):
             self.assertEqual(task_state.started_at, datetime.datetime(2017, 1, 1, 12, 0, 0, tzinfo=pytz.utc))
         else:
             self.assertEqual(task_state.started_at, datetime.datetime(2017, 1, 1, 12, 0, 0))
-        self.assertEqual(task_state.finished_at, None)
+        self.assertIsNone(task_state.finished_at)
 
     @override_settings(WAGTAIL_WORKFLOW_CANCEL_ON_PUBLISH=True)
     def test_publishing_page_cancels_workflow_when_cancel_on_publish_true(self):

--- a/wagtail/core/tests/tests.py
+++ b/wagtail/core/tests/tests.py
@@ -107,11 +107,11 @@ class TestPageUrlTags(TestCase):
     def test_bad_slugurl(self):
         # no 'request' object in context
         result = slugurl(template.Context({}), 'bad-slug-doesnt-exist')
-        self.assertEqual(result, None)
+        self.assertIsNone(result)
 
         # 'request' object in context, but no 'site' attribute
         result = slugurl(context=template.Context({'request': HttpRequest()}), slug='bad-slug-doesnt-exist')
-        self.assertEqual(result, None)
+        self.assertIsNone(result)
 
     @override_settings(ALLOWED_HOSTS=['testserver', 'localhost', 'site2.example.com'])
     def test_slugurl_tag_returns_url_for_current_site(self):

--- a/wagtail/documents/tests/test_admin_views.py
+++ b/wagtail/documents/tests/test_admin_views.py
@@ -357,7 +357,7 @@ class TestDocumentEditView(TestCase, WagtailTestUtils):
         self.assertEqual(response.status_code, 302)
 
         url_finder = AdminURLFinder(self.user)
-        self.assertEqual(url_finder.get_edit_url(self.document), None)
+        self.assertIsNone(url_finder.get_edit_url(self.document))
 
     def test_post_with_limited_permissions(self):
         self.user.is_superuser = False

--- a/wagtail/embeds/tests/test_embeds.py
+++ b/wagtail/embeds/tests/test_embeds.py
@@ -98,7 +98,7 @@ class TestGetFinders(TestCase):
         self.assertEqual(finders[0].app_id, '1234567890')
         self.assertEqual(finders[0].app_secret, 'abcdefghijklmnop')
         # omitscript defaults to False
-        self.assertEqual(finders[0].omitscript, False)
+        self.assertIs(finders[0].omitscript, False)
 
     @override_settings(WAGTAILEMBEDS_FINDERS=[
         {
@@ -115,7 +115,7 @@ class TestGetFinders(TestCase):
         self.assertEqual(finders[0].app_id, '1234567890')
         self.assertEqual(finders[0].app_secret, 'abcdefghijklmnop')
         # omitscript defaults to False
-        self.assertEqual(finders[0].omitscript, False)
+        self.assertIs(finders[0].omitscript, False)
 
 
 class TestEmbeds(TestCase):
@@ -225,7 +225,7 @@ class TestEmbeds(TestCase):
         embed = get_embed('www.test.com/1234', max_width=400, finder=self.dummy_finder_invalid_width)
 
         # Width must be set to None
-        self.assertEqual(embed.width, None)
+        self.assertIsNone(embed.width)
 
     def test_no_html(self):
         def no_html_finder(url, max_width=None, max_height=None):
@@ -714,7 +714,7 @@ class TestEmbedBlock(TestCase):
 
         # empty values should yield None
         empty_block_val = block.to_python('')
-        self.assertEqual(empty_block_val, None)
+        self.assertIsNone(empty_block_val)
 
     def test_serialize(self):
         block = EmbedBlock(required=False)
@@ -781,17 +781,17 @@ class TestEmbedBlock(TestCase):
 
         # empty value should result in None
         empty_val = block.value_from_datadict({'myembed': ''}, {}, prefix='myembed')
-        self.assertEqual(empty_val, None)
+        self.assertIsNone(empty_val)
 
     def test_default(self):
         block1 = EmbedBlock()
-        self.assertEqual(block1.get_default(), None)
+        self.assertIsNone(block1.get_default())
 
         block2 = EmbedBlock(default='')
-        self.assertEqual(block2.get_default(), None)
+        self.assertIsNone(block2.get_default())
 
         block3 = EmbedBlock(default=None)
-        self.assertEqual(block3.get_default(), None)
+        self.assertIsNone(block3.get_default())
 
         block4 = EmbedBlock(default='http://www.example.com/foo')
         self.assertIsInstance(block4.get_default(), EmbedValue)

--- a/wagtail/images/tests/test_admin_views.py
+++ b/wagtail/images/tests/test_admin_views.py
@@ -602,7 +602,7 @@ class TestImageEditView(TestCase, WagtailTestUtils):
         self.assertEqual(response.status_code, 302)
 
         url_finder = AdminURLFinder(self.user)
-        self.assertEqual(url_finder.get_edit_url(self.image), None)
+        self.assertIsNone(url_finder.get_edit_url(self.image))
 
     def test_edit_with_new_image_file(self):
         file_content = get_test_image_file().file.getvalue()

--- a/wagtail/images/tests/test_models.py
+++ b/wagtail/images/tests/test_models.py
@@ -40,7 +40,7 @@ class TestImage(TestCase):
         self.assertTrue(self.image.get_rect(), Rect(0, 0, 640, 480))
 
     def test_get_focal_point(self):
-        self.assertEqual(self.image.get_focal_point(), None)
+        self.assertIsNone(self.image.get_focal_point())
 
         # Add a focal point to the image
         self.image.focal_point_x = 100
@@ -63,10 +63,10 @@ class TestImage(TestCase):
         self.assertTrue(self.image.has_focal_point())
 
     def test_set_focal_point(self):
-        self.assertEqual(self.image.focal_point_x, None)
-        self.assertEqual(self.image.focal_point_y, None)
-        self.assertEqual(self.image.focal_point_width, None)
-        self.assertEqual(self.image.focal_point_height, None)
+        self.assertIsNone(self.image.focal_point_x)
+        self.assertIsNone(self.image.focal_point_y)
+        self.assertIsNone(self.image.focal_point_width)
+        self.assertIsNone(self.image.focal_point_height)
 
         self.image.set_focal_point(Rect(100, 150, 200, 350))
 
@@ -77,10 +77,10 @@ class TestImage(TestCase):
 
         self.image.set_focal_point(None)
 
-        self.assertEqual(self.image.focal_point_x, None)
-        self.assertEqual(self.image.focal_point_y, None)
-        self.assertEqual(self.image.focal_point_width, None)
-        self.assertEqual(self.image.focal_point_height, None)
+        self.assertIsNone(self.image.focal_point_x)
+        self.assertIsNone(self.image.focal_point_y)
+        self.assertIsNone(self.image.focal_point_width)
+        self.assertIsNone(self.image.focal_point_height)
 
     def test_is_stored_locally(self):
         self.assertTrue(self.image.is_stored_locally())
@@ -157,7 +157,7 @@ class TestImageQuerySet(TestCase):
                 image.title: [tag.name for tag in image.tags.all()]
                 for image in Image.get_indexed_objects()
             }
-            self.assertTrue('aardvark' in results['Test image 0'])
+            self.assertIn('aardvark', results['Test image 0'])
 
 
 class TestImagePermissions(TestCase, WagtailTestUtils):

--- a/wagtail/images/tests/tests.py
+++ b/wagtail/images/tests/tests.py
@@ -46,9 +46,9 @@ class TestImageTag(TestCase):
         result = self.render_image_tag(self.image, 'width-400')
 
         # Check that all the required HTML attributes are set
-        self.assertTrue('width="400"' in result)
-        self.assertTrue('height="300"' in result)
-        self.assertTrue('alt="Test image"' in result)
+        self.assertIn('width="400"', result)
+        self.assertIn('height="300"', result)
+        self.assertIn('alt="Test image"', result)
 
     def test_image_tag_none(self):
         result = self.render_image_tag(None, "width-500")
@@ -70,9 +70,9 @@ class TestImageTag(TestCase):
         result = self.render_image_tag_as(self.image, 'width-400')
 
         # Check that all the required HTML attributes are set
-        self.assertTrue('width="400"' in result)
-        self.assertTrue('height="300"' in result)
-        self.assertTrue('alt="Test image"' in result)
+        self.assertIn('width="400"', result)
+        self.assertIn('height="300"', result)
+        self.assertIn('alt="Test image"', result)
 
     def render_image_tag_with_extra_attributes(self, image, title):
         temp = template.Template(
@@ -86,11 +86,11 @@ class TestImageTag(TestCase):
         result = self.render_image_tag_with_extra_attributes(self.image, 'My Wonderful Title')
 
         # Check that all the required HTML attributes are set
-        self.assertTrue('width="400"' in result)
-        self.assertTrue('height="300"' in result)
-        self.assertTrue('class="photo"' in result)
-        self.assertTrue('alt="Alternate"' in result)
-        self.assertTrue('title="my wonderful title"' in result)
+        self.assertIn('width="400"', result)
+        self.assertIn('height="300"', result)
+        self.assertIn('class="photo"', result)
+        self.assertIn('alt="Alternate"', result)
+        self.assertIn('title="my wonderful title"', result)
 
     def render_image_tag_with_filters(self, image):
         temp = template.Template(
@@ -101,13 +101,13 @@ class TestImageTag(TestCase):
 
     def test_image_tag_with_filters(self):
         result = self.render_image_tag_with_filters(self.image)
-        self.assertTrue('width="400"' in result)
-        self.assertTrue('height="300"' in result)
+        self.assertIn('width="400"', result)
+        self.assertIn('height="300"', result)
 
     def test_image_tag_with_chained_filters(self):
         result = self.render_image_tag(self.image, 'fill-200x200 height-150')
-        self.assertTrue('width="150"' in result)
-        self.assertTrue('height="150"' in result)
+        self.assertIn('width="150"', result)
+        self.assertIn('height="150"', result)
 
     def test_filter_specs_must_match_allowed_pattern(self):
         with self.assertRaises(template.TemplateSyntaxError):
@@ -662,7 +662,7 @@ class TestDifferentUpload(TestCase):
 
         # The files should be uploaded based on it's content, not just
         # it's filename
-        self.assertFalse(image.file.url == second_image.file.url)
+        self.assertNotEqual(image.file.url, second_image.file.url)
 
 
 class TestGetImageModel(WagtailTestUtils, TestCase):

--- a/wagtail/search/tests/test_index_functions.py
+++ b/wagtail/search/tests/test_index_functions.py
@@ -38,7 +38,7 @@ class TestGetIndexedInstance(TestCase):
         # We've told it not to index anything with the title "Don't index me"
         # get_indexed_instance should return None
         indexed_instance = index.get_indexed_instance(obj.book_ptr)
-        self.assertEqual(indexed_instance, None)
+        self.assertIsNone(indexed_instance)
 
 
 @mock.patch('wagtail.search.tests.DummySearchBackend', create=True)

--- a/wagtail/search/tests/test_queries.py
+++ b/wagtail/search/tests/test_queries.py
@@ -324,7 +324,7 @@ class TestBalancedReduce(SimpleTestCase):
 
         self.assertRaises(RuntimeError, balanced_reduce, add, TestFailingIter())
 
-        self.assertEqual(balanced_reduce(add, [], None), None)
+        self.assertIsNone(balanced_reduce(add, [], None))
         self.assertEqual(balanced_reduce(add, [], 42), 42)
 
         class BadSeq:

--- a/wagtail/sites/tests.py
+++ b/wagtail/sites/tests.py
@@ -51,7 +51,7 @@ class TestSiteCreateView(TestCase, WagtailTestUtils):
         # we should have loaded with a single site
         self.assertEqual(self.localhost.hostname, 'localhost')
         self.assertEqual(self.localhost.port, 80)
-        self.assertEqual(self.localhost.is_default_site, True)
+        self.assertIs(self.localhost.is_default_site, True)
         self.assertEqual(self.localhost.root_page, self.home_page)
 
     def test_simple(self):
@@ -82,7 +82,7 @@ class TestSiteCreateView(TestCase, WagtailTestUtils):
 
         # Should return the form with errors
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(bool(response.context['form'].errors), True)
+        self.assertIs(bool(response.context['form'].errors), True)
 
         # Check that the site was not created
         sites = Site.objects.filter(hostname='also_default')
@@ -113,7 +113,7 @@ class TestSiteCreateView(TestCase, WagtailTestUtils):
 
         # Should return the form with errors
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(bool(response.context['form'].errors), True)
+        self.assertIs(bool(response.context['form'].errors), True)
 
         # Check that the site was not created, still only one localhost entry
         self.assertEqual(Site.objects.filter(hostname='localhost').count(), 1)
@@ -188,7 +188,7 @@ class TestSiteEditView(TestCase, WagtailTestUtils):
         # Should redirect back to index
         self.assertRedirects(response, reverse('wagtailsites:index'))
         # Check that the site is no longer default
-        self.assertEqual(Site.objects.get(id=self.localhost.id).is_default_site, False)
+        self.assertIs(Site.objects.get(id=self.localhost.id).is_default_site, False)
 
         # Now make the second site default
         response = self.post(
@@ -201,7 +201,7 @@ class TestSiteEditView(TestCase, WagtailTestUtils):
         # Should redirect back to index
         self.assertRedirects(response, reverse('wagtailsites:index'))
         # Check that the second site is now set as default
-        self.assertEqual(Site.objects.get(id=second_site.id).is_default_site, True)
+        self.assertIs(Site.objects.get(id=second_site.id).is_default_site, True)
 
     def test_making_a_second_site_the_default_not_allowed(self):
         second_site = Site.objects.create(
@@ -218,11 +218,11 @@ class TestSiteEditView(TestCase, WagtailTestUtils):
 
         # Should return the form with errors
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(bool(response.context['form'].errors), True)
+        self.assertIs(bool(response.context['form'].errors), True)
 
         # Check that the site was not editd
 
-        self.assertEqual(Site.objects.get(id=second_site.id).is_default_site, False)
+        self.assertIs(Site.objects.get(id=second_site.id).is_default_site, False)
 
 
 class TestSiteDeleteView(TestCase, WagtailTestUtils):

--- a/wagtail/snippets/tests.py
+++ b/wagtail/snippets/tests.py
@@ -586,7 +586,7 @@ class TestSnippetEditView(BaseTestSnippetEditView):
         self.assertEqual(response.status_code, 302)
 
         url_finder = AdminURLFinder(self.user)
-        self.assertEqual(url_finder.get_edit_url(self.test_snippet), None)
+        self.assertIsNone(url_finder.get_edit_url(self.test_snippet))
 
     def test_edit_invalid(self):
         response = self.post(post_data={'foo': 'bar'})
@@ -1418,7 +1418,7 @@ class TestSnippetChooserBlock(TestCase):
         self.assertEqual(block.get_prep_value(test_advert), test_advert.id)
 
         # None should serialize to None
-        self.assertEqual(block.get_prep_value(None), None)
+        self.assertIsNone(block.get_prep_value(None))
 
     def test_deserialize(self):
         """The serialized value of a SnippetChooserBlock (an ID) should deserialize to a snippet instance"""
@@ -1428,7 +1428,7 @@ class TestSnippetChooserBlock(TestCase):
         self.assertEqual(block.to_python(test_advert.id), test_advert)
 
         # None should deserialize to None
-        self.assertEqual(block.to_python(None), None)
+        self.assertIsNone(block.to_python(None))
 
     def test_reference_model_by_string(self):
         block = SnippetChooserBlock('tests.Advert')
@@ -1462,7 +1462,7 @@ class TestSnippetChooserBlock(TestCase):
         self.assertEqual(value, test_advert)
 
         empty_value = block.value_from_datadict({'advert': ''}, {}, 'advert')
-        self.assertEqual(empty_value, None)
+        self.assertIsNone(empty_value)
 
     def test_clean(self):
         required_block = SnippetChooserBlock(Advert)
@@ -1474,7 +1474,7 @@ class TestSnippetChooserBlock(TestCase):
             required_block.clean(None)
 
         self.assertEqual(nonrequired_block.clean(test_advert), test_advert)
-        self.assertEqual(nonrequired_block.clean(None), None)
+        self.assertIsNone(nonrequired_block.clean(None))
 
 
 class TestAdminSnippetChooserWidget(TestCase, WagtailTestUtils):
@@ -1601,7 +1601,7 @@ class TestSnippetChooserBlockWithCustomPrimaryKey(TestCase):
         self.assertEqual(block.get_prep_value(test_advert), test_advert.pk)
 
         # None should serialize to None
-        self.assertEqual(block.get_prep_value(None), None)
+        self.assertIsNone(block.get_prep_value(None))
 
     def test_deserialize(self):
         """The serialized value of a SnippetChooserBlock (an ID) should deserialize to a snippet instance"""
@@ -1611,7 +1611,7 @@ class TestSnippetChooserBlockWithCustomPrimaryKey(TestCase):
         self.assertEqual(block.to_python(test_advert.pk), test_advert)
 
         # None should deserialize to None
-        self.assertEqual(block.to_python(None), None)
+        self.assertIsNone(block.to_python(None))
 
     def test_adapt(self):
         block = SnippetChooserBlock(AdvertWithCustomPrimaryKey, help_text="pick an advert, any advert")
@@ -1640,7 +1640,7 @@ class TestSnippetChooserBlockWithCustomPrimaryKey(TestCase):
         self.assertEqual(value, test_advert)
 
         empty_value = block.value_from_datadict({'advertwithcustomprimarykey': ''}, {}, 'advertwithcustomprimarykey')
-        self.assertEqual(empty_value, None)
+        self.assertIsNone(empty_value)
 
     def test_clean(self):
         required_block = SnippetChooserBlock(AdvertWithCustomPrimaryKey)
@@ -1652,7 +1652,7 @@ class TestSnippetChooserBlockWithCustomPrimaryKey(TestCase):
             required_block.clean(None)
 
         self.assertEqual(nonrequired_block.clean(test_advert), test_advert)
-        self.assertEqual(nonrequired_block.clean(None), None)
+        self.assertIsNone(nonrequired_block.clean(None))
 
 
 class TestSnippetChooserPanelWithCustomPrimaryKey(TestCase, WagtailTestUtils):

--- a/wagtail/tests/utils/wagtail_tests.py
+++ b/wagtail/tests/utils/wagtail_tests.py
@@ -189,7 +189,7 @@ class WagtailTestUtils:
                 msg_prefix + "Found %d instances of '%s' in response (expected %d)" % (real_count, needle, count)
             )
         else:
-            self.assertTrue(real_count != 0, msg_prefix + "Couldn't find '%s' in response" % needle)
+            self.assertNotEqual(real_count, 0, msg_prefix + "Couldn't find '%s' in response" % needle)
 
     def assertNotInHTML(self, needle, haystack, msg_prefix=''):
         self.assertInHTML(needle, haystack, count=0, msg_prefix=msg_prefix)
@@ -213,4 +213,4 @@ class WagtailTestUtils:
                 msg_prefix + "Found %d instances of '%s' in template script (expected %d)" % (real_count, needle, count)
             )
         else:
-            self.assertTrue(real_count != 0, msg_prefix + "Couldn't find '%s' in template script" % needle)
+            self.assertNotEqual(real_count, 0, msg_prefix + "Couldn't find '%s' in template script" % needle)

--- a/wagtail/users/tests/test_admin_views.py
+++ b/wagtail/users/tests/test_admin_views.py
@@ -782,9 +782,9 @@ class TestUserEditView(TestCase, WagtailTestUtils):
         user = get_user_model().objects.get(pk=self.test_user.pk)
         self.assertEqual(user.first_name, 'Edited')
         # Check that the user is no longer superuser
-        self.assertEqual(user.is_superuser, False)
+        self.assertIs(user.is_superuser, False)
         # Check that the user is no longer active
-        self.assertEqual(user.is_active, False)
+        self.assertIs(user.is_active, False)
 
     def test_edit_and_make_superuser(self):
         response = self.post({
@@ -805,9 +805,9 @@ class TestUserEditView(TestCase, WagtailTestUtils):
         user = get_user_model().objects.get(pk=self.test_user.pk)
 
         # Check that the user is now superuser
-        self.assertEqual(user.is_superuser, True)
+        self.assertIs(user.is_superuser, True)
         # Check that the user is now active
-        self.assertEqual(user.is_active, True)
+        self.assertIs(user.is_active, True)
 
     def test_edit_self(self):
         response = self.post({
@@ -829,9 +829,9 @@ class TestUserEditView(TestCase, WagtailTestUtils):
         self.assertEqual(user.first_name, 'Edited Myself')
 
         # Check that the user is still superuser
-        self.assertEqual(user.is_superuser, True)
+        self.assertIs(user.is_superuser, True)
         # Check that the user is still active
-        self.assertEqual(user.is_active, True)
+        self.assertIs(user.is_active, True)
 
     def test_editing_own_password_does_not_log_out(self):
         response = self.post({
@@ -882,9 +882,9 @@ class TestUserEditView(TestCase, WagtailTestUtils):
         self.assertEqual(user.first_name, 'Edited Myself')
 
         # Check that the user is still superuser
-        self.assertEqual(user.is_superuser, True)
+        self.assertIs(user.is_superuser, True)
         # Check that the user is still active
-        self.assertEqual(user.is_active, True)
+        self.assertIs(user.is_active, True)
 
     @unittest.skipUnless(settings.AUTH_USER_MODEL == 'customuser.CustomUser', "Only applicable to CustomUser")
     @override_settings(
@@ -1089,7 +1089,7 @@ class TestUserEditViewForNonSuperuser(TestCase, WagtailTestUtils):
         self.assertEqual(user.first_name, "Escalating")
 
         # Check that the user did not escalate its is_superuser status
-        self.assertEqual(user.is_superuser, False)
+        self.assertIs(user.is_superuser, False)
 
 
 class TestGroupIndexView(TestCase, WagtailTestUtils):


### PR DESCRIPTION
These improvements were based on flake8-assertive, which compiled an extensive
list of patterns to replace with more precise assertions. This should make
the error messages better in case of failures.

Thanks for contributing to Wagtail! 🎉

Before submitting, please review the contributor guidelines <https://docs.wagtail.org/en/latest/contributing/index.html> and check the following:

* Do the tests still pass? (https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
* Does the code comply with the style guide? (Run `make lint` from the Wagtail root)
* For Python changes: Have you added tests to cover the new/fixed behaviour?
* For front-end changes: Did you test on all of [Wagtail’s supported environments](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)?
    * **Please list the exact browser and operating system versions you tested**.
    * **Please list which assistive technologies you tested**.
* For new features: Has the documentation been updated accordingly?
