### PR TITLE
Disable Webpack css-loader URL handling in Storybook. Fix #8646

### DIFF
--- a/client/storybook/main.js
+++ b/client/storybook/main.js
@@ -22,7 +22,12 @@ module.exports = {
         test: /\.(scss|css)$/,
         use: [
           'style-loader',
-          'css-loader',
+          {
+            loader: 'css-loader',
+            options: {
+              url: false,
+            },
+          },
           {
             loader: 'postcss-loader',
             options: {


### PR DESCRIPTION
Fixes #8646. This issue was due to us building CSS differently in Storybook – we disabled Webpack’s URL handling in #8518, and forgot to do the same thing in Storybook. This wasn’t a problem up until #8564, which loads the Jcrop GIF with the assumption URL handling is turned off.

---

This fix will just prevent the error, this isn’t enough to actually have the GIF load in Storybook – but I think it’s not really likely we’d want to test Jcrop in Storybook anyway.