### PR TITLE
Fix plural handling for "no permission to delete these snippets" errors

### DIFF
--- a/wagtail/snippets/templates/wagtailsnippets/bulk_actions/confirm_bulk_delete.html
+++ b/wagtail/snippets/templates/wagtailsnippets/bulk_actions/confirm_bulk_delete.html
@@ -43,10 +43,16 @@
 
 
 {% block items_with_no_access %}
-
-    {% blocktrans with snippet_type_name=model_opts.verbose_name snippet_plural_name=model_opts.verbose_name_plural|capfirst trimmed asvar no_access_msg count counter=items_with_no_access|length  %}You don't have permission to delete this {{ snippet_type_name }}{% plural %}You don't have permission to delete these {{ snippet_plural_name }} {% endblocktrans %}
+    {% if items_with_no_access|length == 1 %}
+        {% blocktrans with snippet_type_name=model_opts.verbose_name trimmed asvar no_access_msg %}
+            You don't have permission to delete this {{ snippet_type_name }}
+        {% endblocktrans %}
+    {% else %}
+        {% blocktrans with snippet_plural_name=model_opts.verbose_name_plural trimmed asvar no_access_msg %}
+            You don't have permission to delete these {{ snippet_plural_name }}
+        {% endblocktrans %}
+    {% endif %}
     {% include 'wagtailsnippets/bulk_actions/list_items_with_no_access.html' with items=items_with_no_access no_access_msg=no_access_msg %}
-
 {% endblock items_with_no_access %}
 
 {% block form_section %}

--- a/wagtail/snippets/tests/test_bulk_actions/test_bulk_delete.py
+++ b/wagtail/snippets/tests/test_bulk_actions/test_bulk_delete.py
@@ -1,7 +1,6 @@
 from django.contrib.auth.models import Permission
 from django.test import TestCase
 from django.urls import reverse
-from django.utils.text import capfirst
 
 from wagtail.test.snippets.models import StandardSnippet
 from wagtail.test.utils import WagtailTestUtils
@@ -65,7 +64,7 @@ class TestSnippetDeleteView(TestCase, WagtailTestUtils):
 
         html = response.content.decode()
         self.assertInHTML(
-            f"<p>You don't have permission to delete these {capfirst(self.snippet_model._meta.verbose_name_plural)}</p>",
+            "<p>You don't have permission to delete these standard snippets</p>",
             html,
         )
 


### PR DESCRIPTION
`./manage.py compilemessages` does not allow variables to differ between the singular and plural forms - it fails with

    a format specification for argument 'snippet_type_name', as in 'msgstr[0]', doesn't exist in 'msgid_plural'

It's not possible to use the gettext pluralisation mechanism properly here, because we're using Django's verbose_name and verbose_name_plural properties which don't cover the requirements of languages with complex pluralisation rules. Since we can only hope to support English-style (`if n == 1`) pluralisation, use an n==1 test directly (as we have elsewhere in the template) rather than trying to shoehorn this into gettext pluralisation.

While we're at it, remove the capitalisation of the snippet name - it makes no sense here (especially when only done for the plural).
