### PR TITLE
Fix #1267 Caching OEmbed markup prevents markup changes for existing embeds

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -26,6 +26,7 @@ Changelog
  * Remove unnecessary box-sizing: border-box declarations in SCSS (Albina Starykova)
  * Add full support for secondary buttons with icons in the Wagtail design system - `button bicolor button--icon button-secondary` including the `button-small` variant (Seremba Patrick)
  * Migrated `initTooltips` to TypeScript add JSDoc and unit tests (Fatuma Abdullahi)
+ * Add `purge_embeds` management command to delete all the cached embed objects in the database (Aman Pandey)
  * Fix: Make sure workflow timeline icons are visible in high-contrast mode (Loveth Omokaro)
  * Fix: Ensure authentication forms (login, password reset) have a visible border in Windows high-contrast mode (Loveth Omokaro)
  * Fix: Ensure visual consistency between buttons and links as buttons in Windows high-contrast mode (Albina Starykova)

--- a/docs/advanced_topics/embeds.md
+++ b/docs/advanced_topics/embeds.md
@@ -405,3 +405,5 @@ repopulate the records that are being used on the site.
 You may want to do this if you've changed from oEmbed to Embedly or vice-versa
 as the embed code they generate may be slightly different and lead to
 inconsistency on your site.
+
+In general whenever you make changes to embed settings you are recommended to clear out Embed objects using [`purge_embeds` command](purge_embeds).

--- a/docs/reference/management_commands.md
+++ b/docs/reference/management_commands.md
@@ -57,6 +57,16 @@ This command deletes old page revisions which are not in moderation, live, appro
 revision for a page. If the `days` argument is supplied, only revisions older than the specified number of
 days will be deleted.
 
+(purge_embeds)=
+
+## purge_embeds
+
+```sh
+manage.py purge_embeds
+```
+
+This command deletes all the cached embed objects from the database. It is recommended to run this command after changes are made to any embed settings so that subsequent embed usage does not from the database cache.
+
 (update_index)=
 
 ## update_index

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -35,6 +35,7 @@ depth: 1
  * Remove unnecessary box-sizing: border-box declarations in SCSS (Albina Starykova)
  * Add full support for secondary buttons with icons in the Wagtail design system - `button bicolor button--icon button-secondary` including the `button-small` variant (Seremba Patrick)
  * Migrated `initTooltips` to TypeScript add JSDoc and unit tests (Fatuma Abdullahi)
+ * Add [`purge_embeds`](purge_embeds) management command to delete all the cached embed objects in the database (Aman Pandey)
 
 ### Bug fixes
 

--- a/wagtail/management/commands/purge_embeds.py
+++ b/wagtail/management/commands/purge_embeds.py
@@ -1,0 +1,21 @@
+from django.core.management.base import BaseCommand
+
+from wagtail.embeds.models import Embed
+
+
+class Command(BaseCommand):
+    help = "Deletes all of the Embed model objects"
+
+    def handle(self, *args, **options):
+
+        embeds = Embed.objects.all()
+
+        deleted_embeds_count = embeds.delete()[0]
+        if deleted_embeds_count:
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"Successfully deleted {deleted_embeds_count} embeds"
+                )
+            )
+        else:
+            self.stdout.write("Successfully deleted 0 embeds")


### PR DESCRIPTION
For issue #1267 [Caching OEmbed markup prevents markup changes for existing embeds ](https://github.com/wagtail/wagtail/issues/1267) 

**Issuse  : ** whenever you make a change in settings to make a new configuration for embeds, for eg changing 
``` WAGTAILEMBEDS_FINDERS ```  changed don't usually take place even after making the changes.

**Reason : **  whenever wagtail makes a call for embed code, it save the code in an Embed model to cache the result, hence 
changes made to the embed settings doesn't take effect as  embed code is used from cached embed objects so they need to be refreshed .

**Proposed solution / Fix  : **  a management command  ``` manage.py  purge_embeds ```  that  deletes all the chached Embed objects from db. 
which is required to be run everytime a change is made in Embed settings.

**After fix : ** 
1.  a simple embeded video with default settings 
``` 
WAGTAILEMBEDS_FINDERS = [
    {
        'class': 'wagtail.embeds.finders.oembed'
    }
]
```
![image](https://user-images.githubusercontent.com/74553951/199323953-405b807d-aa1e-4cc0-aa9b-8079965ee973.png)

2. changed settings that only embeds one perticular video, so this setting is applied embed video should change to the hard coded video in the settings 
``` 
WAGTAILEMBEDS_FINDERS = [
    {
        'class': 'blog.embeds.CustomEmbedFinder'
    }
]
```
but changes won't take place hence we will run the ``` purge_embeds ```  command  
![image](https://user-images.githubusercontent.com/74553951/199324888-f4fe80f7-4a91-4fae-ac40-66686c6ba355.png)
![image](https://user-images.githubusercontent.com/74553951/199325188-d11899e2-72e7-4b14-a5f5-2e32383e7394.png)

new changes are visible after the command .

test for the command and documents are included.