### PR TITLE
#8334 - chechbox visible in high contrast

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -80,6 +80,7 @@ Changelog
  * Fix: Ensure the linting/formatting npm scripts work on Windows (Anuja Verma)
  * Fix: Fix display of dates in exported xlsx files on macOS Preview and Numbers (Jaap Roes)
  * Fix: Make progress bars’ progress visible in forced colors mode (Anuja Verma)
+ * Fix: Make checkboxes visible in forced colors mode (Anuja Verma)
 
 
 3.0.1 (16.06.2022)

--- a/client/scss/elements/_forms.scss
+++ b/client/scss/elements/_forms.scss
@@ -218,8 +218,10 @@ input[type='checkbox']:checked:before {
   height: 1rem;
   top: 2px;
   inset-inline-start: 2px;
-  filter: contrast(0);
-  fill: currentColor;
+
+  @media (forced-colors: active) {
+    background: ButtonText;
+  }
 }
 
 input[type='checkbox'][disabled]:before {

--- a/client/scss/elements/_forms.scss
+++ b/client/scss/elements/_forms.scss
@@ -218,6 +218,8 @@ input[type='checkbox']:checked:before {
   height: 1rem;
   top: 2px;
   inset-inline-start: 2px;
+  filter:contrast(0);
+  fill:currentColor;
 }
 
 input[type='checkbox'][disabled]:before {

--- a/client/scss/elements/_forms.scss
+++ b/client/scss/elements/_forms.scss
@@ -218,8 +218,8 @@ input[type='checkbox']:checked:before {
   height: 1rem;
   top: 2px;
   inset-inline-start: 2px;
-  filter:contrast(0);
-  fill:currentColor;
+  filter: contrast(0);
+  fill: currentColor;
 }
 
 input[type='checkbox'][disabled]:before {

--- a/docs/releases/4.0.md
+++ b/docs/releases/4.0.md
@@ -92,6 +92,7 @@ When using a queryset to render a list of images, you can now use the `prefetch_
  * Ensure the linting/formatting npm scripts work on Windows (Anuja Verma)
  * Fix display of dates in exported xlsx files on macOS Preview and Numbers (Jaap Roes)
  * Make progress bars’ progress visible in forced colors mode (Anuja Verma)
+ * Make checkboxes visible in forced colors mode (Anuja Verma)
 
 
 ## Upgrade considerations


### PR DESCRIPTION
<!--
Thanks for contributing to Wagtail! 🎉

Before submitting, please review the [contributor guidelines](https://docs.wagtail.org/en/latest/contributing/index.html).
-->

_Please check the following:_

-   [ ] Do the tests still pass?[^1]
-   [ ] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [x] **Please list the exact browser and operating system versions you tested**: Browser : Chrome, Operating System : Windows 11
    -   [x] **Please list which assistive technologies [^3] you tested**: Contrast themes in windows 11 : Aquatic,Dusk,Night Sky,Desert

**Please describe additional details for testing this change**.
Step1: turn on any High contrast modes in windows
Step2: Open the wagtail admin, go to Settings> Users
Step3: Click on the left side to select the uer
Step4: You should be able to see the checkmark even in high contrast mode

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)

Fixes #8334 