### PR TITLE
Revert chooser button labels to "Choose another X"

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -37,6 +37,7 @@ Changelog
  * Fix: Only show draft / live status tags on snippets that have `DraftStateMixin` applied (Sage Abdullah)
  * Fix: Prevent JS error when initialising chooser modals with no tabs (LB (Ben) Johnston)
  * Fix: Add missing vertical spacing between chooser modal header and body when there are no tabs (LB (Ben) Johnston)
+ * Fix: Reinstate specific labels for chooser buttons (for example 'Choose another page', 'Edit this page' not 'Change', 'Edit') so that it is clearer for users and non-English translations (Matt Westcott)
 
 
 4.0.1 (05.09.2022)

--- a/client/src/entrypoints/admin/telepath/__snapshots__/widgets.test.js.snap
+++ b/client/src/entrypoints/admin/telepath/__snapshots__/widgets.test.js.snap
@@ -10,12 +10,12 @@ exports[`telepath: wagtail.widgets.PageChooser it renders correctly 1`] = `
             <ul class=\\"chooser__actions\\">
               <li>
                 <button type=\\"button\\" class=\\"button action-choose button-small button-secondary\\" aria-describedby=\\"the-id-title\\">
-                  Change
+                  Choose another page
                 </button>
               </li>
               <li>
                 <a href=\\"/admin/pages/60/edit/\\" class=\\"edit-link button button-small button-secondary\\" target=\\"_blank\\" rel=\\"noreferrer\\" aria-describedby=\\"the-id-title\\">
-                  Edit
+                  Edit this page
                 </a>
               </li>
             </ul>
@@ -37,12 +37,12 @@ exports[`telepath: wagtail.widgets.PageChooser setState() changes the current pa
             <ul class=\\"chooser__actions\\">
               <li>
                 <button type=\\"button\\" class=\\"button action-choose button-small button-secondary\\" aria-describedby=\\"the-id-title\\">
-                  Change
+                  Choose another page
                 </button>
               </li>
               <li>
                 <a href=\\"/admin/pages/34/edit/\\" class=\\"edit-link button button-small button-secondary\\" target=\\"_blank\\" rel=\\"noreferrer\\" aria-describedby=\\"the-id-title\\">
-                  Edit
+                  Edit this page
                 </a>
               </li>
             </ul>
