### PR TITLE
Add bulk delete action to form submissions in Wagtail contrib form builder app

### DIFF
--- a/wagtail/contrib/forms/bulk_actions/delete.py
+++ b/wagtail/contrib/forms/bulk_actions/delete.py
@@ -2,7 +2,6 @@ from wagtail.contrib.forms.bulk_actions.form_bulk_action import FormBulkAction
 from django.utils.translation import gettext_lazy as _
 
 
-
 class DeleteBulkAction(FormBulkAction):
     display_name = _("Delete")
     aria_label = _("Delete selected objects")
@@ -11,13 +10,8 @@ class DeleteBulkAction(FormBulkAction):
 
     @classmethod
     def execute_action(cls, objects, **kwargs):
-        user = kwargs.get('user', None)
         num_forms = 0
         for obj in objects:
             num_forms = num_forms + 1
-            obj.delete() 
+            obj.delete()
         return num_forms, cls.action_type
-        
-    
-    
-  

--- a/wagtail/contrib/forms/bulk_actions/delete.py
+++ b/wagtail/contrib/forms/bulk_actions/delete.py
@@ -1,6 +1,5 @@
 from wagtail.contrib.forms.bulk_actions.form_bulk_action import FormBulkAction
 from django.utils.translation import gettext_lazy as _
-import json 
 
 
 
@@ -12,11 +11,8 @@ class DeleteBulkAction(FormBulkAction):
 
     @classmethod
     def execute_action(cls, objects, **kwargs):
-        # the kwargs here is the output of the get_execution_context method
         user = kwargs.get('user', None)
         num_forms = 0
-        # you could run the action per object or run them in bulk using django's bulk update and delete methods
-        cls.form_objects = objects
         for obj in objects:
             num_forms = num_forms + 1
             obj.delete() 

--- a/wagtail/contrib/forms/bulk_actions/delete.py
+++ b/wagtail/contrib/forms/bulk_actions/delete.py
@@ -1,0 +1,27 @@
+from wagtail.contrib.forms.bulk_actions.form_bulk_action import FormBulkAction
+from django.utils.translation import gettext_lazy as _
+import json 
+
+
+
+class DeleteBulkAction(FormBulkAction):
+    display_name = _("Delete")
+    aria_label = _("Delete selected objects")
+    action_type = "delete"
+    template_name = "wagtailforms/bulk_actions/confirm_bulk_delete.html"
+
+    @classmethod
+    def execute_action(cls, objects, **kwargs):
+        # the kwargs here is the output of the get_execution_context method
+        user = kwargs.get('user', None)
+        num_forms = 0
+        # you could run the action per object or run them in bulk using django's bulk update and delete methods
+        cls.form_objects = objects
+        for obj in objects:
+            num_forms = num_forms + 1
+            obj.delete() 
+        return num_forms, cls.action_type
+        
+    
+    
+  

--- a/wagtail/contrib/forms/bulk_actions/delete.py
+++ b/wagtail/contrib/forms/bulk_actions/delete.py
@@ -1,8 +1,8 @@
-from wagtail.contrib.forms.bulk_actions.form_bulk_action import FormBulkAction
+from wagtail.contrib.forms.bulk_actions.form_bulk_action import FormSubmissionBulkAction
 from django.utils.translation import gettext_lazy as _
 
 
-class DeleteBulkAction(FormBulkAction):
+class DeleteBulkAction(FormSubmissionBulkAction):
     display_name = _("Delete")
     aria_label = _("Delete selected objects")
     action_type = "delete"

--- a/wagtail/contrib/forms/bulk_actions/form_bulk_action.py
+++ b/wagtail/contrib/forms/bulk_actions/form_bulk_action.py
@@ -3,20 +3,15 @@ from django.utils.translation import gettext_lazy as _
 from wagtail.contrib.forms.models import FormSubmission
 
 
-
 class FormBulkAction(BulkAction):
     models = [FormSubmission]
 
-    def get_success_message(self, num_forms,action_done):
-        return _("{} form submissions have been {}d".format(num_forms,action_done))
+    def get_success_message(self, num_forms, action_done):
+        return _("{} form submissions have been {}d".format(num_forms, action_done))
 
     def get_execution_context(self):
