### PR TITLE
Page explorer regression fixes

### DIFF
--- a/client/src/components/Button/Button.tsx
+++ b/client/src/components/Button/Button.tsx
@@ -16,6 +16,11 @@ const handleClick = (
     onClick(e);
   }
 
+  // Do not capture click events with modifier keys or non-main buttons.
+  if (e.ctrlKey || e.shiftKey || e.metaKey || (e.button && e.button !== 0)) {
+    return;
+  }
+
   // If a navigate handler has been specified, replace the default behaviour
   if (navigate && !e.defaultPrevented) {
     e.preventDefault();

--- a/client/src/components/PageExplorer/PageExplorerPanel.tsx
+++ b/client/src/components/PageExplorer/PageExplorerPanel.tsx
@@ -129,13 +129,8 @@ class PageExplorerPanel extends React.Component<
           allowOutsideClick: true,
         }}
       >
-        <div role="dialog">
-          <Transition
-            name={transition}
-            className="c-page-explorer"
-            component="nav"
-            label={gettext('Page explorer')}
-          >
+        <div role="dialog" aria-label={gettext('Page explorer')}>
+          <Transition name={transition} className="c-page-explorer">
             <div key={depth} className="c-transition-group">
               <PageExplorerHeader
                 depth={depth}

--- a/client/src/components/PageExplorer/__snapshots__/PageExplorerPanel.test.js.snap
+++ b/client/src/components/PageExplorer/__snapshots__/PageExplorerPanel.test.js.snap
@@ -14,13 +14,13 @@ exports[`PageExplorerPanel general rendering #isError 1`] = `
   paused={false}
 >
   <div
+    aria-label="Page explorer"
     role="dialog"
   >
     <Transition
       className="c-page-explorer"
-      component="nav"
+      component="div"
       duration={210}
-      label="Page explorer"
       name="push"
     >
       <div
@@ -89,13 +89,13 @@ exports[`PageExplorerPanel general rendering #isFetching 1`] = `
   paused={false}
 >
   <div
+    aria-label="Page explorer"
     role="dialog"
   >
     <Transition
       className="c-page-explorer"
-      component="nav"
+      component="div"
       duration={210}
-      label="Page explorer"
       name="push"
     >
       <div
@@ -145,13 +145,13 @@ exports[`PageExplorerPanel general rendering #items 1`] = `
   paused={false}
 >
   <div
+    aria-label="Page explorer"
     role="dialog"
   >
     <Transition
       className="c-page-explorer"
-      component="nav"
+      component="div"
       duration={210}
-      label="Page explorer"
       name="push"
     >
       <div
@@ -229,13 +229,13 @@ exports[`PageExplorerPanel general rendering no children 1`] = `
   paused={false}
 >
   <div
+    aria-label="Page explorer"
     role="dialog"
   >
     <Transition
       className="c-page-explorer"
-      component="nav"
+      component="div"
       duration={210}
-      label="Page explorer"
       name="push"
     >
       <div
@@ -282,13 +282,13 @@ exports[`PageExplorerPanel general rendering renders 1`] = `
   paused={false}
 >
   <div
+    aria-label="Page explorer"
     role="dialog"
   >
     <Transition
       className="c-page-explorer"
-      component="nav"
+      component="div"
       duration={210}
-      label="Page explorer"
       name="push"
     >
       <div

--- a/client/src/components/Sidebar/menu/PageExplorerMenuItem.tsx
+++ b/client/src/components/Sidebar/menu/PageExplorerMenuItem.tsx
@@ -81,7 +81,7 @@ export const PageExplorerMenuItem: React.FunctionComponent<
         <button
           onClick={onClick}
           className="sidebar-menu-item__link"
-          aria-haspopup="menu"
+          aria-haspopup="dialog"
           aria-expanded={isOpen ? 'true' : 'false'}
           type="button"
         >

--- a/client/src/components/Sidebar/menu/__snapshots__/PageExplorererMenuItem.test.js.snap
+++ b/client/src/components/Sidebar/menu/__snapshots__/PageExplorererMenuItem.test.js.snap
@@ -10,7 +10,7 @@ exports[`PageExplorerMenuItem should render with the minimum required props 1`] 
   >
     <button
       aria-expanded="false"
-      aria-haspopup="menu"
+      aria-haspopup="dialog"
       className="sidebar-menu-item__link"
       onClick={[Function]}
       type="button"

--- a/client/src/components/Transition/Transition.js
+++ b/client/src/components/Transition/Transition.js
@@ -12,21 +12,13 @@ export const POP = 'pop';
 /**
  * Wrapper around react-transition-group with default values.
  */
-const Transition = ({
-  name,
-  component,
-  className,
-  duration,
-  children,
-  label,
-}) => (
+const Transition = ({ name, component, className, duration, children }) => (
   <CSSTransitionGroup
     component={component}
     transitionEnterTimeout={duration}
     transitionLeaveTimeout={duration}
     transitionName={`c-transition-${name}`}
     className={className}
-    aria-label={label}
   >
     {children}
   </CSSTransitionGroup>
@@ -38,7 +30,6 @@ Transition.propTypes = {
   className: PropTypes.string,
   duration: PropTypes.number,
   children: PropTypes.node,
-  label: PropTypes.string,
 };
 
 Transition.defaultProps = {
@@ -46,7 +37,6 @@ Transition.defaultProps = {
   children: null,
   className: null,
   duration: TRANSITION_DURATION,
-  label: null,
 };
 
 export default Transition;

--- a/client/src/components/Transition/__snapshots__/Transition.test.js.snap
+++ b/client/src/components/Transition/__snapshots__/Transition.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`Transition basic 1`] = `
 <CSSTransitionGroup
-  aria-label={null}
   className={null}
   component="div"
   transitionAppear={false}
@@ -16,7 +15,6 @@ exports[`Transition basic 1`] = `
 
 exports[`Transition label 1`] = `
 <CSSTransitionGroup
-  aria-label="Page explorer"
   className={null}
   component="div"
   transitionAppear={false}


### PR DESCRIPTION
This contains two unrelated page explorer changes:

- Follow-up fixes for #8447. I completely missed the tests were failing when merging this. Our ARIA markup was incorrect – I removed the `<nav>` and added the missing label to the `dialog`.
- The fix for #8384. We now have this logic duplicated in quite a few places around the sidebar, would be nice to refactor this a bit but not right now.

To test this, for each link inside the page explorer, make sure they support a middle-click if they should. Middle click should work for:

- Page explorer header for the root link
- The page explorer items’ main link
- The page explorer items’ edit link

And it _shouldn’t_ work for:

- The page explorer header when used as a back button
- The page explorer items’ "go to children" button