### PR TITLE
Add horizontal padding back to inline panels

### DIFF
--- a/wagtail/admin/static_src/wagtailadmin/scss/layouts/page-editor.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/layouts/page-editor.scss
@@ -607,6 +607,11 @@ footer .preview {
       @include column(10);
       padding-inline-start: 0;
       padding-inline-end: 0;
+
+      > li {
+        padding-inline-end: 1rem;
+        padding-inline-start: 1rem;
+      }
     }
 
     &.empty .add {

--- a/wagtail/admin/static_src/wagtailadmin/scss/layouts/page-editor.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/layouts/page-editor.scss
@@ -609,8 +609,8 @@ footer .preview {
       padding-inline-end: 0;
 
       > li {
-        padding-inline-end: 1rem;
-        padding-inline-start: 1rem;
+        padding-inline-end: 1.25rem;
+        padding-inline-start: 1.25rem;
       }
     }
 

--- a/wagtail/admin/static_src/wagtailadmin/scss/layouts/page-editor.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/layouts/page-editor.scss
@@ -609,8 +609,7 @@ footer .preview {
       padding-inline-end: 0;
 
       > li {
-        padding-inline-end: 1.25rem;
-        padding-inline-start: 1.25rem;
+        padding: 1em 10em 1em 1.5em;
       }
     }
 


### PR DESCRIPTION
Adds missing padding back to inline panels. This is to act as a hotfix untill the page editor field panels new UI is implemented and will eventually be overwritten i'm sure.

### Issue summary
This was happening to all inline panel children with borders. From what I can tell the padding was being reset by some styles inside of button.scss that share the same class name and nesting (for some reason haha). This line is the culprit:
https://github.com/wagtail/wagtail/blob/8efb235695887ca6b0388f7f5640452ee92a2c22/client/scss/components/_button.scss#L604 it sets `.multiple > li` `padding-inline-start: 0;` and `padding-inline-end: 0;`

### Screenshot Before:
<img width="1075" alt="Screen Shot 2022-04-28 at 8 20 53 PM" src="https://user-images.githubusercontent.com/25041665/165876525-1bb2a49d-1ebb-4830-9c4b-d7593cea27db.png">

### Screenshot after hotfix:
<img width="1050" alt="Screen Shot 2022-04-28 at 8 33 47 PM" src="https://user-images.githubusercontent.com/25041665/165877227-07b4ce37-0425-41a9-89dd-a1bcd460f166.png">


### Browsers tested on
Mac: Chrome 100, Safari 15.2, Firefox 99
Windows: chrome 99