### PR TITLE
Remove `DeleteMenuItem` in `PageActionMenu`

### DIFF
--- a/wagtail/admin/action_menu.py
+++ b/wagtail/admin/action_menu.py
@@ -209,21 +209,6 @@ class UnpublishMenuItem(ActionMenuItem):
         return reverse("wagtailadmin_pages:unpublish", args=(context["page"].id,))
 
 
-class DeleteMenuItem(ActionMenuItem):
-    name = "action-delete"
-    label = _("Delete")
-    icon_name = "bin"
-    classname = "action-secondary"
-
-    def is_shown(self, context):
-        if context["view"] == "edit":
-            perms_tester = self.get_user_page_permissions_tester(context)
-            return not perms_tester.page_locked() and perms_tester.can_delete()
-
-    def get_url(self, context):
-        return reverse("wagtailadmin_pages:delete", args=(context["page"].id,))
-
-
 class SaveDraftMenuItem(ActionMenuItem):
     name = "action-save-draft"
     label = _("Save Draft")
@@ -265,7 +250,6 @@ def _get_base_page_action_menu_items():
     if BASE_PAGE_ACTION_MENU_ITEMS is None:
         BASE_PAGE_ACTION_MENU_ITEMS = [
             SaveDraftMenuItem(order=0),
-            DeleteMenuItem(order=10),
             UnpublishMenuItem(order=20),
             PublishMenuItem(order=30),
             CancelWorkflowMenuItem(order=40),


### PR DESCRIPTION
Functionality has been replaced by the page header buttons. Fixes #8932.

<!--
Thanks for contributing to Wagtail! 🎉

Before submitting, please review the [contributor guidelines](https://docs.wagtail.org/en/latest/contributing/index.html).
-->

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?