### PR TITLE
Fixing translations for 'Title' in listing templates

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -574,6 +574,7 @@ Contributors
 * Mariusz Felisiak
 * Dharmik Gangani
 * Kyle Hart
+* Stephanie Cheng Smith
 
 Translators
 ===========

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_list_choose.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_list_choose.html
@@ -8,7 +8,7 @@
 
 {% block pre_parent_page_headers %}
     <tr class="table-headers">
-        <th class="title">Title</th>
+        <th class="title">{% trans 'Title' %}</th>
         {% if show_parent %}
             <th class="parent">{% trans 'Parent' %}</th>
         {% endif %}

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_list_move.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_list_move.html
@@ -8,7 +8,7 @@
 
 {% block pre_parent_page_headers %}
     <tr class="table-headers">
-        <th class="title">Title</th>
+        <th class="title">{% trans 'Title' %}</th>
         {% if show_parent %}
             <th class="parent">{% trans 'Parent' %}</th>
         {% endif %}


### PR DESCRIPTION
 Fixes #8215 by replacing the `Title` strings with `{% trans 'Title' %}`. Tested by changing my default language and checking for the translation text when in the "Move" and "Page chooser" dialogs.