### PR TITLE
Re-add editor guide link

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -43,5 +43,6 @@ Index
    extending/index
    reference/index
    support
+   editor_manual/index
    contributing/index
    releases/index


### PR DESCRIPTION
Following feedback from @Scotchester. Follow-up from #9479.

This re-adds the link to the placeholder page, so people can still locate the guide in our navigation. We will need to cherry-pick this to `stable/4.1.x` after merge.