### PR TITLE
Added a border to the input feild for high contrast visibility

### DIFF
--- a/client/scss/layouts/_login.scss
+++ b/client/scss/layouts/_login.scss
@@ -71,7 +71,7 @@ $desktop-nice-padding: 100px;
       }
 
       input {
-        border-top: 1px dashed $color-input-border;
+        border: 1px dashed $color-input-border;
       }
     }
 

--- a/client/scss/layouts/_login.scss
+++ b/client/scss/layouts/_login.scss
@@ -82,7 +82,11 @@ $desktop-nice-padding: 100px;
     }
 
     &:first-child input {
-      border: 2px solid transparent;
+      /* stylelint-disable max-nesting-depth */
+      @media (forced-colors: active) {
+        border: 2px solid transparent;
+      }
+      /* stylelint-enable max-nesting-depth */
     }
   }
 

--- a/client/scss/layouts/_login.scss
+++ b/client/scss/layouts/_login.scss
@@ -71,7 +71,13 @@ $desktop-nice-padding: 100px;
       }
 
       input {
-        border: 1px dashed $color-input-border;
+        border-top: 1px dashed $color-input-border;
+
+        /* stylelint-disable max-nesting-depth */
+        @media (forced-colors: active) {
+          border: 2px solid $color-input-border;
+        }
+        /* stylelint-enable max-nesting-depth */
       }
     }
 

--- a/client/scss/layouts/_login.scss
+++ b/client/scss/layouts/_login.scss
@@ -76,7 +76,7 @@ $desktop-nice-padding: 100px;
     }
 
     &:first-child input {
-      border: 0;
+      border: 2 px transparent;
     }
   }
 

--- a/client/scss/layouts/_login.scss
+++ b/client/scss/layouts/_login.scss
@@ -76,7 +76,7 @@ $desktop-nice-padding: 100px;
     }
 
     &:first-child input {
-      border: 2 px transparent;
+      border: 2px solid transparent;
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for contributing to Wagtail! 🎉

Before submitting, please review the [contributor guidelines](https://docs.wagtail.org/en/latest/contributing/index.html).
-->

_Please check the following:_

-   [ ] Do the tests still pass?[^1]
-   [ ] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [x] **Please list the exact browser and operating system versions you tested**: Operating System - Windows 11, Browser- Chrome
    -   [x] **Please list which assistive technologies [^3] you tested**: Windows High Contrast Themes - Aquatic,Desert,Dusk,Night Sky

**Please describe additional details for testing this change**.

Thi PR fixes #8837 
Added transparent borders to the input feilds. The change has been made in file(file path)- `client\scss\layouts\_login.scss`
The Screenshots showing the results of this PR are below
Dark Modes:

![Screenshot (155)](https://user-images.githubusercontent.com/52713215/181005597-c5b4adc0-e23d-4e9e-85d5-b43cb43f17dc.png)

Light Modes:

![Screenshot (154)](https://user-images.githubusercontent.com/52713215/181005647-f08daf33-6d0a-4dbb-afd4-fb429b47caaf.png)

Login form feild(Dark Mode)

![Screenshot (175)](https://user-images.githubusercontent.com/52713215/181303876-8a4a2ab2-06c5-4ba7-8d2e-9a0902333022.png)


[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
