### PR TITLE
Use PostgreSQL 11 when testing against Django main

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,10 +82,13 @@ jobs:
           - python: '3.10'
             django: 'git+https://github.com/django/django.git@main#egg=Django'
             experimental: true
+            postgres: 'postgres:11'
 
     services:
       postgres:
-        image: postgres:10.8
+        image: ${{ matrix.postgres || 'postgres:10.8' }}
+        env:
+          POSTGRES_PASSWORD: postgres
         ports:
           - 5432:5432
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
@@ -110,7 +113,7 @@ jobs:
           DATABASE_ENGINE: django.db.backends.postgresql
           DATABASE_HOST: localhost
           DATABASE_USER: postgres
-          DATABASE_PASS: postgres
+          DATABASE_PASSWORD: postgres
           USE_EMAIL_USER_MODEL: ${{ matrix.emailuser }}
           DISABLE_TIMEZONE: ${{ matrix.notz }}
 
@@ -288,7 +291,7 @@ jobs:
           DATABASE_ENGINE: django.db.backends.postgresql
           DATABASE_HOST: localhost
           DATABASE_USER: postgres
-          DATABASE_PASS: postgres
+          DATABASE_PASSWORD: postgres
           USE_EMAIL_USER_MODEL: ${{ matrix.emailuser }}
 
   test-postgres-elasticsearch7:
@@ -338,5 +341,5 @@ jobs:
           DATABASE_ENGINE: django.db.backends.postgresql
           DATABASE_HOST: localhost
           DATABASE_USER: postgres
-          DATABASE_PASS: postgres
+          DATABASE_PASSWORD: postgres
           USE_EMAIL_USER_MODEL: ${{ matrix.emailuser }}


### PR DESCRIPTION
Django dropped support for PostgreSQL 10 as of Django 4.1

https://github.com/django/django/pull/15655

Kindly review @gasman 😄

<!--
Thanks for contributing to Wagtail! 🎉

Before submitting, please review the [contributor guidelines](https://docs.wagtail.org/en/latest/contributing/index.html).
-->

_Please check the following:_

- [x] Do the tests still pass?[^1]
- [x] Does the code comply with the style guide? 
    - [x] Run `make lint` from the Wagtail root. 
- [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
- [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    - [ ] **Please list the exact browser and operating system versions you tested**:
    - [ ] **Please list which assistive technologies [^3] you tested**: 
- [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**. 

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets) 
