### PR TITLE
Fix code style of example in Wagtail API docs

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -48,6 +48,7 @@ Changelog
  * Fix: Add missing vertical space between header and content in embed chooser modal (LB (Ben) Johnston)
  * Fix: Use the correct type scale for heading levels in rich text (Steven Steinwand)
  * Fix: Update alignment and reveal logic of fields’ comment buttons (Steven Steinwand)
+ * Fix: Regression from Markdown conversion in documentation for API configuration - update to correctly use PEP-8 for example code (Storm Heg)
 
 
 4.0.1 (05.09.2022)

--- a/docs/advanced_topics/api/v2/configuration.md
+++ b/docs/advanced_topics/api/v2/configuration.md
@@ -108,27 +108,27 @@ For example:
 
 from wagtail.api import APIField
 
-class blogpageauthor(orderable):
-    page = models.foreignkey('blog.blogpage', on_delete=models.cascade, related_name='authors')
-    name = models.charfield(max_length=255)
+class BlogPageAuthor(Orderable):
+    page = models.ForeignKey('blog.BlogPage', on_delete=models.CASCADE, related_name='authors')
+    name = models.CharField(max_length=255)
 
     api_fields = [
         APIField('name'),
     ]
 
 
-class blogpage(page):
-    published_date = models.datetimefield()
-    body = richtextfield()
-    feed_image = models.foreignkey('wagtailimages.image', on_delete=models.set_null, null=true, ...)
-    private_field = models.charfield(max_length=255)
+class BlogPage(page):
+    published_date = models.DateTimeField()
+    body = RichTextField()
+    feed_image = models.ForeignKey('wagtailimages.Image', on_delete=models.SET_NULL, null=true, ...)
+    private_field = models.CharField(max_length=255)
 
     # export fields over the api
     api_fields = [
         APIField('published_date'),
         APIField('body'),
         APIField('feed_image'),
-        APIField('authors'),  # this will nest the relevant blogpageauthor objects in the api response
+        APIField('authors'),  # this will nest the relevant BlogPageAuthor objects in the api response
     ]
 ```
 

--- a/docs/releases/4.0.2.md
+++ b/docs/releases/4.0.2.md
@@ -26,3 +26,4 @@ depth: 1
  * Add missing vertical space between header and content in embed chooser modal (LB (Ben) Johnston)
  * Use the correct type scale for heading levels in rich text (Steven Steinwand)
  * Update alignment and reveal logic of fields’ comment buttons (Steven Steinwand)
+ * Regression from Markdown conversion in documentation for API configuration - update to correctly use PEP-8 for example code (Storm Heg)


### PR DESCRIPTION
Example code should be compliant with PEP-8.

Noticed this when reading this section of the docs and decided to volunteer a few minutes to fix it 😁

Looks like the class names were accidentally changed to lowercase when this section was converted to markdown in 7e73349dc186c7324c1d85d44363172d9b13f45d.

---

Should we perhaps consider adding some sort of formatter / linter for the documentation examples to ensure our examples follow the same code style?