### PR TITLE
Update aging_pages.py

### DIFF
--- a/wagtail/admin/views/reports/aging_pages.py
+++ b/wagtail/admin/views/reports/aging_pages.py
@@ -49,7 +49,7 @@ class AgingPagesView(PageReportView):
         "title",
         "status_string",
         "last_published_at",
-        "last_published_by_user",
+        "last_published_by",
         "content_type",
     ]
 

--- a/wagtail/admin/views/reports/aging_pages.py
+++ b/wagtail/admin/views/reports/aging_pages.py
@@ -42,7 +42,7 @@ class AgingPagesView(PageReportView):
     export_headings = {
         "status_string": _("Status"),
         "last_published_at": _("Last published at"),
-        "last_published_by_user": _("Last published by"),
+        "last_published_by": _("Last published by"),
         "content_type": _("Type"),
     }
     list_export = [


### PR DESCRIPTION
Removes `_user` from `last_published_by_user` in `list_export` because reports don't appear to work with annotations of get_queryset.
