### PR TITLE
Simplify page chooser views with class-based views

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -108,6 +108,7 @@ Changelog
  * Update base Draftail/TextField form designs as part of the page editor redesign (Thibaud Colas)
  * Move commenting trigger to inline toolbar and move block splitting to the block toolbar and command palette only in Draftail (Thibaud Colas)
  * Pages are now locked when they are scheduled for publishing (Karl Hobley)
+ * Simplify page chooser views by converting to class-based views (Matt Westcott)
  * Fix: Typo in `ResumeWorkflowActionFormatter` message (Stefan Hammer)
  * Fix: Throw a meaningful error when saving an image to an unrecognised image format (Christian Franke)
  * Fix: Remove extra padding for headers with breadcrumbs on mobile viewport (Steven Steinwand)

--- a/client/src/entrypoints/admin/page-chooser-modal.js
+++ b/client/src/entrypoints/admin/page-chooser-modal.js
@@ -21,17 +21,7 @@ const PAGE_CHOOSER_MODAL_ONLOAD_HANDLERS = {
       return false;
     });
 
-    /*
-    Set up submissions of the search form to open in the modal.
-
-    FIXME: wagtailadmin.views.chooser.browse doesn't actually return a modal-workflow
-    response for search queries, so this just fails with a JS error.
-    Luckily, the search-as-you-type logic below means that we never actually need to
-    submit the form to get search results, so this has the desired effect of preventing
-    plain vanilla form submissions from completing (which would clobber the entire
-    calling page, not just the modal). It would be nice to do that without throwing
-    a JS error, that's all...
-    */
+    /* Set up submissions of the search form to open in the modal. */
     modal.ajaxifyForm($('form.search-form', modal.body));
 
     /* Set up search-as-you-type behaviour on the search box */
@@ -50,7 +40,6 @@ const PAGE_CHOOSER_MODAL_ONLOAD_HANDLERS = {
           data: {
             // eslint-disable-next-line id-length
             q: query,
-            results_only: true,
           },
           success(data) {
             request = null;

--- a/docs/releases/4.0.md
+++ b/docs/releases/4.0.md
@@ -168,6 +168,7 @@ The bulk of these enhancements have been from Paarth Agarwal, who has been doing
  * Update base Draftail/TextField form designs as part of the page editor redesign (Thibaud Colas)
  * Move commenting trigger to inline toolbar and move block splitting to the block toolbar and command palette only in Draftail (Thibaud Colas)
  * Pages are now locked when they are scheduled for publishing (Karl Hobley)
+ * Simplify page chooser views by converting to class-based views (Matt Westcott)
 
 ### Bug fixes
 

--- a/wagtail/admin/templates/wagtailadmin/chooser/tables/page_title_cell.html
+++ b/wagtail/admin/templates/wagtailadmin/chooser/tables/page_title_cell.html
@@ -6,7 +6,7 @@
         {% else %}
             {{ value }}
         {% endif %}
-        {% if show_locale_labels and page.depth == 2 %}
+        {% if column.show_locale_labels and page.depth == 2 %}
             <span class="status-tag status-tag--label">{{ page.locale.get_display_name }}</span>
         {% endif %}
 

--- a/wagtail/admin/templates/wagtailadmin/chooser/tables/parent_page_cell.html
+++ b/wagtail/admin/templates/wagtailadmin/chooser/tables/parent_page_cell.html
@@ -1,6 +1,6 @@
 <td {% if column.classname %}class="{{ column.classname }}"{% endif %}>
     {% if value %}
         <a href="{% url 'wagtailadmin_choose_page_child' value.id %}" class="navigate-parent">{{ value.get_admin_display_title }}</a>
-        {% if show_locale_labels %}<span class="status-tag status-tag--label">{{ value.locale.get_display_name }}</span>{% endif %}
+        {% if column.show_locale_labels %}<span class="status-tag status-tag--label">{{ value.locale.get_display_name }}</span>{% endif %}
     {% endif %}
 </td>

--- a/wagtail/admin/urls/__init__.py
+++ b/wagtail/admin/urls/__init__.py
@@ -38,31 +38,35 @@ urlpatterns = [
     ),
     path("pages/", include(wagtailadmin_pages_urls, namespace="wagtailadmin_pages")),
     # TODO: Move into wagtailadmin_pages namespace
-    path("choose-page/", chooser.browse, name="wagtailadmin_choose_page"),
+    path("choose-page/", chooser.BrowseView.as_view(), name="wagtailadmin_choose_page"),
     path(
         "choose-page/<int:parent_page_id>/",
-        chooser.browse,
+        chooser.BrowseView.as_view(),
         name="wagtailadmin_choose_page_child",
     ),
-    path("choose-page/search/", chooser.search, name="wagtailadmin_choose_page_search"),
+    path(
+        "choose-page/search/",
+        chooser.SearchView.as_view(),
+        name="wagtailadmin_choose_page_search",
+    ),
     path(
         "choose-external-link/",
-        chooser.external_link,
+        chooser.ExternalLinkView.as_view(),
         name="wagtailadmin_choose_page_external_link",
     ),
     path(
         "choose-email-link/",
-        chooser.email_link,
+        chooser.EmailLinkView.as_view(),
         name="wagtailadmin_choose_page_email_link",
     ),
     path(
         "choose-phone-link/",
-        chooser.phone_link,
+        chooser.PhoneLinkView.as_view(),
         name="wagtailadmin_choose_page_phone_link",
     ),
     path(
         "choose-anchor-link/",
-        chooser.anchor_link,
+        chooser.AnchorLinkView.as_view(),
         name="wagtailadmin_choose_page_anchor_link",
     ),
     path("tag-autocomplete/", tags.autocomplete, name="wagtailadmin_tag_autocomplete"),

--- a/wagtail/admin/views/chooser.py
+++ b/wagtail/admin/views/chooser.py
@@ -161,7 +161,7 @@ class BrowseView(View):
     def columns(self):
         return [
             PageTitleColumn(
-                "title", label=_("Title"), show_locale_labels=self.show_locale_labels
+                "title", label=_("Title"), show_locale_labels=self.i18n_enabled
             ),
             DateColumn(
                 "updated",
@@ -182,7 +182,7 @@ class BrowseView(View):
     def get_object_list(self):
         # Get children of parent page (without streamfields)
         pages = self.parent_page.get_children().defer_streamfields().specific()
-        if self.show_locale_labels:
+        if self.i18n_enabled:
             pages = pages.select_related("locale")
         return pages
 
@@ -203,7 +203,7 @@ class BrowseView(View):
         return pages
 
     def get(self, request, parent_page_id=None):
-        self.show_locale_labels = getattr(settings, "WAGTAIL_I18N_ENABLED", False)
+        self.i18n_enabled = getattr(settings, "WAGTAIL_I18N_ENABLED", False)
 
         # A missing or empty page_type parameter indicates 'all page types'
         # (i.e. descendants of wagtailcore.page)
@@ -258,7 +258,7 @@ class BrowseView(View):
 
         selected_locale = None
         locale_options = []
-        if self.show_locale_labels:
+        if self.i18n_enabled:
             if self.parent_page.is_root():
                 # 'locale' is the current value of the "Locale" selector in the UI
                 if request.GET.get("locale"):
@@ -359,7 +359,7 @@ class BrowseView(View):
                     for desired_class in self.desired_classes
                 ],
                 "page_types_restricted": (page_type_string != "wagtailcore.page"),
-                "show_locale_labels": self.show_locale_labels,
+                "show_locale_labels": self.i18n_enabled,
                 "locale_options": locale_options,
                 "selected_locale": selected_locale,
             },
@@ -379,10 +379,10 @@ class SearchView(View):
     def columns(self):
         return [
             PageTitleColumn(
-                "title", label=_("Title"), show_locale_labels=self.show_locale_labels
+                "title", label=_("Title"), show_locale_labels=self.i18n_enabled
             ),
             ParentPageColumn(
-                "parent", label=_("Parent"), show_locale_labels=self.show_locale_labels
+                "parent", label=_("Parent"), show_locale_labels=self.i18n_enabled
             ),
             DateColumn(
                 "updated",
@@ -400,7 +400,7 @@ class SearchView(View):
         ]
 
     def get(self, request):
-        self.show_locale_labels = getattr(settings, "WAGTAIL_I18N_ENABLED", False)
+        self.i18n_enabled = getattr(settings, "WAGTAIL_I18N_ENABLED", False)
         # A missing or empty page_type parameter indicates 'all page types' (i.e. descendants of wagtailcore.page)
         page_type_string = request.GET.get("page_type") or "wagtailcore.page"
 
@@ -410,7 +410,7 @@ class SearchView(View):
             raise Http404
 
         pages = Page.objects.all()
-        if self.show_locale_labels:
+        if self.i18n_enabled:
             pages = pages.select_related("locale")
 
         # allow hooks to modify the queryset
@@ -448,7 +448,7 @@ class SearchView(View):
                     "table": table,
                     "pages": pages,
                     "page_type_string": page_type_string,
-                    "show_locale_labels": self.show_locale_labels,
+                    "show_locale_labels": self.i18n_enabled,
                 },
             ),
         )

