### PR TITLE
Add custom permissions section to permissions docs

### DIFF
--- a/docs/topics/permissions.md
+++ b/docs/topics/permissions.md
@@ -57,7 +57,7 @@ Users are not allowed to move or delete the collection that is used to assign th
 
 ## Adding custom permissions
 
-See Django's documentation on :ref:`custom permissions <django:custom-permissions>` for details on how to set permissions up.
+See Django's documentation on [custom permissions](https://docs.djangoproject.com/en/stable/topics/auth/customizing/#custom-permissions) for details on how to set permissions up.
 
 ```{note}
 Custom permissions starting with `add_`, `change_` or `delete_` are not currently supported in Wagtail as these will conflict with standard model permissions.

--- a/docs/topics/permissions.md
+++ b/docs/topics/permissions.md
@@ -60,7 +60,7 @@ Users are not allowed to move or delete the collection that is used to assign th
 See Django's documentation on :ref:`custom permissions <django:custom-permissions>` for details on how to set permissions up.
 
 ```{note}
-Custom permissions starting with `add_`, `change_` or `delete_` will conflict with the standard model permissions due to how permissions are handled in wagtail.
+Custom permissions starting with `add_`, `change_` or `delete_` are not currently supported in Wagtail as these will conflict with standard model permissions.
 ```
 
 ## Displaying custom permissions in the admin

--- a/docs/topics/permissions.md
+++ b/docs/topics/permissions.md
@@ -55,6 +55,14 @@ Permission for managing collections themselves can be attached at any point in t
 Users are not allowed to move or delete the collection that is used to assign them permission to manage collections.
 ```
 
+## Adding custom permissions
+
+See Django's documentation on :ref:`custom permissions <django:custom-permissions>` for details on how to set permissions up.
+
+```{note}
+Custom permissions starting with `add_`, `change_` or `delete_` will conflict with the standard model permissions due to how permissions are handled in wagtail.
+```
+
 ## Displaying custom permissions in the admin
 
 Most permissions will automatically show up in the wagtail admin Group edit form, however, you can also add them using the `register_permissions` hook (see [](register_permissions)).


### PR DESCRIPTION
Added information to the permissions section of the docs on adding custom permissions. This information is available in the docs currently but only on the  [FieldPanel docs](https://docs.wagtail.org/en/stable/reference/pages/panels.html#wagtail.admin.panels.FieldPanel.permission) which is not necessarily an obvious place to look.

Also added a note about the issue of creating custom blocks that conflict with the standard model permissions due to the implementation of `format_permissions` https://github.com/wagtail/wagtail/blob/c111deef03c02c24941e06d44274a6ddf83556e4/wagtail/users/templatetags/wagtailusers_tags.py#L70-L71

The problem and discussion that lead to this PR can be found at https://wagtailcms.slack.com/archives/C81FGJR2S/p1666018850881099