### PR TITLE
Hide side_panel_button if empty

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/pages/side_panels/includes/side_panel_button.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/side_panels/includes/side_panel_button.html
@@ -8,9 +8,10 @@
     has_toggle - Show toggle icon on the button
     attr - custom attributes for the button
 {% endcomment %}
-<button type="button" class="{{ classes }} w-bg-transparent w-text-14 w-p-0 w-text-teal-200 hover:w-text-teal-600 w-inline-flex w-justify-center w-transition" {% if data_url %}data-url="{{ data_url }}" {% endif %}{% if has_toggle %}data-button-with-dropdown-toggle {% endif %}{{ attr }}>
-    {{ text }}
-    {% if has_toggle %}
-        {% icon name='arrow-down' class_name='w-w-4 w-h-4 w-transition motion-reduce:w-transition-none' %}
-    {% endif %}
-</button>
+{% spaceless %}
+    <button type="button" class="{{ classes }} w-bg-transparent w-text-14 w-p-0 w-text-teal-200 hover:w-text-teal-600 w-inline-flex w-justify-center w-transition empty:w-hidden" {% if data_url %}data-url="{{ data_url }}" {% endif %}{% if has_toggle %}data-button-with-dropdown-toggle {% endif %}{{ attr }}>{{ text }}
+        {% if has_toggle %}
+            {% icon name='arrow-down' class_name='w-w-4 w-h-4 w-transition motion-reduce:w-transition-none' %}
+        {% endif %}
+    </button>
+{% endspaceless %}

--- a/wagtail/admin/templates/wagtailadmin/pages/side_panels/includes/side_panel_button.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/side_panels/includes/side_panel_button.html
@@ -8,10 +8,11 @@
     has_toggle - Show toggle icon on the button
     attr - custom attributes for the button
 {% endcomment %}
-{% spaceless %}
-    <button type="button" class="{{ classes }} w-bg-transparent w-text-14 w-p-0 w-text-teal-200 hover:w-text-teal-600 w-inline-flex w-justify-center w-transition empty:w-hidden" {% if data_url %}data-url="{{ data_url }}" {% endif %}{% if has_toggle %}data-button-with-dropdown-toggle {% endif %}{{ attr }}>{{ text }}
+{% if text %}
+    <button type="button" class="{{ classes }} w-bg-transparent w-text-14 w-p-0 w-text-teal-200 hover:w-text-teal-600 w-inline-flex w-justify-center w-transition" {% if data_url %}data-url="{{ data_url }}" {% endif %}{% if has_toggle %}data-button-with-dropdown-toggle {% endif %}{{ attr }}>
+        {{ text }}
         {% if has_toggle %}
             {% icon name='arrow-down' class_name='w-w-4 w-h-4 w-transition motion-reduce:w-transition-none' %}
         {% endif %}
     </button>
-{% endspaceless %}
+{% endif %}


### PR DESCRIPTION
Addresses #8465. Using the empty: selector with css we are able to hide the button if there is nothing inside of it so that the empty element cannot be tabbed to. 

- Wrapped side_panel_button.html in spaceless to ensure there are no spaces inside the button when its empty and the `empty:` variant still works as expected
- Added `empty:w-hidden` to hide the side panel button from screen readers when it is empty. 


https://user-images.githubusercontent.com/25041665/167016644-e06a3190-20b8-4af4-a608-1b3c638e20a4.mp4

 
### Tested on 
Chrome 100, Safari 15.2, Firefox 99 (with browser-sync)