### PR TITLE
Added functionality in bulk actions: ability to use shift+click to select multiple items at once

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -18,6 +18,7 @@ Changelog
  * Add better handling and informative developer errors for cross linking URLS (e.g. success after add) in generic views `wagtail.admin.views.generic` (Matt Westcott)
  * Introduce `wagtail.admin.widgets.chooser.BaseChooser` to make it easier to build custom chooser inputs (Matt Westcott)
  * Introduce JavaScript chooser module, including a SearchController class which encapsulates the standard pattern of re-rendering the results panel in response to search queries and pagination (Matt Westcott)
+ * Add ability to select multiple items at once within bulk actions selections when holding shift on subsequent clicks (Hitansh Shah)
  * Fix: Typo in `ResumeWorkflowActionFormatter` message (Stefan Hammer)
  * Fix: Throw a meaningful error when saving an image to an unrecognised image format (Christian Franke)
  * Fix: Remove extra padding for headers with breadcrumbs on mobile viewport (Steven Steinwand)

--- a/client/src/entrypoints/admin/bulk-actions.js
+++ b/client/src/entrypoints/admin/bulk-actions.js
@@ -15,6 +15,7 @@ const checkedState = {
   numObjects: 0,
   selectAllInListing: false,
   shouldShowAllInListingText: true,
+  prevCheckedObject: null,
 };
 
 /**
@@ -72,6 +73,42 @@ function onSelectAllChange(e) {
     document.querySelector(BULK_ACTION_FOOTER).classList.add('hidden');
   } else {
     toggleMoreActionsDropdownBtn(false);
+  }
+}
+
+/**
+ * Event listener for clicking individual checkbox and checking if shift key is pressed
+ *
+ * @param {Event} event
+ */
+function onClickIndividualCheckbox(event) {
+  if (event.shiftKey && checkedState.prevCheckedObject) {
+    const individualCheckboxList = [
+      ...document.querySelectorAll(BULK_ACTION_PAGE_CHECKBOX_INPUT),
+    ];
+    const prevCheckedObjectIndex = individualCheckboxList.findIndex(
+      (el) => el.dataset.objectId === checkedState.prevCheckedObject,
+    );
+    const shiftClickedObjectIndex = individualCheckboxList.findIndex(
+      (el) => el.dataset.objectId === event.target.dataset.objectId,
+    );
+
+    const startingIndex =
+      (prevCheckedObjectIndex > shiftClickedObjectIndex
+        ? shiftClickedObjectIndex
+        : prevCheckedObjectIndex) + 1;
+    const endingIndex =
+      (prevCheckedObjectIndex <= shiftClickedObjectIndex
+        ? shiftClickedObjectIndex
+        : prevCheckedObjectIndex) - 1;
+
+    for (let i = startingIndex; i <= endingIndex; i++) {
+      const changeEvent = new Event('change');
+      individualCheckboxList[i].checked =
+        individualCheckboxList[prevCheckedObjectIndex].checked;
+      individualCheckboxList[i].dispatchEvent(changeEvent);
+    }
+    checkedState.prevCheckedObject = event.target.dataset.objectId;
   }
 }
 
@@ -146,6 +183,9 @@ function onSelectIndividualCheckbox(e) {
     document.querySelector(BULK_ACTION_NUM_OBJECTS).textContent =
       numObjectsSelected;
   }
+
+  // Updating previously checked object
+  checkedState.prevCheckedObject = e.target.dataset.objectId;
 }
 
 /**
@@ -192,6 +232,7 @@ function addBulkActionListeners() {
   document.querySelectorAll(BULK_ACTION_PAGE_CHECKBOX_INPUT).forEach((el) => {
     checkedState.numObjects++;
     el.addEventListener('change', onSelectIndividualCheckbox);
+    el.addEventListener('click', onClickIndividualCheckbox);
   });
   document.querySelectorAll(BULK_ACTION_SELECT_ALL_CHECKBOX).forEach((el) => {
     el.addEventListener('change', onSelectAllChange);

--- a/docs/releases/4.0.md
+++ b/docs/releases/4.0.md
@@ -23,6 +23,7 @@ depth: 1
  * Add better handling and informative developer errors for cross linking URLS (e.g. success after add) in generic views `wagtail.admin.views.generic` (Matt Westcott)
  * Introduce `wagtail.admin.widgets.chooser.BaseChooser` to make it easier to build custom chooser inputs (Matt Westcott)
  * Introduce JavaScript chooser module, including a SearchController class which encapsulates the standard pattern of re-rendering the results panel in response to search queries and pagination (Matt Westcott)
+ * Add ability to select multiple items at once within bulk actions selections when holding shift on subsequent clicks (Hitansh Shah)
 
 ### Bug fixes
 


### PR DESCRIPTION
#8490 

Signed-off-by: Hitansh Shah <shah.hitanshsanjay.mat20@itbhu.ac.in>

<!--
Thanks for contributing to Wagtail! 🎉

Before submitting, please review the [contributor guidelines](https://docs.wagtail.org/en/latest/contributing/index.html).
-->

_Please check the following:_

- [x] Do the tests still pass?[^1]
- [x] Does the code comply with the style guide? 
    - [x] Run `make lint` from the Wagtail root. 
- [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
- [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    - [ ] **Please list the exact browser and operating system versions you tested**:
    - [ ] **Please list which assistive technologies [^3] you tested**: 
- [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**. 

I added `prevCheckedObject` to `checkedState` in [`client/src/entrypoints/admin/bulk-actions.js`](https://github.com/wagtail/wagtail/blob/main/client/src/entrypoints/admin/bulk-actions.js) which is initially set to `null` and when a checkbox is selected or deselected it updates itself to `dataset.objectId` of that checkbox. I have also added `click` event to every checkbox. The event-handler for this event checks if `shift` key was pressed and if yes then it selects/deselects all the checkbox in between the currently clicked and previously clicked checkboxes. 
The reason to add separate event for this is that `click` event comes with an inbuilt method called `shiftKey` which returns `true` if shift-key is pressed. The "change" event lacks this functionality.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets) 
