### PR TITLE
Fix deep_update for Python 3.10

### DIFF
--- a/wagtail/tests/test_utils.py
+++ b/wagtail/tests/test_utils.py
@@ -18,6 +18,7 @@ from wagtail.coreutils import (
     string_to_ascii,
 )
 from wagtail.models import Page, Site
+from wagtail.utils.utils import deep_update
 
 
 class TestCamelCaseToUnderscore(TestCase):
@@ -405,3 +406,38 @@ class TestGetDummyRequest(TestCase):
 
         request = get_dummy_request(site=site)
         self.assertEqual(request.get_host(), "other.example.com:8888")
+
+
+class TestDeepUpdate(TestCase):
+    def test_deep_update(self):
+        val = {
+            "captain": "picard",
+            "beverage": {
+                "type": "coffee",
+                "temperature": "hot",
+            },
+        }
+
+        deep_update(
+            val,
+            {
+                "beverage": {
+                    "type": "tea",
+                    "variant": "earl grey",
+                },
+                "starship": "enterprise",
+            },
+        )
+
+        self.assertEqual(
+            val,
+            {
+                "captain": "picard",
+                "beverage": {
+                    "type": "tea",
+                    "variant": "earl grey",
+                    "temperature": "hot",
+                },
+                "starship": "enterprise",
+            },
+        )

--- a/wagtail/utils/utils.py
+++ b/wagtail/utils/utils.py
@@ -1,4 +1,4 @@
-import collections
+from collections.abc import Mapping
 
 
 def deep_update(source, overrides):
@@ -7,7 +7,7 @@ def deep_update(source, overrides):
     Modify ``source`` in place.
     """
     for key, value in overrides.items():
-        if isinstance(value, collections.Mapping) and value:
+        if isinstance(value, Mapping) and value:
             returned = deep_update(source.get(key, {}), value)
             source[key] = returned
         else:


### PR DESCRIPTION
This is only used by the Elasticsearch backend, so we were missing test runs for it over all Python versions.

Thanks to @przemub for reporting and the initial fix (#8388).