-        return {
-            'user': self.request.user
-        }
-        
+        return {"user": self.request.user}
+
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         return context
-
-

--- a/wagtail/contrib/forms/bulk_actions/form_bulk_action.py
+++ b/wagtail/contrib/forms/bulk_actions/form_bulk_action.py
@@ -1,0 +1,24 @@
+from wagtail.admin.views.bulk_action import BulkAction
+from django.utils.translation import gettext_lazy as _
+from wagtail.contrib.forms.models import FormSubmission
+
+
+
+class FormBulkAction(BulkAction):
+    models = [FormSubmission]
+
+
+
+    def get_success_message(self, num_forms,action_done):
+        return _("{} forms have been {}d".format(num_forms,action_done))
+
+    def get_execution_context(self):
+        return {
+            'user': self.request.user
+        }
+        
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        return context
+
+

--- a/wagtail/contrib/forms/bulk_actions/form_bulk_action.py
+++ b/wagtail/contrib/forms/bulk_actions/form_bulk_action.py
@@ -7,10 +7,8 @@ from wagtail.contrib.forms.models import FormSubmission
 class FormBulkAction(BulkAction):
     models = [FormSubmission]
 
-
-
     def get_success_message(self, num_forms,action_done):
-        return _("{} forms have been {}d".format(num_forms,action_done))
+        return _("{} form submissions have been {}d".format(num_forms,action_done))
 
     def get_execution_context(self):
         return {

--- a/wagtail/contrib/forms/bulk_actions/form_bulk_action.py
+++ b/wagtail/contrib/forms/bulk_actions/form_bulk_action.py
@@ -3,7 +3,7 @@ from django.utils.translation import gettext_lazy as _
 from wagtail.contrib.forms.models import FormSubmission
 
 
-class FormBulkAction(BulkAction):
+class FormSubmissionBulkAction(BulkAction):
     models = [FormSubmission]
 
     def get_success_message(self, num_forms, action_done):

--- a/wagtail/contrib/forms/bulk_actions/form_bulk_action.py
+++ b/wagtail/contrib/forms/bulk_actions/form_bulk_action.py
@@ -1,10 +1,13 @@
+from pydoc import doc
 from wagtail.admin.views.bulk_action import BulkAction
 from django.utils.translation import gettext_lazy as _
 from wagtail.contrib.forms.models import FormSubmission
+from wagtail.models import Page
 
 
 class FormSubmissionBulkAction(BulkAction):
     models = [FormSubmission]
+    form_page = None
 
     def get_success_message(self, num_forms, action_done):
         return _("{} form submissions have been {}d".format(num_forms, action_done))
@@ -14,4 +17,19 @@ class FormSubmissionBulkAction(BulkAction):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
+        self.form_page = kwargs.get("form_page")
+        data_headings = []
+        for name in context["items"][0]["item"].form_data:
+            data_headings.append(
+                {
+                    "name": name.replace("_", " ").title(),
+                }
+            )
+        context.update(
+            {
+                "data_headings": data_headings,
+                "app_label": "wagtailforms",
+                "model_name": "formsubmission",
+            }
+        )
         return context

--- a/wagtail/contrib/forms/templates/wagtailforms/bulk_actions/confirm_bulk_delete.html
+++ b/wagtail/contrib/forms/templates/wagtailforms/bulk_actions/confirm_bulk_delete.html
@@ -17,62 +17,8 @@
         Are you sure you want to delete these form submissions?
     {% endblocktrans %}
 </p>
-<table class="listing">
-    <thead>     
-        <tr>
-            <th id="submit_time" class="">
-                Submission date
-            </th>
-            <th id="subject" class="">
-                Subject
-            </th>
 
-            <th id="your_name" class="">
-                Your Name
-            </th>
-
-            <th id="your_email" class="">
-                Your Email
-            </th>
-
-            <th id="purpose" class="">
-                Purpose
-            </th>
-
-            <th id="body" class="">
-                Body
-            </th>
-        </tr>
-    </thead>
-{% for item in items %}
-    <tbody>
-        <tr>
-            <td>
-                {{item.item.submit_time}}
-            </td>
-            <td>
-                {{item.item.form_data.subject}}
-            </td>
-        
-            <td>
-                {{item.item.form_data.your_name}}
-            </td>
-        
-            <td>
-                {{item.item.form_data.your_email}}
-            </td>
-        
-            <td>
-                {{item.item.form_data.purpose}}
-            </td>
-        
-            <td>
-                {{item.item.form_data.body}}
-            </td>
-        </tr>
-    </tbody>
-{% endfor %}
-</table>
+{% include 'wagtailforms/bulk_actions/list_form_submissions.html' %}
 
 {% if items %}
     {% trans 'Yes, delete' as action_button_text %}

--- a/wagtail/contrib/forms/templates/wagtailforms/bulk_actions/confirm_bulk_delete.html
+++ b/wagtail/contrib/forms/templates/wagtailforms/bulk_actions/confirm_bulk_delete.html
@@ -1,0 +1,84 @@
+{% extends 'wagtailadmin/bulk_actions/confirmation/base.html' %}
+{% load i18n wagtailadmin_tags %}
+
+{% block titletag %}{% blocktrans count counter=items|length %}Delete 1 item{% plural %}Delete {{ counter }} items{% endblocktrans %}{% endblock %}
+
+{% block header %}
+    {% trans "Delete" as del_str %}
+    {% include "wagtailadmin/shared/header.html" with title=del_str icon="doc-empty-inverse" %}
+{% endblock header %}
+
+
+{% block form_section %}
+<p>
+    {% blocktrans trimmed count counter=items|length %}
+        Are you sure you want to delete this form submission?
+    {% plural %}
+        Are you sure you want to delete these form submissions?
+    {% endblocktrans %}
+</p>
+<table class="listing">
+    <thead>     
+        <tr>
+            <th id="submit_time" class="">
+                Submission date
+            </th>
+            <th id="subject" class="">
+                Subject
+            </th>
+
+            <th id="your_name" class="">
+                Your Name
+            </th>
+
+            <th id="your_email" class="">
+                Your Email
+            </th>
+
+            <th id="purpose" class="">
+                Purpose
+            </th>
+
+            <th id="body" class="">
+                Body
+            </th>
+        </tr>
+    </thead>
+{% for item in items %}
+    <tbody>
+        <tr>
+            <td>
+                {{item.item.submit_time}}
+            </td>
+            <td>
+                {{item.item.form_data.subject}}
+            </td>
+        
+            <td>
+                {{item.item.form_data.your_name}}
+            </td>
+        
+            <td>
+                {{item.item.form_data.your_email}}
+            </td>
+        
+            <td>
+                {{item.item.form_data.purpose}}
+            </td>
+        
+            <td>
+                {{item.item.form_data.body}}
+            </td>
+        </tr>
+    </tbody>
+{% endfor %}
+</table>
+
+{% if items %}
+    {% trans 'Yes, delete' as action_button_text %}
+    {% trans "No, don't delete" as no_action_button_text %}
+    {% include 'wagtailadmin/bulk_actions/confirmation/form.html' with action_button_class="serious" %}
+{% else %}
+    {% include 'wagtailadmin/bulk_actions/confirmation/go_back.html' %}
+{% endif %}
+{% endblock form_section %}

--- a/wagtail/contrib/forms/templates/wagtailforms/bulk_actions/list_form_submissions.html
+++ b/wagtail/contrib/forms/templates/wagtailforms/bulk_actions/list_form_submissions.html
@@ -5,25 +5,11 @@
             <th id="submit_time" class="">
                 Submission date
             </th>
-            <th id="subject" class="">
-                Subject
+            {% for heading in data_headings %}
+            <th>
+                {{ heading.name }}
             </th>
-
-            <th id="your_name" class="">
-                Your Name
-            </th>
-
-            <th id="your_email" class="">
-                Your Email
-            </th>
-
-            <th id="purpose" class="">
-                Purpose
-            </th>
-
-            <th id="body" class="">
-                Body
-            </th>
+            {% endfor %}
         </tr>
     </thead>
 {% for item in items %}
@@ -32,25 +18,11 @@
             <td>
                 {{item.item.submit_time}}
             </td>
+            {% for label,data in item.item.form_data.items %}
             <td>
-                {{item.item.form_data.subject}}
+                {{ data }}
             </td>
-        
-            <td>
-                {{item.item.form_data.your_name}}
-            </td>
-        
-            <td>
-                {{item.item.form_data.your_email}}
-            </td>
-        
-            <td>
-                {{item.item.form_data.purpose}}
-            </td>
-        
-            <td>
-                {{item.item.form_data.body}}
-            </td>
+            {% endfor %}
         </tr>
     </tbody>
 {% endfor %}

--- a/wagtail/contrib/forms/templates/wagtailforms/bulk_actions/list_form_submissions.html
+++ b/wagtail/contrib/forms/templates/wagtailforms/bulk_actions/list_form_submissions.html
@@ -1,0 +1,57 @@
+{% load i18n %}
+<table class="listing">
+    <thead>     
+        <tr>
+            <th id="submit_time" class="">
+                Submission date
+            </th>
+            <th id="subject" class="">
+                Subject
+            </th>
+
+            <th id="your_name" class="">
+                Your Name
+            </th>
+
+            <th id="your_email" class="">
+                Your Email
+            </th>
+
+            <th id="purpose" class="">
+                Purpose
+            </th>
+
+            <th id="body" class="">
+                Body
+            </th>
+        </tr>
+    </thead>
+{% for item in items %}
+    <tbody>
+        <tr>
+            <td>
+                {{item.item.submit_time}}
+            </td>
+            <td>
+                {{item.item.form_data.subject}}
+            </td>
+        
+            <td>
+                {{item.item.form_data.your_name}}
+            </td>
+        
+            <td>
+                {{item.item.form_data.your_email}}
+            </td>
+        
+            <td>
+                {{item.item.form_data.purpose}}
+            </td>
+        
+            <td>
+                {{item.item.form_data.body}}
+            </td>
+        </tr>
+    </tbody>
+{% endfor %}
+</table>

--- a/wagtail/contrib/forms/templates/wagtailforms/index_submissions.html
+++ b/wagtail/contrib/forms/templates/wagtailforms/index_submissions.html
@@ -120,10 +120,8 @@
     </header>
     <div class="nice-padding">
         {% if submissions %}
-            {% comment %} <form action="{% url 'wagtailforms:delete_submissions' form_page.id %}" method="get"> {% endcomment %}
-                {% include "wagtailforms/list_submissions.html" %}
-                {% include "wagtailadmin/shared/pagination_nav.html" with items=page_obj %}
-            {% comment %} </form> {% endcomment %}
+            {% include "wagtailforms/list_submissions.html" %}
+            {% include "wagtailadmin/shared/pagination_nav.html" with items=page_obj %}
         {% else %}
             <p class="no-results-message">{% blocktrans trimmed with title=form_page.title %}There have been no submissions of the '{{ title }}' form.{% endblocktrans %}</p>
         {% endif %}

--- a/wagtail/contrib/forms/templates/wagtailforms/index_submissions.html
+++ b/wagtail/contrib/forms/templates/wagtailforms/index_submissions.html
@@ -79,6 +79,10 @@
             updateActions();
         });
     </script>
