### PR TITLE
Eslint - disable rule class-methods-use-this

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,6 @@
 // Rules which have been enforced in configuration upgrades and flag issues in existing code.
 // We need to consider whether to disable those rules permanently, or fix the issues.
 const legacyCode = {
-  'class-methods-use-this': 'off',
   'constructor-super': 'off',
   'default-param-last': 'off',
   'max-classes-per-file': 'off',
@@ -28,6 +27,8 @@ module.exports = {
     '@typescript-eslint/explicit-module-boundary-types': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/no-use-before-define': ['error'],
+    // it is often helpful to pull out logic to class methods that may not use `this`
+    'class-methods-use-this': 'off',
     'import/extensions': [
       'error',
       'always',
@@ -73,7 +74,6 @@ module.exports = {
         'client/src/entrypoints/admin/page-editor.js',
         'client/src/entrypoints/admin/telepath/widgets.js',
         'client/src/entrypoints/contrib/typed_table_block/typed_table_block.js',
-        'client/src/entrypoints/images/image-chooser-modal.js',
         'client/src/utils/actions.ts',
         'client/src/utils/version.js',
       ],

--- a/client/src/includes/chooserModal.js
+++ b/client/src/includes/chooserModal.js
@@ -231,7 +231,6 @@ class ChooserModalOnloadHandlerFactory {
     initTooltips();
   }
 
-  // eslint-disable-next-line class-methods-use-this
   modalHasTabs(modal) {
     return $('[data-tabs]', modal.body).length;
   }


### PR DESCRIPTION
- Relates to #8731
- This rule makes it more complex to pull behaviour out to class methods where suitable or to provide 'base' class methods that we may want to make available to other classes.