### PR TITLE
Extract generic UnpublishView and add unpublish action to snippets with DraftStateMixin

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -86,6 +86,7 @@ Changelog
  * Add HTML-aware max_length validation and character count on RichTextField and RichTextBlock (Matt Westcott, Thibaud Colas)
  * Remove undocumented `SearchableListMixin` (Sage Abdullah)
  * Extract filtering code from ReportView to generic IndexView (Sage Abdullah)
+ * Extract unpublish code for pages to generic UnpublishView (Sage Abdullah)
  * Retain other query params in header search behaviour (Sage Abdullah)
  * Remove `is_parent` kwarg in various page button hooks as this approach is no longer required (Paarth Agarwal)
  * Improve security of redirect imports by adding a file hash (signature) check for so that any tampering of file contents between requests will throw a `BadSignature` error (Jaap Roes)

--- a/docs/releases/4.0.md
+++ b/docs/releases/4.0.md
@@ -130,6 +130,7 @@ The bulk of these enhancements have been from Paarth Agarwal, who has been doing
  * Migrate Home (Dashboard) view to use generic Wagtail class based view (LB (Ben) Johnston)
  * Combine most of Wagtail’s stylesheets into the global `core.css` file (Thibaud Colas)
  * Update `ReportView` to extend from generic `wagtail.admin.views.generic.models.IndexView` (Sage Abdullah)
+ * Update pages `Unpublish` view to extend from generic `wagtail.admin.views.generic.models.UnpublishView` (Sage Abdullah)
  * Introduce a `wagtail.admin.viewsets.chooser.ChooserViewSet` module to serve as a common base implementation for chooser modals (Matt Westcott)
  * Add documentation for `wagtail.admin.viewsets.model.ModelViewSet` (Matt Westcott)
  * Added [multi-site support](api_filtering_pages_by_site) to the API (Sævar Öfjörð Magnússon)

--- a/wagtail/actions/unpublish.py
+++ b/wagtail/actions/unpublish.py
@@ -41,7 +41,10 @@ class UnpublishAction:
                 "You do not have permission to unpublish this object"
             )
 
-    def _after_unpublish(self):
+    def _commit_unpublish(self, object):
+        object.save()
+
+    def _after_unpublish(self, object):
         unpublished.send(sender=type(object), instance=object)
 
     def _unpublish_object(self, object, set_expired, commit, user, log_action):
@@ -59,8 +62,7 @@ class UnpublishAction:
                 object.expired = True
 
             if commit:
-                # using clean=False to bypass validation
-                object.save(clean=False)
+                self._commit_unpublish(object)
 
             if log_action:
                 log(
@@ -75,7 +77,7 @@ class UnpublishAction:
 
             object.revisions.update(approved_go_live_at=None)
 
-            self._after_unpublish()
+            self._after_unpublish(object)
 
     def execute(self, skip_permission_checks=False):
         self.check(skip_permission_checks=skip_permission_checks)

--- a/wagtail/actions/unpublish_page.py
+++ b/wagtail/actions/unpublish_page.py
@@ -41,15 +41,17 @@ class UnpublishPageAction(UnpublishAction):
                 "You do not have permission to unpublish this page"
             ) from error
 
-    def _after_unpublish(self):
-        for alias in self.object.aliases.all():
+    def _commit_unpublish(self, object):
+        # using clean=False to bypass validation
+        object.save(clean=False)
+
+    def _after_unpublish(self, object):
+        for alias in object.aliases.all():
             alias.unpublish()
 
-        page_unpublished.send(
-            sender=self.object.specific_class, instance=self.object.specific
-        )
+        page_unpublished.send(sender=object.specific_class, instance=object.specific)
 
-        super()._after_unpublish()
+        super()._after_unpublish(object)
 
     def execute(self, skip_permission_checks=False):
         super().execute(skip_permission_checks)

--- a/wagtail/admin/templates/wagtailadmin/pages/confirm_unpublish.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/confirm_unpublish.html
@@ -1,55 +1,46 @@
-{% extends "wagtailadmin/base.html" %}
+{% extends "wagtailadmin/shared/confirm_unpublish.html" %}
 {% load i18n wagtailadmin_tags %}
-{% block titletag %}{% blocktrans trimmed with title=page.get_admin_display_title %}Unpublish {{ title }}{% endblocktrans %}{% endblock %}
-{% block content %}
-    {% trans "Unpublish" as unpublish_str %}
-    {% include "wagtailadmin/shared/header.html" with title=unpublish_str subtitle=page.get_admin_display_title icon="doc-empty-inverse" %}
 
