### PR TITLE
Add Wagtail 3 classifier to documentation

### DIFF
--- a/docs/contributing/index.rst
+++ b/docs/contributing/index.rst
@@ -49,6 +49,7 @@ If you are developing packages for Wagtail, you can add the following `PyPI <htt
 * `Framework :: Wagtail <https://pypi.org/search/?c=Framework+%3A%3A+Wagtail>`_
 * `Framework :: Wagtail :: 1 <https://pypi.org/search/?c=Framework+%3A%3A+Wagtail+%3A%3A+1>`_
 * `Framework :: Wagtail :: 2 <https://pypi.org/search/?c=Framework+%3A%3A+Wagtail+%3A%3A+2>`_
+* `Framework :: Wagtail :: 3 <https://pypi.org/search/?c=Framework+%3A%3A+Wagtail+%3A%3A+3>`_
 
 You can also find a curated list of awesome packages, articles, and other cool resources from the Wagtail community at `Awesome Wagtail <https://github.com/springload/awesome-wagtail>`_.
 


### PR DESCRIPTION
* We may need to request this classifier be added via Pypi - when I tried to use this pypi would not allow it, nonetheless it should be added to our release 3.0 docs.
* [Framework :: Wagtail :: 3](https://pypi.org/search/?c=Framework+%3A%3A+Wagtail+%3A%3A+3)

The error I was getting when trying to publish `wagtail-hallo` was:
```
Uploading wagtail_hallo-0.1.0-py3-none-any.whl
100% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 72.3/72.3 kB • 00:01 • 19.4 MB/s
WARNING  Error during upload. Retry with the --verbose option for more details.                                                                                                                    
ERROR    HTTPError: 400 Bad Request from https://upload.pypi.org/legacy/                                                                                                                           
         Invalid value for classifiers. Error: Classifier 'Framework :: Wagtail :: 3' is not a valid classifier. 
```