### PR TITLE
Adding security tests for User Management

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -21,6 +21,7 @@ Changelog
  * Adopt new designs and unify the styling styles for `.button-secondary` buttons across the admin interface (Paarth Agarwal)
  * Refine designs for disabled buttons throughout the admin interface (Paarth Agarwal)
  * Update expanding formset add buttons to use `button` not link for behaviour (LB (Ben) Johnston)
+ * Add robust unit testing for authentication scenarios across the user management admin pages (Mehrdad Moradizadeh)
  * Fix: Prevent `PageQuerySet.not_public` from returning all pages when no page restrictions exist (Mehrdad Moradizadeh)
  * Fix: Ensure that duplicate block ids are unique when duplicating stream blocks in the page editor (Joshua Munn)
  * Fix: Revise colour usage so that privacy & locked indicators can be seen in Windows High Contrast mode (LB (Ben Johnston))

--- a/docs/releases/4.1.md
+++ b/docs/releases/4.1.md
@@ -30,6 +30,7 @@ Wagtail 4.1 is designated a Long Term Support (LTS) release. Long Term Support r
  * Adopt new designs and unify the styling styles for `.button-secondary` buttons across the admin interface (Paarth Agarwal)
  * Refine designs for disabled buttons throughout the admin interface (Paarth Agarwal)
  * Update expanding formset add buttons to use `button` not link for behaviour and remove support for disabled as a class (LB (Ben) Johnston)
+ * Add robust unit testing for authentication scenarios across the user management admin pages (Mehrdad Moradizadeh)
 
 ### Bug fixes
 

--- a/wagtail/admin/tests/pages/test_view_draft.py
+++ b/wagtail/admin/tests/pages/test_view_draft.py
@@ -48,7 +48,7 @@ class TestDraftAccess(TestCase, WagtailTestUtils):
         # User can view
         self.assertEqual(response.status_code, 200)
 
-    def test_page_without_preview_modes_is_unauthorized(self):
+    def test_page_without_preview_modes_is_unauthorised(self):
         # Login as admin
         self.user = self.login()
 
@@ -57,10 +57,10 @@ class TestDraftAccess(TestCase, WagtailTestUtils):
             reverse("wagtailadmin_pages:view_draft", args=(self.stream_page.id,))
         )
 
-        # Unauthorized response (because this page type has previewing disabled)
+        # Unauthorised response (because this page type has previewing disabled)
         self.assertRedirects(response, "/admin/")
 
-    def test_draft_access_unauthorized(self):
+    def test_draft_access_unauthorised(self):
         """Test that user without edit/publish permission can't view draft."""
         self.login(username="bob", password="password")
 
@@ -72,7 +72,7 @@ class TestDraftAccess(TestCase, WagtailTestUtils):
         # User gets redirected to the home page
         self.assertEqual(response.status_code, 302)
 
-    def test_draft_access_authorized(self):
+    def test_draft_access_authorised(self):
         """Test that user with edit permission can view draft."""
         # give user the permission to edit page
         user = get_user_model().objects.get(email="bob@example.com")


### PR DESCRIPTION
fixes #9142

Writing tests to make sure only authorized users can access the resources in `wagtail.users.views.users.py`.