### PR TITLE
Add usage guide for using `RevisionMixin`, `DraftStateMixin`, and `PreviewableMixin` with snippets

### DIFF
--- a/docs/reference/pages/model_reference.md
+++ b/docs/reference/pages/model_reference.md
@@ -493,7 +493,7 @@ The `locale` and `translation_key` fields have a unique key constraint to preven
 Pages already include this mixin, so there is no need to add it.
 
 ```{versionadded} 4.0
-The class is added to allow Snippets to have live preview in the editor.
+The class is added to allow snippets to have live preview in the editor. See [](wagtailsnippets_making_snippets_previewable) for more details.
 ```
 
 ### Methods and properties
@@ -520,7 +520,7 @@ The class is added to allow Snippets to have live preview in the editor.
 Pages already include this mixin, so there is no need to add it.
 
 ```{versionadded} 4.0
-The model is added to allow Snippets to save revisions, revert to a previous revision, and compare changes between revisions.
+The model is added to allow snippets to save revisions, revert to a previous revision, and compare changes between revisions. See [](wagtailsnippets_saving_revisions_of_snippets) for more details.
 ```
 
 ### Database fields
@@ -556,7 +556,7 @@ The model is added to allow Snippets to save revisions, revert to a previous rev
 This mixin requires {class}`~wagtail.models.RevisionMixin` to be applied. Pages already include this mixin, so there is no need to add it.
 
 ```{versionadded} 4.0
-The model is added to allow Snippets to have changes that are not immediately reflected to the instance.
+The model is added to allow snippets to have changes that are not immediately reflected to the instance. See [](wagtailsnippets_saving_draft_changes_of_snippets) for more details.
 ```
 
 ### Database fields

--- a/docs/topics/snippets.md
+++ b/docs/topics/snippets.md
@@ -160,6 +160,8 @@ These child objects are now accessible through the page's `advert_placements` pr
 {% endfor %}
 ```
 
+(wagtailsnippets_making_snippets_previewable)=
+
 ## Making snippets previewable
 
 ```{versionadded} 4.0
@@ -272,6 +274,8 @@ class Advert(index.Indexed, models.Model):
     ]
 ```
 
+(wagtailsnippets_saving_revisions_of_snippets)=
+
 ## Saving revisions of snippets
 
 ```{versionadded} 4.0
@@ -310,6 +314,8 @@ The `RevisionMixin` includes a `latest_revision` field that needs to be added to
 With the `RevisionMixin` applied, any changes made from the snippets admin will create an instance of the `Revision` model that contains the state of the snippet instance. The revision instance is attached to the [audit log](audit_log) entry of the edit action, allowing you to revert to a previous revision or compare the changes between revisions from the snippet history page.
 
 You can also save revisions programmatically by calling the {meth}`~wagtail.models.RevisionMixin.save_revision` method. After applying the mixin, it is recommended to call this method (or save the snippet in the admin) at least once for each instance of the snippet that already exists (if any), so that the `latest_revision` field is populated in the database table.
+
+(wagtailsnippets_saving_draft_changes_of_snippets)=
 
 ## Saving draft changes of snippets
 

--- a/docs/topics/snippets.md
+++ b/docs/topics/snippets.md
@@ -2,11 +2,11 @@
 
 # Snippets
 
-Snippets are pieces of content which do not necessitate a full webpage to render. They could be used for making secondary content, such as headers, footers, and sidebars, editable in the Wagtail admin. Snippets are Django models which do not inherit the `Page` class and are thus not organised into the Wagtail tree. However, they can still be made editable by assigning panels and identifying the model as a snippet with the `register_snippet` class decorator.
+Snippets are pieces of content which do not necessitate a full webpage to render. They could be used for making secondary content, such as headers, footers, and sidebars, editable in the Wagtail admin. Snippets are Django models which do not inherit the {class}`~wagtail.models.Page` class and are thus not organised into the Wagtail tree. However, they can still be made editable by assigning panels and identifying the model as a snippet with the `register_snippet` class decorator.
 
 Snippets lack many of the features of pages, such as being orderable in the Wagtail admin or having a defined URL. Decide carefully if the content type you would want to build into a snippet might be more suited to a page.
 
