### PR TITLE
Add missing import django models

### DIFF
--- a/docs/advanced_topics/documents/custom_document_model.md
+++ b/docs/advanced_topics/documents/custom_document_model.md
@@ -14,6 +14,8 @@ Here's an example:
 
 ```python
 # models.py
+from django.db import models
+
 from wagtail.documents.models import Document, AbstractDocument
 
 class CustomDocument(AbstractDocument):


### PR DESCRIPTION
Django models need to be imported

<!--
Thanks for contributing to Wagtail! 🎉

Before submitting, please review the [contributor guidelines](https://docs.wagtail.org/en/latest/contributing/index.html).
-->

_Please check the following:_

- [x] Do the tests still pass?[^1]
- [x] Does the code comply with the style guide? 
    - [x] Run `make lint` from the Wagtail root. 
- [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
- [x] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    - [x] **Please list the exact browser and operating system versions you tested**:
    - [x] **Please list which assistive technologies [^3] you tested**: 
- [x] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**. 

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets) 
