### PR TITLE
Test Django main against git master of django-rest-framework

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,6 +82,7 @@ jobs:
             postgres: 'postgres:12'
           - python: '3.10'
             django: 'git+https://github.com/django/django.git@main#egg=Django'
+            install_extras: 'pip uninstall -y djangorestframework ; pip install git+https://github.com/encode/django-rest-framework.git@master#egg=djangorestframework'
             experimental: true
             postgres: 'postgres:12'
 


### PR DESCRIPTION
Get our CI runs against the Django main branch working again, now that django-rest-framework has merged the necessary fix for Django 4.2(dev): https://github.com/encode/django-rest-framework/pull/8556