### PR TITLE
Add dispatched events for modal shown/hidden

### DIFF
--- a/client/src/includes/dialog.js
+++ b/client/src/includes/dialog.js
@@ -10,12 +10,27 @@ export const dialog = (
     const dialogTemplate = new A11yDialog(templateContent);
 
     // Prevent scrolling when dialog is open
+    // Dispatch events to hook into behaviour of modals showing / hiding that bubble
     dialogTemplate
-      .on('show', () => {
+      .on('show', (element, event) => {
         html.style.overflowY = 'hidden';
+        templateContent.dispatchEvent(
+          new CustomEvent('wagtail:dialog-shown', {
+            bubbles: true,
+            cancelable: false,
+            detail: { event },
+          }),
+        );
       })
-      .on('hide', () => {
+      .on('hide', (element, event) => {
         html.style.overflowY = '';
+        templateContent.dispatchEvent(
+          new CustomEvent('wagtail:dialog-hidden', {
+            bubbles: true,
+            cancelable: false,
+            detail: { event },
+          }),
+        );
       });
 
     // Attach event listeners to the dialog root (element with id), so it's


### PR DESCRIPTION
- a11y modals do dispatch events on the element, however these do not bubble so to listen for ANY dialog open/close events you have to keep track of all potential modals that will open in the DOM
- See https://a11y-dialog.netlify.app/advanced/events#dom-events
- This provides a Wagtail specific event name for when dialogs open or close and follow the convention set up in `panels.ts` with one event that provides the state in its detail object
- Intentionally not documenting this as we may refine this API at some point, plus we are still using Bootstrap modals in many places which have jQuery events and a different approach.

## how to test

* Open wagtail (bakerydemo)
* Go to any page
* In the console type `document.addEventListener('wagtail:dialog-toggle', console.info);`
* Now open the status side panel from the top right & click the privacy button (to trigger the privacy modal)
* You should see the console log details of the event
* Now close the modal
* You should see the console log the details of the closing event