### PR TITLE
Adds permissions to PanelGroups

### DIFF
--- a/wagtail/admin/panels.py
+++ b/wagtail/admin/panels.py
@@ -384,13 +384,15 @@ class PanelGroup(Panel):
     Concrete subclasses must attach a 'children' property
     """
 
-    def __init__(self, children=(), *args, **kwargs):
+    def __init__(self, children=(), permission="", *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.children = children
+        self.permission = permission
 
     def clone_kwargs(self):
         kwargs = super().clone_kwargs()
         kwargs["children"] = self.children
+        kwargs["permission"] = self.permission
         return kwargs
 
     def get_form_options(self):
@@ -462,6 +464,13 @@ class PanelGroup(Panel):
             return [child for child in self.children if child.is_shown()]
 
         def is_shown(self):
+            if self.panel.permission:
+                # If a permission is set and passes, just check the children.
+                if self.request.user.has_perm(self.panel.permission):
+                    return any(child.is_shown() for child in self.children)
+                return False
+
+            # If no permissions, just check regular.
             return any(child.is_shown() for child in self.children)
 
         @property

--- a/wagtail/test/testapp/models.py
+++ b/wagtail/test/testapp/models.py
@@ -375,6 +375,12 @@ class EventPage(Page):
         FieldPanel("feed_image"),
     ]
 
+    class Meta:
+        permissions = [
+            ("custom_see_panel_setting", "Can see the panel."),
+            ("other_custom_see_panel_setting", "Can see the panel."),
+        ]
+
 
 class HeadCountRelatedModelUsingPK(models.Model):
     """Related model that uses a custom primary key (pk) not id"""


### PR DESCRIPTION
<!--
Thanks for contributing to Wagtail! 🎉

Before submitting, please review the [contributor guidelines](https://docs.wagtail.org/en/latest/contributing/index.html).
-->

This PR is to add the ability to pass a permission to a group panel (For our purposes, TabbedInterface and ObjectList). This need has come around locally due to a partner request - they want certain panels hidden from view for different groups (Say, the settings panel, which they deem too complex/out of scope for editors). Thankfully due to the much nicer API of wagtail 3.0, this is a lot easier to do and can be done easily with an overriden class, but felt like a good addition to the framework. We _could_ probably move this into the Panel Group? But I thought maybe not worth it. Happy to discuss.

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?

I've not added any documentation as there didn't seem to be any existing - happy to contribute this if needed!
