### PR TITLE
Remove a stray reference to ChooserPanels

### DIFF
--- a/docs/reference/pages/panels.rst
+++ b/docs/reference/pages/panels.rst
@@ -269,9 +269,9 @@ You must define a ``heading`` or ``label`` when using ``collapsible`` with ``Inl
     content_panels = [
         MultiFieldPanel(
             [
-                ImageChooserPanel('cover'),
-                DocumentChooserPanel('book_file'),
-                PageChooserPanel('publisher'),
+                FieldPanel('cover'),
+                FieldPanel('book_file'),
+                FieldPanel('publisher'),
             ],
             heading="Collection of Book Fields",
             classname="collapsible collapsed"


### PR DESCRIPTION
These are no longer required in Wagtail 3
