### PR TITLE
Renaming base url setting

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -39,6 +39,7 @@ Changelog
  * Add a `page_description` to the Page model, to provide help text for a given page type (Kalob Taulien, Thibaud Colas, Matt Westcott)
  * Add `trimmed` attribute to all blocktrans tags, so spacing is more reliable in translated strings (Harris Lapiroff)
  * Add documentation that describes how to use `ModelAdmin` to manage `Tag`s (Abdulmajeed Isa)
+ * Rename the setting `BASE_URL` (undocumented) to `WAGTAILADMIN_BASE_URL` and add to documentation, `BASE_URL` will be removed in a future release (Sandil Ranasinghe)
  * Fix: When using `simple_translations` ensure that the user is redirected to the page edit view when submitting for a single locale (Mitchel Cabuloy)
  * Fix: When previewing unsaved changes to `Form` pages, ensure that all added fields are correctly shown in the preview (Joshua Munn)
  * Fix: When Documents (e.g. PDFs) have been configured to be served inline via `WAGTAILDOCS_CONTENT_TYPES` & `WAGTAILDOCS_INLINE_CONTENT_TYPES` ensure that the filename is correctly set in the `Content-Disposition` header so that saving the files will use the correct filename (John-Scott Atlakson)

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -584,6 +584,7 @@ Contributors
 * Vinit Kumar
 * Shwet Khatri
 * Abdulmajeed Isa
+* Sandil Ranasinghe
 
 Translators
 ===========

--- a/docs/reference/settings.rst
+++ b/docs/reference/settings.rst
@@ -41,6 +41,26 @@ When ``WAGTAIL_APPEND_SLASH`` is ``False``, requests to Wagtail pages will be se
 
 .. _this Google Search Central Blog post: https://developers.google.com/search/blog/2010/04/to-slash-or-not-to-slash
 
+ADMIN BASE URL
+==============
+
+.. _wagtailadmin_base_url:
+
+``WAGTAILADMIN_BASE_URL``
+--------------------------
+
+.. code-block:: python
+
+    WAGTAILADMIN_BASE_URL = 'http://example.com/'
+
+This is the base URL used by the Wagtail admin site. It is typically used for generating URLs to include in notification emails.
+
+If this setting is not present, Wagtail will try to fall back to ``request.site.root_url`` or to the request's host name.
+
+.. versionchanged:: 3.0
+
+  This setting was previously named ``BASE_URL`` and was undocumented, using ``BASE_URL`` will be removed in a future release.
+
 Search
 ======
 

--- a/docs/releases/3.0.md
+++ b/docs/releases/3.0.md
@@ -69,6 +69,7 @@ class LandingPage(Page):
  * Use Django’s JavaScript catalog feature to manage translatable strings in JavaScript (Karl Hobley)
  * Add `trimmed` attribute to all blocktrans tags, so spacing is more reliable in translated strings (Harris Lapiroff)
  * Add documentation that describes how to use `ModelAdmin` to manage `Tag`s (Abdulmajeed Isa)
+ * Rename the setting `BASE_URL` (undocumented) to [`WAGTAILADMIN_BASE_URL`](wagtailadmin_base_url) and add to documentation, `BASE_URL` will be removed in a future release (Sandil Ranasinghe)
 
 ### Bug fixes
 
