### PR TITLE
Page description (replaces #5607)

### DIFF
--- a/docs/topics/pages.md
+++ b/docs/topics/pages.md
@@ -190,6 +190,20 @@ By default, any page type can be created under any page type and it is not neces
 Setting `parent_page_types` to an empty list is a good way of preventing a particular page type from being created in the editor interface.
 
 ```eval_rst
+.. _page_descriptions:
+```
+
+### Page descriptions
+
+With every Wagtail Page you are able to add a helpful description text, similar to a ``help_text`` model attribute. By adding ``page_description`` to your Page model you'll be adding a short description that can be seen when you create a new page, edit an existing page or when you're prompted to select a child page type.
+
+```python
+class LandingPage(Page):
+
+    page_description = "Use this page for converting users"
+```
+
+```eval_rst
 .. _page_urls:
 ```
 ### Page URLs

--- a/wagtail/admin/templates/wagtailadmin/pages/add_subpage.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/add_subpage.html
@@ -20,7 +20,7 @@
                                 <a href="{% url 'wagtailadmin_pages:add' app_label model_name parent_page.id %}{% if next %}?next={{ next }}{% endif %}" class="icon icon-plus-inverse icon-larger">
                                     {{ verbose_name }}
                                     {% if page_description %}
-                                        <div><small>{{ page_description }}</small></div>
+                                        <div><span class="visuallyhidden">.</span><small>{{ page_description }}</small></div>
                                     {% endif %}
                                 </a>
                             </div>

--- a/wagtail/admin/templates/wagtailadmin/pages/add_subpage.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/add_subpage.html
@@ -18,6 +18,9 @@
                         <div class="row row-flush">
                             <div class="col6">
                                 <a href="{% url 'wagtailadmin_pages:add' app_label model_name parent_page.id %}{% if next %}?next={{ next }}{% endif %}" class="icon icon-plus-inverse icon-larger">{{ verbose_name }}</a>
+                                {% if page_description %}
+                                    <small>{{ page_description }}</small>
+                                {% endif %}
                             </div>
 
                             <small class="col6" style="text-align:right">

--- a/wagtail/admin/templates/wagtailadmin/pages/add_subpage.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/add_subpage.html
@@ -13,7 +13,7 @@
 
         {% if page_types %}
             <ul class="listing">
-                {% for verbose_name, app_label, model_name in page_types %}
+                {% for verbose_name, app_label, model_name, page_description in page_types %}
                     <li>
                         <div class="row row-flush">
                             <div class="col6">

--- a/wagtail/admin/templates/wagtailadmin/pages/add_subpage.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/add_subpage.html
@@ -16,14 +16,16 @@
                 {% for verbose_name, app_label, model_name, page_description in page_types %}
                     <li>
                         <div class="row row-flush">
-                            <div class="col6">
-                                <a href="{% url 'wagtailadmin_pages:add' app_label model_name parent_page.id %}{% if next %}?next={{ next }}{% endif %}" class="icon icon-plus-inverse icon-larger">{{ verbose_name }}</a>
-                                {% if page_description %}
-                                    <small>{{ page_description }}</small>
-                                {% endif %}
+                            <div class="col8">
+                                <a href="{% url 'wagtailadmin_pages:add' app_label model_name parent_page.id %}{% if next %}?next={{ next }}{% endif %}" class="icon icon-plus-inverse icon-larger">
+                                    {{ verbose_name }}
+                                    {% if page_description %}
+                                        <div><small>{{ page_description }}</small></div>
+                                    {% endif %}
+                                </a>
                             </div>
 
-                            <small class="col6" style="text-align:right">
+                            <small class="col4" style="text-align:right">
                                 <a href="{% url 'wagtailadmin_pages:type_use' app_label model_name %}" class="nolink">{% blocktrans with page_type=verbose_name %}Pages using {{ page_type }}{% endblocktrans %}</a>
                             </small>
 

--- a/wagtail/admin/templates/wagtailadmin/pages/create.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/create.html
@@ -15,10 +15,10 @@
                 <h1>
                     {% icon "doc-empty-inverse" class_name="header-title-icon" %}
                     {% trans 'New' %} <span>{{ content_type.model_class.get_verbose_name }}</span>
-                    {% if content_type.model_class.get_page_description %}
-                        <span><small>{{ content_type.model_class.get_page_description }}</small></span>
-                    {% endif %}
                 </h1>
+                {% if content_type.model_class.get_page_description %}
+                    <h3>{{ content_type.model_class.get_page_description }}</h3>
+                {% endif %}
             </div>
         </div>
 

--- a/wagtail/admin/templates/wagtailadmin/pages/create.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/create.html
@@ -12,7 +12,13 @@
 
         <div class="row">
             <div class="left col9 header-title">
-                <h1>{% trans 'New' %} <span>{{ content_type.model_class.get_verbose_name }}</span></h1>
+                <h1>
+                    {% icon "doc-empty-inverse" class_name="header-title-icon" %}
+                    {% trans 'New' %} <span>{{ content_type.model_class.get_verbose_name }}</span>
+                    {% if content_type.model_class.get_page_description %}
+                        <span><small>{{ content_type.model_class.get_page_description }}</small></span>
+                    {% endif %}
+                </h1>
             </div>
         </div>
 

--- a/wagtail/admin/templates/wagtailadmin/pages/create.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/create.html
@@ -17,7 +17,7 @@
                     {% trans 'New' %} <span>{{ content_type.model_class.get_verbose_name }}</span>
                 </h1>
                 {% if content_type.model_class.get_page_description %}
-                    <h3>{{ content_type.model_class.get_page_description }}</h3>
+                    <p>{{ content_type.model_class.get_page_description }}</p>
                 {% endif %}
             </div>
         </div>

--- a/wagtail/admin/templates/wagtailadmin/pages/edit.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/edit.html
@@ -37,12 +37,12 @@
                 {{ content_type.model_class.get_verbose_name }}
             </li>
             {% if content_type.model_class.get_page_description %}
-            <li class="header-meta--type">
-                {% icon name="help" class_name="default" %}
-                <span data-wagtail-tooltip="{{ content_type.model_class.get_page_description }}">
-                    {{ content_type.model_class.get_page_description|truncatewords:4 }}
-                </span>
-            </li>
+                <li class="header-meta--type">
+                    {% icon name="help" class_name="default" %}
+                    <span data-wagtail-tooltip="{{ content_type.model_class.get_page_description }}">
+                        {{ content_type.model_class.get_page_description|truncatewords:4 }}
+                    </span>
+                </li>
             {% endif %}
             {% if locale %}
                 <li class="header-meta--locale">

--- a/wagtail/admin/templates/wagtailadmin/pages/edit.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/edit.html
@@ -16,9 +16,6 @@
                 <h1>
                     {% icon name="doc-empty-inverse" class_name="header-title-icon" %}
                     {% blocktrans with title=page.get_admin_display_title page_type=content_type.model_class.get_verbose_name %}Editing {{ page_type }} <span>{{ title }}</span>{% endblocktrans %}
-                    {% if content_type.model_class.get_page_description %}
-                        <span><small>{{ content_type.model_class.get_page_description }}</small></span>
-                    {% endif %}
                 </h1>
             </div>
             <div class="right col3">

--- a/wagtail/admin/templates/wagtailadmin/pages/edit.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/edit.html
@@ -11,11 +11,16 @@
     <header class="merged tab-merged">
         {% explorer_breadcrumb page page_perms=page_perms show_header_buttons=True %}
 
-        <div class="row">
-            <h1 class="left col9 header-title" title="{% blocktrans with title=page.get_admin_display_title page_type=content_type.model_class.get_verbose_name %}Editing {{ page_type }}{% endblocktrans %}">
-                {{ page.get_admin_display_title }}
-            </h1>
-
+        <div class="row row-flush">
+            <div class="left col9 header-title" title="{% blocktrans with title=page.get_admin_display_title page_type=content_type.model_class.get_verbose_name %}Editing {{ page_type }}{% endblocktrans %}">
+                <h1>
+                    {% icon name="doc-empty-inverse" class_name="header-title-icon" %}
+                    {% blocktrans with title=page.get_admin_display_title page_type=content_type.model_class.get_verbose_name %}Editing {{ page_type }} <span>{{ title }}</span>{% endblocktrans %}
+                    {% if content_type.model_class.get_page_description %}
+                        <span><small>{{ content_type.model_class.get_page_description }}</small></span>
+                    {% endif %}
+                </h1>
+            </div>
             <div class="right col3">
                 {% include "wagtailadmin/pages/_page_view_live_tag.html" with page=page_for_status %}
             </div>

--- a/wagtail/admin/templates/wagtailadmin/pages/edit.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/edit.html
@@ -36,6 +36,14 @@
                 {% icon name="doc-empty-inverse" class_name="default" %}
                 {{ content_type.model_class.get_verbose_name }}
             </li>
+            {% if content_type.model_class.get_page_description %}
+            <li class="header-meta--type">
+                {% icon name="help" class_name="default" %}
+                <span data-wagtail-tooltip="{{ content_type.model_class.get_page_description }}">
+                    {{ content_type.model_class.get_page_description|truncatewords:4 }}
+                </span>
+            </li>
+            {% endif %}
             {% if locale %}
                 <li class="header-meta--locale">
                     {% include "wagtailadmin/shared/locale_selector.html" %}

--- a/wagtail/admin/tests/pages/test_create_page.py
+++ b/wagtail/admin/tests/pages/test_create_page.py
@@ -46,6 +46,7 @@ class TestPageCreation(TestCase, WagtailTestUtils):
             "wagtailadmin_pages:add", args=("tests", "simplepage", self.root_page.id)
         )
         self.assertContains(response, 'href="%s"' % target_url)
