### PR TITLE
add `make format` to cover most auto-fixable formatting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,13 @@ lint:
 	npm run lint:format --silent
 	doc8 docs
 
+format:
+	black --target-version py37 .
+	isort .
+	git ls-files '*.html' | xargs djhtml -i
+	npm run format
+	npm run fix:js
+
 test:
 	python runtests.py
 

--- a/docs/contributing/html_guidelines.rst
+++ b/docs/contributing/html_guidelines.rst
@@ -6,7 +6,8 @@ We use `Django templates <https://docs.djangoproject.com/en/stable/ref/templates
 Linting HTML
 ~~~~~~~~~~~~
 
-We use `jinjalint <https://github.com/motet-a/jinjalint>`_ to lint templates and `djhtml <https://github.com/rtts/djhtml>`_ to format them. If you have installed Wagtail's testing dependencies (``pip install -e .[testing]``), you can check your code by running ``make lint``.
+We use `jinjalint <https://github.com/motet-a/jinjalint>`_ to lint templates and `djhtml <https://github.com/rtts/djhtml>`_ to format them.
+If you have installed Wagtail's testing dependencies (``pip install -e .[testing]``), you can check your code by running ``make lint``, and format your code by running ``make format``.
 
 Principles
 ~~~~~~~~~~

--- a/docs/contributing/python_guidelines.rst
+++ b/docs/contributing/python_guidelines.rst
@@ -16,6 +16,8 @@ In addition, import lines should be sorted according to `isort <https://pycqa.gi
 If you have installed Wagtail's testing dependencies (``pip install -e '.[testing]'``), you can check your code by
 running ``make lint``.
 
+You can run all Python formatting with ``make format``.
+
 Django compatibility
 ~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
* Add a new make script `make format` to automatically fix most things that can be fixed, it will intentionally change files
* This avoids needing to remember the way to call each of the things individually for those that cannot use the pre commit hook (e.g. commits are written outside of the virtual environment)