### PR TITLE
Fix for taggit transparent background

### DIFF
--- a/client/scss/overrides/_vendor.tagit.scss
+++ b/client/scss/overrides/_vendor.tagit.scss
@@ -1,4 +1,5 @@
 @use 'sass:map';
+
 // taggit tagging
 .tagit {
   padding: 0.6em 1.2em;
@@ -25,6 +26,40 @@
   z-index: 1000;
 }
 
+.ui-widget-content,
+.ui-state-default,
+.ui-widget-content .ui-state-default,
+.ui-widget-header .ui-state-default {
+  background-color: $color-white;
+}
+
+.ui-state-hover,
+.ui-widget-content .ui-state-hover,
+.ui-widget-header .ui-state-hover,
+.ui-state-focus,
+.ui-widget-content .ui-state-focus,
+.ui-widget-header .ui-state-focus,
+.ui-state-active,
+.ui-widget-content .ui-state-active,
+.ui-widget-header .ui-state-active {
+  background-color: theme('colors.secondary.100');
+}
+
+.ui-widget-header {
+  background-color: theme('colors.secondary.100');
+  border-color: theme('colors.grey.100');
+}
+
+.ui-state-highlight,
+.ui-widget-content .ui-state-highlight,
+.ui-widget-header .ui-state-highlight {
+  background-color: theme('colors.grey.50');
+}
+
+.ui-menu .ui-menu-item .ui-menu-item-wrapper {
+  border: 1px solid transparent; // ensure border on hover (active) does not move content
+}
+
 .tagit-close {
   .ui-icon-close {
     margin-inline-start: 1rem;
@@ -43,5 +78,19 @@
 
   .ui-icon-close:hover:before {
     color: theme('colors.critical.200');
+  }
+}
+
+@media (forced-colors: $media-forced-colours) {
+  .ui-state-hover,
+  .ui-widget-content .ui-state-hover,
+  .ui-widget-header .ui-state-hover,
+  .ui-state-focus,
+  .ui-widget-content .ui-state-focus,
+  .ui-widget-header .ui-state-focus,
+  .ui-state-active,
+  .ui-widget-content .ui-state-active,
+  .ui-widget-header .ui-state-active {
+    background-color: $system-color-button-text;
   }
 }


### PR DESCRIPTION
- re-adds backgrounds and borders based on new CSS variables in the vendor overrides for taggit
- original backgrounds removed in client/scss/vendor/jquery-ui-1.10.3.verdant.css 4eb35dbc0a6588d3a7e0ae083f14f7c8faf4adde via #8419
- also ensure the drop-down items show correctly in high contrast mode (including highlighted items)
- fixes #9128
-   [X] Do the tests still pass?[^1]
-   [X] Does the code comply with the style guide?
-   [X] For front-end changes: Did you test on all of Wagtail’s supported environments? Safari 15, Firefox 104, Windows Edge (High contrast mode) 97, Chrome 106


## Screenshots after fix

**Edge WHCM**
<img width="706" alt="Screen Shot 2022-09-06 at 5 00 19 pm" src="https://user-images.githubusercontent.com/1396140/188571513-1f4872d4-4493-471d-9a68-317b4eebd041.png">

**Firefox**
<img width="523" alt="Screen Shot 2022-09-06 at 4 58 51 pm" src="https://user-images.githubusercontent.com/1396140/188571526-63ab33cd-82f9-4679-b1c2-6ab7db0f04ca.png">

**Safari**
<img width="1050" alt="Screen Shot 2022-09-06 at 4 56 15 pm" src="https://user-images.githubusercontent.com/1396140/188571537-08736c9d-9b03-4239-9f7f-cec5f80786ce.png">

**Chrome**
<img width="657" alt="Screen Shot 2022-09-06 at 4 55 01 pm" src="https://user-images.githubusercontent.com/1396140/188571541-c6d9743d-f820-4f38-ae59-15d32921300d.png">


