### PR TITLE
Improve explanations in getting started tutorial

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -630,6 +630,7 @@ Contributors
 * Adinapunyo Banerjee
 * Dan Hayden
 * Jadesola Kareem
+* Dauda Yusuf
 
 
 Translators

--- a/docs/getting_started/index.md
+++ b/docs/getting_started/index.md
@@ -19,13 +19,13 @@
 
 ## Quick install
 
-Run the following in a virtual environment of your choice:
+Run the following commands in a virtual environment of your choice:
 
 ```sh
 $ pip install wagtail
 ```
 
-(Installing outside a virtual environment may require `sudo`.)
+(Installing wagtail outside a virtual environment may require `sudo`. sudo is a program for unix-like computer operating system that enables users to run programs with the security privileges of another user, by default the superuser)
 
 Once installed, Wagtail provides a command similar to Django\'s `django-admin startproject` to generate a new site/project:
 
@@ -41,9 +41,9 @@ Inside your `mysite` folder, run the setup steps necessary for any Django projec
 
 ```sh
 $ pip install -r requirements.txt
-$ ./manage.py migrate
-$ ./manage.py createsuperuser
-$ ./manage.py runserver
+$ python manage.py migrate
+$ python manage.py createsuperuser
+$ python manage.py runserver
 ```
 
 Your site is now accessible at `http://localhost:8000`, with the admin backend available at `http://localhost:8000/admin/`.

--- a/docs/getting_started/index.md
+++ b/docs/getting_started/index.md
@@ -25,7 +25,7 @@ Run the following commands in a virtual environment of your choice:
 $ pip install wagtail
 ```
 
-(Installing wagtail outside a virtual environment may require `sudo`. sudo is a program for unix-like computer operating system that enables users to run programs with the security privileges of another user, by default the superuser)
+(Installing wagtail outside a virtual environment may require `sudo`. sudo is a program to run other programs with the security privileges of another user, by default the superuser)
 
 Once installed, Wagtail provides a command similar to Django\'s `django-admin startproject` to generate a new site/project:
 

--- a/docs/getting_started/integrating_into_django.md
+++ b/docs/getting_started/integrating_into_django.md
@@ -113,6 +113,6 @@ Superuser accounts receive automatic access to the Wagtail admin interface; use 
 
 ## Start developing
 
-You're now ready to add a new app to your Django project (via `python manage.py startapp` - remember to add it to `INSTALLED_APPS`) in your settings.py file and set up page models, as described in [Your first Wagtail site](/getting_started/tutorial).
+You're now ready to add a new app to your Django project (via `python manage.py startapp` - remember to add it to `INSTALLED_APPS` in your settings.py file) and set up page models, as described in [Your first Wagtail site](/getting_started/tutorial).
 
 Note that there's one small difference when not using the Wagtail project template: Wagtail creates an initial homepage of the basic type `Page`, which does not include any content fields beyond the title. You'll probably want to replace this with your own `HomePage` class - when you do so, ensure that you set up a site record (under Settings / Sites in the Wagtail admin) to point to the new homepage.

--- a/docs/getting_started/integrating_into_django.md
+++ b/docs/getting_started/integrating_into_django.md
@@ -12,7 +12,7 @@ or add the package to your existing requirements file. This will also install th
 
 ## Settings
 
-In your settings file, add the following apps to `INSTALLED_APPS`:
+In your settings.py file, add the following apps to `INSTALLED_APPS`:
 
 ```python
 'wagtail.contrib.forms',
