### PR TITLE
Split out model binding from EditHandler.bind_to (EditHandler rewrite)

### DIFF
--- a/wagtail/admin/forms/comments.py
+++ b/wagtail/admin/forms/comments.py
@@ -6,14 +6,12 @@ from .models import WagtailAdminModelForm
 
 
 class CommentReplyForm(WagtailAdminModelForm):
-    user = None
-
     class Meta:
         fields = ("text",)
 
     def clean(self):
         cleaned_data = super().clean()
-        user = self.user
+        user = self.for_user
 
         if not self.instance.pk:
             self.instance.user = user
@@ -33,13 +31,19 @@ class CommentForm(WagtailAdminModelForm):
     This is designed to be subclassed and have the user overridden to enable user-based validation within the edit handler system
     """
 
-    user = None
-
     resolved = BooleanField(required=False)
+
+    class Meta:
+        formsets = {
+            "replies": {
+                "form": CommentReplyForm,
+                "inherit_kwargs": ["for_user"],
+            }
+        }
 
     def clean(self):
         cleaned_data = super().clean()
-        user = self.user
+        user = self.for_user
 
         if not self.instance.pk:
             self.instance.user = user
@@ -60,7 +64,7 @@ class CommentForm(WagtailAdminModelForm):
         if self.cleaned_data.get("resolved", False):
             if not getattr(self.instance, "resolved_at"):
                 self.instance.resolved_at = now()
-                self.instance.resolved_by = self.user
+                self.instance.resolved_by = self.for_user
         else:
             self.instance.resolved_by = None
             self.instance.resolved_at = None

--- a/wagtail/admin/forms/models.py
+++ b/wagtail/admin/forms/models.py
@@ -128,7 +128,10 @@ class WagtailAdminModelFormMetaclass(PermissionedFormMetaclass, ClusterFormMetac
 class WagtailAdminModelForm(
     PermissionedForm, ClusterForm, metaclass=WagtailAdminModelFormMetaclass
 ):
-    pass
+    def __init__(self, *args, **kwargs):
+        # keep hold of the `for_user` kwarg as well as passing it on to PermissionedForm
+        self.for_user = kwargs.get("for_user")
+        super().__init__(*args, **kwargs)
 
 
 # Now, any model forms built off WagtailAdminModelForm instead of ModelForm should pick up

--- a/wagtail/admin/forms/workflows.py
+++ b/wagtail/admin/forms/workflows.py
@@ -216,4 +216,4 @@ def get_workflow_edit_handler():
         ),
     ]
     edit_handler = ObjectList(panels, base_form_class=WagtailAdminModelForm)
-    return edit_handler.bind_to(model=Workflow)
+    return edit_handler.bind_to_model(Workflow)

--- a/wagtail/admin/panels.py
+++ b/wagtail/admin/panels.py
@@ -18,7 +18,7 @@ from django.utils.translation import gettext_lazy
 from modelcluster.models import get_serializable_data_for_fields
 
 from wagtail.admin import compare
-from wagtail.admin.forms.comments import CommentForm, CommentReplyForm
+from wagtail.admin.forms.comments import CommentForm
 from wagtail.admin.templatetags.wagtailadmin_tags import avatar_url, user_display_name
 from wagtail.admin.widgets import AdminPageChooser
 from wagtail.blocks import BlockField
@@ -965,29 +965,16 @@ class PrivacyModalPanel(Panel):
 class CommentPanel(Panel):
     def get_form_options(self):
         # add the comments formset
-        # we need to pass in the current user for validation on the formset
-        # this could alternatively be done on the page form itself if we added the
-        # comments formset there, but we typically only add fields via edit handlers
-        current_user = getattr(self.request, "user", None)
-
-        class CommentReplyFormWithRequest(CommentReplyForm):
-            user = current_user
-
-        class CommentFormWithRequest(CommentForm):
-            user = current_user
-
-            class Meta:
-                formsets = {"replies": {"form": CommentReplyFormWithRequest}}
-
         return {
             # Adds the comment notifications field to the form.
             # Note, this field is defined directly on WagtailAdminPageForm.
             "fields": ["comment_notifications"],
             "formsets": {
                 COMMENTS_RELATION_NAME: {
-                    "form": CommentFormWithRequest,
+                    "form": CommentForm,
                     "fields": ["text", "contentpath", "position"],
                     "formset_name": "comments",
+                    "inherit_kwargs": ["for_user"],
                 }
             },
         }

--- a/wagtail/admin/tests/pages/test_preview.py
+++ b/wagtail/admin/tests/pages/test_preview.py
@@ -1,16 +1,14 @@
 import datetime
 from functools import wraps
-from unittest import mock
 
 from django.test import TestCase
 from django.urls import reverse
 from django.utils import timezone
 from freezegun import freeze_time
 
-from wagtail.admin.panels import FieldPanel, ObjectList, TabbedInterface
 from wagtail.admin.views.pages.preview import PreviewOnEdit
 from wagtail.models import Page
-from wagtail.test.testapp.models import EventCategory, EventPage, SimplePage, StreamPage
+from wagtail.test.testapp.models import EventCategory, SimplePage, StreamPage
 from wagtail.test.utils import WagtailTestUtils
 
 
@@ -203,97 +201,6 @@ class TestPreview(TestCase, WagtailTestUtils):
             self.assertEqual(response.status_code, 200)
             response = self.client.get(preview_url)
             self.assertEqual(response.status_code, 200)
-
-    @clear_edit_handler(EventPage)
-    def test_preview_with_custom_edit_handler(self):
-        """
-        The test is based on TestPreview.test_preview_on_create_with_m2m_field, except that the "categories"
-        FieldPanel is only visible to superusers. Non-superusers should not be able to set "categories" for
-        the preview.
-        """
-
-        class SuperuserEventCategoriesObjectList(ObjectList):
-            def on_request_bound(self):
-                new_children = []
-                for child in self.children:
-                    # skip the "categories" FieldPanel for non-superusers
-                    if (
-                        isinstance(child, FieldPanel)
-                        and child.field_name == "categories"
-                        and not self.request.user.is_superuser
-                    ):
-                        continue
-
-                    new_child = child.bind_to(
-                        model=self.model,
-                        instance=self.instance,
-                        request=self.request,
-                        form=self.form,
-                    )
-                    new_children.append(new_child)
-                self.children = new_children
-
-        new_tabbed_interface = TabbedInterface(
-            [
-                SuperuserEventCategoriesObjectList(EventPage.content_panels),
-                ObjectList(EventPage.promote_panels),
-            ]
-        )
-
-        with mock.patch.object(
-            EventPage, "edit_handler", new=new_tabbed_interface, create=True
-        ):
-            # Non-superusers should not see categories panel, so even though "post_data" contains "categories",
-            # it should not be considered for the preview request.
-            self.login(username="siteeditor", password="password")
-
-            preview_url = reverse(
-                "wagtailadmin_pages:preview_on_add",
-                args=("tests", "eventpage", self.home_page.id),
-            )
-            response = self.client.post(preview_url, self.post_data)
-
-            # Check the JSON response
-            self.assertEqual(response.status_code, 200)
-            self.assertJSONEqual(response.content.decode(), {"is_valid": True})
-
-            # Check the user can refresh the preview
-            preview_session_key = "wagtail-preview-tests-eventpage-{}".format(
-                self.home_page.id
-            )
-            self.assertIn(preview_session_key, self.client.session)
-
-            response = self.client.get(preview_url)
-
-            # Check the HTML response
-            self.assertEqual(response.status_code, 200)
-            self.assertTemplateUsed(response, "tests/event_page.html")
-            self.assertContains(response, "Beach party")
-            self.assertNotContains(response, "<li>Parties</li>")
-            self.assertNotContains(response, "<li>Holidays</li>")
-
-            # Since superusers see the "categories" panel, the posted data should be used for the preview.
-            self.login(username="superuser", password="password")
-            response = self.client.post(preview_url, self.post_data)
-
-            # Check the JSON response
-            self.assertEqual(response.status_code, 200)
-            self.assertJSONEqual(response.content.decode(), {"is_valid": True})
-
-            # Check the user can refresh the preview
-            preview_session_key = "wagtail-preview-tests-eventpage-{}".format(
-                self.home_page.id
-            )
-            self.assertIn(preview_session_key, self.client.session)
-
-            response = self.client.get(preview_url)
-
-            # Check the HTML response
-            self.assertEqual(response.status_code, 200)
-            self.assertTemplateUsed(response, "tests/event_page.html")
-            self.assertContains(response, "Beach party")
-            self.assertContains(response, "<li>Parties</li>")
-            self.assertContains(response, "<li>Holidays</li>")
 
 
 class TestDisablePreviewButton(TestCase, WagtailTestUtils):

--- a/wagtail/admin/tests/test_edit_handlers.py
+++ b/wagtail/admin/tests/test_edit_handlers.py
@@ -53,7 +53,7 @@ class TestGetFormForModel(TestCase):
         with self.assertRaisesMessage(
             AttributeError,
             "ObjectList is not bound to a model yet. "
-            "Use `.bind_to(model=model)` before using this method.",
+            "Use `.bind_to_model(model)` before using this method.",
         ):
             edit_handler.get_form_class()
 
@@ -382,7 +382,7 @@ class TestTabbedInterface(TestCase):
                     heading="Speakers",
                 ),
             ]
-        ).bind_to(model=EventPage)
+        ).bind_to_model(EventPage)
 
     def test_get_form_class(self):
         EventPageForm = self.event_page_tabbed_interface.get_form_class()
@@ -472,7 +472,7 @@ class TestObjectList(TestCase):
             ],
             heading="Event details",
             classname="shiny",
-        ).bind_to(model=EventPage)
+        ).bind_to_model(EventPage)
 
     def test_get_form_class(self):
         EventPageForm = self.event_page_object_list.get_form_class()
@@ -534,14 +534,14 @@ class TestFieldPanel(TestCase):
             date_to=date(2014, 7, 21),
         )
 
-        self.end_date_panel = FieldPanel("date_to", classname="full-width").bind_to(
-            model=EventPage
-        )
+        self.end_date_panel = FieldPanel(
+            "date_to", classname="full-width"
+        ).bind_to_model(EventPage)
 
     def test_non_model_field(self):
         # defining a FieldPanel for a field which isn't part of a model is OK,
         # because it might be defined on the form instead
-        field_panel = FieldPanel("barbecue").bind_to(model=Page)
+        field_panel = FieldPanel("barbecue").bind_to_model(Page)
 
         # however, accessing db_field will fail
         with self.assertRaises(FieldDoesNotExist):
@@ -559,7 +559,7 @@ class TestFieldPanel(TestCase):
         # preference to the field's label
         end_date_panel_with_overridden_heading = FieldPanel(
             "date_to", classname="full-width", heading="New heading"
-        ).bind_to(model=EventPage)
+        ).bind_to_model(EventPage)
         end_date_panel_with_overridden_heading = (
             end_date_panel_with_overridden_heading.bind_to(
                 request=self.request, form=self.EventPageForm(), instance=self.event
@@ -702,7 +702,7 @@ class TestFieldRowPanel(TestCase):
                 FieldPanel("date_from", classname="col4", heading="Start"),
                 FieldPanel("date_to", classname="coltwo"),
             ]
-        ).bind_to(model=EventPage)
+        ).bind_to_model(EventPage)
 
     def test_render_as_object(self):
         form = self.EventPageForm(
@@ -854,7 +854,7 @@ class TestFieldRowPanelWithChooser(TestCase):
                 FieldPanel("date_from"),
                 FieldPanel("feed_image"),
             ]
-        ).bind_to(model=EventPage)
+        ).bind_to_model(EventPage)
 
     def test_render_as_object(self):
         form = self.EventPageForm(
@@ -893,8 +893,8 @@ class TestPageChooserPanel(TestCase):
         model = PageChooserModel  # a model with a foreign key to Page which we want to render as a page chooser
 
         # a PageChooserPanel class that works on PageChooserModel's 'page' field
-        self.edit_handler = ObjectList([PageChooserPanel("page")]).bind_to(
-            model=PageChooserModel
+        self.edit_handler = ObjectList([PageChooserPanel("page")]).bind_to_model(
+            PageChooserModel
         )
         self.my_page_chooser_panel = self.edit_handler.children[0]
 
@@ -927,7 +927,7 @@ class TestPageChooserPanel(TestCase):
 
         my_page_object_list = ObjectList(
             [PageChooserPanel("page", can_choose_root=True)]
-        ).bind_to(model=PageChooserModel)
+        ).bind_to_model(PageChooserModel)
         my_page_chooser_panel = my_page_object_list.children[0]
         PageChooserForm = my_page_object_list.get_form_class()
 
@@ -981,7 +981,7 @@ class TestPageChooserPanel(TestCase):
         # to restrict the chooser to that page type
         my_page_object_list = ObjectList(
             [PageChooserPanel("page", "tests.EventPage")]
-        ).bind_to(model=EventPageChooserModel)
+        ).bind_to_model(EventPageChooserModel)
         my_page_chooser_panel = my_page_object_list.children[0]
         PageChooserForm = my_page_object_list.get_form_class()
         form = PageChooserForm(instance=self.test_instance)
@@ -999,8 +999,8 @@ class TestPageChooserPanel(TestCase):
     def test_autodetect_page_type(self):
         # Model has a foreign key to EventPage, which we want to autodetect
         # instead of specifying the page type in PageChooserPanel
-        my_page_object_list = ObjectList([PageChooserPanel("page")]).bind_to(
-            model=EventPageChooserModel,
+        my_page_object_list = ObjectList([PageChooserPanel("page")]).bind_to_model(
+            EventPageChooserModel,
         )
         my_page_chooser_panel = my_page_object_list.children[0]
         PageChooserForm = my_page_object_list.get_form_class()
@@ -1017,19 +1017,19 @@ class TestPageChooserPanel(TestCase):
         self.assertIn(expected_js, result)
 
     def test_target_models(self):
-        panel = PageChooserPanel("page", "wagtailcore.site").bind_to(
-            model=PageChooserModel
+        panel = PageChooserPanel("page", "wagtailcore.site").bind_to_model(
+            PageChooserModel
         )
         widget = panel.get_form_options()["widgets"]["page"]
         self.assertEqual(widget.target_models, [Site])
 
     def test_target_models_malformed_type(self):
-        panel = PageChooserPanel("page", "snowman").bind_to(model=PageChooserModel)
+        panel = PageChooserPanel("page", "snowman").bind_to_model(PageChooserModel)
         self.assertRaises(ImproperlyConfigured, panel.get_form_options)
 
     def test_target_models_nonexistent_type(self):
-        panel = PageChooserPanel("page", "snowman.lorry").bind_to(
-            model=PageChooserModel
+        panel = PageChooserPanel("page", "snowman.lorry").bind_to_model(
+            PageChooserModel
         )
         self.assertRaises(ImproperlyConfigured, panel.get_form_options)
 
@@ -1053,7 +1053,7 @@ class TestInlinePanel(TestCase, WagtailTestUtils):
                     "speakers", label="Speakers", classname="classname-for-speakers"
                 )
             ]
-        ).bind_to(model=EventPage)
+        ).bind_to_model(EventPage)
         EventPageForm = speaker_object_list.get_form_class()
 
         # SpeakerInlinePanel should instruct the form class to include a 'speakers' formset
@@ -1118,7 +1118,7 @@ class TestInlinePanel(TestCase, WagtailTestUtils):
                     ],
                 ),
             ]
-        ).bind_to(model=EventPage)
+        ).bind_to_model(EventPage)
         speaker_inline_panel = speaker_object_list.children[0]
         EventPageForm = speaker_object_list.get_form_class()
 
@@ -1198,7 +1198,7 @@ class TestInlinePanel(TestCase, WagtailTestUtils):
                     ],
                 ),
             ]
-        ).bind_to(model=EventPage)
+        ).bind_to_model(EventPage)
         speaker_inline_panel = speaker_object_list.children[0]
         EventPageForm = speaker_object_list.get_form_class()
         event_page = EventPage.objects.get(slug="christmas")
@@ -1315,9 +1315,9 @@ class TestCommentPanel(TestCase, WagtailTestUtils):
         self.request.user = self.commenting_user
 
         unbound_object_list = ObjectList([CommentPanel()])
-        self.object_list = unbound_object_list.bind_to(model=EventPage)
-        self.tabbed_interface = TabbedInterface([unbound_object_list]).bind_to(
-            model=EventPage
+        self.object_list = unbound_object_list.bind_to_model(EventPage)
+        self.tabbed_interface = TabbedInterface([unbound_object_list]).bind_to_model(
+            EventPage
         )
 
         self.EventPageForm = self.object_list.get_form_class()
@@ -1343,7 +1343,7 @@ class TestCommentPanel(TestCase, WagtailTestUtils):
 
         tabbed_interface_without_content_panel = TabbedInterface(
             [ObjectList(self.event_page.content_panels)]
-        ).bind_to(model=EventPage)
+        ).bind_to_model(EventPage)
         self.assertFalse(tabbed_interface_without_content_panel.show_comments_toggle)
 
     @override_settings(WAGTAILADMIN_COMMENTS_ENABLED=False)

--- a/wagtail/admin/tests/test_edit_handlers.py
+++ b/wagtail/admin/tests/test_edit_handlers.py
@@ -382,7 +382,7 @@ class TestTabbedInterface(TestCase):
                     heading="Speakers",
                 ),
             ]
-        ).bind_to(model=EventPage, request=self.request)
+        ).bind_to(model=EventPage)
 
     def test_get_form_class(self):
         EventPageForm = self.event_page_tabbed_interface.get_form_class()
@@ -402,6 +402,7 @@ class TestTabbedInterface(TestCase):
         tabbed_interface = self.event_page_tabbed_interface.bind_to(
             instance=event,
             form=form,
+            request=self.request,
         )
 
         result = tabbed_interface.render()
@@ -445,6 +446,7 @@ class TestTabbedInterface(TestCase):
         tabbed_interface = self.event_page_tabbed_interface.bind_to(
             instance=event,
             form=form,
+            request=self.request,
         )
 
         result = tabbed_interface.render_form_content()
@@ -470,7 +472,7 @@ class TestObjectList(TestCase):
             ],
             heading="Event details",
             classname="shiny",
-        ).bind_to(model=EventPage, request=self.request)
+        ).bind_to(model=EventPage)
 
     def test_get_form_class(self):
         EventPageForm = self.event_page_object_list.get_form_class()
@@ -490,6 +492,7 @@ class TestObjectList(TestCase):
         object_list = self.event_page_object_list.bind_to(
             instance=event,
             form=form,
+            request=self.request,
         )
 
         result = object_list.render()
@@ -532,7 +535,7 @@ class TestFieldPanel(TestCase):
         )
 
         self.end_date_panel = FieldPanel("date_to", classname="full-width").bind_to(
-            model=EventPage, request=self.request
+            model=EventPage
         )
 
     def test_non_model_field(self):
@@ -547,14 +550,21 @@ class TestFieldPanel(TestCase):
     def test_override_heading(self):
         # unless heading is specified in keyword arguments, an edit handler with bound form should take its
         # heading from the bound field label
-        bound_panel = self.end_date_panel.bind_to(form=self.EventPageForm())
+        bound_panel = self.end_date_panel.bind_to(
+            form=self.EventPageForm(), request=self.request, instance=self.event
+        )
         self.assertEqual(bound_panel.heading, bound_panel.bound_field.label)
 
         # if heading is explicitly provided to constructor, that heading should be taken in
         # preference to the field's label
         end_date_panel_with_overridden_heading = FieldPanel(
             "date_to", classname="full-width", heading="New heading"
-        ).bind_to(model=EventPage, request=self.request, form=self.EventPageForm())
+        ).bind_to(model=EventPage)
+        end_date_panel_with_overridden_heading = (
+            end_date_panel_with_overridden_heading.bind_to(
+                request=self.request, form=self.EventPageForm(), instance=self.event
+            )
+        )
         self.assertEqual(end_date_panel_with_overridden_heading.heading, "New heading")
         self.assertEqual(
             end_date_panel_with_overridden_heading.bound_field.label, "New heading"
@@ -575,6 +585,7 @@ class TestFieldPanel(TestCase):
         field_panel = self.end_date_panel.bind_to(
             instance=self.event,
             form=form,
+            request=self.request,
         )
         result = field_panel.render_as_object()
 
@@ -607,6 +618,7 @@ class TestFieldPanel(TestCase):
         field_panel = self.end_date_panel.bind_to(
             instance=self.event,
             form=form,
+            request=self.request,
         )
         result = field_panel.render_as_field()
 
@@ -642,6 +654,7 @@ class TestFieldPanel(TestCase):
         field_panel = self.end_date_panel.bind_to(
             instance=self.event,
             form=form,
+            request=self.request,
         )
         result = field_panel.render_as_field()
 
@@ -652,6 +665,8 @@ class TestFieldPanel(TestCase):
         form = self.EventPageForm()
         field_panel = self.end_date_panel.bind_to(
             form=form,
+            instance=self.event,
+            request=self.request,
         )
 
         field_panel_repr = repr(field_panel)
@@ -659,7 +674,7 @@ class TestFieldPanel(TestCase):
         self.assertIn(
             "model=<class 'wagtail.test.testapp.models.EventPage'>", field_panel_repr
         )
-        self.assertIn("instance=None", field_panel_repr)
+        self.assertIn("instance=Abergavenny sheepdog trials", field_panel_repr)
         self.assertIn("request=<WSGIRequest: GET '/'>", field_panel_repr)
         self.assertIn("form=EventPageForm", field_panel_repr)
 
@@ -687,7 +702,7 @@ class TestFieldRowPanel(TestCase):
                 FieldPanel("date_from", classname="col4", heading="Start"),
                 FieldPanel("date_to", classname="coltwo"),
             ]
-        ).bind_to(model=EventPage, request=self.request)
+        ).bind_to(model=EventPage)
 
     def test_render_as_object(self):
         form = self.EventPageForm(
@@ -704,6 +719,7 @@ class TestFieldRowPanel(TestCase):
         field_panel = self.dates_panel.bind_to(
             instance=self.event,
             form=form,
+            request=self.request,
         )
         result = field_panel.render_as_object()
 
@@ -728,6 +744,7 @@ class TestFieldRowPanel(TestCase):
         field_panel = self.dates_panel.bind_to(
             instance=self.event,
             form=form,
+            request=self.request,
         )
         result = field_panel.render_as_field()
 
@@ -762,6 +779,7 @@ class TestFieldRowPanel(TestCase):
         field_panel = self.dates_panel.bind_to(
             instance=self.event,
             form=form,
+            request=self.request,
         )
         result = field_panel.render_as_field()
 
@@ -783,6 +801,7 @@ class TestFieldRowPanel(TestCase):
         field_panel = self.dates_panel.bind_to(
             instance=self.event,
             form=form,
+            request=self.request,
         )
 
         result = field_panel.render_as_field()
@@ -804,6 +823,7 @@ class TestFieldRowPanel(TestCase):
         field_panel = self.dates_panel.bind_to(
             instance=self.event,
             form=form,
+            request=self.request,
         )
 
         result = field_panel.render_as_field()
@@ -834,7 +854,7 @@ class TestFieldRowPanelWithChooser(TestCase):
                 FieldPanel("date_from"),
                 FieldPanel("feed_image"),
             ]
-        ).bind_to(model=EventPage, request=self.request)
+        ).bind_to(model=EventPage)
 
     def test_render_as_object(self):
         form = self.EventPageForm(
@@ -851,6 +871,7 @@ class TestFieldRowPanelWithChooser(TestCase):
         field_panel = self.dates_panel.bind_to(
             instance=self.event,
             form=form,
+            request=self.request,
         )
         result = field_panel.render_as_object()
 
@@ -873,7 +894,7 @@ class TestPageChooserPanel(TestCase):
 
         # a PageChooserPanel class that works on PageChooserModel's 'page' field
         self.edit_handler = ObjectList([PageChooserPanel("page")]).bind_to(
-            model=PageChooserModel, request=self.request
+            model=PageChooserModel
         )
         self.my_page_chooser_panel = self.edit_handler.children[0]
 
@@ -887,7 +908,7 @@ class TestPageChooserPanel(TestCase):
 
         self.form = self.PageChooserForm(instance=self.test_instance)
         self.page_chooser_panel = self.my_page_chooser_panel.bind_to(
-            instance=self.test_instance, form=self.form
+            instance=self.test_instance, form=self.form, request=self.request
         )
 
     def test_page_chooser_uses_correct_widget(self):
@@ -979,13 +1000,13 @@ class TestPageChooserPanel(TestCase):
         # Model has a foreign key to EventPage, which we want to autodetect
         # instead of specifying the page type in PageChooserPanel
         my_page_object_list = ObjectList([PageChooserPanel("page")]).bind_to(
-            model=EventPageChooserModel, request=self.request
+            model=EventPageChooserModel,
         )
         my_page_chooser_panel = my_page_object_list.children[0]
         PageChooserForm = my_page_object_list.get_form_class()
         form = PageChooserForm(instance=self.test_instance)
         page_chooser_panel = my_page_chooser_panel.bind_to(
-            instance=self.test_instance, form=form
+            instance=self.test_instance, form=form, request=self.request
         )
 
         result = page_chooser_panel.render_as_field()
@@ -1032,7 +1053,7 @@ class TestInlinePanel(TestCase, WagtailTestUtils):
                     "speakers", label="Speakers", classname="classname-for-speakers"
                 )
             ]
-        ).bind_to(model=EventPage, request=self.request)
+        ).bind_to(model=EventPage)
         EventPageForm = speaker_object_list.get_form_class()
 
         # SpeakerInlinePanel should instruct the form class to include a 'speakers' formset
@@ -1041,7 +1062,9 @@ class TestInlinePanel(TestCase, WagtailTestUtils):
         event_page = EventPage.objects.get(slug="christmas")
 
         form = EventPageForm(instance=event_page)
-        panel = speaker_object_list.bind_to(instance=event_page, form=form)
+        panel = speaker_object_list.bind_to(
+            instance=event_page, form=form, request=self.request
+        )
 
         result = panel.render_as_field()
 
@@ -1095,7 +1118,7 @@ class TestInlinePanel(TestCase, WagtailTestUtils):
                     ],
                 ),
             ]
-        ).bind_to(model=EventPage, request=self.request)
+        ).bind_to(model=EventPage)
         speaker_inline_panel = speaker_object_list.children[0]
         EventPageForm = speaker_object_list.get_form_class()
 
@@ -1105,7 +1128,9 @@ class TestInlinePanel(TestCase, WagtailTestUtils):
         event_page = EventPage.objects.get(slug="christmas")
 
         form = EventPageForm(instance=event_page)
-        panel = speaker_inline_panel.bind_to(instance=event_page, form=form)
+        panel = speaker_inline_panel.bind_to(
+            instance=event_page, form=form, request=self.request
+        )
 
         result = panel.render_as_field()
 
@@ -1173,12 +1198,14 @@ class TestInlinePanel(TestCase, WagtailTestUtils):
                     ],
                 ),
             ]
-        ).bind_to(model=EventPage, request=self.request)
+        ).bind_to(model=EventPage)
         speaker_inline_panel = speaker_object_list.children[0]
         EventPageForm = speaker_object_list.get_form_class()
         event_page = EventPage.objects.get(slug="christmas")
         form = EventPageForm(instance=event_page)
-        panel = speaker_inline_panel.bind_to(instance=event_page, form=form)
+        panel = speaker_inline_panel.bind_to(
+            instance=event_page, form=form, request=self.request
+        )
 
         self.assertIn("maxForms: 1000", panel.render_js_init())
 

--- a/wagtail/admin/views/pages/create.py
+++ b/wagtail/admin/views/pages/create.py
@@ -101,9 +101,6 @@ class CreateView(TemplateResponseMixin, ContextMixin, HookResponseMixin, View):
         self.page = self.page_class(owner=self.request.user)
         self.page.locale = self.locale
         self.edit_handler = self.page_class.get_edit_handler()
-        self.edit_handler = self.edit_handler.bind_to(
-            request=self.request, instance=self.page
-        )
         self.form_class = self.edit_handler.get_form_class()
 
         # Note: Comment notifications should be enabled by default for pages that a user creates
@@ -302,7 +299,6 @@ class CreateView(TemplateResponseMixin, ContextMixin, HookResponseMixin, View):
             self.form,
         )
         self.has_unsaved_changes = True
-        self.edit_handler = self.edit_handler.bind_to(form=self.form)
 
         return self.render_to_response(self.get_context_data())
 
@@ -317,18 +313,20 @@ class CreateView(TemplateResponseMixin, ContextMixin, HookResponseMixin, View):
             for_user=self.request.user,
         )
         self.has_unsaved_changes = False
-        self.edit_handler = self.edit_handler.bind_to(form=self.form)
 
         return self.render_to_response(self.get_context_data())
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
+        bound_panel = self.edit_handler.bind_to(
+            request=self.request, instance=self.page, form=self.form
+        )
         context.update(
             {
                 "content_type": self.page_content_type,
                 "page_class": self.page_class,
                 "parent_page": self.parent_page,
-                "edit_handler": self.edit_handler,
+                "edit_handler": bound_panel,
                 "action_menu": PageActionMenu(
                     self.request, view="create", parent_page=self.parent_page
                 ),

--- a/wagtail/admin/views/pages/edit.py
+++ b/wagtail/admin/views/pages/edit.py
@@ -351,9 +351,6 @@ class EditView(TemplateResponseMixin, ContextMixin, HookResponseMixin, View):
             )
 
         self.edit_handler = self.page_class.get_edit_handler()
-        self.edit_handler = self.edit_handler.bind_to(
-            instance=self.page, request=self.request
-        )
         self.form_class = self.edit_handler.get_form_class()
 
         if getattr(settings, "WAGTAIL_WORKFLOW_ENABLED", True):
@@ -456,7 +453,6 @@ class EditView(TemplateResponseMixin, ContextMixin, HookResponseMixin, View):
             for_user=self.request.user,
         )
         self.has_unsaved_changes = False
-        self.edit_handler = self.edit_handler.bind_to(form=self.form)
         self.add_legacy_moderation_warning()
         self.page_for_status = self.get_page_for_status()
 
@@ -860,7 +856,6 @@ class EditView(TemplateResponseMixin, ContextMixin, HookResponseMixin, View):
         )
         self.has_unsaved_changes = True
 
-        self.edit_handler = self.edit_handler.bind_to(form=self.form)
         self.add_legacy_moderation_warning()
         self.page_for_status = self.get_page_for_status()
 
@@ -868,12 +863,15 @@ class EditView(TemplateResponseMixin, ContextMixin, HookResponseMixin, View):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
+        bound_panel = self.edit_handler.bind_to(
+            instance=self.page, request=self.request, form=self.form
+        )
         context.update(
             {
                 "page": self.page,
                 "page_for_status": self.page_for_status,
                 "content_type": self.page_content_type,
-                "edit_handler": self.edit_handler,
+                "edit_handler": bound_panel,
                 "errors_debug": self.errors_debug,
                 "action_menu": PageActionMenu(
                     self.request, view="edit", page=self.page

--- a/wagtail/admin/views/pages/preview.py
+++ b/wagtail/admin/views/pages/preview.py
@@ -51,11 +51,7 @@ class PreviewOnEdit(View):
         ).get_latest_revision_as_page()
 
     def get_form(self, page, query_dict):
-        form_class = (
-            page.get_edit_handler()
-            .bind_to(instance=page, request=self.request)
-            .get_form_class()
-        )
+        form_class = page.get_edit_handler().get_form_class()
         parent_page = page.get_parent().specific
 
         if self.session_key not in self.request.session:

--- a/wagtail/admin/views/pages/revisions.py
+++ b/wagtail/admin/views/pages/revisions.py
@@ -32,11 +32,12 @@ def revisions_revert(request, page_id, revision_id):
     page_class = content_type.model_class()
 
     edit_handler = page_class.get_edit_handler()
-    edit_handler = edit_handler.bind_to(instance=revision_page, request=request)
     form_class = edit_handler.get_form_class()
 
     form = form_class(instance=revision_page)
-    edit_handler = edit_handler.bind_to(form=form)
+    edit_handler = edit_handler.bind_to(
+        instance=revision_page, request=request, form=form
+    )
 
     user_avatar = render_to_string(
         "wagtailadmin/shared/user_avatar.html", {"user": revision.user}
@@ -140,7 +141,9 @@ def revisions_compare(request, page_id, revision_id_a, revision_id_b):
         )
 
     comparison = (
-        page.get_edit_handler().bind_to(instance=page, request=request).get_comparison()
+        page.get_edit_handler()
+        .bind_to(instance=page, request=request, form=None)
+        .get_comparison()
     )
     comparison = [comp(revision_a, revision_b) for comp in comparison]
     comparison = [comp for comp in comparison if comp.has_changed()]

--- a/wagtail/admin/views/workflows.py
+++ b/wagtail/admin/views/workflows.py
@@ -80,18 +80,11 @@ class Create(CreateView):
 
     def get_edit_handler(self):
         if not self.edit_handler:
-            self.edit_handler = get_workflow_edit_handler().bind_to(
-                request=self.request
-            )
+            self.edit_handler = get_workflow_edit_handler()
         return self.edit_handler
 
     def get_form_class(self):
         return self.get_edit_handler().get_form_class()
-
-    def get_form(self, form_class=None):
-        form = super().get_form(form_class)
-        self.edit_handler = self.edit_handler.bind_to(form=form)
-        return form
 
     def get_pages_formset(self):
         if self.request.method == "POST":
@@ -103,7 +96,11 @@ class Create(CreateView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["edit_handler"] = self.edit_handler
+        form = context["form"]
+        bound_panel = self.edit_handler.bind_to(
+            form=form, instance=form.instance, request=self.request
+        )
+        context["edit_handler"] = bound_panel
         context["pages_formset"] = self.get_pages_formset()
         return context
 
@@ -156,18 +153,11 @@ class Edit(EditView):
 
     def get_edit_handler(self):
         if not self.edit_handler:
-            self.edit_handler = get_workflow_edit_handler().bind_to(
-                request=self.request
-            )
+            self.edit_handler = get_workflow_edit_handler()
         return self.edit_handler
 
     def get_form_class(self):
         return self.get_edit_handler().get_form_class()
-
-    def get_form(self, form_class=None):
-        form = super().get_form(form_class)
-        self.edit_handler = self.edit_handler.bind_to(form=form)
-        return form
 
     def get_pages_formset(self):
         if self.request.method == "POST":
@@ -187,7 +177,11 @@ class Edit(EditView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["edit_handler"] = self.edit_handler
+        form = context["form"]
+        bound_panel = self.edit_handler.bind_to(
+            form=form, instance=form.instance, request=self.request
+        )
+        context["edit_handler"] = bound_panel
         context["pages"] = self.get_paginated_pages()
         context["pages_formset"] = self.get_pages_formset()
         context["can_disable"] = (

--- a/wagtail/contrib/forms/tests/test_views.py
+++ b/wagtail/contrib/forms/tests/test_views.py
@@ -47,7 +47,8 @@ class TestFormResponsesPanel(TestCase):
             fields=["title", "slug", "to_address", "from_address", "subject"],
         )
 
-        self.panel = FormSubmissionsPanel().bind_to(
+        panel = FormSubmissionsPanel().bind_to(model=FormPage)
+        self.panel = panel.bind_to(
             instance=self.form_page, form=self.FormPageForm(), request=self.request
         )
 
@@ -93,7 +94,8 @@ class TestFormResponsesPanelWithCustomSubmissionClass(TestCase, WagtailTestUtils
 
         self.test_user = self.create_user(username="user-n1kola", password="123")
 
-        self.panel = FormSubmissionsPanel().bind_to(
+        panel = FormSubmissionsPanel().bind_to(model=FormPageWithCustomSubmission)
+        self.panel = panel.bind_to(
             instance=self.form_page, form=self.FormPageForm(), request=self.request
         )
 

--- a/wagtail/contrib/forms/tests/test_views.py
+++ b/wagtail/contrib/forms/tests/test_views.py
@@ -47,7 +47,7 @@ class TestFormResponsesPanel(TestCase):
             fields=["title", "slug", "to_address", "from_address", "subject"],
         )
 
-        panel = FormSubmissionsPanel().bind_to(model=FormPage)
+        panel = FormSubmissionsPanel().bind_to_model(FormPage)
         self.panel = panel.bind_to(
             instance=self.form_page, form=self.FormPageForm(), request=self.request
         )
@@ -94,7 +94,7 @@ class TestFormResponsesPanelWithCustomSubmissionClass(TestCase, WagtailTestUtils
 
         self.test_user = self.create_user(username="user-n1kola", password="123")
 
-        panel = FormSubmissionsPanel().bind_to(model=FormPageWithCustomSubmission)
+        panel = FormSubmissionsPanel().bind_to_model(FormPageWithCustomSubmission)
         self.panel = panel.bind_to(
             instance=self.form_page, form=self.FormPageForm(), request=self.request
         )

--- a/wagtail/contrib/modeladmin/options.py
+++ b/wagtail/contrib/modeladmin/options.py
@@ -451,7 +451,9 @@ class ModelAdmin(WagtailRegisterable):
         view_class = self.history_view_class
         return view_class.as_view(**kwargs)(request)
 
-    def get_edit_handler(self, instance, request):
+    # RemovedInWagtail219Warning - remove instance and request args, included here so that
+    # old-style super() calls will still work
+    def get_edit_handler(self, instance=None, request=None):
         """
         Returns the appropriate edit_handler for this modeladmin class.
         edit_handlers can be defined either on the model itself or on the

