### PR TITLE
documentation - fix table of contents issue for pages reference

### DIFF
--- a/docs/reference/pages/index.md
+++ b/docs/reference/pages/index.md
@@ -8,9 +8,8 @@ The presentation of your content, the actual webpages, includes the normal use o
 
 ```{toctree}
 ---
-:maxdepth: 2
+maxdepth: 2
 ---
-
 theory
 model_recipes
 panels


### PR DESCRIPTION
- introduced in bc0f561240c702ecdd1acb7d07eb1212f22551fc
- TOC was not correctly migrated from RST which meant all pages under reference/pages would not show correctly