### PR TITLE
Avoid splitting RichTextBlock when inserting new block at end

### DIFF
--- a/client/src/components/StreamField/blocks/BaseSequenceBlock.js
+++ b/client/src/components/StreamField/blocks/BaseSequenceBlock.js
@@ -121,6 +121,7 @@ export class BaseSequenceChild extends EventEmitter {
     this.sequence = sequence;
 
     const animate = opts && opts.animate;
+    const focus = opts && opts.focus;
     this.collapsed = opts && opts.collapsed;
     this.strings = (opts && opts.strings) || {};
 
@@ -223,7 +224,14 @@ export class BaseSequenceChild extends EventEmitter {
       dom.hide();
       setTimeout(() => {
         dom.slideDown();
+        if (focus) {
+          // focus this field if we can do so without obtrusive UI behaviour
+          this.block.focus({ soft: true });
+        }
       }, 10);
+    } else if (focus) {
+      // focus this field if we can do so without obtrusive UI behaviour
+      this.block.focus({ soft: true });
     }
   }
 
@@ -452,11 +460,10 @@ export class BaseSequenceBlock {
   _onRequestInsert(index, opts) {
     /* handler for an 'insert new block' action */
     const [blockDef, initialState, id] = this._getChildDataForInsertion(opts);
-    const newChild = this._insert(blockDef, initialState, id || null, index, {
+    this._insert(blockDef, initialState, id || null, index, {
       animate: true,
+      focus: true,
     });
-    // focus the newly added field if we can do so without obtrusive UI behaviour
-    newChild.focus({ soft: true });
   }
 
   blockCountChanged() {
@@ -467,6 +474,7 @@ export class BaseSequenceBlock {
   _insert(childBlockDef, initialState, id, index, opts) {
     const prefix = this.prefix + '-' + this.blockCounter;
     const animate = opts && opts.animate;
+    const focus = opts && opts.focus;
     const collapsed = opts && opts.collapsed;
     this.blockCounter++;
 
@@ -501,6 +509,7 @@ export class BaseSequenceBlock {
       this,
       {
         animate,
+        focus,
         collapsed,
         strings: this.blockDef.meta.strings,
       },

--- a/client/src/components/StreamField/blocks/ListBlock.js
+++ b/client/src/components/StreamField/blocks/ListBlock.js
@@ -223,10 +223,10 @@ export class ListBlock extends BaseSequenceBlock {
     const animate = opts && opts.animate;
     this.insert(childValue, index + 1, {
       animate,
+      focus: true,
       collapsed: child.collapsed,
       id: newId,
     });
-    this.children[index + 1].focus({ soft: true });
   }
 
   splitBlock(index, valueBefore, valueAfter, shouldMoveCommentFn, opts) {
@@ -235,6 +235,7 @@ export class ListBlock extends BaseSequenceBlock {
     child.setValue(valueBefore);
     const newChild = this.insert(valueAfter, index + 1, {
       animate,
+      focus: true,
       collapsed: child.collapsed,
     });
     const oldContentPath = child.getContentPath();
@@ -253,8 +254,6 @@ export class ListBlock extends BaseSequenceBlock {
         }
       });
     }
-    // focus the newly added field if we can do so without obtrusive UI behaviour
-    this.children[index + 1].focus({ soft: true });
   }
 
   setError(errorList) {

--- a/client/src/components/StreamField/blocks/StreamBlock.js
+++ b/client/src/components/StreamField/blocks/StreamBlock.js
@@ -386,9 +386,11 @@ export class StreamBlock extends BaseSequenceBlock {
     const child = this.children[index];
     const childState = child.getDuplicatedState();
     const animate = opts && opts.animate;
-    this.insert(childState, index + 1, { animate, collapsed: child.collapsed });
-    // focus the newly added field if we can do so without obtrusive UI behaviour
-    this.children[index + 1].focus({ soft: true });
+    this.insert(childState, index + 1, {
+      animate,
+      focus: true,
+      collapsed: child.collapsed,
+    });
   }
 
   splitBlock(index, valueBefore, valueAfter, shouldMoveCommentFn, opts) {
@@ -398,7 +400,7 @@ export class StreamBlock extends BaseSequenceBlock {
     const newChild = this.insert(
       { type: initialState.type, id: uuidv4(), value: valueAfter },
       index + 1,
-      { animate, collapsed: child.collapsed },
+      { animate, focus: true, collapsed: child.collapsed },
     );
     child.setState({
       type: initialState.type,
@@ -421,8 +423,6 @@ export class StreamBlock extends BaseSequenceBlock {
         }
       });
     }
-    // focus the newly added field if we can do so without obtrusive UI behaviour
-    this.children[index + 1].focus({ soft: true });
   }
 
   setState(values) {

--- a/client/src/entrypoints/admin/telepath/widgets.js
+++ b/client/src/entrypoints/admin/telepath/widgets.js
@@ -213,6 +213,36 @@ class DraftailInsertBlockCommand {
   }
 }
 
+class DraftailSplitCommand {
+  /* Definition for a command in the Draftail context menu that splits the block.
+   * Constructor args:
+   * split - capability descriptor from the containing block's capabilities definition
+   */
+  constructor(split) {
+    this.split = split;
+    this.description = gettext('Split block');
+  }
+
+  icon = '#icon-cut';
+  type = 'split';
+
+  onSelect({ editorState }) {
+    const result = window.draftail.splitState(
+      window.draftail.DraftUtils.resetBlockWithType(editorState, 'unstyled'),
+    );
+    // Run the split after a timeout to circumvent potential race condition.
+    setTimeout(() => {
+      if (result) {
+        this.split.fn(
+          result.stateBefore,
+          result.stateAfter,
+          result.shouldMoveCommentFn,
+        );
+      }
+    }, 50);
+  }
+}
+
 class BoundDraftailWidget {
   constructor(input, options, parentCapabilities) {
     this.input = input;
@@ -308,31 +338,7 @@ class BoundDraftailWidget {
         blockCommands.push({
           label: 'Actions',
           type: 'custom-actions',
-          items: [
-            {
-              icon: '#icon-cut',
-              description: gettext('Split block'),
-              type: 'split',
-              onSelect: ({ editorState }) => {
-                const result = window.draftail.splitState(
-                  window.draftail.DraftUtils.resetBlockWithType(
-                    editorState,
-                    'unstyled',
-                  ),
-                );
-                // Run the split after a timeout to circumvent potential race condition.
-                setTimeout(() => {
-                  if (result) {
-                    split.fn(
-                      result.stateBefore,
-                      result.stateAfter,
-                      result.shouldMoveCommentFn,
-                    );
-                  }
-                }, 50);
-              },
-            },
-          ],
+          items: [new DraftailSplitCommand(split)],
         });
       }
     }

--- a/client/src/entrypoints/admin/telepath/widgets.js
+++ b/client/src/entrypoints/admin/telepath/widgets.js
@@ -212,13 +212,19 @@ class DraftailInsertBlockCommand {
             result.shouldMoveCommentFn,
           );
         }
-        this.addSibling.fn({ type: this.blockDef.name });
+        // setTimeout required to stop Draftail from giving itself focus again
+        setTimeout(() => {
+          this.addSibling.fn({ type: this.blockDef.name });
+        }, 20);
       }, 50);
     } else {
       // Set the current block's content to the 'before' state, to remove the '/' separator and
       // reset the editor state (closing the context menu)
       this.widget.setState(result.stateBefore);
-      this.addSibling.fn({ type: this.blockDef.name });
+      // setTimeout required to stop Draftail from giving itself focus again
+      setTimeout(() => {
+        this.addSibling.fn({ type: this.blockDef.name });
+      }, 20);
     }
   }
 }

--- a/client/src/entrypoints/admin/telepath/widgets.js
+++ b/client/src/entrypoints/admin/telepath/widgets.js
@@ -169,10 +169,12 @@ window.telepath.register(
 class DraftailInsertBlockCommand {
   /* Definition for a command in the Draftail context menu that inserts a block.
    * Constructor args:
+   * widget - the bound Draftail widget
    * blockDef - block definition for the block to be inserted
    * addSibling, split - capability descriptors from the containing block's capabilities definition
    */
-  constructor(blockDef, addSibling, split) {
+  constructor(widget, blockDef, addSibling, split) {
+    this.widget = widget;
     this.blockDef = blockDef;
     this.addSibling = addSibling;
     this.split = split;
@@ -216,9 +218,11 @@ class DraftailInsertBlockCommand {
 class DraftailSplitCommand {
   /* Definition for a command in the Draftail context menu that splits the block.
    * Constructor args:
+   * widget - the bound Draftail widget
    * split - capability descriptor from the containing block's capabilities definition
    */
-  constructor(split) {
+  constructor(widget, split) {
+    this.widget = widget;
     this.split = split;
     this.description = gettext('Split block');
   }
@@ -325,7 +329,7 @@ class BoundDraftailWidget {
       blockCommands = blockGroups.map(([group, blocks]) => {
         const blockControls = blocks.map(
           (blockDef) =>
-            new DraftailInsertBlockCommand(blockDef, addSibling, split),
+            new DraftailInsertBlockCommand(this, blockDef, addSibling, split),
         );
         return {
           label: group || gettext('Blocks'),
@@ -338,7 +342,7 @@ class BoundDraftailWidget {
         blockCommands.push({
           label: 'Actions',
           type: 'custom-actions',
-          items: [new DraftailSplitCommand(split)],
+          items: [new DraftailSplitCommand(this, split)],
         });
       }
     }

--- a/client/src/entrypoints/admin/telepath/widgets.js
+++ b/client/src/entrypoints/admin/telepath/widgets.js
@@ -298,13 +298,6 @@ class BoundDraftailWidget {
               icon: '#icon-cut',
               description: gettext('Split block'),
               type: 'split',
-              render: ({ option, getEditorState }) => {
-                const editorState = getEditorState();
-                const content = editorState.getCurrentContent();
-                const blocks = content.getBlockMap();
-                const text = `${option.description} (will split ${blocks.size} blocks)`;
-                return text;
-              },
               onSelect: ({ editorState }) => {
                 const result = window.draftail.splitState(
                   window.draftail.DraftUtils.resetBlockWithType(

--- a/client/src/entrypoints/admin/telepath/widgets.js
+++ b/client/src/entrypoints/admin/telepath/widgets.js
@@ -201,17 +201,25 @@ class DraftailInsertBlockCommand {
     const result = window.draftail.splitState(
       window.draftail.DraftUtils.resetBlockWithType(editorState, 'unstyled'),
     );
-    // Run the split after a timeout to circumvent potential race condition.
-    setTimeout(() => {
-      if (result) {
-        this.split.fn(
-          result.stateBefore,
-          result.stateAfter,
-          result.shouldMoveCommentFn,
-        );
-      }
+    if (result.stateAfter.getCurrentContent().hasText()) {
+      // There is content after the insertion point, so need to split the existing block.
+      // Run the split after a timeout to circumvent potential race condition.
+      setTimeout(() => {
+        if (result) {
+          this.split.fn(
+            result.stateBefore,
+            result.stateAfter,
+            result.shouldMoveCommentFn,
+          );
+        }
+        this.addSibling.fn({ type: this.blockDef.name });
+      }, 50);
+    } else {
+      // Set the current block's content to the 'before' state, to remove the '/' separator and
+      // reset the editor state (closing the context menu)
+      this.widget.setState(result.stateBefore);
       this.addSibling.fn({ type: this.blockDef.name });
-    }, 50);
+    }
   }
 }
 


### PR DESCRIPTION
Fixes #9335.

* Refactor the construction of the command menu so that it happens under control of the bound Draftail widget (necessary so that we can call widget.setState within the command function)
* Introduce a separate code path when inserting a block at the end of rich text content, where we don't split the existing block, and just insert the new sibling instead
* Fix a wider issue where calling focus() on a newly-inserted block fails to focus it, if the block is inserted with an animation