### PR TITLE
Remove breadcrumbs from ModelAdmin

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -48,7 +48,7 @@ Changelog
  * Use `.iterator()` in a few more places in the admin, to make it more stable on sites with many pages (Andy Babic)
  * Migrate some simple React component files to TypeScript (LB (Ben) Johnston)
  * Deprecate the usage and documentation of the `wagtail.contrib.modeladmin.menus.SubMenu` class, provide a warning if used directing developers to use `wagtail.admin.menu.Menu` instead (Matt Westcott)
- * Remove legacy (non-next) breadcrumbs (Paarth Agarwal)
+ * Remove legacy (non-next) breadcrumbs no longer used, remove `ModelAdmin` usage of breadcrumbs completely (Paarth Agarwal)
  * Fix: Typo in `ResumeWorkflowActionFormatter` message (Stefan Hammer)
  * Fix: Throw a meaningful error when saving an image to an unrecognised image format (Christian Franke)
  * Fix: Remove extra padding for headers with breadcrumbs on mobile viewport (Steven Steinwand)

--- a/docs/releases/4.0.md
+++ b/docs/releases/4.0.md
@@ -51,11 +51,11 @@ When using a queryset to render a list of images, you can now use the `prefetch_
  * Selecting a new parent page for moving a page now uses the chooser modal which allows searching (Viggo de Vries)
  * Add clarity to the search indexing documentation for how `boost` works when using Postgres with the database search backend (Tibor Leupold)
  * Rename `explorer_breadcrumb` template tag to `breadcrumbs` as it is now used in multiple locations (Paarth Agarwal)
- * Remove legacy (non-next) breadcrumbs (Paarth Agarwal)
  * Updated `django-filter` version to support 23 (Yuekui)
  * Use `.iterator()` in a few more places in the admin, to make it more stable on sites with many pages (Andy Babic)
  * Migrate some simple React component files to TypeScript (LB (Ben) Johnston)
  * Deprecate the usage and documentation of the `wagtail.contrib.modeladmin.menus.SubMenu` class, provide a warning if used directing developers to use `wagtail.admin.menu.Menu` instead (Matt Westcott)
+ * Remove legacy (non-next) breadcrumbs no longer used, remove `ModelAdmin` usage of breadcrumbs completely (Paarth Agarwal)
 
 ### Bug fixes
 

--- a/wagtail/contrib/modeladmin/templates/modeladmin/choose_parent.html
+++ b/wagtail/contrib/modeladmin/templates/modeladmin/choose_parent.html
@@ -20,12 +20,17 @@
 {% block content %}
 
     {% block header %}
-        {% include "modeladmin/includes/header_with_breadcrumb.html" with title=view.get_page_title subtitle=view.get_page_subtitle icon=view.header_icon %}
+        {% include "wagtailadmin/shared/header_with_locale_selector.html" with title=view.get_page_title subtitle=view.get_page_subtitle icon=view.header_icon %}
     {% endblock %}
 
     <div>
-
         <div class="nice-padding">
+            <p class="back">
+                <a href="{{ view.index_url }}">
+                    <svg class="icon default" aria-hidden="true"><use href="#icon-arrow-left"></use></svg>
+                    {% blocktrans trimmed with view.verbose_name as model_name %}Back to {{ model_name }} list{% endblocktrans %}
+                </a>
+            </p>
             <h2>{% blocktrans trimmed %}Choose a parent page{% endblocktrans %}</h2>
             <p>{% blocktrans trimmed with view.verbose_name_plural|capfirst as plural %}{{ plural }} can be added to more than one place within your site. Which of the following would you like to be the parent of your new page?{% endblocktrans %}</p>
 

--- a/wagtail/contrib/modeladmin/templates/modeladmin/includes/breadcrumb.html
+++ b/wagtail/contrib/modeladmin/templates/modeladmin/includes/breadcrumb.html
@@ -1,6 +1,0 @@
-{% load i18n wagtailadmin_tags %}
-<ul class="breadcrumb">
-    {% trans 'Home' as home %}
-    <li class="breadcrumb-item home"><a href="{% url 'wagtailadmin_home' %}" class="breadcrumb-link">{% icon name="home" class_name="home_icon" title=home %}{% icon name="arrow-right" class_name="arrow_right_icon" %}</a></li>
-    <li class="breadcrumb-item"><a href="{{ view.index_url }}" class="breadcrumb-link">{{ view.verbose_name_plural|capfirst }}</a></li>
-</ul>

--- a/wagtail/contrib/modeladmin/templates/modeladmin/includes/header_with_breadcrumb.html
+++ b/wagtail/contrib/modeladmin/templates/modeladmin/includes/header_with_breadcrumb.html
@@ -1,5 +1,0 @@
-{% extends "wagtailadmin/shared/header_with_locale_selector.html" %}
-
-{% block breadcrumb %}
-    {% include "modeladmin/includes/breadcrumb.html" %}
-{% endblock %}

--- a/wagtail/contrib/modeladmin/templates/modeladmin/inspect.html
+++ b/wagtail/contrib/modeladmin/templates/modeladmin/inspect.html
@@ -18,16 +18,19 @@
 {% block content %}
 
     {% block header %}
-        {% include "modeladmin/includes/header_with_breadcrumb.html" with title=view.get_page_title subtitle=view.get_page_subtitle icon=view.header_icon %}
+        {% include "wagtailadmin/shared/header_with_locale_selector.html" with title=view.get_page_title subtitle=view.get_page_subtitle icon=view.header_icon %}
     {% endblock %}
 
     <div>
 
         {% block content_main %}
             <div class="nice-padding">
-
-                <p class="back"><a href="{{ view.index_url }}" class="icon icon-arrow-left">{% blocktrans trimmed with view.verbose_name as model_name %}Back to {{ model_name }} list{% endblocktrans %}</a></p>
-
+                <p class="back">
+                    <a href="{{ view.index_url }}">
+                        <svg class="icon default" aria-hidden="true"><use href="#icon-arrow-left"></use></svg>
+                        {% blocktrans trimmed with view.verbose_name as model_name %}Back to {{ model_name }} list{% endblocktrans %}
+                    </a>
+                </p>
                 {% block fields_output %}
                     {% if fields %}
                         <dl>

--- a/wagtail/contrib/modeladmin/tests/test_page_modeladmin.py
+++ b/wagtail/contrib/modeladmin/tests/test_page_modeladmin.py
@@ -176,6 +176,21 @@ class TestInspectView(TestCase, WagtailTestUtils):
         self.assertContains(response, "Birth information")
         self.assertNotContains(response, "author_birth_string")
 
+    def test_back_to_listing(self):
+        response = self.client.get("/admin/modeladmintest/author/inspect/1/")
+        # check that back to listing link exists
+        expected = """
+            <p class="back">
+                    <a href="/admin/modeladmintest/author/">
+                        <svg class="icon default" aria-hidden="true">
+                            <use href="#icon-arrow-left"></use>
+                        </svg>
+                        Back to author list
+                    </a>
+            </p>
+        """
+        self.assertContains(response, expected, html=True)
+
 
 class TestEditView(TestCase, WagtailTestUtils):
     fixtures = ["test_specific.json"]
@@ -256,6 +271,21 @@ class TestChooseParentView(TestCase, WagtailTestUtils):
             response, "%s?next=%s" % (expected_path, expected_next_path)
         )
 
+    def test_back_to_listing(self):
+        response = self.client.post("/admin/tests/eventpage/choose_parent/")
+        # check that back to listing link exists
+        expected = """
+            <p class="back">
+                    <a href="/admin/tests/eventpage/">
+                        <svg class="icon default" aria-hidden="true">
+                            <use href="#icon-arrow-left"></use>
+                        </svg>
+                        Back to event page list
+                    </a>
+            </p>
+        """
+        self.assertContains(response, expected, html=True)
+
 
 class TestChooseParentViewForNonSuperuser(TestCase, WagtailTestUtils):
     fixtures = ["test_specific.json"]
@@ -334,81 +364,6 @@ class TestModeratorAccess(TestCase, WagtailTestUtils):
         self.assertRedirects(
             response, "/admin/pages/4/delete/?next=/admin/tests/eventpage/"
         )
-
-
-class TestHeaderBreadcrumbs(TestCase, WagtailTestUtils):
-    """
-    Test that the <ul class="breadcrumbs">... is inserted within the
-    <header> tag for potential future regression.
-    See https://github.com/wagtail/wagtail/issues/3889
-    """
-
-    fixtures = ["test_specific.json"]
-
-    def setUp(self):
-        self.login()
-
-    def test_choose_parent_page(self):
-        response = self.client.get("/admin/tests/eventpage/choose_parent/")
-
-        # check correct templates were used
-        self.assertTemplateUsed(response, "modeladmin/includes/breadcrumb.html")
-        self.assertTemplateUsed(response, "wagtailadmin/shared/header.html")
-
-        # check that home breadcrumb link exists
-        expected = """
-            <li class="breadcrumb-item home">
-                <a href="/admin/" class="breadcrumb-link">
-                    <svg class="icon icon-home home_icon" aria-hidden="true">
-                        <use href="#icon-home"></use>
-                    </svg>
-                    <span class="visuallyhidden">Home</span>
-                    <svg class="icon icon-arrow-right arrow_right_icon" aria-hidden="true">
-                        <use href="#icon-arrow-right"></use>
-                    </svg>
-                </a>
-            </li>
-        """
-        self.assertContains(response, expected, html=True)
-
-        # check that the breadcrumbs are after the header opening tag
-        content_str = str(response.content)
-        position_of_header = content_str.index(
-            "<header"
-        )  # intentionally not closing tag
-        position_of_breadcrumbs = content_str.index('<ul class="breadcrumb">')
-        self.assertLess(position_of_header, position_of_breadcrumbs)
-
-    def test_choose_inspect_page(self):
-        response = self.client.get("/admin/tests/eventpage/inspect/4/")
-
-        # check correct templates were used
-        self.assertTemplateUsed(response, "modeladmin/includes/breadcrumb.html")
-        self.assertTemplateUsed(response, "wagtailadmin/shared/header.html")
-
-        # check that home breadcrumb link exists
-        expected = """
-            <li class="breadcrumb-item home">
-                <a href="/admin/" class="breadcrumb-link">
-                    <svg class="icon icon-home home_icon" aria-hidden="true">
-                        <use href="#icon-home"></use>
-                    </svg>
-                    <span class="visuallyhidden">Home</span>
-                    <svg class="icon icon-arrow-right arrow_right_icon" aria-hidden="true">
-                        <use href="#icon-arrow-right"></use>
-                    </svg>
-                </a>
-            </li>
-        """
-        self.assertContains(response, expected, html=True)
-
-        # check that the breadcrumbs are after the header opening tag
-        content_str = str(response.content)
-        position_of_header = content_str.index(
-            "<header"
-        )  # intentionally not closing tag
-        position_of_breadcrumbs = content_str.index('<ul class="breadcrumb">')
-        self.assertLess(position_of_header, position_of_breadcrumbs)
 
 
 class TestSearch(TestCase, WagtailTestUtils):

--- a/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
+++ b/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
@@ -595,6 +595,21 @@ class TestInspectView(TestCase, WagtailTestUtils):
         response = self.get_for_book(100)
         self.assertEqual(response.status_code, 404)
 
+    def test_back_to_listing(self):
+        response = self.client.get("/admin/modeladmintest/author/inspect/1/")
+        # check that back to listing link exists
+        expected = """
+            <p class="back">
+                    <a href="/admin/modeladmintest/author/">
+                        <svg class="icon default" aria-hidden="true">
+                            <use href="#icon-arrow-left"></use>
+                        </svg>
+                        Back to author list
+                    </a>
+            </p>
+        """
+        self.assertContains(response, expected, html=True)
+
 
 class TestEditView(TestCase, WagtailTestUtils):
     fixtures = ["modeladmintest_test.json"]
@@ -1019,48 +1034,6 @@ class TestQuoting(TestCase, WagtailTestUtils):
             "/admin/modeladmintest/token/delete/Irregular_5FName/"
         )
         self.assertEqual(response.status_code, 200)
-
-
-class TestHeaderBreadcrumbs(TestCase, WagtailTestUtils):
-    """
-    Test that the <ul class="breadcrumbs">... is inserted within the
-    <header> tag for potential future regression.
-    See https://github.com/wagtail/wagtail/issues/3889
-    """
-
-    fixtures = ["modeladmintest_test.json"]
-
-    def setUp(self):
-        self.login()
-
-    def test_choose_inspect_model(self):
-        response = self.client.get("/admin/modeladmintest/author/inspect/1/")
-
-        # check correct templates were used
-        self.assertTemplateUsed(response, "modeladmin/includes/breadcrumb.html")
-        self.assertTemplateUsed(response, "wagtailadmin/shared/header.html")
-
-        # check that home breadcrumb link exists
-        expected = """
-            <li class="breadcrumb-item home">
-                <a href="/admin/" class="breadcrumb-link">
-                    <svg class="icon icon-home home_icon" aria-hidden="true">
-                        <use href="#icon-home"></use>
-                    </svg>
-                    <span class="visuallyhidden">Home</span>
-                    <svg class="icon icon-arrow-right arrow_right_icon" aria-hidden="true">
-                        <use href="#icon-arrow-right"></use>
-                    </svg>
-                </a>
-            </li>
-        """
-        self.assertContains(response, expected, html=True)
-
-        # check that the breadcrumbs are before the first header closing tag
-        content_str = str(response.content)
-        position_of_header_close = content_str.index("</header>")
-        position_of_breadcrumbs = content_str.index('<ul class="breadcrumb">')
-        self.assertGreater(position_of_header_close, position_of_breadcrumbs)
 
 
 class TestPanelConfigurationChecks(TestCase, WagtailTestUtils):


### PR DESCRIPTION
Addresses 5th part of #8645 and #6904.
I have removed the breadcrumbs from modaladmin.
Added back to events list page button to compensate for breadcrumbs functionality.

Before:

![Screenshot from 2022-06-24 17-59-45](https://user-images.githubusercontent.com/86092410/175536277-2c7b93c5-2c3c-47ea-958e-52d46f28d508.png)
![Screenshot from 2022-06-24 18-00-24](https://user-images.githubusercontent.com/86092410/175536285-cf9a2316-89a5-4ad4-98df-14c68aa63cab.png)

 

After:

![Screenshot from 2022-06-24 17-53-57](https://user-images.githubusercontent.com/86092410/175535935-f0af82bb-8ec4-4959-871c-a4a0633c9708.png)
![Screenshot from 2022-06-24 17-54-18](https://user-images.githubusercontent.com/86092410/175535938-9a7ca5d7-7bec-49bd-87fb-ea768854dee9.png)
![Screenshot from 2022-06-24 17-54-59](https://user-images.githubusercontent.com/86092410/175535941-1e042541-ed7a-41fd-9e29-6c5b990903e4.png)
