### PR TITLE
Implement combined rich text split and block insertion

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -69,6 +69,7 @@ Changelog
  * Add support for right-to-left (RTL) languages to the rich text editor (Thibaud Colas)
  * Change rich text editor placeholder to follow the user’s focus on empty blocks (Thibaud Colas)
  * Add rich text editor empty block highlight by showing their block type (Thibaud Colas)
+ * Add ability to split a rich text field and insert a StreamField block at the same time (Jacob Topp-Mugglestone)
  * Make ModelAdmin InspectView footer actions consistent with other parts of the UI (Thibaud Colas)
  * Introduce a new auto-updating preview panel inside the page editor (Sage Abdullah)
  * Add support for Twitter and other text-only embeds in Draftail embed previews (Iman Syed, Paarth Agarwal)

--- a/client/src/components/Draftail/index.js
+++ b/client/src/components/Draftail/index.js
@@ -5,6 +5,7 @@ import {
   InlineToolbar,
   MetaToolbar,
   CommandPalette,
+  DraftUtils,
 } from 'draftail';
 import { Provider } from 'react-redux';
 
@@ -24,6 +25,7 @@ import MaxLength from './controls/MaxLength';
 import EditorFallback from './EditorFallback/EditorFallback';
 import CommentableEditor, {
   getSplitControl,
+  splitState,
 } from './CommentableEditor/CommentableEditor';
 
 export { default as Link, onPasteLink } from './decorators/Link';
@@ -200,7 +202,9 @@ const initEditor = (selector, originalOptions, currentScript) => {
 export default {
   initEditor,
   getSplitControl,
+  splitState,
   registerPlugin,
+  DraftUtils,
   // Components exposed for third-party reuse.
   ModalWorkflowSource,
   ImageModalWorkflowSource,

--- a/client/src/components/StreamField/blocks/BaseSequenceBlock.js
+++ b/client/src/components/StreamField/blocks/BaseSequenceBlock.js
@@ -192,6 +192,11 @@ export class BaseSequenceChild extends EventEmitter {
       enabled: true,
       fn: this.split.bind(this),
     });
+    capabilities.set('addSibling', {
+      enabled: true,
+      fn: this.addSibling.bind(this),
+      blockGroups: this.sequence.getBlockGroups(),
+    });
 
     this.block = this.blockDef.render(
       blockElement,
@@ -215,6 +220,10 @@ export class BaseSequenceChild extends EventEmitter {
 
   addActionButton(button) {
     button.render(this.actionsContainerElement);
+  }
+
+  addSibling(opts) {
+    this.sequence._onRequestInsert(this.index + 1, opts);
   }
 
   moveUp() {
@@ -391,6 +400,10 @@ export class BaseSequenceBlock {
   }
 
   _getChildDataForInsertion(opts) {
+    throw new Error('not implemented');
+  }
+
+  getBlockGroups() {
     throw new Error('not implemented');
   }
   /* eslint-enable @typescript-eslint/no-unused-vars */

--- a/client/src/components/StreamField/blocks/BaseSequenceBlock.js
+++ b/client/src/components/StreamField/blocks/BaseSequenceBlock.js
@@ -196,6 +196,8 @@ export class BaseSequenceChild extends EventEmitter {
       enabled: true,
       fn: this.addSibling.bind(this),
       blockGroups: this.sequence.getBlockGroups(),
+      getBlockCount: this.sequence.getBlockCount.bind(this.sequence),
+      getBlockMax: this.sequence.getBlockMax.bind(this.sequence),
     });
 
     this.block = this.blockDef.render(

--- a/client/src/components/StreamField/blocks/ListBlock.js
+++ b/client/src/components/StreamField/blocks/ListBlock.js
@@ -296,6 +296,10 @@ export class ListBlock extends BaseSequenceBlock {
       }
     });
   }
+
+  getBlockGroups() {
+    return ['', [this.childBlockDef]];
+  }
 }
 
 export class ListBlockDefinition {

--- a/client/src/components/StreamField/blocks/ListBlock.js
+++ b/client/src/components/StreamField/blocks/ListBlock.js
@@ -290,7 +290,8 @@ export class ListBlock extends BaseSequenceBlock {
   }
 
   getBlockGroups() {
-    return ['', [this.childBlockDef]];
+    const group = ['', [this.blockDef.childBlockDef]];
+    return [group];
   }
 
   getBlockCount() {

--- a/client/src/components/StreamField/blocks/ListBlock.js
+++ b/client/src/components/StreamField/blocks/ListBlock.js
@@ -209,10 +209,6 @@ export class ListBlock extends BaseSequenceBlock {
         for (let i = 0; i < this.inserters.length; i++) {
           this.inserters[i].enable();
         }
-        for (let i = 0; i < this.children.length; i++) {
-          this.children[i].enableDuplication();
-          this.children[i].enableSplit();
-        }
       }
     }
   }

