### PR TITLE
Refactor ModelAdmin breadcrumbs regression tests to be more flexible

### DIFF
--- a/wagtail/contrib/modeladmin/tests/test_page_modeladmin.py
+++ b/wagtail/contrib/modeladmin/tests/test_page_modeladmin.py
@@ -338,8 +338,8 @@ class TestModeratorAccess(TestCase, WagtailTestUtils):
 
 class TestHeaderBreadcrumbs(TestCase, WagtailTestUtils):
     """
-    Test that the <ul class="breadcrumbs">... is inserted within the
-    <header> tag for potential future regression.
+    Test that the breadcrumbs region is inserted before the
+    </header> tag for potential future regression.
     See https://github.com/wagtail/wagtail/issues/3889
     """
 
@@ -371,13 +371,11 @@ class TestHeaderBreadcrumbs(TestCase, WagtailTestUtils):
         """
         self.assertContains(response, expected, html=True)
 
-        # check that the breadcrumbs are after the header opening tag
+        # check that the breadcrumbs are before the first header closing tag
         content_str = str(response.content)
-        position_of_header = content_str.index(
-            "<header"
-        )  # intentionally not closing tag
-        position_of_breadcrumbs = content_str.index('<ul class="breadcrumb">')
-        self.assertLess(position_of_header, position_of_breadcrumbs)
+        position_of_header_close = content_str.index("</header>")
+        position_of_breadcrumbs = content_str.index('<nav aria-label="Breadcrumb">')
+        self.assertGreater(position_of_header_close, position_of_breadcrumbs)
 
     def test_choose_inspect_page(self):
         response = self.client.get("/admin/tests/eventpage/inspect/4/")
@@ -402,13 +400,11 @@ class TestHeaderBreadcrumbs(TestCase, WagtailTestUtils):
         """
         self.assertContains(response, expected, html=True)
 
-        # check that the breadcrumbs are after the header opening tag
+        # check that the breadcrumbs are before the first header closing tag
         content_str = str(response.content)
-        position_of_header = content_str.index(
-            "<header"
-        )  # intentionally not closing tag
-        position_of_breadcrumbs = content_str.index('<ul class="breadcrumb">')
-        self.assertLess(position_of_header, position_of_breadcrumbs)
+        position_of_header_close = content_str.index("</header>")
+        position_of_breadcrumbs = content_str.index('<nav aria-label="Breadcrumb">')
+        self.assertGreater(position_of_header_close, position_of_breadcrumbs)
 
 
 class TestSearch(TestCase, WagtailTestUtils):

--- a/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
+++ b/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
@@ -913,8 +913,8 @@ class TestQuoting(TestCase, WagtailTestUtils):
 
 class TestHeaderBreadcrumbs(TestCase, WagtailTestUtils):
     """
-    Test that the <ul class="breadcrumbs">... is inserted within the
-    <header> tag for potential future regression.
+    Test that the breadcrumbs region is inserted before the
+    </header> tag for potential future regression.
     See https://github.com/wagtail/wagtail/issues/3889
     """
 
@@ -949,7 +949,7 @@ class TestHeaderBreadcrumbs(TestCase, WagtailTestUtils):
         # check that the breadcrumbs are before the first header closing tag
         content_str = str(response.content)
         position_of_header_close = content_str.index("</header>")
-        position_of_breadcrumbs = content_str.index('<ul class="breadcrumb">')
+        position_of_breadcrumbs = content_str.index('<nav aria-label="Breadcrumb">')
         self.assertGreater(position_of_header_close, position_of_breadcrumbs)
 
 


### PR DESCRIPTION
Attempts to fix [test regressions in `stable/3.0.x`](https://github.com/wagtail/wagtail/runs/6450513100?check_suite_focus=true) by making the ModelAdmin breadcrumb tests more flexible. We’ve changed those templates in #8491, and only cherry-picked the most fundamental changes to `stable/3.0.x`, which is causing test failures for that branch only.

There are 3 "breadcrumbs position in ModelAdmin" test cases, 2 were failing. I’ve updated those two to work the same as the one that was still passing. I’ve also updated the three tests to check the presence of the `nav` landmark region, rather than the `ul`, as that’s more semantically what should denote where the breadcrumbs are.

I find the value of this "position" test a bit dubious compared to just testing whether the breadcrumbs are present or not. Hopefully something we could revisit as part of #8539.