### PR TITLE
Removed the forced-colors media query over icons to avoid override

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -93,6 +93,7 @@ Changelog
  * Fix: Fix display of dates in exported xlsx files on macOS Preview and Numbers (Jaap Roes)
  * Fix: Make progress bars’ progress visible in forced colors mode (Anuja Verma)
  * Fix: Make checkboxes visible in forced colors mode (Anuja Verma)
+ * Fix: Display the correct color for icons in forced colors mode (Anuja Verma)
 
 
 3.0.1 (16.06.2022)

--- a/client/scss/components/_icons.scss
+++ b/client/scss/components/_icons.scss
@@ -165,11 +165,3 @@ svg.icon-spinner {
   height: 1.5em;
   color: $color-red;
 }
-
-// Media for Windows High Contrast mode
-
-// @media (forced-colors: $media-forced-colours) {
-//   .icon {
-//     fill: $system-color-link-text;
-//   }
-// }

--- a/client/scss/components/_icons.scss
+++ b/client/scss/components/_icons.scss
@@ -168,8 +168,8 @@ svg.icon-spinner {
 
 // Media for Windows High Contrast mode
 
-@media (forced-colors: $media-forced-colours) {
-  .icon {
-    fill: $system-color-link-text;
-  }
-}
+// @media (forced-colors: $media-forced-colours) {
+//   .icon {
+//     fill: $system-color-link-text;
+//   }
+// }

--- a/docs/releases/4.0.md
+++ b/docs/releases/4.0.md
@@ -113,6 +113,7 @@ Wagtail’s page preview is now available in a side panel within the page editor
  * Fix display of dates in exported xlsx files on macOS Preview and Numbers (Jaap Roes)
  * Make progress bars’ progress visible in forced colors mode (Anuja Verma)
  * Make checkboxes visible in forced colors mode (Anuja Verma)
+ * Display the correct color for icons in forced colors mode (Anuja Verma)
 
 
 ## Upgrade considerations


### PR DESCRIPTION
<!--
Thanks for contributing to Wagtail! 🎉

Before submitting, please review the [contributor guidelines](https://docs.wagtail.org/en/latest/contributing/index.html).
-->

_Please check the following:_

-   [ ] Do the tests still pass?[^1]
-   [ ] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [x] **Please list the exact browser and operating system versions you tested**: Tested in Chrome
    -   [x] **Please list which assistive technologies [^3] you tested**:Windows 11 high contrast modes - Dessert,Night sky,Dusk,Aquatic
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.
The PR is a fix to issue #8816 
To achieve the disired result I commented the media query for forced-colors over the icons. The query was added when chrome was having a bug due to which a override on icons using fill (a css property) was required. Since the bug is remved we would want to remove the override too. 
The change is made in `client/scss/components/_icons.scss`
The screenshots are attached below showing the override being removed in both modes (dark and light) of WHCM

![Screenshot (110)icons](https://user-images.githubusercontent.com/52713215/179046007-80a1eb9a-6b45-42f2-9c4e-feab91eb0f4a.png)


[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
