### PR TITLE
Add Fuzzy() search query class

### DIFF
--- a/docs/topics/search/searching.rst
+++ b/docs/topics/search/searching.rst
@@ -216,6 +216,24 @@ For example:
 
 If you are looking to implement phrase queries using the double-quote syntax, see :ref:`wagtailsearch_query_string_parsing`.
 
+Fuzzy matching
+^^^^^^^^^^^^^^
+
+Fuzzy matching will return documents which contain terms similar to the search term, as measured by a `Levenshtein edit distance <https://en.wikipedia.org/wiki/Levenshtein_distance>`.
+
+A maximum of one edit (transposition, insertion, or removal of a character) is permitted for three to five letter terms, two edits for longer terms, and shorter terms must match exactly.
+
+For example:
+
+.. code-block:: python
+
+    >>> from wagtail.search.query import Fuzzy
+
+    >>> Page.objects.search(Fuzzy("Hallo"))
+    [<Page: Hello World>]
+
+Fuzzy matching is supported by the Elasticsearch search backend only.
+
 
 .. _wagtailsearch_complex_queries:
 

--- a/wagtail/search/backends/elasticsearch5.py
+++ b/wagtail/search/backends/elasticsearch5.py
@@ -24,7 +24,7 @@ from wagtail.search.index import (
     SearchField,
     class_is_indexed,
 )
-from wagtail.search.query import And, Boost, MatchAll, Not, Or, Phrase, PlainText
+from wagtail.search.query import And, Boost, Fuzzy, MatchAll, Not, Or, Phrase, PlainText
 from wagtail.utils.utils import deep_update
 
 
@@ -445,6 +445,19 @@ class Elasticsearch5SearchQueryCompiler(BaseSearchQueryCompiler):
 
             return {"multi_match": match_query}
 
+    def _compile_fuzzy_query(self, query, fields):
+        if self.partial_match:
+            raise NotImplementedError(
+                "Fuzzy search is not supported with partial matches. Pass "
+                "partial_match=False into the search method."
+            )
+        elif len(fields) > 1:
+            raise NotImplementedError(
+                "Fuzzy search on multiple fields is not supported by the "
+                "Elasticsearch search backend."
+            )
+        return {"fuzzy": {fields[0]: query.query_string}}
+
     def _compile_phrase_query(self, query, fields):
         if len(fields) == 1:
             return {"match_phrase": {fields[0]: query.query_string}}
@@ -494,6 +507,9 @@ class Elasticsearch5SearchQueryCompiler(BaseSearchQueryCompiler):
         elif isinstance(query, PlainText):
             return self._compile_plaintext_query(query, [field], boost)
 
+        elif isinstance(query, Fuzzy):
+            return self._compile_fuzzy_query(query, [field])
+
         elif isinstance(query, Phrase):
             return self._compile_phrase_query(query, [field])
 
@@ -529,6 +545,9 @@ class Elasticsearch5SearchQueryCompiler(BaseSearchQueryCompiler):
 
         elif isinstance(self.query, Phrase):
             return self._compile_phrase_query(self.query, fields)
+
+        elif isinstance(self.query, Fuzzy):
+            return self._compile_fuzzy_query(self.query, fields)
 
         else:
             if len(fields) == 1:

--- a/wagtail/search/backends/elasticsearch5.py
+++ b/wagtail/search/backends/elasticsearch5.py
@@ -456,7 +456,14 @@ class Elasticsearch5SearchQueryCompiler(BaseSearchQueryCompiler):
                 "Fuzzy search on multiple fields is not supported by the "
                 "Elasticsearch search backend."
             )
-        return {"fuzzy": {fields[0]: query.query_string}}
+        return {
+            "match": {
+                fields[0]: {
+                    "query": query.query_string,
+                    "fuzziness": "AUTO",
+                }
+            }
+        }
 
     def _compile_phrase_query(self, query, fields):
         if len(fields) == 1:

--- a/wagtail/search/query.py
+++ b/wagtail/search/query.py
@@ -51,6 +51,14 @@ class Phrase(SearchQuery):
         return "<Phrase {}>".format(repr(self.query_string))
 
 
+class Fuzzy(SearchQuery):
+    def __init__(self, query_string: str):
+        self.query_string = query_string
+
+    def __repr__(self):
+        return "<Fuzzy {}>".format(repr(self.query_string))
+
+
 class MatchAll(SearchQuery):
     def __repr__(self):
         return "<MatchAll>"

--- a/wagtail/search/tests/test_elasticsearch5_backend.py
+++ b/wagtail/search/tests/test_elasticsearch5_backend.py
@@ -8,7 +8,7 @@ from django.test import TestCase
 from elasticsearch.serializer import JSONSerializer
 
 from wagtail.search.backends.elasticsearch5 import Elasticsearch5SearchBackend
