### PR TITLE
Disable webpack css url rewriting

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -90,6 +90,7 @@ Changelog
  * Fix: Implement ARIA tabs markup and keyboards interactions for admin tabs (Steven Steinwand)
  * Fix: Ensure `wagtail updatemodulepaths` works when system locale is not UTF-8 (Matt Westcott)
  * Fix: Re-establish focus trap for Pages explorer in slim sidebar (Thibaud Colas)
+ * Fix: Ensure the icon font loads correctly when `STATIC_URL` is not `"/static/"` (Jacob Topp-Mugglestone)
 
 
 2.16.2 (11.04.2022)

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -397,7 +397,12 @@ module.exports = function exports(env, argv) {
           test: /\.(scss|css)$/,
           use: [
             MiniCssExtractPlugin.loader,
-            'css-loader',
+            {
+              loader: 'css-loader',
+              options: {
+                url: false,
+              },
+            },
             {
               loader: 'postcss-loader',
               options: {

--- a/docs/releases/3.0.md
+++ b/docs/releases/3.0.md
@@ -128,6 +128,7 @@ When using a queryset to render a list of items with images, you can now make us
  * Implement ARIA tabs markup and keyboards interactions for admin tabs (Steven Steinwand)
  * Ensure `wagtail updatemodulepaths` works when system locale is not UTF-8 (Matt Westcott)
  * Re-establish focus trap for Pages explorer in slim sidebar (Thibaud Colas)
+ * Ensure the icon font loads correctly when `STATIC_URL` is not `"/static/"` (Jacob Topp-Mugglestone)
 
 
 ## Upgrade considerations - changes affecting all projects


### PR DESCRIPTION
This was causing relative urls to be rewritten to use the `publicPath` in the webpack config, `/static/`.
This meant that the icon font would be referenced at the wrong location if sites had changed STATIC_URL

Fixes https://github.com/wagtail/wagtail/issues/8517