### PR TITLE
Removed redundant text-transform instances

### DIFF
--- a/client/scss/components/_bulk_actions.scss
+++ b/client/scss/components/_bulk_actions.scss
@@ -18,10 +18,6 @@
     .bulk-actions-choices li {
       margin: 0 0.5em;
     }
-
-    .bulk-actions-choices span {
-      text-transform: none;
-    }
   }
 }
 
@@ -85,7 +81,6 @@
     }
 
     .num-objects {
-      text-transform: none;
       margin: 0 5px;
     }
 

--- a/client/scss/components/_button.scss
+++ b/client/scss/components/_button.scss
@@ -339,10 +339,6 @@
     }
   }
 
-  &.text-notransform {
-    text-transform: initial;
-  }
-
   &.button--icon {
     .icon {
       @include svg-icon(1.5em);

--- a/client/scss/components/_dropdown.scss
+++ b/client/scss/components/_dropdown.scss
@@ -66,7 +66,6 @@
   margin-top: 0.75rem;
   padding: 0.75rem 1rem;
   min-width: 8rem;
-  text-transform: none;
   position: absolute;
   z-index: 1000;
   animation: dropdownIn 0.1s ease-out backwards;

--- a/client/scss/components/_forms.scss
+++ b/client/scss/components/_forms.scss
@@ -11,7 +11,6 @@
 //
 // label,
 // .label {
-//     text-transform: none;
 //     font-weight: bold;
 //     color: $color-grey-1;
 //     font-size: 1.1em;

--- a/client/scss/components/_listing.scss
+++ b/client/scss/components/_listing.scss
@@ -193,7 +193,6 @@ ul.listing {
 
     .title-wrapper,
     h2 {
-      text-transform: none;
       margin: 0;
       font-size: 1.15em;
       font-weight: 600;

--- a/client/scss/components/_main-nav.scss
+++ b/client/scss/components/_main-nav.scss
@@ -431,7 +431,6 @@ body.explorer-open {
       padding: 0.2em 0;
       font-size: 1.2em;
       font-weight: 500;
-      text-transform: none;
       text-align: center;
       color: $color-menu-text;
 

--- a/client/scss/core.scss
+++ b/client/scss/core.scss
@@ -158,9 +158,5 @@ These are classes that provide overrides.
 // Legacy utilities
 @import 'overrides/utilities.legacy';
 
-// PAGES: page-specific overrides
-@import 'overrides/pages.homepage';
-@import 'overrides/pages.page-explorer';
-
 // TAILWIND: This is at the bottom so it can take precedence over other css classes
 @tailwind utilities;

--- a/client/scss/elements/_forms.scss
+++ b/client/scss/elements/_forms.scss
@@ -26,7 +26,6 @@ legend {
 
 label,
 .label {
-  text-transform: none;
   font-weight: bold;
   color: $color-grey-1;
   font-size: 1.1em;

--- a/client/scss/elements/_typography.scss
+++ b/client/scss/elements/_typography.scss
@@ -22,7 +22,6 @@ h1 {
   font-weight: 700;
 
   span {
-    text-transform: none;
     font-weight: 300;
   }
 }

--- a/client/scss/overrides/_pages.homepage.scss
+++ b/client/scss/overrides/_pages.homepage.scss
@@ -1,3 +1,0 @@
-.homepage h1 {
-  text-transform: none;
-}

--- a/client/scss/overrides/_pages.page-explorer.scss
+++ b/client/scss/overrides/_pages.page-explorer.scss
@@ -1,3 +1,0 @@
-.page-explorer h2 {
-  text-transform: none;
-}

--- a/client/scss/overrides/_vendor.datetimepicker.scss
+++ b/client/scss/overrides/_vendor.datetimepicker.scss
@@ -68,7 +68,6 @@
     white-space: nowrap;
     width: 2em;
     color: $color-teal;
-    text-transform: none;
     text-align: center;
 
     &:before {

--- a/client/scss/tools/_mixins.general.scss
+++ b/client/scss/tools/_mixins.general.scss
@@ -89,7 +89,6 @@
   font-style: normal;
   font-weight: normal;
   font-variant: normal;
-  text-transform: none;
   speak: none;
   text-decoration: none;
   width: 1.3em;

--- a/client/src/components/CommentApp/components/CommentHeader/style.scss
+++ b/client/src/components/CommentApp/components/CommentHeader/style.scss
@@ -103,7 +103,6 @@
   &__more-actions {
     background-color: #333;
     color: $color-grey-5;
-    text-transform: none;
     position: absolute;
     z-index: 1000;
     list-style: none;

--- a/client/src/components/Draftail/Draftail.scss
+++ b/client/src/components/Draftail/Draftail.scss
@@ -35,7 +35,6 @@ $draftail-editor-font-family: $font-sans;
   h5,
   h6 {
     // Overrides for other parts of the Wagtail admin.
-    text-transform: none;
     font-family: inherit;
     clear: both;
     line-height: 1;

--- a/client/src/components/Sidebar/menu/SubMenuItem.scss
+++ b/client/src/components/Sidebar/menu/SubMenuItem.scss
@@ -46,7 +46,6 @@
     padding: 0.2em 0;
     font-size: 1.2em;
     font-weight: 500;
-    text-transform: none;
     text-align: center;
     color: $color-menu-text;
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -14,5 +14,6 @@ module.exports = {
   corePlugins: {
     // Risk of clashing with existing styles.
     preflight: false,
+    textTransform: false,
   },
 };

--- a/wagtail/admin/static_src/wagtailadmin/css/normalize.css
+++ b/wagtail/admin/static_src/wagtailadmin/css/normalize.css
@@ -422,18 +422,6 @@ input {
 }
 
 /**
- * Address inconsistent `text-transform` inheritance for `button` and `select`.
- * All other form control elements do not inherit `text-transform` values.
- * Correct `button` style inheritance in Chrome, Safari 5+, and IE 6+.
- * Correct `select` style inheritance in Firefox 4+ and Opera.
- */
-
-button,
-select {
-  text-transform: none;
-}
-
-/**
  * 1. Avoid the WebKit bug in Android 4.0.* where (2) destroys native `audio`
  *    and `video` controls.
  * 2. Correct inability to style clickable `input` types in iOS.

--- a/wagtail/admin/static_src/wagtailadmin/scss/layouts/home.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/layouts/home.scss
@@ -28,7 +28,6 @@ header {
   }
 
   .user-name {
-    text-transform: none;
     font-size: 1.3em;
     font-weight: 600;
   }

--- a/wagtail/admin/static_src/wagtailadmin/scss/layouts/login.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/layouts/login.scss
@@ -36,7 +36,6 @@ h1 {
   font-size: 2em;
   line-height: 1em;
   color: $color-white;
-  text-transform: none;
   white-space: nowrap;
 }
 

--- a/wagtail/admin/static_src/wagtailadmin/scss/layouts/page-editor.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/layouts/page-editor.scss
@@ -69,10 +69,6 @@
 
   h1 {
     font-size: 1.915em; // approximately 26px
-
-    &.header-title {
-      text-transform: initial;
-    }
   }
 
   .header-title {
@@ -218,7 +214,6 @@
 
     label {
       display: inline;
-      text-transform: inherit;
       font-weight: inherit;
       float: none;
       width: auto;
@@ -230,7 +225,6 @@
       @include font-smoothing;
       text-shadow: none;
       font-family: $font-wagtail-icons;
-      text-transform: none;
       // UI Redesign: To be removed in page editor redesign
       content: map.get($icons, 'arrow-down');
       text-align: center;


### PR DESCRIPTION
This PR fixes "Refactor Code" and "Configure Tailwind" part of #8121.

- I have removed all redundant text-transform instances from the stylesheets.
- Disabled the text-transform Tailwind plugin.