### PR TITLE
Vertically center footer actions and preview buttons

### DIFF
--- a/wagtail/admin/static_src/wagtailadmin/scss/layouts/page-editor.scss
+++ b/wagtail/admin/static_src/wagtailadmin/scss/layouts/page-editor.scss
@@ -475,6 +475,14 @@
 }
 
 // Footer control bar for performing actions on the page
+footer .actions,
+footer .preview {
+  .button {
+    display: inline-flex;
+    align-items: center;
+  }
+}
+
 footer .actions {
   .button {
     font-weight: 600;


### PR DESCRIPTION
Addresses #8377. Using Flexbox we are able to vertically center the actions and preview buttons in the footer actions menu. 

### Screenshot Before
<img width="546" alt="Screen Shot 2022-04-28 at 8 54 25 PM" src="https://user-images.githubusercontent.com/25041665/165878634-51d558a2-7960-4a9c-8f44-58f7bff92c6a.png">

### Screenshot After
<img width="550" alt="Screen Shot 2022-04-28 at 8 51 55 PM" src="https://user-images.githubusercontent.com/25041665/165878693-26d52a2d-9008-4faa-a4c0-3fe0412568dd.png">
<img width="550" alt="Screen Shot 2022-04-28 at 8 50 26 PM" src="https://user-images.githubusercontent.com/25041665/165878696-930c926c-b8aa-47ad-a3b6-e1cb18e27e6f.png">

### Browsers tested on
Chrome 100, Safari 15.2, Firefox 99
Windows: Chrome 99