### PR TITLE
Fix note markup in developing doc

### DIFF
--- a/docs/contributing/developing.md
+++ b/docs/contributing/developing.md
@@ -109,9 +109,9 @@ If you need to use a different user, password, host or port, use the `PGUSER`, `
 
 ### Testing against a different database
 
-:::{note}
+```{note}
 In order to run these tests, you must install the required client libraries and modules for the given database as described in Django's [Databases documentation](https://docs.djangoproject.com/en/stable/ref/databases/) or 3rd-party database backend's documentation.
-:::
+```
 
 If you need to test against a different database, set the `DATABASE_ENGINE`
 environment variable to the name of the Django database backend to test against:


### PR DESCRIPTION
<!--
Thanks for contributing to Wagtail! 🎉

Before submitting, please review the [contributor guidelines](https://docs.wagtail.org/en/latest/contributing/index.html).
-->

This PR fixes a small markup error I noticed in the development documents.

Original at https://docs.wagtail.org/en/stable/contributing/developing.html#testing-against-a-different-database:

<img width="667" alt="image" src="https://user-images.githubusercontent.com/1977376/191623261-f7a81d5d-0f43-40de-bbe0-acfc03732675.png">

New appearance:

<img width="702" alt="image" src="https://user-images.githubusercontent.com/1977376/191623369-87837659-06c0-439e-ade8-5d2ebd645a55.png">

This appears to be the only instance of this particular markup error within the docs.

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
