### PR TITLE
Page Editor Improvements: TypeScale configuration

### DIFF
--- a/client/src/tokens/typeScale.js
+++ b/client/src/tokens/typeScale.js
@@ -1,0 +1,80 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const plugin = require('tailwindcss/plugin');
+
+// TypeScale plugin:
+// This plugin generates component classes using tailwind's configuration for each object inside of the typeScale const.
+// If the tailwind config is using a prefix such as 'w-' this will be included in the compiled css class eg. .w-h1
+module.exports = plugin(({ addComponents, theme }) => {
+  const headingBaseStyles = {
+    fontWeight: theme('fontWeight.bold'),
+    color: theme('colors.primary.DEFAULT'),
+    lineHeight: theme('lineHeight.tight'),
+  };
+
+  const typeScale = {
+    '.h1': {
+      fontSize: theme('fontSize.30'),
+      fontWeight: theme('fontWeight.extrabold'),
+      color: theme('colors.primary.DEFAULT'),
+      lineHeight: theme('lineHeight.tight'),
+    },
+    '.h2': {
+      fontSize: theme('fontSize.24'),
+      ...headingBaseStyles,
+    },
+    '.h3': {
+      fontSize: theme('fontSize.22'),
+      ...headingBaseStyles,
+    },
+    '.h4': {
+      fontSize: theme('fontSize.18'),
+      ...headingBaseStyles,
+    },
+    '.h5': {
+      fontSize: theme('fontSize.16'),
+      ...headingBaseStyles,
+    },
+    '.h6': {
+      fontSize: theme('fontSize.15'),
+      ...headingBaseStyles,
+    },
+    '.label-1': {
+      fontSize: theme('fontSize.16'),
+      fontWeight: theme('fontWeight.bold'),
+      color: theme('colors.primary.DEFAULT'),
+      lineHeight: theme('lineHeight.tight'),
+    },
+    '.label-2': {
+      fontSize: theme('fontSize.15'),
+      fontWeight: theme('fontWeight.semibold'),
+      color: theme('colors.primary.DEFAULT'),
+      lineHeight: theme('lineHeight.tight'),
+    },
+    '.label-3': {
+      fontSize: theme('fontSize.15'),
+      fontWeight: theme('fontWeight.medium'),
+      color: theme('colors.primary.DEFAULT'),
+      lineHeight: theme('lineHeight.tight'),
+    },
+    '.body-text': {
+      fontSize: theme('fontSize.16'),
+      fontWeight: theme('fontWeight.normal'),
+      color: theme('colors.grey.600'),
+      lineHeight: theme('lineHeight.normal'),
+    },
+    '.body-text-large': {
+      fontSize: theme('fontSize.18'),
+      fontWeight: theme('fontWeight.normal'),
+      color: theme('colors.grey.600'),
+      lineHeight: theme('lineHeight.normal'),
+    },
+    '.help-text': {
+      fontSize: theme('fontSize.16'),
+      fontWeight: theme('fontWeight.normal'),
+      color: theme('colors.grey.400'),
+      lineHeight: theme('lineHeight.tight'),
+    },
+  };
+
+  addComponents(typeScale);
+});

