### PR TITLE
Support DRF / non-model-based choosers

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -92,6 +92,7 @@ Changelog
  * Refresh designs for Home (Dashboard) site summary panels, use theme spacing and colours, add support for RTL layouts and better support for small devices (Paarth Agarwal, LB (Ben) Johnston)
  * Include all CSS system colors in allowed values in Stylelint's declaration-strict-value rule (Thibaud Colas)
  * Add JavaScript `range` util for (LB (Ben) Johnston)
+ * Allow generic chooser viewsets to support non-model data such as an API endpoint (Matt Wescott)
  * Fix: Typo in `ResumeWorkflowActionFormatter` message (Stefan Hammer)
  * Fix: Throw a meaningful error when saving an image to an unrecognised image format (Christian Franke)
  * Fix: Remove extra padding for headers with breadcrumbs on mobile viewport (Steven Steinwand)

--- a/client/src/components/ChooserWidget/index.js
+++ b/client/src/components/ChooserWidget/index.js
@@ -89,7 +89,13 @@ export class Chooser {
     }
     this.chooserElement.classList.remove('blank');
     if (this.editLink) {
-      this.editLink.setAttribute('href', newState[this.editLinkStateKey]);
+      const editUrl = newState[this.editLinkStateKey];
+      if (editUrl) {
+        this.editLink.setAttribute('href', editUrl);
+        this.editLink.classList.remove('u-hidden');
+      } else {
+        this.editLink.classList.add('u-hidden');
+      }
     }
   }
 

