### PR TITLE
add consistent class to header & subtitle across templates

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/home.html
+++ b/wagtail/admin/templates/wagtailadmin/home.html
@@ -12,11 +12,11 @@
 {% endblock %}
 
 {% block content %}
-    <header class="merged header--home">
+    <header class="header merged header--home">
         <div class="avatar"><img src="{% avatar_url user %}" alt="" /></div>
 
         <div class="sm:w-ml-4">
-            <h1>{% block branding_welcome %}{% blocktrans trimmed %}Welcome to the {{ site_name }} Wagtail CMS{% endblocktrans %}{% endblock %}</h1>
+            <h1 class="header__title">{% block branding_welcome %}{% blocktrans trimmed %}Welcome to the {{ site_name }} Wagtail CMS{% endblocktrans %}{% endblock %}</h1>
             <div class="user-name">{{ user|user_display_name }}</div>
         </div>
     </header>

--- a/wagtail/admin/templates/wagtailadmin/pages/index.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/index.html
@@ -4,7 +4,7 @@
 {% block bodyclass %}page-explorer {% if ordering == 'ord' %}reordering{% endif %}{% endblock %}
 
 {% block content %}
-    <header class="merged no-border">
+    <header class="header merged no-border">
         <h1 class="visuallyhidden">Explorer</h1>
 
         {% explorer_breadcrumb parent_page %}

--- a/wagtail/admin/templates/wagtailadmin/pages/move_choose_destination.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/move_choose_destination.html
@@ -2,10 +2,10 @@
 {% load i18n wagtailadmin_tags %}
 {% block titletag %}{% blocktrans trimmed with title=page_to_move.specific_deferred.get_admin_display_title %}Select a new parent page for {{ title }}{% endblocktrans %}{% endblock %}
 {% block content %}
-    <header>
+    <header class="header">
         {% move_breadcrumb page_to_move viewed_page %}
         <div class="row">
-            <h1>
+            <h1 class="header__title">
                 {% icon name="doc-empty-inverse" %}
                 {% blocktrans trimmed with title=page_to_move.specific_deferred.get_admin_display_title %}Select a new parent page for <span>{{ title }}</span>{% endblocktrans %}
             </h1>

--- a/wagtail/admin/templates/wagtailadmin/pages/preview_error.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/preview_error.html
@@ -4,8 +4,8 @@
 {% block titletag %}{% trans 'Preview error' %}{% endblock %}
 
 {% block content %}
-    <header class="header--with-padding">
-        <h1>{% trans 'Preview error' %}</h1>
+    <header class="header header--with-padding">
+        <h1 class="header__title">{% trans 'Preview error' %}</h1>
     </header>
     <div class="nice-padding">
         <p>

--- a/wagtail/admin/templates/wagtailadmin/reports/base_report.html
+++ b/wagtail/admin/templates/wagtailadmin/reports/base_report.html
@@ -4,13 +4,13 @@
 {% block titletag %}{{ title }}{% endblock %}
 
 {% block content %}
-    <header role="banner">
+    <header class="header" role="banner">
         <div class="row">
             <div class="left">
                 <div class="col">
-                    <h1>
+                    <h1 class="header__title">
                         {% if header_icon %}{% icon name=header_icon %}{% endif %}
-                        {{ title }}{% if subtitle %} <span>{{ subtitle }}</span>{% endif %}
+                        {{ title }}{% if subtitle %} <span class="header__subtitle">{{ subtitle }}</span>{% endif %}
                     </h1>
                 </div>
             </div>

--- a/wagtail/admin/templates/wagtailadmin/shared/header.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/header.html
@@ -14,13 +14,15 @@
     - `action_icon` - icon for the 'action' button, default is 'icon-plus'
 
 {% endcomment %}
-<header class="{% if merged %}merged{% endif %} {% if search_form %}hasform{% endif %}">
+<header class="header {% if merged %}merged{% endif %} {% if search_form %}hasform{% endif %}">
     {% block breadcrumb %}{% endblock %}
     <div class="row">
         <div class="left">
             <div class="col">
