### PR TITLE
documentation - extending generic views - fix typo

### DIFF
--- a/docs/extending/generic_views.md
+++ b/docs/extending/generic_views.md
@@ -267,3 +267,4 @@ class BaseUserChooseView(BaseChooseView):
         paginator = APIPaginator(result['meta']['total_count'], self.per_page)
         page = Page(result['items'], page_number, paginator)
         return page
+```


### PR DESCRIPTION
- closing ``` (backticks) were missing
- did not make a visual change (looks like the parser cleaned this up) but would be an issue if new sections were added after