### PR TITLE
Revert caching on ModelAdmin permissions

### DIFF
--- a/wagtail/admin/tests/pages/test_edit_page.py
+++ b/wagtail/admin/tests/pages/test_edit_page.py
@@ -1698,7 +1698,7 @@ class TestPageEdit(TestCase, WagtailTestUtils):
         )
 
     def test_page_edit_num_queries(self):
-        with self.assertNumQueries(50):
+        with self.assertNumQueries(40):
             self.client.get(
                 reverse("wagtailadmin_pages:edit", args=(self.event_page.id,))
             )

--- a/wagtail/admin/tests/pages/test_edit_page.py
+++ b/wagtail/admin/tests/pages/test_edit_page.py
@@ -1698,7 +1698,7 @@ class TestPageEdit(TestCase, WagtailTestUtils):
         )
 
     def test_page_edit_num_queries(self):
-        with self.assertNumQueries(40):
+        with self.assertNumQueries(50):
             self.client.get(
                 reverse("wagtailadmin_pages:edit", args=(self.event_page.id,))
             )

--- a/wagtail/admin/tests/pages/test_edit_page.py
+++ b/wagtail/admin/tests/pages/test_edit_page.py
@@ -1698,6 +1698,10 @@ class TestPageEdit(TestCase, WagtailTestUtils):
         )
 
     def test_page_edit_num_queries(self):
+        # Warm up cache so that result is the same when running this test in isolation
+        # as when running it within the full test suite
+        self.client.get(reverse("wagtailadmin_pages:edit", args=(self.event_page.id,)))
+
         with self.assertNumQueries(40):
             self.client.get(
                 reverse("wagtailadmin_pages:edit", args=(self.event_page.id,))

--- a/wagtail/contrib/modeladmin/helpers/permission.py
+++ b/wagtail/contrib/modeladmin/helpers/permission.py
@@ -1,6 +1,7 @@
 from django.contrib.auth import get_permission_codename
 from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
+from django.utils.functional import cached_property
 
 from wagtail.models import Page, UserPagePermissionsProxy
 
@@ -28,6 +29,14 @@ class PermissionHelper:
             content_type__model=self.opts.model_name,
         )
 
+    @cached_property
+    def all_permission_codenames(self):
+        return list(
+            self.get_all_model_permissions()
+            .values_list("codename", flat=True)
+            .distinct()
+        )
+
     def get_perm_codename(self, action):
         return get_permission_codename(action, self.opts)
 
