### PR TITLE
Documentation - update sphinx theme to fix dark mode issues + add copy code button

### DIFF
--- a/docs/_templates/searchbox.html
+++ b/docs/_templates/searchbox.html
@@ -1,5 +1,5 @@
 {%- if builder != "singlehtml" %}
-    <div id="searchbox" class="" role="search">
+    <div id="searchbox" class="">
         <form id="search-form" action="{{ pathto('search') }}" autocomplete="off" method="get">
             <div class="input-group flex-nowrap">
                 <div class="input-group-prepend">

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -56,6 +56,7 @@ os.environ["DATABASE_ENGINE"] = "django.db.backends.sqlite3"
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.intersphinx",
+    "sphinx_copybutton",
     "myst_parser",
     "sphinx_wagtail_theme",
 ]

--- a/docs/releases/4.1.md
+++ b/docs/releases/4.1.md
@@ -31,6 +31,14 @@ Note that on first upgrading to Wagtail 4.1, you will need to run the `rebuild_r
 
 This feature was developed by Karl Hobley and Matt Westcott.
 
+### Documentation improvements
+
+There are multiple improvements to the documentation theme this release, here are some highlights.
+
+* Code snippets now have a quick copy to clipboard button (Mohammad Areeb)
+* Improve the dark mode theme adoption, avoid flashing the wrong theme on first load, reduce the need for scrollbars in page TOC, link underline fixes in Safari (LB (Ben) Johnston, Kartik Kankurte)
+* Better accessibility support with a skip to content link (LB (Ben) Johnston)
+
 ### Other features
 
  * Add basic keyboard control and screen reader support for page listing re-ordering (Paarth Agarwal, Thomas van der Hoeven)

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
-myst_parser==0.17.2
-sphinx-wagtail-theme==5.3.0
+myst_parser==0.18.1
+sphinx-wagtail-theme==5.3.2
+sphinx-copybutton>=0.5,<1.0

--- a/setup.py
+++ b/setup.py
@@ -74,8 +74,9 @@ documentation_extras = [
     "sphinxcontrib-spelling>=5.4.0,<6",
     "Sphinx>=1.5.2",
     "sphinx-autobuild>=0.6.0",
-    "sphinx-wagtail-theme==5.3.0",
-    "myst_parser==0.17.0",
+    "sphinx-wagtail-theme==5.3.2",
+    "myst_parser==0.18.1",
+    "sphinx_copybutton>=0.5,<1.0",
 ]
 
 setup(


### PR DESCRIPTION
- Upgrade Wagtail sphinx theme to 5.3.2
- Upgrade MyST parser to 0.18.1
- https://github.com/wagtail/sphinx_wagtail_theme/blob/main/CHANGELOG.md#531---2022-10-13
- Addition of copy button to code snippets, resolve multiple issues with the dark mode theme.
- The main fix is no longer flashing the light theme when your device is on dark mode on load.