### PR TITLE
Backport - Fix copy-then-publish IntegrityError with Translatable Orderables to 2.16.x

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -10,6 +10,7 @@ Changelog
  * Fix: Ensure that all descendant pages are logged when deleting a page, not just immediate children (Jake Howard)
  * Fix: Refactor `FormPagesListView` in wagtail.contrib.forms to avoid undefined `locale` variable when subclassing (Dan Braghis)
  * Fix: page copy in Wagtail admin ignores `exclude_fields_in_copy` (John-Scott Atlakson)
+ * Fix: Translation key `IntegrityError` when publishing pages with translatable `Orderable`s that were copied without being published (Kalob Taulien, Dan Braghis)
 
 
 2.16.1 (11.02.2022)

--- a/docs/releases/2.16.2.md
+++ b/docs/releases/2.16.2.md
@@ -16,6 +16,7 @@
  * Ensure that all descendant pages are logged when deleting a page, not just immediate children (Jake Howard)
  * Refactor `FormPagesListView` in wagtail.contrib.forms to avoid undefined `locale` variable when subclassing (Dan Braghis)
  * Ensure page copy in Wagtail admin doesn't ignore `exclude_fields_in_copy` (John-Scott Atlakson)
+ * Generate new translation keys for translatable `Orderable`s when page is copied without being published (Kalob Taulien, Dan Braghis)
 
 ## Upgrade considerations
 

--- a/wagtail/core/tests/test_page_model.py
+++ b/wagtail/core/tests/test_page_model.py
@@ -1766,6 +1766,34 @@ class TestCopyPage(TestCase):
         # The copy should just be a copy of the original page, not an alias
         self.assertIsNone(about_us_alias_copy.alias_of)
 
+    def test_copy_page_with_unique_uuids_in_orderables(self):
+        """
+        Test that a page with orderables can be copied and the translation
+        keys are updated.
+        """
+        christmas_page = EventPage.objects.get(url_path="/home/events/christmas/")
+        christmas_page.speakers.add(
+            EventPageSpeaker(
+                first_name="Santa",
+                last_name="Claus",
+            )
+        )
+        christmas_page.save()
+        # ensure there's a revision (which should capture the new speaker orderables)
+        christmas_page.save_revision().publish()
+
+        new_page = christmas_page.copy(
+            update_attrs={
+                "title": "Orderable Page",
+                "slug": "translated-orderable-page",
+            },
+        )
+        new_page.save_revision().publish()
+        self.assertNotEqual(
+            christmas_page.speakers.first().translation_key,
+            new_page.speakers.first().translation_key,
+        )
+
 
 class TestCreateAlias(TestCase):
     fixtures = ['test.json']


### PR DESCRIPTION
Backports #8161 to 2.16.x