### PR TITLE
Fixed: Text change Is default site to Is default site?

### DIFF
--- a/wagtail/locale/ar/LC_MESSAGES/django.po
+++ b/wagtail/locale/ar/LC_MESSAGES/django.po
@@ -260,7 +260,7 @@ msgstr "اسم قابل للقراءة من قبل الإنسان للموقع."
 msgid "root page"
 msgstr "الصفحة الرئيسية"
 
-msgid "is default site"
+msgid "Is default site?"
 msgstr "أهذا هو الموقع الافتراضي"
 
 msgid ""

--- a/wagtail/locale/be/LC_MESSAGES/django.po
+++ b/wagtail/locale/be/LC_MESSAGES/django.po
@@ -286,7 +286,7 @@ msgstr "Чалавека-зразумелая імя для сайта."
 msgid "root page"
 msgstr "каранёвая старонка"
 
-msgid "is default site"
+msgid "Is default site?"
 msgstr "сайт па змаўчанні"
 
 msgid ""

--- a/wagtail/locale/ca/LC_MESSAGES/django.po
+++ b/wagtail/locale/ca/LC_MESSAGES/django.po
@@ -387,7 +387,7 @@ msgstr "Nom del lloc llegible per humans"
 msgid "root page"
 msgstr "pàgina arrel"
 
-msgid "is default site"
+msgid "Is default site?"
 msgstr "és el lloc predeterminat"
 
 msgid ""

--- a/wagtail/locale/cs/LC_MESSAGES/django.po
+++ b/wagtail/locale/cs/LC_MESSAGES/django.po
@@ -512,7 +512,7 @@ msgstr "Jméno webu v podobě čitelné člověkem."
 msgid "root page"
 msgstr "výchozí stránka"
 
-msgid "is default site"
+msgid "Is default site?"
 msgstr "je defaultní web"
 
 msgid ""

--- a/wagtail/locale/de/LC_MESSAGES/django.po
+++ b/wagtail/locale/de/LC_MESSAGES/django.po
@@ -566,7 +566,7 @@ msgstr "Für Menschen lesbarer Name für die Website"
 msgid "root page"
 msgstr "Ursprungsseite"
 
-msgid "is default site"
+msgid "Is default site?"
 msgstr "Ist die standardmäßige Website"
 
 msgid ""

--- a/wagtail/locale/el/LC_MESSAGES/django.po
+++ b/wagtail/locale/el/LC_MESSAGES/django.po
@@ -354,7 +354,7 @@ msgstr "Φιλικό όνομα για το site."
 msgid "root page"
 msgstr "κεντρική σελίδα"
 
-msgid "is default site"
+msgid "Is default site?"
 msgstr "είναι το προεπιλεγμένο site"
 
 msgid ""

--- a/wagtail/locale/en/LC_MESSAGES/django.po
+++ b/wagtail/locale/en/LC_MESSAGES/django.po
@@ -688,7 +688,7 @@ msgid "root page"
 msgstr ""
 
 #: models/sites.py:100
-msgid "is default site"
+msgid "Is default site?"
 msgstr ""
 
 #: models/sites.py:103

--- a/wagtail/locale/es/LC_MESSAGES/django.po
+++ b/wagtail/locale/es/LC_MESSAGES/django.po
@@ -559,7 +559,7 @@ msgstr "Nombre del sitio legible para usuarios"
 msgid "root page"
 msgstr "página raíz"
 
-msgid "is default site"
+msgid "Is default site?"
 msgstr "es sitio por defecto"
 
 msgid ""

--- a/wagtail/locale/et/LC_MESSAGES/django.po
+++ b/wagtail/locale/et/LC_MESSAGES/django.po
@@ -461,7 +461,7 @@ msgstr "Inimloetav saidi nimi."
 msgid "root page"
 msgstr "juurleht"
 
-msgid "is default site"
+msgid "Is default site?"
 msgstr "on vaikesait"
 
 msgid ""

--- a/wagtail/locale/fa/LC_MESSAGES/django.po
+++ b/wagtail/locale/fa/LC_MESSAGES/django.po
@@ -270,7 +270,7 @@ msgstr "نام قابل فهم برای این سایت."
 msgid "root page"
 msgstr "صفحه ریشه"
 
