### PR TITLE
Make report titles sentence case consistently

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -26,6 +26,7 @@ Changelog
  * Fix: Ensure that duplicate block ids are unique when duplicating stream blocks in the page editor (Joshua Munn)
  * Fix: Revise colour usage so that privacy & locked indicators can be seen in Windows High Contrast mode (LB (Ben Johnston))
  * Fix: Ensure that disabled buttons have a consistent presentation on hover to indicate no interaction is available (Paarth Agarwal)
+ * Fix: Update the 'Locked pages' report menu title so that it is consistent with other pages reports and its own title on viewing (Nicholas Johnson)
 
 
 4.0.2 (xx.xx.xxxx) - IN DEVELOPMENT
@@ -48,7 +49,7 @@ Changelog
 4.0.1 (05.09.2022)
 ~~~~~~~~~~~~~~~~~~
 
- * Fix: On the Locked Pages report, limit the "locked by" filter to just users who have locked pages (Stefan Hammer)
+ * Fix: On the Locked pages report, limit the "locked by" filter to just users who have locked pages (Stefan Hammer)
  * Fix: Prevent JavaScript error when using StreamField on views without commenting support, such as snippets (Jacob Topp-Mugglestone)
  * Fix: Modify base template for new projects so that links opened from the preview panel open in a new window (Sage Abdullah)
  * Fix: Prevent circular import error between custom document models and document chooser blocks (Matt Westcott)
@@ -242,7 +243,7 @@ Changelog
 3.0.3 (05.09.2022)
 ~~~~~~~~~~~~~~~~~~
 
- * Fix: On the Locked Pages report, limit the "locked by" filter to just users who have locked pages (Stefan Hammer)
+ * Fix: On the Locked pages report, limit the "locked by" filter to just users who have locked pages (Stefan Hammer)
  * Fix: Prevent JavaScript error when using StreamField on views without commenting support, such as snippets (Jacob Topp-Mugglestone)
 
 
@@ -355,7 +356,7 @@ Changelog
 ~~~~~~~~~~~~~~~~~~~
 
  * Fix: Ensure the upgrade notification request for the latest release, which can be disabled via the `WAGTAIL_ENABLE_UPDATE_CHECK` sends the referrer origin with `strict-origin-when-cross-origin` (Karl Hobley)
- * Fix: On the Locked Pages report, limit the "locked by" filter to just users who have locked pages (Stefan Hammer)
+ * Fix: On the Locked pages report, limit the "locked by" filter to just users who have locked pages (Stefan Hammer)
  * Fix: Ensure Python 3.10 compatibility when using Elasticsearch backend (Przemysław Buczkowski, Matt Westcott)
 
 
@@ -449,7 +450,7 @@ Changelog
 ~~~~~~~~~~~~~~~~~~~
 
  * Fix: Ensure the upgrade notification request for the latest release, which can be disabled via the `WAGTAIL_ENABLE_UPDATE_CHECK` sends the referrer origin with `strict-origin-when-cross-origin` (Karl Hobley)
- * Fix: On the Locked Pages report, limit the "locked by" filter to just users who have locked pages (Stefan Hammer)
+ * Fix: On the Locked pages report, limit the "locked by" filter to just users who have locked pages (Stefan Hammer)
  * Fix: Ensure Python 3.10 compatibility when using Elasticsearch backend (Przemysław Buczkowski, Matt Westcott)
 
 

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -624,6 +624,7 @@ Contributors
 * Adam Johnson
 * Josh Thomas
 * Christophe Bastin
+* Nicholas Johnson
 
 
 Translators

