### PR TITLE
When running manage.py loaddata setting locale to Locale.get_default() is wrong.

### DIFF
--- a/wagtail/models/i18n.py
+++ b/wagtail/models/i18n.py
@@ -335,16 +335,13 @@ def get_translatable_models(include_subclasses=False):
 
 @receiver(pre_save)
 def set_locale_on_new_instance(sender, instance, **kwargs):
+    if kwargs["raw"]:
+        return
+
     if not isinstance(instance, TranslatableMixin):
         return
 
     if instance.locale_id is not None:
-        return
-
-    # If this is a fixture load, use the global default Locale
-    # as the page tree is probably in an flux
-    if kwargs["raw"]:
-        instance.locale = Locale.get_default()
         return
 
     instance.locale = instance.get_default_locale()

--- a/wagtail/signal_handlers.py
+++ b/wagtail/signal_handlers.py
@@ -11,6 +11,9 @@ logger = logging.getLogger("wagtail")
 
 # Clear the wagtail_site_root_paths from the cache whenever Site records are updated.
 def post_save_site_signal_handler(instance, update_fields=None, **kwargs):
+    if kwargs["raw"]:
+        return
+
     cache.delete("wagtail_site_root_paths")
 
 

--- a/wagtail/test/demosite/fixtures/demosite.json
+++ b/wagtail/test/demosite/fixtures/demosite.json
@@ -1,8 +1,16 @@
 [
   {
     "pk": 1,
+    "model": "wagtailcore.locale",
+    "fields": {
+      "language_code": "en"
+    }
+  },
+  {
+    "pk": 1,
     "model": "wagtailcore.page",
     "fields": {
+      "locale": 1,
       "title": "Root",
       "draft_title": "Root",
       "numchild": 1,
@@ -23,6 +31,7 @@
     "pk": 2,
     "model": "wagtailcore.page",
     "fields": {
+      "locale": 1,
       "title": "Home page",
       "draft_title": "Home page",
       "numchild": 5,
@@ -43,6 +52,7 @@
     "pk": 4,
     "model": "wagtailcore.page",
     "fields": {
+      "locale": 1,
       "title": "Events index",
       "draft_title": "Events index",
       "numchild": 2,
@@ -63,6 +73,7 @@
     "pk": 5,
     "model": "wagtailcore.page",
     "fields": {
+      "locale": 1,
       "title": "Blog index",
       "draft_title": "Blog index",
       "numchild": 3,
@@ -83,6 +94,7 @@
     "pk": 6,
     "model": "wagtailcore.page",
     "fields": {
+      "locale": 1,
       "title": "Standard index",
       "draft_title": "Standard index",
       "numchild": 4,
@@ -103,6 +115,7 @@
     "pk": 8,
     "model": "wagtailcore.page",
     "fields": {
+      "locale": 1,
       "title": "Event 1",
       "draft_title": "Event 1",
       "numchild": 0,
@@ -123,6 +136,7 @@
     "pk": 9,
     "model": "wagtailcore.page",
     "fields": {
+      "locale": 1,
       "title": "Event 2",
       "draft_title": "Event 2",
       "numchild": 0,
@@ -143,6 +157,7 @@
     "pk": 10,
     "model": "wagtailcore.page",
     "fields": {
+      "locale": 1,
       "title": "Standard page 1",
       "draft_title": "Standard page 1",
       "numchild": 0,
@@ -163,6 +178,7 @@
     "pk": 12,
     "model": "wagtailcore.page",
     "fields": {
+      "locale": 1,
       "title": "Contact page",
       "draft_title": "Contact page",
       "numchild": 0,
@@ -183,6 +199,7 @@
     "pk": 13,
     "model": "wagtailcore.page",
     "fields": {
+      "locale": 1,
       "title": "James Joyce",
       "draft_title": "James Joyce",
       "numchild": 0,
@@ -203,6 +220,7 @@
     "pk": 14,
     "model": "wagtailcore.page",
     "fields": {
+      "locale": 1,
       "title": "David Mitchell",
       "draft_title": "David Mitchell",
       "numchild": 0,
@@ -223,6 +241,7 @@
     "pk": 15,
     "model": "wagtailcore.page",
     "fields": {
+      "locale": 1,
       "title": "Standard page 2",
       "draft_title": "Standard page 2",
       "numchild": 0,
@@ -243,6 +262,7 @@
     "pk": 16,
     "model": "wagtailcore.page",
     "fields": {
+      "locale": 1,
       "title": "Blog post",
       "draft_title": "Blog post",
       "numchild": 0,
@@ -263,6 +283,7 @@
     "pk": 17,
     "model": "wagtailcore.page",
     "fields": {
+      "locale": 1,
       "title": "Photo credits",
       "draft_title": "Photo credits",
       "numchild": 0,
@@ -283,6 +304,7 @@
     "pk": 18,
     "model": "wagtailcore.page",
     "fields": {
+      "locale": 1,
       "title": "Blog post again",
       "draft_title": "Blog post again",
       "numchild": 0,
@@ -303,6 +325,7 @@
     "pk": 19,
     "model": "wagtailcore.page",
     "fields": {
+      "locale": 1,
       "title": "Another blog post",
       "draft_title": "Another blog post",
       "numchild": 0,
@@ -323,6 +346,7 @@
     "pk": 20,
     "model": "wagtailcore.page",
     "fields": {
+      "locale": 1,
       "title": "People",
       "draft_title": "People",
       "numchild": 2,
@@ -343,6 +367,7 @@
     "pk": 21,
     "model": "wagtailcore.page",
     "fields": {
+      "locale": 1,
       "title": "A deeper menu level",
       "draft_title": "A deeper menu level",
       "numchild": 2,
@@ -363,6 +388,7 @@
     "pk": 22,
     "model": "wagtailcore.page",
     "fields": {
+      "locale": 1,
       "title": "A grandchild page",
       "draft_title": "A grandchild page",
       "numchild": 0,
@@ -383,6 +409,7 @@
     "pk": 23,
     "model": "wagtailcore.page",
     "fields": {
+      "locale": 1,
       "title": "Another grandchild page",
       "draft_title": "Another grandchild page",
       "numchild": 0,

--- a/wagtail/test/modeladmintest/fixtures/modeladmintest_test.json
+++ b/wagtail/test/modeladmintest/fixtures/modeladmintest_test.json
@@ -105,7 +105,8 @@
     "model": "modeladmintest.translatablebook",
     "fields": {
       "title": "The Lord of the Rings",
-      "author_id": 1
+      "author_id": 1,
+      "locale_id": 1
     }
   },
   {

--- a/wagtail/test/modeladmintest/fixtures/modeladmintest_test.json
+++ b/wagtail/test/modeladmintest/fixtures/modeladmintest_test.json
@@ -1,6 +1,13 @@
 [
   {
     "pk": 1,
+    "model": "wagtailcore.locale",
+    "fields": {
+      "language_code": "en"
+    }
+  },
+  {
+    "pk": 1,
     "model": "modeladmintest.author",
     "fields": {
       "name": "J. R. R. Tolkien",
@@ -121,6 +128,7 @@
     "pk": 1,
     "model": "wagtailcore.page",
     "fields": {
+      "locale": 1,
       "title": "Root",
       "draft_title": "Root",
       "numchild": 1,
@@ -138,6 +146,7 @@
     "pk": 2,
     "model": "wagtailcore.page",
     "fields": {
+      "locale": 1,
       "title": "Welcome to the Wagtail test site!",
       "draft_title": "Welcome to the Wagtail test site!",
       "numchild": 5,
@@ -155,6 +164,7 @@
     "pk": 3,
     "model": "wagtailcore.page",
     "fields": {
+      "locale": 1,
       "title": "Events",
       "draft_title": "Events",
       "numchild": 4,
@@ -179,6 +189,7 @@
     "pk": 4,
     "model": "wagtailcore.page",
     "fields": {
+      "locale": 1,
       "title": "Christmas",
       "draft_title": "Christmas",
       "numchild": 3,
@@ -206,6 +217,7 @@
     "pk": 5,
     "model": "wagtailcore.page",
     "fields": {
+      "locale": 1,
       "title": "Santa's Grotto",
       "draft_title": "Santa's Grotto",
       "numchild": 0,
@@ -230,6 +242,7 @@
     "pk": 6,
     "model": "wagtailcore.page",
     "fields": {
+      "locale": 1,
       "title": "Santa's Workshop",
       "draft_title": "Santa's Workshop",
       "numchild": 0,
@@ -254,6 +267,7 @@
     "pk": 7,
     "model": "wagtailcore.page",
     "fields": {
+      "locale": 1,
       "title": "Claim your free present!",
       "draft_title": "Claim your free present!",
       "numchild": 0,

--- a/wagtail/test/testapp/fixtures/test.json
+++ b/wagtail/test/testapp/fixtures/test.json
@@ -648,6 +648,7 @@
     "pk": 21,
     "model": "wagtailcore.page",
     "fields": {
+      "locale": 1,
       "title": "This page has a field that shouldn't be copied",
       "draft_title": "This page has a field that shouldn't be copied",
       "numchild": 0,

--- a/wagtail/test/testapp/fixtures/test.json
+++ b/wagtail/test/testapp/fixtures/test.json
@@ -1,8 +1,16 @@
 [
   {
     "pk": 1,
+    "model": "wagtailcore.locale",
+    "fields": {
+      "language_code": "en"
+    }
+  },
+  {
+    "pk": 1,
     "model": "wagtailcore.page",
     "fields": {
+      "locale": 1,
       "title": "Root",
       "draft_title": "Root",
       "numchild": 2,
@@ -20,6 +28,7 @@
     "pk": 2,
     "model": "wagtailcore.page",
     "fields": {
+      "locale": 1,
       "title": "Welcome to the Wagtail test site!",
       "draft_title": "Welcome to the Wagtail test site!",
       "numchild": 10,
@@ -38,6 +47,7 @@
     "pk": 3,
     "model": "wagtailcore.page",
     "fields": {
+      "locale": 1,
       "title": "Events",
       "draft_title": "Events",
       "numchild": 6,
@@ -62,6 +72,7 @@
     "pk": 4,
     "model": "wagtailcore.page",
     "fields": {
+      "locale": 1,
       "title": "Christmas",
       "draft_title": "Christmas",
       "numchild": 0,
@@ -92,6 +103,7 @@
     "pk": 13,
     "model": "wagtailcore.page",
     "fields": {
+      "locale": 1,
       "title": "Saint Patrick",
       "draft_title": "Saint Patrick",
       "numchild": 0,
@@ -129,6 +141,7 @@
     "model": "tests.eventpagespeaker",
     "fields": {
       "page": 4,
+      "locale": 1,
       "first_name": "Father",
       "last_name": "Christmas",
       "sort_order": 0
@@ -139,6 +152,7 @@
     "pk": 5,
     "model": "wagtailcore.page",
     "fields": {
+      "locale": 1,
       "title": "Tentative Unpublished Event",
       "draft_title": "Tentative Unpublished Event",
       "numchild": 0,
@@ -168,6 +182,7 @@
     "pk": 6,
     "model": "wagtailcore.page",
     "fields": {
+      "locale": 1,
       "title": "Someone Else's Event",
       "draft_title": "Someone Else's Event",
       "numchild": 0,
@@ -197,6 +212,7 @@
     "pk": 7,
     "model": "wagtailcore.page",
     "fields": {
+      "locale": 1,
       "title": "About us",
       "draft_title": "About us",
       "numchild": 0,
@@ -223,6 +239,7 @@
     "pk": 8,
     "model": "wagtailcore.page",
     "fields": {
+      "locale": 1,
       "title": "Contact us",
       "draft_title": "Contact us",
       "numchild": 0,
@@ -249,6 +266,7 @@
     "pk": 9,
     "model": "wagtailcore.page",
     "fields": {
+      "locale": 1,
       "title": "Ameristralia Day",
       "draft_title": "Ameristralia Day",
       "numchild": 0,
@@ -324,6 +342,7 @@
     "pk": 10,
     "model": "wagtailcore.page",
     "fields": {
+      "locale": 1,
       "title": "Old style route method",
       "draft_title": "Old style route method",
       "numchild": 0,
@@ -348,6 +367,7 @@
     "pk": 11,
     "model": "wagtailcore.page",
     "fields": {
+      "locale": 1,
       "title": "Secret plans",
       "draft_title": "Secret plans",
       "numchild": 1,
@@ -372,6 +392,7 @@
     "pk": 12,
     "model": "wagtailcore.page",
     "fields": {
+      "locale": 1,
       "title": "Steal underpants",
       "draft_title": "Steal underpants",
       "numchild": 0,
@@ -399,6 +420,7 @@
     "pk": 14,
     "model": "wagtailcore.page",
     "fields": {
+      "locale": 1,
       "title": "My locked page",
       "draft_title": "My locked page",
       "numchild": 0,
@@ -416,6 +438,7 @@
     "pk": 15,
     "model": "wagtailcore.page",
     "fields": {
+      "locale": 1,
       "title": "Businessy events",
       "draft_title": "Businessy events",
       "numchild": 1,
@@ -439,6 +462,7 @@
     "pk": 16,
     "model": "wagtailcore.page",
     "fields": {
+      "locale": 1,
       "title": "Board meetings",
       "draft_title": "Board meetings",
       "numchild": 0,
@@ -462,6 +486,7 @@
     "pk": 17,
     "model": "wagtailcore.page",
     "fields": {
+      "locale": 1,
       "title": "Contact us one more time",
       "draft_title": "Contact us one more time",
       "numchild": 0,
@@ -558,6 +583,7 @@
     "pk": 18,
     "model": "wagtailcore.page",
     "fields": {
+      "locale": 1,
       "title": "Secret event editor plans",
       "draft_title": "Secret event editor plans",
       "numchild": 0,
@@ -581,6 +607,7 @@
     "pk": 19,
     "model": "wagtailcore.page",
     "fields": {
+      "locale": 1,
       "title": "Secret login plans",
       "draft_title": "Secret login plans",
       "numchild": 0,
@@ -604,6 +631,7 @@
     "pk": 20,
     "model": "wagtailcore.page",
     "fields": {
+      "locale": 1,
       "title": "This page doesn't get served",
       "draft_title": "This page doesn't get served",
       "numchild": 0,

--- a/wagtail/test/testapp/fixtures/test_explorable_pages.json
+++ b/wagtail/test/testapp/fixtures/test_explorable_pages.json
@@ -1,8 +1,10 @@
 [
+  {"model": "wagtailcore.locale", "pk": 1, "fields": {"language_code": "en"}},
   {
     "pk": 1,
     "model": "wagtailcore.page",
     "fields": {
+      "locale": 1,
       "title": "Root",
       "draft_title": "Root",
       "numchild": 1,
@@ -20,6 +22,7 @@
     "pk": 2,
     "model": "wagtailcore.page",
     "fields": {
+      "locale": 1,
       "title": "Welcome to testserver!",
       "draft_title": "Welcome to testserver!",
       "numchild": 1,
@@ -48,6 +51,7 @@
     "pk": 3,
     "model": "wagtailcore.page",
     "fields": {
+      "locale": 1,
       "title": "About us",
       "draft_title": "About us",
       "numchild": 0,
@@ -76,6 +80,7 @@
     "pk": 4,
     "model": "wagtailcore.page",
     "fields": {
+      "locale": 1,
       "title": "Welcome to example.com!",
       "draft_title": "Welcome to example.com!",
       "numchild": 1,
@@ -104,6 +109,7 @@
     "pk": 5,
     "model": "wagtailcore.page",
     "fields": {
+      "locale": 1,
       "title": "Content",
       "draft_title": "Content",
       "numchild": 2,
@@ -133,6 +139,7 @@
     "pk": 6,
     "model": "wagtailcore.page",
     "fields": {
+      "locale": 1,
       "title": "Page 1",
       "draft_title": "Page 1",
       "numchild": 0,
@@ -162,6 +169,7 @@
     "pk": 7,
     "model": "wagtailcore.page",
     "fields": {
+      "locale": 1,
       "title": "Page 2",
       "draft_title": "Page 2",
       "numchild": 1,
@@ -191,6 +199,7 @@
     "pk": 8,
     "model": "wagtailcore.page",
     "fields": {
+      "locale": 1,
       "title": "Other Content",
       "draft_title": "Other Content",
       "numchild": 0,
@@ -220,6 +229,7 @@
     "pk": 9,
     "model": "wagtailcore.page",
     "fields": {
+      "locale": 1,
       "title": "Child 1 of Page 2",
       "draft_title": "Child 1 of Page 2",
       "numchild": 0,
@@ -249,6 +259,7 @@
     "pk": 10,
     "model": "wagtailcore.page",
     "fields": {
+      "locale": 1,
       "title": "Welcome to example2.com!",
       "draft_title": "Welcome to example2.com!",
       "numchild": 0,

--- a/wagtail/test/testapp/fixtures/test_explorable_pages.json
+++ b/wagtail/test/testapp/fixtures/test_explorable_pages.json
@@ -1,5 +1,9 @@
 [
-  {"model": "wagtailcore.locale", "pk": 1, "fields": {"language_code": "en"}},
+  {
+    "model": "wagtailcore.locale",
+    "pk": 1,
+    "fields": { "language_code": "en" }
+  },
   {
     "pk": 1,
     "model": "wagtailcore.page",

--- a/wagtail/test/testapp/fixtures/test_specific.json
+++ b/wagtail/test/testapp/fixtures/test_specific.json
@@ -1,8 +1,10 @@
 [
+  {"model": "wagtailcore.locale", "pk": 1, "fields": {"language_code": "en"}},
   {
     "pk": 1,
     "model": "wagtailcore.page",
     "fields": {
+      "locale": 1,
       "title": "Root",
       "draft_title": "Root",
       "numchild": 1,
@@ -20,6 +22,7 @@
     "pk": 2,
     "model": "wagtailcore.page",
     "fields": {
+      "locale": 1,
       "title": "Welcome to the Wagtail test site!",
       "draft_title": "Welcome to the Wagtail test site!",
       "numchild": 5,
@@ -37,6 +40,7 @@
     "pk": 3,
     "model": "wagtailcore.page",
     "fields": {
+      "locale": 1,
       "title": "Events",
       "draft_title": "Events",
       "numchild": 4,
@@ -61,6 +65,7 @@
     "pk": 4,
     "model": "wagtailcore.page",
     "fields": {
+      "locale": 1,
       "title": "Christmas",
       "draft_title": "Christmas",
       "numchild": 0,
@@ -103,6 +108,7 @@
     "pk": 5,
     "model": "wagtailcore.page",
     "fields": {
+      "locale": 1,
       "title": "Tentative Unpublished Event",
       "draft_title": "Tentative Unpublished Event",
       "numchild": 0,
@@ -132,6 +138,7 @@
     "pk": 6,
     "model": "wagtailcore.page",
     "fields": {
+      "locale": 1,
       "title": "Someone Else's Event",
       "draft_title": "Someone Else's Event",
       "numchild": 0,
@@ -161,6 +168,7 @@
     "pk": 7,
     "model": "wagtailcore.page",
     "fields": {
+      "locale": 1,
       "title": "About us",
       "draft_title": "About us",
       "numchild": 0,
@@ -185,6 +193,7 @@
     "pk": 11,
     "model": "wagtailcore.page",
     "fields": {
+      "locale": 1,
       "title": "Other events",
       "draft_title": "Other events",
       "numchild": 1,
@@ -209,6 +218,7 @@
     "pk": 12,
     "model": "wagtailcore.page",
     "fields": {
+      "locale": 1,
       "title": "Special event",
       "draft_title": "Special event",
       "numchild": 0,

--- a/wagtail/test/testapp/fixtures/test_specific.json
+++ b/wagtail/test/testapp/fixtures/test_specific.json
@@ -1,5 +1,9 @@
 [
-  {"model": "wagtailcore.locale", "pk": 1, "fields": {"language_code": "en"}},
+  {
+    "model": "wagtailcore.locale",
+    "pk": 1,
+    "fields": { "language_code": "en" }
+  },
   {
     "pk": 1,
     "model": "wagtailcore.page",


### PR DESCRIPTION
There is no reason at all the locale is not also in the database dump and setting
it to Locale.get_default() is completely random and more likely than not wrong.

We get the following error because at the point this code is called, the default locale does not exist yet:

wagtail.core.models.i18n.Locale.DoesNotExist: Problem installing fixture '/tmp/tmp5jf3l5s9/bla/db.json': Locale matching query does not exist.