### PR TITLE
Introduce new template fragment composition tags: BlockInclusionNode and fragment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
       - run: pipenv run isort --check-only --diff .
       - run: pipenv run black --target-version py37 --check --diff .
       - run: git ls-files '*.html' | xargs pipenv run djhtml --check
-      - run: pipenv run curlylint --exclude '(dialog.html|end_dialog.html)' --parse-only wagtail
+      - run: pipenv run curlylint --parse-only wagtail
       - run: pipenv run doc8 docs
       - run: DATABASE_NAME=wagtail.db pipenv run python -u runtests.py
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -53,6 +53,7 @@ Changelog
  * Added `WAGTAILADMIN_USER_PASSWORD_RESET_FORM` setting for overriding the admin password reset form (Michael Karamuth)
  * Prefetch workflow states in edit page view to to avoid queries in other parts of the view/templates that need it (Tidiane Dia)
  * Remove the edit link from edit bird in previews to avoid confusion (Sævar Öfjörð Magnússon)
+ * Introduce new template fragment and block level enclosure tags for easier template composition (Thibaud Colas)
  * Fix: Typo in `ResumeWorkflowActionFormatter` message (Stefan Hammer)
  * Fix: Throw a meaningful error when saving an image to an unrecognised image format (Christian Franke)
  * Fix: Remove extra padding for headers with breadcrumbs on mobile viewport (Steven Steinwand)

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ lint-server:
 	black --target-version py37 --check --diff .
 	flake8
 	isort --check-only --diff .
-	curlylint --exclude '(dialog.html|end_dialog.html)' --parse-only wagtail
+	curlylint --parse-only wagtail
 	git ls-files '*.html' | xargs djhtml --check
 
 lint-client:

--- a/docs/releases/4.0.md
+++ b/docs/releases/4.0.md
@@ -60,6 +60,7 @@ When using a queryset to render a list of images, you can now use the `prefetch_
  * Added `WAGTAILADMIN_USER_PASSWORD_RESET_FORM` setting for overriding the admin password reset form (Michael Karamuth)
  * Prefetch workflow states in edit page view to to avoid queries in other parts of the view/templates that need it (Tidiane Dia)
  * Remove the edit link from edit bird in previews to avoid confusion (Sævar Öfjörð Magnússon)
+ * Introduce new template fragment and block level enclosure tags for easier template composition (Thibaud Colas)
 
 ### Bug fixes
 

--- a/wagtail/admin/templates/wagtailadmin/home.html
+++ b/wagtail/admin/templates/wagtailadmin/home.html
@@ -8,11 +8,15 @@
 {% endblock %}
 
 {% block content %}
+    {% fragment as header_title %}
+        {% block branding_welcome %}{% blocktrans trimmed %}Welcome to the {{ site_name }} Wagtail CMS{% endblocktrans %}{% endblock %}
+    {% endfragment %}
+
     <header class="header merged header--home">
         <div class="avatar"><img src="{% avatar_url user %}" alt="" /></div>
 
         <div class="sm:w-ml-4">
-            <h1 class="header__title">{% block branding_welcome %}{% blocktrans trimmed %}Welcome to the {{ site_name }} Wagtail CMS{% endblocktrans %}{% endblock %}</h1>
+            <h1 class="header__title">{{ header_title }}</h1>
             <div class="user-name">{{ user|user_display_name }}</div>
         </div>
     </header>

--- a/wagtail/admin/templates/wagtailadmin/shared/dialog/dialog.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/dialog/dialog.html
@@ -32,8 +32,8 @@
                     <p class="w-dialog__subtitle w-help-text">{{ subtitle }}</p>
                 {% endif %}
 
-
-                {% comment %}
-    This markup is intentionally left without closing div tags so that the contents can be populated with child elements between dialog and enddialog
-    For the end tags please see end-dialog.html
-                {% endcomment %}
+                {{ children }}
+            </div>
+        </div>
+    </div>
+</template>

--- a/wagtail/admin/templates/wagtailadmin/shared/dialog/end_dialog.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/dialog/end_dialog.html
@@ -1,8 +1,0 @@
-</div>
-</div>
-</div>
-</template>
-
-{% comment %}
-    This markup is used to close the end tags for dialog.html so that content can be nested between both tags like {% dialog %}{% enddialog %}
-{% endcomment %}

--- a/wagtail/admin/templates/wagtailadmin/shared/help_block.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/help_block.html
@@ -1,0 +1,10 @@
+{% load wagtailadmin_tags %}
+
+<div class="help-block help-{{ status }}">
+    {% if status == 'info' %}
+        {% icon name='help' %}
+    {% else %}
+        {% icon name='warning' %}
+    {% endif %}
+    {{ children }}
+</div>

--- a/wagtail/contrib/styleguide/templates/wagtailstyleguide/base.html
+++ b/wagtail/contrib/styleguide/templates/wagtailstyleguide/base.html
@@ -256,21 +256,18 @@
                 Help text is not to be confused with the messages that appear in a banner drop down from the top of the screen. Help text are permanent instructions, visible on every page view, that explain or warn about something.
             </p>
 
-            <div class="help-block help-info">
-                {% icon name='help' %}
+            {% help_block status="info" %}
                 <p>This is help text that might be just for information, explaining what happens next, or drawing the user's attention to something they're about to do</p>
                 <p>It could be multiple lines</p>
-            </div>
+            {% endhelp_block %}
 
-            <p class="help-block help-warning">
-                {% icon name='warning' %}
+            {% help_block status="warning" %}
                 A warning message might be output in cases where a user's action could have serious consequences
-            </p>
+            {% endhelp_block %}
 
-            <div class="help-block help-critical">
-                {% icon name='warning' %}
+            {% help_block status="critical" %}
                 A critical message would probably be rare, in cases where a particularly brittle or dangerously destructive action could be performed and needs to be warned about.
-            </div>
+            {% endhelp_block %}
 
         </section>
 


### PR DESCRIPTION
Follow-up to #8775. This adds two related template tags to help with UI refactorings in the admin. Both tags essentially serve the same purpose of making it possible to compose template fragments in Django Templates. The main need for this is to render a UI component (for example a modal dialog) with arbitrary contents within. With Django Templates built-ins this is only possible with inheritance, which doesn’t scale well.

## BlockInclusionNode

(thoughts on naming very welcome). This is named after Django’s InclusionNode (used via `register.inclusion_tag`), but doesn’t technically rely on it. This template node works similarly – it has a template, renders it with additional context specified as tag parameters. The difference is that it has a start and end tag, and the template fragment in-between is rendered and then available within the included template as a `children` context variable.

Example:

```jinja2
{% load wagtailadmin_tags %}

