### PR TITLE
Prevent error on creating automatic redirects for sites with non-standard ports

### DIFF
--- a/wagtail/core/tests/test_utils.py
+++ b/wagtail/core/tests/test_utils.py
@@ -5,11 +5,11 @@ from django.utils.text import slugify
 from django.utils.translation import _trans
 from django.utils.translation import gettext_lazy as _
 
-from wagtail.core.models import Page
+from wagtail.core.models import Page, Site
 from wagtail.core.utils import (
     accepts_kwarg, camelcase_to_underscore, cautious_slugify, find_available_slug,
-    get_content_languages, get_supported_content_language_variant, multigetattr, safe_snake_case,
-    string_to_ascii)
+    get_content_languages, get_dummy_request, get_supported_content_language_variant, multigetattr,
+    safe_snake_case, string_to_ascii)
 
 
 class TestCamelCaseToUnderscore(TestCase):
@@ -354,3 +354,23 @@ class TestMultigetattr(TestCase):
         with self.assertRaises(SuspiciousOperation):
             multigetattr(self.thing, 'poke')
         self.assertFalse(self.thing.poke_was_called)
+
+
+class TestGetDummyRequest(TestCase):
+    def test_standard_port(self):
+        site = Site.objects.first()
+        site.hostname = 'other.example.com'
+        site.port = 80
+        site.save()
+
+        request = get_dummy_request(site=site)
+        self.assertEqual(request.get_host(), 'other.example.com')
+
+    def test_non_standard_port(self):
+        site = Site.objects.first()
+        site.hostname = 'other.example.com'
+        site.port = 8888
+        site.save()
+
+        request = get_dummy_request(site=site)
+        self.assertEqual(request.get_host(), 'other.example.com:8888')

--- a/wagtail/core/utils.py
+++ b/wagtail/core/utils.py
@@ -397,8 +397,6 @@ def get_dummy_request(path: str = "/", site: 'Site' = None) -> HttpRequest:
     SERVER_PORT = 80
     if site:
         SERVER_NAME = site.hostname
-        if site.port not in [80, 443]:
-            SERVER_NAME += f":{site.port}"
         SERVER_PORT = site.port
     elif settings.ALLOWED_HOSTS == ["*"]:
         SERVER_NAME = "example.com"


### PR DESCRIPTION
Fixes #7942 - get_dummy_request should not include the port number in SERVER_NAME.