### PR TITLE
Issue#3589 check for raw in signal handlers 

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -33,6 +33,7 @@ Changelog
  * Fix: Allow both horizontal and vertical manual resizing of TextFields (Anisha Singh)
  * Fix: Move DateField, DateTimeField, TimeField comment buttons to be right next to the fields (Theresa Okoro)
  * Fix: Support text resizing in workflow steps cards (Ivy Jeptoo)
+ * Fix: Ignore images added via fixtures when using `WAGTAILIMAGES_FEATURE_DETECTION_ENABLED` to avoid errors for images that do not exist (Aman Pandey)
  * Docs: Add custom permissions section to permissions documentation page (Dan Hayden)
  * Docs: Add documentation for how to get started with contributing translations for the Wagtail admin (Ogunbanjo Oluwadamilare)
  * Docs: Officially recommend `fnm` over `nvm` in development documentation (LB (Ben) Johnston)

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -45,6 +45,7 @@ depth: 1
  * Allow both horizontal and vertical manual resizing of TextFields (Anisha Singh)
  * Move DateField, DateTimeField, TimeField comment buttons to be right next to the fields (Theresa Okoro)
  * Support text resizing in workflow steps cards (Ivy Jeptoo)
+ * Ignore images added via fixtures when using `WAGTAILIMAGES_FEATURE_DETECTION_ENABLED` to avoid errors for images that do not exist (Aman Pandey)
 
 ### Documentation
 

--- a/wagtail/images/signal_handlers.py
+++ b/wagtail/images/signal_handlers.py
@@ -16,10 +16,12 @@ def post_delete_purge_rendition_cache(instance, **kwargs):
 
 def pre_save_image_feature_detection(instance, **kwargs):
     if getattr(settings, "WAGTAILIMAGES_FEATURE_DETECTION_ENABLED", False):
-        # Make sure the image doesn't already have a focal point
-        if not instance.has_focal_point():
-            # Set the focal point
-            instance.set_focal_point(instance.get_suggested_focal_point())
+        # Make sure the image is not from a fixture
+        if kwargs["raw"] is False:
+            # Make sure the image doesn't already have a focal point
+            if not instance.has_focal_point():
+                # Set the focal point
+                instance.set_focal_point(instance.get_suggested_focal_point())
 
 
 def register_signal_handlers():

--- a/wagtail/images/tests/test_signal_handlers.py
+++ b/wagtail/images/tests/test_signal_handlers.py
@@ -1,9 +1,11 @@
 from django.db import transaction
-from django.test import TransactionTestCase, override_settings
+from django.test import TestCase, TransactionTestCase, override_settings
 
 from wagtail.images import get_image_model, signal_handlers
 from wagtail.images.tests.utils import get_test_image_file
 from wagtail.models import Collection
+
+from .utils import Image
 
 
 class TestFilesDeletedForDefaultModels(TransactionTestCase):
@@ -80,3 +82,16 @@ class TestFilesDeletedForCustomModels(TestFilesDeletedForDefaultModels):
         self.assertEqual(
             "%s.%s" % (cls._meta.app_label, cls.__name__), "tests.CustomImage"
         )
+
+
+@override_settings(WAGTAILIMAGES_FEATURE_DETECTION_ENABLED=True)
+class TestRawForPreSaveImageFeatureDetection(TestCase):
+    fixtures = ["test.json"]
+
+    # just to test the file is from a fixture doesn't actually exists.
+    # raw check in pre_save_image_feature_detection skips on the provided condition of this test
+    # hence avoiding an error
+
+    def test_image_does_not_exist(self):
+        bad_image = Image.objects.get(pk=1)
+        self.assertFalse(bad_image.file.storage.exists(bad_image.file.name))


### PR DESCRIPTION
<!--
Thanks for contributing to Wagtail! 🎉

Before submitting, please review the [contributor guidelines](https://docs.wagtail.org/en/latest/contributing/index.html).
-->

_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [ ] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [ ] **Please list the exact browser and operating system versions you tested**:
    -   [ ] **Please list which assistive technologies [^3] you tested**:
-   [ ] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)

for issue https://github.com/wagtail/wagtail/issues/3589

okay okay so initially there's only this problem whenever  we try to load data with fixtures and if  WAGTAILIMAGES_FEATURE_DETECTION_ENABLED=True , pre_save_image_feature_detection signal handler used to throw an error
if the WAGTAILIMAGES_FEATURE_DETECTION_ENABLED=True and image file described in fixture doesn't exists 
![image](https://user-images.githubusercontent.com/74553951/198544625-19db9148-b1a8-444f-a9b0-29a76a872417.png)
after the check pre_save signal now check for raw==true for fixtures .
![image](https://user-images.githubusercontent.com/74553951/198545456-81cfc25f-0502-453e-aa5a-75ad69e85ec3.png)


basically i wrote the test which creates the condition, where  WAGTAILIMAGES_FEATURE_DETECTION_ENABLED is True and source image described via fixture doesn't exist,  initially it fails when pre_save_image_feature_detection triggers because there wasn't any check for raw which indicated loading from fixtures, and in that case when images is not found it fails to load the fixture and throws an error, added check for "raw is false" , makes the signal runs only if raw is false when not from fixture, and if its true (in this case pre_save_image_feature_detection shouldn't do anything as that no error occurs)
signal doesn't fail, and still loads the fixture as demanded  by the issue 

