### PR TITLE
Add missing JS call to LockUnlockAction on page index

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/pages/index.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/index.html
@@ -30,6 +30,11 @@
     <script src="{% versioned_static 'wagtailadmin/js/modal-workflow.js' %}"></script>
     <script src="{% versioned_static 'wagtailadmin/js/privacy-switch.js' %}"></script>
 
+    <script src="{% versioned_static 'wagtailadmin/js/lock-unlock-action.js' %}"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', () => LockUnlockAction('{{ csrf_token|escapejs }}', '{% url 'wagtailadmin_pages:edit' parent_page.id %}'));
+    </script>
+
     {% comment %}
     The first column will display checkboxes only if ordering is not being carried out, in which case
     that column will have the drag and drop buttons to enable ordering


### PR DESCRIPTION
Fyi: I've used the edit-page of the locked page as the target for the following redirect (after locking/unlocking). Redirecting back to the explorer does not work quite well, because only the unlock-action currently creates a "message"-notification.

This made sense in the past, as only the unlock-action is currently called "externally" from the locked-pages report or the home-page-section. The lock action does not use a notification, as it was only used on the edit-page, and if a page is locked, a permanent info-message is already shown at the top.
If this redirect should be changed, we probably need a success-message for "lock", which is only shown, if the redirect is not targeting the edit-page.

Fixes #9481

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**: Firefox 106 (Linux Mint)
    -   [ ] **Please list which assistive technologies [^3] you tested**:

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
