### PR TITLE
Use captureOnCommitCallbacks in signal handler tests

### DIFF
--- a/wagtail/contrib/redirects/tests/test_signal_handlers.py
+++ b/wagtail/contrib/redirects/tests/test_signal_handlers.py
@@ -1,5 +1,4 @@
 from django.contrib.auth import get_user_model
-from django.db import connection
 from django.test import TestCase, override_settings
 
 from wagtail.contrib.redirects.models import Redirect
@@ -28,10 +27,8 @@ class TestAutocreateRedirects(TestCase, WagtailTestUtils):
 
     def trigger_page_slug_changed_signal(self, page):
         page.slug += "-extra"
-        page.save(log_action="wagtail.publish", user=self.user, clean=False)
-        # simulate database transaction commit:
-        for _, func in connection.run_on_commit:
-            func()
+        with self.captureOnCommitCallbacks(execute=True):
+            page.save(log_action="wagtail.publish", user=self.user, clean=False)
 
     def test_golden_path(self):
         # the page we'll be triggering the change for here is...


### PR DESCRIPTION
Fixes test failures against current Django main (4.2 alpha). Our tests were calling the internal Django API `run_on_commit` to trigger signal handlers, but in https://github.com/django/django/commit/4a1150b41d1312feacd4316b2691227f5a509ae9 this API was changed to add an extra tuple element, breaking this code and causing the failure:

```
Traceback (most recent call last):
  File "/home/runner/work/wagtail/wagtail/wagtail/contrib/redirects/tests/test_signal_handlers.py", line 107, in test_handling_of_existing_redirects
    self.trigger_page_slug_changed_signal(test_subject)
  File "/home/runner/work/wagtail/wagtail/wagtail/contrib/redirects/tests/test_signal_handlers.py", line 33, in trigger_page_slug_changed_signal
    for _, func in connection.run_on_commit:
ValueError: too many values to unpack (expected 2)
```


Replace this with the official captureOnCommitCallbacks method introduced in Django 3.2: https://docs.djangoproject.com/en/4.1/topics/testing/tools/#django.test.TestCase.captureOnCommitCallbacks

Replaces #9241 