### PR TITLE
Eliminate duplicated code on image / document creation

### DIFF
--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -213,7 +213,7 @@ This setting lets you provide your own image model for use in Wagtail, which sho
 WAGTAILIMAGES_IMAGE_FORM_BASE = 'myapp.forms.MyImageBaseForm'
 ```
 
-This setting lets you provide your own image base form for use in Wagtail, which might extend the built-in `BaseImageForm` class or replace it entirely.
+This setting lets you provide your own image base form for use in Wagtail, which should extend the built-in `BaseImageForm` class.
 You can use it to specify or override the widgets to use in the admin form.
 
 ### `WAGTAILIMAGES_MAX_UPLOAD_SIZE`
@@ -292,7 +292,7 @@ This setting lets you provide your own document model for use in Wagtail, which 
 WAGTAILDOCS_DOCUMENT_FORM_BASE = 'myapp.forms.MyDocumentBaseForm'
 ```
 
-This setting lets you provide your own Document base form for use in Wagtail, which might extend the built-in `BaseDocumentForm` class or replace it entirely.
+This setting lets you provide your own Document base form for use in Wagtail, which should extend the built-in `BaseDocumentForm` class.
 You can use it to specify or override the widgets to use in the admin form.
 
 (wagtaildocs_serve_method)=

--- a/docs/releases/4.0.md
+++ b/docs/releases/4.0.md
@@ -280,3 +280,7 @@ As part of our support for theming across all colors, we’ve had to rename or r
 -   `--color-primary-light-lightness` is now `--w-color-secondary-50-lightness`
 
 We’ve additionally removed all `--color-input-focus` and `--color-input-focus-border` variables, as Wagtail’s form fields no longer have a different color on focus.
+
+### `WAGTAILDOCS_DOCUMENT_FORM_BASE` and `WAGTAILIMAGES_IMAGE_FORM_BASE` must inherit from `BaseDocumentForm` / `BaseImageForm`
+
+Previously, it was valid to specify an arbitrary model form as the `WAGTAILDOCS_DOCUMENT_FORM_BASE` / `WAGTAILIMAGES_IMAGE_FORM_BASE` settings. This is no longer supported; these forms must now inherit from `wagtail.documents.forms.BaseDocumentForm` and `wagtail.images.forms.BaseImageForm` respectively.

--- a/wagtail/documents/models.py
+++ b/wagtail/documents/models.py
@@ -134,6 +134,15 @@ class AbstractDocument(CollectionMember, index.Indexed, models.Model):
 
         return self.file_hash
 
+    def _set_document_file_metadata(self):
+        # Set new document file size
+        self.file_size = self.file.size
+
+        # Set new document file hash
+        self.file.seek(0)
+        self._set_file_hash(self.file.read())
+        self.file.seek(0)
+
     def __str__(self):
         return self.title
 

--- a/wagtail/documents/models.py
+++ b/wagtail/documents/models.py
@@ -135,6 +135,8 @@ class AbstractDocument(CollectionMember, index.Indexed, models.Model):
         return self.file_hash
 
     def _set_document_file_metadata(self):
+        self.file.open()
+
         # Set new document file size
         self.file_size = self.file.size
 

--- a/wagtail/documents/models.py
+++ b/wagtail/documents/models.py
@@ -141,7 +141,6 @@ class AbstractDocument(CollectionMember, index.Indexed, models.Model):
         self.file_size = self.file.size
 
         # Set new document file hash
-        self.file.seek(0)
         self._set_file_hash(self.file.read())
         self.file.seek(0)
 

--- a/wagtail/documents/views/chooser.py
+++ b/wagtail/documents/views/chooser.py
@@ -23,7 +23,6 @@ from wagtail.admin.widgets import BaseChooser
 from wagtail.documents import get_document_model
 from wagtail.documents.forms import get_document_form
 from wagtail.documents.permissions import permission_policy
-from wagtail.search import index as search_index
 
 
 class DocumentChosenResponseMixin(ChosenResponseMixin):
