### PR TITLE
Add `read_only` option to `FieldPanel`

### DIFF
--- a/client/scss/components/forms/_field-textoutput.scss
+++ b/client/scss/components/forms/_field-textoutput.scss
@@ -1,0 +1,18 @@
+@use 'sass:map';
+
+/**
+ * A container for rendering human-readable field values in forms in a way
+ that makes them 'focusable' without rendering an actual input.
+ */
+
+.w-field__textoutput {
+  @include input-base();
+  @apply w-body-text-large;
+  background-color: theme('colors.grey.50');
+  width: 100%;
+  padding: theme('spacing.[1.5]') theme('spacing.5');
+  min-height: $text-input-height;
+  position: relative;
+  overflow: hidden;
+  overflow-wrap: break-word;
+}

--- a/client/scss/components/forms/_field.scss
+++ b/client/scss/components/forms/_field.scss
@@ -40,6 +40,7 @@
 .w-field__label {
   @apply w-label-3;
   display: block;
+  margin-top: 0;
   margin-bottom: 0;
 }
 

--- a/client/scss/core.scss
+++ b/client/scss/core.scss
@@ -125,6 +125,7 @@ These are classes for components.
 @import 'components/forms/field';
 @import 'components/forms/field-row';
 @import 'components/forms/field-comment-control';
+@import 'components/forms/field-textoutput';
 @import 'components/forms/form-width';
 @import 'components/forms/nested-panel';
 @import 'components/tabs';

--- a/docs/reference/pages/panels.md
+++ b/docs/reference/pages/panels.md
@@ -19,7 +19,7 @@ Here are some Wagtail-specific types that you might include as fields in your mo
 ### FieldPanel
 
 ```{eval-rst}
-.. class:: FieldPanel(field_name, classname=None, widget=None, heading='', disable_comments=False, permission=None)
+.. class:: FieldPanel(field_name, classname=None, widget=None, heading='', disable_comments=False, permission=None, read_only=False)
 
     This is the panel used for basic Django field types.
 
@@ -52,6 +52,15 @@ Here are some Wagtail-specific types that you might include as fields in your mo
     .. attribute:: FieldPanel.permission (optional)
 
         Allows a field to be selectively shown to users with sufficient permission. Accepts a permission codename such as ``'myapp.change_blog_category'`` - if the logged-in user does not have that permission, the field will be omitted from the form. See Django's documentation on :ref:`custom permissions <django:custom-permissions>` for details on how to set permissions up; alternatively, if you want to set a field as only available to superusers, you can use any arbitrary string (such as ``'superuser'``) as the codename, since superusers automatically pass all permission tests.
+
+    .. attribute:: FieldPanel.read_only (optional)
+
+        Allows you to prevent a model field value from being set or updated by editors.
+
+        For most field types, the field value will be rendered in the form for editors to see (along with field's label and help text), but no form inputs will be displayed, and the form will ignore attempts to change the value in POST data (e.g. by injecting a hidden input into the form HTML before submitting).
+
+        By default, field values from ``StreamField`` or ``RichTextField`` are redacted to prevent rendering of potentially insecure HTML mid-form. You can change this behaviour for custom panel types by overriding ``Panel.format_value_for_display()``.
+
 ```
 
 ### MultiFieldPanel

--- a/wagtail/admin/panels/base.py
+++ b/wagtail/admin/panels/base.py
@@ -1,13 +1,16 @@
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.safestring import mark_safe
 
+from wagtail.admin.compare import text_from_html
 from wagtail.admin.forms.models import (
     WagtailAdminDraftStateFormMixin,
     WagtailAdminModelForm,
 )
 from wagtail.admin.ui.components import Component
+from wagtail.blocks import StreamValue
 from wagtail.coreutils import safe_snake_case
 from wagtail.models import DraftStateMixin
