### PR TITLE
Improve ability to expose form fields from the API & add documentation

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -10,6 +10,7 @@ Changelog
  * Add full support for secondary buttons with icons in the Wagtail design system - `button bicolor button--icon button-secondary` including the `button-small` variant (Seremba Patrick)
  * Add `purge_embeds` management command to delete all the cached embed objects in the database (Aman Pandey)
  * Make it possible to resize the page editor’s side panels (Sage Abdullah)
+ * Add ability to include `form_fields` as an APIField on `FormPage` (Sævar Öfjörð Magnússon, Suyash Singh, LB (Ben) Johnston)
  * Fix: Make sure workflow timeline icons are visible in high-contrast mode (Loveth Omokaro)
  * Fix: Ensure authentication forms (login, password reset) have a visible border in Windows high-contrast mode (Loveth Omokaro)
  * Fix: Ensure visual consistency between buttons and links as buttons in Windows high-contrast mode (Albina Starykova)

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -666,6 +666,7 @@ Contributors
 * Florian Vogt
 * Fatuma Abdullahi
 * Elizabeth Bassey
+* Suyash Singh
 
 Translators
 ===========

--- a/docs/advanced_topics/api/v2/configuration.md
+++ b/docs/advanced_topics/api/v2/configuration.md
@@ -137,6 +137,22 @@ This will make `published_date`, `body`, `feed_image` and a list of
 fields, you must select the `blog.BlogPage` type using the `?type`
 [parameter in the API itself](apiv2_custom_page_fields).
 
+(form_page_fields_api_field)=
+
+### Adding form fields to the API
+
+If you have a FormBuilder page called `FormPage` this is an example of how you would expose the form fields to the API:
+
+```python
+from wagtail.api import APIField
+
+class FormPage(AbstractEmailForm):
+    #...
+    api_fields = [
+        APIField('form_fields'),
+    ]
+```
+
 ### Custom serializers
 
 [Serializers](https://www.django-rest-framework.org/api-guide/fields/) are used to convert the database representation of a model into

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -20,6 +20,7 @@ depth: 1
  * Add full support for secondary buttons with icons in the Wagtail design system - `button bicolor button--icon button-secondary` including the `button-small` variant (Seremba Patrick)
  * Add [`purge_embeds`](purge_embeds) management command to delete all the cached embed objects in the database (Aman Pandey)
  * Make it possible to resize the page editor’s side panels (Sage Abdullah)
+ * Add ability to include [`form_fields` as an APIField](form_page_fields_api_field) on `FormPage` (Sævar Öfjörð Magnússon, Suyash Singh, LB (Ben) Johnston)
 
 ### Bug fixes
 

--- a/wagtail/api/v2/tests/test_pages.py
+++ b/wagtail/api/v2/tests/test_pages.py
@@ -1554,6 +1554,60 @@ class TestPageDetail(TestCase):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(content, {"message": "'title' does not support nested fields"})
 
+    def test_form_fields_on_form_page(self):
+        """
+        Check that adding form_fields will correctly return then in the API response when declared
+        """
+
+        home_page = Page.objects.get(slug="home-page")
+        form_page = home_page.add_child(instance=models.FormPage(title="Contact us"))
+
+        field_1 = models.FormField.objects.create(
+            page=form_page,
+            sort_order=1,
+            label="email",
+            field_type="email",
+        )
+        field_2 = models.FormField.objects.create(
+            page=form_page,
+            sort_order=2,
+            label="message",
+            field_type="multiline",
+            required=True,
+            help_text="<em>please</em> be polite",
+        )
+
+        response = self.get_response(form_page.pk, fields="form_fields")
+        content = json.loads(response.content.decode("UTF-8"))
+
+        self.assertEqual(
+            content["form_fields"],
+            [
+                {
+                    "id": field_1.pk,
+                    "clean_name": "email",
+                    "meta": {"type": "demosite.FormField"},
+                    "label": "email",
+                    "help_text": "",
+                    "required": True,
+                    "field_type": "email",
+                    "choices": "",
+                    "default_value": "",
+                },
+                {
+                    "id": field_2.pk,
+                    "clean_name": "message",
+                    "meta": {"type": "demosite.FormField"},
+                    "label": "message",
+                    "help_text": "<em>please</em> be polite",
+                    "required": True,
+                    "field_type": "multiline",
+                    "choices": "",
+                    "default_value": "",
+                },
+            ],
+        )
+
 
 class TestPageFind(TestCase):
     fixtures = ["demosite.json"]

--- a/wagtail/contrib/forms/models.py
+++ b/wagtail/contrib/forms/models.py
@@ -11,6 +11,7 @@ from django.utils.translation import gettext_lazy as _
 
 from wagtail.admin.mail import send_mail
 from wagtail.admin.panels import FieldPanel
+from wagtail.api import APIField
 from wagtail.contrib.forms.utils import get_field_clean_name
 from wagtail.models import Orderable, Page
 
@@ -119,6 +120,16 @@ class AbstractFormField(Orderable):
         FieldPanel("field_type", classname="formbuilder-type"),
         FieldPanel("choices", classname="formbuilder-choices"),
         FieldPanel("default_value", classname="formbuilder-default"),
+    ]
+
+    api_fields = [
+        APIField("clean_name"),
+        APIField("label"),
+        APIField("field_type"),
+        APIField("help_text"),
+        APIField("required"),
+        APIField("choices"),
+        APIField("default_value"),
     ]
 
     def get_field_clean_name(self):

