### PR TITLE
Add missing can_reorder_children() check, fixes #8458

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -35,6 +35,7 @@ Changelog
  * Fix: Ensure that custom document or image models support custom tag models (Matt Westcott)
  * Fix: Ensure comments use translated values for their placeholder text (Stefan Hammer)
  * Fix: Ensure the upgrade notification, shown to admins on the dashboard if Wagtail is out of date, content is translatable (LB (Ben) Johnston)
+ * Fix: Show the re-ordering option to users that have permission to publish pages within the page listing (Stefan Hammer)
 
 
 3.0 (16.05.2022)

--- a/docs/releases/4.0.md
+++ b/docs/releases/4.0.md
@@ -49,6 +49,7 @@ When using a queryset to render a list of images, you can now use the ``prefetch
  * Ensure that custom document or image models support custom tag models (Matt Westcott)
  * Ensure comments use translated values for their placeholder text (Stefan Hammer)
  * Ensure the upgrade notification, shown to admins on the dashboard if Wagtail is out of date, content is translatable (LB (Ben) Johnston)
+ * Only show the re-ordering option to users that have permission to publish pages within the page listing (Stefan Hammer)
 
 
 ## Upgrade considerations

--- a/wagtail/admin/wagtail_hooks.py
+++ b/wagtail/admin/wagtail_hooks.py
@@ -350,7 +350,7 @@ def page_listing_more_buttons(page, page_perms, is_parent=False, next_url=None):
             priority=50,
         )
 
-    if is_parent:
+    if is_parent and page_perms.can_reorder_children():
         yield Button(
             _("Sort menu order"),
             "?ordering=ord",


### PR DESCRIPTION
Users which weren't allowed to reorder child pages (e.g. due to missing "publish" permission), still saw the menu item to start reordering (see #8458).

The existing tests still pass. I've looked into the tests, but I don't know exactly where and how I should test that fix.

_Please check the following:_

- [x] Do the tests still pass?[^1]
- [x] Does the code comply with the style guide? 
    - [x] Run `make lint` from the Wagtail root. 
- [x] For Python changes: Have you added tests to cover the new/fixed behaviour?

**Please describe additional details for testing this change**. 

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
