### PR TITLE
Make side panels resizable

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -9,6 +9,7 @@ Changelog
  * Ensure that the `rebuild_references_index` command can run without console output if called with `--verbosity 0` (Omerzahid Ali, Aman Pandey)
  * Add full support for secondary buttons with icons in the Wagtail design system - `button bicolor button--icon button-secondary` including the `button-small` variant (Seremba Patrick)
  * Add `purge_embeds` management command to delete all the cached embed objects in the database (Aman Pandey)
+ * Make it possible to resize the page editor’s side panels (Sage Abdullah)
  * Fix: Make sure workflow timeline icons are visible in high-contrast mode (Loveth Omokaro)
  * Fix: Ensure authentication forms (login, password reset) have a visible border in Windows high-contrast mode (Loveth Omokaro)
  * Fix: Ensure visual consistency between buttons and links as buttons in Windows high-contrast mode (Albina Starykova)

--- a/client/scss/components/_form-side.scss
+++ b/client/scss/components/_form-side.scss
@@ -6,6 +6,14 @@
   @apply w-overflow-y-hidden sm:w-overflow-y-auto;
 }
 
+.side-panel-resizing {
+  @apply w-select-none w-cursor-ew-resize;
+
+  .form-side {
+    @apply w-transition;
+  }
+}
+
 .form-side {
   @apply w-absolute
       w-right-0
@@ -15,18 +23,16 @@
       md:w-w-1/3
       w-transform
       w-translate-x-full
-      w-px-5
-      xl:w-px-10
-      w-py-4
       w-bg-white
       w-box-border
-      w-transition
+      w-transition-all
+      motion-reduce:w-transition-none
       w-duration-300
       w-border-l
       w-border-grey-100
-      w-overflow-y-auto
-      w-scrollbar-thin
+      w-min-w-full
       md:w-min-w-[22.875rem]
+      w-max-w-full
       sm:w-max-w-[22.5rem]
       md:w-max-w-[35.937rem]
       lg:w-max-w-[31.25rem]
@@ -41,6 +47,10 @@
     @apply w-transition-none;
   }
 
+  &--preview {
+    @apply sm:w-max-w-[70vw];
+  }
+
   &__close-button {
     @apply w-text-primary w-absolute w-left-3 w-top-3 hover:w-text-primary-200 w-bg-white w-p-3 w-hidden w-transition;
 
@@ -49,12 +59,45 @@
     }
   }
 
+  &__resize-grip-container {
+    @apply w-absolute w-place-items-center w-hidden md:w-flex w-z-10 w-left-[-21.5px];
+
+    height: calc(100% - theme('spacing.8'));
+  }
+
+  &__resize-grip {
+    @apply w-text-primary hover:w-text-primary-200 w-border w-border-transparent w-rounded w-bg-white w-p-3 w-hidden w-touch-pinch-zoom w-cursor-ew-resize;
+
+    .form-side--open & {
+      @apply w-flex;
+    }
+
+    &:focus-within:has(:focus-visible) {
+      @include focus-outline;
+    }
+
+    @supports not selector(:focus-visible) {
+      &:focus-within {
+        /* Fallback for browsers without :focus-visible support */
+        @include focus-outline;
+      }
+    }
+
+    .icon {
+      @apply w-w-4 w-h-4;
+    }
+  }
+
+  &__width-input {
+    @apply w-w-0 w-h-0 w-opacity-0 w-absolute w-pointer-events-none;
+  }
+
   &--open .form-side__close-button,
   &--open .form-side__panel {
     @apply w-block;
   }
 
   &__panel {
-    @apply w-hidden w-h-full;
+    @apply w-px-5 xl:w-px-10 w-py-4 w-w-full w-h-full w-overflow-y-auto w-scrollbar-thin w-hidden;
   }
 }

--- a/client/scss/components/_preview-panel.scss
+++ b/client/scss/components/_preview-panel.scss
@@ -19,6 +19,7 @@
   }
 
   &__wrapper {
+    position: relative;
     width: calc(var(--preview-iframe-width) * var(--preview-width-ratio));
     height: 100%;
     margin-inline-start: auto;

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -19,6 +19,7 @@ depth: 1
  * Ensure that the `rebuild_references_index` command can run without console output if called with `--verbosity 0` (Omerzahid Ali, Aman Pandey)
  * Add full support for secondary buttons with icons in the Wagtail design system - `button bicolor button--icon button-secondary` including the `button-small` variant (Seremba Patrick)
  * Add [`purge_embeds`](purge_embeds) management command to delete all the cached embed objects in the database (Aman Pandey)
+ * Make it possible to resize the page editor’s side panels (Sage Abdullah)
 
 ### Bug fixes
 

--- a/wagtail/admin/templates/wagtailadmin/shared/side_panels.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/side_panels.html
@@ -5,6 +5,14 @@
         {% icon name="expand-right" %}
     </button>
 
+    <div class="form-side__resize-grip-container">
+        <label class="form-side__resize-grip" data-form-side-resize-grip>
+            <input type="range" step="10" class="form-side__width-input" name="wagtail-side-panel-width" data-form-side-width-input />
+            <span class="w-sr-only">{% trans 'Side panel width' %}</span>
+            {% icon name="grip" %}
+        </label>
+    </div>
+
     {% for panel in side_panels %}
         <div class="form-side__panel" data-side-panel="{{ panel.name }}" hidden>
             <h2 id="side-panel-{{ panel.name }}-title" class="w-sr-only">{{ panel.title }}</h2>


### PR DESCRIPTION
This PR adds a resize grip to the side panel that resizes the side panel when dragged. Works with mouse, touch, and keyboard.

For keyboard accessibility, the side panel is resizable using an invisible `<input type="range" />` that's wrapped inside the "grip". To use it, focus on the grip and press left and right buttons on your keyboard.

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [x] **Please list the exact browser and operating system versions you tested**: Chrome 107, Firefox 106, Safari 15.4
    -   [x] **Please list which assistive technologies [^3] you tested**: VoiceOver on macOS Ventura 13.0.1

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
