### PR TITLE
Cleanup - eslint re-organise & remove some react rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -84,7 +84,6 @@ module.exports = {
       files: ['client/src/components/**'],
       rules: {
         ...legacyCode,
-        'jsx-a11y/anchor-is-valid': 'off',
         'jsx-a11y/click-events-have-key-events': 'off',
         'jsx-a11y/interactive-supports-focus': 'off',
         'jsx-a11y/no-noninteractive-element-interactions': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -84,7 +84,6 @@ module.exports = {
       files: ['client/src/components/**'],
       rules: {
         ...legacyCode,
-        'jsx-a11y/alt-text': 'off',
         'jsx-a11y/anchor-is-valid': 'off',
         'jsx-a11y/click-events-have-key-events': 'off',
         'jsx-a11y/interactive-supports-focus': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -94,7 +94,6 @@ module.exports = {
         'react/destructuring-assignment': 'off',
         'react/forbid-prop-types': 'off',
         'react/function-component-definition': 'off',
-        'react/jsx-filename-extension': 'off',
         'react/jsx-no-useless-fragment': 'off',
         'react/jsx-props-no-spreading': 'off',
         'react/no-danger': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -94,7 +94,6 @@ module.exports = {
         'react/destructuring-assignment': 'off',
         'react/forbid-prop-types': 'off',
         'react/function-component-definition': 'off',
-        'react/jsx-curly-brace-presence': 'off',
         'react/jsx-filename-extension': 'off',
         'react/jsx-no-useless-fragment': 'off',
         'react/jsx-props-no-spreading': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -94,7 +94,6 @@ module.exports = {
         'react/destructuring-assignment': 'off',
         'react/forbid-prop-types': 'off',
         'react/function-component-definition': 'off',
-        'react/jsx-no-useless-fragment': 'off',
         'react/jsx-props-no-spreading': 'off',
         'react/no-danger': 'off',
         'react/no-deprecated': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,12 +4,6 @@ const legacyCode = {
   'class-methods-use-this': 'off',
   'constructor-super': 'off',
   'default-param-last': 'off',
-  'jsx-a11y/alt-text': 'off',
-  'jsx-a11y/anchor-is-valid': 'off',
-  'jsx-a11y/click-events-have-key-events': 'off',
-  'jsx-a11y/interactive-supports-focus': 'off',
-  'jsx-a11y/no-noninteractive-element-interactions': 'off',
-  'jsx-a11y/role-supports-aria-props': 'off',
   'max-classes-per-file': 'off',
   'no-await-in-loop': 'off',
   'no-continue': 'off',
@@ -20,19 +14,6 @@ const legacyCode = {
   'no-this-before-super': 'off',
   'prefer-destructuring': 'off',
   'prefer-promise-reject-errors': 'off',
-  'react-hooks/exhaustive-deps': 'off',
-  'react-hooks/rules-of-hooks': 'off',
-  'react/button-has-type': 'off',
-  'react/destructuring-assignment': 'off',
-  'react/forbid-prop-types': 'off',
-  'react/function-component-definition': 'off',
-  'react/jsx-curly-brace-presence': 'off',
-  'react/jsx-filename-extension': 'off',
-  'react/jsx-no-useless-fragment': 'off',
-  'react/jsx-props-no-spreading': 'off',
-  'react/no-danger': 'off',
-  'react/no-deprecated': 'off',
-  'react/require-default-props': 'off',
 };
 
 module.exports = {
@@ -89,7 +70,6 @@ module.exports = {
     // Legacy Code - remove from `files` when adopting desired rules in new code progressively
     {
       files: [
-        'client/src/components/**',
         'client/src/entrypoints/**',
         'client/src/utils/**',
         '**/documents/static_src/wagtaildocs/js/add-multiple.js',
@@ -98,6 +78,32 @@ module.exports = {
         '**/snippets/static_src/wagtailsnippets/js/snippet-multiple-select.js',
       ],
       rules: legacyCode,
+    },
+    // Rules that we are ignoring currently due to legacy code in React components only
+    {
+      files: ['client/src/components/**'],
+      rules: {
+        ...legacyCode,
+        'jsx-a11y/alt-text': 'off',
+        'jsx-a11y/anchor-is-valid': 'off',
+        'jsx-a11y/click-events-have-key-events': 'off',
+        'jsx-a11y/interactive-supports-focus': 'off',
+        'jsx-a11y/no-noninteractive-element-interactions': 'off',
+        'jsx-a11y/role-supports-aria-props': 'off',
+        'react-hooks/exhaustive-deps': 'off',
+        'react-hooks/rules-of-hooks': 'off',
+        'react/button-has-type': 'off',
+        'react/destructuring-assignment': 'off',
+        'react/forbid-prop-types': 'off',
+        'react/function-component-definition': 'off',
+        'react/jsx-curly-brace-presence': 'off',
+        'react/jsx-filename-extension': 'off',
+        'react/jsx-no-useless-fragment': 'off',
+        'react/jsx-props-no-spreading': 'off',
+        'react/no-danger': 'off',
+        'react/no-deprecated': 'off',
+        'react/require-default-props': 'off',
+      },
     },
     // Rules we don’t want to enforce for test and tooling code.
     {

--- a/client/src/components/CommentApp/components/Comment/index.tsx
+++ b/client/src/components/CommentApp/components/Comment/index.tsx
@@ -82,12 +82,12 @@ export interface CommentProps {
 }
 
 export default class CommentComponent extends React.Component<CommentProps> {
-  renderReplies({ hideNewReply = false } = {}): React.ReactFragment {
+  renderReplies({ hideNewReply = false } = {}): React.ReactFragment | null {
     const { comment, isFocused, store, user } = this.props;
 
     if (!comment.remoteId) {
       // Hide replies UI if the comment itself isn't saved yet
-      return <></>;
+      return null;
     }
 
     const onChangeNewReply = (value: string) => {
@@ -154,7 +154,7 @@ export default class CommentComponent extends React.Component<CommentProps> {
     // Hide new reply if a reply is being edited as well
     const newReplyHidden = hideNewReply || replyBeingEdited;
 
-    let replyForm = <></>;
+    let replyForm;
     if (!newReplyHidden && (isFocused || comment.newReply)) {
       replyForm = (
         <form onSubmit={sendReply}>
@@ -186,7 +186,7 @@ export default class CommentComponent extends React.Component<CommentProps> {
       // If there is no form, or replies, don't add any elements to the dom
       // This is in case there is a warning after the comment, some special styling
       // is added if that element is that last child so we can't have any hidden elements here.
-      return <></>;
+      return null;
     }
 
     return (

--- a/client/src/components/CommentApp/components/CommentHeader/index.tsx
+++ b/client/src/components/CommentApp/components/CommentHeader/index.tsx
@@ -151,11 +151,7 @@ export const CommentHeader: FunctionComponent<CommentHeaderProps> = ({
         )}
       </div>
       {author && author.avatarUrl && (
-        <img
-          className="comment-header__avatar"
-          src={author.avatarUrl}
-          role="presentation"
-        />
+        <img className="comment-header__avatar" src={author.avatarUrl} alt="" />
       )}
       <span id={descriptionId}>
         <p className="comment-header__author">{author ? author.name : ''}</p>

--- a/client/src/components/Draftail/CommentableEditor/CommentableEditor.tsx
+++ b/client/src/components/Draftail/CommentableEditor/CommentableEditor.tsx
@@ -540,7 +540,7 @@ function getCommentDecorator(commentApp: CommentApp) {
     }, [commentId, annotationNode, blockKey]);
 
     if (!enabled) {
-      return <>{children}</>;
+      return children;
     }
 
     const onClick = () => {

--- a/client/src/components/Draftail/CommentableEditor/CommentableEditor.tsx
+++ b/client/src/components/Draftail/CommentableEditor/CommentableEditor.tsx
@@ -334,7 +334,7 @@ export function getSplitControl(
     return () => (
       <button
         name={name}
-        className={'Draftail-ToolbarButton'}
+        className="Draftail-ToolbarButton"
         type="button"
         aria-label={title}
         data-draftail-balloon={title}

--- a/client/src/components/Draftail/decorators/Link.test.js
+++ b/client/src/components/Draftail/decorators/Link.test.js
@@ -34,6 +34,7 @@ describe('Link', () => {
         <Link
           contentState={content}
           entityKey="1"
+          href="#test"
           onEdit={() => {}}
           onRemove={() => {}}
         >

--- a/client/src/components/Draftail/decorators/__snapshots__/Link.test.js.snap
+++ b/client/src/components/Draftail/decorators/__snapshots__/Link.test.js.snap
@@ -53,6 +53,7 @@ exports[`Link works 1`] = `
     }
   }
   entityKey="1"
+  href="#test"
   icon={
     <Icon
       name="link"

--- a/client/src/components/Draftail/sources/ModalWorkflowSource.test.js
+++ b/client/src/components/Draftail/sources/ModalWorkflowSource.test.js
@@ -425,7 +425,7 @@ describe('ModalWorkflowSource', () => {
             block: () => {},
           }}
           entity={entity}
-          entityKey={'first'}
+          entityKey="first"
           onComplete={onComplete}
           onClose={() => {}}
         />,

--- a/client/src/components/Sidebar/modules/Search.tsx
+++ b/client/src/components/Sidebar/modules/Search.tsx
@@ -41,7 +41,7 @@ export const SearchInput: React.FunctionComponent<SearchInputProps> = ({
   return (
     <form
       role="search"
-      className={`w-h-[42px] w-relative w-box-border w-flex w-items-center w-justify-start w-flex-row w-flex-shrink-0`}
+      className="w-h-[42px] w-relative w-box-border w-flex w-items-center w-justify-start w-flex-row w-flex-shrink-0"
       action={searchUrl}
       method="get"
       onSubmit={onSubmitForm}


### PR DESCRIPTION
- Part of https://github.com/wagtail/wagtail/issues/8731
- Minimal function changes (1 accessibility fix and a few cases where we return `null` instead of an empty react fragment)
- Move all react/jsx legacy rules to their own section that covers the components folder only (easier to manage and more likely that these legacy ignores will last longer as there are a substantial amount of issues flagged).
- remove `'react/jsx-filename-extension` rule ignoring as this is not needed (there is already a tsx specific override in the global rules section)
- remove `'react/jsx-curly-brace-presence'` rule ignoring ans fix minor formatting items
- remove `'jsx-a11y/anchor-is-valid` rule ignoring and fix the only issue (within unit tests)
- remove `' jsx-a11y/alt-text '` rule ignoring & apply correct fix