### PR TITLE
Remove outdated references to old db search backend in docs

### DIFF
--- a/docs/topics/search/backends.md
+++ b/docs/topics/search/backends.md
@@ -58,10 +58,6 @@ Here's a list of backends that Wagtail supports out of the box.
 The database search backend searches content in the database using the full text search features of the database backend in use (such as PostgreSQL FTS, SQLite FTS5).
 This backend is intended to be used for development and also should be good enough to use in production on sites that don't require any Elasticsearch specific features.
 
-```{versionchanged} 2.15
-`wagtail.search.backends.database` replaces the old `wagtail.search.backends.db` backend which works using simple substring matching only. `wagtail.search.backends.db` is still the default if `WAGTAILSEARCH_BACKENDS` is not specified; `wagtail.search.backends.database` will become the default in Wagtail 2.17.
-```
-
 (wagtailsearch_backends_elasticsearch)=
 
 ### Elasticsearch Backend

--- a/docs/topics/search/indexing.md
+++ b/docs/topics/search/indexing.md
@@ -173,10 +173,6 @@ Filtering on `index.RelatedFields` with the `QuerySet` API is planned for a futu
 
 ### Indexing callables and other attributes
 
-```{note}
-This is not supported in the {ref}`wagtailsearch_backends_database`
-```
-
 Search/filter fields do not need to be Django model fields. They can also be any method or attribute on your model class.
 
 One use for this is indexing the `get_*_display` methods Django creates automatically for fields with choices.


### PR DESCRIPTION
Remove some outdated information about the database search backend that was actually referring to the old `wagtail.search.backends.db` backend.