### PR TITLE
Extract asterisk from translation string with format_lazy

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -92,7 +92,7 @@ Changelog
  * Fix: Resolve inconsistency in action button positions in InlinePanel (Thibaud Colas)
  * Fix: Use h3 elements with a counter in InlinePanel so screen reader users can navigate by heading (Thibaud Colas)
  * Fix: Ensure that buttons on custom chooser widgets are correctly shown on hover (Thibaud Colas)
- * Fix: Add missing asterisk to title field placeholder (Seremba Patrick)
+ * Fix: Add missing asterisk to title field placeholder (Seremba Patrick, Stefan Hammer)
  * Fix: Avoid creating an extra rich text block when inserting a new block at the end of the content (Matt Westcott)
  * Fix: Removed the extra dot in the Wagtail version shown within the admin settings menu item (Loveth Omokaro)
  * Fix: Fully remove the obsolete `wagtailsearch_editorspick` table that prevents flushing the database (Matt Westcott)

--- a/docs/releases/4.1.md
+++ b/docs/releases/4.1.md
@@ -126,7 +126,7 @@ There are multiple improvements to the documentation theme this release, here ar
  * Resolve inconsistency in action button positions in InlinePanel (Thibaud Colas)
  * Use h3 elements with a counter in InlinePanel so screen reader users can navigate by heading (Thibaud Colas)
  * Ensure that buttons on custom chooser widgets are correctly shown on hover (Thibaud Colas)
- * Add missing asterisk to title field placeholder (Seremba Patrick)
+ * Add missing asterisk to title field placeholder (Seremba Patrick, Stefan Hammer)
  * Avoid creating an extra rich text block when inserting a new block at the end of the content (Matt Westcott)
  * Removed the extra dot in the Wagtail version shown within the admin settings menu item (Loveth Omokaro)
  * Fully remove the obsolete `wagtailsearch_editorspick` table that prevents flushing the database (Matt Westcott)

--- a/wagtail/admin/panels.py
+++ b/wagtail/admin/panels.py
@@ -13,6 +13,7 @@ from django.forms.formsets import DELETION_FIELD_NAME, ORDERING_FIELD_NAME
 from django.forms.models import fields_for_model
 from django.utils.functional import cached_property
 from django.utils.safestring import mark_safe
+from django.utils.text import format_lazy
 from django.utils.translation import gettext_lazy
 from modelcluster.models import get_serializable_data_for_fields
 
@@ -1213,7 +1214,13 @@ def set_default_page_edit_handlers(cls):
         FieldPanel(
             "title",
             classname="title",
-            widget=forms.TextInput(attrs={"placeholder": gettext_lazy("Page title*")}),
+            widget=forms.TextInput(
+                attrs={
+                    "placeholder": format_lazy(
+                        "{title}*", title=gettext_lazy("Page title")
+                    )
+                }
+            ),
         ),
     ]
 


### PR DESCRIPTION
As noted in https://github.com/wagtail/wagtail/pull/9348#issuecomment-1282249542, this changes the translation string back to the original version without the asterisk, and uses `format_lazy` instead to combine it with the asterisk.
I think this should be safe to be merged into the 4.1 RC.

Related: #9028

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
