### PR TITLE
Fix check for duplicate FormField.clean_names

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -51,6 +51,7 @@ Changelog
  * Fix: Ensure `for_user` argument is passed to the form class when previewing pages (Matt Westcott)
  * Fix: Ensure the capitalisation of the `timesince_simple` tag is consistently added in the template based on usage in context (Stefan Hammer)
  * Fix: Add missing translation usage for the `timesince_last_update` and ensure the translated labels can be easier to work with in Transifex (Stefan Hammer)
+ * Fix: Add additional checks for duplicate form field `clean_name` values in the Form Builder validation and increase performance of checks (Dan Bentley)
 
 4.0.3 (xx.xx.xxxx) - IN DEVELOPMENT
 ~~~~~~~~~~~~~~~~~~

--- a/docs/releases/4.1.md
+++ b/docs/releases/4.1.md
@@ -76,6 +76,7 @@ This feature was developed by Karl Hobley and Matt Westcott.
  * Ensure `for_user` argument is passed to the form class when previewing pages (Matt Westcott)
  * Ensure the capitalisation of the `timesince_simple` tag is consistently added in the template based on usage in context (Stefan Hammer)
  * Add missing translation usage for the `timesince_last_update` and ensure the translated labels can be easier to work with in Transifex (Stefan Hammer)
+ * Add additional checks for duplicate form field `clean_name` values in the Form Builder validation and increase performance of checks (Dan Bentley)
 
 ## Upgrade considerations
 


### PR DESCRIPTION
`WagtailAdminFormPageForm.clean` checks for duplicate labels by generating a `clean_name` from `FormField.label` and iterates over the field list, comparing clean_names.

However, once saved, a FormField's `clean_name` cannot change. It's therefore possible for a `clean_name` clash if a field is renamed and a new field is added with the original field's label:

 - Create `FormPage` with "Test Field" (`clean_names: ["test_field"]`)
 - Rename "Test Field" to "Other Field" (`clean_names: ["test_field"]`)
 - Add new "Test Field"  (`clean_names: ["test_field", "test_field"]`)

Updated duplicate check to use existing `clean_name` or generate one. Refactored logic to avoid nested loops.

I think it might be better for `FormFields.clean_name` to be determined earlier to reduce the number of times we use an existing `clean_name` or generate a new one (`field.clean_name or field.get_field_clean_name()`) but I'm not 100% sure where that should be.

In the event of two matching `clean_names`, the error is likely to be a bit misleading ("There is another field with the label Test Field, please change one of them.") since the labels are likely to be different. Happy to create a separate error message.

<!--
Thanks for contributing to Wagtail! 🎉

Before submitting, please review the [contributor guidelines](https://docs.wagtail.org/en/latest/contributing/index.html).
-->

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