--- a/wagtail/contrib/modeladmin/tests/test_modeladmin_edit_handlers.py
+++ b/wagtail/contrib/modeladmin/tests/test_modeladmin_edit_handlers.py
@@ -80,7 +80,7 @@ class TestExtractPanelDefinitionsFromModelAdmin(TestCase, WagtailTestUtils):
         # edit_handler defined
         model_admin = PersonAdmin()
         edit_handler = model_admin.get_edit_handler()
-        edit_handler = edit_handler.bind_to(model=model_admin.model)
+        edit_handler = edit_handler.bind_to_model(model_admin.model)
         form_class = edit_handler.get_form_class()
         form = form_class()
         self.assertEqual(list(form.fields), ["first_name", "last_name", "phone_number"])
@@ -95,7 +95,7 @@ class TestExtractPanelDefinitionsFromModelAdmin(TestCase, WagtailTestUtils):
             FieldPanel("address"),
         ]
         edit_handler = model_admin.get_edit_handler()
-        edit_handler = edit_handler.bind_to(model=model_admin.model)
+        edit_handler = edit_handler.bind_to_model(model_admin.model)
         form_class = edit_handler.get_form_class()
         form = form_class()
         self.assertEqual(list(form.fields), ["last_name", "phone_number", "address"])
@@ -116,7 +116,7 @@ class TestExtractPanelDefinitionsFromModelAdmin(TestCase, WagtailTestUtils):
             ]
         )
         edit_handler = model_admin.get_edit_handler()