+    <script>
+        window.wagtailConfig.BULK_ACTION_ITEM_TYPE = 'FORMSUBMISSION';
+    </script>
+    <script defer src="{% versioned_static 'wagtailadmin/js/bulk-actions.js' %}"></script>
 {% endblock %}
 {% block content %}
     <header>
@@ -116,12 +120,14 @@
     </header>
     <div class="nice-padding">
         {% if submissions %}
-            <form action="{% url 'wagtailforms:delete_submissions' form_page.id %}" method="get">
+            {% comment %} <form action="{% url 'wagtailforms:delete_submissions' form_page.id %}" method="get"> {% endcomment %}
                 {% include "wagtailforms/list_submissions.html" %}
                 {% include "wagtailadmin/shared/pagination_nav.html" with items=page_obj %}
-            </form>
+            {% comment %} </form> {% endcomment %}
         {% else %}
             <p class="no-results-message">{% blocktrans trimmed with title=form_page.title %}There have been no submissions of the '{{ title }}' form.{% endblocktrans %}</p>
         {% endif %}
     </div>
+    {% trans "Select all documents in listing" as select_all_text %}
+    {% include 'wagtailadmin/bulk_actions/footer.html' with select_all_obj_text=select_all_text app_label=app_label model_name=model_name objects=data_rows %}
 {% endblock %}

