### PR TITLE
Remove redundant role="main" for <main> element

### DIFF
--- a/client/src/components/Sidebar/Sidebar.stories.tsx
+++ b/client/src/components/Sidebar/Sidebar.stories.tsx
@@ -232,7 +232,7 @@ function renderSidebarStory(
         navigate={navigate}
         onExpandCollapse={onExpandCollapse}
       />
-      <main id="main" className="content-wrapper" role="main">
+      <main id="main" className="content-wrapper">
         <div className="content">
           <b>Current path:</b> {currentPath}
         </div>

--- a/wagtail/admin/templates/wagtailadmin/account/password_reset/complete.html
+++ b/wagtail/admin/templates/wagtailadmin/account/password_reset/complete.html
@@ -10,7 +10,7 @@
 {% endblock %}
 
 {% block furniture %}
-    <main class="content-wrapper" role="main">
+    <main class="content-wrapper">
         <h1>{% trans "Password change successful" %}</h1>
         <p><a href="{% url 'wagtailadmin_login' %}" class="button button-primary">{% trans "Login" %}</a></p>
     </main>

--- a/wagtail/admin/templates/wagtailadmin/account/password_reset/confirm.html
+++ b/wagtail/admin/templates/wagtailadmin/account/password_reset/confirm.html
@@ -16,7 +16,7 @@
 {% endblock %}
 
 {% block furniture %}
-    <main class="content-wrapper" role="main">
+    <main class="content-wrapper">
         {% if validlink %}
             <form method="post" novalidate>
                 {% csrf_token %}

--- a/wagtail/admin/templates/wagtailadmin/account/password_reset/done.html
+++ b/wagtail/admin/templates/wagtailadmin/account/password_reset/done.html
@@ -10,7 +10,7 @@
 {% endblock %}
 
 {% block furniture %}
-    <main class="content-wrapper" role="main">
+    <main class="content-wrapper">
         <h1>{% trans "Check your email" %}</h1>
         <p>{% trans "A link to reset your password has been emailed to you if an account exists for this address." %}</p>
     </main>

--- a/wagtail/admin/templates/wagtailadmin/account/password_reset/form.html
+++ b/wagtail/admin/templates/wagtailadmin/account/password_reset/form.html
@@ -10,7 +10,7 @@
 {% endblock %}
 
 {% block furniture %}
-    <main class="content-wrapper" role="main">
+    <main class="content-wrapper">
         {% include "wagtailadmin/shared/non_field_errors.html" %}
 
         <form method="post" novalidate>

--- a/wagtail/admin/templates/wagtailadmin/base.html
+++ b/wagtail/admin/templates/wagtailadmin/base.html
@@ -38,7 +38,7 @@
         </script>
     {% endif %}
 
-    <main class="content-wrapper" role="main" id="main">
+    <main class="content-wrapper" id="main">
         <div class="content">
             {# Always show messages div so it can be appended to by JS #}
             <div class="messages">

--- a/wagtail/admin/templates/wagtailadmin/login.html
+++ b/wagtail/admin/templates/wagtailadmin/login.html
@@ -10,7 +10,7 @@
 {% endblock %}
 
 {% block furniture %}
-    <main class="content-wrapper" role="main">
+    <main class="content-wrapper">
         {% if messages or form.errors %}
             <div class="messages">
                 <ul>


### PR DESCRIPTION
Fixes [#8211](https://github.com/wagtail/wagtail/issues/8211) by removing `role="main"` redundant attributes from the `<main>` element.