### PR TITLE
Add support for image rendition prefetching

### DIFF
--- a/docs/advanced_topics/images/renditions.rst
+++ b/docs/advanced_topics/images/renditions.rst
@@ -34,3 +34,23 @@ be accessed through the Rendition's ``image`` property:
     True
 
 See also: :ref:`image_tag`
+
+.. _image_rendition_methods:
+
+Model methods involved in rendition generation
+----------------------------------------------
+
+The following ``AbstractImage`` model methods are involved in finding and generating a renditions. If using a custom image model, you can customise the behaviour of either of these methods by overriding them on your model:
+
+.. automodule:: wagtail.images.models
+
+.. class:: AbstractImage
+    :noindex:
+
+    .. autofunction:: get_rendition
+
+    .. autofunction:: find_existing_rendition
+
+    .. autofunction:: create_rendition
+
+    .. autofunction:: generate_rendition_file

--- a/docs/releases/3.0.md
+++ b/docs/releases/3.0.md
@@ -56,6 +56,42 @@ class LandingPage(Page):
 
 Trying to upload an image that's a duplicate of one already in the image library will now lead to a confirmation step. This feature was developed by Tidiane Dia and sponsored by The Motley Fool.
 
+### Image renditions can now be prefetched
+
+When using a queryset to render a list of items with images, you can now make use of Django's built-in ``prefetch_related()`` queryset method to prefetch the renditions needed for rendering with a single extra query. For long lists of items, or where multiple renditions are used for each item, this can provide a significant boost to performance.
+
+For example, say you were rendering a list of events (with thumbnail images for each). The queryset for your source data might look something like this:
+
+```python
+EventPage.objects.live().select_related("listing_image")
+```
+
+Now that renditions are prefetchable, you can reduce the number of additional database queries needed for rendering by updating the original queryset like so:
+
+```python
+EventPage.objects.live().select_related("listing_image").prefetch_related("listing_image__renditions")
+```
+
+If each image in your project has large numbers of renditions, you might want to consider using a ``Prefetch`` object to select only the renditions you need. For example:
+
+```python
+from django.db.models import Prefetch
+from wagtail.images import get_image_model
+
+
+# These are the renditions required for rendering
+renditions = get_image_model().get_rendition_model().objects.filter(
+    filter_spec__in=["fill-300x186", "fill-600x400", "fill-940x680"]
+)
+
+# `Prefetch` is used to only fetch the required renditions
+events = EventPage.objects.live().select_related("listing_image").prefetch_related(
+    Prefetch("listing_image__renditions", queryset=renditions)
+)
+```
+
+This feature was developed by Andy Babic.
+
 ### Other features
 
  * Upgrade ESLint and Stylelint configurations to latest shared Wagtail configs (Thibaud Colas, Paarth Agarwal)

--- a/wagtail/images/models.py
+++ b/wagtail/images/models.py
@@ -346,6 +346,11 @@ class AbstractImage(ImageFileMixin, CollectionMember, index.Indexed, models.Mode
             rendition = self.find_existing_rendition(filter)
         except Rendition.DoesNotExist:
             rendition = self.create_rendition(filter)
+            # Reuse this rendition if requested again from this object
+            if "renditions" in getattr(self, "_prefetched_objects_cache", {}):
+                self._prefetched_objects_cache["renditions"]._result_cache.append(
+                    rendition
+                )
 
         try:
             cache = caches["renditions"]

--- a/wagtail/images/tests/test_models.py
+++ b/wagtail/images/tests/test_models.py
@@ -303,6 +303,17 @@ class TestRenditions(TestCase):
         # The renditions should NOT match
         self.assertNotEqual(original_rendition, second_rendition)
 
+        # Request the same rendition again
+        with self.assertNumQueries(0):
+            # Newly created renditions are appended to the prefetched
+            # rendition queryset, so that multiple requests for the same
+            # rendition can reuse the same value
+            third_rendition = image.get_rendition("height-66")
+
+        # The second and third renditions should be references to the
+        # exact same in-memory object
+        self.assertIs(second_rendition, third_rendition)
+
     def test_alt_attribute(self):
         rendition = self.image.get_rendition("width-400")
         self.assertEqual(rendition.alt, "Test image")


### PR DESCRIPTION
Let's say you are rendering a list of 20 `EventPage` objects on a responsive website, and each representation has three renditions of the event's `listing_image`, targeting multiple devices. 

## Without these changes

The optimal QuerySet looks something like:

```
EventPage.objects.select_related("listing_image")[:20]
```

Rendering this page for the first time will require 20 x 3 x 5 database operations just for card image renditions, because of the need to look up each rendition separately, and to create each new rendition with `get_or_create()` to avoid race conditions. If rendition caching is used, you can add to that 20 x 3 individual cache reads and 20 x 3 individual cache write operations.

Rendering the page a second time will require 20 x 3 database or cache lookup operations for card image generation (depending on whether rendition caching is being used)

## With these changes

The optimal QuerySet looks something like:

```
EventPage.objects.select_related("listing_image").prefetch_related("listing_image__renditions")[:20]
```

Rendering this page for the first time will require (20 x 3 x 4) + 1 database queries for card image generation (a ~20% reduction). If rendition caching is used, you can add to that 20 x 3 individual cache write operations, but zero reads (a 50% reduction in cache operations overall).

Rendering the page a second time will require 1 database operation to fetch all renditions (whether rendition caching is enabled or not). In this example, that is at least a 5,000% improvement.

## What else have I changed here?

The single `get_rendtion()` method was already a bit difficult to follow, and bringing prefetch support into the mix only made that situation worse. So, I thought it only right to break things down into several more dedicated methods. With the addition of docstrings and type hints, I'm sure you'll agree that it makes things much easier to follow overall.

## Considerations

If all renditions are prefetched, and two or more `EventPage` objects shared the same `listing_image`, the performance of the first render will be negatively impacted, because renditions generated for each instance of `listing_image` would not be shared by the others... leading to the same thumbnail images being freshly generated multiple times. 

We could sacrifice some of the performance gains elsewhere to reduce this impact - However, I think optimising for the more common scenario (each image being unique) is the better route. 

We could also solve this problem a different way: By passing in the current ``HttpRequest`` (or some other arbitrary mutable object), and caching any newly created renditions on there - making them available practically anywhere within the same thread.