### PR TITLE
Update Azure frontend cache invalidator to use the newest Azure SDK

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,8 +49,8 @@ testing_extras = [
     "boto3>=1.16,<1.17",
     "freezegun>=0.3.8",
     "openpyxl>=2.6.4",
-    "azure-mgmt-cdn>=5.1,<6.0",
-    "azure-mgmt-frontdoor>=0.3,<0.4",
+    "azure-mgmt-cdn>=12,<13",
+    "azure-mgmt-frontdoor>=1,<2",
     "django-pattern-library>=0.7,<0.8",
     # For coverage and PEP8 linting
     "coverage>=3.7.0",

--- a/wagtail/contrib/frontend_cache/tests.py
+++ b/wagtail/contrib/frontend_cache/tests.py
@@ -149,8 +149,8 @@ class TestBackendConfiguration(TestCase):
         self.assertEqual(set(backends.keys()), {"azure_cdn"})
         client = backends["azure_cdn"]._get_client()
         self.assertIsInstance(client, CdnManagementClient)
-        self.assertEqual(client.config.subscription_id, "fake-subscription-id")
-        self.assertIs(client.config.credentials, mock_credentials)
+        self.assertEqual(client._config.subscription_id, "fake-subscription-id")
+        self.assertIs(client._config.credential, mock_credentials)
 
     def test_azure_front_door_get_client(self):
         mock_credentials = mock.MagicMock()
@@ -168,8 +168,8 @@ class TestBackendConfiguration(TestCase):
         client = backends["azure_front_door"]._get_client()
         self.assertEqual(set(backends.keys()), {"azure_front_door"})
         self.assertIsInstance(client, FrontDoorManagementClient)
-        self.assertEqual(client.config.subscription_id, "fake-subscription-id")
-        self.assertIs(client.config.credentials, mock_credentials)
+        self.assertEqual(client._config.subscription_id, "fake-subscription-id")
+        self.assertIs(client._config.credential, mock_credentials)
 
     @mock.patch(
         "wagtail.contrib.frontend_cache.backends.AzureCdnBackend._make_purge_call"
@@ -183,6 +183,7 @@ class TestBackendConfiguration(TestCase):
                     "CDN_PROFILE_NAME": "wagtail-io-profile",
                     "CDN_ENDPOINT_NAME": "wagtail-io-endpoint",
                     "CREDENTIALS": "Fake credentials",
+                    "SUBSCRIPTION_ID": "fake-subscription-id",
                 },
             }
         )
@@ -224,6 +225,7 @@ class TestBackendConfiguration(TestCase):
                     "RESOURCE_GROUP_NAME": "test-resource-group",
                     "FRONT_DOOR_NAME": "wagtail-io-front-door",
                     "CREDENTIALS": "Fake credentials",
+                    "SUBSCRIPTION_ID": "fake-subscription-id",
                 },
             }
         )


### PR DESCRIPTION
* Make Azure front-end cache invalidator compatible with the newest version of SDK packages.
   * Removes `CUSTOM_HEADERS` setting as that is no longer supported. 
* This will make it incompatible with the old Azure SDKs. Given we don't enforce versions this may be problematic. I can't see a benefit of maintaining the old version support given how recently this has been added to Wagtail.

PR that originally added the Azure backend: #6119.

## Testing locally

You will need Azure CDN and Front Door services provisioned.

Install the SDK libraries.

```
azure-mgmt-cdn
azure-mgmt-frontdoor
```

Set up the backend in you settings.

```python
WAGTAILFRONTENDCACHE = {
    'azure_cdn': {
        'BACKEND': 'wagtail.contrib.frontend_cache.backends.AzureCdnBackend',
        'RESOURCE_GROUP_NAME': '',
        'CDN_PROFILE_NAME': '',
        'CDN_ENDPOINT_NAME': '',
    },
    'azure_front_door': {
        'BACKEND': 'wagtail.contrib.frontend_cache.backends.AzureFrontDoorBackend',
        'RESOURCE_GROUP_NAME': '',
        'FRONT_DOOR_NAME': '',
    }
}
```

Test purging in your `./manage.py shell`.

```python
from  wagtail.contrib.frontend_cache.utils import get_backends

fd = get_backends()['azure_front_door']
fd.purge("/test/")

cdn = get_backends()['azure_cdn']
cdn.purge("/test/")
```