### PR TITLE
Fix typo flikr to flickr in oembed_providers.py

### DIFF
--- a/wagtail/embeds/oembed_providers.py
+++ b/wagtail/embeds/oembed_providers.py
@@ -59,7 +59,7 @@ dailymotion = {
     ],
 }
 
-flikr = {
+flickr = {
     "endpoint": "https://www.flickr.com/services/oembed/",
     "urls": [
         r"^https?://[-\w]+\.flickr\.com/photos/.+$",
@@ -658,7 +658,7 @@ all_providers = [
     deviantart,
     blip_tv,
     dailymotion,
-    flikr,
+    flickr,
     hulu,
     nfb,
     qik,


### PR DESCRIPTION
I notice a small typo in the file oembed_providers.py. Variable name should be flickr instead of flikr
