### PR TITLE
forms - remove unidecode and legacy clean name approach

### DIFF
--- a/docs/releases/3.0.md
+++ b/docs/releases/3.0.md
@@ -156,3 +156,9 @@ When overriding the `get_form_class` method of a ModelAdmin `CreateView` or `Edi
 `StreamField` now requires a `use_json_field` keyword argument that can be set to `True`/`False`. If set to `True`, the field will use `JSONField` as its internal type instead of `TextField`, which will change the data type used on the database and allow you to use `JSONField` lookups and transforms on the `StreamField`. If set to `False`, the field will keep its previous behaviour and no database changes will be made. If set to `None` (the default), the field will keep its previous behaviour and a warning (`RemovedInWagtail50Warning`) will appear.
 
 After setting the keyword argument, make sure to generate and run the migrations for the models.
+
+### Removal of legacy `clean_name` on `AbstractFormField`
+
+-   If you have a project migrating from pre 2.10 to this release and you are using the Wagtail form builder and you have existing form submissions you must first upgrade to at least 2.11. Then run migrations and run the application with your data to ensure that any existing form fields are correctly migrated.
+-   In Wagtail 2.10 a `clean_name` field was added to form field models that extend `AbstractFormField` and this initially supported legacy migration of the [Unidecode](https://pypi.org/project/Unidecode/) label conversion.
+-   Any new fields created since then will have used the [AnyAscii](https://pypi.org/project/anyascii/) conversion and Unidecode has been removed from the included packages.

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,6 @@ testing_extras = [
     "boto3>=1.16,<1.17",
     "freezegun>=0.3.8",
     "openpyxl>=2.6.4",
-    "Unidecode>=0.04.14,<2.0",
     "azure-mgmt-cdn>=5.1,<6.0",
     "azure-mgmt-frontdoor>=0.3,<0.4",
     "django-pattern-library>=0.7,<0.8",

--- a/wagtail/contrib/forms/tests/test_views.py
+++ b/wagtail/contrib/forms/tests/test_views.py
@@ -5,7 +5,6 @@ from io import BytesIO
 
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
-from django.core.checks import Info
 from django.test import RequestFactory, TestCase, override_settings
 from django.urls import reverse
 from openpyxl import load_workbook
@@ -520,49 +519,6 @@ class TestFormsSubmissionsList(TestCase, WagtailTestUtils):
         # check ordering matches 'submit_time' (oldest first)
         first_row_values = response.context["data_rows"][0]["fields"]
         self.assertIn("this is a really old message", first_row_values)
-
-
-class TestFormsSubmissionsListLegacyFieldName(TestCase, WagtailTestUtils):
-    fixtures = ["test.json"]
-
-    def setUp(self):
-        self.login(username="siteeditor", password="password")
-        self.form_page = Page.objects.get(
-            url_path="/home/contact-us-one-more-time/"
-        ).specific
-
-        # running checks should show an info message AND update blank clean_name values
-
-        messages = FormFieldWithCustomSubmission.check()
-
-        self.assertEqual(
-            messages,
-            [
-                Info(
-                    "Added `clean_name` on 3 form field(s)",
-                    obj=FormFieldWithCustomSubmission,
-                )
-            ],
-        )
-
-        # check clean_name has been updated
-        self.assertEqual(
-            FormFieldWithCustomSubmission.objects.all()[0].clean_name, "your-email"
-        )
-
-    def test_list_submissions(self):
-        response = self.client.get(
-            reverse("wagtailforms:list_submissions", args=(self.form_page.id,))
-        )
-
-        # Check response
-        self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, "wagtailforms/index_submissions.html")
-        self.assertEqual(len(response.context["data_rows"]), 2)
-
-        # check display of list values within form submissions
-        self.assertContains(response, "old@example.com")
-        self.assertContains(response, "new@example.com")
 
 
 class TestFormsSubmissionsExport(TestCase, WagtailTestUtils):

--- a/wagtail/images/models.py
+++ b/wagtail/images/models.py
@@ -187,7 +187,7 @@ class AbstractImage(ImageFileMixin, CollectionMember, index.Indexed, models.Mode
         folder_name = "original_images"
         filename = self.file.field.storage.get_valid_name(filename)
 
-        # do a unidecode in the filename and then
+        # convert the filename to simple ascii characters and then
         # replace non-ascii characters in filename with _ , to sidestep issues with filesystem encoding
         filename = "".join(
             (i if ord(i) < 128 else "_") for i in string_to_ascii(filename)

--- a/wagtail/test/testapp/fixtures/test.json
+++ b/wagtail/test/testapp/fixtures/test.json
@@ -487,7 +487,7 @@
     "pk": 1,
     "model": "tests.formfieldwithcustomsubmission",
     "fields": {
-      "clean_name": "",
+      "clean_name": "your_email",
       "sort_order": 1,
       "label": "Your email",
       "field_type": "email",
@@ -502,7 +502,7 @@
     "pk": 2,
     "model": "tests.formfieldwithcustomsubmission",
     "fields": {
-      "clean_name": "",
+      "clean_name": "your_message",
       "sort_order": 2,
       "label": "Your message",
       "field_type": "multiline",
@@ -517,7 +517,7 @@
     "pk": 3,
     "model": "tests.formfieldwithcustomsubmission",
     "fields": {
-      "clean_name": "",
+      "clean_name": "your_choices",
       "sort_order": 3,
       "label": "Your choices",
       "field_type": "checkboxes",


### PR DESCRIPTION
- resolves #7975
- remove unidecode completely for upcoming release - see #3311 for more context
- removes unit tests and update test data, also include release notes upgrade considerations