### PR TITLE
Convert edit view in contrib.settings to a class based View

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -7,6 +7,7 @@ Changelog
  * Add custom permissions section to permissions documentation page (Dan Hayden)
  * Remove unsquashed `testapp` migrations (Matt Westcott)
  * Switch to using Willow instead of Pillow for images (Darrel O'Pry)
+ * Adopt `wagtail.admin.views.generic` views in contrib Settings (Tidiane Dia)
  * Fix: Make sure workflow timeline icons are visible in high-contrast mode (Loveth Omokaro)
  * Fix: Ensure authentication forms (login, password reset) have a visible border in Windows high-contrast mode (Loveth Omokaro)
  * Fix: Ensure visual consistency between buttons and links as buttons in Windows high-contrast mode (Albina Starykova)

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -17,6 +17,7 @@ depth: 1
  * Add custom permissions section to permissions documentation page (Dan Hayden)
  * Wagtail's documentation (v2.9 to v4.0) has been updated on [Dash user contributions](https://github.com/Kapeli/Dash-User-Contributions) for [Dash](https://kapeli.com/dash) or [Zeal](https://zealdocs.org/) offline docs applications (Damilola Oladele, (Mary Ayobami)
  * Switch to using [Willow](https://github.com/wagtail/Willow/) instead of Pillow for images (Darrel O'Pry)
+ * Adopt `wagtail.admin.views.generic` views in contrib Settings (Tidiane Dia)
 
 ### Bug fixes
 

--- a/wagtail/contrib/settings/registry.py
+++ b/wagtail/contrib/settings/registry.py
@@ -79,7 +79,6 @@ class Registry(list):
         # Don't bother registering this if it is already registered
         if model in self:
             return model
-        self.append(model)
 
         # Register a new menu item in the settings menu
         @hooks.register("register_settings_menu_item")
@@ -113,6 +112,7 @@ class Registry(list):
 
         register_admin_url_finder(model, finder_class)
 
+        self.append(model)
         return model
 
     def register_decorator(self, model=None, **kwargs):

--- a/wagtail/contrib/settings/templates/wagtailsettings/edit.html
+++ b/wagtail/contrib/settings/templates/wagtailsettings/edit.html
@@ -22,7 +22,7 @@
         {% csrf_token %}
 
         <div class="nice-padding">
-            {{ edit_handler.render_form_content }}
+            {{ panel.render_form_content }}
         </div>
 
         <footer class="footer">

--- a/wagtail/contrib/settings/tests/generic/test_admin.py
+++ b/wagtail/contrib/settings/tests/generic/test_admin.py
@@ -117,6 +117,20 @@ class TestGenericSettingCreateView(BaseTestGenericSettingView):
         # Ensure the form supports file uploads
         self.assertContains(response, 'enctype="multipart/form-data"')
 
+    def test_edit_creates_new_instance_if_unexisting(self):
+        self.assertEqual(TestGenericSetting.objects.count(), 0)
+        self.client.get(
+            reverse(
+                "wagtailsettings:edit",
+                args=[
+                    TestGenericSetting._meta.app_label,
+                    TestGenericSetting._meta.model_name,
+                    1,
+                ],
+            )
+        )
+        self.assertEqual(TestGenericSetting.objects.count(), 1)
+
 
 class TestGenericSettingEditView(BaseTestGenericSettingView):
     def setUp(self):
@@ -129,12 +143,6 @@ class TestGenericSettingEditView(BaseTestGenericSettingView):
     def test_get_edit(self):
         response = self.get()
         self.assertEqual(response.status_code, 200)
-
-    def test_non_existent_model(self):
-        response = self.client.get(
-            reverse("wagtailsettings:edit", args=["test", "foo", 1])
-        )
-        self.assertEqual(response.status_code, 404)
 
     def test_edit_invalid(self):
         response = self.post(post_data={"foo": "bar"})

--- a/wagtail/contrib/settings/tests/site_specific/test_admin.py
+++ b/wagtail/contrib/settings/tests/site_specific/test_admin.py
@@ -132,12 +132,6 @@ class TestSiteSettingEditView(BaseTestSiteSettingView):
         response = self.get()
         self.assertEqual(response.status_code, 200)
 
-    def test_non_existant_model(self):
-        response = self.client.get(
-            reverse("wagtailsettings:edit", args=["test", "foo", 1])
-        )
-        self.assertEqual(response.status_code, 404)
-
     def test_edit_invalid(self):
         response = self.post(post_data={"foo": "bar"})
         self.assertContains(response, "The setting could not be saved due to errors.")

--- a/wagtail/contrib/settings/tests/tests.py
+++ b/wagtail/contrib/settings/tests/tests.py
@@ -1,0 +1,36 @@
+from django.test import TestCase
+from django.urls import reverse
+
+from wagtail.contrib.settings.registry import Registry
+from wagtail.test.testapp.models import SimplePage
+from wagtail.test.utils import WagtailTestUtils
+
+
+class TestRegister(TestCase, WagtailTestUtils):
+    def setUp(self):
+        self.registry = Registry()
+        self.login()
+
+    def test_register_invalid_setting_model(self):
+        self.assertNotIn(SimplePage, self.registry)
+
+        with self.assertRaises(NotImplementedError):
+            self.registry.register_decorator(SimplePage)
+
+        self.assertNotIn(SimplePage, self.registry)
+
+
+class TestEditSettingView(TestCase, WagtailTestUtils):
+    def setUp(self):
+        self.user = self.login()
+
+    def test_inexistent_model(self):
+        response = self.client.get(
+            reverse("wagtailsettings:edit", args=["test", "foo", 1])
+        )
+        self.assertEqual(response.status_code, 404)
+
+    def test_invalid_model(self):
+        args = [SimplePage._meta.app_label, SimplePage._meta.model_name, 1]
+        response = self.client.get(reverse("wagtailsettings:edit", args=args))
+        self.assertEqual(response.status_code, 404)


### PR DESCRIPTION
This PR aims to turn the edit view in contrib.settings to a CBV. This will make it easier to add other settings models (See #6873) and to follow the logic.

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
