### PR TITLE
Fixed #8813 -- Correctly validate from/to column index in redirect import

### DIFF
--- a/wagtail/contrib/redirects/tests/files/example_offset_columns.csv
+++ b/wagtail/contrib/redirects/tests/files/example_offset_columns.csv
@@ -1,0 +1,4 @@
+ID,UUID,Type,Requested by,Granted,Imported,Site,User,Date,Time,Permanent,Notes,Checked,Category,Protocol,Domain,From,To
+1,4aaafa99-9362-4170-9949-d628482f847f,Redirect,Ann Smith,TRUE,FALSE,1,Admin User,06/07/2022,14:46,FALSE,…,TRUE,Offsite,HTTPS,www.example.com,/goodbye,https://www.example.com/cya/
+2,713e00d5-599e-4f9d-bd1b-be5ff3ab627c,Redirect,Ngaio Bailo,TRUE,FALSE,1,Admin User,06/07/2022,14:43,FALSE,…,TRUE,Offsite,HTTPS,www.example.com,/hello,https://www.example.com/hi/
+3,0e9e4f6a-cb56-4ea4-9301-61dff68b9961,Redirect,Cheng Lee,TRUE,FALSE,1,Admin User,06/07/2022,14:43,FALSE,…,TRUE,Samesite,HTTPS,,/welcome,/hello

--- a/wagtail/contrib/redirects/tests/test_import_admin_views.py
+++ b/wagtail/contrib/redirects/tests/test_import_admin_views.py
@@ -114,6 +114,35 @@ class TestImportAdminViews(TestCase, WagtailTestUtils):
             )
             self.assertEqual(Redirect.objects.all().count(), 2)
 
+    def test_import_step_with_offset_columns(self):
+        f = "{}/files/example_offset_columns.csv".format(TEST_ROOT)
+        (_, filename) = os.path.split(f)
+
+        with open(f, "rb") as infile:
+            upload_file = SimpleUploadedFile(filename, infile.read())
+
+            self.assertEqual(Redirect.objects.all().count(), 0)
+
+            response = self.post(
+                {
+                    "import_file": upload_file,
+                }
+            )
+
+            import_response = self.post_import(
+                {
+                    **response.context["form"].initial,
+                    "from_index": 16,
+                    "to_index": 17,
+                    "permanent": True,
+                },
+            )
+
+            self.assertTemplateUsed(
+                import_response, "wagtailredirects/import_summary.html"
+            )
+            self.assertEqual(Redirect.objects.all().count(), 2)
+
     def test_permanent_setting(self):
         f = "{}/files/example.csv".format(TEST_ROOT)
         (_, filename) = os.path.split(f)


### PR DESCRIPTION
Fixes issue #6913 (and #8813 which is a duplicate). In addition this PR makes it impossible for the user to manipulate the values of the hidden `import_file_name` and `input_format` fields by signing these values.