### PR TITLE
Add missing gettext-call to timesince_last_update-tag

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -49,6 +49,8 @@ Changelog
  * Fix: Remove `capitalize()` calls to avoid issues with other languages or incorrectly presented model names for reporting and parts of site settings (Stefan Hammer)
  * Fix: Add back rendering of `help_text` for InlinePanel (Matt Westcott)
  * Fix: Ensure `for_user` argument is passed to the form class when previewing pages (Matt Westcott)
+ * Fix: Ensure the capitalisation of the `timesince_simple` tag is consistently added in the template based on usage in context (Stefan Hammer)
+ * Fix: Add missing translation usage for the `timesince_last_update` and ensure the translated labels can be easier to work with in Transifex (Stefan Hammer)
 
 4.0.3 (xx.xx.xxxx) - IN DEVELOPMENT
 ~~~~~~~~~~~~~~~~~~

--- a/docs/releases/4.1.md
+++ b/docs/releases/4.1.md
@@ -74,6 +74,8 @@ This feature was developed by Karl Hobley and Matt Westcott.
  * Remove `capitalize()` calls to avoid issues with other languages or incorrectly presented model names for reporting and parts of site settings (Stefan Hammer)
  * Add back rendering of `help_text` for InlinePanel (Matt Westcott)
  * Ensure `for_user` argument is passed to the form class when previewing pages (Matt Westcott)
+ * Ensure the capitalisation of the `timesince_simple` tag is consistently added in the template based on usage in context (Stefan Hammer)
+ * Add missing translation usage for the `timesince_last_update` and ensure the translated labels can be easier to work with in Transifex (Stefan Hammer)
 
 ## Upgrade considerations
 

--- a/wagtail/admin/templates/wagtailadmin/shared/human_readable_date.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/human_readable_date.html
@@ -2,7 +2,7 @@
 
 <button type="button" class="w-human-readable-date" data-tippy-content="{{ date|date:"DATETIME_FORMAT" }}">
     <time class="w-human-readable-date__date" datetime="{{ date|date:"c" }}">
-        {{ date|timesince_simple }}
+        {{ date|timesince_simple|capfirst }}
     </time>
     {% if description %}
         <span class="w-human-readable-date__description">{{ description }}</span>

--- a/wagtail/admin/templates/wagtailadmin/shared/last_updated.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/last_updated.html
@@ -1,6 +1,6 @@
 {% load i18n wagtailadmin_tags %}
 {% if last_updated %}
     <span title="{{ last_updated }}" data-wagtail-tooltip="{{ last_updated }}" {% if classname %}class="{{ classname }}"{% endif %}>
-        {% if since_text %}{{ since_text }}{% endif %} {% timesince_last_update last_updated time_prefix=time_prefix %}
+        {% if since_text %}{{ since_text }}{% endif %} {% timesince_last_update last_updated show_time_prefix=show_time_prefix %}
     </span>
 {% endif %}

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -697,7 +697,7 @@ def timesince_simple(d):
     # Note: Duplicate code in timesince_last_update()
     time_period = timesince(d).split(",")[0]
     if time_period == avoid_wrapping(_("0 minutes")):
-        return _("Just now")
+        return _("just now")
     return _("%(time_period)s ago") % {"time_period": time_period}
 
 

--- a/wagtail/admin/tests/test_templatetags.py
+++ b/wagtail/admin/tests/test_templatetags.py
@@ -124,7 +124,7 @@ class TestTimesinceTags(TestCase):
     def test_timesince_simple(self):
         now = timezone.now()
         ts = timesince_simple(now)
-        self.assertEqual(ts, "Just now")
+        self.assertEqual(ts, "just now")
 
         ts = timesince_simple(now - timedelta(hours=1, minutes=10))
         self.assertEqual(ts, "1\xa0hour ago")
@@ -192,6 +192,21 @@ class TestTimesinceTags(TestCase):
             timesince_last_update(dt, user_display_name="Gary", show_time_prefix=True),
             timesince,
         )
+
+    def test_human_readable_date(self):
+        now = timezone.now()
+        template = """
+            {% load wagtailadmin_tags %}
+            {% human_readable_date date %}
+        """
+
+        html = Template(template).render(Context({"date": now}))
+        self.assertIn("Just now", html)
+
+        html = Template(template).render(
+            Context({"date": now - timedelta(hours=1, minutes=10)})
+        )
+        self.assertIn("1\xa0hour ago", html)
 
 
 class TestComponentTag(TestCase):

--- a/wagtail/admin/tests/test_templatetags.py
+++ b/wagtail/admin/tests/test_templatetags.py
@@ -142,8 +142,8 @@ class TestTimesinceTags(TestCase):
         self.assertEqual(timesince, formatted_time)
 
         # Check prefix output
-        timesince = timesince_last_update(dt, time_prefix="my prefix")
-        self.assertEqual(timesince, "my prefix {}".format(formatted_time))
+        timesince = timesince_last_update(dt, show_time_prefix=True)
+        self.assertEqual(timesince, "at {}".format(formatted_time))
 
         # Check user output
         timesince = timesince_last_update(dt, user_display_name="Gary")
