### PR TITLE
Fix `WagtailImageField.to_python()` with `TemporaryUploadedFile`s

### DIFF
--- a/wagtail/images/fields.py
+++ b/wagtail/images/fields.py
@@ -124,10 +124,11 @@ class WagtailImageField(ImageField):
         if f is None:
             return None
 
-        # We need to get a file object for Pillow. We might have a path or we might
-        # have to read the data into memory.
+        # We need to get a file object for Pillow. When we get a path, we need to open
+        # the file first. And we have to read the data into memory to pass to Willow.
         if hasattr(data, "temporary_file_path"):
-            file = data.temporary_file_path()
+            with open(data.temporary_file_path(), "rb") as fh:
+                file = BytesIO(fh.read())
         else:
             if hasattr(data, "read"):
                 file = BytesIO(data.read())


### PR DESCRIPTION
Fixes #9561

Django's `ImageField` will happily accept a filepath and will handle it with Pillow.
With our change to using Willow, that no longer is the case as Willow's image plugin open expects a file-like (e.g. `BytesIO`) value.

Did not catch this while testing #8974 as `TemporaryUploadedFile` is used when the uploaded file is bigger than the threshold (default 2.5MB)