### PR TITLE
Throw error if images.Filter.run cannot create output

### DIFF
--- a/wagtail/images/exceptions.py
+++ b/wagtail/images/exceptions.py
@@ -1,2 +1,10 @@
 class InvalidFilterSpecError(ValueError):
     pass
+
+
+class UnknownOutputImageFormatError(ValueError):
+    """
+    Exception thrown when an unknown output format is requested for an image conversion
+    """
+
+    pass

--- a/wagtail/images/models.py
+++ b/wagtail/images/models.py
@@ -25,7 +25,10 @@ from willow.image import Image as WillowImage
 from wagtail import hooks
 from wagtail.admin.models import get_object_usage
 from wagtail.coreutils import string_to_ascii
-from wagtail.images.exceptions import InvalidFilterSpecError
+from wagtail.images.exceptions import (
+    InvalidFilterSpecError,
+    UnknownOutputImageFormatError,
+)
 from wagtail.images.image_operations import (
     FilterOperation,
     ImageTransform,
@@ -677,6 +680,9 @@ class Filter:
                     quality = getattr(settings, "WAGTAILIMAGES_WEBP_QUALITY", 85)
 
                 return willow.save_as_webp(output, quality=quality)
+            raise UnknownOutputImageFormatError(
+                f"Unknown output image format '{output_format}'"
+            )
 
     def get_cache_key(self, image):
         vary_parts = []

--- a/wagtail/images/tests/utils.py
+++ b/wagtail/images/tests/utils.py
@@ -27,3 +27,10 @@ def get_test_image_file_webp(filename="test.webp", colour="white", size=(640, 48
     image = PIL.Image.new("RGB", size, colour)
     image.save(f, "WEBP")
     return ImageFile(f, name=filename)
+
+
+def get_test_image_file_tiff(filename="test.tiff", colour="white", size=(640, 480)):
+    f = BytesIO()
+    image = PIL.Image.new("RGB", size, colour)
+    image.save(f, "TIFF")
+    return ImageFile(f, name=filename)


### PR DESCRIPTION
If Filter.run is requested to create an unknown output format,
it should not fail silently without writing any output, but instead
throw an exception.