--- a/wagtail/admin/views/chooser.py
+++ b/wagtail/admin/views/chooser.py
@@ -8,6 +8,7 @@ from django.template.response import TemplateResponse
 from django.urls.base import reverse
 from django.utils.http import urlencode
 from django.utils.translation import gettext as _
+from django.views.generic.base import View
 
 from wagtail import hooks
 from wagtail.admin.forms.choosers import (
@@ -158,144 +159,62 @@ class PageNavigateToChildrenColumn(Column):
         return instance
 
 
-def browse(request, parent_page_id=None):
-    # A missing or empty page_type parameter indicates 'all page types'
-    # (i.e. descendants of wagtailcore.page)
-    page_type_string = request.GET.get("page_type") or "wagtailcore.page"
-    user_perm = request.GET.get("user_perms", False)
+class BrowseView(View):
+    def get(self, request, parent_page_id=None):
+        # A missing or empty page_type parameter indicates 'all page types'
+        # (i.e. descendants of wagtailcore.page)
+        page_type_string = request.GET.get("page_type") or "wagtailcore.page"
+        user_perm = request.GET.get("user_perms", False)
 
-    try:
-        desired_classes = page_models_from_string(page_type_string)
-    except (ValueError, LookupError):
-        raise Http404
+        try:
+            desired_classes = page_models_from_string(page_type_string)
+        except (ValueError, LookupError):
+            raise Http404
 
-    # Find parent page
-    if parent_page_id:
-        parent_page = get_object_or_404(Page, id=parent_page_id)
-    elif desired_classes == (Page,):
-        # Just use the root page
-        parent_page = Page.get_first_root_node()
-    else:
-        # Find the highest common ancestor for the specific classes passed in
-        # In many cases, such as selecting an EventPage under an EventIndex,
-        # this will help the administrator find their page quicker.
-        all_desired_pages = Page.objects.all().type(*desired_classes)
-        parent_page = all_desired_pages.first_common_ancestor()
-
-    parent_page = parent_page.specific
-
-    # Get children of parent page (without streamfields)
-    pages = parent_page.get_children().defer_streamfields().specific()
-
-    # allow hooks to modify the queryset
-    for hook in hooks.get_hooks("construct_page_chooser_queryset"):
-        pages = hook(pages, request)
-
-    # Filter them by page type
-    if desired_classes != (Page,):
-        # restrict the page listing to just those pages that:
-        # - are of the given content type (taking into account class inheritance)
-        # - or can be navigated into (i.e. have children)
-        choosable_pages = pages.type(*desired_classes)
-        descendable_pages = pages.filter(numchild__gt=0)
-        pages = choosable_pages | descendable_pages
-
-    can_choose_root = request.GET.get("can_choose_root", False)
-    target_pages = Page.objects.filter(
-        pk__in=[int(pk) for pk in request.GET.getlist("target_pages[]", []) if pk]
-    )
-
-    match_subclass = request.GET.get("match_subclass", True)
-
-    # Do permission lookups for this user now, instead of for every page.
-    permission_proxy = UserPagePermissionsProxy(request.user)
-
-    # Parent page can be chosen if it is a instance of desired_classes
-    parent_page.can_choose = can_choose_page(
-        parent_page,
-        permission_proxy,
-        desired_classes,
-        can_choose_root,
-        user_perm,
-        target_pages=target_pages,
-        match_subclass=match_subclass,
-    )
-    parent_page.is_parent_page = True
-    parent_page.can_descend = False
-
-    selected_locale = None
-    locale_options = []
-    show_locale_labels = getattr(settings, "WAGTAIL_I18N_ENABLED", False)
-    if show_locale_labels:
-        pages = pages.select_related("locale")
-
-        if parent_page.is_root():
-            # 'locale' is the current value of the "Locale" selector in the UI
-            if request.GET.get("locale"):
-                selected_locale = get_object_or_404(
-                    Locale, language_code=request.GET["locale"]
-                )
-                active_locale_id = selected_locale.pk
-            else:
-                active_locale_id = Locale.get_active().pk
-
-            # we are at the Root level, so get the locales from the current pages
-            choose_url = reverse("wagtailadmin_choose_page")
-            locale_options = [
-                {
-                    "locale": locale,
-                    "url": choose_url
-                    + "?"
-                    + urlencode(
-                        {"page_type": page_type_string, "locale": locale.language_code}
-                    ),
-                }
-                for locale in Locale.objects.filter(
-                    pk__in=pages.values_list("locale_id")
-                ).exclude(pk=active_locale_id)
-            ]
+        # Find parent page
+        if parent_page_id:
+            parent_page = get_object_or_404(Page, id=parent_page_id)
+        elif desired_classes == (Page,):
+            # Just use the root page
+            parent_page = Page.get_first_root_node()
         else:
-            # We have a parent page (that is not the root page). Use its locale as the selected localer
-            selected_locale = parent_page.locale
-            # and get the locales based on its available translations
-            locales_and_parent_pages = {
-                item["locale"]: item["pk"]
-                for item in Page.objects.translation_of(parent_page).values(
-                    "locale", "pk"
-                )
-            }
-            locales_and_parent_pages[selected_locale.pk] = parent_page.pk
-            for locale in Locale.objects.filter(
-                pk__in=list(locales_and_parent_pages.keys())
-            ).exclude(pk=selected_locale.pk):
-                choose_child_url = reverse(
-                    "wagtailadmin_choose_page_child",
-                    args=[locales_and_parent_pages[locale.pk]],
-                )
+            # Find the highest common ancestor for the specific classes passed in
+            # In many cases, such as selecting an EventPage under an EventIndex,
+            # this will help the administrator find their page quicker.
+            all_desired_pages = Page.objects.all().type(*desired_classes)
+            parent_page = all_desired_pages.first_common_ancestor()
 
-                locale_options.append(
-                    {
-                        "locale": locale,
-                        "url": choose_child_url
-                        + "?"
-                        + urlencode({"page_type": page_type_string}),
-                    }
-                )
+        parent_page = parent_page.specific
 
-        # finally, filter the browseable pages on the selected locale
-        if selected_locale:
-            pages = pages.filter(locale=selected_locale)
+        # Get children of parent page (without streamfields)
+        pages = parent_page.get_children().defer_streamfields().specific()
 
-    # Pagination
-    # We apply pagination first so we don't need to walk the entire list
-    # in the block below
-    paginator = Paginator(pages, per_page=25)
-    pages = paginator.get_page(request.GET.get("p"))
+        # allow hooks to modify the queryset
+        for hook in hooks.get_hooks("construct_page_chooser_queryset"):
+            pages = hook(pages, request)
 
-    # Annotate each page with can_choose/can_decend flags
-    for page in pages:
-        page.can_choose = can_choose_page(
-            page,
+        # Filter them by page type
+        if desired_classes != (Page,):
+            # restrict the page listing to just those pages that:
+            # - are of the given content type (taking into account class inheritance)
+            # - or can be navigated into (i.e. have children)
+            choosable_pages = pages.type(*desired_classes)
+            descendable_pages = pages.filter(numchild__gt=0)
+            pages = choosable_pages | descendable_pages
+
+        can_choose_root = request.GET.get("can_choose_root", False)
+        target_pages = Page.objects.filter(
+            pk__in=[int(pk) for pk in request.GET.getlist("target_pages[]", []) if pk]
+        )
+
+        match_subclass = request.GET.get("match_subclass", True)
+
+        # Do permission lookups for this user now, instead of for every page.
+        permission_proxy = UserPagePermissionsProxy(request.user)
+
+        # Parent page can be chosen if it is a instance of desired_classes
+        parent_page.can_choose = can_choose_page(
+            parent_page,
             permission_proxy,
             desired_classes,
             can_choose_root,
@@ -303,122 +222,216 @@ def browse(request, parent_page_id=None):
             target_pages=target_pages,
             match_subclass=match_subclass,
         )
-        page.can_descend = page.get_children_count()
-        page.is_parent_page = False
+        parent_page.is_parent_page = True
+        parent_page.can_descend = False
 
-    table = PageChooserTable(
-        [
-            PageTitleColumn("title", label=_("Title")),
-            DateColumn(
-                "updated",
-                label=_("Updated"),
-                width="12%",
-                accessor="latest_revision_created_at",
-            ),
-            Column(
-                "type", label=_("Type"), width="12%", accessor="page_type_display_name"
-            ),
-            PageStatusColumn("status", label=_("Status"), width="12%"),
-            PageNavigateToChildrenColumn("children", label="", width="10%"),
-        ],
-        [parent_page] + list(pages),
-    )
+        selected_locale = None
+        locale_options = []
+        show_locale_labels = getattr(settings, "WAGTAIL_I18N_ENABLED", False)
+        if show_locale_labels:
+            pages = pages.select_related("locale")
 
-    # Render
-    context = shared_context(
-        request,
-        {
-            "parent_page": parent_page,
-            "parent_page_id": parent_page.pk,
-            "table": table,
-            "pagination_page": pages,
-            "search_form": SearchForm(),
-            "page_type_string": page_type_string,
-            "page_type_names": [
-                desired_class.get_verbose_name() for desired_class in desired_classes
+            if parent_page.is_root():
+                # 'locale' is the current value of the "Locale" selector in the UI
+                if request.GET.get("locale"):
+                    selected_locale = get_object_or_404(
+                        Locale, language_code=request.GET["locale"]
+                    )
+                    active_locale_id = selected_locale.pk
+                else:
+                    active_locale_id = Locale.get_active().pk
+
+                # we are at the Root level, so get the locales from the current pages
+                choose_url = reverse("wagtailadmin_choose_page")
+                locale_options = [
+                    {
+                        "locale": locale,
+                        "url": choose_url
+                        + "?"
+                        + urlencode(
+                            {
+                                "page_type": page_type_string,
+                                "locale": locale.language_code,
+                            }
+                        ),
+                    }
+                    for locale in Locale.objects.filter(
+                        pk__in=pages.values_list("locale_id")
+                    ).exclude(pk=active_locale_id)
+                ]
+            else:
+                # We have a parent page (that is not the root page). Use its locale as the selected localer
+                selected_locale = parent_page.locale
+                # and get the locales based on its available translations
+                locales_and_parent_pages = {
+                    item["locale"]: item["pk"]
+                    for item in Page.objects.translation_of(parent_page).values(
+                        "locale", "pk"
+                    )
+                }
+                locales_and_parent_pages[selected_locale.pk] = parent_page.pk
+                for locale in Locale.objects.filter(
+                    pk__in=list(locales_and_parent_pages.keys())
+                ).exclude(pk=selected_locale.pk):
+                    choose_child_url = reverse(
+                        "wagtailadmin_choose_page_child",
+                        args=[locales_and_parent_pages[locale.pk]],
+                    )
+
+                    locale_options.append(
+                        {
+                            "locale": locale,
+                            "url": choose_child_url
+                            + "?"
+                            + urlencode({"page_type": page_type_string}),
+                        }
+                    )
+
+            # finally, filter the browseable pages on the selected locale
+            if selected_locale:
+                pages = pages.filter(locale=selected_locale)
+
+        # Pagination
+        # We apply pagination first so we don't need to walk the entire list
+        # in the block below
+        paginator = Paginator(pages, per_page=25)
+        pages = paginator.get_page(request.GET.get("p"))
+
+        # Annotate each page with can_choose/can_decend flags
+        for page in pages:
+            page.can_choose = can_choose_page(
+                page,
+                permission_proxy,
+                desired_classes,
+                can_choose_root,
+                user_perm,
+                target_pages=target_pages,
+                match_subclass=match_subclass,
+            )
+            page.can_descend = page.get_children_count()
+            page.is_parent_page = False
+
+        table = PageChooserTable(
+            [
+                PageTitleColumn("title", label=_("Title")),
+                DateColumn(
+                    "updated",
+                    label=_("Updated"),
+                    width="12%",
+                    accessor="latest_revision_created_at",
+                ),
+                Column(
+                    "type",
+                    label=_("Type"),
+                    width="12%",
+                    accessor="page_type_display_name",
+                ),
+                PageStatusColumn("status", label=_("Status"), width="12%"),
+                PageNavigateToChildrenColumn("children", label="", width="10%"),
             ],
-            "page_types_restricted": (page_type_string != "wagtailcore.page"),
-            "show_locale_labels": show_locale_labels,
-            "locale_options": locale_options,
-            "selected_locale": selected_locale,
-        },
-    )
+            [parent_page] + list(pages),
+        )
 
-    return render_modal_workflow(
-        request,
-        "wagtailadmin/chooser/browse.html",
-        None,
-        context,
-        json_data={"step": "browse", "parent_page_id": context["parent_page_id"]},
-    )
-
-
-def search(request, parent_page_id=None):
-    # A missing or empty page_type parameter indicates 'all page types' (i.e. descendants of wagtailcore.page)
-    page_type_string = request.GET.get("page_type") or "wagtailcore.page"
-
-    try:
-        desired_classes = page_models_from_string(page_type_string)
-    except (ValueError, LookupError):
-        raise Http404
-
-    pages = Page.objects.all()
-    show_locale_labels = getattr(settings, "WAGTAIL_I18N_ENABLED", False)
-    if show_locale_labels:
-        pages = pages.select_related("locale")
-
-    # allow hooks to modify the queryset
-    for hook in hooks.get_hooks("construct_page_chooser_queryset"):
-        pages = hook(pages, request)
-
-    search_form = SearchForm(request.GET)
-    if search_form.is_valid() and search_form.cleaned_data["q"]:
-        pages = pages.exclude(depth=1)  # never include root
-        pages = pages.type(*desired_classes)
-        pages = pages.specific()
-        pages = pages.search(search_form.cleaned_data["q"])
-    else:
-        pages = pages.none()
-
-    paginator = Paginator(pages, per_page=25)
-    pages = paginator.get_page(request.GET.get("p"))
-
-    for page in pages:
-        page.can_choose = True
-        page.is_parent_page = False
-
-    table = PageChooserTable(
-        [
-            PageTitleColumn("title", label=_("Title")),
-            ParentPageColumn("parent", label=_("Parent")),
-            DateColumn(
-                "updated",
-                label=_("Updated"),
-                width="12%",
-                accessor="latest_revision_created_at",
-            ),
-            Column(
-                "type", label=_("Type"), width="12%", accessor="page_type_display_name"
-            ),
-            PageStatusColumn("status", label=_("Status"), width="12%"),
-        ],
-        pages,
-    )
-
-    return TemplateResponse(
-        request,
-        "wagtailadmin/chooser/_search_results.html",
-        shared_context(
+        # Render
+        context = shared_context(
             request,
             {
-                "searchform": search_form,
+                "parent_page": parent_page,
+                "parent_page_id": parent_page.pk,
                 "table": table,
-                "pages": pages,
+                "pagination_page": pages,
+                "search_form": SearchForm(),
                 "page_type_string": page_type_string,
+                "page_type_names": [
+                    desired_class.get_verbose_name()
+                    for desired_class in desired_classes
+                ],
+                "page_types_restricted": (page_type_string != "wagtailcore.page"),
                 "show_locale_labels": show_locale_labels,
+                "locale_options": locale_options,
+                "selected_locale": selected_locale,
             },
-        ),
-    )
+        )
+
+        return render_modal_workflow(
+            request,
+            "wagtailadmin/chooser/browse.html",
+            None,
+            context,
+            json_data={"step": "browse", "parent_page_id": context["parent_page_id"]},
+        )
+
+
+class SearchView(View):
+    def get(self, request):
+        # A missing or empty page_type parameter indicates 'all page types' (i.e. descendants of wagtailcore.page)
+        page_type_string = request.GET.get("page_type") or "wagtailcore.page"
+
+        try:
+            desired_classes = page_models_from_string(page_type_string)
+        except (ValueError, LookupError):
+            raise Http404
+
+        pages = Page.objects.all()
+        show_locale_labels = getattr(settings, "WAGTAIL_I18N_ENABLED", False)
+        if show_locale_labels:
+            pages = pages.select_related("locale")
+
+        # allow hooks to modify the queryset
+        for hook in hooks.get_hooks("construct_page_chooser_queryset"):
+            pages = hook(pages, request)
+
+        search_form = SearchForm(request.GET)
+        if search_form.is_valid() and search_form.cleaned_data["q"]:
+            pages = pages.exclude(depth=1)  # never include root
+            pages = pages.type(*desired_classes)
+            pages = pages.specific()
+            pages = pages.search(search_form.cleaned_data["q"])
+        else:
+            pages = pages.none()
+
+        paginator = Paginator(pages, per_page=25)
+        pages = paginator.get_page(request.GET.get("p"))
+
+        for page in pages:
+            page.can_choose = True
+            page.is_parent_page = False
+
+        table = PageChooserTable(
+            [
+                PageTitleColumn("title", label=_("Title")),
+                ParentPageColumn("parent", label=_("Parent")),
+                DateColumn(
+                    "updated",
+                    label=_("Updated"),
+                    width="12%",
+                    accessor="latest_revision_created_at",
+                ),
+                Column(
+                    "type",
+                    label=_("Type"),
+                    width="12%",
+                    accessor="page_type_display_name",
+                ),
+                PageStatusColumn("status", label=_("Status"), width="12%"),
+            ],
+            pages,
+        )
+
+        return TemplateResponse(
+            request,
+            "wagtailadmin/chooser/_search_results.html",
+            shared_context(
+                request,
+                {
+                    "searchform": search_form,
+                    "table": table,
+                    "pages": pages,
+                    "page_type_string": page_type_string,
+                    "show_locale_labels": show_locale_labels,
+                },
+            ),
+        )
 
 
 LINK_CONVERSION_ALL = "all"
@@ -426,41 +439,152 @@ LINK_CONVERSION_EXACT = "exact"
 LINK_CONVERSION_CONFIRM = "confirm"
 
 
-def external_link(request):
-    initial_data = {
-        "url": request.GET.get("link_url", ""),
-        "link_text": request.GET.get("link_text", ""),
-    }
+class ExternalLinkView(View):
+    def dispatch(self, request):
+        initial_data = {
+            "url": request.GET.get("link_url", ""),
+            "link_text": request.GET.get("link_text", ""),
+        }
 
-    if request.method == "POST":
-        form = ExternalLinkChooserForm(
-            request.POST, initial=initial_data, prefix="external-link-chooser"
-        )
+        if request.method == "POST":
+            form = ExternalLinkChooserForm(
+                request.POST, initial=initial_data, prefix="external-link-chooser"
+            )
 
-        if form.is_valid():
-            submitted_url = form.cleaned_data["url"]
-            result = {
-                "url": submitted_url,
-                "title": form.cleaned_data["link_text"].strip()
-                or form.cleaned_data["url"],
-                # If the user has explicitly entered / edited something in the link_text field,
-                # always use that text. If not, we should favour keeping the existing link/selection
-                # text, where applicable.
-                # (Normally this will match the link_text passed in the URL here anyhow,
-                # but that won't account for non-text content such as images.)
-                "prefer_this_title_as_link_text": ("link_text" in form.changed_data),
-            }
+            if form.is_valid():
+                submitted_url = form.cleaned_data["url"]
+                result = {
+                    "url": submitted_url,
+                    "title": form.cleaned_data["link_text"].strip()
+                    or form.cleaned_data["url"],
+                    # If the user has explicitly entered / edited something in the link_text field,
+                    # always use that text. If not, we should favour keeping the existing link/selection
+                    # text, where applicable.
+                    # (Normally this will match the link_text passed in the URL here anyhow,
+                    # but that won't account for non-text content such as images.)
+                    "prefer_this_title_as_link_text": (
+                        "link_text" in form.changed_data
+                    ),
+                }
 
-            link_conversion = getattr(
-                settings, "WAGTAILADMIN_EXTERNAL_LINK_CONVERSION", LINK_CONVERSION_ALL
-            ).lower()
+                link_conversion = getattr(
+                    settings,
+                    "WAGTAILADMIN_EXTERNAL_LINK_CONVERSION",
+                    LINK_CONVERSION_ALL,
+                ).lower()
 
-            if link_conversion not in [
-                LINK_CONVERSION_ALL,
-                LINK_CONVERSION_EXACT,
-                LINK_CONVERSION_CONFIRM,
-            ]:
-                # We should not attempt to convert external urls to page links
+                if link_conversion not in [
+                    LINK_CONVERSION_ALL,
+                    LINK_CONVERSION_EXACT,
+                    LINK_CONVERSION_CONFIRM,
+                ]:
+                    # We should not attempt to convert external urls to page links
+                    return render_modal_workflow(
+                        request,
+                        None,
+                        None,
+                        None,
+                        json_data={"step": "external_link_chosen", "result": result},
+                    )
+
+                # Next, we should check if the url matches an internal page
+                # Strip the url of its query/fragment link parameters - these won't match a page
+                url_without_query = re.split(r"\?|#", submitted_url)[0]
+
+                # Start by finding any sites the url could potentially match
+                sites = getattr(request, "_wagtail_cached_site_root_paths", None)
+                if sites is None:
+                    sites = Site.get_site_root_paths()
+
+                match_relative_paths = submitted_url.startswith("/") and len(sites) == 1
+                # We should only match relative urls if there's only a single site
+                # Otherwise this could get very annoying accidentally matching coincidentally
+                # named pages on different sites
+
+                if match_relative_paths:
+                    possible_sites = [
+                        (pk, url_without_query)
+                        for pk, path, url, language_code in sites
+                    ]
+                else:
+                    possible_sites = [
+                        (pk, url_without_query[len(url) :])
+                        for pk, path, url, language_code in sites
+                        if submitted_url.startswith(url)
+                    ]
+
+                # Loop over possible sites to identify a page match
+                for pk, url in possible_sites:
+                    try:
+                        route = Site.objects.get(pk=pk).root_page.specific.route(
+                            request,
+                            [component for component in url.split("/") if component],
+                        )
+
+                        matched_page = route.page.specific
+
+                        internal_data = {
+                            "id": matched_page.pk,
+                            "parentId": matched_page.get_parent().pk,
+                            "adminTitle": matched_page.draft_title,
+                            "editUrl": reverse(
+                                "wagtailadmin_pages:edit", args=(matched_page.pk,)
+                            ),
+                            "url": matched_page.url,
+                        }
+
+                        # Let's check what this page's normal url would be
+                        normal_url = (
+                            matched_page.get_url_parts(request=request)[-1]
+                            if match_relative_paths
+                            else matched_page.get_full_url(request=request)
+                        )
+
+                        # If that's what the user provided, great. Let's just convert the external
+                        # url to an internal link automatically unless we're set up tp manually check
+                        # all conversions
+                        if (
+                            normal_url == submitted_url
+                            and link_conversion != LINK_CONVERSION_CONFIRM
+                        ):
+                            return render_modal_workflow(
+                                request,
+                                None,
+                                None,
+                                None,
+                                json_data={
+                                    "step": "external_link_chosen",
+                                    "result": internal_data,
+                                },
+                            )
+                        # If not, they might lose query parameters or routable page information
+
+                        if link_conversion == LINK_CONVERSION_EXACT:
+                            # We should only convert exact matches
+                            continue
+
+                        # Let's confirm the conversion with them explicitly
+                        else:
+                            return render_modal_workflow(
+                                request,
+                                "wagtailadmin/chooser/confirm_external_to_internal.html",
+                                None,
+                                {
+                                    "submitted_url": submitted_url,
+                                    "internal_url": normal_url,
+                                    "page": matched_page.draft_title,
+                                },
+                                json_data={
+                                    "step": "confirm_external_to_internal",
+                                    "external": result,
+                                    "internal": internal_data,
+                                },
+                            )
+
+                    except Http404:
+                        continue
+
+                # Otherwise, with no internal matches, fall back to an external url
                 return render_modal_workflow(
                     request,
                     None,
@@ -468,257 +592,167 @@ def external_link(request):
                     None,
                     json_data={"step": "external_link_chosen", "result": result},
                 )
-
-            # Next, we should check if the url matches an internal page
-            # Strip the url of its query/fragment link parameters - these won't match a page
-            url_without_query = re.split(r"\?|#", submitted_url)[0]
-
-            # Start by finding any sites the url could potentially match
-            sites = getattr(request, "_wagtail_cached_site_root_paths", None)
-            if sites is None:
-                sites = Site.get_site_root_paths()
-
-            match_relative_paths = submitted_url.startswith("/") and len(sites) == 1
-            # We should only match relative urls if there's only a single site
-            # Otherwise this could get very annoying accidentally matching coincidentally
-            # named pages on different sites
-
-            if match_relative_paths:
-                possible_sites = [
-                    (pk, url_without_query) for pk, path, url, language_code in sites
-                ]
-            else:
-                possible_sites = [
-                    (pk, url_without_query[len(url) :])
-                    for pk, path, url, language_code in sites
-                    if submitted_url.startswith(url)
-                ]
-
-            # Loop over possible sites to identify a page match
-            for pk, url in possible_sites:
-                try:
-                    route = Site.objects.get(pk=pk).root_page.specific.route(
-                        request,
-                        [component for component in url.split("/") if component],
-                    )
-
-                    matched_page = route.page.specific
-
-                    internal_data = {
-                        "id": matched_page.pk,
-                        "parentId": matched_page.get_parent().pk,
-                        "adminTitle": matched_page.draft_title,
-                        "editUrl": reverse(
-                            "wagtailadmin_pages:edit", args=(matched_page.pk,)
-                        ),
-                        "url": matched_page.url,
-                    }
-
-                    # Let's check what this page's normal url would be
-                    normal_url = (
-                        matched_page.get_url_parts(request=request)[-1]
-                        if match_relative_paths
-                        else matched_page.get_full_url(request=request)
-                    )
-
-                    # If that's what the user provided, great. Let's just convert the external
-                    # url to an internal link automatically unless we're set up tp manually check
-                    # all conversions
-                    if (
-                        normal_url == submitted_url
-                        and link_conversion != LINK_CONVERSION_CONFIRM
-                    ):
-                        return render_modal_workflow(
-                            request,
-                            None,
-                            None,
-                            None,
-                            json_data={
-                                "step": "external_link_chosen",
-                                "result": internal_data,
-                            },
-                        )
-                    # If not, they might lose query parameters or routable page information
-
-                    if link_conversion == LINK_CONVERSION_EXACT:
-                        # We should only convert exact matches
-                        continue
-
-                    # Let's confirm the conversion with them explicitly
-                    else:
-                        return render_modal_workflow(
-                            request,
-                            "wagtailadmin/chooser/confirm_external_to_internal.html",
-                            None,
-                            {
-                                "submitted_url": submitted_url,
-                                "internal_url": normal_url,
-                                "page": matched_page.draft_title,
-                            },
-                            json_data={
-                                "step": "confirm_external_to_internal",
-                                "external": result,
-                                "internal": internal_data,
-                            },
-                        )
-
-                except Http404:
-                    continue
-
-            # Otherwise, with no internal matches, fall back to an external url
-            return render_modal_workflow(
-                request,
-                None,
-                None,
-                None,
-                json_data={"step": "external_link_chosen", "result": result},
+        else:
+            form = ExternalLinkChooserForm(
+                initial=initial_data, prefix="external-link-chooser"
             )
-    else:
-        form = ExternalLinkChooserForm(
-            initial=initial_data, prefix="external-link-chooser"
+
+        return render_modal_workflow(
+            request,
+            "wagtailadmin/chooser/external_link.html",
+            None,
+            shared_context(
+                request,
+                {
+                    "form": form,
+                },
+            ),
+            json_data={"step": "external_link"},
         )
 
-    return render_modal_workflow(
-        request,
-        "wagtailadmin/chooser/external_link.html",
-        None,
-        shared_context(
+
+class AnchorLinkView(View):
+    def dispatch(self, request):
+        initial_data = {
+            "link_text": request.GET.get("link_text", ""),
+            "url": request.GET.get("link_url", ""),
+        }
+
+        if request.method == "POST":
+            form = AnchorLinkChooserForm(
+                request.POST, initial=initial_data, prefix="anchor-link-chooser"
+            )
+
+            if form.is_valid():
+                result = {
+                    "url": "#" + form.cleaned_data["url"],
+                    "title": form.cleaned_data["link_text"].strip()
+                    or form.cleaned_data["url"],
+                    "prefer_this_title_as_link_text": (
+                        "link_text" in form.changed_data
+                    ),
+                }
+                return render_modal_workflow(
+                    request,
+                    None,
+                    None,
+                    None,
+                    json_data={"step": "external_link_chosen", "result": result},
+                )
+        else:
+            form = AnchorLinkChooserForm(
+                initial=initial_data, prefix="anchor-link-chooser"
+            )
+
+        return render_modal_workflow(
             request,
-            {
-                "form": form,
-            },
-        ),
-        json_data={"step": "external_link"},
-    )
-
-
-def anchor_link(request):
-    initial_data = {
-        "link_text": request.GET.get("link_text", ""),
-        "url": request.GET.get("link_url", ""),
-    }
-
-    if request.method == "POST":
-        form = AnchorLinkChooserForm(
-            request.POST, initial=initial_data, prefix="anchor-link-chooser"
+            "wagtailadmin/chooser/anchor_link.html",
+            None,
+            shared_context(
+                request,
+                {
+                    "form": form,
+                },
+            ),
+            json_data={"step": "anchor_link"},
         )
 
-        if form.is_valid():
-            result = {
-                "url": "#" + form.cleaned_data["url"],
-                "title": form.cleaned_data["link_text"].strip()
-                or form.cleaned_data["url"],
-                "prefer_this_title_as_link_text": ("link_text" in form.changed_data),
-            }
-            return render_modal_workflow(
-                request,
-                None,
-                None,
-                None,
-                json_data={"step": "external_link_chosen", "result": result},
+
+class EmailLinkView(View):
+    def dispatch(self, request):
+        initial_data = {
+            "link_text": request.GET.get("link_text", ""),
+            "email_address": request.GET.get("link_url", ""),
+        }
+
+        if request.method == "POST":
+            form = EmailLinkChooserForm(
+                request.POST, initial=initial_data, prefix="email-link-chooser"
             )
-    else:
-        form = AnchorLinkChooserForm(initial=initial_data, prefix="anchor-link-chooser")
 
-    return render_modal_workflow(
-        request,
-        "wagtailadmin/chooser/anchor_link.html",
-        None,
-        shared_context(
+            if form.is_valid():
+                result = {
+                    "url": "mailto:" + form.cleaned_data["email_address"],
+                    "title": form.cleaned_data["link_text"].strip()
+                    or form.cleaned_data["email_address"],
+                    # If the user has explicitly entered / edited something in the link_text field,
+                    # always use that text. If not, we should favour keeping the existing link/selection
+                    # text, where applicable.
+                    "prefer_this_title_as_link_text": (
+                        "link_text" in form.changed_data
+                    ),
+                }
+                return render_modal_workflow(
+                    request,
+                    None,
+                    None,
+                    None,
+                    json_data={"step": "external_link_chosen", "result": result},
+                )
+        else:
+            form = EmailLinkChooserForm(
+                initial=initial_data, prefix="email-link-chooser"
+            )
+
+        return render_modal_workflow(
             request,
-            {
-                "form": form,
-            },
-        ),
-        json_data={"step": "anchor_link"},
-    )
-
-
-def email_link(request):
-    initial_data = {
-        "link_text": request.GET.get("link_text", ""),
-        "email_address": request.GET.get("link_url", ""),
-    }
-
-    if request.method == "POST":
-        form = EmailLinkChooserForm(
-            request.POST, initial=initial_data, prefix="email-link-chooser"
+            "wagtailadmin/chooser/email_link.html",
+            None,
+            shared_context(
+                request,
+                {
+                    "form": form,
+                },
+            ),
+            json_data={"step": "email_link"},
         )
 
-        if form.is_valid():
-            result = {
-                "url": "mailto:" + form.cleaned_data["email_address"],
-                "title": form.cleaned_data["link_text"].strip()
-                or form.cleaned_data["email_address"],
-                # If the user has explicitly entered / edited something in the link_text field,
-                # always use that text. If not, we should favour keeping the existing link/selection
-                # text, where applicable.
-                "prefer_this_title_as_link_text": ("link_text" in form.changed_data),
-            }
-            return render_modal_workflow(
-                request,
-                None,
-                None,
-                None,
-                json_data={"step": "external_link_chosen", "result": result},
+
+class PhoneLinkView(View):
+    def dispatch(self, request):
+        initial_data = {
+            "link_text": request.GET.get("link_text", ""),
+            "phone_number": request.GET.get("link_url", ""),
+        }
+
+        if request.method == "POST":
+            form = PhoneLinkChooserForm(
+                request.POST, initial=initial_data, prefix="phone-link-chooser"
             )
-    else:
-        form = EmailLinkChooserForm(initial=initial_data, prefix="email-link-chooser")
 
-    return render_modal_workflow(
-        request,
-        "wagtailadmin/chooser/email_link.html",
-        None,
-        shared_context(
+            if form.is_valid():
+                result = {
+                    "url": "tel:" + form.cleaned_data["phone_number"],
+                    "title": form.cleaned_data["link_text"].strip()
+                    or form.cleaned_data["phone_number"],
+                    # If the user has explicitly entered / edited something in the link_text field,
+                    # always use that text. If not, we should favour keeping the existing link/selection
+                    # text, where applicable.
+                    "prefer_this_title_as_link_text": (
+                        "link_text" in form.changed_data
+                    ),
+                }
+                return render_modal_workflow(
+                    request,
+                    None,
+                    None,
+                    None,
+                    json_data={"step": "external_link_chosen", "result": result},
+                )
+        else:
+            form = PhoneLinkChooserForm(
+                initial=initial_data, prefix="phone-link-chooser"
+            )
+
+        return render_modal_workflow(
             request,
-            {
-                "form": form,
-            },
-        ),
-        json_data={"step": "email_link"},
-    )
-
-
-def phone_link(request):
-    initial_data = {
-        "link_text": request.GET.get("link_text", ""),
-        "phone_number": request.GET.get("link_url", ""),
-    }
-
-    if request.method == "POST":
-        form = PhoneLinkChooserForm(
-            request.POST, initial=initial_data, prefix="phone-link-chooser"
+            "wagtailadmin/chooser/phone_link.html",
+            None,
+            shared_context(
+                request,
+                {
+                    "form": form,
+                },
+            ),
+            json_data={"step": "phone_link"},
         )
-
-        if form.is_valid():
-            result = {
-                "url": "tel:" + form.cleaned_data["phone_number"],
-                "title": form.cleaned_data["link_text"].strip()
-                or form.cleaned_data["phone_number"],
-                # If the user has explicitly entered / edited something in the link_text field,
-                # always use that text. If not, we should favour keeping the existing link/selection
-                # text, where applicable.
-                "prefer_this_title_as_link_text": ("link_text" in form.changed_data),
-            }
-            return render_modal_workflow(
-                request,
-                None,
-                None,
-                None,
-                json_data={"step": "external_link_chosen", "result": result},
-            )
-    else:
-        form = PhoneLinkChooserForm(initial=initial_data, prefix="phone-link-chooser")
-
-    return render_modal_workflow(
-        request,
-        "wagtailadmin/chooser/phone_link.html",
-        None,
-        shared_context(
-            request,
-            {
-                "form": form,
-            },
-        ),
-        json_data={"step": "phone_link"},
-    )


### PR DESCRIPTION
Some standalone cleanup work on the page chooser that can be reviewed independently of the generic chooser rewrites.

(After getting this far I'm not sure if it's realistic to port this to the generic chooser framework, or whether it's just too custom, but at least this is some useful refactoring while I ponder further...)