### PR TITLE
Fix - use correct icon template tag instead of hard-coded svg use

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/panels/single_field_panel.html
+++ b/wagtail/admin/templates/wagtailadmin/panels/single_field_panel.html
@@ -1,4 +1,4 @@
-{% load i18n %}
+{% load i18n wagtailadmin_tags %}
 
 <div data-contentpath="{{ self.field_name }}">
     <fieldset>
@@ -13,8 +13,8 @@
     {% if show_add_comment_button %}
         <div class="field-comment-control field-comment-control--object">
             <button type="button" data-component="add-comment-button" data-comment-add class="u-hidden" aria-label="{% trans 'Add comment' %}">
-                <svg class="icon icon-comment-add initial icon-default" aria-hidden="true"><use href="#icon-comment-add"></use></svg>
-                <svg class="icon icon-comment-add initial icon-reversed" aria-hidden="true"><use href="#icon-comment-add-reversed"></use></svg>
+                {% icon name="comment-add" class_name="initial icon-default" %}
+                {% icon name="comment-add-reversed" class_name="initial icon-reversed" %}
             </button>
         </div>
     {% endif %}

--- a/wagtail/admin/templates/wagtailadmin/shared/field.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/field.html
@@ -29,8 +29,8 @@
     {% if show_add_comment_button %}
         <div class="field-comment-control">
             <button type="button" data-component="add-comment-button" data-comment-add class="u-hidden" aria-label="{% trans 'Add comment' %}">
-                <svg class="icon icon-comment-add initial icon-default" aria-hidden="true"><use href="#icon-comment-add"></use></svg>
-                <svg class="icon icon-comment-add initial icon-reversed" aria-hidden="true"><use href="#icon-comment-add-reversed"></use></svg>
+                {% icon name="comment-add" class_name="initial icon-default" %}
+                {% icon name="comment-add-reversed" class_name="initial icon-reversed" %}
             </button>
         </div>
     {% endif %}

--- a/wagtail/admin/templates/wagtailadmin/shared/icon.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/icon.html
@@ -1,5 +1,5 @@
 {% spaceless %}
-    {# Reference implementation: components/Icon.js #}
+    {# Reference implementation: components/Icon.tsx #}
     {% if wrapped %}<span class="icon-wrapper">{% endif %}
     <svg class="icon icon-{{ name }} {{ class_name }}" aria-hidden="true">
         <use href="#icon-{{ name }}"></use>

--- a/wagtail/admin/templates/wagtailadmin/shared/wagtail_icon.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/wagtail_icon.html
@@ -1,9 +1,0 @@
-{% spaceless %}
-    {# Reference implementation: components/Icon.js #}
-    <span>
-        <span class="icon icon-{{ name }} {{ className }}" aria-hidden="true"></span>
-        {% if title %}
-            <span class="visuallyhidden">{{ title }}</span>
-        {% endif %}
-    </span>
-{% endspaceless %}

--- a/wagtail/admin/templates/wagtailadmin/userbar/base.html
+++ b/wagtail/admin/templates/wagtailadmin/userbar/base.html
@@ -18,6 +18,7 @@
                             </defs>
                         </svg>
                     </div>
+                    {% comment %} Intentionally not using the icon template tag to show as SVG only {% endcomment %}
                     <svg class="wagtail-userbar-icon" aria-hidden="true">
                         <use href="#icon-wagtail-icon"></use>
                     </svg>

--- a/wagtail/contrib/modeladmin/templates/modeladmin/choose_parent.html
+++ b/wagtail/contrib/modeladmin/templates/modeladmin/choose_parent.html
@@ -27,7 +27,7 @@
         <div class="nice-padding">
             <p class="back">
                 <a href="{{ view.index_url }}">
-                    <svg class="icon default" aria-hidden="true"><use href="#icon-arrow-left"></use></svg>
+                    {% icon name="arrow-left" class_name="default" %}
                     {% blocktrans trimmed with view.verbose_name as model_name %}Back to {{ model_name }} list{% endblocktrans %}
                 </a>
             </p>

--- a/wagtail/contrib/modeladmin/templates/modeladmin/inspect.html
+++ b/wagtail/contrib/modeladmin/templates/modeladmin/inspect.html
@@ -27,7 +27,7 @@
             <div class="nice-padding">
                 <p class="back">
                     <a href="{{ view.index_url }}">
-                        <svg class="icon default" aria-hidden="true"><use href="#icon-arrow-left"></use></svg>
+                        {% icon name="arrow-left" class_name="default" %}
                         {% blocktrans trimmed with view.verbose_name as model_name %}Back to {{ model_name }} list{% endblocktrans %}
                     </a>
                 </p>

--- a/wagtail/contrib/modeladmin/tests/test_page_modeladmin.py
+++ b/wagtail/contrib/modeladmin/tests/test_page_modeladmin.py
@@ -182,7 +182,7 @@ class TestInspectView(TestCase, WagtailTestUtils):
         expected = """
             <p class="back">
                     <a href="/admin/modeladmintest/author/">
-                        <svg class="icon default" aria-hidden="true">
+                        <svg class="icon icon-arrow-left default" aria-hidden="true">
                             <use href="#icon-arrow-left"></use>
                         </svg>
                         Back to author list
@@ -277,7 +277,7 @@ class TestChooseParentView(TestCase, WagtailTestUtils):
         expected = """
             <p class="back">
                     <a href="/admin/tests/eventpage/">
-                        <svg class="icon default" aria-hidden="true">
+                        <svg class="icon icon-arrow-left default" aria-hidden="true">
                             <use href="#icon-arrow-left"></use>
                         </svg>
                         Back to event page list

--- a/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
+++ b/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
@@ -601,7 +601,7 @@ class TestInspectView(TestCase, WagtailTestUtils):
         expected = """
             <p class="back">
                     <a href="/admin/modeladmintest/author/">
-                        <svg class="icon default" aria-hidden="true">
+                        <svg class="icon icon-arrow-left default" aria-hidden="true">
                             <use href="#icon-arrow-left"></use>
                         </svg>
                         Back to author list


### PR DESCRIPTION
### Small icon template tag fixes

- Fix issue introduced in  #8743 where icon was hard-coded instead of using the template tag
- Fix a similar issue with the comments icon where the the template tag was not used
- Add note where the the template tag is intentionally not used
- Remove a legacy template file that was causing confusion added in 4e7ccdcdc9ca00d69438b1f446bd8c1fb2fc12af / #4381 but then replaced in  eed16e00348c6ddfe8f997e1150006a3211a1216 but the original template was never removed
-   [X] Do the tests still pass?[^1]
-   [X] Does the code comply with the style guide?
-   [X] For Python changes: Have you added tests to cover the new/fixed behaviour?