### PR TITLE
Fix RTL sidebar branding cropping

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -41,6 +41,7 @@ Changelog
  * Fix: Ensure the upgrade notification, shown to admins on the dashboard if Wagtail is out of date, content is translatable (LB (Ben) Johnston)
  * Fix: Show the re-ordering option to users that have permission to publish pages within the page listing (Stefan Hammer)
  * Fix: Ensure `TabbedInterface` will not show a tab if no panels are visible due to permissions (Paarth Agarwal)
+ * Fix: Ensure default sidebar branding (bird logo) is not cropped in RTL mode (Steven Steinwand)
 
 
 3.0 (16.05.2022)

--- a/client/src/components/Sidebar/Sidebar.stories.tsx
+++ b/client/src/components/Sidebar/Sidebar.stories.tsx
@@ -6,6 +6,7 @@ import { MainMenuModuleDefinition } from './modules/MainMenu';
 import { PageExplorerMenuItemDefinition } from './menu/PageExplorerMenuItem';
 import { LinkMenuItemDefinition } from './menu/LinkMenuItem';
 import { SubMenuItemDefinition } from './menu/SubMenuItem';
+import { WagtailBrandingModuleDefinition } from './modules/WagtailBranding';
 
 export default {
   title: 'Sidebar/Sidebar',
@@ -188,6 +189,10 @@ function renderSidebarStory(
   modules: ModuleDefinition[],
   { rtl = false }: RenderSidebarStoryOptions = {},
 ) {
+  // Add branding to all sidebar stories by default
+  const wagtailBrandingModule = new WagtailBrandingModuleDefinition('');
+  modules.unshift(wagtailBrandingModule);
+
   // Simulate navigation
   const [currentPath, setCurrentPath] = React.useState('/admin/');
 
@@ -347,7 +352,7 @@ export function withLargeSubmenu() {
 }
 
 export function withoutSearch() {
-  return renderSidebarStory([wagtailBrandingModule(), bogStandardMenuModule()]);
+  return renderSidebarStory([bogStandardMenuModule()]);
 }
 
 function arabicMenuModule(): MainMenuModuleDefinition {

--- a/client/src/components/Sidebar/modules/WagtailLogo.tsx
+++ b/client/src/components/Sidebar/modules/WagtailLogo.tsx
@@ -11,10 +11,12 @@ const WagtailLogo = ({ className, slim }: WagtailLogoProps) => {
 
   return (
     <svg
+      style={{
+        left: slim ? '-1.125rem' : '-1.75rem',
+      }}
       className={`
          sidebar-wagtail-branding__icon
          !w-overflow-visible
-         w-pr-6
          w-group
          w-text-primary
          w-z-10
@@ -26,8 +28,8 @@ const WagtailLogo = ({ className, slim }: WagtailLogoProps) => {
          ${className || ''}
          ${
            slim
-             ? 'w-w-[58px] w-h-[57px] w-top-2 w-left-[-18px] hover:-w-translate-y-1'
-             : 'w-w-[120px] w-h-[200px] -w-top-1 -w-left-7 hover:w-translate-x-2 hover:-w-translate-y-3'
+             ? 'w-w-[58px] w-h-[57px] w-top-2 hover:-w-translate-y-1'
+             : 'w-w-[120px] w-h-[200px] -w-top-1  hover:w-translate-x-2 hover:-w-translate-y-3'
          }
       `}
       width="430"

--- a/docs/releases/4.0.md
+++ b/docs/releases/4.0.md
@@ -55,6 +55,7 @@ When using a queryset to render a list of images, you can now use the ``prefetch
  * Ensure the upgrade notification, shown to admins on the dashboard if Wagtail is out of date, content is translatable (LB (Ben) Johnston)
  * Only show the re-ordering option to users that have permission to publish pages within the page listing (Stefan Hammer)
  * Ensure `TabbedInterface` will not show a tab if no panels are visible due to permissions (Paarth Agarwal)
+ * Ensure default sidebar branding (bird logo) is not cropped in RTL mode (Steven Steinwand)
 
 
 ## Upgrade considerations


### PR DESCRIPTION
Addresses #8641: Sidebar branding isn't showing correctly when using RTL html styling.

### Changes made
- Updated styling of the `sidebar-wagtail-branding__icon` to not change position when switching to RTL languages.

**Screenshot**
![Screen Shot 2022-06-07 at 5 10 18 PM](https://user-images.githubusercontent.com/25041665/172501244-766e14f3-5175-4e78-9d12-aa592a7a7a73.png)


- Also updated storybook to show wagtail branding on all sidebar stories (as this wasn't showing before)

https://user-images.githubusercontent.com/25041665/172501291-79337cf5-0352-4619-a855-a480500d248b.mp4

_Please check the following:_

-   [X] Do the tests still pass?[^1]
-   [X] Does the code comply with the style guide?
    -   [X] Run `make lint` from the Wagtail root.
-   [X] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [X] **Please list the exact browser and operating system versions you tested**:

**Please describe additional details for testing this change**.
The storybook changes can be tested by using wagtail's storybook setup

The logo crop issue can be tested by inspecting wagtail's admin and changing the direction to `dir="rtl"`of the html element. 
![Screen Shot 2022-06-07 at 5 42 55 PM](https://user-images.githubusercontent.com/25041665/172501493-b81eb3b2-a485-4c5f-9554-08a99c949cd3.png)
