### PR TITLE
Allow customising snippet listing columns with list_display

### DIFF
--- a/docs/reference/viewsets.md
+++ b/docs/reference/viewsets.md
@@ -77,6 +77,7 @@ Viewsets are Wagtail's mechanism for defining a group of related admin views wit
 ```{eval-rst}
 .. autoclass:: wagtail.snippets.views.snippets.SnippetViewSet
 
+   .. autoattribute:: list_display
    .. autoattribute:: filterset_class
    .. autoattribute:: index_view_class
    .. autoattribute:: add_view_class

--- a/wagtail/admin/ui/tables.py
+++ b/wagtail/admin/ui/tables.py
@@ -9,6 +9,7 @@ from django.template.loader import get_template
 from django.urls import reverse
 from django.utils.functional import cached_property
 from django.utils.text import capfirst
+from django.utils.translation import gettext as _
 
 from wagtail.admin.ui.components import Component
 from wagtail.coreutils import multigetattr
@@ -197,10 +198,35 @@ class StatusTagColumn(Column):
         return context
 
 
+class LiveStatusTagColumn(StatusTagColumn):
+    """Represents a live/draft status tag"""
+
+    def __init__(self, **kwargs):
+        super().__init__(
+            "status_string",
+            label=kwargs.pop("label", _("Status")),
+            sort_key=kwargs.pop("sort_key", "live"),
+            primary=lambda instance: instance.live,
+            **kwargs,
+        )
+
+
 class DateColumn(Column):
     """Outputs a date in human-readable format"""
 
     cell_template_name = "wagtailadmin/tables/date_cell.html"
+
+
+class UpdatedAtColumn(DateColumn):
+    """Outputs the _updated_at date annotation in human-readable format"""
+
+    def __init__(self, **kwargs):
+        super().__init__(
+            "_updated_at",
+            label=kwargs.pop("label", _("Updated")),
+            sort_key=kwargs.pop("sort_key", "_updated_at"),
+            **kwargs,
+        )
 
 
 class UserColumn(Column):

--- a/wagtail/snippets/views/chooser.py
+++ b/wagtail/snippets/views/chooser.py
@@ -1,6 +1,6 @@
 from django.utils.translation import gettext_lazy as _
 
-from wagtail.admin.ui.tables import StatusTagColumn
+from wagtail.admin.ui.tables import LiveStatusTagColumn
 from wagtail.admin.views.generic.chooser import (
     BaseChooseView,
     ChooseResultsViewMixin,
@@ -27,13 +27,7 @@ class BaseSnippetChooseView(BaseChooseView):
     def columns(self):
         columns = super().columns
         if issubclass(self.model, DraftStateMixin):
-            columns += [
-                StatusTagColumn(
-                    "status_string",
-                    label=_("Status"),
-                    primary=lambda instance: instance.live,
-                ),
-            ]
+            columns += [LiveStatusTagColumn(sort_key=None)]
         return columns
 
     def get_context_data(self, **kwargs):

--- a/wagtail/test/snippets/models.py
+++ b/wagtail/test/snippets/models.py
@@ -80,6 +80,12 @@ class FilterableSnippet(index.Indexed, models.Model):
     def __str__(self):
         return self.text
 
+    def get_foo_country_code(self):
+        return f"Foo {self.country_code}"
+
+    get_foo_country_code.admin_order_field = "country_code"
+    get_foo_country_code.short_description = "Custom foo column"
+
 
 class FilterableSnippetFilterSet(WagtailFilterSet):
     class Meta:

--- a/wagtail/test/snippets/views.py
+++ b/wagtail/test/snippets/views.py
@@ -1,6 +1,8 @@
+from wagtail.admin.ui.tables import UpdatedAtColumn
 from wagtail.snippets.views.snippets import SnippetViewSet
 from wagtail.test.snippets.models import FilterableSnippetFilterSet
 
 
 class FilterableSnippetViewSet(SnippetViewSet):
     filterset_class = FilterableSnippetFilterSet
+    list_display = ["text", "country_code", "get_foo_country_code", UpdatedAtColumn()]


### PR DESCRIPTION
This PR adds support for customising the columns on the snippet listing view. This can be done by defining a `list_display` on the `SnippetViewSet` (or `IndexView`) that is a list or tuple that contains any of:
- Name of a field on the model
- Name of a method/property on the model
- An instance of the `Column` class

<!--
Thanks for contributing to Wagtail! 🎉

Before submitting, please review the [contributor guidelines](https://docs.wagtail.org/en/latest/contributing/index.html).
-->

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
