### PR TITLE
Turn off SQLite `legacy_alter_table` before running `Revision` migration

### DIFF
--- a/wagtail/migrations/0070_rename_pagerevision_revision.py
+++ b/wagtail/migrations/0070_rename_pagerevision_revision.py
@@ -4,6 +4,12 @@ from django.conf import settings
 from django.db import migrations, models
 
 
+def disable_sqlite_legacy_alter_table(apps, schema_editor):
+    # Fix for https://github.com/wagtail/wagtail/issues/8635
+    if schema_editor.connection.vendor == "sqlite":
+        schema_editor.execute("PRAGMA legacy_alter_table = OFF")
+
+
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -12,6 +18,10 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        migrations.RunPython(
+            disable_sqlite_legacy_alter_table,
+            migrations.RunPython.noop,
+        ),
         migrations.RenameModel(
             old_name="PageRevision",
             new_name="Revision",


### PR DESCRIPTION
Fixes #8635.

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
