### PR TITLE
Docs: Make it easier to understand where to place a ModelAdmin

### DIFF
--- a/docs/reference/contrib/modeladmin/index.md
+++ b/docs/reference/contrib/modeladmin/index.md
@@ -2,6 +2,8 @@
 
 The `modeladmin` module allows you to add any model in your project to the Wagtail admin. You can create customisable listing pages for a model, including plain Django models, and add navigation elements so that a model can be accessed directly from the Wagtail admin. Simply extend the `ModelAdmin` class, override a few attributes to suit your needs, register it with Wagtail using an easy one-line `modeladmin_register` method (you can copy and paste from the examples below), and you're good to go. Your model doesn’t need to extend `Page` or be registered as a `Snippet`, and it won’t interfere with any of the existing admin functionality that Wagtail provides.
 
+We follow an already existing pattern in Django: The appropriate place to create your Wagtail `ModelAdmin` classes and call `modeladmin_register` is in your app's `admin.py`, alongside any custom Django admin class definitions.
+
 (modeladmin_feature_summary)=
 
 ## Summary of features


### PR DESCRIPTION
I had difficulty understanding where the class definitions of ModelAdmins should be located and registered. Of course the answer m
_Please check the following:_

-   [ ] Do the tests still pass?[^1]
-   [ ] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
