### PR TITLE
Add `<base>` tag for preview panel in the default `base.html` template

### DIFF
--- a/docs/releases/4.0.md
+++ b/docs/releases/4.0.md
@@ -271,6 +271,20 @@ There are also many improvements to the documentation both under the hood and in
 
 As part of making previews available to non-page models, the `serve_preview()` method has been decoupled from the `serve()` method and extracted into the `PreviewableMixin` class. If you have overridden the `serve()` method in your page models, you will likely need to override `serve_preview()`, `get_preview_template()`, and/or `get_preview_context()` methods to handle previews accordingly. Alternatively, you can also override the `preview_modes` property to return an empty list to disable previews.
 
+### Opening links within the live preview panel
+
+The live preview panel utilises an iframe to display the preview in the editor page, which requires the page in the iframe to have the `X-Frame-Options` header set to `SAMEORIGIN` (or unset). If you click a link within the preview panel, you may notice that the iframe stops working. This is because the link is loaded within the iframe and the linked page may have the `X-Frame-Options` header set to `DENY`. To work around this problem, add the following `<base>` tag within your `<head>` element in your `base.html` template, before any `<link>` elements:
+
+```html+django
+{% if request.in_preview_panel %}
+    <base target="_blank">
+{% endif %}
+```
+
+This will make all links in the live preview panel open in a new tab.
+
+New Wagtail projects already include this change in the base template.
+
 ### `base_url_path` keyword argument added to AdminURLHelper
 
 The `wagtail.contrib.modeladmin.helpers.AdminURLHelper` class now accepts a `base_url_path` keyword argument on its constructor. Custom subclasses of this class should be updated to accept this keyword argument.

--- a/wagtail/project_template/project_name/templates/base.html
+++ b/wagtail/project_template/project_name/templates/base.html
@@ -16,6 +16,11 @@
         <meta name="description" content="" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
 
+        {% templatetag opencomment %} Force all links in the live preview panel to be opened in a new tab {% templatetag closecomment %}
+        {% templatetag openblock %} if request.in_preview_panel {% templatetag closeblock %}
+        <base target="_blank">
+        {% templatetag openblock %} endif {% templatetag closeblock %}
+
         {% templatetag opencomment %} Global stylesheets {% templatetag closecomment %}
         <link rel="stylesheet" type="text/css" href="{% templatetag openblock %} static 'css/{{ project_name }}.css' {% templatetag closeblock %}">
 


### PR DESCRIPTION
<!--
Thanks for contributing to Wagtail! 🎉

Before submitting, please review the [contributor guidelines](https://docs.wagtail.org/en/latest/contributing/index.html).
-->

Fixes #9123. Added a section in the upgrade considerations to instruct users to make the same change in their own projects (suggestions welcome).

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [x] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

- Spin up a new project
- Open the live preview panel (e.g. in a create or edit view)
- Make sure the previewed page has a link, and click it (any link)
- The link should open in a new tab

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
