### PR TITLE
Fixed init method of legacy BaseSetting class, fixes #8996, fixes #9006

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -166,6 +166,7 @@ Changelog
  * Fix: Ensure that `BaseSiteSetting` / `BaseGenericSetting` objects can be pickled (Andy Babic)
  * Fix: Ensure `DocumentChooserBlock` can be deconstructed for migrations (Matt Westcott)
  * Fix: Resolve frontent console error and unintented console logging issues (Matt Wescott, Paarth Agarwal)
+ * Fix: Resolve issue with sites that have not yet migrated away from `BaseSetting` when upgrading to Wagtail 4.0 (Stefan Hammer)
 
 
 3.0.1 (16.06.2022)

--- a/docs/releases/4.0.md
+++ b/docs/releases/4.0.md
@@ -223,6 +223,7 @@ The bulk of these enhancements have been from Paarth Agarwal, who has been doing
  * Ensure that `BaseSiteSetting` / `BaseGenericSetting` objects can be pickled (Andy Babic)
  * Ensure `DocumentChooserBlock` can be deconstructed for migrations (Matt Westcott)
  * Resolve frontent console error and unintented console logging issues (Matt Wescott, Paarth Agarwal)
+ * Resolve issue with sites that have not yet migrated away from `BaseSetting` when upgrading to Wagtail 4.0 (Stefan Hammer)
 
 
 ## Upgrade considerations

--- a/wagtail/contrib/settings/models.py
+++ b/wagtail/contrib/settings/models.py
@@ -217,4 +217,4 @@ class BaseSetting(BaseSiteSetting):
             category=RemovedInWagtail50Warning,
             stacklevel=2,
         )
-        return super().__init__(self, *args, **kwargs)
+        super().__init__(*args, **kwargs)


### PR DESCRIPTION
The "return" statement was only a minor improvement, the breaking code was the passed "self" argument.

fixes #8996, fixes #9006

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
