### PR TITLE
Adopted shared header for form submission page

### DIFF
--- a/client/scss/components/_forms.scss
+++ b/client/scss/components/_forms.scss
@@ -292,6 +292,7 @@ label.required:after {
   @include clearfix();
   padding-top: 0.5em;
   padding-bottom: 1.2em;
+  list-style: none;
 }
 
 .field-row {

--- a/wagtail/admin/templates/wagtailadmin/shared/header.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/header.html
@@ -15,6 +15,7 @@
     - `action_text` - text for the 'action' button
     - `action_icon` - icon for the 'action' button, default is 'icon-plus'
     - `extra_actions` - extra action buttons for the header. This is the HTML to be used for the extra buttons
+    - `extra_rows` - extra form rows for the header. This is the HTML to be used for the extra rows
 
 {% endcomment %}
 <header class="{% classnames "w-header" classname merged|yesno:"w-header--merged," search_form|yesno:"w-header--hasform," %}">
@@ -57,5 +58,7 @@
             {{ extra_actions }}
         </div>
     </div>
-    {% block extra_rows %}{% endblock %}
+    {% block extra_rows %}
+        {{ extra_rows }}
+    {% endblock %}
 </header>

--- a/wagtail/contrib/forms/templates/wagtailforms/index_submissions.html
+++ b/wagtail/contrib/forms/templates/wagtailforms/index_submissions.html
@@ -81,39 +81,29 @@
     </script>
 {% endblock %}
 {% block content %}
-    <header class="w-header w-header--hasform">
-        <form action="" method="get" novalidate>
-            <div class="row">
-                <div class="left">
-                    <div class="col">
-                        <h1 class="w-header__title">
-                            {% icon class_name="w-header__glyph" name="form" %}
-                            {% blocktrans trimmed with form_title=form_page.title|capfirst %}Form data <span class="w-header__subtitle">{{ form_title }}</span>{% endblocktrans %}
-                        </h1>
-                    </div>
-                    <div class="col search-bar">
-                        <ul class="fields row rowflush">
-                            {% for field in select_date_form %}
-                                {% include "wagtailadmin/shared/field_as_li.html" with field=field field_classes="field-small" li_classes="col4" %}
-                            {% endfor %}
-                            <li class="submit col2">
-                                <button type="submit" name="action" value="filter" class="button button-filter">{% trans 'Filter' %}</button>
-                            </li>
-                        </ul>
-                    </div>
-                </div>
-                <div class="right">
-                    <div class="dropdown dropdown-button match-width">
-                        <a href="?export=xlsx" class="button bicolor button--icon">{% icon name="download" wrapped=1 %}{% trans 'Download XLSX' %}</a>
-                        <div class="dropdown-toggle">{% icon name="arrow-down" %}</div>
-                        <ul>
-                            <li><a  class="button bicolor button--icon" href="?export=csv">{% icon name="download" wrapped=1 %}{% trans 'Download CSV' %}</a></li>
-                        </ul>
-                    </div>
-                </div>
-            </div>
-        </form>
-    </header>
+
+    {% fragment as form_actions %}
+        <div class="dropdown dropdown-button match-width">
+            <a href="?export=xlsx" class="button bicolor button--icon">{% icon name="download" wrapped=1 %}{% trans 'Download XLSX' %}</a>
+            <div class="dropdown-toggle">{% icon name="arrow-down" %}</div>
+            <ul>
+                <li><a  class="button bicolor button--icon" href="?export=csv">{% icon name="download" wrapped=1 %}{% trans 'Download CSV' %}</a></li>
+            </ul>
+        </div>
+    {% endfragment %}
+
+    {% fragment as form_rows %}
+        <ul class="fields row rowflush">
+            {% for field in select_date_form %}
+                {% include "wagtailadmin/shared/field_as_li.html" with field=field field_classes="field-small" li_classes="col4" %}
+            {% endfor %}
+            <li class="submit col2">
+                <button type="submit" name="action" value="filter" class="button button-filter">{% trans 'Filter' %}</button>
+            </li>
+        </ul>
+    {% endfragment %}
+
+    {% include "wagtailadmin/shared/header.html" with title="Form data" subtitle=form_page.title|capfirst icon="form" merged=1 extra_actions=form_actions extra_rows=form_rows %}
     <div class="nice-padding">
         {% if submissions %}
             <form action="{% url 'wagtailforms:delete_submissions' form_page.id %}" method="get">


### PR DESCRIPTION
Addresses #8539.
I have adopted shared header template for form submissions page.
As discussed with @lb- I have shifted form rows to the bottom of header.
Before:

![Screenshot from 2022-07-15 09-54-08](https://user-images.githubusercontent.com/86092410/179150259-96a68061-ed8d-4e7b-83cc-6931928e043c.png)

![Screenshot from 2022-07-15 09-54-40](https://user-images.githubusercontent.com/86092410/179150264-53b74f09-7f14-474a-aea3-f9dc4439e34c.png)

![Screenshot from 2022-07-15 09-54-58](https://user-images.githubusercontent.com/86092410/179150266-d2849b3c-bad8-4bf7-b961-17e1a8d831dc.png)


![Screenshot from 2022-07-15 09-55-18](https://user-images.githubusercontent.com/86092410/179150267-75b15cdc-fa09-4629-968a-be5a1f2190b6.png)


After:

![Screenshot from 2022-07-15 09-48-20](https://user-images.githubusercontent.com/86092410/179150366-2f460061-da57-43f2-8b3e-16af9ca43e3c.png)

![Screenshot from 2022-07-15 09-52-53](https://user-images.githubusercontent.com/86092410/179150374-3a3eb21b-7429-409b-80fd-1f822c00bdeb.png)

![Screenshot from 2022-07-15 09-53-16](https://user-images.githubusercontent.com/86092410/179150379-c00eddcd-fa30-4cb4-9026-20426b49158b.png)

![Screenshot from 2022-07-15 09-53-40](https://user-images.githubusercontent.com/86092410/179150380-c6de1279-a58e-4734-8a41-067388d12b62.png)

 

