### PR TITLE
Bug: page copy in the Wagtail admin ignores ``exclude_fields_in_copy``

### DIFF
--- a/wagtail/actions/copy_page.py
+++ b/wagtail/actions/copy_page.py
@@ -103,12 +103,12 @@ class CopyPageAction:
     def _copy_page(
         self, page, to=None, update_attrs=None, exclude_fields=None, _mpnode_attrs=None
     ):
+        specific_page = page.specific
         exclude_fields = (
-            page.default_exclude_fields_in_copy
-            + page.exclude_fields_in_copy
+            specific_page.default_exclude_fields_in_copy
+            + specific_page.exclude_fields_in_copy
             + (exclude_fields or [])
         )
-        specific_page = page.specific
         if self.keep_live:
             base_update_attrs = {
                 "alias_of": None,

--- a/wagtail/admin/tests/api/test_pages.py
+++ b/wagtail/admin/tests/api/test_pages.py
@@ -11,8 +11,13 @@ from wagtail import hooks
 from wagtail.api.v2.tests.test_pages import TestPageDetail, TestPageListing
 from wagtail.models import GroupPagePermission, Locale, Page, PageLogEntry
 from wagtail.test.demosite import models
-from wagtail.test.testapp.models import EventIndex, EventPage, SimplePage, StreamPage, \
-    PageWithExcludedCopyField
+from wagtail.test.testapp.models import (
+    EventIndex,
+    EventPage,
+    PageWithExcludedCopyField,
+    SimplePage,
+    StreamPage,
+)
 from wagtail.users.models import UserProfile
 
 from .utils import AdminAPITestCase
@@ -1144,8 +1149,8 @@ class TestCopyPageAction(AdminAPITestCase):
         self.assertEqual(new_page.content, original_page.content)
         self.assertNotEqual(new_page.special_field, original_page.special_field)
         self.assertEqual(
-            new_page.special_field,
-            new_page._meta.get_field('special_field').default)
+            new_page.special_field, new_page._meta.get_field("special_field").default
+        )
 
     def test_copy_page_destination(self):
         response = self.get_response(3, {"destination_page_id": 3})

--- a/wagtail/admin/tests/api/test_pages.py
+++ b/wagtail/admin/tests/api/test_pages.py
@@ -11,7 +11,8 @@ from wagtail import hooks
 from wagtail.api.v2.tests.test_pages import TestPageDetail, TestPageListing
 from wagtail.models import GroupPagePermission, Locale, Page, PageLogEntry
 from wagtail.test.demosite import models
-from wagtail.test.testapp.models import EventIndex, EventPage, SimplePage, StreamPage
+from wagtail.test.testapp.models import EventIndex, EventPage, SimplePage, StreamPage, \
+    PageWithExcludedCopyField
 from wagtail.users.models import UserProfile
 
 from .utils import AdminAPITestCase
@@ -1131,6 +1132,20 @@ class TestCopyPageAction(AdminAPITestCase):
 
         new_page = Page.objects.get(id=content["id"])
         self.assertEqual(new_page.slug, "new-slug")
+
+    def test_copy_page_with_exclude_fields_in_copy(self):
+        response = self.get_response(21, {})
+
+        self.assertEqual(response.status_code, 201)
+        content = json.loads(response.content.decode("utf-8"))
+
+        original_page = PageWithExcludedCopyField.objects.get(pk=21)
+        new_page = PageWithExcludedCopyField.objects.get(id=content["id"])
+        self.assertEqual(new_page.content, original_page.content)
+        self.assertNotEqual(new_page.special_field, original_page.special_field)
+        self.assertEqual(
+            new_page.special_field,
+            new_page._meta.get_field('special_field').default)
 
     def test_copy_page_destination(self):
         response = self.get_response(3, {"destination_page_id": 3})

--- a/wagtail/admin/tests/pages/test_copy_page.py
+++ b/wagtail/admin/tests/pages/test_copy_page.py
@@ -45,17 +45,6 @@ class TestPageCopy(TestCase, WagtailTestUtils):
             )
         )
 
-        self.test_exclude_fields_in_copy_page = self.test_page.add_child(
-            instance=PageWithExcludedCopyField(
-                title="Page with exclude_fields_in_copy",
-                slug="page-with-exclude-fields-in-copy",
-                content="Copy me",
-                special_field="Don't copy me",
-                live=True,
-                has_unpublished_changes=False,
-            )
-        )
-
         # Login
         self.user = self.login()
 
@@ -165,7 +154,16 @@ class TestPageCopy(TestCase, WagtailTestUtils):
         )
 
     def test_page_with_exclude_fields_in_copy(self):
