### PR TITLE
Fix live preview error banner overlapping with preview mode selector

### DIFF
--- a/client/scss/components/_preview-panel.scss
+++ b/client/scss/components/_preview-panel.scss
@@ -160,9 +160,15 @@
     align-items: center;
     justify-content: center;
     gap: 1rem;
+    margin-bottom: 0;
+    background-color: theme('colors.white.DEFAULT');
 
-    label {
+    .w-field__label {
       margin-bottom: 0;
     }
+  }
+
+  &__mode-select {
+    @apply w-outline-offset-inside;
   }
 }

--- a/wagtail/admin/templates/wagtailadmin/shared/side_panels/preview.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/side_panels/preview.html
@@ -46,7 +46,7 @@
             {% if has_multiple_modes %}
                 {% trans 'Preview mode' as label_text %}
                 {% field label_text=label_text id_for_label="id_preview_mode" classname="preview-panel__modes" %}
-                    <select id="id_preview_mode" name="preview_mode" data-preview-mode-select>
+                    <select id="id_preview_mode" name="preview_mode" class="preview-panel__mode-select" data-preview-mode-select>
                         {% for internal_name, display_name in object.preview_modes %}
                             <option value="{{ internal_name }}"{% if internal_name == object.default_preview_mode %} selected{% endif %}>{{ display_name }}</option>
                         {% endfor %}

--- a/wagtail/admin/tests/pages/test_preview.py
+++ b/wagtail/admin/tests/pages/test_preview.py
@@ -387,7 +387,7 @@ class TestEnablePreview(TestCase, WagtailTestUtils):
         # Should not show the preview mode selection
         self.assertNotContains(
             response,
-            '<select id="id_preview_mode" name="preview_mode" data-preview-mode-select>',
+            '<select id="id_preview_mode" name="preview_mode" class="preview-panel__mode-select" data-preview-mode-select>',
         )
 
     def test_show_preview_panel_on_create_with_multiple_modes(self):
@@ -412,7 +412,7 @@ class TestEnablePreview(TestCase, WagtailTestUtils):
         # should show the preview mode selection
         self.assertContains(
             response,
-            '<select id="id_preview_mode" name="preview_mode" data-preview-mode-select>',
+            '<select id="id_preview_mode" name="preview_mode" class="preview-panel__mode-select" data-preview-mode-select>',
         )
         self.assertContains(response, '<option value="original">Original</option>')
 
@@ -443,7 +443,7 @@ class TestEnablePreview(TestCase, WagtailTestUtils):
         # Should not show the preview mode selection
         self.assertNotContains(
             response,
-            '<select id="id_preview_mode" name="preview_mode" data-preview-mode-select>',
+            '<select id="id_preview_mode" name="preview_mode" class="preview-panel__mode-select" data-preview-mode-select>',
         )
 
     def test_show_preview_panel_on_edit_with_multiple_modes(self):
@@ -468,7 +468,7 @@ class TestEnablePreview(TestCase, WagtailTestUtils):
         # should show the preview mode selection
         self.assertContains(
             response,
-            '<select id="id_preview_mode" name="preview_mode" data-preview-mode-select>',
+            '<select id="id_preview_mode" name="preview_mode" class="preview-panel__mode-select" data-preview-mode-select>',
         )
         self.assertContains(response, '<option value="original">Original</option>')
 

--- a/wagtail/snippets/tests/test_preview.py
+++ b/wagtail/snippets/tests/test_preview.py
@@ -250,7 +250,7 @@ class TestEnablePreview(TestCase, WagtailTestUtils):
         # Should not show the preview mode selection
         self.assertNotContains(
             response,
-            '<select id="id_preview_mode" name="preview_mode" data-preview-mode-select>',
+            '<select id="id_preview_mode" name="preview_mode" class="preview-panel__mode-select" data-preview-mode-select>',
         )
 
     def test_show_preview_panel_on_create_with_multiple_modes(self):
@@ -275,7 +275,7 @@ class TestEnablePreview(TestCase, WagtailTestUtils):
         # should show the preview mode selection
         self.assertContains(
             response,
-            '<select id="id_preview_mode" name="preview_mode" data-preview-mode-select>',
+            '<select id="id_preview_mode" name="preview_mode" class="preview-panel__mode-select" data-preview-mode-select>',
         )
         self.assertContains(response, '<option value="">Normal</option>')
 
@@ -308,7 +308,7 @@ class TestEnablePreview(TestCase, WagtailTestUtils):
         # Should not show the preview mode selection
         self.assertNotContains(
             response,
-            '<select id="id_preview_mode" name="preview_mode" data-preview-mode-select>',
+            '<select id="id_preview_mode" name="preview_mode" class="preview-panel__mode-select" data-preview-mode-select>',
         )
 
     def test_show_preview_panel_on_edit_with_multiple_modes(self):
@@ -335,7 +335,7 @@ class TestEnablePreview(TestCase, WagtailTestUtils):
         # should show the preview mode selection
         self.assertContains(
             response,
-            '<select id="id_preview_mode" name="preview_mode" data-preview-mode-select>',
+            '<select id="id_preview_mode" name="preview_mode" class="preview-panel__mode-select" data-preview-mode-select>',
         )
         self.assertContains(response, '<option value="">Normal</option>')
 


### PR DESCRIPTION
Fixes #9040. Not sure if we need to adjust the preview mode selector size...

https://user-images.githubusercontent.com/6379424/185370155-d6525586-9244-4299-bbf6-7b1553bbe61e.mov