### PR TITLE
Cleanup - eslint - refine the ignored rules for test files

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -116,9 +116,12 @@ module.exports = {
       ],
       rules: {
         '@typescript-eslint/no-empty-function': 'off',
+        '@typescript-eslint/no-unused-vars': 'off',
         '@typescript-eslint/no-var-requires': 'off',
+        'global-require': 'off',
         'import/first': 'off',
         'import/no-extraneous-dependencies': 'off',
+        'no-unused-expressions': 'off',
         'react/function-component-definition': 'off',
         'react/jsx-props-no-spreading': 'off',
       },

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -57,6 +57,7 @@ Changelog
  * Add a `classnames` template tag to easily build up classes from variables provided to a template (Paarth Agarwal)
  * Migrate the dashboard (home) view header to the shared header template and update designs (Paarth Agarwal)
  * Update classes and styles for the shared header templates to align with UI guidelines (Paarth Agarwal)
+ * Clean up multiple eslint rules usage and configs to align better with the Wagtail coding guidelines (LB (Ben Johnston))
  * Fix: Typo in `ResumeWorkflowActionFormatter` message (Stefan Hammer)
  * Fix: Throw a meaningful error when saving an image to an unrecognised image format (Christian Franke)
  * Fix: Remove extra padding for headers with breadcrumbs on mobile viewport (Steven Steinwand)

--- a/client/src/components/StreamField/blocks/FieldBlock.test.js
+++ b/client/src/components/StreamField/blocks/FieldBlock.test.js
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
-
 import $ from 'jquery';
 import { FieldBlockDefinition } from './FieldBlock';
 

--- a/client/src/components/StreamField/blocks/ListBlock.test.js
+++ b/client/src/components/StreamField/blocks/ListBlock.test.js
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
-
 import $ from 'jquery';
 import { FieldBlock, FieldBlockDefinition } from './FieldBlock';
 import { ListBlockDefinition, ListBlockValidationError } from './ListBlock';

--- a/client/src/components/StreamField/blocks/StreamBlock.test.js
+++ b/client/src/components/StreamField/blocks/StreamBlock.test.js
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
-
 import $ from 'jquery';
 import { FieldBlockDefinition } from './FieldBlock';
 import {

--- a/client/src/components/StreamField/blocks/StructBlock.test.js
+++ b/client/src/components/StreamField/blocks/StructBlock.test.js
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
-
 import $ from 'jquery';
 import { FieldBlockDefinition } from './FieldBlock';
 import {

--- a/client/src/entrypoints/contrib/typed_table_block/typed_table_block.test.js
+++ b/client/src/entrypoints/contrib/typed_table_block/typed_table_block.test.js
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
-
 import '../../admin/telepath/telepath';
 import $ from 'jquery';
 import { TypedTableBlockDefinition } from './typed_table_block';

--- a/client/src/utils/text.test.js
+++ b/client/src/utils/text.test.js
@@ -10,7 +10,6 @@ describe('escapeHtml', () => {
 });
 
 describe('cleanForSlug', () => {
-  // eslint-disable-next-line no-unused-expressions, global-require
   require('../../../wagtail/admin/static_src/wagtailadmin/js/vendor/urlify')
     .default;
 

--- a/docs/releases/4.0.md
+++ b/docs/releases/4.0.md
@@ -64,6 +64,7 @@ When using a queryset to render a list of images, you can now use the `prefetch_
  * Add a `classnames` template tag to easily build up classes from variables provided to a template (Paarth Agarwal)
  * Migrate the dashboard (home) view header to the shared header template and update designs (Paarth Agarwal)
  * Update classes and styles for the shared header templates to align with UI guidelines (Paarth Agarwal)
+ * Clean up multiple eslint rules usage and configs to align better with the Wagtail coding guidelines (LB (Ben Johnston))
 
 ### Bug fixes
 


### PR DESCRIPTION
- disable some additional general rules within the tests folders to make writing tests simpler
- `no-unused-expressions` - often needed if we need to test side effects of other functions being loaded (ideally should not happen but for now this is a common use case for jQuery code)
- `global-require` - similar use case to above (side effects) but when importing a module
- `'@typescript-eslint/no-unused-vars` - again, same as above but for ts imports
- Split from https://github.com/wagtail/wagtail/pull/8578