### PR TITLE
Fix updatemodulepaths for Python 3.7

### DIFF
--- a/wagtail/bin/wagtail.py
+++ b/wagtail/bin/wagtail.py
@@ -353,7 +353,14 @@ class UpdateModulePaths(Command):
                     found_unicode_error = True
                 else:
                     line = self._rewrite_line(original_line)
-                    sys.stdout.write(line.encode("utf-8"))
+                    if CURRENT_PYTHON >= (3, 8):
+                        sys.stdout.write(line.encode("utf-8"))
+                    else:
+                        # Python 3.7 opens the output stream in text mode, so write the line back as
+                        # text rather than bytes:
+                        # https://github.com/python/cpython/commit/be6dbfb43b89989ccc83fbc4c5234f50f44c47ad
+                        sys.stdout.write(line)
+
                     if line != original_line:
                         change_count += 1
 


### PR DESCRIPTION
Fixes #8970. Python 3.7 incorrectly opens the stream for writing in text mode (https://github.com/python/cpython/commit/be6dbfb43b89989ccc83fbc4c5234f50f44c47ad), so work around this by writing the unicode string back rather than encoding back to bytes.

This will probably fail if we're on Windows AND Python 3.7 AND encounter non-ASCII characters (because in that case it'll be open for writing as Windows-1252 encoding), but it's probably the best we can do without abandoning the fileinput library entirely.

(Note: this should probably be backported to 3.0.x when it gets merged)