### PR TITLE
fix - ensure tooltips get re-initialised (for human-readable-date widget)

### DIFF
--- a/client/src/entrypoints/admin/core.js
+++ b/client/src/entrypoints/admin/core.js
@@ -1,4 +1,5 @@
 import $ from 'jquery';
+import { initTooltips } from '../../includes/initTooltips';
 
 /* generic function for adding a message to message area through JS alone */
 function addMessage(status, text) {
@@ -331,6 +332,8 @@ $(() => {
           },
           complete() {
             window.wagtail.ui.initDropDowns();
+            // Reinitialise any tooltips
+            initTooltips();
             $inputContainer.removeClass(workingClasses);
           },
         });

--- a/client/src/includes/chooserModal.js
+++ b/client/src/includes/chooserModal.js
@@ -1,6 +1,7 @@
 /* eslint-disable max-classes-per-file */
 import $ from 'jquery';
 import { initTabs } from './tabs';
+import { initTooltips } from './initTooltips';
 import { gettext } from '../utils/gettext';
 
 const submitCreationForm = (modal, form, { errorContainerSelector }) => {
@@ -197,6 +198,9 @@ class ChooserModalOnloadHandlerFactory {
 
     // Reinitialize tabs to hook up tab event listeners in the modal
     if (this.modalHasTabs(modal)) initTabs();
+
+    // Reinitialise any tooltips
+    initTooltips();
   }
 
   // eslint-disable-next-line class-methods-use-this


### PR DESCRIPTION
- fix - ensure tooltips get re-initialised
- chooser modals (e.g. documents)
- header search
-  [X] Do the tests still pass?
-  [X] Does the code comply with the style guide?
- Issue introduced when adopting tooltips (JS) driven components - https://github.com/wagtail/wagtail/pull/8697
- We need to ensure that any possible HTML re-generation is covered, a bit of a cat & mouse game but hopefully they are all fixed with these changes
- Issue discovered by @zerolab  (thanks for that) https://github.com/wagtail/wagtail/issues/8408#issuecomment-1172544502