### PR TITLE
Fixed typo in classname

### DIFF
--- a/client/scss/components/_header.scss
+++ b/client/scss/components/_header.scss
@@ -15,7 +15,7 @@
     position: relative;
   }
 
-  .w-header__glpyh {
+  .w-header__glyph {
     position: absolute;
     inset-inline-start: -1.5em;
     vertical-align: text-top;

--- a/wagtail/admin/templates/wagtailadmin/reports/base_report.html
+++ b/wagtail/admin/templates/wagtailadmin/reports/base_report.html
@@ -9,7 +9,7 @@
             <div class="left">
                 <div class="col">
                     <h1 class="w-header__title">
-                        {% if header_icon %}{% icon class_name="w-header__glpyh" name=header_icon %}{% endif %}
+                        {% if header_icon %}{% icon class_name="w-header__glyph" name=header_icon %}{% endif %}
                         {{ title }}{% if subtitle %} <span class="w-header__subtitle">{{ subtitle }}</span>{% endif %}
                     </h1>
                 </div>

--- a/wagtail/admin/templates/wagtailadmin/shared/header.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/header.html
@@ -23,9 +23,9 @@
             <div class="col">
                 <h1 class="w-header__title">
                     {% if icon %}
-                        {% icon class_name="w-header__glpyh" name=icon %}
+                        {% icon class_name="w-header__glyph" name=icon %}
                     {% elif avatar %}
-                        <div class="w-header__glpyh avatar"><img src="{{ avatar }}" alt="" /></div>
+                        <div class="w-header__glyph avatar"><img src="{{ avatar }}" alt="" /></div>
                     {% endif %}
                     {{ title }}{% if subtitle %} <span class="w-header__subtitle">{{ subtitle }}</span>{% endif %}
                 </h1>

--- a/wagtail/admin/templates/wagtailadmin/workflows/index.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/index.html
@@ -7,7 +7,7 @@
             <div class="left">
                 <div class="col">
                     <h1 class="w-header__title">
-                        {% if view.header_icon %}{% icon class_name="w-header__glpyh" name=view.header_icon %}{% endif %}
+                        {% if view.header_icon %}{% icon class_name="w-header__glyph" name=view.header_icon %}{% endif %}
                         {{ view.page_title }}{% if view.subtitle %} <span class="header__subtitle">{{ view.subtitle }}</span>{% endif %}
                     </h1>
                 </div>

--- a/wagtail/admin/templates/wagtailadmin/workflows/task_index.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/task_index.html
@@ -7,7 +7,7 @@
             <div class="left">
                 <div class="col">
                     <h1 class="w-header__title">
-                        {% if view.header_icon %}{% icon class_name="w-header__glpyh" name=view.header_icon %}{% endif %}
+                        {% if view.header_icon %}{% icon class_name="w-header__glyph" name=view.header_icon %}{% endif %}
                         {{ view.page_title }}{% if view.subtitle %} <span class="w-header__subtitle">{{ view.subtitle }}</span>{% endif %}
                     </h1>
                 </div>

--- a/wagtail/contrib/forms/templates/wagtailforms/index_submissions.html
+++ b/wagtail/contrib/forms/templates/wagtailforms/index_submissions.html
@@ -87,7 +87,7 @@
                 <div class="left">
                     <div class="col">
                         <h1 class="w-header__title">
-                            {% icon class_name="w-header__glpyh" name="form" %}
+                            {% icon class_name="w-header__glyph" name="form" %}
                             {% blocktrans trimmed with form_title=form_page.title|capfirst %}Form data <span class="w-header__subtitle">{{ form_title }}</span>{% endblocktrans %}
                         </h1>
                     </div>

--- a/wagtail/contrib/modeladmin/templates/modeladmin/index.html
+++ b/wagtail/contrib/modeladmin/templates/modeladmin/index.html
@@ -24,7 +24,7 @@
                     <div class="col">
                         {% block h1 %}
                             <h1 class="w-header__title">
-                                {% if view.header_icon %}{% icon class_name="w-header__glpyh" name=view.header_icon %}{% endif %}
+                                {% if view.header_icon %}{% icon class_name="w-header__glyph" name=view.header_icon %}{% endif %}
                                 {{ view.get_page_title }}
                                 {% if view.get_page_subtitle %} <span class="w-header__subtitle">{{ view.get_page_subtitle }}</span> {% endif %}
                                 {% include 'modeladmin/includes/result_count.html' %}

--- a/wagtail/contrib/redirects/templates/wagtailredirects/index.html
+++ b/wagtail/contrib/redirects/templates/wagtailredirects/index.html
@@ -33,7 +33,7 @@
                 <div class="left">
                     <div class="col">
                         <h1 class="w-header__title">
-                            {% icon class_name="w-header__glpyh" name="redirect" %}
+                            {% icon class_name="w-header__glyph" name="redirect" %}
                             {{ redirects_str }}
                         </h1>
                     </div>

--- a/wagtail/contrib/settings/templates/wagtailsettings/edit.html
+++ b/wagtail/contrib/settings/templates/wagtailsettings/edit.html
@@ -10,7 +10,7 @@
             <div class="left">
                 <div class="col">
                     <h1 class="w-header__title">
-                        {% icon class_name="w-header__glpyh" name="cogs" %}
+                        {% icon class_name="w-header__glyph" name="cogs" %}
                         {% trans "Editing" %}
                         <span class="w-header__subtitle">{{ setting_type_name|capfirst }}</span>
                     </h1>

--- a/wagtail/snippets/templates/wagtailsnippets/snippets/type_index.html
+++ b/wagtail/snippets/templates/wagtailsnippets/snippets/type_index.html
@@ -23,7 +23,7 @@
             <div class="left">
                 <div class="col">
                     <h1 class="w-header__title">
-                        {% icon class_name="w-header__glpyh" name="snippet" %} {{ model_opts.verbose_name_plural|capfirst }}
+                        {% icon class_name="w-header__glyph" name="snippet" %} {{ model_opts.verbose_name_plural|capfirst }}
                     </h1>
                     {% if is_searchable and search_url %}
                         <form class="col search-form" action="{% url search_url %}" method="get" novalidate>


### PR DESCRIPTION
Renamed `w-header__glpyh` to `w-header__glyph`.
Based on https://github.com/wagtail/wagtail/pull/8799#pullrequestreview-1029707808.
Introduced in #8799. 

