### PR TITLE
Use RichText object for adding rich text blocks

### DIFF
--- a/docs/topics/streamfield.rst
+++ b/docs/topics/streamfield.rst
@@ -536,8 +536,9 @@ A StreamField's value behaves as a list, and blocks can be inserted, overwritten
     # Delete the last block
     del my_page.body[-1]
 
-    # Append a block to the stream
-    my_page.body.append(('paragraph', "<p>And they all lived happily ever after.</p>"))
+    # Append a rich text block to the stream
+    from wagtail.rich_text import RichText
+    my_page.body.append(('paragraph', RichText("<p>And they all lived happily ever after.</p>")))
 
     # Save the updated data back to the database
     my_page.save()


### PR DESCRIPTION
I have just tried to follow the original instructions and got an `AttributeError: 'str' object has no attribute 'source'` when trying to append a rich text block to a `StreamField` programmatically. 

Wrapping the value in a `RichText` object solved the issue. This seems to be in line with the behavior described further down the page.

