### PR TITLE
Increase z-index draftail editor

### DIFF
--- a/client/src/components/Draftail/Draftail.scss
+++ b/client/src/components/Draftail/Draftail.scss
@@ -12,6 +12,7 @@ $draftail-editor-padding: 0.75rem;
 $draftail-editor-background: $color-white;
 $draftail-toolbar-radius: 5px;
 $draftail-toolbar-icon-size: 1em;
+$draftail-editor-z-index: 200;
 
 $draftail-editor-font-family: $font-sans;
 


### PR DESCRIPTION
This makes sure the draftail editor toolbar is displayed above the sticky header:
https://github.com/wagtail/wagtail/issues/8915