### PR TITLE
Header breadcrumb spacing fixes for #8471 

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -15,6 +15,7 @@ Changelog
  * Add informational Codecov status checks for GitHub CI pipelines (Tom Hu)
  * Fix: Typo in `ResumeWorkflowActionFormatter` message (Stefan Hammer)
  * Fix: Throw a meaningful error when saving an image to an unrecognised image format (Christian Franke)
+ * Fix: Remove extra padding for headers with breadcrumbs on mobile viewport (Steven Steinwand)
 
 
 3.0 (xx.xx.xxxx) - IN DEVELOPMENT

--- a/client/scss/components/_breadcrumb.scss
+++ b/client/scss/components/_breadcrumb.scss
@@ -4,7 +4,6 @@
   padding-top: 1.4em;
   font-size: 0.85em;
   line-height: 1.5em;
-  margin-inline-start: 2em;
   background: $color-teal;
 
   li,
@@ -72,11 +71,23 @@
     transform: scale(1.75) translate(0.3em, 0.1em);
   }
 
+  // Adjust padding and size of breadcrumbs when nested inside of headers
+  header & {
+    display: flex;
+    align-items: center;
+    height: $mobile-nav-indent;
+    padding-top: 0;
+    padding-inline-start: $mobile-nav-indent + 10px;
+
+    @include media-breakpoint-up(sm) {
+      padding-inline-start: 0;
+      height: auto;
+    }
+  }
+
   @include media-breakpoint-up(sm) {
     padding-top: 0;
     background: $color-teal-darker;
-    margin-inline-start: -($desktop-nice-padding);
-    margin-inline-end: -($desktop-nice-padding);
 
     .home_icon {
       margin-inline-start: 1.25em;

--- a/client/scss/components/_header.scss
+++ b/client/scss/components/_header.scss
@@ -4,11 +4,6 @@
 header {
   @apply w-text-primary w-mb-8;
 
-  padding-top: 0.5rem;
-  padding-bottom: 1.5rem;
-  padding-inline-start: 110px;
-  padding-inline-end: 20px;
-
   a {
     @apply w-text-primary w-underline;
   }
@@ -36,6 +31,26 @@ header {
       margin-inline-start: 0.3125rem;
       font-weight: 400;
     }
+  }
+
+  // Give padding to the rows inside of headers so that nested breadcrumbs aren't padded by their parent header el.
+  // Use header--with-padding for headers that don't contain .row elements.
+  &.header--with-padding,
+  > .row {
+    padding-top: 0.5rem;
+    padding-bottom: 1.5rem;
+    padding-inline-start: 110px;
+    padding-inline-end: 20px;
+  }
+
+  .breadcrumb + .row {
+    padding-inline-start: $mobile-nav-indent + 10px;
+  }
+
+  &.header--home {
+    @include nice-padding();
+    padding-top: 0.5rem;
+    margin-top: $mobile-nav-indent;
   }
 
   .col {
@@ -77,17 +92,6 @@ header {
 
   &.no-border {
     border: 0;
-
-    @include media-breakpoint-down(xs) {
-      // To all hamburger menu to be visible
-      padding-inline-start: 1.6em;
-      padding-inline-end: 1.6em;
-      padding-top: 11px;
-
-      .nice-padding {
-        margin-inline-start: -$desktop-nice-padding;
-      }
-    }
   }
 
   &.merged.no-border {
@@ -166,9 +170,20 @@ header {
 
 @include media-breakpoint-up(sm) {
   header {
-    padding-top: 1.5rem;
-    padding-inline-start: 90px;
-    padding-inline-end: 90px;
+    .row {
+      padding-top: 1.5rem;
+      padding-inline-start: 90px;
+      padding-inline-end: 90px;
+    }
+
+    .breadcrumb + .row {
+      padding-inline-start: 90px;
+    }
+
+    &.header--home {
+      padding-top: 1.5rem;
+      margin-top: 0;
+    }
 
     .left {
       float: left;

--- a/docs/releases/4.0.md
+++ b/docs/releases/4.0.md
@@ -25,6 +25,7 @@ depth: 1
  * Fix issue where `ModelAdmin` index listings with export list enabled would show buttons with an incorrect layout (Josh Woodcock)
  * Fix typo in `ResumeWorkflowActionFormatter` message (Stefan Hammer)
  * Throw a meaningful error when saving an image to an unrecognised image format (Christian Franke)
+ * Remove extra padding for headers with breadcrumbs on mobile viewport (Steven Steinwand)
 
 
 ## Upgrade considerations

--- a/wagtail/admin/templates/wagtailadmin/home.html
+++ b/wagtail/admin/templates/wagtailadmin/home.html
@@ -12,10 +12,10 @@
 {% endblock %}
 
 {% block content %}
-    <header class="merged nice-padding">
+    <header class="merged header--home">
         <div class="avatar"><img src="{% avatar_url user %}" alt="" /></div>
 
-        <div>
+        <div class="sm:w-ml-4">
             <h1>{% block branding_welcome %}{% blocktrans trimmed %}Welcome to the {{ site_name }} Wagtail CMS{% endblocktrans %}{% endblock %}</h1>
             <div class="user-name">{{ user|user_display_name }}</div>
         </div>

--- a/wagtail/admin/templates/wagtailadmin/pages/index.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/index.html
@@ -4,7 +4,7 @@
 {% block bodyclass %}page-explorer {% if ordering == 'ord' %}reordering{% endif %}{% endblock %}
 
 {% block content %}
-    <header class="merged no-border nice-padding no-v-padding">
+    <header class="merged no-border">
         <h1 class="visuallyhidden">Explorer</h1>
 
         {% explorer_breadcrumb parent_page %}

--- a/wagtail/admin/templates/wagtailadmin/pages/move_choose_destination.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/move_choose_destination.html
@@ -2,14 +2,14 @@
 {% load i18n wagtailadmin_tags %}
 {% block titletag %}{% blocktrans trimmed with title=page_to_move.specific_deferred.get_admin_display_title %}Select a new parent page for {{ title }}{% endblocktrans %}{% endblock %}
 {% block content %}
-    <div class="nice-padding">
-        {% move_breadcrumb page_to_move viewed_page %}
-    </div>
     <header>
-        <h1>
-            {% icon name="doc-empty-inverse" %}
-            {% blocktrans trimmed with title=page_to_move.specific_deferred.get_admin_display_title %}Select a new parent page for <span>{{ title }}</span>{% endblocktrans %}
-        </h1>
+        {% move_breadcrumb page_to_move viewed_page %}
+        <div class="row">
+            <h1>
+                {% icon name="doc-empty-inverse" %}
+                {% blocktrans trimmed with title=page_to_move.specific_deferred.get_admin_display_title %}Select a new parent page for <span>{{ title }}</span>{% endblocktrans %}
+            </h1>
+        </div>
     </header>
     <div class="nice-padding">
         {% include "wagtailadmin/pages/listing/_list_move.html" with pages=child_pages parent_page=viewed_page %}

--- a/wagtail/admin/templates/wagtailadmin/pages/preview_error.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/preview_error.html
@@ -4,7 +4,7 @@
 {% block titletag %}{% trans 'Preview error' %}{% endblock %}
 
 {% block content %}
-    <header>
+    <header class="header--with-padding">
         <h1>{% trans 'Preview error' %}</h1>
     </header>
     <div class="nice-padding">

--- a/wagtail/contrib/modeladmin/static_src/wagtailmodeladmin/scss/breadcrumbs_page.scss
+++ b/wagtail/contrib/modeladmin/static_src/wagtailmodeladmin/scss/breadcrumbs_page.scss
@@ -1,9 +1,2 @@
 @import '../../../../../../client/scss/settings';
 @import '../../../../../../client/scss/tools';
-
-@include media-breakpoint-down(sm) {
-  .breadcrumb {
-    margin-inline-start: 30px;
-    margin-inline-end: -20px;
-  }
-}

--- a/wagtail/contrib/modeladmin/static_src/wagtailmodeladmin/scss/breadcrumbs_page.scss
+++ b/wagtail/contrib/modeladmin/static_src/wagtailmodeladmin/scss/breadcrumbs_page.scss
@@ -1,12 +1,9 @@
 @import '../../../../../../client/scss/settings';
 @import '../../../../../../client/scss/tools';
 
-.breadcrumb {
-  margin: -1.2em 0 2em;
-}
-
-@include media-breakpoint-up(sm) {
+@include media-breakpoint-down(sm) {
   .breadcrumb {
-    margin-top: -1.8em;
+    margin-inline-start: 30px;
+    margin-inline-end: -20px;
   }
 }

--- a/wagtail/contrib/modeladmin/templates/modeladmin/includes/header_with_breadcrumb.html
+++ b/wagtail/contrib/modeladmin/templates/modeladmin/includes/header_with_breadcrumb.html
@@ -1,5 +1,4 @@
-{% extends "wagtailadmin/shared/header_with_locale_selector.html" %}
-
-{% block breadcrumb %}
+<div class="nice-padding">
     {% include "modeladmin/includes/breadcrumb.html" %}
-{% endblock %}
+</div>
+{% include "wagtailadmin/shared/header_with_locale_selector.html" %}

--- a/wagtail/contrib/modeladmin/templates/modeladmin/includes/header_with_breadcrumb.html
+++ b/wagtail/contrib/modeladmin/templates/modeladmin/includes/header_with_breadcrumb.html
@@ -1,4 +1,5 @@
-<div class="nice-padding">
+{% extends "wagtailadmin/shared/header_with_locale_selector.html" %}
+
+{% block breadcrumb %}
     {% include "modeladmin/includes/breadcrumb.html" %}
-</div>
-{% include "wagtailadmin/shared/header_with_locale_selector.html" %}
+{% endblock %}


### PR DESCRIPTION
## About
Addresses breadcrumb spacing issues mentioned in #8471. 
This PR moves header padding to the  `.row` class and adds a padding modifier for headers that don't contain `.row`. This allows the breadcrumbs to be be aligned separately of sibling header elements  

## Screenshots of changes

#### Desktop: inspect.html template being used with breadcrumbs

![Screen Shot 2022-05-11 at 3 38 35 PM](https://user-images.githubusercontent.com/25041665/167958579-cea14fd8-2248-4cd7-9965-54871f6db7c7.png)

#### Mobile: inspect.html template being used with breadcrumbs

![Screen Shot 2022-05-11 at 3 37 33 PM](https://user-images.githubusercontent.com/25041665/167958584-a9127fae-a232-4518-861a-fcda130ca922.png)

#### Mobile: home.html header (this header is unique to all others)
![Screen Shot 2022-05-11 at 3 01 59 PM](https://user-images.githubusercontent.com/25041665/167958587-a2285bb4-3010-4b9e-9ddf-e3168bc9a217.png)

#### Mobile: page explorer template being used with breadcrumbs
![Screen Shot 2022-05-11 at 2 52 45 PM](https://user-images.githubusercontent.com/25041665/167958589-d3dc225d-da60-4f71-aadb-e1ad151594b0.png)


### Browsers tested on 
Chrome 100, Safari 15.2, Firefox 99
Windows: Chrome 99