### PR TITLE
Ensure `wagtail updatemodulepaths` works when system locale is not UTF-8

### DIFF
--- a/wagtail/bin/wagtail.py
+++ b/wagtail/bin/wagtail.py
@@ -10,7 +10,7 @@ from difflib import unified_diff
 from django.core.management import ManagementUtility
 
 CURRENT_PYTHON = sys.version_info[:2]
-REQUIRED_PYTHON = (3, 5)
+REQUIRED_PYTHON = (3, 7)
 
 if CURRENT_PYTHON < REQUIRED_PYTHON:
     sys.stderr.write(
@@ -275,17 +275,33 @@ class UpdateModulePaths(Command):
 
     def _show_diff(self, filename, relative_path=None):
         change_count = 0
+        found_unicode_error = False
         original = []
         updated = []
 
-        with open(filename) as f:
-            for original_line in f:
-                original.append(original_line)
+        with open(filename, mode="rb") as f:
+            for raw_original_line in f:
+                try:
+                    original_line = raw_original_line.decode("utf-8")
+                except UnicodeDecodeError:
+                    found_unicode_error = True
+                    # retry decoding as utf-8, mangling invalid bytes so that we have a usable string to use the diff
+                    line = original_line = raw_original_line.decode(
+                        "utf-8", errors="replace"
+                    )
+                else:
+                    line = self._rewrite_line(original_line)
 
-                line = self._rewrite_line(original_line)
+                original.append(original_line)
                 updated.append(line)
                 if line != original_line:
                     change_count += 1
+
+        if found_unicode_error:
+            sys.stderr.write(
+                "Warning - %s is not a valid UTF-8 file. Lines with decode errors have been ignored\n"
+                % filename
+            )
 
         if change_count:
             relative_path = relative_path or filename
@@ -303,24 +319,49 @@ class UpdateModulePaths(Command):
 
     def _count_changes(self, filename):
         change_count = 0
+        found_unicode_error = False
 
-        with open(filename) as f:
-            for original_line in f:
-                line = self._rewrite_line(original_line)
-                if line != original_line:
-                    change_count += 1
+        with open(filename, mode="rb") as f:
+            for raw_original_line in f:
+                try:
+                    original_line = raw_original_line.decode("utf-8")
+                except UnicodeDecodeError:
+                    found_unicode_error = True
+                else:
+                    line = self._rewrite_line(original_line)
+                    if line != original_line:
+                        change_count += 1
+
+        if found_unicode_error:
+            sys.stderr.write(
+                "Warning - %s is not a valid UTF-8 file. Lines with decode errors have been ignored\n"
+                % filename
+            )
 
         return change_count
 
     def _rewrite_file(self, filename):
         change_count = 0
+        found_unicode_error = False
 
-        with fileinput.FileInput(filename, inplace=True) as f:
-            for original_line in f:
-                line = self._rewrite_line(original_line)
-                print(line, end="")  # NOQA
-                if line != original_line:
-                    change_count += 1
+        with fileinput.FileInput(filename, inplace=True, mode="rb") as f:
+            for raw_original_line in f:
+                try:
+                    original_line = raw_original_line.decode("utf-8")
+                except UnicodeDecodeError:
+                    sys.stdout.write(raw_original_line)
+                    found_unicode_error = True
+                else:
+                    line = self._rewrite_line(original_line)
+                    sys.stdout.write(line.encode("utf-8"))
+                    if line != original_line:
+                        change_count += 1
+
+        if found_unicode_error:
+            sys.stderr.write(
+                "Warning - %s is not a valid UTF-8 file. Lines with decode errors have been ignored\n"
+                % filename
+            )
 
         return change_count
 


### PR DESCRIPTION
Prompted by https://github.com/wagtail/wagtail/discussions/8362#discussioncomment-2647505 - Python files are expected to be in UTF-8, but `open()` will use the system default encoding, which is likely to be Windows-1252 on Windows. Unfortunately [fileinput](https://docs.python.org/3/library/fileinput.html) doesn't provide an encoding argument until Python 3.10, so we have to over-engineer things a bit to keep things consistent across the rewrite / list / diff modes - opening files in binary mode and explicitly decoding each line as utf-8 (with graceful fallback behaviour on UnicodeDecodeError, so that we don't end up clobbering a file mid-write).

Testing notes: unfortunately I wasn't able to find a way to 'fake' the system locale to non-UTF-8 on a non-Windows platform to replicate the issue, but the fact that all I/O is now explicitly in binary mode should eliminate any opportunity for OS-level encoding quirks to creep in. Running against this test file

    from wagtail.core.rich_text.rewriters import extract_attrs

    print("a mööse bit me once")

saved in both UTF-8 and Windows-1252 shows all modes (`wagtail updatemodulepaths`, `wagtail updatemodulepaths --list`, `wagtail updatemodulepaths --diff`) completing as expected, with the appropriate warning output when the file is Windows-1252.