### PR TITLE
Add ValidationError if tag is larger than 100 characters

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -53,6 +53,7 @@ Changelog
  * Fix: Allow bulk publishing of pages without revisions (Andy Chosak)
  * Fix: Stop skipping heading levels in Wagtail welcome page (Jesse Menn)
  * Fix: Add missing `lang` attributes to `<html>` elements (James Ray)
+ * Fix: Avoid 503 server error when entering tags over 100chars and instead show a user facing validation error (Vu Pham, Khanh Hoang)
 
 
 2.16.2 (xx.xx.xxxx) - IN DEVELOPMENT

--- a/docs/releases/3.0.md
+++ b/docs/releases/3.0.md
@@ -88,6 +88,7 @@ class LandingPage(Page):
  * Stop skipping heading levels in Wagtail welcome page (Jesse Menn)
  * Add missing `lang` attributes to `<html>` elements (James Ray)
  * Add missing translation usage in Workflow templates (Anuja Verma, Saurabh Kumar)
+ * Avoid 503 server error when entering tags over 100chars and instead show a user facing validation error (Vu Pham, Khanh Hoang)
 
 
 ## Upgrade considerations

--- a/wagtail/admin/tests/test_widgets.py
+++ b/wagtail/admin/tests/test_widgets.py
@@ -485,6 +485,16 @@ class TestTagField(TestCase):
         self.assertTrue(form.is_valid())
         self.assertEqual(set(form.cleaned_data["tags"]), {"Italian", "delicious"})
 
+    def test_tag_over_one_hundred_characters(self):
+        class RestaurantTagForm(forms.Form):
+            tags = TagField(tag_model=RestaurantTag)
+
+        tag_name = ""
+        for _ in range(101):
+            tag_name += "a"
+        form = RestaurantTagForm({"tags": tag_name})
+        self.assertFalse(form.is_valid())
+
 
 class TestFilteredSelect(TestCase):
     def test_render(self):


### PR DESCRIPTION
Fixes #4564 with @thoang43 

The new behavior will look something like this:
![image](https://user-images.githubusercontent.com/46913707/160234518-d2c25318-4e58-403e-b23f-fea36106163a.png)

If there are any comments about our tests, or if there is any documentation that need to be updated (we can't find any that we should update for now), please let us know

* Do the tests still pass? yes
* For Python changes: Have you added tests to cover the new/fixed behaviour? Yes

Tested on Chrome, Window WSL (Ubuntu)