### PR TITLE
Add missing rendered output in documentation guidelines. Fix #9331

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -638,6 +638,7 @@ Contributors
 * Umar Farouk Yunusa
 * Chizoba Nweke
 * Seremba Patrick
+* Ruqouyyah Muhammad
 
 
 Translators

--- a/docs/contributing/documentation_guidelines.md
+++ b/docs/contributing/documentation_guidelines.md
@@ -83,16 +83,19 @@ Make sure to include the correct language code for syntax highlighting, and to f
     ```
 
 <details>
-    <summary>Rendered output</summary>
-    ```python<br>
-    INSTALLED_APPS = [<br>
-        ...<br>
-        "wagtail",<br>
-        ...<br>
-    ]
-    ```
+
+<summary>Rendered output</summary>
+
+```python
+INSTALLED_APPS = [
+    ...
+    "wagtail",
+    ...
+]
+```
     
 </details>
+
 #### When using console (terminal) code blocks
 
 ```{note}
@@ -107,14 +110,16 @@ Use `sh` as it has better support for comment and code syntax highlighting in My
     ```
     
 <details>
-    <summary>Rendered output</summary>
 
-    ```sh
-    # some comment
-    some command
-    ```
+<summary>Rendered output</summary>
+
+```sh
+# some comment
+some command
+```
 
 </details>
+
 Use `doscon` (DOS Console) only if explicitly calling out Windows commands alongside their bash equivalent.
 
     ```doscon

--- a/docs/contributing/documentation_guidelines.md
+++ b/docs/contributing/documentation_guidelines.md
@@ -82,6 +82,17 @@ Make sure to include the correct language code for syntax highlighting, and to f
     ]
     ```
 
+<details>
+    <summary>Rendered output</summary>
+    ```python<br>
+    INSTALLED_APPS = [<br>
+        ...<br>
+        "wagtail",<br>
+        ...<br>
+    ]
+    ```
+    
+</details>
 #### When using console (terminal) code blocks
 
 ```{note}
@@ -94,13 +105,31 @@ Use `sh` as it has better support for comment and code syntax highlighting in My
     # some comment
     some command
     ```
+    
+<details>
+    <summary>Rendered output</summary>
 
+    ```sh
+    # some comment
+    some command
+    ```
+
+</details>
 Use `doscon` (DOS Console) only if explicitly calling out Windows commands alongside their bash equivalent.
 
     ```doscon
     # some comment
     some command
     ```
+<details>
+    <summary>Rendered output</summary>
+
+    ```doscon
+    # some comment
+    some command
+    ```
+
+</details>
 
 ### Links
 

--- a/docs/contributing/documentation_guidelines.md
+++ b/docs/contributing/documentation_guidelines.md
@@ -121,13 +121,15 @@ Use `doscon` (DOS Console) only if explicitly calling out Windows commands along
     # some comment
     some command
     ```
-<details>
-    <summary>Rendered output</summary>
 
-    ```doscon
-    # some comment
-    some command
-    ```
+<details>
+
+<summary>Rendered output</summary>
+
+```doscon
+# some comment
+some command
+```
 
 </details>
 


### PR DESCRIPTION
Included Rendered Output for 'Code blocks' and 'When using console (terminal) code blocks' sections,
#9331 