### PR TITLE
added filter invert on prefered-color dark to the wagtail logo on the…

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -15,6 +15,7 @@ Changelog
  * Fix: references extraction for ChooserBlock (Alex Tomkins)
  * Fix: Incorrectly formatted link in the documentation for Wagtail community support (Bolarinwa Comfort Ajayi)
  * Fix: Text within status tags text will now resize correctly when customizing browser font size (Mary Ojo)
+ * Fix: Ensure logo shows correctly on log in page in Windows high-contrast mode (Loveth Omokaro)
 
 
 4.1 LTS (xx.xx.xxxx) - IN DEVELOPMENT

--- a/client/scss/layouts/_login.scss
+++ b/client/scss/layouts/_login.scss
@@ -126,4 +126,10 @@
     margin: theme('spacing.8') auto 0;
     width: theme('spacing.8');
   }
+
+  @media (forced-colors: $media-forced-colours) and (prefers-color-scheme: dark) {
+    .login-logo-img {
+      filter: invert(100%);
+    }
+  }
 }

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -27,6 +27,7 @@ depth: 1
  * Ensure visual consistency between buttons and links as buttons in Windows high-contrast mode (Albina Starykova)
  * Ensure `ChooserBlock.extract_references` uses the model class, not the model string (Alex Tomkins)
  * Incorrectly formatted link in the documentation for Wagtail community support (Bolarinwa Comfort Ajayi)
+ * Ensure logo shows correctly on log in page in Windows high-contrast mode (Loveth Omokaro)
 
 ## Upgrade considerations
 

--- a/wagtail/admin/templates/wagtailadmin/login.html
+++ b/wagtail/admin/templates/wagtailadmin/login.html
@@ -59,7 +59,7 @@
 
         {% block branding_logo %}
             <div class="login-logo">
-                <img src="{% versioned_static 'wagtailadmin/images/wagtail-logo.svg' %}" alt=""/>
+                <img class="login-logo-img" alt="" src="{% versioned_static 'wagtailadmin/images/wagtail-logo.svg' %}" />
             </div>
         {% endblock %}
     </main>


### PR DESCRIPTION
… admin login interface

Added filter invert at 100% to the wagtail logo svg image on prefered-colors-mode dark so that it doesn't blend with the dark background on the admin login interface.

Fixes wagtail/wagtail#9428

**On dark mode**

![image](https://user-images.githubusercontent.com/38161296/197345679-138c7919-7199-4ddf-8cea-ddb62ded18c7.png)

**On light mode**

![image](https://user-images.githubusercontent.com/38161296/197345698-b3301cb7-77ed-4ac9-be40-3f20819892f0.png)

**Without forced colors**

![image](https://user-images.githubusercontent.com/38161296/197345768-96c3ab84-692d-443b-901e-0208b350c5bb.png)
