### PR TITLE
Remove unused `note` title from page inline panel docs

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -16,6 +16,7 @@ Changelog
  * Add a `docs.wagtail.org/.well-known/security.txt` so that the security policy is available as per the specification on https://securitytxt.org/ (Jake Howard)
  * Add unit tests for the `classnames` Wagtail admin template tag (Mehrdad Moradizadeh)
  * Show an inverse locked indicator when the page has been locked by the current user in reports and dashboard listings (Vaibhav Shukla, LB (Ben Johnston))
+ * Add clarity to the development documentation that `admonition` should not be used and titles for `note` are not supported, including clean up of some existing incorrect usage (LB (Ben Johnston))
  * Fix: Prevent `PageQuerySet.not_public` from returning all pages when no page restrictions exist (Mehrdad Moradizadeh)
  * Fix: Ensure that duplicate block ids are unique when duplicating stream blocks in the page editor (Joshua Munn)
  * Fix: Revise colour usage so that privacy & locked indicators can be seen in Windows High Contrast mode (LB (Ben Johnston))

--- a/docs/contributing/documentation_guidelines.md
+++ b/docs/contributing/documentation_guidelines.md
@@ -168,6 +168,12 @@ Warnings can be scary.
 
 </details>
 
+These call-outs do not support titles, so be careful not to include them, titles will just be moved to the body of the call-out.
+
+    ```{note} Title's here will not work correctly
+    Notes can provide complementary information.
+    ```
+
 ### Images
 
 Images are hard to keep up-to-date as documentation evolves, but can be worthwhile nonetheless. Here are guidelines when adding images:
@@ -305,7 +311,7 @@ There is some formatting in the documentation which is technically supported, bu
 
 ### Call-outs
 
-We only use `{note}` and `{warning}` call-outs. Avoid `{important}`, `{topic}`, and `{tip}`. If you find one of these, please replace it with `{note}`.
+We only use `{note}` and `{warning}` call-outs. Avoid `{admonition}`, `{important}`, `{topic}`, and `{tip}`. If you find one of these, please replace it with `{note}`.
 
 ### Glossary
 

--- a/docs/releases/4.1.md
+++ b/docs/releases/4.1.md
@@ -25,6 +25,7 @@ Wagtail 4.1 is designated a Long Term Support (LTS) release. Long Term Support r
  * Add a `docs.wagtail.org/.well-known/security.txt` so that the security policy is available as per the specification on [https://securitytxt.org/](https://securitytxt.org/) (Jake Howard)
  * Add unit tests for the `classnames` Wagtail admin template tag (Mehrdad Moradizadeh)
  * Show an inverse locked indicator when the page has been locked by the current user in reports and dashboard listings (Vaibhav Shukla, LB (Ben Johnston))
+ * Add clarity to the development documentation that `admonition` should not be used and titles for `note` are not supported, including clean up of some existing incorrect usage (LB (Ben Johnston))
 
 ### Bug fixes
 

--- a/docs/topics/pages.md
+++ b/docs/topics/pages.md
@@ -340,7 +340,7 @@ Each inline model requires the following:
 -   It must inherit from {class}`wagtail.models.Orderable`
 -   It must have a `ParentalKey` to the parent model
 
-````{note} django-modelcluster and ParentalKey
+````{note}
 The model inlining feature is provided by [django-modelcluster](https://github.com/torchbox/django-modelcluster) and the `ParentalKey` field type must be imported from there:
 
 ```python


### PR DESCRIPTION
- add clarity to the docs that `admonition` is also not to be used
- title for this note is not required
- fixes #9125
