### PR TITLE
Writing unit tests for the classnames template tag

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -14,6 +14,7 @@ Changelog
  * Provide a more accessible page title where the unique information is shown first and the CMS name is shown last (Mehrdad Moradizadeh)
  * Pull out behaviour from `AbstractFormField` to `FormMixin` and `AbstractEmailForm` to `EmailFormMixin` to allow use with subclasses of `Page` (Mehrdad Moradizadeh, Kurt Wall)
  * Add a `docs.wagtail.org/.well-known/security.txt` so that the security policy is available as per the specification on https://securitytxt.org/ (Jake Howard)
+ * Add unit tests for the `classnames` Wagtail admin template tag (Mehrdad Moradizadeh)
  * Fix: Prevent `PageQuerySet.not_public` from returning all pages when no page restrictions exist (Mehrdad Moradizadeh)
  * Fix: Ensure that duplicate block ids are unique when duplicating stream blocks in the page editor (Joshua Munn)
 

--- a/docs/releases/4.1.md
+++ b/docs/releases/4.1.md
@@ -23,6 +23,7 @@ Wagtail 4.1 is designated a Long Term Support (LTS) release. Long Term Support r
  * Provide a more accessible page title where the unique information is shown first and the CMS name is shown last (Mehrdad Moradizadeh)
  * Pull out behaviour from `AbstractFormField` to `FormMixin` and `AbstractEmailForm` to `EmailFormMixin` to allow use with subclasses of `Page` [](form_builder_mixins) (Mehrdad Moradizadeh, Kurt Wall)
  * Add a `docs.wagtail.org/.well-known/security.txt` so that the security policy is available as per the specification on [https://securitytxt.org/](https://securitytxt.org/) (Jake Howard)
+ * Add unit tests for the `classnames` Wagtail admin template tag (Mehrdad Moradizadeh)
 
 ### Bug fixes
 

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -156,6 +156,7 @@ def page_permissions(context, page):
 @register.simple_tag
 def classnames(*classes):
     """
+    Usage <div class="{% classnames "w-base" classname active|yesno:"w-base--active," any_other_var %}"></div>
     Returns any args as a space-separated joined string for using in HTML class names.
     """
     return " ".join([classname.strip() for classname in classes if classname])

--- a/wagtail/admin/tests/test_templatetags.py
+++ b/wagtail/admin/tests/test_templatetags.py
@@ -369,3 +369,73 @@ class FragmentTagTest(TestCase):
         """
 
         self.assertHTMLEqual(expected, Template(template).render(context))
+
+
+class ClassnamesTagTest(TestCase):
+    def test_with_single_arg(self):
+        template = """
+            {% load wagtailadmin_tags %}
+            <p class="{% classnames "w-header" classname  %}">Hello!</p>
+        """
+
+        expected = """
+            <p class="w-header">Hello!</p>
+        """
+
+        actual = Template(template).render(Context())
+
+        self.assertHTMLEqual(expected, actual)
+
+    def test_with_multiple_args(self):
+        template = """
+            {% load wagtailadmin_tags %}
+            <p class="{% classnames "w-header" classname "w-header--merged" "w-header--hasform" %}">
+                Hello!
+            </p>
+        """
+
+        expected = """
+            <p class="w-header w-header--merged w-header--hasform">
+                Hello!
+            </p>
+        """
+
+        actual = Template(template).render(Context())
+
+        self.assertHTMLEqual(expected, actual)
+
+    def test_with_falsy_args(self):
+        template = """
+            {% load wagtailadmin_tags %}
+            <p class="{% classnames "w-header" classname "" %}">Hello!</p>
+        """
+
+        expected = """
+            <p class="w-header">Hello!</p>
+        """
+
+        actual = Template(template).render(Context())
+
+        self.assertEqual(expected.strip(), actual.strip())
+
+    def test_with_args_with_extra_whitespace(self):
+        context = Context(
+            {
+                "merged": "w-header--merged ",
+                "search_form": " w-header--hasform",
+                "name": " wagtail ",
+            }
+        )
+
+        template = """
+            {% load wagtailadmin_tags %}
+            <p class="{% classnames "w-header" classname merged search_form name %}">Hello!</p>
+        """
+
+        expected = """
+            <p class="w-header w-header--merged w-header--hasform wagtail">Hello!</p>
+        """
+
+        actual = Template(template).render(context)
+
+        self.assertEqual(expected.strip(), actual.strip())


### PR DESCRIPTION
fixes #9103

## Add unit tests for the `classnames` template tag.

Writing 4 unit tests to cover a single arg, multiple args, falsey args and also strings with extra whitespace.

<!--
Thanks for contributing to Wagtail! 🎉

Before submitting, please review the [contributor guidelines](https://docs.wagtail.org/en/latest/contributing/index.html).
-->


_Please check the following:_

-   [x] Do the tests still pass?
-   [x] Does the code comply with the style guide?
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
