### PR TITLE
Attempting to fix SQLite errors in Squash deployments by updating Docker image

### DIFF
--- a/.squash.yml
+++ b/.squash.yml
@@ -8,7 +8,7 @@ deployments:
       - pip install setuptools pip --upgrade --force-reinstall
       - cd /code
     post_build_steps:
-      - npm install --no-save --no-audit
+      - npm ci --audit=false --progress=false
       - npm run build
       - pip install /code
       - mkdir /myproject

--- a/.squash.yml
+++ b/.squash.yml
@@ -8,7 +8,7 @@ deployments:
       - pip install setuptools pip --upgrade --force-reinstall
       - cd /code
     post_build_steps:
-      - npm install --no-save --no-audit --progress=false
+      - npm install --no-save --no-audit
       - npm run build
       - pip install /code
       - mkdir /myproject

--- a/.squash.yml
+++ b/.squash.yml
@@ -18,6 +18,7 @@ deployments:
       - python manage.py migrate
       - echo "<br><h1>Wagtail test instance</h1><p>Log into <a href='/admin/'>/admin/</a> with 'admin' / 'changeme'.</p>" > home/templates/home/welcome_page.html
       - echo "from django.contrib.auth import get_user_model; User = get_user_model(); User.objects.create_superuser('admin', 'admin@example.com', 'changeme')" | python manage.py shell
+      - echo "CSRF_TRUSTED_ORIGINS = ['https://*.squash.io']" >> mysite/settings/dev.py
     launch_steps:
       - cd /myproject/mysite
       - python manage.py runserver 0.0.0.0:80

--- a/.squash.yml
+++ b/.squash.yml
@@ -1,6 +1,6 @@
 deployments:
   default:
-    dockerimage: python:3.7.4-stretch
+    dockerimage: python:3.10.5-slim-buster
     build_steps:
       - apt-get update && apt-get install -y libssl-dev libpq-dev git build-essential libfontconfig1 libfontconfig1-dev curl
       - RUN bash -c "curl -sL https://deb.nodesource.com/setup_16.x | bash -"

--- a/wagtail/project_template/project_name/settings/dev.py
+++ b/wagtail/project_template/project_name/settings/dev.py
@@ -8,6 +8,7 @@ SECRET_KEY = "{{ secret_key }}"
 
 # SECURITY WARNING: define the correct hosts in production!
 ALLOWED_HOSTS = ["*"]
+CSRF_TRUSTED_ORIGINS = ["*"]
 
 EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 

--- a/wagtail/project_template/project_name/settings/dev.py
+++ b/wagtail/project_template/project_name/settings/dev.py
@@ -8,7 +8,6 @@ SECRET_KEY = "{{ secret_key }}"
 
 # SECURITY WARNING: define the correct hosts in production!
 ALLOWED_HOSTS = ["*"]
-CSRF_TRUSTED_ORIGINS = ["*"]
 
 EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 


### PR DESCRIPTION
Squash deployments are currently failing, apparently due to use of an old version of SQLite.

Some warnings and errors I see:

```
System check identified some issues:
WARNINGS:
: (wagtailsearch.W002) Your SQLite version is older than 3.19.0. A fallback search backend will be used instead.
	HINT: Upgrade your SQLite version to at least 3.19.0
```

```
 Applying wagtailcore.0070_rename_pagerevision_revision...Traceback (most recent call last):
  File "manage.py", line 10, in 
    execute_from_command_line(sys.argv)

  ... [full traceback truncated] ...

  File "/usr/local/lib/python3.7/site-packages/django/db/backends/sqlite3/schema.py", line 94, in alter_db_table
    ) % old_db_table)
django.db.utils.NotSupportedError: Renaming the 'wagtailcore_pagerevision' table while in a transaction
is not supported on SQLite < 3.26 because it would break referential integrity.
Try adding `atomic = False` to the Migration class.
```

`npm install` also failed, and I'm hoping this update will fix that, too:

```
FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
 1: 0xb09c10 node::Abort() [npm install]
 2: 0xa1c193 node::FatalError(char const*, char const*) [npm install]
 3: 0xcf8dde v8::Utils::ReportOOMFailure(v8::internal::Isolate*, char const*, bool) [npm install]
 4: 0xcf9157 v8::internal::V8::FatalProcessOutOfMemory(v8::internal::Isolate*, char const*, bool) [npm install]
 5: 0xeb09f5  [npm install]
 6: 0xec06bd v8::internal::Heap::CollectGarbage(v8::internal::AllocationSpace, v8::internal::GarbageCollectionReason, v8::GCCallbackFlags) [npm install]
 7: 0xec33be v8::internal::Heap::AllocateRawWithRetryOrFailSlowPath(int, v8::internal::AllocationType, v8::internal::AllocationOrigin, v8::internal::AllocationAlignment) [npm install]
 8: 0xe848fa v8::internal::Factory::NewFillerObject(int, bool, v8::internal::AllocationType, v8::internal::AllocationOrigin) [npm install]
 9: 0x11fd646 v8::internal::Runtime_AllocateInYoungGeneration(int, unsigned long*, v8::internal::Isolate*) [npm install]
10: 0x15f20b9  [npm install]
/post_build.sh: line 2:    15 Aborted                 (core dumped) npm install --no-save --no-audit --progress=false
> wagtail@1.0.0 build
> webpack --config ./client/webpack.config.js --mode production
sh: 1: webpack: not found
```

[skip ci]