### PR TITLE
cleanup - add `noop` function for common use case

### DIFF
--- a/client/src/components/Button/Button.test.js
+++ b/client/src/components/Button/Button.test.js
@@ -35,8 +35,8 @@ describe('Button', () => {
   it('is clickable', () => {
     const onClick = jest.fn();
     shallow(<Button onClick={onClick} />).simulate('click', {
-      preventDefault() {},
-      stopPropagation() {},
+      preventDefault: jest.fn(),
+      stopPropagation: jest.fn(),
     });
     expect(onClick).toHaveBeenCalledTimes(1);
   });
@@ -46,7 +46,7 @@ describe('Button', () => {
     const preventDefault = jest.fn();
     shallow(<Button />).simulate('click', {
       preventDefault,
-      stopPropagation() {},
+      stopPropagation: jest.fn(),
     });
     expect(preventDefault).toHaveBeenCalledTimes(1);
   });
@@ -55,7 +55,7 @@ describe('Button', () => {
     const preventDefault = jest.fn();
     shallow(<Button href="/admin/" />).simulate('click', {
       preventDefault,
-      stopPropagation() {},
+      stopPropagation: jest.fn(),
     });
     expect(preventDefault).toHaveBeenCalledTimes(0);
   });
@@ -67,7 +67,7 @@ describe('Button', () => {
 
     shallow(<Button href="/admin/" navigate={navigate} />).simulate('click', {
       preventDefault,
-      stopPropagation() {},
+      stopPropagation: jest.fn(),
     });
     expect(preventDefault).toHaveBeenCalledTimes(1);
     expect(navigate).toHaveBeenCalledTimes(1);

--- a/client/src/components/Draftail/CommentableEditor/CommentableEditor.test.tsx
+++ b/client/src/components/Draftail/CommentableEditor/CommentableEditor.test.tsx
@@ -7,6 +7,7 @@ import { EditorState, SelectionState } from 'draft-js';
 import { CommentApp } from '../../CommentApp/main';
 import { updateGlobalSettings } from '../../CommentApp/actions/settings';
 import { newComment } from '../../CommentApp/state/comments';
+import { noop } from '../../../utils/noop';
 
 import CommentableEditor, {
   updateCommentPositions,
@@ -119,9 +120,9 @@ describe('CommentableEditor', () => {
           fieldNode={fieldNode}
           contentPath={contentpath}
           rawContentState={content}
-          onSave={() => {}}
+          onSave={noop}
           inlineStyles={[]}
-          editorRef={() => {}}
+          editorRef={noop}
           colorConfig={{
             standardHighlight: '#FF0000',
             overlappingHighlight: '#00FF00',

--- a/client/src/components/Draftail/blocks/EmbedBlock.test.js
+++ b/client/src/components/Draftail/blocks/EmbedBlock.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 
 import EmbedBlock from './EmbedBlock';
+import { noop } from '../../../utils/noop';
 
 describe('EmbedBlock', () => {
   it('renders', () => {
@@ -37,7 +38,7 @@ describe('EmbedBlock', () => {
             entity: {
               getData: () => ({}),
             },
-            onChange: () => {},
+            onChange: noop,
           }}
         />,
       ),

--- a/client/src/components/Sidebar/index.tsx
+++ b/client/src/components/Sidebar/index.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom';
 import Cookies from 'js-cookie';
 
 import { Sidebar } from './Sidebar';
+import { noop } from '../../utils/noop';
 
 export const SIDEBAR_COLLAPSED_COOKIE_NAME = 'wagtail_sidebar_collapsed';
 
@@ -18,8 +19,7 @@ export function initSidebar() {
     // This promise is used to indicate to any open submenus that the next page has loaded and it should close.
     // As all navigation from the menu at the moment takes the user to another page, we don't need to close the menus.
     // We will need to update this if we later add the ability to render views on the client side.
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    return new Promise<void>(() => {});
+    return new Promise<void>(noop);
   };
 
   if (element && rawProps?.textContent) {

--- a/client/src/components/StreamField/blocks/StaticBlock.test.js
+++ b/client/src/components/StreamField/blocks/StaticBlock.test.js
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
-
 import $ from 'jquery';
 import { StaticBlockDefinition } from './StaticBlock';
 
@@ -28,6 +26,10 @@ describe('telepath: wagtail.blocks.StaticBlock', () => {
   test('it renders correctly', () => {
     expect(document.body.innerHTML).toMatchSnapshot();
   });
+
+  test('boundblock matches the snapshot', () => {
+    expect(boundBlock).toMatchSnapshot();
+  });
 });
 
 describe('telepath: wagtail.blocks.StaticBlock HTML escaping', () => {
@@ -55,6 +57,10 @@ describe('telepath: wagtail.blocks.StaticBlock HTML escaping', () => {
   test("javascript can't execute", () => {
     expect(window.somethingBad.mock.calls.length).toBe(0);
   });
+
+  test('boundblock matches the snapshot', () => {
+    expect(boundBlock).toMatchSnapshot();
+  });
 });
 
 describe('telepath: wagtail.blocks.StaticBlock allows safe HTML', () => {
@@ -81,5 +87,9 @@ describe('telepath: wagtail.blocks.StaticBlock allows safe HTML', () => {
 
   test('javascript can execute', () => {
     expect(window.somethingBad.mock.calls.length).toBe(1);
+  });
+
+  test('boundblock matches the snapshot', () => {
+    expect(boundBlock).toMatchSnapshot();
   });
 });

--- a/client/src/components/StreamField/blocks/__snapshots__/StaticBlock.test.js.snap
+++ b/client/src/components/StreamField/blocks/__snapshots__/StaticBlock.test.js.snap
@@ -1,7 +1,46 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`telepath: wagtail.blocks.StaticBlock HTML escaping boundblock matches the snapshot 1`] = `
+StaticBlock {
+  "blockDef": StaticBlockDefinition {
+    "meta": Object {
+      "icon": "icon",
+      "label": "The label",
+      "text": "The admin text <script>somethingBad();</script>",
+    },
+    "name": "test_field",
+  },
+}
+`;
+
 exports[`telepath: wagtail.blocks.StaticBlock HTML escaping it renders correctly 1`] = `"<div>The admin text &lt;script&gt;somethingBad();&lt;/script&gt;</div>"`;
 
+exports[`telepath: wagtail.blocks.StaticBlock allows safe HTML boundblock matches the snapshot 1`] = `
+StaticBlock {
+  "blockDef": StaticBlockDefinition {
+    "meta": Object {
+      "html": "The admin text <script>somethingBad();</script>",
+      "icon": "icon",
+      "label": "The label",
+    },
+    "name": "test_field",
+  },
+}
+`;
+
 exports[`telepath: wagtail.blocks.StaticBlock allows safe HTML it renders correctly 1`] = `"<div>The admin text <script>somethingBad();</script></div>"`;
+
+exports[`telepath: wagtail.blocks.StaticBlock boundblock matches the snapshot 1`] = `
+StaticBlock {
+  "blockDef": StaticBlockDefinition {
+    "meta": Object {
+      "icon": "icon",
+      "label": "The label",
+      "text": "The admin text",
+    },
+    "name": "test_field",
+  },
+}
+`;
 
 exports[`telepath: wagtail.blocks.StaticBlock it renders correctly 1`] = `"<div>The admin text</div>"`;

--- a/client/src/entrypoints/admin/modal-workflow.js
+++ b/client/src/entrypoints/admin/modal-workflow.js
@@ -5,6 +5,7 @@ possibly after several navigation steps
 
 import $ from 'jquery';
 
+import { noop } from '../../utils/noop';
 import { gettext } from '../../utils/gettext';
 
 /* eslint-disable */
@@ -20,7 +21,7 @@ function ModalWorkflow(opts) {
 
   const self = {};
   const responseCallbacks = opts.responses || {};
-  const errorCallback = opts.onError || function () {};
+  const errorCallback = opts.onError || noop;
 
   /* remove any previous modals before continuing (closing doesn't remove them from the dom) */
   $('body > .modal').remove();

--- a/client/src/utils/noop.test.js
+++ b/client/src/utils/noop.test.js
@@ -1,0 +1,7 @@
+import { noop } from './noop';
+
+describe('noop', () => {
+  it('should return undefined', () => {
+    expect(noop()).toEqual(undefined);
+  });
+});

--- a/client/src/utils/noop.ts
+++ b/client/src/utils/noop.ts
@@ -1,0 +1,7 @@
+/**
+ * This method does nothing, returns `undefined`.
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const noop = (): void => {};
+
+export { noop };


### PR DESCRIPTION
- Adds a `noop` util for common use case where a default function needs to be provided
- Avoids the need to add ignoring where used legitimately, however in some cases there were better alternatives in unit tests like `jest.fn` which does the same thing. Additionally https://github.com/wagtail/wagtail/pull/8749 will allow for no function body in test functions so did not go too far down that rabbit hole.
- Added a small improvement to the bound block unit tests - so we do not have to ignore unused variables here (added snapshots)
- Split from https://github.com/wagtail/wagtail/pull/8578
- This should make other parts of the eslint clean up & rules adoption work easier https://github.com/wagtail/wagtail/issues/8731