--- a/docs/extending/generic_views.md
+++ b/docs/extending/generic_views.md
@@ -77,3 +77,174 @@ def register_viewset():
 ```
 
 Registering a chooser viewset will also set up a chooser widget to be used whenever a ForeignKey field to that model appears in a `WagtailAdminModelForm` - see [](./forms). In particular, this means that a panel definition such as `FieldPanel("author")`, where `author` is a foreign key to the `Person` model, will automatically use this chooser interface.
+
+## Chooser viewsets for non-model datasources
+
+While the generic chooser views are primarily designed to use Django models as the data source, choosers based on other sources such as REST API endpoints can be implemented by overriding the individual methods that deal with data retrieval.
+
+Within `wagtail.admin.views.generic.chooser`:
+
+-   `BaseChooseView.get_object_list()` - returns a list of records to be displayed in the chooser. (In the default implementation, this is a Django QuerySet, and the records are model instances.)
+-   `BaseChooseView.columns` - a list of `wagtail.admin.ui.tables.Column` objects specifying the fields of the record to display in the final table
+-   `BaseChooseView.apply_object_list_ordering(objects)` - given a list of records as returned from `get_object_list`, returns the list with the desired ordering applied
+-   `ChosenViewMixin.get_object(pk)` - returns the record identified by the given primary key
+-   `ChosenResponseMixin.get_chosen_response_data(item)` - given a record, returns the dictionary of data that will be passed back to the chooser widget to populate it (consisting of items `id` and `title`, unless the chooser widget's JavaScript has been customised)
+
+Within `wagtail.admin.widgets`:
+
+-   `BaseChooser.get_instance(value)` - given a value that may be a record, a primary key or None, returns the corresponding record or None
+-   `BaseChooser.get_value_data_from_instance(item)` - given a record, returns the dictionary of data that will populate the chooser widget (consisting of items `id` and `title`, unless the widget's JavaScript has been customised)
+
+For example, the following code will implement a chooser that runs against a JSON endpoint for the User model at `http://localhost:8000/api/users/`, set up with Django REST Framework using the default configuration and no pagination:
+
+```python
+from django.views.generic.base import View
+import requests
+
+from wagtail.admin.ui.tables import Column, TitleColumn
+from wagtail.admin.views.generic.chooser import (
+    BaseChooseView, ChooseViewMixin, ChooseResultsViewMixin, ChosenResponseMixin, ChosenViewMixin, CreationFormMixin
+)
+from wagtail.admin.viewsets.chooser import ChooserViewSet
+from wagtail.admin.widgets import BaseChooser
+
+
+class BaseUserChooseView(BaseChooseView):
+    @property
+    def columns(self):
+        return [
+            TitleColumn(
+                "title",
+                label="Title",
+                accessor='username',
+                id_accessor='id',
+                url_name=self.chosen_url_name,
+                link_attrs={"data-chooser-modal-choice": True},
+            ),
+            Column(
+                "email", label="Email", accessor="email"
+            )
+        ]
+
+    def get_object_list(self):
+        r = requests.get("http://localhost:8000/api/users/")
+        r.raise_for_status()
+        results = r.json()
+        return results
+
+    def apply_object_list_ordering(self, objects):
+        return objects
+
+
+class UserChooseView(ChooseViewMixin, CreationFormMixin, BaseUserChooseView):
+    pass
+
+
+class UserChooseResultsView(ChooseResultsViewMixin, CreationFormMixin, BaseUserChooseView):
+    pass
+
+
+class UserChosenViewMixin(ChosenViewMixin):
+    def get_object(self, pk):
+        r = requests.get("http://localhost:8000/api/users/%d/" % int(pk))
+        r.raise_for_status()
+        return r.json()
+
+
+class UserChosenResponseMixin(ChosenResponseMixin):
+    def get_chosen_response_data(self, item):
+        return {
+            "id": item["id"],
+            "title": item["username"],
+        }
+
+
+class UserChosenView(UserChosenViewMixin, UserChosenResponseMixin, View):
+    pass
+
+
+class BaseUserChooserWidget(BaseChooser):
+    def get_instance(self, value):
+        if value is None:
+            return None
+        elif isinstance(value, dict):
+            return value
+        else:
+            r = requests.get("http://localhost:8000/api/users/%d/" % int(value))
+            r.raise_for_status()
+            return r.json()
+
+    def get_value_data_from_instance(self, instance):
+        return {
+            "id": instance["id"],
+            "title": instance["username"],
+        }
+
+
+class UserChooserViewSet(ChooserViewSet):
+    icon = "user"
+    choose_one_text = "Choose a user"
+    choose_another_text = "Choose another user"
+    edit_item_text = "Edit this user"
+
+    choose_view_class = UserChooseView
+    choose_results_view_class = UserChooseResultsView
+    chosen_view_class = UserChosenView
+    base_widget_class = BaseUserChooserWidget
+
+
+user_chooser_viewset = UserChooserViewSet("user_chooser", url_prefix="user-chooser")
+```
+
+If the data source implements its own pagination - meaning that the pagination mechanism built into the chooser should be bypassed - the `BaseChooseView.get_results_page(request)` method can be overridden instead of `get_object_list`. This should return an instance of `django.core.paginator.Page`. For example, if the API in the above example followed the conventions of the Wagtail API, implementing pagination with `offset` and `limit` URL parameters and returning a dict consisting of `meta` and `results`, the `BaseUserChooseView` implementation could be modified as follows:
+
+```python
+from django.core.paginator import Page, Paginator
+
+class APIPaginator(Paginator):
+    """
+    Customisation of Django's Paginator class for use when we don't want it to handle
+    slicing on the result set, but still want it to generate the page numbering based
+    on a known result count.
+    """
+    def __init__(self, count, per_page, **kwargs):
+        self._count = int(count)
+        super().__init__([], per_page, **kwargs)
+
+    @property
+    def count(self):
+        return self._count
+
+class BaseUserChooseView(BaseChooseView):
+    @property
+    def columns(self):
+        return [
+            TitleColumn(
+                "title",
+                label="Title",
+                accessor='username',
+                id_accessor='id',
+                url_name=self.chosen_url_name,
+                link_attrs={"data-chooser-modal-choice": True},
+            ),
+            Column(
+                "email", label="Email", accessor="email"
+            )
+        ]
+
+    def get_results_page(self, request):
+        try:
+            page_number = int(request.GET.get('p', 1))
+        except ValueError:
+            page_number = 1
+
+        r = requests.get("http://localhost:8000/api/users/", params={
+            'offset': (page_number - 1) * self.per_page,
+            'limit': self.per_page,
+        })
+        r.raise_for_status()
+        result = r.json()
+        paginator = APIPaginator(result['meta']['total_count'], self.per_page)
+        page = Page(result['items'], page_number, paginator)
+        return page
+```

