### PR TITLE
Add some dummy modules for wagtail.tests

### DIFF
--- a/wagtail/bin/wagtail.py
+++ b/wagtail/bin/wagtail.py
@@ -151,6 +151,7 @@ class UpdateModulePaths(Command):
             "wagtail.contrib.styleguide",
         ),
         # Added in Wagtail 3.0
+        (re.compile(r"\bwagtail\.tests\b"), "wagtail.test"),
         (re.compile(r"\bwagtail\.core\b"), "wagtail"),
     ]
 

--- a/wagtail/tests/settings.py
+++ b/wagtail/tests/settings.py
@@ -1,0 +1,1 @@
+from wagtail.test.settings import *  # noqa

--- a/wagtail/tests/utils/__init__.py
+++ b/wagtail/tests/utils/__init__.py
@@ -1,0 +1,1 @@
+from wagtail.test.utils import *  # noqa

--- a/wagtail/tests/utils/form_data.py
+++ b/wagtail/tests/utils/form_data.py
@@ -1,0 +1,1 @@
+from wagtail.test.utils.form_data import *  # noqa

--- a/wagtail/tests/utils/page_tests.py
+++ b/wagtail/tests/utils/page_tests.py
@@ -1,0 +1,1 @@
+from wagtail.test.utils.page_tests import *  # noqa

--- a/wagtail/tests/utils/wagtail_tests.py
+++ b/wagtail/tests/utils/wagtail_tests.py
@@ -1,0 +1,1 @@
+from wagtail.test.utils.wagtail_tests import *  # noqa


### PR DESCRIPTION
``wagtail.tests.settings`` is being called directly by ``wagtail-localize``: https://app.circleci.com/pipelines/github/wagtail/wagtail-localize/1568/workflows/3b8b8db9-3bc0-432e-9994-b64f61af2806/jobs/2798

This PR adds a few more dummy modules in for modules under ``wagtail.tests`` that may be imported by third party app test suites. It also adds another rule into ``updatemodulepaths`` to replace ``wagtail.tests`` with ``wagtail.test`` in imports.