--- a/client/src/components/Sidebar/Sidebar.stories.tsx
+++ b/client/src/components/Sidebar/Sidebar.stories.tsx
@@ -68,7 +68,7 @@ function bogStandardMenuModule(): MainMenuModuleDefinition {
         [
           new LinkMenuItemDefinition({
             name: 'locked-pages',
-            label: 'Locked Pages',
+            label: 'Locked pages',
             url: '/admin/reports/locked/',
             icon_name: 'lock',
             classnames: '',
@@ -404,7 +404,7 @@ function arabicMenuModule(): MainMenuModuleDefinition {
         [
           new LinkMenuItemDefinition({
             name: 'locked-pages',
-            label: 'Locked Pages',
+            label: 'Locked pages',
             url: '/admin/reports/locked/',
             icon_name: 'lock',
             classnames: '',

--- a/docs/extending/adding_reports.md
+++ b/docs/extending/adding_reports.md
@@ -1,7 +1,7 @@
 # Adding reports
 
 Reports are views with listings of pages matching a specific query. They can also export these listings in spreadsheet format.
-They are found in the _Reports_ submenu: by default, the _Locked Pages_ report is provided, allowing an overview of locked pages on the site.
+They are found in the _Reports_ submenu: by default, the _Locked pages_ report is provided, allowing an overview of locked pages on the site.
 
 It is possible to create your own custom reports in the Wagtail admin. Two base classes are provided:
 `wagtail.admin.views.reports.ReportView`, which provides basic listing and spreadsheet export functionality, and

--- a/docs/releases/2.15.6.rst
+++ b/docs/releases/2.15.6.rst
@@ -16,5 +16,5 @@ Bug fixes
 ~~~~~~~~~
 
  * Ensure the upgrade notification request for the latest release, which can be disabled via the ``WAGTAIL_ENABLE_UPDATE_CHECK`` sends the referrer origin with ``strict-origin-when-cross-origin`` (Karl Hobley)
- * On the Locked Pages report, limit the "locked by" filter to just users who have locked pages (Stefan Hammer)
+ * On the Locked pages report, limit the "locked by" filter to just users who have locked pages (Stefan Hammer)
  * Ensure Python 3.10 compatibility when using Elasticsearch backend (Przemysław Buczkowski, Matt Westcott)

--- a/docs/releases/2.16.3.md
+++ b/docs/releases/2.16.3.md
@@ -13,5 +13,5 @@ _September 5, 2022_
 ### Bug fixes
 
  * Ensure the upgrade notification request for the latest release, which can be disabled via the `WAGTAIL_ENABLE_UPDATE_CHECK` sends the referrer origin with `strict-origin-when-cross-origin` (Karl Hobley)
- * On the Locked Pages report, limit the "locked by" filter to just users who have locked pages (Stefan Hammer)
+ * On the Locked pages report, limit the "locked by" filter to just users who have locked pages (Stefan Hammer)
  * Ensure Python 3.10 compatibility when using Elasticsearch backend (Przemysław Buczkowski, Matt Westcott)

--- a/docs/releases/3.0.3.md
+++ b/docs/releases/3.0.3.md
@@ -13,5 +13,5 @@ depth: 1
 
 ### Bug fixes
 
- * On the Locked Pages report, limit the "locked by" filter to just users who have locked pages (Stefan Hammer
+ * On the Locked pages report, limit the "locked by" filter to just users who have locked pages (Stefan Hammer
  * Prevent JavaScript error when using StreamField on views without commenting support, such as snippets (Jacob Topp-Mugglestone)

--- a/docs/releases/4.0.1.md
+++ b/docs/releases/4.0.1.md
@@ -13,7 +13,7 @@ depth: 1
 
 ### Bug fixes
 
- * On the Locked Pages report, limit the "locked by" filter to just users who have locked pages (Stefan Hammer)
+ * On the Locked pages report, limit the "locked by" filter to just users who have locked pages (Stefan Hammer)
  * Prevent JavaScript error when using StreamField on views without commenting support, such as snippets (Jacob Topp-Mugglestone)
  * Modify base template for new projects so that links opened from the preview panel open in a new window (Sage Abdullah)
  * Prevent circular import error between custom document models and document chooser blocks (Matt Westcott)

--- a/docs/releases/4.1.md
+++ b/docs/releases/4.1.md
@@ -38,6 +38,7 @@ Wagtail 4.1 is designated a Long Term Support (LTS) release. Long Term Support r
  * Ensure that duplicate block ids are unique when duplicating stream blocks in the page editor (Joshua Munn)
  * Revise colour usage so that privacy & locked indicators can be seen in Windows High Contrast mode (LB (Ben Johnston))
  * Ensure that disabled buttons have a consistent presentation on hover to indicate no interaction is available (Paarth Agarwal)
+ * Update the 'Locked pages' report menu title so that it is consistent with other pages reports and its own title on viewing (Nicholas Johnson)
 
 ## Upgrade considerations
 

--- a/wagtail/admin/wagtail_hooks.py
+++ b/wagtail/admin/wagtail_hooks.py
@@ -937,7 +937,7 @@ class AgingPagesReportMenuItem(MenuItem):
 @hooks.register("register_reports_menu_item")
 def register_locked_pages_menu_item():
     return LockedPagesMenuItem(
-        _("Locked Pages"),
+        _("Locked pages"),
         reverse("wagtailadmin_reports:locked_pages"),
         icon_name="lock",
         order=700,


### PR DESCRIPTION
Most report menu items ("Aging pages", "Site history", "Workflow tasks") are sentence case, with "Locked Pages" being the outlier in title case. This change makes all menu items consistently sentence case in the reports menu.

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [x] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [x] **Please list the exact browser and operating system versions you tested**:
    -   [x] **Please list which assistive technologies [^3] you tested**:
-   [x] For new features: Has the documentation been updated accordingly?

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)