### PR TITLE
Add missing vertical space between header and content in embed chooser modal. Fix #9182

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -39,6 +39,7 @@ Changelog
  * Fix: Add missing vertical spacing between chooser modal header and body when there are no tabs (LB (Ben) Johnston)
  * Fix: Reinstate specific labels for chooser buttons (for example 'Choose another page', 'Edit this page' not 'Change', 'Edit') so that it is clearer for users and non-English translations (Matt Westcott)
  * Fix: Resolve issue where searches with a tag and a query param in the image listing would result in an `FilterFieldError` (Stefan Hammer)
+ * Fix: Add missing vertical space between header and content in embed chooser modal (LB (Ben) Johnston)
 
 
 4.0.1 (05.09.2022)

--- a/docs/releases/4.0.2.md
+++ b/docs/releases/4.0.2.md
@@ -23,3 +23,4 @@ depth: 1
  * Add missing vertical spacing between chooser modal header and body when there are no tabs (LB (Ben) Johnston)
  * Reinstate specific labels for chooser buttons (for example 'Choose another page', 'Edit this page' not 'Change', 'Edit') so that it is clearer for users and non-English translations (Matt Westcott)
  * Resolve issue where searches with a tag and a query param in the image listing would result in an `FilterFieldError` (Stefan Hammer)
+ * Add missing vertical space between header and content in embed chooser modal (LB (Ben) Johnston)

--- a/wagtail/embeds/templates/wagtailembeds/chooser/chooser.html
+++ b/wagtail/embeds/templates/wagtailembeds/chooser/chooser.html
@@ -1,7 +1,7 @@
 {% load wagtailimages_tags wagtailadmin_tags %}
 {% load i18n %}
 {% trans "Insert embed" as ins_emb_str %}
-{% include "wagtailadmin/shared/header.html" with title=ins_emb_str merged=1 %}
+{% include "wagtailadmin/shared/header.html" with title=ins_emb_str %}
 
 <div class="tab-content">
     <section id="form" class="active nice-padding">


### PR DESCRIPTION
- Fixes #9182
- No tabs used here so no need to used the merged variant of the header
- [X] Do the tests still pass?
- [X] Does the code comply with the style guide?
- [X] For front-end changes: Did you test on all of Wagtail’s supported environments? Firefox 104, Chrome 106, Safari 15

### Screenshots

<img width="801" alt="Screen Shot 2022-09-13 at 6 13 33 am" src="https://user-images.githubusercontent.com/1396140/189750088-643527b3-8726-4562-8c9a-fc3b5e802a92.png">

<img width="1078" alt="Screen Shot 2022-09-13 at 6 12 41 am" src="https://user-images.githubusercontent.com/1396140/189750140-2284b4c3-e14d-4faa-8183-6791221d5ab8.png">

<img width="1877" alt="Screen Shot 2022-09-13 at 6 13 04 am" src="https://user-images.githubusercontent.com/1396140/189750119-2d987499-932f-4b48-8c3c-47b66f84e6c1.png">

