### PR TITLE
Implement max length UI for RichTextField, with identical client & server character count. Fix #2268

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -81,7 +81,7 @@ Changelog
  * Replace latin abbreviations (i.e. / e.g.) with common English phrases so that documentation is easier to understand (Dominik Lech)
  * Add shortcut for accessing StreamField blocks by block name with new `blocks_by_name` and `first_block_by_name` methods on `StreamValue` (Tidiane Dia, Matt Westcott)
  * Extend support for custom user interface colours across almost all admin colours (Thibaud Colas)
- * Add HTML-aware max_length validation on RichTextField and RichTextBlock (Matt Westcott)
+ * Add HTML-aware max_length validation and character count on RichTextField and RichTextBlock (Matt Westcott, Thibaud Colas)
  * Remove undocumented `SearchableListMixin` (Sage Abdullah)
  * Extract filtering code from ReportView to generic IndexView (Sage Abdullah)
  * Retain other query params in header search behaviour (Sage Abdullah)

--- a/client/src/components/Draftail/Draftail.scss
+++ b/client/src/components/Draftail/Draftail.scss
@@ -124,11 +124,16 @@ $draftail-editor-font-family: $font-sans;
 }
 
 .Draftail-MetaToolbar {
-  visibility: hidden;
+  padding: 0;
 
-  .Draftail-Editor:focus-within &,
-  .Draftail-Editor:hover & {
-    visibility: visible;
+  // Make sure the toolbar is always visible for devices that do not hover.
+  @media (hover: hover) {
+    visibility: hidden;
+
+    .Draftail-Editor:focus-within &,
+    .Draftail-Editor:hover & {
+      visibility: visible;
+    }
   }
 }
 

--- a/client/src/components/Draftail/__snapshots__/index.test.js.snap
+++ b/client/src/components/Draftail/__snapshots__/index.test.js.snap
@@ -16,11 +16,7 @@ Object {
   "commandPalette": [Function],
   "commandToolbar": [Function],
   "commands": true,
-  "controls": Array [
-    Object {
-      "meta": [Function],
-    },
-  ],
+  "controls": Array [],
   "decorators": Array [],
   "editorState": null,
   "enableHorizontalRule": Object {

--- a/client/src/components/Draftail/index.js
+++ b/client/src/components/Draftail/index.js
@@ -94,6 +94,7 @@ const initEditor = (selector, originalOptions, currentScript) => {
   };
 
   const getSharedPropsFromOptions = (newOptions) => {
+    let ariaDescribedBy = null;
     const enableHorizontalRule = newOptions.enableHorizontalRule
       ? {
           description: gettext('Horizontal line'),
@@ -102,7 +103,7 @@ const initEditor = (selector, originalOptions, currentScript) => {
 
     const blockTypes = newOptions.blockTypes || [];
     const inlineStyles = newOptions.inlineStyles || [];
-    const controls = newOptions.controls || [];
+    let controls = newOptions.controls || [];
     const commands = newOptions.commands || true;
     let entityTypes = newOptions.entityTypes || [];
 
@@ -112,6 +113,23 @@ const initEditor = (selector, originalOptions, currentScript) => {
       // Override the properties defined in the JS plugin: Python should be the source of truth.
       return { ...plugin, ...type };
     });
+
+    // Only initialise the character count / max length on fields explicitly requiring it.
+    if (field.hasAttribute('maxlength')) {
+      const maxLengthID = `${field.id}-length`;
+      ariaDescribedBy = maxLengthID;
+      controls = controls.concat([
+        {
+          meta: (props) => (
+            <MaxLength
+              {...props}
+              maxLength={field.maxLength}
+              id={maxLengthID}
+            />
+          ),
+        },
+      ]);
+    }
 
     return {
       rawContentState: rawContentState,
@@ -133,11 +151,12 @@ const initEditor = (selector, originalOptions, currentScript) => {
       ),
       maxListNesting: 4,
       stripPastedStyles: false,
+      ariaDescribedBy,
       ...newOptions,
       blockTypes: blockTypes.map(wrapWagtailIcon),
       inlineStyles: inlineStyles.map(wrapWagtailIcon),
       entityTypes,
-      controls: controls.concat([{ meta: MaxLength }]),
+      controls,
       commands,
       enableHorizontalRule,
     };

--- a/client/src/components/Draftail/index.test.js
+++ b/client/src/components/Draftail/index.test.js
@@ -53,6 +53,18 @@ describe('Draftail', () => {
       });
 
       expect(field.draftailEditor.props).toMatchSnapshot();
+      // Make sure we don’t initialise a character count on fields that have the default unlimited max length.
+      expect(field.draftailEditor.props.ariaDescribedBy).toBe(null);
+    });
+
+    it('maxLength', () => {
+      document.body.innerHTML =
+        '<input id="test" value="null" maxlength="50" />';
+      const field = document.querySelector('#test');
+
+      draftail.initEditor('#test', {});
+
+      expect(field.draftailEditor.props.ariaDescribedBy).toBe('test-length');
     });
 
     describe('selector conflicts', () => {

--- a/client/src/entrypoints/admin/telepath/widgets.test.js
+++ b/client/src/entrypoints/admin/telepath/widgets.test.js
@@ -544,7 +544,7 @@ describe('telepath: wagtail.widgets.DraftailRichTextArea', () => {
     ReactTestUtils.act(() =>
       boundWidget.setCapabilityOptions('split', { enabled: false }),
     );
-    expect(inputElement.draftailEditor.props.controls).toHaveLength(2);
+    expect(inputElement.draftailEditor.props.controls).toHaveLength(1);
     expect(window.draftail.getSplitControl).toHaveBeenLastCalledWith(
       parentCapabilities.get('split').fn,
       false,
@@ -552,7 +552,7 @@ describe('telepath: wagtail.widgets.DraftailRichTextArea', () => {
     ReactTestUtils.act(() =>
       boundWidget.setCapabilityOptions('split', { enabled: true }),
     );
-    expect(inputElement.draftailEditor.props.controls).toHaveLength(2);
+    expect(inputElement.draftailEditor.props.controls).toHaveLength(1);
     expect(window.draftail.getSplitControl).toHaveBeenLastCalledWith(
       parentCapabilities.get('split').fn,
       true,

--- a/docs/advanced_topics/customisation/page_editing_interface.md
+++ b/docs/advanced_topics/customisation/page_editing_interface.md
@@ -49,7 +49,7 @@ class BookPage(Page):
     ]
 ```
 
-`RichTextField` inherits from Django's basic `TextField` field, so you can pass any field parameters into `RichTextField` as if using a normal Django field. This field does not need a special panel and can be defined with `FieldPanel`.
+`RichTextField` inherits from Django's basic `TextField` field, so you can pass any field parameters into `RichTextField` as if using a normal Django field. Its `max_length` will ignore any rich text formatting. This field does not need a special panel and can be defined with `FieldPanel`.
 
 However, template output from `RichTextField` is special and needs to be filtered in order to preserve embedded content. See [](rich_text_filter).
 

--- a/docs/releases/4.0.md
+++ b/docs/releases/4.0.md
@@ -113,7 +113,7 @@ In Wagtail 2.16, we introduced support for Windows High Contrast mode (WHCM). Th
  * Adopt the slim header in page listing views, with buttons moved under the "Actions" dropdown, including addition of translation page in the parent "more" button (Paarth Agarwal)
  * Replace latin abbreviations (i.e. / e.g.) with common English phrases so that documentation is easier to understand (Dominik Lech)
  * Add shortcut for accessing StreamField blocks by block name with new [`blocks_by_name` and `first_block_by_name` methods on `StreamValue`](streamfield_retrieving_blocks_by_name) (Tidiane Dia, Matt Westcott)
- * Add HTML-aware max_length validation on RichTextField and RichTextBlock (Matt Westcott)
+ * Add HTML-aware max_length validation and character count on RichTextField and RichTextBlock (Matt Westcott, Thibaud Colas)
  * Remove `is_parent` kwarg in various page button hooks as this approach is no longer required (Paarth Agarwal)
  * Improve security of redirect imports by adding a file hash (signature) check for so that any tampering of file contents between requests will throw a `BadSignature` error (Jaap Roes)
  * Refresh designs for Home (Dashboard) site summary panels, use theme spacing and colours, add support for RTL layouts and better support for small devices (Paarth Agarwal, LB (Ben) Johnston)

--- a/wagtail/rich_text/__init__.py
+++ b/wagtail/rich_text/__init__.py
@@ -132,7 +132,8 @@ class EmbedHandler(EntityHandler):
 class RichTextMaxLengthValidator(MaxLengthValidator):
     """
     A variant of MaxLengthValidator that only counts text (not HTML tags) towards the limit
+    Un-escapes entities for consistency with client-side character count.
     """
 
     def clean(self, x):
-        return len(strip_tags(x))
+        return len(unescape(strip_tags(x)))


### PR DESCRIPTION
Follow-up to #8822, #8548, #8246. Implements #2268. This integrates the server-side `RichTextMaxLengthValidator` with the client-side MaxLength UI, and implements the target design:

- The character count should only show for fields declaring a max length
- We display the maximum length next to the character count
- With use the correct text styles (designs have a different font family and size but I assumed we wanted it to look like help text)
- The counting logic is the same client-side & server-side
- The field has a `aria-describedby` to the count / max length

Screenshot for reference:

<img width="891" alt="richtext-maxlength" src="https://user-images.githubusercontent.com/877585/182327099-ac0bf35b-f874-40df-9f21-72cd3b80fd7a.png">

## Implementation notes

Validation / error states still are fully based on server-side logic only, until we implement auto-save. On the count, I needed to change `RichTextMaxLengthValidator` to account for escaped HTML, and change the client-side logic to treat content as a single line.

I’ve added tests both sides and tried to make sure it was clear they had to be kept in sync, though the tests are laid out differently. And added a brief mention of `max_length` for RichTextField in the docs. I’ve also updated the release notes right away as it’s for existing items so conflicts are unlikely.

One thing I haven’t done is making sure this bottom toolbar is positioned correctly compared to the field’s help text. I’ll only get to that once we have the new forms markup in place.

## Tests

To test this, add a `max_length` on bakerydemo models:

```python
promo_text = RichTextField(
    null=True,
    blank=True,
    help_text='Write some promotional copy',
    max_length=20,
)
```

Then try some of the different test cases from the unit tests

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [x] **Please list the exact browser and operating system versions you tested**: Chrome 103 macOS 12.4, Chrome Android 11, iOS Safari 15, Safari 15.5 macOS 12.4
    -   [x] **Please list which assistive technologies [^3] you tested**: VoiceOver (sample output: "Character count eleven slash 50, you are currently on a text area") & WHCM
-   [x] For new features: Has the documentation been updated accordingly?
