### PR TITLE
Add in-memory caching to LocaleManager

### DIFF
--- a/docs/advanced_topics/i18n.md
+++ b/docs/advanced_topics/i18n.md
@@ -377,7 +377,7 @@ this into account.
 
 {% if page %}
     {% for translation in page.get_translations.live %}
-        {% get_language_info for translation.locale.language_code as lang %}
+        {% get_language_info for translation.cached_locale.language_code as lang %}
         <a href="{% pageurl translation %}" rel="alternate" hreflang="{{ language_code }}">
             {{ lang.name_local }}
         </a>
@@ -404,7 +404,7 @@ If this is part of a shared base template it may be used in situations where no 
 This `for` block iterates through all published translations of the current page.
 
 ```html+django
-{% get_language_info for translation.locale.language_code as lang %}
+{% get_language_info for translation.cached_locale.language_code as lang %}
 ```
 
 This is a Django built-in tag that gets info about the language of the translation.

--- a/docs/reference/pages/model_reference.md
+++ b/docs/reference/pages/model_reference.md
@@ -472,6 +472,8 @@ The `locale` and `translation_key` fields have a unique key constraint to preven
 .. class:: TranslatableMixin
     :noindex:
 
+    .. autoattribute:: cached_locale
+
     .. automethod:: get_translations
 
     .. automethod:: get_translation

--- a/wagtail/admin/templates/wagtailadmin/chooser/_browse_results.html
+++ b/wagtail/admin/templates/wagtailadmin/chooser/_browse_results.html
@@ -12,7 +12,7 @@
             <div class="c-dropdown t-inverted {{ class }}" style="display: inline-block;">
                 <div class="c-dropdown__button u-btn-current">
                     {% icon name="site" class_name="default" %}
-                    {{ parent_page.locale.get_display_name }}
+                    {{ parent_page.cached_locale }}
                 </div>
             </div>
         {% endif %}

--- a/wagtail/admin/templates/wagtailadmin/chooser/tables/page_title_cell.html
+++ b/wagtail/admin/templates/wagtailadmin/chooser/tables/page_title_cell.html
@@ -7,7 +7,7 @@
             {{ value }}
         {% endif %}
         {% if column.show_locale_labels and page.depth == 2 %}
-            <span class="status-tag status-tag--label">{{ page.locale.get_display_name }}</span>
+            <span class="status-tag status-tag--label">{{ page.cached_locale }}</span>
         {% endif %}
 
         {% include "wagtailadmin/pages/listing/_privacy_indicator.html" with page=page %}

--- a/wagtail/admin/templates/wagtailadmin/chooser/tables/parent_page_cell.html
+++ b/wagtail/admin/templates/wagtailadmin/chooser/tables/parent_page_cell.html
@@ -1,6 +1,6 @@
 <td {% if column.classname %}class="{{ column.classname }}"{% endif %}>
     {% if value %}
         <a href="{% url 'wagtailadmin_choose_page_child' value.id %}" class="navigate-parent">{{ value.get_admin_display_title }}</a>
-        {% if column.show_locale_labels %}<span class="status-tag status-tag--label">{{ value.locale.get_display_name }}</span>{% endif %}
+        {% if column.show_locale_labels %}<span class="status-tag status-tag--label">{{ value.cached_locale }}</span>{% endif %}
     {% endif %}
 </td>

--- a/wagtail/admin/templates/wagtailadmin/home/locked_pages.html
+++ b/wagtail/admin/templates/wagtailadmin/home/locked_pages.html
@@ -20,11 +20,9 @@
                         <td class="title" valign="top">
                             <div class="title-wrapper">
                                 <a href="{% url 'wagtailadmin_pages:edit' page.id %}" title="{% trans 'Edit this page' %}">{{ page.get_admin_display_title }}</a>
-
                                 {% i18n_enabled as show_locale_labels %}
-                                {% if show_locale_labels and page.locale_id %}
-                                    {% locale_label_from_id page.locale_id as locale_label %}
-                                    <span class="status-tag status-tag--label">{{ locale_label }}</span>
+                                {% if show_locale_labels %}
+                                    <span class="status-tag status-tag--label">{{ page.cached_locale }}</span>
                                 {% endif %}
                                 {% include "wagtailadmin/pages/listing/_privacy_indicator.html" with page=page %}
                                 {% include "wagtailadmin/pages/listing/_locked_indicator.html" with page=page %}

