### PR TITLE
Re-add Pages explorer focus trap. Fixes #8035

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -87,6 +87,7 @@ Changelog
  * Fix: Ignore `GenericRelation` when copying pages (John-Scott Atlakson)
  * Fix: Implement ARIA tabs markup and keyboards interactions for admin tabs (Steven Steinwand)
  * Fix: Ensure `wagtail updatemodulepaths` works when system locale is not UTF-8 (Matt Westcott)
+ * Fix: Re-establish focus trap for Pages explorer in slim sidebar (Thibaud Colas)
 
 
 2.16.2 (11.04.2022)

--- a/client/src/components/PageExplorer/PageExplorer.tsx
+++ b/client/src/components/PageExplorer/PageExplorer.tsx
@@ -46,7 +46,6 @@ const mapStateToProps = (state: State) => ({
 const mapDispatchToProps = (dispatch) => ({
   gotoPage: (id: number, transition: number) =>
     dispatch(actions.gotoPage(id, transition)),
-  onClose: () => dispatch(actions.closePageExplorer()),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(PageExplorer);

--- a/client/src/components/PageExplorer/PageExplorerPanel.tsx
+++ b/client/src/components/PageExplorer/PageExplorerPanel.tsx
@@ -125,7 +125,8 @@ class PageExplorerPanel extends React.Component<
         paused={!page || page.isFetchingChildren || page.isFetchingTranslations}
         focusTrapOptions={{
           onDeactivate: onClose,
-          clickOutsideDeactivates: true,
+          clickOutsideDeactivates: false,
+          allowOutsideClick: true,
         }}
       >
         <div role="dialog">

--- a/client/src/components/PageExplorer/PageExplorerPanel.tsx
+++ b/client/src/components/PageExplorer/PageExplorerPanel.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import FocusTrap from 'focus-trap-react';
 
 import { gettext } from '../../utils/gettext';
 import { MAX_EXPLORER_PAGES } from '../../config/wagtailConfig';
@@ -116,33 +117,44 @@ class PageExplorerPanel extends React.Component<
   }
 
   render() {
-    const { page, depth, gotoPage } = this.props;
+    const { page, depth, gotoPage, onClose } = this.props;
     const { transition } = this.state;
 
     return (
-      <Transition
-        name={transition}
-        className="c-page-explorer"
-        component="nav"
-        label={gettext('Page explorer')}
+      <FocusTrap
+        paused={!page || page.isFetchingChildren || page.isFetchingTranslations}
+        focusTrapOptions={{
+          onDeactivate: onClose,
+          clickOutsideDeactivates: true,
+        }}
       >
-        <div key={depth} className="c-transition-group">
-          <PageExplorerHeader
-            depth={depth}
-            page={page}
-            onClick={this.onHeaderClick}
-            gotoPage={gotoPage}
-            navigate={this.props.navigate}
-          />
+        <div role="dialog">
+          <Transition
+            name={transition}
+            className="c-page-explorer"
+            component="nav"
+            label={gettext('Page explorer')}
+          >
+            <div key={depth} className="c-transition-group">
+              <PageExplorerHeader
+                depth={depth}
+                page={page}
+                onClick={this.onHeaderClick}
+                gotoPage={gotoPage}
+                navigate={this.props.navigate}
+              />
 
-          {this.renderChildren()}
+              {this.renderChildren()}
 
-          {page.isError ||
-          (page.children.items && page.children.count > MAX_EXPLORER_PAGES) ? (
-            <PageCount page={page} />
-          ) : null}
+              {page.isError ||
+              (page.children.items &&
+                page.children.count > MAX_EXPLORER_PAGES) ? (
+                <PageCount page={page} />
+              ) : null}
+            </div>
+          </Transition>
         </div>
-      </Transition>
+      </FocusTrap>
     );
   }
 }

--- a/client/src/components/Sidebar/menu/PageExplorerMenuItem.tsx
+++ b/client/src/components/Sidebar/menu/PageExplorerMenuItem.tsx
@@ -27,6 +27,17 @@ export const PageExplorerMenuItem: React.FunctionComponent<
     store.current = initPageExplorerStore();
   }
 
+  const onCloseExplorer = () => {
+    // When a submenu is closed, we have to wait for the close animation
+    // to finish before making it invisible
+    setTimeout(() => {
+      setIsVisible(false);
+      if (store.current) {
+        store.current.dispatch(closePageExplorer());
+      }
+    }, SIDEBAR_TRANSITION_DURATION);
+  };
+
   React.useEffect(() => {
     if (isOpen) {
       // isOpen is set at the moment the user clicks the menu item
@@ -36,14 +47,7 @@ export const PageExplorerMenuItem: React.FunctionComponent<
         store.current.dispatch(openPageExplorer(item.startPageId));
       }
     } else if (!isOpen && isVisible) {
-      // When a submenu is closed, we have to wait for the close animation
-      // to finish before making it invisible
-      setTimeout(() => {
-        setIsVisible(false);
-        if (store.current) {
-          store.current.dispatch(closePageExplorer());
-        }
-      }, SIDEBAR_TRANSITION_DURATION);
+      onCloseExplorer();
     }
   }, [isOpen]);
 
