### PR TITLE
Fix issue with edit page header delete button showing an invalid next URL

### DIFF
--- a/wagtail/admin/wagtail_hooks.py
+++ b/wagtail/admin/wagtail_hooks.py
@@ -295,12 +295,13 @@ def page_listing_more_buttons(page, page_perms, next_url=None):
         )
     if page_perms.can_delete():
         url = reverse("wagtailadmin_pages:delete", args=[page.id])
+        include_next_url = True
 
         # After deleting the page, it is impossible to redirect to it.
         if next_url == reverse("wagtailadmin_explore", args=[page.id]):
-            next_url = None
+            include_next_url = False
 
-        if next_url:
+        if next_url and include_next_url:
             url += "?" + urlencode({"next": next_url})
 
         yield Button(
@@ -402,11 +403,16 @@ def page_header_buttons(page, page_perms, next_url=None):
     if page_perms.can_delete():
         url = reverse("wagtailadmin_pages:delete", args=[page.id])
 
+        include_next_url = True
+
         # After deleting the page, it is impossible to redirect to it.
         if next_url == reverse("wagtailadmin_explore", args=[page.id]):
-            next_url = None
+            include_next_url = False
 
-        if next_url:
+        if next_url == reverse("wagtailadmin_pages:edit", args=[page.id]):
+            include_next_url = False
+
+        if next_url and include_next_url:
             url += "?" + urlencode({"next": next_url})
 
         yield Button(


### PR DESCRIPTION
- Fixes #9195
- Header button on edit page & page listing - unpublish now correctly includes the next url (was missing on page listing previously)
- Header button on edit page - delete button does not include next url (as this would be the edit page for what was deleted).
- Adds more robust unit tests for the page listing & page header more hooks, including splitting the tests out to separate classes (it was not clear which area of the code was being tested).

## How to test 

Details | Screenshot
--- | --- 
**Edit page - header**  <br/> Delete  <br/> No next URL |  <img width="854" alt="Screen Shot 2022-09-14 at 4 30 59 pm" src="https://user-images.githubusercontent.com/1396140/190078104-fe386e06-02ee-4ffc-b895-4bc616313bfc.png">
**Edit page - header**  <br/> Unpublish  <br/> Has next URL | <img width="850" alt="Screen Shot 2022-09-14 at 4 31 09 pm" src="https://user-images.githubusercontent.com/1396140/190078532-d91f46f9-7750-4489-8dc0-5895cd9f85c4.png">
**Page listing - header**  <br/> Delete <br/> No next URL | <img width="855" alt="Screen Shot 2022-09-14 at 4 30 26 pm" src="https://user-images.githubusercontent.com/1396140/190078750-ebe866cb-e8e0-4c50-b67c-b11ce2c9fe41.png">
**Page listing - header**  <br/> Unpublish <br/> Has next URL | <img width="846" alt="Screen Shot 2022-09-14 at 4 30 32 pm" src="https://user-images.githubusercontent.com/1396140/190078817-7bd98c7d-3949-4f2b-9fe6-829a3826a088.png">
**Page listing - more button**  <br/> Delete <br/> Has next URL **to parent** |  <img width="855" alt="Screen Shot 2022-09-14 at 4 30 17 pm" src="https://user-images.githubusercontent.com/1396140/190078986-b303966a-12aa-4902-b7cd-404546688d18.png">

