### PR TITLE
Fix 'create one now' link on snippet choosers

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -60,6 +60,7 @@ Changelog
  * Fix: Ensure `aria-label` is not set on locale selection dropdown within page chooser modal as it was a duplicate of the button contents (LB (Ben Johnston))
  * Fix: Revise the `ModelAdmin` title column behaviour to only link to 'edit' if the user has the correct permissions, fallback to the 'inspect' view or a non-clickable title if needed (Stefan Hammer)
  * Fix: Ensure that `DecimalBlock` preserves the `Decimal` type when retrieving from the database (Yves Serrano)
+ * Fix: When no snippets are added, ensure the snippet chooser modal would have the correct URL for creating a new snippet (Matt Westcott)
 
 
 3.0.1 (16.06.2022)

--- a/docs/releases/4.0.md
+++ b/docs/releases/4.0.md
@@ -72,6 +72,7 @@ When using a queryset to render a list of images, you can now use the ``prefetch
  * Ensure `aria-label` is not set on locale selection dropdown within page chooser modal as it was a duplicate of the button contents (LB (Ben Johnston))
  * Revise the `ModelAdmin` title column behaviour to only link to 'edit' if the user has the correct permissions, fallback to the 'inspect' view or a non-clickable title if needed (Stefan Hammer)
  * Ensure that `DecimalBlock` preserves the `Decimal` type when retrieving from the database (Yves Serrano)
+ * When no snippets are added, ensure the snippet chooser modal would have the correct URL for creating a new snippet (Matt Westcott)
 
 
 ## Upgrade considerations

--- a/wagtail/snippets/templates/wagtailsnippets/chooser/results.html
+++ b/wagtail/snippets/templates/wagtailsnippets/chooser/results.html
@@ -18,7 +18,7 @@
     {% if is_searching %}
         <p role="alert">{% blocktrans trimmed %}Sorry, no snippets match "<em>{{ query_string }}</em>"{% endblocktrans %}</p>
     {% else %}
-        {% url view.add_url_name as wagtailsnippets_create_snippet_url %}
+        {% url add_url_name as wagtailsnippets_create_snippet_url %}
         <p>{% blocktrans trimmed with snippet_type_name=model_opts.verbose_name %}You haven't created any {{ snippet_type_name }} snippets. Why not <a href="{{ wagtailsnippets_create_snippet_url }}" target="_blank" rel="noreferrer">create one now</a>?{% endblocktrans %}</p>
     {% endif %}
 {% endif %}

--- a/wagtail/snippets/tests.py
+++ b/wagtail/snippets/tests.py
@@ -1736,6 +1736,13 @@ class TestSnippetChoose(TestCase, WagtailTestUtils):
             response.json()["html"],
         )
 
+    def test_no_results(self):
+        Advert.objects.all().delete()
+        response = self.get()
+        self.assertTemplateUsed(response, "wagtailsnippets/chooser/choose.html")
+        response_html = response.json()["html"]
+        self.assertIn('href="/admin/snippets/tests/advert/add/"', response_html)
+
     def test_ordering(self):
         """
         Listing should be ordered by PK if no ordering has been set on the model
@@ -1784,6 +1791,32 @@ class TestSnippetChoose(TestCase, WagtailTestUtils):
 
         self.assertEqual(len(response.context["items"]), 1)
         self.assertEqual(response.context["items"][0].text, "English snippet")
+
+
+class TestSnippetChooseResults(TestCase, WagtailTestUtils):
+    fixtures = ["test.json"]
+
+    def setUp(self):
+        self.login()
+        self.url_args = ["tests", "advert"]
+
+    def get(self, params=None):
+        return self.client.get(
+            reverse("wagtailsnippets:choose_results", args=self.url_args), params or {}
+        )
+
+    def test_simple(self):
+        response = self.get()
+        self.assertTemplateUsed(response, "wagtailsnippets/chooser/results.html")
+
+    def test_no_results(self):
+        Advert.objects.all().delete()
+        response = self.get()
+        self.assertTemplateUsed(response, "wagtailsnippets/chooser/results.html")
+        self.assertContains(
+            response,
+            'href="/admin/snippets/tests/advert/add/"',
+        )
 
 
 class TestSnippetChooseWithSearchableSnippet(TestCase, WagtailTestUtils):

--- a/wagtail/snippets/views/chooser.py
+++ b/wagtail/snippets/views/chooser.py
@@ -116,6 +116,8 @@ class BaseChooseView(View):
 class ChooseView(BaseChooseView):
     # Return the choose view as a ModalWorkflow response
     def render_to_response(self):
+        app_label = self.model._meta.app_label
+        model_name = self.model._meta.model_name
         return render_modal_workflow(
             self.request,
             "wagtailsnippets/chooser/choose.html",
@@ -134,6 +136,7 @@ class ChooseView(BaseChooseView):
                 "locale_options": Locale.objects.all()
                 if issubclass(self.model, TranslatableMixin)
                 else [],
+                "add_url_name": f"wagtailsnippets_{app_label}_{model_name}:add",
             },
             json_data={"step": "choose"},
         )


### PR DESCRIPTION
Fix regression introduced in #8422. The change to one URL route per model meant that the URL route for the "create one now" link in the snippet chooser had to be constructed in the view rather than directly in a `{% url %}` tag; however, this wasn't being passed correctly.

* the template was looking for the attribute `view.add_url_name` rather than the `add_url_name` context variable
* results.html is also included from the main ChooseView, so `add_url_name` needs to be passed there too