--- a/client/src/tokens/typeScale.js
+++ b/client/src/tokens/typeScale.js
@@ -67,7 +67,7 @@ module.exports = plugin(({ addComponents, theme }) => {
       lineHeight: theme('lineHeight.normal'),
     },
     '.help-text': {
-      fontSize: theme('fontSize.16'),
+      fontSize: theme('fontSize.14'),
       fontWeight: theme('fontWeight.normal'),
       color: theme('colors.grey.400'),
       lineHeight: theme('lineHeight.tight'),

--- a/client/src/tokens/typeScale.js
+++ b/client/src/tokens/typeScale.js
@@ -59,13 +59,11 @@ module.exports = plugin(({ addComponents, theme }) => {
     '.body-text': {
       fontSize: theme('fontSize.16'),
       fontWeight: theme('fontWeight.normal'),
-      color: theme('colors.grey.600'),
       lineHeight: theme('lineHeight.normal'),
     },
     '.body-text-large': {
       fontSize: theme('fontSize.18'),
       fontWeight: theme('fontWeight.normal'),
-      color: theme('colors.grey.600'),
       lineHeight: theme('lineHeight.normal'),
     },
     '.help-text': {

--- a/client/src/tokens/typeScale.js
+++ b/client/src/tokens/typeScale.js
@@ -51,7 +51,7 @@ module.exports = plugin(({ addComponents, theme }) => {
       lineHeight: theme('lineHeight.tight'),
     },
     '.label-3': {
-      fontSize: theme('fontSize.15'),
+      fontSize: theme('fontSize.14'),
       fontWeight: theme('fontWeight.medium'),
       color: theme('colors.primary.DEFAULT'),
       lineHeight: theme('lineHeight.tight'),

--- a/client/src/tokens/typeScale.js
+++ b/client/src/tokens/typeScale.js
@@ -30,14 +30,6 @@ module.exports = plugin(({ addComponents, theme }) => {
       fontSize: theme('fontSize.18'),
       ...headingBaseStyles,
     },
-    '.h5': {
-      fontSize: theme('fontSize.16'),
-      ...headingBaseStyles,
-    },
-    '.h6': {
-      fontSize: theme('fontSize.15'),
-      ...headingBaseStyles,
-    },
     '.label-1': {
       fontSize: theme('fontSize.16'),
       fontWeight: theme('fontWeight.bold'),

--- a/client/src/tokens/typography.js
+++ b/client/src/tokens/typography.js
@@ -1,7 +1,6 @@
 // Note: Tailwind does not automatically escape font names.
 // If a font name contains an invalid identifier (like a space), we wrap it in quotes to escape the invalid characters.
 // Font stack optimised for built-in fonts of each major operating system, with support for emojis.
-
 const systemUIFontStack = [
   '-apple-system',
   'BlinkMacSystemFont',

--- a/client/src/tokens/typography.js
+++ b/client/src/tokens/typography.js
@@ -1,6 +1,7 @@
 // Note: Tailwind does not automatically escape font names.
 // If a font name contains an invalid identifier (like a space), we wrap it in quotes to escape the invalid characters.
 // Font stack optimised for built-in fonts of each major operating system, with support for emojis.
+
 const systemUIFontStack = [
   '-apple-system',
   'BlinkMacSystemFont',
@@ -56,17 +57,8 @@ const letterSpacing = {
 
 const lineHeight = {
   none: '1',
-  tight: '1.25',
-  snug: '1.375',
+  tight: '1.3',
   normal: '1.5',
-  relaxed: '1.625',
-  loose: '2',
-  3: '.75rem',
-  4: '1rem',
-  5: '1.25rem',
-  6: '1.5rem',
-  7: '1.75rem',
-  8: '2rem',
 };
 
 module.exports = {

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -1,3 +1,6 @@
+/**
+ * Design Tokens
+ */
 const colors = require('./src/tokens/colors');
 const {
   fontFamily,
@@ -14,6 +17,15 @@ const {
 } = require('./src/tokens/objectStyles');
 const { spacing } = require('./src/tokens/spacing');
 
+/**
+ * Plugins
+ */
+const typeScale = require('./src/tokens/typeScale');
+
+/**
+ * Functions
+ * themeColors: For converting our design tokens into a format that tailwind accepts
+ */
 const themeColors = Object.fromEntries(
   Object.entries(colors).map(([key, hues]) => {
     const shades = Object.fromEntries(
@@ -51,6 +63,6 @@ module.exports = {
     },
     spacing,
   },
-  plugins: [],
+  plugins: [typeScale],
   corePlugins: {},
 };


### PR DESCRIPTION
Addresses #7982: 

This PR is to pre-configure a set of TypeScale css classes using tailwind's plugin API. By defining these values inside of an isolated plugin instead of sass we are easily able to take advantage of tailwind's theme() function as well as inherit any settings that are set by the configuration (eg. prefixes like `w-` will automatically be appended to classnames output). Only classes used in the markup or documentation will appear in the compiled css.  

Browsers Tested On: 
Chrome v98 / Safari 15.2