@@ -196,3 +197,9 @@ After setting the keyword argument, make sure to generate and run the migrations
 -   If you have a project migrating from pre 2.10 to this release and you are using the Wagtail form builder and you have existing form submissions you must first upgrade to at least 2.11. Then run migrations and run the application with your data to ensure that any existing form fields are correctly migrated.
 -   In Wagtail 2.10 a `clean_name` field was added to form field models that extend `AbstractFormField` and this initially supported legacy migration of the [Unidecode](https://pypi.org/project/Unidecode/) label conversion.
 -   Any new fields created since then will have used the [AnyAscii](https://pypi.org/project/anyascii/) conversion and Unidecode has been removed from the included packages.
+
+## Setting change `BASE_URL` is now `WAGTAILADMIN_BASE_URL`
+
+-   See [](wagtailadmin_base_url).
+-   `BASE_URL` was not documented but it provides a way to configure the base URL for the Wagtail admin which is used mostly in notifications.
+-    Usage of `BASE_URL` will be removed in a future release and it is recommended that the you update the setting in this release.

--- a/wagtail/admin/templates/wagtailadmin/notifications/base.html
+++ b/wagtail/admin/templates/wagtailadmin/notifications/base.html
@@ -1,4 +1,5 @@
 {% load wagtailadmin_tags i18n %}
+{% base_url_setting as base_url %}
 {% get_current_language as LANGUAGE_CODE %}
 {% get_current_language_bidi as LANGUAGE_BIDI %}
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
@@ -118,7 +119,7 @@
 
                                         <div style="font-size: 10px; margin-top: 20px;">
                                             {% block preferences %}
-                                                {% trans "Edit your notification preferences here:" %} <a href="{{ settings.BASE_URL }}{% url 'wagtailadmin_account' %}#notifications">{{ settings.BASE_URL }}{% url 'wagtailadmin_account' %}#notifications</a>
+                                                {% trans "Edit your notification preferences here:" %} <a href="{{ base_url }}{% url 'wagtailadmin_account' %}#notifications">{{ base_url }}{% url 'wagtailadmin_account' %}#notifications</a>
                                             {% endblock %}
                                         </div>
                                     </td>

--- a/wagtail/admin/templates/wagtailadmin/notifications/base.txt
+++ b/wagtail/admin/templates/wagtailadmin/notifications/base.txt
@@ -1,4 +1,5 @@
-{% load i18n %}
+{% load wagtailadmin_tags i18n %}
+{% base_url_setting as base_url %}
 
 {% block greeting %}
 {% blocktrans trimmed with username=user.get_short_name|default:user.get_username %}Hello {{ username }},{% endblocktrans %}
@@ -6,5 +7,5 @@
 {% block content %}
 {% endblock %}
 {% block preferences %}
-{% trans "Edit your notification preferences here:" %} {{ settings.BASE_URL }}{% url 'wagtailadmin_account' %}#notifications
+{% trans "Edit your notification preferences here:" %} {{ base_url }}{% url 'wagtailadmin_account' %}#notifications
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/rejected.html
+++ b/wagtail/admin/templates/wagtailadmin/notifications/rejected.html
@@ -1,7 +1,8 @@
 {% extends 'wagtailadmin/notifications/base.html' %}
-{% load i18n %}
+{% load wagtailadmin_tags i18n %}
+{% base_url_setting as base_url %}
 
 {% block content %}
     <p>{% blocktrans trimmed with title=revision.page.get_admin_display_title|safe %}The page "{{ title }}" has been rejected.{% endblocktrans %}</p>
-    <p>{% trans "You can edit the page here:"%} <a href="{{ settings.BASE_URL }}{% url 'wagtailadmin_pages:edit' revision.page.id %}">{{ settings.BASE_URL }}{% url 'wagtailadmin_pages:edit' revision.page.id %}</a></p>
+    <p>{% trans "You can edit the page here:"%} <a href="{{ base_url }}{% url 'wagtailadmin_pages:edit' revision.page.id %}">{{ base_url }}{% url 'wagtailadmin_pages:edit' revision.page.id %}</a></p>
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/rejected.txt
+++ b/wagtail/admin/templates/wagtailadmin/notifications/rejected.txt
@@ -1,8 +1,9 @@
 {% extends 'wagtailadmin/notifications/base.txt' %}
-{% load i18n %}
+{% load wagtailadmin_tags i18n %}
+{% base_url_setting as base_url %}
 
 {% block content %}
 {% blocktrans trimmed with title=revision.page.get_admin_display_title|safe %}The page "{{ title }}" has been rejected.{% endblocktrans %}
 
-{% trans "You can edit the page here:"%} {{ settings.BASE_URL }}{% url 'wagtailadmin_pages:edit' revision.page.id %}
+{% trans "You can edit the page here:"%} {{ base_url }}{% url 'wagtailadmin_pages:edit' revision.page.id %}
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/submitted.html
+++ b/wagtail/admin/templates/wagtailadmin/notifications/submitted.html
@@ -1,14 +1,14 @@
 {% extends 'wagtailadmin/notifications/base.html' %}
-
 {% load wagtailadmin_tags i18n %}
+{% base_url_setting as base_url %}
 
 {% block content %}
     <p>{% blocktrans trimmed with page=revision.page|safe editor=revision.user|user_display_name %}The page "{{ page }}" has been submitted for moderation by {{ editor }}.{% endblocktrans %}</p>
 
     <p>
         {% if revision.page.is_previewable %}
-            {% trans "You can preview the page here:" %} <a href="{{ settings.BASE_URL }}{% url 'wagtailadmin_pages:preview_for_moderation' revision.id %}">{{ settings.BASE_URL }}{% url 'wagtailadmin_pages:preview_for_moderation' revision.id %}</a><br/>
+            {% trans "You can preview the page here:" %} <a href="{{ base_url }}{% url 'wagtailadmin_pages:preview_for_moderation' revision.id %}">{{ base_url }}{% url 'wagtailadmin_pages:preview_for_moderation' revision.id %}</a><br/>
         {% endif %}
-        {% trans "You can edit the page here:" %} <a href="{{ settings.BASE_URL }}{% url 'wagtailadmin_pages:edit' revision.page.id %}">{{ settings.BASE_URL }}{% url 'wagtailadmin_pages:edit' revision.page.id %}</a>
+        {% trans "You can edit the page here:" %} <a href="{{ base_url }}{% url 'wagtailadmin_pages:edit' revision.page.id %}">{{ base_url }}{% url 'wagtailadmin_pages:edit' revision.page.id %}</a>
     </p>
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/submitted.txt
+++ b/wagtail/admin/templates/wagtailadmin/notifications/submitted.txt
@@ -1,9 +1,10 @@
 {% extends 'wagtailadmin/notifications/base.txt' %}
 {% load wagtailadmin_tags i18n %}
+{% base_url_setting as base_url %}
 
 {% block content %}
 {% blocktrans trimmed with page=revision.page|safe editor=revision.user|user_display_name %}The page "{{ page }}" has been submitted for moderation by {{ editor }}.{% endblocktrans %}
 
-{% if revision.page.is_previewable %}{% trans "You can preview the page here:" %} {{ settings.BASE_URL }}{% url 'wagtailadmin_pages:preview_for_moderation' revision.id %}{% endif %}
-{% trans "You can edit the page here:" %} {{ settings.BASE_URL }}{% url 'wagtailadmin_pages:edit' revision.page.id %}
+{% if revision.page.is_previewable %}{% trans "You can preview the page here:" %} {{ base_url }}{% url 'wagtailadmin_pages:preview_for_moderation' revision.id %}{% endif %}
+{% trans "You can edit the page here:" %} {{ base_url }}{% url 'wagtailadmin_pages:edit' revision.page.id %}
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/task_state_approved.html
+++ b/wagtail/admin/templates/wagtailadmin/notifications/task_state_approved.html
@@ -1,7 +1,8 @@
 {% extends 'wagtailadmin/notifications/base.html' %}
-{% load i18n %}
+{% load wagtailadmin_tags i18n %}
+{% base_url_setting as base_url %}
 
 {% block content %}
     <p>{% blocktrans trimmed with title=page.get_admin_display_title task=task.name %}The page "{{ title }}" has been approved in moderation stage "{{ task }}".{% endblocktrans %}</p>
-    <p>{% trans "You can edit the page here:"%} <a href="{{ settings.BASE_URL }}{% url 'wagtailadmin_pages:edit' page.id %}">{{ settings.BASE_URL }}{% url 'wagtailadmin_pages:edit' page.id %}</a></p>
+    <p>{% trans "You can edit the page here:"%} <a href="{{ base_url }}{% url 'wagtailadmin_pages:edit' page.id %}">{{ base_url }}{% url 'wagtailadmin_pages:edit' page.id %}</a></p>
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/task_state_approved.txt
+++ b/wagtail/admin/templates/wagtailadmin/notifications/task_state_approved.txt
@@ -1,7 +1,8 @@
 {% extends 'wagtailadmin/notifications/base.txt' %}
-{% load i18n %}
+{% load wagtailadmin_tags i18n %}
+{% base_url_setting as base_url %}
 
 {% block content %}
 {% blocktrans trimmed with title=page.get_admin_display_title|safe task=task.name|safe %}The page "{{ title }}" has been approved in moderation stage "{{ task }}".{% endblocktrans %}
-{% trans "You can edit the page here:"%} {{ settings.BASE_URL }}{% url 'wagtailadmin_pages:edit' page.id %}
+{% trans "You can edit the page here:"%} {{ base_url }}{% url 'wagtailadmin_pages:edit' page.id %}
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/task_state_rejected.html
+++ b/wagtail/admin/templates/wagtailadmin/notifications/task_state_rejected.html
@@ -1,7 +1,8 @@
 {% extends 'wagtailadmin/notifications/base.html' %}
-{% load i18n %}
+{% load wagtailadmin_tags i18n %}
+{% base_url_setting as base_url %}
 
 {% block content %}
     <p>{% blocktrans trimmed with title=page.get_admin_display_title task=task.name %}The page "{{ title }}" has been rejected in moderation stage "{{ task }}".{% endblocktrans %}</p>
-    <p>{% trans "You can edit the page here:"%} <a href="{{ settings.BASE_URL }}{% url 'wagtailadmin_pages:edit' page.id %}">{{ settings.BASE_URL }}{% url 'wagtailadmin_pages:edit' page.id %}</a></p>
+    <p>{% trans "You can edit the page here:"%} <a href="{{ base_url }}{% url 'wagtailadmin_pages:edit' page.id %}">{{ base_url }}{% url 'wagtailadmin_pages:edit' page.id %}</a></p>
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/task_state_rejected.txt
+++ b/wagtail/admin/templates/wagtailadmin/notifications/task_state_rejected.txt
@@ -1,7 +1,8 @@
 {% extends 'wagtailadmin/notifications/base.txt' %}
-{% load i18n %}
+{% load wagtailadmin_tags i18n %}
+{% base_url_setting as base_url %}
 
 {% block content %}
 {% blocktrans trimmed with title=page.get_admin_display_title|safe task=task.name|safe %}The page "{{ title }}" has been rejected in moderation stage "{{ task }}".{% endblocktrans %}
-{% trans "You can edit the page here:"%} {{ settings.BASE_URL }}{% url 'wagtailadmin_pages:edit' page.id %}
+{% trans "You can edit the page here:"%} {{ base_url }}{% url 'wagtailadmin_pages:edit' page.id %}
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/task_state_submitted.html
+++ b/wagtail/admin/templates/wagtailadmin/notifications/task_state_submitted.html
@@ -1,12 +1,12 @@
 {% extends 'wagtailadmin/notifications/base.html' %}
-
-{% load i18n %}
+{% load wagtailadmin_tags i18n %}
+{% base_url_setting as base_url %}
 
 {% block content %}
     <p>{% blocktrans trimmed with task=task.name title=page.get_admin_display_title %}The page "{{ title }}" has been submitted for approval in moderation stage "{{ task }}".{% endblocktrans %}</p>
 
     <p>
-        {% trans "You can preview the page here:" %} <a href="{{ settings.BASE_URL }}{% url 'wagtailadmin_pages:workflow_preview' page.id task.id %}">{{ settings.BASE_URL }}{% url 'wagtailadmin_pages:workflow_preview' page.id task.id %}</a><br/>
-        {% trans "You can edit the page here:" %} <a href="{{ settings.BASE_URL }}{% url 'wagtailadmin_pages:edit' page.id %}">{{ settings.BASE_URL }}{% url 'wagtailadmin_pages:edit' page.id %}</a>
+        {% trans "You can preview the page here:" %} <a href="{{ base_url }}{% url 'wagtailadmin_pages:workflow_preview' page.id task.id %}">{{ base_url }}{% url 'wagtailadmin_pages:workflow_preview' page.id task.id %}</a><br/>
+        {% trans "You can edit the page here:" %} <a href="{{ base_url }}{% url 'wagtailadmin_pages:edit' page.id %}">{{ base_url }}{% url 'wagtailadmin_pages:edit' page.id %}</a>
     </p>
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/task_state_submitted.txt
+++ b/wagtail/admin/templates/wagtailadmin/notifications/task_state_submitted.txt
@@ -1,12 +1,11 @@
 {% extends 'wagtailadmin/notifications/base.txt' %}
-
-{% load i18n %}
+{% load wagtailadmin_tags i18n %}
+{% base_url_setting as base_url %}
 
 {% block content %}
 {% blocktrans trimmed with task=task.name|safe title=page.get_admin_display_title|safe %}The page "{{ title }}" has been submitted for approval to moderation stage "{{ task }}".{% endblocktrans %}
 
-
-{% trans "You can preview the page here:" %} {{ settings.BASE_URL }}{% url 'wagtailadmin_pages:workflow_preview' page.id task.id %}
-{% trans "You can edit the page here:" %} {{ settings.BASE_URL }}{% url 'wagtailadmin_pages:edit' page.id %}
+{% trans "You can preview the page here:" %} {{ base_url }}{% url 'wagtailadmin_pages:workflow_preview' page.id task.id %}
+{% trans "You can edit the page here:" %} {{ base_url }}{% url 'wagtailadmin_pages:edit' page.id %}
 
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/updated_comments.html
+++ b/wagtail/admin/templates/wagtailadmin/notifications/updated_comments.html
@@ -1,5 +1,6 @@
 {% extends 'wagtailadmin/notifications/base.html' %}
 {% load i18n wagtailadmin_tags %}
+{% base_url_setting as base_url %}
 
 {% block content %}
     <p>
@@ -52,7 +53,7 @@
         </ul>
     {% endif %}
 
-    <p>{% trans "You can edit the page here:"%} <a href="{{ settings.BASE_URL }}{% url 'wagtailadmin_pages:edit' page.id %}">{{ settings.BASE_URL }}{% url 'wagtailadmin_pages:edit' page.id %}</a></p>
+    <p>{% trans "You can edit the page here:"%} <a href="{{ base_url }}{% url 'wagtailadmin_pages:edit' page.id %}">{{ base_url }}{% url 'wagtailadmin_pages:edit' page.id %}</a></p>
 {% endblock %}
 
 

--- a/wagtail/admin/templates/wagtailadmin/notifications/updated_comments.txt
+++ b/wagtail/admin/templates/wagtailadmin/notifications/updated_comments.txt
@@ -1,5 +1,6 @@
 {% extends 'wagtailadmin/notifications/base.txt' %}
 {% load i18n wagtailadmin_tags %}
+{% base_url_setting as base_url %}
 
 {% block content %}{% blocktrans trimmed with title=page.get_admin_display_title|safe editor=editor|user_display_name|safe %}{{ editor }} has updated comments on "{{ title }}".{% endblocktrans %}
 {% spaceless %}
@@ -29,6 +30,5 @@
   {% trans 'New replies to:' %} "{{ thread.comment.text }}"{% for reply in thread.replies %}
    - "{{ reply.text }}"{% endfor %}{% endfor %}{% endif %}
 
-
-{% trans "You can edit the page here:" %} {{ settings.BASE_URL }}{% url 'wagtailadmin_pages:edit' page.id %}
+{% trans "You can edit the page here:" %} {{ base_url }}{% url 'wagtailadmin_pages:edit' page.id %}
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/workflow_state_rejected.html
+++ b/wagtail/admin/templates/wagtailadmin/notifications/workflow_state_rejected.html
@@ -1,5 +1,6 @@
 {% extends 'wagtailadmin/notifications/base.html' %}
 {% load wagtailadmin_tags i18n %}
+{% base_url_setting as base_url %}
 
 {% block content %}
     {% if task_state.finished_by %}
@@ -10,5 +11,5 @@
     {% if comment %}
         <p>{% blocktrans trimmed %}The following comment was left: "{{ comment }}"{% endblocktrans %}</p>
     {% endif %}
-    <p>{% trans "You can edit the page here:"%} <a href="{{ settings.BASE_URL }}{% url 'wagtailadmin_pages:edit' page.id %}">{{ settings.BASE_URL }}{% url 'wagtailadmin_pages:edit' page.id %}</a></p>
+    <p>{% trans "You can edit the page here:"%} <a href="{{ base_url }}{% url 'wagtailadmin_pages:edit' page.id %}">{{ base_url }}{% url 'wagtailadmin_pages:edit' page.id %}</a></p>
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/workflow_state_rejected.txt
+++ b/wagtail/admin/templates/wagtailadmin/notifications/workflow_state_rejected.txt
@@ -1,5 +1,6 @@
 {% extends 'wagtailadmin/notifications/base.txt' %}
 {% load wagtailadmin_tags i18n %}
+{% base_url_setting as base_url %}
 
 {% block content %}
 {% if task_state.finished_by %}
@@ -10,5 +11,5 @@
 {% if comment %}
     {% blocktrans trimmed with comment=comment|safe %}The following comment was left: "{{ comment }}"{% endblocktrans %}</p>
 {% endif %}
-{% trans "You can edit the page here:"%} {{ settings.BASE_URL }}{% url 'wagtailadmin_pages:edit' page.id %}
+{% trans "You can edit the page here:"%} {{ base_url }}{% url 'wagtailadmin_pages:edit' page.id %}
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/workflow_state_submitted.html
+++ b/wagtail/admin/templates/wagtailadmin/notifications/workflow_state_submitted.html
@@ -1,6 +1,6 @@
 {% extends 'wagtailadmin/notifications/base.html' %}
-
 {% load wagtailadmin_tags i18n %}
+{% base_url_setting as base_url %}
 
 {% block content %}
     {% if requested_by %}
@@ -10,6 +10,6 @@
     {% endif %}
 
     <p>
-        {% trans "You can edit the page here:" %} <a href="{{ settings.BASE_URL }}{% url 'wagtailadmin_pages:edit' page.id %}">{{ settings.BASE_URL }}{% url 'wagtailadmin_pages:edit' page.id %}</a>
+        {% trans "You can edit the page here:" %} <a href="{{ base_url }}{% url 'wagtailadmin_pages:edit' page.id %}">{{ base_url }}{% url 'wagtailadmin_pages:edit' page.id %}</a>
     </p>
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/workflow_state_submitted.txt
+++ b/wagtail/admin/templates/wagtailadmin/notifications/workflow_state_submitted.txt
@@ -1,12 +1,12 @@
 {% extends 'wagtailadmin/notifications/base.txt' %}
-
 {% load wagtailadmin_tags i18n %}
+{% base_url_setting as base_url %}
 
 {% block content %}
 {% if requested_by %}{% blocktrans trimmed with workflow=workflow.name|safe title=page.get_admin_display_title|safe requester=requested_by|user_display_name|safe %}The page "{{ title }}" has been submitted for moderation to workflow "{{ workflow }}" by {{ requester }}.{% endblocktrans %}
 {% else %}{% blocktrans trimmed with workflow=workflow.name|safe title=page.get_admin_display_title|safe %}The page "{{ title }}" has been submitted for moderation to workflow "{{ workflow }}".{% endblocktrans %}
 {% endif %}
 
-{% trans "You can edit the page here:" %} {{ settings.BASE_URL }}{% url 'wagtailadmin_pages:edit' page.id %}
+{% trans "You can edit the page here:" %} {{ base_url }}{% url 'wagtailadmin_pages:edit' page.id %}
 
 {% endblock %}

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -30,6 +30,7 @@ from wagtail.admin.navigation import get_explorable_root_page
 from wagtail.admin.search import admin_search_areas
 from wagtail.admin.staticfiles import versioned_static as versioned_static_func
 from wagtail.admin.ui import sidebar
+from wagtail.admin.utils import get_admin_base_url
 from wagtail.admin.views.bulk_action.registry import bulk_action_registry
 from wagtail.admin.views.pages.utils import get_valid_next_url_from_request
 from wagtail.admin.widgets import ButtonWithDropdown, PageListingButton
@@ -282,9 +283,9 @@ def usage_count_enabled():
     return getattr(settings, "WAGTAIL_USAGE_COUNT_ENABLED", False)
 
 
-@register.simple_tag
-def base_url_setting():
-    return getattr(settings, "BASE_URL", None)
+@register.simple_tag(takes_context=True)
+def base_url_setting(context=None):
+    return get_admin_base_url(context=context)
 
 
 @register.simple_tag
@@ -698,7 +699,7 @@ def js_translation_strings():
 def notification_static(path):
     """
     Variant of the {% static %}` tag for use in notification emails - tries to form
-    a full URL using BASE_URL if the static URL isn't already a full URL.
+    a full URL using WAGTAILADMIN_BASE_URL if the static URL isn't already a full URL.
     """
     return urljoin(base_url_setting(), static(path))
 

--- a/wagtail/admin/tests/test_password_reset.py
+++ b/wagtail/admin/tests/test_password_reset.py
@@ -55,7 +55,9 @@ class TestUserPasswordReset(TestCase, WagtailTestUtils):
         self.assertEqual(len(mail.outbox), 1)
         self.assertIn("testserver", mail.outbox[0].body)
 
-    @override_settings(ROOT_URLCONF="wagtail.admin.urls", BASE_URL="http://mysite.com")
+    @override_settings(
+        ROOT_URLCONF="wagtail.admin.urls", WAGTAILADMIN_BASE_URL="http://mysite.com"
+    )
     def test_email_found_base_url(self):
         response = self.client.post(
             reverse("wagtailadmin_password_reset"), {"email": "siteeditor@example.com"}

--- a/wagtail/admin/tests/test_templatetags.py
+++ b/wagtail/admin/tests/test_templatetags.py
@@ -71,11 +71,15 @@ class TestNotificationStaticTemplateTag(TestCase):
     def test_local_notification_static(self):
         url = notification_static("wagtailadmin/images/email-header.jpg")
         self.assertEqual(
-            "{}/static/wagtailadmin/images/email-header.jpg".format(settings.BASE_URL),
+            "{}/static/wagtailadmin/images/email-header.jpg".format(
+                settings.WAGTAILADMIN_BASE_URL
+            ),
             url,
         )
 
-    @override_settings(STATIC_URL="/static/", BASE_URL="http://localhost:8000")
+    @override_settings(
+        STATIC_URL="/static/", WAGTAILADMIN_BASE_URL="http://localhost:8000"
+    )
     def test_local_notification_static_baseurl(self):
         url = notification_static("wagtailadmin/images/email-header.jpg")
         self.assertEqual(
@@ -84,7 +88,7 @@ class TestNotificationStaticTemplateTag(TestCase):
 
     @override_settings(
         STATIC_URL="https://s3.amazonaws.com/somebucket/static/",
-        BASE_URL="http://localhost:8000",
+        WAGTAILADMIN_BASE_URL="http://localhost:8000",
     )
     def test_remote_notification_static(self):
         url = notification_static("wagtailadmin/images/email-header.jpg")

--- a/wagtail/admin/utils.py
+++ b/wagtail/admin/utils.py
@@ -1,0 +1,34 @@
+from warnings import warn
+
+from django.conf import settings
+
+from wagtail.utils.deprecation import RemovedInWagtail50Warning
+
+
+def get_admin_base_url(context=None):
+    """
+    Gets the base URL for the wagtail admin site. This is set in `settings.WAGTAILADMIN_BASE_URL`,
+    which was previously `settings.BASE_URL`.
+    If setting is omitted and this is called in a request context, falls back to
+    `request.site.root_url` or next the host_name of the request.
+    """
+
+    admin_base_url = getattr(settings, "WAGTAILADMIN_BASE_URL", None)
+    if admin_base_url is None and hasattr(settings, "BASE_URL"):
+        warn(
+            "settings.BASE_URL has been renamed to settings.WAGTAILADMIN_BASE_URL",
+            category=RemovedInWagtail50Warning,
+        )
+        admin_base_url = settings.BASE_URL
+
+    if admin_base_url is None and context is not None:
+        request = context["request"]
+        admin_base_url = getattr(request.site, "root_url", None)
+        if admin_base_url is None:
+            admin_base_url = request.get_host()
+            secure_prefix = "http"
+            if request.is_secure():
+                secure_prefix = "https"
+            admin_base_url = secure_prefix + "://" + admin_base_url
+
+    return admin_base_url

--- a/wagtail/images/models.py
+++ b/wagtail/images/models.py
@@ -638,8 +638,8 @@ class AbstractRendition(ImageFileMixin, models.Model):
     @property
     def full_url(self):
         url = self.url
-        if hasattr(settings, "BASE_URL") and url.startswith("/"):
-            url = settings.BASE_URL + url
+        if hasattr(settings, "WAGTAILADMIN_BASE_URL") and url.startswith("/"):
+            url = settings.WAGTAILADMIN_BASE_URL + url
         return url
 
     @property

--- a/wagtail/project_template/project_name/settings/base.py
+++ b/wagtail/project_template/project_name/settings/base.py
@@ -163,4 +163,4 @@ WAGTAILSEARCH_BACKENDS = {
 
 # Base URL to use when referring to full URLs within the Wagtail admin backend -
 # e.g. in notification emails. Don't include '/admin' or a trailing slash
-BASE_URL = "http://example.com"
+WAGTAILADMIN_BASE_URL = "http://example.com"

--- a/wagtail/test/settings.py
+++ b/wagtail/test/settings.py
@@ -5,7 +5,7 @@ from django.utils.translation import gettext_lazy as _
 
 DEBUG = False
 WAGTAIL_ROOT = os.path.dirname(os.path.dirname(__file__))
-BASE_URL = "http://testserver"
+WAGTAILADMIN_BASE_URL = "http://testserver"
 STATIC_ROOT = os.path.join(WAGTAIL_ROOT, "tests", "test-static")
 MEDIA_ROOT = os.path.join(WAGTAIL_ROOT, "tests", "test-media")
 MEDIA_URL = "/media/"


### PR DESCRIPTION
Changing BASE_URL to WAGTAILADMIN_BASE_URL according to #3248

- `settings.BASE_URL` changed to `settings.WAGTAILADMIN_BASE_URL`
- falls back to `request.site.root_url` or the host name of the request if in a request context
- added documentation for WAGTAILADMIN_BASE_URL
- updated usage of `settings.BASE_URL` in html templates to use a tag (`base_url_setting`) instead
- pulled out code for getting the base_url from the tag `base_url_setting` to a separate function `get_admin_base_url`