### PR TITLE
Use iterator() wherever PageQueryset result caching is not needed

### DIFF
--- a/docs/reference/contrib/redirects.rst
+++ b/docs/reference/contrib/redirects.rst
@@ -55,9 +55,12 @@ For more information, please see :meth:`~wagtail.models.Page.get_route_paths`.
 Disabling automatic redirect creation
 -------------------------------------
 
-Wagtail's default implementation works best for small-to-medium sized projects (5000 pages or fewer) that mostly use Wagtail's built-in methods for URL generation.
+.. versionupdated:: 4.0
+  When generating redirects, custom field values are now fetched as part of the
+  initial database query, so using custom field values in overridden url methods
+  will no longer trigger additional per-object queries.
 
-Overrides to the following ``Page`` methods are respected when generating redirects, but use of specific page fields in those overrides will trigger additional database queries.
+Wagtail's default implementation works best for small-to-medium sized projects (5000 pages or fewer) that mostly use Wagtail's built-in methods for URL generation. However, overrides to the following ``Page`` methods are respected when generating redirects.
 
 * :meth:`~wagtail.models.Page.get_url_parts()`
 * :meth:`~wagtail.models.Page.get_route_paths()`

--- a/wagtail/actions/copy_page.py
+++ b/wagtail/actions/copy_page.py
@@ -311,7 +311,7 @@ class CopyPageAction:
         if self.recursive:
             numchild = 0
 
-            for child_page in page.get_children().specific():
+            for child_page in page.get_children().specific().iterator():
                 newdepth = _mpnode_attrs[1] + 1
                 child_mpnode_attrs = (
                     Page._get_path(_mpnode_attrs[0], newdepth, numchild),

--- a/wagtail/actions/create_alias.py
+++ b/wagtail/actions/create_alias.py
@@ -217,7 +217,7 @@ class CreatePageAliasAction:
 
             numchild = 0
 
-            for child_page in page.get_children().specific():
+            for child_page in page.get_children().specific().iterator():
                 newdepth = _mpnode_attrs[1] + 1
                 child_mpnode_attrs = (
                     Page._get_path(_mpnode_attrs[0], newdepth, numchild),

--- a/wagtail/actions/delete_page.py
+++ b/wagtail/actions/delete_page.py
@@ -33,7 +33,7 @@ class DeletePageAction:
         # works around a bug in treebeard <= 3.0 where calling SpecificPage.delete() fails to delete
         # child pages that are not instances of SpecificPage
         if type(page) is Page:
-            for child in page.get_descendants().specific():
+            for child in page.get_descendants().specific().iterator():
                 self.log_deletion(child)
             self.log_deletion(page.specific)
 

--- a/wagtail/actions/unpublish_page.py
+++ b/wagtail/actions/unpublish_page.py
@@ -96,7 +96,11 @@ class UnpublishPageAction:
 
             user_perms = UserPagePermissionsProxy(self.user)
             for live_descendant_page in (
-                self.page.get_descendants().live().defer_streamfields().specific()
+                self.page.get_descendants()
+                .live()
+                .defer_streamfields()
+                .specific()
+                .iterator()
             ):
                 action = UnpublishPageAction(live_descendant_page)
                 if user_perms.for_page(live_descendant_page).can_unpublish():

--- a/wagtail/admin/views/pages/bulk_actions/publish.py
+++ b/wagtail/admin/views/pages/bulk_actions/publish.py
@@ -48,7 +48,11 @@ class PublishBulkAction(PageBulkAction):
 
             if include_descendants:
                 for draft_descendant_page in (
-                    page.get_descendants().not_live().defer_streamfields().specific()
+                    page.get_descendants()
+                    .not_live()
+                    .defer_streamfields()
+                    .specific()
+                    .iterator()
                 ):
                     if (
                         user is None

--- a/wagtail/admin/views/pages/bulk_actions/unpublish.py
+++ b/wagtail/admin/views/pages/bulk_actions/unpublish.py
@@ -52,7 +52,11 @@ class UnpublishBulkAction(PageBulkAction):
 
             if include_descendants:
                 for live_descendant_page in (
-                    page.get_descendants().live().defer_streamfields().specific()
+                    page.get_descendants()
+                    .live()
+                    .defer_streamfields()
+                    .specific()
+                    .iterator()
                 ):
                     if user is None or permission_checker(live_descendant_page):
                         live_descendant_page.unpublish()

--- a/wagtail/contrib/redirects/signal_handlers.py
+++ b/wagtail/contrib/redirects/signal_handlers.py
@@ -157,7 +157,9 @@ def create_redirects(page: Page, page_old: Page, sites: Iterable[Site]) -> None:
     # change, so we can use in-memory manipulation of `url_path` to figure out what
     # the old URLS were
 
-    for descendant in page.get_descendants().live().specific(defer=True).iterator():
+    for descendant in (
+        page.get_descendants().live().defer_streamfields().specific().iterator()
+    ):
         new_urls = _page_urls_for_sites(descendant, sites, cache_target=page)
 
         # Restore old 'url_path' value on in-memory instance

--- a/wagtail/contrib/sitemaps/sitemap_generator.py
+++ b/wagtail/contrib/sitemaps/sitemap_generator.py
@@ -41,7 +41,7 @@ class Sitemap(DjangoSitemap):
         urls = []
         last_mods = set()
 
-        for item in self.paginator.page(page).object_list:
+        for item in self.paginator.page(page).object_list.iterator():
 
             url_info_items = item.get_sitemap_urls(self.request)
 


### PR DESCRIPTION
Follow up to #8271, which made it possible to use `iterator()` alongside `specific()`.

These changes should make Wagtail more stable when encountering unexpectedly high numbers of pages.