### PR TITLE
More actions dropdown button toggling on bulk actions

### DIFF
--- a/client/scss/components/_dropdown.scss
+++ b/client/scss/components/_dropdown.scss
@@ -1,9 +1,10 @@
 // =============================================================================
 // Listing view smaller dropdowns
 // =============================================================================
+.c-dropdown.hidden {
+  display: none;
+}
 
-// .c-dropdown {
-// }
 .c-dropdown__button {
   display: inline-block;
   box-sizing: border-box;

--- a/client/src/entrypoints/admin/bulk-actions.js
+++ b/client/src/entrypoints/admin/bulk-actions.js
@@ -8,6 +8,7 @@ const BULK_ACTION_FOOTER = '[data-bulk-action-footer]';
 const BULK_ACTION_NUM_OBJECTS = '[data-bulk-action-num-objects]';
 const BULK_ACTION_NUM_OBJECTS_IN_LISTING =
   '[data-bulk-action-num-objects-in-listing]';
+const MORE_ACTIONS_DROPDOWN_BUTTON_SELECTOR = '.actions [data-dropdown]';
 
 const checkedState = {
   checkedObjects: new Set(),
@@ -15,6 +16,30 @@ const checkedState = {
   selectAllInListing: false,
   shouldShowAllInListingText: true,
 };
+
+/**
+ * Hides the 'more' dropdown button in listing pages.
+ */
+function hideMoreActionsDropdownBtn() {
+  const MoreActionsDropdown = document.querySelector(
+    MORE_ACTIONS_DROPDOWN_BUTTON_SELECTOR,
+  );
+  if (MoreActionsDropdown !== null) {
+    MoreActionsDropdown.classList.add('hidden');
+  }
+}
+
+/**
+ * Shows the 'more' dropdown button in listing pages.
+ */
+function showMoreActionsDropdownBtn() {
+  const MoreActionsDropdown = document.querySelector(
+    MORE_ACTIONS_DROPDOWN_BUTTON_SELECTOR,
+  );
+  if (MoreActionsDropdown !== null) {
+    MoreActionsDropdown.classList.remove('hidden');
+  }
+}
 
 /**
  * Utility function to get the appropriate string for display in action bar
@@ -48,9 +73,12 @@ function onSelectAllChange(e) {
     }
   });
   if (!e.target.checked) {
+    showMoreActionsDropdownBtn();
     // when deselecting all checkbox, simply hide the footer for smooth transition
     checkedState.checkedObjects.clear();
     document.querySelector(BULK_ACTION_FOOTER).classList.add('hidden');
+  } else {
+    hideMoreActionsDropdownBtn();
   }
 }
 
@@ -74,12 +102,14 @@ function onSelectIndividualCheckbox(e) {
 
   if (numCheckedObjects === 0) {
     /* when all checkboxes are unchecked */
+    showMoreActionsDropdownBtn();
     document.querySelector(BULK_ACTION_FOOTER).classList.add('hidden');
     document
       .querySelectorAll(BULK_ACTION_PAGE_CHECKBOX_INPUT)
       .forEach((el) => el.classList.remove('show'));
   } else if (numCheckedObjects === 1 && prevLength === 0) {
     /* when 1 checkbox is checked for the first time */
+    hideMoreActionsDropdownBtn();
     document.querySelectorAll(BULK_ACTION_PAGE_CHECKBOX_INPUT).forEach((el) => {
       el.classList.add('show');
     });

--- a/client/src/entrypoints/admin/bulk-actions.js
+++ b/client/src/entrypoints/admin/bulk-actions.js
@@ -26,9 +26,11 @@ function toggleMoreActionsDropdownBtn(show) {
     MORE_ACTIONS_DROPDOWN_BUTTON_SELECTOR,
   );
   if (moreActionsDropdown !== null) {
-    show === true
-      ? moreActionsDropdown.classList.remove('hidden')
-      : moreActionsDropdown.classList.add('hidden');
+    if (show === true) {
+      moreActionsDropdown.classList.remove('hidden');
+    } else {
+      moreActionsDropdown.classList.add('hidden');
+    }
   }
 }
 

--- a/client/src/entrypoints/admin/bulk-actions.js
+++ b/client/src/entrypoints/admin/bulk-actions.js
@@ -18,26 +18,17 @@ const checkedState = {
 };
 
 /**
- * Hides the 'more' dropdown button in listing pages.
+ * Toggles the 'more' dropdown button in listing pages.
+ * @param {boolean} show - Determines if the button should be shown or not.
  */
-function hideMoreActionsDropdownBtn() {
-  const MoreActionsDropdown = document.querySelector(
+function toggleMoreActionsDropdownBtn(show) {
+  const moreActionsDropdown = document.querySelector(
     MORE_ACTIONS_DROPDOWN_BUTTON_SELECTOR,
   );
-  if (MoreActionsDropdown !== null) {
-    MoreActionsDropdown.classList.add('hidden');
-  }
-}
-
-/**
- * Shows the 'more' dropdown button in listing pages.
- */
-function showMoreActionsDropdownBtn() {
-  const MoreActionsDropdown = document.querySelector(
-    MORE_ACTIONS_DROPDOWN_BUTTON_SELECTOR,
-  );
-  if (MoreActionsDropdown !== null) {
-    MoreActionsDropdown.classList.remove('hidden');
+  if (moreActionsDropdown !== null) {
+    show === true
+      ? moreActionsDropdown.classList.remove('hidden')
+      : moreActionsDropdown.classList.add('hidden');
   }
 }
 
@@ -73,12 +64,12 @@ function onSelectAllChange(e) {
     }
   });
   if (!e.target.checked) {
-    showMoreActionsDropdownBtn();
+    toggleMoreActionsDropdownBtn((show = true));
     // when deselecting all checkbox, simply hide the footer for smooth transition
     checkedState.checkedObjects.clear();
     document.querySelector(BULK_ACTION_FOOTER).classList.add('hidden');
   } else {
-    hideMoreActionsDropdownBtn();
+    toggleMoreActionsDropdownBtn((show = false));
   }
 }
 
@@ -102,14 +93,14 @@ function onSelectIndividualCheckbox(e) {
 
   if (numCheckedObjects === 0) {
     /* when all checkboxes are unchecked */
-    showMoreActionsDropdownBtn();
+    toggleMoreActionsDropdownBtn((show = true));
     document.querySelector(BULK_ACTION_FOOTER).classList.add('hidden');
     document
       .querySelectorAll(BULK_ACTION_PAGE_CHECKBOX_INPUT)
       .forEach((el) => el.classList.remove('show'));
   } else if (numCheckedObjects === 1 && prevLength === 0) {
     /* when 1 checkbox is checked for the first time */
-    hideMoreActionsDropdownBtn();
+    toggleMoreActionsDropdownBtn((show = false));
     document.querySelectorAll(BULK_ACTION_PAGE_CHECKBOX_INPUT).forEach((el) => {
       el.classList.add('show');
     });

--- a/client/src/entrypoints/admin/bulk-actions.js
+++ b/client/src/entrypoints/admin/bulk-actions.js
@@ -64,12 +64,12 @@ function onSelectAllChange(e) {
     }
   });
   if (!e.target.checked) {
-    toggleMoreActionsDropdownBtn((show = true));
+    toggleMoreActionsDropdownBtn(true);
     // when deselecting all checkbox, simply hide the footer for smooth transition
     checkedState.checkedObjects.clear();
     document.querySelector(BULK_ACTION_FOOTER).classList.add('hidden');
   } else {
-    toggleMoreActionsDropdownBtn((show = false));
+    toggleMoreActionsDropdownBtn(false);
   }
 }
 
