### PR TITLE
Storybook story for status tag

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -50,6 +50,7 @@ Changelog
  * Deprecate the usage and documentation of the `wagtail.contrib.modeladmin.menus.SubMenu` class, provide a warning if used directing developers to use `wagtail.admin.menu.Menu` instead (Matt Westcott)
  * Remove legacy (non-next) breadcrumbs no longer used, remove `ModelAdmin` usage of breadcrumbs completely (Paarth Agarwal)
  * Replace human-readable-date hover pattern with accessible tooltip variant across all of admin (Bernd de Ridder)
+ * Add legacy and new status tags to the pattern library (Steven Steinwand)
  * Fix: Typo in `ResumeWorkflowActionFormatter` message (Stefan Hammer)
  * Fix: Throw a meaningful error when saving an image to an unrecognised image format (Christian Franke)
  * Fix: Remove extra padding for headers with breadcrumbs on mobile viewport (Steven Steinwand)

--- a/docs/releases/4.0.md
+++ b/docs/releases/4.0.md
@@ -57,6 +57,7 @@ When using a queryset to render a list of images, you can now use the `prefetch_
  * Deprecate the usage and documentation of the `wagtail.contrib.modeladmin.menus.SubMenu` class, provide a warning if used directing developers to use `wagtail.admin.menu.Menu` instead (Matt Westcott)
  * Remove legacy (non-next) breadcrumbs no longer used, remove `ModelAdmin` usage of breadcrumbs completely (Paarth Agarwal)
  * Replace human-readable-date hover pattern with accessible tooltip variant across all of admin (Bernd de Ridder)
+ * Add legacy and new status tags to the pattern library (Steven Steinwand)
 
 ### Bug fixes
 

--- a/wagtail/admin/templates/wagtailadmin/shared/page_status_tag.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/page_status_tag.html
@@ -1,4 +1,9 @@
 {% load i18n %}
+{% comment  "text/markdown" %}
+    Variables this template accepts:
+
+    `page` - A wagtail page object
+{% endcomment %}
 {% if page.live %}
     {% with page_url=page.url %}
         {% if page_url is not None %}

--- a/wagtail/admin/templates/wagtailadmin/shared/page_status_tag.stories.tsx
+++ b/wagtail/admin/templates/wagtailadmin/shared/page_status_tag.stories.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { Pattern, generateDocs } from 'storybook-django/src/react';
+
+import template from './page_status_tag.html';
+
+const { docs, argTypes } = generateDocs(template);
+
+export default {
+  parameters: { docs },
+  argTypes: {
+    ...argTypes,
+    url: {
+      options: [null, 'https://wagtail.io'],
+    },
+  },
+};
+
+const Template = (args) => (
+  <Pattern filename={__filename} context={{ page: args }} />
+);
+export const Live = Template.bind({});
+
+Live.args = {
+  live: true,
+  status_string: 'live',
+  url: null,
+};
+
+export const Draft = Template.bind({});
+
+Draft.args = {
+  live: false,
+  status_string: 'draft',
+};

--- a/wagtail/admin/templates/wagtailadmin/shared/page_status_tag_new.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/page_status_tag_new.html
@@ -4,7 +4,6 @@
     Variables accepted by this template:
 
     - `page` - A wagtail page object
-    - `classes` - String of extra css classes to pass to this component
 {% endcomment %}
 
 {% if page.live and page.url is not None %}

--- a/wagtail/admin/templates/wagtailadmin/shared/page_status_tag_new.stories.tsx
+++ b/wagtail/admin/templates/wagtailadmin/shared/page_status_tag_new.stories.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { Pattern, generateDocs } from 'storybook-django/src/react';
+
+import template from './page_status_tag_new.html';
+
+const { docs, argTypes } = generateDocs(template);
+
+export default {
+  parameters: { docs },
+  argTypes: { ...argTypes },
+};
+
+const PublicTemplate = (args) => (
+  <Pattern
+    filename={__filename}
+    tags={{
+      test_page_is_public: {
+        'page as is_public': {
+          raw: false,
+        },
+      },
+    }}
+    context={{ page: args }}
+  />
+);
+
+export const Public = PublicTemplate.bind({});
+Public.args = {
+  live: true,
+  url: '#',
+};
+
+const PrivateTemplate = (args) => (
+  <Pattern
+    filename={__filename}
+    tags={{
+      test_page_is_public: {
+        'page as is_public': {
+          raw: true,
+        },
+      },
+    }}
+    context={{ page: args }}
+  />
+);
+
+export const Private = PrivateTemplate.bind({});
+Private.args = {
+  live: true,
+  url: '#',
+};

--- a/wagtail/admin/templatetags/patternlibrary_override_tags.py
+++ b/wagtail/admin/templatetags/patternlibrary_override_tags.py
@@ -1,0 +1,5 @@
+from pattern_library.monkey_utils import override_tag
+
+from wagtail.admin.templatetags.wagtailadmin_tags import register
+
+override_tag(register, name="test_page_is_public")


### PR DESCRIPTION
Addresses #8656.

This PR adds stories for status tags in wagtail. 

- A set of stories for the legacy status tag
- A story for the new status tag. 

### Screenshot
![Screen Shot 2022-06-09 at 4 18 25 PM](https://user-images.githubusercontent.com/25041665/172954696-78513e5f-5b2b-412d-9c6d-3b6bdeeb7627.png)

### How to test

Start up the django-pattern-library and storybook and view the stories labelled: 
`Page Status Tag` && `Page Status Tag New`

### Browsers tested on 
Chrome 102, Storybook