### PR TITLE
clarify what happens when converting external link to internal link

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+unreleased (xx.xx.xxxx) - IN DEVELOPMENT
+~~~~~~~~~~~~~~~~
+
+ * Add clarity to confirmation when being asked to convert an external link to an internal one (Thijs Kramer)
+
+
 3.0 (xx.xx.xxxx) - IN DEVELOPMENT
 ~~~~~~~~~~~~~~~~
 

--- a/wagtail/admin/templates/wagtailadmin/chooser/confirm_external_to_internal.html
+++ b/wagtail/admin/templates/wagtailadmin/chooser/confirm_external_to_internal.html
@@ -12,7 +12,7 @@
     </p>
     <p>
         {% blocktrans trimmed %}
-            Converting this to an internal link to {{ page }} would make the link more robust.
+            Converting this to an internal link to {{ page }} would make the link automatically update if the underlying page changes its URL.
             Would you like to do this?
         {% endblocktrans %}
     </p>


### PR DESCRIPTION
<!--
Thanks for contributing to Wagtail! 🎉

Before submitting, please review the [contributor guidelines](https://docs.wagtail.org/en/latest/contributing/index.html).
-->

_Please check the following:_

- [X] Do the tests still pass?[^1]
- [X] Does the code comply with the style guide? 
    - [X] Run `make lint` from the Wagtail root. 

**Please describe additional details for testing this change**. 

While translating the untranslated strings of Wagtail 3.0-rc.1  in Transifex I found making a link more "robust" hard to understand. After a talk with @lb- on Slack we came to this change in wording.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)

