### PR TITLE
Applied new design for delete buttons

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -17,9 +17,11 @@ Changelog
  * Add unit tests for the `classnames` Wagtail admin template tag (Mehrdad Moradizadeh)
  * Show an inverse locked indicator when the page has been locked by the current user in reports and dashboard listings (Vaibhav Shukla, LB (Ben Johnston))
  * Add clarity to the development documentation that `admonition` should not be used and titles for `note` are not supported, including clean up of some existing incorrect usage (LB (Ben Johnston))
+ * Unify the styling of delete/destructive button styles across the admin interface (Paarth Agarwal)
  * Fix: Prevent `PageQuerySet.not_public` from returning all pages when no page restrictions exist (Mehrdad Moradizadeh)
  * Fix: Ensure that duplicate block ids are unique when duplicating stream blocks in the page editor (Joshua Munn)
  * Fix: Revise colour usage so that privacy & locked indicators can be seen in Windows High Contrast mode (LB (Ben Johnston))
+ * Fix: Ensure that disabled buttons have a consistent presentation on hover to indicate no interaction is available (Paarth Agarwal)
 
 
 4.0.2 (xx.xx.xxxx) - IN DEVELOPMENT

--- a/client/scss/components/_button.scss
+++ b/client/scss/components/_button.scss
@@ -79,14 +79,9 @@
 
   &.no,
   &.serious {
-    background-color: $color-button-no;
-    border-color: $color-button-no;
-
-    &.button-secondary {
-      border-color: $color-button-no;
-      color: $color-button-no;
-      background-color: transparent;
-    }
+    background-color: $color-white;
+    border: 1px solid $color-button-no;
+    color: $color-button-no;
 
     &:hover {
       color: $color-white;
@@ -253,6 +248,13 @@
     border-color: $color-grey-3;
     color: $color-grey-2;
     cursor: default;
+
+    &:hover {
+      background-color: $color-grey-3;
+      border-color: $color-grey-3;
+      color: $color-grey-2;
+      cursor: default;
+    }
 
     @media (forced-colors: active) {
       color: GrayText;

--- a/client/scss/components/_button.scss
+++ b/client/scss/components/_button.scss
@@ -38,6 +38,12 @@
     line-height: calc(2em - 2px); // account for border
   }
 
+  &.button--icon {
+    .icon {
+      @include svg-icon(1.5em);
+    }
+  }
+
   &.button-secondary {
     color: $color-button;
     background-color: transparent;

--- a/client/scss/components/_listing.scss
+++ b/client/scss/components/_listing.scss
@@ -263,17 +263,6 @@ ul.listing {
     border-color: $color-grey-4;
     background: $color-white;
 
-    &.no {
-      // Override `background-color: transparent;` from _buttons.scss
-      background: $color-white;
-
-      &:hover {
-        border-color: $color-button-no;
-        background-color: $color-button-no;
-        color: $color-white;
-      }
-    }
-
     &:hover {
       border-color: $color-teal;
       background-color: $color-teal;

--- a/client/src/components/CommentApp/components/Comment/index.tsx
+++ b/client/src/components/CommentApp/components/Comment/index.tsx
@@ -418,7 +418,7 @@ export default class CommentComponent extends React.Component<CommentProps> {
           </button>
           <button
             type="button"
-            className="comment__button comment__button--primary"
+            className="comment__button button button-small no"
             onClick={onClickDelete}
           >
             {gettext('Delete')}

--- a/docs/releases/4.1.md
+++ b/docs/releases/4.1.md
@@ -26,16 +26,22 @@ Wagtail 4.1 is designated a Long Term Support (LTS) release. Long Term Support r
  * Add unit tests for the `classnames` Wagtail admin template tag (Mehrdad Moradizadeh)
  * Show an inverse locked indicator when the page has been locked by the current user in reports and dashboard listings (Vaibhav Shukla, LB (Ben Johnston))
  * Add clarity to the development documentation that `admonition` should not be used and titles for `note` are not supported, including clean up of some existing incorrect usage (LB (Ben Johnston))
+ * Unify the styling of delete/destructive button styles across the admin interface (Paarth Agarwal)
 
 ### Bug fixes
 
  * Prevent `PageQuerySet.not_public` from returning all pages when no page restrictions exist (Mehrdad Moradizadeh)
  * Ensure that duplicate block ids are unique when duplicating stream blocks in the page editor (Joshua Munn)
  * Revise colour usage so that privacy & locked indicators can be seen in Windows High Contrast mode (LB (Ben Johnston))
+ * Ensure that disabled buttons have a consistent presentation on hover to indicate no interaction is available (Paarth Agarwal)
 
 ## Upgrade considerations
 
 ### Button styling class changes
+
+When adding custom buttons using the `ModelAdmin` `ButtonHelper` class, custom buttons will no longer include the `button-secondary` class by default in index listings.
+
+If using the hook `register_user_listing_buttons` to register buttons along with the undocumented `UserListingButton` class, the `button-secondary` class will no longer be included by default.
 
 The following button classes have been removed:
 

--- a/wagtail/admin/templates/wagtailadmin/generic/edit.html
+++ b/wagtail/admin/templates/wagtailadmin/generic/edit.html
@@ -4,6 +4,6 @@
 {% block actions %}
     <input type="submit" value="{% trans 'Save' %}" class="button" />
     {% if delete_url %}
-        <a href="{{ delete_url }}" class="button button-secondary no">{{ delete_item_label }}</a>
+        <a href="{{ delete_url }}" class="button no">{{ delete_item_label }}</a>
     {% endif %}
 {% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/generic/multiple_upload/edit_form.html
+++ b/wagtail/admin/templates/wagtailadmin/generic/multiple_upload/edit_form.html
@@ -14,7 +14,7 @@
         {% endfor %}
         <li>
             <button type="submit" class="button button-longrunning">{% icon name="spinner" %}{% trans 'Update' %}</button>
-            <a href="{{ delete_action }}" class="delete button button-secondary no">{% trans "Delete" %}</a>
+            <a href="{{ delete_action }}" class="delete button no">{% trans "Delete" %}</a>
         </li>
     </ul>
 </form>

--- a/wagtail/admin/templates/wagtailadmin/home/pages_for_moderation.html
+++ b/wagtail/admin/templates/wagtailadmin/home/pages_for_moderation.html
@@ -49,7 +49,7 @@
                                 <li class="no-border">
                                     <form action="{% url 'wagtailadmin_pages:reject_moderation' revision.id %}" method="POST">
                                         {% csrf_token %}
-                                        <input type="submit" class="button button-small button-secondary no" value="{% trans 'Reject' %}">
+                                        <input type="submit" class="button button-small no" value="{% trans 'Reject' %}">
                                     </form>
                                 </li>
                                 {% if page_perms.can_edit %}

--- a/wagtail/admin/templates/wagtailadmin/pages/confirm_workflow_cancellation.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/confirm_workflow_cancellation.html
@@ -17,5 +17,5 @@
     <p>{% trans 'Publishing this page will cancel the current workflow.' %}</p>
     <p>{% trans 'Would you still like to publish this page?' %}</p>
     <button type="submit" class="button" data-confirm-cancellation>{% trans 'Publish' %}</button>
-    <button type="submit" class="button button-secondary no" data-cancel-dialog>{% trans 'Cancel' %}</button>
+    <button type="submit" class="button no" data-cancel-dialog>{% trans 'Cancel' %}</button>
 </div>

--- a/wagtail/admin/templates/wagtailadmin/permissions/includes/collection_member_permissions_form.html
+++ b/wagtail/admin/templates/wagtailadmin/permissions/includes/collection_member_permissions_form.html
@@ -13,5 +13,5 @@
 {% endfor %}
 
 <td>
-    <button class="button button-secondary button-small no" type="button" id="{{ form.DELETE.id_for_label }}-button">{% trans "Delete" %}</button>
+    <button class="button button-small no" type="button" id="{{ form.DELETE.id_for_label }}-button">{% trans "Delete" %}</button>
 </td>

--- a/wagtail/admin/templates/wagtailadmin/workflows/includes/workflow_pages_form.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/includes/workflow_pages_form.html
@@ -5,5 +5,5 @@
 </td>
 
 <td>
-    <button class="button button-secondary button-small no" type="button" id="{{ form.DELETE.id_for_label }}-button">{% trans "Delete" %}</button>
+    <button class="button button-small no" type="button" id="{{ form.DELETE.id_for_label }}-button">{% trans "Delete" %}</button>
 </td>

--- a/wagtail/contrib/modeladmin/helpers/button.py
+++ b/wagtail/contrib/modeladmin/helpers/button.py
@@ -7,8 +7,8 @@ class ButtonHelper:
 
     default_button_classnames = ["button"]
     add_button_classnames = ["bicolor", "icon", "icon-plus"]
-    inspect_button_classnames = []
-    edit_button_classnames = []
+    inspect_button_classnames = ["button-secondary"]
+    edit_button_classnames = ["button-secondary"]
     delete_button_classnames = ["no"]
 
     def __init__(self, view, request):

--- a/wagtail/contrib/modeladmin/views.py
+++ b/wagtail/contrib/modeladmin/views.py
@@ -406,7 +406,7 @@ class IndexView(SpreadsheetExportMixin, WMABaseView):
 
     def get_buttons_for_obj(self, obj):
         return self.button_helper.get_buttons_for_obj(
-            obj, classnames_add=["button-small", "button-secondary"]
+            obj, classnames_add=["button-small"]
         )
 
     def get_search_results(self, request, queryset, search_term):

--- a/wagtail/contrib/redirects/templates/wagtailredirects/edit.html
+++ b/wagtail/contrib/redirects/templates/wagtailredirects/edit.html
@@ -18,7 +18,7 @@
             <li>
                 <input type="submit" value="{% trans 'Save' %}" class="button" />
                 {% if user_can_delete %}
-                    <a href="{% url 'wagtailredirects:delete' redirect.id %}" class="button button-secondary no">{% trans "Delete redirect" %}</a>
+                    <a href="{% url 'wagtailredirects:delete' redirect.id %}" class="button no">{% trans "Delete redirect" %}</a>
                 {% endif %}
             </li>
         </ul>

--- a/wagtail/contrib/search_promotions/templates/wagtailsearchpromotions/edit.html
+++ b/wagtail/contrib/search_promotions/templates/wagtailsearchpromotions/edit.html
@@ -17,7 +17,7 @@
             </li>
             <li>
                 <input type="submit" value="{% trans 'Save' %}" class="button" />
-                <a href="{% url 'wagtailsearchpromotions:delete' query.id %}" class="button button-secondary no">{% trans "Delete" %}</a>
+                <a href="{% url 'wagtailsearchpromotions:delete' query.id %}" class="button no">{% trans "Delete" %}</a>
             </li>
         </ul>
     </form>

--- a/wagtail/contrib/styleguide/templates/wagtailstyleguide/base.html
+++ b/wagtail/contrib/styleguide/templates/wagtailstyleguide/base.html
@@ -514,7 +514,7 @@
                             {% include "wagtailadmin/shared/field_as_li.html" %}
                         {% endif %}
                     {% endfor %}
-                    <li><button type="submit" class="button">{% trans 'Save' %}</button><a href="#" class="button button-secondary no">{% trans "Delete image" %}</a></li>
+                    <li><button type="submit" class="button">{% trans 'Save' %}</button><a href="#" class="button no">{% trans "Delete image" %}</a></li>
                 </ul>
             </form>
         </section>

--- a/wagtail/documents/templates/wagtaildocs/documents/edit.html
+++ b/wagtail/documents/templates/wagtaildocs/documents/edit.html
@@ -47,7 +47,7 @@
                     <li>
                         <input type="submit" value="{% trans 'Save' %}" class="button" />
                         {% if user_can_delete %}
-                            <a href="{% url 'wagtaildocs:delete' document.id %}{% if next %}?next={{ next|urlencode }}{% endif %}" class="button button-secondary no">{% trans "Delete document" %}</a>
+                            <a href="{% url 'wagtaildocs:delete' document.id %}{% if next %}?next={{ next|urlencode }}{% endif %}" class="button no">{% trans "Delete document" %}</a>
                         {% endif %}
                     </li>
                 </ul>

--- a/wagtail/images/templates/wagtailimages/images/confirm_duplicate_upload.html
+++ b/wagtail/images/templates/wagtailimages/images/confirm_duplicate_upload.html
@@ -9,7 +9,7 @@
         <button class="button button-longrunning confirm-upload">{% icon name="spinner" %}{% trans 'Keep new image' %}</button>
         <form method="POST">
             {% csrf_token %}
-            <a href="{{ delete_action }}" class="delete button button-secondary no">{% trans "Delete new image" %}</a>
+            <a href="{{ delete_action }}" class="delete button no">{% trans "Delete new image" %}</a>
         </form>
     </div>
 </div>

--- a/wagtail/images/templates/wagtailimages/images/edit.html
+++ b/wagtail/images/templates/wagtailimages/images/edit.html
@@ -49,7 +49,7 @@
                 <div class="w-hidden sm:w-block">
                     <input type="submit" value="{% trans 'Save' %}" class="button" />
                     {% if user_can_delete %}
-                        <a href="{% url 'wagtailimages:delete' image.id %}{% if next %}?next={{ next|urlencode }}{% endif %}" class="button button-secondary no">{% trans "Delete image" %}</a>
+                        <a href="{% url 'wagtailimages:delete' image.id %}{% if next %}?next={{ next|urlencode }}{% endif %}" class="button no">{% trans "Delete image" %}</a>
                     {% endif %}
                 </div>
             </div>
@@ -108,7 +108,7 @@
             <div class="col5">
                 <input type="submit" value="{% trans 'Save' %}" class="button" />
                 {% if user_can_delete %}
-                    <a href="{% url 'wagtailimages:delete' image.id %}{% if next %}?next={{ next }}{% endif %}" class="button button-secondary no">{% trans "Delete image" %}</a>
+                    <a href="{% url 'wagtailimages:delete' image.id %}{% if next %}?next={{ next }}{% endif %}" class="button no">{% trans "Delete image" %}</a>
                 {% endif %}
             </div>
         </div>

--- a/wagtail/users/templates/wagtailusers/groups/edit.html
+++ b/wagtail/users/templates/wagtailusers/groups/edit.html
@@ -41,7 +41,7 @@
                     <input type="submit" value="{% trans 'Save' %}" class="button" />
 
                     {% if perms.auth.delete_group %}
-                        <a href="{% url 'wagtailusers_groups:delete' group.id %}" class="button button-secondary no">{% trans "Delete group" %}</a>
+                        <a href="{% url 'wagtailusers_groups:delete' group.id %}" class="button no">{% trans "Delete group" %}</a>
                     {% endif %}
                 </div>
             </div>

--- a/wagtail/users/templates/wagtailusers/groups/includes/page_permissions_form.html
+++ b/wagtail/users/templates/wagtailusers/groups/includes/page_permissions_form.html
@@ -10,5 +10,5 @@
 {% endfor %}
 
 <td>
-    <button class="button button-secondary button-small no" type="button" id="{{ form.DELETE.id_for_label }}-button">{% trans "Delete" %}</button>
+    <button class="button button-small no" type="button" id="{{ form.DELETE.id_for_label }}-button">{% trans "Delete" %}</button>
 </td>

--- a/wagtail/users/templates/wagtailusers/users/edit.html
+++ b/wagtail/users/templates/wagtailusers/users/edit.html
@@ -51,7 +51,7 @@
                         <li>
                             <input type="submit" value="{% trans 'Save' %}" class="button"/>
                             {% if can_delete %}
-                                <a href="{% url 'wagtailusers_users:delete' user.pk %}" class="button button-secondary no">{% trans "Delete user" %}</a>
+                                <a href="{% url 'wagtailusers_users:delete' user.pk %}" class="button no">{% trans "Delete user" %}</a>
                             {% endif %}
                         </li>
                     </ul>
@@ -72,7 +72,7 @@
                         <li>
                             <input type="submit" value="{% trans 'Save' %}" class="button"/>
                             {% if can_delete %}
-                                <a href="{% url 'wagtailusers_users:delete' user.pk %}" class="button button-secondary no">{% trans "Delete user" %}</a>
+                                <a href="{% url 'wagtailusers_users:delete' user.pk %}" class="button no">{% trans "Delete user" %}</a>
                             {% endif %}
                         </li>
                     </ul>

--- a/wagtail/users/wagtail_hooks.py
+++ b/wagtail/users/wagtail_hooks.py
@@ -139,6 +139,7 @@ def user_listing_buttons(context, user):
     yield UserListingButton(
         _("Edit"),
         reverse("wagtailusers_users:edit", args=[user.pk]),
+        classes={"button-secondary"},
         attrs={"title": _("Edit this user")},
         priority=10,
     )

--- a/wagtail/users/widgets.py
+++ b/wagtail/users/widgets.py
@@ -3,5 +3,5 @@ from wagtail.admin.widgets import Button
 
 class UserListingButton(Button):
     def __init__(self, label, url, classes=set(), **kwargs):
-        classes = {"button", "button-small", "button-secondary"} | set(classes)
+        classes = {"button", "button-small"} | set(classes)
         super().__init__(label, url, classes=classes, **kwargs)


### PR DESCRIPTION
Fixes #3823.
I'm putting a PR fixing these inconsistencies:
Normal and hover state
![Screenshot from 2022-09-07 00-25-06](https://user-images.githubusercontent.com/86092410/188716260-c93621f7-84cf-4aa0-b358-c2418a21b156.png)

Delete image button after the fix:
![Screenshot from 2022-09-07 00-08-18](https://user-images.githubusercontent.com/86092410/188715927-e15194fa-bd3d-4177-86cf-59c5043fa60c.png)

Delete user button after the fix:
![Screenshot from 2022-09-07 00-08-53](https://user-images.githubusercontent.com/86092410/188715978-5aae8ed9-de49-4ec0-91a3-feca3a80c7cc.png)

Delete button in listings:
![Screenshot from 2022-09-07 00-28-48](https://user-images.githubusercontent.com/86092410/188716921-8dbdd302-462d-4347-84c7-9634c64a129e.png)

The delete button in listings is supposed to be like that and has styles over-ridding button.scss. Let me know if I should remove it to match our new designs. 

**69th PR**