-    <div class="nice-padding">
-        <p>
-            {% trans "Are you sure you want to unpublish this page?" %}
-            {% if translation_count %}
-                {% blocktrans trimmed with translation_count=translation_count count counter=translation_count %}
-                    This will also unpublish one translation of the page.
+{% block confirmation_text %}
+    <p>
+        {% trans "Are you sure you want to unpublish this page?" %}
+        {% if translation_count %}
+            {% blocktrans trimmed with translation_count=translation_count count counter=translation_count %}
+                This will also unpublish one translation of the page.
+            {% plural %}
+                This will also unpublish all {{ translation_count }} translations of the page.
+            {% endblocktrans %}
+        {% endif %}
+    </p>
+{% endblock %}
+
+{% block form_content %}
+    <input type="hidden" name="next" value="{{ next_url }}">
+
+    {% if live_descendant_count > 0 or translation_descendant_count > 0 %}
+        {% fragment as text %}
+            {% if translation_descendant_count %}
+                {% if translation_descendant_count == 1 %}
+                    {% blocktrans trimmed count counter=live_descendant_count %}
+                        This page has one subpage and its translations have a combined one translated child page. Unpublish these too
+                    {% plural %}
+                        This page has {{ live_descendant_count }} child pages and its translations have a combined one translated child page. Unpublish these too
+                    {% endblocktrans %}
+                {% else %}
+                    {% blocktrans trimmed count counter=live_descendant_count %}
+                        This page has one child page and its translations have a combined {{ translation_descendant_count }} translated child pages. Unpublish these too
+                    {% plural %}
+                        This page has {{ live_descendant_count }} child pages and its translations have a combined {{ translation_descendant_count }} translated child pages. Unpublish these too
+                    {% endblocktrans %}
+                {% endif %}
+            {% else %}
+                {% blocktrans trimmed count counter=live_descendant_count %}
+                    This page has one subpage. Unpublish this too
                 {% plural %}
-                    This will also unpublish all {{ translation_count }} translations of the page.
+                    This page has {{ live_descendant_count }} subpages. Unpublish these too
                 {% endblocktrans %}
             {% endif %}
-        </p>
-
-        <form action="{% url 'wagtailadmin_pages:unpublish' page.id %}" method="POST">
-            {% csrf_token %}
-            <input type="hidden" name="next" value="{{ next }}">
-            {% if live_descendant_count > 0 or translation_descendant_count > 0 %}
-                {% fragment as text %}
-                    {% if translation_descendant_count %}
-                        {% if translation_descendant_count == 1 %}
-                            {% blocktrans trimmed count counter=live_descendant_count %}
-                                This page has one subpage and its translations have a combined one translated child page. Unpublish these too
-                            {% plural %}
-                                This page has {{ live_descendant_count }} child pages and its translations have a combined one translated child page. Unpublish these too
-                            {% endblocktrans %}
-                        {% else %}
-                            {% blocktrans trimmed count counter=live_descendant_count %}
-                                This page has one child page and its translations have a combined {{ translation_descendant_count }} translated child pages. Unpublish these too
-                            {% plural %}
-                                This page has {{ live_descendant_count }} child pages and its translations have a combined {{ translation_descendant_count }} translated child pages. Unpublish these too
-                            {% endblocktrans %}
-                        {% endif %}
-                    {% else %}
-                        {% blocktrans trimmed count counter=live_descendant_count %}
-                            This page has one subpage. Unpublish this too
-                        {% plural %}
-                            This page has {{ live_descendant_count }} subpages. Unpublish these too
-                        {% endblocktrans %}
-                    {% endif %}
-                {% endfragment %}
-                {% include "wagtailadmin/shared/forms/single_checkbox.html" with name="include_descendants" label_classname="w-label-3 w-mb-4" text=text %}
-            {% endif %}
-            <div>
-                <button class="button" type="submit">{% trans 'Yes, unpublish it' %}</button>
-                <a href="{% if next %}{{ next }}{% else %}{% url 'wagtailadmin_explore' page.get_parent.id %}{% endif %}" class="button button-secondary">{% trans "No, don't unpublish" %}</a>
-            </div>
-        </form>
-    </div>
+        {% endfragment %}
+        {% include "wagtailadmin/shared/forms/single_checkbox.html" with name="include_descendants" label_classname="w-label-3 w-mb-4" text=text %}
+    {% endif %}
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/shared/confirm_unpublish.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/confirm_unpublish.html
@@ -1,0 +1,29 @@
+{% extends "wagtailadmin/base.html" %}
+{% load i18n wagtailadmin_tags %}
+{% block titletag %}{% blocktrans trimmed with title=object_display_title %}Unpublish {{ title }}{% endblocktrans %}{% endblock %}
+{% block content %}
+    {% trans "Unpublish" as unpublish_str %}
+    {% include "wagtailadmin/shared/header.html" with title=unpublish_str subtitle=object_display_title icon="doc-empty-inverse" %}
+
+    <div class="nice-padding">
+        {% block confirmation_text %}
+            <p>
+                {% blocktrans trimmed with model_name=model_opts.verbose_name %}
+                    Are you sure you want to unpublish this {{ model_name }}?
+                {% endblocktrans %}
+            </p>
+        {% endblock %}
+
+        <form action="{{ unpublish_url }}" method="POST">
+            {% csrf_token %}
+
+            {% block form_content %}
+            {% endblock %}
+
+            <div>
+                <button class="button" type="submit">{% trans 'Yes, unpublish it' %}</button>
+                <a href="{{ next_url }}" class="button button-secondary">{% trans "No, don't unpublish" %}</a>
+            </div>
+        </form>
+    </div>
+{% endblock %}

