### PR TITLE
Add lazy loading and async decoding to images

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -7,6 +7,7 @@ Changelog
 
  * Add basic keyboard control and screen reader support for page listing re-ordering (Paarth Agarwal, Thomas van der Hoeven)
  * Add `PageQuerySet.private` method as an alias of `not_public` (Mehrdad Moradizadeh)
+ * Most images in the admin will now only load once they are visible on screen (Jake Howard)
  * Allow setting default attributes on image tags (Jake Howard)
  * Fix: Prevent `PageQuerySet.not_public` from returning all pages when no page restrictions exist (Mehrdad Moradizadeh)
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -7,6 +7,7 @@ Changelog
 
  * Add basic keyboard control and screen reader support for page listing re-ordering (Paarth Agarwal, Thomas van der Hoeven)
  * Add `PageQuerySet.private` method as an alias of `not_public` (Mehrdad Moradizadeh)
+ * Allow setting default attributes on image tags (Jake Howard)
  * Fix: Prevent `PageQuerySet.not_public` from returning all pages when no page restrictions exist (Mehrdad Moradizadeh)
 
 

--- a/client/src/components/CommentApp/components/CommentHeader/index.tsx
+++ b/client/src/components/CommentApp/components/CommentHeader/index.tsx
@@ -151,7 +151,13 @@ export const CommentHeader: FunctionComponent<CommentHeaderProps> = ({
         )}
       </div>
       {author && author.avatarUrl && (
-        <img className="comment-header__avatar" src={author.avatarUrl} alt="" />
+        <img
+          className="comment-header__avatar"
+          src={author.avatarUrl}
+          alt=""
+          decoding="async"
+          loading="lazy"
+        />
       )}
       <span id={descriptionId}>
         <p className="comment-header__author">{author ? author.name : ''}</p>

