### PR TITLE
Improve locked_by-filter for locked pages report, fixes #9116

### DIFF
--- a/wagtail/admin/tests/test_reports_views.py
+++ b/wagtail/admin/tests/test_reports_views.py
@@ -30,6 +30,16 @@ class TestLockedPagesView(TestCase, WagtailTestUtils):
         # Initially there should be no locked pages
         self.assertContains(response, "No locked pages found.")
 
+        # No user locked anything
+        self.assertInHTML(
+            """
+            <select name="locked_by" id="id_locked_by">
+                <option value="" selected>---------</option>
+            </select>
+            """,
+            response.content.decode(),
+        )
+
         self.page = Page.objects.first()
         self.page.locked = True
         self.page.locked_by = self.user
@@ -42,6 +52,16 @@ class TestLockedPagesView(TestCase, WagtailTestUtils):
         self.assertTemplateUsed(response, "wagtailadmin/reports/locked_pages.html")
         self.assertNotContains(response, "No locked pages found.")
         self.assertContains(response, self.page.title)
+
+        self.assertInHTML(
+            f"""
+            <select name="locked_by" id="id_locked_by">
+                <option value="" selected>---------</option>
+                <option value="{self.user.pk}">{self.user}</option>
+            </select>
+            """,
+            response.content.decode(),
+        )
 
     def test_csv_export(self):
 

--- a/wagtail/admin/views/reports/locked_pages.py
+++ b/wagtail/admin/views/reports/locked_pages.py
@@ -2,6 +2,7 @@ import datetime
 
 import django_filters
 from django.conf import settings
+from django.contrib.auth import get_user_model
 from django.core.exceptions import PermissionDenied
 from django.utils.translation import gettext_lazy as _
 
@@ -11,8 +12,16 @@ from wagtail.models import Page, UserPagePermissionsProxy
 from .base import PageReportView
 
 
+def get_users_for_filter():
+    User = get_user_model()
+    return User.objects.filter(locked_pages__isnull=False).order_by(User.USERNAME_FIELD)
+
+
 class LockedPagesReportFilterSet(WagtailFilterSet):
     locked_at = django_filters.DateFromToRangeFilter(widget=DateRangePickerWidget)
+    locked_by = django_filters.ModelChoiceFilter(
+        field_name="locked_by", queryset=lambda request: get_users_for_filter()
+    )
 
     class Meta:
         model = Page


### PR DESCRIPTION
It now only displays users, which have actually locked something.
I've added simple html checks to the existing tests, I hope that's ok?

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
