### PR TITLE
Fix scheduled publishing dialog with custom `settings_panels`

### DIFF
--- a/client/scss/components/forms/_publishing.scss
+++ b/client/scss/components/forms/_publishing.scss
@@ -1,5 +1,5 @@
 // Styles for the fields in the scheduled publishing dialog
-.w-panel.publishing {
+.w-dialog.publishing {
   .w-panel__wrapper {
     margin-top: theme('spacing.2');
     margin-bottom: theme('spacing.2');

--- a/wagtail/admin/panels.py
+++ b/wagtail/admin/panels.py
@@ -1115,6 +1115,7 @@ class PublishingPanel(MultiFieldPanel):
             context = super().get_context_data(parent_context)
             context["request"] = self.request
             context["instance"] = self.instance
+            context["classname"] = self.classname
             if isinstance(self.instance, Page):
                 context["page"] = self.instance
             return context

--- a/wagtail/admin/templates/wagtailadmin/panels/publishing/schedule_publishing_panel.html
+++ b/wagtail/admin/templates/wagtailadmin/panels/publishing/schedule_publishing_panel.html
@@ -13,12 +13,10 @@
     {% endif %}
 {% endif %}
 
-<div data-schedule-publishing-dialog-root>
-    {% dialog id='schedule-publishing-dialog' dialog_root_selector='[data-schedule-publishing-dialog-root]' icon_name='calendar-alt' title=schedule_publishing_dialog_title subtitle=schedule_publishing_dialog_subtitle message_icon_name='info' message_status='info' message_heading=message_heading message_description=message_description %}
-        {% include 'wagtailadmin/panels/multi_field_panel.html' %}
+{% dialog id='schedule-publishing-dialog' dialog_root_selector='[data-edit-form]' classname=classname icon_name='calendar-alt' title=schedule_publishing_dialog_title subtitle=schedule_publishing_dialog_subtitle message_icon_name='info' message_status='info' message_heading=message_heading message_description=message_description %}
+    {% include 'wagtailadmin/panels/multi_field_panel.html' %}
 
-        <button type="submit" class="button action-save button-longrunning" data-clicked-text="{% trans 'Saving…' %}">
-            <em>{% trans 'Save schedule' %}</em>
-        </button>
-    {% enddialog %}
-</div>
+    <button type="submit" class="button action-save button-longrunning" data-clicked-text="{% trans 'Saving…' %}">
+        <em>{% trans 'Save schedule' %}</em>
+    </button>
+{% enddialog %}

--- a/wagtail/admin/templates/wagtailadmin/shared/dialog/dialog.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/dialog/dialog.html
@@ -4,7 +4,7 @@
         id="{{ id }}"
         aria-labelledby="title-{{ id }}"
         aria-hidden="true"
-        class="w-dialog"
+        class="w-dialog{% if classname %} {{ classname }}{% endif %}"
         {% if dialog_root_selector %}
             data-dialog-root-selector="{{ dialog_root_selector }}"
         {% endif %}

--- a/wagtail/admin/tests/pages/test_edit_page.py
+++ b/wagtail/admin/tests/pages/test_edit_page.py
@@ -410,6 +410,14 @@ class TestPageEdit(TestCase, WagtailTestUtils):
             allow_extra_attrs=True,
         )
 
+        # Should show the dialog template pointing to the [data-edit-form] selector as the root
+        self.assertTagInHTML(
+            '<div id="schedule-publishing-dialog" class="w-dialog publishing" data-dialog-root-selector="[data-edit-form]">',
+            html,
+            count=1,
+            allow_extra_attrs=True,
+        )
+
         self.assertContains(
             response,
             "This publishing schedule will only take effect after you have published",
@@ -1002,6 +1010,14 @@ class TestPageEdit(TestCase, WagtailTestUtils):
         html = response.content.decode()
         self.assertTagInHTML(
             '<button type="button" data-a11y-dialog-show="schedule-publishing-dialog">Edit schedule</button>',
+            html,
+            count=1,
+            allow_extra_attrs=True,
+        )
+
+        # Should show the dialog template pointing to the [data-edit-form] selector as the root
+        self.assertTagInHTML(
+            '<div id="schedule-publishing-dialog" class="w-dialog publishing" data-dialog-root-selector="[data-edit-form]">',
             html,
             count=1,
             allow_extra_attrs=True,

--- a/wagtail/snippets/tests/test_snippets.py
+++ b/wagtail/snippets/tests/test_snippets.py
@@ -1956,6 +1956,14 @@ class TestEditDraftStateSnippet(BaseTestSnippetEditView):
             allow_extra_attrs=True,
         )
 
+        # Should show the dialog template pointing to the [data-edit-form] selector as the root
+        self.assertTagInHTML(
+            '<div id="schedule-publishing-dialog" class="w-dialog publishing" data-dialog-root-selector="[data-edit-form]">',
+            html,
+            count=1,
+            allow_extra_attrs=True,
+        )
+
     def test_edit_scheduled_go_live_before_expiry(self):
         response = self.post(
             post_data={
@@ -2089,6 +2097,14 @@ class TestEditDraftStateSnippet(BaseTestSnippetEditView):
             allow_extra_attrs=True,
         )
 
+        # Should show the dialog template pointing to the [data-edit-form] selector as the root
+        self.assertTagInHTML(
+            '<div id="schedule-publishing-dialog" class="w-dialog publishing" data-dialog-root-selector="[data-edit-form]">',
+            html,
+            count=1,
+            allow_extra_attrs=True,
+        )
+
     def test_edit_post_publish_now_an_already_scheduled_unpublished(self):
         # First let's publish an object with a go_live_at in the future
         go_live_at = now() + datetime.timedelta(days=1)
@@ -2149,6 +2165,14 @@ class TestEditDraftStateSnippet(BaseTestSnippetEditView):
         html = response.content.decode()
         self.assertTagInHTML(
             '<button type="button" data-a11y-dialog-show="schedule-publishing-dialog">Edit schedule</button>',
+            html,
+            count=1,
+            allow_extra_attrs=True,
+        )
+
+        # Should show the dialog template pointing to the [data-edit-form] selector as the root
+        self.assertTagInHTML(
+            '<div id="schedule-publishing-dialog" class="w-dialog publishing" data-dialog-root-selector="[data-edit-form]">',
             html,
             count=1,
             allow_extra_attrs=True,
@@ -2234,6 +2258,14 @@ class TestEditDraftStateSnippet(BaseTestSnippetEditView):
         html = response.content.decode()
         self.assertTagInHTML(
             '<button type="button" data-a11y-dialog-show="schedule-publishing-dialog">Edit schedule</button>',
+            html,
+            count=1,
+            allow_extra_attrs=True,
+        )
+
+        # Should show the dialog template pointing to the [data-edit-form] selector as the root
+        self.assertTagInHTML(
+            '<div id="schedule-publishing-dialog" class="w-dialog publishing" data-dialog-root-selector="[data-edit-form]">',
             html,
             count=1,
             allow_extra_attrs=True,
@@ -2407,6 +2439,14 @@ class TestEditDraftStateSnippet(BaseTestSnippetEditView):
             allow_extra_attrs=True,
         )
 
+        # Should show the dialog template pointing to the [data-edit-form] selector as the root
+        self.assertTagInHTML(
+            '<div id="schedule-publishing-dialog" class="w-dialog publishing" data-dialog-root-selector="[data-edit-form]">',
+            html,
+            count=1,
+            allow_extra_attrs=True,
+        )
+
     def test_edit_post_publish_schedule_before_a_scheduled_expire(self):
         # First let's publish an object with *just* an expire_at in the future
         expire_at = now() + datetime.timedelta(days=20)
@@ -2500,6 +2540,14 @@ class TestEditDraftStateSnippet(BaseTestSnippetEditView):
         html = response.content.decode()
         self.assertTagInHTML(
             '<button type="button" data-a11y-dialog-show="schedule-publishing-dialog">Edit schedule</button>',
+            html,
+            count=1,
+            allow_extra_attrs=True,
+        )
+
+        # Should show the dialog template pointing to the [data-edit-form] selector as the root
+        self.assertTagInHTML(
+            '<div id="schedule-publishing-dialog" class="w-dialog publishing" data-dialog-root-selector="[data-edit-form]">',
             html,
             count=1,
             allow_extra_attrs=True,
@@ -2601,6 +2649,14 @@ class TestEditDraftStateSnippet(BaseTestSnippetEditView):
         html = response.content.decode()
         self.assertTagInHTML(
             '<button type="button" data-a11y-dialog-show="schedule-publishing-dialog">Edit schedule</button>',
+            html,
+            count=1,
+            allow_extra_attrs=True,
+        )
+
+        # Should show the dialog template pointing to the [data-edit-form] selector as the root
+        self.assertTagInHTML(
+            '<div id="schedule-publishing-dialog" class="w-dialog publishing" data-dialog-root-selector="[data-edit-form]">',
             html,
             count=1,
             allow_extra_attrs=True,


### PR DESCRIPTION
Fixes #9452.

## Note

We may be able to get away with such issue for now because the scheduled publishing stuff is within a dialog component.

However, if in the future we have more form fields that are rendered using our Panels API but with the `show_panel_furniture()` returning `False` (i.e. they're actually "outside" of the editor UI), we'll need to think of a more robust solution.

I'm thinking we can have a method that collects those fields, then use it to render them outside of the tabs (but still in the form element). Sort of like how `render_missing_fields()`, but relying on `show_panel_furniture()` instead of `is_shown()`, and collecting the child fields recursively instead of relying on the immediate child to handle the descendants.

Or, maybe we'll find a way to safely separate such elements from the root edit handler...

<!--
Thanks for contributing to Wagtail! 🎉

Before submitting, please review the [contributor guidelines](https://docs.wagtail.org/en/latest/contributing/index.html).
-->

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
