### PR TITLE
Added full_url field for image rendition

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -7,6 +7,7 @@ unreleased (xx.xx.xxxx) - IN DEVELOPMENT
  * Add clarity to confirmation when being asked to convert an external link to an internal one (Thijs Kramer)
  * Convert various pages in the documentation to Markdown (Daniel Kirkham)
  * Add `base_url_path` to `ModelAdmin` so that the default URL structure of app_label/model_name can be overridden, sub-classes of `AdminURLHelper` overriding `__init__` will need to accept a new kwarg of `base_url_path` (Vu Pham, Khanh Hoang)
+ * Add `full_url` to the API output of `ImageRenditionField` (Paarth Agarwal)
 
 
 3.0 (xx.xx.xxxx) - IN DEVELOPMENT

--- a/docs/advanced_topics/api/v2/configuration.rst
+++ b/docs/advanced_topics/api/v2/configuration.rst
@@ -206,6 +206,7 @@ For example:
 
 .. code-block:: python
 
+    from wagtail.api import APIField
     from wagtail.images.api.fields import ImageRenditionField
 
     class BlogPage(Page):
@@ -239,6 +240,7 @@ This would add the following to the JSON:
         },
         "feed_image_thumbnail": {
             "url": "/media/images/a_test_image.fill-100x100.jpg",
+            "full_url": "http://www.example.com/media/images/a_test_image.fill-100x100.jpg",
             "width": 100,
             "height": 100,
             "alt": "image alt text"

--- a/wagtail/images/api/fields.py
+++ b/wagtail/images/api/fields.py
@@ -13,6 +13,7 @@ class ImageRenditionField(Field):
     Example:
     "thumbnail": {
         "url": "/media/images/myimage.max-165x165.jpg",
+        "full_url": "https://media.example.com/media/images/myimage.max-165x165.jpg",
         "width": 165,
         "height": 100,
         "alt": "Image alt text"
@@ -37,6 +38,7 @@ class ImageRenditionField(Field):
             return OrderedDict(
                 [
                     ("url", thumbnail.url),
+                    ("full_url", thumbnail.full_url),
                     ("width", thumbnail.width),
                     ("height", thumbnail.height),
                     ("alt", thumbnail.alt),

--- a/wagtail/images/tests/test_api_fields.py
+++ b/wagtail/images/tests/test_api_fields.py
@@ -15,8 +15,11 @@ class TestImageRenditionField(TestCase):
     def test_api_representation(self):
         rendition = self.image.get_rendition("width-400")
         representation = ImageRenditionField("width-400").to_representation(self.image)
-        self.assertEqual(set(representation.keys()), {"url", "width", "height", "alt"})
+        self.assertEqual(
+            set(representation.keys()), {"url", "full_url", "width", "height", "alt"}
+        )
         self.assertEqual(representation["url"], rendition.url)
+        self.assertEqual(representation["full_url"], rendition.full_url)
         self.assertEqual(representation["width"], rendition.width)
         self.assertEqual(representation["height"], rendition.height)
         self.assertEqual(representation["alt"], rendition.alt)


### PR DESCRIPTION
I have added the `full_url` field for image renditions. Fixes #7558.
It is my first time doing API changes here, so please check and let me know if there are any necessary adjustments. 