### PR TITLE
Add secondary button with icon to styleguide/storybook (for #9198)

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -35,6 +35,7 @@ Changelog
  * Adopt `wagtail.admin.views.generic.CreateView` for the User creation view (Mehrdad Moradizadeh)
  * Adopt `wagtail.admin.views.generic.DeleteView` for the User delete view (Mehrdad Moradizadeh)
  * Adopt `wagtail.admin.views.generic.EditView` for the User edit view (Mehrdad Moradizadeh)
+ * Add `button-secondary bicolor` variants to the pattern library and styleguide (Adinapunyo Banerjee)
  * Fix: Prevent `PageQuerySet.not_public` from returning all pages when no page restrictions exist (Mehrdad Moradizadeh)
  * Fix: Ensure that duplicate block ids are unique when duplicating stream blocks in the page editor (Joshua Munn)
  * Fix: Revise colour usage so that privacy & locked indicators can be seen in Windows High Contrast mode (LB (Ben Johnston))

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -627,6 +627,7 @@ Contributors
 * Nicholas Johnson
 * Shohan Dutta Roy
 * Alex (sashashura)
+* Adinapunyo Banerjee
 
 
 Translators

--- a/docs/releases/4.1.md
+++ b/docs/releases/4.1.md
@@ -50,6 +50,7 @@ Snippet models that inherit from `DraftStateMixin` can now be assigned go-live a
  * Render `help_text` when set on `FieldPanel`, `MultiFieldPanel`, `FieldRowPanel`, and other panel APIs where it previously worked without official support (Matt Westcott)
  * Consolidate usage of Excel libraries to a single library `openpyxl`, removing usage of `XlsxWriter`, `tablib`, `xlrd` and `xlwt` (Jaap Roes)
  * Adopt generic class based views for the create User create view, User edit view, user delete view and Users index listing / search results (Mehrdad Moradizadeh)
+ * Add `button-secondary bicolor` variants to the pattern library and styleguide (Adinapunyo Banerjee)
 
 ### Bug fixes
 

--- a/wagtail/admin/templates/wagtailadmin/shared/button.stories.tsx
+++ b/wagtail/admin/templates/wagtailadmin/shared/button.stories.tsx
@@ -104,6 +104,39 @@ const Template = ({ url }) => (
       button disabled
     </button>
 
+    <h4>Bi-color secondary icon buttons with text</h4>
+    <a href={url} className="button bicolor button--icon button-secondary">
+      <span className="icon-wrapper">
+        <svg className="icon icon-plus icon" aria-hidden="true">
+          <use href="#icon-plus" />
+        </svg>
+      </span>
+      button link
+    </a>
+    <button
+      type="button"
+      className="button bicolor button--icon button-secondary"
+    >
+      <span className="icon-wrapper">
+        <svg className="icon icon-plus icon" aria-hidden="true">
+          <use href="#icon-plus" />
+        </svg>
+      </span>
+      button element
+    </button>
+    <button
+      type="button"
+      className="button bicolor button--icon button-secondary"
+      disabled
+    >
+      <span className="icon-wrapper">
+        <svg className="icon icon-plus icon" aria-hidden="true">
+          <use href="#icon-plus" />
+        </svg>
+      </span>
+      button disabled
+    </button>
+
     <h4>
       Bi-color icon buttons with text <small>(small)</small>
     </h4>
@@ -126,6 +159,44 @@ const Template = ({ url }) => (
     <button
       type="button"
       className="button button-small bicolor button--icon"
+      disabled
+    >
+      <span className="icon-wrapper">
+        <svg className="icon icon-plus icon" aria-hidden="true">
+          <use href="#icon-plus" />
+        </svg>
+      </span>
+      button disabled
+    </button>
+
+    <h4>
+      Bi-color secondary icon buttons with text <small>(small)</small>
+    </h4>
+    <a
+      href={url}
+      className="button button-small bicolor button--icon button-secondary"
+    >
+      <span className="icon-wrapper">
+        <svg className="icon icon-plus icon" aria-hidden="true">
+          <use href="#icon-plus" />
+        </svg>
+      </span>
+      button link
+    </a>
+    <button
+      type="button"
+      className="button button-small bicolor button--icon button-secondary"
+    >
+      <span className="icon-wrapper">
+        <svg className="icon icon-plus icon" aria-hidden="true">
+          <use href="#icon-plus" />
+        </svg>
+      </span>
+      button element
+    </button>
+    <button
+      type="button"
+      className="button button-small bicolor button--icon button-secondary"
       disabled
     >
       <span className="icon-wrapper">

--- a/wagtail/contrib/styleguide/templates/wagtailstyleguide/base.html
+++ b/wagtail/contrib/styleguide/templates/wagtailstyleguide/base.html
@@ -244,11 +244,21 @@
             <button class="button bicolor button--icon" type="button">{% icon name="plus" wrapped=1 %}button element</button>
             <button class="button bicolor button--icon" disabled type="button">{% icon name="plus" wrapped=1 %}button disabled</button>
 
+            <h4>Bi-color secondary icon buttons with text</h4>
+            <a href="#" class="button bicolor button--icon button-secondary">{% icon name="plus" wrapped=1 %}button link</a>
+            <button class="button bicolor button--icon button-secondary" type="button">{% icon name="plus" wrapped=1 %}button element</button>
+            <button class="button bicolor button--icon button-secondary" disabled type="button">{% icon name="plus" wrapped=1 %}button disabled</button>
+
             <h4>Bi-color icon buttons with text <small>(small)</small></h4>
 
             <a href="#" class="button button-small bicolor button--icon">{% icon name="plus" wrapped=1 %}button link</a>
             <button class="button button-small bicolor button--icon" type="button">{% icon name="plus" wrapped=1 %}button element</button>
             <button class="button button-small bicolor button--icon" disabled type="button">{% icon name="plus" wrapped=1 %}button disabled</button>
+
+            <h4>Bi-color secondary icon buttons with text <small>(small)</small></h4>
+            <a href="#" class="button button-small bicolor button--icon button-secondary">{% icon name="plus" wrapped=1 %}button link</a>
+            <button class="button button-small bicolor button--icon button-secondary" type="button">{% icon name="plus" wrapped=1 %}button element</button>
+            <button class="button button-small bicolor button--icon button-secondary" disabled type="button">{% icon name="plus" wrapped=1 %}button disabled</button>
 
             <h3>Icon buttons without text</h3>
 


### PR DESCRIPTION
Added two new button variants using `.button-secondary` with `bicolor button-icon` and `button-small` to the Styleguide. No changes to the `_button.scss` has been made.