### PR TITLE
Change description text for switch locales

### DIFF
--- a/wagtail/admin/side_panels.py
+++ b/wagtail/admin/side_panels.py
@@ -68,6 +68,7 @@ class StatusSidePanel(BaseSidePanel):
                         .select_related("locale")
                         if user_perms.for_page(translation).can_edit()
                     ],
+                    "translations_total": self.page.get_translations().count() + 1,
                 }
             )
 

--- a/wagtail/admin/side_panels.py
+++ b/wagtail/admin/side_panels.py
@@ -68,6 +68,7 @@ class StatusSidePanel(BaseSidePanel):
                         .select_related("locale")
                         if user_perms.for_page(translation).can_edit()
                     ],
+                    # The sum of translated pages plus 1 to account for the current page
                     "translations_total": self.page.get_translations().count() + 1,
                 }
             )

--- a/wagtail/admin/templates/wagtailadmin/pages/side_panels/includes/page_locale_status.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/side_panels/includes/page_locale_status.html
@@ -5,8 +5,8 @@
     {% trans 'Page Locale: ' as screen_reader_title_prefix %}
 
     {% if translations %}
-        {% blocktrans trimmed with count=page.get_translations.count asvar help_text %}
-            Translated to {{ count }} other locales
+        {% blocktrans trimmed asvar help_text %}
+            Available in {{ translations_total }} locales
         {% endblocktrans %}
     {% else %}
         {% trans 'No other translations' as help_text %}


### PR DESCRIPTION
Change the wording for the description of a translated page to “Available in X locales”. 
Get the number of translations and add 1 to the count for the current translated page.

### Screenshots
<img width="423" alt="Screen Shot 2022-05-11 at 9 56 26 PM" src="https://user-images.githubusercontent.com/25041665/167989175-7a08b120-137e-4d6a-b1e0-7f059200eeff.png">

### Browsers tested in
Chrome 100, safari 15.2, firefox 99
