### PR TITLE
Python 3.10.x support in 2.16.x

### DIFF
--- a/wagtail/utils/utils.py
+++ b/wagtail/utils/utils.py
@@ -1,4 +1,4 @@
-import collections
+from collections.abc import Mapping
 
 
 def deep_update(source, overrides):
@@ -7,7 +7,7 @@ def deep_update(source, overrides):
     Modify ``source`` in place.
     """
     for key, value in overrides.items():
-        if isinstance(value, collections.Mapping) and value:
+        if isinstance(value, Mapping) and value:
             returned = deep_update(source.get(key, {}), value)
             source[key] = returned
         else:


### PR DESCRIPTION
Fixes support for Python 3.10 by importing `Mapping` from `collections.abc` instead of from `collections`, as noted in issue #9095 

_Please check the following:_

-   [X] Do the tests still pass?[^1]
-   [X] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?
