### PR TITLE
Document the prefix_default_language parameter to i18n_patterns

### DIFF
--- a/docs/advanced_topics/i18n.md
+++ b/docs/advanced_topics/i18n.md
@@ -274,7 +274,7 @@ urlpatterns += i18n_patterns(
 
 ##### Bypass language prefix for the default language
 
-If you want your default language to have urls that resolve normally without a language prefix, 
+If you want your default language to have URLs that resolve normally without a language prefix, 
 you can set the `prefix_default_language` parameter of `i18n_patterns` to `False`.
 For example, if you have your languages configured like this:
 

--- a/docs/advanced_topics/i18n.md
+++ b/docs/advanced_topics/i18n.md
@@ -250,7 +250,7 @@ want to be translated) into an `i18n_patterns` block:
 ```python
 # /my_project/urls.py
 
-...
+# ...
 
 from django.conf.urls.i18n import i18n_patterns
 
@@ -270,6 +270,49 @@ urlpatterns += i18n_patterns(
     path('search/', search_views.search, name='search'),
     path("", include(wagtail_urls)),
 )
+```
+
+##### Bypass language prefix for the default language
+
+If you want your default language to have urls that resolve normally without a language prefix, 
+you can set the `prefix_default_language` parameter of `i18n_patterns` to `False`.
+For example, if you have your languages configured like this:
+
+```python
+# myproject/settings.py
+
+# ...
+
+LANGUAGE_CODE = 'en'
+WAGTAIL_CONTENT_LANGUAGES = LANGUAGES = [
+    ('en', "English"),
+    ('fr', "French"),
+]
+
+# ... 
+```
+
+And your `urls.py` configured like this:
+
+```python
+# myproject/urls.py
+# ...
+
+# These URLs will be available under a language code prefix only for languages that 
+# are not set as default in LANGUAGE_CODE.
+
+urlpatterns += i18n_patterns(
+    path('search/', search_views.search, name='search'),
+    path("", include(wagtail_urls)),
+    prefix_default_language=False,
+)
+```
+
+Your URLs will now be prefixed only for the French version of your website, e.g.
+
+```
+- /search/
+- /fr/search/
 ```
 
 #### User language auto-detection


### PR DESCRIPTION
It would be nice to document the `prefix_default_language` parameter to `18n_patterns` since many people coming to Wagtail might not have intricate knowledge of Django internals.

Setting this parameter as `False` allows you to have "normal" URLs for your default language, and prefixed for all other languages, so I this this piece of information is helpful for developers using Wagtail.

_Please check the following:_

-   [x] ~~Do the tests still pass?[^1]~~
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] ~~For Python changes: Have you added tests to cover the new/fixed behaviour?~~
-   [x] ~~For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]~~
    -   [x] ~~**Please list the exact browser and operating system versions you tested**:~~
    -   [x] ~~**Please list which assistive technologies [^3] you tested**:~~
-   [x] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
