### PR TITLE
Prevent custom MESSAGE_TAGS settings from leaking into admin styles

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/base.html
+++ b/wagtail/admin/templates/wagtailadmin/base.html
@@ -45,8 +45,9 @@
                 {% if messages %}
                     <ul>
                         {% for message in messages %}
+                            {% message_level_tag message as level_tag %}
                             <li class="{% message_tags message %}">
-                                {% if message.level_tag == "error" %}
+                                {% if level_tag == "error" %}
                                     {# There is no error icon, use warning icon instead #}
                                     {% icon name="warning" class_name="messages-icon" %}
                                 {% elif message.extra_tags == "lock" %}
@@ -54,7 +55,7 @@
                                 {% elif message.extra_tags == "unlock" %}
                                     {% icon name="lock-open" class_name="messages-icon" %}
                                 {% else %}
-                                    {% icon name=message.level_tag class_name="messages-icon" %}
+                                    {% icon name=level_tag class_name="messages-icon" %}
                                 {% endif %}
                                 {{ message|safe }}
                             </li>

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -634,8 +634,18 @@ def bulk_action_choices(context, app_label, model_name):
 
 
 @register.simple_tag
+def message_level_tag(message):
+    """
+    Return the tag for this message's level as defined in
+    django.contrib.messages.constants.DEFAULT_TAGS, ignoring the project-level
+    MESSAGE_TAGS setting (which end-users might customise).
+    """
+    return MESSAGE_TAGS.get(message.level)
+
+
+@register.simple_tag
 def message_tags(message):
-    level_tag = MESSAGE_TAGS.get(message.level)
+    level_tag = message_level_tag(message)
     if message.extra_tags and level_tag:
         return message.extra_tags + " " + level_tag
     elif message.extra_tags:

--- a/wagtail/admin/tests/test_messages.py
+++ b/wagtail/admin/tests/test_messages.py
@@ -1,18 +1,8 @@
-from django.contrib import messages
-from django.test import TestCase, override_settings
+from django.test import TestCase
 from django.urls import reverse
 
 
 class TestPageExplorer(TestCase):
-    @override_settings(
-        MESSAGE_TAGS={
-            messages.DEBUG: "my-custom-tag",
-            messages.INFO: "my-custom-tag",
-            messages.SUCCESS: "my-custom-tag",
-            messages.WARNING: "my-custom-tag",
-            messages.ERROR: "my-custom-tag",
-        }
-    )
     def test_message_tag_classes(self):
         url = reverse("testapp_message_test")
 
@@ -23,7 +13,10 @@ class TestPageExplorer(TestCase):
         self.assertContains(response, "A message")
         # Make sure the Wagtail-require CSS tag appears
         self.assertContains(response, "success")
-        # Make sure the classes set in the settings do *not* appear
+
+        # https://github.com/wagtail/wagtail/issues/2551 -
+        # `my-custom-tag` is set in MESSAGE_TAGS in the project settings, which
+        # end-users should be able to do without it leaking into the admin styles.
         self.assertNotContains(response, "my-custom-tag")
 
         response = self.client.post(

--- a/wagtail/locales/tests.py
+++ b/wagtail/locales/tests.py
@@ -1,4 +1,5 @@
 from django.contrib.messages import get_messages
+from django.contrib.messages.constants import ERROR
 from django.test import TestCase, override_settings
 from django.urls import reverse
 
@@ -243,7 +244,7 @@ class TestLocaleDeleteView(TestCase, WagtailTestUtils):
 
         # Check error message
         messages = list(get_messages(response.wsgi_request))
-        self.assertEqual(messages[0].level_tag, "error")
+        self.assertEqual(messages[0].level, ERROR)
         self.assertEqual(
             messages[0].message,
             "This locale cannot be deleted because there are pages and/or other objects using it.\n\n\n\n\n",
@@ -319,7 +320,7 @@ class TestLocaleDeleteView(TestCase, WagtailTestUtils):
 
         # Check error message
         messages = list(get_messages(response.wsgi_request))
-        self.assertEqual(messages[0].level_tag, "error")
+        self.assertEqual(messages[0].level, ERROR)
         self.assertEqual(
             messages[0].message,
             "This locale cannot be deleted because there are no other locales.\n\n\n\n\n",

--- a/wagtail/tests/settings.py
+++ b/wagtail/tests/settings.py
@@ -1,5 +1,6 @@
 import os
 
+from django.contrib.messages import constants as message_constants
 from django.utils.translation import gettext_lazy as _
 
 DEBUG = False
@@ -238,3 +239,15 @@ REST_FRAMEWORK = {
 
 # Disable redirect autocreation for the majority of tests (to improve efficiency)
 WAGTAILREDIRECTS_AUTO_CREATE = False
+
+
+# https://github.com/wagtail/wagtail/issues/2551 - projects should be able to set
+# MESSAGE_TAGS for their own purposes without them leaking into Wagtail admin styles.
+
+MESSAGE_TAGS = {
+    message_constants.DEBUG: "my-custom-tag",
+    message_constants.INFO: "my-custom-tag",
+    message_constants.SUCCESS: "my-custom-tag",
+    message_constants.WARNING: "my-custom-tag",
+    message_constants.ERROR: "my-custom-tag",
+}


### PR DESCRIPTION
Fixes a test failure against Django main.

In #2552, a fix was applied to ensure that the project-level MESSAGE_TAGS setting was ignored, allowing end-users to customise that setting for their own projects without it leaking into Wagtail admin styles.

Unfortunately, the test was flawed (or was broken in a Django regression at some point): in Django <=4.0, MESSAGE_TAGS was not affected by override_settings after the first request, which meant that unless the test was run in isolation, the custom classname that was supposed to flag up the problem never got applied, and the test always succeeded.

The change to SVG icons broke the intent of #2552, since it used message.level_tag for the icon's classname (and this picks up MESSAGE_TAGS customisations), but due to the broken test this went unnoticed.

https://github.com/django/django/commit/24b316536a7ee4c54a54f632de1852aecb4038c0 fixed the override_settings behaviour, making the test fail as it should have done long ago.

Here we adjust the test to not rely on override_settings (so that it does what it's supposed to do on all Django versions), fix a test that gets broken as a side effect (because it's unnecessarily checking message.level_tag), and fixes our SVG-icon-powered message include to bypass the MESSAGE_TAGS setting like the old implementation did.

Confusing? Yes.
