### PR TITLE
Use css custom properties for new font stacks

### DIFF
--- a/client/scss/elements/_root.scss
+++ b/client/scss/elements/_root.scss
@@ -1,3 +1,5 @@
+@use 'sass:meta';
+
 :root {
   --w-font-sans: #{$font-sans};
   --w-font-mono: #{$font-mono};

--- a/client/scss/settings/_variables.scss
+++ b/client/scss/settings/_variables.scss
@@ -1,4 +1,6 @@
 @use 'sass:color';
+@use 'sass:meta';
+
 // paths
 
 // We can't use absolute paths here, because those are dependent on Django's
@@ -102,7 +104,7 @@ $system-color-button-text: ButtonText;
 // Our fonts are based off of a list of system fallbacks to ensure
 // that the most 'up-to-date' and available system font is used and rendered consistently as possible across browsers.
 
-$font-sans:
+$w-font-sans:
   // iOS Safari, macOS Safari, macOS Firefox
   -apple-system,
   // macOS Chrome
@@ -122,7 +124,7 @@ $font-sans:
   'Apple Color Emoji',
   'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
 
-$font-mono:
+$w-font-mono:
   // iOS Safari, MacOS Safari
   ui-monospace, Menlo, Monaco,
   // Windows
@@ -141,6 +143,9 @@ $font-mono:
   // All the emojis 👋🙂
   'Apple Color Emoji',
   'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+
+$font-sans: var(--w-font-sans, #{meta.inspect($w-font-sans)});
+$font-mono: var(--w-font-mono, #{meta.inspect($w-font-mono)});
 
 // Legacy icon font, to be removed in the near future.
 $font-wagtail-icons: wagtail;

--- a/client/src/tokens/typography.js
+++ b/client/src/tokens/typography.js
@@ -45,8 +45,8 @@ const monoFontStack = [
 ];
 
 const fontFamily = {
-  sans: systemUIFontStack,
-  mono: monoFontStack,
+  sans: `var(--w-font-sans, ${systemUIFontStack.join(', ')})`,
+  mono: `var(--w-font-mono, ${monoFontStack.join(', ')})`,
 };
 
 // Key is equal to the pixel size of the rem value.

--- a/docs/advanced_topics/customisation/admin_templates.rst
+++ b/docs/advanced_topics/customisation/admin_templates.rst
@@ -91,6 +91,22 @@ To replace the welcome message on the dashboard, create a template file ``dashbo
 
     {% block branding_welcome %}Welcome to Frank's Site{% endblock %}
 
+.. _custom_user_interface_fonts:
+
+Custom user interface fonts
+===========================
+
+To customise the font families used in the admin user interface, inject a CSS file using the hook :ref:`insert_global_admin_css` and override the variables within the ``:root`` selector:
+
+
+.. code-block:: text
+
+    :root {
+        --w-font-sans: Papyrus;
+        --w-font-mono: Courier;
+    }
+
+
 .. _custom_user_interface_colors:
 
 Custom user interface colors
@@ -100,7 +116,7 @@ Custom user interface colors
 .. warning::
     The default Wagtail colors conform to the WCAG2.1 AA level color contrast requirements. When customizing the admin colors you should test the contrast using tools like `Axe <https://www.deque.com/axe/browser-extensions/>`_.
 
-To customize the primary color used in the admin user interface, inject a CSS file using the hook :ref:`insert_global_admin_css` and override the variables within the ``:root`` selector:
+To customise the primary color used in the admin user interface, inject a CSS file using the hook :ref:`insert_global_admin_css` and override the variables within the ``:root`` selector:
 
 .. code-block:: text
 

--- a/wagtail/contrib/styleguide/templates/wagtailstyleguide/base.html
+++ b/wagtail/contrib/styleguide/templates/wagtailstyleguide/base.html
@@ -247,6 +247,11 @@
 
             <code>This is an example of code</code>
 
+            <h3>Font families</h3>
+
+            <p class="w-font-sans">Font family sans</p>
+            <p class="w-font-mono">Font family mono</p>
+
         </section>
 
         <section id="help">


### PR DESCRIPTION
| see https://github.com/wagtail/wagtail/pull/8544 instead |
|---|

- add `--w-font-sans` as a custom property, and `w-font-sans` scss variable
- add `--w-font-mono` as a custom property, and `w-font-mono` scss variable
- resolves #8406
- Not sure on scss variable name approach, I have kept `$font-sans` as the SCSS variable that uses the custom property and made the `$w-font-sans` the scss variable that contains the actual font family.
- Happy change this though so that `$w-font-sans` is the custom property usage and maybe `w-font-sans-family` is the family?
- Also, added the tailwind font usages `w-font-sans` and `w-font-mono` to the styleguide so that they are picked up by Tailwind (I could not see that either were actually being picked up as none of those classes were used anywhere in the new code, not sure if I missed something here though.
- [x] Do the tests still pass?[^1]
- [x] Does the code comply with the style guide? 
- [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    - only tested on macOS (Firefox 99, Chrome 100, Safari 15)
- [x] For new features: Has the documentation been updated accordingly?
- [X]  tested documented approach (see below)

<img width="610" alt="Screen Shot 2022-04-21 at 9 45 54 pm" src="https://user-images.githubusercontent.com/1396140/164452681-9da5022e-8a6e-4de9-8e54-ae905e9e33eb.png">