@@ -151,18 +151,47 @@ class TestTimesinceTags(TestCase):
 
         # Check user and prefix output
         timesince = timesince_last_update(
-            dt, time_prefix="my prefix", user_display_name="Gary"
+            dt, show_time_prefix=True, user_display_name="Gary"
         )
-        self.assertEqual(timesince, "my prefix {} by Gary".format(formatted_time))
+        self.assertEqual(timesince, "at {} by Gary".format(formatted_time))
 
     def test_timesince_last_update_before_today_shows_timeago(self):
         dt = timezone.now() - timedelta(weeks=1, days=2)
 
+        # 1) use_shorthand=False
+
         timesince = timesince_last_update(dt, use_shorthand=False)
         self.assertEqual(timesince, "1\xa0week, 2\xa0days ago")
+        # The prefix is not used, if the date is older than the current day.
+        self.assertEqual(
+            timesince_last_update(dt, use_shorthand=False, show_time_prefix=True),
+            timesince,
+        )
+
+        # Check user output
+        timesince = timesince_last_update(
+            dt, use_shorthand=False, user_display_name="Gary"
+        )
+        self.assertEqual(timesince, "1\xa0week, 2\xa0days ago by Gary")
+        self.assertEqual(
+            timesince_last_update(
+                dt, use_shorthand=False, user_display_name="Gary", show_time_prefix=True
+            ),
+            timesince,
+        )
+
+        # 2) use_shorthand=True
 
         timesince = timesince_last_update(dt)
         self.assertEqual(timesince, "1\xa0week ago")
+        self.assertEqual(timesince_last_update(dt, show_time_prefix=True), timesince)
+
+        timesince = timesince_last_update(dt, user_display_name="Gary")
+        self.assertEqual(timesince, "1\xa0week ago by Gary")
+        self.assertEqual(
+            timesince_last_update(dt, user_display_name="Gary", show_time_prefix=True),
+            timesince,
+        )
 
 
 class TestComponentTag(TestCase):

--- a/wagtail/contrib/modeladmin/templates/modeladmin/includes/header_with_history.html
+++ b/wagtail/contrib/modeladmin/templates/modeladmin/includes/header_with_history.html
@@ -8,7 +8,7 @@
                 <li>
                     <span class="avatar small" data-wagtail-tooltip="{{ latest_log_entry.user_display_name }}"><img src="{% avatar_url latest_log_entry.user size=25 %}" alt="" decoding="async" loading="async" /></span>
                     {% trans "Last updated" %}
-                    {% include "wagtailadmin/shared/last_updated.html" with last_updated=latest_log_entry.timestamp time_prefix="at" %}
+                    {% include "wagtailadmin/shared/last_updated.html" with last_updated=latest_log_entry.timestamp show_time_prefix=True %}
                 </li>
                 {% if history_url %}
                     <li><a href="{{ history_url }}">{% icon "history" class_name="default" %} {% trans "History" %}</a></li>

--- a/wagtail/snippets/templates/wagtailsnippets/snippets/_header_with_history.html
+++ b/wagtail/snippets/templates/wagtailsnippets/snippets/_header_with_history.html
@@ -8,7 +8,7 @@
                 <li>
                     <span class="avatar small" data-wagtail-tooltip="{{ latest_log_entry.user_display_name }}"><img src="{% avatar_url latest_log_entry.user size=25 %}" alt="" decoding="async" loading="lazy"/></span>
                     {% trans "Last updated" %}
-                    {% include "wagtailadmin/shared/last_updated.html" with last_updated=latest_log_entry.timestamp time_prefix="at" %}
+                    {% include "wagtailadmin/shared/last_updated.html" with last_updated=latest_log_entry.timestamp show_time_prefix=True %}
                 </li>
                 {% if history_url %}
                     <li><a href="{{ history_url }}">{% icon "history" class_name="default" %} {% trans "History" %}</a></li>


### PR DESCRIPTION
Used in the status panel of a page for example:
![wagtail_missing_translation_timesince_last_update](https://user-images.githubusercontent.com/468164/192997630-042b00f7-306e-49d2-8f6e-6d93d7333205.png)

**TBD:** I've also moved the leading space outside the gettext-call.
Maybe I oversee something obvious, maybe there are languages where this spaces are replaced with something else, so they have to be kept, then of course, I will change my PR.
But during the time I'm actively translating for wagtail, I've fixed multiple strings where the first translator missed the white space (which is quite easy, since you don't see them and translators probably often just write their own version instead of copying the original string, if it doesn't contain any placeholders).
For example: https://github.com/wagtail/wagtail-localize/commit/e23dc8cea862016fee9e65c6e2b20f9e061843fa#diff-d34c885092c6e928532288ec254e9e991b4cb6b40f341ca72b5842854c18f3cbR107

If this approach is ok, we may add a point to the i18n discussion #8017 for future strings, @lb- ?
Should we change existing strings with white spaces too, or just keep that in mind for future strings?

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