--- a/wagtail/contrib/forms/templates/wagtailforms/list_submissions.html
+++ b/wagtail/contrib/forms/templates/wagtailforms/list_submissions.html
@@ -15,9 +15,10 @@
             </tr>
         </thead>
         <tbody>
+            {% trans "Select document" as checkbox_aria_label %}
             {% for row in data_rows %}
                 <tr>
-                    {% include "wagtailadmin/bulk_actions/listing_checkbox_cell.html" with obj_type="formsubmission" obj=row aria_labelledby_prefix="formsubmission_" aria_labelledby=row.model_id aria_labelledby_suffix="_title" %}
+                    {% include "wagtailadmin/bulk_actions/listing_checkbox_cell.html" with obj_type="data_rows" obj=row aria_labelledby_prefix="form_" aria_labelledby=row.model_id aria_labelledby_suffix="_title" %}
                     {% for cell in row.fields %}
                         <td>
                             {{ cell }}

--- a/wagtail/contrib/forms/templates/wagtailforms/list_submissions.html
+++ b/wagtail/contrib/forms/templates/wagtailforms/list_submissions.html
@@ -6,12 +6,7 @@
         <col />
         <thead>
             <tr>
-                <th colspan="{{ data_headings|length|add:1 }}">
-                    <button class="button no" id="delete-submissions" style="visibility: hidden">{% trans "Delete selected submissions" %}</button>
-                </th>
-            </tr>
-            <tr>
-                <th><input type="checkbox" id="select-all" /></th>
+                {% include 'wagtailadmin/bulk_actions/select_all_checkbox_cell.html' %}
                 {% for heading in data_headings %}
                     <th id="{{ heading.name }}" class="{% if heading.order %}ordered {{ heading.order }}{% endif %}">
                         {% if heading.order %}<a href="?order_by={% if heading.order == 'ascending' %}-{% endif %}{{ heading.name }}">{{ heading.label }}</a>{% else %}{{ heading.label }}{% endif %}
