### PR TITLE
Header styling tweaks

### DIFF
--- a/client/scss/components/_button.scss
+++ b/client/scss/components/_button.scss
@@ -48,11 +48,6 @@
       border-color: transparent;
       background-color: $color-button-yes-hover;
     }
-
-    &.button-nobg:hover {
-      color: $color-button-yes;
-      background-color: transparent;
-    }
   }
 
   &.warning {
@@ -69,11 +64,6 @@
       color: $color-white;
       border-color: transparent;
       background-color: $color-button-warning-hover;
-    }
-
-    &.button-nobg:hover {
-      color: $color-button-warning;
-      background-color: transparent;
     }
   }
 
@@ -93,16 +83,6 @@
       border-color: transparent;
       background-color: $color-button-no-hover;
     }
-
-    &.button-nobg:hover {
-      color: $color-button-no;
-      background-color: transparent;
-    }
-  }
-
-  &.button-nobg {
-    border: 0;
-    background-color: transparent;
   }
 
   &.bicolor {
@@ -329,10 +309,6 @@
     &:hover {
       border-color: $color-grey-2;
     }
-
-    &.button-nobg:hover {
-      background-color: transparent;
-    }
   }
 
   &.button--icon {
@@ -463,11 +439,6 @@ button.button.bicolor .icon-wrapper {
     border-color: transparent;
     background-color: $color-button-yes-hover;
   }
-
-  &.button-nobg:hover {
-    color: $color-button-yes;
-    background-color: transparent;
-  }
 }
 
 .no,
@@ -486,16 +457,6 @@ button.button.bicolor .icon-wrapper {
     border-color: transparent;
     background-color: $color-button-no-hover;
   }
