### PR TITLE
Comment button positioning and style adjustments

### DIFF
--- a/client/scss/components/_chooser.scss
+++ b/client/scss/components/_chooser.scss
@@ -64,6 +64,21 @@
   @apply w-body-text-large;
 }
 
+@media (hover: hover) {
+  .chooser__actions {
+    opacity: 0;
+  }
+
+  .w-field__input:hover,
+  .w-field__input:focus-within {
+    // Hiding for devices capable of hover states only,
+    // with opacity only so keyboard focus can move to the first interactive element to reveal it.
+    .chooser__actions {
+      opacity: 1;
+    }
+  }
+}
+
 .chooser__actions {
   display: flex;
   gap: theme('spacing.[1.5]');
@@ -71,17 +86,6 @@
   .button {
     // Subdued border as there can be a lot of chooser action buttons on a page.
     border-color: theme('colors.grey.150');
-  }
-
-  // Hiding for devices capable of hover states only,
-  // with opacity only so keyboard focus can move to the first interactive element to reveal it.
-  @media (hover: hover) {
-    opacity: 0;
-
-    .chooser:hover &,
-    .chooser:focus-within & {
-      opacity: 1;
-    }
   }
 }
 

--- a/client/scss/components/forms/_field-comment-control.scss
+++ b/client/scss/components/forms/_field-comment-control.scss
@@ -1,30 +1,27 @@
 $button-size: theme('spacing.5');
+$button-space: theme('spacing.3');
 
 .w-field__comment-button {
+  $root: &;
+
   @include transition(opacity 0.2s ease);
-  position: absolute;
   // Text input’s default top margin.
-  top: theme('spacing.[1.5]');
-  inset-inline-end: 0;
   color: $color-teal;
   background: none;
   border: 0;
-  width: $button-size;
-  height: $button-size;
   padding: 0;
+  margin-inline-start: $button-space;
+  display: flex;
+  align-items: center;
 
-  @include media-breakpoint-up(sm) {
-    inset-inline-end: calc(-1 * $button-size);
-  }
+  visibility: hidden;
+  opacity: 0;
 
   .icon {
     width: $button-size;
     height: $button-size;
     color: inherit;
   }
-
-  visibility: hidden;
-  opacity: 0;
 
   // For devices without hover support, always show when comments are enabled.
   @media (hover: none) {
@@ -47,15 +44,17 @@ $button-size: theme('spacing.5');
   }
 }
 
-// Add extra space to the right of commentable fields for the buttons.
 .w-field--commentable {
+  // Allow comment buttons to be placed along side the field by display flex
   .tab-content--comments-enabled & .w-field__input {
-    padding-inline-end: $button-size;
+    display: flex;
+    align-items: center;
+  }
 
-    @include media-breakpoint-up(sm) {
-      // Partial offset to reduce the change in layout with/without comments.
-      padding-inline-end: calc($button-size / 1.5);
-    }
+  textarea ~ .w-field__comment-button,
+  &.w-field--checkbox_select_multiple .w-field__comment-button,
+  &.w-field--admin_tag_widget .w-field__comment-button {
+    align-self: flex-start;
   }
 }
 

--- a/client/scss/components/forms/_input-text.scss
+++ b/client/scss/components/forms/_input-text.scss
@@ -38,6 +38,14 @@ textarea {
 .w-field--date_field,
 .w-field--date_time_field,
 .w-field--time_field {
+  // If these fields are in an inline panels' row then allow them to take up their grid size
+  .w-field-row & {
+    input {
+      width: 100%;
+      max-width: 15.625rem;
+    }
+  }
+
   input {
     width: auto;
   }


### PR DESCRIPTION
Follow-up to #9072, fixing issues listed in #9025. This contains three commits from @stevedya that I took out of #9072 so other fixes could make it into Wagtail 4.0.

Here are corresponding changes as described by Steve:

- Changed comment buttons from absolute positioning to flex box positioning in order to align items horizontally.
- (better version of) Fixed issues with field rows fields overlapping the comment buttons
- Changed fields with comments' hoverable area to include the comment Icon space, so it stays visible when hovering beside the field (instead of only focusing within)
- Ensured that all text fields with multiple lines will have the comment icon at the top of the field
- Positioned the comment button to be beside the other actions for chooser widgets

Demonstration Video:

https://user-images.githubusercontent.com/25041665/186269455-13120f21-be7f-4b17-80b9-99da372e8f77.mp4

