### PR TITLE
Ensure MultiFieldPanel outputs all child classnames

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/panels/multi_field_panel.html
+++ b/wagtail/admin/templates/wagtailadmin/panels/multi_field_panel.html
@@ -1,7 +1,7 @@
 {% load wagtailadmin_tags %}
 {# Avoid semantic markup here. Children of this panel can either be fields, or other groups. #}
 {% for child in self.visible_children %}
-    <div class="w-panel__wrapper {{ child.classname }}">
+    <div class="w-panel__wrapper {{ child.classes|join:' ' }}">
         {% if child.heading %}
             {% fragment as label_content %}
                 {{ child.heading }}{% if child.is_required %}<span class="w-required-mark">*</span>{% endif %}


### PR DESCRIPTION
Fixes #9232. The on-hover behaviour for StreamField controls relies on the classname `w-panel--nested` being set on a container element. This is added to FieldPanel via the `classes` method. However, MultiFieldPanel was outputting `child.classname` which only includes the classname passed to the panel constructor, bypassing the `classes` method. As a result, `w-panel--nested` was not being added.
