### PR TITLE
Adopted non collapsible breadcrumbs for root page

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/pages/page_listing_header.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/page_listing_header.html
@@ -2,11 +2,16 @@
 {% load wagtailadmin_tags i18n %}
 
 {% block header_content %}
-    {% breadcrumbs parent_page 'wagtailadmin_explore' url_root_name='wagtailadmin_explore_root' %}
-
+    {# Accessible page title #}
     <h1 class="w-sr-only">
         {{ title }}
     </h1>
+    {# breadcrumbs #}
+    {% if parent_page.is_root %}
+        <div class="w-pl-3">{% breadcrumbs parent_page 'wagtailadmin_explore' url_root_name='wagtailadmin_explore_root' is_expanded=True %}</div>
+    {% else %}
+        {% breadcrumbs parent_page 'wagtailadmin_explore' url_root_name='wagtailadmin_explore_root' %}
+    {% endif %}
     {# Actions divider #}
     <div class="w-w-px w-h-[30px] w-ml-auto sm:w-ml-0 w-bg-grey-100"></div>
     {# Page actions dropdown #}


### PR DESCRIPTION
Addresses #8539.
I have adopted non-collapsible breadcrumbs on the root page.

Before:

![Screenshot from 2022-07-26 16-17-39](https://user-images.githubusercontent.com/86092410/180988777-46eb3e97-ba5e-440a-b0c8-0a8101f2d2f7.png)

After:

![Screenshot from 2022-07-26 16-12-42](https://user-images.githubusercontent.com/86092410/180988616-a3f810e0-f90b-4fc4-8c12-552b896aaf79.png)
 
