### PR TITLE
Redirect api

### DIFF
--- a/docs/reference/contrib/redirects.md
+++ b/docs/reference/contrib/redirects.md
@@ -93,3 +93,21 @@ Options:
 
     .. automethod:: add_redirect
 ```
+
+## API
+
+This app provides an API endpoint to retrieve redirects by path.
+
+See the [](api_v2_configuration) documentation on how to configure the Wagtail API. 
+
+Add the following code to add the redirects endpoint:
+
+```python
+from wagtail.contrib.redirects.api import RedirectsAPIViewSet
+
+api_router.register_endpoint('redirects', RedirectsAPIViewSet)
+```
+
+With this configuration, redirects will be available at `/api/v2/redirects/find/?html_path=<path>`.
+
+This will return either a `200` response with the redirects detail, or a `404` not found response.

--- a/wagtail/contrib/redirects/api.py
+++ b/wagtail/contrib/redirects/api.py
@@ -1,0 +1,40 @@
+from django.http import Http404
+from django.urls import path
+from rest_framework import serializers, viewsets
+
+from wagtail.contrib.redirects.middleware import get_redirect
+from wagtail.contrib.redirects.models import Redirect
+
+
+class RedirectSerializer(serializers.ModelSerializer):
+    location = serializers.CharField(source="link")
+
+    class Meta:
+        model = Redirect
+        fields = ("is_permanent", "location")
+
+
+class RedirectsAPIViewSet(viewsets.ReadOnlyModelViewSet):
+    model = Redirect
+    serializer_class = RedirectSerializer
+
+    def get_object(self):
+        request = self.request
+
+        if "html_path" in request.GET:
+            redirect = get_redirect(
+                request, request.GET["html_path"], exact_match=False
+            )
+            if redirect is not None:
+                return redirect
+
+        raise Http404()
+
+    @classmethod
+    def get_urlpatterns(cls):
+        """
+        This returns a list of URL patterns for the endpoint
+        """
+        return [
+            path("find/", cls.as_view({"get": "retrieve"}), name="detail"),
+        ]

--- a/wagtail/contrib/redirects/middleware.py
+++ b/wagtail/contrib/redirects/middleware.py
@@ -15,12 +15,15 @@ def _get_redirect(request, path):
         return None
 
     site = Site.find_for_request(request)
-    try:
-        return models.Redirect.get_for_site(site).get(old_path=path)
-    except models.Redirect.MultipleObjectsReturned:
+    redirects = models.Redirect.get_for_site(site).filter(old_path=path)
+    if len(redirects) == 1:
+        return redirects[0]
+    elif len(redirects) > 1:
         # We have a site-specific and a site-ambivalent redirect; prefer the specific one
-        return models.Redirect.objects.get(site=site, old_path=path)
-    except models.Redirect.DoesNotExist:
+        for redirect in redirects:
+            if redirect.site == site:
+                return redirect
+    else:
         return None
 
 

--- a/wagtail/contrib/redirects/middleware.py
+++ b/wagtail/contrib/redirects/middleware.py
@@ -24,11 +24,19 @@ def _get_redirect(request, path):
         return None
 
 
-def get_redirect(request, path):
+def get_redirect(request, path, *, exact_match=True):
+    path = models.Redirect.normalise_path(path)
     redirect = _get_redirect(request, path)
-    if not redirect:
+    if redirect is None:
         # try unencoding the path
         redirect = _get_redirect(request, uri_to_iri(path))
+
+    if redirect is None and not exact_match:
+        # Get the path without the query string or params
+        path_without_query = urlparse(path).path
+        if path != path_without_query:
+            redirect = get_redirect(request, path_without_query)
+
     return redirect
 
 
@@ -40,21 +48,12 @@ class RedirectMiddleware(MiddlewareMixin):
             return response
 
         # Get the path
-        path = models.Redirect.normalise_path(request.get_full_path())
+        path = request.get_full_path()
 
         # Find redirect
-        redirect = get_redirect(request, path)
+        redirect = get_redirect(request, path, exact_match=False)
         if redirect is None:
-            # Get the path without the query string or params
-            path_without_query = urlparse(path).path
-
-            if path == path_without_query:
-                # don't try again if we know we will get the same response
-                return response
-
-            redirect = get_redirect(request, path_without_query)
-            if redirect is None:
-                return response
+            return response
 
         if redirect.link is None:
             return response

--- a/wagtail/contrib/redirects/tests/test_redirects_api.py
+++ b/wagtail/contrib/redirects/tests/test_redirects_api.py
@@ -1,0 +1,98 @@
+from http import HTTPStatus
+
+from django.test import TestCase, modify_settings
+from django.urls import reverse
+
+from wagtail.contrib.redirects.models import Redirect
+from wagtail.models import Page, Site
+
+
+@modify_settings(ALLOWED_HOSTS={"append": "example"})
+class TestRedirectsAPI(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        example_home = Page.objects.get(slug="home").add_sibling(
+            instance=Page(title="Example Homepage", slug="example-home")
+        )
+        example_page = example_home.add_child(
+            instance=Page(title="Example Page", slug="example-page")
+        )
+        example_site = Site.objects.create(hostname="example", root_page=example_home)
+        # Site specific redirect for /hello-world
+        Redirect.objects.create(
+            old_path="/hello-world",
+            site=example_site,
+            redirect_link="https://www.example.com/hello-world/",
+        )
+        # Site agnostic redirect for /hello-world (for all sites except example_site)
+        Redirect.add_redirect(
+            old_path="/hello-world", redirect_to="https://www.example.net/hello-world/"
+        )
+        # Site agnostic (temporary) redirect to a page in example_site
+        Redirect.add_redirect(
+            old_path="/old-example", redirect_to=example_home, is_permanent=False
+        )
+        # Site agnostic (temporary) with a querystring
+        Redirect.add_redirect(
+            old_path="/old-example?bar=foo&foo=bar",
+            redirect_to=example_page,
+            is_permanent=False,
+        )
+
+    def test_no_filter(self):
+        """Requires html_path filter"""
+        response = self.client.get(reverse("wagtailapi_v2:redirects:detail"))
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
+
+    def test_generic_redirect(self):
+        """Returns a matching (not site specific) redirect"""
+        response = self.client.get(
+            reverse("wagtailapi_v2:redirects:detail"),
+            {"html_path": "/hello-world/"},  # Trailing slash is intentional
+        )
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        # Redirect to example.net
+        self.assertEqual(
+            response.json(),
+            {"location": "https://www.example.net/hello-world/", "is_permanent": True},
+        )
+
+    def test_site_specific_redirect(self):
+        """Returns a site specific redirect"""
+        response = self.client.get(
+            reverse("wagtailapi_v2:redirects:detail"),
+            {"html_path": "/hello-world/"},  # Trailing slash is intentional
+            HTTP_HOST="example",
+        )
+        # Redirect to example.com
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertEqual(
+            response.json(),
+            {"location": "https://www.example.com/hello-world/", "is_permanent": True},
+        )
+
+    def test_page_redirect(self):
+        """Returns a redirect to a wagtail page"""
+        response = self.client.get(
+            reverse("wagtailapi_v2:redirects:detail"),
+            {"html_path": "/old-example/"},  # Trailing slash is intentional
+        )
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        # Redirect to example_site homepage (example_home),
+        # wagtail doesn't use the slug for site.root_page
+        self.assertEqual(
+            response.json(), {"location": "http://example/", "is_permanent": False}
+        )
+
+    def test_html_path_with_querystring(self):
+        """Finds redirect, matching querystring"""
+        response = self.client.get(
+            reverse("wagtailapi_v2:redirects:detail"),
+            {"html_path": "/old-example/?foo=bar&bar=foo"},  # Order shouldn't matter
+        )
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        # Redirect to example.net
+        self.assertEqual(
+            response.json(),
+            {"location": "http://example/example-page/", "is_permanent": False},
+        )

--- a/wagtail/test/urls.py
+++ b/wagtail/test/urls.py
@@ -9,6 +9,7 @@ from wagtail.admin.views import home
 from wagtail.api.v2.router import WagtailAPIRouter
 from wagtail.api.v2.tests.test_pages import Test10411APIViewSet
 from wagtail.api.v2.views import PagesAPIViewSet
+from wagtail.contrib.redirects.api import RedirectsAPIViewSet
 from wagtail.contrib.sitemaps import Sitemap
 from wagtail.contrib.sitemaps import views as sitemaps_views
 from wagtail.documents import urls as wagtaildocs_urls
@@ -23,6 +24,7 @@ api_router = WagtailAPIRouter("wagtailapi_v2")
 api_router.register_endpoint("pages", PagesAPIViewSet)
 api_router.register_endpoint("images", ImagesAPIViewSet)
 api_router.register_endpoint("documents", DocumentsAPIViewSet)
+api_router.register_endpoint("redirects", RedirectsAPIViewSet)
 api_router.register_endpoint("issue_10411", Test10411APIViewSet)
 
 


### PR DESCRIPTION
This PR adds an API endpoint to the redirects app. This is an alternative to the solution proposed in PR #6110, that doesn't mix wagtail core and contrib and works for external redirects.