--- a/client/src/components/Draftail/blocks/MediaBlock.js
+++ b/client/src/components/Draftail/blocks/MediaBlock.js
@@ -117,7 +117,14 @@ class MediaBlock extends Component {
         <span className="MediaBlock__icon-wrapper" aria-hidden>
           <Icon icon={entityType.icon} className="MediaBlock__icon" />
         </span>
-        <img className="MediaBlock__img" src={src} alt={alt} width="256" />
+        <img
+          className="MediaBlock__img"
+          src={src}
+          alt={alt}
+          width="256"
+          decoding="async"
+          loading="lazy"
+        />
 
         {src ? null : (
           <span className="MediaBlock__fallback">{fallbackText}</span>

--- a/client/src/components/Draftail/blocks/__snapshots__/MediaBlock.test.js.snap
+++ b/client/src/components/Draftail/blocks/__snapshots__/MediaBlock.test.js.snap
@@ -20,6 +20,8 @@ exports[`MediaBlock no data, no fallback 1`] = `
   <img
     alt=""
     className="MediaBlock__img"
+    decoding="async"
+    loading="lazy"
     src=""
     width="256"
   />
@@ -49,6 +51,8 @@ exports[`MediaBlock no data, with fallback 1`] = `
   <img
     alt=""
     className="MediaBlock__img"
+    decoding="async"
+    loading="lazy"
     src=""
     width="256"
   />
@@ -100,6 +104,8 @@ exports[`MediaBlock renders 1`] = `
   <img
     alt=""
     className="MediaBlock__img"
+    decoding="async"
+    loading="lazy"
     src="example.png"
     width="256"
   />

--- a/client/src/components/Sidebar/modules/MainMenu.tsx
+++ b/client/src/components/Sidebar/modules/MainMenu.tsx
@@ -239,7 +239,12 @@ export const Menu: React.FunctionComponent<MenuProps> = ({
             type="button"
           >
             <div className="avatar avatar-on-dark w-flex-shrink-0 !w-w-[28px] !w-h-[28px]">
-              <img src={user.avatarUrl} alt="" />
+              <img
+                src={user.avatarUrl}
+                alt=""
+                decoding="async"
+                loading="lazy"
+              />
             </div>
             <div className="sidebar-footer__account-toggle">
               <div className="sidebar-footer__account-label w-label-3">

--- a/client/src/components/Sidebar/modules/__snapshots__/MainMenu.test.js.snap
+++ b/client/src/components/Sidebar/modules/__snapshots__/MainMenu.test.js.snap
@@ -46,6 +46,8 @@ exports[`Menu should render with the minimum required props 1`] = `
         >
           <img
             alt=""
+            decoding="async"
+            loading="lazy"
             src="https://gravatar/profile"
           />
         </div>

--- a/docs/advanced_topics/performance.md
+++ b/docs/advanced_topics/performance.md
@@ -83,3 +83,9 @@ TEMPLATES = [{
 To support high volumes of traffic with excellent response times, we recommend a caching proxy. Both [Varnish](https://varnish-cache.org/) and [Squid](http://www.squid-cache.org/) have been tested in production. Hosted proxies like [Cloudflare](https://www.cloudflare.com/) should also work well.
 
 Wagtail supports automatic cache invalidation for Varnish/Squid. See [](frontend_cache_purging) for more information.
+
+### Image attributes
+
+For some images, it may be beneficial to lazy load images, so the rest of the page can continue to load. It can be configured site-wide [](adding_default_attributes_to_images) or per-image [](image_tag_alt). For more details you can read about the [`loading='lazy'` attribute](https://developer.mozilla.org/en-US/docs/Web/Performance/Lazy_loading#images_and_iframes) and the [`'decoding='async'` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#attr-decoding) or this [web.dev article on lazy loading images](https://web.dev/lazy-loading-images/).
+
+This optimisation is already handled for you for images in the admin site.

--- a/docs/releases/4.1.md
+++ b/docs/releases/4.1.md
@@ -15,7 +15,7 @@ Wagtail 4.1 is designated a Long Term Support (LTS) release. Long Term Support r
 
  * Add basic keyboard control and screen reader support for page listing re-ordering (Paarth Agarwal, Thomas van der Hoeven)
  * Add `PageQuerySet.private` method as an alias of `not_public` (Mehrdad Moradizadeh)
-
+ * Most images in the admin will now only load once they are visible on screen (Jake Howard)
  * Allow setting default attributes on image tags [](adding_default_attributes_to_images) (Jake Howard)
 
 ### Bug fixes

--- a/docs/releases/4.1.md
+++ b/docs/releases/4.1.md
@@ -16,10 +16,10 @@ Wagtail 4.1 is designated a Long Term Support (LTS) release. Long Term Support r
  * Add basic keyboard control and screen reader support for page listing re-ordering (Paarth Agarwal, Thomas van der Hoeven)
  * Add `PageQuerySet.private` method as an alias of `not_public` (Mehrdad Moradizadeh)
 
+ * Allow setting default attributes on image tags [](adding_default_attributes_to_images) (Jake Howard)
 
 ### Bug fixes
 
  * Prevent `PageQuerySet.not_public` from returning all pages when no page restrictions exist (Mehrdad Moradizadeh)
-
 
 ## Upgrade considerations

--- a/docs/topics/images.md
+++ b/docs/topics/images.md
@@ -161,7 +161,7 @@ Wagtail does not allow deforming or stretching images. Image dimension ratios wi
 
 Wagtail provides two shortcuts to give greater control over the `img` element:
 
-**1. Adding attributes to the {% image %} tag**
+### 1. Adding attributes to the {% image %} tag
 
 Extra attributes can be specified with the syntax `attribute="value"`:
 
@@ -171,7 +171,9 @@ Extra attributes can be specified with the syntax `attribute="value"`:
 
 You can set a more relevant `alt` attribute this way, overriding the one automatically generated from the title of the image. The `src`, `width`, and `height` attributes can also be overridden, if necessary.
 
-**2. Generating the image "as foo" to access individual properties**
+You can also add default attributes to all images (a default class or data attribute for example) - see [](adding_default_attributes_to_images).
+
+### 2. Generating the image "as foo" to access individual properties
 
 Wagtail can assign the image data to another variable using Django's `as` syntax:
 
@@ -227,6 +229,35 @@ If your site defines a custom image model using `AbstractImage`, any additional 
 Therefore, if you'd added the field `author` to your AbstractImage in the above example, you'd access it using `{{ page.photo.author }}` rather than `{{ tmp_photo.author }}`.
 
 (Due to the links in the database between renditions and their parent image, you _could_ access it as `{{ tmp_photo.image.author }}`, but that has reduced readability.)
+
+(adding_default_attributes_to_images)=
+
+## Adding default attributes to all images
+
+We can configure the `wagtail.images` application to specify additional attributes to add to images. This is done by setting up a custom `AppConfig` class within your project folder (i.e. the package containing the top-level settings and urls modules).
+
+To do this, create or update your existing `apps.py` file with the following:
+
+```python
+from wagtail.images.apps import WagtailImagesAppConfig
+
+
+class CustomImagesAppConfig(WagtailImagesAppConfig):
+    default_attrs = {"decoding": "async", "loading": "lazy"}
+```
+
+Then, replace `wagtail.images` in `settings.INSTALLED_APPS` with the path to `CustomUsersAppConfig`:
+
+```python
+INSTALLED_APPS = [
+    ...,
+    "myapplication.apps.CustomImagesAppConfig",
+    # "wagtail.images",
+    ...,
+]
+```
+
+Now, images created with `{% image %}` will additionally have `decoding="async" loading="lazy"` attributes. This also goes for images added to Rich Text and `ImageBlock` blocks.
 
 ## Alternative HTML tags
 

--- a/wagtail/admin/templates/wagtailadmin/pages/workflow_history/detail.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/workflow_history/detail.html
@@ -18,7 +18,7 @@
 
         <p>
             {% blocktrans trimmed with modified_by=workflow_state.requested_by|user_display_name %}Requested by <b>{{ modified_by }}</b>{% endblocktrans %}
-            <span class="avatar small"><img src="{% avatar_url workflow_state.requested_by size=25 %}" alt="" /></span>
+            <span class="avatar small"><img src="{% avatar_url workflow_state.requested_by size=25 %}" alt="" decoding="async" loading="lazy"/></span>
         </p>
 
         <p>

--- a/wagtail/admin/templates/wagtailadmin/shared/user_avatar.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/user_avatar.html
@@ -1,7 +1,7 @@
 {% load wagtailadmin_tags %}
 
 <span class="avatar small">
-    <img src="{% avatar_url user size=25 %}" alt="" />
+    <img src="{% avatar_url user size=25 %}" alt="" decoding="async" loading="lazy"/>
 </span>
 
 {% if not username %}{{ user }}{% else %}{{ username }}{% endif %}

--- a/wagtail/contrib/modeladmin/mixins.py
+++ b/wagtail/contrib/modeladmin/mixins.py
@@ -41,6 +41,8 @@ class ThumbnailMixin:
             "src": self.thumb_default,
             "width": self.thumb_image_width,
             "class": self.thumb_classname,
+            "decoding": "async",
+            "loading": "lazy",
         }
         if not image:
             if self.thumb_default:

--- a/wagtail/contrib/modeladmin/templates/modeladmin/includes/header_with_history.html
+++ b/wagtail/contrib/modeladmin/templates/modeladmin/includes/header_with_history.html
@@ -6,7 +6,7 @@
         {% if latest_log_entry %}
             <ul>
                 <li>
-                    <span class="avatar small" data-wagtail-tooltip="{{ latest_log_entry.user_display_name }}"><img src="{% avatar_url latest_log_entry.user size=25 %}" alt="" /></span>
+                    <span class="avatar small" data-wagtail-tooltip="{{ latest_log_entry.user_display_name }}"><img src="{% avatar_url latest_log_entry.user size=25 %}" alt="" decoding="async" loading="async" /></span>
                     {% trans "Last updated" %}
                     {% include "wagtailadmin/shared/last_updated.html" with last_updated=latest_log_entry.timestamp time_prefix="at" %}
                 </li>

--- a/wagtail/embeds/finders/embedly.py
+++ b/wagtail/embeds/finders/embedly.py
@@ -1,3 +1,5 @@
+from django.utils.html import format_html
+
 from wagtail.embeds.exceptions import EmbedException, EmbedNotFoundException
 
 from .base import EmbedFinder
@@ -52,7 +54,7 @@ class EmbedlyFinder(EmbedFinder):
 
         # Convert photos into HTML
         if oembed["type"] == "photo":
-            html = '<img src="%s" alt="">' % (oembed["url"],)
+            html = format_html('<img src="{}" alt="">', oembed["url"])
         else:
             html = oembed.get("html")
 

--- a/wagtail/images/apps.py
+++ b/wagtail/images/apps.py
@@ -11,6 +11,7 @@ class WagtailImagesAppConfig(AppConfig):
     label = "wagtailimages"
     verbose_name = _("Wagtail images")
     default_auto_field = "django.db.models.AutoField"
+    default_attrs = {}
 
     def ready(self):
         register_signal_handlers()

--- a/wagtail/images/models.py
+++ b/wagtail/images/models.py
@@ -7,6 +7,7 @@ from contextlib import contextmanager
 from io import BytesIO
 from typing import Union
 
+from django.apps import apps
 from django.conf import settings
 from django.core import checks
 from django.core.cache import InvalidCacheBackendError, caches
@@ -826,7 +827,11 @@ class AbstractRendition(ImageFileMixin, models.Model):
 
     def img_tag(self, extra_attributes={}):
         attrs = self.attrs_dict.copy()
+
+        attrs.update(apps.get_app_config("wagtailimages").default_attrs)
+
         attrs.update(extra_attributes)
+
         return mark_safe("<img{}>".format(flatatt(attrs)))
 
     def __html__(self):

--- a/wagtail/images/templates/wagtailimages/images/edit.html
+++ b/wagtail/images/templates/wagtailimages/images/edit.html
@@ -66,7 +66,7 @@
                     data-focal-point-height="{{ image.focal_point_height|default_if_none:'' }}"
                     data-focal-input-label="{% trans 'Image focal point' %}"
                 >
-                    <img {{ rendition.attrs }} data-original-width="{{ image.width|unlocalize }}" data-original-height="{{ image.height|unlocalize }}" class="show-transparency">
+                    <img {{ rendition.attrs }} decoding="async" data-original-width="{{ image.width|unlocalize }}" data-original-height="{{ image.height|unlocalize }}" class="show-transparency">
                     <div class="current-focal-point-indicator{% if not image.has_focal_point %} hidden{% endif %}"></div>
                 </div>
 

--- a/wagtail/images/templates/wagtailimages/widgets/image_chooser.html
+++ b/wagtail/images/templates/wagtailimages/widgets/image_chooser.html
@@ -2,5 +2,5 @@
 
 {% block chosen_icon %}
     {# Empty alt because the chosen item’s title is already displayed next to the image. #}
-    <img class="chooser__image" data-chooser-image alt="" class="show-transparency" height="{{ preview.height }}" src="{{ preview.url }}" width="{{ preview.width }}">
+    <img class="chooser__image" data-chooser-image alt="" class="show-transparency" decoding="async" height="{{ preview.height }}" src="{{ preview.url }}" width="{{ preview.width }}">
 {% endblock chosen_icon %}

--- a/wagtail/images/tests/test_blocks.py
+++ b/wagtail/images/tests/test_blocks.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*
 import os
+import unittest.mock
 
+from django.apps import apps
 from django.conf import settings
 from django.core import serializers
 from django.test import TestCase
@@ -54,6 +56,19 @@ class TestImageChooserBlock(TestCase):
         )
 
         self.assertHTMLEqual(html, expected_html)
+
+    def test_render_with_custom_default_attrs(self):
+        block = ImageChooserBlock()
+        with unittest.mock.patch.object(
+            apps.get_app_config("wagtailimages"),
+            "default_attrs",
+            new={"decoding": "async", "loading": "lazy"},
+        ):
+            html = block.render(self.bad_image)
+        self.assertHTMLEqual(
+            html,
+            '<img alt="missing image" src="/media/not-found" width="0" height="0" decoding="async" loading="lazy">',
+        )
 
     def test_render_missing(self):
         block = ImageChooserBlock()

--- a/wagtail/images/tests/test_jinja2.py
+++ b/wagtail/images/tests/test_jinja2.py
@@ -1,6 +1,8 @@
 import os
+import unittest.mock
 
 from django import template
+from django.apps import apps
 from django.conf import settings
 from django.core import serializers
 from django.template import engines
@@ -98,6 +100,19 @@ class TestImagesJinja(TestCase):
     def test_invalid_character(self):
         with self.assertRaises(template.TemplateSyntaxError):
             self.render('{{ image(myimage, "fill-200×200") }}', {"myimage": self.image})
+
+    def test_custom_default_attrs(self):
+        with unittest.mock.patch.object(
+            apps.get_app_config("wagtailimages"),
+            "default_attrs",
+            new={"decoding": "async", "loading": "lazy"},
+        ):
+            self.assertHTMLEqual(
+                self.render(
+                    '{{ image(myimage, "width-200") }}', {"myimage": self.bad_image}
+                ),
+                '<img alt="missing image" src="/media/not-found" width="0" height="0" decoding="async" loading="lazy">',
+            )
 
     def test_chaining_filterspecs(self):
         self.assertHTMLEqual(

--- a/wagtail/images/tests/tests.py
+++ b/wagtail/images/tests/tests.py
@@ -211,7 +211,8 @@ class TestMissingImage(TestCase):
         response = self.client.get("/events/christmas/")
         self.assertContains(
             response,
-            '<img src="/media/not-found" width="0" height="0" alt="A missing image" class="feed-image">',
+            '<img src="/media/not-found" width="0" height="0" alt="A missing image" \
+            class="feed-image">',
             html=True,
         )
 

--- a/wagtail/snippets/templates/wagtailsnippets/snippets/_header_with_history.html
+++ b/wagtail/snippets/templates/wagtailsnippets/snippets/_header_with_history.html
@@ -6,7 +6,7 @@
         <div class="row last-updated">
             <ul>
                 <li>
-                    <span class="avatar small" data-wagtail-tooltip="{{ latest_log_entry.user_display_name }}"><img src="{% avatar_url latest_log_entry.user size=25 %}" alt="" /></span>
+                    <span class="avatar small" data-wagtail-tooltip="{{ latest_log_entry.user_display_name }}"><img src="{% avatar_url latest_log_entry.user size=25 %}" alt="" decoding="async" loading="lazy"/></span>
                     {% trans "Last updated" %}
                     {% include "wagtailadmin/shared/last_updated.html" with last_updated=latest_log_entry.timestamp time_prefix="at" %}
                 </li>

--- a/wagtail/users/templates/wagtailusers/users/list.html
+++ b/wagtail/users/templates/wagtailusers/users/list.html
@@ -36,7 +36,7 @@
                 {% include "wagtailadmin/bulk_actions/listing_checkbox_cell.html" with obj_type="user" obj=user aria_labelledby_prefix="user_" aria_labelledby=user.pk|unlocalize aria_labelledby_suffix="_title" %}
                 <td id="user_{{ user.pk|unlocalize }}_title" class="title" valign="top">
                     <div class="title-wrapper">
-                        <span class="avatar small"><img src="{% avatar_url user size=25 %}" alt="" /></span>
+                        <span class="avatar small"><img src="{% avatar_url user size=25 %}" alt="" decoding="async" loading="lazy"/></span>
                         <a href="{% url 'wagtailusers_users:edit' user.pk %}">{{ user|user_display_name }}</a>
                     </div>
                     <ul class="actions">


### PR DESCRIPTION
This improves page responsiveness on first load, especially on pages with many images (eg images list in Wagtail admin)


_Please check the following:_

- [x] Do the tests still pass?[^1]
- [x] Does the code comply with the style guide? 
    - [x] Run `make lint` from the Wagtail root. 
- [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
- [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    - [ ] **Please list the exact browser and operating system versions you tested**:
    - [ ] **Please list which assistive technologies [^3] you tested**: 
- [x] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**. 

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets) 
