### PR TITLE
Fix issue with React inline style creation (console error)

### DIFF
--- a/client/src/components/Draftail/CommentableEditor/CommentableEditor.tsx
+++ b/client/src/components/Draftail/CommentableEditor/CommentableEditor.tsx
@@ -886,8 +886,8 @@ function CommentableEditor({
                 // Use the focused colour if one of the comments is focused
                 background = focusedHighlight;
                 return {
-                  'background-color': background,
-                  'color': standardHighlight,
+                  backgroundColor: background,
+                  color: standardHighlight,
                 };
               } else if (numStyles > 1) {
                 // Otherwise if we're in a region with overlapping comments, use a slightly darker colour than usual
@@ -895,7 +895,7 @@ function CommentableEditor({
                 background = overlappingHighlight;
               }
               return {
-                'background-color': background,
+                backgroundColor: background,
               };
             }
             return undefined;


### PR DESCRIPTION
- as per docs https://www.draftail.org/docs/inline-styles
- inline styles should be React camelCase styles not CSS kebab-case styles
- fixes #9081

## before

<img width="1492" alt="Screen Shot 2022-08-25 at 7 17 55 am" src="https://user-images.githubusercontent.com/1396140/186525434-b7e097da-51dc-4088-a508-6686fad8777a.png">


## after

<img width="1317" alt="Screen Shot 2022-08-25 at 7 15 57 am" src="https://user-images.githubusercontent.com/1396140/186525124-f1b8aa75-85a8-491b-9673-bb3ef9613056.png">





