### PR TITLE
Py3.10: collections.Mapping was moved

### DIFF
--- a/wagtail/utils/utils.py
+++ b/wagtail/utils/utils.py
@@ -1,4 +1,4 @@
-import collections
+import collections.abc
 
 
 def deep_update(source, overrides):
@@ -7,7 +7,7 @@ def deep_update(source, overrides):
     Modify ``source`` in place.
     """
     for key, value in overrides.items():
-        if isinstance(value, collections.Mapping) and value:
+        if isinstance(value, collections.abc.Mapping) and value:
             returned = deep_update(source.get(key, {}), value)
             source[key] = returned
         else:


### PR DESCRIPTION
collections.Mapping has been moved to collections.abc.Mapping
in Python 3.3. Starting from Python 3.10, collections.Mapping
does not point to the new name any more.

This change updates the naming.

See: https://docs.python.org/3/library/collections.abc.html


- [X] Do the tests still pass?[^1]
- [X] Does the code comply with the style guide? 
    - [X] Run `make lint` from the Wagtail root. 

**Please describe additional details for testing this change**. 

Since this is a Python compatibility change, it is tested by the fact that all tests using this utility function fail without it.