### PR TITLE
Refactored button styles

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -9,7 +9,7 @@ Changelog
  * Most images in the admin will now only load once they are visible on screen (Jake Howard)
  * Allow setting default attributes on image tags (Jake Howard)
  * Optimise the performance of the Wagtail userbar to remove duplicated queries, improving page loads when viewing live pages while signed in (Jake Howard)
- * Remove legacy `unbutton` styling for buttons (Paarth Agarwal)
+ * Remove legacy styling classes for buttons (`unbutton`, `button-neutral`, `button-strokeonhover`, `hover-no`) and refactor button styles to be more maintainable (Paarth Agarwal, LB (Ben Johnston))
  * Add button variations to the pattern library (Paarth Agarwal)
  * Provide a more accessible page title where the unique information is shown first and the CMS name is shown last (Mehrdad Moradizadeh)
  * Pull out behaviour from `AbstractFormField` to `FormMixin` and `AbstractEmailForm` to `EmailFormMixin` to allow use with subclasses of `Page` (Mehrdad Moradizadeh, Kurt Wall)

--- a/client/scss/components/_button.scss
+++ b/client/scss/components/_button.scss
@@ -1,18 +1,17 @@
+// stylelint-disable max-nesting-depth
+
+// Core button styles
+
 @use 'sass:color';
