### PR TITLE
Allow reviewing or reverting to a page's initial revision

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -37,6 +37,7 @@ Changelog
  * Fix: Restore ability to perform JSONField query operations against StreamField when running against the Django 4.2 development branch (Sage Abdullah)
  * Fix: Ensure there is correct grammar and pluralisation for Tab error counts shown to screen readers (Aman Pandey)
  * Fix: Pass through expected expected `cc`, `bcc` and `reply_to` to the Django mail helper from `wagtail.admin.mail.send_mail` (Ben Gosney)
+ * Fix: Allow reviewing or reverting to a Page's initial revision (Andy Chosak)
  * Docs: Add custom permissions section to permissions documentation page (Dan Hayden)
  * Docs: Add documentation for how to get started with contributing translations for the Wagtail admin (Ogunbanjo Oluwadamilare)
  * Docs: Officially recommend `fnm` over `nvm` in development documentation (LB (Ben) Johnston)

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -49,6 +49,7 @@ depth: 1
  * Restore ability to perform JSONField query operations against StreamField when running against the Django 4.2 development branch (Sage Abdullah)
  * Ensure there is correct grammar and pluralisation for Tab error counts shown to screen readers (Aman Pandey)
  * Pass through expected expected `cc`, `bcc` and `reply_to` to the Django mail helper from `wagtail.admin.mail.send_mail` (Ben Gosney)
+ * Allow reviewing or reverting to a Page's initial revision (Andy Chosak)
 
 ### Documentation
 

--- a/wagtail/admin/tests/test_audit_log.py
+++ b/wagtail/admin/tests/test_audit_log.py
@@ -197,7 +197,7 @@ class TestAuditLogAdmin(TestCase, WagtailTestUtils):
         history_url = reverse("wagtailadmin_pages:history", args=[self.hello_page.id])
         self.assertContains(response, history_url)
 
-    def test_create_and_publish_does_not_log_revision_save(self):
+    def test_create_and_publish_logs_revision_save(self):
         self.login(user=self.administrator)
         post_data = {
             "title": "New page!",
@@ -225,7 +225,7 @@ class TestAuditLogAdmin(TestCase, WagtailTestUtils):
                 .values_list("action", flat=True)
                 .order_by("action")
             ),
-            ["wagtail.create", "wagtail.publish"],
+            ["wagtail.create", "wagtail.edit", "wagtail.publish"],
         )
 
     def test_revert_and_publish_logs_reversion_and_publish(self):

--- a/wagtail/admin/views/pages/create.py
+++ b/wagtail/admin/views/pages/create.py
@@ -170,7 +170,7 @@ class CreateView(TemplateResponseMixin, ContextMixin, HookResponseMixin, View):
         self.parent_page.add_child(instance=self.page)
 
         # Save revision
-        self.page.save_revision(user=self.request.user, log_action=False)
+        self.page.save_revision(user=self.request.user, log_action=True)
 
         # Save subscription settings
         self.subscription.page = self.page
@@ -196,7 +196,7 @@ class CreateView(TemplateResponseMixin, ContextMixin, HookResponseMixin, View):
         self.parent_page.add_child(instance=self.page)
 
         # Save revision
-        revision = self.page.save_revision(user=self.request.user, log_action=False)
+        revision = self.page.save_revision(user=self.request.user, log_action=True)
 
         # Save subscription settings
         self.subscription.page = self.page
@@ -252,7 +252,7 @@ class CreateView(TemplateResponseMixin, ContextMixin, HookResponseMixin, View):
         self.parent_page.add_child(instance=self.page)
 
         # Save revision
-        self.page.save_revision(user=self.request.user, log_action=False)
+        self.page.save_revision(user=self.request.user, log_action=True)
 
         # Submit
         workflow = self.page.get_workflow()

--- a/wagtail/management/commands/create_log_entries_from_revisions.py
+++ b/wagtail/management/commands/create_log_entries_from_revisions.py
@@ -90,20 +90,19 @@ class Command(BaseCommand):
                         self.log_page_action("wagtail.publish", previous_revision, True)
 
                 if is_new_page or has_content_changes or published:
+                    actions = []
+
                     if is_new_page:
-                        action = "wagtail.create"
-                    elif published:
-                        action = "wagtail.publish"
-                    else:
-                        action = "wagtail.edit"
+                        actions.append("wagtail.create")
 
-                    if published and has_content_changes:
-                        # When publishing, also log the 'draft save', but only if there have been content changes
-                        self.log_page_action(
-                            "wagtail.edit", revision, has_content_changes
-                        )
+                    if is_new_page or has_content_changes:
+                        actions.append("wagtail.edit")
 
-                    self.log_page_action(action, revision, has_content_changes)
+                    if published:
+                        actions.append("wagtail.publish")
+
+                    for action in actions:
+                        self.log_page_action(action, revision, has_content_changes)
 
             previous_revision = revision
 

--- a/wagtail/tests/test_management_commands.py
+++ b/wagtail/tests/test_management_commands.py
@@ -784,15 +784,28 @@ class TestCreateLogEntriesFromRevisionsCommand(TestCase):
 
         # Should not create entries for empty revisions.
         self.assertListEqual(
-            list(PageLogEntry.objects.values_list("action", flat=True)),
-            [
-                "wagtail.publish",
-                "wagtail.edit",
-                "wagtail.create",
-                "wagtail.publish",
-                "wagtail.edit",
-                "wagtail.create",
-            ],
+            list(PageLogEntry.objects.values_list("page_id", "action")),
+            # Default PageLogEntry sort order is from newest event to oldest.
+            # We reverse here to make it easier to understand what is being
+            # tested. The events here should correspond with setUp above.
+            list(
+                reversed(
+                    [
+                        # The SimplePage was created in draft mode, with an initial revision.
+                        (self.page.pk, "wagtail.create"),
+                        (self.page.pk, "wagtail.edit"),
+                        # The SimplePage was edited as a new draft, then published.
+                        (self.page.pk, "wagtail.edit"),
+                        (self.page.pk, "wagtail.publish"),
+                        # The SecretPage was created in draft mode, with an initial revision.
+                        (self.secret_page.pk, "wagtail.create"),
+                        (self.secret_page.pk, "wagtail.edit"),
+                        # The SecretPage was edited as a new draft, then published.
+                        (self.secret_page.pk, "wagtail.edit"),
+                        (self.secret_page.pk, "wagtail.publish"),
+                    ]
+                )
+            ),
         )
 
     def test_command_doesnt_crash_for_revisions_without_page_model(self):


### PR DESCRIPTION
Currently it's not possible to review or revert to a page's initial revision because we don't log a PageLogEntry "wagtail.edit" event in certain cases:

- When a page is first created, and saved as draft
- When a page is first created, and published right away
- When a page is first created, and submitted for moderation

This commit alters the current behavior so that a "wagtail.edit" event is created in those cases. This allows these initial revisions to be reviewed or reverted to in the page history view.

This commit also updates the existing create_log_entries_from_revisions management command to try to populate these initial revisions there as well. The relevant unit tests have been updated.

Fixes #8337 - please see that issue for specific testing steps.

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?