### PR TITLE
Add better control over StructBlock sub-block display order

### DIFF
--- a/docs/advanced_topics/customisation/streamfield_blocks.md
+++ b/docs/advanced_topics/customisation/streamfield_blocks.md
@@ -88,6 +88,52 @@ A form template for a StructBlock must include the output of `render_form` for e
 </div>
 ```
 
+(controlling_structblock_block_order)=
+
+## Using ``block_order`` to control block order
+
+```{versionadded} 4.0
+```
+
+To customise the order that blocks appear in the page editor without customising the template, you can specify a `block_order` attribute (either as a keyword argument to the `StructBlock` constructor, or in a subclass's `Meta`). The value should be a list of block names in the order you wish for them to be displayed.
+
+This option is particularly useful when using inheritance, for example:
+
+```python
+class BasePersonBlock(blocks.StructBlock):
+    first_name = blocks.CharBlock()
+    surname = blocks.CharBlock()
+    photo = ImageChooserBlock(required=False)
+    biography = blocks.RichTextBlock()
+
+
+class TeacherBlock(BasePersonBlock):
+    title = blocks.ChoiceBlock(choices=[
+        ("Dr", "Dr"),
+        ("Miss", "Miss"),
+        ("Mr", "Mr"),
+        ("Mrs", "Mrs"),
+        ("Ms", "Ms"),
+        ("Prof", "Prof"),
+    ])
+    suffix = blocks.CharBlock(required=False)
+    department = SnippetChooserBlock("departments.Departement")
+
+    class Meta:
+        icon = 'user'
+        # Show name fields in the correct order,
+        # followed by 'department', then any other fields
+        block_order = [
+            "title",
+            "first_name",
+            "surname",
+            "suffix",
+            "department"
+        ]
+```
+
+Any sub-blocks whose names are not specified will be displayed after those that are named.
+
 ## Additional JavaScript on `StructBlock` forms
 
 Often it may be desirable to attach custom JavaScript behaviour to a StructBlock form. For example, given a block such as:

--- a/docs/reference/streamfield/blocks.md
+++ b/docs/reference/streamfield/blocks.md
@@ -411,6 +411,7 @@ All block definitions accept the following optional keyword arguments:
 
    :param form_classname: An HTML ``class`` attribute to set on the root element of this block as displayed in the editing interface. Defaults to ``struct-block``; note that the admin interface has CSS styles defined on this class, so it is advised to include ``struct-block`` in this value when overriding. See :ref:`custom_editing_interfaces_for_structblock`.
    :param form_template: Path to a Django template to use to render this block's form. See :ref:`custom_editing_interfaces_for_structblock`.
+   :param block_order: A list or tuple of strings indicating the preferred display order of sub-blocks in the admin interface. Any sub-blocks whose names are missing from the list will be displayed after those that are included. See :ref:`_controlling_structblock_block_order`.
    :param value_class: A subclass of ``wagtail.blocks.StructValue`` to use as the type of returned values for this block. See :ref:`custom_value_class_for_structblock`.
    :param label_format:
      Determines the label shown when the block is collapsed in the editing interface. By default, the value of the first sub-block in the StructBlock is shown, but this can be customised by setting a string here with block names contained in braces - e.g. ``label_format = "Profile for {first_name} {surname}"``

--- a/wagtail/tests/test_blocks.py
+++ b/wagtail/tests/test_blocks.py
@@ -1747,6 +1747,66 @@ class TestStructBlock(SimpleTestCase):
         expected = "<b>world</b>"
         self.assertEqual(str(body_bound_block), expected)
 
+    def test_block_order_specified_on_meta_class(self):
+        class SectionBlock(blocks.StructBlock):
+            """
+            Without ordering specified, the child_blocks should remain
+            in the order specified below
+            """
+
+            title = blocks.CharBlock()
+            heading_level = blocks.IntegerBlock()
+            body = blocks.RichTextBlock()
+
+        class ReverseOrderSectionBlock(SectionBlock):
+            """
+            child_blocks should be in the following order:
+            1. body
+            2. heading_level
+            3. title
+            """
+
+            class Meta:
+                block_order = ["body", "heading_level", "title"]
+
+        class PartiallyOrderedSectionBlock(SectionBlock):
+            """
+            child_blocks should be in the following order:
+            1. heading_level
+            2. title
+            3. body
+            """
+
+            class Meta:
+                block_order = ["heading_level"]
+
+        for block_class, expected_block_order in (
+            (SectionBlock, ["title", "heading_level", "body"]),
+            (ReverseOrderSectionBlock, ["body", "heading_level", "title"]),
+            (PartiallyOrderedSectionBlock, ["heading_level", "title", "body"]),
+        ):
+            block = block_class()
+            self.assertEqual(list(block.child_blocks.keys()), expected_block_order)
+
+    def test_block_order_specified_as_init_kwarg(self):
+        class SectionBlock(blocks.StructBlock):
+            title = blocks.CharBlock()
+            heading_level = blocks.IntegerBlock()
+            body = blocks.RichTextBlock()
+
+        for specified_block_order, expected_child_block_order in (
+            (None, ["title", "heading_level", "body"]),
+            (
+                ["body", "heading_level", "title"],
+                ["body", "heading_level", "title"],
+            ),
+            (["heading_level"], ["heading_level", "title", "body"]),
+        ):
+            block = SectionBlock(block_order=specified_block_order)
+            self.assertEqual(
+                list(block.child_blocks.keys()), expected_child_block_order
+            )
+
     def test_get_form_context(self):
         class LinkBlock(blocks.StructBlock):
             title = blocks.CharBlock()


### PR DESCRIPTION
Related issue: #7370

Whilst having a full set of 'layout components' to play around with would be awesome, 80% of the time, just having some control over the block order when there are one or more levels of inheritance is super valuable, and can be achieved with very little work. 

This PR adds a `block_order` option for `StructBlock`, which can be specified on the block's `Meta` class OR provided as a keyword argument when creating a block instance (much like you can do with `label` / `icon` / `template` etc), and the value is a list of sub-block names in the developer's preferred display order.

There's no existing mechanism for 'hiding' sub-blocks for `StructBlock`, so this option does not introduce one, so all sub-blocks are still rendered in the form. Any blocks not named in `block_order` simply appear _after_ those that are.

Check out the [documentation additions](https://github.com/wagtail/wagtail/blob/9c2d0431f0edc516df84b1d3455f029de90a45c2/docs/advanced_topics/customisation/streamfield_blocks.rst#using-block_order-to-control-block-order) for a more in-depth description of how to use it.
 
- [x] Do the tests still pass?
- [x] Does the code comply with the style guide? 
    - [x] Run `make lint` from the Wagtail root. 
- [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
- [x] For new features: Has the documentation been updated accordingly?

## How to test these changes

In bakerydemo:

1. In Wagtail, edit a page and add a new `ImageBlock` to the page body. The sub-blocks should display in the order: `("image", "caption", "attribution")`

### Test specifying order for all blocks

2. Add `block_order = ["attribution", "caption", "image"]` to the `Meta` class for `ImageBlock` and save the changes
https://github.com/wagtail/bakerydemo/blob/master/bakerydemo/base/blocks.py#L17-L19
3. In Wagtail again, edit a page and add another `ImageBlock` to the page body. The sub-blocks should now display in the order: `("attribution", "caption", "image")`

### Test specifying order for some blocks only

4. Add `block_order = ["caption"]` to the `Meta` class for `ImageBlock` and save the changes
https://github.com/wagtail/bakerydemo/blob/master/bakerydemo/base/blocks.py#L17-L19
5. In Wagtail again, edit a page and add another `ImageBlock` to the page body. The sub-blocks should now display in the order: `("caption", "attribution", "image")`

### Repeat above tests using the __init__() kwarg option

Revert any changes you have made already, then repeat the above steps- Only, instead of setting the `block_order` attribute on the block's `Meta` class, specify it as a keyword argument to `ImageBlock()` on the following line, instead: https://github.com/wagtail/bakerydemo/blob/master/bakerydemo/base/blocks.py#L62