### PR TITLE
Update duplicate upload tab to work with new tab module

### DIFF
--- a/wagtail/images/templates/wagtailimages/chooser/confirm_duplicate_upload.html
+++ b/wagtail/images/templates/wagtailimages/chooser/confirm_duplicate_upload.html
@@ -4,7 +4,7 @@
     <link rel="stylesheet" href="{% versioned_static 'wagtailimages/css/chooser-duplicate-upload.css' %}" type="text/css" />
 {% endblock %}
 
-<section id="upload" class="duplicate-upload active nice-padding">
+<section id="tab-upload" class="duplicate-upload w-tabs__panel" role="tabpanel" aria-labelledby="tab-label-upload">
     <p class="help-block help-warning">
         {% icon name='warning' %}
         {% trans "Upload successful. However, your new image seems to be a duplicate of an existing image. You may delete it if it wasn't required." %}


### PR DESCRIPTION
This PR fixes a regression from #8333, taking into consideration notes specified [here](https://github.com/wagtail/wagtail/blob/66c2f3d328bfbca0eb6beb3eb29961181a57ee54/client/src/includes/tabs.js#L2-L5).

Currently, the duplicate upload tab is still active when we switch to the search tab:  


![Screenshot from 2022-04-13 17-51-02](https://user-images.githubusercontent.com/71412737/163240760-942c3901-ae0e-4950-9a19-2388fe1dddec.png)

Moreover, its content is still shown:

![Screenshot from 2022-04-13 17-51-09 (1)](https://user-images.githubusercontent.com/71412737/163241202-421618a8-18ec-48e2-9f04-92192c748132.png)


- [x] Do the tests still pass?
- [x] Does the code comply with the style guide? 
    - [x] Run `make lint` from the Wagtail root. 
- [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
- [ ] For front-end changes: Did you test on all of Wagtail’s supported environments? No
    - [ ] **Please list the exact browser and operating system versions you tested**: Chrome
    - [ ] **Please list which assistive technologies [^3] you tested**: None
