### PR TITLE
removed padding from input field  of the login page

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -103,6 +103,7 @@ Changelog
  * Fix: Fully remove the obsolete `wagtailsearch_editorspick` table that prevents flushing the database (Matt Westcott)
  * Fix: Update latest version message on Dashboard to accept dev build version format used on nlightly builds (Sam Moran)
  * Fix: references extraction for ChooserBlock (Alex Tomkins)
+ * Fix: Regression in field width for authentication pages (log in / password reset) (Chisom)
 
 
 4.0.4 (18.10.2022)

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -654,6 +654,7 @@ Contributors
 * Damee Zivah Olawuyi
 * Harry Percival
 * Akua Dokua Asiedu
+* Chisom
 
 Translators
 ===========

--- a/client/scss/layouts/_login.scss
+++ b/client/scss/layouts/_login.scss
@@ -82,6 +82,10 @@
     font-weight: theme('fontWeight.bold');
   }
 
+  .w-field__input {
+    padding: 0; // reset padding for field not used inside the admin interface
+  }
+
   .w-field__wrapper {
     margin-bottom: theme('spacing.6');
   }

--- a/docs/releases/4.1.md
+++ b/docs/releases/4.1.md
@@ -133,6 +133,7 @@ There are multiple improvements to the documentation theme this release, here ar
  * Fully remove the obsolete `wagtailsearch_editorspick` table that prevents flushing the database (Matt Westcott)
  * Update latest version message on Dashboard to accept dev build version format used on nlightly builds (Sam Moran)
  * Ensure `ChooserBlock.extract_references` uses the model class, not the model string (Alex Tomkins)
+ * Regression in field width for authentication pages (log in / password reset) (Chisom)
 
 ## Upgrade considerations
 


### PR DESCRIPTION
Fixes wagtail/wagtail#9440
Removed padding of 2rem from username/password fields so that they take the full width of the container and align with that of the sign-in button.

**Before fix**
![issh authentication](https://user-images.githubusercontent.com/82041329/197357867-6ab6ac7b-691e-4b08-9888-d34c05b02b80.jpg)

**After fix**
![resolved_shott](https://user-images.githubusercontent.com/82041329/197357882-28ef8a8d-90c3-495b-8c68-c4a5aff6a935.PNG)


