### PR TITLE
Adopted shared header for menu settings editing view

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -56,7 +56,7 @@ Changelog
  * Introduce new template fragment and block level enclosure tags for easier template composition (Thibaud Colas)
  * Add a `classnames` template tag to easily build up classes from variables provided to a template (Paarth Agarwal)
  * Migrate the dashboard (home) view header to the shared header template and update designs (Paarth Agarwal)
- * Switch all report views and workflow and redirects listing views to use Wagtail’s reusable header component (Paarth Agarwal)
+ * Switch all report workflow, redirects, site settings views to use Wagtail’s reusable header component (Paarth Agarwal)
  * Update classes and styles for the shared header templates to align with UI guidelines (Paarth Agarwal)
  * Clean up multiple eslint rules usage and configs to align better with the Wagtail coding guidelines (LB (Ben Johnston))
  * Add inline toolbar for Draftail, to avoid clashing with the page’s header (Thibaud Colas)

--- a/docs/releases/4.0.md
+++ b/docs/releases/4.0.md
@@ -83,7 +83,7 @@ Wagtail’s page preview is now available in a side panel within the page editor
  * Update classes and styles for the shared header templates to align with UI guidelines (Paarth Agarwal)
  * Clean up multiple eslint rules usage and configs to align better with the Wagtail coding guidelines (LB (Ben Johnston))
  * Make ModelAdmin InspectView footer actions consistent with other parts of the UI (Thibaud Colas)
- * Switch all report views and workflow and redirects listing views to use Wagtail’s reusable header component (Paarth Agarwal)
+ * Switch all report workflow, redirects, site settings views to use Wagtail’s reusable header component (Paarth Agarwal)
  * Add support for Twitter and other text-only embeds in Draftail embed previews (Iman Syed, Paarth Agarwal)
 
 ### Bug fixes

--- a/wagtail/contrib/settings/templates/wagtailsettings/edit.html
+++ b/wagtail/contrib/settings/templates/wagtailsettings/edit.html
@@ -5,34 +5,22 @@
 {% block bodyclass %}menu-settings{% endblock %}
 
 {% block content %}
-    <header class="w-header w-header--merged">
-        <div class="row">
-            <div class="left">
-                <div class="col">
-                    <h1 class="w-header__title">
-                        {% icon class_name="w-header__glyph" name="cogs" %}
-                        {% trans "Editing" %}
-                        <span class="w-header__subtitle">{{ setting_type_name|capfirst }}</span>
-                    </h1>
-                </div>
-            </div>
-            <div class="right">
-                {% if site_switcher %}
-                    <div class="field choice_field">
-                        <form method="get" class="setting-site-switch-form" id="settings-site-switch" novalidate>
-                            <label for="{{ site_switcher.site.id_for_label }}">
-                                {% trans "Site" %}:
-                            </label>
-                            <div class="input">
-                                {{ site_switcher.site }}
-                                <span></span>
-                            </div>
-                        </form>
+    {% fragment as editing_actions %}
+        {% if site_switcher %}
+            <div class="field choice_field">
+                <form method="get" class="setting-site-switch-form" id="settings-site-switch" novalidate>
+                    <label for="{{ site_switcher.site.id_for_label }}">
+                        {% trans "Site" %}:
+                    </label>
+                    <div class="input">
+                        {{ site_switcher.site }}
+                        <span></span>
                     </div>
-                {% endif %}
+                </form>
             </div>
-        </div>
-    </header>
+        {% endif %}
+    {% endfragment %}
+    {% include "wagtailadmin/shared/header.html" with title="Editing" icon="cogs" subtitle=setting_type_name|capfirst merged=1 extra_actions=editing_actions %}
 
     <form action="{% url 'wagtailsettings:edit' opts.app_label opts.model_name form_id %}" method="POST" novalidate{% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>
         {% csrf_token %}


### PR DESCRIPTION
**This is my 50th PR in the wagtail organisation. Cheers!** 
Addresses #8539.
I've adopted shared header for the menu setting editing view.
We can't test this on bakerydemo, so for testing, I used the test site for wagtail. 
Before: 
![Screenshot from 2022-07-14 18-00-25](https://user-images.githubusercontent.com/86092410/178982759-b11da242-0b53-4031-bad7-0e55f973ddcd.png)

After:
![Screenshot from 2022-07-14 18-00-01](https://user-images.githubusercontent.com/86092410/178982794-3e65d4d3-5a99-42af-a878-d37a61f7a4de.png)

I observe no visual changes.