--- a/wagtail/admin/urls/pages.py
+++ b/wagtail/admin/urls/pages.py
@@ -46,7 +46,7 @@ urlpatterns = [
     path("<int:page_id>/view_draft/", preview.view_draft, name="view_draft"),
     path("<int:parent_page_id>/add_subpage/", create.add_subpage, name="add_subpage"),
     path("<int:page_id>/delete/", delete.delete, name="delete"),
-    path("<int:page_id>/unpublish/", unpublish.unpublish, name="unpublish"),
+    path("<int:page_id>/unpublish/", unpublish.Unpublish.as_view(), name="unpublish"),
     path(
         "<int:page_id>/convert_alias/",
         convert_alias.convert_alias,

--- a/wagtail/admin/views/pages/unpublish.py
+++ b/wagtail/admin/views/pages/unpublish.py
@@ -1,83 +1,93 @@
 from django.conf import settings
 from django.core.exceptions import PermissionDenied
-from django.shortcuts import get_object_or_404, redirect
-from django.template.response import TemplateResponse
+from django.shortcuts import get_object_or_404
 from django.urls import reverse
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy as _
 
 from wagtail import hooks
 from wagtail.actions.unpublish_page import UnpublishPageAction
-from wagtail.admin import messages
+from wagtail.admin.views.generic.models import UnpublishView
 from wagtail.admin.views.pages.utils import get_valid_next_url_from_request
 from wagtail.models import Page, UserPagePermissionsProxy
 
 
-def unpublish(request, page_id):
-    page = get_object_or_404(Page, id=page_id).specific
+class Unpublish(UnpublishView):
+    model = Page
+    index_url_name = "wagtailadmin_explore"
+    edit_url_name = "wagtailadmin_pages:edit"
+    unpublish_url_name = "wagtailadmin_pages:unpublish"
+    success_message = _("Page '{0}' unpublished.")
+    template_name = "wagtailadmin/pages/confirm_unpublish.html"
 
-    user_perms = UserPagePermissionsProxy(request.user)
-    if not user_perms.for_page(page).can_unpublish():
-        raise PermissionDenied
+    def setup(self, request, page_id, *args, **kwargs):
+        # Rename path kwargs from pk to page_id
+        return super().setup(request, page_id, *args, **kwargs)
 
-    next_url = get_valid_next_url_from_request(request)
+    def get_object(self, queryset=None):
+        return get_object_or_404(Page, id=self.pk).specific
 
-    pages_to_unpublish = {page}
+    def get_object_display_title(self):
+        return self.object.get_admin_display_title()
 
-    if getattr(settings, "WAGTAIL_I18N_ENABLED", False):
-        for fn in hooks.get_hooks("construct_translated_pages_to_cascade_actions"):
-            fn_pages = fn([page], "unpublish")
-            if fn_pages and isinstance(fn_pages, dict):
-                for additional_pages in fn_pages.values():
-                    pages_to_unpublish.update(additional_pages)
+    def dispatch(self, request, *args, **kwargs):
+        user_perms = UserPagePermissionsProxy(request.user)
+        if not user_perms.for_page(self.object).can_unpublish():
+            raise PermissionDenied
+        return super().dispatch(request, *args, **kwargs)
 
-    pages_to_unpublish = list(pages_to_unpublish)
+    def get_success_message(self):
+        return self.success_message.format(self.object.get_admin_display_title())
 
-    if request.method == "POST":
-        include_descendants = request.POST.get("include_descendants", False)
+    def get_next_url(self):
+        next_url = get_valid_next_url_from_request(self.request)
+        if next_url:
+            return next_url
+        return reverse(self.index_url_name, args=(self.object.get_parent().id,))
 
-        for fn in hooks.get_hooks("before_unpublish_page"):
-            result = fn(request, page)
-            if hasattr(result, "status_code"):
-                return result
+    def get_objects_to_unpublish(self):
+        objects_to_unpublish = {self.object}
 
-        for page in pages_to_unpublish:
+        if getattr(settings, "WAGTAIL_I18N_ENABLED", False):
+            for fn in hooks.get_hooks("construct_translated_pages_to_cascade_actions"):
+                fn_pages = fn([self.object], "unpublish")
+                if fn_pages and isinstance(fn_pages, dict):
+                    for additional_pages in fn_pages.values():
+                        objects_to_unpublish.update(additional_pages)
+
+        return list(objects_to_unpublish)
+
+    def unpublish(self):
+        hook_response = self.run_hook(
+            "before_unpublish_page", self.request, self.object
+        )
+        if hook_response is not None:
+            return hook_response
+
+        include_descendants = self.request.POST.get("include_descendants", False)
+
+        for object in self.objects_to_unpublish:
             action = UnpublishPageAction(
-                page, user=request.user, include_descendants=include_descendants
+                object, user=self.request.user, include_descendants=include_descendants
             )
             action.execute(skip_permission_checks=True)
 
-        for fn in hooks.get_hooks("after_unpublish_page"):
-            result = fn(request, page)
-            if hasattr(result, "status_code"):
-                return result
+        hook_response = self.run_hook("after_unpublish_page", self.request, self.object)
+        if hook_response is not None:
+            return hook_response
 
-        messages.success(
-            request,
-            _("Page '{0}' unpublished.").format(page.get_admin_display_title()),
-            buttons=[
-                messages.button(
-                    reverse("wagtailadmin_pages:edit", args=(page.id,)), _("Edit")
-                )
-            ],
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context.update(
+            {
+                "page": self.object,
+                "live_descendant_count": self.object.get_descendants().live().count(),
+                "translation_count": len(self.objects_to_unpublish[1:]),
+                "translation_descendant_count": sum(
+                    [
+                        p.get_descendants().filter(alias_of__isnull=True).live().count()
+                        for p in self.objects_to_unpublish[1:]
+                    ]
+                ),
+            }
         )
-
-        if next_url:
-            return redirect(next_url)
-        return redirect("wagtailadmin_explore", page.get_parent().id)
-
-    return TemplateResponse(
-        request,
-        "wagtailadmin/pages/confirm_unpublish.html",
-        {
-            "page": page,
-            "next": next_url,
-            "live_descendant_count": page.get_descendants().live().count(),
-            "translation_count": len(pages_to_unpublish[1:]),
-            "translation_descendant_count": sum(
-                [
-                    p.get_descendants().filter(alias_of__isnull=True).live().count()
-                    for p in pages_to_unpublish[1:]
-                ]
-            ),
-        },
-    )
+        return context

--- a/wagtail/snippets/action_menu.py
+++ b/wagtail/snippets/action_menu.py
@@ -75,6 +75,27 @@ class PublishMenuItem(ActionMenuItem):
         return context["request"].user.has_perm(publish_permission)
 
 
+class UnpublishMenuItem(ActionMenuItem):
+    label = _("Unpublish")
+    name = "action-unpublish"
+    icon_name = "download-alt"
+    classname = "action-secondary"
+
+    def is_shown(self, context):
+        if context["view"] == "edit" and context["instance"].live:
+            publish_permission = get_permission_name("publish", context["model"])
+            return context["request"].user.has_perm(publish_permission)
+        return False
+
+    def get_url(self, context):
+        app_label = context["model"]._meta.app_label
+        model_name = context["model"]._meta.model_name
+        return reverse(
+            f"wagtailsnippets_{app_label}_{model_name}:unpublish",
+            args=[quote(context["instance"].pk)],
+        )
+
+
 class DeleteMenuItem(ActionMenuItem):
     name = "action-delete"
     label = _("Delete")
@@ -112,10 +133,13 @@ def get_base_snippet_action_menu_items(model):
     """
     menu_items = [
         SaveMenuItem(order=0),
-        DeleteMenuItem(order=20),
+        DeleteMenuItem(order=10),
     ]
     if issubclass(model, DraftStateMixin):
-        menu_items += [PublishMenuItem(order=10)]
+        menu_items += [
+            UnpublishMenuItem(order=20),
+            PublishMenuItem(order=30),
+        ]
 
     for hook in hooks.get_hooks("register_snippet_action_menu_item"):
         action_menu_item = hook(model)


### PR DESCRIPTION
-   [x] Do the tests still pass?
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?

**Please describe additional details for testing this change**.

- Create a snippet with DraftStateMixin applied
- Publish the snippet
- Open the edit view and click on the unpublish action menu