### PR TITLE
Remove unneeded utility classes

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -18,6 +18,7 @@ Changelog
  * Clean up Prettier & Eslint usage for search promotions formset JS file (LB (Ben Johnston))
  * Ensure that translation file generation ignores JavaScript unit tests and clean up unit tests for Django gettext utils (LB (Ben Johnston))
  * Migrated `initButtonSelects` from core.js to own TypesScript file and add unit tests (Loveth Omokaro)
+ * Clean up some unused utility classes and migrate `unlist` to Tailwind utility class `w-list-none` (Loveth Omokaro)
  * Fix: Make sure workflow timeline icons are visible in high-contrast mode (Loveth Omokaro)
  * Fix: Ensure authentication forms (login, password reset) have a visible border in Windows high-contrast mode (Loveth Omokaro)
  * Fix: Ensure visual consistency between buttons and links as buttons in Windows high-contrast mode (Albina Starykova)

--- a/client/scss/overrides/_utilities.legacy.scss
+++ b/client/scss/overrides/_utilities.legacy.scss
@@ -21,10 +21,6 @@
   .divider-before {
     border-inline-start: 1px solid $color-grey-4;
   }
-
-  .divider-after {
-    border-inline-end: 1px solid $color-grey-4;
-  }
 }
 
 body.reordering {
@@ -47,10 +43,6 @@ body.reordering {
 
 .block {
   display: block;
-}
-
-.unlist {
-  @include unlist();
 }
 
 // utility class to allow things to be scrollable if their contents can't wrap more nicely

--- a/client/src/tokens/typography.js
+++ b/client/src/tokens/typography.js
@@ -108,6 +108,10 @@ const lineHeight = {
   normal: '1.5',
 };
 
+const listStyleType = {
+  none: 'none',
+};
+
 const headingBaseStyles = {
   fontWeight: 'fontWeight.bold',
   color: 'colors.primary.DEFAULT',
@@ -181,5 +185,6 @@ module.exports = {
   fontWeight,
   letterSpacing,
   lineHeight,
+  listStyleType,
   typeScale,
 };

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -11,6 +11,7 @@ const {
   fontWeight,
   letterSpacing,
   lineHeight,
+  listStyleType,
   typeScale,
 } = require('./src/tokens/typography');
 const { breakpoints } = require('./src/tokens/breakpoints');
@@ -76,6 +77,7 @@ module.exports = {
     fontSize,
     fontWeight,
     lineHeight,
+    listStyleType,
     letterSpacing,
     borderRadius,
     borderWidth,

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -27,6 +27,7 @@ depth: 1
  * Add documentation for [`register_user_listing_buttons`](register_user_listing_buttons) hook (LB (Ben Johnston))
  * Ensure that translation file generation ignores JavaScript unit tests and clean up unit tests for Django gettext utils (LB (Ben Johnston))
  * Migrated `initButtonSelects` from core.js to own TypesScript file and add unit tests (Loveth Omokaro)
+ * Clean up some unused utility classes and migrate `unlist` to Tailwind utility class `w-list-none` (Loveth Omokaro)
 
 ### Bug fixes
 

--- a/wagtail/contrib/styleguide/templates/wagtailstyleguide/base.html
+++ b/wagtail/contrib/styleguide/templates/wagtailstyleguide/base.html
@@ -19,7 +19,7 @@
     <div class="nice-padding">
         <h2>Contents</h2>
         <nav>
-            <ul class="unlist">
+            <ul class="w-pl-0">
                 <li><a href="#typography">Typography</a></li>
                 <li><a href="#help">Help text</a></li>
                 <li><a href="#listings">Listings</a></li>
@@ -594,7 +594,7 @@
                 }
             </style>
 
-            <ul class="unlist">
+            <ul class="w-list-none">
                 <li>{% icon 'wagtail-icon' %} wagtail</li>
                 <li>{% icon 'wagtail-inverse' %} wagtail-inverse</li>
                 <li>{% icon 'cogs' %} cogs</li>


### PR DESCRIPTION
First PR for issue wagtail/wagtail#8947

**Summary**

I removed three classes from the _utilities.legacy.scss file.
- The first is the `divider-before` class which wasn't used anywhere in the codebase
- The second is the `divider-after` class and it was used in 3 places. I removed it from those files/places because it wasn't really doing much and had no effect.

***Found in edit image admin panel***

<table>
  <tr>
    <td>Before</td>
     <td>After</td>
  </tr>
  <tr>
    <td valign="top"><img alt="image-before-removing-divder-after" src="https://user-images.githubusercontent.com/38161296/198559829-3a2544a4-b0bf-45a7-9daa-2195b1cd9348.PNG"></td>
    <td valign="top"><img alt="image-after-removing-divider-after" src="https://user-images.githubusercontent.com/38161296/198559872-8437e86f-bcaf-4358-a46a-a834a6986e97.PNG">
  </tr>
 </table>

***Found in edit snippets admin panel***

<table>
  <tr>
    <td>Before</td>
     <td>After</td>
  </tr>
  <tr>
    <td valign="top"><img alt="snippets-before-removing-divider-after" src="https://user-images.githubusercontent.com/38161296/198561913-8bb050a0-c575-4df8-8495-4fa90d3c5bed.PNG"></td>
    <td valign="top"><img alt="snippets-after-removing-divider-afte" src="https://user-images.githubusercontent.com/38161296/198562021-16b9c19d-b9c7-4bb4-8d5c-1eef575d5dd3.PNG">
  </tr>
 </table>

***Found in edit document admin panel***

<table>
  <tr>
    <td>Before</td>
     <td>After</td>
  </tr>
  <tr>
    <td valign="top"><img alt="document-before-removing-divider-after" src="https://user-images.githubusercontent.com/38161296/198562535-eefab6b8-ac8b-4bc5-9350-bdf9dedc6bcb.PNG"></td>
    <td valign="top"><img alt="document-after-removing-divider-after" src="https://user-images.githubusercontent.com/38161296/198562674-c3433638-b674-4e8a-a6de-31c8cfbf4728.PNG">
  </tr>
 </table>

- The third   was the `unlist` class and it was used in 2 places the styleguide. 
    First of all, I removed it from the first instance but the `ul` element then inherented a `padding-inline-start: 40px` . So I had to used a tailwind class of `w-pl-0` to offest that.

***First instance in styleguide***

<table>
  <tr>
    <td>Before removing unlist class</td>
     <td>After removing unlist</td>
     <td>After adding tailwind class</td>
  </tr>
  <tr>
    <td valign="top"><img alt="styleguid-before-removing-unlist1" src="https://user-images.githubusercontent.com/38161296/198563485-8ff2ba7c-5676-47d2-b660-be2d97c3425d.PNG"></td>
    <td valign="top"><img alt="after removing unlist" src="https://user-images.githubusercontent.com/38161296/198564242-d8e356ae-643b-4720-9772-3c7c3bc3c68a.png"></td>
<td valign="top"><img alt="after adding tailwind class" src="https://user-images.githubusercontent.com/38161296/198677718-4c757444-bd83-4a89-b166-5f6fab4eeeb1.PNG" >
  </tr>
</table>

Then lastly, it was also present in the `ul` element for the  icons section. When I removed it from there, the icons list had the default style so i had to use tailwind class of `list-none` which wasn't present in the codebase. I had to add it to the tailwind.config.js file and also the typography.js file.

***Second instance in styleguide***

<table>
  <tr>
    <td>Before  removing unlist</td>
     <td>After removing unlist</td>
     <td>After adding created tailwind class</td>
  </tr>
  <tr>
    <td valign="top"><img alt="styleguid-before" src="https://user-images.githubusercontent.com/38161296/198566079-3c9765cc-7ef6-4a20-8a7b-e3d1deecc23f.PNG"></td>
    <td valign="top"><img alt="after removing unlist" src="https://user-images.githubusercontent.com/38161296/198564242-d8e356ae-643b-4720-9772-3c7c3bc3c68a.png"><td>
<td valign="top"><img alt="after adding tailwind class" src="https://user-images.githubusercontent.com/38161296/198566754-4eec1b96-ecf9-4d7e-b11e-fe9481fe350a.PNG" >
  </tr>
 </table>
