### PR TITLE
Use PostgreSQL 12 when testing against Django main

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,7 +82,7 @@ jobs:
           - python: '3.10'
             django: 'git+https://github.com/django/django.git@main#egg=Django'
             experimental: true
-            postgres: 'postgres:11'
+            postgres: 'postgres:12'
 
     services:
       postgres:


### PR DESCRIPTION
<!--
Thanks for contributing to Wagtail! 🎉

Before submitting, please review the [contributor guidelines](https://docs.wagtail.org/en/latest/contributing/index.html).
-->

Django has pushed the `stable/4.1.x` branch and dropped support for PostgreSQL 11 in Django 4.2 (`main`): https://github.com/django/django/pull/15707

Kindly review @gasman