### PR TITLE
Adding test to make sure ordering is valid ordering based on the r…

### DIFF
--- a/wagtail/users/tests/test_admin_views.py
+++ b/wagtail/users/tests/test_admin_views.py
@@ -196,10 +196,12 @@ class TestUserIndexView(TestCase, WagtailTestUtils):
             self.assertEqual(response.status_code, 200)
 
     def test_valid_ordering(self):
-        # checking that only valid ordering used
-        # in case of `IndexView` the valid ordering fields are "name" and "username".
+        # checking that only valid ordering used, in case of `IndexView` the valid
+        # ordering fields are "name" and "username".
         response = self.get({"ordering": "email"})
         self.assertNotEqual(response.context_data["ordering"], "email")
+        # name is default ordering in `IndexView`.
+        self.assertEqual(response.context_data["ordering"], "name")
         response = self.get({"ordering": "username"})
         self.assertEqual(response.context_data["ordering"], "username")
 

--- a/wagtail/users/tests/test_admin_views.py
+++ b/wagtail/users/tests/test_admin_views.py
@@ -195,6 +195,14 @@ class TestUserIndexView(TestCase, WagtailTestUtils):
             response = self.get({"p": page})
             self.assertEqual(response.status_code, 200)
 
+    def test_valid_ordering(self):
+        # checking that only valid ordering used
+        # in case of `IndexView` the valid ordering fields are "name" and "username".
+        response = self.get({"ordering": "email"})
+        self.assertNotEqual(response.context_data["ordering"], "email")
+        response = self.get({"ordering": "username"})
+        self.assertEqual(response.context_data["ordering"], "username")
+
 
 class TestUserCreateView(TestCase, WagtailTestUtils):
     def setUp(self):


### PR DESCRIPTION
As mentioned in https://github.com/wagtail/wagtail/pull/9114#pullrequestreview-1129217790 `wagtail.users.views.users.index` does not have test coverage to make sure that the `ordering` is valid ordering based on the result of `get_valid_orderings`. This PR adds a test to ensure that the bug does not happen again.