### PR TITLE
Run Python tests with coverage and upload coverage data to codecov

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,9 +59,14 @@ jobs:
           pip install "${{ matrix.django }}"
       - name: Test
         run: |
-          ./runtests.py
+          coverage run --parallel-mode --source wagtail runtests.py
         env:
           DATABASE_ENGINE: django.db.backends.sqlite3
+      - name: Upload coverage data
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage-data
+          path: .coverage.*
 
   test-postgres:
     runs-on: ubuntu-latest
@@ -114,7 +119,7 @@ jobs:
           ${{ matrix.install_extras }}
       - name: Test
         run: |
-          ./runtests.py
+          coverage run --parallel-mode --source wagtail runtests.py
         env:
           DATABASE_ENGINE: django.db.backends.postgresql
           DATABASE_HOST: localhost
@@ -122,6 +127,11 @@ jobs:
           DATABASE_PASSWORD: postgres
           USE_EMAIL_USER_MODEL: ${{ matrix.emailuser }}
           DISABLE_TIMEZONE: ${{ matrix.notz }}
+      - name: Upload coverage data
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage-data
+          path: .coverage.*
 
   test-mysql:
     runs-on: ubuntu-latest
@@ -163,11 +173,16 @@ jobs:
           pip install "${{ matrix.django }}"
       - name: Test
         run: |
-          ./runtests.py
+          coverage run --parallel-mode --source wagtail runtests.py
         env:
           DATABASE_ENGINE: django.db.backends.mysql
           DATABASE_HOST: '127.0.0.1'
           DATABASE_USER: root
+      - name: Upload coverage data
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage-data
+          path: .coverage.*
 
   # https://github.com/elastic/elastic-github-actions doesn't work for Elasticsearch 5,
   # but https://github.com/getong/elasticsearch-action does
@@ -207,9 +222,14 @@ jobs:
           pip install certifi
       - name: Test
         run: |
-          ./runtests.py wagtail.search wagtail.documents wagtail.images --elasticsearch5
+          coverage run --parallel-mode --source wagtail runtests.py wagtail.search wagtail.documents wagtail.images --elasticsearch5
         env:
           DATABASE_ENGINE: django.db.backends.sqlite3
+      - name: Upload coverage data
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage-data
+          path: .coverage.*
 
   test-sqlite-elasticsearch7:
     runs-on: ubuntu-latest
@@ -248,10 +268,15 @@ jobs:
           pip install certifi
       - name: Test
         run: |
-          ./runtests.py wagtail.search wagtail.documents wagtail.images --elasticsearch7
+          coverage run --parallel-mode --source wagtail runtests.py wagtail.search wagtail.documents wagtail.images --elasticsearch7
         env:
           DATABASE_ENGINE: django.db.backends.sqlite3
           USE_EMAIL_USER_MODEL: ${{ matrix.emailuser }}
+      - name: Upload coverage data
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage-data
+          path: .coverage.*
 
   # https://github.com/getong/elasticsearch-action doesn't work for Elasticsearch 6,
   # but https://github.com/elastic/elastic-github-actions does
@@ -297,13 +322,18 @@ jobs:
           pip install certifi
       - name: Test
         run: |
-          ./runtests.py wagtail.search wagtail.documents wagtail.images --elasticsearch6
+          coverage run --parallel-mode --source wagtail runtests.py wagtail.search wagtail.documents wagtail.images --elasticsearch6
         env:
           DATABASE_ENGINE: django.db.backends.postgresql
           DATABASE_HOST: localhost
           DATABASE_USER: postgres
           DATABASE_PASSWORD: postgres
           USE_EMAIL_USER_MODEL: ${{ matrix.emailuser }}
+      - name: Upload coverage data
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage-data
+          path: .coverage.*
 
   test-postgres-elasticsearch7:
     runs-on: ubuntu-latest
@@ -349,10 +379,54 @@ jobs:
           pip install certifi
       - name: Test
         run: |
-          ./runtests.py wagtail.search wagtail.documents wagtail.images --elasticsearch7
+          coverage run --parallel-mode --source wagtail runtests.py wagtail.search wagtail.documents wagtail.images --elasticsearch7
         env:
           DATABASE_ENGINE: django.db.backends.postgresql
           DATABASE_HOST: localhost
           DATABASE_USER: postgres
           DATABASE_PASSWORD: postgres
           USE_EMAIL_USER_MODEL: ${{ matrix.emailuser }}
+      - name: Upload coverage data
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage-data
+          path: .coverage.*
+
+  coverage:
+    needs:
+      - test-sqlite
+      - test-postgres
+      - test-mysql
+      - test-sqlite-elasticsearch5
+      - test-sqlite-elasticsearch7
+      - test-postgres-elasticsearch6
+      - test-postgres-elasticsearch7
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install coverage
+
+      - name: Download coverage data
+        uses: actions/download-artifact@v3
+        with:
+          name: coverage-data
+
+      - name: Combine coverage data
+        run: |
+          coverage combine
+          coverage report -m --skip-covered
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          flags: backend


### PR DESCRIPTION
Fixes #9283.

I don't know whether we should run this on the whole CI setup (including PRs) or just `push` events, though. Currently this config will always (including PRs) run the tests on GitHub Actions with `coverage --parallel-mode`, upload the partial coverage data as artifacts, combine them all with `coverage combine`, then upload the result to Codecov.

I didn't bother adding `coverage` to our CircleCI setup as combining the coverage with the ones from GitHub Actions would be a pain, and there's not much point in doing so as the setup there should match one of the GitHub Actions job anyway.

I've tested this config on my personal account here and it seems to work: https://github.com/laymonage/wagtail-unforked/pull/1

I added a `backend` flag for the Python coverage so we can see both the combined and separate coverage on Codecov. Example:

https://app.codecov.io/github/laymonage/wagtail-unforked/flags

(Don't know why the frontend says "No Data" though, maybe because I just ran the tests a few minutes ago. We'll see if it shows up later.)