### PR TITLE
Skiplink

### DIFF
--- a/client/scss/components/_skiplink.scss
+++ b/client/scss/components/_skiplink.scss
@@ -10,8 +10,9 @@
   }
 
   &.button {
-    background: theme('colors.positive.100');
-    color: theme('colors.black.DEFAULT');
+    background: theme('colors.secondary.DEFAULT');
     border: theme('colors.positive.100');
+   
+    
   }
 }

--- a/client/scss/components/_skiplink.scss
+++ b/client/scss/components/_skiplink.scss
@@ -11,6 +11,7 @@
 
   &.button {
     background: theme('colors.positive.100');
+    color: theme('colors.black.DEFAULT');
     border: theme('colors.positive.100');
   }
 }

--- a/client/src/tokens/colors.js
+++ b/client/src/tokens/colors.js
@@ -137,8 +137,8 @@ const colors = {
       contrastText: 'white',
     },
     DEFAULT: {
-      hex: '#007D7E',
-      hsl: 'hsl(180 100% 25%)',
+      hex: '#17009b',
+      hsl: 'hsl(249deg 100% 30%)',
       bgUtility: 'w-bg-secondary',
       textUtility: 'w-text-secondary',
       cssVariable: '--w-color-secondary',


### PR DESCRIPTION
The skip to content link, which is only available when using the keyboard to navigate the page, does not meet the contrast guidelines.

in order to resolve this issue,  picked the colors that meets the contrast guide line

this is the initial out put which did not meet the contrast requirements

![Screenshot (37)](https://user-images.githubusercontent.com/104570312/198888414-d47e1de9-8222-4bdb-ab64-84ba102ab810.png)

![Uploading Screenshot (29).png…]()


so, in order to meet the requirements, i went to the client/src/token/color.js and made changes to the code 

![Screenshot (38)](https://user-images.githubusercontent.com/104570312/198888528-b1702ad7-32f0-4e6b-b30e-47e829bce138.png)
 
then this is the new result

![Screenshot (39)](https://user-images.githubusercontent.com/104570312/198888570-70bb56d8-986c-4bb7-8b30-7f0d534a200d.png)

![Screenshot (32)](https://user-images.githubusercontent.com/104570312/198888582-ea81bb33-6ca4-4815-8965-84d22c0e57a9.png)
