### PR TITLE
Pin sphinx-wagtail-theme==5.1.1

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,2 @@
 myst_parser==0.17.0
-sphinx-wagtail-theme==5.1.0
+sphinx-wagtail-theme==5.1.1

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ documentation_extras = [
     "sphinxcontrib-spelling>=5.4.0,<6",
     "Sphinx>=1.5.2",
     "sphinx-autobuild>=0.6.0",
-    "sphinx-wagtail-theme==5.1.0",
+    "sphinx-wagtail-theme==5.1.1",
     "myst_parser==0.17.0",
 ]
 


### PR DESCRIPTION
@gasman We had a last minute fix. 

The code highlight has now sufficient contrast.
Example of the fixed highlight: https://wagtail--8308.org.readthedocs.build/en/8308/topics/streamfield.html#listblock

Refs
- https://github.com/wagtail/sphinx_wagtail_theme/pull/154
- https://github.com/wagtail/wagtail/pull/8306