### PR TITLE
Extend the rich-text feature registry to allow adding rewriters

### DIFF
--- a/docs/extending/rich_text_internals.md
+++ b/docs/extending/rich_text_internals.md
@@ -204,20 +204,20 @@ If you need to add a new rich text feature that does not fit the pattern of the 
 Rewriters must be callables, that receive a single argument - the rich-text HTML - and are registered with the `register_frontend_rewriter` call on the rich-text `features` object. By convention they are written as classes with a `__call__` method, but a function would also suffice for simple replacers.
 
 ```python
-class GreenRewriter:
-    TAG_RE = re.compile(r"<green>(.+?)</green>")
+class MaoriRewriter:
+    TAG_RE = re.compile(r"<maori>(.+?)</maori>")
 
     def replace_tag(self, match):
         content = match.groups(1)[0]
-        return '<span style="color: green">{content}</span>'.format(content=content)
+        return '<span lang="mi">{content}</span>'.format(content=content)
 
     def __call__(self, html):
         return self.TAG_RE.sub(self.replace_tag, html)
 
 
 @hooks.register("register_rich_text_features")
-def register_green_feature(features):
-    features.register_frontend_rewriter(GreenRewriter(), order=300)
+def register_maori_feature(features):
+    features.register_frontend_rewriter(MaoriRewriter(), order=300)
 ```
 
 Note that as the rewriters do not have any defined specificity, the registration method takes an optional `order` value, in case the order of execution is significant. The default Link and Embed rewriters have an order of 100 and 200, respectively, so you will usually want to add your rewriters after these (with a larger number for `order`).

--- a/wagtail/rich_text/__init__.py
+++ b/wagtail/rich_text/__init__.py
@@ -23,6 +23,7 @@ features = FeatureRegistry()
 def get_rewriter():
     embed_rules = features.get_embed_types()
     link_rules = features.get_link_types()
+    extra_rewriters = features.get_frontend_rewriters()
     return MultiRuleRewriter(
         [
             LinkRewriter(
@@ -46,6 +47,7 @@ def get_rewriter():
                 },
             ),
         ]
+        + extra_rewriters
     )
 
 

--- a/wagtail/rich_text/feature_registry.py
+++ b/wagtail/rich_text/feature_registry.py
@@ -38,6 +38,11 @@ class FeatureRegistry:
         # HTML fragment to replace it with
         self.embed_types = {}
 
+        # a series of rewriter classes, and their ordering, for rewriting custom tags in the
+        # database representation of richtext into the frontend representation. Used for adding an
+        # entirely new concept to rich text, outside of the default link and embed rewriters
+        self.frontend_rewriters = []
+
         # a dict of dicts, one for each converter backend (editorhtml, contentstate etc);
         # each dict is a mapping of feature names to 'rule' objects that define how to convert
         # that feature's elements between editor representation and database representation
@@ -97,6 +102,18 @@ class FeatureRegistry:
             return self.converter_rules_by_converter[converter_name][feature_name]
         except KeyError:
             return None
+
+    def register_frontend_rewriter(self, rewriter, order=300):
+        self.frontend_rewriters.append({"rewriter": rewriter, "order": order})
+
+    def get_frontend_rewriters(self):
+        if not self.has_scanned_for_features:
+            self._scan_for_features()
+
+        return [
+            r["rewriter"]
+            for r in sorted(self.frontend_rewriters, key=lambda e: e["order"])
+        ]
 
     @staticmethod
     def function_as_entity_handler(identifier, fn):

--- a/wagtail/tests/test_rich_text.py
+++ b/wagtail/tests/test_rich_text.py
@@ -154,14 +154,20 @@ class TestFeatureRegistry(TestCase):
         self.assertIsNone(features.get_editor_plugin("draftail", "made_up_feature"))
 
     def test_rewriters_registry(self):
-        # testapp/wagtail_hooks.py defines a 'green' rich text feature and rewriter - test
-        # that it comes back in the list, and is in the correct order
+        # testapp/wagtail_hooks.py defines a rich text feature and rewriter for
+        # each "green" and "embedoverlapping" - test that it comes back in the
+        # list, and is in the correct order
         features = FeatureRegistry()
 
         rewriters = features.get_frontend_rewriters()
