### PR TITLE
Make sure chooser buttons can be revealed for all widgets. Fix #9260

### DIFF
--- a/client/scss/components/_chooser.scss
+++ b/client/scss/components/_chooser.scss
@@ -82,8 +82,9 @@
   @media (hover: hover) {
     opacity: 0;
 
-    // Ensure the hovering over the comment icon will still show chooser actions for these specific ones
-    :is(.w-field--admin_task_chooser, .w-field--admin_page_chooser, .w-field--document_chooser_widget, .w-field--admin_image_chooser, .w-field--admin_snippet_chooser):is(:hover, :focus-within)
+    // Ensure the hovering over the comment icon will still show chooser actions.
+    // Uses a form-field class as well as widget classes, as all core and custom choosers use different widgets.
+    :is(.w-field--model_choice_field, .w-field--admin_task_chooser, .w-field--admin_page_chooser, .w-field--document_chooser_widget, .w-field--admin_image_chooser, .w-field--admin_snippet_chooser):is(:hover, :focus-within)
       & {
       opacity: 1;
     }


### PR DESCRIPTION
Fixes #9260. This bug affects custom choosers, _and_ Wagtail’s `AdminPageMoveChooser`. As far as I could tell this was the only chooser to have been left out.

I’m not happy with this approach, as it we’ve had lots of issues in the past when tying our rendering to specific form fields (rather than widgets). The most common case being MultipleChoiceField, which can be rendered with quite a few different widgets. In this case though – I can’t think of choosers being rendered for anything else than a ModelChoiceField.

If this assumption is incorrect – we can update this to:

```css
:is(.w-field--model_choice_field, .w-field--admin_task_chooser, .w-field--admin_page_chooser, .w-field--document_chooser_widget, .w-field--admin_image_chooser, .w-field--admin_snippet_chooser):is(:hover, :focus-within) & {
      opacity: 1;
}
```

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
-   ~~[ ] For Python changes: Have you added tests to cover the new/fixed behaviour?~~
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [X] **Please list the exact browser and operating system versions you tested**: Chrome 106 only
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   ~~[ ] For new features: Has the documentation been updated accordingly?~~

Go to the "Move page" UI and hover the chooser.