### PR TITLE
Remove button-group component

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -66,6 +66,7 @@ Changelog
  * Add support for right-to-left (RTL) languages to the rich text editor (Thibaud Colas)
  * Change rich text editor placeholder to follow the user’s focus on empty blocks (Thibaud Colas)
  * Add rich text editor empty block highlight by showing their block type (Thibaud Colas)
+ * Make ModelAdmin InspectView footer actions consistent with other parts of the UI (Thibaud Colas)
  * Fix: Typo in `ResumeWorkflowActionFormatter` message (Stefan Hammer)
  * Fix: Throw a meaningful error when saving an image to an unrecognised image format (Christian Franke)
  * Fix: Remove extra padding for headers with breadcrumbs on mobile viewport (Steven Steinwand)

--- a/client/scss/components/_button.scss
+++ b/client/scss/components/_button.scss
@@ -499,45 +499,6 @@ button {
   }
 }
 
-.button-group {
-  @include clearfix;
-
-  input[type='submit'],
-  input[type='reset'],
-  input[type='button'],
-  .button,
-  button {
-    border-radius: 0;
-    float: left;
-    margin-inline-end: 1px;
-    margin-inline-start: 0;
-
-    &:only-child {
-      border-radius: 3px;
-    }
-
-    &:first-child {
-      border-radius: 3px 0 0 3px;
-    }
-
-    &:last-child {
-      border-radius: 0 3px 3px 0;
-      margin-inline-end: 0;
-    }
-  }
-
-  &.button-group-square {
-    &,
-    input[type='submit'],
-    input[type='reset'],
-    input[type='button'],
-    .button,
-    button {
-      border-radius: 0;
-    }
-  }
-}
-
 .multiple {
   padding: 0;
   max-width: 1024px - 50px;

--- a/docs/releases/4.0.md
+++ b/docs/releases/4.0.md
@@ -78,6 +78,7 @@ As part of the page editor redesign project sponsored by Google, we have made a 
  * Migrate the dashboard (home) view header to the shared header template and update designs (Paarth Agarwal)
  * Update classes and styles for the shared header templates to align with UI guidelines (Paarth Agarwal)
  * Clean up multiple eslint rules usage and configs to align better with the Wagtail coding guidelines (LB (Ben Johnston))
+ * Make ModelAdmin InspectView footer actions consistent with other parts of the UI (Thibaud Colas)
 
 ### Bug fixes
 

--- a/wagtail/contrib/modeladmin/templates/modeladmin/inspect.html
+++ b/wagtail/contrib/modeladmin/templates/modeladmin/inspect.html
@@ -49,7 +49,7 @@
     {% block footer %}
         {% if buttons %}
             <footer class="footer">
-                <div class="button-group footer__container">
+                <div class="footer__container">
                     {% for button in buttons %}
                         {% include "modeladmin/includes/button.html" %}
                     {% endfor %}

--- a/wagtail/contrib/styleguide/templates/wagtailstyleguide/base.html
+++ b/wagtail/contrib/styleguide/templates/wagtailstyleguide/base.html
@@ -483,22 +483,6 @@
 
         </section>
 
-        <section id="button-groups">
-            <h2>Button groups</h2>
-            <p>Adds rounding to first and last items only</p>
-            <div class="button-group">
-                <button class="button">button element</button>
-                <button class="button">button element</button>
-                <button class="button">button element</button>
-            </div>
-            <br/>
-            <div class="button-group">
-                <button class="button button--icon text-replace yes">{% icon name="tick" %}A proper button</button>
-                <a href="#" class="button button--icon text-replace white">{% icon name="cog" %}A link button</a>
-                <span class="button button--icon text-replace no">{% icon name="bin" %}A non-link button</span>
-            </div>
-        </section>
-
         <section id="dropdowns">
             <h2>Dropdown buttons</h2>
 


### PR DESCRIPTION
Aside from the styleguide, our `button-group` component is only used in one place, the ModelAdmin InspectView’s footer. And even there, I’d argue the buttons look better _without_ those "group" styles – we don’t display buttons side-by-side as a single pill in many places, and when we do, at least the buttons are of the same color.

Here is a before/after:

![button-group-bye](https://user-images.githubusercontent.com/877585/178251327-98ac9ca4-1d73-4130-a14f-a1307dfba954.gif)

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
-   ~~[ ] For Python changes: Have you added tests to cover the new/fixed behaviour?~~
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [x] **Please list the exact browser and operating system versions you tested**: Chrome only
    -   ~~[ ] **Please list which assistive technologies [^3] you tested**:~~ N/A

---

To test this on bakerydemo, add `inspect_view_enabled = True` to a ModelAdmin hook. For example: https://github.com/wagtail/bakerydemo/pull/345