### PR TITLE
Block Usage report

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/reports/block_usage.html
+++ b/wagtail/admin/templates/wagtailadmin/reports/block_usage.html
@@ -1,0 +1,37 @@
+{% extends 'wagtailadmin/reports/base_report.html' %}
+{% load i18n wagtailadmin_tags %}
+
+{% block results %}
+    {% if blocks %}
+        <table class="listing">
+            <thead>
+                <tr>
+                    <th class="title">
+                        {% trans 'Name' %}
+                    </th>
+                    <th class="status">
+                        {% trans 'Usage' %}
+                    </th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for label, usage in blocks %}
+                    <tr>
+                        <td class="title" valign="top">
+                            {{ label }}
+                        </td>
+                        <td class="status" valign="top">
+                            {{ usage }}
+                        </td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    {% else %}
+        <p>{% trans "No blocks found." %}</p>
+    {% endif %}
+{% endblock %}
+
+{% block no_results %}
+    <p>{% trans "No blocks found." %}</p>
+{% endblock %}

--- a/wagtail/admin/urls/reports.py
+++ b/wagtail/admin/urls/reports.py
@@ -2,6 +2,7 @@ from django.urls import path
 
 from wagtail.admin.views.reports.aging_pages import AgingPagesView
 from wagtail.admin.views.reports.audit_logging import LogEntriesView
+from wagtail.admin.views.reports.block_usage import block_usage
 from wagtail.admin.views.reports.locked_pages import LockedPagesView
 from wagtail.admin.views.reports.workflows import WorkflowTasksView, WorkflowView
 
@@ -12,4 +13,5 @@ urlpatterns = [
     path("workflow_tasks/", WorkflowTasksView.as_view(), name="workflow_tasks"),
     path("site-history/", LogEntriesView.as_view(), name="site_history"),
     path("aging-pages/", AgingPagesView.as_view(), name="aging_pages"),
+    path("block-usage/", block_usage, name="block_usage"),
 ]

--- a/wagtail/admin/utils.py
+++ b/wagtail/admin/utils.py
@@ -1,7 +1,10 @@
+from collections import Counter
 from warnings import warn
 
+from django.apps import apps
 from django.conf import settings
 
+from wagtail.fields import StreamField
 from wagtail.utils.deprecation import RemovedInWagtail50Warning
 
 
@@ -20,3 +23,36 @@ def get_admin_base_url():
         admin_base_url = settings.BASE_URL
 
     return admin_base_url
+
+
+def get_block_usage():
+    """
+    Scans all StreamFields in the database and counts the number of times each block type has been used.
+
+    Returns:
+        A list of 2-tuples (block, usage_count) where 'block' is an instance of a Block and the usage_count
+        is the number of times that block has been used.
+    """
+    blocks = {}
+    counter = Counter()
+
+    for model in apps.get_models():
+        stream_fields = [
+            field
+            for field in model._meta.get_fields()
+            if isinstance(field, StreamField)
+        ]
+
+        if not stream_fields:
+            continue
+
+        for stream_values in model.objects.all().values_list(
+            *[field.name for field in stream_fields]
+        ):
+            for stream_value in stream_values:
+                blocks.update({id(block.block): block.block for block in stream_value})
+                counter.update(id(block.block) for block in stream_value)
+
+    return [
+        (blocks[block], usage_count) for block, usage_count in counter.most_common()
+    ]

--- a/wagtail/admin/views/reports/block_usage.py
+++ b/wagtail/admin/views/reports/block_usage.py
@@ -1,0 +1,15 @@
+from django.shortcuts import render
+from django.utils.translation import gettext as _
+
+from wagtail.admin.utils import get_block_usage
+
+
+def block_usage(request):
+    return render(
+        request,
+        "wagtailadmin/reports/block_usage.html",
+        {
+            "title": _("Block usage"),
+            "blocks": [(block.label, usage) for block, usage in get_block_usage()],
+        },
+    )

--- a/wagtail/admin/wagtail_hooks.py
+++ b/wagtail/admin/wagtail_hooks.py
@@ -955,6 +955,16 @@ def register_aging_pages_report_menu_item():
     )
 
 
+@hooks.register("register_reports_menu_item")
+def register_block_usage_report_menu_item():
+    return MenuItem(
+        _("Block usage"),
+        reverse("wagtailadmin_reports:block_usage"),
+        icon_name="form",
+        order=1200,
+    )
+
+
 @hooks.register("register_admin_menu_item")
 def register_reports_menu():
     return SubmenuMenuItem(_("Reports"), reports_menu, icon_name="site", order=9000)


### PR DESCRIPTION
This PR implements a report on how often blocks are used on a site.

![image](https://user-images.githubusercontent.com/1093808/193289076-1f58afc8-1a0d-492b-851b-ec99c8551725.png)

TODO:
 - [ ] Test performance on a large site (probably will be quite poor)
 - [ ] Add unit tests
 - [ ] Should we add a separate view to see the pages/snippets that use the block?