### PR TITLE
Add factory class for generating chooser modal onload handlers

### DIFF
--- a/client/src/entrypoints/admin/task-chooser-modal.js
+++ b/client/src/entrypoints/admin/task-chooser-modal.js
@@ -45,6 +45,7 @@ const TASK_CHOOSER_MODAL_ONLOAD_HANDLERS = {
 
     const searchController = new SearchController({
       form: $('form.task-search', modal.body),
+      containerElement: modal.body,
       resultsContainerSelector: '#search-results',
       onLoadResults: (context) => {
         ajaxifyLinks(context);

--- a/client/src/entrypoints/documents/document-chooser-modal.js
+++ b/client/src/entrypoints/documents/document-chooser-modal.js
@@ -58,7 +58,6 @@ class DocumentChooserModalOnloadHandlerFactory extends ChooserModalOnloadHandler
 
 window.DOCUMENT_CHOOSER_MODAL_ONLOAD_HANDLERS =
   new DocumentChooserModalOnloadHandlerFactory({
-    searchFormSelector: 'form.document-search',
     searchFilterSelectors: ['#collection_chooser_collection_id'],
     searchInputDelay: 50,
     chosenResponseName: 'documentChosen',

--- a/client/src/entrypoints/documents/document-chooser-modal.js
+++ b/client/src/entrypoints/documents/document-chooser-modal.js
@@ -58,8 +58,6 @@ class DocumentChooserModalOnloadHandlerFactory extends ChooserModalOnloadHandler
 
 window.DOCUMENT_CHOOSER_MODAL_ONLOAD_HANDLERS =
   new DocumentChooserModalOnloadHandlerFactory({
-    chooseStepName: 'chooser',
-    chosenStepName: 'document_chosen',
     searchFormSelector: 'form.document-search',
     searchFilterSelectors: ['#collection_chooser_collection_id'],
     searchInputDelay: 50,

--- a/client/src/entrypoints/documents/document-chooser-modal.js
+++ b/client/src/entrypoints/documents/document-chooser-modal.js
@@ -60,7 +60,6 @@ window.DOCUMENT_CHOOSER_MODAL_ONLOAD_HANDLERS =
   new DocumentChooserModalOnloadHandlerFactory({
     chooseStepName: 'chooser',
     chosenStepName: 'document_chosen',
-    chosenLinkSelector: 'a.document-choice',
     searchFormSelector: 'form.document-search',
     searchFilterSelectors: ['#collection_chooser_collection_id'],
     searchInputDelay: 50,

--- a/client/src/entrypoints/documents/document-chooser-modal.js
+++ b/client/src/entrypoints/documents/document-chooser-modal.js
@@ -1,5 +1,4 @@
 import $ from 'jquery';
-import { initTabs } from '../../includes/tabs';
 import { ChooserModalOnloadHandlerFactory } from '../../includes/chooserModal';
 
 class DocumentChooserModalOnloadHandlerFactory extends ChooserModalOnloadHandlerFactory {
@@ -15,23 +14,6 @@ class DocumentChooserModalOnloadHandlerFactory extends ChooserModalOnloadHandler
 
       event.preventDefault();
     });
-
-    // Reinitialize tabs to hook up tab event listeners in the modal
-    initTabs();
-  }
-
-  onLoadReshowCreationFormStep(modal, jsonData) {
-    $('#tab-upload', modal.body).replaceWith(jsonData.htmlFragment);
-    initTabs();
-    this.ajaxifyCreationForm(modal);
-  }
-
-  getOnLoadHandlers() {
-    const handlers = super.getOnLoadHandlers();
-    handlers.reshow_upload_form = (modal, jsonData) => {
-      this.onLoadReshowCreationFormStep(modal, jsonData);
-    };
-    return handlers;
   }
 }
 
@@ -41,8 +23,9 @@ window.DOCUMENT_CHOOSER_MODAL_ONLOAD_HANDLERS =
     searchInputDelay: 50,
     chosenResponseName: 'documentChosen',
     creationFormSelector: 'form.document-upload',
-    creationFormErrorContainerSelector: '#tab-upload',
+    creationFormTabSelector: '#tab-upload',
     creationFormFileFieldSelector: '#id_document-chooser-upload-file',
     creationFormTitleFieldSelector: '#id_document-chooser-upload-title',
     creationFormEventName: 'wagtail:documents-upload',
+    reshowCreationFormStepName: 'reshow_upload_form',
   }).getOnLoadHandlers();

--- a/client/src/entrypoints/documents/document-chooser-modal.js
+++ b/client/src/entrypoints/documents/document-chooser-modal.js
@@ -27,5 +27,4 @@ window.DOCUMENT_CHOOSER_MODAL_ONLOAD_HANDLERS =
     creationFormFileFieldSelector: '#id_document-chooser-upload-file',
     creationFormTitleFieldSelector: '#id_document-chooser-upload-title',
     creationFormEventName: 'wagtail:documents-upload',
-    reshowCreationFormStepName: 'reshow_upload_form',
   }).getOnLoadHandlers();

--- a/client/src/entrypoints/documents/document-chooser-modal.js
+++ b/client/src/entrypoints/documents/document-chooser-modal.js
@@ -1,26 +1,6 @@
 import $ from 'jquery';
 import { initTabs } from '../../includes/tabs';
-import {
-  submitCreationForm,
-  initPrefillTitleFromFilename,
-  ChooserModalOnloadHandlerFactory,
-} from '../../includes/chooserModal';
-
-function ajaxifyDocumentUploadForm(modal) {
-  $('form.document-upload', modal.body).on('submit', (event) => {
-    submitCreationForm(modal, event.currentTarget, {
-      errorContainerSelector: '#tab-upload',
-    });
-
-    return false;
-  });
-
-  initPrefillTitleFromFilename(modal, {
-    fileFieldSelector: '#id_document-chooser-upload-file',
-    titleFieldSelector: '#id_document-chooser-upload-title',
-    eventName: 'wagtail:documents-upload',
-  });
-}
+import { ChooserModalOnloadHandlerFactory } from '../../includes/chooserModal';
 
 class DocumentChooserModalOnloadHandlerFactory extends ChooserModalOnloadHandlerFactory {
   ajaxifyLinks(modal, context) {
@@ -40,17 +20,16 @@ class DocumentChooserModalOnloadHandlerFactory extends ChooserModalOnloadHandler
     initTabs();
   }
 
-  onLoadChooseStep(modal, jsonData) {
-    super.onLoadChooseStep(modal, jsonData);
-    ajaxifyDocumentUploadForm(modal);
+  onLoadReshowCreationFormStep(modal, jsonData) {
+    $('#tab-upload', modal.body).replaceWith(jsonData.htmlFragment);
+    initTabs();
+    this.ajaxifyCreationForm(modal);
   }
 
   getOnLoadHandlers() {
     const handlers = super.getOnLoadHandlers();
     handlers.reshow_upload_form = (modal, jsonData) => {
-      $('#tab-upload', modal.body).replaceWith(jsonData.htmlFragment);
-      initTabs();
-      ajaxifyDocumentUploadForm(modal);
+      this.onLoadReshowCreationFormStep(modal, jsonData);
     };
     return handlers;
   }
@@ -61,4 +40,9 @@ window.DOCUMENT_CHOOSER_MODAL_ONLOAD_HANDLERS =
     searchFilterSelectors: ['#collection_chooser_collection_id'],
     searchInputDelay: 50,
     chosenResponseName: 'documentChosen',
+    creationFormSelector: 'form.document-upload',
+    creationFormErrorContainerSelector: '#tab-upload',
+    creationFormFileFieldSelector: '#id_document-chooser-upload-file',
+    creationFormTitleFieldSelector: '#id_document-chooser-upload-title',
+    creationFormEventName: 'wagtail:documents-upload',
   }).getOnLoadHandlers();

--- a/client/src/entrypoints/images/image-chooser-modal.js
+++ b/client/src/entrypoints/images/image-chooser-modal.js
@@ -54,6 +54,7 @@ window.IMAGE_CHOOSER_MODAL_ONLOAD_HANDLERS = {
 
     searchController = new SearchController({
       form: $('form.image-search', modal.body),
+      containerElement: modal.body,
       resultsContainerSelector: '#image-results',
       onLoadResults: (context) => {
         ajaxifyLinks(context);

--- a/client/src/entrypoints/snippets/snippet-chooser-modal.js
+++ b/client/src/entrypoints/snippets/snippet-chooser-modal.js
@@ -1,36 +1,9 @@
-import $ from 'jquery';
-import { SearchController } from '../../includes/chooserModal';
+import { ChooserModalOnloadHandlerFactory } from '../../includes/chooserModal';
 
-window.SNIPPET_CHOOSER_MODAL_ONLOAD_HANDLERS = {
-  choose: (modal) => {
-    let searchController;
-
-    function ajaxifyLinks(context) {
-      $('a.snippet-choice', modal.body).on('click', (event) => {
-        modal.loadUrl(event.currentTarget.href);
-        return false;
-      });
-
-      $('.pagination a', context).on('click', (event) => {
-        searchController.fetchResults(event.currentTarget.href);
-        return false;
-      });
-    }
-
-    searchController = new SearchController({
-      form: $('form.snippet-search', modal.body),
-      resultsContainerSelector: '#search-results',
-      onLoadResults: (context) => {
-        ajaxifyLinks(context);
-      },
-    });
-    searchController.attachSearchInput('#id_q');
-    searchController.attachSearchFilter('#snippet-chooser-locale');
-
-    ajaxifyLinks(modal.body);
-  },
-  chosen: (modal, jsonData) => {
-    modal.respond('snippetChosen', jsonData.result);
-    modal.close();
-  },
-};
+window.SNIPPET_CHOOSER_MODAL_ONLOAD_HANDLERS =
+  new ChooserModalOnloadHandlerFactory({
+    chosenLinkSelector: 'a.snippet-choice',
+    searchFormSelector: 'form.snippet-search',
+    searchFilterSelectors: ['#snippet-chooser-locale'],
+    chosenResponseName: 'snippetChosen',
+  }).getOnLoadHandlers();

--- a/client/src/entrypoints/snippets/snippet-chooser-modal.js
+++ b/client/src/entrypoints/snippets/snippet-chooser-modal.js
@@ -2,6 +2,5 @@ import { ChooserModalOnloadHandlerFactory } from '../../includes/chooserModal';
 
 window.SNIPPET_CHOOSER_MODAL_ONLOAD_HANDLERS =
   new ChooserModalOnloadHandlerFactory({
-    searchFilterSelectors: ['#snippet-chooser-locale'],
     chosenResponseName: 'snippetChosen',
   }).getOnLoadHandlers();

--- a/client/src/entrypoints/snippets/snippet-chooser-modal.js
+++ b/client/src/entrypoints/snippets/snippet-chooser-modal.js
@@ -2,7 +2,6 @@ import { ChooserModalOnloadHandlerFactory } from '../../includes/chooserModal';
 
 window.SNIPPET_CHOOSER_MODAL_ONLOAD_HANDLERS =
   new ChooserModalOnloadHandlerFactory({
-    searchFormSelector: 'form.snippet-search',
     searchFilterSelectors: ['#snippet-chooser-locale'],
     chosenResponseName: 'snippetChosen',
   }).getOnLoadHandlers();

--- a/client/src/entrypoints/snippets/snippet-chooser-modal.js
+++ b/client/src/entrypoints/snippets/snippet-chooser-modal.js
@@ -2,7 +2,6 @@ import { ChooserModalOnloadHandlerFactory } from '../../includes/chooserModal';
 
 window.SNIPPET_CHOOSER_MODAL_ONLOAD_HANDLERS =
   new ChooserModalOnloadHandlerFactory({
-    chosenLinkSelector: 'a.snippet-choice',
     searchFormSelector: 'form.snippet-search',
     searchFilterSelectors: ['#snippet-chooser-locale'],
     chosenResponseName: 'snippetChosen',

--- a/client/src/includes/chooserModal.js
+++ b/client/src/includes/chooserModal.js
@@ -151,7 +151,8 @@ class ChooserModalOnloadHandlerFactory {
       opts?.chosenLinkSelector || 'a[data-chooser-modal-choice]';
     this.paginationLinkSelector =
       opts?.paginationLinkSelector || '.pagination a';
-    this.searchFormSelector = opts?.searchFormSelector || 'form[data-search]';
+    this.searchFormSelector =
+      opts?.searchFormSelector || 'form[data-chooser-modal-search]';
     this.resultsContainerSelector =
       opts?.resultsContainerSelector || '#search-results';
     this.searchInputSelectors = opts?.searchInputSelectors || ['#id_q'];

--- a/client/src/includes/chooserModal.js
+++ b/client/src/includes/chooserModal.js
@@ -143,7 +143,8 @@ class ChooserModalOnloadHandlerFactory {
   constructor(opts) {
     this.chooseStepName = opts?.chooseStepName || 'choose';
     this.chosenStepName = opts?.chosenStepName || 'chosen';
-    this.chosenLinkSelector = opts?.chosenLinkSelector || 'a[data-item-choice]';
+    this.chosenLinkSelector =
+      opts?.chosenLinkSelector || 'a[data-chooser-modal-choice]';
     this.paginationLinkSelector =
       opts?.paginationLinkSelector || '.pagination a';
     this.searchFormSelector = opts?.searchFormSelector || 'form[data-search]';

--- a/client/src/includes/chooserModal.js
+++ b/client/src/includes/chooserModal.js
@@ -156,7 +156,9 @@ class ChooserModalOnloadHandlerFactory {
     this.resultsContainerSelector =
       opts?.resultsContainerSelector || '#search-results';
     this.searchInputSelectors = opts?.searchInputSelectors || ['#id_q'];
-    this.searchFilterSelectors = opts?.searchFilterSelectors || [];
+    this.searchFilterSelectors = opts?.searchFilterSelectors || [
+      '[data-chooser-modal-search-filter]',
+    ];
     this.chosenResponseName = opts?.chosenResponseName || 'chosen';
     this.searchInputDelay = opts?.searchInputDelay || 200;
 

--- a/client/src/includes/chooserModal.js
+++ b/client/src/includes/chooserModal.js
@@ -77,8 +77,12 @@ const initPrefillTitleFromFilename = (
 class SearchController {
   constructor(opts) {
     this.form = opts.form;
+    this.containerElement = opts.containerElement;
     this.onLoadResults = opts.onLoadResults;
-    this.resultsContainer = $(opts.resultsContainerSelector);
+    this.resultsContainer = $(
+      opts.resultsContainerSelector,
+      this.containerElement,
+    );
     this.inputDelay = opts.inputDelay || 200;
 
     this.searchUrl = this.form.attr('action');
@@ -93,7 +97,7 @@ class SearchController {
   attachSearchInput(selector) {
     let timer;
 
-    $(selector).on('input', () => {
+    $(selector, this.containerElement).on('input', () => {
       if (this.request) {
         this.request.abort();
       }
@@ -105,7 +109,7 @@ class SearchController {
   }
 
   attachSearchFilter(selector) {
-    $(selector).on('change', () => {
+    $(selector, this.containerElement).on('change', () => {
       this.searchFromForm();
     });
   }
@@ -158,19 +162,19 @@ class ChooserModalOnloadHandlerFactory {
     this.searchController = null;
   }
 
-  ajaxifyLinks(modal, context) {
+  ajaxifyLinks(modal, containerElement) {
     if (!this.searchController) {
       throw new Error(
         'Cannot call ajaxifyLinks until a SearchController is set up',
       );
     }
 
-    $(this.chosenLinkSelector, modal.body).on('click', (event) => {
+    $(this.chosenLinkSelector, containerElement).on('click', (event) => {
       modal.loadUrl(event.currentTarget.href);
       return false;
     });
 
-    $(this.paginationLinkSelector, context).on('click', (event) => {
+    $(this.paginationLinkSelector, containerElement).on('click', (event) => {
       this.searchController.fetchResults(event.currentTarget.href);
       return false;
     });
@@ -179,9 +183,10 @@ class ChooserModalOnloadHandlerFactory {
   initSearchController(modal) {
     this.searchController = new SearchController({
       form: $(this.searchFormSelector, modal.body),
+      containerElement: modal.body,
       resultsContainerSelector: this.resultsContainerSelector,
-      onLoadResults: (context) => {
-        this.ajaxifyLinks(modal, context);
+      onLoadResults: (containerElement) => {
+        this.ajaxifyLinks(modal, containerElement);
       },
       inputDelay: this.searchInputDelay,
     });

--- a/client/src/includes/chooserModal.js
+++ b/client/src/includes/chooserModal.js
@@ -199,6 +199,7 @@ class ChooserModalOnloadHandlerFactory {
     if (this.modalHasTabs(modal)) initTabs();
   }
 
+  // eslint-disable-next-line class-methods-use-this
   modalHasTabs(modal) {
     return $('[data-tabs]', modal.body).length;
   }

--- a/client/src/includes/chooserModal.js
+++ b/client/src/includes/chooserModal.js
@@ -141,6 +141,8 @@ class SearchController {
 
 class ChooserModalOnloadHandlerFactory {
   constructor(opts) {
+    this.chooseStepName = opts?.chooseStepName || 'choose';
+    this.chosenStepName = opts?.chosenStepName || 'chosen';
     this.chosenLinkSelector = opts?.chosenLinkSelector || 'a[data-item-choice]';
     this.paginationLinkSelector =
       opts?.paginationLinkSelector || '.pagination a';
@@ -150,6 +152,7 @@ class ChooserModalOnloadHandlerFactory {
     this.searchInputSelectors = opts?.searchInputSelectors || ['#id_q'];
     this.searchFilterSelectors = opts?.searchFilterSelectors || [];
     this.chosenResponseName = opts?.chosenResponseName || 'chosen';
+    this.searchInputDelay = opts?.searchInputDelay || 200;
 
     this.searchController = null;
   }
@@ -179,6 +182,7 @@ class ChooserModalOnloadHandlerFactory {
       onLoadResults: (context) => {
         this.ajaxifyLinks(modal, context);
       },
+      inputDelay: this.searchInputDelay,
     });
     this.searchInputSelectors.forEach((selector) => {
       this.searchController.attachSearchInput(selector);
@@ -200,10 +204,10 @@ class ChooserModalOnloadHandlerFactory {
 
   getOnLoadHandlers() {
     return {
-      choose: (modal, jsonData) => {
+      [this.chooseStepName]: (modal, jsonData) => {
         this.onLoadChooseStep(modal, jsonData);
       },
-      chosen: (modal, jsonData) => {
+      [this.chosenStepName]: (modal, jsonData) => {
         this.onLoadChosenStep(modal, jsonData);
       },
     };

--- a/wagtail/admin/templates/wagtailadmin/tables/attrs.html
+++ b/wagtail/admin/templates/wagtailadmin/tables/attrs.html
@@ -1,0 +1,1 @@
+{% for name, value in attrs.items %}{% if value is not False %} {{ name }}{% if value is not True %}="{{ value|stringformat:'s' }}"{% endif %}{% endif %}{% endfor %}

--- a/wagtail/admin/templates/wagtailadmin/tables/title_cell.html
+++ b/wagtail/admin/templates/wagtailadmin/tables/title_cell.html
@@ -1,7 +1,7 @@
 <td class="{% if column.classname %}{{ column.classname }} {% endif %}title">
     <div class="title-wrapper">
         {% if link_url %}
-            <a href="{{ link_url }}" {% if link_classname %}class="{{ link_classname }}"{% endif %}>{{ value }}</a>
+            <a {% include "wagtailadmin/tables/attrs.html" with attrs=link_attrs %}>{{ value }}</a>
         {% else %}
             {{ value }}
         {% endif %}

--- a/wagtail/admin/tests/ui/test_tables.py
+++ b/wagtail/admin/tests/ui/test_tables.py
@@ -94,6 +94,7 @@ class TestTable(TestCase):
                     "hostname",
                     url_name="wagtailsites:edit",
                     link_classname="choose-site",
+                    link_attrs={"data-chooser": "yes"},
                 ),
                 Column("site_name", label="Site name"),
             ],
@@ -112,7 +113,7 @@ class TestTable(TestCase):
                     <tr>
                         <td class="title">
                             <div class="title-wrapper">
-                                <a href="/admin/sites/%d/" class="choose-site">blog.example.com</a>
+                                <a href="/admin/sites/%d/" class="choose-site" data-chooser="yes">blog.example.com</a>
                             </div>
                         </td>
                         <td>My blog</td>
@@ -120,7 +121,7 @@ class TestTable(TestCase):
                     <tr>
                         <td class="title">
                             <div class="title-wrapper">
-                                <a href="/admin/sites/%d/" class="choose-site">gallery.example.com</a>
+                                <a href="/admin/sites/%d/" class="choose-site" data-chooser="yes">gallery.example.com</a>
                             </div>
                         </td>
                         <td>My gallery</td>

--- a/wagtail/admin/ui/tables.py
+++ b/wagtail/admin/ui/tables.py
@@ -128,17 +128,28 @@ class TitleColumn(Column):
     cell_template_name = "wagtailadmin/tables/title_cell.html"
 
     def __init__(
-        self, name, url_name=None, get_url=None, link_classname=None, **kwargs
+        self,
+        name,
+        url_name=None,
+        get_url=None,
+        link_classname=None,
+        link_attrs=None,
+        **kwargs,
     ):
         super().__init__(name, **kwargs)
         self.url_name = url_name
         self._get_url_func = get_url
+        self.link_attrs = link_attrs or {}
         self.link_classname = link_classname
 
     def get_cell_context_data(self, instance, parent_context):
         context = super().get_cell_context_data(instance, parent_context)
-        context["link_url"] = self.get_link_url(instance, parent_context)
-        context["link_classname"] = self.link_classname
+        context["link_attrs"] = self.link_attrs.copy()
+        context["link_attrs"]["href"] = context["link_url"] = self.get_link_url(
+            instance, parent_context
+        )
+        if self.link_classname is not None:
+            context["link_attrs"]["class"] = self.link_classname
         return context
 
     def get_link_url(self, instance, parent_context):

--- a/wagtail/documents/templates/wagtaildocs/chooser/chooser.html
+++ b/wagtail/documents/templates/wagtaildocs/chooser/chooser.html
@@ -25,7 +25,7 @@
             role="tabpanel"
             aria-labelledby="tab-label-search"
         >
-            <form class="document-search search-bar" action="{% url 'wagtaildocs:chooser_results' %}" method="GET" novalidate>
+            <form data-chooser-modal-search class="search-bar" action="{% url 'wagtaildocs:chooser_results' %}" method="GET" novalidate>
                 <ul class="fields">
                     {% for field in searchform %}
                         {% include "wagtailadmin/shared/field_as_li.html" with field=field %}

--- a/wagtail/documents/tests/test_admin_views.py
+++ b/wagtail/documents/tests/test_admin_views.py
@@ -1418,7 +1418,7 @@ class TestDocumentChooserView(TestCase, WagtailTestUtils):
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "wagtaildocs/chooser/chooser.html")
         response_json = json.loads(response.content.decode())
-        self.assertEqual(response_json["step"], "chooser")
+        self.assertEqual(response_json["step"], "choose")
 
         # draftail should NOT be a standard JS include on this page
         self.assertNotIn("wagtailadmin/js/draftail.js", response_json["html"])
@@ -1437,7 +1437,7 @@ class TestDocumentChooserView(TestCase, WagtailTestUtils):
         response = self.client.get(reverse("wagtaildocs:chooser"))
         self.assertEqual(response.status_code, 200)
         response_json = json.loads(response.content.decode())
-        self.assertEqual(response_json["step"], "chooser")
+        self.assertEqual(response_json["step"], "choose")
         self.assertTemplateUsed(response, "wagtaildocs/chooser/chooser.html")
 
         # custom form fields should be present
@@ -1576,7 +1576,7 @@ class TestDocumentChooserChosenView(TestCase, WagtailTestUtils):
         )
         self.assertEqual(response.status_code, 200)
         response_json = json.loads(response.content.decode())
-        self.assertEqual(response_json["step"], "document_chosen")
+        self.assertEqual(response_json["step"], "chosen")
 
 
 class TestDocumentChooserUploadView(TestCase, WagtailTestUtils):
@@ -1601,9 +1601,9 @@ class TestDocumentChooserUploadView(TestCase, WagtailTestUtils):
         }
         response = self.client.post(reverse("wagtaildocs:chooser_upload"), post_data)
 
-        # Check that the response is the 'document_chosen' step
+        # Check that the response is the 'chosen' step
         response_json = json.loads(response.content.decode())
-        self.assertEqual(response_json["step"], "document_chosen")
+        self.assertEqual(response_json["step"], "chosen")
 
         # Document should be created
         self.assertTrue(models.Document.objects.filter(title="Test document").exists())
@@ -1681,7 +1681,7 @@ class TestDocumentChooserUploadViewWithLimitedPermissions(TestCase, WagtailTestU
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "wagtaildocs/chooser/chooser.html")
         response_json = json.loads(response.content.decode())
-        self.assertEqual(response_json["step"], "chooser")
+        self.assertEqual(response_json["step"], "choose")
 
         # user only has access to one collection -> should not see the collections field
         self.assertNotIn("id_collection", response_json["html"])
@@ -1697,9 +1697,9 @@ class TestDocumentChooserUploadViewWithLimitedPermissions(TestCase, WagtailTestU
         }
         response = self.client.post(reverse("wagtaildocs:chooser_upload"), post_data)
 
-        # Check that the response is the 'document_chosen' step
+        # Check that the response is the 'chosen' step
         response_json = json.loads(response.content.decode())
-        self.assertEqual(response_json["step"], "document_chosen")
+        self.assertEqual(response_json["step"], "chosen")
 
         # Document should be created
         doc = models.Document.objects.filter(title="Test document")

--- a/wagtail/documents/tests/test_admin_views.py
+++ b/wagtail/documents/tests/test_admin_views.py
@@ -1588,7 +1588,7 @@ class TestDocumentChooserUploadView(TestCase, WagtailTestUtils):
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "wagtaildocs/chooser/upload_form.html")
         response_json = json.loads(response.content.decode())
-        self.assertEqual(response_json["step"], "reshow_upload_form")
+        self.assertEqual(response_json["step"], "reshow_creation_form")
 
     def test_post(self):
         # Build a fake file
@@ -1670,7 +1670,7 @@ class TestDocumentChooserUploadViewWithLimitedPermissions(TestCase, WagtailTestU
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "wagtaildocs/chooser/upload_form.html")
         response_json = json.loads(response.content.decode())
-        self.assertEqual(response_json["step"], "reshow_upload_form")
+        self.assertEqual(response_json["step"], "reshow_creation_form")
 
         # user only has access to one collection -> should not see the collections field
         self.assertNotIn("id_collection", response_json["htmlFragment"])

--- a/wagtail/documents/views/chooser.py
+++ b/wagtail/documents/views/chooser.py
@@ -106,7 +106,7 @@ class BaseChooseView(View):
                 "title",
                 label=_("Title"),
                 url_name="wagtaildocs:document_chosen",
-                link_classname="document-choice",
+                link_attrs={"data-chooser-modal-choice": True},
             ),
             DownloadColumn("filename", label=_("File")),
             DateColumn("created_at", label=_("Created"), width="16%"),

--- a/wagtail/documents/views/chooser.py
+++ b/wagtail/documents/views/chooser.py
@@ -30,7 +30,7 @@ def get_document_chosen_response(request, document):
         None,
         None,
         json_data={
-            "step": "document_chosen",
+            "step": "chosen",
             "result": {
                 "id": document.id,
                 "title": document.title,
@@ -144,7 +144,7 @@ class ChooseView(BaseChooseView):
             None,
             self.get_context_data(),
             json_data={
-                "step": "chooser",
+                "step": "choose",
                 "tag_autocomplete_url": reverse("wagtailadmin_tag_autocomplete"),
             },
         )

--- a/wagtail/documents/views/chooser.py
+++ b/wagtail/documents/views/chooser.py
@@ -199,7 +199,7 @@ def chooser_upload(request):
         None,
         None,
         json_data={
-            "step": "reshow_upload_form",
+            "step": "reshow_creation_form",
             "htmlFragment": render_to_string(
                 "wagtaildocs/chooser/upload_form.html", {"form": form}, request
             ),

--- a/wagtail/snippets/templates/wagtailsnippets/chooser/choose.html
+++ b/wagtail/snippets/templates/wagtailsnippets/chooser/choose.html
@@ -22,7 +22,7 @@
                 <ul class="fields">
                     <li class="col">
                         <div class="field field-small">
-                            <select id="snippet-chooser-locale" name="locale_filter">
+                            <select data-chooser-modal-search-filter name="locale_filter">
                                 {% for locale_option in locale_options %}
                                     <option value="{{ locale_option.language_code }}"{% if locale_option == selected_locale %} selected{% endif %}>{{ locale_option.get_display_name }}</option>
                                 {% endfor %}

--- a/wagtail/snippets/templates/wagtailsnippets/chooser/choose.html
+++ b/wagtail/snippets/templates/wagtailsnippets/chooser/choose.html
@@ -4,7 +4,7 @@
 
 <div class="nice-padding">
     {% if is_searchable or locale or locale_options %}
-        <form class="snippet-search search-bar" action="{% url 'wagtailsnippets:choose_results' model_opts.app_label model_opts.model_name %}" method="GET" novalidate>
+        <form data-chooser-modal-search class="search-bar" action="{% url 'wagtailsnippets:choose_results' model_opts.app_label model_opts.model_name %}" method="GET" novalidate>
             {% if locale %}
                 <input type="hidden" name="locale" value="{{ locale.language_code }}">
             {% endif %}

--- a/wagtail/snippets/tests.py
+++ b/wagtail/snippets/tests.py
@@ -1352,7 +1352,8 @@ class TestSnippetChoose(TestCase, WagtailTestUtils):
 
         # Check locale filter doesn't exist normally
         self.assertNotIn(
-            '<select id="snippet-chooser-locale" name="lang">', response.json()["html"]
+            '<select data-chooser-modal-search-filter name="lang">',
+            response.json()["html"],
         )
 
     def test_ordering(self):
@@ -1389,7 +1390,7 @@ class TestSnippetChoose(TestCase, WagtailTestUtils):
 
         # Check the filter is added
         self.assertIn(
-            '<select id="snippet-chooser-locale" name="locale_filter">',
+            '<select data-chooser-modal-search-filter name="locale_filter">',
             response.json()["html"],
         )
 

--- a/wagtail/snippets/views/chooser.py
+++ b/wagtail/snippets/views/chooser.py
@@ -101,7 +101,7 @@ class BaseChooseView(View):
                     "title",
                     self.model,
                     label=_("Title"),
-                    link_classname="snippet-choice",
+                    link_attrs={"data-chooser-modal-choice": True},
                 ),
             ],
             self.paginated_items,


### PR DESCRIPTION
Incorporates #8532. Further reduce code duplication in `foo-chooser-modal.js` modules by adding a `ChooserModalOnloadHandlerFactory` class that can generate the dictionary of onload handlers to be passed to ModalWorkflow. This can be configured with a wide range of parameters (to specify things like "the jquery selector for the tab containing the creation form" that are not yet standardised across the choosers), used as-is with default settings (which will allow us to define new 'simple' chooser types with no new JS), or subclassed for deeper customisations.

Currently the snippet and document choosers use this new factory class - others will follow later.