### PR TITLE
Improvement - use "search" input type for documentation search

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -26,6 +26,7 @@ Changelog
  * Avoid assuming an integer PK named 'id' on multiple upload views (Matt Westcott)
  * Add a toggle to collapse/expand all page panels at once (Helen Chapman)
  * Improve the GitHub Workflows (CI) security (Alex (sashashura))
+ * Use `search` type input in documentation search (LB (Ben) Johnston)
  * Fix: Prevent `PageQuerySet.not_public` from returning all pages when no page restrictions exist (Mehrdad Moradizadeh)
  * Fix: Ensure that duplicate block ids are unique when duplicating stream blocks in the page editor (Joshua Munn)
  * Fix: Revise colour usage so that privacy & locked indicators can be seen in Windows High Contrast mode (LB (Ben Johnston))

--- a/docs/_templates/searchbox.html
+++ b/docs/_templates/searchbox.html
@@ -5,7 +5,7 @@
                 <div class="input-group-prepend">
                     <div class="input-group-text border-right-0 bg-white py-3 pl-3 pr-2"><span class="fas fa-search"></span></div>
                 </div>
-                <input class="form-control py-3 pr-3 pl-3 h-100 border-left-0" type="text" name="q" placeholder="Search" aria-label="Search" id="searchinput" />
+                <input class="form-control py-3 pr-3 pl-3 h-100 border-left-0" type="search" name="q" placeholder="Search" aria-label="Search" id="searchinput" />
             </div>
             <input type="submit" style="visibility:hidden;position:absolute;display:block;">
         </form>

--- a/docs/releases/4.1.md
+++ b/docs/releases/4.1.md
@@ -38,6 +38,7 @@ Scheduled publishing settings can now be found within the Status side panel of t
  * Avoid assuming an integer PK named 'id' on multiple upload views (Matt Westcott)
  * Add a toggle to collapse/expand all page panels at once (Helen Chapman)
  * Improve the GitHub Workflows (CI) security (Alex (sashashura))
+ * Use `search` type input in documentation search (LB (Ben) Johnston)
 
 ### Bug fixes
 


### PR DESCRIPTION
- See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/search
- Not a huge change but has a nice improvement where the keyboard on devices will use the 'search' icon for submit, plus  potential small accessibility win https://css-tricks.com/what-do-you-get-for-using-a-search-input-type/

## Screenshots

### Firefox 104, Safari 15.4, Chrome 107

<img width="1449" alt="Screen Shot 2022-09-19 at 7 45 49 pm" src="https://user-images.githubusercontent.com/1396140/190992111-c4b28a5b-dc82-4d9e-bdee-0355dbe624a3.png">


### VoiceOver

Reads 'search' at the end of the input type.

<img width="1379" alt="Screen Shot 2022-09-19 at 7 52 56 pm" src="https://user-images.githubusercontent.com/1396140/190992793-2105ab7e-0509-4a94-a6f2-559014f88a84.png">


### iOS 14.5 Xcode emulator (see 'search' on the input button)

<img width="435" alt="Screen Shot 2022-09-19 at 7 51 47 pm" src="https://user-images.githubusercontent.com/1396140/190992508-1b281c89-0073-4e77-bf9b-38a5ceef3ce2.png">

