### PR TITLE
migrate Home (dashboard) to class based view

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -26,6 +26,7 @@ Changelog
  * Allow users to sort by different fields in the image library (Tidiane Dia, with sponsorship from YouGov)
  * Add `prefetch_renditions` method to `ImageQueryset` for performance optimisation on image listings (Tidiane Dia, Karl Hobley)
  * Add ability to define a custom `get_field_clean_name` method when defining `FormField` models that extend `AbstractFormField` (LB (Ben) Johnston)
+ * Migrate Home (Dashboard) view to use generic Wagtail class based view (LB (Ben) Johnston)
  * Fix: Typo in `ResumeWorkflowActionFormatter` message (Stefan Hammer)
  * Fix: Throw a meaningful error when saving an image to an unrecognised image format (Christian Franke)
  * Fix: Remove extra padding for headers with breadcrumbs on mobile viewport (Steven Steinwand)

--- a/docs/releases/4.0.md
+++ b/docs/releases/4.0.md
@@ -35,6 +35,7 @@ When using a queryset to render a list of images, you can now use the ``prefetch
  * Allow users to sort by different fields in the image library (Tidiane Dia, with sponsorship from YouGov)
  * Add `prefetch_renditions` method to `ImageQueryset` for performance optimisation on image listings (Tidiane Dia, Karl Hobley)
  * Add ability to define a custom `get_field_clean_name` method when defining `FormField` models that extend `AbstractFormField` (LB (Ben) Johnston)
+ * Migrate Home (Dashboard) view to use generic Wagtail class based view (LB (Ben) Johnston)
 
 ### Bug fixes
 

--- a/wagtail/admin/templates/wagtailadmin/home.html
+++ b/wagtail/admin/templates/wagtailadmin/home.html
@@ -1,6 +1,5 @@
-{% extends "wagtailadmin/base.html" %}
+{% extends "wagtailadmin/generic/base.html" %}
 {% load wagtailadmin_tags i18n %}
-{% block titletag %}{% trans "Dashboard" %}{% endblock %}
 {% block bodyclass %}homepage{% endblock %}
 
 {% block extra_css %}

--- a/wagtail/admin/urls/__init__.py
+++ b/wagtail/admin/urls/__init__.py
@@ -23,7 +23,7 @@ from wagtail.admin.views.pages import listing
 from wagtail.utils.urlpatterns import decorate_urlpatterns
 
 urlpatterns = [
-    path("", home.home, name="wagtailadmin_home"),
+    path("", home.HomeView.as_view(), name="wagtailadmin_home"),
     path("test404/", TemplateView.as_view(template_name="wagtailadmin/404.html")),
     path("api/", include(api_urls)),
     path("failwhale/", home.error_test, name="wagtailadmin_error_test"),

--- a/wagtail/admin/views/generic/__init__.py
+++ b/wagtail/admin/views/generic/__init__.py
@@ -1,3 +1,4 @@
+from .base import WagtailAdminTemplateMixin  # noqa
 from .mixins import (  # noqa
     BeforeAfterHookMixin,
     HookResponseMixin,


### PR DESCRIPTION
- resolves #8366
- does not change the dashboard / home layout (visually) or behaviour but simply migrates the home view to a class based view leveraging the shared base mixins/templates
- [x] Do the tests still pass?[^1]
- [x] Does the code comply with the style guide? 
    - [x] Run `make lint` from the Wagtail root. 
- [x] For Python changes: Have you added tests to cover the new/fixed behaviour? **no changes to behaviour**

**Please describe additional details for testing this change**. 

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets) 
