### PR TITLE
Moved the bind_to() calls with forms in page create/edit views

### DIFF
--- a/wagtail/admin/views/pages/create.py
+++ b/wagtail/admin/views/pages/create.py
@@ -123,6 +123,7 @@ class CreateView(TemplateResponseMixin, ContextMixin, HookResponseMixin, View):
             subscription=self.subscription,
             parent_page=self.parent_page,
         )
+        self.edit_handler = self.edit_handler.bind_to(form=self.form)
 
         if self.form.is_valid():
             return self.form_valid(self.form)
@@ -301,7 +302,6 @@ class CreateView(TemplateResponseMixin, ContextMixin, HookResponseMixin, View):
             self.form,
         )
         self.has_unsaved_changes = True
-        self.edit_handler = self.edit_handler.bind_to(form=self.form)
 
         return self.render_to_response(self.get_context_data())
 

--- a/wagtail/admin/views/pages/edit.py
+++ b/wagtail/admin/views/pages/edit.py
@@ -486,6 +486,7 @@ class EditView(TemplateResponseMixin, ContextMixin, HookResponseMixin, View):
             subscription=self.subscription,
             parent_page=self.parent,
         )
+        self.edit_handler = self.edit_handler.bind_to(form=self.form)
 
         self.is_cancelling_workflow = (
             bool(self.request.POST.get("action-cancel-workflow"))
@@ -856,7 +857,6 @@ class EditView(TemplateResponseMixin, ContextMixin, HookResponseMixin, View):
         )
         self.has_unsaved_changes = True
 
-        self.edit_handler = self.edit_handler.bind_to(form=self.form)
         self.add_legacy_moderation_warning()
         self.page_for_status = self.get_page_for_status()
 


### PR DESCRIPTION
Until now, if `EditHandler`s used `on_form_bound()` to modify the form, these changes were only used for the GET requests. The `bind_to()` call for POST requests has been called after the validation process, so too late.

Hope this small change can make it into a release soon, as it would make tasks like disabling page fields on certain conditions a lot easier for us.

**TBD:** For the test I've duplicated the `clear_edit_handler`-decorator from https://github.com/wagtail/wagtail/pull/7538.
Since it is the 3rd copy of the decorator, it may be a good point to extract it into a module?