### PR TITLE
Show draft/live status tags on snippet history only if `DraftStateMixin` is applied

### DIFF
--- a/wagtail/snippets/templates/wagtailsnippets/snippets/revisions/_actions.html
+++ b/wagtail/snippets/templates/wagtailsnippets/snippets/revisions/_actions.html
@@ -4,8 +4,10 @@
     {% if revision_enabled and instance.revision %}
         {% with revision=instance.revision latest_revision=object.get_latest_revision previous_revision=instance.revision.get_previous %}
             <span>{{ value }}</span>
-            {% if instance.action == 'wagtail.publish' and revision == object.live_revision %}<span class="status-tag primary">{% trans 'Live version' %}</span>
-            {% elif instance.content_changed and revision == latest_revision %}<span class="status-tag primary">{% trans 'Current draft' %}</span>{% endif %}
+            {% if draftstate_enabled %}
+                {% if instance.action == 'wagtail.publish' and revision == object.live_revision %}<span class="status-tag primary">{% trans 'Live version' %}</span>
+                {% elif instance.content_changed and revision == latest_revision %}<span class="status-tag primary">{% trans 'Current draft' %}</span>{% endif %}
+            {% endif %}
             <ul class="actions">
                 {% if preview_enabled and object.is_previewable %}
                     <li><a href="{% url view.revisions_view_url_name object.pk|admin_urlquote revision.pk %}" class="button button-small button-secondary" target="_blank" rel="noreferrer">{% trans 'Preview' %}</a></li>

--- a/wagtail/snippets/views/snippets.py
+++ b/wagtail/snippets/views/snippets.py
@@ -582,6 +582,7 @@ class ActionColumn(Column):
     def get_cell_context_data(self, instance, parent_context):
         context = super().get_cell_context_data(instance, parent_context)
         context["revision_enabled"] = isinstance(self.object, RevisionMixin)
+        context["draftstate_enabled"] = isinstance(self.object, DraftStateMixin)
         context["preview_enabled"] = isinstance(self.object, PreviewableMixin)
         context["object"] = self.object
         context["view"] = self.view


### PR DESCRIPTION
Fixes #9175.

<!--
Thanks for contributing to Wagtail! 🎉

Before submitting, please review the [contributor guidelines](https://docs.wagtail.org/en/latest/contributing/index.html).
-->

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?


[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
