### PR TITLE
documentation - update node installation instructions

### DIFF
--- a/docs/contributing/developing.rst
+++ b/docs/contributing/developing.rst
@@ -15,8 +15,8 @@ If you'd prefer to set up all the components manually, read on. These instructio
 Setting up the Wagtail codebase
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Install `Node.js <https://nodejs.org/>`_, version 16.
-You can also use Node version manager (nvm) since Wagtail supplies a ``.nvmrc`` file in the root of the project with the minimum required Node version - see nvm's `installation instructions <https://github.com/creationix/nvm>`_.
+The preferred option is to install the correct version of Node using Node Version Manager (nvm), which will always align the version with the supplied  ``.nvmrc`` file in the root of the project. See nvm's `installation instructions <https://github.com/creationix/nvm>`_.
+Alternatively, you can install `Node.js <https://nodejs.org/>`_ directly, ensure you install the version as declared in the project's root ``.nvmrc`` file.
 
 You will also need to install the **libjpeg** and **zlib** libraries, if you haven't done so already - see Pillow's `platform-specific installation instructions <https://pillow.readthedocs.org/en/latest/installation.html#external-libraries>`_.
 


### PR DESCRIPTION
- advise that `nvm` is the preferred option
- avoid an explicit reference to the node version in use, but instead direct the dev to read .nvmrc
- this aims to avoid issues where new contributors get confused about node versions and refer to the 'stable' docs instead of the 'latest' when getting started as node versions may have changed across releases compared to main
- while node 14 to node 16 is a bit of a unique hurdle (it will break), I think this should help long term for future node upgrades

see issues encountered by contributors
- https://github.com/wagtail/wagtail/pull/8130#issuecomment-1068816388
- https://wagtailcms.slack.com/archives/CTL4SFX29/p1647376088161149