### PR TITLE
adopted shared header template in workflows

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -56,7 +56,7 @@ Changelog
  * Introduce new template fragment and block level enclosure tags for easier template composition (Thibaud Colas)
  * Add a `classnames` template tag to easily build up classes from variables provided to a template (Paarth Agarwal)
  * Migrate the dashboard (home) view header to the shared header template and update designs (Paarth Agarwal)
- * Switch all report views and the redirects listing view to use Wagtail’s reusable header component (Paarth Agarwal)
+ * Switch all report views and workflow and redirects listing views to use Wagtail’s reusable header component (Paarth Agarwal)
  * Update classes and styles for the shared header templates to align with UI guidelines (Paarth Agarwal)
  * Clean up multiple eslint rules usage and configs to align better with the Wagtail coding guidelines (LB (Ben Johnston))
  * Add inline toolbar for Draftail, to avoid clashing with the page’s header (Thibaud Colas)

--- a/docs/releases/4.0.md
+++ b/docs/releases/4.0.md
@@ -83,7 +83,7 @@ Wagtail’s page preview is now available in a side panel within the page editor
  * Update classes and styles for the shared header templates to align with UI guidelines (Paarth Agarwal)
  * Clean up multiple eslint rules usage and configs to align better with the Wagtail coding guidelines (LB (Ben Johnston))
  * Make ModelAdmin InspectView footer actions consistent with other parts of the UI (Thibaud Colas)
- * Switch all report views and the redirects listing view to use Wagtail’s reusable header component (Paarth Agarwal)
+ * Switch all report views and workflow and redirects listing views to use Wagtail’s reusable header component (Paarth Agarwal)
  * Add support for Twitter and other text-only embeds in Draftail embed previews (Iman Syed, Paarth Agarwal)
 
 ### Bug fixes

--- a/wagtail/admin/templates/wagtailadmin/workflows/index.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/index.html
@@ -2,28 +2,17 @@
 {% load i18n wagtailadmin_tags %}
 
 {% block content %}
-    <header class="w-header" role="banner">
-        <div class="row">
-            <div class="left">
-                <div class="col">
-                    <h1 class="w-header__title">
-                        {% if view.header_icon %}{% icon class_name="w-header__glyph" name=view.header_icon %}{% endif %}
-                        {{ view.page_title }}{% if view.subtitle %} <span class="header__subtitle">{{ view.subtitle }}</span>{% endif %}
-                    </h1>
-                </div>
-            </div>
-            <div class="right">
-                <a href="{% url "wagtailadmin_workflows:index" %}?show_disabled={% if showing_disabled %}false{% else %}true{% endif %}" class="button button-secondary button--icon w-inline-flex w-items-center w-gap-2">
-                    {% if showing_disabled %}
-                        {% icon name="no-view" %}{% trans "Hide disabled workflows" %}
-                    {% else %}
-                        {% icon name="view" %}{% trans "Show disabled workflows" %}
-                    {% endif %}
-                </a>
-                <a href="{% url view.add_url_name %}" class="button bicolor icon icon-plus">{{ view.add_item_label }}</a>
-            </div>
-        </div>
-    </header>
+    {% fragment as workflow_actions %}
+        <a href="{% url "wagtailadmin_workflows:index" %}?show_disabled={% if showing_disabled %}false{% else %}true{% endif %}" class="button button-secondary button--icon w-inline-flex w-items-center w-gap-2">
+            {% if showing_disabled %}
+                {% icon name="no-view" %}{% trans "Hide disabled workflows" %}
+            {% else %}
+                {% icon name="view" %}{% trans "Show disabled workflows" %}
+            {% endif %}
+        </a>
+        <a href="{% url view.add_url_name %}" class="button bicolor icon icon-plus">{{ view.add_item_label }}</a>
+    {% endfragment %}
+    {% include "wagtailadmin/shared/header.html" with title=view.page_title icon=view.header_icon merged=1 extra_actions=workflow_actions %}
 
     <div class="nice-padding">
         {% if workflows %}

--- a/wagtail/admin/templates/wagtailadmin/workflows/index.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/index.html
@@ -12,7 +12,7 @@
         </a>
         <a href="{% url view.add_url_name %}" class="button bicolor icon icon-plus">{{ view.add_item_label }}</a>
     {% endfragment %}
-    {% include "wagtailadmin/shared/header.html" with title=view.page_title icon=view.header_icon merged=1 extra_actions=workflow_actions %}
+    {% include "wagtailadmin/shared/header.html" with title=view.page_title icon=view.header_icon extra_actions=workflow_actions %}
 
     <div class="nice-padding">
         {% if workflows %}

