### PR TITLE
Remove stale reference to bootstrap-tab

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/admin_base.html
+++ b/wagtail/admin/templates/wagtailadmin/admin_base.html
@@ -50,7 +50,6 @@
     <script src="{% versioned_static 'wagtailadmin/js/vendor/jquery.autosize.js' %}"></script>
     <script src="{% versioned_static 'wagtailadmin/js/vendor/bootstrap-transition.js' %}"></script>
     <script src="{% versioned_static 'wagtailadmin/js/vendor/bootstrap-modal.js' %}"></script>
-    <script src="{% versioned_static 'wagtailadmin/js/vendor/bootstrap-tab.js' %}"></script>
     <script src="{% versioned_static 'wagtailadmin/js/vendor/tag-it.js' %}"></script>
     <script src="{% url 'wagtailadmin_javascript_catalog' %}"></script>
     <script src="{% versioned_static 'wagtailadmin/js/core.js' %}"></script>


### PR DESCRIPTION
This prevents the admin from loading.

Fixes a regression from #8266

```
ValueError: Missing staticfiles manifest entry for 'wagtailadmin/js/vendor/bootstrap-tab.js'
```

- [ ] Do the tests still pass?[^1]
- [ ] Does the code comply with the style guide? 
    - [ ] Run `make lint` from the Wagtail root. 
- [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
- [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    - [ ] **Please list the exact browser and operating system versions you tested**:
    - [ ] **Please list which assistive technologies [^3] you tested**: 
- [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**. 

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets) 
