### PR TITLE
Simple / admin breadcrumbs

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/shared/breadcrumbs.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/breadcrumbs.html
@@ -8,7 +8,7 @@
 {% endcomment %}
 {% with breadcrumb_link_classes='w-flex w-items-center w-h-full w-text-primary w-px-0.5 w-text-14 w-no-underline w-outline-offset-inside hover:w-underline hover:w-text-primary w-h-full' breadcrumb_item_classes='w-h-full w-flex w-items-center w-overflow-hidden w-transition w-duration-300 w-whitespace-nowrap w-flex-shrink-0 w-font-bold' icon_classes='w-w-4 w-h-4 w-ml-3' %}
     {# Breadcrumbs are visible on mobile by default but hidden on desktop #}
-    <div class="w-breadcrumb w-flex w-flex-row w-items-center w-overflow-x-auto w-overflow-y-hidden w-scrollbar-thin" data-breadcrumb-next{% if not pages %} hidden{% endif %}>
+    <div class="w-breadcrumb w-flex w-flex-row w-items-center w-overflow-x-auto w-overflow-y-hidden w-scrollbar-thin{% if is_expanded %} w-pl-4{% endif %}" data-breadcrumb-next{% if not pages %} hidden{% endif %}>
         {% if not is_expanded %}
             <button
                 type="button"
@@ -28,7 +28,7 @@
                         {% if page.is_root and url_root_name %}
                             {% url url_root_name as breadcrumb_url %}
                         {% else %}
-                            {% url url_name page.id as breadcrumb_url %}
+                            {% if page.id %}{% url url_name page.id as breadcrumb_url %}{% else %}{% firstof page.url as breadcrumb_url %}{% endif %}
                         {% endif %}
                         {% if page.is_root %}
                             <li
@@ -40,7 +40,7 @@
                                     class="{{ breadcrumb_link_classes }}"
                                     href="{{ breadcrumb_url }}{{ querystring_value }}"
                                 >
-                                    {% trans "Root" %}
+                                    {% if page.id %}{% trans "Root" %}{% else %}{{ page.label }}{% endif %}
                                 </a>
                                 {% icon name="arrow-right" class_name=icon_classes %}
                             </li>
@@ -62,9 +62,8 @@
                                 {% if trailing_breadcrumb_title or is_expanded %}data-breadcrumb-item{% endif %}
                                 {% if trailing_breadcrumb_title and not is_expanded %}hidden{% endif %}
                             >
-                                <a class="{{ breadcrumb_link_classes }}"
-                                    href="{{ breadcrumb_url }}{{ querystring_value }}">
-                                    {{ page.get_admin_display_title }}
+                                <a class="{{ breadcrumb_link_classes }}" href="{{ breadcrumb_url }}{{ querystring_value }}">
+                                    {% if page.id %}{{ page.get_admin_display_title }}{% else %}{{ page.label }}{% endif %}
                                 </a>
                                 {% if trailing_breadcrumb_title %}
                                     {% icon name="arrow-right" class_name=icon_classes %}
@@ -77,7 +76,7 @@
                                 {% if not is_expanded %}hidden{% endif %}
                             >
                                 <a class="{{ breadcrumb_link_classes }}" href="{{ breadcrumb_url }}{{ querystring_value }}">
-                                    {{ page.get_admin_display_title }}
+                                    {% if page.id %}{{ page.get_admin_display_title }}{% else %}{{ page.label }}{% endif %}
                                 </a>
                                 {% icon name="arrow-right" class_name=icon_classes %}
                             </li>

--- a/wagtail/admin/templates/wagtailadmin/shared/headers/page_edit_header.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/headers/page_edit_header.html
@@ -2,7 +2,7 @@
 {% load wagtailadmin_tags i18n %}
 
 {% block header_content %}
-    {% breadcrumbs page 'wagtailadmin_explore' url_root_name='wagtailadmin_explore_root' page_perms=page_perms %}
+    {% breadcrumbs page 'wagtailadmin_explore' url_root_name='wagtailadmin_explore_root' %}
 
     <h1 class="w-sr-only">
         {% blocktrans trimmed with title=page.get_admin_display_title page_type=content_type.model_class.get_verbose_name %}Editing {{ page_type }} {{ title }}{% endblocktrans %}

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -64,7 +64,6 @@ def breadcrumbs(
     url_root_name=None,
     include_self=True,
     is_expanded=False,
-    page_perms=None,
     querystring_value=None,
     trailing_breadcrumb_title=None,
 ):
@@ -82,10 +81,28 @@ def breadcrumbs(
         .specific(),
         "current_page": page,
         "is_expanded": is_expanded,
-        "page_perms": page_perms,
         "querystring_value": querystring_value or "",
         "trailing_breadcrumb_title": trailing_breadcrumb_title,  # Only used in collapsible breadcrumb templates
         "url_name": url_name,
+        "url_root_name": url_root_name,
+    }
+
+
+@register.inclusion_tag("wagtailadmin/shared/breadcrumbs.html")
+def breadcrumbs_admin(
+    label,
+    url,
+    is_expanded=True,
+    querystring_value=None,
+    root_label=_("Home"),
+    trailing_breadcrumb_title=None,
+    url_root_name="wagtailadmin_home",
+):
+    return {
+        "is_expanded": is_expanded,
+        "pages": [{"label": root_label, "is_root": True}, {"label": label, "url": url}],
+        "querystring_value": querystring_value or "",
+        "trailing_breadcrumb_title": trailing_breadcrumb_title,  # Only used in collapsible breadcrumb templates
         "url_root_name": url_root_name,
     }
 

--- a/wagtail/contrib/modeladmin/templates/modeladmin/choose_parent.html
+++ b/wagtail/contrib/modeladmin/templates/modeladmin/choose_parent.html
@@ -20,6 +20,7 @@
 {% block content %}
 
     {% block header %}
+        {% breadcrumbs_admin view.verbose_name_plural|capfirst view.index_url %}
         {% include "wagtailadmin/shared/header_with_locale_selector.html" with title=view.get_page_title subtitle=view.get_page_subtitle icon=view.header_icon %}
     {% endblock %}
 
@@ -27,7 +28,7 @@
         <div class="nice-padding">
             <p class="back">
                 <a href="{{ view.index_url }}">
-                    <svg class="icon default" aria-hidden="true"><use href="#icon-arrow-left"></use></svg>
+                    {% icon name="arrow-left" class_name="default" %}
                     {% blocktrans trimmed with view.verbose_name as model_name %}Back to {{ model_name }} list{% endblocktrans %}
                 </a>
             </p>

--- a/wagtail/contrib/modeladmin/templates/modeladmin/inspect.html
+++ b/wagtail/contrib/modeladmin/templates/modeladmin/inspect.html
@@ -27,7 +27,7 @@
             <div class="nice-padding">
                 <p class="back">
                     <a href="{{ view.index_url }}">
-                        <svg class="icon default" aria-hidden="true"><use href="#icon-arrow-left"></use></svg>
+                        {% icon name="arrow-left" class_name="default" %}
                         {% blocktrans trimmed with view.verbose_name as model_name %}Back to {{ model_name }} list{% endblocktrans %}
                     </a>
                 </p>


### PR DESCRIPTION
* POC implementation of https://github.com/wagtail/wagtail/issues/8767 to get feedback
* Note: please ignore the icon fix & `page_perm` removal - that is some other breadcrumbs clean up work

Questions
* Name `breadcrumbs_admin` ?
* API - providing just one URL / label enough for now?
* Padding - needed for the header expanded one but may be too much when added to the chooser usage
* Name of 'admin' home as "Home"? instead of "Root" for when used as a page tree
* Do we want an icon here also to visually differentiate it from the page tree breadcrumbs usage
* Is this too 'hacky' in the way it is integrated with the existing template

**Admin Breadcrumbs**

<img width="813" alt="Screen Shot 2022-06-28 at 11 51 10 pm" src="https://user-images.githubusercontent.com/1396140/176195771-5f6ae622-c5f0-4fa2-8ce5-4846893370b7.png">

**Padding added to the chooser**

<img width="1218" alt="Screen Shot 2022-06-29 at 12 20 09 am" src="https://user-images.githubusercontent.com/1396140/176202494-34de60a9-fb6f-4446-9bb4-0b171de3f5bc.png">

