### PR TITLE
Show which subpages are going to be deleted

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/pages/confirm_delete.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/confirm_delete.html
@@ -17,9 +17,9 @@
         {% if descendant_count %}
             <p>
                 {% blocktrans trimmed count counter=descendant_count %}
-                    {{ descendant_count }} subpage:
+                    {{ counter }} subpage:
                 {% plural %}
-                    {{ descendant_count }} subpages:
+                    {{ counter }} subpages:
                 {% endblocktrans %}
             </p>
             <ul>
@@ -32,9 +32,9 @@
         {% if translation_count %}
             <p>
                 {% blocktrans trimmed count counter=translation_count %}
-                    {{ translation_count }} translation:
+                    {{ counter }} translation:
                 {% plural %}
-                    {{ translation_count }} translations:
+                    {{ counter }} translations:
                 {% endblocktrans %}
             </p>
             <ul>
@@ -47,9 +47,9 @@
         {% if translation_count and translation_descendant_count %}
             <p>
                 {% blocktrans trimmed count counter=translation_descendant_count %}
-                    {{ translation_descendant_count }} translated subpage:
+                    {{ counter }} translated subpage:
                 {% plural %}
-                    {{ translation_descendant_count }} translated subpages:
+                    {{ counter }} translated subpages:
                 {% endblocktrans %}
             </p>
             <ul>
@@ -62,8 +62,15 @@
         <form action="{% url 'wagtailadmin_pages:delete' page.id %}" method="POST">
             {% csrf_token %}
             <input type="hidden" name="next" value="{{ next }}">
-            <input type="submit" value="{% trans 'Yes, delete it' %}" class="button serious">
-            <a href="{% if next %}{{ next }}{% else %}{% url 'wagtailadmin_explore' page.get_parent.id %}{% endif %}" class="button button-secondary">{% trans "No, don't delete it" %}</a>
+
+            {% blocktranslate trimmed count counter=object_delete_count asvar delete_text %}
+                Yes, delete {{ counter }} page
+            {% plural %}
+                Yes, delete {{ counter }} pages
+            {% endblocktranslate %}
+            <input type="submit" value="{{ delete_text }}" class="button serious">
+
+            <a href="{% if next %}{{ next }}{% else %}{% url 'wagtailadmin_explore' page.get_parent.id %}{% endif %}" class="button button-secondary">{% trans "No, don't delete" %}</a>
         </form>
 
         {% page_permissions page as page_perms %}

--- a/wagtail/admin/templates/wagtailadmin/pages/confirm_delete.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/confirm_delete.html
@@ -1,5 +1,5 @@
 {% extends "wagtailadmin/base.html" %}
-{% load i18n wagtailadmin_tags %}
+{% load i18n wagtailadmin_tags wagtailcore_tags %}
 {% block titletag %}{% blocktrans trimmed with title=page.get_admin_display_title %}Delete {{ title }}{% endblocktrans %}{% endblock %}
 
 {% block content %}
@@ -9,62 +9,55 @@
     <div class="nice-padding">
         <p>
             {% trans 'Are you sure you want to delete this page?' %}
