### PR TITLE
New Option for assertCanCreate based on pr#4756

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -8,6 +8,7 @@ Changelog
  * Remove unsquashed `testapp` migrations (Matt Westcott)
  * Switch to using Willow instead of Pillow for images (Darrel O'Pry)
  * Add documentation for how to get started with contributing translations for the Wagtail admin (Ogunbanjo Oluwadamilare)
+ * Test assertion util `WagtailPageTestCase.assertCanCreate` now supports the kwarg `publish=True` to check publish redirection (Harry Percival, Akua Dokua Asiedu)
  * Fix: Make sure workflow timeline icons are visible in high-contrast mode (Loveth Omokaro)
  * Fix: Ensure authentication forms (login, password reset) have a visible border in Windows high-contrast mode (Loveth Omokaro)
  * Fix: Ensure visual consistency between buttons and links as buttons in Windows high-contrast mode (Albina Starykova)

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -653,6 +653,7 @@ Contributors
 * Ogunbanjo Oluwadamilare
 * Damee Zivah Olawuyi
 * Harry Percival
+* Akua Dokua Asiedu
 
 Translators
 ===========

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -652,6 +652,7 @@ Contributors
 * Precious Arinda
 * Ogunbanjo Oluwadamilare
 * Damee Zivah Olawuyi
+* Harry Percival
 
 Translators
 ===========

--- a/docs/advanced_topics/testing.md
+++ b/docs/advanced_topics/testing.md
@@ -140,10 +140,12 @@ def test_cant_create_under_event_page(self):
     self.assertCanNotCreateAt(EventPage, ContentPage)
 ```
 
-**assertCanCreate(_parent, child_model, data, msg=None_)**
+**assertCanCreate(_parent, child_model, data, msg=None_, publish=True)**
 Assert that a child of the given Page type can be created under the parent, using the supplied POST data.
 
 `parent` should be a Page instance, and `child_model` should be a Page subclass. `data` should be a dict that will be POSTed at the Wagtail admin Page creation method.
+
+`publish` specifies whether the page being created should be published or not, default is `False`. When `True`, it checks if the response url includes the url of the Wagtail Explorer Page, displaying an error if does not include that url. Otherwise it checks that the correct edit page loads.
 
 ```python
 from wagtail.test.utils.form_data import nested_form_data, streamfield

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -18,6 +18,7 @@ depth: 1
  * Wagtail's documentation (v2.9 to v4.0) has been updated on [Dash user contributions](https://github.com/Kapeli/Dash-User-Contributions) for [Dash](https://kapeli.com/dash) or [Zeal](https://zealdocs.org/) offline docs applications (Damilola Oladele, (Mary Ayobami)
  * Switch to using [Willow](https://github.com/wagtail/Willow/) instead of Pillow for images (Darrel O'Pry)
  * Add documentation for how to get started with [contributing translations](contributing_translations) for the Wagtail admin (Ogunbanjo Oluwadamilare)
+ * Test assertion [`WagtailPageTestCase.assertCanCreate`](testing_reference) now supports the kwarg `publish=True` to check publish redirection (Harry Percival, Akua Dokua Asiedu)
 
 ### Bug fixes
 

--- a/wagtail/tests/test_tests.py
+++ b/wagtail/tests/test_tests.py
@@ -172,6 +172,14 @@ class TestWagtailPageTests(WagtailPageTests):
             },
         )
 
+    def test_assert_can_create_for_page_with_publish(self):
+        self.assertCanCreate(
+            self.root,
+            SimplePage,
+            {"title": "Simple Lorem Page", "content": "Lorem ipsum dolor sit amet"},
+            publish=True,
+        )
+
     def test_assert_can_create_with_form_helpers(self):
         # same as test_assert_can_create, but using the helpers from wagtail.test.utils.form_data
         # as an end-to-end test


### PR DESCRIPTION
Added docs for this [pull request](https://github.com/wagtail/wagtail/pull/4756) but for only the first and second commits as the third commit does not check whether the redirect chain includes the Wagtail admin explorer page url.

<!--
Thanks for contributing to Wagtail! 🎉

Before submitting, please review the [contributor guidelines](https://docs.wagtail.org/en/latest/contributing/index.html).
-->

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [x] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
