### PR TITLE
Update myst_parser to v0.17.2

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,2 @@
-myst_parser==0.17.0
+myst_parser==0.17.2
 sphinx-wagtail-theme==5.1.1


### PR DESCRIPTION
To resolve issue with the removed `attrs` module.

See: https://github.com/executablebooks/MyST-Parser/pull/557