### PR TITLE
Fix an issue with incorrect Tag field styling in WHCM

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -32,6 +32,7 @@ Changelog
  * Fix: Comments notice background overflows its container (Yekasumah)
  * Fix: Ensure links within help blocks meet colour contrast guidelines for accessibility (Theresa Okoro)
  * Fix: Ensure the skip link (used for keyboard control) meets colour contrast guidelines for accessibility (Dauda Yusuf)
+ * Fix: Ensure tag fields correctly show in both dark and light Windows high-contrast modes (Albina Starykova)
 
 
 4.1.1 (xx.xx.xxxx) - IN DEVELOPMENT

--- a/client/scss/components/forms/_tagit.scss
+++ b/client/scss/components/forms/_tagit.scss
@@ -7,17 +7,17 @@
 }
 
 @media (forced-colors: $media-forced-colours) {
-  .tagit,
-  .tagit .tagit-choice,
-  .tagit .tagit-new .ui-widget-content {
-    box-shadow: inset 1000px 0 0 0 $color-black;
-    color: $color-white;
-    forced-color-adjust: none;
+  .tagit {
+    .tag {
+      border: 1px solid;
+
+      &::before {
+        background: $system-color-button-text;
+      }
+    }
   }
 
-  .tagit span.tagit-label:before,
-  .tagit span.tagit-label {
-    color: $color-black;
-    forced-color-adjust: none;
+  .tagit-close .ui-icon.ui-icon-close:before {
+    background: $system-color-button-text;
   }
 }

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -43,6 +43,7 @@ depth: 1
  * Comments notice background overflows its container (Yekasumah)
  * Ensure links within help blocks meet colour contrast guidelines for accessibility (Theresa Okoro)
  * Ensure the skip link (used for keyboard control) meets colour contrast guidelines for accessibility (Dauda Yusuf)
+ * Ensure tag fields correctly show in both dark and light Windows high-contrast modes (Albina Starykova)
 
 ## Upgrade considerations
 


### PR DESCRIPTION
Fixes #9529 

I replaced `forced-color-adjust: none` and custom color styles with system colors for Tag field and tags in it to achieve a contrast ratio 21:1 instead of 4.39:1, as well as overall style consistency.

| Before  | After |
| ------------- | ------------- |
| <img width="339" alt="image" src="https://user-images.githubusercontent.com/51043550/198534636-5b2ea732-f9f1-48b4-9528-4559a8f1c284.png">  | <img width="338" alt="image" src="https://user-images.githubusercontent.com/51043550/198534784-1b95e2a7-f33e-4347-a0bb-a0d50d8b0738.png"> |
| <img width="339" alt="image" src="https://user-images.githubusercontent.com/51043550/198534703-54cd6731-a11b-4597-bfe6-6a329b4f9447.png">  | <img width="343" alt="image" src="https://user-images.githubusercontent.com/51043550/198534847-ad4e7b64-3d32-4688-be31-1de7b671aeed.png">  |
| 4.39:1  | 21:1  |
