### PR TITLE
Fixed the comments notice background overlay issue

### DIFF
--- a/client/src/components/CommentApp/main.scss
+++ b/client/src/components/CommentApp/main.scss
@@ -62,8 +62,6 @@ $box-padding: 10px;
     width: calc(100% + #{$box-padding} * 2);
     padding: 5px 10px;
     box-sizing: border-box;
-    border-bottom-left-radius: $box-border-radius;
-    border-bottom-right-radius: $box-border-radius;
     
     svg.icon {
       color: theme('colors.warning.100');
@@ -73,9 +71,9 @@ $box-padding: 10px;
       vertical-align: text-bottom;
     }
   }
-
-  > :last-child &__notice {
-    bottom: -$box-padding;
+ & > &__notice-placeholder:last-child &__notice,
+  &__replies:last-child > :last-child &__notice
+  {
     // Remove once we drop support for Safari 14.
     // stylelint-disable-next-line property-disallowed-list
     border-bottom-left-radius: $box-border-radius;

--- a/client/src/components/CommentApp/main.scss
+++ b/client/src/components/CommentApp/main.scss
@@ -63,8 +63,8 @@ $box-padding: 10px;
     padding: 5px 10px;
     box-sizing: border-box;
     border-bottom-left-radius: $box-border-radius;
-    border-end-start-radius: $box-border-radius;
- 
+    border-bottom-right-radius: $box-border-radius;
+    
     svg.icon {
       color: theme('colors.warning.100');
       width: 14px;

--- a/client/src/components/CommentApp/main.scss
+++ b/client/src/components/CommentApp/main.scss
@@ -62,7 +62,9 @@ $box-padding: 10px;
     width: calc(100% + #{$box-padding} * 2);
     padding: 5px 10px;
     box-sizing: border-box;
-
+    border-bottom-left-radius: $box-border-radius;
+    border-end-start-radius: $box-border-radius;
+ 
     svg.icon {
       color: theme('colors.warning.100');
       width: 14px;


### PR DESCRIPTION
I fixed the comments notice background overlay in #9446  by adding border-bottom-radius-left & right of 5px to line 57 and it worked. 

<img width="838" alt="Screenshot 2022-10-23 at 12 42 01" src="https://user-images.githubusercontent.com/105293813/197410076-c7a69aaf-38a4-43fa-a9ba-892c252c36e9.png">



<img width="770" alt="Screenshot 2022-10-23 at 12 41 26" src="https://user-images.githubusercontent.com/105293813/197410158-ba6f8e5e-9bcd-4ea9-be3b-5fa97e69feb7.png">



