### PR TITLE
fix issue with image model docstrings

### DIFF
--- a/wagtail/images/models.py
+++ b/wagtail/images/models.py
@@ -330,11 +330,11 @@ class AbstractImage(ImageFileMixin, CollectionMember, index.Indexed, models.Mode
 
     def get_rendition(self, filter: Union["Filter", str]) -> "AbstractRendition":
         """
-        Returns a ``Rendition*`` instance with a ``file`` field value (an
+        Returns a ``Rendition`` instance with a ``file`` field value (an
         image) reflecting the supplied ``filter`` value and focal point values
         from this object.
 
-        *If using custom image models, an instance of the custom rendition
+        Note: If using custom image models, an instance of the custom rendition
         model will be returned.
         """
         if isinstance(filter, str):
@@ -365,14 +365,14 @@ class AbstractImage(ImageFileMixin, CollectionMember, index.Indexed, models.Mode
 
     def find_existing_rendition(self, filter: "Filter") -> "AbstractRendition":
         """
-        Returns an existing ``Rendition*`` instance with a ``file`` field value
+        Returns an existing ``Rendition`` instance with a ``file`` field value
         (an image) reflecting the supplied ``filter`` value and focal point
         values from this object.
 
         If no such rendition exists, a ``DoesNotExist`` error is raised for the
         relevant model.
 
-        *If using custom image models, an instance of the custom rendition
+        Note: If using custom image models, an instance of the custom rendition
         model will be returned.
         """
 
@@ -408,14 +408,14 @@ class AbstractImage(ImageFileMixin, CollectionMember, index.Indexed, models.Mode
 
     def create_rendition(self, filter: "Filter") -> "AbstractRendition":
         """
-        Creates and returns a ``Rendition*`` instance with a ``file`` field
+        Creates and returns a ``Rendition`` instance with a ``file`` field
         value (an image) reflecting the supplied ``filter`` value and focal
         point values from this object.
 
         This method is usually called by ``Image.get_rendition()``, after first
         checking that a suitable rendition does not already exist.
 
-        *If using custom image models, an instance of the custom rendition
+        Note: If using custom image models, an instance of the custom rendition
         model will be returned.
         """
         # Because of unique constraints applied to the model, we use


### PR DESCRIPTION
* asterisk was being parsed as markdown and not rendering correctly in the documentation
* Used `Note: ` instead of `* ` as a reference to the rendition.

### before

<img width="926" alt="Screen Shot 2022-05-12 at 7 59 39 am" src="https://user-images.githubusercontent.com/1396140/167954891-9fe3ba53-2448-4930-873e-ed7cdc6a4a94.png">

### after

<img width="1009" alt="Screen Shot 2022-05-12 at 7 59 05 am" src="https://user-images.githubusercontent.com/1396140/167954920-1254b1e1-b6fc-4fb6-b4e2-306f52d6c9a0.png">


