### PR TITLE
Retain filter params in ModelAdmin's search form

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -29,6 +29,7 @@ Changelog
  * Fix: Ensure that disabled buttons have a consistent presentation on hover to indicate no interaction is available (Paarth Agarwal)
  * Fix: Update the 'Locked pages' report menu title so that it is consistent with other pages reports and its own title on viewing (Nicholas Johnson)
  * Fix: Support `formfield_callback` handling on `ModelForm.Meta` for future Django 4.2 release (Matt Westcott)
+ * Fix: Ensure that `ModelAdmin` correctly supports filters in combination with subsequent searches without clearing the applied filters (Stefan Hammer)
 
 
 4.0.2 (xx.xx.xxxx) - IN DEVELOPMENT

--- a/docs/releases/4.1.md
+++ b/docs/releases/4.1.md
@@ -41,6 +41,7 @@ Wagtail 4.1 is designated a Long Term Support (LTS) release. Long Term Support r
  * Ensure that disabled buttons have a consistent presentation on hover to indicate no interaction is available (Paarth Agarwal)
  * Update the 'Locked pages' report menu title so that it is consistent with other pages reports and its own title on viewing (Nicholas Johnson)
  * Support `formfield_callback` handling on `ModelForm.Meta` for future Django 4.2 release (Matt Westcott)
+ * Ensure that `ModelAdmin` correctly supports filters in combination with subsequent searches without clearing the applied filters (Stefan Hammer)
 
 ## Upgrade considerations
 

--- a/wagtail/contrib/modeladmin/templates/modeladmin/includes/search_form.html
+++ b/wagtail/contrib/modeladmin/templates/modeladmin/includes/search_form.html
@@ -6,5 +6,9 @@
             <input id="id_q" name="{{ search_var }}" value="{{ view.query }}" placeholder="{% blocktrans trimmed with view.verbose_name_plural|lower as name %}Search {{ name }}{% endblocktrans %}" type="text">
         {% endfield %}
         <button type="submit" class="w-sr-only">{% trans 'Search' %}</button>
+        {# Keep all parameters from the query string (e.g. filter state). #}
+        {% for name, value in view.params.items %}
+            {% if name != search_var %}<input type="hidden" name="{{ name }}" value="{{ value }}">{% endif %}
+        {% endfor %}
     </form>
 {% endif %}

--- a/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
+++ b/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
@@ -156,6 +156,13 @@ class TestBookIndexView(TestCase, WagtailTestUtils):
             response, '<span class="result-count">2 out of 4</span>', html=True
         )
 
+        # The search form should retain the filter
+        self.assertContains(
+            response,
+            '<input type="hidden" name="author__id__exact" value="1">',
+            html=True,
+        )
+
         for book in response.context["object_list"]:
             self.assertEqual(book.author_id, 1)
 


### PR DESCRIPTION
This basically uses the same code as django uses for the search form in its ModelAdmin, to retain the current query params (see https://github.com/django/django/blob/8e93fc561e4ead282abe2a12bd6ac393c9d308be/django/contrib/admin/templates/admin/search_form.html#L11-L13).

Fixes #6006

**Testing:**

1. Install the latest bakerydemo
2. Login to admin and go to `/admin/base/people/`
3. Filter by assistant editor, which should only result in one person
4. Now search for "m"

Without the fix, all people with "m" will be searched, since the filter state is now gone.
With the fix, only the single person already filtered should remain in the list.

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
