### PR TITLE
Explicitly specify `get_preview_template` and `get_preview_context` parameters

### DIFF
--- a/wagtail/models/__init__.py
+++ b/wagtail/models/__init__.py
@@ -735,13 +735,13 @@ class PreviewableMixin:
             self.get_preview_context(request, mode_name),
         )
 
-    def get_preview_context(self, request, *args, **kwargs):
+    def get_preview_context(self, request, mode_name):
         """
         Returns a context dictionary for use in templates for previewing this object.
         """
         return {"object": self, "request": request}
 
-    def get_preview_template(self, request, *args, **kwargs):
+    def get_preview_template(self, request, mode_name):
         """
         Returns a template to be used when previewing this object.
 
@@ -1727,8 +1727,8 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
 
         return context
 
-    def get_preview_context(self, request, *args, **kwargs):
-        return self.get_context(request, *args, **kwargs)
+    def get_preview_context(self, request, mode_name):
+        return self.get_context(request)
 
     def get_template(self, request, *args, **kwargs):
         if request.headers.get("x-requested-with") == "XMLHttpRequest":
@@ -1736,8 +1736,8 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
         else:
             return self.template
 
-    def get_preview_template(self, request, *args, **kwargs):
-        return self.get_template(request, *args, **kwargs)
+    def get_preview_template(self, request, mode_name):
+        return self.get_template(request)
 
     def serve(self, request, *args, **kwargs):
         request.is_preview = False

--- a/wagtail/test/testapp/models.py
+++ b/wagtail/test/testapp/models.py
@@ -191,10 +191,10 @@ class MultiPreviewModesPage(Page):
     def default_preview_mode(self):
         return "alt#1"
 
-    def get_preview_template(self, request, mode_name, *args, **kwargs):
+    def get_preview_template(self, request, mode_name):
         if mode_name == "alt#1":
             return "tests/simple_page_alt.html"
-        return super().get_preview_template(request, *args, **kwargs)
+        return super().get_preview_template(request, mode_name)
 
 
 # Page with Excluded Fields when copied
@@ -1009,7 +1009,7 @@ class PreviewableModel(PreviewableMixin, ClusterableModel):
     def __str__(self):
         return self.text
 
-    def get_preview_template(self, request, mode_name, *args, **kwargs):
+    def get_preview_template(self, request, mode_name):
         return "tests/previewable_model.html"
 
 
@@ -1030,7 +1030,7 @@ class MultiPreviewModesModel(PreviewableMixin, RevisionMixin, models.Model):
     def default_preview_mode(self):
         return "alt#1"
 
-    def get_preview_template(self, request, mode_name, *args, **kwargs):
+    def get_preview_template(self, request, mode_name):
         templates = {
             "": "tests/previewable_model.html",
             "alt#1": "tests/previewable_model_alt.html",


### PR DESCRIPTION
The `serve_preview` method has always only accepted `request` and `mode_name` parameters:
https://github.com/wagtail/wagtail/blob/a5f699ffbd7312c260c9c7d31d92b6781753bcfd/wagtail/models/__init__.py#L1798

https://github.com/wagtail/wagtail/blob/9aeb2e3e49bb98201029d99fa613b0da9c6f1865/wagtail/models/__init__.py#L720

In #8709, we decoupled the method from the `serve` method by introducing `get_preview_template` and `get_preview_context` methods.

In that PR, the new methods accept arbitrary `*args` and `**kwargs`, which are not necessary for the `serve_preview` method. This PR removes those arbitrary parameters and replace them with explicit `request` and `mode_name` parameters to match the `serve_preview` method and to make overriding the methods more straightforward.

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