-from wagtail.search.query import MATCH_ALL, Phrase
+from wagtail.search.query import Fuzzy, MATCH_ALL, Phrase
 from wagtail.test.search import models
 
 from .elasticsearch_common_tests import ElasticsearchCommonSearchBackendTests
@@ -559,6 +559,55 @@ class TestElasticsearch5SearchQuery(TestCase):
         # Check it
         expected_result = {"match_phrase": {"title": "Hello world"}}
         self.assertDictEqual(query_compiler.get_inner_query(), expected_result)
+
+    def test_fuzzy_query(self):
+        # Create a query
+        query_compiler = self.query_compiler_class(
+            models.Book.objects.all(), Fuzzy("Hello world"), partial_match=False,
+        )
+
+        # Check it
+        expected_result = {"fuzzy": {"_all": "Hello world"}}
+        self.assertDictEqual(query_compiler.get_inner_query(), expected_result)
+
+    def test_fuzzy_query_single_field(self):
+        # Create a query
+        query_compiler = self.query_compiler_class(
+            models.Book.objects.all(),
+            Fuzzy("Hello world"),
+            fields=["title"],
+            partial_match=False,
+        )
+
+        # Check it
+        expected_result = {"fuzzy": {"title": "Hello world"}}
+        self.assertDictEqual(query_compiler.get_inner_query(), expected_result)
+
+    def test_fuzzy_query_multiple_fields_disallowed(self):
+        # Create a query
+        query_compiler = self.query_compiler_class(
+            models.Book.objects.all(),
+            Fuzzy("Hello world"),
+            fields=["title", "body"],
+            partial_match=False,
+        )
+
+        # Check it
+        with self.assertRaises(NotImplementedError):
+            query_compiler.get_inner_query()
+
+    def test_fuzzy_query_partial_match_disallowed(self):
+        # Create a query
+        query_compiler = self.query_compiler_class(
+            models.Book.objects.all(),
+            Fuzzy("Hello world"),
+            fields=["_all"],
+            partial_match=True,
+        )
+
+        # Check it
+        with self.assertRaises(NotImplementedError):
+            query_compiler.get_inner_query()
 
     def test_year_filter(self):
         # Create a query

--- a/wagtail/search/tests/test_elasticsearch5_backend.py
+++ b/wagtail/search/tests/test_elasticsearch5_backend.py
@@ -8,7 +8,7 @@ from django.test import TestCase
 from elasticsearch.serializer import JSONSerializer
 
 from wagtail.search.backends.elasticsearch5 import Elasticsearch5SearchBackend
-from wagtail.search.query import Fuzzy, MATCH_ALL, Phrase
+from wagtail.search.query import MATCH_ALL, Fuzzy, Phrase
 from wagtail.test.search import models
 
 from .elasticsearch_common_tests import ElasticsearchCommonSearchBackendTests
@@ -563,11 +563,15 @@ class TestElasticsearch5SearchQuery(TestCase):
     def test_fuzzy_query(self):
         # Create a query
         query_compiler = self.query_compiler_class(
-            models.Book.objects.all(), Fuzzy("Hello world"), partial_match=False,
+            models.Book.objects.all(),
+            Fuzzy("Hello world"),
+            partial_match=False,
         )
 
         # Check it
-        expected_result = {"fuzzy": {"_all": "Hello world"}}
+        expected_result = {
+            "match": {"_all": {"query": "Hello world", "fuzziness": "AUTO"}}
+        }
         self.assertDictEqual(query_compiler.get_inner_query(), expected_result)
 
     def test_fuzzy_query_single_field(self):
@@ -580,7 +584,9 @@ class TestElasticsearch5SearchQuery(TestCase):
         )
 
         # Check it
-        expected_result = {"fuzzy": {"title": "Hello world"}}
+        expected_result = {
+            "match": {"title": {"query": "Hello world", "fuzziness": "AUTO"}}
+        }
         self.assertDictEqual(query_compiler.get_inner_query(), expected_result)
 
     def test_fuzzy_query_multiple_fields_disallowed(self):

--- a/wagtail/search/tests/test_elasticsearch6_backend.py
+++ b/wagtail/search/tests/test_elasticsearch6_backend.py
@@ -8,7 +8,7 @@ from django.test import TestCase
 from elasticsearch.serializer import JSONSerializer
 
 from wagtail.search.backends.elasticsearch6 import Elasticsearch6SearchBackend
