### PR TITLE
Defer removal of use_json_field=None until Wagtail 5.0

### DIFF
--- a/wagtail/fields.py
+++ b/wagtail/fields.py
@@ -8,7 +8,7 @@ from django.utils.encoding import force_str
 
 from wagtail.blocks import Block, BlockField, StreamBlock, StreamValue
 from wagtail.rich_text import get_text_for_indexing
-from wagtail.utils.deprecation import RemovedInWagtail40Warning
+from wagtail.utils.deprecation import RemovedInWagtail50Warning
 
 
 class RichTextField(models.TextField):
@@ -102,7 +102,7 @@ class StreamField(models.Field):
         if type(self.use_json_field) is not bool:
             warnings.warn(
                 f"StreamField must explicitly set use_json_field argument to True/False instead of {self.use_json_field}.",
-                RemovedInWagtail40Warning,
+                RemovedInWagtail50Warning,
                 stacklevel=3,
             )
 

--- a/wagtail/tests/test_streamfield.py
+++ b/wagtail/tests/test_streamfield.py
@@ -22,7 +22,7 @@ from wagtail.test.testapp.models import (
     MinMaxCountStreamModel,
     StreamModel,
 )
-from wagtail.utils.deprecation import RemovedInWagtail40Warning
+from wagtail.utils.deprecation import RemovedInWagtail50Warning
 
 
 class TestLazyStreamField(TestCase):
@@ -232,7 +232,7 @@ class TestUseJsonFieldWarning(TestCase):
 
     def test_system_check_validates_block(self):
         message = "StreamField must explicitly set use_json_field argument to True/False instead of None."
-        with self.assertWarnsMessage(RemovedInWagtail40Warning, message):
+        with self.assertWarnsMessage(RemovedInWagtail50Warning, message):
 
             class DeprecatedStreamModel(models.Model):
                 body = StreamField(


### PR DESCRIPTION
Removing it in 4.0 creates a problem for bakerydemo, since it makes it impossible to write a StreamField definition that works on both the current released version (2.16) and Wagtail main (4.0a0).