+from wagtail.rich_text import RichText
 
 
 def get_form_for_model(
@@ -184,6 +187,22 @@ class Panel:
         making use of this and requiring uniqueness should validate and modify the return value as needed.
         """
         return safe_snake_case(self.heading)
+
+    def format_value_for_display(self, value):
+        """
+        Hook to allow formatting of raw field values (and other attribute values) for human-readable
+        display. For example, if rendering a ``RichTextField`` value, you might extract text from the HTML
+        to generate a safer display value.
+        """
+        # Improve representation of many-to-many values
+        if callable(getattr(value, "all", "")):
+            return ", ".join(str(obj) for obj in value.all()) or "None"
+
+        # Avoid rendering potentially unsafe HTML mid-form
+        if isinstance(value, (RichText, StreamValue)):
+            return text_from_html(value)
+
+        return value
 
     class BoundPanel(Component):
         """

--- a/wagtail/admin/panels/field_panel.py
+++ b/wagtail/admin/panels/field_panel.py
@@ -1,6 +1,7 @@
 import functools
 
 from django.core.exceptions import FieldDoesNotExist, ImproperlyConfigured
+from django.forms.models import ModelChoiceIterator
 from django.template.loader import get_template
 from django.utils.functional import cached_property
 from django.utils.text import capfirst
@@ -93,6 +94,30 @@ class FieldPanel(Panel):
     @property
     def clean_name(self):
         return self.field_name
+
+    def format_value_for_display(self, value):
+        """
+        Overrides ``Panel.format_value_for_display()`` to add additional treatment
+        for choice fields.
+        """
+
+        # NOTE: We look for formfield.choices over db_field.choices here,
+        # as more field types can benefit that way.
+        choices = getattr(self.db_field.formfield(), "choices", None)
+        if not isinstance(choices, ModelChoiceIterator) and choices:
+            labels = dict(choices)
+            display_values = [
+                labels.get(v, v)  # Use raw value if no match found
+                for v in (
+                    # Account for single AND multiple choice fields
+                    tuple(value)
+                    if isinstance(value, (list, tuple))
+                    else (value,)
+                )
+            ]
+            return ", ".join(display_values)
+
+        return super().format_value_for_display(value)
 
     def __repr__(self):
         return "<%s '%s' with model=%s>" % (

--- a/wagtail/admin/panels/field_panel.py
+++ b/wagtail/admin/panels/field_panel.py
@@ -1,7 +1,9 @@
 import functools
 
 from django.core.exceptions import FieldDoesNotExist, ImproperlyConfigured
+from django.template.loader import get_template
 from django.utils.functional import cached_property
+from django.utils.text import capfirst
 
 from wagtail.admin import compare
 from wagtail.blocks import BlockField
@@ -11,15 +13,23 @@ from .base import Panel
 
 class FieldPanel(Panel):
     TEMPLATE_VAR = "field_panel"
+    read_only_output_template_name = "wagtailadmin/panels/read_only_output.html"
 
     def __init__(
-        self, field_name, widget=None, disable_comments=None, permission=None, **kwargs
+        self,
+        field_name,
+        widget=None,
+        disable_comments=None,
+        permission=None,
+        read_only=False,
+        **kwargs,
     ):
         super().__init__(**kwargs)
         self.field_name = field_name
         self.widget = widget
         self.disable_comments = disable_comments
         self.permission = permission
+        self.read_only = read_only
 
     def clone_kwargs(self):
         kwargs = super().clone_kwargs()
@@ -28,10 +38,14 @@ class FieldPanel(Panel):
             widget=self.widget,
             disable_comments=self.disable_comments,
             permission=self.permission,
+            read_only=self.read_only,
         )
         return kwargs
 
     def get_form_options(self):
+        if self.read_only:
+            return {}
+
         opts = {
             "fields": [self.field_name],
         }
@@ -93,16 +107,28 @@ class FieldPanel(Panel):
         def __init__(self, **kwargs):
             super().__init__(**kwargs)
 
+            self.bound_field = None
+            self.read_only = False
+
             if self.form is None:
-                self.bound_field = None
                 return
 
             try:
                 self.bound_field = self.form[self.field_name]
             except KeyError:
-                self.bound_field = None
+                if self.panel.read_only:
+                    self.read_only = True
+                    # Ensure heading and help_text are set to something useful
+                    self.heading = self.panel.heading or capfirst(
+                        self.panel.db_field.verbose_name
+                    )
+                    self.help_text = self.panel.help_text or capfirst(
+                        self.panel.db_field.help_text
+                    )
                 return
 
+            # Ensure heading and help_text are consistant accross
+            # Panel, BoundPanel and Field
             if self.panel.heading:
                 self.heading = self.bound_field.label = self.panel.heading
             else:
@@ -115,7 +141,11 @@ class FieldPanel(Panel):
             return self.panel.field_name
 
         def is_shown(self):
-            if self.form is not None and self.bound_field is None:
+            if (
+                self.form is not None
+                and self.bound_field is None
+                and not self.read_only
+            ):
                 # this field is missing from the form
                 return False
 
@@ -129,19 +159,29 @@ class FieldPanel(Panel):
             return True
 
         def is_required(self):
+            if self.bound_field is None:
+                return False
             return self.bound_field.field.required
 
         def classes(self):
-            is_streamfield = isinstance(self.bound_field.field, BlockField)
-            extra_classes = ["w-panel--nested"] if is_streamfield else []
-
-            return self.panel.classes() + extra_classes
+            classes = self.panel.classes()
+            if self.bound_field and isinstance(self.bound_field.field, BlockField):
+                classes.append("w-panel--nested")
+            return classes
 
         @property
         def icon(self):
             """
             Display a different icon depending on the field's type.
             """
+            if self.panel.icon:
+                return self.panel.icon
+
+            if self.bound_field is None:
+                form_field = self.panel.db_field.formfield()
+            else:
+                form_field = self.bound_field.field
+
             field_icons = {
                 # Icons previously-defined as StreamField block icons.
                 # Commented out until they can be reviewed for appropriateness in this new context.
@@ -157,30 +197,41 @@ class FieldPanel(Panel):
                 # "RegexField": "code",
                 # "BooleanField": "tick-inverse",
             }
-            field_type = self.bound_field.field.__class__.__name__
-
-            return self.panel.icon or field_icons.get(field_type, None)
+            return field_icons.get(form_field.__class__.__name__, None)
 
         def id_for_label(self):
+            if self.read_only:
+                return self.prefix
             return self.bound_field.id_for_label
 
         @property
         def comments_enabled(self):
-            if self.panel.disable_comments is None:
+            if self.panel.disable_comments is None and not self.read_only:
                 # by default, enable comments on all fields except StreamField (which has its own comment handling)
                 return not isinstance(self.bound_field.field, BlockField)
             else:
                 return not self.panel.disable_comments
 
+        @cached_property
+        def value_from_instance(self):
+            return getattr(self.instance, self.field_name)
+
         def get_context_data(self, parent_context=None):
             context = super().get_context_data(parent_context)
+            if self.read_only:
+                context.update(self.get_read_only_context_data())
+            else:
+                context.update(self.get_editable_context_data())
+            return context
+
+        def get_editable_context_data(self):
 
             widget_described_by_ids = []
-            help_text = self.bound_field.help_text
             help_text_id = "%s-helptext" % self.prefix
             error_message_id = "%s-errors" % self.prefix
 
-            if help_text:
+            widget_described_by_ids = []
+            if self.help_text:
                 widget_described_by_ids.append(help_text_id)
 
             if self.bound_field.errors:
@@ -215,19 +266,39 @@ class FieldPanel(Panel):
 
                 rendered_field = self.bound_field.as_widget(attrs=widget_attrs)
 
-            context.update(
-                {
-                    "field": self.bound_field,
-                    "rendered_field": rendered_field,
-                    "help_text": help_text,
-                    "help_text_id": help_text_id,
-                    "error_message_id": error_message_id,
-                    "show_add_comment_button": self.comments_enabled
-                    and getattr(
-                        self.bound_field.field.widget, "show_add_comment_button", True
-                    ),
-                }
-            )
+            return {
+                "field": self.bound_field,
+                "rendered_field": rendered_field,
+                "error_message_id": error_message_id,
+                "help_text": self.help_text,
+                "help_text_id": help_text_id,
+                "show_add_comment_button": self.comments_enabled
+                and getattr(
+                    self.bound_field.field.widget,
+                    "show_add_comment_button",
+                    True,
+                ),
+            }
+
+        def get_read_only_context_data(self):
+            # Define context data for BoundPanel AND read-only output rendering
+            context = {
+                "id_for_label": self.id_for_label(),
+                "help_text_id": "%s-helptext" % self.prefix,
+                "help_text": self.help_text,
+                "show_add_comment_button": self.comments_enabled,
+                "raw_value": self.value_from_instance,
+                "display_value": self.panel.format_value_for_display(
+                    self.value_from_instance
+                ),
+            }
+
+            # Render read-only output
+            template = get_template(self.panel.read_only_output_template_name)
+            rendered_field = template.render(context)
+
+            # Add rendered output to BoundPanel context data
+            context["rendered_field"] = rendered_field
             return context
 
         def get_comparison(self):

--- a/wagtail/admin/templates/wagtailadmin/panels/multi_field_panel_child.html
+++ b/wagtail/admin/templates/wagtailadmin/panels/multi_field_panel_child.html
@@ -4,7 +4,9 @@
         {% fragment as label_content %}
             {{ child.heading }}{% if child.is_required %}<span class="w-required-mark">*</span>{% endif %}
         {% endfragment %}
-        {% if child.id_for_label %}
+        {% if child.read_only %}
+            <h3 class="w-field__label" id="{{ child.id_for_label }}-label">{{ label_content }}</h3>
+        {% elif child.id_for_label %}
             <label class="w-field__label" for="{{ child.id_for_label }}" id="{{ child.id_for_label }}-label">{{ label_content }}</label>
         {% else %}
             <h3 class="w-field__label">{{ label_content }}</h3>

--- a/wagtail/admin/templates/wagtailadmin/panels/read_only_output.html
+++ b/wagtail/admin/templates/wagtailadmin/panels/read_only_output.html
@@ -1,0 +1,3 @@
+<div class="w-field__textoutput" role="textbox" tabindex="0" aria-labelledby="{{ id_for_label }}-label"{% if help_text %} aria-describedby="{{ help_text_id }}"{% endif %} aria-readonly="true">
+    {{ display_value }}
+</div>

--- a/wagtail/admin/tests/test_edit_handlers.py
+++ b/wagtail/admin/tests/test_edit_handlers.py
@@ -1,5 +1,6 @@
 from datetime import date, datetime, timezone
 from functools import wraps
+from typing import Any, List, Mapping, Optional
 from unittest import mock
 
 from django import forms
@@ -22,6 +23,7 @@ from wagtail.admin.panels import (
     MultiFieldPanel,
     ObjectList,
     PageChooserPanel,
+    Panel,
     PublishingPanel,
     TabbedInterface,
     extract_panel_definitions_from_model_class,
@@ -33,6 +35,7 @@ from wagtail.admin.widgets import (
     AdminDateInput,
     AdminPageChooser,
 )
+from wagtail.images import get_image_model
 from wagtail.models import Comment, CommentReply, Page, Site
 from wagtail.test.testapp.forms import ValidatedPageForm
 from wagtail.test.testapp.models import (
@@ -653,27 +656,88 @@ class TestObjectList(TestCase):
         self.assertNotIn("signup_link", result)
 
 
+class TestFormatValueForDisplay(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.panel = Panel()
+        self.event = EventPage(
+            title="Abergavenny sheepdog trials",
+            date_from=date(2014, 7, 20),
+            date_to=date(2014, 7, 21),
+            audience="public",
+        )
+
+    def test_charfield_return_value(self):
+        result = self.panel.format_value_for_display(self.event.title)
+        self.assertIs(result, self.event.title)
+
+    def test_datefield_return_value(self):
+        result = self.panel.format_value_for_display(self.event.date_from)
+        self.assertIs(result, self.event.date_from)
+
+    def test_queryset_return_value(self):
+        result = self.panel.format_value_for_display(Page.objects.all())
+        self.assertEqual(result, "Root, Welcome to your new Wagtail site!")
+
+
 class TestFieldPanel(TestCase):
     def setUp(self):
         self.request = RequestFactory().get("/")
         user = AnonymousUser()  # technically, Anonymous users cannot access the admin
         self.request.user = user
 
-        self.EventPageForm = get_form_for_model(
-            EventPage,
-            form_class=WagtailAdminPageForm,
-            fields=["title", "slug", "date_from", "date_to"],
-            formsets=[],
-        )
         self.event = EventPage(
             title="Abergavenny sheepdog trials",
             date_from=date(2014, 7, 20),
             date_to=date(2014, 7, 21),
+            audience="public",
         )
 
         self.end_date_panel = FieldPanel(
             "date_to", classname="full-width"
         ).bind_to_model(EventPage)
+
+        self.read_only_end_date_panel = FieldPanel(
+            "date_to", read_only=True
+        ).bind_to_model(EventPage)
+
+        self.read_only_audience_panel = FieldPanel(
+            "audience", read_only=True
+        ).bind_to_model(EventPage)
+
+        self.read_only_image_panel = FieldPanel(
+            "feed_image", read_only=True
+        ).bind_to_model(EventPage)
+
+        self.pontypridd_event_data = {
+            "title": "Pontypridd sheepdog trials",
+            "date_from": "2014-06-01",
+            "date_to": "2014-06-02",
+        }
+
+    def _get_form(
+        self,
+        data: Optional[Mapping[str, Any]] = None,
+        fields: Optional[List[str]] = None,
+    ) -> WagtailAdminPageForm:
+        cls = get_form_for_model(
+            EventPage,
+            form_class=WagtailAdminPageForm,
+            fields=fields if fields is not None else ["title", "slug", "date_to"],
+            formsets=[],
+        )
+        return cls(data=data, instance=self.event)
+
+    def _get_bound_panel(
+        self, panel: FieldPanel, form: WagtailAdminPageForm = None
+    ) -> FieldPanel.BoundPanel:
+        if not panel.model:
+            panel = panel.bind_to_model(EventPage)
+        return panel.get_bound_panel(
+            form=form or self._get_form(),
+            request=self.request,
+            instance=self.event,
+        )
 
     def test_non_model_field(self):
         # defining a FieldPanel for a field which isn't part of a model is OK,
@@ -684,90 +748,138 @@ class TestFieldPanel(TestCase):
         with self.assertRaises(FieldDoesNotExist):
             field_panel.db_field
 
+    def test_get_form_options_includes_non_read_only_fields(self):
+        panel = self.end_date_panel
+        result = panel.get_form_options()
+        self.assertIn("fields", result)
+        self.assertEqual(result["fields"], ["date_to"])
+
+    def test_get_form_options_does_not_include_read_only_fields(self):
+        panel = self.read_only_end_date_panel
+        result = panel.get_form_options()
+        self.assertNotIn("fields", result)
+
+    def test_boundpanel_is_shown(self):
+        form = self._get_form(fields=["body", "title"])
+        for field_name, make_read_only, expected_value in (
+            ("title", True, True),
+            ("body", True, True),
+        ):
+            panel = FieldPanel(field_name, read_only=make_read_only)
+            bound_panel = self._get_bound_panel(panel, form=form)
+            with self.subTest(f"{field_name}, read_only={make_read_only}"):
+                self.assertIs(bound_panel.is_shown(), expected_value)
+
     def test_override_heading(self):
         # unless heading is specified in keyword arguments, an edit handler with bound form should take its
         # heading from the bound field label
-        bound_panel = self.end_date_panel.get_bound_panel(
-            form=self.EventPageForm(), request=self.request, instance=self.event
-        )
+        bound_panel = self._get_bound_panel(self.end_date_panel)
         self.assertEqual(bound_panel.heading, bound_panel.bound_field.label)
 
         # if heading is explicitly provided to constructor, that heading should be taken in
         # preference to the field's label
-        end_date_panel_with_overridden_heading = FieldPanel(
-            "date_to", classname="full-width", heading="New heading"
-        ).bind_to_model(EventPage)
-        end_date_panel_with_overridden_heading = (
-            end_date_panel_with_overridden_heading.get_bound_panel(
-                request=self.request, form=self.EventPageForm(), instance=self.event
-            )
+        bound_panel = self._get_bound_panel(
+            FieldPanel("date_to", classname="full-width", heading="New heading")
         )
-        self.assertEqual(end_date_panel_with_overridden_heading.heading, "New heading")
-        self.assertEqual(
-            end_date_panel_with_overridden_heading.bound_field.label, "New heading"
-        )
+        self.assertEqual(bound_panel.heading, "New heading")
+        self.assertEqual(bound_panel.bound_field.label, "New heading")
 
     def test_render_html(self):
-        form = self.EventPageForm(
-            {
-                "title": "Pontypridd sheepdog trials",
-                "date_from": "2014-07-20",
-                "date_to": "2014-07-22",
-            },
-            instance=self.event,
+        for data, expected_input_value in (
+            (None, str(self.event.date_to)),
+            (self.pontypridd_event_data, self.pontypridd_event_data["date_to"]),
+        ):
+            form = self._get_form(data=data, fields=["title", "slug", "date_to"])
+            form.is_valid()
+            bound_panel = self._get_bound_panel(self.end_date_panel, form=form)
+            result = bound_panel.render_html()
+            with self.subTest(f"form data = {data}"):
+                # An <input> should be rendered
+                self.assertIn("<input", result)
+
+                # The input should have the expected value
+                self.assertIn(f'value="{expected_input_value}"', result)
+
+                # help text should rendered
+                self.assertIn("Not required if event is on a single day", result)
+
+                # there should be no errors on this field
+                self.assertNotIn("error-message", result)
+
+    def test_render_html_when_read_only(self):
+        # NOTE: Tests with and without providing POST data to the form to
+        # prove that posted values have no impact on the output for
+        # read-only panels.
+        expected_value_output = self.event.date_to.strftime("%B %-d, %Y")
+
+        for panel, data in (
+            (self.read_only_end_date_panel, None),
+            (
+                self.read_only_end_date_panel,
+                self.pontypridd_event_data,
+            ),
+        ):
+            form = self._get_form(data=data, fields=["title", "slug"])
+            form.is_valid()
+            bound_panel = self._get_bound_panel(panel, form=form)
+            with self.subTest(f"form data = {data}"):
+                result = bound_panel.render_html()
+
+                # No <input> should be rendered
+                self.assertNotIn("<input", result)
+
+                # Though, we should still see a representation of the value
+                self.assertIn(expected_value_output, result)
+
+                # Help text should still be rendered, too
+                self.assertIn("Not required if event is on a single day", result)
+
+    def test_format_value_for_display_with_choicefield(self):
+        result = self.read_only_audience_panel.format_value_for_display(
+            self.event.audience
         )
+        self.assertEqual(result, "Public")
 
-        form.is_valid()
-
-        field_panel = self.end_date_panel.get_bound_panel(
-            instance=self.event,
-            form=form,
-            request=self.request,
-        )
-        result = field_panel.render_html()
-
-        self.assertIn("Not required if event is on a single day", result)
-
-        # check that the populated form field is included
-        self.assertIn('value="2014-07-22"', result)
-
-        # there should be no errors on this field
-        self.assertNotIn("error-message", result)
+    def test_format_value_for_display_with_modelchoicefield(self):
+        """
+        `ForeignKey.formfield()` returns a `ModelChoiceField`, which returns a
+        `ModelChoiceIterator` instance when it's `choices` property is
+        accessed. This test is to show that `format_value_for_display()` avoids
+        evaluating `ModelChoiceIterator` instances, and the database query
+        that would trigger.
+        """
+        value = get_image_model()(title="Title")
+        expected_result = str(value)
+        with self.assertNumQueries(0):
+            self.assertEqual(
+                self.read_only_image_panel.format_value_for_display(value),
+                expected_result,
+            )
 
     def test_required_fields(self):
         result = self.end_date_panel.get_form_options()["fields"]
         self.assertEqual(result, ["date_to"])
 
     def test_error_message_is_rendered(self):
-        form = self.EventPageForm(
-            {
+        form = self._get_form(
+            data={
                 "title": "Pontypridd sheepdog trials",
                 "date_from": "2014-07-20",
                 "date_to": "2014-07-33",
             },
-            instance=self.event,
         )
-
         form.is_valid()
 
-        field_panel = self.end_date_panel.get_bound_panel(
-            instance=self.event,
-            form=form,
-            request=self.request,
-        )
-        result = field_panel.render_html()
+        bound_panel = self._get_bound_panel(self.end_date_panel, form)
+
+        result = bound_panel.render_html()
 
         self.assertIn("Enter a valid date.", result)
 
     def test_repr(self):
-        form = self.EventPageForm()
-        field_panel = self.end_date_panel.get_bound_panel(
-            form=form,
-            instance=self.event,
-            request=self.request,
-        )
+        bound_panel = self._get_bound_panel(self.end_date_panel)
 
-        field_panel_repr = repr(field_panel)
+        field_panel_repr = repr(bound_panel)
 
         self.assertIn(
             "model=<class 'wagtail.test.testapp.models.EventPage'>", field_panel_repr

--- a/wagtail/admin/tests/test_edit_handlers.py
+++ b/wagtail/admin/tests/test_edit_handlers.py
@@ -848,12 +848,11 @@ class TestFieldPanel(TestCase):
         evaluating `ModelChoiceIterator` instances, and the database query
         that would trigger.
         """
-        value = get_image_model()(title="Title")
-        expected_result = str(value)
+        image = get_image_model()(title="Title")
         with self.assertNumQueries(0):
             self.assertEqual(
-                self.read_only_image_panel.format_value_for_display(value),
-                expected_result,
+                self.read_only_image_panel.format_value_for_display(image),
+                image,
             )
 
     def test_required_fields(self):


### PR DESCRIPTION
Related issue/discussion: #2893

Supersedes: #6194 and #6067

### When would you use this?

When you want to show a model field value in a form without it ever being editable, use `read_only=True` in the `FieldPanel` constructor, e.g. `FieldPanel("slug", read_only=True)`. 

### What is displayed in read-only mode?

Following the "Form follows function" design principle, if we don't intend for the value to be updated, there's no point in presenting the user with a form control (whether hidden, disabled or in any other special state). So, for read-only panels, we avoid adding fields to the (dynamically generated) `ModelForm`, and simplify the output.

Instead of a form control, we render the field value in a `<div>` element, which looks a lot like a disabled `<input type="text">` element, but is screen-reader navigable in much the same way as a regular (non-disabled) input.

While setting the `disabled` attribute on the Django form field would grant us similar protection, not including a field in the form at all gives us a cast-iron guarantee that field values included in POSTed data will not be applied to the model (unexpected values are simply ignored and will never be included in `form.cleaned_data`). Validation isn't applied to non-fields values either.

### Can I use it to display arbitrary attribute values?

I'm afraid not. `FieldPanel` has a pre-existing restriction that allows it to be used for model fields only (which makes sense when you consider the name). For arbitrary model instance values, it makes sense to introduce an entirely new panel type, which will contributed via a separate PR.

On the plus side: Having a model field allows us to pull `verbose_name` and `help_text` values from there and display them in a familiar manner.

### Are all field types supported?

Yes, but displaying chunks of user-controlled HTML mid-form is a touch on the risky side so, for `StreamField` or `RichTextField` values, a text-only representation is extracted from the HTML (using the same method as used for the 'compare revisions' view) and used for display instead.

If for any reason you don't like the default representation of a field value, you can override the `format_value_for_display()` method to control what is rendered.

```
class KeyIngredientsPanel(FieldPanel):
    """
    A custom FieldPanel for use with the 'key_ingredients' ParentalManyToManyField 
    """

    def format_value_for_display(self, value):
        # Show a comma-separate list of ingredients when in read-only mode
        return ", ".join(obj.get_listing_summary() for obj in value.all())
```

### How it looks

As children of a `MultiFieldPanel`:

<img width="952" alt="Screenshot 2022-09-07 at 1 06 47 pm" src="https://user-images.githubusercontent.com/7779588/188874911-3d1e37eb-bd5a-4af4-9941-95257e8805eb.png">

As top-level `FieldPanel` instances:

<img width="919" alt="Screenshot 2022-09-07 at 1 07 20 pm" src="https://user-images.githubusercontent.com/7779588/188875020-4d6d4c77-f56c-4708-a409-90e7b0450437.png">