### PR TITLE
Switch locales selector JS error

### DIFF
--- a/client/src/includes/initTooltips.js
+++ b/client/src/includes/initTooltips.js
@@ -116,7 +116,6 @@ export function initModernDropdown() {
         hoverTooltipInstance = tippy(toggle, {
           content: hoverTooltip,
           placement: 'bottom',
-          multiple: true,
           plugins: [hideTooltipOnEsc],
         });
       }
@@ -127,7 +126,6 @@ export function initModernDropdown() {
         interactive: true,
         theme: 'dropdown',
         placement: 'bottom',
-        multiple: true,
         plugins: [
           hideTooltipOnEsc,
           hideTooltipOnBreadcrumbExpandAndCollapse,

--- a/client/src/includes/initTooltips.js
+++ b/client/src/includes/initTooltips.js
@@ -133,11 +133,15 @@ export function initModernDropdown() {
           hideTooltipOnBreadcrumbExpandAndCollapse,
           rotateToggleIcon,
         ],
-        onShow(instance, event) {
-          hoverTooltipInstance.disable();
+        onShow() {
+          if (hoverTooltipInstance) {
+            hoverTooltipInstance.disable();
+          }
         },
-        onHide(instance, event) {
-          hoverTooltipInstance.enable();
+        onHide() {
+          if (hoverTooltipInstance) {
+            hoverTooltipInstance.enable();
+          }
         },
       });
     }


### PR DESCRIPTION
Addresses #8466. Error caused by tippy trying to disable a hoverTooltipInstance that doesn't exist. 

#### Fix applied
-Wrapped hoverTooltipInstance inside of an if statement to ensure it exists before trying to call `disable` or `enable`. This is needed as hover-tooltip-content is an optional attribute which turns this feature on and off. 

-Removed `multiple: true` on tippy instances as it is not needed anymore. This addresses #8462 as well. 
**Extra Info about this:** Since we are using two instances of tippy on the same element for the actions toggle specifically, using the multiple: true attribute allowed us to have multiple instances of tippy for the same element. However in tippy v5 and v6 is they've changed it so as long as you reference the same element it will init multiple for the same tippy instance. [Tippy migration notes](https://github.com/atomiks/tippyjs/blob/8f7b2df156ae39c4df23c481b77ab59fe7f08c44/MIGRATION_GUIDE.md#if-you-were-using-multiple-or-relying-on-its-behavior )
