### PR TITLE
Remove `is_searchable` check from shared header template

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/shared/header.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/header.html
@@ -22,7 +22,7 @@
                 <h1>{% if icon %}{% icon name=icon class_name="header-title-icon" %}{% endif %}
                     {{ title }}{% if subtitle %} <span>{{ subtitle }}</span>{% endif %}</h1>
             </div>
-            {% if is_searchable and search_url %}
+            {% if search_url %}
                 <form class="col search-form" action="{% url search_url %}{% if query_parameters %}?{{ query_parameters }}{% endif %}" method="get" novalidate role="search">
                     <ul class="fields">
                         {% for field in search_form %}

--- a/wagtail/documents/tests/test_admin_views.py
+++ b/wagtail/documents/tests/test_admin_views.py
@@ -136,6 +136,19 @@ class TestDocumentIndexView(TestCase, WagtailTestUtils):
         next_url = quote(response._request.get_full_path())
         self.assertContains(response, "%s?next=%s" % (edit_url, next_url))
 
+    def test_search_form_rendered(self):
+        response = self.get()
+        html = response.content.decode()
+        search_url = reverse("wagtaildocs:index")
+
+        # Search form in the header should be rendered.
+        self.assertTagInHTML(
+            f"""<form action="{search_url}" method="get" role="search">""",
+            html,
+            count=1,
+            allow_extra_attrs=True,
+        )
+
 
 class TestDocumentListingResultsView(TestCase, WagtailTestUtils):
     def setUp(self):

--- a/wagtail/images/tests/test_admin_views.py
+++ b/wagtail/images/tests/test_admin_views.py
@@ -193,6 +193,19 @@ class TestImageIndexView(TestCase, WagtailTestUtils):
             "?p=3&amp;tag=even" in response_body or "?tag=even&amp;p=3" in response_body
         )
 
+    def test_search_form_rendered(self):
+        response = self.get()
+        html = response.content.decode()
+        search_url = reverse("wagtailimages:index")
+
+        # Search form in the header should be rendered.
+        self.assertTagInHTML(
+            f"""<form action="{search_url}" method="get" role="search">""",
+            html,
+            count=1,
+            allow_extra_attrs=True,
+        )
+
 
 class TestImageListingResultsView(TestCase, WagtailTestUtils):
     def setUp(self):


### PR DESCRIPTION
Regression in #8361, reported by @thibaudcolas.

Not all views that use this template extend from generic `IndexView`.
They might only define `search_url` without `is_searchable` in the context.

The generic view has also handled this anyway:

https://github.com/wagtail/wagtail/blob/6f74668dac6b8bb48959e311c91117bb9c391203/wagtail/admin/views/generic/models.py#L96-L99

<!--
Thanks for contributing to Wagtail! 🎉

Before submitting, please review the [contributor guidelines](https://docs.wagtail.org/en/latest/contributing/index.html).
-->

_Please check the following:_

- [x] Do the tests still pass?[^1]
- [x] Does the code comply with the style guide? 
    - [x] Run `make lint` from the Wagtail root. 
- [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
- [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    - [ ] **Please list the exact browser and operating system versions you tested**:
    - [ ] **Please list which assistive technologies [^3] you tested**: 
- [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**. 

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets) 
