### PR TITLE
Added breadcrumbs next to Explorer 

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -33,7 +33,7 @@ Changelog
  * Update `ReportView` to extend from generic `wagtail.admin.views.generic.models.IndexView` (Sage Abdullah)
  * Introduce a `wagtail.admin.viewsets.chooser.ChooserViewSet` module to serve as a common base implementation for chooser modals (Matt Westcott)
  * Add documentation for `wagtail.admin.viewsets.model.ModelViewSet` (Matt Westcott)
- * Enhance new Breadcrumbs so they can be added to any header or element (Paarth Agarwal)
+ * Enhance new Breadcrumbs so they can be added to any header or container element and adopt on the page explorer (listing) view (Paarth Agarwal)
  * Fix: Typo in `ResumeWorkflowActionFormatter` message (Stefan Hammer)
  * Fix: Throw a meaningful error when saving an image to an unrecognised image format (Christian Franke)
  * Fix: Remove extra padding for headers with breadcrumbs on mobile viewport (Steven Steinwand)

--- a/client/scss/components/_header.scss
+++ b/client/scss/components/_header.scss
@@ -47,6 +47,10 @@ header {
     padding-inline-start: $mobile-nav-indent + 10px;
   }
 
+  &.merged .w-breadcrumb {
+    padding-inline-start: $mobile-nav-indent;
+  }
+
   &.header--home {
     @include nice-padding();
     padding-top: 0.5rem;
@@ -178,6 +182,10 @@ header {
 
     .breadcrumb + .row {
       padding-inline-start: 90px;
+    }
+
+    &.merged .w-breadcrumb {
+      padding-inline-start: 0;
     }
 
     &.header--home {

--- a/client/src/entrypoints/admin/page-editor.js
+++ b/client/src/entrypoints/admin/page-editor.js
@@ -1,6 +1,5 @@
 import $ from 'jquery';
 import { cleanForSlug } from '../../utils/cleanForSlug';
-import initCollapsibleBreadcrumbs from '../../includes/breadcrumbs';
 
 function InlinePanel(opts) {
   // lgtm[js/unused-local-variable]
@@ -290,7 +289,6 @@ $(() => {
   initSlugCleaning();
   initErrorDetection();
   initKeyboardShortcuts();
-  initCollapsibleBreadcrumbs();
 
   //
   // Preview

--- a/client/src/entrypoints/admin/wagtailadmin.js
+++ b/client/src/entrypoints/admin/wagtailadmin.js
@@ -4,6 +4,7 @@ import { Icon, Portal, initUpgradeNotification, initSkipLink } from '../..';
 import { initModernDropdown, initTooltips } from '../../includes/initTooltips';
 import { initTabs } from '../../includes/tabs';
 import { dialog } from '../../includes/dialog';
+import initCollapsibleBreadcrumbs from '../../includes/breadcrumbs';
 
 if (process.env.NODE_ENV === 'development') {
   // Run react-axe in development only, so it does not affect performance
@@ -29,4 +30,5 @@ document.addEventListener('DOMContentLoaded', () => {
   initTabs();
   initSkipLink();
   dialog();
+  initCollapsibleBreadcrumbs();
 });

--- a/docs/releases/4.0.md
+++ b/docs/releases/4.0.md
@@ -42,7 +42,7 @@ When using a queryset to render a list of images, you can now use the ``prefetch
  * Update `ReportView` to extend from generic `wagtail.admin.views.generic.models.IndexView` (Sage Abdullah)
  * Introduce a `wagtail.admin.viewsets.chooser.ChooserViewSet` module to serve as a common base implementation for chooser modals (Matt Westcott)
  * Add documentation for `wagtail.admin.viewsets.model.ModelViewSet` (Matt Westcott)
- * Enhance new Breadcrumbs so they can be added to any header or container element (Paarth Agarwal)
+ * Enhance new Breadcrumbs so they can be added to any header or container element and adopt on the page explorer (listing) view (Paarth Agarwal)
 
 ### Bug fixes
 

--- a/wagtail/admin/templates/wagtailadmin/pages/index.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/index.html
@@ -7,7 +7,7 @@
     <header class="header merged no-border">
         <h1 class="visuallyhidden">Explorer</h1>
 
-        {% explorer_breadcrumb parent_page %}
+        {% explorer_breadcrumb parent_page use_next_template=True %}
     </header>
 
     <form id="page-reorder-form">

--- a/wagtail/admin/templates/wagtailadmin/shared/breadcrumb-next.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/breadcrumb-next.html
@@ -8,7 +8,7 @@
 {% with breadcrumb_link_classes='w-flex w-items-center w-h-full w-text-primary w-px-0.5 w-text-14 w-no-underline w-outline-offset-inside hover:w-underline hover:w-text-primary w-h-full' breadcrumb_item_classes='w-h-full w-flex w-items-center w-overflow-hidden w-transition w-duration-300 w-whitespace-nowrap w-flex-shrink-0 w-font-bold' icon_classes='w-w-4 w-h-4 w-ml-3' %}
     {# Breadcrumbs are visible on mobile by default but hidden on desktop #}
 
-    <div class="w-flex w-flex-row w-items-center w-overflow-x-auto w-overflow-y-hidden w-scrollbar-thin" data-breadcrumb-next>
+    <div class="w-breadcrumb w-flex w-flex-row w-items-center w-overflow-x-auto w-overflow-y-hidden w-scrollbar-thin" data-breadcrumb-next>
         <button
             type="button"
             data-toggle-breadcrumbs
@@ -19,7 +19,7 @@
             {% icon name="breadcrumb-expand" class_name="w-w-4 w-h-4" %}
         </button>
 
-        <div class="w-relative w-h-[50px] w-mr-4 w-bg-grey-50 w-top-0 w-z-20 w-flex w-items-center w-flex-row w-flex-1 sm:w-flex-none w-transition w-duration-300">
+        <div class="w-relative w-h-[50px] w-mr-4 w-top-0 w-z-20 w-flex w-items-center w-flex-row w-flex-1 sm:w-flex-none w-transition w-duration-300">
             <nav class="w-flex w-items-center w-flex-row w-h-full"
                 aria-label="{% trans 'Breadcrumb' %}">
                 <ol class="w-flex w-flex-row w-justify-start w-items-center w-h-full w-pl-0 w-my-0 w-gap-2 sm:w-gap-0 sm:w-space-x-2">

--- a/wagtail/admin/tests/pages/test_explorer_view.py
+++ b/wagtail/admin/tests/pages/test_explorer_view.py
@@ -377,6 +377,17 @@ class TestPageExplorer(TestCase, WagtailTestUtils):
 class TestBreadcrumb(TestCase, WagtailTestUtils):
     fixtures = ["test.json"]
 
+    def test_breadcrumb_next_present(self):
+        self.user = self.login()
+
+        # get the explorer view for a subpage of a SimplePage
+        page = Page.objects.get(url_path="/home/secret-plans/steal-underpants/")
+        response = self.client.get(reverse("wagtailadmin_explore", args=(page.id,)))
+        self.assertEqual(response.status_code, 200)
+
+        # The data-breadcrumb-next should be present
+        self.assertContains(response, "data-breadcrumb-next")
+
     def test_breadcrumb_uses_specific_titles(self):
         self.user = self.login()
 
@@ -389,18 +400,21 @@ class TestBreadcrumb(TestCase, WagtailTestUtils):
             "wagtailadmin_explore",
             args=(Page.objects.get(url_path="/home/secret-plans/").id,),
         )
+
         expected = (
             """
-            <li class="breadcrumb-item">
-                <a class="breadcrumb-link" href="%s"><span class="title">Secret plans (simple page)</span>
-                    <svg class="icon icon-arrow-right arrow_right_icon" aria-hidden="true">
-                        <use href="#icon-arrow-right"></use>
-                    </svg>
+            <li class="w-h-full w-flex w-items-center w-overflow-hidden w-transition w-duration-300 w-whitespace-nowrap w-flex-shrink-0 w-font-bold w-max-w-0" data-breadcrumb-item hidden>
+                <a class="w-flex w-items-center w-h-full w-text-primary w-px-0.5 w-text-14 w-no-underline w-outline-offset-inside hover:w-underline hover:w-text-primary w-h-full" href="%s">
+                                    Secret plans (simple page)
                 </a>
+                <svg class="icon icon-arrow-right w-w-4 w-h-4 w-ml-3" aria-hidden="true">
+                    <use href="#icon-arrow-right"></use>
+                </svg>
             </li>
         """
             % expected_url
         )
+
         self.assertContains(response, expected, html=True)
 
 
@@ -621,38 +635,36 @@ class TestExplorablePageVisibility(TestCase, WagtailTestUtils):
         response = self.client.get(reverse("wagtailadmin_explore", args=[6]))
         self.assertEqual(response.status_code, 200)
         expected = """
-            <li class="home breadcrumb-item">
-                <a class="breadcrumb-link" href="/admin/pages/">
-                    <svg class="icon icon-site home_icon" aria-hidden="true">
-                        <use href="#icon-site"></use>
-                    </svg>
-                    <span class="visuallyhidden">Root</span>
-                    <svg class="icon icon-arrow-right arrow_right_icon" aria-hidden="true">
-                        <use href="#icon-arrow-right"></use>
-                    </svg>
+            <li class="w-h-full w-flex w-items-center w-overflow-hidden w-transition w-duration-300 w-whitespace-nowrap w-flex-shrink-0 w-font-bold w-max-w-0" data-breadcrumb-item hidden>
+                <a class="w-flex w-items-center w-h-full w-text-primary w-px-0.5 w-text-14 w-no-underline w-outline-offset-inside hover:w-underline hover:w-text-primary w-h-full" href="/admin/pages/">
+                                    Root
                 </a>
+                <svg class="icon icon-arrow-right w-w-4 w-h-4 w-ml-3" aria-hidden="true">
+                    <use href="#icon-arrow-right"></use>
+                </svg>
+            </li>
+
+        """
+        self.assertContains(response, expected, html=True)
+        expected = """
+            <li class="w-h-full w-flex w-items-center w-overflow-hidden w-transition w-duration-300 w-whitespace-nowrap w-flex-shrink-0 w-font-bold w-max-w-0" data-breadcrumb-item hidden>
+                <a class="w-flex w-items-center w-h-full w-text-primary w-px-0.5 w-text-14 w-no-underline w-outline-offset-inside hover:w-underline hover:w-text-primary w-h-full" href="/admin/pages/4/">
+                                    Welcome to example.com!
+                </a>
+                <svg class="icon icon-arrow-right w-w-4 w-h-4 w-ml-3" aria-hidden="true">
+                    <use href="#icon-arrow-right"></use>
+                </svg>
             </li>
         """
         self.assertContains(response, expected, html=True)
         expected = """
-            <li class="breadcrumb-item">
-                <a class="breadcrumb-link" href="/admin/pages/4/">
-                    <span class="title">Welcome to example.com!</span>
-                    <svg class="icon icon-arrow-right arrow_right_icon" aria-hidden="true">
-                        <use href="#icon-arrow-right"></use>
-                    </svg>
+            <li class="w-h-full w-flex w-items-center w-overflow-hidden w-transition w-duration-300 w-whitespace-nowrap w-flex-shrink-0 w-font-bold w-max-w-0" data-breadcrumb-item hidden>
+                <a class="w-flex w-items-center w-h-full w-text-primary w-px-0.5 w-text-14 w-no-underline w-outline-offset-inside hover:w-underline hover:w-text-primary w-h-full" href="/admin/pages/5/">
+                                    Content
                 </a>
-            </li>
-        """
-        self.assertContains(response, expected, html=True)
-        expected = """
-            <li class="breadcrumb-item">
-                <a class="breadcrumb-link" href="/admin/pages/5/">
-                    <span class="title">Content</span>
-                    <svg class="icon icon-arrow-right arrow_right_icon" aria-hidden="true">
-                        <use href="#icon-arrow-right"></use>
-                    </svg>
-                </a>
+                <svg class="icon icon-arrow-right w-w-4 w-h-4 w-ml-3" aria-hidden="true">
+                    <use href="#icon-arrow-right"></use>
+                </svg>
             </li>
         """
         self.assertContains(response, expected, html=True)
@@ -664,27 +676,24 @@ class TestExplorablePageVisibility(TestCase, WagtailTestUtils):
         # While at "Page 1", Josh should see the breadcrumbs leading only as far back as the example.com homepage,
         # since it's his Closest Common Ancestor.
         expected = """
-            <li class="home breadcrumb-item">
-                <a class="breadcrumb-link" href="/admin/pages/4/">
-                    <svg class="icon icon-site home_icon" aria-hidden="true">
-                        <use href="#icon-site"></use>
-                    </svg>
-                    <span class="visuallyhidden">Home</span>
-                    <svg class="icon icon-arrow-right arrow_right_icon" aria-hidden="true">
-                        <use href="#icon-arrow-right"></use>
-                    </svg>
+            <li class="w-h-full w-flex w-items-center w-overflow-hidden w-transition w-duration-300 w-whitespace-nowrap w-flex-shrink-0 w-font-bold w-max-w-0" data-breadcrumb-item hidden>
+                <a class="w-flex w-items-center w-h-full w-text-primary w-px-0.5 w-text-14 w-no-underline w-outline-offset-inside hover:w-underline hover:w-text-primary w-h-full" href="/admin/pages/4/">
+                                    Root
                 </a>
+                <svg class="icon icon-arrow-right w-w-4 w-h-4 w-ml-3" aria-hidden="true">
+                    <use href="#icon-arrow-right"></use>
+                </svg>
             </li>
         """
         self.assertContains(response, expected, html=True)
         expected = """
-            <li class="breadcrumb-item">
-                <a class="breadcrumb-link" href="/admin/pages/5/">
-                    <span class="title">Content</span>
-                    <svg class="icon icon-arrow-right arrow_right_icon" aria-hidden="true">
-                        <use href="#icon-arrow-right"></use>
-                    </svg>
+            <li class="w-h-full w-flex w-items-center w-overflow-hidden w-transition w-duration-300 w-whitespace-nowrap w-flex-shrink-0 w-font-bold w-max-w-0" data-breadcrumb-item hidden>
+                <a class="w-flex w-items-center w-h-full w-text-primary w-px-0.5 w-text-14 w-no-underline w-outline-offset-inside hover:w-underline hover:w-text-primary w-h-full" href="/admin/pages/5/">
+                                    Content
                 </a>
+                <svg class="icon icon-arrow-right w-w-4 w-h-4 w-ml-3" aria-hidden="true">
+                    <use href="#icon-arrow-right"></use>
+                </svg>
             </li>
         """
         self.assertContains(response, expected, html=True)


### PR DESCRIPTION
1. Added breadcrumbs-next to explorer
Before:

![Screenshot from 2022-06-14 17-36-41](https://user-images.githubusercontent.com/86092410/173577552-f83f2c24-6b88-42f9-93f3-1969aade95a3.png)
On Firefox, Ubuntu 20.04
After:

![Screenshot from 2022-06-14 16-40-04](https://user-images.githubusercontent.com/86092410/173577526-1cb41ffa-fb6e-42e8-94f7-fe2debd8d591.png)

On Edge, Ubuntu 20.04

![Screenshot from 2022-06-14 16-43-07](https://user-images.githubusercontent.com/86092410/173577536-e5aded9e-9090-4aa9-87ed-c6ca96ab45ec.png)

On Firefox, Ubuntu 20.04

![Screenshot from 2022-06-14 16-44-19](https://user-images.githubusercontent.com/86092410/173577541-8f688525-a200-4192-b09a-90f13668a8c4.png)

![Screenshot from 2022-06-14 16-45-20](https://user-images.githubusercontent.com/86092410/173577547-a63d48ce-6d0d-4547-8abe-93acfc0c74cf.png)
Below 800px, the breadcrumb icon gets under the sidebar toggle. It will be fixed when we do the header.
2. Removed odd grey colour appearing behind breadcrumb items
Before:

![Screenshot from 2022-06-14 17-56-41](https://user-images.githubusercontent.com/86092410/173577555-842ea268-f8fa-47bd-9e03-1789e4ffbb28.png)

After:

![Screenshot from 2022-06-14 18-11-21](https://user-images.githubusercontent.com/86092410/173579499-cbe21d10-01ce-496f-a058-dc56e6465806.png)


3. Added Test to check the presence of `data-breadcrumb-next` and updated existing test according to new DOM.

Addresses #8645. 