-from wagtail.search.query import Fuzzy, MATCH_ALL, Phrase
+from wagtail.search.query import MATCH_ALL, Fuzzy, Phrase
 from wagtail.test.search import models
 
 from .elasticsearch_common_tests import ElasticsearchCommonSearchBackendTests
@@ -608,11 +608,15 @@ class TestElasticsearch6SearchQuery(TestCase):
     def test_fuzzy_query(self):
         # Create a query
         query_compiler = self.query_compiler_class(
-            models.Book.objects.all(), Fuzzy("Hello world"), partial_match=False,
+            models.Book.objects.all(),
+            Fuzzy("Hello world"),
+            partial_match=False,
         )
 
         # Check it
-        expected_result = {"fuzzy": {"_all_text": "Hello world"}}
+        expected_result = {
+            "match": {"_all_text": {"query": "Hello world", "fuzziness": "AUTO"}}
+        }
         self.assertDictEqual(query_compiler.get_inner_query(), expected_result)
 
     def test_fuzzy_query_single_field(self):
@@ -625,7 +629,9 @@ class TestElasticsearch6SearchQuery(TestCase):
         )
 
         # Check it
-        expected_result = {"fuzzy": {"title": "Hello world"}}
+        expected_result = {
+            "match": {"title": {"query": "Hello world", "fuzziness": "AUTO"}}
+        }
         self.assertDictEqual(query_compiler.get_inner_query(), expected_result)
 
     def test_fuzzy_query_multiple_fields_disallowed(self):

--- a/wagtail/search/tests/test_elasticsearch6_backend.py
+++ b/wagtail/search/tests/test_elasticsearch6_backend.py
@@ -8,7 +8,7 @@ from django.test import TestCase
 from elasticsearch.serializer import JSONSerializer
 
 from wagtail.search.backends.elasticsearch6 import Elasticsearch6SearchBackend
-from wagtail.search.query import MATCH_ALL, Phrase
+from wagtail.search.query import Fuzzy, MATCH_ALL, Phrase
 from wagtail.test.search import models
 
 from .elasticsearch_common_tests import ElasticsearchCommonSearchBackendTests
@@ -604,6 +604,55 @@ class TestElasticsearch6SearchQuery(TestCase):
         # Check it
         expected_result = {"match_phrase": {"title": "Hello world"}}
         self.assertDictEqual(query_compiler.get_inner_query(), expected_result)
+
+    def test_fuzzy_query(self):
+        # Create a query
+        query_compiler = self.query_compiler_class(
+            models.Book.objects.all(), Fuzzy("Hello world"), partial_match=False,
+        )
+
+        # Check it
+        expected_result = {"fuzzy": {"_all_text": "Hello world"}}
+        self.assertDictEqual(query_compiler.get_inner_query(), expected_result)
+
+    def test_fuzzy_query_single_field(self):
+        # Create a query
+        query_compiler = self.query_compiler_class(
+            models.Book.objects.all(),
+            Fuzzy("Hello world"),
+            fields=["title"],
+            partial_match=False,
+        )
+
+        # Check it
+        expected_result = {"fuzzy": {"title": "Hello world"}}
+        self.assertDictEqual(query_compiler.get_inner_query(), expected_result)
+
+    def test_fuzzy_query_multiple_fields_disallowed(self):
+        # Create a query
+        query_compiler = self.query_compiler_class(
+            models.Book.objects.all(),
+            Fuzzy("Hello world"),
+            fields=["title", "body"],
+            partial_match=False,
+        )
+
+        # Check it
+        with self.assertRaises(NotImplementedError):
+            query_compiler.get_inner_query()
+
+    def test_fuzzy_query_partial_match_disallowed(self):
+        # Create a query
+        query_compiler = self.query_compiler_class(
+            models.Book.objects.all(),
+            Fuzzy("Hello world"),
+            fields=["_all"],
+            partial_match=True,
+        )
+
+        # Check it
+        with self.assertRaises(NotImplementedError):
+            query_compiler.get_inner_query()
 
     def test_year_filter(self):
         # Create a query

--- a/wagtail/search/tests/test_elasticsearch7_backend.py
+++ b/wagtail/search/tests/test_elasticsearch7_backend.py
@@ -8,7 +8,7 @@ from django.test import TestCase
 from elasticsearch.serializer import JSONSerializer
 
 from wagtail.search.backends.elasticsearch7 import Elasticsearch7SearchBackend
-from wagtail.search.query import MATCH_ALL, Phrase
+from wagtail.search.query import Fuzzy, MATCH_ALL, Phrase
 from wagtail.test.search import models
 
 from .elasticsearch_common_tests import ElasticsearchCommonSearchBackendTests
