### PR TITLE
resolved the skiplink contrast issues to meet with the required contr…

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -29,6 +29,7 @@ Changelog
  * Fix: Ensure logo shows correctly on log in page in Windows high-contrast mode (Loveth Omokaro)
  * Fix: Comments notice background overflows its container (Yekasumah)
  * Fix: Ensure links within help blocks meet colour contrast guidelines for accessibility (Theresa Okoro)
+ * Fix: Ensure the skip link (used for keyboard control) meets colour contrast guidelines for accessibility (Dauda Yusuf)
 
 
 4.1.1 (xx.xx.xxxx) - IN DEVELOPMENT

--- a/client/scss/components/_skiplink.scss
+++ b/client/scss/components/_skiplink.scss
@@ -10,7 +10,7 @@
   }
 
   &.button {
-    background: theme('colors.positive.100');
-    border: theme('colors.positive.100');
+    background: theme('colors.secondary.DEFAULT');
+    border: theme('colors.secondary.DEFAULT');
   }
 }

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -40,6 +40,7 @@ depth: 1
  * Ensure logo shows correctly on log in page in Windows high-contrast mode (Loveth Omokaro)
  * Comments notice background overflows its container (Yekasumah)
  * Ensure links within help blocks meet colour contrast guidelines for accessibility (Theresa Okoro)
+ * Ensure the skip link (used for keyboard control) meets colour contrast guidelines for accessibility (Dauda Yusuf)
 
 ## Upgrade considerations
 


### PR DESCRIPTION
The skip to content link, which is only available when using the keyboard to navigate the page, does not meet the contrast guidelines.

to meet the contrast requirements, I changed the background to use the new secondary color background: theme('colors.secondary.DEFAULT'); 

Here is the link to the issue : https://github.com/wagtail/wagtail/issues/9515

here is the initial code and its result

![Screenshot (41)](https://user-images.githubusercontent.com/104570312/199194808-c12753a7-0230-480f-967f-064bfbc8815c.png)

![inial](https://user-images.githubusercontent.com/104570312/199194873-449950ce-25e8-4ecf-ad82-3babd4f597b2.png)

And here is the final result

![Screenshot (42)](https://user-images.githubusercontent.com/104570312/199194990-eb239ba2-e996-487f-bb8b-bb54fb401d6d.png)


![Screenshot (40)](https://user-images.githubusercontent.com/104570312/199195088-3d6dfe68-ee98-4576-9c1d-ea58138d33d1.png)