--- a/wagtail/admin/templates/wagtailadmin/home/pages_for_moderation.html
+++ b/wagtail/admin/templates/wagtailadmin/home/pages_for_moderation.html
@@ -33,8 +33,7 @@
 
                                 {% i18n_enabled as show_locale_labels %}
                                 {% if show_locale_labels and revision.content_object.locale_id %}
-                                    {% locale_label_from_id revision.content_object.locale_id as locale_label %}
-                                    <span class="status-tag status-tag--label">{{ locale_label }}</span>
+                                    <span class="status-tag status-tag--label">{{ revision.content_object.cached_locale }}</span>
                                 {% endif %}
                                 {% include "wagtailadmin/pages/listing/_privacy_indicator.html" with page=revision.content_object %}
                                 {% include "wagtailadmin/pages/listing/_locked_indicator.html" with page=revision.content_object %}

--- a/wagtail/admin/templates/wagtailadmin/home/recent_edits.html
+++ b/wagtail/admin/templates/wagtailadmin/home/recent_edits.html
@@ -23,9 +23,8 @@
                                 <a href="{% url 'wagtailadmin_pages:edit' page.id %}" title="{% trans 'Edit this page' %}">{{ page.get_admin_display_title }}</a>
 
                                 {% i18n_enabled as show_locale_labels %}
-                                {% if show_locale_labels and page.locale_id %}
-                                    {% locale_label_from_id page.locale_id as locale_label %}
-                                    <span class="status-tag status-tag--label">{{ locale_label }}</span>
+                                {% if show_locale_labels %}
+                                    <span class="status-tag status-tag--label">{{ page.cached_locale }}</span>
                                 {% endif %}
                                 {% include "wagtailadmin/pages/listing/_privacy_indicator.html" with page=page %}
                                 {% include "wagtailadmin/pages/listing/_locked_indicator.html" with page=page %}

--- a/wagtail/admin/templates/wagtailadmin/home/user_pages_in_workflow_moderation.html
+++ b/wagtail/admin/templates/wagtailadmin/home/user_pages_in_workflow_moderation.html
@@ -29,9 +29,8 @@
                                     {% endif %}
 
                                     {% i18n_enabled as show_locale_labels %}
-                                    {% if show_locale_labels and workflow_state.page.locale_id %}
-                                        {% locale_label_from_id workflow_state.page.locale_id as locale_label %}
-                                        <span class="status-tag status-tag--label">{{ locale_label }}</span>
+                                    {% if show_locale_labels %}
+                                        <span class="status-tag status-tag--label">{{ workflow_state.page.cached_locale }}</span>
                                     {% endif %}
                                     {% include "wagtailadmin/pages/listing/_privacy_indicator.html" with page=workflow_state.page %}
                                     {% include "wagtailadmin/pages/listing/_locked_indicator.html" with page=workflow_state.page %}

--- a/wagtail/admin/templates/wagtailadmin/home/workflow_pages_to_moderate.html
+++ b/wagtail/admin/templates/wagtailadmin/home/workflow_pages_to_moderate.html
@@ -30,8 +30,7 @@
 
                                     {% i18n_enabled as show_locale_labels %}
                                     {% if show_locale_labels and revision.content_object.locale_id %}
-                                        {% locale_label_from_id revision.content_object.locale_id as locale_label %}
-                                        <span class="status-tag status-tag--label">{{ locale_label }}</span>
+                                        <span class="status-tag status-tag--label">{{ revision.content_object.cached_locale }}</span>
                                     {% endif %}
                                     {% include "wagtailadmin/pages/listing/_privacy_indicator.html" with page=revision.content_object %}
                                     {% include "wagtailadmin/pages/listing/_locked_indicator.html" with page=revision.content_object %}

--- a/wagtail/admin/templates/wagtailadmin/pages/listing/_page_title_explore.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/listing/_page_title_explore.html
@@ -16,7 +16,7 @@
     {% endif %}
 
     {% if show_locale_labels %}
-        <span class="status-tag status-tag--label">{{ page.locale.get_display_name }}</span>
+        <span class="status-tag status-tag--label">{{ page.cached_locale }}</span>
     {% endif %}
 
     {% include "wagtailadmin/pages/listing/_privacy_indicator.html" with page=page %}

