### PR TITLE
Fixed hover behaviour of Delete button

### DIFF
--- a/client/scss/components/_button.scss
+++ b/client/scss/components/_button.scss
@@ -80,9 +80,9 @@
     color: $color-button-no;
 
     &:hover {
-      color: $color-white;
-      border-color: transparent;
-      background-color: $color-button-no;
+      color: $color-button-no;
+      border-color: $color-button-no;
+      background-color: theme('colors.critical.50');
     }
   }
 


### PR DESCRIPTION
Hover styles were broken for delete buttons.
Before:

![Screenshot from 2022-09-13 17-31-20](https://user-images.githubusercontent.com/86092410/189895669-a2978d77-b865-414b-9b00-21a82070bf6f.png)

After the fix:

![Screenshot from 2022-09-13 17-26-43](https://user-images.githubusercontent.com/86092410/189895277-f4fc47c5-18d6-4501-b817-5bd3fe82aa9a.png)

