### PR TITLE
Ensure 'next' param on image / doc listings always links back to index page, not results view

### DIFF
--- a/wagtail/documents/tests/test_admin_views.py
+++ b/wagtail/documents/tests/test_admin_views.py
@@ -137,6 +137,25 @@ class TestDocumentIndexView(TestCase, WagtailTestUtils):
         self.assertContains(response, "%s?next=%s" % (edit_url, next_url))
 
 
+class TestDocumentListingResultsView(TestCase, WagtailTestUtils):
+    def setUp(self):
+        self.login()
+
+    def get(self, params={}):
+        return self.client.get(reverse("wagtaildocs:listing_results"), params)
+
+    def test_search(self):
+        doc = models.Document.objects.create(title="A boring report")
+
+        response = self.get({"q": "boring"})
+        self.assertEqual(response.status_code, 200)
+        # 'next' param on edit page link should point back to the documents index, not the results view
+        self.assertContains(
+            response,
+            "/admin/documents/edit/%d/?next=/admin/documents/%%3Fq%%3Dboring" % doc.id,
+        )
+
+
 class TestDocumentAddView(TestCase, WagtailTestUtils):
     def setUp(self):
         self.login()

--- a/wagtail/documents/views/documents.py
+++ b/wagtail/documents/views/documents.py
@@ -71,13 +71,18 @@ class BaseListingView(TemplateView):
         paginator = Paginator(documents, per_page=20)
         documents = paginator.get_page(self.request.GET.get("p"))
 
+        next_url = reverse("wagtaildocs:index")
+        request_query_string = self.request.META.get("QUERY_STRING")
+        if request_query_string:
+            next_url += "?" + request_query_string
+
         context.update(
             {
                 "ordering": ordering,
                 "documents": documents,
                 "query_string": query_string,
                 "is_searching": bool(query_string),
-                "next": self.request.get_full_path(),
+                "next": next_url,
             }
         )
         return context

--- a/wagtail/images/tests/test_admin_views.py
+++ b/wagtail/images/tests/test_admin_views.py
@@ -194,6 +194,28 @@ class TestImageIndexView(TestCase, WagtailTestUtils):
         )
 
 
+class TestImageListingResultsView(TestCase, WagtailTestUtils):
+    def setUp(self):
+        self.login()
+
+    def get(self, params={}):
+        return self.client.get(reverse("wagtailimages:listing_results"), params)
+
+    def test_search(self):
+        monster = Image.objects.create(
+            title="A scary monster",
+            file=get_test_image_file(),
+        )
+
+        response = self.get({"q": "monster"})
+        self.assertEqual(response.status_code, 200)
+        # 'next' param on edit page link should point back to the images index, not the results view
+        self.assertContains(
+            response,
+            "/admin/images/%d/?next=/admin/images/%%3Fq%%3Dmonster" % monster.id,
+        )
+
+
 class TestImageAddView(TestCase, WagtailTestUtils):
     def setUp(self):
         self.login()

--- a/wagtail/images/views/images.py
+++ b/wagtail/images/views/images.py
@@ -82,12 +82,17 @@ class BaseListingView(TemplateView):
         paginator = Paginator(images, per_page=INDEX_PAGE_SIZE)
         images = paginator.get_page(self.request.GET.get("p"))
 
+        next_url = reverse("wagtailimages:index")
+        request_query_string = self.request.META.get("QUERY_STRING")
+        if request_query_string:
+            next_url += "?" + request_query_string
+
         context.update(
             {
                 "images": images,
                 "query_string": query_string,
                 "is_searching": bool(query_string),
-                "next": self.request.get_full_path(),
+                "next": next_url,
             }
         )
 


### PR DESCRIPTION
Fixes #8291. When results listings are generated as partial AJAX responses through the listing_results review, the 'next' parameter on those results should point back to the main 'index' view so that on return from the edit view, the user gets back a full page rather than a partial response.

- [ ] Do the tests still pass?[^1]
- [ ] Does the code comply with the style guide? 
    - [ ] Run `make lint` from the Wagtail root. 
- [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
- [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    - [ ] **Please list the exact browser and operating system versions you tested**:
    - [ ] **Please list which assistive technologies [^3] you tested**: 
- [ ] For new features: Has the documentation been updated accordingly?

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets) 
