### PR TITLE
Feedback requested - split template tag util class

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/home.html
+++ b/wagtail/admin/templates/wagtailadmin/home.html
@@ -8,14 +8,14 @@
 {% endblock %}
 
 {% block content %}
-    <header class="header merged header--home">
+    {% header title='My DashboardZ!' %}
         <div class="avatar"><img src="{% avatar_url user %}" alt="" /></div>
 
         <div class="sm:w-ml-4">
             <h1 class="header__title">{% block branding_welcome %}{% blocktrans trimmed %}Welcome to the {{ site_name }} Wagtail CMS{% endblocktrans %}{% endblock %}</h1>
             <div class="user-name">{{ user|user_display_name }}</div>
         </div>
-    </header>
+    {% endheader %}
 
     {% if panels %}
         {% for panel in panels %}

--- a/wagtail/admin/templates/wagtailadmin/shared/header.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/header.html
@@ -47,6 +47,7 @@
                     </div>
                 {% endif %}
             {% endblock %}
+            <!-- START:END -->
         </div>
     </div>
     {% block extra_rows %}{% endblock %}

--- a/wagtail/admin/templatetags/util.py
+++ b/wagtail/admin/templatetags/util.py
@@ -1,0 +1,124 @@
+from inspect import getfullargspec, unwrap
+
+from django.core.exceptions import ImproperlyConfigured
+from django.template.library import InclusionNode, parse_bits
+
+
+class PartialNode(InclusionNode):
+    """
+    Splits an existing template into to based on a string provided in the template
+    to act as two separate virtual (partial) templates for a start & end either
+    side of the split string.
+    The split string is not included in either final template.
+    """
+
+    def __init__(self, *args, **kwargs):
+        is_end = kwargs.pop("is_end", False)
+        split_tag = kwargs.pop("split_tag")  # required
+
+        super().__init__(*args, **kwargs)
+
+        self.is_end = is_end
+        self.split_tag = split_tag
+
+    def render(self, context):
+        template = context.template.engine.get_template(self.filename)
+        source = template.source
+        parts = source.split(self.split_tag)
+
+        # patch in a template that is just a partial version of the original & re-apply metadata for debugging
+        self.filename = context.template.engine.from_string(
+            parts[1] if self.is_end else parts[0]
+        )
+        self.filename.name = template.name
+        self.filename.origin = template.origin
+        self.filename.source = template.source
+
+        content = super().render(context)
+
+        return content
+
+
+class SplitTemplateTag:
+    """
+    Base class for building a split template tag in the format.
+    `{% birdbath %} {% birdbathend %}`
+    Must provide `name` (the template tag name) and `filename` (the template inclusion).
+    `start` & `end` static methods can be overridden to be used as the template tag functions
+    and will behave the same way as functions used with `@register.inclusion_tag`. By default these return an empty context Dict.
+    `takes_context` will set the context as the first param of start and end function.
+    """
+
+    name = ""
+    takes_context = False
+    filename = ""
+    split_tag = "<!-- START:END -->"
+
+    def __init__(self, register):
+        if not self.name:
+            raise ImproperlyConfigured("`name` must be provided to the class.")
+
+        if not self.filename:
+            raise ImproperlyConfigured("`filename` must be provided to the class.")
+
+        self.register = register
+
+    @staticmethod
+    def start():
+        """Emulates what you would pass into register inclusion tag."""
+        return {}
+
+    @staticmethod
+    def end():
+        """Emulates what you would pass into register inclusion tag."""
+        return {}
+
+    def get_tag(self, is_end=False):
+        takes_context = self.takes_context
+        filename = self.filename
+        split_tag = self.split_tag
+        name = f"end{self.name}" if is_end else self.name
+        func = self.end if is_end else self.start
+        func.__name__ = name  # ensure the debugging name matches the template tag
+
+        def tag(parser, token):
+            (
+                params,
+                varargs,
+                varkw,
+                defaults,
+                kwonly,
+                kwonly_defaults,
+                _,
+            ) = getfullargspec(unwrap(func))
+
+            bits = token.split_contents()[1:]
+
+            args, kwargs = parse_bits(
+                parser,
+                bits,
+                params,
+                varargs,
+                varkw,
+                defaults,
+                kwonly,
+                kwonly_defaults,
+                takes_context,
+                name,
+            )
+
+            return PartialNode(
+                func,
+                takes_context,
+                args,
+                kwargs,
+                filename,
+                split_tag=split_tag,
+                is_end=is_end,
+            )
+
+        return [name, tag]
+
+    def register_tags(self):
+        self.register.tag(*self.get_tag())
+        self.register.tag(*self.get_tag(is_end=True))

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -27,6 +27,7 @@ from wagtail.admin.menu import admin_menu
 from wagtail.admin.navigation import get_explorable_root_page
 from wagtail.admin.search import admin_search_areas
 from wagtail.admin.staticfiles import versioned_static as versioned_static_func
+from wagtail.admin.templatetags.util import SplitTemplateTag
 from wagtail.admin.ui import sidebar
 from wagtail.admin.utils import get_admin_base_url
 from wagtail.admin.views.bulk_action.registry import bulk_action_registry
@@ -940,6 +941,25 @@ def dialog(
 @register.inclusion_tag("wagtailadmin/shared/dialog/end-dialog.html")
 def enddialog():
     return
+
+
+class HeaderSplitTemplateTag(SplitTemplateTag):
+    """
+    Sets up the config for adding a start/end template tag
+    {% header %}Additional buttons{% endheader %}
+    """
+
+    name = "header"
+    filename = "wagtailadmin/shared/header.html"
+
+    @staticmethod
+    def start(title):
+        return {
+            "title": title,
+        }
+
+
+HeaderSplitTemplateTag(register).register_tags()
 
 
 # Button used to open dialogs


### PR DESCRIPTION
This is a proposed approach to make it easier to work with split template tags where we want to be able to do something like:

```
{% header icon="calendar" title="View submissions" breadcrumb_items=my_list %}
    {% button label="My action" %}
{% endheader %}
```

This is part of some prep work for the GSoC UX unification project to help Paarth a bit so he did not have to dig into the internals of template tags. But also it should help us with some related work in the breadcrumbs and the existing dialog code.

This is pushing my knowledge of Django a bit so please excuse me if this is not what we had in mind at all.

### Questions

* Do we already have something like this in Wagtail (I assume not as we did currently use two split template tags for `dialog`)
* Is this too hacky to be put into `main`?
* Is the API a reasonable starting point? (a class based approach that you instantiate and then register)
* Should we try to find a way to do the splitting with a Django block (e.g.` {% children %}`) instead of a HTML comment. If so - how can I go about that?
* Is this location ok (utils within the template tags) or should I put this file somewhere else?

### Additional info

* https://github.com/wagtail/wagtail/issues/8767
* https://github.com/wagtail/wagtail/issues/8539
* Dialog work (already in main but uses two separate template files) - https://github.com/wagtail/wagtail/pull/8541/files
  * `wagtail/admin/templates/wagtailadmin/shared/dialog/dialog.html`
  * `wagtail/admin/templates/wagtailadmin/shared/dialog/end-dialog.html`
