### PR TITLE
Add reference docs for `RevisionMixin`, `DraftStateMixin`, and `PreviewableMixin`

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -110,6 +110,7 @@ Changelog
  * Move commenting trigger to inline toolbar and move block splitting to the block toolbar and command palette only in Draftail (Thibaud Colas)
  * Pages are now locked when they are scheduled for publishing (Karl Hobley)
  * Simplify page chooser views by converting to class-based views (Matt Westcott)
+ * Add reference documentation for `RevisionMixin`, `DraftStateMixin`, and `PreviewableMixin` (Sage Abdullah)
  * Fix: Typo in `ResumeWorkflowActionFormatter` message (Stefan Hammer)
  * Fix: Throw a meaningful error when saving an image to an unrecognised image format (Christian Franke)
  * Fix: Remove extra padding for headers with breadcrumbs on mobile viewport (Steven Steinwand)

--- a/docs/reference/pages/model_reference.md
+++ b/docs/reference/pages/model_reference.md
@@ -487,6 +487,42 @@ The `locale` and `translation_key` fields have a unique key constraint to preven
     .. autoattribute:: localized
 ```
 
+## `RevisionMixin`
+
+`RevisionMixin` is an abstract model that can be added to any non-page Django model to allow saving revisions of its instances.
+Pages already include this mixin, so there is no need to add it.
+
+```{versionadded} 4.0
+The model is added to allow Snippets to save revisions, revert to a previous revision, and compare changes between revisions.
+```
+
+### Database fields
+
+```{eval-rst}
+.. class:: RevisionMixin
+
+    .. attribute:: latest_revision
+
+        (foreign key to :class:`~wagtail.models.Revision`)
+
+        This points to the latest revision created for the object. This reference is stored in the database for performance optimisation.
+```
+
+### Methods and properties
+
+```{eval-rst}
+.. class:: RevisionMixin
+    :noindex:
+
+    .. autoattribute:: revisions
+
+    .. automethod:: save_revision
+
+    .. automethod:: get_latest_revision_as_object
+
+    .. automethod:: with_content_json
+```
+
 (revision_model_ref)=
 
 ## `Revision`

--- a/docs/reference/pages/model_reference.md
+++ b/docs/reference/pages/model_reference.md
@@ -523,6 +523,66 @@ The model is added to allow Snippets to save revisions, revert to a previous rev
     .. automethod:: with_content_json
 ```
 
+## `DraftStateMixin`
+
+`DraftStateMixin` is an abstract model that can be added to any non-page Django model to allow its instances to have unpublished changes.
+This mixin requires {class}`~wagtail.models.RevisionMixin` to be applied. Pages already include this mixin, so there is no need to add it.
+
+```{versionadded} 4.0
+The model is added to allow Snippets to have changes that are not immediately reflected to the instance.
+```
+
+### Database fields
+
+```{eval-rst}
+.. class:: DraftStateMixin
+
+    .. attribute:: live
+
+        (boolean)
+
+        A boolean that is set to ``True`` if the object is published.
+
+        Note: this field defaults to ``True`` meaning that any objects that are created programmatically will be published by default.
+
+    .. attribute:: live_revision
+
+        (foreign key to :class:`~wagtail.models.Revision`)
+
+        This points to the revision that is currently live.
+
+    .. attribute:: has_unpublished_changes
+
+        (boolean)
+
+        A boolean that is set to ``True`` when the object is either in draft or published with draft changes.
+
+    .. attribute:: first_published_at
+
+        (date/time)
+
+        The date/time when the object was first published.
+
+    .. attribute:: last_published_at
+
+        (date/time)
+
+        The date/time when the object was last published.
+```
+
+### Methods and properties
+
+```{eval-rst}
+.. class:: DraftStateMixin
+    :noindex:
+
+    .. automethod:: publish
+
+    .. automethod:: unpublish
+
+    .. automethod:: with_content_json
+```
+
 (revision_model_ref)=
 
 ## `Revision`