@@ -22,9 +17,7 @@
         <tbody>
             {% for row in data_rows %}
                 <tr>
-                    <td>
-                        <input type="checkbox" name="selected-submissions" class="select-submission" value="{{ row.model_id }}" />
-                    </td>
+                    {% include "wagtailadmin/bulk_actions/listing_checkbox_cell.html" with obj_type="formsubmission" obj=row aria_labelledby_prefix="formsubmission_" aria_labelledby=row.model_id aria_labelledby_suffix="_title" %}
                     {% for cell in row.fields %}
                         <td>
                             {{ cell }}

--- a/wagtail/contrib/forms/templates/wagtailforms/list_submissions.html
+++ b/wagtail/contrib/forms/templates/wagtailforms/list_submissions.html
@@ -15,7 +15,7 @@
             </tr>
         </thead>
         <tbody>
-            {% trans "Select document" as checkbox_aria_label %}
+            {% trans "Select response" as checkbox_aria_label %}
             {% for row in data_rows %}
                 <tr>
                     {% include "wagtailadmin/bulk_actions/listing_checkbox_cell.html" with obj_type="data_rows" obj=row aria_labelledby_prefix="form_" aria_labelledby=row.model_id aria_labelledby_suffix="_title" %}

--- a/wagtail/contrib/forms/urls.py
+++ b/wagtail/contrib/forms/urls.py
@@ -10,5 +10,5 @@ urlpatterns = [
     path("", FormPagesListView.as_view(), name="index"),
     path(
         "submissions/<int:page_id>/", get_submissions_list_view, name="list_submissions"
-    )
+    ),
 ]

--- a/wagtail/contrib/forms/urls.py
+++ b/wagtail/contrib/forms/urls.py
@@ -1,7 +1,6 @@
 from django.urls import path
 
 from wagtail.contrib.forms.views import (
-    DeleteSubmissionsView,
     FormPagesListView,
     get_submissions_list_view,
 )
@@ -11,10 +10,5 @@ urlpatterns = [
     path("", FormPagesListView.as_view(), name="index"),
     path(
         "submissions/<int:page_id>/", get_submissions_list_view, name="list_submissions"
-    ),
-    path(
-        "submissions/<int:page_id>/delete/",
-        DeleteSubmissionsView.as_view(),
-        name="delete_submissions",
-    ),
+    )
 ]

