### PR TITLE
Raise an error when an indexed field is not found

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -594,6 +594,7 @@ Contributors
 * Daniel Kirkham
 * Luz Paz
 * Simon Krull
+* Przemysław Buczkowski
 
 Translators
 ===========

--- a/wagtail/search/index.py
+++ b/wagtail/search/index.py
@@ -233,6 +233,9 @@ class BaseField:
                 if self.field_name in base_cls.__dict__:
                     return base_cls
 
+            # If not found, re-raise
+            raise
+
     def get_type(self, cls):
         if "type" in self.kwargs:
             return self.kwargs["type"]


### PR DESCRIPTION
Before, a None would be returned from BaseField.get_definition_model(),
leading to arcane errors in its sole caller,
Elasticsearch5Mapping.get_field_column_name.

This commit re-raises the Django FieldDoesNotExist exception, which
generates a much more user-friendly message.

This was reported before in #6483.

<!--
Thanks for contributing to Wagtail! 🎉

Before submitting, please review the [contributor guidelines](https://docs.wagtail.org/en/latest/contributing/index.html).
-->

_Please check the following:_

- [X] Do the tests still pass?[^1]
- [X] Does the code comply with the style guide? 
    - [X] Run `make lint` from the Wagtail root. 
- [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?

**Please describe additional details for testing this change**. 

TBD
