### PR TITLE
Clean up - spelling of multi-site

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -541,7 +541,7 @@ Changelog
  * Added instructions on copying and aliasing pages to the editor's guide in documentation (Vlad Podgurschi)
  * Allow ListBlock to raise validation errors that are not attached to an individual child block (Matt Westcott)
  * Use `DATETIME_FORMAT` for localization in templates (Andrew Stone)
- * Added documentation on multi site, multi instance and multi tenancy setups (Coen Van Der Kamp)
+ * Added documentation on multi-site, multi instance and multi tenancy setups (Coen Van Der Kamp)
  * Updated Facebook / Instagram oEmbed endpoints to v11.0 (Thomas Kremmel)
  * Performance improvements for admin listing pages (Jake Howard, Dan Braghis, Tom Usher)
  * Fix: Invalid filter values for foreign key fields in the API now give an error instead of crashing (Tidiane Dia)

--- a/docs/editor_manual/managing_redirects.md
+++ b/docs/editor_manual/managing_redirects.md
@@ -37,7 +37,7 @@ To configure redirects head over to 'Redirects', which can be found in the Setti
 ![](../_static/images/screen43_redirects_edit_redirect.png)
 
 -   Set _Redirect from_ to the URL pattern which is no longer available on your site.
--   Set the _From site_ if applicable (for eg: a multisite environment).
+-   Set the _From site_ if applicable (for eg: a multi-site environment).
 -   Check whether the redirect is _Permanent_ or temporary (unchecked).
 
 As a last step you can either redirect to a new page within Wagtail **or** you can redirect the page to a different domain outside of Wagtail.

--- a/docs/reference/contrib/settings.md
+++ b/docs/reference/contrib/settings.md
@@ -267,7 +267,7 @@ settings for the default site instead:
 
 **Note:** You can not reliably get the correct settings instance for the
 current site from this template tag if the request object is not available.
-This is only relevant for multisite instances of Wagtail.
+This is only relevant for multi-site instances of Wagtail.
 
 You can store the settings instance in a variable to save some typing,
 if you have to use multiple values from one model:

--- a/docs/releases/2.14.rst
+++ b/docs/releases/2.14.rst
@@ -27,7 +27,7 @@ New features
  * Add Google Data Studio to the list of oEmbed providers (Petr Dlouhý)
  * Allow ListBlock to raise validation errors that are not attached to an individual child block (Matt Westcott)
  * Use ``DATETIME_FORMAT`` for localization in templates (Andrew Stone)
- * Added documentation on multi site, multi instance and multi tenancy setups (Coen Van Der Kamp)
+ * Added documentation on multi-site, multi instance and multi tenancy setups (Coen Van Der Kamp)
  * Updated Facebook / Instagram oEmbed endpoints to v11.0 (Thomas Kremmel)
  * Performance improvements for admin listing pages (Jake Howard, Dan Braghis, Tom Usher)
 

--- a/wagtail/contrib/settings/tests/site_specific/test_templates.py
+++ b/wagtail/contrib/settings/tests/site_specific/test_templates.py
@@ -26,7 +26,7 @@ class TestContextProcessor(TemplateTestCase):
             self.default_settings.title,
         )
 
-    def test_multisite(self):
+    def test_multi_site(self):
         """Check that the correct setting for the current site is returned"""
         request = self.get_request(site=self.default_site)
         self.assertEqual(
@@ -219,7 +219,7 @@ class TestSiteSettingsJinja(TemplateTestCase):
             self.default_settings.title,
         )
 
-    def test_multisite(self):
+    def test_multi_site(self):
         """Check that the correct setting for the current site is returned"""
         context = {"site": self.default_site}
         self.assertEqual(

--- a/wagtail/test/demosite/fixtures/demosite.json
+++ b/wagtail/test/demosite/fixtures/demosite.json
@@ -403,8 +403,8 @@
     "pk": 24,
     "model": "wagtailcore.page",
     "fields": {
-      "title": "Home page multi site",
-      "draft_title": "Home page multi site",
+      "title": "Home page multi-site",
+      "draft_title": "Home page multi-site",
       "numchild": 1,
       "show_in_menus": true,
       "live": true,
@@ -423,8 +423,8 @@
     "pk": 25,
     "model": "wagtailcore.page",
     "fields": {
-      "title": "Events index multi site",
-      "draft_title": "Events index multi site",
+      "title": "Events index multi-site",
+      "draft_title": "Events index multi-site",
       "numchild": 0,
       "show_in_menus": true,
       "live": true,


### PR DESCRIPTION
- small clean up, while reviewing the 4.0 blog post I realised that we have mostly referred to multi-site (hyphenated) but there were a few outliers