### PR TITLE
Design review changes - Info panel, Page title field

### DIFF
--- a/client/src/includes/initTooltips.js
+++ b/client/src/includes/initTooltips.js
@@ -58,27 +58,15 @@ const hideTooltipOnBreadcrumbExpand = {
 const rotateToggleIcon = {
   name: 'rotateToggleIcon',
   fn(instance) {
-    const dropdownIcon = instance.reference.querySelector('.icon');
+    const dropdownIcon = instance.reference.querySelector('.icon-arrow-down');
 
-    function setRotate() {
-      if (dropdownIcon) {
-        dropdownIcon.classList.add('w-rotate-180');
-      }
-    }
-
-    function removeRotate() {
-      if (dropdownIcon) {
-        dropdownIcon.classList.remove('w-rotate-180');
-      }
+    if (!dropdownIcon) {
+      return {};
     }
 
     return {
-      onShow() {
-        setRotate();
-      },
-      onHide() {
-        removeRotate();
-      },
+      onShow: () => dropdownIcon.classList.add('w-rotate-180'),
+      onHide: () => dropdownIcon.classList.remove('w-rotate-180'),
     };
   },
 };

--- a/client/src/includes/initTooltips.js
+++ b/client/src/includes/initTooltips.js
@@ -58,9 +58,7 @@ const hideTooltipOnBreadcrumbExpand = {
 const rotateToggleIcon = {
   name: 'rotateToggleIcon',
   fn(instance) {
-    const dropdownIcon = instance.reference.querySelector(
-      '[data-has-toggle] .icon',
-    );
+    const dropdownIcon = instance.reference.querySelector('.icon');
 
     function setRotate() {
       if (dropdownIcon) {

--- a/client/src/includes/initTooltips.js
+++ b/client/src/includes/initTooltips.js
@@ -52,6 +52,39 @@ const hideTooltipOnBreadcrumbExpand = {
   },
 };
 
+/*
+ If the toggle button has a toggle arrow, rotate it when open and closed
+ */
+const rotateToggleIcon = {
+  name: 'rotateToggleIcon',
+  fn(instance) {
+    const dropdownIcon = instance.reference.querySelector(
+      '[data-has-toggle] .icon',
+    );
+
+    function setRotate() {
+      if (dropdownIcon) {
+        dropdownIcon.classList.add('w-rotate-180');
+      }
+    }
+
+    function removeRotate() {
+      if (dropdownIcon) {
+        dropdownIcon.classList.remove('w-rotate-180');
+      }
+    }
+
+    return {
+      onShow() {
+        setRotate();
+      },
+      onHide() {
+        removeRotate();
+      },
+    };
+  },
+};
+
 /**
  Default Tippy Tooltips
  */
@@ -81,14 +114,6 @@ export function initModernDropdown() {
     );
 
     if (toggle) {
-      toggle.addEventListener('click', () => {
-        const dropdownIcon = container.querySelector('.icon');
-
-        if (dropdownIcon) {
-          dropdownIcon.classList.toggle('w-rotate-180');
-        }
-      });
-
       if (content) {
         content.classList.remove('w-hidden');
       }
@@ -99,7 +124,11 @@ export function initModernDropdown() {
         interactive: true,
         theme: 'dropdown',
         placement: 'bottom',
-        plugins: [hideTooltipOnEsc, hideTooltipOnBreadcrumbExpand],
+        plugins: [
+          hideTooltipOnEsc,
+          hideTooltipOnBreadcrumbExpand,
+          rotateToggleIcon,
+        ],
       });
     }
   });

--- a/client/src/includes/initTooltips.js
+++ b/client/src/includes/initTooltips.js
@@ -83,7 +83,10 @@ export function initModernDropdown() {
     if (toggle) {
       toggle.addEventListener('click', () => {
         const dropdownIcon = container.querySelector('.icon');
-        dropdownIcon.classList.toggle('w-rotate-180');
+
+        if (dropdownIcon) {
+          dropdownIcon.classList.toggle('w-rotate-180');
+        }
       });
 
       if (content) {

--- a/client/src/includes/initTooltips.js
+++ b/client/src/includes/initTooltips.js
@@ -30,6 +30,7 @@ const hideTooltipOnBreadcrumbExpand = {
     function onBreadcrumbToggleHover() {
       hide();
     }
+
     const breadcrumbsToggle = document.querySelector(
       '[data-toggle-breadcrumbs]',
     );
@@ -80,7 +81,14 @@ export function initModernDropdown() {
     );
 
     if (toggle) {
-      content.classList.remove('w-hidden');
+      toggle.addEventListener('click', () => {
+        const dropdownIcon = container.querySelector('.icon');
+        dropdownIcon.classList.toggle('w-rotate-180');
+      });
+
+      if (content) {
+        content.classList.remove('w-hidden');
+      }
 
       tippy(toggle, {
         content: content,

--- a/wagtail/admin/static_src/wagtailadmin/scss/layouts/page-editor.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/layouts/page-editor.scss
@@ -158,7 +158,7 @@
       @apply w-text-primary w-absolute w-left-2 w-top-2 hover:w-text-primary-200 w-bg-white w-p-2.5 w-hidden w-transition;
 
       .icon {
-        @apply w-w-5 w-h-5;
+        @apply w-w-4 w-h-4;
       }
     }
 
@@ -470,6 +470,7 @@
   textarea {
     font-size: 2em;
     font-family: $font-sans;
+    font-weight: 800;
   }
 }
 

--- a/wagtail/admin/templates/wagtailadmin/pages/side_panels/includes/page_locale_status.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/side_panels/includes/page_locale_status.html
@@ -24,7 +24,7 @@
             {% include 'wagtailadmin/pages/side_panels/includes/side_panel_button.html' with attr='data-button-with-dropdown-toggle' text=action_text dropdown=True %}
             {% icon name='arrow-down' class_name='w-w-5 w-h-5 w-text-teal-200 w-transition motion-reduce:w-transition-none' %}
 
-            <div class="w-hidden w-text-white w-flex w-flex-col w-justify-start w-py-2 w-transition" data-button-with-dropdown-content>
+            <div class="w-hidden w-text-white w-flex w-flex-col w-justify-start w-py-2" data-button-with-dropdown-content>
                 {% for translation in translations %}
                     <a href="{{ translation.url }}"
                         lang="{{ translation.locale.language_code }}"

--- a/wagtail/admin/templates/wagtailadmin/pages/side_panels/includes/page_locale_status.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/side_panels/includes/page_locale_status.html
@@ -21,7 +21,7 @@
     {% if translations %}
         <div data-button-with-dropdown>
             {% trans 'Switch locales' as action_text %}
-            {% include 'wagtailadmin/pages/side_panels/includes/side_panel_button.html' with attr='data-button-with-dropdown-toggle' text=action_text has_toggle=True %}
+            {% include 'wagtailadmin/pages/side_panels/includes/side_panel_button.html' with attr='data-button-with-dropdown-toggle' text=action_text has_toggle_icon=True %}
 
             <div class="w-hidden w-text-white w-flex w-flex-col w-justify-start w-py-2" data-button-with-dropdown-content>
                 {% for translation in translations %}

--- a/wagtail/admin/templates/wagtailadmin/pages/side_panels/includes/page_locale_status.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/side_panels/includes/page_locale_status.html
@@ -21,7 +21,7 @@
     {% if translations %}
         <div class="w-inline-flex w-justify-center" data-button-with-dropdown>
             {% trans 'Switch locales' as action_text %}
-            {% include 'wagtailadmin/pages/side_panels/includes/side_panel_button.html' with attr='data-button-with-dropdown-toggle' text=action_text dropdown=True %}
+            {% include 'wagtailadmin/pages/side_panels/includes/side_panel_button.html' with attr='data-button-with-dropdown-toggle' text=action_text %}
             {% icon name='arrow-down' class_name='w-w-5 w-h-5 w-text-teal-200 w-transition motion-reduce:w-transition-none' %}
 
             <div class="w-hidden w-text-white w-flex w-flex-col w-justify-start w-py-2" data-button-with-dropdown-content>

--- a/wagtail/admin/templates/wagtailadmin/pages/side_panels/includes/page_locale_status.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/side_panels/includes/page_locale_status.html
@@ -19,10 +19,9 @@
 
 {% block action %}
     {% if translations %}
-        <div class="w-inline-flex w-justify-center" data-button-with-dropdown>
+        <div data-button-with-dropdown>
             {% trans 'Switch locales' as action_text %}
-            {% include 'wagtailadmin/pages/side_panels/includes/side_panel_button.html' with attr='data-button-with-dropdown-toggle' text=action_text %}
-            {% icon name='arrow-down' class_name='w-w-5 w-h-5 w-text-teal-200 w-transition motion-reduce:w-transition-none' %}
+            {% include 'wagtailadmin/pages/side_panels/includes/side_panel_button.html' with attr='data-button-with-dropdown-toggle' text=action_text has_toggle=True %}
 
             <div class="w-hidden w-text-white w-flex w-flex-col w-justify-start w-py-2" data-button-with-dropdown-content>
                 {% for translation in translations %}

--- a/wagtail/admin/templates/wagtailadmin/pages/side_panels/includes/page_locale_status.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/side_panels/includes/page_locale_status.html
@@ -21,7 +21,7 @@
     {% if translations %}
         <div data-button-with-dropdown>
             {% trans 'Switch locales' as action_text %}
-            {% include 'wagtailadmin/pages/side_panels/includes/side_panel_button.html' with attr='data-button-with-dropdown-toggle' text=action_text has_toggle_icon=True %}
+            {% include 'wagtailadmin/pages/side_panels/includes/side_panel_button.html' with text=action_text has_toggle=True %}
 
             <div class="w-hidden w-text-white w-flex w-flex-col w-justify-start w-py-2" data-button-with-dropdown-content>
                 {% for translation in translations %}

--- a/wagtail/admin/templates/wagtailadmin/pages/side_panels/includes/page_locale_status.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/side_panels/includes/page_locale_status.html
@@ -19,11 +19,12 @@
 
 {% block action %}
     {% if translations %}
-        <div data-button-with-dropdown>
+        <div class="w-inline-flex w-justify-center" data-button-with-dropdown>
             {% trans 'Switch locales' as action_text %}
-            {% include 'wagtailadmin/pages/side_panels/includes/side_panel_button.html' with attr='data-button-with-dropdown-toggle' text=action_text %}
+            {% include 'wagtailadmin/pages/side_panels/includes/side_panel_button.html' with attr='data-button-with-dropdown-toggle' text=action_text dropdown=True %}
+            {% icon name='arrow-down' class_name='w-w-5 w-h-5 w-text-teal-200 w-transition motion-reduce:w-transition-none' %}
 
-            <div class="w-hidden w-text-white w-flex w-flex-col w-justify-start w-py-2" data-button-with-dropdown-content>
+            <div class="w-hidden w-text-white w-flex w-flex-col w-justify-start w-py-2 w-transition" data-button-with-dropdown-content>
                 {% for translation in translations %}
                     <a href="{{ translation.url }}"
                         lang="{{ translation.locale.language_code }}"

--- a/wagtail/admin/templates/wagtailadmin/pages/side_panels/includes/page_privacy_status.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/side_panels/includes/page_privacy_status.html
@@ -25,7 +25,7 @@
 {% block action %}
     {% page_permissions page as page_perms %}
     {% if page.id and page_perms.can_set_view_restrictions %}
-        {% trans 'Set privacy' as set_privacy_text %}
+        {% trans 'Change privacy' as set_privacy_text %}
         {% url 'wagtailadmin_pages:set_privacy' page.id as privacy_url %}
         {% include 'wagtailadmin/pages/side_panels/includes/side_panel_button.html' with attr='data-action-set-privacy' data_url=privacy_url text=set_privacy_text %}
     {% else %}

--- a/wagtail/admin/templates/wagtailadmin/pages/side_panels/includes/page_privacy_status.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/side_panels/includes/page_privacy_status.html
@@ -25,7 +25,7 @@
 {% block action %}
     {% page_permissions page as page_perms %}
     {% if page.id and page_perms.can_set_view_restrictions %}
-        {% trans 'Change privacy' as set_privacy_text %}
+        {% trans 'Set privacy' as set_privacy_text %}
         {% url 'wagtailadmin_pages:set_privacy' page.id as privacy_url %}
         {% include 'wagtailadmin/pages/side_panels/includes/side_panel_button.html' with attr='data-action-set-privacy' data_url=privacy_url text=set_privacy_text %}
     {% else %}

--- a/wagtail/admin/templates/wagtailadmin/pages/side_panels/includes/side_panel_button.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/side_panels/includes/side_panel_button.html
@@ -5,12 +5,12 @@
     text - The text that shows up on the button
     classes - custom css classes for styling or js
     data_url - A url for javascript to use
-    has_toggle_icon - Show toggle icon on the button
+    has_toggle - Show toggle icon on the button
     attr - custom attributes for the button
 {% endcomment %}
-<button type="button" class="{{ classes }} w-bg-transparent w-text-14 w-p-0 w-text-teal-200 hover:w-underline w-inline-flex w-justify-center" {% if data_url %}data-url="{{ data_url }}" {% endif %} {% if has_toggle_icon %}data-has-toggle {% endif %} {{ attr }}>
+<button type="button" class="{{ classes }} w-bg-transparent w-text-14 w-p-0 w-text-teal-200 hover:w-underline w-inline-flex w-justify-center" {% if data_url %}data-url="{{ data_url }}" {% endif %} {% if has_toggle %}data-button-with-dropdown-toggle {% endif %} {{ attr }}>
     {{ text }}
-    {% if has_toggle_icon %}
+    {% if has_toggle %}
         {% icon name='arrow-down' class_name='w-w-4 w-h-4 w-text-teal-200 w-transition motion-reduce:w-transition-none' %}
     {% endif %}
 </button>

--- a/wagtail/admin/templates/wagtailadmin/pages/side_panels/includes/side_panel_button.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/side_panels/includes/side_panel_button.html
@@ -10,7 +10,7 @@
 {% endcomment %}
 <button type="button" class="{{ classes }} w-bg-transparent w-text-14 w-p-0 w-text-teal-200 hover:w-underline w-inline-flex w-justify-center" {% if data_url %}data-url="{{ data_url }}" {% endif %} {% if has_toggle_icon %}data-has-toggle {% endif %} {{ attr }}>
     {{ text }}
-    {% if has_toggle %}
+    {% if has_toggle_icon %}
         {% icon name='arrow-down' class_name='w-w-4 w-h-4 w-text-teal-200 w-transition motion-reduce:w-transition-none' %}
     {% endif %}
 </button>

--- a/wagtail/admin/templates/wagtailadmin/pages/side_panels/includes/side_panel_button.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/side_panels/includes/side_panel_button.html
@@ -1,9 +1,16 @@
+{% load wagtailadmin_tags %}
 {% comment %}
     Variables this template accepts:
 
     text - The text that shows up on the button
     classes - custom css classes for styling or js
     data_url - A url for javascript to use
+    has_toggle - Show toggle icon on the button
     attr - custom attributes for the button
 {% endcomment %}
-<button type="button" class="{{ classes }} w-bg-transparent w-text-14 w-p-0 w-text-teal-200 hover:w-underline" {% if data_url %}data-url="{{ data_url }}"{% endif %} {{ attr }}>{{ text }}</button>
+<button type="button" class="{{ classes }} w-bg-transparent w-text-14 w-p-0 w-text-teal-200 hover:w-underline w-inline-flex w-justify-center" {% if data_url %}data-url="{{ data_url }}" {% endif %} {% if has_toggle %}data-has-toggle {% endif %} {{ attr }}>
+    {{ text }}
+    {% if has_toggle %}
+        {% icon name='arrow-down' class_name='w-w-4 w-h-4 w-text-teal-200 w-transition motion-reduce:w-transition-none' %}
+    {% endif %}
+</button>

--- a/wagtail/admin/templates/wagtailadmin/pages/side_panels/includes/side_panel_button.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/side_panels/includes/side_panel_button.html
@@ -8,7 +8,7 @@
     has_toggle - Show toggle icon on the button
     attr - custom attributes for the button
 {% endcomment %}
-<button type="button" class="{{ classes }} w-bg-transparent w-text-14 w-p-0 w-text-teal-200 hover:w-underline w-inline-flex w-justify-center" {% if data_url %}data-url="{{ data_url }}" {% endif %} {% if has_toggle %}data-button-with-dropdown-toggle {% endif %} {{ attr }}>
+<button type="button" class="{{ classes }} w-bg-transparent w-text-14 w-p-0 w-text-teal-200 hover:w-underline w-inline-flex w-justify-center" {% if data_url %}data-url="{{ data_url }}" {% endif %}{% if has_toggle %}data-button-with-dropdown-toggle {% endif %} {{ attr }}>
     {{ text }}
     {% if has_toggle %}
         {% icon name='arrow-down' class_name='w-w-4 w-h-4 w-text-teal-200 w-transition motion-reduce:w-transition-none' %}

--- a/wagtail/admin/templates/wagtailadmin/pages/side_panels/includes/side_panel_button.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/side_panels/includes/side_panel_button.html
@@ -5,10 +5,10 @@
     text - The text that shows up on the button
     classes - custom css classes for styling or js
     data_url - A url for javascript to use
-    has_toggle - Show toggle icon on the button
+    has_toggle_icon - Show toggle icon on the button
     attr - custom attributes for the button
 {% endcomment %}
-<button type="button" class="{{ classes }} w-bg-transparent w-text-14 w-p-0 w-text-teal-200 hover:w-underline w-inline-flex w-justify-center" {% if data_url %}data-url="{{ data_url }}" {% endif %} {% if has_toggle %}data-has-toggle {% endif %} {{ attr }}>
+<button type="button" class="{{ classes }} w-bg-transparent w-text-14 w-p-0 w-text-teal-200 hover:w-underline w-inline-flex w-justify-center" {% if data_url %}data-url="{{ data_url }}" {% endif %} {% if has_toggle_icon %}data-has-toggle {% endif %} {{ attr }}>
     {{ text }}
     {% if has_toggle %}
         {% icon name='arrow-down' class_name='w-w-4 w-h-4 w-text-teal-200 w-transition motion-reduce:w-transition-none' %}

--- a/wagtail/admin/templates/wagtailadmin/pages/side_panels/includes/side_panel_button.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/side_panels/includes/side_panel_button.html
@@ -8,7 +8,7 @@
     has_toggle - Show toggle icon on the button
     attr - custom attributes for the button
 {% endcomment %}
-<button type="button" class="{{ classes }} w-bg-transparent w-text-14 w-p-0 w-text-teal-200 hover:w-underline w-inline-flex w-justify-center" {% if data_url %}data-url="{{ data_url }}" {% endif %}{% if has_toggle %}data-button-with-dropdown-toggle {% endif %} {{ attr }}>
+<button type="button" class="{{ classes }} w-bg-transparent w-text-14 w-p-0 w-text-teal-200 hover:w-underline w-inline-flex w-justify-center" {% if data_url %}data-url="{{ data_url }}" {% endif %}{% if has_toggle %}data-button-with-dropdown-toggle {% endif %}{{ attr }}>
     {{ text }}
     {% if has_toggle %}
         {% icon name='arrow-down' class_name='w-w-4 w-h-4 w-text-teal-200 w-transition motion-reduce:w-transition-none' %}


### PR DESCRIPTION
Addresses these parts of #8398

## Info panel

- [X] Add a down arrow to right of Switch Locales
- [X] Change the wording “Set Privacy” to “Change Privacy”
- [X] Make the close icon on the info panel the same size as the close icon on the slim sidebar

![Screen Shot 2022-04-21 at 8 15 24 AM](https://user-images.githubusercontent.com/25041665/164477720-7d09d8a5-f7a0-4495-81e9-a7744dcac697.png)


## Title field 
- [x] Make text font weight 800
<img width="654" alt="Screen Shot 2022-04-21 at 12 59 59 AM" src="https://user-images.githubusercontent.com/25041665/164476595-4ff83d75-767d-459d-a211-f6498c3447cd.png">

**Checklist**
- [X] Do the tests still pass?[^1]
- [X] Does the code comply with the style guide? 
    - [X] Run `make lint` from the Wagtail root. 
- [X] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    - [X] **Please list the exact browser and operating system versions you tested**:


### Browsers tested on 
Mac: Chrome 100, Safari 15.2, Firefox 99
Windows: Chrome 98