-
-  &.button-nobg:hover {
-    color: $color-button-no;
-    background-color: transparent;
-  }
-}
-
-.button-nobg {
-  border: 0;
-  background-color: transparent;
 }
 
 .bicolor {

--- a/client/scss/components/_button.scss
+++ b/client/scss/components/_button.scss
@@ -116,7 +116,9 @@
 
     .icon-wrapper {
       background-color: rgba(0, 0, 0, 0.2);
-      display: block;
+      display: flex;
+      align-items: center;
+      justify-content: center;
       position: absolute;
       // Remove once we drop support for Safari 14.
       // stylelint-disable-next-line property-disallowed-list
@@ -124,7 +126,6 @@
       inset-inline-start: 0;
       top: 0;
       width: 3em;
-      line-height: 1.85em;
       height: 100%;
       text-align: center;
       // Remove once we drop support for Safari 14.
@@ -140,11 +141,6 @@
     &.button--icon {
       &:before {
         display: none; // TODO: remove once the icon font styles are gone
-      }
-
-      .icon {
-        @include svg-icon(1rem);
-        padding: 0.75em;
       }
     }
 

--- a/client/scss/components/_dropdown.legacy.scss
+++ b/client/scss/components/_dropdown.legacy.scss
@@ -351,6 +351,5 @@
   .button svg.icon {
     // TODO: leave only class when iconfont styles are removed
     @include svg-icon();
-    margin-inline-end: 0.5em;
   }
 }

--- a/client/scss/components/_forms.scss
+++ b/client/scss/components/_forms.scss
@@ -192,11 +192,15 @@ label.required:after {
     &:before,
     &:after {
       font-family: $font-wagtail-icons;
+      display: flex;
+      flex-flow: row nowrap;
+      align-items: center;
       position: absolute;
-      top: 0.5em;
+      top: 0;
+      height: 100%;
       line-height: 100%;
       font-size: 2em;
-      color: $color-grey-3;
+      color: theme('colors.grey.200');
     }
 
     &:before {
@@ -227,7 +231,6 @@ label.required:after {
       &:before,
       &:after {
         font-size: 1.3rem; // REMs are necessary here because IE doesn't treat generated content correctly
-        top: 0.3em;
       }
 
       &:before {

--- a/client/scss/components/_header.scss
+++ b/client/scss/components/_header.scss
@@ -2,10 +2,12 @@
 @use 'sass:color';
 
 header {
-  @apply w-text-primary w-py-6 w-mb-8;
+  @apply w-text-primary w-mb-8;
 
-  padding-inline-start: 90px;
-  padding-inline-end: 90px;
+  padding-top: 0.5rem;
+  padding-bottom: 1.5rem;
+  padding-inline-start: 110px;
+  padding-inline-end: 20px;
 
   a {
     @apply w-text-primary w-underline;
@@ -78,6 +80,7 @@ header {
   // For case where content below header should merge with it
   &.merged {
     margin-bottom: 0;
+    padding-bottom: 1rem;
   }
 
   &.header-with-breadcrumb {
@@ -183,6 +186,10 @@ header {
 
 @include media-breakpoint-up(sm) {
   header {
+    padding-top: 1.5rem;
+    padding-inline-start: 90px;
+    padding-inline-end: 90px;
+
     .left {
       float: left;
       margin-inline-end: 0;

--- a/client/scss/components/_header.scss
+++ b/client/scss/components/_header.scss
@@ -19,14 +19,25 @@ header {
 
   h1 {
     position: relative;
+    font-size: 30px;
+    font-weight: 800;
+    line-height: 130%;
 
     > svg.icon {
       position: absolute;
-      left: -2em;
+      // Remove once we drop support for Safari 13.
+      // stylelint-disable-next-line property-disallowed-list
+      left: -1.5em;
+      inset-inline-start: -1.5em;
+      top: 0.125em;
+      max-width: 1em;
+      max-height: 1em;
+      vertical-align: text-top;
     }
 
     span {
       margin-inline-start: 0.3125rem;
+      font-weight: 400;
     }
   }
 
@@ -213,16 +224,5 @@ header {
     .col9 {
       @include column(9);
     }
-  }
-}
-
-.header-title {
-  @include media-breakpoint-down(xs) {
-    padding-inline-start: $mobile-nav-indent;
-  }
-
-  &-icon {
-    @include svg-icon();
-    margin-inline-end: 0.5em;
   }
 }

--- a/client/scss/components/_header.scss
+++ b/client/scss/components/_header.scss
@@ -81,18 +81,6 @@ header {
     padding-bottom: 1rem;
   }
 
-  &.header-with-breadcrumb {
-    padding-top: 0;
-
-    .breadcrumb {
-      margin-bottom: 1rem;
-      padding-inline-start: math.div(
-        $desktop-nice-padding,
-        2
-      ); // rather than padding-inline-start: revert;
-    }
-  }
-
   &.no-border {
     border: 0;
 

--- a/client/scss/components/_header.scss
+++ b/client/scss/components/_header.scss
@@ -132,15 +132,6 @@ header {
     @include visuallyhidden();
   }
 
-  input[type='text'],
-  select {
-    border-width: 0;
-
-    &:focus {
-      background-color: $color-white;
-    }
-  }
-
   .error-message {
     color: inherit;
   }

--- a/client/scss/components/_header.scss
+++ b/client/scss/components/_header.scss
@@ -4,6 +4,9 @@
 header {
   @apply w-text-primary w-py-4 w-mb-8;
 
+  padding-inline-start: 90px;
+  padding-inline-end: 90px;
+
   a {
     @apply w-text-primary w-underline;
   }
@@ -15,15 +18,11 @@ header {
   }
 
   h1 {
-    display: inline-flex;
-    flex-wrap: wrap;
-    align-items: center;
+    position: relative;
 
-    &.icon:before {
-      width: 1em;
-      display: none;
-      margin-inline-end: 0.4em;
-      font-size: 1.5em;
+    > svg.icon {
+      position: absolute;
+      left: -2em;
     }
 
     span {

--- a/client/scss/components/_header.scss
+++ b/client/scss/components/_header.scss
@@ -2,7 +2,7 @@
 @use 'sass:color';
 
 header {
-  @apply w-bg-grey-50 w-text-primary w-border-b w-border-grey-100 w-py-4 w-mb-8;
+  @apply w-text-primary w-py-4 w-mb-8;
 
   a {
     @apply w-text-primary w-underline;

--- a/client/scss/components/_header.scss
+++ b/client/scss/components/_header.scss
@@ -123,6 +123,11 @@ header {
     }
   }
 
+  .button-secondary {
+    color: $color-teal-darker;
+    background-color: transparent;
+  }
+
   label {
     @include visuallyhidden();
   }

--- a/client/scss/components/_header.scss
+++ b/client/scss/components/_header.scss
@@ -64,14 +64,15 @@ header {
   }
 
   .search-form .icon {
-    @include svg-icon(1.3rem);
-    color: color.adjust($color-white, $lightness: -20%);
+    @include svg-icon(1.2rem);
+    color: theme('colors.primary.DEFAULT');
     position: absolute;
-    top: 0.3em;
+    top: 0;
+    height: 100%;
     // Remove once we drop support for Safari 13.
     // stylelint-disable-next-line property-disallowed-list
-    left: 0.5em;
-    inset-inline-start: 0.5em;
+    left: 0.7em;
+    inset-inline-start: 0.7em;
   }
 
   // For case where content below header should merge with it

--- a/client/scss/components/_header.scss
+++ b/client/scss/components/_header.scss
@@ -2,7 +2,7 @@
 @use 'sass:color';
 
 header {
-  @apply w-text-primary w-py-4 w-mb-8;
+  @apply w-text-primary w-py-6 w-mb-8;
 
   padding-inline-start: 90px;
   padding-inline-end: 90px;

--- a/client/scss/components/_header.scss
+++ b/client/scss/components/_header.scss
@@ -20,10 +20,8 @@ header {
   }
 
   h1 {
+    @apply w-h1;
     position: relative;
-    font-size: 30px;
-    font-weight: 800;
-    line-height: 130%;
 
     > svg.icon {
       position: absolute;

--- a/client/scss/components/_modals.scss
+++ b/client/scss/components/_modals.scss
@@ -123,7 +123,7 @@ $zindex-modal-background: 500;
       @apply w-text-white;
 
       font-weight: 700;
-      font-size: 18px;
+      font-size: 1.125rem;
       line-height: 130%;
     }
   }

--- a/client/scss/components/_modals.scss
+++ b/client/scss/components/_modals.scss
@@ -118,8 +118,6 @@ $zindex-modal-background: 500;
 
   header {
     @apply w-bg-primary w-text-white;
-    padding-inline-start: 2em;
-    padding-inline-end: 100px;
 
     h1 {
       @apply w-text-white;

--- a/client/scss/components/_modals.scss
+++ b/client/scss/components/_modals.scss
@@ -121,13 +121,11 @@ $zindex-modal-background: 500;
 
     h1 {
       @apply w-text-white;
-    }
-  }
 
-  .header-title {
-    // stylelint-disable-next-line declaration-no-important
-    padding-inline-start: 0 !important;
-    margin-inline-start: -36px;
+      font-weight: 700;
+      font-size: 18px;
+      line-height: 130%;
+    }
   }
 }
 

--- a/wagtail/admin/static_src/wagtailadmin/scss/layouts/home.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/layouts/home.scss
@@ -9,6 +9,10 @@ h1 {
 header {
   @apply w-text-primary;
 
+  display: flex;
+  flex-flow: row nowrap;
+  gap: 1em;
+
   .col1 {
     width: 50px;
     margin-inline-end: 1em;
@@ -25,11 +29,8 @@ header {
   }
 
   .avatar {
-    position: absolute;
-    // Remove once we drop support for Safari 13.
-    // stylelint-disable-next-line property-disallowed-list
-    left: -60px;
-    inset-inline-start: -60px;
+    margin-top: 0.5em;
+    flex-shrink: 0;
   }
 
   .user-name {

--- a/wagtail/admin/static_src/wagtailadmin/scss/layouts/home.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/layouts/home.scss
@@ -24,6 +24,11 @@ header {
     }
   }
 
+  .avatar {
+    position: absolute;
+    left: -70px;
+  }
+
   .user-name {
     font-size: 1.3em;
     font-weight: 600;

--- a/wagtail/admin/static_src/wagtailadmin/scss/layouts/home.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/layouts/home.scss
@@ -26,7 +26,10 @@ header {
 
   .avatar {
     position: absolute;
-    left: -70px;
+    // Remove once we drop support for Safari 13.
+    // stylelint-disable-next-line property-disallowed-list
+    left: -60px;
+    inset-inline-start: -60px;
   }
 
   .user-name {

--- a/wagtail/admin/static_src/wagtailadmin/scss/layouts/login.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/layouts/login.scss
@@ -190,10 +190,11 @@ a.button {
       .input:before {
         display: inline-block;
         position: absolute;
-        color: $color-grey-4;
-        border: 2px solid $color-grey-4;
+        color: theme('colors.grey.200');
+        border: 2px solid theme('colors.grey.200');
         border-radius: 100%;
         width: 1em;
+        height: 1em;
         padding: 0.3em;
         // Remove once we drop support for Safari 13.
         // stylelint-disable-next-line property-disallowed-list

--- a/wagtail/admin/static_src/wagtailadmin/scss/layouts/page-editor.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/layouts/page-editor.scss
@@ -67,14 +67,6 @@
     }
   }
 
-  .header-title {
-    padding-inline-start: 0;
-  }
-
-  .modal-body .header-title h1 {
-    font-size: 1.5em;
-  }
-
   .header-meta {
     list-style: none;
     margin-top: 0;

--- a/wagtail/admin/static_src/wagtailadmin/scss/layouts/report.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/layouts/report.scss
@@ -38,8 +38,6 @@
 
     input[type='checkbox'] {
       display: block;
-      width: unset;
-      height: unset;
       margin-bottom: 10px;
     }
 

--- a/wagtail/admin/templates/wagtailadmin/account/account.html
+++ b/wagtail/admin/templates/wagtailadmin/account/account.html
@@ -4,7 +4,7 @@
 {% block titletag %}{% trans "Account" %}{% endblock %}
 {% block content %}
     {% trans "Account" as account_str %}
-    {% include "wagtailadmin/shared/header.html" with title=account_str merged=1 %}
+    {% include "wagtailadmin/shared/header.html" with title=account_str icon="user" merged=1 %}
 
     <div class="w-tabs" data-tabs data-tabs-animate>
         <div class="w-tabs__wrapper">

--- a/wagtail/admin/templates/wagtailadmin/home.html
+++ b/wagtail/admin/templates/wagtailadmin/home.html
@@ -12,9 +12,13 @@
 {% endblock %}
 
 {% block content %}
-    <header class="merged">
-        <h1><div class="avatar"><img src="{% avatar_url user %}" alt="" /></div>{% block branding_welcome %}{% blocktrans trimmed %}Welcome to the {{ site_name }} Wagtail CMS{% endblocktrans %}{% endblock %}</h1>
-        <div class="user-name">{{ user|user_display_name }}</div>
+    <header class="merged nice-padding">
+       <div class="avatar"><img src="{% avatar_url user %}" alt="" /></div>
+
+        <div>
+            <h1>{% block branding_welcome %}{% blocktrans trimmed %}Welcome to the {{ site_name }} Wagtail CMS{% endblocktrans %}{% endblock %}</h1>
+            <div class="user-name">{{ user|user_display_name }}</div>
+        </div>
     </header>
 
     {% if panels %}

--- a/wagtail/admin/templates/wagtailadmin/home.html
+++ b/wagtail/admin/templates/wagtailadmin/home.html
@@ -13,15 +13,8 @@
 
 {% block content %}
     <header class="merged">
-        <div class="row">
-            <div class="col1">
-                <div class="avatar"><img src="{% avatar_url user %}" alt="" /></div>
-            </div>
-            <div class="col9">
-                <h1>{% block branding_welcome %}{% blocktrans trimmed %}Welcome to the {{ site_name }} Wagtail CMS{% endblocktrans %}{% endblock %}</h1>
-                <div class="user-name">{{ user|user_display_name }}</div>
-            </div>
-        </div>
+        <h1><div class="avatar"><img src="{% avatar_url user %}" alt="" /></div>{% block branding_welcome %}{% blocktrans trimmed %}Welcome to the {{ site_name }} Wagtail CMS{% endblocktrans %}{% endblock %}</h1>
+        <div class="user-name">{{ user|user_display_name }}</div>
     </header>
 
     {% if panels %}

--- a/wagtail/admin/templates/wagtailadmin/home.html
+++ b/wagtail/admin/templates/wagtailadmin/home.html
@@ -13,7 +13,7 @@
 
 {% block content %}
     <header class="merged nice-padding">
-       <div class="avatar"><img src="{% avatar_url user %}" alt="" /></div>
+        <div class="avatar"><img src="{% avatar_url user %}" alt="" /></div>
 
         <div>
             <h1>{% block branding_welcome %}{% blocktrans trimmed %}Welcome to the {{ site_name }} Wagtail CMS{% endblocktrans %}{% endblock %}</h1>

--- a/wagtail/admin/templates/wagtailadmin/home.html
+++ b/wagtail/admin/templates/wagtailadmin/home.html
@@ -12,7 +12,7 @@
 {% endblock %}
 
 {% block content %}
-    <header class="merged nice-padding">
+    <header class="merged">
         <div class="row">
             <div class="col1">
                 <div class="avatar"><img src="{% avatar_url user %}" alt="" /></div>

--- a/wagtail/admin/templates/wagtailadmin/pages/move_choose_destination.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/move_choose_destination.html
@@ -2,7 +2,7 @@
 {% load i18n wagtailadmin_tags %}
 {% block titletag %}{% blocktrans trimmed with title=page_to_move.specific_deferred.get_admin_display_title %}Select a new parent page for {{ title }}{% endblocktrans %}{% endblock %}
 {% block content %}
-    <header class="nice-padding header-with-breadcrumb">
+    <header class="header-with-breadcrumb">
         {% move_breadcrumb page_to_move viewed_page %}
         <h1>
             {% icon name="doc-empty-inverse" class_name="header-title-icon" %}

--- a/wagtail/admin/templates/wagtailadmin/pages/move_choose_destination.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/move_choose_destination.html
@@ -2,8 +2,10 @@
 {% load i18n wagtailadmin_tags %}
 {% block titletag %}{% blocktrans trimmed with title=page_to_move.specific_deferred.get_admin_display_title %}Select a new parent page for {{ title }}{% endblocktrans %}{% endblock %}
 {% block content %}
-    <header class="header-with-breadcrumb">
+    <div class="nice-padding">
         {% move_breadcrumb page_to_move viewed_page %}
+    </div>
+    <header>
         <h1>
             {% icon name="doc-empty-inverse" %}
             {% blocktrans trimmed with title=page_to_move.specific_deferred.get_admin_display_title %}Select a new parent page for <span>{{ title }}</span>{% endblocktrans %}

--- a/wagtail/admin/templates/wagtailadmin/pages/move_choose_destination.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/move_choose_destination.html
@@ -5,7 +5,7 @@
     <header class="header-with-breadcrumb">
         {% move_breadcrumb page_to_move viewed_page %}
         <h1>
-            {% icon name="doc-empty-inverse" class_name="header-title-icon" %}
+            {% icon name="doc-empty-inverse" %}
             {% blocktrans trimmed with title=page_to_move.specific_deferred.get_admin_display_title %}Select a new parent page for <span>{{ title }}</span>{% endblocktrans %}
         </h1>
     </header>

--- a/wagtail/admin/templates/wagtailadmin/pages/preview_error.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/preview_error.html
@@ -4,7 +4,7 @@
 {% block titletag %}{% trans 'Preview error' %}{% endblock %}
 
 {% block content %}
-    <header class="nice-padding">
+    <header>
         <h1>{% trans 'Preview error' %}</h1>
     </header>
     <div class="nice-padding">

--- a/wagtail/admin/templates/wagtailadmin/reports/base_report.html
+++ b/wagtail/admin/templates/wagtailadmin/reports/base_report.html
@@ -5,7 +5,7 @@
 
 {% block content %}
     <header role="banner">
-        <div class="row nice-padding">
+        <div class="row">
             <div class="left">
                 <div class="col header-title">
                     <h1>

--- a/wagtail/admin/templates/wagtailadmin/reports/base_report.html
+++ b/wagtail/admin/templates/wagtailadmin/reports/base_report.html
@@ -7,9 +7,9 @@
     <header role="banner">
         <div class="row">
             <div class="left">
-                <div class="col header-title">
+                <div class="col">
                     <h1>
-                        {% if header_icon %}{% icon name=header_icon class_name="header-title-icon" %}{% endif %}
+                        {% if header_icon %}{% icon name=header_icon %}{% endif %}
                         {{ title }}{% if subtitle %} <span>{{ subtitle }}</span>{% endif %}
                     </h1>
                 </div>

--- a/wagtail/admin/templates/wagtailadmin/shared/header.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/header.html
@@ -18,8 +18,8 @@
     {% block breadcrumb %}{% endblock %}
     <div class="row">
         <div class="left">
-            <div class="col header-title">
-                <h1>{% if icon %}{% icon name=icon class_name="header-title-icon" %}{% endif %}
+            <div class="col">
+                <h1>{% if icon %}{% icon name=icon %}{% endif %}
                     {{ title }}{% if subtitle %} <span>{{ subtitle }}</span>{% endif %}</h1>
             </div>
             {% if search_url %}

--- a/wagtail/admin/templates/wagtailadmin/shared/header.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/header.html
@@ -16,7 +16,7 @@
 {% endcomment %}
 <header class="{% if merged %}merged{% endif %} {% if search_form %}hasform{% endif %}">
     {% block breadcrumb %}{% endblock %}
-    <div class="row nice-padding">
+    <div class="row">
         <div class="left">
             <div class="col header-title">
                 <h1>{% if icon %}{% icon name=icon class_name="header-title-icon" %}{% endif %}

--- a/wagtail/admin/templates/wagtailadmin/shared/headers/slim_header.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/headers/slim_header.html
@@ -1,6 +1,6 @@
 {% load wagtailadmin_tags i18n %}
 {# Z index 99 to ensure header is always above  #}
-<header class="w-flex w-flex-col sm:w-flex-row w-items-center w-justify-between w-bg-gray-50 w-py-0 w-mb-0 w-relative w-top-0 w-z-[99] sm:w-sticky w--h-[50px]">
+<header class="w-flex w-flex-col sm:w-flex-row w-items-center w-justify-between w-bg-grey-50 w-border-b w-border-grey-100 w-py-0 w-mb-0 w-relative w-top-0 w-z-[99] sm:w-sticky w--h-[50px]">
 
     {# Padding left on mobile to give space for navigation toggle, #}
     <div class="w-pl-[50px] w-min-h-[50px] sm:w-pl-0 sm:w-pr-2 w-w-full w-flex-1 w-overflow-x-auto w-box-border" data-slim-header>

--- a/wagtail/admin/templates/wagtailadmin/shared/headers/slim_header.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/headers/slim_header.html
@@ -1,6 +1,6 @@
 {% load wagtailadmin_tags i18n %}
 {# Z index 99 to ensure header is always above  #}
-<header class="w-flex w-flex-col sm:w-flex-row w-items-center w-justify-between w-bg-grey-50 w-border-b w-border-grey-100 w-py-0 w-mb-0 w-relative w-top-0 w-z-[99] sm:w-sticky w--h-[50px]">
+<header class="w-flex w-flex-col sm:w-flex-row w-items-center w-justify-between w-bg-grey-50 w-border-b w-border-grey-100 w-px-0 w-py-0 w-mb-0 w-relative w-top-0 w-z-[99] sm:w-sticky w--h-[50px]">
 
     {# Padding left on mobile to give space for navigation toggle, #}
     <div class="w-pl-[50px] w-min-h-[50px] sm:w-pl-0 sm:w-pr-2 w-w-full w-flex-1 w-overflow-x-auto w-box-border" data-slim-header>

--- a/wagtail/admin/templates/wagtailadmin/shared/locale_selector.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/locale_selector.html
@@ -2,7 +2,7 @@
 {% load wagtailadmin_tags %}
 {% if translations %}
     <div class="c-dropdown t-inverted {{ class }}" style="display: inline-block;" data-dropdown>
-        <a href="javascript:void(0)" aria-label="{{ locale.get_display_name }}" class="c-dropdown__button  u-btn-current">
+        <a href="javascript:void(0)" aria-label="{{ locale.get_display_name }}" class="c-dropdown__button u-btn-current w-no-underline">
             {% icon name="site" class_name="default" %}
             {{ locale.get_display_name }}
             <div data-dropdown-toggle class="o-icon c-dropdown__toggle c-dropdown__togle--icon [ icon icon-arrow-down ]">
@@ -13,7 +13,7 @@
             <ul class="c-dropdown__menu u-toggle  u-arrow u-arrow--tl u-background">
                 {% for translation in translations %}
                     <li class="c-dropdown__item ">
-                        <a href="{{ translation.url }}" aria-label="{{ translation.locale.get_display_name }}" class="u-link is-live">
+                        <a href="{{ translation.url }}" aria-label="{{ translation.locale.get_display_name }}" class="u-link is-live w-no-underline">
                             {{ translation.locale.get_display_name }}
                         </a>
                     </li>

--- a/wagtail/admin/templates/wagtailadmin/workflows/index.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/index.html
@@ -5,8 +5,8 @@
     <header role="banner">
         <div class="row">
             <div class="left">
-                <div class="col header-title">
-                    <h1>{% if view.header_icon %}{% icon name=view.header_icon class_name="header-title-icon" %}{% endif %}
+                <div class="col">
+                    <h1>{% if view.header_icon %}{% icon name=view.header_icon %}{% endif %}
                         {{ view.page_title }}{% if view.subtitle %} <span>{{ view.subtitle }}</span>{% endif %}</h1>
                 </div>
             </div>

--- a/wagtail/admin/templates/wagtailadmin/workflows/index.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/index.html
@@ -3,7 +3,7 @@
 
 {% block content %}
     <header role="banner">
-        <div class="row nice-padding">
+        <div class="row">
             <div class="left">
                 <div class="col header-title">
                     <h1>{% if view.header_icon %}{% icon name=view.header_icon class_name="header-title-icon" %}{% endif %}

--- a/wagtail/admin/templates/wagtailadmin/workflows/index.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/index.html
@@ -11,7 +11,7 @@
                 </div>
             </div>
             <div class="right">
-                <a href="{% url "wagtailadmin_workflows:index" %}?show_disabled={% if showing_disabled %}false{% else %}true{% endif %}" class="button button--icon">
+                <a href="{% url "wagtailadmin_workflows:index" %}?show_disabled={% if showing_disabled %}false{% else %}true{% endif %}" class="button button-secondary button--icon w-inline-flex w-items-center w-gap-2">
                     {% if showing_disabled %}
                         {% icon name="no-view" %}{% trans "Hide disabled workflows" %}
                     {% else %}

--- a/wagtail/admin/templates/wagtailadmin/workflows/index.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/index.html
@@ -11,7 +11,7 @@
                 </div>
             </div>
             <div class="right">
-                <a href="{% url "wagtailadmin_workflows:index" %}?show_disabled={% if showing_disabled %}false{% else %}true{% endif %}" class="button button-nobg button--icon">
+                <a href="{% url "wagtailadmin_workflows:index" %}?show_disabled={% if showing_disabled %}false{% else %}true{% endif %}" class="button button--icon">
                     {% if showing_disabled %}
                         {% icon name="no-view" %}{% trans "Hide disabled workflows" %}
                     {% else %}

--- a/wagtail/admin/templates/wagtailadmin/workflows/task_index.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/task_index.html
@@ -5,8 +5,8 @@
     <header role="banner">
         <div class="row">
             <div class="left">
-                <div class="col header-title">
-                    <h1>{% if view.header_icon %}{% icon name=view.header_icon class_name="header-title-icon" %}{% endif %}
+                <div class="col">
+                    <h1>{% if view.header_icon %}{% icon name=view.header_icon %}{% endif %}
                         {{ view.page_title }}{% if view.subtitle %} <span>{{ view.subtitle }}</span>{% endif %}</h1>
                 </div>
             </div>

--- a/wagtail/admin/templates/wagtailadmin/workflows/task_index.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/task_index.html
@@ -3,7 +3,7 @@
 
 {% block content %}
     <header role="banner">
-        <div class="row nice-padding">
+        <div class="row">
             <div class="left">
                 <div class="col header-title">
                     <h1>{% if view.header_icon %}{% icon name=view.header_icon class_name="header-title-icon" %}{% endif %}

--- a/wagtail/admin/templates/wagtailadmin/workflows/task_index.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/task_index.html
@@ -11,11 +11,11 @@
                 </div>
             </div>
             <div class="right">
-                <a href="{% url "wagtailadmin_workflows:task_index" %}?show_disabled={% if showing_disabled %}false{% else %}true{% endif %}" class="button button--icon w-inline-flex w-items-center">
+                <a href="{% url "wagtailadmin_workflows:task_index" %}?show_disabled={% if showing_disabled %}false{% else %}true{% endif %}" class="button button-secondary button--icon w-inline-flex w-items-center w-gap-2">
                     {% if showing_disabled %}
-                        {% icon name="no-view" class_name="w-mr-2" %}{% trans "Hide disabled tasks" %}
+                        {% icon name="no-view" %}{% trans "Hide disabled tasks" %}
                     {% else %}
-                        {% icon name="view" class_name="w-mr-2" %}{% trans "Show disabled tasks" %}
+                        {% icon name="view" %}{% trans "Show disabled tasks" %}
                     {% endif %}
                 </a>
                 <a href="{% url view.add_url_name %}" class="button bicolor icon icon-plus">{{ view.add_item_label }}</a>

--- a/wagtail/admin/tests/pages/test_explorer_view.py
+++ b/wagtail/admin/tests/pages/test_explorer_view.py
@@ -734,7 +734,7 @@ class TestLocaleSelector(TestCase, WagtailTestUtils):
         )
         self.assertContains(
             response,
-            f'<a href="{add_translation_url}" aria-label="French" class="u-link is-live">',
+            f'<a href="{add_translation_url}" aria-label="French" class="u-link is-live w-no-underline">',
         )
 
     @override_settings(WAGTAIL_I18N_ENABLED=False)
@@ -750,5 +750,5 @@ class TestLocaleSelector(TestCase, WagtailTestUtils):
         )
         self.assertNotContains(
             response,
-            f'<a href="{add_translation_url}" aria-label="French" class="u-link is-live">',
+            f'<a href="{add_translation_url}" aria-label="French" class="u-link is-live w-no-underline">',
         )

--- a/wagtail/admin/tests/test_page_chooser.py
+++ b/wagtail/admin/tests/test_page_chooser.py
@@ -1024,7 +1024,7 @@ class TestCanChoosePage(TestCase, WagtailTestUtils):
 class TestPageChooserLocaleSelector(TestCase, WagtailTestUtils):
     fixtures = ["test.json"]
 
-    LOCALE_SELECTOR_HTML = '<a href="javascript:void(0)" aria-label="English" class="c-dropdown__button  u-btn-current">'
+    LOCALE_SELECTOR_HTML = '<a href="javascript:void(0)" aria-label="English" class="c-dropdown__button u-btn-current w-no-underline">'
     LOCALE_INDICATOR_HTML = '<use href="#icon-site"></use></svg>\n    English'
 
     def setUp(self):
@@ -1044,7 +1044,7 @@ class TestPageChooserLocaleSelector(TestCase, WagtailTestUtils):
         switch_to_french_url = self.get_choose_page_url(
             self.fr_locale, parent_page_id=self.child_page_fr.pk
         )
-        self.LOCALE_SELECTOR_HTML_FR = f'<a href="{switch_to_french_url}" aria-label="French" class="u-link is-live">'
+        self.LOCALE_SELECTOR_HTML_FR = f'<a href="{switch_to_french_url}" aria-label="French" class="u-link is-live w-no-underline">'
 
         self.login()
 
@@ -1075,7 +1075,7 @@ class TestPageChooserLocaleSelector(TestCase, WagtailTestUtils):
         self.assertIn(self.LOCALE_SELECTOR_HTML, html)
 
         switch_to_french_url = self.get_choose_page_url(locale=self.fr_locale)
-        fr_selector = f'<a href="{switch_to_french_url}" aria-label="French" class="u-link is-live">'
+        fr_selector = f'<a href="{switch_to_french_url}" aria-label="French" class="u-link is-live w-no-underline">'
         self.assertIn(fr_selector, html)
 
     def test_locale_selector(self):
@@ -1104,14 +1104,14 @@ class TestPageChooserLocaleSelector(TestCase, WagtailTestUtils):
         self.assertNotIn(f'data-title="{self.root_page.title}"', html)
         self.assertIn(self.root_page_fr.title, html)
         self.assertIn(
-            '<a href="javascript:void(0)" aria-label="French" class="c-dropdown__button  u-btn-current">',
+            '<a href="javascript:void(0)" aria-label="French" class="c-dropdown__button u-btn-current w-no-underline">',
             html,
         )
         switch_to_english_url = self.get_choose_page_url(
             locale=Locale.objects.get(language_code="en")
         )
         self.assertIn(
-            f'<a href="{switch_to_english_url}" aria-label="English" class="u-link is-live">',
+            f'<a href="{switch_to_english_url}" aria-label="English" class="u-link is-live w-no-underline">',
             html,
         )
 

--- a/wagtail/admin/views/reports/aging_pages.py
+++ b/wagtail/admin/views/reports/aging_pages.py
@@ -33,6 +33,7 @@ class AgingPagesReportFilterSet(WagtailFilterSet):
 class AgingPagesView(PageReportView):
     template_name = "wagtailadmin/reports/aging_pages.html"
     title = _("Aging pages")
+    header_icon = "time"
     filterset_class = AgingPagesReportFilterSet
     export_headings = {
         "status_string": _("Status"),

--- a/wagtail/contrib/forms/templates/wagtailforms/index_submissions.html
+++ b/wagtail/contrib/forms/templates/wagtailforms/index_submissions.html
@@ -81,7 +81,7 @@
     </script>
 {% endblock %}
 {% block content %}
-    <header class="nice-padding">
+    <header>
         <form action="" method="get" novalidate>
             <div class="row">
                 <div class="left">

--- a/wagtail/contrib/forms/templates/wagtailforms/index_submissions.html
+++ b/wagtail/contrib/forms/templates/wagtailforms/index_submissions.html
@@ -85,9 +85,9 @@
         <form action="" method="get" novalidate>
             <div class="row">
                 <div class="left">
-                    <div class="col header-title">
+                    <div class="col">
                         <h1>
-                            {% icon name="form" class_name="header-title-icon" %}
+                            {% icon name="form" %}
                             {% blocktrans trimmed with form_title=form_page.title|capfirst %}Form data <span>{{ form_title }}</span>{% endblocktrans %}
                         </h1>
                     </div>

--- a/wagtail/contrib/forms/tests/test_views.py
+++ b/wagtail/contrib/forms/tests/test_views.py
@@ -267,10 +267,10 @@ class TestFormsIndexWithLocalisationEnabled(TestCase, WagtailTestUtils):
             )
 
     def get_switch_current_locale_markup(self, locale):
-        return f'<a href="javascript:void(0)" aria-label="{locale.get_display_name()}" class="c-dropdown__button  u-btn-current">'
+        return f'<a href="javascript:void(0)" aria-label="{locale.get_display_name()}" class="c-dropdown__button u-btn-current w-no-underline">'
 
     def get_switch_link_markup(self, locale):
-        return f'<a href="{self.forms_index_url}?locale={locale.language_code}" aria-label="{locale.get_display_name()}" class="u-link is-live">'
+        return f'<a href="{self.forms_index_url}?locale={locale.language_code}" aria-label="{locale.get_display_name()}" class="u-link is-live w-no-underline">'
 
     def test_forms_index(self):
         response = self.client.get(self.forms_index_url)

--- a/wagtail/contrib/modeladmin/templates/modeladmin/index.html
+++ b/wagtail/contrib/modeladmin/templates/modeladmin/index.html
@@ -17,7 +17,7 @@
     {% block header %}
         <header class="hasform">
             {% block breadcrumb %}{% endblock %}
-            <div class="row nice-padding">
+            <div class="row">
                 <div class="left header-left">
                     <div class="col header-title">
                         {% block h1 %}

--- a/wagtail/contrib/modeladmin/templates/modeladmin/index.html
+++ b/wagtail/contrib/modeladmin/templates/modeladmin/index.html
@@ -19,10 +19,10 @@
             {% block breadcrumb %}{% endblock %}
             <div class="row">
                 <div class="left header-left">
-                    <div class="col header-title">
+                    <div class="col">
                         {% block h1 %}
                             <h1>
-                                {% if view.header_icon %}{% icon name=view.header_icon class_name="header-title-icon" %}{% endif %}
+                                {% if view.header_icon %}{% icon name=view.header_icon %}{% endif %}
                                 {{ view.get_page_title }}
                                 {% if view.get_page_subtitle %} <span>{{ view.get_page_subtitle }}</span> {% endif %}
                                 {% include 'modeladmin/includes/result_count.html' %}

--- a/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
+++ b/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
@@ -454,12 +454,12 @@ class TestTranslatableCreateView(TestCase, WagtailTestUtils):
         self.assertEqual(response.status_code, 200)
 
         # Check that the locale select exists and is set correctly
-        expected = '<a href="javascript:void(0)" aria-label="French" class="c-dropdown__button  u-btn-current">'
+        expected = '<a href="javascript:void(0)" aria-label="French" class="c-dropdown__button u-btn-current w-no-underline">'
         self.assertContains(response, expected)
 
         # Check that the other locale link is right
         expected = """
-        <a href="/admin/modeladmintest/translatablebook/create/?locale=en" aria-label="English" class="u-link is-live">
+        <a href="/admin/modeladmintest/translatablebook/create/?locale=en" aria-label="English" class="u-link is-live w-no-underline">
             English
         </a>"""
         self.assertContains(response, expected, html=True)
@@ -695,7 +695,7 @@ class TestTranslatableBookEditView(TestCase, WagtailTestUtils):
 
         # Check the locale switcher is there
         expected = """
-        <a href="/admin/modeladmintest/translatablebook/edit/1/?locale=en" aria-label="English" class="u-link is-live">
+        <a href="/admin/modeladmintest/translatablebook/edit/1/?locale=en" aria-label="English" class="u-link is-live w-no-underline">
             English
         </a>"""
         self.assertContains(response, expected, html=True)

--- a/wagtail/contrib/redirects/templates/wagtailredirects/index.html
+++ b/wagtail/contrib/redirects/templates/wagtailredirects/index.html
@@ -31,7 +31,7 @@
             {% block breadcrumb %}{% endblock %}
             <div class="row">
                 <div class="left">
-                    <div class="col header-title">
+                    <div class="col">
                         <h1 class="icon icon-redirect">{{ redirects_str }}</h1>
                     </div>
                     <form class="col search-form" action="{% url "wagtailredirects:index" %}{% if query_parameters %}?{{ query_parameters }}{% endif %}" method="get" novalidate role="search">

--- a/wagtail/contrib/redirects/templates/wagtailredirects/index.html
+++ b/wagtail/contrib/redirects/templates/wagtailredirects/index.html
@@ -29,7 +29,7 @@
 
         <header class="hasform">
             {% block breadcrumb %}{% endblock %}
-            <div class="row nice-padding">
+            <div class="row">
                 <div class="left">
                     <div class="col header-title">
                         <h1 class="icon icon-redirect">{{ redirects_str }}</h1>

--- a/wagtail/contrib/redirects/templates/wagtailredirects/index.html
+++ b/wagtail/contrib/redirects/templates/wagtailredirects/index.html
@@ -32,7 +32,7 @@
             <div class="row">
                 <div class="left">
                     <div class="col">
-                        <h1 class="icon icon-redirect">{{ redirects_str }}</h1>
+                        <h1>{% icon name="redirect" %}{{ redirects_str }}</h1>
                     </div>
                     <form class="col search-form" action="{% url "wagtailredirects:index" %}{% if query_parameters %}?{{ query_parameters }}{% endif %}" method="get" novalidate role="search">
                         <ul class="fields">

--- a/wagtail/contrib/settings/templates/wagtailsettings/edit.html
+++ b/wagtail/contrib/settings/templates/wagtailsettings/edit.html
@@ -3,7 +3,7 @@
 {% block titletag %}{% blocktrans trimmed %}Editing {{ setting_type_name}} - {{ instance }}{% endblocktrans %}{% endblock %}
 {% block bodyclass %}menu-settings{% endblock %}
 {% block content %}
-    <header class="nice-padding merged">
+    <header class="merged">
         <div class="row">
             <div class="left">
                 <div class="col">

--- a/wagtail/contrib/settings/templates/wagtailsettings/edit.html
+++ b/wagtail/contrib/settings/templates/wagtailsettings/edit.html
@@ -8,7 +8,7 @@
             <div class="left">
                 <div class="col">
                     <h1>
-                        {% icon name="cogs" class_name="header-title-icon" %}
+                        {% icon name="cogs" %}
                         {% trans "Editing" %}
                         <span>{{ setting_type_name|capfirst }}</span>
                     </h1>

--- a/wagtail/contrib/styleguide/templates/wagtailstyleguide/base.html
+++ b/wagtail/contrib/styleguide/templates/wagtailstyleguide/base.html
@@ -626,7 +626,7 @@
             </div>
 
             <p>These can also have an inverted  theme:</p>
-            <header class="nice-padding">
+            <header>
                 <div class="c-dropdown  t-inverted" data-dropdown="">
                     <a class="c-dropdown__button  u-btn-current">
                         More

--- a/wagtail/snippets/templates/wagtailsnippets/snippets/type_index.html
+++ b/wagtail/snippets/templates/wagtailsnippets/snippets/type_index.html
@@ -19,7 +19,7 @@
 {% block content %}
 
     <header>
-        <div class="row row-flush">
+        <div class="row">
             <div class="left">
                 <div class="col">
                     <h1>{% icon name="snippet" %}

--- a/wagtail/snippets/templates/wagtailsnippets/snippets/type_index.html
+++ b/wagtail/snippets/templates/wagtailsnippets/snippets/type_index.html
@@ -18,7 +18,7 @@
 
 {% block content %}
 
-    <header class="nice-padding">
+    <header>
         <div class="row row-flush">
             <div class="left">
                 <div class="col header-title">

--- a/wagtail/snippets/templates/wagtailsnippets/snippets/type_index.html
+++ b/wagtail/snippets/templates/wagtailsnippets/snippets/type_index.html
@@ -21,8 +21,8 @@
     <header>
         <div class="row row-flush">
             <div class="left">
-                <div class="col header-title">
-                    <h1>{% icon name="snippet" class_name="header-title-icon" %}
+                <div class="col">
+                    <h1>{% icon name="snippet" %}
                         {% blocktrans trimmed with snippet_type_name_plural=model_opts.verbose_name_plural|capfirst %}Snippets <span>{{ snippet_type_name_plural }}</span>{% endblocktrans %}</h1>
 
                     {% if is_searchable and search_url %}

--- a/wagtail/snippets/tests.py
+++ b/wagtail/snippets/tests.py
@@ -195,7 +195,7 @@ class TestLocaleSelectorOnList(TestCase, WagtailTestUtils):
         )
         self.assertContains(
             response,
-            f'<a href="{switch_to_french_url}" aria-label="French" class="u-link is-live">',
+            f'<a href="{switch_to_french_url}" aria-label="French" class="u-link is-live w-no-underline">',
         )
 
         # Check that the add URLs include the locale
@@ -223,7 +223,7 @@ class TestLocaleSelectorOnList(TestCase, WagtailTestUtils):
         )
         self.assertNotContains(
             response,
-            f'<a href="{switch_to_french_url}" aria-label="French" class="u-link is-live">',
+            f'<a href="{switch_to_french_url}" aria-label="French" class="u-link is-live w-no-underline">',
         )
 
         # Check that the add URLs don't include the locale
@@ -239,7 +239,9 @@ class TestLocaleSelectorOnList(TestCase, WagtailTestUtils):
     def test_locale_selector_not_present_on_non_translatable_snippet(self):
         response = self.client.get(reverse("wagtailsnippets_tests_advert:list"))
 
-        self.assertNotContains(response, 'aria-label="French" class="u-link is-live">')
+        self.assertNotContains(
+            response, 'aria-label="French" class="u-link is-live w-no-underline">'
+        )
 
         # Check that the add URLs don't include the locale
         add_url = reverse("wagtailsnippets_tests_advert:add")
@@ -577,7 +579,7 @@ class TestLocaleSelectorOnCreate(TestCase, WagtailTestUtils):
         )
         self.assertContains(
             response,
-            f'<a href="{switch_to_french_url}" aria-label="French" class="u-link is-live">',
+            f'<a href="{switch_to_french_url}" aria-label="French" class="u-link is-live w-no-underline">',
         )
 
     @override_settings(WAGTAIL_I18N_ENABLED=False)
@@ -592,7 +594,7 @@ class TestLocaleSelectorOnCreate(TestCase, WagtailTestUtils):
         )
         self.assertNotContains(
             response,
-            f'<a href="{switch_to_french_url}" aria-label="French" class="u-link is-live">',
+            f'<a href="{switch_to_french_url}" aria-label="French" class="u-link is-live w-no-underline">',
         )
 
     def test_locale_selector_not_present_on_non_translatable_snippet(self):
@@ -603,7 +605,7 @@ class TestLocaleSelectorOnCreate(TestCase, WagtailTestUtils):
         )
         self.assertNotContains(
             response,
-            f'<a href="{switch_to_french_url}" aria-label="French" class="u-link is-live">',
+            f'<a href="{switch_to_french_url}" aria-label="French" class="u-link is-live w-no-underline">',
         )
 
 
@@ -899,7 +901,7 @@ class TestEditFileUploadSnippet(BaseTestSnippetEditView):
 class TestLocaleSelectorOnEdit(BaseTestSnippetEditView):
     fixtures = ["test.json"]
 
-    LOCALE_SELECTOR_HTML = '<a href="javascript:void(0)" aria-label="English" class="c-dropdown__button  u-btn-current">'
+    LOCALE_SELECTOR_HTML = '<a href="javascript:void(0)" aria-label="English" class="c-dropdown__button u-btn-current w-no-underline">'
     LOCALE_INDICATOR_HTML = '<use href="#icon-site"></use></svg>\n    English'
 
     def setUp(self):
@@ -920,7 +922,7 @@ class TestLocaleSelectorOnEdit(BaseTestSnippetEditView):
         )
         self.assertContains(
             response,
-            f'<a href="{switch_to_french_url}" aria-label="French" class="u-link is-live">',
+            f'<a href="{switch_to_french_url}" aria-label="French" class="u-link is-live w-no-underline">',
         )
 
     def test_locale_selector_without_translation(self):
@@ -936,7 +938,7 @@ class TestLocaleSelectorOnEdit(BaseTestSnippetEditView):
         )
         self.assertNotContains(
             response,
-            f'<a href="{switch_to_french_url}" aria-label="French" class="u-link is-live">',
+            f'<a href="{switch_to_french_url}" aria-label="French" class="u-link is-live w-no-underline">',
         )
 
     @override_settings(WAGTAIL_I18N_ENABLED=False)
@@ -951,7 +953,7 @@ class TestLocaleSelectorOnEdit(BaseTestSnippetEditView):
         )
         self.assertNotContains(
             response,
-            f'<a href="{switch_to_french_url}" aria-label="French" class="u-link is-live">',
+            f'<a href="{switch_to_french_url}" aria-label="French" class="u-link is-live w-no-underline">',
         )
 
     def test_locale_selector_not_present_on_non_translatable_snippet(self):

--- a/wagtail/users/templates/wagtailusers/groups/index.html
+++ b/wagtail/users/templates/wagtailusers/groups/index.html
@@ -1,11 +1,11 @@
 {% extends "wagtailadmin/base.html" %}
 {% load i18n %}
-{% block titletag %}{% trans "groups" %}{% endblock %}
+{% block titletag %}{{ page_title }}{% endblock %}
 {% block extra_js %}
     {{ block.super }}
     <script>
         window.headerSearch = {
-            url: "{% url 'wagtailusers_groups:index' %}",
+            url: "{% url view.index_url_name %}",
             termInput: "#id_q",
             targetOutput: "#group-results"
         }
@@ -13,10 +13,8 @@
 {% endblock %}
 
 {% block content %}
-    {% trans "groups" as groups_str %}
-    {% trans "Add a group" as add_a_group_str %}
-    {% url "wagtailusers_groups:add" as add_link %}
-    {% include "wagtailadmin/shared/header.html" with title=groups_str action_url=add_link action_text=add_a_group_str icon="group" search_url="wagtailusers_groups:index" %}
+    {% url view.add_url_name as add_link %}
+    {% include "wagtailadmin/shared/header.html" with title=page_title action_url=add_link action_text=view.add_item_label icon=header_icon search_url=view.index_url_name %}
 
     <div class="nice-padding">
         <div id="group-results" class="groups">


### PR DESCRIPTION
Changes are as follows:

**Remove the header background and update fonts and spacing as per design**

_Note that the header text should now start in a fixed position, no matter how wide the icon is (of if one is even set)._

Before:
![image](https://user-images.githubusercontent.com/1093808/165586907-fe30ef8d-91f8-49aa-9ad1-b88c81f4438b.png) 

After:
![image](https://user-images.githubusercontent.com/1093808/165586979-925f2b6c-5918-4b75-9658-ab518f3bb2c9.png)

**Fix hidden icon on workflow tasks index and align the icon with the text. And make it a secondary button**

| Before | After |
| --- | --- |
|  ![image](https://user-images.githubusercontent.com/1093808/165587860-f2ec014c-88e2-45af-b59d-bf1fc7b1a554.png) | ![image](https://user-images.githubusercontent.com/1093808/165587945-bfa8e6f5-b9a1-425c-a753-8d1cb63faf7d.png)

**Fix alignment of icons in bicolour buttons**

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/1093808/165588192-2e0fd9eb-cb25-4fa3-8b5d-ec13e8566f51.png) | ![image](https://user-images.githubusercontent.com/1093808/165588388-d93e3033-dec0-4c84-8a71-4afee9173433.png)
| ![image](https://user-images.githubusercontent.com/1093808/165588314-e9daacc5-034e-473c-a5e0-5887252c0b0d.png) | ![image](https://user-images.githubusercontent.com/1093808/165588477-83ac98bb-6cbf-439d-8289-e4cd2d37135e.png)

**Add a couple of missing header icons on aging pages report and account form**

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/1093808/165588852-cf238014-4385-4da4-96ff-e0ad9717649e.png) | ![image](https://user-images.githubusercontent.com/1093808/165588922-222d6ead-69da-47fd-b8a7-feca28f5ce62.png) |
| ![image](https://user-images.githubusercontent.com/1093808/165589116-f0f64149-654d-44be-90a9-aea929220911.png) | ![image](https://user-images.githubusercontent.com/1093808/165589169-c691606c-b2b3-457a-8bb3-fb782a06673c.png) |

**Remove underline from locale selector**

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/1093808/165590340-f13fa382-220e-43ff-9553-3fd245b2c0db.png) | ![image](https://user-images.githubusercontent.com/1093808/165590516-3795fbed-9512-4e42-81b0-2b52a7be4979.png)

**Use default field styling in headers. Fix alignment of search icon and make it teal**

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/1093808/165590811-a9eed2e8-6501-401b-8a4f-205dcc62eaef.png) | ![image](https://user-images.githubusercontent.com/1093808/165590872-513209f6-9231-4275-aa0b-de5f0eaefeaf.png) |

**Fix flat checkbox in reports**

Noticed this one in testing, but definitely looks like something we should fix for 3.0!

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/1093808/165591206-f579c615-c20a-4063-9d90-eb5c730c01cc.png) | ![image](https://user-images.githubusercontent.com/1093808/165591314-b8367992-30d0-481a-aaba-020aa93e9798.png) |

**Use accessible colour for date field icons and fix alignment**

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/1093808/165594170-30b57820-ba81-4707-8d9a-762c4786f15c.png) | ![image](https://user-images.githubusercontent.com/1093808/165594260-6b208325-7d98-4492-97f6-f6664e36c186.png) |
| ![image](https://user-images.githubusercontent.com/1093808/165594451-35b0cb38-7cda-4a86-9d82-ef5979a14189.png) | ![image](https://user-images.githubusercontent.com/1093808/165594737-ed8382b4-04ed-4cd8-ac2a-f3766b227394.png) |

**Fix layout of "move page - choose destination" template**

This issue was caused by earlier changes. Putting this screenshot here to show what that commit is doing.

Before:
![image](https://user-images.githubusercontent.com/1093808/165598552-b90dc0ee-1ea4-448e-a00a-7f50b4d01dc7.png)

After:
![image](https://user-images.githubusercontent.com/1093808/165598629-e076a069-d57b-45d3-b51e-5256b6c9515a.png)


**Other changes**

 - Update groups index template to take header configuration from view (this fixes the capitalisation issue with the "Groups" title)
 - Switch to SVG icon on redirects index