### PR TITLE
Provide a StreamField chooser block for generic choosers

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -103,6 +103,7 @@ Changelog
  * Remove usage of inline script to focus on the username field, instead use `autofocus` (LB (Ben) Johnston)
  * Improve organisation of the settings reference page in the documentation (Akash Kumar Sen)
  * Added `path` and `re_path` decorators to the `RoutablePageMixin` module which emulate their Django URL utils equivalent, redirect `re_path` to the original `route` decorator (Tidiane Dia)
+ * `BaseChooser` widget now provides a Telepath adapter that's directly usable for any subclasses that use the chooser widget and modal JS as-is with no customisations (Matt Westcott)
  * Fix: Typo in `ResumeWorkflowActionFormatter` message (Stefan Hammer)
  * Fix: Throw a meaningful error when saving an image to an unrecognised image format (Christian Franke)
  * Fix: Remove extra padding for headers with breadcrumbs on mobile viewport (Steven Steinwand)

--- a/client/src/components/ChooserWidget/index.js
+++ b/client/src/components/ChooserWidget/index.js
@@ -138,3 +138,22 @@ export class Chooser {
     });
   }
 }
+
+export class ChooserFactory {
+  widgetClass = Chooser;
+
+  constructor(html, idPattern) {
+    this.html = html;
+    this.idPattern = idPattern;
+  }
+
+  render(placeholder, name, id, initialState) {
+    const html = this.html.replace(/__NAME__/g, name).replace(/__ID__/g, id);
+    // eslint-disable-next-line no-param-reassign
+    placeholder.outerHTML = html;
+    // eslint-disable-next-line new-cap
+    const chooser = new this.widgetClass(id);
+    chooser.setState(initialState);
+    return chooser;
+  }
+}

