### PR TITLE
Fix test to match new stylesheet tag format in Django 4.1

### DIFF
--- a/wagtail/admin/tests/tests.py
+++ b/wagtail/admin/tests/tests.py
@@ -3,6 +3,7 @@
 import json
 import unittest
 
+from django import VERSION as DJANGO_VERSION
 from django.conf import settings
 from django.contrib.auth.models import Group, Permission
 from django.core import mail
@@ -71,11 +72,18 @@ class TestHome(TestCase, WagtailTestUtils):
         self.assertContains(response, "<p>0 broken links</p>")
 
         # check that media attached to summary items is correctly pulled in
-        self.assertContains(
-            response,
-            '<link href="/static/testapp/css/broken-links.css" type="text/css" media="all" rel="stylesheet">',
-            html=True,
-        )
+        if DJANGO_VERSION >= (4, 1):
+            self.assertContains(
+                response,
+                '<link href="/static/testapp/css/broken-links.css" media="all" rel="stylesheet">',
+                html=True,
+            )
+        else:
+            self.assertContains(
+                response,
+                '<link href="/static/testapp/css/broken-links.css" type="text/css" media="all" rel="stylesheet">',
+                html=True,
+            )
 
     def test_never_cache_header(self):
         # This tests that wagtailadmins global cache settings have been applied correctly


### PR DESCRIPTION
As of https://github.com/django/django/commit/7c4f3965098baad2396e24501e09237425a7bd6f the type="text/css" attribute is omitted.

(One of the very few test failures against the Django main branch that's actually in Wagtail itself rather than a dependency...)