### PR TITLE
convert DecimalBlock value back to Decimal for #4647

### DIFF
--- a/wagtail/blocks/field_block.py
+++ b/wagtail/blocks/field_block.py
@@ -1,4 +1,5 @@
 import datetime
+from decimal import Decimal
 
 from django import forms
 from django.db.models.fields import BLANK_CHOICE_DASH
@@ -244,6 +245,9 @@ class DecimalBlock(FieldBlock):
             validators=validators,
         )
         super().__init__(*args, **kwargs)
+
+    def to_python(self, value):
+        return Decimal(value)
 
     class Meta:
         icon = "plus-inverse"

--- a/wagtail/tests/test_blocks.py
+++ b/wagtail/tests/test_blocks.py
@@ -411,6 +411,13 @@ class TestDecimalBlock(TestCase):
         block_val = block.value_from_form(Decimal("1.63"))
         self.assertEqual(type(block_val), Decimal)
 
+    def test_type_to_python(self):
+        block = blocks.DecimalBlock()
+        block_val = block.to_python(
+            "1.63"
+        )  # decimals get saved as string in JSON field
+        self.assertEqual(type(block_val), Decimal)
+
     def test_render(self):
         block = blocks.DecimalBlock()
         test_val = Decimal(1.63)


### PR DESCRIPTION
_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [X] Does the code comply with the style guide?
    -   [X] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

see issue #4647
DecimalBlock values work as expected when previewing a page, however they become strings when the published page is rendered.

A decimal value is stored as string in a JSON field. To get a real Decimal value back in python, it needs to be casted as Decimal. Without this PR you get a string type object back instead.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
