### PR TITLE
Page renderers

### DIFF
--- a/wagtail/api/v2/renderers.py
+++ b/wagtail/api/v2/renderers.py
@@ -1,11 +1,9 @@
-from django.conf import settings
 from django.http import JsonResponse
 
-from wagtail.models import Page, PageViewRestriction, Site
 from wagtail.renderers import BasePageRenderer
 
 from .router import WagtailAPIRouter
-from .utils import parse_fields_parameter
+from .utils import get_base_queryset, parse_fields_parameter
 from .views import PagesAPIViewSet
 
 
@@ -15,44 +13,6 @@ class APIV2PageRenderer(BasePageRenderer):
     """
 
     media_type = "application/json; version=2"
-
-    def get_base_queryset(self, request):
-        """
-        Returns a queryset containing all pages that can be seen by this user.
-
-        This is used as the base for get_queryset and is also used to find the
-        parent pages when using the child_of and descendant_of filters as well.
-        """
-        # Get all live pages
-        queryset = Page.objects.all().live()
-
-        # Exclude pages that the user doesn't have access to
-        restricted_pages = [
-            restriction.page
-            for restriction in PageViewRestriction.objects.all().select_related("page")
-            if not restriction.accept_request(request)
-        ]
-
-        # Exclude the restricted pages and their descendants from the queryset
-        for restricted_page in restricted_pages:
-            queryset = queryset.not_descendant_of(restricted_page, inclusive=True)
-
-        # Filter by site
-        site = Site.find_for_request(request)
-        if site:
-            base_queryset = queryset
-            queryset = base_queryset.descendant_of(site.root_page, inclusive=True)
-
-            # If internationalisation is enabled, include pages from other language trees
-            if getattr(settings, "WAGTAIL_I18N_ENABLED", False):
-                for translation in site.root_page.get_translations():
-                    queryset |= base_queryset.descendant_of(translation, inclusive=True)
-
-        else:
-            # No sites configured
-            queryset = queryset.none()
-
-        return queryset
 
     def get_serializer_class(self, request, page, router):
         return PagesAPIViewSet._get_serializer_class(
@@ -70,7 +30,7 @@ class APIV2PageRenderer(BasePageRenderer):
             context={
                 "request": request,
                 "router": router,
-                "base_queryset": self.get_base_queryset(request),
+                "base_queryset": get_base_queryset(request),
             },
         )
         return JsonResponse(serializer.data)

--- a/wagtail/api/v2/renderers.py
+++ b/wagtail/api/v2/renderers.py
@@ -1,0 +1,76 @@
+from django.conf import settings
+from django.http import JsonResponse
+
+from wagtail.models import Page, PageViewRestriction, Site
+from wagtail.renderers import BasePageRenderer
+
+from .router import WagtailAPIRouter
+from .utils import parse_fields_parameter
+from .views import PagesAPIViewSet
+
+
+class APIV2PageRenderer(BasePageRenderer):
+    """
+    Renders a page using the Wagtail API serializer that can be configured using the `.api_fields` attribute on the page.
+    """
+
+    media_type = "application/json; version=2"
+
+    def get_base_queryset(self, request):
+        """
+        Returns a queryset containing all pages that can be seen by this user.
+
+        This is used as the base for get_queryset and is also used to find the
+        parent pages when using the child_of and descendant_of filters as well.
+        """
+        # Get all live pages
+        queryset = Page.objects.all().live()
+
+        # Exclude pages that the user doesn't have access to
+        restricted_pages = [
+            restriction.page
+            for restriction in PageViewRestriction.objects.all().select_related("page")
+            if not restriction.accept_request(request)
+        ]
+
+        # Exclude the restricted pages and their descendants from the queryset
+        for restricted_page in restricted_pages:
+            queryset = queryset.not_descendant_of(restricted_page, inclusive=True)
+
+        # Filter by site
+        site = Site.find_for_request(request)
+        if site:
+            base_queryset = queryset
+            queryset = base_queryset.descendant_of(site.root_page, inclusive=True)
+
+            # If internationalisation is enabled, include pages from other language trees
+            if getattr(settings, "WAGTAIL_I18N_ENABLED", False):
+                for translation in site.root_page.get_translations():
+                    queryset |= base_queryset.descendant_of(translation, inclusive=True)
+
+        else:
+            # No sites configured
+            queryset = queryset.none()
+
+        return queryset
+
+    def get_serializer_class(self, request, page, router):
+        return PagesAPIViewSet._get_serializer_class(
+            router,
+            type(page),
+            parse_fields_parameter("-detail_url"),
+            show_details=True,
+        )
+
+    def render(self, request, media_type, page, args, kwargs):
+        router = WagtailAPIRouter("")
+        serializer_class = self.get_serializer_class(request, page, router)
+        serializer = serializer_class(
+            page,
+            context={
+                "request": request,
+                "router": router,
+                "base_queryset": self.get_base_queryset(request),
+            },
+        )
+        return JsonResponse(serializer.data)

--- a/wagtail/api/v2/serializers.py
+++ b/wagtail/api/v2/serializers.py
@@ -24,7 +24,10 @@ class TypeField(Field):
 
     def to_representation(self, obj):
         name = type(obj)._meta.app_label + "." + type(obj).__name__
-        self.context["view"].seen_types[name] = type(obj)
+
+        if "view" in self.context:
+            self.context["view"].seen_types[name] = type(obj)
+
         return name
 
 
@@ -88,7 +91,10 @@ class PageTypeField(Field):
         if page.specific_class is None:
             return None
         name = page.specific_class._meta.app_label + "." + page.specific_class.__name__
-        self.context["view"].seen_types[name] = page.specific_class
+
+        if "view" in self.context:
+            self.context["view"].seen_types[name] = page.specific_class
+
         return name
 
 

--- a/wagtail/api/v2/tests/test_page_renderer.py
+++ b/wagtail/api/v2/tests/test_page_renderer.py
@@ -1,0 +1,115 @@
+import json
+
+from django.test import TestCase
+from django.test.utils import override_settings
+
+from wagtail.test.utils import WagtailTestUtils
+
+
+@override_settings(
+    WAGTAIL_PAGE_RENDERERS=["wagtail.api.v2.renderers.APIV2PageRenderer"]
+)
+class TestPageRenderer(TestCase, WagtailTestUtils):
+    fixtures = ["demosite.json"]
+
+    def get_response(self, path, **params):
+        return self.client.get(path, params, HTTP_ACCEPT="application/json; version=2")
+
+    def test(self):
+        response = self.get_response("/blog-index/blog-post/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-type"], "application/json")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-type"], "application/json")
+
+        # Will crash if the JSON is invalid
+        content = json.loads(response.content.decode("UTF-8"))
+
+        # Check the id field
+        self.assertIn("id", content)
+        self.assertEqual(content["id"], 16)
+
+        # Check that the meta section is there
+        self.assertIn("meta", content)
+        self.assertIsInstance(content["meta"], dict)
+
+        # Check the meta type
+        self.assertIn("type", content["meta"])
+        self.assertEqual(content["meta"]["type"], "demosite.BlogEntryPage")
+
+        # Unline the standard API representation, this must not contain the detail_url
+        self.assertNotIn("detail_url", content["meta"])
+
+        # Check the meta html_url
+        self.assertIn("html_url", content["meta"])
+        self.assertEqual(
+            content["meta"]["html_url"], "http://localhost/blog-index/blog-post/"
+        )
+
+        # Check the parent field
+        self.assertIn("parent", content["meta"])
+        self.assertIsInstance(content["meta"]["parent"], dict)
+        self.assertEqual(set(content["meta"]["parent"].keys()), {"id", "meta", "title"})
+        self.assertEqual(content["meta"]["parent"]["id"], 5)
+        self.assertIsInstance(content["meta"]["parent"]["meta"], dict)
+        self.assertEqual(
+            set(content["meta"]["parent"]["meta"].keys()),
+            {"type", "html_url"},
+        )
+        self.assertEqual(
+            content["meta"]["parent"]["meta"]["type"], "demosite.BlogIndexPage"
+        )
+        self.assertEqual(
+            content["meta"]["parent"]["meta"]["html_url"],
+            "http://localhost/blog-index/",
+        )
+
+        # Check the alias_of field
+        # See test_alias_page for a test on an alias page
+        self.assertIn("alias_of", content["meta"])
+        self.assertIsNone(content["meta"]["alias_of"])
+
+        # Check that the custom fields are included
+        self.assertIn("date", content)
+        self.assertIn("body", content)
+        self.assertIn("tags", content)
+        self.assertIn("feed_image", content)
+        self.assertIn("related_links", content)
+        self.assertIn("carousel_items", content)
+
+        # Check that the date was serialised properly
+        self.assertEqual(content["date"], "2013-12-02")
+
+        # Check that the tags were serialised properly
+        self.assertEqual(content["tags"], ["bird", "wagtail"])
+
+        # Check that the feed image was serialised properly
+        self.assertIsInstance(content["feed_image"], dict)
+        self.assertEqual(set(content["feed_image"].keys()), {"id", "meta"})
+        self.assertEqual(content["feed_image"]["id"], 7)
+        self.assertIsInstance(content["feed_image"]["meta"], dict)
+        self.assertEqual(
+            set(content["feed_image"]["meta"].keys()),
+            {"type"},
+        )
+        self.assertEqual(content["feed_image"]["meta"]["type"], "wagtailimages.Image")
+
+        # Check that the feed images' thumbnail was serialised properly
+        self.assertEqual(
+            content["feed_image_thumbnail"],
+            {
+                # This is OK because it tells us it used ImageRenditionField to generate the output
+                "error": "SourceImageIOError"
+            },
+        )
+
+        # Check that the child relations were serialised properly
+        self.assertEqual(content["related_links"], [])
+        for carousel_item in content["carousel_items"]:
+            self.assertEqual(
+                set(carousel_item.keys()),
+                {"id", "meta", "embed_url", "link", "caption", "image"},
+            )
+            self.assertEqual(set(carousel_item["meta"].keys()), {"type"})

--- a/wagtail/api/v2/utils.py
+++ b/wagtail/api/v2/utils.py
@@ -4,7 +4,7 @@ from django.conf import settings
 from django.utils.encoding import force_str
 
 from wagtail.coreutils import resolve_model_string
-from wagtail.models import Page, Site
+from wagtail.models import Page, PageViewRestriction, Site
 
 
 class BadRequestError(Exception):
@@ -266,3 +266,42 @@ def parse_boolean(value):
         return False
     else:
         raise ValueError("expected 'true' or 'false', got '%s'" % value)
+
+
+def get_base_queryset(request):
+    """
+    Returns a queryset containing all pages that can be seen by this user.
+
+    This is used as the base for get_queryset and is also used to find the
+    parent pages when using the child_of and descendant_of filters as well.
+    """
+    # Get all live pages
+    queryset = Page.objects.all().live()
+
+    # Exclude pages that the user doesn't have access to
+    restricted_pages = [
+        restriction.page
+        for restriction in PageViewRestriction.objects.all().select_related("page")
+        if not restriction.accept_request(request)
+    ]
+
+    # Exclude the restricted pages and their descendants from the queryset
+    for restricted_page in restricted_pages:
+        queryset = queryset.not_descendant_of(restricted_page, inclusive=True)
+
+    # Filter by site
+    site = Site.find_for_request(request)
+    if site:
+        base_queryset = queryset
+        queryset = base_queryset.descendant_of(site.root_page, inclusive=True)
+
+        # If internationalisation is enabled, include pages from other language trees
+        if getattr(settings, "WAGTAIL_I18N_ENABLED", False):
+            for translation in site.root_page.get_translations():
+                queryset |= base_queryset.descendant_of(translation, inclusive=True)
+
+    else:
+        # No sites configured
+        queryset = queryset.none()
+
+    return queryset

--- a/wagtail/api/v2/views.py
+++ b/wagtail/api/v2/views.py
@@ -12,7 +12,7 @@ from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
 
 from wagtail.api import APIField
-from wagtail.models import Page, PageViewRestriction, Site
+from wagtail.models import Page, Site
 
 from .filters import (
     AncestorOfFilter,
@@ -28,6 +28,7 @@ from .pagination import WagtailPagination
 from .serializers import BaseSerializer, PageSerializer, get_serializer_class
 from .utils import (
     BadRequestError,
+    get_base_queryset,
     get_object_detail_url,
     page_models_from_string,
     parse_fields_parameter,
@@ -488,42 +489,7 @@ class PagesAPIViewSet(BaseAPIViewSet):
         return Site.find_for_request(self.request).root_page
 
     def get_base_queryset(self):
-        """
-        Returns a queryset containing all pages that can be seen by this user.
-
-        This is used as the base for get_queryset and is also used to find the
-        parent pages when using the child_of and descendant_of filters as well.
-        """
-        # Get all live pages
-        queryset = Page.objects.all().live()
-
-        # Exclude pages that the user doesn't have access to
-        restricted_pages = [
-            restriction.page
-            for restriction in PageViewRestriction.objects.all().select_related("page")
-            if not restriction.accept_request(self.request)
-        ]
-
-        # Exclude the restricted pages and their descendants from the queryset
-        for restricted_page in restricted_pages:
-            queryset = queryset.not_descendant_of(restricted_page, inclusive=True)
-
-        # Filter by site
-        site = Site.find_for_request(self.request)
-        if site:
-            base_queryset = queryset
-            queryset = base_queryset.descendant_of(site.root_page, inclusive=True)
-
-            # If internationalisation is enabled, include pages from other language trees
-            if getattr(settings, "WAGTAIL_I18N_ENABLED", False):
-                for translation in site.root_page.get_translations():
-                    queryset |= base_queryset.descendant_of(translation, inclusive=True)
-
-        else:
-            # No sites configured
-            queryset = queryset.none()
-
-        return queryset
+        return get_base_queryset(self.request)
 
     def get_queryset(self):
         request = self.request

--- a/wagtail/renderers.py
+++ b/wagtail/renderers.py
@@ -1,0 +1,102 @@
+import functools
+
+from django.conf import settings
+from django.core.signals import setting_changed
+from django.dispatch import receiver
+from django.utils.module_loading import import_string
+from rest_framework import HTTP_HEADER_ENCODING
+from rest_framework.utils.mediatypes import (
+    _MediaType,
+    media_type_matches,
+    order_by_precedence,
+)
+
+
+class BasePageRenderer:
+    media_type = None
+
+    def render(self, request, media_type, page, args, kwargs):
+        raise NotImplementedError("Renderer class requires .render() to be implemented")
+
+
+class ServePageRenderer(BasePageRenderer):
+    """
+    Renders a page by calling the .serve() method on the model.
+    """
+
+    media_type = "text/html"
+
+    def render(self, request, media_type, page, args, kwargs):
+        return page.serve(request, *args, **kwargs)
+
+
+@functools.lru_cache()
+def get_page_renderers():
+    """
+    Returns the list of renderer classes that are registered in WAGTAIL_PAGE_RENDERERS.
+    """
+    renderer_strings = getattr(
+        settings, "WAGTAIL_PAGE_RENDERERS", ["wagtail.renderers.ServePageRenderer"]
+    )
+
+    return [import_string(renderer_string)() for renderer_string in renderer_strings]
+
+
+@receiver(setting_changed)
+def reset_page_renderers_cache(**kwargs):
+    """
+    Clear cache when WAGTAIL_PAGE_RENDERERS setting is changed
+    """
+    if kwargs["setting"] in ("WAGTAIL_PAGE_RENDERERS"):
+        get_page_renderers.cache_clear()
+
+
+class PageRendererNotFoundError(LookupError):
+    pass
+
+
+def get_page_renderer_for_request(request):
+    """
+    Returns the best renderer to use for the request.
+
+    If no renderer can be found for the requests, this raises RendererNotFoundError
+
+    Args:
+        request (Request): A Django Request object to find a renderer for
+
+    Raises:
+        PageRendererNotFoundError: If there is no renderer that could be used for the request
+    """
+    # Implementation is based on similar code in Django REST Framework
+    # https://github.com/encode/django-rest-framework/blob/71e6c30034a1dd35a39ca74f86c371713e762c79/rest_framework/negotiation.py
+    header = request.META.get("HTTP_ACCEPT", "*/*")
+    accept_list = [token.strip() for token in header.split(",")]
+
+    for media_type_set in order_by_precedence(accept_list):
+        for renderer in get_page_renderers():
+            for media_type in media_type_set:
+                if media_type_matches(renderer.media_type, media_type):
+                    # Return the most specific media type as accepted.
+                    media_type_wrapper = _MediaType(media_type)
+                    if (
+                        _MediaType(renderer.media_type).precedence
+                        > media_type_wrapper.precedence
+                    ):
+                        # Eg client requests '*/*'
+                        # Accepted media type is 'application/html'
+                        full_media_type = ";".join(
+                            (renderer.media_type,)
+                            + tuple(
+                                "{}={}".format(key, value.decode(HTTP_HEADER_ENCODING))
+                                for key, value in media_type_wrapper.params.items()
+                            )
+                        )
+                        return renderer, full_media_type
+                    else:
+                        # Eg client requests 'application/json; indent=8'
+                        # Accepted media type is 'application/json; indent=8'
+                        return renderer, media_type
+
+    raise PageRendererNotFoundError(
+        f"Could not find a renderer for media type '{media_type}'"
+    )

--- a/wagtail/views.py
+++ b/wagtail/views.py
@@ -7,6 +7,7 @@ from django.utils.http import url_has_allowed_host_and_scheme
 from wagtail import hooks
 from wagtail.forms import PasswordViewRestrictionForm
 from wagtail.models import Page, PageViewRestriction, Site
+from wagtail.renderers import PageRendererNotFoundError, get_page_renderer_for_request
 
 
 def serve(request, path):
@@ -25,7 +26,12 @@ def serve(request, path):
         if isinstance(result, HttpResponse):
             return result
 
-    return page.serve(request, *args, **kwargs)
+    try:
+        renderer, media_type = get_page_renderer_for_request(request)
+    except PageRendererNotFoundError:
+        return HttpResponse(status=406)
+
+    return renderer.render(request, media_type, page, args, kwargs)
 
 
 def authenticate_with_password(request, page_view_restriction_id, page_id):


### PR DESCRIPTION
This PR implements an idea for an API that allows developers to create renderers for pages in alternative media types (for example, JSON).

See discussion in: https://github.com/wagtail/wagtail/discussions/8374#discussioncomment-2585201

- [ ] Integrate this nicely with ``RoutablePageMixin``
- [ ] Could this be used to generate API representations of page previews?
- [ ] Documentation