### PR TITLE
Add ability to trigger frontend deprecation warnings

### DIFF
--- a/client/src/entrypoints/admin/development.js
+++ b/client/src/entrypoints/admin/development.js
@@ -1,0 +1,23 @@
+/**
+ * The purpose of this entrypoint is to add code that can be run when working
+ * with Django on DEBUG mode.
+ * This is intentionally mean to run even for production builds of the JS itself
+ * but provide those building on Wagtail to get some helpful warnings.
+ */
+
+/* eslint-disable no-console */
+// see client/src/utils/deprecation.ts - enable client-side debug
+
+console.info('Wagtail developer debug mode enabled');
+
+/**
+ * Listen to any development warning events and log them to the console as
+ * a warning with the detail added to the message.
+ */
+document.addEventListener('wagtail:development-warning', ({ detail, target }) =>
+  console.warn(
+    ...[...Object.values(detail), target !== document && target].filter(
+      Boolean,
+    ),
+  ),
+);

--- a/client/src/entrypoints/admin/page-chooser.js
+++ b/client/src/entrypoints/admin/page-chooser.js
@@ -1,4 +1,5 @@
 import { Chooser } from '../../components/ChooserWidget';
+import { removedInWagtail50Warning } from '../../utils/deprecation';
 
 class PageChooser extends Chooser {
   // eslint-disable-next-line no-undef
@@ -49,7 +50,9 @@ class PageChooser extends Chooser {
 window.PageChooser = PageChooser;
 
 function createPageChooser(id, parentId, options) {
-  /* RemovedInWagtail50Warning */
+  removedInWagtail50Warning(
+    '`createPageChooser(id)` should be replaced with `new PageChooser(id)`',
+  );
   return new PageChooser(id, parentId, options);
 }
 window.createPageChooser = createPageChooser;

--- a/client/src/entrypoints/documents/document-chooser.js
+++ b/client/src/entrypoints/documents/document-chooser.js
@@ -1,4 +1,5 @@
 import { Chooser } from '../../components/ChooserWidget';
+import { removedInWagtail50Warning } from '../../utils/deprecation';
 
 class DocumentChooser extends Chooser {
   // eslint-disable-next-line no-undef
@@ -7,7 +8,9 @@ class DocumentChooser extends Chooser {
 window.DocumentChooser = DocumentChooser;
 
 function createDocumentChooser(id) {
-  /* RemovedInWagtail50Warning */
+  removedInWagtail50Warning(
+    '`createDocumentChooser(id)` should be replaced with `new DocumentChooser(id)`',
+  );
   return new DocumentChooser(id);
 }
 window.createDocumentChooser = createDocumentChooser;

--- a/client/src/entrypoints/images/image-chooser.js
+++ b/client/src/entrypoints/images/image-chooser.js
@@ -1,4 +1,5 @@
 import { Chooser } from '../../components/ChooserWidget';
+import { removedInWagtail50Warning } from '../../utils/deprecation';
 
 class ImageChooser extends Chooser {
   // eslint-disable-next-line no-undef
@@ -37,7 +38,9 @@ class ImageChooser extends Chooser {
 window.ImageChooser = ImageChooser;
 
 function createImageChooser(id) {
-  /* RemovedInWagtail50Warning */
+  removedInWagtail50Warning(
+    '`createImageChooser(id)` should be replaced with `newImageChooser(id)`',
+  );
   return new ImageChooser(id);
 }
 

--- a/client/src/entrypoints/snippets/snippet-chooser.js
+++ b/client/src/entrypoints/snippets/snippet-chooser.js
@@ -1,4 +1,5 @@
 import { Chooser } from '../../components/ChooserWidget';
+import { removedInWagtail50Warning } from '../../utils/deprecation';
 
 /* global wagtailConfig */
 
@@ -20,7 +21,9 @@ class SnippetChooser extends Chooser {
 window.SnippetChooser = SnippetChooser;
 
 function createSnippetChooser(id) {
-  /* RemovedInWagtail50Warning */
+  removedInWagtail50Warning(
+    '`createSnippetChooser(id)` should be replaced with `new SnippetChooser(id)`',
+  );
   return new SnippetChooser(id);
 }
 window.createSnippetChooser = createSnippetChooser;

--- a/client/src/utils/deprecation.test.js
+++ b/client/src/utils/deprecation.test.js
@@ -1,0 +1,59 @@
+import * as allDeprecationWarnings from './deprecation';
+
+// jest.spyOn(console, 'info').mockImplementation(() => {});
+// const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+describe('deprecation warnings', () => {
+  const warn = jest.fn();
+  document.addEventListener(
+    'wagtail:development-warning',
+    ({ detail, target }) => warn({ detail, target }),
+  );
+
+  beforeEach(jest.resetAllMocks);
+
+  // so we do not have to update the tests each new version - just grab one warning export
+  const [removedInWagtailVersionWarning] = Object.values(
+    allDeprecationWarnings,
+  );
+
+  it('should export a warning function', () => {
+    expect(removedInWagtailVersionWarning).toBeInstanceOf(Function);
+  });
+
+  it('should dispatch a warning via custom event dispatch', () => {
+    expect(warn).not.toHaveBeenCalled();
+    removedInWagtailVersionWarning('some message', {
+      data: { additional: true },
+    });
+
+    expect(warn).toHaveBeenCalledWith({
+      detail: expect.objectContaining({
+        message: 'some message',
+        title: expect.stringContaining('Warning'),
+        data: { additional: true },
+      }),
+      target: window.document,
+    });
+  });
+
+  it('should allow an explicit target to be supplied', () => {
+    document.body.innerHTML = '<h1 id="header">Header</h1>';
+    const header = document.getElementById('header');
+
+    expect(warn).not.toHaveBeenCalled();
+
+    removedInWagtailVersionWarning('this element is gonna break!', {
+      target: header,
+    });
+
+    expect(warn).toHaveBeenCalledWith({
+      detail: expect.objectContaining({
+        message: 'this element is gonna break!',
+        title: expect.stringContaining('Warning'),
+        data: null,
+      }),
+      target: header,
+    });
+  });
+});

--- a/client/src/utils/deprecation.ts
+++ b/client/src/utils/deprecation.ts
@@ -1,0 +1,43 @@
+/**
+ * Prepare a function to dispatch a warning event with a specific title.
+ *
+ * @param title - Warning type in UpperCamelCase
+ */
+const developerWarning =
+  (title: string) =>
+  /**
+   * Dispatch a warning event.
+   *
+   * @param message - specific message to this warning
+   * @param options
+   * @param options.data - optional data object which will be logged to the console
+   * @param options.target - optional target DOM element to dispatch the event from
+   */
+  (
+    message: string,
+    {
+      data = null,
+      target = document,
+    }: {
+      data?: Record<string, unknown> | null;
+      target?: EventTarget;
+    } = {},
+  ): void => {
+    target.dispatchEvent(
+      new CustomEvent('wagtail:development-warning', {
+        bubbles: true,
+        cancelable: false,
+        detail: { title, message, data },
+      }),
+    );
+  };
+
+export const deprecationWarning = developerWarning('DeprecationWarning');
+
+export const pendingDeprecationWarning = developerWarning(
+  'PendingDeprecationWarning',
+);
+
+export const removedInWagtail50Warning = developerWarning(
+  'RemovedInWagtail50Warning',
+);

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -37,6 +37,7 @@ module.exports = function exports(env, argv) {
       'comments',
       'core',
       'date-time-chooser',
+      'development',
       'draftail',
       'expanding-formset',
       'filtered-select',

--- a/wagtail/admin/templates/wagtailadmin/admin_base.html
+++ b/wagtail/admin/templates/wagtailadmin/admin_base.html
@@ -51,6 +51,7 @@
     <script src="{% versioned_static 'wagtailadmin/js/vendor/bootstrap-modal.js' %}"></script>
     <script src="{% versioned_static 'wagtailadmin/js/vendor/tag-it.js' %}"></script>
     <script src="{% url 'wagtailadmin_javascript_catalog' %}"></script>
+    {% is_debug as load_development_script %}{% if load_development_script %}<script src="{% versioned_static 'wagtailadmin/js/development.js' %}"></script>{% endif %}
     <script src="{% versioned_static 'wagtailadmin/js/core.js' %}"></script>
     <script src="{% versioned_static 'wagtailadmin/js/vendor.js' %}"></script>
     <script src="{% versioned_static 'wagtailadmin/js/wagtailadmin.js' %}"></script>

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -1078,3 +1078,8 @@ def human_readable_date(date, description=None):
         "date": date,
         "description": description,
     }
+
+
+@register.simple_tag()
+def is_debug():
+    return settings.DEBUG

--- a/wagtail/admin/tests/test_templatetags.py
+++ b/wagtail/admin/tests/test_templatetags.py
@@ -369,3 +369,36 @@ class FragmentTagTest(TestCase):
         """
 
         self.assertHTMLEqual(expected, Template(template).render(context))
+
+
+class IsDebugTagTest(TestCase):
+    def test_debug_false(self):
+        context = Context({})
+
+        template = """
+            {% load wagtailadmin_tags %}
+            {% is_debug as debug %}
+            {% if debug %}DEBUG!{% else %}NOT DEBUG!{% endif %}
+        """
+
+        expected = """
+        NOT DEBUG!
+        """
+
+        self.assertHTMLEqual(expected, Template(template).render(context))
+
+    @override_settings(DEBUG=True)
+    def test_debug_true(self):
+        context = Context({})
+
+        template = """
+            {% load wagtailadmin_tags %}
+            {% is_debug as debug %}
+            {% if debug %}DEBUG!{% else %}NOT DEBUG!{% endif %}
+        """
+
+        expected = """
+        DEBUG!
+        """
+
+        self.assertHTMLEqual(expected, Template(template).render(context))


### PR DESCRIPTION
Adds a basic client-side / front-end deprecation warnings system that emulates the Python / Django approach, however instead of throwing an error with the deprecation class we simply use `console.warn`.

There are other ways to throw an error that is 'ignored' but it seemed to be bad practice and may be more frustrating to the developer than helpful.

Instead, in JavaScript it appears more common to use the `console` (info/warn/error) messaging to quietly communicate non-blocking issues to the developer.

**To test this behaviour**

* Open Wagtail, go to the page editor and trigger one of the soon to be deprecated chooser functions e.g. ` window.createDocumentChooser('13');`.
* When running Django with DEBUG=True (settings) it should fire a console warning about the preferred method to use, if not in DEBUG mode it should not trigger the warning (and the development.js file should not even be added to the script tags).
* Reminder - bakerydemo sets `DEBUG = True` in both settings for base and for dev + you will need to build the production JS assets to test the non-debug version.

<img width="1062" alt="Screen Shot 2022-08-18 at 8 24 37 am" src="https://user-images.githubusercontent.com/1396140/185254208-49850dd4-da77-4898-b024-5360b4946ff6.png">


---

- resolves #8956
- [X] Do the tests still pass?
- [X] Does the code comply with the style guide?
- [X] For Python changes: Have you added tests to cover the new/fixed behaviour?
- [X] For front-end changes: Did you test on all of Wagtail’s supported environments?
- For new features: Has the documentation been updated accordingly? **no**
  - Documentation not included as yet - not sure if we do want to document this at all but happy to update if needed
