### PR TITLE
converting defaults of form fields to textarea

### DIFF
--- a/wagtail/contrib/forms/models.py
+++ b/wagtail/contrib/forms/models.py
@@ -100,9 +100,8 @@ class AbstractFormField(Orderable):
         blank=True,
         help_text=_('Comma separated list of choices. Only applicable in checkboxes, radio and dropdown.')
     )
-    default_value = models.CharField(
+    default_value = models.TextField(
         verbose_name=_('default value'),
-        max_length=255,
         blank=True,
         help_text=_('Default value. Comma separated values supported for checkboxes.')
     )


### PR DESCRIPTION
it is good to have textarea input box for multilines  field type, and it waill not affect anything else (backward compatible), it is kinda like options input box (textarea) that is not obvious due to number of rows set to "1" but can automatically expanded based on the lines of texts inside it

Thanks for contributing to Wagtail! 🎉

Before submitting, please review the contributor guidelines <https://docs.wagtail.org/en/latest/contributing/index.html> and check the following:

* Do the tests still pass? (https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
* Does the code comply with the style guide? (Run `make lint` from the Wagtail root)
* For Python changes: Have you added tests to cover the new/fixed behaviour?
* For front-end changes: Did you test on all of [Wagtail’s supported environments](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)?
    * **Please list the exact browser and operating system versions you tested**.
    * **Please list which assistive technologies you tested**.
* For new features: Has the documentation been updated accordingly?
