### PR TITLE
This needs Feedback from the Docs team

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -46,3 +46,4 @@ Index
    editor_manual/index
    contributing/index
    releases/index
+   streamfield

--- a/docs/streamfield.md
+++ b/docs/streamfield.md
@@ -1,0 +1,34 @@
+# StreamField block reference (sample docs)
+
+
+```{eval-rst}
+.. autoclass:: wagtail.blocks.CharBlock
+    :show-inheritance:
+    :inherited-members:
+    :members: get_searchable_content
+
+.. autoclass:: wagtail.blocks.TextBlock
+    :show-inheritance:
+    :inherited-members:
+    :members: field, get_searchable_content
+
+.. autoclass:: wagtail.blocks.FloatBlock
+    :show-inheritance:
+    :inherited-members:
+    :members:
+
+.. autoclass:: wagtail.blocks.DecimalBlock
+    :show-inheritance:
+    :inherited-members:
+    :members:
+
+.. autoclass:: wagtail.blocks.RegexBlock
+    :show-inheritance:
+    :inherited-members:
+    :members:
+
+.. autoclass:: wagtail.blocks.URLBlock
+    :show-inheritance:
+    :inherited-members:
+    :members:
+```


### PR DESCRIPTION
Hi @thibaudcolas @allcaps @lb- Please do review

Some few observations:
- With the **`autoclass`** directive, we would be unable to add in text, except it is added in from the docstrings. I have tried doing this, and it wouldn't render. It throws an error.
- I would think this a **theme** issue. The documentation is rendered having the class and their methods on the indent level. I would think the methods might use some indentation to make the documentation more navigable.
- Then lastly, the contributor who raised the issue, #9012 seemed to want a graphical representation. He thinks this would better feed the imagination of his developers--as against text. 

Then, I only created this in a separate documentation because it is easier to just iterate and improve before merging in into the right section of the documentation where it should be.