### PR TITLE
Move page locking logic into and create a `LockableMixin`

### DIFF
--- a/wagtail/admin/action_menu.py
+++ b/wagtail/admin/action_menu.py
@@ -44,11 +44,10 @@ class ActionMenuItem(Component):
             'user_page_permissions' = a UserPagePermissionsProxy for the current user, to test permissions against
             may also contain:
             'user_page_permissions_tester' = a PagePermissionTester for the current user and page
+            'lock' = a Lock object if the page is locked, otherwise None
+            'locked_for_user' = True if the lock prevents the current user from editing the page
         """
-        return (
-            context["view"] == "create"
-            or not self.get_user_page_permissions_tester(context).page_locked()
-        )
+        return context["view"] == "create" or not context["locked_for_user"]
 
     def get_context_data(self, parent_context):
         """Defines context for the template, overridable to use more data"""
@@ -86,7 +85,7 @@ class PublishMenuItem(ActionMenuItem):
             )
         else:  # view == 'edit' or 'revisions_revert'
             perms_tester = self.get_user_page_permissions_tester(context)
-            return not perms_tester.page_locked() and perms_tester.can_publish()
+            return not context["locked_for_user"] and perms_tester.can_publish()
 
     def get_context_data(self, parent_context):
         context = super().get_context_data(parent_context)
@@ -110,7 +109,7 @@ class SubmitForModerationMenuItem(ActionMenuItem):
             perms_tester = self.get_user_page_permissions_tester(context)
             return (
                 perms_tester.can_submit_for_moderation()
-                and not perms_tester.page_locked()
+                and not context["locked_for_user"]
             )
         # context == revisions_revert
         return False
@@ -154,8 +153,7 @@ class WorkflowMenuItem(ActionMenuItem):
 
     def is_shown(self, context):
         if context["view"] == "edit":
-            perms_tester = self.get_user_page_permissions_tester(context)
-            return not perms_tester.page_locked()
+            return not context["locked_for_user"]
 
 
 class RestartWorkflowMenuItem(ActionMenuItem):
@@ -172,7 +170,7 @@ class RestartWorkflowMenuItem(ActionMenuItem):
             perms_tester = self.get_user_page_permissions_tester(context)
             return (
                 perms_tester.can_submit_for_moderation()
-                and not perms_tester.page_locked()
+                and not context["locked_for_user"]
                 and workflow_state
                 and workflow_state.user_can_cancel(context["request"].user)
             )
@@ -203,7 +201,7 @@ class UnpublishMenuItem(ActionMenuItem):
     def is_shown(self, context):
         if context["view"] == "edit":
             perms_tester = self.get_user_page_permissions_tester(context)
-            return not perms_tester.page_locked() and perms_tester.can_unpublish()
+            return not context["locked_for_user"] and perms_tester.can_unpublish()
 
     def get_url(self, context):
         return reverse("wagtailadmin_pages:unpublish", args=(context["page"].id,))
@@ -218,7 +216,7 @@ class DeleteMenuItem(ActionMenuItem):
     def is_shown(self, context):
         if context["view"] == "edit":
             perms_tester = self.get_user_page_permissions_tester(context)
-            return not perms_tester.page_locked() and perms_tester.can_delete()
+            return not context["locked_for_user"] and perms_tester.can_delete()
 
     def get_url(self, context):
         return reverse("wagtailadmin_pages:delete", args=(context["page"].id,))
@@ -241,10 +239,7 @@ class PageLockedMenuItem(ActionMenuItem):
     template_name = "wagtailadmin/pages/action_menu/page_locked.html"
 
     def is_shown(self, context):
-        return (
-            "page" in context
-            and self.get_user_page_permissions_tester(context).page_locked()
-        )
+        return "page" in context and context["locked_for_user"]
 
     def get_context_data(self, parent_context):
         context = super().get_context_data(parent_context)

--- a/wagtail/admin/templates/wagtailadmin/shared/side_panels/includes/status/locked.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/side_panels/includes/status/locked.html
@@ -4,15 +4,31 @@
 {% block content %}
     {% trans 'Page locking: ' as screen_reader_title_prefix %}
 
-    {% if page.locked %}
+    {% if lock %}
         {% trans 'Locked' as title %}
-        {% trans 'Only you can edit this page. Unlock it to allow others to edit' as help_text %}
+
+        {% if not locked_for_user and user_can_unlock %}
+            {% trans 'You can edit this page, but others may not. Unlock it to allow others to edit.' as help_text %}
+        {% elif not locked_for_user %}
+            {% trans 'You can edit this page, but others may not.' as help_text %}
+        {% elif user_can_unlock %}
+            {% trans 'You cannot edit this page. Unlock it to edit.' as help_text %}
+        {% else %}
+            {% trans 'You cannot edit this page.' as help_text %}
+        {% endif %}
+
         {% with icon_name='lock' %}
             {{ block.super }}
         {% endwith %}
     {% else %}
         {% trans 'Unlocked' as title %}
-        {% trans 'Anyone can edit this page. Lock it to prevent others from editing' as help_text %}
+
+        {% if user_can_lock %}
+            {% trans 'Anyone can edit this page. Lock it to prevent others from editing.' as help_text %}
+        {% else %}
+            {% trans 'Anyone can edit this page.' as help_text %}
+        {% endif %}
+
         {% with icon_name='lock-open' %}
             {{ block.super }}
         {% endwith %}
@@ -20,12 +36,12 @@
 {% endblock %}
 
 {% block action %}
-    {% if user_can_unlock and page.locked %}
+    {% if user_can_unlock and lock %}
         {% url 'wagtailadmin_pages:unlock' page.id as unlock_url %}
         {% trans 'Unlock' as unlock_text %}
         {% include 'wagtailadmin/shared/side_panels/includes/side_panel_button.html' with attr='data-action-lock-unlock' data_url=unlock_url text=unlock_text %}
     {% endif %}
-    {% if user_can_lock and not page.locked %}
+    {% if user_can_lock and not lock %}
         {% url 'wagtailadmin_pages:lock' page.id as lock_url %}
         {% trans 'Lock' as lock_text %}
         {% include 'wagtailadmin/shared/side_panels/includes/side_panel_button.html' with attr='data-action-lock-unlock' data_url=lock_url text=lock_text %}

--- a/wagtail/admin/views/pages/create.py
+++ b/wagtail/admin/views/pages/create.py
@@ -328,7 +328,11 @@ class CreateView(TemplateResponseMixin, ContextMixin, HookResponseMixin, View):
             request=self.request, instance=self.page, form=self.form
         )
         action_menu = PageActionMenu(
-            self.request, view="create", parent_page=self.parent_page
+            self.request,
+            view="create",
+            parent_page=self.parent_page,
+            lock=None,
+            locked_for_user=False,
         )
         side_panels = PageSidePanels(
             self.request,

--- a/wagtail/admin/views/pages/edit.py
+++ b/wagtail/admin/views/pages/edit.py
@@ -815,7 +815,13 @@ class EditView(TemplateResponseMixin, ContextMixin, HookResponseMixin, View):
         bound_panel = self.edit_handler.get_bound_panel(
             instance=self.page, request=self.request, form=self.form
         )
-        action_menu = PageActionMenu(self.request, view="edit", page=self.page)
+        action_menu = PageActionMenu(
+            self.request,
+            view="edit",
+            page=self.page,
+            lock=self.lock,
+            locked_for_user=self.locked_for_user,
+        )
         side_panels = PageSidePanels(
             self.request,
             self.page_for_status,

--- a/wagtail/admin/views/pages/edit.py
+++ b/wagtail/admin/views/pages/edit.py
@@ -10,7 +10,6 @@ from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.html import format_html
-from django.utils.safestring import mark_safe
 from django.utils.translation import gettext as _
 from django.views.generic.base import ContextMixin, TemplateResponseMixin, View
 
@@ -22,6 +21,7 @@ from wagtail.admin.ui.side_panels import PageSidePanels
 from wagtail.admin.views.generic import HookResponseMixin
 from wagtail.admin.views.pages.utils import get_valid_next_url_from_request
 from wagtail.exceptions import PageClassNotFoundError
+from wagtail.locks import BasicLock
 from wagtail.models import (
     COMMENTS_RELATION_NAME,
     Comment,
@@ -334,6 +334,10 @@ class EditView(TemplateResponseMixin, ContextMixin, HookResponseMixin, View):
         self.parent = self.page.get_parent()
 
         self.page_perms = self.page.permissions_for_user(self.request.user)
+        self.lock = self.page.get_lock()
+        self.locked_for_user = self.lock is not None and self.lock.for_user(
+            self.request.user
+        )
 
         if not self.page_perms.can_edit():
             raise PermissionDenied
@@ -375,79 +379,21 @@ class EditView(TemplateResponseMixin, ContextMixin, HookResponseMixin, View):
         return super().dispatch(request)
 
     def get(self, request):
-        if self.page_perms.user_has_lock():
-            if self.page.locked_at:
-                lock_message = format_html(
-                    _("<b>Page '{}' was locked</b> by <b>you</b> on <b>{}</b>."),
-                    self.page.get_admin_display_title(),
-                    self.page.locked_at.strftime("%d %b %Y %H:%M"),
-                )
-            else:
-                lock_message = format_html(
-                    _("<b>Page '{}' is locked</b> by <b>you</b>."),
-                    self.page.get_admin_display_title(),
-                )
-
-            lock_message += format_html(
-                '<span class="buttons"><button type="button" class="button button-small button-secondary" data-action-lock-unlock data-url="{}">{}</button></span>',
-                reverse("wagtailadmin_pages:unlock", args=(self.page.id,)),
-                _("Unlock"),
-            )
-            messages.warning(self.request, lock_message, extra_tags="lock")
-
-        elif self.page.locked and self.page_perms.page_locked():
-            # the page can also be locked at a permissions level if in a workflow, on a task the user is not a reviewer for
-            # this should be indicated separately
-            if self.page.locked_by and self.page.locked_at:
-                lock_message = format_html(
-                    _("<b>Page '{}' was locked</b> by <b>{}</b> on <b>{}</b>."),
-                    self.page.get_admin_display_title(),
-                    str(self.page.locked_by),
-                    self.page.locked_at.strftime("%d %b %Y %H:%M"),
-                )
-            else:
-                # Page was probably locked with an old version of Wagtail, or a script
-                lock_message = format_html(
-                    _("<b>Page '{}' is locked</b>."),
-                    self.page.get_admin_display_title(),
-                )
-
-            if self.page_perms.can_unlock():
-                lock_message += format_html(
-                    '<span class="buttons"><button type="button" class="button button-small button-secondary" data-action-lock-unlock data-url="{}">{}</button></span>',
-                    reverse("wagtailadmin_pages:unlock", args=(self.page.id,)),
-                    _("Unlock"),
-                )
-            messages.error(self.request, lock_message, extra_tags="lock")
-
-        if self.page.current_workflow_state:
-            workflow = self.workflow_state.workflow
-            task = self.workflow_state.current_task_state.task
-            if (
-                self.workflow_state.status != WorkflowState.STATUS_NEEDS_CHANGES
-                and task.specific.page_locked_for_user(self.page, self.request.user)
-            ):
-                # Check for revisions still undergoing moderation and warn
-                if len(self.workflow_tasks) == 1:
-                    # If only one task in workflow, show simple message
-                    workflow_info = _("This page is currently awaiting moderation.")
-                else:
-                    workflow_info = format_html(
-                        _(
-                            "This page is awaiting <b>'{}'</b> in the <b>'{}'</b> workflow."
-                        ),
-                        task.name,
-                        workflow.name,
+        if self.lock:
+            lock_message = self.lock.get_message(self.request.user)
+            if lock_message:
+                if isinstance(self.lock, BasicLock) and self.page_perms.can_unlock():
+                    lock_message = format_html(
+                        '{} <span class="buttons"><button type="button" class="button button-small button-secondary" data-action-lock-unlock data-url="{}">{}</button></span>',
+                        lock_message,
+                        reverse("wagtailadmin_pages:unlock", args=(self.page.id,)),
+                        _("Unlock"),
                     )
-                messages.error(
-                    self.request,
-                    mark_safe(
-                        workflow_info
-                        + " "
-                        + _("Only reviewers for this task can edit the page.")
-                    ),
-                    extra_tags="lock",
-                )
+
+                if self.locked_for_user:
+                    messages.error(self.request, lock_message, extra_tags="lock")
+                else:
+                    messages.warning(self.request, lock_message, extra_tags="lock")
 
         self.form = self.form_class(
             instance=self.page,
@@ -496,7 +442,7 @@ class EditView(TemplateResponseMixin, ContextMixin, HookResponseMixin, View):
             and self.workflow_state.user_can_cancel(self.request.user)
         )
 
-        if self.form.is_valid() and not self.page_perms.page_locked():
+        if self.form.is_valid() and not self.locked_for_user:
             return self.form_valid(self.form)
         else:
             return self.form_invalid(self.form)
@@ -840,7 +786,7 @@ class EditView(TemplateResponseMixin, ContextMixin, HookResponseMixin, View):
             self.workflow_state.cancel(user=self.request.user)
             self.add_cancel_workflow_confirmation_message()
 
-        if self.page_perms.page_locked():
+        if self.locked_for_user:
             messages.error(
                 self.request, _("The page could not be saved as it is locked")
             )
@@ -889,7 +835,7 @@ class EditView(TemplateResponseMixin, ContextMixin, HookResponseMixin, View):
                 "form": self.form,
                 "next": self.next_url,
                 "has_unsaved_changes": self.has_unsaved_changes,
-                "page_locked": self.page_perms.page_locked(),
+                "page_locked": self.locked_for_user,
                 "workflow_state": self.workflow_state
                 if self.workflow_state and self.workflow_state.is_active
                 else None,

--- a/wagtail/admin/views/pages/revisions.py
+++ b/wagtail/admin/views/pages/revisions.py
@@ -43,7 +43,15 @@ def revisions_revert(request, page_id, revision_id):
         instance=revision_page, request=request, form=form
     )
 
-    action_menu = PageActionMenu(request, view="revisions_revert", page=page)
+    lock = page.get_lock()
+
+    action_menu = PageActionMenu(
+        request,
+        view="revisions_revert",
+        page=page,
+        lock=lock,
+        locked_for_user=lock is not None and lock.for_user(request.user),
+    )
     side_panels = PageSidePanels(
         request,
         page,

--- a/wagtail/locks.py
+++ b/wagtail/locks.py
@@ -1,0 +1,48 @@
+from django.conf import settings
+
+
+class BaseLock:
+    """
+    Holds information about a lock on an object.
+
+    Returned by LockableMixin.get_lock() (or Page.get_lock()).
+    """
+
+    def for_user(self, user):
+        """
+        Returns True if the lock applies to the given user.
+        """
+        return NotImplemented
+
+
+class BasicLock(BaseLock):
+    """
+    A lock that is enabled when the "locked" attribute of a page is True.
+
+    The object may be editable by a user depending on whether the locked_by field is set
+    and if WAGTAILADMIN_GLOBAL_PAGE_EDIT_LOCK is not set to True.
+    """
+
+    def __init__(self, page):
+        self.page = page
+
+    def for_user(self, user):
+        if getattr(settings, "WAGTAILADMIN_GLOBAL_PAGE_EDIT_LOCK", False):
+            return True
+        else:
+            return user.pk != self.page.locked_by_id
+
+
+class WorkflowLock(BaseLock):
+    """
+    A lock that requires the user to pass the Task.page_locked_for_user test on the given workflow task.
+
+    Can be applied to pages only.
+    """
+
+    def __init__(self, task, page):
+        self.task = task
+        self.page = page
+
+    def for_user(self, user):
+        return self.task.page_locked_for_user(self.page, user)


### PR DESCRIPTION
This PR moves the locking logic out of ``UserPagePermissionsProxy`` and onto the page model itself. It also extracts the locking fields and this new ``get_lock`` method into a new mixin.

The mixin is not currently usable on snippets, this will be implemented in a future PR.

I've moved locking out of the permissions proxy for a couple of reasons:

 - I think locking is a separate concern to permissions and it's inconsistent with the way the permissions model in Wagtail works
 - A method on the model allows the locking behaviour to be customised by mixins or on the specific page model

It removes about 20 duplicated queries by adding the locked state to the context in the action menu (all action menu items currently perform `.page_perms.page_locked()`)

This PR also fixes a couple of bugs I've discovered in the info panel:

 - When the page is locked by another user, the following message is shown, even when you don't have permission to unlock "Only you can edit this page, unlock it to allow others to edit"
 - When a page is locked by a workflow task, the info panel says the page is unlocked