### PR TITLE
adopt shared header template on the dashboard view

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -54,6 +54,7 @@ Changelog
  * Prefetch workflow states in edit page view to to avoid queries in other parts of the view/templates that need it (Tidiane Dia)
  * Remove the edit link from edit bird in previews to avoid confusion (Sævar Öfjörð Magnússon)
  * Introduce new template fragment and block level enclosure tags for easier template composition (Thibaud Colas)
+ * Add a `classnames` template tag to easily build up classes from variables provided to a template (Paarth Agarwal)
  * Fix: Typo in `ResumeWorkflowActionFormatter` message (Stefan Hammer)
  * Fix: Throw a meaningful error when saving an image to an unrecognised image format (Christian Franke)
  * Fix: Remove extra padding for headers with breadcrumbs on mobile viewport (Steven Steinwand)

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -55,6 +55,7 @@ Changelog
  * Remove the edit link from edit bird in previews to avoid confusion (Sævar Öfjörð Magnússon)
  * Introduce new template fragment and block level enclosure tags for easier template composition (Thibaud Colas)
  * Add a `classnames` template tag to easily build up classes from variables provided to a template (Paarth Agarwal)
+ * Migrate the dashboard (home) view header to the shared header template and update designs (Paarth Agarwal)
  * Fix: Typo in `ResumeWorkflowActionFormatter` message (Stefan Hammer)
  * Fix: Throw a meaningful error when saving an image to an unrecognised image format (Christian Franke)
  * Fix: Remove extra padding for headers with breadcrumbs on mobile viewport (Steven Steinwand)