--- a/client/src/components/StreamField/blocks/ListBlock.js
+++ b/client/src/components/StreamField/blocks/ListBlock.js
@@ -300,6 +300,14 @@ export class ListBlock extends BaseSequenceBlock {
   getBlockGroups() {
     return ['', [this.childBlockDef]];
   }
+
+  getBlockCount() {
+    return this.children.length;
+  }
+
+  getBlockMax() {
+    return this.blockDef.meta.maxNum || 0;
+  }
 }
 
 export class ListBlockDefinition {

--- a/client/src/components/StreamField/blocks/ListBlock.js
+++ b/client/src/components/StreamField/blocks/ListBlock.js
@@ -200,10 +200,6 @@ export class ListBlock extends BaseSequenceBlock {
         for (let i = 0; i < this.inserters.length; i++) {
           this.inserters[i].disable();
         }
-        for (let i = 0; i < this.children.length; i++) {
-          this.children[i].disableDuplication();
-          this.children[i].disableSplit();
-        }
       } else {
         /* allow adding new blocks */
         for (let i = 0; i < this.inserters.length; i++) {

--- a/client/src/components/StreamField/blocks/ListBlock.test.js
+++ b/client/src/components/StreamField/blocks/ListBlock.test.js
@@ -360,13 +360,13 @@ describe('telepath: wagtail.blocks.ListBlock with maxNum set', () => {
   };
 
   const assertCannotAddBlock = () => {
-    // Test duplicate button
+    // Test duplicate button is always enabled
     // querySelector always returns the first element it sees so this only checks the first block
     expect(
       document
         .querySelector('button[title="Duplicate"]')
         .getAttribute('disabled'),
-    ).toEqual('disabled');
+    ).toBe(null);
 
     // Test menu
     expect(
@@ -424,55 +424,5 @@ describe('telepath: wagtail.blocks.ListBlock with maxNum set', () => {
     boundBlock.deleteBlock(2);
 
     assertCanAddBlock();
-  });
-
-  test('initialising at maxNum disables split', () => {
-    document.body.innerHTML = '<div id="placeholder"></div>';
-    const boundBlock = blockDef.render($('#placeholder'), 'the-prefix', [
-      { value: 'First value', id: '11111111-1111-1111-1111-111111111111' },
-      { value: 'Second value', id: '22222222-2222-2222-2222-222222222222' },
-      { value: 'Third value', id: '33333333-3333-3333-3333-333333333333' },
-    ]);
-
-    expect(
-      boundBlock.children[0].block.parentCapabilities.get('split').enabled,
-    ).toBe(false);
-  });
-
-  test('insert disables split', () => {
-    document.body.innerHTML = '<div id="placeholder"></div>';
-    const boundBlock = blockDef.render($('#placeholder'), 'the-prefix', [
-      { value: 'First value', id: '11111111-1111-1111-1111-111111111111' },
-      { value: 'Second value', id: '22222222-2222-2222-2222-222222222222' },
-    ]);
-
-    expect(
-      boundBlock.children[0].block.parentCapabilities.get('split').enabled,
-    ).toBe(true);
-
-    boundBlock.insert('Third value', 2);
-
-    expect(
-      boundBlock.children[0].block.parentCapabilities.get('split').enabled,
-    ).toBe(false);
-  });
-
-  test('delete enables split', () => {
-    document.body.innerHTML = '<div id="placeholder"></div>';
-    const boundBlock = blockDef.render($('#placeholder'), 'the-prefix', [
-      { value: 'First value', id: '11111111-1111-1111-1111-111111111111' },
-      { value: 'Second value', id: '22222222-2222-2222-2222-222222222222' },
-      { value: 'Third value', id: '33333333-3333-3333-3333-333333333333' },
-    ]);
-
-    expect(
-      boundBlock.children[0].block.parentCapabilities.get('split').enabled,
-    ).toBe(false);
-
-    boundBlock.deleteBlock(2);
-
-    expect(
-      boundBlock.children[0].block.parentCapabilities.get('split').enabled,
-    ).toBe(true);
   });
 });

--- a/client/src/components/StreamField/blocks/ListBlock.test.js
+++ b/client/src/components/StreamField/blocks/ListBlock.test.js
@@ -397,6 +397,21 @@ describe('telepath: wagtail.blocks.ListBlock with maxNum set', () => {
     assertCannotAddBlock();
   });
 
+  test('addSibling capability works', () => {
+    document.body.innerHTML = '<div id="placeholder"></div>';
+    const boundBlock = blockDef.render($('#placeholder'), 'the-prefix', [
+      { value: 'First value', id: '11111111-1111-1111-1111-111111111111' },
+      { value: 'Second value', id: '22222222-2222-2222-2222-222222222222' },
+      { value: 'Third value', id: '33333333-3333-3333-3333-333333333333' },
+    ]);
+    const addSibling =
+      boundBlock.children[0].block.parentCapabilities.get('addSibling');
+    expect(addSibling.getBlockMax()).toEqual(3);
+    expect(addSibling.getBlockCount()).toEqual(3);
+    addSibling.fn();
+    expect(boundBlock.children.length).toEqual(4);
+  });
+
   test('insert disables new block', () => {
     document.body.innerHTML = '<div id="placeholder"></div>';
     const boundBlock = blockDef.render($('#placeholder'), 'the-prefix', [

--- a/client/src/components/StreamField/blocks/StreamBlock.js
+++ b/client/src/components/StreamField/blocks/StreamBlock.js
@@ -282,7 +282,7 @@ export class StreamBlock extends BaseSequenceBlock {
     if (!type) {
       return this.blockDef.meta.maxNum;
     }
-    return this.blockDef.meta.blockCounts[type];
+    return this.blockDef.meta.blockCounts[type]?.max_num;
   }
 
   _updateBlockCount(type) {
@@ -313,12 +313,12 @@ export class StreamBlock extends BaseSequenceBlock {
     this.disabledBlockTypes = new Set();
     for (const blockType in this.blockDef.meta.blockCounts) {
       if (this.blockDef.meta.blockCounts.hasOwnProperty(blockType)) {
-        const counts = this.blockDef.meta.blockCounts[blockType];
+        const maxNum = this.getBlockMax(blockType);
 
-        if (typeof counts.max_num === 'number') {
+        if (typeof maxNum === 'number') {
           const currentBlockCount = this.getBlockCount(blockType);
 
-          if (currentBlockCount >= counts.max_num) {
+          if (currentBlockCount >= maxNum) {
             this.disabledBlockTypes.add(blockType);
           }
         }

--- a/client/src/components/StreamField/blocks/StreamBlock.js
+++ b/client/src/components/StreamField/blocks/StreamBlock.js
@@ -259,6 +259,10 @@ export class StreamBlock extends BaseSequenceBlock {
     }
   }
 
+  getBlockGroups() {
+    return this.blockDef.groupedChildBlockDefs;
+  }
+
   /*
    * Called whenever a block is added or removed
    *

--- a/client/src/components/StreamField/blocks/StreamBlock.js
+++ b/client/src/components/StreamField/blocks/StreamBlock.js
@@ -325,18 +325,6 @@ export class StreamBlock extends BaseSequenceBlock {
       }
     }
 
-    for (let i = 0; i < this.children.length; i++) {
-      const canDuplicate =
-        this.canAddBlock && !this.disabledBlockTypes.has(this.children[i].type);
-
-      if (canDuplicate) {
-        this.children[i].enableDuplication();
-        this.children[i].enableSplit();
-      } else {
-        this.children[i].disableDuplication();
-        this.children[i].disableSplit();
-      }
-    }
     for (let i = 0; i < this.inserters.length; i++) {
       this.inserters[i].setNewBlockRestrictions(
         this.canAddBlock,

--- a/client/src/components/StreamField/blocks/StreamBlock.js
+++ b/client/src/components/StreamField/blocks/StreamBlock.js
@@ -233,6 +233,9 @@ export class StreamBlock extends BaseSequenceBlock {
     // StreamChild objects for the current (non-deleted) child blocks
     this.children = [];
 
+    // Cache for child block counting (not guaranteed to be fully populated)
+    this.childBlockCounts = new Map();
+
     // Insertion control objects - there are one more of these than there are children.
     // The control at index n will insert a block at index n
     this.inserters = [];
@@ -263,6 +266,32 @@ export class StreamBlock extends BaseSequenceBlock {
     return this.blockDef.groupedChildBlockDefs;
   }
 
+  getBlockCount(type) {
+    // Get the block count for a particular type, or if none is provided, the total block count
+    if (!type) {
+      return this.children.length;
+    }
+    if (!this.childBlockCounts.has(type)) {
+      this._updateBlockCount(type);
+    }
+    return this.childBlockCounts.get(type) || 0;
+  }
+
+  getBlockMax(type) {
+    // Get the maximum number of blocks allowable for a particular type, or if none is provided, the total maximum
+    if (!type) {
+      return this.blockDef.meta.maxNum;
+    }
+    return this.blockDef.meta.blockCounts[type];
+  }
+
+  _updateBlockCount(type) {
+    const currentBlockCount = this.children.filter(
+      (child) => child.type === type,
+    ).length;
+    this.childBlockCounts.set(type, currentBlockCount);
+  }
+
   /*
    * Called whenever a block is added or removed
    *
@@ -271,6 +300,7 @@ export class StreamBlock extends BaseSequenceBlock {
   blockCountChanged() {
     super.blockCountChanged();
     this.canAddBlock = true;
+    this.childBlockCounts.clear();
 
     if (
       typeof this.blockDef.meta.maxNum === 'number' &&
@@ -279,21 +309,17 @@ export class StreamBlock extends BaseSequenceBlock {
       this.canAddBlock = false;
     }
 
-    // If we can add blocks, check if there are any block types that have count limits
+    // Check if there are any block types that have count limits
     this.disabledBlockTypes = new Set();
-    if (this.canAddBlock) {
-      for (const blockType in this.blockDef.meta.blockCounts) {
-        if (this.blockDef.meta.blockCounts.hasOwnProperty(blockType)) {
-          const counts = this.blockDef.meta.blockCounts[blockType];
+    for (const blockType in this.blockDef.meta.blockCounts) {
+      if (this.blockDef.meta.blockCounts.hasOwnProperty(blockType)) {
+        const counts = this.blockDef.meta.blockCounts[blockType];
 
-          if (typeof counts.max_num === 'number') {
-            const currentBlockCount = this.children.filter(
-              (child) => child.type === blockType,
-            ).length;
+        if (typeof counts.max_num === 'number') {
+          const currentBlockCount = this.getBlockCount(blockType);
 
-            if (currentBlockCount >= counts.max_num) {
-              this.disabledBlockTypes.add(blockType);
-            }
+          if (currentBlockCount >= counts.max_num) {
+            this.disabledBlockTypes.add(blockType);
           }
         }
       }

--- a/client/src/components/StreamField/blocks/StreamBlock.test.js
+++ b/client/src/components/StreamField/blocks/StreamBlock.test.js
@@ -554,6 +554,30 @@ describe('telepath: wagtail.blocks.StreamBlock with maxNum set', () => {
     assertCannotAddBlock();
   });
 
+  test('addSibling capability works', () => {
+    document.body.innerHTML = '<div id="placeholder"></div>';
+    const boundBlock = blockDef.render($('#placeholder'), 'the-prefix', [
+      {
+        id: '1',
+        type: 'test_block_a',
+        value: 'First value',
+      },
+      {
+        id: '2',
+        type: 'test_block_b',
+        value: 'Second value',
+      },
+    ]);
+    const addSibling =
+      boundBlock.children[0].block.parentCapabilities.get('addSibling');
+    expect(addSibling.getBlockMax('test_block_a')).toBeUndefined();
+    expect(addSibling.getBlockMax()).toEqual(3);
+    expect(addSibling.getBlockCount()).toEqual(2);
+    addSibling.fn({ type: 'test_block_a' });
+    expect(boundBlock.children.length).toEqual(3);
+    expect(boundBlock.children[1].type).toEqual('test_block_a');
+  });
+
   test('insert disables new block', () => {
     document.body.innerHTML = '<div id="placeholder"></div>';
     const boundBlock = blockDef.render($('#placeholder'), 'the-prefix', [
@@ -708,6 +732,29 @@ describe('telepath: wagtail.blocks.StreamBlock with blockCounts.max_num set', ()
     ).toEqual('disabled');
   };
 
+  test('addSibling capability works', () => {
+    document.body.innerHTML = '<div id="placeholder"></div>';
+    const boundBlock = blockDef.render($('#placeholder'), 'the-prefix', [
+      {
+        id: '1',
+        type: 'test_block_a',
+        value: 'First value',
+      },
+      {
+        id: '2',
+        type: 'test_block_b',
+        value: 'Second value',
+      },
+    ]);
+    const addSibling =
+      boundBlock.children[0].block.parentCapabilities.get('addSibling');
+    expect(addSibling.getBlockMax('test_block_a')).toEqual(2);
+    expect(addSibling.getBlockCount('test_block_a')).toEqual(1);
+    addSibling.fn({ type: 'test_block_a' });
+    expect(boundBlock.children.length).toEqual(3);
+    expect(boundBlock.children[1].type).toEqual('test_block_a');
+  });
+
   test('single instance allows creation of new block and duplication', () => {
     document.body.innerHTML = '<div id="placeholder"></div>';
     const boundBlock = blockDef.render($('#placeholder'), 'the-prefix', [
@@ -727,7 +774,7 @@ describe('telepath: wagtail.blocks.StreamBlock with blockCounts.max_num set', ()
     assertCanAddBlock();
   });
 
-  test('initialising at max_num disables adding new block of that type and duplication', () => {
+  test('initialising at max_num disables adding new block of that type', () => {
     document.body.innerHTML = '<div id="placeholder"></div>';
     const boundBlock = blockDef.render($('#placeholder'), 'the-prefix', [
       {

--- a/client/src/components/StreamField/blocks/StreamBlock.test.js
+++ b/client/src/components/StreamField/blocks/StreamBlock.test.js
@@ -495,13 +495,13 @@ describe('telepath: wagtail.blocks.StreamBlock with maxNum set', () => {
   };
 
   const assertCannotAddBlock = () => {
-    // Test duplicate button
+    // Test duplicate button is still enabled even when at block limit
     // querySelector always returns the first element it sees so this only checks the first block
     expect(
       document
         .querySelector('button[title="Duplicate"]')
         .getAttribute('disabled'),
-    ).toEqual('disabled');
+    ).toBe(null);
 
     // Test menu
     expect(
@@ -692,13 +692,13 @@ describe('telepath: wagtail.blocks.StreamBlock with blockCounts.max_num set', ()
   };
 
   const assertCannotAddBlock = () => {
-    // Test duplicate button
+    // Test duplicate button is always enabled
     // querySelector always returns the first element it sees so this only checks the first block
     expect(
       document
         .querySelector('button[title="Duplicate"]')
         .getAttribute('disabled'),
-    ).toEqual('disabled');
+    ).toBe(null);
 
     // Test menu item
     expect(
@@ -749,93 +749,6 @@ describe('telepath: wagtail.blocks.StreamBlock with blockCounts.max_num set', ()
     boundBlock.inserters[0].open();
 
     assertCannotAddBlock();
-  });
-
-  test('initialising at max_num disables splitting', () => {
-    document.body.innerHTML = '<div id="placeholder"></div>';
-    const boundBlock = blockDef.render($('#placeholder'), 'the-prefix', [
-      {
-        id: '1',
-        type: 'test_block_a',
-        value: 'First value',
-      },
-      {
-        id: '2',
-        type: 'test_block_b',
-        value: 'Second value',
-      },
-      {
-        id: '3',
-        type: 'test_block_a',
-        value: 'Third value',
-      },
-    ]);
-    expect(
-      boundBlock.children[2].block.parentCapabilities.get('split').enabled,
-    ).toBe(false);
-  });
-
-  test('insert disables splitting', () => {
-    document.body.innerHTML = '<div id="placeholder"></div>';
-    const boundBlock = blockDef.render($('#placeholder'), 'the-prefix', [
-      {
-        id: '1',
-        type: 'test_block_a',
-        value: 'First value',
-      },
-      {
-        id: '2',
-        type: 'test_block_b',
-        value: 'Second value',
-      },
-    ]);
-
-    expect(
-      boundBlock.children[0].block.parentCapabilities.get('split').enabled,
-    ).toBe(true);
-
-    boundBlock.insert(
-      {
-        id: '3',
-        type: 'test_block_a',
-        value: 'Third value',
-      },
-      2,
-    );
-
-    expect(
-      boundBlock.children[0].block.parentCapabilities.get('split').enabled,
-    ).toBe(false);
-  });
-
-  test('delete enables splitting', () => {
-    document.body.innerHTML = '<div id="placeholder"></div>';
-    const boundBlock = blockDef.render($('#placeholder'), 'the-prefix', [
-      {
-        id: '1',
-        type: 'test_block_a',
-        value: 'First value',
-      },
-      {
-        id: '2',
-        type: 'test_block_b',
-        value: 'Second value',
-      },
-      {
-        id: '3',
-        type: 'test_block_a',
-        value: 'Third value',
-      },
-    ]);
-    expect(
-      boundBlock.children[0].block.parentCapabilities.get('split').enabled,
-    ).toBe(false);
-
-    boundBlock.deleteBlock(2);
-
-    expect(
-      boundBlock.children[0].block.parentCapabilities.get('split').enabled,
-    ).toBe(true);
   });
 
   test('insert disables new block', () => {

--- a/client/src/entrypoints/admin/telepath/widgets.js
+++ b/client/src/entrypoints/admin/telepath/widgets.js
@@ -171,9 +171,11 @@ class DraftailRichTextArea {
     this.options = options;
   }
 
+  /**
+   * Given original options object, return the options overrides
+   * that account for its contextual abilities (splitting or adding additional blocks)
+   */
   getCapabilityOptions(originalOptions, parentCapabilities) {
-    // Given original options object, return the options overrides
-    // that account for its contextual abilities (splitting or adding additional blocks)
     const options = {};
     const capabilities = parentCapabilities;
     const split = capabilities.get('split');
@@ -209,7 +211,13 @@ class DraftailRichTextArea {
               return `${option.description}${limitText}`;
             },
             onSelect: ({ editorState }) => {
-              const result = window.draftail.splitState(editorState);
+              // Reset the current block to unstyled and empty before splitting, so we remove the command prompt if used.
+              const result = window.draftail.splitState(
+                window.draftail.DraftUtils.resetBlockWithType(
+                  editorState,
+                  'unstyled',
+                ),
+              );
               // Run the split after a timeout to circumvent potential race condition.
               setTimeout(() => {
                 if (result) {
@@ -230,18 +238,8 @@ class DraftailRichTextArea {
           items: blockControls,
         };
       });
-    }
 
-    options.commands = [
-      {
-        label: gettext('Rich text'),
-        type: 'blockTypes',
-      },
-      {
-        type: 'entityTypes',
-      },
-      ...blockCommands,
-      {
+      blockCommands.push({
         label: 'Actions',
         type: 'custom-actions',
         items: [
@@ -257,7 +255,12 @@ class DraftailRichTextArea {
               return text;
             },
             onSelect: ({ editorState }) => {
-              const result = window.draftail.splitState(editorState);
+              const result = window.draftail.splitState(
+                window.draftail.DraftUtils.resetBlockWithType(
+                  editorState,
+                  'unstyled',
+                ),
+              );
               // Run the split after a timeout to circumvent potential race condition.
               setTimeout(() => {
                 if (result) {
@@ -271,7 +274,18 @@ class DraftailRichTextArea {
             },
           },
         ],
+      });
+    }
+
+    options.commands = [
+      {
+        label: gettext('Rich text'),
+        type: 'blockTypes',
       },
+      {
+        type: 'entityTypes',
+      },
+      ...blockCommands,
     ];
 
     return options;

--- a/client/src/entrypoints/admin/telepath/widgets.js
+++ b/client/src/entrypoints/admin/telepath/widgets.js
@@ -178,25 +178,18 @@ class DraftailRichTextArea {
     const split = capabilities.get('split');
     const addSibling = capabilities.get('addSibling');
     let blockCommands = [];
-<<<<<<< HEAD
-    if (split && split.enabled) {
+    if (split) {
       options.controls = originalOptions.controls
         ? [...originalOptions.controls]
         : [];
-=======
-    if (split) {
-      options.controls = originalOptions.controls ? [...originalOptions.controls] : [];
->>>>>>> 320474ed14... fixup! Move command generation out of render and update them when capabilities change
       options.controls.push({
         meta: window.draftail.getSplitControl(split.fn, !!split.enabled),
       });
 
-<<<<<<< HEAD
       const blockGroups =
-        addSibling && addSibling.enabled ? addSibling.blockGroups : [];
-=======
-      const blockGroups = (addSibling && addSibling.enabled && split.enabled) ? addSibling.blockGroups : [];
->>>>>>> 320474ed14... fixup! Move command generation out of render and update them when capabilities change
+        addSibling && addSibling.enabled && split.enabled
+          ? addSibling.blockGroups
+          : [];
       // Create commands for splitting + inserting a block. This requires both the split
       // and addSibling capabilities to be available and enabled
       blockCommands = blockGroups.map(([group, blocks]) => {
@@ -210,7 +203,7 @@ class DraftailRichTextArea {
               // If the specific block has a limit, render the current number/max alongside the description
               const limitText =
                 typeof blockMax === 'number'
-                  ? `(${addSibling.getBlockCount(blockDef.name)}/${blockMax})`
+                  ? ` (${addSibling.getBlockCount(blockDef.name)}/${blockMax})`
                   : '';
               return `${option.description}${limitText}`;
             },
@@ -349,9 +342,9 @@ class DraftailRichTextArea {
           capabilities.get(capability),
           capabilityOptions,
         );
-        capabilities.set(capability, newCapability)
+        capabilities.set(capability, newCapability);
         setOptions(getFullOptions(originalOptions, capabilities));
-      }
+      },
     };
 
     if (initialiseBlank) {

--- a/client/src/entrypoints/admin/telepath/widgets.js
+++ b/client/src/entrypoints/admin/telepath/widgets.js
@@ -1,4 +1,5 @@
 /* global $ */
+import { gettext } from '../../../utils/gettext';
 
 class BoundWidget {
   constructor(element, name, idForLabel, initialState, parentCapabilities) {

--- a/client/src/entrypoints/admin/telepath/widgets.js
+++ b/client/src/entrypoints/admin/telepath/widgets.js
@@ -178,16 +178,25 @@ class DraftailRichTextArea {
     const split = capabilities.get('split');
     const addSibling = capabilities.get('addSibling');
     let blockCommands = [];
+<<<<<<< HEAD
     if (split && split.enabled) {
       options.controls = originalOptions.controls
         ? [...originalOptions.controls]
         : [];
+=======
+    if (split) {
+      options.controls = originalOptions.controls ? [...originalOptions.controls] : [];
+>>>>>>> 320474ed14... fixup! Move command generation out of render and update them when capabilities change
       options.controls.push({
         meta: window.draftail.getSplitControl(split.fn, !!split.enabled),
       });
 
+<<<<<<< HEAD
       const blockGroups =
         addSibling && addSibling.enabled ? addSibling.blockGroups : [];
+=======
+      const blockGroups = (addSibling && addSibling.enabled && split.enabled) ? addSibling.blockGroups : [];
+>>>>>>> 320474ed14... fixup! Move command generation out of render and update them when capabilities change
       // Create commands for splitting + inserting a block. This requires both the split
       // and addSibling capabilities to be available and enabled
       blockCommands = blockGroups.map(([group, blocks]) => {
@@ -294,10 +303,12 @@ class DraftailRichTextArea {
     const initialiseBlank = !!initialState.getCurrentContent;
     input.value = initialiseBlank ? 'null' : initialState;
     container.appendChild(input);
+
+    const getFullOptions = this.getFullOptions.bind(this);
     // eslint-disable-next-line no-undef
     const [, setOptions] = draftail.initEditor(
       '#' + id,
-      this.getFullOptions(originalOptions, parentCapabilities),
+      getFullOptions(originalOptions, parentCapabilities),
       document.currentScript,
     );
 
@@ -338,9 +349,9 @@ class DraftailRichTextArea {
           capabilities.get(capability),
           capabilityOptions,
         );
-        capabilities.set(capability, newCapability);
-        setOptions(this.getFullOptions(originalOptions, capabilities));
-      },
+        capabilities.set(capability, newCapability)
+        setOptions(getFullOptions(originalOptions, capabilities));
+      }
     };
 
     if (initialiseBlank) {

--- a/docs/advanced_topics/customisation/admin_templates.md
+++ b/docs/advanced_topics/customisation/admin_templates.md
@@ -236,6 +236,7 @@ window.Draftail;
 
 // Wagtail’s Draftail-related APIs and components.
 window.draftail;
+window.draftail.DraftUtils;
 window.draftail.ModalWorkflowSource;
 window.draftail.ImageModalWorkflowSource;
 window.draftail.EmbedModalWorkflowSource;

--- a/docs/releases/4.0.md
+++ b/docs/releases/4.0.md
@@ -31,6 +31,7 @@ As part of the page editor redesign project sponsored by Google, we have made a 
 * RTL support: The editor’s UI now displays correctly in right-to-left languages.
 * Focus-aware placeholder: The editor’s placeholder text will now follow the user’s focus, to make it easier to understand where to type in long fields.
 * Empty heading highlight: The editor now highlights empty headings and list items by showing their type (“Heading 3”) as a placeholder, so content is less likely to be published with empty headings.
+* Split and insert: rich text fields can now be split while inserting a new StreamField block of the desired type.
 
 ### Live preview panel
 


### PR DESCRIPTION
<!--
Thanks for contributing to Wagtail! 🎉

Before submitting, please review the [contributor guidelines](https://docs.wagtail.org/en/latest/contributing/index.html).
-->
Rebased version of https://github.com/wagtail/wagtail/pull/8826.

The block limits are currently plain text in the picker UI. Note that this PR makes it possible to add streamfield blocks / duplicate when over the block limit, but does not add any additional streamfield error state for being over the limit.


_Please check the following:_

-   [ ] Do the tests still pass?[^1]
-   [ ] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
