### PR TITLE
Ensure for_user is consistently passed to WagtailAdminModelForm

### DIFF
--- a/wagtail/admin/views/generic/preview.py
+++ b/wagtail/admin/views/generic/preview.py
@@ -58,9 +58,9 @@ class PreviewOnEdit(View):
 
         if not query_dict:
             # Query dict is empty, return null form
-            return form_class(instance=self.object)
+            return form_class(instance=self.object, for_user=self.request.user)
 
-        return form_class(query_dict, instance=self.object)
+        return form_class(query_dict, instance=self.object, for_user=self.request.user)
 
     def _get_data_from_session(self):
         post_data, _ = self.request.session.get(self.session_key, (None, None))

--- a/wagtail/admin/views/pages/preview.py
+++ b/wagtail/admin/views/pages/preview.py
@@ -37,9 +37,18 @@ class PreviewOnEdit(GenericPreviewOnEdit):
 
         if not query_dict:
             # Query dict is empty, return null form
-            return form_class(instance=self.object, parent_page=parent_page)
+            return form_class(
+                instance=self.object,
+                parent_page=parent_page,
+                for_user=self.request.user,
+            )
 
-        return form_class(query_dict, instance=self.object, parent_page=parent_page)
+        return form_class(
+            query_dict,
+            instance=self.object,
+            parent_page=parent_page,
+            for_user=self.request.user,
+        )
 
 
 class PreviewOnCreate(PreviewOnEdit):

--- a/wagtail/admin/views/pages/revisions.py
+++ b/wagtail/admin/views/pages/revisions.py
@@ -38,7 +38,7 @@ def revisions_revert(request, page_id, revision_id):
     edit_handler = page_class.get_edit_handler()
     form_class = edit_handler.get_form_class()
 
-    form = form_class(instance=revision_page)
+    form = form_class(instance=revision_page, for_user=request.user)
     edit_handler = edit_handler.get_bound_panel(
         instance=revision_page, request=request, form=form
     )

--- a/wagtail/test/testapp/forms.py
+++ b/wagtail/test/testapp/forms.py
@@ -11,7 +11,9 @@ class ValidatedPageForm(WagtailAdminPageForm):
             return
 
         value = self.cleaned_data["foo"]
-        if value != "bar":
+        if self.for_user.is_superuser and value == "superbar":
+            pass
+        elif value != "bar":
             raise forms.ValidationError("Field foo must be bar")
         return value
 

--- a/wagtail/test/testapp/templates/tests/validated_page.html
+++ b/wagtail/test/testapp/templates/tests/validated_page.html
@@ -1,0 +1,5 @@
+{% extends "tests/base.html" %}
+
+{% block content %}
+    <h2>foo = {{ page.foo }}</h2>
+{% endblock %}


### PR DESCRIPTION
Fixes #9230. When instantiating forms returned from `wagtail.admin.panels.get_form_for_model` (which are assumed to be WagtailAdminModelForm subclasses), always pass the for_user argument so that the form can incorporate custom logic that's dependent on the user object. Previously this was done for the main create/edit views, but not previews or revert.
