### PR TITLE
Fixes Design update - secondary button with icon #9198 

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -24,6 +24,7 @@ Changelog
  * Add development (contributing to Wagtail) documentation notes for development on Windows (Akua Dokua Asiedu)
  * Clean up linting on legacy code and add shared util `hasOwn` in TypeScript (Loveth Omokaro)
  * Remove unnecessary box-sizing: border-box declarations in SCSS (Albina Starykova)
+ * Add full support for secondary buttons with icons in the Wagtail design system - `button bicolor button--icon button-secondary` including the `button-small` variant (Seremba Patrick)
  * Fix: Make sure workflow timeline icons are visible in high-contrast mode (Loveth Omokaro)
  * Fix: Ensure authentication forms (login, password reset) have a visible border in Windows high-contrast mode (Loveth Omokaro)
  * Fix: Ensure visual consistency between buttons and links as buttons in Windows high-contrast mode (Albina Starykova)

--- a/client/scss/components/_button.scss
+++ b/client/scss/components/_button.scss
@@ -150,7 +150,22 @@
     }
 
     &.button-secondary {
-      border-color: theme('colors.black-20');
+      .icon-wrapper {
+        border-inline-end: 1px solid $color-button;
+        background-color: transparent;
+      }
+
+      &:hover {
+        background-color: theme('colors.secondary.50');
+      }
+
+      &:disabled,
+      &[disabled],
+      &.disabled {
+        .icon-wrapper {
+          border-color: $color-grey-4;
+        }
+      }
     }
 
     &.button-small {
@@ -163,6 +178,35 @@
       &.button--icon .icon {
         @include svg-icon(0.9rem);
         padding: 0.25em;
+      }
+
+      &.button-secondary {
+        border: 0;
+        padding-inline-start: 2.2em;
+
+        .icon-wrapper {
+          border: 1px solid $color-button;
+          border-radius: 50%;
+          height: fit-content;
+          width: fit-content;
+        }
+
+        &:hover {
+          background-color: transparent;
+
+          .icon-wrapper {
+            background-color: $color-button;
+            color: $color-white;
+          }
+        }
+
+        &:disabled,
+        &[disabled],
+        &.disabled {
+          .icon-wrapper {
+            background-color: transparent;
+          }
+        }
       }
     }
   }

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -33,6 +33,7 @@ depth: 1
  * Add development (contributing to Wagtail) documentation notes for [development on Windows](development_on_windows) (Akua Dokua Asiedu)
  * Clean up linting on legacy code and add shared util `hasOwn` in TypeScript (Loveth Omokaro)
  * Remove unnecessary box-sizing: border-box declarations in SCSS (Albina Starykova)
+ * Add full support for secondary buttons with icons in the Wagtail design system - `button bicolor button--icon button-secondary` including the `button-small` variant (Seremba Patrick)
 
 ### Bug fixes
 


### PR DESCRIPTION
styled both the default secondary button with an icon and the secondary small button with an icon using CSS/SCSS
This fixes #9198 
before
![seconadry_button_with_icon](https://user-images.githubusercontent.com/45463621/198117253-75aef907-21f2-49a9-83fe-728bad4ce8ee.jpeg)
After
![Screenshot from 2022-10-26 12-37-11](https://user-images.githubusercontent.com/45463621/198117319-f351a290-305e-40c3-b11b-7da5b4a3fadc.png)
