### PR TITLE
Fix scrolling to the top of editor in Chrome

### DIFF
--- a/client/src/entrypoints/admin/modal-workflow.js
+++ b/client/src/entrypoints/admin/modal-workflow.js
@@ -50,7 +50,7 @@ function ModalWorkflow(opts) {
 
   // add listener - once modal is fully hidden (closed & css transitions end) - re-focus on trigger and remove from DOM
   container.on('hidden.bs.modal', function () {
-    self.triggerElement.focus();
+    self.triggerElement.focus({preventScroll:true});
     container.remove();
   });
 


### PR DESCRIPTION
In Chrome, when you have Hallo editor with a long text, and you insert a link at the end, you are scrolled to the top of the element with halloeditor. This fixes it.

I'm sorry but I didn't test this besides FF and Chrome. Also, this happens only with Hallo editor. 

I didn't want to go through the whole procedure described in contributing guidelines but I still want to help Wagtail. So at least I created this PR. `¯\_(ツ)_/¯` If you would like me to do something more, please write.

Also, thanks for Wagtail, it's great. :heart: 