### PR TITLE
Draft: Tailwind css vars setup for theming

### DIFF
--- a/client/scss/elements/_root.scss
+++ b/client/scss/elements/_root.scss
@@ -1,34 +1,34 @@
 :root {
-  @include define-color('color-primary', #007d7e);
+  @include define-color('legacy-color-primary', #007d7e);
   @include define-color(
-    'color-primary-darker',
-    css-darken(css-adjust-hue(get-color('color-primary'), 1), 4%)
+    'legacy-color-primary-darker',
+    css-darken(css-adjust-hue(get-color('legacy-color-primary'), 1), 4%)
   );
   @include define-color(
     'color-primary-dark',
-    css-darken(css-adjust-hue(get-color('color-primary'), 1), 7%)
+    css-darken(css-adjust-hue(get-color('legacy-color-primary'), 1), 7%)
   );
   @include define-color(
     'color-primary-lighter',
     css-lighten(
-      css-desaturate(css-adjust-hue(get-color('color-primary'), 1), 46%),
+      css-desaturate(css-adjust-hue(get-color('legacy-color-primary'), 1), 46%),
       48%
     )
   );
   @include define-color(
     'color-primary-light',
     css-lighten(
-      css-desaturate(css-adjust-hue(get-color('color-primary'), 1), 44%),
+      css-desaturate(css-adjust-hue(get-color('legacy-color-primary'), 1), 44%),
       58%
     )
   );
 
   @include define-color(
     'color-input-focus',
-    css-lighten(css-desaturate(get-color('color-primary'), 40%), 72%)
+    css-lighten(css-desaturate(get-color('legacy-color-primary'), 40%), 72%)
   );
   @include define-color(
     'color-input-focus-border',
-    css-lighten(css-saturate(get-color('color-primary'), 12%), 10%)
+    css-lighten(css-saturate(get-color('legacy-color-primary'), 12%), 10%)
   );
 }

--- a/client/scss/settings/_variables.scss
+++ b/client/scss/settings/_variables.scss
@@ -31,11 +31,11 @@ $breakpoints: (
 );
 
 // colours
-$color-teal-light: var(--color-primary-light);
-$color-teal-lighter: var(--color-primary-lighter);
-$color-teal: var(--color-primary);
-$color-teal-darker: var(--color-primary-darker);
-$color-teal-dark: var(--color-primary-dark);
+$color-teal-light: var(--legacy-color-primary-light);
+$color-teal-lighter: var(--legacy-color-primary-lighter);
+$color-teal: var(--legacy-color-primary);
+$color-teal-darker: var(--legacy-color-primary-darker);
+$color-teal-dark: var(--legacy-color-primary-dark);
 
 $color-blue: #71b2d4;
 $color-red: #cd3238;

--- a/client/src/tokens/colors.js
+++ b/client/src/tokens/colors.js
@@ -110,14 +110,18 @@ const colors = {
   },
   primary: {
     DEFAULT: {
-      hex: '#2E1F5E',
+      hex: '#2e1f5e',
+      rgb: '46, 31, 94',
+      cssVar: '--color-primary',
       bgUtility: 'w-bg-primary',
       textUtility: 'w-text-primary',
       usage: 'Wagtail branding, Panels, Headings, Buttons, Labels',
       contrastText: 'white',
     },
     200: {
-      hex: '#261A4E',
+      hex: '#261a4e',
+      rgb: '38, 26, 78',
+      cssVar: '--color-primary-darker',
       bgUtility: 'w-bg-primary-200',
       textUtility: 'w-text-primary-200',
       usage:


### PR DESCRIPTION
Addresses parts of #8400. Draft attempt of how css vars could work for tailwind setup. 

- A new tailwind plugin uses design tokens to create base root variable values 
- Allow tailwind to still use their opacity cssVar on utilties generated with cssVars
- Adds params to design tokens color objects for cssVars and rgb values
- Allows you to use `--color-primary` and `--color-primary-darker` for the new UI changes and converts legacy vars into `--legacy-color-primary` 

<img width="1864" alt="Screen Shot 2022-04-29 at 1 59 29 AM" src="https://user-images.githubusercontent.com/25041665/165906033-39f9a0a4-d74f-4992-9c5e-238ef1b2bf75.png">

