### PR TITLE
Move DateField, DateTimeField, TimeField comment buttons to be right next to the fields. Fix #9543

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -30,6 +30,7 @@ Changelog
  * Fix: Use consistent heading styles on top-level fields in the page editor (Sage Abdullah)
  * Fix: Allow button labels to wrap onto two lines in dropdown buttons (Coen van der Kamp)
  * Fix: Allow both horizontal and vertical manual resizing of TextFields (Anisha Singh)
+ * Fix: Move DateField, DateTimeField, TimeField comment buttons to be right next to the fields (Theresa Okoro)
  * Docs: Add custom permissions section to permissions documentation page (Dan Hayden)
  * Docs: Add documentation for how to get started with contributing translations for the Wagtail admin (Ogunbanjo Oluwadamilare)
  * Docs: Officially recommend `fnm` over `nvm` in development documentation (LB (Ben) Johnston)
@@ -67,6 +68,7 @@ Changelog
  * Fix: Use consistent heading styles on top-level fields in the page editor (Sage Abdullah)
  * Fix: Allow button labels to wrap onto two lines in dropdown buttons (Coen van der Kamp)
  * Fix: Allow both horizontal and vertical manual resizing of TextFields (Anisha Singh)
+ * Fix: Move DateField, DateTimeField, TimeField comment buttons to be right next to the fields (Theresa Okoro)
 
 
 4.1.1 (11.11.2022)

--- a/client/scss/components/forms/_field-comment-control.scss
+++ b/client/scss/components/forms/_field-comment-control.scss
@@ -47,6 +47,14 @@
     transform: translateY(0);
     top: 0.3125rem;
   }
+
+  .w-field--date_field &,
+  .w-field--date_time_field &,
+  .w-field--time_field & {
+    position: relative;
+    transform: translateY(0);
+    top: 0.3125rem;
+  }
 }
 
 .w-field__comment-button--add {

--- a/docs/releases/4.1.2.md
+++ b/docs/releases/4.1.2.md
@@ -18,3 +18,4 @@ depth: 1
  * Use consistent heading styles on top-level fields in the page editor (Sage Abdullah)
  * Allow button labels to wrap onto two lines in dropdown buttons (Coen van der Kamp)
  * Allow both horizontal and vertical manual resizing of TextFields (Anisha Singh)
+ * Move DateField, DateTimeField, TimeField comment buttons to be right next to the fields (Theresa Okoro)

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -42,6 +42,7 @@ depth: 1
  * Use consistent heading styles on top-level fields in the page editor (Sage Abdullah)
  * Allow button labels to wrap onto two lines in dropdown buttons (Coen van der Kamp)
  * Allow both horizontal and vertical manual resizing of TextFields (Anisha Singh)
+ * Move DateField, DateTimeField, TimeField comment buttons to be right next to the fields (Theresa Okoro)
 
 ### Documentation
 


### PR DESCRIPTION
PR for issue https://github.com/wagtail/wagtail/issues/9543

ISSUE
There was a large space difference between the datefield input and the comment button

CAUSE OF ISSUE
All input fields had a `width: 100%` but the datefield wield was adjusted to `width: auto` so this caused the space between the datefield and the comment button as seen in the screenshot below

SOLUTION
Added the below code to change the position of the comment button

`.w-field--date_field,
.w-field--date_time_field,
.w-field--time_field {
  .w-field__comment-button {
    position: relative;
  }
}`

RESULT

BEFORE
![wagcommentissuereproduced](https://user-images.githubusercontent.com/62052443/198981943-f123645f-088d-4867-8c17-34d4f6bbd701.PNG)

AFTER
![wagcommentissueresolved](https://user-images.githubusercontent.com/62052443/198983550-4adbbdf7-b88b-4607-8acc-a2d5bb55d3af.PNG)
