### PR TITLE
Cleanup - eslint - move some rules ignoring to global

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,7 +5,6 @@ const legacyCode = {
   'default-param-last': 'off',
   'no-await-in-loop': 'off',
   'no-continue': 'off',
-  'no-else-return': 'off',
   'no-plusplus': 'off',
   'no-prototype-builtins': 'off',
   'no-restricted-syntax': 'off',
@@ -55,6 +54,8 @@ module.exports = {
     ],
     // does not align with preference for allowing multiple items per file
     'max-classes-per-file': 'off',
+    // sometimes code just naturally reads as an equal choice between two alternatives, also allows for easier refactoring between return in branches or return at end if off
+    'no-else-return': 'off',
     // allow for one specific edge case
     'no-underscore-dangle': [
       'error',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,7 +9,6 @@ const legacyCode = {
   'no-prototype-builtins': 'off',
   'no-restricted-syntax': 'off',
   'no-this-before-super': 'off',
-  'prefer-promise-reject-errors': 'off',
 };
 
 module.exports = {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,10 +1,8 @@
 // Rules which have been enforced in configuration upgrades and flag issues in existing code.
 // We need to consider whether to disable those rules permanently, or fix the issues.
 const legacyCode = {
-  'class-methods-use-this': 'off',
   'constructor-super': 'off',
   'default-param-last': 'off',
-  'max-classes-per-file': 'off',
   'no-await-in-loop': 'off',
   'no-continue': 'off',
   'no-else-return': 'off',
@@ -33,6 +31,8 @@ module.exports = {
     '@typescript-eslint/explicit-module-boundary-types': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/no-use-before-define': ['error'],
+    // ignoring as it is often convenient to move logic into a class method and static methods are not inherited
+    'class-methods-use-this': 'off',
     'import/extensions': [
       'error',
       'always',
@@ -54,13 +54,17 @@ module.exports = {
       'always',
       { exceptAfterSingleLine: true },
     ],
-    // note you must disable the base rule as it can report incorrect errors
-    'no-use-before-define': 'off',
-    'react/jsx-filename-extension': ['error', { extensions: ['.js', '.tsx'] }],
+    // does not align with preference for allowing multiple items per file
+    'max-classes-per-file': 'off',
+    // allow for one specific edge case
     'no-underscore-dangle': [
       'error',
       { allow: ['__REDUX_DEVTOOLS_EXTENSION__'] },
     ],
+    // note you must disable the base rule as it can report incorrect errors
+    'no-use-before-define': 'off',
+    // using .tsx instead of .jsx for Typescript React components
+    'react/jsx-filename-extension': ['error', { extensions: ['.js', '.tsx'] }],
   },
   settings: {
     'import/core-modules': ['jquery'],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,7 +10,6 @@ const legacyCode = {
   'no-prototype-builtins': 'off',
   'no-restricted-syntax': 'off',
   'no-this-before-super': 'off',
-  'prefer-destructuring': 'off',
   'prefer-promise-reject-errors': 'off',
 };
 
@@ -63,6 +62,8 @@ module.exports = {
     ],
     // note you must disable the base rule as it can report incorrect errors
     'no-use-before-define': 'off',
+    // this rule can be confusing for new JS devs and forces some non-intuitive code for variable assignment
+    'prefer-destructuring': 'off',
     // using .tsx instead of .jsx for Typescript React components
     'react/jsx-filename-extension': ['error', { extensions: ['.js', '.tsx'] }],
   },

--- a/client/src/includes/chooserModal.js
+++ b/client/src/includes/chooserModal.js
@@ -1,4 +1,3 @@
-/* eslint-disable max-classes-per-file */
 import $ from 'jquery';
 import { initTabs } from './tabs';
 import { initTooltips } from './initTooltips';
@@ -231,7 +230,6 @@ class ChooserModalOnloadHandlerFactory {
     initTooltips();
   }
 
-  // eslint-disable-next-line class-methods-use-this
   modalHasTabs(modal) {
     return $('[data-tabs]', modal.body).length;
   }


### PR DESCRIPTION
**Review https://github.com/wagtail/wagtail/pull/9233 first - smaller scoped version of this PR**

---

- Part of https://github.com/wagtail/wagtail/issues/8731
- Allow all code to ignore these two rules as this aligns better with common conventions in the code, move these ignoring rules out of `legacyCode` and into the general ignoring.
- [ ] Follow up - If approved / merged - I will raise an issue for each of these on the wagtail eslint repo for these maybe being removed at that level (along with any others).
- [ ] Additional follow up - PR based on https://github.com/lb-/wagtail/tree/cleanup/8731-eslint-fix-utils-version (clean up of the `version` file, including unit tests & migration to typescript)

---
- remove `prefer-promise-reject-errors` ignoring completely - this does not flag any warnings and is a useful default to have
- `'max-classes-per-file'` - this does not align with larger portions of code where one file can contain multiple 'things', there is not a strict convention of one file per thing (as per the rule to not use default only export being ignored) and adding this strictness does not seem to give much benefit.
- `'class-methods-use-this'` - this also seems to not give much benefit and forces us away from common conventions where splitting logic up into class methods where suitable is useful. Static methods cannot be inherited easily and external functions do not always make sense.
- `no-else-return`- See [comment](https://github.com/wagtail/wagtail/pull/8734#discussion_r904991844). Sometimes code just naturally reads as an equal choice between two alternatives - "return one thing, or return another thing" - and turning one of those cases into a fall-through just seems needlessly quirky for no benefit. It also causes some issues if you wrote the code one way (returning for branches) and then want to re-write for return at the bottom you now have to re-add all the else.
- `prefer-destructuring` - See [comment](https://github.com/wagtail/wagtail/pull/8736#discussion_r905014986). This can cause confusion with "map this object to an object with one property" vs "read this property and set it to a variable". It really does not aid readability, nor does it give us too much benefit for potential code issues. Plus, for new JS devs - destructuring can be hard to grok.
