### PR TITLE
Ensure telepath adapter gets registered for document chooser widget

### DIFF
--- a/docs/reference/viewsets.md
+++ b/docs/reference/viewsets.md
@@ -59,6 +59,7 @@ Viewsets are Wagtail's mechanism for defining a group of related admin views wit
    .. autoattribute:: create_view_class
    .. autoattribute:: base_widget_class
    .. autoattribute:: widget_class
+   .. autoattribute:: widget_telepath_adapter_class
    .. autoattribute:: register_widget
    .. autoattribute:: base_block_class
    .. automethod:: get_block_class

--- a/wagtail/admin/viewsets/chooser.py
+++ b/wagtail/admin/viewsets/chooser.py
@@ -7,6 +7,7 @@ from wagtail.admin.forms.models import register_form_field_override
 from wagtail.admin.views.generic import chooser as chooser_views
 from wagtail.admin.widgets.chooser import BaseChooser
 from wagtail.blocks import ChooserBlock
+from wagtail.telepath import register as register_telepath_adapter
 
 from .base import ViewSet
 
@@ -44,6 +45,10 @@ class ChooserViewSet(ViewSet):
 
     #: The base Widget class that the chooser widget will be derived from.
     base_widget_class = BaseChooser
+
+    #: The adapter class used to map the widget class to its JavaScript implementation - see :ref:`streamfield_widget_api`.
+    #: Only required if the chooser uses custom JavaScript code.
+    widget_telepath_adapter_class = None
 
     #: The base ChooserBlock class that the StreamField chooser block will be derived from.
     base_block_class = ChooserBlock
@@ -204,3 +209,6 @@ class ChooserViewSet(ViewSet):
             register_form_field_override(
                 ForeignKey, to=self.model, override={"widget": self.widget_class}
             )
+            if self.widget_telepath_adapter_class:
+                adapter = self.widget_telepath_adapter_class()
+                register_telepath_adapter(adapter, self.widget_class)

--- a/wagtail/documents/views/chooser.py
+++ b/wagtail/documents/views/chooser.py
@@ -19,7 +19,7 @@ from wagtail.admin.views.generic.chooser import (
     CreationFormMixin,
 )
 from wagtail.admin.viewsets.chooser import ChooserViewSet
-from wagtail.admin.widgets import BaseChooser
+from wagtail.admin.widgets import BaseChooser, BaseChooserAdapter
 from wagtail.blocks import ChooserBlock
 from wagtail.documents import get_document_model
 from wagtail.documents.permissions import permission_policy
@@ -168,6 +168,18 @@ class BaseAdminDocumentChooser(BaseChooser):
         )
 
 
+class DocumentChooserAdapter(BaseChooserAdapter):
+    js_constructor = "wagtail.documents.widgets.DocumentChooser"
+
+    @cached_property
+    def media(self):
+        return forms.Media(
+            js=[
+                versioned_static("wagtaildocs/js/document-chooser-telepath.js"),
+            ]
+        )
+
+
 class BaseDocumentChooserBlock(ChooserBlock):
     def render_basic(self, value, context=None):
         if value:
@@ -182,6 +194,7 @@ class DocumentChooserViewSet(ChooserViewSet):
     chosen_view_class = DocumentChosenView
     create_view_class = DocumentChooserUploadView
     base_widget_class = BaseAdminDocumentChooser
+    widget_telepath_adapter_class = DocumentChooserAdapter
     base_block_class = BaseDocumentChooserBlock
     permission_policy = permission_policy
 

--- a/wagtail/documents/widgets.py
+++ b/wagtail/documents/widgets.py
@@ -1,24 +1,3 @@
-from django import forms
-from django.utils.functional import cached_property
-
-from wagtail.admin.staticfiles import versioned_static
-from wagtail.admin.widgets import BaseChooserAdapter
 from wagtail.documents.views.chooser import viewset as chooser_viewset
-from wagtail.telepath import register
 
 AdminDocumentChooser = chooser_viewset.widget_class
-
-
-class DocumentChooserAdapter(BaseChooserAdapter):
-    js_constructor = "wagtail.documents.widgets.DocumentChooser"
-
-    @cached_property
-    def media(self):
-        return forms.Media(
-            js=[
-                versioned_static("wagtaildocs/js/document-chooser-telepath.js"),
-            ]
-        )
-
-
-register(DocumentChooserAdapter(), AdminDocumentChooser)


### PR DESCRIPTION
Fixes #9010. `wagtail.documents.widgets` is no longer reliably imported on startup now that the chooser widget is constructed within wagtail.documents.views.chooser instead, so the telepath adapter wasn't getting registered. This meant that DocumentChooserBlocks in StreamField were using the base chooser implementation, which didn't include customisations such as populating the title field from the file upload field. Fix this by making ChooserViewSet responsible for registering the telepath adapter.
