### PR TITLE
Add PyPI classifier for Wagtail 4 to developer docs

### DIFF
--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -43,6 +43,7 @@ If you are developing packages for Wagtail, you can add the following [PyPI](htt
 -   [`Framework :: Wagtail :: 1`](https://pypi.org/search/?c=Framework+%3A%3A+Wagtail+%3A%3A+1)
 -   [`Framework :: Wagtail :: 2`](https://pypi.org/search/?c=Framework+%3A%3A+Wagtail+%3A%3A+2)
 -   [`Framework :: Wagtail :: 3`](https://pypi.org/search/?c=Framework+%3A%3A+Wagtail+%3A%3A+3)
+-   [`Framework :: Wagtail :: 4`](https://pypi.org/search/?c=Framework+%3A%3A+Wagtail+%3A%3A+4)
 
 You can also find a curated list of awesome packages, articles, and other cool resources from the Wagtail community at [Awesome Wagtail](https://github.com/springload/awesome-wagtail).
 


### PR DESCRIPTION
`Framework :: Wagtail :: 4` is now added to the trove-classifiers list as per https://github.com/pypa/trove-classifiers/pull/116