### PR TITLE
Correctly handle missing WAGTAILADMIN_BASE_URL setting

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -34,6 +34,7 @@ Changelog
  * Introduce a `wagtail.admin.viewsets.chooser.ChooserViewSet` module to serve as a common base implementation for chooser modals (Matt Westcott)
  * Add documentation for `wagtail.admin.viewsets.model.ModelViewSet` (Matt Westcott)
  * Enhance new Breadcrumbs so they can be added to any header or container element and adopt on the page explorer (listing) view (Paarth Agarwal)
+ * Add warning when `WAGTAILADMIN_BASE_URL` is not configured (Matt Westcott)
  * Fix: Typo in `ResumeWorkflowActionFormatter` message (Stefan Hammer)
  * Fix: Throw a meaningful error when saving an image to an unrecognised image format (Christian Franke)
  * Fix: Remove extra padding for headers with breadcrumbs on mobile viewport (Steven Steinwand)
@@ -47,6 +48,8 @@ Changelog
  * Fix: Ensure non-square avatar images will correctly show throughout the admin (LB (Ben) Johnston)
  * Fix: Ignore translations in test files and re-include some translations that were accidentally ignored (Stefan Hammer)
  * Fix: Show alternative message when no page types are available to be created (Jaspreet Singh)
+ * Fix: Stop emails from breaking when `WAGTAILADMIN_BASE_URL` is absent due to the request object not being available (Matt Westcott)
+ * Fix: Make try/except on sending email less broad so that legitimate template rendering errors are exposed (Matt Westcott)
 
 
 3.0.1 (xx.xx.xxxx) - IN DEVELOPMENT

--- a/docs/releases/4.0.md
+++ b/docs/releases/4.0.md
@@ -43,6 +43,7 @@ When using a queryset to render a list of images, you can now use the ``prefetch
  * Introduce a `wagtail.admin.viewsets.chooser.ChooserViewSet` module to serve as a common base implementation for chooser modals (Matt Westcott)
  * Add documentation for `wagtail.admin.viewsets.model.ModelViewSet` (Matt Westcott)
  * Enhance new Breadcrumbs so they can be added to any header or container element and adopt on the page explorer (listing) view (Paarth Agarwal)
+ * Add warning when `WAGTAILADMIN_BASE_URL` is not configured (Matt Westcott)
 
 ### Bug fixes
 
@@ -61,6 +62,8 @@ When using a queryset to render a list of images, you can now use the ``prefetch
  * Ensure non-square avatar images will correctly show throughout the admin (LB (Ben) Johnston)
  * Ignore translations in test files and re-include some translations that were accidentally ignored (Stefan Hammer)
  * Show alternative message when no page types are available to be created (Jaspreet Singh)
+ * Stop emails from breaking when `WAGTAILADMIN_BASE_URL` is absent due to the request object not being available (Matt Westcott)
+ * Make try/except on sending email less broad so that legitimate template rendering errors are exposed (Matt Westcott)
 
 
 ## Upgrade considerations

--- a/wagtail/admin/checks.py
+++ b/wagtail/admin/checks.py
@@ -164,3 +164,22 @@ There are no default tabs on non-Page models so there will be no \
         errors.append(error)
 
     return errors
+
+
+@register("wagtailadmin_base_url")
+def wagtail_admin_base_url_check(app_configs, **kwargs):
+    from django.conf import settings
+
+    errors = []
+
+    if getattr(settings, "WAGTAILADMIN_BASE_URL", None) is None:
+        errors.append(
+            Warning(
+                "The WAGTAILADMIN_BASE_URL setting is not defined",
+                hint="This should be the base URL used to access the Wagtail admin site. "
+                "Without this, URLs in notification emails will not display correctly.",
+                id="wagtailadmin.W003",
+            )
+        )
+
+    return errors

--- a/wagtail/admin/mail.py
+++ b/wagtail/admin/mail.py
@@ -121,20 +121,20 @@ def send_notification(recipient_users, notification, extra_context):
         # Send emails
         sent_count = 0
         for recipient in email_recipients:
+            # update context with this recipient
+            context["user"] = recipient
+
+            # Translate text to the recipient language settings
+            with override(recipient.wagtail_userprofile.get_preferred_language()):
+                # Get email subject and content
+                email_subject = render_to_string(template_subject, context).strip()
+                email_content = render_to_string(template_text, context).strip()
+
+            kwargs = {}
+            if getattr(settings, "WAGTAILADMIN_NOTIFICATION_USE_HTML", False):
+                kwargs["html_message"] = render_to_string(template_html, context)
+
             try:
-                # update context with this recipient
-                context["user"] = recipient
-
-                # Translate text to the recipient language settings
-                with override(recipient.wagtail_userprofile.get_preferred_language()):
-                    # Get email subject and content
-                    email_subject = render_to_string(template_subject, context).strip()
-                    email_content = render_to_string(template_text, context).strip()
-
-                kwargs = {}
-                if getattr(settings, "WAGTAILADMIN_NOTIFICATION_USE_HTML", False):
-                    kwargs["html_message"] = render_to_string(template_html, context)
-
                 # Send email
                 send_mail(
                     email_subject,
@@ -257,31 +257,28 @@ class EmailNotificationMixin:
 
                 # Send emails
                 for recipient in recipients:
+                    # update context with this recipient
+                    context["user"] = recipient
+
+                    # Translate text to the recipient language settings
+                    with override(
+                        recipient.wagtail_userprofile.get_preferred_language()
+                    ):
+                        # Get email subject and content
+                        email_subject = render_to_string(
+                            template_set["subject"], context
+                        ).strip()
+                        email_content = render_to_string(
+                            template_set["text"], context
+                        ).strip()
+
+                    kwargs = {}
+                    if getattr(settings, "WAGTAILADMIN_NOTIFICATION_USE_HTML", False):
+                        kwargs["html_message"] = render_to_string(
+                            template_set["html"], context
+                        )
+
                     try:
-
-                        # update context with this recipient
-                        context["user"] = recipient
-
-                        # Translate text to the recipient language settings
-                        with override(
-                            recipient.wagtail_userprofile.get_preferred_language()
-                        ):
-                            # Get email subject and content
-                            email_subject = render_to_string(
-                                template_set["subject"], context
-                            ).strip()
-                            email_content = render_to_string(
-                                template_set["text"], context
-                            ).strip()
-
-                        kwargs = {}
-                        if getattr(
-                            settings, "WAGTAILADMIN_NOTIFICATION_USE_HTML", False
-                        ):
-                            kwargs["html_message"] = render_to_string(
-                                template_set["html"], context
-                            )
-
                         # Send email
                         send_mail(
                             email_subject,

--- a/wagtail/admin/templates/wagtailadmin/notifications/base.html
+++ b/wagtail/admin/templates/wagtailadmin/notifications/base.html
@@ -1,5 +1,5 @@
 {% load wagtailadmin_tags i18n %}
-{% base_url_setting as base_url %}
+{% base_url_setting default="" as base_url %}
 {% get_current_language as LANGUAGE_CODE %}
 {% get_current_language_bidi as LANGUAGE_BIDI %}
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">

--- a/wagtail/admin/templates/wagtailadmin/notifications/base.txt
+++ b/wagtail/admin/templates/wagtailadmin/notifications/base.txt
@@ -1,5 +1,5 @@
 {% load wagtailadmin_tags i18n %}
-{% base_url_setting as base_url %}
+{% base_url_setting default="" as base_url %}
 
 {% block greeting %}
 {% blocktrans trimmed with username=user.get_short_name|default:user.get_username %}Hello {{ username }},{% endblocktrans %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/rejected.html
+++ b/wagtail/admin/templates/wagtailadmin/notifications/rejected.html
@@ -1,6 +1,6 @@
 {% extends 'wagtailadmin/notifications/base.html' %}
 {% load wagtailadmin_tags i18n %}
-{% base_url_setting as base_url %}
+{% base_url_setting default="" as base_url %}
 
 {% block content %}
     <p>{% blocktrans trimmed with title=revision.content_object.get_admin_display_title|safe %}The page "{{ title }}" has been rejected.{% endblocktrans %}</p>

--- a/wagtail/admin/templates/wagtailadmin/notifications/rejected.txt
+++ b/wagtail/admin/templates/wagtailadmin/notifications/rejected.txt
@@ -1,6 +1,6 @@
 {% extends 'wagtailadmin/notifications/base.txt' %}
 {% load wagtailadmin_tags i18n %}
-{% base_url_setting as base_url %}
+{% base_url_setting default="" as base_url %}
 
 {% block content %}
 {% blocktrans trimmed with title=revision.content_object.get_admin_display_title|safe %}The page "{{ title }}" has been rejected.{% endblocktrans %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/submitted.html
+++ b/wagtail/admin/templates/wagtailadmin/notifications/submitted.html
@@ -1,6 +1,6 @@
 {% extends 'wagtailadmin/notifications/base.html' %}
 {% load wagtailadmin_tags i18n %}
-{% base_url_setting as base_url %}
+{% base_url_setting default="" as base_url %}
 
 {% block content %}
     <p>{% blocktrans trimmed with page=revision.content_object|safe editor=revision.user|user_display_name %}The page "{{ page }}" has been submitted for moderation by {{ editor }}.{% endblocktrans %}</p>

--- a/wagtail/admin/templates/wagtailadmin/notifications/submitted.txt
+++ b/wagtail/admin/templates/wagtailadmin/notifications/submitted.txt
@@ -1,6 +1,6 @@
 {% extends 'wagtailadmin/notifications/base.txt' %}
 {% load wagtailadmin_tags i18n %}
-{% base_url_setting as base_url %}
+{% base_url_setting default="" as base_url %}
 
 {% block content %}
 {% blocktrans trimmed with page=revision.content_object|safe editor=revision.user|user_display_name %}The page "{{ page }}" has been submitted for moderation by {{ editor }}.{% endblocktrans %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/task_state_approved.html
+++ b/wagtail/admin/templates/wagtailadmin/notifications/task_state_approved.html
@@ -1,6 +1,6 @@
 {% extends 'wagtailadmin/notifications/base.html' %}
 {% load wagtailadmin_tags i18n %}
-{% base_url_setting as base_url %}
+{% base_url_setting default="" as base_url %}
 
 {% block content %}
     <p>{% blocktrans trimmed with title=page.get_admin_display_title task=task.name %}The page "{{ title }}" has been approved in moderation stage "{{ task }}".{% endblocktrans %}</p>

--- a/wagtail/admin/templates/wagtailadmin/notifications/task_state_approved.txt
+++ b/wagtail/admin/templates/wagtailadmin/notifications/task_state_approved.txt
@@ -1,6 +1,6 @@
 {% extends 'wagtailadmin/notifications/base.txt' %}
 {% load wagtailadmin_tags i18n %}
-{% base_url_setting as base_url %}
+{% base_url_setting default="" as base_url %}
 
 {% block content %}
 {% blocktrans trimmed with title=page.get_admin_display_title|safe task=task.name|safe %}The page "{{ title }}" has been approved in moderation stage "{{ task }}".{% endblocktrans %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/task_state_rejected.html
+++ b/wagtail/admin/templates/wagtailadmin/notifications/task_state_rejected.html
@@ -1,6 +1,6 @@
 {% extends 'wagtailadmin/notifications/base.html' %}
 {% load wagtailadmin_tags i18n %}
-{% base_url_setting as base_url %}
+{% base_url_setting default="" as base_url %}
 
 {% block content %}
     <p>{% blocktrans trimmed with title=page.get_admin_display_title task=task.name %}The page "{{ title }}" has been rejected in moderation stage "{{ task }}".{% endblocktrans %}</p>

--- a/wagtail/admin/templates/wagtailadmin/notifications/task_state_rejected.txt
+++ b/wagtail/admin/templates/wagtailadmin/notifications/task_state_rejected.txt
@@ -1,6 +1,6 @@
 {% extends 'wagtailadmin/notifications/base.txt' %}
 {% load wagtailadmin_tags i18n %}
-{% base_url_setting as base_url %}
+{% base_url_setting default="" as base_url %}
 
 {% block content %}
 {% blocktrans trimmed with title=page.get_admin_display_title|safe task=task.name|safe %}The page "{{ title }}" has been rejected in moderation stage "{{ task }}".{% endblocktrans %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/task_state_submitted.html
+++ b/wagtail/admin/templates/wagtailadmin/notifications/task_state_submitted.html
@@ -1,6 +1,6 @@
 {% extends 'wagtailadmin/notifications/base.html' %}
 {% load wagtailadmin_tags i18n %}
-{% base_url_setting as base_url %}
+{% base_url_setting default="" as base_url %}
 
 {% block content %}
     <p>{% blocktrans trimmed with task=task.name title=page.get_admin_display_title %}The page "{{ title }}" has been submitted for approval in moderation stage "{{ task }}".{% endblocktrans %}</p>

--- a/wagtail/admin/templates/wagtailadmin/notifications/task_state_submitted.txt
+++ b/wagtail/admin/templates/wagtailadmin/notifications/task_state_submitted.txt
@@ -1,6 +1,6 @@
 {% extends 'wagtailadmin/notifications/base.txt' %}
 {% load wagtailadmin_tags i18n %}
-{% base_url_setting as base_url %}
+{% base_url_setting default="" as base_url %}
 
 {% block content %}
 {% blocktrans trimmed with task=task.name|safe title=page.get_admin_display_title|safe %}The page "{{ title }}" has been submitted for approval to moderation stage "{{ task }}".{% endblocktrans %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/updated_comments.html
+++ b/wagtail/admin/templates/wagtailadmin/notifications/updated_comments.html
@@ -1,6 +1,6 @@
 {% extends 'wagtailadmin/notifications/base.html' %}
 {% load i18n wagtailadmin_tags %}
-{% base_url_setting as base_url %}
+{% base_url_setting default="" as base_url %}
 
 {% block content %}
     <p>

--- a/wagtail/admin/templates/wagtailadmin/notifications/updated_comments.txt
+++ b/wagtail/admin/templates/wagtailadmin/notifications/updated_comments.txt
@@ -1,6 +1,6 @@
 {% extends 'wagtailadmin/notifications/base.txt' %}
 {% load i18n wagtailadmin_tags %}
-{% base_url_setting as base_url %}
+{% base_url_setting default="" as base_url %}
 
 {% block content %}{% blocktrans trimmed with title=page.get_admin_display_title|safe editor=editor|user_display_name|safe %}{{ editor }} has updated comments on "{{ title }}".{% endblocktrans %}
 {% spaceless %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/workflow_state_rejected.html
+++ b/wagtail/admin/templates/wagtailadmin/notifications/workflow_state_rejected.html
@@ -1,6 +1,6 @@
 {% extends 'wagtailadmin/notifications/base.html' %}
 {% load wagtailadmin_tags i18n %}
-{% base_url_setting as base_url %}
+{% base_url_setting default="" as base_url %}
 
 {% block content %}
     {% if task_state.finished_by %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/workflow_state_rejected.txt
+++ b/wagtail/admin/templates/wagtailadmin/notifications/workflow_state_rejected.txt
@@ -1,6 +1,6 @@
 {% extends 'wagtailadmin/notifications/base.txt' %}
 {% load wagtailadmin_tags i18n %}
-{% base_url_setting as base_url %}
+{% base_url_setting default="" as base_url %}
 
 {% block content %}
 {% if task_state.finished_by %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/workflow_state_submitted.html
+++ b/wagtail/admin/templates/wagtailadmin/notifications/workflow_state_submitted.html
@@ -1,6 +1,6 @@
 {% extends 'wagtailadmin/notifications/base.html' %}
 {% load wagtailadmin_tags i18n %}
-{% base_url_setting as base_url %}
+{% base_url_setting default="" as base_url %}
 
 {% block content %}
     {% if requested_by %}

--- a/wagtail/admin/templates/wagtailadmin/notifications/workflow_state_submitted.txt
+++ b/wagtail/admin/templates/wagtailadmin/notifications/workflow_state_submitted.txt
@@ -1,6 +1,6 @@
 {% extends 'wagtailadmin/notifications/base.txt' %}
 {% load wagtailadmin_tags i18n %}
-{% base_url_setting as base_url %}
+{% base_url_setting default="" as base_url %}
 
 {% block content %}
 {% if requested_by %}{% blocktrans trimmed with workflow=workflow.name|safe title=page.get_admin_display_title|safe requester=requested_by|user_display_name|safe %}The page "{{ title }}" has been submitted for moderation to workflow "{{ workflow }}" by {{ requester }}.{% endblocktrans %}

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -228,9 +228,9 @@ def usage_count_enabled():
     return getattr(settings, "WAGTAIL_USAGE_COUNT_ENABLED", False)
 
 
-@register.simple_tag(takes_context=True)
-def base_url_setting(context=None):
-    return get_admin_base_url(context=context)
+@register.simple_tag
+def base_url_setting():
+    return get_admin_base_url()
 
 
 @register.simple_tag

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -229,8 +229,8 @@ def usage_count_enabled():
 
 
 @register.simple_tag
-def base_url_setting():
-    return get_admin_base_url()
+def base_url_setting(default=None):
+    return get_admin_base_url() or default
 
 
 @register.simple_tag

--- a/wagtail/admin/tests/test_password_reset.py
+++ b/wagtail/admin/tests/test_password_reset.py
@@ -66,6 +66,14 @@ class TestUserPasswordReset(TestCase, WagtailTestUtils):
         self.assertEqual(len(mail.outbox), 1)
         self.assertIn("mysite.com", mail.outbox[0].body)
 
+    @override_settings(ROOT_URLCONF="wagtail.admin.urls", WAGTAILADMIN_BASE_URL=None)
+    def test_email_without_base_url(self):
+        response = self.client.post(
+            reverse("wagtailadmin_password_reset"), {"email": "siteeditor@example.com"}
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(len(mail.outbox), 1)
+
     @unittest.skipUnless(
         settings.AUTH_USER_MODEL == "customuser.CustomUser",
         "only applicable to CustomUser",

--- a/wagtail/admin/utils.py
+++ b/wagtail/admin/utils.py
@@ -5,12 +5,10 @@ from django.conf import settings
 from wagtail.utils.deprecation import RemovedInWagtail50Warning
 
 
-def get_admin_base_url(context=None):
+def get_admin_base_url():
     """
     Gets the base URL for the wagtail admin site. This is set in `settings.WAGTAILADMIN_BASE_URL`,
     which was previously `settings.BASE_URL`.
-    If setting is omitted and this is called in a request context, falls back to
-    `request.site.root_url` or next the host_name of the request.
     """
 
     admin_base_url = getattr(settings, "WAGTAILADMIN_BASE_URL", None)
@@ -20,15 +18,5 @@ def get_admin_base_url(context=None):
             category=RemovedInWagtail50Warning,
         )
         admin_base_url = settings.BASE_URL
-
-    if admin_base_url is None and context is not None:
-        request = context["request"]
-        admin_base_url = getattr(request.site, "root_url", None)
-        if admin_base_url is None:
-            admin_base_url = request.get_host()
-            secure_prefix = "http"
-            if request.is_secure():
-                secure_prefix = "https"
-            admin_base_url = secure_prefix + "://" + admin_base_url
 
     return admin_base_url


### PR DESCRIPTION
Fixes #8582 as per https://github.com/wagtail/wagtail/issues/8582#issuecomment-1154244542 - remove logic that attempts to construct the base URL from the request (because the request generally isn't available).