### PR TITLE
Only show locale filter in choosers when i18n is enabled in settings

### DIFF
--- a/wagtail/admin/views/generic/chooser.py
+++ b/wagtail/admin/views/generic/chooser.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.contrib.admin.utils import unquote
 from django.core.exceptions import (
     ImproperlyConfigured,
@@ -109,7 +110,9 @@ class BaseChooseView(ModalPageFurnitureMixin, ModelLookupMixin, ContextMixin, Vi
                     bases.insert(0, SearchFilterMixin)
                 if issubclass(self.model_class, CollectionMember):
                     bases.insert(0, CollectionFilterMixin)
-                if issubclass(self.model_class, TranslatableMixin):
+
+                i18n_enabled = getattr(settings, "WAGTAIL_I18N_ENABLED", False)
+                if i18n_enabled and issubclass(self.model_class, TranslatableMixin):
                     bases.insert(0, LocaleFilterMixin)
 
             return type(

--- a/wagtail/snippets/tests/test_snippets.py
+++ b/wagtail/snippets/tests/test_snippets.py
@@ -2721,6 +2721,21 @@ class TestSnippetChoose(TestCase, WagtailTestUtils):
         # filter_form should not have a search field
         self.assertFalse(self.get().context["filter_form"].fields.get("q"))
 
+    @override_settings(WAGTAIL_I18N_ENABLED=False)
+    def test_locale_filter_requires_i18n_enabled(self):
+        self.url_args = ["snippetstests", "translatablesnippet"]
+        fr_locale = Locale.objects.create(language_code="fr")
+
+        TranslatableSnippet.objects.create(text="English snippet")
+        TranslatableSnippet.objects.create(text="French snippet", locale=fr_locale)
+
+        response = self.get()
+
+        # Check the filter is omitted
+        response_html = response.json()["html"]
+        self.assertNotIn("data-chooser-modal-search-filter", response_html)
+        self.assertNotIn('name="locale"', response_html)
+
     @override_settings(WAGTAIL_I18N_ENABLED=True)
     def test_filter_by_locale(self):
         self.url_args = ["snippetstests", "translatablesnippet"]


### PR DESCRIPTION
Fixes #9038

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
