### PR TITLE
Add missing chevron-down.svg

### DIFF
--- a/wagtail/admin/static_src/wagtailadmin/images/icons/chevron-down.svg
+++ b/wagtail/admin/static_src/wagtailadmin/images/icons/chevron-down.svg
@@ -1,0 +1,4 @@
+<svg id="icon-chevron-down" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+    <!-- Font Awesome Free 5.15.3 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License) -->
+    <path d="M6.035 7.195a.644.644 0 00.902 0l5.333-5.304c.246-.274.246-.684 0-.93l-.63-.629c-.245-.246-.656-.246-.93 0L6.5 4.543 2.262.332c-.274-.246-.684-.246-.93 0L.703.961c-.246.246-.246.656 0 .93l5.332 5.304z"></path>
+</svg>


### PR DESCRIPTION
Fixes #8988. This file existed under wagtailadmin/templates/icons/ but not under wagtailadmin/static(_src)/images/icons where it needs to be for references in .css to work.

As well as `./manage.py collectstatic` now working, select dropdowns now show a down chevron that was missing before.

Before:
![Screenshot 2022-08-15 at 15 25 30](https://user-images.githubusercontent.com/85097/184656976-9d343580-afc1-4f24-ad14-5d54cb8dcbf3.png)
After:
![Screenshot 2022-08-15 at 15 34 42](https://user-images.githubusercontent.com/85097/184657016-ec7bdf48-6abc-4328-b75a-f8ab9a841f8b.png)

Note that there's already an arrow-down.svg in there, but (aside from the offsets needing a fixup) it doesn't look quite as nice:
![Screenshot 2022-08-15 at 15 38 56](https://user-images.githubusercontent.com/85097/184657238-85535530-b98a-47eb-9e35-38064692187d.png)

