### PR TITLE
Exclude tests from makemessages

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -46,6 +46,7 @@ Changelog
  * Fix: Add an accessible label to the image focal point input when editing images (Lucie Le Frapper)
  * Fix: Remove unused header search JavaScript on the redirects import page (LB (Ben) Johnston)
  * FIx: Ensure non-square avatar images will correctly show throughout the admin (LB (Ben) Johnston)
+ * Fix: Ignore translations in test files and re-include some translations that were accidentally ignored (Stefan Hammer)
 
 
 3.0 (16.05.2022)

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -45,7 +45,7 @@ Changelog
  * Fix: Specific snippets list language picker was not properly styled (Sage Abdullah)
  * Fix: Add an accessible label to the image focal point input when editing images (Lucie Le Frapper)
  * Fix: Remove unused header search JavaScript on the redirects import page (LB (Ben) Johnston)
- * FIx: Ensure non-square avatar images will correctly show throughout the admin (LB (Ben) Johnston)
+ * Fix: Ensure non-square avatar images will correctly show throughout the admin (LB (Ben) Johnston)
  * Fix: Ignore translations in test files and re-include some translations that were accidentally ignored (Stefan Hammer)
 
 

--- a/docs/releases/4.0.md
+++ b/docs/releases/4.0.md
@@ -60,6 +60,7 @@ When using a queryset to render a list of images, you can now use the ``prefetch
  * Add an accessible label to the image focal point input when editing images (Lucie Le Frapper)
  * Remove unused header search JavaScript on the redirects import page (LB (Ben) Johnston)
  * Ensure non-square avatar images will correctly show throughout the admin (LB (Ben) Johnston)
+ * Ignore translations in test files and re-include some translations that were accidentally ignored (Stefan Hammer)
 
 
 ## Upgrade considerations

