### PR TITLE
Migrate Portal React component to Typescript

### DIFF
--- a/client/src/components/Portal/Portal.tsx
+++ b/client/src/components/Portal/Portal.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/static-property-placement */
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { createPortal } from 'react-dom';
@@ -7,7 +8,32 @@ import { createPortal } from 'react-dom';
  * when certain events happen outside.
  * See https://reactjs.org/docs/portals.html.
  */
-class Portal extends Component {
+class Portal extends Component<{
+  closeOnClick: boolean;
+  closeOnResize: boolean;
+  closeOnType: boolean;
+  node: Element;
+  onClose: () => void;
+}> {
+  static propTypes = {
+    onClose: PropTypes.func.isRequired,
+    node: PropTypes.instanceOf(Element),
+    children: PropTypes.node,
+    closeOnClick: PropTypes.bool,
+    closeOnType: PropTypes.bool,
+    closeOnResize: PropTypes.bool,
+  };
+
+  static defaultProps = {
+    node: document.body,
+    children: null,
+    closeOnClick: false,
+    closeOnType: false,
+    closeOnResize: false,
+  };
+
+  portal: HTMLElement;
+
   constructor(props) {
     super(props);
 
@@ -16,10 +42,11 @@ class Portal extends Component {
     this.onCloseEvent = this.onCloseEvent.bind(this);
   }
 
-  onCloseEvent(e) {
+  onCloseEvent(event: MouseEvent) {
     const { onClose } = this.props;
+    const target = event.target as Element;
 
-    if (!this.portal.contains(e.target)) {
+    if (!this.portal.contains(target)) {
       onClose();
     }
   }
@@ -59,22 +86,5 @@ class Portal extends Component {
     return createPortal(children, this.portal);
   }
 }
-
-Portal.propTypes = {
-  onClose: PropTypes.func.isRequired,
-  node: PropTypes.instanceOf(Element),
-  children: PropTypes.node,
-  closeOnClick: PropTypes.bool,
-  closeOnType: PropTypes.bool,
-  closeOnResize: PropTypes.bool,
-};
-
-Portal.defaultProps = {
-  node: document.body,
-  children: null,
-  closeOnClick: false,
-  closeOnType: false,
-  closeOnResize: false,
-};
 
 export default Portal;

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "@types/draft-js": "^0.10.45",
         "@types/jest": "^26.0.24",
         "@types/react": "^16.14.21",
+        "@types/react-dom": "^16.0",
         "@types/react-redux": "^7.1.20",
         "@typescript-eslint/eslint-plugin": "^5.8.0",
         "@typescript-eslint/parser": "^5.8.0",
@@ -13362,6 +13363,15 @@
         "@types/prop-types": "*",
         "@types/scheduler": "*",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "16.9.16",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.16.tgz",
+      "integrity": "sha512-Oqc0RY4fggGA3ltEgyPLc3IV9T73IGoWjkONbsyJ3ZBn+UPPCYpU2ec0i3cEbJuEdZtkqcCF2l1zf2pBdgUGSg==",
+      "dev": true,
+      "dependencies": {
+        "@types/react": "^16"
       }
     },
     "node_modules/@types/react-redux": {
@@ -40709,6 +40719,15 @@
         "csstype": {
           "version": "3.0.10"
         }
+      }
+    },
+    "@types/react-dom": {
+      "version": "16.9.16",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.16.tgz",
+      "integrity": "sha512-Oqc0RY4fggGA3ltEgyPLc3IV9T73IGoWjkONbsyJ3ZBn+UPPCYpU2ec0i3cEbJuEdZtkqcCF2l1zf2pBdgUGSg==",
+      "dev": true,
+      "requires": {
+        "@types/react": "^16"
       }
     },
     "@types/react-redux": {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@types/draft-js": "^0.10.45",
     "@types/jest": "^26.0.24",
     "@types/react": "^16.14.21",
+    "@types/react-dom": "^16.0",
     "@types/react-redux": "^7.1.20",
     "@typescript-eslint/eslint-plugin": "^5.8.0",
     "@typescript-eslint/parser": "^5.8.0",


### PR DESCRIPTION
- medium change to the `Portal` component but means this is now in Typescript so we get some type safety
- adds react-dom types so that Portal is correctly recognised
- Split from https://github.com/wagtail/wagtail/pull/8618