### PR TITLE
Fix status side panel info in edit view for snippets without DraftStateMixin

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/shared/side_panels/includes/status/workflow.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/side_panels/includes/status/workflow.html
@@ -18,10 +18,12 @@
             {% with workflow_state=object.current_workflow_state draft_revision=object.get_latest_revision live_revision=object.live_revision %}
 
                 {# Live section #}
-                {% if object.live %}
+                {% if not draftstate_enabled or object.live %}
                     {% trans 'Live' as title %}
                     {% if live_revision %}
                         {% timesince_last_update live_revision.created_at user_display_name=live_revision.user|user_display_name use_shorthand=True as help_text %}
+                    {% elif live_last_updated_info %}
+                        {% timesince_last_update live_last_updated_info.timestamp user_display_name=live_last_updated_info.user_display_name use_shorthand=True as help_text %}
                     {% endif %}
 
                     {% with icon_name='doc-full-inverse' %}
@@ -162,7 +164,7 @@
                     {% endif %}
                 </div>
             </div>
-        {% elif not has_live_publishing_schedule %}
+        {% elif draftstate_enabled and not has_live_publishing_schedule %}
             <div class="w-flex w-justify-between w-items-center w-w-full">
                 <div class="w-ml-8 w-pr-4 w-label-3">{% trans 'No publishing schedule set' %}</div>
                 {% if show_schedule_publishing_toggle and not page_perms.page_locked %}

--- a/wagtail/admin/ui/side_panels.py
+++ b/wagtail/admin/ui/side_panels.py
@@ -58,9 +58,11 @@ class BaseStatusSidePanel(BaseSidePanel):
 
     def get_scheduled_publishing_context(self):
         if not isinstance(self.object, DraftStateMixin):
-            return {}
+            return {"draftstate_enabled": False}
 
         context = {
+            # Used for hiding the info completely if the model doesn't extend DraftStateMixin
+            "draftstate_enabled": True,
             # The dialog toggle can be hidden (e.g. if PublishingPanel is not present)
             # but the scheduled publishing info should still be shown
             "show_schedule_publishing_toggle": self.show_schedule_publishing_toggle,

--- a/wagtail/admin/views/generic/models.py
+++ b/wagtail/admin/views/generic/models.py
@@ -671,16 +671,6 @@ class EditView(
             "user_display_name": user_display_name(revision.user),
         }
 
-    def get_draft_last_updated_info(self):
-        if not (self.draftstate_enabled and self.object.has_unpublished_changes):
-            return None
-
-        revision = self.object.latest_revision
-        return {
-            "timestamp": revision.created_at,
-            "user_display_name": user_display_name(revision.user),
-        }
-
     def form_valid(self, form):
         self.form = form
         with transaction.atomic():
@@ -722,7 +712,6 @@ class EditView(
         context["draftstate_enabled"] = self.draftstate_enabled
 
         context["live_last_updated_info"] = self.get_live_last_updated_info()
-        context["draft_last_updated_info"] = self.get_draft_last_updated_info()
         return context
 
 

--- a/wagtail/snippets/side_panels.py
+++ b/wagtail/snippets/side_panels.py
@@ -10,19 +10,6 @@ from wagtail.models import PreviewableMixin
 
 
 class SnippetStatusSidePanel(BaseStatusSidePanel):
-    def get_status_templates(self, context):
-        templates = []
-
-        if self.object.pk:
-            templates += [
-                "wagtailadmin/shared/side_panels/includes/status/workflow.html",
-            ]
-
-        if context.get("locale"):
-            templates += ["wagtailadmin/shared/side_panels/includes/status/locale.html"]
-
-        return templates
-
     def get_context_data(self, parent_context):
         context = super().get_context_data(parent_context)
         inherit = [
@@ -31,7 +18,6 @@ class SnippetStatusSidePanel(BaseStatusSidePanel):
             "revision_enabled",
             "draftstate_enabled",
             "live_last_updated_info",
-            "draft_last_updated_info",
             "locale",
             "translations",
         ]


### PR DESCRIPTION
There was a regression (sorry!) in 5112da98bb9a99a3707f66bcdfd69f67a51c7cdb where, as a result of using the shared status panel template in snippets, the "No publishing schedule set" info is always shown on snippets that do not extend `DraftStateMixin` because the shared status panel template always assumed it's working on pages.

I've added a test for this and made sure that the test fails without the fix applied.

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?