+        self.assertContains(response, "A simple page description")
         # List of available page types should not contain pages with is_creatable = False
         self.assertNotContains(response, "MTI base page")
         # List of available page types should not contain abstract pages

--- a/wagtail/admin/views/pages/create.py
+++ b/wagtail/admin/views/pages/create.py
@@ -24,7 +24,12 @@ def add_subpage(request, parent_page_id):
         raise PermissionDenied
 
     page_types = [
-        (model.get_verbose_name(), model._meta.app_label, model._meta.model_name, model.get_page_description())
+        (
+            model.get_verbose_name(),
+            model._meta.app_label,
+            model._meta.model_name,
+            model.get_page_description(),
+        )
         for model in type(parent_page).creatable_subpage_models()
         if model.can_create_at(parent_page)
     ]

--- a/wagtail/admin/views/pages/create.py
+++ b/wagtail/admin/views/pages/create.py
@@ -24,7 +24,7 @@ def add_subpage(request, parent_page_id):
         raise PermissionDenied
 
     page_types = [
-        (model.get_verbose_name(), model._meta.app_label, model._meta.model_name)
+        (model.get_verbose_name(), model._meta.app_label, model._meta.model_name, model.get_page_description())
         for model in type(parent_page).creatable_subpage_models()
         if model.can_create_at(parent_page)
     ]

