### PR TITLE
Fix RichTextField to StreamField example migration

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -672,6 +672,7 @@ Contributors
 * Benita Anawonah
 * Anisha Singh
 * Ivy Jeptoo
+* Jeremy Thompson
 
 Translators
 ===========

--- a/docs/topics/streamfield.md
+++ b/docs/topics/streamfield.md
@@ -629,7 +629,7 @@ from wagtail.rich_text import RichText
 def page_to_streamfield(page):
     changed = False
     if page.body.raw_text and not page.body:
-        page.body = [('rich_text', {'rich_text': RichText(page.body.raw_text)})]
+        page.body = [('rich_text', RichText(page.body.raw_text))]
         changed = True
     return page, changed
 


### PR DESCRIPTION
When following [the documentation steps](https://docs.wagtail.org/en/stable/topics/streamfield.html#migrating-richtextfields-to-streamfield) for migrating from a `RichTextField` to the newer `StreamField`, I was running in to the error ```AttributeError: 'dict' object has no attribute 'source'```

<details>
<summary>Full error log ▼</summary>

```
python manage.py migrate
...
Running migrations:
  Applying cms.0016_convert_cms_menuinformationpage_to_streamfield...Traceback (most recent call last):
  File "manage.py", line 24, in <module>
    main()
  File "manage.py", line 20, in main
    execute_from_command_line(sys.argv)
  File "/Users/jeremy/GitHub/pei-roadrunners/venv/lib/python3.8/site-packages/django/core/management/__init__.py", line 419, in execute_from_command_line
    utility.execute()
  File "/Users/jeremy/GitHub/pei-roadrunners/venv/lib/python3.8/site-packages/django/core/management/__init__.py", line 413, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/Users/jeremy/GitHub/pei-roadrunners/venv/lib/python3.8/site-packages/django/core/management/base.py", line 354, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/Users/jeremy/GitHub/pei-roadrunners/venv/lib/python3.8/site-packages/django/core/management/base.py", line 398, in execute
    output = self.handle(*args, **options)
  File "/Users/jeremy/GitHub/pei-roadrunners/venv/lib/python3.8/site-packages/django/core/management/base.py", line 89, in wrapped
    res = handle_func(*args, **kwargs)
  File "/Users/jeremy/GitHub/pei-roadrunners/venv/lib/python3.8/site-packages/django/core/management/commands/migrate.py", line 244, in handle
    post_migrate_state = executor.migrate(
  File "/Users/jeremy/GitHub/pei-roadrunners/venv/lib/python3.8/site-packages/django/db/migrations/executor.py", line 117, in migrate
    state = self._migrate_all_forwards(state, plan, full_plan, fake=fake, fake_initial=fake_initial)
  File "/Users/jeremy/GitHub/pei-roadrunners/venv/lib/python3.8/site-packages/django/db/migrations/executor.py", line 147, in _migrate_all_forwards
    state = self.apply_migration(state, migration, fake=fake, fake_initial=fake_initial)
  File "/Users/jeremy/GitHub/pei-roadrunners/venv/lib/python3.8/site-packages/django/db/migrations/executor.py", line 227, in apply_migration
    state = migration.apply(state, schema_editor)
  File "/Users/jeremy/GitHub/pei-roadrunners/venv/lib/python3.8/site-packages/django/db/migrations/migration.py", line 126, in apply
    operation.database_forwards(self.app_label, schema_editor, old_state, project_state)
  File "/Users/jeremy/GitHub/pei-roadrunners/venv/lib/python3.8/site-packages/django/db/migrations/operations/special.py", line 190, in database_forwards
    self.code(from_state.apps, schema_editor)
  File "/Users/jeremy/GitHub/pei-roadrunners/cms/migrations/0016_convert_cms_menuinformationpage_to_streamfield.py", line 58, in convert_to_streamfield
    return convert(apps, schema_editor, page_to_streamfield, pagerevision_to_streamfield)
  File "/Users/jeremy/GitHub/pei-roadrunners/cms/migrations/0016_convert_cms_menuinformationpage_to_streamfield.py", line 46, in convert
    page.save()
  File "/Users/jeremy/GitHub/pei-roadrunners/venv/lib/python3.8/site-packages/django/db/models/base.py", line 726, in save
    self.save_base(using=using, force_insert=force_insert,
  File "/Users/jeremy/GitHub/pei-roadrunners/venv/lib/python3.8/site-packages/django/db/models/base.py", line 763, in save_base
    updated = self._save_table(
  File "/Users/jeremy/GitHub/pei-roadrunners/venv/lib/python3.8/site-packages/django/db/models/base.py", line 845, in _save_table
    updated = self._do_update(base_qs, using, pk_val, values, update_fields,
  File "/Users/jeremy/GitHub/pei-roadrunners/venv/lib/python3.8/site-packages/django/db/models/base.py", line 899, in _do_update
    return filtered._update(values) > 0
  File "/Users/jeremy/GitHub/pei-roadrunners/venv/lib/python3.8/site-packages/django/db/models/query.py", line 802, in _update
    return query.get_compiler(self.db).execute_sql(CURSOR)
  File "/Users/jeremy/GitHub/pei-roadrunners/venv/lib/python3.8/site-packages/django/db/models/sql/compiler.py", line 1559, in execute_sql
    cursor = super().execute_sql(result_type)
  File "/Users/jeremy/GitHub/pei-roadrunners/venv/lib/python3.8/site-packages/django/db/models/sql/compiler.py", line 1162, in execute_sql
    sql, params = self.as_sql()
  File "/Users/jeremy/GitHub/pei-roadrunners/venv/lib/python3.8/site-packages/django/db/models/sql/compiler.py", line 1525, in as_sql
    val = field.get_db_prep_save(val, connection=self.connection)
  File "/Users/jeremy/GitHub/pei-roadrunners/venv/lib/python3.8/site-packages/django/db/models/fields/__init__.py", line 842, in get_db_prep_save
    return self.get_db_prep_value(value, connection=connection, prepared=False)
  File "/Users/jeremy/GitHub/pei-roadrunners/venv/lib/python3.8/site-packages/django/db/models/fields/__init__.py", line 837, in get_db_prep_value
    value = self.get_prep_value(value)
  File "/Users/jeremy/GitHub/pei-roadrunners/venv/lib/python3.8/site-packages/wagtail/core/fields.py", line 145, in get_prep_value
    return json.dumps(self.stream_block.get_prep_value(value), cls=DjangoJSONEncoder)
  File "/Users/jeremy/GitHub/pei-roadrunners/venv/lib/python3.8/site-packages/wagtail/core/blocks/stream_block.py", line 250, in get_prep_value
    return value.get_prep_value()
  File "/Users/jeremy/GitHub/pei-roadrunners/venv/lib/python3.8/site-packages/wagtail/core/blocks/stream_block.py", line 534, in get_prep_value
    prep_value.append(item.get_prep_value())
  File "/Users/jeremy/GitHub/pei-roadrunners/venv/lib/python3.8/site-packages/wagtail/core/blocks/stream_block.py", line 371, in get_prep_value
    'value': self.block.get_prep_value(self.value),
  File "/Users/jeremy/GitHub/pei-roadrunners/venv/lib/python3.8/site-packages/wagtail/core/blocks/field_block.py", line 589, in get_prep_value
    return value.source
AttributeError: 'dict' object has no attribute 'source'
```
</details>

I was trying to use the second example in the documentation, which migrates `Page` and `PageRevision` objects. The code to migrate just `Page` objects in the first example in the documentation is different from the second example that migrates both `Page` and `PageRevision` objects. This PR changes the second example to match the code in the first.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets) 
