### PR TITLE
Fix translate buttons without simple_translation being enabled

### DIFF
--- a/wagtail/admin/tests/pages/test_edit_page.py
+++ b/wagtail/admin/tests/pages/test_edit_page.py
@@ -563,7 +563,7 @@ class TestPageEdit(TestCase, WagtailTestUtils):
         # because the changes are not visible as a live page yet
         self.assertTrue(
             child_page_new.has_unpublished_changes,
-            "A page scheduled for future publishing should have has_unpublished_changes=True",
+            msg="A page scheduled for future publishing should have has_unpublished_changes=True",
         )
 
         self.assertEqual(child_page_new.status_string, "scheduled")
@@ -676,7 +676,7 @@ class TestPageEdit(TestCase, WagtailTestUtils):
         # because the changes are not visible as a live page yet
         self.assertTrue(
             child_page_new.has_unpublished_changes,
-            "A page scheduled for future publishing should have has_unpublished_changes=True",
+            msg="A page scheduled for future publishing should have has_unpublished_changes=True",
         )
 
         self.assertNotEqual(
@@ -688,7 +688,7 @@ class TestPageEdit(TestCase, WagtailTestUtils):
         self.assertEqual(
             child_page_new.title,
             original_title,
-            "A live page with scheduled revisions should still have original content",
+            msg="A live page with scheduled revisions should still have original content",
         )
 
     def test_edit_post_publish_now_an_already_scheduled_published_page(self):
@@ -1281,7 +1281,7 @@ class TestPageEdit(TestCase, WagtailTestUtils):
         )
 
     def test_page_edit_num_queries(self):
-        with self.assertNumQueries(46):
+        with self.assertNumQueries(45):
             self.client.get(
                 reverse("wagtailadmin_pages:edit", args=(self.event_page.id,))
             )

--- a/wagtail/admin/wagtail_hooks.py
+++ b/wagtail/admin/wagtail_hooks.py
@@ -45,14 +45,7 @@ from wagtail.admin.views.pages.bulk_actions import (
 )
 from wagtail.admin.viewsets import viewsets
 from wagtail.admin.widgets import Button, ButtonWithDropdownFromHook, PageListingButton
-from wagtail.models import (
-    Collection,
-    Locale,
-    Page,
-    Task,
-    UserPagePermissionsProxy,
-    Workflow,
-)
+from wagtail.models import Collection, Page, Task, UserPagePermissionsProxy, Workflow
 from wagtail.permissions import (
     collection_permission_policy,
     task_permission_policy,
@@ -453,34 +446,6 @@ def page_header_buttons(page, page_perms, next_url=None):
             },
             priority=70,
         )
-    if Permission.objects.filter(
-        content_type__app_label="simple_translation", codename="submit_translation"
-    ):
-        if (
-            page_perms.user.has_perm("simple_translation.submit_translation")
-            and not page.is_root()
-        ):
-            # If there's at least one locale that we haven't translated into yet, show "Translate this page" button
-            has_locale_to_translate_to = Locale.objects.exclude(
-                id__in=page.get_translations(inclusive=True).values_list(
-                    "locale_id", flat=True
-                )
-            ).exists()
-
-            if has_locale_to_translate_to:
-                url = reverse(
-                    "simple_translation:submit_page_translation", args=[page.id]
-                )
-                yield Button(
-                    _("Translate"),
-                    url,
-                    icon_name="globe",
-                    attrs={
-                        "title": _("Translate this page")
-                        % {"title": page.get_admin_display_title()}
-                    },
-                    priority=80,
-                )
 
 
 @hooks.register("register_admin_urls")

--- a/wagtail/contrib/simple_translation/wagtail_hooks.py
+++ b/wagtail/contrib/simple_translation/wagtail_hooks.py
@@ -53,7 +53,8 @@ def page_listing_more_buttons(page, page_perms, next_url=None):
         page_perms.user.has_perm("simple_translation.submit_translation")
         and not page.is_root()
     ):
-        # If there's at least one locale that we haven't translated into yet, show "Translate this page" button
+        # If there's at least one locale that we haven't translated into yet,
+        # show "Translate this page" button
         has_locale_to_translate_to = Locale.objects.exclude(
             id__in=page.get_translations(inclusive=True).values_list(
                 "locale_id", flat=True
@@ -63,6 +64,33 @@ def page_listing_more_buttons(page, page_perms, next_url=None):
         if has_locale_to_translate_to:
             url = reverse("simple_translation:submit_page_translation", args=[page.id])
             yield wagtailadmin_widgets.Button(_("Translate"), url, priority=60)
+
+
+@hooks.register("register_page_header_buttons")
+def page_header_buttons(page, page_perms, next_url=None):
+    if not page.is_root() and page_perms.user.has_perm(
+        "simple_translation.submit_translation"
+    ):
+        # If there's at least one locale that we haven't translated into yet,
+        # show "Translate this page" button
+        has_locale_to_translate_to = Locale.objects.exclude(
+            id__in=page.get_translations(inclusive=True).values_list(
+                "locale_id", flat=True
+            )
+        ).exists()
+
+        if has_locale_to_translate_to:
+            url = reverse("simple_translation:submit_page_translation", args=[page.id])
+            yield wagtailadmin_widgets.Button(
+                _("Translate"),
+                url,
+                icon_name="globe",
+                attrs={
+                    "title": _("Translate this page")
+                    % {"title": page.get_admin_display_title()}
+                },
+                priority=80,
+            )
 
 
 @hooks.register("register_snippet_listing_buttons")


### PR DESCRIPTION
When moving from simple_translation to wagtail-localize in Wagtail 4.0.1, I see two "Translate" button in the page header buttons list. The change came in #8895

This PR fixes that.

To-Do:
- [ ] add a test