@@ -604,6 +604,55 @@ class TestElasticsearch7SearchQuery(TestCase):
         # Check it
         expected_result = {"match_phrase": {"title": "Hello world"}}
         self.assertDictEqual(query_compiler.get_inner_query(), expected_result)
+
+    def test_fuzzy_query(self):
+        # Create a query
+        query_compiler = self.query_compiler_class(
+            models.Book.objects.all(), Fuzzy("Hello world"), partial_match=False,
+        )
+
+        # Check it
+        expected_result = {"fuzzy": {"_all_text": "Hello world"}}
+        self.assertDictEqual(query_compiler.get_inner_query(), expected_result)
+
+    def test_fuzzy_query_single_field(self):
+        # Create a query
+        query_compiler = self.query_compiler_class(
+            models.Book.objects.all(),
+            Fuzzy("Hello world"),
+            fields=["title"],
+            partial_match=False,
+        )
+
+        # Check it
+        expected_result = {"fuzzy": {"title": "Hello world"}}
+        self.assertDictEqual(query_compiler.get_inner_query(), expected_result)
+
+    def test_fuzzy_query_multiple_fields_disallowed(self):
+        # Create a query
+        query_compiler = self.query_compiler_class(
+            models.Book.objects.all(),
+            Fuzzy("Hello world"),
+            fields=["title", "body"],
+            partial_match=False,
+        )
+
+        # Check it
+        with self.assertRaises(NotImplementedError):
+            query_compiler.get_inner_query()
+
+    def test_fuzzy_query_partial_match_disallowed(self):
+        # Create a query
+        query_compiler = self.query_compiler_class(
+            models.Book.objects.all(),
+            Fuzzy("Hello world"),
+            fields=["_all"],
+            partial_match=True,
+        )
+
+        # Check it
+        with self.assertRaises(NotImplementedError):
+            query_compiler.get_inner_query()
 
     def test_year_filter(self):
         # Create a query

--- a/wagtail/search/tests/test_elasticsearch7_backend.py
+++ b/wagtail/search/tests/test_elasticsearch7_backend.py
@@ -8,7 +8,7 @@ from django.test import TestCase
 from elasticsearch.serializer import JSONSerializer
 
 from wagtail.search.backends.elasticsearch7 import Elasticsearch7SearchBackend
-from wagtail.search.query import Fuzzy, MATCH_ALL, Phrase
+from wagtail.search.query import MATCH_ALL, Fuzzy, Phrase
 from wagtail.test.search import models
 
 from .elasticsearch_common_tests import ElasticsearchCommonSearchBackendTests
@@ -608,11 +608,15 @@ class TestElasticsearch7SearchQuery(TestCase):
     def test_fuzzy_query(self):
         # Create a query
         query_compiler = self.query_compiler_class(
-            models.Book.objects.all(), Fuzzy("Hello world"), partial_match=False,
+            models.Book.objects.all(),
+            Fuzzy("Hello world"),
+            partial_match=False,
         )
 
         # Check it
-        expected_result = {"fuzzy": {"_all_text": "Hello world"}}
+        expected_result = {
+            "match": {"_all_text": {"query": "Hello world", "fuzziness": "AUTO"}}
+        }
         self.assertDictEqual(query_compiler.get_inner_query(), expected_result)
 
     def test_fuzzy_query_single_field(self):
@@ -625,7 +629,9 @@ class TestElasticsearch7SearchQuery(TestCase):
         )
 
         # Check it
-        expected_result = {"fuzzy": {"title": "Hello world"}}
+        expected_result = {
+            "match": {"title": {"query": "Hello world", "fuzziness": "AUTO"}}
+        }
         self.assertDictEqual(query_compiler.get_inner_query(), expected_result)
 
     def test_fuzzy_query_multiple_fields_disallowed(self):


### PR DESCRIPTION
This adds a Fuzzy() search query, similar to the `wagtail.search.query.Phrase` added in Wagtail 2.10. This is supported only by the Elasticsearch backends.

Additionally, since fuzzy searching is computationally expensive, it is not possible with multiple fields, or when partial matching is enabled.

Elasticsearch documentation: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-fuzzy-query.html

To do:

- [x] add documentation
- [x] deal with the deprecation timeline for partial matching (see [comment](https://github.com/wagtail/wagtail/pull/8498/#issuecomment-1151304643))
- [ ] consider handling other parameters, as per https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-fuzzy-query.html#fuzzy-query-field-params

Example result from the Wagtail Bakery:

![image](https://user-images.githubusercontent.com/1473980/167177548-c6a1d58b-3841-425b-b756-8c8c14a5df27.png)