### PR TITLE
Django main (4.1) compatibility

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,6 +78,7 @@ jobs:
           - python: '3.10'
             django: 'git+https://github.com/django/django.git@main#egg=Django'
             experimental: true
+            install_extras: 'pip uninstall -y django-modelcluster ; pip uninstall -y django-taggit ; pip install git+https://github.com/gasman/django-modelcluster.git@fix/unsaved-instance-live-queryset#egg=django-modelcluster git+https://github.com/gasman/django-taggit.git@fix/cached-pathinfo#egg=django-taggit'
 
     services:
       postgres:
@@ -98,6 +99,7 @@ jobs:
           pip install "psycopg2>=2.6"
           pip install -e .[testing]
           pip install "${{ matrix.django }}"
+          ${{ matrix.install_extras }}
       - name: Test
         run: |
           ./runtests.py

--- a/wagtail/admin/templates/wagtailadmin/base.html
+++ b/wagtail/admin/templates/wagtailadmin/base.html
@@ -45,8 +45,9 @@
                 {% if messages %}
                     <ul>
                         {% for message in messages %}
+                            {% message_level_tag message as level_tag %}
                             <li class="{% message_tags message %}">
-                                {% if message.level_tag == "error" %}
+                                {% if level_tag == "error" %}
                                     {# There is no error icon, use warning icon instead #}
                                     {% icon name="warning" class_name="messages-icon" %}
                                 {% elif message.extra_tags == "lock" %}
@@ -54,7 +55,7 @@
                                 {% elif message.extra_tags == "unlock" %}
                                     {% icon name="lock-open" class_name="messages-icon" %}
                                 {% else %}
-                                    {% icon name=message.level_tag class_name="messages-icon" %}
+                                    {% icon name=level_tag class_name="messages-icon" %}
                                 {% endif %}
                                 {{ message|safe }}
                             </li>

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -634,8 +634,18 @@ def bulk_action_choices(context, app_label, model_name):
 
 
 @register.simple_tag
+def message_level_tag(message):
+    """
+    Return the tag for this message's level as defined in
+    django.contrib.messages.constants.DEFAULT_TAGS, ignoring the project-level
+    MESSAGE_TAGS setting (which end-users might customise).
+    """
+    return MESSAGE_TAGS.get(message.level)
+
+
+@register.simple_tag
 def message_tags(message):
-    level_tag = MESSAGE_TAGS.get(message.level)
+    level_tag = message_level_tag(message)
     if message.extra_tags and level_tag:
         return message.extra_tags + " " + level_tag
     elif message.extra_tags:

--- a/wagtail/admin/tests/test_messages.py
+++ b/wagtail/admin/tests/test_messages.py
@@ -1,18 +1,8 @@
-from django.contrib import messages
-from django.test import TestCase, override_settings
+from django.test import TestCase
 from django.urls import reverse
 
 
 class TestPageExplorer(TestCase):
-    @override_settings(
-        MESSAGE_TAGS={
-            messages.DEBUG: "my-custom-tag",
-            messages.INFO: "my-custom-tag",
-            messages.SUCCESS: "my-custom-tag",
-            messages.WARNING: "my-custom-tag",
-            messages.ERROR: "my-custom-tag",
-        }
-    )
     def test_message_tag_classes(self):
         url = reverse("testapp_message_test")
 
@@ -23,7 +13,10 @@ class TestPageExplorer(TestCase):
         self.assertContains(response, "A message")
         # Make sure the Wagtail-require CSS tag appears
         self.assertContains(response, "success")
-        # Make sure the classes set in the settings do *not* appear
+
+        # https://github.com/wagtail/wagtail/issues/2551 -
+        # `my-custom-tag` is set in MESSAGE_TAGS in the project settings, which
+        # end-users should be able to do without it leaking into the admin styles.
         self.assertNotContains(response, "my-custom-tag")
 
         response = self.client.post(

--- a/wagtail/admin/tests/tests.py
+++ b/wagtail/admin/tests/tests.py
@@ -3,6 +3,7 @@
 import json
 import unittest
 
+from django import VERSION as DJANGO_VERSION
 from django.conf import settings
 from django.contrib.auth.models import Group, Permission
 from django.core import mail
@@ -71,11 +72,18 @@ class TestHome(TestCase, WagtailTestUtils):
         self.assertContains(response, "<p>0 broken links</p>")
 
         # check that media attached to summary items is correctly pulled in
-        self.assertContains(
-            response,
-            '<link href="/static/testapp/css/broken-links.css" type="text/css" media="all" rel="stylesheet">',
-            html=True,
-        )
+        if DJANGO_VERSION >= (4, 1):
+            self.assertContains(
+                response,
+                '<link href="/static/testapp/css/broken-links.css" media="all" rel="stylesheet">',
+                html=True,
+            )
+        else:
+            self.assertContains(
+                response,
+                '<link href="/static/testapp/css/broken-links.css" type="text/css" media="all" rel="stylesheet">',
+                html=True,
+            )
 
     def test_never_cache_header(self):
         # This tests that wagtailadmins global cache settings have been applied correctly

--- a/wagtail/locales/tests.py
+++ b/wagtail/locales/tests.py
@@ -1,4 +1,5 @@
 from django.contrib.messages import get_messages
+from django.contrib.messages.constants import ERROR
 from django.test import TestCase, override_settings
 from django.urls import reverse
 
@@ -243,7 +244,7 @@ class TestLocaleDeleteView(TestCase, WagtailTestUtils):
 
         # Check error message
         messages = list(get_messages(response.wsgi_request))
-        self.assertEqual(messages[0].level_tag, "error")
+        self.assertEqual(messages[0].level, ERROR)
         self.assertEqual(
             messages[0].message,
             "This locale cannot be deleted because there are pages and/or other objects using it.\n\n\n\n\n",
@@ -319,7 +320,7 @@ class TestLocaleDeleteView(TestCase, WagtailTestUtils):
 
         # Check error message
         messages = list(get_messages(response.wsgi_request))
-        self.assertEqual(messages[0].level_tag, "error")
+        self.assertEqual(messages[0].level, ERROR)
         self.assertEqual(
             messages[0].message,
             "This locale cannot be deleted because there are no other locales.\n\n\n\n\n",

--- a/wagtail/tests/settings.py
+++ b/wagtail/tests/settings.py
@@ -1,5 +1,6 @@
 import os
 
+from django.contrib.messages import constants as message_constants
 from django.utils.translation import gettext_lazy as _
 
 DEBUG = False
@@ -238,3 +239,15 @@ REST_FRAMEWORK = {
 
 # Disable redirect autocreation for the majority of tests (to improve efficiency)
 WAGTAILREDIRECTS_AUTO_CREATE = False
+
+
+# https://github.com/wagtail/wagtail/issues/2551 - projects should be able to set
+# MESSAGE_TAGS for their own purposes without them leaking into Wagtail admin styles.
+
+MESSAGE_TAGS = {
+    message_constants.DEBUG: "my-custom-tag",
+    message_constants.INFO: "my-custom-tag",
+    message_constants.SUCCESS: "my-custom-tag",
+    message_constants.WARNING: "my-custom-tag",
+    message_constants.ERROR: "my-custom-tag",
+}

--- a/wagtail/users/forms.py
+++ b/wagtail/users/forms.py
@@ -309,12 +309,19 @@ class BaseGroupPagePermissionFormSet(forms.BaseFormSet):
         if instance is None:
             instance = Group()
 
+        if instance.pk is None:
+            full_page_permissions = []
+        else:
+            full_page_permissions = instance.page_permissions.select_related(
+                "page"
+            ).order_by("page")
+
         self.instance = instance
 
         initial_data = []
 
         for page, page_permissions in groupby(
-            instance.page_permissions.select_related("page").order_by("page"),
+            full_page_permissions,
             lambda pp: pp.page,
         ):
             initial_data.append(


### PR DESCRIPTION
Get tests passing against current Django main branch. Incorporates #8026 and #8027, and pulls in fixes from django-taggit and django-modelcluster:

https://github.com/jazzband/django-taggit/pull/791
https://github.com/jazzband/django-taggit/pull/792
https://github.com/wagtail/django-modelcluster/pull/154

along with an additional fix for https://github.com/django/django/pull/15318, which was just merged today and feels like it's going to bite a lot of Django code in the wild (so I may well drop the django-developers mailing list a line tomorrow to ask if it's really a good idea to put that in a minor release with no deprecation path...)