### PR TITLE
Remove deprecated jinja2 references

### DIFF
--- a/wagtail/admin/jinja2tags.py
+++ b/wagtail/admin/jinja2tags.py
@@ -10,7 +10,7 @@ class WagtailUserbarExtension(Extension):
 
         self.environment.globals.update(
             {
-                "wagtailuserbar": jinja2.contextfunction(wagtailuserbar),
+                "wagtailuserbar": jinja2.pass_context(wagtailuserbar),
             }
         )
 

--- a/wagtail/contrib/settings/jinja2tags.py
+++ b/wagtail/contrib/settings/jinja2tags.py
@@ -57,7 +57,7 @@ class SiteSettings(dict):
         return out
 
 
-@jinja2.contextfunction
+@jinja2.pass_context
 def get_setting(context, model_string, use_default_site=False):
     if use_default_site:
         site = Site.objects.get(is_default_site=True)

--- a/wagtail/jinja2tags.py
+++ b/wagtail/jinja2tags.py
@@ -1,6 +1,7 @@
 import jinja2
 import jinja2.nodes
 from jinja2.ext import Extension
+from markupsafe import Markup, escape
 
 from .templatetags.wagtailcore_tags import (
     pageurl,
@@ -19,9 +20,9 @@ class WagtailCoreExtension(Extension):
 
         self.environment.globals.update(
             {
-                "pageurl": jinja2.contextfunction(pageurl),
-                "slugurl": jinja2.contextfunction(slugurl),
-                "wagtail_site": jinja2.contextfunction(wagtail_site),
+                "pageurl": jinja2.pass_context(pageurl),
+                "slugurl": jinja2.pass_context(slugurl),
+                "wagtail_site": jinja2.pass_context(wagtail_site),
                 "wagtail_version": wagtail_version,
             }
         )
@@ -73,9 +74,9 @@ class WagtailCoreExtension(Extension):
             result = value
 
         if context.eval_ctx.autoescape:
-            return jinja2.escape(result)
+            return escape(result)
         else:
-            return jinja2.Markup(result)
+            return Markup(result)
 
 
 # Nicer import names


### PR DESCRIPTION
Jinja2 3.1 was released a couple of days ago, pallets love deprecating things in point releases - [release notes](https://jinja.palletsprojects.com/en/3.1.x/changes/#version-3-1-0)
