### PR TITLE
Style comments as per page editor design, in side panel

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -41,6 +41,7 @@ Changelog
  * Revise alignment and spacing of form fields and sections (Thibaud Colas)
  * Update Wagtail’s type scale so StreamField block labels and field labels are the same size (Thibaud Colas)
  * Allow customising the `search_fields` and search backend via SnippetViewSet (Sage Abdullah)
+ * Style comments as per page editor design, in side panel (Karl Hobley, Thibaud Colas)
  * Fix: Ensure `label_format` on StructBlock gracefully handles missing variables (Aadi jindal)
  * Fix: Adopt a no-JavaScript and more accessible solution for the 'Reset to default' switch to Gravatar when editing user profile (Loveth Omokaro)
  * Fix: Ensure `Site.get_site_root_paths` works on cache backends that do not preserve Python objects (Jaap Roes)

--- a/client/scss/components/_form-side.scss
+++ b/client/scss/components/_form-side.scss
@@ -53,7 +53,7 @@
   }
 
   &__close-button {
-    @apply w-text-primary w-absolute w-left-3 w-top-3 hover:w-text-primary-200 w-bg-white w-p-3 w-hidden w-transition;
+    @apply w-text-primary w-absolute w-left-3 w-top-3 hover:w-text-primary-200 w-bg-white w-p-3 w-transition;
 
     .icon {
       @apply w-w-4 w-h-4;
@@ -91,10 +91,6 @@
 
   &__width-input {
     @apply w-w-0 w-h-0 w-opacity-0 w-absolute w-pointer-events-none;
-  }
-
-  &--open .form-side__close-button {
-    @apply w-block;
   }
 
   &__panel {

--- a/client/src/components/CommentApp/components/Comment/index.tsx
+++ b/client/src/components/CommentApp/components/Comment/index.tsx
@@ -411,7 +411,7 @@ export default class CommentComponent extends React.Component<CommentProps> {
           {gettext('Are you sure?')}
           <button
             type="button"
-            className="comment__button"
+            className="comment__button button button-small"
             onClick={onClickCancel}
           >
             {gettext('Cancel')}

--- a/client/src/components/CommentApp/components/Comment/style.scss
+++ b/client/src/components/CommentApp/components/Comment/style.scss
@@ -1,43 +1,23 @@
 .comment {
   @include box;
 
-  width: calc(100vw - 40px);
-  max-width: calc(100vw - 19%);
+  width: 300px;
   display: block;
   transition: top 0.5s ease 0s, inset-inline-end 0.5s ease 0s,
     height 0.5s ease 0s;
   pointer-events: auto;
   padding-bottom: 0;
-  inset-inline-end: -2000px;
-  background-color: theme('colors.white.DEFAULT');
-
-  @include media-breakpoint-up(sm) {
-    width: calc(100vw - 40px);
-    max-width: 400px;
-    inset-inline-start: initial;
-  }
-
-  @include media-breakpoint-up(md) {
-    max-width: 200px;
-    inset-inline-end: 0;
-  }
-
-  @include media-breakpoint-up(lg) {
-    max-width: 275px;
-  }
+  inset-inline-end: 0;
 
   &--focused {
-    inset-inline-end: 35px;
-
-    @include media-breakpoint-up(md) {
-      inset-inline-end: 50px;
-    }
+    inset-inline-end: 30px;
   }
 
   &__text {
     color: $color-box-text;
-    font-size: 13px;
-    line-height: 19px;
+    font-weight: 400;
+    font-size: 16px;
+    line-height: 150%;
     margin-bottom: 0;
     padding-top: 10px;
     padding-bottom: 10px;
@@ -53,11 +33,11 @@
 
   &--mode-creating form {
     border-top: 0;
-    margin-top: 10px;
+    margin-top: 12px;
   }
 
   &--mode-editing form {
-    margin-top: 10px;
+    margin-top: 12px;
   }
 
   &--mode-deleting &__text {
@@ -76,13 +56,13 @@
 
   &__actions,
   &__reply-actions {
-    padding-bottom: 10px;
+    padding-bottom: 20px;
   }
 
   &__actions &__button,
   &__reply-actions &__button {
     margin-inline-end: 10px;
-    margin-top: 10px;
+    margin-top: 12px;
   }
 
   &__confirm-delete &__button {

--- a/client/src/components/CommentApp/components/CommentHeader/style.scss
+++ b/client/src/components/CommentApp/components/CommentHeader/style.scss
@@ -16,8 +16,10 @@
     ); // Leave room for actions to the right and avatar to the left
     margin: 0;
     margin-inline-start: 45px;
-    font-size: 11px;
-    line-height: 15px;
+    font-weight: 600;
+    font-size: 14px;
+    line-height: 130%;
+    color: theme('colors.primary.DEFAULT');
   }
 
   &__date {

--- a/client/src/components/CommentApp/components/CommentReply/style.scss
+++ b/client/src/components/CommentApp/components/CommentReply/style.scss
@@ -6,8 +6,9 @@
 
   &__text {
     color: $color-box-text;
-    font-size: 13px;
-    line-height: 19px;
+    font-weight: 400;
+    font-size: 16px;
+    line-height: 150%;
     margin-bottom: 0;
     padding-top: 10px;
     padding-bottom: 10px;

--- a/client/src/components/CommentApp/main.scss
+++ b/client/src/components/CommentApp/main.scss
@@ -1,16 +1,14 @@
 @import '../../../scss/settings/variables';
 
-$color-comment-separator: theme('colors.grey.100');
+$color-comment-separator: theme('colors.grey.200');
 
 $color-box-background: $color-white;
-$color-box-border: $color-grey-3;
-$color-box-border-focused: $color-grey-2;
+$color-box-background-focused: theme('colors.grey.50');
+$color-box-border: theme('colors.grey.150');
+$color-box-border-focused: theme('colors.grey.200');
 $color-box-text: $color-black;
-$color-textarea-background: theme('colors.grey.50');
-$color-textarea-border: $color-input-border;
-$color-textarea-placeholder-text: $color-grey-2;
 $box-border-radius: 5px;
-$box-padding: 10px;
+$box-padding: 20px;
 
 @mixin focus-outline {
   outline: $color-focus-outline solid 3px;
@@ -18,28 +16,28 @@ $box-padding: 10px;
 
 @mixin box {
   background-color: $color-box-background;
-  border: 1px solid $color-box-border;
   padding: $box-padding;
-  font-size: 11px;
   border-radius: $box-border-radius;
   color: $color-box-text;
+  border: 1px solid $color-box-border;
 
   &--focused {
+    background-color: $color-box-background-focused;
+    border: 1px solid $color-box-border-focused;
     box-shadow: 3px 2px 3px -1px theme('colors.black-10');
   }
 
   textarea {
-    font-family: $font-sans;
     margin: 0;
-    padding: 10px;
+    padding: 12px;
     width: 100%;
-    background-color: $color-textarea-background;
-    border: 1px solid $color-textarea-border;
+    background-color: $color-white;
+    border: 1px solid $color-input-border;
     border-radius: 5px;
     color: $color-box-text;
 
     &::placeholder {
-      color: $color-textarea-placeholder-text;
+      color: theme('colors.grey.400');
       opacity: 1;
     }
   }
@@ -89,12 +87,10 @@ $box-padding: 10px;
   border-radius: 3px;
   color: $color-teal;
   cursor: pointer;
-  font-family: inherit;
-  font-size: 12px;
-  font-weight: bold;
-  height: 25px;
-  padding-inline-start: 5px;
-  padding-inline-end: 5px;
+  font-weight: 700;
+  height: 30px;
+  padding-inline-start: 10px;
+  padding-inline-end: 10px;
 
   &--primary {
     color: $color-white;
@@ -119,13 +115,10 @@ $box-padding: 10px;
 }
 
 .comments-list {
-  width: 400px;
   position: absolute;
-  top: 30px;
-  inset-inline-end: 35px;
-  z-index: 95;
-  font-family: $font-sans;
-  pointer-events: none;
+  top: 20px;
+  inset-inline-end: 20px;
+  z-index: calc(theme('zIndex.header') + 5);
 }
 
 // stylelint-disable no-invalid-position-at-import-rule

--- a/client/src/components/CommentApp/main.tsx
+++ b/client/src/components/CommentApp/main.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import ReactDOM from 'react-dom';
 import { createStore } from 'redux';
 
@@ -21,7 +21,6 @@ import {
   selectComments,
   selectCommentsForContentPathFactory,
   selectCommentFactory,
-  selectEnabled,
   selectFocused,
   selectIsDirty,
   selectCommentCount,
@@ -70,17 +69,59 @@ const getAuthor = (
   };
 };
 
-function renderCommentsUi(
-  store: Store,
-  layout: LayoutController,
-  comments: Comment[],
-): React.ReactElement {
+interface CommentListingProps {
+  store: Store;
+  layout: LayoutController;
+  comments: Comment[];
+}
+
+function CommentListing({
+  store,
+  layout,
+  comments,
+}: CommentListingProps): React.ReactElement {
   const state = store.getState();
-  const { commentsEnabled, user, currentTab } = state.settings;
+  const { user, currentTab } = state.settings;
   const { focusedComment, forceFocus } = state.comments;
+  const commentsListRef = React.useRef<HTMLOListElement | null>(null);
+  // Update the position of the comments listing as the window scrolls to keep the comments in line with the content
+  const updateScroll = useCallback(
+    (e: Event) => {
+      if (!commentsListRef.current) {
+        return;
+      }
+
+      if (
+        e.type === 'scroll' &&
+        !document.querySelector('.form-side--comments')
+      ) {
+        return;
+      }
+
+      const scrollContainer = document.querySelector('.content');
+      const top = scrollContainer?.getBoundingClientRect().top;
+      commentsListRef.current.style.top = `${top}px`;
+    },
+    [commentsListRef],
+  );
   let commentsToRender = comments;
 
-  if (!commentsEnabled || !user) {
+  React.useEffect(() => {
+    const root = document.querySelector('#main');
+    const commentSidePanel = document.querySelector(
+      '[data-side-panel="comments"]',
+    );
+
+    root?.addEventListener('scroll', updateScroll);
+    commentSidePanel?.addEventListener('show', updateScroll);
+
+    return () => {
+      root?.removeEventListener('scroll', updateScroll);
+      commentSidePanel?.removeEventListener('show', updateScroll);
+    };
+  }, []);
+
+  if (!user) {
     commentsToRender = [];
   }
   // Hide all resolved/deleted comments
@@ -99,7 +140,11 @@ function renderCommentsUi(
       isVisible={layout.getCommentVisible(currentTab, comment.localId)}
     />
   ));
-  return <ol className="comments-list">{commentsRendered}</ol>;
+  return (
+    <ol ref={commentsListRef} className="comments-list">
+      {commentsRendered}
+    </ol>
+  );
   /* eslint-enable react/no-danger */
 }
 
@@ -115,13 +160,13 @@ export class CommentApp {
 
   selectors = {
     selectComments,
-    selectEnabled,
     selectFocused,
     selectIsDirty,
     selectCommentCount,
   };
 
   actions = commentActionFunctions;
+  activationHandlers: (() => void)[] = [];
 
   constructor() {
     this.store = createStore(reducer, {
@@ -189,12 +234,12 @@ export class CommentApp {
     return commentId;
   }
 
-  setVisible(visible: boolean) {
-    this.store.dispatch(
-      updateGlobalSettings({
-        commentsEnabled: visible,
-      }),
-    );
+  activate() {
+    this.activationHandlers.forEach((handler) => handler());
+  }
+
+  onActivate(handler: () => void) {
+    this.activationHandlers.push(handler);
   }
 
   invalidateContentPath(contentPath: string) {
@@ -255,7 +300,11 @@ export class CommentApp {
       }
 
       ReactDOM.render(
-        renderCommentsUi(this.store, this.layout, commentList),
+        <CommentListing
+          store={this.store}
+          layout={this.layout}
+          comments={commentList}
+        />,
         element,
         () => {
           // Render again if layout has changed (eg, a comment was added, deleted or resized)
@@ -263,7 +312,11 @@ export class CommentApp {
           this.layout.refreshDesiredPositions(state.settings.currentTab);
           if (this.layout.refreshLayout()) {
             ReactDOM.render(
-              renderCommentsUi(this.store, this.layout, commentList),
+              <CommentListing
+                store={this.store}
+                layout={this.layout}
+                comments={commentList}
+              />,
               element,
             );
           }

--- a/client/src/components/CommentApp/selectors/index.ts
+++ b/client/src/components/CommentApp/selectors/index.ts
@@ -27,8 +27,6 @@ export function selectCommentFactory(localId: number) {
   });
 }
 
-export const selectEnabled = (state: State) => state.settings.commentsEnabled;
-
 export const selectIsDirty = createSelector(
   selectComments,
   selectRemoteCommentCount,

--- a/client/src/components/CommentApp/state/settings.ts
+++ b/client/src/components/CommentApp/state/settings.ts
@@ -5,7 +5,6 @@ import { update } from './utils';
 
 export interface SettingsState {
   user: Author | null;
-  commentsEnabled: boolean;
   currentTab: string | null;
 }
 
@@ -14,7 +13,6 @@ export type SettingsStateUpdate = Partial<SettingsState>;
 // Reducer with initial state
 export const INITIAL_STATE: SettingsState = {
   user: null,
-  commentsEnabled: false,
   currentTab: null,
 };
 

--- a/client/src/components/Draftail/CommentableEditor/CommentableEditor.scss
+++ b/client/src/components/Draftail/CommentableEditor/CommentableEditor.scss
@@ -1,3 +1,11 @@
+.Draftail-CommentControl {
+  display: none;
+
+  .tab-content--comments-enabled & {
+    display: block;
+  }
+}
+
 .Draftail-CommentControl .Draftail-ToolbarButton {
   color: theme('colors.secondary.100');
 

--- a/client/src/components/Draftail/CommentableEditor/CommentableEditor.test.tsx
+++ b/client/src/components/Draftail/CommentableEditor/CommentableEditor.test.tsx
@@ -5,7 +5,6 @@ import { createEditorStateFromRaw } from 'draftail';
 import { DraftInlineStyleType, EditorState, SelectionState } from 'draft-js';
 
 import { CommentApp } from '../../CommentApp/main';
-import { updateGlobalSettings } from '../../CommentApp/actions/settings';
 import { newComment } from '../../CommentApp/state/comments';
 import { noop } from '../../../utils/noop';
 
@@ -137,18 +136,10 @@ describe('CommentableEditor', () => {
     commentApp = new CommentApp();
   });
   it('has control', () => {
-    commentApp.setVisible(true);
     const editor = mount(getEditorComponent(commentApp));
     const controls = editor.find('DraftailEditor').prop('controls');
     expect(controls).toHaveLength(1);
     expect(controls[0].inline).toBeTruthy();
-    editor.unmount();
-  });
-  it('has no control when comments disabled', () => {
-    commentApp.store.dispatch(updateGlobalSettings({ commentsEnabled: false }));
-    const editor = mount(getEditorComponent(commentApp));
-    const controls = editor.find('DraftailEditor').prop('controls');
-    expect(controls).toHaveLength(0);
     editor.unmount();
   });
   it('can update comment positions', () => {

--- a/client/src/includes/sidePanel.js
+++ b/client/src/includes/sidePanel.js
@@ -43,14 +43,7 @@ export default function initSidePanel() {
     if (panelName && !selectedPanel) return;
 
     // Open / close side panel
-
-    // HACK: For now, the comments will show without the side-panel opening.
-    // They will later be updated so that they render inside the side panel.
-    // We couldn't implement this for Wagtail 3.0 as the existing field styling
-    // renders the "Add comment" button on the right hand side, and this gets
-    // covered up by the side panel.
-
-    if (panelName === '' || panelName === 'comments') {
+    if (panelName === '') {
       sidePanelWrapper.classList.remove('form-side--open');
       sidePanelWrapper.removeAttribute('aria-labelledby');
     } else {
@@ -128,6 +121,14 @@ export default function initSidePanel() {
       setPanel(panelName);
     }
   };
+
+  // Open the side panel if the 'open' custom event is triggered on the side panel
+  // This is allows panels to be opened with JavaScript without hacking the toggle
+  document.querySelectorAll('[data-side-panel]').forEach((panel) => {
+    panel.addEventListener('open', () => {
+      setPanel(panel.dataset.sidePanel);
+    });
+  });
 
   document.querySelectorAll('[data-side-panel-toggle]').forEach((toggle) => {
     toggle.addEventListener('click', () => {

--- a/docs/releases/5.0.md
+++ b/docs/releases/5.0.md
@@ -80,6 +80,7 @@ Those improvements were implemented by Albina Starykova as part of an [Outreachy
  * Revise alignment and spacing of form fields and sections (Thibaud Colas)
  * Update Wagtail’s type scale so StreamField block labels and field labels are the same size (Thibaud Colas)
  * Allow customising the `search_fields` and search backend via SnippetViewSet (Sage Abdullah)
+ * Style comments as per page editor design, in side panel (Karl Hobley, Thibaud Colas)
 
 ### Bug fixes
 

--- a/wagtail/admin/templates/wagtailadmin/pages/create.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/create.html
@@ -5,7 +5,6 @@
 {% block titletag %}{% blocktrans trimmed with page_type=content_type.model_class.get_verbose_name %}New {{ page_type }}{% endblocktrans %}{% endblock %}
 
 {% block content %}
-    <div id="comments"></div>
 
     <div class="w-sticky w-top-0 w-z-header">
         {% include 'wagtailadmin/shared/headers/page_create_header.html' %}

--- a/wagtail/admin/templates/wagtailadmin/pages/edit.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/edit.html
@@ -6,7 +6,6 @@
 {% block bodyclass %}{% if page.live %}page-is-live{% endif %} {% if page_locked %}content-locked{% endif %}{% endblock %}
 
 {% block content %}
-    <div id="comments"></div>
     {% page_permissions page as page_perms %}
 
     <div class="w-sticky w-top-0 w-z-header">

--- a/wagtail/admin/templates/wagtailadmin/shared/field.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/field.html
@@ -73,7 +73,7 @@
             {% endblock %}
 
             {% if show_add_comment_button %}
-                <button class="w-field__comment-button w-field__comment-button--add u-hidden" type="button" data-component="add-comment-button" data-comment-add aria-label="{% trans 'Add comment' %}" {% if label_for %}aria-describedby="{{ label_id }}"{% endif %}>
+                <button class="w-field__comment-button w-field__comment-button--add" type="button" data-component="add-comment-button" data-comment-add aria-label="{% trans 'Add comment' %}" {% if label_for %}aria-describedby="{{ label_id }}"{% endif %}>
                     {% icon name="comment-add" %}
                     {% icon name="comment-add-reversed" %}
                 </button>

--- a/wagtail/admin/templates/wagtailadmin/shared/side_panels/comments.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/side_panels/comments.html
@@ -1,0 +1,1 @@
+<div id="comments"></div>


### PR DESCRIPTION
This PR changes the following:
 - Styles comments to look like the design
 - Updates the way comments are positioned, so they stick to the side panel on the X axis but follow the content on the Y axis
 - Makes the comment toggles always display (there is some form CSS we could clean up here, but I've left it in as removing it will conflict with a separate PR will remove it all anyway)
 
![image](https://user-images.githubusercontent.com/1093808/163148032-5e65b51b-85c5-48eb-a681-e4d7d20f9c76.png)
