### PR TITLE
Change AbstractForm to a mixin class

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -13,6 +13,7 @@ Changelog
  * Remove legacy `unbutton` styling for buttons (Paarth Agarwal)
  * Add button variations to the pattern library (Paarth Agarwal)
  * Provide a more accessible page title where the unique information is shown first and the CMS name is shown last (Mehrdad Moradizadeh)
+ * Pull out behaviour from `AbstractFormField` to `FormMixin` and `AbstractEmailForm` to `EmailFormMixin` to allow use with subclasses of `Page` (Mehrdad Moradizadeh, Kurt Wall)
  * Fix: Prevent `PageQuerySet.not_public` from returning all pages when no page restrictions exist (Mehrdad Moradizadeh)
 
 

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -620,6 +620,7 @@ Contributors
 * Mehrdad Moradizadeh
 * ariadi
 * Thomas van der Hoeven
+* Kurt Wall
 
 
 Translators

--- a/docs/reference/contrib/forms/customisation.md
+++ b/docs/reference/contrib/forms/customisation.md
@@ -793,3 +793,31 @@ class FormPage(AbstractEmailForm):
     class FormPage(AbstractEmailForm):
         # ... page definitions
 ```
+
+(form_builder_mixins)=
+
+## Using `FormMixin` or `EmailFormMixin` to use with other `Page` subclasses
+
+If you need to add form behaviour while extending an additional class, you can use the base mixins instead of the abstract modals.
+
+```python
+from wagtail.models import Page
+from wagtail.contrib.forms.models import EmailFormMixin, FormMixin
+
+
+class BasePage(Page):
+    """
+    A shared base page used throughout the project.
+    """
+
+    # ...
+
+class FormPage(FormMixin, BasePage):
+    intro = RichTextField(blank=True)
+    # ...
+
+class EmailFormPage(EmailFormMixin, FormMixin, BasePage):
+    intro = RichTextField(blank=True)
+    # ...
+
+```

--- a/docs/releases/4.1.md
+++ b/docs/releases/4.1.md
@@ -21,6 +21,7 @@ Wagtail 4.1 is designated a Long Term Support (LTS) release. Long Term Support r
  * Remove legacy `unbutton` styling for buttons (Paarth Agarwal)
  * Add button variations to the pattern library (Paarth Agarwal)
  * Provide a more accessible page title where the unique information is shown first and the CMS name is shown last (Mehrdad Moradizadeh)
+ * Pull out behaviour from `AbstractFormField` to `FormMixin` and `AbstractEmailForm` to `EmailFormMixin` to allow use with subclasses of `Page` [](form_builder_mixins) (Mehrdad Moradizadeh, Kurt Wall)
 
 ### Bug fixes
 

--- a/wagtail/contrib/forms/utils.py
+++ b/wagtail/contrib/forms/utils.py
@@ -18,10 +18,10 @@ def get_field_clean_name(label):
 def get_form_types():
     global _FORM_CONTENT_TYPES
     if _FORM_CONTENT_TYPES is None:
-        from wagtail.contrib.forms.models import AbstractForm
+        from wagtail.contrib.forms.models import FormMixin
 
         form_models = [
-            model for model in get_page_models() if issubclass(model, AbstractForm)
+            model for model in get_page_models() if issubclass(model, FormMixin)
         ]
 
         _FORM_CONTENT_TYPES = list(


### PR DESCRIPTION
fixes #2900

As mentioned in #2900, since `AbstractForm` inherits from `Page`, any custom `Page` subclass cannot use it. Therefore, we can convert the class to a mixin, so the subclasses of `Page` can also use Form Builder functionality.