--- a/wagtail/test/demosite/migrations/0001_initial.py
+++ b/wagtail/test/demosite/migrations/0001_initial.py
@@ -1204,4 +1204,120 @@ class Migration(migrations.Migration):
             ),
             preserve_default=True,
         ),
+        migrations.CreateModel(
+            name="FormPage",
+            fields=[
+                (
+                    "page_ptr",
+                    models.OneToOneField(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        parent_link=True,
+                        primary_key=True,
+                        related_name="+",
+                        serialize=False,
+                        to="wagtailcore.page",
+                    ),
+                ),
+            ],
+            options={
+                "abstract": False,
+            },
+            bases=("wagtailcore.page",),
+        ),
+        migrations.CreateModel(
+            name="FormField",
+            fields=[
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                (
+                    "sort_order",
+                    models.IntegerField(blank=True, editable=False, null=True),
+                ),
+                (
+                    "clean_name",
+                    models.CharField(
+                        blank=True,
+                        default="",
+                        help_text="Safe name of the form field, the label converted to ascii_snake_case",
+                        max_length=255,
+                        verbose_name="name",
+                    ),
+                ),
+                (
+                    "label",
+                    models.CharField(
+                        help_text="The label of the form field",
+                        max_length=255,
+                        verbose_name="label",
+                    ),
+                ),
+                (
+                    "field_type",
+                    models.CharField(
+                        choices=[
+                            ("singleline", "Single line text"),
+                            ("multiline", "Multi-line text"),
+                            ("email", "Email"),
+                            ("number", "Number"),
+                            ("url", "URL"),
+                            ("checkbox", "Checkbox"),
+                            ("checkboxes", "Checkboxes"),
+                            ("dropdown", "Drop down"),
+                            ("multiselect", "Multiple select"),
+                            ("radio", "Radio buttons"),
+                            ("date", "Date"),
+                            ("datetime", "Date/time"),
+                            ("hidden", "Hidden field"),
+                        ],
+                        max_length=16,
+                        verbose_name="field type",
+                    ),
+                ),
+                (
+                    "required",
+                    models.BooleanField(default=True, verbose_name="required"),
+                ),
+                (
+                    "choices",
+                    models.TextField(
+                        blank=True,
+                        help_text="Comma or new line separated list of choices. Only applicable in checkboxes, radio and dropdown.",
+                        verbose_name="choices",
+                    ),
+                ),
+                (
+                    "default_value",
+                    models.TextField(
+                        blank=True,
+                        help_text="Default value. Comma or new line separated values supported for checkboxes.",
+                        verbose_name="default value",
+                    ),
+                ),
+                (
+                    "help_text",
+                    models.CharField(
+                        blank=True, max_length=255, verbose_name="help text"
+                    ),
+                ),
+                (
+                    "page",
+                    modelcluster.fields.ParentalKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="form_fields",
+                        to="demosite.formpage",
+                    ),
+                ),
+            ],
+            options={
+                "ordering": ["sort_order"],
+                "abstract": False,
+            },
+        ),
     ]

--- a/wagtail/test/demosite/models.py
+++ b/wagtail/test/demosite/models.py
@@ -9,6 +9,7 @@ from taggit.models import TaggedItemBase
 
 from wagtail.admin.panels import FieldPanel, InlinePanel, MultiFieldPanel
 from wagtail.api import APIField
+from wagtail.contrib.forms.models import AbstractForm, AbstractFormField
 from wagtail.fields import RichTextField
 from wagtail.images.api.fields import ImageRenditionField
 from wagtail.models import Orderable, Page
@@ -677,3 +678,18 @@ ContactPage.promote_panels = [
     MultiFieldPanel(Page.promote_panels, "Common page configuration"),
     FieldPanel("feed_image"),
 ]
+
+
+class FormField(AbstractFormField):
+    page = ParentalKey("FormPage", related_name="form_fields", on_delete=models.CASCADE)
+
+
+class FormPage(AbstractForm):
+
+    page_ptr = models.OneToOneField(
+        Page, parent_link=True, related_name="+", on_delete=models.CASCADE
+    )
+    api_fields = [APIField("form_fields")]
+    content_panels = AbstractForm.content_panels + [
+        InlinePanel("form_fields", label="Form fields")
+    ]


### PR DESCRIPTION
Adding information about how to retrieve form fields from the API.

<!--
Thanks for contributing to Wagtail! 🎉

Before submitting, please review the [contributor guidelines](https://docs.wagtail.org/en/latest/contributing/index.html).
-->

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [x] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [x] **Please list the exact browser and operating system versions you tested**:
    -   [x] **Please list which assistive technologies [^3] you tested**:
-   [x] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
