### PR TITLE
AbstractFormField.save - add to the docstring about clean name

### DIFF
--- a/wagtail/contrib/forms/models.py
+++ b/wagtail/contrib/forms/models.py
@@ -131,6 +131,8 @@ class AbstractFormField(Orderable):
         When new fields are created, generate a template safe ascii name to use as the
         JSON storage reference for this field. Previously created fields will be updated
         to use the legacy unidecode method via checks & _migrate_legacy_clean_name.
+        We do not want to update the clean name on any subsequent changes to the label
+        as this would invalidate any previously submitted data.
         """
 
         is_new = self.pk is None


### PR DESCRIPTION
- small docstring change
- attempt to alleviate issues like this https://github.com/wagtail/wagtail/issues/8200
- note: intentionally not added to the main docs as this is a lower level item that may confuse the main docs