### PR TITLE
Adjusts headings on welcome_page.html

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -49,6 +49,7 @@ Changelog
  * Fix: Make sure the “Title” column label can be translated in the page chooser and page move UI (Stephanie Cheng Smith)
  * Fix: Remove redundant `role="main"` attributes on `<main>` elements causing HTML validation issues (Luis Espinoza)
  * Fix: Allow bulk publishing of pages without revisions (Andy Chosak)
+ * Fix: Stop skipping heading levels in Wagtail welcome page (Jesse Menn)
 
 
 2.16.2 (xx.xx.xxxx) - IN DEVELOPMENT

--- a/docs/releases/3.0.md
+++ b/docs/releases/3.0.md
@@ -84,6 +84,7 @@ class LandingPage(Page):
  * Make sure the “Title” column label can be translated in the page chooser and page move UI (Stephanie Cheng Smith)
  * Remove redundant `role="main"` attributes on `<main>` elements causing HTML validation issues (Luis Espinoza)
  * Allow bulk publishing of pages without revisions (Andy Chosak)
+ * Stop skipping heading levels in Wagtail welcome page (Jesse Menn)
 
 
 ## Upgrade considerations

--- a/wagtail/project_template/home/static/css/welcome_page.css
+++ b/wagtail/project_template/home/static/css/welcome_page.css
@@ -140,7 +140,7 @@ svg:not(:root) {
     position: absolute;
 }
 
-.option h4 {
+.option h2 {
     font-size: 19px;
     text-decoration: underline;
 }

--- a/wagtail/project_template/home/templates/home/welcome_page.html
+++ b/wagtail/project_template/home/templates/home/welcome_page.html
@@ -31,21 +31,21 @@
     <a class="option option-one" href="{% templatetag openblock %} wagtail_documentation_path {% templatetag closeblock %}/">
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M9 21c0 .5.4 1 1 1h4c.6 0 1-.5 1-1v-1H9v1zm3-19C8.1 2 5 5.1 5 9c0 2.4 1.2 4.5 3 5.7V17c0 .5.4 1 1 1h6c.6 0 1-.5 1-1v-2.3c1.8-1.3 3-3.4 3-5.7 0-3.9-3.1-7-7-7zm2.9 11.1l-.9.6V16h-4v-2.3l-.9-.6C7.8 12.2 7 10.6 7 9c0-2.8 2.2-5 5-5s5 2.2 5 5c0 1.6-.8 3.2-2.1 4.1z"/></svg>
         <div>
-            <h4>{% templatetag openblock %} trans "Wagtail Documentation" {% templatetag closeblock %}</h4>
+            <h2>{% templatetag openblock %} trans "Wagtail Documentation" {% templatetag closeblock %}</h2>
             <p>{% templatetag openblock %} trans "Topics, references, & how-tos" {% templatetag closeblock %}</p>
         </div>
     </a>
     <a class="option option-two" href="{% templatetag openblock %} wagtail_documentation_path {% templatetag closeblock %}/getting_started/tutorial.html">
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M9.4 16.6L4.8 12l4.6-4.6L8 6l-6 6 6 6 1.4-1.4zm5.2 0l4.6-4.6-4.6-4.6L16 6l6 6-6 6-1.4-1.4z"/></svg>
         <div>
-            <h4>{% templatetag openblock %} trans "Tutorial" {% templatetag closeblock %}</h4>
+            <h2>{% templatetag openblock %} trans "Tutorial" {% templatetag closeblock %}</h2>
             <p>{% templatetag openblock %} trans "Build your first Wagtail site" {% templatetag closeblock %}</p>
         </div>
     </a>
     <a class="option option-three" href="{% templatetag openblock %} url 'wagtailadmin_home' {% templatetag closeblock %}">
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M0 0h24v24H0z" fill="none"/><path d="M16.5 13c-1.2 0-3.07.34-4.5 1-1.43-.67-3.3-1-4.5-1C5.33 13 1 14.08 1 16.25V19h22v-2.75c0-2.17-4.33-3.25-6.5-3.25zm-4 4.5h-10v-1.25c0-.54 2.56-1.75 5-1.75s5 1.21 5 1.75v1.25zm9 0H14v-1.25c0-.46-.2-.86-.52-1.22.88-.3 1.96-.53 3.02-.53 2.44 0 5 1.21 5 1.75v1.25zM7.5 12c1.93 0 3.5-1.57 3.5-3.5S9.43 5 7.5 5 4 6.57 4 8.5 5.57 12 7.5 12zm0-5.5c1.1 0 2 .9 2 2s-.9 2-2 2-2-.9-2-2 .9-2 2-2zm9 5.5c1.93 0 3.5-1.57 3.5-3.5S18.43 5 16.5 5 13 6.57 13 8.5s1.57 3.5 3.5 3.5zm0-5.5c1.1 0 2 .9 2 2s-.9 2-2 2-2-.9-2-2 .9-2 2-2z"/></svg>
         <div>
-            <h4>{% templatetag openblock %} trans "Admin Interface" {% templatetag closeblock %}</h4>
+            <h2>{% templatetag openblock %} trans "Admin Interface" {% templatetag closeblock %}</h2>
             <p>{% templatetag openblock %} trans "Create your superuser first!" {% templatetag closeblock %}</p>
         </div>
     </a>


### PR DESCRIPTION
While the default welcome_page.html file is frequently deleted immediately after installing wagtail, a couple of people noted to me that it skips headings, moving from an `h1` to an `h4`. This changes the `h4` to `h2` to be slightly more accessible. 