-        original_page = self.test_exclude_fields_in_copy_page
+        original_page = self.test_page.add_child(
+            instance=PageWithExcludedCopyField(
+                title="Page with exclude_fields_in_copy",
+                slug="page-with-exclude-fields-in-copy",
+                content="Copy me",
+                special_field="Don't copy me",
+                live=True,
+                has_unpublished_changes=False,
+            )
+        )
         post_data = {
             "new_title": f"{original_page.title} 2",
             "new_slug": f"{original_page.slug}-2",

--- a/wagtail/admin/tests/pages/test_copy_page.py
+++ b/wagtail/admin/tests/pages/test_copy_page.py
@@ -180,8 +180,8 @@ class TestPageCopy(TestCase, WagtailTestUtils):
         self.assertEqual(page_copy.content, original_page.content)
         self.assertNotEqual(page_copy.special_field, original_page.special_field)
         self.assertEqual(
-            page_copy.special_field,
-            page_copy._meta.get_field('special_field').default)
+            page_copy.special_field, page_copy._meta.get_field("special_field").default
+        )
 
     def test_page_copy_post_copy_subpages(self):
         post_data = {

--- a/wagtail/admin/tests/pages/test_copy_page.py
+++ b/wagtail/admin/tests/pages/test_copy_page.py
@@ -4,7 +4,7 @@ from django.test import TestCase
 from django.urls import reverse
 
 from wagtail.models import GroupPagePermission, Page
-from wagtail.test.testapp.models import SimplePage
+from wagtail.test.testapp.models import PageWithExcludedCopyField, SimplePage
 from wagtail.test.utils import WagtailTestUtils
 
 
@@ -42,6 +42,17 @@ class TestPageCopy(TestCase, WagtailTestUtils):
                 content="hello",
                 live=False,
                 has_unpublished_changes=True,
+            )
+        )
+
+        self.test_exclude_fields_in_copy_page = self.test_page.add_child(
+            instance=PageWithExcludedCopyField(
+                title="Page with exclude_fields_in_copy",
+                slug="page-with-exclude-fields-in-copy",
+                content="Copy me",
+                special_field="Don't copy me",
+                live=True,
+                has_unpublished_changes=False,
             )
         )
 
@@ -152,6 +163,27 @@ class TestPageCopy(TestCase, WagtailTestUtils):
         self.assertFalse(
             any(Page.find_problems()), "treebeard found consistency problems"
         )
+
+    def test_page_with_exclude_fields_in_copy(self):
+        original_page = self.test_exclude_fields_in_copy_page
+        post_data = {
+            "new_title": f"{original_page.title} 2",
+            "new_slug": f"{original_page.slug}-2",
+            "new_parent_page": str(self.root_page.id),
+            "copy_subpages": False,
+            "publish_copies": False,
+            "alias": False,
+        }
+        self.client.post(
+            reverse("wagtailadmin_pages:copy", args=(original_page.id,)), post_data
+        )
+        # Get copy
+        page_copy = PageWithExcludedCopyField.objects.get(slug=post_data["new_slug"])
+        self.assertEqual(page_copy.content, original_page.content)
+        self.assertNotEqual(page_copy.special_field, original_page.special_field)
+        self.assertEqual(
+            page_copy.special_field,
+            page_copy._meta.get_field('special_field').default)
 
     def test_page_copy_post_copy_subpages(self):
         post_data = {

--- a/wagtail/test/testapp/fixtures/test.json
+++ b/wagtail/test/testapp/fixtures/test.json
@@ -22,7 +22,7 @@
     "fields": {
       "title": "Welcome to the Wagtail test site!",
       "draft_title": "Welcome to the Wagtail test site!",
-      "numchild": 9,
+      "numchild": 10,
       "show_in_menus": false,
       "live": true,
       "depth": 2,
@@ -594,7 +594,6 @@
       "content": "<p>collect logs</p>"
     }
   },
-
   {
     "pk": 20,
     "model": "wagtailcore.page",
@@ -611,7 +610,30 @@
       "slug": "does-not-exist"
     }
   },
-
+  {
+    "pk": 21,
+    "model": "wagtailcore.page",
+    "fields": {
+      "title": "This page has a field that shouldn't be copied",
+      "draft_title": "This page has a field that shouldn't be copied",
+      "numchild": 0,
+      "show_in_menus": true,
+      "live": true,
+      "depth": 3,
+      "content_type": ["tests", "pagewithexcludedcopyfield"],
+      "path": "000100010010",
+      "url_path": "/home/page-with-exclude-fields-in-copy/",
+      "slug": "page-with-exclude-fields-in-copy"
+    }
+  },
+  {
+    "pk": 21,
+    "model": "tests.pagewithexcludedcopyfield",
+    "fields": {
+      "content": "Copy me.",
+      "special_field": "Don't copy me."
+    }
+  },
   {
     "pk": 1,
     "model": "wagtailcore.site",


### PR DESCRIPTION
When copying a page in the Wagtail admin, it only passes through a plain Page instance so if a subclass defines ``exclude_fields_in_copy``, this is ignored.

The bug appears to be here:

https://github.com/wagtail/wagtail/blob/3bf9b65c06671b9a2c9a6715a18b2fced6a992e1/wagtail/core/actions/copy_page.py#L103-L111

From my limited perspective, this should always ensure it's dealing with a specific instance before collecting excluded fields. The first commit in this PR is a test to demonstrate the issue. Will push additional commits to address.

The existing tests only tested the ``page.copy()`` method called on a specific instance so it was not affected by this bug:

https://github.com/wagtail/wagtail/blob/3bf9b65c06671b9a2c9a6715a18b2fced6a992e1/wagtail/core/tests/test_page_model.py#L1954-L1964

Their currently aren't any tests for copying with excluded fields through the API but it also was not affected by this bug because the API view always ensures the object acted upon is a specific instance:

https://github.com/wagtail/wagtail/blob/3bf9b65c06671b9a2c9a6715a18b2fced6a992e1/wagtail/admin/api/views.py#L100-L105

Refs #5172 and perhaps others