-msgid "is default site"
+msgid "Is default site?"
 msgstr "سایت پیش فرض"
 
 msgid ""

--- a/wagtail/locale/fi/LC_MESSAGES/django.po
+++ b/wagtail/locale/fi/LC_MESSAGES/django.po
@@ -483,7 +483,7 @@ msgstr "Ihmisen luettava nimi sivustolle."
 msgid "root page"
 msgstr "juurisivu"
 
-msgid "is default site"
+msgid "Is default site?"
 msgstr "on oletussivusto"
 
 msgid ""

--- a/wagtail/locale/fr/LC_MESSAGES/django.po
+++ b/wagtail/locale/fr/LC_MESSAGES/django.po
@@ -559,7 +559,7 @@ msgstr "Nom compréhensible par un humain pour le site."
 msgid "root page"
 msgstr "page racine"
 
-msgid "is default site"
+msgid "Is default site?"
 msgstr "site par défaut"
 
 msgid ""

--- a/wagtail/locale/gl/LC_MESSAGES/django.po
+++ b/wagtail/locale/gl/LC_MESSAGES/django.po
@@ -544,7 +544,7 @@ msgstr "Nome do sitio web lexible por humáns"
 msgid "root page"
 msgstr "páxina raíz"
 
-msgid "is default site"
+msgid "Is default site?"
 msgstr "é sitio web por defecto"
 
 msgid ""

--- a/wagtail/locale/hr_HR/LC_MESSAGES/django.po
+++ b/wagtail/locale/hr_HR/LC_MESSAGES/django.po
@@ -483,7 +483,7 @@ msgstr "Naziv sjedišta čitljiv ljudima"
 msgid "root page"
 msgstr "korijenska stranica"
 
-msgid "is default site"
+msgid "Is default site?"
 msgstr "zadana stranica"
 
 msgid ""

--- a/wagtail/locale/hu/LC_MESSAGES/django.po
+++ b/wagtail/locale/hu/LC_MESSAGES/django.po
@@ -542,7 +542,7 @@ msgstr "A webhely neve emberi nyelven"
 msgid "root page"
 msgstr "főoldal"
 
-msgid "is default site"
+msgid "Is default site?"
 msgstr "az alapértelmezett webhely"
 
 msgid ""

--- a/wagtail/locale/id_ID/LC_MESSAGES/django.po
+++ b/wagtail/locale/id_ID/LC_MESSAGES/django.po
@@ -267,7 +267,7 @@ msgstr "Nama situs yang mudah dibaca manusia."
 msgid "root page"
 msgstr "halaman akar"
 
-msgid "is default site"
+msgid "Is default site?"
 msgstr "adalah situs utama"
 
 msgid ""

--- a/wagtail/locale/is_IS/LC_MESSAGES/django.po
+++ b/wagtail/locale/is_IS/LC_MESSAGES/django.po
@@ -537,7 +537,7 @@ msgstr "Lesanlegt nafn fyrir síðuna"
 msgid "root page"
 msgstr "rótarsíða"
 
-msgid "is default site"
+msgid "Is default site?"
 msgstr "er sjálfgefin síða"
 
 msgid ""

--- a/wagtail/locale/it/LC_MESSAGES/django.po
+++ b/wagtail/locale/it/LC_MESSAGES/django.po
@@ -531,7 +531,7 @@ msgstr "Nome leggibile per il sito."
 msgid "root page"
 msgstr "pagina radice"
 
-msgid "is default site"
+msgid "Is default site?"
 msgstr "è sito di default"
 
 msgid ""

--- a/wagtail/locale/ja/LC_MESSAGES/django.po
+++ b/wagtail/locale/ja/LC_MESSAGES/django.po
@@ -369,7 +369,7 @@ msgstr "わかりやすいサイト名"
 msgid "root page"
 msgstr "ルートページ"
 
-msgid "is default site"
+msgid "Is default site?"
 msgstr "デフォルトのサイトです"
 
 msgid ""

