### PR TITLE
Fix URLs in latest.txt

### DIFF
--- a/scripts/latest.txt
+++ b/scripts/latest.txt
@@ -1,7 +1,7 @@
 {
     "version": "2.16.1",
-    "url":     "https://docs.wagtail.org/en/stable/releases/2.16.html",
-    "minorUrl": "https://docs.wagtail.org/en/stable/releases/2.16.1.html",
+    "url":     "https://docs.wagtail.org/en/stable/releases/2.16.1.html",
+    "minorUrl": "https://docs.wagtail.org/en/stable/releases/2.16.html",
     "lts": {
         "version": "2.15.4",
         "url": "https://docs.wagtail.org/en/stable/releases/2.15.4.html",


### PR DESCRIPTION
The `url` key is meant for the latest release (2.16.1). The `minorUrl` key is for the latest "minor" release (2.16).

PR #7652 adds the functionality to show the appropriate link in the upgrade notification based on the difference between the currently used and the latest version.