### PR TITLE
Use FormData for docs/images add-multiple's edit handling

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -11,6 +11,7 @@ Changelog
  * Fix issue where `ModelAdmin` index listings with export list enabled would show buttons with an incorrect layout (Josh Woodcock)
  * Use `InlinePanel`'s label when available for field comparison label (Sandil Ranasinghe)
  * Drop support for Safari 13 by removing left/right positioning in favour of CSS logical properties (Thibaud Colas)
+ * Use `FormData` instead of jQuery's `form.serialize` when editing documents or images just added so that additional fields can be better supported (Stefan Hammer)
  * Fix: Typo in `ResumeWorkflowActionFormatter` message (Stefan Hammer)
  * Fix: Throw a meaningful error when saving an image to an unrecognised image format (Christian Franke)
 

--- a/docs/releases/4.0.md
+++ b/docs/releases/4.0.md
@@ -16,6 +16,7 @@ depth: 1
  * Add `base_url_path` to `ModelAdmin` so that the default URL structure of app_label/model_name can be overridden (Vu Pham, Khanh Hoang)
  * Add `full_url` to the API output of `ImageRenditionField` (Paarth Agarwal)
  * Use `InlinePanel`'s label when available for field comparison label (Sandil Ranasinghe)
+ * Use `FormData` instead of jQuery's `form.serialize` when editing documents or images just added so that additional fields can be better supported (Stefan Hammer)
  * Drop support for Safari 13 by removing left/right positioning in favour of CSS logical properties (Thibaud Colas)
 
 ### Bug fixes

--- a/wagtail/documents/static_src/wagtaildocs/js/add-multiple.js
+++ b/wagtail/documents/static_src/wagtaildocs/js/add-multiple.js
@@ -144,14 +144,24 @@ $(function () {
     },
   });
 
-  // ajax-enhance forms added on done()
+  /**
+   * ajax-enhance forms added on done()
+   * allows the user to modify the title, collection, tags and delete after upload
+   */
   $('#upload-list').on('submit', 'form', function (e) {
     var form = $(this);
+    var formData = new FormData(this);
     var itemElement = form.closest('#upload-list > li');
 
     e.preventDefault();
 
-    $.post(this.action, form.serialize(), function (data) {
+    $.ajax({
+      contentType: false,
+      data: formData,
+      processData: false,
+      type: 'POST',
+      url: this.action,
+    }).done(function (data) {
       if (data.success) {
         var statusText = $('.status-msg.update-success').text();
         addMessage('success', statusText);

--- a/wagtail/images/static_src/wagtailimages/js/add-multiple.js
+++ b/wagtail/images/static_src/wagtailimages/js/add-multiple.js
@@ -185,14 +185,24 @@ $(function () {
     },
   });
 
-  // ajax-enhance forms added on done()
+  /**
+   * ajax-enhance forms added on done()
+   * allows the user to modify the title, collection, tags and delete after upload
+   */
   $('#upload-list').on('submit', 'form', function (e) {
     var form = $(this);
+    var formData = new FormData(this);
     var itemElement = form.closest('#upload-list > li');
 
     e.preventDefault();
 
-    $.post(this.action, form.serialize(), function (data) {
+    $.ajax({
+      contentType: false,
+      data: formData,
+      processData: false,
+      type: 'POST',
+      url: this.action,
+    }).done(function (data) {
       if (data.success) {
         var statusText = $('.status-msg.update-success').text();
         addMessage('success', statusText);


### PR DESCRIPTION
The ajax-request now uses multipart/form-data, similar to `image-chooser-modal.js`/`document-chooser-modal.js`, which allows to add and use `FileFields` in the bulk-upload-views.

This PR is a bit related to https://github.com/wagtail/wagtail/issues/8314, because we needed an additional `FileField` for our images, where the user can attach a license proof in some cases (depends on other custom fields and validation).
This works in the image chooser, but did not work in the bulk-upload-tool (`add-multiple.js`), because those file-inputs have not been transferred to the backend with jquery's `.serialize()`.
So as a quickfix, we had to customize/patch `get_image_multi_form()`, to exclude the license proof for now, but to allow customizations in a clean way, I've created #8314.

_Please check the following:_

- [x] Do the tests still pass?[^1]
- [x] Does the code comply with the style guide? 
    - [x] Run `make lint` from the Wagtail root. 
- [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    - [x] **Please list the exact browser and operating system versions you tested**:
    Google Chrome 100.0.4896.75, Firefox 99.0 (both on Linux Mint/Ubuntu)
    - [ ] **Please list which assistive technologies [^3] you tested**: 
- [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**. 

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets) 
