### PR TITLE
Cleanup - eslint spread rules - remove ignoring & fix up

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,7 +19,6 @@ const legacyCode = {
   'no-restricted-syntax': 'off',
   'no-this-before-super': 'off',
   'prefer-destructuring': 'off',
-  'prefer-object-spread': 'off',
   'prefer-promise-reject-errors': 'off',
   'react-hooks/exhaustive-deps': 'off',
   'react-hooks/rules-of-hooks': 'off',

--- a/client/src/components/Draftail/index.js
+++ b/client/src/components/Draftail/index.js
@@ -102,7 +102,7 @@ const initEditor = (selector, originalOptions, currentScript) => {
       const plugin = PLUGINS[type.type];
 
       // Override the properties defined in the JS plugin: Python should be the source of truth.
-      return Object.assign({}, plugin, type);
+      return { ...plugin, ...type };
     });
     return {
       rawContentState: rawContentState,

--- a/client/src/components/PageExplorer/PageCount.test.js
+++ b/client/src/components/PageExplorer/PageCount.test.js
@@ -22,7 +22,7 @@ describe('PageCount', () => {
   });
 
   it('plural', () => {
-    const props = Object.assign({}, mockProps);
+    const props = { ...mockProps };
     props.page.children.count = 5;
     expect(shallow(<PageCount {...props} />)).toMatchSnapshot();
   });

--- a/client/src/components/PageExplorer/PageExplorerItem.test.js
+++ b/client/src/components/PageExplorer/PageExplorerItem.test.js
@@ -35,19 +35,19 @@ describe('PageExplorerItem', () => {
   });
 
   it('children', () => {
-    const props = Object.assign({}, mockProps);
+    const props = { ...mockProps };
     props.item.meta.children.count = 5;
     expect(shallow(<PageExplorerItem {...props} />)).toMatchSnapshot();
   });
 
   it('should show a publication status with unpublished changes', () => {
-    const props = Object.assign({}, mockProps);
+    const props = { ...mockProps };
     props.item.meta.status.has_unpublished_changes = true;
     expect(shallow(<PageExplorerItem {...props} />)).toMatchSnapshot();
   });
 
   it('should show a publication status if not live', () => {
-    const props = Object.assign({}, mockProps);
+    const props = { ...mockProps };
     props.item.meta.status.live = false;
     expect(shallow(<PageExplorerItem {...props} />)).toMatchSnapshot();
   });

--- a/client/src/components/PageExplorer/PageExplorerPanel.test.js
+++ b/client/src/components/PageExplorer/PageExplorerPanel.test.js
@@ -36,7 +36,7 @@ describe('PageExplorerPanel', () => {
         shallow(
           <PageExplorerPanel
             {...mockProps}
-            page={Object.assign({ isFetching: true }, mockProps.page)}
+            page={{ isFetching: true, ...mockProps.page }}
           />,
         ),
       ).toMatchSnapshot();
@@ -47,7 +47,7 @@ describe('PageExplorerPanel', () => {
         shallow(
           <PageExplorerPanel
             {...mockProps}
-            page={Object.assign({ isError: true }, mockProps.page)}
+            page={{ isError: true, ...mockProps.page }}
           />,
         ),
       ).toMatchSnapshot();

--- a/client/src/components/PageExplorer/actions.test.js
+++ b/client/src/components/PageExplorer/actions.test.js
@@ -25,7 +25,7 @@ describe('actions', () => {
     });
 
     it('open', () => {
-      const stub = Object.assign({}, stubState);
+      const stub = { ...stubState };
       stub.explorer.isVisible = false;
       const store = mockStore(stub);
       store.dispatch(actions.openPageExplorer(5));
@@ -41,7 +41,7 @@ describe('actions', () => {
     });
 
     it('open at root', () => {
-      const stub = Object.assign({}, stubState);
+      const stub = { ...stubState };
       stub.explorer.isVisible = false;
       const store = mockStore(stub);
       store.dispatch(actions.openPageExplorer(1));
@@ -73,7 +73,7 @@ describe('actions', () => {
     });
 
     it('triggers getChildren', () => {
-      const stub = Object.assign({}, stubState);
+      const stub = { ...stubState };
       stub.nodes[5].isFetching = false;
       const store = mockStore(stub);
       store.dispatch(actions.gotoPage(5, 1));

--- a/client/src/components/PageExplorer/reducers/nodes.ts
+++ b/client/src/components/PageExplorer/reducers/nodes.ts
@@ -134,22 +134,17 @@ export type Action =
 const node = (state = defaultPageState, action: Action): PageState => {
   switch (action.type) {
     case GET_PAGE_SUCCESS:
-      return Object.assign({}, state, action.payload.data, {
-        isError: false,
-      });
+      return { ...state, ...action.payload.data, isError: false };
 
     case GET_CHILDREN_START:
-      return Object.assign({}, state, {
-        isFetchingChildren: true,
-      });
+      return { ...state, isFetchingChildren: true };
 
     case GET_TRANSLATIONS_START:
-      return Object.assign({}, state, {
-        isFetchingTranslations: true,
-      });
+      return { ...state, isFetchingTranslations: true };
 
     case GET_CHILDREN_SUCCESS:
-      return Object.assign({}, state, {
+      return {
+        ...state,
         isFetchingChildren: false,
         isError: false,
         children: {
@@ -158,7 +153,7 @@ const node = (state = defaultPageState, action: Action): PageState => {
             .concat(action.payload.items.map((item) => item.id)),
           count: action.payload.meta.total_count,
         },
-      });
+      };
 
     case GET_TRANSLATIONS_SUCCESS:
       // eslint-disable-next-line no-case-declarations
@@ -168,20 +163,22 @@ const node = (state = defaultPageState, action: Action): PageState => {
         translations.set(item.meta.locale, item.id);
       });
 
-      return Object.assign({}, state, {
+      return {
+        ...state,
         isFetchingTranslations: false,
         isError: false,
         translations,
-      });
+      };
 
     case GET_PAGE_FAILURE:
     case GET_CHILDREN_FAILURE:
     case GET_TRANSLATIONS_FAILURE:
-      return Object.assign({}, state, {
+      return {
+        ...state,
         isFetchingChildren: false,
         isFetchingTranslations: true,
         isError: true,
-      });
+      };
 
     default:
       return state;
@@ -200,9 +197,7 @@ const defaultState: State = {};
 export default function nodes(state = defaultState, action: Action) {
   switch (action.type) {
     case OPEN_EXPLORER: {
-      return Object.assign({}, state, {
-        [action.payload.id]: Object.assign({}, defaultPageState),
-      });
+      return { ...state, [action.payload.id]: { ...defaultPageState } };
     }
 
     case GET_PAGE_SUCCESS:
@@ -211,20 +206,21 @@ export default function nodes(state = defaultState, action: Action) {
     case GET_PAGE_FAILURE:
     case GET_CHILDREN_FAILURE:
     case GET_TRANSLATIONS_FAILURE:
-      return Object.assign({}, state, {
-        // Delegate logic to single-node reducer.
+      return {
+        ...state, // Delegate logic to single-node reducer.
         [action.payload.id]: node(state[action.payload.id], action),
-      });
+      };
 
     case GET_CHILDREN_SUCCESS:
     case GET_TRANSLATIONS_SUCCESS:
       // eslint-disable-next-line no-case-declarations
-      const newState = Object.assign({}, state, {
+      const newState = {
+        ...state,
         [action.payload.id]: node(state[action.payload.id], action),
-      });
+      };
 
       action.payload.items.forEach((item) => {
-        newState[item.id] = Object.assign({}, defaultPageState, item);
+        newState[item.id] = { ...defaultPageState, ...item };
       });
 
       return newState;

--- a/client/src/components/Sidebar/modules/MainMenu.tsx
+++ b/client/src/components/Sidebar/modules/MainMenu.tsx
@@ -50,7 +50,7 @@ export interface MenuState {
 }
 
 function menuReducer(state: MenuState, action: MenuAction) {
-  const newState = Object.assign({}, state);
+  const newState = { ...state };
 
   if (action.type === 'set-active-path') {
     newState.activePath = action.path;

--- a/client/src/entrypoints/admin/core.js
+++ b/client/src/entrypoints/admin/core.js
@@ -29,21 +29,19 @@ function escapeHtml(text) {
 window.escapeHtml = escapeHtml;
 
 function initTagField(id, autocompleteUrl, options) {
-  const finalOptions = Object.assign(
-    {
-      autocomplete: { source: autocompleteUrl },
-      preprocessTag(val) {
-        // Double quote a tag if it contains a space
-        // and if it isn't already quoted.
-        if (val && val[0] !== '"' && val.indexOf(' ') > -1) {
-          return '"' + val + '"';
-        }
+  const finalOptions = {
+    autocomplete: { source: autocompleteUrl },
+    preprocessTag(val) {
+      // Double quote a tag if it contains a space
+      // and if it isn't already quoted.
+      if (val && val[0] !== '"' && val.indexOf(' ') > -1) {
+        return '"' + val + '"';
+      }
 
-        return val;
-      },
+      return val;
     },
-    options,
-  );
+    ...options,
+  };
 
   $('#' + id).tagit(finalOptions);
 }


### PR DESCRIPTION
- Part of https://github.com/wagtail/wagtail/issues/8731
- No functional changes, purely semantics/formatting to align with the baseline eslint rules
- ~~remove `'prefer-destructuring'` rule ignoring & format code~~ See [comment](https://github.com/wagtail/wagtail/pull/8736#discussion_r905014986) - will ignore this globally instead
- remove `'prefer-object-spread'` rule ignoring & format code
