### PR TITLE
Support showing / hiding FieldPanels based on user permissions

### DIFF
--- a/docs/reference/pages/panels.rst
+++ b/docs/reference/pages/panels.rst
@@ -15,7 +15,7 @@ Here are some Wagtail-specific types that you might include as fields in your mo
 FieldPanel
 ~~~~~~~~~~
 
-.. class:: FieldPanel(field_name, classname=None, widget=None, heading='', disable_comments=False)
+.. class:: FieldPanel(field_name, classname=None, widget=None, heading='', disable_comments=False, permission=None)
 
     This is the panel used for basic Django field types.
 
@@ -42,6 +42,11 @@ FieldPanel
     .. attribute:: FieldPanel.disable_comments (optional)
 
         This allows you to prevent a field level comment button showing for this panel if set to ``True`` (see :ref:`commenting`).
+
+    .. attribute:: FieldPanel.permission (optional)
+
+        Allows a field to be selectively shown to users with sufficient permission. Accepts a permission codename such as ``'myapp.change_blog_category'`` - if the logged-in user does not have that permission, the field will be omitted from the form. See Django's documentation on :ref:`custom permissions <django:custom-permissions>` for details on how to set permissions up; alternatively, if you want to set a field as only available to superusers, you can use any arbitrary string (such as ``'superuser'``) as the codename, since superusers automatically pass all permission tests.
+
 
 StreamFieldPanel
 ~~~~~~~~~~~~~~~~