@@ -44,8 +53,8 @@ class PermissionHelper:
         Return a boolean to indicate whether `user` has any model-wide
         permissions
         """
-        for perm in self.get_all_model_permissions().values("codename"):
-            if self.user_has_specific_permission(user, perm["codename"]):
+        for perm_codename in self.all_permission_codenames:
+            if self.user_has_specific_permission(user, perm_codename):
                 return True
         return False
 

--- a/wagtail/contrib/modeladmin/helpers/permission.py
+++ b/wagtail/contrib/modeladmin/helpers/permission.py
@@ -1,9 +1,6 @@
-from functools import lru_cache
-
 from django.contrib.auth import get_permission_codename
 from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
-from django.utils.functional import cached_property
 
 from wagtail.models import Page, UserPagePermissionsProxy
 
@@ -31,14 +28,6 @@ class PermissionHelper:
             content_type__model=self.opts.model_name,
         )
 
-    @cached_property
-    def all_permission_codenames(self):
-        return list(
-            self.get_all_model_permissions()
-            .values_list("codename", flat=True)
-            .distinct()
-        )
-
     def get_perm_codename(self, action):
         return get_permission_codename(action, self.opts)
 
@@ -50,14 +39,13 @@ class PermissionHelper:
 
         return user.has_perm("%s.%s" % (self.opts.app_label, perm_codename))
 
-    @lru_cache(maxsize=128)
     def user_has_any_permissions(self, user):
         """
         Return a boolean to indicate whether `user` has any model-wide
         permissions
         """
-        for perm_codename in self.all_permission_codenames:
-            if self.user_has_specific_permission(user, perm_codename):
+        for perm in self.get_all_model_permissions().values("codename"):
+            if self.user_has_specific_permission(user, perm["codename"]):
                 return True
         return False
 

--- a/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
+++ b/wagtail/contrib/modeladmin/tests/test_simple_modeladmin.py
@@ -11,9 +11,7 @@ from django.utils.timezone import make_aware
 from openpyxl import load_workbook
 
 from wagtail.admin.admin_url_finder import AdminURLFinder
-from wagtail.admin.models import Admin
 from wagtail.admin.panels import FieldPanel, TabbedInterface
-from wagtail.contrib.modeladmin.helpers.permission import PermissionHelper
 from wagtail.contrib.modeladmin.helpers.search import DjangoORMSearchHandler
 from wagtail.images.models import Image
 from wagtail.images.tests.utils import get_test_image_file
@@ -963,18 +961,6 @@ class TestEditorAccess(TestCase, WagtailTestUtils):
     def test_delete_post_permitted(self):
         response = self.client.post("/admin/modeladmintest/book/delete/2/")
         self.assertRedirects(response, "/admin/")
-
-    def test_permission_helper(self):
-        permission_helper = PermissionHelper(Admin)
-
-        # Populate user permissions cache
-        with self.assertNumQueries(2):
-            self.assertTrue(self.user.has_perm("wagtailadmin.access_admin"))
-
-        with self.assertNumQueries(1):
-            # Only one query - to retrieve the model's codenames - should be performed.
-            self.assertTrue(permission_helper.user_has_any_permissions(self.user))
-            self.assertTrue(permission_helper.user_can_list(self.user))
 
 
 class TestHistoryView(TestCase, WagtailTestUtils):

--- a/wagtail/images/tests/test_admin_views.py
+++ b/wagtail/images/tests/test_admin_views.py
@@ -323,7 +323,7 @@ class TestImageIndexView(TestCase, WagtailTestUtils):
 
     def test_num_queries(self):
         # Initial number of queries.
-        with self.assertNumQueries(13):
+        with self.assertNumQueries(23):
             self.get()
 
         # Add 5 images.
@@ -333,11 +333,11 @@ class TestImageIndexView(TestCase, WagtailTestUtils):
                 file=get_test_image_file(size=(1, 1)),
             )
 
-        with self.assertNumQueries(35):
+        with self.assertNumQueries(45):
             # The renditions needed don't exist yet. We have 20 = 5 * 4 + 2 additional queries.
             self.get()
 
-        with self.assertNumQueries(15):
+        with self.assertNumQueries(25):
             # No extra additional queries since renditions exist and are saved in
             # the prefetched objects cache.
             self.get()

--- a/wagtail/images/tests/test_admin_views.py
+++ b/wagtail/images/tests/test_admin_views.py
@@ -323,7 +323,7 @@ class TestImageIndexView(TestCase, WagtailTestUtils):
 
     def test_num_queries(self):
         # Initial number of queries.
-        with self.assertNumQueries(23):
+        with self.assertNumQueries(13):
             self.get()
 
         # Add 5 images.
@@ -333,11 +333,11 @@ class TestImageIndexView(TestCase, WagtailTestUtils):
                 file=get_test_image_file(size=(1, 1)),
             )
 
-        with self.assertNumQueries(45):
+        with self.assertNumQueries(35):
             # The renditions needed don't exist yet. We have 20 = 5 * 4 + 2 additional queries.
             self.get()
 
-        with self.assertNumQueries(25):
+        with self.assertNumQueries(15):
             # No extra additional queries since renditions exist and are saved in
             # the prefetched objects cache.
             self.get()

--- a/wagtail/images/tests/test_admin_views.py
+++ b/wagtail/images/tests/test_admin_views.py
@@ -322,6 +322,10 @@ class TestImageIndexView(TestCase, WagtailTestUtils):
         )
 
     def test_num_queries(self):
+        # Warm up cache so that result is the same when running this test in isolation
+        # as when running it within the full test suite.
+        self.get()
+
         # Initial number of queries.
         with self.assertNumQueries(13):
             self.get()


### PR DESCRIPTION
Fixes #9207. Revert cb4017c649ee5e7be373d7a35e700d1c322d5b63, and extend tests to verify that changes to permissions immediately take effect on subsequent page requests, rather than being improperly cached.