### PR TITLE
Fix jinjalint exclusion in 'make lint'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ lint:
 	isort --check-only --diff .
 	# Filter out known false positives, while preserving normal output and error codes.
 	# See https://github.com/motet-a/jinjalint/issues/18.
-	jinjalint --parse-only wagtail | grep -v 'welcome_page.html:6:70' | tee /dev/tty | wc -l | grep -q '0'
+	jinjalint --parse-only wagtail | grep -v 'welcome_page.html:6:76' | tee /dev/tty | wc -l | grep -q '0'
 	git ls-files '*.html' | xargs djhtml --check
 	npm run lint:css --silent
 	npm run lint:js --silent


### PR DESCRIPTION
As of 01986cfa1702929352ac8b6d58ada6070da2c700 the false positive occurs on 6:76 rather than 6:70.
