### PR TITLE
Fix locale selector background color

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -42,6 +42,7 @@ Changelog
  * Fix: Show the re-ordering option to users that have permission to publish pages within the page listing (Stefan Hammer)
  * Fix: Ensure `TabbedInterface` will not show a tab if no panels are visible due to permissions (Paarth Agarwal)
  * Fix: Ensure default sidebar branding (bird logo) is not cropped in RTL mode (Steven Steinwand)
+ * Fix: Specific snippets list language picker was not properly styled (Sage Abdullah)
 
 
 3.0 (16.05.2022)

--- a/client/scss/overrides/_utilities.dropdowns.scss
+++ b/client/scss/overrides/_utilities.dropdowns.scss
@@ -43,12 +43,13 @@
 }
 
 .t-inverted .u-btn-current {
+  background-color: $color-teal-darker;
   border-color: rgba(0, 0, 0, 0.35);
   color: #fff;
 }
 
 .t-inverted .u-btn-current:hover {
-  background-color: $color-teal-darker;
+  background-color: $color-teal-dark;
   border-color: rgba(0, 0, 0, 0.35);
 }
 

--- a/docs/releases/4.0.md
+++ b/docs/releases/4.0.md
@@ -56,6 +56,7 @@ When using a queryset to render a list of images, you can now use the ``prefetch
  * Only show the re-ordering option to users that have permission to publish pages within the page listing (Stefan Hammer)
  * Ensure `TabbedInterface` will not show a tab if no panels are visible due to permissions (Paarth Agarwal)
  * Ensure default sidebar branding (bird logo) is not cropped in RTL mode (Steven Steinwand)
+ * Specific snippets list language picker was not properly styled (Sage Abdullah)
 
 
 ## Upgrade considerations

--- a/wagtail/admin/templates/wagtailadmin/shared/header_with_locale_selector.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/header_with_locale_selector.html
@@ -7,7 +7,7 @@
             {% if locale %}
                 <li class="col">
                     <div class="field">
-                        {% include 'wagtailadmin/shared/locale_selector.html' with class='c-dropdown--large w-bg-primary' %}
+                        {% include 'wagtailadmin/shared/locale_selector.html' with class='c-dropdown--large' %}
                     </div>
                 </li>
             {% endif %}


### PR DESCRIPTION
Fixes #8588. Should be backported to 3.0.x.

## Before

<img width="1504" alt="image" src="https://user-images.githubusercontent.com/6379424/170180430-3d1ca235-488c-4fe6-bc47-859666eae882.png">

In addition, I think the locale selector on the Forms section isn't supposed to be indigo yet because it's inconsistent:

<img width="1504" alt="image" src="https://user-images.githubusercontent.com/6379424/170180341-84ea06f0-0e48-4a6f-8d43-d200761a56ed.png">

Hence, the fix is...

## After

### Normal

<img width="1455" alt="image" src="https://user-images.githubusercontent.com/6379424/170179442-05fceea7-45d6-465e-bc63-afda6f797a04.png">

<img width="1504" alt="image" src="https://user-images.githubusercontent.com/6379424/170181284-0600ef88-6b67-4dfd-a2e8-ac660bed5d93.png">

### On hover

(I activated hover state on both the locale selector and the "Add" button to show that they use the same color.)
<img width="1455" alt="image" src="https://user-images.githubusercontent.com/6379424/170179481-844acfb8-af32-4e67-a930-5664a7171b9a.png">

## Backport to 2.15.x?

The CSS fix should probably backported to 2.15.x as well. See details.
<details>
In 2.15.x, the locale selector background colour doesn't match the other buttons because it's transparent:

### Before

#### Normal
<img width="418" alt="image" src="https://user-images.githubusercontent.com/6379424/170179988-c5bd8b73-5439-4299-87be-699419fe9da4.png">

#### On hover
<img width="418" alt="image" src="https://user-images.githubusercontent.com/6379424/170180083-40dfab64-4564-49bc-b24f-0eba08bbf593.png">

### After

#### Normal
<img width="408" alt="image" src="https://user-images.githubusercontent.com/6379424/170178769-b38fb5d2-2af2-4ba0-9cc7-90025640d74d.png">

#### On hover
<img width="408" alt="image" src="https://user-images.githubusercontent.com/6379424/170178854-72b6bbe1-33bb-4b97-bc23-7ed7cab4e2ea.png">
</details>