### PR TITLE
Fix MySQL search on Django 4.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,7 @@ concurrency:
 # - django 4.0, python 3.10, postgres, USE_EMAIL_USER_MODEL=yes
 # - django 4.1, python 3.10, postgres, DISABLE_TIMEZONE=yes
 # - django stable/4.1.x, python 3.10, postgres (allow failures)
+# - django stable/4.1.x, python 3.10, mysql (allow failures)
 # - django main, python 3.10, postgres (allow failures)
 # - elasticsearch 5, django 3.2, python 3.7, sqlite
 # - elasticsearch 6, django 3.2, python 3.7, postgres
@@ -131,6 +132,9 @@ jobs:
           - python: '3.9'
             django: 'Django>=4.1,<4.2'
             experimental: false
+          - python: '3.10'
+            django: 'git+https://github.com/django/django.git@stable/4.1.x#egg=Django'
+            experimental: true
 
     services:
       mysql:


### PR DESCRIPTION
Django 4.1 introduced some new behavior around boolean filtering in MySQL which broke how search worked in Wagtail.

In Django 4.0, a search match expression would produce this SQL `WHERE` clause:

```
WHERE ... MATCH (`title`, `body`) AGAINST (query IN BOOLEAN MODE)
```

In Django 4.1, this behavior was changed ([ticket 32691](https://code.djangoproject.com/ticket/32691), https://github.com/django/django/commit/407fe95cb116599adeb4b9ed01df5673aa5cb1db) so that instead this SQL `WHERE` clause is generated, explicitly filtering against `= True`:

```
WHERE ... MATCH (`title`, `body`) AGAINST (query IN BOOLEAN MODE) = True
```

This no longer works properly because [MATCH returns a floating point score as a measurement of the match quality](https://dev.mysql.com/doc/refman/8.0/en/fulltext-boolean.html), not a boolean value:

In order for filtering on `= True` to work, this PR changes the match expression SQL to be:

```
WHERE ... CASE WHEN MATCH (`title`, `body`) AGAINST (query IN BOOLEAN MODE) THEN True ELSE False END = True
```

This PR also adds MySQL / Django 4.1.x to the regular GitHub Actions testing matrix, similar to how Postgres testing is currently configured.

Fixes #8946 - thanks to @gasman for the pointer there to the Django commit that broke this.

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?