### PR TITLE
Shortcut for accessing StreamField blocks by block name/type

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -76,6 +76,8 @@ Changelog
  * Add an extra confirmation prompt when deleting pages with a large number of child pages (Jaspreet Singh)
  * Adopt the slim header in page listing views, with buttons moved under the "Actions" dropdown (Paarth Agarwal)
  * Improve help block styles in Windows High Contrast Mode with less reliance on communication via colour alone (Anuja Verma)
+ * Replace latin abbreviations (i.e. / e.g.) with common English phrases so that documentation is easier to understand (Dominik Lech)
+ * Add shortcut for accessing StreamField blocks by block name with new `blocks_by_name` and `first_block_by_name` methods on `StreamValue` (Tidiane Dia, Matt Westcott)
  * Fix: Typo in `ResumeWorkflowActionFormatter` message (Stefan Hammer)
  * Fix: Throw a meaningful error when saving an image to an unrecognised image format (Christian Franke)
  * Fix: Remove extra padding for headers with breadcrumbs on mobile viewport (Steven Steinwand)
@@ -2204,7 +2206,6 @@ Changelog
  * Added a system check to warn if Pillow is compiled without JPEG / PNG support
  * Page chooser now prevents users from selecting the root node where this would be invalid
  * New translations for Dutch (Netherlands), Georgian, Swedish and Turkish (Turkey)
- * Replace latin abbreviations (i.e. / e.g.) with common English phrases so that documentation is easier to understand (Dominik Lech)
  * Fix: Page slugs are no longer auto-updated from the page title if the page is already published
  * Fix: Deleting a page permission from the groups admin UI does not immediately submit the form
  * Fix: Wagtail userbar is shown on pages that do not pass a `page` variable to the template (e.g. because they override the `serve` method)

--- a/docs/releases/4.0.md
+++ b/docs/releases/4.0.md
@@ -97,6 +97,7 @@ Wagtail’s page preview is now available in a side panel within the page editor
  * Adopt the slim header in page listing views, with buttons moved under the "Actions" dropdown (Paarth Agarwal)
  * Improve help block styles in Windows High Contrast Mode with less reliance on communication via colour alone (Anuja Verma)
  * Replace latin abbreviations (i.e. / e.g.) with common English phrases so that documentation is easier to understand (Dominik Lech)
+ * Add shortcut for accessing StreamField blocks by block name with new [`blocks_by_name` and `first_block_by_name` methods on `StreamValue`](streamfield_retrieving_blocks_by_name) (Tidiane Dia, Matt Westcott)
 
 ### Bug fixes
 

--- a/docs/topics/streamfield.md
+++ b/docs/topics/streamfield.md
@@ -519,6 +519,43 @@ my_page.body.append(('paragraph', RichText("<p>And they all lived happily ever a
 my_page.save()
 ```
 
+(streamfield_retrieving_blocks_by_name)=
+
+## Retrieving blocks by name
+
+```{versionadded} 4.0
+The `blocks_by_name` and `first_block_by_name` methods were added.
+```
+
+StreamField values provide a `blocks_by_name` method for retrieving all blocks of a given name:
+
+```python
+my_page.body.blocks_by_name('heading')  # returns a list of 'heading' blocks
+```
+
+Calling `blocks_by_name` with no arguments returns a `dict`-like object, mapping block names to the list of blocks of that name. This is particularly useful in template code, where passing arguments isn't possible:
+
+```html+django
+<h2>Table of contents</h2>
+<ol>
+    {% for heading_block in page.body.blocks_by_name.heading %}
+        <li>{{ heading_block.value }}</li>
+    {% endfor %}
+</ol>
+```
+
+The `first_block_by_name` method returns the first block of the given name in the stream, or `None` if no matching block is found:
+
+```
+hero_image = my_page.body.first_block_by_name('image')
+```
+
+`first_block_by_name` can also be called without arguments to return a `dict`-like mapping:
+
+```html+django
+<div class="hero-image">{{ page.body.first_block_by_name.image }}</div>
+```
+
 (streamfield_migrating_richtext)=
 
 ## Migrating RichTextFields to StreamField


### PR DESCRIPTION
Rebase of #7266 by @Tijani-Dia.

See #7240 

This PR adds three methods/shortcuts to `StreamValue` class.
- `blocks_by_type` Arguments: None
This method returns a  dict consisting of all blocks organised by type.
It allows writing something like the following in templates:
`<h1>{{ page.body.blocks_by_type.heading.0 }}</h1>
`

- `blocks_of_type` Arguments: `block_type`
This method returns all blocks of type `block_type`.

- `first_block_of_type` Arguments: `block_type`
This method returns the first block of type `block_type`

* Do the tests still pass?
  Yes
* Does the code comply with the style guide? 
  Yes
* For Python changes: Have you added tests to cover the new/fixed behaviour?
  Yes
* For new features: Has the documentation been updated accordingly?
  Not yet. I will add it if the implementation is approved.