-
-            {% if descendant_count %}
-                {% blocktrans trimmed count counter=descendant_count %}
-                    Deleting this page will also delete {{ descendant_count }} child page.
-                {% plural %}
-                    Deleting this page will also delete {{ descendant_count }} more child pages.
-                {% endblocktrans %}
-
-                {% if translation_count %} {# has translations #}
-                    {% if translation_descendant_count %} {# has translations with descendants #}
-                        {% if translation_count == 1 %}
-                            {% blocktrans trimmed count counter=translation_descendant_count %}
-                                It will also delete 1 translation and its combined {{ translation_descendant_count }} translated child page.
-                            {% plural %}
-                                It will also delete 1 translation and its combined {{ translation_descendant_count }} translated child pages.
-                            {% endblocktrans %}
-                        {% else %}
-                            {% blocktrans trimmed count counter=translation_descendant_count %}
-                                It will also delete {{ translation_count }} translations and their combined {{ translation_descendant_count }} translated child page.
-                            {% plural %}
-                                It will also delete {{ translation_count }} translations and their combined {{ translation_descendant_count }} translated child pages.
-                            {% endblocktrans %}
-                        {% endif %}
-                    {% else %}
-                        {% blocktrans trimmed count counter=translation_count %}
-                            It will also delete {{ translation_count }} translation.
-                        {% plural %}
-                            It will also delete {{ translation_count }} translations.
-                        {% endblocktrans %}
-                    {% endif %}
-                {% endif %}
-            {% elif translation_count %} {# no descendants #}
-                {% if translation_descendant_count %} {# has translations with descendants #}
-                    {% if translation_count == 1 %}
-                        {% blocktrans trimmed count counter=translation_descendant_count %}
-                            Deleting this page will also delete 1 translation and its combined {{ translation_descendant_count }} translated child page.
-                        {% plural %}
-                            Deleting this page will also delete 1 translation and its combined {{ translation_descendant_count }} translated child pages.
-                        {% endblocktrans %}
-                    {% else %}
-                        {% blocktrans trimmed count counter=translation_descendant_count %}
-                            Deleting this page will also delete {{ translation_count }} translations and their combined {{ translation_descendant_count }} translated child page.
-                        {% plural %}
-                            Deleting this page will also delete {{ translation_count }} translations and their combined {{ translation_descendant_count }} translated child pages.
-                        {% endblocktrans %}
-                    {% endif %}
-                {% else %}
-                    {% blocktrans trimmed count counter=translation_count %}
-                        Deleting this page will also delete {{ translation_count }} translation of this page.
-                    {% plural %}
-                        This will also delete {{ descendant_count }} more child pages.
-                        Deleting this page will also delete {{ translation_count }} translations of this page.
-                    {% endblocktrans %}
-                {% endif %}
+            {% if descendant_count or translation_count or translation_descendant_count %}
+                {% trans "This will also delete:" %}
             {% endif %}
         </p>
+
+        {% if descendant_count %}
+            <p>
+                {% blocktrans trimmed count counter=descendant_count %}
+                    {{ descendant_count }} subpage:
+                {% plural %}
+                    {{ descendant_count }} subpages:
+                {% endblocktrans %}
+            </p>
+            <ul>
+                {% for descendant in descendants.iterator %}
+                    <li><a href="{% url 'wagtailadmin_pages:edit' descendant.id %}">{{ descendant.title }}</a> ({{ descendant.specific_class.get_verbose_name }})</li>
+                {% endfor %}
+            </ul>
+        {% endif %}
+
+        {% if translation_count %}
+            <p>
+                {% blocktrans trimmed count counter=translation_count %}
+                    {{ translation_count }} translation:
+                {% plural %}
+                    {{ translation_count }} translations:
+                {% endblocktrans %}
+            </p>
+            <ul>
+                {% for translation in translations %}
+                    <li><a href="{% url 'wagtailadmin_pages:edit' translation.id %}">{{ translation.title }}</a> ({{ translation.specific_class.get_verbose_name }})</li>
+                {% endfor %}
+            </ul>
+        {% endif %}
+
+        {% if translation_count and translation_descendant_count %}
+            <p>
+                {% blocktrans trimmed count counter=translation_descendant_count %}
+                    {{ translation_descendant_count }} translated subpage:
+                {% plural %}
+                    {{ translation_descendant_count }} translated subpages:
+                {% endblocktrans %}
+            </p>
+            <ul>
+                {% for descendant in translation_descendants.iterator %}
+                    <li><a href="{% url 'wagtailadmin_pages:edit' descendant.id %}">{{ descendant.title }}</a> ({{ descendant.specific_class.get_verbose_name }})</li>
+                {% endfor %}
+            </ul>
+        {% endif %}
 
         <form action="{% url 'wagtailadmin_pages:delete' page.id %}" method="POST">
             {% csrf_token %}

--- a/wagtail/admin/tests/pages/test_delete_page.py
+++ b/wagtail/admin/tests/pages/test_delete_page.py
@@ -33,9 +33,10 @@ class TestPageDelete(TestCase, WagtailTestUtils):
         self.user = self.login()
 
     def test_page_delete(self):
-        response = self.client.get(
-            reverse("wagtailadmin_pages:delete", args=(self.child_page.id,))
-        )
+        with self.assertNumQueries(29):
+            response = self.client.get(
+                reverse("wagtailadmin_pages:delete", args=(self.child_page.id,))
+            )
         self.assertEqual(response.status_code, 200)
         # deletion should not actually happen on GET
         self.assertTrue(SimplePage.objects.filter(id=self.child_page.id).exists())
@@ -76,9 +77,10 @@ class TestPageDelete(TestCase, WagtailTestUtils):
         page_unpublished.connect(mock_handler)
 
         # Post
-        response = self.client.post(
-            reverse("wagtailadmin_pages:delete", args=(self.child_page.id,))
-        )
+        with self.assertNumQueries(180):
+            response = self.client.post(
+                reverse("wagtailadmin_pages:delete", args=(self.child_page.id,))
+            )
 
         # Should be redirected to explorer page
         self.assertRedirects(

--- a/wagtail/admin/views/pages/delete.py
+++ b/wagtail/admin/views/pages/delete.py
@@ -90,19 +90,27 @@ def delete(request, page_id):
         ),
     ).distinct()
 
+    descendant_count = page.get_descendant_count()
+    translation_descendant_count = translation_descendants_to_delete.count()
+
+    object_delete_count = (
+        len(translations_to_delete) + descendant_count + translation_descendant_count
+    )
+
     return TemplateResponse(
         request,
         "wagtailadmin/pages/confirm_delete.html",
         {
             "page": page,
-            "descendant_count": page.get_descendant_count(),
+            "object_delete_count": object_delete_count,
+            "descendant_count": descendant_count,
             "descendants": page.get_descendants()
             .order_by(Lower("title"))
             .only("id", "title"),
             "next": next_url,
             "translation_count": len(translations_to_delete),
             "translations": translations_to_delete,
-            "translation_descendant_count": translation_descendants_to_delete.count(),
+            "translation_descendant_count": translation_descendant_count,
             "translation_descendants": translation_descendants_to_delete.order_by(
                 Lower("title")
             ).only("id", "title"),


### PR DESCRIPTION
This makes it harder to accidentally delete the wrong page, as it's more obvious whether a page has unexpected descendents

![image](https://user-images.githubusercontent.com/6527489/162013500-03084161-192a-40b9-89df-adfd76567a35.png)

Inspired by the way Django Admin shows affected models during a delete. This implementation should be much faster than Django's, as we know we only need to show descendant pages.

Someone who is more CSS-y, I'm open to improvements. A simple `ul` definitely felt fine enough.

_Please check the following:_

- [ ] Do the tests still pass?[^1]
- [ ] Does the code comply with the style guide? 
    - [ ] Run `make lint` from the Wagtail root. 
- [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
- [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    - [ ] **Please list the exact browser and operating system versions you tested**:
    - [ ] **Please list which assistive technologies [^3] you tested**: 
- [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**. 

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets) 
