### PR TITLE
Monospace proposed stack (Issue #8043):

### DIFF
--- a/client/scss/settings/_variables.scss
+++ b/client/scss/settings/_variables.scss
@@ -121,6 +121,26 @@ $font-sans:
   'Apple Color Emoji',
   'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
 
+$font-mono:
+ //iOS Safari, MacOS Safari
+  ui-monospace, Menlo, Monaco,
+  //Windows
+  'Cascadia Mono',
+  'Segoe UI Mono',
+  //Linux
+  'Roboto Mono',
+  'Oxygen Mono', 'Ubuntu Monospace',
+  //Android
+  'Source Code Pro',
+  //Firefox
+  'Fira Mono',
+  //Last resort Android/others
+  'Droid Sans Mono',
+  'Courier New', monospace,
+  // All the emojis 👋🙂
+  'Apple Color Emoji',
+  'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+
 // Legacy icon font, to be removed in the near future.
 $font-wagtail-icons: wagtail;
 


### PR DESCRIPTION
ui-monospace, Menlo, Monaco, "Cascadia Mono", "Segoe UI Mono", "Roboto Mono", "Oxygen Mono", "Ubuntu Monospace", "Source Code Pro", "Fira Mono", "Droid Sans Mono", "Courier New", monospace;

Operating Systems and their fonts:
ui-monospace, Menlo, Monaco -> MacOS
Cascadia  ->Windows (since Vista)
Roboto -> Android (since 4.0)
Fira -> Firefox OS
Droid -> Android (<4.0)
Oxygen -> KDE
Ubuntu -> Ubuntu
In addition, ui-monospace is supported for Safari/MacOS (only way to access SF Mono in Mac); Menlo and Monaco are fallbacks for older versions of MacOS
Cascadia is a new Microsoft font-face, and Segue is the old one. Segue is the fallback.


Note: I've changed font in styleguide only temporarily, that's why everything is monospace. It's not in this PR.
<!--
Thanks for contributing to Wagtail! 🎉

Before submitting, please review the [contributor guidelines](https://docs.wagtail.org/en/latest/contributing/index.html).
-->

_Please check the following:_

- [yes] Do the tests still pass?[^1]
- [yes] Does the code comply with the style guide? 
    - [yes] Run `make lint` from the Wagtail root. 
- [NA] For Python changes: Have you added tests to cover the new/fixed behaviour?
- [yes] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    - [x] **Please list the exact browser and operating system versions you tested**: Brave, Safari, Chrome
    
![image](https://user-images.githubusercontent.com/43480121/163032932-735bd526-4729-4834-bf78-54e683ed53a7.png)

    - [ ] **Please list which assistive technologies [^3] you tested**: monospace (in styleguide for testing)
- [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**. 

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets) 