--- a/scripts/rebuild-translation-sources.sh
+++ b/scripts/rebuild-translation-sources.sh
@@ -5,7 +5,7 @@ find ../wagtail -iname *.po -iwholename */en/* -delete
 for d in $(find ../wagtail -iwholename */locale/* | sed 's|\(.*\)/locale.*|\1|' | sort -u);
 do
     pushd $d
-    django-admin makemessages --locale=en
+    django-admin makemessages --locale=en --ignore=test/* --ignore=tests/* --ignore=tests.py
     popd
 done
 

--- a/wagtail/admin/forms/workflows.py
+++ b/wagtail/admin/forms/workflows.py
@@ -2,7 +2,7 @@ from django import forms
 from django.core.exceptions import ImproperlyConfigured, ValidationError
 from django.utils.functional import cached_property
 from django.utils.translation import gettext as _
-from django.utils.translation import gettext_lazy as __
+from django.utils.translation import gettext_lazy
 
 from wagtail.admin import widgets
 from wagtail.admin.forms import WagtailAdminModelForm
@@ -14,7 +14,7 @@ from wagtail.models import Page, Task, Workflow, WorkflowPage
 
 class TaskChooserSearchForm(forms.Form):
     q = forms.CharField(
-        label=__("Search term"), widget=forms.TextInput(), required=False
+        label=gettext_lazy("Search term"), widget=forms.TextInput(), required=False
     )
 
     def __init__(self, *args, task_type_choices=None, **kwargs):

--- a/wagtail/test/testapp/models.py
+++ b/wagtail/test/testapp/models.py
@@ -11,7 +11,7 @@ from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 from django.db import models
 from django.shortcuts import redirect
 from django.template.response import TemplateResponse
-from django.utils.functional import lazystr
+from django.utils.translation import gettext_lazy as _
 from modelcluster.contrib.taggit import ClusterTaggableManager
 from modelcluster.fields import ParentalKey, ParentalManyToManyField
 from modelcluster.models import ClusterableModel
@@ -998,7 +998,7 @@ class BusinessChild(Page):
 
     subpage_types = []
     parent_page_types = ["tests.BusinessIndex", BusinessSubIndex]
-    page_description = lazystr("A lazy business child page description")
+    page_description = _("A lazy business child page description")
 
 
 class BusinessNowherePage(Page):

--- a/wagtail/tests/test_blocks.py
+++ b/wagtail/tests/test_blocks.py
@@ -12,7 +12,7 @@ from django.forms.utils import ErrorList
 from django.template.loader import render_to_string
 from django.test import SimpleTestCase, TestCase
 from django.utils.safestring import SafeData, mark_safe
-from django.utils.translation import gettext_lazy as __
+from django.utils.translation import gettext_lazy as _
 
 from wagtail import blocks
 from wagtail.blocks.field_block import FieldBlockAdapter
@@ -926,8 +926,8 @@ class TestChoiceBlock(WagtailTestUtils, SimpleTestCase):
     def test_searchable_content_with_lazy_translation(self):
         block = blocks.ChoiceBlock(
             choices=[
-                ("choice-1", __("Choice 1")),
-                ("choice-2", __("Choice 2")),
+                ("choice-1", _("Choice 1")),
+                ("choice-2", _("Choice 2")),
             ]
         )
         result = block.get_searchable_content("choice-1")
@@ -940,17 +940,17 @@ class TestChoiceBlock(WagtailTestUtils, SimpleTestCase):
         block = blocks.ChoiceBlock(
             choices=[
                 (
-                    __("Section 1"),
+                    _("Section 1"),
                     [
-                        ("1-1", __("Block 1")),
-                        ("1-2", __("Block 2")),
+                        ("1-1", _("Block 1")),
+                        ("1-2", _("Block 2")),
                     ],
                 ),
                 (
-                    __("Section 2"),
+                    _("Section 2"),
                     [
-                        ("2-1", __("Block 1")),
-                        ("2-2", __("Block 2")),
+                        ("2-1", _("Block 1")),
+                        ("2-2", _("Block 2")),
                     ],
                 ),
             ]
@@ -1303,8 +1303,8 @@ class TestMultipleChoiceBlock(WagtailTestUtils, SimpleTestCase):
     def test_searchable_content_with_lazy_translation(self):
         block = blocks.MultipleChoiceBlock(
             choices=[
-                ("choice-1", __("Choice 1")),
-                ("choice-2", __("Choice 2")),
+                ("choice-1", _("Choice 1")),
+                ("choice-2", _("Choice 2")),
             ]
         )
         result = block.get_searchable_content("choice-1")
@@ -1317,17 +1317,17 @@ class TestMultipleChoiceBlock(WagtailTestUtils, SimpleTestCase):
         block = blocks.MultipleChoiceBlock(
             choices=[
                 (
-                    __("Section 1"),
+                    _("Section 1"),
                     [
-                        ("1-1", __("Block 1")),
-                        ("1-2", __("Block 2")),
+                        ("1-1", _("Block 1")),
+                        ("1-2", _("Block 2")),
                     ],
                 ),
                 (
-                    __("Section 2"),
+                    _("Section 2"),
                     [
-                        ("2-1", __("Block 1")),
-                        ("2-2", __("Block 2")),
+                        ("2-1", _("Block 1")),
+                        ("2-2", _("Block 2")),
                     ],
                 ),
             ]


### PR DESCRIPTION
During translation I've found multiple strings, which are only used by the tests and therefore don't make sense to be translated (this has been confirmed [here](https://github.com/wagtail/wagtail/pull/8527#issuecomment-1124797853)). Here are some examples:
https://github.com/wagtail/wagtail/blob/1f3605b98aaa2e236b13d3b48528001597dc064a/wagtail/admin/locale/en/LC_MESSAGES/django.po#L2716-L2720
https://github.com/wagtail/wagtail/blob/1f3605b98aaa2e236b13d3b48528001597dc064a/wagtail/locale/en/LC_MESSAGES/django.po#L751-L753

**Current solutions to avoid that:**

1) I've found tests that avoid the language files by using `__()` instead of `_()`, see https://github.com/wagtail/wagtail/blob/1f3605b98aaa2e236b13d3b48528001597dc064a/wagtail/tests/test_blocks.py#L15

    I've also found the same technique in regular code at one place, which I've fixed now. The translation for this string ("Search term") worked, because it has been used correctly somewhere else.
    https://github.com/wagtail/wagtail/blob/1f3605b98aaa2e236b13d3b48528001597dc064a/wagtail/admin/forms/workflows.py#L17

2) In my last PR I've used lazystr() instead of gettext_lazy(): https://github.com/wagtail/wagtail/pull/8527#issue-1233696888

At the end that's not very clean and new developers will probably use simple gettext methods to translate strings and so those dummy strings will unintentionally land in the language files.

**Changes in this PR:**

1) I've found the following places for tests during a quick search:
    ```
    wagtail/test/*
    wagtail/**/tests/*
    wagtail/**/tests.py
    ```

    Since the `rebuild-translation-sources.sh` walks through all apps with "locale" directories, I've added `--ignore=test/* --ignore=tests/* --ignore=tests.py` to the `makemessages` call.

2) I've replaced the tweaks to avoid `makemessages` with regular usages of gettext.

3) I've fixed one irregular usage of such a bypass-tweak.

**Testing the PR:**
To test the result and to avoid any line-number-noise, checkout the main branch, run `rebuild-translation-sources.sh`, so all the line numbers get refreshed, then checkout my PR and run it again. You will see, that the test strings get removed, and the fixed "Search term" gets its additional occurrence in `workflows.py`. No further strings get added/removed, so it looks good to me.

Currently I cannot see any issue with excluding the tests from makemessages, what do you think?

_Please check the following:_

- [x] Do the tests still pass?[^1]
- [x] Does the code comply with the style guide? 
    - [x] Run `make lint` from the Wagtail root. 
- [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
- [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**. 

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets) 
