### PR TITLE
Cleanup - eslint import rules - formatting

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,7 +5,6 @@ const legacyCode = {
   'constructor-super': 'off',
   'default-param-last': 'off',
   'import/first': 'off',
-  'import/newline-after-import': 'off',
   'import/no-cycle': 'off',
   'import/no-extraneous-dependencies': 'off',
   'import/no-useless-path-segments': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,7 +4,6 @@ const legacyCode = {
   'class-methods-use-this': 'off',
   'constructor-super': 'off',
   'default-param-last': 'off',
-  'import/first': 'off',
   'import/no-cycle': 'off',
   'import/no-extraneous-dependencies': 'off',
   'jsx-a11y/alt-text': 'off',
@@ -119,6 +118,7 @@ module.exports = {
       rules: {
         '@typescript-eslint/no-empty-function': 'off',
         '@typescript-eslint/no-var-requires': 'off',
+        'import/first': 'off',
         'import/no-extraneous-dependencies': 'off',
         'react/function-component-definition': 'off',
         'react/jsx-props-no-spreading': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,7 +7,6 @@ const legacyCode = {
   'import/first': 'off',
   'import/no-cycle': 'off',
   'import/no-extraneous-dependencies': 'off',
-  'import/no-useless-path-segments': 'off',
   'jsx-a11y/alt-text': 'off',
   'jsx-a11y/anchor-is-valid': 'off',
   'jsx-a11y/click-events-have-key-events': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,7 +8,6 @@ const legacyCode = {
   'import/no-cycle': 'off',
   'import/no-extraneous-dependencies': 'off',
   'import/no-useless-path-segments': 'off',
-  'import/order': 'off',
   'jsx-a11y/alt-text': 'off',
   'jsx-a11y/anchor-is-valid': 'off',
   'jsx-a11y/click-events-have-key-events': 'off',

--- a/client/src/components/CommentApp/state/comments.test.ts
+++ b/client/src/components/CommentApp/state/comments.test.ts
@@ -1,3 +1,4 @@
+import { createStore } from 'redux';
 import { basicCommentsState } from '../__fixtures__/state';
 import {
   Comment,
@@ -6,7 +7,6 @@ import {
   CommentUpdate,
   reducer,
 } from './comments';
-import { createStore } from 'redux';
 
 import * as actions from '../actions/comments';
 

--- a/client/src/components/CommentApp/state/comments.ts
+++ b/client/src/components/CommentApp/state/comments.ts
@@ -1,7 +1,7 @@
+import produce, { enableMapSet, enableES5 } from 'immer';
 import type { Annotation } from '../utils/annotation';
 import * as actions from '../actions/comments';
 import { update } from './utils';
-import produce, { enableMapSet, enableES5 } from 'immer';
 
 enableES5();
 enableMapSet();

--- a/client/src/components/CommentApp/state/settings.ts
+++ b/client/src/components/CommentApp/state/settings.ts
@@ -1,7 +1,7 @@
+import produce from 'immer';
 import * as actions from '../actions/settings';
 import type { Author } from './comments';
 import { update } from './utils';
-import produce from 'immer';
 
 export interface SettingsState {
   user: Author | null;

--- a/client/src/components/CommentApp/utils/storybook.tsx
+++ b/client/src/components/CommentApp/utils/storybook.tsx
@@ -10,7 +10,7 @@ import {
   newCommentReply,
   NewReplyOptions,
 } from '../state/comments';
-import { LayoutController } from '../utils/layout';
+import { LayoutController } from './layout';
 import { getNextCommentId } from './sequences';
 
 import CommentComponent from '../components/Comment/index';

--- a/client/src/components/Draftail/CommentableEditor/CommentableEditor.tsx
+++ b/client/src/components/Draftail/CommentableEditor/CommentableEditor.tsx
@@ -1,7 +1,3 @@
-import { gettext } from '../../../utils/gettext';
-import type { CommentApp } from '../../CommentApp/main';
-import type { Annotation } from '../../CommentApp/utils/annotation';
-import type { Comment } from '../../CommentApp/state/comments';
 import {
   DraftailEditor,
   ToolbarButton,
@@ -32,6 +28,10 @@ import React, {
   useState,
 } from 'react';
 import { useSelector, shallowEqual } from 'react-redux';
+import type { Comment } from '../../CommentApp/state/comments';
+import type { Annotation } from '../../CommentApp/utils/annotation';
+import type { CommentApp } from '../../CommentApp/main';
+import { gettext } from '../../../utils/gettext';
 
 import Icon from '../../Icon/Icon';
 

--- a/client/src/components/Draftail/blocks/EmbedBlock.js
+++ b/client/src/components/Draftail/blocks/EmbedBlock.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import { gettext } from '../../../utils/gettext';
-import MediaBlock from '../blocks/MediaBlock';
+import MediaBlock from './MediaBlock';
 
 /**
  * Editor block to display media and edit content.

--- a/client/src/components/Draftail/blocks/EmbedBlock.test.js
+++ b/client/src/components/Draftail/blocks/EmbedBlock.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 
-import EmbedBlock from '../blocks/EmbedBlock';
+import EmbedBlock from './EmbedBlock';
 
 describe('EmbedBlock', () => {
   it('renders', () => {

--- a/client/src/components/Draftail/blocks/ImageBlock.js
+++ b/client/src/components/Draftail/blocks/ImageBlock.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import { gettext } from '../../../utils/gettext';
-import MediaBlock from '../blocks/MediaBlock';
+import MediaBlock from './MediaBlock';
 
 /**
  * Editor block to preview and edit images.

--- a/client/src/components/Draftail/blocks/ImageBlock.test.js
+++ b/client/src/components/Draftail/blocks/ImageBlock.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 
-import ImageBlock from '../blocks/ImageBlock';
+import ImageBlock from './ImageBlock';
 
 describe('ImageBlock', () => {
   it('renders', () => {

--- a/client/src/components/Draftail/blocks/MediaBlock.js
+++ b/client/src/components/Draftail/blocks/MediaBlock.js
@@ -2,9 +2,9 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { Icon } from 'draftail';
 
+import { SelectionState, EditorState } from 'draft-js';
 import Tooltip from '../Tooltip/Tooltip';
 import Portal from '../../Portal/Portal';
-import { SelectionState, EditorState } from 'draft-js';
 
 // Constraints the maximum size of the tooltip.
 const OPTIONS_MAX_WIDTH = 300;

--- a/client/src/components/Draftail/blocks/MediaBlock.test.js
+++ b/client/src/components/Draftail/blocks/MediaBlock.test.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import { shallow, mount } from 'enzyme';
 
-import MediaBlock from '../blocks/MediaBlock';
 import { EditorState } from 'draft-js';
+import MediaBlock from '../blocks/MediaBlock';
 
 describe('MediaBlock', () => {
   it('renders', () => {

--- a/client/src/components/Draftail/blocks/MediaBlock.test.js
+++ b/client/src/components/Draftail/blocks/MediaBlock.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { shallow, mount } from 'enzyme';
 
 import { EditorState } from 'draft-js';
-import MediaBlock from '../blocks/MediaBlock';
+import MediaBlock from './MediaBlock';
 
 describe('MediaBlock', () => {
   it('renders', () => {

--- a/client/src/components/Draftail/decorators/Document.js
+++ b/client/src/components/Draftail/decorators/Document.js
@@ -4,7 +4,7 @@ import React from 'react';
 import { gettext } from '../../../utils/gettext';
 import Icon from '../../Icon/Icon';
 
-import TooltipEntity from '../decorators/TooltipEntity';
+import TooltipEntity from './TooltipEntity';
 
 const documentIcon = <Icon name="doc-full" />;
 const missingDocumentIcon = <Icon name="warning" />;

--- a/client/src/components/Draftail/decorators/Link.js
+++ b/client/src/components/Draftail/decorators/Link.js
@@ -4,7 +4,7 @@ import React from 'react';
 import { gettext } from '../../../utils/gettext';
 import Icon from '../../Icon/Icon';
 
-import TooltipEntity from '../decorators/TooltipEntity';
+import TooltipEntity from './TooltipEntity';
 
 const LINK_ICON = <Icon name="link" />;
 const BROKEN_LINK_ICON = <Icon name="warning" />;

--- a/client/src/components/Draftail/index.js
+++ b/client/src/components/Draftail/index.js
@@ -6,11 +6,6 @@ import { Provider } from 'react-redux';
 import { gettext } from '../../utils/gettext';
 import Icon from '../Icon/Icon';
 
-export { default as Link } from './decorators/Link';
-export { default as Document } from './decorators/Document';
-export { default as ImageBlock } from './blocks/ImageBlock';
-export { default as EmbedBlock } from './blocks/EmbedBlock';
-
 import {
   ModalWorkflowSource,
   ImageModalWorkflowSource,
@@ -24,6 +19,11 @@ import EditorFallback from './EditorFallback/EditorFallback';
 import CommentableEditor, {
   getSplitControl,
 } from './CommentableEditor/CommentableEditor';
+
+export { default as Link } from './decorators/Link';
+export { default as Document } from './decorators/Document';
+export { default as ImageBlock } from './blocks/ImageBlock';
+export { default as EmbedBlock } from './blocks/EmbedBlock';
 
 // 1024x1024 SVG path rendering of the "↵" character, that renders badly in MS Edge.
 const BR_ICON =

--- a/client/src/components/Draftail/sources/ModalWorkflowSource.test.js
+++ b/client/src/components/Draftail/sources/ModalWorkflowSource.test.js
@@ -1,13 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 
-import {
-  ImageModalWorkflowSource,
-  EmbedModalWorkflowSource,
-  LinkModalWorkflowSource,
-  DocumentModalWorkflowSource,
-} from './ModalWorkflowSource';
-import * as DraftUtils from '../DraftUtils';
 import { DraftUtils as DraftailUtils } from 'draftail';
 import {
   EditorState,
@@ -16,6 +9,13 @@ import {
   RichUtils,
   Modifier,
 } from 'draft-js';
+import {
+  ImageModalWorkflowSource,
+  EmbedModalWorkflowSource,
+  LinkModalWorkflowSource,
+  DocumentModalWorkflowSource,
+} from './ModalWorkflowSource';
+import * as DraftUtils from '../DraftUtils';
 
 global.ModalWorkflow = () => {};
 

--- a/client/src/components/LoadingSpinner/LoadingSpinner.js
+++ b/client/src/components/LoadingSpinner/LoadingSpinner.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { gettext } from '../../utils/gettext';
-import Icon from '../../components/Icon/Icon';
+import Icon from '../Icon/Icon';
 
 /**
  * A loading indicator with a text label next to it.

--- a/client/src/components/PageExplorer/PageExplorerHeader.tsx
+++ b/client/src/components/PageExplorer/PageExplorerHeader.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import { ADMIN_URLS } from '../../config/wagtailConfig';
 
 import { gettext } from '../../utils/gettext';
-import Button from '../../components/Button/Button';
-import Icon from '../../components/Icon/Icon';
+import Button from '../Button/Button';
+import Icon from '../Icon/Icon';
 import { PageState } from './reducers/nodes';
 
 interface SelectLocaleProps {

--- a/client/src/components/PageExplorer/PageExplorerItem.tsx
+++ b/client/src/components/PageExplorer/PageExplorerItem.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 
 import { gettext } from '../../utils/gettext';
 import { ADMIN_URLS, LOCALE_NAMES } from '../../config/wagtailConfig';
-import Icon from '../../components/Icon/Icon';
-import Button from '../../components/Button/Button';
-import PublicationStatus from '../../components/PublicationStatus/PublicationStatus';
+import Icon from '../Icon/Icon';
+import Button from '../Button/Button';
+import PublicationStatus from '../PublicationStatus/PublicationStatus';
 import { PageState } from './reducers/nodes';
 
 // Hoist icons in the explorer item, as it is re-rendered many times.

--- a/client/src/components/Sidebar/menu/LinkMenuItem.tsx
+++ b/client/src/components/Sidebar/menu/LinkMenuItem.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 
+import Tippy from '@tippyjs/react';
 import Icon from '../../Icon/Icon';
 import { MenuItemDefinition, MenuItemProps } from './MenuItem';
-import Tippy from '@tippyjs/react';
 
 export const LinkMenuItem: React.FunctionComponent<
   MenuItemProps<LinkMenuItemDefinition>

--- a/client/src/components/Sidebar/menu/PageExplorerMenuItem.tsx
+++ b/client/src/components/Sidebar/menu/PageExplorerMenuItem.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
 
+import { Provider } from 'react-redux';
+import Tippy from '@tippyjs/react';
 import Icon from '../../Icon/Icon';
 import { MenuItemProps } from './MenuItem';
 import { LinkMenuItemDefinition } from './LinkMenuItem';
-import { Provider } from 'react-redux';
 import PageExplorer, { initPageExplorerStore } from '../../PageExplorer';
 import {
   openPageExplorer,
@@ -11,7 +12,6 @@ import {
 } from '../../PageExplorer/actions';
 import { SidebarPanel } from '../SidebarPanel';
 import { SIDEBAR_TRANSITION_DURATION } from '../Sidebar';
-import Tippy from '@tippyjs/react';
 
 export const PageExplorerMenuItem: React.FunctionComponent<
   MenuItemProps<PageExplorerMenuItemDefinition>

--- a/client/src/components/Sidebar/menu/SubMenuItem.tsx
+++ b/client/src/components/Sidebar/menu/SubMenuItem.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
+import Tippy from '@tippyjs/react';
 import Icon from '../../Icon/Icon';
 
 import { renderMenu } from '../modules/MainMenu';
 import { SidebarPanel } from '../SidebarPanel';
 import { SIDEBAR_TRANSITION_DURATION } from '../Sidebar';
 import { MenuItemDefinition, MenuItemProps } from './MenuItem';
-import Tippy from '@tippyjs/react';
 
 interface SubMenuItemProps extends MenuItemProps<SubMenuItemDefinition> {
   slim: boolean;

--- a/client/src/components/Sidebar/modules/MainMenu.tsx
+++ b/client/src/components/Sidebar/modules/MainMenu.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 
+import Tippy from '@tippyjs/react';
 import { gettext } from '../../../utils/gettext';
 import Icon from '../../Icon/Icon';
 
@@ -7,7 +8,6 @@ import { LinkMenuItemDefinition } from '../menu/LinkMenuItem';
 import { MenuItemDefinition } from '../menu/MenuItem';
 import { SubMenuItemDefinition } from '../menu/SubMenuItem';
 import { ModuleDefinition } from '../Sidebar';
-import Tippy from '@tippyjs/react';
 
 export function renderMenu(
   path: string,

--- a/client/src/components/Sidebar/modules/Search.tsx
+++ b/client/src/components/Sidebar/modules/Search.tsx
@@ -1,10 +1,9 @@
 import * as React from 'react';
 
+import Tippy from '@tippyjs/react';
 import { gettext } from '../../../utils/gettext';
 import Icon from '../../Icon/Icon';
 import { ModuleDefinition, SIDEBAR_TRANSITION_DURATION } from '../Sidebar';
-
-import Tippy from '@tippyjs/react';
 
 interface SearchInputProps {
   slim: boolean;

--- a/client/src/components/StreamField/blocks/FieldBlock.js
+++ b/client/src/components/StreamField/blocks/FieldBlock.js
@@ -1,7 +1,7 @@
 /* global $ */
-import { escapeHtml as h } from '../../../utils/text';
 import ReactDOM from 'react-dom';
 import React from 'react';
+import { escapeHtml as h } from '../../../utils/text';
 import Icon from '../../Icon/Icon';
 
 export class FieldBlock {

--- a/client/src/components/StreamField/blocks/FieldBlock.test.js
+++ b/client/src/components/StreamField/blocks/FieldBlock.test.js
@@ -3,6 +3,7 @@
 import { FieldBlockDefinition } from './FieldBlock';
 
 import $ from 'jquery';
+
 window.$ = $;
 
 window.comments = {

--- a/client/src/components/StreamField/blocks/FieldBlock.test.js
+++ b/client/src/components/StreamField/blocks/FieldBlock.test.js
@@ -1,8 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
-import { FieldBlockDefinition } from './FieldBlock';
-
 import $ from 'jquery';
+import { FieldBlockDefinition } from './FieldBlock';
 
 window.$ = $;
 

--- a/client/src/components/StreamField/blocks/ListBlock.test.js
+++ b/client/src/components/StreamField/blocks/ListBlock.test.js
@@ -1,9 +1,8 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
+import $ from 'jquery';
 import { FieldBlock, FieldBlockDefinition } from './FieldBlock';
 import { ListBlockDefinition, ListBlockValidationError } from './ListBlock';
-
-import $ from 'jquery';
 
 window.$ = $;
 

--- a/client/src/components/StreamField/blocks/ListBlock.test.js
+++ b/client/src/components/StreamField/blocks/ListBlock.test.js
@@ -4,6 +4,7 @@ import { FieldBlock, FieldBlockDefinition } from './FieldBlock';
 import { ListBlockDefinition, ListBlockValidationError } from './ListBlock';
 
 import $ from 'jquery';
+
 window.$ = $;
 
 window.comments = {

--- a/client/src/components/StreamField/blocks/StaticBlock.test.js
+++ b/client/src/components/StreamField/blocks/StaticBlock.test.js
@@ -1,8 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
-import { StaticBlockDefinition } from './StaticBlock';
-
 import $ from 'jquery';
+import { StaticBlockDefinition } from './StaticBlock';
 
 window.$ = $;
 

--- a/client/src/components/StreamField/blocks/StaticBlock.test.js
+++ b/client/src/components/StreamField/blocks/StaticBlock.test.js
@@ -3,6 +3,7 @@
 import { StaticBlockDefinition } from './StaticBlock';
 
 import $ from 'jquery';
+
 window.$ = $;
 
 window.comments = {

--- a/client/src/components/StreamField/blocks/StreamBlock.test.js
+++ b/client/src/components/StreamField/blocks/StreamBlock.test.js
@@ -1,12 +1,11 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
+import $ from 'jquery';
 import { FieldBlockDefinition } from './FieldBlock';
 import {
   StreamBlockDefinition,
   StreamBlockValidationError,
 } from './StreamBlock';
-
-import $ from 'jquery';
 
 window.$ = $;
 

--- a/client/src/components/StreamField/blocks/StreamBlock.test.js
+++ b/client/src/components/StreamField/blocks/StreamBlock.test.js
@@ -7,6 +7,7 @@ import {
 } from './StreamBlock';
 
 import $ from 'jquery';
+
 window.$ = $;
 
 window.comments = {

--- a/client/src/components/StreamField/blocks/StructBlock.test.js
+++ b/client/src/components/StreamField/blocks/StructBlock.test.js
@@ -7,6 +7,7 @@ import {
 } from './StructBlock';
 
 import $ from 'jquery';
+
 window.$ = $;
 
 window.comments = {

--- a/client/src/components/StreamField/blocks/StructBlock.test.js
+++ b/client/src/components/StreamField/blocks/StructBlock.test.js
@@ -1,12 +1,11 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
+import $ from 'jquery';
 import { FieldBlockDefinition } from './FieldBlock';
 import {
   StructBlockDefinition,
   StructBlockValidationError,
 } from './StructBlock';
-
-import $ from 'jquery';
 
 window.$ = $;
 

--- a/client/src/entrypoints/admin/expanding-formset.test.js
+++ b/client/src/entrypoints/admin/expanding-formset.test.js
@@ -1,5 +1,6 @@
 /* global buildExpandingFormset */
 import $ from 'jquery';
+
 window.$ = $;
 
 import './expanding-formset';

--- a/client/src/entrypoints/admin/modal-workflow.test.js
+++ b/client/src/entrypoints/admin/modal-workflow.test.js
@@ -1,4 +1,5 @@
 import $ from 'jquery';
+
 window.$ = $;
 window.jQuery = $;
 

--- a/client/src/entrypoints/contrib/table_block/table.test.js
+++ b/client/src/entrypoints/contrib/table_block/table.test.js
@@ -1,4 +1,5 @@
 import $ from 'jquery';
+
 window.$ = $;
 
 import '../../admin/telepath/telepath';

--- a/client/src/entrypoints/contrib/typed_table_block/typed_table_block.test.js
+++ b/client/src/entrypoints/contrib/typed_table_block/typed_table_block.test.js
@@ -1,10 +1,9 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 import '../../admin/telepath/telepath';
+import $ from 'jquery';
 import { TypedTableBlockDefinition } from './typed_table_block';
 import { FieldBlockDefinition } from '../../../components/StreamField/blocks/FieldBlock';
-
-import $ from 'jquery';
 
 window.$ = $;
 

--- a/client/src/entrypoints/contrib/typed_table_block/typed_table_block.test.js
+++ b/client/src/entrypoints/contrib/typed_table_block/typed_table_block.test.js
@@ -5,6 +5,7 @@ import { TypedTableBlockDefinition } from './typed_table_block';
 import { FieldBlockDefinition } from '../../../components/StreamField/blocks/FieldBlock';
 
 import $ from 'jquery';
+
 window.$ = $;
 
 window.comments = {

--- a/client/src/utils/cleanForSlug.test.js
+++ b/client/src/utils/cleanForSlug.test.js
@@ -1,8 +1,8 @@
+import { cleanForSlug } from './cleanForSlug';
+
 // eslint-disable-next-line no-unused-expressions
 require('../../../wagtail/admin/static_src/wagtailadmin/js/vendor/urlify')
   .default;
-
-import { cleanForSlug } from './cleanForSlug';
 
 describe('page-editor tests', () => {
   describe('cleanForSlug without unicode slugs enabled', () => {

--- a/client/src/utils/cleanForSlug.test.js
+++ b/client/src/utils/cleanForSlug.test.js
@@ -1,6 +1,7 @@
 // eslint-disable-next-line no-unused-expressions
 require('../../../wagtail/admin/static_src/wagtailadmin/js/vendor/urlify')
   .default;
+
 import { cleanForSlug } from './cleanForSlug';
 
 describe('page-editor tests', () => {


### PR DESCRIPTION
* Part of https://github.com/wagtail/wagtail/issues/8731
- remove `'import/first'` rule & format code (move rule to keep in test section though as needed there)
- remove `'import/newline-after-import'` rule & format code
- remove `'import/no-useless-path-segments'` rule & format code
- remove `'import/order'` rule & format code