### PR TITLE
Applied new designs to disabled buttons

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -19,6 +19,7 @@ Changelog
  * Add clarity to the development documentation that `admonition` should not be used and titles for `note` are not supported, including clean up of some existing incorrect usage (LB (Ben Johnston))
  * Unify the styling of delete/destructive button styles across the admin interface (Paarth Agarwal)
  * Adopt new designs and unify the styling styles for `.button-secondary` buttons across the admin interface (Paarth Agarwal)
+ * Refine designs for disabled buttons throughout the admin interface (Paarth Agarwal)
  * Fix: Prevent `PageQuerySet.not_public` from returning all pages when no page restrictions exist (Mehrdad Moradizadeh)
  * Fix: Ensure that duplicate block ids are unique when duplicating stream blocks in the page editor (Joshua Munn)
  * Fix: Revise colour usage so that privacy & locked indicators can be seen in Windows High Contrast mode (LB (Ben Johnston))

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -20,6 +20,7 @@ Changelog
  * Unify the styling of delete/destructive button styles across the admin interface (Paarth Agarwal)
  * Adopt new designs and unify the styling styles for `.button-secondary` buttons across the admin interface (Paarth Agarwal)
  * Refine designs for disabled buttons throughout the admin interface (Paarth Agarwal)
+ * Update expanding formset add buttons to use `button` not link for behaviour (LB (Ben) Johnston)
  * Fix: Prevent `PageQuerySet.not_public` from returning all pages when no page restrictions exist (Mehrdad Moradizadeh)
  * Fix: Ensure that duplicate block ids are unique when duplicating stream blocks in the page editor (Joshua Munn)
  * Fix: Revise colour usage so that privacy & locked indicators can be seen in Windows High Contrast mode (LB (Ben Johnston))

