### PR TITLE
Documentation - clarify that preview_modes=[] will disable preview

### DIFF
--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -249,6 +249,8 @@ WAGTAIL_AUTO_UPDATE_PREVIEW = True
 When enabled, the preview panel in the page editor is automatically updated on each change. If set to `False`, a refresh button will be shown and the preview is only updated when the button is clicked.
 This behaviour is enabled by default.
 
+To completely disable the preview panel, set [preview modes](wagtail.models.Page.preview_modes) to be empty on your model `preview_modes = []`.
+
 ### `WAGTAIL_AUTO_UPDATE_PREVIEW_INTERVAL`
 
 ```python

--- a/wagtail/models/__init__.py
+++ b/wagtail/models/__init__.py
@@ -700,7 +700,7 @@ class PreviewableMixin:
         will only have one display mode, but subclasses can override this -
         for example, a page containing a form might have a default view of the form,
         and a post-submission 'thank you' page.
-        Set to `[]` to completely disable previewing for this model.
+        Set to ``[]`` to completely disable previewing for this model.
         """
         return PreviewableMixin.DEFAULT_PREVIEW_MODES
 

--- a/wagtail/models/__init__.py
+++ b/wagtail/models/__init__.py
@@ -700,6 +700,7 @@ class PreviewableMixin:
         will only have one display mode, but subclasses can override this -
         for example, a page containing a form might have a default view of the form,
         and a post-submission 'thank you' page.
+        Set to `[]` to completely disable previewing for this model.
         """
         return PreviewableMixin.DEFAULT_PREVIEW_MODES
 


### PR DESCRIPTION
* For headless usage of Wagtail, the preview panel may not make sense or even function at all.
* With 4.0 introducing the preview panel, the DOM will load an iframe of the preview on first load, even if `WAGTAIL_AUTO_UPDATE_PREVIEW` is set to false (loads the first time).
* Wagtail has supported the ability to disable previews on a per model basis for some time, but it is not super clear in the docs, this PR adds a bit of clarity.
* See https://wagtailcms.slack.com/archives/C81FGJR2S/p1662528472449859
* Adding as a 4.0.2 milestone as this is a small docs change but will be useful for those using headless