### PR TITLE
Applied new designs to secondary buttons

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -18,6 +18,7 @@ Changelog
  * Show an inverse locked indicator when the page has been locked by the current user in reports and dashboard listings (Vaibhav Shukla, LB (Ben Johnston))
  * Add clarity to the development documentation that `admonition` should not be used and titles for `note` are not supported, including clean up of some existing incorrect usage (LB (Ben Johnston))
  * Unify the styling of delete/destructive button styles across the admin interface (Paarth Agarwal)
+ * Adopt new designs and unify the styling styles for `.button-secondary` buttons across the admin interface (Paarth Agarwal)
  * Fix: Prevent `PageQuerySet.not_public` from returning all pages when no page restrictions exist (Mehrdad Moradizadeh)
  * Fix: Ensure that duplicate block ids are unique when duplicating stream blocks in the page editor (Joshua Munn)
  * Fix: Revise colour usage so that privacy & locked indicators can be seen in Windows High Contrast mode (LB (Ben Johnston))

--- a/client/scss/components/_button.scss
+++ b/client/scss/components/_button.scss
@@ -47,6 +47,12 @@
   &.button-secondary {
     color: $color-button;
     background-color: transparent;
+
+    &:hover {
+      background-color: theme('colors.secondary.50');
+      border-color: currentColor;
+      color: $color-button;
+    }
   }
 
   &.warning {
@@ -66,6 +72,7 @@
     }
   }
 
+  // no/serious is not compatible with the button-secondary class
   &.no,
   &.serious {
     background-color: $color-white;

--- a/client/scss/components/_header.scss
+++ b/client/scss/components/_header.scss
@@ -88,20 +88,6 @@
     padding-bottom: 0;
   }
 
-  .button {
-    background-color: $color-teal-darker;
-
-    &:hover {
-      color: $color-white;
-      background-color: $color-teal-dark;
-    }
-  }
-
-  .button-secondary {
-    color: $color-teal-darker;
-    background-color: transparent;
-  }
-
   .error-message {
     color: inherit;
   }

--- a/client/scss/components/_listing.scss
+++ b/client/scss/components/_listing.scss
@@ -259,21 +259,6 @@ ul.listing {
     }
   }
 
-  .button-secondary {
-    border-color: $color-grey-4;
-    background: $color-white;
-
-    &:hover {
-      border-color: $color-teal;
-      background-color: $color-teal;
-    }
-  }
-
-  // stylelint-disable-next-line no-duplicate-selectors
-  .button-secondary {
-    background-color: $color-white;
-  }
-
   .moderate-actions form {
     float: left;
     margin: 0 1em 1em 0;

--- a/client/scss/components/_messages.scss
+++ b/client/scss/components/_messages.scss
@@ -37,8 +37,22 @@
     height: 1.5em;
   }
 
+  .button.button-secondary {
+    border-color: currentColor;
+    color: inherit;
+
+    &:hover {
+      background-color: transparent;
+      color: $color-white;
+    }
+  }
+
   .error {
     background-color: theme('colors.critical.200');
+
+    .button:hover {
+      color: $color-grey-1;
+    }
   }
 
   .warning {
@@ -48,19 +62,9 @@
 
   .success {
     background-color: theme('colors.positive.100');
-  }
 
-  .success .button:hover {
-    background-color: $color-teal-dark;
-  }
-
-  .button-secondary {
-    border-color: currentColor;
-    color: inherit;
-
-    &:hover {
-      border-color: transparent;
-      color: $color-white;
+    .button:hover {
+      background-color: $color-teal-dark;
     }
   }
 

--- a/docs/releases/4.1.md
+++ b/docs/releases/4.1.md
@@ -27,6 +27,7 @@ Wagtail 4.1 is designated a Long Term Support (LTS) release. Long Term Support r
  * Show an inverse locked indicator when the page has been locked by the current user in reports and dashboard listings (Vaibhav Shukla, LB (Ben Johnston))
  * Add clarity to the development documentation that `admonition` should not be used and titles for `note` are not supported, including clean up of some existing incorrect usage (LB (Ben Johnston))
  * Unify the styling of delete/destructive button styles across the admin interface (Paarth Agarwal)
+ * Adopt new designs and unify the styling styles for `.button-secondary` buttons across the admin interface (Paarth Agarwal)
 
 ### Bug fixes
 
@@ -38,6 +39,8 @@ Wagtail 4.1 is designated a Long Term Support (LTS) release. Long Term Support r
 ## Upgrade considerations
 
 ### Button styling class changes
+
+The `button-secondary` class is no longer compatible with either the `.serious` or `.no` classes, this partially worked previously but is no longer officially supported.
 
 When adding custom buttons using the `ModelAdmin` `ButtonHelper` class, custom buttons will no longer include the `button-secondary` class by default in index listings.
 

--- a/wagtail/admin/templates/wagtailadmin/shared/button.stories.tsx
+++ b/wagtail/admin/templates/wagtailadmin/shared/button.stories.tsx
@@ -177,6 +177,10 @@ const Template = ({ url }) => (
     <h4>
       Negative <small>(small)</small>
     </h4>
+    <p>
+      Should not be used with <code>.button-secondary</code> on the same
+      element.
+    </p>
     <a href={url} className="button button-small no">
       No
     </a>

--- a/wagtail/contrib/styleguide/templates/wagtailstyleguide/base.html
+++ b/wagtail/contrib/styleguide/templates/wagtailstyleguide/base.html
@@ -260,6 +260,7 @@
             <button class="button button-small text-replace button--icon" type="button">{% icon name="cog" %}button element</button>
 
             <h3>Negative</h3>
+            <p>Should not be used with <code>.button-secondary</code> on the same element.</p>
 
             <a href="#" class="button no">No link</a>
             <button class="button no" type="button">No button</button>


### PR DESCRIPTION
Addresses #8790.
Applied new designs to secondary buttons and removed unnecessary style duplication for header buttons and for page listings.
After:
![Screenshot from 2022-09-08 14-20-02](https://user-images.githubusercontent.com/86092410/189080139-85ddfcc2-b41d-443b-b042-b8c3efd894f4.png)
![Screenshot from 2022-09-08 14-20-46](https://user-images.githubusercontent.com/86092410/189080148-8b9dcb9b-9c60-4bdb-a87b-56e871c9dac9.png)
 
