### PR TITLE
button stying fixes & follow up

### DIFF
--- a/client/scss/components/_button.scss
+++ b/client/scss/components/_button.scss
@@ -11,7 +11,7 @@
   padding: 0 1em;
   font-size: theme('fontSize.14');
   font-weight: theme('fontWeight.normal');
-  line-height: 2.25em;
+  line-height: calc(2.25em - 2px); // account for border
   vertical-align: middle;
   display: inline-block;
   background-color: $color-button;
@@ -21,7 +21,6 @@
   white-space: nowrap;
   position: relative;
   overflow: hidden;
-  box-sizing: content-box;
   transition: background-color 0.1s ease;
   // stylelint-disable-next-line property-no-vendor-prefix
   -moz-appearance: none;
@@ -36,7 +35,7 @@
     padding: 0 0.8em;
     height: 2em;
     font-size: calc(theme('fontSize.14') * 0.87);
-    line-height: 2em;
+    line-height: calc(2em - 2px); // account for border
   }
 
   &.button-secondary {
@@ -46,10 +45,10 @@
 
   &.yes {
     background-color: $color-button-yes;
-    border: 1px solid $color-button-yes;
+    border-color: $color-button-yes;
 
     &.button-secondary {
-      border: 1px solid $color-button-yes;
+      border-color: $color-button-yes;
       color: $color-button-yes;
       background-color: transparent;
     }
@@ -63,10 +62,10 @@
 
   &.warning {
     background-color: $color-button-warning;
-    border: 1px solid $color-button-warning;
+    border-color: $color-button-warning;
 
     &.button-secondary {
-      border: 1px solid $color-button-warning;
+      border-color: $color-button-warning;
       color: $color-button-warning;
       background-color: transparent;
     }
@@ -81,10 +80,10 @@
   &.no,
   &.serious {
     background-color: $color-button-no;
-    border: 1px solid $color-button-no;
+    border-color: $color-button-no;
 
     &.button-secondary {
-      border: 1px solid $color-button-no;
+      border-color: $color-button-no;
       color: $color-button-no;
       background-color: transparent;
     }
@@ -97,7 +96,6 @@
   }
 
   &.bicolor {
-    border: 1px solid transparent;
     padding-inline-start: 3.5em;
 
     &:before {
@@ -161,7 +159,7 @@
     }
 
     &.button-secondary {
-      border: 1px solid theme('colors.black-20');
+      border-color: theme('colors.black-20');
     }
 
     &.button-small {
@@ -339,7 +337,7 @@
     font-size: theme('fontSize.14');
     padding: 0 1.4em;
     height: 3em;
-    line-height: 3em;
+    line-height: calc(3em - 2px); // account for border
 
     &.bicolor {
       padding-inline-start: 3.5em;

--- a/client/scss/components/_dropdown.legacy.scss
+++ b/client/scss/components/_dropdown.legacy.scss
@@ -14,7 +14,6 @@
     line-height: 3em;
     text-align: start;
     float: left;
-    box-sizing: border-box;
   }
 
   .action-secondary {

--- a/client/scss/components/_modals.scss
+++ b/client/scss/components/_modals.scss
@@ -85,7 +85,7 @@ $zindex-modal-background: 500;
   }
 }
 
-.modal .close {
+.modal .close.button {
   position: absolute;
   display: inline-flex;
   justify-content: center;
@@ -138,7 +138,7 @@ $zindex-modal-background: 500;
     width: auto;
   }
 
-  .modal .close {
+  .modal .close.button {
     width: theme('spacing.12');
     height: theme('spacing.12');
   }

--- a/wagtail/admin/templates/wagtailadmin/shared/button.stories.tsx
+++ b/wagtail/admin/templates/wagtailadmin/shared/button.stories.tsx
@@ -16,6 +16,16 @@ const Template = ({ url }) => (
       button element
     </button>
 
+    <h4>
+      Basic buttons <small>(small)</small>
+    </h4>
+    <a href={url} className="button button-small">
+      button link
+    </a>
+    <button type="button" className="button button-small">
+      button element
+    </button>
+
     <h3>Secondary buttons</h3>
     <a href={url} className="button button-secondary">
       button link
@@ -24,19 +34,13 @@ const Template = ({ url }) => (
       button element
     </button>
 
-    <h3>Small buttons</h3>
-    <a href={url} className="button button-small">
+    <h4>
+      Secondary buttons <small>(small)</small>
+    </h4>
+    <a href={url} className="button button-secondary button-small">
       button link
     </a>
-    <button type="button" className="button button-small">
-      button element
-    </button>
-
-    <h4>Secondary buttons</h4>
-    <a href={url} className="button button-small button-secondary">
-      button link
-    </a>
-    <button type="button" className="button button-small button-secondary">
+    <button type="button" className="button button-secondary button-small">
       button element
     </button>
 
@@ -44,7 +48,27 @@ const Template = ({ url }) => (
     <a href={url} className="button disabled">
       button link
     </a>
+    <button type="button" className="button" disabled>
+      button element
+    </button>
+    <button type="button" className="button button-secondary" disabled>
+      button element
+    </button>
+
+    <h4>
+      Disabled buttons <small>(small)</small>
+    </h4>
+    <a href={url} className="button button-small disabled">
+      button link
+    </a>
     <button type="button" className="button button-small disabled">
+      button element
+    </button>
+    <button
+      type="button"
+      className="button button-small button-secondary"
+      disabled
+    >
       button element
     </button>
 
@@ -65,8 +89,18 @@ const Template = ({ url }) => (
       </span>
       button element
     </button>
+    <button type="button" className="button bicolor button--icon" disabled>
+      <span className="icon-wrapper">
+        <svg className="icon icon-plus icon" aria-hidden="true">
+          <use href="#icon-plus" />
+        </svg>
+      </span>
+      button disabled
+    </button>
 
-    <h4>(small)</h4>
+    <h4>
+      Bi-color icon buttons with text <small>(small)</small>
+    </h4>
     <a href={url} className="button button-small bicolor button--icon">
       <span className="icon-wrapper">
         <svg className="icon icon-plus icon" aria-hidden="true">
@@ -83,6 +117,18 @@ const Template = ({ url }) => (
       </span>
       button element
     </button>
+    <button
+      type="button"
+      className="button button-small bicolor button--icon"
+      disabled
+    >
+      <span className="icon-wrapper">
+        <svg className="icon icon-plus icon" aria-hidden="true">
+          <use href="#icon-plus" />
+        </svg>
+      </span>
+      button disabled
+    </button>
 
     <h3>Icon buttons without text</h3>
     <a href={url} className="button text-replace button--icon">
@@ -98,7 +144,9 @@ const Template = ({ url }) => (
       button element
     </button>
 
-    <h4>(small)</h4>
+    <h4>
+      Icon buttons without text <small>(small)</small>
+    </h4>
     <a href={url} className="button button-small text-replace button--icon">
       <svg className="icon icon-cog icon" aria-hidden="true">
         <use href="#icon-cog" />
@@ -115,36 +163,66 @@ const Template = ({ url }) => (
       button element
     </button>
 
-    <h3>Colour signifiers</h3>
-
-    <h4>Positive</h4>
-    <a href={url} className="button button-small yes">
-      yes
+    <h3>Colour signifiers - Positive</h3>
+    <a href={url} className="button yes">
+      Yes link
     </a>
-    <a href={url} className="button button-small yes">
-      yes
-    </a>
+    <button type="button" className="button yes">
+      Yes button
+    </button>
+    <button type="button" className="button yes" disabled>
+      Yes disabled
+    </button>
 
-    <h4>Negative</h4>
+    <h4>
+      Positive <small>(small)</small>
+    </h4>
+    <a href={url} className="button button-small yes">
+      Yes
+    </a>
+    <button type="button" className="button button-small yes">
+      Yes
+    </button>
+    <button type="button" className="button button-small yes" disabled>
+      Yes disabled
+    </button>
+
+    <h3>Colour signifiers - Negative</h3>
+
+    <a href={url} className="button no">
+      No link
+    </a>
+    <button type="button" className="button no">
+      No button
+    </button>
+    <button type="button" className="button no" disabled>
+      No disabled
+    </button>
+
+    <h4>
+      Negative <small>(small)</small>
+    </h4>
     <a href={url} className="button button-small no">
       No
     </a>
-    <a href={url} className="button button-small no">
+    <button type="button" className="button button-small no">
       No
-    </a>
+    </button>
+    <button type="button" className="button button-small no" disabled>
+      Disabled
+    </button>
 
-    <h3>
-      Buttons with internal loading indicators (currently only{' '}
-      <code>button</code> supported)
-    </h3>
+    <h3>Buttons with internal loading indicators</h3>
+    <p>
+      Currently only <code>button</code> elements are supported.
+    </p>
+
     <button type="button" className="button button-longrunning">
       <svg className="icon icon-spinner icon" aria-hidden="true">
         <use href="#icon-spinner" />
       </svg>
       Click me
     </button>
-
-    <h4>Secondary</h4>
     <button
       type="button"
       className="button button-secondary button-longrunning"
@@ -154,8 +232,6 @@ const Template = ({ url }) => (
       </svg>
       Click me
     </button>
-
-    <h4>Small</h4>
     <button type="button" className="button button-small button-longrunning">
       <svg className="icon icon-spinner icon" aria-hidden="true">
         <use href="#icon-spinner" />

--- a/wagtail/contrib/styleguide/templates/wagtailstyleguide/base.html
+++ b/wagtail/contrib/styleguide/templates/wagtailstyleguide/base.html
@@ -202,87 +202,103 @@
 
         <section id="buttons">
             <h2>Buttons</h2>
-            <p class="help-block help-warning">{% icon name='warning' %}Do not use <code>{% filter force_escape|lower %}<input type="button">{% endfilter %}</code> use <code>{% filter force_escape|lower %}<button type="button"></button>{% endfilter %}</code> instead. This addresses inconsistencies between rendering of buttons x-browser.</p>
-
-
-            <p>Buttons must have interaction possible (i.e be an input or button element) to get a suitable hover cursor</p>
+            <p class="help-block help-warning">{% icon name='warning' %}Do not use <code>{% filter force_escape|lower %}<input type="button">{% endfilter %}</code> use <code>{% filter force_escape|lower %}<button type="button"></button>{% endfilter %}</code> instead. This addresses inconsistencies between rendering of buttons across browsers.</p>
+            <p>Buttons must have interaction possible (i.e be an input or button element) to get a suitable hover cursor.</p>
 
             <h3>Basic buttons</h3>
 
             <a href="#" class="button">button link</a>
-            <button class="button">button element</button>
+            <button class="button" type="button">button element</button>
+
+            <h4>Basic buttons <small>(small)</small></h4>
+
+            <a href="#" class="button button-small">button link</a>
+            <button class="button button-small" type="button">button element</button>
 
             <h3>Secondary buttons</h3>
 
             <a href="#" class="button button-secondary">button link</a>
-            <button class="button button-secondary">button element</button>
+            <button class="button button-secondary" type="button">button element</button>
 
-            <h3>Small buttons</h3>
-
-            <a href="#" class="button button-small">button link</a>
-            <button class="button button-small">button element</button>
-
-            <h4>(secondary)</h4>
+            <h4>Secondary buttons <small>(small)</small></h4>
             <a href="#" class="button button-small button-secondary">button link</a>
-            <button class="button button-small button-secondary">button element</button>
+            <button class="button button-small button-secondary" type="button">button element</button>
 
             <h3>Disabled buttons</h3>
 
             <a href="#" class="button disabled">button link</a>
-            <button class="button button-small disabled">button element</button>
+            <button class="button disabled" type="button">button element</button>
+            <button class="button button-secondary disabled" type="button">button secondary</button>
+
+            <h4>Disabled buttons <small>(small)</small></h4>
+
+            <a href="#" class="button button-small disabled">button link</a>
+            <button class="button button-small" disabled type="button">button element</button>
+            <button class="button button-small button-secondary" disabled type="button">button secondary</button>
 
             <h3>Bi-color icon buttons with text</h3>
             <p>Note that <code>input</code> elements are not supported by any icon buttons.</p>
 
             <a href="#" class="button bicolor button--icon">{% icon name="plus" wrapped=1 %}button link</a>
-            <button class="button bicolor button--icon">{% icon name="plus" wrapped=1 %}button element</button>
+            <button class="button bicolor button--icon" type="button">{% icon name="plus" wrapped=1 %}button element</button>
+            <button class="button bicolor button--icon" disabled type="button">{% icon name="plus" wrapped=1 %}button disabled</button>
 
-            <h4>(small)</h4>
+            <h4>Bi-color icon buttons with text <small>(small)</small></h4>
 
             <a href="#" class="button button-small bicolor button--icon">{% icon name="plus" wrapped=1 %}button link</a>
-            <button class="button button-small bicolor button--icon">{% icon name="plus" wrapped=1 %}button element</button>
+            <button class="button button-small bicolor button--icon" type="button">{% icon name="plus" wrapped=1 %}button element</button>
+            <button class="button button-small bicolor button--icon" disabled type="button">{% icon name="plus" wrapped=1 %}button disabled</button>
 
             <h3>Icon buttons without text</h3>
 
             <a href="#" class="button text-replace button--icon">{% icon name="cog" %}button link</a>
-            <button class="button text-replace button--icon">{% icon name="cog" %}button element</button>
+            <button class="button text-replace button--icon" type="button">{% icon name="cog" %}button element</button>
 
-            <h4>(small)</h4>
+            <h4>Icon buttons without text <small>(small)</small></h4>
 
             <a href="#" class="button button-small text-replace button--icon">{% icon name="cog" %}button link</a>
-            <button class="button button-small text-replace button--icon">{% icon name="cog" %}button element</button>
+            <button class="button button-small text-replace button--icon" type="button">{% icon name="cog" %}button element</button>
 
-            <h3>Colour signifiers</h3>
+            <h3>Colour signifiers - Positive</h3>
 
-            <h4>Positive</h4>
+            <a href="#" class="button yes">Yes link</a>
+            <button class="button yes" type="button">Yes button</button>
+            <button class="button yes" disabled type="button">Yes disabled</button>
 
-            <a href="#" class="button button-small yes">yes</a>
-            <a href="#" class="button button-small yes">yes</a>
+            <h4>Positive <small>(small)</small></h4>
 
-            <h4>Negative</h4>
+            <a href="#" class="button button-small yes">Yes</a>
+            <button class="button button-small yes" type="button">Yes</button>
+            <button class="button button-small yes" disabled type="button">Disabled</button>
+
+            <h3>Colour signifiers - Negative</h3>
+
+            <a href="#" class="button no">No link</a>
+            <button class="button no" type="button">No button</button>
+            <button class="button no" disabled type="button">No disabled</button>
+
+            <h4>Negative <small>(small)</small></h4>
 
             <a href="#" class="button button-small no">No</a>
-            <a href="#" class="button button-small no">No</a>
+            <button class="button button-small no" type="button">No</button>
+            <button class="button button-small no" disabled type="button">Disabled</button>
 
-            <h3>Buttons with internal loading indicators (currently only <code>button</code> supported)</h3>
+            <h3>Buttons with internal loading indicators</h3>
+            <p>Currently only <code>button</code> elements are supported.</p>
             <p class="help-block help-warning">{% icon name='warning' %}Note that in some browsers, clicking these buttons minutely affects the appearance of Dropdown buttons, below. This is yet to be resolved.</p>
-            <button class="button button-longrunning">{% icon name="spinner" %}Click me</button>
 
-            <h4>Secondary</h4>
-            <button class="button button-secondary button-longrunning">{% icon name="spinner" %}Click me</button>
-
-            <h4>Small</h4>
-            <button class="button button-small button-longrunning">{% icon name="spinner" %}Click me</button>
+            <button class="button button-longrunning" type="button">{% icon name="spinner" %}Click me</button>
+            <button class="button button-secondary button-longrunning" type="button">{% icon name="spinner" %}Click me</button>
+            <button class="button button-small button-longrunning" type="button">{% icon name="spinner" %}Click me</button>
 
             <h4>Buttons where the text is replaced on click</h4>
-            <button class="button button-longrunning" data-clicked-text="Test">{% icon name="spinner" %}<em>Click me</em></button>
+            <button class="button button-longrunning" data-clicked-text="Test" type="button">{% icon name="spinner" %}<em>Click me</em></button>
 
             <h3>Mixtures</h3>
 
-            <button class="button button--icon text-replace yes">{% icon name="tick" %}A proper button</button>
+            <button class="button button--icon text-replace yes" type="button">{% icon name="tick" %}A proper button</button>
             <a href="#" class="button button--icon text-replace white">{% icon name="cog" %}A link button</a>
             <a href="#" class="button button--icon bicolor disabled">{% icon name="tick" wrapped=1 %}button link</a>
-
         </section>
 
         <section id="dropdowns">


### PR DESCRIPTION
* follow up to #9104
* relates to #8790
* fix up styleguide example buttons for yes/no variants, add more disabled variants
* add type="button" to styleguide example buttons
* revert box-sizing change and use line-height with calc for borders instead
* revise border overrides to set border-color only
* fix modal button override