--- a/client/scss/components/_button.scss
+++ b/client/scss/components/_button.scss
@@ -242,13 +242,14 @@
   &.disabled {
     background-color: $color-grey-3;
     border-color: $color-grey-3;
-    color: $color-grey-2;
+    color: $color-white;
     cursor: default;
+    pointer-events: none;
 
     &:hover {
       background-color: $color-grey-3;
       border-color: $color-grey-3;
-      color: $color-grey-2;
+      color: $color-white;
       cursor: default;
     }
 
@@ -263,7 +264,7 @@
   &.button-secondary[disabled],
   &.button-secondary.disabled {
     background-color: $color-white;
-    border-color: $color-grey-3;
+    border-color: $color-grey-4;
     color: $color-grey-3;
   }
 

--- a/client/src/entrypoints/admin/expanding-formset.js
+++ b/client/src/entrypoints/admin/expanding-formset.js
@@ -21,9 +21,7 @@ function buildExpandingFormset(prefix, opts = {}) {
     emptyFormTemplate = emptyFormTemplate.textContent;
   }
 
-  // eslint-disable-next-line consistent-return
   addButton.on('click', () => {
-    if (addButton.hasClass('disabled')) return false;
     const newFormHtml = emptyFormTemplate
       .replace(/__prefix__(.*?['"])/g, formCount + '$1')
       .replace(/<-(-*)\/script>/g, '<$1/script>');

--- a/client/src/entrypoints/admin/expanding-formset.test.js
+++ b/client/src/entrypoints/admin/expanding-formset.test.js
@@ -106,7 +106,7 @@ describe('buildExpandingFormset', () => {
         `,
         )}
       </ul>
-      <button class="button disabled" id="${prefix}-ADD" type="button">
+      <button class="button" id="${prefix}-ADD" type="button" disabled>
         Add form fields (DISABLED)
       </button>
       <script type="text/django-form-template" id="${prefix}-EMPTY_FORM_TEMPLATE">
@@ -137,9 +137,7 @@ describe('buildExpandingFormset', () => {
     expect(onInit).toHaveBeenNthCalledWith(2, 1);
 
     // click the 'add' button
-    document
-      .getElementById(`${prefix}-ADD`)
-      .dispatchEvent(new MouseEvent('click'));
+    document.getElementById(`${prefix}-ADD`).click();
 
     // check that no template was generated and additional onInit / onAdd not called
     expect(onAdd).not.toHaveBeenCalled();

--- a/docs/releases/4.1.md
+++ b/docs/releases/4.1.md
@@ -29,6 +29,7 @@ Wagtail 4.1 is designated a Long Term Support (LTS) release. Long Term Support r
  * Unify the styling of delete/destructive button styles across the admin interface (Paarth Agarwal)
  * Adopt new designs and unify the styling styles for `.button-secondary` buttons across the admin interface (Paarth Agarwal)
  * Refine designs for disabled buttons throughout the admin interface (Paarth Agarwal)
+ * Update expanding formset add buttons to use `button` not link for behaviour and remove support for disabled as a class (LB (Ben) Johnston)
 
 ### Bug fixes
 
@@ -48,6 +49,8 @@ When adding custom buttons using the `ModelAdmin` `ButtonHelper` class, custom b
 If using the hook `register_user_listing_buttons` to register buttons along with the undocumented `UserListingButton` class, the `button-secondary` class will no longer be included by default.
 
 Avoid using `disabled` as a class on `button` elements, instead use the [`disabled` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/disabled) as support for this as a class may be removed in a future version of Wagtail and is not accessible.
+
+If using custom `expanding-formset` the add button will no longer support the `disabled` class but instead must require the `disabled` attribute to be set.
 
 The following button classes have been removed, none of which were being used within the admin but may have been used by custom code or packages:
 

--- a/docs/releases/4.1.md
+++ b/docs/releases/4.1.md
@@ -28,6 +28,7 @@ Wagtail 4.1 is designated a Long Term Support (LTS) release. Long Term Support r
  * Add clarity to the development documentation that `admonition` should not be used and titles for `note` are not supported, including clean up of some existing incorrect usage (LB (Ben Johnston))
  * Unify the styling of delete/destructive button styles across the admin interface (Paarth Agarwal)
  * Adopt new designs and unify the styling styles for `.button-secondary` buttons across the admin interface (Paarth Agarwal)
+ * Refine designs for disabled buttons throughout the admin interface (Paarth Agarwal)
 
 ### Bug fixes
 
@@ -45,6 +46,8 @@ The `button-secondary` class is no longer compatible with either the `.serious` 
 When adding custom buttons using the `ModelAdmin` `ButtonHelper` class, custom buttons will no longer include the `button-secondary` class by default in index listings.
 
 If using the hook `register_user_listing_buttons` to register buttons along with the undocumented `UserListingButton` class, the `button-secondary` class will no longer be included by default.
+
+Avoid using `disabled` as a class on `button` elements, instead use the [`disabled` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/disabled) as support for this as a class may be removed in a future version of Wagtail and is not accessible.
 
 The following button classes have been removed, none of which were being used within the admin but may have been used by custom code or packages:
 

--- a/wagtail/admin/templates/wagtailadmin/permissions/includes/collection_member_permissions_formset.html
+++ b/wagtail/admin/templates/wagtailadmin/permissions/includes/collection_member_permissions_formset.html
@@ -54,7 +54,7 @@
     </script>
 
     <p class="add">
-        <a class="button bicolor button--icon" id="id_{{ formset.prefix }}-ADD" value="Add">{% icon name="plus" wrapped=1 %}{% block add_button_label %}{% endblock %}</a>
+        <button class="button bicolor button--icon" id="id_{{ formset.prefix }}-ADD" value="Add" type="button">{% icon name="plus" wrapped=1 %}{% block add_button_label %}{% endblock %}</button>
     </p>
 
     <script>

--- a/wagtail/admin/templates/wagtailadmin/shared/button.stories.tsx
+++ b/wagtail/admin/templates/wagtailadmin/shared/button.stories.tsx
@@ -45,6 +45,12 @@ const Template = ({ url }) => (
     </button>
 
     <h3>Disabled buttons</h3>
+    <p>
+      <strong>Important</strong>: Adding <code>disabled</code> as a class should
+      be avoided on buttons, instead use the disabled attribute. Some examples
+      below use classes to validate existing styling still works.
+    </p>
+
     <a href={url} className="button disabled">
       button link
     </a>

--- a/wagtail/admin/templates/wagtailadmin/workflows/includes/workflow_pages_formset.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/includes/workflow_pages_formset.html
@@ -48,7 +48,7 @@
 </script>
 
 <p class="add">
-    <a class="button bicolor icon icon-plus" id="id_{{ formset.prefix }}-ADD" value="Add">{% trans "Assign to another page" %}</a>
+    <button class="button bicolor icon icon-plus" id="id_{{ formset.prefix }}-ADD" value="Add" type="button">{% trans "Assign to another page" %}</button>
 </p>
 
 

--- a/wagtail/contrib/styleguide/templates/wagtailstyleguide/base.html
+++ b/wagtail/contrib/styleguide/templates/wagtailstyleguide/base.html
@@ -225,6 +225,7 @@
             <button class="button button-small button-secondary" type="button">button element</button>
 
             <h3>Disabled buttons</h3>
+            <p><strong>Important</strong>: Adding <code>disabled</code> as a class should be avoided on buttons, instead use the disabled attribute. Some examples below use classes to validate existing styling still works.</p>
 
             <a href="#" class="button disabled">button link</a>
             <button class="button disabled" type="button">button element</button>

--- a/wagtail/users/templates/wagtailusers/groups/includes/page_permissions_formset.html
+++ b/wagtail/users/templates/wagtailusers/groups/includes/page_permissions_formset.html
@@ -53,7 +53,7 @@
     </script>
 
     <p class="add">
-        <a class="button bicolor button--icon" id="id_{{ formset.prefix }}-ADD" value="Add">{% icon name="plus" wrapped=1 %}{% trans "Add a page permission" %}</a>
+        <button class="button bicolor button--icon" id="id_{{ formset.prefix }}-ADD" value="Add" type="button">{% icon name="plus" wrapped=1 %}{% trans "Add a page permission" %}</button>
     </p>
 
 {% endpanel %}


### PR DESCRIPTION
Addresses #8790.
Applied new designs to disabled buttons.
Before:

![Screenshot from 2022-09-08 14-41-01](https://user-images.githubusercontent.com/86092410/189083581-50333882-ffb1-4262-af48-68a568d84544.png)

After:

![Screenshot from 2022-09-08 14-49-00](https://user-images.githubusercontent.com/86092410/189085328-510a5085-77e0-4295-8ac4-2c9528f52a8a.png)


