### PR TITLE
 Cleanup - eslint import rules - removal

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,7 +6,6 @@ const legacyCode = {
   'default-param-last': 'off',
   'import/first': 'off',
   'import/newline-after-import': 'off',
-  'import/no-cycle': 'off',
   'import/no-useless-path-segments': 'off',
   'import/order': 'off',
   'jsx-a11y/alt-text': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,7 +7,6 @@ const legacyCode = {
   'import/first': 'off',
   'import/newline-after-import': 'off',
   'import/no-cycle': 'off',
-  'import/no-extraneous-dependencies': 'off',
   'import/no-useless-path-segments': 'off',
   'import/order': 'off',
   'jsx-a11y/alt-text': 'off',

--- a/client/src/entrypoints/admin/wagtailadmin.js
+++ b/client/src/entrypoints/admin/wagtailadmin.js
@@ -9,7 +9,7 @@ import initCollapsibleBreadcrumbs from '../../includes/breadcrumbs';
 if (process.env.NODE_ENV === 'development') {
   // Run react-axe in development only, so it does not affect performance
   // in production, and does not break unit tests either.
-  // eslint-disable-next-line global-require, @typescript-eslint/no-var-requires
+  // eslint-disable-next-line global-require, @typescript-eslint/no-var-requires, import/no-extraneous-dependencies
   const axe = require('react-axe');
   axe(React, ReactDOM, 1000);
 }


### PR DESCRIPTION
* Part of https://github.com/wagtail/wagtail/issues/8731
* may conflict with #8732 but merging order does not matter
- remove `'import/no-cycle'` rule as it no longer has any errors
- remove `'import/no-extraneous-dependencies'` rule and add single ignore (required)