### PR TITLE
Slim sidebar visual design issues

### DIFF
--- a/client/scss/settings/_variables.scss
+++ b/client/scss/settings/_variables.scss
@@ -148,7 +148,7 @@ $font-wagtail-icons: wagtail;
 // misc sizing
 $thumbnail-width: 130px;
 $menu-width: 200px;
-$menu-width-slim: 65px;
+$menu-width-slim: 60px;
 
 $menu-width-max: 320px;
 

--- a/client/src/components/PageExplorer/PageExplorer.scss
+++ b/client/src/components/PageExplorer/PageExplorer.scss
@@ -118,7 +118,7 @@ $explorer-header-horizontal-padding: 10px;
     // stylelint-disable-next-line property-disallowed-list
     right: 1rem;
     inset-inline-end: 1rem;
-    inset-block-start: 0.85rem;
+    top: 0.85rem;
     width: 1.25rem;
     height: 1.25rem;
 

--- a/client/src/components/PageExplorer/PageExplorer.scss
+++ b/client/src/components/PageExplorer/PageExplorer.scss
@@ -112,15 +112,15 @@ $explorer-header-horizontal-padding: 10px;
 
   // Add select arrow back on browsers where native ui has been removed
   &-icon {
+    @apply w-text-primary;
     position: absolute;
     // Remove once we drop support for Safari 13.
     // stylelint-disable-next-line property-disallowed-list
     right: 1rem;
     inset-inline-end: 1rem;
-    top: 1rem;
+    inset-block-start: 0.85rem;
     width: 1.25rem;
     height: 1.25rem;
-    color: $color-grey-3;
 
     .ie & {
       display: none;

--- a/client/src/components/PageExplorer/PageExplorer.scss
+++ b/client/src/components/PageExplorer/PageExplorer.scss
@@ -121,6 +121,7 @@ $explorer-header-horizontal-padding: 10px;
     top: 0.85rem;
     width: 1.25rem;
     height: 1.25rem;
+    pointer-events: none;
 
     .ie & {
       display: none;

--- a/client/src/components/PageExplorer/PageExplorer.scss
+++ b/client/src/components/PageExplorer/PageExplorer.scss
@@ -55,15 +55,12 @@ $explorer-header-horizontal-padding: 10px;
 }
 
 .c-page-explorer__header__title {
+  @apply hover:w-bg-primary hover:w-text-white focus:w-bg-primary focus:w-text-white;
   color: inherit;
-
-  &:focus,
-  &:hover {
-    @apply w-bg-black/50 w-text-white;
-  }
 }
 
 .c-page-explorer__header__title__inner {
+  @apply w-flex;
   padding: 1em $explorer-header-horizontal-padding;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -76,7 +73,7 @@ $explorer-header-horizontal-padding: 10px;
   }
 
   .icon--explorer-header {
-    @apply w-text-white/85;
+    @apply w-text-white/85 w-mr-2;
     width: 1.25em;
     height: 1.25em;
     margin-inline-end: 0.25rem;
@@ -95,7 +92,6 @@ $explorer-header-horizontal-padding: 10px;
 
   > select {
     padding: 5px 30px 5px 10px;
-    border-radius: 0;
     border-color: #4c4e4d;
     font-size: 0.875rem;
 

--- a/client/src/components/PageExplorer/PageExplorer.scss
+++ b/client/src/components/PageExplorer/PageExplorer.scss
@@ -41,7 +41,7 @@ $menu-footer-height: 50px;
 $explorer-header-horizontal-padding: 10px;
 
 .c-page-explorer__header {
-  @apply w-bg-black/50 w-text-white/85;
+  @apply w-bg-primary-200 w-text-white/85 w-border-b w-border-primary;
   display: grid;
   grid-template-columns: 1fr auto;
   align-items: center;

--- a/client/src/components/PageExplorer/PageExplorerItem.scss
+++ b/client/src/components/PageExplorer/PageExplorerItem.scss
@@ -25,7 +25,7 @@
 }
 
 .c-page-explorer__item__action {
-  @apply w-text-white/85 w-transition;
+  @apply w-text-white/85 w-transition hover:w-bg-primary hover:w-text-white focus:w-bg-primary focus:w-text-white;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -35,12 +35,6 @@
   line-height: 1;
   font-size: 2em;
   cursor: pointer;
-
-  &:focus,
-  &:hover {
-    background: $c-page-explorer-bg-active;
-    color: $color-white;
-  }
 
   .icon::before {
     margin-inline-end: 0;

--- a/client/src/components/PageExplorer/PageExplorerItem.scss
+++ b/client/src/components/PageExplorer/PageExplorerItem.scss
@@ -1,20 +1,10 @@
 .c-page-explorer__item {
-  @apply w-flex w-flex-row w-flex-nowrap w-border-0 w-border-b w-border-solid w-border-black/50 w-divide-x w-divide-solid w-divide-black/50 w-divide-y-0;
+  @apply w-flex w-flex-row w-flex-nowrap w-border-0 w-border-b w-border-solid w-border-primary w-divide-x w-divide-solid w-divide-primary w-divide-y-0;
 }
 
 .c-page-explorer__item__link {
-  @apply w-inline-flex w-items-start sm:w-items-center w-flex-wrap w-grow w-cursor-pointer w-gap-1 w-transition;
+  @apply w-inline-flex w-items-start sm:w-items-center w-flex-wrap w-grow w-cursor-pointer w-gap-1 w-transition hover:w-bg-primary focus:w-bg-primary focus:w-text-white hover:w-text-white;
   padding: 1.45em 1em;
-
-  &:focus,
-  &:hover {
-    background: $c-page-explorer-bg-active;
-    color: $color-white;
-  }
-
-  @include hover {
-    background: $c-page-explorer-bg-active;
-  }
 
   @include media-breakpoint-up(sm) {
     padding: 1.45em 1.75em;

--- a/client/src/components/Sidebar/Sidebar.scss
+++ b/client/src/components/Sidebar/Sidebar.scss
@@ -61,6 +61,13 @@
     border-inline-end: 1px solid transparent;
   }
 
+  .icon--menuitem {
+    width: 1rem;
+    height: 1rem;
+    min-width: 1rem;
+    vertical-align: text-top;
+  }
+
   &--slim {
     width: $menu-width-slim;
   }
@@ -86,14 +93,6 @@
   // When in mobile mode, hide the collapse-toggle and show the nav-toggle (which is defined in the .sidebar-nav-toggle class below)
   &--mobile &__collapse-toggle {
     display: none;
-  }
-
-  .icon--menuitem {
-    width: 1rem;
-    height: 1rem;
-    min-width: 1rem;
-    margin-inline-end: 0.5rem;
-    vertical-align: text-top;
   }
 }
 

--- a/client/src/components/Sidebar/Sidebar.scss
+++ b/client/src/components/Sidebar/Sidebar.scss
@@ -89,10 +89,10 @@
   }
 
   .icon--menuitem {
-    width: 1.25em;
-    height: 1.25em;
-    min-width: 1.25em;
-    margin-inline-end: 0.5em;
+    width: 1rem;
+    height: 1rem;
+    min-width: 1rem;
+    margin-inline-end: 0.5rem;
     vertical-align: text-top;
   }
 }

--- a/client/src/components/Sidebar/Sidebar.scss
+++ b/client/src/components/Sidebar/Sidebar.scss
@@ -65,7 +65,6 @@
     width: 1rem;
     height: 1rem;
     min-width: 1rem;
-    vertical-align: text-top;
   }
 
   &--slim {

--- a/client/src/components/Sidebar/Sidebar.tsx
+++ b/client/src/components/Sidebar/Sidebar.tsx
@@ -189,9 +189,7 @@ export const Sidebar: React.FunctionComponent<SidebarProps> = ({
             >
               <Icon
                 name="expand-right"
-                className={`w-transition motion-reduce:w-transition-none
-                ${!collapsed ? '-w-rotate-180' : ''}
-                `}
+                className={!collapsed ? '-w-rotate-180' : ''}
               />
             </button>
           </div>

--- a/client/src/components/Sidebar/__snapshots__/Sidebar.test.js.snap
+++ b/client/src/components/Sidebar/__snapshots__/Sidebar.test.js.snap
@@ -29,9 +29,7 @@ exports[`Sidebar should render with the minimum required props 1`] = `
           type="button"
         >
           <Icon
-            className="w-transition motion-reduce:w-transition-none
-                -w-rotate-180
-                "
+            className="-w-rotate-180"
             name="expand-right"
           />
         </button>

--- a/client/src/components/Sidebar/menu/MenuItem.scss
+++ b/client/src/components/Sidebar/menu/MenuItem.scss
@@ -117,7 +117,7 @@
 
     .sidebar-menu-item__link {
       justify-content: flex-start;
-      padding-inline: 20px;
+      padding: 20px;
     }
   }
 }

--- a/client/src/components/Sidebar/menu/MenuItem.scss
+++ b/client/src/components/Sidebar/menu/MenuItem.scss
@@ -23,7 +23,8 @@
     background: transparent;
     text-align: start;
     color: $color-menu-text;
-    padding: 13px 20px;
+    padding-block: 13px;
+    padding-inline: 20px;
     font-weight: 400;
     line-height: 1;
     overflow: hidden;
@@ -42,7 +43,6 @@
       width: 1rem;
       height: 1rem;
       font-size: 1rem;
-      vertical-align: -15%;
       display: flex;
       align-items: center;
       margin-inline-end: 0;
@@ -58,23 +58,18 @@
       right: 0.5em;
       inset-inline-end: 0.5em;
       top: 0.5em;
-      margin-top: 0;
-    }
-
-    // Disable icon margin, this is instead applied to the left of the .menuitem-label
-    // This is because SVG icons and legacy icons apply this margin differently,
-    // we could remove this override when we remove legacy icons
-    .icon {
-      margin-inline-end: 0 !important;
     }
   }
 
   &--in-sub-menu {
     @apply hover:w-bg-primary;
 
-    #{$root}__link {
+    #{$root}__link,
+    .menuitem-label {
+      @apply w-leading-tight;
       // Links inside a submenu should have normal wrapping
       white-space: normal;
+      align-items: flex-start;
     }
   }
 
@@ -101,13 +96,30 @@
 .sidebar--slim {
   .sidebar-menu-item {
     .menuitem-label {
+      @apply w-sr-only;
       opacity: 0;
+    }
+  }
+
+  .sidebar-menu-item__link {
+    margin-inline-start: auto;
+    display: inline-flex;
+
+    .sidebar-sub-menu-trigger-icon {
+      margin-inline-start: 0;
     }
   }
 
   .sidebar-menu-item--in-sub-menu {
     .menuitem-label {
+      @apply w-not-sr-only;
       opacity: 1;
+      margin-inline-start: 1rem;
+    }
+
+    .sidebar-menu-item__link {
+      justify-content: flex-start;
+      padding-inline: 20px;
     }
   }
 }

--- a/client/src/components/Sidebar/menu/MenuItem.scss
+++ b/client/src/components/Sidebar/menu/MenuItem.scss
@@ -15,14 +15,15 @@
     width: 100%;
     box-sizing: border-box;
     white-space: nowrap;
-    border-inline-start: 3px solid transparent;
+    border-inline: 3px solid transparent;
     -webkit-font-smoothing: auto;
     border: 0;
     background: transparent;
     text-align: start;
     color: $color-menu-text;
-    padding: 11px 20px;
+    padding: 13px 20px;
     font-weight: 400;
+    line-height: 1;
 
     // Note, font-weights lower than normal,
     // and font-size smaller than 1em (80% ~= 12.8px),
@@ -84,6 +85,7 @@
 .menuitem-label {
   @include transition(opacity $menu-transition-duration ease);
   margin-inline-start: 0.5em;
+  line-height: 1;
 }
 
 .sidebar--slim {

--- a/client/src/components/Sidebar/menu/MenuItem.scss
+++ b/client/src/components/Sidebar/menu/MenuItem.scss
@@ -96,7 +96,6 @@
   .sidebar-menu-item {
     .menuitem-label {
       @apply w-sr-only;
-      opacity: 0;
     }
   }
 

--- a/client/src/components/Sidebar/menu/MenuItem.scss
+++ b/client/src/components/Sidebar/menu/MenuItem.scss
@@ -17,7 +17,8 @@
     width: 100%;
     box-sizing: border-box;
     white-space: nowrap;
-    border-inline: 3px solid transparent;
+    border-inline-start: 3px solid transparent;
+    border-inline-end: 3px solid transparent;
     -webkit-font-smoothing: auto;
     border: 0;
     background: transparent;

--- a/client/src/components/Sidebar/menu/MenuItem.scss
+++ b/client/src/components/Sidebar/menu/MenuItem.scss
@@ -23,8 +23,7 @@
     background: transparent;
     text-align: start;
     color: $color-menu-text;
-    padding-block: 13px;
-    padding-inline: 20px;
+    padding: 13px 20px;
     font-weight: 400;
     overflow: hidden;
 

--- a/client/src/components/Sidebar/menu/MenuItem.scss
+++ b/client/src/components/Sidebar/menu/MenuItem.scss
@@ -11,7 +11,9 @@
       background-color $menu-transition-duration ease
     );
     position: relative;
-    display: block;
+    display: flex;
+    justify-content: flex-start;
+    align-items: center;
     width: 100%;
     box-sizing: border-box;
     white-space: nowrap;
@@ -24,6 +26,7 @@
     padding: 13px 20px;
     font-weight: 400;
     line-height: 1;
+    overflow: hidden;
 
     // Note, font-weights lower than normal,
     // and font-size smaller than 1em (80% ~= 12.8px),
@@ -36,9 +39,13 @@
     }
 
     &:before {
+      width: 1rem;
+      height: 1rem;
       font-size: 1rem;
       vertical-align: -15%;
-      margin-inline-end: 0.5em;
+      display: flex;
+      align-items: center;
+      margin-inline-end: 0;
     }
 
     // only really used for spinners and settings menu
@@ -84,8 +91,11 @@
 
 .menuitem-label {
   @include transition(opacity $menu-transition-duration ease);
-  margin-inline-start: 0.5em;
+  margin-inline-start: 1rem;
   line-height: 1;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
 }
 
 .sidebar--slim {

--- a/client/src/components/Sidebar/menu/MenuItem.scss
+++ b/client/src/components/Sidebar/menu/MenuItem.scss
@@ -112,7 +112,6 @@
   .sidebar-menu-item--in-sub-menu {
     .menuitem-label {
       @apply w-not-sr-only;
-      opacity: 1;
       margin-inline-start: 1rem;
     }
 

--- a/client/src/components/Sidebar/menu/MenuItem.scss
+++ b/client/src/components/Sidebar/menu/MenuItem.scss
@@ -5,7 +5,7 @@
   position: relative;
 
   &__link {
-    @apply w-text-14;
+    @apply w-text-14 w-leading-none;
     @include transition(
       border-color $menu-transition-duration ease,
       background-color $menu-transition-duration ease
@@ -26,7 +26,6 @@
     padding-block: 13px;
     padding-inline: 20px;
     font-weight: 400;
-    line-height: 1;
     overflow: hidden;
 
     // Note, font-weights lower than normal,

--- a/client/src/components/Sidebar/menu/SubMenuItem.scss
+++ b/client/src/components/Sidebar/menu/SubMenuItem.scss
@@ -3,14 +3,10 @@
   display: block;
   width: 20px;
   height: 20px;
-  position: absolute;
   // Remove once we drop support for Safari 13.
   // stylelint-disable-next-line property-disallowed-list
-  right: 15px;
   inset-inline-end: 15px;
-  top: 0;
-  bottom: 0;
-  margin: auto 0;
+  margin-inline-start: auto;
 
   @include transition(
     transform $menu-transition-duration ease,

--- a/client/src/components/Sidebar/menu/SubMenuItem.scss
+++ b/client/src/components/Sidebar/menu/SubMenuItem.scss
@@ -20,13 +20,13 @@
   }
 
   .sidebar--slim & {
-    width: 16px;
-    height: 16px;
-    transform: translate3d(13px, 0, 0);
-  }
-
-  .sidebar--slim &--open {
-    transform: translate3d(13px, 0, 0) rotate(180deg);
+    width: 1rem;
+    height: 1rem;
+    position: absolute;
+    // Remove once we drop support for Safari 13.
+    // stylelint-disable-next-line property-disallowed-list
+    right: 0;
+    inset-inline-end: 0;
   }
 }
 
@@ -41,7 +41,7 @@
 
   > h2 {
     // w-min-h-[160px] is to vertically align the title and icon combination to the search input on the left
-    @apply w-min-h-[160px] w-mt-0 w-px-4 w-box-border w-text-center w-text-white w-mb-0 w-inline-flex w-flex-col w-justify-center w-items-center;
+    @apply w-min-h-[220px] w-mt-0 w-px-4 w-box-border w-text-center w-text-white w-mb-0 w-inline-flex w-flex-col w-justify-center w-items-center;
 
     &:before {
       font-size: 4em;
@@ -53,7 +53,7 @@
     }
 
     @at-root .sidebar--slim & {
-      @apply w-mt-[35px];
+      @apply w-min-h-[150px];
     }
   }
 

--- a/client/src/components/Sidebar/menu/SubMenuItem.scss
+++ b/client/src/components/Sidebar/menu/SubMenuItem.scss
@@ -1,8 +1,8 @@
 .sidebar-sub-menu-trigger-icon {
   $root: &;
   display: block;
-  width: 20px;
-  height: 20px;
+  width: 1.25rem;
+  height: 1rem;
   // Remove once we drop support for Safari 13.
   // stylelint-disable-next-line property-disallowed-list
   inset-inline-end: 15px;

--- a/client/src/components/Sidebar/menu/SubMenuItem.scss
+++ b/client/src/components/Sidebar/menu/SubMenuItem.scss
@@ -44,8 +44,8 @@
   }
 
   > h2 {
-    // w-min-h-[160px] and w-mt-[35px] classes are to vertically align the title and icon combination to the search input on the left
-    @apply w-min-h-[160px] w-mt-[45px] w-px-4 w-box-border w-text-center w-text-white w-mb-0 w-inline-flex w-flex-col w-justify-center w-items-center;
+    // w-min-h-[160px] is to vertically align the title and icon combination to the search input on the left
+    @apply w-min-h-[160px] w-mt-0 w-px-4 w-box-border w-text-center w-text-white w-mb-0 w-inline-flex w-flex-col w-justify-center w-items-center;
 
     &:before {
       font-size: 4em;
@@ -57,7 +57,7 @@
     }
 
     @at-root .sidebar--slim & {
-      @apply w-mt-3;
+      @apply w-mt-[35px];
     }
   }
 

--- a/client/src/components/Sidebar/modules/MainMenu.tsx
+++ b/client/src/components/Sidebar/modules/MainMenu.tsx
@@ -219,11 +219,7 @@ export const Menu: React.FunctionComponent<MenuProps> = ({
           (isVisible ? ' sidebar-footer--visible' : '')
         }
       >
-        <Tippy
-          disabled={!slim}
-          content={gettext('Edit your account')}
-          placement="right"
-        >
+        <Tippy disabled={!slim} content={gettext('Account')} placement="right">
           <button
             className="
             sidebar-footer__account

--- a/client/src/components/Sidebar/modules/Search.tsx
+++ b/client/src/components/Sidebar/modules/Search.tsx
@@ -98,7 +98,9 @@ export const SearchInput: React.FunctionComponent<SearchInputProps> = ({
           className={`
             ${slim || !isVisible ? 'w-hidden' : ''}
             !w-pl-[45px]
+            !w-py-[13px]
             !w-subpixel-antialiased
+            padding: 13px 20px;
             !w-absolute
             !w-left-0
             !w-font-normal
@@ -109,6 +111,7 @@ export const SearchInput: React.FunctionComponent<SearchInputProps> = ({
             !w-rounded-none
             !w-text-white/80
             !w-outline-offset-inside
+            !w-leading-none
             placeholder:!w-text-white/80`}
           type="text"
           id="menu-search-q"

--- a/client/src/components/Sidebar/modules/Search.tsx
+++ b/client/src/components/Sidebar/modules/Search.tsx
@@ -97,7 +97,7 @@ export const SearchInput: React.FunctionComponent<SearchInputProps> = ({
         <input
           className={`
             ${slim || !isVisible ? 'w-hidden' : ''}
-            !w-pl-[45px]
+            !w-pl-[55px]
             !w-py-[13px]
             !w-subpixel-antialiased
             padding: 13px 20px;

--- a/client/src/components/Sidebar/modules/Search.tsx
+++ b/client/src/components/Sidebar/modules/Search.tsx
@@ -100,7 +100,6 @@ export const SearchInput: React.FunctionComponent<SearchInputProps> = ({
             !w-pl-[55px]
             !w-py-[13px]
             !w-subpixel-antialiased
-            padding: 13px 20px;
             !w-absolute
             !w-left-0
             !w-font-normal

--- a/client/src/components/Sidebar/modules/WagtailBranding.scss
+++ b/client/src/components/Sidebar/modules/WagtailBranding.scss
@@ -18,7 +18,7 @@
   align-items: center;
   color: #aaa;
   -webkit-font-smoothing: auto;
-  margin: 0 auto 4rem;
+  margin: 4rem auto;
   text-align: center;
   width: 110px;
   height: 110px;
@@ -27,6 +27,10 @@
     padding-top $menu-transition-duration ease;
   box-sizing: border-box;
   border-radius: 100%;
+
+  @include media-breakpoint-up(sm) {
+    margin: 0 auto 4rem;
+  }
 
   // Reduce overall size when in slim mode
   .sidebar--slim & {

--- a/client/src/components/Sidebar/modules/WagtailBranding.scss
+++ b/client/src/components/Sidebar/modules/WagtailBranding.scss
@@ -18,23 +18,20 @@
   align-items: center;
   color: #aaa;
   -webkit-font-smoothing: auto;
-  margin: 4em auto 1.8em;
+  margin: 0 auto 4rem;
   text-align: center;
-  width: 100px;
-  height: 100px;
+  width: 110px;
+  height: 110px;
   transition: transform 150ms cubic-bezier(0.28, 0.15, 0, 2.1),
     width $menu-transition-duration ease, height $menu-transition-duration ease,
     padding-top $menu-transition-duration ease;
   box-sizing: border-box;
   border-radius: 100%;
 
-  @include media-breakpoint-up(sm) {
-    margin: 1.8em auto 2.5em;
-  }
-
   // Reduce overall size when in slim mode
   .sidebar--slim & {
     @include show-focus-outline-inside();
+    margin: 1.125em auto 2.5em;
     width: 60px;
     height: 60px;
   }
@@ -70,8 +67,8 @@
   &__icon-wrapper {
     @apply w-bg-white/15 w-relative w-overflow-hidden hover:w-overflow-visible;
     margin: auto;
-    width: 100px;
-    height: 100px;
+    width: 110px;
+    height: 110px;
     border-radius: 50%;
 
     .sidebar--slim & {

--- a/client/src/components/Sidebar/modules/WagtailBranding.scss
+++ b/client/src/components/Sidebar/modules/WagtailBranding.scss
@@ -1,4 +1,5 @@
 // stylelint-disable declaration-no-important
+$logo-size: 110px;
 
 // Wagging animation
 @keyframes tail-wag {
@@ -20,8 +21,8 @@
   -webkit-font-smoothing: auto;
   margin: 4rem auto;
   text-align: center;
-  width: 110px;
-  height: 110px;
+  width: $logo-size;
+  height: $logo-size;
   transition: transform 150ms cubic-bezier(0.28, 0.15, 0, 2.1),
     width $menu-transition-duration ease, height $menu-transition-duration ease,
     padding-top $menu-transition-duration ease;
@@ -71,8 +72,8 @@
   &__icon-wrapper {
     @apply w-bg-white/15 w-relative w-overflow-hidden hover:w-overflow-visible;
     margin: auto;
-    width: 110px;
-    height: 110px;
+    width: $logo-size;
+    height: $logo-size;
     border-radius: 50%;
 
     .sidebar--slim & {

--- a/client/src/components/Sidebar/modules/WagtailLogo.tsx
+++ b/client/src/components/Sidebar/modules/WagtailLogo.tsx
@@ -14,19 +14,20 @@ const WagtailLogo = ({ className, slim }: WagtailLogoProps) => {
       className={`
          sidebar-wagtail-branding__icon
          !w-overflow-visible
+         w-pr-6
          w-group
          w-text-primary
          w-z-10
          w-absolute
          w-transition-all
          w-duration-150
-         hover:w-scale-75
-         hover:w-rotate-6
+         hover:w-scale-[0.85]
+         hover:w-rotate-[5deg]
          ${className || ''}
          ${
            slim
-             ? 'w-w-[42px] w-h-[51px] w-top-2.5 w-left-[-9px] hover:-w-translate-y-1.5 hover:w-translate-x-1'
-             : 'w-w-[100px] w-h-[125px] w-top-[25px] -w-left-5 hover:w-translate-x-2.5 hover:-w-translate-y-5'
+             ? 'w-w-[58px] w-h-[57px] w-top-2 w-left-[-18px] hover:-w-translate-y-1'
+             : 'w-w-[120px] w-h-[200px] -w-top-1 -w-left-7 hover:w-translate-x-2 hover:-w-translate-y-3'
          }
       `}
       width="430"

--- a/client/src/components/Sidebar/modules/__snapshots__/MainMenu.test.js.snap
+++ b/client/src/components/Sidebar/modules/__snapshots__/MainMenu.test.js.snap
@@ -14,7 +14,7 @@ exports[`Menu should render with the minimum required props 1`] = `
     className="sidebar-footer sidebar-footer--visible"
   >
     <ForwardRef(TippyWrapper)
-      content="Edit your account"
+      content="Account"
       disabled={true}
       placement="right"
     >

--- a/client/src/entrypoints/admin/page-editor.js
+++ b/client/src/entrypoints/admin/page-editor.js
@@ -476,4 +476,6 @@ document.addEventListener('DOMContentLoaded', () => {
       setPanel('');
     });
   }
+
+  setPanel('status');
 });

--- a/client/src/entrypoints/admin/page-editor.js
+++ b/client/src/entrypoints/admin/page-editor.js
@@ -476,6 +476,4 @@ document.addEventListener('DOMContentLoaded', () => {
       setPanel('');
     });
   }
-
-  setPanel('status');
 });


### PR DESCRIPTION
Addresses these points of #8311:

> * [X]  **Visual design** – Collapsed sidebar is wider than intended
> * [X]  **Visual design** – Change “Edit your account” to “Account” tooltip
> * [X]  **Visual design** – Slim side bar on bird hover, make the bird a little big bigger (don’t make it shrink as much)
> * [X] ~**Visual design** – Change the tooltip to the darker indigo~  (discussed with ben and this is no longer necessary)
> * [X]  **Visual design** – Expand the space between the menu items (add 3px padding) - then adjust the flyout menu items spacing too
> * [X]  **Visual design** – Get the labels and icons to align vertically (space between icon and label)
> * [X]  **Visual design** – Make the width 60px
> * [x]  **Visual design** – Make the arrows slightly smaller and closer to the icons on slim view
> * [X]  **Visual design** – Move the bird higher up and slightly smaller, as per the designs
> * [X]  **Animations** – I wonder if the new `|->` icon should flip horizontally rather than roll? (or maybe not animate at all?) The rolling animation feels a little strange as I think the pipe is meant to represent the always vertical menu
> * [X]  **Animations** – The Bird seems to have two hover states (try slowly moving your mouse cursor from top to bottom and you'll see it's wing appears before the hover animation is triggered). Not sure if this is intended behaviour.
> * [X]  **UX** – Unexpected behavior with the search – clicking the "Search" icon submits a search, while all other icons in the sidebar are safe to click (This will expand the menu in slim mode and only have pointer events to submit in expanded mode which should be acceptable as its the submit button for the field?)

> * After RC:
> * [x]  **Accessibility** – Scrollbar isn’t wide enough to be clicked on

### Screenshots
![Screen Shot 2022-04-20 at 4 49 18 PM](https://user-images.githubusercontent.com/25041665/164339647-79841604-1336-4b03-98dd-c0657472828e.png)
![Screen Shot 2022-04-20 at 4 44 34 PM](https://user-images.githubusercontent.com/25041665/164339650-25040386-04d9-46fb-b83d-44cac5f7d857.png)

## Browsers tested on
Chrome 100, Safari 15.2, Firefox 99.0.1
