### PR TITLE
Show Status column in snippet chooser view if `DraftStateMixin` is applied

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/tables/status_tag_cell.html
+++ b/wagtail/admin/templates/wagtailadmin/tables/status_tag_cell.html
@@ -1,3 +1,3 @@
 <td {% if column.classname %}class="{{ column.classname }}"{% endif %}>
-    <div class="status-tag primary">{{ value }}</div>
+    <div class="status-tag {% if primary %}primary{% endif %}">{{ value }}</div>
 </td>

--- a/wagtail/admin/ui/tables.py
+++ b/wagtail/admin/ui/tables.py
@@ -182,6 +182,20 @@ class StatusTagColumn(Column):
 
     cell_template_name = "wagtailadmin/tables/status_tag_cell.html"
 
+    def __init__(self, name, primary=None, **kwargs):
+        super().__init__(name, **kwargs)
+        self.primary = primary
+
+    def get_primary(self, instance):
+        if callable(self.primary):
+            return self.primary(instance)
+        return self.primary
+
+    def get_cell_context_data(self, instance, parent_context):
+        context = super().get_cell_context_data(instance, parent_context)
+        context["primary"] = self.get_primary(instance)
+        return context
+
 
 class DateColumn(Column):
     """Outputs a date in human-readable format"""

--- a/wagtail/admin/views/generic/models.py
+++ b/wagtail/admin/views/generic/models.py
@@ -259,7 +259,12 @@ class IndexView(
         return column_class("_updated_at", label=_("Updated"), sort_key="_updated_at")
 
     def _get_status_tag_column(self, column_class=StatusTagColumn):
-        return column_class("status_string", label=_("Status"), sort_key="live")
+        return column_class(
+            "status_string",
+            label=_("Status"),
+            sort_key="live",
+            primary=lambda instance: instance.live,
+        )
 
     def _get_default_columns(self):
         columns = [

--- a/wagtail/snippets/tests/test_snippets.py
+++ b/wagtail/snippets/tests/test_snippets.py
@@ -2595,6 +2595,43 @@ class TestSnippetChooseResults(TestCase, WagtailTestUtils):
         )
 
 
+class TestSnippetChooseStatus(TestCase, WagtailTestUtils):
+    def setUp(self):
+        self.login()
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.draft = DraftStateModel.objects.create(text="foo", live=False)
+        cls.live = DraftStateModel.objects.create(text="bar", live=True)
+        cls.live_draft = DraftStateModel.objects.create(text="baz", live=True)
+        cls.live_draft.save_revision()
+
+    def get(self, view_name, params=None):
+        return self.client.get(
+            reverse(f"wagtailsnippetchoosers_tests_draftstatemodel:{view_name}"),
+            params or {},
+        )
+
+    def test_choose_view_shows_status_column(self):
+        response = self.get("choose")
+        html = response.json()["html"]
+        self.assertTagInHTML("<th>Status</th>", html)
+        self.assertTagInHTML('<div class="status-tag ">draft</div>', html)
+        self.assertTagInHTML('<div class="status-tag primary">live</div>', html)
+        self.assertTagInHTML('<div class="status-tag primary">live + draft</div>', html)
+
+    def test_choose_results_view_shows_status_column(self):
+        response = self.get("choose_results")
+        self.assertContains(response, "<th>Status</th>", html=True)
+        self.assertContains(response, '<div class="status-tag ">draft</div>', html=True)
+        self.assertContains(
+            response, '<div class="status-tag primary">live</div>', html=True
+        )
+        self.assertContains(
+            response, '<div class="status-tag primary">live + draft</div>', html=True
+        )
+
+
 class TestSnippetChooseWithSearchableSnippet(TestCase, WagtailTestUtils):
     def setUp(self):
         self.login()

--- a/wagtail/snippets/views/chooser.py
+++ b/wagtail/snippets/views/chooser.py
@@ -1,5 +1,6 @@
 from django.utils.translation import gettext_lazy as _
 
+from wagtail.admin.ui.tables import StatusTagColumn
 from wagtail.admin.views.generic.chooser import (
     BaseChooseView,
     ChooseResultsViewMixin,
@@ -8,6 +9,7 @@ from wagtail.admin.views.generic.chooser import (
     CreationFormMixin,
 )
 from wagtail.admin.viewsets.chooser import ChooserViewSet
+from wagtail.models import DraftStateMixin
 
 
 class BaseSnippetChooseView(BaseChooseView):
@@ -20,6 +22,19 @@ class BaseSnippetChooseView(BaseChooseView):
     @property
     def page_subtitle(self):
         return self.model._meta.verbose_name
+
+    @property
+    def columns(self):
+        columns = super().columns
+        if issubclass(self.model, DraftStateMixin):
+            columns += [
+                StatusTagColumn(
+                    "status_string",
+                    label=_("Status"),
+                    primary=lambda instance: instance.live,
+                ),
+            ]
+        return columns
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)


### PR DESCRIPTION
This PR adds a "Status" column in snippet chooser views if the snippet has the `DraftStateMixin` applied. This helps users be more careful when choosing Snippets that may be in a draft status, considering that we haven't really added any meaning towards what a "draft snippet" is.

<img width="935" alt="image" src="https://user-images.githubusercontent.com/6379424/184074250-1088ac42-6285-4343-b7c8-6a79cefd313f.png">

_Please check the following:_

-   [x] Do the tests still pass?
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?

**Please describe additional details for testing this change**.

- Create a snippet model that extends `DraftStateMixin`
- Create a page or other snippet that references the model
- Click on the chooser's "Choose" button
- Verify that the Status column is shown in the table
