### PR TITLE
Update wagtail requirements to fix Django 4.x compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ install_requires = [
     "Django>=3.2,<4.1",
     "django-modelcluster>=5.2,<6.0",
     "django-taggit>=2.0,<3.0",
-    "django-treebeard>=4.2.0,<5.0,!=4.5",
+    "django-treebeard>=4.5.1,<5.0",
     "djangorestframework>=3.11.1,<4.0",
     "django-filter>=2.2,<22",
     "draftjs_exporter>=2.1.5,<3.0",


### PR DESCRIPTION
The django-treebeard 4.3.x is not compatible with Django 4.x because of the dreaded ugettext alias removal problem. This makes sure that a proper django-treebeard version will be installed.

*IMPORTANT*: Please notice that django treebeard *does not* officially support django 4.x. However from my tests I have concludeded that it works fine after you install the version 4.5.x.
