### PR TITLE
Added handling for lazily evaluated page_description, fixes #8523

### DIFF
--- a/wagtail/admin/tests/pages/test_create_page.py
+++ b/wagtail/admin/tests/pages/test_create_page.py
@@ -69,6 +69,7 @@ class TestPageCreation(TestCase, WagtailTestUtils):
         self.assertEqual(response.status_code, 200)
 
         self.assertContains(response, "Business child")
+        self.assertContains(response, "A lazy business child page description")
         # List should not contain page types not in the subpage_types list
         self.assertNotContains(response, "Simple page")
 

--- a/wagtail/models/__init__.py
+++ b/wagtail/models/__init__.py
@@ -1509,6 +1509,9 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
         # make sure that page_description is actually a string rather than a model field
         if isinstance(description, str):
             return description
+        elif getattr(description, "_delegate_text", None):
+            # description is a lazy object (e.g. the result of gettext_lazy())
+            return str(description)
         else:
             return ""
 

--- a/wagtail/test/testapp/models.py
+++ b/wagtail/test/testapp/models.py
@@ -11,6 +11,7 @@ from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 from django.db import models
 from django.shortcuts import redirect
 from django.template.response import TemplateResponse
+from django.utils.functional import lazystr
 from modelcluster.contrib.taggit import ClusterTaggableManager
 from modelcluster.fields import ParentalKey, ParentalManyToManyField
 from modelcluster.models import ClusterableModel
@@ -976,6 +977,7 @@ class BusinessChild(Page):
 
     subpage_types = []
     parent_page_types = ["tests.BusinessIndex", BusinessSubIndex]
+    page_description = lazystr("A lazy business child page description")
 
 
 class BusinessNowherePage(Page):


### PR DESCRIPTION
This change allows the usage of lazily translated strings for `page_description`, based on the information I've got [here](https://github.com/wagtail/wagtail/issues/8523#issuecomment-1124031671).

**TBD:** While translating new strings in german lately, I've found/translated some (unnecessary) strings from the tests. With this in mind I've now used `lazystr()` instead of `gettext_lazy()` which basically results in the same proxy object, but avoids a new string in the language files.

Should I open a new ticket to exclude tests from the language files or has this been discussed (and for some reason discarded) in the past?

_Please check the following:_

- [x] Do the tests still pass?[^1]
- [x] Does the code comply with the style guide? 
    - [x] Run `make lint` from the Wagtail root. 
- [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
- [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**. 

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets) 
