### PR TITLE
Fix disabled style on StreamField add button

### DIFF
--- a/client/src/components/StreamField/scss/components/c-sf-add-button.scss
+++ b/client/src/components/StreamField/scss/components/c-sf-add-button.scss
@@ -51,5 +51,13 @@
     @media (forced-colors: active) {
       color: GrayText;
     }
+
+    @media (hover: hover) {
+      opacity: 0;
+
+      .w-panel--nested:is(:hover, :focus-within) & {
+        opacity: 0.2;
+      }
+    }
   }
 }


### PR DESCRIPTION
Fixes #9512

An `opacity: 0.2` style is defined for the disabled button state, but the `opacity: 1` hover style takes precedence over it. As a result, the only time it kicks in - on media with hover support - is when the StreamField does NOT have hover / focus, which would ordinarily be the time when the button is hidden entirely.

Fix this by adding hover states to the `&[disabled]` case, to match the order of precedence for the normal button state.
