### PR TITLE
reorder nav (sidebar) imports so that hooks can still override them

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/admin_base.html
+++ b/wagtail/admin/templates/wagtailadmin/admin_base.html
@@ -5,9 +5,10 @@
     <link rel="stylesheet" href="{% versioned_static 'wagtailadmin/css/vendor/jquery-ui/jquery-ui-1.10.3.verdant.css' %}" />
     <link rel="stylesheet" href="{% versioned_static 'wagtailadmin/css/vendor/jquery.tagit.css' %}">
     <link rel="stylesheet" href="{% versioned_static 'wagtailadmin/css/core.css' %}" type="text/css" />
-    {% hook_output 'insert_global_admin_css' %}
 
     {% main_nav_css %}
+
+    {% hook_output 'insert_global_admin_css' %}
 
     {% block extra_css %}{% endblock %}
 {% endblock %}
@@ -52,11 +53,10 @@
     <script src="{% versioned_static 'wagtailadmin/js/core.js' %}"></script>
     <script src="{% versioned_static 'wagtailadmin/js/vendor.js' %}"></script>
     <script src="{% versioned_static 'wagtailadmin/js/wagtailadmin.js' %}"></script>
-    {% hook_output 'insert_global_admin_js' %}
-
-
 
     {% main_nav_js %}
+
+    {% hook_output 'insert_global_admin_js' %}
 
     {% block extra_js %}{% endblock %}
 {% endblock %}


### PR DESCRIPTION
- main_nav_css & main_nav_js were added when the new slim sidebar was being built
- with the legacy styles/js - there was little risk of there being conflicts
- with the new sidebar CSS, this sidebar bundle comes with a large duplicate of what is in core.css so we should add it before the hooks run so that hook scan override if needed as per our documentation
- this is a temporary fix for #7943 - ideally we should avoid sidebar.scss bundle duplicating so much of the core css
- note: JS is lower risk but should follow the same convention