@@ -95,7 +99,11 @@ export const PageExplorerMenuItem: React.FunctionComponent<
         >
           {store.current && (
             <Provider store={store.current}>
-              <PageExplorer isVisible={isVisible} navigate={navigate} />
+              <PageExplorer
+                isVisible={isVisible}
+                navigate={navigate}
+                onClose={onCloseExplorer}
+              />
             </Provider>
           )}
         </SidebarPanel>

--- a/docs/releases/3.0.md
+++ b/docs/releases/3.0.md
@@ -127,6 +127,7 @@ When using a queryset to render a list of items with images, you can now make us
  * Ignore `GenericRelation` when copying pages (John-Scott Atlakson)
  * Implement ARIA tabs markup and keyboards interactions for admin tabs (Steven Steinwand)
  * Ensure `wagtail updatemodulepaths` works when system locale is not UTF-8 (Matt Westcott)
+ * Re-establish focus trap for Pages explorer in slim sidebar (Thibaud Colas)
 
 
 ## Upgrade considerations - changes affecting all projects


### PR DESCRIPTION
Fixes #8035. Release blocker for Wagtail 3.0 RC3. This re-adds a focus trap around page explorer panels, based on the [original implementation](https://github.com/wagtail/wagtail/blob/01e147a5bb9eaa1ca529e8c2fe6589a2f9acbe26/client/src/components/Explorer/ExplorerPanel.tsx#L159-L169) we had of this.

The differences in implementation are because:

- The whole sidebar now has its own "click outside" behavior – so we don’t want the focus trap to have its own click-outside-closes implementation on top.
- We’re now allowing "click outside" within the sidebar to keep the explorer open, so we need to disable the focus-trap click outside plain and simple. And we don’t have to track a custom `paused` state.
- With the new page explorer implementation, on activation of the focus trap, we want the focus to move to its first item: the panel header. So we don’t need to set `initialFocus` – "first focusable item" is the default.

This implementation comes with one remaining defect which I’d like us to carry on as-is: when the explorer is opened, clicking the "Search" field _doesn’t_ move focus to the field. This is because even though we allow outside clicks, the focus itself can’t be set outside the focus trap. This might be fixable, but we’ve discussed proceeding with #8063 which would make this issue completely redundant, so it doesn’t feel worthwhile. If we wanted to fix this we could likely close the explorer on that specific click with `clickOutsideDeactivates` and `allowOutsideClick` as functions, checking what element the event is on.

- [x] Do the tests still pass?[^1]
- [x] Does the code comply with the style guide? 
    - [x] Run `make lint` from the Wagtail root. 
- ~~[ ] For Python changes: Have you added tests to cover the new/fixed behaviour?~~
- ~~[ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]~~
    - [x] **Please list the exact browser and operating system versions you tested**: Safari, Chrome, Firefox on macOS
    - [x] **Please list which assistive technologies [^3] you tested**: Safari + VoiceOver
- ~~[ ] For new features: Has the documentation been updated accordingly?~~

As far as testing this in particular, what’s most important to check is:

- Tab and back-tab should stay trapped once the explorer is open
- The explorer should remain opened when clicking on slim mode toggle
- The explorer should close when clicking on sub-menus in the main menu, and Account sub-menu