### PR TITLE
Pin MarkupSafe to fix tests on 2.15.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ install_requires = [
     "tablib[xls,xlsx]>=0.14.0",
     "anyascii>=0.1.5",
     "telepath>=0.1.1,<1",
+    "markupsafe==2.0.1",
 ]
 
 # Testing dependencies


### PR DESCRIPTION
MarkupSafe release [2.1.0](https://markupsafe.palletsprojects.com/en/2.1.x/changes/#version-2-1-0) removed method `soft_unicode`. Jinja2 version 2.11.3 [doesn't put an upper bound on its MarkupSafe dependency](https://github.com/pallets/jinja/blob/cf215390d4a4d6f0a4de27e2687eed176878f13d/setup.py#L53), so pulls in this changed version of MarkupSafe.

The Wagtail tests [specify a Jinja2 `version >=2.11,<3.0`](https://github.com/wagtail/wagtail/blob/6f0f188bfc4270c4199cc87cdb7344659eeff1d0/setup.py#L48), so they try to import Jinja2 2.11.3 and MarkupSafe 2.1.1. These versions are incompatible due to the removal of `soft_unicode`, producing this error:

> ImportError: cannot import name 'soft_unicode' from 'markupsafe'

This fails CI, [for example](https://github.com/wagtail/wagtail/runs/5793338719?check_suite_focus=true).

This change adds an upper bound to Wagtail's import of MarkupSafe, which allows the tests to pass.

Relevant MarkupSafe issue discussing the deprecation: [link](https://github.com/pallets/markupsafe/issues/286).
Comparable project choosing to similarly pin MarkupSafe: [link](https://github.com/elastic/ecs/pull/1804).