### PR TITLE
feat: allow float for image size

### DIFF
--- a/wagtail/images/image_operations.py
+++ b/wagtail/images/image_operations.py
@@ -119,16 +119,11 @@ class ImageTransform:
 
     @staticmethod
     def _check_size(size):
-        if (
-            not isinstance(size, tuple)
-            or len(size) != 2
-            or int(size[0]) != size[0]
-            or int(size[1]) != size[1]
-        ):
-            raise TypeError("Image size must be a 2-tuple of integers")
+        if not isinstance(size, tuple) or len(size) != 2:
+            raise TypeError("Image size must be a 2-tuple of positive numbers")
 
-        if size[0] < 1 or size[1] < 1:
-            raise ValueError("Image width and height must both be 1 or greater")
+        if size[0] <= 0 or size[1] <= 0:
+            raise ValueError("Image width and height must both be 0 or greater")
 
 
 class TransformOperation(Operation):

--- a/wagtail/images/tests/test_image_operations.py
+++ b/wagtail/images/tests/test_image_operations.py
@@ -9,7 +9,7 @@ from wagtail.images.exceptions import (
     InvalidFilterSpecError,
     UnknownOutputImageFormatError,
 )
-from wagtail.images.image_operations import TransformOperation
+from wagtail.images.image_operations import ImageTransform, TransformOperation
 from wagtail.images.models import Filter, Image
 from wagtail.images.tests.utils import (
     get_test_image_file,
@@ -57,16 +57,7 @@ class DummyImageTransform:
 
     @staticmethod
     def _check_size(size):
-        if (
-            not isinstance(size, tuple)
-            or len(size) != 2
-            or int(size[0]) != size[0]
-            or int(size[1]) != size[1]
-        ):
-            raise TypeError("Image size must be a 2-tuple of integers")
-
-        if size[0] < 1 or size[1] < 1:
-            raise ValueError("Image width and height must both be 1 or greater")
+        return ImageTransform._check_size(size)
 
 
 class ImageTransformOperationTestCase(TestCase):

--- a/wagtail/images/tests/test_transform.py
+++ b/wagtail/images/tests/test_transform.py
@@ -6,13 +6,17 @@ from wagtail.images.rect import Rect, Vector
 
 class TestTransform(TestCase):
     def test_resize(self):
-        context = ImageTransform((640, 480))
+        context = ImageTransform((640.5, 480.5))
         resized = context.resize((320, 240))
+        # scale = (320/640.5, 240/480.5) = (0.4996096799, 0.4994797086)
 
         vector = Vector(100, 200)
+        # expected = (100 * 0.4996096799, 200 * 0.4994797086) = (49.96096799, 99.8959417)
+        expected = Vector(49.96096799, 99.8959417)
         transformed = resized.transform_vector(vector)
 
-        self.assertEqual(transformed, Vector(50, 100))
+        self.assertAlmostEqual(transformed.x, expected.x)
+        self.assertAlmostEqual(transformed.y, expected.y)
 
         untransformed = resized.untransform_vector(transformed)
 


### PR DESCRIPTION
SVGs allow for floating point width and height in the viewbox definition Illustrator and other editing tools generate floating point values and the SVG support code in development use the Viewbox width and height for the image width and height.  While the SVG implementation in willow could round this width and height, from a fidelity perspective it is best to defer rounding to as late a possible to minimize artifacts such as skewing that could be created by rounding errors.

For example a designer with a poorly scaled coordinate system who zoomed in way to far in illustrator and ended up with a viewbox like 0 0 0.320 0.480. If we rounded this at image  load it would result in a 1x1 image. if max: 320x480 were set, it would result in a 320x320 with pretty extreme skewing.  However if the *max* operation mathematically scales .320x.480 it would yield a 320x480 image. 

<!--
Thanks for contributing to Wagtail! 🎉

Before submitting, please review the [contributor guidelines](https://docs.wagtail.org/en/latest/contributing/index.html).
-->

_Please check the following:_

-   [ ] Do the tests still pass?[^1]
-   [ ] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [ ] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
