### PR TITLE
Fix for chooser modals with no tabs (layout & JS console error). Fix #9130

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -35,6 +35,8 @@ Changelog
  * Fix: Ensure tag autocompletion dropdown has a solid background (LB (Ben) Johnston)
  * Fix: Allow inline panels to be ordered (LB (Ben) Johnston)
  * Fix: Only show draft / live status tags on snippets that have `DraftStateMixin` applied (Sage Abdullah)
+ * Fix: Prevent JS error when initialising chooser modals with no tabs (LB (Ben) Johnston)
+ * Fix: Add missing vertical spacing between chooser modal header and body when there are no tabs (LB (Ben) Johnston)
 
 
 4.0.1 (05.09.2022)

--- a/docs/releases/4.0.2.md
+++ b/docs/releases/4.0.2.md
@@ -19,3 +19,5 @@ depth: 1
  * Ensure tag autocompletion dropdown has a solid background (LB (Ben) Johnston)
  * Allow inline panels to be ordered (LB (Ben) Johnston)
  * Only show draft / live status tags on snippets that have `DraftStateMixin` applied (Sage Abdullah)
+ * Prevent JS error when initialising chooser modals with no tabs (LB (Ben) Johnston)
+ * Add missing vertical spacing between chooser modal header and body when there are no tabs (LB (Ben) Johnston)

--- a/wagtail/admin/templates/wagtailadmin/generic/chooser/chooser.html
+++ b/wagtail/admin/templates/wagtailadmin/generic/chooser/chooser.html
@@ -1,12 +1,13 @@
 {% load i18n wagtailadmin_tags %}
-{% include "wagtailadmin/shared/header.html" with title=page_title subtitle=page_subtitle merged=1 icon=header_icon %}
+{% include "wagtailadmin/shared/header.html" with title=page_title merged=1 subtitle=page_subtitle icon=header_icon %}
 
 {% if creation_form %}
     {{ creation_form.media.js }}
     {{ creation_form.media.css }}
 {% endif %}
 
-<div class="w-tabs" data-tabs data-tabs-disable-url>
+{% comment %} Do not attach JavaScript behaviour (data-tabs) below if there are no actual tabs used {% endcomment %}
+<div class="w-tabs" {% if creation_form %}data-tabs data-tabs-disable-url{% endif %}>
     {% if creation_form %}
         <div class="w-tabs__wrapper w-overflow-hidden">
             <div role="tablist" class="w-tabs__list w-w-full">
@@ -14,6 +15,9 @@
                 {% include 'wagtailadmin/shared/tabs/tab_nav_link.html' with tab_id=view.creation_tab_id title=creation_tab_label %}
             </div>
         </div>
+    {% else %}
+        {% comment %} Ensure layout still works as expected (gap under header from tabs wrapper) even if no tabs used {% endcomment %}
+        <div class="w-tabs__wrapper"></div>
     {% endif %}
 
     <div class="tab-content">


### PR DESCRIPTION
- Fixes https://github.com/wagtail/wagtail/issues/9130
- Also fixes the console error for single (non nav) tabs usage in the basic chooser modal


**Firefox 104** 

<img width="952" alt="Screen Shot 2022-09-07 at 4 32 23 pm" src="https://user-images.githubusercontent.com/1396140/188805399-35e0f138-0be9-49b3-b6d6-b45176ebed84.png">

**Safari 15.4**

![Screen Shot 2022-09-07 at 4 33 15 pm](https://user-images.githubusercontent.com/1396140/188805585-50aa2e42-034a-4f4e-ad99-fdafe3658074.png)

**Chrome 106**

<img width="1458" alt="Screen Shot 2022-09-07 at 4 34 03 pm" src="https://user-images.githubusercontent.com/1396140/188805743-293bcc71-83f8-430e-bed8-eb9339333a3a.png">
