### PR TITLE
Ensure "recent edits" panel works when page record is missing

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -56,6 +56,7 @@ Changelog
  * Fix: Prevent JS error on images index view when collections dropdown is omitted (Tidiane Dia)
  * Fix: Prevent "Entries per page" dropdown on images index view from reverting to 10 (Tidiane Dia)
  * Fix: Set related_name on user revision relation to avoid conflict with django-reversion (Matt Westcott)
+ * Fix: Ensure the "recent edits" panel on the Dashboard (home) page works when page record is missing (Matt Westcott)
 
 
 4.0.1 (05.09.2022)

--- a/docs/releases/4.0.2.md
+++ b/docs/releases/4.0.2.md
@@ -31,3 +31,4 @@ depth: 1
  * Prevent JS error on images index view when collections dropdown is omitted (Tidiane Dia)
  * Prevent "Entries per page" dropdown on images index view from reverting to 10 (Tidiane Dia)
  * Set related_name on user revision relation to avoid conflict with django-reversion (Matt Westcott)
+ * Ensure the "recent edits" panel on the Dashboard (home) page works when page record is missing (Matt Westcott)

--- a/wagtail/admin/views/home.py
+++ b/wagtail/admin/views/home.py
@@ -207,9 +207,12 @@ class RecentEditsPanel(Component):
         # The revision's object_id is a string, so cast it to int first.
         page_keys = [int(pr.object_id) for pr in last_edits]
         pages = Page.objects.specific().in_bulk(page_keys)
-        context["last_edits"] = [
-            [revision, pages.get(int(revision.object_id))] for revision in last_edits
-        ]
+        context["last_edits"] = []
+        for revision in last_edits:
+            page = pages.get(int(revision.object_id))
+            if page:
+                context["last_edits"].append([revision, page])
+
         context["request"] = request
         return context
 


### PR DESCRIPTION
Fixes #9185

If [the "recent edits" query](https://github.com/wagtail/wagtail/blob/882ed28359d6497c9f7c4a2a3d437cd5b81dc3f4/wagtail/admin/views/home.py#L178-L205) returns a revision object for which no corresponding page exists, the template will be passed `None` for the page object, which causes the `NoReverseMatch` error as described in #9185.

It's not clear how this situation arises - we don't have any working 'steps to reproduce' from the reporters, and in my testing, deleting a page always causes its revision objects to be deleted. All I can say is that the move to a generic foreign key for the Revision model means that there's no longer a database constraint to prevent it from happening...

This PR modifies the behaviour so that the revision is silently dropped from the list. My only concern is that we're just kicking the can down the road, and that these 'orphaned' revision records could just cause failures in more obscure situations (e.g. during moderation workflows or scheduled publishing).