### PR TITLE
Fixed #8062 -- Make sure get_site_root_paths returns a list of SiteRootPath instances

### DIFF
--- a/wagtail/models/__init__.py
+++ b/wagtail/models/__init__.py
@@ -22,7 +22,6 @@ from django.contrib.auth.models import Group
 from django.contrib.contenttypes.fields import GenericForeignKey, GenericRelation
 from django.contrib.contenttypes.models import ContentType
 from django.core import checks
-from django.core.cache import cache
 from django.core.exceptions import (
     ImproperlyConfigured,
     PermissionDenied,
@@ -1192,7 +1191,7 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
         # Note: New translations of existing site roots are considered site roots as well, so we must
         # always check if this page is a site root, even if it's new.
         if self.is_site_root():
-            cache.delete("wagtail_site_root_paths")
+            Site.clear_site_root_paths_cache()
 
         # Log
         if is_new:

--- a/wagtail/models/sites.py
+++ b/wagtail/models/sites.py
@@ -254,6 +254,11 @@ class Site(models.Model):
                 version=SITE_ROOT_PATHS_CACHE_VERSION,
             )
 
+        else:
+            # Convert the cache result to a list of SiteRootPath tuples, as some
+            # cache backends (e.g. Redis) don't support named tuples.
+            result = [SiteRootPath(*result) for result in result]
+
         return result
 
     @staticmethod

--- a/wagtail/models/sites.py
+++ b/wagtail/models/sites.py
@@ -71,6 +71,10 @@ class SiteManager(models.Manager):
 
 SiteRootPath = namedtuple("SiteRootPath", "site_id root_path root_url language_code")
 
