### PR TITLE
Set BaseSetting deprecation to 5.0

### DIFF
--- a/wagtail/contrib/settings/models.py
+++ b/wagtail/contrib/settings/models.py
@@ -5,12 +5,12 @@ from django.utils.functional import cached_property
 
 from wagtail.coreutils import InvokeViaAttributeShortcut
 from wagtail.models import Site
-from wagtail.utils.deprecation import RemovedInWagtail60Warning
+from wagtail.utils.deprecation import RemovedInWagtail50Warning
 
 from .registry import register_setting
 
 __all__ = [
-    "BaseSetting",  # RemovedInWagtail60Warning
+    "BaseSetting",  # RemovedInWagtail50Warning
     "BaseGenericSetting",
     "BaseSiteSetting",
     "register_setting",
@@ -214,7 +214,7 @@ class BaseSetting(BaseSiteSetting):
                 "`wagtail.contrib.settings.models.BaseSiteSetting` or "
                 "`wagtail.contrib.settings.models.BaseGenericSetting`"
             ),
-            category=RemovedInWagtail60Warning,
+            category=RemovedInWagtail50Warning,
             stacklevel=2,
         )
         return super().__init__(self, *args, **kwargs)


### PR DESCRIPTION
Since adopting SemVer we haven't addressed the question of what it means for our deprecation policy - but the deprecation of BaseSetting (which is currently tagged as `RemovedInWagtail60Warning` in the code) prompts us to make a decision on this. My thinking is:

* We don't currently know how many releases into the future 5.0 and 6.0 will be - version 6.0 could be a very long time away indeed, and we don't really want to have "dead" code sitting around long term
* According to the principles of SemVer, it would be fair game to drop the compatibility shim in 5.0, because the major version bump tells people to expect breaking changes
* If the next release (November 2022) happens to be 5.0 after all, that would mean developers don't get the two release window to update their code, that we've previously given them.
* However: I don't think anyone's going to complain if we state our intention to remove a feature in 5.0 now, but later decide to postpone the removal. (Python delaying the move from `collections` to `collections.abc` springs to mind as a precedent...)

So, I propose to mark these as `RemovedInWagtail50Warning` now, but leave open the possibility of bumping them to `RemovedInWagtail60Warning` later, if and when we make the decision to version-bump the November release to 5.0.