### PR TITLE
Wrap JS in missing callbacks for DOMContentLoaded

### DIFF
--- a/wagtail/admin/templates/wagtailadmin/home/locked_pages.html
+++ b/wagtail/admin/templates/wagtailadmin/home/locked_pages.html
@@ -31,7 +31,7 @@
                             </div>
                             <ul class="actions">
                                 {% if can_remove_locks %}
-                                    <li><button data-action-lock-unlock="{% url 'wagtailadmin_pages:unlock' page.id %}" class="button button-small button-secondary">{% trans "Unlock" %}</button></li>
+                                    <li><button data-action-lock-unlock data-url="{% url 'wagtailadmin_pages:unlock' page.id %}" class="button button-small button-secondary">{% trans "Unlock" %}</button></li>
                                 {% endif %}
                                 <li><a href="{% url 'wagtailadmin_pages:edit' page.id %}" class="button button-small button-secondary">{% trans "Edit" %}</a></li>
                                 {% if page.has_unpublished_changes and page.is_previewable %}
@@ -55,6 +55,6 @@
     {% endpanel %}
     <script src="{% versioned_static 'wagtailadmin/js/lock-unlock-action.js' %}"></script>
     <script>
-        document.addEventListener('DOMContentLoaded', LockUnlockAction('{{ csrf_token|escapejs }}', '{% url 'wagtailadmin_home' %}'));
+        document.addEventListener('DOMContentLoaded', () => LockUnlockAction('{{ csrf_token|escapejs }}', '{% url 'wagtailadmin_home' %}'));
     </script>
 {% endif %}

--- a/wagtail/admin/templates/wagtailadmin/home/workflow_pages_to_moderate.html
+++ b/wagtail/admin/templates/wagtailadmin/home/workflow_pages_to_moderate.html
@@ -84,7 +84,7 @@
     <script src="{% versioned_static 'wagtailadmin/js/workflow-action.js' %}"></script>
     <script src="{% versioned_static 'wagtailadmin/js/vendor/bootstrap-tooltip.js' %}"></script>
     <script>
-        document.addEventListener('DOMContentLoaded', ActivateWorkflowActionsForDashboard('{{ csrf_token|escapejs }}'));
+        document.addEventListener('DOMContentLoaded', () => ActivateWorkflowActionsForDashboard('{{ csrf_token|escapejs }}'));
         /* Tooltips used by the workflow status component */
         $(function() {
             $('[data-wagtail-tooltip]').tooltip({

--- a/wagtail/admin/templates/wagtailadmin/pages/index.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/index.html
@@ -25,6 +25,10 @@
 
 {% block extra_js %}
     {{ block.super }}
+    <script src="{% versioned_static 'wagtailadmin/js/lock-unlock-action.js' %}"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', () => LockUnlockAction('{{ csrf_token|escapejs }}', '{% url 'wagtailadmin_home' %}'));
+    </script>
 
     {% comment %} modal-workflow is required by the view restrictions interface {% endcomment %}
     <script src="{% versioned_static 'wagtailadmin/js/modal-workflow.js' %}"></script>


### PR DESCRIPTION
Until now, those calls have been executed synchronously with the call of `addEventListener`. This was not really an issue, because those script-tags where placed after the relevant DOM nodes, but it may lead to bugs in the future if those scripts or the HTML get moved.

I've found those calls while implementing #9528, where I've first copied the lines from https://github.com/wagtail/wagtail/blob/b84825487381b3d5ac7bb0859924c20157227d61/wagtail/admin/templates/wagtailadmin/home/locked_pages.html#L56-L59 and wondered, why they aren't working in for the side panel.

**Testing:**
1) [locked_pages.html](https://github.com/wagtail/wagtail/pull/9530/files#diff-2768442c7fcba9a30cfaaa6c5323a32f8c6656b6c6b33d17a45de29b54cb4520)
Lock a page, go to the CMS homepage, click the unlock-button -> should unlock it.
2) [workflow_pages_to_moderate.html](https://github.com/wagtail/wagtail/pull/9530/files#diff-4e6c888b8329052bbb304eadd18c68096a6e799e3883ebe905f8243243ec42a3)
Edit a page and submit it for moderation, go to the CMS homepage and use one of the moderation actions (e.g. approve with comment) -> should execute the action or open an overlay.

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**: Firefox 106 (Linux Mint)
    -   [ ] **Please list which assistive technologies [^3] you tested**:

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
