### PR TITLE
Corrected a typo in #9412 and removed accidental extra space in #9294

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -641,6 +641,7 @@ Contributors
 * Ruqouyyah Muhammad
 * Loveth Omokaro
 * Abayomi Victory
+* Toria
 
 
 Translators

--- a/docs/releases/4.1.md
+++ b/docs/releases/4.1.md
@@ -140,7 +140,7 @@ After upgrading, you will need to run `./manage.py rebuild_references_index` in 
 
 ### Recommend `WagtailPageTestCase` in place of `WagtailPageTests`
 
-* `WagtailPageTestCase` is the base testing class and is now recommended over using `WagtailPageTestCase` [](testing_reference).
+* `WagtailPageTestCase` is the base testing class and is now recommended over using `WagtailPageTests` [](testing_reference).
 * `WagtailPageTests` will continue to work and does log in the user on test `setUp` but may be deprecated in the future.
 
 ```python


### PR DESCRIPTION
Made changes to WagtailPageTestCase Upgrade Considerations typo #9412 by changing the second reference in the first dot point from "WagtailPageTestCase" to ""WagtailPageTests" and fixed the accidental extra space before [ ] on #9294