### PR TITLE
Restyle badge for tab errors

### DIFF
--- a/client/scss/components/_tabs.scss
+++ b/client/scss/components/_tabs.scss
@@ -47,26 +47,19 @@
 
   &__errors {
     @apply w-hidden
-    w-box-border
-    w-w-4
-    w-h-4
-    w-text-[0.75rem]
-    w-flex
-    w-justify-center
-    w-items-center
+    w-absolute
+    -w-mr-3
+    w-py-0.5
+    w-px-[0.325rem]
+    w-top-1
+    -w-right-1
+    w-text-[0.5625rem]
     w-font-bold
     w-bg-critical-200
     w-text-white
     w-border
-    w-border-white
-    w-rounded-full
-    w-absolute
-    w-top-[0.4375rem]
-    -w-right-[0.9375rem];
-
-    &--active {
-      @apply w-flex;
-    }
+    w-border-grey-50
+    w-rounded-[1rem];
   }
 
   // Optional animate attr for tabs to animate in

--- a/client/src/entrypoints/admin/page-editor.js
+++ b/client/src/entrypoints/admin/page-editor.js
@@ -256,9 +256,9 @@ function initErrorDetection() {
   // eslint-disable-next-line guard-for-in
   for (const index in errorSections) {
     $('[data-tabs] a[href="#' + index + '"]')
-      .find('.w-tabs__errors')
-      .addClass('w-tabs__errors--active')
-      .find('.w-tabs__errors-count')
+      .find('[data-tabs-errors]')
+      .addClass('!w-flex')
+      .find('[data-tabs-errors-count]')
       .text(errorSections[index]);
   }
 }

--- a/wagtail/admin/templates/wagtailadmin/shared/tabs/tab_nav_link.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/tabs/tab_nav_link.html
@@ -11,9 +11,9 @@
 {% endcomment %}
 
 <a id="tab-label-{{ tab_id|cautious_slugify }}" href="#tab-{{ tab_id|cautious_slugify }}" class="w-tabs__tab {{ classes }}" role="tab" aria-selected="false" tabindex="-1">
-    <div class="w-tabs__errors {% if errors_count %}w-tabs__errors--active{% endif %}">
+    <div data-tabs-errors class="w-tabs__errors {% if errors_count %}!w-flex{% endif %}">
         <span class="w-sr-only">{% trans 'Errors Count: ' %}</span>
-        <span class="w-tabs__errors-count">{{ errors_count }}</span>
+        <span data-tabs-errors-count>{{ errors_count }}</span>
     </div>
     {{ title }}
 </a>


### PR DESCRIPTION
Restyle badge for tab errors as part of Apr 25 design review #8399 

### Screenshots
<img width="460" alt="Screen Shot 2022-04-28 at 12 21 28 AM" src="https://user-images.githubusercontent.com/25041665/165690635-aad0a905-7d22-425b-82ed-5a40da1bfb60.png">

### Browsers tested on 
Chrome 100, firefox 99, safari 15.2
Windows: chrome 99