### PR TITLE
Fix redirect signal handler tests for Django 4.2

### DIFF
--- a/wagtail/contrib/redirects/tests/test_signal_handlers.py
+++ b/wagtail/contrib/redirects/tests/test_signal_handlers.py
@@ -30,8 +30,10 @@ class TestAutocreateRedirects(TestCase, WagtailTestUtils):
         page.slug += "-extra"
         page.save(log_action="wagtail.publish", user=self.user, clean=False)
         # simulate database transaction commit:
-        for _, func in connection.run_on_commit:
-            func()
+        for callback in connection.run_on_commit:
+            # callback is a tuple of (sids, func) on Django <=4.1
+            # and (sids, func, robust) on Django >=4.2; call func
+            callback[1]()
 
     def test_golden_path(self):
         # the page we'll be triggering the change for here is...


### PR DESCRIPTION
Pre-emptive fix for a failure occurring against Django main, which will land in Django 4.2.

`wagtail.contrib.redirects.tests_test_signal_handlers` taps into the internal undocumented `run_on_commit` property (a list of tuples) to trigger signal handlers. In https://github.com/django/django/commit/4a1150b41d1312feacd4316b2691227f5a509ae9 an extra element has been added to those tuples, causing the failure:

```
Traceback (most recent call last):
  File "/home/runner/work/wagtail/wagtail/wagtail/contrib/redirects/tests/test_signal_handlers.py", line 107, in test_handling_of_existing_redirects
    self.trigger_page_slug_changed_signal(test_subject)
  File "/home/runner/work/wagtail/wagtail/wagtail/contrib/redirects/tests/test_signal_handlers.py", line 33, in trigger_page_slug_changed_signal
    for _, func in connection.run_on_commit:
ValueError: too many values to unpack (expected 2)
```

Here we tweak the test code to work against both versions.