### PR TITLE
Remove broken reference to Image.LoaderError

### DIFF
--- a/wagtail/images/checks.py
+++ b/wagtail/images/checks.py
@@ -13,7 +13,7 @@ def has_jpeg_support():
     with open(wagtail_jpg, "rb") as f:
         try:
             Image.open(f)
-        except (IOError, Image.LoaderError):
+        except IOError:
             succeeded = False
 
     return succeeded
@@ -27,7 +27,7 @@ def has_png_support():
     with open(wagtail_png, "rb") as f:
         try:
             Image.open(f)
-        except (IOError, Image.LoaderError):
+        except IOError:
             succeeded = False
 
     return succeeded


### PR DESCRIPTION
This exception has not existed since Willow 0.3. Type checking on the 'except' line only happens when an exception occurs, so most of the time this is harmless, but if an unrelated exception occurs here (such as that caused by a faulty filetype library: https://github.com/h2non/filetype.py/issues/130) the real exception gets masked by an AttributeError for the missing definition.
