### PR TITLE
3.0 - add JSON1 SQLite compatibility requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Wagtail supports:
 
 -   Django 3.2.x and 4.0.x
 -   Python 3.7, 3.8, 3.9 and 3.10
--   PostgreSQL, MySQL and SQLite as database backends
+-   PostgreSQL, MySQL and SQLite (with JSON1) as database backends
 
 [Previous versions of Wagtail](https://docs.wagtail.org/en/stable/releases/upgrading.html#compatible-django-python-versions) additionally supported Python 2.7 and earlier Django versions.
 

--- a/docs/releases/3.0.md
+++ b/docs/releases/3.0.md
@@ -160,6 +160,11 @@ References to `BASE_URL` in your settings should be updated to [`WAGTAILADMIN_BA
 
 All uses of `StreamField` should be updated to include the argument `use_json_field=True`. After adding this, make sure to generate and run migrations. This converts the field to use `JSONField` as its internal type instead of `TextField`, which will allow you to use `JSONField` lookups and transforms on the field. This change is necessary to ensure that the database migration is applied; a future release will drop support for `TextField`-based StreamFields.
 
+### SQLite now requires the `JSON1` extension enabled
+
+Due to [`JSONField`](https://docs.djangoproject.com/en/stable/ref/models/fields/#django.db.models.JSONField) requirements, SQLite will only be supported with the JSON1 extension enabled.
+See [Enabling JSON1 extension on SQLite](https://docs.djangoproject.com/en/stable/ref/databases/#sqlite-json1) and [JSON1 extension](https://www.sqlite.org/json1.html) for details.
+
 ## Upgrade considerations - deprecation of old functionality
 
 ### Removed support for Internet Explorer (IE11)


### PR DESCRIPTION
- see https://github.com/wagtail/wagtail/discussions/8362#discussioncomment-2621936
- Wagtail 3.0 will no longer work if the `JSON1` extension is disabled, while this should be enabled in most installations, it should be called out in the documentation as the error Django gives does not really help point developers in the right direction
- https://code.djangoproject.com/wiki/JSON1Extension

`... (fields.E180) SQLite does not support JSONFields.`

