### PR TITLE
Contrast themes: help block border styles

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -75,6 +75,7 @@ Changelog
  * Add `menu_item_name` to modify MenuItem's name for ModelAdmin (Alexander Rogovskyy, Vu Pham)
  * Add an extra confirmation prompt when deleting pages with a large number of child pages (Jaspreet Singh)
  * Adopt the slim header in page listing views, with buttons moved under the "Actions" dropdown (Paarth Agarwal)
+ * Improve help block styles in Windows High Contrast Mode with less reliance on communication via colour alone (Anuja Verma)
  * Fix: Typo in `ResumeWorkflowActionFormatter` message (Stefan Hammer)
  * Fix: Throw a meaningful error when saving an image to an unrecognised image format (Christian Franke)
  * Fix: Remove extra padding for headers with breadcrumbs on mobile viewport (Steven Steinwand)

--- a/client/scss/components/_help-block.scss
+++ b/client/scss/components/_help-block.scss
@@ -60,25 +60,16 @@
 }
 
 // Media for Windows High Contrast
-@media (forced-colors: $media-forced-colours) {
+@media (forced-colors: active) {
   .help-block {
-    forced-color-adjust: none;
-    border: 1px solid $system-color-link-text; // ensure visible separation in Windows High Contrast mode
-    background-color: transparent;
-    color: $color-white;
-
-    &:before {
-      color: currentColor;
-    }
+    border: 3px solid currentColor; // ensure visible separation in Windows High Contrast mode
   }
 
   .help-warning {
-    color: $color-text-warning-forced-color;
-    border-color: $color-text-warning-forced-color;
+    border-style: dotted;
   }
 
   .help-critical {
-    color: $color-text-error-forced-color;
-    border-color: $color-text-error-forced-color;
+    border-style: dashed;
   }
 }

--- a/docs/releases/4.0.md
+++ b/docs/releases/4.0.md
@@ -95,6 +95,7 @@ Wagtail’s page preview is now available in a side panel within the page editor
  * Add `menu_item_name` to modify MenuItem's name for ModelAdmin (Alexander Rogovskyy, Vu Pham)
  * Add an extra confirmation prompt when deleting pages with a large number of child pages (Jaspreet Singh)
  * Adopt the slim header in page listing views, with buttons moved under the "Actions" dropdown (Paarth Agarwal)
+ * Improve help block styles in Windows High Contrast Mode with less reliance on communication via colour alone (Anuja Verma)
 
 ### Bug fixes
 


### PR DESCRIPTION
#8816. Added new border styles to help boxes and made the text inside the help box visible in forced-color mode.

<!--
Thanks for contributing to Wagtail! 🎉

Before submitting, please review the [contributor guidelines](https://docs.wagtail.org/en/latest/contributing/index.html).
-->

_Please check the following:_

-   [ ] Do the tests still pass?[^1]
-   [ ] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [x] **Please list the exact browser and operating system versions you tested**: Tested in Chrome, Operating System -Windows 11
    -   [x] **Please list which assistive technologies [^3] you tested**: Windows 11 high contrast modes : Night sky,Dusk,Desert,Aquatic
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.
This fixes issue- #8817 
The boxes(help,critical message and warning boxes) were styled oddly giving a visual traffic to eyes in WHMC.  The PR added three types of borders to the three kinds of boxes and removed any color from texts or borders. This provides a distinct look as well as more visual clarity to the viewer in WHMC.
Along with border styling the issue pertaining to text inside the first box (help box) in lighter modes of high contrast earlier was not visible as in the below screenshot

![Screenshot (101)](https://user-images.githubusercontent.com/52713215/178974680-9ac8aa52-9c1b-405e-b05b-4d8fdbb199da.png)

Its is visible now after the changes made in this PR.
The changes are made in `client\scss\components\_help-block.scss`

Screenshots of the changes are added below

Dark mode

![Screenshot (111)](https://user-images.githubusercontent.com/52713215/178974189-2c899c18-32b8-48a9-9c06-efb1bafda562.png)

Light mode

![Screenshot (110)](https://user-images.githubusercontent.com/52713215/178974221-b11305df-0e98-4f6c-91c6-cb2ba51ff7a0.png)

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
