### PR TITLE
Make `ReportView` extend from generic `IndexView`

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -30,6 +30,7 @@ Changelog
  * Combine most of Wagtail’s stylesheets into the global `core.css` file (Thibaud Colas)
  * Add new Breadcrumbs to the Wagtail pattern library (Paarth Agarwal)
  * Adopt new Page Editor UI tabs in the workflow history report page (Paarth Agarwal)
+ * Update `ReportView` to extend from generic `wagtail.admin.views.generic.models.IndexView` (Sage Abdullah)
  * Fix: Typo in `ResumeWorkflowActionFormatter` message (Stefan Hammer)
  * Fix: Throw a meaningful error when saving an image to an unrecognised image format (Christian Franke)
  * Fix: Remove extra padding for headers with breadcrumbs on mobile viewport (Steven Steinwand)

--- a/docs/releases/4.0.md
+++ b/docs/releases/4.0.md
@@ -39,6 +39,7 @@ When using a queryset to render a list of images, you can now use the ``prefetch
  * Combine most of Wagtail’s stylesheets into the global `core.css` file (Thibaud Colas)
  * Add new Breadcrumbs to the Wagtail pattern library (Paarth Agarwal)
  * Adopt new Page Editor UI tabs in the workflow history report page (Paarth Agarwal)
+ * Update `ReportView` to extend from generic `wagtail.admin.views.generic.models.IndexView` (Sage Abdullah)
 
 ### Bug fixes
 

--- a/wagtail/admin/views/generic/models.py
+++ b/wagtail/admin/views/generic/models.py
@@ -75,6 +75,8 @@ class IndexView(
 
     def setup(self, request, *args, **kwargs):
         super().setup(request, *args, **kwargs)
+        if not hasattr(self, "columns"):
+            self.columns = self.get_columns()
         self.setup_search()
 
     def setup_search(self):
@@ -115,12 +117,6 @@ class IndexView(
             placeholder=_("Search %(model_name)s")
             % {"model_name": self.model._meta.verbose_name_plural}
         )
-
-    def get(self, request, *args, **kwargs):
-        if not hasattr(self, "columns"):
-            self.columns = self.get_columns()
-
-        return super().get(request, *args, **kwargs)
 
     def get_columns(self):
         try:

--- a/wagtail/admin/views/reports/base.py
+++ b/wagtail/admin/views/reports/base.py
@@ -1,13 +1,10 @@
 from django.utils.translation import gettext_lazy as _
-from django.views.generic.base import TemplateResponseMixin, View
-from django.views.generic.list import MultipleObjectMixin
 
+from wagtail.admin.views.generic.models import IndexView
 from wagtail.admin.views.mixins import SpreadsheetExportMixin
 
 
-class ReportView(
-    SpreadsheetExportMixin, TemplateResponseMixin, MultipleObjectMixin, View
-):
+class ReportView(SpreadsheetExportMixin, IndexView):
     header_icon = ""
     page_kwarg = "p"
     template_name = "wagtailadmin/reports/base_report.html"


### PR DESCRIPTION
This is a small refactoring to make it easier to use the tables UI framework in a Report view. The columns and tables initialisation is already done in the generic `IndexView`, so Report views can just declare the columns and use `{% component table %}` in the templates.

_Please check the following:_

-   [x] Do the tests still pass?
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.