@@ -64,12 +64,12 @@ exports[`telepath: wagtail.widgets.PageChooser setState() to null clears the fie
             <ul class=\\"chooser__actions\\">
               <li>
                 <button type=\\"button\\" class=\\"button action-choose button-small button-secondary\\" aria-describedby=\\"the-id-title\\">
-                  Change
+                  Choose another page
                 </button>
               </li>
               <li>
                 <a href=\\"/admin/pages/60/edit/\\" class=\\"edit-link button button-small button-secondary\\" target=\\"_blank\\" rel=\\"noreferrer\\" aria-describedby=\\"the-id-title\\">
-                  Edit
+                  Edit this page
                 </a>
               </li>
             </ul>

--- a/client/src/entrypoints/admin/telepath/widgets.test.js
+++ b/client/src/entrypoints/admin/telepath/widgets.test.js
@@ -231,7 +231,7 @@ describe('telepath: wagtail.widgets.PageChooser', () => {
             <ul class="chooser__actions">
               <li>
                 <button type="button" class="button action-choose button-small button-secondary" aria-describedby="__ID__-title">
-                  Change
+                  Choose another page
                 </button>
               </li>
               <li>
@@ -242,7 +242,7 @@ describe('telepath: wagtail.widgets.PageChooser', () => {
                   rel="noreferrer"
                   aria-describedby="__ID__-title"
                 >
-                  Edit
+                  Edit this page
                 </a>
               </li>
             </ul>

--- a/docs/editor_manual/copying_aliasing_existing_pages.md
+++ b/docs/editor_manual/copying_aliasing_existing_pages.md
@@ -28,9 +28,9 @@ For example, let's say you have a page about Brioche in the Breads section. You 
 Here is how to create an alias to an existing page:
 
 -   The first step is the same as it is for [](copying_page_label). When you hover over a page in the {doc}`Explorer page <finding_your_way_around/the_explorer_page>`, click on _More_ and then _Copy_.
--   When you get to the copy page form, you can then choose another page as the parent page. Click the New parent page’s _Change_ button.
+-   When you get to the copy page form, you can then choose another page as the parent page. Click the _Choose another page_ button.
 
-![Clicking the change button during the copy page form in order to change the parent of the copied page.](../_static/images/screen12.7_1_alias_choose_parent_page_button.png)
+![Clicking the "choose another page" button during the copy page form in order to change the parent of the copied page.](../_static/images/screen12.7_1_alias_choose_parent_page_button.png)
 
 -   Select and click on the desired parent page.
 -   Make sure the _Alias_ checkbox is ticked.

--- a/docs/extending/generic_views.md
+++ b/docs/extending/generic_views.md
@@ -63,6 +63,8 @@ class PersonChooserViewSet(ChooserViewSet):
 
     icon = "user"
     choose_one_text = "Choose a person"
+    choose_another_text = "Choose another person"
+    edit_item_text = "Edit this person"
     form_fields = ["first_name", "last_name"]  # fields to show in the "Create" tab
 
 

--- a/docs/releases/4.0.2.md
+++ b/docs/releases/4.0.2.md
@@ -21,3 +21,4 @@ depth: 1
  * Only show draft / live status tags on snippets that have `DraftStateMixin` applied (Sage Abdullah)
  * Prevent JS error when initialising chooser modals with no tabs (LB (Ben) Johnston)
  * Add missing vertical spacing between chooser modal header and body when there are no tabs (LB (Ben) Johnston)
+ * Reinstate specific labels for chooser buttons (for example 'Choose another page', 'Edit this page' not 'Change', 'Edit') so that it is clearer for users and non-English translations (Matt Westcott)

--- a/wagtail/admin/tests/test_edit_handlers.py
+++ b/wagtail/admin/tests/test_edit_handlers.py
@@ -906,7 +906,7 @@ class TestPageChooserPanel(TestCase):
             result,
         )
         self.assertIn(
-            '<a href="/admin/pages/%d/edit/" aria-describedby="id_page-title" class="edit-link button button-small button-secondary" target="_blank" rel="noreferrer">Edit</a>'
+            '<a href="/admin/pages/%d/edit/" aria-describedby="id_page-title" class="edit-link button button-small button-secondary" target="_blank" rel="noreferrer">Edit this page</a>'
             % self.christmas_page.id,
             result,
         )

--- a/wagtail/admin/viewsets/chooser.py
+++ b/wagtail/admin/viewsets/chooser.py
@@ -25,7 +25,7 @@ class ChooserViewSet(ViewSet):
     )  #: Label for the 'choose' button in the chooser widget when choosing an initial item
     page_title = None  #: Title text for the chooser modal (defaults to the same as ``choose_one_text``)`
     choose_another_text = _(
-        "Change"
+        "Choose another"
     )  #: Label for the 'choose' button in the chooser widget, when an item has already been chosen
     edit_item_text = _("Edit")  #: Label for the 'edit' button in the chooser widget
 

--- a/wagtail/admin/widgets/chooser.py
+++ b/wagtail/admin/widgets/chooser.py
@@ -22,9 +22,9 @@ from wagtail.widget_adapters import WidgetAdapter
 
 class AdminChooser(WidgetWithScript, widgets.Input):
     choose_one_text = _("Choose an item")
-    choose_another_text = _("Change")
-    clear_choice_text = _("Clear")
-    link_to_chosen_text = _("Edit")
+    choose_another_text = _("Choose another item")
+    clear_choice_text = _("Clear choice")
+    link_to_chosen_text = _("Edit this item")
     show_edit_link = True
     show_clear_link = True
 
@@ -89,9 +89,9 @@ class AdminChooser(WidgetWithScript, widgets.Input):
 
 class BaseChooser(widgets.Input):
     choose_one_text = _("Choose an item")
-    choose_another_text = _("Change")
-    clear_choice_text = _("Clear")
-    link_to_chosen_text = _("Edit")
+    choose_another_text = _("Choose another item")
+    clear_choice_text = _("Clear choice")
+    link_to_chosen_text = _("Edit this item")
     show_edit_link = True
     show_clear_link = True
     template_name = "wagtailadmin/widgets/chooser.html"
@@ -266,6 +266,8 @@ register(BaseChooserAdapter(), BaseChooser)
 
 class AdminPageChooser(BaseChooser):
     choose_one_text = _("Choose a page")
+    choose_another_text = _("Choose another page")
+    link_to_chosen_text = _("Edit this page")
     display_title_key = "display_title"
     chooser_modal_url_name = "wagtailadmin_choose_page"
     icon = "doc-empty-inverse"

--- a/wagtail/admin/widgets/workflows.py
+++ b/wagtail/admin/widgets/workflows.py
@@ -10,6 +10,8 @@ from wagtail.models import Task
 
 class AdminTaskChooser(BaseChooser):
     choose_one_text = _("Choose a task")
+    choose_another_text = _("Choose another task")
+    link_to_chosen_text = _("Edit this task")
     model = Task
     icon = "thumbtack"
     chooser_modal_url_name = "wagtailadmin_workflows:task_chooser"

--- a/wagtail/documents/views/chooser.py
+++ b/wagtail/documents/views/chooser.py
@@ -202,6 +202,8 @@ class DocumentChooserViewSet(ChooserViewSet):
     choose_one_text = _("Choose a document")
     create_action_label = _("Upload")
     create_action_clicked_label = _("Uploading…")
+    choose_another_text = _("Choose another document")
+    edit_item_text = _("Edit this document")
 
 
 viewset = DocumentChooserViewSet(

--- a/wagtail/images/views/chooser.py
+++ b/wagtail/images/views/chooser.py
@@ -300,6 +300,8 @@ class ImageChooserViewSet(ChooserViewSet):
     choose_one_text = _("Choose an image")
     create_action_label = _("Upload")
     create_action_clicked_label = _("Uploading…")
+    choose_another_text = _("Choose another image")
+    edit_item_text = _("Edit this image")
 
     @property
     def select_format_view(self):

--- a/wagtail/images/widgets.py
+++ b/wagtail/images/widgets.py
@@ -13,6 +13,8 @@ from wagtail.telepath import register
 
 class AdminImageChooser(BaseChooser):
     choose_one_text = _("Choose an image")
+    choose_another_text = _("Change image")
+    link_to_chosen_text = _("Edit this image")
     template_name = "wagtailimages/widgets/image_chooser.html"
     chooser_modal_url_name = "wagtailimages_chooser:choose"
     icon = "image"

--- a/wagtail/sites/forms.py
+++ b/wagtail/sites/forms.py
@@ -10,6 +10,7 @@ class SiteForm(forms.ModelForm):
         super().__init__(*args, **kwargs)
         self.fields["root_page"].widget = AdminPageChooser(
             choose_one_text=_("Choose a root page"),
+            choose_another_text=_("Choose a different root page"),
             show_clear_link=False,
         )
 

--- a/wagtail/snippets/tests/test_snippets.py
+++ b/wagtail/snippets/tests/test_snippets.py
@@ -2074,7 +2074,7 @@ class TestSnippetChooserPanel(TestCase, WagtailTestUtils):
         field_html = self.snippet_chooser_panel.render_html()
         self.assertIn(self.advert_text, field_html)
         self.assertIn("Choose advert", field_html)
-        self.assertIn("Change", field_html)
+        self.assertIn("Choose another advert", field_html)
 
     def test_render_as_empty_field(self):
         test_snippet = SnippetChooserModel()
@@ -2091,7 +2091,7 @@ class TestSnippetChooserPanel(TestCase, WagtailTestUtils):
 
         field_html = snippet_chooser_panel.render_html()
         self.assertIn("Choose advert", field_html)
-        self.assertIn("Change", field_html)
+        self.assertIn("Choose another advert", field_html)
 
     def test_render_js(self):
         self.assertIn(
@@ -3527,7 +3527,7 @@ class TestSnippetChooserPanelWithCustomPrimaryKey(TestCase, WagtailTestUtils):
         field_html = self.snippet_chooser_panel.render_html()
         self.assertIn(self.advert_text, field_html)
         self.assertIn("Choose advert with custom primary key", field_html)
-        self.assertIn("Change", field_html)
+        self.assertIn("Choose another advert with custom primary key", field_html)
 
     def test_render_as_empty_field(self):
         test_snippet = SnippetChooserModelWithCustomPrimaryKey()
@@ -3544,7 +3544,7 @@ class TestSnippetChooserPanelWithCustomPrimaryKey(TestCase, WagtailTestUtils):
 
         field_html = snippet_chooser_panel.render_html()
         self.assertIn("Choose advert with custom primary key", field_html)
-        self.assertIn("Change", field_html)
+        self.assertIn("Choose another advert with custom primary key", field_html)
 
     def test_render_js(self):
         self.assertIn(

--- a/wagtail/snippets/widgets.py
+++ b/wagtail/snippets/widgets.py
@@ -22,6 +22,8 @@ class AdminSnippetChooser(BaseChooser):
         self.model = model
         name = self.model._meta.verbose_name
         self.choose_one_text = _("Choose %s") % name
+        self.choose_another_text = _("Choose another %s") % name
+        self.link_to_chosen_text = _("Edit this %s") % name
 
         super().__init__(**kwargs)
 


### PR DESCRIPTION
Fixes #9113

#8934 changed these labels to "Change", which is too semantically similar to the neighbouring "Edit" button - to the point that some languages used the same translation for both (#9045, #9193).