### PR TITLE
Fix legacy dropdown buttons using a different size from toggle. Fix #9476

### DIFF
--- a/client/scss/components/_dropdown.legacy.scss
+++ b/client/scss/components/_dropdown.legacy.scss
@@ -111,7 +111,6 @@
     .button,
     button {
       border-radius: 0;
-      font-size: 0.95em;
       -webkit-font-smoothing: auto;
     }
 


### PR DESCRIPTION
Fixes #9476, replacing #9500. This font-size override is undesirable – we’d rather have buttons within dropdowns displayed the same size as the dropdown’s button face. This got broken in #9104 where we forgot to update / remove this undesirable override to font-size.

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
-   ~~[ ] For Python changes: Have you added tests to cover the new/fixed behaviour?~~
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [x] **Please list the exact browser and operating system versions you tested**: Chrome 106, macOS 12.5.1
    -   [x] **Please list which assistive technologies [^3] you tested**: None
-   ~~[ ] For new features: Has the documentation been updated accordingly?~~

---

To test this, go to a page with a legacy dropdown with two-tone icon buttons such as `http://localhost:8000/admin/reports/locked/`. The font-size, height, and icon width of the buttons should be identical. Screenshot:

![reports-buttons-font-size](https://user-images.githubusercontent.com/877585/199012428-b7f1ad11-4c8f-49a7-9dc9-80842c06b855.png)
