### PR TITLE
4.0 release notes - add GSoC UX Unification section

### DIFF
--- a/docs/releases/4.0.md
+++ b/docs/releases/4.0.md
@@ -59,7 +59,7 @@ In Wagtail 2.16, we introduced support for Windows High Contrast mode (WHCM). Th
 ### UX unification and consistency improvements
 
 In Wagtail 3.0, a new Page Editor experience was introduced, this release brings many of the UX and UI improvements to other parts of Wagtail for a more consistent experience.
-The bulk of these enhancements have been from Paarth Agarwal, who has been doing the [UX Unification](https://github.com/wagtail/wagtail/discussions/8158) Google Summer of Code project, sponsored by Torchbox with support from LB (Ben Johnston), Thibaud Colas and Helen Chapman.
+The bulk of these enhancements have been from Paarth Agarwal, who has been doing the [UX Unification](https://github.com/wagtail/wagtail/discussions/8158) internship project alongside other Google Summer of Code participants. This internship has been sponsored by Torchbox with mentoring support from LB (Ben Johnston), Thibaud Colas and Helen Chapman.
 
  * Breadcrumbs
    * Add Breadcrumbs to the Wagtail pattern library

--- a/docs/releases/4.0.md
+++ b/docs/releases/4.0.md
@@ -56,6 +56,34 @@ In Wagtail 2.16, we introduced support for Windows High Contrast mode (WHCM). Th
 * Display the correct color for icons in forced colors mode
 * Add a border around modal dialogs so they can be identified in forced colors mode
 
+### UX unification and consistency improvements
+
+In Wagtail 3.0, a new Page Editor experience was introduced, this release brings many of the UX and UI improvements to other parts of Wagtail for a more consistent experience.
+The bulk of these enhancements have been from Paarth Agarwal, who has been doing the [UX Unification](https://github.com/wagtail/wagtail/discussions/8158) Google Summer of Code project, sponsored by Torchbox with support from LB (Ben Johnston), Thibaud Colas and Helen Chapman.
+
+ * Breadcrumbs
+   * Add Breadcrumbs to the Wagtail pattern library
+   * Enhance new breadcrumbs so they can be added to any header or container element
+   * Adopt new breadcrumbs on the page explorer (listing) view and the page chooser modal, remove legacy breadcrumbs code for move page as no longer used
+   * Rename `explorer_breadcrumb` template tag to `breadcrumbs` as it is now used in multiple locations
+   * Remove legacy (non-next) breadcrumbs no longer used, remove `ModelAdmin` usage of breadcrumbs completely and adopt consistent 'back' link approach
+ * Headers
+   * Update classes and styles for the shared header templates to align with UI guidelines
+   * Switch all report workflow, redirects, form submissions, site settings views to use Wagtail’s reusable header component
+   * Resolve issues throughout Wagtail where the sidebar toggle would overlap content on small devices
+ * Tabs
+   * Add Tabs to the Wagtail pattern library
+   * Adopt new Tabs component in the workflow history report page, removing the bespoke implementation there
+ * Dashboard (home) view
+   * Migrate the dashboard (home) view header to the shared header template and update designs
+   * Refresh designs for Home (Dashboard) site summary panels, use theme spacing and colours
+   * Add support for RTL layouts and better support for small devices
+   * Add CSS support for more than three summary items if added via customisations
+ * Page Listing view
+   * Adopt the slim header in page listing views, with buttons moved under the "Actions" dropdown
+   * Add convenient access to the translate page button in the parent "more" button
+
+
 ### Other features
 
  * Add clarity to confirmation when being asked to convert an external link to an internal one (Thijs Kramer)
@@ -81,47 +109,36 @@ In Wagtail 2.16, we introduced support for Windows High Contrast mode (WHCM). Th
  * Add ability to define a custom `get_field_clean_name` method when defining `FormField` models that extend `AbstractFormField` (LB (Ben) Johnston)
  * Migrate Home (Dashboard) view to use generic Wagtail class based view (LB (Ben) Johnston)
  * Combine most of Wagtail’s stylesheets into the global `core.css` file (Thibaud Colas)
- * Add new Breadcrumbs and Tabs to the Wagtail pattern library (Paarth Agarwal)
- * Adopt new Page Editor UI tabs in the workflow history report page (Paarth Agarwal)
  * Update `ReportView` to extend from generic `wagtail.admin.views.generic.models.IndexView` (Sage Abdullah)
  * Introduce a `wagtail.admin.viewsets.chooser.ChooserViewSet` module to serve as a common base implementation for chooser modals (Matt Westcott)
  * Add documentation for `wagtail.admin.viewsets.model.ModelViewSet` (Matt Westcott)
- * Enhance new breadcrumbs so they can be added to any header or container element (Paarth Agarwal)
- * Adopt new breadcrumbs on the page explorer (listing) view and the page chooser modal, remove legacy breadcrumbs code for move page as no longer used (Paarth Agarwal)
  * Added [multi-site support](api_filtering_pages_by_site) to the API (Sævar Öfjörð Magnússon)
  * Add `add_to_admin_menu` option for ModelAdmin (Oliver Parker)
  * Implement [Fuzzy matching](fuzzy_matching) for Elasticsearch (Nick Smith)
  * Cache model permission codenames in `PermissionHelper` (Tidiane Dia)
  * Selecting a new parent page for moving a page now uses the chooser modal which allows searching (Viggo de Vries)
  * Add clarity to the search indexing documentation for how `boost` works when using Postgres with the database search backend (Tibor Leupold)
- * Rename `explorer_breadcrumb` template tag to `breadcrumbs` as it is now used in multiple locations (Paarth Agarwal)
  * Updated `django-filter` version to support 23 (Yuekui)
  * Use `.iterator()` in a few more places in the admin, to make it more stable on sites with many pages (Andy Babic)
  * Migrate some simple React component files to TypeScript (LB (Ben) Johnston)
  * Deprecate the usage and documentation of the `wagtail.contrib.modeladmin.menus.SubMenu` class, provide a warning if used directing developers to use `wagtail.admin.menu.Menu` instead (Matt Westcott)
- * Remove legacy (non-next) breadcrumbs no longer used, remove `ModelAdmin` usage of breadcrumbs completely (Paarth Agarwal)
  * Replace human-readable-date hover pattern with accessible tooltip variant across all of admin (Bernd de Ridder)
  * Added `WAGTAILADMIN_USER_PASSWORD_RESET_FORM` setting for overriding the admin password reset form (Michael Karamuth)
  * Prefetch workflow states in edit page view to to avoid queries in other parts of the view/templates that need it (Tidiane Dia)
  * Remove the edit link from edit bird in previews to avoid confusion (Sævar Öfjörð Magnússon)
  * Introduce new template fragment and block level enclosure tags for easier template composition (Thibaud Colas)
  * Add a `classnames` template tag to easily build up classes from variables provided to a template (Paarth Agarwal)
- * Migrate the dashboard (home) view header to the shared header template and update designs (Paarth Agarwal)
- * Update classes and styles for the shared header templates to align with UI guidelines (Paarth Agarwal)
  * Clean up multiple eslint rules usage and configs to align better with the Wagtail coding guidelines (LB (Ben Johnston))
  * Make ModelAdmin InspectView footer actions consistent with other parts of the UI (Thibaud Colas)
- * Switch all report workflow, redirects, form submissions, site settings views to use Wagtail’s reusable header component (Paarth Agarwal)
  * Add support for Twitter and other text-only embeds in Draftail embed previews (Iman Syed, Paarth Agarwal)
  * Use new modal dialog component for privacy settings modal (Sage Abdullah)
  * Add `menu_item_name` to modify MenuItem's name for ModelAdmin (Alexander Rogovskyy, Vu Pham)
  * Add an extra confirmation prompt when deleting pages with a large number of child pages (Jaspreet Singh)
- * Adopt the slim header in page listing views, with buttons moved under the "Actions" dropdown, including addition of translation page in the parent "more" button (Paarth Agarwal)
  * Replace latin abbreviations (i.e. / e.g.) with common English phrases so that documentation is easier to understand (Dominik Lech)
  * Add shortcut for accessing StreamField blocks by block name with new [`blocks_by_name` and `first_block_by_name` methods on `StreamValue`](streamfield_retrieving_blocks_by_name) (Tidiane Dia, Matt Westcott)
  * Add HTML-aware max_length validation on RichTextField and RichTextBlock (Matt Westcott)
  * Remove `is_parent` kwarg in various page button hooks as this approach is no longer required (Paarth Agarwal)
  * Improve security of redirect imports by adding a file hash (signature) check for so that any tampering of file contents between requests will throw a `BadSignature` error (Jaap Roes)
- * Refresh designs for Home (Dashboard) site summary panels, use theme spacing and colours, add support for RTL layouts and better support for small devices (Paarth Agarwal, LB (Ben) Johnston)
 
 ### Bug fixes
 


### PR DESCRIPTION
Pull out the main UX unification work done by Paarth under Google Summer of Code 2022


Note: This is not all of the items done by Paarth for this release but I have just pulled out the ones that clearly align with the UX unification work.

**This should be merged in before 4.0 goes live but is not a blocker for the Release Candidate to go out.**