--- a/docs/reference/viewsets.md
+++ b/docs/reference/viewsets.md
@@ -52,6 +52,7 @@ Viewsets are Wagtail's mechanism for defining a group of related admin views wit
    .. autoattribute:: page_title
    .. autoattribute:: choose_another_text
    .. autoattribute:: edit_item_text
+   .. autoattribute:: per_page
    .. autoattribute:: choose_view_class
    .. autoattribute:: choose_results_view_class
    .. autoattribute:: chosen_view_class

--- a/docs/releases/4.0.md
+++ b/docs/releases/4.0.md
@@ -141,6 +141,7 @@ The bulk of these enhancements have been from Paarth Agarwal, who has been doing
  * Add HTML-aware max_length validation and character count on RichTextField and RichTextBlock (Matt Westcott, Thibaud Colas)
  * Remove `is_parent` kwarg in various page button hooks as this approach is no longer required (Paarth Agarwal)
  * Improve security of redirect imports by adding a file hash (signature) check for so that any tampering of file contents between requests will throw a `BadSignature` error (Jaap Roes)
+ * Allow generic chooser viewsets to support non-model data such as an API endpoint (Matt Wescott)
 
 ### Bug fixes
 

--- a/wagtail/admin/templates/wagtailadmin/widgets/chooser.html
+++ b/wagtail/admin/templates/wagtailadmin/widgets/chooser.html
@@ -23,7 +23,7 @@
             {% if widget.show_edit_link %}
                 <li>
                     {% block edit_link %}
-                        <a href="{% block edit_chosen_item_url %}{{ edit_url }}{% endblock %}" class="edit-link button button-small button-secondary" target="_blank" rel="noreferrer">{{ widget.link_to_chosen_text }}</a>
+                        <a href="{% block edit_chosen_item_url %}{{ edit_url }}{% endblock %}" class="edit-link button button-small button-secondary{% if not edit_url %} u-hidden{% endif %}" target="_blank" rel="noreferrer">{{ widget.link_to_chosen_text }}</a>
                     {% endblock %}
                 </li>
             {% endif %}

--- a/wagtail/admin/ui/tables.py
+++ b/wagtail/admin/ui/tables.py
@@ -138,6 +138,7 @@ class TitleColumn(Column):
         get_url=None,
         link_classname=None,
         link_attrs=None,
+        id_accessor="pk",
         **kwargs,
     ):
         super().__init__(name, **kwargs)
@@ -145,6 +146,7 @@ class TitleColumn(Column):
         self._get_url_func = get_url
         self.link_attrs = link_attrs or {}
         self.link_classname = link_classname
+        self.id_accessor = id_accessor
 
     def get_cell_context_data(self, instance, parent_context):
         context = super().get_cell_context_data(instance, parent_context)
@@ -160,7 +162,8 @@ class TitleColumn(Column):
         if self._get_url_func:
             return self._get_url_func(instance)
         else:
-            return reverse(self.url_name, args=(quote(instance.pk),))
+            id = multigetattr(instance, self.id_accessor)
+            return reverse(self.url_name, args=(quote(id),))
 
 
 class StatusFlagColumn(Column):

--- a/wagtail/admin/views/generic/chooser.py
+++ b/wagtail/admin/views/generic/chooser.py
@@ -61,7 +61,8 @@ class ModelLookupMixin:
 
     @cached_property
     def model_class(self):
-        return resolve_model_string(self.model)
+        if self.model:
+            return resolve_model_string(self.model)
 
 
 class BaseChooseView(ModalPageFurnitureMixin, ModelLookupMixin, ContextMixin, View):
