### PR TITLE
Cleanup - eslint fixes - utils actions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -73,7 +73,6 @@ module.exports = {
         'client/src/entrypoints/admin/page-editor.js',
         'client/src/entrypoints/admin/telepath/widgets.js',
         'client/src/entrypoints/contrib/typed_table_block/typed_table_block.js',
-        'client/src/utils/actions.ts',
         'client/src/utils/version.js',
       ],
       rules: legacyCode,

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -81,6 +81,7 @@ Changelog
  * Maintenance: Clean up expanding formset and `InlinePanel` JavaScript initialisation code and adopt a class approach (Matt Westcott)
  * Maintenance: Extracted revision and draft state logic from generic views into mixins (Sage Abdullah)
  * Maintenance: Extracted generic lock / unlock views from page lock / unlock views (Sage Abdullah)
+ * Maintenance: Move `identity` JavaScript util into shared utils folder (LB (Ben Johnston))
 
 
 4.1.2 (xx.xx.xxxx) - IN DEVELOPMENT

--- a/client/src/utils/actions.test.js
+++ b/client/src/utils/actions.test.js
@@ -1,0 +1,40 @@
+import { createAction } from './actions';
+
+describe('createAction', () => {
+  it('should accept an action creator and return a function that creates an action', () => {
+    const actionCreator = jest.fn(({ param }) => ({
+      data: true,
+      hasParam: param,
+    }));
+
+    expect(
+      createAction('SOME_ACTION_NAME', actionCreator)({ param: true }),
+    ).toEqual({
+      type: 'SOME_ACTION_NAME',
+      payload: { data: true, hasParam: true },
+    });
+
+    expect(actionCreator).toHaveBeenCalledWith({ param: true });
+  });
+
+  it('should accept an action & meta creator and return a function that creates an action', () => {
+    const actionCreator = jest.fn(() => ({ data: true }));
+
+    const metaCreator = jest.fn(() => ({ meta: true }));
+
+    expect(
+      createAction(
+        'SOME_ACTION_NAME',
+        actionCreator,
+        metaCreator,
+      )({ param: true }),
+    ).toEqual({
+      type: 'SOME_ACTION_NAME',
+      meta: { meta: true },
+      payload: { data: true },
+    });
+
+    expect(actionCreator).toHaveBeenCalledWith({ param: true });
+    expect(metaCreator).toHaveBeenCalledWith({ param: true });
+  });
+});

--- a/client/src/utils/actions.ts
+++ b/client/src/utils/actions.ts
@@ -1,7 +1,4 @@
-// Returns the value of the first argument. All others are ignored.
-function identity<T extends any[]>(...func: T): T[0] {
-  return func[0];
-}
+import { identity } from './identity';
 
 interface Action<N, P, M> {
   type: N;

--- a/client/src/utils/actions.ts
+++ b/client/src/utils/actions.ts
@@ -11,13 +11,13 @@ interface Action<N, P, M> {
 // https://github.com/acdlite/redux-actions/blob/79c68635fb1524c1b1cf8e2398d4b099b53ca8de/src/createAction.js
 export function createAction<N extends string, T extends any[], P, M>(
   type: N,
-  actionCreator: (...args: T) => P = identity,
+  actionCreator?: (...args: T) => P,
   metaCreator?: (...args: T) => M,
 ): (...args: T) => Action<N, P, M> {
   return (...args) => {
     const action: Action<N, P, M> = {
       type,
-      payload: actionCreator(...args),
+      payload: (actionCreator || identity)(...args),
     };
 
     if (action.payload instanceof Error) {

--- a/client/src/utils/identity.test.js
+++ b/client/src/utils/identity.test.js
@@ -1,0 +1,11 @@
+import { identity } from './identity';
+
+describe('identity', () => {
+  it('should return undefined if not called with anything', () => {
+    expect(identity()).toEqual(undefined);
+  });
+
+  it('should return the first value from multiple args supplied', () => {
+    expect(identity('wagtail', 'bird', 'sans')).toEqual('wagtail');
+  });
+});

--- a/client/src/utils/identity.ts
+++ b/client/src/utils/identity.ts
@@ -1,0 +1,10 @@
+/**
+ * Returns the value of the first argument. All others are ignored.
+ *
+ * @example
+ * identity(7, 8, 9)
+ * // 7
+ */
+const identity = <T extends any[]>(...args: T): T[0] => args[0];
+
+export { identity };

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -100,6 +100,7 @@ Wagtail now provides a set of utilities for creating data migrations on StreamFi
  * Clean up expanding formset and `InlinePanel` JavaScript initialisation code and adopt a class approach (Matt Westcott)
  * Extracted revision and draft state logic from generic views into mixins (Sage Abdullah)
  * Extracted generic lock / unlock views from page lock / unlock views (Sage Abdullah)
+ * Move `identity` JavaScript util into shared utils folder (LB (Ben Johnston))
 
 ## Upgrade considerations
 


### PR DESCRIPTION
* part of #8731 - split from #8578
* move `identity` to its own util file (this is a really useful function) & add unit tests for it
* fix the only linting issue in utils/actions.ts - prefer-default-first with a small change
* add a basic set of unit tests for actions.ts