### PR TITLE
Fix some casing code in examples in API configuration docs

### DIFF
--- a/docs/advanced_topics/api/v2/configuration.md
+++ b/docs/advanced_topics/api/v2/configuration.md
@@ -117,18 +117,18 @@ class BlogPageAuthor(Orderable):
     ]
 
 
-class BlogPage(page):
+class BlogPage(Page):
     published_date = models.DateTimeField()
     body = RichTextField()
-    feed_image = models.ForeignKey('wagtailimages.Image', on_delete=models.SET_NULL, null=true, ...)
+    feed_image = models.ForeignKey('wagtailimages.Image', on_delete=models.SET_NULL, null=True, ...)
     private_field = models.CharField(max_length=255)
 
-    # export fields over the api
+    # Export fields over the API
     api_fields = [
         APIField('published_date'),
         APIField('body'),
         APIField('feed_image'),
-        APIField('authors'),  # this will nest the relevant BlogPageAuthor objects in the api response
+        APIField('authors'),  # This will nest the relevant BlogPageAuthor objects in the API response
     ]
 ```
 


### PR DESCRIPTION
Casing in this code example went askew with the rst -> md migration, it seems - It looks like someone has fixed up some of it, but the Page class and `True` were missed.

The comments have been updated with their casing from prior to the migration also