### PR TITLE
Upgrade to latest Draftail RC, fixing command palette selection issue #9017

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@tippyjs/react": "^4.2.6",
         "a11y-dialog": "^7.4.0",
         "draft-js": "^0.10.5",
-        "draftail": "^2.0.0-rc.1",
+        "draftail": "^2.0.0-rc.2",
         "draftjs-filters": "^3.0.1",
         "focus-trap-react": "^8.4.2",
         "immer": "^9.0.6",
@@ -17951,9 +17951,9 @@
       }
     },
     "node_modules/draftail": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/draftail/-/draftail-2.0.0-rc.1.tgz",
-      "integrity": "sha512-dUa+Z4HnNTxLbChw0FibaVzFwPE8uQL0BYM5QOkvgpZSciQ4UT09NUvEUOAYxQRkS9/VbVBgnZy0VRYf4CBnKQ==",
+      "version": "2.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/draftail/-/draftail-2.0.0-rc.2.tgz",
+      "integrity": "sha512-3KNMXv54k0yxAoOk8Ho9m/YRxJxArv7VwS/3X1yX0Xi2dUzvRzvYW5piGMSIX6vgYoWSN9p5bM+XtytciL93ig==",
       "dependencies": {
         "@tippyjs/react": "^4.2.6",
         "decorate-component-with-props": "^1.0.2",
@@ -43954,9 +43954,9 @@
       }
     },
     "draftail": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/draftail/-/draftail-2.0.0-rc.1.tgz",
-      "integrity": "sha512-dUa+Z4HnNTxLbChw0FibaVzFwPE8uQL0BYM5QOkvgpZSciQ4UT09NUvEUOAYxQRkS9/VbVBgnZy0VRYf4CBnKQ==",
+      "version": "2.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/draftail/-/draftail-2.0.0-rc.2.tgz",
+      "integrity": "sha512-3KNMXv54k0yxAoOk8Ho9m/YRxJxArv7VwS/3X1yX0Xi2dUzvRzvYW5piGMSIX6vgYoWSN9p5bM+XtytciL93ig==",
       "requires": {
         "@tippyjs/react": "^4.2.6",
         "decorate-component-with-props": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "@tippyjs/react": "^4.2.6",
     "a11y-dialog": "^7.4.0",
     "draft-js": "^0.10.5",
-    "draftail": "^2.0.0-rc.1",
+    "draftail": "^2.0.0-rc.2",
     "draftjs-filters": "^3.0.1",
     "focus-trap-react": "^8.4.2",
     "immer": "^9.0.6",


### PR DESCRIPTION
Updates Draftail to the latest RC, which only contains the [bug fix](https://github.com/springload/draftail/commit/6fa900de2487c923468cc682d4c8503cbc453e3d) for #9017. Selecting items with the mouse needs special handling within the `/-command` version of the block toolbar, as we need the keyboard focus to stay within the editor.

Here’s a recording of all three means of interaction – keyboard with arrow keys only, keyboard with a search pattern, and keyboard + mouse:

![9017-click-handling](https://user-images.githubusercontent.com/877585/185302349-3fd8f70b-cd6e-4ca2-8a15-7054f73dc804.gif)

---

Only tested in Chrome & Firefox on macOS.