### PR TITLE
Only use hidden until-found in panels if browsers supports it

### DIFF
--- a/client/src/includes/panels.ts
+++ b/client/src/includes/panels.ts
@@ -12,10 +12,12 @@ const toggleCollapsiblePanel = (
 
   if (expanded) {
     content.removeAttribute('hidden');
-  } else {
+  } else if ('onbeforematch' in document.body) {
     // Use experimental `until-found` value, so users can search inside the panels.
-    // Browsers without support for `until-found` will ignore the value and just `display: none` the panel.
     content.setAttribute('hidden', 'until-found');
+  } else {
+    // Browsers without support for `until-found` will not have this value set
+    content.setAttribute('hidden', '');
   }
 
   content.dispatchEvent(


### PR DESCRIPTION
- fixes #8961
- Note: There may be a different fix for this (CSS only) but this seemed the quickest way to get to the goal of the panels closing / opening correctly by using feature detection for this + as browsers upgrade they will automatically get the new behaviour.
- Tested on Chrome, Firefox and Safari - all now correctly collapse the panels, but Chrome still has the ability to search in the page to find content within collapsed items.
