### PR TITLE
Resize textareas onload and tab-changed event

### DIFF
--- a/client/src/entrypoints/admin/core.js
+++ b/client/src/entrypoints/admin/core.js
@@ -252,12 +252,12 @@ $(() => {
     });
   }
 
+  console.log('core.js init');
   // Resize autosize textareas on page load and tab changed
   $(document).ready(resizeTextAreas);
-  $(document).ready(() => {
-    $(document).on('tab-changed', () => {
-      resizeTextAreas();
-    });
+  $(document).on('wagtail:tab-changed', () => {
+    console.log('core.js tab-changed event listener');
+    resizeTextAreas();
   });
 
   // eslint-disable-next-line func-names

--- a/client/src/entrypoints/admin/core.js
+++ b/client/src/entrypoints/admin/core.js
@@ -252,11 +252,9 @@ $(() => {
     });
   }
 
-  // Resize autosize textareas on page load and tab changed
+  // Resize textareas on page load and when tab changed
   $(document).ready(resizeTextAreas);
-  $(document).on('wagtail:tab-changed', () => {
-    resizeTextAreas();
-  });
+  document.addEventListener('wagtail:tab-changed', resizeTextAreas);
 
   // eslint-disable-next-line func-names
   $('.dropdown').each(function () {

--- a/client/src/entrypoints/admin/core.js
+++ b/client/src/entrypoints/admin/core.js
@@ -252,11 +252,9 @@ $(() => {
     });
   }
 
-  console.log('core.js init');
   // Resize autosize textareas on page load and tab changed
   $(document).ready(resizeTextAreas);
   $(document).on('wagtail:tab-changed', () => {
-    console.log('core.js tab-changed event listener');
     resizeTextAreas();
   });
 

--- a/client/src/entrypoints/admin/core.js
+++ b/client/src/entrypoints/admin/core.js
@@ -244,12 +244,19 @@ $(() => {
   });
 
   /* Functions that need to run/rerun when active tabs are changed */
-  document.addEventListener('tab-changed', () => {
-    // Resize autosize textareas
+  function resizeTextAreas() {
     // eslint-disable-next-line func-names
     $('textarea[data-autosize-on]').each(function () {
       // eslint-disable-next-line no-undef
       autosize.update($(this).get());
+    });
+  }
+
+  // Resize autosize textareas on page load and tab changed
+  $(document).ready(resizeTextAreas);
+  $(document).ready(() => {
+    $(document).on('tab-changed', () => {
+      resizeTextAreas();
     });
   });
 

--- a/client/src/includes/tabs.js
+++ b/client/src/includes/tabs.js
@@ -230,13 +230,6 @@ class Tabs {
         }
       }
     });
-
-    // Dispatch tab-changed on window load
-    window.onload = () => {
-      if (this.tabContainer) {
-        document.dispatchEvent(new CustomEvent('wagtail:tab-changed'));
-      }
-    };
   }
 
   /**
@@ -333,4 +326,11 @@ export default Tabs;
 
 export const initTabs = (tabs = document.querySelectorAll('[data-tabs]')) => {
   tabs.forEach((tabSet) => new Tabs(tabSet));
+
+  // Dispatch tab-changed on window load
+  if (tabs) {
+    document.addEventListener('DOMContentLoaded', () => {
+      document.dispatchEvent(new CustomEvent('wagtail:tab-changed'));
+    });
+  }
 };

--- a/client/src/includes/tabs.js
+++ b/client/src/includes/tabs.js
@@ -164,7 +164,7 @@ class Tabs {
       }),
     );
     // Dispatch tab-changed event on the document
-    document.dispatchEvent(new CustomEvent('tab-changed'));
+    document.dispatchEvent(new CustomEvent('wagtail:tab-changed'));
 
     // Set URL hash and browser history
     if (!this.disableURL) {
@@ -230,6 +230,13 @@ class Tabs {
         }
       }
     });
+
+    // Dispatch tab-changed on window load
+    window.onload = () => {
+      if (this.tabContainer) {
+        document.dispatchEvent(new CustomEvent('wagtail:tab-changed'));
+      }
+    };
   }
 
   /**


### PR DESCRIPTION
Addresses an issue where textareas with multiple lines were losing their autosizing. 

**Cause** 
Textareas are resized with Jquery when a tab-changed event is fired, however they weren't being resized on page load either (so pages using textareas without tabs would have had that issue as well).
The new tabs component does fire a tab-changed however this is happening before core.js initializes and is listening for them.

**Solution**
- Dispatch tab-changed event when content is loaded so that core.js has attached the event listeners and autosizes textareas. 
- Resize text areas on document ready as well to catch any text areas that need resizing outside of tabs

### Screenshots

**Before fix**
![Screen Shot 2022-04-27 at 11 45 08 AM](https://user-images.githubusercontent.com/25041665/165588132-19b4d057-7bb3-4e2f-8731-4e667f0c84d4.png)
**After fix**
![Screen Shot 2022-04-27 at 11 06 46 AM](https://user-images.githubusercontent.com/25041665/165588136-52bd11ad-a1d2-4e8f-b451-2baa706663d7.png)

### Browsers tested on 
Chrome 100, Safari 15.2, Firefox 99