--- a/wagtail/locale/ko/LC_MESSAGES/django.po
+++ b/wagtail/locale/ko/LC_MESSAGES/django.po
@@ -299,7 +299,7 @@ msgstr "사람이 읽을 수 있는 사이트명"
 msgid "root page"
 msgstr "기본 페이지"
 
-msgid "is default site"
+msgid "Is default site?"
 msgstr "기본 사이트임"
 
 msgid ""

--- a/wagtail/locale/lt/LC_MESSAGES/django.po
+++ b/wagtail/locale/lt/LC_MESSAGES/django.po
@@ -304,7 +304,7 @@ msgstr "Skaitymui/atvaizdavimui skirtas tinklalapio pavadinimas."
 msgid "root page"
 msgstr "šakninis puslapis"
 
-msgid "is default site"
+msgid "Is default site?"
 msgstr "yra numatytasis tinklalapis"
 
 msgid ""

--- a/wagtail/locale/mi/LC_MESSAGES/django.po
+++ b/wagtail/locale/mi/LC_MESSAGES/django.po
@@ -441,7 +441,7 @@ msgstr "He Ingoa tūturu mō tēnei pae. Pānui-a-tangata"
 msgid "root page"
 msgstr "whārangi rarau"
 
-msgid "is default site"
+msgid "Is default site?"
 msgstr "kō te pae taunoa"
 
 msgid ""

--- a/wagtail/locale/mn/LC_MESSAGES/django.po
+++ b/wagtail/locale/mn/LC_MESSAGES/django.po
@@ -223,7 +223,7 @@ msgstr "Хүмүүст харагдах сайтын нэр."
 msgid "root page"
 msgstr "үндэс хуудас"
 
-msgid "is default site"
+msgid "Is default site?"
 msgstr "өгөгдмөл сайт уу"
 
 msgid "site"

--- a/wagtail/locale/nb/LC_MESSAGES/django.po
+++ b/wagtail/locale/nb/LC_MESSAGES/django.po
@@ -285,7 +285,7 @@ msgstr "Lesbart navn for nettstedet"
 msgid "root page"
 msgstr "rotside"
 
-msgid "is default site"
+msgid "Is default site?"
 msgstr "er standard nettsted"
 
 msgid ""

--- a/wagtail/locale/nl/LC_MESSAGES/django.po
+++ b/wagtail/locale/nl/LC_MESSAGES/django.po
@@ -547,7 +547,7 @@ msgstr "Leesbare naam voor de site."
 msgid "root page"
 msgstr "beginpagina"
 
-msgid "is default site"
+msgid "Is default site?"
 msgstr "is standaard site"
 
 msgid ""

--- a/wagtail/locale/pl/LC_MESSAGES/django.po
+++ b/wagtail/locale/pl/LC_MESSAGES/django.po
@@ -502,7 +502,7 @@ msgstr "Nazwa serwisu przyjazna człowiekowi"
 msgid "root page"
 msgstr "Strona nadrzędna"
 
-msgid "is default site"
+msgid "Is default site?"
 msgstr "czy serwis domyślny"
 
 msgid ""

--- a/wagtail/locale/pt_BR/LC_MESSAGES/django.po
+++ b/wagtail/locale/pt_BR/LC_MESSAGES/django.po
@@ -556,7 +556,7 @@ msgstr "nome legível para o site."
 msgid "root page"
 msgstr "página raiz"
 
-msgid "is default site"
+msgid "Is default site?"
 msgstr "é o site padrão"
 
 msgid ""

--- a/wagtail/locale/pt_PT/LC_MESSAGES/django.po
+++ b/wagtail/locale/pt_PT/LC_MESSAGES/django.po
@@ -524,7 +524,7 @@ msgstr "Nome legível para o site."
 msgid "root page"
 msgstr "página raiz"
 
-msgid "is default site"
+msgid "Is default site?"
 msgstr "é o site pré-definido"
 
 msgid ""

