### PR TITLE
Update admin_views.md

### DIFF
--- a/docs/extending/admin_views.md
+++ b/docs/extending/admin_views.md
@@ -159,7 +159,7 @@ def index(request):
 def month(request):
     current_year = timezone.now().year
     current_month = timezone.now().month
-    calendar_html = calendar.HTMLCalendar().format_month(current_year, current_month)
+    calendar_html = calendar.HTMLCalendar().formatmonth(current_year, current_month)
 
     return HttpResponse(calendar_html)
 ```


### PR DESCRIPTION
typo method from `format_month(current_year, current_month)` to `formatmonth(current_year, current_month)`

<!--
Thanks for contributing to Wagtail! 🎉

Before submitting, please review the [contributor guidelines](https://docs.wagtail.org/en/latest/contributing/index.html).
-->

_Please check the following:_

-   [ ] Do the tests still pass?[^1]
-   [ ] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
