### PR TITLE
Reword special-purpose FieldPanel deprecation message for clarity

### DIFF
--- a/wagtail/admin/panels.py
+++ b/wagtail/admin/panels.py
@@ -867,7 +867,9 @@ class FieldPanel(Panel):
 class RichTextFieldPanel(FieldPanel):
     def __init__(self, *args, **kwargs):
         warn(
-            "wagtail.admin.edit_handlers.RichTextFieldPanel is obsolete and should be replaced by wagtail.admin.panels.FieldPanel",
+            "RichTextFieldPanel is no longer required for rich text fields, and should be replaced by FieldPanel. "
+            "RichTextFieldPanel will be removed in a future release. "
+            "See https://docs.wagtail.org/en/stable/releases/3.0.html#removal-of-special-purpose-field-panel-types",
             category=RemovedInWagtail50Warning,
             stacklevel=2,
         )
@@ -1293,7 +1295,9 @@ def reset_edit_handler_cache(**kwargs):
 class StreamFieldPanel(FieldPanel):
     def __init__(self, *args, **kwargs):
         warn(
-            "wagtail.admin.edit_handlers.StreamFieldPanel is obsolete and should be replaced by wagtail.admin.panels.FieldPanel",
+            "StreamFieldPanel is no longer required when using StreamField, and should be replaced by FieldPanel. "
+            "StreamFieldPanel will be removed in a future release. "
+            "See https://docs.wagtail.org/en/stable/releases/3.0.html#removal-of-special-purpose-field-panel-types",
             category=RemovedInWagtail50Warning,
             stacklevel=2,
         )

--- a/wagtail/documents/edit_handlers.py
+++ b/wagtail/documents/edit_handlers.py
@@ -7,7 +7,9 @@ from wagtail.utils.deprecation import RemovedInWagtail50Warning
 class DocumentChooserPanel(FieldPanel):
     def __init__(self, *args, **kwargs):
         warn(
-            "wagtail.documents.edit_handlers.DocumentChooserPanel is obsolete and should be replaced by wagtail.admin.panels.FieldPanel",
+            "DocumentChooserPanel is no longer required for document choosers, and should be replaced by FieldPanel. "
+            "DocumentChooserPanel will be removed in a future release. "
+            "See https://docs.wagtail.org/en/stable/releases/3.0.html#removal-of-special-purpose-field-panel-types",
             category=RemovedInWagtail50Warning,
             stacklevel=2,
         )

--- a/wagtail/images/edit_handlers.py
+++ b/wagtail/images/edit_handlers.py
@@ -10,7 +10,9 @@ from wagtail.utils.deprecation import RemovedInWagtail50Warning
 class ImageChooserPanel(FieldPanel):
     def __init__(self, *args, **kwargs):
         warn(
-            "wagtail.images.edit_handlers.ImageChooserPanel is obsolete and should be replaced by wagtail.admin.panels.FieldPanel",
+            "ImageChooserPanel is no longer required for image choosers, and should be replaced by FieldPanel. "
+            "ImageChooserPanel will be removed in a future release. "
+            "See https://docs.wagtail.org/en/stable/releases/3.0.html#removal-of-special-purpose-field-panel-types",
             category=RemovedInWagtail50Warning,
             stacklevel=2,
         )

--- a/wagtail/snippets/edit_handlers.py
+++ b/wagtail/snippets/edit_handlers.py
@@ -7,7 +7,9 @@ from wagtail.utils.deprecation import RemovedInWagtail50Warning
 class SnippetChooserPanel(FieldPanel):
     def __init__(self, *args, **kwargs):
         warn(
-            "wagtail.snippets.edit_handlers.SnippetChooserPanel is obsolete and should be replaced by wagtail.admin.panels.FieldPanel",
+            "SnippetChooserPanel is no longer required for snippet choosers, and should be replaced by FieldPanel. "
+            "SnippetChooserPanel will be removed in a future release. "
+            "See https://docs.wagtail.org/en/stable/releases/3.0.html#removal-of-special-purpose-field-panel-types",
             category=RemovedInWagtail50Warning,
             stacklevel=2,
         )


### PR DESCRIPTION
Multiple people on Slack support have asked "how do I fix this error" now, which suggests that the wording here needs improvement...

* change "is obsolete" to "is no longer required", to make it sound less "your code is broken" and more "here's an improvement you can make" (but also state that it'll be removed in a future release, to make it clear that you have to do it soomer or later)
* leave out the full module paths - they're probably coming across as internal tech gobbledegook rather than informative, and obscuring the word "Panel" which is the most important thing in the message
* link to the release note to clear up any remaining confusion

(Note: We should cherry-pick this to stable/3.0.x and stable/4.0.x to be included in the next patch release of those releases.)