### PR TITLE
Reorganise 3.0 upgrade consideration notes

### DIFF
--- a/docs/releases/3.0.md
+++ b/docs/releases/3.0.md
@@ -106,7 +106,7 @@ class LandingPage(Page):
  * Ignore `GenericRelation` when copying pages (John-Scott Atlakson)
 
 
-## Upgrade considerations
+## Upgrade considerations - changes affecting all projects
 
 ### Changes to module paths
 
@@ -125,31 +125,33 @@ wagtail updatemodulepaths --diff  # show the changes to be made, without updatin
 wagtail updatemodulepaths  # actually update the files
 ```
 
-### Removed warning in Internet Explorer (IE11)
+### `BASE_URL` setting renamed to `WAGTAILADMIN_BASE_URL`
 
-* IE11 support was officially dropped in Wagtail 2.15, as of this release there will no longer be a warning shown to users of this browser.
-* Wagtail is fully compatible with Microsoft Edge, Microsoft’s replacement for Internet Explorer. You may consider using its [IE mode](https://docs.microsoft.com/en-us/deployedge/edge-ie-mode) to keep access to IE11-only sites, while other sites and apps like Wagtail can leverage modern browser capabilities.
+References to `BASE_URL` in your settings should be updated to [`WAGTAILADMIN_BASE_URL`](wagtailadmin_base_url). This setting was not previously documented, but was part of the default project template when starting a project with the `wagtail start` command, and specifies the full base URL for the Wagtail admin, for use primarily in email notifications.
 
-### Replaced `content_json` `TextField` with `content` `JSONField` in `PageRevision`
+### `use_json_field` argument added to `StreamField`
 
-* The `content_json` field in the `PageRevision` model has been renamed to `content`.
-* The field now internally uses `JSONField` instead of `TextField`.
-* If you have a large number of `PageRevision` objects, running the migrations might take a while.
+All uses of `StreamField` should be updated to include the argument `use_json_field=True`. After adding this, make sure to generate and run migrations. This converts the field to use `JSONField` as its internal type instead of `TextField`, which will allow you to use `JSONField` lookups and transforms on the field. This change is necessary to ensure that the database migration is applied; a future release will drop support for `TextField`-based StreamFields.
 
-### Replaced `data_json` `TextField` with `data` `JSONField` in `BaseLogEntry`
+## Upgrade considerations - deprecation of old functionality
 
-* The `data_json` field in the `BaseLogEntry` model has been renamed to `data`.
-* The field now internally uses `JSONField` instead of `TextField`.
-* The default empty value for the field has been changed from `""` to `{}`.
-* This change also affects `BaseLogEntry` subclasses, i.e. `PageLogEntry` and `ModelLogEntry`.
-* If you have a large number of objects for these models, running the migrations might take a while.
+### Removed support for Internet Explorer (IE11)
+
+IE11 support was officially dropped in Wagtail 2.15, and as of this release there will no longer be a warning shown to users of this browser. Wagtail is fully compatible with Microsoft Edge, Microsoft’s replacement for Internet Explorer. You may consider using its [IE mode](https://docs.microsoft.com/en-us/deployedge/edge-ie-mode) to keep access to IE11-only sites, while other sites and apps like Wagtail can leverage modern browser capabilities.
 
 ### Hallo legacy rich text editor has moved to an external package
 
-* Hallo was deprecated in [Wagtail v2.0 (February 2018)](https://docs.wagtail.org/en/stable/releases/2.0.html#new-rich-text-editor) and has had only a minimal level of support since then.
-* If you still require Hallo for your Wagtail installation, you will need to install the [Wagtail Hallo editor](https://github.com/wagtail/wagtail-hallo) legacy package.
-* We encourage all users of the Hallo editor to take steps to migrate to the new Draftail editor as this external package is unlikely to have ongoing maintenance.
-* `window.registerHalloPlugin` will no longer be created on the page editor load, unless the legacy package is installed.
+Hallo was deprecated in [Wagtail v2.0 (February 2018)](https://docs.wagtail.org/en/stable/releases/2.0.html#new-rich-text-editor) and has had only a minimal level of support since then. If you still require Hallo for your Wagtail installation, you will need to install the [Wagtail Hallo editor](https://github.com/wagtail/wagtail-hallo) legacy package. We encourage all users of the Hallo editor to take steps to migrate to the new Draftail editor as this external package is unlikely to have ongoing maintenance. `window.registerHalloPlugin` will no longer be created on the page editor load, unless the legacy package is installed.
+
+### Removal of legacy `clean_name` on `AbstractFormField`
+
+If you are upgrading a pre-2.10 project that uses the [Wagtail form builder](form_builder), and has existing form submission data that needs to be preserved, you must first upgrade to a version between 2.10 and 2.16, and run migrations and start the application server, before upgrading to 3.0. This ensures that the `clean_name` field introduced in Wagtail 2.10 is populated. The mechanism for doing this (which had a dependency on the [Unidecode](https://pypi.org/project/Unidecode/) package) has been dropped in Wagtail 3.0. Any new form fields created under Wagtail 2.10 or above use the [AnyAscii](https://pypi.org/project/anyascii/) library instead.
+
+### Removed support for Jinja2 2.x
+
+Jinja2 2.x is no longer supported as of this release; if you are using Jinja2 templating on your project, please upgrade to Jinja2 3.0 or above.
+
+## Upgrade considerations - changes affecting Wagtail customisations
 
 ### API changes to panels (EditHandlers)
 
@@ -194,29 +196,14 @@ Some changes of behaviour have been made to ModelAdmin as a result of the panel 
 * The `ModelAdmin.get_form_fields_exclude` method is no longer passed a `request` argument. Subclasses that override this method should remove this from the method signature. If the request object is being used to vary the set of fields based on the user's permission, this can be replaced with the new `permission` option on `FieldPanel`.
 * The `ModelAdmin.get_edit_handler` method is no longer passed a `request` or `instance` argument. Subclasses that override this method should remove this from the method signature.
 
-### Removed the `size` argument of the undocumented `wagtail.utils.sendfile_streaming_backend.was_modified_since` function
+### Replaced `content_json` `TextField` with `content` `JSONField` in `PageRevision`
 
--   The `size` argument was used to add a `length` parameter to the HTTP header.
--   This was never part of the HTTP/1.0 and HTTP/1.1 specifications see [RFC7232](https://httpwg.org/specs/rfc7232.html#header.if-modified-since) and existed only as a an unofficial implementation in IE browsers.
+The `content_json` field in the `PageRevision` model has been renamed to `content`, and this field now internally uses `JSONField` instead of `TextField`. If you have a large number of `PageRevision` objects, running the migrations might take a while.
 
-### `StreamField`s must explicitly set `use_json_field` argument to `True`/`False`
+### Replaced `data_json` `TextField` with `data` `JSONField` in `BaseLogEntry`
 
-`StreamField` now requires a `use_json_field` keyword argument that can be set to `True`/`False`. If set to `True`, the field will use `JSONField` as its internal type instead of `TextField`, which will change the data type used on the database and allow you to use `JSONField` lookups and transforms on the `StreamField`. If set to `False`, the field will keep its previous behaviour and no database changes will be made. If set to `None` (the default), the field will keep its previous behaviour and a warning (`RemovedInWagtail50Warning`) will appear.
+The `data_json` field in the `BaseLogEntry` model (and its subclasses `PageLogEntry` and `ModelLogEntry`) has been renamed to `data`, and this field now internally uses `JSONField` instead of `TextField`. If you have a large number of objects for these models, running the migrations might take a while.
 
-After setting the keyword argument, make sure to generate and run the migrations for the models.
+### Removed `size` argument from `wagtail.utils.sendfile_streaming_backend.was_modified_since`
 
-### Removal of legacy `clean_name` on `AbstractFormField`
-
--   If you have a project migrating from pre 2.10 to this release and you are using the Wagtail form builder and you have existing form submissions you must first upgrade to at least 2.11. Then run migrations and run the application with your data to ensure that any existing form fields are correctly migrated.
--   In Wagtail 2.10 a `clean_name` field was added to form field models that extend `AbstractFormField` and this initially supported legacy migration of the [Unidecode](https://pypi.org/project/Unidecode/) label conversion.
--   Any new fields created since then will have used the [AnyAscii](https://pypi.org/project/anyascii/) conversion and Unidecode has been removed from the included packages.
-
-### Setting change `BASE_URL` is now `WAGTAILADMIN_BASE_URL`
-
--   See [](wagtailadmin_base_url).
--   `BASE_URL` was not documented but it provides a way to configure the base URL for the Wagtail admin which is used mostly in notifications.
--    Usage of `BASE_URL` will be removed in a future release and it is recommended that the you update the setting in this release.
-
-### Removed support for Jinja2 2.x
-
-Jinja2 2.x is no longer supported as of this release; if you are using Jinja2 templating on your project, please upgrade to Jinja2 3.0 or above.
+The `size` argument of the undocumented `wagtail.utils.sendfile_streaming_backend.was_modified_since` function has been removed. This argument was used to add a `length` parameter to the HTTP header; however, this was never part of the HTTP/1.0 and HTTP/1.1 specifications see [RFC7232](https://httpwg.org/specs/rfc7232.html#header.if-modified-since) and existed only as a an unofficial implementation in IE browsers.


### PR DESCRIPTION
The upgrade consideration notes for 3.0 cover a lot of ground, ranging from "everyone with a Wagtail site needs to update their code right now" to "some undocumented internal function changed slightly", and there's a real danger of a TL;DR effect if we don't flag up the most important ones and spell out the changes users need to make. I've reorganised them into sections, ordered by how likely they are to be relevant to a plain vanilla Wagtail project, and reworded some of them to put the "here's what you have to change" instructions up front.