### PR TITLE
Add a toggle to collapse/expand all page panels at once. Fix #9152

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -23,6 +23,7 @@ Changelog
  * Update expanding formset add buttons to use `button` not link for behaviour (LB (Ben) Johnston)
  * Add robust unit testing for authentication scenarios across the user management admin pages (Mehrdad Moradizadeh)
  * Avoid assuming an integer PK named 'id' on multiple upload views (Matt Westcott)
+ * Add a toggle to collapse/expand all page panels at once (Helen Chapman)
  * Fix: Prevent `PageQuerySet.not_public` from returning all pages when no page restrictions exist (Mehrdad Moradizadeh)
  * Fix: Ensure that duplicate block ids are unique when duplicating stream blocks in the page editor (Joshua Munn)
  * Fix: Revise colour usage so that privacy & locked indicators can be seen in Windows High Contrast mode (LB (Ben Johnston))

--- a/client/src/entrypoints/admin/wagtailadmin.js
+++ b/client/src/entrypoints/admin/wagtailadmin.js
@@ -9,6 +9,7 @@ import initSidePanel from '../../includes/sidePanel';
 import {
   initAnchoredPanels,
   initCollapsiblePanels,
+  initCollapseAllPanels,
 } from '../../includes/panels';
 
 if (process.env.NODE_ENV === 'development') {
@@ -38,6 +39,7 @@ document.addEventListener('DOMContentLoaded', () => {
   initCollapsibleBreadcrumbs();
   initSidePanel();
   initCollapsiblePanels();
+  initCollapseAllPanels();
 });
 
 /**

--- a/docs/releases/4.1.md
+++ b/docs/releases/4.1.md
@@ -32,6 +32,7 @@ Wagtail 4.1 is designated a Long Term Support (LTS) release. Long Term Support r
  * Update expanding formset add buttons to use `button` not link for behaviour and remove support for disabled as a class (LB (Ben) Johnston)
  * Add robust unit testing for authentication scenarios across the user management admin pages (Mehrdad Moradizadeh)
  * Avoid assuming an integer PK named 'id' on multiple upload views (Matt Westcott)
+ * Add a toggle to collapse/expand all page panels at once (Helen Chapman)
 
 ### Bug fixes
 

--- a/wagtail/admin/templates/wagtailadmin/pages/create.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/create.html
@@ -14,6 +14,10 @@
 
     <form id="page-edit-form" action="{% url 'wagtailadmin_pages:add' content_type.app_label content_type.model parent_page.id %}" method="POST" novalidate{% if form.is_multipart %} enctype="multipart/form-data"{% endif %} data-edit-form>
         {% csrf_token %}
+
+        {# Note that the position of the button within the form allows the js to collapse / expand only those panels within the same form #}
+        {% include "wagtailadmin/shared/collapse_all_toggle.html" %}
+
         <input type="hidden" name="next" value="{{ next }}">
 
         {% if parent_page.is_root %}

--- a/wagtail/admin/templates/wagtailadmin/pages/edit.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/edit.html
@@ -15,8 +15,12 @@
     </div>
 
     {% block form %}
+
         <form id="page-edit-form" action="{% url 'wagtailadmin_pages:edit' page.id %}" method="POST" novalidate{% if form.is_multipart %} enctype="multipart/form-data"{% endif %} data-edit-form>
             {% csrf_token %}
+
+            {# Note that the position of the button within the form allows the js to collapse / expand only those panels within the same form #}
+            {% include "wagtailadmin/shared/collapse_all_toggle.html" %}
 
             <input type="hidden" name="next" value="{{ next }}">
             {{ edit_handler.render_form_content }}

--- a/wagtail/admin/templates/wagtailadmin/shared/collapse_all_toggle.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/collapse_all_toggle.html
@@ -1,0 +1,13 @@
+{% load i18n %}
+
+<button
+    type="button"
+    {# Temporary styles pending addition of the minimap component. #}
+    class="button button-small button-secondary w-absolute w-right-0 w-m-4"
+    data-all-panels-toggle
+    data-expand-text="{% trans 'Expand all' %}"
+    data-collapse-text="{% trans 'Collapse all' %}"
+    aria-expanded="true"
+>
+    {% trans "Collapse all" %}
+</button>


### PR DESCRIPTION
See https://github.com/wagtail/wagtail/issues/9152

<!--
Thanks for contributing to Wagtail! 🎉

Before submitting, please review the [contributor guidelines](https://docs.wagtail.org/en/latest/contributing/index.html).
-->

_Please check the following:_

-   [ ] Do the tests still pass?[^1]
-   [ ] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
