### PR TITLE
Readme - add badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ Wagtail is an open source content management system built on Django, with a stro
 
 ![Wagtail screenshot](https://cdn.jsdelivr.net/gh/wagtail/wagtail@main/.github/wagtail-screenshot-with-browser.png)
 
+[![PyPI - License (BSD)](https://img.shields.io/pypi/l/wagtail)](https://github.com/wagtail/wagtail/blob/main/LICENSE)
+[![PyPI version](https://badge.fury.io/py/wagtail.svg)](https://pypi.org/project/wagtail/)
+[![Wagtail CI](https://github.com/wagtail/wagtail/actions/workflows/test.yml/badge.svg)](https://github.com/wagtail/wagtail/actions/workflows/test.yml)
+
 ### Features
 
 * A fast, attractive interface for authors


### PR DESCRIPTION
Add badges to the readme for Python package info, licence and code tests passing.

Since we are adopting this a preferred convention for Wagtail packages within the Wagtail org I thought it would be nice to add the main repo. 

I elected to put the badges further down in the readme as the top seemed a bit distracting. 

I could not work out how to add code coverage, I recall we scrapped that but I could be mistaken. 