### PR TITLE
make new font stacks available as css custom properties (3.0)

### DIFF
--- a/client/scss/elements/_root.scss
+++ b/client/scss/elements/_root.scss
@@ -1,8 +1,6 @@
-@use 'sass:meta';
-
 :root {
-  --w-font-sans: #{meta.inspect($font-sans)};
-  --w-font-mono: #{meta.inspect($font-mono)};
+  --w-font-sans: #{$font-sans};
+  --w-font-mono: #{$font-mono};
 
   @include define-color('color-primary', #007d7e);
   @include define-color(

--- a/client/scss/elements/_root.scss
+++ b/client/scss/elements/_root.scss
@@ -1,4 +1,9 @@
+@use 'sass:meta';
+
 :root {
+  --w-font-sans: #{meta.inspect($font-sans)};
+  --w-font-mono: #{meta.inspect($font-mono)};
+
   @include define-color('color-primary', #007d7e);
   @include define-color(
     'color-primary-darker',


### PR DESCRIPTION
**This is a request to merge into 3.0 branch - CI does not seem to like it.**

This is a much smaller scoped version of https://github.com/wagtail/wagtail/pull/8409 which relates to https://github.com/wagtail/wagtail/issues/8406 

The goal here is to NOT change any of our existing font usage, but rather make the added font stacks available as CSS custom properties for anyone that needs to use them in their own customisations.

For example - you may have a custom datetime picker widget that tests the font to something else and you want that to use Wagtail's `font-sans` font stack, you do not have to copy/paste the entire set but rather just use `font-family: --var(w-font-sans);`

I have not documented this, as the current documentation we have for custom properties relates to overriding them to change Wagtail's styles, however that is too large a scope for 3.0 changes and instead  is covered in https://github.com/wagtail/wagtail/pull/8409

---
- [x] Do the tests still pass?
- [x] Does the code comply with the style guide? 
- [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    - only tested on macOS (Firefox 99, Chrome 100, Safari 15)
- [ ] For new features: Has the documentation been updated accordingly? **intentionally undocumented**

**Example of this working**
In the screenshot below I changed the font family to use our `w-font-mono` stack for some arbitrary element.

<img width="1349" alt="Screen Shot 2022-04-22 at 7 31 52 am" src="https://user-images.githubusercontent.com/1396140/164556128-4f779a40-5103-4151-ab36-5013af54c77c.png">


