### PR TITLE
Add admin tag manager documentation to edit and delete tags

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -38,6 +38,7 @@ Changelog
  * Use Django’s JavaScript catalog feature to manage translatable strings in JavaScript (Karl Hobley)
  * Add a `page_description` to the Page model, to provide help text for a given page type (Kalob Taulien, Thibaud Colas, Matt Westcott)
  * Add `trimmed` attribute to all blocktrans tags, so spacing is more reliable in translated strings (Harris Lapiroff)
+ * Add documentation that describes how to use `ModelAdmin` to manage `Tag`s (Abdulmajeed Isa)
  * Fix: When using `simple_translations` ensure that the user is redirected to the page edit view when submitting for a single locale (Mitchel Cabuloy)
  * Fix: When previewing unsaved changes to `Form` pages, ensure that all added fields are correctly shown in the preview (Joshua Munn)
  * Fix: When Documents (e.g. PDFs) have been configured to be served inline via `WAGTAILDOCS_CONTENT_TYPES` & `WAGTAILDOCS_INLINE_CONTENT_TYPES` ensure that the filename is correctly set in the `Content-Disposition` header so that saving the files will use the correct filename (John-Scott Atlakson)

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -583,6 +583,7 @@ Contributors
 * Shrey Parekh
 * Vinit Kumar
 * Shwet Khatri
+* Abdulmajeed Isa
 
 Translators
 ===========

--- a/docs/reference/pages/model_recipes.rst
+++ b/docs/reference/pages/model_recipes.rst
@@ -255,3 +255,33 @@ By default, tag fields work on a "free tagging" basis: editors can enter anythin
             verbose_name_plural = "blog tags"
 
 Here we have registered ``BlogTag`` as a snippet, to provide an interface for administrators (and other users with the appropriate permissions) to manage the allowed set of tags. With the ``free_tagging = False`` option set, editors can no longer enter arbitrary text into the tag field, and must instead select existing tags from the autocomplete dropdown.
+
+Managing tags with Wagtail's `ModelAdmin`
+-----------------------------------------
+
+In order to manage all the tags used in a project, you can a use the ``ModelAdmin`` to add the ``Tag`` model to the Wagtail admin. This will allow you to have a tag admin interface within the main menu in which you can add, edit or delete your tags.
+
+Tags that are removed from a content don't get deleted from the ``Tag`` model and will still be shown in typeahead tag completion. So having a tag interface is a great way to completely get rid of tags you don't need.
+
+To add the tag interface, add the following block of code to a ``wagtail_hooks.py`` file within any your project’s apps:
+
+.. code-block:: python
+
+    from wagtail.contrib.modeladmin.options import ModelAdmin, modeladmin_register
+    from taggit.models import Tag
+
+
+    class TagsModelAdmin(ModelAdmin):
+        Tag.panels = [FieldPanel("name")]  # only show the name field
+        model = Tag
+        menu_label = "Tags"
+        menu_icon = "tag"  # change as required
+        menu_order = 200  # will put in 3rd place (000 being 1st, 100 2nd)
+        list_display = ["name", "slug"]
+        search_fields = ("name",)
+
+
+    modeladmin_register(TagsModelAdmin)
+
+
+A ``Tag`` model has a ``name`` and ``slug`` required fields. If you decide to add a tag, it is recommended to only display the ``name`` field panel as the slug field is autofilled when the ``name`` field is filled and you don't need to enter the same name in both the fields.

--- a/docs/releases/3.0.md
+++ b/docs/releases/3.0.md
@@ -68,6 +68,7 @@ class LandingPage(Page):
  * Add support for embedding Instagram reels (Luis Nell)
  * Use Django’s JavaScript catalog feature to manage translatable strings in JavaScript (Karl Hobley)
  * Add `trimmed` attribute to all blocktrans tags, so spacing is more reliable in translated strings (Harris Lapiroff)
+ * Add documentation that describes how to use `ModelAdmin` to manage `Tag`s (Abdulmajeed Isa)
 
 ### Bug fixes
 


### PR DESCRIPTION
Solution to #1220 .
Added admin tag manager solution to the documentation where you can set up admin tag interface to manage tags.
