### PR TITLE
Add missing gettext calls to site settings

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -31,6 +31,7 @@ Changelog
  * Fix: Update the 'Locked pages' report menu title so that it is consistent with other pages reports and its own title on viewing (Nicholas Johnson)
  * Fix: Support `formfield_callback` handling on `ModelForm.Meta` for future Django 4.2 release (Matt Westcott)
  * Fix: Ensure that `ModelAdmin` correctly supports filters in combination with subsequent searches without clearing the applied filters (Stefan Hammer)
+ * Fix: Add missing translated values to site settings' headers and models presented in listings (Stefan Hammer)
 
 
 4.0.2 (xx.xx.xxxx) - IN DEVELOPMENT

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -32,6 +32,7 @@ Changelog
  * Fix: Support `formfield_callback` handling on `ModelForm.Meta` for future Django 4.2 release (Matt Westcott)
  * Fix: Ensure that `ModelAdmin` correctly supports filters in combination with subsequent searches without clearing the applied filters (Stefan Hammer)
  * Fix: Add missing translated values to site settings' headers and models presented in listings (Stefan Hammer)
+ * Fix: Remove `capitalize()` calls to avoid issues with other languages or incorrectly presented model names for reporting and parts of site settings (Stefan hammer)
 
 
 4.0.2 (xx.xx.xxxx) - IN DEVELOPMENT

--- a/docs/releases/4.1.md
+++ b/docs/releases/4.1.md
@@ -43,6 +43,7 @@ Wagtail 4.1 is designated a Long Term Support (LTS) release. Long Term Support r
  * Update the 'Locked pages' report menu title so that it is consistent with other pages reports and its own title on viewing (Nicholas Johnson)
  * Support `formfield_callback` handling on `ModelForm.Meta` for future Django 4.2 release (Matt Westcott)
  * Ensure that `ModelAdmin` correctly supports filters in combination with subsequent searches without clearing the applied filters (Stefan Hammer)
+ * Add missing translated values to site settings' headers and models presented in listings (Stefan Hammer)
 
 ## Upgrade considerations
 

--- a/docs/releases/4.1.md
+++ b/docs/releases/4.1.md
@@ -44,6 +44,7 @@ Wagtail 4.1 is designated a Long Term Support (LTS) release. Long Term Support r
  * Support `formfield_callback` handling on `ModelForm.Meta` for future Django 4.2 release (Matt Westcott)
  * Ensure that `ModelAdmin` correctly supports filters in combination with subsequent searches without clearing the applied filters (Stefan Hammer)
  * Add missing translated values to site settings' headers and models presented in listings (Stefan Hammer)
+ * Remove `capitalize()` calls to avoid issues with other languages or incorrectly presented model names for reporting and parts of site settings (Stefan hammer)
 
 ## Upgrade considerations
 

--- a/wagtail/contrib/settings/models.py
+++ b/wagtail/contrib/settings/models.py
@@ -146,7 +146,7 @@ class BaseSiteSetting(AbstractSetting):
 
     def __str__(self):
         return _("%(site_setting)s for %(site)s") % {
-            "site_setting": self._meta.verbose_name.capitalize(),
+            "site_setting": self._meta.verbose_name,
             "site": self.site,
         }
 
@@ -203,7 +203,7 @@ class BaseGenericSetting(AbstractSetting):
         return obj
 
     def __str__(self):
-        return self._meta.verbose_name.capitalize()
+        return self._meta.verbose_name
 
 
 class BaseSetting(BaseSiteSetting):

--- a/wagtail/contrib/settings/models.py
+++ b/wagtail/contrib/settings/models.py
@@ -2,6 +2,7 @@ import warnings
 
 from django.db import models
 from django.utils.functional import cached_property
+from django.utils.translation import gettext as _
 
 from wagtail.coreutils import InvokeViaAttributeShortcut
 from wagtail.models import Site
@@ -144,7 +145,10 @@ class BaseSiteSetting(AbstractSetting):
         return instance
 
     def __str__(self):
-        return "%s for %s" % (self._meta.verbose_name.capitalize(), self.site)
+        return _("%(site_setting)s for %(site)s") % {
+            "site_setting": self._meta.verbose_name.capitalize(),
+            "site": self.site,
+        }
 
 
 class BaseGenericSetting(AbstractSetting):

--- a/wagtail/contrib/settings/templates/wagtailsettings/edit.html
+++ b/wagtail/contrib/settings/templates/wagtailsettings/edit.html
@@ -1,7 +1,7 @@
 {% extends "wagtailadmin/base.html" %}
 {% load i18n wagtailadmin_tags %}
 
-{% block titletag %}{% blocktrans trimmed %}Editing {{ instance }}{% endblocktrans %}{% endblock %}
+{% block titletag %}{% blocktrans trimmed with instance=instance|capfirst %}Editing {{ instance }}{% endblocktrans %}{% endblock %}
 {% block bodyclass %}menu-settings{% endblock %}
 
 {% block content %}

--- a/wagtail/contrib/settings/templates/wagtailsettings/edit.html
+++ b/wagtail/contrib/settings/templates/wagtailsettings/edit.html
@@ -15,7 +15,8 @@
             </form>
         {% endif %}
     {% endfragment %}
-    {% include "wagtailadmin/shared/header.html" with title="Editing" icon="cogs" subtitle=setting_type_name|capfirst merged=1 extra_actions=editing_actions %}
+    {% trans "Editing" as editing_str %}
+    {% include "wagtailadmin/shared/header.html" with title=editing_str icon="cogs" subtitle=setting_type_name|capfirst merged=1 extra_actions=editing_actions %}
 
     <form action="{% url 'wagtailsettings:edit' opts.app_label opts.model_name form_id %}" method="POST" novalidate{% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>
         {% csrf_token %}

--- a/wagtail/contrib/settings/templates/wagtailsettings/index.html
+++ b/wagtail/contrib/settings/templates/wagtailsettings/index.html
@@ -4,7 +4,8 @@
 {% block bodyclass %}menu-settings{% endblock %}
 {% block content %}
 
-    {% include "wagtailadmin/shared/header.html" with title="Settings" icon="cogs" %}
+    {% trans "Settings" as settings_str %}
+    {% include "wagtailadmin/shared/header.html" with title=settings_str icon="cogs" %}
 
     <div class="nice-padding">
         <ul class="listing">

--- a/wagtail/coreutils.py
+++ b/wagtail/coreutils.py
@@ -16,7 +16,7 @@ from django.db.models.base import ModelBase
 from django.dispatch import receiver
 from django.http import HttpRequest
 from django.utils.encoding import force_str
-from django.utils.text import slugify
+from django.utils.text import capfirst, slugify
 from django.utils.translation import check_for_language, get_supported_language_variant
 
 if TYPE_CHECKING:
@@ -157,10 +157,10 @@ def get_content_type_label(content_type):
     """
     model = content_type.model_class()
     if model:
-        return model._meta.verbose_name.capitalize()
+        return str(capfirst(model._meta.verbose_name))
     else:
         # no corresponding model class found; fall back on the name field of the ContentType
-        return content_type.model.capitalize()
+        return capfirst(content_type.model)
 
 
 def accepts_kwarg(func, kwarg):


### PR DESCRIPTION
_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
