### PR TITLE
Adjust checkbox and radio label colours, remove margin on fields in group permission tables, and adjust spacing between error icon and message

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -52,6 +52,8 @@ Changelog
  * Fix: Ensure the capitalisation of the `timesince_simple` tag is consistently added in the template based on usage in context (Stefan Hammer)
  * Fix: Add missing translation usage for the `timesince_last_update` and ensure the translated labels can be easier to work with in Transifex (Stefan Hammer)
  * Fix: Add additional checks for duplicate form field `clean_name` values in the Form Builder validation and increase performance of checks (Dan Bentley)
+ * Fix: Use correct color for labels of radio and checkbox fields (Steven Steinwand)
+ * Fix: Adjust spacing of fields’ error messages and position in tables (Steven Steinwand)
 
 4.0.3 (xx.xx.xxxx) - IN DEVELOPMENT
 ~~~~~~~~~~~~~~~~~~

--- a/client/scss/components/forms/_field.scss
+++ b/client/scss/components/forms/_field.scss
@@ -28,7 +28,7 @@
   top: 0.125em;
   width: 1em;
   height: 1em;
-  margin-inline-end: 0.375em;
+  margin-inline-end: 0.625rem;
   color: theme('colors.critical.200');
 
   // Avoid displaying the error message icon if we already have an icon.
@@ -49,6 +49,11 @@
   // be wrapped into groups (for example a row), so it’s safer to add a margin regardless
   // of what the next element is.
   margin-bottom: theme('spacing.5');
+
+  // Inside of listing tables we don't need the bottom margin because the table row will handle it.
+  table.listing td & {
+    margin-bottom: 0;
+  }
 }
 
 .w-field__input {

--- a/client/scss/components/forms/_radio-checkbox-multiple.scss
+++ b/client/scss/components/forms/_radio-checkbox-multiple.scss
@@ -14,6 +14,7 @@
 
   label {
     @apply w-label-3;
+    color: theme('colors.grey.600');
     display: inline-flex;
     align-items: center;
     line-height: normal;

--- a/docs/releases/4.1.md
+++ b/docs/releases/4.1.md
@@ -77,6 +77,8 @@ This feature was developed by Karl Hobley and Matt Westcott.
  * Ensure the capitalisation of the `timesince_simple` tag is consistently added in the template based on usage in context (Stefan Hammer)
  * Add missing translation usage for the `timesince_last_update` and ensure the translated labels can be easier to work with in Transifex (Stefan Hammer)
  * Add additional checks for duplicate form field `clean_name` values in the Form Builder validation and increase performance of checks (Dan Bentley)
+ * Use correct color for labels of radio and checkbox fields (Steven Steinwand)
+ * Adjust spacing of fields’ error messages and position in tables (Steven Steinwand)
 
 ## Upgrade considerations
 


### PR DESCRIPTION
Addresses #9033. Form style design review fixes:

- [x]  Center-align fields within group permission tables
<img width="903" alt="Screen Shot 2022-08-23 at 10 58 28 PM" src="https://user-images.githubusercontent.com/25041665/186332860-7c4ce28b-8a38-4463-af82-d079242bf043.png">

- [x]  Checkbox & radio option label should be grey
<img width="272" alt="Screen Shot 2022-08-23 at 10 58 46 PM" src="https://user-images.githubusercontent.com/25041665/186332888-290f392c-c7a7-47c7-aaca-c008a1ef9c03.png">

- [x]  Spacing between error icon and message
<img width="854" alt="Screen Shot 2022-08-23 at 10 57 18 PM" src="https://user-images.githubusercontent.com/25041665/186332931-bf0857ac-5449-4734-8dbb-7db56b8db2f6.png">

## Browsers tested on
Chrome 104 , Safari 15.6, Firefox 103