### PR TITLE
Set comment position correctly relative to scroll position

### DIFF
--- a/client/src/components/CommentApp/utils/layout.ts
+++ b/client/src/components/CommentApp/utils/layout.ts
@@ -51,15 +51,20 @@ export class LayoutController {
       return;
     }
 
-    const currentNodeTop = annotation
-      .getAnchorNode(commentId === this.pinnedComment)
-      .getBoundingClientRect().top;
+    const currentNode = annotation.getAnchorNode(
+      commentId === this.pinnedComment,
+    );
+    let currentNodeTop = currentNode.getBoundingClientRect().top;
+    // adjust currentNodeTop for scroll positions of all ancestor elements
+    let parent = currentNode.parentElement;
+    while (parent) {
+      currentNodeTop += parent.scrollTop;
+      parent = parent.parentElement;
+    }
 
     this.commentDesiredPositions.set(
       commentId,
-      currentNodeTop !== 0
-        ? currentNodeTop + document.documentElement.scrollTop + OFFSET
-        : 0,
+      currentNodeTop !== 0 ? currentNodeTop + OFFSET : 0,
     );
   }
 


### PR DESCRIPTION
Fixes #8500. As a consequence of the CSS changes in c6fdb6bbb30f785651fc24da4254409e9918a451, scroll position is no longer reflected in the document element's scrollTop property, but on the `<main>` element instead. As a result, comment positions were not being adjusted for scroll position. To account for this (and any future CSS changes), we walk all ancestor elements to calculate the true scroll position.

Tested on Chrome 101.0.4951.54 and Firefox 97.0.1 on OS X.

_Please check the following:_

- [ ] Do the tests still pass?[^1]
- [ ] Does the code comply with the style guide? 
    - [ ] Run `make lint` from the Wagtail root. 
- [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
- [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    - [ ] **Please list the exact browser and operating system versions you tested**:
    - [ ] **Please list which assistive technologies [^3] you tested**: 
- [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**. 

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets) 