--- a/wagtail/admin/views/pages/create.py
+++ b/wagtail/admin/views/pages/create.py
@@ -39,7 +39,7 @@ def add_subpage(request, parent_page_id):
     if len(page_types) == 1:
         # Only one page type is available - redirect straight to the create form rather than
         # making the user choose
-        verbose_name, app_label, model_name = page_types[0]
+        verbose_name, app_label, model_name, description = page_types[0]
         return redirect("wagtailadmin_pages:add", app_label, model_name, parent_page.id)
 
     return TemplateResponse(

--- a/wagtail/core/models/__init__.py
+++ b/wagtail/core/models/__init__.py
@@ -1502,9 +1502,9 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
     @classmethod
     def get_page_description(cls):
         """
-        Returns a page description, or nothing if it's not set. eg "A multi-purpose website".
+        Returns a page description if it's not set. eg "A multi-purpose web page".
         """
-        return getattr(cls, 'page_description', None)
+        return getattr(cls, 'page_description', '')
 
     @property
     def status_string(self):

--- a/wagtail/core/models/__init__.py
+++ b/wagtail/core/models/__init__.py
@@ -1499,6 +1499,13 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
         # except this doesn't convert any characters to lowercase
         return capfirst(cls._meta.verbose_name)
 
+    @classmethod
+    def get_page_description(cls):
+        """
+        Returns a page description, or nothing if it's not set. eg "A multi-purpose website".
+        """
+        return getattr(cls, 'page_description', None)
+
     @property
     def status_string(self):
         if not self.live:

--- a/wagtail/core/models/__init__.py
+++ b/wagtail/core/models/__init__.py
@@ -1504,7 +1504,7 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
         """
         Returns a page description if it's set. For example "A multi-purpose web page".
         """
-        return getattr(cls, 'page_description', '')
+        return getattr(cls, "page_description", "")
 
     @property
     def status_string(self):

--- a/wagtail/core/models/__init__.py
+++ b/wagtail/core/models/__init__.py
@@ -1502,7 +1502,7 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
     @classmethod
     def get_page_description(cls):
         """
-        Returns a page description if it's not set. eg "A multi-purpose web page".
+        Returns a page description if it's set. For example "A multi-purpose web page".
         """
         return getattr(cls, 'page_description', '')
 

--- a/wagtail/tests/testapp/models.py
+++ b/wagtail/tests/testapp/models.py
@@ -168,6 +168,7 @@ class RelatedLink(LinkFields):
 # Simple page
 class SimplePage(Page):
     content = models.TextField()
+    page_description = "A simple page description"
 
     content_panels = [
         FieldPanel("title", classname="full title"),


### PR DESCRIPTION
Originally from @KalobTaulien in #5607. This had been approved but not merged, and there were conflicts. I had to create a new branch / PR in order to fix the conflicts.

---

* Do the tests still pass? ✅
* Does the code comply with the style guide? ✅
* Have you added tests to cover the new/fixed behaviour? ✅
* Has the documentation been updated accordingly? ✅

Added a "help text"-style optional attribute to the Page model that will display the Page's helpful text in three different locations in the Wagtail admin. Previews below.

**Note:** I did _not_ add any frontend styling. I'd be happy for some constructive feedback on the design implementation and would be happy to open another PR for better design/frontend implementation. 

<img width="402" alt="Screen Shot 2019-10-07 at 7 19 07 PM" src="https://user-images.githubusercontent.com/4743971/66362293-61879e00-e93f-11e9-9adc-5fa17f4bf408.png">