### PR TITLE
added forced color to buttons to allow accessibilty in all high contr…

### DIFF
--- a/client/scss/components/_button.scss
+++ b/client/scss/components/_button.scss
@@ -603,3 +603,13 @@ button {
   padding-bottom: 2em;
   clear: both;
 }
+
+@media (forced-colors: active) {
+  .no,
+  .serious {
+    forced-color-adjust: none;
+  }
+  .button {
+    forced-color-adjust: none;
+  }
+}

--- a/client/scss/components/_button.scss
+++ b/client/scss/components/_button.scss
@@ -609,6 +609,7 @@ button {
   .serious {
     forced-color-adjust: none;
   }
+
   .button {
     forced-color-adjust: none;
   }


### PR DESCRIPTION
…ast modes

<!--
Thanks for contributing to Wagtail! 🎉

Before submitting, please review the [contributor guidelines](https://docs.wagtail.org/en/latest/contributing/index.html).
-->

_Please check the following:_

-   [ ] Do the tests still pass?[^1]
-   [ ] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [x] **Please list the exact browser and operating system versions you tested**: Operating System-Windows 11, Browser-Chrome
    -   [x] **Please list which assistive technologies [^3] you tested**: Tested using Windows Contrast Themes with modes-Aquatic,Desert,Dusk,Night Sky


**Please describe additional details for testing this change**.
The confirmation buttons that apperaed after clicking on Delete(in Image deleting or document deleting) appeared oddly in contrast themes.
The PR focuses on fixing the issue using forced colors

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
