### PR TITLE
Added missing gettext calls to the CommentComponent

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -24,6 +24,7 @@ Changelog
  * Fix: Ensure the upgrade notification request for the latest release, which can be disabled via the `WAGTAIL_ENABLE_UPDATE_CHECK` sends the referrer origin with `strict-origin-when-cross-origin` (Karl Hobley)
  * Fix: Ensure radio buttons / checkboxes display vertically under Django 4.0 (Matt Westcott)
  * Fix: Ensure that custom document or image models support custom tag models (Matt Westcott)
+ * Fix: Ensure comments use translated values for their placeholder text (Stefan Hammer)
 
 
 3.0 (16.05.2022)

--- a/client/src/components/CommentApp/components/Comment/index.tsx
+++ b/client/src/components/CommentApp/components/Comment/index.tsx
@@ -160,7 +160,7 @@ export default class CommentComponent extends React.Component<CommentProps> {
         <form onSubmit={sendReply}>
           <TextArea
             className="comment__reply-input"
-            placeholder="Enter your reply..."
+            placeholder={gettext('Enter your reply...')}
             value={comment.newReply}
             onChange={onChangeNewReply}
           />
@@ -235,7 +235,7 @@ export default class CommentComponent extends React.Component<CommentProps> {
             className="comment__input"
             value={comment.newText}
             onChange={onChangeText}
-            placeholder="Enter your comments..."
+            placeholder={gettext('Enter your comments...')}
             additionalAttributes={{
               'aria-describedby': descriptionId,
             }}

--- a/docs/releases/4.0.md
+++ b/docs/releases/4.0.md
@@ -34,6 +34,7 @@ depth: 1
  * Ensure the upgrade notification request for the latest release, which can be disabled via the `WAGTAIL_ENABLE_UPDATE_CHECK` sends the referrer origin with `strict-origin-when-cross-origin` (Karl Hobley)
  * Ensure radio buttons / checkboxes display vertically under Django 4.0 (Matt Westcott)
  * Ensure that custom document or image models support custom tag models (Matt Westcott)
+ * Ensure comments use translated values for their placeholder text (Stefan Hammer)
 
 
 ## Upgrade considerations


### PR DESCRIPTION
Just found these 2 untranslated strings.

Note: I haven't contributed anything to the frontend code yet, so I've simply based my changes on the following code:
https://github.com/wagtail/wagtail/blob/501b28c62b41bf6d32227ec6e108d69bab17a0ac/client/src/components/Sidebar/modules/Search.tsx#L118
Tests, `npm run build` and `make lint` have completed successfully.

_Please check the following:_

- [x] Do the tests still pass?[^1]
- [x] Does the code comply with the style guide? 
    - [x] Run `make lint` from the Wagtail root. 
- [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    - [ ] **Please list the exact browser and operating system versions you tested**:
    - [ ] **Please list which assistive technologies [^3] you tested**: 

**Please describe additional details for testing this change**. 

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets) 
