### PR TITLE
Add missing translated labels to audit logging filters

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -31,7 +31,7 @@ Changelog
  * Fix: Update the 'Locked pages' report menu title so that it is consistent with other pages reports and its own title on viewing (Nicholas Johnson)
  * Fix: Support `formfield_callback` handling on `ModelForm.Meta` for future Django 4.2 release (Matt Westcott)
  * Fix: Ensure that `ModelAdmin` correctly supports filters in combination with subsequent searches without clearing the applied filters (Stefan Hammer)
- * Fix: Add missing translated values to site settings' headers and models presented in listings (Stefan Hammer)
+ * Fix: Add missing translated values to site settings' headers plus models presented in listings and audit report filtering labels (Stefan Hammer)
  * Fix: Remove `capitalize()` calls to avoid issues with other languages or incorrectly presented model names for reporting and parts of site settings (Stefan hammer)
 
 

--- a/docs/releases/4.1.md
+++ b/docs/releases/4.1.md
@@ -43,7 +43,7 @@ Wagtail 4.1 is designated a Long Term Support (LTS) release. Long Term Support r
  * Update the 'Locked pages' report menu title so that it is consistent with other pages reports and its own title on viewing (Nicholas Johnson)
  * Support `formfield_callback` handling on `ModelForm.Meta` for future Django 4.2 release (Matt Westcott)
  * Ensure that `ModelAdmin` correctly supports filters in combination with subsequent searches without clearing the applied filters (Stefan Hammer)
- * Add missing translated values to site settings' headers and models presented in listings (Stefan Hammer)
+ * Add missing translated values to site settings' headers plus models presented in listings and audit report filtering labels (Stefan Hammer)
  * Remove `capitalize()` calls to avoid issues with other languages or incorrectly presented model names for reporting and parts of site settings (Stefan hammer)
 
 ## Upgrade considerations

--- a/wagtail/admin/views/pages/history.py
+++ b/wagtail/admin/views/pages/history.py
@@ -24,13 +24,17 @@ from wagtail.models import (
 
 
 class PageHistoryReportFilterSet(WagtailFilterSet):
-    action = django_filters.ChoiceFilter(choices=log_action_registry.get_choices)
+    action = django_filters.ChoiceFilter(
+        label=_("Action"),
+        choices=log_action_registry.get_choices,
+    )
     hide_commenting_actions = django_filters.BooleanFilter(
         label=_("Hide commenting actions"),
         method="filter_hide_commenting_actions",
         widget=forms.CheckboxInput,
     )
     user = django_filters.ModelChoiceFilter(
+        label=_("User"),
         field_name="user",
         queryset=lambda request: PageLogEntry.objects.all().get_users(),
     )

--- a/wagtail/admin/views/reports/audit_logging.py
+++ b/wagtail/admin/views/reports/audit_logging.py
@@ -40,7 +40,10 @@ def get_content_types_for_filter():
 
 
 class SiteHistoryReportFilterSet(WagtailFilterSet):
-    action = django_filters.ChoiceFilter(choices=log_action_registry.get_choices)
+    action = django_filters.ChoiceFilter(
+        label=_("Action"),
+        choices=log_action_registry.get_choices,
+    )
     hide_commenting_actions = django_filters.BooleanFilter(
         label=_("Hide commenting actions"),
         method="filter_hide_commenting_actions",
@@ -51,7 +54,9 @@ class SiteHistoryReportFilterSet(WagtailFilterSet):
     )
     label = django_filters.CharFilter(label=_("Name"), lookup_expr="icontains")
     user = django_filters.ModelChoiceFilter(
-        field_name="user", queryset=lambda request: get_users_for_filter()
+        label=_("User"),
+        field_name="user",
+        queryset=lambda request: get_users_for_filter(),
     )
     object_type = ContentTypeFilter(
         label=_("Type"),

--- a/wagtail/snippets/views/snippets.py
+++ b/wagtail/snippets/views/snippets.py
@@ -557,8 +557,12 @@ def redirect_to_usage(request, app_label, model_name, pk):
 
 
 class SnippetHistoryReportFilterSet(WagtailFilterSet):
-    action = django_filters.ChoiceFilter(choices=log_registry.get_choices)
+    action = django_filters.ChoiceFilter(
+        label=_("Action"),
+        choices=log_registry.get_choices,
+    )
     user = django_filters.ModelChoiceFilter(
+        label=_("User"),
         field_name="user",
         queryset=lambda request: ModelLogEntry.objects.all().get_users(),
     )


### PR DESCRIPTION
I've found some places in the audit logging filters where labels are not translated.

Here one example in the site history (green: translated table headers, red: untranslated filter labels):
![wagtail_missing_translations](https://user-images.githubusercontent.com/468164/190657918-7415231c-f168-4fe6-9ff3-65333ce44cac.png)


_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
