### PR TITLE
moving branding_title to the end of page title for admin users

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -12,6 +12,7 @@ Changelog
  * Optimise the performance of the Wagtail userbar to remove duplicated queries, improving page loads when viewing live pages while signed in (Jake Howard)
  * Remove legacy `unbutton` styling for buttons (Paarth Agarwal)
  * Add button variations to the pattern library (Paarth Agarwal)
+ * Provide a more accessible page title where the unique information is shown first and the CMS name is shown last (Mehrdad Moradizadeh)
  * Fix: Prevent `PageQuerySet.not_public` from returning all pages when no page restrictions exist (Mehrdad Moradizadeh)
 
 

--- a/client/tests/integration/groups.test.js
+++ b/client/tests/integration/groups.test.js
@@ -4,7 +4,7 @@ describe('Groups', () => {
   }, 10000);
 
   it('has the right heading', async () => {
-    expect(await page.title()).toContain('Wagtail - Editing Editors');
+    expect(await page.title()).toContain('Editing Editors - Wagtail');
   });
 
   it('axe', async () => {

--- a/client/tests/integration/listing.test.js
+++ b/client/tests/integration/listing.test.js
@@ -5,7 +5,7 @@ describe('Listing', () => {
 
   it('has the right heading', async () => {
     expect(await page.title()).toContain(
-      'Wagtail - Exploring Welcome to your new Wagtail site!',
+      'Exploring Welcome to your new Wagtail site! - Wagtail',
     );
   });
 

--- a/docs/releases/4.1.md
+++ b/docs/releases/4.1.md
@@ -20,6 +20,7 @@ Wagtail 4.1 is designated a Long Term Support (LTS) release. Long Term Support r
  * Optimise the performance of the Wagtail userbar to remove duplicated queries, improving page loads when viewing live pages while signed in (Jake Howard)
  * Remove legacy `unbutton` styling for buttons (Paarth Agarwal)
  * Add button variations to the pattern library (Paarth Agarwal)
+ * Provide a more accessible page title where the unique information is shown first and the CMS name is shown last (Mehrdad Moradizadeh)
 
 ### Bug fixes
 

--- a/wagtail/admin/templates/wagtailadmin/skeleton.html
+++ b/wagtail/admin/templates/wagtailadmin/skeleton.html
@@ -5,7 +5,7 @@
 <html lang="{{ LANGUAGE_CODE }}" dir="{% if LANGUAGE_BIDI %}rtl{% else %}ltr{% endif %}">
     <head>
         <meta charset="utf-8" />
-        <title>{% block branding_title %}Wagtail{% endblock %} - {% block titletag %}{% endblock %}</title>
+        <title>{% block titletag %}{% endblock %} - {% block branding_title %}Wagtail{% endblock %}</title>
         <meta name="description" content="" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta name="robots" content="noindex" />

--- a/wagtail/admin/tests/pages/test_edit_page.py
+++ b/wagtail/admin/tests/pages/test_edit_page.py
@@ -862,7 +862,7 @@ class TestPageEdit(TestCase, WagtailTestUtils):
         # We should have an error page because we are unable to
         # preview; the page key was not in the session.
         self.assertContains(
-            response, "<title>Wagtail - Preview not available</title>", html=True
+            response, "<title>Preview not available - Wagtail</title>", html=True
         )
         self.assertContains(
             response,

--- a/wagtail/admin/tests/pages/test_preview.py
+++ b/wagtail/admin/tests/pages/test_preview.py
@@ -149,7 +149,7 @@ class TestPreview(TestCase, WagtailTestUtils):
         self.assertTemplateUsed(response, "wagtailadmin/generic/preview_error.html")
         self.assertContains(
             response,
-            "<title>Wagtail - Preview not available</title>",
+            "<title>Preview not available - Wagtail</title>",
             html=True,
         )
         self.assertContains(
@@ -188,7 +188,7 @@ class TestPreview(TestCase, WagtailTestUtils):
         self.assertTemplateUsed(response, "wagtailadmin/generic/preview_error.html")
         self.assertContains(
             response,
-            "<title>Wagtail - Preview not available</title>",
+            "<title>Preview not available - Wagtail</title>",
             html=True,
         )
         self.assertContains(
@@ -345,7 +345,7 @@ class TestPreview(TestCase, WagtailTestUtils):
         self.assertTemplateUsed(response, "wagtailadmin/generic/preview_error.html")
         self.assertContains(
             response,
-            "<title>Wagtail - Preview not available</title>",
+            "<title>Preview not available - Wagtail</title>",
             html=True,
         )
         self.assertContains(
@@ -380,7 +380,7 @@ class TestPreview(TestCase, WagtailTestUtils):
         self.assertTemplateUsed(response, "wagtailadmin/generic/preview_error.html")
         self.assertContains(
             response,
-            "<title>Wagtail - Preview not available</title>",
+            "<title>Preview not available - Wagtail</title>",
             html=True,
         )
         self.assertContains(

--- a/wagtail/snippets/tests/test_preview.py
+++ b/wagtail/snippets/tests/test_preview.py
@@ -50,7 +50,7 @@ class TestPreview(TestCase, WagtailTestUtils):
         self.assertTemplateUsed(response, "wagtailadmin/generic/preview_error.html")
         self.assertContains(
             response,
-            "<title>Wagtail - Preview not available</title>",
+            "<title>Preview not available - Wagtail</title>",
             html=True,
         )
         self.assertContains(
@@ -81,7 +81,7 @@ class TestPreview(TestCase, WagtailTestUtils):
         self.assertTemplateUsed(response, "wagtailadmin/generic/preview_error.html")
         self.assertContains(
             response,
-            "<title>Wagtail - Preview not available</title>",
+            "<title>Preview not available - Wagtail</title>",
             html=True,
         )
         self.assertContains(
@@ -220,7 +220,7 @@ class TestPreview(TestCase, WagtailTestUtils):
         self.assertTemplateUsed(response, "wagtailadmin/generic/preview_error.html")
         self.assertContains(
             response,
-            "<title>Wagtail - Preview not available</title>",
+            "<title>Preview not available - Wagtail</title>",
             html=True,
         )
         self.assertContains(
@@ -250,7 +250,7 @@ class TestPreview(TestCase, WagtailTestUtils):
         self.assertTemplateUsed(response, "wagtailadmin/generic/preview_error.html")
         self.assertContains(
             response,
-            "<title>Wagtail - Preview not available</title>",
+            "<title>Preview not available - Wagtail</title>",
             html=True,
         )
         self.assertContains(


### PR DESCRIPTION
fixes #9054 

Moving the `branding_title` - Wagtail text - to the end of the page title, to make it more readable for the admin user. 

*Note:* Normally, the `branding_title` appears at the beginning of the page title; as a result, the browser tab shows just the text Wagtail. Also, as the browser tab shows the Wagtail favicon, the tab doesn't need to display the text Wagtail. 