### PR TITLE
Fixed FilterFieldError in image search

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -38,6 +38,7 @@ Changelog
  * Fix: Prevent JS error when initialising chooser modals with no tabs (LB (Ben) Johnston)
  * Fix: Add missing vertical spacing between chooser modal header and body when there are no tabs (LB (Ben) Johnston)
  * Fix: Reinstate specific labels for chooser buttons (for example 'Choose another page', 'Edit this page' not 'Change', 'Edit') so that it is clearer for users and non-English translations (Matt Westcott)
+ * Fix: Resolve issue where searches with a tag and a query param in the image listing would result in an `FilterFieldError` (Stefan Hammer)
 
 
 4.0.1 (05.09.2022)

--- a/docs/releases/4.0.2.md
+++ b/docs/releases/4.0.2.md
@@ -22,3 +22,4 @@ depth: 1
  * Prevent JS error when initialising chooser modals with no tabs (LB (Ben) Johnston)
  * Add missing vertical spacing between chooser modal header and body when there are no tabs (LB (Ben) Johnston)
  * Reinstate specific labels for chooser buttons (for example 'Choose another page', 'Edit this page' not 'Change', 'Edit') so that it is clearer for users and non-English translations (Matt Westcott)
+ * Resolve issue where searches with a tag and a query param in the image listing would result in an `FilterFieldError` (Stefan Hammer)

--- a/wagtail/images/tests/test_admin_views.py
+++ b/wagtail/images/tests/test_admin_views.py
@@ -279,6 +279,29 @@ class TestImageIndexView(TestCase, WagtailTestUtils):
             "?p=3&amp;tag=even" in response_body or "?tag=even&amp;p=3" in response_body
         )
 
+    def test_tag_filtering_with_search_term(self):
+        Image.objects.create(
+            title="Test image with no tags",
+            file=get_test_image_file(),
+        )
+
+        image_one_tag = Image.objects.create(
+            title="Test image with one tag",
+            file=get_test_image_file(),
+        )
+        image_one_tag.tags.add("one")
+
+        image_two_tags = Image.objects.create(
+            title="Test image with two tags",
+            file=get_test_image_file(),
+        )
+        image_two_tags.tags.add("one", "two")
+
+        # The tag gets ignored, if a valid search term is present, so this will find all
+        # images, as all of them contain "test" in their titles.
+        response = self.get({"tag": "one", "q": "test"})
+        self.assertEqual(response.context["images"].paginator.count, 3)
+
     def test_search_form_rendered(self):
         response = self.get()
         html = response.content.decode()

--- a/wagtail/images/views/images.py
+++ b/wagtail/images/views/images.py
@@ -96,14 +96,6 @@ class BaseListingView(TemplateView):
             except (ValueError, Collection.DoesNotExist):
                 pass
 
-        # Filter by tag
-        self.current_tag = self.request.GET.get("tag")
-        if self.current_tag:
-            try:
-                images = images.filter(tags__name=self.current_tag)
-            except (AttributeError):
-                self.current_tag = None
-
         # Search
         query_string = None
         if "q" in self.request.GET:
@@ -114,6 +106,14 @@ class BaseListingView(TemplateView):
                 images = images.search(query_string)
         else:
             self.form = SearchForm(placeholder=_("Search images"))
+
+        # Filter by tag
+        self.current_tag = self.request.GET.get("tag")
+        if self.current_tag:
+            try:
+                images = images.filter(tags__name=self.current_tag)
+            except (AttributeError):
+                self.current_tag = None
 
         entries_per_page = self.get_num_entries_per_page()
         paginator = Paginator(images, per_page=entries_per_page)


### PR DESCRIPTION
Also added test for the use case of a combined search request.

fixes #9160

This implements the suggested quick-fix mentioned in https://github.com/wagtail/wagtail/issues/9160#issuecomment-1239218350

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