--- a/wagtail/locale/ro/LC_MESSAGES/django.po
+++ b/wagtail/locale/ro/LC_MESSAGES/django.po
@@ -544,7 +544,7 @@ msgstr "Titlu sait lizibil pentru om"
 msgid "root page"
 msgstr "pagină de bază"
 
-msgid "is default site"
+msgid "Is default site?"
 msgstr "sait implicit"
 
 msgid ""

--- a/wagtail/locale/ru/LC_MESSAGES/django.po
+++ b/wagtail/locale/ru/LC_MESSAGES/django.po
@@ -535,7 +535,7 @@ msgstr "Человеко-понятное имя для сайта."
 msgid "root page"
 msgstr "корневая страница"
 
-msgid "is default site"
+msgid "Is default site?"
 msgstr "сайт по умолчанию"
 
 msgid ""

--- a/wagtail/locale/sk_SK/LC_MESSAGES/django.po
+++ b/wagtail/locale/sk_SK/LC_MESSAGES/django.po
@@ -246,7 +246,7 @@ msgstr "Názov sídla viditeľný pre verejnosť."
 msgid "root page"
 msgstr "koreňová stránka"
 
-msgid "is default site"
+msgid "Is default site?"
 msgstr "je predvolené sídlo"
 
 msgid ""

--- a/wagtail/locale/sl/LC_MESSAGES/django.po
+++ b/wagtail/locale/sl/LC_MESSAGES/django.po
@@ -380,7 +380,7 @@ msgstr "Berljiva oblika imena spletnega mesta."
 msgid "root page"
 msgstr "začetna stran"
 
-msgid "is default site"
+msgid "Is default site?"
 msgstr "privzeto spletno mesto"
 
 msgid "site"

--- a/wagtail/locale/sv/LC_MESSAGES/django.po
+++ b/wagtail/locale/sv/LC_MESSAGES/django.po
@@ -517,7 +517,7 @@ msgstr "Läsbart namn för sajten"
 msgid "root page"
 msgstr "rotsida"
 
-msgid "is default site"
+msgid "Is default site?"
 msgstr "är standardsajten"
 
 msgid ""

--- a/wagtail/locale/tet/LC_MESSAGES/django.po
+++ b/wagtail/locale/tet/LC_MESSAGES/django.po
@@ -228,7 +228,7 @@ msgstr "naran situs lee fasil"
 msgid "root page"
 msgstr "pajina fuan"
 
-msgid "is default site"
+msgid "Is default site?"
 msgstr "Ne'e situs detallu"
 
 msgid ""

--- a/wagtail/locale/th/LC_MESSAGES/django.po
+++ b/wagtail/locale/th/LC_MESSAGES/django.po
@@ -250,7 +250,7 @@ msgstr "ชื่อของเว็บไซด์ที่มนุษย์
 msgid "root page"
 msgstr "ต้นฉบับ"
 
-msgid "is default site"
+msgid "Is default site?"
 msgstr "คือเว็บไซด์ต้นแบบ"
 
 msgid ""

--- a/wagtail/locale/tr/LC_MESSAGES/django.po
+++ b/wagtail/locale/tr/LC_MESSAGES/django.po
@@ -261,7 +261,7 @@ msgstr "Okunabilir site adı."
 msgid "root page"
 msgstr "root (kök) sayfası"
 
-msgid "is default site"
+msgid "Is default site?"
 msgstr "varsayılan site mi"
 
 msgid ""

--- a/wagtail/locale/tr_TR/LC_MESSAGES/django.po
+++ b/wagtail/locale/tr_TR/LC_MESSAGES/django.po
@@ -267,7 +267,7 @@ msgstr "Okunabilir site adı."
 msgid "root page"
 msgstr "root (kök) sayfası"
 
-msgid "is default site"
+msgid "Is default site?"
 msgstr "varsayılan site mi"
 
 msgid ""

--- a/wagtail/locale/uk/LC_MESSAGES/django.po
+++ b/wagtail/locale/uk/LC_MESSAGES/django.po
@@ -549,7 +549,7 @@ msgstr "Ім'я сайту, зручне для людини"
 msgid "root page"
 msgstr "коренева сторінка"
 
-msgid "is default site"
+msgid "Is default site?"
 msgstr "є типовим сайтом"
 
 msgid ""

