### PR TITLE
Add trimmed to blocktrans tags

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -37,6 +37,7 @@ Changelog
  * Add support for embedding Instagram reels (Luis Nell)
  * Use Django’s JavaScript catalog feature to manage translatable strings in JavaScript (Karl Hobley)
  * Add a `page_description` to the Page model, to provide help text for a given page type (Kalob Taulien, Thibaud Colas, Matt Westcott)
+ * Add `trimmed` attribute to all blocktrans tags, so spacing is more reliable in translated strings (Harris Lapiroff)
  * Fix: When using `simple_translations` ensure that the user is redirected to the page edit view when submitting for a single locale (Mitchel Cabuloy)
  * Fix: When previewing unsaved changes to `Form` pages, ensure that all added fields are correctly shown in the preview (Joshua Munn)
  * Fix: When Documents (e.g. PDFs) have been configured to be served inline via `WAGTAILDOCS_CONTENT_TYPES` & `WAGTAILDOCS_INLINE_CONTENT_TYPES` ensure that the filename is correctly set in the `Content-Disposition` header so that saving the files will use the correct filename (John-Scott Atlakson)

--- a/docs/extending/custom_bulk_actions.rst
+++ b/docs/extending/custom_bulk_actions.rst
@@ -48,7 +48,7 @@ An example for a confirmation template is as follows:
   {% extends 'wagtailadmin/bulk_actions/confirmation/base.html' %}
   {% load i18n wagtailadmin_tags %}
 
-  {% block titletag %}{% blocktrans count counter=items|length %}Delete 1 item{% plural %}Delete {{ counter }} items{% endblocktrans %}{% endblock %}
+  {% block titletag %}{% blocktrans trimmed count counter=items|length %}Delete 1 item{% plural %}Delete {{ counter }} items{% endblocktrans %}{% endblock %}
 
   {% block header %}
       {% trans "Delete" as del_str %}
@@ -70,7 +70,7 @@ An example for a confirmation template is as follows:
 
   {% block items_with_no_access %}
 
-  {% blocktrans asvar no_access_msg count counter=items_with_no_access|length %}You don't have permission to delete this item{% plural %}You don't have permission to delete these items{% endblocktrans %}
+  {% blocktrans trimmed asvar no_access_msg count counter=items_with_no_access|length %}You don't have permission to delete this item{% plural %}You don't have permission to delete these items{% endblocktrans %}
   {% include './list_items_with_no_access.html' with items=items_with_no_access no_access_msg=no_access_msg %}
 
   {% endblock items_with_no_access %}

--- a/docs/releases/3.0.md
+++ b/docs/releases/3.0.md
@@ -67,7 +67,7 @@ class LandingPage(Page):
  * Split up linting / formatting tasks in Makefile into client and server components (Hitansh Shah)
  * Add support for embedding Instagram reels (Luis Nell)
  * Use Django’s JavaScript catalog feature to manage translatable strings in JavaScript (Karl Hobley)
-
+ * Add `trimmed` attribute to all blocktrans tags, so spacing is more reliable in translated strings (Harris Lapiroff)
 
 ### Bug fixes
 

--- a/wagtail/admin/templates/wagtailadmin/chooser/_search_results.html
+++ b/wagtail/admin/templates/wagtailadmin/chooser/_search_results.html
@@ -1,7 +1,7 @@
 {% load i18n wagtailadmin_tags %}
 
 <h2 role="alert">
-    {% blocktrans count counter=pages.paginator.count %}
+    {% blocktrans trimmed count counter=pages.paginator.count %}
         There is {{ counter }} match
     {% plural %}
         There are {{ counter }} matches

--- a/wagtail/admin/templates/wagtailadmin/chooser/browse.html
+++ b/wagtail/admin/templates/wagtailadmin/chooser/browse.html
@@ -13,7 +13,7 @@
     {% if page_types_restricted %}
         <p class="help-block help-warning">
             {% icon name='warning' %}
-            {% blocktrans with type=page_type_names|join:", " count counter=page_type_names|length %}
+            {% blocktrans trimmed with type=page_type_names|join:", " count counter=page_type_names|length %}
                 Only pages of type "{{ type }}" may be chosen for this field. Search results will exclude pages of other types.
             {% plural %}
                 Only the following page types may be chosen for this field: {{ type }}. Search results will exclude pages of other types.

--- a/wagtail/admin/templates/wagtailadmin/chooser/confirm_external_to_internal.html
+++ b/wagtail/admin/templates/wagtailadmin/chooser/confirm_external_to_internal.html
@@ -4,14 +4,14 @@
 
 <div class="nice-padding">
     <p>
-        {% blocktrans %}
+        {% blocktrans trimmed %}
             The URL you entered, <a target="_blank" rel="noreferrer" href="{{ submitted_url }}">{{ submitted_url }}</a>,
             looks like it matches the internal page {{ page }}, which has the URL
             <a target="_blank" rel="noreferrer" href="{{ internal_url }}">{{ internal_url }}</a>.
         {% endblocktrans %}
     </p>
     <p>
-        {% blocktrans %}
+        {% blocktrans trimmed %}
             Converting this to an internal link to {{ page }} would make the link more robust.
             Would you like to do this?
         {% endblocktrans %}

--- a/wagtail/admin/templates/wagtailadmin/collections/index.html
+++ b/wagtail/admin/templates/wagtailadmin/collections/index.html
@@ -29,7 +29,7 @@
             </table>
         {% else %}
             {% url 'wagtailadmin_collections:add' as add_collection_url %}
-            <p>{% blocktrans %}No collections have been created. Why not <a href="{{ add_collection_url }}">add one</a>?{% endblocktrans %}</p>
+            <p>{% blocktrans trimmed %}No collections have been created. Why not <a href="{{ add_collection_url }}">add one</a>?{% endblocktrans %}</p>
         {% endif %}
     </div>
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/home.html
+++ b/wagtail/admin/templates/wagtailadmin/home.html
@@ -18,7 +18,7 @@
                 <div class="avatar"><img src="{% avatar_url user %}" alt="" /></div>
             </div>
             <div class="col9">
-                <h1>{% block branding_welcome %}{% blocktrans %}Welcome to the {{ site_name }} Wagtail CMS{% endblocktrans %}{% endblock %}</h1>
+                <h1>{% block branding_welcome %}{% blocktrans trimmed %}Welcome to the {{ site_name }} Wagtail CMS{% endblocktrans %}{% endblock %}</h1>
                 <div class="user-name">{{ user|user_display_name }}</div>
             </div>
         </div>

