### PR TITLE
Prevent locale switcher in page chooser from breaking at the root level

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/chooser/_browse_results.html
+++ b/wagtail/admin/templates/wagtailadmin/chooser/_browse_results.html
@@ -2,9 +2,7 @@
 
 {% include "wagtailadmin/shared/chooser_breadcrumb.html" with page=parent_page show_locale_labels=show_locale_labels %}
 
-{% if pages %}
-    {% include "wagtailadmin/pages/listing/_list_choose.html" with allow_navigation=1 orderable=0 pages=pages parent_page=parent_page show_locale_labels=show_locale_labels %}
+{% include "wagtailadmin/pages/listing/_list_choose.html" with allow_navigation=1 orderable=0 pages=pages parent_page=parent_page show_locale_labels=show_locale_labels %}
 
-    {% url 'wagtailadmin_choose_page_child' parent_page.id as pagination_base_url %}
-    {% paginate pages base_url=pagination_base_url classnames="navigate-pages" %}
-{% endif %}
+{% url 'wagtailadmin_choose_page_child' parent_page.id as pagination_base_url %}
+{% paginate pages base_url=pagination_base_url classnames="navigate-pages" %}

--- a/wagtail/admin/templates/wagtailadmin/shared/chooser_breadcrumb.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/chooser_breadcrumb.html
@@ -10,7 +10,7 @@
                     {% include "wagtailadmin/shared/locale_selector.html" with translations=locale_options locale=page.locale only %}
                 {% endif %}
             {% else %}
-                <div class="c-dropdown t-inverted {{ class }}" style="display: inline-block;" data-dropdown>
+                <div class="c-dropdown t-inverted {{ class }}" style="display: inline-block;">
                     <div aria-label="{{ page.locale.get_display_name }}" class="c-dropdown__button u-btn-current">
                         {% icon name="site" class_name="default" %}
                         {{ page.locale.get_display_name }}

--- a/wagtail/admin/views/chooser.py
+++ b/wagtail/admin/views/chooser.py
@@ -161,7 +161,7 @@ def browse(request, parent_page_id=None):
     if show_locale_labels:
         pages = pages.select_related("locale")
 
-        if parent_page_id is None:
+        if parent_page.is_root():
             # 'locale' is the current value of the "Locale" selector in the UI
             if request.GET.get("locale"):
                 selected_locale = get_object_or_404(


### PR DESCRIPTION
Fixes #8079

The bug occurs whenever the page chooser modal is opened from a page chooser widget where the initial value is the root page or an immediate child of it (as is the case when editing the initial site record). Not really up to speed on how multi-language is supposed to work, but here's my analysis:

The JS error was occurring because the switcher was missing [a toggle element](https://github.com/wagtail/wagtail/blob/096ab2a8b45d447ddb1ce8543df1af7703a9a00a/client/src/entrypoints/admin/core.js#L661) (i.e. one with a `data-dropdown-toggle` attribute). This is because it was not rendering the real locale selector widget from `wagtailadmin/shared/locale_selector.html`, but [the fake one in `wagtailadmin/shared/chooser_breadcrumb.html`](https://github.com/wagtail/wagtail/blob/096ab2a8b45d447ddb1ce8543df1af7703a9a00a/wagtail/admin/templates/wagtailadmin/shared/chooser_breadcrumb.html#L13-L18) that's used when `locale_options` is empty.

Looking at [where the page chooser view populates `locale_options`](https://github.com/wagtail/wagtail/blob/096ab2a8b45d447ddb1ce8543df1af7703a9a00a/wagtail/admin/views/chooser.py#L164-L215), there are two code paths: `parent_page_id is None` and `# We have a parent page (that is not the root page)`. However, `parent_page_id` is only None if the chooser modal has been launched from an initially blank chooser widget - this code overlooks the possibility that `parent_page_id` has been explicitly set to a top-level page. The fix therefore is to check if the resolved `parent_page` is a root page, rather than checking the incoming URL parameter.

The question remains whether the 'fake' locale switcher in chooser_breadcrumb.html has any legitimate use - if so, it should probably be fixed to include a `data-dropdown-toggle` element, and if not, it should be removed.