### PR TITLE
Different lock color when it's locked by current user

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -15,8 +15,10 @@ Changelog
  * Pull out behaviour from `AbstractFormField` to `FormMixin` and `AbstractEmailForm` to `EmailFormMixin` to allow use with subclasses of `Page` (Mehrdad Moradizadeh, Kurt Wall)
  * Add a `docs.wagtail.org/.well-known/security.txt` so that the security policy is available as per the specification on https://securitytxt.org/ (Jake Howard)
  * Add unit tests for the `classnames` Wagtail admin template tag (Mehrdad Moradizadeh)
+ * Show an inverse locked indicator when the page has been locked by the current user in reports and dashboard listings (Vaibhav Shukla, LB (Ben Johnston))
  * Fix: Prevent `PageQuerySet.not_public` from returning all pages when no page restrictions exist (Mehrdad Moradizadeh)
  * Fix: Ensure that duplicate block ids are unique when duplicating stream blocks in the page editor (Joshua Munn)
+ * Fix: Revise colour usage so that privacy & locked indicators can be seen in Windows High Contrast mode (LB (Ben Johnston))
 
 
 4.0.1 (05.09.2022)

--- a/client/scss/components/_indicator.scss
+++ b/client/scss/components/_indicator.scss
@@ -20,7 +20,27 @@
 }
 
 .indicator {
-  margin-inline-end: 0;
   font-size: 1em;
-  opacity: 0.7;
+  margin-inline-end: 0;
+  opacity: theme('opacity.70');
+
+  .icon {
+    border: 1px solid transparent;
+    border-radius: 50%;
+    font-size: 1.25em;
+    padding: 2px;
+    vertical-align: middle; // reset vertical-align set by icon.initial
+
+    @media (forced-colors: active) {
+      background-color: ButtonText;
+    }
+  }
+
+  &.indicator--is-inverse {
+    .icon {
+      border-color: $color-white; // ensure border is available for high contrast mode
+      background-color: $color-grey-1;
+      color: $color-white;
+    }
+  }
 }

--- a/client/scss/components/_indicator.scss
+++ b/client/scss/components/_indicator.scss
@@ -18,3 +18,9 @@
     }
   }
 }
+
+.indicator {
+  margin-inline-end: 0;
+  font-size: 1em;
+  opacity: 0.7;
+}

--- a/client/scss/components/_listing.scss
+++ b/client/scss/components/_listing.scss
@@ -408,12 +408,6 @@ ul.listing {
     opacity: 0.7;
   }
 
-  .indicator {
-    margin-inline-end: 0;
-    font-size: 1em;
-    opacity: 0.7;
-  }
-
   .status-tag {
     margin: 0;
     margin-inline: 0;

--- a/client/scss/core.scss
+++ b/client/scss/core.scss
@@ -150,7 +150,7 @@ These are classes for components.
 @import 'components/loading-mask';
 @import 'components/human-readable-date';
 @import 'components/link.legacy';
-@import 'components/privacy-indicator';
+@import 'components/indicator';
 @import 'components/status-tag';
 @import 'components/button-select';
 @import 'components/skiplink';

--- a/docs/releases/4.1.md
+++ b/docs/releases/4.1.md
@@ -24,11 +24,13 @@ Wagtail 4.1 is designated a Long Term Support (LTS) release. Long Term Support r
  * Pull out behaviour from `AbstractFormField` to `FormMixin` and `AbstractEmailForm` to `EmailFormMixin` to allow use with subclasses of `Page` [](form_builder_mixins) (Mehrdad Moradizadeh, Kurt Wall)
  * Add a `docs.wagtail.org/.well-known/security.txt` so that the security policy is available as per the specification on [https://securitytxt.org/](https://securitytxt.org/) (Jake Howard)
  * Add unit tests for the `classnames` Wagtail admin template tag (Mehrdad Moradizadeh)
+ * Show an inverse locked indicator when the page has been locked by the current user in reports and dashboard listings (Vaibhav Shukla, LB (Ben Johnston))
 
 ### Bug fixes
 
  * Prevent `PageQuerySet.not_public` from returning all pages when no page restrictions exist (Mehrdad Moradizadeh)
  * Ensure that duplicate block ids are unique when duplicating stream blocks in the page editor (Joshua Munn)
+ * Revise colour usage so that privacy & locked indicators can be seen in Windows High Contrast mode (LB (Ben Johnston))
 
 ## Upgrade considerations
 

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_locked_indicator.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_locked_indicator.html
@@ -7,6 +7,10 @@
 {% endcomment %}
 
 {% if page.locked %}
-    {# TODO: Different look when it's locked by current user? #}
-    <span class="indicator locked-indicator icon icon-locked" title="{% trans 'This page is locked to further editing' %}"></span>
+    <span
+        class="indicator locked-indicator {% if page.locked_by == request.user %}indicator--is-inverse{% endif %}"
+        title="{% if page.locked_by == request.user %}{% trans 'This page is locked, by you, to further editing' %}{% else %}{% trans 'This page is locked to further editing' %}{% endif %}"
+    >
+        {% icon name="lock" class_name="initial" %}
+    </span>
 {% endif %}

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_privacy_indicator.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_privacy_indicator.html
@@ -8,5 +8,10 @@
 
 {% test_page_is_public page as is_public %}
 {% if not is_public %}
-    <span class="indicator privacy-indicator icon icon-no-view" title="{% trans "This page is protected from public view" %}"></span>
+    <span
+        class="indicator privacy-indicator"
+        title="{% trans "This page is protected from public view" %}"
+    >
+        {% icon name="no-view" class_name="initial" %}
+    </span>
 {% endif %}

--- a/wagtail/admin/tests/test_privacy.py
+++ b/wagtail/admin/tests/test_privacy.py
@@ -401,7 +401,7 @@ class TestPrivacyIndicators(TestCase, WagtailTestUtils):
         # Must have one privacy icon (next to the private page)
         self.assertContains(
             response,
-            '<span class="indicator privacy-indicator icon icon-no-view"',
+            'class="indicator privacy-indicator"',
             count=1,
         )
 
@@ -420,7 +420,7 @@ class TestPrivacyIndicators(TestCase, WagtailTestUtils):
         # Must have one privacy icon (next to the private child page)
         self.assertContains(
             response,
-            '<span class="indicator privacy-indicator icon icon-no-view"',
+            'class="indicator privacy-indicator"',
             count=1,
         )
 

--- a/wagtail/admin/tests/test_reports_views.py
+++ b/wagtail/admin/tests/test_reports_views.py
@@ -63,6 +63,12 @@ class TestLockedPagesView(TestCase, WagtailTestUtils):
             response.content.decode(),
         )
 
+        # Locked by current user shown in indicator
+        self.assertContains(response, "locked-indicator indicator--is-inverse")
+        self.assertContains(
+            response, 'title="This page is locked, by you, to further editing"'
+        )
+
     def test_csv_export(self):
 
         self.page = Page.objects.first()


### PR DESCRIPTION
The lock will turn orange indicating that that specific page is locked by the current user.

![image](https://user-images.githubusercontent.com/52421094/183256483-9a8edda4-209c-4b02-be6f-57b64aa703f0.png)


**NOTE: we can also add this line on the top "Golden locks are pages locked by YOU"**

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets) 
