### PR TITLE
Fix banner date logic

### DIFF
--- a/docs/_static/js/banner.js
+++ b/docs/_static/js/banner.js
@@ -28,7 +28,7 @@ $(() => {
 
   if (
     !hasCookie('wagtailSpaceNLClosed', 'true') &&
-    new Date() < new Date(2022, 6, 18)
+    new Date() < new Date(2022, 5, 18) // Month is 0-based, so subtract one from the real month number!
   ) {
     $('main').prepend($wagtailspace);
     $wagtailspace.find('.wagtailspace-close').click(() => {


### PR DESCRIPTION
Months in `new Date(y, m, d)` are 0-based, just to be awkward