### PR TITLE
Fix help block <a> to meet colour contrast guidelines

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -25,6 +25,7 @@ Changelog
  * Fix: Text within status tags text will now resize correctly when customizing browser font size (Mary Ojo)
  * Fix: Ensure logo shows correctly on log in page in Windows high-contrast mode (Loveth Omokaro)
  * Fix: Comments notice background overflows its container (Yekasumah)
+ * Fix: Ensure links within help blocks meet colour contrast guidelines for accessibility (Theresa Okoro)
 
 
 4.1.1 (xx.xx.xxxx) - IN DEVELOPMENT

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -659,6 +659,7 @@ Contributors
 * Jordan Rob
 * Juliet Adeboye
 * Yekasumah
+* Theresa Okoro
 
 Translators
 ===========

--- a/client/scss/components/_help-block.scss
+++ b/client/scss/components/_help-block.scss
@@ -16,7 +16,7 @@
   }
 
   a {
-    color: theme('colors.secondary.DEFAULT');
+    color: theme('colors.secondary.400');
     text-decoration: underline;
     text-decoration-thickness: 2px;
     text-underline-offset: 3px;

--- a/docs/releases/4.2.md
+++ b/docs/releases/4.2.md
@@ -36,6 +36,7 @@ depth: 1
  * Incorrectly formatted link in the documentation for Wagtail community support (Bolarinwa Comfort Ajayi)
  * Ensure logo shows correctly on log in page in Windows high-contrast mode (Loveth Omokaro)
  * Comments notice background overflows its container (Yekasumah)
+ * Ensure links within help blocks meet colour contrast guidelines for accessibility (Theresa Okoro)
 
 ## Upgrade considerations
 


### PR DESCRIPTION
<!--
Thanks for contributing to Wagtail! 🎉

Before submitting, please review the [contributor guidelines](https://docs.wagtail.org/en/latest/contributing/index.html).
-->

This fixes https://github.com/wagtail/wagtail/issues/9569

This PR rectifies the issue of the <a> tag in help block which does not meet the accepted contrast ratio according to AXE DevTools - The Configure a site link and moderators approval has an insufficient color contrast of 4.25 (foreground color: #8080, background color: #e3f5fc, font size: 10.2pt (13.6px), font weight: normal). Expected contrast ratio of 4.5:1

The following code was edited as the previous Foreground colour against the Background colour did not meet the guideline.

Please see pictures below;

BEFORE


![wagfirstissuecolorcontrastt](https://user-images.githubusercontent.com/62052443/199947357-c79907d3-f67b-4f59-8d73-1db4fc3acf24.PNG)

AFTER
![wagfirstissuecolorcontrastissue4](https://user-images.githubusercontent.com/62052443/199947347-a18a08e9-ef50-40d7-8483-833be9c2fc64.PNG)
![wagfirstissuecolorcontrastissue3](https://user-images.githubusercontent.com/62052443/199947340-ad64fe5a-03a6-4c26-96e3-8044112526d5.PNG)