-                <h1>{% if icon %}{% icon name=icon %}{% endif %}
-                    {{ title }}{% if subtitle %} <span>{{ subtitle }}</span>{% endif %}</h1>
+                <h1 class="header__title">
+                    {% if icon %}{% icon name=icon %}{% endif %}
+                    {{ title }}{% if subtitle %} <span class="header__subtitle">{{ subtitle }}</span>{% endif %}
+                </h1>
             </div>
             {% if search_url %}
                 <form class="col search-form" action="{% url search_url %}{% if query_parameters %}?{{ query_parameters }}{% endif %}" method="get" novalidate role="search">

--- a/wagtail/admin/templates/wagtailadmin/workflows/index.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/index.html
@@ -2,12 +2,14 @@
 {% load i18n wagtailadmin_tags %}
 
 {% block content %}
-    <header role="banner">
+    <header class="header" role="banner">
         <div class="row">
             <div class="left">
                 <div class="col">
-                    <h1>{% if view.header_icon %}{% icon name=view.header_icon %}{% endif %}
-                        {{ view.page_title }}{% if view.subtitle %} <span>{{ view.subtitle }}</span>{% endif %}</h1>
+                    <h1 class="header__title">
+                        {% if view.header_icon %}{% icon name=view.header_icon %}{% endif %}
+                        {{ view.page_title }}{% if view.subtitle %} <span class="header__subtitle">{{ view.subtitle }}</span>{% endif %}
+                    </h1>
                 </div>
             </div>
             <div class="right">

--- a/wagtail/admin/templates/wagtailadmin/workflows/task_index.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/task_index.html
@@ -2,12 +2,14 @@
 {% load i18n wagtailadmin_tags %}
 
 {% block content %}
-    <header role="banner">
+    <header class="header" role="banner">
         <div class="row">
             <div class="left">
                 <div class="col">
-                    <h1>{% if view.header_icon %}{% icon name=view.header_icon %}{% endif %}
-                        {{ view.page_title }}{% if view.subtitle %} <span>{{ view.subtitle }}</span>{% endif %}</h1>
+                    <h1 class="header__title">
+                        {% if view.header_icon %}{% icon name=view.header_icon %}{% endif %}
+                        {{ view.page_title }}{% if view.subtitle %} <span class="header__subtitle">{{ view.subtitle }}</span>{% endif %}
+                    </h1>
                 </div>
             </div>
             <div class="right">

--- a/wagtail/admin/tests/pages/test_edit_page.py
+++ b/wagtail/admin/tests/pages/test_edit_page.py
@@ -858,7 +858,9 @@ class TestPageEdit(TestCase, WagtailTestUtils):
         self.assertContains(
             response, "<title>Wagtail - Preview error</title>", html=True
         )
