### PR TITLE
Add a border around modal dialogs so they can be identified in forced colors mode. Fixes #8833

### DIFF
--- a/client/scss/components/_dialog.scss
+++ b/client/scss/components/_dialog.scss
@@ -107,6 +107,10 @@
     align-items: center;
     padding: theme('spacing.5');
 
+    @media (forced-colors: $media-forced-colours) {
+      border-bottom: 1px solid currentColor;
+    }
+
     &--info {
       background: theme('colors.info.50');
       color: theme('colors.info.100');

--- a/client/scss/components/_dialog.scss
+++ b/client/scss/components/_dialog.scss
@@ -37,6 +37,9 @@
     @include media-breakpoint-up(sm) {
       width: 600px;
     }
+    @media (forced-colors: $media-forced-colours) {
+      border: 5px solid currentColor;
+    }
   }
 
   &__close-button {


### PR DESCRIPTION
<!--
Thanks for contributing to Wagtail! 🎉

Before submitting, please review the [contributor guidelines](https://docs.wagtail.org/en/latest/contributing/index.html).
-->

_Please check the following:_

-   [ ] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [x] **Please list the exact browser and operating system versions you tested**: Operating System : Windows 11; Browser : Chrome
    -   [x] **Please list which assistive technologies [^3] you tested**: Windows High Contrast with following mode : NIght Sky,Desert,Dusk,Aquatic

**Please describe additional details for testing this change**.

To make the modal look distinctly visible in light and dark modes of windows high contrast themes, borders were added to the modal box. The changes were made in the following file (file path): `\client\scss\components\_dialog.scss`

Below are screenshots this PR reflects:

![Screenshot (135)](https://user-images.githubusercontent.com/52713215/179807348-2299145d-6efa-4ee2-9073-f2a2190f6934.png)

![Screenshot (136)](https://user-images.githubusercontent.com/52713215/179807397-a089cddb-ac8f-41c9-bd34-d71f038f8381.png)

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
