### PR TITLE
Fix issue with snippets and custom user model related to django-filter

### DIFF
--- a/wagtail/models/audit_log.py
+++ b/wagtail/models/audit_log.py
@@ -160,7 +160,7 @@ class BaseLogEntry(models.Model):
     )
 
     user = models.ForeignKey(
-        settings.AUTH_USER_MODEL,
+        get_user_model(),
         null=True,  # Null if actioned by system
         blank=True,
         on_delete=models.DO_NOTHING,


### PR DESCRIPTION
The introduction of filters on the SnippetHistoryView in Wagtail 4.1 seems to cause issues in cases where:

* A custom User model is being used
* @register_snippet is used in models.py to register a snippet

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/django_filters/utils.py", line 174, in get_field_parts
    opts = field.remote_field.model._meta
AttributeError: 'str' object has no attribute '_meta'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.10/threading.py", line 1016, in _bootstrap_inner
    self.run()
  File "/usr/local/lib/python3.10/threading.py", line 953, in run
    self._target(*self._args, **self._kwargs)
  File "/usr/local/lib/python3.10/site-packages/django/utils/autoreload.py", line 64, in wrapper
    fn(*args, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/django/core/management/commands/runserver.py", line 125, in inner_run
    autoreload.raise_last_exception()
  File "/usr/local/lib/python3.10/site-packages/django/utils/autoreload.py", line 87, in raise_last_exception
    raise _exception[1]
  File "/usr/local/lib/python3.10/site-packages/django/core/management/__init__.py", line 398, in execute
    autoreload.check_errors(django.setup)()
  File "/usr/local/lib/python3.10/site-packages/django/utils/autoreload.py", line 64, in wrapper
    fn(*args, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/django/__init__.py", line 24, in setup
    apps.populate(settings.INSTALLED_APPS)
  File "/usr/local/lib/python3.10/site-packages/django/apps/registry.py", line 116, in populate
    app_config.import_models()
  File "/usr/local/lib/python3.10/site-packages/django/apps/config.py", line 269, in import_models
    self.models_module = import_module(models_module_name)
  File "/usr/local/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/pwd/testerror/home/models.py", line 13, in <module>
    class SnippetA(models.Model):
  File "/usr/local/lib/python3.10/site-packages/wagtail/snippets/models.py", line 47, in register_snippet
    from wagtail.snippets.views.snippets import SnippetViewSet
  File "/usr/local/lib/python3.10/site-packages/wagtail/snippets/views/snippets.py", line 628, in <module>
    class SnippetHistoryReportFilterSet(WagtailFilterSet):
  File "/usr/local/lib/python3.10/site-packages/django_filters/filterset.py", line 62, in __new__
    new_class.base_filters = new_class.get_filters()
  File "/usr/local/lib/python3.10/site-packages/django_filters/filterset.py", line 325, in get_filters
    field = get_model_field(cls._meta.model, field_name)
  File "/usr/local/lib/python3.10/site-packages/django_filters/utils.py", line 144, in get_model_field
    fields = get_field_parts(model, field_name)
  File "/usr/local/lib/python3.10/site-packages/django_filters/utils.py", line 179, in get_field_parts
    raise RuntimeError(
RuntimeError: Unable to resolve relationship `user` for `wagtailcore.ModelLogEntry`. Django is most likely not initialized, and its apps registry not populated. Ensure Django has finished setup before loading `FilterSet`s.```

This change resolves the problem although I expect it is addressing the symptom rather than the cause, so this may warrant some further investigation/untangling of imports.