### PR TITLE
Set atomic = False when renaming PageRevision table

### DIFF
--- a/wagtail/migrations/0070_rename_pagerevision_revision.py
+++ b/wagtail/migrations/0070_rename_pagerevision_revision.py
@@ -17,6 +17,8 @@ class Migration(migrations.Migration):
         ("wagtailcore", "0069_log_entry_jsonfield"),
     ]
 
+    atomic = False
+
     operations = [
         migrations.RunPython(
             disable_sqlite_legacy_alter_table,


### PR DESCRIPTION
This allows it to complete on SQLite <3.26, as per https://github.com/wagtail/wagtail/issues/8635#issuecomment-1209385465