--- a/wagtail/admin/templates/wagtailadmin/home/locked_pages.html
+++ b/wagtail/admin/templates/wagtailadmin/home/locked_pages.html
@@ -49,7 +49,7 @@
                                 </ul>
                             </td>
                             <td>{# Deliberately empty #}</td>
-                            <td valign="top"><div class="human-readable-date" title="{{ page.locked_at|date:"DATETIME_FORMAT" }}">{% blocktrans with time_period=page.locked_at|timesince_simple %}{{ time_period }}{% endblocktrans %}</div></td>
+                            <td valign="top"><div class="human-readable-date" title="{{ page.locked_at|date:"DATETIME_FORMAT" }}">{% blocktrans trimmed with time_period=page.locked_at|timesince_simple %}{{ time_period }}{% endblocktrans %}</div></td>
                         </tr>
                     {% endfor %}
                 </tbody>

--- a/wagtail/admin/templates/wagtailadmin/home/pages_for_moderation.html
+++ b/wagtail/admin/templates/wagtailadmin/home/pages_for_moderation.html
@@ -66,7 +66,7 @@
                                 {{ revision.page.content_type.model_class.get_verbose_name }}
                             </td>
                             <td valign="top">
-                                <div class="human-readable-date" title="{{ revision.created_at|date:"DATETIME_FORMAT" }}">{% blocktrans with time_period=revision.created_at|timesince_simple %}{{ time_period }}{% endblocktrans %} </div>
+                                <div class="human-readable-date" title="{{ revision.created_at|date:"DATETIME_FORMAT" }}">{% blocktrans trimmed with time_period=revision.created_at|timesince_simple %}{{ time_period }}{% endblocktrans %} </div>
                                 {% if revision.user %}
                                     by {{ revision.user|user_display_name }}
                                 {% endif %}

--- a/wagtail/admin/templates/wagtailadmin/home/recent_edits.html
+++ b/wagtail/admin/templates/wagtailadmin/home/recent_edits.html
@@ -46,7 +46,7 @@
                             <td valign="top">
                                 {% include "wagtailadmin/shared/page_status_tag.html" with page=page %}
                             </td>
-                            <td valign="top"><div class="human-readable-date" title="{{ revision.created_at|date:"DATETIME_FORMAT" }}">{% blocktrans with time_period=revision.created_at|timesince_simple %}{{ time_period }}{% endblocktrans %}</div></td>
+                            <td valign="top"><div class="human-readable-date" title="{{ revision.created_at|date:"DATETIME_FORMAT" }}">{% blocktrans trimmed with time_period=revision.created_at|timesince_simple %}{{ time_period }}{% endblocktrans %}</div></td>
                         </tr>
                     {% endfor %}
                 </tbody>

--- a/wagtail/admin/templates/wagtailadmin/home/site_summary_pages.html
+++ b/wagtail/admin/templates/wagtailadmin/home/site_summary_pages.html
@@ -3,7 +3,7 @@
 <li>
     {% icon name="doc-empty-inverse" %}
     <a href="{% url 'wagtailadmin_explore' root_page.pk %}">
-        {% blocktrans count counter=total_pages with total_pages|intcomma as total %}
+        {% blocktrans trimmed count counter=total_pages with total_pages|intcomma as total %}
             <span>{{ total }}</span> Page <span class="visuallyhidden">created in {{ site_name }}</span>
         {% plural %}
             <span>{{ total }}</span> Pages <span class="visuallyhidden">created in {{ site_name }}</span>

--- a/wagtail/admin/templates/wagtailadmin/home/user_pages_in_workflow_moderation.html
+++ b/wagtail/admin/templates/wagtailadmin/home/user_pages_in_workflow_moderation.html
@@ -46,7 +46,7 @@
                                     {{ workflow_state.current_task_state.task.name }}
                                 </td>
                                 <td valign="top">
-                                    <div class="human-readable-date" title="{{ workflow_state.current_task_state.started_at|date:"DATETIME_FORMAT" }}">{% blocktrans with time_period=workflow_state.current_task_state.started_at|timesince_simple %}{{ time_period }}{% endblocktrans %} </div>
+                                    <div class="human-readable-date" title="{{ workflow_state.current_task_state.started_at|date:"DATETIME_FORMAT" }}">{% blocktrans trimmed with time_period=workflow_state.current_task_state.started_at|timesince_simple %}{{ time_period }}{% endblocktrans %} </div>
                                 </td>
                             </tr>
                         {% endwith %}

--- a/wagtail/admin/templates/wagtailadmin/home/workflow_pages_to_moderate.html
+++ b/wagtail/admin/templates/wagtailadmin/home/workflow_pages_to_moderate.html
@@ -74,7 +74,7 @@
                                     {% if revision.user %}{{ revision.user|user_display_name }}{% endif %}
                                 </td>
                                 <td valign="top">
-                                    <div class="human-readable-date" title="{{ task_state.started_at|date:"DATETIME_FORMAT" }}">{% blocktrans with time_period=task_state.started_at|timesince_simple %}{{ time_period }}{% endblocktrans %}</div>
+                                    <div class="human-readable-date" title="{{ task_state.started_at|date:"DATETIME_FORMAT" }}">{% blocktrans trimmed with time_period=task_state.started_at|timesince_simple %}{{ time_period }}{% endblocktrans %}</div>
                                 </td>
                             </tr>
                         {% endwith %}

--- a/wagtail/admin/templates/wagtailadmin/login.html
+++ b/wagtail/admin/templates/wagtailadmin/login.html
@@ -15,7 +15,7 @@
             <div class="messages">
                 <ul>
                     {% if form.errors %}
-                        <li class="error">{% blocktrans %}Your {{ username_field }} and password didn't match. Please try again.{% endblocktrans %}</li>
+                        <li class="error">{% blocktrans trimmed %}Your {{ username_field }} and password didn't match. Please try again.{% endblocktrans %}</li>
                     {% endif %}
                     {% for message in messages %}
                         <li class="{{ message.tags }}">{{ message }}</li>

--- a/wagtail/admin/templates/wagtailadmin/notifications/approved.html
+++ b/wagtail/admin/templates/wagtailadmin/notifications/approved.html
@@ -2,6 +2,6 @@
 {% load i18n %}
 
 {% block content %}
-    <p>{% blocktrans with title=revision.page.get_admin_display_title|safe %}The page "{{ title }}" has been approved.{% endblocktrans %}</p>
+    <p>{% blocktrans trimmed with title=revision.page.get_admin_display_title|safe %}The page "{{ title }}" has been approved.{% endblocktrans %}</p>
     <p>{% trans "You can view the page here:" %} <a href="{{ revision.page.full_url }}">{{ revision.page.full_url }}</a></p>
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/approved.txt
+++ b/wagtail/admin/templates/wagtailadmin/notifications/approved.txt
@@ -2,7 +2,7 @@
 {% load i18n %}
 
 {% block content %}
-{% blocktrans with title=revision.page.get_admin_display_title|safe %}The page "{{ title }}" has been approved.{% endblocktrans %}
+{% blocktrans trimmed with title=revision.page.get_admin_display_title|safe %}The page "{{ title }}" has been approved.{% endblocktrans %}
 
 {% trans "You can view the page here:" %} {{ revision.page.full_url }}
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/approved_subject.txt
+++ b/wagtail/admin/templates/wagtailadmin/notifications/approved_subject.txt
@@ -1,3 +1,3 @@
 {% load i18n %}
 
-{% blocktrans with title=revision.page.get_admin_display_title|safe %}The page "{{ title }}" has been approved{% endblocktrans %}
+{% blocktrans trimmed with title=revision.page.get_admin_display_title|safe %}The page "{{ title }}" has been approved{% endblocktrans %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/base.html
+++ b/wagtail/admin/templates/wagtailadmin/notifications/base.html
@@ -108,7 +108,7 @@
                                         {% endblock %}
 
                                         {% block greeting %}
-                                            <p>{% blocktrans with username=user.get_short_name|default:user.get_username %}Hello {{ username }},{% endblocktrans %}</p>
+                                            <p>{% blocktrans trimmed with username=user.get_short_name|default:user.get_username %}Hello {{ username }},{% endblocktrans %}</p>
                                         {% endblock %}
 
                                         {% block content %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/base.txt
+++ b/wagtail/admin/templates/wagtailadmin/notifications/base.txt
@@ -1,7 +1,7 @@
 {% load i18n %}
 
 {% block greeting %}
-{% blocktrans with username=user.get_short_name|default:user.get_username %}Hello {{ username }},{% endblocktrans %}
+{% blocktrans trimmed with username=user.get_short_name|default:user.get_username %}Hello {{ username }},{% endblocktrans %}
 {% endblock %}
 {% block content %}
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/rejected.html
+++ b/wagtail/admin/templates/wagtailadmin/notifications/rejected.html
@@ -2,6 +2,6 @@
 {% load i18n %}
 
 {% block content %}
-    <p>{% blocktrans with title=revision.page.get_admin_display_title|safe %}The page "{{ title }}" has been rejected.{% endblocktrans %}</p>
+    <p>{% blocktrans trimmed with title=revision.page.get_admin_display_title|safe %}The page "{{ title }}" has been rejected.{% endblocktrans %}</p>
     <p>{% trans "You can edit the page here:"%} <a href="{{ settings.BASE_URL }}{% url 'wagtailadmin_pages:edit' revision.page.id %}">{{ settings.BASE_URL }}{% url 'wagtailadmin_pages:edit' revision.page.id %}</a></p>
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/rejected.txt
+++ b/wagtail/admin/templates/wagtailadmin/notifications/rejected.txt
@@ -2,7 +2,7 @@
 {% load i18n %}
 
 {% block content %}
-{% blocktrans with title=revision.page.get_admin_display_title|safe %}The page "{{ title }}" has been rejected.{% endblocktrans %}
+{% blocktrans trimmed with title=revision.page.get_admin_display_title|safe %}The page "{{ title }}" has been rejected.{% endblocktrans %}
 
 {% trans "You can edit the page here:"%} {{ settings.BASE_URL }}{% url 'wagtailadmin_pages:edit' revision.page.id %}
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/rejected_subject.txt
+++ b/wagtail/admin/templates/wagtailadmin/notifications/rejected_subject.txt
@@ -1,3 +1,3 @@
 {% load i18n %}
 
-{% blocktrans with title=revision.page.get_admin_display_title|safe %}The page "{{ title }}" has been rejected{% endblocktrans %}
+{% blocktrans trimmed with title=revision.page.get_admin_display_title|safe %}The page "{{ title }}" has been rejected{% endblocktrans %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/submitted.html
+++ b/wagtail/admin/templates/wagtailadmin/notifications/submitted.html
@@ -3,7 +3,7 @@
 {% load wagtailadmin_tags i18n %}
 
 {% block content %}
-    <p>{% blocktrans with page=revision.page|safe editor=revision.user|user_display_name %}The page "{{ page }}" has been submitted for moderation by {{ editor }}.{% endblocktrans %}</p>
+    <p>{% blocktrans trimmed with page=revision.page|safe editor=revision.user|user_display_name %}The page "{{ page }}" has been submitted for moderation by {{ editor }}.{% endblocktrans %}</p>
 
     <p>
         {% if revision.page.is_previewable %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/submitted.txt
+++ b/wagtail/admin/templates/wagtailadmin/notifications/submitted.txt
@@ -2,7 +2,7 @@
 {% load wagtailadmin_tags i18n %}
 
 {% block content %}
-{% blocktrans with page=revision.page|safe editor=revision.user|user_display_name %}The page "{{ page }}" has been submitted for moderation by {{ editor }}.{% endblocktrans %}
+{% blocktrans trimmed with page=revision.page|safe editor=revision.user|user_display_name %}The page "{{ page }}" has been submitted for moderation by {{ editor }}.{% endblocktrans %}
 
 {% if revision.page.is_previewable %}{% trans "You can preview the page here:" %} {{ settings.BASE_URL }}{% url 'wagtailadmin_pages:preview_for_moderation' revision.id %}{% endif %}
 {% trans "You can edit the page here:" %} {{ settings.BASE_URL }}{% url 'wagtailadmin_pages:edit' revision.page.id %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/submitted_subject.txt
+++ b/wagtail/admin/templates/wagtailadmin/notifications/submitted_subject.txt
@@ -1,3 +1,3 @@
 {% load i18n %}
 
-{% blocktrans with page=revision.page|safe %}The page "{{ page }}" has been submitted for moderation{% endblocktrans %}
+{% blocktrans trimmed with page=revision.page|safe %}The page "{{ page }}" has been submitted for moderation{% endblocktrans %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/task_state_approved.html
+++ b/wagtail/admin/templates/wagtailadmin/notifications/task_state_approved.html
@@ -2,6 +2,6 @@
 {% load i18n %}
 
 {% block content %}
-    <p>{% blocktrans with title=page.get_admin_display_title task=task.name %}The page "{{ title }}" has been approved in moderation stage "{{ task }}".{% endblocktrans %}</p>
+    <p>{% blocktrans trimmed with title=page.get_admin_display_title task=task.name %}The page "{{ title }}" has been approved in moderation stage "{{ task }}".{% endblocktrans %}</p>
     <p>{% trans "You can edit the page here:"%} <a href="{{ settings.BASE_URL }}{% url 'wagtailadmin_pages:edit' page.id %}">{{ settings.BASE_URL }}{% url 'wagtailadmin_pages:edit' page.id %}</a></p>
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/task_state_approved.txt
+++ b/wagtail/admin/templates/wagtailadmin/notifications/task_state_approved.txt
@@ -2,6 +2,6 @@
 {% load i18n %}
 
 {% block content %}
-{% blocktrans with title=page.get_admin_display_title|safe task=task.name|safe %}The page "{{ title }}" has been approved in moderation stage "{{ task }}".{% endblocktrans %}
+{% blocktrans trimmed with title=page.get_admin_display_title|safe task=task.name|safe %}The page "{{ title }}" has been approved in moderation stage "{{ task }}".{% endblocktrans %}
 {% trans "You can edit the page here:"%} {{ settings.BASE_URL }}{% url 'wagtailadmin_pages:edit' page.id %}
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/task_state_approved_subject.txt
+++ b/wagtail/admin/templates/wagtailadmin/notifications/task_state_approved_subject.txt
@@ -1,3 +1,3 @@
 {% load i18n %}
 
-{% blocktrans with title=page.get_admin_display_title|safe task=task.name|safe %}The page "{{ title }}" has been approved in "{{ task }}".{% endblocktrans %}
+{% blocktrans trimmed with title=page.get_admin_display_title|safe task=task.name|safe %}The page "{{ title }}" has been approved in "{{ task }}".{% endblocktrans %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/task_state_rejected.html
+++ b/wagtail/admin/templates/wagtailadmin/notifications/task_state_rejected.html
@@ -2,6 +2,6 @@
 {% load i18n %}
 
 {% block content %}
-    <p>{% blocktrans with title=page.get_admin_display_title task=task.name %}The page "{{ title }}" has been rejected in moderation stage "{{ task }}".{% endblocktrans %}</p>
+    <p>{% blocktrans trimmed with title=page.get_admin_display_title task=task.name %}The page "{{ title }}" has been rejected in moderation stage "{{ task }}".{% endblocktrans %}</p>
     <p>{% trans "You can edit the page here:"%} <a href="{{ settings.BASE_URL }}{% url 'wagtailadmin_pages:edit' page.id %}">{{ settings.BASE_URL }}{% url 'wagtailadmin_pages:edit' page.id %}</a></p>
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/task_state_rejected.txt
+++ b/wagtail/admin/templates/wagtailadmin/notifications/task_state_rejected.txt
@@ -2,6 +2,6 @@
 {% load i18n %}
 
 {% block content %}
-{% blocktrans with title=page.get_admin_display_title|safe task=task.name|safe %}The page "{{ title }}" has been rejected in moderation stage "{{ task }}".{% endblocktrans %}
+{% blocktrans trimmed with title=page.get_admin_display_title|safe task=task.name|safe %}The page "{{ title }}" has been rejected in moderation stage "{{ task }}".{% endblocktrans %}
 {% trans "You can edit the page here:"%} {{ settings.BASE_URL }}{% url 'wagtailadmin_pages:edit' page.id %}
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/task_state_rejected_subject.txt
+++ b/wagtail/admin/templates/wagtailadmin/notifications/task_state_rejected_subject.txt
@@ -1,3 +1,3 @@
 {% load i18n %}
 
-{% blocktrans with title=page.get_admin_display_title|safe task=task.name|safe %}The page "{{ title }}" has been rejected during "{{ task }}".{% endblocktrans %}
+{% blocktrans trimmed with title=page.get_admin_display_title|safe task=task.name|safe %}The page "{{ title }}" has been rejected during "{{ task }}".{% endblocktrans %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/task_state_submitted.html
+++ b/wagtail/admin/templates/wagtailadmin/notifications/task_state_submitted.html
@@ -3,7 +3,7 @@
 {% load i18n %}
 
 {% block content %}
-    <p>{% blocktrans with task=task.name title=page.get_admin_display_title %}The page "{{ title }}" has been submitted for approval in moderation stage "{{ task }}".{% endblocktrans %}</p>
+    <p>{% blocktrans trimmed with task=task.name title=page.get_admin_display_title %}The page "{{ title }}" has been submitted for approval in moderation stage "{{ task }}".{% endblocktrans %}</p>
 
     <p>
         {% trans "You can preview the page here:" %} <a href="{{ settings.BASE_URL }}{% url 'wagtailadmin_pages:workflow_preview' page.id task.id %}">{{ settings.BASE_URL }}{% url 'wagtailadmin_pages:workflow_preview' page.id task.id %}</a><br/>

--- a/wagtail/admin/templates/wagtailadmin/notifications/task_state_submitted.txt
+++ b/wagtail/admin/templates/wagtailadmin/notifications/task_state_submitted.txt
@@ -3,7 +3,7 @@
 {% load i18n %}
 
 {% block content %}
-{% blocktrans with task=task.name|safe title=page.get_admin_display_title|safe %}The page "{{ title }}" has been submitted for approval to moderation stage "{{ task }}".{% endblocktrans %}
+{% blocktrans trimmed with task=task.name|safe title=page.get_admin_display_title|safe %}The page "{{ title }}" has been submitted for approval to moderation stage "{{ task }}".{% endblocktrans %}
 
 
 {% trans "You can preview the page here:" %} {{ settings.BASE_URL }}{% url 'wagtailadmin_pages:workflow_preview' page.id task.id %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/task_state_submitted_subject.txt
+++ b/wagtail/admin/templates/wagtailadmin/notifications/task_state_submitted_subject.txt
@@ -1,3 +1,3 @@
 {% load i18n %}
 
-{% blocktrans with title=page.get_admin_display_title|safe task=task.name|safe %}The page "{{ title }}" has been submitted for approval in moderation stage "{{ task }}" {% endblocktrans %}
+{% blocktrans trimmed with title=page.get_admin_display_title|safe task=task.name|safe %}The page "{{ title }}" has been submitted for approval in moderation stage "{{ task }}" {% endblocktrans %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/updated_comments.html
+++ b/wagtail/admin/templates/wagtailadmin/notifications/updated_comments.html
@@ -3,7 +3,7 @@
 
 {% block content %}
     <p>
-        {% blocktrans with title=page.get_admin_display_title editor=editor|user_display_name %}{{ editor }} has updated comments on "{{ title }}".{% endblocktrans %}
+        {% blocktrans trimmed with title=page.get_admin_display_title editor=editor|user_display_name %}{{ editor }} has updated comments on "{{ title }}".{% endblocktrans %}
     </p>
 
     {% if new_comments %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/updated_comments.txt
+++ b/wagtail/admin/templates/wagtailadmin/notifications/updated_comments.txt
@@ -1,7 +1,7 @@
 {% extends 'wagtailadmin/notifications/base.txt' %}
 {% load i18n wagtailadmin_tags %}
 
-{% block content %}{% blocktrans with title=page.get_admin_display_title|safe editor=editor|user_display_name|safe %}{{ editor }} has updated comments on "{{ title }}".{% endblocktrans %}
+{% block content %}{% blocktrans trimmed with title=page.get_admin_display_title|safe editor=editor|user_display_name|safe %}{{ editor }} has updated comments on "{{ title }}".{% endblocktrans %}
 {% spaceless %}
 
 {% endspaceless %}{% if new_comments %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/updated_comments_subject.txt
+++ b/wagtail/admin/templates/wagtailadmin/notifications/updated_comments_subject.txt
@@ -1,3 +1,3 @@
 {% load i18n wagtailadmin_tags %}
 
-{% blocktrans with title=page.get_admin_display_title|safe editor=editor|user_display_name|safe %}{{ editor }} has updated comments on "{{ title }}"{% endblocktrans %}
+{% blocktrans trimmed with title=page.get_admin_display_title|safe editor=editor|user_display_name|safe %}{{ editor }} has updated comments on "{{ title }}"{% endblocktrans %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/workflow_state_approved.html
+++ b/wagtail/admin/templates/wagtailadmin/notifications/workflow_state_approved.html
@@ -2,6 +2,6 @@
 {% load i18n %}
 
 {% block content %}
-    <p>{% blocktrans with title=page.get_admin_display_title workflow=workflow.name %}The page "{{ title }}" has been approved in workflow "{{ workflow }}".{% endblocktrans %}</p>
+    <p>{% blocktrans trimmed with title=page.get_admin_display_title workflow=workflow.name %}The page "{{ title }}" has been approved in workflow "{{ workflow }}".{% endblocktrans %}</p>
     <p>{% trans "You can view the page here:" %} <a href="{{ page.full_url }}">{{ page.full_url }}</a></p>
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/workflow_state_approved.txt
+++ b/wagtail/admin/templates/wagtailadmin/notifications/workflow_state_approved.txt
@@ -2,6 +2,6 @@
 {% load i18n %}
 
 {% block content %}
-{% blocktrans with title=page.get_admin_display_title|safe workflow=workflow.name|safe %}The page "{{ title }}" has been approved in workflow "{{ workflow }}".{% endblocktrans %}
+{% blocktrans trimmed with title=page.get_admin_display_title|safe workflow=workflow.name|safe %}The page "{{ title }}" has been approved in workflow "{{ workflow }}".{% endblocktrans %}
 {% trans "You can view the page here:" %} {{ page.full_url }}
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/workflow_state_approved_subject.txt
+++ b/wagtail/admin/templates/wagtailadmin/notifications/workflow_state_approved_subject.txt
@@ -1,3 +1,3 @@
 {% load i18n %}
 
-{% blocktrans with title=page.get_admin_display_title|safe workflow=workflow.name|safe %}The page "{{ title }}" has been approved in "{{ workflow }}".{% endblocktrans %}
+{% blocktrans trimmed with title=page.get_admin_display_title|safe workflow=workflow.name|safe %}The page "{{ title }}" has been approved in "{{ workflow }}".{% endblocktrans %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/workflow_state_rejected.html
+++ b/wagtail/admin/templates/wagtailadmin/notifications/workflow_state_rejected.html
@@ -3,12 +3,12 @@
 
 {% block content %}
     {% if task_state.finished_by %}
-        <p>{% blocktrans with title=page.get_admin_display_title workflow=workflow.name task=task.name rejector=task_state.finished_by|user_display_name %}The page "{{ title }}" has been rejected during "{{ task }}" in workflow "{{ workflow }}" by {{ rejector }}.{% endblocktrans %}</p>
+        <p>{% blocktrans trimmed with title=page.get_admin_display_title workflow=workflow.name task=task.name rejector=task_state.finished_by|user_display_name %}The page "{{ title }}" has been rejected during "{{ task }}" in workflow "{{ workflow }}" by {{ rejector }}.{% endblocktrans %}</p>
     {% else %}
-        <p>{% blocktrans with title=page.get_admin_display_title workflow=workflow.name task=task.name %}The page "{{ title }}" has been rejected during "{{ task }}" in workflow "{{ workflow }}".{% endblocktrans %}</p>
+        <p>{% blocktrans trimmed with title=page.get_admin_display_title workflow=workflow.name task=task.name %}The page "{{ title }}" has been rejected during "{{ task }}" in workflow "{{ workflow }}".{% endblocktrans %}</p>
     {% endif %}
     {% if comment %}
-        <p>{% blocktrans %}The following comment was left: "{{ comment }}"{% endblocktrans %}</p>
+        <p>{% blocktrans trimmed %}The following comment was left: "{{ comment }}"{% endblocktrans %}</p>
     {% endif %}
     <p>{% trans "You can edit the page here:"%} <a href="{{ settings.BASE_URL }}{% url 'wagtailadmin_pages:edit' page.id %}">{{ settings.BASE_URL }}{% url 'wagtailadmin_pages:edit' page.id %}</a></p>
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/workflow_state_rejected.txt
+++ b/wagtail/admin/templates/wagtailadmin/notifications/workflow_state_rejected.txt
@@ -3,12 +3,12 @@
 
 {% block content %}
 {% if task_state.finished_by %}
-    {% blocktrans with title=page.get_admin_display_title|safe workflow=workflow.name|safe task=task.name|safe rejector=task_state.finished_by|user_display_name %}The page "{{ title }}" has been rejected during "{{ task }}" in workflow "{{ workflow }}" by {{ rejector }}.{% endblocktrans %}
+    {% blocktrans trimmed with title=page.get_admin_display_title|safe workflow=workflow.name|safe task=task.name|safe rejector=task_state.finished_by|user_display_name %}The page "{{ title }}" has been rejected during "{{ task }}" in workflow "{{ workflow }}" by {{ rejector }}.{% endblocktrans %}
 {% else %}
-    {% blocktrans with title=page.get_admin_display_title|safe workflow=workflow.name|safe task=task.name|safe %}The page "{{ title }}" has been rejected during "{{ task }}" in workflow "{{ workflow }}".{% endblocktrans %}
+    {% blocktrans trimmed with title=page.get_admin_display_title|safe workflow=workflow.name|safe task=task.name|safe %}The page "{{ title }}" has been rejected during "{{ task }}" in workflow "{{ workflow }}".{% endblocktrans %}
 {% endif %}
 {% if comment %}
-    {% blocktrans with comment=comment|safe %}The following comment was left: "{{ comment }}"{% endblocktrans %}</p>
+    {% blocktrans trimmed with comment=comment|safe %}The following comment was left: "{{ comment }}"{% endblocktrans %}</p>
 {% endif %}
 {% trans "You can edit the page here:"%} {{ settings.BASE_URL }}{% url 'wagtailadmin_pages:edit' page.id %}
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/workflow_state_rejected_subject.txt
+++ b/wagtail/admin/templates/wagtailadmin/notifications/workflow_state_rejected_subject.txt
@@ -1,3 +1,3 @@
 {% load i18n %}
 
-{% blocktrans with title=page.get_admin_display_title|safe workflow=workflow.name|safe %}The page "{{ title }}" has been rejected during "{{ workflow }}".{% endblocktrans %}
+{% blocktrans trimmed with title=page.get_admin_display_title|safe workflow=workflow.name|safe %}The page "{{ title }}" has been rejected during "{{ workflow }}".{% endblocktrans %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/workflow_state_submitted.html
+++ b/wagtail/admin/templates/wagtailadmin/notifications/workflow_state_submitted.html
@@ -4,9 +4,9 @@
 
 {% block content %}
     {% if requested_by %}
-        <p>{% blocktrans with workflow=workflow.name title=page.get_admin_display_title requester=requested_by|user_display_name %}The page "{{ title }}" has been submitted for moderation to workflow "{{ workflow }}" by {{ requester }}.{% endblocktrans %}</p>
+        <p>{% blocktrans trimmed with workflow=workflow.name title=page.get_admin_display_title requester=requested_by|user_display_name %}The page "{{ title }}" has been submitted for moderation to workflow "{{ workflow }}" by {{ requester }}.{% endblocktrans %}</p>
     {% else %}
-        <p>{% blocktrans with workflow=workflow.name title=page.get_admin_display_title %}The page "{{ title }}" has been submitted for moderation to workflow "{{ workflow }}".{% endblocktrans %}</p>
+        <p>{% blocktrans trimmed with workflow=workflow.name title=page.get_admin_display_title %}The page "{{ title }}" has been submitted for moderation to workflow "{{ workflow }}".{% endblocktrans %}</p>
     {% endif %}
 
     <p>

--- a/wagtail/admin/templates/wagtailadmin/notifications/workflow_state_submitted.txt
+++ b/wagtail/admin/templates/wagtailadmin/notifications/workflow_state_submitted.txt
@@ -3,8 +3,8 @@
 {% load wagtailadmin_tags i18n %}
 
 {% block content %}
-{% if requested_by %}{% blocktrans with workflow=workflow.name|safe title=page.get_admin_display_title|safe requester=requested_by|user_display_name|safe %}The page "{{ title }}" has been submitted for moderation to workflow "{{ workflow }}" by {{ requester }}.{% endblocktrans %}
-{% else %}{% blocktrans with workflow=workflow.name|safe title=page.get_admin_display_title|safe %}The page "{{ title }}" has been submitted for moderation to workflow "{{ workflow }}".{% endblocktrans %}
+{% if requested_by %}{% blocktrans trimmed with workflow=workflow.name|safe title=page.get_admin_display_title|safe requester=requested_by|user_display_name|safe %}The page "{{ title }}" has been submitted for moderation to workflow "{{ workflow }}" by {{ requester }}.{% endblocktrans %}
+{% else %}{% blocktrans trimmed with workflow=workflow.name|safe title=page.get_admin_display_title|safe %}The page "{{ title }}" has been submitted for moderation to workflow "{{ workflow }}".{% endblocktrans %}
 {% endif %}
 
 {% trans "You can edit the page here:" %} {{ settings.BASE_URL }}{% url 'wagtailadmin_pages:edit' page.id %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/workflow_state_submitted_subject.txt
+++ b/wagtail/admin/templates/wagtailadmin/notifications/workflow_state_submitted_subject.txt
@@ -1,3 +1,3 @@
 {% load i18n %}
 
-{% blocktrans with title=page.get_admin_display_title|safe workflow=workflow.name|safe %}The page "{{ title }}" has been submitted to workflow "{{ workflow }}" {% endblocktrans %}
+{% blocktrans trimmed with title=page.get_admin_display_title|safe workflow=workflow.name|safe %}The page "{{ title }}" has been submitted to workflow "{{ workflow }}" {% endblocktrans %}

--- a/wagtail/admin/templates/wagtailadmin/pages/_unsaved_changes_warning.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/_unsaved_changes_warning.html
@@ -2,9 +2,9 @@
 <li class="footer__container footer__container--hidden" data-unsaved-warning>
     <div hidden data-unsaved-type="any" class="footer__save-warning footer__emphasise-span-tags">
         <div>
-            <b hidden data-unsaved-type="edits">{% blocktrans %}You have <span>unsaved edits</span>{% endblocktrans %}</b>
-            <b hidden data-unsaved-type="comments">{% blocktrans %}You have <span>unsaved comments</span>{% endblocktrans %}</b>
-            <b hidden data-unsaved-type="all">{% blocktrans %}You have <span>unsaved edits</span> and <span>comments</span>{% endblocktrans %}</b>
+            <b hidden data-unsaved-type="edits">{% blocktrans trimmed %}You have <span>unsaved edits</span>{% endblocktrans %}</b>
+            <b hidden data-unsaved-type="comments">{% blocktrans trimmed %}You have <span>unsaved comments</span>{% endblocktrans %}</b>
+            <b hidden data-unsaved-type="all">{% blocktrans trimmed %}You have <span>unsaved edits</span> and <span>comments</span>{% endblocktrans %}</b>
             <p>{% trans 'Save the page before leaving' %}</p>
         </div>
     </div>

--- a/wagtail/admin/templates/wagtailadmin/pages/add_subpage.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/add_subpage.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 {% load wagtailadmin_tags %}
 
-{% block titletag %}{% blocktrans with title=parent_page.get_admin_display_title %}Create a page in {{ title }}{% endblocktrans %}{% endblock %}
+{% block titletag %}{% blocktrans trimmed with title=parent_page.get_admin_display_title %}Create a page in {{ title }}{% endblocktrans %}{% endblock %}
 
 {% block content %}
     {% trans "Create a page in" as create_str %}
@@ -26,7 +26,7 @@
                             </div>
 
                             <small class="col4" style="text-align:end">
-                                <a href="{% url 'wagtailadmin_pages:type_use' app_label model_name %}" class="nolink">{% blocktrans with page_type=verbose_name %}Pages using {{ page_type }}{% endblocktrans %}</a>
+                                <a href="{% url 'wagtailadmin_pages:type_use' app_label model_name %}" class="nolink">{% blocktrans trimmed with page_type=verbose_name %}Pages using {{ page_type }}{% endblocktrans %}</a>
                             </small>
 
                         </div>

--- a/wagtail/admin/templates/wagtailadmin/pages/bulk_actions/confirm_bulk_delete.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/bulk_actions/confirm_bulk_delete.html
@@ -1,7 +1,7 @@
 {% extends 'wagtailadmin/bulk_actions/confirmation/base.html' %}
 {% load i18n wagtailadmin_tags %}
 
-{% block titletag %}{% blocktrans count counter=items|length %}Delete 1 page {% plural %}Delete {{ counter }} pages{% endblocktrans %}{% endblock %}
+{% block titletag %}{% blocktrans trimmed count counter=items|length %}Delete 1 page {% plural %}Delete {{ counter }} pages{% endblocktrans %}{% endblock %}
 
 {% block header %}
     {% trans "Delete" as del_str %}
@@ -17,7 +17,7 @@
                     <a href="{% url 'wagtailadmin_pages:edit' page.item.id %}" target="_blank" rel="noreferrer">{{ page.item.get_admin_display_title }}</a>
                     {% if page.descendant_count %}
                         <p>
-                            {% blocktrans count counter=page.descendant_count %}
+                            {% blocktrans trimmed count counter=page.descendant_count %}
                                 This will also delete one more subpage.
                             {% plural %}
                                 This will also delete {{ counter }} more subpages.
@@ -32,7 +32,7 @@
 
 {% block items_with_no_access %}
 
-    {% blocktrans asvar no_access_msg count counter=items_with_no_access|length %}You don't have permission to delete this page{% plural %}You don't have permission to delete these pages{% endblocktrans %}
+    {% blocktrans trimmed asvar no_access_msg count counter=items_with_no_access|length %}You don't have permission to delete this page{% plural %}You don't have permission to delete these pages{% endblocktrans %}
     {% include './list_items_with_no_access.html' with items=items_with_no_access no_access_msg=no_access_msg %}
 
 {% endblock items_with_no_access %}

--- a/wagtail/admin/templates/wagtailadmin/pages/bulk_actions/confirm_bulk_move.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/bulk_actions/confirm_bulk_move.html
@@ -1,7 +1,7 @@
 {% extends 'wagtailadmin/bulk_actions/confirmation/base.html' %}
 {% load i18n %}
 
-{% block titletag %}{% blocktrans count counter=items|length %}Move 1 page{% plural %}Move {{ counter }} pages{% endblocktrans %}
+{% block titletag %}{% blocktrans trimmed count counter=items|length %}Move 1 page{% plural %}Move {{ counter }} pages{% endblocktrans %}
 {% endblock %}
 
 {% block header %}
@@ -18,7 +18,7 @@
                     <a href="{% url 'wagtailadmin_pages:edit' page.item.id %}" target="_blank" rel="noreferrer">{{ page.item.get_admin_display_title }}</a>
                     {% if not page.item.is_leaf %}
                         <p>
-                            {% blocktrans count counter=page.child_pages %}
+                            {% blocktrans trimmed count counter=page.child_pages %}
                                 This page has one child page
                             {% plural %}
                                 This page has {{ counter }} child pages
@@ -33,13 +33,13 @@
 
 {% block items_with_no_access %}
 
-    {% blocktrans asvar no_access_msg count counter=items_with_no_access|length %}You don't have permission to move this page{% plural %}You don't have permission to move these pages{% endblocktrans %}
+    {% blocktrans trimmed asvar no_access_msg count counter=items_with_no_access|length %}You don't have permission to move this page{% plural %}You don't have permission to move these pages{% endblocktrans %}
     {% include './list_items_with_no_access.html' with items=items_with_no_access no_access_msg=no_access_msg %}
 
-    {% blocktrans asvar no_access_msg with dest_title=destination.title count counter=items_with_no_access|length %}The following page cannot be moved to {{dest_title}} {% plural %}The following pages cannot be moved to {{dest_title}}{% endblocktrans %}
+    {% blocktrans trimmed asvar no_access_msg with dest_title=destination.title count counter=items_with_no_access|length %}The following page cannot be moved to {{dest_title}} {% plural %}The following pages cannot be moved to {{dest_title}}{% endblocktrans %}
     {% include './list_items_with_no_access.html' with items=pages_without_destination_access no_access_msg=no_access_msg %}
 
-    {% blocktrans asvar no_access_msg count counter=pages_with_duplicate_slugs|length %}The following page cannot be moved due to duplicate slug{% plural %}The following pages cannot be moved due to duplicate slugs{% endblocktrans %}
+    {% blocktrans trimmed asvar no_access_msg count counter=pages_with_duplicate_slugs|length %}The following page cannot be moved due to duplicate slug{% plural %}The following pages cannot be moved due to duplicate slugs{% endblocktrans %}
     {% include './list_items_with_no_access.html' with items=pages_with_duplicate_slugs no_access_msg=no_access_msg %}
 
     {% trans "There is no valid destination page for these pages" as no_access_msg %}

--- a/wagtail/admin/templates/wagtailadmin/pages/bulk_actions/confirm_bulk_publish.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/bulk_actions/confirm_bulk_publish.html
@@ -1,7 +1,7 @@
 {% extends 'wagtailadmin/bulk_actions/confirmation/base.html' %}
 {% load i18n %}
 
-{% block titletag %}{% blocktrans count counter=items|length %}Publish 1 page {% plural %}Publish {{ counter }} pages{% endblocktrans %}{% endblock %}
+{% block titletag %}{% blocktrans trimmed count counter=items|length %}Publish 1 page {% plural %}Publish {{ counter }} pages{% endblocktrans %}{% endblock %}
 
 {% block header %}
     {% trans "Publish" as publish_str %}
@@ -17,7 +17,7 @@
                     <a href="{% url 'wagtailadmin_pages:edit' page.item.id %}" target="_blank" rel="noreferrer">{{ page.item.get_admin_display_title }}</a>
                     {% if page.draft_descendant_count %}
                         <p>
-                            {% blocktrans count counter=page.draft_descendant_count %}
+                            {% blocktrans trimmed count counter=page.draft_descendant_count %}
                                 This page has one unpublished subpage
                             {% plural %}
                                 This page has {{ counter }} unpublished subpages
@@ -32,7 +32,7 @@
 
 {% block items_with_no_access %}
 
-    {% blocktrans asvar no_access_msg count counter=items_with_no_access|length %}You don't have permission to publish this page{% plural %}You don't have permission to publish these pages{% endblocktrans %}
+    {% blocktrans trimmed asvar no_access_msg count counter=items_with_no_access|length %}You don't have permission to publish this page{% plural %}You don't have permission to publish these pages{% endblocktrans %}
     {% include './list_items_with_no_access.html' with items=items_with_no_access no_access_msg=no_access_msg %}
 
 {% endblock items_with_no_access %}

--- a/wagtail/admin/templates/wagtailadmin/pages/bulk_actions/confirm_bulk_unpublish.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/bulk_actions/confirm_bulk_unpublish.html
@@ -1,7 +1,7 @@
 {% extends 'wagtailadmin/bulk_actions/confirmation/base.html' %}
 {% load i18n %}
 
-{% block titletag %}{% blocktrans count counter=items|length %}Unpublish 1 page {% plural %}Unpublish {{ counter }} pages{% endblocktrans %}{% endblock %}
+{% block titletag %}{% blocktrans trimmed count counter=items|length %}Unpublish 1 page {% plural %}Unpublish {{ counter }} pages{% endblocktrans %}{% endblock %}
 
 {% block header %}
     {% trans "Unpublish" as unpublish_str %}
@@ -17,7 +17,7 @@
                     <a href="{% url 'wagtailadmin_pages:edit' page.item.id %}" target="_blank" rel="noreferrer">{{ page.item.get_admin_display_title }}</a>
                     <p>
                         {% if page.live_descendant_count %}
-                            {% blocktrans count counter=page.live_descendant_count %}
+                            {% blocktrans trimmed count counter=page.live_descendant_count %}
                                 This page has one subpage
                             {% plural %}
                                 This page has {{ counter }} subpages
@@ -32,7 +32,7 @@
 
 {% block items_with_no_access %}
 
-    {% blocktrans asvar no_access_msg count counter=items_with_no_access|length %}You don't have permission to unpublish this page{% plural %}You don't have permission to unpublish these pages{% endblocktrans %}
+    {% blocktrans trimmed asvar no_access_msg count counter=items_with_no_access|length %}You don't have permission to unpublish this page{% plural %}You don't have permission to unpublish these pages{% endblocktrans %}
     {% include './list_items_with_no_access.html' with items=items_with_no_access no_access_msg=no_access_msg %}
 
 {% endblock items_with_no_access %}

--- a/wagtail/admin/templates/wagtailadmin/pages/confirm_convert_alias.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/confirm_convert_alias.html
@@ -1,6 +1,6 @@
 {% extends "wagtailadmin/base.html" %}
 {% load i18n wagtailadmin_tags %}
-{% block titletag %}{% blocktrans with title=page.get_admin_display_title %}Convert alias {{ title }}{% endblocktrans %}{% endblock %}
+{% block titletag %}{% blocktrans trimmed with title=page.get_admin_display_title %}Convert alias {{ title }}{% endblocktrans %}{% endblock %}
 
 {% block content %}
     {% trans "Convert alias" as del_str %}

--- a/wagtail/admin/templates/wagtailadmin/pages/confirm_delete.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/confirm_delete.html
@@ -1,6 +1,6 @@
 {% extends "wagtailadmin/base.html" %}
 {% load i18n wagtailadmin_tags %}
-{% block titletag %}{% blocktrans with title=page.get_admin_display_title %}Delete {{ title }}{% endblocktrans %}{% endblock %}
+{% block titletag %}{% blocktrans trimmed with title=page.get_admin_display_title %}Delete {{ title }}{% endblocktrans %}{% endblock %}
 
 {% block content %}
     {% trans "Delete" as del_str %}
@@ -10,7 +10,7 @@
         <p>
             {% trans 'Are you sure you want to delete this page?' %}
             {% if descendant_count %}
-                {% blocktrans count counter=descendant_count %}
+                {% blocktrans trimmed count counter=descendant_count %}
                     This will also delete one more subpage.
                 {% plural %}
                     This will also delete {{ descendant_count }} more subpages.
@@ -28,7 +28,7 @@
         {% page_permissions page as page_perms %}
         {% if page_perms.can_unpublish %}
             {% url 'wagtailadmin_pages:unpublish' page.id as unpublish_url %}
-            <p style="margin-top: 1em">{% blocktrans %}Alternatively you can <a href="{{ unpublish_url }}">unpublish the page</a>. This removes the page from public view and you can edit or publish it again later.{% endblocktrans %}</p>
+            <p style="margin-top: 1em">{% blocktrans trimmed %}Alternatively you can <a href="{{ unpublish_url }}">unpublish the page</a>. This removes the page from public view and you can edit or publish it again later.{% endblocktrans %}</p>
         {% endif %}
     </div>
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/pages/confirm_move.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/confirm_move.html
@@ -1,15 +1,15 @@
 {% extends "wagtailadmin/base.html" %}
 {% load i18n %}
-{% block titletag %}{% blocktrans with title=page_to_move.get_admin_display_title %}Move {{ title }}{% endblocktrans %}{% endblock %}
+{% block titletag %}{% blocktrans trimmed with title=page_to_move.get_admin_display_title %}Move {{ title }}{% endblocktrans %}{% endblock %}
 {% block content %}
     {% trans "Move" as move_str %}
     {% include "wagtailadmin/shared/header.html" with title=move_str subtitle=page_to_move.get_admin_display_title icon="doc-empty-inverse" %}
 
     <div class="nice-padding">
         {% if page_to_move.is_leaf %}
-            <p>{% blocktrans with title=destination.get_admin_display_title %}Are you sure you want to move this page into '{{ title }}'?{% endblocktrans %}</p>
+            <p>{% blocktrans trimmed with title=destination.get_admin_display_title %}Are you sure you want to move this page into '{{ title }}'?{% endblocktrans %}</p>
         {% else %}
-            <p>{% blocktrans with title=destination.get_admin_display_title %}Are you sure you want to move this page and all of its children into '{{ title }}'?{% endblocktrans %}</p>
+            <p>{% blocktrans trimmed with title=destination.get_admin_display_title %}Are you sure you want to move this page and all of its children into '{{ title }}'?{% endblocktrans %}</p>
         {% endif %}
 
         <form action="{% url 'wagtailadmin_pages:move_confirm' page_to_move.id destination.id %}" method="POST">

--- a/wagtail/admin/templates/wagtailadmin/pages/confirm_unpublish.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/confirm_unpublish.html
@@ -1,6 +1,6 @@
 {% extends "wagtailadmin/base.html" %}
 {% load i18n %}
-{% block titletag %}{% blocktrans with title=page.get_admin_display_title %}Unpublish {{ title }}{% endblocktrans %}{% endblock %}
+{% block titletag %}{% blocktrans trimmed with title=page.get_admin_display_title %}Unpublish {{ title }}{% endblocktrans %}{% endblock %}
 {% block content %}
     {% trans "Unpublish" as unpublish_str %}
     {% include "wagtailadmin/shared/header.html" with title=unpublish_str subtitle=page.get_admin_display_title icon="doc-empty-inverse" %}
@@ -17,7 +17,7 @@
                             <div class="field-content">
                                 <div class="input">
                                     <input id="id_include_descendants" name="include_descendants" type="checkbox">
-                                    <label for="id_include_descendants" class="plain-checkbox-label">{% blocktrans count counter=live_descendant_count %}
+                                    <label for="id_include_descendants" class="plain-checkbox-label">{% blocktrans trimmed count counter=live_descendant_count %}
                                         This page has one subpage. Unpublish this too
                                     {% plural %}
                                         This page has {{ live_descendant_count }} subpages. Unpublish these too

--- a/wagtail/admin/templates/wagtailadmin/pages/confirm_workflow_cancellation.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/confirm_workflow_cancellation.html
@@ -5,11 +5,11 @@
 <div class="nice-padding">
     <p>
         {% if needs_changes %}
-            {% blocktrans %}
+            {% blocktrans trimmed %}
                 This page was marked as needing changes at <strong>{{ task }}</strong> in <strong>{{ workflow }}</strong>.
             {% endblocktrans %}
         {% else %}
-            {% blocktrans %}
+            {% blocktrans trimmed %}
                 This page is currently at <strong>{{ task }}</strong> in <strong>{{ workflow }}</strong>.
             {% endblocktrans %}
         {% endif %}

--- a/wagtail/admin/templates/wagtailadmin/pages/content_type_use.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/content_type_use.html
@@ -1,6 +1,6 @@
 {% extends "wagtailadmin/base.html" %}
 {% load i18n %}
-{% block titletag %}{% blocktrans with page_class_verbose_name=page_class.get_verbose_name %}Pages using {{ page_class_verbose_name }}{% endblocktrans %}{% endblock %}
+{% block titletag %}{% blocktrans trimmed with page_class_verbose_name=page_class.get_verbose_name %}Pages using {{ page_class_verbose_name }}{% endblocktrans %}{% endblock %}
 
 {% block content %}
     {% trans "Pages using" as pages_str %}

--- a/wagtail/admin/templates/wagtailadmin/pages/copy.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/copy.html
@@ -1,6 +1,6 @@
 {% extends "wagtailadmin/base.html" %}
 {% load i18n %}
-{% block titletag %}{% blocktrans with title=page.specific_deferred.get_admin_display_title %}Copy {{ title }}{% endblocktrans %}{% endblock %}
+{% block titletag %}{% blocktrans trimmed with title=page.specific_deferred.get_admin_display_title %}Copy {{ title }}{% endblocktrans %}{% endblock %}
 {% block content %}
     {% trans "Copy" as copy_str %}
     {% include "wagtailadmin/shared/header.html" with title=copy_str subtitle=page.specific_deferred.get_admin_display_title icon="doc-empty-inverse" %}

--- a/wagtail/admin/templates/wagtailadmin/pages/create.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/create.html
@@ -2,7 +2,7 @@
 {% load wagtailadmin_tags %}
 {% load i18n %}
 
-{% block titletag %}{% blocktrans with page_type=content_type.model_class.get_verbose_name %}New {{ page_type }}{% endblocktrans %}{% endblock %}
+{% block titletag %}{% blocktrans trimmed with page_type=content_type.model_class.get_verbose_name %}New {{ page_type }}{% endblocktrans %}{% endblock %}
 {% block bodyclass %}page-editor create model-{{ content_type.model }}{% endblock %}
 
 {% block content %}

--- a/wagtail/admin/templates/wagtailadmin/pages/edit.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/edit.html
@@ -2,7 +2,7 @@
 {% load wagtailadmin_tags %}
 {% load i18n %}
 {% load l10n %}
-{% block titletag %}{% blocktrans with title=page.get_admin_display_title page_type=content_type.model_class.get_verbose_name %}Editing {{ page_type }}: {{ title }}{% endblocktrans %}{% endblock %}
+{% block titletag %}{% blocktrans trimmed with title=page.get_admin_display_title page_type=content_type.model_class.get_verbose_name %}Editing {{ page_type }}: {{ title }}{% endblocktrans %}{% endblock %}
 {% block bodyclass %}page-editor {% if page.live %}page-is-live{% endif %} model-{{ content_type.model }} {% if page_locked %}page-locked{% endif %}{% endblock %}
 
 {% block content %}
@@ -12,10 +12,10 @@
         {% explorer_breadcrumb page page_perms=page_perms show_header_buttons=True %}
 
         <div class="row row-flush">
-            <div class="left col9 header-title" title="{% blocktrans with title=page.get_admin_display_title page_type=content_type.model_class.get_verbose_name %}Editing {{ page_type }}{% endblocktrans %}">
+            <div class="left col9 header-title" title="{% blocktrans trimmed with title=page.get_admin_display_title page_type=content_type.model_class.get_verbose_name %}Editing {{ page_type }}{% endblocktrans %}">
                 <h1>
                     {% icon name="doc-empty-inverse" class_name="header-title-icon" %}
-                    {% blocktrans with title=page.get_admin_display_title page_type=content_type.model_class.get_verbose_name %}Editing {{ page_type }} <span>{{ title }}</span>{% endblocktrans %}
+                    {% blocktrans trimmed with title=page.get_admin_display_title page_type=content_type.model_class.get_verbose_name %}Editing {{ page_type }} <span>{{ title }}</span>{% endblocktrans %}
                 </h1>
             </div>
             <div class="right col3">

--- a/wagtail/admin/templates/wagtailadmin/pages/history.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/history.html
@@ -1,7 +1,7 @@
 {% extends 'wagtailadmin/reports/base_report.html' %}
 {% load i18n wagtailadmin_tags %}
 
-{% block titletag %}{% blocktrans with title=subtitle %}Page history for {{ subtitle }}{% endblocktrans %}{% endblock %}
+{% block titletag %}{% blocktrans trimmed with title=subtitle %}Page history for {{ subtitle }}{% endblocktrans %}{% endblock %}
 
 {% block actions %}
     <a href="{% url 'wagtailadmin_pages:edit' page.id %}" class="button bicolor icon icon-edit">{% trans "Edit this page" %}</a>
@@ -47,7 +47,7 @@
                             {% include "wagtailadmin/shared/user_avatar.html" with user=entry.user username=entry.user_display_name %}
                         </td>
                         <td class="updated">
-                            <div class="human-readable-date" title="{{ entry.timestamp|date:"DATETIME_FORMAT" }}">{% blocktrans with time_period=entry.timestamp|timesince %}{{ time_period }} ago{% endblocktrans %}</div>
+                            <div class="human-readable-date" title="{{ entry.timestamp|date:"DATETIME_FORMAT" }}">{% blocktrans trimmed with time_period=entry.timestamp|timesince %}{{ time_period }} ago{% endblocktrans %}</div>
                         </td>
                     </tr>
                 {% endfor %}

--- a/wagtail/admin/templates/wagtailadmin/pages/index.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/index.html
@@ -1,6 +1,6 @@
 {% extends "wagtailadmin/base.html" %}
 {% load wagtailadmin_tags i18n %}
-{% block titletag %}{% blocktrans with title=parent_page.get_admin_display_title %}Exploring {{ title }}{% endblocktrans %}{% endblock %}
+{% block titletag %}{% blocktrans trimmed with title=parent_page.get_admin_display_title %}Exploring {{ title }}{% endblocktrans %}{% endblock %}
 {% block bodyclass %}page-explorer {% if ordering == 'ord' %}reordering{% endif %}{% endblock %}
 
 {% block content %}

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_list.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_list.html
@@ -24,7 +24,7 @@
                     {% block parent_page_title %}
                     {% endblock %}
                 </td>
-                <td class="updated" valign="bottom">{% if parent_page.latest_revision_created_at %}<div class="human-readable-date" title="{{ parent_page.latest_revision_created_at|date:"DATETIME_FORMAT" }}">{% blocktrans with time_period=parent_page.latest_revision_created_at|timesince %}{{ time_period }} ago{% endblocktrans %}</div>{% endif %}</td>
+                <td class="updated" valign="bottom">{% if parent_page.latest_revision_created_at %}<div class="human-readable-date" title="{{ parent_page.latest_revision_created_at|date:"DATETIME_FORMAT" }}">{% blocktrans trimmed with time_period=parent_page.latest_revision_created_at|timesince %}{{ time_period }} ago{% endblocktrans %}</div>{% endif %}</td>
                 <td class="type" valign="bottom">
                     {% if not parent_page.is_root %}
                         {{ parent_page.content_type.model_class.get_verbose_name }}
@@ -68,7 +68,7 @@
                             {% endblock %}
                         </td>
                     {% endif %}
-                    <td class="updated" valign="top">{% if page.latest_revision_created_at %}<div class="human-readable-date" title="{{ page.latest_revision_created_at|date:"DATETIME_FORMAT" }}">{% blocktrans with time_period=page.latest_revision_created_at|timesince %}{{ time_period }} ago{% endblocktrans %}</div>{% endif %}</td>
+                    <td class="updated" valign="top">{% if page.latest_revision_created_at %}<div class="human-readable-date" title="{{ page.latest_revision_created_at|date:"DATETIME_FORMAT" }}">{% blocktrans trimmed with time_period=page.latest_revision_created_at|timesince %}{{ time_period }} ago{% endblocktrans %}</div>{% endif %}</td>
                     <td class="type" valign="top">{{ page.content_type.model_class.get_verbose_name }}</td>
                     <td class="status" valign="top">
                         {% include "wagtailadmin/shared/page_status_tag.html" with page=page %}

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_list_explore.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_list_explore.html
@@ -17,7 +17,7 @@
                 {% if perms.wagtailcore.add_site %}
                     {% url 'wagtailsites:index' as wagtailsites_index_url %}
                     <p>
-                        {% blocktrans %}
+                        {% blocktrans trimmed %}
                             The root level is where you can add new sites to your Wagtail installation. Pages created here will not be accessible at any URL until they are associated with a site.
                         {% endblocktrans %}
                         {% if wagtailsites_index_url %}
@@ -25,12 +25,12 @@
                         {% endif %}
                     </p>
                     <p>
-                        {% blocktrans %}
+                        {% blocktrans trimmed %}
                             If you just want to add pages to an existing site, create them as children of the homepage instead.
                         {% endblocktrans %}
                     </p>
                 {% else %}
-                    {% blocktrans %}
+                    {% blocktrans trimmed %}
                         Pages created here will not be accessible at any URL. To add pages to an existing site, create them as children of the homepage.
                     {% endblocktrans %}
                 {% endif %}
@@ -41,14 +41,14 @@
                 {% icon name='warning' %}
                 {% if perms.wagtailcore.add_site %}
                     {% url 'wagtailsites:index' as wagtailsites_index_url %}
-                    {% blocktrans %}
+                    {% blocktrans trimmed %}
                         There is no site set up for this location. Pages created here will not be accessible at any URL until a site is associated with this location.
                     {% endblocktrans %}
                     {% if wagtailsites_index_url %}
                         <a href="{{ wagtailsites_index_url }}">{% trans "Configure a site now." %}</a>
                     {% endif %}
                 {% else %}
-                    {% blocktrans %}
+                    {% blocktrans trimmed %}
                         There is no site record for this location. Pages created here will not be accessible at any URL.
                     {% endblocktrans %}
                 {% endif %}
@@ -69,5 +69,5 @@
 
 {% block no_results %}
     {% url 'wagtailadmin_pages:add_subpage' parent_page.id as add_page_url%}
-    <tr><td colspan="3" class="no-results-message"><p>{% trans "No pages have been created at this location." %}{% if parent_page and parent_page_perms.can_add_subpage %} {% blocktrans %}Why not <a href="{{ add_page_url }}">create one</a>?{% endblocktrans %}{% endif %}</p></td></tr>
+    <tr><td colspan="3" class="no-results-message"><p>{% trans "No pages have been created at this location." %}{% if parent_page and parent_page_perms.can_add_subpage %} {% blocktrans trimmed %}Why not <a href="{{ add_page_url }}">create one</a>?{% endblocktrans %}{% endif %}</p></td></tr>
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_navigation_choose.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_navigation_choose.html
@@ -6,6 +6,6 @@ Navigation controls for the page listing in 'choose' mode
 
 <td class="{% if allow_navigation and page.can_descend %}children{% endif %}">
     {% if allow_navigation and page.can_descend %}
-        <a href="{% url 'wagtailadmin_choose_page_child' page.id %}{% querystring p=None %}" class="icon text-replace icon-arrow-right navigate-pages" title="{% blocktrans with title=page.get_admin_display_title %}Explore subpages of '{{ title }}'{% endblocktrans %}">{% trans 'Explore' %}</a>
+        <a href="{% url 'wagtailadmin_choose_page_child' page.id %}{% querystring p=None %}" class="icon text-replace icon-arrow-right navigate-pages" title="{% blocktrans trimmed with title=page.get_admin_display_title %}Explore subpages of '{{ title }}'{% endblocktrans %}">{% trans 'Explore' %}</a>
     {% endif %}
 </td>

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_navigation_explore.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_navigation_explore.html
@@ -9,15 +9,15 @@ Navigation controls for the page listing in 'explore' mode
         <a
             href="{% url 'wagtailadmin_explore' page.id %}"
             class="icon icon-arrow-right text-replace"
-            title="{% blocktrans with title=page.get_admin_display_title %}Explore child pages of '{{ title }}'{% endblocktrans %}"
-            aria-label="{% blocktrans with title=page.get_admin_display_title %}Explore child pages of '{{ title }}'{% endblocktrans %}"
+            title="{% blocktrans trimmed with title=page.get_admin_display_title %}Explore child pages of '{{ title }}'{% endblocktrans %}"
+            aria-label="{% blocktrans trimmed with title=page.get_admin_display_title %}Explore child pages of '{{ title }}'{% endblocktrans %}"
         ></a>
     {% elif page_perms.can_add_subpage %}
         <a
             href="{% url 'wagtailadmin_pages:add_subpage' page.id %}"
             class="icon icon-plus-inverse text-replace"
-            title="{% blocktrans with title=page.get_admin_display_title %}Add a child page to '{{ title }}'{% endblocktrans %}"
-            aria-label="{% blocktrans with title=page.get_admin_display_title %}Add a child page to '{{ title }}'{% endblocktrans %}"
+            title="{% blocktrans trimmed with title=page.get_admin_display_title %}Add a child page to '{{ title }}'{% endblocktrans %}"
+            aria-label="{% blocktrans trimmed with title=page.get_admin_display_title %}Add a child page to '{{ title }}'{% endblocktrans %}"
         ></a>
     {% endif %}
 </td>

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_navigation_move.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_navigation_move.html
@@ -6,6 +6,6 @@ Navigation controls for the page listing in 'move' mode
 
 <td class="{% if page.can_descend %}children{% endif %}">
     {% if page.can_descend %}
-        <a href="{% url 'wagtailadmin_pages:move_choose_destination' page_to_move.id page.id %}" class="icon text-replace icon-arrow-right navigate-pages" title="{% blocktrans with title=page.get_admin_display_title %}Explore subpages of '{{ title }}'{% endblocktrans %}">{% trans 'Explore' %}</a>
+        <a href="{% url 'wagtailadmin_pages:move_choose_destination' page_to_move.id page.id %}" class="icon text-replace icon-arrow-right navigate-pages" title="{% blocktrans trimmed with title=page.get_admin_display_title %}Explore subpages of '{{ title }}'{% endblocktrans %}">{% trans 'Explore' %}</a>
     {% endif %}
 </td>

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_pagination.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_pagination.html
@@ -5,7 +5,7 @@ Pagination for page listings. Used by the `{% paginate %}` template tag.
 {% endcomment %}
 
 <nav class="pagination" aria-label="{% trans 'Pagination' %}">
-    <p>{% blocktrans with page_number=page.number num_pages=paginator.num_pages %}
+    <p>{% blocktrans trimmed with page_number=page.number num_pages=paginator.num_pages %}
         Page {{ page_number }} of {{ num_pages }}.
     {% endblocktrans %}</p>
     <ul>

--- a/wagtail/admin/templates/wagtailadmin/pages/move_choose_destination.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/move_choose_destination.html
@@ -1,12 +1,12 @@
 {% extends "wagtailadmin/base.html" %}
 {% load i18n wagtailadmin_tags %}
-{% block titletag %}{% blocktrans with title=page_to_move.specific_deferred.get_admin_display_title %}Select a new parent page for {{ title }}{% endblocktrans %}{% endblock %}
+{% block titletag %}{% blocktrans trimmed with title=page_to_move.specific_deferred.get_admin_display_title %}Select a new parent page for {{ title }}{% endblocktrans %}{% endblock %}
 {% block content %}
     <header class="nice-padding header-with-breadcrumb">
         {% move_breadcrumb page_to_move viewed_page %}
         <h1>
             {% icon name="doc-empty-inverse" class_name="header-title-icon" %}
-            {% blocktrans with title=page_to_move.specific_deferred.get_admin_display_title %}Select a new parent page for <span>{{ title }}</span>{% endblocktrans %}
+            {% blocktrans trimmed with title=page_to_move.specific_deferred.get_admin_display_title %}Select a new parent page for <span>{{ title }}</span>{% endblocktrans %}
         </h1>
     </header>
     <div class="nice-padding">

--- a/wagtail/admin/templates/wagtailadmin/pages/preview_error.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/preview_error.html
@@ -9,7 +9,7 @@
     </header>
     <div class="nice-padding">
         <p>
-            {% blocktrans %}
+            {% blocktrans trimmed %}
                 Impossible to preview this page, some errors are remaining.
                 Please close this tab, edit the page to fix these errors,
                 then use preview again.

--- a/wagtail/admin/templates/wagtailadmin/pages/revisions/compare.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/revisions/compare.html
@@ -1,7 +1,7 @@
 {% extends "wagtailadmin/base.html" %}
 {% load i18n wagtailadmin_tags %}
 
-{% block titletag %}{% blocktrans with title=page.get_admin_display_title %}Comparing {{ title }}{% endblocktrans %}{% endblock %}
+{% block titletag %}{% blocktrans trimmed with title=page.get_admin_display_title %}Comparing {{ title }}{% endblocktrans %}{% endblock %}
 
 {% block content %}
     {% trans "Comparing" as comparing_str %}
@@ -44,13 +44,13 @@
                                                     {% icon name='help' %}
                                                     <p>
                                                         {% if move > 0 %}
-                                                            {% blocktrans count counter=move %}
+                                                            {% blocktrans trimmed count counter=move %}
                                                                 Moved down 1 place.
                                                             {% plural %}
                                                                 Moved down {{ counter }} places.
                                                             {% endblocktrans %}
                                                         {% elif move < 0 %}
-                                                            {% blocktrans count counter=move|abs %}
+                                                            {% blocktrans trimmed count counter=move|abs %}
                                                                 Moved up 1 place.
                                                             {% plural %}
                                                                 Moved up {{ counter }} places.

--- a/wagtail/admin/templates/wagtailadmin/pages/revisions/confirm_unschedule.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/revisions/confirm_unschedule.html
@@ -1,6 +1,6 @@
 {% extends "wagtailadmin/base.html" %}
 {% load i18n %}
-{% block titletag %}{% blocktrans with title=page.get_admin_display_title %}Unschedule Revision {{ revision.id }} for {{ title }}{% endblocktrans %}{% endblock %}
+{% block titletag %}{% blocktrans trimmed with title=page.get_admin_display_title %}Unschedule Revision {{ revision.id }} for {{ title }}{% endblocktrans %}{% endblock %}
 {% block content %}
     {% trans "Unschedule" as unschedule_str %}
     {% include "wagtailadmin/shared/header.html" with title=unschedule_str subtitle=subtitle icon="doc-empty-inverse" %}

--- a/wagtail/admin/templates/wagtailadmin/pages/search_results.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/search_results.html
@@ -2,7 +2,7 @@
 <div class="nice-padding">
     {% if pages %}
         <h2 role="alert">
-            {% blocktrans count counter=all_pages.count %}
+            {% blocktrans trimmed count counter=all_pages.count %}
                 There is one matching page
             {% plural %}
                 There are {{ counter }} matching pages
@@ -38,7 +38,7 @@
         {% paginate pages base_url=pagination_base_url %}
     {% else %}
         {% if query_string %}
-            <h2 role="alert">{% blocktrans %}Sorry, no pages match <em>{{ query_string }}</em>{% endblocktrans %}</h2>
+            <h2 role="alert">{% blocktrans trimmed %}Sorry, no pages match <em>{{ query_string }}</em>{% endblocktrans %}</h2>
 
             {% search_other %}
         {% else %}

--- a/wagtail/admin/templates/wagtailadmin/pages/workflow_history/detail.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/workflow_history/detail.html
@@ -17,16 +17,16 @@
         <h2>{% icon "clipboard-list" class_name="initial" %} {{ workflow_state.workflow.name }}</h2>
 
         <p>
-            {% blocktrans with modified_by=workflow_state.requested_by|user_display_name %}Requested by <b>{{ modified_by }}</b>{% endblocktrans %}
+            {% blocktrans trimmed with modified_by=workflow_state.requested_by|user_display_name %}Requested by <b>{{ modified_by }}</b>{% endblocktrans %}
             <span class="avatar small"><img src="{% avatar_url workflow_state.requested_by size=25 %}" alt="" /></span>
         </p>
 
         <p>
-            {% blocktrans with workflow_state.created_at as started_at %}Started at <b>{{ started_at }}</b>{% endblocktrans %}
+            {% blocktrans trimmed with workflow_state.created_at as started_at %}Started at <b>{{ started_at }}</b>{% endblocktrans %}
         </p>
 
         <p>
-            {% blocktrans with workflow_state.get_status_display as status %}Status <span class="status-tag primary"> {{ status }}</span>{% endblocktrans %}
+            {% blocktrans trimmed with workflow_state.get_status_display as status %}Status <span class="status-tag primary"> {{ status }}</span>{% endblocktrans %}
         </p>
 
         <div class="workflow-progress-tabs__buttons">
@@ -57,11 +57,11 @@
                                 {% if not forloop.first %}
                                     {% trans "Page edited" as action %}
                                     {% if revision.user %}
-                                        {% blocktrans with '<b>'|add:action|add:'</b>' as action and revision.user|user_display_name as who and revision.created_at as at %}
+                                        {% blocktrans trimmed with '<b>'|add:action|add:'</b>' as action and revision.user|user_display_name as who and revision.created_at as at %}
                                             {{ action }} by <b>{{ who }}</b> at <b>{{ at }}</b>
                                         {% endblocktrans %}
                                     {% else %}
-                                        {% blocktrans with '<b>'|add:action|add:'</b>' as action and revision.created_at as at %}
+                                        {% blocktrans trimmed with '<b>'|add:action|add:'</b>' as action and revision.created_at as at %}
                                             {{ action }} at <b>{{ at }}</b>
                                         {% endblocktrans %}
                                     {% endif %}
@@ -72,11 +72,11 @@
                             <td>
                                 {% if task_state.status == 'approved' or task_state.status == 'rejected' %}
                                     {% if task_state.finished_by %}
-                                        {% blocktrans with action='<div class="status-tag primary">'|add:task_state.get_status_display|add:'</div>'|safe who=task_state.finished_by|user_display_name at=task_state.finished_at %}
+                                        {% blocktrans trimmed with action='<div class="status-tag primary">'|add:task_state.get_status_display|add:'</div>'|safe who=task_state.finished_by|user_display_name at=task_state.finished_at %}
                                             {{ action }} by <b>{{ who }}</b> at <b>{{ at }}</b>
                                         {% endblocktrans %}
                                     {% else %}
-                                        {% blocktrans with action='<div class="status-tag primary">'|add:task_state.get_status_display|add:'</div>'|safe at=task_state.finished_at %}
+                                        {% blocktrans trimmed with action='<div class="status-tag primary">'|add:task_state.get_status_display|add:'</div>'|safe at=task_state.finished_at %}
                                             {{ action }} at <b>{{ at }}</b>
                                         {% endblocktrans %}
                                     {% endif %}
@@ -113,7 +113,7 @@
                             {% elif timeline_item.action == 'page_edited' %}
                                 {% trans "Page edited" as action %}
                                 {% if revision.user %}
-                                    {% blocktrans with '<b>'|add:action|add:'</b>' as action and timeline_item.revision.user|user_display_name as who %}
+                                    {% blocktrans trimmed with '<b>'|add:action|add:'</b>' as action and timeline_item.revision.user|user_display_name as who %}
                                         {{ action }} by <b>{{ who }}</b>
                                     {% endblocktrans %}
                                 {% else %}
@@ -123,7 +123,7 @@
                                 <b>{{ timeline_item.task_state.task }}</b>
 
                                 {% if timeline_item.task_state.finished_by %}
-                                    {% blocktrans with action='<div class="status-tag primary">'|add:timeline_item.task_state.get_status_display|add:'</div>'|safe who=timeline_item.task_state.finished_by|user_display_name %}
+                                    {% blocktrans trimmed with action='<div class="status-tag primary">'|add:timeline_item.task_state.get_status_display|add:'</div>'|safe who=timeline_item.task_state.finished_by|user_display_name %}
                                         {{ action }} by <b>{{ who }}</b>
                                     {% endblocktrans %}
                                 {% else %}

--- a/wagtail/admin/templates/wagtailadmin/pages/workflow_history/index.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/workflow_history/index.html
@@ -1,7 +1,7 @@
 {% extends "wagtailadmin/base.html" %}
 {% load i18n %}
 
-{% block titletag %}{% blocktrans with title=page.specific_deferred.get_admin_display_title %}Workflow history for {{ title }}{% endblocktrans %}{% endblock %}
+{% block titletag %}{% blocktrans trimmed with title=page.specific_deferred.get_admin_display_title %}Workflow history for {{ title }}{% endblocktrans %}{% endblock %}
 
 {% block content %}
     {% trans "Workflow history for" as workflow_history_str %}

--- a/wagtail/admin/templates/wagtailadmin/pages/workflow_history/list.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/workflow_history/list.html
@@ -45,7 +45,7 @@
                     <td>{{ workflow_state.requested_by|user_display_name }}</td>
                     <td>
                         <div class="human-readable-date" title="{{ workflow_state.created_at|date:"DATETIME_FORMAT" }}">
-                            {% blocktrans with time_period=workflow_state.created_at|timesince %}{{ time_period }} ago{% endblocktrans %}
+                            {% blocktrans trimmed with time_period=workflow_state.created_at|timesince %}{{ time_period }} ago{% endblocktrans %}
                         </div>
                     </td>
                 </tr>

--- a/wagtail/admin/templates/wagtailadmin/pages/workflow_history/results.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/workflow_history/results.html
@@ -5,5 +5,5 @@
 
     {% include "wagtailadmin/shared/pagination_nav.html" with items=workflow_states linkurl="wagtailadmin_pages:workflow_history" %}
 {% else %}
-    <p>{% blocktrans %}This page hasn't been submitted for moderation yet{% endblocktrans %}</p>
+    <p>{% blocktrans trimmed %}This page hasn't been submitted for moderation yet{% endblocktrans %}</p>
 {% endif %}

--- a/wagtail/admin/templates/wagtailadmin/panels/inline_panel.html
+++ b/wagtail/admin/templates/wagtailadmin/panels/inline_panel.html
@@ -26,6 +26,6 @@
 <p class="add">
     <button type="button" class="button bicolor button--icon" id="id_{{ self.formset.prefix }}-ADD">
         {% icon name="plus" wrapped=1 %}
-        {% blocktrans with label=self.label|lower %}Add {{ label }}{% endblocktrans %}
+        {% blocktrans trimmed with label=self.label|lower %}Add {{ label }}{% endblocktrans %}
     </button>
 </p>

--- a/wagtail/admin/templates/wagtailadmin/reports/aging_pages.html
+++ b/wagtail/admin/templates/wagtailadmin/reports/aging_pages.html
@@ -39,7 +39,7 @@
                         </td>
                         <td class="updated" valign="top">
                             <div class="human-readable-date" title="{{ page.last_published_at|date:'DATETIME_FORMAT' }}">
-                                {% blocktrans with time_period=page.last_published_at|timesince %}
+                                {% blocktrans trimmed with time_period=page.last_published_at|timesince %}
                                     {{ time_period }} ago
                                 {% endblocktrans %}
                             </div>

--- a/wagtail/admin/templates/wagtailadmin/reports/listing/_list_unlock.html
+++ b/wagtail/admin/templates/wagtailadmin/reports/listing/_list_unlock.html
@@ -17,16 +17,16 @@
                 {% with page.locked_at|date:"DATETIME_FORMAT" as locking_date %}
                     {% if page.locked_by %}
                         {% if page.locked_by_id == request.user.pk %}
-                            {% blocktrans %}
+                            {% blocktrans trimmed %}
                                 Locked by <b>you</b> at <b>{{ locking_date }}</b>
                             {% endblocktrans %}
                         {% else %}
-                            {% blocktrans with locked_by=page.locked_by %}
+                            {% blocktrans trimmed with locked_by=page.locked_by %}
                                 Locked by <b>{{ locked_by }}</b> at <b>{{ locking_date }}</b>
                             {% endblocktrans %}
                         {% endif %}
                     {% else %}
-                        {% blocktrans %}
+                        {% blocktrans trimmed %}
                             Locked at <b>{{ locking_date }}</b>
                         {% endblocktrans %}
                     {% endif %}

--- a/wagtail/admin/templates/wagtailadmin/reports/site_history.html
+++ b/wagtail/admin/templates/wagtailadmin/reports/site_history.html
@@ -43,7 +43,7 @@
                             {% include "wagtailadmin/shared/user_avatar.html" with user=entry.user username=entry.user_display_name %}
                         </td>
                         <td class="updated">
-                            <div class="human-readable-date" title="{{ entry.timestamp|date:"DATETIME_FORMAT" }}">{% blocktrans with time_period=entry.timestamp|timesince %}{{ time_period }} ago{% endblocktrans %}</div>
+                            <div class="human-readable-date" title="{{ entry.timestamp|date:"DATETIME_FORMAT" }}">{% blocktrans trimmed with time_period=entry.timestamp|timesince %}{{ time_period }} ago{% endblocktrans %}</div>
                         </td>
                     </tr>
                 {% endfor %}

--- a/wagtail/admin/templates/wagtailadmin/reports/workflow_tasks.html
+++ b/wagtail/admin/templates/wagtailadmin/reports/workflow_tasks.html
@@ -60,6 +60,6 @@
             </tbody>
         </table>
     {% else %}
-        <p>{% blocktrans %}No pages have been submitted for moderation yet{% endblocktrans %}</p>
+        <p>{% blocktrans trimmed %}No pages have been submitted for moderation yet{% endblocktrans %}</p>
     {% endif %}
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/shared/ajax_pagination_nav.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/ajax_pagination_nav.html
@@ -3,7 +3,7 @@
 {% load wagtailadmin_tags %}
 
 <nav class="pagination" aria-label="{% trans 'Pagination' %}">
-    <p>{% blocktrans with page_num=items.number total_pages=items.paginator.num_pages %}Page {{ page_num }} of {{ total_pages }}.{% endblocktrans %}</p>
+    <p>{% blocktrans trimmed with page_num=items.number total_pages=items.paginator.num_pages %}Page {{ page_num }} of {{ total_pages }}.{% endblocktrans %}</p>
     <ul>
         <li class="prev">
             {% if items.has_previous %}

--- a/wagtail/admin/templates/wagtailadmin/shared/pagination_nav.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/pagination_nav.html
@@ -9,7 +9,7 @@
 {% resolve_url linkurl as url_path %}
 
 <nav class="pagination" aria-label="{% trans 'Pagination' %}">
-    <p>{% blocktrans with page_num=items.number total_pages=items.paginator.num_pages %}Page {{ page_num }} of {{ total_pages }}.{% endblocktrans %}</p>
+    <p>{% blocktrans trimmed with page_num=items.number total_pages=items.paginator.num_pages %}Page {{ page_num }} of {{ total_pages }}.{% endblocktrans %}</p>
     <ul>
         <li class="prev">
             {% if items.has_previous %}

--- a/wagtail/admin/templates/wagtailadmin/skeleton.html
+++ b/wagtail/admin/templates/wagtailadmin/skeleton.html
@@ -70,7 +70,7 @@
         </script>
 
         <noscript class="capabilitymessage">
-            {% blocktrans %}
+            {% blocktrans trimmed %}
                 JavaScript is required to use Wagtail, but it is currently disabled.<br />
                 Here are the <a href="https://www.enable-javascript.com/" target="_blank" rel="noreferrer">instructions how to enable JavaScript in your web browser</a>.
             {% endblocktrans %}

--- a/wagtail/admin/templates/wagtailadmin/tables/date_cell.html
+++ b/wagtail/admin/templates/wagtailadmin/tables/date_cell.html
@@ -1,6 +1,6 @@
 {% load i18n wagtailadmin_tags %}
 <td {% if column.classname %}class="{{ column.classname }}"{% endif %}>
     {% if value %}
-        <div class="human-readable-date" title="{{ value|date:"DATETIME_FORMAT" }}">{% blocktrans with time_period=value|timesince %}{{ time_period }} ago{% endblocktrans %}</div>
+        <div class="human-readable-date" title="{{ value|date:"DATETIME_FORMAT" }}">{% blocktrans trimmed with time_period=value|timesince %}{{ time_period }} ago{% endblocktrans %}</div>
     {% endif %}
 </td>

--- a/wagtail/admin/templates/wagtailadmin/workflows/index.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/index.html
@@ -53,7 +53,7 @@
                             <td class="title">
                                 <div class="title-wrapper">
                                     <a href="{% url 'wagtailadmin_workflows:usage' workflow.pk %}">
-                                        {% blocktrans count counter=workflow.all_pages.count %}
+                                        {% blocktrans trimmed count counter=workflow.all_pages.count %}
                                             1 page
                                         {% plural %}
                                             {{ counter }} pages
@@ -65,15 +65,15 @@
                                 <ul class="workflow-tasks">
                                     {% for task in workflow.tasks|slice:":5" %}
                                         <a href="{% url 'wagtailadmin_workflows:edit_task' task.pk %}">
-                                            <li class="workflow-tasks__task" data-wagtail-tooltip="{% blocktrans with forloop.counter as step_number %}Step {{ step_number }}{% endblocktrans %}: {{ task.name }}">
-                                                <div class="workflow-tasks__step">{% blocktrans with forloop.counter as step_number %}Step {{ step_number }}{% endblocktrans %}</div>
+                                            <li class="workflow-tasks__task" data-wagtail-tooltip="{% blocktrans trimmed with forloop.counter as step_number %}Step {{ step_number }}{% endblocktrans %}: {{ task.name }}">
+                                                <div class="workflow-tasks__step">{% blocktrans trimmed with forloop.counter as step_number %}Step {{ step_number }}{% endblocktrans %}</div>
                                                 <h4 class="workflow-tasks__name">{{ task.name }}</h4>
                                             </li>
                                         </a>
                                     {% endfor %}
                                     {% if workflow.tasks.count > 5 %}
                                         <li class="workflow-tasks__extra-tasks">
-                                            {% blocktrans count counter=workflow.tasks.count|add:-5 %}+{{ counter }} more{% plural %}+{{ counter }} more{% endblocktrans %}
+                                            {% blocktrans trimmed count counter=workflow.tasks.count|add:-5 %}+{{ counter }} more{% plural %}+{{ counter }} more{% endblocktrans %}
                                         </li>
                                     {% endif %}
                                 </ul>
@@ -85,9 +85,9 @@
         {% else %}
             {% url view.add_url_name as add_url %}
             {% if showing_disabled %}
-                <p>{% blocktrans %}No workflows have been created. Why not <a href="{{ add_url }}">add one</a>?{% endblocktrans %}</p>
+                <p>{% blocktrans trimmed %}No workflows have been created. Why not <a href="{{ add_url }}">add one</a>?{% endblocktrans %}</p>
             {% else %}
-                <p>{% blocktrans %}There are no enabled workflows. Why not <a href="{{ add_url }}">add one</a>?{% endblocktrans %}</p>
+                <p>{% blocktrans trimmed %}There are no enabled workflows. Why not <a href="{{ add_url }}">add one</a>?{% endblocktrans %}</p>
             {% endif %}
         {% endif %}
     </div>

--- a/wagtail/admin/templates/wagtailadmin/workflows/task_chooser/includes/results.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/task_chooser/includes/results.html
@@ -2,7 +2,7 @@
 {% if tasks %}
     {% if search_form.is_searching %}
         <h2 role="alert">
-            {% blocktrans count counter=tasks.paginator.count %}
+            {% blocktrans trimmed count counter=tasks.paginator.count %}
                 There is {{ counter }} match
             {% plural %}
                 There are {{ counter }} matches
@@ -50,7 +50,7 @@
                             {% trans "Not used" %}
                         {% endfor %}
                         {% if task.active_workflows.count > 5 %}
-                            {% blocktrans count counter=task.active_workflows.count|add:-5 %}+{{ counter }} more{% plural %}+{{ counter }} more{% endblocktrans %}
+                            {% blocktrans trimmed count counter=task.active_workflows.count|add:-5 %}+{{ counter }} more{% plural %}+{{ counter }} more{% endblocktrans %}
                         {% endif %}
                     </td>
                 </tr>
@@ -61,12 +61,12 @@
     {% include "wagtailadmin/shared/pagination_nav.html" with items=tasks linkurl='wagtailadmin_workflows:task_chooser_results' %}
 {% else %}
     {% if all_tasks.exists %}
-        <p role="alert">{% blocktrans %}Sorry, no tasks match "<em>{{ query_string }}</em>"{% endblocktrans %}</p>
+        <p role="alert">{% blocktrans trimmed %}Sorry, no tasks match "<em>{{ query_string }}</em>"{% endblocktrans %}</p>
     {% else %}
         <p>
             {% trans "You haven't created any tasks." %}
             {% if can_create %}
-                {% blocktrans %}
+                {% blocktrans trimmed %}
                     Why not <a class="create-one-now" href="#">create one now</a>?
                 {% endblocktrans %}
             {% endif %}

--- a/wagtail/admin/templates/wagtailadmin/workflows/task_index.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/task_index.html
@@ -60,7 +60,7 @@
                                     {% trans "Not used" %}
                                 {% endfor %}
                                 {% if task.active_workflows.count > 5 %}
-                                    {% blocktrans count counter=task.active_workflows.count|add:-5 %}+{{ counter }} more{% plural %}+{{ counter }} more{% endblocktrans %}
+                                    {% blocktrans trimmed count counter=task.active_workflows.count|add:-5 %}+{{ counter }} more{% plural %}+{{ counter }} more{% endblocktrans %}
                                 {% endif %}
                             </td>
                         </tr>
@@ -70,9 +70,9 @@
         {% else %}
             {% url view.add_url_name as add_url %}
             {% if showing_disabled %}
-                <p>{% blocktrans %}No tasks have been created. Why not <a href="{{ add_url }}">add one</a>?{% endblocktrans %}</p>
+                <p>{% blocktrans trimmed %}No tasks have been created. Why not <a href="{{ add_url }}">add one</a>?{% endblocktrans %}</p>
             {% else %}
-                <p>{% blocktrans %}There are no enabled tasks. Why not <a href="{{ add_url }}">add one</a>?{% endblocktrans %}</p>
+                <p>{% blocktrans trimmed %}There are no enabled tasks. Why not <a href="{{ add_url }}">add one</a>?{% endblocktrans %}</p>
             {% endif %}
         {% endif %}
     </div>

--- a/wagtail/admin/templates/wagtailadmin/workflows/usage.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/usage.html
@@ -1,6 +1,6 @@
 {% extends "wagtailadmin/base.html" %}
 {% load i18n %}
-{% block titletag %}{% blocktrans with name=workflow.name %}Pages that use workflow '{{ name }}'{% endblocktrans %}{% endblock %}
+{% block titletag %}{% blocktrans trimmed with name=workflow.name %}Pages that use workflow '{{ name }}'{% endblocktrans %}{% endblock %}
 {% block content %}
     {% trans "Pages that use workflow" as usage_str %}
     {% include "wagtailadmin/shared/header.html" with title=usage_str subtitle=workflow.name %}

--- a/wagtail/admin/templates/wagtailadmin/workflows/workflow_status.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/workflow_status.html
@@ -9,7 +9,7 @@
                 Submitted to <em>{{ workflow_name }}</em> at {{ started_at }}
             {% endblocktrans %}
             {% if workflow_state.requested_by %}
-                {% blocktrans with modified_by=workflow_state.requested_by|user_display_name %}by {{ modified_by }}{% endblocktrans %}
+                {% blocktrans trimmed with modified_by=workflow_state.requested_by|user_display_name %}by {{ modified_by }}{% endblocktrans %}
                 <span class="avatar small"><img src="{% avatar_url page.get_latest_revision.user size=25 %}" alt="" /></span>
             {% endif %}
         </p>

--- a/wagtail/contrib/forms/templates/wagtailforms/confirm_delete.html
+++ b/wagtail/contrib/forms/templates/wagtailforms/confirm_delete.html
@@ -1,6 +1,6 @@
 {% extends "wagtailadmin/base.html" %}
 {% load i18n %}
-{% block titletag %}{% blocktrans with title=page.title %}Delete form data {{ title }}{% endblocktrans %}{% endblock %}
+{% block titletag %}{% blocktrans trimmed with title=page.title %}Delete form data {{ title }}{% endblocktrans %}{% endblock %}
 {% block bodyclass %}menu-explorer{% endblock %}
 
 {% block content %}
@@ -9,7 +9,7 @@
 
     <div class="nice-padding">
         <p>
-            {% blocktrans count counter=submissions.count %}
+            {% blocktrans trimmed count counter=submissions.count %}
                 Are you sure you want to delete this form submission?
             {% plural %}
                 Are you sure you want to delete these form submissions?

--- a/wagtail/contrib/forms/templates/wagtailforms/index_submissions.html
+++ b/wagtail/contrib/forms/templates/wagtailforms/index_submissions.html
@@ -1,6 +1,6 @@
 {% extends "wagtailadmin/base.html" %}
 {% load i18n wagtailadmin_tags %}
-{% block titletag %}{% blocktrans with form_title=form_page.title|capfirst %}Submissions of {{ form_title }}{% endblocktrans %}{% endblock %}
+{% block titletag %}{% blocktrans trimmed with form_title=form_page.title|capfirst %}Submissions of {{ form_title }}{% endblocktrans %}{% endblock %}
 {% block extra_js %}
     {{ block.super }}
 
@@ -88,7 +88,7 @@
                     <div class="col header-title">
                         <h1>
                             {% icon name="form" class_name="header-title-icon" %}
-                            {% blocktrans with form_title=form_page.title|capfirst %}Form data <span>{{ form_title }}</span>{% endblocktrans %}
+                            {% blocktrans trimmed with form_title=form_page.title|capfirst %}Form data <span>{{ form_title }}</span>{% endblocktrans %}
                         </h1>
                     </div>
                     <div class="col search-bar">
@@ -121,7 +121,7 @@
                 {% include "wagtailadmin/shared/pagination_nav.html" with items=page_obj %}
             </form>
         {% else %}
-            <p class="no-results-message">{% blocktrans with title=form_page.title %}There have been no submissions of the '{{ title }}' form.{% endblocktrans %}</p>
+            <p class="no-results-message">{% blocktrans trimmed with title=form_page.title %}There have been no submissions of the '{{ title }}' form.{% endblocktrans %}</p>
         {% endif %}
     </div>
 {% endblock %}

--- a/wagtail/contrib/modeladmin/templates/modeladmin/choose_parent.html
+++ b/wagtail/contrib/modeladmin/templates/modeladmin/choose_parent.html
@@ -27,8 +27,8 @@
     <div>
 
         <div class="nice-padding">
-            <h2>{% blocktrans %}Choose a parent page{% endblocktrans %}</h2>
-            <p>{% blocktrans with view.verbose_name_plural|capfirst as plural %}{{ plural }} can be added to more than one place within your site. Which of the following would you like to be the parent of your new page?{% endblocktrans %}</p>
+            <h2>{% blocktrans trimmed %}Choose a parent page{% endblocktrans %}</h2>
+            <p>{% blocktrans trimmed with view.verbose_name_plural|capfirst as plural %}{{ plural }} can be added to more than one place within your site. Which of the following would you like to be the parent of your new page?{% endblocktrans %}</p>
 
             <form action="" method="post" novalidate>
                 {% csrf_token %}

--- a/wagtail/contrib/modeladmin/templates/modeladmin/delete.html
+++ b/wagtail/contrib/modeladmin/templates/modeladmin/delete.html
@@ -12,8 +12,8 @@
     {% block content_main %}
         <div class="nice-padding">
             {% if protected_error %}
-                <h2>{% blocktrans with view.verbose_name|capfirst as model_name %}{{ model_name }} could not be deleted{% endblocktrans %}</h2>
-                <p>{% blocktrans with instance as instance_name %}'{{ instance_name }}' is currently referenced by other objects, and cannot be deleted without jeopardising data integrity. To delete it successfully, first remove references from the following objects, then try again:{% endblocktrans %}</p>
+                <h2>{% blocktrans trimmed with view.verbose_name|capfirst as model_name %}{{ model_name }} could not be deleted{% endblocktrans %}</h2>
+                <p>{% blocktrans trimmed with instance as instance_name %}'{{ instance_name }}' is currently referenced by other objects, and cannot be deleted without jeopardising data integrity. To delete it successfully, first remove references from the following objects, then try again:{% endblocktrans %}</p>
                 <ul>
                     {% for obj in linked_objects %}<li><b>{{ obj|get_content_type_for_obj|title }}:</b> {{ obj }}</li>{% endfor %}
                 </ul>

--- a/wagtail/contrib/modeladmin/templates/modeladmin/includes/filter.html
+++ b/wagtail/contrib/modeladmin/templates/modeladmin/includes/filter.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-{% blocktrans with filter_title=title %} By {{ filter_title }} {% endblocktrans %}
+{% blocktrans trimmed with filter_title=title %} By {{ filter_title }} {% endblocktrans %}
 <ul>
     {% for choice in choices %}
         <li{% if choice.selected %} class="selected"{% endif %}>

--- a/wagtail/contrib/modeladmin/templates/modeladmin/includes/result_count.html
+++ b/wagtail/contrib/modeladmin/templates/modeladmin/includes/result_count.html
@@ -1,4 +1,4 @@
 {% load i18n %}
 {% block result_count %}
-    <span class="result-count">{% blocktrans %}{{ result_count }} out of {{ all_count }}{% endblocktrans %}</span>
+    <span class="result-count">{% blocktrans trimmed %}{{ result_count }} out of {{ all_count }}{% endblocktrans %}</span>
 {% endblock %}

--- a/wagtail/contrib/modeladmin/templates/modeladmin/includes/result_list.html
+++ b/wagtail/contrib/modeladmin/templates/modeladmin/includes/result_list.html
@@ -20,7 +20,7 @@
     </table>
 {% else %}
     <div class="nice-padding no-search-results">
-        <p>{% blocktrans with view.verbose_name_plural as name %}Sorry, there are no {{ name }} matching your search parameters.{% endblocktrans %}</p>
+        <p>{% blocktrans trimmed with view.verbose_name_plural as name %}Sorry, there are no {{ name }} matching your search parameters.{% endblocktrans %}</p>
     </div>
 {% endif %}
 

--- a/wagtail/contrib/modeladmin/templates/modeladmin/includes/search_form.html
+++ b/wagtail/contrib/modeladmin/templates/modeladmin/includes/search_form.html
@@ -8,7 +8,7 @@
                     <div class="field-content">
                         <div class="input">
                             {% icon name="search" %}
-                            <input id="id_q" name="{{ search_var }}" value="{{ view.query }}" placeholder="{% blocktrans with view.verbose_name_plural|lower as name %}Search {{ name }}{% endblocktrans %}" type="text">
+                            <input id="id_q" name="{{ search_var }}" value="{{ view.query }}" placeholder="{% blocktrans trimmed with view.verbose_name_plural|lower as name %}Search {{ name }}{% endblocktrans %}" type="text">
                             <span></span>
                         </div>
                     </div>

--- a/wagtail/contrib/modeladmin/templates/modeladmin/index.html
+++ b/wagtail/contrib/modeladmin/templates/modeladmin/index.html
@@ -73,14 +73,14 @@
                             {% if not all_count %}
                                 <div class="nice-padding" style="margin-top:30px;">
                                     {% if no_valid_parents %}
-                                        <p>{% blocktrans with view.verbose_name_plural as name %}No {{ name }} have been created yet. One of the following must be created before you can add any {{ name }}:{% endblocktrans %}</p>
+                                        <p>{% blocktrans trimmed with view.verbose_name_plural as name %}No {{ name }} have been created yet. One of the following must be created before you can add any {{ name }}:{% endblocktrans %}</p>
                                         <ul>
                                             {% for type in required_parent_types %}<li><b>{{ type|title }}</b></li>{% endfor %}
                                         </ul>
                                     {% else %}
-                                        <p>{% blocktrans with view.verbose_name_plural as name %}No {{ name }} have been created yet.{% endblocktrans %}
+                                        <p>{% blocktrans trimmed with view.verbose_name_plural as name %}No {{ name }} have been created yet.{% endblocktrans %}
                                             {% if user_can_create %}
-                                                {% blocktrans with view.create_url as url %}
+                                                {% blocktrans trimmed with view.create_url as url %}
                                                     Why not <a href="{{ url }}">add one</a>?
                                                 {% endblocktrans %}
                                             {% endif %}</p>
@@ -94,7 +94,7 @@
 
                     {% block pagination %}
                         <nav class="pagination {% if view.has_filters and all_count %}col9{% else %}col12{% endif %}" aria-label="{% trans 'Pagination' %}">
-                            <p>{% blocktrans with page_obj.number as current_page and paginator.num_pages as num_pages %}Page {{ current_page }} of {{ num_pages }}.{% endblocktrans %}</p>
+                            <p>{% blocktrans trimmed with page_obj.number as current_page and paginator.num_pages as num_pages %}Page {{ current_page }} of {{ num_pages }}.{% endblocktrans %}</p>
                             {% if paginator.num_pages > 1 %}
                                 <ul>
                                     {% pagination_link_previous page_obj view %}

--- a/wagtail/contrib/modeladmin/templates/modeladmin/inspect.html
+++ b/wagtail/contrib/modeladmin/templates/modeladmin/inspect.html
@@ -25,7 +25,7 @@
         {% block content_main %}
             <div class="nice-padding">
 
-                <p class="back"><a href="{{ view.index_url }}" class="icon icon-arrow-left">{% blocktrans with view.verbose_name as model_name %}Back to {{ model_name }} list{% endblocktrans %}</a></p>
+                <p class="back"><a href="{{ view.index_url }}" class="icon icon-arrow-left">{% blocktrans trimmed with view.verbose_name as model_name %}Back to {{ model_name }} list{% endblocktrans %}</a></p>
 
                 {% block fields_output %}
                     {% if fields %}

--- a/wagtail/contrib/redirects/templates/wagtailredirects/choose_import_file.html
+++ b/wagtail/contrib/redirects/templates/wagtailredirects/choose_import_file.html
@@ -20,7 +20,7 @@
     <div class="nice-padding">
         <div class="help-block help-info">
             {% icon name='help' %}
-            {% blocktrans %}
+            {% blocktrans trimmed %}
                 <p>Select a file where redirects are separated into rows and contains the columns representing <code>from</code> and <code>to</code> (they can be named anything).</p>
                 <p>After submitting you will be taken to a confirmation view where you can customize your redirects before import.</p>
             {% endblocktrans %}

--- a/wagtail/contrib/redirects/templates/wagtailredirects/confirm_delete.html
+++ b/wagtail/contrib/redirects/templates/wagtailredirects/confirm_delete.html
@@ -1,6 +1,6 @@
 {% extends "wagtailadmin/base.html" %}
 {% load i18n %}
-{% block titletag %}{% blocktrans with title=redirect.title %}Delete redirect {{ title }}{% endblocktrans %}{% endblock %}
+{% block titletag %}{% blocktrans trimmed with title=redirect.title %}Delete redirect {{ title }}{% endblocktrans %}{% endblock %}
 {% block content %}
     {% trans "Delete" as delete_str %}
     {% include "wagtailadmin/shared/header.html" with title=delete_str subtitle=redirect.title icon="redirect" %}

--- a/wagtail/contrib/redirects/templates/wagtailredirects/edit.html
+++ b/wagtail/contrib/redirects/templates/wagtailredirects/edit.html
@@ -1,6 +1,6 @@
 {% extends "wagtailadmin/base.html" %}
 {% load i18n %}
-{% block titletag %}{% blocktrans with title=redirect.title %}Editing {{ title }}{% endblocktrans %}{% endblock %}
+{% block titletag %}{% blocktrans trimmed with title=redirect.title %}Editing {{ title }}{% endblocktrans %}{% endblock %}
 {% block content %}
     {% trans "Editing" as editing_str %}
     {% include "wagtailadmin/shared/header.html" with title=editing_str subtitle=redirect.title icon="redirect" %}

--- a/wagtail/contrib/redirects/templates/wagtailredirects/import_summary.html
+++ b/wagtail/contrib/redirects/templates/wagtailredirects/import_summary.html
@@ -8,7 +8,7 @@
     <section id="summary" class="nice-padding">
         <p class="help-block help-warning">
             {% icon name='warning' %}
-            {% blocktrans with total=import_summary.total successes=import_summary.successes errors=import_summary.errors_count %}Found {{ total }} redirects, created {{ successes }} and found {{ errors }} errors.{% endblocktrans %}
+            {% blocktrans trimmed with total=import_summary.total successes=import_summary.successes errors=import_summary.errors_count %}Found {{ total }} redirects, created {{ successes }} and found {{ errors }} errors.{% endblocktrans %}
         </p>
 
         <table class="listing">

--- a/wagtail/contrib/redirects/templates/wagtailredirects/results.html
+++ b/wagtail/contrib/redirects/templates/wagtailredirects/results.html
@@ -2,7 +2,7 @@
 {% if redirects %}
     {% if query_string %}
         <h2 role="alert">
-            {% blocktrans count counter=redirects.paginator.count %}
+            {% blocktrans trimmed count counter=redirects.paginator.count %}
                 There is {{ counter }} match
             {% plural %}
                 There are {{ counter }} matches
@@ -15,9 +15,9 @@
     {% include "wagtailadmin/shared/pagination_nav.html" with items=redirects linkurl="wagtailredirects:index" %}
 {% else %}
     {% if query_string %}
-        <p role="alert">{% blocktrans %}Sorry, no redirects match "<em>{{ query_string }}</em>"{% endblocktrans %}</p>
+        <p role="alert">{% blocktrans trimmed %}Sorry, no redirects match "<em>{{ query_string }}</em>"{% endblocktrans %}</p>
     {% else %}
         {% url 'wagtailredirects:add' as wagtailredirects_add_redirect_url %}
-        <p>{% blocktrans %}No redirects have been created. Why not <a href="{{ wagtailredirects_add_redirect_url }}">add one</a>?{% endblocktrans %}</p>
+        <p>{% blocktrans trimmed %}No redirects have been created. Why not <a href="{{ wagtailredirects_add_redirect_url }}">add one</a>?{% endblocktrans %}</p>
     {% endif %}
 {% endif %}

--- a/wagtail/contrib/search_promotions/templates/wagtailsearchpromotions/add.html
+++ b/wagtail/contrib/search_promotions/templates/wagtailsearchpromotions/add.html
@@ -8,11 +8,11 @@
     <div class="nice-padding">
         <div class="help-block help-info">
             {% icon name='help' %}
-            {% blocktrans %}
+            {% blocktrans trimmed %}
                 <p>Promoted search results are a means of recommending specific pages that might not organically come high up in search results. E.g recommending your primary donation page to a user searching with the less common term "<em>giving</em>".</p>
             {% endblocktrans %}
 
-            {% blocktrans %}
+            {% blocktrans trimmed %}
                 <p>The "Search term(s)/phrase" field below must contain the full and exact search for which you wish to provide recommended results, <em>including</em> any misspellings/user error. To help, you can choose from search terms that have been popular with users of your site.</p>
             {% endblocktrans %}
         </div>

--- a/wagtail/contrib/search_promotions/templates/wagtailsearchpromotions/confirm_delete.html
+++ b/wagtail/contrib/search_promotions/templates/wagtailsearchpromotions/confirm_delete.html
@@ -1,6 +1,6 @@
 {% extends "wagtailadmin/base.html" %}
 {% load i18n %}
-{% block titletag %}{% blocktrans with query=query.query_string %}Delete {{ query }}{% endblocktrans %}{% endblock %}
+{% block titletag %}{% blocktrans trimmed with query=query.query_string %}Delete {{ query }}{% endblocktrans %}{% endblock %}
 {% block content %}
     {% trans "Delete" as delete_str %}
     {% include "wagtailadmin/shared/header.html" with title=delete_str subtitle=query.query_string %}

--- a/wagtail/contrib/search_promotions/templates/wagtailsearchpromotions/edit.html
+++ b/wagtail/contrib/search_promotions/templates/wagtailsearchpromotions/edit.html
@@ -1,6 +1,6 @@
 {% extends "wagtailadmin/base.html" %}
 {% load i18n wagtailadmin_tags %}
-{% block titletag %}{% blocktrans with query=query.query_string %}Editing {{ query }}{% endblocktrans %}{% endblock %}
+{% block titletag %}{% blocktrans trimmed with query=query.query_string %}Editing {{ query }}{% endblocktrans %}{% endblock %}
 {% block content %}
     {% trans "Editing" as editing_str %}
     {% include "wagtailadmin/shared/header.html" with title=editing_str subtitle=query.query_string icon="pick"  %}

--- a/wagtail/contrib/search_promotions/templates/wagtailsearchpromotions/results.html
+++ b/wagtail/contrib/search_promotions/templates/wagtailsearchpromotions/results.html
@@ -2,7 +2,7 @@
 {% if queries %}
     {% if is_searching %}
         <h2 role="alert">
-            {% blocktrans count counter=queries|length %}
+            {% blocktrans trimmed count counter=queries|length %}
                 There is {{ counter }} match
             {% plural %}
                 There are {{ counter }} matches
@@ -15,9 +15,9 @@
     {% include "wagtailadmin/shared/pagination_nav.html" with items=queries linkurl="wagtailsearchpromotions:index" %}
 {% else %}
     {% if is_searching %}
-        <p role="alert">{% blocktrans %}Sorry, no promoted results match "<em>{{ query_string }}</em>"{% endblocktrans %}</p>
+        <p role="alert">{% blocktrans trimmed %}Sorry, no promoted results match "<em>{{ query_string }}</em>"{% endblocktrans %}</p>
     {% else %}
         {% url 'wagtailsearchpromotions:add' as wagtailsearchpromotions_add_url %}
-        <p>{% blocktrans %}No promoted results have been created. Why not <a href="{{ wagtailsearchpromotions_add_url }}">add one</a>?{% endblocktrans %}</p>
+        <p>{% blocktrans trimmed %}No promoted results have been created. Why not <a href="{{ wagtailsearchpromotions_add_url }}">add one</a>?{% endblocktrans %}</p>
     {% endif %}
 {% endif %}

--- a/wagtail/contrib/settings/templates/wagtailsettings/edit.html
+++ b/wagtail/contrib/settings/templates/wagtailsettings/edit.html
@@ -1,6 +1,6 @@
 {% extends "wagtailadmin/base.html" %}
 {% load i18n wagtailadmin_tags %}
-{% block titletag %}{% blocktrans %}Editing {{ setting_type_name}} - {{ instance }}{% endblocktrans %}{% endblock %}
+{% block titletag %}{% blocktrans trimmed %}Editing {{ setting_type_name}} - {{ instance }}{% endblocktrans %}{% endblock %}
 {% block bodyclass %}menu-settings{% endblock %}
 {% block content %}
     <header class="nice-padding {% if tabbed %}merged tab-merged{% endif %}">

--- a/wagtail/documents/templates/wagtaildocs/bulk_actions/confirm_bulk_add_tags.html
+++ b/wagtail/documents/templates/wagtaildocs/bulk_actions/confirm_bulk_add_tags.html
@@ -1,7 +1,7 @@
 {% extends 'wagtailadmin/bulk_actions/confirmation/base.html' %}
 {% load i18n %}
 {% load wagtailimages_tags wagtailadmin_tags %}
-{% block titletag %}{% blocktrans count counter=items|length %}Add tags to 1 document {% plural %}Add tags to {{ counter }} documents{% endblocktrans %}{% endblock %}
+{% block titletag %}{% blocktrans trimmed count counter=items|length %}Add tags to 1 document {% plural %}Add tags to {{ counter }} documents{% endblocktrans %}{% endblock %}
 
 {% block extra_js %}
     {{ block.super }}
@@ -41,7 +41,7 @@
 
 {% block items_with_no_access %}
 
-    {% blocktrans asvar no_access_msg count counter=items_with_no_access|length %}You don't have permission to add tags to this document{% plural %}You don't have permission to add tags to these documents{% endblocktrans %}
+    {% blocktrans trimmed asvar no_access_msg count counter=items_with_no_access|length %}You don't have permission to add tags to this document{% plural %}You don't have permission to add tags to these documents{% endblocktrans %}
     {% include 'wagtaildocs/bulk_actions/list_items_with_no_access.html' with items=items_with_no_access no_access_msg=no_access_msg %}
 
 {% endblock items_with_no_access %}

--- a/wagtail/documents/templates/wagtaildocs/bulk_actions/confirm_bulk_add_to_collection.html
+++ b/wagtail/documents/templates/wagtaildocs/bulk_actions/confirm_bulk_add_to_collection.html
@@ -1,7 +1,7 @@
 {% extends 'wagtailadmin/bulk_actions/confirmation/base.html' %}
 {% load i18n %}
 {% load wagtailimages_tags wagtailadmin_tags %}
-{% block titletag %}{% blocktrans count counter=items|length %}Add 1 document to new collection {% plural %}Add {{ counter }} documents to new collection{% endblocktrans %}{% endblock %}
+{% block titletag %}{% blocktrans trimmed count counter=items|length %}Add 1 document to new collection {% plural %}Add {{ counter }} documents to new collection{% endblocktrans %}{% endblock %}
 
 {% block header %}
     {% trans "Add documents to collection" as add_str %}
@@ -29,7 +29,7 @@
 
 {% block items_with_no_access %}
 
-    {% blocktrans asvar no_access_msg count counter=items_with_no_access|length %}You don't have permission to add this document to a collection{% plural %}You don't have permission to add these documents to a collection{% endblocktrans %}
+    {% blocktrans trimmed asvar no_access_msg count counter=items_with_no_access|length %}You don't have permission to add this document to a collection{% plural %}You don't have permission to add these documents to a collection{% endblocktrans %}
     {% include 'wagtaildocs/bulk_actions/list_items_with_no_access.html' with items=items_with_no_access no_access_msg=no_access_msg %}
 
 {% endblock items_with_no_access %}

--- a/wagtail/documents/templates/wagtaildocs/bulk_actions/confirm_bulk_delete.html
+++ b/wagtail/documents/templates/wagtaildocs/bulk_actions/confirm_bulk_delete.html
@@ -1,6 +1,6 @@
 {% extends 'wagtailadmin/bulk_actions/confirmation/base.html' %}
 {% load wagtailadmin_tags i18n %}
-{% block titletag %}{% blocktrans count counter=items|length %}Delete 1 document {% plural %}Delete {{ counter }} documents{% endblocktrans %}{% endblock %}
+{% block titletag %}{% blocktrans trimmed count counter=items|length %}Delete 1 document {% plural %}Delete {{ counter }} documents{% endblocktrans %}{% endblock %}
 
 {% block header %}
     {% trans "Delete documents" as del_str %}
@@ -22,7 +22,7 @@
                     <a href="{% url 'wagtaildocs:edit' document.item.id %}"  target="_blank" rel="noreferrer">{{document.item.title}}</a>
                     {% usage_count_enabled as uc_enabled %}
                     {% if uc_enabled %}
-                        (<a href="{{ document.item.usage_url }}">{% blocktrans count usage_count=document.item.get_usage.count %}Used {{ usage_count }} time{% plural %}Used {{ usage_count }} times{% endblocktrans %}</a>)
+                        (<a href="{{ document.item.usage_url }}">{% blocktrans trimmed count usage_count=document.item.get_usage.count %}Used {{ usage_count }} time{% plural %}Used {{ usage_count }} times{% endblocktrans %}</a>)
                     {% endif %}
                 </li>
             {% endfor %}
@@ -32,7 +32,7 @@
 
 {% block items_with_no_access %}
 
-    {% blocktrans asvar no_access_msg count counter=items_with_no_access|length %}You don't have permission to delete this document{% plural %}You don't have permission to delete these documents{% endblocktrans %}
+    {% blocktrans trimmed asvar no_access_msg count counter=items_with_no_access|length %}You don't have permission to delete this document{% plural %}You don't have permission to delete these documents{% endblocktrans %}
     {% include 'wagtaildocs/bulk_actions/list_items_with_no_access.html' with items=items_with_no_access no_access_msg=no_access_msg %}
 
 {% endblock items_with_no_access %}

--- a/wagtail/documents/templates/wagtaildocs/chooser/results.html
+++ b/wagtail/documents/templates/wagtaildocs/chooser/results.html
@@ -2,7 +2,7 @@
 {% if documents %}
     {% if is_searching %}
         <h2 role="alert">
-            {% blocktrans count counter=documents.paginator.count %}
+            {% blocktrans trimmed count counter=documents.paginator.count %}
                 There is {{ counter }} match
             {% plural %}
                 There are {{ counter }} matches
@@ -16,7 +16,7 @@
     {% include "wagtailadmin/shared/pagination_nav.html" with items=documents linkurl='wagtaildocs:chooser_results' %}
 {% else %}
     {% if documents_exist %}
-        <p role="alert">{% blocktrans %}Sorry, no documents match "<em>{{ query_string }}</em>"{% endblocktrans %}</p>
+        <p role="alert">{% blocktrans trimmed %}Sorry, no documents match "<em>{{ query_string }}</em>"{% endblocktrans %}</p>
     {% else %}
         <p>
             {% if collection_id %}
@@ -26,7 +26,7 @@
             {% endif %}
             {% if uploadform %}
                 {% url 'wagtaildocs:add_multiple' as wagtaildocs_add_document_url %}
-                {% blocktrans %}
+                {% blocktrans trimmed %}
                     Why not <a class="upload-one-now" href="{{ wagtaildocs_add_document_url }}">upload one now</a>?
                 {% endblocktrans %}
             {% endif %}

--- a/wagtail/documents/templates/wagtaildocs/documents/confirm_delete.html
+++ b/wagtail/documents/templates/wagtaildocs/documents/confirm_delete.html
@@ -1,6 +1,6 @@
 {% extends "wagtailadmin/base.html" %}
 {% load wagtailadmin_tags i18n %}
-{% block titletag %}{% blocktrans with title=document.title %}Delete {{ title }}{% endblocktrans %}{% endblock %}
+{% block titletag %}{% blocktrans trimmed with title=document.title %}Delete {{ title }}{% endblocktrans %}{% endblock %}
 {% block content %}
     {% trans "Delete document" as del_str %}
     {% include "wagtailadmin/shared/header.html" with title=del_str subtitle=document.title icon="doc-full-inverse" %}
@@ -10,7 +10,7 @@
         {% usage_count_enabled as uc_enabled %}
         {% if uc_enabled %}
             <div class="usagecount">
-                <a href="{{ document.usage_url }}">{% blocktrans count usage_count=document.get_usage.count %}Used {{ usage_count }} time{% plural %}Used {{ usage_count }} times{% endblocktrans %}</a>
+                <a href="{{ document.usage_url }}">{% blocktrans trimmed count usage_count=document.get_usage.count %}Used {{ usage_count }} time{% plural %}Used {{ usage_count }} times{% endblocktrans %}</a>
             </div>
         {% endif %}
 

--- a/wagtail/documents/templates/wagtaildocs/documents/edit.html
+++ b/wagtail/documents/templates/wagtaildocs/documents/edit.html
@@ -1,7 +1,7 @@
 {% extends "wagtailadmin/base.html" %}
 {% load i18n %}
 {% load wagtailimages_tags wagtailadmin_tags %}
-{% block titletag %}{% blocktrans with title=document.title %}Editing {{ title }}{% endblocktrans %}{% endblock %}
+{% block titletag %}{% blocktrans trimmed with title=document.title %}Editing {{ title }}{% endblocktrans %}{% endblock %}
 
 {% block extra_js %}
     {{ block.super }}
@@ -64,7 +64,7 @@
                 {% if uc_enabled %}
                     <dt>{% trans "Usage" %}</dt>
                     <dd>
-                        <a href="{{ document.usage_url }}">{% blocktrans count usage_count=document.get_usage.count %}Used {{ usage_count }} time{% plural %}Used {{ usage_count }} times{% endblocktrans %}</a>
+                        <a href="{{ document.usage_url }}">{% blocktrans trimmed count usage_count=document.get_usage.count %}Used {{ usage_count }} time{% plural %}Used {{ usage_count }} times{% endblocktrans %}</a>
                     </dd>
                 {% endif %}
             </dl>

--- a/wagtail/documents/templates/wagtaildocs/documents/list.html
+++ b/wagtail/documents/templates/wagtaildocs/documents/list.html
@@ -48,7 +48,7 @@
                 {% endif %}
                 <td>
                     <div class="human-readable-date" title="{{ doc.created_at|date:"DATETIME_FORMAT" }}">
-                        {% blocktrans with time_period=doc.created_at|timesince %}{{ time_period }} ago{% endblocktrans %}
+                        {% blocktrans trimmed with time_period=doc.created_at|timesince %}{{ time_period }} ago{% endblocktrans %}
                     </div>
                 </td>
             </tr>

--- a/wagtail/documents/templates/wagtaildocs/documents/results.html
+++ b/wagtail/documents/templates/wagtaildocs/documents/results.html
@@ -2,7 +2,7 @@
 {% if documents %}
     {% if is_searching %}
         <h2 role="alert">
-            {% blocktrans count counter=documents|length %}
+            {% blocktrans trimmed count counter=documents|length %}
                 There is {{ counter }} match
             {% plural %}
                 There are {{ counter }} matches
@@ -17,15 +17,15 @@
     {% include "wagtailadmin/shared/pagination_nav.html" with items=documents %}
 {% else %}
     {% if is_searching %}
-        <h2 role="alert">{% blocktrans %}Sorry, no documents match "<em>{{ query_string }}</em>"{% endblocktrans %}</h2>
+        <h2 role="alert">{% blocktrans trimmed %}Sorry, no documents match "<em>{{ query_string }}</em>"{% endblocktrans %}</h2>
 
         {% search_other %}
     {% else %}
         {% url 'wagtaildocs:add_multiple' as wagtaildocs_add_document_url %}
         {% if current_collection %}
-            <p>{% blocktrans %}You haven't uploaded any documents in this collection. Why not <a href="{{ wagtaildocs_add_document_url }}">upload one now</a>?{% endblocktrans %}</p>
+            <p>{% blocktrans trimmed %}You haven't uploaded any documents in this collection. Why not <a href="{{ wagtaildocs_add_document_url }}">upload one now</a>?{% endblocktrans %}</p>
         {% else %}
-            <p>{% blocktrans %}You haven't uploaded any documents. Why not <a href="{{ wagtaildocs_add_document_url }}">upload one now</a>?{% endblocktrans %}</p>
+            <p>{% blocktrans trimmed %}You haven't uploaded any documents. Why not <a href="{{ wagtaildocs_add_document_url }}">upload one now</a>?{% endblocktrans %}</p>
         {% endif %}
     {% endif %}
 {% endif %}

--- a/wagtail/documents/templates/wagtaildocs/documents/usage.html
+++ b/wagtail/documents/templates/wagtaildocs/documents/usage.html
@@ -1,6 +1,6 @@
 {% extends "wagtailadmin/base.html" %}
 {% load i18n %}
-{% block titletag %}{% blocktrans with title=document.title %}Usage of {{ title }}{% endblocktrans %}{% endblock %}
+{% block titletag %}{% blocktrans trimmed with title=document.title %}Usage of {{ title }}{% endblocktrans %}{% endblock %}
 {% block content %}
     {% trans "Usage of" as usage_str %}
     {% include "wagtailadmin/shared/header.html" with title=usage_str subtitle=document.title %}

--- a/wagtail/documents/templates/wagtaildocs/homepage/site_summary_documents.html
+++ b/wagtail/documents/templates/wagtaildocs/homepage/site_summary_documents.html
@@ -3,7 +3,7 @@
 <li>
     {% icon name="doc-full-inverse" %}
     <a href="{% url 'wagtaildocs:index' %}">
-        {% blocktrans count counter=total_docs with total_docs|intcomma as total %}
+        {% blocktrans trimmed count counter=total_docs with total_docs|intcomma as total %}
             <span>{{ total }}</span> Document <span class="visuallyhidden">created in {{ site_name }}</span>
         {% plural %}
             <span>{{ total }}</span> Documents <span class="visuallyhidden">created in {{ site_name }}</span>

--- a/wagtail/images/templates/wagtailimages/bulk_actions/confirm_bulk_add_tags.html
+++ b/wagtail/images/templates/wagtailimages/bulk_actions/confirm_bulk_add_tags.html
@@ -1,7 +1,7 @@
 {% extends 'wagtailadmin/bulk_actions/confirmation/base.html' %}
 {% load i18n %}
 {% load wagtailimages_tags wagtailadmin_tags %}
-{% block titletag %}{% blocktrans count counter=items|length %}Add tags to 1 image {% plural %}Add tags to {{ counter }} images{% endblocktrans %}{% endblock %}
+{% block titletag %}{% blocktrans trimmed count counter=items|length %}Add tags to 1 image {% plural %}Add tags to {{ counter }} images{% endblocktrans %}{% endblock %}
 
 {% block extra_js %}
     {{ block.super }}
@@ -41,7 +41,7 @@
 
 {% block items_with_no_access %}
 
-    {% blocktrans asvar no_access_msg count counter=items_with_no_access|length %}You don't have permission to add tags to this image{% plural %}You don't have permission to add tags to these images{% endblocktrans %}
+    {% blocktrans trimmed asvar no_access_msg count counter=items_with_no_access|length %}You don't have permission to add tags to this image{% plural %}You don't have permission to add tags to these images{% endblocktrans %}
     {% include 'wagtailimages/bulk_actions/list_items_with_no_access.html' with items=items_with_no_access no_access_msg=no_access_msg %}
 
 {% endblock items_with_no_access %}

--- a/wagtail/images/templates/wagtailimages/bulk_actions/confirm_bulk_add_to_collection.html
+++ b/wagtail/images/templates/wagtailimages/bulk_actions/confirm_bulk_add_to_collection.html
@@ -1,7 +1,7 @@
 {% extends 'wagtailadmin/bulk_actions/confirmation/base.html' %}
 {% load i18n %}
 {% load wagtailimages_tags wagtailadmin_tags %}
-{% block titletag %}{% blocktrans count counter=items|length %}Add 1 image to new collection {% plural %}Add {{ counter }} images to new collection{% endblocktrans %}{% endblock %}
+{% block titletag %}{% blocktrans trimmed count counter=items|length %}Add 1 image to new collection {% plural %}Add {{ counter }} images to new collection{% endblocktrans %}{% endblock %}
 
 {% block header %}
     {% trans "Add images to collection" as add_str %}
@@ -29,7 +29,7 @@
 
 {% block items_with_no_access %}
 
-    {% blocktrans asvar no_access_msg count counter=items_with_no_access|length %}You don't have permission to add this image to a collection{% plural %}You don't have permission to add these images to a collection{% endblocktrans %}
+    {% blocktrans trimmed asvar no_access_msg count counter=items_with_no_access|length %}You don't have permission to add this image to a collection{% plural %}You don't have permission to add these images to a collection{% endblocktrans %}
     {% include 'wagtailimages/bulk_actions/list_items_with_no_access.html' with items=items_with_no_access no_access_msg=no_access_msg %}
 
 {% endblock items_with_no_access %}

--- a/wagtail/images/templates/wagtailimages/bulk_actions/confirm_bulk_delete.html
+++ b/wagtail/images/templates/wagtailimages/bulk_actions/confirm_bulk_delete.html
@@ -1,6 +1,6 @@
 {% extends 'wagtailadmin/bulk_actions/confirmation/base.html' %}
 {% load wagtailadmin_tags i18n %}
-{% block titletag %}{% blocktrans count counter=items|length %}Delete 1 image{% plural %}Delete {{ counter }} images{% endblocktrans %}{% endblock %}
+{% block titletag %}{% blocktrans trimmed count counter=items|length %}Delete 1 image{% plural %}Delete {{ counter }} images{% endblocktrans %}{% endblock %}
 
 {% block header %}
     {% trans "Delete images" as del_str %}
@@ -22,7 +22,7 @@
                 <li>
                     <a href="{% url 'wagtailimages:edit' image.item.id %}"  target="_blank" rel="noreferrer">{{image.item.title}}</a>
                     {% if uc_enabled %}
-                        (<a href="{{ image.item.usage_url }}">{% blocktrans count usage_count=image.item.get_usage.count %}Used {{ usage_count }} time{% plural %}Used {{ usage_count }} times{% endblocktrans %}</a>)
+                        (<a href="{{ image.item.usage_url }}">{% blocktrans trimmed count usage_count=image.item.get_usage.count %}Used {{ usage_count }} time{% plural %}Used {{ usage_count }} times{% endblocktrans %}</a>)
                     {% endif %}
                 </li>
             {% endfor %}
@@ -32,7 +32,7 @@
 
 {% block items_with_no_access %}
 
-    {% blocktrans asvar no_access_msg count counter=items_with_no_access|length %}You don't have permission to delete this image{% plural %}You don't have permission to delete these images{% endblocktrans %}
+    {% blocktrans trimmed asvar no_access_msg count counter=items_with_no_access|length %}You don't have permission to delete this image{% plural %}You don't have permission to delete these images{% endblocktrans %}
     {% include 'wagtailimages/bulk_actions/list_items_with_no_access.html' with items=items_with_no_access no_access_msg=no_access_msg %}
 
 {% endblock items_with_no_access %}

--- a/wagtail/images/templates/wagtailimages/chooser/results.html
+++ b/wagtail/images/templates/wagtailimages/chooser/results.html
@@ -3,7 +3,7 @@
 {% if images %}
     {% if is_searching %}
         <h2 role="alert">
-            {% blocktrans count counter=images.paginator.count %}
+            {% blocktrans trimmed count counter=images.paginator.count %}
                 There is {{ counter }} match
             {% plural %}
                 There are {{ counter }} matches

--- a/wagtail/images/templates/wagtailimages/homepage/site_summary_images.html
+++ b/wagtail/images/templates/wagtailimages/homepage/site_summary_images.html
@@ -3,7 +3,7 @@
 <li>
     {% icon name="image" %}
     <a href="{% url 'wagtailimages:index' %}">
-        {% blocktrans count counter=total_images with total_images|intcomma as total %}
+        {% blocktrans trimmed count counter=total_images with total_images|intcomma as total %}
             <span>{{ total }}</span> Image <span class="visuallyhidden">created in {{ site_name }}</span>
         {% plural %}
             <span>{{ total }}</span> Images <span class="visuallyhidden">created in {{ site_name }}</span>

--- a/wagtail/images/templates/wagtailimages/images/confirm_delete.html
+++ b/wagtail/images/templates/wagtailimages/images/confirm_delete.html
@@ -14,12 +14,12 @@
             {% usage_count_enabled as uc_enabled %}
             {% if uc_enabled %}
                 <div class="usagecount">
-                    <a href="{{ image.usage_url }}">{% blocktrans count usage_count=image.get_usage.count %}Used {{ usage_count }} time{% plural %}Used {{ usage_count }} times{% endblocktrans %}</a>
+                    <a href="{{ image.usage_url }}">{% blocktrans trimmed count usage_count=image.get_usage.count %}Used {{ usage_count }} time{% plural %}Used {{ usage_count }} times{% endblocktrans %}</a>
                 </div>
             {% endif %}
             <p>
                 {# This message will only appear in the singular, but we specify a plural so it can share the translation string with confirm_bulk_delete.html #}
-                {% blocktrans count counter=1 %}
+                {% blocktrans trimmed count counter=1 %}
                     Are you sure you want to delete this image?
                 {% plural %}
                     Are you sure you want to delete these images?

--- a/wagtail/images/templates/wagtailimages/images/edit.html
+++ b/wagtail/images/templates/wagtailimages/images/edit.html
@@ -1,6 +1,6 @@
 {% extends "wagtailadmin/base.html" %}
 {% load wagtailimages_tags wagtailadmin_tags i18n l10n %}
-{% block titletag %}{% blocktrans with title=image.title %}Editing image {{ title }}{% endblocktrans %}{% endblock %}
+{% block titletag %}{% blocktrans trimmed with title=image.title %}Editing image {{ title }}{% endblocktrans %}{% endblock %}
 {% block extra_css %}
     {{ block.super }}
 
@@ -99,7 +99,7 @@
                             {% if uc_enabled %}
                                 <dt>{% trans "Usage" %}</dt>
                                 <dd>
-                                    <a href="{{ image.usage_url }}">{% blocktrans count usage_count=image.get_usage.count %}Used {{ usage_count }} time{% plural %}Used {{ usage_count }} times{% endblocktrans %}</a>
+                                    <a href="{{ image.usage_url }}">{% blocktrans trimmed count usage_count=image.get_usage.count %}Used {{ usage_count }} time{% plural %}Used {{ usage_count }} times{% endblocktrans %}</a>
                                 </dd>
                             {% endif %}
                         </dl>

--- a/wagtail/images/templates/wagtailimages/images/results.html
+++ b/wagtail/images/templates/wagtailimages/images/results.html
@@ -3,7 +3,7 @@
 {% if images %}
     {% if is_searching %}
         <h2 role="alert">
-            {% blocktrans count counter=images.paginator.count %}
+            {% blocktrans trimmed count counter=images.paginator.count %}
                 There is {{ counter }} match
             {% plural %}
                 There are {{ counter }} matches
@@ -40,15 +40,15 @@
 
 {% else %}
     {% if is_searching %}
-        <h2 role="alert">{% blocktrans %}Sorry, no images match "<em>{{ query_string }}</em>"{% endblocktrans %}</h2>
+        <h2 role="alert">{% blocktrans trimmed %}Sorry, no images match "<em>{{ query_string }}</em>"{% endblocktrans %}</h2>
 
         {% search_other %}
     {% else %}
         {% url 'wagtailimages:add_multiple' as wagtailimages_add_image_url %}
         {% if current_collection %}
-            <p>{% blocktrans %}You haven't uploaded any images in this collection. Why not <a href="{{ wagtailimages_add_image_url }}">upload one now</a>?{% endblocktrans %}</p>
+            <p>{% blocktrans trimmed %}You haven't uploaded any images in this collection. Why not <a href="{{ wagtailimages_add_image_url }}">upload one now</a>?{% endblocktrans %}</p>
         {% else %}
-            <p>{% blocktrans %}You haven't uploaded any images. Why not <a href="{{ wagtailimages_add_image_url }}">upload one now</a>?{% endblocktrans %}</p>
+            <p>{% blocktrans trimmed %}You haven't uploaded any images. Why not <a href="{{ wagtailimages_add_image_url }}">upload one now</a>?{% endblocktrans %}</p>
         {% endif %}
     {% endif %}
 {% endif %}

--- a/wagtail/images/templates/wagtailimages/images/url_generator.html
+++ b/wagtail/images/templates/wagtailimages/images/url_generator.html
@@ -1,7 +1,7 @@
 {% extends "wagtailadmin/base.html" %}
 {% load wagtailimages_tags wagtailadmin_tags i18n %}
 
-{% block titletag %}{% blocktrans with title=image.title %}Editing image {{ title }}{% endblocktrans %}{% endblock %}
+{% block titletag %}{% blocktrans trimmed with title=image.title %}Editing image {{ title }}{% endblocktrans %}{% endblock %}
 
 {% block content %}
     {% trans "Generating URL" as title_str %}

--- a/wagtail/images/templates/wagtailimages/images/usage.html
+++ b/wagtail/images/templates/wagtailimages/images/usage.html
@@ -1,6 +1,6 @@
 {% extends "wagtailadmin/base.html" %}
 {% load i18n %}
-{% block titletag %}{% blocktrans with title=image.title %}Usage of {{ title }}{% endblocktrans %}{% endblock %}
+{% block titletag %}{% blocktrans trimmed with title=image.title %}Usage of {{ title }}{% endblocktrans %}{% endblock %}
 {% block content %}
     {% trans "Usage of" as usage_str %}
     {% include "wagtailadmin/shared/header.html" with title=usage_str subtitle=image.title %}

--- a/wagtail/snippets/templates/wagtailsnippets/chooser/results.html
+++ b/wagtail/snippets/templates/wagtailsnippets/chooser/results.html
@@ -2,7 +2,7 @@
 {% if items %}
     {% if is_searching %}
         <h2 role="alert">
-            {% blocktrans count counter=items.paginator.count %}
+            {% blocktrans trimmed count counter=items.paginator.count %}
                 There is {{ counter }} match
             {% plural %}
                 There are {{ counter }} matches
@@ -16,9 +16,9 @@
     {% include "wagtailadmin/shared/pagination_nav.html" with items=items linkurl=pagination_base_url %}
 {% else %}
     {% if is_searching %}
-        <p role="alert">{% blocktrans %}Sorry, no snippets match "<em>{{ query_string }}</em>"{% endblocktrans %}</p>
+        <p role="alert">{% blocktrans trimmed %}Sorry, no snippets match "<em>{{ query_string }}</em>"{% endblocktrans %}</p>
     {% else %}
         {% url 'wagtailsnippets:add' model_opts.app_label model_opts.model_name as wagtailsnippets_create_snippet_url %}
-        <p>{% blocktrans with snippet_type_name=model_opts.verbose_name %}You haven't created any {{ snippet_type_name }} snippets. Why not <a href="{{ wagtailsnippets_create_snippet_url }}" target="_blank" rel="noreferrer">create one now</a>?{% endblocktrans %}</p>
+        <p>{% blocktrans trimmed with snippet_type_name=model_opts.verbose_name %}You haven't created any {{ snippet_type_name }} snippets. Why not <a href="{{ wagtailsnippets_create_snippet_url }}" target="_blank" rel="noreferrer">create one now</a>?{% endblocktrans %}</p>
     {% endif %}
 {% endif %}

--- a/wagtail/snippets/templates/wagtailsnippets/snippets/confirm_delete.html
+++ b/wagtail/snippets/templates/wagtailsnippets/snippets/confirm_delete.html
@@ -2,7 +2,7 @@
 {% load wagtailadmin_tags i18n %}
 {% block titletag %}
     {% if count == 1 %}
-        {% blocktrans with snippet_type_name=model_opts.verbose_name %}Delete {{ snippet_type_name }}{% endblocktrans %} - {{ instances|first }}
+        {% blocktrans trimmed with snippet_type_name=model_opts.verbose_name %}Delete {{ snippet_type_name }}{% endblocktrans %} - {{ instances|first }}
     {% else %}
         {{ count }} {{ model_opts.verbose_name_plural|capfirst }}
     {% endif %}
@@ -20,12 +20,12 @@
             {% usage_count_enabled as uc_enabled %}
             {% if uc_enabled %}
                 <div class="usagecount">
-                    <a href="{{ instances.0.usage_url }}">{% blocktrans count usage_count=instances.0.get_usage.count %}Used {{ usage_count }} time{% plural %}Used {{ usage_count }} times{% endblocktrans %}</a>
+                    <a href="{{ instances.0.usage_url }}">{% blocktrans trimmed count usage_count=instances.0.get_usage.count %}Used {{ usage_count }} time{% plural %}Used {{ usage_count }} times{% endblocktrans %}</a>
                 </div>
             {% endif %}
-            <p>{% blocktrans with snippet_type_name=model_opts.verbose_name %}Are you sure you want to delete this {{ snippet_type_name }}?{% endblocktrans %}</p>
+            <p>{% blocktrans trimmed with snippet_type_name=model_opts.verbose_name %}Are you sure you want to delete this {{ snippet_type_name }}?{% endblocktrans %}</p>
         {% else %}
-            <p>{% blocktrans with snippet_type_name=model_opts.verbose_name_plural %}Are you sure you want to delete {{ count }} {{ snippet_type_name }}?{% endblocktrans %}</p>
+            <p>{% blocktrans trimmed with snippet_type_name=model_opts.verbose_name_plural %}Are you sure you want to delete {{ count }} {{ snippet_type_name }}?{% endblocktrans %}</p>
             <ul>
                 {% for instance in instances %}
                     <li>{{ instance }}</li>

--- a/wagtail/snippets/templates/wagtailsnippets/snippets/create.html
+++ b/wagtail/snippets/templates/wagtailsnippets/snippets/create.html
@@ -1,6 +1,6 @@
 {% extends "wagtailadmin/base.html" %}
 {% load i18n wagtailadmin_tags %}
-{% block titletag %}{% blocktrans with snippet_type_name=model_opts.verbose_name %}New  {{ snippet_type_name }}{% endblocktrans %}{% endblock %}
+{% block titletag %}{% blocktrans trimmed with snippet_type_name=model_opts.verbose_name %}New  {{ snippet_type_name }}{% endblocktrans %}{% endblock %}
 {% block content %}
     {% trans "New" as new_str %}
     {% include "wagtailadmin/shared/header_with_locale_selector.html" with title=new_str subtitle=model_opts.verbose_name icon="snippet" tabbed=1 merged=1 %}

--- a/wagtail/snippets/templates/wagtailsnippets/snippets/edit.html
+++ b/wagtail/snippets/templates/wagtailsnippets/snippets/edit.html
@@ -1,6 +1,6 @@
 {% extends "wagtailadmin/base.html" %}
 {% load wagtailadmin_tags i18n %}
-{% block titletag %}{% blocktrans with snippet_type_name=model_opts.verbose_name %}Editing {{ snippet_type_name }} - {{ instance }}{% endblocktrans %}{% endblock %}
+{% block titletag %}{% blocktrans trimmed with snippet_type_name=model_opts.verbose_name %}Editing {{ snippet_type_name }} - {{ instance }}{% endblocktrans %}{% endblock %}
 {% block content %}
     {% trans "Editing" as editing_str %}
     {% include "wagtailsnippets/snippets/_header_with_history.html" with title=editing_str subtitle=instance icon="snippet" tabbed=1 merged=1 %}
@@ -31,7 +31,7 @@
                 <dl>
                     <dt>{% trans "Usage" %}</dt>
                     <dd>
-                        <a href="{{ instance.usage_url }}">{% blocktrans count usage_count=instance.get_usage.count %}Used {{ usage_count }} time{% plural %}Used {{ usage_count }} times{% endblocktrans %}</a>
+                        <a href="{{ instance.usage_url }}">{% blocktrans trimmed count usage_count=instance.get_usage.count %}Used {{ usage_count }} time{% plural %}Used {{ usage_count }} times{% endblocktrans %}</a>
                     </dd>
                 </dl>
             </div>

--- a/wagtail/snippets/templates/wagtailsnippets/snippets/list.html
+++ b/wagtail/snippets/templates/wagtailsnippets/snippets/list.html
@@ -7,7 +7,7 @@
             {% if can_delete_snippets %}
                 <th>
                     <input type="checkbox" class="toggle-select-all" id="toggle-select-all-snippets" />
-                    <label for="toggle-select-all-snippets" class="visuallyhidden">{% blocktrans with snippet_type_name_plural=model_opts.verbose_name_plural %}Select all {{ snippet_type_name_plural }}{% endblocktrans %}</label>
+                    <label for="toggle-select-all-snippets" class="visuallyhidden">{% blocktrans trimmed with snippet_type_name_plural=model_opts.verbose_name_plural %}Select all {{ snippet_type_name_plural }}{% endblocktrans %}</label>
                 </th>
             {% endif %}
             <th>{% trans "Title" %}</th>
@@ -19,7 +19,7 @@
                 {% if can_delete_snippets %}
                     <td class="select">
                         <input type="checkbox" name="select_snippet" id="select-snippet-{{ snippet.pk }}" value="{{ snippet.pk }}" class="toggle-select-row"/>
-                        <label for="select-snippet-{{ snippet.pk }}" class="visuallyhidden">{% blocktrans %}Select {{ snippet }}{% endblocktrans %}</label>
+                        <label for="select-snippet-{{ snippet.pk }}" class="visuallyhidden">{% blocktrans trimmed %}Select {{ snippet }}{% endblocktrans %}</label>
                     </td>
                 {% endif %}
                 <td class="title">

--- a/wagtail/snippets/templates/wagtailsnippets/snippets/results.html
+++ b/wagtail/snippets/templates/wagtailsnippets/snippets/results.html
@@ -2,7 +2,7 @@
 {% if items %}
     {% if is_searching %}
         <h2 role="alert">
-            {% blocktrans count counter=items.paginator.count %}
+            {% blocktrans trimmed count counter=items.paginator.count %}
                 There is {{ counter }} match
             {% plural %}
                 There are {{ counter }} matches
@@ -16,16 +16,16 @@
     {% include "wagtailadmin/shared/pagination_nav.html" with items=items linkurl=wagtailsnippets_list_url %}
 {% else %}
     {% if is_searching %}
-        <p role="alert">{% blocktrans %}Sorry, no snippets match "<em>{{ query_string }}</em>"{% endblocktrans %}</p>
+        <p role="alert">{% blocktrans trimmed %}Sorry, no snippets match "<em>{{ query_string }}</em>"{% endblocktrans %}</p>
     {% else %}
         {% url 'wagtailsnippets:add' model_opts.app_label model_opts.model_name as wagtailsnippets_create_url %}
 
         {# NOTE: The two strings in the following messages are exactly the same #}
         {# The difference is that the first variant appends '?locale={{ locale.language_code}}' to 'wagtailsnippets_create_url' #}
         {% if locale %}
-            <p class="no-results-message">{% blocktrans with snippet_type_name_plural=model_opts.verbose_name_plural wagtailsnippets_create_url=wagtailsnippets_create_url|add:'?locale='|add:locale.language_code %}No {{ snippet_type_name_plural }} have been created. Why not <a href="{{ wagtailsnippets_create_url }}">add one</a>?{% endblocktrans %}</p>
+            <p class="no-results-message">{% blocktrans trimmed with snippet_type_name_plural=model_opts.verbose_name_plural wagtailsnippets_create_url=wagtailsnippets_create_url|add:'?locale='|add:locale.language_code %}No {{ snippet_type_name_plural }} have been created. Why not <a href="{{ wagtailsnippets_create_url }}">add one</a>?{% endblocktrans %}</p>
         {% else %}
-            <p class="no-results-message">{% blocktrans with snippet_type_name_plural=model_opts.verbose_name_plural %}No {{ snippet_type_name_plural }} have been created. Why not <a href="{{ wagtailsnippets_create_url }}">add one</a>?{% endblocktrans %}</p>
+            <p class="no-results-message">{% blocktrans trimmed with snippet_type_name_plural=model_opts.verbose_name_plural %}No {{ snippet_type_name_plural }} have been created. Why not <a href="{{ wagtailsnippets_create_url }}">add one</a>?{% endblocktrans %}</p>
         {% endif %}
     {% endif %}
 {% endif %}

--- a/wagtail/snippets/templates/wagtailsnippets/snippets/type_index.html
+++ b/wagtail/snippets/templates/wagtailsnippets/snippets/type_index.html
@@ -1,6 +1,6 @@
 {% extends "wagtailadmin/base.html" %}
 {% load i18n wagtailadmin_tags %}
-{% block titletag %}{% blocktrans with snippet_type_name_plural=model_opts.verbose_name_plural|capfirst %}Snippets {{ snippet_type_name_plural }}{% endblocktrans %}{% endblock %}
+{% block titletag %}{% blocktrans trimmed with snippet_type_name_plural=model_opts.verbose_name_plural|capfirst %}Snippets {{ snippet_type_name_plural }}{% endblocktrans %}{% endblock %}
 
 {% block extra_js %}
     {{ block.super }}
@@ -23,7 +23,7 @@
             <div class="left">
                 <div class="col header-title">
                     <h1>{% icon name="snippet" class_name="header-title-icon" %}
-                        {% blocktrans with snippet_type_name_plural=model_opts.verbose_name_plural|capfirst %}Snippets <span>{{ snippet_type_name_plural }}</span>{% endblocktrans %}</h1>
+                        {% blocktrans trimmed with snippet_type_name_plural=model_opts.verbose_name_plural|capfirst %}Snippets <span>{{ snippet_type_name_plural }}</span>{% endblocktrans %}</h1>
 
                     {% if is_searchable %}
                         <form class="col search-form" action="{% url 'wagtailsnippets:list' model_opts.app_label model_opts.model_name %}" method="get" novalidate>
@@ -50,7 +50,7 @@
                             <li class="col">
                                 <a class="button bicolor button--icon serious delete-button u-hidden" data-url="{% url 'wagtailsnippets:delete-multiple' model_opts.app_label model_opts.model_name %}?">
                                     {% icon name="bin" wrapped=1 %}
-                                    {% blocktrans with snippet_type_name=model_opts.verbose_name_plural %}Delete {{ snippet_type_name }}{% endblocktrans %}
+                                    {% blocktrans trimmed with snippet_type_name=model_opts.verbose_name_plural %}Delete {{ snippet_type_name }}{% endblocktrans %}
                                 </a>
                             </li>
                         {% endif %}
@@ -65,7 +65,7 @@
                             <li class="col">
                                 <a href="{% url 'wagtailsnippets:add' model_opts.app_label model_opts.model_name %}{% if locale %}?locale={{ locale.language_code }}{% endif %}" class="button bicolor button--icon">
                                     {% icon name="plus" wrapped=1 %}
-                                    {% blocktrans with snippet_type_name=model_opts.verbose_name %}Add {{ snippet_type_name }}{% endblocktrans %}</a>
+                                    {% blocktrans trimmed with snippet_type_name=model_opts.verbose_name %}Add {{ snippet_type_name }}{% endblocktrans %}</a>
                                 {# TODO: figure out a way of saying "Add a/an [foo]" #}
                             </li>
                         {% endif %}

--- a/wagtail/snippets/templates/wagtailsnippets/snippets/usage.html
+++ b/wagtail/snippets/templates/wagtailsnippets/snippets/usage.html
@@ -1,6 +1,6 @@
 {% extends "wagtailadmin/base.html" %}
 {% load i18n %}
-{% block titletag %}{% blocktrans with title=instance %}Usage of {{ title }}{% endblocktrans %}{% endblock %}
+{% block titletag %}{% blocktrans trimmed with title=instance %}Usage of {{ title }}{% endblocktrans %}{% endblock %}
 {% block content %}
     {% trans "Usage of" as usage_str %}
     {% include "wagtailadmin/shared/header.html" with title=usage_str subtitle=instance %}

--- a/wagtail/users/templates/wagtailusers/bulk_actions/confirm_bulk_assign_role.html
+++ b/wagtail/users/templates/wagtailusers/bulk_actions/confirm_bulk_assign_role.html
@@ -1,7 +1,7 @@
 {% extends 'wagtailadmin/bulk_actions/confirmation/base.html' %}
 {% load i18n wagtailusers_tags wagtailadmin_tags %}
 
-{% block titletag %}{% blocktrans count counter=items|length %}Assign role to 1 user {% plural %}Assign role to {{ counter }} users{% endblocktrans %}{% endblock %}
+{% block titletag %}{% blocktrans trimmed count counter=items|length %}Assign role to 1 user {% plural %}Assign role to {{ counter }} users{% endblocktrans %}{% endblock %}
 
 {% block header %}
     {% trans "Assign role" as header_str %}
@@ -23,7 +23,7 @@
 
 {% block items_with_no_access %}
 
-    {% blocktrans asvar no_access_msg count counter=items_with_no_access|length %}You don't have permission to edit this user{% plural %}You don't have permission to edit these users{% endblocktrans %}
+    {% blocktrans trimmed asvar no_access_msg count counter=items_with_no_access|length %}You don't have permission to edit this user{% plural %}You don't have permission to edit these users{% endblocktrans %}
     {% include 'wagtailusers/bulk_actions/list_items_with_no_access.html' with items=items_with_no_access no_access_msg=no_access_msg %}
 
 {% endblock items_with_no_access %}

--- a/wagtail/users/templates/wagtailusers/bulk_actions/confirm_bulk_delete.html
+++ b/wagtail/users/templates/wagtailusers/bulk_actions/confirm_bulk_delete.html
@@ -1,7 +1,7 @@
 {% extends 'wagtailadmin/bulk_actions/confirmation/base.html' %}
 {% load i18n wagtailusers_tags wagtailadmin_tags %}
 
-{% block titletag %}{% blocktrans count counter=items|length %}Delete 1 user {% plural %}Delete {{ counter }} users{% endblocktrans %}{% endblock %}
+{% block titletag %}{% blocktrans trimmed count counter=items|length %}Delete 1 user {% plural %}Delete {{ counter }} users{% endblocktrans %}{% endblock %}
 
 {% block header %}
     {% trans "Delete" as del_str %}
@@ -23,7 +23,7 @@
 
 {% block items_with_no_access %}
 
-    {% blocktrans asvar no_access_msg count counter=items_with_no_access|length %}You don't have permission to delete this user{% plural %}You don't have permission to delete these users{% endblocktrans %}
+    {% blocktrans trimmed asvar no_access_msg count counter=items_with_no_access|length %}You don't have permission to delete this user{% plural %}You don't have permission to delete these users{% endblocktrans %}
     {% include 'wagtailusers/bulk_actions/list_items_with_no_access.html' with items=items_with_no_access no_access_msg=no_access_msg %}
 
 {% endblock items_with_no_access %}

--- a/wagtail/users/templates/wagtailusers/bulk_actions/confirm_bulk_set_active_state.html
+++ b/wagtail/users/templates/wagtailusers/bulk_actions/confirm_bulk_set_active_state.html
@@ -1,7 +1,7 @@
 {% extends 'wagtailadmin/bulk_actions/confirmation/base.html' %}
 {% load i18n wagtailusers_tags wagtailadmin_tags %}
 
-{% block titletag %}{% blocktrans count counter=items|length %}Change active state for 1 user {% plural %}Change active state for {{ counter }} users{% endblocktrans %}{% endblock %}
+{% block titletag %}{% blocktrans trimmed count counter=items|length %}Change active state for 1 user {% plural %}Change active state for {{ counter }} users{% endblocktrans %}{% endblock %}
 
 {% block header %}
     {% trans "Set active state" as header_str %}
@@ -23,7 +23,7 @@
 
 {% block items_with_no_access %}
 
-    {% blocktrans asvar no_access_msg count counter=items_with_no_access|length %}You don't have permission to edit this user{% plural %}You don't have permission to edit these users{% endblocktrans %}
+    {% blocktrans trimmed asvar no_access_msg count counter=items_with_no_access|length %}You don't have permission to edit this user{% plural %}You don't have permission to edit these users{% endblocktrans %}
     {% include 'wagtailusers/bulk_actions/list_items_with_no_access.html' with items=items_with_no_access no_access_msg=no_access_msg %}
 
     {% trans "You cannot change your own active status" as no_access_msg %}

--- a/wagtail/users/templates/wagtailusers/groups/confirm_delete.html
+++ b/wagtail/users/templates/wagtailusers/groups/confirm_delete.html
@@ -8,7 +8,7 @@
 
     <div class="nice-padding">
         <p>
-            {% blocktrans with group_name=group.name count group_user_count=group.user_set.count %}
+            {% blocktrans trimmed with group_name=group.name count group_user_count=group.user_set.count %}
                 The group '{{ group_name }}' has <strong>{{ group_user_count }}</strong> member.
             {% plural %}
                 The group '{{ group_name }}' has <strong>{{ group_user_count }}</strong> members.

--- a/wagtail/users/templates/wagtailusers/groups/results.html
+++ b/wagtail/users/templates/wagtailusers/groups/results.html
@@ -5,8 +5,8 @@
 
     {% include "wagtailadmin/shared/pagination_nav.html" with items=page_obj linkurl="wagtailusers_groups:index" %}
 {% elif is_searching %}
-    <p role="alert">{% blocktrans with query=search_form.q.value %}Sorry, no groups match "{{ query }}"{% endblocktrans %}</p>
+    <p role="alert">{% blocktrans trimmed with query=search_form.q.value %}Sorry, no groups match "{{ query }}"{% endblocktrans %}</p>
 {% else %}
     {% url 'wagtailusers_groups:add' as wagtailusers_create_group_url %}
-    <p>{% blocktrans %}There are no groups configured. Why not <a href="{{ wagtailusers_create_group_url }}">add some</a>?{% endblocktrans %}</p>
+    <p>{% blocktrans trimmed %}There are no groups configured. Why not <a href="{{ wagtailusers_create_group_url }}">add some</a>?{% endblocktrans %}</p>
 {% endif %}

--- a/wagtail/users/templates/wagtailusers/users/list.html
+++ b/wagtail/users/templates/wagtailusers/users/list.html
@@ -46,7 +46,7 @@
                 <td class="username" valign="top">{{ user.get_username }}</td>
                 <td class="level" valign="top">{% if user.is_superuser %}{% trans "Admin" %}{% endif %}</td>
                 <td class="status" valign="top"><div class="status-tag {% if user.is_active %}primary{% endif %}">{% if user.is_active %}{% trans "Active" %}{% else %}{% trans "Inactive" %}{% endif %}</div></td>
-                <td {% if user.last_login %} class="human-readable-date" title="{{ user.last_login|date:"DATETIME_FORMAT" }}"{% endif %}>{% if user.last_login %}{% blocktrans with time_period=user.last_login|timesince %}{{ time_period }} ago{% endblocktrans %}{% endif %}</td>
+                <td {% if user.last_login %} class="human-readable-date" title="{{ user.last_login|date:"DATETIME_FORMAT" }}"{% endif %}>{% if user.last_login %}{% blocktrans trimmed with time_period=user.last_login|timesince %}{{ time_period }} ago{% endblocktrans %}{% endif %}</td>
             </tr>
         {% endfor %}
     </tbody>

--- a/wagtail/users/templates/wagtailusers/users/results.html
+++ b/wagtail/users/templates/wagtailusers/users/results.html
@@ -2,7 +2,7 @@
 {% if users %}
     {% if is_searching %}
         <h2 role="alert">
-            {% blocktrans count counter=users|length %}
+            {% blocktrans trimmed count counter=users|length %}
                 There is {{ counter }} match
             {% plural %}
                 There are {{ counter }} matches
@@ -18,17 +18,17 @@
     {% include "wagtailadmin/shared/pagination_nav.html" with items=users %}
 {% else %}
     {% if is_searching %}
-        <h2 role="alert">{% blocktrans %}Sorry, no users match "<em>{{ query_string }}</em>"{% endblocktrans %}</h2>
+        <h2 role="alert">{% blocktrans trimmed %}Sorry, no users match "<em>{{ query_string }}</em>"{% endblocktrans %}</h2>
 
         {% search_other %}
     {% else %}
         {% url 'wagtailusers_users:add' as wagtailusers_add_url %}
         {% if group %}
             {% with group.name as group_name %}
-                <p>{% blocktrans %}The {{ group_name }} group has no users configured. Why not <a href="{{ wagtailusers_add_url }}">add some</a>?{% endblocktrans %}</p>
+                <p>{% blocktrans trimmed %}The {{ group_name }} group has no users configured. Why not <a href="{{ wagtailusers_add_url }}">add some</a>?{% endblocktrans %}</p>
             {% endwith %}
         {% else %}
-            <p>{% blocktrans %}There are no users configured. Why not <a href="{{ wagtailusers_add_url }}">add some</a>?{% endblocktrans %}</p>
+            <p>{% blocktrans trimmed %}There are no users configured. Why not <a href="{{ wagtailusers_add_url }}">add some</a>?{% endblocktrans %}</p>
         {% endif %}
     {% endif %}
 {% endif %}


### PR DESCRIPTION
This was done via an automated find-replace process. I did a review over the places where the replacement happened and didn't find any places where spacing seemed like it would be significant.

In the process I also noticed a bunch of very long template lines (possibly made long to avoid the problem of spacing being included in the translation string?) that could now be broken onto separate lines for legibility.

Resolves #8217 

_Please check the following:_

- [ ] Do the tests still pass?[^1]
- [ ] Does the code comply with the style guide? 
    - [ ] Run `make lint` from the Wagtail root. 
- [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
- [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    - [ ] **Please list the exact browser and operating system versions you tested**:
    - [ ] **Please list which assistive technologies [^3] you tested**: 
- [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**. 

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets) 
