### PR TITLE
Add missing media context in `revisions_revert` view

### DIFF
--- a/wagtail/admin/tests/pages/test_revisions.py
+++ b/wagtail/admin/tests/pages/test_revisions.py
@@ -169,13 +169,16 @@ class TestStreamRevisions(TestCase, WagtailTestUtils):
         response = self.client.get(test_page_revert_url)
         self.assertEqual(response.status_code, 200)
 
-        # The media files for StreamField should be included
+        html = response.content.decode()
         blocks_js = versioned_static("wagtailadmin/js/telepath/blocks.js")
         streamfield_css = versioned_static("wagtailadmin/css/panels/streamfield.css")
-        self.assertContains(response, f'<script src="{blocks_js}"></script>')
-        self.assertContains(
-            response,
-            f'<link href="{streamfield_css}" type="text/css" media="all" rel="stylesheet">',
+
+        # The media files for StreamField should be included in the HTML
+        self.assertTagInHTML(f'<script src="{blocks_js}"></script>', html)
+        self.assertTagInHTML(
+            f'<link href="{streamfield_css}" media="all" rel="stylesheet">',
+            html,
+            allow_extra_attrs=True,  # Django 4.1 removes the type="text/css" attribute
         )
 
 

--- a/wagtail/admin/tests/pages/test_revisions.py
+++ b/wagtail/admin/tests/pages/test_revisions.py
@@ -5,9 +5,11 @@ from django.test import TestCase
 from django.urls import reverse
 from freezegun import freeze_time
 
+from wagtail.admin.staticfiles import versioned_static
 from wagtail.admin.tests.pages.timestamps import local_datetime
 from wagtail.models import Page
 from wagtail.test.testapp.models import (
+    DefaultStreamPage,
     EventPage,
     FormClassAdditionalFieldPage,
     SecretPage,
@@ -140,6 +142,41 @@ class TestRevisions(TestCase, WagtailTestUtils):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Page scheduled for publishing at 26 Dec 2014")
         self.assertContains(response, this_christmas_unschedule_url)
+
+
+class TestStreamRevisions(TestCase, WagtailTestUtils):
+    def setUp(self):
+        self.root_page = Page.objects.get(id=2)
+
+        self.test_page = DefaultStreamPage(
+            title="A DefaultStreamPage",
+            slug="a-defaultstreampage",
+        )
+        self.root_page.add_child(instance=self.test_page)
+
+        self.test_page.title = "An Updated DefaultStreamPage"
+        self.first_revision = self.test_page.save_revision()
+        self.first_revision.created_at = local_datetime(2022, 5, 10)
+        self.first_revision.save()
+
+        self.login()
+
+    def test_revert_revision(self):
+        test_page_revert_url = reverse(
+            "wagtailadmin_pages:revisions_revert",
+            args=(self.test_page.id, self.first_revision.id),
+        )
+        response = self.client.get(test_page_revert_url)
+        self.assertEqual(response.status_code, 200)
+
+        # The media files for StreamField should be included
+        blocks_js = versioned_static("wagtailadmin/js/telepath/blocks.js")
+        streamfield_css = versioned_static("wagtailadmin/css/panels/streamfield.css")
+        self.assertContains(response, f'<script src="{blocks_js}"></script>')
+        self.assertContains(
+            response,
+            f'<link href="{streamfield_css}" type="text/css" media="all" rel="stylesheet">',
+        )
 
 
 class TestCompareRevisions(TestCase, WagtailTestUtils):

--- a/wagtail/admin/views/pages/revisions.py
+++ b/wagtail/admin/views/pages/revisions.py
@@ -11,6 +11,7 @@ from django.utils.translation import gettext as _
 from wagtail.admin import messages
 from wagtail.admin.action_menu import PageActionMenu
 from wagtail.admin.auth import user_has_any_page_permission, user_passes_test
+from wagtail.admin.side_panels import PageSidePanels
 from wagtail.admin.views.pages.utils import get_valid_next_url_from_request
 from wagtail.models import Page, UserPagePermissionsProxy
 
@@ -37,6 +38,19 @@ def revisions_revert(request, page_id, revision_id):
     form = form_class(instance=revision_page)
     edit_handler = edit_handler.get_bound_panel(
         instance=revision_page, request=request, form=form
+    )
+
+    if revision_page.live and revision_page.has_unpublished_changes:
+        # Page status needs to present the version of the page containing the correct live URL
+        page_for_status = page.specific
+    else:
+        page_for_status = revision_page
+
+    action_menu = PageActionMenu(request, view="revisions_revert", page=page)
+    side_panels = PageSidePanels(
+        request,
+        page_for_status,
+        comments_enabled=form.show_comments_toggle,
     )
 
     user_avatar = render_to_string(
@@ -66,9 +80,14 @@ def revisions_revert(request, page_id, revision_id):
             "content_type": content_type,
             "edit_handler": edit_handler,
             "errors_debug": None,
-            "action_menu": PageActionMenu(request, view="revisions_revert", page=page),
+            "action_menu": action_menu,
+            "side_panels": side_panels,
             "preview_modes": page.preview_modes,
             "form": form,  # Used in unit tests
+            "media": edit_handler.media
+            + form.media
+            + action_menu.media
+            + side_panels.media,
         },
     )
 

--- a/wagtail/admin/views/pages/revisions.py
+++ b/wagtail/admin/views/pages/revisions.py
@@ -40,16 +40,10 @@ def revisions_revert(request, page_id, revision_id):
         instance=revision_page, request=request, form=form
     )
 
-    if revision_page.live and revision_page.has_unpublished_changes:
-        # Page status needs to present the version of the page containing the correct live URL
-        page_for_status = page.specific
-    else:
-        page_for_status = revision_page
-
     action_menu = PageActionMenu(request, view="revisions_revert", page=page)
     side_panels = PageSidePanels(
         request,
-        page_for_status,
+        page.specific,
         comments_enabled=form.show_comments_toggle,
     )
 


### PR DESCRIPTION
Fixes #8505.

Kindly review @gasman @kaedroho, thanks!

<!--
Thanks for contributing to Wagtail! 🎉

Before submitting, please review the [contributor guidelines](https://docs.wagtail.org/en/latest/contributing/index.html).
-->

_Please check the following:_

- [x] Do the tests still pass?[^1]
- [x] Does the code comply with the style guide? 
    - [x] Run `make lint` from the Wagtail root. 
- [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
- [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    - [ ] **Please list the exact browser and operating system versions you tested**:
    - [ ] **Please list which assistive technologies [^3] you tested**: 
- [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**. 

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets) 
