### PR TITLE
Add instructions about where to find cloudflare zone id

### DIFF
--- a/docs/reference/contrib/frontendcache.rst
+++ b/docs/reference/contrib/frontendcache.rst
@@ -65,8 +65,7 @@ To use an account-wide API key, find the key `as described in the Cloudflare doc
 
 To use a limited API token, `create a token <https://support.cloudflare.com/hc/en-us/articles/200167836-Managing-API-Tokens-and-Keys#12345680>`_ configured with the 'Zone, Cache Purge' permission and specify the ``BEARER_TOKEN`` parameter.
 
-A ``ZONEID`` parameter will need to be set for either option. To find the ``ZONEID`` for your domain, read the `Cloudflare API Documentation <https://api.cloudflare.com/#getting-started-resource-ids>`_.
-It can also be found from the GUI in the overview tab of your domain, in the right sidebar, under API section.
+A ``ZONEID`` parameter will need to be set for either option. To find the ``ZONEID`` for your domain, read the `Cloudflare API Documentation <https://developers.cloudflare.com/fundamentals/get-started/basic-tasks/find-account-and-zone-ids/>`_.
 
 With an API key:
 

--- a/docs/reference/contrib/frontendcache.rst
+++ b/docs/reference/contrib/frontendcache.rst
@@ -65,7 +65,8 @@ To use an account-wide API key, find the key `as described in the Cloudflare doc
 
 To use a limited API token, `create a token <https://support.cloudflare.com/hc/en-us/articles/200167836-Managing-API-Tokens-and-Keys#12345680>`_ configured with the 'Zone, Cache Purge' permission and specify the ``BEARER_TOKEN`` parameter.
 
-A ``ZONEID`` parameter will need to be set for either option. To find the ``ZONEID`` for your domain, read the `Cloudflare API Documentation <https://api.cloudflare.com/#getting-started-resource-ids>`_
+A ``ZONEID`` parameter will need to be set for either option. To find the ``ZONEID`` for your domain, read the `Cloudflare API Documentation <https://api.cloudflare.com/#getting-started-resource-ids>`.
+It can also be found from the GUI in the overview tab of your domain, in the right sidebar, under API section._
 
 With an API key:
 

--- a/docs/reference/contrib/frontendcache.rst
+++ b/docs/reference/contrib/frontendcache.rst
@@ -65,7 +65,7 @@ To use an account-wide API key, find the key `as described in the Cloudflare doc
 
 To use a limited API token, `create a token <https://support.cloudflare.com/hc/en-us/articles/200167836-Managing-API-Tokens-and-Keys#12345680>`_ configured with the 'Zone, Cache Purge' permission and specify the ``BEARER_TOKEN`` parameter.
 
-A ``ZONEID`` parameter will need to be set for either option. To find the ``ZONEID`` for your domain, read the `Cloudflare API Documentation <https://api.cloudflare.com/#getting-started-resource-ids>`_.  
+A ``ZONEID`` parameter will need to be set for either option. To find the ``ZONEID`` for your domain, read the `Cloudflare API Documentation <https://api.cloudflare.com/#getting-started-resource-ids>`_.
 It can also be found from the GUI in the overview tab of your domain, in the right sidebar, under API section.
 
 With an API key:

--- a/docs/reference/contrib/frontendcache.rst
+++ b/docs/reference/contrib/frontendcache.rst
@@ -65,8 +65,8 @@ To use an account-wide API key, find the key `as described in the Cloudflare doc
 
 To use a limited API token, `create a token <https://support.cloudflare.com/hc/en-us/articles/200167836-Managing-API-Tokens-and-Keys#12345680>`_ configured with the 'Zone, Cache Purge' permission and specify the ``BEARER_TOKEN`` parameter.
 
-A ``ZONEID`` parameter will need to be set for either option. To find the ``ZONEID`` for your domain, read the `Cloudflare API Documentation <https://api.cloudflare.com/#getting-started-resource-ids>`.
-It can also be found from the GUI in the overview tab of your domain, in the right sidebar, under API section._
+A ``ZONEID`` parameter will need to be set for either option. To find the ``ZONEID`` for your domain, read the `Cloudflare API Documentation <https://api.cloudflare.com/#getting-started-resource-ids>`_.  
+It can also be found from the GUI in the overview tab of your domain, in the right sidebar, under API section.
 
 With an API key:
 


### PR DESCRIPTION
This adds some information about how to get the zone ID from Cloudflare, from the GUI, in [this documentation's section](https://docs.wagtail.org/en/stable/reference/contrib/frontendcache.html#cloudflare)