### PR TITLE
Fixed: Text change Is default site to Is default site?

### DIFF
--- a/wagtail/models/sites.py
+++ b/wagtail/models/sites.py
@@ -97,7 +97,7 @@ class Site(models.Model):
         on_delete=models.CASCADE,
     )
     is_default_site = models.BooleanField(
-        verbose_name=_("is default site"),
+        verbose_name=_("is default site?"),
         default=False,
         help_text=_(
             "If true, this site will handle requests for all other hostnames that do not have a site entry of their own"


### PR DESCRIPTION
<!--
Thanks for contributing to Wagtail! 🎉

Before submitting, please review the [contributor guidelines](https://docs.wagtail.org/en/latest/contributing/index.html).
-->

**Issue Summary**
While adding/editing pages, there is an option to make a page the default/home page. This is a boolean question however there is no question mark to indicate this.

**Before:**
![197378648-0ca16b9b-7d50-4771-9d6e-4c1a53c4706c](https://user-images.githubusercontent.com/76876709/199694177-28731203-4953-4e98-992e-17a1263c91a6.png)


- Fixed issue [#9468](https://github.com/wagtail/wagtail/issues/9468) by adding **"?"** after **is default sit**e.

**After:**

![WhatsApp Image 2022-11-02 at 21 07 09](https://user-images.githubusercontent.com/76876709/199693663-422dcf27-bfd1-4bb7-803c-7d022c7b4c8c.jpg)




_Please check the following:_

-   [x] Do the tests still pass?[^1] 
-   [x] For front-end changes: Did you test on all of Wagtail’s supported environments?[^2]   
-   [x] For new features: Has the documentation been updated accordingly?

**Please describe additional details for testing this change**.

[^1]: [Development Testing](https://docs.wagtail.org/en/latest/contributing/developing.html#testing)
[^2]: [Browser and device support](https://docs.wagtail.org/en/latest/contributing/developing.html#browser-and-device-support)
[^3]: [Accessibility Target](https://docs.wagtail.org/en/latest/contributing/developing.html#accessibility-targets)
