### PR TITLE
Ensure the Page chooser modal listing uses buttons

### DIFF
--- a/client/scss/components/_listing.scss
+++ b/client/scss/components/_listing.scss
@@ -113,6 +113,7 @@ ul.listing {
     }
 
     tbody .parent-page .title {
+      button,
       a {
         display: inline-block;
       }
@@ -133,6 +134,8 @@ ul.listing {
 
       .title a,
       .title a:hover,
+      .title button,
+      .title button:hover,
       .title label {
         color: $color-white;
       }
@@ -204,11 +207,17 @@ ul.listing {
       @apply w-label-1;
       margin: 0;
 
-      a {
+      a,
+      button {
+        background: inherit;
         color: inherit;
+        font-weight: inherit;
+        padding: 0;
+        text-align: start;
         text-decoration: none;
+        width: 100%;
 
-        // stylelint-disable max-nesting-depth
+        // stylelint-disable-next-line max-nesting-depth
         &:hover {
           color: $color-link;
         }
@@ -230,8 +239,6 @@ ul.listing {
       float: left;
       padding: 0 0.5em 0 0;
       margin: 0 0 0.5em;
-
-      // line-height: 1em;
     }
   }
 
@@ -554,6 +561,7 @@ table.listing {
           text-align: center;
           height: 180px;
 
+          // stylelint-disable-next-line max-nesting-depth
           &:before {
             content: '';
             display: inline-block;
@@ -562,6 +570,7 @@ table.listing {
             margin-inline-end: -0.25em;
           }
 
+          // stylelint-disable-next-line max-nesting-depth
           img {
             display: inline-block;
             vertical-align: middle;
@@ -569,6 +578,7 @@ table.listing {
         }
 
         &:hover {
+          // stylelint-disable-next-line max-nesting-depth
           img {
             border-color: $color-teal;
           }

--- a/client/src/entrypoints/admin/page-chooser-modal.js
+++ b/client/src/entrypoints/admin/page-chooser-modal.js
@@ -124,7 +124,7 @@ const PAGE_CHOOSER_MODAL_ONLOAD_HANDLERS = {
 
       /* Set up behaviour of choose-page links, to pass control back to the calling page */
       // eslint-disable-next-line func-names
-      $('a.choose-page', modal.body).on('click', function () {
+      $('[data-choose-item]', modal.body).on('click', function () {
         const pageData = $(this).data();
         pageData.parentId = jsonData.parent_page_id;
         modal.respond('pageChosen', pageData);

--- a/wagtail/admin/templates/wagtailadmin/chooser/tables/page_title_cell.html
+++ b/wagtail/admin/templates/wagtailadmin/chooser/tables/page_title_cell.html
@@ -1,11 +1,24 @@
-{% load l10n wagtailadmin_tags %}
+{% load i18n l10n wagtailadmin_tags %}
 <td class="{% if column.classname %}{{ column.classname }} {% endif %}title">
     <div class="title-wrapper">
         {% if page.can_choose %}
             {% if column.is_multiple_choice %}
                 <label for="chooser-modal-select-{{ page.id|unlocalize }}">{{ value }}</label>
             {% else %}
-                <a class="choose-page" href="#{{ page.id|unlocalize }}" data-id="{{ page.id|unlocalize }}" data-title="{{ page.title }}" data-admin-title="{{ page.get_admin_display_title }}" data-url="{{ page.url }}" data-parent-id="{{ page.get_parent.id|unlocalize }}" data-edit-url="{% url 'wagtailadmin_pages:edit' page.id %}">{{ value }}</a>
+                <button
+                    class="choose-page"
+                    type="button"
+                    aria-description="{% trans "Select page" %}"
+                    data-admin-title="{{ page.get_admin_display_title }}"
+                    data-choose-item
+                    data-edit-url="{% url 'wagtailadmin_pages:edit' page.id %}"
+                    data-id="{{ page.id|unlocalize }}"
+                    data-parent-id="{{ page.get_parent.id|unlocalize }}"
+                    data-title="{{ page.title }}"
+                    data-url="{{ page.url }}"
+                >
+                    {{ value }}
+                </button>
             {% endif %}
         {% else %}
             {{ value }}


### PR DESCRIPTION
- Use `button` not `a` (link) for the page chooser listing, select page buttons.
- Fixes #5408
- This was a small leftover goal from page editor rework and UX unification so just trying to get this sorted

## Details

- Clean up some commented out css & also split out specific scss ignore lines in _listing.scss, the goal here being to clean up a little bit of this file but basically make the button look exactly the same as the a (link) variants used everywhere else.
- Add proper aria-description (intentionally not aria-label) to provide extra context for this button's purpose `aria-description="{% trans "Select page" %}"`.
- Use `classnames` template tag for simpler classes generation.
- Note: The issue had an additional call out to change the way hover behaviour works (hover only on the clickable targets, I gave this a go but honestly the DOM structure & CSS here is pretty fragile and I opted for a smaller fix for the core issue before we start re-working everything.
- If this is merged, I will raise a new issue for the styling of the clickable buttons in page listings, we may want to add an explicit 'select' button (similar to full sized page listings) but this will require some additional thought.
- If this is merged, I will raise a new issue to adopt this solution for other chooser listings (images, document, snippets) along with the 'children' button.
  - `wagtail/images/templates/wagtailimages/images/results.html`
  - `wagtail/images/templates/wagtailimages/chooser/results.html`
  - Potentially others

## Checklist
- [X] Do the tests still pass?
- [X] Does the code comply with the style guide?
- [X] For front-end changes: Did you test on all of Wagtail’s supported environments?
  - Safari 15.4, Firefox 104, Chrome 105 including VoiceOver
  - Edge with NVDA

## Screenshots

<img width="1450" alt="Screen Shot 2022-09-16 at 5 15 22 pm" src="https://user-images.githubusercontent.com/1396140/190581662-48a43bfa-84f0-4911-84d5-a50aad2f30f0.png">

<img width="1660" alt="Screen Shot 2022-09-16 at 5 17 16 pm" src="https://user-images.githubusercontent.com/1396140/190580938-85adb95c-3525-4468-82a4-95bacbecc8d7.png">


