### PR TITLE
Documentation - clean up small typos and whitespace issues

### DIFF
--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -4,7 +4,7 @@
 
 The easiest way to contribute to Wagtail is to tell us how to improve it! First, check to see if your bug or feature request has already been submitted at [github.com/wagtail/wagtail/issues](https://github.com/wagtail/wagtail/issues). If it has, and you have some supporting information which may help us deal with it, comment on the existing issue. If not, please [create a new one](https://github.com/wagtail/wagtail/issues/new), providing as much relevant context as possible. For example, if you're experiencing problems with installation, detail your environment and the steps you've already taken. If something isn't displaying correctly, tell us what browser you're using, and include a screenshot if possible.
 
-If your bug report is a security issue, **do not** report it with an issue. Please read our ​guide to [reporting security issues](security).
+If your bug report is a security issue, **do not** report it with an issue. Please read our guide to [reporting security issues](security).
 
 ```{toctree}
 :maxdepth: 2

--- a/docs/reference/pages/theory.md
+++ b/docs/reference/pages/theory.md
@@ -110,10 +110,10 @@ In addition to scheduling a page to be published, it is also possible to schedul
 
 -   Scheduling is done by setting the _expire at_ field of the page and clicking _Publish_. If the _go-live at_ field is also set, then the unpublishing schedule will only be applied after the revision goes live.
 -   Consider a live page that is scheduled to be unpublished on e.g. 14 June. Then sometime before the schedule, consider that a new revision is scheduled to be published on a date that's **earlier** than the unpublishing schedule, e.g. 9 June. When the new revision goes live on 9 June, the _expire at_ field contained in the new revision will replace the existing unpublishing schedule. This means:
-    -    If the new revision contains a different _expire at_ field (e.g. 17 June), the new revision will go live on 9 June and the page will not be unpublished on 14 June but it will be unpublished on 17 June.
-    -    If the new revision has the _expire at_ field unset, the new revision will go live on 9 June and the unpublishing schedule will be unset, thus the page will not be unpublished.
+    -   If the new revision contains a different _expire at_ field (e.g. 17 June), the new revision will go live on 9 June and the page will not be unpublished on 14 June but it will be unpublished on 17 June.
+    -   If the new revision has the _expire at_ field unset, the new revision will go live on 9 June and the unpublishing schedule will be unset, thus the page will not be unpublished.
 -   Consider another live page that is scheduled to be unpublished on e.g. 14 June. Then sometime before the schedule, consider that a new revision is scheduled to be published on a date that's **later** than the unpublishing schedule, e.g. 21 June. The new revision will not take effect until it goes live on 21 June, so the page will still be unpublished on 14 June. This means:
-    -    If the new revision contains a different _expire at_ field (e.g. 25 June), the page will be unpublished on 14 June, the new revision will go live on 21 June and the page will be unpublished again on 25 June.
-    -    If the new revision has the _expire at_ field unset, the page will be unpublished on 14 June and the new revision will go live on 21 June.
+    -   If the new revision contains a different _expire at_ field (e.g. 25 June), the page will be unpublished on 14 June, the new revision will go live on 21 June and the page will be unpublished again on 25 June.
+    -   If the new revision has the _expire at_ field unset, the page will be unpublished on 14 June and the new revision will go live on 21 June.
 
 The same scheduling mechanism also applies to snippets with {class}`~wagtail.models.DraftStateMixin` applied. For more details, see [](wagtailsnippets_saving_draft_changes_of_snippets).

--- a/docs/releases/2.15.rst
+++ b/docs/releases/2.15.rst
@@ -67,7 +67,7 @@ Individual fixes were implemented by a large number of first-time and seasoned c
  * Update tab styles so the active tab can be identified (Dmitrii Faiazov, LB (Ben Johnston))
  * Make hamburger menu a button for tab and high contrast accessibility (Amy Chan, Dan Braghis)
  * Tag fields now have the correct background (Desai Akshata, LB (Ben Johnston))
- * Added sidebar vertical seperation with main content (Onkar Apte, LB (Ben Johnston))
+ * Added sidebar vertical separation with main content (Onkar Apte, LB (Ben Johnston))
  * Added vertical separation between field panels (Chakita Muttaraju, LB (Ben Johnston))
  * Switch widgets on/off states are now visually distinguishable (Sakshi Uppoor, Thibaud Colas)
  * Checkbox widgets on/off states are now visually distinguishable (Thibaud Colas, Jacob Topp-Mugglestone, LB (Ben Johnston))

--- a/docs/support.md
+++ b/docs/support.md
@@ -28,7 +28,7 @@ Our [Github discussion boards](https://github.com/wagtail/wagtail/discussions) a
 
 If you think you've found a bug in Wagtail, or you'd like to suggest a new feature, please check the current list at [github.com/wagtail/wagtail/issues](https://github.com/wagtail/wagtail/issues). If your bug or suggestion isn't there, raise a new issue, providing as much relevant context as possible.
 
-If your bug report is a security issue, **do not** report it with an issue. Please read our ​guide to [reporting security issues](../contributing/security).
+If your bug report is a security issue, **do not** report it with an issue. Please read our guide to [reporting security issues](../contributing/security).
 
 ## Torchbox
 

--- a/docs/topics/snippets.md
+++ b/docs/topics/snippets.md
@@ -395,7 +395,6 @@ class Advert(ClusterableModel):
 
 The [documentation on tagging pages](tagging) has more information on how to use tags in views.
 
-
 (wagtailsnippets_custom_admin_views)=
 
 ## Customising snippets admin views
@@ -439,7 +438,7 @@ class MemberFilterSet(WagtailFilterSet):
         fields = ["shirt_size"]
 ```
 
-You can define a {attr}`~wagtail.snippets.views.snippets.SnippetViewSet.list_display` attribute to specify the columns shown on the listing view. You can also add the ability to filter the listing view by defining a {attr}`~wagtail.snippets.views.snippets.SnippetViewSet.filterset_class` attribute on a subclass of `SnippetViewSet`.  For example:
+You can define a {attr}`~wagtail.snippets.views.snippets.SnippetViewSet.list_display` attribute to specify the columns shown on the listing view. You can also add the ability to filter the listing view by defining a {attr}`~wagtail.snippets.views.snippets.SnippetViewSet.filterset_class` attribute on a subclass of `SnippetViewSet`. For example:
 
 ```python
 # views.py


### PR DESCRIPTION
- Some files had zero-width spaces
- Fix one typo
- Fix formatting / line breaks in some markdown
