### PR TITLE
double code remove in views.py, unuse able else conditions remove in locks.py and gettext_lazy remove because django4.0 is remove on this place use gettext

### DIFF
--- a/wagtail/forms.py
+++ b/wagtail/forms.py
@@ -1,12 +1,11 @@
 from django import forms
 from django.utils.crypto import constant_time_compare
 from django.utils.translation import gettext as _
-from django.utils.translation import gettext_lazy
 
 
 class PasswordViewRestrictionForm(forms.Form):
     password = forms.CharField(
-        label=gettext_lazy("Password"), widget=forms.PasswordInput
+        label=_("Password"), widget=forms.PasswordInput
     )
     return_url = forms.CharField(widget=forms.HiddenInput)
 

--- a/wagtail/locks.py
+++ b/wagtail/locks.py
@@ -38,8 +38,7 @@ class BasicLock(BaseLock):
     def for_user(self, user):
         if getattr(settings, "WAGTAILADMIN_GLOBAL_PAGE_EDIT_LOCK", False):
             return True
-        else:
-            return user.pk != self.page.locked_by_id
+        return user.pk != self.page.locked_by_id
 
     def get_message(self, user):
         if self.page.locked_by_id == user.pk:
@@ -49,26 +48,22 @@ class BasicLock(BaseLock):
                     self.page.get_admin_display_title(),
                     self.page.locked_at.strftime("%d %b %Y %H:%M"),
                 )
-
-            else:
-                return format_html(
-                    _("<b>Page '{}' is locked</b> by <b>you</b>."),
-                    self.page.get_admin_display_title(),
-                )
-        else:
-            if self.page.locked_by and self.page.locked_at:
-                return format_html(
-                    _("<b>Page '{}' was locked</b> by <b>{}</b> on <b>{}</b>."),
-                    self.page.get_admin_display_title(),
-                    str(self.page.locked_by),
-                    self.page.locked_at.strftime("%d %b %Y %H:%M"),
-                )
-            else:
-                # Page was probably locked with an old version of Wagtail, or a script
-                return format_html(
-                    _("<b>Page '{}' is locked</b>."),
-                    self.page.get_admin_display_title(),
-                )
+            return format_html(
+                _("<b>Page '{}' is locked</b> by <b>you</b>."),
+                self.page.get_admin_display_title(),
+            )
+        if self.page.locked_by and self.page.locked_at:
+            return format_html(
+                _("<b>Page '{}' was locked</b> by <b>{}</b> on <b>{}</b>."),
+                self.page.get_admin_display_title(),
+                str(self.page.locked_by),
+                self.page.locked_at.strftime("%d %b %Y %H:%M"),
+            )
+        # Page was probably locked with an old version of Wagtail, or a script
+        return format_html(
+            _("<b>Page '{}' is locked</b>."),
+            self.page.get_admin_display_title(),
+        )
 
 
 class WorkflowLock(BaseLock):

--- a/wagtail/views.py
+++ b/wagtail/views.py
@@ -35,9 +35,8 @@ def authenticate_with_password(request, page_view_restriction_id, page_id):
     """
     restriction = get_object_or_404(PageViewRestriction, id=page_view_restriction_id)
     page = get_object_or_404(Page, id=page_id).specific
-
+    form = PasswordViewRestrictionForm(instance=restriction, request.POST or None)
     if request.method == "POST":
-        form = PasswordViewRestrictionForm(request.POST, instance=restriction)
         if form.is_valid():
             return_url = form.cleaned_data["return_url"]
 
@@ -48,8 +47,6 @@ def authenticate_with_password(request, page_view_restriction_id, page_id):
 
             restriction.mark_as_passed(request)
             return redirect(return_url)
-    else:
-        form = PasswordViewRestrictionForm(instance=restriction)
 
     action_url = reverse(
         "wagtailcore_authenticate_with_password", args=[restriction.id, page.id]


### PR DESCRIPTION
…locks.py and gettext_lazy remove because django4.0 is remove on this place use gettext

<!--
Thanks for contributing to Wagtail! 🎉

Before submitting, please review the [contributor guidelines](https://docs.wagtail.org/en/latest/contributing/index.html).
-->

_Please check the following:_

-   [ ] Do the tests still pass?[^1]
-   [ ] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
