### PR TITLE
fixed border for admin login screen in windows high contrast mode for issue #9350

### DIFF
--- a/client/scss/layouts/_login.scss
+++ b/client/scss/layouts/_login.scss
@@ -65,6 +65,10 @@
       max-width: calc(theme('spacing.32') * 3.5);
       padding: theme('spacing.12') theme('spacing.14');
     }
+
+    @media (forced-colors: active) {
+      border: 5px solid transparent;
+    }
   }
 
   h1 {


### PR DESCRIPTION
fixeds#9350


![image](https://user-images.githubusercontent.com/38161296/195699518-5c7d85a9-54a9-4ad5-81cc-112f1b5412fa.png)

