### PR TITLE
resolved skip link contrast requirements

### DIFF
--- a/client/scss/components/_skiplink.scss
+++ b/client/scss/components/_skiplink.scss
@@ -11,6 +11,7 @@
 
   &.button {
     background: theme('colors.positive.100');
+    color: theme('colors.black.DEFAULT');
     border: theme('colors.positive.100');
   }
 }


### PR DESCRIPTION
Issue Summary
The skip to content link, which is only available when using the keyboard to navigate the page, does not meet the contrast guidelines.

this image shows the initial button button that failed to meet up with requirements

![Screenshot (29)](https://user-images.githubusercontent.com/104570312/198836006-1ffac0d1-82b9-4c56-bbdb-1273a0bcfd2e.png)


this is the changes made prior to the issue above

![Screenshot (31)](https://user-images.githubusercontent.com/104570312/198836090-e276daae-09b2-4082-8ac8-3ca48529d846.png)

and this is the final result after making the changes
![Screenshot (30)](https://user-images.githubusercontent.com/104570312/198836156-baafc3ca-3472-4835-9708-2a1b26561f35.png)