+SITE_ROOT_PATHS_CACHE_KEY = "wagtail_site_root_paths"
+# Increase the cache version whenever the structure SiteRootPath tuple changes
+SITE_ROOT_PATHS_CACHE_VERSION = 2
+
 
 class Site(models.Model):
     hostname = models.CharField(
@@ -209,13 +213,11 @@ class Site(models.Model):
         - `root_url` - The scheme/domain name of the site (for example 'https://www.example.com/')
         - `language_code` - The language code of the site (for example 'en')
         """
-        result = cache.get("wagtail_site_root_paths")
+        result = cache.get(
+            SITE_ROOT_PATHS_CACHE_KEY, version=SITE_ROOT_PATHS_CACHE_VERSION
+        )
 
-        # Wagtail 2.11 changed the way site root paths were stored. This can cause an upgraded 2.11
-        # site to break when loading cached site root paths that were cached with 2.10.2 or older
-        # versions of Wagtail. The line below checks if the any of the cached site urls is consistent
-        # with an older version of Wagtail and invalidates the cache.
-        if result is None or any(len(site_record) == 3 for site_record in result):
+        if result is None:
             result = []
 
             for site in Site.objects.select_related(
@@ -245,6 +247,15 @@ class Site(models.Model):
                         )
                     )
 
-            cache.set("wagtail_site_root_paths", result, 3600)
+            cache.set(
+                SITE_ROOT_PATHS_CACHE_KEY,
+                result,
+                3600,
+                version=SITE_ROOT_PATHS_CACHE_VERSION,
+            )
 
         return result
+
+    @staticmethod
+    def clear_site_root_paths_cache():
+        cache.delete(SITE_ROOT_PATHS_CACHE_KEY, version=SITE_ROOT_PATHS_CACHE_VERSION)

--- a/wagtail/signal_handlers.py
+++ b/wagtail/signal_handlers.py
@@ -2,7 +2,6 @@ import logging
 from contextlib import contextmanager
 
 from asgiref.local import Local
-from django.core.cache import cache
 from django.db import transaction
 from django.db.models.signals import (
     post_delete,
@@ -21,11 +20,11 @@ logger = logging.getLogger("wagtail")
 
 # Clear the wagtail_site_root_paths from the cache whenever Site records are updated.
 def post_save_site_signal_handler(instance, update_fields=None, **kwargs):
-    cache.delete("wagtail_site_root_paths")
+    Site.clear_site_root_paths_cache()
 
 
 def post_delete_site_signal_handler(instance, **kwargs):
-    cache.delete("wagtail_site_root_paths")
+    Site.clear_site_root_paths_cache()
 
 
 def pre_delete_page_unpublish(sender, instance, **kwargs):

--- a/wagtail/tests/test_page_model.py
+++ b/wagtail/tests/test_page_model.py
@@ -767,9 +767,7 @@ class TestServeView(TestCase):
         # Explicitly clear the cache of site root paths. Normally this would be kept
         # in sync by the Site.save logic, but this is bypassed when the database is
         # rolled back between tests using transactions.
-        from django.core.cache import cache
-
-        cache.delete("wagtail_site_root_paths")
+        Site.clear_site_root_paths_cache()
 
         # also need to clear urlresolver caches before/after tests, because we override
         # ROOT_URLCONF in some tests here

--- a/wagtail/tests/tests.py
+++ b/wagtail/tests/tests.py
@@ -8,6 +8,10 @@ from django.utils.safestring import SafeString
 
 from wagtail.coreutils import resolve_model_string
 from wagtail.models import Locale, Page, Site, SiteRootPath
+from wagtail.models.sites import (
+    SITE_ROOT_PATHS_CACHE_KEY,
+    SITE_ROOT_PATHS_CACHE_VERSION,
+)
 from wagtail.templatetags.wagtailcore_tags import richtext, slugurl
 from wagtail.test.testapp.models import SimplePage
 
@@ -217,7 +221,7 @@ class TestSiteRootPathsCache(TestCase):
 
         # Check that the cache has been set correctly
         self.assertEqual(
-            cache.get("wagtail_site_root_paths"),
+            cache.get(SITE_ROOT_PATHS_CACHE_KEY, version=SITE_ROOT_PATHS_CACHE_VERSION),
             [
                 SiteRootPath(
                     site_id=1,
@@ -239,13 +243,17 @@ class TestSiteRootPathsCache(TestCase):
         _ = homepage.url  # noqa
 
         # Check that the cache has been set
-        self.assertTrue(cache.get("wagtail_site_root_paths"))
+        self.assertTrue(
+            cache.get(SITE_ROOT_PATHS_CACHE_KEY, version=SITE_ROOT_PATHS_CACHE_VERSION)
+        )
 
         # Save the site
         Site.objects.get(is_default_site=True).save()
 
         # Check that the cache has been cleared
-        self.assertFalse(cache.get("wagtail_site_root_paths"))
+        self.assertFalse(
+            cache.get(SITE_ROOT_PATHS_CACHE_KEY, version=SITE_ROOT_PATHS_CACHE_VERSION)
+        )
 
     def test_cache_clears_when_site_deleted(self):
         """
@@ -258,13 +266,17 @@ class TestSiteRootPathsCache(TestCase):
         _ = homepage.url  # noqa
 
         # Check that the cache has been set
-        self.assertTrue(cache.get("wagtail_site_root_paths"))
+        self.assertTrue(
+            cache.get(SITE_ROOT_PATHS_CACHE_KEY, version=SITE_ROOT_PATHS_CACHE_VERSION)
+        )
 
         # Delete the site
         Site.objects.get(is_default_site=True).delete()
 
         # Check that the cache has been cleared
-        self.assertFalse(cache.get("wagtail_site_root_paths"))
+        self.assertFalse(
+            cache.get(SITE_ROOT_PATHS_CACHE_KEY, version=SITE_ROOT_PATHS_CACHE_VERSION)
+        )
 
     def test_cache_clears_when_site_root_moves(self):
         """

--- a/wagtail/tests/tests.py
+++ b/wagtail/tests/tests.py
@@ -211,6 +211,11 @@ class TestWagtailSiteTag(TestCase):
 class TestSiteRootPathsCache(TestCase):
     fixtures = ["test.json"]
 
+    def get_cached_site_root_paths(self):
+        return cache.get(
+            SITE_ROOT_PATHS_CACHE_KEY, version=SITE_ROOT_PATHS_CACHE_VERSION
+        )
+
     def test_cache(self):
         """
         This tests that the cache is populated when building URLs
@@ -223,7 +228,7 @@ class TestSiteRootPathsCache(TestCase):
 
         # Check that the cache has been set correctly
         self.assertEqual(
-            cache.get(SITE_ROOT_PATHS_CACHE_KEY, version=SITE_ROOT_PATHS_CACHE_VERSION),
+            self.get_cached_site_root_paths(),
             [
                 SiteRootPath(
                     site_id=1,
@@ -275,17 +280,23 @@ class TestSiteRootPathsCache(TestCase):
         _ = homepage.url  # noqa
 
         # Check that the cache has been set
-        self.assertTrue(
-            cache.get(SITE_ROOT_PATHS_CACHE_KEY, version=SITE_ROOT_PATHS_CACHE_VERSION)
+        self.assertEqual(
+            self.get_cached_site_root_paths(),
+            [
+                SiteRootPath(
+                    site_id=1,
+                    root_path="/home/",
+                    root_url="http://localhost",
+                    language_code="en",
+                )
+            ],
         )
 
         # Save the site
         Site.objects.get(is_default_site=True).save()
 
         # Check that the cache has been cleared
-        self.assertFalse(
-            cache.get(SITE_ROOT_PATHS_CACHE_KEY, version=SITE_ROOT_PATHS_CACHE_VERSION)
-        )
+        self.assertIsNone(self.get_cached_site_root_paths())
 
     def test_cache_clears_when_site_deleted(self):
         """
@@ -298,17 +309,23 @@ class TestSiteRootPathsCache(TestCase):
         _ = homepage.url  # noqa
 
         # Check that the cache has been set
-        self.assertTrue(
-            cache.get(SITE_ROOT_PATHS_CACHE_KEY, version=SITE_ROOT_PATHS_CACHE_VERSION)
+        self.assertEqual(
+            self.get_cached_site_root_paths(),
+            [
+                SiteRootPath(
+                    site_id=1,
+                    root_path="/home/",
+                    root_url="http://localhost",
+                    language_code="en",
+                )
+            ],
         )
 
         # Delete the site
         Site.objects.get(is_default_site=True).delete()
 
         # Check that the cache has been cleared
-        self.assertFalse(
-            cache.get(SITE_ROOT_PATHS_CACHE_KEY, version=SITE_ROOT_PATHS_CACHE_VERSION)
-        )
+        self.assertIsNone(self.get_cached_site_root_paths())
 
     def test_cache_clears_when_site_root_moves(self):
         """


### PR DESCRIPTION
This PR fixes an issue (reported in #8062) where a cache backend (e.g. Redis) might serialize a list of namedtuples as a list of lists.

In addition I cleaned up the cache invalidation check for cache values from Wagtail <= 2.10.2 by versioning the cache key.