### PR TITLE
Add clarification on where to register entity plugins

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -37,6 +37,7 @@ Changelog
  * Docs: Add development (contributing to Wagtail) documentation notes for development on Windows (Akua Dokua Asiedu)
  * Docs: Mention Wagtail’s usage of Django’s default user model by default (Temidayo Azeez)
  * Docs: Add links to treebeard documentation for relevant methods (Temidayo Azeez)
+ * Docs: Add clarification on where to register entity plugins (ChickenF622)
  * Maintenance: Remove unsquashed `testapp` migrations (Matt Westcott)
  * Maintenance: Upgrade to Node 18 for frontend build tooling (LB (Ben) Johnston)
  * Maintenance: Run Python tests with coverage and upload coverage data to codecov (Sage Abdullah)

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -668,6 +668,7 @@ Contributors
 * Elizabeth Bassey
 * Suyash Singh
 * Temidayo Azeez
+* ChickenF622
 
 Translators
 ===========

--- a/docs/extending/extending_draftail.md
+++ b/docs/extending/extending_draftail.md
@@ -303,7 +303,7 @@ const Stock = (props) => {
 
 This is a straightforward React component. It does not use JSX since we do not want to have to use a build step for our JavaScript.
 
-Finally, we register the JS components of our plugin:
+Finally, we register the JS components of our plugin *note this is ran outside of an event listener such as DOMContentLoaded*:
 
 ```javascript
 window.draftail.registerPlugin({

--- a/docs/extending/extending_draftail.md
+++ b/docs/extending/extending_draftail.md
@@ -303,9 +303,10 @@ const Stock = (props) => {
 
 This is a straightforward React component. It does not use JSX since we do not want to have to use a build step for our JavaScript.
 
-Finally, we register the JS components of our plugin *note this is ran outside of an event listener such as DOMContentLoaded*:
+Finally, we register the JS components of our plugin:
 
 ```javascript
+// Register the plugin directly on script execution so the editor loads it when initialising.
 window.draftail.registerPlugin({
     type: 'STOCK',
     source: StockSource,

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -51,8 +51,9 @@ depth: 1
  * Mention the importance of passing `request` and `current_site` to `get_url` on the [performance](performance) documentation page (Jake Howard)
  * Add documentation for [`register_user_listing_buttons`](register_user_listing_buttons) hook (LB (Ben Johnston))
  * Add development (contributing to Wagtail) documentation notes for [development on Windows](development_on_windows) (Akua Dokua Asiedu)
- * Docs: Mention Wagtail’s usage of Django’s default user model by default (Temidayo Azeez)
- * Docs: Add links to treebeard documentation for relevant methods (Temidayo Azeez)
+ * Mention Wagtail’s usage of Django’s default user model by default (Temidayo Azeez)
+ * Add links to treebeard documentation for relevant methods (Temidayo Azeez)
+ * Add clarification on where to register entity plugins (ChickenF622)
 
 ### Maintenance
 


### PR DESCRIPTION
Was running into the issue of running the draftail.registerPlugin within a DOMContentLoaded event listener and figured it would be a good note to add for anyone else that had this issue.

<!--
Thanks for contributing to Wagtail! 🎉

Before submitting, please review the [contributor guidelines](https://docs.wagtail.org/en/latest/contributing/index.html).
-->

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -    [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [x] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [x] **Please list the exact browser and operating system versions you tested**:
    -   [x] **Please list which assistive technologies [^3] you tested**:
-   [x] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