@@ -105,14 +105,14 @@ urlpatterns = [
 
 Note that this only works in development mode (`DEBUG = True`); in production, you will need to configure your web server to serve files from `MEDIA_ROOT`. For further details, see the Django documentation: [Serving files uploaded by a user during development](https://docs.djangoproject.com/en/stable/howto/static-files/#serving-files-uploaded-by-a-user-during-development) and [Deploying static files](https://docs.djangoproject.com/en/stable/howto/static-files/deployment/).
 
-With this configuration in place, you are ready to run `./manage.py migrate` to create the database tables used by Wagtail.
+With this configuration in place, you are ready to run `python manage.py migrate` to create the database tables used by Wagtail.
 
 ## User accounts
 
-Superuser accounts receive automatic access to the Wagtail admin interface; use `./manage.py createsuperuser` if you don't already have one. Custom user models are supported, with some restrictions; Wagtail uses an extension of Django's permissions framework, so your user model must at minimum inherit from `AbstractBaseUser` and `PermissionsMixin`.
+Superuser accounts receive automatic access to the Wagtail admin interface; use `python manage.py createsuperuser` if you don't already have one. Custom user models are supported, with some restrictions; Wagtail uses an extension of Django's permissions framework, so your user model must at minimum inherit from `AbstractBaseUser` and `PermissionsMixin`.
 
 ## Start developing
 
-You're now ready to add a new app to your Django project (via `./manage.py startapp` - remember to add it to `INSTALLED_APPS`) and set up page models, as described in [Your first Wagtail site](/getting_started/tutorial).
+You're now ready to add a new app to your Django project (via `python manage.py startapp` - remember to add it to `INSTALLED_APPS`) in your settings.py file and set up page models, as described in [Your first Wagtail site](/getting_started/tutorial).
 
 Note that there's one small difference when not using the Wagtail project template: Wagtail creates an initial homepage of the basic type `Page`, which does not include any content fields beyond the title. You'll probably want to replace this with your own `HomePage` class - when you do so, ensure that you set up a site record (under Settings / Sites in the Wagtail admin) to point to the new homepage.

--- a/docs/getting_started/tutorial.md
+++ b/docs/getting_started/tutorial.md
@@ -11,7 +11,7 @@ If you'd like to add Wagtail to an existing Django project instead, see [](integ
 
 Wagtail supports Python 3.7, 3.8, 3.9 and 3.10.
 
-To check the current version of python currently installed on your machine, run the command bellow:
+To check whether you have an appropriate version of Python 3:
 
 ```console
 $ python3 --version
@@ -36,13 +36,9 @@ This tutorial uses [`venv`](https://docs.python.org/3/tutorial/venv.html), which
 > python3 -m venv mysite\env
 > mysite\env\Scripts\activate.bat
 
-```
-Or 
+Or:
 
-```doscon
-> python3 -m venv "name-of-your-virtual-environment"
-> "name-of-your-virtual-environment"\Scripts\activate
-
+> mysite\env\Scripts\activate
 ```
 
 **On GNU/Linux or MacOS** (bash):
@@ -78,7 +74,7 @@ and a sample "search" app.
 Because the folder `mysite` was already created by `venv`, run `wagtail start` with an additional argument to specify the destination directory:
 
 ```console
-$ wagtail start mysite
+$ wagtail start mysite mysite
 ```
 
 ```{note}
@@ -92,8 +88,8 @@ $ cd mysite
 $ pip install -r requirements.txt
 ```
 
-the `requirements.txt` file contains all the dependencies needed
-in order to run the project.
+This ensures that you have the relevant versions of Wagtail, Django, and any other dependencies for the project you have just created.
+The `requirements.txt` file contains all the dependencies needed in order to run the project.
 
 ### Create the database
 
@@ -183,7 +179,7 @@ Edit `home/templates/home/home_page.html` to contain the following:
 {% endblock %}
 ```
 
-`base.html` refers to a parent template and must always be the first template tag used in a template. Extending from this template saves you from rewriting codes and allows pages across your app to share a similar frame (by using block tags in the child template, you are able to override specific content within the parent template).
+`base.html` refers to a parent template and must always be the first template tag used in a template. Extending from this template saves you from rewriting code and allows pages across your app to share a similar frame (by using block tags in the child template, you are able to override specific content within the parent template).
 
 `wagtailcore_tags` must also be loaded at the top of the template and provide additional tags to those provided by Django.
 

--- a/docs/getting_started/tutorial.md
+++ b/docs/getting_started/tutorial.md
@@ -11,7 +11,7 @@ If you'd like to add Wagtail to an existing Django project instead, see [](integ
 
 Wagtail supports Python 3.7, 3.8, 3.9 and 3.10.
 
-To check whether you have an appropriate version of Python 3:
+To check the current version of python currently installed on your machine, run the command bellow:
 
 ```console
 $ python3 --version
@@ -35,6 +35,14 @@ This tutorial uses [`venv`](https://docs.python.org/3/tutorial/venv.html), which
 ```doscon
 > python3 -m venv mysite\env
 > mysite\env\Scripts\activate.bat
+
+```
+Or 
+
+```doscon
+> python3 -m venv "name-of-your-virtual-environment"
+> "name-of-your-virtual-environment"\Scripts\activate
+
 ```
 
 **On GNU/Linux or MacOS** (bash):
@@ -70,11 +78,11 @@ and a sample "search" app.
 Because the folder `mysite` was already created by `venv`, run `wagtail start` with an additional argument to specify the destination directory:
 
 ```console
-$ wagtail start mysite mysite
+$ wagtail start mysite
 ```
 
 ```{note}
-Generally, in Wagtail, each page type, or content type, is represented by a single app. However, different apps can be aware of each other and access each other's data. All of the apps need to be registered within the `INSTALLED_APPS` section of the `settings` file. Look at this file to see how the `start` command has listed them in there.
+Generally, in Wagtail, each page type, or content type, is represented by a single app. However, different apps can be aware of each other and access each other's data. All of the apps need to be registered within the `INSTALLED_APPS` section of the `settings.py` file. Look at this file to see how the `start` command has listed them in there.
 ```
 
 ### Install project dependencies
@@ -84,10 +92,8 @@ $ cd mysite
 $ pip install -r requirements.txt
 ```
 
-This ensures that you have the relevant versions of
-Wagtail,
-Django,
-and any other dependencies for the project you have just created.
+the `requirements.txt` file contains all the dependencies needed
+in order to run the project.
 
 ### Create the database
 
@@ -177,7 +183,7 @@ Edit `home/templates/home/home_page.html` to contain the following:
 {% endblock %}
 ```
 
-`base.html` refers to a parent template and must always be the first template tag used in a template. Extending from this template saves you from rewriting code and allows pages across your app to share a similar frame (by using block tags in the child template, you are able to override specific content within the parent template).
+`base.html` refers to a parent template and must always be the first template tag used in a template. Extending from this template saves you from rewriting codes and allows pages across your app to share a similar frame (by using block tags in the child template, you are able to override specific content within the parent template).
 
 `wagtailcore_tags` must also be loaded at the top of the template and provide additional tags to those provided by Django.
 
@@ -266,7 +272,7 @@ takes a Wagtail Page object as an argument.
 
 In the Wagtail admin, create a `BlogIndexPage` as a child of the Homepage,
 make sure it has the slug "blog" on the Promote tab, and publish it.
-You should now be able to access the url `/blog` on your site
+You should now be able to access the url `http://127.0.0.1:8000/blog` on your site
 (note how the slug from the Promote tab defines the page URL).
 
 Now we need a model and template for our blog posts. In `blog/models.py`:


### PR DESCRIPTION
while reading the getting started documentation, I came across some steps I followed from the documentation but didn't get the expected results. especially guides on how to create and activate virtual environments, as well, added some explicit explanations to the existing ones