### PR TITLE
Add test case for preview requests on sites with a per-site cache

### DIFF
--- a/wagtail/test/routablepage/models.py
+++ b/wagtail/test/routablepage/models.py
@@ -63,4 +63,4 @@ class RoutablePageTest(RoutablePage):
 class RoutablePageWithOverriddenIndexRouteTest(RoutablePage):
     @route(r"^$")
     def main(self, request):
-        return HttpResponse("OVERRIDDEN INDEX ROUTE")
+        return HttpResponse("OVERRIDDEN INDEX ROUTE title=" + self.title)


### PR DESCRIPTION
This contains the extracted test case from the PR #7581, which solved a caching issue. That issue has been fixed later by #8709 for wagtail >= 4.

You can trigger a failing test by removing the important call to `patch_cache_control` (which disables caching) here:
https://github.com/wagtail/wagtail/blob/dbe87bdc5d76afc967e5bb1bd245676044833473/wagtail/models/__init__.py#L623

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
