### PR TITLE
Separate tab focus and selection to avoid always setting URL hash

### DIFF
--- a/client/src/includes/tabs.js
+++ b/client/src/includes/tabs.js
@@ -210,9 +210,6 @@ class Tabs {
         e.preventDefault();
         this.selectTab(tab);
       });
-      tab.addEventListener('focusin', () => {
-        this.selectTab(tab);
-      });
       tab.addEventListener('keydown', this.keydownEventListener);
       // Set index of tab used in keyboard controls
       // eslint-disable-next-line no-param-reassign
@@ -298,7 +295,9 @@ class Tabs {
       const target = event.target;
       if (target.index !== undefined) {
         if (tabs[target.index + direction[pressed]]) {
-          tabs[target.index + direction[pressed]].focus();
+          const tab = tabs[target.index + direction[pressed]];
+          tab.focus();
+          this.selectTab(tab);
         } else if (pressed === keys.left) {
           this.focusLastTab();
         } else if (pressed === keys.right) {
@@ -309,11 +308,15 @@ class Tabs {
   }
 
   focusFirstTab() {
-    this.tabButtons[0].focus();
+    const tab = this.tabButtons[0];
+    tab.focus();
+    this.selectTab(tab);
   }
 
   focusLastTab() {
-    this.tabButtons[this.tabButtons.length - 1].focus();
+    const tab = this.tabButtons[this.tabButtons.length - 1];
+    tab.focus();
+    this.selectTab(tab);
   }
 
   selectFirstTab() {


### PR DESCRIPTION
Fixes an issue with the new tabs’ implementation of URL hash updates. Without this fix, whenever the tab receives focus, the URL hash is updated to have the tab ID. This isn’t desirable when the user is simply tabbing through the page top to bottom, and happens to go through a tab stop on the currently-opened tab.

This change separates the tab activation from the focus event, so we only "select" a tab and move focus to it when the user actually attempts to change which tab is active.

---

To test this, go to a page edit view (e.g. http://localhost:8000/admin/pages/60/edit/), tab through the page past the tablist, and check there is no URL hash of `#tab-content` added to the URL bar. Then test all other tab functionality and make sure it still works as expected.

