### PR TITLE
eslint - disable perfer-default-export globally

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,7 +11,6 @@ const legacyCode = {
   'import/no-unresolved': ['error', { ignore: ['jquery'] }],
   'import/no-useless-path-segments': 'off',
   'import/order': 'off',
-  'import/prefer-default-export': 'off',
   'jsx-a11y/alt-text': 'off',
   'jsx-a11y/anchor-is-valid': 'off',
   'jsx-a11y/click-events-have-key-events': 'off',
@@ -79,6 +78,8 @@ module.exports = {
         },
       },
     ],
+    // does not align with the majority of legacy and newer code, some use named others use default exports
+    'import/prefer-default-export': 'off',
     // note you must disable the base rule as it can report incorrect errors
     'no-use-before-define': 'off',
     'react/jsx-filename-extension': ['error', { extensions: ['.js', '.tsx'] }],

--- a/client/src/includes/dialog.js
+++ b/client/src/includes/dialog.js
@@ -1,6 +1,5 @@
 import A11yDialog from 'a11y-dialog';
 
-// eslint-disable-next-line import/prefer-default-export
 export const dialog = (
   dialogs = document.querySelectorAll('[data-dialog]'),
 ) => {

--- a/client/storybook/preview.js
+++ b/client/storybook/preview.js
@@ -3,7 +3,6 @@ import '../tests/stubs';
 import '../../wagtail/admin/static_src/wagtailadmin/scss/core.scss';
 import './preview.scss';
 
-// eslint-disable-next-line import/prefer-default-export
 export const parameters = {
   controls: {
     hideNoControlsWarning: true,


### PR DESCRIPTION
- default / named exports are used in varying places and it is not a critical blocker for future code
- disable this rule and in the future it can be re-assessed or moved to the core wagtail eslint config

## Opinion

There does not appear to be a good consensus online about the best practice here, named exports seems to be the way to go for easier integration with editors but sometimes it adds an overhead to simple files that is not necessary.

For now it is more important to adopt the rest of our eslint rules across the code and this rule is a blocker for a large amount of existing code to adopt the eslint rules.