### PR TITLE
add makefile command to run test server more easily

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ help:
 	@echo "format - enforce a consistent code style across the codebase, sort python files with isort and fix frontend css/js"
 	@echo "test - run tests"
 	@echo "coverage - check code coverage"
+	@echo "run-test-server - migrates & runs local dev server with testapp"
 
 clean-pyc:
 	find . -name '*.pyc' -exec rm -f {} +
@@ -53,3 +54,9 @@ coverage:
 	coverage report -m
 	coverage html
 	open coverage_html_report/index.html
+
+run-test-server:
+	export DJANGO_SETTINGS_MODULE=wagtail.test.settings_ui
+	./wagtail/test/manage.py migrate
+	./wagtail/test/manage.py createcachetable
+	./wagtail/test/manage.py runserver 0:8000

--- a/docs/contributing/developing.md
+++ b/docs/contributing/developing.md
@@ -259,6 +259,14 @@ $ npm start
 Wagtail’s UI component library is built with [Storybook](https://storybook.js.org/) and [django-pattern-library](https://github.com/torchbox/django-pattern-library). To run it locally,
 
 ```console
+$ make run-test-server
+# In a separate terminal:
+$ npm run storybook
+```
+
+or you can run each command individually if already set up,
+
+```console
 $ export DJANGO_SETTINGS_MODULE=wagtail.test.settings_ui
 # Assumes the current environment contains a valid installation of Wagtail for local development.
 $ ./wagtail/test/manage.py migrate


### PR DESCRIPTION
* storybook requires the test server to run and doing these steps manually multiple times is a pain
* instead adding a make script to easily get the test server up & running