### PR TITLE
Add bottom border to messages. Fixes #8836

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -76,6 +76,7 @@ Changelog
  * Add an extra confirmation prompt when deleting pages with a large number of child pages (Jaspreet Singh)
  * Adopt the slim header in page listing views, with buttons moved under the "Actions" dropdown (Paarth Agarwal)
  * Improve help block styles in Windows High Contrast Mode with less reliance on communication via colour alone (Anuja Verma)
+ * Add a bottom border to top messages so they stand out from the header (Anuja Verma)
  * Replace latin abbreviations (i.e. / e.g.) with common English phrases so that documentation is easier to understand (Dominik Lech)
  * Add shortcut for accessing StreamField blocks by block name with new `blocks_by_name` and `first_block_by_name` methods on `StreamValue` (Tidiane Dia, Matt Westcott)
  * Extend support for custom user interface colours across almost all admin colours (Thibaud Colas)

--- a/client/scss/components/_messages.scss
+++ b/client/scss/components/_messages.scss
@@ -20,6 +20,7 @@
     // @include nice-padding;
     padding: 1.6em 3em 1.6em 1.6em;
     color: $color-white;
+    border-bottom: 1px solid transparent;
   }
 
   > ul > li:before {

--- a/docs/releases/4.0.md
+++ b/docs/releases/4.0.md
@@ -100,6 +100,7 @@ In Wagtail 2.12, we introduced theming support for Wagtail’s primary brand col
  * Add an extra confirmation prompt when deleting pages with a large number of child pages (Jaspreet Singh)
  * Adopt the slim header in page listing views, with buttons moved under the "Actions" dropdown (Paarth Agarwal)
  * Improve help block styles in Windows High Contrast Mode with less reliance on communication via colour alone (Anuja Verma)
+ * Add a bottom border to top messages so they stand out from the header (Anuja Verma)
  * Replace latin abbreviations (i.e. / e.g.) with common English phrases so that documentation is easier to understand (Dominik Lech)
  * Add shortcut for accessing StreamField blocks by block name with new [`blocks_by_name` and `first_block_by_name` methods on `StreamValue`](streamfield_retrieving_blocks_by_name) (Tidiane Dia, Matt Westcott)
  * Add HTML-aware max_length validation on RichTextField and RichTextBlock (Matt Westcott)


### PR DESCRIPTION
<!--
Thanks for contributing to Wagtail! 🎉

Before submitting, please review the [contributor guidelines](https://docs.wagtail.org/en/latest/contributing/index.html).
-->

_Please check the following:_

-   [ ] Do the tests still pass?[^1]
-   [ ] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [x] **Please list the exact browser and operating system versions you tested**: Operating System : Windows 11, Browser: Chrome
    -   [x] **Please list which assistive technologies [^3] you tested**: Windows High Contrast Modes: Aquatic,Dusk,Desert,Night Sky

**Please describe additional details for testing this change**.

To allow a distinct visual style for messages over high contrast mode, transparent bottom borders are added in this PR(as suggested in the issue #8836). The changes are ade in the file(file path)- `client\scss\components\_messages.scss`

Below are the screenshots for the changes reflected in this PR:

![Screenshot (138)](https://user-images.githubusercontent.com/52713215/179814085-36945060-7e19-462b-96bf-fbb41d867eb4.png)

![Screenshot (137)](https://user-images.githubusercontent.com/52713215/179814121-7b79a7b3-4f2c-484e-808f-07b87e4360b2.png)


[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
