### PR TITLE
Prefetch workflow states in edit page view

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -52,6 +52,7 @@ Changelog
  * Replace human-readable-date hover pattern with accessible tooltip variant across all of admin (Bernd de Ridder)
  * Add legacy and new status tags to the pattern library (Steven Steinwand)
  * Added `WAGTAILADMIN_USER_PASSWORD_RESET_FORM` setting for overriding the admin password reset form (Michael Karamuth)
+ * Prefetch workflow states in edit page view to to avoid queries in other parts of the view/templates that need it (Tidiane Dia)
  * Fix: Typo in `ResumeWorkflowActionFormatter` message (Stefan Hammer)
  * Fix: Throw a meaningful error when saving an image to an unrecognised image format (Christian Franke)
  * Fix: Remove extra padding for headers with breadcrumbs on mobile viewport (Steven Steinwand)

--- a/docs/releases/4.0.md
+++ b/docs/releases/4.0.md
@@ -59,6 +59,7 @@ When using a queryset to render a list of images, you can now use the `prefetch_
  * Replace human-readable-date hover pattern with accessible tooltip variant across all of admin (Bernd de Ridder)
  * Add legacy and new status tags to the pattern library (Steven Steinwand)
  * Added `WAGTAILADMIN_USER_PASSWORD_RESET_FORM` setting for overriding the admin password reset form (Michael Karamuth)
+ * Prefetch workflow states in edit page view to to avoid queries in other parts of the view/templates that need it (Tidiane Dia)
 
 ### Bug fixes
 

--- a/wagtail/admin/tests/pages/test_edit_page.py
+++ b/wagtail/admin/tests/pages/test_edit_page.py
@@ -1269,6 +1269,12 @@ class TestPageEdit(TestCase, WagtailTestUtils):
             response, reverse("wagtailadmin_pages:edit", args=(self.child_page.id,))
         )
 
+    def test_page_edit_num_queries(self):
+        with self.assertNumQueries(53):
+            self.client.get(
+                reverse("wagtailadmin_pages:edit", args=(self.event_page.id,))
+            )
+
 
 class TestPageEditReordering(TestCase, WagtailTestUtils):
     def setUp(self):

--- a/wagtail/admin/views/pages/edit.py
+++ b/wagtail/admin/views/pages/edit.py
@@ -312,7 +312,9 @@ class EditView(TemplateResponseMixin, ContextMixin, HookResponseMixin, View):
             return self.page
 
     def dispatch(self, request, page_id):
-        self.real_page_record = get_object_or_404(Page, id=page_id)
+        self.real_page_record = get_object_or_404(
+            Page.objects.prefetch_workflow_states(), id=page_id
+        )
         self.latest_revision = self.real_page_record.get_latest_revision()
         self.page_content_type = self.real_page_record.cached_content_type
         self.page_class = self.real_page_record.specific_class


### PR DESCRIPTION
The goal of the PR is to make use of the `prefetch_workflow_states` method in the edit page view to avoid queries in other parts of the view/templates that need it.

I've added before/after commits to show the gains.

-   [ ] Do the tests still pass?[^1]
-   [ ] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?