@@ -191,16 +190,6 @@ class DocumentChooserUploadView(
     def dispatch(self, request, *args, **kwargs):
         self.model = get_document_model()
         return super().dispatch(request, *args, **kwargs)
-
-    def save_form(self, form):
-        document = form.instance
-        document._set_document_file_metadata()
-        form.save()
-
-        # Reindex the document to make sure all tags are indexed
-        search_index.insert_or_update_object(document)
-
-        return document
 
 
 class BaseAdminDocumentChooser(BaseChooser):

--- a/wagtail/documents/views/chooser.py
+++ b/wagtail/documents/views/chooser.py
@@ -194,13 +194,7 @@ class DocumentChooserUploadView(
 
     def save_form(self, form):
         document = form.instance
-        document.file_size = document.file.size
-
-        # Set new document file hash
-        document.file.seek(0)
-        document._set_file_hash(document.file.read())
-        document.file.seek(0)
-
+        document._set_document_file_metadata()
         form.save()
 
         # Reindex the document to make sure all tags are indexed

--- a/wagtail/documents/views/documents.py
+++ b/wagtail/documents/views/documents.py
@@ -173,17 +173,11 @@ def edit(request, document_id):
     next_url = get_valid_next_url_from_request(request)
 
     if request.method == "POST":
-        original_file = doc.file
         form = DocumentForm(
             request.POST, request.FILES, instance=doc, user=request.user
         )
         if form.is_valid():
             doc = form.save()
-            if "file" in form.changed_data:
-                # If providing a new document file, delete the old one.
-                # NB Doing this via original_file.delete() clears the file field,
-                # which definitely isn't what we want...
-                original_file.storage.delete(original_file.name)
 
             edit_url = reverse("wagtaildocs:edit", args=(doc.id,))
             redirect_url = "wagtaildocs:index"

--- a/wagtail/documents/views/documents.py
+++ b/wagtail/documents/views/documents.py
@@ -133,13 +133,7 @@ def add(request):
             request.POST, request.FILES, instance=doc, user=request.user
         )
         if form.is_valid():
-            doc.file_size = doc.file.size
-
-            # Set new document file hash
-            doc.file.seek(0)
-            doc._set_file_hash(doc.file.read())
-            doc.file.seek(0)
-
+            doc._set_document_file_metadata()
             form.save()
 
             # Reindex the document to make sure all tags are indexed
@@ -191,12 +185,7 @@ def edit(request, document_id):
         if form.is_valid():
             if "file" in form.changed_data:
                 doc = form.save(commit=False)
-                doc.file_size = doc.file.size
-
-                # Set new document file hash
-                doc.file.seek(0)
-                doc._set_file_hash(doc.file.read())
-                doc.file.seek(0)
+                doc._set_document_file_metadata()
                 doc.save()
                 form.save_m2m()
 

--- a/wagtail/documents/views/multiple.py
+++ b/wagtail/documents/views/multiple.py
@@ -9,7 +9,6 @@ from wagtail.admin.views.generic.multiple_upload import (
 )
 from wagtail.admin.views.generic.multiple_upload import DeleteView as BaseDeleteView
 from wagtail.admin.views.generic.multiple_upload import EditView as BaseEditView
-from wagtail.search.backends import get_search_backends
 
 from .. import get_document_model
 from ..forms import get_document_form, get_document_multi_form
@@ -81,10 +80,6 @@ class EditView(BaseEditView):
     def save_object(self, form):
         form.save()
 
-        # Reindex the doc to make sure all tags are indexed
-        for backend in get_search_backends():
-            backend.add(self.object)
-
 
 class DeleteView(BaseDeleteView):
     permission_policy = permission_policy
@@ -118,12 +113,11 @@ class CreateFromUploadedDocumentView(BaseCreateFromUploadView):
             os.path.basename(self.upload.file.name), self.upload.file.file, save=False
         )
         self.object.uploaded_by_user = self.request.user
+
+        # form.save() would normally handle writing the image file metadata, but in this case the
+        # file handling happens outside the form, so we need to do that manually
         self.object._set_document_file_metadata()
         form.save()
-
-        # Reindex the document to make sure all tags are indexed
-        for backend in get_search_backends():
-            backend.add(self.object)
 
 
 class DeleteUploadView(BaseDeleteUploadView):

--- a/wagtail/documents/views/multiple.py
+++ b/wagtail/documents/views/multiple.py
@@ -118,7 +118,6 @@ class CreateFromUploadedDocumentView(BaseCreateFromUploadView):
             os.path.basename(self.upload.file.name), self.upload.file.file, save=False
         )
         self.object.uploaded_by_user = self.request.user
