### PR TITLE
Add the ability to globally disable the "Upload" tab for images and documents

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -26,6 +26,7 @@ Changelog
  * Add documentation for defining custom form validation on models used in Wagtail's `modelAdmin` (Serafeim Papastefanos)
  * Update `README.md` logo to work for GitHub dark mode (Paarth Agarwal)
  * Avoid an unnecessary page reload when pressing enter within the header search bar (Images, Pages, Documents) (Riley de Mestre)
+ * Add the ability to globally disable the "Upload" tab for the image and documents chooser (Jake Howard)
  * Fix: When using `simple_translations` ensure that the user is redirected to the page edit view when submitting for a single locale (Mitchel Cabuloy)
  * Fix: When previewing unsaved changes to `Form` pages, ensure that all added fields are correctly shown in the preview (Joshua Munn)
  * Fix: When Documents (e.g. PDFs) have been configured to be served inline via `WAGTAILDOCS_CONTENT_TYPES` & `WAGTAILDOCS_INLINE_CONTENT_TYPES` ensure that the filename is correctly set in the `Content-Disposition` header so that saving the files will use the correct filename (John-Scott Atlakson)

--- a/docs/reference/settings.rst
+++ b/docs/reference/settings.rst
@@ -635,24 +635,28 @@ a custom user model is being used and extra fields are required in the user crea
 
 A list of the extra custom fields to be appended to the default list.
 
-.. _WAGTAIL_USAGE_COUNT_ENABLED:
-
 Choosers
 ========================================
 
-``WAGTAIL_CHOOSER_UPLOAD_ENABLED``
+``WAGTAIL_CHOOSER_IMAGE_UPLOAD_ENABLED``
 --------------------------------
 
 .. code-block:: python
 
-    WAGTAIL_CHOOSER_UPLOAD_ENABLED = False
+    WAGTAIL_CHOOSER_IMAGE_UPLOAD_ENABLED = False
 
 By default, Wagtail allows the ability to upload images and documents in the chooser modal.
-This setting can be used to disable this functionality, only giving the editor the ability to choose already uploaded media.
+This setting can be used to disable this functionality, only giving the editor the ability to choose already uploaded images.
 
-.. note::
+``WAGTAIL_CHOOSER_DOCUMENT_UPLOAD_ENABLED``
+--------------------------------
 
-    This is only applicable to the images and documents choosers, and disables both together.
+.. code-block:: python
+
+    WAGTAIL_CHOOSER_DOCUMENT_UPLOAD_ENABLED = False
+
+By default, Wagtail allows the ability to upload documents in the chooser modal.
+This setting can be used to disable this functionality, only giving the editor the ability to choose already uploaded documents.
 
 .. _WAGTAIL_USAGE_COUNT_ENABLED:
 

--- a/docs/reference/settings.rst
+++ b/docs/reference/settings.rst
@@ -636,10 +636,10 @@ a custom user model is being used and extra fields are required in the user crea
 A list of the extra custom fields to be appended to the default list.
 
 Choosers
-========================================
+========
 
 ``WAGTAIL_CHOOSER_IMAGE_UPLOAD_ENABLED``
---------------------------------
+----------------------------------------
 
 .. code-block:: python
 
@@ -649,7 +649,7 @@ By default, Wagtail allows the ability to upload images and documents in the cho
 This setting can be used to disable this functionality, only giving the editor the ability to choose already uploaded images.
 
 ``WAGTAIL_CHOOSER_DOCUMENT_UPLOAD_ENABLED``
---------------------------------
+-------------------------------------------
 
 .. code-block:: python
 

--- a/docs/reference/settings.rst
+++ b/docs/reference/settings.rst
@@ -637,6 +637,25 @@ A list of the extra custom fields to be appended to the default list.
 
 .. _WAGTAIL_USAGE_COUNT_ENABLED:
 
+Choosers
+========================================
+
+``WAGTAIL_CHOOSER_UPLOAD_ENABLED``
+--------------------------------
+
+.. code-block:: python
+
+    WAGTAIL_CHOOSER_UPLOAD_ENABLED = False
+
+By default, Wagtail allows the ability to upload images and documents in the chooser modal.
+This setting can be used to disable this functionality, only giving the editor the ability to choose already uploaded media.
+
+.. note::
+
+    This is only applicable to the images and documents choosers, and disables both together.
+
+.. _WAGTAIL_USAGE_COUNT_ENABLED:
+
 Usage for images, documents and snippets
 ========================================
 

--- a/wagtail/documents/tests/test_admin_views.py
+++ b/wagtail/documents/tests/test_admin_views.py
@@ -1530,6 +1530,11 @@ class TestDocumentChooserView(TestCase, WagtailTestUtils):
         self.assertContains(response, "<th>Collection</th>")
         self.assertContains(response, "<td>Root</td>")
 
+    def test_disable_chooser_upload(self):
+        with self.settings(WAGTAIL_CHOOSER_UPLOAD_ENABLED=False):
+            response = self.client.get(reverse("wagtaildocs:chooser"))
+        self.assertIsNone(response.context["uploadform"])
+
 
 class TestDocumentChooserChosenView(TestCase, WagtailTestUtils):
     def setUp(self):

--- a/wagtail/documents/tests/test_admin_views.py
+++ b/wagtail/documents/tests/test_admin_views.py
@@ -1531,7 +1531,7 @@ class TestDocumentChooserView(TestCase, WagtailTestUtils):
         self.assertContains(response, "<td>Root</td>")
 
     def test_disable_chooser_upload(self):