--- a/wagtail/admin/templates/wagtailadmin/workflows/task_index.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/task_index.html
@@ -2,29 +2,18 @@
 {% load i18n wagtailadmin_tags %}
 
 {% block content %}
-    <header class="w-header" role="banner">
-        <div class="row">
-            <div class="left">
-                <div class="col">
-                    <h1 class="w-header__title">
-                        {% if view.header_icon %}{% icon class_name="w-header__glyph" name=view.header_icon %}{% endif %}
-                        {{ view.page_title }}{% if view.subtitle %} <span class="w-header__subtitle">{{ view.subtitle }}</span>{% endif %}
-                    </h1>
-                </div>
-            </div>
-            <div class="right">
-                <a href="{% url "wagtailadmin_workflows:task_index" %}?show_disabled={% if showing_disabled %}false{% else %}true{% endif %}" class="button button-secondary button--icon w-inline-flex w-items-center w-gap-2">
-                    {% if showing_disabled %}
-                        {% icon name="no-view" %}{% trans "Hide disabled tasks" %}
-                    {% else %}
-                        {% icon name="view" %}{% trans "Show disabled tasks" %}
-                    {% endif %}
-                </a>
-                <a href="{% url view.add_url_name %}" class="button bicolor icon icon-plus">{{ view.add_item_label }}</a>
-            </div>
-        </div>
-    </header>
-
+    {% fragment as workflow_actions %}
+        <a href="{% url "wagtailadmin_workflows:task_index" %}?show_disabled={% if showing_disabled %}false{% else %}true{% endif %}" class="button button-secondary button--icon w-inline-flex w-items-center w-gap-2">
+            {% if showing_disabled %}
+                {% icon name="no-view" %}{% trans "Hide disabled tasks" %}
+            {% else %}
+                {% icon name="view" %}{% trans "Show disabled tasks" %}
+            {% endif %}
+        </a>
+    <a href="{% url view.add_url_name %}" class="button bicolor icon icon-plus">{{ view.add_item_label }}</a>
+    {% endfragment %}    
+    {% include "wagtailadmin/shared/header.html" with title=view.page_title icon=view.header_icon merged=1 extra_actions=workflow_actions %}
+    
     <div class="nice-padding">
         {% if tasks %}
             <table class="listing">

--- a/wagtail/admin/templates/wagtailadmin/workflows/task_index.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/task_index.html
@@ -12,7 +12,7 @@
         </a>
         <a href="{% url view.add_url_name %}" class="button bicolor icon icon-plus">{{ view.add_item_label }}</a>
     {% endfragment %}
-    {% include "wagtailadmin/shared/header.html" with title=view.page_title icon=view.header_icon merged=1 extra_actions=workflow_actions %}
+    {% include "wagtailadmin/shared/header.html" with title=view.page_title icon=view.header_icon extra_actions=workflow_actions %}
 
     <div class="nice-padding">
         {% if tasks %}

--- a/wagtail/admin/templates/wagtailadmin/workflows/task_index.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/task_index.html
@@ -10,10 +10,10 @@
                 {% icon name="view" %}{% trans "Show disabled tasks" %}
             {% endif %}
         </a>
-    <a href="{% url view.add_url_name %}" class="button bicolor icon icon-plus">{{ view.add_item_label }}</a>
-    {% endfragment %}    
+        <a href="{% url view.add_url_name %}" class="button bicolor icon icon-plus">{{ view.add_item_label }}</a>
+    {% endfragment %}
     {% include "wagtailadmin/shared/header.html" with title=view.page_title icon=view.header_icon merged=1 extra_actions=workflow_actions %}
-    
+
     <div class="nice-padding">
         {% if tasks %}
             <table class="listing">


### PR DESCRIPTION
Addresses #8539.
I have adopted shared header template for workflows.
Before:
![Screenshot from 2022-07-14 12-10-00](https://user-images.githubusercontent.com/86092410/178917935-ffa48b43-f3dd-48c5-9e8d-b2ae284312f4.png)
![Screenshot from 2022-07-14 12-09-38](https://user-images.githubusercontent.com/86092410/178917926-18e73c58-6f31-47fe-a18c-f775a415a42b.png)


After:
 
![Screenshot from 2022-07-14 12-07-49](https://user-images.githubusercontent.com/86092410/178917974-67ffc055-8f35-492a-9571-543f08da4435.png)
![Screenshot from 2022-07-14 12-08-10](https://user-images.githubusercontent.com/86092410/178917984-e0c78678-94fa-44cd-ad04-d849b7150c37.png)

The before and after screenshots appear identical to me.