-        self.object.file.open()
         self.object._set_document_file_metadata()
         form.save()
 

--- a/wagtail/documents/views/multiple.py
+++ b/wagtail/documents/views/multiple.py
@@ -77,9 +77,6 @@ class EditView(BaseEditView):
     def get_edit_form_class(self):
         return get_document_multi_form(self.model)
 
-    def save_object(self, form):
-        form.save()
-
 
 class DeleteView(BaseDeleteView):
     permission_policy = permission_policy

--- a/wagtail/documents/views/multiple.py
+++ b/wagtail/documents/views/multiple.py
@@ -46,13 +46,7 @@ class AddView(BaseAddView):
     def save_object(self, form):
         doc = form.save(commit=False)
         doc.uploaded_by_user = self.request.user
-        doc.file_size = doc.file.size
-
-        # Set new document file hash
-        doc.file.seek(0)
-        doc._set_file_hash(doc.file.read())
-        doc.file.seek(0)
-
+        doc._set_document_file_metadata()
         doc.save()
 
         return doc
@@ -124,11 +118,8 @@ class CreateFromUploadedDocumentView(BaseCreateFromUploadView):
             os.path.basename(self.upload.file.name), self.upload.file.file, save=False
         )
         self.object.uploaded_by_user = self.request.user
-        self.object.file_size = self.object.file.size
         self.object.file.open()
-        self.object.file.seek(0)
-        self.object._set_file_hash(self.object.file.read())
-        self.object.file.seek(0)
+        self.object._set_document_file_metadata()
         form.save()
 
         # Reindex the document to make sure all tags are indexed

