### PR TITLE
Add styling for Django 4 div-based radio buttons markup

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,7 +4,7 @@ Changelog
 4.0 (xx.xx.xxxx) - IN DEVELOPMENT
 ~~~~~~~~~~~~~~~~
 
-* Added a new `BaseGenericSetting` base model class that allows defining a settings model that applies to all sites rather than just a single site (Kyle Bayliss)
+ * Added a new `BaseGenericSetting` base model class that allows defining a settings model that applies to all sites rather than just a single site (Kyle Bayliss)
  * Add clarity to confirmation when being asked to convert an external link to an internal one (Thijs Kramer)
  * Convert various pages in the documentation to Markdown (Khanh Hoang, Vu Pham, Daniel Kirkham, LB (Ben) Johnston, Thiago Costa de Souza, Benedict Faw, Noble Mittal, Sævar Öfjörð Magnússon, Sandeep M A, Stefano Silvestri)
  * Add `base_url_path` to `ModelAdmin` so that the default URL structure of app_label/model_name can be overridden (Vu Pham, Khanh Hoang)
@@ -101,6 +101,7 @@ Changelog
  * Fix: Display the correct color for icons in forced colors mode (Anuja Verma)
  * Fix: Remove outdated reference to 30-character limit on usernames in help text (minusf)
  * Fix: Resolve multiple form submissions index listing page layout issues including title not being visible on mobile and interaction with large tables (Paarth Agarwal)
+ * Fix: Ensure ModelAdmin single selection lists show correctly with Django 4.0 form template changes (Coen van der Kamp)
 
 
 3.0.1 (16.06.2022)

--- a/client/scss/layouts/_modeladmin-choose-parent-page.scss
+++ b/client/scss/layouts/_modeladmin-choose-parent-page.scss
@@ -7,3 +7,18 @@
 .modeladmin #id_parent_page li label {
   float: none;
 }
+
+// stylelint-disable-next-line selector-max-id
+.modeladmin #id_parent_page div {
+  margin: 15px 0;
+}
+
+// stylelint-disable-next-line selector-max-id
+.modeladmin #id_parent_page div label {
+  float: none;
+}
+
+// stylelint-disable-next-line selector-max-id
+.modeladmin #id_parent_page div label input {
+  transform: translateY(8px);
+}

--- a/docs/releases/4.0.md
+++ b/docs/releases/4.0.md
@@ -95,7 +95,6 @@ Wagtail’s page preview is now available in a side panel within the page editor
  * Add `menu_item_name` to modify MenuItem's name for ModelAdmin (Alexander Rogovskyy, Vu Pham)
  * Add an extra confirmation prompt when deleting pages with a large number of child pages (Jaspreet Singh)
  * Adopt the slim header in page listing views, with buttons moved under the "Actions" dropdown (Paarth Agarwal)
- * Resolve multiple form submissions index listing page layout issues including title not being visible on mobile and interaction with large tables (Paarth Agarwal)
 
 ### Bug fixes
 
@@ -126,6 +125,8 @@ Wagtail’s page preview is now available in a side panel within the page editor
  * Make checkboxes visible in forced colors mode (Anuja Verma)
  * Display the correct color for icons in forced colors mode (Anuja Verma)
  * Remove outdated reference to 30-character limit on usernames in help text (minusf)
+ * Resolve multiple form submissions index listing page layout issues including title not being visible on mobile and interaction with large tables (Paarth Agarwal)
+ * Ensure ModelAdmin single selection lists show correctly with Django 4.0 form template changes (Coen van der Kamp)
 
 
 ## Upgrade considerations


### PR DESCRIPTION
Fix for https://github.com/wagtail/wagtail/issues/8869

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [x] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]

- OSX / Chrome Version 103.0.5060.114 (Official Build) (arm64)
- OSX / FireFox 102.0.1 (64-bits)
- OSX / Safari Version 15.4 (17613.1.17.1.13)

- Please list which assistive technologies [^3] you tested N/A
- For new features: Has the documentation been updated accordingly? N/A

Additional details for testing this change:
- Make sure Django 4 is installed.
- Create a modelAdmin like described [in the linked issue.](https://github.com/wagtail/wagtail/issues/8869)

