### PR TITLE
Remember last opened side panel in the editor on page load

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -43,6 +43,7 @@ Changelog
  * Switch StreamField blocks to use a `<section>` element so screen reader users can bypass them more easily (Thibaud Colas)
  * Add anchor links to StreamField blocks so users can navigate straight to a given block (Thibaud Colas)
  * Support "Ctrl + f" in-page search within collapsed StreamField blocks (Thibaud Colas)
+ * Remember the last opened side panel in the page editor, activating it on page load (Sage Abdullah)
  * Fix: Prevent `PageQuerySet.not_public` from returning all pages when no page restrictions exist (Mehrdad Moradizadeh)
  * Fix: Ensure that duplicate block ids are unique when duplicating stream blocks in the page editor (Joshua Munn)
  * Fix: Revise colour usage so that privacy & locked indicators can be seen in Windows High Contrast mode (LB (Ben Johnston))

--- a/client/scss/components/_form-side.scss
+++ b/client/scss/components/_form-side.scss
@@ -31,6 +31,10 @@
     @apply w-translate-x-0;
   }
 
+  &--initial {
+    @apply w-transition-none;
+  }
+
   &__close-button {
     @apply w-text-primary w-absolute w-left-3 w-top-3 hover:w-text-primary-200 w-bg-white w-p-3 w-hidden w-transition;
 

--- a/client/src/entrypoints/admin/preview-panel.js
+++ b/client/src/entrypoints/admin/preview-panel.js
@@ -43,6 +43,7 @@ function initPreview() {
     const deviceWidth = event.target.dataset.deviceWidth;
 
     setPreviewWidth(deviceWidth);
+    localStorage.setItem('wagtail-preview-panel-device', device);
 
     // Ensure only one device class is applied
     sizeInputs.forEach((input) => {
@@ -150,6 +151,9 @@ function initPreview() {
   };
 
   const setPreviewData = () => {
+    // Bail out if there is already a pending update
+    if (hasPendingUpdate) return Promise.resolve();
+
     hasPendingUpdate = true;
     spinnerTimeout = setTimeout(
       () => loadingSpinner.classList.remove('w-hidden'),
@@ -274,7 +278,13 @@ function initPreview() {
   clearPreviewData()
     .then(() => setPreviewData())
     .then(() => reloadIframe());
-  setPreviewWidth();
+
+  // Remember last selected device size
+  const lastDevice = localStorage.getItem('wagtail-preview-panel-device');
+  const lastDeviceInput =
+    previewPanel.querySelector(`[data-device-width][value="${lastDevice}"]`) ||
+    defaultSizeInput;
+  lastDeviceInput.click();
 }
 
 document.addEventListener('DOMContentLoaded', () => {

--- a/client/src/entrypoints/admin/preview-panel.js
+++ b/client/src/entrypoints/admin/preview-panel.js
@@ -43,7 +43,11 @@ function initPreview() {
     const deviceWidth = event.target.dataset.deviceWidth;
 
     setPreviewWidth(deviceWidth);
-    localStorage.setItem('wagtail-preview-panel-device', device);
+    try {
+      localStorage.setItem('wagtail:preview-panel-device', device);
+    } catch (e) {
+      // Skip saving the device if localStorage fails.
+    }
 
     // Ensure only one device class is applied
     sizeInputs.forEach((input) => {
@@ -280,7 +284,12 @@ function initPreview() {
     .then(() => reloadIframe());
 
   // Remember last selected device size
-  const lastDevice = localStorage.getItem('wagtail-preview-panel-device');
+  let lastDevice = null;
+  try {
+    lastDevice = localStorage.getItem('wagtail:preview-panel-device');
+  } catch (e) {
+    // Initialise with the default device if the last one cannot be restored.
+  }
   const lastDeviceInput =
     previewPanel.querySelector(`[data-device-width][value="${lastDevice}"]`) ||
     defaultSizeInput;

--- a/client/src/includes/sidePanel.js
+++ b/client/src/includes/sidePanel.js
@@ -1,7 +1,21 @@
 export default function initSidePanel() {
+  const sidePanelWrapper = document.querySelector('[data-form-side]');
+
+  // Abort if the side panel isn't available
+  if (!sidePanelWrapper) return;
+
+  // For now, we do not want to persist the side panel state in the explorer
+  const inExplorer = 'formSideExplorer' in sidePanelWrapper.dataset;
+
   const setPanel = (panelName) => {
-    const sidePanelWrapper = document.querySelector('[data-form-side]');
     const body = document.querySelector('body');
+    const selectedPanel = document.querySelector(
+      `[data-side-panel-toggle="${panelName}"]`,
+    );
+
+    // Abort if panelName is specified but it does not exist
+    if (panelName && !selectedPanel) return;
+
     // Open / close side panel
 
     // HACK: For now, the comments will show without the side-panel opening.
@@ -44,6 +58,11 @@ export default function initSidePanel() {
         toggle.dataset.sidePanelToggle === panelName ? 'true' : 'false',
       );
     });
+
+    // Remember last opened side panel if not in explorer
+    if (!inExplorer) {
+      localStorage.setItem('wagtail-side-panel-open', panelName);
+    }
   };
 
   const togglePanel = (panelName) => {
@@ -72,4 +91,19 @@ export default function initSidePanel() {
       setPanel('');
     });
   }
+
+  // Open the last opened panel if not in explorer,
+  // use timeout to allow comments to load first
+  setTimeout(() => {
+    const sidePanelOpen = localStorage.getItem('wagtail-side-panel-open');
+    if (!inExplorer && sidePanelOpen) {
+      setPanel(sidePanelOpen);
+    }
+
+    // Skip the animation on initial load only,
+    // use timeout to ensure the panel has been triggered to open
+    setTimeout(() => {
+      sidePanelWrapper.classList.remove('form-side--initial');
+    });
+  });
 }

--- a/client/src/includes/sidePanel.js
+++ b/client/src/includes/sidePanel.js
@@ -61,7 +61,11 @@ export default function initSidePanel() {
 
     // Remember last opened side panel if not in explorer
     if (!inExplorer) {
-      localStorage.setItem('wagtail-side-panel-open', panelName);
+      try {
+        localStorage.setItem('wagtail:side-panel-open', panelName);
+      } catch (e) {
+        // Proceed without saving the last-open panel.
+      }
     }
   };
 
@@ -95,9 +99,13 @@ export default function initSidePanel() {
   // Open the last opened panel if not in explorer,
   // use timeout to allow comments to load first
   setTimeout(() => {
-    const sidePanelOpen = localStorage.getItem('wagtail-side-panel-open');
-    if (!inExplorer && sidePanelOpen) {
-      setPanel(sidePanelOpen);
+    try {
+      const sidePanelOpen = localStorage.getItem('wagtail:side-panel-open');
+      if (!inExplorer && sidePanelOpen) {
+        setPanel(sidePanelOpen);
+      }
+    } catch (e) {
+      // Proceed without remembering the last-open panel.
     }
 
     // Skip the animation on initial load only,

--- a/docs/releases/4.1.md
+++ b/docs/releases/4.1.md
@@ -65,6 +65,7 @@ This feature was developed by Karl Hobley and Matt Westcott.
  * Switch StreamField blocks to use a `<section>` element so screen reader users can bypass them more easily (Thibaud Colas)
  * Add anchor links to StreamField blocks so users can navigate straight to a given block (Thibaud Colas)
  * Support "Ctrl + f" in-page search within collapsed StreamField blocks (Thibaud Colas)
+ * Remember the last opened side panel in the page editor, activating it on page load (Sage Abdullah)
 
 ### Bug fixes
 

--- a/wagtail/admin/templates/wagtailadmin/pages/index.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/index.html
@@ -7,7 +7,7 @@
     {% page_permissions parent_page as parent_page_perms %}
     <div class="w-sticky w-top-0 w-z-header">
         {% include 'wagtailadmin/pages/page_listing_header.html' with title=parent_page.get_admin_display_title page_perms=parent_page_perms %}
-        {% include "wagtailadmin/shared/side_panels.html" %}
+        {% include "wagtailadmin/shared/side_panels.html" with in_explorer=True %}
     </div>
     <form id="page-reorder-form">
         {% csrf_token %}

--- a/wagtail/admin/templates/wagtailadmin/shared/side_panels.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/side_panels.html
@@ -1,6 +1,6 @@
 {% load wagtailadmin_tags i18n %}
 
-<aside class="form-side" data-form-side>
+<aside class="form-side form-side--initial" data-form-side {% if in_explorer %}data-form-side-explorer{% endif %}>
     <button type="button" class="form-side__close-button" data-form-side-close-button aria-label="{% trans 'Toggle side panel' %}">
         {% icon name="expand-right" %}
     </button>

--- a/wagtail/admin/tests/pages/test_edit_page.py
+++ b/wagtail/admin/tests/pages/test_edit_page.py
@@ -149,6 +149,13 @@ class TestPageEdit(TestCase, WagtailTestUtils):
             '<button type="submit" name="action-submit" value="Submit to Moderators approval" class="button">',
         )
 
+        # test that side panel is shown
+        self.assertContains(
+            response,
+            '<aside class="form-side form-side--initial" data-form-side >',
+        )
+        self.assertNotContains(response, "data-form-side-explorer")
+
         # test that AdminURLFinder returns the edit view for the page
         url_finder = AdminURLFinder(self.user)
         expected_url = "/admin/pages/%d/edit/" % self.event_page.id

--- a/wagtail/admin/tests/pages/test_explorer_view.py
+++ b/wagtail/admin/tests/pages/test_explorer_view.py
@@ -418,6 +418,26 @@ class TestBreadcrumb(TestCase, WagtailTestUtils):
         self.assertContains(response, expected, html=True)
 
 
+class TestPageExplorerSidePanel(TestCase, WagtailTestUtils):
+    fixtures = ["test.json"]
+
+    def test_side_panel_present(self):
+        self.user = self.login()
+
+        # get the explorer view for a subpage of a SimplePage
+        page = Page.objects.get(url_path="/home/secret-plans/steal-underpants/")
+        response = self.client.get(reverse("wagtailadmin_explore", args=(page.id,)))
+        self.assertEqual(response.status_code, 200)
+
+        # The side panel should be present with data-form-side-explorer attribute
+        html = response.content.decode()
+        self.assertTagInHTML(
+            "<aside data-form-side data-form-side-explorer>",
+            html,
+            allow_extra_attrs=True,
+        )
+
+
 class TestPageExplorerSignposting(TestCase, WagtailTestUtils):
     fixtures = ["test.json"]
 


### PR DESCRIPTION
<!--
Thanks for contributing to Wagtail! 🎉

Before submitting, please review the [contributor guidelines](https://docs.wagtail.org/en/latest/contributing/index.html).
-->

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [x] **Please list the exact browser and operating system versions you tested**:
            Chrome 105.0.5195.125, Firefox 105.0.1, Safari 16.0
    -   [ ] **Please list which assistive technologies [^3] you tested**:

**Please describe additional details for testing this change**.

- Open the page/snippet editor
- Open one of the side panels
- Reload the page
- The last opened side panel should remain open on initial page load
- Close the side panel
- Reload the page
- The side panel should remain closed on initial page load
- Go to the page explorer
- Ensure that the behaviour of the side panel on the page explorer is completely independent of the page editor. It shouldn't remember the last opened side panel (i.e. it's always closed on initial page load) and opening/closing the side panel in the explorer shouldn't affect the side panel preferences in the page editor.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