<div class="help-block help-{{ status }}">
    {% if status == 'info' %}
        {% icon name='help' %}
    {% else %}
        {% icon name='warning' %}
    {% endif %}
    {{ children }}
</div>
```

The Python code for this is just boilerplate:

```python
class HelpBlockNode(BlockInclusionNode):
    template = "wagtailadmin/shared/help_block.html"


register.tag("help_block", HelpBlockNode.handle)
```

---

There are a few Django libraries providing this capability with a web-components style slots API. I chose to base this on the API of Slippers’ [ComponentNode](https://github.com/mixxorz/slippers/blob/254c720e6bb02eb46ae07d104863fce41d4d3164/slippers/templatetags/slippers.py#L47)) instead for the sake of simplicity. We rarely need more than one set of "children", and when we do we can use the new `fragment` tag.

## fragment

`fragment` is very simple and flexible – it renders a template fragment, and stores the result in a variable so it can be used just like any other variable in context. Here is an example:

```jinja2
{% fragment as header_title %}
        {% block branding_welcome %}{% blocktrans trimmed %}Welcome to the {{ site_name }} Wagtail CMS{% endblocktrans %}{% endblock %}
{% endfragment %}

<h1 class="header__title">{{ header_title }}</h1>
```

This becomes very useful when we need to pass arbitrary template content into a `{% include %}`, or so a `{% block %}` can be rendered in different places depending on conditions.

---

Aside from the two new tags/nodes, I refactored the existing `dialog` tag and introduced a new `help_block` tag as a way to illustrate / test this.

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   ~~[ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]~~
-  ~~[ ] For new features: Has the documentation been updated accordingly?~~

To test this,

- Open the styleguide and check the output of the different tags.
- Check `curlylint` is happy with the tag pairs.
- (Try to override `branding_welcome` in a `home.html` to see the block getting overridden as expected).