### PR TITLE
Add help text messages for tags based on the value of TAG_SPACES_ALLOWED

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -51,6 +51,7 @@ Changelog
  * Support chunking in `PageQuerySet.specific()` to reduce memory consumption (Andy Babic)
  * Implement new tabs design across the admin interface (Steven Steinwand)
  * Move page meta information from the header to a new status side panel component inside of the page editing UI (Steven Steinwand, Karl Hobley)
+ * Add useful help text to Tag fields to advise what content is allowed inside tags, including when `TAG_SPACES_ALLOWED` is `True` or `False` (Abdulmajeed Isa)
  * Fix: When using `simple_translations` ensure that the user is redirected to the page edit view when submitting for a single locale (Mitchel Cabuloy)
  * Fix: When previewing unsaved changes to `Form` pages, ensure that all added fields are correctly shown in the preview (Joshua Munn)
  * Fix: When Documents (e.g. PDFs) have been configured to be served inline via `WAGTAILDOCS_CONTENT_TYPES` & `WAGTAILDOCS_INLINE_CONTENT_TYPES` ensure that the filename is correctly set in the `Content-Disposition` header so that saving the files will use the correct filename (John-Scott Atlakson)

--- a/docs/releases/3.0.md
+++ b/docs/releases/3.0.md
@@ -80,6 +80,7 @@ class LandingPage(Page):
  * Add the ability for choices to be separated by new lines instead of just commas within the form builder, commas will still be supported if used (Abdulmajeed Isa)
  * Add internationalisation UI to modeladmin (Andrés Martano)
  * Support chunking in `PageQuerySet.specific()` to reduce memory consumption (Andy Babic)
+ * Add useful help text to Tag fields to advise what content is allowed inside tags, including when `TAG_SPACES_ALLOWED` is `True` or `False` (Abdulmajeed Isa)
  * Fix: Implement ARIA tabs markup and keyboards interactions for admin tabs (Steven Steinwand)
 
 ### Bug fixes

--- a/wagtail/admin/templates/wagtailadmin/widgets/tag_widget.html
+++ b/wagtail/admin/templates/wagtailadmin/widgets/tag_widget.html
@@ -1,4 +1,5 @@
 {% include 'django/forms/widgets/text.html' %}
+<p class="help">{{ widget.help_text }}</p>
 <script>
     initTagField(
         "{{ widget.attrs.id|escapejs }}",

--- a/wagtail/admin/widgets/tags.py
+++ b/wagtail/admin/widgets/tags.py
@@ -2,6 +2,7 @@ import json
 
 from django.conf import settings
 from django.urls import reverse
+from django.utils.translation import gettext_lazy as _
 from taggit.forms import TagWidget
 from taggit.models import Tag
 
@@ -31,6 +32,15 @@ class AdminTagWidget(TagWidget):
         else:
             free_tagging = self.free_tagging
 
+        tag_spaces_allowed = getattr(settings, "TAG_SPACES_ALLOWED", True)
+        if tag_spaces_allowed:
+            help_text = _(
+                'Multi-word tags with spaces will automatically be enclosed in double quotes (").'
+            )
+        else:
+            help_text = _("Tags can only consist of a single word, no spaces allowed.")
+
+        context["widget"]["help_text"] = help_text
         context["widget"]["autocomplete_url"] = autocomplete_url
         context["widget"]["options_json"] = json.dumps(
             {


### PR DESCRIPTION
Fix for #1874 
Depending on the value of `TAG_SPACES_ALLOWED`, different help text messages will be displayed below the tag field. When the value is True (default), it explains the need to quote a multi-word tag, and when it's False, it mentions to only use a one-word tag. The message variable is defined within the AdminTagWidget class so that the help text message will always be displayed when the widget is used.