--- a/client/scss/components/_header.scss
+++ b/client/scss/components/_header.scss
@@ -17,20 +17,28 @@ header {
   h1 {
     @apply w-h1;
     position: relative;
+  }
 
-    > svg.icon {
-      position: absolute;
-      inset-inline-start: -1.5em;
+  h1 > svg.icon, // can remove once all headers use shared include
+  .w-header__glpyh {
+    position: absolute;
+    inset-inline-start: -1.5em;
+    vertical-align: text-top;
+
+    &.icon {
       top: 0.125em;
       max-width: 1em;
       max-height: 1em;
-      vertical-align: text-top;
     }
 
-    span {
-      margin-inline-start: 0.3125rem;
-      font-weight: 400;
+    &.avatar {
+      inset-inline-start: -1.75em;
     }
+  }
+
+  .w-header__subtitle {
+    margin-inline-start: 0.3125rem;
+    font-weight: 400;
   }
 
   // Give padding to the rows inside of headers so that nested breadcrumbs aren't padded by their parent header el.
@@ -45,12 +53,6 @@ header {
 
   &.merged .w-breadcrumb {
     padding-inline-start: $mobile-nav-indent;
-  }
-
-  &.header--home {
-    @include nice-padding();
-    padding-top: 0.5rem;
-    margin-top: $mobile-nav-indent;
   }
 
   .col {
@@ -180,11 +182,6 @@ header {
       padding-inline-start: 0;
     }
 
-    &.header--home {
-      padding-top: 1.5rem;
-      margin-top: 0;
-    }
-
     .left {
       float: left;
       margin-inline-end: 0;
@@ -202,10 +199,6 @@ header {
       .left {
         float: right;
       }
-    }
-
-    h1.icon:before {
-      display: inline-block;
     }
 
     .col3 {

--- a/client/scss/layouts/_home.scss
+++ b/client/scss/layouts/_home.scss
@@ -1,34 +1,4 @@
-.homepage header {
-  @apply w-text-primary;
-
-  display: flex;
-  flex-flow: row nowrap;
-  gap: 1em;
-
-  .col1 {
-    width: 50px;
-    margin-inline-end: 1em;
-    padding: 0;
-
-    // make way for the nav-menu button on mobile
-    @include media-breakpoint-down(xs) {
-      position: relative;
-      inset-inline-start: $mobile-nav-indent;
-    }
-  }
-
-  .avatar {
-    margin-top: 0.5em;
-    flex-shrink: 0;
-  }
-
-  .user-name {
-    font-size: 1.3em;
-    font-weight: 600;
-  }
-}
-
-.summary {
+.homepage .summary {
   @include clearfix();
   margin-bottom: 2em;
   padding-top: 2em;

--- a/docs/releases/4.0.md
+++ b/docs/releases/4.0.md
@@ -61,6 +61,7 @@ When using a queryset to render a list of images, you can now use the `prefetch_
  * Prefetch workflow states in edit page view to to avoid queries in other parts of the view/templates that need it (Tidiane Dia)
  * Remove the edit link from edit bird in previews to avoid confusion (Sævar Öfjörð Magnússon)
  * Introduce new template fragment and block level enclosure tags for easier template composition (Thibaud Colas)
+ * Add a `classnames` template tag to easily build up classes from variables provided to a template (Paarth Agarwal)
 
 ### Bug fixes
 

--- a/docs/releases/4.0.md
+++ b/docs/releases/4.0.md
@@ -62,6 +62,7 @@ When using a queryset to render a list of images, you can now use the `prefetch_
  * Remove the edit link from edit bird in previews to avoid confusion (Sævar Öfjörð Magnússon)
  * Introduce new template fragment and block level enclosure tags for easier template composition (Thibaud Colas)
  * Add a `classnames` template tag to easily build up classes from variables provided to a template (Paarth Agarwal)
+ * Migrate the dashboard (home) view header to the shared header template and update designs (Paarth Agarwal)
 
 ### Bug fixes
 

--- a/wagtail/admin/templates/wagtailadmin/home.html
+++ b/wagtail/admin/templates/wagtailadmin/home.html
@@ -12,14 +12,8 @@
         {% block branding_welcome %}{% blocktrans trimmed %}Welcome to the {{ site_name }} Wagtail CMS{% endblocktrans %}{% endblock %}
     {% endfragment %}
 
-    <header class="header merged header--home">
-        <div class="avatar"><img src="{% avatar_url user %}" alt="" /></div>
-
-        <div class="sm:w-ml-4">
-            <h1 class="header__title">{{ header_title }}</h1>
-            <div class="user-name">{{ user|user_display_name }}</div>
-        </div>
-    </header>
+    {% avatar_url user as avatar %}
+    {% include "wagtailadmin/shared/header.html" with title=header_title subtitle=user|user_display_name avatar=avatar merged=1 %}
 
     {% if panels %}
         {% for panel in panels %}

--- a/wagtail/admin/templates/wagtailadmin/shared/header.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/header.html
@@ -3,6 +3,7 @@
 
     Variables accepted by this template:
 
+    - `classname` - if present, adds classname to the header class list. This will be the class/classes added to the header class list
     - `title` - Displayed as `h1`
     - `subtitle` - Within the `h1` tag but smaller
     - `search_url` - if present, display a search box. This is a URL route name (taking no parameters) to be used as the action for that search box
@@ -14,7 +15,7 @@
     - `action_icon` - icon for the 'action' button, default is 'icon-plus'
 
 {% endcomment %}
-<header class="header {% if merged %}merged{% endif %} {% if search_form %}hasform{% endif %}">
+<header class="{% classnames "header" classname merged|yesno:"merged," search_form|yesno:"hasform," %}">
     {% block breadcrumb %}{% endblock %}
     <div class="row">
         <div class="left">

--- a/wagtail/admin/templates/wagtailadmin/shared/header.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/header.html
@@ -9,6 +9,7 @@
     - `search_url` - if present, display a search box. This is a URL route name (taking no parameters) to be used as the action for that search box
     - `query_parameters` - a query string (without the '?') to be placed after the search URL
     - `icon` - name of an icon to place against the title
+    - `avatar` - if present, display an 'avatar' in place of icon. This is the URL to be used as the img src for avatar 
     - `merged` - if true, add the classname 'merged'
     - `action_url` - if present, display an 'action' button. This is the URL to be used as the link URL for the button
     - `action_text` - text for the 'action' button
@@ -21,8 +22,12 @@
         <div class="left">
             <div class="col">
                 <h1 class="header__title">
-                    {% if icon %}{% icon name=icon %}{% endif %}
-                    {{ title }}{% if subtitle %} <span class="header__subtitle">{{ subtitle }}</span>{% endif %}
+                    {% if icon %}
+                        {% icon class_name="w-header__glpyh" name=icon %}
+                    {% elif avatar %}
+                        <div class="w-header__glpyh avatar"><img src="{{ avatar }}" alt="" /></div>
+                    {% endif %}
+                    {{ title }}{% if subtitle %} <span class="w-header__subtitle">{{ subtitle }}</span>{% endif %}
                 </h1>
             </div>
             {% if search_url %}

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -153,6 +153,14 @@ def page_permissions(context, page):
     return _get_user_page_permissions(context).for_page(page)
 
 
+@register.simple_tag
+def classnames(*classes):
+    """
+    Returns any args as a space-separated joined string for using in HTML class names.
+    """
+    return " ".join([classname.strip() for classname in classes if classname])
+
+
 @register.simple_tag(takes_context=True)
 def test_collection_is_public(context, collection):
     """


### PR DESCRIPTION
Addresses #8539.
Applied shared header to dashboard.
Before:

![Screenshot from 2022-06-30 15-57-54](https://user-images.githubusercontent.com/86092410/176655625-c2433e0b-9418-47da-a494-13defce6118b.png)


After:

![Screenshot from 2022-07-04 18-29-46](https://user-images.githubusercontent.com/86092410/177203944-802f8354-adec-4cb5-b24f-265bfc5bdfe4.png)

![Screenshot from 2022-07-04 18-31-07](https://user-images.githubusercontent.com/86092410/177203959-079c89b5-ca24-4016-9068-7669e3bcdf0f.png)

![Screenshot from 2022-07-04 18-31-35](https://user-images.githubusercontent.com/86092410/177203961-1dffd6fc-08c9-4647-a6db-6a446b13f63b.png)



 
Edit1: Updated Screenshot
Edit2: Updated Screenshot