### PR TITLE
Add icon attribute to settings models to be shown in header

### DIFF
--- a/docs/reference/contrib/settings.rst
+++ b/docs/reference/contrib/settings.rst
@@ -88,7 +88,10 @@ Appearance
 
 You can change the label used in the menu by changing the :attr:`~django.db.models.Options.verbose_name` of your model.
 
-You can add an icon to the menu by passing an 'icon' argument to the ``register_setting`` decorator:
+You can add an icon to the menu by passing an 'icon' argument to the
+``register_setting`` decorator, and customize the icon in the header by setting
+``icon`` on the class:
+
 
 .. code-block:: python
 
@@ -96,6 +99,8 @@ You can add an icon to the menu by passing an 'icon' argument to the ``register_
     class SocialMediaSettings(BaseSetting):
         class Meta:
             verbose_name = 'social media accounts'
+
+        icon = 'placeholder'
         ...
 
 For a list of all available icons, please see the :ref:`styleguide`.

--- a/wagtail/contrib/settings/models.py
+++ b/wagtail/contrib/settings/models.py
@@ -22,6 +22,8 @@ class BaseSetting(models.Model):
         Site, unique=True, db_index=True, editable=False, on_delete=models.CASCADE
     )
 
+    icon = "cogs"
+
     class Meta:
         abstract = True
 

--- a/wagtail/contrib/settings/templates/wagtailsettings/edit.html
+++ b/wagtail/contrib/settings/templates/wagtailsettings/edit.html
@@ -8,7 +8,7 @@
             <div class="left">
                 <div class="col">
                     <h1 class="header__title">
-                        {% icon name="cogs" %}
+                        {% icon name=instance.icon %}
                         {% trans "Editing" %}
                         <span class="header__subtitle">{{ setting_type_name|capfirst }}</span>
                     </h1>


### PR DESCRIPTION
Currently, when specifying an icon to register a custom setting, the icon is only shown in the menu. It is not shown in the header. The header is hard-coded to show `cogs`. However Wagtail's own settings do show a custom icon in the header. This makes any user-defined settings feel a bit second-class and inconsistent. https://docs.wagtail.org/en/stable/reference/contrib/settings.html#appearance

This change adds an `icon` attribute to the settings model, which is used in the header.

**I totally understand that this is not a good solution**, but hopefully this is a starting point to get this UI inconsistency fixed. I would prefer that `@register_setting()` automatically wires up the icon in both the menu and the header - but that seems a bit impossible based on the current implementation.

