### PR TITLE
Added style to clearly indicate the 'active' mode

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -34,6 +34,7 @@ Changelog
  * Fix: Ensure the skip link (used for keyboard control) meets colour contrast guidelines for accessibility (Dauda Yusuf)
  * Fix: Ensure tag fields correctly show in both dark and light Windows high-contrast modes (Albina Starykova)
  * Fix: Ensure new tooltips & tooltip menus have visible borders and tip triangle in Windows high-contrast mode (Juliet Adeboye)
+ * Fix: Ensure there is a visual difference of 'active/current link' vs normal links in Windows high-contrast mode (Mohammad Areeb)
 
 
 4.1.1 (xx.xx.xxxx) - IN DEVELOPMENT

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -662,6 +662,7 @@ Contributors
 * Omerzahid Ali
 * Aman Pandey
 * Doug Harris
+* Mohammad Areeb
 
 Translators
 ===========

--- a/client/scss/components/_link.legacy.scss
+++ b/client/scss/components/_link.legacy.scss
@@ -5,6 +5,10 @@
   &:hover {
     color: $color-teal;
   }
+
+  @media (forced-colors: $media-forced-colours) {
+    color: GrayText;
+  }
 }
 
 a.underlined {

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -45,6 +45,7 @@ depth: 1
  * Ensure the skip link (used for keyboard control) meets colour contrast guidelines for accessibility (Dauda Yusuf)
  * Ensure tag fields correctly show in both dark and light Windows high-contrast modes (Albina Starykova)
  * Ensure new tooltips & tooltip menus have visible borders and tip triangle in Windows high-contrast mode (Juliet Adeboye)
+ * Ensure there is a visual difference of 'active/current link' vs normal links in Windows high-contrast mode (Mohammad Areeb)
 
 ## Upgrade considerations
 


### PR DESCRIPTION
Towards: [#9578 ](https://github.com/wagtail/wagtail/issues/9578)

After:
![image](https://user-images.githubusercontent.com/77102111/199544708-b312de65-6003-4dc4-b774-5fac1e99040c.png)

