### PR TITLE
Add base_url_path functionality for ModelAdmin

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -6,6 +6,7 @@ unreleased (xx.xx.xxxx) - IN DEVELOPMENT
 
  * Add clarity to confirmation when being asked to convert an external link to an internal one (Thijs Kramer)
  * Convert various pages in the documentation to Markdown (Daniel Kirkham)
+ * Add `base_url_path` to `ModelAdmin` so that the default URL structure of app_label/model_name can be overridden, sub-classes of `AdminURLHelper` overriding `__init__` will need to accept a new kwarg of `base_url_path` (Vu Pham, Khanh Hoang)
 
 
 3.0 (xx.xx.xxxx) - IN DEVELOPMENT

--- a/docs/reference/contrib/modeladmin/base_url.md
+++ b/docs/reference/contrib/modeladmin/base_url.md
@@ -1,0 +1,17 @@
+# Customising the base URL path
+
+You can use the following attributes and methods on the `ModelAdmin` class to alter the base URL path used to represent your model in Wagtail's admin area.
+
+```{contents}
+---
+local:
+depth: 1
+---
+```
+
+## `ModelAdmin.base_url_path`
+
+**Expected value**: A string.
+
+Set this attribute to a string value to override the default base URL path used for the model to `admin/{base_url_path}`.
+If not set, the base URL path will be `admin/{app_label}/{model_name}`.

--- a/docs/reference/contrib/modeladmin/index.rst
+++ b/docs/reference/contrib/modeladmin/index.rst
@@ -43,6 +43,7 @@ Want to know more about customising ``ModelAdmin``?
     :maxdepth: 1
 
     primer
+    base_url
     menu_item
     indexview
     create_edit_delete_views
@@ -117,6 +118,7 @@ to create, view, and edit ``Book`` entries.
 
     class BookAdmin(ModelAdmin):
         model = Book
+        base_url_path = 'bookadmin' # customise the URL from default to admin/bookadmin
         menu_label = 'Book'  # ditch this to use verbose_name_plural from model
         menu_icon = 'pilcrow'  # change as required
         menu_order = 200  # will put in 3rd place (000 being 1st, 100 2nd)

--- a/wagtail/contrib/modeladmin/helpers/url.py
+++ b/wagtail/contrib/modeladmin/helpers/url.py
@@ -6,19 +6,24 @@ from django.utils.functional import cached_property
 
 
 class AdminURLHelper:
-    def __init__(self, model):
+    def __init__(self, model, base_url_path=None):
         self.model = model
         self.opts = model._meta
+        self.base_url_path = self._get_base_url_path(base_url_path)
+
+    def _get_base_url_path(self, base_url_path):
+        if base_url_path:
+            return base_url_path.strip().strip("/")
+        return r"%s/%s" % (self.opts.app_label, self.opts.model_name)
 
     def _get_action_url_pattern(self, action):
         if action == "index":
-            return r"^%s/%s/$" % (self.opts.app_label, self.opts.model_name)
-        return r"^%s/%s/%s/$" % (self.opts.app_label, self.opts.model_name, action)
+            return r"^%s/$" % (self.base_url_path)
+        return r"^%s/%s/$" % (self.base_url_path, action)
 
     def _get_object_specific_action_url_pattern(self, action):
-        return r"^%s/%s/%s/(?P<instance_pk>[-\w]+)/$" % (
-            self.opts.app_label,
-            self.opts.model_name,
+        return r"^%s/%s/(?P<instance_pk>[-\w]+)/$" % (
+            self.base_url_path,
             action,
         )
 
@@ -28,9 +33,8 @@ class AdminURLHelper:
         return self._get_object_specific_action_url_pattern(action)
 
     def get_action_url_name(self, action):
-        return "%s_%s_modeladmin_%s" % (
-            self.opts.app_label,
-            self.opts.model_name,
+        return "%s_modeladmin_%s" % (
+            self.base_url_path.replace("/", "_"),
             action,
         )
 

--- a/wagtail/contrib/modeladmin/tests/test_modeladmin_edit_handlers.py
+++ b/wagtail/contrib/modeladmin/tests/test_modeladmin_edit_handlers.py
@@ -50,7 +50,7 @@ class TestExtractPanelDefinitionsFromModelAdmin(TestCase, WagtailTestUtils):
     def test_model_panels(self):
         """loads the 'create' view and verifies that form fields are returned
         which have been defined via model Friend.panels"""
-        response = self.client.get("/admin/modeladmintest/friend/create/")
+        response = self.client.get("/admin/friendadmin/create/")
         self.assertEqual(
             list(response.context["form"].fields), ["first_name", "phone_number"]
         )

--- a/wagtail/test/modeladmintest/wagtail_hooks.py
+++ b/wagtail/test/modeladmintest/wagtail_hooks.py
@@ -148,6 +148,7 @@ class PersonAdmin(ModelAdmin):
 
 class FriendAdmin(ModelAdmin):
     model = Friend
+    base_url_path = "friendadmin"
 
 
 class VisitorAdmin(ModelAdmin):


### PR DESCRIPTION
Fixes #8038 with @thoang43 
Now ModelAdmin can support a base_url_path option

This is my first time contributing to the documentation, so if you have any suggestions, please let me know

- [x] Do the tests still pass?[^1]
- [x] Does the code comply with the style guide? 
    - [x] Run `make lint` from the Wagtail root. 
- [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
- [x] For new features: Has the documentation been updated accordingly?

