### PR TITLE
fix issue with spinner icon & longrunning active state

### DIFF
--- a/client/scss/components/_button.scss
+++ b/client/scss/components/_button.scss
@@ -231,7 +231,6 @@
 
     &-active {
       display: inline-flex;
-      justify-content: center;
       align-items: center;
     }
 

--- a/client/scss/layouts/_page-editor.scss
+++ b/client/scss/layouts/_page-editor.scss
@@ -460,7 +460,7 @@ footer .preview {
     @apply w-leading-none w-inline-flex w-items-center;
 
     .icon {
-      @apply w-pr-2;
+      margin-inline-end: theme('spacing.2');
     }
   }
 }


### PR DESCRIPTION
- using padding meant the icon would visually spin 'wobbly'
- button content is no longer centre aligned so button longrunning active state should not be either
- fixes #8615
- tested on Safari 15.4 Firefox 101, Chrome 100, also tested with rtl active
- also validated sign in form spinner, single submit action spinner and page edit submit draft spinner

### Validation screenshots

<img width="1321" alt="Screen Shot 2022-06-12 at 11 15 08 am" src="https://user-images.githubusercontent.com/1396140/173210474-76822622-92c3-482e-83a2-e1dc7c9a6a24.png">

<img width="1175" alt="Screen Shot 2022-06-12 at 11 14 58 am" src="https://user-images.githubusercontent.com/1396140/173210476-1a12d69d-c681-4cd5-a361-ed51eedd21bd.png">



