### PR TITLE
docs: Fix a few typos

### DIFF
--- a/wagtail/contrib/modeladmin/options.py
+++ b/wagtail/contrib/modeladmin/options.py
@@ -337,7 +337,7 @@ class ModelAdmin(WagtailRegisterable):
     def get_extra_attrs_for_row(self, obj, context):
         """
         Return a dictionary of HTML attributes to be added to the `<tr>`
-        element for the suppled `obj` when rendering the results table in
+        element for the supplied `obj` when rendering the results table in
         `index_view`. `data-object-pk` is already added by default.
         """
         return {}

--- a/wagtail/models/__init__.py
+++ b/wagtail/models/__init__.py
@@ -2435,7 +2435,7 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
         obj.depth = self.depth
         obj.numchild = self.numchild
 
-        # Update url_path to reflect potential slug changes, but maintining the page's
+        # Update url_path to reflect potential slug changes, but maintaining the page's
         # existing tree position
         obj.set_url_path(self.get_parent())
 


### PR DESCRIPTION
There are small typos in:
- wagtail/contrib/modeladmin/options.py
- wagtail/models/__init__.py

Fixes:
- Should read `supplied` rather than `suppled`.
- Should read `maintaining` rather than `maintining`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md