--- a/docs/reference/pages/model_reference.md
+++ b/docs/reference/pages/model_reference.md
@@ -487,6 +487,33 @@ The `locale` and `translation_key` fields have a unique key constraint to preven
     .. autoattribute:: localized
 ```
 
+## `PreviewableMixin`
+
+`PreviewableMixin` is a mixin class that can be added to any non-page Django model to allow previewing its instances.
+Pages already include this mixin, so there is no need to add it.
+
+```{versionadded} 4.0
+The class is added to allow Snippets to have live preview in the editor.
+```
+
+### Methods and properties
+
+```{eval-rst}
+.. class:: PreviewableMixin
+
+    .. autoattribute:: preview_modes
+
+    .. autoattribute:: default_preview_mode
+
+    .. automethod:: is_previewable
+
+    .. automethod:: get_preview_context
+
+    .. automethod:: get_preview_template
+
+    .. automethod:: serve_preview
+```
+
 ## `RevisionMixin`
 
 `RevisionMixin` is an abstract model that can be added to any non-page Django model to allow saving revisions of its instances.

--- a/docs/reference/pages/model_reference.md
+++ b/docs/reference/pages/model_reference.md
@@ -404,7 +404,7 @@ The {meth}`~wagtail.models.Site.find_for_request` function returns the Site obje
     .. automethod:: get_site_root_paths
 ```
 
-## Locale
+## `Locale`
 
 The `Locale` model defines the set of languages and/or locales that can be used on a site.
 Each `Locale` record corresponds to a "language code" defined in the :ref:`wagtail_content_languages_setting` setting.
@@ -440,18 +440,17 @@ database queries making them unable to be edited or viewed.
     .. automethod:: get_display_name
 ```
 
-## Translatable Mixin
+## `TranslatableMixin`
 
 `TranslatableMixin` is an abstract model that can be added to any non-page Django model to make it translatable.
 Pages already include this mixin, so there is no need to add it.
 
-### Methods and properties
+### Database fields
 
 The `locale` and `translation_key` fields have a unique key constraint to prevent the object being translated into a language more than once.
 
 ```{eval-rst}
 .. class:: TranslatableMixin
-    :noindex:
 
     .. attribute:: locale
 
@@ -465,6 +464,13 @@ The `locale` and `translation_key` fields have a unique key constraint to preven
 
         A UUID that is randomly generated whenever a new model instance is created.
         This is shared with all translations of that instance so can be used for querying translations.
+```
+
+### Methods and properties
+
+```{eval-rst}
+.. class:: TranslatableMixin
+    :noindex:
 
     .. automethod:: get_translations
 

--- a/docs/reference/pages/model_reference.md
+++ b/docs/reference/pages/model_reference.md
@@ -616,9 +616,9 @@ The model is added to allow Snippets to have changes that are not immediately re
 
 Every time a page is edited, a new `Revision` is created and saved to the database. It can be used to find the full history of all changes that have been made to a page and it also provides a place for new changes to be kept before going live.
 
