### PR TITLE
Fix issue where links as buttons would not look consistent in windows high contrast mode

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -8,6 +8,7 @@ Changelog
  * Remove unsquashed `testapp` migrations (Matt Westcott)
  * Fix: Make sure workflow timeline icons are visible in high-contrast mode (Loveth Omokaro)
  * Fix: Ensure authentication forms (login, password reset) have a visible border in Windows high-contrast mode (Loveth Omokaro)
+ * Fix: Ensure visual consistency between buttons and links as buttons in Windows high-contrast mode (Albina Starykova)
 
 
 4.1 LTS (xx.xx.xxxx) - IN DEVELOPMENT

--- a/client/scss/components/_button.scss
+++ b/client/scss/components/_button.scss
@@ -253,7 +253,7 @@
       cursor: default;
     }
 
-    @media (forced-colors: active) {
+    @media (forced-colors: $media-forced-colours) {
       color: GrayText;
       border-color: GrayText;
       border-style: dashed;
@@ -352,6 +352,19 @@
         &:before {
           width: 1.75em;
         }
+      }
+    }
+  }
+
+  // Ensure visual consistency between button and a elements in WHCM
+
+  @media (forced-colors: $media-forced-colours) {
+    &:not(:disabled):not(.disabled):not([disabled]) {
+      color: ButtonText;
+      border-color: ButtonText;
+
+      &:hover {
+        border-color: Highlight;
       }
     }
   }

--- a/client/scss/components/_dropdown.legacy.scss
+++ b/client/scss/components/_dropdown.legacy.scss
@@ -62,8 +62,6 @@
 
       li a,
       li button {
-        forced-color-adjust: none;
-        background-color: $color-black;
         border-color: $color-white;
         color: $color-white;
       }

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -20,6 +20,7 @@ depth: 1
 
  * Make sure workflow timeline icons are visible in high-contrast mode (Loveth Omokaro)
  * Ensure authentication forms (login, password reset) have a visible border in Windows high-contrast mode (Loveth Omokaro)
+ * Ensure visual consistency between buttons and links as buttons in Windows high-contrast mode (Albina Starykova)
 
 ## Upgrade considerations
 


### PR DESCRIPTION
Ensure visual consistency between buttons and a elements in WHCM #9078
Fixes #9078:

Applied rules for both static and `:hover` states for `button` and `a` elements in `forced-colors` mode.
I used `ButtonText` for `color` & `border-color`, and `Highlight` for `:hover border-color`.

I tested this solution via Assistive Labs on all 4 WHCMs available in 21H2 version (High Contrast Black, High Contrast White, High Contrast #1, High Contrast #2), both Edge & Chrome.

I also put all `forced-colors` related code in one block.

| Before  | After |
| ------------- | ------------- |
| <img width="383" alt="image" src="https://user-images.githubusercontent.com/51043550/195769967-30eb7c73-f579-4d93-a660-9720dda6c7e4.png"> | <img width="376" alt="image" src="https://user-images.githubusercontent.com/51043550/195770025-9686e28e-79cb-4f8f-b639-f1ea902b018c.png"> |

