### PR TITLE
Check get_url_parts return value in automatic redirect creation

### DIFF
--- a/wagtail/contrib/redirects/signal_handlers.py
+++ b/wagtail/contrib/redirects/signal_handlers.py
@@ -102,7 +102,10 @@ def _page_urls_for_sites(
                 cache_target._wagtail_cached_site_root_paths
             )
 
-        site_id, root_url, page_path = page.get_url_parts(request)
+        url_parts = page.get_url_parts(request)
+        if url_parts is None:
+            continue
+        site_id, root_url, page_path = url_parts
 
         if page_path:
             for route_path in page.get_route_paths():


### PR DESCRIPTION
Addresses #7999. get_url_parts _should_ always return a valid result since we only run it on sites that the page belongs to, but if it doesn't, we don't want it to error out (since this is only a background task).
