### PR TITLE
Update InlinePanel for change in ClusterForm formsets/exclude_formsets semantics (EditHandler rewrite)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ except ImportError:
 
 install_requires = [
     "Django>=3.2,<4.1",
-    "django-modelcluster>=5.2,<6.0",
+    "django-modelcluster>=6.0,<7.0",
     "django-taggit>=2.0,<3.0",
     "django-treebeard>=4.5.1,<5.0",
     "djangorestframework>=3.11.1,<4.0",

--- a/wagtail/admin/edit_handlers.py
+++ b/wagtail/admin/edit_handlers.py
@@ -707,6 +707,7 @@ class InlinePanel(EditHandler):
                 "validate_min": self.min_num is not None,
                 "max_num": self.max_num,
                 "validate_max": self.max_num is not None,
+                "formsets": child_edit_handler.required_formsets(),
             }
         }
 

--- a/wagtail/admin/tests/test_edit_handlers.py
+++ b/wagtail/admin/tests/test_edit_handlers.py
@@ -57,7 +57,7 @@ class TestGetFormForModel(TestCase):
         ):
             edit_handler.get_form_class()
 
-    def test_get_form_for_model(self):
+    def test_get_form_for_model_without_formsets(self):
         EventPageForm = get_form_for_model(EventPage, form_class=WagtailAdminPageForm)
         form = EventPageForm()
 
@@ -72,6 +72,14 @@ class TestGetFormForModel(TestCase):
 
         # treebeard's 'path' field should be excluded
         self.assertNotIn("path", form.fields)
+
+    def test_get_form_for_model_with_formsets(self):
+        EventPageForm = get_form_for_model(
+            EventPage,
+            form_class=WagtailAdminPageForm,
+            formsets=["speakers", "related_links"],
+        )
+        form = EventPageForm()
 
         # all child relations become formsets by default
         self.assertIn("speakers", form.formsets)


### PR DESCRIPTION
django-modelcluster 6.0 is planned to include https://github.com/wagtail/django-modelcluster/pull/158, which changes the semantics of formsets/exclude_formsets so that a ClusterForm that specifies neither of them will have no formsets defined, rather than formsets for all child relations. (This corrects an implementation wart in the upcoming EditHandler refactor.) This doesn't affect Wagtail for the most part, because EditHandler passes an explicit formsets option - but nested InlinePanels currently rely on the old behaviour, because modelcluster <=5 provides no way to pass the inner panel's formset definition inside the outer one. We fix this by adding the necessary 'formsets' key introduced in https://github.com/wagtail/django-modelcluster/pull/158.