### PR TITLE
Sidebar animation fixes

### DIFF
--- a/client/scss/components/_grid.legacy.scss
+++ b/client/scss/components/_grid.legacy.scss
@@ -2,9 +2,9 @@
   @include clearfix();
   height: 100vh;
   transition: transform 0.2s ease;
+  @apply w-transition-sidebar w-duration-150 w-ease-linear;
 
   @include media-breakpoint-up(sm) {
-    @include transition(padding-inline-start $menu-transition-duration ease);
     transform: none;
     padding-inline-start: $menu-width;
 

--- a/client/scss/components/_grid.legacy.scss
+++ b/client/scss/components/_grid.legacy.scss
@@ -2,7 +2,7 @@
   @include clearfix();
   height: 100vh;
   transition: transform 0.2s ease;
-  @apply w-transition-sidebar w-duration-150 w-ease-linear;
+  @apply w-transition-sidebar;
 
   @include media-breakpoint-up(sm) {
     transform: none;

--- a/client/scss/components/_grid.legacy.scss
+++ b/client/scss/components/_grid.legacy.scss
@@ -1,8 +1,7 @@
 .wrapper {
   @include clearfix();
-  height: 100vh;
-  transition: transform 0.2s ease;
   @apply w-transition-sidebar;
+  height: 100vh;
 
   @include media-breakpoint-up(sm) {
     transform: none;

--- a/client/src/components/Sidebar/Sidebar.scss
+++ b/client/src/components/Sidebar/Sidebar.scss
@@ -49,14 +49,6 @@
   left: 0;
   inset-inline-start: 0;
 
-  //@include transition(
-  //  width $menu-transition-duration ease,
-  //  // Remove once we drop support for Safari 13.
-  //  // stylelint-disable-next-line property-disallowed-list
-  //  left $menu-transition-duration ease,
-  //  inset-inline-start $menu-transition-duration ease
-  //);
-
   @media (forced-colors: $media-forced-colours) {
     border-inline-end: 1px solid transparent;
   }
@@ -86,7 +78,7 @@
 
   &__inner {
     // On medium, make it possible for the nav links to scroll.
-    @apply w-h-full w-bg-primary w-flex w-flex-col w-flex-nowrap w-relative;
+    @apply w-h-full w-bg-primary w-flex w-flex-col w-flex-nowrap;
   }
 
   &__collapse-toggle {

--- a/client/src/components/Sidebar/Sidebar.scss
+++ b/client/src/components/Sidebar/Sidebar.scss
@@ -79,6 +79,11 @@
     inset-inline-start: -$menu-width;
   }
 
+  // When sidebar is completely closed and animations have finished
+  &--closed {
+    display: none;
+  }
+
   &__inner {
     // On medium, make it possible for the nav links to scroll.
     @apply w-h-full w-bg-primary w-flex w-flex-col w-flex-nowrap w-relative;

--- a/client/src/components/Sidebar/Sidebar.scss
+++ b/client/src/components/Sidebar/Sidebar.scss
@@ -42,7 +42,7 @@
 }
 
 .sidebar {
-  @apply w-fixed w-flex w-flex-col w-h-full w-bg-primary w-z-[300] w-transition-sidebar w-duration-150 w-ease-linear;
+  @apply w-fixed w-flex w-flex-col w-h-full w-bg-primary w-z-[300] w-transition-sidebar;
   width: $menu-width;
   // Remove once we drop support for Safari 13.
   // stylelint-disable-next-line property-disallowed-list

--- a/client/src/components/Sidebar/Sidebar.scss
+++ b/client/src/components/Sidebar/Sidebar.scss
@@ -42,20 +42,20 @@
 }
 
 .sidebar {
-  @apply w-fixed w-flex w-flex-col w-h-full w-bg-primary w-z-[300];
+  @apply w-fixed w-flex w-flex-col w-h-full w-bg-primary w-z-[300] w-transition-sidebar w-duration-150 w-ease-linear;
   width: $menu-width;
   // Remove once we drop support for Safari 13.
   // stylelint-disable-next-line property-disallowed-list
   left: 0;
   inset-inline-start: 0;
 
-  @include transition(
-    width $menu-transition-duration ease,
-    // Remove once we drop support for Safari 13.
-    // stylelint-disable-next-line property-disallowed-list
-    left $menu-transition-duration ease,
-    inset-inline-start $menu-transition-duration ease
-  );
+  //@include transition(
+  //  width $menu-transition-duration ease,
+  //  // Remove once we drop support for Safari 13.
+  //  // stylelint-disable-next-line property-disallowed-list
+  //  left $menu-transition-duration ease,
+  //  inset-inline-start $menu-transition-duration ease
+  //);
 
   @media (forced-colors: $media-forced-colours) {
     border-inline-end: 1px solid transparent;
@@ -81,7 +81,7 @@
 
   &__inner {
     // On medium, make it possible for the nav links to scroll.
-    @apply w-h-full w-bg-primary w-flex w-flex-col w-flex-nowrap;
+    @apply w-h-full w-bg-primary w-flex w-flex-col w-flex-nowrap w-relative;
   }
 
   &__collapse-toggle {

--- a/client/src/components/Sidebar/Sidebar.scss
+++ b/client/src/components/Sidebar/Sidebar.scss
@@ -41,7 +41,8 @@
   }
 }
 
-.sidebar {
+.sidebar,
+.sidebar-loading {
   @apply w-fixed w-flex w-flex-col w-h-full w-bg-primary w-z-[300] w-transition-sidebar;
   width: $menu-width;
   // Remove once we drop support for Safari 13.
@@ -90,6 +91,10 @@
   &--mobile &__collapse-toggle {
     display: none;
   }
+}
+
+.sidebar-collapsed .sidebar-loading {
+  width: $menu-width-slim;
 }
 
 // This is a separate component as it needs to display in the header

--- a/client/src/components/Sidebar/Sidebar.tsx
+++ b/client/src/components/Sidebar/Sidebar.tsx
@@ -14,7 +14,6 @@ export interface ModuleRenderContext {
   onHideMobile: () => void;
   onSearchClick: () => void;
   currentPath: string;
-
   navigate(url: string): Promise<void>;
 }
 
@@ -26,9 +25,7 @@ export interface SidebarProps {
   modules: ModuleDefinition[];
   currentPath: string;
   collapsedOnLoad: boolean;
-
   navigate(url: string): Promise<void>;
-
   onExpandCollapse?(collapsed: boolean);
 }
 

--- a/client/src/components/Sidebar/Sidebar.tsx
+++ b/client/src/components/Sidebar/Sidebar.tsx
@@ -63,28 +63,29 @@ export const Sidebar: React.FunctionComponent<SidebarProps> = ({
   const checkWindowSizeIsMobile = () => window.innerWidth < 800;
   const [isMobile, setIsMobile] = React.useState(checkWindowSizeIsMobile());
   React.useEffect(() => {
-    // wait for animation to finish then hide menu from screen readers as well.
-    const finishHidingMenu = setTimeout(() => {
-      setClosedOnMobile(true);
-    }, SIDEBAR_TRANSITION_DURATION);
-
-    function handleResize(hideMenuCallback) {
+    function handleResize() {
       if (checkWindowSizeIsMobile()) {
         setIsMobile(true);
+        return null;
       } else {
         setIsMobile(false);
 
         // Close the menu and animate out as this state is not used in desktop
         setVisibleOnMobile(false);
-        hideMenuCallback();
+        // wait for animation to finish then hide menu from screen readers as well.
+        return setTimeout(() => {
+          setClosedOnMobile(true);
+        }, SIDEBAR_TRANSITION_DURATION);
       }
     }
 
     window.addEventListener('resize', handleResize);
-    handleResize(finishHidingMenu);
+    const closeTimeout = handleResize();
     return () => {
       window.removeEventListener('resize', handleResize);
-      clearTimeout(finishHidingMenu);
+      if (closeTimeout) {
+        clearTimeout(closeTimeout);
+      }
     };
   }, []);
 

--- a/client/src/components/Sidebar/Sidebar.tsx
+++ b/client/src/components/Sidebar/Sidebar.tsx
@@ -10,7 +10,6 @@ export interface ModuleRenderContext {
   key: number;
   slim: boolean;
   expandingOrCollapsing: boolean;
-  onAccountExpand: () => void;
   onHideMobile: () => void;
   onSearchClick: () => void;
   currentPath: string;
@@ -52,7 +51,7 @@ export const Sidebar: React.FunctionComponent<SidebarProps> = ({
   // 'visibleOnMobile' indicates whether the sidebar is currently visible on mobile
   // On mobile, the sidebar is completely hidden by default and must be opened manually
   const [visibleOnMobile, setVisibleOnMobile] = React.useState(false);
-  // 'closedOnMobile' is used to set the menu to display none so it can no longer interacted with when its hidden
+  // 'closedOnMobile' is used to set the menu to display none so it can no longer be interacted with by keyboard when its hidden
   const [closedOnMobile, setClosedOnMobile] = React.useState(true);
 
   // Tracks whether the screen is below 800 pixels. In this state, the menu is completely hidden.
@@ -87,13 +86,12 @@ export const Sidebar: React.FunctionComponent<SidebarProps> = ({
   }, []);
 
   // Whether or not to display the menu with slim layout.
-  // Separate from 'collapsed' as the menu can still be displayed with an expanded
-  // layout while in 'collapsed' mode if the user is 'peeking' into it (see above)
   const slim = collapsed && !isMobile;
 
   // 'expandingOrCollapsing' is set to true whilst the the menu is transitioning between slim and expanded layouts
   const [expandingOrCollapsing, setExpandingOrCollapsing] =
     React.useState(false);
+
   React.useEffect(() => {
     setExpandingOrCollapsing(true);
     const finishTimeout = setTimeout(() => {
@@ -148,12 +146,6 @@ export const Sidebar: React.FunctionComponent<SidebarProps> = ({
     }
   };
 
-  const onAccountExpand = () => {
-    if (slim) {
-      onClickCollapseToggle();
-    }
-  };
-
   React.useEffect(() => {
     // wait for animation to finish then hide menu from screen readers as well.
     const finishHidingMenu = setTimeout(() => {
@@ -182,7 +174,6 @@ export const Sidebar: React.FunctionComponent<SidebarProps> = ({
       key: index,
       slim,
       expandingOrCollapsing,
-      onAccountExpand,
       onHideMobile,
       onSearchClick,
       currentPath,

--- a/client/src/components/Sidebar/Sidebar.tsx
+++ b/client/src/components/Sidebar/Sidebar.tsx
@@ -68,7 +68,7 @@ export const Sidebar: React.FunctionComponent<SidebarProps> = ({
       setClosedOnMobile(true);
     }, SIDEBAR_TRANSITION_DURATION);
 
-    function handleResize(menuHideCallback) {
+    function handleResize(hideMenuCallback) {
       if (checkWindowSizeIsMobile()) {
         setIsMobile(true);
       } else {
@@ -76,7 +76,7 @@ export const Sidebar: React.FunctionComponent<SidebarProps> = ({
 
         // Close the menu and animate out as this state is not used in desktop
         setVisibleOnMobile(false);
-        menuHideCallback();
+        hideMenuCallback();
       }
     }
 

--- a/client/src/components/Sidebar/SidebarPanel.scss
+++ b/client/src/components/Sidebar/SidebarPanel.scss
@@ -1,5 +1,5 @@
 .sidebar-panel {
-  @apply w-transition w-duration-150;
+  @apply w-transition-sidebar w-duration-150 w-ease-linear;
   // With CSS variable allows panels with different widths to animate properly
   --width: #{$menu-width};
 

--- a/client/src/components/Sidebar/SidebarPanel.scss
+++ b/client/src/components/Sidebar/SidebarPanel.scss
@@ -1,5 +1,5 @@
 .sidebar-panel {
-  @apply w-transition-sidebar w-duration-150 w-ease-linear;
+  @apply w-transition-sidebar;
   // With CSS variable allows panels with different widths to animate properly
   --width: #{$menu-width};
 

--- a/client/src/components/Sidebar/__snapshots__/Sidebar.test.js.snap
+++ b/client/src/components/Sidebar/__snapshots__/Sidebar.test.js.snap
@@ -2,6 +2,17 @@
 
 exports[`Sidebar should render with the minimum required props 1`] = `
 <Fragment>
+  <button
+    aria-expanded="false"
+    aria-label="Toggle sidebar"
+    className="button sidebar-nav-toggle"
+    onClick={[Function]}
+    type="button"
+  >
+    <Icon
+      name="bars"
+    />
+  </button>
   <div
     className="sidebar"
   >
@@ -36,16 +47,5 @@ exports[`Sidebar should render with the minimum required props 1`] = `
       </div>
     </div>
   </div>
-  <button
-    aria-expanded="false"
-    aria-label="Toggle sidebar"
-    className="button sidebar-nav-toggle"
-    onClick={[Function]}
-    type="button"
-  >
-    <Icon
-      name="bars"
-    />
-  </button>
 </Fragment>
 `;

--- a/client/src/components/Sidebar/index.tsx
+++ b/client/src/components/Sidebar/index.tsx
@@ -52,6 +52,9 @@ export function initSidebar() {
       element,
       () => {
         document.body.classList.add('ready');
+        document
+          .querySelector('[data-wagtail-sidebar]')
+          ?.classList.remove('sidebar-loading');
       },
     );
   }

--- a/client/src/components/Sidebar/menu/MenuItem.scss
+++ b/client/src/components/Sidebar/menu/MenuItem.scss
@@ -116,7 +116,6 @@
 
     .sidebar-menu-item__link {
       justify-content: flex-start;
-      padding: 20px;
     }
   }
 }

--- a/client/src/components/Sidebar/menu/MenuItem.scss
+++ b/client/src/components/Sidebar/menu/MenuItem.scss
@@ -24,7 +24,7 @@
     background: transparent;
     text-align: start;
     color: $color-menu-text;
-    padding: 13px 20px;
+    padding: 13px 15px 13px 20px;
     font-weight: 400;
     overflow: hidden;
 
@@ -85,7 +85,7 @@
 
 .menuitem-label {
   @include transition(opacity $menu-transition-duration ease);
-  margin-inline-start: 1rem;
+  margin-inline-start: 0.875rem;
   line-height: 1;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/client/src/components/Sidebar/menu/SubMenuItem.scss
+++ b/client/src/components/Sidebar/menu/SubMenuItem.scss
@@ -31,7 +31,7 @@
 }
 
 .sidebar-sub-menu-panel {
-  @apply w-flex w-flex-col w-bg-primary-200 w-h-screen w-transition-sidebar w-duration-150 w-ease-linear;
+  @apply w-flex w-flex-col w-bg-primary-200 w-h-screen w-transition-sidebar;
   width: $menu-width;
 
   > h2,
@@ -41,7 +41,7 @@
 
   > h2 {
     // w-min-h-[160px] and w-mt-[35px] classes are to vertically align the title and icon combination to the search input on the left
-    @apply w-min-h-[160px] w-mt-[45px] w-px-4 w-box-border w-text-center w-text-white w-mb-0 w-inline-flex w-flex-col w-justify-center w-items-center w-transition-sidebar w-duration-150 w-ease-linear;
+    @apply w-min-h-[160px] w-mt-[45px] w-px-4 w-box-border w-text-center w-text-white w-mb-0 w-inline-flex w-flex-col w-justify-center w-items-center w-transition-sidebar;
 
     &:before {
       font-size: 4em;

--- a/client/src/components/Sidebar/menu/SubMenuItem.scss
+++ b/client/src/components/Sidebar/menu/SubMenuItem.scss
@@ -1,7 +1,7 @@
 .sidebar-sub-menu-trigger-icon {
   $root: &;
   display: block;
-  width: 1.25rem;
+  width: 1rem;
   height: 1rem;
   // Remove once we drop support for Safari 13.
   // stylelint-disable-next-line property-disallowed-list

--- a/client/src/components/Sidebar/menu/SubMenuItem.scss
+++ b/client/src/components/Sidebar/menu/SubMenuItem.scss
@@ -31,7 +31,7 @@
 }
 
 .sidebar-sub-menu-panel {
-  @apply w-flex w-flex-col w-bg-primary-200 w-h-screen;
+  @apply w-flex w-flex-col w-bg-primary-200 w-h-screen w-transition-sidebar w-duration-150 w-ease-linear;
   width: $menu-width;
 
   > h2,
@@ -40,8 +40,8 @@
   }
 
   > h2 {
-    // w-min-h-[160px] is to vertically align the title and icon combination to the search input on the left
-    @apply w-min-h-[220px] w-mt-0 w-px-4 w-box-border w-text-center w-text-white w-mb-0 w-inline-flex w-flex-col w-justify-center w-items-center;
+    // w-min-h-[160px] and w-mt-[35px] classes are to vertically align the title and icon combination to the search input on the left
+    @apply w-min-h-[160px] w-mt-[45px] w-px-4 w-box-border w-text-center w-text-white w-mb-0 w-inline-flex w-flex-col w-justify-center w-items-center w-transition-sidebar w-duration-150 w-ease-linear;
 
     &:before {
       font-size: 4em;
@@ -64,6 +64,7 @@
   }
 
   > ul {
+    @apply w-scrollbar-thin;
     flex-grow: 1;
     padding: 0;
     margin: 0;

--- a/client/src/components/Sidebar/modules/MainMenu.scss
+++ b/client/src/components/Sidebar/modules/MainMenu.scss
@@ -34,7 +34,6 @@
 .sidebar-footer {
   @apply w-bg-primary w-mt-auto;
   transition: width $menu-transition-duration ease !important; // Override body.ready
-  width: 100%;
 
   > ul,
   ul > li {
@@ -85,7 +84,7 @@
     }
 
     &__account-toggle {
-      @apply w-sr-only;
+      @apply w-hidden;
     }
   }
 

--- a/client/src/components/Sidebar/modules/MainMenu.scss
+++ b/client/src/components/Sidebar/modules/MainMenu.scss
@@ -2,14 +2,6 @@
 .sidebar-main-menu {
   overflow: auto;
   overflow-x: hidden;
-  // So the last items in the menu will be seen when the menu is vertically scrollable
-  margin-bottom: 52px;
-
-  @include transition(margin-bottom $menu-transition-duration ease);
-
-  &--open-footer {
-    margin-bottom: 127px;
-  }
 
   &__list {
     margin: 0;
@@ -40,9 +32,9 @@
 }
 
 .sidebar-footer {
-  @apply w-bg-primary w-bottom-0 w-fixed;
+  @apply w-bg-primary w-mt-auto;
   transition: width $menu-transition-duration ease !important; // Override body.ready
-  width: $menu-width;
+  width: 100%;
 
   > ul,
   ul > li {
@@ -54,7 +46,7 @@
   ul > li {
     position: relative;
 
-    @include transition(border-color $menu-transition-duration ease);
+    //@include transition(border-color $menu-transition-duration ease);
   }
 
   > ul {
@@ -90,8 +82,6 @@
   }
 
   @at-root .sidebar--slim #{&} {
-    width: $menu-width-slim;
-
     &__account {
       @apply w-px-0 w-pb-3 w-justify-center;
     }
@@ -102,8 +92,6 @@
   }
 
   &--open {
-    width: $menu-width !important; // Override collapsed style
-
     > ul {
       $footer-submenu-height: 85px;
       max-height: $footer-submenu-height;

--- a/client/src/components/Sidebar/modules/MainMenu.scss
+++ b/client/src/components/Sidebar/modules/MainMenu.scss
@@ -81,11 +81,11 @@
 
   @at-root .sidebar--slim #{&} {
     &__account {
-      @apply w-px-0 w-pb-3 w-justify-center;
+      @apply w-pb-3;
     }
 
     &__account-toggle {
-      @apply w-hidden;
+      @apply w-sr-only;
     }
   }
 

--- a/client/src/components/Sidebar/modules/MainMenu.scss
+++ b/client/src/components/Sidebar/modules/MainMenu.scss
@@ -45,8 +45,6 @@
 
   ul > li {
     position: relative;
-
-    //@include transition(border-color $menu-transition-duration ease);
   }
 
   > ul {

--- a/client/src/components/Sidebar/modules/MainMenu.test.js
+++ b/client/src/components/Sidebar/modules/MainMenu.test.js
@@ -4,16 +4,10 @@ import { Menu } from './MainMenu';
 
 describe('Menu', () => {
   const user = { avatarUrl: 'https://gravatar/profile' };
-  const onAccountExpand = jest.fn();
 
   it('should render with the minimum required props', () => {
     const wrapper = shallow(
-      <Menu
-        accountMenuItems={[]}
-        menuItems={[]}
-        user={user}
-        onAccountExpand={onAccountExpand}
-      />,
+      <Menu accountMenuItems={[]} menuItems={[]} user={user} />,
     );
 
     expect(wrapper).toMatchSnapshot();
@@ -21,12 +15,7 @@ describe('Menu', () => {
 
   it('should toggle the sidebar footer (account) when clicked', () => {
     const wrapper = shallow(
-      <Menu
-        accountMenuItems={[]}
-        menuItems={[]}
-        user={user}
-        onAccountExpand={onAccountExpand}
-      />,
+      <Menu accountMenuItems={[]} menuItems={[]} user={user} />,
     );
 
     // default is closed

--- a/client/src/components/Sidebar/modules/MainMenu.tsx
+++ b/client/src/components/Sidebar/modules/MainMenu.tsx
@@ -67,7 +67,6 @@ interface MenuProps {
   user: MainMenuModuleDefinition['user'];
   slim: boolean;
   expandingOrCollapsing: boolean;
-  onAccountExpand: () => void;
   onHideMobile: () => void;
   currentPath: string;
 
@@ -79,7 +78,6 @@ export const Menu: React.FunctionComponent<MenuProps> = ({
   accountMenuItems,
   user,
   expandingOrCollapsing,
-  onAccountExpand,
   onHideMobile,
   slim,
   currentPath,
@@ -99,7 +97,7 @@ export const Menu: React.FunctionComponent<MenuProps> = ({
 
   React.useEffect(() => {
     // Force account navigation to closed state when in slim mode
-    if (slim) {
+    if (slim && accountSettingsOpen) {
       dispatch({
         type: 'set-navigation-path',
         path: '',
@@ -183,7 +181,6 @@ export const Menu: React.FunctionComponent<MenuProps> = ({
 
   const onClickAccountSettings = () => {
     // Pass account expand information to Sidebar component
-    onAccountExpand();
 
     if (accountSettingsOpen) {
       dispatch({
@@ -216,9 +213,10 @@ export const Menu: React.FunctionComponent<MenuProps> = ({
           (isVisible ? ' sidebar-footer--visible' : '')
         }
       >
-        <Tippy disabled={!slim} content={gettext('Account')} placement="right">
+        <Tippy disabled={!slim} content={user.name} placement="right">
           <button
-            className="
+            className={`
+            ${slim ? 'w-px-4' : 'w-px-5'}
             sidebar-footer__account
             w-bg-primary
             w-text-white
@@ -229,11 +227,10 @@ export const Menu: React.FunctionComponent<MenuProps> = ({
             w-appearance-none
             w-border-0
             w-overflow-hidden
-            w-px-5
             w-py-3
             hover:w-bg-primary-200
             focus:w-bg-primary-200
-            w-transition"
+            w-transition`}
             title={gettext('Edit your account')}
             onClick={onClickAccountSettings}
             aria-label={gettext('Edit your account')}
@@ -285,7 +282,6 @@ export class MainMenuModuleDefinition implements ModuleDefinition {
   render({
     slim,
     expandingOrCollapsing,
-    onAccountExpand,
     onHideMobile,
     key,
     currentPath,
@@ -298,7 +294,6 @@ export class MainMenuModuleDefinition implements ModuleDefinition {
         user={this.user}
         slim={slim}
         expandingOrCollapsing={expandingOrCollapsing}
-        onAccountExpand={onAccountExpand}
         onHideMobile={onHideMobile}
         key={key}
         currentPath={currentPath}

--- a/client/src/components/Sidebar/modules/MainMenu.tsx
+++ b/client/src/components/Sidebar/modules/MainMenu.tsx
@@ -68,7 +68,9 @@ interface MenuProps {
   slim: boolean;
   expandingOrCollapsing: boolean;
   onAccountExpand: () => void;
+  onHideMobile: () => void;
   currentPath: string;
+
   navigate(url: string): Promise<void>;
 }
 
@@ -78,6 +80,7 @@ export const Menu: React.FunctionComponent<MenuProps> = ({
   user,
   expandingOrCollapsing,
   onAccountExpand,
+  onHideMobile,
   slim,
   currentPath,
   navigate,
@@ -138,6 +141,10 @@ export const Menu: React.FunctionComponent<MenuProps> = ({
           type: 'set-navigation-path',
           path: '',
         });
+
+        if (state.navigationPath === '') {
+          onHideMobile();
+        }
       }
     };
 
@@ -162,7 +169,7 @@ export const Menu: React.FunctionComponent<MenuProps> = ({
       document.removeEventListener('mousedown', onClickOutside);
       document.removeEventListener('touchend', onClickOutside);
     };
-  }, []);
+  }, [state]);
 
   const onClickAccountSettings = () => {
     // Pass account expand information to Sidebar component
@@ -269,6 +276,7 @@ export class MainMenuModuleDefinition implements ModuleDefinition {
     slim,
     expandingOrCollapsing,
     onAccountExpand,
+    onHideMobile,
     key,
     currentPath,
     navigate,
@@ -281,6 +289,7 @@ export class MainMenuModuleDefinition implements ModuleDefinition {
         slim={slim}
         expandingOrCollapsing={expandingOrCollapsing}
         onAccountExpand={onAccountExpand}
+        onHideMobile={onHideMobile}
         key={key}
         currentPath={currentPath}
         navigate={navigate}

--- a/client/src/components/Sidebar/modules/MainMenu.tsx
+++ b/client/src/components/Sidebar/modules/MainMenu.tsx
@@ -164,29 +164,9 @@ export const Menu: React.FunctionComponent<MenuProps> = ({
     };
   }, []);
 
-  // Determine if the sidebar is expanded from account button click
-  const [expandedFromAccountClick, setExpandedFromAccountClick] =
-    React.useState<boolean>(false);
-
-  // Whenever the parent Sidebar component collapses or expands, close any open menus
-  React.useEffect(() => {
-    if (expandingOrCollapsing && !expandedFromAccountClick) {
-      dispatch({
-        type: 'set-navigation-path',
-        path: '',
-      });
-    }
-    if (expandedFromAccountClick) {
-      setExpandedFromAccountClick(false);
-    }
-  }, [expandingOrCollapsing]);
-
   const onClickAccountSettings = () => {
     // Pass account expand information to Sidebar component
     onAccountExpand();
-    if (slim) {
-      setExpandedFromAccountClick(true);
-    }
 
     if (accountSettingsOpen) {
       dispatch({

--- a/client/src/components/Sidebar/modules/MainMenu.tsx
+++ b/client/src/components/Sidebar/modules/MainMenu.tsx
@@ -70,6 +70,7 @@ interface MenuProps {
   onAccountExpand: () => void;
   onHideMobile: () => void;
   currentPath: string;
+
   navigate(url: string): Promise<void>;
 }
 
@@ -93,8 +94,18 @@ export const Menu: React.FunctionComponent<MenuProps> = ({
     navigationPath: '',
     activePath: '',
   });
-  const accountSettingsOpen = state.navigationPath.startsWith('.account');
   const isVisible = !slim || expandingOrCollapsing;
+  const accountSettingsOpen = state.navigationPath.startsWith('.account');
+
+  React.useEffect(() => {
+    // Force account navigation to closed state when in slim mode
+    if (slim) {
+      dispatch({
+        type: 'set-navigation-path',
+        path: '',
+      });
+    }
+  }, [slim]);
 
   // Whenever currentPath or menu changes, work out new activePath
   React.useEffect(() => {

--- a/client/src/components/Sidebar/modules/MainMenu.tsx
+++ b/client/src/components/Sidebar/modules/MainMenu.tsx
@@ -70,7 +70,6 @@ interface MenuProps {
   onAccountExpand: () => void;
   onHideMobile: () => void;
   currentPath: string;
-
   navigate(url: string): Promise<void>;
 }
 
@@ -169,7 +168,7 @@ export const Menu: React.FunctionComponent<MenuProps> = ({
       document.removeEventListener('mousedown', onClickOutside);
       document.removeEventListener('touchend', onClickOutside);
     };
-  }, [state]);
+  }, []);
 
   const onClickAccountSettings = () => {
     // Pass account expand information to Sidebar component

--- a/client/src/components/Sidebar/modules/WagtailBranding.scss
+++ b/client/src/components/Sidebar/modules/WagtailBranding.scss
@@ -36,7 +36,7 @@ $logo-size: 110px;
   // Reduce overall size when in slim mode
   .sidebar--slim & {
     @include show-focus-outline-inside();
-    margin: 1.125em auto 2.5em;
+    margin: 1.125em auto 4em;
     width: 40px;
     height: 40px;
   }

--- a/client/src/components/Sidebar/modules/WagtailBranding.scss
+++ b/client/src/components/Sidebar/modules/WagtailBranding.scss
@@ -37,8 +37,8 @@ $logo-size: 110px;
   .sidebar--slim & {
     @include show-focus-outline-inside();
     margin: 1.125em auto 2.5em;
-    width: 60px;
-    height: 60px;
+    width: 40px;
+    height: 40px;
   }
 
   // Remove background on 404 page

--- a/client/src/components/Sidebar/modules/__snapshots__/MainMenu.test.js.snap
+++ b/client/src/components/Sidebar/modules/__snapshots__/MainMenu.test.js.snap
@@ -14,7 +14,6 @@ exports[`Menu should render with the minimum required props 1`] = `
     className="sidebar-footer sidebar-footer--visible"
   >
     <ForwardRef(TippyWrapper)
-      content="Account"
       disabled={true}
       placement="right"
     >
@@ -23,6 +22,7 @@ exports[`Menu should render with the minimum required props 1`] = `
         aria-haspopup="menu"
         aria-label="Edit your account"
         className="
+            w-px-5
             sidebar-footer__account
             w-bg-primary
             w-text-white
@@ -33,7 +33,6 @@ exports[`Menu should render with the minimum required props 1`] = `
             w-appearance-none
             w-border-0
             w-overflow-hidden
-            w-px-5
             w-py-3
             hover:w-bg-primary-200
             focus:w-bg-primary-200

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -76,6 +76,10 @@ module.exports = {
       outlineOffset: {
         inside: '-3px',
       },
+      transitionProperty: {
+        sidebar:
+          'left, inset-inline-start, padding-inline-start, width, transform, margin-top, min-height',
+      },
     },
   },
   plugins: [

--- a/wagtail/admin/templates/wagtailadmin/base.html
+++ b/wagtail/admin/templates/wagtailadmin/base.html
@@ -4,8 +4,7 @@
 {% block furniture %}
     <template data-wagtail-sidebar-branding-logo>{% block branding_logo %}{% endblock %}</template>
     {% sidebar_props %}
-    <aside id="wagtail-sidebar" data-wagtail-sidebar></aside>
-
+    <aside id="wagtail-sidebar" class="sidebar-loading" data-wagtail-sidebar></aside>
     <main class="content-wrapper" id="main">
         <div class="content">
             {# Always show messages div so it can be appended to by JS #}

--- a/wagtail/admin/templates/wagtailadmin/base.html
+++ b/wagtail/admin/templates/wagtailadmin/base.html
@@ -4,7 +4,7 @@
 {% block furniture %}
     <template data-wagtail-sidebar-branding-logo>{% block branding_logo %}{% endblock %}</template>
     {% sidebar_props %}
-    <aside id="wagtail-sidebar" class="sidebar-loading" data-wagtail-sidebar></aside>
+    <aside id="wagtail-sidebar" class="sidebar-loading" data-wagtail-sidebar aria-label="{% trans 'Sidebar' %}"></aside>
     <main class="content-wrapper" id="main">
         <div class="content">
             {# Always show messages div so it can be appended to by JS #}


### PR DESCRIPTION
Addresses these parts of #8311 

- [x] Animations – The close animation for sub-menus doesn't seem to play when the menu is expanded - **Made it so sub menu's stay open when the menu is expanded and collapsed**
- [x] Animations – The account menu seems to have a different tween animation to the rest of the menu. Causing it to do a weird thing when you collapse the menu while the account menu is open 
- [x] Animations – The avatar suddenly jumps to the right when you collapse the menu
- [x] Animations – The Bird seems to have two hover states (try slowly moving your mouse cursor from top to bottom and you'll see it's wing appears before the hover animation is triggered). Not sure if this is intended behaviour.
- [x] Accessibility – Focus order is incorrect on the mobile version (it should be possible to move to the sidebar after having toggled it)
- [x] Try and fit more letters in to the sidebar menu items by reduce the padding / margin on the right side of the arrow, and reduce the gap between the icon and the text a tiny bit
- [x] Make it so when you have a menu open (e.g. Bakery misc) and you click the slim sidebar icon, the menu stays open as the menu gets slim. 

### Browsers tested on
Chrome 100, Safari 15.2, Firefox 99