### PR TITLE
added border-style to the title field on the admin panel to make it v…

### DIFF
--- a/wagtail/admin/panels.py
+++ b/wagtail/admin/panels.py
@@ -1201,7 +1201,7 @@ def set_default_page_edit_handlers(cls):
         FieldPanel(
             "title",
             classname="title",
-            widget=forms.TextInput(attrs={"placeholder": gettext_lazy("Page title")}),
+            widget=forms.TextInput(attrs={'style': 'border-style:double; placeholder: gettext_lazy("Page title*")'}),
         ),
     ]
 


### PR DESCRIPTION
on the admin panel, the "page title" didn't have a border=style, making it difficult for the user to notice that the title is supposed to be there, so, I added the border style to make it easier for users to see that the title for the page is supposed to be there