### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -89,6 +89,10 @@ setup(
     author="Wagtail core team + contributors",
     author_email="hello@wagtail.org",  # For support queries, please see https://docs.wagtail.org/en/stable/support.html
     url="https://wagtail.org/",
+    project_urls={
+        "Documentation": "https://docs.wagtail.org",
+        "Source": "https://github.com/wagtail/wagtail",
+    },
     packages=find_packages(),
     include_package_data=True,
     license="BSD",


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help the automation tool find the source code for Requests.

Example: [pypi.org/pypi/requests/json](https://pypi.org/pypi/requests/json)
Docs: [packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls)

Thanks for contributing to Wagtail! 🎉

Before submitting, please review the contributor guidelines <https://docs.wagtail.org/en/latest/contributing/index.html> and check the following:

* Do the tests still pass? (https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
* Does the code comply with the style guide? (Run `make lint` from the Wagtail root)
* For Python changes: Have you added tests to cover the new/fixed behaviour?
* For front-end changes: Did you test on all of [Wagtail’s supported environments](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)?
    * **Please list the exact browser and operating system versions you tested**.
    * **Please list which assistive technologies you tested**.
* For new features: Has the documentation been updated accordingly?
