### PR TITLE
Changed a reference to deprecated BASE_URL to the new WAGTAILADMIN_BASE_URL

### DIFF
--- a/docs/topics/images.md
+++ b/docs/topics/images.md
@@ -214,7 +214,7 @@ A shorthand for outputting the attributes `src`, `width`, `height` and `alt` in 
 
 ### `full_url`
 
-Same as `url`, but always returns a full absolute URL. This requires `BASE_URL` to be set in the project settings.
+Same as `url`, but always returns a full absolute URL. This requires `WAGTAILADMIN_BASE_URL` to be set in the project settings.
 
 This is useful for images that will be re-used outside of the current site, such as social share images:
 


### PR DESCRIPTION
The docs didn't match the code, so an user trying to set BASE_URL as shown will do nothing.