### PR TITLE
Centered spinner icon and signing in text for login page

### DIFF
--- a/client/scss/layouts/_login.scss
+++ b/client/scss/layouts/_login.scss
@@ -103,6 +103,12 @@
     // no need for margin bottom due to padding on content-wrapper
     margin-top: theme('spacing.8');
     text-align: center;
+
+    .button-longrunning {
+      &-active {
+        justify-content: center;
+      }
+    }
   }
 
   .login-form .w-field__errors {


### PR DESCRIPTION
Fixes #9083.
In my opinion, this issue was introduced with https://github.com/wagtail/wagtail/pull/8670.

After fix:

![Screenshot (687)](https://user-images.githubusercontent.com/86092410/186687904-bf99fd78-ebbb-4722-aed3-ce946b508855.png)