--- a/wagtail/contrib/forms/urls.py
+++ b/wagtail/contrib/forms/urls.py
@@ -1,6 +1,7 @@
 from django.urls import path
 
 from wagtail.contrib.forms.views import (
+    DeleteSubmissionsView,
     FormPagesListView,
     get_submissions_list_view,
 )
@@ -10,5 +11,10 @@ urlpatterns = [
     path("", FormPagesListView.as_view(), name="index"),
     path(
         "submissions/<int:page_id>/", get_submissions_list_view, name="list_submissions"
+    ),
+    path(
+        "submissions/<int:page_id>/delete/",
+        DeleteSubmissionsView.as_view(),
+        name="delete_submissions",
     ),
 ]

--- a/wagtail/contrib/forms/views.py
+++ b/wagtail/contrib/forms/views.py
@@ -316,7 +316,7 @@ class SubmissionsListView(SpreadsheetExportMixin, SafePaginateListView):
                     if isinstance(val, list):
                         val = ", ".join(val)
                     data_row.append(val)
-                data_rows.append({"model_id": submission.id, "fields": data_row})
+                data_rows.append({"model_id": submission.id,"id":submission.id, "fields": data_row})
             # Build data_headings as list of dicts containing model_id and fields
             ordering_by_field = self.get_validated_ordering()
             orderable_fields = self.orderable_fields

--- a/wagtail/contrib/forms/views.py
+++ b/wagtail/contrib/forms/views.py
@@ -4,12 +4,10 @@ from collections import OrderedDict
 from django.conf import settings
 from django.core.exceptions import PermissionDenied
 from django.core.paginator import InvalidPage
-from django.shortcuts import get_object_or_404, redirect
+from django.shortcuts import get_object_or_404
 from django.urls import reverse
-from django.utils.translation import ngettext
-from django.views.generic import ListView, TemplateView
+from django.views.generic import ListView
 
-from wagtail.admin import messages
 from wagtail.admin.views.mixins import SpreadsheetExportMixin
 from wagtail.contrib.forms.forms import SelectDateForm
 from wagtail.contrib.forms.utils import get_forms_for_user
@@ -111,7 +109,6 @@ class FormPagesListView(SafePaginateListView):
         return context
 
 
-
 class SubmissionsListView(SpreadsheetExportMixin, SafePaginateListView):
     """Lists submissions for the provided form page"""
 
@@ -125,8 +122,6 @@ class SubmissionsListView(SpreadsheetExportMixin, SafePaginateListView):
         "submit_time",
     )  # used to validate ordering in URL
     select_date_form = None
-    app_label= "wagtailforms"
-    model_name= "formsubmission"
 
     def dispatch(self, request, *args, **kwargs):
         """Check permissions and set the form page"""
@@ -254,7 +249,9 @@ class SubmissionsListView(SpreadsheetExportMixin, SafePaginateListView):
                     if isinstance(val, list):
                         val = ", ".join(val)
                     data_row.append(val)
-                data_rows.append({"model_id": submission.id,"id":submission.id, "fields": data_row})
+                data_rows.append(
+                    {"model_id": submission.id, "id": submission.id, "fields": data_row}
+                )
             # Build data_headings as list of dicts containing model_id and fields
             ordering_by_field = self.get_validated_ordering()
             orderable_fields = self.orderable_fields
@@ -281,8 +278,8 @@ class SubmissionsListView(SpreadsheetExportMixin, SafePaginateListView):
                     "select_date_form": self.select_date_form,
                     "data_headings": data_headings,
                     "data_rows": data_rows,
-                    "app_label": self.app_label,
-                    "model_name": self.model_name,
+                    "app_label": "wagtailforms",
+                    "model_name": "formsubmission",
                 }
             )
 

--- a/wagtail/contrib/forms/views.py
+++ b/wagtail/contrib/forms/views.py
@@ -111,68 +111,6 @@ class FormPagesListView(SafePaginateListView):
         return context
 
 
