### PR TITLE
Eslint - disable rule max-classes-per-file

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,7 +4,6 @@ const legacyCode = {
   'class-methods-use-this': 'off',
   'constructor-super': 'off',
   'default-param-last': 'off',
-  'max-classes-per-file': 'off',
   'no-continue': 'off',
   'no-else-return': 'off',
   'no-restricted-syntax': 'off',
@@ -49,6 +48,7 @@ module.exports = {
       'always',
       { exceptAfterSingleLine: true },
     ],
+    'max-classes-per-file': 'off',
     // note you must disable the base rule as it can report incorrect errors
     'no-use-before-define': 'off',
     'react/jsx-filename-extension': ['error', { extensions: ['.js', '.tsx'] }],
@@ -67,7 +67,6 @@ module.exports = {
     // Legacy Code - remove from `files` when adopting desired rules in new code progressively
     {
       files: [
-        'client/src/entrypoints/admin/comments.js',
         'client/src/entrypoints/admin/core.js',
         'client/src/entrypoints/admin/page-chooser.js',
         'client/src/entrypoints/admin/page-editor.js',

--- a/client/src/includes/chooserModal.js
+++ b/client/src/includes/chooserModal.js
@@ -1,4 +1,3 @@
-/* eslint-disable max-classes-per-file */
 import $ from 'jquery';
 import { initTabs } from './tabs';
 import { initTooltips } from './initTooltips';


### PR DESCRIPTION
- Relates to #8731
- This rule does not align well with existing code where we often declare/initialise multiple classes in a single file. It makes sense for a React only (class components) code base but not globally in Wagtail as we are currently writing JS.