--- a/client/src/components/ChooserWidget/index.js
+++ b/client/src/components/ChooserWidget/index.js
@@ -4,7 +4,7 @@ export class Chooser {
   modalOnloadHandlers = chooserModalOnloadHandlers;
 
   titleStateKey = 'title'; // key used in the 'state' dictionary to hold the human-readable title
-  editLinkStateKey = 'edit_link'; // key used in the 'state' dictionary to hold the URL of the edit page
+  editUrlStateKey = 'edit_url'; // key used in the 'state' dictionary to hold the URL of the edit page
   chosenResponseName = 'chosen'; // identifier for the ModalWorkflow response that indicates an item was chosen
 
   constructor(id) {
@@ -34,7 +34,7 @@ export class Chooser {
   getStateFromHTML() {
     /*
         Construct initial state of the chooser from the rendered (static) HTML.
-        State is either null (= no item chosen) or a dict of id, title and edit_link.
+        State is either null (= no item chosen) or a dict of id, title and edit_url.
 
         The result returned from the chooser modal (see get_chosen_response_data in
         wagtail.admin.views.generic.chooser.ChosenView) is a superset of this, and can therefore be
@@ -47,8 +47,8 @@ export class Chooser {
       if (this.titleElement && this.titleStateKey) {
         state[this.titleStateKey] = this.titleElement.textContent;
       }
-      if (this.editLink && this.editLinkStateKey) {
-        state[this.editLinkStateKey] = this.editLink.getAttribute('href');
+      if (this.editLink && this.editUrlStateKey) {
+        state[this.editUrlStateKey] = this.editLink.getAttribute('href');
       }
       return state;
     } else {
@@ -89,7 +89,7 @@ export class Chooser {
     }
     this.chooserElement.classList.remove('blank');
     if (this.editLink) {
-      const editUrl = newState[this.editLinkStateKey];
+      const editUrl = newState[this.editUrlStateKey];
       if (editUrl) {
         this.editLink.setAttribute('href', editUrl);
         this.editLink.classList.remove('u-hidden');

--- a/client/src/components/Draftail/sources/ModalWorkflowSource.test.js
+++ b/client/src/components/Draftail/sources/ModalWorkflowSource.test.js
@@ -156,7 +156,7 @@ describe('ModalWorkflowSource', () => {
           title: 'Test',
           alt: 'Test',
           class: 'richtext-image right',
-          edit_link: '/admin/images/53/',
+          edit_url: '/admin/images/53/',
           format: 'right',
           preview: {
             url: '/media/images/test.width-500.jpg',
@@ -183,7 +183,7 @@ describe('ModalWorkflowSource', () => {
     it('DOCUMENT', () => {
       expect(
         documentSource.filterEntityData({
-          edit_link: '/admin/documents/edit/1/',
+          edit_url: '/admin/documents/edit/1/',
           filename: 'test.pdf',
           id: 1,
           title: 'Test',

--- a/client/src/entrypoints/admin/chooser-widget-telepath.js
+++ b/client/src/entrypoints/admin/chooser-widget-telepath.js
@@ -1,0 +1,3 @@
+import { ChooserFactory } from '../../components/ChooserWidget';
+
+window.telepath.register('wagtail.admin.widgets.Chooser', ChooserFactory);

--- a/client/src/entrypoints/admin/page-chooser.js
+++ b/client/src/entrypoints/admin/page-chooser.js
@@ -4,7 +4,7 @@ class PageChooser extends Chooser {
   // eslint-disable-next-line no-undef
   modalOnloadHandlers = PAGE_CHOOSER_MODAL_ONLOAD_HANDLERS;
   titleStateKey = 'adminTitle';
-  editLinkStateKey = 'editUrl';
+  editUrlStateKey = 'editUrl';
   chosenResponseName = 'pageChosen';
 
   constructor(id, parentId, options) {

--- a/client/src/entrypoints/documents/document-chooser-telepath.js
+++ b/client/src/entrypoints/documents/document-chooser-telepath.js
@@ -1,19 +1,8 @@
-class DocumentChooserFactory {
-  constructor(html, idPattern) {
-    this.html = html;
-    this.idPattern = idPattern;
-  }
+import { ChooserFactory } from '../../components/ChooserWidget';
 
-  render(placeholder, name, id, initialState) {
-    const html = this.html.replace(/__NAME__/g, name).replace(/__ID__/g, id);
-    // eslint-disable-next-line no-param-reassign
-    placeholder.outerHTML = html;
-    /* the DocumentChooser object also serves as the JS widget representation */
-    // eslint-disable-next-line no-undef
-    const chooser = new DocumentChooser(id);
-    chooser.setState(initialState);
-    return chooser;
-  }
+class DocumentChooserFactory extends ChooserFactory {
+  // eslint-disable-next-line no-undef
+  widgetClass = DocumentChooser;
 }
 window.telepath.register(
   'wagtail.documents.widgets.DocumentChooser',

--- a/client/src/entrypoints/images/image-chooser-telepath.js
+++ b/client/src/entrypoints/images/image-chooser-telepath.js
@@ -1,19 +1,8 @@
-class ImageChooserFactory {
-  constructor(html, idPattern) {
-    this.html = html;
-    this.idPattern = idPattern;
-  }
+import { ChooserFactory } from '../../components/ChooserWidget';
 
-  render(placeholder, name, id, initialState) {
-    const html = this.html.replace(/__NAME__/g, name).replace(/__ID__/g, id);
-    // eslint-disable-next-line no-param-reassign
-    placeholder.outerHTML = html;
-    /* the ImageChooser object also serves as the JS widget representation */
-    // eslint-disable-next-line no-undef
-    const chooser = new ImageChooser(id);
-    chooser.setState(initialState);
-    return chooser;
-  }
+class ImageChooserFactory extends ChooserFactory {
+  // eslint-disable-next-line no-undef
+  widgetClass = ImageChooser;
 }
 window.telepath.register(
   'wagtail.images.widgets.ImageChooser',

--- a/client/src/entrypoints/images/image-chooser.js
+++ b/client/src/entrypoints/images/image-chooser.js
@@ -12,7 +12,7 @@ class ImageChooser extends Chooser {
   getStateFromHTML() {
     /*
     Construct initial state of the chooser from the rendered (static) HTML.
-    State is either null (= no image chosen) or a dict of id, edit_link, title
+    State is either null (= no image chosen) or a dict of id, edit_url, title
     and preview (= a dict of url, width, height).
     */
     const state = super.getStateFromHTML();

--- a/client/src/entrypoints/snippets/snippet-chooser-telepath.js
+++ b/client/src/entrypoints/snippets/snippet-chooser-telepath.js
@@ -1,19 +1,8 @@
-class SnippetChooserFactory {
-  constructor(html, idPattern) {
-    this.html = html;
-    this.idPattern = idPattern;
-  }
+import { ChooserFactory } from '../../components/ChooserWidget';
 
-  render(placeholder, name, id, initialState) {
-    const html = this.html.replace(/__NAME__/g, name).replace(/__ID__/g, id);
-    // eslint-disable-next-line no-param-reassign
-    placeholder.outerHTML = html;
-    /* the SnippetChooser object also serves as the JS widget representation */
-    // eslint-disable-next-line no-undef
-    const chooser = new SnippetChooser(id);
-    chooser.setState(initialState);
-    return chooser;
-  }
+class SnippetChooserFactory extends ChooserFactory {
+  // eslint-disable-next-line no-undef
+  widgetClass = SnippetChooser;
 }
 window.telepath.register(
   'wagtail.snippets.widgets.SnippetChooser',

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -33,6 +33,7 @@ module.exports = function exports(env, argv) {
     'admin': [
       'chooser-modal',
       'chooser-widget',
+      'chooser-widget-telepath',
       'comments',
       'core',
       'date-time-chooser',

--- a/docs/reference/viewsets.md
+++ b/docs/reference/viewsets.md
@@ -57,8 +57,10 @@ Viewsets are Wagtail's mechanism for defining a group of related admin views wit
    .. autoattribute:: choose_results_view_class
    .. autoattribute:: chosen_view_class
    .. autoattribute:: create_view_class
+   .. autoattribute:: base_widget_class
    .. autoattribute:: widget_class
    .. autoattribute:: register_widget
+   .. autoattribute:: base_block_class
    .. autoattribute:: block_class
    .. autoattribute:: creation_form_class
    .. autoattribute:: form_fields

--- a/docs/reference/viewsets.md
+++ b/docs/reference/viewsets.md
@@ -59,6 +59,7 @@ Viewsets are Wagtail's mechanism for defining a group of related admin views wit
    .. autoattribute:: create_view_class
    .. autoattribute:: widget_class
    .. autoattribute:: register_widget
+   .. autoattribute:: block_class
    .. autoattribute:: creation_form_class
    .. autoattribute:: form_fields
    .. autoattribute:: exclude_form_fields

--- a/docs/releases/4.0.md
+++ b/docs/releases/4.0.md
@@ -162,6 +162,7 @@ The bulk of these enhancements have been from Paarth Agarwal, who has been doing
  * Allow generic chooser viewsets to support non-model data such as an API endpoint (Matt Wescott)
  * Improve organisation of the settings reference page in the documentation (Akash Kumar Sen)
  * Added `path` and `re_path` decorators to the `RoutablePageMixin` module which emulate their Django URL utils equivalent, redirect `re_path` to the original `route` decorator (Tidiane Dia)
+ * `BaseChooser` widget now provides a Telepath adapter that's directly usable for any subclasses that use the chooser widget and modal JS as-is with no customisations (Matt Westcott)
 
 ### Bug fixes
 

--- a/wagtail/admin/views/generic/chooser.py
+++ b/wagtail/admin/views/generic/chooser.py
@@ -347,7 +347,7 @@ class ChosenResponseMixin:
         return {
             "id": str(self.get_object_id(item)),
             self.response_data_title_key: self.get_display_title(item),
-            "edit_link": self.get_edit_item_url(item),
+            "edit_url": self.get_edit_item_url(item),
         }
 
     def get_chosen_response(self, item):

--- a/wagtail/admin/widgets/chooser.py
+++ b/wagtail/admin/widgets/chooser.py
@@ -234,10 +234,34 @@ class BaseChooser(widgets.Input):
     def render_js_init(self, id_, name, value_data):
         return "new Chooser({0});".format(json.dumps(id_))
 
-    class Media:
-        js = [
-            "wagtailadmin/js/chooser-widget.js",
+    @cached_property
+    def media(self):
+        return forms.Media(
+            js=[
+                versioned_static("wagtailadmin/js/chooser-widget.js"),
+            ]
+        )
+
+
+class BaseChooserAdapter(WidgetAdapter):
+    js_constructor = "wagtail.admin.widgets.Chooser"
+
+    def js_args(self, widget):
+        return [
+            widget.render_html("__NAME__", None, attrs={"id": "__ID__"}),
+            widget.id_for_label("__ID__"),
         ]
+
+    @cached_property
+    def media(self):
+        return forms.Media(
+            js=[
+                versioned_static("wagtailadmin/js/chooser-widget-telepath.js"),
+            ]
+        )
+
+
+register(BaseChooserAdapter(), BaseChooser)
 
 
 class AdminPageChooser(BaseChooser):

--- a/wagtail/blocks/field_block.py
+++ b/wagtail/blocks/field_block.py
@@ -803,6 +803,9 @@ class ChooserBlock(FieldBlock):
             except self.target_model.DoesNotExist:
                 return None
 
+    def get_form_state(self, value):
+        return self.widget.get_value_data(value)
+
     def clean(self, value):
         # ChooserBlock works natively with model instances as its 'value' type (because that's what you
         # want to work with when doing front-end templating), but ModelChoiceField.clean expects an ID

--- a/wagtail/blocks/field_block.py
+++ b/wagtail/blocks/field_block.py
@@ -757,9 +757,13 @@ class ChooserBlock(FieldBlock):
     """Abstract superclass for fields that implement a chooser interface (page, image, snippet etc)"""
 
     @cached_property
+    def model_class(self):
+        return resolve_model_string(self.target_model)
+
+    @cached_property
     def field(self):
         return forms.ModelChoiceField(
-            queryset=self.target_model.objects.all(),
+            queryset=self.model_class.objects.all(),
             widget=self.widget,
             required=self._required,
             validators=self._validators,
@@ -772,8 +776,8 @@ class ChooserBlock(FieldBlock):
             return value
         else:
             try:
-                return self.target_model.objects.get(pk=value)
-            except self.target_model.DoesNotExist:
+                return self.model_class.objects.get(pk=value)
+            except self.model_class.DoesNotExist:
                 return None
 
     def bulk_to_python(self, values):
@@ -781,7 +785,7 @@ class ChooserBlock(FieldBlock):
 
         The instances must be returned in the same order as the values and keep None values.
         """
-        objects = self.target_model.objects.in_bulk(values)
+        objects = self.model_class.objects.in_bulk(values)
         return [
             objects.get(id) for id in values
         ]  # Keeps the ordering the same as in values.
@@ -795,12 +799,12 @@ class ChooserBlock(FieldBlock):
 
     def value_from_form(self, value):
         # ModelChoiceField sometimes returns an ID, and sometimes an instance; we want the instance
-        if value is None or isinstance(value, self.target_model):
+        if value is None or isinstance(value, self.model_class):
             return value
         else:
             try:
-                return self.target_model.objects.get(pk=value)
-            except self.target_model.DoesNotExist:
+                return self.model_class.objects.get(pk=value)
+            except self.model_class.DoesNotExist:
                 return None
 
     def get_form_state(self, value):
@@ -814,7 +818,7 @@ class ChooserBlock(FieldBlock):
         # type) so we convert our instance back to an ID here. It means we have a wasted round-trip to
         # the database when ModelChoiceField.clean promptly does its own lookup, but there's no easy way
         # around that...
-        if isinstance(value, self.target_model):
+        if isinstance(value, self.model_class):
             value = value.pk
         return super().clean(value)
 

--- a/wagtail/documents/blocks.py
+++ b/wagtail/documents/blocks.py
@@ -24,7 +24,7 @@ class DocumentChooserBlock(ChooserBlock):
         else:
             return {
                 "id": value_data["id"],
-                "edit_link": value_data["edit_url"],
+                "edit_url": value_data["edit_url"],
                 "title": value_data["title"],
             }
 

--- a/wagtail/documents/blocks.py
+++ b/wagtail/documents/blocks.py
@@ -17,17 +17,6 @@ class DocumentChooserBlock(ChooserBlock):
 
         return AdminDocumentChooser()
 
-    def get_form_state(self, value):
-        value_data = self.widget.get_value_data(value)
-        if value_data is None:
-            return None
-        else:
-            return {
-                "id": value_data["id"],
-                "edit_url": value_data["edit_url"],
-                "title": value_data["title"],
-            }
-
     def render_basic(self, value, context=None):
         if value:
             return format_html('<a href="{0}">{1}</a>', value.url, value.title)

--- a/wagtail/documents/blocks.py
+++ b/wagtail/documents/blocks.py
@@ -1,27 +1,3 @@
-from django.utils.functional import cached_property
-from django.utils.html import format_html
+from wagtail.documents.views.chooser import viewset as chooser_viewset
 
-from wagtail.blocks import ChooserBlock
-
-
-class DocumentChooserBlock(ChooserBlock):
-    @cached_property
-    def target_model(self):
-        from wagtail.documents import get_document_model
-
-        return get_document_model()
-
-    @cached_property
-    def widget(self):
-        from wagtail.documents.widgets import AdminDocumentChooser
-
-        return AdminDocumentChooser()
-
-    def render_basic(self, value, context=None):
-        if value:
-            return format_html('<a href="{0}">{1}</a>', value.url, value.title)
-        else:
-            return ""
-
-    class Meta:
-        icon = "doc-empty"
+DocumentChooserBlock = chooser_viewset.block_class

--- a/wagtail/documents/views/chooser.py
+++ b/wagtail/documents/views/chooser.py
@@ -3,6 +3,7 @@ import json
 from django import forms
 from django.urls import reverse
 from django.utils.functional import cached_property
+from django.utils.html import format_html
 from django.utils.translation import gettext_lazy as _
 from django.views.generic.base import View
 
@@ -19,8 +20,8 @@ from wagtail.admin.views.generic.chooser import (
 )
 from wagtail.admin.viewsets.chooser import ChooserViewSet
 from wagtail.admin.widgets import BaseChooser
+from wagtail.blocks import ChooserBlock
 from wagtail.documents import get_document_model
-from wagtail.documents.forms import get_document_form
 from wagtail.documents.permissions import permission_policy
 
 
@@ -40,6 +41,8 @@ class DocumentCreationFormMixin(CreationFormMixin):
     creation_tab_id = "upload"
 
     def get_creation_form_class(self):
+        from wagtail.documents.forms import get_document_form
+
         return get_document_form(self.model)
 
     def get_creation_form_kwargs(self):
@@ -165,12 +168,21 @@ class BaseAdminDocumentChooser(BaseChooser):
         )
 
 
+class BaseDocumentChooserBlock(ChooserBlock):
+    def render_basic(self, value, context=None):
+        if value:
+            return format_html('<a href="{0}">{1}</a>', value.url, value.title)
+        else:
+            return ""
+
+
 class DocumentChooserViewSet(ChooserViewSet):
     choose_view_class = DocumentChooseView
     choose_results_view_class = DocumentChooseResultsView
     chosen_view_class = DocumentChosenView
     create_view_class = DocumentChooserUploadView
     base_widget_class = BaseAdminDocumentChooser
+    base_block_class = BaseDocumentChooserBlock
     permission_policy = permission_policy
 
     icon = "doc-full-inverse"

--- a/wagtail/documents/widgets.py
+++ b/wagtail/documents/widgets.py
@@ -2,21 +2,15 @@ from django import forms
 from django.utils.functional import cached_property
 
 from wagtail.admin.staticfiles import versioned_static
+from wagtail.admin.widgets import BaseChooserAdapter
 from wagtail.documents.views.chooser import viewset as chooser_viewset
 from wagtail.telepath import register
-from wagtail.widget_adapters import WidgetAdapter
 
 AdminDocumentChooser = chooser_viewset.widget_class
 
 
-class DocumentChooserAdapter(WidgetAdapter):
+class DocumentChooserAdapter(BaseChooserAdapter):
     js_constructor = "wagtail.documents.widgets.DocumentChooser"
-
-    def js_args(self, widget):
-        return [
-            widget.render_html("__NAME__", None, attrs={"id": "__ID__"}),
-            widget.id_for_label("__ID__"),
-        ]
 
     @cached_property
     def media(self):

--- a/wagtail/images/blocks.py
+++ b/wagtail/images/blocks.py
@@ -20,18 +20,6 @@ class ImageChooserBlock(ChooserBlock):
 
         return AdminImageChooser()
 
-    def get_form_state(self, value):
-        value_data = self.widget.get_value_data(value)
-        if value_data is None:
-            return None
-        else:
-            return {
-                "id": value_data["id"],
-                "edit_url": value_data["edit_url"],
-                "title": value_data["title"],
-                "preview": value_data["preview"],
-            }
-
     def render_basic(self, value, context=None):
         if value:
             return get_rendition_or_not_found(value, "original").img_tag()

--- a/wagtail/images/blocks.py
+++ b/wagtail/images/blocks.py
@@ -27,7 +27,7 @@ class ImageChooserBlock(ChooserBlock):
         else:
             return {
                 "id": value_data["id"],
-                "edit_link": value_data["edit_url"],
+                "edit_url": value_data["edit_url"],
                 "title": value_data["title"],
                 "preview": value_data["preview"],
             }

--- a/wagtail/images/widgets.py
+++ b/wagtail/images/widgets.py
@@ -5,11 +5,10 @@ from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 
 from wagtail.admin.staticfiles import versioned_static
-from wagtail.admin.widgets import BaseChooser
+from wagtail.admin.widgets import BaseChooser, BaseChooserAdapter
 from wagtail.images import get_image_model
 from wagtail.images.shortcuts import get_rendition_or_not_found
 from wagtail.telepath import register
-from wagtail.widget_adapters import WidgetAdapter
 
 
 class AdminImageChooser(BaseChooser):
@@ -53,14 +52,8 @@ class AdminImageChooser(BaseChooser):
         )
 
 
-class ImageChooserAdapter(WidgetAdapter):
+class ImageChooserAdapter(BaseChooserAdapter):
     js_constructor = "wagtail.images.widgets.ImageChooser"
-
-    def js_args(self, widget):
-        return [
-            widget.render_html("__NAME__", None, attrs={"id": "__ID__"}),
-            widget.id_for_label("__ID__"),
-        ]
 
     @cached_property
     def media(self):

--- a/wagtail/snippets/blocks.py
+++ b/wagtail/snippets/blocks.py
@@ -19,16 +19,5 @@ class SnippetChooserBlock(ChooserBlock):
 
         return AdminSnippetChooser(self.target_model)
 
-    def get_form_state(self, value):
-        value_data = self.widget.get_value_data(value)
-        if value_data is None:
-            return None
-        else:
-            return {
-                "id": value_data["id"],
-                "edit_url": value_data["edit_url"],
-                "string": value_data["string"],
-            }
-
     class Meta:
         icon = "snippet"

--- a/wagtail/snippets/blocks.py
+++ b/wagtail/snippets/blocks.py
@@ -26,7 +26,7 @@ class SnippetChooserBlock(ChooserBlock):
         else:
             return {
                 "id": value_data["id"],
-                "edit_link": value_data["edit_url"],
+                "edit_url": value_data["edit_url"],
                 "string": value_data["string"],
             }
 

--- a/wagtail/snippets/widgets.py
+++ b/wagtail/snippets/widgets.py
@@ -8,10 +8,9 @@ from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 
 from wagtail.admin.staticfiles import versioned_static
-from wagtail.admin.widgets import BaseChooser
+from wagtail.admin.widgets import BaseChooser, BaseChooserAdapter
 from wagtail.admin.widgets.button import ListingButton
 from wagtail.telepath import register
-from wagtail.widget_adapters import WidgetAdapter
 
 
 class AdminSnippetChooser(BaseChooser):
@@ -59,14 +58,8 @@ class AdminSnippetChooser(BaseChooser):
         )
 
 
-class SnippetChooserAdapter(WidgetAdapter):
+class SnippetChooserAdapter(BaseChooserAdapter):
     js_constructor = "wagtail.snippets.widgets.SnippetChooser"
-
-    def js_args(self, widget):
-        return [
-            widget.render_html("__NAME__", None, attrs={"id": "__ID__"}),
-            widget.id_for_label("__ID__"),
-        ]
 
     @cached_property
     def media(self):


### PR DESCRIPTION
Part of #8480.

The BaseChooser widget now provides a telepath adapter that's directly usable for any subclasses that use the chooser widget and modal JS as-is with no customisations. Along with a bit of cleanup to iron out some inconsistencies in the JSON representation (some places used `edit_link`, others used `edit_url`) this makes it straightforward to define new ChooserBlock subclasses just by specifying `target_model` and `widget` properties (and an icon in Meta). Since the model, widget and icon are all details that ChooserViewSet knows about, we can then make ChooserViewSet responsible for generating the ChooserBlock for a given model.

Along the way, we tweak the view and widget classes to allow passing `model` as either a string or a model class, to avoid the tendency for this to throw circular import errors (because chooser blocks appear in model definitions and are also defined in terms of models).