--- a/wagtail/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/wagtail/locale/zh_Hans/LC_MESSAGES/django.po
@@ -509,7 +509,7 @@ msgstr "此站点的可读名称"
 msgid "root page"
 msgstr "根页面"
 
-msgid "is default site"
+msgid "Is default site?"
 msgstr "是默认站点"
 
 msgid ""

--- a/wagtail/locale/zh_Hant/LC_MESSAGES/django.po
+++ b/wagtail/locale/zh_Hant/LC_MESSAGES/django.po
@@ -428,7 +428,7 @@ msgstr "此站點的可讀名稱"
 msgid "root page"
 msgstr "根頁面"
 
-msgid "is default site"
+msgid "Is default site?"
 msgstr "是預設站點"
 
 msgid ""

--- a/wagtail/migrations/0001_squashed_0016_change_page_url_path_to_text_field.py
+++ b/wagtail/migrations/0001_squashed_0016_change_page_url_path_to_text_field.py
@@ -467,7 +467,7 @@ class Migration(migrations.Migration):
                     "is_default_site",
                     models.BooleanField(
                         default=False,
-                        verbose_name="Is default site",
+                        verbose_name="Is default site?",
                         help_text=(
                             "If true, this site will handle requests for all other hostnames"
                             " that do not have a site entry of their own"

--- a/wagtail/migrations/0014_add_verbose_name.py
+++ b/wagtail/migrations/0014_add_verbose_name.py
@@ -114,7 +114,7 @@ class Migration(migrations.Migration):
                 default=False,
                 help_text="If true, this site will handle requests for all other hostnames"
                 " that do not have a site entry of their own",
-                verbose_name="Is default site",
+                verbose_name="Is default site?",
             ),
             preserve_default=True,
         ),

--- a/wagtail/migrations/0021_capitalizeverbose.py
+++ b/wagtail/migrations/0021_capitalizeverbose.py
@@ -248,7 +248,7 @@ class Migration(migrations.Migration):
             field=models.BooleanField(
                 default=False,
                 help_text="If true, this site will handle requests for all other hostnames that do not have a site entry of their own",
-                verbose_name="is default site",
+                verbose_name="Is default site?",
             ),
         ),
         migrations.AlterField(

--- a/wagtail/models/sites.py
+++ b/wagtail/models/sites.py
@@ -97,7 +97,7 @@ class Site(models.Model):
         on_delete=models.CASCADE,
     )
     is_default_site = models.BooleanField(
-        verbose_name=_("is default site"),
+        verbose_name=_("Is default site?"),
         default=False,
         help_text=_(
             "If true, this site will handle requests for all other hostnames that do not have a site entry of their own"


### PR DESCRIPTION
<!--
Thanks for contributing to Wagtail! 🎉

Before submitting, please review the [contributor guidelines](https://docs.wagtail.org/en/latest/contributing/index.html).
-->

**Issue Summary**
While adding/editing pages, there is an option to make a page the default/home page. This is a boolean question however there is no question mark to indicate this.

**Before:**
![197378648-0ca16b9b-7d50-4771-9d6e-4c1a53c4706c](https://user-images.githubusercontent.com/76876709/199694177-28731203-4953-4e98-992e-17a1263c91a6.png)


- Fixed issue [#9468](https://github.com/wagtail/wagtail/issues/9468) by making changes to over 40 files, added **"?"** after **is default sit**e.

**After:**

![WhatsApp Image 2022-11-02 at 21 07 09](https://user-images.githubusercontent.com/76876709/199693663-422dcf27-bfd1-4bb7-803c-7d022c7b4c8c.jpg)




_Please check the following:_

-   [x] Do the tests still pass?[^1]
-   [x] Does the code comply with the style guide?
    -   [x] Run `make lint` from the Wagtail root.
-   [x] For Python changes: Have you added tests to cover the new/fixed behaviour?
-   [x] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]
    -   [x] **Please list the exact browser and operating system versions you tested**:
    -   [x] **Please list which assistive technologies [^3] you tested**:
-   [x] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