-class DeleteSubmissionsView(TemplateView):
-    """Delete the selected submissions"""
-
-    template_name = "wagtailforms/confirm_delete.html"
-    page = None
-    submissions = None
-    success_url = "wagtailforms:list_submissions"
-
-    def get_queryset(self):
-        """Returns a queryset for the selected submissions"""
-        submission_ids = self.request.GET.getlist("selected-submissions")
-        submission_class = self.page.get_submission_class()
-        return submission_class._default_manager.filter(id__in=submission_ids)
-
-    def handle_delete(self, submissions):
-        """Deletes the given queryset"""
-        count = submissions.count()
-        submissions.delete()
-        messages.success(
-            self.request,
-            ngettext(
-                "One submission has been deleted.",
-                "%(count)d submissions have been deleted.",
-                count,
-            )
-            % {"count": count},
-        )
-
-    def get_success_url(self):
-        """Returns the success URL to redirect to after a successful deletion"""
-        return self.success_url
-
-    def dispatch(self, request, *args, **kwargs):
-        """Check permissions, set the page and submissions, handle delete"""
-        page_id = kwargs.get("page_id")
-
-        if not get_forms_for_user(self.request.user).filter(id=page_id).exists():
-            raise PermissionDenied
-
-        self.page = get_object_or_404(Page, id=page_id).specific
-
-        self.submissions = self.get_queryset()
-
-        if self.request.method == "POST":
-            self.handle_delete(self.submissions)
-            return redirect(self.get_success_url(), page_id)
-
-        return super().dispatch(request, *args, **kwargs)
-
-    def get_context_data(self, **kwargs):
-        """Get the context for this view"""
-        context = super().get_context_data(**kwargs)
-
-        context.update(
-            {
-                "page": self.page,
-                "submissions": self.submissions,
-            }
-        )
-
-        return context
-
 
 class SubmissionsListView(SpreadsheetExportMixin, SafePaginateListView):
     """Lists submissions for the provided form page"""

--- a/wagtail/contrib/forms/views.py
+++ b/wagtail/contrib/forms/views.py
@@ -187,6 +187,8 @@ class SubmissionsListView(SpreadsheetExportMixin, SafePaginateListView):
         "submit_time",
     )  # used to validate ordering in URL
     select_date_form = None
+    app_label= "wagtailforms"
+    model_name= "formsubmission"
 
     def dispatch(self, request, *args, **kwargs):
         """Check permissions and set the form page"""
@@ -341,6 +343,8 @@ class SubmissionsListView(SpreadsheetExportMixin, SafePaginateListView):
                     "select_date_form": self.select_date_form,
                     "data_headings": data_headings,
                     "data_rows": data_rows,
+                    "app_label": self.app_label,
+                    "model_name": self.model_name,
                 }
             )
 

--- a/wagtail/contrib/forms/wagtail_hooks.py
+++ b/wagtail/contrib/forms/wagtail_hooks.py
@@ -5,6 +5,9 @@ from wagtail import hooks
 from wagtail.admin.menu import MenuItem
 from wagtail.contrib.forms import urls
 from wagtail.contrib.forms.utils import get_forms_for_user
+from wagtail.contrib.forms.bulk_actions.delete import (
+    DeleteBulkAction,
+)
 
 
 @hooks.register("register_admin_urls")
@@ -29,3 +32,7 @@ def register_forms_menu_item():
         icon_name="form",
         order=700,
     )
+
+
+for action_class in [DeleteBulkAction]:
+    hooks.register("register_bulk_action", action_class)


### PR DESCRIPTION
<!--
Thanks for contributing to Wagtail! 🎉

Before submitting, please review the [contributor guidelines](https://docs.wagtail.org/en/latest/contributing/index.html).
-->

_Please check the following:_

- [ ] Do the tests still pass?[^1]
- [x] Does the code comply with the style guide? 
    - [x] Run `make lint` from the Wagtail root. 
- [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
- [x] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    - [x] **Please list the exact browser and operating system versions you tested**:
      - I have tested the delete confirmation page as well as changed the index-submissions page on Firefox, Chrome and Brave. 
    - [ ] **Please list which assistive technologies [^3] you tested**: 
- [ ] For new features: Has the documentation been updated accordingly?

Solves issue #8182 
I have added BulkActions for the Wagtailform, I have even created a separate FormBulkAction class which can be inherited to add more BulkActions.  

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets) 
