### PR TITLE
InlinePanel.get_comparison passes label as field_label

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -9,6 +9,7 @@ Changelog
  * Add `base_url_path` to `ModelAdmin` so that the default URL structure of app_label/model_name can be overridden (Vu Pham, Khanh Hoang)
  * Add `full_url` to the API output of `ImageRenditionField` (Paarth Agarwal)
  * Fix issue where `ModelAdmin` index listings with export list enabled would show buttons with an incorrect layout (Josh Woodcock)
+ * Use `InlinePanel`'s label when available for field comparison label (Sandil Ranasinghe)
 
 
 3.0 (xx.xx.xxxx) - IN DEVELOPMENT

--- a/docs/releases/4.0.md
+++ b/docs/releases/4.0.md
@@ -15,6 +15,7 @@ depth: 1
  * Convert various pages in the documentation to Markdown (Daniel Kirkham)
  * Add `base_url_path` to `ModelAdmin` so that the default URL structure of app_label/model_name can be overridden (Vu Pham, Khanh Hoang)
  * Add `full_url` to the API output of `ImageRenditionField` (Paarth Agarwal)
+ * Use `InlinePanel`'s label when available for field comparison label (Sandil Ranasinghe)
 
 ### Bug fixes
 

--- a/wagtail/admin/compare.py
+++ b/wagtail/admin/compare.py
@@ -423,11 +423,12 @@ class ChildRelationComparison:
     is_field = False
     is_child_relation = True
 
-    def __init__(self, field, field_comparisons, obj_a, obj_b):
+    def __init__(self, field, field_comparisons, obj_a, obj_b, label=""):
         self.field = field
         self.field_comparisons = field_comparisons
         self.val_a = getattr(obj_a, field.related_name)
         self.val_b = getattr(obj_b, field.related_name)
+        self.label = label
 
     def field_label(self):
         """
@@ -437,7 +438,12 @@ class ChildRelationComparison:
 
         if verbose_name is None:
             # Relations don't have a verbose_name
-            verbose_name = self.field.name.replace("_", " ")
+            if self.label:
+                # If the panel has a label, we set it instead.
+                # See InlinePanel.get_comparision for usage
+                verbose_name = self.label
+            else:
+                verbose_name = self.field.name.replace("_", " ")
 
         return capfirst(verbose_name)
 

--- a/wagtail/admin/panels.py
+++ b/wagtail/admin/panels.py
@@ -920,6 +920,7 @@ class InlinePanel(Panel):
                     compare.ChildRelationComparison,
                     self.panel.db_field,
                     field_comparisons,
+                    label=self.label,
                 )
             ]
 

--- a/wagtail/admin/tests/test_compare.py
+++ b/wagtail/admin/tests/test_compare.py
@@ -1265,6 +1265,30 @@ class TestChildRelationComparison(TestCase):
         self.assertEqual(added, [0])  # Add new Father Christmas
         self.assertEqual(deleted, [0])  # Delete old Father Christmas
 
+    def test_panel_label_as_field_label(self):
+        # Just to check whether passing `label` changes field_label
+        event_page = EventPage(title="Event page", slug="event")
+        event_page.speakers.add(
+            EventPageSpeaker(
+                first_name="Father",
+            )
+        )
+
+        comparison = self.comparison_class(
+            EventPage._meta.get_field("speaker"),
+            [
+                partial(
+                    self.field_comparison_class,
+                    EventPageSpeaker._meta.get_field("first_name"),
+                )
+            ],
+            event_page,
+            event_page,
+            label="Speakers",
+        )
+
+        self.assertEqual(comparison.field_label(), "Speakers")
+
 
 class TestChildObjectComparison(TestCase):
     field_comparison_class = compare.FieldComparison

--- a/wagtail/admin/tests/test_edit_handlers.py
+++ b/wagtail/admin/tests/test_edit_handlers.py
@@ -1224,6 +1224,29 @@ class TestInlinePanel(TestCase, WagtailTestUtils):
             )
 
 
+class TestInlinePanelGetComparison(TestCase):
+    fixtures = ["test.json"]
+
+    def setUp(self):
+        self.request = RequestFactory().get("/")
+        user = AnonymousUser()  # technically, Anonymous users cannot access the admin
+        self.request.user = user
+
+    def test_get_comparison(self):
+        # Test whether the InlinePanel passes it's label in get_comparison
+
+        page = Page.objects.get(id=4).specific
+        comparison = (
+            page.get_edit_handler()
+            .bind_to(instance=page, request=self.request)
+            .get_comparison()
+        )
+
+        comparison = [comp(page, page) for comp in comparison]
+        field_labels = [comp.field_label() for comp in comparison]
+        self.assertIn("Speakers", field_labels)
+
+
 class TestInlinePanelRelatedModelPanelConfigChecks(TestCase):
     def setUp(self):
         self.original_panels = EventPageSpeaker.panels


### PR DESCRIPTION
For issue #4732 (FieldComparison.field_label should pick up labels from InlinePanel)

- Passed panel label from `InlinePanel.get_comparison`
- `ChildRelationComparison.field_label()` now uses panel_label if it is passed in the absence of verbose_name