### PR TITLE
Avoid circular imports of custom document models from wagtail.documents.views.chooser

### DIFF
--- a/wagtail/documents/permissions.py
+++ b/wagtail/documents/permissions.py
@@ -1,7 +1,8 @@
-from wagtail.documents import get_document_model
-from wagtail.documents.models import Document
+from wagtail.documents import get_document_model_string
 from wagtail.permission_policies.collections import CollectionOwnershipPermissionPolicy
 
 permission_policy = CollectionOwnershipPermissionPolicy(
-    get_document_model(), auth_model=Document, owner_field_name="uploaded_by_user"
+    get_document_model_string(),
+    auth_model="wagtaildocs.Document",
+    owner_field_name="uploaded_by_user",
 )

--- a/wagtail/documents/views/chooser.py
+++ b/wagtail/documents/views/chooser.py
@@ -21,7 +21,7 @@ from wagtail.admin.views.generic.chooser import (
 from wagtail.admin.viewsets.chooser import ChooserViewSet
 from wagtail.admin.widgets import BaseChooser, BaseChooserAdapter
 from wagtail.blocks import ChooserBlock
-from wagtail.documents import get_document_model
+from wagtail.documents import get_document_model, get_document_model_string
 from wagtail.documents.permissions import permission_policy
 
 
@@ -153,7 +153,7 @@ class BaseAdminDocumentChooser(BaseChooser):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.model = get_document_model()
+        self.model = get_document_model_string()
 
     def render_js_init(self, id_, name, value_data):
         return "new DocumentChooser({0});".format(json.dumps(id_))
@@ -206,6 +206,6 @@ class DocumentChooserViewSet(ChooserViewSet):
 
 viewset = DocumentChooserViewSet(
     "wagtaildocs_chooser",
-    model=get_document_model(),
+    model=get_document_model_string(),
     url_prefix="documents/chooser",
 )

--- a/wagtail/permission_policies/collections.py
+++ b/wagtail/permission_policies/collections.py
@@ -218,14 +218,17 @@ class CollectionOwnershipPermissionPolicy(
         super().__init__(model, auth_model=auth_model)
         self.owner_field_name = owner_field_name
 
+    def check_model(self, model):
+        super().check_model(model)
+
         # make sure owner_field_name is a field that exists on the model
         try:
-            self.model._meta.get_field(self.owner_field_name)
+            model._meta.get_field(self.owner_field_name)
         except FieldDoesNotExist:
             raise ImproperlyConfigured(
                 "%s has no field named '%s'. To use this model with "
                 "CollectionOwnershipPermissionPolicy, you must specify a valid field name as "
-                "owner_field_name." % (self.model, self.owner_field_name)
+                "owner_field_name." % (model, self.owner_field_name)
             )
 
     def user_has_permission(self, user, action):


### PR DESCRIPTION
Fixes #9118. Permission policies can now be initialised by passing a model string rather than a class; wagtail.admin.widgets.chooser.BaseChooser had this capability already. Between these, we can adjust wagtail.documents.views.chooser so that no models need to be imported at module load time. As a result, definitions that depend on this module (such as DocumentChooserBlock) can now be included in the same models file as a custom document model, without causing a circular import.

Unfortunately I don't think we can add test coverage for this, short of adding a completely new test run with a custom `WAGTAILDOCS_DOCUMENT_MODEL` setting - our existing tests for custom document models use `override_settings`, which isn't sufficient for checking what happens at server startup time.

_Please check the following:_

-   [x] Do the tests still pass?
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
