### PR TITLE
Add helper properties to `Locale` model

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -20,6 +20,7 @@ Changelog
  * Ensure that changed or cleared selection from choosers will dispatch a DOM `change` event (George Sakkis)
  * Add the ability to disable model indexing by setting `search_fields = []` (Daniel Kirkham)
  * Enhance `wagtail.search.utils.parse_query_string` to allow inner single quotes for key/value parsing (Aman Pandey)
+ * Add helpful properties to `Locale` for more convenient usage within templates (Andy Babic)
  * Fix: Ensure `label_format` on StructBlock gracefully handles missing variables (Aadi jindal)
  * Fix: Adopt a no-JavaScript and more accessible solution for the 'Reset to default' switch to Gravatar when editing user profile (Loveth Omokaro)
  * Fix: Ensure `Site.get_site_root_paths` works on cache backends that do not preserve Python objects (Jaap Roes)

--- a/docs/advanced_topics/i18n.md
+++ b/docs/advanced_topics/i18n.md
@@ -355,7 +355,7 @@ languages.
 
 If you're not convinced that you need this, have a look at [https://www.w3.org/International/questions/qa-site-conneg#yyyshortcomings](https://www.w3.org/International/questions/qa-site-conneg#yyyshortcomings) for some rationale.
 
-(basic_example)=
+(i18n_basic_example)=
 
 ##### Basic example
 
@@ -371,15 +371,13 @@ otherwise skip to the next section that has a more complicated example which tak
 this into account.
 
 ```html+django
-
 {# make sure these are at the top of the file #}
-{% load i18n wagtailcore_tags %}
+{% load wagtailcore_tags %}
 
 {% if page %}
     {% for translation in page.get_translations.live %}
-        {% get_language_info for translation.locale.language_code as lang %}
-        <a href="{% pageurl translation %}" rel="alternate" hreflang="{{ language_code }}">
-            {{ lang.name_local }}
+        <a href="{% pageurl translation %}" rel="alternate" hreflang="{{ translation.locale.language_code }}">
+            {{ translation.locale.language_name_local }}
         </a>
     {% endfor %}
 {% endif %}
@@ -404,26 +402,26 @@ If this is part of a shared base template it may be used in situations where no 
 This `for` block iterates through all published translations of the current page.
 
 ```html+django
-{% get_language_info for translation.locale.language_code as lang %}
-```
-
-This is a Django built-in tag that gets info about the language of the translation.
-For more information, see [get_language_info() in the Django docs](https://docs.djangoproject.com/en/stable/topics/i18n/translation/#django.utils.translation.get_language_info).
-
-```html+django
-<a href="{% pageurl translation %}" rel="alternate" hreflang="{{ language_code }}">
-    {{ lang.name_local }}
+<a href="{% pageurl translation %}" rel="alternate" hreflang="{{ translation.locale.language_code }}">
+    {{ translation.locale.language_name_local }}
 </a>
 ```
 
-This adds a link to the translation. We use `{{ lang.name_local }}` to display
-the name of the locale in its own language. We also add `rel` and `hreflang`
-attributes to the `<a>` tag for SEO.
+This adds a link to the translation. We use `{{ translation.locale.language_name_local }}` to display
+the name of the locale in its own language. We also add `rel` and `hreflang` attributes to the `<a>` tag for SEO.
+`translation.locale` is an instance of the [Locale model](locale_model_ref).
+
+Alternatively, a built-in tag from Django that gets info about the language of the translation.
+For more information, see [get_language_info() in the Django docs](https://docs.djangoproject.com/en/stable/topics/i18n/translation/#django.utils.translation.get_language_info).
+
+```html+django
+{% get_language_info for translation.locale.language_code as lang %}
+```
 
 ##### Handling locales that share content
 
 Rather than iterating over pages, this example iterates over all of the configured
-languages and finds the page for each one. This works better than the [Basic example](basic_example)
+languages and finds the page for each one. This works better than the [Basic example](i18n_basic_example)
 above on sites that have extra Django `LANGUAGES` that share the same Wagtail content.
 
 For this example to work, you firstly need to add Django's

--- a/docs/reference/pages/model_reference.md
+++ b/docs/reference/pages/model_reference.md
@@ -392,6 +392,8 @@ The {meth}`~wagtail.models.Site.find_for_request` function returns the Site obje
     .. automethod:: get_site_root_paths
 ```
 
+(locale_model_ref)=
+
 ## `Locale`
 
 The `Locale` model defines the set of languages and/or locales that can be used on a site.
@@ -424,6 +426,18 @@ database queries making them unable to be edited or viewed.
     .. automethod:: get_default
 
     .. automethod:: get_active
+
+    .. autoattribute:: language_name
+
+    .. autoattribute:: language_name_local
+
+    .. autoattribute:: language_name_localized
+
+    .. autoattribute:: is_default
+
+    .. autoattribute:: is_active
+
+    .. autoattribute:: is_bidi
 
     .. automethod:: get_display_name
 ```

--- a/docs/releases/5.0.md
+++ b/docs/releases/5.0.md
@@ -32,6 +32,7 @@ Support for adding custom validation logic to StreamField blocks has been formal
  * Ensure that changed or cleared selection from choosers will dispatch a DOM `change` event (George Sakkis)
  * Add the ability to [disable model indexing](wagtailsearch_disable_indexing) by setting `search_fields = []` (Daniel Kirkham)
  * Enhance `wagtail.search.utils.parse_query_string` to allow inner single quotes for key/value parsing (Aman Pandey)
+ * Add helpful properties to [`Locale`](locale_model_ref) for more convenient usage within templates, see [](i18n_basic_example) (Andy Babic)
 
 ### Bug fixes
 


### PR DESCRIPTION
This PR adds the following properties to the Locale model to make working with Locales more convenient. 

While Django provides template tags for accessing this information, the details of using those (and how locales relate to languages in Django) are often difficult to recall, and the resulting template markup is much more complex as a result.

I feel strongly that using a Django model for Locale was the right decision. However, we're only really benefiting from a data integrity perspective currently. Let's make the most of the design and help developers write clearer and more concise code!

## language_name

Uses data from `django.conf.locale` to return the language name in English. For example, if the object's `language_code` were `"fr"`, the return value would be `"French"`.

Raises `KeyError` if `django.conf.locale` has no information for the object's `language_code` value.

## language_name_local

Uses data from `django.conf.locale` to return the language name in the language itself. For example, if the `language_code` were `"fr"` (French), the return value would be `"français"`.

NOTE: The case of the return value can vary. You may wish to use `title()` to enforce title case in output.

Raises `KeyError` if `django.conf.locale` has no information for the object's `language_code` value.

## language_name_localized

Uses data from `django.conf.locale` to return the language name in the currently active language. For example, if `language_code` were `"fr"` (French), and the active language were `"da"` (Danish), the return value would be `"Fransk"`.

Raises `KeyError` if `django.conf.locale` has no information for the object's `language_code` value.

## is_bidi

Return a boolean indicating whether the language is bi-directional.

## is_default

Returns a boolean indicating whether this object is the default locale.

## is_active

Returns a boolean indicating whether this object is the currently active locale.
