### PR TITLE
Fix tag imports for html lang/dir attributes

### DIFF
--- a/wagtail/project_template/project_name/templates/500.html
+++ b/wagtail/project_template/project_name/templates/500.html
@@ -1,8 +1,5 @@
-{% load wagtailadmin_tags i18n %}
-{% get_current_language as LANGUAGE_CODE %}
-{% get_current_language_bidi as LANGUAGE_BIDI %}
 <!DOCTYPE html>
-<html lang="{{ LANGUAGE_CODE }}" dir="{% if LANGUAGE_BIDI %}rtl{% else %}ltr{% endif %}">
+<html lang="en" dir="ltr">
     <head>
         <meta charset="utf-8" />
         <title>Internal server error</title>

--- a/wagtail/project_template/project_name/templates/500.html
+++ b/wagtail/project_template/project_name/templates/500.html
@@ -1,4 +1,11 @@
-<!DOCTYPE html>
+{% comment %}
+This error template is intentionally left as static HTML to ensure that it is still renderable even
+during system-wide failures such as a missing database.
+
+Any Django template tags here - including this comment - will be processed at the point of cloning
+the project template with `wagtail start`, and not during page rendering (unless escaped with
+'templatetag').
+{% endcomment %}<!DOCTYPE html>
 <html lang="en" dir="ltr">
     <head>
         <meta charset="utf-8" />

--- a/wagtail/templates/wagtailcore/login.html
+++ b/wagtail/templates/wagtailcore/login.html
@@ -1,5 +1,4 @@
 {% load i18n %}
-{% load wagtailadmin_tags i18n %}
 {% get_current_language as LANGUAGE_CODE %}
 {% get_current_language_bidi as LANGUAGE_BIDI %}
 <!DOCTYPE HTML>

--- a/wagtail/templates/wagtailcore/page.html
+++ b/wagtail/templates/wagtailcore/page.html
@@ -1,4 +1,4 @@
-{% load wagtailadmin_tags i18n %}
+{% load i18n %}
 {% get_current_language as LANGUAGE_CODE %}
 {% get_current_language_bidi as LANGUAGE_BIDI %}
 <!DOCTYPE HTML>

--- a/wagtail/templates/wagtailcore/password_required.html
+++ b/wagtail/templates/wagtailcore/password_required.html
@@ -1,5 +1,4 @@
 {% load i18n %}
-{% load wagtailadmin_tags i18n %}
 {% get_current_language as LANGUAGE_CODE %}
 {% get_current_language_bidi as LANGUAGE_BIDI %}
 <!DOCTYPE HTML>

--- a/wagtail/test/testapp/templates/tests/base.html
+++ b/wagtail/test/testapp/templates/tests/base.html
@@ -1,5 +1,5 @@
 {% load wagtailuserbar %}
-{% load wagtailadmin_tags i18n %}
+{% load i18n %}
 {% get_current_language as LANGUAGE_CODE %}
 {% get_current_language_bidi as LANGUAGE_BIDI %}
 <!DOCTYPE HTML>


### PR DESCRIPTION
Follow-up to #8220:

* project_template/500.html should not include template tags because they get parsed during `wagtail start` rather than on page render, and 500.html is static HTML by design - hard-code lang="en" instead
* remove redundant wagtailadmin_tags imports
