### PR TITLE
Fix crash when accessing Snippet delete and history views with i18n enabled

### DIFF
--- a/wagtail/admin/views/generic/mixins.py
+++ b/wagtail/admin/views/generic/mixins.py
@@ -78,7 +78,7 @@ class LocaleMixin:
 
     def get_locale(self):
         i18n_enabled = getattr(settings, "WAGTAIL_I18N_ENABLED", False)
-        if hasattr(self, "model"):
+        if hasattr(self, "model") and self.model:
             i18n_enabled = i18n_enabled and issubclass(self.model, TranslatableMixin)
 
         if not i18n_enabled:

--- a/wagtail/snippets/tests.py
+++ b/wagtail/snippets/tests.py
@@ -1046,6 +1046,20 @@ class TestSnippetDelete(TestCase, WagtailTestUtils):
         )
         self.assertEqual(response.status_code, 200)
 
+    @override_settings(WAGTAIL_I18N_ENABLED=True)
+    def test_delete_get_with_i18n_enabled(self):
+        response = self.client.get(
+            reverse(
+                "wagtailsnippets:delete",
+                args=(
+                    "tests",
+                    "advert",
+                    quote(self.test_snippet.pk),
+                ),
+            )
+        )
+        self.assertEqual(response.status_code, 200)
+
     def test_delete_post_with_limited_permissions(self):
         self.user.is_superuser = False
         self.user.user_permissions.add(
@@ -1388,6 +1402,11 @@ class TestSnippetHistory(TestCase, WagtailTestUtils):
             response,
             '<div class="human-readable-date" title="Sept. 30, 2021, 10:01 a.m.">',
         )
+
+    @override_settings(WAGTAIL_I18N_ENABLED=True)
+    def test_get_with_i18n_enabled(self):
+        response = self.get()
+        self.assertEqual(response.status_code, 200)
 
 
 class TestSnippetChoose(TestCase, WagtailTestUtils):

--- a/wagtail/snippets/views/snippets.py
+++ b/wagtail/snippets/views/snippets.py
@@ -446,11 +446,11 @@ class Delete(DeleteView):
         return self.run_hook("after_delete_snippet", self.request, self.objects)
 
     def setup(self, request, *args, app_label, model_name, pk=None, **kwargs):
-        super().setup(request, *args, **kwargs)
         self.app_label = app_label
         self.model_name = model_name
         self.pk = pk
         self.model = self._get_model()
+        super().setup(request, *args, **kwargs)
         self.objects = self.get_objects()
 
     def _get_model(self):

--- a/wagtail/snippets/views/snippets.py
+++ b/wagtail/snippets/views/snippets.py
@@ -594,13 +594,12 @@ class HistoryView(IndexView):
         DateColumn("timestamp", label=gettext_lazy("Date")),
     ]
 
-    def dispatch(self, request, app_label, model_name, pk):
+    def setup(self, request, *args, app_label, model_name, pk, **kwargs):
         self.app_label = app_label
         self.model_name = model_name
         self.model = get_snippet_model_from_url_params(app_label, model_name)
         self.object = get_object_or_404(self.model, pk=unquote(pk))
-
-        return super().dispatch(request)
+        super().setup(request, *args, **kwargs)
 
     def get_page_subtitle(self):
         return str(self.object)


### PR DESCRIPTION
Accessing the Snippet delete and history views will crash if the `WAGTAIL_I18N_ENABLED` is set to `True`. The generic classes for these views now extend `LocaleMixin` as of #8361. The crash happens because these views do not have the `self.model` attribute set correctly *before* calling `super().setup()`. It's set to `None` and `issubclass(None, TranslatableMixin)` throws a `TypeError`.

https://github.com/wagtail/wagtail/blob/19c259d107c2d49183bb04f0b7ce711df94f4a26/wagtail/admin/views/generic/mixins.py#L82

<!--
Thanks for contributing to Wagtail! 🎉

Before submitting, please review the [contributor guidelines](https://docs.wagtail.org/en/latest/contributing/index.html).
-->

_Please check the following:_

- [x] Do the tests still pass?[^1]
- [x] Does the code comply with the style guide? 
    - [x] Run `make lint` from the Wagtail root. 
- [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
- [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    - [ ] **Please list the exact browser and operating system versions you tested**:
    - [ ] **Please list which assistive technologies [^3] you tested**: 
- [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**. 

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets) 
