### PR TITLE
Reinstate use_json_field=None fallback as a Wagtail 5.0 deprecation

### DIFF
--- a/wagtail/fields.py
+++ b/wagtail/fields.py
@@ -1,6 +1,6 @@
 import json
+import warnings
 
-from django.core.exceptions import ImproperlyConfigured
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db import models
 from django.db.models.fields.json import KeyTransform
@@ -8,6 +8,7 @@ from django.utils.encoding import force_str
 
 from wagtail.blocks import Block, BlockField, StreamBlock, StreamValue
 from wagtail.rich_text import get_text_for_indexing
+from wagtail.utils.deprecation import RemovedInWagtail50Warning
 
 
 class RichTextField(models.TextField):
@@ -99,8 +100,10 @@ class StreamField(models.Field):
 
     def _check_json_field(self):
         if type(self.use_json_field) is not bool:
-            raise ImproperlyConfigured(
+            warnings.warn(
                 f"StreamField must explicitly set use_json_field argument to True/False instead of {self.use_json_field}.",
+                RemovedInWagtail50Warning,
+                stacklevel=3,
             )
 
     def get_internal_type(self):

--- a/wagtail/tests/test_streamfield.py
+++ b/wagtail/tests/test_streamfield.py
@@ -3,7 +3,6 @@ import json
 from unittest import skip
 
 from django.apps import apps
-from django.core.exceptions import ImproperlyConfigured
 from django.db import connection, models
 from django.template import Context, Template, engines
 from django.test import TestCase, skipUnlessDBFeature
@@ -23,6 +22,7 @@ from wagtail.test.testapp.models import (
     MinMaxCountStreamModel,
     StreamModel,
 )
+from wagtail.utils.deprecation import RemovedInWagtail50Warning
 
 
 class TestLazyStreamField(TestCase):
@@ -231,7 +231,8 @@ class TestUseJsonFieldWarning(TestCase):
         apps.clear_cache()
 
     def test_system_check_validates_block(self):
-        with self.assertRaises(ImproperlyConfigured):
+        message = "StreamField must explicitly set use_json_field argument to True/False instead of None."
+        with self.assertWarnsMessage(RemovedInWagtail50Warning, message):
 
             class DeprecatedStreamModel(models.Model):
                 body = StreamField(


### PR DESCRIPTION
As per #8435 - revert the removal of `use_json_field=None` performed in 262e94401a053adf0383e0c61cd96393764b3089.