### PR TITLE
Updated help block colors

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -113,6 +113,7 @@ Changelog
  * Fix: Remove outdated reference to 30-character limit on usernames in help text (minusf)
  * Fix: Resolve multiple form submissions index listing page layout issues including title not being visible on mobile and interaction with large tables (Paarth Agarwal)
  * Fix: Ensure ModelAdmin single selection lists show correctly with Django 4.0 form template changes (Coen van der Kamp)
+ * Fix: Ensure icons within help blocks have accessible contrasting colours, and links have a darker colour plus underline to indicate they are links (Paarth Agarwal)
 
 
 3.0.1 (16.06.2022)

--- a/client/scss/components/_help-block.scss
+++ b/client/scss/components/_help-block.scss
@@ -16,7 +16,14 @@
   }
 
   a {
-    color: $color-link;
+    color: theme('colors.secondary.DEFAULT');
+    text-decoration: underline;
+    text-decoration-thickness: 2px;
+    text-underline-offset: 3px;
+
+    &:hover {
+      text-decoration: none;
+    }
   }
 }
 
@@ -47,7 +54,7 @@
   background-color: theme('colors.warning.50');
 
   .icon-warning {
-    color: theme('colors.warning.100');
+    color: theme('colors.primary.DEFAULT');
   }
 }
 

--- a/docs/releases/4.0.md
+++ b/docs/releases/4.0.md
@@ -143,6 +143,7 @@ In Wagtail 2.16, we introduced support for Windows High Contrast mode (WHCM). Th
  * Remove outdated reference to 30-character limit on usernames in help text (minusf)
  * Resolve multiple form submissions index listing page layout issues including title not being visible on mobile and interaction with large tables (Paarth Agarwal)
  * Ensure ModelAdmin single selection lists show correctly with Django 4.0 form template changes (Coen van der Kamp)
+ * Ensure icons within help blocks have accessible contrasting colours, and links have a darker colour plus underline to indicate they are links (Paarth Agarwal)
 
 
 ## Upgrade considerations


### PR DESCRIPTION
Fixes #8791.
Before:
![Screenshot from 2022-07-23 19-27-09](https://user-images.githubusercontent.com/86092410/180608229-0c5f8600-02ed-42ee-8f43-2d7fc48acd14.png)

After:
![Screenshot from 2022-07-23 19-14-26](https://user-images.githubusercontent.com/86092410/180608242-fc288623-ced2-43f1-8197-5819b0fbaef8.png)

I've changed the text colour of links present in help-block to theme('colors.secondary.100') because we haven't defined '200' variant.
