### PR TITLE
Add note about schedules taking effect after publish

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/panels/publishing/schedule_publishing_panel.html
+++ b/wagtail/admin/templates/wagtailadmin/panels/publishing/schedule_publishing_panel.html
@@ -5,7 +5,9 @@
 
 {% page_permissions instance as page_perms %}
 
-{% if not page_perms.can_publish %}
+{% if page_perms.can_publish %}
+    {% trans "This publishing schedule will only take effect after you have published" as message_heading %}
+{% else %}
     {% trans "Anyone with editing permissions can create schedules" as message_heading %}
     {% trans "But only those with publishing permissions can make them effective." as message_description %}
 {% endif %}
@@ -15,7 +17,7 @@
         {% include 'wagtailadmin/panels/multi_field_panel.html' %}
 
         <button type="submit" class="button action-save button-longrunning" data-clicked-text="{% trans 'Saving…' %}">
-            <em>{% trans 'Save date' %}</em>
+            <em>{% trans 'Save schedule' %}</em>
         </button>
     {% enddialog %}
 </div>

--- a/wagtail/admin/tests/pages/test_edit_page.py
+++ b/wagtail/admin/tests/pages/test_edit_page.py
@@ -399,6 +399,23 @@ class TestPageEdit(TestCase, WagtailTestUtils):
             allow_extra_attrs=True,
         )
 
+        self.assertContains(
+            response,
+            "This publishing schedule will only take effect after you have published",
+        )
+
+    def test_schedule_panel_without_publish_permission(self):
+        editor = self.create_user("editor", password="password")
+        editor.groups.add(Group.objects.get(name="Editors"))
+        self.login(username="editor")
+        response = self.client.get(
+            reverse("wagtailadmin_pages:edit", args=(self.event_page.id,))
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(
+            response, "Anyone with editing permissions can create schedules"
+        )
+
     def test_edit_scheduled_go_live_before_expiry(self):
         post_data = {
             "title": "I've been edited!",


### PR DESCRIPTION
Fixes #9247

(Used the 'info' icon rather than the 'warning' from the design, as it's borderline which one this is, and switching the icon for the two alternative messages would involve more reworking of the template than it's worth.)