### PR TITLE
feat: customize package details with environment variables

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+import os
 
 from wagtail import __version__
 from wagtail.utils.setup import assets, check_bdist_egg, sdist
@@ -78,26 +79,49 @@ documentation_extras = [
     "myst_parser==0.17.0",
 ]
 
-setup(
-    name="wagtail",
-    version=__version__,
-    description="A Django content management system.",
-    author="Wagtail core team + contributors",
-    author_email="hello@wagtail.org",  # For support queries, please see https://docs.wagtail.org/en/stable/support.html
-    url="https://wagtail.org/",
-    project_urls={
-        "Documentation": "https://docs.wagtail.org",
-        "Source": "https://github.com/wagtail/wagtail",
-    },
-    packages=find_packages(),
-    include_package_data=True,
-    license="BSD",
-    long_description="Wagtail is an open source content management \
+name = os.getenv("WAGTAIL_PACKAGE_META_NAME", "wagtail")
+
+version = os.getenv("WAGTAIL_PACKAGE_META_VERSION", __version__)
+description = os.getenv(
+    "WAGTAIL_PACKAGE_META_DESCRIPTION", "A Django content management system."
+)
+author = os.getenv("WAGTAIL_PACKAGE_META_AUTHOR", "Wagtail core team + contributors")
+author_email = os.getenv(
+    "WAGTAIL_PACKAGE_META_AUTHOR_EMAIL", "hello@wagtail.org"
+)  # For support queries, please see https://docs.wagtail.org/en/stable/support.html
+url = os.getenv("WAGTAIL_PACKAGE_META_URL", "https://wagtail.org/")
+project_urls_docs = os.getenv(
+    "WAGTAIL_PACKAGE_META_PROJECT_URLS_DOCS", "https://docs.wagtail.org"
+)
+project_urls_src = os.getenv(
+    "WAGTAIL_PACKAGE_META_PROJECT_URLS_SRC", "https://github.com/wagtail/wagtail"
+)
+long_description = os.getenv(
+    "WAGTAIL_PACKAGE_META_LONG_DESCRIPTION",
+    "Wagtail is an open source content management \
 system built on Django, with a strong community and commercial support. \
 It’s focused on user experience, and offers precise control for \
 designers and developers.\n\n\
 For more details, see https://wagtail.org, https://docs.wagtail.org and \
 https://github.com/wagtail/wagtail/.",
+)
+
+
+setup(
+    name=name,
+    version=version,
+    description=description,
+    author=author,
+    author_email=author_email,
+    url=url,
+    project_urls={
+        "Documentation": project_urls_docs,
+        "Source": project_urls_src,
+    },
+    packages=find_packages(),
+    include_package_data=True,
+    license="BSD",
+    long_description=long_description,
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Environment :: Web Environment",


### PR DESCRIPTION
Allow overriding package details for teams that want to fork wagtail, so they can more easily publish their fork to a repository and pip install their fork. This is useful when your team is working faster than upstream and needs to go ahead and implement features to meet their own timeline while proposing the changes upstream. Overriding packaging with environment variables will allow teams to quickly generate a forked package using CI, without needing to worry about setup.py changes ending up in PRs to upstream.

<!--
Thanks for contributing to Wagtail! 🎉

Before submitting, please review the [contributor guidelines](https://docs.wagtail.org/en/latest/contributing/index.html).
-->

_Please check the following:_

-   [ ] Do the tests still pass?[^1]
-   [ ] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
