### PR TITLE
Log deletes of all descendent pages during delete

### DIFF
--- a/wagtail/actions/delete_page.py
+++ b/wagtail/actions/delete_page.py
@@ -33,8 +33,8 @@ class DeletePageAction:
         # works around a bug in treebeard <= 3.0 where calling SpecificPage.delete() fails to delete
         # child pages that are not instances of SpecificPage
         if type(page) is Page:
-            for child in page.get_descendants():
-                self.log_deletion(child.specific)
+            for child in page.get_descendants().specific():
+                self.log_deletion(child)
             self.log_deletion(page.specific)
 
             # this is a Page instance, so carry on as we were

--- a/wagtail/actions/delete_page.py
+++ b/wagtail/actions/delete_page.py
@@ -33,9 +33,8 @@ class DeletePageAction:
         # works around a bug in treebeard <= 3.0 where calling SpecificPage.delete() fails to delete
         # child pages that are not instances of SpecificPage
         if type(page) is Page:
-            if page.get_children().exists():
-                for child in page.get_children():
-                    self.log_deletion(child.specific)
+            for child in page.get_descendants():
+                self.log_deletion(child.specific)
             self.log_deletion(page.specific)
 
             # this is a Page instance, so carry on as we were

--- a/wagtail/tests/test_audit_log.py
+++ b/wagtail/tests/test_audit_log.py
@@ -285,7 +285,9 @@ class TestAuditLog(TestCase):
         )
 
         # check deleting a parent page logs descendent deletion
-        self.home_page.delete()
+        with self.assertNumQueries(189):
+            self.home_page.delete()
+
         self.assertEqual(
             PageLogEntry.objects.filter(action="wagtail.delete").count(), 4
         )

--- a/wagtail/tests/test_audit_log.py
+++ b/wagtail/tests/test_audit_log.py
@@ -278,28 +278,29 @@ class TestAuditLog(TestCase):
                 title="Another child", slug="child-page-2", content="hello"
             )
         )
-
-        child.delete()
-        self.assertEqual(
-            PageLogEntry.objects.filter(action="wagtail.delete").count(), 1
+        child.add_child(
+            instance=SimplePage(
+                title="Grandchild", slug="grandchild-page", content="hello"
+            )
         )
 
-        # check deleting a parent page logs child deletion
+        # check deleting a parent page logs descendent deletion
         self.home_page.delete()
         self.assertEqual(
-            PageLogEntry.objects.filter(action="wagtail.delete").count(), 3
+            PageLogEntry.objects.filter(action="wagtail.delete").count(), 4
         )
-        self.assertListEqual(
-            list(
+        self.assertEqual(
+            set(
                 PageLogEntry.objects.filter(action="wagtail.delete").values_list(
                     "label", flat=True
                 )
             ),
-            [
+            {
                 "Homepage (simple page)",
+                "Grandchild (simple page)",
                 "Child (simple page)",
                 "Another child (simple page)",
-            ],
+            },
         )
 
     def test_workflow_actions(self):


### PR DESCRIPTION
Currently, when deleting a page, only the page itself and its direct children are logged. This change adds log entries for all descendents, and thus all the pages which are deleted. The crux of the issue being that `.get_children()` only returns direct children.

This will slow down deletes slightly, but make them more correct. To counter this, I've added `.specific` to the queryset.

_Please check the following:_

- [x] Do the tests still pass?[^1]
- [x] Does the code comply with the style guide? 
    - [ ] Run `make lint` from the Wagtail root. 
- [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
- [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    - [ ] **Please list the exact browser and operating system versions you tested**:
    - [ ] **Please list which assistive technologies [^3] you tested**: 
- [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**. 

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets) 
