### PR TITLE
Ensure consistent sidebar icon position whether expanded or collapsed

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -115,6 +115,7 @@ Changelog
  * Fix: Resolve multiple form submissions index listing page layout issues including title not being visible on mobile and interaction with large tables (Paarth Agarwal)
  * Fix: Ensure ModelAdmin single selection lists show correctly with Django 4.0 form template changes (Coen van der Kamp)
  * Fix: Ensure icons within help blocks have accessible contrasting colours, and links have a darker colour plus underline to indicate they are links (Paarth Agarwal)
+ * Fix: Ensure consistent sidebar icon position whether expanded or collapsed (Scott Cranfill)
 
 
 3.0.1 (16.06.2022)

--- a/client/src/components/Sidebar/Sidebar.scss
+++ b/client/src/components/Sidebar/Sidebar.scss
@@ -48,6 +48,8 @@
     width: 1rem;
     height: 1rem;
     min-width: 1rem;
+    // Ensure consistent button height in collapsed state where no text line-height is adding 1.5px.
+    margin: 0.046875rem 0;
   }
 
   &--slim {

--- a/client/src/components/Sidebar/menu/MenuItem.scss
+++ b/client/src/components/Sidebar/menu/MenuItem.scss
@@ -43,7 +43,8 @@
       font-size: 1rem;
       display: flex;
       align-items: center;
-      margin-inline-end: 0;
+      // Ensure consistent button height in collapsed state where no text line-height is adding 1.5px.
+      margin: 0.046875rem 0;
     }
 
     // only really used for spinners and settings menu

--- a/docs/releases/4.0.md
+++ b/docs/releases/4.0.md
@@ -145,6 +145,7 @@ In Wagtail 2.16, we introduced support for Windows High Contrast mode (WHCM). Th
  * Resolve multiple form submissions index listing page layout issues including title not being visible on mobile and interaction with large tables (Paarth Agarwal)
  * Ensure ModelAdmin single selection lists show correctly with Django 4.0 form template changes (Coen van der Kamp)
  * Ensure icons within help blocks have accessible contrasting colours, and links have a darker colour plus underline to indicate they are links (Paarth Agarwal)
+ * Ensure consistent sidebar icon position whether expanded or collapsed (Scott Cranfill)
 
 
 ## Upgrade considerations


### PR DESCRIPTION
I noticed that the sidebar icons shift up slightly in the collapsed state, compared to the expanded state:

![Wagtail sidebar - collapsed on left, expanded on right](https://user-images.githubusercontent.com/1044670/181084845-528de426-9e77-4680-b718-f1454b12b6a1.png)

When the sidebar is expanded and the text is present, the line-height of the text gives the buttons an additional 1.5px of height. Adding vertical margin to the icons gives them same height as the text's line-height, resulting in consistent positioning in both states.

---

_Please check the following:_

-   [ ] Do the tests still pass?[^1]
-   [ ] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
