### PR TITLE
Fixed padding and close button bugs for chooser modal

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -180,6 +180,7 @@ Changelog
  * Fix: Only show locale filter in choosers when i18n is enabled in settings (Matt Westcott)
  * Fix: Ensure that the live preview panel correctly clears the cache when a new page is created (Sage Abdullah)
  * Fix: Ensure that there is a larger hoverable area for add block (+) within the Drafttail editor (Steven Steinwand)
+ * Fix: Resolve multiple header styling issues for modal, alignment on small devices, outside click handling target on medium devices, close button target size and hover styles (Paarth Agarwal)
 
 
 3.0.2 (xx.xx.xxxx) - IN DEVELOPMENT

--- a/client/scss/components/_modals.scss
+++ b/client/scss/components/_modals.scss
@@ -86,14 +86,23 @@ $zindex-modal-background: 500;
 }
 
 .modal .close {
-  @apply w-bg-primary-200 hover:w-bg-black w-border-primary;
-  padding: 0;
   position: absolute;
-  width: 50px;
-  height: 50px;
-  top: 10px;
-  inset-inline-end: 10px;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  background-color: transparent;
+  padding: 0;
+  top: theme('spacing.3');
+  inset-inline-end: theme('spacing.3');
+  width: theme('spacing.8');
+  height: theme('spacing.8');
+  color: theme('colors.white.DEFAULT');
   z-index: 1;
+
+  &:hover {
+    background-color: theme('colors.black.DEFAULT');
+    color: theme('colors.grey.50');
+  }
 }
 
 // Where all modal content resides
@@ -101,12 +110,19 @@ $zindex-modal-background: 500;
   position: relative;
   padding-bottom: 2em;
 
-  header {
-    @apply w-bg-primary w-text-white;
+  .w-header {
+    color: theme('colors.white.DEFAULT');
+    background-color: theme('colors.primary.DEFAULT');
 
-    h1 {
-      @apply w-text-white;
+    > .row {
+      // reset inline padding added to w-header for sidebar offset
+      padding-inline-start: theme('spacing.16');
+      // ensure title can never overlap the close button
+      padding-inline-end: theme('spacing.16');
+    }
 
+    .w-header__title {
+      color: inherit;
       font-weight: 700;
       font-size: 1.125rem;
       line-height: 130%;
@@ -116,12 +132,22 @@ $zindex-modal-background: 500;
 
 @include media-breakpoint-up(sm) {
   .modal-dialog {
-    padding: 0 0 2em $menu-width;
+    margin-inline-end: theme('spacing.20');
+    margin-inline-start: theme('spacing.20');
+    padding: 0 0 2em 0;
+    width: auto;
+  }
+
+  .modal .close {
+    width: theme('spacing.12');
+    height: theme('spacing.12');
   }
 }
 
 @include media-breakpoint-up(xl) {
   .modal-dialog {
+    margin-inline-end: auto;
+    margin-inline-start: auto;
     max-width: 100em;
     padding: 0 0 2em;
   }

--- a/client/scss/core.scss
+++ b/client/scss/core.scss
@@ -131,8 +131,8 @@ These are classes for components.
 @import 'components/dropdown';
 @import 'components/dropdown.legacy';
 @import 'components/help-block';
-@import 'components/modals';
 @import 'components/button';
+@import 'components/modals';
 @import 'components/chooser';
 @import 'components/tag';
 @import 'components/listing';

--- a/docs/releases/4.0.md
+++ b/docs/releases/4.0.md
@@ -238,6 +238,7 @@ The bulk of these enhancements have been from Paarth Agarwal, who has been doing
  * Only show locale filter in choosers when i18n is enabled in settings (Matt Westcott)
  * Ensure that the live preview panel correctly clears the cache when a new page is created (Sage Abdullah)
  * Ensure that there is a larger hoverable area for add block (+) within the Drafttail editor (Steven Steinwand)
+ * Resolve multiple header styling issues for modal, alignment on small devices, outside click handling target on medium devices, close button target size and hover styles (Paarth Agarwal)
 
 
 ## Upgrade considerations


### PR DESCRIPTION
Fixes #9053 and #9014.
Compensated the padding with margin. I tested it on different screen sizes, works well for me. 
Made close button white.
After:
![Screenshot from 2022-08-21 22-17-55](https://user-images.githubusercontent.com/86092410/185805401-877fb80b-e776-4a3d-87f6-e62c4920daab.png)