@@ -103,12 +104,13 @@ class BaseChooseView(ModalPageFurnitureMixin, ModelLookupMixin, ContextMixin, Vi
             return self.filter_form_class
         else:
             bases = [BaseFilterForm]
-            if class_is_indexed(self.model_class):
-                bases.insert(0, SearchFilterMixin)
-            if issubclass(self.model_class, CollectionMember):
-                bases.insert(0, CollectionFilterMixin)
-            if issubclass(self.model_class, TranslatableMixin):
-                bases.insert(0, LocaleFilterMixin)
+            if self.model_class:
+                if class_is_indexed(self.model_class):
+                    bases.insert(0, SearchFilterMixin)
+                if issubclass(self.model_class, CollectionMember):
+                    bases.insert(0, CollectionFilterMixin)
+                if issubclass(self.model_class, TranslatableMixin):
+                    bases.insert(0, LocaleFilterMixin)
 
             return type(
                 "FilterForm",

--- a/wagtail/admin/views/generic/chooser.py
+++ b/wagtail/admin/views/generic/chooser.py
@@ -128,7 +128,6 @@ class BaseChooseView(ModalPageFurnitureMixin, ModelLookupMixin, ContextMixin, Vi
             for hook in hooks.get_hooks(self.construct_queryset_hook_name):
                 objects = hook(objects, self.request)
 
-        self.filter_form = self.get_filter_form()
         if self.filter_form.is_valid():
             objects = self.filter_form.filter(objects)
         return objects
@@ -148,13 +147,17 @@ class BaseChooseView(ModalPageFurnitureMixin, ModelLookupMixin, ContextMixin, Vi
             ),
         ]
 
-    def get(self, request):
+    def get_results_page(self, request):
         objects = self.get_object_list()
         objects = self.apply_object_list_ordering(objects)
         objects = self.filter_object_list(objects)
 
         paginator = Paginator(objects, per_page=self.per_page)
-        self.results = paginator.get_page(request.GET.get("p"))
+        return paginator.get_page(request.GET.get("p"))
+
+    def get(self, request):
+        self.filter_form = self.get_filter_form()
+        self.results = self.get_results_page(request)
         self.table = Table(self.columns, self.results)
 
         return self.render_to_response()

--- a/wagtail/admin/views/generic/chooser.py
+++ b/wagtail/admin/views/generic/chooser.py
@@ -10,6 +10,7 @@ from django.http import Http404
 from django.template.loader import render_to_string
 from django.template.response import TemplateResponse
 from django.urls import reverse
+from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 from django.views.generic.base import ContextMixin, View
 
@@ -23,6 +24,7 @@ from wagtail.admin.forms.choosers import (
 )
 from wagtail.admin.modal_workflow import render_modal_workflow
 from wagtail.admin.ui.tables import Table, TitleColumn
+from wagtail.coreutils import resolve_model_string
 from wagtail.models import CollectionMember, TranslatableMixin
 from wagtail.permission_policies import BlanketPermissionPolicy, ModelPermissionPolicy
 from wagtail.search.index import class_is_indexed
@@ -49,13 +51,25 @@ class ModalPageFurnitureMixin(ContextMixin):
         return context
 
 
-class BaseChooseView(ModalPageFurnitureMixin, ContextMixin, View):
+class ModelLookupMixin:
+    """
+    Allows a class to have a `model` attribute, which can be set as either a model class or a string,
+    and then retrieve it as `model_class` to consistently get back a model class
+    """
+
+    model = None
+
+    @cached_property
+    def model_class(self):
+        return resolve_model_string(self.model)
+
+
+class BaseChooseView(ModalPageFurnitureMixin, ModelLookupMixin, ContextMixin, View):
     """
     Provides common functionality for views that present a (possibly searchable / filterable) list
     of objects to choose from
     """
 
-    model = None
     per_page = 10
     ordering = None
     chosen_url_name = None
@@ -68,7 +82,7 @@ class BaseChooseView(ModalPageFurnitureMixin, ContextMixin, View):
     construct_queryset_hook_name = None
 
     def get_object_list(self):
-        return self.model.objects.all()
+        return self.model_class.objects.all()
 
     def apply_object_list_ordering(self, objects):
         if isinstance(self.ordering, (list, tuple)):
@@ -89,11 +103,11 @@ class BaseChooseView(ModalPageFurnitureMixin, ContextMixin, View):
             return self.filter_form_class
         else:
             bases = [BaseFilterForm]
-            if class_is_indexed(self.model):
+            if class_is_indexed(self.model_class):
                 bases.insert(0, SearchFilterMixin)
-            if issubclass(self.model, CollectionMember):
+            if issubclass(self.model_class, CollectionMember):
                 bases.insert(0, CollectionFilterMixin)
-            if issubclass(self.model, TranslatableMixin):
+            if issubclass(self.model_class, TranslatableMixin):
                 bases.insert(0, LocaleFilterMixin)
 
             return type(
@@ -162,7 +176,7 @@ class BaseChooseView(ModalPageFurnitureMixin, ContextMixin, View):
         raise NotImplementedError()
 
 
-class CreationFormMixin:
+class CreationFormMixin(ModelLookupMixin):
     """
     Provides a form class for creating new objects
     """
@@ -180,8 +194,8 @@ class CreationFormMixin:
     def get_permission_policy(self):
         if self.permission_policy:
             return self.permission_policy
-        elif self.model:
-            return ModelPermissionPolicy(self.model)
+        elif self.model_class:
+            return ModelPermissionPolicy(self.model_class)
         else:
             return BlanketPermissionPolicy(None)
 
@@ -195,7 +209,9 @@ class CreationFormMixin:
             return self.creation_form_class
         elif self.form_fields is not None or self.exclude_form_fields is not None:
             return modelform_factory(
-                self.model, fields=self.form_fields, exclude=self.exclude_form_fields
+                self.model_class,
+                fields=self.form_fields,
+                exclude=self.exclude_form_fields,
             )
 
     def get_creation_form_kwargs(self):
@@ -344,16 +360,14 @@ class ChosenResponseMixin:
         )
 
 
-class ChosenViewMixin:
+class ChosenViewMixin(ModelLookupMixin):
     """
     A view that takes an object ID in the URL and returns a modal workflow response indicating
     that object has been chosen
     """
 
-    model = None
-
     def get_object(self, pk):
-        return self.model.objects.get(pk=pk)
+        return self.model_class.objects.get(pk=pk)
 
     def get(self, request, pk):
         try:

--- a/wagtail/admin/viewsets/chooser.py
+++ b/wagtail/admin/viewsets/chooser.py
@@ -27,6 +27,8 @@ class ChooserViewSet(ViewSet):
     )  #: Label for the 'choose' button in the chooser widget, when an item has already been chosen
     edit_item_text = _("Edit")  #: Label for the 'edit' button in the chooser widget
 
+    per_page = 10  #: Number of results to show per page
+
     #: The view class to use for the overall chooser modal; must be a subclass of ``wagtail.admin.views.generic.chooser.ChooseView``.
     choose_view_class = chooser_views.ChooseView
 
@@ -78,6 +80,7 @@ class ChooserViewSet(ViewSet):
             create_url_name=self.get_url_name("create"),
             icon=self.icon,
             page_title=self.page_title,
+            per_page=self.per_page,
             creation_form_class=self.creation_form_class,
             form_fields=self.form_fields,
             exclude_form_fields=self.exclude_form_fields,
@@ -94,6 +97,7 @@ class ChooserViewSet(ViewSet):
             model=self.model,
             chosen_url_name=self.get_url_name("chosen"),
             results_url_name=self.get_url_name("choose_results"),
+            per_page=self.per_page,
             creation_form_class=self.creation_form_class,
             form_fields=self.form_fields,
             exclude_form_fields=self.exclude_form_fields,

--- a/wagtail/admin/viewsets/chooser.py
+++ b/wagtail/admin/viewsets/chooser.py
@@ -124,8 +124,13 @@ class ChooserViewSet(ViewSet):
         """
         Returns the form widget class for this chooser.
         """
+        if isinstance(self.model, str):
+            model_name = self.model.split(".")[-1]
+        else:
+            model_name = self.model.__name__
+
         return type(
-            "%sChooserWidget" % self.model.__name__,
+            "%sChooserWidget" % model_name,
             (self.base_widget_class,),
             {
                 "model": self.model,

--- a/wagtail/admin/viewsets/chooser.py
+++ b/wagtail/admin/viewsets/chooser.py
@@ -15,6 +15,8 @@ class ChooserViewSet(ViewSet):
     A viewset that creates a chooser modal interface for choosing model instances.
     """
 
+    model = None
+
     icon = "snippet"  #: The icon to use in the header of the chooser modal, and on the chooser widget
     choose_one_text = _(
         "Choose"
@@ -124,13 +126,17 @@ class ChooserViewSet(ViewSet):
         """
         Returns the form widget class for this chooser.
         """
-        if isinstance(self.model, str):
-            model_name = self.model.split(".")[-1]
+        if self.model is None:
+            widget_class_name = "ChooserWidget"
         else:
-            model_name = self.model.__name__
+            if isinstance(self.model, str):
+                model_name = self.model.split(".")[-1]
+            else:
+                model_name = self.model.__name__
+            widget_class_name = "%sChooserWidget" % model_name
 
         return type(
-            "%sChooserWidget" % model_name,
+            widget_class_name,
             (self.base_widget_class,),
             {
                 "model": self.model,
@@ -151,7 +157,7 @@ class ChooserViewSet(ViewSet):
         ]
 
     def on_register(self):
-        if self.register_widget:
+        if self.model and self.register_widget:
             register_form_field_override(
                 ForeignKey, to=self.model, override={"widget": self.widget_class}
             )

--- a/wagtail/admin/widgets/chooser.py
+++ b/wagtail/admin/widgets/chooser.py
@@ -6,6 +6,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.forms import widgets
 from django.template.loader import render_to_string
 from django.urls import reverse
+from django.utils.functional import cached_property
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
 
@@ -99,6 +100,7 @@ class BaseChooser(widgets.Input):
     )
     icon = None
     classname = None
+    model = None
 
     # when looping over form fields, this one should appear in visible_fields, not hidden_fields
     # despite the underlying input being type="hidden"
@@ -120,6 +122,10 @@ class BaseChooser(widgets.Input):
         if "show_clear_link" in kwargs:
             self.show_clear_link = kwargs.pop("show_clear_link")
         super().__init__(**kwargs)
+
+    @cached_property
+    def model_class(self):
+        return resolve_model_string(self.model)
 
     def value_from_datadict(self, data, files, name):
         # treat the empty string as None
@@ -176,10 +182,10 @@ class BaseChooser(widgets.Input):
         """
         if value is None:
             return None
-        elif isinstance(value, self.model):
+        elif isinstance(value, self.model_class):
             return value
         else:  # assume instance ID
-            return self.model.objects.get(pk=value)
+            return self.model_class.objects.get(pk=value)
 
     def get_display_title(self, instance):
         """

--- a/wagtail/utils/registry.py
+++ b/wagtail/utils/registry.py
@@ -1,6 +1,8 @@
 from django.core.exceptions import ImproperlyConfigured
 from django.db import models
 
+from wagtail.coreutils import resolve_model_string
+
 
 class ObjectTypeRegistry:
     """
@@ -66,7 +68,7 @@ class ModelFieldRegistry(ObjectTypeRegistry):
     def register(self, field_class, to=None, value=None, exact_class=False):
         if to:
             if field_class == models.ForeignKey:
-                self.values_by_fk_related_model[to] = value
+                self.values_by_fk_related_model[resolve_model_string(to)] = value
             else:
                 raise ImproperlyConfigured(
                     "The 'to' argument on ModelFieldRegistry.register is only valid for ForeignKey fields"


### PR DESCRIPTION
Part of #8480; incorporates #8804.

Makes minor changes to the chooser implementation so that they don't fail outright when a model is not specified, then adds documentation for how to override the appropriate methods for building a chooser powered by a non-model data source.

Ideally I'd have liked to provide a generic base implementation for API-based choosers rather than just documenting the things to override - but given how wildly APIs can differ in their JSON structure (if indeed it's JSON at all) and mechanisms for pagination and filtering, I think that would be best handled by a separate utility class that wraps those differences and presents a standard interface for querying that dataset. And, furthermore, that interface should be a strict subset of Django's QuerySet (so that the 95% of choosers that _are_ using models can use the native queryset interface instead of having to adopt a new dumbed-down one). At that point this becomes a whole other project, one that would probably be a worthwhile addition to the Django ecosystem in its own right, but definitely out of scope for the page editor redevelopment project.