### PR TITLE
Small documentation clean up items

### DIFF
--- a/docs/getting_started/tutorial.md
+++ b/docs/getting_started/tutorial.md
@@ -19,10 +19,10 @@ $ python3 --version
 
 If this does not return a version number or returns a version lower than 3.7, you will need to [install Python 3](https://www.python.org/downloads/).
 
-```{important}
-   Before installing Wagtail, it is necessary to install the **libjpeg** and **zlib** libraries, which provide support for working with JPEG, PNG and GIF images (via the Python **Pillow** library).
-   The way to do this varies by platform—see Pillow's
-   [platform-specific installation instructions](https://pillow.readthedocs.org/en/latest/installation.html#external-libraries).
+```{note}
+Before installing Wagtail, it is necessary to install the **libjpeg** and **zlib** libraries, which provide support for working with JPEG, PNG and GIF images (via the Python **Pillow** library).
+The way to do this varies by platform—see Pillow's
+[platform-specific installation instructions](https://pillow.readthedocs.org/en/latest/installation.html#external-libraries).
 ```
 
 ### Create and activate a virtual environment

--- a/docs/releases/3.0.md
+++ b/docs/releases/3.0.md
@@ -244,7 +244,7 @@ The `form_data` field in the `AbstractFormSubmission` model (and its subclasses 
 
 Example change
 
-```
+```python
 def process_form_submission(self, form):
     self.get_submission_class().objects.create(
         # form_data=json.dumps(form.cleaned_data, cls=DjangoJSONEncoder),

--- a/docs/releases/3.0.md
+++ b/docs/releases/3.0.md
@@ -245,12 +245,12 @@ The `form_data` field in the `AbstractFormSubmission` model (and its subclasses 
 Example change
 
 ```
-    def process_form_submission(self, form):
-        self.get_submission_class().objects.create(
-            # form_data=json.dumps(form.cleaned_data, cls=DjangoJSONEncoder),
-            form_data=form.cleaned_data, # new
-            page=self, user=form.user
-        )
+def process_form_submission(self, form):
+    self.get_submission_class().objects.create(
+        # form_data=json.dumps(form.cleaned_data, cls=DjangoJSONEncoder),
+        form_data=form.cleaned_data, # new
+        page=self, user=form.user
+    )
 ```
 
 ### Removed `size` argument from `wagtail.utils.sendfile_streaming_backend.was_modified_since`


### PR DESCRIPTION
- replace `important` call out - should all be replaced with `note` or `warning`
- remove unnecessary indent in code snippet for 3.0 release notes (see screenshot below)

<img width="947" alt="Screen Shot 2022-09-06 at 1 16 02 pm" src="https://user-images.githubusercontent.com/1396140/188539632-11318ffa-708b-4267-9fea-8dfade8339d8.png">
