### PR TITLE
Fix extract_references for DocumentChooserBlock

### DIFF
--- a/wagtail/blocks/field_block.py
+++ b/wagtail/blocks/field_block.py
@@ -829,7 +829,7 @@ class ChooserBlock(FieldBlock):
 
     def extract_references(self, value):
         if value is not None:
-            yield self.target_model, str(value.pk), "", ""
+            yield self.model_class, str(value.pk), "", ""
 
     class Meta:
         # No icon specified here, because that depends on the purpose that the

--- a/wagtail/documents/tests/test_blocks.py
+++ b/wagtail/documents/tests/test_blocks.py
@@ -1,6 +1,9 @@
 from django.test import TestCase
 
+from wagtail.documents import get_document_model
 from wagtail.documents.blocks import DocumentChooserBlock
+
+from .utils import get_test_document_file
 
 
 class TestDocumentChooserBlock(TestCase):
@@ -10,3 +13,18 @@ class TestDocumentChooserBlock(TestCase):
         self.assertEqual(path, "wagtail.documents.blocks.DocumentChooserBlock")
         self.assertEqual(args, ())
         self.assertEqual(kwargs, {"required": False})
+
+    def test_extract_references(self):
+        Document = get_document_model()
+        document = Document.objects.create(
+            title="Test document", file=get_test_document_file()
+        )
+        block = DocumentChooserBlock()
+
+        self.assertListEqual(
+            list(block.extract_references(document)),
+            [(Document, str(document.id), "", "")],
+        )
+
+        # None should not yield any references
+        self.assertListEqual(list(block.extract_references(None)), [])


### PR DESCRIPTION
Closes #9434

I'm not super familiar with `extract_references`, however I've copied a similar test from the `ImageChooserBlock`. Perhaps someone a bit more familiar with chooser blocks can double check to see if I've got the right approach to fixing this one.

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?

**Please describe additional details for testing this change**.

To test:

- Follow instructions in #9434 with this branch
- Save a document in a document chooser block
- Should save instead of 500
- Also test `./manage.py rebuild_references_index`