### PR TITLE
Removed outdated handling of length parameter to If-Modified-Since header.

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -26,6 +26,7 @@ Changelog
  * Add documentation for defining custom form validation on models used in Wagtail's `modelAdmin` (Serafeim Papastefanos)
  * Update `README.md` logo to work for GitHub dark mode (Paarth Agarwal)
  * Avoid an unnecessary page reload when pressing enter within the header search bar (Images, Pages, Documents) (Riley de Mestre)
+ * Removed unofficial length parameter on `If-Modified-Since` header in `sendfile_streaming_backend` which was only used by IE (Mariusz Felisiak)
  * Fix: When using `simple_translations` ensure that the user is redirected to the page edit view when submitting for a single locale (Mitchel Cabuloy)
  * Fix: When previewing unsaved changes to `Form` pages, ensure that all added fields are correctly shown in the preview (Joshua Munn)
  * Fix: When Documents (e.g. PDFs) have been configured to be served inline via `WAGTAILDOCS_CONTENT_TYPES` & `WAGTAILDOCS_INLINE_CONTENT_TYPES` ensure that the filename is correctly set in the `Content-Disposition` header so that saving the files will use the correct filename (John-Scott Atlakson)

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -571,6 +571,7 @@ Contributors
 * Nicolas Ferrari
 * Vibhakar Solanki
 * Riley de Mestre
+* Mariusz Felisiak
 
 Translators
 ===========

--- a/docs/releases/2.17.md
+++ b/docs/releases/2.17.md
@@ -51,6 +51,7 @@ The panel types `StreamFieldPanel`, `RichTextFieldPanel`, `ImageChooserPanel`, `
  * Add documentation for defining [custom form validation](modeladmin_custom_clean) on models used in Wagtail's `modelAdmin` (Serafeim Papastefanos)
  * Update `README.md` logo to work for GitHub dark mode (Paarth Agarwal)
  * Avoid an unnecessary page reload when pressing enter within the header search bar (Images, Pages, Documents) (Riley de Mestre)
+ * Removed unofficial length parameter on `If-Modified-Since` header in `sendfile_streaming_backend` which was only used by IE (Mariusz Felisiak)
 
 
 ### Bug fixes
@@ -108,3 +109,8 @@ If you do continue to use a custom panel class, note that the template context f
 ### ModelAdmin forms must subclass `WagtailAdminModelForm`
 
 When overriding the `get_form_class` method of a ModelAdmin `CreateView` or `EditView` to pass a custom form class, that form class must now inherit from `wagtail.admin.forms.models.WagtailAdminModelForm`. Passing a plain Django ModelForm subclass is no longer valid.
+
+### Removed the `size` argument of the undocumented `wagtail.utils.sendfile_streaming_backend.was_modified_since` function
+
+-   The `size` argument was used to add a `length` parameter to the HTTP header.
+-   This was never part of the HTTP/1.0 and HTTP/1.1 specifications see [RFC7232](https://httpwg.org/specs/rfc7232.html#header.if-modified-since) and existed only as a an unofficial implementation in IE browsers.


### PR DESCRIPTION
The length parameter is not described in [RFC-7232](https://httpwg.org/specs/rfc7232.html#header.if-modified-since) and it's against HTTP/1.0 and HTTP/1.1 specifications. It was an old and unofficial extension set by some ancient versions of IE.

See also https://github.com/django/django/pull/15500.