-        with self.settings(WAGTAIL_CHOOSER_UPLOAD_ENABLED=False):
+        with self.settings(WAGTAIL_CHOOSER_DOCUMENT_UPLOAD_ENABLED=False):
             response = self.client.get(reverse("wagtaildocs:chooser"))
         self.assertIsNone(response.context["uploadform"])
 

--- a/wagtail/documents/views/chooser.py
+++ b/wagtail/documents/views/chooser.py
@@ -58,7 +58,7 @@ class BaseChooseView(View):
         Document = get_document_model()
 
         if getattr(
-            settings, "WAGTAIL_CHOOSER_UPLOAD_ENABLED", True
+            settings, "WAGTAIL_CHOOSER_DOCUMENT_UPLOAD_ENABLED", True
         ) and permission_policy.user_has_permission(request.user, "add"):
             DocumentForm = get_document_form(Document)
             self.uploadform = DocumentForm(
@@ -172,7 +172,7 @@ def document_chosen(request, document_id):
 
 @permission_checker.require("add")
 def chooser_upload(request):
-    if not getattr(settings, "WAGTAIL_CHOOSER_UPLOAD_ENABLED", True):
+    if not getattr(settings, "WAGTAIL_CHOOSER_DOCUMENT_UPLOAD_ENABLED", True):
         raise PermissionDenied
 
     Document = get_document_model()

--- a/wagtail/documents/views/chooser.py
+++ b/wagtail/documents/views/chooser.py
@@ -1,3 +1,5 @@
+from django.conf import settings
+from django.core.exceptions import PermissionDenied
 from django.core.paginator import Paginator
 from django.shortcuts import get_object_or_404
 from django.template.loader import render_to_string
@@ -55,7 +57,9 @@ class BaseChooseView(View):
     def get(self, request):
         Document = get_document_model()
 
-        if permission_policy.user_has_permission(request.user, "add"):
+        if getattr(
+            settings, "WAGTAIL_CHOOSER_UPLOAD_ENABLED", True
+        ) and permission_policy.user_has_permission(request.user, "add"):
             DocumentForm = get_document_form(Document)
             self.uploadform = DocumentForm(
                 user=request.user, prefix="document-chooser-upload"
@@ -168,6 +172,9 @@ def document_chosen(request, document_id):
 
 @permission_checker.require("add")
 def chooser_upload(request):
+    if not getattr(settings, "WAGTAIL_CHOOSER_UPLOAD_ENABLED", True):
+        raise PermissionDenied
+
     Document = get_document_model()
     DocumentForm = get_document_form(Document)
 

--- a/wagtail/images/tests/test_admin_views.py
+++ b/wagtail/images/tests/test_admin_views.py
@@ -1130,7 +1130,7 @@ class TestImageChooserView(TestCase, WagtailTestUtils):
         self.assertEqual(response.context["images"][0], image)
 
     def test_disable_chooser_upload(self):
-        with self.settings(WAGTAIL_CHOOSER_UPLOAD_ENABLED=False):
+        with self.settings(WAGTAIL_CHOOSER_IMAGE_UPLOAD_ENABLED=False):
             response = self.get()
         self.assertIsNone(response.context["uploadform"])
 

--- a/wagtail/images/tests/test_admin_views.py
+++ b/wagtail/images/tests/test_admin_views.py
@@ -1129,6 +1129,11 @@ class TestImageChooserView(TestCase, WagtailTestUtils):
         self.assertEqual(len(response.context["images"]), 1)
         self.assertEqual(response.context["images"][0], image)
 
+    def test_disable_chooser_upload(self):
+        with self.settings(WAGTAIL_CHOOSER_UPLOAD_ENABLED=False):
+            response = self.get()
+        self.assertIsNone(response.context["uploadform"])
+
 
 class TestImageChooserChosenView(TestCase, WagtailTestUtils):
     def setUp(self):

--- a/wagtail/images/views/chooser.py
+++ b/wagtail/images/views/chooser.py
@@ -98,7 +98,7 @@ class ChooseView(BaseChooseView):
         context = super().get_context_data()
 
         if getattr(
-            settings, "WAGTAIL_CHOOSER_UPLOAD_ENABLED", True
+            settings, "WAGTAIL_CHOOSER_IMAGE_UPLOAD_ENABLED", True
         ) and permission_policy.user_has_permission(self.request.user, "add"):
             ImageForm = get_image_form(self.image_model)
             uploadform = ImageForm(
@@ -161,7 +161,7 @@ def image_chosen(request, image_id):
 
 @permission_checker.require("add")
 def chooser_upload(request):
-    if not getattr(settings, "WAGTAIL_CHOOSER_UPLOAD_ENABLED", True):
+    if not getattr(settings, "WAGTAIL_CHOOSER_IMAGE_UPLOAD_ENABLED", True):
         raise PermissionDenied
 
     Image = get_image_model()
@@ -237,7 +237,7 @@ def chooser_upload(request):
 
 
 def chooser_select_format(request, image_id):
-    if not getattr(settings, "WAGTAIL_CHOOSER_UPLOAD_ENABLED", True):
+    if not getattr(settings, "WAGTAIL_CHOOSER_IMAGE_UPLOAD_ENABLED", True):
         raise PermissionDenied
 
     image = get_object_or_404(get_image_model(), id=image_id)


### PR DESCRIPTION
As a sort-of solution to https://github.com/wagtail/wagtail/issues/8185, this PR adds the ability to disable the "Upload" tab for the images / documents chooser. This forces editors to upload images through the "Images" or "Documents" screens, accessible from the sidebar. It intentionally reuses the same codepaths as if a user didn't have permission to upload, to save duplication.

For obvious reasons, this is enabled by default!

This does slow down UX, but enables permissions checks around the images / documents it's possible to "choose" to be internally consistent.