### PR TITLE
Form Builder - allow subclasses to override form field get clean name

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -25,6 +25,7 @@ Changelog
  * Add the ability to change the number of images displayed per page in the image library (Tidiane Dia, with sponsorship from YouGov)
  * Allow users to sort by different fields in the image library (Tidiane Dia, with sponsorship from YouGov)
  * Add `prefetch_renditions` method to `ImageQueryset` for performance optimisation on image listings (Tidiane Dia, Karl Hobley)
+ * Add ability to define a custom `get_field_clean_name` method when defining `FormField` models that extend `AbstractFormField` (LB (Ben) Johnston)
  * Fix: Typo in `ResumeWorkflowActionFormatter` message (Stefan Hammer)
  * Fix: Throw a meaningful error when saving an image to an unrecognised image format (Christian Franke)
  * Fix: Remove extra padding for headers with breadcrumbs on mobile viewport (Steven Steinwand)

--- a/docs/reference/contrib/forms/customisation.md
+++ b/docs/reference/contrib/forms/customisation.md
@@ -761,3 +761,36 @@ class FormPage(AbstractEmailForm):
 
         send_mail(subject, self.render_email(form), addresses, self.from_address,)
 ```
+
+## Custom `clean_name` generation
+
+* Each time a new `FormField` is added a `clean_name` also gets generated based on the user entered `label`.
+* `AbstractFormField` has a method `get_field_clean_name` to convert the label into a HTML valid `lower_snake_case` ASCII string using the [AnyAscii](https://pypi.org/project/anyascii/) library which can be overridden to generate a custom conversion.
+* The resolved `clean_name` is also used as the form field name in rendered HTML forms.
+* Ensure that any conversion will be unique enough to not create conflicts within your `FormPage` instance.
+* This method gets called on creation of new fields only and as such will not have access to its own `Page` or `pk`. This does not get called when labels are edited as modifying the `clean_name` after any form responses are submitted will mean those field responses will not be retrieved.
+* This method gets called for form previews and also validation of duplicate labels.
+
+```python
+    import uuid
+
+    from django.db import models
+    from modelcluster.fields import ParentalKey
+
+    # ... other field and edit_handler imports
+    from wagtail.contrib.forms.models import AbstractEmailForm, AbstractFormField
+
+
+    class FormField(AbstractFormField):
+        page = ParentalKey('FormPage', on_delete=models.CASCADE, related_name='form_fields')
+
+        def get_field_clean_name(self):
+            clean_name = super().get_field_clean_name()
+            id = str(uuid.uuid4())[:8] # short uuid
+            return f"{id}_{clean_name}"
+
+
+    class FormPage(AbstractEmailForm):
+        # ... page definitions
+```
+

--- a/docs/releases/4.0.md
+++ b/docs/releases/4.0.md
@@ -34,6 +34,7 @@ When using a queryset to render a list of images, you can now use the ``prefetch
  * Add the ability to change the number of images displayed per page in the image library (Tidiane Dia, with sponsorship from YouGov)
  * Allow users to sort by different fields in the image library (Tidiane Dia, with sponsorship from YouGov)
  * Add `prefetch_renditions` method to `ImageQueryset` for performance optimisation on image listings (Tidiane Dia, Karl Hobley)
+ * Add ability to define a custom `get_field_clean_name` method when defining `FormField` models that extend `AbstractFormField` (LB (Ben) Johnston)
 
 ### Bug fixes
 

--- a/wagtail/contrib/forms/forms.py
+++ b/wagtail/contrib/forms/forms.py
@@ -6,7 +6,6 @@ from django.utils.html import conditional_escape
 from django.utils.translation import gettext_lazy as _
 
 from wagtail.admin.forms import WagtailAdminPageForm
-from wagtail.contrib.forms.utils import get_field_clean_name
 
 
 class BaseForm(django.forms.Form):
@@ -142,7 +141,7 @@ class FormBuilder:
             # If the field hasn't been saved to the database yet (e.g. we are previewing
             # a FormPage with unsaved changes) it won't have a clean_name as this is
             # set in FormField.save.
-            clean_name = field.clean_name or get_field_clean_name(field.label)
+            clean_name = field.clean_name or field.get_field_clean_name()
             formfields[clean_name] = create_field(field, options)
 
         return formfields
@@ -187,12 +186,10 @@ class WagtailAdminFormPageForm(WagtailAdminPageForm):
             for i, form in enumerate(_forms):
                 if "label" in form.changed_data:
                     label = form.cleaned_data.get("label")
-                    clean_name = get_field_clean_name(label)
+                    clean_name = form.instance.get_field_clean_name()
                     for idx, ff in enumerate(_forms):
                         # Exclude self
-                        ff_clean_name = get_field_clean_name(
-                            ff.cleaned_data.get("label")
-                        )
+                        ff_clean_name = ff.instance.get_field_clean_name()
                         if idx != i and clean_name == ff_clean_name:
                             form.add_error(
                                 "label",

--- a/wagtail/contrib/forms/models.py
+++ b/wagtail/contrib/forms/models.py
@@ -121,6 +121,16 @@ class AbstractFormField(Orderable):
         FieldPanel("default_value", classname="formbuilder-default"),
     ]
 
+    def get_field_clean_name(self):
+        """
+        Prepare an ascii safe lower_snake_case variant of the field name to use as the field key.
+        This key is used to reference the field responses in the JSON store and as the field name in forms.
+        Called for new field creation, validation of duplicate labels and form previews.
+        When called, does not have access to the Page, nor its own id as the record is not yet created.
+        """
+
+        return get_field_clean_name(self.label)
+
     def save(self, *args, **kwargs):
         """
         When new fields are created, generate a template safe ascii name to use as the
@@ -132,7 +142,7 @@ class AbstractFormField(Orderable):
 
         is_new = self.pk is None
         if is_new:
-            clean_name = get_field_clean_name(self.label)
+            clean_name = self.get_field_clean_name()
             self.clean_name = clean_name
 
         super().save(*args, **kwargs)

--- a/wagtail/contrib/forms/tests/test_forms.py
+++ b/wagtail/contrib/forms/tests/test_forms.py
@@ -352,3 +352,34 @@ class TestCustomFormBuilder(TestCase):
         self.assertIsInstance(
             form.base_fields["device_ip_address"], forms.GenericIPAddressField
         )
+
+    def test_unsaved_fields_in_form_builder_formfields_with_clean_name_override(self):
+        """
+        Ensure unsaved FormField instances are added to FormBuilder.formfields dict
+        with a clean_name that uses the `get_field_clean_name` method that can be overridden.
+        """
+
+        unsaved_field_1 = ExtendedFormField(
+            page=self.form_page,
+            sort_order=14,
+            label="Unsaved field 1",
+            field_type="number",
+            required=True,
+        )
+        self.form_page.form_fields.add(unsaved_field_1)
+
+        unsaved_field_2 = ExtendedFormField(
+            page=self.form_page,
+            sort_order=15,
+            label="duplicate (suffix removed)",
+            field_type="singleline",
+            required=True,
+        )
+        self.form_page.form_fields.add(unsaved_field_2)
+
+        form_class = self.form_page.get_form_class()
+        form = form_class()
+
+        # See ExtendedFormField get_field_clean_name method
+        self.assertIn("number_field--unsaved_field_1", form.base_fields)
+        self.assertIn("test duplicate", form.base_fields)

--- a/wagtail/contrib/forms/tests/test_views.py
+++ b/wagtail/contrib/forms/tests/test_views.py
@@ -1695,3 +1695,42 @@ class TestDuplicateFormFieldLabels(TestCase, WagtailTestUtils):
             response,
             text="There is another field with the label LOW EARTH ORBIT, please change one of them.",
         )
+
+    def test_adding_duplicate_form_labels_using_override_clean_name(self):
+        """
+        Ensure form submission fails when attempting to create labels that will resolve
+        to the same clean_name that already exists when using a custom `get_field_clean_name` method
+        """
+
+        post_data = {
+            "title": "Form page!",
+            "content": "Some content",
+            "slug": "contact-us",
+            "form_fields-TOTAL_FORMS": "3",
+            "form_fields-INITIAL_FORMS": "3",
+            "form_fields-MIN_NUM_FORMS": "0",
+            "form_fields-MAX_NUM_FORMS": "1000",
+            "form_fields-0-id": "",
+            "form_fields-0-label": "duplicate 1",
+            "form_fields-0-field_type": "singleline",
+            "form_fields-1-id": "",
+            "form_fields-1-label": "duplicate 2",
+            "form_fields-1-field_type": "singleline",
+            "form_fields-2-id": "",
+            "form_fields-2-label": "bar",
+            "form_fields-2-field_type": "singleline",
+        }
+        response = self.client.post(
+            reverse(
+                "wagtailadmin_pages:add",
+                args=("tests", "formpagewithcustomformbuilder", self.root_page.id),
+            ),
+            post_data,
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        self.assertContains(
+            response,
+            text="There is another field with the label duplicate 1, please change one of them.",
+        )

--- a/wagtail/contrib/forms/utils.py
+++ b/wagtail/contrib/forms/utils.py
@@ -9,8 +9,8 @@ _FORM_CONTENT_TYPES = None
 
 def get_field_clean_name(label):
     """
-    Converts a user entered field label to a template and JSON safe ascii value to be used
-    as the internal key (clean name) for the field.
+    Converts a user entered field label to a string that is safe to use for both a
+    HTML attribute (field's name) and a JSON key used internally to store the responses.
     """
     return safe_snake_case(label)
 

--- a/wagtail/test/testapp/models.py
+++ b/wagtail/test/testapp/models.py
@@ -773,7 +773,10 @@ EXTENDED_CHOICES = FORM_FIELD_CHOICES + (("ipaddress", "IP Address"),)
 
 
 class ExtendedFormField(AbstractFormField):
-    """Override the field_type field with extended choices."""
+    """
+    Override the field_type field with extended choices
+    and a custom clean_name override.
+    """
 
     page = ParentalKey(
         "FormPageWithCustomFormBuilder",
@@ -783,6 +786,19 @@ class ExtendedFormField(AbstractFormField):
     field_type = models.CharField(
         verbose_name="field type", max_length=16, choices=EXTENDED_CHOICES
     )
+
+    def get_field_clean_name(self):
+        clean_name = super().get_field_clean_name()
+
+        # scoping to field type to easily test behaviour in isolation
+        if self.field_type == "number":
+            return f"number_field--{clean_name}"
+
+        # scoping to field label to easily test duplicate behaviour in isolation
+        if "duplicate" in self.label:
+            return "test duplicate"
+
+        return clean_name
 
 
 class CustomFormBuilder(FormBuilder):


### PR DESCRIPTION
* **includes two PRs which should be merged first**
  * #8006
  * #8007
* Adds the ability to customise the way the `AbstractFormField` field's clean name is generated.
  * resolves #6903

