### PR TITLE
Fix JS string extraction for ngettext

### DIFF
--- a/client/extract-translatable-strings.js
+++ b/client/extract-translatable-strings.js
@@ -18,8 +18,8 @@ extractor
     }),
     JsExtractors.callExpression('ngettext', {
       arguments: {
-        text: 1,
-        textPlural: 2,
+        text: 0,
+        textPlural: 1,
         context: 3,
       },
     }),


### PR DESCRIPTION
The definition for ngettext in extract-translatable-strings had incorrect argument positions, and as a result strings translated with ngettext were missed from the .po file.