-// Core button style
-// Note that these styles include methods to render buttons the same x-browser, described here:
-// http: //cbjdigital.com/blog/2010/08/bulletproof_css_input_button_heights
-// input[type=submit],
-// input[type=reset],
-// input[type=button],
+
 .button {
-  border-radius: 3px;
-  font-family: $font-sans;
+  border-radius: theme('borderRadius.sm');
   width: auto;
-  height: 2.4em;
+  height: 2.25em;
   padding: 0 1em;
-  font-size: 0.9em;
-  font-weight: normal;
+  font-size: theme('fontSize.14');
+  font-weight: theme('fontWeight.normal');
+  line-height: 2.25em;
   vertical-align: middle;
   display: inline-block;
   background-color: $color-button;
@@ -22,15 +21,27 @@
   white-space: nowrap;
   position: relative;
   overflow: hidden;
-  box-sizing: border-box;
-  -webkit-font-smoothing: auto;
+  box-sizing: content-box;
+  transition: background-color 0.1s ease;
   // stylelint-disable-next-line property-no-vendor-prefix
   -moz-appearance: none;
+  -webkit-font-smoothing: auto;
 
-  transition: background-color 0.1s ease;
+  + .button {
+    // ensure buttons can sit next to each other with a nice margin
+    margin-inline-start: theme('spacing.4');
+  }
 
-  &:hover {
-    color: $color-teal;
+  &.button-small {
+    padding: 0 0.8em;
+    height: 2em;
+    font-size: calc(theme('fontSize.14') * 0.87);
+    line-height: 2em;
+  }
+
+  &.button-secondary {
+    color: $color-button;
+    background-color: transparent;
   }
 
   &.yes {
@@ -91,12 +102,12 @@
 
     &:before {
       // iconfont
-      font-size: 1rem;
+      font-size: theme('fontSize.15');
       position: absolute;
       inset-inline-start: 0;
       top: 0;
       width: 2em;
-      line-height: 1.85em;
+      line-height: inherit;
       height: 100%;
       text-align: center;
       background-color: theme('colors.black-20');
@@ -137,6 +148,10 @@
       &:before {
         display: none; // TODO: remove once the icon font styles are gone
       }
+
+      .icon {
+        @include svg-icon(1.5em);
+      }
     }
 
     &.button--icon-flipped {
@@ -148,37 +163,18 @@
     &.button-secondary {
       border: 1px solid theme('colors.black-20');
     }
-  }
 
-  &.button-small.bicolor {
-    padding-inline-start: 3.5em;
+    &.button-small {
+      padding-inline-start: 3.5em;
 
-    .icon-wrapper {
-      width: 2em;
-    }
+      .icon-wrapper {
+        width: theme('spacing.8');
+      }
 
-    &.button--icon .icon {
-      @include svg-icon(0.9rem);
-      padding: 0.25em;
-    }
-  }
-
-  // + input[type=submit],
-  // + input[type=reset],
-  // + input[type=button],
-  + .button {
-    // + button {
-    margin-inline-start: 1em;
-  }
-
-  // stylelint-disable-next-line no-duplicate-selectors
-  &:hover {
-    background-color: $color-button-hover;
-    color: $color-white;
-    border-color: transparent;
-
-    &.hover-no {
-      background-color: $color-button-no;
+      &.button--icon .icon {
+        @include svg-icon(0.9rem);
+        padding: 0.25em;
+      }
     }
   }
 
@@ -188,7 +184,7 @@
       @include transition(all 0.3s ease);
       transform: scale(0.9);
       display: inline-block;
-      height: 0.9em;
+      height: 1em;
       position: relative;
       opacity: 0;
       width: 0;
@@ -199,21 +195,6 @@
 
     em {
       font-style: normal;
-    }
-
-    &-active {
-      display: inline-flex;
-      align-items: center;
-    }
-
-    &-active span {
-      // iconfont
-      transform: scale(1);
-      visibility: visible;
-      width: 1em;
-      height: 1em;
-      opacity: 0.8;
-      padding-inline-end: 0.5em;
     }
 
     span.icon-spinner:after {
@@ -231,19 +212,42 @@
       @include transition(all 0.3s ease);
       display: none;
     }
+  }
 
-    &-active svg.icon-spinner {
+  &.button-longrunning-active {
+    display: inline-flex;
+    align-items: center;
+
+    span {
+      // iconfont
+      transform: scale(1);
+      visibility: visible;
+      width: 1em;
+      height: 1em;
+      opacity: 0.8;
+      padding-inline-end: 0.5em;
+    }
+
+    svg.icon-spinner {
       @include svg-icon();
       display: inline-block;
       opacity: 0.8;
       padding: 0;
     }
 
-    &-active .button-longrunning__icon {
+    .button-longrunning__icon {
       display: none;
     }
   }
 
+  // Base hover state
+  &:hover {
+    background-color: $color-button-hover;
+    color: $color-white;
+    border-color: transparent;
+  }
+
+  // Disabled state
   &:disabled,
   &[disabled],
   &.disabled {
@@ -251,6 +255,7 @@
     border-color: $color-grey-3;
     color: $color-grey-2;
     cursor: default;
+
     @media (forced-colors: active) {
       color: GrayText;
       border-color: GrayText;
@@ -266,221 +271,91 @@
     color: $color-grey-3;
   }
 
-  &.button-strokeonhover {
-    border: 1px solid transparent;
-
-    &:hover {
-      border-color: $color-grey-2;
-    }
-  }
-
-  &.button--icon {
-    .icon {
-      @include svg-icon(1.5em);
-    }
-  }
-
-  @include media-breakpoint-up(sm) {
-    font-size: 0.95em;
-    padding: 0 1.4em;
-    height: 3em;
-
-    &.bicolor {
-      padding-inline-start: 3.7em;
-
-      &:before {
-        width: 2em;
-        line-height: 2.2em;
-        font-size: 1.1rem;
-      }
-    }
-
-    &.button-small.bicolor {
-      // line-height: 2.2em;
-      padding-inline-start: 3em;
-
-      &:before {
-        width: 1.8em;
-        line-height: 1.65em;
-      }
-    }
-  }
-}
-
-.button-small {
-  padding: 0 0.8em;
-  height: 2em;
-  font-size: 0.95em;
-}
-
-.button-secondary {
-  color: $color-button;
-  background-color: transparent;
-}
-
-// Buttons which are only an icon
-.button.icon.text-replace {
-  // iconfont
-  font-size: 0; // unavoidable duplication of setting in icons.scss
-  width: 1.8rem;
-  height: 1.8rem;
-  box-sizing: content-box;
-
-  &:before {
-    line-height: 1.7em;
-  }
-
-  @include media-breakpoint-up(sm) {
-    width: 2.2rem;
-    height: 2.2rem;
-
-    &:before {
-      line-height: 2.1em;
-    }
-
-    &.button-small {
-      height: 1.8rem;
-      width: 1.8rem;
+  // Buttons which are only an icon
+  &.text-replace {
+    &.icon {
+      // iconfont
+      font-size: 0; // unavoidable duplication of setting in icons.scss
+      height: inherit;
+      width: inherit;
+      box-sizing: content-box;
 
       &:before {
         line-height: 1.7em;
       }
     }
-  }
-}
 
-.button--icon.text-replace {
-  background-color: transparent;
-  color: $color-grey-2;
-  border-color: transparent;
-  font-size: 0;
-  text-align: center;
+    &.button--icon {
+      background-color: transparent;
+      color: $color-grey-2;
+      border-color: transparent;
+      font-size: 0;
+      text-align: center;
+      height: inherit;
+      width: inherit;
 
-  &:hover {
-    color: $color-grey-1;
-  }
+      &:hover {
+        color: $color-grey-1;
+      }
 
-  .icon {
-    font-size: initial;
-    @include svg-icon(1rem, middle);
-    padding: 0.5em;
-    box-sizing: content-box;
-  }
+      .icon {
+        @include svg-icon(1rem, middle);
 
-  &.button-small {
-    line-height: 1.7rem;
-    height: 1.8rem;
-    width: 1.8rem;
+        font-size: initial;
+        padding: 0.5em;
+        box-sizing: content-box;
+      }
 
-    .icon {
-      padding: 0.25em;
+      &.button-small {
+        line-height: 1.75em;
+
+        .icon {
+          padding: 0.25em;
+        }
+      }
+    }
+
+    @include media-breakpoint-up(sm) {
+      &.icon {
+        &:before {
+          line-height: 2.1em;
+        }
+
+        &.button-small {
+          width: 1.75em;
+          height: 1.75em;
+
+          &:before {
+            line-height: 1.7em;
+          }
+        }
+      }
     }
   }
 
-  @include media-breakpoint-up(sm) {
-    width: 2.2rem;
-    height: 2.2rem;
-  }
-}
-
-button.button.bicolor .icon-wrapper {
-  line-height: 1.65em; // work around differences in a and button elements
-}
-
-.button-neutral {
-  color: $color-grey-2;
-
-  &:hover {
-    color: $color-teal;
-  }
-}
-
-.yes {
-  background-color: $color-button-yes;
-  border: 1px solid $color-button-yes;
-
-  &.button-secondary {
-    border: 1px solid $color-button-yes;
-    color: $color-button-yes;
-    background-color: transparent;
-  }
-
-  &:hover {
-    color: $color-white;
-    border-color: transparent;
-    background-color: $color-button-yes;
-  }
-}
-
-.no,
-.serious {
-  background-color: $color-button-no;
-  border: 1px solid $color-button-no;
-
-  &.button-secondary {
-    border: 1px solid $color-button-no;
-    color: $color-button-no;
-    background-color: transparent;
-  }
-
-  &:hover {
-    color: $color-white;
-    border-color: transparent;
-    background-color: $color-button-no;
-  }
-}
-
-.bicolor {
-  border: 0;
-  padding-inline-start: 3.5em;
-
-  &:before {
-    font-size: 1rem;
-    position: absolute;
-    inset-inline-start: 0;
-    top: 0;
-    width: 2em;
-    line-height: 1.85em;
-    height: 100%;
-    text-align: center;
-    background-color: theme('colors.black-20');
-    display: block;
-  }
-}
-
-.button-small.bicolor {
-  padding-inline-start: 3.5em;
-
-  &:before {
-    width: 2em;
-    font-size: 0.8rem;
-    line-height: 1.65em;
-  }
-}
-
-a.button {
-  line-height: 2.4em;
-  height: auto;
-
-  &.button-small {
-    line-height: 1.85em;
-  }
+  // Larger viewport width adjustments
 
   @include media-breakpoint-up(sm) {
-    line-height: 2.9em;
-  }
-}
+    font-size: theme('fontSize.14');
+    padding: 0 1.4em;
+    height: 3em;
+    line-height: 3em;
 
-// Special styles to counteract Firefox's completely unwarranted assumptions about button styles
-input[type='submit'],
-input[type='reset'],
-input[type='button'],
-button {
-  padding: 0 1em;
+    &.bicolor {
+      padding-inline-start: 3.5em;
 
-  @include media-breakpoint-up(sm) {
-    &.button-small {
-      height: 2em;
+      &:before {
+        width: 2em;
+        font-size: theme('fontSize.16');
+      }
+
+      &.button-small {
+        padding-inline-start: 3em;
+
+        &:before {
+          width: 1.75em;
+        }
+      }
     }
   }
 }

--- a/client/scss/components/_dropdown.legacy.scss
+++ b/client/scss/components/_dropdown.legacy.scss
@@ -14,6 +14,7 @@
     line-height: 3em;
     text-align: start;
     float: left;
+    box-sizing: border-box;
   }
 
   .action-secondary {

--- a/client/scss/generic/_normalize.scss
+++ b/client/scss/generic/_normalize.scss
@@ -485,6 +485,18 @@ input[type='search']::-webkit-search-decoration {
 }
 
 /**
+ * Special styles to counteract Firefox's completely unwarranted assumptions
+ * about button styles
+ */
+
+input[type='submit'],
+input[type='reset'],
+input[type='button'],
+button {
+  padding: 0 1em;
+}
+
+/**
  * Remove inner padding and border in Firefox 3+.
  */
 

--- a/docs/releases/4.1.md
+++ b/docs/releases/4.1.md
@@ -18,7 +18,7 @@ Wagtail 4.1 is designated a Long Term Support (LTS) release. Long Term Support r
  * Most images in the admin will now only load once they are visible on screen (Jake Howard)
  * Allow setting default attributes on image tags [](adding_default_attributes_to_images) (Jake Howard)
  * Optimise the performance of the Wagtail userbar to remove duplicated queries, improving page loads when viewing live pages while signed in (Jake Howard)
- * Remove legacy `unbutton` styling for buttons (Paarth Agarwal)
+ * Remove legacy styling classes for buttons and refactor button styles to be more maintainable (Paarth Agarwal, LB (Ben Johnston))
  * Add button variations to the pattern library (Paarth Agarwal)
  * Provide a more accessible page title where the unique information is shown first and the CMS name is shown last (Mehrdad Moradizadeh)
  * Pull out behaviour from `AbstractFormField` to `FormMixin` and `AbstractEmailForm` to `EmailFormMixin` to allow use with subclasses of `Page` [](form_builder_mixins) (Mehrdad Moradizadeh, Kurt Wall)
@@ -28,3 +28,12 @@ Wagtail 4.1 is designated a Long Term Support (LTS) release. Long Term Support r
  * Prevent `PageQuerySet.not_public` from returning all pages when no page restrictions exist (Mehrdad Moradizadeh)
 
 ## Upgrade considerations
+
+### Button styling class changes
+
+The following button classes have been removed:
+
+* `unbutton`
+* `button-neutral`
+* `button-strokeonhover`
+* `hover-no`

--- a/wagtail/admin/templates/wagtailadmin/shared/button.stories.tsx
+++ b/wagtail/admin/templates/wagtailadmin/shared/button.stories.tsx
@@ -118,7 +118,7 @@ const Template = ({ url }) => (
     <h3>Colour signifiers</h3>
 
     <h4>Positive</h4>
-    <a href={url} className="button yes">
+    <a href={url} className="button button-small yes">
       yes
     </a>
     <a href={url} className="button button-small yes">
@@ -126,7 +126,7 @@ const Template = ({ url }) => (
     </a>
 
     <h4>Negative</h4>
-    <a href={url} className="button no">
+    <a href={url} className="button button-small no">
       No
     </a>
     <a href={url} className="button button-small no">

--- a/wagtail/contrib/styleguide/templates/wagtailstyleguide/base.html
+++ b/wagtail/contrib/styleguide/templates/wagtailstyleguide/base.html
@@ -256,12 +256,12 @@
 
             <h4>Positive</h4>
 
-            <a href="#" class="button yes">yes</a>
+            <a href="#" class="button button-small yes">yes</a>
             <a href="#" class="button button-small yes">yes</a>
 
             <h4>Negative</h4>
 
-            <a href="#" class="button no">No</a>
+            <a href="#" class="button button-small no">No</a>
             <a href="#" class="button button-small no">No</a>
 
             <h3>Buttons with internal loading indicators (currently only <code>button</code> supported)</h3>
@@ -277,21 +277,10 @@
             <h4>Buttons where the text is replaced on click</h4>
             <button class="button button-longrunning" data-clicked-text="Test">{% icon name="spinner" %}<em>Click me</em></button>
 
-            <h4>Arbitrarily bigger</h4>
-            <style>
-                #button-arbitrarily-bigger {
-                    font-size: 1.5em;
-                    padding: 1.1em 2.4em;
-                    height: 3.5em;
-                }
-            </style>
-            <button class="button button-longrunning" id="button-arbitrarily-bigger">{% icon name="spinner" %}Click me</button>
-
             <h3>Mixtures</h3>
 
             <button class="button button--icon text-replace yes">{% icon name="tick" %}A proper button</button>
             <a href="#" class="button button--icon text-replace white">{% icon name="cog" %}A link button</a>
-            <span class="button button--icon text-replace no ">{% icon name="bin" %}A non-link button</span>
             <a href="#" class="button button--icon bicolor disabled">{% icon name="tick" wrapped=1 %}button link</a>
 
         </section>
@@ -586,13 +575,6 @@
                     animation-duration: 500ms;
                     animation-iteration-count: infinite;
                     animation-timing-function: linear;
-                }
-                @keyframes spin-wag {
-                    from {
-                        transform: translateY(0.6em) rotate(0deg);
-                    } to {
-                        transform: translateY(0.6em) rotate(360deg);
-                    }
                 }
             </style>
 


### PR DESCRIPTION
Addresses #8790.

1. Removed: .button-neutral, .button-strokeonhover and .hover-no.
2. Replaced hardcoded padding, height, width and font size values with theme variables.
3. Removed overridden duplicate styles for .yes, .no and .bicolor.
4. Merged a few styles under one class.
5. Removed non-link button which was using span tag from styleguide.

