### PR TITLE
Mention WAGTAILADMIN_RICH_TEXT_EDITORS on admin customization page.

### DIFF
--- a/docs/advanced_topics/customisation/page_editing_interface.md
+++ b/docs/advanced_topics/customisation/page_editing_interface.md
@@ -90,7 +90,7 @@ The process for creating new features is described in the following pages:
 -   [](../../extending/rich_text_internals)
 -   [](../../extending/extending_draftail)
 
-You can also provide a setting for naming a group of rich text features. See [](../../reference/settings.html#id17).
+You can also provide a setting for naming a group of rich text features. See [WAGTAILADMIN_RICH_TEXT_EDITORS](wagtailadmin_rich_text_editors).
 
 (rich_text_image_formats)=
 

--- a/docs/advanced_topics/customisation/page_editing_interface.md
+++ b/docs/advanced_topics/customisation/page_editing_interface.md
@@ -90,6 +90,9 @@ The process for creating new features is described in the following pages:
 -   [](../../extending/rich_text_internals)
 -   [](../../extending/extending_draftail)
 
+
+You can also provide a setting for naming a group of rich text features. See [](../../reference/settings.html#id17).
+
 (rich_text_image_formats)=
 
 ### Image Formats in the Rich Text Editor

--- a/docs/advanced_topics/customisation/page_editing_interface.md
+++ b/docs/advanced_topics/customisation/page_editing_interface.md
@@ -90,7 +90,6 @@ The process for creating new features is described in the following pages:
 -   [](../../extending/rich_text_internals)
 -   [](../../extending/extending_draftail)
 
-
 You can also provide a setting for naming a group of rich text features. See [](../../reference/settings.html#id17).
 
 (rich_text_image_formats)=


### PR DESCRIPTION
fixes #9070 

Mentioning on [Limiting features in a rich text field](https://docs.wagtail.org/en/stable/advanced_topics/customisation/page_editing_interface.html#limiting-features-in-a-rich-text-field) it is also possible to name a group of rich text features. 