### PR TITLE
Fix preview for pages using FormMixin

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -49,6 +49,7 @@ Changelog
 * Render `help_text` when set on `FieldPanel`, `MultiFieldPanel`, `FieldRowPanel`, and other panel APIs where it previously worked without official support (Matt Westcott)
 * Update special-purpose `FieldPanel` deprecation message to add clarity for developers (Matt Westcott)
 * Fix: Add back rendering of `help_text` for InlinePanel (Matt Westcott)
+* Fix: Ensure that `AbstractForm` & `AbstractEmailForm` page models correctly pass the form to the preview context (Dan Bentley)
 
 4.0.2 (23.09.2022)
 ~~~~~~~~~~~~~~~~~~

--- a/docs/releases/4.0.3.md
+++ b/docs/releases/4.0.3.md
@@ -17,3 +17,4 @@ depth: 1
 ### Bug fixes
 
  * Add back rendering of `help_text` for InlinePanel (Matt Westcott)
+ * Ensure that `AbstractForm` & `AbstractEmailForm` page models correctly pass the form to the preview context (Dan Bentley)

--- a/wagtail/contrib/forms/models.py
+++ b/wagtail/contrib/forms/models.py
@@ -288,6 +288,11 @@ class FormMixin:
         else:
             return super().serve_preview(request, mode_name)
 
+    def get_preview_context(self, request, mode_name):
+        context = super().get_preview_context(request, mode_name)
+        context["form"] = self.get_form(page=self, user=request.user)
+        return context
+
 
 def validate_to_address(value):
     for address in value.split(","):


### PR DESCRIPTION
We found when testing #9254 that a `FormMixin`'s form isn't visible in the preview.

This fix adds missing form to the preview context.

<!--
Thanks for contributing to Wagtail! 🎉

Before submitting, please review the [contributor guidelines](https://docs.wagtail.org/en/latest/contributing/index.html).
-->

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)