-        self.assertContains(response, "<h1>Preview error</h1>", html=True)
+        self.assertContains(
+            response, '<h1 class="header__title">Preview error</h1>', html=True
+        )
 
     @override_settings(
         CACHES={

--- a/wagtail/contrib/forms/templates/wagtailforms/index_submissions.html
+++ b/wagtail/contrib/forms/templates/wagtailforms/index_submissions.html
@@ -81,12 +81,12 @@
     </script>
 {% endblock %}
 {% block content %}
-    <header>
+    <header class="header">
         <form action="" method="get" novalidate>
             <div class="row">
                 <div class="left">
                     <div class="col">
-                        <h1>
+                        <h1 class="header__title">
                             {% icon name="form" %}
                             {% blocktrans trimmed with form_title=form_page.title|capfirst %}Form data <span>{{ form_title }}</span>{% endblocktrans %}
                         </h1>

--- a/wagtail/contrib/modeladmin/templates/modeladmin/index.html
+++ b/wagtail/contrib/modeladmin/templates/modeladmin/index.html
@@ -15,7 +15,7 @@
 
 {% block content %}
     {% block header %}
-        <header class="hasform">
+        <header class="header hasform">
             {% block breadcrumb %}{% endblock %}
             <div class="row">
                 <div class="left header-left">
@@ -24,7 +24,7 @@
                             <h1>
                                 {% if view.header_icon %}{% icon name=view.header_icon %}{% endif %}
                                 {{ view.get_page_title }}
-                                {% if view.get_page_subtitle %} <span>{{ view.get_page_subtitle }}</span> {% endif %}
+                                {% if view.get_page_subtitle %} <span class="header__subtitle">{{ view.get_page_subtitle }}</span> {% endif %}
                                 {% include 'modeladmin/includes/result_count.html' %}
                             </h1>
                         {% endblock %}

--- a/wagtail/contrib/redirects/templates/wagtailredirects/index.html
+++ b/wagtail/contrib/redirects/templates/wagtailredirects/index.html
@@ -27,7 +27,7 @@
         {% trans "Import redirects" as import_str %}
         {% trans "Export redirects" as export_str %}
 
-        <header class="hasform">
+        <header class="header hasform">
             {% block breadcrumb %}{% endblock %}
             <div class="row">
                 <div class="left">

--- a/wagtail/contrib/settings/templates/wagtailsettings/edit.html
+++ b/wagtail/contrib/settings/templates/wagtailsettings/edit.html
@@ -3,14 +3,14 @@
 {% block titletag %}{% blocktrans trimmed %}Editing {{ setting_type_name}} - {{ instance }}{% endblocktrans %}{% endblock %}
 {% block bodyclass %}menu-settings{% endblock %}
 {% block content %}
-    <header class="merged">
+    <header class="header merged">
         <div class="row">
             <div class="left">
                 <div class="col">
-                    <h1>
+                    <h1 class="header__title">
                         {% icon name="cogs" %}
                         {% trans "Editing" %}
-                        <span>{{ setting_type_name|capfirst }}</span>
+                        <span class="header__subtitle">{{ setting_type_name|capfirst }}</span>
                     </h1>
                 </div>
             </div>

--- a/wagtail/contrib/styleguide/templates/wagtailstyleguide/base.html
+++ b/wagtail/contrib/styleguide/templates/wagtailstyleguide/base.html
@@ -626,7 +626,7 @@
             </div>
 
             <p>These can also have an inverted  theme:</p>
-            <header>
+            <header class="header">
                 <div class="c-dropdown  t-inverted" data-dropdown="">
                     <a class="c-dropdown__button  u-btn-current">
                         More

--- a/wagtail/snippets/templates/wagtailsnippets/snippets/type_index.html
+++ b/wagtail/snippets/templates/wagtailsnippets/snippets/type_index.html
@@ -18,13 +18,14 @@
 
 {% block content %}
 
-    <header>
+    <header class="header">
         <div class="row">
             <div class="left">
                 <div class="col">
-                    <h1>{% icon name="snippet" %}
-                        {% blocktrans trimmed with snippet_type_name_plural=model_opts.verbose_name_plural|capfirst %}Snippets <span>{{ snippet_type_name_plural }}</span>{% endblocktrans %}</h1>
-
+                    <h1 class="header__title">
+                        {% icon name="snippet" %}
+                        {% blocktrans trimmed with snippet_type_name_plural=model_opts.verbose_name_plural|capfirst %}Snippets <span>{{ snippet_type_name_plural }}</span>{% endblocktrans %}
+                    </h1>
                     {% if is_searchable and search_url %}
                         <form class="col search-form" action="{{ search_url }}" method="get" novalidate>
                             <ul class="fields">
@@ -36,7 +37,6 @@
                         </form>
                     {% endif %}
                 </div>
-
                 {% if locales %}
                     <div class="col">
 


### PR DESCRIPTION
* no changes to styling (intentional), just addition of consistent classes for our `header`, `h1` title and subtitle (span within the h1)
* I have opted for BEM classes for these as it seemed to be the most consistent for future direction
* I have also raised that our usage of `role='banner'` is very inconsistent in the `#ui` channel on slack, but not addressed that in this PR