### PR TITLE
Cleanup - eslint formatting rules - removal & formatting

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,7 +16,6 @@ const legacyCode = {
   'no-else-return': 'off',
   'no-extra-boolean-cast': 'off',
   'no-import-assign': 'off',
-  'no-lonely-if': 'off',
   'no-plusplus': 'off',
   'no-prototype-builtins': 'off',
   'no-restricted-syntax': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,7 +14,6 @@ const legacyCode = {
   'no-await-in-loop': 'off',
   'no-continue': 'off',
   'no-else-return': 'off',
-  'no-import-assign': 'off',
   'no-plusplus': 'off',
   'no-prototype-builtins': 'off',
   'no-restricted-syntax': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,7 +10,6 @@ const legacyCode = {
   'jsx-a11y/interactive-supports-focus': 'off',
   'jsx-a11y/no-noninteractive-element-interactions': 'off',
   'jsx-a11y/role-supports-aria-props': 'off',
-  'lines-between-class-members': 'off',
   'max-classes-per-file': 'off',
   'no-await-in-loop': 'off',
   'no-continue': 'off',
@@ -73,6 +72,12 @@ module.exports = {
     ],
     // does not align with the majority of legacy and newer code, some use named others use default exports
     'import/prefer-default-export': 'off',
+    // allow no lines between single line members (e.g. static declarations)
+    'lines-between-class-members': [
+      'error',
+      'always',
+      { exceptAfterSingleLine: true },
+    ],
     // note you must disable the base rule as it can report incorrect errors
     'no-use-before-define': 'off',
     'react/jsx-filename-extension': ['error', { extensions: ['.js', '.tsx'] }],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,7 +19,6 @@ const legacyCode = {
   'no-prototype-builtins': 'off',
   'no-restricted-syntax': 'off',
   'no-this-before-super': 'off',
-  'operator-assignment': 'off',
   'prefer-destructuring': 'off',
   'prefer-object-spread': 'off',
   'prefer-promise-reject-errors': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,7 +14,6 @@ const legacyCode = {
   'no-await-in-loop': 'off',
   'no-continue': 'off',
   'no-else-return': 'off',
-  'no-extra-boolean-cast': 'off',
   'no-import-assign': 'off',
   'no-plusplus': 'off',
   'no-prototype-builtins': 'off',

--- a/client/src/components/ChooserWidget/index.js
+++ b/client/src/components/ChooserWidget/index.js
@@ -47,9 +47,11 @@ export class Chooser {
   getState() {
     return this.state;
   }
+
   getValue() {
     return this.state && this.state.id;
   }
+
   setState(newState) {
     this.state = newState;
     if (newState) {
@@ -58,13 +60,16 @@ export class Chooser {
       this.renderEmptyState();
     }
   }
+
   clear() {
     this.setState(null);
   }
+
   renderEmptyState() {
     this.input.setAttribute('value', '');
     this.chooserElement.classList.add('blank');
   }
+
   renderState(newState) {
     this.input.setAttribute('value', newState.id);
     this.titleElement.innerText = newState.title;
@@ -80,6 +85,7 @@ export class Chooser {
     }
     return result;
   }
+
   focus() {
     this.chooserElement.querySelector('.action-choose').focus();
   }

--- a/client/src/components/CommentApp/main.tsx
+++ b/client/src/components/CommentApp/main.tsx
@@ -105,11 +105,14 @@ function renderCommentsUi(
 
 export class CommentApp {
   store: Store;
+
   layout: LayoutController;
+
   utils = {
     selectCommentsForContentPathFactory,
     selectCommentFactory,
   };
+
   selectors = {
     selectComments,
     selectEnabled,
@@ -117,6 +120,7 @@ export class CommentApp {
     selectIsDirty,
     selectCommentCount,
   };
+
   actions = commentActionFunctions;
 
   constructor() {
@@ -136,19 +140,23 @@ export class CommentApp {
       }),
     );
   }
+
   updateAnnotation(annotation: Annotation, commentId: number) {
     this.attachAnnotationLayout(annotation, commentId);
     this.store.dispatch(updateComment(commentId, { annotation: annotation }));
   }
+
   attachAnnotationLayout(annotation: Annotation, commentId: number) {
     // Attach an annotation to an existing comment in the layout
 
     // const layout engine know the annotation so it would position the comment correctly
     this.layout.setCommentAnnotation(commentId, annotation);
   }
+
   setCurrentTab(tab: string | null) {
     this.store.dispatch(updateGlobalSettings({ currentTab: tab }));
   }
+
   makeComment(annotation: Annotation, contentpath: string, position = '') {
     const commentId = getNextCommentId();
 
@@ -180,6 +188,7 @@ export class CommentApp {
     );
     return commentId;
   }
+
   setVisible(visible: boolean) {
     this.store.dispatch(
       updateGlobalSettings({
@@ -187,15 +196,18 @@ export class CommentApp {
       }),
     );
   }
+
   invalidateContentPath(contentPath: string) {
     // Called when a given content path on the form is no longer valid (eg, a block has been deleted)
     this.store.dispatch(invalidateContentPath(contentPath));
   }
+
   updateContentPath(commentId: number, newContentPath: string) {
     this.store.dispatch(
       updateComment(commentId, { contentpath: newContentPath }),
     );
   }
+
   renderApp(
     element: HTMLElement,
     outputElement: HTMLElement,

--- a/client/src/components/Draftail/CommentableEditor/CommentableEditor.tsx
+++ b/client/src/components/Draftail/CommentableEditor/CommentableEditor.tsx
@@ -482,7 +482,7 @@ export function findLeastCommonCommentId(block: ContentBlock, offset: number) {
       findCommentStyleRanges(
         block,
         () => {
-          counter = counter + 1;
+          counter += 1;
         },
         (metadata) =>
           metadata.getStyle().some((rangeStyle) => rangeStyle === style),

--- a/client/src/components/Draftail/CommentableEditor/CommentableEditor.tsx
+++ b/client/src/components/Draftail/CommentableEditor/CommentableEditor.tsx
@@ -75,27 +75,32 @@ export class DraftailInlineAnnotation implements Annotation {
     this.focusedBlockKey = '';
     this.cachedMedianRef = null;
   }
+
   addDecoratorRef(ref: DecoratorRef, blockKey: BlockKey) {
     this.decoratorRefs.set(ref, blockKey);
 
     // We're adding a ref, so remove the cached median refs - this needs to be recalculated
     this.cachedMedianRef = null;
   }
+
   removeDecoratorRef(ref: DecoratorRef) {
     this.decoratorRefs.delete(ref);
 
     // We're deleting a ref, so remove the cached median refs - this needs to be recalculated
     this.cachedMedianRef = null;
   }
+
   setFocusedBlockKey(blockKey: BlockKey) {
     this.focusedBlockKey = blockKey;
   }
+
   static getHeightForRef(ref: DecoratorRef) {
     if (ref.current) {
       return ref.current.getBoundingClientRect().top;
     }
     return 0;
   }
+
   static getMedianRef(refArray: Array<DecoratorRef>) {
     const refs = refArray.sort(
       (firstRef, secondRef) =>
@@ -107,9 +112,11 @@ export class DraftailInlineAnnotation implements Annotation {
     }
     return null;
   }
+
   getTab() {
     return this.field.closest('[role="tabpanel"]')?.getAttribute('id');
   }
+
   getAnchorNode(focused = false) {
     // The comment should always aim to float by an annotation, rather than between them
     // so calculate which annotation is the median one by height and float the comment by that

--- a/client/src/components/StreamField/blocks/BaseSequenceBlock.js
+++ b/client/src/components/StreamField/blocks/BaseSequenceBlock.js
@@ -51,6 +51,7 @@ class ActionButton {
   enable() {
     this.dom.removeAttr('disabled');
   }
+
   disable() {
     this.dom.attr('disabled', 'true');
   }
@@ -258,31 +259,38 @@ export class BaseSequenceChild extends EventEmitter {
       this.block.setCapabilityOptions('duplicate', { enabled: true });
     }
   }
+
   disableDuplication() {
     this.emit('disableDuplication');
     if (this.block && this.block.setCapabilityOptions) {
       this.block.setCapabilityOptions('duplicate', { enabled: false });
     }
   }
+
   enableSplit() {
     if (this.block && this.block.setCapabilityOptions) {
       this.block.setCapabilityOptions('split', { enabled: true });
     }
   }
+
   disableSplit() {
     if (this.block && this.block.setCapabilityOptions) {
       this.block.setCapabilityOptions('split', { enabled: false });
     }
   }
+
   enableMoveUp() {
     this.emit('enableMoveUp');
   }
+
   disableMoveUp() {
     this.emit('disableMoveUp');
   }
+
   enableMoveDown() {
     this.emit('enableMoveDown');
   }
+
   disableMoveDown() {
     this.emit('disableMoveDown');
   }

--- a/client/src/components/StreamField/blocks/StreamBlock.js
+++ b/client/src/components/StreamField/blocks/StreamBlock.js
@@ -173,6 +173,7 @@ class StreamBlockMenu extends BaseInsertionControl {
       this.open({ animate: true });
     }
   }
+
   open(opts) {
     if (!this.canAddBlock) {
       return;
@@ -188,6 +189,7 @@ class StreamBlockMenu extends BaseInsertionControl {
     this.outerContainer.attr('aria-hidden', 'false');
     this.isOpen = true;
   }
+
   close(opts) {
     if (opts && opts.animate) {
       this.outerContainer.slideUp();

--- a/client/src/entrypoints/admin/bulk-actions.js
+++ b/client/src/entrypoints/admin/bulk-actions.js
@@ -167,18 +167,16 @@ function onSelectIndividualCheckbox(e) {
     let numObjectsSelected = '';
     if (numCheckedObjects === 1) {
       numObjectsSelected = getStringForListing('SINGULAR');
+    } else if (numCheckedObjects === checkedState.numObjects) {
+      numObjectsSelected = getStringForListing('ALL').replace(
+        '{0}',
+        numCheckedObjects,
+      );
     } else {
-      if (numCheckedObjects === checkedState.numObjects) {
-        numObjectsSelected = getStringForListing('ALL').replace(
-          '{0}',
-          numCheckedObjects,
-        );
-      } else {
-        numObjectsSelected = getStringForListing('PLURAL').replace(
-          '{0}',
-          numCheckedObjects,
-        );
-      }
+      numObjectsSelected = getStringForListing('PLURAL').replace(
+        '{0}',
+        numCheckedObjects,
+      );
     }
     document.querySelector(BULK_ACTION_NUM_OBJECTS).textContent =
       numObjectsSelected;

--- a/client/src/entrypoints/admin/telepath/widgets.js
+++ b/client/src/entrypoints/admin/telepath/widgets.js
@@ -8,15 +8,19 @@ class BoundWidget {
     this.setState(initialState);
     this.parentCapabilities = parentCapabilities || new Map();
   }
+
   getValue() {
     return this.input.val();
   }
+
   getState() {
     return this.input.val();
   }
+
   setState(state) {
     this.input.val(state);
   }
+
   getTextLabel(opts) {
     const val = this.getValue();
     if (typeof val !== 'string') return null;
@@ -26,9 +30,11 @@ class BoundWidget {
     }
     return val;
   }
+
   focus() {
     this.input.focus();
   }
+
   setCapabilityOptions(capability, options) {
     Object.assign(this.parentCapabilities.get(capability), options);
   }
@@ -63,9 +69,11 @@ class BoundCheckboxInput extends BoundWidget {
   getValue() {
     return this.input.is(':checked');
   }
+
   getState() {
     return this.input.is(':checked');
   }
+
   setState(state) {
     // if false, set attribute value to null to remove it
     this.input.attr('checked', state || null);
@@ -85,15 +93,19 @@ class BoundRadioSelect {
     this.selector = 'input[name="' + name + '"]:checked';
     this.setState(initialState);
   }
+
   getValue() {
     return this.element.find(this.selector).val();
   }
+
   getState() {
     return this.element.find(this.selector).val();
   }
+
   setState(state) {
     this.element.find('input[name="' + this.name + '"]').val([state]);
   }
+
   focus() {
     this.element.find('input[name="' + this.name + '"]').focus();
   }

--- a/client/src/entrypoints/contrib/typed_table_block/typed_table_block.js
+++ b/client/src/entrypoints/contrib/typed_table_block/typed_table_block.js
@@ -153,10 +153,12 @@ export class TypedTableBlock {
     this.addColumnMenu.show();
     this.addColumnCallback = callback;
   }
+
   hideAddColumnMenu() {
     this.addColumnMenu.hide();
     this.addColumnMenuBaseElement = null;
   }
+
   toggleAddColumnMenu(baseElement, callback) {
     if (this.addColumnMenuBaseElement === baseElement) {
       this.hideAddColumnMenu();
@@ -164,6 +166,7 @@ export class TypedTableBlock {
       this.showAddColumnMenu(baseElement, callback);
     }
   }
+
   clear() {
     // reset to initial empty state with no rows or columns
     this.columns = [];
@@ -192,6 +195,7 @@ export class TypedTableBlock {
     this.tbody.replaceChildren();
     this.addRowButton.hide();
   }
+
   insertColumn(index, blockDef, opts) {
     const column = {
       blockDef,

--- a/client/src/utils/performance.js
+++ b/client/src/utils/performance.js
@@ -13,7 +13,7 @@ if (process.env.NODE_ENV !== 'production') {
     const middleware = (next) => (action) => {
       let result;
 
-      if (!!console.time) {
+      if (console.time) {
         console.time(action.type);
         result = next(action);
         console.timeEnd(action.type);

--- a/wagtail/snippets/static_src/wagtailsnippets/js/snippet-multiple-select.js
+++ b/wagtail/snippets/static_src/wagtailsnippets/js/snippet-multiple-select.js
@@ -21,7 +21,7 @@ var updateDeleteButton = function (anySelected, newState) {
     // hide button and add url
     $deleteButton.removeClass('u-hidden');
     var url = $deleteButton.data('url');
-    url = url + $.param({ id: ids }, true);
+    url += $.param({ id: ids }, true);
     $deleteButton.attr('href', url);
   } else {
     // show button and remove url


### PR DESCRIPTION
* Part of https://github.com/wagtail/wagtail/issues/8731
* This is 100% formatting only - no behaviour will change
* Remove `'lines-between-class-members'` ignoring in legacy rules but allow single lines to be next to each other (e.g. static declarations) for all classes
* ~~Remove `'no-else-return'` ignoring~~ See [comment](https://github.com/wagtail/wagtail/pull/8734#discussion_r904991844) - this will be added to global ignore instead.
* Remove `'no-extra-boolean-cast'` ignoring & format
* Remove `'no-import-assign'` ignoring as no issues flagged
* Remove ` 'no-lonely-if' ignoring & format