### PR TITLE
Redirects import page does not need header search JS

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -44,6 +44,7 @@ Changelog
  * Fix: Ensure default sidebar branding (bird logo) is not cropped in RTL mode (Steven Steinwand)
  * Fix: Specific snippets list language picker was not properly styled (Sage Abdullah)
  * Fix: Add an accessible label to the image focal point input when editing images (Lucie Le Frapper)
+ * Fix: Remove unused header search JavaScript on the redirects import page (LB (Ben) Johnston)
 
 
 3.0 (16.05.2022)

--- a/docs/releases/4.0.md
+++ b/docs/releases/4.0.md
@@ -58,6 +58,7 @@ When using a queryset to render a list of images, you can now use the ``prefetch
  * Ensure default sidebar branding (bird logo) is not cropped in RTL mode (Steven Steinwand)
  * Specific snippets list language picker was not properly styled (Sage Abdullah)
  * Add an accessible label to the image focal point input when editing images (Lucie Le Frapper)
+ * Remove unused header search JavaScript on the redirects import page (LB (Ben) Johnston)
 
 
 ## Upgrade considerations

--- a/wagtail/contrib/redirects/templates/wagtailredirects/choose_import_file.html
+++ b/wagtail/contrib/redirects/templates/wagtailredirects/choose_import_file.html
@@ -2,17 +2,6 @@
 {% load i18n wagtailadmin_tags %}
 {% block titletag %}{% trans "Redirects" %}{% endblock %}
 
-{% block extra_js %}
-    {{ block.super }}
-    <script>
-        window.headerSearch = {
-            url: "{% url 'wagtailredirects:index' %}",
-            termInput: "#id_q",
-            targetOutput: "#redirects-results"
-        }
-    </script>
-{% endblock %}
-
 {% block content %}
     {% trans "Import redirects" as header_title %}
     {% include "wagtailadmin/shared/header.html" with title=header_title icon="redirect" %}


### PR DESCRIPTION
- This page has no header search but was still adding an inline script to instantiate the header search
- Removing as it is unused (probably just copied from the redirects index page when the import page was set up)
- relates to #7053
- [X] Do the tests still pass?
- [X] Does the code comply with the style guide?
