### PR TITLE
Removed the extra dot from wagtail version number in admin

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -72,6 +72,7 @@ Changelog
  * Fix: Ensure that buttons on custom chooser widgets are correctly shown on hover (Thibaud Colas)
  * Fix: Add missing asterisk to title field placeholder (Seremba Patrick)
  * Fix: Avoid creating an extra rich text block when inserting a new block at the end of the content (Matt Westcott)
+ * Fix: Removed the extra dot in the Wagtail version shown within the admin settings menu item (Loveth Omokaro)
 
 
 4.0.3 (xx.xx.xxxx) - IN DEVELOPMENT

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -639,6 +639,7 @@ Contributors
 * Chizoba Nweke
 * Seremba Patrick
 * Ruqouyyah Muhammad
+* Loveth Omokaro
 
 
 Translators

--- a/docs/releases/4.1.md
+++ b/docs/releases/4.1.md
@@ -97,6 +97,7 @@ This feature was developed by Karl Hobley and Matt Westcott.
  * Ensure that buttons on custom chooser widgets are correctly shown on hover (Thibaud Colas)
  * Add missing asterisk to title field placeholder (Seremba Patrick)
  * Avoid creating an extra rich text block when inserting a new block at the end of the content (Matt Westcott)
+ * Removed the extra dot in the Wagtail version shown within the admin settings menu item (Loveth Omokaro)
 
 ## Upgrade considerations
 

--- a/wagtail/admin/wagtail_hooks.py
+++ b/wagtail/admin/wagtail_hooks.py
@@ -102,7 +102,7 @@ class SettingsMenuItem(SubmenuMenuItem):
             self.menu.render_component(request),
             icon_name=self.icon_name,
             classnames=self.classnames,
-            footer_text="Wagtail v." + __version__,
+            footer_text="Wagtail v" + __version__,
         )
 
 


### PR DESCRIPTION
Removed the extra dot in wagtail version number on the admin panel #9352 . 
Fixes #9352 

I tested this change on wagtail version 4.1a0 using  Chrome Version 106.0.5249.119


![Before (1)](https://user-images.githubusercontent.com/38161296/195976857-55f445ea-f83d-4f2a-b4c6-ef09e45f3e8c.png)
