### PR TITLE
Set referer policy of upgrade notifcation to "strict-origin-when-cross-origin"

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -13,10 +13,11 @@ Changelog
  * Drop support for Safari 13 by removing left/right positioning in favour of CSS logical properties (Thibaud Colas)
  * Use `FormData` instead of jQuery's `form.serialize` when editing documents or images just added so that additional fields can be better supported (Stefan Hammer)
  * Add informational Codecov status checks for GitHub CI pipelines (Tom Hu)
+ * Replace `PageRevision` with generic `Revision` model (Sage Abdullah)
  * Fix: Typo in `ResumeWorkflowActionFormatter` message (Stefan Hammer)
  * Fix: Throw a meaningful error when saving an image to an unrecognised image format (Christian Franke)
  * Fix: Remove extra padding for headers with breadcrumbs on mobile viewport (Steven Steinwand)
- * Replace `PageRevision` with generic `Revision` model (Sage Abdullah)
+ * Fix: Ensure the upgrade notification request for the latest release, which can be disabled via the `WAGTAIL_ENABLE_UPDATE_CHECK` sends the referrer origin with `strict-origin-when-cross-origin` (Karl Hobley)
 
 
 3.0 (16.05.2022)

--- a/client/src/components/UpgradeNotification/index.js
+++ b/client/src/components/UpgradeNotification/index.js
@@ -17,7 +17,9 @@ const initUpgradeNotification = () => {
   const releasesUrl = 'https://releases.wagtail.org/latest.txt';
   const currentVersion = container.dataset.wagtailVersion;
 
-  fetch(releasesUrl)
+  fetch(releasesUrl, {
+    referrerPolicy: 'strict-origin-when-cross-origin',
+  })
     .then((response) => {
       if (response.status !== 200) {
         // eslint-disable-next-line no-console

--- a/docs/releases/4.0.md
+++ b/docs/releases/4.0.md
@@ -27,6 +27,7 @@ depth: 1
  * Throw a meaningful error when saving an image to an unrecognised image format (Christian Franke)
  * Remove extra padding for headers with breadcrumbs on mobile viewport (Steven Steinwand)
  * Replace `PageRevision` with generic `Revision` model (Sage Abdullah)
+ * Ensure the upgrade notification request for the latest release, which can be disabled via the `WAGTAIL_ENABLE_UPDATE_CHECK` sends the referrer origin with `strict-origin-when-cross-origin` (Karl Hobley)
 
 
 ## Upgrade considerations


### PR DESCRIPTION
Since Django 3.1, all Wagtail admin responses have been given a ``referer-policy: same-origin`` header. See: https://chipcullen.com/django-3-referrer-policy-change/

This prevents the upgrade check from sending a "referer" header, which we use internally to measure the number of active Wagtail sites there are over time (this can be disabled with the [``WAGTAIL_ENABLE_UPDATE_CHECK`` setting](https://docs.wagtail.org/en/stable/reference/settings.html#wagtail-enable-update-check)).

This PR changes the referer policy of this ``fetch()`` request to ``strict-origin-when-cross-origin`` so that the ``Referer`` is set again on these requests.