### PR TITLE
Add missing `trans` block in usage templates

### DIFF
--- a/wagtail/documents/templates/wagtaildocs/documents/usage.html
+++ b/wagtail/documents/templates/wagtaildocs/documents/usage.html
@@ -16,7 +16,7 @@
             <tbody>
                 {% for label, edit_url, edit_link_title, references in results %}
                     <tr>
-                        <td class="title" valign="top">
+                        <td class="title">
                             <div class="title-wrapper">
                                 {% if edit_url %}<a href="{{ edit_url }}" title="{{ edit_link_title }}">{% endif %}
                                 {{ label }}

--- a/wagtail/documents/templates/wagtaildocs/documents/usage.html
+++ b/wagtail/documents/templates/wagtaildocs/documents/usage.html
@@ -10,7 +10,7 @@
             <thead>
                 <tr>
                     <th class="title">{% trans "Title" %}</th>
-                    <th>Field</th>
+                    <th>{% trans "Field" %}</th>
                 </tr>
             </thead>
             <tbody>

--- a/wagtail/images/templates/wagtailimages/images/usage.html
+++ b/wagtail/images/templates/wagtailimages/images/usage.html
@@ -16,7 +16,7 @@
             <tbody>
                 {% for label, edit_url, edit_link_title, references in results %}
                     <tr>
-                        <td class="title" valign="top">
+                        <td class="title">
                             <div class="title-wrapper">
                                 {% if edit_url %}<a href="{{ edit_url }}" title="{{ edit_link_title }}">{% endif %}
                                 {{ label }}

--- a/wagtail/images/templates/wagtailimages/images/usage.html
+++ b/wagtail/images/templates/wagtailimages/images/usage.html
@@ -10,7 +10,7 @@
             <thead>
                 <tr>
                     <th class="title">{% trans "Title" %}</th>
-                    <th>Field</th>
+                    <th>{% trans "Field" %}</th>
                 </tr>
             </thead>
             <tbody>

--- a/wagtail/snippets/templates/wagtailsnippets/snippets/usage.html
+++ b/wagtail/snippets/templates/wagtailsnippets/snippets/usage.html
@@ -14,7 +14,7 @@
             <thead>
                 <tr>
                     <th class="title">{% trans "Title" %}</th>
-                    <th>Field</th>
+                    <th>{% trans "Field" %}</th>
                 </tr>
             </thead>
             <tbody>

--- a/wagtail/snippets/templates/wagtailsnippets/snippets/usage.html
+++ b/wagtail/snippets/templates/wagtailsnippets/snippets/usage.html
@@ -20,7 +20,7 @@
             <tbody>
                 {% for label, edit_url, edit_link_title, references in results %}
                     <tr>
-                        <td class="title" valign="top">
+                        <td class="title">
                             <div class="title-wrapper">
                                 {% if edit_url %}<a href="{{ edit_url }}" title="{{ edit_link_title }}">{% endif %}
                                 {{ label }}


### PR DESCRIPTION
The usage templates were updated in #9170 / #9279, but the "Field" column header was not translated.

While at it, dropped `valign="top"` from the entity type cell since we don't output anything else in there.

Before | After
-------|---------
![before](https://user-images.githubusercontent.com/31622/197394618-f445e0ac-9430-4052-aa9b-b452db936efa.png) | ![after](https://user-images.githubusercontent.com/31622/197394620-befe1df9-5331-4354-b152-993cf7d1692c.png)
