### PR TITLE
Update development instructions to use Node.js 16

### DIFF
--- a/docs/contributing/developing.rst
+++ b/docs/contributing/developing.rst
@@ -15,7 +15,7 @@ If you'd prefer to set up all the components manually, read on. These instructio
 Setting up the Wagtail codebase
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Install `Node.js <https://nodejs.org/>`_, version 14.
+Install `Node.js <https://nodejs.org/>`_, version 16.
 You can also use Node version manager (nvm) since Wagtail supplies a ``.nvmrc`` file in the root of the project with the minimum required Node version - see nvm's `installation instructions <https://github.com/creationix/nvm>`_.
 
 You will also need to install the **libjpeg** and **zlib** libraries, if you haven't done so already - see Pillow's `platform-specific installation instructions <https://pillow.readthedocs.org/en/latest/installation.html#external-libraries>`_.


### PR DESCRIPTION
The Node.js version was updated to 16 as of https://github.com/wagtail/wagtail/pull/7876#issuecomment-1025864756.

---

Thanks for contributing to Wagtail! 🎉

<details>
<summary>
Before submitting, please review the contributor guidelines <https://docs.wagtail.org/en/latest/contributing/index.html> and check the following:

</summary>

* Do the tests still pass? (https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
* Does the code comply with the style guide? (Run `make lint` from the Wagtail root)
* For Python changes: Have you added tests to cover the new/fixed behaviour?
* For front-end changes: Did you test on all of [Wagtail’s supported environments](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)?
    * **Please list the exact browser and operating system versions you tested**.
    * **Please list which assistive technologies you tested**.
* For new features: Has the documentation been updated accordingly?

</details>