-        # Expect only the Green rewriter -- Link and Embed are added later
-        self.assertEqual(len(rewriters), 1)
+        # Expect only the two added rewriters -- Link and Embed are added later
+        self.assertEqual(len(rewriters), 2)
 
+        embed_overlapping_rewriter = rewriters[0]
+        self.assertEqual(
+            embed_overlapping_rewriter.__class__.__name__,
+            "EmbedOverlappingRewriter",
+        )
         green_rewriter = rewriters[-1]
         self.assertEqual(green_rewriter.__class__.__name__, "GreenRewriter")
 
@@ -335,4 +341,22 @@ class TestCustomRichTextRewriter(TestCase):
     def test_custom_tag_replacement(self):
         expanded = expand_db_html("<green>traffic light</green>")
         self.assertNotIn("<green>", expanded)
-        self.assertEqual(expanded, '<span style="color: green">traffic light</span>')
+        self.assertEqual(expanded, '<span class="make-me-green">traffic light</span>')
+
+    def test_ordering_expecting_replacement(self):
+        url = "https://upload.wikimedia.org/wikipedia/commons/c/c8/Example.ogg"
+        expanded = expand_db_html(
+            '<embed audio_source="{}" embedtype="media" url="https://www.youtube.com/watch?v=dQw4w9WgXcQ"/>'.format(
+                url
+            )
+        )
+        self.assertIn("", expanded)
+        self.assertIn('<audio controls src="{}"></audio>'.format(url), expanded)
+        self.assertNotIn("dQw4w9WgXcQ", expanded)
+
+    def test_ordering_expecting_fallthrough(self):
+        expanded = expand_db_html(
+            '<embed embedtype="media" url="https://www.youtube.com/watch?v=dQw4w9WgXcQ"/>'
+        )
+        self.assertIn("dQw4w9WgXcQ", expanded)
+        self.assertNotIn("audio controls", expanded)

--- a/wagtail/tests/test_rich_text.py
+++ b/wagtail/tests/test_rich_text.py
@@ -153,6 +153,18 @@ class TestFeatureRegistry(TestCase):
         self.assertIsNone(features.get_editor_plugin("made_up_editor", "blockquote"))
         self.assertIsNone(features.get_editor_plugin("draftail", "made_up_feature"))
 
+    def test_rewriters_registry(self):
+        # testapp/wagtail_hooks.py defines a 'green' rich text feature and rewriter - test
+        # that it comes back in the list, and is in the correct order
+        features = FeatureRegistry()
+
+        rewriters = features.get_frontend_rewriters()
+        # Expect only the Green rewriter -- Link and Embed are added later
+        self.assertEqual(len(rewriters), 1)
+
+        green_rewriter = rewriters[-1]
+        self.assertEqual(green_rewriter.__class__.__name__, "GreenRewriter")
+
 
 class TestLinkRewriterTagReplacing(TestCase):
     def test_should_follow_default_behaviour(self):
@@ -317,3 +329,10 @@ class TestRichTextMaxLengthValidator(TestCase):
         self.assertEqual(validator.clean("<p>U+2764 U+FE0F ❤️</p>"), 16)
         # Counts symbols with zero-width joiners.
         self.assertEqual(validator.clean("<p>👨‍👨‍👧</p>"), 5)
+
+
+class TestCustomRichTextRewriter(TestCase):
+    def test_custom_tag_replacement(self):
+        expanded = expand_db_html("<green>traffic light</green>")
+        self.assertNotIn("<green>", expanded)
+        self.assertEqual(expanded, '<span style="color: green">traffic light</span>')


### PR DESCRIPTION
The ability to add custom frontend-rewriters allows cleaner implementation of new types of rich-text formatting, and completes the interface to allow this.

To date, my primary use case for this approach has been to add language markup around text on mixed-language pages, where sometimes a single word or sentence may need to be marked as in a different language to comply with WCAG AA requirements.

An existing implementation I have patched in replaced the `global` FRONTEND_REWRITERS before the blocks are rendered, but this is messy and fragile (and broken by #9170), as it requires rebuilding the link and embed rewriters, then adding on the extra.