### PR TITLE
Tailwind setup follow-up: RTL support and Windows High Contrast mode

### DIFF
--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -1,3 +1,4 @@
+const plugin = require('tailwindcss/plugin');
 const vanillaRTL = require('tailwindcss-vanilla-rtl');
 
 /**
@@ -51,6 +52,8 @@ module.exports = {
       inherit: 'inherit',
       current: 'currentColor',
       transparent: 'transparent',
+      LinkText: 'LinkText',
+      ButtonText: 'ButtonText',
     },
     fontFamily,
     fontSize,
@@ -65,7 +68,19 @@ module.exports = {
     },
     spacing,
   },
-  plugins: [typeScale, vanillaRTL],
+  plugins: [
+    typeScale,
+    vanillaRTL,
+    /**
+     * forced-colors media query for Windows High-Contrast mode support
+     * See:
+     * - https://developer.mozilla.org/en-US/docs/Web/CSS/@media/forced-colors
+     * - https://github.com/tailwindlabs/tailwindcss/blob/7b4cc36f5ea1f7e208dcd3af3e8288878735f45f/src/corePlugins.js#L169-L172
+     */
+    plugin(({ addVariant }) => {
+      addVariant('forced-colors', '@media (forced-colors: active)');
+    }),
+  ],
   corePlugins: {
     ...vanillaRTL.disabledCorePlugins,
     // Disable float and clear which have poor RTL support.

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -52,6 +52,7 @@ module.exports = {
       inherit: 'inherit',
       current: 'currentColor',
       transparent: 'transparent',
+      /* allow system colours https://www.w3.org/TR/css-color-4/#css-system-colors */
       LinkText: 'LinkText',
       ButtonText: 'ButtonText',
     },
@@ -75,7 +76,7 @@ module.exports = {
      * forced-colors media query for Windows High-Contrast mode support
      * See:
      * - https://developer.mozilla.org/en-US/docs/Web/CSS/@media/forced-colors
-     * - https://github.com/tailwindlabs/tailwindcss/blob/7b4cc36f5ea1f7e208dcd3af3e8288878735f45f/src/corePlugins.js#L169-L172
+     * - https://github.com/tailwindlabs/tailwindcss/blob/v3.0.23/src/corePlugins.js#L168-L171
      */
     plugin(({ addVariant }) => {
       addVariant('forced-colors', '@media (forced-colors: active)');

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -1,3 +1,5 @@
+const vanillaRTL = require('tailwindcss-vanilla-rtl');
+
 /**
  * Design Tokens
  */
@@ -63,6 +65,11 @@ module.exports = {
     },
     spacing,
   },
-  plugins: [typeScale],
-  corePlugins: {},
+  plugins: [typeScale, vanillaRTL],
+  corePlugins: {
+    ...vanillaRTL.disabledCorePlugins,
+    // Disable float and clear which have poor RTL support.
+    float: false,
+    clear: false,
+  },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "wagtail",
       "version": "1.0.0",
       "dependencies": {
         "draft-js": "^0.10.5",
@@ -62,6 +63,7 @@
         "storybook-django": "^0.3.0",
         "stylelint": "^14.2.0",
         "tailwindcss": "^3.0.23",
+        "tailwindcss-vanilla-rtl": "^0.1.0",
         "ts-jest": "^26.5.6",
         "ts-loader": "^9.2.6",
         "typescript": "^4.5.4",
@@ -27052,6 +27054,15 @@
         "postcss": "^8.0.9"
       }
     },
+    "node_modules/tailwindcss-vanilla-rtl": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/tailwindcss-vanilla-rtl/-/tailwindcss-vanilla-rtl-0.1.0.tgz",
+      "integrity": "sha512-cSfjIF0h+qJFhERQANxP5WplC8DJRHcxFoo+9NS0uKmk5BUnDfIVRrU7xzIqTpik0BErTaxzpWpoAR2Y1gvS6w==",
+      "dev": true,
+      "peerDependencies": {
+        "tailwindcss": "^3.0.0"
+      }
+    },
     "node_modules/tailwindcss/node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -50453,6 +50464,13 @@
           }
         }
       }
+    },
+    "tailwindcss-vanilla-rtl": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/tailwindcss-vanilla-rtl/-/tailwindcss-vanilla-rtl-0.1.0.tgz",
+      "integrity": "sha512-cSfjIF0h+qJFhERQANxP5WplC8DJRHcxFoo+9NS0uKmk5BUnDfIVRrU7xzIqTpik0BErTaxzpWpoAR2Y1gvS6w==",
+      "dev": true,
+      "requires": {}
     },
     "tapable": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "storybook-django": "^0.3.0",
     "stylelint": "^14.2.0",
     "tailwindcss": "^3.0.23",
+    "tailwindcss-vanilla-rtl": "^0.1.0",
     "ts-jest": "^26.5.6",
     "ts-loader": "^9.2.6",
     "typescript": "^4.5.4",


### PR DESCRIPTION
Sets up two additional Tailwind plugins for #8052. Note I chose not to do the enhanced Sass integration in the end – I think we first need to discuss a potential plan to gradually improve the existing stylesheets.

- For WHCM – I added a Tailwind modifier, and system colors matching our existing usage. Example utility class: `forced-colors:w-bg-LinkText`.
- For RTL – I added a standalone plugin of my own making (setup discussed with @stevedya), which allows us to write LTR styles matching the utilities of Tailwind core, and outputs RTL-friendly styles. Example utility class: `w-mr-4`.

In both cases, I’m hoping we will get to revisit this (!) as Tailwind support for both use cases shapes up:

- https://github.com/tailwindlabs/tailwindcss/discussions/1483
- https://github.com/tailwindlabs/tailwindcss/discussions/7839

---

There isn’t much to test here aside from adding those two utilities in test HTML, and making sure the output looks correct. I chose not to refactor existing components for the time being so this has to be done as a one-off trial if needed.