@@ -93,14 +93,14 @@ function onSelectIndividualCheckbox(e) {
 
   if (numCheckedObjects === 0) {
     /* when all checkboxes are unchecked */
-    toggleMoreActionsDropdownBtn((show = true));
+    toggleMoreActionsDropdownBtn(true);
     document.querySelector(BULK_ACTION_FOOTER).classList.add('hidden');
     document
       .querySelectorAll(BULK_ACTION_PAGE_CHECKBOX_INPUT)
       .forEach((el) => el.classList.remove('show'));
   } else if (numCheckedObjects === 1 && prevLength === 0) {
     /* when 1 checkbox is checked for the first time */
-    toggleMoreActionsDropdownBtn((show = false));
+    toggleMoreActionsDropdownBtn(false);
     document.querySelectorAll(BULK_ACTION_PAGE_CHECKBOX_INPUT).forEach((el) => {
       el.classList.add('show');
     });


### PR DESCRIPTION
Targets #8045.

The goal of this PR is to hide the 'more' dropdown button in listing pages when a child page is selected to perform bulk actions.

* Do the tests still pass? Yes
* Does the code comply with the style guide? 
* For front-end changes: Did you test on all of Wagtail’s supported environments? No
    * **Please list the exact browser and operating system versions you tested**. Firefox, Chrome
    * **Please list which assistive technologies you tested**. None
