### PR TITLE
fix:Tippy tooltip arrows render as rectangles in WHCM

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -33,6 +33,7 @@ Changelog
  * Fix: Ensure links within help blocks meet colour contrast guidelines for accessibility (Theresa Okoro)
  * Fix: Ensure the skip link (used for keyboard control) meets colour contrast guidelines for accessibility (Dauda Yusuf)
  * Fix: Ensure tag fields correctly show in both dark and light Windows high-contrast modes (Albina Starykova)
+ * Fix: Ensure new tooltips & tooltip menus have visible borders and tip triangle in Windows high-contrast mode (Juliet Adeboye)
 
 
 4.1.1 (xx.xx.xxxx) - IN DEVELOPMENT

--- a/client/scss/overrides/_vendor.tippy.scss
+++ b/client/scss/overrides/_vendor.tippy.scss
@@ -29,3 +29,17 @@
     @apply w-p-0;
   }
 }
+
+// Media for Windows High Contrast mode
+@media (forced-colors: $media-forced-colours) {
+  .tippy-box[data-theme='dropdown'] {
+    .tippy-content {
+      border: 2px solid transparent;
+    }
+  }
+
+  .tippy-box[data-placement^='bottom'] > .tippy-arrow::before {
+    @apply w-border-b-primary;
+    clip-path: polygon(50% 0, 0 100%, 100% 100%);
+  }
+}

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -44,6 +44,7 @@ depth: 1
  * Ensure links within help blocks meet colour contrast guidelines for accessibility (Theresa Okoro)
  * Ensure the skip link (used for keyboard control) meets colour contrast guidelines for accessibility (Dauda Yusuf)
  * Ensure tag fields correctly show in both dark and light Windows high-contrast modes (Albina Starykova)
+ * Ensure new tooltips & tooltip menus have visible borders and tip triangle in Windows high-contrast mode (Juliet Adeboye)
 
 ## Upgrade considerations
 


### PR DESCRIPTION
<!--
Thanks for contributing to Wagtail! 🎉

Before submitting, please review the [contributor guidelines](https://docs.wagtail.org/en/latest/contributing/index.html).
-->

Fixed [issue #8835](https://github.com/wagtail/wagtail/issues/8835) 
Added a thick border to the tippy tooltip so it is easily identified in WHCM.
Used the clip path to fix the tooltip arrow in W
![Screenshot (454)](https://user-images.githubusercontent.com/62646559/198604731-c0c918ad-ffbd-43f6-9f71-453737f36708.png)
HCM