### PR TITLE
Set the filename in Content-Disposition for inline files

### DIFF
--- a/wagtail/documents/tests/test_views.py
+++ b/wagtail/documents/tests/test_views.py
@@ -51,7 +51,7 @@ class TestServeView(TestCase):
     def test_inline_content_disposition_header(self):
         self.assertEqual(
             self.get(self.pdf_document)['Content-Disposition'],
-            'inline')
+            'inline; filename="{}"'.format(self.pdf_document.filename))
 
     @mock.patch('wagtail.documents.views.serve.hooks')
     @mock.patch('wagtail.documents.views.serve.get_object_or_404')

--- a/wagtail/utils/sendfile.py
+++ b/wagtail/utils/sendfile.py
@@ -70,28 +70,27 @@ def sendfile(request, filename, attachment=False, attachment_filename=None, mime
 
     response = _sendfile(request, filename, mimetype=mimetype)
     if attachment:
-        if attachment_filename is None:
-            attachment_filename = os.path.basename(filename)
         parts = ['attachment']
-        if attachment_filename:
-            from django.utils.encoding import force_str
-
-            from wagtail.core.utils import string_to_ascii
-
-            attachment_filename = force_str(attachment_filename)
-            ascii_filename = string_to_ascii(attachment_filename)
-            parts.append('filename="%s"' % ascii_filename)
-
-            if ascii_filename != attachment_filename:
-                from urllib.parse import quote
-
-                quoted_filename = quote(attachment_filename)
-                parts.append('filename*=UTF-8\'\'%s' % quoted_filename)
-
-        response['Content-Disposition'] = '; '.join(parts)
     else:
-        response['Content-Disposition'] = 'inline'
+        parts = ['inline']
+    if attachment_filename is None:
+        attachment_filename = os.path.basename(filename)
+    if attachment_filename:
+        from django.utils.encoding import force_str
 
+        from wagtail.core.utils import string_to_ascii
+
+        attachment_filename = force_str(attachment_filename)
+        ascii_filename = string_to_ascii(attachment_filename)
+        parts.append('filename="%s"' % ascii_filename)
+
+        if ascii_filename != attachment_filename:
+            from urllib.parse import quote
+
+            quoted_filename = quote(attachment_filename)
+            parts.append('filename*=UTF-8\'\'%s' % quoted_filename)
+
+    response['Content-Disposition'] = '; '.join(parts)
     response['Content-length'] = os.path.getsize(filename)
     response['Content-Type'] = mimetype
     response['Content-Encoding'] = encoding or guessed_encoding


### PR DESCRIPTION
In 2.11, the [sendfile util ](https://github.com/wagtail/wagtail/commit/8edf16e5ff03cb9aec25f15fa201c7345732d120)was changed to serve PDFs inline. In the process, this prevented the filename from being set so when users go to save the PDF, the filename would be blank in the save dialog. This PR always sends the ``filename`` in the "Content-Disposition" header whether the file is served as inline or attachment so the save dialog will have a sensible default value.
