### PR TITLE
Added support for only-server=true and only-client-true in make lint and make format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,19 @@ develop: clean-pyc
 	npm install --no-save && npm run build
 
 lint:
+ifdef only-server
+	black --target-version py37 --check --diff .
+	flake8
+	isort --check-only --diff .
+	curlylint --parse-only wagtail
+else
+ifdef only-client
+	git ls-files '*.html' | xargs djhtml --check
+	npm run lint:css --silent
+	npm run lint:js --silent
+	npm run lint:format --silent
+	doc8 docs
+else
 	black --target-version py37 --check --diff .
 	flake8
 	isort --check-only --diff .
@@ -26,14 +39,26 @@ lint:
 	npm run lint:js --silent
 	npm run lint:format --silent
 	doc8 docs
+endif
+endif
 
 format:
+ifdef only-server
+	black --target-version py37 .
+	isort .
+else
+ifdef only-client
+	git ls-files '*.html' | xargs djhtml -i
+	npm run format
+	npm run fix:js
+else
 	black --target-version py37 .
 	isort .
 	git ls-files '*.html' | xargs djhtml -i
 	npm run format
 	npm run fix:js
-
+endif
+endif
 test:
 	python runtests.py
 


### PR DESCRIPTION
I have put some conditional statements for `lint` and `format` in `Makefile`. So one can pass `only-server=true` or `only-client=true`. Arguments with leading `--` like `--only-server` were not possible because `make` would consider these arguments as built-in, resulting in error. Moreover the implementation is such that `only-server=anything` is equivalent to `only-server=true`. This can be avoided by nesting more conditional statements which can result in longer `Makefile`. Conclusion being that if one wants to use these arguments, assignment to something is necessary in command line otherwise if alone `only-server` is passed without assigning a value it would not take effect.