### PR TITLE
update browserslist - not ie 11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "wagtail",
       "version": "1.0.0",
       "dependencies": {
         "draft-js": "^0.10.5",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "last 2 Edge versions",
     "last 1 Firefox version",
     "last 2 iOS versions",
-    "last 3 Safari versions"
+    "last 3 Safari versions",
+    "not ie 11"
   ],
   "jest": {
     "moduleFileExtensions": [


### PR DESCRIPTION
* Update browserslist configuration to explicitly include `not ie 11` to align with our documentation and current development support
* Note that this does not actually get used for the JS bundle generation (that gets declared at tsconfig) so this change should not adjust the existing JS build
* Tested on Firefox 97, Chrome 100, Safari 15 on macOS 
* Also - the wagtail name removal in package lock is just the result of running npm install