### PR TITLE
Ensure non-square avatar image will correctly show

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -45,6 +45,7 @@ Changelog
  * Fix: Specific snippets list language picker was not properly styled (Sage Abdullah)
  * Fix: Add an accessible label to the image focal point input when editing images (Lucie Le Frapper)
  * Fix: Remove unused header search JavaScript on the redirects import page (LB (Ben) Johnston)
+ * FIx: Ensure non-square avatar images will correctly show throughout the admin (LB (Ben) Johnston)
 
 
 3.0 (16.05.2022)

--- a/client/scss/objects/_avatar.scss
+++ b/client/scss/objects/_avatar.scss
@@ -16,6 +16,9 @@
     inset-inline-start: 0;
     inset-inline-end: 0;
     border: 0;
+    object-fit: cover;
+    width: 100%;
+    height: 100%;
   }
 
   &.small {

--- a/client/src/components/CommentApp/components/CommentHeader/style.scss
+++ b/client/src/components/CommentApp/components/CommentHeader/style.scss
@@ -6,6 +6,7 @@
     width: 30px;
     height: 30px;
     border-radius: 15px;
+    object-fit: cover;
   }
 
   &__author,

--- a/docs/releases/4.0.md
+++ b/docs/releases/4.0.md
@@ -59,6 +59,7 @@ When using a queryset to render a list of images, you can now use the ``prefetch
  * Specific snippets list language picker was not properly styled (Sage Abdullah)
  * Add an accessible label to the image focal point input when editing images (Lucie Le Frapper)
  * Remove unused header search JavaScript on the redirects import page (LB (Ben) Johnston)
+ * Ensure non-square avatar images will correctly show throughout the admin (LB (Ben) Johnston)
 
 
 ## Upgrade considerations


### PR DESCRIPTION
- fixes #8428
- [x] Do the tests still pass?[^1]
- [x] Does the code comply with the style guide? 
- [x] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
- [X] **Please list the exact browser and operating system versions you tested**: Safari 15.4, Firefox 99, Chrome 103 all on macOS 12.3
- [X] **Please list which assistive technologies [^3] you tested**: N/A
- [X] For new features: Has the documentation been updated accordingly? N/A


## Testing this change
- places to check when testing this; bottom left sidebar (user logo), user editing page, dashboard header, page history list.

## Screenshots

<img width="1324" alt="Screen Shot 2022-05-11 at 10 05 30 pm" src="https://user-images.githubusercontent.com/1396140/167847113-f3e39d1a-e76d-4cff-8f25-4d66dcca9163.png">

<img width="2030" alt="Screen Shot 2022-05-11 at 10 09 35 pm" src="https://user-images.githubusercontent.com/1396140/167846875-b1f51c0d-1aad-41fc-9f05-d29ae581ecbc.png">

<img width="756" alt="Screen Shot 2022-05-11 at 10 06 25 pm" src="https://user-images.githubusercontent.com/1396140/167846901-ce668b9e-8ba6-491d-a7df-4718fae943a5.png">

<img width="817" alt="Screen Shot 2022-05-11 at 10 05 46 pm" src="https://user-images.githubusercontent.com/1396140/167846912-5460f5d0-6be6-4c6c-a86a-fd3caa6d0142.png">


[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets) 
