### PR TITLE
Mention the importance of passing `request` and `current_site` to `get_url`

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -11,6 +11,7 @@ Changelog
  * Upgrade to Node 18 for frontend build tooling (LB (Ben) Johnston)
  * Officially recommend `fnm` over `nvm` in development documentation (LB (Ben) Johnston)
  * Test assertion util `WagtailPageTestCase.assertCanCreate` now supports the kwarg `publish=True` to check publish redirection (Harry Percival, Akua Dokua Asiedu)
+ * Mention the importance of passing `request` and `current_site` to `get_url` on the [performance](performance) documentation page (Jake Howard)
  * Fix: Make sure workflow timeline icons are visible in high-contrast mode (Loveth Omokaro)
  * Fix: Ensure authentication forms (login, password reset) have a visible border in Windows high-contrast mode (Loveth Omokaro)
  * Fix: Ensure visual consistency between buttons and links as buttons in Windows high-contrast mode (Albina Starykova)

--- a/docs/advanced_topics/performance.md
+++ b/docs/advanced_topics/performance.md
@@ -58,6 +58,14 @@ Another side benefit is it prevents errors during conversation from causing page
 
 The same can be achieved in Python using [`generate_image_url`](dynamic_image_urls).
 
+### Page URLs
+
+To fully resolve the URL of a page, Wagtail requires information from a few different sources.
+
+The methods used to get the URL of a `Page` such as `Page.get_url` and `Page.get_full_url` optionally accept extra arguments for `request` and `current_site`. Passing these arguments enable much of underlying site-level URL information to be reused for the current request. In situations such as navigation menu generation, plus any links that appear in page content, providing `request` or `current_site` can result in a drastic reduction in the number of cache or database queries your site will generate for a given page load.
+
+When using the [`{% pageurl %}`](page_urls) template tag, the request is automatically passed in, so no further optimisation is needed.
+
 ### Search
 
 Wagtail has strong support for [Elasticsearch](https://www.elastic.co) - both in the editor interface and for users of your site - but can fall back to a database search if Elasticsearch isn't present. Elasticsearch is faster and more powerful than the Django ORM for text search, so we recommend installing it or using a hosted service like [Searchly](http://www.searchly.com/).

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -21,6 +21,7 @@ depth: 1
  * Test assertion [`WagtailPageTestCase.assertCanCreate`](testing_reference) now supports the kwarg `publish=True` to check publish redirection (Harry Percival, Akua Dokua Asiedu)
  * Upgrade to Node 18 for frontend build tooling (LB (Ben) Johnston)
  * Officially recommend `fnm` over `nvm` in development documentation (LB (Ben) Johnston)
+ * Mention the importance of passing `request` and `current_site` to `get_url` on the [performance](performance) documentation page (Jake Howard)
 
 ### Bug fixes
 


### PR DESCRIPTION
<!--
Thanks for contributing to Wagtail! 🎉

Before submitting, please review the [contributor guidelines](https://docs.wagtail.org/en/latest/contributing/index.html).
-->

_Please check the following:_

-   [ ] Do the tests still pass?[^1]
-   [ ] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)

Originally covered in https://docs.wagtail.org/en/stable/releases/1.11.html?highlight=get_url#caching-of-site-level-url-information-throughout-the-request-cycle, it's very important to pass in the `request` and `current_site` arguments when they're available.

This documents this optimisation on the performance page.