--- a/wagtail/admin/templates/wagtailadmin/reports/aging_pages.html
+++ b/wagtail/admin/templates/wagtailadmin/reports/aging_pages.html
@@ -30,8 +30,7 @@
                             </a>
                             {% i18n_enabled as show_locale_labels %}
                             {% if show_locale_labels %}
-                                {% locale_label_from_id page.locale_id as locale_label %}
-                                <span class="status-tag status-tag--label">{{ locale_label }}</span>
+                                <span class="status-tag status-tag--label">{{ page.cached_locale }}</span>
                             {% endif %}
                         </td>
                         <td class="status" valign="top">

--- a/wagtail/admin/templates/wagtailadmin/reports/workflow.html
+++ b/wagtail/admin/templates/wagtailadmin/reports/workflow.html
@@ -45,8 +45,7 @@
                             </a>
                             {% i18n_enabled as show_locale_labels %}
                             {% if show_locale_labels %}
-                                {% locale_label_from_id workflow_state.page.locale_id as locale_label %}
-                                <span class="status-tag status-tag--label">{{ locale_label }}</span>
+                                <span class="status-tag status-tag--label">{{ workflow_state.page.cached_locale }}</span>
                             {% endif %}
                         </td>
                         <td>

--- a/wagtail/admin/templates/wagtailadmin/reports/workflow_tasks.html
+++ b/wagtail/admin/templates/wagtailadmin/reports/workflow_tasks.html
@@ -43,8 +43,7 @@
                                 </a>
                                 {% i18n_enabled as show_locale_labels %}
                                 {% if show_locale_labels %}
-                                    {% locale_label_from_id page.locale_id as locale_label %}
-                                    <span class="status-tag status-tag--label">{{ locale_label }}</span>
+                                    <span class="status-tag status-tag--label">{{ page.cached_locale }}</span>
                                 {% endif %}
                             {% endwith %}
                         </td>

--- a/wagtail/admin/templatetags/wagtailadmin_tags.py
+++ b/wagtail/admin/templatetags/wagtailadmin_tags.py
@@ -36,11 +36,7 @@ from wagtail.admin.views.bulk_action.registry import bulk_action_registry
 from wagtail.admin.widgets import ButtonWithDropdown, PageListingButton
 from wagtail.coreutils import camelcase_to_underscore
 from wagtail.coreutils import cautious_slugify as _cautious_slugify
-from wagtail.coreutils import (
-    escape_script,
-    get_content_type_label,
-    get_locales_display_names,
-)
+from wagtail.coreutils import escape_script, get_content_type_label
 from wagtail.models import (
     CollectionViewRestriction,
     Locale,
@@ -809,14 +805,6 @@ def locales():
             for locale in Locale.objects.all()
         ]
     )
-
-
-@register.simple_tag
-def locale_label_from_id(locale_id):
-    """
-    Returns the Locale display name given its id.
-    """
-    return get_locales_display_names().get(locale_id)
 
 
 @register.simple_tag(takes_context=True)

--- a/wagtail/admin/tests/test_templatetags.py
+++ b/wagtail/admin/tests/test_templatetags.py
@@ -11,11 +11,7 @@ from django.utils.html import format_html
 from freezegun import freeze_time
 
 from wagtail.admin.staticfiles import versioned_static
-from wagtail.admin.templatetags.wagtailadmin_tags import (
-    avatar_url,
-    i18n_enabled,
-    locale_label_from_id,
-)
+from wagtail.admin.templatetags.wagtailadmin_tags import avatar_url, i18n_enabled
 from wagtail.admin.templatetags.wagtailadmin_tags import locales as locales_tag
 from wagtail.admin.templatetags.wagtailadmin_tags import (
     notification_static,
@@ -280,17 +276,6 @@ class TestInternationalisationTags(TestCase):
                 {"code": "ru", "display_name": "Russian"},
             ],
         )
-
-    def test_locale_label_from_id(self):
-        with self.assertNumQueries(1):
-            self.assertEqual(locale_label_from_id(self.locale_ids[0]), "English")
-
-        with self.assertNumQueries(0):
-            self.assertEqual(locale_label_from_id(self.locale_ids[1]), "French")
-
-        # check with an invalid id
-        with self.assertNumQueries(0):
-            self.assertIsNone(locale_label_from_id(self.locale_ids[-1] + 100), None)
 
 
 class ComponentTest(TestCase):

