### PR TITLE
Add documentation for register_user_listing_buttons hook

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -14,6 +14,7 @@ Changelog
  * Mention the importance of passing `request` and `current_site` to `get_url` on the [performance](performance) documentation page (Jake Howard)
  * Run Python tests with coverage and upload coverage data to codecov (Sage Abdullah)
  * Clean up duplicate JavaScript for the `escapeHtml` function (Jordan Rob)
+ * Add documentation for `register_user_listing_buttons` hook (LB (Ben Johnston))
  * Fix: Make sure workflow timeline icons are visible in high-contrast mode (Loveth Omokaro)
  * Fix: Ensure authentication forms (login, password reset) have a visible border in Windows high-contrast mode (Loveth Omokaro)
  * Fix: Ensure visual consistency between buttons and links as buttons in Windows high-contrast mode (Albina Starykova)

--- a/docs/reference/hooks.md
+++ b/docs/reference/hooks.md
@@ -379,6 +379,24 @@ Return a QuerySet of `Permission` objects to be shown in the Groups administrati
       ])
 ```
 
+(register_user_listing_buttons)=
+
+### `register_user_listing_buttons`
+
+Add buttons to the user list. This example will add a simple button to the listing:
+
+```python
+from wagtail.users.widgets import UserListingButton
+
+@hooks.register("register_user_listing_buttons")
+def user_listing_external_profile(context, user):
+    yield UserListingButton(
+        "Show profile",
+        f"/goes/to/a/url/{user.pk}",
+        priority=30,
+    )
+```
+
 (filter_form_submissions_for_user)=
 
 ### `filter_form_submissions_for_user`

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -24,6 +24,7 @@ depth: 1
  * Mention the importance of passing `request` and `current_site` to `get_url` on the [performance](performance) documentation page (Jake Howard)
  * Run Python tests with coverage and upload coverage data to codecov (Sage Abdullah)
  * Clean up duplicate JavaScript for the `escapeHtml` function (Jordan Rob)
+ * Add documentation for [`register_user_listing_buttons`](register_user_listing_buttons) hook (LB (Ben Johnston))
 
 ### Bug fixes
 


### PR DESCRIPTION
* Add documentation for `register_user_listing_buttons` hook, it appears to have been in the code base for some time (Wagtail 1.6) - 14919f3b41da8d089c870975bcd0364af6176d59
* Found this while validating some delete button scenarios for https://github.com/wagtail/wagtail/pull/9153
* I do not see a reason we would not want to document this feature - seems pretty handy
* I intentionally did not document the usage of `UserListingButton` as it seemed like we may remove this one day as it is just a thin wrapper around `widgets.Button`.