-## Snippet Models
+## Snippet models
 
 Here's an example snippet model:
 
@@ -36,9 +36,9 @@ The `Advert` model uses the basic Django model class and defines two properties:
 
 `@register_snippet` tells Wagtail to treat the model as a snippet. The `panels` list defines the fields to show on the snippet editing page. It's also important to provide a string representation of the class through `def __str__(self):` so that the snippet objects make sense when listed in the Wagtail admin.
 
-## Including Snippets in Template Tags
+## Including snippets in template tags
 
-The simplest way to make your snippets available to templates is with a template tag. This is mostly done with vanilla Django, so perhaps reviewing Django's documentation for :doc:`django custom template tags <howto/custom-template-tags>` will be more helpful. We'll go over the basics, though, and point out any considerations to make for Wagtail.
+The simplest way to make your snippets available to templates is with a template tag. This is mostly done with vanilla Django, so perhaps reviewing Django's documentation for [custom template tags](django:howto/custom-template-tags) will be more helpful. We'll go over the basics, though, and point out any considerations to make for Wagtail.
 
 First, add a new python file to a `templatetags` folder within your app - for example, `myproject/demo/templatetags/demo_tags.py`. We'll need to load some Django modules and our app's models, and ready the `register` decorator:
 
@@ -89,9 +89,9 @@ Then, in your own page templates, you can include your snippet template tag with
 {% endblock %}
 ```
 
-## Binding Pages to Snippets
+## Binding pages to snippets
 
-In the above example, the list of adverts is a fixed list that is displayed via the custom template tag independent of any other content on the page. This might be what you want for a common panel in a sidebar, but, in another scenario, you might wish to display just one specific instance of a snippet on a particular page. This can be accomplished by defining a foreign key to the snippet model within your page model and adding a `FieldPanel` to the page's `content_panels` list. For example, if you wanted to display a specific advert on a `BookPage` instance:
+In the above example, the list of adverts is a fixed list that is displayed via the custom template tag independent of any other content on the page. This might be what you want for a common panel in a sidebar, but, in another scenario, you might wish to display just one specific instance of a snippet on a particular page. This can be accomplished by defining a foreign key to the snippet model within your page model and adding a {class}`~wagtail.admin.panels.FieldPanel` to the page's `content_panels` list. For example, if you wanted to display a specific advert on a `BookPage` instance:
 
 ```python
   # ...
@@ -148,7 +148,7 @@ class BookPage(Page):
     ]
 ```
 
-These child objects are now accessible through the page's `advert_placements` property, and from there we can access the linked Advert snippet as `advert`. In the template for `BookPage`, we could include the following:
+These child objects are now accessible through the page's `advert_placements` property, and from there we can access the linked `Advert` snippet as `advert`. In the template for `BookPage`, we could include the following:
 
 ```html+django
 {% for advert_placement in page.advert_placements.all %}
@@ -162,9 +162,9 @@ These child objects are now accessible through the page's `advert_placements` pr
 
 (wagtailsnippets_making_snippets_searchable)=
 
-## Making Snippets Searchable
+## Making snippets searchable
 
-If a snippet model inherits from `wagtail.search.index.Indexed`, as described in [](wagtailsearch_indexing_models), Wagtail will automatically add a search box to the chooser interface for that snippet type. For example, the `Advert` snippet could be made searchable as follows:
+If a snippet model inherits from {class}`wagtail.search.index.Indexed`, as described in [](wagtailsearch_indexing_models), Wagtail will automatically add a search box to the chooser interface for that snippet type. For example, the `Advert` snippet could be made searchable as follows:
 
 ```python
 # ...


### PR DESCRIPTION
~~Needs #9021 to be merged.~~

This PR adds a usage guide on how to use the mixins documented in #9000 with snippets.

I haven't added a management command or migration code example to populate the `latest_revision` and `live_revision` fields for existing snippets, and I'm not sure if that's necessary. I've already added hints on how to do it programmatically, though.