### PR TITLE
Update version.js to accept dev build version format

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -78,6 +78,7 @@ Changelog
  * Fix: Avoid creating an extra rich text block when inserting a new block at the end of the content (Matt Westcott)
  * Fix: Removed the extra dot in the Wagtail version shown within the admin settings menu item (Loveth Omokaro)
  * Fix: Fully remove the obsolete `wagtailsearch_editorspick` table that prevents flushing the database (Matt Westcott)
+ * Fix: Update latest version message on Dashboard to accept dev build version format used on nlightly builds (Sam Moran)
 
 
 4.0.3 (xx.xx.xxxx) - IN DEVELOPMENT

--- a/client/src/utils/version.js
+++ b/client/src/utils/version.js
@@ -25,7 +25,7 @@ class VersionDeltaType {
 class VersionNumber {
   constructor(versionString) {
     const versionRegex =
-      /^(?<major>\d+)\.{1}(?<minor>\d+)((\.{1}(?<patch>\d+))|(?<preReleaseStep>a|b|rc){1}(?<preReleaseVersion>\d+)){0,1}$/;
+      /^(?<major>\d+)\.{1}(?<minor>\d+)((\.{1}(?<patch>\d+))|(?<preReleaseStep>a|b|rc|\.dev){1}(?<preReleaseVersion>\d+)){0,1}$/;
     const matches = versionString.match(versionRegex);
     if (matches === null) {
       throw new VersionNumberFormatError(versionString);

--- a/client/src/utils/version.test.js
+++ b/client/src/utils/version.test.js
@@ -116,6 +116,16 @@ describe('version.VersionNumber initialisation', () => {
     expect(result.preReleaseVersion).toBe(23);
   });
 
+  it('initialises dev 4.1.dev20220912', () => {
+    const result = new VersionNumber('4.1.dev20220912');
+
+    expect(result.major).toBe(4);
+    expect(result.minor).toBe(1);
+    expect(result.patch).toBe(0);
+    expect(result.preReleaseStep).toBe('.dev');
+    expect(result.preReleaseVersion).toBe(20220912);
+  });
+
   it('initialisation throws error for 1', () => {
     expect(() => new VersionNumber('1')).toThrow(VersionNumberFormatError);
   });

--- a/docs/releases/4.1.md
+++ b/docs/releases/4.1.md
@@ -110,6 +110,7 @@ There are multiple improvements to the documentation theme this release, here ar
  * Avoid creating an extra rich text block when inserting a new block at the end of the content (Matt Westcott)
  * Removed the extra dot in the Wagtail version shown within the admin settings menu item (Loveth Omokaro)
  * Fully remove the obsolete `wagtailsearch_editorspick` table that prevents flushing the database (Matt Westcott)
+ * Update latest version message on Dashboard to accept dev build version format used on nlightly builds (Sam Moran)
 
 ## Upgrade considerations
 


### PR DESCRIPTION
<!--
Thanks for contributing to Wagtail! 🎉

Before submitting, please review the [contributor guidelines](https://docs.wagtail.org/en/latest/contributing/index.html).
-->

Fix for #9184.
Update version.js to accept dev version numbers and added a test case for a newly supported version number.

_Please check the following:_

-   [X] Do the tests still pass?[^1]
-   [X] Does the code comply with the style guide?
    -   [X] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour? **N/A**
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2] **N/A**
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
