### PR TITLE
Hide anchors and toggles for page titles from screen readers

### DIFF
--- a/client/scss/components/forms/_title.scss
+++ b/client/scss/components/forms/_title.scss
@@ -15,13 +15,11 @@
 .w-panel.title:nth-child(1),
 .w-panel.title:nth-child(2) {
   .w-panel__header {
+    @apply w-sr-only;
+
     .w-panel__anchor,
     .w-panel__toggle {
       @apply w-hidden;
-    }
-
-    .w-panel__heading {
-      @apply w-sr-only;
     }
   }
 

--- a/client/scss/components/forms/_title.scss
+++ b/client/scss/components/forms/_title.scss
@@ -19,6 +19,7 @@
     .w-panel__toggle {
       @apply w-hidden;
     }
+
     .w-panel__heading {
       @apply w-sr-only;
     }

--- a/client/scss/components/forms/_title.scss
+++ b/client/scss/components/forms/_title.scss
@@ -15,7 +15,13 @@
 .w-panel.title:nth-child(1),
 .w-panel.title:nth-child(2) {
   .w-panel__header {
-    @apply w-sr-only;
+    .w-panel__anchor,
+    .w-panel__toggle {
+      @apply w-hidden;
+    }
+    .w-panel__heading {
+      @apply w-sr-only;
+    }
   }
 
   input,


### PR DESCRIPTION
Addresses #9029. 

This PR hides the anchors and toggles for the panels containing titles of pages. So that screen reader users don't have an empty tab stop on their journey. 

Demonstration Video:

https://user-images.githubusercontent.com/25041665/185472591-de84399e-536d-424b-8096-51cb9e4e0ff8.mp4

## Browsers tested on 
Chrome 104 , Safari 15.6, Firefox 103