--- a/wagtail/coreutils.py
+++ b/wagtail/coreutils.py
@@ -322,19 +322,6 @@ def get_supported_content_language_variant(lang_code, strict=False):
     raise LookupError(lang_code)
 
 
-@functools.lru_cache()
-def get_locales_display_names() -> dict:
-    """
-    Cache of the locale id -> locale display name mapping
-    """
-    from wagtail.models import Locale  # inlined to avoid circular imports
-
-    locales_map = {
-        locale.pk: locale.get_display_name() for locale in Locale.objects.all()
-    }
-    return locales_map
-
-
 @receiver(setting_changed)
 def reset_cache(**kwargs):
     """

--- a/wagtail/models/i18n.py
+++ b/wagtail/models/i18n.py
@@ -129,6 +129,16 @@ class TranslatableMixin(models.Model):
         abstract = True
         unique_together = [("translation_key", "locale")]
 
+    @property
+    def cached_locale(self):
+        """
+        Can be used instead of ``self.locale`` to retrieve a ``Locale``
+        from LocaleManager's in-memory cache. This is great for efficiently
+        displaying language information for objects without hitting the
+        database, but for all other purposes, it's safer to use `self.locale`.
+        """
+        return Locale.objects.get_for_id(self.locale_id)
+
     @classmethod
     def check(cls, **kwargs):
         errors = super(TranslatableMixin, cls).check(**kwargs)

--- a/wagtail/signal_handlers.py
+++ b/wagtail/signal_handlers.py
@@ -13,7 +13,6 @@ from django.db.models.signals import (
 )
 from modelcluster.fields import ParentalKey
 
-from wagtail.coreutils import get_locales_display_names
 from wagtail.models import Locale, Page, ReferenceIndex, Site
 
 logger = logging.getLogger("wagtail")
@@ -37,10 +36,6 @@ def pre_delete_page_unpublish(sender, instance, **kwargs):
 
 def post_delete_page_log_deletion(sender, instance, **kwargs):
     logger.info('Page deleted: "%s" id=%d', instance.title, instance.id)
-
-
-def reset_locales_display_names_cache(sender, instance, **kwargs):
-    get_locales_display_names.cache_clear()
 
 
 def clear_localemanager_cache(sender, *args, **kwargs):
@@ -123,9 +118,6 @@ def register_signal_handlers():
 
     pre_delete.connect(pre_delete_page_unpublish, sender=Page)
     post_delete.connect(post_delete_page_log_deletion, sender=Page)
-
-    post_save.connect(reset_locales_display_names_cache, sender=Locale)
-    post_delete.connect(reset_locales_display_names_cache, sender=Locale)
 
     post_delete.connect(clear_localemanager_cache, sender=Locale)
     post_save.connect(clear_localemanager_cache, sender=Locale)

--- a/wagtail/signal_handlers.py
+++ b/wagtail/signal_handlers.py
@@ -43,6 +43,13 @@ def reset_locales_display_names_cache(sender, instance, **kwargs):
     get_locales_display_names.cache_clear()
 
 
+def clear_localemanager_cache(sender, *args, **kwargs):
+    # This will only affect the cache in the current running instance. Other
+    # instances will refresh their caches themselves if they come across a
+    # new Locale.
+    Locale.objects.clear_cache()
+
+
 reference_index_auto_update_disabled = Local()
 
 
@@ -119,6 +126,9 @@ def register_signal_handlers():
 
     post_save.connect(reset_locales_display_names_cache, sender=Locale)
     post_delete.connect(reset_locales_display_names_cache, sender=Locale)
+
+    post_delete.connect(clear_localemanager_cache, sender=Locale)
+    post_save.connect(clear_localemanager_cache, sender=Locale)
 
     # Reference index signal handlers
     connect_reference_index_signal_handlers()


### PR DESCRIPTION
The number of locales used in any one project is typically quite small (< 100), and locale objects themselves so simple and so unlikely to change, they feel like a perfect candidate for caching. Django does this for ContentTypes, which are used heavily by Wagtail. So, I figured: why not do a similar thing with Locales? So here it is...
