### PR TITLE
Follow-up fixes from documentation parser switch (recommonmark -> MyST)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
       # Only install if .venv wasn’t cached.
       - run: |
           if [[ ! -e ".venv" ]]; then
-              pipenv install -e .[testing]
+              pipenv install -e .[testing,docs]
           fi
       - save_cache:
           key: pipenv-v1-{{ checksum "setup.py" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,13 +22,8 @@ jobs:
       - run: pipenv run flake8
       - run: pipenv run isort --check-only --diff .
       - run: pipenv run black --target-version py37 --check --diff .
-      # Filter out known false positives, while preserving normal output and error codes.
-      # See https://github.com/motet-a/jinjalint/issues/18.
-      # And https://circleci.com/docs/2.0/configuration-reference/#default-shell-options.
       - run: git ls-files '*.html' | xargs pipenv run djhtml --check
-      - run:
-          shell: /bin/bash -e
-          command: pipenv run jinjalint --parse-only wagtail | grep -v 'welcome_page.html:6:76' | tee /dev/tty | wc -l | grep -q '0'
+      - run: pipenv run curlylint --parse-only wagtail
       - run: pipenv run doc8 docs
       - run: DATABASE_NAME=wagtail.db pipenv run python -u runtests.py
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -17,6 +17,8 @@ Changelog
  * Remove the legacy Hallo rich text editor as it has moved to an external package (LB (Ben Johnston))
  * Increase the size of checkboxes throughout the UI, and simplify their alignment (Steven Steinwand)
  * Adopt [MyST](https://myst-parser.readthedocs.io/en/latest/) for parsing documentation written in Markdown, replaces recommonmark (LB (Ben Johnston), Thibaud Colas)
+ * Installing docs extras requirements in CircleCI so issues with the docs requirements are picked up earlier (Thibaud Colas)
+ * Remove core usage of jinjalint and migrate to curlylint to resolve dependency incompatibility issues (Thibaud Colas)
  * Fix: When using `simple_translations` ensure that the user is redirected to the page edit view when submitting for a single locale (Mitchel Cabuloy)
  * Fix: When previewing unsaved changes to `Form` pages, ensure that all added fields are correctly shown in the preview (Joshua Munn)
  * Fix: When Documents (e.g. PDFs) have been configured to be served inline via `WAGTAILDOCS_CONTENT_TYPES` & `WAGTAILDOCS_INLINE_CONTENT_TYPES` ensure that the filename is correctly set in the `Content-Disposition` header so that saving the files will use the correct filename (John-Scott Atlakson)

--- a/Makefile
+++ b/Makefile
@@ -20,9 +20,7 @@ lint:
 	black --target-version py37 --check --diff .
 	flake8
 	isort --check-only --diff .
-	# Filter out known false positives, while preserving normal output and error codes.
-	# See https://github.com/motet-a/jinjalint/issues/18.
-	jinjalint --parse-only wagtail | grep -v 'welcome_page.html:6:76' | tee /dev/tty | wc -l | grep -q '0'
+	curlylint --parse-only wagtail
 	git ls-files '*.html' | xargs djhtml --check
 	npm run lint:css --silent
 	npm run lint:js --silent

--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -1,3 +1,14 @@
+/* Add additional spacing between sections using semantic section elements, until we update sphinx-wagtail-theme */
+section {
+  margin-top: 2.5rem;
+  margin-bottom: 2.5rem;
+}
+
+/* Workaround for https://github.com/executablebooks/MyST-Parser/issues/533 */
+li > p {
+  margin-bottom: 0;
+}
+
 /* Wagtail Space */
 .wagtailspace {
   background: #00676a;

--- a/docs/contributing/documentation_guidelines.md
+++ b/docs/contributing/documentation_guidelines.md
@@ -206,31 +206,25 @@ With its [autodoc](https://www.sphinx-doc.org/en/master/usage/extensions/autodoc
 
 ### Tables
 
-Only use tables when needed, with the “simple” reStructuredText syntax, which is hard enough to format as it is.
+Only use tables when needed, using the [GitHub Flavored Markdown table syntax](https://github.github.com/gfm/#tables-extension-).
 
-    ```{eval-rst}
-    =============  =============
-    Browser        Device/OS    
-    =============  =============
-    Stock browser  Android      
-    IE             Desktop      
-    Safari         Windows      
-    =============  =============
-    ```
+```md
+| Browser       | Device/OS |
+| ------------- | --------- |
+| Stock browser | Android   |
+| IE            | Desktop   |
+| Safari        | Windows   |
+```
 
 <details>
 
 <summary>Rendered output</summary>
 
-```{eval-rst}
-=============  =============
-Browser        Device/OS    
-=============  =============
-Stock browser  Android      
-IE             Desktop      
-Safari         Windows      
-=============  =============
-```
+| Browser       | Device/OS |
+| ------------- | --------- |
+| Stock browser | Android   |
+| IE            | Desktop   |
+| Safari        | Windows   |
 
 </details>
 

--- a/docs/contributing/html_guidelines.rst
+++ b/docs/contributing/html_guidelines.rst
@@ -6,7 +6,7 @@ We use `Django templates <https://docs.djangoproject.com/en/stable/ref/templates
 Linting HTML
 ~~~~~~~~~~~~
 
-We use `jinjalint <https://github.com/motet-a/jinjalint>`_ to lint templates and `djhtml <https://github.com/rtts/djhtml>`_ to format them.
+We use `curlylint <https://www.curlylint.org/>`_ to lint templates and `djhtml <https://github.com/rtts/djhtml>`_ to format them.
 If you have installed Wagtail's testing dependencies (``pip install -e .[testing]``), you can check your code by running ``make lint``, and format your code by running ``make format``.
 
 Principles

--- a/docs/releases/2.17.md
+++ b/docs/releases/2.17.md
@@ -37,6 +37,8 @@ The panel types `StreamFieldPanel`, `RichTextFieldPanel`, `ImageChooserPanel`, `
  * Remove the legacy Hallo rich text editor as it has moved to an external package (LB (Ben Johnston))
  * Increase the size of checkboxes throughout the UI, and simplify their alignment (Steven Steinwand)
  * Adopt [MyST](https://myst-parser.readthedocs.io/en/latest/) for parsing documentation written in Markdown, replaces recommonmark (LB (Ben Johnston), Thibaud Colas)
+ * Installing docs extras requirements in CircleCI so issues with the docs requirements are picked up earlier (Thibaud Colas)
+ * Remove core usage of jinjalint and migrate to curlylint to resolve dependency incompatibility issues (Thibaud Colas)
 
 
 ### Bug fixes
@@ -87,3 +89,8 @@ As of this release, the use of special-purpose field panel types such as `Stream
  * If the panel provides a `get_comparison_class` method, your code should instead call `wagtail.admin.compare.register_comparison_class` to register the comparison class against the relevant model field type.
 
 If you do continue to use a custom panel class, note that the template context for panels derived from `BaseChooserPanel` has changed - the context variable `is_chosen`, and the variable name given by the panel's `object_type_name` property, are no longer available on the template. The only available variables are now `field` and `show_add_comment_button`. If your template depends on these additional variables, you will need to pass them explicitly by overriding the `render_as_field` method.
+
+### jinjalint replaced with curlylint
+
+* Jinjalint is no longer actively maintained so the core Wagtail code has moved to a fork of this project [`curlylint`](https://github.com/thibaudcolas/curlylint).
+* If your usage of Wagtail relies on the inclusion of [`jinjalint`](https://github.com/motet-a/jinjalint), you will now need to explicitly include this as a separate dependency.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,2 @@
-docutils==0.17
 myst_parser==0.17.0
 sphinx-wagtail-theme==5.0.4

--- a/setup.py
+++ b/setup.py
@@ -66,8 +66,6 @@ testing_extras = [
     "jinjalint>=0.5",
     # For template indenting
     "djhtml==1.4.13",
-    # Pipenv hack to fix broken dependency causing CircleCI failures
-    "docutils==0.15",
     # for validating string formats in .po translation files
     "polib>=1.1,<2.0",
 ]

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ testing_extras = [
     "doc8==0.8.1",
     "flake8-assertive==2.0.0",
     # For templates linting
-    "jinjalint>=0.5",
+    "curlylint==0.13.0",
     # For template indenting
     "djhtml==1.4.13",
     # for validating string formats in .po translation files


### PR DESCRIPTION
Follow-up to #8084. Fixes #8099. There are a lot of assorted changes here. Here are the ones related to #8099:

- Installing our `docs` extras in CircleCI so issues like #8099 are picked up by CI tests
- Switching from jinjalint to curlylint to fix the actual dependency incompatibility issue

Since curlylint is a fork of jinjalint, it should work more or less the same as its predecessor for our current usage. Its usage of `attrs` (the dependency conflict in question) is very basic, so it supports all versions from 17 onwards.

And things I had picked up in #8084 but decided they weren’t worth waiting on:

- Adding spacing to fix the rendering issues with the new docs parser
- Switching to GFM Markdown tables rather than eval-rst for tables in Markdown documents

I have been investigating the spacing issue in https://github.com/executablebooks/MyST-Parser/issues/533, and it turns out it’s more complicated than initially thought, so I think we should go ahead with a CSS workaround even if inelegant.

---

I tested this all locally, but the real test here will be what happens in CircleCI and with our RTD build.