--- a/wagtail/images/models.py
+++ b/wagtail/images/models.py
@@ -237,6 +237,8 @@ class AbstractImage(ImageFileMixin, CollectionMember, index.Indexed, models.Mode
         return self.file_hash
 
     def _set_image_file_metadata(self):
+        self.file.open()
+
         # Set new image file size
         self.file_size = self.file.size
 

--- a/wagtail/images/models.py
+++ b/wagtail/images/models.py
@@ -236,6 +236,15 @@ class AbstractImage(ImageFileMixin, CollectionMember, index.Indexed, models.Mode
 
         return self.file_hash
 
+    def _set_image_file_metadata(self):
+        # Set new image file size
+        self.file_size = self.file.size
+
+        # Set new image file hash
+        self.file.seek(0)
+        self._set_file_hash(self.file.read())
+        self.file.seek(0)
+
     def get_upload_to(self, filename):
         folder_name = "original_images"
         filename = self.file.field.storage.get_valid_name(filename)

--- a/wagtail/images/models.py
+++ b/wagtail/images/models.py
@@ -243,7 +243,6 @@ class AbstractImage(ImageFileMixin, CollectionMember, index.Indexed, models.Mode
         self.file_size = self.file.size
 
         # Set new image file hash
-        self.file.seek(0)
         self._set_file_hash(self.file.read())
         self.file.seek(0)
 

--- a/wagtail/images/views/chooser.py
+++ b/wagtail/images/views/chooser.py
@@ -210,14 +210,7 @@ def chooser_upload(request):
         )
 
         if form.is_valid():
-            # Set image file size
-            image.file_size = image.file.size
-
-            # Set image file hash
-            image.file.seek(0)
-            image._set_file_hash(image.file.read())
-            image.file.seek(0)
-
+            image._set_image_file_metadata()
             form.save()
 
             # Reindex the image to make sure all tags are indexed

--- a/wagtail/images/views/chooser.py
+++ b/wagtail/images/views/chooser.py
@@ -17,7 +17,6 @@ from wagtail.images.formats import get_image_format
 from wagtail.images.forms import ImageInsertionForm, get_image_form
 from wagtail.images.permissions import permission_policy
 from wagtail.images.utils import find_image_duplicates
-from wagtail.search import index as search_index
 
 permission_checker = PermissionPolicyChecker(permission_policy)
 
@@ -210,11 +209,7 @@ def chooser_upload(request):
         )
 
         if form.is_valid():
-            image._set_image_file_metadata()
             form.save()
-
-            # Reindex the image to make sure all tags are indexed
-            search_index.insert_or_update_object(image)
 
             duplicates = find_image_duplicates(
                 image=image,

--- a/wagtail/images/views/images.py
+++ b/wagtail/images/views/images.py
@@ -190,17 +190,9 @@ def edit(request, image_id):
     next_url = get_valid_next_url_from_request(request)
 
     if request.method == "POST":
-        original_file = image.file
         form = ImageForm(request.POST, request.FILES, instance=image, user=request.user)
         if form.is_valid():
             form.save()
-
-            if "file" in form.changed_data:
-                # if providing a new image file, delete the old one and all renditions.
-                # NB Doing this via original_file.delete() clears the file field,
-                # which definitely isn't what we want...
-                original_file.storage.delete(original_file.name)
-                image.renditions.all().delete()
 
             edit_url = reverse("wagtailimages:edit", args=(image.id,))
             redirect_url = "wagtailimages:index"

--- a/wagtail/images/views/images.py
+++ b/wagtail/images/views/images.py
@@ -195,13 +195,7 @@ def edit(request, image_id):
         form = ImageForm(request.POST, request.FILES, instance=image, user=request.user)
         if form.is_valid():
             if "file" in form.changed_data:
-                # Set new image file size
-                image.file_size = image.file.size
-
-                # Set new image file hash
-                image.file.seek(0)
-                image._set_file_hash(image.file.read())
-                image.file.seek(0)
+                image._set_image_file_metadata()
 
             form.save()
 
@@ -391,14 +385,7 @@ def add(request):
         image = ImageModel(uploaded_by_user=request.user)
         form = ImageForm(request.POST, request.FILES, instance=image, user=request.user)
         if form.is_valid():
-            # Set image file size
-            image.file_size = image.file.size
-
-            # Set image file hash
-            image.file.seek(0)
-            image._set_file_hash(image.file.read())
-            image.file.seek(0)
-
+            image._set_image_file_metadata()
             form.save()
 
             # Reindex the image to make sure all tags are indexed

--- a/wagtail/images/views/multiple.py
+++ b/wagtail/images/views/multiple.py
@@ -118,9 +118,6 @@ class EditView(BaseEditView):
     def get_edit_form_class(self):
         return get_image_multi_form(self.model)
 
-    def save_object(self, form):
-        form.save()
-
 
 class DeleteView(BaseDeleteView):
     permission_policy = permission_policy

--- a/wagtail/images/views/multiple.py
+++ b/wagtail/images/views/multiple.py
@@ -81,10 +81,7 @@ class AddView(BaseAddView):
     def save_object(self, form):
         image = form.save(commit=False)
         image.uploaded_by_user = self.request.user
-        image.file_size = image.file.size
-        image.file.seek(0)
-        image._set_file_hash(image.file.read())
-        image.file.seek(0)
+        image._set_image_file_metadata()
         image.save()
         return image
 
@@ -163,11 +160,8 @@ class CreateFromUploadedImageView(BaseCreateFromUploadView):
             os.path.basename(self.upload.file.name), self.upload.file.file, save=False
         )
         self.object.uploaded_by_user = self.request.user
-        self.object.file_size = self.object.file.size
         self.object.file.open()
-        self.object.file.seek(0)
-        self.object._set_file_hash(self.object.file.read())
-        self.object.file.seek(0)
+        self.object._set_image_file_metadata()
         form.save()
 
         # Reindex the image to make sure all tags are indexed

--- a/wagtail/images/views/multiple.py
+++ b/wagtail/images/views/multiple.py
@@ -160,7 +160,6 @@ class CreateFromUploadedImageView(BaseCreateFromUploadView):
             os.path.basename(self.upload.file.name), self.upload.file.file, save=False
         )
         self.object.uploaded_by_user = self.request.user
-        self.object.file.open()
         self.object._set_image_file_metadata()
         form.save()
 


### PR DESCRIPTION
In the various views where images and documents are created or updated, there's a bunch of boilerplate code for setting the file size and hash fields and reindexing the object. Move this to the form / model to eliminate the duplication.

The tradeoff is that we now require custom forms set via WAGTAILIMAGES_IMAGE_FORM_BASE / WAGTAILDOCS_DOCUMENT_FORM_BASE to inherit from Wagtail's base form classes, otherwise they'll be missing core functionality - previously the docs suggested the possibility of replacing them outright. I very much doubt anyone took advantage of that option though...

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
