### PR TITLE
Refactor out duplicated code from chooser modal JS

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -112,12 +112,7 @@ module.exports = {
       globals: { $: 'readonly' },
     },
     {
-      files: [
-        'wagtail/**/**',
-        'client/src/entrypoints/documents/document-chooser-modal.js',
-        'client/src/entrypoints/images/image-chooser-modal.js',
-        'client/src/entrypoints/snippets/snippet-chooser-modal.js',
-      ],
+      files: ['wagtail/**/**'],
       globals: {
         $: 'readonly',
         addMessage: 'readonly',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -116,6 +116,7 @@ module.exports = {
         'wagtail/**/**',
         'client/src/entrypoints/documents/document-chooser-modal.js',
         'client/src/entrypoints/images/image-chooser-modal.js',
+        'client/src/entrypoints/snippets/snippet-chooser-modal.js',
       ],
       globals: {
         $: 'readonly',

--- a/client/src/entrypoints/admin/task-chooser-modal.js
+++ b/client/src/entrypoints/admin/task-chooser-modal.js
@@ -1,6 +1,6 @@
 import $ from 'jquery';
 import { initTabs } from '../../includes/tabs';
-import { gettext } from '../../utils/gettext';
+import { submitCreationForm } from '../../includes/chooserModal';
 
 const ajaxifyTaskCreateTab = (modal) => {
   $(
@@ -13,35 +13,7 @@ const ajaxifyTaskCreateTab = (modal) => {
 
   // eslint-disable-next-line func-names
   $('form.task-create', modal.body).on('submit', function () {
-    const formdata = new FormData(this);
-
-    $.ajax({
-      url: this.action,
-      data: formdata,
-      processData: false,
-      contentType: false,
-      type: 'POST',
-      dataType: 'text',
-      success: modal.loadResponseText,
-      error(response, textStatus, errorThrown) {
-        const message =
-          gettext(
-            'Report this error to your website administrator with the following information:',
-          ) +
-          '<br />' +
-          errorThrown +
-          ' - ' +
-          response.status;
-        $('#tab-new', modal.body).append(
-          '<div class="help-block help-critical">' +
-            '<strong>' +
-            gettext('Server Error') +
-            ': </strong>' +
-            message +
-            '</div>',
-        );
-      },
-    });
+    submitCreationForm(modal, this, { errorContainerSelector: '#tab-new' });
 
     return false;
   });

--- a/client/src/entrypoints/admin/task-chooser-modal.js
+++ b/client/src/entrypoints/admin/task-chooser-modal.js
@@ -1,7 +1,8 @@
 import $ from 'jquery';
 import { initTabs } from '../../includes/tabs';
+import { gettext } from '../../utils/gettext';
 
-const ajaxifyTaskCreateTab = (modal, jsonData) => {
+const ajaxifyTaskCreateTab = (modal) => {
   $(
     '#tab-new a.task-type-choice, #tab-new a.choose-different-task-type',
     modal.body,
@@ -24,7 +25,9 @@ const ajaxifyTaskCreateTab = (modal, jsonData) => {
       success: modal.loadResponseText,
       error(response, textStatus, errorThrown) {
         const message =
-          jsonData.error_message +
+          gettext(
+            'Report this error to your website administrator with the following information:',
+          ) +
           '<br />' +
           errorThrown +
           ' - ' +
@@ -32,7 +35,7 @@ const ajaxifyTaskCreateTab = (modal, jsonData) => {
         $('#tab-new', modal.body).append(
           '<div class="help-block help-critical">' +
             '<strong>' +
-            jsonData.error_label +
+            gettext('Server Error') +
             ': </strong>' +
             message +
             '</div>',

--- a/client/src/entrypoints/documents/document-chooser-modal.js
+++ b/client/src/entrypoints/documents/document-chooser-modal.js
@@ -1,5 +1,6 @@
 import $ from 'jquery';
 import { initTabs } from '../../includes/tabs';
+import { gettext } from '../../utils/gettext';
 
 function ajaxifyDocumentUploadForm(modal) {
   $('form.document-upload', modal.body).on('submit', function () {
@@ -15,7 +16,9 @@ function ajaxifyDocumentUploadForm(modal) {
       success: modal.loadResponseText,
       error: function (response, textStatus, errorThrown) {
         var message =
-          jsonData.error_message +
+          gettext(
+            'Report this error to your website administrator with the following information:',
+          ) +
           '<br />' +
           errorThrown +
           ' - ' +
@@ -23,7 +26,7 @@ function ajaxifyDocumentUploadForm(modal) {
         $('#tab-upload', modal.body).append(
           '<div class="help-block help-critical">' +
             '<strong>' +
-            jsonData.error_label +
+            gettext('Server Error') +
             ': </strong>' +
             message +
             '</div>',

--- a/client/src/entrypoints/documents/document-chooser-modal.js
+++ b/client/src/entrypoints/documents/document-chooser-modal.js
@@ -7,8 +7,10 @@ import {
 } from '../../includes/chooserModal';
 
 function ajaxifyDocumentUploadForm(modal) {
-  $('form.document-upload', modal.body).on('submit', function () {
-    submitCreationForm(modal, this, { errorContainerSelector: '#tab-upload' });
+  $('form.document-upload', modal.body).on('submit', (event) => {
+    submitCreationForm(modal, event.currentTarget, {
+      errorContainerSelector: '#tab-upload',
+    });
 
     return false;
   });
@@ -21,33 +23,35 @@ function ajaxifyDocumentUploadForm(modal) {
 }
 
 window.DOCUMENT_CHOOSER_MODAL_ONLOAD_HANDLERS = {
-  chooser: function (modal, jsonData) {
+  chooser: (modal) => {
+    let searchController;
+
     function ajaxifyLinks(context) {
-      $('a.document-choice', context).on('click', function () {
-        modal.loadUrl(this.href);
+      $('a.document-choice', context).on('click', (event) => {
+        modal.loadUrl(event.currentTarget.href);
         return false;
       });
 
-      $('.pagination a', context).on('click', function () {
-        searchController.fetchResults(this.href);
+      $('.pagination a', context).on('click', (event) => {
+        searchController.fetchResults(event.currentTarget.href);
         return false;
       });
 
-      $('a.upload-one-now').on('click', function (e) {
+      $('a.upload-one-now').on('click', (event) => {
         // Set current collection ID at upload form tab
         const collectionId = $('#collection_chooser_collection_id').val();
         if (collectionId) {
           $('#id_document-chooser-upload-collection').val(collectionId);
         }
 
-        e.preventDefault();
+        event.preventDefault();
       });
 
       // Reinitialize tabs to hook up tab event listeners in the modal
       initTabs();
     }
 
-    const searchController = new SearchController({
+    searchController = new SearchController({
       form: $('form.document-search', modal.body),
       resultsContainerSelector: '#search-results',
       onLoadResults: (context) => {
@@ -61,11 +65,11 @@ window.DOCUMENT_CHOOSER_MODAL_ONLOAD_HANDLERS = {
     ajaxifyLinks(modal.body);
     ajaxifyDocumentUploadForm(modal);
   },
-  document_chosen: function (modal, jsonData) {
+  document_chosen: (modal, jsonData) => {
     modal.respond('documentChosen', jsonData.result);
     modal.close();
   },
-  reshow_upload_form: function (modal, jsonData) {
+  reshow_upload_form: (modal, jsonData) => {
     $('#tab-upload', modal.body).replaceWith(jsonData.htmlFragment);
     initTabs();
     ajaxifyDocumentUploadForm(modal);

--- a/client/src/entrypoints/images/image-chooser-modal.js
+++ b/client/src/entrypoints/images/image-chooser-modal.js
@@ -7,9 +7,9 @@ import {
 } from '../../includes/chooserModal';
 
 function ajaxifyImageUploadForm(modal) {
-  $('form.image-upload', modal.body).on('submit', function () {
+  $('form.image-upload', modal.body).on('submit', (event) => {
     if (!$('#id_image-chooser-upload-title', modal.body).val()) {
-      var li = $('#id_image-chooser-upload-title', modal.body).closest('li');
+      const li = $('#id_image-chooser-upload-title', modal.body).closest('li');
       if (!li.hasClass('error')) {
         li.addClass('error');
         $('#id_image-chooser-upload-title', modal.body)
@@ -18,9 +18,10 @@ function ajaxifyImageUploadForm(modal) {
             '<p class="error-message"><span>This field is required.</span></p>',
           );
       }
+      // eslint-disable-next-line no-undef
       setTimeout(cancelSpinner, 500);
     } else {
-      submitCreationForm(modal, this, {
+      submitCreationForm(modal, event.currentTarget, {
         errorContainerSelector: '#tab-upload',
       });
     }
@@ -36,20 +37,22 @@ function ajaxifyImageUploadForm(modal) {
 }
 
 window.IMAGE_CHOOSER_MODAL_ONLOAD_HANDLERS = {
-  chooser: function (modal, jsonData) {
+  chooser: (modal) => {
+    let searchController;
+
     function ajaxifyLinks(context) {
-      $('.listing a', context).on('click', function () {
-        modal.loadUrl(this.href);
+      $('.listing a', context).on('click', (event) => {
+        modal.loadUrl(event.currentTarget.href);
         return false;
       });
 
-      $('.pagination a', context).on('click', function () {
-        searchController.fetchResults(this.href);
+      $('.pagination a', context).on('click', (event) => {
+        searchController.fetchResults(event.currentTarget.href);
         return false;
       });
     }
 
-    const searchController = new SearchController({
+    searchController = new SearchController({
       form: $('form.image-search', modal.body),
       resultsContainerSelector: '#image-results',
       onLoadResults: (context) => {
@@ -62,10 +65,10 @@ window.IMAGE_CHOOSER_MODAL_ONLOAD_HANDLERS = {
     ajaxifyLinks(modal.body);
     ajaxifyImageUploadForm(modal);
 
-    $('a.suggested-tag').on('click', function () {
+    $('a.suggested-tag').on('click', (event) => {
       $('#id_q').val('');
       searchController.search({
-        tag: $(this).text(),
+        tag: $(event.currentTarget).text(),
         collection_id: $('#collection_chooser_collection_id').val(),
       });
       return false;
@@ -74,29 +77,31 @@ window.IMAGE_CHOOSER_MODAL_ONLOAD_HANDLERS = {
     // Reinitialize tabs to hook up tab event listeners in the modal
     initTabs();
   },
-  image_chosen: function (modal, jsonData) {
+  image_chosen: (modal, jsonData) => {
     modal.respond('imageChosen', jsonData.result);
     modal.close();
   },
-  duplicate_found: function (modal, jsonData) {
+  duplicate_found: (modal, jsonData) => {
     $('#tab-upload', modal.body).replaceWith(jsonData.htmlFragment);
-    $('.use-new-image', modal.body).on('click', function () {
-      modal.loadUrl(this.href);
+    $('.use-new-image', modal.body).on('click', (event) => {
+      modal.loadUrl(event.currentTarget.href);
       return false;
     });
-    $('.use-existing-image', modal.body).on('click', function () {
-      var form = $(this).closest('form');
+    $('.use-existing-image', modal.body).on('click', (event) => {
+      var form = $(event.currentTarget).closest('form');
       var CSRFToken = $('input[name="csrfmiddlewaretoken"]', form).val();
-      modal.postForm(this.href, { csrfmiddlewaretoken: CSRFToken });
+      modal.postForm(event.currentTarget.href, {
+        csrfmiddlewaretoken: CSRFToken,
+      });
       return false;
     });
   },
-  reshow_upload_form: function (modal, jsonData) {
+  reshow_upload_form: (modal, jsonData) => {
     $('#tab-upload', modal.body).replaceWith(jsonData.htmlFragment);
     initTabs();
     ajaxifyImageUploadForm(modal);
   },
-  select_format: function (modal) {
+  select_format: (modal) => {
     var decorativeImage = document.querySelector(
       '#id_image-chooser-insertion-image_is_decorative',
     );
@@ -106,20 +111,6 @@ window.IMAGE_CHOOSER_MODAL_ONLOAD_HANDLERS = {
     var altTextLabel = document.querySelector(
       '[for="id_image-chooser-insertion-alt_text"]',
     );
-
-    if (decorativeImage.checked) {
-      disableAltText();
-    } else {
-      enableAltText();
-    }
-
-    decorativeImage.addEventListener('change', function (event) {
-      if (event.target.checked) {
-        disableAltText();
-      } else {
-        enableAltText();
-      }
-    });
 
     function disableAltText() {
       altText.setAttribute('disabled', 'disabled');
@@ -131,8 +122,27 @@ window.IMAGE_CHOOSER_MODAL_ONLOAD_HANDLERS = {
       altTextLabel.classList.add('required');
     }
 
-    $('form', modal.body).on('submit', function () {
-      $.post(this.action, $(this).serialize(), modal.loadResponseText, 'text');
+    if (decorativeImage.checked) {
+      disableAltText();
+    } else {
+      enableAltText();
+    }
+
+    decorativeImage.addEventListener('change', (event) => {
+      if (event.target.checked) {
+        disableAltText();
+      } else {
+        enableAltText();
+      }
+    });
+
+    $('form', modal.body).on('submit', (event) => {
+      $.post(
+        event.currentTarget.action,
+        $(event.currentTarget).serialize(),
+        modal.loadResponseText,
+        'text',
+      );
 
       return false;
     });

--- a/client/src/entrypoints/images/image-chooser-modal.js
+++ b/client/src/entrypoints/images/image-chooser-modal.js
@@ -1,5 +1,6 @@
 import $ from 'jquery';
 import { initTabs } from '../../includes/tabs';
+import { gettext } from '../../utils/gettext';
 
 function ajaxifyImageUploadForm(modal) {
   $('form.image-upload', modal.body).on('submit', function () {
@@ -27,7 +28,9 @@ function ajaxifyImageUploadForm(modal) {
         success: modal.loadResponseText,
         error: function (response, textStatus, errorThrown) {
           var message =
-            jsonData.error_message +
+            gettext(
+              'Report this error to your website administrator with the following information:',
+            ) +
             '<br />' +
             errorThrown +
             ' - ' +
@@ -35,7 +38,7 @@ function ajaxifyImageUploadForm(modal) {
           $('#tab-upload').append(
             '<div class="help-block help-critical">' +
               '<strong>' +
-              jsonData.error_label +
+              gettext('Server Error') +
               ': </strong>' +
               message +
               '</div>',

--- a/client/src/entrypoints/snippets/snippet-chooser-modal.js
+++ b/client/src/entrypoints/snippets/snippet-chooser-modal.js
@@ -1,5 +1,7 @@
-SNIPPET_CHOOSER_MODAL_ONLOAD_HANDLERS = {
-  choose: function (modal, jsonData) {
+import $ from 'jquery';
+
+window.SNIPPET_CHOOSER_MODAL_ONLOAD_HANDLERS = {
+  choose: function (modal) {
     function ajaxifyLinks(context) {
       $('a.snippet-choice', modal.body).on('click', function () {
         modal.loadUrl(this.href);

--- a/client/src/entrypoints/snippets/snippet-chooser-modal.js
+++ b/client/src/entrypoints/snippets/snippet-chooser-modal.js
@@ -1,4 +1,5 @@
 import $ from 'jquery';
+import { SearchController } from '../../includes/chooserModal';
 
 window.SNIPPET_CHOOSER_MODAL_ONLOAD_HANDLERS = {
   choose: function (modal) {
@@ -9,49 +10,20 @@ window.SNIPPET_CHOOSER_MODAL_ONLOAD_HANDLERS = {
       });
 
       $('.pagination a', context).on('click', function () {
-        loadResults(this.href);
+        searchController.fetchResults(this.href);
         return false;
       });
     }
 
-    var searchForm$ = $('form.snippet-search', modal.body);
-    var searchUrl = searchForm$.attr('action');
-    var request;
-
-    function search() {
-      loadResults(searchUrl, searchForm$.serialize());
-      return false;
-    }
-
-    function loadResults(url, data) {
-      var opts = {
-        url: url,
-        success: function (resultsData, status) {
-          request = null;
-          $('#search-results').html(resultsData);
-          ajaxifyLinks($('#search-results'));
-        },
-        error: function () {
-          request = null;
-        },
-      };
-      if (data) {
-        opts.data = data;
-      }
-      request = $.ajax(opts);
-    }
-
-    $('form.snippet-search', modal.body).on('submit', search);
-    $('#snippet-chooser-locale', modal.body).on('change', search);
-
-    $('#id_q').on('input', function () {
-      if (request) {
-        request.abort();
-      }
-      clearTimeout($.data(this, 'timer'));
-      var wait = setTimeout(search, 200);
-      $(this).data('timer', wait);
+    const searchController = new SearchController({
+      form: $('form.snippet-search', modal.body),
+      resultsContainerSelector: '#search-results',
+      onLoadResults: (context) => {
+        ajaxifyLinks(context);
+      },
     });
+    searchController.attachSearchInput('#id_q');
+    searchController.attachSearchFilter('#snippet-chooser-locale');
 
     ajaxifyLinks(modal.body);
   },

--- a/client/src/entrypoints/snippets/snippet-chooser-modal.js
+++ b/client/src/entrypoints/snippets/snippet-chooser-modal.js
@@ -2,20 +2,22 @@ import $ from 'jquery';
 import { SearchController } from '../../includes/chooserModal';
 
 window.SNIPPET_CHOOSER_MODAL_ONLOAD_HANDLERS = {
-  choose: function (modal) {
+  choose: (modal) => {
+    let searchController;
+
     function ajaxifyLinks(context) {
-      $('a.snippet-choice', modal.body).on('click', function () {
-        modal.loadUrl(this.href);
+      $('a.snippet-choice', modal.body).on('click', (event) => {
+        modal.loadUrl(event.currentTarget.href);
         return false;
       });
 
-      $('.pagination a', context).on('click', function () {
-        searchController.fetchResults(this.href);
+      $('.pagination a', context).on('click', (event) => {
+        searchController.fetchResults(event.currentTarget.href);
         return false;
       });
     }
 
-    const searchController = new SearchController({
+    searchController = new SearchController({
       form: $('form.snippet-search', modal.body),
       resultsContainerSelector: '#search-results',
       onLoadResults: (context) => {
@@ -27,7 +29,7 @@ window.SNIPPET_CHOOSER_MODAL_ONLOAD_HANDLERS = {
 
     ajaxifyLinks(modal.body);
   },
-  chosen: function (modal, jsonData) {
+  chosen: (modal, jsonData) => {
     modal.respond('snippetChosen', jsonData.result);
     modal.close();
   },

--- a/client/src/includes/chooserModal.js
+++ b/client/src/includes/chooserModal.js
@@ -1,0 +1,141 @@
+import $ from 'jquery';
+import { gettext } from '../utils/gettext';
+
+const submitCreationForm = (modal, form, { errorContainerSelector }) => {
+  const formdata = new FormData(form);
+
+  $.ajax({
+    url: form.action,
+    data: formdata,
+    processData: false,
+    contentType: false,
+    type: 'POST',
+    dataType: 'text',
+    success: modal.loadResponseText,
+    error(response, textStatus, errorThrown) {
+      const message =
+        gettext(
+          'Report this error to your website administrator with the following information:',
+        ) +
+        '<br />' +
+        errorThrown +
+        ' - ' +
+        response.status;
+      $(errorContainerSelector, modal.body).append(
+        '<div class="help-block help-critical">' +
+          '<strong>' +
+          gettext('Server Error') +
+          ': </strong>' +
+          message +
+          '</div>',
+      );
+    },
+  });
+};
+
+const initPrefillTitleFromFilename = (
+  modal,
+  { fileFieldSelector, titleFieldSelector, eventName },
+) => {
+  const fileWidget = $(fileFieldSelector, modal.body);
+  fileWidget.on('change', () => {
+    const titleWidget = $(titleFieldSelector, modal.body);
+    const title = titleWidget.val();
+    // do not override a title that already exists (from manual editing or previous upload)
+    if (title === '') {
+      // The file widget value example: `C:\fakepath\image.jpg`
+      const parts = fileWidget.val().split('\\');
+      const filename = parts[parts.length - 1];
+
+      // allow event handler to override filename (used for title) & provide maxLength as int to event
+      const maxTitleLength =
+        parseInt(titleWidget.attr('maxLength') || '0', 10) || null;
+      const data = { title: filename.replace(/\.[^.]+$/, '') };
+
+      // allow an event handler to customise data or call event.preventDefault to stop any title pre-filling
+      const form = fileWidget.closest('form').get(0);
+      const event = form.dispatchEvent(
+        new CustomEvent(eventName, {
+          bubbles: true,
+          cancelable: true,
+          detail: {
+            data: data,
+            filename: filename,
+            maxTitleLength: maxTitleLength,
+          },
+        }),
+      );
+
+      if (!event) return; // do not set a title if event.preventDefault(); is called by handler
+
+      titleWidget.val(data.title);
+    }
+  });
+};
+
+class SearchController {
+  constructor(opts) {
+    this.form = opts.form;
+    this.onLoadResults = opts.onLoadResults;
+    this.resultsContainer = $(opts.resultsContainerSelector);
+    this.inputDelay = opts.inputDelay || 200;
+
+    this.searchUrl = this.form.attr('action');
+    this.request = null;
+
+    this.form.on('submit', () => {
+      this.searchFromForm();
+      return false;
+    });
+  }
+
+  attachSearchInput(selector) {
+    let timer;
+
+    $(selector).on('input', () => {
+      if (this.request) {
+        this.request.abort();
+      }
+      clearTimeout(timer);
+      timer = setTimeout(() => {
+        this.searchFromForm();
+      }, this.inputDelay);
+    });
+  }
+
+  attachSearchFilter(selector) {
+    $(selector).on('change', () => {
+      this.searchFromForm();
+    });
+  }
+
+  fetchResults(url, queryParams) {
+    const requestOptions = {
+      url: url,
+      success: (resultsData) => {
+        this.request = null;
+        this.resultsContainer.html(resultsData);
+        if (this.onLoadResults) {
+          this.onLoadResults(this.resultsContainer);
+        }
+      },
+      error() {
+        this.request = null;
+      },
+    };
+    if (queryParams) {
+      requestOptions.data = queryParams;
+    }
+    this.request = $.ajax(requestOptions);
+  }
+
+  search(queryParams) {
+    this.fetchResults(this.searchUrl, queryParams);
+  }
+
+  searchFromForm() {
+    this.search(this.form.serialize());
+  }
+}
+
+export { submitCreationForm, initPrefillTitleFromFilename, SearchController };

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -66,7 +66,11 @@ module.exports = function exports(env, argv) {
       'document-chooser-modal',
       'document-chooser-telepath',
     ],
-    'snippets': ['snippet-chooser', 'snippet-chooser-telepath'],
+    'snippets': [
+      'snippet-chooser',
+      'snippet-chooser-modal',
+      'snippet-chooser-telepath',
+    ],
     'contrib/table_block': ['table'],
     'contrib/typed_table_block': ['typed_table_block'],
   };

--- a/wagtail/admin/views/workflows.py
+++ b/wagtail/admin/views/workflows.py
@@ -655,12 +655,7 @@ class BaseTaskChooserView(TemplateView):
         return task_type_choices
 
     def get_form_js_context(self):
-        return {
-            "error_label": _("Server Error"),
-            "error_message": _(
-                "Report this error to your website administrator with the following information:"
-            ),
-        }
+        return {}
 
     def get_task_listing_context_data(self):
         search_form = TaskChooserSearchForm(

--- a/wagtail/documents/views/chooser.py
+++ b/wagtail/documents/views/chooser.py
@@ -145,10 +145,6 @@ class ChooseView(BaseChooseView):
             self.get_context_data(),
             json_data={
                 "step": "chooser",
-                "error_label": _("Server Error"),
-                "error_message": _(
-                    "Report this error to your website administrator with the following information:"
-                ),
                 "tag_autocomplete_url": reverse("wagtailadmin_tag_autocomplete"),
             },
         )

--- a/wagtail/images/views/chooser.py
+++ b/wagtail/images/views/chooser.py
@@ -5,7 +5,6 @@ from django.template.loader import render_to_string
 from django.template.response import TemplateResponse
 from django.urls import reverse
 from django.utils.http import urlencode
-from django.utils.translation import gettext as _
 from django.views.generic.base import View
 
 from wagtail import hooks
@@ -130,10 +129,6 @@ class ChooseView(BaseChooseView):
             self.get_context_data(),
             json_data={
                 "step": "chooser",
-                "error_label": _("Server Error"),
-                "error_message": _(
-                    "Report this error to your website administrator with the following information:"
-                ),
                 "tag_autocomplete_url": reverse("wagtailadmin_tag_autocomplete"),
             },
         )


### PR DESCRIPTION
Moves a bunch of common functionality from chooser modal JS into a utility module, including a SearchController class which encapsulates the standard pattern of re-rendering the results panel in response to search queries and pagination. Also uses the JS catalog feature from #7953 for translations of the "server error" message, to avoid the need to pass these as part of the initial ModalWorkflow dance, and makes these modules no longer an exception to eslint rules.