### PR TITLE
chore(ci): add informational Codecov status checks

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -12,6 +12,7 @@ Changelog
  * Use `InlinePanel`'s label when available for field comparison label (Sandil Ranasinghe)
  * Drop support for Safari 13 by removing left/right positioning in favour of CSS logical properties (Thibaud Colas)
  * Use `FormData` instead of jQuery's `form.serialize` when editing documents or images just added so that additional fields can be better supported (Stefan Hammer)
+ * Add informational Codecov status checks for GitHub CI pipelines (Tom Hu)
  * Fix: Typo in `ResumeWorkflowActionFormatter` message (Stefan Hammer)
  * Fix: Throw a meaningful error when saving an image to an unrecognised image format (Christian Franke)
 

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -597,6 +597,7 @@ Contributors
 * Przemysław Buczkowski
 * Josh Woodcock
 * Christian Franke
+* Tom Hu
 
 Translators
 ===========

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,11 +1,14 @@
 codecov:
   notify:
-    after_n_builds: 10
     require_ci_to_pass: no
 
 coverage:
   status:
-    project: off
-    patch: off
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
 
 comment: off

--- a/docs/releases/4.0.md
+++ b/docs/releases/4.0.md
@@ -16,8 +16,9 @@ depth: 1
  * Add `base_url_path` to `ModelAdmin` so that the default URL structure of app_label/model_name can be overridden (Vu Pham, Khanh Hoang)
  * Add `full_url` to the API output of `ImageRenditionField` (Paarth Agarwal)
  * Use `InlinePanel`'s label when available for field comparison label (Sandil Ranasinghe)
- * Use `FormData` instead of jQuery's `form.serialize` when editing documents or images just added so that additional fields can be better supported (Stefan Hammer)
  * Drop support for Safari 13 by removing left/right positioning in favour of CSS logical properties (Thibaud Colas)
+ * Use `FormData` instead of jQuery's `form.serialize` when editing documents or images just added so that additional fields can be better supported (Stefan Hammer)
+ * Add informational Codecov status checks for GitHub CI pipelines (Tom Hu)
 
 ### Bug fixes
 


### PR DESCRIPTION
Hi, Tom from Codecov here. I noticed that you were using Codecov but weren't actually getting any notifications on pull requests. I figured it would be useful to get some idea if code being changed is being tested, but also not blocking CI/merging. Let me know if this makes sense or if we can do something that would be helpful.

_Please check the following:_

- [ ] Do the tests still pass?[^1]
- [x] Does the code comply with the style guide? 
    - [ ] Run `make lint` from the Wagtail root. 
- [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
- [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    - [ ] **Please list the exact browser and operating system versions you tested**:
    - [ ] **Please list which assistive technologies [^3] you tested**: 
- [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**. 

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets) 
