### PR TITLE
Make 'upload one now' link on document chooser work after results refresh

### DIFF
--- a/client/src/entrypoints/admin/task-chooser-modal.js
+++ b/client/src/entrypoints/admin/task-chooser-modal.js
@@ -60,6 +60,9 @@ const TASK_CHOOSER_MODAL_ONLOAD_HANDLERS = {
         fetchResults(this.href);
         return false;
       });
+
+      // Reinitialize tabs to hook up tab event listeners in the modal
+      initTabs();
     }
 
     const searchForm = $('form.task-search', modal.body);
@@ -113,9 +116,6 @@ const TASK_CHOOSER_MODAL_ONLOAD_HANDLERS = {
       const wait = setTimeout(search, 50);
       $(this).data('timer', wait);
     });
-
-    // Reinitialize tabs to hook up tab event listeners in the modal
-    initTabs();
   },
   task_chosen(modal, jsonData) {
     modal.respond('taskChosen', jsonData.result);

--- a/client/src/entrypoints/documents/document-chooser-modal.js
+++ b/client/src/entrypoints/documents/document-chooser-modal.js
@@ -92,6 +92,9 @@ window.DOCUMENT_CHOOSER_MODAL_ONLOAD_HANDLERS = {
 
         e.preventDefault();
       });
+
+      // Reinitialize tabs to hook up tab event listeners in the modal
+      initTabs();
     }
 
     var searchForm = $('form.document-search', modal.body);
@@ -135,9 +138,6 @@ window.DOCUMENT_CHOOSER_MODAL_ONLOAD_HANDLERS = {
     });
 
     $('#collection_chooser_collection_id').on('change', search);
-
-    // Reinitialize tabs to hook up tab event listeners in the modal
-    initTabs();
   },
   document_chosen: function (modal, jsonData) {
     modal.respond('documentChosen', jsonData.result);


### PR DESCRIPTION
Fixes #8528
Put the initTabs call inside ajaxifyLinks so that it's reapplied when the results container (including the 'no results message') is replaced.
