### PR TITLE
Fix duplicate block ids when duplicating stream blocks in page editor

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -14,3 +14,4 @@ wagtail/snippets/static
 wagtail/users/static
 wagtail/contrib/*/static
 wagtail/contrib/search_promotions/templates/wagtailsearchpromotions/includes/searchpromotions_formset.js
+.mypy_cache

--- a/.prettierignore
+++ b/.prettierignore
@@ -12,3 +12,4 @@ _build
 # Files which contain incompatible syntax.
 *.html
 wagtail/contrib/search_promotions/templates/wagtailsearchpromotions/includes/searchpromotions_formset.js
+.mypy_cache

--- a/client/src/components/StreamField/blocks/BaseSequenceBlock.js
+++ b/client/src/components/StreamField/blocks/BaseSequenceBlock.js
@@ -2,6 +2,7 @@
 
 /* global $ */
 
+import { v4 as uuidv4 } from 'uuid';
 import EventEmitter from 'events';
 import { escapeHtml as h } from '../../../utils/text';
 
@@ -362,6 +363,16 @@ export class BaseSequenceChild extends EventEmitter {
       this.collapse();
     }
   }
+
+  getDuplicatedState() {
+    return {
+      id: uuidv4(),
+      value:
+        this.block.getDuplicatedState === undefined
+          ? this.block.getState()
+          : this.block.getDuplicatedState(),
+    };
+  }
 }
 
 export class BaseInsertionControl {
@@ -627,6 +638,10 @@ export class BaseSequenceBlock {
 
   getState() {
     return this.children.map((child) => child.getState());
+  }
+
+  getDuplicatedState() {
+    return this.children.map((child) => child.getDuplicatedState());
   }
 
   getValue() {

--- a/client/src/components/StreamField/blocks/ListBlock.js
+++ b/client/src/components/StreamField/blocks/ListBlock.js
@@ -219,11 +219,13 @@ export class ListBlock extends BaseSequenceBlock {
 
   duplicateBlock(index, opts) {
     const child = this.children[index];
-    // child.getState() is the state of the ListChild, which is a dict of value and id;
-    // for inserting a new child block, we just want the value (and will assign a new id).
-    const childState = child.getState().value;
+    const { id: newId, value: childValue } = child.getDuplicatedState();
     const animate = opts && opts.animate;
-    this.insert(childState, index + 1, { animate, collapsed: child.collapsed });
+    this.insert(childValue, index + 1, {
+      animate,
+      collapsed: child.collapsed,
+      id: newId,
+    });
     this.children[index + 1].focus({ soft: true });
   }
 

--- a/client/src/components/StreamField/blocks/ListBlock.test.js
+++ b/client/src/components/StreamField/blocks/ListBlock.test.js
@@ -278,9 +278,10 @@ describe('telepath: wagtail.blocks.ListBlock', () => {
 
   test('duplicated blocks have unique ids', () => {
     boundBlock.duplicateBlock(0);
-    expect(boundBlock.children[1].id).not.toBeUndefined();
-    expect(boundBlock.children[1].id).not.toBeNull();
-    expect(boundBlock.children[1].id).not.toEqual(boundBlock.children[0].id);
+
+    expect(boundBlock.children[1]).not.toHaveSameBlockIdAs(
+      boundBlock.children[0],
+    );
   });
 
   test('blocks can be split', () => {
@@ -544,11 +545,8 @@ describe('telepath: wagtail.blocks.ListBlock with StreamBlock child', () => {
     const originalStreamBlock = boundBlock.children[0].block;
 
     // Test the ids on the duplicated stream child of the stream-block-in-list-block
-    expect(duplicatedStreamBlock.children[0].id).not.toBeUndefined();
-    expect(duplicatedStreamBlock.children[0].id).not.toBeNull();
-
-    expect(duplicatedStreamBlock.children[0].id).not.toEqual(
-      originalStreamBlock.children[0].id,
+    expect(duplicatedStreamBlock.children[0]).not.toHaveSameBlockIdAs(
+      originalStreamBlock.children[0],
     );
   });
 });
@@ -628,14 +626,10 @@ describe('telepath: wagtail.blocks.ListBlock inside a StreamBlock', () => {
     const originalStreamChild = boundBlock.children[0];
     const duplicatedStreamChild = boundBlock.children[1];
 
-    expect(duplicatedStreamChild.id).not.toBeNull();
-    expect(duplicatedStreamChild.id).not.toBeUndefined();
-    expect(duplicatedStreamChild.id).not.toEqual(originalStreamChild.id);
+    expect(duplicatedStreamChild).not.toHaveSameBlockIdAs(originalStreamChild);
 
-    expect(duplicatedStreamChild.block.children[0].id).not.toBeNull();
-    expect(duplicatedStreamChild.block.children[0].id).not.toBeUndefined();
-    expect(duplicatedStreamChild.block.children[0].id).not.toEqual(
-      originalStreamChild.block.children[0].id,
+    expect(duplicatedStreamChild.block.children[0]).not.toHaveSameBlockIdAs(
+      originalStreamChild.block.children[0],
     );
   });
 });

--- a/client/src/components/StreamField/blocks/StreamBlock.js
+++ b/client/src/components/StreamField/blocks/StreamBlock.js
@@ -31,6 +31,17 @@ class StreamChild extends BaseSequenceChild {
     };
   }
 
+  getDuplicatedState() {
+    return {
+      type: this.type,
+      value:
+        this.block.getDuplicatedState === undefined
+          ? this.block.getState()
+          : this.block.getDuplicatedState(),
+      id: uuidv4(),
+    };
+  }
+
   setState({ type, value, id }) {
     this.type = type;
     this.block.setState(value);
@@ -377,12 +388,15 @@ export class StreamBlock extends BaseSequenceBlock {
 
   duplicateBlock(index, opts) {
     const child = this.children[index];
-    const childState = child.getState();
+    const childState = child.getDuplicatedState();
     const animate = opts && opts.animate;
-    childState.id = null;
     this.insert(childState, index + 1, { animate, collapsed: child.collapsed });
     // focus the newly added field if we can do so without obtrusive UI behaviour
     this.children[index + 1].focus({ soft: true });
+  }
+
+  getDuplicatedState() {
+    return this.children.map((streamChild) => streamChild.getDuplicatedState());
   }
 
   splitBlock(index, valueBefore, valueAfter, shouldMoveCommentFn, opts) {

--- a/client/src/components/StreamField/blocks/StreamBlock.js
+++ b/client/src/components/StreamField/blocks/StreamBlock.js
@@ -33,12 +33,8 @@ class StreamChild extends BaseSequenceChild {
 
   getDuplicatedState() {
     return {
+      ...super.getDuplicatedState(),
       type: this.type,
-      value:
-        this.block.getDuplicatedState === undefined
-          ? this.block.getState()
-          : this.block.getDuplicatedState(),
-      id: uuidv4(),
     };
   }
 
@@ -393,10 +389,6 @@ export class StreamBlock extends BaseSequenceBlock {
     this.insert(childState, index + 1, { animate, collapsed: child.collapsed });
     // focus the newly added field if we can do so without obtrusive UI behaviour
     this.children[index + 1].focus({ soft: true });
-  }
-
-  getDuplicatedState() {
-    return this.children.map((streamChild) => streamChild.getDuplicatedState());
   }
 
   splitBlock(index, valueBefore, valueAfter, shouldMoveCommentFn, opts) {

--- a/client/src/components/StreamField/blocks/StreamBlock.test.js
+++ b/client/src/components/StreamField/blocks/StreamBlock.test.js
@@ -337,11 +337,11 @@ describe('telepath: wagtail.blocks.StreamBlock', () => {
   });
 });
 
-describe('telepath: wagtail.blocks.StreamBlock with nested stream blocks', () => {
+describe('telepath: wagtail.blocks.StreamBlock with nested stream block', () => {
   let boundBlock;
 
   beforeEach(() => {
-    // Define a test block
+    // Define a test block - StreamBlock[StreamBlock[FieldBlock]]
     const innerStreamDef = new StreamBlockDefinition(
       'inner_stream',
       [
@@ -385,25 +385,7 @@ describe('telepath: wagtail.blocks.StreamBlock with nested stream blocks', () =>
 
     const blockDef = new StreamBlockDefinition(
       '',
-      [
-        [
-          '',
-          [
-            new StructBlockDefinition(
-              'struct_with_inner_stream',
-              [innerStreamDef],
-              {
-                label: 'Struct with inner stream',
-                required: false,
-                icon: 'placeholder',
-                classname: 'struct-block',
-                helpText: '',
-                helpIcon: '',
-              },
-            ),
-          ],
-        ],
-      ],
+      [['', [innerStreamDef]]],
       {},
       {
         label: '',
@@ -427,40 +409,26 @@ describe('telepath: wagtail.blocks.StreamBlock with nested stream blocks', () =>
 
     // Render it
     document.body.innerHTML = '<div id="placeholder"></div>';
-    boundBlock = blockDef.render($('#placeholder'), 'the-prefix', []);
+    boundBlock = blockDef.render($('#placeholder'), 'the-prefix', [
+      {
+        type: 'inner_stream',
+        value: [{ type: 'test_block_a', value: 'hello', id: 'inner-block-1' }],
+        id: 'nested-stream-1',
+      },
+    ]);
   });
 
   test('duplicateBlock does not duplicate block ids', () => {
-    // Insert an instance of our struct block
-    boundBlock.insert(
-      {
-        type: 'struct_with_inner_stream',
-        value: { inner_stream: [] },
-        id: 'struct-1',
-      },
-      0,
-    );
-
-    // Insert a block into its nested stream field
-    boundBlock.children[0].block.childBlocks.inner_stream.insert(
-      {
-        type: 'test_block_a',
-        value: 'hello',
-        id: 'inner-id-1',
-      },
-      0,
-    );
-
-    // Duplicate the struct block (outermost) instance
     boundBlock.children[0].duplicate();
+    const duplicatedStreamChild = boundBlock.children[1];
+    const originalStreamChild = boundBlock.children[0];
 
-    expect(boundBlock.children[1].id).not.toBeNull();
-    expect(boundBlock.children[1].id).not.toEqual(boundBlock.children[0].id);
+    expect(duplicatedStreamChild.id).not.toBeNull();
+    expect(duplicatedStreamChild.id).not.toBeUndefined();
+    expect(duplicatedStreamChild.id).not.toEqual(originalStreamChild.id);
 
-    expect(
-      boundBlock.children[1].block.childBlocks.inner_stream.children[0].id,
-    ).not.toEqual(
-      boundBlock.children[0].block.childBlocks.inner_stream.children[0].id,
+    expect(duplicatedStreamChild.block.children[0].id).not.toEqual(
+      originalStreamChild.block.children[0].id,
     );
   });
 });

--- a/client/src/components/StreamField/blocks/StreamBlock.test.js
+++ b/client/src/components/StreamField/blocks/StreamBlock.test.js
@@ -423,12 +423,12 @@ describe('telepath: wagtail.blocks.StreamBlock with nested stream block', () => 
     const duplicatedStreamChild = boundBlock.children[1];
     const originalStreamChild = boundBlock.children[0];
 
-    expect(duplicatedStreamChild.id).not.toBeNull();
-    expect(duplicatedStreamChild.id).not.toBeUndefined();
-    expect(duplicatedStreamChild.id).not.toEqual(originalStreamChild.id);
+    // Test the outermost stream child
+    expect(duplicatedStreamChild).not.toHaveSameBlockIdAs(originalStreamChild);
 
-    expect(duplicatedStreamChild.block.children[0].id).not.toEqual(
-      originalStreamChild.block.children[0].id,
+    // Test the nested child
+    expect(duplicatedStreamChild.block.children[0]).not.toHaveSameBlockIdAs(
+      originalStreamChild.block.children[0],
     );
   });
 });

--- a/client/src/components/StreamField/blocks/StructBlock.js
+++ b/client/src/components/StreamField/blocks/StructBlock.js
@@ -111,6 +111,19 @@ export class StructBlock {
     return state;
   }
 
+  getDuplicatedState() {
+    const state = {};
+    // eslint-disable-next-line guard-for-in
+    for (const name in this.childBlocks) {
+      const block = this.childBlocks[name];
+      state[name] =
+        block.getDuplicatedState === undefined
+          ? block.getState()
+          : block.getDuplicatedState();
+    }
+    return state;
+  }
+
   getValue() {
     const value = {};
     // eslint-disable-next-line guard-for-in

--- a/client/src/components/StreamField/blocks/StructBlock.test.js
+++ b/client/src/components/StreamField/blocks/StructBlock.test.js
@@ -421,26 +421,20 @@ describe('telepath: wagtail.blocks.StructBlock in stream block', () => {
   });
 
   test('ids are not duplicated when duplicating struct blocks', () => {
-    const testIds = (oldChild, newChild) => {
-      expect(newChild.id).not.toBeNull();
-      expect(newChild.id).not.toBeUndefined();
-      expect(newChild.id).not.toEqual(oldChild.id);
-    };
-
     boundBlock.children[0].duplicate();
 
     const duplicatedStreamChild = boundBlock.children[1];
     const originalStreamChild = boundBlock.children[0];
 
-    testIds(originalStreamChild, duplicatedStreamChild);
+    expect(duplicatedStreamChild).not.toHaveSameBlockIdAs(originalStreamChild);
 
     const duplicatedStreamBlockInStruct =
       duplicatedStreamChild.block.childBlocks.inner_stream;
     const originalStreamBlockInStruct =
       originalStreamChild.block.childBlocks.inner_stream;
-    testIds(
+
+    expect(duplicatedStreamBlockInStruct.children[0]).not.toHaveSameBlockIdAs(
       originalStreamBlockInStruct.children[0],
-      duplicatedStreamBlockInStruct.children[0],
     );
   });
 });

--- a/client/src/components/StreamField/blocks/__snapshots__/ListBlock.test.js.snap
+++ b/client/src/components/StreamField/blocks/__snapshots__/ListBlock.test.js.snap
@@ -130,11 +130,11 @@ exports[`telepath: wagtail.blocks.ListBlock blocks can be duplicated 1`] = `
         </div>
       </div><button type=\\"button\\" title=\\"Add\\" data-streamfield-list-add=\\"\\" class=\\"c-sf-add-button c-sf-add-button--visible\\">
         <svg class=\\"icon icon-plus\\" aria-hidden=\\"true\\"><use href=\\"#icon-plus\\"></use></svg>
-      </button><div aria-hidden=\\"false\\" data-contentpath-disabled=\\"\\">
+      </button><div aria-hidden=\\"false\\" data-contentpath=\\"fake-uuid-v4-value\\">
         <input type=\\"hidden\\" name=\\"the-prefix-2-deleted\\" value=\\"\\">
         <input type=\\"hidden\\" name=\\"the-prefix-2-order\\" value=\\"2\\">
         <input type=\\"hidden\\" name=\\"the-prefix-2-type\\" value=\\"\\">
-        <input type=\\"hidden\\" name=\\"the-prefix-2-id\\" value=\\"\\">
+        <input type=\\"hidden\\" name=\\"the-prefix-2-id\\" value=\\"fake-uuid-v4-value\\">
 
         <div>
           <div class=\\"c-sf-container__block-container\\">

--- a/client/src/components/StreamField/blocks/__snapshots__/StreamBlock.test.js.snap
+++ b/client/src/components/StreamField/blocks/__snapshots__/StreamBlock.test.js.snap
@@ -144,11 +144,11 @@ exports[`telepath: wagtail.blocks.StreamBlock blocks can be duplicated 1`] = `
         <div data-streamblock-menu-outer=\\"\\" style=\\"display: none;\\" aria-hidden=\\"true\\">
           <div data-streamblock-menu-inner=\\"\\" class=\\"c-sf-add-panel\\"></div>
         </div>
-      </div><div aria-hidden=\\"false\\" data-contentpath-disabled=\\"\\">
+      </div><div aria-hidden=\\"false\\" data-contentpath=\\"fake-uuid-v4-value\\">
         <input type=\\"hidden\\" name=\\"the-prefix-2-deleted\\" value=\\"\\">
         <input type=\\"hidden\\" name=\\"the-prefix-2-order\\" value=\\"2\\">
         <input type=\\"hidden\\" name=\\"the-prefix-2-type\\" value=\\"test_block_b\\">
-        <input type=\\"hidden\\" name=\\"the-prefix-2-id\\" value=\\"\\">
+        <input type=\\"hidden\\" name=\\"the-prefix-2-id\\" value=\\"fake-uuid-v4-value\\">
 
         <div>
           <div class=\\"c-sf-container__block-container\\">

--- a/client/src/entrypoints/contrib/typed_table_block/typed_table_block.js
+++ b/client/src/entrypoints/contrib/typed_table_block/typed_table_block.js
@@ -466,10 +466,7 @@ export class TypedTableBlock {
 
   getState() {
     const state = {
-      columns: this.columns.map((column) => ({
-        type: column.blockDef.name,
-        heading: column.headingInput.value,
-      })),
+      columns: this.getColumnStates(),
       rows: this.rows.map((row) => ({
         values: row.blocks.map((block) => block.getState()),
       })),
@@ -477,17 +474,34 @@ export class TypedTableBlock {
     return state;
   }
 
+  getDuplicatedState() {
+    return {
+      columns: this.getColumnStates(),
+      rows: this.rows.map((row) => ({
+        values: row.blocks.map((block) =>
+          block.getDuplicatedState === undefined
+            ? block.getState()
+            : block.getDuplicatedState(),
+        ),
+      })),
+    };
+  }
+
   getValue() {
     const value = {
-      columns: this.columns.map((column) => ({
-        type: column.blockDef.name,
-        heading: column.headingInput.value,
-      })),
+      columns: this.getColumnStates(),
       rows: this.rows.map((row) => ({
         values: row.blocks.map((block) => block.getValue()),
       })),
     };
     return value;
+  }
+
+  getColumnStates() {
+    return this.columns.map((column) => ({
+      type: column.blockDef.name,
+      heading: column.headingInput.value,
+    }));
   }
 
   getTextLabel(opts) {

--- a/client/src/entrypoints/contrib/typed_table_block/typed_table_block.test.js
+++ b/client/src/entrypoints/contrib/typed_table_block/typed_table_block.test.js
@@ -2,6 +2,7 @@ import '../../admin/telepath/telepath';
 import $ from 'jquery';
 import { TypedTableBlockDefinition } from './typed_table_block';
 import { FieldBlockDefinition } from '../../../components/StreamField/blocks/FieldBlock';
+import { StreamBlockDefinition } from '../../../components/StreamField/blocks/StreamBlock';
 
 window.$ = $;
 
@@ -189,5 +190,152 @@ describe('wagtail.contrib.typed_table_block.blocks.TypedTableBlock', () => {
     boundBlock.insertRow(0);
     expect(boundBlock.rows.length).toBe(2);
     expect(document.getElementsByName('mytable-row-count')[0].value).toBe('3');
+  });
+});
+
+describe('wagtail.contrib.typed_table_block.blocks.TypedTableBlock in StreamBlock', () => {
+  let boundBlock;
+  let innerStreamDef;
+
+  beforeEach(() => {
+    innerStreamDef = new StreamBlockDefinition(
+      'inner_stream',
+      [
+        [
+          '',
+          [
+            new FieldBlockDefinition(
+              'test_block_a',
+              new DummyWidgetDefinition('Block A Widget'),
+              {
+                label: 'Test Block A',
+                required: false,
+                icon: 'pilcrow',
+                classname:
+                  'w-field w-field--char_field w-field--admin_auto_height_text_input',
+              },
+            ),
+          ],
+        ],
+      ],
+      {},
+      {
+        label: 'Inner Stream',
+        required: false,
+        icon: 'placeholder',
+        classname: null,
+        helpText: '',
+        helpIcon: '',
+        maxNum: null,
+        minNum: null,
+        blockCounts: {},
+        strings: {
+          MOVE_UP: 'Move up',
+          MOVE_DOWN: 'Move down',
+          DELETE: 'Delete',
+          DUPLICATE: 'Duplicate',
+          ADD: 'Add',
+        },
+      },
+    );
+
+    const streamBlockDef = new StreamBlockDefinition(
+      '',
+      [
+        [
+          '',
+          [
+            new TypedTableBlockDefinition(
+              'table',
+              [innerStreamDef],
+              {},
+              {
+                label: '',
+                required: true,
+                icon: 'placeholder',
+                classname: null,
+                helpText: 'use <strong>plenty</strong> of these',
+                helpIcon: '<div class="icon-help">?</div>',
+                strings: {
+                  ADD_COLUMN: 'Add column',
+                  ADD_ROW: 'Add row',
+                  COLUMN_HEADING: 'Column heading',
+                  INSERT_COLUMN: 'Insert column',
+                  DELETE_COLUMN: 'Delete column',
+                  INSERT_ROW: 'Insert row',
+                  DELETE_ROW: 'Delete row',
+                },
+              },
+            ),
+          ],
+        ],
+      ],
+      {},
+      {
+        label: '',
+        required: true,
+        icon: 'placeholder',
+        classname: null,
+        helpText: 'use <strong>plenty</strong> of these',
+        helpIcon: '<div class="icon-help">?</div>',
+        maxNum: null,
+        minNum: null,
+        blockCounts: {},
+        strings: {
+          MOVE_UP: 'Move up',
+          MOVE_DOWN: 'Move down',
+          DELETE: 'Delete',
+          DUPLICATE: 'Duplicate',
+          ADD: 'Add',
+        },
+      },
+    );
+
+    // Render it
+    document.body.innerHTML = '<div id="placeholder"></div>';
+    boundBlock = streamBlockDef.render($('#placeholder'), 'the-prefix', []);
+  });
+
+  test('duplicateBlock does not duplicate stream block ids in typed table blocks', () => {
+    // Insert a typed table block at the top level
+    boundBlock.insert(
+      {
+        type: 'table',
+        value: { rows: [], columns: [] },
+        id: 'old-id-1',
+      },
+      0,
+    );
+
+    const tableBlock = boundBlock.children[0].block;
+
+    // Add a column and row for the nested stream block
+    tableBlock.insertColumn(0, innerStreamDef);
+    tableBlock.insertRow(0);
+    const innerStreamBlock = tableBlock.rows[0].blocks[0];
+
+    // Insert a block into the inner stream
+    innerStreamBlock.insert(
+      { type: 'test_block_a', value: 'foobar', id: 'old-inner-stream-id-1' },
+      0,
+    );
+
+    // Duplicate the outermost block (typed table block)
+    boundBlock.duplicateBlock(0);
+
+    // Check the ids on the top level blocks
+    expect(boundBlock.children[1].id).not.toBeNull();
+    expect(boundBlock.children[1].id).not.toEqual(boundBlock.children[0].id);
+
+    // Check the ids on the nested blocks
+    expect(
+      boundBlock.children[1].block.rows[0].blocks[0].children[0].id,
+    ).not.toBeNull();
+
+    expect(
+      boundBlock.children[1].block.rows[0].blocks[0].children[0].id,
+    ).not.toEqual(
+      boundBlock.children[0].block.rows[0].blocks[0].children[0].id,
+    );
   });
 });

--- a/client/src/entrypoints/contrib/typed_table_block/typed_table_block.test.js
+++ b/client/src/entrypoints/contrib/typed_table_block/typed_table_block.test.js
@@ -324,18 +324,15 @@ describe('wagtail.contrib.typed_table_block.blocks.TypedTableBlock in StreamBloc
     boundBlock.duplicateBlock(0);
 
     // Check the ids on the top level blocks
-    expect(boundBlock.children[1].id).not.toBeNull();
-    expect(boundBlock.children[1].id).not.toEqual(boundBlock.children[0].id);
+    expect(boundBlock.children[1]).not.toHaveSameBlockIdAs(
+      boundBlock.children[0],
+    );
 
     // Check the ids on the nested blocks
     expect(
-      boundBlock.children[1].block.rows[0].blocks[0].children[0].id,
-    ).not.toBeNull();
-
-    expect(
-      boundBlock.children[1].block.rows[0].blocks[0].children[0].id,
-    ).not.toEqual(
-      boundBlock.children[0].block.rows[0].blocks[0].children[0].id,
+      boundBlock.children[1].block.rows[0].blocks[0].children[0],
+    ).not.toHaveSameBlockIdAs(
+      boundBlock.children[0].block.rows[0].blocks[0].children[0],
     );
   });
 });

--- a/client/tests/utils.js
+++ b/client/tests/utils.js
@@ -1,0 +1,32 @@
+expect.extend({
+  toHaveSameBlockIdAs(received, otherChild) {
+    const { id: thisId } = received;
+    const { id: otherId } = otherChild;
+
+    if (thisId === undefined || thisId === null) {
+      return {
+        message: 'expected block id not to be null or undefined',
+        pass: false,
+      };
+    }
+
+    if (otherId === undefined || otherId === null) {
+      return {
+        message: 'expected other block id not to be null or undefined',
+        pass: false,
+      };
+    }
+
+    return thisId === otherId
+      ? {
+          message: () =>
+            `expected block id '${thisId}' not to match other id '${otherId}'`,
+          pass: true,
+        }
+      : {
+          message: () =>
+            `expected block id '${thisId}' to match other id '${otherId}'`,
+          pass: false,
+        };
+  },
+});

--- a/package.json
+++ b/package.json
@@ -46,6 +46,9 @@
       "./client/tests/mock-fetch.js",
       "./client/tests/mock-jquery.js"
     ],
+    "setupFilesAfterEnv": [
+      "./client/tests/utils.js"
+    ],
     "snapshotSerializers": [
       "enzyme-to-json/serializer"
     ]


### PR DESCRIPTION
fixes #7712 (duplication of block ids when duplicating stream field blocks in page editor), supersedes https://github.com/wagtail/wagtail/pull/7713.

This implementation (based on @gasman and @jacobtoppm 's comments on https://github.com/wagtail/wagtail/pull/7713) adds `getDuplicatedState` methods to `BaseSequenceChild`, `BaseSequenceBlock` (inherited by `ListBlock` and `StreamChild`), `StreamChild`, and `StructBlock`.

`getDuplicatedState` generates new block ids for stream/list children (at all levels of nesting) when duplicating blocks. It is called in the `duplicate`/`duplicateBlock` methods of compound block types.

Tested manually that block duplication still works as expected in the page editor in Firefox and Chrome. 
