### PR TITLE
Move `get_snippet_panel` to `get_edit_handler` and fix missing return in `get_snippet_edit_handler`

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -41,6 +41,7 @@ Changelog
  * Rename `Page.get_latest_revision_as_page` to `Page.get_latest_revision_as_object` (Sage Abdullah)
  * Cache model permission codenames in PermissionHelper (Tidiane Dia)
  * Selecting a new parent page for moving a page now uses the chooser modal which allows searching (Viggo de Vries)
+ * Move `get_snippet_edit_handler` function to `wagtail.admin.panels.get_edit_handler` (Sage Abdullah)
  * Fix: Typo in `ResumeWorkflowActionFormatter` message (Stefan Hammer)
  * Fix: Throw a meaningful error when saving an image to an unrecognised image format (Christian Franke)
  * Fix: Remove extra padding for headers with breadcrumbs on mobile viewport (Steven Steinwand)

--- a/docs/releases/4.0.md
+++ b/docs/releases/4.0.md
@@ -118,3 +118,7 @@ The `Page.get_latest_revision_as_page` method has been renamed to `Page.get_late
 ### `AdminChooser` replaced with `BaseChooser`
 
 Custom choosers should no longer use `wagtail.admin.widgets.chooser.AdminChooser` which has been replaced with `wagtail.admin.widgets.chooser.BaseChooser`.
+
+### `get_snippet_edit_handler` moved to `wagtail.admin.panels.get_edit_handler`
+
+The `get_snippet_edit_handler` function in `wagtail.snippets.views.snippets` has been moved to `get_edit_handler` in `wagtail.admin.panels`.


### PR DESCRIPTION
The reinstatement of `get_snippet_edit_handler` in #8407 was missing a `return`.

While working on other PRs for snippets, I found the `get_snippet_panel` function to be generic enough to be used in any model, and moving it to `wagtail.admin.panels` would really help in making some views generic (e.g. the revisions compare view).

Kindly review @kaedroho @gasman, thanks!

<!--
Thanks for contributing to Wagtail! 🎉

Before submitting, please review the [contributor guidelines](https://docs.wagtail.org/en/latest/contributing/index.html).
-->

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
