### PR TITLE
Introduce get_form_options to EditHandler API (EditHandler rewrite)

### DIFF
--- a/wagtail/admin/forms/pages.py
+++ b/wagtail/admin/forms/pages.py
@@ -135,11 +135,6 @@ class WagtailAdminPageForm(WagtailAdminModelForm):
     # Could be set to False by a subclass constructed by TabbedInterface
     show_comments_toggle = True
 
-    class Meta:
-        # (dealing with Treebeard's tree-related fields that really should have
-        # been editable=False)
-        exclude = ["content_type", "path", "depth", "numchild"]
-
     def __init__(
         self,
         data=None,

--- a/wagtail/admin/panels.py
+++ b/wagtail/admin/panels.py
@@ -397,6 +397,11 @@ class BaseFormEditHandler(PanelGroup):
     # WagtailAdminModelForm
     base_form_class = None
 
+    def __init__(self, *args, **kwargs):
+        self.base_form_class = kwargs.pop("base_form_class", None)
+        super().__init__(*args, **kwargs)
+        self.show_comments_toggle = "comment_notifications" in self.required_fields()
+
     def get_form_class(self):
         """
         Construct a form class that has all the fields and formsets named in
@@ -413,7 +418,7 @@ class BaseFormEditHandler(PanelGroup):
         model_form_class = getattr(self.model, "base_form_class", WagtailAdminModelForm)
         base_form_class = self.base_form_class or model_form_class
 
-        return get_form_for_model(
+        form_class = get_form_for_model(
             self.model,
             form_class=base_form_class,
             fields=self.required_fields(),
@@ -421,18 +426,6 @@ class BaseFormEditHandler(PanelGroup):
             widgets=self.widget_overrides(),
             field_permissions=self.field_permissions(),
         )
-
-
-class TabbedInterface(BaseFormEditHandler):
-    template = "wagtailadmin/panels/tabbed_interface.html"
-
-    def __init__(self, *args, **kwargs):
-        self.base_form_class = kwargs.pop("base_form_class", None)
-        super().__init__(*args, **kwargs)
-        self.show_comments_toggle = "comment_notifications" in self.required_fields()
-
-    def get_form_class(self):
-        form_class = super().get_form_class()
 
         # Set show_comments_toggle attribute on form class
         return type(
@@ -447,7 +440,11 @@ class TabbedInterface(BaseFormEditHandler):
         return kwargs
 
 
-class ObjectList(TabbedInterface):
+class TabbedInterface(BaseFormEditHandler):
+    template = "wagtailadmin/panels/tabbed_interface.html"
+
+
+class ObjectList(BaseFormEditHandler):
     template = "wagtailadmin/panels/object_list.html"
 
 

--- a/wagtail/admin/panels.py
+++ b/wagtail/admin/panels.py
@@ -426,15 +426,10 @@ class BaseFormEditHandler(PanelGroup):
 class TabbedInterface(BaseFormEditHandler):
     template = "wagtailadmin/panels/tabbed_interface.html"
 
-    def __init__(self, *args, show_comments_toggle=None, **kwargs):
+    def __init__(self, *args, **kwargs):
         self.base_form_class = kwargs.pop("base_form_class", None)
         super().__init__(*args, **kwargs)
-        if show_comments_toggle is not None:
-            self.show_comments_toggle = show_comments_toggle
-        else:
-            self.show_comments_toggle = (
-                "comment_notifications" in self.required_fields()
-            )
+        self.show_comments_toggle = "comment_notifications" in self.required_fields()
 
     def get_form_class(self):
         form_class = super().get_form_class()
@@ -449,7 +444,6 @@ class TabbedInterface(BaseFormEditHandler):
     def clone_kwargs(self):
         kwargs = super().clone_kwargs()
         kwargs["base_form_class"] = self.base_form_class
-        kwargs["show_comments_toggle"] = self.show_comments_toggle
         return kwargs
 
 

--- a/wagtail/admin/panels.py
+++ b/wagtail/admin/panels.py
@@ -499,27 +499,28 @@ class HelpPanel(Panel):
 class FieldPanel(Panel):
     TEMPLATE_VAR = "field_panel"
 
-    def __init__(self, field_name, *args, **kwargs):
-        widget = kwargs.pop("widget", None)
-        if widget is not None:
-            self.widget = widget
-        self.permission = kwargs.pop("permission", None)
-        self.disable_comments = kwargs.pop("disable_comments", None)
-        super().__init__(*args, **kwargs)
+    def __init__(
+        self, field_name, widget=None, disable_comments=None, permission=None, **kwargs
+    ):
+        super().__init__(**kwargs)
         self.field_name = field_name
+        self.widget = widget
+        self.disable_comments = disable_comments
+        self.permission = permission
 
     def clone_kwargs(self):
         kwargs = super().clone_kwargs()
         kwargs.update(
             field_name=self.field_name,
-            widget=self.widget if hasattr(self, "widget") else None,
+            widget=self.widget,
+            disable_comments=self.disable_comments,
             permission=self.permission,
         )
         return kwargs
 
     def widget_overrides(self):
         """check if a specific widget has been defined for this field"""
-        if hasattr(self, "widget"):
+        if self.widget:
             return {self.field_name: self.widget}
         return {}
 

--- a/wagtail/admin/panels.py
+++ b/wagtail/admin/panels.py
@@ -165,15 +165,6 @@ class Panel:
             )
             options["formsets"] = self.required_formsets()
 
-        if not getattr(self.field_permissions, "is_original_method", False):
-            warn(
-                "The `field_permissions` method (on %r) is deprecated; "
-                "these should be returned from `get_form_options` as a "
-                "`field_permissions` item instead." % type(self),
-                category=RemovedInWagtail219Warning,
-            )
-            options["field_permissions"] = self.field_permissions()
-
         return options
 
     # RemovedInWagtail219Warning - edit handlers should override get_form_options instead
@@ -193,13 +184,6 @@ class Panel:
         return {}
 
     required_formsets.is_original_method = True
-
-    # return a dict mapping field name to the permission codename that a user must have for that
-    # field to be included in the form
-    def field_permissions(self):
-        return {}
-
-    field_permissions.is_original_method = True
 
     # return any HTML that needs to be output on the edit page once per edit handler definition.
     # Typically this will be used to define snippets of HTML within <script type="text/x-template"></script> blocks

--- a/wagtail/admin/panels.py
+++ b/wagtail/admin/panels.py
@@ -45,39 +45,22 @@ def widget_with_script(widget, script):
 def get_form_for_model(
     model,
     form_class=WagtailAdminModelForm,
-    fields=None,
-    exclude=None,
-    formsets=None,
-    exclude_formsets=None,
-    widgets=None,
-    field_permissions=None,
+    **kwargs,
 ):
+    # django's modelform_factory, but accepting arbitrary kwargs to pass to
+    # the form's Meta class to support additions such as ClusterForm's `formsets`
+    # attribute
 
-    # django's modelform_factory with a bit of custom behaviour
-    attrs = {"model": model}
-    if fields is not None:
-        attrs["fields"] = fields
-    if exclude is not None:
-        attrs["exclude"] = exclude
-    if widgets is not None:
-        attrs["widgets"] = widgets
-    if formsets is not None:
-        attrs["formsets"] = formsets
-    if exclude_formsets is not None:
-        attrs["exclude_formsets"] = exclude_formsets
-    if field_permissions is not None:
-        attrs["field_permissions"] = field_permissions
+    meta_class_attrs = kwargs
+    meta_class_attrs["model"] = model
 
     # Give this new form class a reasonable name.
-    class_name = model.__name__ + str("Form")
-    bases = (object,)
-    if hasattr(form_class, "Meta"):
-        bases = (form_class.Meta,) + bases
-
-    form_class_attrs = {"Meta": type(str("Meta"), bases, attrs)}
+    class_name = model.__name__ + "Form"
+    bases = (form_class.Meta,) if hasattr(form_class, "Meta") else ()
+    Meta = type("Meta", bases, meta_class_attrs)
+    form_class_attrs = {"Meta": Meta}
 
     metaclass = type(form_class)
-
     return metaclass(class_name, (form_class,), form_class_attrs)
 
 

--- a/wagtail/admin/panels.py
+++ b/wagtail/admin/panels.py
@@ -611,11 +611,6 @@ class FieldPanel(Panel):
         return [self.field_name]
 
     def get_comparison_class(self):
-        # Hide fields with hidden widget
-        widget_override = self.widget_overrides().get(self.field_name, None)
-        if widget_override and widget_override.is_hidden:
-            return
-
         try:
             field = self.db_field
 

--- a/wagtail/admin/tests/test_edit_handlers.py
+++ b/wagtail/admin/tests/test_edit_handlers.py
@@ -58,7 +58,11 @@ class TestGetFormForModel(TestCase):
             edit_handler.get_form_class()
 
     def test_get_form_for_model_without_formsets(self):
-        EventPageForm = get_form_for_model(EventPage, form_class=WagtailAdminPageForm)
+        EventPageForm = get_form_for_model(
+            EventPage,
+            form_class=WagtailAdminPageForm,
+            fields=["title", "slug", "date_from", "date_to"],
+        )
         form = EventPageForm()
 
         # form should be a subclass of WagtailAdminModelForm
@@ -77,6 +81,7 @@ class TestGetFormForModel(TestCase):
         EventPageForm = get_form_for_model(
             EventPage,
             form_class=WagtailAdminPageForm,
+            fields=["title", "slug", "date_from", "date_to"],
             formsets=["speakers", "related_links"],
         )
         form = EventPageForm()
@@ -89,7 +94,12 @@ class TestGetFormForModel(TestCase):
         # Test that field overrides defined through DIRECT_FORM_FIELD_OVERRIDES
         # are applied
 
-        SimplePageForm = get_form_for_model(SimplePage, form_class=WagtailAdminPageForm)
+        SimplePageForm = get_form_for_model(
+            SimplePage,
+            form_class=WagtailAdminPageForm,
+            fields=["title", "slug", "content"],
+        )
+        self.assertTrue(issubclass(SimplePageForm, WagtailAdminPageForm))
         simple_form = SimplePageForm()
         # plain TextFields should use AdminAutoHeightTextInput as the widget
         self.assertEqual(
@@ -98,7 +108,9 @@ class TestGetFormForModel(TestCase):
 
         # This override should NOT be applied to subclasses of TextField such as
         # RichTextField - they should retain their default widgets
-        EventPageForm = get_form_for_model(EventPage, form_class=WagtailAdminPageForm)
+        EventPageForm = get_form_for_model(
+            EventPage, form_class=WagtailAdminPageForm, fields=["title", "slug", "body"]
+        )
         event_form = EventPageForm()
         self.assertEqual(type(event_form.fields["body"].widget), DraftailRichTextArea)
 
@@ -134,9 +146,6 @@ class TestGetFormForModel(TestCase):
         self.assertEqual(type(form.fields["date_from"].widget), AdminDateInput)
         self.assertNotIn("title", form.fields)
 
-        # 'path' is not excluded any more, as the excluded fields were overridden
-        self.assertIn("path", form.fields)
-
         # formsets should include speakers but not related_links
         self.assertIn("speakers", form.formsets)
         self.assertNotIn("related_links", form.formsets)
@@ -145,6 +154,7 @@ class TestGetFormForModel(TestCase):
         EventPageForm = get_form_for_model(
             EventPage,
             form_class=WagtailAdminPageForm,
+            fields=["date_to", "date_from"],
             widgets={"date_from": forms.PasswordInput},
         )
         form = EventPageForm()
@@ -156,6 +166,7 @@ class TestGetFormForModel(TestCase):
         EventPageForm = get_form_for_model(
             EventPage,
             form_class=WagtailAdminPageForm,
+            fields=["date_to", "date_from"],
             widgets={"date_from": forms.PasswordInput()},
         )
         form = EventPageForm()
@@ -165,7 +176,9 @@ class TestGetFormForModel(TestCase):
 
     def test_tag_widget_is_passed_tag_model(self):
         RestaurantPageForm = get_form_for_model(
-            RestaurantPage, form_class=WagtailAdminPageForm
+            RestaurantPage,
+            form_class=WagtailAdminPageForm,
+            fields=["title", "slug", "tags"],
         )
         form_html = RestaurantPageForm().as_p()
         self.assertIn("/admin/tag\\u002Dautocomplete/tests/restauranttag/", form_html)
@@ -481,7 +494,10 @@ class TestFieldPanel(TestCase):
         self.request.user = user
 
         self.EventPageForm = get_form_for_model(
-            EventPage, form_class=WagtailAdminPageForm, formsets=[]
+            EventPage,
+            form_class=WagtailAdminPageForm,
+            fields=["title", "slug", "date_from", "date_to"],
+            formsets=[],
         )
         self.event = EventPage(
             title="Abergavenny sheepdog trials",
@@ -629,7 +645,10 @@ class TestFieldRowPanel(TestCase):
         self.request.user = user
 
         self.EventPageForm = get_form_for_model(
-            EventPage, form_class=WagtailAdminPageForm, formsets=[]
+            EventPage,
+            form_class=WagtailAdminPageForm,
+            fields=["title", "slug", "date_from", "date_to"],
+            formsets=[],
         )
         self.event = EventPage(
             title="Abergavenny sheepdog trials",
@@ -773,7 +792,10 @@ class TestFieldRowPanelWithChooser(TestCase):
         self.request.user = user
 
         self.EventPageForm = get_form_for_model(
-            EventPage, form_class=WagtailAdminPageForm, formsets=[]
+            EventPage,
+            form_class=WagtailAdminPageForm,
+            fields=["title", "slug", "date_from", "date_to"],
+            formsets=[],
         )
         self.event = EventPage(
             title="Abergavenny sheepdog trials",

--- a/wagtail/contrib/forms/tests/test_views.py
+++ b/wagtail/contrib/forms/tests/test_views.py
@@ -42,7 +42,9 @@ class TestFormResponsesPanel(TestCase):
         self.form_page = make_form_page()
 
         self.FormPageForm = get_form_for_model(
-            FormPage, form_class=WagtailAdminPageForm
+            FormPage,
+            form_class=WagtailAdminPageForm,
+            fields=["title", "slug", "to_address", "from_address", "subject"],
         )
 
         self.panel = FormSubmissionsPanel().bind_to(
@@ -84,7 +86,9 @@ class TestFormResponsesPanelWithCustomSubmissionClass(TestCase, WagtailTestUtils
         self.form_page = make_form_page_with_custom_submission()
 
         self.FormPageForm = get_form_for_model(
-            FormPageWithCustomSubmission, form_class=WagtailAdminPageForm
+            FormPageWithCustomSubmission,
+            form_class=WagtailAdminPageForm,
+            fields=["title", "slug", "to_address", "from_address", "subject"],
         )
 
         self.test_user = self.create_user(username="user-n1kola", password="123")


### PR DESCRIPTION
Revise the EditHandler API so that rather than providing separate `required_fields`, `required_formsets`, `widget_overrides` and `field_permissions` methods that feed into `get_form_for_model` to construct a form class, there's a unified `get_form_options` method that returns a dict of options (including `fields`, `formsets`, `widgets` and `field_permissions`) to be set on the final form class's `class Meta`.

Incorporates #8191