--- a/docs/releases/2.17.md
+++ b/docs/releases/2.17.md
@@ -81,3 +81,7 @@ As of this release, the use of special-purpose field panel types such as `Stream
  * If the panel provides a `get_comparison_class` method, your code should instead call `wagtail.admin.compare.register_comparison_class` to register the comparison class against the relevant model field type.
 
 If you do continue to use a custom panel class, note that the template context for panels derived from `BaseChooserPanel` has changed - the context variable `is_chosen`, and the variable name given by the panel's `object_type_name` property, are no longer available on the template. The only available variables are now `field` and `show_add_comment_button`. If your template depends on these additional variables, you will need to pass them explicitly by overriding the `render_as_field` method.
+
+### ModelAdmin forms must subclass `WagtailAdminModelForm`
+
+When overriding the `get_form_class` method of a ModelAdmin `CreateView` or `EditView` to pass a custom form class, that form class must now inherit from `wagtail.admin.forms.models.WagtailAdminModelForm`. Passing a plain Django ModelForm subclass is no longer valid.

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ except ImportError:
 install_requires = [
     "Django>=3.2,<4.1",
     "django-modelcluster>=5.2,<6.0",
+    "django-permissionedforms>=0.1,<1.0",
     "django-taggit>=2.0,<3.0",
     "django-treebeard>=4.5.1,<5.0",
     "djangorestframework>=3.11.1,<4.0",

--- a/wagtail/admin/edit_handlers.py
+++ b/wagtail/admin/edit_handlers.py
@@ -514,7 +514,11 @@ class FieldPanel(EditHandler):
             return {}
 
     def is_shown(self):
-        if self.permission and not self.request.user.has_perm(self.permission):
+        if (
+            self.permission
+            and self.request
+            and not self.request.user.has_perm(self.permission)
+        ):
             return False
 
         return True

--- a/wagtail/admin/forms/models.py
+++ b/wagtail/admin/forms/models.py
@@ -2,7 +2,12 @@ import copy
 
 from django.core.exceptions import ImproperlyConfigured
 from django.db import models
-from modelcluster.forms import ClusterForm, ClusterFormMetaclass
+from modelcluster.forms import ClusterForm, ClusterFormMetaclass, ClusterFormOptions
+from permissionedforms import (
+    PermissionedForm,
+    PermissionedFormMetaclass,
+    PermissionedFormOptionsMixin,
+)
 from taggit.managers import TaggableManager
 
 from wagtail.admin import widgets
@@ -86,7 +91,15 @@ def formfield_for_dbfield(db_field, **kwargs):
     return db_field.formfield(**kwargs)
 
 
-class WagtailAdminModelFormMetaclass(ClusterFormMetaclass):
+class WagtailAdminModelFormOptions(PermissionedFormOptionsMixin, ClusterFormOptions):
+    # Container for the options set in the inner 'class Meta' of a model form, supporting
+    # extensions for both ClusterForm ('formsets') and PermissionedForm ('field_permissions').
+    pass
+
+
+class WagtailAdminModelFormMetaclass(PermissionedFormMetaclass, ClusterFormMetaclass):
+    options_class = WagtailAdminModelFormOptions
+
     # Override the behaviour of the regular ModelForm metaclass -
     # which handles the translation of model fields to form fields -
     # to use our own formfield_for_dbfield function to do that translation.
@@ -112,7 +125,9 @@ class WagtailAdminModelFormMetaclass(ClusterFormMetaclass):
         return WagtailAdminModelForm
 
 
-class WagtailAdminModelForm(ClusterForm, metaclass=WagtailAdminModelFormMetaclass):
+class WagtailAdminModelForm(
+    PermissionedForm, ClusterForm, metaclass=WagtailAdminModelFormMetaclass
+):
     pass
 
 

--- a/wagtail/admin/templates/wagtailadmin/edit_handlers/field_row_panel.html
+++ b/wagtail/admin/templates/wagtailadmin/edit_handlers/field_row_panel.html
@@ -1,5 +1,5 @@
 <ul class="field-row {{ self.classes|join:" " }}">
-    {% for child in self.children %}
+    {% for child in self.visible_children %}
         <li class="field-col {{ child.classes|join:" " }}">
             {{ child.render_as_field }}
         </li>

--- a/wagtail/admin/templates/wagtailadmin/edit_handlers/multi_field_panel.html
+++ b/wagtail/admin/templates/wagtailadmin/edit_handlers/multi_field_panel.html
@@ -1,7 +1,7 @@
 <fieldset>
     <legend>{{ self.heading }}</legend>
     <ul class="fields">
-        {% for child in self.children %}
+        {% for child in self.visible_children %}
             <li class="{{ child.classes|join:" " }}">{{ child.render_as_field }}</li>
         {% endfor %}
     </ul>

--- a/wagtail/admin/templates/wagtailadmin/edit_handlers/object_list.html
+++ b/wagtail/admin/templates/wagtailadmin/edit_handlers/object_list.html
@@ -1,7 +1,7 @@
 {% load wagtailadmin_tags  %}
 
 <ul class="objects">
-    {% for child in self.children %}
+    {% for child in self.visible_children %}
         <li class="object {{ child.classes|join:" " }}">
             {% if child.heading %}
                 <div class="title-wrapper">

--- a/wagtail/admin/tests/pages/test_create_page.py
+++ b/wagtail/admin/tests/pages/test_create_page.py
@@ -1069,7 +1069,7 @@ class TestPageCreation(TestCase, WagtailTestUtils):
         self.assertEqual(response.context["page"].locale, fr_locale)
 
 
-class TestPerRequestEditHandler(TestCase, WagtailTestUtils):
+class TestPermissionedFieldPanels(TestCase, WagtailTestUtils):
     fixtures = ["test.json"]
 
     def setUp(self):
@@ -1081,9 +1081,9 @@ class TestPerRequestEditHandler(TestCase, WagtailTestUtils):
             permission_type="add",
         )
 
-    def test_create_page_with_per_request_custom_edit_handlers(self):
+    def test_create_page_with_permissioned_field_panel(self):
         """
-        Test that per-request custom behaviour in edit handlers is honoured
+        Test that permission rules on field panels are honoured
         """
         # non-superusers should not see secret_data
         self.login(username="siteeditor", password="password")

--- a/wagtail/admin/views/pages/create.py
+++ b/wagtail/admin/views/pages/create.py
@@ -122,6 +122,7 @@ class CreateView(TemplateResponseMixin, ContextMixin, HookResponseMixin, View):
             instance=self.page,
             subscription=self.subscription,
             parent_page=self.parent_page,
+            for_user=self.request.user,
         )
 
         if self.form.is_valid():
@@ -313,6 +314,7 @@ class CreateView(TemplateResponseMixin, ContextMixin, HookResponseMixin, View):
             instance=self.page,
             subscription=self.subscription,
             parent_page=self.parent_page,
+            for_user=self.request.user,
         )
         self.has_unsaved_changes = False
         self.edit_handler = self.edit_handler.bind_to(form=self.form)

--- a/wagtail/admin/views/pages/edit.py
+++ b/wagtail/admin/views/pages/edit.py
@@ -450,7 +450,10 @@ class EditView(TemplateResponseMixin, ContextMixin, HookResponseMixin, View):
                 )
 
         self.form = self.form_class(
-            instance=self.page, subscription=self.subscription, parent_page=self.parent
+            instance=self.page,
+            subscription=self.subscription,
+            parent_page=self.parent,
+            for_user=self.request.user,
         )
         self.has_unsaved_changes = False
         self.edit_handler = self.edit_handler.bind_to(form=self.form)
@@ -485,6 +488,7 @@ class EditView(TemplateResponseMixin, ContextMixin, HookResponseMixin, View):
             instance=self.page,
             subscription=self.subscription,
             parent_page=self.parent,
+            for_user=self.request.user,
         )
 
         self.is_cancelling_workflow = (

--- a/wagtail/contrib/modeladmin/views.py
+++ b/wagtail/contrib/modeladmin/views.py
@@ -182,7 +182,7 @@ class ModelFormView(WMABaseView, FormView):
 
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
-        kwargs.update({"instance": self.get_instance()})
+        kwargs.update({"instance": self.get_instance(), "for_user": self.request.user})
         return kwargs
 
     @property

--- a/wagtail/contrib/settings/views.py
+++ b/wagtail/contrib/settings/views.py
@@ -71,7 +71,9 @@ def edit(request, app_name, model_name, site_pk):
     form_class = edit_handler.get_form_class()
 
     if request.method == "POST":
-        form = form_class(request.POST, request.FILES, instance=instance)
+        form = form_class(
+            request.POST, request.FILES, instance=instance, for_user=request.user
+        )
 
         if form.is_valid():
             with transaction.atomic():
@@ -89,7 +91,7 @@ def edit(request, app_name, model_name, site_pk):
                 request, _("The setting could not be saved due to errors."), form
             )
     else:
-        form = form_class(instance=instance)
+        form = form_class(instance=instance, for_user=request.user)
 
     edit_handler = edit_handler.bind_to(form=form)
 

--- a/wagtail/snippets/views/snippets.py
+++ b/wagtail/snippets/views/snippets.py
@@ -245,7 +245,9 @@ def create(request, app_label, model_name):
     form_class = edit_handler.get_form_class()
 
     if request.method == "POST":
-        form = form_class(request.POST, request.FILES, instance=instance)
+        form = form_class(
+            request.POST, request.FILES, instance=instance, for_user=request.user
+        )
 
         if form.is_valid():
             with transaction.atomic():
@@ -290,7 +292,7 @@ def create(request, app_label, model_name):
                 request, _("The snippet could not be created due to errors."), form
             )
     else:
-        form = form_class(instance=instance)
+        form = form_class(instance=instance, for_user=request.user)
 
     edit_handler = edit_handler.bind_to(instance=instance, form=form)
 
@@ -345,7 +347,9 @@ def edit(request, app_label, model_name, pk):
     form_class = edit_handler.get_form_class()
 
     if request.method == "POST":
-        form = form_class(request.POST, request.FILES, instance=instance)
+        form = form_class(
+            request.POST, request.FILES, instance=instance, for_user=request.user
+        )
 
         if form.is_valid():
             with transaction.atomic():
@@ -381,7 +385,7 @@ def edit(request, app_label, model_name, pk):
                 request, _("The snippet could not be saved due to errors."), form
             )
     else:
-        form = form_class(instance=instance)
+        form = form_class(instance=instance, for_user=request.user)
 
     edit_handler = edit_handler.bind_to(form=form)
     latest_log_entry = log_registry.get_logs_for_instance(instance).first()

--- a/wagtail/tests/modeladmintest/forms.py
+++ b/wagtail/tests/modeladmintest/forms.py
@@ -1,9 +1,9 @@
-from django import forms
+from wagtail.admin.forms.models import WagtailAdminModelForm
 
 from .models import Publisher
 
 
-class PublisherModelAdminForm(forms.ModelForm):
+class PublisherModelAdminForm(WagtailAdminModelForm):
     class Meta:
         model = Publisher
         fields = ["name"]

--- a/wagtail/tests/testapp/migrations/0041_secretpage.py
+++ b/wagtail/tests/testapp/migrations/0041_secretpage.py
@@ -2,7 +2,6 @@
 
 from django.db import migrations, models
 import django.db.models.deletion
-import wagtail.tests.testapp.models
 
 
 class Migration(migrations.Migration):
@@ -33,6 +32,6 @@ class Migration(migrations.Migration):
             options={
                 "abstract": False,
             },
-            bases=(wagtail.tests.testapp.models.PerUserPageMixin, "wagtailcore.page"),
+            bases=("wagtailcore.page",),
         ),
     ]


### PR DESCRIPTION
Integrate [django-permissionedforms](https://github.com/wagtail/django-permissionedforms) into EditHandler-based forms (pages, snippets, ModelAdmin and settings) so that fields can be made only available to users with specified permissions via the FieldPanel definition, e.g.

    FieldPanel('subtitle', permission='blog.can_change_subtitle')

This is intended as an upgrade path from the semi-official PerUserContentPanels recipe introduced in #4749, which is a blocker to refactoring edit handlers to work in a more idiomatic Django way, as it relies on the EditHandler having access to the request object before returning a form class (when it would be far more reasonable to have one persistent form class per page model, and introduce any ad-hoc per-request differences when instantiating the form).