-        edit_handler = edit_handler.bind_to(model=model_admin.model)
+        edit_handler = edit_handler.bind_to_model(model_admin.model)
         form_class = edit_handler.get_form_class()
         form = form_class()
         self.assertEqual(list(form.fields), ["phone_number", "address"])

--- a/wagtail/contrib/modeladmin/tests/test_modeladmin_edit_handlers.py
+++ b/wagtail/contrib/modeladmin/tests/test_modeladmin_edit_handlers.py
@@ -4,7 +4,6 @@ from django.test import RequestFactory, TestCase
 
 from wagtail.admin.panels import FieldPanel, ObjectList, TabbedInterface
 from wagtail.contrib.modeladmin.views import CreateView
-from wagtail.test.modeladmintest.models import Person
 from wagtail.test.modeladmintest.wagtail_hooks import PersonAdmin
 from wagtail.test.utils import WagtailTestUtils
 
@@ -45,10 +44,8 @@ class TestExtractPanelDefinitionsFromModelAdmin(TestCase, WagtailTestUtils):
 
         edit_handler_call = mock_modeladmin_get_edit_handler.call_args_list[0]
         call_args, call_kwargs = edit_handler_call
-        # not using CreateView.get_instance since
-        # CreateView.get_instance always returns a new instance
-        self.assertEqual(type(call_kwargs["instance"]), Person)
-        self.assertEqual(call_kwargs["request"], request)
+        # as of Wagtail 2.17, ModelAdmin.get_edit_handler is NOT passed instance or request
+        self.assertEqual(call_kwargs, {})
 
     def test_model_panels(self):
         """loads the 'create' view and verifies that form fields are returned
@@ -82,7 +79,7 @@ class TestExtractPanelDefinitionsFromModelAdmin(TestCase, WagtailTestUtils):
         # form creation, since PersonAdmin has neither panels nor an
         # edit_handler defined
         model_admin = PersonAdmin()
-        edit_handler = model_admin.get_edit_handler(None, None)
+        edit_handler = model_admin.get_edit_handler()
         edit_handler = edit_handler.bind_to(model=model_admin.model)
         form_class = edit_handler.get_form_class()
         form = form_class()
@@ -97,7 +94,7 @@ class TestExtractPanelDefinitionsFromModelAdmin(TestCase, WagtailTestUtils):
             FieldPanel("phone_number"),
             FieldPanel("address"),
         ]
-        edit_handler = model_admin.get_edit_handler(None, None)
+        edit_handler = model_admin.get_edit_handler()
         edit_handler = edit_handler.bind_to(model=model_admin.model)
         form_class = edit_handler.get_form_class()
         form = form_class()
@@ -118,7 +115,7 @@ class TestExtractPanelDefinitionsFromModelAdmin(TestCase, WagtailTestUtils):
                 ),
             ]
         )
-        edit_handler = model_admin.get_edit_handler(None, None)
+        edit_handler = model_admin.get_edit_handler()
         edit_handler = edit_handler.bind_to(model=model_admin.model)
         form_class = edit_handler.get_form_class()
         form = form_class()

--- a/wagtail/contrib/modeladmin/views.py
+++ b/wagtail/contrib/modeladmin/views.py
@@ -175,7 +175,7 @@ class ModelFormView(WMABaseView, FormView):
                 category=RemovedInWagtail219Warning,
             )
 
-        return edit_handler.bind_to(model=self.model_admin.model)
+        return edit_handler.bind_to_model(self.model_admin.model)
 
     def get_form_class(self):
         return self.edit_handler.get_form_class()

--- a/wagtail/contrib/modeladmin/views.py
+++ b/wagtail/contrib/modeladmin/views.py
@@ -160,11 +160,9 @@ class ModelFormView(WMABaseView, FormView):
 
     def get_form(self):
         form = super().get_form()
-        self.edit_handler = self.edit_handler.bind_to(form=form)
         return form
 
     def get_edit_handler(self):
-        instance = self.get_instance()
         try:
             edit_handler = self.model_admin.get_edit_handler()
         except TypeError:
@@ -177,9 +175,7 @@ class ModelFormView(WMABaseView, FormView):
                 category=RemovedInWagtail219Warning,
             )
 
-        return edit_handler.bind_to(
-            model=self.model_admin.model, request=self.request, instance=instance
-        )
+        return edit_handler.bind_to(model=self.model_admin.model)
 
     def get_form_class(self):
         return self.edit_handler.get_form_class()
@@ -206,10 +202,14 @@ class ModelFormView(WMABaseView, FormView):
         if form is None:
             form = self.get_form()
 
+        bound_panel = self.edit_handler.bind_to(
+            form=form, instance=form.instance, request=self.request
+        )
+
         prepopulated_fields = self.get_prepopulated_fields(form)
         context = {
             "is_multipart": form.is_multipart(),
-            "edit_handler": self.edit_handler,
+            "edit_handler": bound_panel,
             "form": form,
             "prepopulated_fields": prepopulated_fields,
         }

--- a/wagtail/contrib/modeladmin/views.py
+++ b/wagtail/contrib/modeladmin/views.py
@@ -43,6 +43,7 @@ from wagtail.admin.views.generic.base import WagtailAdminTemplateMixin
 from wagtail.admin.views.mixins import SpreadsheetExportMixin
 from wagtail.log_actions import log
 from wagtail.log_actions import registry as log_registry
+from wagtail.utils.deprecation import RemovedInWagtail219Warning
 
 from .forms import ParentChooserForm
 
@@ -164,9 +165,18 @@ class ModelFormView(WMABaseView, FormView):
 
     def get_edit_handler(self):
         instance = self.get_instance()
-        edit_handler = self.model_admin.get_edit_handler(
-            instance=instance, request=self.request
-        )
+        try:
+            edit_handler = self.model_admin.get_edit_handler()
+        except TypeError:
+            edit_handler = self.model_admin.get_edit_handler(
+                instance=None, request=None
+            )
+            warnings.warn(
+                "%s.get_edit_handler should not accept instance or request arguments"
+                % type(self.model_admin).__name__,
+                category=RemovedInWagtail219Warning,
+            )
+
         return edit_handler.bind_to(
             model=self.model_admin.model, request=self.request, instance=instance
         )

--- a/wagtail/contrib/settings/views.py
+++ b/wagtail/contrib/settings/views.py
@@ -67,7 +67,6 @@ def edit(request, app_name, model_name, site_pk):
 
     instance = model.for_site(site)
     edit_handler = get_setting_edit_handler(model)
-    edit_handler = edit_handler.bind_to(instance=instance, request=request)
     form_class = edit_handler.get_form_class()
 
     if request.method == "POST":
@@ -93,7 +92,7 @@ def edit(request, app_name, model_name, site_pk):
     else:
         form = form_class(instance=instance, for_user=request.user)
 
-    edit_handler = edit_handler.bind_to(form=form)
+    edit_handler = edit_handler.bind_to(instance=instance, request=request, form=form)
 
     # Show a site switcher form if there are multiple sites
     site_switcher = None

--- a/wagtail/contrib/settings/views.py
+++ b/wagtail/contrib/settings/views.py
@@ -40,7 +40,7 @@ def get_setting_edit_handler(model):
     else:
         panels = extract_panel_definitions_from_model_class(model, ["site"])
         edit_handler = ObjectList(panels)
-    return edit_handler.bind_to(model=model)
+    return edit_handler.bind_to_model(model)
 
 
 def edit_current_site(request, app_name, model_name):

--- a/wagtail/snippets/tests.py
+++ b/wagtail/snippets/tests.py
@@ -1339,8 +1339,8 @@ class TestSnippetChooserPanel(TestCase, WagtailTestUtils):
         )
 
     def test_target_model_autodetected(self):
-        edit_handler = ObjectList([FieldPanel("advert")]).bind_to(
-            model=SnippetChooserModel
+        edit_handler = ObjectList([FieldPanel("advert")]).bind_to_model(
+            SnippetChooserModel
         )
         form_class = edit_handler.get_form_class()
         form = form_class()
@@ -2194,9 +2194,9 @@ class TestSnippetChooserPanelWithCustomPrimaryKey(TestCase, WagtailTestUtils):
         )
 
     def test_target_model_autodetected(self):
-        edit_handler = ObjectList([FieldPanel("advertwithcustomprimarykey")]).bind_to(
-            model=SnippetChooserModelWithCustomPrimaryKey
-        )
+        edit_handler = ObjectList(
+            [FieldPanel("advertwithcustomprimarykey")]
+        ).bind_to_model(SnippetChooserModelWithCustomPrimaryKey)
         form_class = edit_handler.get_form_class()
         form = form_class()
         widget = form.fields["advertwithcustomprimarykey"].widget

--- a/wagtail/snippets/views/snippets.py
+++ b/wagtail/snippets/views/snippets.py
@@ -60,7 +60,7 @@ def get_snippet_edit_handler(model):
             panels = extract_panel_definitions_from_model_class(model)
             edit_handler = ObjectList(panels)
 
-        SNIPPET_EDIT_HANDLERS[model] = edit_handler.bind_to(model=model)
+        SNIPPET_EDIT_HANDLERS[model] = edit_handler.bind_to_model(model)
 
     return SNIPPET_EDIT_HANDLERS[model]
 

--- a/wagtail/snippets/views/snippets.py
+++ b/wagtail/snippets/views/snippets.py
@@ -238,7 +238,6 @@ def create(request, app_label, model_name):
 
     # Make edit handler
     edit_handler = get_snippet_edit_handler(model)
-    edit_handler = edit_handler.bind_to(request=request)
     form_class = edit_handler.get_form_class()
 
     if request.method == "POST":
@@ -291,7 +290,7 @@ def create(request, app_label, model_name):
     else:
         form = form_class(instance=instance, for_user=request.user)
 
-    edit_handler = edit_handler.bind_to(instance=instance, form=form)
+    edit_handler = edit_handler.bind_to(request=request, instance=instance, form=form)
 
     context = {
         "model_opts": model._meta,
@@ -340,7 +339,6 @@ def edit(request, app_label, model_name, pk):
             return result
 
     edit_handler = get_snippet_edit_handler(model)
-    edit_handler = edit_handler.bind_to(instance=instance, request=request)
     form_class = edit_handler.get_form_class()
 
     if request.method == "POST":
@@ -384,7 +382,7 @@ def edit(request, app_label, model_name, pk):
     else:
         form = form_class(instance=instance, for_user=request.user)
 
-    edit_handler = edit_handler.bind_to(form=form)
+    edit_handler = edit_handler.bind_to(instance=instance, request=request, form=form)
     latest_log_entry = log_registry.get_logs_for_instance(instance).first()
 
     context = {


### PR DESCRIPTION
Aims to avoid some of the inconsistency around the order that binding happens in, and which items are expected to be bound before calling certain EditHandler methods - as well as bringing things a bit closer to standard Django forms framework idioms.

The `model` argument of `EditHandler.bind_to` is now split out into its own `bind_to_model` method. The sequence of actions performed by view code is now:

* Retrieves the EditHandler instance for a given model
* Call `bind_to_model` on the EditHandler
* Call `get_form_class`, which constructs a form class based on the results of `get_form_options` from all child panels
* Instantiate the form class, passing `for_user=request.user` along with the standard form kwargs
* Call `bind_to(instance, request, form)`

Note that this means `get_form_options` must be able to return a valid result when only the model is bound - it is no longer legal to vary the form class based on the request / user.