--   Revisions can be created from any {class}`~wagtail.models.Page` object by calling its {meth}`~Page.save_revision` method
--   The content of the page is JSON-serialisable and stored in the {attr}`~Revision.content` field
--   You can retrieve a `Revision` as a {class}`~wagtail.models.Page` object by calling the {meth}`~Revision.as_object` method
+-   Revisions can be created from any instance of {class}`~wagtail.models.RevisionMixin` by calling its {meth}`~RevisionMixin.save_revision` method.
+-   The content of the page is JSON-serialisable and stored in the {attr}`~Revision.content` field.
+-   You can retrieve a `Revision` as an instance of the object's model by calling the {meth}`~Revision.as_object` method.
 
 ```{versionchanged} 4.0
 The model has been renamed from ``PageRevision`` to ``Revision`` and it now references the ``Page`` model using a {class}`~django.contrib.contenttypes.fields.GenericForeignKey`.
@@ -633,49 +633,49 @@ The model has been renamed from ``PageRevision`` to ``Revision`` and it now refe
 
         (generic foreign key)
 
-        This property returns the object this revision belongs to as an instance of the specific class.
+        The object this revision belongs to. For page revisions, the object is an instance of the specific class.
 
     .. attribute:: content_type
 
         (foreign key to :class:`~django.contrib.contenttypes.models.ContentType`)
 
-        This is the content type of the object this revision belongs to. For page revisions, this means the content type of the specific page type.
+        The content type of the object this revision belongs to. For page revisions, this means the content type of the specific page type.
 
     .. attribute:: base_content_type
 
         (foreign key to :class:`~django.contrib.contenttypes.models.ContentType`)
 
-        This is the base content type of the object this revision belongs to. For page revisions, this means the content type of the :class:`~wagtail.models.Page` model.
+        The base content type of the object this revision belongs to. For page revisions, this means the content type of the :class:`~wagtail.models.Page` model.
 
     .. attribute:: object_id
 
         (string)
 
-        This represents the primary key of the object this revision belongs to.
+        The primary key of the object this revision belongs to.
 
     .. attribute:: submitted_for_moderation
 
         (boolean)
 
-        ``True`` if this revision is in moderation
+        ``True`` if this revision is in moderation.
 
     .. attribute:: created_at
 
         (date/time)
 
-        This is the time the revision was created
+        The time the revision was created.
 
     .. attribute:: user
 
         (foreign key to user model)
 
-        This links to the user that created the revision
+        The user that created the revision.
 
     .. attribute:: content
 
         (dict)
 
-        This field contains the JSON content for the page at the time the revision was created
+        The JSON content for the object at the time the revision was created.
 
         .. versionchanged:: 3.0
 
@@ -741,15 +741,15 @@ The model has been renamed from ``PageRevision`` to ``Revision`` and it now refe
 
     .. automethod:: approve_moderation
 
-        Calling this on a revision that's in moderation will mark it as approved and publish it
+        Calling this on a revision that's in moderation will mark it as approved and publish it.
 
     .. automethod:: reject_moderation
 
-        Calling this on a revision that's in moderation will mark it as rejected
+        Calling this on a revision that's in moderation will mark it as rejected.
 
     .. automethod:: is_latest_revision
 
-        Returns ``True`` if this revision is the object's latest revision
+        Returns ``True`` if this revision is the object's latest revision.
 
     .. automethod:: publish
 

--- a/docs/releases/4.0.md
+++ b/docs/releases/4.0.md
@@ -170,6 +170,7 @@ The bulk of these enhancements have been from Paarth Agarwal, who has been doing
  * Move commenting trigger to inline toolbar and move block splitting to the block toolbar and command palette only in Draftail (Thibaud Colas)
  * Pages are now locked when they are scheduled for publishing (Karl Hobley)
  * Simplify page chooser views by converting to class-based views (Matt Westcott)
+ * Add reference documentation for `RevisionMixin`, `DraftStateMixin`, and `PreviewableMixin` (Sage Abdullah)
 
 ### Bug fixes
 

--- a/wagtail/models/__init__.py
+++ b/wagtail/models/__init__.py
@@ -1552,9 +1552,9 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
 
         This is called by Wagtail whenever a page with aliases is published.
 
-        :param revision: The revision of the original page that we are updating to (used for logging purposes)
+        :param revision: The revision of the original page that we are updating to (used for logging purposes).
         :type revision: Revision, optional
-        :param user: The user who is publishing (used for logging purposes)
+        :param user: The user who is publishing (used for logging purposes).
         :type user: User, optional
         """
         specific_self = self.specific

--- a/wagtail/models/__init__.py
+++ b/wagtail/models/__init__.py
@@ -232,12 +232,14 @@ class RevisionMixin(models.Model):
     @property
     def revisions(self):
         """
-        Returns revisions that belong to this object.
+        Returns revisions that belong to the object.
 
-        Subclasses should define a GenericRelation to Revision and override
-        this property to return that GenericRelation. This allows subclasses
-        to customise the `related_query_name` of the GenericRelation and add
-        some custom logic (e.g. to always use the specific instance in Page).
+        Subclasses should define a
+        :class:`~django.contrib.contenttypes.fields.GenericRelation` to
+        :class:`~wagtail.models.Revision` and override this property to return
+        that ``GenericRelation``. This allows subclasses to customise the
+        ``related_query_name`` of the ``GenericRelation`` and add custom logic
+        (e.g. to always use the specific instance in ``Page``).
         """
         return Revision.objects.filter(
             content_type=self.get_content_type(),
@@ -263,6 +265,10 @@ class RevisionMixin(models.Model):
         return self.latest_revision
 
     def get_latest_revision_as_object(self):
+        """
+        Returns the latest revision of the object as an instance of the model.
+        If no latest revision exists, returns the object itself.
+        """
         latest_revision = self.get_latest_revision()
         if latest_revision:
             return latest_revision.as_object()
@@ -295,7 +301,8 @@ class RevisionMixin(models.Model):
 
         * ``latest_revision``
 
-        If ``TranslatableMixin`` is applied, the following field values are also preserved:
+        If :class:`~wagtail.models.TranslatableMixin` is applied, the following field values
+        are also preserved:
 
         * ``translation_key``
         * ``locale``
@@ -331,15 +338,17 @@ class RevisionMixin(models.Model):
     ):
         """
         Creates and saves a revision.
-        :param user: the user performing the action
-        :param submitted_for_moderation: indicates whether the object was submitted for moderation
-        :param approved_go_live_at: the date and time the revision is approved to go live
-        :param changed: indicates whether there were any content changes
-        :param log_action: flag for logging the action. Pass False to skip logging. Can be passed an action string.
-            Defaults to 'wagtail.edit' when no 'previous_revision' param is passed, otherwise 'wagtail.revert'
-        :param previous_revision: indicates a revision reversal. Should be set to the previous revision instance
-        :param clean: Set this to False to skip cleaning object content before saving this revision
-        :return: the newly created revision
+
+        :param user: The user performing the action.
+        :param submitted_for_moderation: Indicates whether the object was submitted for moderation.
+        :param approved_go_live_at: The date and time the revision is approved to go live.
+        :param changed: Indicates whether there were any content changes.
+        :param log_action: Flag for logging the action. Pass ``False`` to skip logging. Can be passed an action string.
+            Defaults to ``"wagtail.edit"`` when no ``previous_revision`` param is passed, otherwise ``"wagtail.revert"``.
+        :param previous_revision: Indicates a revision reversal. Should be set to the previous revision instance.
+        :type previous_revision: Revision
+        :param clean: Set this to ``False`` to skip cleaning object content before saving this revision.
+        :return: The newly created revision.
         """
         if clean:
             self.full_clean()

--- a/wagtail/models/__init__.py
+++ b/wagtail/models/__init__.py
@@ -480,6 +480,17 @@ class DraftStateMixin(models.Model):
     def publish(
         self, revision, user=None, changed=True, log_action=True, previous_revision=None
     ):
+        """
+        Publish a revision of the object by applying the changes in the revision to the live object.
+
+        :param revision: Revision to publish.
+        :type revision: Revision
+        :param user: The publishing user.
+        :param changed: Indicated whether content has changed.
+        :param log_action: Flag for the logging action, pass ``False`` to skip logging.
+        :param previous_revision: Indicates a revision reversal. Should be set to the previous revision instance.
+        :type previous_revision: Revision
+        """
         return PublishRevisionAction(
             revision,
             user=user,
@@ -489,6 +500,14 @@ class DraftStateMixin(models.Model):
         ).execute()
 
     def unpublish(self, set_expired=False, commit=True, user=None, log_action=True):
+        """
+        Unpublish the live object.
+
+        :param set_expired: Mark the object as expired.
+        :param commit: Commit the changes to the database.
+        :param user: The unpublishing user.
+        :param log_action: Flag for the logging action, pass ``False`` to skip logging.
+        """
         return UnpublishAction(
             self,
             set_expired=set_expired,
@@ -499,23 +518,12 @@ class DraftStateMixin(models.Model):
 
     def with_content_json(self, content):
         """
-        Returns a new version of the object with field values updated to reflect changes
-        in the provided ``content`` (which usually comes from a previously-saved revision).
+        Similar to :meth:`RevisionMixin.with_content_json`,
+        but with the following fields also preserved:
 
-        Certain field values are preserved in order to prevent errors if the returned
-        object is saved, such as ``id``. The following field values are also preserved,
-        as they are considered to be meaningful to the object as a whole, rather than
-        to a specific revision:
-
-        * ``latest_revision``
         * ``live``
         * ``has_unpublished_changes``
         * ``first_published_at``
-
-        If ``TranslatableMixin`` is applied, the following field values are also preserved:
-
-        * ``translation_key``
-        * ``locale``
         """
         obj = super().with_content_json(content)
 


### PR DESCRIPTION
For #8609.

This PR adds reference documentation for `RevisionMixin`, `DraftStateMixin`, and `PreviewableMixin`.

I'm putting this in Page's model reference because I don't know where else to put it. Creating a new Snippets section in the model reference doesn't seem right because these mixins are also used in Page. Plus, the existing `TranslatableMixin` documentation is written in the same document.

Note that this only covers the model reference, not the "how-to" guide on how to use it. I'm planning to write that in [the existing "topic" guide on Snippets](https://docs.wagtail.org/en/stable/topics/snippets.html). That may or may not be in this same PR.