### PR TITLE
Remove unneeded float styles on 404 page

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -37,6 +37,7 @@ Changelog
  * Maintenance: Refactor image / document / snippet usage views into a shared generic view (Sage Abdullah)
  * Maintenance: Rename the Stimulus `AutoFieldController` to the less confusing `SubmitController` (Loveth Omokaro)
  * Maintenance: Replace `script` tags with `template` tag for image/document bulk uploads (Rishabh Kumar Bahukhandi)
+ * Maintenance: Remove unneeded float styles on 404 page (Fabien Le Frapper)
 
 
 4.2.1 (xx.xx.xxxx) - IN DEVELOPMENT

--- a/client/scss/layouts/_404.scss
+++ b/client/scss/layouts/_404.scss
@@ -10,7 +10,6 @@
 }
 
 .page404__logo {
-  float: left;
   width: 400px;
   height: 500px;
 
@@ -21,8 +20,8 @@
 }
 
 .page404__text-container {
-  float: right;
   width: 600px;
+
   height: 500px;
   text-align: center;
 }

--- a/docs/releases/5.0.md
+++ b/docs/releases/5.0.md
@@ -56,6 +56,7 @@ depth: 1
  * Refactor image / document / snippet usage views into a shared generic view (Sage Abdullah)
  * Rename the Stimulus `AutoFieldController` to the less confusing `SubmitController` (Loveth Omokaro)
  * Replace `script` tags with `template` tag for image/document bulk uploads (Rishabh Kumar Bahukhandi)
+ * Remove unneeded float styles on 404 page (Fabien Le Frapper)
 
 ## Upgrade considerations
 


### PR DESCRIPTION
Following https://github.com/wagtail/wagtail/issues/8126 

- [x] 404 page
- [ ] page editor 
- [ ] account page
- [ ] report page
- [ ] login page 
- [ ] styleguide
- [ ] no search results img
- [ ] choose parent page


_Please check the following:_

-   [ ] Do the tests still pass?[^1]
-   [ ] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
