### PR TITLE
Minimap design review fixes

### DIFF
--- a/client/src/components/Minimap/Minimap.scss
+++ b/client/src/components/Minimap/Minimap.scss
@@ -17,17 +17,22 @@ $minimap-z-index: calc(theme('zIndex.header') - 20);
   flex-direction: column;
   height: calc(100vh - 100%);
   z-index: $minimap-z-index;
-  width: $minimap-collapsed-width-mobile;
+  width: $minimap-width;
+  transform: translateX(calc(100% - $minimap-collapsed-width-mobile));
 
   @include media-breakpoint-up(sm) {
     padding-inline-start: $minimap-overflow;
-    width: calc($minimap-collapsed-width + $minimap-overflow);
+    transform: translateX(
+      calc(100% - $minimap-collapsed-width - $minimap-overflow)
+    );
   }
 
   &--expanded {
-    width: $minimap-width;
+    transform: translateX(0);
     // Take up the whole height so overlap with the page looks better.
     height: calc(100vh - $minimap-top-offset);
+    // Only transition when opening, so the closing animation doesn’t interfere with "hover to open".
+    transition: transform 0.3s ease;
   }
 
   > * {

--- a/client/src/components/Minimap/Minimap.scss
+++ b/client/src/components/Minimap/Minimap.scss
@@ -55,7 +55,19 @@ $minimap-z-index: calc(theme('zIndex.header') - 20);
       pointer-events: none;
     }
 
-    &:focus {
+    *:focus {
+      opacity: 1;
+      pointer-events: auto;
+    }
+
+    // Ensure the toggle button is only visible when it has **focus-visible**.
+    // With fallback focus styles for browsers that lack focus-visible support.
+    *:focus:not(:focus-visible) {
+      opacity: 0;
+      pointer-events: none;
+    }
+
+    &:focus-visible {
       opacity: 1;
       pointer-events: auto;
     }

--- a/client/src/components/Minimap/Minimap.tsx
+++ b/client/src/components/Minimap/Minimap.tsx
@@ -192,9 +192,7 @@ const Minimap: React.FunctionComponent<MinimapProps> = ({
   }, [anchorsContainer, setPanelsExpanded]);
 
   return (
-    // Keyboard support is implemented with the toggle button.
-    // eslint-disable-next-line jsx-a11y/mouse-events-have-key-events
-    <div onMouseOver={onMouseOver} onMouseOut={onMouseOut}>
+    <div>
       <CollapseAll
         expanded={panelsExpanded}
         onClick={() => {
@@ -204,7 +202,13 @@ const Minimap: React.FunctionComponent<MinimapProps> = ({
         floating
         insideMinimap={expanded}
       />
-      <div className={`w-minimap ${expanded ? 'w-minimap--expanded' : ''}`}>
+      {/* Keyboard support is implemented with the toggle button. */}
+      {/* eslint-disable-next-line jsx-a11y/mouse-events-have-key-events */}
+      <div
+        className={`w-minimap ${expanded ? 'w-minimap--expanded' : ''}`}
+        onMouseOver={onMouseOver}
+        onMouseOut={onMouseOut}
+      >
         <div className="w-minimap__header">
           <button
             type="button"

--- a/client/src/components/Minimap/Minimap.tsx
+++ b/client/src/components/Minimap/Minimap.tsx
@@ -45,7 +45,8 @@ const updateScrollPosition = (list: HTMLOListElement) => {
     'a[aria-current="true"]',
   );
 
-  if (activeLinks.length === 0) {
+  // Don’t update the scroll position if there are no links, or all links are visible.
+  if (activeLinks.length === 0 || list.scrollHeight === list.clientHeight) {
     return;
   }
 


### PR DESCRIPTION
Addresses minimap design review feedback from @benenright. This contains four independent changes:

- The minimap toggle button shouldn’t be visible for mouse users when the minimap is collapsed (switch reveal from `:focus` to `:focus-visible`, with fallback for browsers lacking support)
- "hover to reveal" should ignore the "collapse all" button. The button is still visually displayed within but will be first in the tab order, and hovering it no longer expands the minimap.
- The minimap animates when opening. It doesn’t animate when closing, as this would clash with the "hover to reveal" (could probably be added with a JS `transitionend` event or similar, but doesn’t feel worthwhile.
- We no longer update the scrolling position of the list when the list isn’t scrollable. This avoids unnecessary rendering of the scrollbar.

---

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
-   ~~[ ] For Python changes: Have you added tests to cover the new/fixed behaviour?~~
-   [ ] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [x] **Please list the exact browser and operating system versions you tested**: Chrome 106, Safari 15.6, Firefox 104 on macOS 12.5.1
    -   [x] **Please list which assistive technologies [^3] you tested**: Keyboard
-   ~~[ ] For new features: Has the documentation been updated accordingly?~~

---

- When closing the minimap by clicking the "toggle" button, the button should disappear
- When closing the minimap by clicking the "toggle" button, there should be no animation getting in the way of closing.
- When closing the minimap by hitting Enter while focusing the toggle button, the button should stay visible
- Hovering over collapse all should no longer affect the minimap.