### PR TITLE
Bugfix for storage backends that overwrite old files using the same name

### DIFF
--- a/wagtail/documents/views/documents.py
+++ b/wagtail/documents/views/documents.py
@@ -195,10 +195,12 @@ def edit(request, document_id):
                 doc.save()
                 form.save_m2m()
 
-                # If providing a new document file, delete the old one.
+                # If providing a new document file, delete the old one, unless it has
+                # the same name. 3rd party storage backends might work that way
                 # NB Doing this via original_file.delete() clears the file field,
                 # which definitely isn't what we want...
-                original_file.storage.delete(original_file.name)
+                if original_file.name != doc.file.name:
+                    original_file.storage.delete(original_file.name)
             else:
                 doc = form.save()
 

--- a/wagtail/images/views/images.py
+++ b/wagtail/images/views/images.py
@@ -159,10 +159,12 @@ def edit(request, image_id):
             form.save()
 
             if "file" in form.changed_data:
-                # if providing a new image file, delete the old one and all renditions.
+                # if providing a new image file, delete the old one (unless it has the
+                # same name) and all renditions.
                 # NB Doing this via original_file.delete() clears the file field,
                 # which definitely isn't what we want...
-                original_file.storage.delete(original_file.name)
+                if original_file.name != image.file.name:
+                    original_file.storage.delete(original_file.name)
                 image.renditions.all().delete()
 
             # Reindex the image to make sure all tags are indexed

--- a/wagtail/tests/dummy_overwriting_storage.py
+++ b/wagtail/tests/dummy_overwriting_storage.py
@@ -1,0 +1,21 @@
+# This file contains a file storage backend that overwrites old files using the same
+# name. This is e g the default setting for django_storages.S3Boto3Storage
+
+# The following behaviours have been changed in this backend:
+#  - .get_available_name returns the name unchanged
+#  - ._save is simplified to doing nothing but saving the file
+import os.path
+
+from django.core.files.storage import FileSystemStorage
+
+
+class DummyOverWritingFileStorage(FileSystemStorage):
+    """Mock storage class that does not change file names."""
+
+    def get_available_name(self, name, max_length=None):
+        return name
+
+    def _save(self, name, content):
+        full_path = self.path(name)
+        open(full_path, "wb").write(content.read())
+        return os.path.relpath(full_path, self.location)


### PR DESCRIPTION
If uploading image och document with the same name and storage backend doesn't change the filename, don't delete the old file, because it will really be the new one. 

Wagtail cannot rely on every backend behaving like the default `FileSystemStorage`. E g the default setting for django-storages' `S3Boto3Storage` is to overwrite with the same filename.

If changing the filename should be enforced, that needs to be checked somehow, but I think this is a better solution.
