### PR TITLE
Return comment count to header toggle with placeholder styling

### DIFF
--- a/client/src/entrypoints/admin/comments.js
+++ b/client/src/entrypoints/admin/comments.js
@@ -337,9 +337,12 @@ window.comments = (() => {
     }
 
     // Keep number of comments up to date with comment app
-    const commentCounter = document.querySelector(
-      '[data-comments-toggle-count]',
+    const commentToggle = document.querySelector(
+      '[data-side-panel-toggle="comments"]',
     );
+    const commentCounter = document.createElement('div');
+    commentCounter.style.marginTop = '-0.8rem'; // TODO: replace this with suitable Tailwind classes
+    commentToggle.appendChild(commentCounter);
     const updateCommentCount = () => {
       const commentCount = commentApp.selectors.selectCommentCount(
         commentApp.store.getState(),
@@ -353,8 +356,7 @@ window.comments = (() => {
       if (commentCount > 0) {
         commentCounter.innerText = commentCount.toString();
       } else {
-        // Note: CSS will hide the circle when its content is empty
-        commentCounter.innerText = '';
+        commentCount.innerText = '';
       }
     };
     commentApp.store.subscribe(updateCommentCount);


### PR DESCRIPTION
The js inline styling is far from ideal, and should definitely be replaced during the RC, but this adds the comment count back to the toggle button (unfortunately I couldn't get the Tailwind styles to work in time - something I'll have to experiment with now we're using that).