### PR TITLE
Added border to tooltip dropdown for high contrast

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -151,6 +151,7 @@ Changelog
  * Fix: Prevent comment buttons from overlapping with fields (Thibaud Colas)
  * Fix: Resolve MySQL search compatibility issue with Django 4.1 (Andy Chosak)
  * Fix: Ensure that the fields on login and password reset forms are visible in forced colors mode (Paarth Agarwal)
+ * Fix: Missing a outline on dropdown content and malformed tooltip arrow in forced colors mode (Anuja Verma, LB (Ben) Johnston)
 
 
 3.0.1 (16.06.2022)

--- a/client/scss/components/_dropdown.scss
+++ b/client/scss/components/_dropdown.scss
@@ -74,6 +74,10 @@
   // Override any right alignment that might've been set by a parent element
   // (such as the snippets header)
   text-align: start;
+
+  @media (forced-colors: active) {
+    border: 2px solid transparent;
+  }
 }
 
 .c-dropdown__item {

--- a/client/scss/overrides/_utilities.dropdowns.scss
+++ b/client/scss/overrides/_utilities.dropdowns.scss
@@ -3,9 +3,12 @@
 // =============================================================================
 .u-arrow:before {
   content: '';
-  border: solid 0.35rem transparent;
+  background: transparent;
   display: block;
   position: absolute;
+  clip-path: polygon(50% 0, 0 100%, 100% 100%);
+  height: 0.5rem;
+  width: 0.75rem;
 }
 
 .u-arrow--tl:before {
@@ -21,10 +24,6 @@
 // =============================================================================
 //  Default dropdown theme
 // =============================================================================
-
-// .t-default {
-
-// }
 .t-default .u-btn-current {
   border-color: $color-grey-4;
   color: $color-teal;
@@ -63,7 +62,11 @@
 }
 
 .t-dark .u-arrow:before {
-  border-bottom-color: $color-grey-1;
+  background-color: $color-grey-1;
+
+  @media (forced-colors: active) {
+    background-color: ButtonText;
+  }
 }
 
 // =============================================================================

--- a/docs/releases/4.0.md
+++ b/docs/releases/4.0.md
@@ -68,6 +68,7 @@ In Wagtail 2.16, we introduced support for Windows High Contrast mode (WHCM). Th
 * Add a border around modal dialogs so they can be identified in forced colors mode
 * Ensure disabled buttons are distinguishable from active buttons in forced colors mode
 * Ensure that the fields on login and password reset forms are visible in forced colors mode
+* Missing a outline on dropdown content and malformed tooltip arrow in forced colors mode
 
 ### UX unification and consistency improvements
 


### PR DESCRIPTION
<!--
Thanks for contributing to Wagtail! 🎉

Before submitting, please review the [contributor guidelines](https://docs.wagtail.org/en/latest/contributing/index.html).
-->

_Please check the following:_

-   [ ] Do the tests still pass?[^1]
-   [ ] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [x] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [x] **Please list the exact browser and operating system versions you tested**: Operating System- Windows 11, Browser- Chrome
    -   [x] **Please list which assistive technologies [^3] you tested**: Windows 11 contrast themes- Aquatic, Desert,Dusk,Night Sky

**Please describe additional details for testing this change**.
This PR fixes #8830 
This PR adds a border to the tooltip dropdown to allow it to be visible distinctly from the background in windows high contrast modes. The file changed : `\client\scss\components\_dropdown.scss`
Below are screenshots relating to the changes in reference to this PR

![Screenshot (147)](https://user-images.githubusercontent.com/52713215/180615646-9c431098-570f-47f5-8b85-38bd65fa9a44.png)

![Screenshot (148)](https://user-images.githubusercontent.com/52713215/180615657-bfffe95e-4956-4f6d-93b7-ac33a2c9826b.png)


[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
