### PR TITLE
Support text resizing in workflow steps cards

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -31,6 +31,7 @@ Changelog
  * Fix: Allow button labels to wrap onto two lines in dropdown buttons (Coen van der Kamp)
  * Fix: Allow both horizontal and vertical manual resizing of TextFields (Anisha Singh)
  * Fix: Move DateField, DateTimeField, TimeField comment buttons to be right next to the fields (Theresa Okoro)
+ * Fix: Support text resizing in workflow steps cards (Ivy Jeptoo)
  * Docs: Add custom permissions section to permissions documentation page (Dan Hayden)
  * Docs: Add documentation for how to get started with contributing translations for the Wagtail admin (Ogunbanjo Oluwadamilare)
  * Docs: Officially recommend `fnm` over `nvm` in development documentation (LB (Ben) Johnston)
@@ -69,6 +70,7 @@ Changelog
  * Fix: Allow button labels to wrap onto two lines in dropdown buttons (Coen van der Kamp)
  * Fix: Allow both horizontal and vertical manual resizing of TextFields (Anisha Singh)
  * Fix: Move DateField, DateTimeField, TimeField comment buttons to be right next to the fields (Theresa Okoro)
+ * Fix: Support text resizing in workflow steps cards (Ivy Jeptoo)
 
 
 4.1.1 (11.11.2022)

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -671,6 +671,7 @@ Contributors
 * Mark McOsker
 * Benita Anawonah
 * Anisha Singh
+* Ivy Jeptoo
 
 Translators
 ===========

--- a/client/scss/components/_workflow-tasks.scss
+++ b/client/scss/components/_workflow-tasks.scss
@@ -10,7 +10,7 @@
     border: 2px solid theme('colors.secondary.100');
     border-radius: 5px;
     color: $color-teal;
-    width: $task-width;
+    min-width: $task-width;
     height: $task-height;
     margin: 7px;
     padding-inline-start: 9px;
@@ -18,12 +18,12 @@
   }
 
   &__step {
-    font-size: 10px;
-    margin-top: 3px;
+    font-size: 0.625rem;
+    margin-top: 0.1875rem;
   }
 
   &__name {
-    font-size: 16px;
+    font-size: 1rem;
     font-weight: bold;
     margin: 0;
 

--- a/docs/releases/4.1.2.md
+++ b/docs/releases/4.1.2.md
@@ -19,3 +19,4 @@ depth: 1
  * Allow button labels to wrap onto two lines in dropdown buttons (Coen van der Kamp)
  * Allow both horizontal and vertical manual resizing of TextFields (Anisha Singh)
  * Move DateField, DateTimeField, TimeField comment buttons to be right next to the fields (Theresa Okoro)
+ * Support text resizing in workflow steps cards (Ivy Jeptoo)

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -43,6 +43,7 @@ depth: 1
  * Allow button labels to wrap onto two lines in dropdown buttons (Coen van der Kamp)
  * Allow both horizontal and vertical manual resizing of TextFields (Anisha Singh)
  * Move DateField, DateTimeField, TimeField comment buttons to be right next to the fields (Theresa Okoro)
+ * Support text resizing in workflow steps cards (Ivy Jeptoo)
 
 ### Documentation
 


### PR DESCRIPTION
<!--
Thanks for contributing to Wagtail! 🎉

Before submitting, please review the [contributor guidelines](https://docs.wagtail.org/en/latest/contributing/index.html).
-->

_Please check the following:_

-   [X] Do the tests still pass?[^1]
-   [X] Does the code comply with the style guide?
    -   [X] Run `make lint` from the Wagtail root.
-   [X] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [X] **Please list the exact browser and operating system versions you tested**:
    - Chrome(Desktop-2)
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.
### Problem Statement
- The tasks display (settings-workflow) on the /admin/workflows/list/ has a few issues which I have listed below and a screenshot attached to it:
1. The font-size declarations in the CSS file are in pixels font-size zooming is difficult for the users who want to zoom. 
2. The task has a width set, and therefore texts get cropped as per the screenshot below:

![Screenshot](https://user-images.githubusercontent.com/98116399/198310292-6324b6a9-f0cc-41e6-a1dd-d9b181bdfd24.png)

### Solution
- As a result I changed the font-size declaration from px to rem and also the margin-top related to it 
- I then used min-width on the task instead of width the output is as:
![Screenshot from 2022-10-27 12-51-08](https://user-images.githubusercontent.com/98116399/198369371-9f7d5f9e-1895-4a2d-b7c3-38eded63fbe4.png)
 (**I create the 'making it longer' task just to test out the changes**)





[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
