### PR TITLE
fix: Status tag in page explorer should have a font size in rem rathe…

### DIFF
--- a/client/src/components/PublicationStatus/PublicationStatus.scss
+++ b/client/src/components/PublicationStatus/PublicationStatus.scss
@@ -2,5 +2,5 @@
   @apply w-bg-black-50 w-tracking-tight w-text-white-80;
   // stylelint-disable-next-line property-disallowed-list
   text-transform: uppercase;
-  font-size: 10px;
+  font-size: 0.625rem;
 }


### PR DESCRIPTION
…r than pixels #9363

<!--
Thanks for contributing to Wagtail! 🎉

Before submitting, please review the [contributor guidelines](https://docs.wagtail.org/en/latest/contributing/index.html).
-->

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [x] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [x] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
